### PR TITLE
feat(jvm): TW03 Phase 3e — heap primitives from Twig source

### DIFF
--- a/code/packages/python/twig-jvm-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-jvm-compiler/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog — twig-jvm-compiler
 
+## [0.3.0] — 2026-04-30 — TW03 Phase 3e (heap primitives from Twig source)
+
+Twig source containing `cons` / `car` / `cdr` / `null?` / `pair?` /
+`symbol?` / `'foo` / `nil` now compiles via the JVM backend
+(builds on the Phase 3b heap-op lowering work).  Non-recursive
+heap programs run end-to-end on real `java`; recursive heap
+programs hit a known JVM-backend obj-pool caller-saves
+limitation that's tracked as a follow-up.
+
+### Added — heap-primitive emission
+
+- `nil` literal lowers to `LOAD_NIL`.
+- `'foo` / `(quote foo)` lowers to `MAKE_SYMBOL` with the symbol
+  name as an `IrLabel`.
+- `cons` lowers to `MAKE_CONS dst, head, tail` (2 args).
+- `car` / `cdr` lower to `CAR` / `CDR` (1 arg each).
+- `null?` / `pair?` / `symbol?` lower to `IS_NULL` / `IS_PAIR` /
+  `IS_SYMBOL` (1 arg each, result is an int 0/1 ready to feed
+  BRANCH_Z).
+- `_HEAP_BUILTINS` table maps Twig-source names to (op, arity)
+  pairs; the apply-site dispatches uniformly.
+- `compile_source` auto-routes to `lower_ir_to_jvm_classes`
+  (the multi-class flow) when ANY heap opcode is present, not
+  just when there are closures.  Cons/Symbol/Nil runtime
+  classes get auto-included in the JAR.
+- Free-variable analysis treats `_HEAP_BUILTINS` as globals so
+  closures over `cons` / `car` / etc work.
+
+### Test additions
+
+- 8 new IR-shape tests covering each heap op's emission shape.
+- 2 new arity-validation tests (`cons` requires 2 args, `car`
+  requires 1).
+- Real-`java` end-to-end test:
+  `(car (cons 42 nil)) → 42` (passes).
+- Real-`java` xfail-strict test for the recursive headline case:
+  `(length (cons 1 (cons 2 (cons 3 nil)))) → 3`.  The IR shape
+  is correct but recursion exposes a JVM Phase 3b limitation:
+  CALL caller-saves only cover `__ca_regs` (int pool), not
+  `__ca_objregs` (object pool), so the cons ref in the obj
+  register gets clobbered before the recursive call returns.
+  Will auto-flip to passing once a follow-up extends caller-saves
+  to the obj pool — same shape as the JVM01 fix that unblocked
+  recursion through int registers.
+- All 45 tests pass + 1 xfail (strict).  91% coverage.
+
+### Limitations
+
+- Recursive heap programs hit the obj-pool caller-saves
+  limitation noted above; non-recursive heap programs work
+  end-to-end.
+- `number?` and `print` builtins still raise (not yet wired —
+  tracked separately in TW02.5).
+
 ## [0.2.0] — 2026-04-29 — JVM02 Phase 2d (closures from Twig source)
 
 Completes the JVM closure trilogy: anonymous lambdas in Twig

--- a/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
+++ b/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
@@ -158,9 +158,30 @@ _BINARY_OPS: dict[str, IrOp] = {
     ">": IrOp.CMP_GT,
 }
 
+# TW03 Phase 3e — heap-primitive builtins now compile (was rejected
+# in v1).  Each maps to its corresponding IR opcode below.  The
+# remaining rejected set is shrunk to opcodes still without a JVM
+# lowering: ``number?`` (would need a tagged-int discriminator the
+# Phase 3b heap pool doesn't have yet) and ``print`` (TW04
+# territory).
 _V1_REJECTED_BUILTINS: frozenset[str] = frozenset(
-    {"cons", "car", "cdr", "null?", "pair?", "number?", "symbol?", "print"}
+    {"number?", "print"}
 )
+
+# TW03 Phase 3e — Lisp heap-primitive builtins.  Each entry maps a
+# builtin name to its IR opcode + arity so the apply-site can
+# generate a uniform call sequence.  ``cons`` is the only 2-arg
+# heap op; the rest are 1-arg.  ``IS_NULL`` / ``IS_PAIR`` /
+# ``IS_SYMBOL`` write 0/1 into an int register so the result feeds
+# straight into BRANCH_Z (no boxing needed).
+_HEAP_BUILTINS: dict[str, tuple[IrOp, int]] = {
+    "cons":    (IrOp.MAKE_CONS, 2),
+    "car":     (IrOp.CAR, 1),
+    "cdr":     (IrOp.CDR, 1),
+    "null?":   (IrOp.IS_NULL, 1),
+    "pair?":   (IrOp.IS_PAIR, 1),
+    "symbol?": (IrOp.IS_SYMBOL, 1),
+}
 
 # Convention shared with the JVM backend's helper register array:
 #   register 0  — scratch zero (also the SYSCALL-arg slot for SYSCALL 1)
@@ -383,15 +404,15 @@ class _Compiler:
         if isinstance(expr, BoolLit):
             return self._compile_int(1 if expr.value else 0, ctx)
         if isinstance(expr, NilLit):
-            raise TwigCompileError(
-                "nil is not yet supported by the JVM backend (heap "
-                "objects come in TW02.5)"
-            )
+            # TW03 Phase 3e: lower nil to LOAD_NIL.
+            dest = self._fresh_holding(ctx)
+            self._emit(IrOp.LOAD_NIL, dest)
+            return dest
         if isinstance(expr, SymLit):
-            raise TwigCompileError(
-                "symbols are not yet supported by the JVM backend "
-                "(heap objects come in TW02.5)"
-            )
+            # TW03 Phase 3e: lower 'foo / (quote foo) to MAKE_SYMBOL.
+            dest = self._fresh_holding(ctx)
+            self._emit(IrOp.MAKE_SYMBOL, dest, IrLabel(expr.name))
+            return dest
         if isinstance(expr, VarRef):
             return self._compile_var_ref(expr, ctx)
         if isinstance(expr, If):
@@ -521,6 +542,21 @@ class _Compiler:
                     "backend — see TW02.5"
                 )
 
+            # TW03 Phase 3e — heap-primitive builtins.  Single-shape
+            # lowering: evaluate args, fresh holding reg for the
+            # result, emit the IR opcode.
+            if name in _HEAP_BUILTINS:
+                op, expected_arity = _HEAP_BUILTINS[name]
+                if len(expr.args) != expected_arity:
+                    raise TwigCompileError(
+                        f"{name!r} expects {expected_arity} arguments, "
+                        f"got {len(expr.args)}"
+                    )
+                arg_regs = [self._compile_expr(a, ctx) for a in expr.args]
+                dest = self._fresh_holding(ctx)
+                self._emit(op, dest, *arg_regs)
+                return dest
+
             # Direct binary builtin
             if name in _BINARY_OPS:
                 if len(expr.args) != 2:
@@ -610,6 +646,7 @@ class _Compiler:
             | set(self._value_consts)
             | set(_BINARY_OPS)
             | _V1_REJECTED_BUILTINS
+            | set(_HEAP_BUILTINS)
         )
         captures = free_vars(lam, globals_)
 
@@ -774,10 +811,23 @@ def compile_source(
         closure_free_var_counts=closure_free_var_counts,
     )
 
+    # TW03 Phase 3e: heap-primitive programs also need the multi-class
+    # output (Cons / Symbol / Nil runtime classes).  Detect either
+    # closures or heap ops in the IR and route to lower_ir_to_jvm_classes.
+    _HEAP_IR_OPS = frozenset({
+        IrOp.MAKE_CONS, IrOp.CAR, IrOp.CDR, IrOp.IS_NULL, IrOp.IS_PAIR,
+        IrOp.MAKE_SYMBOL, IrOp.IS_SYMBOL, IrOp.LOAD_NIL,
+    })
+    uses_heap_ir = any(
+        i.opcode in _HEAP_IR_OPS for i in optimized_ir.instructions
+    )
+
     try:
-        if closure_free_var_counts:
-            # Closure programs need the multi-class output: main class
-            # + Closure interface + per-lambda Closure_<name> subclasses.
+        if closure_free_var_counts or uses_heap_ir:
+            # Multi-class output: main class + Closure interface +
+            # per-lambda Closure_<name> subclasses + Cons/Symbol/Nil
+            # runtime classes (auto-included by lower_ir_to_jvm_classes
+            # when heap ops are detected).
             multi = lower_ir_to_jvm_classes(optimized_ir, config)
             artifact = multi.main
         else:

--- a/code/packages/python/twig-jvm-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_compile.py
@@ -124,24 +124,9 @@ def test_mutual_recursion_compiles() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cons_rejected() -> None:
-    with pytest.raises(TwigCompileError, match="cons"):
-        compile_to_ir("(cons 1 2)")
-
-
 def test_print_rejected() -> None:
     with pytest.raises(TwigCompileError, match="print"):
         compile_to_ir("(print 1)")
-
-
-def test_nil_rejected() -> None:
-    with pytest.raises(TwigCompileError, match="nil"):
-        compile_to_ir("nil")
-
-
-def test_quoted_symbol_rejected() -> None:
-    with pytest.raises(TwigCompileError, match="symbols"):
-        compile_to_ir("'foo")
 
 
 def test_unbound_name_rejected() -> None:
@@ -203,3 +188,71 @@ def test_closure_call_emits_apply_closure() -> None:
     ap = [i for i in ir.instructions if i.opcode is IrOp.APPLY_CLOSURE]
     assert len(ap) == 1
     assert ap[0].operands[2].value == 1
+
+
+# ── Heap primitives (TW03 Phase 3e) ───────────────────────────────────────
+
+
+def test_nil_emits_load_nil() -> None:
+    """A bare ``nil`` literal compiles to ``LOAD_NIL``."""
+    from compiler_ir import IrOp
+    ir = compile_to_ir("nil")
+    assert IrOp.LOAD_NIL in [i.opcode for i in ir.instructions]
+
+
+def test_quoted_symbol_emits_make_symbol() -> None:
+    """``'foo`` (or ``(quote foo)``) compiles to ``MAKE_SYMBOL``
+    with the symbol name as an ``IrLabel``."""
+    from compiler_ir import IrLabel, IrOp
+    ir = compile_to_ir("'foo")
+    mks = [i for i in ir.instructions if i.opcode is IrOp.MAKE_SYMBOL]
+    assert len(mks) == 1
+    assert isinstance(mks[0].operands[1], IrLabel)
+    assert mks[0].operands[1].name == "foo"
+
+
+def test_cons_emits_make_cons() -> None:
+    from compiler_ir import IrOp
+    ir = compile_to_ir("(cons 1 nil)")
+    assert IrOp.MAKE_CONS in [i.opcode for i in ir.instructions]
+
+
+def test_car_emits_car() -> None:
+    from compiler_ir import IrOp
+    ir = compile_to_ir("(car (cons 1 nil))")
+    assert IrOp.CAR in [i.opcode for i in ir.instructions]
+
+
+def test_cdr_emits_cdr() -> None:
+    from compiler_ir import IrOp
+    ir = compile_to_ir("(cdr (cons 1 nil))")
+    assert IrOp.CDR in [i.opcode for i in ir.instructions]
+
+
+def test_null_predicate_emits_is_null() -> None:
+    from compiler_ir import IrOp
+    ir = compile_to_ir("(null? nil)")
+    assert IrOp.IS_NULL in [i.opcode for i in ir.instructions]
+
+
+def test_pair_predicate_emits_is_pair() -> None:
+    from compiler_ir import IrOp
+    ir = compile_to_ir("(pair? (cons 1 nil))")
+    assert IrOp.IS_PAIR in [i.opcode for i in ir.instructions]
+
+
+def test_symbol_predicate_emits_is_symbol() -> None:
+    from compiler_ir import IrOp
+    ir = compile_to_ir("(symbol? 'foo)")
+    assert IrOp.IS_SYMBOL in [i.opcode for i in ir.instructions]
+
+
+def test_cons_arity_validation() -> None:
+    """``cons`` takes exactly 2 args."""
+    with pytest.raises(TwigCompileError, match="cons"):
+        compile_to_ir("(cons 1)")
+
+
+def test_car_arity_validation() -> None:
+    with pytest.raises(TwigCompileError, match="car"):
+        compile_to_ir("(car)")

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -189,3 +189,59 @@ def test_closure_let_bound() -> None:
     result = run_source(src, class_name="TwigLetClos")
     assert result.returncode == 0, result.stderr
     assert result.stdout == b"*"
+
+
+# ── Heap primitives (TW03 Phase 3e) — real-java end-to-end ────────────────
+
+
+@requires_java
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "JVM Phase 3b limitation: caller-saves on CALL only cover "
+        "__ca_regs (int pool), not __ca_objregs (object pool).  "
+        "Recursive `length` re-enters the function and the object "
+        "register holding the cons ref is clobbered before the "
+        "recursive call returns.  Will auto-flip to passing once a "
+        "follow-up extends caller-saves to the obj pool — same "
+        "shape as the JVM01 fix that unblocked recursion through "
+        "int registers."
+    ),
+)
+def test_heap_list_of_ints_length() -> None:
+    """``(length (cons 1 (cons 2 (cons 3 nil)))) → 3``.
+
+    The headline TW03 Phase 3 acceptance criterion.  Currently
+    xfail because of the obj-pool caller-saves limitation noted
+    above; the simpler non-recursive heap test
+    (`test_heap_car_of_singleton_returns_int`) does pass and
+    proves the ir-emit path works."""
+    src = """
+        (define (length xs)
+          (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+        (length (cons 1 (cons 2 (cons 3 nil))))
+    """
+    result = run_source(src, class_name="TwigLength")
+    assert result.returncode == 0, (
+        f"length pipeline broke at runtime.\n"
+        f"  exit code: {result.returncode}\n"
+        f"  stdout: {result.stdout!r}\n"
+        f"  stderr: {result.stderr!r}"
+    )
+    # 3 → byte 0x03.
+    assert result.stdout == b"\x03", (
+        f"expected b'\\x03' (= 3), got {result.stdout!r}"
+    )
+
+
+@requires_java
+def test_heap_car_of_singleton_returns_int() -> None:
+    """``(car (cons 42 nil)) → 42`` exercises the ``CAR`` int-read
+    path: the cons head is written from an int register and CAR
+    reads it back into another int register, ready for SYSCALL
+    output."""
+    src = "(car (cons 42 nil))"
+    result = run_source(src, class_name="TwigCarOne")
+    assert result.returncode == 0, result.stderr
+    # 42 = 0x2a = b'*'.
+    assert result.stdout == b"*"


### PR DESCRIPTION
## Summary

Twig source containing \`cons\` / \`car\` / \`cdr\` / \`null?\` / \`pair?\` / \`symbol?\` / \`'foo\` / \`nil\` now compiles via the JVM backend. Builds on the Phase 3b heap-op lowering.

**Stacked on [#1791](https://github.com/adhithyan15/coding-adventures/pull/1791)** (JVM Phase 3b — heap ops). Will rebase onto main once 3b merges.

## End-to-end status

✅ **Passes** on real \`java\`:
\`\`\`
(car (cons 42 nil)) → 42
\`\`\`

⚠️ **xfail-strict** (will auto-flip when fixed):
\`\`\`
(length (cons 1 (cons 2 (cons 3 nil)))) → 3
\`\`\`
exposes a JVM Phase 3b limitation — CALL caller-saves only cover \`__ca_regs\` (int pool), not \`__ca_objregs\` (object pool), so the cons ref in the obj register gets clobbered before the recursive call returns. Same shape as the JVM01 fix that unblocked recursion through int registers; tracked as a follow-up.

## What's added

- \`_HEAP_BUILTINS\` table maps Twig source names to (IrOp, arity)
- \`nil\` literal → \`LOAD_NIL\`
- \`'foo\` / \`(quote foo)\` → \`MAKE_SYMBOL\` with the name as \`IrLabel\`
- \`cons\` / \`car\` / \`cdr\` / \`null?\` / \`pair?\` / \`symbol?\` → corresponding IR opcodes
- \`compile_source\` auto-routes to multi-class JAR output when ANY heap opcode is present
- Free-variable analysis treats heap builtins as globals so closures over them work

## Test plan

- [x] 8 new IR-shape unit tests (one per heap op)
- [x] 2 new arity-validation tests
- [x] 1 passing real-\`java\` end-to-end test
- [x] 1 xfail-strict real-\`java\` end-to-end test (the recursive headline case)
- [x] 4 obsolete rejection tests removed
- [x] All 45 tests pass + 1 xfail; 91% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)