### PR TITLE
Report digitless HTML numeric references

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -117,6 +117,8 @@ documented in this file.
 - Numeric character references now report invalid-code-point diagnostics and
   recover with replacement/remapping behavior for null, surrogate,
   out-of-range, noncharacter, and Windows-1252 control references.
+- Digitless numeric character references such as `&#;` and `&#x;` now report
+  `absence-of-digits-in-numeric-character-reference` while staying literal.
 - One-dash markup declarations such as `<!->` and `<!-x>` now use
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -28,6 +28,8 @@ classic Latin-1 entity set, preserving entity-name case so legacy names such as
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.
+Digitless numeric references such as `&#;` and `&#x;` stay literal while
+reporting `absence-of-digits-in-numeric-character-reference`.
 Duplicate attributes recover with HTML semantics: the first attribute value is
 kept, later attributes with the same interpreted name are dropped, and a
 `duplicate-attribute` diagnostic is recorded.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -1557,14 +1557,23 @@ from = "text_numeric_character_reference"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["append_temporary_buffer_to_text", "flush_text", "emit(EOF)"]
+actions = [
+  "append_temporary_buffer_to_text",
+  "parse_error(absence-of-digits-in-numeric-character-reference)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "text_numeric_character_reference"
 matcher = { anything = true }
 to = "data"
 consume = false
-actions = ["append_temporary_buffer_to_text", "switch_to_return_state"]
+actions = [
+  "append_temporary_buffer_to_text",
+  "parse_error(absence-of-digits-in-numeric-character-reference)",
+  "switch_to_return_state",
+]
 
 [[transitions]]
 from = "text_numeric_hex_character_reference_start"
@@ -1589,14 +1598,23 @@ from = "text_numeric_hex_character_reference_start"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["append_temporary_buffer_to_text", "flush_text", "emit(EOF)"]
+actions = [
+  "append_temporary_buffer_to_text",
+  "parse_error(absence-of-digits-in-numeric-character-reference)",
+  "flush_text",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "text_numeric_hex_character_reference_start"
 matcher = { anything = true }
 to = "data"
 consume = false
-actions = ["append_temporary_buffer_to_text", "switch_to_return_state"]
+actions = [
+  "append_temporary_buffer_to_text",
+  "parse_error(absence-of-digits-in-numeric-character-reference)",
+  "switch_to_return_state",
+]
 
 [[transitions]]
 from = "text_numeric_hex_character_reference"
@@ -3260,6 +3278,7 @@ to = "done"
 consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
+  "parse_error(absence-of-digits-in-numeric-character-reference)",
   "parse_error(eof-in-tag)",
   "commit_attribute_dedup",
   "emit_current_token",
@@ -3273,6 +3292,7 @@ to = "attribute_value_unquoted"
 consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
+  "parse_error(absence-of-digits-in-numeric-character-reference)",
   "switch_to_return_state",
 ]
 
@@ -3301,6 +3321,7 @@ to = "done"
 consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
+  "parse_error(absence-of-digits-in-numeric-character-reference)",
   "parse_error(eof-in-tag)",
   "commit_attribute_dedup",
   "emit_current_token",
@@ -3314,6 +3335,7 @@ to = "attribute_value_unquoted"
 consume = false
 actions = [
   "append_temporary_buffer_to_attribute_value",
+  "parse_error(absence-of-digits-in-numeric-character-reference)",
   "switch_to_return_state",
 ]
 

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -3547,6 +3547,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_temporary_buffer_to_text".to_string(),
+                "parse_error(absence-of-digits-in-numeric-character-reference)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -3564,6 +3565,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_temporary_buffer_to_text".to_string(),
+                "parse_error(absence-of-digits-in-numeric-character-reference)".to_string(),
                 "switch_to_return_state".to_string(),
             ],
             consume: false,
@@ -3625,6 +3627,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_temporary_buffer_to_text".to_string(),
+                "parse_error(absence-of-digits-in-numeric-character-reference)".to_string(),
                 "flush_text".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -3642,6 +3645,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_temporary_buffer_to_text".to_string(),
+                "parse_error(absence-of-digits-in-numeric-character-reference)".to_string(),
                 "switch_to_return_state".to_string(),
             ],
             consume: false,
@@ -7309,6 +7313,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
+                "parse_error(absence-of-digits-in-numeric-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
                 "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
@@ -7328,6 +7333,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
+                "parse_error(absence-of-digits-in-numeric-character-reference)".to_string(),
                 "switch_to_return_state".to_string(),
             ],
             consume: false,
@@ -7389,6 +7395,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
+                "parse_error(absence-of-digits-in-numeric-character-reference)".to_string(),
                 "parse_error(eof-in-tag)".to_string(),
                 "commit_attribute_dedup".to_string(),
                 "emit_current_token".to_string(),
@@ -7408,6 +7415,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_temporary_buffer_to_attribute_value".to_string(),
+                "parse_error(absence-of-digits-in-numeric-character-reference)".to_string(),
                 "switch_to_return_state".to_string(),
             ],
             consume: false,

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 65);
+    assert_eq!(html1.cases.len(), 66);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 65);
+    assert_eq!(file.tests.len(), 66);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 65);
+    assert_eq!(normalized.cases.len(), 66);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 65);
+    assert_eq!(suite.cases.len(), 66);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -573,6 +573,22 @@
       ]
     },
     {
+      "id": "html-absence-of-digits-numeric-character-reference-recovery",
+      "description": "Numeric character references without digits stay literal and report absence-of-digits diagnostics",
+      "input": "Bad &#; &#x; <a title='&#x;' data=&#;>",
+      "tokens": [
+        "Text(data=Bad &#; &#x; )",
+        "StartTag(name=a, attributes=[title=&#x;, data=&#;], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference",
+        "absence-of-digits-in-numeric-character-reference",
+        "absence-of-digits-in-numeric-character-reference",
+        "absence-of-digits-in-numeric-character-reference"
+      ]
+    },
+    {
       "id": "html-numeric-character-references-rcdata",
       "description": "Seeded title RCDATA context resolves numeric character references as text",
       "input": "Fish &#38; &#x3C;/title>",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -645,6 +645,22 @@
     },
     {
       "id": "html5lib-smoke-50",
+      "description": "numeric character references without digits stay literal",
+      "input": "Bad &#; &#x; <a title='&#x;' data=&#;>",
+      "tokens": [
+        "Text(data=Bad &#; &#x; )",
+        "StartTag(name=a, attributes=[title=&#x;, data=&#;], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference",
+        "absence-of-digits-in-numeric-character-reference",
+        "absence-of-digits-in-numeric-character-reference",
+        "absence-of-digits-in-numeric-character-reference"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-51",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -656,7 +672,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-51",
+      "id": "html5lib-smoke-52",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -669,7 +685,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-52",
+      "id": "html5lib-smoke-53",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -682,7 +698,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-53",
+      "id": "html5lib-smoke-54",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -697,7 +713,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-55",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -710,7 +726,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-55",
+      "id": "html5lib-smoke-56",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -724,7 +740,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-56",
+      "id": "html5lib-smoke-57",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -737,7 +753,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-57",
+      "id": "html5lib-smoke-58",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -751,7 +767,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-58",
+      "id": "html5lib-smoke-59",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [
@@ -765,7 +781,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-59",
+      "id": "html5lib-smoke-60",
       "description": "question mark after tag open recovers as bogus comment",
       "input": "Before<?xml version=\"1.0\"?>After",
       "tokens": [
@@ -779,7 +795,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-60",
+      "id": "html5lib-smoke-61",
       "description": "question mark bogus comment eof has no eof-in-comment error",
       "input": "Before<?xml",
       "tokens": [
@@ -792,7 +808,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-61",
+      "id": "html5lib-smoke-62",
       "description": "incorrectly opened markup declaration reports tokenizer error",
       "input": "Before<!foo>After",
       "tokens": [
@@ -806,7 +822,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-62",
+      "id": "html5lib-smoke-63",
       "description": "empty incorrectly opened markup declaration reconsumes delimiter",
       "input": "Before<!>After",
       "tokens": [
@@ -820,7 +836,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-63",
+      "id": "html5lib-smoke-64",
       "description": "markup declaration opener eof recovers as empty bogus comment",
       "input": "Before<!",
       "tokens": [
@@ -833,7 +849,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-64",
+      "id": "html5lib-smoke-65",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -852,7 +868,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-65",
+      "id": "html5lib-smoke-66",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -559,6 +559,20 @@
       ]
     },
     {
+      "description": "numeric character references without digits stay literal",
+      "input": "Bad &#; &#x; <a title='&#x;' data=&#;>",
+      "output": [
+        ["Character", "Bad &#; &#x; "],
+        ["StartTag", "a", {"title": "&#x;", "data": "&#;"}]
+      ],
+      "errors": [
+        {"code": "absence-of-digits-in-numeric-character-reference", "line": 1, "col": 7},
+        {"code": "absence-of-digits-in-numeric-character-reference", "line": 1, "col": 12},
+        {"code": "absence-of-digits-in-numeric-character-reference", "line": 1, "col": 27},
+        {"code": "absence-of-digits-in-numeric-character-reference", "line": 1, "col": 37}
+      ]
+    },
+    {
       "description": "rcdata numeric character references remain text",
       "initialStates": ["RCDATA state"],
       "lastStartTag": "title",

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1681,6 +1681,48 @@ fn default_html_lexer_reports_invalid_numeric_character_references() {
 }
 
 #[test]
+fn default_html_lexer_reports_numeric_character_references_without_digits() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("Bad &#; &#x; <a title='&#x;' data=&#;>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Bad &#; &#x; ".to_string()),
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "title".to_string(),
+                        value: "&#x;".to_string(),
+                    },
+                    Attribute {
+                        name: "data".to_string(),
+                        value: "&#;".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == "absence-of-digits-in-numeric-character-reference"
+            })
+            .count(),
+        4
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_seeded_rcdata_numeric_character_references() {
     let mut lexer = create_html_lexer().unwrap();
     lexer.set_initial_state("rcdata").unwrap();


### PR DESCRIPTION
## Summary
- report absence-of-digits diagnostics for digitless decimal and hex numeric references
- preserve literal text/attribute values for cases like &#; and &#x;
- regenerate the statically linked HTML1 Rust machine and extend html1/html5lib smoke coverage

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_reports_numeric_character_references_without_digits -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test -- --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test -- --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml --test rust_source_test html1_toml_compiles_to_rust_source -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml --test toml_test lexer_profile_html1_toml_parses_into_typed_definition -- --exact --nocapture
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml --tests
- git diff --check