### PR TITLE
Add WASM execution fuel limits

### DIFF
--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -98,6 +98,8 @@ All notable changes to this package will be documented in this file.
   and output in one end-to-end program.
 - Added a front-door ALGOL source-length limit to the WASM convenience APIs so
   oversized untrusted source is rejected before parsing or semantic analysis.
+- Documented and tested host-side WASM instruction budgets for compiled ALGOL
+  modules so nonterminating `goto` programs can be capped by embedders.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -47,13 +47,20 @@ The convenience APIs reject source strings larger than 256 KiB before parsing.
 The downstream type checker also enforces configurable AST, block-nesting, and
 procedure-nesting limits so recursive semantic analysis fails with explicit
 diagnostics instead of exhausting Python recursion on hostile inputs.
+At execution time, run compiled modules with `WasmRuntime`'s
+`WasmExecutionLimits` when the ALGOL source is untrusted; the instruction
+budget stops nonterminating control-flow programs before they monopolize the
+host process.
 
 ```python
 from algol_wasm_compiler import compile_source
-from wasm_runtime import WasiConfig, WasiHost, WasmRuntime
+from wasm_runtime import WasiConfig, WasiHost, WasmExecutionLimits, WasmRuntime
 
 compiled = compile_source("begin integer result; result := 7 end")
 assert WasmRuntime().load_and_run(compiled.binary, "_start", []) == [7]
+
+bounded_runtime = WasmRuntime(limits=WasmExecutionLimits(max_instructions=100_000))
+assert bounded_runtime.load_and_run(compiled.binary, "_start", []) == [7]
 
 print_only = compile_source("begin print('Hi') end")
 captured_print: list[str] = []

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 from algol_ir_compiler.compiler import _MAX_STRING_OUTPUT_BYTES, _MAX_TOTAL_OUTPUT_BYTES
-from wasm_runtime import WasiConfig, WasiHost, WasmRuntime
+from wasm_execution import TrapError
+from wasm_runtime import WasiConfig, WasiHost, WasmExecutionLimits, WasmRuntime
 
 from algol_wasm_compiler import (
     MAX_SOURCE_LENGTH,
@@ -532,6 +533,13 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [4]
+
+    def test_runtime_instruction_budget_stops_nonterminating_goto_loop(self) -> None:
+        result = compile_source("begin integer result; loop: goto loop end")
+        runtime = WasmRuntime(limits=WasmExecutionLimits(max_instructions=128))
+
+        with pytest.raises(TrapError, match="instruction budget exhausted"):
+            runtime.load_and_run(result.binary, "_start", [])
 
     def test_local_goto_strategy_preserves_procedure_calls(self) -> None:
         result = compile_source(

--- a/code/packages/python/wasm-execution/CHANGELOG.md
+++ b/code/packages/python/wasm-execution/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Added `WasmExecutionLimits(max_instructions=...)` so embedders can bound
+  interpreted WASM instruction fuel and receive a `TrapError` when execution
+  exhausts the configured budget.
+
 ## [0.1.0] - 2026-04-05
 
 ### Added

--- a/code/packages/python/wasm-execution/README.md
+++ b/code/packages/python/wasm-execution/README.md
@@ -10,6 +10,13 @@ WebAssembly 1.0 wasm-execution
 - wasm-module-parser
 - virtual-machine
 
+## Execution Limits
+
+`WasmExecutionEngine` accepts `WasmExecutionLimits` so embedders can cap
+runtime work for untrusted modules. The first limit is `max_instructions`,
+which counts interpreted WASM instructions across module-defined calls and
+raises a `TrapError` once the budget is exhausted.
+
 ## Development
 
 ```bash

--- a/code/packages/python/wasm-execution/src/wasm_execution/__init__.py
+++ b/code/packages/python/wasm-execution/src/wasm_execution/__init__.py
@@ -7,7 +7,7 @@ linear memory, tables, instruction handlers, and the execution engine.
 __version__ = "0.1.0"
 
 from wasm_execution.const_expr import evaluate_const_expr
-from wasm_execution.engine import WasmExecutionEngine
+from wasm_execution.engine import WasmExecutionEngine, WasmExecutionLimits
 from wasm_execution.host_interface import HostFunction, HostInterface, TrapError
 from wasm_execution.linear_memory import LinearMemory
 from wasm_execution.table import Table
@@ -26,6 +26,7 @@ from wasm_execution.values import (
 
 __all__ = [
     "WasmExecutionEngine",
+    "WasmExecutionLimits",
     "LinearMemory",
     "Table",
     "TrapError",

--- a/code/packages/python/wasm-execution/src/wasm_execution/engine.py
+++ b/code/packages/python/wasm-execution/src/wasm_execution/engine.py
@@ -6,13 +6,18 @@ using the GenericVM infrastructure.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from virtual_machine.generic_vm import GenericVM
-from virtual_machine.vm import CodeObject
-from wasm_types import FuncType, FunctionBody, GlobalType
+from virtual_machine.vm import CodeObject, Instruction
+from wasm_types import FunctionBody, FuncType, GlobalType
 
-from wasm_execution.decoder import build_control_flow_map, decode_function_body, to_vm_instructions
+from wasm_execution.decoder import (
+    build_control_flow_map,
+    decode_function_body,
+    to_vm_instructions,
+)
 from wasm_execution.host_interface import TrapError
 from wasm_execution.instructions.control import register_control
 from wasm_execution.instructions.dispatch import register_all_instructions
@@ -22,6 +27,17 @@ from wasm_execution.types import WasmExecutionContext
 from wasm_execution.values import WasmValue, default_value
 
 MAX_CALL_DEPTH = 1024
+
+
+@dataclass(frozen=True)
+class WasmExecutionLimits:
+    """Configurable safety limits for WASM execution."""
+
+    max_instructions: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_instructions is not None and self.max_instructions < 0:
+            raise ValueError("max_instructions must be non-negative")
 
 
 class WasmExecutionEngine:
@@ -50,6 +66,7 @@ class WasmExecutionEngine:
         func_types: list[FuncType],
         func_bodies: list[FunctionBody | None],
         host_functions: list[Any | None],
+        limits: WasmExecutionLimits | None = None,
     ) -> None:
         self._memory = memory
         self._tables = tables
@@ -58,6 +75,8 @@ class WasmExecutionEngine:
         self._func_types = func_types
         self._func_bodies = func_bodies
         self._host_functions = host_functions
+        self._limits = limits or WasmExecutionLimits()
+        self._instructions_executed = 0
 
         # Decoded function body cache (decoded once, reused)
         self._decoded_cache: dict[int, Any] = {}
@@ -69,6 +88,7 @@ class WasmExecutionEngine:
         # Register all WASM instruction handlers
         register_all_instructions(self._vm)
         register_control(self._vm)
+        self._install_instruction_budget_hook()
 
     def call_function(self, func_index: int, args: list[WasmValue]) -> list[WasmValue]:
         """Call a WASM function by index.
@@ -83,10 +103,14 @@ class WasmExecutionEngine:
         if func_index < 0 or func_index >= len(self._func_types):
             msg = f"undefined function index {func_index}"
             raise TrapError(msg)
+        self._instructions_executed = 0
 
         func_type = self._func_types[func_index]
         if len(args) != len(func_type.params):
-            msg = f"function {func_index} expects {len(func_type.params)} arguments, got {len(args)}"
+            msg = (
+                f"function {func_index} expects {len(func_type.params)} "
+                f"arguments, got {len(args)}"
+            )
             raise TrapError(msg)
 
         # Check if this is a host (imported) function
@@ -147,6 +171,7 @@ class WasmExecutionEngine:
         # Re-register handlers after reset
         register_all_instructions(self._vm)
         register_control(self._vm)
+        self._install_instruction_budget_hook()
 
         current_code = code
         while True:
@@ -175,6 +200,25 @@ class WasmExecutionEngine:
                 results.insert(0, self._vm.pop_typed())
 
         return results
+
+    def _install_instruction_budget_hook(self) -> None:
+        if self._limits.max_instructions is None:
+            self._vm.set_pre_instruction_hook(None)
+            return
+
+        def consume_instruction_budget(
+            _vm: GenericVM,
+            _instruction: Instruction,
+            _code: CodeObject,
+        ) -> None:
+            if self._instructions_executed >= self._limits.max_instructions:
+                raise TrapError(
+                    "WASM execution instruction budget exhausted "
+                    f"(limit: {self._limits.max_instructions})"
+                )
+            self._instructions_executed += 1
+
+        self._vm.set_pre_instruction_hook(consume_instruction_budget)
 
     def _resume_saved_frame(self, ctx: WasmExecutionContext) -> CodeObject:
         frame = ctx.saved_frames.pop()

--- a/code/packages/python/wasm-runtime/CHANGELOG.md
+++ b/code/packages/python/wasm-runtime/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this package will be documented in this file.
 - **`compiler_math` host imports** — `WasiHost` now resolves `f64_sin`,
   `f64_cos`, `f64_atan`, `f64_ln`, `f64_exp`, and `f64_pow` for generic compiler
   pipeline modules that need non-core WASM real math.
+- `WasmRuntime` now accepts `WasmExecutionLimits`, including a
+  `max_instructions` budget that traps nonterminating module execution
+  predictably.
 
 ### Changed
 

--- a/code/packages/python/wasm-runtime/README.md
+++ b/code/packages/python/wasm-runtime/README.md
@@ -39,6 +39,19 @@ result = runtime.load_and_run(wasm_bytes, "square", [5])
 print(result)  # [25]
 ```
 
+### Bounding execution
+
+```python
+from wasm_runtime import WasmExecutionLimits, WasmRuntime
+
+runtime = WasmRuntime(limits=WasmExecutionLimits(max_instructions=100_000))
+runtime.load_and_run(wasm_bytes, "_start", [])
+```
+
+When the instruction budget is exhausted, execution traps before dispatching
+the next WASM instruction. This lets untrusted compiled programs fail
+predictably instead of monopolizing the Python host.
+
 ### WASI Tier 1 (stdin/stdout/stderr capture)
 
 ```python

--- a/code/packages/python/wasm-runtime/src/wasm_runtime/__init__.py
+++ b/code/packages/python/wasm-runtime/src/wasm_runtime/__init__.py
@@ -2,6 +2,8 @@
 
 __version__ = "0.1.0"
 
+from wasm_execution import WasmExecutionLimits
+
 from wasm_runtime.instance import WasmInstance
 from wasm_runtime.runtime import WasmRuntime
 from wasm_runtime.wasi_host import (
@@ -16,6 +18,7 @@ from wasm_runtime.wasi_host import (
 
 __all__ = [
     "WasmRuntime",
+    "WasmExecutionLimits",
     "WasmInstance",
     "WasiHost",
     "WasiConfig",

--- a/code/packages/python/wasm-runtime/src/wasm_runtime/runtime.py
+++ b/code/packages/python/wasm-runtime/src/wasm_runtime/runtime.py
@@ -7,15 +7,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from wasm_module_parser import WasmModuleParser
-from wasm_types import ExternalKind, FuncType, FunctionBody, GlobalType, ValueType, WasmModule
-from wasm_validator import ValidatedModule, validate
-
 from wasm_execution import (
     LinearMemory,
     Table,
     TrapError,
     WasmExecutionEngine,
+    WasmExecutionLimits,
     WasmValue,
     evaluate_const_expr,
     f32,
@@ -23,6 +20,16 @@ from wasm_execution import (
     i32,
     i64,
 )
+from wasm_module_parser import WasmModuleParser
+from wasm_types import (
+    ExternalKind,
+    FunctionBody,
+    FuncType,
+    GlobalType,
+    ValueType,
+    WasmModule,
+)
+from wasm_validator import ValidatedModule, validate
 
 from wasm_runtime.instance import WasmInstance
 
@@ -37,9 +44,14 @@ class WasmRuntime:
         # result == [25]
     """
 
-    def __init__(self, host: Any | None = None) -> None:
+    def __init__(
+        self,
+        host: Any | None = None,
+        limits: WasmExecutionLimits | None = None,
+    ) -> None:
         self._parser = WasmModuleParser()
         self._host = host
+        self._limits = limits or WasmExecutionLimits()
 
     def load(self, wasm_bytes: bytes | bytearray) -> WasmModule:
         """Parse a .wasm binary into a WasmModule."""
@@ -67,18 +79,34 @@ class WasmRuntime:
                 func_type = module.types[type_idx]
                 func_types.append(func_type)
                 func_bodies.append(None)
-                host_func = self._host.resolve_function(imp.module_name, imp.name) if self._host else None
+                host_func = (
+                    self._host.resolve_function(imp.module_name, imp.name)
+                    if self._host
+                    else None
+                )
                 host_functions.append(host_func)
             elif imp.kind == ExternalKind.MEMORY:
-                imported_mem = self._host.resolve_memory(imp.module_name, imp.name) if self._host else None
+                imported_mem = (
+                    self._host.resolve_memory(imp.module_name, imp.name)
+                    if self._host
+                    else None
+                )
                 if imported_mem:
                     memory = imported_mem
             elif imp.kind == ExternalKind.TABLE:
-                imported_table = self._host.resolve_table(imp.module_name, imp.name) if self._host else None
+                imported_table = (
+                    self._host.resolve_table(imp.module_name, imp.name)
+                    if self._host
+                    else None
+                )
                 if imported_table:
                     tables.append(imported_table)
             elif imp.kind == ExternalKind.GLOBAL:
-                imported_global = self._host.resolve_global(imp.module_name, imp.name) if self._host else None
+                imported_global = (
+                    self._host.resolve_global(imp.module_name, imp.name)
+                    if self._host
+                    else None
+                )
                 if imported_global:
                     global_types.append(imported_global["type"])
                     globals_list.append(imported_global["value"])
@@ -99,10 +127,12 @@ class WasmRuntime:
 
         # Allocate tables
         for table_type in module.tables:
-            tables.append(Table(
-                table_type.limits.min,
-                table_type.limits.max,
-            ))
+            tables.append(
+                Table(
+                    table_type.limits.min,
+                    table_type.limits.max,
+                )
+            )
 
         # Initialize globals
         for global_def in module.globals:
@@ -144,7 +174,11 @@ class WasmRuntime:
         )
 
         # Bind linear memory on the WASI host if it exposes set_memory().
-        if self._host is not None and hasattr(self._host, "set_memory") and memory is not None:
+        if (
+            self._host is not None
+            and hasattr(self._host, "set_memory")
+            and memory is not None
+        ):
             self._host.set_memory(memory)
 
         # Call start function
@@ -157,12 +191,18 @@ class WasmRuntime:
                 func_types=instance.func_types,
                 func_bodies=instance.func_bodies,
                 host_functions=instance.host_functions,
+                limits=self._limits,
             )
             engine.call_function(module.start, [])
 
         return instance
 
-    def call(self, instance: WasmInstance, name: str, args: list[int | float]) -> list[int | float]:
+    def call(
+        self,
+        instance: WasmInstance,
+        name: str,
+        args: list[int | float],
+    ) -> list[int | float]:
         """Call an exported function by name."""
         exp = instance.exports.get(name)
         if exp is None:
@@ -177,7 +217,9 @@ class WasmRuntime:
         # Convert plain numbers to WasmValues
         wasm_args: list[WasmValue] = []
         for idx, arg in enumerate(args):
-            param_type = func_type.params[idx] if idx < len(func_type.params) else ValueType.I32
+            param_type = (
+                func_type.params[idx] if idx < len(func_type.params) else ValueType.I32
+            )
             if param_type == ValueType.I32:
                 wasm_args.append(i32(int(arg)))
             elif param_type == ValueType.I64:
@@ -197,6 +239,7 @@ class WasmRuntime:
             func_types=instance.func_types,
             func_bodies=instance.func_bodies,
             host_functions=instance.host_functions,
+            limits=self._limits,
         )
 
         results = engine.call_function(exp["index"], wasm_args)

--- a/code/packages/python/wasm-runtime/tests/test_runtime.py
+++ b/code/packages/python/wasm-runtime/tests/test_runtime.py
@@ -7,16 +7,15 @@ load_and_run shortcut.
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
+from wasm_execution import TrapError, WasmExecutionLimits
 from wasm_types import (
     DataSegment,
     Element,
     Export,
     ExternalKind,
-    FuncType,
     FunctionBody,
+    FuncType,
     Global,
     GlobalType,
     Import,
@@ -27,10 +26,7 @@ from wasm_types import (
     WasmModule,
 )
 
-from wasm_execution import TrapError
-from wasm_runtime.instance import WasmInstance
 from wasm_runtime.runtime import WasmRuntime
-
 
 # ===========================================================================
 # Helper: build a module that computes f(x) = x * x
@@ -52,7 +48,12 @@ def _square_module() -> WasmModule:
         exports=[Export(name="square", kind=ExternalKind.FUNCTION, index=0)],
         start=None,
         elements=[],
-        code=[FunctionBody(locals=(), code=bytes([0x20, 0x00, 0x20, 0x00, 0x6C, 0x0B]))],
+        code=[
+            FunctionBody(
+                locals=(),
+                code=bytes([0x20, 0x00, 0x20, 0x00, 0x6C, 0x0B]),
+            )
+        ],
         data=[],
         customs=[],
     )
@@ -71,6 +72,29 @@ def _identity_module() -> WasmModule:
         start=None,
         elements=[],
         code=[FunctionBody(locals=(), code=bytes([0x20, 0x00, 0x0B]))],
+        data=[],
+        customs=[],
+    )
+
+
+def _spinning_module() -> WasmModule:
+    """Build a module with spin() = loop { br 0 }."""
+    return WasmModule(
+        types=[FuncType(params=(), results=())],
+        imports=[],
+        functions=[0],
+        tables=[],
+        memories=[],
+        globals=[],
+        exports=[Export(name="spin", kind=ExternalKind.FUNCTION, index=0)],
+        start=None,
+        elements=[],
+        code=[
+            FunctionBody(
+                locals=(),
+                code=bytes([0x03, 0x40, 0x0C, 0x00, 0x0B]),
+            )
+        ],
         data=[],
         customs=[],
     )
@@ -127,6 +151,13 @@ class TestRuntimeBasic:
         instance = runtime.instantiate(module)
         with pytest.raises(TrapError, match="not a function"):
             runtime.call(instance, "mem", [])
+
+    def test_instruction_budget_traps_nonterminating_function(self) -> None:
+        runtime = WasmRuntime(limits=WasmExecutionLimits(max_instructions=8))
+        instance = runtime.instantiate(_spinning_module())
+
+        with pytest.raises(TrapError, match="instruction budget exhausted"):
+            runtime.call(instance, "spin", [])
 
 
 # ===========================================================================
@@ -350,8 +381,15 @@ class TestRuntimeWithWasi:
 
         module = WasmModule(
             types=[
-                FuncType(params=(ValueType.I32, ValueType.I32, ValueType.I32, ValueType.I32),
-                         results=(ValueType.I32,)),
+                FuncType(
+                    params=(
+                        ValueType.I32,
+                        ValueType.I32,
+                        ValueType.I32,
+                        ValueType.I32,
+                    ),
+                    results=(ValueType.I32,),
+                ),
                 FuncType(params=(ValueType.I32,), results=(ValueType.I32,)),
             ],
             imports=[

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -1537,9 +1537,10 @@ Current implementation note: the Python ALGOL lane enforces the first
 front-end limits through the WASM package's source-length guard and the type
 checker's configurable AST-depth, block-depth, and procedure-depth checks. The
 runtime lowering already keeps frames, dynamic arrays, output, eval-thunk
-descriptors, and generated control/helper label state bounded; future
-convergence work should continue closing the remaining host-execution budget
-items against this list.
+descriptors, and generated control/helper label state bounded. The pure-Python
+WASM runtime now also exposes a configurable instruction budget so embedders
+can cap nonterminating compiled programs at execution time; future convergence
+work should keep closing any remaining host-budget items against this list.
 
 ## Documentation Requirements
 


### PR DESCRIPTION
## Summary
- add configurable `WasmExecutionLimits(max_instructions=...)` to the pure-Python WASM execution engine and surface it through `WasmRuntime`
- count interpreted WASM instructions across module-defined calls and trap predictably when the configured budget is exhausted
- add raw WASM and ALGOL `goto` spin-loop regressions, plus docs/changelog updates for the ALGOL security roadmap

## Tests
- `bash BUILD` in `code/packages/python/wasm-execution`: 287 passed
- `bash BUILD` in `code/packages/python/wasm-runtime`: 74 passed
- `bash BUILD` in `code/packages/python/algol-wasm-compiler`: 170 passed before rebasing; rebase introduced no Python/spec changes in this stack
- `python -m pytest -o addopts= code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py::TestAlgolWasmCompiler::test_runtime_instruction_budget_stops_nonterminating_goto_loop -q`: 1 passed after rebase
- scoped `ruff check --select E,F,I`: passed
- `git diff --check origin/main`: passed
- security review: no new risky subprocess/shell/network/file-write/deserialization/secret patterns found