### PR TITLE
Batch HTML lexer named reference prefix recovery

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -136,3 +136,7 @@ documented in this file.
   force-quirks token instead of a clean partial declaration.
 - Malformed `DOCTYPE` keyword text now marks force-quirks mode while preserving
   the recovered keyword text as the best-effort DOCTYPE name.
+- Named character reference recovery now uses the longest matching known
+  entity prefix in text and RCDATA, while preserving ambiguous ampersands
+  literally in attribute values when the missing-semicolon reference would be
+  followed by an ASCII alphanumeric character or `=`.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -25,6 +25,11 @@ the project, but the first real HTML authoring artifact that must keep HTML
 The default lexer already resolves the core named character references and the
 classic Latin-1 entity set, preserving entity-name case so legacy names such as
 `Agrave` and `agrave` remain distinct.
+Named character reference scanning now follows the longest-prefix shape of the
+HTML tokenizer: text and RCDATA recover inputs such as `&copycat` as `©cat`
+with a missing-semicolon diagnostic, while attribute values preserve ambiguous
+ampersands like `&copycat` literally when the would-be reference is followed by
+an ASCII alphanumeric character or `=`.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -99,7 +99,7 @@ fn fixture_manifests_parse() {
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 66);
+    assert_eq!(file.tests.len(), 69);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 66);
+    assert_eq!(normalized.cases.len(), 69);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 66);
+    assert_eq!(suite.cases.len(), 69);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -80,6 +80,8 @@ currently supports:
   `copy`, and `reg` before delimiters and EOF
 - generic named-character-reference scanning with literal fallback for unknown
   names
+- longest-prefix named-character-reference recovery for text and RCDATA, with
+  ambiguous ampersand preservation in attributes
 - semicolon-terminated decimal and hexadecimal numeric character references in
   data, RCDATA, and attribute values
 - missing-semicolon decimal and hexadecimal numeric character reference

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -605,6 +605,49 @@
     },
     {
       "id": "html5lib-smoke-47",
+      "description": "data state named character references use the longest matching prefix",
+      "input": "Text &notit; &copycat &sumtotal",
+      "tokens": [
+        "Text(data=Text \u00acit; \u00a9cat \u2211total)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-48",
+      "description": "attribute named character references preserve ambiguous ampersands",
+      "input": "<a title=\"&notit; &copycat &copy\" rel=&notin data=&notin;>",
+      "tokens": [
+        "StartTag(name=a, attributes=[title=&notit; &copycat \u00a9, rel=\u2209, data=\u2209], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-49",
+      "description": "rcdata named character references use the longest matching prefix",
+      "input": "&notit; &copycat</title>",
+      "tokens": [
+        "Text(data=\u00acit; \u00a9cat)",
+        "EndTag(name=title)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ],
+      "initial_state": "RCDATA state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-50",
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "tokens": [
@@ -616,7 +659,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-48",
+      "id": "html5lib-smoke-51",
       "description": "attribute numeric character references",
       "input": "<a title=\"&#65;&#x42;\" data-x='&#X43;' note=&#0;>",
       "tokens": [
@@ -628,7 +671,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-49",
+      "id": "html5lib-smoke-52",
       "description": "invalid numeric character reference recovery",
       "input": "<a data='&#0; &#xD800; &#x110000; &#xFDD0; &#x80;'>",
       "tokens": [
@@ -644,7 +687,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-50",
+      "id": "html5lib-smoke-53",
       "description": "numeric character references without digits stay literal",
       "input": "Bad &#; &#x; <a title='&#x;' data=&#;>",
       "tokens": [
@@ -660,7 +703,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-51",
+      "id": "html5lib-smoke-54",
       "description": "rcdata numeric character references remain text",
       "input": "Fish &#38; &#x3C;/title>",
       "tokens": [
@@ -672,7 +715,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-52",
+      "id": "html5lib-smoke-55",
       "description": "data state numeric character references missing semicolons",
       "input": "Letters: &#65 &#x42Z",
       "tokens": [
@@ -685,7 +728,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-53",
+      "id": "html5lib-smoke-56",
       "description": "attribute numeric character references missing semicolons",
       "input": "<a title=&#65 data-x=&#x42>",
       "tokens": [
@@ -698,7 +741,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-54",
+      "id": "html5lib-smoke-57",
       "description": "rcdata numeric character references missing semicolons",
       "input": "Fish &#38 &#x3C/title>",
       "tokens": [
@@ -713,7 +756,7 @@
       "last_start_tag": "title"
     },
     {
-      "id": "html5lib-smoke-55",
+      "id": "html5lib-smoke-58",
       "description": "script data double escaped state keeps first script end tag literal",
       "input": "x </script> y --></script>",
       "tokens": [
@@ -726,7 +769,7 @@
       "last_start_tag": "script"
     },
     {
-      "id": "html5lib-smoke-56",
+      "id": "html5lib-smoke-59",
       "description": "CDATA section state literalizes markup until delimiter",
       "input": "<not-markup> &amp; ]]><p>x</p>",
       "tokens": [
@@ -740,7 +783,7 @@
       "initial_state": "CDATA section state"
     },
     {
-      "id": "html5lib-smoke-57",
+      "id": "html5lib-smoke-60",
       "description": "markup declaration CDATA opener enters CDATA section",
       "input": "<![CDATA[<not-markup> &amp; ]]><p>After</p>",
       "tokens": [
@@ -753,7 +796,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-58",
+      "id": "html5lib-smoke-61",
       "description": "nested comment opener reports tokenizer error",
       "input": "Before<!--a <!-- b -->After",
       "tokens": [
@@ -767,7 +810,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-59",
+      "id": "html5lib-smoke-62",
       "description": "incorrectly closed comment end bang",
       "input": "Before<!--x--!>After",
       "tokens": [
@@ -781,7 +824,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-60",
+      "id": "html5lib-smoke-63",
       "description": "question mark after tag open recovers as bogus comment",
       "input": "Before<?xml version=\"1.0\"?>After",
       "tokens": [
@@ -795,7 +838,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-61",
+      "id": "html5lib-smoke-64",
       "description": "question mark bogus comment eof has no eof-in-comment error",
       "input": "Before<?xml",
       "tokens": [
@@ -808,7 +851,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-62",
+      "id": "html5lib-smoke-65",
       "description": "incorrectly opened markup declaration reports tokenizer error",
       "input": "Before<!foo>After",
       "tokens": [
@@ -822,7 +865,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-63",
+      "id": "html5lib-smoke-66",
       "description": "empty incorrectly opened markup declaration reconsumes delimiter",
       "input": "Before<!>After",
       "tokens": [
@@ -836,7 +879,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-64",
+      "id": "html5lib-smoke-67",
       "description": "markup declaration opener eof recovers as empty bogus comment",
       "input": "Before<!",
       "tokens": [
@@ -849,7 +892,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-65",
+      "id": "html5lib-smoke-68",
       "description": "one dash markup declaration recovers as bogus comment",
       "input": "Before<!->Middle<!-x>After<!-",
       "tokens": [
@@ -868,7 +911,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-66",
+      "id": "html5lib-smoke-69",
       "description": "invalid end tag opener recovers as bogus comment",
       "input": "Before</3>After",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -518,6 +518,52 @@
       ]
     },
     {
+      "description": "data state named character references use the longest matching prefix",
+      "input": "Text &notit; &copycat &sumtotal",
+      "output": [
+        ["Character", "Text "],
+        ["Character", "\u00AC"],
+        ["Character", "it; "],
+        ["Character", "\u00A9"],
+        ["Character", "cat "],
+        ["Character", "\u2211"],
+        ["Character", "total"]
+      ],
+      "errors": [
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 10},
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 18},
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 27}
+      ]
+    },
+    {
+      "description": "attribute named character references preserve ambiguous ampersands",
+      "input": "<a title=\"&notit; &copycat &copy\" rel=&notin data=&notin;>",
+      "output": [
+        ["StartTag", "a", {"title": "&notit; &copycat \u00A9", "rel": "\u2209", "data": "\u2209"}]
+      ],
+      "errors": [
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 33},
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 45}
+      ]
+    },
+    {
+      "description": "rcdata named character references use the longest matching prefix",
+      "initialStates": ["RCDATA state"],
+      "lastStartTag": "title",
+      "input": "&notit; &copycat</title>",
+      "output": [
+        ["Character", "\u00AC"],
+        ["Character", "it; "],
+        ["Character", "\u00A9"],
+        ["Character", "cat"],
+        ["EndTag", "title"]
+      ],
+      "errors": [
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 5},
+        {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 13}
+      ]
+    },
+    {
       "description": "data state numeric character references",
       "input": "Letters: &#65; &#x42; &#X43; &#0;",
       "output": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -2151,6 +2151,108 @@ fn default_html_lexer_falls_back_for_unknown_named_character_references() {
 }
 
 #[test]
+fn default_html_lexer_uses_longest_named_character_reference_prefix_in_text() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Text &notit; &copycat &sumtotal").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Text \u{00AC}it; \u{00A9}cat \u{2211}total".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == "missing-semicolon-after-character-reference"
+            })
+            .count(),
+        3
+    );
+}
+
+#[test]
+fn default_html_lexer_preserves_ambiguous_ampersands_in_attributes() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("<a title=\"&notit; &copycat &copy\" rel=&notin data=&notin;>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "title".to_string(),
+                        value: "&notit; &copycat \u{00A9}".to_string(),
+                    },
+                    Attribute {
+                        name: "rel".to_string(),
+                        value: "\u{2209}".to_string(),
+                    },
+                    Attribute {
+                        name: "data".to_string(),
+                        value: "\u{2209}".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == "missing-semicolon-after-character-reference"
+            })
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn default_html_lexer_uses_longest_named_character_reference_prefix_in_rcdata() {
+    let mut lexer = create_html_lexer().unwrap();
+    lexer.set_initial_state("rcdata").unwrap();
+    lexer.set_last_start_tag("title");
+
+    lexer.push("&notit; &copycat</title>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("\u{00AC}it; \u{00A9}cat".to_string()),
+            Token::EndTag {
+                name: "title".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == "missing-semicolon-after-character-reference"
+            })
+            .count(),
+        2
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_numeric_character_references_in_data() {
     let tokens = lex_html("Letters: &#65; &#x42; &#X43; &#0;").unwrap();
 

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -110,6 +110,11 @@ Diagnostics and stream control:
 It also enforces a per-input step limit so malformed reconsume-style machines
 cannot spin forever on one code point.
 
+Named character reference actions consume the longest matching known entity
+prefix in text-like contexts and preserve ambiguous ampersands in attribute
+contexts when a missing-semicolon reference would be followed by an ASCII
+alphanumeric character or `=`.
+
 `commit_attribute_dedup` commits the current attribute only when the current
 start tag does not already have an attribute with the same interpreted name. If
 there is already a matching attribute, the runtime drops the current attribute

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -588,18 +588,43 @@ impl Tokenizer {
                     self.attribute_mut(action)?.value.push_str(replacement);
                 }
                 "append_named_character_reference_or_temporary_buffer_to_text" => {
-                    if let Some(replacement) = named_character_reference(&self.temporary_buffer) {
-                        self.text_buffer.push_str(replacement);
+                    if let Some(reference) =
+                        consume_named_character_reference(&self.temporary_buffer, false)
+                    {
+                        let remainder = reference.remainder.to_string();
+                        let missing_semicolon = reference.missing_semicolon;
+                        self.text_buffer.push_str(reference.replacement);
+                        self.text_buffer.push_str(&remainder);
                         self.temporary_buffer.clear();
+                        if missing_semicolon {
+                            self.diagnostics.push(Diagnostic {
+                                code: "missing-semicolon-after-character-reference".to_string(),
+                                position,
+                                state: state.to_string(),
+                            });
+                        }
                     } else {
                         self.text_buffer.push_str(&self.temporary_buffer);
                         self.temporary_buffer.clear();
                     }
                 }
                 "append_named_character_reference_or_temporary_buffer_to_attribute_value" => {
-                    if let Some(replacement) = named_character_reference(&self.temporary_buffer) {
+                    if let Some(reference) =
+                        consume_named_character_reference(&self.temporary_buffer, true)
+                    {
+                        let remainder = reference.remainder.to_string();
+                        let replacement = reference.replacement;
+                        let missing_semicolon = reference.missing_semicolon;
                         self.temporary_buffer.clear();
                         self.attribute_mut(action)?.value.push_str(replacement);
+                        self.attribute_mut(action)?.value.push_str(&remainder);
+                        if missing_semicolon {
+                            self.diagnostics.push(Diagnostic {
+                                code: "missing-semicolon-after-character-reference".to_string(),
+                                position,
+                                state: state.to_string(),
+                            });
+                        }
                     } else {
                         let temporary_buffer = std::mem::take(&mut self.temporary_buffer);
                         self.attribute_mut(action)?
@@ -608,9 +633,13 @@ impl Tokenizer {
                     }
                 }
                 "recover_named_character_reference_to_text" => {
-                    if let Some(replacement) = named_character_reference(&self.temporary_buffer) {
+                    if let Some(reference) =
+                        consume_named_character_reference(&self.temporary_buffer, false)
+                    {
+                        let remainder = reference.remainder.to_string();
+                        self.text_buffer.push_str(reference.replacement);
+                        self.text_buffer.push_str(&remainder);
                         self.temporary_buffer.clear();
-                        self.text_buffer.push_str(replacement);
                         self.diagnostics.push(Diagnostic {
                             code: "missing-semicolon-after-character-reference".to_string(),
                             position,
@@ -622,9 +651,14 @@ impl Tokenizer {
                     }
                 }
                 "recover_named_character_reference_to_attribute_value" => {
-                    if let Some(replacement) = named_character_reference(&self.temporary_buffer) {
+                    if let Some(reference) =
+                        consume_named_character_reference(&self.temporary_buffer, true)
+                    {
+                        let remainder = reference.remainder.to_string();
+                        let replacement = reference.replacement;
                         self.temporary_buffer.clear();
                         self.attribute_mut(action)?.value.push_str(replacement);
+                        self.attribute_mut(action)?.value.push_str(&remainder);
                         self.diagnostics.push(Diagnostic {
                             code: "missing-semicolon-after-character-reference".to_string(),
                             position,
@@ -1447,12 +1481,65 @@ fn windows_1252_control_replacement(value: u32) -> Option<char> {
     }
 }
 
-fn named_character_reference(buffer: &str) -> Option<&'static str> {
-    match buffer
-        .strip_prefix('&')
-        .unwrap_or(buffer)
-        .trim_end_matches(';')
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ConsumedNamedCharacterReference<'a> {
+    replacement: &'static str,
+    remainder: &'a str,
+    missing_semicolon: bool,
+}
+
+fn consume_named_character_reference(
+    buffer: &str,
+    in_attribute: bool,
+) -> Option<ConsumedNamedCharacterReference<'_>> {
+    let body = buffer.strip_prefix('&').unwrap_or(buffer);
+    for end in body
+        .char_indices()
+        .map(|(index, _)| index)
+        .chain(std::iter::once(body.len()))
+        .filter(|end| *end > 0)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
     {
+        let candidate = &body[..end];
+        let (name, missing_semicolon) = match candidate.strip_suffix(';') {
+            Some(name) => (name, false),
+            None => (candidate, true),
+        };
+        let Some(replacement) = named_character_reference_name(name) else {
+            continue;
+        };
+        let remainder = &body[end..];
+
+        if missing_semicolon
+            && in_attribute
+            && remainder
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '=')
+        {
+            return None;
+        }
+
+        return Some(ConsumedNamedCharacterReference {
+            replacement,
+            remainder,
+            missing_semicolon,
+        });
+    }
+
+    None
+}
+
+fn named_character_reference(buffer: &str) -> Option<&'static str> {
+    let name = buffer.strip_prefix('&').unwrap_or(buffer);
+    let name = name.strip_suffix(';').unwrap_or(name);
+    named_character_reference_name(name)
+}
+
+fn named_character_reference_name(name: &str) -> Option<&'static str> {
+    match name {
         "AElig" => Some("\u{00C6}"),
         "Aacute" => Some("\u{00C1}"),
         "Acirc" => Some("\u{00C2}"),


### PR DESCRIPTION
## Summary
- consume the longest matching named-character-reference prefix in text and RCDATA recovery paths
- preserve ambiguous ampersands in attributes when a missing-semicolon reference would be followed by an ASCII alphanumeric character or equals sign
- add native lexer tests plus upstream-style and normalized html5lib smoke fixtures for the behavior
- document the runtime semantics and fixture importer coverage

## Verification
- python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
- rustfmt code/packages/rust/state-machine-tokenizer/src/lib.rs code/packages/rust/html-lexer/tests/html_lexer_test.rs code/packages/rust/html-lexer/tests/conformance_test.rs
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check