### PR TITLE
Close ALGOL switch-formal convergence gap

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -100,6 +100,10 @@ All notable changes to this package will be documented in this file.
 - Added configurable generated-state limits for eval thunks, conditional label
   sets, loop label sets, switch dispatch states, and output helper label sets,
   with targeted `CompileError` diagnostics when lowering would exceed them.
+- Copied every switch-entry value into a stable result register in the
+  switch-formal evaluation helper, so multi-entry switch parameters now return
+  the label selected by the runtime index instead of depending on the last
+  compiled entry register.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -1,6 +1,6 @@
 # algol-ir-compiler
 
-Lower the first ALGOL 60 compiler subset to compiler IR.
+Lower the Python ALGOL 60 semantic lane to compiler IR.
 
 The compiler accepts a checked ALGOL AST and emits `compiler_ir.IrProgram`
 instructions that the existing structured IR-to-WASM lowerer can consume.

--- a/code/packages/python/algol-ir-compiler/pyproject.toml
+++ b/code/packages/python/algol-ir-compiler/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "coding-adventures-algol-ir-compiler"
 version = "0.1.0"
-description = "Lower the first ALGOL 60 compiler subset to compiler IR"
+description = "Lower the Python ALGOL 60 semantic lane to compiler IR"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/__init__.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/__init__.py
@@ -1,4 +1,4 @@
-"""algol-ir-compiler — Lower the first ALGOL 60 compiler subset to compiler IR
+"""algol-ir-compiler — Lower the Python ALGOL 60 semantic lane to compiler IR
 
 This package is part of the coding-adventures monorepo, a ground-up
 implementation of the computing stack from transistors to operating systems.

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -1,4 +1,4 @@
-"""Lower the first ALGOL 60 compiler subset into compiler IR."""
+"""Lower the Python ALGOL 60 semantic lane into compiler IR."""
 
 from __future__ import annotations
 
@@ -1442,7 +1442,8 @@ class AlgolIrCompiler:
         entry_scope: _FrameScope,
     ) -> int:
         dispatch_index = self._next_switch_index()
-        result = self._const_reg(0)
+        result = self._fresh_reg()
+        self._emit(IrOp.LOAD_IMM, IrRegister(result), IrImmediate(0))
         end_label = f"switch_value_{dispatch_index}_end"
         self.active_switch_selection_ids.append(selection.switch_id)
         try:
@@ -1465,7 +1466,8 @@ class AlgolIrCompiler:
                     raise CompileError(
                         f"switch {selection.name!r} entry {entry_index} is missing"
                     )
-                result = self._compile_designational_value(entry, entry_scope)
+                entry_value = self._compile_designational_value(entry, entry_scope)
+                self._copy_reg(dst=result, src=entry_value)
                 self._emit(IrOp.JUMP, IrLabel(end_label))
                 self._label(next_label)
         finally:

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -1,17 +1,17 @@
 # algol-type-checker
 
-Type checker for the first ALGOL 60 compiler subset.
+Type checker for the Python ALGOL 60 compiler lane.
 
 This package consumes the generic AST from `algol-parser` and validates the
-structured integer subset described by `code/specs/PL03-algol60-wasm-compiler.md`.
-It currently supports scalar declarations, assignments, arithmetic,
-comparisons, boolean conditions, nested blocks, `if` statements,
-`for ... step ... until ... do` loops, value/by-name procedures, and
-descriptor metadata for typed arrays with integer bounds. Direct labels and
-direct local `goto`/`go to` statements are accepted within one active ALGOL frame, as
-are direct nonlocal block `goto` statements that stay inside the same lowered
-function. Local switch declarations, switch selections, and conditional
-designational `goto` forms are also supported.
+semantic model described by `code/specs/PL04-algol60-full-wasm-runtime.md`.
+It supports scalar declarations, assignments, arithmetic, comparisons, boolean
+conditions, nested blocks, `if` statements, `for` loops with simple, `while`,
+and `step`/`until` elements, value/by-name procedures, and descriptor metadata
+for typed arrays with runtime bounds. Direct labels and direct local
+`goto`/`go to` statements are accepted within one active ALGOL frame, as are
+direct nonlocal block `goto` statements that stay inside the same lowered
+function. Switch declarations, switch selections, and conditional designational
+`goto` forms are also supported.
 
 The expression checker also accepts chained assignments, ALGOL conditional
 expressions, tolerant trailing/repeated semicolons from the parser, and

--- a/code/packages/python/algol-type-checker/pyproject.toml
+++ b/code/packages/python/algol-type-checker/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "coding-adventures-algol-type-checker"
 version = "0.1.0"
-description = "Type checker for the first ALGOL 60 compiler subset"
+description = "Type checker for the Python ALGOL 60 compiler lane"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/__init__.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/__init__.py
@@ -1,4 +1,4 @@
-"""algol-type-checker — Type checker for the first ALGOL 60 compiler subset
+"""algol-type-checker — Type checker for the Python ALGOL 60 compiler lane
 
 This package is part of the coding-adventures monorepo, a ground-up
 implementation of the computing stack from transistors to operating systems.

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -420,7 +420,7 @@ class TypeCheckError(Exception):
 
 
 class AlgolTypeChecker:
-    """Validate the first ALGOL 60 compiler subset."""
+    """Validate the Python ALGOL 60 compiler lane."""
 
     def __init__(self, limits: TypeCheckLimits | None = None) -> None:
         self.limits = limits or TypeCheckLimits()

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -100,6 +100,14 @@ All notable changes to this package will be documented in this file.
   oversized untrusted source is rejected before parsing or semantic analysis.
 - Documented and tested host-side WASM instruction budgets for compiled ALGOL
   modules so nonterminating `goto` programs can be capped by embedders.
+- Fixed multi-entry switch-formal dispatch so procedure calls that receive a
+  switch parameter return the selected entry label even when another label
+  formal points at an earlier caller label.
+- Added a full-surface golden fixture that combines `own` scalars and arrays,
+  default-real arrays, nested and single-statement procedures, value/by-name
+  procedure calls, label and switch formals, multiple `for` element forms,
+  parenthesized conditional designational expressions, numeric labels, boolean
+  operators, real arithmetic, and output in one end-to-end WASM program.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -1,6 +1,6 @@
 # algol-wasm-compiler
 
-Package the first ALGOL 60 compiler subset as WebAssembly.
+Package the Python ALGOL 60 compiler lane as WebAssembly.
 
 This package is the orchestration layer for the first ALGOL 60 compiled lane:
 
@@ -39,9 +39,14 @@ the current lane already supports a substantial ALGOL 60 surface:
 - builtin `print(...)` / `output(...)` for integers, booleans, reals, strings,
   and string variables
 
-The implementation is not yet a full ALGOL 60 conformance lane, but it is well
-beyond a toy arithmetic subset and is now useful for representative block- and
-procedure-heavy programs.
+Within the repository's lowercase ASCII `algol60` grammar, the executable
+declaration, statement, expression, procedure, array, by-name, and designational
+surface is now implemented and covered by golden WASM fixtures. It is not a
+claim of historical whole-environment compatibility with every ALGOL system:
+the package intentionally keeps the observable I/O surface to `print(...)` /
+`output(...)`, uses the bundled token spelling rather than typographic ALGOL
+publication notation, and applies explicit source, semantic, generated-state,
+memory, and host execution limits for untrusted programs.
 
 The convenience APIs reject source strings larger than 256 KiB before parsing.
 The downstream type checker also enforces configurable AST, block-nesting, and
@@ -112,6 +117,11 @@ local WASM runtime. Those fixtures cover:
 - switch dispatch, procedure-formal dispatch, and procedure-crossing `goto`
 - conditional expressions, chained assignment, and exponentiation in the same
   end-to-end program
+- a full-surface convergence program combining `own` scalars and arrays,
+  default-real arrays, nested and single-statement procedures, value and
+  by-name procedure formals, label and switch formals, multiple `for` element
+  forms, parenthesized conditional designational expressions, numeric labels,
+  boolean operators, real arithmetic, and output
 
 ## Dependencies
 

--- a/code/packages/python/algol-wasm-compiler/pyproject.toml
+++ b/code/packages/python/algol-wasm-compiler/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "coding-adventures-algol-wasm-compiler"
 version = "0.1.0"
-description = "Package the first ALGOL 60 compiler subset as WebAssembly"
+description = "Package the Python ALGOL 60 compiler lane as WebAssembly"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/__init__.py
+++ b/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/__init__.py
@@ -1,4 +1,4 @@
-"""algol-wasm-compiler — Package the first ALGOL 60 compiler subset as WebAssembly
+"""algol-wasm-compiler — Package the Python ALGOL 60 compiler lane as WebAssembly
 
 This package is part of the coding-adventures monorepo, a ground-up
 implementation of the computing stack from transistors to operating systems.

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/full-surface.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/full-surface.alg
@@ -1,0 +1,92 @@
+begin
+  own integer counter;
+  own integer array hits[1:2];
+  integer result, i, total, loops, switches;
+  real scale;
+  boolean flag;
+  string msg;
+  integer array a[1:4], m[1:2, 1:2];
+  array weights[1:2];
+
+  integer procedure inc(x);
+    value x;
+    integer x;
+    inc := x + 1;
+
+  procedure bump;
+    begin counter := counter + 1; hits[counter] := counter end;
+
+  integer procedure twice(x);
+    integer x;
+    begin twice := x + x end;
+
+  integer procedure apply(p, x);
+    value x;
+    integer p, x;
+    procedure p;
+    begin apply := p(x) end;
+
+  integer procedure fold(k, lo, hi, term);
+    value lo, hi;
+    integer k, lo, hi, term;
+    begin
+      fold := 0;
+      for k := lo step 1 until hi do fold := fold + term
+    end;
+
+  procedure jumpVia(s, fallback);
+    switch s;
+    label fallback;
+    begin
+      if counter = 0 then goto fallback else goto s[1]
+    end;
+
+  switch route := (if flag then left else right), 90;
+
+  msg := 'COMPLETE';
+  flag := true;
+  result := total := 0;
+  scale := 2.0 ^ (0 - 1);
+  weights[1] := scale + 1.0;
+  weights[2] := weights[1] + 0.5;
+  a[1] := 1;
+  a[2] := if flag then inc(a[1]) else 0;
+  a[3] := 3;
+  a[4] := 4;
+  m[1, 1] := 5;
+  m[1, 2] := 6;
+  m[2, 1] := 7;
+  m[2, 2] := 8;
+  bump;
+  bump;
+  total := fold(i, 1, 4, a[i] * i);
+  total := total + apply(twice, hits[2]);
+  total := total + entier(weights[2] * 10);
+  loops := 0;
+  for i := 1, 3 step 1 until 4, 10 while loops < 3 do
+    begin loops := loops + i end;
+  total := total + loops;
+  switches := 0;
+  jumpVia(route, fallback);
+  switches := 99;
+  goto afterSwitch;
+fallback:
+  switches := 3;
+  goto afterSwitch;
+left:
+  switches := 11;
+  go to afterSwitch;
+right:
+  switches := 17;
+  goto afterSwitch;
+90:
+  switches := 90;
+afterSwitch:
+  total := total + switches;
+  flag := (total = 73) and ((counter = 2) impl true) and (true eqv true) and not false;
+  if flag or false then result := total + m[2, 2] else result := 0;
+  print(msg);
+  output(' ');
+  print(result);
+done:
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -803,6 +803,21 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
+    def test_switch_parameter_dispatch_uses_selected_entry_result(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure escape(sw, fallback); switch sw; label fallback; "
+            "begin goto sw[1] end; "
+            "switch s := left, 90; "
+            "escape(s, fallback); result := 99; goto done; "
+            "fallback: result := 3; goto done; "
+            "left: result := 11; go to done; "
+            "90: result := 90; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [11]
+
     def test_procedure_parameter_statement_call_dispatches_actual(self) -> None:
         result = compile_source(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -27,6 +27,7 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="control-flow", result=[7], stdout="FLOW 7"),
     GoldenFixture(name="convergence", result=[39], stdout="CONVERGE 39"),
     GoldenFixture(name="standard-real-math", result=[478], stdout="MATH 478"),
+    GoldenFixture(name="full-surface", result=[81], stdout="COMPLETE 81"),
 )
 
 

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -1572,6 +1572,15 @@ This roadmap does not require:
 
 ## Completion Definition
 
+Current Python-lane status: the bundled lowercase ASCII `algol60` grammar is
+now treated as the executable language surface for the WASM package. The
+remaining documented dialect boundaries are environment-level choices rather
+than parser-supported constructs left without lowering: I/O is intentionally
+limited to the package's `print(...)` / `output(...)` builtins, typographic
+ALGOL publication notation is normalized through the repository token grammar,
+and untrusted compilation/execution remains bounded by explicit source,
+semantic, generated-state, memory, and instruction limits.
+
 Full ALGOL 60 to WASM is complete when:
 
 - the existing `algol60` grammar is the only grammar used by the lane


### PR DESCRIPTION
## Summary
- Fix switch-formal evaluation so multi-entry switch parameters copy the selected entry label into a stable result register.
- Add a regression for switch parameters combined with label formals and earlier caller labels.
- Add a full-surface golden ALGOL fixture covering own storage, default-real arrays, nested/single-statement procedures, value/by-name procedure calls, label/switch formals, multiple for-element forms, conditional designational expressions, numeric labels, boolean operators, real arithmetic, and output.
- Update ALGOL package docs/spec wording from the early subset framing to the current Python ALGOL-to-WASM lane status and documented dialect boundaries.

## Verification
- `bash BUILD` in `code/packages/python/algol-wasm-compiler` -> 172 passed, coverage 87.13%
- `bash BUILD` in `code/packages/python/algol-ir-compiler` -> 102 passed, coverage 87.42%
- `bash BUILD` in `code/packages/python/algol-type-checker` -> 132 passed, coverage 83.50%
- Post-rebase focused checks for the switch regression, golden fixtures, IR switch helper, and type-checker label coverage all passed with `--no-cov`.
- Security review: no new process, network, file write, or host import paths; the runtime change stays inside existing bounded IR register/control-flow lowering.