### PR TITLE
feat(twig): TW04 Phase 4b — module resolver

### DIFF
--- a/code/packages/python/twig/CHANGELOG.md
+++ b/code/packages/python/twig/CHANGELOG.md
@@ -3,6 +3,55 @@
 All notable changes to this package will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] — 2026-04-29 (TW04 Phase 4b — module resolver)
+
+### Added
+
+- **`twig.module_resolver`** — new module that walks the import
+  graph from a named entry module and returns every reachable
+  module's parsed AST in topological order.
+
+  ```python
+  from pathlib import Path
+  from twig import resolve_modules
+
+  modules = resolve_modules(
+      "user/hello",
+      search_paths=[Path("src/")],
+  )
+  for m in modules:
+      # ``m.name``, ``m.program``, ``m.source_path``
+      compile_one(m)  # backends iterate; deps come first
+  ```
+
+- **`ResolvedModule`** dataclass — `name`, `program`,
+  `source_path` (None for the synthetic `host` module).
+
+- **Synthetic `host` module** — ``(import host)`` works without
+  a `host.tw` file; the resolver materialises a `Module` with
+  the v1 export surface (`write-byte`, `read-byte`, `exit`) on
+  demand.  Per-backend lowering (Phase 4d–4f) will intercept
+  these names and emit the runtime-specific implementations.
+
+- **Cycle detection** with full path messages —
+  ``cycle: a -> b -> c -> a`` — using a three-colour DFS so
+  the user sees exactly which edge to break.
+
+- **Path / name validation** — a file reached via the resolver
+  MUST declare `(module name)` matching the import path.
+  Single-file programs without a module declaration still work
+  through the existing direct compile-source API; the resolver
+  only governs explicit-module imports.
+
+### Tests
+
+- 17 new tests in `tests/test_module_resolver.py`:
+  happy-path single / chain / diamond / nested-path / multiple
+  search paths / re-imports; cycle (2-, 3-, self-); missing
+  entry / transitive / no-search-paths; path-name mismatches.
+- 145/145 twig tests pass; 100% coverage on
+  `module_resolver.py`; package-wide 95.58%.
+
 ## [0.2.0] — 2026-04-29 (TW04 Phase 4a — module form in parser/AST)
 
 ### Added

--- a/code/packages/python/twig/src/twig/__init__.py
+++ b/code/packages/python/twig/src/twig/__init__.py
@@ -21,6 +21,12 @@ from __future__ import annotations
 from twig.ast_extract import extract_program
 from twig.ast_nodes import Module, Program
 from twig.compiler import compile_program
+from twig.module_resolver import (
+    HOST_EXPORTS,
+    HOST_MODULE_NAME,
+    ResolvedModule,
+    resolve_modules,
+)
 from twig.errors import (
     TwigCompileError,
     TwigError,
@@ -43,6 +49,11 @@ __all__ = [
     # AST surface (TW04 Phase 4a — module declarations)
     "Module",
     "Program",
+    # Module resolution (TW04 Phase 4b)
+    "ResolvedModule",
+    "resolve_modules",
+    "HOST_MODULE_NAME",
+    "HOST_EXPORTS",
     # Heap surface
     "Heap",
     "HeapHandle",

--- a/code/packages/python/twig/src/twig/module_resolver.py
+++ b/code/packages/python/twig/src/twig/module_resolver.py
@@ -1,0 +1,308 @@
+"""TW04 Phase 4b — Twig module resolver.
+
+What this does
+==============
+Given an *entry module name* (e.g. ``user/hello``) and a list of
+*module search paths* (directories to look in), the resolver
+walks the import graph and returns every reachable module's
+parsed AST in topological order — deepest dependencies first,
+entry module last.
+
+Why it's its own module
+-----------------------
+Module resolution is a discrete compilation phase that sits
+between parsing (TW04 Phase 4a) and IR emission (Phase 4c+).
+Keeping it isolated lets the per-backend compilers stay
+single-module — they just ask the resolver "give me everything
+this entry needs, in the right order" and lower each module
+in turn.  The resolver knows nothing about IR or backends; the
+backends know nothing about file paths or the ``host``
+synthetic module.
+
+What it does NOT do
+-------------------
+- **No code generation.**  Returns ASTs only.  Phase 4c adds
+  cross-module IR ops; 4d–4f wire per-backend lowering.
+- **No name resolution within a module.**  The resolver checks
+  that imports exist (their files are findable, their declared
+  names match their paths, no cycles).  Whether
+  ``(host/write-byte 65)`` actually refers to a real export is
+  a Phase 4c concern.
+- **No transitive re-exports.**  ``(import a)`` brings in ``a``'s
+  exports, not ``a``'s imports' exports.  Re-exports are a v2
+  feature per the TW04 non-goals.
+- **No package-manager behaviour.**  Search paths are just a
+  list of directories; resolution is purely positional.
+
+The synthetic ``host`` module
+-----------------------------
+The compiler's ``host`` module isn't on disk — it's the
+cross-backend host-call surface (``write-byte`` / ``read-byte`` /
+``exit``).  The resolver synthesises it on demand when something
+imports ``host``.  Each backend's Phase 4d/e/f lowering will
+intercept the host-named exports and emit the per-runtime
+implementations instead of looking for a ``host.tw`` file.
+
+Algorithmic shape
+-----------------
+Standard DFS post-order topological sort with three-colour
+cycle detection:
+
+* **WHITE** — name not yet visited (absent from both sets).
+* **GRAY**  — name in the current DFS stack (in ``visiting``).
+              Encountering a GRAY name means a cycle.
+* **BLACK** — name fully resolved (in ``cache``).
+
+Because we record GRAY entries on a stack rather than just a
+set, we can produce a precise cycle path for the error message
+("a → b → c → a") rather than just naming the offending node.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from twig.ast_extract import extract_program
+from twig.ast_nodes import Module, Program
+from twig.errors import TwigCompileError
+from twig.parser import parse_twig
+
+# ── The synthetic ``host`` module ─────────────────────────────────────────
+
+HOST_MODULE_NAME: str = "host"
+
+# v1 host surface — see TW04 spec §"The host package".  Three primitives,
+# fixed signatures, every backend lowers them to the corresponding
+# runtime facility.
+HOST_EXPORTS: tuple[str, ...] = ("write-byte", "read-byte", "exit")
+
+
+# ── Public API surface ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ResolvedModule:
+    """One module discovered by the resolver.
+
+    * ``name`` — the module's declared / synthesised name
+      (``stdlib/io``, ``user/compiler/lexer``, ``host``).
+    * ``program`` — the parsed :class:`Program` AST.  Always
+      has a non-``None`` ``module`` field after resolution
+      (the resolver rejects files that lack a ``(module ...)``
+      declaration — that's an unambiguous error when the file
+      was reached via an import).
+    * ``source_path`` — the file the module was loaded from,
+      or ``None`` for the synthetic ``host`` module which has
+      no on-disk source.
+    """
+
+    name: str
+    program: Program
+    source_path: Path | None
+
+
+def resolve_modules(
+    entry_module: str,
+    *,
+    search_paths: Sequence[Path],
+) -> list[ResolvedModule]:
+    """Resolve ``entry_module`` and its transitive imports.
+
+    Returns the resolved modules in topological order — every
+    module appears AFTER all of its (transitive) imports, with
+    the entry module last.  This is exactly the order each
+    backend wants to lower modules in: a downstream consumer
+    can iterate the list once and emit code without forward
+    references.
+
+    Raises :class:`TwigCompileError` on:
+
+    * **Missing module file** — ``entry_module`` or any
+      imported module isn't found in any search path.
+    * **Path / name mismatch** — a file at ``stdlib/io.tw``
+      declares ``(module foo)`` (or omits the form entirely
+      while being imported by name).
+    * **Import cycle** — module ``A`` imports ``B`` which
+      imports ``A`` (transitively).  The error message names
+      the full cycle path.
+
+    The synthetic ``host`` module is auto-resolved without
+    consulting the search path.
+    """
+    # Topo state — three-colour DFS.
+    cache: dict[str, ResolvedModule] = {}      # BLACK: fully resolved
+    visiting: set[str] = set()                 # GRAY: on current DFS stack
+    out: list[ResolvedModule] = []
+    stack: list[str] = []                      # for cycle-path messages
+
+    _resolve_dfs(
+        entry_module,
+        search_paths=search_paths,
+        cache=cache,
+        visiting=visiting,
+        stack=stack,
+        out=out,
+    )
+    return out
+
+
+# ── Implementation ────────────────────────────────────────────────────────
+
+
+def _synthetic_host_module() -> ResolvedModule:
+    """Build the ``host`` module on the fly.
+
+    The Module declares the v1 host surface; the body is empty
+    because every export is implemented by per-backend lowering,
+    not by Twig source.  The resolver hands the same Program
+    shape back as for on-disk modules so downstream code never
+    needs a "host?" branch — it iterates ``ResolvedModule``s
+    uniformly.
+    """
+    program = Program(
+        forms=[],
+        module=Module(
+            name=HOST_MODULE_NAME,
+            exports=list(HOST_EXPORTS),
+            imports=[],
+        ),
+    )
+    return ResolvedModule(
+        name=HOST_MODULE_NAME,
+        program=program,
+        source_path=None,
+    )
+
+
+def _module_name_to_relpath(name: str) -> Path:
+    """Map a module name to its relative file path on disk.
+
+    ``stdlib/io`` → ``stdlib/io.tw`` (path-shaped).  The
+    forward slashes in the module name map directly to path
+    separators so module hierarchy mirrors directory hierarchy
+    on every OS — ``pathlib.Path`` normalises the result for
+    the host platform.
+    """
+    parts = name.split("/")
+    return Path(*parts).with_suffix(".tw")
+
+
+def _find_module_file(name: str, search_paths: Sequence[Path]) -> Path:
+    """Locate the file backing ``name`` in the search paths.
+
+    Search paths are tried in order; the first hit wins.  This
+    matches Python's ``sys.path`` and Rust's ``--extern``
+    semantics — earlier paths shadow later ones.
+    """
+    rel = _module_name_to_relpath(name)
+    tried: list[str] = []
+    for sp in search_paths:
+        candidate = sp / rel
+        tried.append(str(candidate))
+        if candidate.is_file():
+            return candidate
+    if not tried:
+        raise TwigCompileError(
+            f"module {name!r} not found.  No module search "
+            f"paths configured."
+        )
+    raise TwigCompileError(
+        f"module {name!r} not found.  Looked in:\n  "
+        + "\n  ".join(tried)
+    )
+
+
+def _load_and_validate(name: str, path: Path) -> Program:
+    """Parse a file and check its (module ...) declaration.
+
+    A file reached via the resolver MUST declare a
+    ``(module ...)`` form whose name matches the import path.
+    Implicit-default-module (no ``(module ...)`` form) is only
+    legal when compiling a single-file program through the
+    direct compile-source API — never when the module is
+    reached by name through the import graph.
+    """
+    source = path.read_text()
+    program = extract_program(parse_twig(source))
+
+    if program.module is None:
+        raise TwigCompileError(
+            f"file {path} has no (module ...) declaration but was "
+            f"reached as module {name!r} through an import"
+        )
+    if program.module.name != name:
+        raise TwigCompileError(
+            f"file {path} declares (module {program.module.name!r}) "
+            f"but was reached as module {name!r} — module names "
+            f"must match their file paths"
+        )
+    return program
+
+
+def _resolve_dfs(
+    name: str,
+    *,
+    search_paths: Sequence[Path],
+    cache: dict[str, ResolvedModule],
+    visiting: set[str],
+    stack: list[str],
+    out: list[ResolvedModule],
+) -> None:
+    """Visit ``name``, recurse into its imports, then append it.
+
+    Post-order DFS over the import graph yields topo-sorted
+    modules: every node appears AFTER all of its transitive
+    dependencies in ``out``.  See module docstring for the
+    three-colour invariant.
+    """
+    # BLACK: already resolved.  Nothing to do — re-imports are fine
+    # (they're DAG joins, not cycles).
+    if name in cache:
+        return
+
+    # GRAY: revisiting a node still on the DFS stack — cycle.
+    # The cycle path is ``stack[idx..] + [name]`` where ``idx``
+    # is where the offending node first appeared.
+    if name in visiting:
+        idx = stack.index(name)
+        cycle = stack[idx:] + [name]
+        raise TwigCompileError(
+            f"module import cycle detected: {' -> '.join(cycle)}"
+        )
+
+    # The synthetic host module short-circuits.  Visit-order
+    # matters: it goes into ``out`` BEFORE any module that
+    # imports it, so backends emit the host stubs first.
+    if name == HOST_MODULE_NAME:
+        host = _synthetic_host_module()
+        cache[name] = host
+        out.append(host)
+        return
+
+    visiting.add(name)
+    stack.append(name)
+
+    path = _find_module_file(name, search_paths)
+    program = _load_and_validate(name, path)
+    assert program.module is not None  # _load_and_validate enforces
+
+    # Recurse into imports first (post-order = topo sort).
+    for imp in program.module.imports:
+        _resolve_dfs(
+            imp,
+            search_paths=search_paths,
+            cache=cache,
+            visiting=visiting,
+            stack=stack,
+            out=out,
+        )
+
+    # Done with this node — flip GRAY → BLACK and emit.
+    resolved = ResolvedModule(name=name, program=program, source_path=path)
+    cache[name] = resolved
+    out.append(resolved)
+
+    visiting.remove(name)
+    stack.pop()

--- a/code/packages/python/twig/tests/test_module_resolver.py
+++ b/code/packages/python/twig/tests/test_module_resolver.py
@@ -1,0 +1,250 @@
+"""Tests for ``twig.module_resolver`` (TW04 Phase 4b).
+
+The resolver walks the import graph and returns every reachable
+module's parsed AST in topological order — deepest dependencies
+first, entry module last.  These tests cover the four classes of
+behaviour the spec calls out:
+
+1. **Happy path** — single module, transitive imports, the
+   synthetic ``host`` module, multiple search paths.
+2. **Cycle detection** — two-node and longer cycles produce
+   precise path messages.
+3. **Missing imports** — entry or transitive module not found
+   on disk.
+4. **Path / name mismatches** — file at ``stdlib/io.tw``
+   declaring ``(module foo)`` is rejected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from twig.errors import TwigCompileError
+from twig.module_resolver import (
+    HOST_EXPORTS,
+    HOST_MODULE_NAME,
+    ResolvedModule,
+    resolve_modules,
+)
+
+
+def _write(root: Path, rel: str, contents: str) -> Path:
+    """Create ``root/<rel>`` with the given contents and return its path."""
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+    return path
+
+
+# ── Happy path ────────────────────────────────────────────────────────────
+
+
+def test_single_module_with_no_imports(tmp_path: Path) -> None:
+    """A module with no imports resolves to a single-element list."""
+    _write(tmp_path, "lone.tw", "(module lone (export f))\n(define f 42)\n")
+    result = resolve_modules("lone", search_paths=[tmp_path])
+    assert len(result) == 1
+    assert result[0].name == "lone"
+    assert result[0].source_path is not None
+    assert result[0].program.module is not None
+    assert result[0].program.module.exports == ["f"]
+
+
+def test_module_importing_another_module(tmp_path: Path) -> None:
+    """``a`` imports ``b``; both appear in topological order
+    (``b`` before ``a``).
+    """
+    _write(tmp_path, "a.tw", "(module a (import b))\n(define x 1)\n")
+    _write(tmp_path, "b.tw", "(module b (export y))\n(define y 2)\n")
+    result = resolve_modules("a", search_paths=[tmp_path])
+    names = [r.name for r in result]
+    assert names == ["b", "a"], (
+        "topological order should put dependencies before importers"
+    )
+
+
+def test_transitive_imports_chain(tmp_path: Path) -> None:
+    """``a`` → ``b`` → ``c``: result is ``[c, b, a]``."""
+    _write(tmp_path, "a.tw", "(module a (import b))\n(define x 1)\n")
+    _write(tmp_path, "b.tw", "(module b (import c) (export f))\n(define f 2)\n")
+    _write(tmp_path, "c.tw", "(module c (export g))\n(define g 3)\n")
+    result = resolve_modules("a", search_paths=[tmp_path])
+    assert [r.name for r in result] == ["c", "b", "a"]
+
+
+def test_diamond_dependency(tmp_path: Path) -> None:
+    """``a`` imports ``b`` and ``c``; both import ``d``.
+
+    Diamond shape — ``d`` should appear exactly once and before
+    both ``b`` and ``c``, which both appear before ``a``.
+    """
+    _write(tmp_path, "a.tw", "(module a (import b c))\n(define x 1)\n")
+    _write(tmp_path, "b.tw", "(module b (import d) (export f))\n(define f 2)\n")
+    _write(tmp_path, "c.tw", "(module c (import d) (export g))\n(define g 3)\n")
+    _write(tmp_path, "d.tw", "(module d (export h))\n(define h 4)\n")
+    result = resolve_modules("a", search_paths=[tmp_path])
+    names = [r.name for r in result]
+    assert names.count("d") == 1, "shared dependency must not be duplicated"
+    assert names.index("d") < names.index("b")
+    assert names.index("d") < names.index("c")
+    assert names.index("b") < names.index("a")
+    assert names.index("c") < names.index("a")
+
+
+def test_nested_module_path(tmp_path: Path) -> None:
+    """Slash-separated module names map to nested directories.
+
+    ``user/compiler/lexer`` lives at
+    ``<search_path>/user/compiler/lexer.tw``.
+    """
+    _write(
+        tmp_path,
+        "user/compiler/lexer.tw",
+        "(module user/compiler/lexer (export tokenise))\n"
+        "(define tokenise 0)\n",
+    )
+    result = resolve_modules(
+        "user/compiler/lexer", search_paths=[tmp_path]
+    )
+    assert len(result) == 1
+    assert result[0].name == "user/compiler/lexer"
+
+
+def test_synthetic_host_module_is_auto_resolved(tmp_path: Path) -> None:
+    """Importing ``host`` works without a ``host.tw`` file.
+
+    The resolver synthesises the module on the fly with the v1
+    export surface (``write-byte``, ``read-byte``, ``exit``).
+    """
+    _write(
+        tmp_path,
+        "user/hello.tw",
+        "(module user/hello (import host))\n(host/write-byte 65)\n",
+    )
+    result = resolve_modules("user/hello", search_paths=[tmp_path])
+    names = [r.name for r in result]
+    assert names == [HOST_MODULE_NAME, "user/hello"]
+    host = next(r for r in result if r.name == HOST_MODULE_NAME)
+    assert host.source_path is None, "host module has no on-disk source"
+    assert host.program.module is not None
+    assert tuple(host.program.module.exports) == HOST_EXPORTS
+
+
+def test_multiple_search_paths_first_hit_wins(tmp_path: Path) -> None:
+    """Search paths are consulted in order; earlier paths shadow later
+    ones — same semantics as Python's ``sys.path``.
+    """
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _write(a, "io.tw", "(module io (export from-a))\n(define from-a 1)\n")
+    _write(b, "io.tw", "(module io (export from-b))\n(define from-b 2)\n")
+    result = resolve_modules("io", search_paths=[a, b])
+    assert len(result) == 1
+    assert result[0].source_path is not None
+    assert result[0].source_path.is_relative_to(a)
+
+
+def test_re_imported_module_appears_once(tmp_path: Path) -> None:
+    """If a module is imported through multiple paths in the graph,
+    the resolver visits it once.  Plain DAG-join behaviour.
+    """
+    _write(
+        tmp_path,
+        "a.tw",
+        "(module a (import b c))\n(define x 1)\n",
+    )
+    _write(tmp_path, "b.tw", "(module b (import c) (export f))\n(define f 2)\n")
+    _write(tmp_path, "c.tw", "(module c (export g))\n(define g 3)\n")
+    result = resolve_modules("a", search_paths=[tmp_path])
+    names = [r.name for r in result]
+    assert names.count("c") == 1
+    assert names == ["c", "b", "a"]
+
+
+# ── Cycle detection ───────────────────────────────────────────────────────
+
+
+def test_two_module_cycle_rejected(tmp_path: Path) -> None:
+    """``a`` imports ``b`` imports ``a``."""
+    _write(tmp_path, "a.tw", "(module a (import b))\n(define x 1)\n")
+    _write(tmp_path, "b.tw", "(module b (import a))\n(define y 2)\n")
+    with pytest.raises(TwigCompileError, match=r"cycle.*a -> b -> a"):
+        resolve_modules("a", search_paths=[tmp_path])
+
+
+def test_three_module_cycle_rejected(tmp_path: Path) -> None:
+    """Longer cycle: ``a → b → c → a``.  The error message names
+    the full path so the user can see which edge to break."""
+    _write(tmp_path, "a.tw", "(module a (import b))\n(define x 1)\n")
+    _write(tmp_path, "b.tw", "(module b (import c))\n(define y 2)\n")
+    _write(tmp_path, "c.tw", "(module c (import a))\n(define z 3)\n")
+    with pytest.raises(TwigCompileError, match=r"cycle.*a -> b -> c -> a"):
+        resolve_modules("a", search_paths=[tmp_path])
+
+
+def test_self_cycle_rejected(tmp_path: Path) -> None:
+    """A module that imports itself."""
+    _write(tmp_path, "a.tw", "(module a (import a))\n(define x 1)\n")
+    with pytest.raises(TwigCompileError, match=r"cycle.*a -> a"):
+        resolve_modules("a", search_paths=[tmp_path])
+
+
+# ── Missing imports ───────────────────────────────────────────────────────
+
+
+def test_missing_entry_module(tmp_path: Path) -> None:
+    with pytest.raises(TwigCompileError, match=r"not found"):
+        resolve_modules("nope", search_paths=[tmp_path])
+
+
+def test_missing_transitive_import(tmp_path: Path) -> None:
+    """Entry exists but imports a module that doesn't."""
+    _write(tmp_path, "a.tw", "(module a (import nope))\n(define x 1)\n")
+    with pytest.raises(TwigCompileError, match=r"'nope'.*not found"):
+        resolve_modules("a", search_paths=[tmp_path])
+
+
+def test_no_search_paths_configured() -> None:
+    """A clearer error message when the resolver has nowhere to look."""
+    with pytest.raises(TwigCompileError, match=r"No module search paths"):
+        resolve_modules("anything", search_paths=[])
+
+
+# ── Path / name mismatches ────────────────────────────────────────────────
+
+
+def test_file_with_no_module_form_rejected_when_imported(
+    tmp_path: Path,
+) -> None:
+    """A file reached through an import MUST declare a
+    ``(module ...)`` form whose name matches.  Implicit-default-
+    module is only legal for the direct compile-source API."""
+    _write(tmp_path, "a.tw", "(define x 1)\n")  # no (module ...)
+    with pytest.raises(TwigCompileError, match=r"no \(module \.\.\.\)"):
+        resolve_modules("a", search_paths=[tmp_path])
+
+
+def test_file_declaring_wrong_module_name_rejected(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "stdlib/io.tw",
+        "(module wrong-name (export f))\n(define f 1)\n",
+    )
+    with pytest.raises(
+        TwigCompileError, match=r"declares.*'wrong-name'.*'stdlib/io'"
+    ):
+        resolve_modules("stdlib/io", search_paths=[tmp_path])
+
+
+def test_resolved_module_carries_program_and_path(tmp_path: Path) -> None:
+    """``ResolvedModule`` exposes both the parsed Program and the
+    source path so downstream phases (4c+) can attribute errors
+    to specific files."""
+    src = "(module x (export f))\n(define f 42)\n"
+    written = _write(tmp_path, "x.tw", src)
+    result = resolve_modules("x", search_paths=[tmp_path])
+    assert isinstance(result[0], ResolvedModule)
+    assert result[0].source_path == written
+    assert result[0].program.forms[0] is not None  # the (define f 42)

--- a/code/specs/TW04-modules-and-host-package.md
+++ b/code/specs/TW04-modules-and-host-package.md
@@ -288,6 +288,11 @@ cleanly to anything.
    that takes (entry module name, search paths) and returns a
    topologically-sorted list of `(module name, AST)` pairs.
    Detects cycles, missing imports, name conflicts.
+   **Status: shipped — `twig` v0.3.0.**  Returns
+   `list[ResolvedModule]` (each carrying `name`, `program`,
+   `source_path`).  The synthetic `host` module is auto-resolved
+   without consulting the search path.  Cycle errors include
+   the full path (`a -> b -> c -> a`) for diagnosability.
 
 3. **Phase 4c — `host` module + cross-module IR ops.**  Two
    new IR ops (`HOST_CALL`, `MODULE_CALL`) — or, simpler, extend


### PR DESCRIPTION
## Summary
- New `twig.module_resolver` walks the import graph from a named entry module and returns every reachable module's parsed AST in topological order — deepest deps first, entry last.  Per-backend compilers can iterate the result without forward references.
- DFS post-order with three-colour cycle detection; cycle errors name the full path (`a -> b -> c -> a`) so the user sees exactly which edge to break.
- Synthetic `host` module is auto-resolved without consulting disk — `(import host)` Just Works.  Per-backend lowering (Phase 4d–4f) will intercept the host exports.
- Validates path/name agreement: a file reached via import MUST declare `(module name)` matching the import path.

## Test plan
- [x] `twig` package: 145 tests pass, 95.58% coverage; 100% on `module_resolver.py`
- [x] 17 new resolver tests covering: single / chain / diamond / nested / multi-search-path / DAG-re-import / host-synthesis happy paths; 2-node / 3-node / self cycles; missing-entry / missing-transitive / no-search-paths errors; missing-module-form / wrong-declared-name path-mismatches
- [x] Spec ([`code/specs/TW04-modules-and-host-package.md`](code/specs/TW04-modules-and-host-package.md)) updated to mark Phase 4b shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)