### PR TITLE
Recover attributes in HTML text-mode end tags

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -226,6 +226,18 @@ id = "script_data_end_tag_whitespace"
 id = "script_data_escaped_end_tag_whitespace"
 
 [[states]]
+id = "rcdata_end_tag_attributes"
+
+[[states]]
+id = "rawtext_end_tag_attributes"
+
+[[states]]
+id = "script_data_end_tag_attributes"
+
+[[states]]
+id = "script_data_escaped_end_tag_attributes"
+
+[[states]]
 id = "rcdata_self_closing_end_tag"
 
 [[states]]
@@ -1604,46 +1616,189 @@ actions = [
 [[transitions]]
 from = "rcdata_end_tag_whitespace"
 matcher = { anything = true }
+to = "rcdata_end_tag_attributes"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = " " }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = "\n" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = "\t" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = "\r" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = ">" }
+to = "rawtext"
+actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { anything = true }
+to = "rawtext_end_tag_attributes"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = " " }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = "\n" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = "\t" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = "\r" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { literal = ">" }
+to = "script_data"
+actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
+matcher = { anything = true }
+to = "script_data_end_tag_attributes"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = " " }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = "\n" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = "\t" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = "\r" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = ">" }
+to = "script_data_escaped"
+actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
+  "flush_text",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { anything = true }
+to = "script_data_escaped_end_tag_attributes"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_attributes"
+matcher = { literal = ">" }
 to = "rcdata"
+actions = ["emit_rcdata_end_tag_with_attributes_or_text"]
+
+[[transitions]]
+from = "rcdata_end_tag_attributes"
+matcher = { eof = true }
+to = "done"
+consume = false
 actions = [
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
-  "append_text(current)",
+  "flush_text",
+  "emit(EOF)",
 ]
 
 [[transitions]]
-from = "rawtext_end_tag_whitespace"
-matcher = { literal = " " }
-to = "rawtext_end_tag_whitespace"
+from = "rcdata_end_tag_attributes"
+matcher = { anything = true }
+to = "rcdata_end_tag_attributes"
 actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
-from = "rawtext_end_tag_whitespace"
-matcher = { literal = "\n" }
-to = "rawtext_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "rawtext_end_tag_whitespace"
-matcher = { literal = "\t" }
-to = "rawtext_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "rawtext_end_tag_whitespace"
-matcher = { literal = "\r" }
-to = "rawtext_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "rawtext_end_tag_whitespace"
+from = "rawtext_end_tag_attributes"
 matcher = { literal = ">" }
 to = "rawtext"
-actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+actions = ["emit_rcdata_end_tag_with_attributes_or_text"]
 
 [[transitions]]
-from = "rawtext_end_tag_whitespace"
+from = "rawtext_end_tag_attributes"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -1656,48 +1811,19 @@ actions = [
 ]
 
 [[transitions]]
-from = "rawtext_end_tag_whitespace"
+from = "rawtext_end_tag_attributes"
 matcher = { anything = true }
-to = "rawtext"
-actions = [
-  "discard_current_token",
-  "append_text(</)",
-  "append_temporary_buffer_to_text",
-  "append_text(current)",
-]
-
-[[transitions]]
-from = "script_data_end_tag_whitespace"
-matcher = { literal = " " }
-to = "script_data_end_tag_whitespace"
+to = "rawtext_end_tag_attributes"
 actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
-from = "script_data_end_tag_whitespace"
-matcher = { literal = "\n" }
-to = "script_data_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "script_data_end_tag_whitespace"
-matcher = { literal = "\t" }
-to = "script_data_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "script_data_end_tag_whitespace"
-matcher = { literal = "\r" }
-to = "script_data_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "script_data_end_tag_whitespace"
+from = "script_data_end_tag_attributes"
 matcher = { literal = ">" }
 to = "script_data"
-actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+actions = ["emit_rcdata_end_tag_with_attributes_or_text"]
 
 [[transitions]]
-from = "script_data_end_tag_whitespace"
+from = "script_data_end_tag_attributes"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -1710,48 +1836,19 @@ actions = [
 ]
 
 [[transitions]]
-from = "script_data_end_tag_whitespace"
+from = "script_data_end_tag_attributes"
 matcher = { anything = true }
-to = "script_data"
-actions = [
-  "discard_current_token",
-  "append_text(</)",
-  "append_temporary_buffer_to_text",
-  "append_text(current)",
-]
-
-[[transitions]]
-from = "script_data_escaped_end_tag_whitespace"
-matcher = { literal = " " }
-to = "script_data_escaped_end_tag_whitespace"
+to = "script_data_end_tag_attributes"
 actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
-from = "script_data_escaped_end_tag_whitespace"
-matcher = { literal = "\n" }
-to = "script_data_escaped_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "script_data_escaped_end_tag_whitespace"
-matcher = { literal = "\t" }
-to = "script_data_escaped_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "script_data_escaped_end_tag_whitespace"
-matcher = { literal = "\r" }
-to = "script_data_escaped_end_tag_whitespace"
-actions = ["append_temporary_buffer(current)"]
-
-[[transitions]]
-from = "script_data_escaped_end_tag_whitespace"
+from = "script_data_escaped_end_tag_attributes"
 matcher = { literal = ">" }
 to = "script_data_escaped"
-actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+actions = ["emit_rcdata_end_tag_with_attributes_or_text"]
 
 [[transitions]]
-from = "script_data_escaped_end_tag_whitespace"
+from = "script_data_escaped_end_tag_attributes"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -1764,15 +1861,10 @@ actions = [
 ]
 
 [[transitions]]
-from = "script_data_escaped_end_tag_whitespace"
+from = "script_data_escaped_end_tag_attributes"
 matcher = { anything = true }
-to = "script_data_escaped"
-actions = [
-  "discard_current_token",
-  "append_text(</)",
-  "append_temporary_buffer_to_text",
-  "append_text(current)",
-]
+to = "script_data_escaped_end_tag_attributes"
+actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
 from = "rcdata_self_closing_end_tag"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -926,6 +926,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             external_entry: true,
         },
         StateDefinition {
+            id: "rawtext_end_tag_attributes".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
             id: "rawtext_end_tag_name".to_string(),
             initial: false,
             accepting: false,
@@ -983,6 +990,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         StateDefinition {
             id: "rcdata_character_reference_lt".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
+            id: "rcdata_end_tag_attributes".to_string(),
             initial: false,
             accepting: false,
             final_state: false,
@@ -1073,6 +1087,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             external_entry: false,
         },
         StateDefinition {
+            id: "script_data_end_tag_attributes".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
             id: "script_data_end_tag_name".to_string(),
             initial: false,
             accepting: false,
@@ -1123,6 +1144,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         StateDefinition {
             id: "script_data_escaped_dash_dash".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
+            id: "script_data_escaped_end_tag_attributes".to_string(),
             initial: false,
             accepting: false,
             final_state: false,
@@ -3649,25 +3677,383 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
+                "rcdata_end_tag_attributes".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "rawtext".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "flush_text".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "rawtext_end_tag_attributes".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "script_data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "flush_text".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "script_data_end_tag_attributes".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "script_data_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+                "flush_text".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "script_data_escaped_end_tag_attributes".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_attributes".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
                 "rcdata".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "emit_rcdata_end_tag_with_attributes_or_text".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_attributes".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
-                "append_text(current)".to_string(),
+                "flush_text".to_string(),
+                "emit(EOF)".to_string(),
             ],
-            consume: true,
+            consume: false,
         },
         TransitionDefinition {
-            from: "rawtext_end_tag_whitespace".to_string(),
+            from: "rcdata_end_tag_attributes".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
+            matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "rawtext_end_tag_whitespace".to_string(),
+                "rcdata_end_tag_attributes".to_string(),
             ],
             guard: None,
             stack_pop: None,
@@ -3678,52 +4064,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             consume: true,
         },
         TransitionDefinition {
-            from: "rawtext_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
-            to: vec![
-                "rawtext_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "rawtext_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
-            to: vec![
-                "rawtext_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "rawtext_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
-            to: vec![
-                "rawtext_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "rawtext_end_tag_whitespace".to_string(),
+            from: "rawtext_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
@@ -3733,12 +4074,12 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+                "emit_rcdata_end_tag_with_attributes_or_text".to_string(),
             ],
             consume: true,
         },
         TransitionDefinition {
-            from: "rawtext_end_tag_whitespace".to_string(),
+            from: "rawtext_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
@@ -3757,29 +4098,11 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             consume: false,
         },
         TransitionDefinition {
-            from: "rawtext_end_tag_whitespace".to_string(),
+            from: "rawtext_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "rawtext".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "discard_current_token".to_string(),
-                "append_text(</)".to_string(),
-                "append_temporary_buffer_to_text".to_string(),
-                "append_text(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "script_data_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
-            to: vec![
-                "script_data_end_tag_whitespace".to_string(),
+                "rawtext_end_tag_attributes".to_string(),
             ],
             guard: None,
             stack_pop: None,
@@ -3790,52 +4113,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             consume: true,
         },
         TransitionDefinition {
-            from: "script_data_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
-            to: vec![
-                "script_data_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "script_data_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
-            to: vec![
-                "script_data_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "script_data_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
-            to: vec![
-                "script_data_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "script_data_end_tag_whitespace".to_string(),
+            from: "script_data_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
@@ -3845,12 +4123,12 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+                "emit_rcdata_end_tag_with_attributes_or_text".to_string(),
             ],
             consume: true,
         },
         TransitionDefinition {
-            from: "script_data_end_tag_whitespace".to_string(),
+            from: "script_data_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
@@ -3869,29 +4147,11 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             consume: false,
         },
         TransitionDefinition {
-            from: "script_data_end_tag_whitespace".to_string(),
+            from: "script_data_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "script_data".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "discard_current_token".to_string(),
-                "append_text(</)".to_string(),
-                "append_temporary_buffer_to_text".to_string(),
-                "append_text(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "script_data_escaped_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal(" ".to_string())),
-            to: vec![
-                "script_data_escaped_end_tag_whitespace".to_string(),
+                "script_data_end_tag_attributes".to_string(),
             ],
             guard: None,
             stack_pop: None,
@@ -3902,52 +4162,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             consume: true,
         },
         TransitionDefinition {
-            from: "script_data_escaped_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\n".to_string())),
-            to: vec![
-                "script_data_escaped_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "script_data_escaped_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\t".to_string())),
-            to: vec![
-                "script_data_escaped_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "script_data_escaped_end_tag_whitespace".to_string(),
-            on: None,
-            matcher: Some(MatcherDefinition::Literal("\r".to_string())),
-            to: vec![
-                "script_data_escaped_end_tag_whitespace".to_string(),
-            ],
-            guard: None,
-            stack_pop: None,
-            stack_push: Vec::new(),
-            actions: vec![
-                "append_temporary_buffer(current)".to_string(),
-            ],
-            consume: true,
-        },
-        TransitionDefinition {
-            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            from: "script_data_escaped_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
@@ -3957,12 +4172,12 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
+                "emit_rcdata_end_tag_with_attributes_or_text".to_string(),
             ],
             consume: true,
         },
         TransitionDefinition {
-            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            from: "script_data_escaped_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
@@ -3981,20 +4196,17 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             consume: false,
         },
         TransitionDefinition {
-            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            from: "script_data_escaped_end_tag_attributes".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "script_data_escaped".to_string(),
+                "script_data_escaped_end_tag_attributes".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "discard_current_token".to_string(),
-                "append_text(</)".to_string(),
-                "append_temporary_buffer_to_text".to_string(),
-                "append_text(current)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
         },

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1110,6 +1110,72 @@ fn default_html_lexer_keeps_mismatched_text_mode_end_tag_whitespace_literal() {
 }
 
 #[test]
+fn default_html_lexer_recovers_seeded_text_mode_end_tags_with_attributes() {
+    for (initial_state, last_start_tag, text, close) in [
+        ("rcdata", "title", "Hello", "</title class=x>"),
+        ("rawtext", "style", "body {}", "</style data-x>"),
+        ("script_data", "script", "if (ready)", "</script ignored=1>"),
+        (
+            "script_data_escaped",
+            "script",
+            "<!-- ok -->",
+            "</script type=text/javascript>",
+        ),
+    ] {
+        let mut lexer = create_html_lexer().unwrap();
+        lexer.set_initial_state(initial_state).unwrap();
+        lexer.set_last_start_tag(last_start_tag);
+
+        lexer.push(&format!("{text}{close}")).unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![
+                Token::Text(text.to_string()),
+                Token::EndTag {
+                    name: last_start_tag.to_string()
+                },
+                Token::Eof,
+            ],
+            "state {initial_state} should emit the appropriate end tag"
+        );
+        assert!(
+            lexer
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.code == "end-tag-with-attributes"),
+            "state {initial_state} should report attribute recovery"
+        );
+    }
+}
+
+#[test]
+fn default_html_lexer_keeps_mismatched_text_mode_end_tag_attributes_literal() {
+    let mut lexer = create_html_lexer().unwrap();
+    lexer.set_initial_state("script_data").unwrap();
+    lexer.set_last_start_tag("script");
+
+    lexer.push("x</style class=x>y</script>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("x</style class=x>y".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(!lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "end-tag-with-attributes"));
+}
+
+#[test]
 fn default_html_lexer_supports_seeded_rcdata_lt_references() {
     let mut lexer = create_html_lexer().unwrap();
     lexer.set_initial_state("rcdata").unwrap();

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -713,6 +713,7 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
         | "emit_rcdata_end_tag_or_text"
         | "emit_rcdata_end_tag_with_trailing_solidus_or_text"
         | "emit_rcdata_end_tag_with_whitespace_or_text"
+        | "emit_rcdata_end_tag_with_attributes_or_text"
         | "emit_current_token" => return Ok(()),
         _ => {}
     }

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -100,6 +100,7 @@ Temporary buffers and controlled state changes:
 - `emit_rcdata_end_tag_or_text`
 - `emit_rcdata_end_tag_with_trailing_solidus_or_text`
 - `emit_rcdata_end_tag_with_whitespace_or_text`
+- `emit_rcdata_end_tag_with_attributes_or_text`
 
 Diagnostics and stream control:
 

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -678,6 +678,9 @@ impl Tokenizer {
                 "emit_rcdata_end_tag_with_whitespace_or_text" => {
                     self.emit_rcdata_end_tag_with_whitespace_or_text(action, position, state)?
                 }
+                "emit_rcdata_end_tag_with_attributes_or_text" => {
+                    self.emit_rcdata_end_tag_with_attributes_or_text(action, position, state)?
+                }
                 "emit(EOF)" => self.tokens.push_back(Token::Eof),
                 _ if action.starts_with("set_return_state(") && action.ends_with(')') => {
                     let state = action
@@ -1110,6 +1113,47 @@ impl Tokenizer {
         if self.last_start_tag.as_deref() == Some(candidate.as_str()) {
             self.diagnostics.push(Diagnostic {
                 code: "unexpected-whitespace-after-end-tag-name".to_string(),
+                position,
+                state: state.to_string(),
+            });
+            self.flush_text();
+            self.emit_current_token("emit_current_token")?;
+        } else {
+            self.current_token = None;
+            self.current_attribute = None;
+            self.text_buffer.push_str("</");
+            self.text_buffer.push_str(&self.temporary_buffer);
+            self.text_buffer.push('>');
+        }
+        self.temporary_buffer.clear();
+        Ok(())
+    }
+
+    fn emit_rcdata_end_tag_with_attributes_or_text(
+        &mut self,
+        action: &str,
+        position: SourcePosition,
+        state: &str,
+    ) -> Result<()> {
+        let candidate = match self.current_token.as_ref() {
+            Some(CurrentToken::EndTag { name }) => name.clone(),
+            Some(other) => {
+                return Err(TokenizerError::InvalidCurrentToken {
+                    action: action.to_string(),
+                    expected: "end-tag",
+                    actual: other.kind_name(),
+                })
+            }
+            None => {
+                return Err(TokenizerError::MissingCurrentToken {
+                    action: action.to_string(),
+                })
+            }
+        };
+
+        if self.last_start_tag.as_deref() == Some(candidate.as_str()) {
+            self.diagnostics.push(Diagnostic {
+                code: "end-tag-with-attributes".to_string(),
                 position,
                 state: state.to_string(),
             });


### PR DESCRIPTION
## Summary
- recover appropriate RCDATA, RAWTEXT, script data, and script escaped end tags when ignored attributes appear before `>`
- preserve mismatched text-mode end-tag candidates with attributes as literal text
- regenerate the static Rust HTML1 lexer and extend tokenizer action vocabulary

## Verification
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/state-machine-markup-deserializer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml html1_toml_compiles_to_rust_source`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml`