### PR TITLE
fix(jvm): mutual recursion + let-bound closure used twice

### DIFF
--- a/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
@@ -1,5 +1,49 @@
 # ir-to-jvm-class-file
 
+## 0.12.0 — 2026-04-30 — gate ADD_IMM-0 obj propagation on per-region typing
+
+Fixes a memory-safety class of bug in the previous obj-pool work:
+the unconditional ADD_IMM-0 obj-slot copy was clobbering caller's
+`__ca_objregs` slots when an int-typed source got moved.
+
+### Bug
+
+JVM uses a SHARED static `__ca_objregs` array.  v0.11.0's
+ADD_IMM-0 obj propagation copied `__ca_objregs[src] →
+__ca_objregs[dst]` whenever `_needs_objregs` was True and the
+immediate was 0 — regardless of whether the source was actually
+obj-typed in that region.
+
+Concrete failure: `(let ((add5 (mk-adder 5))) (+ (add5 10) (add5 27)))`.
+Inside the lifted lambda body: `ADD_IMM v11, v3, 0` (v3 is the
+explicit int arg).  Pre-fix this wrote `__ca_objregs[3] (= null)`
+into `__ca_objregs[11]`, clobbering the closure ref the CALLER
+had stored there.  Second `(add5 27)` then NPE'd reading
+`__ca_objregs[11]`.
+
+### Fix — `_collect_region_obj_regs`
+
+New per-region analysis (mirrors the CLR backend's typed-pool
+approach, just adapted to JVM's static layout).  Computes the
+set of registers each region uses obj-style by:
+
+* **Writes** producing object refs (MAKE_CLOSURE, MAKE_CONS,
+  MAKE_SYMBOL, LOAD_NIL, CDR).
+* **Reads** consuming object operands (CAR/CDR/IS_*/MAKE_CONS-tail/
+  APPLY_CLOSURE-closure_reg).
+* **Back-prop** through ADD_IMM-0 to a fixed point.
+
+ADD_IMM-0 obj propagation now fires only when SRC is in the
+region's obj_regs set — int-typed sources stop polluting the
+shared obj pool.
+
+### Tests
+
+All 113 ir-to-jvm-class-file tests pass; coverage 92%.  No new
+test cases — the fix's correctness is validated by the
+twig-jvm-compiler tests for closure / heap / mutual-recursion
+patterns that exercise the cross-region obj flow.
+
 ## 0.11.0 — 2026-04-30 — obj-pool caller-saves + ADD_IMM-0 obj propagation
 
 Closes the obj-pool gap left by JVM Phase 3b.  Recursive heap

--- a/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
@@ -1,5 +1,26 @@
 # ir-to-jvm-class-file
 
+## 0.13.0 — 2026-04-30 — APPLY_CLOSURE obj-result propagation (3-deep curry)
+
+Closure-returning closures (e.g. `(((mk2 a) b) c)`) now run
+end-to-end on real `java`.
+
+### Bug
+
+APPLY_CLOSURE only stored its int result into `__ca_regs[dst]`.
+When the callee actually returned a closure ref, the lifted
+lambda's body had propagated it into `__ca_objregs[1]` via the
+obj-typed RET, but APPLY_CLOSURE didn't carry it onward to
+`__ca_objregs[dst]` — so the next
+`APPLY_CLOSURE closure_reg=v13` read null.
+
+### Fix
+
+After APPLY_CLOSURE, when the dst register is obj-typed in the
+current region (per `_collect_region_obj_regs`), also copy
+`__ca_objregs[1] → __ca_objregs[dst]`.  Mirrors the obj-pool
+caller-restore's "skip index 1" convention.
+
 ## 0.12.0 — 2026-04-30 — gate ADD_IMM-0 obj propagation on per-region typing
 
 Fixes a memory-safety class of bug in the previous obj-pool work:

--- a/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
+++ b/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
@@ -492,6 +492,11 @@ class _JvmClassLowerer:
         # appears.  Default False so methods that don't need obj-pool
         # caller-saves emit the original int-only sequence.
         self._needs_objregs = False
+        # Per-region set of registers used as object refs.  Set by
+        # ``_emit_region_instructions`` before each region's body
+        # emission.  Used by ADD_IMM-0 emission to gate obj-slot
+        # propagation (see ``_collect_region_obj_regs`` for why).
+        self._region_obj_regs: set[int] = set()
 
     def lower(self) -> JVMClassArtifact:
         self._validate_class_name()
@@ -899,6 +904,90 @@ class _JvmClassLowerer:
             self._emit_push_int(builder, reg_idx)
             self._emit_aload(builder, reg_count + reg_idx)
             builder.emit_opcode(_OP_AASTORE)
+
+    def _collect_region_obj_regs(
+        self, region: _CallableRegion,
+    ) -> set[int]:
+        """Compute the IR-register indices that ``region`` uses as
+        object refs (cons / symbol / nil / closure).
+
+        Used by ADD_IMM-0 emission to gate obj-slot propagation:
+        only copy ``__ca_objregs[src] → __ca_objregs[dst]`` when
+        ``src`` actually holds an object in this region's
+        type-flow.  Without this gate the canonical move idiom
+        would propagate junk (zeros) into the obj pool whenever
+        an int-typed source gets copied — and because
+        ``__ca_objregs`` is a SHARED static array, that junk
+        clobbers obj refs other parts of the program rely on.
+
+        Three sources of "obj-ness" contribute:
+
+        * **Writes** that produce object refs: MAKE_CLOSURE,
+          MAKE_CONS, MAKE_SYMBOL, LOAD_NIL, CDR.  Direct producers.
+        * **Reads** by ops that consume an object operand: CAR,
+          CDR, IS_NULL, IS_PAIR, IS_SYMBOL, MAKE_CONS-tail,
+          APPLY_CLOSURE-closure_reg.  Catches obj-typed parameter
+          slots that the body only ever reads (mirrors the CLR
+          backend's obj-source-read inference).
+        * **Back-prop** through ADD_IMM-0 (the move idiom): if
+          dst is obj-typed, src is too.  Iterated to a fixed
+          point.  Catches the param→holding-reg copy at the top
+          of the body.
+        """
+        obj_regs: set[int] = set()
+        for instr in region.instructions:
+            op = instr.opcode
+            if op in (
+                IrOp.MAKE_CLOSURE, IrOp.MAKE_CONS, IrOp.MAKE_SYMBOL,
+                IrOp.LOAD_NIL, IrOp.CDR,
+            ):
+                if instr.operands and isinstance(
+                    instr.operands[0], IrRegister,
+                ):
+                    obj_regs.add(instr.operands[0].index)
+            if op in (
+                IrOp.CAR, IrOp.CDR, IrOp.IS_NULL, IrOp.IS_PAIR, IrOp.IS_SYMBOL,
+            ):
+                if (
+                    len(instr.operands) >= 2
+                    and isinstance(instr.operands[1], IrRegister)
+                ):
+                    obj_regs.add(instr.operands[1].index)
+            if op is IrOp.MAKE_CONS:
+                if (
+                    len(instr.operands) >= 3
+                    and isinstance(instr.operands[2], IrRegister)
+                ):
+                    obj_regs.add(instr.operands[2].index)
+            if op is IrOp.APPLY_CLOSURE:
+                if (
+                    len(instr.operands) >= 2
+                    and isinstance(instr.operands[1], IrRegister)
+                ):
+                    obj_regs.add(instr.operands[1].index)
+        # Back-prop through ADD_IMM-0 to a fixed point.
+        changed = True
+        cap = len(region.instructions) + 4
+        while changed and cap > 0:
+            changed = False
+            cap -= 1
+            for instr in region.instructions:
+                if instr.opcode is not IrOp.ADD_IMM:
+                    continue
+                if len(instr.operands) < 3:
+                    continue
+                ops = instr.operands
+                if not (
+                    isinstance(ops[0], IrRegister)
+                    and isinstance(ops[1], IrRegister)
+                    and isinstance(ops[2], IrImmediate)
+                    and ops[2].value == 0
+                ):
+                    continue
+                if ops[0].index in obj_regs and ops[1].index not in obj_regs:
+                    obj_regs.add(ops[1].index)
+                    changed = True
+        return obj_regs
 
     def _emit_aload(self, builder: _BytecodeBuilder, index: int) -> None:
         """Load an object reference from JVM local slot ``index``."""
@@ -1804,6 +1893,17 @@ class _JvmClassLowerer:
         lambda method (Phase 2c.5) can prepend a JVM-args prologue
         and re-use the same instruction-by-instruction emission.
         """
+        # Per-region obj-typed register analysis.  The JVM uses a
+        # SHARED static ``__ca_objregs`` array, so a method that
+        # writes garbage to slot N (e.g. an int-typed ADD_IMM-0
+        # propagating zeros into the obj pool) corrupts every
+        # caller's view of that slot.  Stash the set of registers
+        # this region uses obj-style so the ADD_IMM-0 obj
+        # propagation only fires when the source actually holds an
+        # object — same correctness rule the CLR backend's typed
+        # register pool enforces, just adapted to JVM's static
+        # shared layout.
+        self._region_obj_regs = self._collect_region_obj_regs(region)
         for instruction in region.instructions:
             if instruction.opcode == IrOp.LABEL:
                 label = _as_label(instruction.operands[0], "LABEL operand")
@@ -1991,6 +2091,17 @@ class _JvmClassLowerer:
                     self._needs_objregs
                     and instruction.opcode == IrOp.ADD_IMM
                     and imm.value == 0
+                    # Gate on per-region obj-typing — only propagate
+                    # the obj slot when SRC actually holds an object
+                    # in this region.  Without the gate, an int-typed
+                    # ADD_IMM-0 (e.g. ``ADD_IMM v11, v3, 0`` inside a
+                    # lambda body where v3 is an int arg) would write
+                    # null to ``__ca_objregs[v11]`` and clobber a
+                    # caller's obj-typed v11 slot — the JVM static
+                    # ``__ca_objregs`` pool is shared across method
+                    # invocations, so any unconditional write to an
+                    # obj slot is a memory-safety concern.
+                    and src.index in self._region_obj_regs
                 ):
                     builder.emit_u2_instruction(
                         _OP_GETSTATIC,

--- a/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
+++ b/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
@@ -1170,6 +1170,31 @@ class _JvmClassLowerer:
             _OP_INVOKESTATIC,
             self._method_ref(self._helper_reg_set, _DESC_INT_INT_TO_VOID),
         )
+        # Closure-returning closure: when dst is obj-typed in this
+        # region (e.g. ((mk2 a) b) where the inner result is itself
+        # a closure that gets passed to a third APPLY_CLOSURE), the
+        # callee's RET propagated the obj ref into __ca_objregs[1]
+        # via the lifted lambda's ADD_IMM-0 obj propagation.  Copy
+        # __ca_objregs[1] → __ca_objregs[dst] so the next ADD_IMM-0
+        # / APPLY_CLOSURE can pick it up.
+        #
+        # Without this, IClosure.apply([I)I's int return type drops
+        # the obj-slot propagation chain at the call boundary and
+        # 3-deep curries like (((mk2 a) b) c) NPE on the second
+        # APPLY_CLOSURE.
+        if dst.index in self._region_obj_regs:
+            builder.emit_u2_instruction(
+                _OP_GETSTATIC,
+                self._field_ref(self._objreg_field, _DESC_OBJECT_ARRAY),
+            )
+            self._emit_push_int(builder, dst.index)
+            builder.emit_u2_instruction(
+                _OP_GETSTATIC,
+                self._field_ref(self._objreg_field, _DESC_OBJECT_ARRAY),
+            )
+            self._emit_push_int(builder, 1)
+            builder.emit_opcode(_OP_AALOAD)
+            builder.emit_opcode(_OP_AASTORE)
 
     # ------------------------------------------------------------------
     # TW03 Phase 3b — heap-primitive lowering (cons / symbol / nil)

--- a/code/packages/python/twig-jvm-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-jvm-compiler/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog — twig-jvm-compiler
 
-## [0.5.0] — 2026-04-30 — mutual recursion + let-bound-twice closures
+## [0.5.0] — 2026-04-30 — mutual recursion + let-bound-twice + 3-deep curry
+
+Three cross-region bug fixes that bring more Twig source patterns
+to working state on real `java`:
+
+- `(define (mk2 a) (lambda (b) (lambda (c) ...))) (((mk2 10) 20) 12) → 42`
+  works (was a NullReferenceException on the second
+  APPLY_CLOSURE because closure-returning closures didn't
+  propagate the obj ref through APPLY_CLOSURE's int-only return).
+
+The fixes break down as:
 
 Two cross-region bug fixes that bring more Twig source patterns
 to working state on real `java`:

--- a/code/packages/python/twig-jvm-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-jvm-compiler/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — twig-jvm-compiler
 
+## [0.5.0] — 2026-04-30 — mutual recursion + let-bound-twice closures
+
+Two cross-region bug fixes that bring more Twig source patterns
+to working state on real `java`:
+
+### Fixed — mutual recursion (`(define (evp n) ...) (define (odp n) ...) (evp 8)`)
+
+Failed pre-fix with "Duplicate IR label" because `_fresh_label`
+used a per-region counter (`ctx.next_label`).  `evp`'s body
+emitted `_else_0` and `odp`'s body also emitted `_else_0` — the
+JVM backend's label collector rejected the duplicate.
+
+Fix: bump the counter program-wide via `self._next_label_id`
+(same convention twig-beam-compiler already uses).  Each label
+gets a unique `_<prefix>_<idx>` suffix.
+
+### Tests
+
+The user's "complex programs" matrix verifies both fixes pass on
+real `java` end-to-end.  All 46 existing tests still pass.
+
 ## [0.4.0] — 2026-04-30 — recursive heap programs flip to passing
 
 The previously xfail-strict

--- a/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
+++ b/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
@@ -217,9 +217,6 @@ class _FnCtx:
     # Next holding-register index to allocate for intermediate values.
     next_holding: int = _REG_HOLDING_BASE
 
-    # Fresh-label counter (per region, so labels don't collide).
-    next_label: int = 0
-
 
 # ---------------------------------------------------------------------------
 # Compiler
@@ -260,6 +257,13 @@ class _Compiler:
         # emitted at the use site.
         self._lifted_lambdas: list[tuple[str, list[str], Lambda]] = []
         self._lambda_counter = 0
+        # Program-wide fresh-label counter.  Per-region counters
+        # collide between functions (``evp``'s ``_else_0`` would
+        # clash with ``odp``'s ``_else_0`` and the JVM backend
+        # rejects duplicate labels).  Bumping it once per call
+        # keeps every emitted label name unique across the entire
+        # IR program — same convention twig-beam-compiler uses.
+        self._next_label_id = 0
 
     # ------------------------------------------------------------------
     # Top-level driver
@@ -751,9 +755,10 @@ class _Compiler:
         ctx.next_holding += 1
         return IrRegister(index=idx)
 
-    def _fresh_label(self, ctx: _FnCtx, prefix: str) -> str:
-        ctx.next_label += 1
-        return f"{prefix}_{ctx.next_label}"
+    def _fresh_label(self, _ctx: _FnCtx, prefix: str) -> str:
+        idx = self._next_label_id
+        self._next_label_id += 1
+        return f"_{prefix}_{idx}"
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -245,6 +245,34 @@ def test_mutual_recursion_even_odd() -> None:
 
 
 @requires_java
+def test_three_deep_curry() -> None:
+    """``(((mk2 a) b) c) → 42`` — closure that returns a closure
+    that returns an int.
+
+    Was a NullReferenceException pre-fix because APPLY_CLOSURE
+    only stored its int result into ``__ca_regs[dst]``.  When the
+    callee actually returned a closure ref, the lifted lambda's
+    body had propagated it into ``__ca_objregs[1]`` via the
+    obj-typed RET, but APPLY_CLOSURE didn't carry it onward to
+    ``__ca_objregs[dst]`` — so the next ``APPLY_CLOSURE
+    closure_reg=v13`` read null.
+
+    Fix (in ir-to-jvm-class-file): after APPLY_CLOSURE, when the
+    dst register is obj-typed in the current region, also copy
+    ``__ca_objregs[1] → __ca_objregs[dst]``.  Mirror of the
+    obj-pool caller-restore's "skip index 1" convention.
+    """
+    src = """
+        (define (mk2 a) (lambda (b) (lambda (c) (+ a (+ b c)))))
+        (((mk2 10) 20) 12)
+    """
+    result = run_source(src, class_name="TwCurry3")
+    assert result.returncode == 0, result.stderr
+    # 10 + 20 + 12 = 42 = 0x2a = b'*'
+    assert result.stdout == b"*"
+
+
+@requires_java
 def test_let_bound_closure_called_twice() -> None:
     """``(let ((add5 (mk-adder 5))) (+ (add5 10) (add5 27))) → 47``.
 

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -227,6 +227,47 @@ def test_heap_list_of_ints_length() -> None:
 
 
 @requires_java
+def test_mutual_recursion_even_odd() -> None:
+    """``(evp 8) → 1`` via mutually-recursive ``evp`` / ``odp``.
+
+    Was a "Duplicate IR label" failure pre-fix because
+    twig-jvm-compiler's ``_fresh_label`` used a per-region counter
+    so ``evp``'s ``_else_0`` collided with ``odp``'s ``_else_0``.
+    """
+    src = """
+        (define (evp n) (if (= n 0) 1 (odp (- n 1))))
+        (define (odp n) (if (= n 0) 0 (evp (- n 1))))
+        (evp 8)
+    """
+    result = run_source(src, class_name="TwMutEvenOdd")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([1])
+
+
+@requires_java
+def test_let_bound_closure_called_twice() -> None:
+    """``(let ((add5 (mk-adder 5))) (+ (add5 10) (add5 27))) → 47``.
+
+    Was a NullReferenceException pre-fix because the JVM
+    backend's ADD_IMM-0 obj-slot propagation fired
+    unconditionally — the lifted lambda body's
+    ``ADD_IMM v11, v3, 0`` (v3 is an int arg) would clobber
+    ``__ca_objregs[11]`` (the caller's closure-holding slot)
+    with null.  Fix: gate obj-slot propagation on per-region
+    obj-typed register analysis.
+    """
+    src = """
+        (define (mk-adder n) (lambda (x) (+ x n)))
+        (let ((add5 (mk-adder 5)))
+          (+ (add5 10) (add5 27)))
+    """
+    result = run_source(src, class_name="TwLetTwiceClos")
+    assert result.returncode == 0, result.stderr
+    # 15 + 32 = 47 = 0x2f = b'/'
+    assert result.stdout == b"/"
+
+
+@requires_java
 def test_heap_car_of_singleton_returns_int() -> None:
     """``(car (cons 42 nil)) → 42`` exercises the ``CAR`` int-read
     path: the cons head is written from an int register and CAR


### PR DESCRIPTION
## Summary

Three JVM bug fixes from the user's complex-program matrix, brought into one PR:

| Program | Pre-fix | Post-fix |
|---|---|---|
| Mutual recursion `(evp 8) → 1` | ❌ Duplicate IR label | ✅ |
| `(let ((add5 (mk-adder 5))) (+ (add5 10) (add5 27)))` | ❌ NullReferenceException | ✅ → 47 |
| 3-deep curry `(((mk2 a) b) c)` | ❌ NullReferenceException | ✅ → 42 |

## 1. twig-jvm-compiler: program-wide fresh-label counter

`evp`'s body emitted `_else_0` and `odp`'s body also emitted `_else_0` — JVM backend's label collector rejected the duplicate. Switch from per-region `ctx.next_label` to program-wide `self._next_label_id`.

## 2. ir-to-jvm-class-file: gate ADD_IMM-0 obj propagation on per-region typing

v0.11.0's obj-pool work copied `__ca_objregs[src] → __ca_objregs[dst]` unconditionally — clobbering the shared static `__ca_objregs` array when an int-typed source was moved (e.g. lifted lambda body's `ADD_IMM v11, v3, 0` where v3 = int arg). New `_collect_region_obj_regs` analysis classifies each region's registers via writes + obj-source reads + ADD_IMM-0 back-prop fixed point; obj propagation now fires only when SRC is obj-typed.

## 3. ir-to-jvm-class-file: APPLY_CLOSURE obj-result propagation

Closure-returning closures NPE'd because APPLY_CLOSURE only stored its int result. Now also copies `__ca_objregs[1] → __ca_objregs[dst]` when dst is obj-typed in the current region.

## Test plan

- [x] 3 new real-`java` tests in twig-jvm-compiler
- [x] All 113 ir-to-jvm-class-file tests pass (92% coverage)
- [x] All 49 twig-jvm-compiler tests pass (91% coverage)

## Known follow-up

CLR 3-deep curry still SIGSEGVs (separate issue — CLR uses per-method local slots, no shared `__ca_objregs` static, so the closure ref doesn't survive across `IClosure.Apply([I)I`'s int32 return). Fixing CLR requires either widening `IClosure.Apply`'s return type to `Object` or adding a parallel obj-return interface. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)