### PR TITLE
feat(compiler-ir): TW03 Phase 3a — heap-primitive IR ops

### DIFF
--- a/code/packages/python/compiler-ir/CHANGELOG.md
+++ b/code/packages/python/compiler-ir/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## [Unreleased]
 
-### Added
+### Added — TW03 Phase 3a heap-primitive ops
+
+Eight new opcodes (55–62) introducing the cross-backend Lisp
+heap-primitive interface.  See
+[TW03-phase3-heap-primitives.md](../../../specs/TW03-phase3-heap-primitives.md)
+for the multi-backend lowering plan.
+
+- **`IrOp.MAKE_CONS` (55)** — allocate a cons cell.  Operand layout:
+  `MAKE_CONS dst, head_reg, tail_reg`.
+- **`IrOp.CAR` (56)** — read the head of a cons cell.
+  `CAR dst, src`.
+- **`IrOp.CDR` (57)** — read the tail of a cons cell.
+  `CDR dst, src`.
+- **`IrOp.IS_NULL` (58)** — sets `dst=1` if `src` is the nil sentinel,
+  else 0.  Result feeds straight into `BRANCH_Z` / `BRANCH_NZ`.
+- **`IrOp.IS_PAIR` (59)** — sets `dst=1` if `src` is a cons cell.
+- **`IrOp.MAKE_SYMBOL` (60)** — intern a symbol named by an `IrLabel`
+  (reuses the existing label round-trip path).  `MAKE_SYMBOL dst, name_label`.
+- **`IrOp.IS_SYMBOL` (61)** — sets `dst=1` if `src` is a symbol.
+- **`IrOp.LOAD_NIL` (62)** — store the nil sentinel into `dst`.
+
+These are the **cross-backend interface** for TW03 Phase 3.
+Per-backend lowering ships in subsequent phases (JVM03 / CLR03 /
+BEAM03).  Adding new opcodes does not touch existing 0–54 IDs, so
+older serialized IR text round-trips unchanged.
+
+### Added — earlier (rolled into 0.5.0)
 
 - **`IrOp.F64_SQRT` (49)** — unary 64-bit floating square root
   (`dst = sqrt(src)`) for frontends that need standard real math builtins.

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -31,6 +31,8 @@ The opcodes are grouped by category:
   System:       SYSCALL, HALT
   Meta:         NOP, COMMENT
   Closures:     MAKE_CLOSURE, APPLY_CLOSURE   (TW03 Phase 2)
+  Heap:         MAKE_CONS, CAR, CDR, IS_NULL, IS_PAIR,
+                MAKE_SYMBOL, IS_SYMBOL, LOAD_NIL   (TW03 Phase 3)
 
 Text Names
 ----------
@@ -324,6 +326,84 @@ class IrOp(IntEnum):
 
     #   F64_EXP v1, v2    →  v1 = exp(v2)
     F64_EXP = 54
+
+    # ── Heap primitives (TW03 Phase 3 — Lisp cons / symbols / nil) ───────
+    # These ops introduce three new heap-allocated value kinds beyond the
+    # int and closure values we already have:
+    #
+    #   cons  — pair of (head, tail) heap references; produced by MAKE_CONS,
+    #           inspected by CAR / CDR / IS_PAIR.
+    #   symbol — interned identifier; produced by MAKE_SYMBOL, inspected by
+    #            IS_SYMBOL.  Two MAKE_SYMBOL with the same name yield refs
+    #            that compare equal under the host's equality semantics.
+    #   nil   — the empty-list sentinel; produced by LOAD_NIL, inspected by
+    #           IS_NULL.  Lispy code uses nil as both "false" and "end of
+    #           list", as is traditional in Scheme/Lisp.
+    #
+    # Backend lowering strategies (filled in by JVM03 / CLR03 / BEAM03
+    # sister specs):
+    #   - JVM/CLR: emit Cons / Symbol / Nil classes; allocations use ``new``;
+    #              the host GC reclaims unreachable heap nodes — no explicit
+    #              free / mark / sweep work for the compiler.
+    #   - BEAM:    cons cells map directly to Erlang lists (``put_list``);
+    #              symbols map to atoms; nil maps to ``[]``.  BEAM's own GC
+    #              handles reclamation.
+    #   - vm-core: delegates to the host-side ``twig.heap.Heap`` API
+    #              (already implemented in TW01).
+    #
+    # All seven ops follow the cross-backend "object-typed register"
+    # convention introduced for closures: backends with int-uniform
+    # registers must extend their typed pool to hold these new reference
+    # kinds (see CLR02 Phase 2c.5 / JVM02 Phase 2c.5 for the precedent).
+    #
+    # Numbered 55–62 so the existing 0–54 opcode IDs stay stable across
+    # serialized IR text files.
+    #
+    # MAKE_CONS dst, head_reg, tail_reg
+    #   Allocate a cons cell (head, tail) and store a reference to it
+    #   into ``dst``.  Both operands are register-valued; the cell holds
+    #   whatever those registers hold (int, cons, symbol, nil, closure).
+    MAKE_CONS = 55
+
+    # CAR dst, src
+    #   Read the head of the cons cell referenced by ``src`` into ``dst``.
+    #   Result type matches whatever was passed to MAKE_CONS as head.
+    #   Trapping behaviour on non-cons input is backend-defined; lowering
+    #   typically emits an unchecked field load (correctness obligation
+    #   on the frontend / type checker).
+    CAR = 56
+
+    # CDR dst, src
+    #   Read the tail of the cons cell referenced by ``src`` into ``dst``.
+    #   Counterpart to CAR.
+    CDR = 57
+
+    # IS_NULL dst, src
+    #   Set ``dst`` to 1 if ``src`` holds the nil value, else 0.  ``dst``
+    #   is an int-typed register so the result feeds straight into
+    #   BRANCH_Z / BRANCH_NZ.
+    IS_NULL = 58
+
+    # IS_PAIR dst, src
+    #   Set ``dst`` to 1 if ``src`` holds a cons cell, else 0.
+    IS_PAIR = 59
+
+    # MAKE_SYMBOL dst, name_label
+    #   Intern the symbol whose name is ``name_label`` (a label-encoded
+    #   identifier — chosen so the existing IR text format already
+    #   round-trips it) and store a reference to the interned symbol
+    #   into ``dst``.  Two MAKE_SYMBOL instructions with the same label
+    #   must yield references that compare equal.
+    MAKE_SYMBOL = 60
+
+    # IS_SYMBOL dst, src
+    #   Set ``dst`` to 1 if ``src`` holds a symbol, else 0.
+    IS_SYMBOL = 61
+
+    # LOAD_NIL dst
+    #   Store the nil value into ``dst``.  Used to terminate cons-cell
+    #   chains and as the canonical "false" / "empty-list" sentinel.
+    LOAD_NIL = 62
 
 
 # Canonical name → opcode mapping. Built from the enum at module load time.

--- a/code/packages/python/compiler-ir/tests/test_compiler_ir.py
+++ b/code/packages/python/compiler-ir/tests/test_compiler_ir.py
@@ -105,10 +105,20 @@ class TestIrOp:
         assert IrOp.F64_ATAN == 52
         assert IrOp.F64_LN == 53
         assert IrOp.F64_EXP == 54
+        assert IrOp.MAKE_CONS == 55
+        assert IrOp.CAR == 56
+        assert IrOp.CDR == 57
+        assert IrOp.IS_NULL == 58
+        assert IrOp.IS_PAIR == 59
+        assert IrOp.MAKE_SYMBOL == 60
+        assert IrOp.IS_SYMBOL == 61
+        assert IrOp.LOAD_NIL == 62
 
     def test_total_opcode_count(self) -> None:
-        """There are exactly 55 opcodes after adding f64 standard math."""
-        assert len(IrOp) == 55
+        """There are exactly 63 opcodes after adding TW03 Phase 3 heap
+        primitives (cons / car / cdr / is_null / is_pair / make_symbol /
+        is_symbol / load_nil)."""
+        assert len(IrOp) == 63
 
     def test_name_to_op_roundtrip(self) -> None:
         """NAME_TO_OP[op.name] == op for every opcode."""
@@ -1035,6 +1045,22 @@ class TestAllOpcodesPrintParse:
                 IrImmediate(1),
                 IrRegister(4),
             ],
+            # MAKE_CONS dst, head_reg, tail_reg
+            IrOp.MAKE_CONS:    [IrRegister(5), IrRegister(1), IrRegister(2)],
+            # CAR dst, src
+            IrOp.CAR:          [IrRegister(2), IrRegister(5)],
+            # CDR dst, src
+            IrOp.CDR:          [IrRegister(2), IrRegister(5)],
+            # IS_NULL dst, src
+            IrOp.IS_NULL:      [IrRegister(2), IrRegister(5)],
+            # IS_PAIR dst, src
+            IrOp.IS_PAIR:      [IrRegister(2), IrRegister(5)],
+            # MAKE_SYMBOL dst, name_label
+            IrOp.MAKE_SYMBOL:  [IrRegister(2), IrLabel("foo")],
+            # IS_SYMBOL dst, src
+            IrOp.IS_SYMBOL:    [IrRegister(2), IrRegister(5)],
+            # LOAD_NIL dst
+            IrOp.LOAD_NIL:     [IrRegister(2)],
         }
         for idx, op in enumerate(IrOp):
             operands = operands_by_opcode[op]

--- a/code/specs/TW03-phase3-heap-primitives.md
+++ b/code/specs/TW03-phase3-heap-primitives.md
@@ -1,0 +1,176 @@
+# TW03 Phase 3 — heap primitives across the native backends
+
+## Why this spec exists
+
+[TW03](TW03-lisp-primitives-and-gc.md) Phase 3 is "Lisp on every
+backend": cons cells, `car`, `cdr`, `null?`, `pair?`, symbols,
+`quote`, and `nil` running natively on JVM / CLR / BEAM (and
+later WASM) without falling back to vm-core interpretation.
+
+Phase 2 (closures) shipped the precedent for "object-typed
+register slot" lowering in CLR Phase 2c.5 / JVM Phase 2c.5.  This
+spec extends the same pattern from one boxed reference kind
+(closures) to four (closures + cons + symbol + nil), so the
+existing typed-pool plumbing in
+[ir-to-jvm-class-file](../packages/python/ir-to-jvm-class-file/)
+and [ir-to-cil-bytecode](../packages/python/ir-to-cil-bytecode/)
+already does most of the work — we just teach the heap-primitive
+opcodes how to allocate and inspect.
+
+## Acceptance criterion
+
+```python
+>>> from twig_jvm_compiler import run_source
+>>> run_source(
+...   "(define (length xs)"
+...   "  (if (null? xs) 0 (+ 1 (length (cdr xs)))))"
+...   "(length (cons 1 (cons 2 (cons 3 nil))))",
+...   class_name="Length",
+... ).stdout.strip()
+b'\\x03'   # = 3
+```
+
+The same source must produce exit-code 3 on real `dotnet` via
+`twig_clr_compiler.run_source` and on real `erl` via
+`twig_beam_compiler.run_source`.
+
+## Cross-backend value model
+
+The IR-level convention introduced for closures in Phase 2c.5 is
+unchanged: every IR register has both an int slot and an
+object-reference slot, and per-register typing decides which slot
+each operation reads or writes.  Phase 3 adds three new
+reference-kind tags inside the object slot:
+
+| Tag    | Backend representation (JVM / CLR / BEAM) |
+|--------|--------------------------------------------|
+| `int`     | unboxed int (existing) |
+| `closure` | `Closure_<name>` instance (Phase 2 — existing) |
+| `cons`    | `coding_adventures.twig.runtime.Cons` instance |
+| `symbol`  | interned `coding_adventures.twig.runtime.Symbol` |
+| `nil`     | a single sentinel `Nil` instance (per assembly) |
+
+On BEAM the mapping is even more direct: cons → `[H \| T]`,
+symbol → atom, nil → `[]`.  No extra "runtime" classes needed.
+
+## New IR ops (this spec — Phase 3a)
+
+Added to `compiler-ir` v0.5.0 (opcodes 55–62, leaving the
+existing 0–54 stable so older serialized IR text round-trips):
+
+```
+MAKE_CONS    dst, head_reg, tail_reg
+CAR          dst, src
+CDR          dst, src
+IS_NULL      dst, src
+IS_PAIR      dst, src
+MAKE_SYMBOL  dst, name_label
+IS_SYMBOL    dst, src
+LOAD_NIL     dst
+```
+
+`name_label` reuses `IrLabel` — the existing IR text format
+already round-trips identifier-shaped labels, so symbol names
+travel through `print_ir` / `parse_ir` for free.
+
+`IS_NULL`, `IS_PAIR`, `IS_SYMBOL` write into an int-typed
+register so the result feeds straight into `BRANCH_Z` /
+`BRANCH_NZ` without the boxing dance the closure ops needed.
+
+## Implementation phases
+
+This is a multi-PR change; staging mirrors what worked for
+Phase 2:
+
+### Phase 3a — IR ops + scaffolding (this PR)
+
+- Add the eight opcodes to `compiler-ir`.
+- Tests: opcode-numbering invariant + parse/print round-trip
+  for every new op.
+- No backend lowering yet — that lives in 3b/3c/3d.
+- This unblocks parallel work on JVM03, CLR03, BEAM03.
+
+### Phase 3b — JVM heap primitives (JVM03)
+
+- Generate `coding_adventures.twig.runtime.Cons` (final fields
+  `head`, `tail`; both `Object`), `Symbol` (`String name`,
+  static intern map), and a `Nil` sentinel class.
+- Lower `MAKE_CONS` to `new Cons; dup; aload head; aload tail;
+  invokespecial Cons.<init>(LObject;LObject;)V`, then
+  `aastore __ca_objregs[dst]`.
+- Lower `CAR` / `CDR` to `aaload __ca_objregs[src];
+  getfield Cons.head/tail; aastore __ca_objregs[dst]`.
+- Lower `IS_NULL` to identity check against the per-program
+  `NIL` static field; `IS_PAIR` and `IS_SYMBOL` to
+  `instanceof` against `Cons` / `Symbol`.
+- `MAKE_SYMBOL` calls a static `Symbol.intern(String)` that
+  hashes into a `HashMap<String,Symbol>`.
+- `LOAD_NIL` reads the per-program `NIL` static field.
+
+### Phase 3c — CLR heap primitives (CLR03)
+
+- Same shape as JVM but as additional `TypeDef` rows in the
+  single PE/CLI assembly (the multi-TypeDef plumbing from
+  CLR02 Phase 2b carries over verbatim).
+- `Cons` / `Symbol` / `Nil` types under the assembly's
+  namespace; `Symbol.Intern(string)` static method.
+- `IS_PAIR` / `IS_SYMBOL` lower to `isinst` + `ldnull; cgt.un`.
+
+### Phase 3d — BEAM heap primitives (BEAM03)
+
+- `MAKE_CONS` lowers to `put_list head, tail, dst`.
+- `CAR` / `CDR` lower to `get_hd` / `get_tl`.
+- `IS_NULL` lowers to `is_nil` test op (matches `[]`).
+- `IS_PAIR` lowers to `is_nonempty_list`.
+- `MAKE_SYMBOL` lowers to a literal atom in the atom table
+  (BEAM atoms are global per VM, so "interning" is free).
+- `IS_SYMBOL` lowers to `is_atom`.
+- `LOAD_NIL` lowers to `move nil dst` (the `[]` literal).
+
+### Phase 3e — Twig frontend acceptance
+
+- `twig.parser` already accepts `cons`, `car`, `cdr`, `null?`,
+  `pair?`, `quote` / `'foo`, `nil` (the AST nodes exist for
+  the vm-core path).  Currently `twig_jvm_compiler` /
+  `twig_clr_compiler` / `twig_beam_compiler` raise
+  `TwigCompileError` for these; the per-backend Phase 3e
+  removes the rejection and emits the new IR ops.
+- New end-to-end tests: `length`, `reverse`, `member?`,
+  symbol-based dispatch — all running on real
+  `java` / `dotnet` / `erl`.
+
+## Risk register
+
+- **Per-program nil sentinel.**  JVM and CLR each need a single
+  `Nil` instance shared across all closure / heap operations
+  in the same assembly.  Mitigation: emit a static `NIL` field
+  on the program's main class, initialised in `<clinit>`.
+- **Symbol intern table thread safety.**  HashMap-based interns
+  are not thread-safe.  Twig today is single-threaded; document
+  the limit and revisit if/when we add a thread spec.
+- **Tagged-pointer migration.**  TW03's headline design quotes a
+  64-bit tagged pointer; the closure work shipped a parallel
+  object-slot pool instead.  Phase 3 stays consistent with the
+  shipped closure design — no migration in this phase.  If we
+  later add an FFI / WASM backend that genuinely needs tagged
+  pointers, that's a separate spec.
+- **`IS_PAIR` on closure / symbol values.**  Returns 0 (good).
+  The Cons/Symbol/Closure classes are unrelated, so
+  `instanceof Cons` correctly says "no" on a Symbol or Closure
+  reference.  Tests will lock this down.
+
+## Out of scope
+
+- **Mutation** (`set-car!`, `set-cdr!`).  Cons cells are
+  immutable in TW03 v1.  R5RS allows mutation but our cons
+  fields are `final` for simplicity.  Add a separate spec if a
+  use case appears.
+- **Vector / hashmap / record types.**  Pure-Lisp v1 is just
+  cons + atom + nil.
+- **Equal-symbols-by-name across assemblies.**  Each compiled
+  assembly has its own intern table.  Two Twig programs running
+  in the same JVM will have separate `'foo` symbols.  Document
+  it; revisit if cross-assembly symbol equality matters.
+- **GC** — TW03 Phase 4 territory.  On JVM/CLR/BEAM the host GC
+  reclaims our objects automatically once Phase 3 lands; no
+  extra compiler work needed.  On WASM, see TW04.


### PR DESCRIPTION
## Summary

Adds the cross-backend Lisp heap-primitive interface — 8 new IR opcodes (IDs 55–62) plus the implementation spec at [code/specs/TW03-phase3-heap-primitives.md](code/specs/TW03-phase3-heap-primitives.md).

This is the foundational scaffolding for **TW03 Phase 3** (Lisp on every backend). Backend lowering ships in subsequent phases (JVM03, CLR03, BEAM03), so this PR unblocks parallel work on all three native backends.

## New opcodes

| Opcode | ID | Layout |
|---|---|---|
| `MAKE_CONS` | 55 | `dst, head_reg, tail_reg` |
| `CAR` | 56 | `dst, src` |
| `CDR` | 57 | `dst, src` |
| `IS_NULL` | 58 | `dst, src` |
| `IS_PAIR` | 59 | `dst, src` |
| `MAKE_SYMBOL` | 60 | `dst, name_label` |
| `IS_SYMBOL` | 61 | `dst, src` |
| `LOAD_NIL` | 62 | `dst` |

Type-test ops write into int-typed registers so results feed straight into `BRANCH_Z` / `BRANCH_NZ`. `MAKE_SYMBOL` takes an `IrLabel` so the existing IR text round-trip path handles symbol names with no parser changes. Opcode IDs 0–54 are unchanged → older serialized IR text round-trips byte-for-byte.

## Test plan

- [x] Opcode-numbering invariant extended for IDs 55–62
- [x] Total-opcode-count assertion bumped to 63
- [x] Print/parse round-trip extended with one fixture per new op
- [x] 114 compiler-ir tests pass
- [x] Downstream ir-to-jvm-class-file (85 passed) and ir-to-cil-bytecode (64 passed) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)