### PR TITLE
feat(prolog): add term text io predicates

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -55,6 +55,8 @@
   finite text goals
 - adapt Prolog text inspection predicates `atom_length/2`, `string_length/2`,
   `sub_atom/5`, and `sub_string/5` into finite text goals
+- adapt Prolog term text I/O predicates `term_to_atom/2` and `atom_to_term/3`
+  through the parser boundary
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -17,6 +17,8 @@ It keeps parsing side-effect free, then exposes helpers to:
   `atomic_list_concat/2,3`, and `number_string/2`
 - adapt text inspection builtins such as `atom_length/2`, `string_length/2`,
   `sub_atom/5`, and `sub_string/5`
+- adapt term text I/O builtins such as `term_to_atom/2` and `atom_to_term/3`
+  through the parser boundary
 - adapt callable CLP(FD) forms such as `in/2`, `ins/2`, `#=/2`,
   `all_different/1`, and `labeling/2`
 - flatten nested additive CLP(FD) equality expressions such as

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import re
+from collections.abc import Callable, Iterator
 
 from logic_builtins import (
     abolisho,
@@ -120,7 +121,11 @@ from logic_engine import (
     GoalExpr,
     LogicVar,
     NeqExpr,
+    Number,
+    Program,
     RelationCall,
+    State,
+    String,
     Term,
     atom,
     conj,
@@ -128,7 +133,11 @@ from logic_engine import (
     eq,
     fresh,
     goal_from_term,
+    logic_list,
+    native_goal,
+    reify,
     relation,
+    solve_from,
     term,
 )
 from logic_stdlib import (
@@ -148,10 +157,14 @@ from logic_stdlib import (
     sorto,
 )
 from prolog_core import expand_dcg_phrase
+from prolog_parser import PrologParseError
+from swi_prolog_parser import parse_swi_term
 
 _PREDICATE_INDICATOR = relation("/", 2)
 _IF_THEN = "->"
 _FD_REIFIABLE_RELATIONS = frozenset({"#=", "#\\=", "#<", "#=<", "#>", "#>="})
+_PLAIN_ATOM_RE = re.compile(r"^[a-z][A-Za-z0-9_]*$")
+_VARIABLE_RE = re.compile(r"^(?:[A-Z_][A-Za-z0-9_]*)$")
 type IndicatorBuilder = Callable[[Term, Term], GoalExpr]
 
 
@@ -368,6 +381,10 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return copytermo(*args)
     if name == "term_variables" and goal.relation.arity == 2:
         return term_variableso(*args)
+    if name == "term_to_atom" and goal.relation.arity == 2:
+        return _term_to_atom_goal(*args)
+    if name == "atom_to_term" and goal.relation.arity == 3:
+        return _atom_to_term_goal(*args)
     if name == "atom_concat" and goal.relation.arity == 3:
         return atom_concato(*args)
     if name == "atom_length" and goal.relation.arity == 2:
@@ -452,6 +469,136 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return goal if property_goal is None else property_goal
 
     return goal
+
+
+def _term_to_atom_goal(term_value: object, atom_value: object) -> GoalExpr:
+    def run(
+        program_value: Program,
+        state: State,
+        args: tuple[Term, ...],
+    ) -> Iterator[State]:
+        term_arg, atom_arg = args
+        reified_term = reify(term_arg, state.substitution)
+        reified_atom = reify(atom_arg, state.substitution)
+
+        if not isinstance(reified_term, LogicVar):
+            rendered = _render_prolog_term(reified_term)
+            yield from solve_from(program_value, eq(atom_arg, atom(rendered)), state)
+            return
+
+        if not isinstance(reified_atom, Atom):
+            return
+        parsed = _parse_atom_text(reified_atom)
+        if parsed is None:
+            return
+        yield from solve_from(program_value, eq(term_arg, parsed.term), state)
+
+    return native_goal(run, term_value, atom_value)
+
+
+def _atom_to_term_goal(
+    atom_value: object,
+    term_value: object,
+    bindings: object,
+) -> GoalExpr:
+    def run(
+        program_value: Program,
+        state: State,
+        args: tuple[Term, ...],
+    ) -> Iterator[State]:
+        atom_arg, term_arg, bindings_arg = args
+        reified_atom = reify(atom_arg, state.substitution)
+        if not isinstance(reified_atom, Atom):
+            return
+
+        parsed = _parse_atom_text(reified_atom)
+        if parsed is None:
+            return
+        yield from solve_from(
+            program_value,
+            conj(
+                eq(term_arg, parsed.term),
+                eq(bindings_arg, _variable_bindings(parsed.variables)),
+            ),
+            state,
+        )
+
+    return native_goal(run, atom_value, term_value, bindings)
+
+
+def _parse_atom_text(atom_value: Atom) -> object | None:
+    try:
+        return parse_swi_term(atom_value.symbol.name)
+    except PrologParseError:
+        return None
+
+
+def _variable_bindings(variables: dict[str, LogicVar]) -> Term:
+    return logic_list(
+        [term("=", atom(name), variable) for name, variable in variables.items()],
+    )
+
+
+def _render_prolog_term(term_value: Term) -> str:
+    list_text = _render_list(term_value)
+    if list_text is not None:
+        return list_text
+    if isinstance(term_value, Atom):
+        return _render_atom(term_value.symbol.name)
+    if isinstance(term_value, Number):
+        return str(term_value.value)
+    if isinstance(term_value, String):
+        return '"' + _escape_string(term_value.value) + '"'
+    if isinstance(term_value, LogicVar):
+        return _render_variable(term_value)
+    if isinstance(term_value, Compound):
+        args = ", ".join(_render_prolog_term(argument) for argument in term_value.args)
+        return f"{_render_functor(term_value.functor.name)}({args})"
+    raise TypeError(f"cannot render {type(term_value).__name__} as Prolog term")
+
+
+def _render_list(term_value: Term) -> str | None:
+    items: list[str] = []
+    current = term_value
+    while (
+        isinstance(current, Compound)
+        and current.functor.name == "."
+        and len(current.args) == 2
+    ):
+        items.append(_render_prolog_term(current.args[0]))
+        current = current.args[1]
+    if isinstance(current, Atom) and current.symbol.name == "[]":
+        return "[" + ", ".join(items) + "]"
+    if items:
+        return "[" + ", ".join(items) + " | " + _render_prolog_term(current) + "]"
+    return None
+
+
+def _render_functor(name: str) -> str:
+    if _PLAIN_ATOM_RE.fullmatch(name) or name in {"!", "[]"}:
+        return name
+    return "'" + _escape_atom(name) + "'"
+
+
+def _render_atom(name: str) -> str:
+    if _PLAIN_ATOM_RE.fullmatch(name) or name in {"!", "[]"}:
+        return name
+    return "'" + _escape_atom(name) + "'"
+
+
+def _render_variable(variable: LogicVar) -> str:
+    name = None if variable.display_name is None else variable.display_name.name
+    if name is not None and _VARIABLE_RE.fullmatch(name):
+        return name
+    return f"_G{abs(variable.id)}"
+
+
+def _escape_atom(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _escape_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _adapt_fd_equality(left: Term, right: Term) -> GoalExpr:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -954,6 +954,12 @@ class TestPrologGoalAdapter:
                 term("box", LogicVar(id=16)),
                 LogicVar(id=17),
             ),
+            relation("term_to_atom", 2)(term("box", atom("tea")), LogicVar(id=84)),
+            relation("atom_to_term", 3)(
+                atom("box(X)"),
+                LogicVar(id=85),
+                LogicVar(id=86),
+            ),
             relation("current_prolog_flag", 2)(
                 atom("unknown"),
                 LogicVar(id=18),
@@ -1127,12 +1133,14 @@ class TestPrologGoalAdapter:
             "string_chars(String, [h, i]), "
             "string_length(\"hello\", StringLength), "
             "sub_string(\"logic\", 2, 2, 1, SubString), "
+            "term_to_atom(pair(tea, [cup, cake]), RenderedTerm), "
+            "atom_to_term('pair(X, tea)', ParsedTerm, Bindings), "
             'string_codes("ok", Codes).',
         )
 
         adapted = adapt_prolog_goal(parsed.goal)
 
-        assert solve_all(
+        answers = solve_all(
             program(),
             (
                 parsed.variables["Chars"],
@@ -1150,29 +1158,38 @@ class TestPrologGoalAdapter:
                 parsed.variables["String"],
                 parsed.variables["StringLength"],
                 parsed.variables["SubString"],
+                parsed.variables["RenderedTerm"],
+                parsed.variables["ParsedTerm"],
+                parsed.variables["Bindings"],
                 parsed.variables["Codes"],
             ),
             adapted,
-        ) == [
-            (
-                logic_list(["t", "e", "a"]),
-                atom("tea"),
-                num(42),
-                num(3.5),
-                num(7),
-                atom("teacup"),
-                atom("tea"),
-                num(6),
-                atom("cup"),
-                atom("tea-2-go"),
-                logic_list(["tea", "cup"]),
-                atom("Z"),
-                string("hi"),
-                num(5),
-                string("gi"),
-                logic_list([111, 107]),
-            ),
-        ]
+        )
+        assert len(answers) == 1
+        answer = answers[0]
+        parsed_term = answer[16]
+        assert isinstance(parsed_term, Compound)
+        assert answer == (
+            logic_list(["t", "e", "a"]),
+            atom("tea"),
+            num(42),
+            num(3.5),
+            num(7),
+            atom("teacup"),
+            atom("tea"),
+            num(6),
+            atom("cup"),
+            atom("tea-2-go"),
+            logic_list(["tea", "cup"]),
+            atom("Z"),
+            string("hi"),
+            num(5),
+            string("gi"),
+            atom("pair(tea, [cup, cake])"),
+            term("pair", parsed_term.args[0], "tea"),
+            logic_list([term("=", "X", parsed_term.args[0])]),
+            logic_list([111, 107]),
+        )
 
     def test_adapt_prolog_goal_rewrites_term_equality_failures(self) -> None:
         parsed_unifiable = parse_swi_query("?- X \\= box(tea).")

--- a/code/packages/python/prolog-operator-parser/CHANGELOG.md
+++ b/code/packages/python/prolog-operator-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added `ParsedOperatorTerm` and `parse_operator_named_term_tokens(...)` so
+  dialect frontends can parse one term while retaining named variable bindings.
+
 ## 0.1.0
 
 - Added a token-level operator-aware Prolog parser shared by dialect frontends

--- a/code/packages/python/prolog-operator-parser/src/prolog_operator_parser/__init__.py
+++ b/code/packages/python/prolog-operator-parser/src/prolog_operator_parser/__init__.py
@@ -2,8 +2,10 @@
 
 from prolog_operator_parser.parser import (
     ParsedOperatorSource,
+    ParsedOperatorTerm,
     __version__,
     parse_operator_goal_tokens,
+    parse_operator_named_term_tokens,
     parse_operator_program_tokens,
     parse_operator_query_tokens,
     parse_operator_source_tokens,
@@ -13,7 +15,9 @@ from prolog_operator_parser.parser import (
 __all__ = [
     "__version__",
     "ParsedOperatorSource",
+    "ParsedOperatorTerm",
     "parse_operator_goal_tokens",
+    "parse_operator_named_term_tokens",
     "parse_operator_program_tokens",
     "parse_operator_query_tokens",
     "parse_operator_source_tokens",

--- a/code/packages/python/prolog-operator-parser/src/prolog_operator_parser/parser.py
+++ b/code/packages/python/prolog-operator-parser/src/prolog_operator_parser/parser.py
@@ -76,6 +76,14 @@ class ParsedOperatorSource:
     predicate_registry: PredicateRegistry
 
 
+@dataclass(frozen=True, slots=True)
+class ParsedOperatorTerm:
+    """A parsed term plus its named variable scope."""
+
+    term: Term
+    variables: dict[str, LogicVar]
+
+
 @dataclass(slots=True)
 class _Scope:
     """Per-clause or per-query variable scope."""
@@ -184,11 +192,14 @@ class _OperatorParser:
         return ParsedQuery(goal=goal, variables=dict(scope.variables))
 
     def parse_term(self) -> Term:
+        return self.parse_named_term().term
+
+    def parse_named_term(self) -> ParsedOperatorTerm:
         scope = _Scope(variables={})
         parsed = self._parse_term_expression(scope, 1200, stop_types={"EOF"})
         if not self._at_end():
             raise self._error(self._current_or_eof(), "unexpected tokens after term")
-        return parsed.value
+        return ParsedOperatorTerm(term=parsed.value, variables=dict(scope.variables))
 
     def _parse_query_statement(self) -> ParsedQuery:
         scope = _Scope(variables={})
@@ -620,3 +631,16 @@ def parse_operator_term_tokens(
         operator_table,
         allow_directives=False,
     ).parse_term()
+
+
+def parse_operator_named_term_tokens(
+    tokens: list[Token],
+    operator_table: OperatorTable,
+) -> ParsedOperatorTerm:
+    """Parse a bare term and retain its named variable scope."""
+
+    return _OperatorParser(
+        _strip_eof(tokens),
+        operator_table,
+        allow_directives=False,
+    ).parse_named_term()

--- a/code/packages/python/prolog-operator-parser/tests/test_prolog_operator_parser.py
+++ b/code/packages/python/prolog-operator-parser/tests/test_prolog_operator_parser.py
@@ -3,7 +3,15 @@
 from __future__ import annotations
 
 import pytest
-from logic_engine import atom, goal_as_term, logic_list, relation, solve_all, term
+from logic_engine import (
+    Compound,
+    atom,
+    goal_as_term,
+    logic_list,
+    relation,
+    solve_all,
+    term,
+)
 from prolog_core import iso_operator_table
 from prolog_lexer import tokenize_prolog
 from prolog_parser import PrologParseError
@@ -11,6 +19,7 @@ from prolog_parser import PrologParseError
 from prolog_operator_parser import (
     __version__,
     parse_operator_goal_tokens,
+    parse_operator_named_term_tokens,
     parse_operator_program_tokens,
     parse_operator_query_tokens,
     parse_operator_source_tokens,
@@ -53,6 +62,22 @@ class TestOperatorParsing:
         )
 
         assert parsed == term("*", term("+", 1, 2), 3)
+
+    def test_parse_named_term_returns_variables(self) -> None:
+        parsed = parse_operator_named_term_tokens(
+            tokenize_prolog("pair(X, Y, X, _)"),
+            iso_operator_table(),
+        )
+
+        assert isinstance(parsed.term, Compound)
+        assert parsed.term == term(
+            "pair",
+            parsed.variables["X"],
+            parsed.variables["Y"],
+            parsed.variables["X"],
+            parsed.term.args[3],
+        )
+        assert list(parsed.variables) == ["X", "Y"]
 
     def test_parse_goal_lowers_control_and_relational_operators(self) -> None:
         parsed = parse_operator_goal_tokens(

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -59,6 +59,8 @@
   `number_string/2`.
 - Run Prolog text inspection predicates through the VM path, including
   `atom_length/2`, `string_length/2`, `sub_atom/5`, and `sub_string/5`.
+- Run Prolog term text I/O predicates through the VM path, including
+  `term_to_atom/2` and `atom_to_term/3`.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -143,6 +143,7 @@ The package includes end-to-end stress tests for:
   `atomic_list_concat/3`, and `number_string/2`
 - text inspection with `atom_length/2`, `string_length/2`, `sub_atom/5`, and
   `sub_string/5`
+- term text I/O with `term_to_atom/2` and `atom_to_term/3`
 - runtime flag introspection and branch-local updates with
   `current_prolog_flag/2` and `set_prolog_flag/2`
 - finite integer builtins such as `integer/1`, `between/3`, and `succ/2`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from logic_engine import Disequality, LogicVar, atom, logic_list, num, string, term
+from logic_engine import (
+    Compound,
+    Disequality,
+    LogicVar,
+    atom,
+    logic_list,
+    num,
+    string,
+    term,
+)
 
 from prolog_vm_compiler import (
     compile_swi_prolog_project,
@@ -188,32 +197,39 @@ class TestPrologVMStress:
                string_chars(String, [h, i]),
                string_length("hello", StringLength),
                sub_string("logic", 2, 2, 1, SubString),
+               term_to_atom(pair(tea, [cup, cake]), RenderedTerm),
+               atom_to_term('pair(X, tea)', ParsedTerm, Bindings),
                string_codes("ok", Codes).
             """,
         )
 
         answers = run_compiled_prolog_query_answers(compiled)
 
-        assert [answer.as_dict() for answer in answers] == [
-            {
-                "Chars": logic_list(["t", "e", "a"]),
-                "Atom": atom("tea"),
-                "Number": num(42),
-                "Float": num(3.5),
-                "Parsed": num(7),
-                "Joined": atom("teacup"),
-                "Prefix": atom("tea"),
-                "AtomLength": num(6),
-                "SubAtom": atom("cup"),
-                "AtomList": atom("tea-2-go"),
-                "Split": logic_list(["tea", "cup"]),
-                "Char": atom("Z"),
-                "String": string("hi"),
-                "StringLength": num(5),
-                "SubString": string("gi"),
-                "Codes": logic_list([111, 107]),
-            },
-        ]
+        assert len(answers) == 1
+        answer = answers[0].as_dict()
+        parsed_term = answer["ParsedTerm"]
+        assert isinstance(parsed_term, Compound)
+        assert answer == {
+            "Chars": logic_list(["t", "e", "a"]),
+            "Atom": atom("tea"),
+            "Number": num(42),
+            "Float": num(3.5),
+            "Parsed": num(7),
+            "Joined": atom("teacup"),
+            "Prefix": atom("tea"),
+            "AtomLength": num(6),
+            "SubAtom": atom("cup"),
+            "AtomList": atom("tea-2-go"),
+            "Split": logic_list(["tea", "cup"]),
+            "Char": atom("Z"),
+            "String": string("hi"),
+            "StringLength": num(5),
+            "SubString": string("gi"),
+            "RenderedTerm": atom("pair(tea, [cup, cake])"),
+            "ParsedTerm": term("pair", parsed_term.args[0], "tea"),
+            "Bindings": logic_list([term("=", "X", parsed_term.args[0])]),
+            "Codes": logic_list([111, 107]),
+        }
 
     def test_current_prolog_flag_runs_through_vm(self) -> None:
         compiled = compile_swi_prolog_source(

--- a/code/packages/python/swi-prolog-parser/CHANGELOG.md
+++ b/code/packages/python/swi-prolog-parser/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Parse natural SWI CLP(FD) infix syntax such as `X in 1..4`,
   `[X,Y] ins 1..4`, and `Z #= X + Y`.
+- Expose `parse_swi_term(...)` for single-term parsing with named variable
+  bindings.
 
 ## 0.1.0
 

--- a/code/packages/python/swi-prolog-parser/src/swi_prolog_parser/__init__.py
+++ b/code/packages/python/swi-prolog-parser/src/swi_prolog_parser/__init__.py
@@ -12,6 +12,7 @@ from swi_prolog_parser.parser import (
     parse_swi_program,
     parse_swi_query,
     parse_swi_source,
+    parse_swi_term,
 )
 
 __all__ = [
@@ -28,6 +29,7 @@ __all__ = [
     "parse_swi_program",
     "parse_swi_query",
     "parse_swi_source",
+    "parse_swi_term",
 ]
 
 __version__ = "0.1.0"

--- a/code/packages/python/swi-prolog-parser/src/swi_prolog_parser/parser.py
+++ b/code/packages/python/swi-prolog-parser/src/swi_prolog_parser/parser.py
@@ -17,6 +17,8 @@ from prolog_core import (
     swi_operator_table,
 )
 from prolog_operator_parser import (
+    ParsedOperatorTerm,
+    parse_operator_named_term_tokens,
     parse_operator_program_tokens,
     parse_operator_query_tokens,
     parse_operator_source_tokens,
@@ -137,3 +139,17 @@ def parse_swi_query(
         tokens,
         active_operator_table,
     )
+
+
+def parse_swi_term(
+    source: str,
+    *,
+    operator_table: OperatorTable | None = None,
+) -> ParsedOperatorTerm:
+    """Parse one SWI-Prolog term and retain its named variable scope."""
+
+    tokens = tokenize_swi_prolog(source)
+    active_operator_table = (
+        swi_operator_table() if operator_table is None else operator_table
+    )
+    return parse_operator_named_term_tokens(tokens, active_operator_table)

--- a/code/packages/python/swi-prolog-parser/tests/test_swi_prolog_parser.py
+++ b/code/packages/python/swi-prolog-parser/tests/test_swi_prolog_parser.py
@@ -14,6 +14,7 @@ from swi_prolog_parser import (
     parse_swi_program,
     parse_swi_query,
     parse_swi_source,
+    parse_swi_term,
 )
 
 
@@ -154,6 +155,17 @@ class TestSwiParser:
         query = parse_swi_query("?- X is 1 + 2 * 3.\n")
 
         assert str(goal_as_term(query.goal)) == "is(X, +(1, *(2, 3)))"
+
+    def test_parse_swi_term_returns_named_variables(self) -> None:
+        parsed = parse_swi_term("pair(X, Y, X)")
+
+        assert parsed.term == term(
+            "pair",
+            parsed.variables["X"],
+            parsed.variables["Y"],
+            parsed.variables["X"],
+        )
+        assert list(parsed.variables) == ["X", "Y"]
 
     def test_parse_swi_query_understands_clpfd_infix_forms(self) -> None:
         query = parse_swi_query("?- [X,Y] ins 1..4, Z #= X + Y, X #< Y.\n")

--- a/code/specs/PR55-prolog-term-text-io.md
+++ b/code/specs/PR55-prolog-term-text-io.md
@@ -1,0 +1,49 @@
+# PR55: Prolog Term Text I/O
+
+## Goal
+
+Add the next parser-backed text bridge for the Prolog-on-Logic-VM path:
+converting runtime terms to atom text and parsing atom text back into runtime
+terms. This closes a practical metaprogramming gap without moving parser
+dependencies into the pure `logic-builtins` package.
+
+## Scope
+
+The parser layer exposes:
+
+```text
+parse_operator_named_term_tokens(tokens, operator_table)
+parse_swi_term(source)
+```
+
+The loader adapter exposes the source-level predicates:
+
+```text
+term_to_atom/2
+atom_to_term/3
+```
+
+## Semantics
+
+These predicates intentionally support finite, VM-friendly modes:
+
+- `term_to_atom/2` renders a bound runtime term into canonical Prolog atom text.
+- If the atom side of `term_to_atom/2` is already bound and the term side is
+  open, the atom text is parsed and unified with the term.
+- `atom_to_term/3` parses a bound atom as one SWI-Prolog term, unifies that
+  parsed term with the second argument, and unifies the third argument with a
+  `Name = Var` list for named variables found in the parsed text.
+- Invalid term text fails rather than raising out of the logic query.
+- Fully open calls fail rather than enumerating infinite term text.
+- Rendering is canonical and deliberately conservative; it does not attempt to
+  preserve source operator spelling or comments.
+
+## Verification
+
+- `prolog-operator-parser` tests cover single-term parsing with named variable
+  retention.
+- `swi-prolog-parser` tests expose the dialect-specific single-term parser.
+- `prolog-loader` tests prove `term_to_atom/2` and `atom_to_term/3` adapt into
+  executable goals and preserve parsed variable bindings.
+- `prolog-vm-compiler` stress coverage runs both predicates through parser,
+  loader, compiler, VM, and named-answer extraction.


### PR DESCRIPTION
## Summary
- expose named single-term parsing from the operator and SWI parser layers
- adapt source-level term_to_atom/2 and atom_to_term/3 at the loader boundary
- extend VM stress coverage and document the finite-mode semantics in PR55

## Verification
- bash BUILD in code/packages/python/prolog-operator-parser
- bash BUILD in code/packages/python/swi-prolog-parser
- bash BUILD in code/packages/python/prolog-loader
- bash BUILD in code/packages/python/prolog-vm-compiler
- ./.venv/bin/ruff check . --fix in all four touched Python packages
- git diff --check
- /tmp/ca-build-tool-prolog-term-text-io -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-term-text-io-build-plan.json