### PR TITLE
Report attributes on HTML end tags

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -457,6 +457,9 @@ id = "tag_name"
 id = "end_tag_name"
 
 [[states]]
+id = "end_tag_attributes"
+
+[[states]]
 id = "before_attribute_name"
 
 [[states]]
@@ -6999,8 +7002,30 @@ actions = [
 [[transitions]]
 from = "before_end_tag_close"
 matcher = { anything = true }
-to = "before_end_tag_close"
-actions = ["parse_error(unexpected-character-after-end-tag-name)"]
+to = "end_tag_attributes"
+actions = ["parse_error(end-tag-with-attributes)"]
+
+[[transitions]]
+from = "end_tag_attributes"
+matcher = { literal = ">" }
+to = "data"
+actions = ["emit_current_token"]
+
+[[transitions]]
+from = "end_tag_attributes"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(eof-in-end-tag-name-state)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "end_tag_attributes"
+matcher = { anything = true }
+to = "end_tag_attributes"
 
 [[transitions]]
 from = "end_tag_name"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -891,6 +891,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             external_entry: false,
         },
         StateDefinition {
+            id: "end_tag_attributes".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
             id: "end_tag_name".to_string(),
             initial: false,
             accepting: false,
@@ -14609,14 +14616,59 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "before_end_tag_close".to_string(),
+                "end_tag_attributes".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "parse_error(unexpected-character-after-end-tag-name)".to_string(),
+                "parse_error(end-tag-with-attributes)".to_string(),
             ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "end_tag_attributes".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal(">".to_string())),
+            to: vec![
+                "data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "emit_current_token".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "end_tag_attributes".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(eof-in-end-tag-name-state)".to_string(),
+                "emit_current_token".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "end_tag_attributes".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "end_tag_attributes".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
             consume: true,
         },
         TransitionDefinition {

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -786,6 +786,38 @@ fn default_html_lexer_recovers_end_tag_with_trailing_solidus() {
 }
 
 #[test]
+fn default_html_lexer_recovers_end_tag_with_attributes() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before</p class=x data-y>After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"));
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "end-tag-with-attributes")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn default_html_lexer_recovers_abrupt_empty_html_comment() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- add an end-tag attribute recovery state for ordinary data-state end tags
- report `end-tag-with-attributes` once for ignored attribute text while still emitting the end tag
- regenerate the static Rust HTML1 lexer and add regression coverage

## Verification
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test`
- `cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml html1_toml_compiles_to_rust_source`
- `cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml`