### PR TITLE
feat(prolog): add term read write options

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -57,6 +57,8 @@
   `sub_atom/5`, and `sub_string/5` into finite text goals
 - adapt Prolog term text I/O predicates `term_to_atom/2` and `atom_to_term/3`
   through the parser boundary
+- adapt Prolog term read/write predicates `read_term_from_atom/3` and
+  `write_term_to_atom/3` with finite option-list support
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -19,6 +19,8 @@ It keeps parsing side-effect free, then exposes helpers to:
   `sub_atom/5`, and `sub_string/5`
 - adapt term text I/O builtins such as `term_to_atom/2` and `atom_to_term/3`
   through the parser boundary
+- adapt parser-backed term read/write helpers such as `read_term_from_atom/3`
+  and `write_term_to_atom/3`
 - adapt callable CLP(FD) forms such as `in/2`, `ins/2`, `#=/2`,
   `all_different/1`, and `labeling/2`
 - flatten nested additive CLP(FD) equality expressions such as

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -385,6 +385,10 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return _term_to_atom_goal(*args)
     if name == "atom_to_term" and goal.relation.arity == 3:
         return _atom_to_term_goal(*args)
+    if name == "read_term_from_atom" and goal.relation.arity == 3:
+        return _read_term_from_atom_goal(*args)
+    if name == "write_term_to_atom" and goal.relation.arity == 3:
+        return _write_term_to_atom_goal(*args)
     if name == "atom_concat" and goal.relation.arity == 3:
         return atom_concato(*args)
     if name == "atom_length" and goal.relation.arity == 2:
@@ -526,6 +530,58 @@ def _atom_to_term_goal(
     return native_goal(run, atom_value, term_value, bindings)
 
 
+def _read_term_from_atom_goal(
+    atom_value: object,
+    term_value: object,
+    options: object,
+) -> GoalExpr:
+    def run(
+        program_value: Program,
+        state: State,
+        args: tuple[Term, ...],
+    ) -> Iterator[State]:
+        atom_arg, term_arg, options_arg = args
+        reified_atom = reify(atom_arg, state.substitution)
+        if not isinstance(reified_atom, Atom):
+            return
+
+        parsed = _parse_atom_text(reified_atom)
+        if parsed is None:
+            return
+        options_goal = _read_term_options_goal(options_arg, parsed.variables)
+        if options_goal is None:
+            return
+        yield from solve_from(
+            program_value,
+            conj(eq(term_arg, parsed.term), options_goal),
+            state,
+        )
+
+    return native_goal(run, atom_value, term_value, options)
+
+
+def _write_term_to_atom_goal(
+    term_value: object,
+    atom_value: object,
+    options: object,
+) -> GoalExpr:
+    def run(
+        program_value: Program,
+        state: State,
+        args: tuple[Term, ...],
+    ) -> Iterator[State]:
+        term_arg, atom_arg, options_arg = args
+        reified_term = reify(term_arg, state.substitution)
+        if isinstance(reified_term, LogicVar):
+            return
+        if not _write_term_options_supported(reify(options_arg, state.substitution)):
+            return
+        rendered = _render_prolog_term(reified_term)
+        yield from solve_from(program_value, eq(atom_arg, atom(rendered)), state)
+
+    return native_goal(run, term_value, atom_value, options)
+
+
 def _parse_atom_text(atom_value: Atom) -> object | None:
     try:
         return parse_swi_term(atom_value.symbol.name)
@@ -537,6 +593,51 @@ def _variable_bindings(variables: dict[str, LogicVar]) -> Term:
     return logic_list(
         [term("=", atom(name), variable) for name, variable in variables.items()],
     )
+
+
+def _variable_values(variables: dict[str, LogicVar]) -> Term:
+    return logic_list(list(variables.values()))
+
+
+def _read_term_options_goal(
+    options: Term,
+    variables: dict[str, LogicVar],
+) -> GoalExpr | None:
+    items = _logic_list_items(options)
+    if items is None:
+        return None
+
+    goals: list[GoalExpr] = []
+    for item in items:
+        if not isinstance(item, Compound) or len(item.args) != 1:
+            return None
+        if item.functor.name == "variable_names":
+            goals.append(eq(item.args[0], _variable_bindings(variables)))
+        elif item.functor.name == "variables":
+            goals.append(eq(item.args[0], _variable_values(variables)))
+        else:
+            return None
+    return conj(*goals)
+
+
+def _write_term_options_supported(options: Term) -> bool:
+    items = _logic_list_items(options)
+    if items is None:
+        return False
+    for item in items:
+        if not isinstance(item, Compound) or len(item.args) != 1:
+            return False
+        option_name = item.functor.name
+        value = item.args[0]
+        if option_name in {"quoted", "ignore_ops", "numbervars"}:
+            if (
+                not isinstance(value, Atom)
+                or value.symbol.name not in {"true", "false"}
+            ):
+                return False
+            continue
+        return False
+    return True
 
 
 def _render_prolog_term(term_value: Term) -> str:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -960,6 +960,16 @@ class TestPrologGoalAdapter:
                 LogicVar(id=85),
                 LogicVar(id=86),
             ),
+            relation("read_term_from_atom", 3)(
+                atom("box(X)"),
+                LogicVar(id=87),
+                logic_list([]),
+            ),
+            relation("write_term_to_atom", 3)(
+                term("box", atom("tea")),
+                LogicVar(id=88),
+                logic_list([]),
+            ),
             relation("current_prolog_flag", 2)(
                 atom("unknown"),
                 LogicVar(id=18),
@@ -1189,6 +1199,68 @@ class TestPrologGoalAdapter:
             term("pair", parsed_term.args[0], "tea"),
             logic_list([term("=", "X", parsed_term.args[0])]),
             logic_list([111, 107]),
+        )
+
+    def test_adapt_prolog_goal_rewrites_term_read_write_options(self) -> None:
+        parsed = parse_swi_query(
+            "?- read_term_from_atom('pair(X, Y, X)', Term, "
+            "[variable_names(Names), variables(Vars)]), "
+            "write_term_to_atom(pair(tea, [cup]), Rendered, "
+            "[quoted(true), ignore_ops(false)]).",
+        )
+
+        answers = solve_all(
+            program(),
+            (
+                parsed.variables["Term"],
+                parsed.variables["Names"],
+                parsed.variables["Vars"],
+                parsed.variables["Rendered"],
+            ),
+            adapt_prolog_goal(parsed.goal),
+        )
+
+        assert len(answers) == 1
+        term_value, names, vars_value, rendered = answers[0]
+        assert isinstance(term_value, Compound)
+        assert term_value == term(
+            "pair",
+            term_value.args[0],
+            term_value.args[1],
+            term_value.args[0],
+        )
+        assert names == logic_list(
+            [
+                term("=", "X", term_value.args[0]),
+                term("=", "Y", term_value.args[1]),
+            ],
+        )
+        assert vars_value == logic_list([term_value.args[0], term_value.args[1]])
+        assert rendered == atom("pair(tea, [cup])")
+
+    def test_adapt_prolog_goal_rejects_unsupported_term_io_options(self) -> None:
+        parsed_read = parse_swi_query(
+            "?- read_term_from_atom('pair(X)', Term, [unknown(true)]).",
+        )
+        parsed_write = parse_swi_query(
+            "?- write_term_to_atom(pair(tea), Atom, [quoted(maybe)]).",
+        )
+
+        assert (
+            solve_all(
+                program(),
+                parsed_read.variables["Term"],
+                adapt_prolog_goal(parsed_read.goal),
+            )
+            == []
+        )
+        assert (
+            solve_all(
+                program(),
+                parsed_write.variables["Atom"],
+                adapt_prolog_goal(parsed_write.goal),
+            )
+            == []
         )
 
     def test_adapt_prolog_goal_rewrites_term_equality_failures(self) -> None:

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -61,6 +61,8 @@
   `atom_length/2`, `string_length/2`, `sub_atom/5`, and `sub_string/5`.
 - Run Prolog term text I/O predicates through the VM path, including
   `term_to_atom/2` and `atom_to_term/3`.
+- Run Prolog term read/write option predicates through the VM path, including
+  `read_term_from_atom/3` and `write_term_to_atom/3`.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -143,7 +143,8 @@ The package includes end-to-end stress tests for:
   `atomic_list_concat/3`, and `number_string/2`
 - text inspection with `atom_length/2`, `string_length/2`, `sub_atom/5`, and
   `sub_string/5`
-- term text I/O with `term_to_atom/2` and `atom_to_term/3`
+- term text I/O with `term_to_atom/2`, `atom_to_term/3`,
+  `read_term_from_atom/3`, and `write_term_to_atom/3`
 - runtime flag introspection and branch-local updates with
   `current_prolog_flag/2` and `set_prolog_flag/2`
 - finite integer builtins such as `integer/1`, `between/3`, and `succ/2`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -199,6 +199,10 @@ class TestPrologVMStress:
                sub_string("logic", 2, 2, 1, SubString),
                term_to_atom(pair(tea, [cup, cake]), RenderedTerm),
                atom_to_term('pair(X, tea)', ParsedTerm, Bindings),
+               read_term_from_atom('pair(X, Y, X)', ReadTerm,
+                   [variable_names(Names), variables(Vars)]),
+               write_term_to_atom(pair(tea, [cup]), WrittenTerm,
+                   [quoted(true), ignore_ops(false)]),
                string_codes("ok", Codes).
             """,
         )
@@ -208,7 +212,9 @@ class TestPrologVMStress:
         assert len(answers) == 1
         answer = answers[0].as_dict()
         parsed_term = answer["ParsedTerm"]
+        read_term = answer["ReadTerm"]
         assert isinstance(parsed_term, Compound)
+        assert isinstance(read_term, Compound)
         assert answer == {
             "Chars": logic_list(["t", "e", "a"]),
             "Atom": atom("tea"),
@@ -228,6 +234,20 @@ class TestPrologVMStress:
             "RenderedTerm": atom("pair(tea, [cup, cake])"),
             "ParsedTerm": term("pair", parsed_term.args[0], "tea"),
             "Bindings": logic_list([term("=", "X", parsed_term.args[0])]),
+            "ReadTerm": term(
+                "pair",
+                read_term.args[0],
+                read_term.args[1],
+                read_term.args[0],
+            ),
+            "Names": logic_list(
+                [
+                    term("=", "X", read_term.args[0]),
+                    term("=", "Y", read_term.args[1]),
+                ],
+            ),
+            "Vars": logic_list([read_term.args[0], read_term.args[1]]),
+            "WrittenTerm": atom("pair(tea, [cup])"),
             "Codes": logic_list([111, 107]),
         }
 

--- a/code/specs/PR56-prolog-term-read-write-options.md
+++ b/code/specs/PR56-prolog-term-read-write-options.md
@@ -1,0 +1,45 @@
+# PR56: Prolog Term Read/Write Options
+
+## Goal
+
+Build on PR55's parser-backed term text bridge by adding source-level
+read/write helpers that accept option lists. This moves another practical
+metaprogramming pattern into the Logic VM path while keeping the supported
+modes finite and explicit.
+
+## Scope
+
+The loader adapter exposes:
+
+```text
+read_term_from_atom/3
+write_term_to_atom/3
+```
+
+The VM path supports both predicates through the existing parser, loader,
+compiler, and runtime pipeline.
+
+## Semantics
+
+These predicates intentionally support a conservative option subset:
+
+- `read_term_from_atom(Atom, Term, Options)` parses a bound atom as one
+  SWI-Prolog term and unifies it with `Term`.
+- `read_term_from_atom/3` supports `variable_names(Names)` and
+  `variables(Vars)` options, unifying them with the named-variable binding list
+  and variable value list from the parsed term.
+- `write_term_to_atom(Term, Atom, Options)` renders a bound runtime term into
+  canonical Prolog atom text.
+- `write_term_to_atom/3` accepts finite `quoted/1`, `ignore_ops/1`, and
+  `numbervars/1` boolean options, but rendering remains canonical for now.
+- Unsupported options fail cleanly rather than approximating behavior we do
+  not yet implement.
+- Fully open calls fail rather than enumerating infinite term text or option
+  spaces.
+
+## Verification
+
+- `prolog-loader` tests cover successful read/write option handling and
+  unsupported option failure.
+- `prolog-vm-compiler` stress coverage runs both predicates through parser,
+  loader, compiler, VM, and named-answer extraction.


### PR DESCRIPTION
## Summary
- adapt read_term_from_atom/3 with finite variable_names/1 and variables/1 option support
- adapt write_term_to_atom/3 with conservative finite write option validation
- extend Prolog VM stress coverage and document the option subset in PR56

## Verification
- bash BUILD in code/packages/python/prolog-loader
- bash BUILD in code/packages/python/prolog-vm-compiler
- ./.venv/bin/ruff check . --fix in both touched Python packages
- git diff --check
- /tmp/ca-build-tool-prolog-term-read-write-options -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-term-read-write-options-build-plan.json