### PR TITLE
Support typed ALGOL equality comparisons

### DIFF
--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -276,6 +276,8 @@ factor       = primary { ( CARET | POWER ) primary } ;
 primary      = INTEGER_LIT
              | REAL_LIT
              | STRING_LIT
+             | "true"
+             | "false"
              | proc_call
              | variable
              | LPAREN arith_expr RPAREN ;
@@ -302,14 +304,14 @@ bool_factor  = bool_secondary { "and" bool_secondary } ;
 
 bool_secondary = "not" bool_secondary | bool_primary ;
 
-bool_primary = "true"
+bool_primary = relation
+             | "true"
              | "false"
-             | relation
              | proc_call
              | variable
              | LPAREN bool_expr RPAREN ;
 
-# A relation compares two arithmetic expressions.
+# A relation compares two scalar expressions.
 # Note: the operands are simple_arith (not full arith_expr) to avoid ambiguity
 # with the conditional expression form.
 relation     = simple_arith ( EQ | NEQ | LT | LEQ | GT | GEQ ) simple_arith ;

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -2504,7 +2504,38 @@ class AlgolIrCompiler:
         if not isinstance(operator, Token):
             raise CompileError("expected comparison operator")
         dst = self._fresh_reg()
-        if _REAL_TYPE in {left_type, right_type}:
+        if _STRING_TYPE in {left_type, right_type}:
+            if left_type != _STRING_TYPE or right_type != _STRING_TYPE:
+                raise CompileError(
+                    "string comparison requires two string operands"
+                )
+            if operator.value not in {"=", "!="}:
+                raise CompileError(
+                    f"comparison operator {operator.value!r} is not supported "
+                    "for strings"
+                )
+            dst = self._emit_string_equality(left, right, scope)
+            if operator.value == "!=":
+                dst = self._invert_bool(dst)
+        elif _BOOLEAN_TYPE in {left_type, right_type}:
+            if left_type != _BOOLEAN_TYPE or right_type != _BOOLEAN_TYPE:
+                raise CompileError(
+                    "boolean comparison requires two boolean operands"
+                )
+            if operator.value == "=":
+                self._emit(
+                    IrOp.CMP_EQ, IrRegister(dst), IrRegister(left), IrRegister(right)
+                )
+            elif operator.value == "!=":
+                self._emit(
+                    IrOp.CMP_NE, IrRegister(dst), IrRegister(left), IrRegister(right)
+                )
+            else:
+                raise CompileError(
+                    f"comparison operator {operator.value!r} is not supported "
+                    "for booleans"
+                )
+        elif _REAL_TYPE in {left_type, right_type}:
             left = self._coerce_reg_to_type(
                 left,
                 left_type,
@@ -2593,6 +2624,139 @@ class AlgolIrCompiler:
                     f"comparison operator {operator.value!r} is not supported"
                 )
         return dst
+
+    def _emit_string_equality(
+        self, left_pointer: int, right_pointer: int, scope: _FrameScope
+    ) -> int:
+        index = self._next_if_index()
+        loop_label = f"algol_label_string_equal_{index}_loop"
+        compare_label = f"algol_label_string_equal_{index}_compare"
+        end_label = f"algol_label_string_equal_{index}_end"
+        result = self._fresh_reg()
+        cursor = self._fresh_reg()
+        at_end = self._fresh_reg()
+        same_length = self._fresh_reg()
+        left_byte = self._fresh_reg()
+        right_byte = self._fresh_reg()
+        same_byte = self._fresh_reg()
+        next_cursor = self._fresh_reg()
+        left_length, left_data = self._emit_string_descriptor_parts(
+            left_pointer,
+            scope,
+        )
+        right_length, right_data = self._emit_string_descriptor_parts(
+            right_pointer,
+            scope,
+        )
+
+        self._emit(IrOp.LOAD_IMM, IrRegister(result), IrImmediate(0))
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(same_length),
+            IrRegister(left_length),
+            IrRegister(right_length),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(same_length), IrLabel(end_label))
+        self._emit(IrOp.LOAD_IMM, IrRegister(cursor), IrImmediate(0))
+        self._label(loop_label)
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(at_end),
+            IrRegister(cursor),
+            IrRegister(left_length),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(at_end), IrLabel(compare_label))
+        self._emit(IrOp.LOAD_IMM, IrRegister(result), IrImmediate(1))
+        self._emit(IrOp.JUMP, IrLabel(end_label))
+        self._label(compare_label)
+        self._emit(
+            IrOp.LOAD_BYTE,
+            IrRegister(left_byte),
+            IrRegister(left_data),
+            IrRegister(cursor),
+        )
+        self._emit(
+            IrOp.LOAD_BYTE,
+            IrRegister(right_byte),
+            IrRegister(right_data),
+            IrRegister(cursor),
+        )
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(same_byte),
+            IrRegister(left_byte),
+            IrRegister(right_byte),
+        )
+        self._emit(IrOp.BRANCH_Z, IrRegister(same_byte), IrLabel(end_label))
+        self._emit(
+            IrOp.ADD_IMM,
+            IrRegister(next_cursor),
+            IrRegister(cursor),
+            IrImmediate(1),
+        )
+        self._copy_reg(dst=cursor, src=next_cursor)
+        self._emit(IrOp.JUMP, IrLabel(loop_label))
+        self._label(end_label)
+        return result
+
+    def _emit_string_descriptor_parts(
+        self, pointer_reg: int, scope: _FrameScope
+    ) -> tuple[int, int]:
+        index = self._next_if_index()
+        done_label = f"algol_label_string_descriptor_{index}_done"
+        data_guard_done_label = (
+            f"algol_label_string_descriptor_{index}_data_guard_done"
+        )
+        length_reg = self._fresh_reg()
+        data_reg = self._fresh_reg()
+        negative_length_reg = self._fresh_reg()
+        too_large_reg = self._fresh_reg()
+        missing_data_reg = self._fresh_reg()
+
+        self._emit(IrOp.LOAD_IMM, IrRegister(length_reg), IrImmediate(0))
+        self._emit(IrOp.LOAD_IMM, IrRegister(data_reg), IrImmediate(0))
+        self._emit(IrOp.BRANCH_Z, IrRegister(pointer_reg), IrLabel(done_label))
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            length_reg,
+            pointer_reg,
+            _STRING_DESCRIPTOR_LENGTH_OFFSET,
+        )
+        self._emit_load_scalar(
+            _INTEGER_TYPE,
+            data_reg,
+            pointer_reg,
+            _STRING_DESCRIPTOR_DATA_POINTER_OFFSET,
+        )
+        self._emit(
+            IrOp.CMP_LT,
+            IrRegister(negative_length_reg),
+            IrRegister(length_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit_runtime_failure_guard(negative_length_reg, scope)
+        self._emit(
+            IrOp.CMP_GT,
+            IrRegister(too_large_reg),
+            IrRegister(length_reg),
+            IrRegister(self._const_reg(_MAX_STRING_OUTPUT_BYTES)),
+        )
+        self._emit_runtime_failure_guard(too_large_reg, scope)
+        self._emit(
+            IrOp.BRANCH_Z,
+            IrRegister(length_reg),
+            IrLabel(data_guard_done_label),
+        )
+        self._emit(
+            IrOp.CMP_EQ,
+            IrRegister(missing_data_reg),
+            IrRegister(data_reg),
+            IrRegister(_ZERO_REG),
+        )
+        self._emit_runtime_failure_guard(missing_data_reg, scope)
+        self._label(data_guard_done_label)
+        self._label(done_label)
+        return length_reg, data_reg
 
     def _emit_numeric(
         self,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -238,6 +238,25 @@ class TestAlgolIrCompiler:
         assert IrOp.LOAD_BYTE in opcodes
         assert any(label.startswith("algol_label_output_string_") for label in labels)
 
+    def test_compiles_string_equality_to_descriptor_loop(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; string left, right; "
+                "left := 'Hi'; right := 'Hi'; "
+                "if left = right then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert IrOp.LOAD_BYTE in opcodes
+        assert any(label.startswith("algol_label_string_equal_") for label in labels)
+
     def test_compiles_string_output_guards_for_length_and_total_bytes(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -659,6 +678,19 @@ class TestAlgolIrCompiler:
             parse_algol(
                 "begin integer result; "
                 "if true eqv false then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.CMP_EQ in opcodes
+
+    def test_compiles_boolean_equality_comparison(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; boolean flag; "
+                "flag := true; "
+                "if flag = true then result := 1 else result := 0 "
                 "end"
             )
         )

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -486,6 +486,18 @@ class TestBooleanExpression:
         )
         assert ast.rule_name == "program"
 
+    def test_boolean_literal_relation(self) -> None:
+        """Boolean literals can be operands in equality relations."""
+        ast = parse(
+            "begin integer x; boolean b; "
+            "b := true; "
+            "if b = true then x := 1 else x := 0 "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "relation")
+
     def test_implication_expression(self) -> None:
         """Boolean expression with IMPL."""
         ast = parse(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1722,7 +1722,7 @@ class AlgolTypeChecker:
                 and child.value in {"=", "!=", "<", "<=", ">", ">="}
                 for child in meaningful
             ):
-                return self._infer_numeric_comparison(expr, meaningful, scope)
+                return self._infer_comparison(expr, meaningful, scope)
             return self._infer_expr(meaningful[0], scope)
 
         if expr.rule_name in {"expr_add", "simple_arith", "expr_mul", "term"}:
@@ -3130,23 +3130,38 @@ class AlgolTypeChecker:
             index += 2
         return current_type
 
-    def _infer_numeric_comparison(
+    def _infer_comparison(
         self,
         node: ASTNode,
         children: list[ASTNode | Token],
         scope: Scope,
     ) -> str:
         left = self._infer_expr(children[0], scope)
+        operator = children[1]
         right = self._infer_expr(children[2], scope)
         if left == ERROR or right == ERROR:
             return ERROR
-        if not _is_numeric_type(left):
-            self._error(node, f"operator requires numeric operand, got {left}")
+        if not isinstance(operator, Token):
+            self._error(node, "expected comparison operator")
             return ERROR
-        if not _is_numeric_type(right):
-            self._error(node, f"operator requires numeric operand, got {right}")
+        if _is_numeric_type(left) and _is_numeric_type(right):
+            return BOOLEAN
+        if (
+            operator.value in {"=", "!="}
+            and left == right
+            and left in {BOOLEAN, STRING}
+        ):
+            return BOOLEAN
+        if operator.value not in {"=", "!="}:
+            actual = left if not _is_numeric_type(left) else right
+            self._error(node, f"operator requires numeric operand, got {actual}")
             return ERROR
-        return BOOLEAN
+        self._error(
+            node,
+            f"operator {operator.value!r} requires compatible operands, got "
+            f"{left} and {right}",
+        )
+        return ERROR
 
     def _can_assign(self, target_type: str, value_type: str) -> bool:
         if target_type == value_type:

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -387,6 +387,17 @@ class TestAlgolTypeChecker:
         assert result.ok
         assert result.root_scope.children[0].symbols["flag"].type_name == "boolean"
 
+    def test_accepts_boolean_equality_comparison(self) -> None:
+        ast = parse_algol(
+            "begin integer result; boolean flag; "
+            "flag := true; "
+            "if flag = true then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+
     def test_reports_arithmetic_operand_that_is_not_integer(self) -> None:
         ast = parse_algol("begin integer result; result := true + 1 end")
         result = check_algol(ast)
@@ -2029,6 +2040,45 @@ class TestAlgolTypeChecker:
 
         assert result.ok
         assert result.root_scope.children[0].symbols["msg"].type_name == "string"
+
+    def test_accepts_string_equality_comparison(self) -> None:
+        ast = parse_algol(
+            "begin integer result; string msg; "
+            "msg := 'Hi'; "
+            "if msg = 'Hi' then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+
+    def test_rejects_string_ordering_comparison(self) -> None:
+        ast = parse_algol(
+            "begin integer result; string msg; "
+            "msg := 'Hi'; "
+            "if msg < 'Hz' then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "operator requires numeric operand, got string" in (
+            result.diagnostics[0].message
+        )
+
+    def test_rejects_mismatched_equality_comparison(self) -> None:
+        ast = parse_algol(
+            "begin integer result; string msg; "
+            "msg := 'Hi'; "
+            "if msg = 1 then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "requires compatible operands, got string and integer" in (
+            result.diagnostics[0].message
+        )
 
     def test_accepts_builtin_print_with_string_variable(self) -> None:
         ast = parse_algol(

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/typed-comparisons.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/typed-comparisons.alg
@@ -1,0 +1,30 @@
+begin
+  integer result;
+  boolean ready;
+  string first, second;
+  string array words[1:2];
+
+  string procedure memo(s);
+    value s;
+    string s;
+    begin
+      own string saved;
+      if saved = '' then saved := s;
+      memo := saved
+    end;
+
+  ready := true;
+  first := memo('READY');
+  second := memo('OTHER');
+  words[1] := first;
+  words[2] := 'READY';
+  result := 0;
+  if ready = true then result := result + 1 else result := result + 100;
+  if first = words[1] then result := result + 2 else result := result + 100;
+  if words[1] = words[2] then result := result + 4 else result := result + 100;
+  if second != 'OTHER' then result := result + 8 else result := result + 100;
+  if words[2] != '' then result := result + 16 else result := result + 100;
+  print(first);
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1808,6 +1808,15 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_boolean_equality_comparison(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean flag; "
+            "flag := true; "
+            "if flag = true then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
     def test_string_array_element_store_and_output(self) -> None:
         result = compile_source(
             "begin integer result; string array messages[1:2]; "
@@ -1832,6 +1841,27 @@ class TestAlgolWasmCompiler:
 
         assert runtime.load_and_run(result.binary, "_start", []) == [9]
         assert "".join(captured) == "Bye"
+
+    def test_string_equality_comparison_uses_descriptor_contents(self) -> None:
+        result = compile_source(
+            "begin integer result; string msg; "
+            "string procedure memo(s); value s; string s; "
+            "begin own string saved; "
+            "if saved = '' then saved := s; "
+            "memo := saved "
+            "end; "
+            "msg := memo('Hi'); "
+            "if msg = 'Hi' then result := 1 else result := 100; "
+            "if memo('Bye') != 'Bye' then result := result + 6 "
+            "else result := result + 100; "
+            "print(msg) "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [7]
+        assert "".join(captured) == "Hi"
 
     def test_multidimensional_real_array_uses_row_major_offsets(self) -> None:
         result = compile_source(

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -29,6 +29,7 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="standard-real-math", result=[478], stdout="MATH 478"),
     GoldenFixture(name="full-surface", result=[81], stdout="COMPLETE 81"),
     GoldenFixture(name="switch-actuals", result=[42], stdout="SWITCH 42"),
+    GoldenFixture(name="typed-comparisons", result=[31], stdout="READY 31"),
 )
 
 


### PR DESCRIPTION
## Summary
- allow ALGOL relations to parse Boolean literals so `flag = true` works naturally
- extend type checking for Boolean and string equality/inequality while keeping ordering numeric-only
- lower string equality to byte-wise descriptor comparison with existing runtime guards and add WASM coverage

## Verification
- `code/packages/python/algol-type-checker/.venv/bin/python -m pytest code/packages/python/algol-parser/tests/test_algol_parser.py`
- `code/packages/python/algol-type-checker/.venv/bin/python -m pytest code/packages/python/algol-type-checker/tests/test_algol_type_checker.py`
- `code/packages/python/algol-ir-compiler/.venv/bin/python -m pytest code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py`
- `code/packages/python/algol-wasm-compiler/.venv/bin/python -m pytest code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py`
- `bash BUILD` in `code/packages/python/algol-type-checker`
- `bash BUILD` in `code/packages/python/algol-ir-compiler`
- `bash BUILD` in `code/packages/python/algol-wasm-compiler`

## Security Review
- `git diff --cached --check`
- scanned the staged diff for process, network, file I/O, deserialization, secrets, and host import additions
- no new external I/O or privilege boundary changes; new runtime logic only compares in-memory string descriptors