### PR TITLE
fix(prolog): preserve control goal freshening

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -34,6 +34,12 @@ All notable changes to this package will be documented in this file.
 - `iftheno(...)` and `ifthenelseo(...)` now preserve rule-local variable
   freshening when their condition and branches can be represented as callable
   terms.
+- `onceo(...)`, `noto(...)`, and `forallo(...)` now preserve rule-local
+  variable freshening when their embedded goals can be represented as callable
+  terms.
+- `findallo(...)`, `bagofo(...)`, and `setofo(...)` now preserve rule-local
+  variable freshening when their embedded goals can be represented as callable
+  terms.
 
 ## [0.13.0] - 2026-04-22
 

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -1448,6 +1448,29 @@ def findallo(template: object, goal: object, results: object) -> GoalExpr:
     """Collect every solution of `goal` into `results`, preserving proof order."""
 
     called_goal = _as_goal(goal)
+    goal_term = _goal_term_or_none(called_goal)
+
+    if goal_term is not None:
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            template_term, called_goal_term, results_term = args
+            try:
+                reified_goal = goal_from_term(_reified(called_goal_term, state))
+            except TypeError:
+                return
+            values = _collect_template_values(
+                program_value,
+                state,
+                template_term,
+                reified_goal,
+            )
+            yield from _unify_collection(program_value, state, results_term, values)
+
+        return native_goal(run_terms, template, goal_term, results)
 
     def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
         template_term, results_term = args
@@ -1466,6 +1489,31 @@ def bagofo(template: object, goal: object, results: object) -> GoalExpr:
     """Collect a non-empty proof-order bag of solutions."""
 
     called_goal = _as_goal(goal)
+    goal_term = _goal_term_or_none(called_goal)
+
+    if goal_term is not None:
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            template_term, called_goal_term, results_term = args
+            try:
+                reified_goal = goal_from_term(_reified(called_goal_term, state))
+            except TypeError:
+                return
+            values = _collect_template_values(
+                program_value,
+                state,
+                template_term,
+                reified_goal,
+            )
+            if not values:
+                return
+            yield from _unify_collection(program_value, state, results_term, values)
+
+        return native_goal(run_terms, template, goal_term, results)
 
     def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
         template_term, results_term = args
@@ -1486,6 +1534,36 @@ def setofo(template: object, goal: object, results: object) -> GoalExpr:
     """Collect a non-empty sorted set of solutions."""
 
     called_goal = _as_goal(goal)
+    goal_term = _goal_term_or_none(called_goal)
+
+    if goal_term is not None:
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            template_term, called_goal_term, results_term = args
+            try:
+                reified_goal = goal_from_term(_reified(called_goal_term, state))
+            except TypeError:
+                return
+            values = _collect_template_values(
+                program_value,
+                state,
+                template_term,
+                reified_goal,
+            )
+            if not values:
+                return
+            yield from _unify_collection(
+                program_value,
+                state,
+                results_term,
+                _unique_sorted_terms(values),
+            )
+
+        return native_goal(run_terms, template, goal_term, results)
 
     def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
         template_term, results_term = args
@@ -2268,6 +2346,37 @@ def forallo(generator: object, test: object) -> GoalExpr:
 
     generator_goal = _as_goal(generator)
     test_goal = _as_goal(test)
+    generator_term = _goal_term_or_none(generator_goal)
+    test_term = _goal_term_or_none(test_goal)
+
+    if generator_term is not None and test_term is not None:
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            generator_goal_term, test_goal_term = args
+            try:
+                called_generator = goal_from_term(
+                    _reified(generator_goal_term, state),
+                )
+            except TypeError:
+                return
+
+            for generated_state in solve_from(program_value, called_generator, state):
+                try:
+                    called_test = goal_from_term(
+                        _reified(test_goal_term, generated_state),
+                    )
+                except TypeError:
+                    return
+                test_proofs = solve_from(program_value, called_test, generated_state)
+                if next(test_proofs, None) is None:
+                    return
+            yield state
+
+        return native_goal(run_terms, generator_term, test_term)
 
     def run(program_value: Program, state: State, _args: NativeArgs) -> Iterator[State]:
         for generated_state in solve_from(program_value, generator_goal, state):
@@ -2973,6 +3082,26 @@ def onceo(goal: object) -> GoalExpr:
     """Run `goal` and keep at most its first solution."""
 
     called_goal = _as_goal(goal)
+    goal_term = _goal_term_or_none(called_goal)
+
+    if goal_term is not None:
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            (called_goal_term,) = args
+            try:
+                reified_goal = goal_from_term(_reified(called_goal_term, state))
+            except TypeError:
+                return
+            iterator = solve_from(program_value, reified_goal, state)
+            first = next(iterator, None)
+            if first is not None:
+                yield first
+
+        return native_goal(run_terms, goal_term)
 
     def run(program_value: Program, state: State, _args: NativeArgs) -> Iterator[State]:
         iterator = solve_from(program_value, called_goal, state)
@@ -2992,6 +3121,25 @@ def noto(goal: object) -> GoalExpr:
     """
 
     called_goal = _as_goal(goal)
+    goal_term = _goal_term_or_none(called_goal)
+
+    if goal_term is not None:
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            (called_goal_term,) = args
+            try:
+                reified_goal = goal_from_term(_reified(called_goal_term, state))
+            except TypeError:
+                return
+            iterator = solve_from(program_value, reified_goal, state)
+            if next(iterator, None) is None:
+                yield state
+
+        return native_goal(run_terms, goal_term)
 
     def run(program_value: Program, state: State, _args: NativeArgs) -> Iterator[State]:
         iterator = solve_from(program_value, called_goal, state)

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -264,6 +264,42 @@ class TestAdvancedControlBuiltins:
             forallo(disj(eq(item, 1), eq(item, 2)), numbero(item)),
         ) == [item]
 
+    def test_control_goal_terms_preserve_rule_local_freshening(self) -> None:
+        item = var("Item")
+        probe_result = var("Probe")
+        output = var("Output")
+        inner = var("Inner")
+        item_rel = relation("item", 1)
+        blocked = relation("blocked", 1)
+        allowed = relation("allowed", 1)
+        probe = relation("probe", 1)
+        first_probe = relation("first_probe", 1)
+        all_small = relation("all_small", 0)
+        visible = relation("visible", 2)
+
+        prog = program(
+            fact(item_rel("tea")),
+            fact(item_rel("cake")),
+            fact(blocked("cake")),
+            fact(probe("first")),
+            fact(probe("second")),
+            rule(allowed(item), conj(item_rel(item), noto(blocked(item)))),
+            rule(first_probe(probe_result), onceo(probe(probe_result))),
+            rule(
+                all_small(),
+                forallo(disj(eq(inner, 1), eq(inner, 2)), lto(inner, 3)),
+            ),
+            rule(
+                visible(item, probe_result),
+                conj(allowed(item), first_probe(probe_result), all_small()),
+            ),
+        )
+
+        assert solve_all(prog, output, visible(output, probe_result)) == [atom("tea")]
+        assert solve_all(prog, probe_result, visible(output, probe_result)) == [
+            atom("first"),
+        ]
+
     def test_advanced_control_rejects_non_goals(self) -> None:
         with pytest.raises(TypeError):
             iftheno(object(), trueo())
@@ -386,6 +422,37 @@ class TestCollectionBuiltins:
             results,
             findallo(child, parent("homer", child), results),
         ) == [logic_list(["bart", "lisa"])]
+
+    def test_collectors_preserve_rule_local_freshening(self) -> None:
+        item = var("Item")
+        output = var("Output")
+        results = var("Results")
+        item_rel = relation("item", 1)
+        duplicate = relation("duplicate", 1)
+        all_items = relation("all_items", 1)
+        bagged_items = relation("bagged_items", 1)
+        unique_items = relation("unique_items", 1)
+
+        prog = program(
+            fact(item_rel("tea")),
+            fact(item_rel("cake")),
+            fact(duplicate("cake")),
+            fact(duplicate("tea")),
+            fact(duplicate("cake")),
+            rule(all_items(results), findallo(item, item_rel(item), results)),
+            rule(bagged_items(results), bagofo(item, item_rel(item), results)),
+            rule(unique_items(results), setofo(item, duplicate(item), results)),
+        )
+
+        assert solve_all(prog, output, all_items(output)) == [
+            logic_list(["tea", "cake"]),
+        ]
+        assert solve_all(prog, output, bagged_items(output)) == [
+            logic_list(["tea", "cake"]),
+        ]
+        assert solve_all(prog, output, unique_items(output)) == [
+            logic_list(["cake", "tea"]),
+        ]
 
     def test_collectors_reject_non_goals(self) -> None:
         results = var("Results")

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -37,6 +37,8 @@
 - Run Prolog `dif/2` through the VM path as a delayed disequality constraint.
 - Expose residual delayed disequality constraints on named `PrologAnswer`
   values produced by compiled source queries and stateful runtimes.
+- Add end-to-end stress coverage for negation-as-failure, `once/1`,
+  `forall/2`, `bagof/3`, and `setof/3` through the Prolog VM path.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -133,10 +133,11 @@ The package includes end-to-end stress tests for:
 - DCG expansion with `phrase/3`
 - arithmetic evaluation and comparison
 - finite integer builtins such as `integer/1`, `between/3`, and `succ/2`
+- negation and control builtins such as `\+/1`, `once/1`, and `forall/2`
 - callable, natural infix, and nested additive CLP(FD) forms for finite-domain
   puzzles
 - CLP(FD) labeling options such as descending value order
-- collection predicates such as `findall/3`
+- collection predicates such as `findall/3`, `bagof/3`, and `setof/3`
 - common list predicates such as `member/2`, `append/3`, `length/2`,
   `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`
 - dynamic predicates seeded by initialization directives

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -209,6 +209,64 @@ class TestPrologVMStress:
             {"Name": atom("cake"), "Flavor": atom("savory")},
         ]
 
+    def test_negation_once_and_aggregation_control_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            item(tea).
+            item(cake).
+            item(jam).
+            blocked(cake).
+            probe(first).
+            probe(second).
+            score(2).
+            score(1).
+            duplicate(jam).
+            duplicate(tea).
+            duplicate(jam).
+
+            allowed(Item) :- item(Item), \\+ blocked(Item).
+            single_probe(Probe) :- once(probe(Probe)).
+            all_numbers_small :- forall(member(N, [1,2,3]), N < 4).
+            all_allowed(Allowed) :- findall(Value, allowed(Value), Allowed).
+            score_bag(Numbers) :- bagof(Number, score(Number), Numbers).
+            unique_duplicates(Unique) :- setof(Name, duplicate(Name), Unique).
+
+            ?- allowed(Item),
+               single_probe(Probe),
+               all_numbers_small,
+               all_allowed(Allowed),
+               score_bag(Numbers),
+               unique_duplicates(Unique),
+               \\+ allowed(cake).
+            """,
+        )
+        failure = compile_swi_prolog_source(
+            """
+            item(tea).
+            ?- \\+ item(tea).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {
+                "Item": atom("tea"),
+                "Probe": atom("first"),
+                "Allowed": logic_list(["tea", "jam"]),
+                "Numbers": logic_list([2, 1]),
+                "Unique": logic_list(["jam", "tea"]),
+            },
+            {
+                "Item": atom("jam"),
+                "Probe": atom("first"),
+                "Allowed": logic_list(["tea", "jam"]),
+                "Numbers": logic_list([2, 1]),
+                "Unique": logic_list(["jam", "tea"]),
+            },
+        ]
+        assert run_compiled_prolog_query(failure) == []
+
     def test_higher_order_list_predicates_run_through_vm(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR45-prolog-control-aggregation-stress.md
+++ b/code/specs/PR45-prolog-control-aggregation-stress.md
@@ -1,0 +1,48 @@
+# PR45: Prolog VM Control And Aggregation Stress
+
+## Goal
+
+Prove that the Prolog VM path can run practical control and aggregation
+programs from source syntax, not only isolated library-level builtins.
+
+## Scope
+
+This batch fixes rule-local variable freshening for embedded callable goals in
+control builtins and adds end-to-end stress coverage for:
+
+- negation-as-failure with `\+/1`
+- deterministic probing with `once/1`
+- universal checks with `forall/2`
+- collection predicates `findall/3`, `bagof/3`, and `setof/3`
+
+## Motivation
+
+The underlying logic builtins and loader adapters already expose these
+predicates. What was missing was one compact source-level regression that shows
+they compose through the complete stack:
+
+```text
+SWI-style source -> parser -> loader adapter -> Prolog VM compiler -> Logic VM
+```
+
+This matters because real Prolog programs frequently combine control and
+aggregation in one query. A parser-only or builtin-only test can miss integration
+failures in operator handling, callable-goal adaptation, variable visibility, or
+VM query answer projection.
+
+The new stress case exposed one of those integration failures: `onceo(...)`,
+`noto(...)`, `forallo(...)`, `findallo(...)`, `bagofo(...)`, and `setofo(...)`
+captured embedded goal objects too early when used inside rules, so rule
+freshening could leave body variables disconnected from head variables. The fix
+mirrors the existing `iftheno(...)` strategy by passing representable callable
+goals as native-goal arguments and lowering them again from the active reified
+state.
+
+## Acceptance Tests
+
+- `\+/1` succeeds for non-provable goals and fails for provable goals.
+- `once/1` commits to the first proof of a generator.
+- `forall/2` succeeds when every generated proof satisfies the test.
+- `findall/3` preserves all answers in proof order.
+- `bagof/3` preserves grouped answers and fails only when empty.
+- `setof/3` deduplicates and sorts collected answers.


### PR DESCRIPTION
## Summary
- preserve rule-local variable freshening for callable goals embedded in `onceo`, `noto`, `forallo`, `findallo`, `bagofo`, and `setofo`
- add direct logic-builtins regressions for rule-embedded control and collection goals
- add PR45 plus an end-to-end Prolog VM stress test covering `\+/1`, `once/1`, `forall/2`, `findall/3`, `bagof/3`, and `setof/3`

## Verification
- `bash BUILD` in `code/packages/python/logic-builtins`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `code/packages/python/logic-builtins`
- `.venv/bin/ruff check .` in `code/packages/python/prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-control -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-control-build-plan.json`