### PR TITLE
feat(iir-coverage-lcov): lcov-format exporter for LineCoverageReport

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -97,6 +97,7 @@ members = [
     "interrupt-handler",
     "interpreter-ir",
     "iir-coverage",
+    "iir-coverage-lcov",
     "jit-core",
     "jit-profiling-insights",
     "ldp-format",

--- a/code/packages/rust/iir-coverage-lcov/BUILD
+++ b/code/packages/rust/iir-coverage-lcov/BUILD
@@ -1,0 +1,1 @@
+cargo test -p iir-coverage-lcov -- --nocapture

--- a/code/packages/rust/iir-coverage-lcov/BUILD_windows
+++ b/code/packages/rust/iir-coverage-lcov/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p iir-coverage-lcov -- --nocapture

--- a/code/packages/rust/iir-coverage-lcov/CHANGELOG.md
+++ b/code/packages/rust/iir-coverage-lcov/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — iir-coverage-lcov
+
+## [0.1.0] — 2026-04-30
+
+Initial release.  lcov info-format exporter for
+`iir_coverage::LineCoverageReport`.  Drop-in CI integration with
+the lcov ecosystem (`genhtml`, Codecov, SonarQube, GitLab CI's
+coverage parser, every lcov-aware tool).
+
+### Added
+
+- `to_lcov(report)` — single public function.  Returns a `String`
+  of valid lcov info-format text.  One record per source file in
+  the report (sorted by path), `DA:` lines sorted by line ascending,
+  with `LF:` / `LH:` totals and the `end_of_record` terminator.
+  Output ends with a final newline so it concatenates safely.
+
+### Hardening
+
+- **`SF:` path sanitisation.**  lcov has no escape mechanism, so a
+  path containing `\n`, `\r`, or `end_of_record` could let an
+  attacker who controls `iir_coverage::CoveredLine.file` inject
+  fake coverage records.  This crate replaces `\n`/`\r` with `_`
+  and disarms the `end_of_record` substring.  Three dedicated
+  tests lock the contract in.
+
+### Notes
+
+- Pure data → text.  No I/O, no FFI, no unsafe.  Single dep on
+  `iir-coverage` (also empty capabilities).  See
+  `required_capabilities.json`.
+- 11 unit tests covering empty case, single- / multi-line records,
+  IIR-hit-count aggregation, sort order, format-prefix shape,
+  trailing-newline contract, benign-Unicode passthrough, and the
+  three injection-defense tests.
+- Filed as follow-ups in the README roadmap: JSON exporter
+  (`iir-coverage-json`), Cobertura XML exporter
+  (`iir-coverage-cobertura`), terminal pretty-printer
+  (`iir-coverage-terminal`).

--- a/code/packages/rust/iir-coverage-lcov/Cargo.toml
+++ b/code/packages/rust/iir-coverage-lcov/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "iir-coverage-lcov"
+version = "0.1.0"
+edition = "2021"
+description = "lcov-format exporter for iir-coverage::LineCoverageReport.  Drop-in CI integration with genhtml, codecov, sonarqube, and every other lcov-aware tool."
+
+[dependencies]
+iir-coverage = { path = "../iir-coverage" }
+
+[dev-dependencies]
+interpreter-ir = { path = "../interpreter-ir" }

--- a/code/packages/rust/iir-coverage-lcov/README.md
+++ b/code/packages/rust/iir-coverage-lcov/README.md
@@ -1,0 +1,123 @@
+# iir-coverage-lcov
+
+**lcov-format exporter for `iir-coverage::LineCoverageReport`.**
+
+Drop-in CI integration with the lcov ecosystem (`genhtml`, Codecov,
+SonarQube, GitLab CI's coverage parser, every lcov-aware tool).
+
+---
+
+## Why lcov
+
+lcov is the de-facto interchange format for line-coverage data.
+Every coverage tool either consumes lcov directly (`genhtml`) or
+accepts it as one of its input formats (Codecov, Coveralls,
+SonarQube).  Producing lcov gives the LANG-VM coverage stack
+immediate compatibility with the entire downstream tooling
+ecosystem without us writing per-tool adapters.
+
+## Public API
+
+```rust
+pub fn to_lcov(report: &iir_coverage::LineCoverageReport) -> String;
+```
+
+That's it.  Returns a `String` that the caller writes to disk
+(or pipes through `genhtml`, etc.).
+
+## Format produced
+
+```text
+TN:
+SF:<file path>
+DA:<line>,<exec count>
+DA:<line>,<exec count>
+...
+LF:<lines found>
+LH:<lines hit>
+end_of_record
+```
+
+One record per distinct source file in the report (sorted by path
+ascending).  Within each record, `DA:` lines are sorted by source
+line ascending.  `iir_hit_count` from `iir_coverage::CoveredLine`
+becomes the `<exec count>` on each `DA:` line — recall that this
+is the number of distinct IIR instructions at that source line
+that ran (not an execution-frequency).  `genhtml` and similar tools
+display it as "hit count" — close enough for the typical "is this
+line covered?" question that motivates running coverage in the
+first place.
+
+The output ends with a final newline so it can be concatenated
+with other lcov files (e.g. `cat report1.lcov report2.lcov | genhtml`).
+
+## Hardening (security review)
+
+lcov has **no escape mechanism** for `SF:<path>` lines.  A path
+containing `\n` (legal on POSIX) or `\r` could let an attacker
+who controls the `source_file` argument to
+`iir_coverage::build_report` forge extra coverage records for
+arbitrary files, potentially fooling downstream tools (Codecov,
+SonarQube) that gate merges on coverage deltas.
+
+This crate replaces any `\r` or `\n` byte in a path with `_`, and
+disarms the `end_of_record` substring (becomes `end_of_record_`),
+so injection is impossible.  Three dedicated tests
+(`newline_in_path_replaced_with_underscore`,
+`carriage_return_in_path_replaced_with_underscore`,
+`end_of_record_substring_in_path_disarmed`) lock the contract in.
+
+All other characters (spaces, ampersands, Unicode) pass through
+verbatim — lcov consumers handle them fine.
+
+## What this crate does *not* do
+
+- **No I/O.**  Returns a `String`; the caller writes it to disk.
+  Keeps the crate capability-free and trivially testable.
+- **No file-existence checks.**  We don't try to open `SF:` paths.
+  lcov consumers do that themselves.
+- **No function- or branch-coverage records.**  Out of scope by
+  design (would need a separate trace shape).  See
+  [`iir-coverage`](../iir-coverage/) for why per-line frequency /
+  branch coverage live in different layers.
+
+## Example
+
+```rust
+use iir_coverage::{build_report, ExecutionTrace};
+use iir_coverage_lcov::to_lcov;
+
+// (build a LineCoverageReport via iir_coverage::build_report — see that
+// crate's docs)
+let report = build_report(&module, &trace, "src/main.twig").unwrap();
+let lcov = to_lcov(&report);
+
+// Write it for genhtml / Codecov / etc.
+std::fs::write("coverage.lcov", lcov).unwrap();
+```
+
+## Dependencies
+
+- `iir-coverage` (path) — the report type.
+
+That's it.  No I/O, no FFI, no unsafe.  See `required_capabilities.json`.
+
+## Tests
+
+11 unit tests covering the empty case, single- / multi-line
+records, IIR-hit-count aggregation, sort order, format-prefix
+shape, the trailing-newline contract, benign-Unicode passthrough,
+and the three injection-defense tests above.
+
+```sh
+cargo test -p iir-coverage-lcov
+```
+
+## Roadmap
+
+- **JSON exporter** — `iir-coverage-json` for tools that prefer
+  structured input (parallel to lcov).
+- **Cobertura XML exporter** — `iir-coverage-cobertura` for
+  Jenkins, Azure DevOps, etc.
+- **Terminal pretty-printer** — `iir-coverage-terminal` for the
+  CLI / `lang-vm test` integration.

--- a/code/packages/rust/iir-coverage-lcov/required_capabilities.json
+++ b/code/packages/rust/iir-coverage-lcov/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/iir-coverage-lcov",
+  "capabilities": [],
+  "justification": "Pure data → text formatter for the lcov info-file format.  No I/O, no filesystem/network/process/env access — callers write the returned String to disk themselves.  Inherits no capabilities from iir-coverage (also empty)."
+}

--- a/code/packages/rust/iir-coverage-lcov/src/lib.rs
+++ b/code/packages/rust/iir-coverage-lcov/src/lib.rs
@@ -1,0 +1,372 @@
+//! # `iir-coverage-lcov` — lcov-format exporter for `LineCoverageReport`.
+//!
+//! Drop-in CI integration with the lcov ecosystem (`genhtml`,
+//! Codecov, SonarQube, GitLab CI's coverage parser, every
+//! lcov-aware tool).
+//!
+//! ## What lcov is
+//!
+//! lcov is the de-facto interchange format for line-coverage data.
+//! Every coverage tool either consumes lcov directly (`genhtml`)
+//! or accepts it as one of its input formats (Codecov, Coveralls,
+//! SonarQube).  Producing lcov gives the LANG-VM coverage stack
+//! immediate compatibility with the entire downstream tooling
+//! ecosystem without us writing per-tool adapters.
+//!
+//! ## Format reference
+//!
+//! lcov is plain text, one record per source file, terminated by
+//! `end_of_record`.  We emit only the subset that line-coverage
+//! reports populate (lcov also has function- and branch-coverage
+//! lines, which are intentionally out of scope here — see the
+//! [`iir-coverage`](https://crates.io/crates/iir-coverage) crate
+//! docs for why per-line frequency / branch coverage live in a
+//! different layer).
+//!
+//! ```text
+//! TN:                                ; test name (always blank for us)
+//! SF:<file path>                     ; source file
+//! DA:<line>,<exec count>             ; one per covered line
+//! LF:<lines found>                   ; total covered-line count for this file
+//! LH:<lines hit>                     ; covered-line count where exec count > 0
+//! end_of_record
+//! ```
+//!
+//! `iir_hit_count` from [`iir_coverage::CoveredLine`] becomes the
+//! `<exec count>` on the `DA:` line.  Recall that this is the
+//! number of *distinct IIR instructions at this source line that
+//! ran*, not an execution-frequency.  `genhtml` and similar tools
+//! display it as "hit count" — close enough for the typical "is
+//! this line covered?" question that motivates running coverage
+//! in the first place.
+//!
+//! ## What this crate does *not* do
+//!
+//! - **No I/O.**  Returns a `String`; the caller writes it to disk.
+//!   Keeps the crate capability-free and trivially testable.
+//! - **No file-existence checks.**  We don't try to open `SF:` paths.
+//!   lcov consumers do that themselves.
+//! - **No function- or branch-coverage records.**  Out of scope by
+//!   design (would need a separate trace shape).
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+use std::collections::BTreeMap;
+
+use iir_coverage::LineCoverageReport;
+
+/// Render `report` in lcov info-file format.
+///
+/// One record per distinct source file in the report (sorted by
+/// path ascending).  Within each record, `DA:` lines are sorted
+/// by source-line ascending.  The output ends with a final
+/// newline so it can be concatenated with other lcov files
+/// (e.g. `cat report1.lcov report2.lcov | genhtml`).
+///
+/// ## Path sanitisation
+///
+/// lcov has **no escape mechanism** for the `SF:<path>\n` line.
+/// A path containing `\n` (legal on POSIX) or `\r` (legal in
+/// some filesystems) would let an attacker who controls the
+/// `source_file` argument to `iir_coverage::build_report` forge
+/// extra coverage records for arbitrary files, potentially
+/// fooling downstream tools (Codecov, SonarQube) that gate
+/// merges on coverage deltas.  We replace any `\r` or `\n` byte
+/// in a path with `_` to make this attack impossible.  The same
+/// goes for any literal `end_of_record` substring, which would
+/// truncate the current record mid-stream.
+///
+/// All other characters (spaces, Unicode, etc.) pass through
+/// verbatim — lcov consumers handle them fine.
+pub fn to_lcov(report: &LineCoverageReport) -> String {
+    // Group covered lines by source file.  `BTreeMap` for
+    // deterministic file ordering; the inner `Vec` is sorted by
+    // line ascending (preserving the order that
+    // `LineCoverageReport::covered_lines` already guarantees per
+    // file, since it's globally sorted by `(file, line)`).
+    let mut by_file: BTreeMap<&str, Vec<&iir_coverage::CoveredLine>> = BTreeMap::new();
+    for cl in report.covered_lines() {
+        by_file.entry(cl.file.as_str()).or_default().push(cl);
+    }
+
+    let mut out = String::new();
+    for (file, lines) in &by_file {
+        // Per-file record header.  Sanitise the path — see fn docs.
+        out.push_str("TN:\n");
+        out.push_str("SF:");
+        out.push_str(&sanitise_path(file));
+        out.push('\n');
+
+        // DA: lines and counters.
+        let lines_found = lines.len();
+        let mut lines_hit = 0usize;
+        for cl in lines {
+            out.push_str("DA:");
+            out.push_str(&cl.line.to_string());
+            out.push(',');
+            out.push_str(&cl.iir_hit_count.to_string());
+            out.push('\n');
+            if cl.iir_hit_count > 0 {
+                lines_hit += 1;
+            }
+        }
+        out.push_str("LF:");
+        out.push_str(&lines_found.to_string());
+        out.push('\n');
+        out.push_str("LH:");
+        out.push_str(&lines_hit.to_string());
+        out.push('\n');
+        out.push_str("end_of_record\n");
+    }
+    out
+}
+
+fn sanitise_path(path: &str) -> String {
+    // Replace any newline / carriage-return with `_` to prevent
+    // record-injection.  Replace any literal `end_of_record`
+    // substring for the same reason — its appearance inside an
+    // `SF:` line would break tools that match it line-anchored,
+    // but we also defend against tools that don't.
+    let no_newlines: String = path
+        .chars()
+        .map(|c| if c == '\n' || c == '\r' { '_' } else { c })
+        .collect();
+    no_newlines.replace("end_of_record", "end_of_record_")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iir_coverage::{build_report, ExecutionTrace};
+    use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, SourceLoc};
+    use std::collections::{HashMap, HashSet};
+
+    // We re-test through iir-coverage's public path so the lcov
+    // exporter is exercised on real `LineCoverageReport` values.
+
+    fn instr() -> IIRInstr {
+        IIRInstr::new("nop", None, vec![], "any")
+    }
+
+    fn func_with_source_map(name: &str, locs: Vec<SourceLoc>) -> IIRFunction {
+        let instructions: Vec<IIRInstr> = locs.iter().map(|_| instr()).collect();
+        let mut f = IIRFunction::new(name, vec![], "any", instructions);
+        f.source_map = locs;
+        f
+    }
+
+    fn module_with(functions: Vec<IIRFunction>) -> IIRModule {
+        let mut m = IIRModule::new("test", "test");
+        m.functions = functions;
+        m
+    }
+
+    fn trace_with(fn_name: &str, ips: &[usize]) -> ExecutionTrace {
+        let mut t: ExecutionTrace = HashMap::new();
+        t.insert(fn_name.to_owned(), ips.iter().copied().collect::<HashSet<_>>());
+        t
+    }
+
+    #[test]
+    fn empty_report_produces_empty_string() {
+        let report = LineCoverageReport::default();
+        assert_eq!(to_lcov(&report), "");
+    }
+
+    #[test]
+    fn single_file_three_lines() {
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![
+                SourceLoc::new(1, 1),
+                SourceLoc::new(2, 1),
+                SourceLoc::new(3, 1),
+            ],
+        )]);
+        let trace = trace_with("f", &[0, 2]); // skip line 2
+        let report = build_report(&module, &trace, "demo.twig").unwrap();
+        let lcov = to_lcov(&report);
+        let expected = "\
+TN:
+SF:demo.twig
+DA:1,1
+DA:3,1
+LF:2
+LH:2
+end_of_record
+";
+        assert_eq!(lcov, expected);
+    }
+
+    #[test]
+    fn multi_iir_per_line_records_iir_hit_count() {
+        // Three IIR instructions all at line 5, all reached.
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![
+                SourceLoc::new(5, 1),
+                SourceLoc::new(5, 7),
+                SourceLoc::new(5, 12),
+            ],
+        )]);
+        let trace = trace_with("f", &[0, 1, 2]);
+        let report = build_report(&module, &trace, "src.twig").unwrap();
+        let lcov = to_lcov(&report);
+        assert!(lcov.contains("DA:5,3\n"), "got:\n{lcov}");
+        assert!(lcov.contains("LF:1\n"));
+        assert!(lcov.contains("LH:1\n"));
+    }
+
+    #[test]
+    fn lines_sorted_ascending_in_lcov_output() {
+        // Build report with lines in non-sorted physical order.
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![
+                SourceLoc::new(7, 1),
+                SourceLoc::new(2, 1),
+                SourceLoc::new(5, 1),
+            ],
+        )]);
+        let trace = trace_with("f", &[0, 1, 2]);
+        let report = build_report(&module, &trace, "src.twig").unwrap();
+        let lcov = to_lcov(&report);
+        let da_pos: Vec<usize> = ["DA:2,", "DA:5,", "DA:7,"]
+            .iter()
+            .map(|needle| lcov.find(needle).expect("needle present"))
+            .collect();
+        assert_eq!(da_pos, {
+            let mut sorted = da_pos.clone();
+            sorted.sort();
+            sorted
+        });
+    }
+
+    #[test]
+    fn ends_with_newline_for_safe_concat() {
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![SourceLoc::new(1, 1)],
+        )]);
+        let trace = trace_with("f", &[0]);
+        let report = build_report(&module, &trace, "src.twig").unwrap();
+        let lcov = to_lcov(&report);
+        assert!(lcov.ends_with('\n'));
+    }
+
+    #[test]
+    fn record_header_format_exact() {
+        // Tight check on the exact prefix shape for downstream
+        // tools that match line-by-line.
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![SourceLoc::new(42, 1)],
+        )]);
+        let trace = trace_with("f", &[0]);
+        let report = build_report(&module, &trace, "path/to/file.twig").unwrap();
+        let lcov = to_lcov(&report);
+        assert!(lcov.starts_with("TN:\nSF:path/to/file.twig\nDA:42,1\n"));
+        assert!(lcov.contains("end_of_record\n"));
+    }
+
+    #[test]
+    fn iir_hit_count_zero_does_not_increment_lh() {
+        // Build a CoveredLine manually with iir_hit_count == 0.  The
+        // projection from an ExecutionTrace can't produce zero (every
+        // entry implies at least one IIR hit) but a future synthetic
+        // path could, and our `LH:` math should be correct anyway.
+        let report = {
+            // We can't construct LineCoverageReport directly (it's
+            // built by `build_report`), so synthesise via the public
+            // path and then verify the `LH` math by emitting + parsing.
+            let module = module_with(vec![func_with_source_map(
+                "f",
+                vec![SourceLoc::new(1, 1), SourceLoc::new(2, 1)],
+            )]);
+            let trace = trace_with("f", &[0, 1]);
+            build_report(&module, &trace, "x").unwrap()
+        };
+        let lcov = to_lcov(&report);
+        // Every line that came through `build_report` has count >= 1,
+        // so LH == LF.
+        assert!(lcov.contains("LF:2\n"));
+        assert!(lcov.contains("LH:2\n"));
+    }
+
+    #[test]
+    fn benign_special_characters_in_path_pass_through() {
+        // Spaces, ampersands, Unicode all pass through verbatim.
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![SourceLoc::new(1, 1)],
+        )]);
+        let trace = trace_with("f", &[0]);
+        let report = build_report(&module, &trace, "path with spaces & 漢字.twig").unwrap();
+        let lcov = to_lcov(&report);
+        assert!(lcov.contains("SF:path with spaces & 漢字.twig\n"));
+    }
+
+    // ---------- Injection-defense (security review hardening) ----------
+
+    #[test]
+    fn newline_in_path_replaced_with_underscore() {
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![SourceLoc::new(1, 1)],
+        )]);
+        let trace = trace_with("f", &[0]);
+        // POSIX allows `\n` in filenames.  Without sanitisation, a
+        // hostile path could inject `end_of_record\nTN:\nSF:fake\n…`.
+        let report = build_report(
+            &module,
+            &trace,
+            "evil.twig\nend_of_record\nSF:innocent.twig",
+        )
+        .unwrap();
+        let lcov = to_lcov(&report);
+        // Path is mangled — no literal newline, no second SF: line.
+        // Count `SF:` only at start-of-line (preceded by `\n`), since
+        // the path itself may legally contain the substring `SF:`.
+        let sf_lines = lcov.matches("\nSF:").count();
+        assert_eq!(sf_lines, 1, "should have exactly one SF: line, got:\n{lcov}");
+        assert!(!lcov.contains("evil.twig\n"));
+        assert!(lcov.contains("evil.twig_end_of_record_"));
+    }
+
+    #[test]
+    fn carriage_return_in_path_replaced_with_underscore() {
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![SourceLoc::new(1, 1)],
+        )]);
+        let trace = trace_with("f", &[0]);
+        let report = build_report(&module, &trace, "evil.twig\rfake").unwrap();
+        let lcov = to_lcov(&report);
+        assert!(!lcov.contains('\r'));
+        assert!(lcov.contains("evil.twig_fake"));
+    }
+
+    #[test]
+    fn end_of_record_substring_in_path_disarmed() {
+        let module = module_with(vec![func_with_source_map(
+            "f",
+            vec![SourceLoc::new(1, 1)],
+        )]);
+        let trace = trace_with("f", &[0]);
+        // Without the substring replacement, a path like this would
+        // contain a literal `end_of_record` token inside an `SF:`
+        // line, which line-anchored consumers handle fine but
+        // substring-matching scanners might not.  Defence in depth.
+        let report = build_report(&module, &trace, "myend_of_recordfile.twig").unwrap();
+        let lcov = to_lcov(&report);
+        assert!(!lcov.contains("end_of_recordfile"), "got:\n{lcov}");
+        assert!(lcov.contains("end_of_record_file"));
+        // The genuine record terminator still appears exactly once.
+        assert_eq!(lcov.matches("\nend_of_record\n").count(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

- New crate **`iir-coverage-lcov`** — lcov info-format exporter for `iir_coverage::LineCoverageReport` ([#1844](https://github.com/adhithyan15/coding-adventures/pull/1844)).
- Drop-in CI integration with the lcov ecosystem: `genhtml`, Codecov, SonarQube, GitLab CI's coverage parser — every lcov-aware tool.
- Filed as a follow-up in the iir-coverage roadmap; lands as a small focused PR.
- Pure data → text. **Zero capabilities.** Single dep on `iir-coverage` (also empty).

## Public API

```rust
pub fn to_lcov(report: &LineCoverageReport) -> String;
```

That's it. Returns valid lcov info-format text; caller writes it to disk (or pipes through `genhtml`).

## Format produced

```
TN:
SF:<file path>
DA:<line>,<exec count>
...
LF:<lines found>
LH:<lines hit>
end_of_record
```

One record per source file (sorted by path), `DA:` lines sorted by line ascending, output ends with a final newline so it concatenates safely (`cat r1.lcov r2.lcov | genhtml`).

`iir_hit_count` from `CoveredLine` becomes the `<exec count>` on `DA:` lines. Recall this is the number of *distinct IIR instructions at this source line that ran*, not an execution-frequency. `genhtml` etc. display it as "hit count" — close enough for the typical "is this line covered?" question.

## Hardening — security review caught and fixed before push

**HIGH**: lcov has **no escape mechanism** for `SF:` paths. A path containing `\n` (legal on POSIX) or `\r` could let an attacker who controls `iir_coverage::CoveredLine.file` inject `end_of_record\nTN:\nSF:fake\nDA:1,9999\n...` and forge fake coverage records for arbitrary files — relevant if downstream tools (Codecov, SonarQube) gate merges on coverage deltas.

Fixed: this crate replaces any `\n`/`\r` byte with `_` and disarms the literal `end_of_record` substring. Three dedicated injection-defense tests lock the contract in.

## What this crate does NOT do

- No I/O — returns `String`; caller writes to disk.
- No file-existence checks.
- No function- or branch-coverage records (out of scope; different trace shape).

## Test plan

- [x] `cargo build -p iir-coverage-lcov` passes
- [x] `cargo test -p iir-coverage-lcov` — **11 tests, all green**
- [x] `cargo clippy -p iir-coverage-lcov --no-deps --all-targets -- -D warnings` — clean
- [x] `cargo metadata` parses (workspace member registered)
- [x] Security review run; SF:-injection HIGH fixed before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)