### PR TITLE
Recover whitespace in HTML text-mode end tags

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -214,6 +214,18 @@ id = "script_data_end_tag_name"
 id = "script_data_escaped_end_tag_name"
 
 [[states]]
+id = "rcdata_end_tag_whitespace"
+
+[[states]]
+id = "rawtext_end_tag_whitespace"
+
+[[states]]
+id = "script_data_end_tag_whitespace"
+
+[[states]]
+id = "script_data_escaped_end_tag_whitespace"
+
+[[states]]
 id = "rcdata_self_closing_end_tag"
 
 [[states]]
@@ -1326,6 +1338,30 @@ actions = ["emit_rcdata_end_tag_or_text"]
 
 [[transitions]]
 from = "rcdata_end_tag_name"
+matcher = { literal = " " }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_name"
+matcher = { literal = "\n" }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_name"
+matcher = { literal = "\t" }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_name"
+matcher = { literal = "\r" }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_name"
 matcher = { literal = "/" }
 to = "rcdata_self_closing_end_tag"
 
@@ -1356,6 +1392,30 @@ from = "rawtext_end_tag_name"
 matcher = { literal = ">" }
 to = "rawtext"
 actions = ["emit_rcdata_end_tag_or_text"]
+
+[[transitions]]
+from = "rawtext_end_tag_name"
+matcher = { literal = " " }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_name"
+matcher = { literal = "\n" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_name"
+matcher = { literal = "\t" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_name"
+matcher = { literal = "\r" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
 from = "rawtext_end_tag_name"
@@ -1392,6 +1452,30 @@ actions = ["emit_rcdata_end_tag_or_text"]
 
 [[transitions]]
 from = "script_data_end_tag_name"
+matcher = { literal = " " }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_name"
+matcher = { literal = "\n" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_name"
+matcher = { literal = "\t" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_name"
+matcher = { literal = "\r" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_name"
 matcher = { literal = "/" }
 to = "script_data_self_closing_end_tag"
 
@@ -1425,6 +1509,30 @@ actions = ["emit_rcdata_end_tag_or_text"]
 
 [[transitions]]
 from = "script_data_escaped_end_tag_name"
+matcher = { literal = " " }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_name"
+matcher = { literal = "\n" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_name"
+matcher = { literal = "\t" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_name"
+matcher = { literal = "\r" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_name"
 matcher = { literal = "/" }
 to = "script_data_escaped_self_closing_end_tag"
 
@@ -1448,6 +1556,222 @@ to = "script_data_escaped_end_tag_name"
 actions = [
   "append_tag_name(current_lowercase)",
   "append_temporary_buffer(current_lowercase)",
+]
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
+matcher = { literal = " " }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
+matcher = { literal = "\n" }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
+matcher = { literal = "\t" }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
+matcher = { literal = "\r" }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
+matcher = { literal = ">" }
+to = "rcdata"
+actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
+matcher = { anything = true }
+to = "rcdata"
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "append_text(current)",
+]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = " " }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = "\n" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = "\t" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = "\r" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = ">" }
+to = "rawtext"
+actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { anything = true }
+to = "rawtext"
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "append_text(current)",
+]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = " " }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = "\n" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = "\t" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = "\r" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = ">" }
+to = "script_data"
+actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { anything = true }
+to = "script_data"
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "append_text(current)",
+]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = " " }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = "\n" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = "\t" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = "\r" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = ">" }
+to = "script_data_escaped"
+actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { anything = true }
+to = "script_data_escaped"
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "append_text(current)",
 ]
 
 [[transitions]]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -940,6 +940,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             external_entry: false,
         },
         StateDefinition {
+            id: "rawtext_end_tag_whitespace".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
             id: "rawtext_less_than_sign".to_string(),
             initial: false,
             accepting: false,
@@ -990,6 +997,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         StateDefinition {
             id: "rcdata_end_tag_open".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
+            id: "rcdata_end_tag_whitespace".to_string(),
             initial: false,
             accepting: false,
             final_state: false,
@@ -1073,6 +1087,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             external_entry: false,
         },
         StateDefinition {
+            id: "script_data_end_tag_whitespace".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
             id: "script_data_escape_start".to_string(),
             initial: false,
             accepting: false,
@@ -1116,6 +1137,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         StateDefinition {
             id: "script_data_escaped_end_tag_open".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
+            id: "script_data_escaped_end_tag_whitespace".to_string(),
             initial: false,
             accepting: false,
             final_state: false,
@@ -3048,6 +3076,66 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "rcdata_end_tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "rcdata_self_closing_end_tag".to_string(),
@@ -3105,6 +3193,66 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "emit_rcdata_end_tag_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
         },
@@ -3174,6 +3322,66 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_end_tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "script_data_self_closing_end_tag".to_string(),
@@ -3237,6 +3445,66 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_escaped_end_tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "script_data_escaped_self_closing_end_tag".to_string(),
@@ -3279,6 +3547,454 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "append_tag_name(current_lowercase)".to_string(),
                 "append_temporary_buffer(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "rcdata".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "flush_text".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "rcdata".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "append_text(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "rawtext".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "flush_text".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "rawtext".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "append_text(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "script_data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "flush_text".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "script_data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "append_text(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "script_data_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "flush_text".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "script_data_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "append_text(current)".to_string(),
             ],
             consume: true,
         },

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1044,6 +1044,72 @@ fn default_html_lexer_keeps_mismatched_text_mode_end_tag_solidus_literal() {
 }
 
 #[test]
+fn default_html_lexer_recovers_seeded_text_mode_end_tags_with_whitespace() {
+    for (initial_state, last_start_tag, text, close) in [
+        ("rcdata", "title", "Hello", "</title >"),
+        ("rawtext", "style", "body {}", "</style\t>"),
+        ("script_data", "script", "if (ready)", "</script\n>"),
+        (
+            "script_data_escaped",
+            "script",
+            "<!-- ok -->",
+            "</script\r>",
+        ),
+    ] {
+        let mut lexer = create_html_lexer().unwrap();
+        lexer.set_initial_state(initial_state).unwrap();
+        lexer.set_last_start_tag(last_start_tag);
+
+        lexer.push(&format!("{text}{close}")).unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![
+                Token::Text(text.to_string()),
+                Token::EndTag {
+                    name: last_start_tag.to_string()
+                },
+                Token::Eof,
+            ],
+            "state {initial_state} should emit the appropriate end tag"
+        );
+        assert!(
+            lexer
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"),
+            "state {initial_state} should report whitespace recovery"
+        );
+    }
+}
+
+#[test]
+fn default_html_lexer_keeps_mismatched_text_mode_end_tag_whitespace_literal() {
+    let mut lexer = create_html_lexer().unwrap();
+    lexer.set_initial_state("script_data").unwrap();
+    lexer.set_last_start_tag("script");
+
+    lexer.push("x</style >y</script>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("x</style >y".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(!lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"));
+}
+
+#[test]
 fn default_html_lexer_supports_seeded_rcdata_lt_references() {
     let mut lexer = create_html_lexer().unwrap();
     lexer.set_initial_state("rcdata").unwrap();

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -712,6 +712,7 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
         | "switch_to_return_state"
         | "emit_rcdata_end_tag_or_text"
         | "emit_rcdata_end_tag_with_trailing_solidus_or_text"
+        | "emit_rcdata_end_tag_with_whitespace_or_text"
         | "emit_current_token" => return Ok(()),
         _ => {}
     }

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -99,6 +99,7 @@ Temporary buffers and controlled state changes:
 - `switch_to_return_state`
 - `emit_rcdata_end_tag_or_text`
 - `emit_rcdata_end_tag_with_trailing_solidus_or_text`
+- `emit_rcdata_end_tag_with_whitespace_or_text`
 
 Diagnostics and stream control:
 

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -675,6 +675,9 @@ impl Tokenizer {
                 "emit_rcdata_end_tag_with_trailing_solidus_or_text" => {
                     self.emit_rcdata_end_tag_with_trailing_solidus_or_text(action, position, state)?
                 }
+                "emit_rcdata_end_tag_with_whitespace_or_text" => {
+                    self.emit_rcdata_end_tag_with_whitespace_or_text(action, position, state)?
+                }
                 "emit(EOF)" => self.tokens.push_back(Token::Eof),
                 _ if action.starts_with("set_return_state(") && action.ends_with(')') => {
                     let state = action
@@ -1077,6 +1080,47 @@ impl Tokenizer {
             self.text_buffer.push_str("</");
             self.text_buffer.push_str(&self.temporary_buffer);
             self.text_buffer.push_str("/>");
+        }
+        self.temporary_buffer.clear();
+        Ok(())
+    }
+
+    fn emit_rcdata_end_tag_with_whitespace_or_text(
+        &mut self,
+        action: &str,
+        position: SourcePosition,
+        state: &str,
+    ) -> Result<()> {
+        let candidate = match self.current_token.as_ref() {
+            Some(CurrentToken::EndTag { name }) => name.clone(),
+            Some(other) => {
+                return Err(TokenizerError::InvalidCurrentToken {
+                    action: action.to_string(),
+                    expected: "end-tag",
+                    actual: other.kind_name(),
+                })
+            }
+            None => {
+                return Err(TokenizerError::MissingCurrentToken {
+                    action: action.to_string(),
+                })
+            }
+        };
+
+        if self.last_start_tag.as_deref() == Some(candidate.as_str()) {
+            self.diagnostics.push(Diagnostic {
+                code: "unexpected-whitespace-after-end-tag-name".to_string(),
+                position,
+                state: state.to_string(),
+            });
+            self.flush_text();
+            self.emit_current_token("emit_current_token")?;
+        } else {
+            self.current_token = None;
+            self.current_attribute = None;
+            self.text_buffer.push_str("</");
+            self.text_buffer.push_str(&self.temporary_buffer);
+            self.text_buffer.push('>');
         }
         self.temporary_buffer.clear();
         Ok(())


### PR DESCRIPTION
## Summary
- recover appropriate RCDATA, RAWTEXT, script data, and script escaped end tags when whitespace appears before `>`
- keep mismatched text-mode end-tag candidates literal instead of reporting false diagnostics
- regenerate the static Rust HTML1 lexer and extend tokenizer action vocabulary

## Verification
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml html1_toml_compiles_to_rust_source`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml`