### PR TITLE
feat(prolog): batch call n meta calls

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this package will be documented in this file.
   `fd_elemento(index, vars, value)` for richer CLP(FD) modeling constraints.
 - `fd_reify_relationo(left, op, right, truth)` and boolean FD connectives for
   CLP(FD)-style reification and truth-table modeling.
+- variadic `calltermo(term_goal, *extra_args)` for Prolog-style meta-call
+  argument extension.
 
 ### Fixed
 

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -11,7 +11,8 @@ ordinary logic goal expressions.
 ## What It Adds
 
 - `callo(goal)`
-- `calltermo(term_goal)` for executing reified callable goal terms
+- `calltermo(term_goal, *extra_args)` for executing reified callable goal terms
+  and Prolog-style `call/N` argument extension
 - `onceo(goal)`
 - `cuto()` as the library form of Prolog `!/0`
 - `noto(goal)` for negation as failure

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -200,6 +200,13 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("callableo", 1),
     ("callo", 1),
     ("calltermo", 1),
+    ("calltermo", 2),
+    ("calltermo", 3),
+    ("calltermo", 4),
+    ("calltermo", 5),
+    ("calltermo", 6),
+    ("calltermo", 7),
+    ("calltermo", 8),
     ("clauseo", 2),
     ("compare_termo", 3),
     ("compoundo", 1),
@@ -2504,18 +2511,63 @@ def callo(goal: object) -> GoalExpr:
     return native_goal(run)
 
 
-def calltermo(term_goal: object) -> GoalExpr:
-    """Execute a reified callable goal term in the current proof state."""
+def _append_callable_arguments(
+    callable_term: Term,
+    extra_args: tuple[Term, ...],
+) -> Term | None:
+    """Return ``callable_term`` with extra arguments appended, if callable."""
+
+    if not extra_args:
+        return callable_term
+    if isinstance(callable_term, RelationCall):
+        callable_term = callable_term.as_term()
+    if isinstance(callable_term, Atom) and callable_term.symbol.namespace is None:
+        return Compound(functor=callable_term.symbol, args=extra_args)
+    if isinstance(callable_term, Compound):
+        if (
+            callable_term.functor.namespace is None
+            and callable_term.functor.name == ":"
+            and len(callable_term.args) == 2
+        ):
+            qualified_goal = _append_callable_arguments(
+                callable_term.args[1],
+                extra_args,
+            )
+            if qualified_goal is None:
+                return None
+            return Compound(
+                functor=callable_term.functor,
+                args=(callable_term.args[0], qualified_goal),
+            )
+        return Compound(
+            functor=callable_term.functor,
+            args=(*callable_term.args, *extra_args),
+        )
+    return None
+
+
+def calltermo(term_goal: object, *extra_args: object) -> GoalExpr:
+    """Execute a reified callable term, optionally appending arguments."""
 
     def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
-        (goal_term,) = args
+        goal_term, *argument_terms = args
+        reified_args = tuple(
+            _reified(argument_term, state)
+            for argument_term in argument_terms
+        )
+        callable_term = _append_callable_arguments(
+            _reified(goal_term, state),
+            reified_args,
+        )
+        if callable_term is None:
+            return
         try:
-            called_goal = goal_from_term(_reified(goal_term, state))
+            called_goal = goal_from_term(callable_term)
         except TypeError:
             return
         yield from solve_from(program_value, called_goal, state)
 
-    return native_goal(run, _as_callable_term(term_goal))
+    return native_goal(run, _as_callable_term(term_goal), *extra_args)
 
 
 def onceo(goal: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -1372,6 +1372,25 @@ class TestCallableTermBuiltins:
             conj(clauseo(child("bart", "homer"), body), calltermo(body)),
         ) == [term("parent", "homer", "bart")]
 
+    def test_calltermo_appends_arguments_to_callable_terms(self) -> None:
+        parent = relation("parent", 2)
+        child = var("Child")
+        family = program(
+            fact(parent("homer", "bart")),
+            fact(parent("homer", "lisa")),
+        )
+
+        assert solve_all(
+            family,
+            child,
+            calltermo("parent", "homer", child),
+        ) == [atom("bart"), atom("lisa")]
+        assert solve_all(
+            family,
+            child,
+            calltermo(term("parent", "homer"), child),
+        ) == [atom("bart"), atom("lisa")]
+
     def test_calltermo_fails_for_open_or_non_callable_terms(self) -> None:
         goal = var("Goal")
         marker = var("Marker")
@@ -1713,6 +1732,13 @@ class TestPredicateMetadataBuiltins:
 
         assert solve_all(program(), arity, current_predicateo("calltermo", arity)) == [
             num(1),
+            num(2),
+            num(3),
+            num(4),
+            num(5),
+            num(6),
+            num(7),
+            num(8),
         ]
 
     def test_predicate_propertyo_reports_source_properties(self) -> None:
@@ -1736,7 +1762,7 @@ class TestPredicateMetadataBuiltins:
         prop = var("Property")
 
         properties = set(
-            solve_all(program(), prop, predicate_propertyo("calltermo", 1, prop)),
+            solve_all(program(), prop, predicate_propertyo("calltermo", 3, prop)),
         )
 
         assert atom("defined") in properties

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - preserve source query variables across `goal_expansion/2` rewrites
+- adapt Prolog `call/2..8` into variadic callable-term execution
+- preserve extra arguments while rewriting module-qualified `call/N` meta-goals
 - rewrite module-qualified callable arguments inside `findall/3`, `bagof/3`,
   `setof/3`, and `forall/2`
 - expose `rewrite_loaded_prolog_query(...)` for ad-hoc queries that need a

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -10,7 +10,7 @@ It keeps parsing side-effect free, then exposes helpers to:
   `use_module/1,2`
 - collect `initialization/1` directives in source order
 - run those initialization goals explicitly against the loaded `Program`
-- adapt parsed Prolog builtin calls like `call/1`, `dynamic/1`, `assertz/1`,
+- adapt parsed Prolog builtin calls like `call/1..8`, `dynamic/1`, `assertz/1`,
   and `predicate_property/2` into runtime goals before execution
 - adapt finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
 - adapt callable CLP(FD) forms such as `in/2`, `ins/2`, `#=/2`,
@@ -22,7 +22,8 @@ It keeps parsing side-effect free, then exposes helpers to:
 - link multiple loaded sources into one namespace-aware runnable project with
   module-local predicates and weak imports
 - rewrite explicit `module:goal` qualification during linking, including common
-  meta-goal forms like `call/1`, `once/1`, `not/1`, `\\+/1`, and `phrase/2,3`
+  meta-goal forms like `call/1..8`, `once/1`, `not/1`, `\\+/1`, and
+  `phrase/2,3`
 - adapt Prolog control constructs such as `->/2` and
   `(If -> Then ; Else)` into executable builtin goals
 - adapt common list predicates such as `member/2`, `append/3`, `select/3`,

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -263,7 +263,12 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
     if goal.relation.arity == 4 and name in quaternary_list_builtins:
         return quaternary_list_builtins[name](*args)
 
-    if name == "call" and goal.relation.arity == 1:
+    if name == "call" and 1 <= goal.relation.arity <= 8:
+        if goal.relation.arity > 1:
+            extended_call = _extend_callable_term(args[0], args[1:])
+            if extended_call is None:
+                return calltermo(args[0], *args[1:])
+            return _adapt_callable_goal(extended_call)
         return _adapt_callable_goal(args[0])
     if name == "phrase" and goal.relation.arity == 2:
         try:
@@ -546,6 +551,30 @@ def _adapt_callable_goal(term_value: Term) -> GoalExpr:
         return adapt_prolog_goal(goal_from_term(term_value))
     except TypeError:
         return calltermo(term_value)
+
+
+def _extend_callable_term(
+    callable_term: Term,
+    extra_args: tuple[Term, ...],
+) -> Term | None:
+    if isinstance(callable_term, RelationCall):
+        callable_term = callable_term.as_term()
+    if isinstance(callable_term, LogicVar):
+        return None
+    if isinstance(callable_term, Atom) and callable_term.symbol.namespace is None:
+        return term(callable_term.symbol, *extra_args)
+    if isinstance(callable_term, Compound):
+        if (
+            callable_term.functor.namespace is None
+            and callable_term.functor.name == ":"
+            and len(callable_term.args) == 2
+        ):
+            qualified_goal = _extend_callable_term(callable_term.args[1], extra_args)
+            if qualified_goal is None:
+                return None
+            return term(":", callable_term.args[0], qualified_goal)
+        return term(callable_term.functor, *callable_term.args, *extra_args)
+    return None
 
 
 def _adapt_indicator_declaration(

--- a/code/packages/python/prolog-loader/src/prolog_loader/loader.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/loader.py
@@ -1390,7 +1390,24 @@ def _rewrite_goal_term(
             _rewrite_goal_term(term_value.args[1], resolver, module_resolvers),
         )
 
-    if term_value.functor in {_CALL, _ONCE}:
+    if term_value.functor == _CALL and term_value.args:
+        if len(term_value.args) > 1:
+            return term(
+                term_value.functor,
+                _rewrite_callable_closure(
+                    term_value.args[0],
+                    len(term_value.args) - 1,
+                    resolver,
+                    module_resolvers,
+                ),
+                *term_value.args[1:],
+            )
+        return term(
+            term_value.functor,
+            _rewrite_goal_term(term_value.args[0], resolver, module_resolvers),
+        )
+
+    if term_value.functor == _ONCE and len(term_value.args) == 1:
         return term(
             term_value.functor,
             _rewrite_goal_term(term_value.args[0], resolver, module_resolvers),
@@ -1432,6 +1449,54 @@ def _rewrite_goal_term(
     if resolved_relation.symbol == term_value.functor:
         return term_value
     return term(resolved_relation.symbol, *term_value.args)
+
+
+def _rewrite_callable_closure(
+    term_value: Term,
+    extra_arity: int,
+    resolver: RelationResolver,
+    module_resolvers: dict[Symbol, RelationResolver],
+) -> Term:
+    if isinstance(term_value, Compound):
+        qualified = _qualified_goal(term_value)
+        if qualified is not None:
+            module_name, goal_term = qualified
+            target_resolver = module_resolvers.get(module_name)
+            if target_resolver is None:
+                msg = f"module qualification references unknown module {module_name}"
+                raise ValueError(msg)
+            return _rewrite_callable_closure(
+                goal_term,
+                extra_arity,
+                target_resolver,
+                module_resolvers,
+            )
+
+    closure_arity = _callable_closure_arity(term_value, extra_arity)
+    if closure_arity is None:
+        return term_value
+
+    if isinstance(term_value, Atom):
+        resolved = resolver(Relation(symbol=term_value.symbol, arity=closure_arity))
+        if resolved.symbol == term_value.symbol:
+            return term_value
+        return atom(resolved.symbol)
+
+    if isinstance(term_value, Compound):
+        resolved = resolver(Relation(symbol=term_value.functor, arity=closure_arity))
+        if resolved.symbol == term_value.functor:
+            return term_value
+        return term(resolved.symbol, *term_value.args)
+
+    return term_value
+
+
+def _callable_closure_arity(term_value: Term, extra_arity: int) -> int | None:
+    if isinstance(term_value, Atom):
+        return extra_arity
+    if isinstance(term_value, Compound):
+        return len(term_value.args) + extra_arity
+    return None
 
 
 def _qualified_goal(term_value: Compound) -> tuple[Symbol, Term] | None:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -529,6 +529,30 @@ class TestPrologLoader:
             atom("bart"),
         ]
 
+    def test_module_qualification_rewrites_call_n_meta_arguments(self) -> None:
+        project = load_swi_prolog_project(
+            """
+            :- module(family, [ancestor/2]).
+            ancestor(homer, bart).
+            ancestor(homer, lisa).
+            """,
+            """
+            :- module(app, []).
+            ?- call(family:ancestor, homer, Who).
+            """,
+        )
+
+        query = project.queries[0]
+
+        assert solve_all(
+            project.program,
+            query.variables["Who"],
+            adapt_prolog_goal(query.goal),
+        ) == [
+            atom("bart"),
+            atom("lisa"),
+        ]
+
     def test_module_qualified_initialization_goals_execute(self) -> None:
         project = load_swi_prolog_project(
             """
@@ -968,6 +992,19 @@ class TestPrologGoalAdapter:
             (num(3), num(4)),
             (num(4), num(5)),
         ]
+
+    def test_adapt_prolog_goal_rewrites_call_n(self) -> None:
+        parsed = parse_swi_query(
+            "?- call(member, Item, [tea, cake]).",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(
+            program(),
+            parsed.variables["Item"],
+            adapted,
+        ) == [atom("tea"), atom("cake")]
 
     def test_adapt_prolog_goal_rewrites_clpfd_callable_forms(self) -> None:
         parsed = parse_swi_query(

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -126,6 +126,28 @@ class TestPrologVMStress:
             {"Chosen": atom("first"), "Fallback": atom("none")},
         ]
 
+    def test_call_n_meta_calls_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            pick(tea).
+            pick(cake).
+            pair(Name, Flavor) :-
+                call(pick, Name),
+                call(member, Flavor, [sweet, savory]).
+
+            ?- call(pair, Name, Flavor).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"Name": atom("tea"), "Flavor": atom("sweet")},
+            {"Name": atom("tea"), "Flavor": atom("savory")},
+            {"Name": atom("cake"), "Flavor": atom("sweet")},
+            {"Name": atom("cake"), "Flavor": atom("savory")},
+        ]
+
     def test_list_stdlib_predicates_run_through_vm(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR38-prolog-call-n-meta-call.md
+++ b/code/specs/PR38-prolog-call-n-meta-call.md
@@ -1,0 +1,40 @@
+# PR38: Prolog `call/N` Meta-Call
+
+This batch adds Prolog-style meta-call argument extension on top of the existing
+callable-term runtime.
+
+## Scope
+
+- Extend `calltermo(term_goal, *extra_args)` so library callers can append
+  arguments to atoms, compound callable terms, and module-qualified goals.
+- Adapt parsed SWI-style `call/2` through `call/8` into the same builtin path.
+- Preserve extra arguments when loader module-linking rewrites the first
+  meta-call argument.
+- Prove the behavior through direct builtins tests, loader tests, and a Logic VM
+  stress test.
+
+## Examples
+
+```prolog
+?- call(member, Item, [tea, cake]).
+Item = tea ;
+Item = cake.
+```
+
+```prolog
+?- call(pair, Name, Flavor).
+```
+
+where `pair/2` may itself use nested meta-calls:
+
+```prolog
+pair(Name, Flavor) :-
+    call(pick, Name),
+    call(member, Flavor, [sweet, savory]).
+```
+
+## Non-goals
+
+- Full `meta_predicate/1` declaration semantics.
+- Higher-order list predicates such as `maplist/N` and `foldl/N`.
+- Module-sensitive closures beyond explicit `Module:Callable` terms.


### PR DESCRIPTION
## Summary
- Extend `calltermo` to support Prolog-style callable argument extension
- Adapt parsed `call/2..8` through builtin-aware callable expansion
- Preserve module-qualified closure resolution for `call/N` during project linking
- Add direct builtin, loader, and Logic VM stress coverage plus PR38 spec

## Verification
- `bash BUILD` in `code/packages/python/logic-builtins`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/logic-builtins`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `go build -o /tmp/ca-build-tool-prolog-meta-call .` in `code/programs/go/build-tool`
- `/tmp/ca-build-tool-prolog-meta-call -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-meta-call-build-plan.json`
- `git diff --check`