### PR TITLE
Recover invalid HTML numeric references

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -114,6 +114,9 @@ documented in this file.
 - NULL characters in script escaped and double-escaped substates now recover
   with `unexpected-null-character` and append U+FFFD while preserving their
   dash-sensitive state transitions.
+- Numeric character references now report invalid-code-point diagnostics and
+  recover with replacement/remapping behavior for null, surrogate,
+  out-of-range, noncharacter, and Windows-1252 control references.
 - One-dash markup declarations such as `<!->` and `<!-x>` now use
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -25,6 +25,9 @@ the project, but the first real HTML authoring artifact that must keep HTML
 The default lexer already resolves the core named character references and the
 classic Latin-1 entity set, preserving entity-name case so legacy names such as
 `Agrave` and `agrave` remain distinct.
+Numeric character references report invalid-code-point diagnostics and recover
+with the HTML replacement/remapping rules for null, surrogate, out-of-range,
+noncharacter, and Windows-1252 control references.
 Duplicate attributes recover with HTML semantics: the first attribute value is
 kept, later attributes with the same interpreted name are dropped, and a
 `duplicate-attribute` diagnostic is recorded.

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 64);
+    assert_eq!(html1.cases.len(), 65);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 64);
+    assert_eq!(file.tests.len(), 65);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 64);
+    assert_eq!(normalized.cases.len(), 65);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 64);
+    assert_eq!(suite.cases.len(), 65);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -539,6 +539,9 @@
       "tokens": [
         "Text(data=Letters: A B C \uFFFD)",
         "EOF"
+      ],
+      "diagnostics": [
+        "null-character-reference"
       ]
     },
     {
@@ -548,6 +551,25 @@
       "tokens": [
         "StartTag(name=a, attributes=[title=AB, data-x=C, note=\uFFFD], self_closing=false)",
         "EOF"
+      ],
+      "diagnostics": [
+        "null-character-reference"
+      ]
+    },
+    {
+      "id": "html-invalid-numeric-character-reference-recovery",
+      "description": "Invalid numeric character references report spec diagnostics and use replacement or remapped characters",
+      "input": "<a data='&#0; &#xD800; &#x110000; &#xFDD0; &#x80;'>",
+      "tokens": [
+        "StartTag(name=a, attributes=[data=\uFFFD \uFFFD \uFFFD \uFDD0 \u20AC], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "null-character-reference",
+        "surrogate-character-reference",
+        "character-reference-outside-unicode-range",
+        "noncharacter-character-reference",
+        "control-character-reference"
       ]
     },
     {

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -611,7 +611,9 @@
         "Text(data=Letters: A B C \ufffd)",
         "EOF"
       ],
-      "diagnostics": []
+      "diagnostics": [
+        "null-character-reference"
+      ]
     },
     {
       "id": "html5lib-smoke-48",
@@ -621,10 +623,28 @@
         "StartTag(name=a, attributes=[title=AB, data-x=C, note=\ufffd], self_closing=false)",
         "EOF"
       ],
-      "diagnostics": []
+      "diagnostics": [
+        "null-character-reference"
+      ]
     },
     {
       "id": "html5lib-smoke-49",
+      "description": "invalid numeric character reference recovery",
+      "input": "<a data='&#0; &#xD800; &#x110000; &#xFDD0; &#x80;'>",
+      "tokens": [
+        "StartTag(name=a, attributes=[data=\ufffd \ufffd \ufffd \ufdd0 \u20ac], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "null-character-reference",
+        "surrogate-character-reference",
+        "character-reference-outside-unicode-range",
+        "noncharacter-character-reference",
+        "control-character-reference"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-50",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -636,7 +656,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-50",
+      "id": "html5lib-smoke-51",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -649,7 +669,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-51",
+      "id": "html5lib-smoke-52",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -662,7 +682,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-52",
+      "id": "html5lib-smoke-53",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -677,7 +697,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-53",
+      "id": "html5lib-smoke-54",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -690,7 +710,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-55",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -704,7 +724,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-55",
+      "id": "html5lib-smoke-56",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -717,7 +737,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-56",
+      "id": "html5lib-smoke-57",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -731,7 +751,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-57",
+      "id": "html5lib-smoke-58",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [
@@ -745,7 +765,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-58",
+      "id": "html5lib-smoke-59",
       "description": "question mark after tag open recovers as bogus comment",
       "input": "Before<?xml version=\"1.0\"?>After",
       "tokens": [
@@ -759,7 +779,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-59",
+      "id": "html5lib-smoke-60",
       "description": "question mark bogus comment eof has no eof-in-comment error",
       "input": "Before<?xml",
       "tokens": [
@@ -772,7 +792,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-60",
+      "id": "html5lib-smoke-61",
       "description": "incorrectly opened markup declaration reports tokenizer error",
       "input": "Before<!foo>After",
       "tokens": [
@@ -786,7 +806,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-61",
+      "id": "html5lib-smoke-62",
       "description": "empty incorrectly opened markup declaration reconsumes delimiter",
       "input": "Before<!>After",
       "tokens": [
@@ -800,7 +820,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-62",
+      "id": "html5lib-smoke-63",
       "description": "markup declaration opener eof recovers as empty bogus comment",
       "input": "Before<!",
       "tokens": [
@@ -813,7 +833,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-63",
+      "id": "html5lib-smoke-64",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -832,7 +852,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-64",
+      "id": "html5lib-smoke-65",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -529,6 +529,9 @@
         ["Character", "C"],
         ["Character", " "],
         ["Character", "\uFFFD"]
+      ],
+      "errors": [
+        {"code": "null-character-reference", "line": 1, "col": 28}
       ]
     },
     {
@@ -536,6 +539,23 @@
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "output": [
         ["StartTag", "a", {"title": "AB", "data-x": "C", "note": "\uFFFD"}]
+      ],
+      "errors": [
+        {"code": "null-character-reference", "line": 1, "col": 53}
+      ]
+    },
+    {
+      "description": "invalid numeric character reference recovery",
+      "input": "<a data='&#0; &#xD800; &#x110000; &#xFDD0; &#x80;'>",
+      "output": [
+        ["StartTag", "a", {"data": "\uFFFD \uFFFD \uFFFD \uFDD0 \u20AC"}]
+      ],
+      "errors": [
+        {"code": "null-character-reference", "line": 1, "col": 13},
+        {"code": "surrogate-character-reference", "line": 1, "col": 22},
+        {"code": "character-reference-outside-unicode-range", "line": 1, "col": 33},
+        {"code": "noncharacter-character-reference", "line": 1, "col": 42},
+        {"code": "control-character-reference", "line": 1, "col": 49}
       ]
     },
     {

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1640,6 +1640,47 @@ fn default_html_lexer_supports_numeric_character_references_in_attributes() {
 }
 
 #[test]
+fn default_html_lexer_reports_invalid_numeric_character_references() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("<a data='&#0; &#xD800; &#x110000; &#xFDD0; &#x80;'>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![Attribute {
+                    name: "data".to_string(),
+                    value: "\u{FFFD} \u{FFFD} \u{FFFD} \u{FDD0} \u{20AC}".to_string(),
+                }],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+
+    let diagnostics = lexer
+        .diagnostics()
+        .iter()
+        .map(|diagnostic| diagnostic.code.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        diagnostics,
+        vec![
+            "null-character-reference",
+            "surrogate-character-reference",
+            "character-reference-outside-unicode-range",
+            "noncharacter-character-reference",
+            "control-character-reference",
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_seeded_rcdata_numeric_character_references() {
     let mut lexer = create_html_lexer().unwrap();
     lexer.set_initial_state("rcdata").unwrap();

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -33,3 +33,6 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
 - Added DOCTYPE replacement actions for names, public identifiers, and system
   identifiers so lexer definitions can recover invalid DOCTYPE code points with
   U+FFFD.
+- Numeric character-reference actions now report invalid-code-point diagnostics
+  and apply HTML replacement/remapping behavior for null, surrogate,
+  out-of-range, noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -564,14 +564,16 @@ impl Tokenizer {
                         .push_str(&temporary_buffer);
                 }
                 "append_numeric_character_reference_to_text" => {
-                    let ch = numeric_character_reference(&self.temporary_buffer);
+                    let reference = numeric_character_reference(&self.temporary_buffer);
                     self.temporary_buffer.clear();
-                    self.text_buffer.push(ch);
+                    self.text_buffer.push(reference.character);
+                    self.record_diagnostics(reference.diagnostics, position, state);
                 }
                 "append_numeric_character_reference_to_attribute_value" => {
-                    let ch = numeric_character_reference(&self.temporary_buffer);
+                    let reference = numeric_character_reference(&self.temporary_buffer);
                     self.temporary_buffer.clear();
-                    self.attribute_mut(action)?.value.push(ch);
+                    self.attribute_mut(action)?.value.push(reference.character);
+                    self.record_diagnostics(reference.diagnostics, position, state);
                 }
                 "append_named_character_reference_to_text" => {
                     let replacement =
@@ -949,6 +951,20 @@ impl Tokenizer {
         }
     }
 
+    fn record_diagnostics(
+        &mut self,
+        diagnostics: Vec<&'static str>,
+        position: SourcePosition,
+        state: &str,
+    ) {
+        self.diagnostics
+            .extend(diagnostics.into_iter().map(|code| Diagnostic {
+                code: code.to_string(),
+                position,
+                state: state.to_string(),
+            }));
+    }
+
     fn emit_current_token(&mut self, action: &str) -> Result<()> {
         if matches!(self.current_token, Some(CurrentToken::StartTag { .. }))
             && self.current_attribute.is_some()
@@ -1136,9 +1152,18 @@ fn push_lowercase(target: &mut String, ch: char) {
     }
 }
 
-fn numeric_character_reference(buffer: &str) -> char {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NumericCharacterReference {
+    character: char,
+    diagnostics: Vec<&'static str>,
+}
+
+fn numeric_character_reference(buffer: &str) -> NumericCharacterReference {
     let Some(raw_digits) = buffer.strip_prefix("&#") else {
-        return '\u{FFFD}';
+        return NumericCharacterReference {
+            character: '\u{FFFD}',
+            diagnostics: vec!["absence-of-digits-in-numeric-character-reference"],
+        };
     };
     let (radix, digits) = match raw_digits
         .strip_prefix('x')
@@ -1148,19 +1173,146 @@ fn numeric_character_reference(buffer: &str) -> char {
         None => (10, raw_digits),
     };
     if digits.is_empty() {
-        return '\u{FFFD}';
+        return NumericCharacterReference {
+            character: '\u{FFFD}',
+            diagnostics: vec!["absence-of-digits-in-numeric-character-reference"],
+        };
     }
 
-    u32::from_str_radix(digits, radix)
-        .ok()
-        .and_then(|value| {
-            if value == 0 {
-                None
-            } else {
-                char::from_u32(value)
-            }
-        })
-        .unwrap_or('\u{FFFD}')
+    let Ok(value) = u32::from_str_radix(digits, radix) else {
+        return NumericCharacterReference {
+            character: '\u{FFFD}',
+            diagnostics: vec!["character-reference-outside-unicode-range"],
+        };
+    };
+
+    if value == 0 {
+        return NumericCharacterReference {
+            character: '\u{FFFD}',
+            diagnostics: vec!["null-character-reference"],
+        };
+    }
+
+    if value > 0x10FFFF {
+        return NumericCharacterReference {
+            character: '\u{FFFD}',
+            diagnostics: vec!["character-reference-outside-unicode-range"],
+        };
+    }
+
+    if (0xD800..=0xDFFF).contains(&value) {
+        return NumericCharacterReference {
+            character: '\u{FFFD}',
+            diagnostics: vec!["surrogate-character-reference"],
+        };
+    }
+
+    let mut diagnostics = Vec::new();
+    if is_noncharacter(value) {
+        diagnostics.push("noncharacter-character-reference");
+    }
+
+    let character = if let Some(replacement) = windows_1252_control_replacement(value) {
+        diagnostics.push("control-character-reference");
+        replacement
+    } else {
+        let character = char::from_u32(value).unwrap_or('\u{FFFD}');
+        if is_control_character_reference(value) {
+            diagnostics.push("control-character-reference");
+        }
+        character
+    };
+
+    NumericCharacterReference {
+        character,
+        diagnostics,
+    }
+}
+
+fn is_noncharacter(value: u32) -> bool {
+    (0xFDD0..=0xFDEF).contains(&value)
+        || matches!(
+            value,
+            0xFFFE
+                | 0xFFFF
+                | 0x1FFFE
+                | 0x1FFFF
+                | 0x2FFFE
+                | 0x2FFFF
+                | 0x3FFFE
+                | 0x3FFFF
+                | 0x4FFFE
+                | 0x4FFFF
+                | 0x5FFFE
+                | 0x5FFFF
+                | 0x6FFFE
+                | 0x6FFFF
+                | 0x7FFFE
+                | 0x7FFFF
+                | 0x8FFFE
+                | 0x8FFFF
+                | 0x9FFFE
+                | 0x9FFFF
+                | 0xAFFFE
+                | 0xAFFFF
+                | 0xBFFFE
+                | 0xBFFFF
+                | 0xCFFFE
+                | 0xCFFFF
+                | 0xDFFFE
+                | 0xDFFFF
+                | 0xEFFFE
+                | 0xEFFFF
+                | 0xFFFFE
+                | 0xFFFFF
+                | 0x10FFFE
+                | 0x10FFFF
+        )
+}
+
+fn is_control_character_reference(value: u32) -> bool {
+    value == 0x0D || (is_control(value) && !is_ascii_whitespace_control(value))
+}
+
+fn is_control(value: u32) -> bool {
+    value <= 0x1F || (0x7F..=0x9F).contains(&value)
+}
+
+fn is_ascii_whitespace_control(value: u32) -> bool {
+    matches!(value, 0x09 | 0x0A | 0x0C | 0x20)
+}
+
+fn windows_1252_control_replacement(value: u32) -> Option<char> {
+    match value {
+        0x80 => Some('\u{20AC}'),
+        0x82 => Some('\u{201A}'),
+        0x83 => Some('\u{0192}'),
+        0x84 => Some('\u{201E}'),
+        0x85 => Some('\u{2026}'),
+        0x86 => Some('\u{2020}'),
+        0x87 => Some('\u{2021}'),
+        0x88 => Some('\u{02C6}'),
+        0x89 => Some('\u{2030}'),
+        0x8A => Some('\u{0160}'),
+        0x8B => Some('\u{2039}'),
+        0x8C => Some('\u{0152}'),
+        0x8E => Some('\u{017D}'),
+        0x91 => Some('\u{2018}'),
+        0x92 => Some('\u{2019}'),
+        0x93 => Some('\u{201C}'),
+        0x94 => Some('\u{201D}'),
+        0x95 => Some('\u{2022}'),
+        0x96 => Some('\u{2013}'),
+        0x97 => Some('\u{2014}'),
+        0x98 => Some('\u{02DC}'),
+        0x99 => Some('\u{2122}'),
+        0x9A => Some('\u{0161}'),
+        0x9B => Some('\u{203A}'),
+        0x9C => Some('\u{0153}'),
+        0x9E => Some('\u{017E}'),
+        0x9F => Some('\u{0178}'),
+        _ => None,
+    }
 }
 
 fn named_character_reference(buffer: &str) -> Option<&'static str> {

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -617,6 +617,65 @@ fn tokenizer_decodes_numeric_character_references_from_temporary_buffer() {
 }
 
 #[test]
+fn tokenizer_reports_invalid_numeric_character_references() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "done"]),
+            set(&["N"]),
+            vec![EffectfulTransition::new(
+                "data",
+                EffectfulMatcher::Event("N".to_string()),
+                "done",
+            )
+            .with_effects(&[
+                "clear_temporary_buffer",
+                "append_temporary_buffer(&#0)",
+                "append_numeric_character_reference_to_text",
+                "append_text( )",
+                "append_temporary_buffer(&#xD800)",
+                "append_numeric_character_reference_to_text",
+                "append_text( )",
+                "append_temporary_buffer(&#x110000)",
+                "append_numeric_character_reference_to_text",
+                "append_text( )",
+                "append_temporary_buffer(&#xFDD0)",
+                "append_numeric_character_reference_to_text",
+                "append_text( )",
+                "append_temporary_buffer(&#x80)",
+                "append_numeric_character_reference_to_text",
+                "flush_text",
+            ])],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    );
+
+    tokenizer.push("N").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Text(
+            "\u{FFFD} \u{FFFD} \u{FFFD} \u{FDD0} \u{20AC}".to_string()
+        )]
+    );
+    assert_eq!(
+        tokenizer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "null-character-reference",
+            "surrogate-character-reference",
+            "character-reference-outside-unicode-range",
+            "noncharacter-character-reference",
+            "control-character-reference",
+        ]
+    );
+}
+
+#[test]
 fn tokenizer_decodes_named_character_references_from_temporary_buffer() {
     let mut tokenizer = Tokenizer::new(
         EffectfulStateMachine::new(


### PR DESCRIPTION
## Summary
- report HTML numeric character-reference diagnostics for null, surrogate, out-of-range, noncharacter, and control references
- apply replacement/remapping behavior, including Windows-1252 control remaps
- extend tokenizer, wrapper, html1, and html5lib smoke coverage for invalid numeric references

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_reports_invalid_numeric_character_references -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml --tests
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests
- git diff --check