### PR TITLE
Forward array-element actuals through formal procedures

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -957,6 +957,33 @@ class TestAlgolIrCompiler:
         assert "_fn_algol_call_procedure_i32" in labels
         assert IrOp.AND_IMM in opcodes
 
+    def test_compiles_procedure_parameter_call_with_array_element_actual(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; integer array a[1:1]; "
+                "procedure invoke(p); procedure p; begin p(a[1]) end; "
+                "procedure set(x); integer x; begin x := x + 7 end; "
+                "a[1] := 0; invoke(set); result := a[1] "
+                "end"
+            )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+        calls = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert "_fn_algol_call_procedure_i32" in labels
+        assert "_fn_algol_eval_thunk" in labels
+        assert "_fn_algol_store_thunk" in labels
+        assert "_fn_algol_eval_thunk" in calls
+        assert "_fn_algol_store_thunk" in calls
+
     def test_compiles_procedure_parameter_call_with_array_argument(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -2174,6 +2174,8 @@ class AlgolTypeChecker:
                 and self._resolved_bare_procedure_expression(argument) is None
             )
             procedure_argument_ids.append(None)
+            if argument_assignable[-1]:
+                self._record_assignable_actual_write(argument, scope)
             if actual_type != ERROR and actual_type not in {
                 INTEGER,
                 BOOLEAN,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -1087,6 +1087,27 @@ class TestAlgolTypeChecker:
         parameter = result.semantic.procedures[0].parameters[0]
         assert parameter.procedure_call_shapes[0].argument_assignable == (False,)
 
+    def test_accepts_procedure_parameter_actual_with_array_element_by_name_formal(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array a[1:1]; "
+            "procedure invoke(p); procedure p; begin p(a[1]) end; "
+            "procedure set(x); integer x; begin x := 7 end; "
+            "a[1] := 0; invoke(set); result := a[1] "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.procedure_call_shapes[0].argument_assignable == (True,)
+        assert any(
+            access.name == "a" and access.role == "write"
+            for access in result.semantic.array_accesses
+        )
+
     def test_accepts_procedure_parameter_actual_with_array_formal(self) -> None:
         ast = parse_algol(
             "begin integer result; integer array a[1:2]; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -900,6 +900,59 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_procedure_parameter_statement_call_passes_array_element_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:1]; "
+            "procedure invoke(p); procedure p; begin p(a[1]) end; "
+            "procedure set(x); integer x; begin x := x + 7 end; "
+            "a[1] := 0; invoke(set); result := a[1] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_procedure_parameter_statement_call_passes_real_array_element_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; real array a[1:1]; "
+            "procedure invoke(p); procedure p; begin p(a[1]) end; "
+            "procedure set(x); real x; begin x := 2.5 end; "
+            "a[1] := 0.0; invoke(set); result := entier(a[1] * 10) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [25]
+
+    def test_procedure_parameter_statement_call_passes_boolean_array_element_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; boolean array flags[1:1]; "
+            "procedure invoke(p); procedure p; begin p(flags[1]) end; "
+            "procedure set(x); boolean x; begin x := true end; "
+            "flags[1] := false; invoke(set); "
+            "if flags[1] then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_procedure_parameter_statement_call_passes_string_array_element_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; string array messages[1:1]; "
+            "procedure invoke(p); procedure p; begin p(messages[1]) end; "
+            "procedure set(x); string x; begin x := 'OK' end; "
+            "messages[1] := 'NO'; invoke(set); print(messages[1]); result := 7 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [7]
+        assert "".join(captured) == "OK"
+
     def test_procedure_parameter_statement_call_passes_array_argument(self) -> None:
         result = compile_source(
             "begin integer result; integer array a[1:2]; "


### PR DESCRIPTION
## Summary
- Record write metadata for assignable scalar actuals passed through formal procedure calls.
- Cover formal procedure calls that forward integer, real, boolean, and string array elements by name into WASM execution.
- Add type-checker and IR tests for the array-element forwarding path.

## Verification
- `bash BUILD` in `code/packages/python/algol-type-checker`
- `bash BUILD` in `code/packages/python/algol-ir-compiler`
- `bash BUILD` in `code/packages/python/algol-wasm-compiler`
- `git diff --check`
- Security sweep: reviewed added lines for process/network/filesystem/deserialization/secret handling; only new hit is the existing WASI stdout capture test pattern.