### PR TITLE
feat(prolog): expose residual query constraints

### DIFF
--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -35,6 +35,8 @@
 - Run Prolog term equality predicates `=/2`, `\\=/2`, `==/2`, and `\\==/2`
   through the VM path.
 - Run Prolog `dif/2` through the VM path as a delayed disequality constraint.
+- Expose residual delayed disequality constraints on named `PrologAnswer`
+  values produced by compiled source queries and stateful runtimes.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -58,6 +58,10 @@ answers = run_initialized_compiled_prolog_query_answers(compiled)
 assert [answer.as_dict() for answer in answers] == [{"Name": atom("alpha")}]
 ```
 
+Named `PrologAnswer` values also expose `residual_constraints` so delayed goals
+such as `dif(X, tea)` stay visible when the answer still contains unresolved
+logic variables.
+
 ## Stateful Query Runtime
 
 Use `create_swi_prolog_vm_runtime(...)` when you want to consult a program once
@@ -137,6 +141,7 @@ The package includes end-to-end stress tests for:
   `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`
 - dynamic predicates seeded by initialization directives
 - named Python answer bindings
+- residual delayed `dif/2` constraints on named answers
 - loader term/goal expansion before VM compilation
 
 ## Layer Position

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/compiler.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/compiler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass
+from itertools import islice
 from pathlib import Path
 from types import MappingProxyType
 
@@ -11,6 +12,7 @@ from logic_engine import (
     Clause,
     Compound,
     ConjExpr,
+    Disequality,
     DisjExpr,
     FreshExpr,
     GoalExpr,
@@ -106,12 +108,18 @@ class PrologAnswer:
     """A named source-level answer produced by the compiled Prolog VM path."""
 
     bindings: Mapping[str, Term]
+    residual_constraints: tuple[Disequality, ...] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
             "bindings",
             MappingProxyType(dict(self.bindings)),
+        )
+        object.__setattr__(
+            self,
+            "residual_constraints",
+            tuple(self.residual_constraints),
         )
 
     def as_dict(self) -> dict[str, Term]:
@@ -163,7 +171,11 @@ class PrologVMRuntime:
             if committed_state is None:
                 committed_state = proof_state
             answers.append(
-                _answer_from_terms(parsed_query.variables.keys(), outputs, proof_state),
+                _answer_from_terms(
+                    parsed_query.variables.keys(),
+                    outputs,
+                    proof_state,
+                ),
             )
 
         if commit and committed_state is not None:
@@ -440,14 +452,13 @@ def run_compiled_prolog_query_answers(
 ) -> list[PrologAnswer]:
     """Run one source query and return bindings keyed by Prolog variable name."""
 
-    return _answers_from_results(
+    vm = load_compiled_prolog_vm(compiled_program)
+    return _answers_from_vm_query(
         compiled_program,
+        vm,
+        State(),
         source_query_index,
-        run_compiled_prolog_query(
-            compiled_program,
-            source_query_index=source_query_index,
-            limit=limit,
-        ),
+        limit=limit,
     )
 
 
@@ -502,14 +513,14 @@ def run_initialized_compiled_prolog_query_answers(
 ) -> list[PrologAnswer]:
     """Run initializations and return named bindings for one source query."""
 
-    return _answers_from_results(
+    vm = load_compiled_prolog_vm(compiled_program)
+    initialized_state = _run_initializations_on_vm(vm, compiled_program)
+    return _answers_from_vm_query(
         compiled_program,
+        vm,
+        initialized_state,
         source_query_index,
-        run_initialized_compiled_prolog_query(
-            compiled_program,
-            source_query_index=source_query_index,
-            limit=limit,
-        ),
+        limit=limit,
     )
 
 
@@ -690,20 +701,33 @@ def _run_initializations_on_vm(
     return current_state
 
 
-def _answers_from_results(
+def _answers_from_vm_query(
     compiled_program: CompiledPrologVMProgram,
+    vm: LogicVM,
+    state: State,
     source_query_index: int,
-    results: list[Term | tuple[Term, ...]],
+    *,
+    limit: int | None,
 ) -> list[PrologAnswer]:
-    names = compiled_program.source_query_variable_names(source_query_index)
-    if not names:
-        return [PrologAnswer({}) for _result in results]
+    if limit is not None and limit < 0:
+        msg = "query limit must be non-negative"
+        raise ValueError(msg)
 
-    answers: list[PrologAnswer] = []
-    for result in results:
-        values = result if isinstance(result, tuple) else (result,)
-        answers.append(PrologAnswer(dict(zip(names, values, strict=True))))
-    return answers
+    vm_query_index = compiled_program.source_query_vm_index(source_query_index)
+    names = compiled_program.source_query_variable_names(source_query_index)
+    try:
+        outputs = vm.state.queries[vm_query_index].outputs or ()
+    except IndexError as exc:
+        msg = f"query index {vm_query_index} is out of range"
+        raise IndexError(msg) from exc
+
+    proof_states = vm.solve_query_from(state, vm_query_index)
+    if limit is not None:
+        proof_states = islice(proof_states, limit)
+    return [
+        _answer_from_terms(names, tuple(outputs), proof_state)
+        for proof_state in proof_states
+    ]
 
 
 def _answer_from_terms(
@@ -711,13 +735,25 @@ def _answer_from_terms(
     outputs: tuple[Term, ...],
     state: State,
 ) -> PrologAnswer:
+    residual_constraints = _residual_constraints(state)
     if not outputs:
-        return PrologAnswer({})
+        return PrologAnswer({}, residual_constraints=residual_constraints)
     return PrologAnswer(
         {
             name: reify(output, state.substitution)
             for name, output in zip(names, outputs, strict=True)
         },
+        residual_constraints=residual_constraints,
+    )
+
+
+def _residual_constraints(state: State) -> tuple[Disequality, ...]:
+    return tuple(
+        Disequality(
+            left=reify(constraint.left, state.substitution),
+            right=reify(constraint.right, state.substitution),
+        )
+        for constraint in state.constraints
     )
 
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_runtime.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from logic_engine import atom
+from logic_engine import Disequality, LogicVar, atom
 
 from prolog_vm_compiler import (
     compile_swi_prolog_project_from_files,
@@ -81,6 +81,18 @@ class TestPrologVMRuntime:
         )
 
         assert runtime.query_values("pick(Value)", limit=1) == [atom("first")]
+
+    def test_runtime_answers_expose_residual_constraints(self) -> None:
+        runtime = create_swi_prolog_vm_runtime("")
+
+        answers = runtime.query("dif(X, tea).")
+
+        assert len(answers) == 1
+        binding = answers[0].as_dict()["X"]
+        assert isinstance(binding, LogicVar)
+        assert answers[0].residual_constraints == (
+            Disequality(left=binding, right=atom("tea")),
+        )
 
     def test_runtime_can_be_created_from_an_existing_compiled_program(self) -> None:
         compiled = compile_swi_prolog_source(

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from logic_engine import atom, logic_list, num, term
+from logic_engine import Disequality, LogicVar, atom, logic_list, num, term
 
 from prolog_vm_compiler import (
     compile_swi_prolog_project,
@@ -152,6 +152,18 @@ class TestPrologVMStress:
             },
         ]
         assert run_compiled_prolog_query(failure) == []
+
+    def test_dif_residual_constraints_are_visible_on_named_answers(self) -> None:
+        compiled = compile_swi_prolog_source("?- dif(X, tea).")
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert len(answers) == 1
+        binding = answers[0].as_dict()["X"]
+        assert isinstance(binding, LogicVar)
+        assert answers[0].residual_constraints == (
+            Disequality(left=binding, right=atom("tea")),
+        )
 
     def test_if_then_else_commits_to_first_condition_solution(self) -> None:
         compiled = compile_swi_prolog_source(

--- a/code/specs/PR44-prolog-residual-constraints.md
+++ b/code/specs/PR44-prolog-residual-constraints.md
@@ -1,0 +1,44 @@
+# PR44: Prolog VM Residual Constraints
+
+## Goal
+
+Expose delayed constraints that remain after a Prolog query succeeds so Python
+callers can inspect complete Prolog-style answers, not only variable bindings.
+
+## Motivation
+
+`dif/2` can succeed before both sides are fully known by leaving a pending
+disequality constraint in the Logic VM state. The VM already preserves those
+constraints, but the named Prolog answer helpers previously converted proof
+states into raw output values and discarded the residual constraint store.
+
+That made queries such as `?- dif(X, tea).` look like a plain unbound `X`
+answer, hiding the important condition `X \= tea`.
+
+## Design
+
+- Keep raw value helpers such as `run_compiled_prolog_query(...)` unchanged.
+- Preserve proof states in named answer helpers so bindings and residuals come
+  from the same VM solution.
+- Add `PrologAnswer.residual_constraints`, a tuple of reified `Disequality`
+  values.
+- Reify residual constraint terms through the answer state's substitution before
+  exposing them.
+- Apply the same answer shape to compiled source queries and stateful ad-hoc
+  runtime queries.
+
+## Example
+
+```python
+answers = runtime.query("dif(X, tea).")
+answer = answers[0]
+
+assert "X" in answer.as_dict()
+assert answer.residual_constraints
+```
+
+## Follow-Ups
+
+- Add residual visibility for future constraint families beyond disequality.
+- Add a higher-level pretty-printer once the Prolog top-level display layer
+  exists.


### PR DESCRIPTION
## Summary
- preserve VM proof states for named Prolog source-query answers
- expose reified delayed `dif/2` residuals via `PrologAnswer.residual_constraints`
- add stress/runtime coverage plus PR44 spec and docs

## Verification
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-residuals -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-residuals-build-plan.json`