### PR TITLE
Support conditional switch actuals

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -81,6 +81,8 @@ All notable changes to this package will be documented in this file.
   descriptor pointers to actual procedures that declare matching array formals.
 - Lowered label, switch, and procedure arguments through formal procedure
   dispatchers by forwarding label ids and descriptor pointers.
+- Lowered conditional switch designator actuals by selecting and forwarding the
+  chosen switch descriptor through concrete and formal procedure calls.
 - Preserved concrete procedure ids in formal procedure call-shape metadata so
   nested procedure-parameter contracts are checked before IR lowering.
 - Lowered recursive switch self-selection through runtime switch-eval descriptor

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -3384,6 +3384,8 @@ class AlgolIrCompiler:
     ) -> tuple[str, str] | None:
         if self._is_label_designational_actual(argument, scope):
             return "label", "label"
+        if self._is_switch_designator_actual(argument, scope):
+            return "switch", "switch"
 
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
@@ -4208,9 +4210,37 @@ class AlgolIrCompiler:
         scope: _FrameScope,
         descriptor: int | None,
     ) -> int:
+        parts = _conditional_expression_parts(_meaningful_children(argument))
+        if parts is not None:
+            if descriptor is None:
+                raise CompileError("missing reserved descriptor for switch actual")
+            condition, then_expr, else_expr = parts
+            index = self._next_if_index()
+            else_label = f"switch_actual_{index}_else"
+            end_label = f"switch_actual_{index}_end"
+            result = self._fresh_reg()
+            condition_value = self._compile_expr(condition, scope)
+            self._emit(IrOp.BRANCH_Z, IrRegister(condition_value), IrLabel(else_label))
+            then_pointer = self._compile_switch_actual_pointer(
+                then_expr,
+                scope,
+                descriptor,
+            )
+            self._copy_reg(dst=result, src=then_pointer)
+            self._emit(IrOp.JUMP, IrLabel(end_label))
+            self._label(else_label)
+            else_pointer = self._compile_switch_actual_pointer(
+                else_expr,
+                scope,
+                descriptor,
+            )
+            self._copy_reg(dst=result, src=else_pointer)
+            self._label(end_label)
+            return result
+
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
-            raise CompileError("switch parameter actual must be a direct switch")
+            raise CompileError("switch parameter actual must be a switch designator")
         name = _variable_name(variable)
         if name is None:
             raise CompileError("switch parameter actual is missing a name")
@@ -4249,6 +4279,28 @@ class AlgolIrCompiler:
             caller_frame,
         )
         return descriptor
+
+    def _is_switch_designator_actual(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+    ) -> bool:
+        parts = _conditional_expression_parts(_meaningful_children(argument))
+        if parts is not None:
+            _, then_expr, else_expr = parts
+            return self._is_switch_designator_actual(
+                then_expr,
+                scope,
+            ) and self._is_switch_designator_actual(else_expr, scope)
+
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return False
+        name = _variable_name(variable)
+        if name is None:
+            return False
+        resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
+        return resolved is not None and resolved[0].kind == "switch"
 
     def _compile_procedure_actual_pointer(
         self,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -883,6 +883,28 @@ class TestAlgolIrCompiler:
             for instruction in calls
         )
 
+    def test_compiles_switch_parameter_call_with_conditional_actual(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; boolean flag; "
+                "switch a := left; switch b := right; "
+                "procedure escape(sw); switch sw; begin goto sw[1] end; "
+                "flag := false; escape(if flag then a else b); "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
+                "end"
+            )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+
+        assert result.procedure_signatures["_fn_algol_eval_switch"].param_count == 3
+        assert any(label.startswith("switch_actual_") for label in labels)
+
     def test_compiles_procedure_parameter_call_and_dispatcher(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -1100,6 +1122,29 @@ class TestAlgolIrCompiler:
                 "procedure invoke(p); procedure p; begin p(s) end; "
                 "procedure jump(sw); switch sw; begin goto sw[1] end; "
                 "invoke(jump); done: "
+                "end"
+            )
+        )
+
+        assert (
+            result.procedure_signatures["_fn_algol_call_procedure_switch"].param_types
+            == ("integer", "integer", "integer")
+        )
+
+    def test_compiles_procedure_parameter_call_with_conditional_switch_argument(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; boolean flag; "
+                "switch a := left; switch b := right; "
+                "procedure invoke(p); procedure p; "
+                "begin p(if flag then a else b) end; "
+                "procedure jump(sw); switch sw; begin goto sw[1] end; "
+                "flag := false; invoke(jump); "
+                "left: result := 1; goto done; "
+                "right: result := 2; "
+                "done: "
                 "end"
             )
         )

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -55,6 +55,8 @@ All notable changes to this package will be documented in this file.
   parameters for formal procedure parameters.
 - Validated nested procedure-parameter call-shape contracts when a formal
   procedure call forwards a concrete procedure actual.
+- Accepted conditional switch designator actuals for switch formals and formal
+  procedure call-shape recording.
 - Accepted recursive switch self-selection entries so terminating recursive
   designational dispatch can lower through the WASM pipeline.
 - Accepted `go to` as an alternate spelling for direct and designational

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -2276,6 +2276,20 @@ class AlgolTypeChecker:
             )
             return LABEL, LABEL, None
 
+        if self._check_switch_designator_actual(
+            argument,
+            scope,
+            parameter_name="procedure argument",
+            report=False,
+        ):
+            self._check_switch_designator_actual(
+                argument,
+                scope,
+                parameter_name="procedure argument",
+                report=True,
+            )
+            return SWITCH, SWITCH, None
+
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
             return None
@@ -2481,33 +2495,77 @@ class AlgolTypeChecker:
         scope: Scope,
         parameter: ProcedureParameter,
     ) -> Symbol | None:
+        if self._check_switch_designator_actual(
+            argument,
+            scope,
+            parameter_name=parameter.name,
+            report=True,
+        ):
+            return None
+        self._error(
+            argument,
+            f"switch parameter {parameter.name!r} expects a switch designator actual",
+        )
+        return None
+
+    def _check_switch_designator_actual(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+        *,
+        parameter_name: str,
+        report: bool,
+    ) -> bool:
+        parts = _conditional_expression_parts(_meaningful_children(argument))
+        if parts is not None:
+            condition, then_expr, else_expr = parts
+            if report:
+                condition_type = self._infer_expr(condition, scope)
+                if condition_type != ERROR and condition_type != BOOLEAN:
+                    self._error(
+                        condition,
+                        "switch designator actual condition must be boolean",
+                    )
+            then_ok = self._check_switch_designator_actual(
+                then_expr,
+                scope,
+                parameter_name=parameter_name,
+                report=report,
+            )
+            else_ok = self._check_switch_designator_actual(
+                else_expr,
+                scope,
+                parameter_name=parameter_name,
+                report=report,
+            )
+            return then_ok and else_ok
+
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
-            self._error(
-                argument,
-                f"switch parameter {parameter.name!r} expects a direct switch actual",
-            )
-            return None
+            return False
         name = _variable_head_name(variable)
         if name is None:
-            self._error(argument, "switch actual is missing a name")
-            return None
+            if report:
+                self._error(argument, "switch actual is missing a name")
+            return False
         resolved = scope.resolve_with_scope(name.value)
         if resolved is None:
-            self._error(
-                name,
-                f"{name.value!r} is not declared in block {scope.block_id} "
-                "or its lexical parents",
-            )
-            return None
+            if report:
+                self._error(
+                    name,
+                    f"{name.value!r} is not declared in block {scope.block_id} "
+                    "or its lexical parents",
+                )
+            return False
         symbol, _, _ = resolved
-        if symbol.kind != SWITCH:
+        if symbol.kind == SWITCH:
+            return True
+        if report:
             self._error(
                 name,
-                f"switch parameter {parameter.name!r} expects a switch actual",
+                f"switch parameter {parameter_name!r} expects a switch actual",
             )
-            return None
-        return symbol
+        return False
 
     def _check_procedure_parameter_actual(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -989,6 +989,44 @@ class TestAlgolTypeChecker:
             for selection in result.semantic.switch_selections
         )
 
+    def test_accepts_switch_parameter_and_conditional_switch_actual(self) -> None:
+        ast = parse_algol(
+            "begin integer result; boolean flag; "
+            "switch a := left; switch b := right; "
+            "procedure escape(sw); switch sw; begin goto sw[1] end; "
+            "flag := false; escape(if flag then a else b); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "switch"
+        assert parameter.type_name == "switch"
+
+    def test_rejects_switch_parameter_conditional_actual_with_non_boolean_condition(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result, flag; "
+            "switch a := done; switch b := done; "
+            "procedure escape(sw); switch sw; begin goto sw[1] end; "
+            "escape(if flag then a else b); "
+            "done: result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert (
+            "switch designator actual condition must be boolean"
+            in result.diagnostics[0].message
+        )
+
     def test_accepts_value_switch_parameter_and_direct_switch_actual(self) -> None:
         ast = parse_algol(
             "begin integer result; "
@@ -1260,6 +1298,29 @@ class TestAlgolTypeChecker:
             "procedure invoke(p); procedure p; begin p(s) end; "
             "procedure jump(sw); switch sw; begin goto sw[1] end; "
             "invoke(jump); done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        shape = result.semantic.procedures[0].parameters[0].procedure_call_shapes[0]
+        assert shape.argument_kinds == ("switch",)
+        assert shape.argument_types == ("switch",)
+
+    def test_accepts_procedure_parameter_actual_with_conditional_switch_formal(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; boolean flag; "
+            "switch a := left; switch b := right; "
+            "procedure invoke(p); procedure p; "
+            "begin p(if flag then a else b) end; "
+            "procedure jump(sw); switch sw; begin goto sw[1] end; "
+            "flag := false; invoke(jump); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
             "end"
         )
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -74,6 +74,8 @@ All notable changes to this package will be documented in this file.
   procedures, preserving descriptor aliasing and existing `value` array copies.
 - Executed formal procedure calls that forward label, switch, and procedure
   arguments to actual procedures.
+- Executed conditional switch actuals through direct calls, forwarded switch
+  formals, and formal procedure dispatch, with a golden end-to-end fixture.
 - Rejected formal procedure forwarding when a concrete procedure argument does
   not satisfy the nested procedure formal contract expected by the receiver.
 - Executed recursive switch self-selection entries by routing recursive

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/switch-actuals.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/switch-actuals.alg
@@ -1,0 +1,53 @@
+begin
+  integer result, phase;
+  boolean pick;
+
+  switch a := alabel;
+  switch b := blabel;
+
+  procedure jump(sw);
+    switch sw;
+    begin goto sw[1] end;
+
+  procedure relay(x, y);
+    switch x, y;
+    begin jump(if pick then x else y) end;
+
+  procedure invoke(p);
+    procedure p;
+    begin p(if pick then a else b) end;
+
+  result := 0;
+  phase := 1;
+  pick := false;
+  jump(if pick then a else b);
+
+alabel:
+  result := result + phase;
+  goto after;
+
+blabel:
+  result := result + phase * 10;
+  goto after;
+
+after:
+  if phase = 1 then
+    begin
+      phase := 2;
+      pick := true;
+      relay(a, b)
+    end
+  else if phase = 2 then
+    begin
+      phase := 3;
+      pick := false;
+      invoke(jump)
+    end
+  else
+    goto done;
+
+done:
+  print('SWITCH');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -774,6 +774,34 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
 
+    def test_switch_parameter_accepts_conditional_switch_actual(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean flag; "
+            "switch a := left; switch b := right; "
+            "procedure escape(sw); switch sw; begin goto sw[1] end; "
+            "flag := false; escape(if flag then a else b); result := 0; "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_conditional_switch_actual_forwards_switch_parameters(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean flag; "
+            "procedure escape(sw); switch sw; begin goto sw[1] end; "
+            "procedure select(a, b); switch a, b; "
+            "begin escape(if flag then a else b) end; "
+            "switch leftSwitch := left; switch rightSwitch := right; "
+            "flag := false; select(leftSwitch, rightSwitch); result := 0; "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
     def test_forwarded_switch_parameter_propagates_descriptor_through_calls(
         self,
     ) -> None:
@@ -1458,6 +1486,21 @@ class TestAlgolWasmCompiler:
             "procedure invoke(p); procedure p; begin p(s[i]) end; "
             "procedure jump(target); label target; begin goto target end; "
             "i := 2; invoke(jump); "
+            "left: result := 1; goto done; "
+            "right: result := 2; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
+
+    def test_formal_procedure_call_passes_conditional_switch_argument(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean flag; "
+            "switch a := left; switch b := right; "
+            "procedure invoke(p); procedure p; "
+            "begin p(if flag then a else b) end; "
+            "procedure escape(sw); switch sw; begin goto sw[1] end; "
+            "flag := false; invoke(escape); result := 0; "
             "left: result := 1; goto done; "
             "right: result := 2; "
             "done: "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -28,6 +28,7 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="convergence", result=[39], stdout="CONVERGE 39"),
     GoldenFixture(name="standard-real-math", result=[478], stdout="MATH 478"),
     GoldenFixture(name="full-surface", result=[81], stdout="COMPLETE 81"),
+    GoldenFixture(name="switch-actuals", result=[42], stdout="SWITCH 42"),
 )
 
 


### PR DESCRIPTION
## Summary
- Accept conditional switch designator actuals in the ALGOL type checker, including formal procedure call-shape recording.
- Lower conditional switch actuals by selecting and forwarding the chosen switch descriptor through concrete calls and formal procedure dispatch.
- Add runtime coverage for direct conditional switch actuals, forwarded switch-parameter branches, formal procedure dispatch, and a new golden end-to-end fixture.

## Verification
- `bash BUILD` in `code/packages/python/algol-type-checker` (141 passed)
- `bash BUILD` in `code/packages/python/algol-ir-compiler` (108 passed)
- `bash BUILD` in `code/packages/python/algol-wasm-compiler` (185 passed)
- `git diff --check origin/main..HEAD`
- Security sweep over added lines for process/network/filesystem/secret/deserialization/host syscall surfaces