### PR TITLE
Batch HTML lexer form-feed whitespace recovery

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -27,6 +27,7 @@ alphabet = [
   "\n",
   "\t",
   "\r",
+  "\u000C",
   "D",
   "d",
   "O",
@@ -1377,6 +1378,12 @@ actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
 from = "rcdata_end_tag_name"
+matcher = { literal = "\u000C" }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_name"
 matcher = { literal = "/" }
 to = "rcdata_self_closing_end_tag"
 
@@ -1429,6 +1436,12 @@ actions = ["append_temporary_buffer(current)"]
 [[transitions]]
 from = "rawtext_end_tag_name"
 matcher = { literal = "\r" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_name"
+matcher = { literal = "\u000C" }
 to = "rawtext_end_tag_whitespace"
 actions = ["append_temporary_buffer(current)"]
 
@@ -1491,6 +1504,12 @@ actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
 from = "script_data_end_tag_name"
+matcher = { literal = "\u000C" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_name"
 matcher = { literal = "/" }
 to = "script_data_self_closing_end_tag"
 
@@ -1548,6 +1567,12 @@ actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
 from = "script_data_escaped_end_tag_name"
+matcher = { literal = "\u000C" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_name"
 matcher = { literal = "/" }
 to = "script_data_escaped_self_closing_end_tag"
 
@@ -1594,6 +1619,12 @@ actions = ["append_temporary_buffer(current)"]
 [[transitions]]
 from = "rcdata_end_tag_whitespace"
 matcher = { literal = "\r" }
+to = "rcdata_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rcdata_end_tag_whitespace"
+matcher = { literal = "\u000C" }
 to = "rcdata_end_tag_whitespace"
 actions = ["append_temporary_buffer(current)"]
 
@@ -1653,6 +1684,12 @@ actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
 from = "rawtext_end_tag_whitespace"
+matcher = { literal = "\u000C" }
+to = "rawtext_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "rawtext_end_tag_whitespace"
 matcher = { literal = ">" }
 to = "rawtext"
 actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
@@ -1707,6 +1744,12 @@ actions = ["append_temporary_buffer(current)"]
 
 [[transitions]]
 from = "script_data_end_tag_whitespace"
+matcher = { literal = "\u000C" }
+to = "script_data_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_end_tag_whitespace"
 matcher = { literal = ">" }
 to = "script_data"
 actions = ["emit_rcdata_end_tag_with_whitespace_or_text"]
@@ -1756,6 +1799,12 @@ actions = ["append_temporary_buffer(current)"]
 [[transitions]]
 from = "script_data_escaped_end_tag_whitespace"
 matcher = { literal = "\r" }
+to = "script_data_escaped_end_tag_whitespace"
+actions = ["append_temporary_buffer(current)"]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_whitespace"
+matcher = { literal = "\u000C" }
 to = "script_data_escaped_end_tag_whitespace"
 actions = ["append_temporary_buffer(current)"]
 
@@ -3212,6 +3261,11 @@ to = "before_attribute_name"
 
 [[transitions]]
 from = "tag_name"
+matcher = { literal = "\u000C" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "tag_name"
 matcher = { literal = "/" }
 to = "self_closing_start_tag"
 
@@ -3262,6 +3316,11 @@ to = "before_attribute_name"
 [[transitions]]
 from = "before_attribute_name"
 matcher = { literal = "\r" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "\u000C" }
 to = "before_attribute_name"
 
 [[transitions]]
@@ -3334,6 +3393,11 @@ to = "after_attribute_name"
 
 [[transitions]]
 from = "attribute_name"
+matcher = { literal = "\u000C" }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "attribute_name"
 matcher = { literal = "/" }
 to = "self_closing_start_tag"
 actions = ["commit_attribute_dedup"]
@@ -3394,6 +3458,11 @@ to = "after_attribute_name"
 [[transitions]]
 from = "after_attribute_name"
 matcher = { literal = "\r" }
+to = "after_attribute_name"
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "\u000C" }
 to = "after_attribute_name"
 
 [[transitions]]
@@ -3464,6 +3533,11 @@ to = "before_attribute_value"
 [[transitions]]
 from = "before_attribute_value"
 matcher = { literal = "\r" }
+to = "before_attribute_value"
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = "\u000C" }
 to = "before_attribute_value"
 
 [[transitions]]
@@ -3630,6 +3704,12 @@ actions = ["commit_attribute_dedup"]
 [[transitions]]
 from = "attribute_value_unquoted"
 matcher = { literal = "\r" }
+to = "before_attribute_name"
+actions = ["commit_attribute_dedup"]
+
+[[transitions]]
+from = "attribute_value_unquoted"
+matcher = { literal = "\u000C" }
 to = "before_attribute_name"
 actions = ["commit_attribute_dedup"]
 
@@ -5007,6 +5087,11 @@ to = "before_attribute_name"
 
 [[transitions]]
 from = "after_attribute_value_quoted"
+matcher = { literal = "\u000C" }
+to = "before_attribute_name"
+
+[[transitions]]
+from = "after_attribute_value_quoted"
 matcher = { literal = "/" }
 to = "self_closing_start_tag"
 
@@ -5817,6 +5902,11 @@ to = "before_doctype_name"
 
 [[transitions]]
 from = "doctype_after_keyword"
+matcher = { literal = "\u000C" }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "doctype_after_keyword"
 matcher = { literal = ">" }
 to = "data"
 actions = [
@@ -5878,6 +5968,11 @@ to = "before_doctype_name"
 
 [[transitions]]
 from = "before_doctype_name"
+matcher = { literal = "\u000C" }
+to = "before_doctype_name"
+
+[[transitions]]
+from = "before_doctype_name"
 matcher = { literal = ">" }
 to = "data"
 actions = [
@@ -5932,6 +6027,11 @@ to = "after_doctype_name"
 
 [[transitions]]
 from = "doctype_name"
+matcher = { literal = "\u000C" }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "doctype_name"
 matcher = { literal = ">" }
 to = "data"
 actions = ["emit_current_token"]
@@ -5978,6 +6078,11 @@ to = "after_doctype_name"
 [[transitions]]
 from = "after_doctype_name"
 matcher = { literal = "\r" }
+to = "after_doctype_name"
+
+[[transitions]]
+from = "after_doctype_name"
+matcher = { literal = "\u000C" }
 to = "after_doctype_name"
 
 [[transitions]]
@@ -6370,6 +6475,11 @@ to = "before_doctype_public_identifier"
 
 [[transitions]]
 from = "after_doctype_public_keyword"
+matcher = { literal = "\u000C" }
+to = "before_doctype_public_identifier"
+
+[[transitions]]
+from = "after_doctype_public_keyword"
 matcher = { literal = "\"" }
 to = "doctype_public_identifier_double_quoted"
 actions = [
@@ -6436,6 +6546,11 @@ to = "before_doctype_public_identifier"
 [[transitions]]
 from = "before_doctype_public_identifier"
 matcher = { literal = "\r" }
+to = "before_doctype_public_identifier"
+
+[[transitions]]
+from = "before_doctype_public_identifier"
+matcher = { literal = "\u000C" }
 to = "before_doctype_public_identifier"
 
 [[transitions]]
@@ -6588,6 +6703,11 @@ to = "between_doctype_public_and_system_identifiers"
 
 [[transitions]]
 from = "after_doctype_public_identifier"
+matcher = { literal = "\u000C" }
+to = "between_doctype_public_and_system_identifiers"
+
+[[transitions]]
+from = "after_doctype_public_identifier"
 matcher = { literal = ">" }
 to = "data"
 actions = ["emit_current_token"]
@@ -6654,6 +6774,11 @@ to = "between_doctype_public_and_system_identifiers"
 
 [[transitions]]
 from = "between_doctype_public_and_system_identifiers"
+matcher = { literal = "\u000C" }
+to = "between_doctype_public_and_system_identifiers"
+
+[[transitions]]
+from = "between_doctype_public_and_system_identifiers"
 matcher = { literal = ">" }
 to = "data"
 actions = ["emit_current_token"]
@@ -6710,6 +6835,11 @@ to = "before_doctype_system_identifier"
 [[transitions]]
 from = "after_doctype_system_keyword"
 matcher = { literal = "\r" }
+to = "before_doctype_system_identifier"
+
+[[transitions]]
+from = "after_doctype_system_keyword"
+matcher = { literal = "\u000C" }
 to = "before_doctype_system_identifier"
 
 [[transitions]]
@@ -6780,6 +6910,11 @@ to = "before_doctype_system_identifier"
 [[transitions]]
 from = "before_doctype_system_identifier"
 matcher = { literal = "\r" }
+to = "before_doctype_system_identifier"
+
+[[transitions]]
+from = "before_doctype_system_identifier"
+matcher = { literal = "\u000C" }
 to = "before_doctype_system_identifier"
 
 [[transitions]]
@@ -6928,6 +7063,11 @@ to = "after_doctype_system_identifier"
 [[transitions]]
 from = "after_doctype_system_identifier"
 matcher = { literal = "\r" }
+to = "after_doctype_system_identifier"
+
+[[transitions]]
+from = "after_doctype_system_identifier"
+matcher = { literal = "\u000C" }
 to = "after_doctype_system_identifier"
 
 [[transitions]]
@@ -7004,6 +7144,11 @@ to = "before_end_tag_close"
 
 [[transitions]]
 from = "before_end_tag_close"
+matcher = { literal = "\u000C" }
+to = "before_end_tag_close"
+
+[[transitions]]
+from = "before_end_tag_close"
 matcher = { literal = ">" }
 to = "data"
 actions = ["emit_current_token"]
@@ -7074,6 +7219,12 @@ actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
 [[transitions]]
 from = "end_tag_name"
 matcher = { literal = "\r" }
+to = "before_end_tag_close"
+actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
+
+[[transitions]]
+from = "end_tag_name"
+matcher = { literal = "\u000C" }
 to = "before_end_tag_close"
 actions = ["parse_error(unexpected-whitespace-after-end-tag-name)"]
 

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -21,6 +21,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         "\0".to_string(),
         "\t".to_string(),
         "\n".to_string(),
+        "\u{C}".to_string(),
         "\r".to_string(),
         " ".to_string(),
         "!".to_string(),
@@ -3171,6 +3172,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "rcdata_end_tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "rcdata_self_closing_end_tag".to_string(),
@@ -3280,6 +3296,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "rawtext_end_tag_name".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "rawtext_end_tag_whitespace".to_string(),
             ],
@@ -3417,6 +3448,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_end_tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "script_data_self_closing_end_tag".to_string(),
@@ -3540,6 +3586,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_escaped_end_tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "script_data_escaped_self_closing_end_tag".to_string(),
@@ -3634,6 +3695,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "rcdata_end_tag_whitespace".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "rcdata_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "rcdata_end_tag_whitespace".to_string(),
             ],
@@ -3770,6 +3846,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "rawtext_end_tag_whitespace".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "rawtext_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_whitespace".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "rawtext".to_string(),
@@ -3892,6 +3983,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_end_tag_whitespace".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "script_data_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_whitespace".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "script_data".to_string(),
@@ -4000,6 +4106,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "script_data_escaped_end_tag_whitespace".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "script_data_escaped_end_tag_whitespace".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_whitespace".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "script_data_escaped_end_tag_whitespace".to_string(),
             ],
@@ -7175,6 +7296,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "tag_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "before_attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "tag_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "self_closing_start_tag".to_string(),
@@ -7291,6 +7425,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "before_attribute_name".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "before_attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "before_attribute_name".to_string(),
             ],
@@ -7450,6 +7597,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "attribute_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "after_attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "self_closing_start_tag".to_string(),
@@ -7583,6 +7743,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "after_attribute_name".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "after_attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "after_attribute_name".to_string(),
             ],
@@ -7732,6 +7905,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "before_attribute_value".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "before_attribute_value".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_value".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "before_attribute_value".to_string(),
             ],
@@ -8061,6 +8247,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "attribute_value_unquoted".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "before_attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "commit_attribute_dedup".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_value_unquoted".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "before_attribute_name".to_string(),
             ],
@@ -10623,6 +10824,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "after_attribute_value_quoted".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "before_attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_attribute_value_quoted".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
                 "self_closing_start_tag".to_string(),
@@ -12251,6 +12465,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "doctype_after_keyword".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "before_doctype_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "doctype_after_keyword".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "data".to_string(),
@@ -12371,6 +12598,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "before_doctype_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "before_doctype_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_doctype_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "data".to_string(),
@@ -12489,6 +12729,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "doctype_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "after_doctype_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "doctype_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "data".to_string(),
@@ -12593,6 +12846,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "after_doctype_name".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "after_doctype_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_doctype_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "after_doctype_name".to_string(),
             ],
@@ -13358,6 +13624,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "after_doctype_public_keyword".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "before_doctype_public_identifier".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_doctype_public_keyword".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal("\"".to_string())),
             to: vec![
                 "doctype_public_identifier_double_quoted".to_string(),
@@ -13481,6 +13760,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "before_doctype_public_identifier".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "before_doctype_public_identifier".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_doctype_public_identifier".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "before_doctype_public_identifier".to_string(),
             ],
@@ -13784,6 +14076,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "after_doctype_public_identifier".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "between_doctype_public_and_system_identifiers".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_doctype_public_identifier".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "data".to_string(),
@@ -13917,6 +14222,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "between_doctype_public_and_system_identifiers".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "between_doctype_public_and_system_identifiers".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "between_doctype_public_and_system_identifiers".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "data".to_string(),
@@ -14036,6 +14354,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "after_doctype_system_keyword".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "before_doctype_system_identifier".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_doctype_system_keyword".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "before_doctype_system_identifier".to_string(),
             ],
@@ -14171,6 +14502,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "before_doctype_system_identifier".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "before_doctype_system_identifier".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_doctype_system_identifier".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "before_doctype_system_identifier".to_string(),
             ],
@@ -14462,6 +14806,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "after_doctype_system_identifier".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "after_doctype_system_identifier".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_doctype_system_identifier".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "after_doctype_system_identifier".to_string(),
             ],
@@ -14634,6 +14991,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "before_end_tag_close".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
+            to: vec![
+                "before_end_tag_close".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_end_tag_close".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Literal(">".to_string())),
             to: vec![
                 "data".to_string(),
@@ -14787,6 +15157,21 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             from: "end_tag_name".to_string(),
             on: None,
             matcher: Some(MatcherDefinition::Literal("\r".to_string())),
+            to: vec![
+                "before_end_tag_close".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-whitespace-after-end-tag-name)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\u{C}".to_string())),
             to: vec![
                 "before_end_tag_close".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -68,6 +68,35 @@ fn default_html_lexer_supports_html1_attributes_comments_and_doctypes() {
 }
 
 #[test]
+fn default_html_lexer_treats_form_feed_as_tag_whitespace() {
+    let tokens = lex_html("<p\u{000C}class=test\u{000C}data-x=one\u{000C}/></p\u{000C}>").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::StartTag {
+                name: "p".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "class".to_string(),
+                        value: "test".to_string(),
+                    },
+                    Attribute {
+                        name: "data-x".to_string(),
+                        value: "one".to_string(),
+                    },
+                ],
+                self_closing: true,
+            },
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_reports_and_drops_duplicate_attributes() {
     let mut lexer = create_html_lexer().unwrap();
 
@@ -472,6 +501,27 @@ fn default_html_lexer_supports_public_and_system_doctype_identifiers() {
 }
 
 #[test]
+fn default_html_lexer_treats_form_feed_as_doctype_whitespace() {
+    let tokens = lex_html(
+        "<!DOCTYPE\u{000C}html\u{000C}PUBLIC\u{000C}'-//W3C//DTD HTML 4.01//EN'\u{000C}\"about:legacy-compat\"\u{000C}>",
+    )
+    .unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: Some("-//W3C//DTD HTML 4.01//EN".to_string()),
+                system_identifier: Some("about:legacy-compat".to_string()),
+                force_quirks: false,
+            },
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_standalone_system_doctype_identifier() {
     let tokens = lex_html("<!DOCTYPE html SYSTEM \"about:legacy-compat\">").unwrap();
 
@@ -818,6 +868,38 @@ fn default_html_lexer_recovers_end_tag_with_whitespace_then_trailing_solidus() {
 }
 
 #[test]
+fn default_html_lexer_recovers_end_tag_with_form_feed_then_trailing_solidus() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before</p\u{000C}/>After").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before".to_string()),
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"));
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "end-tag-with-trailing-solidus"));
+    assert!(!lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "end-tag-with-attributes"));
+}
+
+#[test]
 fn default_html_lexer_recovers_end_tag_with_attributes() {
     let mut lexer = create_html_lexer().unwrap();
 
@@ -1121,6 +1203,82 @@ fn default_html_lexer_recovers_seeded_text_mode_end_tags_with_whitespace_then_tr
                 .iter()
                 .any(|diagnostic| diagnostic.code == "end-tag-with-attributes"),
             "state {initial_state} should not treat the solidus as attributes"
+        );
+    }
+}
+
+#[test]
+fn default_html_lexer_recovers_seeded_text_mode_end_tags_with_form_feed() {
+    for (initial_state, last_start_tag, text) in [
+        ("rcdata", "title", "Hello"),
+        ("rawtext", "style", "body {}"),
+        ("script_data", "script", "if (ready)"),
+        ("script_data_escaped", "script", "<!-- ok -->"),
+    ] {
+        let mut lexer = create_html_lexer().unwrap();
+        lexer.set_initial_state(initial_state).unwrap();
+        lexer.set_last_start_tag(last_start_tag);
+
+        lexer
+            .push(&format!("{text}</{last_start_tag}\u{000C}>"))
+            .unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![
+                Token::Text(text.to_string()),
+                Token::EndTag {
+                    name: last_start_tag.to_string()
+                },
+                Token::Eof,
+            ],
+            "state {initial_state} should emit the appropriate end tag"
+        );
+        assert!(
+            lexer
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.code == "unexpected-whitespace-after-end-tag-name"),
+            "state {initial_state} should report form-feed whitespace recovery"
+        );
+    }
+}
+
+#[test]
+fn default_html_lexer_recovers_seeded_text_mode_end_tags_with_form_feed_then_trailing_solidus() {
+    for (initial_state, last_start_tag, text) in [
+        ("rcdata", "title", "Hello"),
+        ("rawtext", "style", "body {}"),
+        ("script_data", "script", "if (ready)"),
+        ("script_data_escaped", "script", "<!-- ok -->"),
+    ] {
+        let mut lexer = create_html_lexer().unwrap();
+        lexer.set_initial_state(initial_state).unwrap();
+        lexer.set_last_start_tag(last_start_tag);
+
+        lexer
+            .push(&format!("{text}</{last_start_tag}\u{000C}/>"))
+            .unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![
+                Token::Text(text.to_string()),
+                Token::EndTag {
+                    name: last_start_tag.to_string()
+                },
+                Token::Eof,
+            ],
+            "state {initial_state} should emit the appropriate end tag"
+        );
+        assert!(
+            lexer
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.code == "end-tag-with-trailing-solidus"),
+            "state {initial_state} should report trailing solidus recovery"
         );
     }
 }


### PR DESCRIPTION
## Summary
- add form-feed to the HTML1 lexer alphabet and ASCII-whitespace transition sets
- cover form-feed whitespace in tag/attribute parsing, end-tag recovery, seeded text-mode end tags, and DOCTYPE states
- regenerate the statically linked Rust HTML1 lexer source

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_treats_form_feed_as_tag_whitespace -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_treats_form_feed_as_doctype_whitespace -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_recovers_end_tag_with_form_feed_then_trailing_solidus -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_recovers_seeded_text_mode_end_tags_with_form_feed -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test default_html_lexer_recovers_seeded_text_mode_end_tags_with_form_feed_then_trailing_solidus -- --exact --nocapture
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test
- cargo test --manifest-path code/packages/rust/state-machine-source-compiler/Cargo.toml html1_toml_compiles_to_rust_source
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check