### PR TITLE
feat(prolog): qualify apply family closures

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -7,6 +7,9 @@
 - preserve extra arguments while rewriting module-qualified `call/N` meta-goals
 - rewrite module-qualified callable arguments inside `findall/3`, `bagof/3`,
   `setof/3`, and `forall/2`
+- rewrite module-qualified and imported apply-family closures for `maplist/N`,
+  `convlist/3`, `include/3`, `exclude/3`, `partition/4`, `foldl/N`, and
+  `scanl/N`
 - expose `rewrite_loaded_prolog_query(...)` for ad-hoc queries that need a
   linked project's module/import context
 - adapt Prolog `->/2` and `(If -> Then ; Else)` control constructs into the

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -22,8 +22,8 @@ It keeps parsing side-effect free, then exposes helpers to:
 - link multiple loaded sources into one namespace-aware runnable project with
   module-local predicates and weak imports
 - rewrite explicit `module:goal` qualification during linking, including common
-  meta-goal forms like `call/1..8`, `once/1`, `not/1`, `\\+/1`, and
-  `phrase/2,3`
+  meta-goal forms like `call/1..8`, apply-family closures, `once/1`, `not/1`,
+  `\\+/1`, and `phrase/2,3`
 - adapt Prolog control constructs such as `->/2` and
   `(If -> Then ; Else)` into executable builtin goals
 - adapt common list predicates such as `member/2`, `append/3`, `select/3`,

--- a/code/packages/python/prolog-loader/src/prolog_loader/loader.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/loader.py
@@ -68,6 +68,13 @@ _FINDALL = sym("findall")
 _BAGOF = sym("bagof")
 _SETOF = sym("setof")
 _FORALL = sym("forall")
+_MAPLIST = sym("maplist")
+_CONVLIST = sym("convlist")
+_INCLUDE = sym("include")
+_EXCLUDE = sym("exclude")
+_PARTITION = sym("partition")
+_FOLDL = sym("foldl")
+_SCANL = sym("scanl")
 
 
 class ParsedSourceLike(Protocol):
@@ -1407,6 +1414,22 @@ def _rewrite_goal_term(
             _rewrite_goal_term(term_value.args[0], resolver, module_resolvers),
         )
 
+    apply_extra_arity = _apply_family_closure_extra_arity(
+        term_value.functor,
+        len(term_value.args),
+    )
+    if apply_extra_arity is not None:
+        return term(
+            term_value.functor,
+            _rewrite_callable_closure(
+                term_value.args[0],
+                apply_extra_arity,
+                resolver,
+                module_resolvers,
+            ),
+            *term_value.args[1:],
+        )
+
     if term_value.functor == _ONCE and len(term_value.args) == 1:
         return term(
             term_value.functor,
@@ -1489,6 +1512,23 @@ def _rewrite_callable_closure(
         return term(resolved.symbol, *term_value.args)
 
     return term_value
+
+
+def _apply_family_closure_extra_arity(
+    functor: Symbol,
+    arity: int,
+) -> int | None:
+    if functor == _MAPLIST and 2 <= arity <= 5:
+        return arity - 1
+    if functor in {_INCLUDE, _EXCLUDE} and arity == 3:
+        return 1
+    if functor == _PARTITION and arity == 4:
+        return 1
+    if functor == _CONVLIST and arity == 3:
+        return 2
+    if functor in {_FOLDL, _SCANL} and 4 <= arity <= 7:
+        return arity - 1
+    return None
 
 
 def _callable_closure_arity(term_value: Term, extra_arity: int) -> int | None:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -553,6 +553,63 @@ class TestPrologLoader:
             atom("lisa"),
         ]
 
+    def test_module_qualification_rewrites_apply_family_closures(self) -> None:
+        project = load_swi_prolog_project(
+            """
+            :- module(apply_helpers, [
+                increment/2,
+                convert/2,
+                small/1,
+                pair_push/4,
+                push/3
+            ]).
+            increment(1, 2).
+            increment(2, 3).
+            convert(1, one).
+            convert(3, three).
+            small(1).
+            small(2).
+            pair_push(Left, Right, Acc, [pair(Left, Right)|Acc]).
+            push(Item, Acc, [Item|Acc]).
+            """,
+            """
+            :- module(app, []).
+            :- use_module(apply_helpers, [
+                increment/2,
+                convert/2,
+                small/1,
+                pair_push/4,
+                push/3
+            ]).
+            ?- maplist(increment, [1,2], Ys),
+               convlist(convert, [1,2,3], Converted),
+               include(small, [1,2,3], Small),
+               foldl(pair_push, [a,b], [x,y], [], Folded),
+               scanl(push, [a,b], [], Scanned).
+            """,
+        )
+        query = project.queries[0]
+
+        assert solve_all(
+            project.program,
+            (
+                query.variables["Ys"],
+                query.variables["Converted"],
+                query.variables["Small"],
+                query.variables["Folded"],
+                query.variables["Scanned"],
+            ),
+            adapt_prolog_goal(query.goal),
+        ) == [
+            (
+                logic_list([2, 3]),
+                logic_list(["one", "three"]),
+                logic_list([1, 2]),
+                logic_list([term("pair", "b", "y"), term("pair", "a", "x")]),
+                logic_list([logic_list(["a"]), logic_list(["b", "a"])]),
+            ),
+        ]
+
     def test_module_qualified_initialization_goals_execute(self) -> None:
         project = load_swi_prolog_project(
             """

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -30,6 +30,8 @@
 - Run common Prolog list predicates, including finite `length/2`, `sort/2`,
   `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`, through the VM path
   by adapting them to `logic-stdlib` relations.
+- Run module-imported apply-family closures through the VM path so higher-order
+  list predicates can target predicates from linked modules.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -209,6 +209,54 @@ class TestPrologVMStress:
             },
         ]
 
+    def test_module_qualified_apply_family_closures_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_project(
+            """
+            :- module(apply_helpers, [
+                increment/2,
+                convert/2,
+                small/1,
+                pair_push/4,
+                push/3
+            ]).
+            increment(1, 2).
+            increment(2, 3).
+            convert(1, one).
+            convert(3, three).
+            small(1).
+            small(2).
+            pair_push(Left, Right, Acc, [pair(Left, Right)|Acc]).
+            push(Item, Acc, [Item|Acc]).
+            """,
+            """
+            :- module(app, []).
+            :- use_module(apply_helpers, [
+                increment/2,
+                convert/2,
+                small/1,
+                pair_push/4,
+                push/3
+            ]).
+            ?- maplist(increment, [1,2], Ys),
+               convlist(convert, [1,2,3], Converted),
+               include(small, [1,2,3], Small),
+               foldl(pair_push, [a,b], [x,y], [], Folded),
+               scanl(push, [a,b], [], Scanned).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {
+                "Ys": logic_list([2, 3]),
+                "Converted": logic_list(["one", "three"]),
+                "Small": logic_list([1, 2]),
+                "Folded": logic_list([term("pair", "b", "y"), term("pair", "a", "x")]),
+                "Scanned": logic_list([logic_list(["a"]), logic_list(["b", "a"])]),
+            },
+        ]
+
     def test_list_stdlib_predicates_run_through_vm(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR41-prolog-module-apply-closures.md
+++ b/code/specs/PR41-prolog-module-apply-closures.md
@@ -1,0 +1,40 @@
+# PR41: Module-Aware Apply Closures
+
+This batch makes the higher-order apply-family predicates respect linked module
+imports before they reach the Logic VM.
+
+## Scope
+
+- Rewrite apply-family closure arguments during project linking using the same
+  resolver path already used by `call/N`.
+- Cover `maplist/2..5`, `convlist/3`, `include/3`, `exclude/3`,
+  `partition/4`, `foldl/4..7`, and `scanl/4..7`.
+- Preserve explicit `Module:Closure` handling and imported predicate handling.
+- Prove the behavior through loader tests and full parser -> loader -> compiler
+  -> Logic VM stress coverage.
+
+## Example
+
+```prolog
+:- module(apply_helpers, [increment/2, push/3]).
+increment(1, 2).
+increment(2, 3).
+push(Item, Acc, [Item|Acc]).
+```
+
+```prolog
+:- module(app, []).
+:- use_module(apply_helpers, [increment/2, push/3]).
+
+?- maplist(increment, [1,2], Ys),
+   scanl(push, [a,b], [], States).
+```
+
+The linker qualifies `increment/2` and `push/3` as imported closures before the
+query is adapted into executable builtin goals.
+
+## Non-goals
+
+- Full `meta_predicate/1` declaration parsing and validation.
+- Automatic import of arbitrary unexported predicates.
+- New apply-family predicates beyond the currently supported surface.


### PR DESCRIPTION
## Summary
- qualify imported/module-scoped apply-family closure arguments during Prolog project linking
- cover `maplist/2..5`, `convlist/3`, `include/3`, `exclude/3`, `partition/4`, `foldl/4..7`, and `scanl/4..7`
- add loader and Logic VM stress coverage plus PR41 spec docs

## Verification
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in touched Python packages
- `git diff --check`
- `/tmp/ca-build-tool-prolog-module-apply -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-module-apply-build-plan.json`