### PR TITLE
Handle trailing solidus on HTML end tags

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -6458,6 +6458,12 @@ actions = ["emit_current_token"]
 
 [[transitions]]
 from = "end_tag_name"
+matcher = { literal = "/" }
+to = "before_end_tag_close"
+actions = ["parse_error(end-tag-with-trailing-solidus)"]
+
+[[transitions]]
+from = "end_tag_name"
 matcher = { eof = true }
 to = "done"
 consume = false

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -13473,6 +13473,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "end_tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("/".to_string())),
+            to: vec![
+                "before_end_tag_close".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(end-tag-with-trailing-solidus)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "end_tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
                 "done".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -762,6 +762,30 @@ fn default_html_lexer_recovers_invalid_end_tag_open_as_bogus_comment() {
 }
 
 #[test]
+fn default_html_lexer_recovers_end_tag_with_trailing_solidus() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before</p/>After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "end-tag-with-trailing-solidus"));
+}
+
+#[test]
 fn default_html_lexer_recovers_abrupt_empty_html_comment() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- route `/` in the HTML end tag name state through end-tag close recovery instead of appending it to the tag name
- report `end-tag-with-trailing-solidus` for inputs like `</p/>`
- regenerate the Rust HTML1 lexer table and add a regression test

## Verification
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml html1_toml_compiles_to_rust_source`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml`