### PR TITLE
Accept label designators as procedure actuals

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -1265,7 +1265,7 @@ class AlgolIrCompiler:
             raise CompileError("switch selection was not resolved")
         if execution_scope is None:
             execution_scope = scope
-        indexes = _direct_nodes(node, "arith_expr")
+        indexes = _switch_selection_indexes(node)
         if len(indexes) != 1:
             raise CompileError("switch selection requires exactly one index")
         index_value = self._compile_expr(indexes[0], scope)
@@ -1402,7 +1402,7 @@ class AlgolIrCompiler:
         selection = self.switch_selections.get(id(node))
         if selection is None:
             raise CompileError("switch selection was not resolved")
-        indexes = _direct_nodes(node, "arith_expr")
+        indexes = _switch_selection_indexes(node)
         if len(indexes) != 1:
             raise CompileError("switch selection requires exactly one index")
         index_value = self._compile_expr(indexes[0], scope)
@@ -3382,6 +3382,9 @@ class AlgolIrCompiler:
         argument: ASTNode,
         scope: _FrameScope,
     ) -> tuple[str, str] | None:
+        if self._is_label_designational_actual(argument, scope):
+            return "label", "label"
+
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
             return None
@@ -4302,10 +4305,56 @@ class AlgolIrCompiler:
         argument: ASTNode,
         scope: _FrameScope,
     ) -> int:
+        parts = _conditional_expression_parts(_meaningful_children(argument))
+        if parts is not None:
+            condition, then_expr, else_expr = parts
+            index = self._next_if_index()
+            else_label = f"label_actual_{index}_else"
+            end_label = f"label_actual_{index}_end"
+            result = self._fresh_reg()
+            condition_value = self._compile_expr(condition, scope)
+            self._emit(IrOp.BRANCH_Z, IrRegister(condition_value), IrLabel(else_label))
+            then_value = self._compile_label_actual_value(then_expr, scope)
+            self._copy_reg(dst=result, src=then_value)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(else_label)
+            else_value = self._compile_label_actual_value(else_expr, scope)
+            self._copy_reg(dst=result, src=else_value)
+            self._label(end_label)
+            return result
+
+        literal_label = _single_integer_label_expr(argument)
+        if literal_label is not None:
+            label = self._resolve_label_in_scope_chain(literal_label.value, scope)
+            if label is not None:
+                return self._const_reg(label.label_id)
+            label = self._resolve_label_in_semantic_scope(literal_label.value, scope)
+            if label is not None:
+                return self._const_reg(label.label_id)
+            raise CompileError(
+                f"label actual {literal_label.value!r} has no descriptor"
+            )
+
         variable = _single_variable_expr(argument)
-        if variable is None or _variable_subscripts(variable):
-            raise CompileError("label parameter actual must be a direct label")
+        if variable is None:
+            raise CompileError("label parameter actual must be a label designator")
         name = _variable_name(variable)
+        if name is None and _variable_subscripts(variable):
+            switch_name = _variable_head_name(variable)
+            if switch_name is None:
+                raise CompileError("label switch actual is missing a name")
+            resolved = self._resolve_symbol_in_scope_chain(switch_name.value, scope)
+            if resolved is None:
+                raise CompileError(
+                    f"label switch actual {switch_name.value!r} was not resolved"
+                )
+            symbol, _ = resolved
+            if symbol.kind != "switch":
+                raise CompileError(
+                    f"label parameter actual {switch_name.value!r} is not a "
+                    "switch selection"
+                )
+            return self._compile_switch_selection_value(variable, scope)
         if name is None:
             raise CompileError("label parameter actual is missing a name")
         resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
@@ -4334,6 +4383,43 @@ class AlgolIrCompiler:
         if label is None:
             raise CompileError(f"label actual {name.value!r} has no descriptor")
         return self._const_reg(label.label_id)
+
+    def _is_label_designational_actual(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+    ) -> bool:
+        parts = _conditional_expression_parts(_meaningful_children(argument))
+        if parts is not None:
+            _, then_expr, else_expr = parts
+            return self._is_label_designational_actual(
+                then_expr,
+                scope,
+            ) and self._is_label_designational_actual(else_expr, scope)
+
+        literal_label = _single_integer_label_expr(argument)
+        if literal_label is not None:
+            label = self._resolve_label_in_scope_chain(literal_label.value, scope)
+            if label is not None:
+                return True
+            return (
+                self._resolve_label_in_semantic_scope(literal_label.value, scope)
+                is not None
+            )
+
+        variable = _single_variable_expr(argument)
+        if variable is None:
+            return False
+        name = _variable_head_name(variable)
+        if name is None:
+            return False
+        resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
+        if resolved is None:
+            return False
+        symbol, _ = resolved
+        if _variable_subscripts(variable):
+            return symbol.kind == "switch"
+        return symbol.kind == "label"
 
     def _compile_procedure_parameter_pointer(
         self,
@@ -6798,6 +6884,18 @@ def _single_variable_expr(node: ASTNode | None) -> ASTNode | None:
     return _single_variable_expr(meaningful[0])
 
 
+def _single_integer_label_expr(node: ASTNode | None) -> Token | None:
+    if node is None:
+        return None
+    meaningful = _meaningful_children(node)
+    if len(meaningful) != 1:
+        return None
+    child = meaningful[0]
+    if isinstance(child, Token):
+        return child if child.type_name == "INTEGER_LIT" else None
+    return _single_integer_label_expr(child)
+
+
 def _variable_head_name(node: ASTNode | None) -> Token | None:
     if node is None:
         variable = None
@@ -6820,6 +6918,15 @@ def _variable_subscripts(node: ASTNode | None) -> list[ASTNode]:
         variable = node
     else:
         variable = _first_node(node, "variable")
+    subscripts = _first_direct_node(variable, "subscripts")
+    return _direct_nodes(subscripts, "arith_expr")
+
+
+def _switch_selection_indexes(node: ASTNode | None) -> list[ASTNode]:
+    direct = _direct_nodes(node, "arith_expr")
+    if direct:
+        return direct
+    variable = node if node is not None and node.rule_name == "variable" else None
     subscripts = _first_direct_node(variable, "subscripts")
     return _direct_nodes(subscripts, "arith_expr")
 

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1034,6 +1034,65 @@ class TestAlgolIrCompiler:
             == ("integer", "integer", "integer")
         )
 
+    def test_compiles_label_parameter_call_with_conditional_argument(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; boolean flag; "
+                "procedure jump(l); label l; begin goto l end; "
+                "flag := false; jump(if flag then left else right); "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+        opcodes = [instruction.opcode for instruction in result.program.instructions]
+
+        assert IrOp.BRANCH_Z in opcodes
+
+    def test_compiles_procedure_parameter_call_with_conditional_label_argument(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; boolean flag; "
+                "procedure invoke(p); procedure p; "
+                "begin p(if flag then left else right) end; "
+                "procedure jump(l); label l; begin goto l end; "
+                "flag := false; invoke(jump); "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+
+        assert (
+            result.procedure_signatures["_fn_algol_call_procedure_label"].param_types
+            == ("integer", "integer", "integer")
+        )
+
+    def test_compiles_procedure_parameter_call_with_switch_selection_label_argument(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, i; switch s := left, right; "
+                "procedure invoke(p); procedure p; begin p(s[i]) end; "
+                "procedure jump(l); label l; begin goto l end; "
+                "i := 2; invoke(jump); "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+
+        assert (
+            result.procedure_signatures["_fn_algol_call_procedure_label"].param_types
+            == ("integer", "integer", "integer")
+        )
+
     def test_compiles_procedure_parameter_call_with_switch_argument(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1419,7 +1419,7 @@ class AlgolTypeChecker:
             self._error(name_token, f"{name_token.value!r} is not a switch")
             return
 
-        indexes = _direct_nodes(node, "arith_expr")
+        indexes = _switch_selection_indexes(node)
         if len(indexes) != 1:
             self._error(node, "switch selection requires exactly one index")
             return
@@ -2260,6 +2260,22 @@ class AlgolTypeChecker:
         argument: ASTNode,
         scope: Scope,
     ) -> tuple[str, str, int | None] | None:
+        if self._check_label_designational_actual(
+            argument,
+            scope,
+            parameter_name="procedure argument",
+            report=False,
+            record=False,
+        ):
+            self._check_label_designational_actual(
+                argument,
+                scope,
+                parameter_name="procedure argument",
+                report=True,
+                record=True,
+            )
+            return LABEL, LABEL, None
+
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
             return None
@@ -2350,33 +2366,114 @@ class AlgolTypeChecker:
         scope: Scope,
         parameter: ProcedureParameter,
     ) -> Symbol | None:
-        variable = _single_variable_expr(argument)
-        if variable is None or _variable_subscripts(variable):
-            self._error(
-                argument,
-                f"label parameter {parameter.name!r} expects a direct label actual",
-            )
+        if self._check_label_designational_actual(
+            argument,
+            scope,
+            parameter_name=parameter.name,
+            report=True,
+            record=True,
+        ):
             return None
+        self._error(
+            argument,
+            f"label parameter {parameter.name!r} expects a label designational actual",
+        )
+        return None
+
+    def _check_label_designational_actual(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+        *,
+        parameter_name: str,
+        report: bool,
+        record: bool,
+    ) -> bool:
+        parts = _conditional_expression_parts(_meaningful_children(argument))
+        if parts is not None:
+            condition, then_expr, else_expr = parts
+            if report:
+                condition_type = self._infer_expr(condition, scope)
+                if condition_type != ERROR and condition_type != BOOLEAN:
+                    self._error(
+                        condition,
+                        "label designational actual condition must be boolean",
+                    )
+            then_ok = self._check_label_designational_actual(
+                then_expr,
+                scope,
+                parameter_name=parameter_name,
+                report=report,
+                record=record,
+            )
+            else_ok = self._check_label_designational_actual(
+                else_expr,
+                scope,
+                parameter_name=parameter_name,
+                report=report,
+                record=record,
+            )
+            return then_ok and else_ok
+
+        literal_label = _single_integer_label_expr(argument)
+        if literal_label is not None:
+            resolved = scope.resolve_with_scope(literal_label.value)
+            if resolved is None:
+                if report:
+                    self._error(
+                        literal_label,
+                        f"{literal_label.value!r} is not declared in block "
+                        f"{scope.block_id} or its lexical parents",
+                    )
+                return False
+            symbol, _, _ = resolved
+            if symbol.kind == LABEL:
+                return True
+            if report:
+                self._error(
+                    literal_label,
+                    f"label parameter {parameter_name!r} expects a label actual",
+                )
+            return False
+
+        variable = _single_variable_expr(argument)
+        if variable is None:
+            return False
         name = _variable_head_name(variable)
         if name is None:
-            self._error(argument, "label actual is missing a name")
-            return None
+            if report:
+                self._error(argument, "label actual is missing a name")
+            return False
         resolved = scope.resolve_with_scope(name.value)
         if resolved is None:
-            self._error(
-                name,
-                f"{name.value!r} is not declared in block {scope.block_id} "
-                "or its lexical parents",
-            )
-            return None
+            if report:
+                self._error(
+                    name,
+                    f"{name.value!r} is not declared in block {scope.block_id} "
+                    "or its lexical parents",
+                )
+            return False
         symbol, _, _ = resolved
-        if symbol.kind != LABEL:
+        if _variable_subscripts(variable):
+            if symbol.kind == SWITCH:
+                if record:
+                    self._check_switch_selection(variable, scope)
+                return True
+            if report:
+                self._error(
+                    name,
+                    f"label parameter {parameter_name!r} expects a switch "
+                    "selection or label actual",
+                )
+            return False
+        if symbol.kind == LABEL:
+            return True
+        if report:
             self._error(
                 name,
-                f"label parameter {parameter.name!r} expects a label actual",
+                f"label parameter {parameter_name!r} expects a label actual",
             )
-            return None
-        return symbol
+        return False
 
     def _check_switch_parameter_actual(
         self,
@@ -3459,6 +3556,18 @@ def _single_variable_expr(node: ASTNode | None) -> ASTNode | None:
     return _single_variable_expr(meaningful[0])
 
 
+def _single_integer_label_expr(node: ASTNode | None) -> Token | None:
+    if node is None:
+        return None
+    meaningful = _meaningful_children(node)
+    if len(meaningful) != 1:
+        return None
+    child = meaningful[0]
+    if isinstance(child, Token):
+        return child if child.type_name == "INTEGER_LIT" else None
+    return _single_integer_label_expr(child)
+
+
 def _variable_head_name_value(node: ASTNode | None) -> str | None:
     token = _variable_head_name(node)
     return token.value if token is not None else None
@@ -3496,5 +3605,14 @@ def _variable_subscripts(node: ASTNode | None) -> list[ASTNode]:
         variable = node
     else:
         variable = _first_node(node, "variable")
+    subscripts = _first_direct_node(variable, "subscripts")
+    return _direct_nodes(subscripts, "arith_expr")
+
+
+def _switch_selection_indexes(node: ASTNode | None) -> list[ASTNode]:
+    direct = _direct_nodes(node, "arith_expr")
+    if direct:
+        return direct
+    variable = node if node is not None and node.rule_name == "variable" else None
     subscripts = _first_direct_node(variable, "subscripts")
     return _direct_nodes(subscripts, "arith_expr")

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -899,6 +899,56 @@ class TestAlgolTypeChecker:
         assert parameter.kind == "label"
         assert parameter.type_name == "label"
 
+    def test_accepts_label_parameter_and_conditional_label_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result; boolean flag; "
+            "procedure jump(target); label target; begin goto target end; "
+            "flag := false; jump(if flag then left else right); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "label"
+
+    def test_accepts_label_parameter_and_numeric_label_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure jump(target); label target; begin goto target end; "
+            "jump(10); "
+            "10: result := 7 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert any(label.name == "10" for label in result.semantic.labels)
+
+    def test_accepts_label_parameter_and_switch_selection_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result, i; switch s := left, right; "
+            "procedure jump(target); label target; begin goto target end; "
+            "i := 2; jump(s[i]); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert any(
+            selection.name == "s"
+            for selection in result.semantic.switch_selections
+        )
+
     def test_accepts_value_label_parameter_and_direct_label_actual(self) -> None:
         ast = parse_algol(
             "begin integer result; "
@@ -1156,6 +1206,53 @@ class TestAlgolTypeChecker:
         shape = result.semantic.procedures[0].parameters[0].procedure_call_shapes[0]
         assert shape.argument_kinds == ("label",)
         assert shape.argument_types == ("label",)
+
+    def test_accepts_procedure_parameter_actual_with_conditional_label_formal(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; boolean flag; "
+            "procedure invoke(p); procedure p; "
+            "begin p(if flag then left else right) end; "
+            "procedure jump(l); label l; begin goto l end; "
+            "flag := false; invoke(jump); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        shape = result.semantic.procedures[0].parameters[0].procedure_call_shapes[0]
+        assert shape.argument_kinds == ("label",)
+        assert shape.argument_types == ("label",)
+
+    def test_accepts_procedure_parameter_actual_with_switch_selection_label_formal(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result, i; switch s := left, right; "
+            "procedure invoke(p); procedure p; begin p(s[i]) end; "
+            "procedure jump(l); label l; begin goto l end; "
+            "i := 2; invoke(jump); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        shape = result.semantic.procedures[0].parameters[0].procedure_call_shapes[0]
+        assert shape.argument_kinds == ("label",)
+        assert shape.argument_types == ("label",)
+        assert any(
+            selection.name == "s"
+            for selection in result.semantic.switch_selections
+        )
 
     def test_accepts_procedure_parameter_actual_with_switch_formal(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1378,6 +1378,40 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_label_parameter_accepts_conditional_designational_actual(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean flag; "
+            "procedure jump(target); label target; begin goto target end; "
+            "flag := false; jump(if flag then left else right); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_label_parameter_accepts_numeric_label_actual(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure jump(target); label target; begin goto target end; "
+            "jump(10); result := 1; "
+            "10: result := 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_label_parameter_accepts_switch_selection_actual(self) -> None:
+        result = compile_source(
+            "begin integer result, i; switch s := left, right; "
+            "procedure jump(target); label target; begin goto target end; "
+            "i := 2; jump(s[i]); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
     def test_value_label_parameter_jumps_to_caller_label(self) -> None:
         result = compile_source(
             "begin integer result; "
@@ -1401,6 +1435,35 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
+    def test_formal_procedure_call_passes_conditional_label_argument(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean flag; "
+            "procedure invoke(p); procedure p; "
+            "begin p(if flag then left else right) end; "
+            "procedure jump(target); label target; begin goto target end; "
+            "flag := false; invoke(jump); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_formal_procedure_call_passes_switch_selection_label_argument(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result, i; switch s := left, right; "
+            "procedure invoke(p); procedure p; begin p(s[i]) end; "
+            "procedure jump(target); label target; begin goto target end; "
+            "i := 2; invoke(jump); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
 
     def test_scalar_by_name_parameter_reads_forwarded_pointer(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- Accept ALGOL label designational actuals for concrete and formal procedure calls.
- Support numeric labels, conditional label expressions, and switch selections as label actuals.
- Teach type-checker metadata and IR lowering to carry switch-selection label values through procedure call dispatch.

## Verification
- `bash BUILD` in `code/packages/python/algol-type-checker` (138 passed)
- `bash BUILD` in `code/packages/python/algol-ir-compiler` (106 passed)
- `bash BUILD` in `code/packages/python/algol-wasm-compiler` (181 passed)
- `git diff --check origin/main..HEAD`
- Security sweep over added lines for process/network/filesystem/secret/deserialization/host syscall surfaces

## Notes
- This does not implement conditional switch descriptor actuals yet; that remains a separate runtime descriptor-selection gap.