### PR TITLE
feat(beam): TW03 Phase 3e — heap primitives from Twig source

### DIFF
--- a/code/packages/python/twig-beam-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-beam-compiler/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog — twig-beam-compiler
 
+## 0.4.0 — 2026-04-30 — TW03 Phase 3e (heap primitives from Twig source)
+
+Twig source containing `cons` / `car` / `cdr` / `null?` / `pair?` /
+`symbol?` / `'foo` / `nil` now compiles via the BEAM backend.
+Builds on Phase 3d (BEAM heap-op lowering, already shipped).
+
+The headline TW03 Phase 3 acceptance criterion runs **end-to-end
+on real `erl` from raw Twig source**:
+
+```
+(define (length xs)
+  (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+(length (cons 1 (cons 2 (cons 3 nil))))
+→ 3
+```
+
+This is the first backend where the recursive heap test passes —
+BEAM cons cells are first-class native terms with their own GC,
+so this works without any JVM-style obj-pool caller-saves
+workaround.  The JVM equivalent is currently xfail-strict pending
+the obj-pool caller-saves fix.
+
+Mirrors twig-jvm-compiler v0.3.0 and twig-clr-compiler v0.3.0
+(Phase 3e for JVM and CLR) — same lambda-lifting + heap-builtin
+emission table, just routes to the BEAM backend's Phase 3d
+lowering.
+
+### Added — heap-primitive emission
+
+- `nil` literal → `LOAD_NIL`.
+- `'foo` / `(quote foo)` → `MAKE_SYMBOL` with the symbol name as
+  an `IrLabel`.
+- `cons` → `MAKE_CONS dst, head, tail` (2 args).
+- `car` / `cdr` → `CAR` / `CDR` (1 arg each).
+- `null?` / `pair?` / `symbol?` → `IS_NULL` / `IS_PAIR` /
+  `IS_SYMBOL`.
+- `_HEAP_BUILTINS` table maps Twig source names to (op, arity);
+  the apply-site dispatches uniformly with arity validation.
+- Free-variable analysis treats `_HEAP_BUILTINS` as globals so
+  closures over `cons` / `car` / etc compile correctly.
+
+### Test additions
+
+- 8 new IR-shape tests covering each heap op's emission shape.
+- 2 new arity-validation tests.
+- 3 new real-`erl` end-to-end tests:
+  - `test_heap_list_of_ints_length` — `(length [1 2 3]) → 3`
+    end-to-end from Twig source.
+  - `test_heap_car_returns_int` — `(car (cons 42 nil)) → 42`.
+  - `test_heap_quoted_symbol_returns_atom` — `'foo` returns the
+    atom `foo`.
+- 2 obsolete rejection tests removed.
+- 65/65 tests pass; 91% coverage.
+
 ## 0.3.0 — 2026-04-29 — TW03 Phase 2 (BEAM closures)
 
 ### Added — anonymous lambdas and closure invocation

--- a/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/compiler.py
+++ b/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/compiler.py
@@ -154,9 +154,27 @@ _BINARY_OPS: dict[str, IrOp] = {
     ">": IrOp.CMP_GT,
 }
 
+# TW03 Phase 3e — heap-primitive builtins now compile (was rejected
+# in v1).  Each maps to its corresponding IR opcode below.  The
+# remaining rejected set is shrunk to opcodes still without a BEAM
+# lowering.
 _V1_REJECTED_BUILTINS: frozenset[str] = frozenset(
-    {"cons", "car", "cdr", "null?", "pair?", "number?", "symbol?", "print"}
+    {"number?", "print"}
 )
+
+# TW03 Phase 3e — Lisp heap-primitive builtins.  Each entry maps a
+# builtin name to its IR opcode + arity so the apply-site can
+# generate a uniform call sequence.  Phase 3d's BEAM backend
+# lowering will turn these into native put_list / get_hd / get_tl /
+# is_nil / is_nonempty_list / is_atom / move {atom, idx} opcodes.
+_HEAP_BUILTINS: dict[str, tuple[IrOp, int]] = {
+    "cons":    (IrOp.MAKE_CONS, 2),
+    "car":     (IrOp.CAR, 1),
+    "cdr":     (IrOp.CDR, 1),
+    "null?":   (IrOp.IS_NULL, 1),
+    "pair?":   (IrOp.IS_PAIR, 1),
+    "symbol?": (IrOp.IS_SYMBOL, 1),
+}
 
 
 # Register convention — see module docstring.
@@ -343,8 +361,9 @@ class _Compiler:
             return reg
 
         if isinstance(expr, NilLit):
+            # TW03 Phase 3e: lower nil to LOAD_NIL.
             reg = self._fresh_holding(ctx)
-            self._emit(IrOp.LOAD_IMM, reg, IrImmediate(0))
+            self._emit(IrOp.LOAD_NIL, reg)
             return reg
 
         if isinstance(expr, VarRef):
@@ -376,10 +395,10 @@ class _Compiler:
             return self._compile_anonymous_lambda(expr, ctx)
 
         if isinstance(expr, SymLit):
-            raise TwigCompileError(
-                "quoted symbols are not yet supported by the BEAM "
-                "backend — see TW03 Phase 3."
-            )
+            # TW03 Phase 3e: lower 'foo / (quote foo) to MAKE_SYMBOL.
+            reg = self._fresh_holding(ctx)
+            self._emit(IrOp.MAKE_SYMBOL, reg, IrLabel(expr.name))
+            return reg
 
         msg = f"unsupported Twig form for BEAM v1: {type(expr).__name__}"
         raise TwigCompileError(msg)
@@ -451,6 +470,24 @@ class _Compiler:
                     f"builtin {name!r} is not yet supported by the BEAM "
                     "backend — see TW03 Phase 3 for heap primitives."
                 )
+
+            # TW03 Phase 3e — heap-primitive builtins.  Single-shape
+            # lowering: evaluate args, fresh holding reg for the
+            # result, emit the IR opcode.
+            if name in _HEAP_BUILTINS:
+                op, expected_arity = _HEAP_BUILTINS[name]
+                if len(expr.args) != expected_arity:
+                    raise TwigCompileError(
+                        f"{name!r} expects {expected_arity} arguments, "
+                        f"got {len(expr.args)}"
+                    )
+                arg_regs = [
+                    self._compile_expr(a, ctx) for a in expr.args
+                ]
+                dest = self._fresh_holding(ctx)
+                self._emit(op, dest, *arg_regs)
+                return dest
+
             if name in _BINARY_OPS:
                 if len(expr.args) != 2:
                     raise TwigCompileError(
@@ -528,6 +565,7 @@ class _Compiler:
             | set(self._value_consts)
             | set(_BINARY_OPS)
             | _V1_REJECTED_BUILTINS
+            | set(_HEAP_BUILTINS)
         )
         captures = free_vars(lam, globals_)
 

--- a/code/packages/python/twig-beam-compiler/tests/test_compile.py
+++ b/code/packages/python/twig-beam-compiler/tests/test_compile.py
@@ -155,17 +155,62 @@ class TestRejectedSurface:
         with pytest.raises(TwigCompileError, match="takes 1 arguments"):
             compile_to_ir("(define (id x) x) (id 1 2)")
 
-    def test_cons_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="not yet supported"):
-            compile_to_ir("(cons 1 2)")
-
     def test_print_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="not yet supported"):
             compile_to_ir("(print 42)")
 
-    def test_quoted_symbol_rejected(self) -> None:
-        with pytest.raises(TwigCompileError, match="quoted symbols"):
-            compile_to_ir("'foo")
+    # ── Heap primitives (TW03 Phase 3e for BEAM) ─────────────────────
+
+    def test_nil_emits_load_nil(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("nil")
+        assert IrOp.LOAD_NIL in [i.opcode for i in ir.instructions]
+
+    def test_quoted_symbol_emits_make_symbol(self) -> None:
+        from compiler_ir import IrLabel, IrOp
+        ir = compile_to_ir("'foo")
+        mks = [i for i in ir.instructions if i.opcode is IrOp.MAKE_SYMBOL]
+        assert len(mks) == 1
+        assert isinstance(mks[0].operands[1], IrLabel)
+        assert mks[0].operands[1].name == "foo"
+
+    def test_cons_emits_make_cons(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(cons 1 nil)")
+        assert IrOp.MAKE_CONS in [i.opcode for i in ir.instructions]
+
+    def test_car_emits_car(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(car (cons 1 nil))")
+        assert IrOp.CAR in [i.opcode for i in ir.instructions]
+
+    def test_cdr_emits_cdr(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(cdr (cons 1 nil))")
+        assert IrOp.CDR in [i.opcode for i in ir.instructions]
+
+    def test_null_predicate_emits_is_null(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(null? nil)")
+        assert IrOp.IS_NULL in [i.opcode for i in ir.instructions]
+
+    def test_pair_predicate_emits_is_pair(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(pair? (cons 1 nil))")
+        assert IrOp.IS_PAIR in [i.opcode for i in ir.instructions]
+
+    def test_symbol_predicate_emits_is_symbol(self) -> None:
+        from compiler_ir import IrOp
+        ir = compile_to_ir("(symbol? 'foo)")
+        assert IrOp.IS_SYMBOL in [i.opcode for i in ir.instructions]
+
+    def test_cons_arity_validation(self) -> None:
+        with pytest.raises(TwigCompileError, match="cons"):
+            compile_to_ir("(cons 1)")
+
+    def test_car_arity_validation(self) -> None:
+        with pytest.raises(TwigCompileError, match="car"):
+            compile_to_ir("(car)")
 
     def test_non_literal_value_define_rejected(self) -> None:
         with pytest.raises(TwigCompileError, match="literal RHS"):

--- a/code/packages/python/twig-beam-compiler/tests/test_real_erl.py
+++ b/code/packages/python/twig-beam-compiler/tests/test_real_erl.py
@@ -240,3 +240,56 @@ def test_closure_let_bound() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == b"42"
+
+
+# ── Heap primitives (TW03 Phase 3e for BEAM) ──────────────────────────────
+
+
+@requires_erl
+def test_heap_list_of_ints_length() -> None:
+    """``(length (cons 1 (cons 2 (cons 3 nil)))) → 3`` runs end-to-end
+    on real ``erl`` from raw Twig source.
+
+    The headline TW03 Phase 3 acceptance criterion — Twig parser
+    → IR emitter → BEAM lowering → real ``erl``.  Builds the
+    cons-cell list via ``MAKE_CONS``, walks via ``CDR`` + ``IS_NULL``
+    (lowered to BEAM ``get_tl`` + ``is_nil``), recurses through
+    ``length``.  BEAM cons cells are first-class native terms with
+    their own GC so this works without any JVM-style obj-pool
+    caller-saves workaround.
+    """
+    result = run_source(
+        """
+        (define (length xs)
+          (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+        (length (cons 1 (cons 2 (cons 3 nil))))
+        """,
+        module_name="bm_length",
+    )
+    assert result.returncode == 0, (
+        f"length pipeline broke at runtime.\n"
+        f"  stdout: {result.stdout!r}\n"
+        f"  stderr: {result.stderr!r}"
+    )
+    assert result.stdout.strip() == b"3"
+
+
+@requires_erl
+def test_heap_car_returns_int() -> None:
+    """``(car (cons 42 nil)) → 42`` exercises the int-from-cons-head
+    path."""
+    result = run_source(
+        "(car (cons 42 nil))",
+        module_name="bm_carone",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"42"
+
+
+@requires_erl
+def test_heap_quoted_symbol_returns_atom() -> None:
+    """``'foo`` returns the atom ``foo``.  Real ``erl`` prints atoms
+    unquoted when the name is a valid identifier."""
+    result = run_source("'foo", module_name="bm_symfoo")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == b"foo"


### PR DESCRIPTION
## Summary

Twig source containing \`cons\` / \`car\` / \`cdr\` / \`null?\` / \`pair?\` / \`symbol?\` / \`'foo\` / \`nil\` now compiles via the BEAM backend. Builds on Phase 3d (BEAM heap-op lowering, already shipped).

## End-to-end on real \`erl\` from raw Twig source

The headline TW03 Phase 3 acceptance criterion runs end-to-end:

\`\`\`scheme
(define (length xs)
  (if (null? xs) 0 (+ 1 (length (cdr xs)))))
(length (cons 1 (cons 2 (cons 3 nil))))
→ 3
\`\`\`

**This is the first backend where the recursive heap test passes** — BEAM cons cells are first-class native terms with their own GC, so this works without any JVM-style obj-pool caller-saves workaround. The JVM equivalent is currently xfail-strict pending the obj-pool caller-saves fix.

Mirrors [twig-jvm-compiler v0.3.0](https://github.com/adhithyan15/coding-adventures/pull/1791) and [twig-clr-compiler v0.3.0](https://github.com/adhithyan15/coding-adventures/pull/1797) (Phase 3e for JVM and CLR).

## What's added

- \`_HEAP_BUILTINS\` table maps Twig source names to (IrOp, arity)
- \`nil\` literal → \`LOAD_NIL\`
- \`'foo\` / \`(quote foo)\` → \`MAKE_SYMBOL\` with the name as \`IrLabel\`
- \`cons\` / \`car\` / \`cdr\` / \`null?\` / \`pair?\` / \`symbol?\` → corresponding IR opcodes

## Test plan

- [x] 8 new IR-shape unit tests
- [x] 2 new arity-validation tests
- [x] 3 new real-\`erl\` end-to-end tests
- [x] 2 obsolete rejection tests removed
- [x] 65/65 tests pass; 91% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)