### PR TITLE
feat(jvm,clr): multi-arity closures end-to-end

### DIFF
--- a/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.11.0 — 2026-04-29 — multi-arity closures (IClosure.Apply takes int32[])
+
+`IClosure.Apply` now takes `int32[]` (was `int32`) so closures
+of any arity share a single uniform call site.  The arity-1 hard
+limit on `APPLY_CLOSURE` is gone.
+
+### Interface signature change
+
+```csharp
+interface IClosure {
+    object Apply(int32[] args);   // was: object Apply(int32 arg)
+}
+```
+
+### Closure subclass prologue
+
+The Apply prologue now extracts each explicit arg from the
+`int32[]` parameter via `ldarg.1; ldc.i4 i; ldelem.i4` and stores
+into the captures-first slot `r{2 + num_free + i}`.  Per-closure
+explicit arity comes from `CILBackendConfig.closure_explicit_arities`
+(defaults to 1 for back-compat).
+
+### APPLY_CLOSURE call site
+
+```cil
+ldloc closure
+ldc.i4 num_args                       ; size of args[]
+newarr [System.Runtime]System.Int32   ; allocate int32[num_args]
+; for each arg i:
+dup
+ldc.i4 i
+ldloc arg_i
+stelem.i4
+callvirt instance object IClosure::Apply(int32[])
+```
+
+### CILBackendConfig
+
+New field `closure_explicit_arities: dict[str, int]` parallel to
+the existing `closure_free_var_counts`.  `twig-clr-compiler`
+populates both from each lifted lambda's source-level param list.
+
+### Mirrors JVM `apply([I)I`
+
+The CLR `IClosure.Apply(int32[])` shape mirrors the JVM
+`Closure.apply([I)I` interface that ir-to-jvm-class-file already
+ships.  Both backends now accept any-arity closures from a single
+uniform call site.
+
 ## 0.10.0 — 2026-04-30 — heterogeneous cons cells (Cons.head widened to object)
 
 `Cons.head` is now typed `object` (was `int32`) so cons cells can

--- a/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
@@ -71,6 +71,10 @@ class CILBackendConfig:
     method_max_stack: int = 16
     call_register_count: int | None = 0
     closure_free_var_counts: dict[str, int] = field(default_factory=dict)
+    # Multi-arity follow-up: per-closure explicit arg count.
+    # Defaults to 1 for back-compat; the Twig CLR frontend
+    # populates it from each lambda's source-level param count.
+    closure_explicit_arities: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -1560,12 +1564,13 @@ class _RegionEmitContext:
 # the BEAM backend:
 #
 #   r2..r{1+num_free}                           — captures
-#   r{2+num_free}                               — explicit arg (arity-1)
+#   r{2+num_free}..r{1+num_free+explicit_arity} — explicit args
 #
 # The Apply method's prologue copies captures from instance fields
-# and the explicit arg from ldarg.1 into those slots so the rest of
-# the IR body's lowering works unmodified.
-_CLR_CLOSURE_EXPLICIT_ARITY: int = 1
+# and explicit args from the int32[] parameter (ldarg.1 + ldelem.i4)
+# into those slots so the rest of the IR body's lowering works
+# unmodified.  ``explicit_arity`` is per-closure, populated by the
+# Twig CLR frontend from each lambda's source-level param count.
 _REG_PARAM_BASE: int = 2
 
 
@@ -1610,9 +1615,19 @@ def _lower_closure_region(
         builder.emit_token_instruction(0x7B, field_token)  # ldfld
         builder.emit_stloc(_REG_PARAM_BASE + i)
 
-    # The single explicit arg (param 1) → r{2+num_free}.
-    builder.emit_ldarg(1)
-    builder.emit_stloc(_REG_PARAM_BASE + num_free)
+    # Multi-arity follow-up: explicit args arrive in an ``int32[]``
+    # parameter (ldarg.1).  Extract each arg via
+    # ``ldarg.1; ldc.i4 i; ldelem.i4`` and stloc into the
+    # captures-first slot ``r{2+num_free+i}``.  Per-closure arity
+    # comes from config.closure_explicit_arities (defaults to 1
+    # for back-compat with single-arg closures).
+    explicit_arity = config.closure_explicit_arities.get(region.name, 1)
+    for i in range(explicit_arity):
+        builder.emit_ldarg(1)            # int32[] args param
+        builder.emit_ldc_i4(i)           # index
+        # ldelem.i4 — opcode 0x94, no operand.
+        builder.emit_opcode(0x94)
+        builder.emit_stloc(_REG_PARAM_BASE + num_free + i)
 
     # Body emission.  RET at the end will use ctx.return_type to
     # pick int vs obj slot.  For obj-returning closures the body
@@ -1661,7 +1676,11 @@ def _lower_closure_region(
         max_stack=max(config.method_max_stack, 2),
         local_types=local_types,
         return_type="object",
-        parameter_types=("int32",),
+        # Multi-arity follow-up: parameter is now int32[] (was int32),
+        # matching the IClosure interface contract.  Closures of any
+        # arity share this single signature; the body's prologue
+        # extracts individual args via ldelem.i4.
+        parameter_types=("int32[]",),
         is_instance=True,
     )
 
@@ -1684,6 +1703,11 @@ def _build_closure_extra_types(
     # obj-returning closures return the ref directly, and
     # APPLY_CLOSURE callers unbox.any back to int32 when the dst
     # register is int-typed.
+    # Multi-arity follow-up: IClosure.Apply takes ``int32[]`` (was
+    # ``int32``) so closures of any arity share a single uniform
+    # call site.  The closure subclass's Apply prologue extracts
+    # individual args via ``ldelem.i4`` indexed loads.  Mirrors
+    # JVM's IClosure.apply([I)I shape.
     iclosure = CILTypeArtifact(
         name="IClosure",
         namespace="CodingAdventures",
@@ -1696,7 +1720,7 @@ def _build_closure_extra_types(
                 max_stack=0,
                 local_types=(),
                 return_type="object",
-                parameter_types=("int32",),
+                parameter_types=("int32[]",),
                 is_instance=True,
                 is_abstract=True,
             ),
@@ -2145,11 +2169,24 @@ def _emit_instruction(
         return
 
     if instruction.opcode == IrOp.APPLY_CLOSURE:
-        # APPLY_CLOSURE dst, closure_reg, num_args, arg0
-        # → ldloc closure; ldloc arg0;
-        #   callvirt instance int32 IClosure::Apply(int32);
-        #   stloc dst
-        # v1 supports exactly arity-1.
+        # APPLY_CLOSURE dst, closure_reg, num_args, arg0, ...
+        # →
+        #   ldloc closure;
+        #   ldc.i4 num_args;
+        #   newarr [System.Int32];        // empty int32[num_args]
+        #   <for each arg i:>
+        #     dup;
+        #     ldc.i4 i;
+        #     ldloc arg_i;
+        #     stelem.i4;
+        #   callvirt instance object IClosure::Apply(int32[]);
+        #   <unbox.any/stloc-obj per dst typing>
+        #
+        # Multi-arity follow-up: the IClosure interface's Apply now
+        # takes ``int32[]`` so a single uniform call site supports
+        # any arity.  The closure subclass's prologue extracts each
+        # arg via ``ldelem.i4``.  Mirrors JVM's
+        # ``Closure.apply([I)I`` shape.
         if len(instruction.operands) < 3:
             msg = (
                 f"APPLY_CLOSURE expects at least 3 operands "
@@ -2164,24 +2201,19 @@ def _emit_instruction(
         num_args = _as_immediate(
             instruction.operands[2], "APPLY_CLOSURE num_args"
         ).value
-        if num_args != _CLR_CLOSURE_EXPLICIT_ARITY:
-            msg = (
-                f"APPLY_CLOSURE: V1 CLR backend only supports "
-                f"arity-{_CLR_CLOSURE_EXPLICIT_ARITY} closures, got "
-                f"num_args={num_args}.  Multi-arity closures land in a "
-                "later phase."
-            )
-            raise CILBackendError(msg)
         if len(instruction.operands) != 3 + num_args:
             msg = (
                 f"APPLY_CLOSURE: num_args={num_args} but "
                 f"{len(instruction.operands) - 3} arg operands provided"
             )
             raise CILBackendError(msg)
-        arg_reg = _as_register(instruction.operands[3], "APPLY_CLOSURE arg 0")
+        arg_regs = [
+            _as_register(instruction.operands[3 + i], f"APPLY_CLOSURE arg {i}")
+            for i in range(num_args)
+        ]
 
         # Phase 2c.5: closure_reg is an object-typed register —
-        # read it from the obj slot.  arg_reg is int32.
+        # read it from the obj slot.  arg regs are int32.
         # TW03 Phase 3 follow-up: IClosure.Apply now returns
         # ``object`` (was int32) so closure-returning closures can
         # carry their inner ref through the call.  The caller picks
@@ -2197,7 +2229,20 @@ def _emit_instruction(
             builder.emit_ldloc(ctx.obj_local_for[closure_reg.index])
         else:
             builder.emit_ldloc(closure_reg.index)
-        builder.emit_ldloc(arg_reg.index)
+        # Build int32[num_args] and populate it via dup/stelem.i4.
+        # CIL opcodes:
+        #   0x8D  newarr <type_token>   — pops int length, pushes T[]
+        #   0x25  dup                   — duplicates top stack entry
+        #   0x9E  stelem.i4             — pops (array, index, int)
+        builder.emit_ldc_i4(num_args)
+        builder.emit_token_instruction(
+            0x8D, plan.token_provider.system_int32_typeref_token(),
+        )
+        for i, arg_reg in enumerate(arg_regs):
+            builder.emit_opcode(0x25)            # dup (the array ref)
+            builder.emit_ldc_i4(i)               # index
+            builder.emit_ldloc(arg_reg.index)    # arg value (int32)
+            builder.emit_opcode(0x9E)            # stelem.i4
         builder.emit_callvirt(plan.token_provider.iclosure_apply_token())
         # Stack now: [object]
         #

--- a/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
@@ -873,8 +873,12 @@ class TestClosureLoweringStructure:
         # TW03 Phase 3 follow-up: Apply now returns ``object`` (was
         # ``int32``) so closure-returning closures can carry their
         # inner closure ref through the call boundary.
+        # Multi-arity follow-up: Apply takes ``int32[]`` (was
+        # ``int32``) so closures of any arity share a single uniform
+        # call site.  The body's prologue extracts each arg via
+        # ``ldelem.i4``.
         assert apply.return_type == "object"
-        assert apply.parameter_types == ("int32",)
+        assert apply.parameter_types == ("int32[]",)
 
     def test_closure_class_has_field_per_capture(self) -> None:
         artifact = lower_ir_to_cil_bytecode(
@@ -908,8 +912,10 @@ class TestClosureLoweringStructure:
         # TW03 Phase 3 follow-up: Apply now returns ``object`` (was
         # ``int32``) so closure-returning closures can carry their
         # inner closure ref through the call boundary.
+        # Multi-arity follow-up: Apply takes ``int32[]`` (was
+        # ``int32``).
         assert apply.return_type == "object"
-        assert apply.parameter_types == ("int32",)
+        assert apply.parameter_types == ("int32[]",)
 
     def test_lambda_region_omitted_from_main_methods(self) -> None:
         artifact = lower_ir_to_cil_bytecode(
@@ -941,8 +947,13 @@ class TestClosureLoweringStructure:
             "APPLY_CLOSURE should emit callvirt"
         )
 
-    def test_closure_arity_other_than_one_rejected(self) -> None:
-        """V1 supports arity-1 closures only; arity-2 should error."""
+    def test_apply_closure_multi_arity_lowers_without_error(self) -> None:
+        """Multi-arity follow-up: APPLY_CLOSURE with arity > 1 now
+        lowers successfully (the arity-1 hard limit was removed when
+        IClosure.Apply was widened to take ``int32[]``).  The call
+        site builds an int32[] via ``newarr [System.Int32]`` and
+        populates each slot with ``dup; ldc.i4 i; ldloc; stelem.i4``.
+        """
         program = IrProgram(entry_label="Main")
         program.add_instruction(
             IrInstruction(IrOp.LABEL, [IrLabel("_lambda_0")])
@@ -965,18 +976,29 @@ class TestClosureLoweringStructure:
                 [
                     IrRegister(1),
                     IrRegister(1),
-                    IrImmediate(2),  # arity 2
+                    IrImmediate(2),  # arity 2 — previously rejected
                     IrRegister(2),
                     IrRegister(3),
                 ],
             )
         )
         program.add_instruction(IrInstruction(IrOp.RET, []))
-        with pytest.raises(CILBackendError, match=r"arity-1"):
-            lower_ir_to_cil_bytecode(
-                program,
-                CILBackendConfig(closure_free_var_counts={"_lambda_0": 0}),
-            )
+        artifact = lower_ir_to_cil_bytecode(
+            program,
+            CILBackendConfig(
+                closure_free_var_counts={"_lambda_0": 0},
+                closure_explicit_arities={"_lambda_0": 2},
+            ),
+        )
+        main = next(m for m in artifact.methods if m.name == "Main")
+        # newarr opcode = 0x8D; stelem.i4 = 0x9E.  Both must appear
+        # in the APPLY_CLOSURE call-site sequence.
+        assert 0x8D in main.body, (
+            "APPLY_CLOSURE should emit newarr to build int32[]"
+        )
+        assert 0x9E in main.body, (
+            "APPLY_CLOSURE should emit stelem.i4 to populate args"
+        )
 
     def test_closure_free_var_counts_unknown_region_rejected(self) -> None:
         program = IrProgram(entry_label="Main")

--- a/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/python/ir-to-jvm-class-file/CHANGELOG.md
@@ -1,5 +1,34 @@
 # ir-to-jvm-class-file
 
+## 0.15.0 — 2026-04-29 — multi-arity closures (per-region explicit_arity)
+
+The lifted-lambda emission and per-closure subclass `apply([I)I`
+forwarder now honour each closure's explicit arity (was
+hard-coded arity 1 with a `_CLR_CLOSURE_EXPLICIT_ARITY` constant).
+
+### What changed
+
+* `JvmBackendConfig.closure_explicit_arities: dict[str, int]` — new
+  field, parallel to `closure_free_var_counts`.  Maps lifted lambda
+  region name → number of source-level explicit args (NOT counting
+  captures).  Defaults to 1 per region for back-compat.
+* `_build_lifted_lambda_method` reads `explicit_arity` from config
+  and emits the static method with `num_free + explicit_arity` int
+  params.
+* `build_closure_subclass_artifact(..., explicit_arity=1)` — new
+  kwarg.  The `apply([I)I` body's prologue forwards `args[0..n-1]`
+  for `n = explicit_arity` and `invokestatic`s the lifted lambda's
+  static method with the matching descriptor.
+* `lower_ir_to_jvm_classes` plumbs each closure's arity through to
+  `build_closure_subclass_artifact` from
+  `config.closure_explicit_arities`.
+
+### Frontend wiring
+
+`twig-jvm-compiler` now records each lifted lambda's source-level
+param count in `closure_explicit_arities` so multi-arg lambdas like
+`(lambda (x y) (+ x y))` no longer silently drop the second arg.
+
 ## 0.14.0 — 2026-04-30 — heterogeneous cons cells (Cons.head widened to Object)
 
 `Cons.head` is now typed `Object` (was `int`) so cons cells can

--- a/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
+++ b/code/packages/python/ir-to-jvm-class-file/src/ir_to_jvm_class_file/backend.py
@@ -169,6 +169,13 @@ class JvmBackendConfig:
     emit_main_wrapper: bool = True
     syscall_arg_reg: int = 4  # register holding the SYSCALL print/read argument (Brainfuck=4, BASIC=0)
     closure_free_var_counts: dict[str, int] = field(default_factory=dict)
+    # Multi-arity follow-up: per-closure explicit-arg count (the
+    # number of params the lambda's source declared, NOT counting
+    # captures).  Defaults to 1 per region for back-compat with
+    # existing callers that emit only single-arg closures.  The
+    # Twig compiler frontend populates this from each lambda's
+    # param list so multi-arity ``(lambda (x y) (+ x y))`` works.
+    closure_explicit_arities: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -1849,7 +1856,14 @@ class _JvmClassLowerer:
            the static array via the ``__ca_regGet`` / ``__ca_regSet``
            helpers — runs unchanged.
         """
-        explicit_arity = _CLR_CLOSURE_EXPLICIT_ARITY  # currently 1
+        # Per-closure explicit arity (number of explicit params the
+        # source-level lambda declared, not counting captures).
+        # Defaults to 1 for back-compat; the Twig frontend
+        # populates ``closure_explicit_arities`` for multi-arity
+        # lambdas like ``(lambda (x y) (+ x y))``.
+        explicit_arity = self.config.closure_explicit_arities.get(
+            region.name, _CLR_CLOSURE_EXPLICIT_ARITY,
+        )
         total_arity = num_free + explicit_arity
 
         builder = _BytecodeBuilder()
@@ -2727,11 +2741,17 @@ def lower_ir_to_jvm_classes(
 
     main_binary_name = config.class_name.replace(".", "/")
     for closure_name, num_free in config.closure_free_var_counts.items():
+        # Pass through per-closure explicit arity so the subclass's
+        # Apply forwards the right number of explicit args from
+        # the int[] parameter to the lifted lambda's static method.
+        # Defaults to 1 for back-compat.
+        explicit_arity = config.closure_explicit_arities.get(closure_name, 1)
         classes.append(
             build_closure_subclass_artifact(
                 closure_name,
                 num_free=num_free,
                 main_class_binary_name=main_binary_name,
+                explicit_arity=explicit_arity,
             )
         )
 

--- a/code/packages/python/twig-clr-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-clr-compiler/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — twig-clr-compiler
 
+## 0.6.0 — 2026-04-29 — multi-arity closures
+
+Multi-arg lambdas like `(lambda (x y) (+ x y))` now run on real
+`dotnet`.  Pre-fix, the CLR backend hard-rejected `APPLY_CLOSURE`
+with arity != 1 and `IClosure.Apply` took a single `int32`.
+
+Frontend now records each lifted lambda's source-level param
+count in `closure_explicit_arities` (parallel to
+`closure_free_var_counts`).  Combined with `ir-to-cil-bytecode`
+0.11.0's widened `IClosure.Apply(int32[])` interface, closures of
+any arity share a single uniform call site.
+
+### Acceptance
+
+* `((lambda (x y) (+ x y)) 4 5) → 9`
+* `((lambda (a b c) (+ a (+ b c))) 1 2 3) → 6`
+* `((make-add-pair 10) 4 5) → 19`  (capture + 2 explicit args)
+
+All on real `dotnet`.
+
 ## 0.5.0 — 2026-04-30 — closure-returning closures (3-deep curry)
 
 Closure-returning closures now run end-to-end on real `dotnet`:

--- a/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
+++ b/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
@@ -725,9 +725,20 @@ def compile_source(
     # emission.  ir-to-cil-bytecode uses this to detect closure
     # regions and emit them as ``Apply`` methods on the
     # auto-generated ``Closure_<name>`` TypeDefs.
+    #
+    # Multi-arity follow-up: also record each lambda's explicit
+    # arity (its source-level param count, NOT counting captures)
+    # so the backend's IClosure.Apply prologue extracts the right
+    # number of int args from the int32[] parameter.  Without
+    # this, every closure body would be treated as arity-1 and
+    # multi-arg lambdas like ``(lambda (x y) (+ x y))`` would
+    # silently drop the second arg (arity-1 hard limit removed
+    # in the same change).
     closure_free_var_counts: dict[str, int] = {}
-    for lifted_name, captures, _lam in compiler._lifted_lambdas:  # noqa: SLF001
+    closure_explicit_arities: dict[str, int] = {}
+    for lifted_name, captures, lam in compiler._lifted_lambdas:  # noqa: SLF001
         closure_free_var_counts[lifted_name] = len(captures)
+        closure_explicit_arities[lifted_name] = len(lam.params)
 
     try:
         # ``call_register_count=None`` tells the CIL backend to
@@ -743,6 +754,7 @@ def compile_source(
             CILBackendConfig(
                 call_register_count=None,
                 closure_free_var_counts=closure_free_var_counts,
+                closure_explicit_arities=closure_explicit_arities,
             ),
         )
     except Exception as exc:

--- a/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_real_dotnet.py
@@ -346,3 +346,55 @@ def test_heap_car_of_nested_cons_succeeds() -> None:
         assembly_name="ClrCarPair",
     )
     assert result.returncode == 1, result.stderr
+
+
+# ── Multi-arity closures ─────────────────────────────────────────────────
+
+
+@requires_dotnet
+def test_two_arg_lambda() -> None:
+    """``((lambda (x y) (+ x y)) 4 5) → 9``.
+
+    Multi-arity follow-up: pre-fix, the CLR backend hard-rejected
+    APPLY_CLOSURE with arity != 1, and IClosure.Apply took a
+    single ``int32``.  Post-fix, IClosure.Apply takes ``int32[]``,
+    closures of any arity share the same call site, and the Twig
+    frontend records each lambda's arity so the prologue
+    extracts the right number of args via ``ldelem.i4``.
+    """
+    result = run_source(
+        "((lambda (x y) (+ x y)) 4 5)",
+        assembly_name="ClrTwoArgLam",
+    )
+    assert result.returncode == 9, result.stderr
+
+
+@requires_dotnet
+def test_three_arg_lambda() -> None:
+    """``((lambda (a b c) (+ a (+ b c))) 1 2 3) → 6``."""
+    result = run_source(
+        "((lambda (a b c) (+ a (+ b c))) 1 2 3)",
+        assembly_name="ClrThreeArgLam",
+    )
+    assert result.returncode == 6, result.stderr
+
+
+@requires_dotnet
+def test_two_arg_lambda_with_capture() -> None:
+    """``((make-add-pair 10) 4 5) → 19`` — capture + 2 explicit args.
+
+    Stresses both axes of the closure layout: ``num_free=1`` for
+    the captured ``base`` and ``explicit_arity=2`` for ``(x y)``.
+    The closure subclass's prologue copies ``base`` from
+    ``capt0``, then loads ``args[0]``/``args[1]`` into the
+    explicit-arg slots.
+    """
+    result = run_source(
+        """
+        (define (make-add-pair base)
+          (lambda (x y) (+ base (+ x y))))
+        ((make-add-pair 10) 4 5)
+        """,
+        assembly_name="ClrAddPair",
+    )
+    assert result.returncode == 19, result.stderr

--- a/code/packages/python/twig-jvm-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-jvm-compiler/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — twig-jvm-compiler
 
+## [0.6.0] — 2026-04-29 — multi-arity closures
+
+Multi-arg lambdas like `(lambda (x y) (+ x y))` now run on real
+`java`.  Pre-fix, every closure was silently treated as arity-1:
+the closure subclass's `apply([I)I` only forwarded `args[0]` and
+the lifted lambda's static method was emitted with
+`num_free + 1` int params, dropping every arg past the first.
+
+Frontend now records each lifted lambda's source-level param
+count in `closure_explicit_arities` (parallel to
+`closure_free_var_counts`) so the JVM backend's lifted-lambda
+emission and per-closure `apply` forwarder reserve the right
+number of int slots.
+
+### Acceptance
+
+* `((lambda (x y) (+ x y)) 4 5) → 9`
+* `((lambda (a b c) (+ a (+ b c))) 1 2 3) → 6`
+* `((make-add-pair 10) 4 5) → 19`  (capture + 2 explicit args)
+
+All on real `java`.
+
 ## [0.5.0] — 2026-04-30 — mutual recursion + let-bound-twice + 3-deep curry
 
 Three cross-region bug fixes that bring more Twig source patterns

--- a/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
+++ b/code/packages/python/twig-jvm-compiler/src/twig_jvm_compiler/compiler.py
@@ -806,14 +806,25 @@ def compile_source(
     # ir-to-jvm-class-file uses this to detect closure regions and
     # auto-generate the ``Closure`` interface + per-lambda
     # ``Closure_<name>`` subclasses.
+    #
+    # Multi-arity follow-up: also record each lambda's explicit
+    # arity (its source-level param count, NOT counting captures)
+    # so the backend's lifted-lambda emission and the closure
+    # subclass's ``Apply`` forwarder reserve the right number of
+    # int-arg slots.  Without this every lambda would be treated
+    # as arity-1 — multi-arg lambdas like ``(lambda (x y) (+ x y))``
+    # would silently drop the second arg.
     closure_free_var_counts: dict[str, int] = {}
-    for lifted_name, captures, _lam in compiler._lifted_lambdas:  # noqa: SLF001
+    closure_explicit_arities: dict[str, int] = {}
+    for lifted_name, captures, lam in compiler._lifted_lambdas:  # noqa: SLF001
         closure_free_var_counts[lifted_name] = len(captures)
+        closure_explicit_arities[lifted_name] = len(lam.params)
 
     config = JvmBackendConfig(
         class_name=class_name,
         emit_main_wrapper=True,
         closure_free_var_counts=closure_free_var_counts,
+        closure_explicit_arities=closure_explicit_arities,
     )
 
     # TW03 Phase 3e: heap-primitive programs also need the multi-class

--- a/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
+++ b/code/packages/python/twig-jvm-compiler/tests/test_real_jvm.py
@@ -341,3 +341,52 @@ def test_heap_car_of_nested_cons_succeeds() -> None:
     result = run_source(src, class_name="TwCarPair")
     assert result.returncode == 0, result.stderr
     assert result.stdout == bytes([1])
+
+
+# ── Multi-arity closures ─────────────────────────────────────────────────
+
+@requires_java
+def test_two_arg_lambda() -> None:
+    """``((lambda (x y) (+ x y)) 4 5) → 9``.
+
+    Multi-arity follow-up: pre-fix, every closure was treated as
+    arity-1 — the second arg was silently dropped because the
+    closure subclass's ``apply([I)I`` only forwarded ``args[0]``
+    and the lifted lambda's static method was emitted with
+    ``num_free + 1`` int slots.  Now the Twig frontend records
+    each lambda's source-level arity in ``closure_explicit_arities``
+    and the backend forwards all explicit args via ``args[i]``.
+    """
+    src = "((lambda (x y) (+ x y)) 4 5)"
+    result = run_source(src, class_name="TwTwoArgLam")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([9])
+
+
+@requires_java
+def test_three_arg_lambda() -> None:
+    """``((lambda (a b c) (+ a (+ b c))) 1 2 3) → 6``."""
+    src = "((lambda (a b c) (+ a (+ b c))) 1 2 3)"
+    result = run_source(src, class_name="TwThreeArgLam")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([6])
+
+
+@requires_java
+def test_two_arg_lambda_with_capture() -> None:
+    """``((make-add-pair 10) 4 5) → 19`` — capture + 2 explicit args.
+
+    Stresses both axes of the closure layout: ``num_free=1`` for
+    the captured ``base`` and ``explicit_arity=2`` for ``(x y)``.
+    The lifted lambda's static method takes 3 int params
+    ``(base, x, y)``; the closure subclass's apply forwards
+    ``capt0, args[0], args[1]``.
+    """
+    src = """
+        (define (make-add-pair base)
+          (lambda (x y) (+ base (+ x y))))
+        ((make-add-pair 10) 4 5)
+    """
+    result = run_source(src, class_name="TwAddPair")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == bytes([19])


### PR DESCRIPTION
## Summary
- Multi-arg lambdas like `(lambda (x y) (+ x y))` now run on real `java` and real `dotnet`.  Pre-fix, JVM silently dropped args past the first; CLR raised an arity-1 hard-limit error.
- CLR `IClosure.Apply` widened from `object Apply(int32)` to `object Apply(int32[])`; `APPLY_CLOSURE` builds an `int32[]` via `newarr [System.Int32]` + `dup`/`stelem.i4` and the closure prologue extracts each arg via `ldelem.i4`.
- JVM `_build_lifted_lambda_method` and `build_closure_subclass_artifact` now honour a per-closure `explicit_arity`, populated by both Twig frontends from each lifted lambda's source-level param count.

## Test plan
- [x] `ir-to-cil-bytecode` unit tests (97 passed) — incl. updated `test_apply_closure_multi_arity_lowers_without_error` and `parameter_types == ("int32[]",)` assertions
- [x] `ir-to-jvm-class-file` unit tests (113 passed)
- [x] `twig-jvm-compiler` end-to-end on real `java` (54 passed) — incl. new `test_two_arg_lambda`, `test_three_arg_lambda`, `test_two_arg_lambda_with_capture`
- [x] `twig-clr-compiler` end-to-end on real `dotnet` (71 passed) — same three new multi-arity tests
- [x] All pre-existing closure / recursion / mutual-recursion / 3-deep curry / let-bound-twice / heap-primitive tests still pass — back-compat preserved by `explicit_arity=1` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)