### PR TITLE
[codex] Port neural demos to graph VM

### DIFF
--- a/code/packages/elixir/neural_network/lib/neural_network.ex
+++ b/code/packages/elixir/neural_network/lib/neural_network.ex
@@ -7,11 +7,18 @@ defmodule NeuralNetwork.WeightedInput do
 end
 
 defmodule NeuralNetwork.Graph do
-  defstruct graph_properties: %{"nn.version" => "0"}, nodes: [], node_properties: %{}, edges: [], next_edge_id: 0
+  defstruct graph_properties: %{"nn.version" => "0"},
+            nodes: [],
+            node_properties: %{},
+            edges: [],
+            next_edge_id: 0
 
   def new(name \\ nil) do
     graph = %__MODULE__{}
-    if name == nil, do: graph, else: %{graph | graph_properties: Map.put(graph.graph_properties, "nn.name", name)}
+
+    if name == nil,
+      do: graph,
+      else: %{graph | graph_properties: Map.put(graph.graph_properties, "nn.name", name)}
   end
 
   def add_node(graph, node, properties \\ %{}) do
@@ -21,15 +28,32 @@ defmodule NeuralNetwork.Graph do
       else
         {graph.nodes ++ [node], Map.put(graph.node_properties, node, %{})}
       end
-    %{graph | nodes: nodes, node_properties: Map.update!(node_properties, node, &Map.merge(&1, properties))}
+
+    %{
+      graph
+      | nodes: nodes,
+        node_properties: Map.update!(node_properties, node, &Map.merge(&1, properties))
+    }
   end
 
   def node_properties(graph, node), do: Map.get(graph.node_properties, node, %{})
 
   def add_edge(graph, from, to, weight \\ 1.0, properties \\ %{}, edge_id \\ nil) do
     graph = graph |> add_node(from) |> add_node(to)
-    {id, next_edge_id} = if edge_id == nil, do: {"e#{graph.next_edge_id}", graph.next_edge_id + 1}, else: {edge_id, graph.next_edge_id}
-    edge = %NeuralNetwork.Edge{id: id, from: from, to: to, weight: weight / 1, properties: Map.put(properties, "weight", weight / 1)}
+
+    {id, next_edge_id} =
+      if edge_id == nil,
+        do: {"e#{graph.next_edge_id}", graph.next_edge_id + 1},
+        else: {edge_id, graph.next_edge_id}
+
+    edge = %NeuralNetwork.Edge{
+      id: id,
+      from: from,
+      to: to,
+      weight: weight / 1,
+      properties: Map.put(properties, "weight", weight / 1)
+    }
+
     {%{graph | edges: graph.edges ++ [edge], next_edge_id: next_edge_id}, id}
   end
 
@@ -37,14 +61,27 @@ defmodule NeuralNetwork.Graph do
 
   def topological_sort(graph) do
     indegree = Enum.reduce(graph.nodes, %{}, &Map.put(&2, &1, 0))
-    indegree = Enum.reduce(graph.edges, indegree, fn edge, acc -> acc |> Map.put_new(edge.from, 0) |> Map.update(edge.to, 1, &(&1 + 1)) end)
-    ready = indegree |> Enum.filter(fn {_node, degree} -> degree == 0 end) |> Enum.map(&elem(&1, 0)) |> Enum.sort()
+
+    indegree =
+      Enum.reduce(graph.edges, indegree, fn edge, acc ->
+        acc |> Map.put_new(edge.from, 0) |> Map.update(edge.to, 1, &(&1 + 1))
+      end)
+
+    ready =
+      indegree
+      |> Enum.filter(fn {_node, degree} -> degree == 0 end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.sort()
+
     do_topological_sort(graph.edges, indegree, ready, [])
   end
 
-  defp do_topological_sort(edges, indegree, [], order) do
-    if length(order) == map_size(indegree), do: {:ok, order}, else: {:error, "neural graph contains a cycle"}
+  defp do_topological_sort(_edges, indegree, [], order) do
+    if length(order) == map_size(indegree),
+      do: {:ok, order},
+      else: {:error, "neural graph contains a cycle"}
   end
+
   defp do_topological_sort(edges, indegree, [node | rest], order) do
     {indegree, released} =
       edges
@@ -53,6 +90,7 @@ defmodule NeuralNetwork.Graph do
         next = Map.update!(degrees, edge.to, &(&1 - 1))
         if next[edge.to] == 0, do: {next, [edge.to | released]}, else: {next, released}
       end)
+
     do_topological_sort(edges, indegree, rest ++ Enum.sort(released), order ++ [node])
   end
 end
@@ -60,31 +98,105 @@ end
 defmodule NeuralNetwork.Network do
   defstruct [:graph]
   def new(name \\ nil), do: %__MODULE__{graph: NeuralNetwork.create_neural_graph(name)}
-  def input(network, node, input_name \\ nil, properties \\ %{}), do: %{network | graph: NeuralNetwork.add_input(network.graph, node, input_name || node, properties)}
-  def constant(network, node, value, properties \\ %{}), do: %{network | graph: NeuralNetwork.add_constant(network.graph, node, value, properties)}
-  def weighted_sum(network, node, inputs, properties \\ %{}), do: %{network | graph: NeuralNetwork.add_weighted_sum(network.graph, node, inputs, properties)}
-  def activation(network, node, input, activation, properties \\ %{}, edge_id \\ nil), do: %{network | graph: NeuralNetwork.add_activation(network.graph, node, input, activation, properties, edge_id) |> elem(0)}
-  def output(network, node, input, output_name \\ nil, properties \\ %{}, edge_id \\ nil), do: %{network | graph: NeuralNetwork.add_output(network.graph, node, input, output_name || node, properties, edge_id) |> elem(0)}
+
+  def input(network, node, input_name \\ nil, properties \\ %{}),
+    do: %{
+      network
+      | graph: NeuralNetwork.add_input(network.graph, node, input_name || node, properties)
+    }
+
+  def constant(network, node, value, properties \\ %{}),
+    do: %{network | graph: NeuralNetwork.add_constant(network.graph, node, value, properties)}
+
+  def weighted_sum(network, node, inputs, properties \\ %{}),
+    do: %{
+      network
+      | graph: NeuralNetwork.add_weighted_sum(network.graph, node, inputs, properties)
+    }
+
+  def activation(network, node, input, activation, properties \\ %{}, edge_id \\ nil),
+    do: %{
+      network
+      | graph:
+          NeuralNetwork.add_activation(
+            network.graph,
+            node,
+            input,
+            activation,
+            properties,
+            edge_id
+          )
+          |> elem(0)
+    }
+
+  def output(network, node, input, output_name \\ nil, properties \\ %{}, edge_id \\ nil),
+    do: %{
+      network
+      | graph:
+          NeuralNetwork.add_output(
+            network.graph,
+            node,
+            input,
+            output_name || node,
+            properties,
+            edge_id
+          )
+          |> elem(0)
+    }
 end
 
 defmodule NeuralNetwork do
   alias NeuralNetwork.{Graph, Network, WeightedInput}
   def create_neural_graph(name \\ nil), do: Graph.new(name)
   def create_neural_network(name \\ nil), do: Network.new(name)
-  def wi(from, weight, edge_id), do: %WeightedInput{from: from, weight: weight / 1, edge_id: edge_id, properties: %{}}
 
-  def add_input(graph, node, input_name \\ nil, properties \\ %{}), do: Graph.add_node(graph, node, Map.merge(properties, %{"nn.op" => "input", "nn.input" => input_name || node}))
-  def add_constant(graph, node, value, properties \\ %{}), do: Graph.add_node(graph, node, Map.merge(properties, %{"nn.op" => "constant", "nn.value" => value / 1}))
+  def wi(from, weight, edge_id),
+    do: %WeightedInput{from: from, weight: weight / 1, edge_id: edge_id, properties: %{}}
+
+  def add_input(graph, node, input_name \\ nil, properties \\ %{}),
+    do:
+      Graph.add_node(
+        graph,
+        node,
+        Map.merge(properties, %{"nn.op" => "input", "nn.input" => input_name || node})
+      )
+
+  def add_constant(graph, node, value, properties \\ %{}),
+    do:
+      Graph.add_node(
+        graph,
+        node,
+        Map.merge(properties, %{"nn.op" => "constant", "nn.value" => value / 1})
+      )
+
   def add_weighted_sum(graph, node, inputs, properties \\ %{}) do
     graph = Graph.add_node(graph, node, Map.merge(properties, %{"nn.op" => "weighted_sum"}))
-    Enum.reduce(inputs, graph, fn input, acc -> Graph.add_edge(acc, input.from, node, input.weight, input.properties, input.edge_id) |> elem(0) end)
+
+    Enum.reduce(inputs, graph, fn input, acc ->
+      Graph.add_edge(acc, input.from, node, input.weight, input.properties, input.edge_id)
+      |> elem(0)
+    end)
   end
+
   def add_activation(graph, node, input, activation, properties \\ %{}, edge_id \\ nil) do
-    graph = Graph.add_node(graph, node, Map.merge(properties, %{"nn.op" => "activation", "nn.activation" => activation}))
+    graph =
+      Graph.add_node(
+        graph,
+        node,
+        Map.merge(properties, %{"nn.op" => "activation", "nn.activation" => activation})
+      )
+
     Graph.add_edge(graph, input, node, 1.0, %{}, edge_id)
   end
+
   def add_output(graph, node, input, output_name \\ nil, properties \\ %{}, edge_id \\ nil) do
-    graph = Graph.add_node(graph, node, Map.merge(properties, %{"nn.op" => "output", "nn.output" => output_name || node}))
+    graph =
+      Graph.add_node(
+        graph,
+        node,
+        Map.merge(properties, %{"nn.op" => "output", "nn.output" => output_name || node})
+      )
+
     Graph.add_edge(graph, input, node, 1.0, %{}, edge_id)
   end
 
@@ -93,12 +205,56 @@ defmodule NeuralNetwork do
     |> Network.input("x0")
     |> Network.input("x1")
     |> Network.constant("bias", 1.0, %{"nn.role" => "bias"})
-    |> Network.weighted_sum("h_or_sum", [wi("x0", 20, "x0_to_h_or"), wi("x1", 20, "x1_to_h_or"), wi("bias", -10, "bias_to_h_or")], %{"nn.layer" => "hidden"})
-    |> Network.activation("h_or", "h_or_sum", "sigmoid", %{"nn.layer" => "hidden"}, "h_or_sum_to_h_or")
-    |> Network.weighted_sum("h_nand_sum", [wi("x0", -20, "x0_to_h_nand"), wi("x1", -20, "x1_to_h_nand"), wi("bias", 30, "bias_to_h_nand")], %{"nn.layer" => "hidden"})
-    |> Network.activation("h_nand", "h_nand_sum", "sigmoid", %{"nn.layer" => "hidden"}, "h_nand_sum_to_h_nand")
-    |> Network.weighted_sum("out_sum", [wi("h_or", 20, "h_or_to_out"), wi("h_nand", 20, "h_nand_to_out"), wi("bias", -30, "bias_to_out")], %{"nn.layer" => "output"})
-    |> Network.activation("out_activation", "out_sum", "sigmoid", %{"nn.layer" => "output"}, "out_sum_to_activation")
-    |> Network.output("out", "out_activation", "prediction", %{"nn.layer" => "output"}, "activation_to_out")
+    |> Network.weighted_sum(
+      "h_or_sum",
+      [wi("x0", 20, "x0_to_h_or"), wi("x1", 20, "x1_to_h_or"), wi("bias", -10, "bias_to_h_or")],
+      %{"nn.layer" => "hidden"}
+    )
+    |> Network.activation(
+      "h_or",
+      "h_or_sum",
+      "sigmoid",
+      %{"nn.layer" => "hidden"},
+      "h_or_sum_to_h_or"
+    )
+    |> Network.weighted_sum(
+      "h_nand_sum",
+      [
+        wi("x0", -20, "x0_to_h_nand"),
+        wi("x1", -20, "x1_to_h_nand"),
+        wi("bias", 30, "bias_to_h_nand")
+      ],
+      %{"nn.layer" => "hidden"}
+    )
+    |> Network.activation(
+      "h_nand",
+      "h_nand_sum",
+      "sigmoid",
+      %{"nn.layer" => "hidden"},
+      "h_nand_sum_to_h_nand"
+    )
+    |> Network.weighted_sum(
+      "out_sum",
+      [
+        wi("h_or", 20, "h_or_to_out"),
+        wi("h_nand", 20, "h_nand_to_out"),
+        wi("bias", -30, "bias_to_out")
+      ],
+      %{"nn.layer" => "output"}
+    )
+    |> Network.activation(
+      "out_activation",
+      "out_sum",
+      "sigmoid",
+      %{"nn.layer" => "output"},
+      "out_sum_to_activation"
+    )
+    |> Network.output(
+      "out",
+      "out_activation",
+      "prediction",
+      %{"nn.layer" => "output"},
+      "activation_to_out"
+    )
   end
 end

--- a/code/packages/elixir/perceptron/lib/perceptron.ex
+++ b/code/packages/elixir/perceptron/lib/perceptron.ex
@@ -16,36 +16,38 @@ defmodule Perceptron do
     weights = Matrix.new(w_data)
     bias = 0.0
 
-    {final_weights, final_bias} = Enum.reduce(0..model.epochs, {weights, bias}, fn epoch, {curr_weights, curr_bias} ->
-      raw = features |> Matrix.dot(curr_weights) |> Matrix.add_scalar(curr_bias)
+    {final_weights, final_bias} =
+      Enum.reduce(0..model.epochs, {weights, bias}, fn epoch, {curr_weights, curr_bias} ->
+        raw = features |> Matrix.dot(curr_weights) |> Matrix.add_scalar(curr_bias)
 
-      probs = Enum.map(raw.data, fn [val] -> [ActivationFunctions.sigmoid(val)] end)
-      
-      linear_truth = Enum.map(true_labels.data, fn [v] -> v end)
-      linear_probs = Enum.map(probs, fn [v] -> v end)
+        probs = Enum.map(raw.data, fn [val] -> [ActivationFunctions.sigmoid(val)] end)
 
-      log_loss = LossFunctions.bce(linear_truth, linear_probs)
-      loss_grad = LossFunctions.bce_derivative(linear_truth, linear_probs)
+        linear_truth = Enum.map(true_labels.data, fn [v] -> v end)
+        linear_probs = Enum.map(probs, fn [v] -> v end)
 
-      {grad_data, bias_grad} = Enum.reduce(0..(features.rows - 1), {[], 0.0}, fn i, {acc_grad, acc_bias} ->
-        act_grad = ActivationFunctions.sigmoid_derivative(Enum.at(Enum.at(raw.data, i), 0))
-        combined = Enum.at(loss_grad, i) * act_grad
-        {acc_grad ++ [[combined]], acc_bias + combined}
+        log_loss = LossFunctions.bce(linear_truth, linear_probs)
+        loss_grad = LossFunctions.bce_derivative(linear_truth, linear_probs)
+
+        {grad_data, bias_grad} =
+          Enum.reduce(0..(features.rows - 1), {[], 0.0}, fn i, {acc_grad, acc_bias} ->
+            act_grad = ActivationFunctions.sigmoid_derivative(Enum.at(Enum.at(raw.data, i), 0))
+            combined = Enum.at(loss_grad, i) * act_grad
+            {acc_grad ++ [[combined]], acc_bias + combined}
+          end)
+
+        grad_matrix = Matrix.new(grad_data)
+        weight_grads = features |> Matrix.transpose() |> Matrix.dot(grad_matrix)
+
+        scaled_weights = Matrix.scale(weight_grads, model.learning_rate)
+        new_weights = Matrix.subtract(curr_weights, scaled_weights)
+        new_bias = curr_bias - bias_grad * model.learning_rate
+
+        if rem(epoch, log_steps) == 0 do
+          :io.format("Epoch ~4w | BCE Loss: ~.4f | Bias: ~.2f~n", [epoch, log_loss, new_bias])
+        end
+
+        {new_weights, new_bias}
       end)
-
-      grad_matrix = Matrix.new(grad_data)
-      weight_grads = features |> Matrix.transpose() |> Matrix.dot(grad_matrix)
-
-      scaled_weights = Matrix.scale(weight_grads, model.learning_rate)
-      new_weights = Matrix.subtract(curr_weights, scaled_weights)
-      new_bias = curr_bias - (bias_grad * model.learning_rate)
-
-      if rem(epoch, log_steps) == 0 do
-        :io.format("Epoch ~4w | BCE Loss: ~4.4f | Bias: ~4.2f~n", [epoch, log_loss, new_bias])
-      end
-
-      {new_weights, new_bias}
-    end)
 
     %{model | weights: final_weights, bias: final_bias}
   end

--- a/code/packages/go/perceptron/perceptron.go
+++ b/code/packages/go/perceptron/perceptron.go
@@ -44,7 +44,7 @@ func (p *Perceptron) Fit(xData [][]float64, yData [][]float64, logSteps int) {
 
 			for epoch := 0; epoch <= p.Epochs; epoch++ {
 				raw, _ := features.Dot(p.Weights)
-				raw.AddScalar(p.Bias)
+				raw = raw.AddScalar(p.Bias)
 
 				linearProbs := make([]float64, features.Rows)
 				linearTruth := make([]float64, features.Rows)
@@ -92,7 +92,7 @@ func (p *Perceptron) Predict(xData [][]float64) []float64 {
 
 			features := matrix.New2D(xData)
 			raw, _ := features.Dot(p.Weights)
-			raw.AddScalar(p.Bias)
+			raw = raw.AddScalar(p.Bias)
 
 			predictions := make([]float64, features.Rows)
 			for i := 0; i < features.Rows; i++ {

--- a/code/packages/rust/perceptron/src/lib.rs
+++ b/code/packages/rust/perceptron/src/lib.rs
@@ -1,6 +1,6 @@
-use matrix::Matrix;
 use activation_functions::{sigmoid, sigmoid_derivative};
 use loss_functions::{bce, bce_derivative};
+use matrix::Matrix;
 
 pub struct Perceptron {
     pub learning_rate: f64,
@@ -31,8 +31,10 @@ impl Perceptron {
         self.bias = 0.0;
 
         for epoch in 0..=self.epochs {
-            let mut raw = features.dot(self.weights.as_ref().unwrap()).unwrap();
-            raw.add_scalar(self.bias);
+            let raw = features
+                .dot(self.weights.as_ref().unwrap())
+                .unwrap()
+                .add_scalar(self.bias);
 
             let mut linear_probs = vec![0.0; features.rows];
             let mut linear_truth = vec![0.0; features.rows];
@@ -59,19 +61,30 @@ impl Perceptron {
             let weight_grads = features.transpose().dot(&grad_matrix).unwrap();
 
             let scaled_weights = weight_grads.scale(self.learning_rate);
-            self.weights = Some(self.weights.as_ref().unwrap().subtract(&scaled_weights).unwrap());
+            self.weights = Some(
+                self.weights
+                    .as_ref()
+                    .unwrap()
+                    .subtract(&scaled_weights)
+                    .unwrap(),
+            );
             self.bias -= bias_grad * self.learning_rate;
 
             if epoch % log_steps == 0 {
-                println!("Epoch {:4} | BCE Loss: {:.4} | Bias: {:.2}", epoch, log_loss, self.bias);
+                println!(
+                    "Epoch {:4} | BCE Loss: {:.4} | Bias: {:.2}",
+                    epoch, log_loss, self.bias
+                );
             }
         }
     }
 
     pub fn predict(&self, x_data: Vec<Vec<f64>>) -> Vec<f64> {
         let features = Matrix::new_2d(x_data);
-        let mut raw = features.dot(self.weights.as_ref().unwrap()).unwrap();
-        raw.add_scalar(self.bias);
+        let raw = features
+            .dot(self.weights.as_ref().unwrap())
+            .unwrap()
+            .add_scalar(self.bias);
 
         let mut predictions = vec![0.0; features.rows];
         for i in 0..features.rows {

--- a/code/programs/elixir/celsius_to_fahrenheit_predictor/lib/celsius_to_fahrenheit.ex
+++ b/code/programs/elixir/celsius_to_fahrenheit_predictor/lib/celsius_to_fahrenheit.ex
@@ -7,40 +7,81 @@ defmodule CodingAdventures.CelsiusToFahrenheit do
 
   def train(loss_name, loss_fn, deriv_fn, lr, max_epochs \\ 10000) do
     IO.puts("\n--- Celsius to Fahrenheit Predictor: Training with #{loss_name} ---")
-    train_loop(0, 0.5, 0.5, loss_fn, deriv_fn, lr, max_epochs)
+    train_loop(0, 0.5, 0.5, loss_name, loss_fn, deriv_fn, lr, max_epochs)
   end
 
-  defp train_loop(epoch, w, b, _loss_fn, _deriv_fn, _lr, max_epochs) when epoch >= max_epochs do
-    print_final(w, b)
+  defp train_loop(epoch, w, b, loss_name, _loss_fn, _deriv_fn, _lr, max_epochs)
+       when epoch >= max_epochs do
+    print_final(loss_name, w, b)
   end
 
-  defp train_loop(epoch, w, b, loss_fn, deriv_fn, lr, max_epochs) do
+  defp train_loop(epoch, w, b, loss_name, loss_fn, deriv_fn, lr, max_epochs) do
     y_pred = Enum.map(@celsius, fn c -> w * c + b end)
     err = apply(LF, loss_fn, [@fahrenheit, y_pred])
 
     if err < 0.5 do
       IO.puts("Converged beautifully in #{epoch + 1} epochs! (Loss: #{Float.round(err, 6)})")
       IO.puts("Final Formula: F = C * #{Float.round(w, 6)} + #{Float.round(b, 6)}")
-      print_final(w, b)
+      print_final(loss_name, w, b)
     else
       gradients = apply(LF, deriv_fn, [@fahrenheit, y_pred])
-      
+
       grad_w = Enum.zip(gradients, @celsius) |> Enum.map(fn {g, c} -> g * c end) |> Enum.sum()
       grad_b = Enum.sum(gradients)
 
       [new_w, new_b] = GD.sgd([w, b], [grad_w, grad_b], lr)
 
       if rem(epoch + 1, 1000) == 0 do
-        IO.puts("Epoch #{String.pad_leading(Integer.to_string(epoch + 1), 4, "0")} -> Loss: #{Float.round(err, 6)} | w: #{Float.round(new_w, 4)} | b: #{Float.round(new_b, 4)}")
+        IO.puts(
+          "Epoch #{String.pad_leading(Integer.to_string(epoch + 1), 4, "0")} -> Loss: #{Float.round(err, 6)} | w: #{Float.round(new_w, 4)} | b: #{Float.round(new_b, 4)}"
+        )
       end
 
-      train_loop(epoch + 1, new_w, new_b, loss_fn, deriv_fn, lr, max_epochs)
+      train_loop(epoch + 1, new_w, new_b, loss_name, loss_fn, deriv_fn, lr, max_epochs)
     end
   end
 
-  defp print_final(w, b) do
+  defp print_final(loss_name, w, b) do
     pred_f = w * 100.0 + b
     IO.puts("Prediction for 100.0 C -> #{Float.round(pred_f, 2)} F (Expected ~212.00 F)")
+    run_graph_vm_inference(loss_name, w, b, 100.0)
+  end
+
+  defp run_graph_vm_inference(loss_name, weight, bias, celsius_value) do
+    network =
+      NeuralNetwork.create_neural_network("celsius-to-fahrenheit-#{loss_name}")
+      |> NeuralNetwork.Network.input("celsius")
+      |> NeuralNetwork.Network.constant("bias", 1.0, %{"nn.role" => "bias"})
+      |> NeuralNetwork.Network.weighted_sum(
+        "fahrenheit_sum",
+        [
+          NeuralNetwork.wi("celsius", weight, "celsius_weight"),
+          NeuralNetwork.wi("bias", bias, "fahrenheit_bias")
+        ],
+        %{"nn.layer" => "output", "nn.role" => "weighted_sum"}
+      )
+      |> NeuralNetwork.Network.activation(
+        "fahrenheit_linear",
+        "fahrenheit_sum",
+        "none",
+        %{"nn.layer" => "output", "nn.role" => "identity_activation"},
+        "sum_to_identity"
+      )
+      |> NeuralNetwork.Network.output(
+        "fahrenheit",
+        "fahrenheit_linear",
+        "fahrenheit",
+        %{"nn.layer" => "output"},
+        "identity_to_output"
+      )
+
+    bytecode = NeuralGraphVM.compile_neural_network_to_bytecode(network)
+    outputs = NeuralGraphVM.run_neural_bytecode_forward(bytecode, %{"celsius" => celsius_value})
+    instruction_count = bytecode.functions |> hd() |> Map.fetch!(:instructions) |> length()
+
+    IO.puts(
+      "Graph VM path -> #{Float.round(celsius_value, 1)} C = #{Float.round(outputs["fahrenheit"], 2)} F (#{instruction_count} bytecode ops)"
+    )
   end
 
   def run do

--- a/code/programs/elixir/celsius_to_fahrenheit_predictor/mix.exs
+++ b/code/programs/elixir/celsius_to_fahrenheit_predictor/mix.exs
@@ -20,7 +20,9 @@ defmodule CodingAdventures.CelsiusToFahrenheit.MixProject do
   defp deps do
     [
       {:coding_adventures_loss_functions, path: "../../../packages/elixir/loss_functions"},
-      {:coding_adventures_gradient_descent, path: "../../../packages/elixir/gradient_descent"}
+      {:coding_adventures_gradient_descent, path: "../../../packages/elixir/gradient_descent"},
+      {:neural_network, path: "../../../packages/elixir/neural_network"},
+      {:neural_graph_vm, path: "../../../packages/elixir/neural_graph_vm"}
     ]
   end
 end

--- a/code/programs/elixir/mansion-classifier/lib/mansion_classifier.ex
+++ b/code/programs/elixir/mansion-classifier/lib/mansion_classifier.ex
@@ -3,11 +3,21 @@ defmodule MansionClassifier do
     :io.format("~n--- Booting Elixir Mansion Classifier (OOP V2) ---~n")
 
     house_data = [
-      [4.5, 6.0], [3.8, 5.0], [1.5, 2.0],
-      [0.9, 1.0], [5.5, 7.0], [2.0, 3.0]
+      [4.5, 6.0],
+      [3.8, 5.0],
+      [1.5, 2.0],
+      [0.9, 1.0],
+      [5.5, 7.0],
+      [2.0, 3.0]
     ]
+
     target_data = [
-      [1.0], [1.0], [0.0], [0.0], [1.0], [0.0]
+      [1.0],
+      [1.0],
+      [0.0],
+      [0.0],
+      [1.0],
+      [0.0]
     ]
 
     model = Perceptron.new(0.1, 2000)
@@ -15,11 +25,75 @@ defmodule MansionClassifier do
 
     :io.format("~n--- Final Inference ---~n")
     predictions = Perceptron.predict(model, house_data)
-    
-    Enum.with_index(predictions) |> Enum.each(fn {prob, i} ->
+
+    Enum.with_index(predictions)
+    |> Enum.each(fn {prob, i} ->
       truth = if Enum.at(Enum.at(target_data, i), 0) == 1.0, do: "Mansion", else: "Normal"
       guess = if prob > 0.5, do: "Mansion", else: "Normal"
+
       :io.format("House ~w (Truth: ~s) -> System: ~s (~.2f%)~n", [i + 1, truth, guess, prob * 100])
+    end)
+
+    run_graph_vm_inference(model, house_data)
+  end
+
+  defp run_graph_vm_inference(model, house_data) do
+    if is_nil(model.weights) do
+      raise "Expected trained perceptron weights before graph VM inference"
+    end
+
+    network =
+      NeuralNetwork.create_neural_network("mansion-classifier")
+      |> NeuralNetwork.Network.input("bedrooms")
+      |> NeuralNetwork.Network.input("bathrooms")
+      |> NeuralNetwork.Network.constant("bias", 1.0, %{"nn.role" => "bias"})
+      |> NeuralNetwork.Network.weighted_sum(
+        "mansion_logit",
+        [
+          NeuralNetwork.wi(
+            "bedrooms",
+            model.weights.data |> Enum.at(0) |> Enum.at(0),
+            "bedrooms_weight"
+          ),
+          NeuralNetwork.wi(
+            "bathrooms",
+            model.weights.data |> Enum.at(1) |> Enum.at(0),
+            "bathrooms_weight"
+          ),
+          NeuralNetwork.wi("bias", model.bias, "bias_weight")
+        ],
+        %{"nn.layer" => "output", "nn.role" => "weighted_sum"}
+      )
+      |> NeuralNetwork.Network.activation(
+        "mansion_probability",
+        "mansion_logit",
+        "sigmoid",
+        %{"nn.layer" => "output", "nn.role" => "activation"},
+        "logit_to_sigmoid"
+      )
+      |> NeuralNetwork.Network.output(
+        "mansion_output",
+        "mansion_probability",
+        "mansion_probability",
+        %{"nn.layer" => "output"},
+        "probability_to_output"
+      )
+
+    bytecode = NeuralGraphVM.compile_neural_network_to_bytecode(network)
+
+    :io.format("~n--- Graph VM Inference ---~n")
+
+    Enum.with_index(house_data)
+    |> Enum.each(fn {house, i} ->
+      outputs =
+        NeuralGraphVM.run_neural_bytecode_forward(bytecode, %{
+          "bedrooms" => Enum.at(house, 0),
+          "bathrooms" => Enum.at(house, 1)
+        })
+
+      probability = outputs["mansion_probability"]
+      guess = if probability > 0.5, do: "Mansion", else: "Normal"
+      :io.format("House ~w -> VM: ~s (~.2f%)~n", [i + 1, guess, probability * 100])
     end)
   end
 end

--- a/code/programs/elixir/mansion-classifier/mix.exs
+++ b/code/programs/elixir/mansion-classifier/mix.exs
@@ -22,7 +22,9 @@ defmodule MansionClassifier.MixProject do
       {:matrix, path: "../../../packages/elixir/matrix"},
       {:coding_adventures_loss_functions, path: "../../../packages/elixir/loss_functions"},
       {:activation_functions, path: "../../../packages/elixir/activation_functions"},
-      {:perceptron, path: "../../../packages/elixir/perceptron"}
+      {:perceptron, path: "../../../packages/elixir/perceptron"},
+      {:neural_network, path: "../../../packages/elixir/neural_network"},
+      {:neural_graph_vm, path: "../../../packages/elixir/neural_graph_vm"}
     ]
   end
 end

--- a/code/programs/go/celsius-to-fahrenheit-predictor/go.mod
+++ b/code/programs/go/celsius-to-fahrenheit-predictor/go.mod
@@ -5,8 +5,14 @@ go 1.21
 require (
 	github.com/adhithyan15/coding-adventures/code/packages/go/gradient-descent v0.0.0
 	github.com/adhithyan15/coding-adventures/code/packages/go/loss-functions v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/neural-network v0.0.0
 )
 
 replace github.com/adhithyan15/coding-adventures/code/packages/go/loss-functions => ../../../packages/go/loss-functions
 
 replace github.com/adhithyan15/coding-adventures/code/packages/go/gradient-descent => ../../../packages/go/gradient-descent
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/neural-network => ../../../packages/go/neural-network
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm => ../../../packages/go/neural-graph-vm

--- a/code/programs/go/celsius-to-fahrenheit-predictor/main.go
+++ b/code/programs/go/celsius-to-fahrenheit-predictor/main.go
@@ -6,6 +6,8 @@ import (
 
 	opt "github.com/adhithyan15/coding-adventures/code/packages/go/gradient-descent"
 	loss "github.com/adhithyan15/coding-adventures/code/packages/go/loss-functions"
+	vm "github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm"
+	neuralnetwork "github.com/adhithyan15/coding-adventures/code/packages/go/neural-network"
 )
 
 func train(lossName string, lossFn func([]float64, []float64) (float64, error), lossDerivFn func([]float64, []float64) ([]float64, error), learningRate float64, maxEpochs int) {
@@ -50,7 +52,7 @@ func train(lossName string, lossFn func([]float64, []float64) (float64, error), 
 		if err != nil {
 			log.Fatal(err)
 		}
-		
+
 		w = newParams[0]
 		b = newParams[1]
 
@@ -62,6 +64,29 @@ func train(lossName string, lossFn func([]float64, []float64) (float64, error), 
 	testC := 100.0
 	predF := w*testC + b
 	fmt.Printf("Prediction for 100.0 C -> %.2f F (Expected ~212.00 F)\n", predF)
+	runGraphVMInference(lossName, w, b, testC)
+}
+
+func runGraphVMInference(lossName string, weight float64, bias float64, celsiusValue float64) {
+	network := neuralnetwork.CreateNeuralNetwork("celsius-to-fahrenheit-"+lossName).
+		Input("celsius").
+		Constant("bias", 1.0, neuralnetwork.PropertyBag{"nn.role": "bias"}).
+		WeightedSum("fahrenheit_sum", []neuralnetwork.WeightedInput{
+			{From: "celsius", Weight: weight, EdgeID: "celsius_weight"},
+			{From: "bias", Weight: bias, EdgeID: "fahrenheit_bias"},
+		}, neuralnetwork.PropertyBag{"nn.layer": "output", "nn.role": "weighted_sum"}).
+		Activation("fahrenheit_linear", "fahrenheit_sum", neuralnetwork.None, neuralnetwork.PropertyBag{"nn.layer": "output", "nn.role": "identity_activation"}, "sum_to_identity").
+		Output("fahrenheit", "fahrenheit_linear", "fahrenheit", neuralnetwork.PropertyBag{"nn.layer": "output"}, "identity_to_output")
+
+	bytecode, err := vm.CompileNeuralNetworkToBytecode(network)
+	if err != nil {
+		log.Fatal(err)
+	}
+	outputs, err := vm.RunNeuralBytecodeForward(bytecode, map[string]float64{"celsius": celsiusValue})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Graph VM path -> %.1f C = %.2f F (%d bytecode ops)\n", celsiusValue, outputs["fahrenheit"], len(bytecode.Functions[0].Instructions))
 }
 
 func main() {

--- a/code/programs/go/mansion-classifier/go.mod
+++ b/code/programs/go/mansion-classifier/go.mod
@@ -2,7 +2,11 @@ module github.com/adhithyan15/coding-adventures/code/programs/go/mansion-classif
 
 go 1.21
 
-require github.com/adhithyan15/coding-adventures/code/packages/go/perceptron v0.0.0
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/neural-network v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/perceptron v0.0.0
+)
 
 require (
 	github.com/adhithyan15/coding-adventures/code/packages/go/activation-functions v0.0.0 // indirect
@@ -17,3 +21,7 @@ replace github.com/adhithyan15/coding-adventures/code/packages/go/loss-functions
 replace github.com/adhithyan15/coding-adventures/code/packages/go/activation-functions => ../../../packages/go/activation-functions
 
 replace github.com/adhithyan15/coding-adventures/code/packages/go/perceptron => ../../../packages/go/perceptron
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/neural-network => ../../../packages/go/neural-network
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm => ../../../packages/go/neural-graph-vm

--- a/code/programs/go/mansion-classifier/main.go
+++ b/code/programs/go/mansion-classifier/main.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"fmt"
+	"log"
+
+	vm "github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm"
+	neuralnetwork "github.com/adhithyan15/coding-adventures/code/packages/go/neural-network"
 	"github.com/adhithyan15/coding-adventures/code/packages/go/perceptron"
 )
 
@@ -31,5 +35,47 @@ func main() {
 			guess = "Mansion"
 		}
 		fmt.Printf("House %d (Truth: %s) -> System: %s (%.2f%%)\n", i+1, truth, guess, prob*100)
+	}
+
+	runGraphVMInference(model, houseData)
+}
+
+func runGraphVMInference(model *perceptron.Perceptron, houseData [][]float64) {
+	if model.Weights == nil {
+		log.Fatal("expected trained perceptron weights before graph VM inference")
+	}
+
+	network := neuralnetwork.CreateNeuralNetwork("mansion-classifier").
+		Input("bedrooms").
+		Input("bathrooms").
+		Constant("bias", 1.0, neuralnetwork.PropertyBag{"nn.role": "bias"}).
+		WeightedSum("mansion_logit", []neuralnetwork.WeightedInput{
+			{From: "bedrooms", Weight: model.Weights.Data[0][0], EdgeID: "bedrooms_weight"},
+			{From: "bathrooms", Weight: model.Weights.Data[1][0], EdgeID: "bathrooms_weight"},
+			{From: "bias", Weight: model.Bias, EdgeID: "bias_weight"},
+		}, neuralnetwork.PropertyBag{"nn.layer": "output", "nn.role": "weighted_sum"}).
+		Activation("mansion_probability", "mansion_logit", neuralnetwork.Sigmoid, neuralnetwork.PropertyBag{"nn.layer": "output", "nn.role": "activation"}, "logit_to_sigmoid").
+		Output("mansion_output", "mansion_probability", "mansion_probability", neuralnetwork.PropertyBag{"nn.layer": "output"}, "probability_to_output")
+
+	bytecode, err := vm.CompileNeuralNetworkToBytecode(network)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("\n--- Graph VM Inference ---")
+	for index, house := range houseData {
+		outputs, err := vm.RunNeuralBytecodeForward(bytecode, map[string]float64{
+			"bedrooms":  house[0],
+			"bathrooms": house[1],
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		probability := outputs["mansion_probability"]
+		guess := "Normal"
+		if probability > 0.5 {
+			guess = "Mansion"
+		}
+		fmt.Printf("House %d -> VM: %s (%.2f%%)\n", index+1, guess, probability*100)
 	}
 }

--- a/code/programs/go/xor-hidden-layer-demo/go.mod
+++ b/code/programs/go/xor-hidden-layer-demo/go.mod
@@ -3,11 +3,15 @@ module github.com/adhithyan15/coding-adventures/code/programs/go/xor-hidden-laye
 go 1.21
 
 require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/neural-network v0.0.0
 	github.com/adhithyan15/coding-adventures/code/packages/go/single-layer-network v0.0.0
 	github.com/adhithyan15/coding-adventures/code/packages/go/two-layer-network v0.0.0
 )
 
 replace (
+	github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm => ../../../packages/go/neural-graph-vm
+	github.com/adhithyan15/coding-adventures/code/packages/go/neural-network => ../../../packages/go/neural-network
 	github.com/adhithyan15/coding-adventures/code/packages/go/single-layer-network => ../../../packages/go/single-layer-network
 	github.com/adhithyan15/coding-adventures/code/packages/go/two-layer-network => ../../../packages/go/two-layer-network
 )

--- a/code/programs/go/xor-hidden-layer-demo/main.go
+++ b/code/programs/go/xor-hidden-layer-demo/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	vm "github.com/adhithyan15/coding-adventures/code/packages/go/neural-graph-vm"
+	neuralnetwork "github.com/adhithyan15/coding-adventures/code/packages/go/neural-network"
 	single "github.com/adhithyan15/coding-adventures/code/packages/go/single-layer-network"
 	two "github.com/adhithyan15/coding-adventures/code/packages/go/two-layer-network"
 )
@@ -49,11 +51,32 @@ func runHiddenSuccess() error {
 	return nil
 }
 
+func runGraphVMSuccess() error {
+	bytecode, err := vm.CompileNeuralNetworkToBytecode(neuralnetwork.CreateXorNetwork("xor-graph-vm"))
+	if err != nil {
+		return err
+	}
+	fmt.Println("\nGraph API -> bytecode VM:")
+	for index, input := range xorInputs {
+		outputs, err := vm.RunNeuralBytecodeForward(bytecode, map[string]float64{"x0": input[0], "x1": input[1]})
+		if err != nil {
+			return err
+		}
+		prediction := outputs["prediction"]
+		fmt.Printf("%v target=%.0f prediction=%.4f rounded=%d\n", input, xorTargets[index][0], prediction, rounded(prediction))
+	}
+	fmt.Printf("Compiled %d bytecode instructions from the graph\n", len(bytecode.Functions[0].Instructions))
+	return nil
+}
+
 func main() {
 	if err := runLinearFailure(); err != nil {
 		panic(err)
 	}
 	if err := runHiddenSuccess(); err != nil {
+		panic(err)
+	}
+	if err := runGraphVMSuccess(); err != nil {
 		panic(err)
 	}
 }

--- a/code/programs/python/celsius-to-fahrenheit-predictor/main.py
+++ b/code/programs/python/celsius-to-fahrenheit-predictor/main.py
@@ -1,5 +1,7 @@
 from loss_functions import mse, mse_derivative, mae, mae_derivative
 from gradient_descent import sgd
+from neural_network import WeightedInput, create_neural_network
+from neural_graph_vm import compile_neural_network_to_bytecode, run_neural_bytecode_forward
 
 # Target pairs: C -> F
 celsius = [-40.0, -10.0, 0.0, 8.0, 15.0, 22.0, 38.0]
@@ -34,6 +36,45 @@ def train(loss_name, loss_fn, loss_deriv_fn, learning_rate=0.001, max_epochs=100
     test_c = 100.0
     pred_f = w * test_c + b
     print(f"Prediction for 100.0 C -> {pred_f:.2f} F (Expected ~212.00 F)")
+    run_graph_vm_inference(loss_name, w, b, test_c)
+
+    return w, b
+
+
+def run_graph_vm_inference(loss_name, weight, bias, celsius_value):
+    network = (
+        create_neural_network(f"celsius-to-fahrenheit-{loss_name}")
+        .input("celsius")
+        .constant("bias", 1.0, {"nn.role": "bias"})
+        .weighted_sum(
+            "fahrenheit_sum",
+            [
+                WeightedInput("celsius", weight, "celsius_weight"),
+                WeightedInput("bias", bias, "fahrenheit_bias"),
+            ],
+            {"nn.layer": "output", "nn.role": "weighted_sum"},
+        )
+        .activation(
+            "fahrenheit_linear",
+            "fahrenheit_sum",
+            "none",
+            {"nn.layer": "output", "nn.role": "identity_activation"},
+            "sum_to_identity",
+        )
+        .output(
+            "fahrenheit",
+            "fahrenheit_linear",
+            "fahrenheit",
+            {"nn.layer": "output"},
+            "identity_to_output",
+        )
+    )
+    bytecode = compile_neural_network_to_bytecode(network)
+    outputs = run_neural_bytecode_forward(bytecode, {"celsius": celsius_value})
+    print(
+        f"Graph VM path -> {celsius_value:.1f} C = {outputs['fahrenheit']:.2f} F "
+        f"({len(bytecode.functions[0].instructions)} bytecode ops)"
+    )
 
 if __name__ == "__main__":
     train("Mean Squared Error (MSE)", mse, mse_derivative, learning_rate=0.0005)

--- a/code/programs/python/celsius-to-fahrenheit-predictor/pyproject.toml
+++ b/code/programs/python/celsius-to-fahrenheit-predictor/pyproject.toml
@@ -5,7 +5,9 @@ description = "AI learning C to F"
 requires-python = ">=3.9"
 dependencies = [
     "coding-adventures-loss-functions",
-    "coding-adventures-gradient-descent"
+    "coding-adventures-gradient-descent",
+    "coding-adventures-neural-network",
+    "coding-adventures-neural-graph-vm"
 ]
 
 [tool.hatch.metadata]
@@ -14,3 +16,5 @@ allow-direct-references = true
 [tool.uv.sources]
 coding-adventures-loss-functions = { path = "../../../packages/python/loss-functions" }
 coding-adventures-gradient-descent = { path = "../../../packages/python/gradient-descent" }
+coding-adventures-neural-network = { path = "../../../packages/python/neural-network" }
+coding-adventures-neural-graph-vm = { path = "../../../packages/python/neural-graph-vm" }

--- a/code/programs/python/mansion-classifier/main.py
+++ b/code/programs/python/mansion-classifier/main.py
@@ -1,4 +1,6 @@
 from perceptron import Perceptron
+from neural_network import WeightedInput, create_neural_network
+from neural_graph_vm import compile_neural_network_to_bytecode, run_neural_bytecode_forward
 
 def main():
     print("\n--- Booting Python Mansion Classifier (OOP V2) ---")
@@ -19,6 +21,54 @@ def main():
         truth = "Mansion" if target_data[i][0] == 1.0 else "Normal"
         guess = "Mansion" if prob > 0.5 else "Normal"
         print(f"House {i+1} (Truth: {truth}) -> System: {guess} ({prob*100:.2f}%)")
+
+    run_graph_vm_inference(model, house_data)
+
+
+def run_graph_vm_inference(model, house_data):
+    if model.weights is None:
+        raise ValueError("Expected trained perceptron weights before graph VM inference")
+
+    network = (
+        create_neural_network("mansion-classifier")
+        .input("bedrooms")
+        .input("bathrooms")
+        .constant("bias", 1.0, {"nn.role": "bias"})
+        .weighted_sum(
+            "mansion_logit",
+            [
+                WeightedInput("bedrooms", model.weights.data[0][0], "bedrooms_weight"),
+                WeightedInput("bathrooms", model.weights.data[1][0], "bathrooms_weight"),
+                WeightedInput("bias", model.bias, "bias_weight"),
+            ],
+            {"nn.layer": "output", "nn.role": "weighted_sum"},
+        )
+        .activation(
+            "mansion_probability",
+            "mansion_logit",
+            "sigmoid",
+            {"nn.layer": "output", "nn.role": "activation"},
+            "logit_to_sigmoid",
+        )
+        .output(
+            "mansion_output",
+            "mansion_probability",
+            "mansion_probability",
+            {"nn.layer": "output"},
+            "probability_to_output",
+        )
+    )
+    bytecode = compile_neural_network_to_bytecode(network)
+
+    print("\n--- Graph VM Inference ---")
+    for index, house in enumerate(house_data):
+        outputs = run_neural_bytecode_forward(
+            bytecode,
+            {"bedrooms": house[0], "bathrooms": house[1]},
+        )
+        probability = outputs["mansion_probability"]
+        guess = "Mansion" if probability > 0.5 else "Normal"
+        print(f"House {index+1} -> VM: {guess} ({probability*100:.2f}%)")
 
 if __name__ == "__main__":
     main()

--- a/code/programs/python/mansion-classifier/pyproject.toml
+++ b/code/programs/python/mansion-classifier/pyproject.toml
@@ -4,7 +4,12 @@ version = "0.1.0"
 description = "Binary Classifier for Mansions using Perceptron"
 requires-python = ">=3.12"
 dependencies = [
-    "coding-adventures-matrix", "coding-adventures-loss-functions", "activation-functions", "perceptron"
+    "coding-adventures-matrix",
+    "coding-adventures-loss-functions",
+    "activation-functions",
+    "perceptron",
+    "coding-adventures-neural-network",
+    "coding-adventures-neural-graph-vm"
 ]
 
 [tool.uv.sources]
@@ -12,3 +17,5 @@ coding-adventures-matrix = { path = "../../../packages/python/matrix", editable 
 coding-adventures-loss-functions = { path = "../../../packages/python/loss-functions", editable = true }
 activation-functions = { path = "../../../packages/python/activation-functions", editable = true }
 perceptron = { path = "../../../packages/python/perceptron", editable = true }
+coding-adventures-neural-network = { path = "../../../packages/python/neural-network", editable = true }
+coding-adventures-neural-graph-vm = { path = "../../../packages/python/neural-graph-vm", editable = true }

--- a/code/programs/python/xor-hidden-layer-demo/BUILD
+++ b/code/programs/python/xor-hidden-layer-demo/BUILD
@@ -1,3 +1,5 @@
-(cd ../../../packages/python/single-layer-network && python -m pytest tests)
-(cd ../../../packages/python/two-layer-network && python -m pytest tests)
-PYTHONPATH=../../../packages/python/two-layer-network/src:../../../packages/python/single-layer-network/src python main.py
+(cd ../../../packages/python/single-layer-network && python3 -m pytest tests)
+(cd ../../../packages/python/two-layer-network && python3 -m pytest tests)
+(cd ../../../packages/python/neural-network && python3 -m pytest tests)
+(cd ../../../packages/python/neural-graph-vm && PYTHONPATH=../neural-network/src:src python3 -m pytest tests)
+PYTHONPATH=../../../packages/python/two-layer-network/src:../../../packages/python/single-layer-network/src:../../../packages/python/neural-network/src:../../../packages/python/neural-graph-vm/src python3 main.py

--- a/code/programs/python/xor-hidden-layer-demo/main.py
+++ b/code/programs/python/xor-hidden-layer-demo/main.py
@@ -5,6 +5,8 @@ from two_layer_network import (
     TwoLayerNetwork,
     create_xor_warm_start_parameters,
 )
+from neural_network import create_xor_network
+from neural_graph_vm import compile_neural_network_to_bytecode, run_neural_bytecode_forward
 
 XOR_INPUTS = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
 XOR_TARGETS = [[0.0], [1.0], [1.0], [0.0]]
@@ -37,6 +39,16 @@ def run_hidden_success():
         print(format_row(inputs, target[0], prediction[0], hidden))
 
 
+def run_graph_vm_success():
+    bytecode = compile_neural_network_to_bytecode(create_xor_network("xor-graph-vm"))
+    print("\nGraph API -> bytecode VM:")
+    for inputs, target in zip(XOR_INPUTS, XOR_TARGETS):
+        outputs = run_neural_bytecode_forward(bytecode, {"x0": inputs[0], "x1": inputs[1]})
+        print(format_row(inputs, target[0], outputs["prediction"]))
+    print(f"Compiled {len(bytecode.functions[0].instructions)} bytecode instructions from the graph")
+
+
 if __name__ == "__main__":
     run_linear_failure()
     run_hidden_success()
+    run_graph_vm_success()

--- a/code/programs/python/xor-hidden-layer-demo/pyproject.toml
+++ b/code/programs/python/xor-hidden-layer-demo/pyproject.toml
@@ -6,8 +6,12 @@ requires-python = ">=3.9"
 dependencies = [
     "coding-adventures-single-layer-network",
     "coding-adventures-two-layer-network",
+    "coding-adventures-neural-network",
+    "coding-adventures-neural-graph-vm",
 ]
 
 [tool.uv.sources]
 coding-adventures-single-layer-network = { path = "../../../packages/python/single-layer-network" }
 coding-adventures-two-layer-network = { path = "../../../packages/python/two-layer-network" }
+coding-adventures-neural-network = { path = "../../../packages/python/neural-network" }
+coding-adventures-neural-graph-vm = { path = "../../../packages/python/neural-graph-vm" }

--- a/code/programs/ruby/celsius-to-fahrenheit-predictor/main.rb
+++ b/code/programs/ruby/celsius-to-fahrenheit-predictor/main.rb
@@ -1,5 +1,9 @@
 require_relative '../../../packages/ruby/loss-functions/lib/loss_functions'
 require_relative '../../../packages/ruby/gradient-descent/lib/gradient_descent'
+$LOAD_PATH.unshift(File.expand_path('../../../packages/ruby/neural-network/lib', __dir__))
+$LOAD_PATH.unshift(File.expand_path('../../../packages/ruby/neural-graph-vm/lib', __dir__))
+require 'neural_network'
+require 'neural_graph_vm'
 
 CELSIUS = [-40.0, -10.0, 0.0, 8.0, 15.0, 22.0, 38.0]
 FAHRENHEIT = [-40.0, 14.0, 32.0, 46.4, 59.0, 71.6, 100.4]
@@ -34,6 +38,27 @@ def train(loss_name, loss_method, deriv_method, learning_rate, max_epochs = 1000
 
   pred_f = w * 100.0 + b
   puts "Prediction for 100.0 C -> #{pred_f.round(2)} F (Expected ~212.00 F)"
+  run_graph_vm_inference(loss_name, w, b, 100.0)
+end
+
+def run_graph_vm_inference(loss_name, weight, bias, celsius_value)
+  network = NeuralNetwork.create_neural_network("celsius-to-fahrenheit-#{loss_name}")
+    .input("celsius")
+    .constant("bias", 1.0, "nn.role" => "bias")
+    .weighted_sum("fahrenheit_sum", [
+      NeuralNetwork.wi("celsius", weight, "celsius_weight"),
+      NeuralNetwork.wi("bias", bias, "fahrenheit_bias")
+    ], "nn.layer" => "output", "nn.role" => "weighted_sum")
+    .activation("fahrenheit_linear", "fahrenheit_sum", "none", { "nn.layer" => "output", "nn.role" => "identity_activation" }, "sum_to_identity")
+    .output("fahrenheit", "fahrenheit_linear", "fahrenheit", { "nn.layer" => "output" }, "identity_to_output")
+
+  bytecode = NeuralGraphVM.compile_neural_network_to_bytecode(network)
+  outputs = NeuralGraphVM.run_neural_bytecode_forward(bytecode, "celsius" => celsius_value)
+  puts "Graph VM path -> %.1f C = %.2f F (%d bytecode ops)" % [
+    celsius_value,
+    outputs.fetch("fahrenheit"),
+    bytecode.functions.first.instructions.length
+  ]
 end
 
 train("Mean Squared Error (MSE)", :mse, :mse_derivative, 0.0005)

--- a/code/programs/ruby/mansion-classifier/main.rb
+++ b/code/programs/ruby/mansion-classifier/main.rb
@@ -1,4 +1,8 @@
 require_relative "../../../packages/ruby/perceptron/lib/perceptron"
+$LOAD_PATH.unshift(File.expand_path("../../../packages/ruby/neural-network/lib", __dir__))
+$LOAD_PATH.unshift(File.expand_path("../../../packages/ruby/neural-graph-vm/lib", __dir__))
+require "neural_network"
+require "neural_graph_vm"
 
 puts "\n--- Booting Ruby Mansion Classifier (OOP V2) ---"
 
@@ -19,4 +23,32 @@ predictions.each_with_index do |prob, i|
   target = target_data[i][0] == 1.0 ? "Mansion" : "Normal"
   guess = prob > 0.5 ? "Mansion" : "Normal"
   puts "House #{i+1} (Truth: #{target}) -> System: #{guess} (%.2f%%)" % [prob * 100]
+end
+
+raise "Expected trained perceptron weights before graph VM inference" if model.weights.nil?
+
+network = NeuralNetwork.create_neural_network("mansion-classifier")
+  .input("bedrooms")
+  .input("bathrooms")
+  .constant("bias", 1.0, "nn.role" => "bias")
+  .weighted_sum("mansion_logit", [
+    NeuralNetwork.wi("bedrooms", model.weights.data[0][0], "bedrooms_weight"),
+    NeuralNetwork.wi("bathrooms", model.weights.data[1][0], "bathrooms_weight"),
+    NeuralNetwork.wi("bias", model.bias, "bias_weight")
+  ], "nn.layer" => "output", "nn.role" => "weighted_sum")
+  .activation("mansion_probability", "mansion_logit", "sigmoid", { "nn.layer" => "output", "nn.role" => "activation" }, "logit_to_sigmoid")
+  .output("mansion_output", "mansion_probability", "mansion_probability", { "nn.layer" => "output" }, "probability_to_output")
+
+bytecode = NeuralGraphVM.compile_neural_network_to_bytecode(network)
+
+puts "\n--- Graph VM Inference ---"
+house_data.each_with_index do |house, i|
+  outputs = NeuralGraphVM.run_neural_bytecode_forward(
+    bytecode,
+    "bedrooms" => house[0],
+    "bathrooms" => house[1]
+  )
+  probability = outputs.fetch("mansion_probability")
+  guess = probability > 0.5 ? "Mansion" : "Normal"
+  puts "House #{i+1} -> VM: #{guess} (%.2f%%)" % [probability * 100]
 end

--- a/code/programs/rust/celsius-to-fahrenheit-predictor/Cargo.toml
+++ b/code/programs/rust/celsius-to-fahrenheit-predictor/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 loss-functions = { path = "../../../packages/rust/loss-functions" }
 gradient-descent = { path = "../../../packages/rust/gradient-descent" }
+neural-network = { path = "../../../packages/rust/neural-network" }
+neural-graph-vm = { path = "../../../packages/rust/neural-graph-vm" }

--- a/code/programs/rust/celsius-to-fahrenheit-predictor/src/main.rs
+++ b/code/programs/rust/celsius-to-fahrenheit-predictor/src/main.rs
@@ -1,5 +1,10 @@
-use loss_functions::{mse, mse_derivative, mae, mae_derivative};
 use gradient_descent::sgd;
+use loss_functions::{mae, mae_derivative, mse, mse_derivative};
+use neural_graph_vm::{compile_neural_network_to_bytecode, run_neural_bytecode_forward};
+use neural_network::{
+    create_neural_network, ActivationKind, PropertyBag, PropertyValue, WeightedInput,
+};
+use std::collections::HashMap;
 
 fn train(
     loss_name: &str,
@@ -14,7 +19,10 @@ fn train(
     let mut w = 0.5;
     let mut b = 0.5;
 
-    println!("\n--- Celsius to Fahrenheit Predictor: Training with {} ---", loss_name);
+    println!(
+        "\n--- Celsius to Fahrenheit Predictor: Training with {} ---",
+        loss_name
+    );
 
     for epoch in 0..epochs {
         let mut y_pred = Vec::with_capacity(celsius.len());
@@ -25,7 +33,11 @@ fn train(
         let err = loss_fn(fahrenheit, &y_pred).unwrap();
 
         if err < 0.5 {
-            println!("Converged beautifully in {} epochs! (Loss: {:.6})", epoch + 1, err);
+            println!(
+                "Converged beautifully in {} epochs! (Loss: {:.6})",
+                epoch + 1,
+                err
+            );
             println!("Final Formula: F = C * {:.6} + {:.6}", w, b);
             break;
         }
@@ -44,15 +56,108 @@ fn train(
         b = new_params[1];
 
         if (epoch + 1) % 1000 == 0 {
-            println!("Epoch {:04} -> Loss: {:.6} | w: {:.4} | b: {:.4}", epoch + 1, err, w, b);
+            println!(
+                "Epoch {:04} -> Loss: {:.6} | w: {:.4} | b: {:.4}",
+                epoch + 1,
+                err,
+                w,
+                b
+            );
         }
     }
 
     let pred_f = w * 100.0 + b;
-    println!("Prediction for 100.0 C -> {:.2} F (Expected ~212.00 F)", pred_f);
+    println!(
+        "Prediction for 100.0 C -> {:.2} F (Expected ~212.00 F)",
+        pred_f
+    );
+    run_graph_vm_inference(loss_name, w, b, 100.0);
+}
+
+fn run_graph_vm_inference(loss_name: &str, weight: f64, bias: f64, celsius_value: f64) {
+    let mut bias_props = PropertyBag::new();
+    bias_props.insert(
+        "nn.role".to_string(),
+        PropertyValue::String("bias".to_string()),
+    );
+
+    let mut sum_props = PropertyBag::new();
+    sum_props.insert(
+        "nn.layer".to_string(),
+        PropertyValue::String("output".to_string()),
+    );
+    sum_props.insert(
+        "nn.role".to_string(),
+        PropertyValue::String("weighted_sum".to_string()),
+    );
+
+    let mut activation_props = PropertyBag::new();
+    activation_props.insert(
+        "nn.layer".to_string(),
+        PropertyValue::String("output".to_string()),
+    );
+    activation_props.insert(
+        "nn.role".to_string(),
+        PropertyValue::String("identity_activation".to_string()),
+    );
+
+    let mut output_props = PropertyBag::new();
+    output_props.insert(
+        "nn.layer".to_string(),
+        PropertyValue::String("output".to_string()),
+    );
+
+    let network = create_neural_network(Some(&format!("celsius-to-fahrenheit-{loss_name}")))
+        .input("celsius")
+        .constant("bias", 1.0, bias_props)
+        .weighted_sum(
+            "fahrenheit_sum",
+            vec![
+                WeightedInput::new("celsius", weight, "celsius_weight"),
+                WeightedInput::new("bias", bias, "fahrenheit_bias"),
+            ],
+            sum_props,
+        )
+        .activation(
+            "fahrenheit_linear",
+            "fahrenheit_sum",
+            ActivationKind::None,
+            activation_props,
+            "sum_to_identity",
+        )
+        .output(
+            "fahrenheit",
+            "fahrenheit_linear",
+            "fahrenheit",
+            output_props,
+            "identity_to_output",
+        );
+
+    let bytecode = compile_neural_network_to_bytecode(&network).unwrap();
+    let mut inputs = HashMap::new();
+    inputs.insert("celsius".to_string(), celsius_value);
+    let outputs = run_neural_bytecode_forward(&bytecode, &inputs).unwrap();
+    println!(
+        "Graph VM path -> {:.1} C = {:.2} F ({} bytecode ops)",
+        celsius_value,
+        outputs["fahrenheit"],
+        bytecode.functions[0].instructions.len()
+    );
 }
 
 fn main() {
-    train("Mean Squared Error (MSE)", mse, mse_derivative, 0.0005, 10000);
-    train("Mean Absolute Error (MAE)", mae, mae_derivative, 0.01, 10000);
+    train(
+        "Mean Squared Error (MSE)",
+        mse,
+        mse_derivative,
+        0.0005,
+        10000,
+    );
+    train(
+        "Mean Absolute Error (MAE)",
+        mae,
+        mae_derivative,
+        0.01,
+        10000,
+    );
 }

--- a/code/programs/rust/mansion-classifier/Cargo.toml
+++ b/code/programs/rust/mansion-classifier/Cargo.toml
@@ -8,3 +8,5 @@ matrix = { path = "../../../packages/rust/matrix" }
 loss-functions = { path = "../../../packages/rust/loss-functions" }
 activation-functions = { path = "../../../packages/rust/activation-functions" }
 perceptron = { path = "../../../packages/rust/perceptron" }
+neural-network = { path = "../../../packages/rust/neural-network" }
+neural-graph-vm = { path = "../../../packages/rust/neural-graph-vm" }

--- a/code/programs/rust/mansion-classifier/src/main.rs
+++ b/code/programs/rust/mansion-classifier/src/main.rs
@@ -1,24 +1,138 @@
+use neural_graph_vm::{compile_neural_network_to_bytecode, run_neural_bytecode_forward};
+use neural_network::{
+    create_neural_network, ActivationKind, PropertyBag, PropertyValue, WeightedInput,
+};
 use perceptron::Perceptron;
+use std::collections::HashMap;
 
 fn main() {
     println!("\n--- Booting Rust Mansion Classifier (OOP V2) ---");
 
     let house_data = vec![
-        vec![4.5, 6.0], vec![3.8, 5.0], vec![1.5, 2.0],
-        vec![0.9, 1.0], vec![5.5, 7.0], vec![2.0, 3.0],
+        vec![4.5, 6.0],
+        vec![3.8, 5.0],
+        vec![1.5, 2.0],
+        vec![0.9, 1.0],
+        vec![5.5, 7.0],
+        vec![2.0, 3.0],
     ];
     let target_data = vec![
-        vec![1.0], vec![1.0], vec![0.0], vec![0.0], vec![1.0], vec![0.0],
+        vec![1.0],
+        vec![1.0],
+        vec![0.0],
+        vec![0.0],
+        vec![1.0],
+        vec![0.0],
     ];
 
     let mut model = Perceptron::new(0.1, 2000);
     model.fit(house_data.clone(), target_data.clone(), 400);
 
     println!("\n--- Final Inference ---");
-    let predictions = model.predict(house_data);
+    let predictions = model.predict(house_data.clone());
     for (i, prob) in predictions.iter().enumerate() {
-        let truth = if target_data[i][0] == 1.0 { "Mansion" } else { "Normal" };
+        let truth = if target_data[i][0] == 1.0 {
+            "Mansion"
+        } else {
+            "Normal"
+        };
         let guess = if *prob > 0.5 { "Mansion" } else { "Normal" };
-        println!("House {} (Truth: {}) -> System: {} ({:.2}%)", i + 1, truth, guess, prob * 100.0);
+        println!(
+            "House {} (Truth: {}) -> System: {} ({:.2}%)",
+            i + 1,
+            truth,
+            guess,
+            prob * 100.0
+        );
+    }
+
+    run_graph_vm_inference(&model, &house_data);
+}
+
+fn run_graph_vm_inference(model: &Perceptron, house_data: &[Vec<f64>]) {
+    let weights = model
+        .weights
+        .as_ref()
+        .expect("expected trained perceptron weights before graph VM inference");
+
+    let mut bias_props = PropertyBag::new();
+    bias_props.insert(
+        "nn.role".to_string(),
+        PropertyValue::String("bias".to_string()),
+    );
+
+    let mut sum_props = PropertyBag::new();
+    sum_props.insert(
+        "nn.layer".to_string(),
+        PropertyValue::String("output".to_string()),
+    );
+    sum_props.insert(
+        "nn.role".to_string(),
+        PropertyValue::String("weighted_sum".to_string()),
+    );
+
+    let mut activation_props = PropertyBag::new();
+    activation_props.insert(
+        "nn.layer".to_string(),
+        PropertyValue::String("output".to_string()),
+    );
+    activation_props.insert(
+        "nn.role".to_string(),
+        PropertyValue::String("activation".to_string()),
+    );
+
+    let mut output_props = PropertyBag::new();
+    output_props.insert(
+        "nn.layer".to_string(),
+        PropertyValue::String("output".to_string()),
+    );
+
+    let network = create_neural_network(Some("mansion-classifier"))
+        .input("bedrooms")
+        .input("bathrooms")
+        .constant("bias", 1.0, bias_props)
+        .weighted_sum(
+            "mansion_logit",
+            vec![
+                WeightedInput::new("bedrooms", weights.data[0][0], "bedrooms_weight"),
+                WeightedInput::new("bathrooms", weights.data[1][0], "bathrooms_weight"),
+                WeightedInput::new("bias", model.bias, "bias_weight"),
+            ],
+            sum_props,
+        )
+        .activation(
+            "mansion_probability",
+            "mansion_logit",
+            ActivationKind::Sigmoid,
+            activation_props,
+            "logit_to_sigmoid",
+        )
+        .output(
+            "mansion_output",
+            "mansion_probability",
+            "mansion_probability",
+            output_props,
+            "probability_to_output",
+        );
+
+    let bytecode = compile_neural_network_to_bytecode(&network).unwrap();
+    println!("\n--- Graph VM Inference ---");
+    for (index, house) in house_data.iter().enumerate() {
+        let mut inputs = HashMap::new();
+        inputs.insert("bedrooms".to_string(), house[0]);
+        inputs.insert("bathrooms".to_string(), house[1]);
+        let outputs = run_neural_bytecode_forward(&bytecode, &inputs).unwrap();
+        let probability = outputs["mansion_probability"];
+        let guess = if probability > 0.5 {
+            "Mansion"
+        } else {
+            "Normal"
+        };
+        println!(
+            "House {} -> VM: {} ({:.2}%)",
+            index + 1,
+            guess,
+            probability * 100.0
+        );
     }
 }

--- a/code/programs/typescript/celsius-to-fahrenheit-predictor/package.json
+++ b/code/programs/typescript/celsius-to-fahrenheit-predictor/package.json
@@ -2,14 +2,17 @@
   "name": "celsius-to-fahrenheit-predictor",
   "version": "1.0.0",
   "scripts": {
-    "start": "ts-node src/index.ts"
+    "start": "tsx src/index.ts"
   },
   "dependencies": {
     "coding-adventures-loss-functions": "file:../../../packages/typescript/loss-functions",
-    "coding-adventures-gradient-descent": "file:../../../packages/typescript/gradient-descent"
+    "coding-adventures-gradient-descent": "file:../../../packages/typescript/gradient-descent",
+    "@coding-adventures/neural-network": "file:../../../packages/typescript/neural-network",
+    "@coding-adventures/neural-graph-vm": "file:../../../packages/typescript/neural-graph-vm"
   },
   "devDependencies": {
     "typescript": "^5.0.0",
+    "tsx": "^4.20.6",
     "ts-node": "^10.9.1"
   }
 }

--- a/code/programs/typescript/celsius-to-fahrenheit-predictor/src/index.ts
+++ b/code/programs/typescript/celsius-to-fahrenheit-predictor/src/index.ts
@@ -1,5 +1,11 @@
 import { mse, mae, mseDerivative, maeDerivative } from "coding-adventures-loss-functions/src/loss_functions";
 import { sgd } from "coding-adventures-gradient-descent/src/gradient_descent";
+import { createNeuralNetwork } from "@coding-adventures/neural-network";
+import {
+  compileBytecodeToMatrixPlan,
+  compileNeuralNetworkToBytecode,
+  runNeuralMatrixForwardScalars,
+} from "@coding-adventures/neural-graph-vm";
 
 const celsius = [-40.0, -10.0, 0.0, 8.0, 15.0, 22.0, 38.0];
 const fahrenheit = [-40.0, 14.0, 32.0, 46.4, 59.0, 71.6, 100.4];
@@ -40,6 +46,35 @@ function train(lossName: string, lossFn: Function, derivFn: Function, lr: number
 
   const predF = w * 100.0 + b;
   console.log(`Prediction for 100.0 C -> ${predF.toFixed(2)} F (Expected ~212.00 F)`);
+  runGraphMatrixVmInference(lossName, w, b, 100.0);
+
+  return { w, b };
+}
+
+function runGraphMatrixVmInference(lossName: string, weight: number, bias: number, celsiusValue: number) {
+  const network = createNeuralNetwork(`celsius-to-fahrenheit-${lossName}`)
+    .input("celsius")
+    .constant("bias", 1, { "nn.role": "bias" })
+    .weightedSum("fahrenheit_sum", [
+      { from: "celsius", weight, edgeId: "celsius_weight" },
+      { from: "bias", weight: bias, edgeId: "fahrenheit_bias" },
+    ], { "nn.layer": "output", "nn.role": "weighted_sum" })
+    .activation("fahrenheit_linear", "fahrenheit_sum", "none", {
+      "nn.layer": "output",
+      "nn.role": "identity_activation",
+    }, "sum_to_identity")
+    .output("fahrenheit", "fahrenheit_linear", "fahrenheit", {
+      "nn.layer": "output",
+    }, "identity_to_output");
+
+  const bytecode = compileNeuralNetworkToBytecode(network);
+  const matrixPlan = compileBytecodeToMatrixPlan(bytecode);
+  const outputs = runNeuralMatrixForwardScalars(matrixPlan, { celsius: celsiusValue });
+
+  console.log(
+    `Graph VM matrix path -> ${celsiusValue.toFixed(1)} C = ${outputs.fahrenheit.toFixed(2)} F ` +
+    `(${bytecode.functions[0].instructions.length} bytecode ops, ${matrixPlan.instructions.length} matrix ops)`
+  );
 }
 
 train("Mean Squared Error (MSE)", mse, mseDerivative, 0.0005);

--- a/code/programs/typescript/mansion-classifier/package-lock.json
+++ b/code/programs/typescript/mansion-classifier/package-lock.json
@@ -1,41 +1,19 @@
 {
-  "name": "celsius-to-fahrenheit-predictor",
+  "name": "mansion-classifier",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "celsius-to-fahrenheit-predictor",
+      "name": "mansion-classifier",
       "version": "1.0.0",
       "dependencies": {
         "@coding-adventures/neural-graph-vm": "file:../../../packages/typescript/neural-graph-vm",
-        "@coding-adventures/neural-network": "file:../../../packages/typescript/neural-network",
-        "coding-adventures-gradient-descent": "file:../../../packages/typescript/gradient-descent",
-        "coding-adventures-loss-functions": "file:../../../packages/typescript/loss-functions"
+        "@coding-adventures/neural-network": "file:../../../packages/typescript/neural-network"
       },
       "devDependencies": {
-        "ts-node": "^10.9.1",
+        "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
-        "typescript": "^5.0.0"
-      }
-    },
-    "../../../packages/typescript/gradient-descent": {
-      "name": "coding-adventures-gradient-descent",
-      "version": "1.0.0",
-      "devDependencies": {
-        "@types/jest": "^29.5.0",
-        "jest": "^29.5.0",
-        "ts-jest": "^29.1.0",
-        "typescript": "^5.0.0"
-      }
-    },
-    "../../../packages/typescript/loss-functions": {
-      "name": "coding-adventures-loss-functions",
-      "version": "1.0.0",
-      "devDependencies": {
-        "@types/jest": "^29.5.0",
-        "jest": "^29.5.0",
-        "ts-jest": "^29.1.0",
         "typescript": "^5.0.0"
       }
     },
@@ -586,14 +564,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/acorn": {
@@ -628,14 +606,6 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/coding-adventures-gradient-descent": {
-      "resolved": "../../../packages/typescript/gradient-descent",
-      "link": true
-    },
-    "node_modules/coding-adventures-loss-functions": {
-      "resolved": "../../../packages/typescript/loss-functions",
-      "link": true
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -820,9 +790,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT",
       "peer": true

--- a/code/programs/typescript/mansion-classifier/package.json
+++ b/code/programs/typescript/mansion-classifier/package.json
@@ -1,5 +1,14 @@
 {
   "name": "mansion-classifier",
   "version": "1.0.0",
-  "scripts": { "start": "npx ts-node --transpileOnly src/index.ts" }
+  "scripts": { "start": "tsx src/index.ts" },
+  "dependencies": {
+    "@coding-adventures/neural-network": "file:../../../packages/typescript/neural-network",
+    "@coding-adventures/neural-graph-vm": "file:../../../packages/typescript/neural-graph-vm"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "tsx": "^4.20.6",
+    "typescript": "^5.0.0"
+  }
 }

--- a/code/programs/typescript/mansion-classifier/src/index.ts
+++ b/code/programs/typescript/mansion-classifier/src/index.ts
@@ -1,4 +1,10 @@
 import { Perceptron } from "../../../../packages/typescript/perceptron/src/perceptron";
+import { createNeuralNetwork } from "@coding-adventures/neural-network";
+import {
+  compileBytecodeToMatrixPlan,
+  compileNeuralNetworkToBytecode,
+  runNeuralMatrixForwardScalars,
+} from "@coding-adventures/neural-graph-vm";
 
 console.log("\n--- Booting TS Mansion Classifier (OOP V2) ---");
 
@@ -19,4 +25,38 @@ predictions.forEach((prob, i) => {
   const truth = targetData[i][0] === 1.0 ? "Mansion" : "Normal";
   const guess = prob > 0.5 ? "Mansion" : "Normal";
   console.log(`House ${i+1} (Truth: ${truth}) -> System: ${guess} (${(prob*100).toFixed(2)}%)`);
+});
+
+if (!model.weights) {
+  throw new Error("Expected trained perceptron weights before graph VM inference");
+}
+
+const graphNetwork = createNeuralNetwork("mansion-classifier")
+  .input("bedrooms")
+  .input("bathrooms")
+  .constant("bias", 1, { "nn.role": "bias" })
+  .weightedSum("mansion_logit", [
+    { from: "bedrooms", weight: model.weights.data[0][0], edgeId: "bedrooms_weight" },
+    { from: "bathrooms", weight: model.weights.data[1][0], edgeId: "bathrooms_weight" },
+    { from: "bias", weight: model.bias, edgeId: "bias_weight" },
+  ], { "nn.layer": "output", "nn.role": "weighted_sum" })
+  .activation("mansion_probability", "mansion_logit", "sigmoid", {
+    "nn.layer": "output",
+    "nn.role": "activation",
+  }, "logit_to_sigmoid")
+  .output("mansion_output", "mansion_probability", "mansion_probability", {
+    "nn.layer": "output",
+  }, "probability_to_output");
+
+const bytecode = compileNeuralNetworkToBytecode(graphNetwork);
+const matrixPlan = compileBytecodeToMatrixPlan(bytecode);
+console.log("\n--- Graph VM Matrix Inference ---");
+houseData.forEach((house, i) => {
+  const outputs = runNeuralMatrixForwardScalars(matrixPlan, {
+    bedrooms: house[0],
+    bathrooms: house[1],
+  });
+  const probability = outputs.mansion_probability;
+  const guess = probability > 0.5 ? "Mansion" : "Normal";
+  console.log(`House ${i+1} -> VM: ${guess} (${(probability*100).toFixed(2)}%)`);
 });

--- a/code/programs/typescript/xor-hidden-layer-trainer/BUILD
+++ b/code/programs/typescript/xor-hidden-layer-trainer/BUILD
@@ -1,4 +1,7 @@
 (cd ../../../packages/typescript/matrix && npm ci --quiet)
+(cd ../../../packages/typescript/multi-directed-graph && npm ci --quiet)
+(cd ../../../packages/typescript/neural-graph-vm && npm ci --quiet)
+(cd ../../../packages/typescript/neural-network && npm ci --quiet)
 (cd ../../../packages/typescript/single-layer-network && npm ci --quiet)
 (cd ../../../packages/typescript/two-layer-network && npm ci --quiet)
 npm ci --quiet

--- a/code/programs/typescript/xor-hidden-layer-trainer/package-lock.json
+++ b/code/programs/typescript/xor-hidden-layer-trainer/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@coding-adventures/neural-graph-vm": "file:../../../packages/typescript/neural-graph-vm",
+        "@coding-adventures/neural-network": "file:../../../packages/typescript/neural-network",
         "coding-adventures-single-layer-network": "file:../../../packages/typescript/single-layer-network",
         "coding-adventures-two-layer-network": "file:../../../packages/typescript/two-layer-network",
         "matrix": "file:../../../packages/typescript/matrix"
@@ -16,6 +18,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "ts-node": "^10.9.2",
+        "tsx": "^4.20.6",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
       }
@@ -27,6 +30,33 @@
         "jest": "^29.0.0",
         "ts-jest": "^29.0.0",
         "typescript": "^5.0.0"
+      }
+    },
+    "../../../packages/typescript/neural-graph-vm": {
+      "name": "@coding-adventures/neural-graph-vm",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/multi-directed-graph": "file:../multi-directed-graph",
+        "@coding-adventures/neural-network": "file:../neural-network"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/neural-network": {
+      "name": "@coding-adventures/neural-network",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/multi-directed-graph": "file:../multi-directed-graph"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
       }
     },
     "../../../packages/typescript/single-layer-network": {
@@ -54,6 +84,14 @@
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
       }
+    },
+    "node_modules/@coding-adventures/neural-graph-vm": {
+      "resolved": "../../../packages/typescript/neural-graph-vm",
+      "link": true
+    },
+    "node_modules/@coding-adventures/neural-network": {
+      "resolved": "../../../packages/typescript/neural-network",
+      "link": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1301,6 +1339,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1426,6 +1477,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -1620,6 +1681,26 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/code/programs/typescript/xor-hidden-layer-trainer/package.json
+++ b/code/programs/typescript/xor-hidden-layer-trainer/package.json
@@ -4,13 +4,15 @@
   "description": "XOR hidden-layer training example",
   "main": "src/index.ts",
   "scripts": {
-    "start": "npx ts-node --transpileOnly src/index.ts",
+    "start": "tsx src/index.ts",
     "build": "tsc",
     "test": "vitest run"
   },
   "author": "Adhithya Rajasekaran",
   "license": "MIT",
   "dependencies": {
+    "@coding-adventures/neural-network": "file:../../../packages/typescript/neural-network",
+    "@coding-adventures/neural-graph-vm": "file:../../../packages/typescript/neural-graph-vm",
     "coding-adventures-single-layer-network": "file:../../../packages/typescript/single-layer-network",
     "coding-adventures-two-layer-network": "file:../../../packages/typescript/two-layer-network",
     "matrix": "file:../../../packages/typescript/matrix"
@@ -18,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "ts-node": "^10.9.2",
+    "tsx": "^4.20.6",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0"
   }

--- a/code/programs/typescript/xor-hidden-layer-trainer/src/index.ts
+++ b/code/programs/typescript/xor-hidden-layer-trainer/src/index.ts
@@ -6,6 +6,12 @@ import {
   type TrainingSnapshot,
 } from "coding-adventures-two-layer-network/src/index";
 import { SingleLayerNetwork } from "coding-adventures-single-layer-network/src/index";
+import { createXorNetwork } from "@coding-adventures/neural-network";
+import {
+  compileBytecodeToMatrixPlan,
+  compileNeuralNetworkToBytecode,
+  runNeuralMatrixForwardScalars,
+} from "@coding-adventures/neural-graph-vm";
 
 export const VERSION = "0.1.0";
 
@@ -42,8 +48,11 @@ export interface XorPredictionRow {
 export interface XorRunResult {
   history: TrainingSnapshot[];
   rows: XorPredictionRow[];
+  vmRows: XorPredictionRow[];
   finalLoss: number;
   trace: ExampleTrace;
+  bytecodeInstructionCount: number;
+  matrixInstructionCount: number;
 }
 
 export interface LinearFailureResult {
@@ -108,12 +117,45 @@ export function runXorDemo(options: XorRunOptions = {}): XorRunResult {
       hidden: inspection.hiddenActivations[index]!,
     };
   });
+  const vm = runXorGraphVmDemo();
 
   return {
     history,
     rows,
+    vmRows: vm.rows,
     finalLoss: history[history.length - 1]?.loss ?? 0,
     trace: network.trace(XOR_INPUTS, 1, XOR_TARGETS[1]),
+    bytecodeInstructionCount: vm.bytecodeInstructionCount,
+    matrixInstructionCount: vm.matrixInstructionCount,
+  };
+}
+
+export function runXorGraphVmDemo(): {
+  rows: XorPredictionRow[];
+  bytecodeInstructionCount: number;
+  matrixInstructionCount: number;
+} {
+  const bytecode = compileNeuralNetworkToBytecode(createXorNetwork("xor-graph-vm"));
+  const matrixPlan = compileBytecodeToMatrixPlan(bytecode);
+  const rows = XOR_INPUTS.map((input, index) => {
+    const outputs = runNeuralMatrixForwardScalars(matrixPlan, {
+      x0: input[0]!,
+      x1: input[1]!,
+    });
+    const prediction = outputs.prediction;
+    return {
+      input,
+      target: XOR_TARGETS[index]![0]!,
+      prediction,
+      rounded: prediction >= 0.5 ? 1 : 0,
+      hidden: [],
+    };
+  });
+
+  return {
+    rows,
+    bytecodeInstructionCount: bytecode.functions[0].instructions.length,
+    matrixInstructionCount: matrixPlan.instructions.length,
   };
 }
 
@@ -132,7 +174,11 @@ export function formatXorRun(result: XorRunResult): string {
     })
     .join("\n");
 
-  return `${checkpoints}\n\n${rows}`;
+  const vmRows = result.vmRows
+    .map(row => `[${row.input.join(", ")}] target=${row.target} vm_prediction=${fmt(row.prediction)} rounded=${row.rounded}`)
+    .join("\n");
+
+  return `${checkpoints}\n\n${rows}\n\nGraph VM matrix path (${result.bytecodeInstructionCount} bytecode ops -> ${result.matrixInstructionCount} matrix ops)\n${vmRows}`;
 }
 
 export function formatLinearFailure(result: LinearFailureResult): string {

--- a/code/programs/typescript/xor-hidden-layer-trainer/tests/xor-hidden-layer-trainer.test.ts
+++ b/code/programs/typescript/xor-hidden-layer-trainer/tests/xor-hidden-layer-trainer.test.ts
@@ -27,6 +27,15 @@ describe("xor hidden-layer trainer", () => {
     expect(result.rows.every(row => row.hidden.length === 2)).toBe(true);
   });
 
+  it("runs the canonical XOR graph through bytecode and matrix instructions", () => {
+    const result = runXorDemo({ epochs: 100, logEvery: 100 });
+
+    expect(result.vmRows.map(row => row.rounded)).toEqual([0, 1, 1, 0]);
+    expect(result.bytecodeInstructionCount).toBeGreaterThan(0);
+    expect(result.matrixInstructionCount).toBeGreaterThan(0);
+    expect(result.matrixInstructionCount).toBeLessThan(result.bytecodeInstructionCount);
+  });
+
   it("formats checkpoints and hidden activations", () => {
     const text = formatXorRun(runXorDemo({ epochs: 100, logEvery: 100 }));
 


### PR DESCRIPTION
## Summary
- port the neural demo programs to build graph-native models and execute them through the neural graph VM / matrix-plan path where supported
- wire Celsius, mansion classifier, and XOR hidden-layer examples across the supported language demos
- fix a couple of primitive issues found while stress-testing the path, including perceptron bias application in Go/Rust and Elixir numeric formatting

## Validation
- TypeScript neural-graph-vm: `npm test -- --run`, `npm run build`
- TypeScript Celsius/mansion/XOR demos: `npm start`, `bash BUILD`
- Python Celsius/mansion/XOR demos: direct runs and `bash BUILD`
- Go Celsius/mansion/XOR demos plus package tests
- Rust Celsius/mansion demos plus package tests
- Ruby Celsius/mansion demos
- Elixir Celsius/mansion demos plus package compile/build checks
- `git diff --check`