### PR TITLE
Short-circuit ALGOL boolean chains

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -49,6 +49,8 @@ All notable changes to this package will be documented in this file.
 - Lowered chained assignments, branch-selected conditional expressions, and
   ALGOL-left-associative exponentiation for numeric bases with integer or real
   exponents.
+- Lowered boolean `and`, `or`, and `impl` through short-circuiting control
+  flow while keeping `eqv` strict.
 - Lowered bare no-argument typed procedure names as expression calls, including
   use inside read-only by-name eval thunks.
 - Lowered integer `div` and `mod` zero-divisor checks through the existing

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -34,7 +34,9 @@ comparisons, chained assignment targets, branch-selected conditional
 expressions, and ALGOL-left-associative exponentiation. Integer exponents use
 the existing loop lowering, real bases with negative integer exponents use a
 reciprocal path, and real exponents lower through the imported real `pow`
-runtime with a domain-failure guard.
+runtime with a domain-failure guard. Boolean `and`, `or`, and `impl` lower
+through short-circuiting control flow; `eqv` remains strict and evaluates both
+operands.
 Standard numeric functions `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`,
 `arctan`, `ln`, and `exp` lower to existing integer/f64 comparison,
 arithmetic, conversion, native square-root IR, and imported standard real-math

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -2425,50 +2425,65 @@ class AlgolIrCompiler:
         index = 1
         while index < len(children):
             operator = children[index]
-            right = self._compile_expr(children[index + 1], scope)
             if not isinstance(operator, Token):
                 raise CompileError("expected boolean operator")
             value = operator.value
-            if value == "and":
-                dst = self._fresh_reg()
-                self._emit(
-                    IrOp.AND, IrRegister(dst), IrRegister(current), IrRegister(right)
+            right = children[index + 1]
+            if value in {"and", "or", "impl"}:
+                current = self._emit_short_circuit_bool(
+                    operator=value,
+                    left=current,
+                    right=right,
+                    scope=scope,
                 )
-                current = dst
-            elif value == "or":
-                summed = self._fresh_reg()
-                dst = self._fresh_reg()
-                self._emit(
-                    IrOp.ADD, IrRegister(summed), IrRegister(current), IrRegister(right)
-                )
-                self._emit(
-                    IrOp.CMP_NE, IrRegister(dst), IrRegister(summed), IrRegister(0)
-                )
-                current = dst
-            elif value == "impl":
-                inverted = self._invert_bool(current)
-                summed = self._fresh_reg()
-                dst = self._fresh_reg()
-                self._emit(
-                    IrOp.ADD,
-                    IrRegister(summed),
-                    IrRegister(inverted),
-                    IrRegister(right),
-                )
-                self._emit(
-                    IrOp.CMP_NE, IrRegister(dst), IrRegister(summed), IrRegister(0)
-                )
-                current = dst
             elif value == "eqv":
+                right_reg = self._compile_expr(right, scope)
                 dst = self._fresh_reg()
                 self._emit(
-                    IrOp.CMP_EQ, IrRegister(dst), IrRegister(current), IrRegister(right)
+                    IrOp.CMP_EQ,
+                    IrRegister(dst),
+                    IrRegister(current),
+                    IrRegister(right_reg),
                 )
                 current = dst
             else:
                 raise CompileError(f"boolean operator {value!r} is not supported yet")
             index += 2
         return current
+
+    def _emit_short_circuit_bool(
+        self,
+        *,
+        operator: str,
+        left: int,
+        right: ASTNode | Token,
+        scope: _FrameScope,
+    ) -> int:
+        index = self.if_count
+        self.if_count += 1
+        end_label = f"bool_{index}_{operator}_end"
+        result = self._fresh_reg()
+
+        if operator == "and":
+            self._emit(IrOp.LOAD_IMM, IrRegister(result), IrImmediate(0))
+            self._emit(IrOp.BRANCH_Z, IrRegister(left), IrLabel(end_label))
+            right_reg = self._compile_expr(right, scope)
+            self._copy_reg(dst=result, src=right_reg)
+        elif operator == "or":
+            self._emit(IrOp.LOAD_IMM, IrRegister(result), IrImmediate(1))
+            self._emit(IrOp.BRANCH_NZ, IrRegister(left), IrLabel(end_label))
+            right_reg = self._compile_expr(right, scope)
+            self._copy_reg(dst=result, src=right_reg)
+        elif operator == "impl":
+            self._emit(IrOp.LOAD_IMM, IrRegister(result), IrImmediate(1))
+            self._emit(IrOp.BRANCH_Z, IrRegister(left), IrLabel(end_label))
+            right_reg = self._compile_expr(right, scope)
+            self._copy_reg(dst=result, src=right_reg)
+        else:
+            raise CompileError(f"boolean operator {operator!r} is not supported yet")
+
+        self._label(end_label)
+        return result
 
     def _compile_comparison(
         self, children: list[ASTNode | Token], scope: _FrameScope

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -638,7 +638,8 @@ class TestAlgolIrCompiler:
         )
         opcodes = [instr.opcode for instr in result.program.instructions]
         assert IrOp.CMP_GT in opcodes
-        assert IrOp.AND in opcodes
+        assert IrOp.BRANCH_Z in opcodes
+        assert IrOp.BRANCH_NZ in opcodes
 
     def test_compiles_boolean_implication_form(self) -> None:
         result = compile_algol(
@@ -651,8 +652,7 @@ class TestAlgolIrCompiler:
         opcodes = [instr.opcode for instr in result.program.instructions]
 
         assert IrOp.ADD_IMM in opcodes
-        assert IrOp.AND_IMM in opcodes
-        assert IrOp.CMP_NE in opcodes
+        assert IrOp.BRANCH_Z in opcodes
 
     def test_compiles_boolean_equivalence_form(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to this package will be documented in this file.
 - Executed chained assignments, ALGOL-left-associative exponentiation with
   integer or real exponents, and branch-selected conditional expressions
   through the full WASM path.
+- Executed boolean `and`, `or`, and `impl` with short-circuiting RHS
+  evaluation through the full WASM path, while keeping `eqv` strict.
 - Executed bare no-argument typed procedure names as expression calls,
   including by-name actuals that re-evaluate through eval thunks.
 - Accepted trailing and repeated semicolons in ALGOL block and compound

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -21,6 +21,8 @@ the current lane already supports a substantial ALGOL 60 surface:
 - chained assignment, conditional expressions, tolerant trailing/repeated
   semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer or real exponents
+- boolean `and`, `or`, and `impl` with short-circuiting RHS evaluation, plus
+  strict `eqv`
 - standard numeric functions `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`,
   `arctan`, `ln`, and `exp`; non-native real math is imported through the
   runtime's `compiler_math` host ABI

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -426,6 +426,22 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_boolean_and_or_impl_short_circuit_rhs(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "boolean procedure mark; "
+            "begin result := result + 100; mark := false end; "
+            "result := 0; "
+            "if false and mark then result := result + 1 "
+            "else result := result + 7; "
+            "if true or mark then result := result + 11 "
+            "else result := result + 13; "
+            "if false impl mark then result := result + 17 "
+            "else result := result + 19 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [35]
+
     def test_boolean_equivalence_truth_table(self) -> None:
         result = compile_source(
             "begin integer result; "
@@ -437,6 +453,18 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [10]
+
+    def test_boolean_equivalence_remains_strict(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "boolean procedure mark; "
+            "begin result := result + 100; mark := false end; "
+            "result := 0; "
+            "if true eqv mark then result := result + 1 "
+            "else result := result + 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [107]
 
     def test_or_binds_tighter_than_implication(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- lower ALGOL boolean and/or/impl through short-circuiting control flow
- keep eqv strict, matching the existing equivalence semantics
- add end-to-end WASM coverage for skipped RHS procedure side effects and strict eqv evaluation
- document the boolean evaluation behavior in the ALGOL IR/WASM package docs

## Tests
- algol-ir-compiler pytest: 97 passed
- algol-type-checker pytest: 128 passed
- algol-wasm compiler + fixtures pytest: 168 passed
- scoped ruff check: passed
- git diff --check origin/main: passed
- security review: no new risky subprocess/shell/network/file-write/deserialization/secret patterns found