### PR TITLE
[codex] Render cowsay through Paint VM

### DIFF
--- a/code/packages/rust/layout-to-paint/src/lib.rs
+++ b/code/packages/rust/layout-to-paint/src/lib.rs
@@ -435,6 +435,16 @@ fn wrap_line<S: TextShaper>(
         return vec![segment.to_string()];
     }
 
+    // Preserve source whitespace for fixed-format text when it already fits.
+    // The greedy wrapper below intentionally collapses whitespace for paragraph
+    // text, but ASCII art/code-like content should not be rewritten just because
+    // it passed through UI04.
+    if let Ok(shaped) = shaper.shape(segment, handle, size, &ShapeOptions::default()) {
+        if shaped.total_advance() as f64 <= max_width {
+            return vec![segment.to_string()];
+        }
+    }
+
     let space_width = shaper
         .shape(" ", handle, size, &ShapeOptions::default())
         .map(|r| r.total_advance() as f64)
@@ -880,6 +890,35 @@ mod tests {
                 for (i, g) in gr.glyphs.iter().enumerate() {
                     assert!((g.x - (10.0 + i as f64 * 8.0)).abs() < 1e-6);
                 }
+            }
+            other => panic!("expected GlyphRun, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fixed_format_text_preserves_spaces_when_line_fits() {
+        let leaf = positioned_leaf(text_content("  / \\  "), 0.0, 0.0, 500.0, 20.0);
+        let shaper = FakeShaper;
+        let metrics = FakeMetrics;
+        let resolver = FakeResolver;
+        let opts = make_options(&shaper, &metrics, &resolver);
+        let scene = layout_to_paint(&leaf, &opts);
+
+        match &scene.instructions[0] {
+            PaintInstruction::GlyphRun(gr) => {
+                let glyph_ids: Vec<u32> = gr.glyphs.iter().map(|g| g.glyph_id).collect();
+                assert_eq!(
+                    glyph_ids,
+                    vec![
+                        ' ' as u32,
+                        ' ' as u32,
+                        '/' as u32,
+                        ' ' as u32,
+                        '\\' as u32,
+                        ' ' as u32,
+                        ' ' as u32,
+                    ]
+                );
             }
             other => panic!("expected GlyphRun, got {:?}", other),
         }

--- a/code/packages/rust/paint-vm-ascii/src/lib.rs
+++ b/code/packages/rust/paint-vm-ascii/src/lib.rs
@@ -1,6 +1,6 @@
 //! Terminal backend for `paint-instructions`.
 
-use paint_instructions::{PaintInstruction, PaintRect, PaintScene};
+use paint_instructions::{PaintInstruction, PaintRect, PaintScene, PaintText, TextAlign};
 
 pub const VERSION: &str = "0.1.0";
 
@@ -73,7 +73,7 @@ fn to_row(y: f64, scale_y: u32) -> i32 {
 
 fn render_rect(rect: &PaintRect, buf: &mut CharBuffer, options: AsciiOptions) {
     let fill = rect.fill.as_deref().unwrap_or("#000000");
-    if fill.is_empty() || fill == "transparent" || fill == "none" {
+    if !is_visible_paint(fill) {
         return;
     }
 
@@ -85,6 +85,42 @@ fn render_rect(rect: &PaintRect, buf: &mut CharBuffer, options: AsciiOptions) {
     for row in r1..=r2 {
         for col in c1..=c2 {
             buf.write_char(row, col, '\u{2588}');
+        }
+    }
+}
+
+fn is_visible_paint(paint: &str) -> bool {
+    let paint = paint.trim();
+    !paint.is_empty() && paint != "transparent" && paint != "none"
+}
+
+fn render_text(text: &PaintText, buf: &mut CharBuffer, options: AsciiOptions) {
+    if let Some(fill) = text.fill.as_deref() {
+        if !is_visible_paint(fill) {
+            return;
+        }
+    }
+
+    let anchor_col = to_col(text.x, options.scale_x);
+    let first_row = to_row(text.y, options.scale_y);
+    let align = text.text_align.as_ref().unwrap_or(&TextAlign::Left);
+
+    for (line_index, line) in text.text.split('\n').enumerate() {
+        let width = line.chars().count() as i32;
+        let start_col = match align {
+            TextAlign::Left => anchor_col,
+            TextAlign::Center => anchor_col - width / 2,
+            TextAlign::Right => anchor_col - width,
+        };
+
+        for (col_offset, ch) in line.chars().enumerate() {
+            if ch != '\r' {
+                buf.write_char(
+                    first_row + line_index as i32,
+                    start_col + col_offset as i32,
+                    ch,
+                );
+            }
         }
     }
 }
@@ -125,9 +161,7 @@ pub fn render(scene: &PaintScene, options: AsciiOptions) -> Result<String, Paint
             PaintInstruction::Image(_) => {
                 return Err(PaintVmAsciiError::UnsupportedInstruction("image"))
             }
-            PaintInstruction::Text(_) => {
-                return Err(PaintVmAsciiError::UnsupportedInstruction("text"))
-            }
+            PaintInstruction::Text(text) => render_text(text, &mut buf, options),
         }
     }
 
@@ -137,7 +171,7 @@ pub fn render(scene: &PaintScene, options: AsciiOptions) -> Result<String, Paint
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paint_instructions::{PaintInstruction, PaintLine};
+    use paint_instructions::{PaintBase, PaintInstruction, PaintLine};
 
     #[test]
     fn version_matches() {
@@ -167,6 +201,92 @@ mod tests {
         .expect("rect scene should render");
 
         assert!(output.contains('\u{2588}'));
+    }
+
+    #[test]
+    fn renders_paint_text() {
+        let scene = PaintScene {
+            width: 8.0,
+            height: 3.0,
+            background: "#ffffff".to_string(),
+            instructions: vec![
+                PaintInstruction::Text(PaintText {
+                    base: PaintBase::default(),
+                    x: 0.0,
+                    y: 0.0,
+                    text: "Hi".to_string(),
+                    font_ref: None,
+                    font_size: 12.0,
+                    fill: Some("#000000".to_string()),
+                    text_align: Some(TextAlign::Left),
+                }),
+                PaintInstruction::Text(PaintText {
+                    base: PaintBase::default(),
+                    x: 5.0,
+                    y: 1.0,
+                    text: "Hi".to_string(),
+                    font_ref: None,
+                    font_size: 12.0,
+                    fill: Some("#000000".to_string()),
+                    text_align: Some(TextAlign::Center),
+                }),
+                PaintInstruction::Text(PaintText {
+                    base: PaintBase::default(),
+                    x: 5.0,
+                    y: 2.0,
+                    text: "Hi".to_string(),
+                    font_ref: None,
+                    font_size: 12.0,
+                    fill: Some("#000000".to_string()),
+                    text_align: Some(TextAlign::Right),
+                }),
+            ],
+            id: None,
+            metadata: None,
+        };
+
+        let output = render(
+            &scene,
+            AsciiOptions {
+                scale_x: 1,
+                scale_y: 1,
+            },
+        )
+        .expect("PaintText scene should render");
+
+        assert_eq!(output, "Hi\n    Hi\n   Hi");
+    }
+
+    #[test]
+    fn transparent_paint_text_is_skipped() {
+        let scene = PaintScene {
+            width: 4.0,
+            height: 1.0,
+            background: "#ffffff".to_string(),
+            instructions: vec![PaintInstruction::Text(PaintText {
+                base: PaintBase::default(),
+                x: 0.0,
+                y: 0.0,
+                text: "Hi".to_string(),
+                font_ref: None,
+                font_size: 12.0,
+                fill: Some("transparent".to_string()),
+                text_align: None,
+            })],
+            id: None,
+            metadata: None,
+        };
+
+        let output = render(
+            &scene,
+            AsciiOptions {
+                scale_x: 1,
+                scale_y: 1,
+            },
+        )
+        .expect("transparent PaintText should render to an empty buffer");
+
+        assert_eq!(output, "");
     }
 
     #[test]

--- a/code/packages/rust/paint-vm-direct2d-c/Cargo.toml
+++ b/code/packages/rust/paint-vm-direct2d-c/Cargo.toml
@@ -9,5 +9,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 paint-instructions = { path = "../paint-instructions" }
+
+[target.'cfg(target_os = "windows")'.dependencies]
 paint-vm-direct2d = { path = "../paint-vm-direct2d" }
 paint-vm-gdi = { path = "../paint-vm-gdi" }

--- a/code/packages/rust/paint-vm-direct2d-c/include/paint_vm_direct2d_c.h
+++ b/code/packages/rust/paint-vm-direct2d-c/include/paint_vm_direct2d_c.h
@@ -23,6 +23,24 @@ typedef struct paint_rect_instruction_t {
     paint_rgba8_color_t fill;
 } paint_rect_instruction_t;
 
+enum {
+    PAINT_TEXT_ALIGN_LEFT = 0,
+    PAINT_TEXT_ALIGN_CENTER = 1,
+    PAINT_TEXT_ALIGN_RIGHT = 2
+};
+
+typedef struct paint_text_instruction_t {
+    double x;
+    double y;
+    const uint8_t *text;
+    size_t text_len;
+    const uint8_t *font_ref;
+    size_t font_ref_len;
+    double font_size;
+    paint_rgba8_color_t fill;
+    uint32_t text_align;
+} paint_text_instruction_t;
+
 typedef struct paint_rgba8_buffer_t {
     uint32_t width;
     uint32_t height;
@@ -36,6 +54,28 @@ uint8_t paint_vm_direct2d_render_rect_scene(
     paint_rgba8_color_t background,
     const paint_rect_instruction_t *rects,
     size_t rect_count,
+    paint_rgba8_buffer_t *out_buffer
+);
+
+uint8_t paint_vm_direct2d_render_scene(
+    uint32_t width,
+    uint32_t height,
+    paint_rgba8_color_t background,
+    const paint_rect_instruction_t *rects,
+    size_t rect_count,
+    const paint_text_instruction_t *texts,
+    size_t text_count,
+    paint_rgba8_buffer_t *out_buffer
+);
+
+uint8_t paint_vm_gdi_render_scene(
+    uint32_t width,
+    uint32_t height,
+    paint_rgba8_color_t background,
+    const paint_rect_instruction_t *rects,
+    size_t rect_count,
+    const paint_text_instruction_t *texts,
+    size_t text_count,
     paint_rgba8_buffer_t *out_buffer
 );
 

--- a/code/packages/rust/paint-vm-direct2d-c/src/lib.rs
+++ b/code/packages/rust/paint-vm-direct2d-c/src/lib.rs
@@ -1,4 +1,8 @@
-use paint_instructions::{PaintInstruction, PaintRect, PaintScene};
+#[cfg(target_os = "windows")]
+use paint_instructions::{
+    PaintBase, PaintInstruction, PaintRect, PaintScene, PaintText, TextAlign,
+};
+#[cfg(target_os = "windows")]
 use std::panic::catch_unwind;
 
 #[repr(C)]
@@ -21,6 +25,20 @@ pub struct paint_rect_instruction_t {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
+pub struct paint_text_instruction_t {
+    pub x: f64,
+    pub y: f64,
+    pub text: *const u8,
+    pub text_len: usize,
+    pub font_ref: *const u8,
+    pub font_ref_len: usize,
+    pub font_size: f64,
+    pub fill: paint_rgba8_color_t,
+    pub text_align: u32,
+}
+
+#[repr(C)]
 pub struct paint_rgba8_buffer_t {
     pub width: u32,
     pub height: u32,
@@ -28,6 +46,7 @@ pub struct paint_rgba8_buffer_t {
     pub len: usize,
 }
 
+#[cfg(target_os = "windows")]
 fn color_to_hex(color: paint_rgba8_color_t) -> String {
     if color.a == 255 {
         format!("#{:02x}{:02x}{:02x}", color.r, color.g, color.b)
@@ -39,12 +58,37 @@ fn color_to_hex(color: paint_rgba8_color_t) -> String {
     }
 }
 
+#[cfg(target_os = "windows")]
+unsafe fn utf8_from_parts(ptr: *const u8, len: usize) -> Option<String> {
+    if len == 0 {
+        return Some(String::new());
+    }
+    if ptr.is_null() {
+        return None;
+    }
+    std::str::from_utf8(std::slice::from_raw_parts(ptr, len))
+        .ok()
+        .map(str::to_string)
+}
+
+#[cfg(target_os = "windows")]
+fn text_align_from_u32(value: u32) -> Option<TextAlign> {
+    match value {
+        1 => Some(TextAlign::Center),
+        2 => Some(TextAlign::Right),
+        _ => Some(TextAlign::Left),
+    }
+}
+
+#[cfg(target_os = "windows")]
 fn build_scene(
     width: u32,
     height: u32,
     background: paint_rgba8_color_t,
     rects: *const paint_rect_instruction_t,
     rect_count: usize,
+    texts: *const paint_text_instruction_t,
+    text_count: usize,
 ) -> Option<PaintScene> {
     let rect_slice = if rect_count == 0 {
         &[][..]
@@ -54,24 +98,48 @@ fn build_scene(
         unsafe { std::slice::from_raw_parts(rects, rect_count) }
     };
 
+    let text_slice = if text_count == 0 {
+        &[][..]
+    } else if texts.is_null() {
+        return None;
+    } else {
+        unsafe { std::slice::from_raw_parts(texts, text_count) }
+    };
+
     let mut scene = PaintScene::new(width as f64, height as f64);
     scene.background = color_to_hex(background);
-    scene.instructions = rect_slice
-        .iter()
-        .map(|rect| {
-            PaintInstruction::Rect(PaintRect::filled(
-                rect.x as f64,
-                rect.y as f64,
-                rect.width as f64,
-                rect.height as f64,
-                &color_to_hex(rect.fill),
-            ))
-        })
-        .collect();
+    scene.instructions.extend(rect_slice.iter().map(|rect| {
+        PaintInstruction::Rect(PaintRect::filled(
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            &color_to_hex(rect.fill),
+        ))
+    }));
+    for text in text_slice {
+        let text_value = unsafe { utf8_from_parts(text.text, text.text_len)? };
+        let font_ref = if text.font_ref_len == 0 {
+            None
+        } else {
+            Some(unsafe { utf8_from_parts(text.font_ref, text.font_ref_len)? })
+        };
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: PaintBase::default(),
+            x: text.x,
+            y: text.y,
+            text: text_value,
+            font_ref,
+            font_size: text.font_size,
+            fill: Some(color_to_hex(text.fill)),
+            text_align: text_align_from_u32(text.text_align),
+        }));
+    }
 
     Some(scene)
 }
 
+#[cfg(target_os = "windows")]
 fn render_scene(scene: &PaintScene) -> Option<paint_instructions::PixelContainer> {
     if std::env::var_os("CODING_ADVENTURES_FORCE_GDI").is_some() {
         return catch_unwind(|| paint_vm_gdi::render(scene)).ok();
@@ -91,30 +159,160 @@ pub unsafe extern "C" fn paint_vm_direct2d_render_rect_scene(
     rect_count: usize,
     out_buffer: *mut paint_rgba8_buffer_t,
 ) -> u8 {
-    if out_buffer.is_null() {
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (width, height, background, rects, rect_count);
+        clear_out_buffer(out_buffer);
         return 0;
     }
 
-    let result = catch_unwind(|| {
-        let scene = build_scene(width, height, background, rects, rect_count)?;
-        render_scene(&scene)
-    });
+    #[cfg(target_os = "windows")]
+    {
+        if out_buffer.is_null() {
+            return 0;
+        }
 
-    let Some(pixels) = result.ok().flatten() else {
-        (*out_buffer).width = 0;
-        (*out_buffer).height = 0;
-        (*out_buffer).data = std::ptr::null_mut();
-        (*out_buffer).len = 0;
+        let result = catch_unwind(|| {
+            let scene = build_scene(
+                width,
+                height,
+                background,
+                rects,
+                rect_count,
+                std::ptr::null(),
+                0,
+            )?;
+            render_scene(&scene)
+        });
+
+        let Some(pixels) = result.ok().flatten() else {
+            (*out_buffer).width = 0;
+            (*out_buffer).height = 0;
+            (*out_buffer).data = std::ptr::null_mut();
+            (*out_buffer).len = 0;
+            return 0;
+        };
+
+        let mut data = pixels.data.into_boxed_slice();
+        (*out_buffer).width = pixels.width;
+        (*out_buffer).height = pixels.height;
+        (*out_buffer).len = data.len();
+        (*out_buffer).data = data.as_mut_ptr();
+        std::mem::forget(data);
+        1
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paint_vm_direct2d_render_scene(
+    width: u32,
+    height: u32,
+    background: paint_rgba8_color_t,
+    rects: *const paint_rect_instruction_t,
+    rect_count: usize,
+    texts: *const paint_text_instruction_t,
+    text_count: usize,
+    out_buffer: *mut paint_rgba8_buffer_t,
+) -> u8 {
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (
+            width, height, background, rects, rect_count, texts, text_count,
+        );
+        clear_out_buffer(out_buffer);
         return 0;
-    };
+    }
 
-    let mut data = pixels.data.into_boxed_slice();
-    (*out_buffer).width = pixels.width;
-    (*out_buffer).height = pixels.height;
-    (*out_buffer).len = data.len();
-    (*out_buffer).data = data.as_mut_ptr();
-    std::mem::forget(data);
-    1
+    #[cfg(target_os = "windows")]
+    {
+        if out_buffer.is_null() {
+            return 0;
+        }
+
+        let result = catch_unwind(|| {
+            let scene = build_scene(
+                width, height, background, rects, rect_count, texts, text_count,
+            )?;
+            render_scene(&scene)
+        });
+
+        let Some(pixels) = result.ok().flatten() else {
+            (*out_buffer).width = 0;
+            (*out_buffer).height = 0;
+            (*out_buffer).data = std::ptr::null_mut();
+            (*out_buffer).len = 0;
+            return 0;
+        };
+
+        let mut data = pixels.data.into_boxed_slice();
+        (*out_buffer).width = pixels.width;
+        (*out_buffer).height = pixels.height;
+        (*out_buffer).len = data.len();
+        (*out_buffer).data = data.as_mut_ptr();
+        std::mem::forget(data);
+        1
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paint_vm_gdi_render_scene(
+    width: u32,
+    height: u32,
+    background: paint_rgba8_color_t,
+    rects: *const paint_rect_instruction_t,
+    rect_count: usize,
+    texts: *const paint_text_instruction_t,
+    text_count: usize,
+    out_buffer: *mut paint_rgba8_buffer_t,
+) -> u8 {
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (
+            width, height, background, rects, rect_count, texts, text_count,
+        );
+        clear_out_buffer(out_buffer);
+        return 0;
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if out_buffer.is_null() {
+            return 0;
+        }
+
+        let result = catch_unwind(|| {
+            let scene = build_scene(
+                width, height, background, rects, rect_count, texts, text_count,
+            )?;
+            catch_unwind(|| paint_vm_gdi::render(&scene)).ok()
+        });
+
+        let Some(pixels) = result.ok().flatten() else {
+            (*out_buffer).width = 0;
+            (*out_buffer).height = 0;
+            (*out_buffer).data = std::ptr::null_mut();
+            (*out_buffer).len = 0;
+            return 0;
+        };
+
+        let mut data = pixels.data.into_boxed_slice();
+        (*out_buffer).width = pixels.width;
+        (*out_buffer).height = pixels.height;
+        (*out_buffer).len = data.len();
+        (*out_buffer).data = data.as_mut_ptr();
+        std::mem::forget(data);
+        1
+    }
+}
+
+unsafe fn clear_out_buffer(out_buffer: *mut paint_rgba8_buffer_t) {
+    if out_buffer.is_null() {
+        return;
+    }
+    (*out_buffer).width = 0;
+    (*out_buffer).height = 0;
+    (*out_buffer).data = std::ptr::null_mut();
+    (*out_buffer).len = 0;
 }
 
 #[no_mangle]

--- a/code/packages/rust/paint-vm-metal-c/include/paint_vm_metal_c.h
+++ b/code/packages/rust/paint-vm-metal-c/include/paint_vm_metal_c.h
@@ -23,6 +23,24 @@ typedef struct paint_rect_instruction_t {
     paint_rgba8_color_t fill;
 } paint_rect_instruction_t;
 
+enum {
+    PAINT_TEXT_ALIGN_LEFT = 0,
+    PAINT_TEXT_ALIGN_CENTER = 1,
+    PAINT_TEXT_ALIGN_RIGHT = 2
+};
+
+typedef struct paint_text_instruction_t {
+    double x;
+    double y;
+    const uint8_t *text;
+    size_t text_len;
+    const uint8_t *font_ref;
+    size_t font_ref_len;
+    double font_size;
+    paint_rgba8_color_t fill;
+    uint32_t text_align;
+} paint_text_instruction_t;
+
 typedef struct paint_rgba8_buffer_t {
     uint32_t width;
     uint32_t height;
@@ -36,6 +54,17 @@ uint8_t paint_vm_metal_render_rect_scene(
     paint_rgba8_color_t background,
     const paint_rect_instruction_t *rects,
     size_t rect_count,
+    paint_rgba8_buffer_t *out_buffer
+);
+
+uint8_t paint_vm_metal_render_scene(
+    uint32_t width,
+    uint32_t height,
+    paint_rgba8_color_t background,
+    const paint_rect_instruction_t *rects,
+    size_t rect_count,
+    const paint_text_instruction_t *texts,
+    size_t text_count,
     paint_rgba8_buffer_t *out_buffer
 );
 

--- a/code/packages/rust/paint-vm-metal-c/src/lib.rs
+++ b/code/packages/rust/paint-vm-metal-c/src/lib.rs
@@ -1,4 +1,6 @@
-use paint_instructions::{PaintInstruction, PaintRect, PaintScene};
+use paint_instructions::{
+    PaintBase, PaintInstruction, PaintRect, PaintScene, PaintText, TextAlign,
+};
 use std::panic::catch_unwind;
 
 #[repr(C)]
@@ -21,6 +23,20 @@ pub struct paint_rect_instruction_t {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
+pub struct paint_text_instruction_t {
+    pub x: f64,
+    pub y: f64,
+    pub text: *const u8,
+    pub text_len: usize,
+    pub font_ref: *const u8,
+    pub font_ref_len: usize,
+    pub font_size: f64,
+    pub fill: paint_rgba8_color_t,
+    pub text_align: u32,
+}
+
+#[repr(C)]
 pub struct paint_rgba8_buffer_t {
     pub width: u32,
     pub height: u32,
@@ -39,6 +55,96 @@ fn color_to_hex(color: paint_rgba8_color_t) -> String {
     }
 }
 
+unsafe fn utf8_from_parts(ptr: *const u8, len: usize) -> Option<String> {
+    if len == 0 {
+        return Some(String::new());
+    }
+    if ptr.is_null() {
+        return None;
+    }
+    std::str::from_utf8(std::slice::from_raw_parts(ptr, len))
+        .ok()
+        .map(str::to_string)
+}
+
+fn text_align_from_u32(value: u32) -> Option<TextAlign> {
+    match value {
+        1 => Some(TextAlign::Center),
+        2 => Some(TextAlign::Right),
+        _ => Some(TextAlign::Left),
+    }
+}
+
+unsafe fn build_scene(
+    width: u32,
+    height: u32,
+    background: paint_rgba8_color_t,
+    rects: *const paint_rect_instruction_t,
+    rect_count: usize,
+    texts: *const paint_text_instruction_t,
+    text_count: usize,
+) -> Option<PaintScene> {
+    let rect_slice = if rect_count == 0 {
+        &[][..]
+    } else if rects.is_null() {
+        return None;
+    } else {
+        std::slice::from_raw_parts(rects, rect_count)
+    };
+
+    let text_slice = if text_count == 0 {
+        &[][..]
+    } else if texts.is_null() {
+        return None;
+    } else {
+        std::slice::from_raw_parts(texts, text_count)
+    };
+
+    let mut scene = PaintScene::new(width as f64, height as f64);
+    scene.background = color_to_hex(background);
+    scene.instructions.extend(rect_slice.iter().map(|rect| {
+        PaintInstruction::Rect(PaintRect::filled(
+            rect.x as f64,
+            rect.y as f64,
+            rect.width as f64,
+            rect.height as f64,
+            &color_to_hex(rect.fill),
+        ))
+    }));
+    for text in text_slice {
+        let text_value = utf8_from_parts(text.text, text.text_len)?;
+        let font_ref = if text.font_ref_len == 0 {
+            None
+        } else {
+            Some(utf8_from_parts(text.font_ref, text.font_ref_len)?)
+        };
+        scene.instructions.push(PaintInstruction::Text(PaintText {
+            base: PaintBase::default(),
+            x: text.x,
+            y: text.y,
+            text: text_value,
+            font_ref,
+            font_size: text.font_size,
+            fill: Some(color_to_hex(text.fill)),
+            text_align: text_align_from_u32(text.text_align),
+        }));
+    }
+
+    Some(scene)
+}
+
+unsafe fn write_pixels_to_out_buffer(
+    pixels: paint_instructions::PixelContainer,
+    out_buffer: *mut paint_rgba8_buffer_t,
+) {
+    let mut data = pixels.data.into_boxed_slice();
+    (*out_buffer).width = pixels.width;
+    (*out_buffer).height = pixels.height;
+    (*out_buffer).len = data.len();
+    (*out_buffer).data = data.as_mut_ptr();
+    std::mem::forget(data);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn paint_vm_metal_render_rect_scene(
     width: u32,
@@ -53,29 +159,17 @@ pub unsafe extern "C" fn paint_vm_metal_render_rect_scene(
     }
 
     let result = catch_unwind(|| {
-        let rect_slice = if rect_count == 0 {
-            &[][..]
-        } else if rects.is_null() {
-            return None;
-        } else {
-            unsafe { std::slice::from_raw_parts(rects, rect_count) }
+        let scene = unsafe {
+            build_scene(
+                width,
+                height,
+                background,
+                rects,
+                rect_count,
+                std::ptr::null(),
+                0,
+            )?
         };
-
-        let mut scene = PaintScene::new(width as f64, height as f64);
-        scene.background = color_to_hex(background);
-        scene.instructions = rect_slice
-            .iter()
-            .map(|rect| {
-                PaintInstruction::Rect(PaintRect::filled(
-                    rect.x as f64,
-                    rect.y as f64,
-                    rect.width as f64,
-                    rect.height as f64,
-                    &color_to_hex(rect.fill),
-                ))
-            })
-            .collect();
-
         Some(paint_metal::render(&scene))
     });
 
@@ -87,12 +181,43 @@ pub unsafe extern "C" fn paint_vm_metal_render_rect_scene(
         return 0;
     };
 
-    let mut data = pixels.data.into_boxed_slice();
-    (*out_buffer).width = pixels.width;
-    (*out_buffer).height = pixels.height;
-    (*out_buffer).len = data.len();
-    (*out_buffer).data = data.as_mut_ptr();
-    std::mem::forget(data);
+    write_pixels_to_out_buffer(pixels, out_buffer);
+    1
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paint_vm_metal_render_scene(
+    width: u32,
+    height: u32,
+    background: paint_rgba8_color_t,
+    rects: *const paint_rect_instruction_t,
+    rect_count: usize,
+    texts: *const paint_text_instruction_t,
+    text_count: usize,
+    out_buffer: *mut paint_rgba8_buffer_t,
+) -> u8 {
+    if out_buffer.is_null() {
+        return 0;
+    }
+
+    let result = catch_unwind(|| {
+        let scene = unsafe {
+            build_scene(
+                width, height, background, rects, rect_count, texts, text_count,
+            )?
+        };
+        Some(paint_metal::render(&scene))
+    });
+
+    let Some(pixels) = result.ok().flatten() else {
+        (*out_buffer).width = 0;
+        (*out_buffer).height = 0;
+        (*out_buffer).data = std::ptr::null_mut();
+        (*out_buffer).len = 0;
+        return 0;
+    };
+
+    write_pixels_to_out_buffer(pixels, out_buffer);
     1
 }
 

--- a/code/programs/rust/cowsay/Cargo.toml
+++ b/code/programs/rust/cowsay/Cargo.toml
@@ -8,3 +8,9 @@ cli-builder = { path = "../../../packages/rust/cli-builder" }
 serde_json = "1.0"
 regex = "1.10"
 atty = "0.2"
+layout-ir = { path = "../../../packages/rust/layout-ir" }
+layout-text-measure-native = { path = "../../../packages/rust/layout-text-measure-native" }
+layout-to-paint = { path = "../../../packages/rust/layout-to-paint" }
+paint-codec-png = { path = "../../../packages/rust/paint-codec-png" }
+paint-metal = { path = "../../../packages/rust/paint-metal" }
+text-native = { path = "../../../packages/rust/text-native" }

--- a/code/programs/rust/cowsay/src/main.rs
+++ b/code/programs/rust/cowsay/src/main.rs
@@ -1,5 +1,11 @@
-use cli_builder::{load_spec_from_file, Parser};
 use cli_builder::types::ParserOutput;
+use cli_builder::{load_spec_from_file, Parser};
+use layout_ir::{
+    color_black, color_white, font_spec, Content, PositionedNode, TextAlign, TextContent,
+    TextMeasurer,
+};
+use layout_text_measure_native::NativeMeasurer;
+use layout_to_paint::{layout_to_paint, LayoutToPaintOptions};
 use regex::Regex;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -7,6 +13,23 @@ use std::env;
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use text_native::text_interfaces::{FontMetrics, FontResolver, TextShaper};
+use text_native::{NativeMetrics, NativeResolver, NativeShaper};
+
+#[derive(Debug, Default)]
+struct PaintRenderOptions {
+    png_output: Option<PathBuf>,
+    random_text: bool,
+}
+
+const RANDOM_MESSAGES: &[&str] = &[
+    "Paint VM says hello from native glyph runs",
+    "Moo, but make it Metal",
+    "ASCII art survives the layout pipeline",
+    "This cow was shaped by CoreText",
+    "The bubble is text, the pixels are native",
+];
 
 fn wrap_text(text: &str, width: usize) -> Vec<String> {
     if text.len() <= width {
@@ -52,7 +75,13 @@ fn format_bubble(lines: &[String], is_think: bool) -> String {
 
     if lines.len() == 1 {
         let (start, end) = if is_think { ("(", ")") } else { ("<", ">") };
-        result.push(format!("{} {:<width$} {}", start, lines[0], end, width = max_len));
+        result.push(format!(
+            "{} {:<width$} {}",
+            start,
+            lines[0],
+            end,
+            width = max_len
+        ));
     } else {
         for (i, line) in lines.iter().enumerate() {
             let (start, end) = if is_think {
@@ -64,7 +93,13 @@ fn format_bubble(lines: &[String], is_think: bool) -> String {
             } else {
                 ("|", "|")
             };
-            result.push(format!("{} {:<width$} {}", start, line, end, width = max_len));
+            result.push(format!(
+                "{} {:<width$} {}",
+                start,
+                line,
+                end,
+                width = max_len
+            ));
         }
     }
 
@@ -110,12 +145,18 @@ fn main() {
     let spec = load_spec_from_file(spec_path.to_str().unwrap()).expect("Failed to load spec");
 
     let parser = Parser::new(spec);
-    let args: Vec<String> = env::args().collect();
+    let (args, render_options) = extract_paint_render_options(env::args().collect());
 
     match parser.parse(&args) {
-        Ok(ParserOutput::Parse(result)) => handle_parse_result(result, &root),
+        Ok(ParserOutput::Parse(result)) => handle_parse_result(result, &root, &render_options),
         Ok(ParserOutput::Help(h)) => {
             print!("{}", h.text);
+            if render_options.png_output.is_some() || render_options.random_text {
+                println!("\nPaint VM options:");
+                println!("      --png <PATH>       Render Cowsay as a PNG via paint-metal");
+                println!("      --png-metal <PATH> Alias for --png");
+                println!("      --random-text      Use a built-in random message");
+            }
         }
         Ok(ParserOutput::Version(v)) => {
             println!("{}", v.version);
@@ -127,7 +168,84 @@ fn main() {
     }
 }
 
-fn handle_parse_result(result: cli_builder::types::ParseResult, root: &Path) {
+fn extract_paint_render_options(args: Vec<String>) -> (Vec<String>, PaintRenderOptions) {
+    let mut filtered = Vec::with_capacity(args.len());
+    let mut options = PaintRenderOptions::default();
+    let mut iter = args.into_iter();
+    let mut saw_message = false;
+
+    if let Some(program) = iter.next() {
+        filtered.push(program);
+    }
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "-e" | "--eyes" | "-T" | "--tongue" | "-f" | "--file" | "-W" => {
+                filtered.push(arg.clone());
+                let Some(value) = iter.next() else {
+                    eprintln!("cowsay: {} requires a value", arg);
+                    std::process::exit(2);
+                };
+                filtered.push(value);
+            }
+            "--png" | "--png-metal" => {
+                let Some(path) = iter.next() else {
+                    eprintln!("cowsay: {} requires a path argument", arg);
+                    std::process::exit(2);
+                };
+                options.png_output = Some(PathBuf::from(path));
+            }
+            "--random-text" => {
+                options.random_text = true;
+            }
+            _ if arg.starts_with("--png=") => {
+                options.png_output = Some(PathBuf::from(arg.trim_start_matches("--png=")));
+            }
+            _ if arg.starts_with("--png-metal=") => {
+                options.png_output = Some(PathBuf::from(arg.trim_start_matches("--png-metal=")));
+            }
+            _ => {
+                if !arg.starts_with('-') {
+                    saw_message = true;
+                }
+                filtered.push(arg);
+            }
+        }
+    }
+
+    if options.random_text && !saw_message {
+        filtered.push(random_message());
+    }
+
+    (filtered, options)
+}
+
+fn handle_parse_result(
+    result: cli_builder::types::ParseResult,
+    root: &Path,
+    render_options: &PaintRenderOptions,
+) {
+    let Some(output) = build_cowsay_output(result, root, render_options) else {
+        return;
+    };
+
+    if let Some(path) = &render_options.png_output {
+        if let Err(e) = render_cowsay_png_metal(&output, path) {
+            eprintln!("cowsay: failed to render PNG: {}", e);
+            std::process::exit(1);
+        }
+        eprintln!("cowsay: wrote {}", path.display());
+        return;
+    }
+
+    println!("{}", output);
+}
+
+fn build_cowsay_output(
+    result: cli_builder::types::ParseResult,
+    root: &Path,
+    render_options: &PaintRenderOptions,
+) -> Option<String> {
     let flags = result.flags;
     let args = result.arguments;
 
@@ -140,8 +258,10 @@ fn handle_parse_result(result: cli_builder::types::ParseResult, root: &Path) {
                 let mut buffer = String::new();
                 io::stdin().read_to_string(&mut buffer).ok();
                 message = buffer.trim().to_string();
+            } else if render_options.random_text {
+                message = random_message();
             } else {
-                return;
+                return None;
             }
         } else {
             message = parts
@@ -153,7 +273,11 @@ fn handle_parse_result(result: cli_builder::types::ParseResult, root: &Path) {
     }
 
     if message.is_empty() {
-        return;
+        if render_options.random_text {
+            message = random_message();
+        } else {
+            return None;
+        }
     }
 
     // Handle modes
@@ -175,23 +299,47 @@ fn handle_parse_result(result: cli_builder::types::ParseResult, root: &Path) {
         eyes = "XX".to_string();
         tongue = "U ".to_string();
     }
-    if flags.get("greedy").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if flags
+        .get("greedy")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         eyes = "$$".to_string();
     }
-    if flags.get("paranoid").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if flags
+        .get("paranoid")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         eyes = "@@".to_string();
     }
-    if flags.get("stoned").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if flags
+        .get("stoned")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         eyes = "xx".to_string();
         tongue = "U ".to_string();
     }
-    if flags.get("tired").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if flags
+        .get("tired")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         eyes = "--".to_string();
     }
-    if flags.get("wired").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if flags
+        .get("wired")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         eyes = "OO".to_string();
     }
-    if flags.get("youthful").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if flags
+        .get("youthful")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         eyes = "..".to_string();
     }
 
@@ -201,7 +349,10 @@ fn handle_parse_result(result: cli_builder::types::ParseResult, root: &Path) {
 
     // Handle wrapping
     let mut lines = Vec::new();
-    let nowrap = flags.get("nowrap").and_then(|v| v.as_bool()).unwrap_or(false);
+    let nowrap = flags
+        .get("nowrap")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     if nowrap {
         lines = message.split('\n').map(|s| s.to_string()).collect();
     } else {
@@ -220,7 +371,10 @@ fn handle_parse_result(result: cli_builder::types::ParseResult, root: &Path) {
     }
 
     // Handle speech vs thought
-    let mut is_think = flags.get("think").and_then(|v| v.as_bool()).unwrap_or(false);
+    let mut is_think = flags
+        .get("think")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     if let Some(exe) = env::args().next() {
         if exe.ends_with("cowthink") {
             is_think = true;
@@ -246,7 +400,88 @@ fn handle_parse_result(result: cli_builder::types::ParseResult, root: &Path) {
     // Final unescape
     let cow = cow_template.replace("\\\\", "\\");
 
-    println!("{}", bubble);
-    println!("{}", cow);
+    Some(format!("{}\n{}", bubble, cow))
 }
 
+fn random_message() -> String {
+    let idx = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.subsec_nanos() as usize)
+        .unwrap_or(0)
+        % RANDOM_MESSAGES.len();
+    RANDOM_MESSAGES[idx].to_string()
+}
+
+#[cfg(target_vendor = "apple")]
+fn render_cowsay_png_metal(output: &str, path: &Path) -> Result<(), String> {
+    let font_size = 18.0;
+    let padding = 24.0;
+    let mut font = font_spec("Menlo", font_size);
+    font.line_height = 1.1;
+
+    let measurer = NativeMeasurer::new();
+    let lines: Vec<&str> = output.lines().collect();
+    let line_count = lines.len().max(1) as f64;
+    let max_text_width = lines
+        .iter()
+        .map(|line| measurer.measure(line, &font, None).width)
+        .fold(0.0, f64::max);
+    let line_height = measurer.measure("M", &font, None).height;
+
+    let text_width = (max_text_width + font_size).ceil();
+    let text_height = (line_height * line_count).ceil();
+    let scene_width = (text_width + padding * 2.0).ceil().max(1.0);
+    let scene_height = (text_height + padding * 2.0).ceil().max(1.0);
+
+    let root = PositionedNode {
+        x: padding,
+        y: padding,
+        width: text_width,
+        height: text_height,
+        id: Some("cowsay-text".to_string()),
+        content: Some(Content::Text(TextContent {
+            value: output.to_string(),
+            font,
+            color: color_black(),
+            max_lines: None,
+            text_align: TextAlign::Start,
+        })),
+        children: Vec::new(),
+        ext: HashMap::new(),
+    };
+
+    let resolver = NativeResolver::new();
+    let metrics = NativeMetrics::new();
+    let shaper = NativeShaper::new();
+
+    let _: &dyn FontResolver<Handle = _> = &resolver;
+    let _: &dyn FontMetrics<Handle = _> = &metrics;
+    let _: &dyn TextShaper<Handle = _> = &shaper;
+
+    let options = LayoutToPaintOptions {
+        width: scene_width,
+        height: scene_height,
+        background: color_white(),
+        device_pixel_ratio: 1.0,
+        shaper: &shaper,
+        metrics: &metrics,
+        resolver: &resolver,
+    };
+    let scene = layout_to_paint(&root, &options);
+    let pixels = paint_metal::render(&scene);
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("could not create {}: {}", parent.display(), e))?;
+    }
+    paint_codec_png::write_png(&pixels, &path.to_string_lossy())
+        .map_err(|e| format!("could not write {}: {}", path.display(), e))
+}
+
+#[cfg(not(target_vendor = "apple"))]
+fn render_cowsay_png_metal(_output: &str, _path: &Path) -> Result<(), String> {
+    Err("paint-metal PNG rendering requires an Apple target".to_string())
+}


### PR DESCRIPTION
## Summary

- Adds a Paint VM PNG path to the Rust `cowsay` program via `layout-ir` -> `layout-to-paint` -> native backend rendering.
- Preserves fixed-format whitespace in `layout-to-paint` when text already fits, so ASCII/code-style content survives the text pipeline.
- Teaches `paint-vm-ascii` to render `PaintText` directly with basic alignment support.
- Extends the Metal and Direct2D/GDI C bridge packages with general scene entrypoints that accept rect and text instructions while keeping existing rect-only APIs.

## Notes

`PaintGlyphRun` remains the preferred shaped-text path for advanced/native rendering. `PaintText` is now available for simpler bridge and ASCII backends that do not have shaping/font access.

## Validation

- `cargo check -p paint-vm-metal-c`
- `cargo check -p paint-vm-direct2d-c`
- `cargo test -p paint-vm-ascii -p layout-to-paint`
- `cargo test` in `code/programs/rust/cowsay`
- `cargo run -- --png /Users/adhithya/Downloads/Codex/coding-adventures-cowsay-paint-vm/.codex-artifacts/cowsay-paint-vm-metal.png --random-text`