### PR TITLE
Add ALGOL real exponentiation via math import

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to this package will be documented in this file.
 - Lowered Phase 7b direct nonlocal block `goto` statements by unwinding exited
   block frames before jumping to the outer ALGOL label.
 - Lowered chained assignments, branch-selected conditional expressions, and
-  ALGOL-left-associative exponentiation for numeric bases with integer
+  ALGOL-left-associative exponentiation for numeric bases with integer or real
   exponents.
 - Lowered bare no-argument typed procedure names as expression calls, including
   use inside read-only by-name eval thunks.
@@ -92,6 +92,9 @@ All notable changes to this package will be documented in this file.
 - Lowered standard real builtin functions `sin`, `cos`, `arctan`, `ln`, and
   `exp` to integer-to-real promotion and the corresponding imported f64 math
   IR opcodes, with nonpositive `ln` guarded by the runtime-failure path.
+- Lowered real exponentiation to integer-to-real promotion and the imported
+  `F64_POW` IR opcode, with NaN results routed through the runtime-failure
+  path.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -31,10 +31,10 @@ ALGOL block lifetime instead of leaking through loops or recursive calls.
 
 Expression lowering includes mixed integer/real arithmetic, boolean operators,
 comparisons, chained assignment targets, branch-selected conditional
-expressions, and ALGOL-left-associative exponentiation when the exponent is an
-integer. Real bases with negative integer exponents are lowered through a
-reciprocal path; arbitrary real exponents remain outside this phase until the
-runtime has a real `pow` implementation instead of an approximation shortcut.
+expressions, and ALGOL-left-associative exponentiation. Integer exponents use
+the existing loop lowering, real bases with negative integer exponents use a
+reciprocal path, and real exponents lower through the imported real `pow`
+runtime with a domain-failure guard.
 Standard numeric functions `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`,
 `arctan`, `ln`, and `exp` lower to existing integer/f64 comparison,
 arithmetic, conversion, native square-root IR, and imported standard real-math

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -2398,11 +2398,19 @@ class AlgolIrCompiler:
                     f"numeric operator {operator.value!r} is not supported"
                 )
             exponent_type = self._expr_type(children[index + 1])
-            if exponent_type != _INTEGER_TYPE:
-                raise CompileError("exponentiation exponent must be integer")
-            current = self._emit_power(current, current_type, exponent, scope)
+            if exponent_type not in {_INTEGER_TYPE, _REAL_TYPE}:
+                raise CompileError("exponentiation exponent must be numeric")
+            current = self._emit_power(
+                current,
+                current_type,
+                exponent,
+                exponent_type,
+                scope,
+            )
             current_type = (
-                _REAL_TYPE if current_type == _REAL_TYPE else _INTEGER_TYPE
+                _REAL_TYPE
+                if _REAL_TYPE in {current_type, exponent_type}
+                else _INTEGER_TYPE
             )
             index += 2
         return current
@@ -2699,11 +2707,47 @@ class AlgolIrCompiler:
         self._emit_runtime_failure_guard(failed, scope)
 
     def _emit_power(
-        self, base: int, base_type: str, exponent: int, scope: _FrameScope
+        self,
+        base: int,
+        base_type: str,
+        exponent: int,
+        exponent_type: str,
+        scope: _FrameScope,
     ) -> int:
+        if exponent_type == _REAL_TYPE:
+            return self._emit_real_power(base, base_type, exponent, scope)
         if base_type == _REAL_TYPE:
             return self._emit_real_integer_power(base, exponent, scope)
         return self._emit_integer_power(base, exponent)
+
+    def _emit_real_power(
+        self,
+        base: int,
+        base_type: str,
+        exponent: int,
+        scope: _FrameScope,
+    ) -> int:
+        base = self._coerce_reg_to_type(
+            base,
+            base_type,
+            expected_type=_REAL_TYPE,
+        )
+        result = self._fresh_reg()
+        self._emit(
+            IrOp.F64_POW,
+            IrRegister(result),
+            IrRegister(base),
+            IrRegister(exponent),
+        )
+        failed = self._fresh_reg()
+        self._emit(
+            IrOp.F64_CMP_NE,
+            IrRegister(failed),
+            IrRegister(result),
+            IrRegister(result),
+        )
+        self._emit_runtime_failure_guard(failed, scope)
+        return result
 
     def _emit_integer_power(self, base: int, exponent: int) -> int:
         index = self.if_count

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1430,6 +1430,15 @@ class TestAlgolIrCompiler:
             for instruction in result.program.instructions
         )
 
+    def test_compiles_real_exponentiation_to_pow_import(self) -> None:
+        result = compile_algol(
+            parse_algol("begin real x; x := 9.0 ** 0.5 end")
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.F64_POW in opcodes
+        assert IrOp.F64_CMP_NE in opcodes
+
     def test_compiles_chained_assignment_right_to_left(self) -> None:
         result = compile_algol(
             parse_algol("begin integer result, other; result := other := 1 end")

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this package will be documented in this file.
   procedure/function, while keeping procedure-crossing jumps and nonlocal
   designational branches guarded.
 - Added semantic checking for chained assignments, ALGOL conditional
-  expressions, and numeric exponentiation with integer exponents.
+  expressions, and numeric exponentiation with integer or real exponents.
 - Added semantic resolution for bare no-argument typed procedure names used as
   expressions, while keeping written by-name actuals from treating those calls
   as assignable scalar storage.

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -15,7 +15,8 @@ designational `goto` forms are also supported.
 
 The expression checker also accepts chained assignments, ALGOL conditional
 expressions, tolerant trailing/repeated semicolons from the parser, and
-left-associative exponentiation for numeric bases with integer exponents.
+left-associative exponentiation for numeric bases with integer or real
+exponents.
 Mixed integer/real conditional branches resolve to `real`; incompatible branch
 types are still rejected before IR lowering. Standard numeric functions
 `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`, `arctan`, `ln`, and `exp` are

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -2898,10 +2898,15 @@ class AlgolTypeChecker:
                     f"numeric operator {operator.value!r} is not supported",
                 )
                 return ERROR
-            if exponent_type != INTEGER:
-                self._error(node, "exponentiation exponent must be integer")
+            if not _is_numeric_type(exponent_type):
+                self._error(
+                    node,
+                    f"operator requires numeric operand, got {exponent_type}",
+                )
                 return ERROR
-            current_type = REAL if current_type == REAL else INTEGER
+            current_type = (
+                REAL if REAL in {current_type, exponent_type} else INTEGER
+            )
             index += 2
         return current_type
 

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -366,6 +366,11 @@ class TestAlgolTypeChecker:
         result = check_algol(ast)
         assert result.ok
 
+    def test_accepts_real_exponentiation(self) -> None:
+        ast = parse_algol("begin integer result; real x; x := 4.0 ** 0.5 end")
+        result = check_algol(ast)
+        assert result.ok
+
     def test_accepts_standard_numeric_builtin_functions(self) -> None:
         ast = parse_algol(
             "begin integer result; real x, root; "
@@ -401,12 +406,12 @@ class TestAlgolTypeChecker:
             result.diagnostics[0].message
         )
 
-    def test_rejects_real_exponent_for_exponentiation(self) -> None:
-        ast = parse_algol("begin real result; result := 2.0 ** 3.5 end")
+    def test_rejects_non_numeric_exponent_for_exponentiation(self) -> None:
+        ast = parse_algol("begin real result; result := 2.0 ** false end")
         result = check_algol(ast)
         assert not result.ok
         assert (
-            "exponentiation exponent must be integer"
+            "operator requires numeric operand, got boolean"
             in result.diagnostics[0].message
         )
 

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -41,8 +41,8 @@ All notable changes to this package will be documented in this file.
 - Executed Phase 7b direct nonlocal block `goto` statements through the WASM
   path with frame restoration before later block entry.
 - Executed chained assignments, ALGOL-left-associative exponentiation with
-  integer exponents, and branch-selected conditional expressions through the
-  full WASM path.
+  integer or real exponents, and branch-selected conditional expressions
+  through the full WASM path.
 - Executed bare no-argument typed procedure names as expression calls,
   including by-name actuals that re-evaluate through eval thunks.
 - Accepted trailing and repeated semicolons in ALGOL block and compound
@@ -87,8 +87,10 @@ All notable changes to this package will be documented in this file.
   `exp` through the full parser, type-checker, IR, and WASM pipeline using the
   `compiler_math` host import ABI, with nonpositive `ln` arguments returning
   `0` through the ALGOL runtime failure path.
-- Added a standard-real-math golden fixture covering imported real math and
-  output in one end-to-end program.
+- Executed real exponentiation through the `compiler_math` `f64_pow` import,
+  including integer-base promotion and domain failures returning `0`.
+- Added a standard-real-math golden fixture covering imported real math,
+  real exponentiation, and output in one end-to-end program.
 - Added a convergence golden fixture that combines conditional expressions,
   exponentiation, chained assignment, by-name array summation, real arithmetic,
   and output in one end-to-end program.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -20,7 +20,7 @@ the current lane already supports a substantial ALGOL 60 surface:
   bounds and checked element access
 - chained assignment, conditional expressions, tolerant trailing/repeated
   semicolons, numeric runtime failure guards, and
-  ALGOL-left-associative exponentiation for integer exponents
+  ALGOL-left-associative exponentiation for integer or real exponents
 - standard numeric functions `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`,
   `arctan`, `ln`, and `exp`; non-native real math is imported through the
   runtime's `compiler_math` host ABI
@@ -62,10 +62,10 @@ assert WasmRuntime().load_and_run(with_array.binary, "_start", []) == [9]
 
 with_math = compile_source(
     "begin integer result; real x; "
-    "x := sin(0) + cos(0) + arctan(1) + ln(exp(1)); "
+    "x := sin(0) + cos(0) + arctan(1) + ln(exp(1)) + 4 ^ 0.5; "
     "result := entier(x * 100) end"
 )
-assert WasmRuntime(host=WasiHost()).load_and_run(with_math.binary, "_start", []) == [278]
+assert WasmRuntime(host=WasiHost()).load_and_run(with_math.binary, "_start", []) == [478]
 
 showcase = compile_source(
     "begin own integer counter; integer array a[1:3]; real average; "

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/standard-real-math.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/standard-real-math.alg
@@ -4,7 +4,7 @@ begin
   string msg;
 
   msg := 'MATH';
-  metric := sin(0) + cos(0) + arctan(1) + ln(exp(1));
+  metric := sin(0) + cos(0) + arctan(1) + ln(exp(1)) + 4 ^ 0.5;
   result := entier(metric * 100);
   print(msg); output(' '); print(result);
 end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -101,6 +101,28 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
+    def test_real_exponentiation_runs_through_pow_import(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := 9.0 ^ 0.5; "
+            "result := entier(x * 10) "
+            "end"
+        )
+        assert WasmRuntime(host=WasiHost()).load_and_run(
+            result.binary, "_start", []
+        ) == [30]
+
+    def test_integer_base_real_exponentiation_promotes_to_real(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := 4 ^ 0.5; "
+            "result := entier(x * 10) "
+            "end"
+        )
+        assert WasmRuntime(host=WasiHost()).load_and_run(
+            result.binary, "_start", []
+        ) == [20]
+
     def test_conditional_expression_assigns_selected_branch(self) -> None:
         result = compile_source(
             "begin integer result; result := if false then 1 else 7 end"
@@ -1667,6 +1689,16 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_real_pow_domain_error_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := (0.0 - 1.0) ^ 0.5; result := 7 "
+            "end"
+        )
+        assert WasmRuntime(host=WasiHost()).load_and_run(
+            result.binary, "_start", []
+        ) == [0]
 
     def test_array_failure_in_procedure_unwinds_before_caller_continues(self) -> None:
         result = compile_source(

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -26,7 +26,7 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="jensens-device", result=[30], stdout=""),
     GoldenFixture(name="control-flow", result=[7], stdout="FLOW 7"),
     GoldenFixture(name="convergence", result=[39], stdout="CONVERGE 39"),
-    GoldenFixture(name="standard-real-math", result=[278], stdout="MATH 278"),
+    GoldenFixture(name="standard-real-math", result=[478], stdout="MATH 478"),
 )
 
 

--- a/code/packages/python/compiler-ir/CHANGELOG.md
+++ b/code/packages/python/compiler-ir/CHANGELOG.md
@@ -36,6 +36,8 @@ older serialized IR text round-trips unchanged.
   **`IrOp.F64_ATAN` (52)**, **`IrOp.F64_LN` (53)**, and
   **`IrOp.F64_EXP` (54)** — unary 64-bit floating standard math operations
   for frontends with real numeric libraries.
+- **`IrOp.F64_POW` (63)** — binary 64-bit floating power operation
+  (`dst = pow(base, exponent)`) for frontends with real exponentiation.
 
 ## [0.4.0] — 2026-04-29
 

--- a/code/packages/python/compiler-ir/README.md
+++ b/code/packages/python/compiler-ir/README.md
@@ -8,7 +8,7 @@ This package provides the IR data structures used by the AOT native compiler pip
 
 - **Opcodes** (`IrOp`) — stable integer opcodes covering constants, memory,
   arithmetic, bitwise logic, 64-bit floating operations including standard
-  unary real math, comparison, control flow, system calls, and meta
+  real math, comparison, control flow, system calls, and meta
   instructions
 - **Operand types** — `IrRegister` (v0, v1, ...), `IrImmediate` (literal integers), `IrLabel` (named jump targets)
 - **Instruction** (`IrInstruction`) — opcode + operands + unique ID for source mapping

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -26,7 +26,7 @@ The opcodes are grouped by category:
   Comparison:   CMP_EQ, CMP_NE, CMP_LT, CMP_GT
   Floating:     LOAD_F64_IMM, LOAD_F64, STORE_F64, F64_ADD, ..., F64_FROM_I32,
                 I32_TRUNC_FROM_F64, F64_SQRT, F64_SIN, F64_COS, F64_ATAN,
-                F64_LN, F64_EXP
+                F64_LN, F64_EXP, F64_POW
   Control Flow: LABEL, JUMP, BRANCH_Z, BRANCH_NZ, CALL, RET
   System:       SYSCALL, HALT
   Meta:         NOP, COMMENT
@@ -404,6 +404,11 @@ class IrOp(IntEnum):
     #   Store the nil value into ``dst``.  Used to terminate cons-cell
     #   chains and as the canonical "false" / "empty-list" sentinel.
     LOAD_NIL = 62
+
+    # Binary real power for frontends that need a language-level math runtime.
+    # Appended after TW03 heap opcodes to preserve stable opcode values.
+    #   F64_POW v1, v2, v3 → v1 = pow(v2, v3)
+    F64_POW = 63
 
 
 # Canonical name → opcode mapping. Built from the enum at module load time.

--- a/code/packages/python/compiler-ir/tests/test_compiler_ir.py
+++ b/code/packages/python/compiler-ir/tests/test_compiler_ir.py
@@ -113,12 +113,11 @@ class TestIrOp:
         assert IrOp.MAKE_SYMBOL == 60
         assert IrOp.IS_SYMBOL == 61
         assert IrOp.LOAD_NIL == 62
+        assert IrOp.F64_POW == 63
 
     def test_total_opcode_count(self) -> None:
-        """There are exactly 63 opcodes after adding TW03 Phase 3 heap
-        primitives (cons / car / cdr / is_null / is_pair / make_symbol /
-        is_symbol / load_nil)."""
-        assert len(IrOp) == 63
+        """There are exactly 64 opcodes after heap primitives and f64 pow."""
+        assert len(IrOp) == 64
 
     def test_name_to_op_roundtrip(self) -> None:
         """NAME_TO_OP[op.name] == op for every opcode."""
@@ -1030,6 +1029,7 @@ class TestAllOpcodesPrintParse:
             IrOp.F64_ATAN:     [IrRegister(2), IrRegister(1)],
             IrOp.F64_LN:       [IrRegister(2), IrRegister(1)],
             IrOp.F64_EXP:      [IrRegister(2), IrRegister(1)],
+            IrOp.F64_POW:      [IrRegister(3), IrRegister(1), IrRegister(2)],
             # MAKE_CLOSURE dst, fn_label, num_captured, capt0, capt1
             IrOp.MAKE_CLOSURE: [
                 IrRegister(0),

--- a/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/ir-to-wasm-compiler/CHANGELOG.md
@@ -40,6 +40,8 @@ round-trip, export check.
 - Lowered `IrOp.F64_SIN`, `IrOp.F64_COS`, `IrOp.F64_ATAN`, `IrOp.F64_LN`,
   and `IrOp.F64_EXP` through typed `compiler_math` host imports and inferred
   their destination registers as `f64`.
+- Lowered `IrOp.F64_POW` through the typed binary `compiler_math.f64_pow`
+  host import and inferred its destination register as `f64`.
 - **Oct 8-bit arithmetic e2e tests** (`tests/test_oct_8bit_e2e.py`):
   7 end-to-end tests confirming the WASM backend correctly compiles and
   executes 8-bit integer arithmetic IR — the same IR that the Oct compiler

--- a/code/packages/python/ir-to-wasm-compiler/README.md
+++ b/code/packages/python/ir-to-wasm-compiler/README.md
@@ -32,4 +32,4 @@ integer results are copied into `v1`, while real results are copied into `v31`.
 The f64 lowering path includes arithmetic, comparisons, integer conversion,
 truncation, unary square root via WASM `f64.sqrt`, and standard unary real
 math through typed `compiler_math` imports (`f64_sin`, `f64_cos`, `f64_atan`,
-`f64_ln`, `f64_exp`).
+`f64_ln`, `f64_exp`, `f64_pow`).

--- a/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/src/ir_to_wasm_compiler/compiler.py
@@ -56,6 +56,14 @@ _F64_UNARY_MATH_IMPORT_NAMES: dict[IrOp, str] = {
     IrOp.F64_EXP: "f64_exp",
 }
 _F64_UNARY_MATH_OPS = frozenset(_F64_UNARY_MATH_IMPORT_NAMES)
+_F64_BINARY_MATH_IMPORT_NAMES: dict[IrOp, str] = {
+    IrOp.F64_POW: "f64_pow",
+}
+_F64_BINARY_MATH_OPS = frozenset(_F64_BINARY_MATH_IMPORT_NAMES)
+_F64_MATH_IMPORT_NAMES = {
+    **_F64_UNARY_MATH_IMPORT_NAMES,
+    **_F64_BINARY_MATH_IMPORT_NAMES,
+}
 
 _MEMORY_OPS = frozenset(
     {
@@ -168,6 +176,7 @@ _WASM_SUPPORTED_OPCODES: frozenset[IrOp] = frozenset({
     IrOp.F64_ATAN,
     IrOp.F64_LN,
     IrOp.F64_EXP,
+    IrOp.F64_POW,
     IrOp.F64_CMP_EQ,
     IrOp.F64_CMP_NE,
     IrOp.F64_CMP_LT,
@@ -328,6 +337,17 @@ class _ImportContext:
     syscall_function_indices: dict[int, int]
     math_function_indices: dict[IrOp, int]
     scratch_base: int | None
+
+
+def _compiler_math_func_type(opcode: IrOp) -> FuncType:
+    if opcode in _F64_UNARY_MATH_OPS:
+        return FuncType(params=(ValueType.F64,), results=(ValueType.F64,))
+    if opcode in _F64_BINARY_MATH_OPS:
+        return FuncType(
+            params=(ValueType.F64, ValueType.F64),
+            results=(ValueType.F64,),
+        )
+    raise WasmLoweringError(f"unsupported compiler math opcode: {opcode.name}")
 
 
 class IrToWasmCompiler:
@@ -492,7 +512,7 @@ class IrToWasmCompiler:
                 required_syscalls.add(
                     _expect_immediate(instruction.operands[0], "SYSCALL number").value
                 )
-            elif instruction.opcode in _F64_UNARY_MATH_OPS:
+            elif instruction.opcode in _F64_MATH_IMPORT_NAMES:
                 required_math_ops.add(instruction.opcode)
 
         ordered_imports = (
@@ -536,12 +556,11 @@ class IrToWasmCompiler:
         imports = [
             imp for imp in ordered_imports if imp.syscall_number in required_syscalls
         ]
-        math_type = FuncType(params=(ValueType.F64,), results=(ValueType.F64,))
         imports.extend(
             _FunctionImport(
                 module_name=_COMPILER_MATH_MODULE,
-                name=_F64_UNARY_MATH_IMPORT_NAMES[opcode],
-                func_type=math_type,
+                name=_F64_MATH_IMPORT_NAMES[opcode],
+                func_type=_compiler_math_func_type(opcode),
                 math_opcode=opcode,
             )
             for opcode in sorted(required_math_ops, key=int)
@@ -872,6 +891,8 @@ class _FunctionLowerer:
                 | IrOp.F64_EXP
             ):
                 self._emit_f64_unary_math_call(instruction)
+            case IrOp.F64_POW:
+                self._emit_f64_binary_math_call(instruction)
             case IrOp.CMP_EQ:
                 self._emit_binary_numeric("i32.eq", instruction)
             case IrOp.CMP_NE:
@@ -1075,6 +1096,30 @@ class _FunctionLowerer:
                 f"missing compiler math import for {name}"
             )
         self._emit_local_get(src.index)
+        self._emit_opcode("call")
+        self._emit_u32(function_index)
+        self._emit_local_set(dst.index)
+
+    def _emit_f64_binary_math_call(self, instruction: IrInstruction) -> None:
+        dst = _expect_register(
+            instruction.operands[0], f"{instruction.opcode.name} dst"
+        )
+        lhs = _expect_register(
+            instruction.operands[1], f"{instruction.opcode.name} lhs"
+        )
+        rhs = _expect_register(
+            instruction.operands[2], f"{instruction.opcode.name} rhs"
+        )
+        function_index = self.import_context.math_function_indices.get(
+            instruction.opcode
+        )
+        if function_index is None:
+            name = _F64_MATH_IMPORT_NAMES[instruction.opcode]
+            raise WasmLoweringError(
+                f"missing compiler math import for {name}"
+            )
+        self._emit_local_get(lhs.index)
+        self._emit_local_get(rhs.index)
         self._emit_opcode("call")
         self._emit_u32(function_index)
         self._emit_local_set(dst.index)
@@ -1576,6 +1621,7 @@ def _infer_register_types(
                 | IrOp.F64_ATAN
                 | IrOp.F64_LN
                 | IrOp.F64_EXP
+                | IrOp.F64_POW
                 | IrOp.F64_FROM_I32
             ):
                 dst = _expect_register(instruction.operands[0], f"{instruction.opcode.name} dst")

--- a/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
+++ b/code/packages/python/ir-to-wasm-compiler/tests/test_ir_to_wasm_compiler.py
@@ -419,6 +419,41 @@ def test_compile_f64_unary_math_imports(
     assert result == pytest.approx([expected])
 
 
+def test_compile_f64_pow_import() -> None:
+    gen = IDGenerator()
+    program = IrProgram(entry_label="_fn_real_pow")
+    program.add_instruction(
+        IrInstruction(IrOp.LABEL, [IrLabel("_fn_real_pow")], id=-1)
+    )
+    program.add_instruction(
+        IrInstruction(
+            IrOp.F64_POW,
+            [IrRegister(31), IrRegister(2), IrRegister(3)],
+            id=gen.next(),
+        )
+    )
+    program.add_instruction(IrInstruction(IrOp.RET, [], id=gen.next()))
+
+    module = IrToWasmCompiler().compile(
+        program,
+        function_signatures=[
+            FunctionSignature(
+                label="_fn_real_pow",
+                param_count=2,
+                export_name="real_pow",
+                param_types=(ValueType.F64, ValueType.F64),
+                result_types=(ValueType.F64,),
+            )
+        ],
+    )
+
+    assert [(imp.module_name, imp.name) for imp in module.imports] == [
+        ("compiler_math", "f64_pow")
+    ]
+    result = _runtime_result(module, "real_pow", [9.0, 0.5], host=WasiHost())
+    assert result == pytest.approx([3.0])
+
+
 def test_compile_function_call_and_run_it() -> None:
     gen = IDGenerator()
     program = IrProgram(entry_label="_start")

--- a/code/packages/python/wasm-runtime/CHANGELOG.md
+++ b/code/packages/python/wasm-runtime/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this package will be documented in this file.
 - All new classes exported from `wasm_runtime.__init__`
 - 32 new tests in `tests/test_wasi_tier3.py` covering happy paths, edge cases, no-memory guards, and the `clock_time_get` EINVAL path
 - **`compiler_math` host imports** — `WasiHost` now resolves `f64_sin`,
-  `f64_cos`, `f64_atan`, `f64_ln`, and `f64_exp` for generic compiler
+  `f64_cos`, `f64_atan`, `f64_ln`, `f64_exp`, and `f64_pow` for generic compiler
   pipeline modules that need non-core WASM real math.
 
 ### Changed

--- a/code/packages/python/wasm-runtime/README.md
+++ b/code/packages/python/wasm-runtime/README.md
@@ -87,8 +87,8 @@ host = WasiHost(WasiConfig(clock=FakeClock()))
 ### Compiler math imports
 
 `WasiHost` also resolves the generic compiler pipeline's `compiler_math`
-imports for standard unary f64 math: `f64_sin`, `f64_cos`, `f64_atan`,
-`f64_ln`, and `f64_exp`. These imports are intentionally separate from WASI
+imports for standard f64 math: `f64_sin`, `f64_cos`, `f64_atan`, `f64_ln`,
+`f64_exp`, and `f64_pow`. These imports are intentionally separate from WASI
 so generated modules declare the non-core WASM math surface they need.
 
 ## WASI functions implemented

--- a/code/packages/python/wasm-runtime/src/wasm_runtime/wasi_host.py
+++ b/code/packages/python/wasm-runtime/src/wasm_runtime/wasi_host.py
@@ -27,7 +27,7 @@ can talk to the outside world through imported WASI functions.
 
 Compiler math imports
 ─────────────────────
-The generic compiler pipeline may also import unary f64 math helpers from
+The generic compiler pipeline may also import f64 math helpers from
 ``compiler_math``. These are intentionally separate from WASI so generated
 modules have a small, explicit ABI for non-core WASM math operations.
 
@@ -79,6 +79,16 @@ _COMPILER_MATH_UNARY_F64: dict[str, Callable[[float], float]] = {
     "f64_ln": math.log,
     "f64_exp": math.exp,
 }
+_COMPILER_MATH_BINARY_F64: dict[str, Callable[[float, float], float]] = {
+    "f64_pow": math.pow,
+}
+
+
+def _math_result(fn: Callable[..., float], *args: float) -> WasmValue:
+    try:
+        return f64(fn(*args))
+    except (OverflowError, ValueError):
+        return f64(math.nan)
 
 
 # ---------------------------------------------------------------------------
@@ -335,17 +345,38 @@ class WasiHost:
         return self._make_stub(name)
 
     def _make_compiler_math(self, name: str) -> _HostFunc | None:
-        fn = _COMPILER_MATH_UNARY_F64.get(name)
-        if fn is None:
-            return None
+        unary_fn = _COMPILER_MATH_UNARY_F64.get(name)
+        if unary_fn is not None:
 
-        def unary_f64_impl(args: list[WasmValue]) -> list[WasmValue]:
-            return [f64(fn(float(args[0].value)))]
+            def unary_f64_impl(args: list[WasmValue]) -> list[WasmValue]:
+                return [_math_result(unary_fn, float(args[0].value))]
 
-        return _HostFunc(
-            FuncType(params=(ValueType.F64,), results=(ValueType.F64,)),
-            unary_f64_impl,
-        )
+            return _HostFunc(
+                FuncType(params=(ValueType.F64,), results=(ValueType.F64,)),
+                unary_f64_impl,
+            )
+
+        binary_fn = _COMPILER_MATH_BINARY_F64.get(name)
+        if binary_fn is not None:
+
+            def binary_f64_impl(args: list[WasmValue]) -> list[WasmValue]:
+                return [
+                    _math_result(
+                        binary_fn,
+                        float(args[0].value),
+                        float(args[1].value),
+                    )
+                ]
+
+            return _HostFunc(
+                FuncType(
+                    params=(ValueType.F64, ValueType.F64),
+                    results=(ValueType.F64,),
+                ),
+                binary_f64_impl,
+            )
+
+        return None
 
     def resolve_global(self, _module_name: str, _name: str) -> Any | None:  # noqa: ANN401
         return None

--- a/code/packages/python/wasm-runtime/tests/test_wasi.py
+++ b/code/packages/python/wasm-runtime/tests/test_wasi.py
@@ -6,11 +6,21 @@ resolve_function for known/unknown functions, resolve_global/memory/table.
 
 from __future__ import annotations
 
+import math
+from collections.abc import Callable
+
 import pytest
+from wasm_execution import LinearMemory, f64, i32
 
-from wasm_execution import LinearMemory, i32
-from wasm_runtime.wasi_host import EBADF, ENOSYS, ESUCCESS, ProcExitError, WasiConfig, WasiHost, _HostFunc
-
+from wasm_runtime.wasi_host import (
+    EBADF,
+    ENOSYS,
+    ESUCCESS,
+    ProcExitError,
+    WasiConfig,
+    WasiHost,
+    _HostFunc,
+)
 
 # ===========================================================================
 # ProcExitError
@@ -61,6 +71,22 @@ class TestWasiHostResolve:
         host = WasiHost()
         func = host.resolve_function("some_other_module", "fd_write")
         assert func is None
+
+    def test_resolve_compiler_math_pow(self) -> None:
+        host = WasiHost()
+        func = host.resolve_function("compiler_math", "f64_pow")
+        assert func is not None
+
+        result = func.call([f64(9.0), f64(0.5)])
+        assert result[0].value == pytest.approx(3.0)
+
+    def test_compiler_math_domain_error_returns_nan(self) -> None:
+        host = WasiHost()
+        func = host.resolve_function("compiler_math", "f64_pow")
+        assert func is not None
+
+        result = func.call([f64(-1.0), f64(0.5)])
+        assert math.isnan(result[0].value)
 
     def test_resolve_global_returns_none(self) -> None:
         host = WasiHost()
@@ -127,7 +153,7 @@ class TestFdWrite:
 class TestFdRead:
     def _setup_memory_with_read_iovec(
         self,
-        reader,
+        reader: Callable[[int], bytes],
     ) -> tuple[WasiHost, LinearMemory]:
         host = WasiHost(config=WasiConfig(stdin=reader))
         mem = LinearMemory(1)


### PR DESCRIPTION
## Summary
- add IrOp.F64_POW and lower it to compiler_math.f64_pow
- extend the WASM runtime compiler_math ABI with binary real pow
- allow ALGOL real exponents and guard NaN pow results through the runtime-failure path
- add end-to-end ALGOL WASM coverage and update the standard real math fixture

## Tests
- compiler-ir + ir-to-wasm pytest: 163 passed
- algol-type-checker pytest: 128 passed
- algol-ir-compiler pytest: 97 passed
- wasm-runtime pytest: 73 passed
- algol-wasm compiler + fixtures pytest: 166 passed
- scoped ruff check: passed
- git diff --check origin/main: passed
- security review: no new risky subprocess/shell/network/file-write/deserialization/secret patterns found