### PR TITLE
feat(clr): TW03 Phase 3e — heap primitives from Twig source

### DIFF
--- a/code/packages/python/twig-clr-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-clr-compiler/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog — twig-clr-compiler
 
+## 0.3.0 — 2026-04-30 — TW03 Phase 3e (heap primitives from Twig source)
+
+Twig source containing `cons` / `car` / `cdr` / `null?` / `pair?` /
+`symbol?` / `'foo` / `nil` now compiles via the CLR backend.
+Builds on the Phase 3c heap-op lowering (which ships structural
+PE/CLI bytecode for the eight heap opcodes).
+
+End-to-end on real `dotnet` is deferred until CLR Phase 3c.5
+wires writer-side support for symbol-name string interning and
+the singleton Nil instance — until then heap programs compile to
+verifier-correct CIL but may not execute correctly.
+
+Mirrors twig-jvm-compiler v0.3.0 (TW03 Phase 3e for JVM) — same
+lambda-lifting + heap-builtin emission table, just routes to the
+CLR backend's Phase 3c lowering instead of the JVM Phase 3b path.
+
+### Added — heap-primitive emission
+
+- `nil` literal → `LOAD_NIL`.
+- `'foo` / `(quote foo)` → `MAKE_SYMBOL` with the symbol name as
+  an `IrLabel`.
+- `cons` → `MAKE_CONS dst, head, tail` (2 args).
+- `car` / `cdr` → `CAR` / `CDR` (1 arg each).
+- `null?` / `pair?` / `symbol?` → `IS_NULL` / `IS_PAIR` /
+  `IS_SYMBOL` (1 arg each, result is an int 0/1 ready to feed
+  BRANCH_Z).
+- `_HEAP_BUILTINS` table maps Twig source names to (op, arity)
+  pairs; the apply-site dispatches uniformly with arity validation.
+- Free-variable analysis treats `_HEAP_BUILTINS` as globals so
+  closures over `cons` / `car` / etc compile correctly.
+
+### Removed — obsolete rejection tests
+
+- `test_quoted_symbol_rejected` — now compiles to MAKE_SYMBOL.
+- `test_cons_rejected` — now compiles to MAKE_CONS.
+
+### Test additions
+
+- 8 new IR-shape tests covering each heap op's emission shape.
+- 2 new arity-validation tests.
+- All 61 tests pass; coverage 90%.
+
+### Limitations
+
+- End-to-end on real `dotnet` is deferred to Phase 3c.5 (writer-side
+  intern table for symbol names, singleton Nil instance).
+- `print` and `number?` builtins still raise (TW04 territory).
+
 ## 0.2.0 — 2026-04-29 — CLR02 Phase 2d (closures from Twig source)
 
 ### Added — anonymous lambdas and closure invocation

--- a/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
+++ b/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
@@ -160,9 +160,28 @@ _BINARY_OPS: dict[str, IrOp] = {
     ">": IrOp.CMP_GT,
 }
 
+# TW03 Phase 3e — heap-primitive builtins now compile (was rejected
+# in v1).  Each maps to its corresponding IR opcode below.  The
+# remaining rejected set is shrunk to opcodes still without a CLR
+# lowering.
 _V1_REJECTED_BUILTINS: frozenset[str] = frozenset(
-    {"cons", "car", "cdr", "null?", "pair?", "number?", "symbol?", "print"}
+    {"number?", "print"}
 )
+
+# TW03 Phase 3e — Lisp heap-primitive builtins.  Each entry maps a
+# builtin name to its IR opcode + arity so the apply-site can
+# generate a uniform call sequence.  Phase 3c's CLR backend
+# lowering will turn these into ``newobj`` / ``ldfld`` / ``isinst``
+# CIL bytecode against the auto-generated Cons / Symbol / Nil
+# TypeDefs.
+_HEAP_BUILTINS: dict[str, tuple[IrOp, int]] = {
+    "cons":    (IrOp.MAKE_CONS, 2),
+    "car":     (IrOp.CAR, 1),
+    "cdr":     (IrOp.CDR, 1),
+    "null?":   (IrOp.IS_NULL, 1),
+    "pair?":   (IrOp.IS_PAIR, 1),
+    "symbol?": (IrOp.IS_SYMBOL, 1),
+}
 
 
 # Register convention — see module docstring.
@@ -352,8 +371,9 @@ class _Compiler:
             return reg
 
         if isinstance(expr, NilLit):
+            # TW03 Phase 3e: lower nil to LOAD_NIL.
             reg = self._fresh_holding(ctx)
-            self._emit(IrOp.LOAD_IMM, reg, IrImmediate(0))
+            self._emit(IrOp.LOAD_NIL, reg)
             return reg
 
         if isinstance(expr, VarRef):
@@ -385,10 +405,10 @@ class _Compiler:
             return self._compile_anonymous_lambda(expr, ctx)
 
         if isinstance(expr, SymLit):
-            raise TwigCompileError(
-                "quoted symbols are not yet supported by the CLR "
-                "backend — see TW03 Phase 3."
-            )
+            # TW03 Phase 3e: lower 'foo / (quote foo) to MAKE_SYMBOL.
+            reg = self._fresh_holding(ctx)
+            self._emit(IrOp.MAKE_SYMBOL, reg, IrLabel(expr.name))
+            return reg
 
         msg = f"unsupported Twig form for CLR v1: {type(expr).__name__}"
         raise TwigCompileError(msg)
@@ -460,6 +480,23 @@ class _Compiler:
                     f"builtin {name!r} is not yet supported by the CLR "
                     "backend — see TW03 Phase 3 for heap primitives."
                 )
+
+            # TW03 Phase 3e — heap-primitive builtins.  Single-shape
+            # lowering: evaluate args, fresh holding reg for the
+            # result, emit the IR opcode.
+            if name in _HEAP_BUILTINS:
+                op, expected_arity = _HEAP_BUILTINS[name]
+                if len(expr.args) != expected_arity:
+                    raise TwigCompileError(
+                        f"{name!r} expects {expected_arity} arguments, "
+                        f"got {len(expr.args)}"
+                    )
+                arg_regs = [
+                    self._compile_expr(a, ctx) for a in expr.args
+                ]
+                dest = self._fresh_holding(ctx)
+                self._emit(op, dest, *arg_regs)
+                return dest
 
             if name in _BINARY_OPS:
                 if len(expr.args) != 2:
@@ -538,6 +575,7 @@ class _Compiler:
             | set(self._value_consts)
             | set(_BINARY_OPS)
             | _V1_REJECTED_BUILTINS
+            | set(_HEAP_BUILTINS)
         )
         captures = free_vars(lam, globals_)
 

--- a/code/packages/python/twig-clr-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_compile.py
@@ -174,17 +174,62 @@ class TestRejectedSurface:
         with pytest.raises(TwigCompileError, match="takes 1 arguments"):
             compile_to_ir("(define (id x) x) (id 1 2)")
 
-    def test_quoted_symbol_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="quoted symbols"):
-            compile_to_ir("'foo")
-
-    def test_cons_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(cons 1 2)")
-
     def test_print_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="not yet supported"):
             compile_to_ir("(print 42)")
+
+    # ── Heap primitives (TW03 Phase 3e) ──────────────────────────────
+
+    def test_nil_emits_load_nil(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("nil")
+        assert IrOp.LOAD_NIL in [i.opcode for i in ir.instructions]
+
+    def test_quoted_symbol_emits_make_symbol(self) -> None:
+        from compiler_ir import IrLabel, IrOp
+        ir = compile_to_ir("'foo")
+        mks = [i for i in ir.instructions if i.opcode is IrOp.MAKE_SYMBOL]
+        assert len(mks) == 1
+        assert isinstance(mks[0].operands[1], IrLabel)
+        assert mks[0].operands[1].name == "foo"
+
+    def test_cons_emits_make_cons(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(cons 1 nil)")
+        assert IrOp.MAKE_CONS in [i.opcode for i in ir.instructions]
+
+    def test_car_emits_car(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(car (cons 1 nil))")
+        assert IrOp.CAR in [i.opcode for i in ir.instructions]
+
+    def test_cdr_emits_cdr(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(cdr (cons 1 nil))")
+        assert IrOp.CDR in [i.opcode for i in ir.instructions]
+
+    def test_null_predicate_emits_is_null(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(null? nil)")
+        assert IrOp.IS_NULL in [i.opcode for i in ir.instructions]
+
+    def test_pair_predicate_emits_is_pair(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(pair? (cons 1 nil))")
+        assert IrOp.IS_PAIR in [i.opcode for i in ir.instructions]
+
+    def test_symbol_predicate_emits_is_symbol(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(symbol? 'foo)")
+        assert IrOp.IS_SYMBOL in [i.opcode for i in ir.instructions]
+
+    def test_cons_arity_validation(self) -> None:
+        with pytest.raises(TwigCompileError, match="cons"):
+            compile_to_ir("(cons 1)")
+
+    def test_car_arity_validation(self) -> None:
+        with pytest.raises(TwigCompileError, match="car"):
+            compile_to_ir("(car)")
 
     def test_non_literal_value_define_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="literal RHS"):


### PR DESCRIPTION
## Summary

Twig source containing \`cons\` / \`car\` / \`cdr\` / \`null?\` / \`pair?\` / \`symbol?\` / \`'foo\` / \`nil\` now compiles via the CLR backend.

**Stacked on [#1796](https://github.com/adhithyan15/coding-adventures/pull/1796)** (CLR Phase 3c — heap-op lowering structural). Will rebase onto main once 3c merges.

Mirrors twig-jvm-compiler v0.3.0 (TW03 Phase 3e for JVM) — same lambda-lifting + heap-builtin emission table, just routes to the CLR backend's Phase 3c lowering instead of the JVM Phase 3b path.

## End-to-end status

End-to-end on real \`dotnet\` is deferred until **CLR Phase 3c.5** wires writer-side support for symbol-name string interning and the singleton Nil instance. Until then heap programs compile to verifier-correct CIL but may not execute correctly. This PR adds no real-dotnet tests for that reason; IR-shape tests cover the emission paths.

## What's added

- \`_HEAP_BUILTINS\` table maps Twig source names to (IrOp, arity)
- \`nil\` literal → \`LOAD_NIL\`
- \`'foo\` / \`(quote foo)\` → \`MAKE_SYMBOL\` with the name as \`IrLabel\`
- \`cons\` / \`car\` / \`cdr\` / \`null?\` / \`pair?\` / \`symbol?\` → corresponding IR opcodes
- Free-variable analysis treats heap builtins as globals so closures over them work

## Test plan

- [x] 8 new IR-shape unit tests (one per heap op)
- [x] 2 new arity-validation tests
- [x] 2 obsolete rejection tests removed
- [x] All 61 tests pass; 90% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)