### PR TITLE
fix(jvm): obj-pool caller-saves + ADD_IMM-0 obj propagation

### DIFF
--- a/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
@@ -1,5 +1,55 @@
 # ir-to-jvm-class-file
 
+## 0.11.0 — 2026-04-30 — obj-pool caller-saves + ADD_IMM-0 obj propagation
+
+Closes the obj-pool gap left by JVM Phase 3b.  Recursive heap
+programs (e.g. `(length (cons 1 (cons 2 (cons 3 nil))))`) now run
+correctly on real `java`.
+
+### Fix — obj-pool caller-saves around CALL
+
+The JVM01 caller-saves convention snapshots `__ca_regs` (int pool)
+into JVM locals before each CALL and restores it after, so
+recursion through int registers works.  But the obj pool
+(`__ca_objregs` — cons cells, symbols, nil sentinels, closure
+refs) was uncovered.  Recursion through any obj-typed register
+clobbered the caller's reference when the recursive call's body
+wrote the same slot.
+
+This change extends the existing pattern to the obj pool:
+
+- `_emit_caller_save_objregs` snapshots `__ca_objregs[0..N-1]`
+  into JVM ref locals `N..2N-1` (using `aload`/`astore`).
+- `_emit_caller_restore_objregs` writes them back, skipping
+  index 1 (same convention as the int-pool restore — closure-
+  returning functions put the result in `__ca_objregs[1]`).
+- Triggered only when `_needs_objregs` is True.  Pure-int
+  programs see zero extra emission.
+- `max_locals` doubles to `2 * reg_count` when triggered.
+
+### Fix — ADD_IMM-0 (move idiom) propagates obj slot
+
+Twig compilers use `ADD_IMM dst, src, 0` as the canonical
+register-move idiom.  Pre-fix it only copied the int half of the
+register, so any object reference in the source's obj slot was
+lost.  This worked *by accident* — `make_adder` happened to write
+its closure to a holding reg whose index matched the one `_start`
+then read.  Once obj-pool caller-saves landed, that accident
+broke.
+
+Fix: when `_needs_objregs` is True and the immediate is 0, also
+emit `__ca_objregs[dst] = __ca_objregs[src]` after the int copy.
+Net: `ADD_IMM dst, src, 0` is now a true register-to-register
+copy that propagates BOTH int and obj slots.
+
+### Tests
+
+All 113 ir-to-jvm-class-file tests still pass; coverage 93%.  The
+previously xfail-strict
+`twig_jvm_compiler.test_real_jvm.test_heap_list_of_ints_length`
+now passes (XPASS unblocks; xfail marker removed in
+twig-jvm-compiler v0.4.0).
+
 ## 0.10.0 — 2026-04-30 — TW03 Phase 3b (heap primitives on real java)
 
 Implements the JVM-side lowering for the eight TW03 Phase 3a heap

--- a/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
+++ b/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
@@ -95,6 +95,12 @@ _OP_ANEWARRAY = 0xBD       # reserved for closure pool init
 _OP_ALOAD_0 = 0x2A         # load `this` (or any aload short form)
 _OP_ALOAD_1 = 0x2B         # load arg slot 1 (used in closure Apply forwarder)
 _OP_ALOAD_2 = 0x2C         # load arg slot 2 (used in Cons ctor for tail param)
+_OP_ALOAD_3 = 0x2D         # load arg slot 3 (used in obj-pool caller-saves)
+_OP_ALOAD = 0x19           # generic aload (uses next byte as local index)
+_OP_ASTORE_0 = 0x4B        # store ref to local 0 (used in obj-pool caller-saves)
+_OP_ASTORE_2 = 0x4D        # store ref to local 2
+_OP_ASTORE_3 = 0x4E        # store ref to local 3
+_OP_ASTORE = 0x3A          # generic astore (uses next byte as local index)
 _OP_AASTORE = 0x53
 _OP_AALOAD = 0x32
 _OP_NOP = 0x00
@@ -482,6 +488,10 @@ class _JvmClassLowerer:
         self._helper_load_word = "__ca_loadWord"
         self._helper_store_word = "__ca_storeWord"
         self._helper_syscall = "__ca_syscall"
+        # Set in ``lower()`` once we know if any heap or closure op
+        # appears.  Default False so methods that don't need obj-pool
+        # caller-saves emit the original int-only sequence.
+        self._needs_objregs = False
 
     def lower(self) -> JVMClassArtifact:
         self._validate_class_name()
@@ -508,6 +518,9 @@ class _JvmClassLowerer:
             i.opcode in _HEAP_OPCODES for i in self.program.instructions
         )
         needs_objregs = has_closures or uses_heap
+        # Stash on self so CALL emission can pick the right caller-saves
+        # discipline (int-only vs int + obj).
+        self._needs_objregs = needs_objregs
 
         fields = [
             _FieldSpec(
@@ -827,6 +840,79 @@ class _JvmClassLowerer:
             self._emit_push_int(builder, reg_idx)
             self._emit_iload(builder, reg_idx)
             builder.emit_opcode(_OP_IASTORE)
+
+    # ------------------------------------------------------------------
+    # TW03 Phase 3 follow-up — caller-saves for the obj register pool
+    # ------------------------------------------------------------------
+    #
+    # The JVM01 caller-saves above only snapshot the int register pool
+    # (``__ca_regs``).  Programs that use heap primitives or closures
+    # ALSO have an object register pool (``__ca_objregs``) holding cons
+    # cells, symbols, nil sentinels, and closure refs.  Without obj-pool
+    # caller-saves, recursion through any heap-typed register (e.g.
+    # ``length`` walking a cons list with the tail in an obj-typed reg)
+    # clobbers the caller's obj reg when the recursive call's body
+    # writes the same slot.
+    #
+    # The fix mirrors the int-pool pattern but uses JVM local slots
+    # ``reg_count..2*reg_count-1`` and the ``aload``/``astore`` +
+    # ``aaload``/``aastore`` opcode pair (verifier types these locals
+    # as ``Object`` independently of the int locals 0..reg_count-1).
+    #
+    # Like the int pool, the restore skips index 1 — the callee's
+    # return value lives in ``__ca_regs[1]`` (an int).  The obj pool
+    # has no analogous "return value" slot today; restoring all entries
+    # is correct because closure/heap calls return ints.
+
+    def _emit_caller_save_objregs(
+        self, builder: _BytecodeBuilder, reg_count: int
+    ) -> None:
+        """Snapshot ``__ca_objregs[0..reg_count-1]`` → JVM ref locals
+        ``reg_count..2*reg_count-1``."""
+        for reg_idx in range(reg_count):
+            builder.emit_u2_instruction(
+                _OP_GETSTATIC,
+                self._field_ref(self._objreg_field, _DESC_OBJECT_ARRAY),
+            )
+            self._emit_push_int(builder, reg_idx)
+            builder.emit_opcode(_OP_AALOAD)
+            self._emit_astore(builder, reg_count + reg_idx)
+
+    def _emit_caller_restore_objregs(
+        self, builder: _BytecodeBuilder, reg_count: int
+    ) -> None:
+        """Write the saved JVM ref locals back into ``__ca_objregs``.
+
+        Skips index 1 — same convention as the int-pool restore.
+        Functions that return an object reference (e.g. ``make_adder``
+        returning a closure) put the result in ``__ca_objregs[1]``,
+        and we want the caller to see the new value, not the
+        saved-pre-call one.
+        """
+        for reg_idx in range(reg_count):
+            if reg_idx == 1:
+                continue  # preserve callee's object return value
+            builder.emit_u2_instruction(
+                _OP_GETSTATIC,
+                self._field_ref(self._objreg_field, _DESC_OBJECT_ARRAY),
+            )
+            self._emit_push_int(builder, reg_idx)
+            self._emit_aload(builder, reg_count + reg_idx)
+            builder.emit_opcode(_OP_AASTORE)
+
+    def _emit_aload(self, builder: _BytecodeBuilder, index: int) -> None:
+        """Load an object reference from JVM local slot ``index``."""
+        if 0 <= index <= 3:
+            builder.emit_opcode(_OP_ALOAD_0 + index)
+        else:
+            builder.emit_u1_instruction(_OP_ALOAD, index)
+
+    def _emit_astore(self, builder: _BytecodeBuilder, index: int) -> None:
+        """Store an object reference into JVM local slot ``index``."""
+        if 0 <= index <= 3:
+            builder.emit_opcode(_OP_ASTORE_0 + index)
+        else:
+            builder.emit_u1_instruction(_OP_ASTORE, index)
 
     # ------------------------------------------------------------------
     # JVM02 Phase 2c — closure op emission (structural)
@@ -1629,15 +1715,18 @@ class _JvmClassLowerer:
         self._emit_callable_body(builder, region, reg_count)
 
         descriptor = "(" + "I" * total_arity + ")I"
+        # max_locals = total_arity (for ldarg) + caller-save snapshot
+        # storage (reg_count for int pool, +reg_count again for the obj
+        # pool when the program uses heap/closures — see
+        # _emit_caller_save_objregs).
+        snapshot_locals = (2 * reg_count) if self._needs_objregs else reg_count
         return _MethodSpec(
             access_flags=ACC_PUBLIC | ACC_STATIC,
             name=region.name,
             descriptor=descriptor,
             code=builder.assemble(),
             max_stack=16,
-            # max_locals = total_arity (for ldarg) + reg_count (for
-            # JVM01 caller-saves snapshots used inside the body).
-            max_locals=total_arity + reg_count,
+            max_locals=total_arity + snapshot_locals,
         )
 
     def _emit_jvm_iload_arg(
@@ -1689,17 +1778,18 @@ class _JvmClassLowerer:
             if region.name == self.program.entry_label
             else _ACC_PRIVATE | ACC_STATIC
         )
+        # JVM01: int-pool caller-saves uses JVM locals 0..reg_count-1.
+        # TW03 Phase 3 follow-up: obj-pool caller-saves additionally
+        # uses locals reg_count..2*reg_count-1.  Reserve the extra
+        # space only when the obj pool is actually in play.
+        max_locals = (2 * reg_count) if self._needs_objregs else reg_count
         return _MethodSpec(
             access_flags=access_flags,
             name=region.name,
             descriptor=_DESC_NOARGS_INT,
             code=code,
             max_stack=16,
-            # JVM01: caller-saves convention uses JVM locals
-            # 0..reg_count-1 as snapshot storage across CALL
-            # boundaries.  Reserve at least ``reg_count`` locals so
-            # the JVM verifier accepts the method.
-            max_locals=reg_count,
+            max_locals=max_locals,
         )
 
     def _emit_region_instructions(
@@ -1884,6 +1974,40 @@ class _JvmClassLowerer:
                     _OP_INVOKESTATIC,
                     self._method_ref(self._helper_reg_set, _DESC_INT_INT_TO_VOID),
                 )
+                # TW03 Phase 3 follow-up: ``ADD_IMM dst, src, 0`` is
+                # the canonical register-move idiom in our compilers
+                # (twig-jvm-compiler emits it for things like closure
+                # propagation: ``ADD_IMM r1, r11, 0`` to move a ref
+                # into the return slot).  Without obj-slot propagation
+                # the move only copies the int half of the register
+                # and any object reference held in the source's obj
+                # slot is lost — which broke closure-returning
+                # functions once the obj-pool caller-saves landed.
+                # Mirror the int copy on the obj pool whenever heap
+                # or closure ops are in play.  Net: the move idiom now
+                # propagates BOTH int and obj slots, making ``ADD_IMM
+                # dst, src, 0`` a true register-to-register copy.
+                if (
+                    self._needs_objregs
+                    and instruction.opcode == IrOp.ADD_IMM
+                    and imm.value == 0
+                ):
+                    builder.emit_u2_instruction(
+                        _OP_GETSTATIC,
+                        self._field_ref(
+                            self._objreg_field, _DESC_OBJECT_ARRAY,
+                        ),
+                    )
+                    self._emit_push_int(builder, dst.index)
+                    builder.emit_u2_instruction(
+                        _OP_GETSTATIC,
+                        self._field_ref(
+                            self._objreg_field, _DESC_OBJECT_ARRAY,
+                        ),
+                    )
+                    self._emit_push_int(builder, src.index)
+                    builder.emit_opcode(_OP_AALOAD)
+                    builder.emit_opcode(_OP_AASTORE)
                 continue
 
             if instruction.opcode == IrOp.NOT:
@@ -1983,6 +2107,15 @@ class _JvmClassLowerer:
                 # private to each invocation — this is what makes
                 # recursion work.
                 self._emit_caller_save_registers(builder, reg_count)
+                # TW03 Phase 3 follow-up — also snapshot the obj pool
+                # when the program uses heap primitives or closures.
+                # Without this, recursion through any obj-typed register
+                # (e.g. ``length`` walking a cons list) clobbers the
+                # caller's reference when the recursive call writes the
+                # same slot.  This is the obj-pool analogue of the JVM01
+                # caller-saves fix that unblocked int-register recursion.
+                if self._needs_objregs:
+                    self._emit_caller_save_objregs(builder, reg_count)
                 self._emit_push_int(builder, 1)
                 builder.emit_u2_instruction(
                     _OP_INVOKESTATIC,
@@ -1992,6 +2125,8 @@ class _JvmClassLowerer:
                     _OP_INVOKESTATIC,
                     self._method_ref(self._helper_reg_set, _DESC_INT_INT_TO_VOID),
                 )
+                if self._needs_objregs:
+                    self._emit_caller_restore_objregs(builder, reg_count)
                 self._emit_caller_restore_registers(builder, reg_count)
                 continue
 

--- a/code/packages/python/twig-jvm-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-jvm-compiler/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — twig-jvm-compiler
 
+## [0.4.0] — 2026-04-30 — recursive heap programs flip to passing
+
+The previously xfail-strict
+`test_heap_list_of_ints_length` now passes — the headline TW03
+Phase 3 acceptance criterion runs end-to-end on real `java`:
+
+```
+(define (length xs)
+  (if (null? xs) 0 (+ 1 (length (cdr xs)))))
+(length (cons 1 (cons 2 (cons 3 nil))))
+→ 3   (stdout = b'\x03')
+```
+
+Was unblocked by ir-to-jvm-class-file v0.11.0 — obj-pool
+caller-saves around CALL + ADD_IMM-0 obj-slot propagation.
+
+### Removed
+
+- The `xfail(strict=True)` decorator on
+  `test_heap_list_of_ints_length`.  XPASS is no longer the
+  result — it's an honest pass.
+
 ## [0.3.0] — 2026-04-30 — TW03 Phase 3e (heap primitives from Twig source)
 
 Twig source containing `cons` / `car` / `cdr` / `null?` / `pair?` /

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -195,27 +195,19 @@ def test_closure_let_bound() -> None:
 
 
 @requires_java
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "JVM Phase 3b limitation: caller-saves on CALL only cover "
-        "__ca_regs (int pool), not __ca_objregs (object pool).  "
-        "Recursive `length` re-enters the function and the object "
-        "register holding the cons ref is clobbered before the "
-        "recursive call returns.  Will auto-flip to passing once a "
-        "follow-up extends caller-saves to the obj pool — same "
-        "shape as the JVM01 fix that unblocked recursion through "
-        "int registers."
-    ),
-)
 def test_heap_list_of_ints_length() -> None:
     """``(length (cons 1 (cons 2 (cons 3 nil)))) → 3``.
 
-    The headline TW03 Phase 3 acceptance criterion.  Currently
-    xfail because of the obj-pool caller-saves limitation noted
-    above; the simpler non-recursive heap test
-    (`test_heap_car_of_singleton_returns_int`) does pass and
-    proves the ir-emit path works."""
+    The headline TW03 Phase 3 acceptance criterion — Twig source
+    with cons / cdr / null? + a recursive define compiles to a
+    multi-class JAR and runs end-to-end on real ``java``,
+    producing stdout = ``b'\\x03'``.
+
+    Was xfail-strict in JVM Phase 3b because the obj-pool
+    caller-saves were missing (recursion clobbered the cons ref
+    in the obj register).  Now passes after the obj-pool
+    caller-saves landed (mirrors the JVM01 fix that unblocked
+    recursion through int registers)."""
     src = """
         (define (length xs)
           (if (null? xs) 0 (+ 1 (length (cdr xs)))))


### PR DESCRIPTION
## Summary

Closes the obj-pool gap left by JVM Phase 3b. Recursive heap programs now run end-to-end on real \`java\`:

\`\`\`scheme
(define (length xs)
  (if (null? xs) 0 (+ 1 (length (cdr xs)))))
(length (cons 1 (cons 2 (cons 3 nil))))
→ 3
\`\`\`

Was xfail-strict in twig-jvm-compiler v0.3.0. **Now an honest pass** — the JVM joins BEAM in passing the headline TW03 Phase 3 acceptance criterion end-to-end.

## Two related fixes in ir-to-jvm-class-file

### 1. Obj-pool caller-saves around CALL

The JVM01 caller-saves snapshot \`__ca_regs\` (int pool) before each CALL. The obj pool (\`__ca_objregs\` — cons cells, symbols, nil sentinels, closure refs) was uncovered. Recursion through any obj-typed register clobbered the caller's reference.

\`_emit_caller_save_objregs\` snapshots \`__ca_objregs[0..N-1]\` into JVM ref locals \`N..2N-1\`; \`_emit_caller_restore_objregs\` writes them back, skipping index 1 (closure-returning functions put their result in \`__ca_objregs[1]\`). Triggered only when \`_needs_objregs\` is True.

### 2. \`ADD_IMM dst, src, 0\` (move idiom) propagates obj slot

Pre-fix the move idiom only copied the int half of the register, so any object reference in the source's obj slot was lost. This worked **by accident** pre-3b (\`make_adder\` happened to write its closure to a holding reg whose index matched the one \`_start\` then read). Once obj-pool caller-saves landed, the accident broke.

Fix: when \`_needs_objregs\` is True and the immediate is 0, also emit \`__ca_objregs[dst] = __ca_objregs[src]\` after the int copy.

## Test plan

- [x] All 113 ir-to-jvm-class-file tests pass (93% coverage)
- [x] All 46 twig-jvm-compiler tests pass — no more xfails, 91% coverage
- [x] Removed the \`xfail(strict=True)\` decorator on \`test_heap_list_of_ints_length\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)