### PR TITLE
feat(clr): TW03 Phase 3c — heap primitives lowering (structural)

### DIFF
--- a/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,93 @@
 # Changelog
 
+## 0.7.0 — 2026-04-30 — TW03 Phase 3c (CLR heap primitives, structural)
+
+Adds CLR-side lowering for the eight TW03 Phase 3a heap opcodes
+(`MAKE_CONS`, `CAR`, `CDR`, `IS_NULL`, `IS_PAIR`, `MAKE_SYMBOL`,
+`IS_SYMBOL`, `LOAD_NIL`).  Ships **structural-only** — bytecode
+shape is correct (right opcode bytes, right token-provider
+interaction), three new extra TypeArtifacts (Cons / Symbol / Nil)
+get auto-included in the multi-TypeDef assembly artifact, but a
+follow-up (Phase 3c.5) wires in the cli-assembly-writer-side
+intern table for symbol names and the singleton Nil instance.
+
+Mirrors the staging that worked for closures: Phase 2c shipped
+structural, Phase 2c.5 wired runtime correctness.
+
+### Added — three runtime TypeDefs auto-included on heap-using programs
+
+- `CodingAdventures.Cons` — `int32 head; object tail` + ctor that
+  chains into `System.Object::.ctor()`.  Phase 3c v1 targets
+  list-of-ints (the spec acceptance criterion); a follow-up
+  widens `head` once typed-register inference covers cons head
+  slots.
+- `CodingAdventures.Symbol` — `string name` field + ctor.
+  Phase 3c v1 emits a placeholder `ldnull` for the name argument
+  so two `MAKE_SYMBOL` calls with the same name yield DIFFERENT
+  Symbol instances (semantically wrong, bytecode-shape correct).
+  Phase 3c.5 wires in the proper `ldstr` UserString token via the
+  writer-side intern table.
+- `CodingAdventures.Nil` — empty class with no-arg ctor; used as
+  the `isinst` target for `IS_NULL`.  Phase 3c v1 emits a fresh
+  `newobj Nil` for every `LOAD_NIL` (instead of a singleton);
+  `IS_NULL` still works correctly because every `Nil` instance
+  qualifies as null under the `isinst Nil` test.
+
+### Added — eight opcode lowerings
+
+| Opcode | CIL emission |
+|---|---|
+| `MAKE_CONS dst, head, tail` | `ldloc head; ldloc tail (obj slot); newobj Cons.ctor(int32, object); stloc dst (obj slot)` |
+| `CAR dst, src` | `ldloc src (obj); castclass Cons; ldfld Cons::head; stloc dst (int)` |
+| `CDR dst, src` | `ldloc src (obj); castclass Cons; ldfld Cons::tail; stloc dst (obj)` |
+| `IS_NULL dst, src` | `ldloc src (obj); isinst Nil; ldnull; cgt.un; stloc dst (int)` |
+| `IS_PAIR dst, src` | `ldloc src (obj); isinst Cons; ldnull; cgt.un; stloc dst (int)` |
+| `IS_SYMBOL dst, src` | `ldloc src (obj); isinst Symbol; ldnull; cgt.un; stloc dst (int)` |
+| `MAKE_SYMBOL dst, name_label` | `ldnull; newobj Symbol.ctor(string); stloc dst (obj)` (placeholder) |
+| `LOAD_NIL dst` | `newobj Nil.ctor(); stloc dst (obj)` |
+
+### Added — token provider extension
+
+`SequentialCILTokenProvider` accepts `include_heap_types=True`
+which lays out heap method, field, and TypeDef tokens deterministically
+AFTER any closure rows.  See the docstring for the exact layout.
+
+The Protocol gains 9 new methods: `heap_cons_ctor_token`,
+`heap_cons_head_token`, `heap_cons_tail_token`,
+`heap_symbol_ctor_token`, `heap_symbol_name_token`,
+`heap_nil_ctor_token`, `heap_cons_typedef_token`,
+`heap_symbol_typedef_token`, `heap_nil_typedef_token`.
+
+### Added — type-tracking rules
+
+`_instr_register_type_writes` now classifies:
+- `MAKE_CONS` / `CDR` / `MAKE_SYMBOL` / `LOAD_NIL` dst → object
+- `CAR` / `IS_NULL` / `IS_PAIR` / `IS_SYMBOL` dst → int32
+
+Existing typed-register inference + per-instruction slot picking
+reuses without changes.
+
+### Tests
+
+- 4 new TestHeapExtraTypes tests verifying auto-include + field
+  layouts.
+- 11 new TestHeapOpLowering tests verifying each opcode emits the
+  identifying CIL bytes.
+- 3 new TestHeapTokenLayout tests locking down the deterministic
+  token layout.
+- All 97 tests pass; coverage 92%.
+
+### Limitations (intentional, scoped to follow-ups)
+
+- Symbol names are placeholder-`ldnull` until 3c.5 wires the
+  writer-side UserString intern table.
+- `Nil` is a fresh `newobj` per `LOAD_NIL` until 3c.5 wires a
+  singleton `INSTANCE` static field.
+- `Cons.head` is typed `int32` (matches list-of-ints, the spec
+  acceptance criterion).  Heterogeneous cells need a follow-up.
+- End-to-end on real `dotnet` is deferred until 3c.5 lands the
+  writer-side support.
+
 ## 0.6.0 — 2026-04-29 — CLR02 Phase 2c.5 (typed register pool)
 
 ### Added — runtime-correct closure semantics

--- a/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
@@ -209,6 +209,41 @@ class CILTokenProvider(Protocol):
     def system_object_ctor_token(self) -> int:
         """Return the MemberRef token for ``[System.Runtime]System.Object::.ctor()``."""
 
+    # ── TW03 Phase 3c — heap-primitive tokens ───────────────────────────
+    #
+    # When ``include_heap_types=True`` the provider also lays out the
+    # Cons / Symbol / Nil TypeDef rows after the closure rows.  Each
+    # type contributes one ``.ctor`` MethodDef row; Cons additionally
+    # contributes head + tail Field rows; Symbol contributes a name
+    # Field row.
+
+    def heap_cons_ctor_token(self) -> int:
+        """Return the MethodDef token for ``Cons::.ctor(int32, object)``."""
+
+    def heap_cons_head_token(self) -> int:
+        """Return the Field token for ``Cons::head : int32``."""
+
+    def heap_cons_tail_token(self) -> int:
+        """Return the Field token for ``Cons::tail : object``."""
+
+    def heap_symbol_ctor_token(self) -> int:
+        """Return the MethodDef token for ``Symbol::.ctor(string)``."""
+
+    def heap_symbol_name_token(self) -> int:
+        """Return the Field token for ``Symbol::name : string``."""
+
+    def heap_nil_ctor_token(self) -> int:
+        """Return the MethodDef token for ``Nil::.ctor()``."""
+
+    def heap_cons_typedef_token(self) -> int:
+        """Return the TypeDef token for ``Cons`` (used by ``isinst``)."""
+
+    def heap_symbol_typedef_token(self) -> int:
+        """Return the TypeDef token for ``Symbol`` (used by ``isinst``)."""
+
+    def heap_nil_typedef_token(self) -> int:
+        """Return the TypeDef token for ``Nil`` (used by ``isinst``)."""
+
 
 class SequentialCILTokenProvider:
     """Deterministic token provider for standalone bytecode lowering.
@@ -240,6 +275,7 @@ class SequentialCILTokenProvider:
         *,
         closure_names: tuple[str, ...] = (),
         closure_free_var_counts: dict[str, int] | None = None,
+        include_heap_types: bool = False,
     ) -> None:
         self._method_tokens = {
             name: 0x06000001 + index for index, name in enumerate(method_names)
@@ -271,10 +307,54 @@ class SequentialCILTokenProvider:
                 self._closure_fields[(name, i)] = 0x04000000 | field_row
 
         # System.Object::.ctor MemberRef — present iff any closure
-        # is present (because closures are the only thing that needs
-        # to chain into the base ctor).  Row = helper count + 1.
+        # OR any heap type is present (both need to chain into the
+        # base ctor).  Row = helper count + 1.
+        needs_object_ctor = bool(closure_names) or include_heap_types
         self._object_ctor = (
-            0x0A000000 | (len(CILHelper) + 1) if closure_names else 0
+            0x0A000000 | (len(CILHelper) + 1) if needs_object_ctor else 0
+        )
+
+        # ── TW03 Phase 3c — heap-primitive token layout ────────────
+        #
+        # When ``include_heap_types`` is set, the writer appends three
+        # extra TypeDef rows (Cons, Symbol, Nil) AFTER any closure
+        # types.  Each contributes one ``.ctor`` MethodDef row in
+        # declaration order; Cons additionally contributes head + tail
+        # Field rows, Symbol contributes a name Field row.
+        #
+        # Method rows so far: M (main) + (1 + 2*K) closure rows
+        # (IClosure.Apply + per-closure ctor/Apply).  Heap ctors
+        # follow at offsets +0 (Cons), +1 (Symbol), +2 (Nil).
+        #
+        # Field rows so far: closure capture count.  Heap fields
+        # follow at offsets +0 (Cons.head), +1 (Cons.tail),
+        # +2 (Symbol.name).
+        #
+        # TypeDef rows: <Module>=1, MainType=2, then closure types
+        # (IClosure + Closure_<name> per closure).  Heap types follow.
+        self._include_heap_types = include_heap_types
+        closure_method_rows = (1 + 2 * len(closure_names)) if closure_names else 0
+        heap_method_base = 0x06000001 + m + closure_method_rows
+        self._heap_cons_ctor = heap_method_base if include_heap_types else 0
+        self._heap_symbol_ctor = (heap_method_base + 1) if include_heap_types else 0
+        self._heap_nil_ctor = (heap_method_base + 2) if include_heap_types else 0
+
+        heap_field_base = 0x04000001 + field_row
+        self._heap_cons_head = heap_field_base if include_heap_types else 0
+        self._heap_cons_tail = (heap_field_base + 1) if include_heap_types else 0
+        self._heap_symbol_name = (heap_field_base + 2) if include_heap_types else 0
+
+        # TypeDef rows: <Module>=1, MainType=2.  Then closures (if
+        # any) contribute 1 + len(closure_names) (IClosure +
+        # Closure_<name>...).  Heap types follow.
+        closure_type_rows = (1 + len(closure_names)) if closure_names else 0
+        heap_typedef_base = 0x02000003 + closure_type_rows
+        self._heap_cons_typedef = heap_typedef_base if include_heap_types else 0
+        self._heap_symbol_typedef = (
+            (heap_typedef_base + 1) if include_heap_types else 0
+        )
+        self._heap_nil_typedef = (
+            (heap_typedef_base + 2) if include_heap_types else 0
         )
 
     def method_token(self, method_name: str) -> int:
@@ -328,6 +408,44 @@ class SequentialCILTokenProvider:
             msg = "no closure regions registered with this token provider"
             raise CILBackendError(msg)
         return self._object_ctor
+
+    # ── Heap-primitive token getters (TW03 Phase 3c) ────────────────────
+
+    def _heap_token(self, value: int, name: str) -> int:
+        if not value:
+            msg = (
+                f"heap token {name!r} unavailable — "
+                "include_heap_types=True must be set on the token provider"
+            )
+            raise CILBackendError(msg)
+        return value
+
+    def heap_cons_ctor_token(self) -> int:
+        return self._heap_token(self._heap_cons_ctor, "cons_ctor")
+
+    def heap_cons_head_token(self) -> int:
+        return self._heap_token(self._heap_cons_head, "cons_head")
+
+    def heap_cons_tail_token(self) -> int:
+        return self._heap_token(self._heap_cons_tail, "cons_tail")
+
+    def heap_symbol_ctor_token(self) -> int:
+        return self._heap_token(self._heap_symbol_ctor, "symbol_ctor")
+
+    def heap_symbol_name_token(self) -> int:
+        return self._heap_token(self._heap_symbol_name, "symbol_name")
+
+    def heap_nil_ctor_token(self) -> int:
+        return self._heap_token(self._heap_nil_ctor, "nil_ctor")
+
+    def heap_cons_typedef_token(self) -> int:
+        return self._heap_token(self._heap_cons_typedef, "cons_typedef")
+
+    def heap_symbol_typedef_token(self) -> int:
+        return self._heap_token(self._heap_symbol_typedef, "symbol_typedef")
+
+    def heap_nil_typedef_token(self) -> int:
+        return self._heap_token(self._heap_nil_typedef, "nil_typedef")
 
 
 @dataclass(frozen=True)
@@ -408,6 +526,15 @@ class CILLoweringPipeline:
 
         extra_types = _build_closure_extra_types(plan, closure_apply_methods)
 
+        # TW03 Phase 3c — auto-include Cons/Symbol/Nil TypeDefs when
+        # the program uses any heap opcode.  Programs without heap ops
+        # see zero extra TypeDef rows.
+        uses_heap = any(
+            i.opcode in _HEAP_OPCODES for i in program.instructions
+        )
+        if uses_heap:
+            extra_types = extra_types + _build_heap_extra_types(plan)
+
         return CILProgramArtifact(
             entry_label=program.entry_label,
             methods=tuple(main_methods),
@@ -485,6 +612,31 @@ _CLR_SUPPORTED_OPCODES: frozenset[IrOp] = frozenset({
     # CLR02 Phase 2c — closures.
     IrOp.MAKE_CLOSURE,
     IrOp.APPLY_CLOSURE,
+    # TW03 Phase 3c — heap primitives (cons / symbol / nil).
+    IrOp.MAKE_CONS,
+    IrOp.CAR,
+    IrOp.CDR,
+    IrOp.IS_NULL,
+    IrOp.IS_PAIR,
+    IrOp.MAKE_SYMBOL,
+    IrOp.IS_SYMBOL,
+    IrOp.LOAD_NIL,
+})
+
+
+# TW03 Phase 3c — opcode set that triggers the heap-primitive runtime
+# TypeDefs (Cons / Symbol / Nil) auto-include in the multi-TypeDef
+# assembly artifact.  Programs without these ops see zero extra
+# TypeDef rows.
+_HEAP_OPCODES: frozenset[IrOp] = frozenset({
+    IrOp.MAKE_CONS,
+    IrOp.CAR,
+    IrOp.CDR,
+    IrOp.IS_NULL,
+    IrOp.IS_PAIR,
+    IrOp.MAKE_SYMBOL,
+    IrOp.IS_SYMBOL,
+    IrOp.LOAD_NIL,
 })
 
 
@@ -642,10 +794,18 @@ def _analyze_program(
     # is deterministic.
     closure_names = tuple(r.name for r in regions if r.name in closure_set)
 
+    # TW03 Phase 3c: detect heap-primitive ops so the token provider
+    # also lays out Cons / Symbol / Nil typedef + method + field
+    # tokens after the closure rows.
+    uses_heap = any(
+        i.opcode in _HEAP_OPCODES for i in program.instructions
+    )
+
     provider = token_provider or SequentialCILTokenProvider(
         main_region_names,
         closure_names=closure_names,
         closure_free_var_counts=dict(config.closure_free_var_counts),
+        include_heap_types=uses_heap,
     )
 
     function_return_types = _classify_function_return_types(
@@ -724,6 +884,18 @@ def _instr_register_type_writes(
         new_types[dst.index] = "object"
     elif op is IrOp.APPLY_CLOSURE:
         dst = _as_register(instr.operands[0], "APPLY_CLOSURE dst")
+        new_types[dst.index] = "int32"
+    # TW03 Phase 3c — heap-primitive type-tracking rules.  Same shape
+    # as JVM Phase 3b: CAR reads the int head; CDR / MAKE_CONS /
+    # MAKE_SYMBOL / LOAD_NIL produce object refs; IS_NULL / IS_PAIR /
+    # IS_SYMBOL produce int32 0/1 results ready for BRANCH_Z.
+    elif op in (
+        IrOp.MAKE_CONS, IrOp.CDR, IrOp.MAKE_SYMBOL, IrOp.LOAD_NIL,
+    ):
+        dst = _as_register(instr.operands[0], f"{op.name} dst")
+        new_types[dst.index] = "object"
+    elif op in (IrOp.CAR, IrOp.IS_NULL, IrOp.IS_PAIR, IrOp.IS_SYMBOL):
+        dst = _as_register(instr.operands[0], f"{op.name} dst")
         new_types[dst.index] = "int32"
     elif op is IrOp.CALL:
         target = _as_label(instr.operands[0], "CALL target")
@@ -1162,6 +1334,122 @@ def _build_closure_extra_types(
     return tuple(extras)
 
 
+def _build_heap_extra_types(
+    plan: CILLoweringPlan,
+) -> tuple[CILTypeArtifact, ...]:
+    """Build the Cons / Symbol / Nil TypeArtifacts (TW03 Phase 3c).
+
+    Three TypeDefs are appended after any closure types:
+
+    * ``Cons`` — fields ``int32 head`` + ``object tail``; ctor takes
+      both and stores them.
+    * ``Symbol`` — field ``string name``; ctor takes a string and
+      stores it.
+    * ``Nil`` — empty class with a no-arg ctor; used as the
+      ``isinst`` target for ``IS_NULL``.
+
+    Each ctor chains into ``System.Object::.ctor()`` first, matching
+    the closure-ctor pattern.
+
+    The token provider must have been constructed with
+    ``include_heap_types=True`` so the field/method tokens line up
+    with the row indices the writer will assign.
+    """
+    object_ctor_token = plan.token_provider.system_object_ctor_token()
+
+    # ── Cons ────────────────────────────────────────────────────────
+    cons_ctor_builder = CILBytecodeBuilder()
+    # ldarg.0; call Object::.ctor()
+    cons_ctor_builder.emit_ldarg(0)
+    cons_ctor_builder.emit_call(object_ctor_token)
+    # ldarg.0; ldarg.1; stfld head
+    cons_ctor_builder.emit_ldarg(0)
+    cons_ctor_builder.emit_ldarg(1)
+    cons_ctor_builder.emit_token_instruction(
+        0x7D, plan.token_provider.heap_cons_head_token(),
+    )
+    # ldarg.0; ldarg.2; stfld tail
+    cons_ctor_builder.emit_ldarg(0)
+    cons_ctor_builder.emit_ldarg(2)
+    cons_ctor_builder.emit_token_instruction(
+        0x7D, plan.token_provider.heap_cons_tail_token(),
+    )
+    cons_ctor_builder.emit_ret()
+    cons_ctor = CILMethodArtifact(
+        name=".ctor",
+        body=cons_ctor_builder.assemble(),
+        max_stack=2,
+        local_types=(),
+        return_type="void",
+        parameter_types=("int32", "object"),
+        is_instance=True,
+        is_special_name=True,
+    )
+    cons_type = CILTypeArtifact(
+        name="Cons",
+        namespace="CodingAdventures",
+        extends="System.Object",
+        fields=(
+            CILFieldArtifact(name="head", type="int32"),
+            CILFieldArtifact(name="tail", type="object"),
+        ),
+        methods=(cons_ctor,),
+    )
+
+    # ── Symbol ──────────────────────────────────────────────────────
+    sym_ctor_builder = CILBytecodeBuilder()
+    sym_ctor_builder.emit_ldarg(0)
+    sym_ctor_builder.emit_call(object_ctor_token)
+    sym_ctor_builder.emit_ldarg(0)
+    sym_ctor_builder.emit_ldarg(1)
+    sym_ctor_builder.emit_token_instruction(
+        0x7D, plan.token_provider.heap_symbol_name_token(),
+    )
+    sym_ctor_builder.emit_ret()
+    sym_ctor = CILMethodArtifact(
+        name=".ctor",
+        body=sym_ctor_builder.assemble(),
+        max_stack=2,
+        local_types=(),
+        return_type="void",
+        parameter_types=("string",),
+        is_instance=True,
+        is_special_name=True,
+    )
+    symbol_type = CILTypeArtifact(
+        name="Symbol",
+        namespace="CodingAdventures",
+        extends="System.Object",
+        fields=(CILFieldArtifact(name="name", type="string"),),
+        methods=(sym_ctor,),
+    )
+
+    # ── Nil ─────────────────────────────────────────────────────────
+    nil_ctor_builder = CILBytecodeBuilder()
+    nil_ctor_builder.emit_ldarg(0)
+    nil_ctor_builder.emit_call(object_ctor_token)
+    nil_ctor_builder.emit_ret()
+    nil_ctor = CILMethodArtifact(
+        name=".ctor",
+        body=nil_ctor_builder.assemble(),
+        max_stack=1,
+        local_types=(),
+        return_type="void",
+        parameter_types=(),
+        is_instance=True,
+        is_special_name=True,
+    )
+    nil_type = CILTypeArtifact(
+        name="Nil",
+        namespace="CodingAdventures",
+        extends="System.Object",
+        fields=(),
+        methods=(nil_ctor,),
+    )
+
+    return (cons_type, symbol_type, nil_type)
+
+
 def _build_closure_ctor(
     num_free: int,
     object_ctor_token: int,
@@ -1477,6 +1765,161 @@ def _emit_instruction(
         builder.emit_ldloc(arg_reg.index)
         builder.emit_callvirt(plan.token_provider.iclosure_apply_token())
         builder.emit_stloc(dst.index)
+        return
+
+    # ── TW03 Phase 3c — heap-primitive lowering ─────────────────────────
+    #
+    # Each op picks the int32 vs object slot for its register reads/
+    # writes via ``ctx.obj_local_for`` (mirrors the closure pattern).
+    # CIL opcode bytes used:
+    #   0x14  ldnull              (one byte)
+    #   0x73  newobj <token>
+    #   0x74  castclass <token>
+    #   0x75  isinst <token>
+    #   0x7B  ldfld <token>
+    #   0xFE 0x03  cgt.un          (two bytes)
+    if instruction.opcode == IrOp.MAKE_CONS:
+        if len(instruction.operands) != 3:
+            msg = (
+                f"MAKE_CONS expects 3 operands (dst, head, tail), got "
+                f"{len(instruction.operands)}"
+            )
+            raise CILBackendError(msg)
+        dst = _as_register(instruction.operands[0], "MAKE_CONS dst")
+        head = _as_register(instruction.operands[1], "MAKE_CONS head")
+        tail = _as_register(instruction.operands[2], "MAKE_CONS tail")
+        # head: int32 (from int slot); tail: object (from obj slot)
+        builder.emit_ldloc(head.index)
+        if ctx is not None and tail.index in ctx.obj_local_for:
+            builder.emit_ldloc(ctx.obj_local_for[tail.index])
+        else:
+            builder.emit_ldloc(tail.index)
+        builder.emit_token_instruction(
+            0x73, plan.token_provider.heap_cons_ctor_token(),
+        )
+        # store ref into dst's object slot
+        if ctx is not None and dst.index in ctx.obj_local_for:
+            builder.emit_stloc(ctx.obj_local_for[dst.index])
+        else:
+            builder.emit_stloc(dst.index)
+        return
+
+    if instruction.opcode == IrOp.CAR:
+        if len(instruction.operands) != 2:
+            msg = (
+                f"CAR expects 2 operands (dst, src), got "
+                f"{len(instruction.operands)}"
+            )
+            raise CILBackendError(msg)
+        dst = _as_register(instruction.operands[0], "CAR dst")
+        src = _as_register(instruction.operands[1], "CAR src")
+        if ctx is not None and src.index in ctx.obj_local_for:
+            builder.emit_ldloc(ctx.obj_local_for[src.index])
+        else:
+            builder.emit_ldloc(src.index)
+        builder.emit_token_instruction(
+            0x74, plan.token_provider.heap_cons_typedef_token(),
+        )
+        builder.emit_token_instruction(
+            0x7B, plan.token_provider.heap_cons_head_token(),
+        )
+        builder.emit_stloc(dst.index)  # int32 result → int slot
+        return
+
+    if instruction.opcode == IrOp.CDR:
+        if len(instruction.operands) != 2:
+            msg = (
+                f"CDR expects 2 operands (dst, src), got "
+                f"{len(instruction.operands)}"
+            )
+            raise CILBackendError(msg)
+        dst = _as_register(instruction.operands[0], "CDR dst")
+        src = _as_register(instruction.operands[1], "CDR src")
+        if ctx is not None and src.index in ctx.obj_local_for:
+            builder.emit_ldloc(ctx.obj_local_for[src.index])
+        else:
+            builder.emit_ldloc(src.index)
+        builder.emit_token_instruction(
+            0x74, plan.token_provider.heap_cons_typedef_token(),
+        )
+        builder.emit_token_instruction(
+            0x7B, plan.token_provider.heap_cons_tail_token(),
+        )
+        if ctx is not None and dst.index in ctx.obj_local_for:
+            builder.emit_stloc(ctx.obj_local_for[dst.index])
+        else:
+            builder.emit_stloc(dst.index)
+        return
+
+    if instruction.opcode in (IrOp.IS_NULL, IrOp.IS_PAIR, IrOp.IS_SYMBOL):
+        op_name = instruction.opcode.name
+        if len(instruction.operands) != 2:
+            msg = (
+                f"{op_name} expects 2 operands (dst, src), got "
+                f"{len(instruction.operands)}"
+            )
+            raise CILBackendError(msg)
+        dst = _as_register(instruction.operands[0], f"{op_name} dst")
+        src = _as_register(instruction.operands[1], f"{op_name} src")
+        if instruction.opcode is IrOp.IS_NULL:
+            type_token = plan.token_provider.heap_nil_typedef_token()
+        elif instruction.opcode is IrOp.IS_PAIR:
+            type_token = plan.token_provider.heap_cons_typedef_token()
+        else:
+            type_token = plan.token_provider.heap_symbol_typedef_token()
+        if ctx is not None and src.index in ctx.obj_local_for:
+            builder.emit_ldloc(ctx.obj_local_for[src.index])
+        else:
+            builder.emit_ldloc(src.index)
+        # isinst Type; ldnull; cgt.un  → 1 if src is Type, else 0.
+        builder.emit_token_instruction(0x75, type_token)
+        builder.emit_opcode(0x14)  # ldnull
+        builder.emit_raw(bytes([0xFE, 0x03]))  # cgt.un
+        builder.emit_stloc(dst.index)  # int32 result
+        return
+
+    if instruction.opcode == IrOp.MAKE_SYMBOL:
+        if len(instruction.operands) != 2:
+            msg = (
+                f"MAKE_SYMBOL expects 2 operands (dst, name_label), got "
+                f"{len(instruction.operands)}"
+            )
+            raise CILBackendError(msg)
+        dst = _as_register(instruction.operands[0], "MAKE_SYMBOL dst")
+        # Phase 3c structural: pass null as the name argument.  The
+        # ldstr UserString wiring lands in 3c.5 along with the
+        # writer-side intern table — until then, two MAKE_SYMBOL
+        # calls with the same label produce DIFFERENT Symbol
+        # instances (semantically wrong but bytecode-shape correct).
+        builder.emit_opcode(0x14)  # ldnull (placeholder for the name string)
+        builder.emit_token_instruction(
+            0x73, plan.token_provider.heap_symbol_ctor_token(),
+        )
+        if ctx is not None and dst.index in ctx.obj_local_for:
+            builder.emit_stloc(ctx.obj_local_for[dst.index])
+        else:
+            builder.emit_stloc(dst.index)
+        return
+
+    if instruction.opcode == IrOp.LOAD_NIL:
+        if len(instruction.operands) != 1:
+            msg = (
+                f"LOAD_NIL expects 1 operand (dst), got "
+                f"{len(instruction.operands)}"
+            )
+            raise CILBackendError(msg)
+        dst = _as_register(instruction.operands[0], "LOAD_NIL dst")
+        # Phase 3c structural: newobj Nil.ctor() each time.  The
+        # singleton-INSTANCE wire-up lands in 3c.5; until then
+        # IS_NULL still works correctly via isinst Nil because
+        # every Nil instance qualifies as null.
+        builder.emit_token_instruction(
+            0x73, plan.token_provider.heap_nil_ctor_token(),
+        )
+        if ctx is not None and dst.index in ctx.obj_local_for:
+            builder.emit_stloc(ctx.obj_local_for[dst.index])
+        else:
+            builder.emit_stloc(dst.index)
         return
 
     if instruction.opcode == IrOp.SYSCALL:

--- a/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
@@ -1155,3 +1155,253 @@ class TestTypedRegisterPool:
         assert plan.function_return_types["Main"] == "int32"
         # Closure regions always return int32 per the IClosure contract.
         assert plan.function_return_types["_lambda_0"] == "int32"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# TW03 Phase 3c — heap-primitive lowering (cons / symbol / nil)
+# ─────────────────────────────────────────────────────────────────────────
+#
+# Phase 3c v1 ships **structural-only** lowering: bytecode shape is correct
+# (right opcode bytes, right token-provider interaction), the three new
+# extra TypeArtifacts (Cons / Symbol / Nil) get auto-included, but a
+# follow-up (Phase 3c.5) wires in the cli-assembly-writer-side intern
+# tables for symbol names and the singleton Nil instance.  Until then,
+# IS_NULL still works correctly via ``isinst Nil`` (every Nil instance
+# qualifies as null) but two MAKE_SYMBOL calls with the same name yield
+# different Symbol instances (semantically wrong; bytecode-shape correct).
+
+
+class TestHeapExtraTypes:
+    """Tests for the auto-included Cons / Symbol / Nil TypeDefs."""
+
+    def _heap_program(self, instructions: list[IrInstruction]) -> IrProgram:
+        program = IrProgram(entry_label="Main")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("Main")]))
+        for ins in instructions:
+            program.add_instruction(ins)
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        return program
+
+    def test_extra_types_include_cons_symbol_nil_when_heap_op_present(
+        self,
+    ) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+        ])
+        artifact = lower_ir_to_cil_bytecode(program)
+        names = {(t.namespace, t.name) for t in artifact.extra_types}
+        assert ("CodingAdventures", "Cons") in names
+        assert ("CodingAdventures", "Symbol") in names
+        assert ("CodingAdventures", "Nil") in names
+
+    def test_no_heap_extra_types_when_no_heap_op(self) -> None:
+        program = self._heap_program([])
+        artifact = lower_ir_to_cil_bytecode(program)
+        names = {(t.namespace, t.name) for t in artifact.extra_types}
+        assert ("CodingAdventures", "Cons") not in names
+        assert ("CodingAdventures", "Symbol") not in names
+        assert ("CodingAdventures", "Nil") not in names
+
+    def test_cons_typedef_has_int_head_and_object_tail(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+        ])
+        artifact = lower_ir_to_cil_bytecode(program)
+        cons = next(t for t in artifact.extra_types if t.name == "Cons")
+        field_types = {f.name: f.type for f in cons.fields}
+        assert field_types == {"head": "int32", "tail": "object"}
+
+    def test_symbol_typedef_has_string_name(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+        ])
+        artifact = lower_ir_to_cil_bytecode(program)
+        sym = next(t for t in artifact.extra_types if t.name == "Symbol")
+        field_types = {f.name: f.type for f in sym.fields}
+        assert field_types == {"name": "string"}
+
+    def test_nil_typedef_has_no_fields(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+        ])
+        artifact = lower_ir_to_cil_bytecode(program)
+        nil = next(t for t in artifact.extra_types if t.name == "Nil")
+        assert nil.fields == ()
+        # Single ctor.
+        ctor_names = [m.name for m in nil.methods]
+        assert ctor_names == [".ctor"]
+
+
+class TestHeapOpLowering:
+    """Each heap op should emit its identifying CIL opcode bytes."""
+
+    def _heap_program(self, instructions: list[IrInstruction]) -> IrProgram:
+        program = IrProgram(entry_label="Main")
+        program.add_instruction(IrInstruction(IrOp.LABEL, [IrLabel("Main")]))
+        for ins in instructions:
+            program.add_instruction(ins)
+        program.add_instruction(IrInstruction(IrOp.RET, []))
+        return program
+
+    def _main_body(self, artifact: CILProgramArtifact) -> bytes:
+        return next(m.body for m in artifact.methods if m.name == "Main")
+
+    def test_make_cons_emits_newobj(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(2), IrImmediate(7)]),
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(3)]),
+            IrInstruction(
+                IrOp.MAKE_CONS,
+                [IrRegister(4), IrRegister(2), IrRegister(3)],
+            ),
+        ])
+        artifact = lower_ir_to_cil_bytecode(program)
+        body = self._main_body(artifact)
+        # 0x73 = newobj.
+        assert b"\x73" in body
+
+    def test_car_emits_castclass_and_ldfld(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+            IrInstruction(IrOp.CAR, [IrRegister(3), IrRegister(2)]),
+        ])
+        artifact = lower_ir_to_cil_bytecode(program)
+        body = self._main_body(artifact)
+        # 0x74 = castclass; 0x7B = ldfld.
+        assert b"\x74" in body
+        assert b"\x7B" in body
+
+    def test_cdr_emits_castclass_and_ldfld(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+            IrInstruction(IrOp.CDR, [IrRegister(3), IrRegister(2)]),
+        ])
+        artifact = lower_ir_to_cil_bytecode(program)
+        body = self._main_body(artifact)
+        assert b"\x74" in body
+        assert b"\x7B" in body
+
+    def test_is_null_emits_isinst_ldnull_cgt_un(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+            IrInstruction(IrOp.IS_NULL, [IrRegister(3), IrRegister(2)]),
+        ])
+        artifact = lower_ir_to_cil_bytecode(program)
+        body = self._main_body(artifact)
+        # 0x75 = isinst; 0x14 = ldnull; 0xFE 0x03 = cgt.un (two bytes).
+        assert b"\x75" in body
+        assert b"\x14" in body
+        assert b"\xfe\x03" in body
+
+    def test_is_pair_emits_isinst(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+            IrInstruction(IrOp.IS_PAIR, [IrRegister(3), IrRegister(2)]),
+        ])
+        body = self._main_body(lower_ir_to_cil_bytecode(program))
+        assert b"\x75" in body
+
+    def test_is_symbol_emits_isinst(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+            IrInstruction(IrOp.IS_SYMBOL, [IrRegister(3), IrRegister(2)]),
+        ])
+        body = self._main_body(lower_ir_to_cil_bytecode(program))
+        assert b"\x75" in body
+
+    def test_make_symbol_emits_newobj_and_ldnull_placeholder(self) -> None:
+        """Phase 3c v1: MAKE_SYMBOL emits ``ldnull`` for the name
+        argument (proper ldstr UserString wiring lands in 3c.5)."""
+        program = self._heap_program([
+            IrInstruction(
+                IrOp.MAKE_SYMBOL, [IrRegister(2), IrLabel("foo")],
+            ),
+        ])
+        body = self._main_body(lower_ir_to_cil_bytecode(program))
+        # 0x14 ldnull, 0x73 newobj.
+        assert b"\x14" in body
+        assert b"\x73" in body
+
+    def test_load_nil_emits_newobj(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+        ])
+        body = self._main_body(lower_ir_to_cil_bytecode(program))
+        # 0x73 = newobj (Nil.ctor()).
+        assert b"\x73" in body
+
+    def test_make_cons_arity_validation(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.MAKE_CONS, [IrRegister(2)]),  # missing 2 ops
+        ])
+        with pytest.raises(CILBackendError, match="MAKE_CONS expects"):
+            lower_ir_to_cil_bytecode(program)
+
+    def test_load_nil_arity_validation(self) -> None:
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2), IrRegister(3)]),
+        ])
+        with pytest.raises(CILBackendError, match="LOAD_NIL expects"):
+            lower_ir_to_cil_bytecode(program)
+
+    def test_validate_for_clr_accepts_heap_opcodes(self) -> None:
+        """validate_for_clr no longer rejects the 8 heap opcodes."""
+        program = self._heap_program([
+            IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
+            IrInstruction(IrOp.MAKE_CONS, [
+                IrRegister(3), IrRegister(2), IrRegister(2),
+            ]),
+            IrInstruction(IrOp.CAR, [IrRegister(4), IrRegister(3)]),
+        ])
+        # Empty errors list → no rejections.
+        assert validate_for_clr(program) == []
+
+
+class TestHeapTokenLayout:
+    """Lock down the deterministic heap-token layout so the writer
+    can mirror it.  Tokens are computed relative to the closure
+    counts so future Phase 3c.5 work doesn't shift them."""
+
+    def test_heap_tokens_unavailable_without_include_heap_types(self) -> None:
+        provider = SequentialCILTokenProvider(
+            ("Main",),
+        )
+        with pytest.raises(CILBackendError, match="cons_ctor"):
+            provider.heap_cons_ctor_token()
+
+    def test_heap_tokens_layout_no_closures(self) -> None:
+        """With no closures and one main method, the heap method
+        tokens start at 0x06000002."""
+        provider = SequentialCILTokenProvider(
+            ("Main",), include_heap_types=True,
+        )
+        # M=1 main methods, no closures.  Heap method base = 0x06000002.
+        assert provider.heap_cons_ctor_token() == 0x06000002
+        assert provider.heap_symbol_ctor_token() == 0x06000003
+        assert provider.heap_nil_ctor_token() == 0x06000004
+        # Field tokens start at 0x04000001.
+        assert provider.heap_cons_head_token() == 0x04000001
+        assert provider.heap_cons_tail_token() == 0x04000002
+        assert provider.heap_symbol_name_token() == 0x04000003
+        # TypeDef tokens: row 1=<Module>, row 2=Main, row 3=Cons.
+        assert provider.heap_cons_typedef_token() == 0x02000003
+        assert provider.heap_symbol_typedef_token() == 0x02000004
+        assert provider.heap_nil_typedef_token() == 0x02000005
+
+    def test_heap_tokens_layout_with_closures(self) -> None:
+        """With 1 main method + 2 closures, the heap method tokens
+        follow the closure rows (1 + 2*2 = 5 closure method rows)."""
+        provider = SequentialCILTokenProvider(
+            ("Main",),
+            closure_names=("_l0", "_l1"),
+            closure_free_var_counts={"_l0": 1, "_l1": 2},
+            include_heap_types=True,
+        )
+        # M=1, closure_method_rows = 1 + 2*2 = 5.  Heap base = 0x06000002 + 5.
+        assert provider.heap_cons_ctor_token() == 0x06000007
+        # field_row after closures: 1 + 2 = 3 capture fields.  Heap fields
+        # start at 0x04000001 + 3 = 0x04000004.
+        assert provider.heap_cons_head_token() == 0x04000004
+        # TypeDef rows: <Module>=1, Main=2, IClosure=3, Closure__l0=4,
+        # Closure__l1=5, Cons=6.
+        assert provider.heap_cons_typedef_token() == 0x02000006

--- a/code/packages/python/twig-clr-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-clr-compiler/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog — twig-clr-compiler
 
+## 0.3.0 — 2026-04-30 — TW03 Phase 3e (heap primitives from Twig source)
+
+Twig source containing `cons` / `car` / `cdr` / `null?` / `pair?` /
+`symbol?` / `'foo` / `nil` now compiles via the CLR backend.
+Builds on the Phase 3c heap-op lowering (which ships structural
+PE/CLI bytecode for the eight heap opcodes).
+
+End-to-end on real `dotnet` is deferred until CLR Phase 3c.5
+wires writer-side support for symbol-name string interning and
+the singleton Nil instance — until then heap programs compile to
+verifier-correct CIL but may not execute correctly.
+
+Mirrors twig-jvm-compiler v0.3.0 (TW03 Phase 3e for JVM) — same
+lambda-lifting + heap-builtin emission table, just routes to the
+CLR backend's Phase 3c lowering instead of the JVM Phase 3b path.
+
+### Added — heap-primitive emission
+
+- `nil` literal → `LOAD_NIL`.
+- `'foo` / `(quote foo)` → `MAKE_SYMBOL` with the symbol name as
+  an `IrLabel`.
+- `cons` → `MAKE_CONS dst, head, tail` (2 args).
+- `car` / `cdr` → `CAR` / `CDR` (1 arg each).
+- `null?` / `pair?` / `symbol?` → `IS_NULL` / `IS_PAIR` /
+  `IS_SYMBOL` (1 arg each, result is an int 0/1 ready to feed
+  BRANCH_Z).
+- `_HEAP_BUILTINS` table maps Twig source names to (op, arity)
+  pairs; the apply-site dispatches uniformly with arity validation.
+- Free-variable analysis treats `_HEAP_BUILTINS` as globals so
+  closures over `cons` / `car` / etc compile correctly.
+
+### Removed — obsolete rejection tests
+
+- `test_quoted_symbol_rejected` — now compiles to MAKE_SYMBOL.
+- `test_cons_rejected` — now compiles to MAKE_CONS.
+
+### Test additions
+
+- 8 new IR-shape tests covering each heap op's emission shape.
+- 2 new arity-validation tests.
+- All 61 tests pass; coverage 90%.
+
+### Limitations
+
+- End-to-end on real `dotnet` is deferred to Phase 3c.5 (writer-side
+  intern table for symbol names, singleton Nil instance).
+- `print` and `number?` builtins still raise (TW04 territory).
+
 ## 0.2.0 — 2026-04-29 — CLR02 Phase 2d (closures from Twig source)
 
 ### Added — anonymous lambdas and closure invocation

--- a/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
+++ b/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
@@ -160,9 +160,28 @@ _BINARY_OPS: dict[str, IrOp] = {
     ">": IrOp.CMP_GT,
 }
 
+# TW03 Phase 3e — heap-primitive builtins now compile (was rejected
+# in v1).  Each maps to its corresponding IR opcode below.  The
+# remaining rejected set is shrunk to opcodes still without a CLR
+# lowering.
 _V1_REJECTED_BUILTINS: frozenset[str] = frozenset(
-    {"cons", "car", "cdr", "null?", "pair?", "number?", "symbol?", "print"}
+    {"number?", "print"}
 )
+
+# TW03 Phase 3e — Lisp heap-primitive builtins.  Each entry maps a
+# builtin name to its IR opcode + arity so the apply-site can
+# generate a uniform call sequence.  Phase 3c's CLR backend
+# lowering will turn these into ``newobj`` / ``ldfld`` / ``isinst``
+# CIL bytecode against the auto-generated Cons / Symbol / Nil
+# TypeDefs.
+_HEAP_BUILTINS: dict[str, tuple[IrOp, int]] = {
+    "cons":    (IrOp.MAKE_CONS, 2),
+    "car":     (IrOp.CAR, 1),
+    "cdr":     (IrOp.CDR, 1),
+    "null?":   (IrOp.IS_NULL, 1),
+    "pair?":   (IrOp.IS_PAIR, 1),
+    "symbol?": (IrOp.IS_SYMBOL, 1),
+}
 
 
 # Register convention — see module docstring.
@@ -352,8 +371,9 @@ class _Compiler:
             return reg
 
         if isinstance(expr, NilLit):
+            # TW03 Phase 3e: lower nil to LOAD_NIL.
             reg = self._fresh_holding(ctx)
-            self._emit(IrOp.LOAD_IMM, reg, IrImmediate(0))
+            self._emit(IrOp.LOAD_NIL, reg)
             return reg
 
         if isinstance(expr, VarRef):
@@ -385,10 +405,10 @@ class _Compiler:
             return self._compile_anonymous_lambda(expr, ctx)
 
         if isinstance(expr, SymLit):
-            raise TwigCompileError(
-                "quoted symbols are not yet supported by the CLR "
-                "backend — see TW03 Phase 3."
-            )
+            # TW03 Phase 3e: lower 'foo / (quote foo) to MAKE_SYMBOL.
+            reg = self._fresh_holding(ctx)
+            self._emit(IrOp.MAKE_SYMBOL, reg, IrLabel(expr.name))
+            return reg
 
         msg = f"unsupported Twig form for CLR v1: {type(expr).__name__}"
         raise TwigCompileError(msg)
@@ -460,6 +480,23 @@ class _Compiler:
                     f"builtin {name!r} is not yet supported by the CLR "
                     "backend — see TW03 Phase 3 for heap primitives."
                 )
+
+            # TW03 Phase 3e — heap-primitive builtins.  Single-shape
+            # lowering: evaluate args, fresh holding reg for the
+            # result, emit the IR opcode.
+            if name in _HEAP_BUILTINS:
+                op, expected_arity = _HEAP_BUILTINS[name]
+                if len(expr.args) != expected_arity:
+                    raise TwigCompileError(
+                        f"{name!r} expects {expected_arity} arguments, "
+                        f"got {len(expr.args)}"
+                    )
+                arg_regs = [
+                    self._compile_expr(a, ctx) for a in expr.args
+                ]
+                dest = self._fresh_holding(ctx)
+                self._emit(op, dest, *arg_regs)
+                return dest
 
             if name in _BINARY_OPS:
                 if len(expr.args) != 2:
@@ -538,6 +575,7 @@ class _Compiler:
             | set(self._value_consts)
             | set(_BINARY_OPS)
             | _V1_REJECTED_BUILTINS
+            | set(_HEAP_BUILTINS)
         )
         captures = free_vars(lam, globals_)
 

--- a/code/packages/python/twig-clr-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_compile.py
@@ -174,17 +174,62 @@ class TestRejectedSurface:
         with pytest.raises(TwigCompileError, match="takes 1 arguments"):
             compile_to_ir("(define (id x) x) (id 1 2)")
 
-    def test_quoted_symbol_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="quoted symbols"):
-            compile_to_ir("'foo")
-
-    def test_cons_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(cons 1 2)")
-
     def test_print_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="not yet supported"):
             compile_to_ir("(print 42)")
+
+    # ── Heap primitives (TW03 Phase 3e) ──────────────────────────────
+
+    def test_nil_emits_load_nil(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("nil")
+        assert IrOp.LOAD_NIL in [i.opcode for i in ir.instructions]
+
+    def test_quoted_symbol_emits_make_symbol(self) -> None:
+        from compiler_ir import IrLabel, IrOp
+        ir = compile_to_ir("'foo")
+        mks = [i for i in ir.instructions if i.opcode is IrOp.MAKE_SYMBOL]
+        assert len(mks) == 1
+        assert isinstance(mks[0].operands[1], IrLabel)
+        assert mks[0].operands[1].name == "foo"
+
+    def test_cons_emits_make_cons(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(cons 1 nil)")
+        assert IrOp.MAKE_CONS in [i.opcode for i in ir.instructions]
+
+    def test_car_emits_car(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(car (cons 1 nil))")
+        assert IrOp.CAR in [i.opcode for i in ir.instructions]
+
+    def test_cdr_emits_cdr(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(cdr (cons 1 nil))")
+        assert IrOp.CDR in [i.opcode for i in ir.instructions]
+
+    def test_null_predicate_emits_is_null(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(null? nil)")
+        assert IrOp.IS_NULL in [i.opcode for i in ir.instructions]
+
+    def test_pair_predicate_emits_is_pair(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(pair? (cons 1 nil))")
+        assert IrOp.IS_PAIR in [i.opcode for i in ir.instructions]
+
+    def test_symbol_predicate_emits_is_symbol(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(symbol? 'foo)")
+        assert IrOp.IS_SYMBOL in [i.opcode for i in ir.instructions]
+
+    def test_cons_arity_validation(self) -> None:
+        with pytest.raises(TwigCompileError, match="cons"):
+            compile_to_ir("(cons 1)")
+
+    def test_car_arity_validation(self) -> None:
+        with pytest.raises(TwigCompileError, match="car"):
+            compile_to_ir("(car)")
 
     def test_non_literal_value_define_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="literal RHS"):

--- a/code/specs/TW03-phase3-heap-primitives.md
+++ b/code/specs/TW03-phase3-heap-primitives.md
@@ -124,14 +124,32 @@ head slots.  Heterogeneous cells (`(cons 'foo nil)`) need a
 follow-up that widens `head` to `Object` with autoboxing and
 threads typing for the head-read site.
 
-### Phase 3c — CLR heap primitives (CLR03)
+### Phase 3c — CLR heap primitives (CLR03).  **Shipped (structural).**
 
-- Same shape as JVM but as additional `TypeDef` rows in the
-  single PE/CLI assembly (the multi-TypeDef plumbing from
-  CLR02 Phase 2b carries over verbatim).
-- `Cons` / `Symbol` / `Nil` types under the assembly's
-  namespace; `Symbol.Intern(string)` static method.
-- `IS_PAIR` / `IS_SYMBOL` lower to `isinst` + `ldnull; cgt.un`.
+- `CodingAdventures.Cons` (`int32 head` + `object tail`),
+  `CodingAdventures.Symbol` (`string name`), and
+  `CodingAdventures.Nil` types — auto-included in the
+  multi-TypeDef PE/CLI assembly when any heap opcode appears.
+- `MAKE_CONS` lowers to `ldloc head; ldloc tail (obj); newobj
+  Cons.ctor(int32, object); stloc dst (obj)`.
+- `CAR` / `CDR` lower to `ldloc src (obj); castclass Cons;
+  ldfld Cons::head/tail; stloc dst`.
+- `IS_NULL` / `IS_PAIR` / `IS_SYMBOL` lower to `ldloc src (obj);
+  isinst T; ldnull; cgt.un; stloc dst (int)`.
+- `MAKE_SYMBOL` lowers to `ldnull; newobj Symbol.ctor(string)`
+  (placeholder for the name string — proper `ldstr` UserString
+  wiring lands in 3c.5).
+- `LOAD_NIL` lowers to `newobj Nil.ctor()` (fresh instance per
+  call — singleton wiring lands in 3c.5; `IS_NULL` still works
+  via `isinst Nil`).
+
+`SequentialCILTokenProvider` accepts `include_heap_types=True`
+which lays out heap method/field/TypeDef tokens deterministically
+AFTER any closure rows.
+
+V1 limitation: end-to-end on real `dotnet` is deferred until
+Phase 3c.5 wires writer-side support for the UserString intern
+table (Symbol names) and the singleton `Nil.INSTANCE` field.
 
 ### Phase 3d — BEAM heap primitives (BEAM03).  **Shipped.**
 


### PR DESCRIPTION
## Summary

CLR-side lowering for the eight TW03 Phase 3a heap opcodes (\`MAKE_CONS\`, \`CAR\`, \`CDR\`, \`IS_NULL\`, \`IS_PAIR\`, \`MAKE_SYMBOL\`, \`IS_SYMBOL\`, \`LOAD_NIL\`).

Ships **structural-only** — bytecode shape is correct, three new TypeArtifacts (Cons / Symbol / Nil) get auto-included, but a follow-up (Phase 3c.5) wires writer-side support for symbol-name string interning and the singleton Nil instance.

Mirrors the staging that worked for closures: Phase 2c shipped structural; Phase 2c.5 wired runtime correctness.

## What's added

- 3 runtime TypeDefs auto-included on heap-using programs: \`Cons\`, \`Symbol\`, \`Nil\`
- 8 opcode lowerings using \`newobj\` / \`castclass\` / \`ldfld\` / \`isinst\` / \`ldnull\` / \`cgt.un\`
- \`SequentialCILTokenProvider\` accepts \`include_heap_types=True\` with deterministic token layout AFTER any closure rows
- 9 new token-provider Protocol methods
- Type-tracking rules so the Phase 2c.5 typed register pool routes obj-typed regs correctly

## Test plan

- [x] 4 \`TestHeapExtraTypes\` tests verifying auto-include + field layouts
- [x] 11 \`TestHeapOpLowering\` tests verifying each opcode emits identifying CIL bytes
- [x] 3 \`TestHeapTokenLayout\` tests locking down the deterministic token layout
- [x] All 97 ir-to-cil-bytecode tests pass; coverage 92%

## Limitations (intentional, scoped to Phase 3c.5)

- Symbol names are placeholder-\`ldnull\` until writer-side UserString intern table lands
- \`Nil\` is fresh \`newobj\` per \`LOAD_NIL\` (singleton \`INSTANCE\` static field lands in 3c.5; \`IS_NULL\` still works correctly via \`isinst Nil\`)
- \`Cons.head\` typed \`int32\` (matches list-of-ints, the spec acceptance criterion)
- End-to-end on real \`dotnet\` deferred until Phase 3c.5 wires writer-side support

🤖 Generated with [Claude Code](https://claude.com/claude-code)