### PR TITLE
Replace null characters in HTML script escaped states

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -111,6 +111,9 @@ documented in this file.
   dashes.
 - NULL characters in DOCTYPE names and quoted public/system identifiers now
   recover with `unexpected-null-character` and append U+FFFD.
+- NULL characters in script escaped and double-escaped substates now recover
+  with `unexpected-null-character` and append U+FFFD while preserving their
+  dash-sensitive state transitions.
 - One-dash markup declarations such as `<!->` and `<!-x>` now use
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -31,10 +31,10 @@ kept, later attributes with the same interpreted name are dropped, and a
 Unquoted attribute values also preserve spec-defined unexpected characters
 such as `"`, `'`, `<`, `=`, and `` ` `` while reporting
 `unexpected-character-in-unquoted-attribute-value`.
-NULL characters in data/RCDATA/RAWTEXT/PLAINTEXT/CDATA/script data and
-attribute values recover by reporting `unexpected-null-character` and appending
-U+FFFD, matching the replacement behavior the future parser will expect from
-the lexer/tokenizer boundary.
+NULL characters in data/RCDATA/RAWTEXT/PLAINTEXT/CDATA/script data, script
+escaped/double-escaped states, and attribute values recover by reporting
+`unexpected-null-character` and appending U+FFFD, matching the replacement
+behavior the future parser will expect from the lexer/tokenizer boundary.
 Tag names and attribute names now use the same recovery shape, so a raw NULL in
 markup names becomes U+FFFD and records `unexpected-null-character` instead of
 leaking the raw code point into emitted tokens.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -927,6 +927,12 @@ to = "script_data_escaped_less_than_sign"
 
 [[transitions]]
 from = "script_data_escaped"
+matcher = { literal = "\u0000" }
+to = "script_data_escaped"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
+
+[[transitions]]
+from = "script_data_escaped"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -948,6 +954,12 @@ actions = ["append_text(current)"]
 from = "script_data_escaped_dash"
 matcher = { literal = "<" }
 to = "script_data_escaped_less_than_sign"
+
+[[transitions]]
+from = "script_data_escaped_dash"
+matcher = { literal = "\u0000" }
+to = "script_data_escaped"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
 
 [[transitions]]
 from = "script_data_escaped_dash"
@@ -978,6 +990,12 @@ from = "script_data_escaped_dash_dash"
 matcher = { literal = ">" }
 to = "script_data"
 actions = ["append_text(current)"]
+
+[[transitions]]
+from = "script_data_escaped_dash_dash"
+matcher = { literal = "\u0000" }
+to = "script_data_escaped"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
 
 [[transitions]]
 from = "script_data_escaped_dash_dash"
@@ -1082,6 +1100,12 @@ actions = ["append_text(current)"]
 
 [[transitions]]
 from = "script_data_double_escaped"
+matcher = { literal = "\u0000" }
+to = "script_data_double_escaped"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
+
+[[transitions]]
+from = "script_data_double_escaped"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -1104,6 +1128,12 @@ from = "script_data_double_escaped_dash"
 matcher = { literal = "<" }
 to = "script_data_double_escaped_less_than_sign"
 actions = ["append_text(current)"]
+
+[[transitions]]
+from = "script_data_double_escaped_dash"
+matcher = { literal = "\u0000" }
+to = "script_data_double_escaped"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
 
 [[transitions]]
 from = "script_data_double_escaped_dash"
@@ -1135,6 +1165,12 @@ from = "script_data_double_escaped_dash_dash"
 matcher = { literal = ">" }
 to = "script_data_double_escaped"
 actions = ["append_text(current)"]
+
+[[transitions]]
+from = "script_data_double_escaped_dash_dash"
+matcher = { literal = "\u0000" }
+to = "script_data_double_escaped"
+actions = ["parse_error(unexpected-null-character)", "append_text_replacement"]
 
 [[transitions]]
 from = "script_data_double_escaped_dash_dash"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -2129,6 +2129,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_escaped".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "script_data_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
                 "done".to_string(),
@@ -2183,6 +2199,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "script_data_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
             consume: true,
         },
         TransitionDefinition {
@@ -2256,6 +2288,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_text(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_dash_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "script_data_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
             ],
             consume: true,
         },
@@ -2483,6 +2531,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_double_escaped".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "script_data_double_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_double_escaped".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
                 "done".to_string(),
@@ -2538,6 +2602,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_text(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_double_escaped_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "script_data_double_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
             ],
             consume: true,
         },
@@ -2614,6 +2694,22 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_text(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_double_escaped_dash_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "script_data_double_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "append_text_replacement".to_string(),
             ],
             consume: true,
         },

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -99,7 +99,7 @@ fn fixture_manifests_parse() {
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 62);
+    assert_eq!(file.tests.len(), 64);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 62);
+    assert_eq!(normalized.cases.len(), 64);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 62);
+    assert_eq!(suite.cases.len(), 64);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -408,6 +408,40 @@
     },
     {
       "id": "html5lib-smoke-31",
+      "description": "script data escaped state replaces null characters",
+      "input": "a\u0000-\u0000--\u0000></script>",
+      "tokens": [
+        "Text(data=a\ufffd-\ufffd--\ufffd>)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ],
+      "initial_state": "Script data escaped state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-32",
+      "description": "script data double escaped state replaces null characters",
+      "input": "a\u0000-\u0000--\u0000></script>x</script>",
+      "tokens": [
+        "Text(data=a\ufffd-\ufffd--\ufffd></script>x)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-null-character",
+        "unexpected-null-character",
+        "unexpected-null-character"
+      ],
+      "initial_state": "Script data double escaped state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-33",
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "tokens": [
@@ -417,7 +451,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-32",
+      "id": "html5lib-smoke-34",
       "description": "attribute named character references",
       "input": "<a title=\"Fish &amp; Chips\" data-x='&lt;ok&gt;' note=&quot;hi&quot;>",
       "tokens": [
@@ -427,7 +461,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-33",
+      "id": "html5lib-smoke-35",
       "description": "rcdata named character references remain text",
       "input": "Fish &amp; &lt;/title>",
       "tokens": [
@@ -439,7 +473,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-34",
+      "id": "html5lib-smoke-36",
       "description": "data state legacy named character references",
       "input": "Legacy&nbsp;symbols: &copy; &reg;",
       "tokens": [
@@ -449,7 +483,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-35",
+      "id": "html5lib-smoke-37",
       "description": "attribute legacy named character references",
       "input": "<a title=\"A&nbsp;B\" copy='&copy;' reg=&reg;>",
       "tokens": [
@@ -459,7 +493,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-36",
+      "id": "html5lib-smoke-38",
       "description": "rcdata legacy named character references remain text",
       "input": "Venture&nbsp;&copy;&reg;</title>",
       "tokens": [
@@ -472,7 +506,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-37",
+      "id": "html5lib-smoke-39",
       "description": "data state Latin-1 named character references",
       "input": "Latin-1: &Agrave;&agrave; &frac12; &yen;",
       "tokens": [
@@ -482,7 +516,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-38",
+      "id": "html5lib-smoke-40",
       "description": "attribute Latin-1 named character references",
       "input": "<a title=\"&AElig;&aelig;\" currency=&pound;>",
       "tokens": [
@@ -492,7 +526,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-39",
+      "id": "html5lib-smoke-41",
       "description": "rcdata Latin-1 named character references remain text",
       "input": "&Ntilde;&ntilde;</title>",
       "tokens": [
@@ -505,7 +539,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-40",
+      "id": "html5lib-smoke-42",
       "description": "data state legacy named character references missing semicolons",
       "input": "Legacy&nbsp symbols: &copy/&reg",
       "tokens": [
@@ -519,7 +553,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-41",
+      "id": "html5lib-smoke-43",
       "description": "attribute legacy named character references missing semicolons",
       "input": "<a title=\"A&nbsp B\" copy=&copy reg=&reg>",
       "tokens": [
@@ -533,7 +567,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-42",
+      "id": "html5lib-smoke-44",
       "description": "rcdata legacy named character references missing semicolons",
       "input": "Venture&nbsp &copy &reg</title>",
       "tokens": [
@@ -550,7 +584,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-43",
+      "id": "html5lib-smoke-45",
       "description": "data state named character reference fallback",
       "input": "Known &AMP; unknown &madeup;",
       "tokens": [
@@ -560,7 +594,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-44",
+      "id": "html5lib-smoke-46",
       "description": "attribute named character reference fallback",
       "input": "<a title=\"&copy;\" bogus=&madeup;>",
       "tokens": [
@@ -570,7 +604,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-45",
+      "id": "html5lib-smoke-47",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -580,7 +614,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-46",
+      "id": "html5lib-smoke-48",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -590,7 +624,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-47",
+      "id": "html5lib-smoke-49",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -602,7 +636,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-48",
+      "id": "html5lib-smoke-50",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -615,7 +649,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-49",
+      "id": "html5lib-smoke-51",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -628,7 +662,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-50",
+      "id": "html5lib-smoke-52",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -643,7 +677,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-51",
+      "id": "html5lib-smoke-53",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -656,7 +690,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-52",
+      "id": "html5lib-smoke-54",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -670,7 +704,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-53",
+      "id": "html5lib-smoke-55",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -683,7 +717,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-56",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -697,7 +731,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-55",
+      "id": "html5lib-smoke-57",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [
@@ -711,7 +745,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-56",
+      "id": "html5lib-smoke-58",
       "description": "question mark after tag open recovers as bogus comment",
       "input": "Before<?xml version=\"1.0\"?>After",
       "tokens": [
@@ -725,7 +759,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-57",
+      "id": "html5lib-smoke-59",
       "description": "question mark bogus comment eof has no eof-in-comment error",
       "input": "Before<?xml",
       "tokens": [
@@ -738,7 +772,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-58",
+      "id": "html5lib-smoke-60",
       "description": "incorrectly opened markup declaration reports tokenizer error",
       "input": "Before<!foo>After",
       "tokens": [
@@ -752,7 +786,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-59",
+      "id": "html5lib-smoke-61",
       "description": "empty incorrectly opened markup declaration reconsumes delimiter",
       "input": "Before<!>After",
       "tokens": [
@@ -766,7 +800,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-60",
+      "id": "html5lib-smoke-62",
       "description": "markup declaration opener eof recovers as empty bogus comment",
       "input": "Before<!",
       "tokens": [
@@ -779,7 +813,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-61",
+      "id": "html5lib-smoke-63",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -798,7 +832,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-62",
+      "id": "html5lib-smoke-64",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -319,6 +319,36 @@
       ]
     },
     {
+      "description": "script data escaped state replaces null characters",
+      "initialStates": ["Script data escaped state"],
+      "lastStartTag": "script",
+      "input": "a\u0000-\u0000--\u0000></script>",
+      "output": [
+        ["Character", "a\uFFFd-\uFFFd--\uFFFd>"],
+        ["EndTag", "script"]
+      ],
+      "errors": [
+        {"code": "unexpected-null-character", "line": 1, "col": 2},
+        {"code": "unexpected-null-character", "line": 1, "col": 4},
+        {"code": "unexpected-null-character", "line": 1, "col": 7}
+      ]
+    },
+    {
+      "description": "script data double escaped state replaces null characters",
+      "initialStates": ["Script data double escaped state"],
+      "lastStartTag": "script",
+      "input": "a\u0000-\u0000--\u0000></script>x</script>",
+      "output": [
+        ["Character", "a\uFFFd-\uFFFd--\uFFFd></script>x"],
+        ["EndTag", "script"]
+      ],
+      "errors": [
+        {"code": "unexpected-null-character", "line": 1, "col": 2},
+        {"code": "unexpected-null-character", "line": 1, "col": 4},
+        {"code": "unexpected-null-character", "line": 1, "col": 7}
+      ]
+    },
+    {
       "description": "data state named character references",
       "input": "Fish &amp; &lt;b&gt; &quot;quote&quot; &apos;ok&apos;",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1006,6 +1006,65 @@ fn default_html_lexer_replaces_null_characters_in_text_submodes() {
 }
 
 #[test]
+fn default_html_lexer_replaces_null_characters_in_script_escaped_substates() {
+    let mut escaped = create_html_lexer().unwrap();
+    escaped.set_initial_state("script_data_escaped").unwrap();
+    escaped.set_last_start_tag("script");
+
+    escaped.push("a\0-\0--\0></script>").unwrap();
+    escaped.finish().unwrap();
+
+    assert_eq!(
+        escaped.drain_tokens(),
+        vec![
+            Token::Text("a\u{FFFD}-\u{FFFD}--\u{FFFD}>".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        escaped
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-null-character")
+            .count(),
+        3
+    );
+
+    let mut double_escaped = create_html_lexer().unwrap();
+    double_escaped
+        .set_initial_state("script_data_double_escaped")
+        .unwrap();
+    double_escaped.set_last_start_tag("script");
+
+    double_escaped
+        .push("a\0-\0--\0></script>x</script>")
+        .unwrap();
+    double_escaped.finish().unwrap();
+
+    assert_eq!(
+        double_escaped.drain_tokens(),
+        vec![
+            Token::Text("a\u{FFFD}-\u{FFFD}--\u{FFFD}></script>x".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        double_escaped
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-null-character")
+            .count(),
+        3
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_seeded_rawtext_end_tags() {
     let mut lexer = create_html_lexer().unwrap();
     lexer.set_initial_state("rawtext").unwrap();


### PR DESCRIPTION
## Summary
- add HTML1 TOML transitions for NULL recovery in script escaped and double-escaped substates
- regenerate the statically linked Rust HTML1 lexer source
- extend wrapper and html5lib smoke conformance coverage for script escaped NULL replacement

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_replaces_null_characters_in_script_escaped_substates -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests
- git diff --check