### PR TITLE
feat(prolog): add term generality predicates

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this package will be documented in this file.
   exposed by the Prolog compatibility layer.
 - `set_prolog_flago(name, value)` for branch-local updates to supported
   Prolog runtime flags.
+- `variant_termo(left, right)`, `not_variant_termo(left, right)`, and
+  `subsumes_termo(general, specific)` for non-binding term generality checks.
 
 ### Fixed
 

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -36,6 +36,8 @@ ordinary logic goal expressions.
 - `univo(term, parts)` for Prolog-style `=../2` term decomposition/construction
 - `copytermo(source, copy)`, `same_termo(left, right)`, and
   `not_same_termo(left, right)`
+- `variant_termo(left, right)`, `not_variant_termo(left, right)`, and
+  `subsumes_termo(general, specific)` for non-binding term generality checks
 - `difo(left, right)` for delayed disequality constraints
 - `clauseo(head, body)` for Prolog-style clause introspection
 - `compare_termo(order, left, right)`, `termo_lto(left, right)`,
@@ -105,6 +107,7 @@ from logic_builtins import (
     labelingo,
     maplisto,
     not_same_termo,
+    subsumes_termo,
     noto,
     onceo,
     partitiono,
@@ -114,6 +117,7 @@ from logic_builtins import (
     set_prolog_flago,
     termo_lto,
     univo,
+    variant_termo,
 )
 from logic_engine import (
     atom,
@@ -209,6 +213,8 @@ assert solve_all(
     univo(X, logic_list(["box", "tea", "cake"])),
 ) == [term("box", "tea", "cake")]
 assert solve_all(program(), X, same_termo(X, X)) == [X]
+assert solve_all(program(), X, variant_termo(term("box", X), term("box", Y))) == [X]
+assert solve_all(program(), X, subsumes_termo(term("box", X), term("box", "tea"))) == [X]
 assert solve_all(family, Body, clauseo(child("bart", "homer"), Body)) == [
     term("parent", "homer", "bart"),
 ]

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -84,6 +84,7 @@ from logic_builtins.builtins import (
     neg,
     nonvaro,
     not_same_termo,
+    not_variant_termo,
     noto,
     numbero,
     numeqo,
@@ -106,6 +107,7 @@ from logic_builtins.builtins import (
     setofo,
     stringo,
     sub,
+    subsumes_termo,
     succo,
     term_variableso,
     termo_geqo,
@@ -115,6 +117,7 @@ from logic_builtins.builtins import (
     throwo,
     trueo,
     univo,
+    variant_termo,
     varo,
 )
 
@@ -193,6 +196,7 @@ __all__ = [
     "neg",
     "nonvaro",
     "not_same_termo",
+    "not_variant_termo",
     "noto",
     "numeqo",
     "numneqo",
@@ -221,6 +225,7 @@ __all__ = [
     "set_prolog_flago",
     "stringo",
     "sub",
+    "subsumes_termo",
     "succo",
     "termo_geqo",
     "termo_gto",
@@ -231,6 +236,7 @@ __all__ = [
     "trueo",
     "univo",
     "varo",
+    "variant_termo",
 ]
 
 __version__ = "0.15.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -176,6 +176,9 @@ __all__ = [
     "trueo",
     "univo",
     "varo",
+    "not_variant_termo",
+    "subsumes_termo",
+    "variant_termo",
 ]
 
 
@@ -398,6 +401,9 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("trueo", 0),
     ("univo", 2),
     ("varo", 1),
+    ("not_variant_termo", 2),
+    ("subsumes_termo", 2),
+    ("variant_termo", 2),
 )
 
 
@@ -3862,6 +3868,126 @@ def not_same_termo(left: object, right: object) -> GoalExpr:
         )
 
     return native_goal(run, left, right)
+
+
+def _variant_terms(
+    left: Term,
+    right: Term,
+    left_to_right: dict[LogicVar, LogicVar],
+    right_to_left: dict[LogicVar, LogicVar],
+) -> bool:
+    """Return True when two terms differ only by variable renaming."""
+
+    if isinstance(left, LogicVar) and isinstance(right, LogicVar):
+        mapped_right = left_to_right.get(left)
+        mapped_left = right_to_left.get(right)
+        if mapped_right is None and mapped_left is None:
+            left_to_right[left] = right
+            right_to_left[right] = left
+            return True
+        return mapped_right == right and mapped_left == left
+
+    if isinstance(left, LogicVar) or isinstance(right, LogicVar):
+        return False
+    if isinstance(left, Compound) and isinstance(right, Compound):
+        return (
+            left.functor == right.functor
+            and len(left.args) == len(right.args)
+            and all(
+                _variant_terms(
+                    left_arg,
+                    right_arg,
+                    left_to_right,
+                    right_to_left,
+                )
+                for left_arg, right_arg in zip(left.args, right.args, strict=True)
+            )
+        )
+    return left == right
+
+
+def _subsumes_term(
+    general: Term,
+    specific: Term,
+    bindings: dict[LogicVar, Term],
+) -> bool:
+    """Return True when ``specific`` is an instance of ``general``."""
+
+    if isinstance(general, LogicVar):
+        previous = bindings.get(general)
+        if previous is None:
+            bindings[general] = specific
+            return True
+        return previous == specific
+
+    if isinstance(general, Compound):
+        return (
+            isinstance(specific, Compound)
+            and general.functor == specific.functor
+            and len(general.args) == len(specific.args)
+            and all(
+                _subsumes_term(general_arg, specific_arg, bindings)
+                for general_arg, specific_arg in zip(
+                    general.args,
+                    specific.args,
+                    strict=True,
+                )
+            )
+        )
+    return general == specific
+
+
+def variant_termo(left: object, right: object) -> GoalExpr:
+    """Succeed when two reified terms are variants of each other."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        left_term, right_term = args
+        yield from _succeed_if(
+            _variant_terms(
+                _reified(left_term, state),
+                _reified(right_term, state),
+                {},
+                {},
+            ),
+            state,
+        )
+
+    return native_goal(run, left, right)
+
+
+def not_variant_termo(left: object, right: object) -> GoalExpr:
+    """Succeed when two reified terms are not variants of each other."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        left_term, right_term = args
+        yield from _succeed_if(
+            not _variant_terms(
+                _reified(left_term, state),
+                _reified(right_term, state),
+                {},
+                {},
+            ),
+            state,
+        )
+
+    return native_goal(run, left, right)
+
+
+def subsumes_termo(general: object, specific: object) -> GoalExpr:
+    """Succeed when ``specific`` is an instance of ``general``."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        general_term, specific_term = args
+        yield from _succeed_if(
+            _subsumes_term(
+                _reified(general_term, state),
+                _reified(specific_term, state),
+                {},
+            ),
+            state,
+        )
+
+    return native_goal(run, general, specific)
 
 
 def difo(left: object, right: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -101,6 +101,7 @@ from logic_builtins import (
     neg,
     nonvaro,
     not_same_termo,
+    not_variant_termo,
     noto,
     numbero,
     numeqo,
@@ -119,6 +120,7 @@ from logic_builtins import (
     setofo,
     stringo,
     sub,
+    subsumes_termo,
     succo,
     term_variableso,
     termo_geqo,
@@ -128,6 +130,7 @@ from logic_builtins import (
     throwo,
     trueo,
     univo,
+    variant_termo,
     varo,
 )
 
@@ -1948,6 +1951,72 @@ class TestTermMetaprogrammingBuiltins:
             left,
             not_same_termo(term("box", "tea"), term("box", "cake")),
         ) == [left]
+
+    def test_variant_termo_accepts_alpha_equivalent_terms(self) -> None:
+        left = var("Left")
+        right = var("Right")
+        other = var("Other")
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                variant_termo(
+                    term("pair", left, term("box", left)),
+                    term("pair", right, term("box", right)),
+                ),
+            ),
+        ) == [atom("ok")]
+        assert solve_all(
+            program(),
+            marker,
+            variant_termo(term("pair", left, left), term("pair", right, other)),
+        ) == []
+
+    def test_not_variant_termo_detects_non_variants_without_binding(self) -> None:
+        left = var("Left")
+        right = var("Right")
+        other = var("Other")
+
+        assert solve_all(
+            program(),
+            (left, right),
+            not_variant_termo(term("pair", left, left), term("pair", right, other)),
+        ) == [(left, right)]
+        assert solve_all(
+            program(),
+            left,
+            not_variant_termo(term("box", left), term("box", right)),
+        ) == []
+
+    def test_subsumes_termo_checks_instance_relationship_without_binding(self) -> None:
+        general = var("General")
+        specific = var("Specific")
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            marker,
+            conj(
+                eq(marker, "ok"),
+                subsumes_termo(term("box", general), term("box", "tea")),
+            ),
+        ) == [atom("ok")]
+        assert solve_all(
+            program(),
+            marker,
+            subsumes_termo(term("box", "tea"), term("box", specific)),
+        ) == []
+        assert solve_all(
+            program(),
+            marker,
+            subsumes_termo(
+                term("pair", general, general),
+                term("pair", "tea", "cake"),
+            ),
+        ) == []
 
     def test_difo_delays_disequality_until_later_bindings(self) -> None:
         left = var("Left")

--- a/code/packages/python/prolog-core/CHANGELOG.md
+++ b/code/packages/python/prolog-core/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- Add ISO/Core operator defaults for strict term equality and standard term
-  ordering (`==/2`, `\\==/2`, `@</2`, `@=</2`, `@>/2`, and `@>=/2`).
+- Add ISO/Core operator defaults for strict term equality, variant equality,
+  and standard term ordering (`==/2`, `\\==/2`, `=@=/2`, `\\=@=/2`, `@</2`,
+  `@=</2`, `@>/2`, and `@>=/2`).
 - Add SWI CLP(FD) operator defaults for `#=/2`, `#\=/2`, `#</2`, `#=</2`,
   `#>/2`, `#>=/2`, `in/2`, `ins/2`, and `../2`.
 

--- a/code/packages/python/prolog-core/src/prolog_core/runtime.py
+++ b/code/packages/python/prolog-core/src/prolog_core/runtime.py
@@ -977,6 +977,8 @@ def iso_operator_table() -> OperatorTable:
                 "\\=",
                 "==",
                 "\\==",
+                "=@=",
+                "\\=@=",
                 "@<",
                 "@=<",
                 "@>",

--- a/code/packages/python/prolog-core/tests/test_prolog_core.py
+++ b/code/packages/python/prolog-core/tests/test_prolog_core.py
@@ -51,6 +51,8 @@ class TestOperatorTable:
         assert iso.get(":-", "xfx") is not None
         assert iso.get("==", "xfx") is not None
         assert iso.get("\\==", "xfx") is not None
+        assert iso.get("=@=", "xfx") is not None
+        assert iso.get("\\=@=", "xfx") is not None
         assert iso.get("@<", "xfx") is not None
         assert iso.get("@=<", "xfx") is not None
         assert iso.get("@>", "xfx") is not None

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -45,6 +45,8 @@
 - adapt Prolog `current_prolog_flag/2` into read-only runtime flag
   introspection
 - adapt Prolog `set_prolog_flag/2` into branch-local runtime flag updates
+- adapt Prolog `=@=/2`, `\\=@=/2`, and `subsumes_term/2` into non-binding
+  term generality checks
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -63,6 +63,7 @@ from logic_builtins import (
     maplisto,
     nonvaro,
     not_same_termo,
+    not_variant_termo,
     noto,
     numbero,
     onceo,
@@ -82,6 +83,7 @@ from logic_builtins import (
     set_prolog_flago,
     setofo,
     stringo,
+    subsumes_termo,
     succo,
     term_variableso,
     termo_geqo,
@@ -91,6 +93,7 @@ from logic_builtins import (
     throwo,
     trueo,
     univo,
+    variant_termo,
     varo,
 )
 from logic_engine import (
@@ -364,6 +367,12 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return same_termo(*args)
     if name == "\\==" and goal.relation.arity == 2:
         return not_same_termo(*args)
+    if name == "=@=" and goal.relation.arity == 2:
+        return variant_termo(*args)
+    if name == "\\=@=" and goal.relation.arity == 2:
+        return not_variant_termo(*args)
+    if name == "subsumes_term" and goal.relation.arity == 2:
+        return subsumes_termo(*args)
     if name == "compare" and goal.relation.arity == 3:
         return compare_termo(*args)
     if name == "@<" and goal.relation.arity == 2:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -841,6 +841,18 @@ class TestPrologGoalAdapter:
             relation("dif", 2)(LogicVar(id=15), atom("tea")),
             relation("==", 2)(atom("a"), atom("a")),
             relation("\\==", 2)(atom("a"), atom("b")),
+            relation("=@=", 2)(
+                term("box", LogicVar(id=78)),
+                term("box", LogicVar(id=79)),
+            ),
+            relation("\\=@=", 2)(
+                term("pair", LogicVar(id=80), LogicVar(id=80)),
+                term("pair", LogicVar(id=81), LogicVar(id=82)),
+            ),
+            relation("subsumes_term", 2)(
+                term("box", LogicVar(id=83)),
+                term("box", atom("tea")),
+            ),
             relation("compare", 3)(atom("<"), atom("a"), atom("b")),
             relation("@<", 2)(atom("a"), atom("b")),
             relation("@=<", 2)(atom("a"), atom("b")),
@@ -1047,6 +1059,21 @@ class TestPrologGoalAdapter:
             (parsed.variables["X"], parsed.variables["Result"]),
             adapted,
         ) == [(term("box", "tea"), atom("ok"))]
+
+    def test_adapt_prolog_goal_rewrites_variant_and_subsumes_predicates(self) -> None:
+        parsed = parse_swi_query(
+            "?- pair(X, X) =@= pair(Y, Y), "
+            "pair(X, X) \\=@= pair(Y, Z), "
+            "subsumes_term(box(A), box(tea)), Result = ok.",
+        )
+
+        adapted = adapt_prolog_goal(parsed.goal)
+
+        assert solve_all(
+            program(),
+            parsed.variables["Result"],
+            adapted,
+        ) == [atom("ok")]
 
     def test_adapt_prolog_goal_rewrites_term_equality_failures(self) -> None:
         parsed_unifiable = parse_swi_query("?- X \\= box(tea).")

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -49,6 +49,8 @@
   flag introspection.
 - Run Prolog `set_prolog_flag/2` through the VM path with branch-local
   backtracking semantics.
+- Run Prolog `=@=/2`, `\\=@=/2`, and `subsumes_term/2` through the VM path for
+  source-level term generality checks.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -135,7 +135,8 @@ The package includes end-to-end stress tests for:
 - structured runtime errors for source-level arithmetic instantiation, type,
   and zero-divisor failures
 - exception control with `throw/1`, `catch/3`, and catchable runtime errors
-- term metaprogramming with `term_variables/2`
+- term metaprogramming with `term_variables/2`, `=@=/2`, `\=@=/2`, and
+  `subsumes_term/2`
 - runtime flag introspection and branch-local updates with
   `current_prolog_flag/2` and `set_prolog_flag/2`
 - finite integer builtins such as `integer/1`, `between/3`, and `succ/2`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -130,6 +130,25 @@ class TestPrologVMStress:
         assert run_compiled_prolog_query(identical) == []
         assert run_compiled_prolog_query(equal) == []
 
+    def test_term_variant_and_subsumes_predicates_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            variant_ok :-
+                pair(X, X) =@= pair(Y, Y),
+                pair(X, X) \\=@= pair(Y, Z),
+                subsumes_term(box(A), box(tea)).
+
+            ?- variant_ok,
+               Result = ok.
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"Result": atom("ok")},
+        ]
+
     def test_term_variables_runs_through_vm(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR51-prolog-term-generality.md
+++ b/code/specs/PR51-prolog-term-generality.md
@@ -1,0 +1,56 @@
+# PR51 - Prolog Term Generality Predicates
+
+## Goal
+
+Add non-binding term generality checks to the Python logic builtin layer and
+carry them through parsed Prolog source into the Logic VM path.
+
+## Motivation
+
+Full Prolog systems expose more than strict identity (`==/2`) and unification
+(`=/2`). Metaprogramming code often needs to ask whether two terms are variants
+of each other, or whether one term is more general than another, without
+binding either term. These checks are useful for clause indexing, memoization,
+deduplication, and source-transformation code.
+
+## API
+
+Library callers use:
+
+```python
+variant_termo(left, right)
+not_variant_termo(left, right)
+subsumes_termo(general, specific)
+```
+
+Parsed Prolog source uses:
+
+```prolog
+Left =@= Right
+Left \=@= Right
+subsumes_term(General, Specific)
+```
+
+## Semantics
+
+- `variant_termo/2` succeeds when two reified terms differ only by a bijective
+  variable renaming.
+- `not_variant_termo/2` succeeds when that variant relationship does not hold.
+- `subsumes_termo/2` succeeds when the second reified term is an instance of
+  the first.
+- None of these predicates bind caller variables.
+- Existing bindings are respected because inputs are reified before checking.
+
+## Parser Support
+
+`prolog-core` adds ISO/Core operator defaults for `=@=/2` and `\=@=/2` at the
+same precedence as the other term comparison predicates.
+
+## Acceptance Tests
+
+- Library tests cover positive and negative variant checks, non-variant checks,
+  and subsumption with repeated variables.
+- Loader tests prove parsed `=@=/2`, `\=@=/2`, and `subsumes_term/2` are
+  adapted into builtin goals.
+- VM stress tests prove the predicates run end to end from source through the
+  parser, loader, compiler, and Logic VM.


### PR DESCRIPTION
## Summary
- add non-binding `variant_termo/2`, `not_variant_termo/2`, and `subsumes_termo/2` builtins for term generality checks
- teach Prolog operator/runtime loading about `=@=/2`, `\=@=/2`, and `subsumes_term/2`
- add VM stress coverage plus PR51/docs/changelog updates for the new term metaprogramming layer

## Verification
- `bash BUILD` in `code/packages/python/prolog-core`
- `bash BUILD` in `code/packages/python/logic-builtins`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `.venv/bin/ruff check .` in `prolog-core`, `logic-builtins`, `prolog-loader`, and `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-term-generality -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-term-generality-build-plan.json`