### PR TITLE
feat(jvm,clr): heterogeneous cons cells (Cons.head widened to Object)

### DIFF
--- a/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.10.0 — 2026-04-30 — heterogeneous cons cells (Cons.head widened to object)
+
+`Cons.head` is now typed `object` (was `int32`) so cons cells can
+hold any Twig value — boxed Int32, Symbol, another cons, closure
+ref, nil.  Same shape as the parallel JVM heterogeneous-cons fix
+(ir-to-jvm-class-file v0.14.0).
+
+### Class-layout change
+
+```csharp
+public sealed class Cons : object {
+    public object head;   // was: int32 head
+    public object tail;
+    public Cons(object head, object tail) { ... }
+}
+```
+
+### MAKE_CONS lowering
+
+Head register: ldloc from obj slot if obj-typed in this region;
+else ldloc int and `box [System.Int32]` to wrap.  Tail is always
+object.  Reuses the System.Int32 TypeRef added in
+cli-assembly-writer v0.4.0 for the box opcode.
+
+### CAR lowering
+
+Read `Cons.head` (object).  If dst is obj-typed in this region,
+stloc directly into the obj slot.  Else `unbox.any [System.Int32]`
+to extract the int and stloc.
+
+### Tests
+
+All 97 ir-to-cil-bytecode tests pass; coverage 91%.
+
 ## 0.9.0 — 2026-04-30 — closure-returning closures (3-deep curry)
 
 Closure-returning closures now run end-to-end on real `dotnet`:

--- a/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
@@ -1740,8 +1740,11 @@ def _build_heap_extra_types(
 
     Three TypeDefs are appended after any closure types:
 
-    * ``Cons`` — fields ``int32 head`` + ``object tail``; ctor takes
-      both and stores them.
+    * ``Cons`` — fields ``object head`` + ``object tail``; ctor takes
+      both and stores them.  Heterogeneous-cons follow-up: head is
+      now ``object``-typed (was ``int32``) so cons cells can hold
+      any Twig value (boxed Int32 for ints, Symbol/Nil/Cons refs
+      directly).
     * ``Symbol`` — field ``string name``; ctor takes a string and
       stores it.
     * ``Nil`` — empty class with a no-arg ctor; used as the
@@ -1780,7 +1783,7 @@ def _build_heap_extra_types(
         max_stack=2,
         local_types=(),
         return_type="void",
-        parameter_types=("int32", "object"),
+        parameter_types=("object", "object"),
         is_instance=True,
         is_special_name=True,
     )
@@ -1789,7 +1792,7 @@ def _build_heap_extra_types(
         namespace="CodingAdventures",
         extends="System.Object",
         fields=(
-            CILFieldArtifact(name="head", type="int32"),
+            CILFieldArtifact(name="head", type="object"),
             CILFieldArtifact(name="tail", type="object"),
         ),
         methods=(cons_ctor,),
@@ -2251,8 +2254,19 @@ def _emit_instruction(
         dst = _as_register(instruction.operands[0], "MAKE_CONS dst")
         head = _as_register(instruction.operands[1], "MAKE_CONS head")
         tail = _as_register(instruction.operands[2], "MAKE_CONS tail")
-        # head: int32 (from int slot); tail: object (from obj slot)
-        builder.emit_ldloc(head.index)
+        # Heterogeneous-cons: head is now object-typed (was int32).
+        # If the head register is obj-typed in this region, ldloc
+        # from the obj slot directly.  If int-typed, ldloc int and
+        # box [System.Int32] to wrap into Object.
+        if ctx is not None and head.index in ctx.obj_local_for:
+            builder.emit_ldloc(ctx.obj_local_for[head.index])
+        else:
+            builder.emit_ldloc(head.index)
+            # box [System.Runtime]System.Int32 — opcode 0x8C
+            builder.emit_token_instruction(
+                0x8C, plan.token_provider.system_int32_typeref_token(),
+            )
+        # Tail: always object — load from obj slot.
         if ctx is not None and tail.index in ctx.obj_local_for:
             builder.emit_ldloc(ctx.obj_local_for[tail.index])
         else:
@@ -2286,7 +2300,19 @@ def _emit_instruction(
         builder.emit_token_instruction(
             0x7B, plan.token_provider.heap_cons_head_token(),
         )
-        builder.emit_stloc(dst.index)  # int32 result → int slot
+        # Heterogeneous-cons: head is now Object.  If dst is
+        # obj-typed in this region, the head IS an obj ref —
+        # stloc directly into the obj slot.  If int-typed (the
+        # common list-of-ints case), unbox.any [System.Int32] to
+        # extract the int.
+        if ctx is not None and dst.index in ctx.obj_local_for:
+            builder.emit_stloc(ctx.obj_local_for[dst.index])
+        else:
+            # unbox.any [System.Int32] — opcode 0xA5
+            builder.emit_token_instruction(
+                0xA5, plan.token_provider.system_int32_typeref_token(),
+            )
+            builder.emit_stloc(dst.index)
         return
 
     if instruction.opcode == IrOp.CDR:

--- a/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
@@ -1208,14 +1208,17 @@ class TestHeapExtraTypes:
         assert ("CodingAdventures", "Symbol") not in names
         assert ("CodingAdventures", "Nil") not in names
 
-    def test_cons_typedef_has_int_head_and_object_tail(self) -> None:
+    def test_cons_typedef_has_object_head_and_tail(self) -> None:
+        # Heterogeneous-cons follow-up: head is now object-typed
+        # (was int32) so cons cells can hold any Twig value (boxed
+        # Int32, Symbol, Nil, Cons, closure ref).
         program = self._heap_program([
             IrInstruction(IrOp.LOAD_NIL, [IrRegister(2)]),
         ])
         artifact = lower_ir_to_cil_bytecode(program)
         cons = next(t for t in artifact.extra_types if t.name == "Cons")
         field_types = {f.name: f.type for f in cons.fields}
-        assert field_types == {"head": "int32", "tail": "object"}
+        assert field_types == {"head": "object", "tail": "object"}
 
     def test_symbol_typedef_has_string_name(self) -> None:
         program = self._heap_program([

--- a/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
@@ -1,5 +1,43 @@
 # ir-to-jvm-class-file
 
+## 0.14.0 — 2026-04-30 — heterogeneous cons cells (Cons.head widened to Object)
+
+`Cons.head` is now typed `Object` (was `int`) so cons cells can
+hold any Twig value — boxed Int32, Symbol, another cons, closure
+ref, nil.  Unblocks AST-shaped data, list-of-symbols, and
+nested-cons patterns that any real Lisp program (including a
+self-hosted compiler) needs.
+
+### Class-layout change
+
+```java
+public final class Cons {
+    public final Object head;   // was: int head
+    public final Object tail;
+    public Cons(Object head, Object tail) { ... }
+}
+```
+
+### MAKE_CONS lowering
+
+When the head register is obj-typed in the current region, ldload
+from the obj slot directly.  When int-typed, read the int and box
+via `Integer.valueOf(int) Integer`.  Tail is always Object.
+
+### CAR lowering
+
+Read `Cons.head` as Object.  If dst is obj-typed in the current
+region (e.g. `(symbol? (car ...))`), stloc directly into the obj
+slot.  If int-typed (the common list-of-ints case), `checkcast
+Integer; invokevirtual Integer.intValue()` to unwrap to int.
+
+### Tests
+
+All 113 ir-to-jvm-class-file tests pass; coverage 92%.  Existing
+list-of-ints tests like `(length [1,2,3,4,5])` and `(sum [10 20 30])`
+continue to pass — they exercise the boxing/unboxing path
+transparently.
+
 ## 0.13.0 — 2026-04-30 — APPLY_CLOSURE obj-result propagation (3-deep curry)
 
 Closure-returning closures (e.g. `(((mk2 a) b) c)`) now run

--- a/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
+++ b/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
@@ -1280,8 +1280,14 @@ class _JvmClassLowerer:
     ) -> None:
         """Lower ``MAKE_CONS dst, head_reg, tail_reg``.
 
-        Phase 3b v1: head is read from the int pool, tail from the
-        object pool.  Cons fields are ``int head; Object tail``.
+        Heterogeneous-cons: head is now ``Object``-typed (was
+        ``int``).  When the source register is obj-typed in the
+        current region, load directly from the obj pool.  When
+        int-typed, read the int and box via
+        ``Integer.valueOf(int) Integer``.
+
+        Tail is always ``Object`` and read from the obj pool —
+        unchanged from the prior list-of-ints design.
         """
         if len(instruction.operands) != 3:
             raise JvmBackendError(
@@ -1291,13 +1297,24 @@ class _JvmClassLowerer:
         dst = _as_register(instruction.operands[0], "MAKE_CONS dst")
         head_reg = _as_register(instruction.operands[1], "MAKE_CONS head")
         tail_reg = _as_register(instruction.operands[2], "MAKE_CONS tail")
-        # new Cons; dup; iload head; aload tail; invokespecial ctor;
-        # then store the resulting ref into __ca_objregs[dst].
         builder.emit_u2_instruction(_OP_NEW, self.cp.class_ref(CONS_BINARY_NAME))
         builder.emit_opcode(_OP_DUP)
-        self._emit_reg_get(builder, head_reg.index)
+        # Head: load from obj slot if obj-typed in this region; else
+        # load int and box to Integer.
+        if head_reg.index in self._region_obj_regs:
+            self._emit_objreg_load(builder, head_reg.index)
+        else:
+            self._emit_reg_get(builder, head_reg.index)
+            # Integer.valueOf(int) → Integer (which IS-A Object).
+            builder.emit_u2_instruction(
+                _OP_INVOKESTATIC,
+                self.cp.method_ref(
+                    "java/lang/Integer", "valueOf",
+                    "(I)Ljava/lang/Integer;",
+                ),
+            )
         self._emit_objreg_load(builder, tail_reg.index)
-        ctor_descriptor = "(I" + _DESC_OBJECT + ")V"
+        ctor_descriptor = "(" + _DESC_OBJECT + _DESC_OBJECT + ")V"
         builder.emit_u2_instruction(
             _OP_INVOKESPECIAL,
             self.cp.method_ref(CONS_BINARY_NAME, "<init>", ctor_descriptor),
@@ -1308,7 +1325,15 @@ class _JvmClassLowerer:
     def _emit_car(
         self, builder: _BytecodeBuilder, instruction: IrInstruction,
     ) -> None:
-        """Lower ``CAR dst, src`` — read ``Cons.head`` (int)."""
+        """Lower ``CAR dst, src`` — read ``Cons.head``.
+
+        Heterogeneous-cons: head is ``Object``-typed.  If dst is
+        obj-typed in this region (e.g. ``(car (cons 'foo nil))``
+        where the car flows to another obj op), store the ref
+        directly into the obj slot.  If int-typed (the common
+        list-of-ints case), unwrap via
+        ``Integer.intValue() int`` after a checkcast to Integer.
+        """
         if len(instruction.operands) != 2:
             raise JvmBackendError(
                 f"CAR expects 2 operands (dst, src), got "
@@ -1322,10 +1347,27 @@ class _JvmClassLowerer:
         )
         builder.emit_u2_instruction(
             _OP_GETFIELD,
-            self.cp.field_ref(CONS_BINARY_NAME, "head", _DESC_INT),
+            self.cp.field_ref(CONS_BINARY_NAME, "head", _DESC_OBJECT),
         )
-        # Stack: [int] → __ca_regs[dst] via _emit_intreg_store_top_int.
-        self._emit_intreg_store_top_int(builder, dst.index)
+        # Stack: [Object head]
+        if dst.index in self._region_obj_regs:
+            # Direct obj store — head was an obj ref (cons / symbol /
+            # nil / closure).  No unwrap needed.
+            self._emit_objreg_store_top_ref(builder, dst.index)
+        else:
+            # head is a boxed Integer (or unsafe int read of a
+            # non-int head — well-formed Twig avoids this).  Cast
+            # and unwrap.
+            builder.emit_u2_instruction(
+                _OP_CHECKCAST, self.cp.class_ref("java/lang/Integer"),
+            )
+            builder.emit_u2_instruction(
+                _OP_INVOKEVIRTUAL,
+                self.cp.method_ref(
+                    "java/lang/Integer", "intValue", "()I",
+                ),
+            )
+            self._emit_intreg_store_top_int(builder, dst.index)
 
     def _emit_cdr(
         self, builder: _BytecodeBuilder, instruction: IrInstruction,
@@ -2911,20 +2953,23 @@ def build_closure_subclass_artifact(
 #   - Tests can assert on byte-stable class layouts.
 
 def build_cons_class_artifact() -> JVMClassArtifact:
-    """Return the ``Cons`` class — pair of ``(int head, Object tail)``.
+    """Return the ``Cons`` class — heterogeneous pair of ``(Object head,
+    Object tail)``.
 
-    Phase 3b v1 design: ``head`` is typed ``int`` and ``tail`` is typed
-    ``Object``.  Matches the spec acceptance criterion (list-of-ints
-    terminated by ``Nil.INSTANCE``); a follow-up phase widens ``head``
-    once typed-register inference covers cons head slots.
+    Heterogeneous-cons follow-up: ``head`` is now typed ``Object``
+    (was ``int``) so cons cells can hold ANY Twig value — int
+    (boxed via ``Integer.valueOf`` at MAKE_CONS), symbol, another
+    cons, closure, nil.  This unblocks list-of-symbols, AST-shaped
+    data, and other heterogeneous heap structures that a real Lisp
+    program needs.
 
     Class layout::
 
         public final class Cons {
-            public final int head;
+            public final Object head;
             public final Object tail;
 
-            public Cons(int head, Object tail) {
+            public Cons(Object head, Object tail) {
                 super();
                 this.head = head;
                 this.tail = tail;
@@ -2932,8 +2977,8 @@ def build_cons_class_artifact() -> JVMClassArtifact:
         }
 
     No ``Nil``-injection at allocation time: it's the caller's job
-    (the lowering site) to ensure the tail is either another ``Cons``
-    or ``Nil.INSTANCE``.
+    (the lowering site) to ensure the tail is either another
+    ``Cons`` / ``Nil.INSTANCE`` / ``Symbol`` / etc.  Same for head.
     """
     pool = _ConstantPoolBuilder()
     this_class_index = pool.class_ref(CONS_BINARY_NAME)
@@ -2941,10 +2986,10 @@ def build_cons_class_artifact() -> JVMClassArtifact:
     object_ctor_ref = pool.method_ref("java/lang/Object", "<init>", "()V")
 
     head_field_name = pool.utf8("head")
-    head_field_desc = pool.utf8(_DESC_INT)
+    head_field_desc = pool.utf8(_DESC_OBJECT)
     tail_field_name = pool.utf8("tail")
     tail_field_desc = pool.utf8(_DESC_OBJECT)
-    head_field_ref = pool.field_ref(CONS_BINARY_NAME, "head", _DESC_INT)
+    head_field_ref = pool.field_ref(CONS_BINARY_NAME, "head", _DESC_OBJECT)
     tail_field_ref = pool.field_ref(CONS_BINARY_NAME, "tail", _DESC_OBJECT)
     code_attribute_name_index = pool.utf8("Code")
 
@@ -2953,14 +2998,14 @@ def build_cons_class_artifact() -> JVMClassArtifact:
     ctor_builder.emit_opcode(_OP_ALOAD_0)
     ctor_builder.emit_u2_instruction(_OP_INVOKESPECIAL, object_ctor_ref)
     ctor_builder.emit_opcode(_OP_ALOAD_0)
-    ctor_builder.emit_opcode(_OP_ILOAD_0 + 1)  # iload_1 — head arg
+    ctor_builder.emit_opcode(_OP_ALOAD_1)  # head: Object arg in slot 1
     ctor_builder.emit_u2_instruction(_OP_PUTFIELD, head_field_ref)
     ctor_builder.emit_opcode(_OP_ALOAD_0)
-    ctor_builder.emit_opcode(_OP_ALOAD_2)
+    ctor_builder.emit_opcode(_OP_ALOAD_2)  # tail: Object arg in slot 2
     ctor_builder.emit_u2_instruction(_OP_PUTFIELD, tail_field_ref)
     ctor_builder.emit_opcode(_OP_RETURN)
     ctor_code = ctor_builder.assemble()
-    ctor_descriptor = "(I" + _DESC_OBJECT + ")V"
+    ctor_descriptor = "(" + _DESC_OBJECT + _DESC_OBJECT + ")V"
     ctor_name_index = pool.utf8("<init>")
     ctor_descriptor_index = pool.utf8(ctor_descriptor)
 

--- a/code/packages/python/ir-to-jvm-class-file/tests/test_ir_to_jvm_class_file.py
+++ b/code/packages/python/ir-to-jvm-class-file/tests/test_ir_to_jvm_class_file.py
@@ -1458,9 +1458,10 @@ class TestHeapRuntimeClasses:
         artifact = build_cons_class_artifact()
         assert artifact.class_name == CONS_BINARY_NAME.replace("/", ".")
         cf = parse_class_file(artifact.class_bytes)
-        # Single ctor (I,LObject;)V.
+        # Heterogeneous-cons: head is now Object-typed (was int) so
+        # cons cells can hold any Twig value.  Ctor takes two Objects.
         method_descriptors = [m.descriptor for m in cf.methods]
-        assert "(ILjava/lang/Object;)V" in method_descriptors
+        assert "(Ljava/lang/Object;Ljava/lang/Object;)V" in method_descriptors
         # Field-name UTF8 entries — head + tail.
         assert b"head" in artifact.class_bytes
         assert b"tail" in artifact.class_bytes

--- a/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
@@ -314,3 +314,35 @@ def test_heap_recursive_length_returns_3() -> None:
         assembly_name="ClrLength",
     )
     assert result.returncode == 3, result.stderr
+
+
+@requires_dotnet
+def test_heap_car_of_symbol_succeeds() -> None:
+    """``(symbol? (car (cons 'foo nil))) → 1``.
+
+    Heterogeneous-cons: head can hold a symbol (or any obj ref),
+    not just int.  Pre-fix, ``Cons.head`` was typed ``int32`` and
+    storing a Symbol ref into the int field truncated it; the
+    subsequent ``symbol?`` instanceof check failed.  Post-fix,
+    head is ``object``-typed.
+    """
+    result = run_source(
+        "(if (symbol? (car (cons (quote foo) nil))) 1 0)",
+        assembly_name="ClrCarSym",
+    )
+    assert result.returncode == 1, result.stderr
+
+
+@requires_dotnet
+def test_heap_car_of_nested_cons_succeeds() -> None:
+    """``(pair? (car (cons (cons 1 nil) nil))) → 1``.
+
+    Heterogeneous-cons: head can hold another cons cell.  This
+    is the canonical AST-shaped data pattern that any real Lisp
+    program (including a self-hosted compiler) needs.
+    """
+    result = run_source(
+        "(if (pair? (car (cons (cons 1 nil) nil))) 1 0)",
+        assembly_name="ClrCarPair",
+    )
+    assert result.returncode == 1, result.stderr

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -306,3 +306,38 @@ def test_heap_car_of_singleton_returns_int() -> None:
     assert result.returncode == 0, result.stderr
     # 42 = 0x2a = b'*'.
     assert result.stdout == b"*"
+
+
+@requires_java
+def test_heap_car_of_symbol_succeeds() -> None:
+    """``(symbol? (car (cons 'foo nil))) → 1``.
+
+    Heterogeneous-cons: head can hold a symbol (or any obj ref),
+    not just int.  Pre-fix, ``Cons.head`` was typed ``int`` and
+    storing a symbol ref into the int field truncated it to
+    garbage; the subsequent ``symbol?`` instanceof check failed.
+
+    Post-fix, head is ``Object``-typed.  MAKE_CONS detects the
+    head register's obj-typing in this region and stores the
+    Symbol ref directly; CAR's dst is obj-typed (because the
+    next op reads it as obj-source for IS_SYMBOL) so it's
+    loaded directly from the Object field.
+    """
+    src = "(if (symbol? (car (cons (quote foo) nil))) 1 0)"
+    result = run_source(src, class_name="TwCarSym")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([1])
+
+
+@requires_java
+def test_heap_car_of_nested_cons_succeeds() -> None:
+    """``(pair? (car (cons (cons 1 nil) nil))) → 1``.
+
+    Heterogeneous-cons: head can hold another cons cell.  This
+    is the canonical AST-shaped data pattern that any real Lisp
+    program (including a self-hosted compiler) needs.
+    """
+    src = "(if (pair? (car (cons (cons 1 nil) nil))) 1 0)"
+    result = run_source(src, class_name="TwCarPair")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([1])


### PR DESCRIPTION
## Summary

\`Cons.head\` is now typed \`Object\` on JVM and CLR (was \`int\`/\`int32\`), so cons cells can hold any Twig value:

\`\`\`scheme
(cons 1 nil)               ; int head — boxed to Integer
(cons 'foo nil)            ; symbol head
(cons (cons 1 nil) nil)    ; cons head (nested!)
(cons (lambda (x) x) nil)  ; closure head
\`\`\`

Unblocks AST-shaped data, list-of-symbols, and nested-cons patterns — every real Lisp program (including a self-hosted compiler) needs them.

BEAM was already heterogeneous (cons cells are native first-class BEAM terms), so no BEAM changes.

## Verified end-to-end

On both real \`java\` and real \`dotnet\`:
- \`(length (cons 1 (cons 2 (cons 3 nil)))) → 3\` (existing test, still passes)
- \`(sum (cons 10 (cons 20 (cons 30 nil)))) → 60\` (existing test)
- \`(symbol? (car (cons 'foo nil))) → 1\` (new)
- \`(pair? (car (cons (cons 1 nil) nil))) → 1\` (new)

## JVM lowering (ir-to-jvm-class-file v0.14.0)

- \`Cons\` class: \`Object head; Object tail\` — ctor signature \`(LObject;LObject;)V\`
- MAKE_CONS: head obj-typed → ldload obj slot directly; head int-typed → ldload int and box via \`Integer.valueOf(int) Integer\`
- CAR: read Object head; dst obj-typed → stloc obj; dst int-typed → \`checkcast Integer; invokevirtual Integer.intValue()\`

## CLR lowering (ir-to-cil-bytecode v0.10.0)

- \`Cons\` class: \`object head; object tail\` — ctor signature \`(object, object)\`
- MAKE_CONS: head obj-typed → ldloc obj; int-typed → ldloc int + \`box [System.Int32]\` (reuses TypeRef added in cli-assembly-writer v0.4.0)
- CAR: ldfld Object head; dst obj-typed → stloc obj; int-typed → \`unbox.any [System.Int32]\`

## Test plan

- [x] All 113 ir-to-jvm-class-file tests pass (92% coverage)
- [x] All 97 ir-to-cil-bytecode tests pass (91% coverage)
- [x] All 51 twig-jvm-compiler tests pass (2 new heterogeneous tests)
- [x] All 68 twig-clr-compiler tests pass (2 new heterogeneous tests)

## Pending JVM/CLR issues found while surveying

While testing for this PR, found that **multi-arity closures** are broken on JVM and CLR:
- JVM: \`((mk) 7 35)\` returns 7 — silently drops 2nd arg
- CLR: hard-coded arity-1 limit raises \`CILBackendError\`
- BEAM: works fine

Will address in a follow-up PR (this PR stays scoped to heterogeneous cons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)