### PR TITLE
feat(twig-completion): LSP code-completion items for Twig

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -445,6 +445,7 @@ members = [
     "twig-folding-ranges",
     "twig-document-symbols",
     "twig-semantic-tokens",
+    "twig-completion",
     "twig-ir-compiler",
     "lang-runtime-core",
     "lispy-runtime",

--- a/code/packages/rust/twig-completion/BUILD
+++ b/code/packages/rust/twig-completion/BUILD
@@ -1,0 +1,1 @@
+cargo test -p twig-completion -- --nocapture

--- a/code/packages/rust/twig-completion/BUILD_windows
+++ b/code/packages/rust/twig-completion/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p twig-completion -- --nocapture

--- a/code/packages/rust/twig-completion/CHANGELOG.md
+++ b/code/packages/rust/twig-completion/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog — twig-completion
+
+## [0.1.0] — 2026-05-01
+
+Initial release.  LSP code-completion items for Twig — the sixth
+piece of the Twig authoring-experience layer.
+
+### Added
+
+- `completions(source, prefix) -> Result<Vec<CompletionItem>, TwigParseError>`
+  — parses + walks.
+- `completions_for_program(&Program, prefix) -> Vec<CompletionItem>`
+  — already-parsed AST + prefix → items.
+- `CompletionItem { label, kind, detail }`.
+- `CompletionKind` enum (`#[non_exhaustive]`): `Function`,
+  `Variable`, `Keyword`, `Constant`.
+- `CompletionKind::mnemonic() -> &'static str`.
+
+### Behaviour
+
+- Items sorted: keywords (declaration order) → constants → user
+  symbols (alphabetical).
+- Six built-in keywords: `define`, `if`, `let`, `lambda`, `begin`,
+  `quote`.
+- Three built-in constants: `#t`, `#f`, `nil`.
+- User-defined symbols sourced from `twig-document-symbols`:
+  Function items carry the lambda parameter signature in `detail`;
+  Variable items have `detail = None`.
+- Prefix filter (when `Some`) is exact-prefix and case-sensitive.
+- `prefix = None` returns the full menu (editors that prefer
+  client-side fuzzy can pass `None`).
+- Output is deterministic across calls for the same input.
+
+### Notes
+
+- Pure data → typed completion-item list.  Two deps
+  (`twig-parser`, `twig-document-symbols`), both capability-empty.
+  No I/O, no FFI, no unsafe.  See `required_capabilities.json`.
+- 21 unit tests covering kind mnemonics, built-in always-present,
+  kind classification, sort order (keywords → constants →
+  symbols), keyword declaration order, alphabetical user-symbol
+  order, function/variable detail, prefix filtering (empty /
+  matching / keyword / constant / no-match / case-sensitive),
+  error path, `completions_for_program` direct path, realistic
+  four-symbol menu, and determinism.
+- Filed as follow-ups in README roadmap: snippets (`insert_text`
+  with placeholders), scope-aware suggestions (needs parser
+  threading), doc comments (needs trivia channel), LSP wire
+  encoding.

--- a/code/packages/rust/twig-completion/Cargo.toml
+++ b/code/packages/rust/twig-completion/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "twig-completion"
+version = "0.1.0"
+edition = "2021"
+description = "LSP code-completion items for Twig — the editor 'autocomplete this' feed.  Walks a parsed Program plus an optional partial-typed prefix and returns user-defined symbols, built-in keywords, and constant literals."
+
+[dependencies]
+twig-document-symbols = { path = "../twig-document-symbols" }
+twig-parser = { path = "../twig-parser" }

--- a/code/packages/rust/twig-completion/README.md
+++ b/code/packages/rust/twig-completion/README.md
@@ -1,0 +1,155 @@
+# twig-completion
+
+**LSP code-completion items for Twig.**  Walks a parsed
+`twig_parser::Program` plus an optional partial-typed prefix and
+returns the editor's autocomplete menu — defined symbols + built-
+in keywords + constant literals.  Drives
+`textDocument/completion`.
+
+The **sixth piece of the Twig authoring-experience layer**
+(alongside [`twig-formatter`](../twig-formatter/),
+[`twig-semantic-tokens`](../twig-semantic-tokens/),
+[`twig-document-symbols`](../twig-document-symbols/),
+[`twig-folding-ranges`](../twig-folding-ranges/),
+[`twig-hover`](../twig-hover/)).
+
+---
+
+## What's surfaced
+
+| Source                                           | `CompletionKind` | `detail`               |
+|--------------------------------------------------|------------------|------------------------|
+| Top-level `(define name (lambda params body))`   | `Function`       | `"(params)"`           |
+| Top-level `(define name expr)` (any other)       | `Variable`       | `None`                 |
+| Built-in keyword (`if`/`let`/`lambda`/`begin`/`define`/`quote`) | `Keyword` | `None`        |
+| Constant literal (`#t`/`#f`/`nil`)               | `Constant`       | `None`                 |
+
+## Public API
+
+```rust
+pub fn completions(
+    source: &str,
+    prefix: Option<&str>,
+) -> Result<Vec<CompletionItem>, TwigParseError>;
+
+pub fn completions_for_program(
+    program: &Program,
+    prefix: Option<&str>,
+) -> Vec<CompletionItem>;
+
+pub struct CompletionItem {
+    pub label:  String,
+    pub kind:   CompletionKind,
+    pub detail: Option<String>,
+}
+
+pub enum CompletionKind {  // #[non_exhaustive]
+    Function, Variable, Keyword, Constant,
+}
+```
+
+`CompletionKind::mnemonic() -> &'static str` returns lowercase
+strings (`"function"`, `"variable"`, `"keyword"`, `"constant"`).
+
+## Output order
+
+Items come back sorted: **keywords first** (in declaration order
+— `define`, `if`, `let`, `lambda`, `begin`, `quote`), **constants
+next** (`#t`, `#f`, `nil`), then **user-defined symbols in name
+order** (alphabetical).  Matches what most editor completion menus
+expect when no score-based ranking is supplied.
+
+## Prefix filtering
+
+When `prefix` is `Some`, items whose `label` doesn't start with
+it are filtered out.  When `None`, every item is returned.
+Editors typically pass the substring already typed before the
+cursor (for `(squa|` the prefix is `"squa"`).
+
+Exact-prefix and case-sensitive — editors that want fuzzy
+matching pass `prefix = None` and run their own client-side
+fuzzy matcher.
+
+## What this crate does NOT do
+
+- **No fuzzy match.**  Pass `None` for client-side fuzzy.
+- **No snippets.**  V1 emits `label` only; no `insert_text`
+  templates like `(if ${1:cond} ${2:then} ${3:else})`.
+- **No scope-aware suggestions.**  Parameters and let-bindings
+  aren't surfaced (the parser doesn't thread per-binding
+  positions).  Tracks alongside `twig-hover`'s scope-resolution
+  follow-up.
+- **No LSP wire encoding.**  Returns a typed
+  `Vec<CompletionItem>`; the JSON `CompletionItem[]` shape is
+  one level up.
+
+## Caller responsibilities
+
+Inherits the non-guarantees of `twig-parser` and
+`twig-document-symbols`.
+
+---
+
+## Example
+
+```rust
+use twig_completion::{completions, CompletionKind};
+
+let src = "\
+(define greeting 'hello)
+(define (square x) (* x x))
+(define pi 3)";
+
+// Unfiltered — full menu.
+let items = completions(src, None).unwrap();
+assert_eq!(items.len(), 6 + 3 + 3);  // 6 kw + 3 const + 3 user
+
+// Prefix-filtered — only items starting with "sq".
+let items = completions(src, Some("sq")).unwrap();
+assert_eq!(items.len(), 1);
+assert_eq!(items[0].label, "square");
+assert_eq!(items[0].kind, CompletionKind::Function);
+assert_eq!(items[0].detail.as_deref(), Some("(x)"));
+```
+
+---
+
+## Dependencies
+
+- [`twig-parser`](../twig-parser/) — Twig source → typed AST.
+- [`twig-document-symbols`](../twig-document-symbols/) — top-level
+  define table.
+
+That's it.  No I/O, no FFI, no unsafe.  See `required_capabilities.json`.
+
+---
+
+## Tests
+
+21 unit tests covering `CompletionKind` mnemonics, builtin items
+always-present (keywords + constants), kind classification, sort
+order (keywords → constants → symbols), keyword declaration
+order, alphabetical user-symbol order, function detail = signature,
+variable detail = none, prefix filtering (empty / matching /
+keyword / constant / no-match / case-sensitive), error path,
+`completions_for_program` direct path, a realistic four-symbol
+menu, and determinism across calls.
+
+```sh
+cargo test -p twig-completion
+```
+
+---
+
+## Roadmap
+
+- **Snippets.**  Add `insert_text: Option<String>` with snippet
+  templates (`(if ${1:cond} ${2:then} ${3:else})`) so editors
+  can offer parameter placeholders for compound forms.
+- **Scope-aware suggestions.**  Once `twig-parser` threads per-
+  binding positions, surface parameters and let-bindings in
+  scope at the cursor.
+- **Documentation comments.**  Once the lexer grows a trivia
+  channel, populate a `documentation: Option<String>` field.
+- **LSP wire encoding.**  `twig-lsp` consumes this typed Vec and
+  maps to LSP's `CompletionList` JSON shape.

--- a/code/packages/rust/twig-completion/required_capabilities.json
+++ b/code/packages/rust/twig-completion/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/twig-completion",
+  "capabilities": [],
+  "justification": "Pure data → typed completion-item list: walks twig-document-symbols + builtin keywords + literal constants, optionally prefix-filters, returns Vec<CompletionItem>.  No I/O, no FFI, no filesystem/network/process/env access.  Two deps (twig-parser, twig-document-symbols) — both empty."
+}

--- a/code/packages/rust/twig-completion/src/lib.rs
+++ b/code/packages/rust/twig-completion/src/lib.rs
@@ -1,0 +1,450 @@
+//! # `twig-completion` — LSP code-completion items for Twig.
+//!
+//! Walks a parsed [`twig_parser::Program`] plus an optional
+//! partial-typed prefix and returns the editor's autocomplete
+//! menu — defined symbols + built-in keywords + constant
+//! literals.  Drives `textDocument/completion`.
+//!
+//! The **sixth piece of the Twig authoring-experience layer**
+//! (alongside [`twig-formatter`](../twig-formatter/),
+//! [`twig-semantic-tokens`](../twig-semantic-tokens/),
+//! [`twig-document-symbols`](../twig-document-symbols/),
+//! [`twig-folding-ranges`](../twig-folding-ranges/),
+//! [`twig-hover`](../twig-hover/)).
+//!
+//! ## What's surfaced
+//!
+//! | Source                                           | `CompletionKind` | `detail`               |
+//! |--------------------------------------------------|------------------|------------------------|
+//! | Top-level `(define name (lambda params body))`   | `Function`       | `"(params)"`           |
+//! | Top-level `(define name expr)` (any other)       | `Variable`       | `None`                 |
+//! | Built-in keyword (`if`/`let`/`lambda`/`begin`/`define`/`quote`) | `Keyword` | `None`        |
+//! | Constant literal (`#t`/`#f`/`nil`)               | `Constant`       | `None`                 |
+//!
+//! ## Public API
+//!
+//! - [`completions(source, prefix)`] — `&str` + `Option<&str>` →
+//!   `Result<Vec<CompletionItem>, TwigParseError>`.  The common case.
+//! - [`completions_for_program(program, prefix)`] — already-parsed
+//!   `&Program` + `Option<&str>` → `Vec<CompletionItem>`.
+//!
+//! When `prefix` is `Some`, items whose `label` doesn't start with
+//! it are filtered out.  When `None`, every item is returned.
+//! Editors typically pass the substring already typed before the
+//! cursor, e.g. for `(squa|` the prefix is `"squa"`.
+//!
+//! Items come back sorted: keywords first (in declaration order),
+//! constants next, then user-defined symbols in name order.  This
+//! matches what most editor completion menus expect when no
+//! score-based ranking is supplied.
+//!
+//! ## What this crate does NOT do
+//!
+//! - **No fuzzy match.**  Prefix filtering is exact.  Editors that
+//!   want fuzzy matching should pass `prefix = None` and run their
+//!   own client-side fuzzy matcher.
+//! - **No snippets.**  `(if ${1:cond} ${2:then} ${3:else})` would
+//!   be a separate `insert_text` field; v1 only emits `label`.
+//! - **No scope-aware suggestions.**  Parameters and let-bindings
+//!   aren't surfaced (the parser doesn't thread per-binding
+//!   positions).  Fixes alongside `twig-hover`'s scope-resolution
+//!   follow-up.
+//! - **No LSP wire encoding.**  Returns a typed `Vec<CompletionItem>`;
+//!   the JSON `CompletionItem[]` shape is one level up.
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+use std::fmt;
+
+use twig_document_symbols::{symbols_for_program, DocumentSymbol, SymbolKind};
+use twig_parser::{parse, Program, TwigParseError};
+
+// ---------------------------------------------------------------------------
+// CompletionKind
+// ---------------------------------------------------------------------------
+
+/// Classification of a completion item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CompletionKind {
+    /// User-defined function (a `(define name (lambda …))`).
+    Function,
+    /// User-defined value (a `(define name expr)` for non-lambda
+    /// `expr`).
+    Variable,
+    /// Built-in keyword (`if`, `let`, `lambda`, `begin`, `define`,
+    /// `quote`).
+    Keyword,
+    /// Constant literal (`#t`, `#f`, `nil`).
+    Constant,
+}
+
+impl CompletionKind {
+    /// Stable lowercase mnemonic.
+    pub fn mnemonic(self) -> &'static str {
+        match self {
+            CompletionKind::Function => "function",
+            CompletionKind::Variable => "variable",
+            CompletionKind::Keyword => "keyword",
+            CompletionKind::Constant => "constant",
+        }
+    }
+}
+
+impl fmt::Display for CompletionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.mnemonic())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CompletionItem
+// ---------------------------------------------------------------------------
+
+/// One menu entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionItem {
+    /// What the user sees and what gets inserted.
+    pub label: String,
+    /// Classification.
+    pub kind: CompletionKind,
+    /// Optional one-line summary surfaced next to the label
+    /// (e.g. lambda parameter signature).
+    pub detail: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Built-in items
+// ---------------------------------------------------------------------------
+
+/// The six Twig keywords surfaced for completion, in declaration
+/// order — matches the order users learn them.
+const BUILTIN_KEYWORDS: &[&str] = &["define", "if", "let", "lambda", "begin", "quote"];
+
+/// The three constant literals.
+const BUILTIN_CONSTANTS: &[&str] = &["#t", "#f", "nil"];
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// Parse `source` and return completion items, optionally filtered
+/// to those whose `label` starts with `prefix`.
+pub fn completions(
+    source: &str,
+    prefix: Option<&str>,
+) -> Result<Vec<CompletionItem>, TwigParseError> {
+    let program = parse(source)?;
+    Ok(completions_for_program(&program, prefix))
+}
+
+/// Walk an already-parsed `Program` and return completion items,
+/// optionally filtered.
+pub fn completions_for_program(program: &Program, prefix: Option<&str>) -> Vec<CompletionItem> {
+    let mut out: Vec<CompletionItem> = Vec::new();
+
+    // Keywords first — matches the editor convention of grouping
+    // language constructs above user code.
+    for kw in BUILTIN_KEYWORDS {
+        out.push(CompletionItem {
+            label: (*kw).to_owned(),
+            kind: CompletionKind::Keyword,
+            detail: None,
+        });
+    }
+    // Constants next.
+    for c in BUILTIN_CONSTANTS {
+        out.push(CompletionItem {
+            label: (*c).to_owned(),
+            kind: CompletionKind::Constant,
+            detail: None,
+        });
+    }
+
+    // User-defined symbols, sorted by name for deterministic output.
+    let mut symbols = symbols_for_program(program);
+    symbols.sort_by(|a, b| a.name.cmp(&b.name));
+    for sym in &symbols {
+        out.push(item_for_symbol(sym));
+    }
+
+    if let Some(p) = prefix {
+        out.retain(|c| c.label.starts_with(p));
+    }
+    out
+}
+
+fn item_for_symbol(sym: &DocumentSymbol) -> CompletionItem {
+    let kind = match sym.kind {
+        SymbolKind::Function => CompletionKind::Function,
+        SymbolKind::Variable => CompletionKind::Variable,
+        // SymbolKind is `#[non_exhaustive]`; future variants
+        // surface as Variable until this crate is updated.
+        _ => CompletionKind::Variable,
+    };
+    CompletionItem {
+        label: sym.name.clone(),
+        kind,
+        detail: sym.detail.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cs(src: &str) -> Vec<CompletionItem> {
+        completions(src, None).expect("parse")
+    }
+
+    fn cs_prefix(src: &str, prefix: &str) -> Vec<CompletionItem> {
+        completions(src, Some(prefix)).expect("parse")
+    }
+
+    fn labels(items: &[CompletionItem]) -> Vec<&str> {
+        items.iter().map(|c| c.label.as_str()).collect()
+    }
+
+    // ---------- CompletionKind ----------
+
+    #[test]
+    fn completion_kind_mnemonics_distinct() {
+        let all = [
+            CompletionKind::Function,
+            CompletionKind::Variable,
+            CompletionKind::Keyword,
+            CompletionKind::Constant,
+        ];
+        let mut mns: Vec<&'static str> = all.iter().map(|k| k.mnemonic()).collect();
+        mns.sort();
+        mns.dedup();
+        assert_eq!(mns.len(), all.len());
+    }
+
+    #[test]
+    fn completion_kind_displays_as_mnemonic() {
+        assert_eq!(format!("{}", CompletionKind::Function), "function");
+    }
+
+    // ---------- Built-in items always present ----------
+
+    #[test]
+    fn empty_program_still_yields_keywords_and_constants() {
+        let items = cs("");
+        let lbls = labels(&items);
+        // All keywords present.
+        for kw in BUILTIN_KEYWORDS {
+            assert!(lbls.contains(kw), "missing keyword {kw}");
+        }
+        // All constants present.
+        for c in BUILTIN_CONSTANTS {
+            assert!(lbls.contains(c), "missing constant {c}");
+        }
+    }
+
+    #[test]
+    fn keyword_items_are_keyword_kind() {
+        let items = cs("");
+        let kw_items: Vec<&CompletionItem> = items
+            .iter()
+            .filter(|c| c.kind == CompletionKind::Keyword)
+            .collect();
+        assert_eq!(kw_items.len(), BUILTIN_KEYWORDS.len());
+    }
+
+    #[test]
+    fn constant_items_are_constant_kind() {
+        let items = cs("");
+        let cnt_items: Vec<&CompletionItem> = items
+            .iter()
+            .filter(|c| c.kind == CompletionKind::Constant)
+            .collect();
+        assert_eq!(cnt_items.len(), BUILTIN_CONSTANTS.len());
+    }
+
+    // ---------- Order: keywords → constants → symbols ----------
+
+    #[test]
+    fn order_keywords_first_then_constants_then_symbols() {
+        let items = cs("(define b 1) (define a 2)");
+        // Find the first keyword index, first constant index,
+        // first symbol (Variable) index.
+        let mut first_kw = None;
+        let mut first_const = None;
+        let mut first_sym = None;
+        for (i, c) in items.iter().enumerate() {
+            match c.kind {
+                CompletionKind::Keyword => {
+                    if first_kw.is_none() {
+                        first_kw = Some(i);
+                    }
+                }
+                CompletionKind::Constant => {
+                    if first_const.is_none() {
+                        first_const = Some(i);
+                    }
+                }
+                CompletionKind::Variable | CompletionKind::Function => {
+                    if first_sym.is_none() {
+                        first_sym = Some(i);
+                    }
+                }
+            }
+        }
+        assert!(first_kw.unwrap() < first_const.unwrap());
+        assert!(first_const.unwrap() < first_sym.unwrap());
+    }
+
+    #[test]
+    fn user_symbols_sorted_alphabetically() {
+        let items = cs("(define banana 1) (define apple 2) (define cherry 3)");
+        let symbol_labels: Vec<&str> = items
+            .iter()
+            .filter(|c| matches!(c.kind, CompletionKind::Variable | CompletionKind::Function))
+            .map(|c| c.label.as_str())
+            .collect();
+        assert_eq!(symbol_labels, vec!["apple", "banana", "cherry"]);
+    }
+
+    #[test]
+    fn keyword_order_is_declaration_order() {
+        let items = cs("");
+        let keyword_labels: Vec<&str> = items
+            .iter()
+            .filter(|c| c.kind == CompletionKind::Keyword)
+            .map(|c| c.label.as_str())
+            .collect();
+        // Must match BUILTIN_KEYWORDS verbatim.
+        assert_eq!(keyword_labels, BUILTIN_KEYWORDS.to_vec());
+    }
+
+    // ---------- User symbols ----------
+
+    #[test]
+    fn user_function_has_signature_detail() {
+        let items = cs("(define (square x) (* x x))");
+        let square = items.iter().find(|c| c.label == "square").unwrap();
+        assert_eq!(square.kind, CompletionKind::Function);
+        assert_eq!(square.detail.as_deref(), Some("(x)"));
+    }
+
+    #[test]
+    fn user_variable_has_no_detail() {
+        let items = cs("(define greeting 'hello)");
+        let g = items.iter().find(|c| c.label == "greeting").unwrap();
+        assert_eq!(g.kind, CompletionKind::Variable);
+        assert!(g.detail.is_none());
+    }
+
+    // ---------- Prefix filtering ----------
+
+    #[test]
+    fn empty_prefix_keeps_everything() {
+        let with_none = cs("(define x 1)");
+        let with_empty = cs_prefix("(define x 1)", "");
+        assert_eq!(with_none.len(), with_empty.len());
+    }
+
+    #[test]
+    fn prefix_filters_to_matching_items_only() {
+        let items = cs_prefix("(define apple 1) (define banana 2)", "ap");
+        let lbls = labels(&items);
+        assert_eq!(lbls, vec!["apple"]);
+    }
+
+    #[test]
+    fn prefix_matches_keywords_too() {
+        let items = cs_prefix("", "le");
+        let lbls = labels(&items);
+        assert_eq!(lbls, vec!["let"]);
+    }
+
+    #[test]
+    fn prefix_matches_constants_too() {
+        let items = cs_prefix("", "#");
+        let lbls = labels(&items);
+        // #t and #f.  nil starts with `n`, not `#`.
+        assert_eq!(lbls, vec!["#t", "#f"]);
+    }
+
+    #[test]
+    fn prefix_no_match_returns_empty() {
+        let items = cs_prefix("(define x 1)", "zzz");
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn prefix_is_case_sensitive() {
+        let items = cs_prefix("(define MyVar 1)", "my");
+        // `MyVar` doesn't start with lowercase `my`.
+        let lbls = labels(&items);
+        assert!(!lbls.contains(&"MyVar"));
+    }
+
+    // ---------- Errors ----------
+
+    #[test]
+    fn unparseable_input_returns_parse_error() {
+        let err = completions("(unbalanced", None).unwrap_err();
+        let _ = err;
+    }
+
+    // ---------- completions_for_program direct path ----------
+
+    #[test]
+    fn completions_for_program_skips_parse() {
+        let p = twig_parser::parse("(define x 1)").expect("parse");
+        let items = completions_for_program(&p, None);
+        assert!(items.iter().any(|c| c.label == "x"));
+    }
+
+    #[test]
+    fn completions_for_program_with_prefix() {
+        let p = twig_parser::parse("(define apple 1) (define banana 2)").expect("parse");
+        let items = completions_for_program(&p, Some("ban"));
+        assert_eq!(labels(&items), vec!["banana"]);
+    }
+
+    // ---------- Realistic ----------
+
+    #[test]
+    fn realistic_program_yields_expected_menu() {
+        let src = "(define greeting 'hello)\n\
+                   (define (square x) (* x x))\n\
+                   (define (factorial n) (if (= n 0) 1 (* n (factorial (- n 1)))))\n\
+                   (define pi 3)";
+        let items = cs(src);
+        // 6 keywords + 3 constants + 4 user symbols
+        assert_eq!(items.len(), 6 + 3 + 4);
+
+        // User symbols sorted: factorial, greeting, pi, square.
+        let user: Vec<&CompletionItem> = items
+            .iter()
+            .filter(|c| {
+                matches!(c.kind, CompletionKind::Function | CompletionKind::Variable)
+            })
+            .collect();
+        let user_labels: Vec<&str> = user.iter().map(|c| c.label.as_str()).collect();
+        assert_eq!(user_labels, vec!["factorial", "greeting", "pi", "square"]);
+
+        // factorial is a function with detail "(n)".
+        let fact = user.iter().find(|c| c.label == "factorial").unwrap();
+        assert_eq!(fact.kind, CompletionKind::Function);
+        assert_eq!(fact.detail.as_deref(), Some("(n)"));
+    }
+
+    // ---------- Determinism ----------
+
+    #[test]
+    fn output_is_deterministic_across_calls() {
+        let src = "(define z 1) (define a 2) (define m 3)";
+        let a = cs(src);
+        let b = cs(src);
+        assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary

- New crate **`twig-completion`** — the **sixth piece of the Twig authoring-experience layer** (alongside [`twig-formatter`](https://github.com/adhithyan15/coding-adventures/pull/1858), [`twig-semantic-tokens`](https://github.com/adhithyan15/coding-adventures/pull/1861), [`twig-document-symbols`](https://github.com/adhithyan15/coding-adventures/pull/1862), [`twig-folding-ranges`](https://github.com/adhithyan15/coding-adventures/pull/1863), [`twig-hover`](https://github.com/adhithyan15/coding-adventures/pull/1872)).
- Walks a parsed `Program` plus an optional prefix and returns the editor's autocomplete menu — defined symbols + built-in keywords + constant literals. Drives `textDocument/completion`.
- Pure data → typed list. **Zero capabilities.** Two deps (`twig-parser`, `twig-document-symbols`), both empty.

## Public API

```rust
pub fn completions(source: &str, prefix: Option<&str>) -> Result<Vec<CompletionItem>, TwigParseError>;
pub fn completions_for_program(program: &Program, prefix: Option<&str>) -> Vec<CompletionItem>;

pub struct CompletionItem {
    pub label:  String,
    pub kind:   CompletionKind,
    pub detail: Option<String>,
}

pub enum CompletionKind {  // #[non_exhaustive]
    Function, Variable, Keyword, Constant,
}
```

## What's surfaced

| Source | `CompletionKind` | `detail` |
|--------|------------------|----------|
| `(define name (lambda params body))` | `Function` | `"(params)"` |
| `(define name expr)` (other expr)    | `Variable` | `None`     |
| Built-in keyword (`if`/`let`/`lambda`/`begin`/`define`/`quote`) | `Keyword` | `None` |
| Constant literal (`#t`/`#f`/`nil`)   | `Constant` | `None`     |

## Output order

Items come back sorted: **keywords first** (in declaration order — `define`, `if`, `let`, `lambda`, `begin`, `quote`), **constants next** (`#t`, `#f`, `nil`), then **user-defined symbols in name order** (alphabetical).

## Prefix filtering

When `prefix` is `Some`, items whose `label` doesn't start with it are filtered out. Exact-prefix and case-sensitive — editors that want fuzzy matching pass `prefix = None` and run their own client-side fuzzy matcher.

## Out of scope (filed as follow-ups)

- **Snippets** — `insert_text` with placeholders (`(if ${1:cond} …)`).
- **Scope-aware suggestions** for params and let-bindings — needs parser threading.
- **Doc comments** — needs lexer trivia channel.
- **LSP wire encoding** — separate `twig-lsp` crate.

## Test plan

- [x] `cargo build -p twig-completion` passes
- [x] `cargo test -p twig-completion` — **21 tests, all green**
- [x] `cargo clippy -p twig-completion --no-deps --all-targets -- -D warnings` — clean
- [x] `cargo metadata` parses (workspace member registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)