### PR TITLE
Recover spaced trailing solidus on HTML end tags

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -1605,6 +1605,11 @@ actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
 
 [[transitions]]
 from = "rcdata_end_tag_whitespace"
+matcher = { literal = "/" }
+to = "rcdata_self_closing_end_tag"
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -1651,6 +1656,11 @@ from = "rawtext_end_tag_whitespace"
 matcher = { literal = ">" }
 to = "rawtext"
 actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
+matcher = { literal = "/" }
+to = "rawtext_self_closing_end_tag"
 
 [[transitions]]
 from = "rawtext_end_tag_whitespace"
@@ -1703,6 +1713,11 @@ actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
 
 [[transitions]]
 from = "script_data_end_tag_whitespace"
+matcher = { literal = "/" }
+to = "script_data_self_closing_end_tag"
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
 matcher = { eof = true }
 to = "done"
 consume = false
@@ -1749,6 +1764,11 @@ from = "script_data_escaped_end_tag_whitespace"
 matcher = { literal = ">" }
 to = "script_data_escaped"
 actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = "/" }
+to = "script_data_escaped_self_closing_end_tag"
 
 [[transitions]]
 from = "script_data_escaped_end_tag_whitespace"
@@ -6998,6 +7018,12 @@ actions = [
   "emit_current_token",
   "emit(EOF)",
 ]
+
+[[transitions]]
+from = "before_end_tag_close"
+matcher = { literal = "/" }
+to = "before_end_tag_close"
+actions = ["parse_error(end-tag-with-trailing-solidus)"]
 
 [[transitions]]
 from = "before_end_tag_close"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -3663,6 +3663,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "rcdata_end_tag_whitespace".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("/".to_string())),
+            to: vec![
+                "rcdata_self_closing_end_tag".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
                 "done".to_string(),
@@ -3767,6 +3780,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
             ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("/".to_string())),
+            to: vec![
+                "rawtext_self_closing_end_tag".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
             consume: true,
         },
         TransitionDefinition {
@@ -3881,6 +3907,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_end_tag_whitespace".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("/".to_string())),
+            to: vec![
+                "script_data_self_closing_end_tag".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Eof),
             to: vec![
                 "done".to_string(),
@@ -3985,6 +4024,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "emit_rcdata_end_tag_with_whitespace_or_text".to_string(),
             ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("/".to_string())),
+            to: vec![
+                "script_data_escaped_self_closing_end_tag".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
             consume: true,
         },
         TransitionDefinition {
@@ -14610,6 +14662,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "before_end_tag_close".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("/".to_string())),
+            to: vec![
+                "before_end_tag_close".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(end-tag-with-trailing-solidus)".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "before_end_tag_close".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -786,6 +786,38 @@ fn default_html_lexer_recovers_end_tag_with_trailing_solidus() {
 }
 
 #[test]
+fn default_html_lexer_recovers_end_tag_with_whitespace_then_trailing_solidus() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before</p />After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"));
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "end-tag-with-trailing-solidus"));
+    assert!(!lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "end-tag-with-attributes"));
+}
+
+#[test]
 fn default_html_lexer_recovers_end_tag_with_attributes() {
     let mut lexer = create_html_lexer().unwrap();
 
@@ -1051,28 +1083,73 @@ fn default_html_lexer_recovers_seeded_text_mode_end_tags_with_trailing_solidus()
 }
 
 #[test]
+fn default_html_lexer_recovers_seeded_text_mode_end_tags_with_whitespace_then_trailing_solidus() {
+    for (initial_state, last_start_tag, text) in [
+        ("rcdata", "title", "Hello"),
+        ("rawtext", "style", "body {}"),
+        ("script_data", "script", "if (ready)"),
+        ("script_data_escaped", "script", "<!-- ok -->"),
+    ] {
+        let mut lexer = create_html_lexer().unwrap();
+        lexer.set_initial_state(initial_state).unwrap();
+        lexer.set_last_start_tag(last_start_tag);
+
+        lexer.push(&format!("{text}</{last_start_tag} />")).unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![
+                Token::Text(text.to_string()),
+                Token::EndTag {
+                    name: last_start_tag.to_string()
+                },
+                Token::Eof,
+            ],
+            "state {initial_state} should emit the appropriate end tag"
+        );
+        assert!(
+            lexer
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.code == "end-tag-with-trailing-solidus"),
+            "state {initial_state} should report trailing solidus recovery"
+        );
+        assert!(
+            !lexer
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.code == "end-tag-with-attributes"),
+            "state {initial_state} should not treat the solidus as attributes"
+        );
+    }
+}
+
+#[test]
 fn default_html_lexer_keeps_mismatched_text_mode_end_tag_solidus_literal() {
-    let mut lexer = create_html_lexer().unwrap();
-    lexer.set_initial_state("script_data").unwrap();
-    lexer.set_last_start_tag("script");
+    for close in ["</style/>", "</style />"] {
+        let mut lexer = create_html_lexer().unwrap();
+        lexer.set_initial_state("script_data").unwrap();
+        lexer.set_last_start_tag("script");
 
-    lexer.push("x</style/>y</script>").unwrap();
-    lexer.finish().unwrap();
+        lexer.push(&format!("x{close}y</script>")).unwrap();
+        lexer.finish().unwrap();
 
-    assert_eq!(
-        lexer.drain_tokens(),
-        vec![
-            Token::Text("x</style/>y".to_string()),
-            Token::EndTag {
-                name: "script".to_string()
-            },
-            Token::Eof,
-        ]
-    );
-    assert!(!lexer
-        .diagnostics()
-        .iter()
-        .any(|diagnostic| diagnostic.code == "end-tag-with-trailing-solidus"));
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![
+                Token::Text(format!("x{close}y")),
+                Token::EndTag {
+                    name: "script".to_string()
+                },
+                Token::Eof,
+            ]
+        );
+        assert!(!lexer
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.code == "end-tag-with-trailing-solidus"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- route slash after end-tag whitespace through trailing-solidus recovery instead of the ignored-attributes path
- extend the same recovery to seeded RCDATA, RAWTEXT, script data, and escaped script data end tags
- regenerate the statically linked Rust HTML1 lexer source and cover matching/mismatched text-mode behavior

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_recovers_end_tag_with_whitespace_then_trailing_solidus -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_recovers_seeded_text_mode_end_tags_with_whitespace_then_trailing_solidus -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_keeps_mismatched_text_mode_end_tag_solidus_literal -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml html1_toml_compiles_to_rust_source
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check