### PR TITLE
Broaden ALGOL source spelling support

### DIFF
--- a/code/grammars/algol/algol60.tokens
+++ b/code/grammars/algol/algol60.tokens
@@ -20,7 +20,7 @@
 #   **  must come before  *   (POWER before STAR)
 #   <=  must come before  <   (LEQ before LT)
 #   >=  must come before  >   (GEQ before GT)
-#   !=  must come before any single-char use of !
+#   != and <> must come before any single-char use of !, <, or >
 #   REAL_LIT must come before INTEGER_LIT (decimal/exponent before plain digits)
 
 # ---------------------------------------------------------------------------
@@ -39,9 +39,10 @@ REAL_LIT    = /[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+/
 # Integer literal: one or more decimal digits, no decimal point, no exponent.
 INTEGER_LIT = /[0-9]+/
 
-# String literal: single-quoted. ALGOL 60 strings have no escape sequences —
-# a single quote cannot appear inside a string literal.
-STRING_LIT  = /'[^']*'/
+# String literal: quoted. ALGOL 60 strings have no escape sequences, so the
+# opening quote cannot appear unescaped inside the literal. Both single and
+# double quotes are accepted as common ASCII representations of string quotes.
+STRING_LIT  = /'[^']*'|"[^"]*"/
 
 # Identifier: letter followed by zero or more letters or digits.
 # No underscore — original ALGOL 60 did not allow it.
@@ -63,10 +64,11 @@ ASSIGN      = ":="
 # ** must come before * so "**" is not lexed as STAR STAR.
 POWER       = "**"
 
-# Relational operators (ASCII for ≤, ≥, ≠)
+# Relational operators (ASCII for ≤, ≥, ≠). Not-equal accepts both the modern
+# C-like spelling and the common ALGOL/Pascal-style angle spelling.
 LEQ         = "<="
 GEQ         = ">="
-NEQ         = "!="
+NEQ         = /!=|<>/
 
 # ---------------------------------------------------------------------------
 # Single-character operators
@@ -172,6 +174,7 @@ skip:
 
   # Comment syntax: the word "comment" followed by any text up to the next ";".
   # Example: comment this is a comment;
-  # The pattern matches "comment" (already consumed as a keyword trigger above)
-  # but the comment skip rule runs first in the skip phase.
-  COMMENT    = /comment[^;]*;/
+  # Skip patterns run before keyword reclassification, so require an identifier
+  # boundary after the case-insensitive keyword to avoid swallowing identifiers
+  # such as "commentary".
+  COMMENT    = /(?i:comment)\b[^;]*;/

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -106,6 +106,8 @@ All notable changes to this package will be documented in this file.
   switch-formal evaluation helper, so multi-entry switch parameters now return
   the label selected by the runtime index instead of depending on the last
   compiled entry register.
+- Lowered `<>` as the same not-equal comparison as `!=` for numeric, boolean,
+  and string operands.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -2509,13 +2509,13 @@ class AlgolIrCompiler:
                 raise CompileError(
                     "string comparison requires two string operands"
                 )
-            if operator.value not in {"=", "!="}:
+            if operator.value not in {"=", "!=", "<>"}:
                 raise CompileError(
                     f"comparison operator {operator.value!r} is not supported "
                     "for strings"
                 )
             dst = self._emit_string_equality(left, right, scope)
-            if operator.value == "!=":
+            if operator.value in {"!=", "<>"}:
                 dst = self._invert_bool(dst)
         elif _BOOLEAN_TYPE in {left_type, right_type}:
             if left_type != _BOOLEAN_TYPE or right_type != _BOOLEAN_TYPE:
@@ -2526,7 +2526,7 @@ class AlgolIrCompiler:
                 self._emit(
                     IrOp.CMP_EQ, IrRegister(dst), IrRegister(left), IrRegister(right)
                 )
-            elif operator.value == "!=":
+            elif operator.value in {"!=", "<>"}:
                 self._emit(
                     IrOp.CMP_NE, IrRegister(dst), IrRegister(left), IrRegister(right)
                 )
@@ -2553,7 +2553,7 @@ class AlgolIrCompiler:
                     IrRegister(left),
                     IrRegister(right),
                 )
-            elif operator.value == "!=":
+            elif operator.value in {"!=", "<>"}:
                 self._emit(
                     IrOp.F64_CMP_NE,
                     IrRegister(dst),
@@ -2597,7 +2597,7 @@ class AlgolIrCompiler:
                 self._emit(
                     IrOp.CMP_EQ, IrRegister(dst), IrRegister(left), IrRegister(right)
                 )
-            elif operator.value == "!=":
+            elif operator.value in {"!=", "<>"}:
                 self._emit(
                     IrOp.CMP_NE, IrRegister(dst), IrRegister(left), IrRegister(right)
                 )
@@ -7149,7 +7149,8 @@ def _switch_selection_indexes(node: ASTNode | None) -> list[ASTNode]:
 
 def _has_comparison(children: list[ASTNode | Token]) -> bool:
     return any(
-        isinstance(child, Token) and child.value in {"=", "!=", "<", "<=", ">", ">="}
+        isinstance(child, Token)
+        and child.value in {"=", "!=", "<>", "<", "<=", ">", ">="}
         for child in children
     )
 

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -763,6 +763,15 @@ class TestAlgolIrCompiler:
         opcodes = [instr.opcode for instr in result.program.instructions]
         assert IrOp.CMP_NE in opcodes
 
+    def test_compiles_angle_not_equal_comparison(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; if 1 <> 2 then result := 1 else result := 0 end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        assert IrOp.CMP_NE in opcodes
+
     def test_compiles_nested_block(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-lexer/CHANGELOG.md
+++ b/code/packages/python/algol-lexer/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Accepted uppercase and mixed-case ALGOL keywords in the wrapper without
+  lowercasing identifiers or string literal contents.
+- Accepted `COMMENT`/mixed-case `comment` as comment starters while preserving
+  identifiers such as `commentary` through keyword-boundary matching.
+- Accepted `<>` as an alternate ASCII spelling for ALGOL not-equal.
+- Accepted double-quoted string literals in addition to single-quoted strings.
+
 ## [0.1.0] — 2026-04-06
 
 ### Added
@@ -16,10 +27,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Grammar-driven implementation using `algol.tokens` and the `GrammarLexer`
   engine from `coding-adventures-lexer`.
 - Full support for all ALGOL 60 token types:
-  - Value tokens: `INTEGER_LIT`, `REAL_LIT` (with exponent), `STRING_LIT`
-    (single-quoted), `IDENT`
+  - Value tokens: `INTEGER_LIT`, `REAL_LIT` (with exponent), `STRING_LIT`,
+    `IDENT`
   - Multi-character operators: `ASSIGN` (`:=`), `POWER` (`**`), `LEQ` (`<=`),
-    `GEQ` (`>=`), `NEQ` (`!=`)
+    `GEQ` (`>=`), `NEQ` (`!=`, `<>`)
   - Single-character operators: `PLUS`, `MINUS`, `STAR`, `SLASH`, `CARET`,
     `EQ`, `LT`, `GT`
   - Delimiters: `LPAREN`, `RPAREN`, `LBRACKET`, `RBRACKET`, `SEMICOLON`,

--- a/code/packages/python/algol-lexer/README.md
+++ b/code/packages/python/algol-lexer/README.md
@@ -85,7 +85,7 @@ tokens = lexer.tokenize()
 | Values | `INTEGER_LIT`, `REAL_LIT`, `STRING_LIT`, `IDENT` |
 | Assignment | `ASSIGN` (`:=`) |
 | Exponentiation | `POWER` (`**`), `CARET` (`^`) |
-| Relational | `EQ` (`=`), `NEQ` (`!=`), `LT` (`<`), `GT` (`>`), `LEQ` (`<=`), `GEQ` (`>=`) |
+| Relational | `EQ` (`=`), `NEQ` (`!=`, `<>`), `LT` (`<`), `GT` (`>`), `LEQ` (`<=`), `GEQ` (`>=`) |
 | Arithmetic | `PLUS` (`+`), `MINUS` (`-`), `STAR` (`*`), `SLASH` (`/`) |
 | Delimiters | `LPAREN`, `RPAREN`, `LBRACKET`, `RBRACKET`, `SEMICOLON`, `COMMA`, `COLON` |
 
@@ -103,19 +103,29 @@ if x = 42 then ...  (* equality test: is x equal to 42? *)
 
 ### Comments
 
-ALGOL comments use the keyword `comment` followed by text up to the next `;`:
+ALGOL comments use the case-insensitive keyword `comment` followed by text up
+to the next `;`:
 
 ```algol
 comment this is a comment;
+COMMENT this is also a comment;
 x := 1; comment set x to one;
 ```
 
 The comment (including its terminating semicolon) is consumed silently.
+Identifiers that merely start with those letters, such as `commentary`, remain
+identifiers.
 
 ### Keywords Are Case-Insensitive
 
 `BEGIN`, `Begin`, and `begin` all produce the same `BEGIN` token. Keyword
 matching is done after normalizing to lowercase.
+
+### String Literals
+
+String literals may use single or double quotes. The delimiter cannot appear
+inside the literal because the grammar intentionally does not define escape
+sequences.
 
 ### Real Literals
 

--- a/code/packages/python/algol-lexer/src/algol_lexer/tokenizer.py
+++ b/code/packages/python/algol-lexer/src/algol_lexer/tokenizer.py
@@ -61,7 +61,7 @@ The lexer produces the following token kinds (defined in ``algol.tokens``):
 Value tokens:
 - ``REAL_LIT``    — floating-point literals: ``3.14``, ``1.5E3``, ``1.5E-3``
 - ``INTEGER_LIT`` — integer literals: ``42``, ``0``, ``1000``
-- ``STRING_LIT``  — single-quoted strings: ``'hello world'``
+- ``STRING_LIT``  — quoted strings: ``'hello world'`` or ``"hello world"``
 - ``IDENT``       — identifiers (reclassified as keywords when applicable)
 
 Multi-character operators (must match before their single-char prefixes):
@@ -69,7 +69,7 @@ Multi-character operators (must match before their single-char prefixes):
 - ``POWER``   — ``**``  (exponentiation, Fortran convention)
 - ``LEQ``     — ``<=``
 - ``GEQ``     — ``>=``
-- ``NEQ``     — ``!=``
+- ``NEQ``     — ``!=`` or ``<>``
 
 Single-character operators:
 - ``PLUS``, ``MINUS``, ``STAR``, ``SLASH``, ``CARET``, ``EQ``, ``LT``, ``GT``
@@ -99,14 +99,17 @@ ALGOL 60 uses a distinctive comment syntax::
 
     comment this is the comment text;
 
-The word ``comment`` triggers comment-skip mode: everything from that word up
-to (and including) the next ``;`` is consumed silently. This means a ``comment``
-appearing after a statement-terminating semicolon skips the rest of the line::
+The word ``comment`` is matched case-insensitively and triggers comment-skip
+mode: everything from that word up to (and including) the next ``;`` is consumed
+silently. This means a ``comment`` appearing after a statement-terminating
+semicolon skips the rest of the line::
 
     x := 42; comment set x to 42;
     y := x + 1
 
 The second semicolon ends both the comment and serves as the logical separator.
+Identifiers that merely start with those letters, such as ``commentary``, stay
+ordinary identifiers.
 
 Why ALGOL Uses := for Assignment
 -----------------------------------
@@ -145,7 +148,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from grammar_tools import parse_token_grammar
-from lexer import GrammarLexer, Token
+from lexer import GrammarLexer, Token, TokenType
 
 # ---------------------------------------------------------------------------
 # Grammar File Location
@@ -169,6 +172,39 @@ def resolve_tokens_path(version: str = "algol60") -> Path:
     return GRAMMAR_DIR / "algol" / f"{version}.tokens"
 
 
+def _normalize_case_insensitive_keywords(
+    tokens: list[Token],
+    keywords: set[str],
+) -> list[Token]:
+    """Promote ALGOL keywords without lowercasing the whole source stream."""
+    normalized: list[Token] = []
+    for token in tokens:
+        value = token.value.lower()
+        if token.type in (TokenType.NAME, "NAME") and value in keywords:
+            normalized.append(
+                Token(
+                    type=TokenType.KEYWORD,
+                    value=value,
+                    line=token.line,
+                    column=token.column,
+                    flags=token.flags,
+                )
+            )
+        elif token.type in (TokenType.KEYWORD, "KEYWORD") and value in keywords:
+            normalized.append(
+                Token(
+                    type=token.type,
+                    value=value,
+                    line=token.line,
+                    column=token.column,
+                    flags=token.flags,
+                )
+            )
+        else:
+            normalized.append(token)
+    return normalized
+
+
 def create_algol_lexer(source: str, version: str = "algol60") -> GrammarLexer:
     """Create a ``GrammarLexer`` configured for ALGOL 60 text.
 
@@ -185,7 +221,7 @@ def create_algol_lexer(source: str, version: str = "algol60") -> GrammarLexer:
     - **Case insensitivity**: ``BEGIN``, ``Begin``, and ``begin`` all produce
       the same token kind. The grammar normalizes to lowercase.
     - **Comment skipping**: ``comment text;`` is consumed without emitting
-      any token.
+      any token, and the keyword is matched case-insensitively.
     - **Operator ordering**: ``:=`` is matched before ``:``, ``**`` before
       ``*``, ``<=`` before ``<``, ``>=`` before ``>``.
 
@@ -206,7 +242,12 @@ def create_algol_lexer(source: str, version: str = "algol60") -> GrammarLexer:
         tokens = lexer.tokenize()
     """
     grammar = parse_token_grammar(resolve_tokens_path(version).read_text())
-    return GrammarLexer(source, grammar)
+    lexer = GrammarLexer(source, grammar)
+    keyword_set = {keyword.lower() for keyword in grammar.keywords}
+    lexer.add_post_tokenize(
+        lambda tokens: _normalize_case_insensitive_keywords(tokens, keyword_set)
+    )
+    return lexer
 
 
 def tokenize_algol(source: str, version: str = "algol60") -> list[Token]:
@@ -221,12 +262,12 @@ def tokenize_algol(source: str, version: str = "algol60") -> list[Token]:
     Value tokens:
     - **REAL_LIT**    — floating-point: ``3.14``, ``1.5E3``, ``100E2``
     - **INTEGER_LIT** — integer: ``42``, ``0``, ``1000``
-    - **STRING_LIT**  — single-quoted: ``'hello world'``
+    - **STRING_LIT**  — quoted: ``'hello world'`` or ``"hello world"``
     - **IDENT**       — identifiers not matching any keyword
 
     Operators:
     - **ASSIGN** (``:=``), **POWER** (``**``), **CARET** (``^``)
-    - **LEQ** (``<=``), **GEQ** (``>=``), **NEQ** (``!=``)
+    - **LEQ** (``<=``), **GEQ** (``>=``), **NEQ** (``!=`` or ``<>``)
     - **PLUS**, **MINUS**, **STAR**, **SLASH**, **EQ**, **LT**, **GT**
 
     Delimiters:

--- a/code/packages/python/algol-lexer/tests/test_algol_lexer.py
+++ b/code/packages/python/algol-lexer/tests/test_algol_lexer.py
@@ -26,8 +26,8 @@ ALGOL 60 has several tokenization behaviors that differ from modern languages:
    INTEGER_LIT so that ``3.14`` matches as one REAL_LIT, not INTEGER_LIT
    ``3`` followed by a syntax error on ``.14``.
 
-6. **String literals are single-quoted**: ``'hello'``, not ``"hello"``.
-   No escape sequences — a quote cannot appear inside an ALGOL 60 string.
+6. **String literals are quoted**: ``'hello'`` or ``"hello"``.
+   No escape sequences — the opening quote cannot appear inside the string.
 """
 
 from __future__ import annotations
@@ -47,7 +47,9 @@ def token_types(source: str) -> list[str]:
     """Tokenize and return just the type names (excluding EOF)."""
     tokens = tokenize_algol(source)
     return [
-        t.type if isinstance(t.type, str) else t.type.name
+        t.value.upper()
+        if (t.type if isinstance(t.type, str) else t.type.name) == "KEYWORD"
+        else (t.type if isinstance(t.type, str) else t.type.name)
         for t in tokens
         if (t.type if isinstance(t.type, str) else t.type.name) != "EOF"
     ]
@@ -226,7 +228,7 @@ class TestOperators:
     Key design facts:
     - ``:=`` is ASSIGN (not ``:`` + ``=`` — the multi-char match fires first)
     - ``**`` is POWER (not ``*`` + ``*``)
-    - ``<=`` is LEQ, ``>=`` is GEQ, ``!=`` is NEQ
+    - ``<=`` is LEQ, ``>=`` is GEQ, ``!=`` and ``<>`` are NEQ
     - ``^`` is CARET (alternative exponentiation, same precedence as ``**``)
     - ``=`` is EQ (equality test, NOT assignment)
     """
@@ -261,6 +263,11 @@ class TestOperators:
         types = token_types("!=")
         assert types == ["NEQ"]
 
+    def test_angle_neq(self) -> None:
+        """``<>`` is also accepted as an ALGOL/Pascal-style NEQ token."""
+        types = token_types("<>")
+        assert types == ["NEQ"]
+
     def test_eq(self) -> None:
         """``=`` is EQ (equality), not assignment."""
         types = token_types("=")
@@ -288,8 +295,8 @@ class TestOperators:
 
     def test_all_relational_operators(self) -> None:
         """All six relational operators tokenize correctly."""
-        types = token_types("< <= = != >= >")
-        assert types == ["LT", "LEQ", "EQ", "NEQ", "GEQ", "GT"]
+        types = token_types("< <= = != <> >= >")
+        assert types == ["LT", "LEQ", "EQ", "NEQ", "NEQ", "GEQ", "GT"]
 
 
 # ---------------------------------------------------------------------------
@@ -449,9 +456,9 @@ class TestRealLiteral:
 class TestStringLiteral:
     """Tests for ALGOL 60 string literal tokenization.
 
-    ALGOL 60 uses single quotes for strings. There are no escape sequences —
-    the original language had no way to include a single quote inside a string
-    literal. The lexer matches everything between opening and closing ``'``.
+    ALGOL 60 uses quoted strings. There are no escape sequences — the original
+    language had no way to include the opening quote inside a string literal.
+    The lexer accepts both common ASCII quote spellings.
     """
 
     def test_simple_string(self) -> None:
@@ -470,6 +477,18 @@ class TestStringLiteral:
     def test_empty_string(self) -> None:
         """An empty single-quoted string: ``''``."""
         types = token_types("''")
+        assert types == ["STRING_LIT"]
+
+    def test_double_quoted_string(self) -> None:
+        """A double-quoted string is also accepted."""
+        types = token_types('"hello"')
+        values = token_values('"hello"')
+        assert types == ["STRING_LIT"]
+        assert values == ['"hello"']
+
+    def test_empty_double_quoted_string(self) -> None:
+        """An empty double-quoted string is also accepted."""
+        types = token_types('""')
         assert types == ["STRING_LIT"]
 
     def test_string_with_digits(self) -> None:
@@ -508,6 +527,11 @@ class TestCommentSkipping:
         types = token_types("comment this is a comment;")
         assert types == []
 
+    def test_comment_keyword_is_case_insensitive(self) -> None:
+        """COMMENT follows the same case-insensitive keyword policy."""
+        assert token_types("COMMENT this is a comment;") == []
+        assert token_types("Comment this is a comment;") == []
+
     def test_code_after_comment(self) -> None:
         """Tokens after a comment are still emitted."""
         types = token_types("comment ignore this; x")
@@ -539,6 +563,13 @@ class TestCommentSkipping:
         # Just verify no crash and reasonable token count.
         tokens = token_values(source)
         assert "42" in tokens or "0" in tokens  # some tokens visible
+
+    def test_comment_prefix_identifier_is_not_skipped(self) -> None:
+        """Identifiers beginning with comment still respect keyword boundaries."""
+        source = "commentary := 1;"
+
+        assert token_types(source) == ["NAME", "ASSIGN", "INTEGER_LIT", "SEMICOLON"]
+        assert token_values(source)[0] == "commentary"
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/algol-parser/CHANGELOG.md
+++ b/code/packages/python/algol-parser/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   semicolons, matching common ALGOL dummy-statement style.
 - `goto_stmt` now accepts the report-style two-word `go to` spelling in
   addition to the compact `goto` spelling.
+- Parsed uppercase and mixed-case keywords/comments, `<>` not-equal relations,
+  and double-quoted string literals through the shared ALGOL lexer.
 
 ## [0.1.0] — 2026-04-06
 

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -128,16 +128,38 @@ class TestMinimalProgram:
         """A block contains BEGIN and END tokens."""
         ast = parse("begin integer x; x := 42 end")
         all_tokens: list[Token] = []
+
         def collect_tokens(node: ASTNode) -> None:
             for child in node.children:
                 if isinstance(child, Token):
                     all_tokens.append(child)
                 else:
                     collect_tokens(child)
+
         collect_tokens(ast)
         token_values = [token.value for token in all_tokens]
         assert "begin" in token_values
         assert "end" in token_values
+
+    def test_keywords_are_case_insensitive(self) -> None:
+        """Uppercase keywords parse through the ALGOL front door."""
+        ast = parse("BEGIN INTEGER x; x := 42 END")
+
+        assert ast.rule_name == "program"
+
+    def test_uppercase_comment_is_ignored(self) -> None:
+        """Uppercase COMMENT follows ALGOL's case-insensitive keyword policy."""
+        ast = parse("begin COMMENT setup; integer x; x := 42 end")
+
+        assert ast.rule_name == "program"
+
+    def test_comment_prefixed_identifier_is_not_ignored(self) -> None:
+        """A variable whose name starts with comment is still a variable."""
+        ast = parse("begin integer commentary; commentary := 42 end")
+        assign_nodes = find_nodes(ast, "assign_stmt")
+
+        assert ast.rule_name == "program"
+        assert assign_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +301,12 @@ class TestIfStatement:
         assert ast.rule_name == "program"
         cond_nodes = find_nodes(ast, "cond_stmt")
         assert len(cond_nodes) >= 1
+
+    def test_if_with_angle_not_equal(self) -> None:
+        """The common ``<>`` not-equal spelling parses as a relation."""
+        ast = parse("begin integer x; if x <> 0 then x := 1 end")
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "relation")
 
     def test_if_with_boolean_operators(self) -> None:
         """Conditional with AND and NOT in the boolean expression."""
@@ -650,6 +678,12 @@ class TestProcedureCall:
         )
         proc_nodes = find_nodes(ast, "proc_stmt")
         assert len(proc_nodes) >= 1
+
+    def test_procedure_call_with_double_quoted_string_arg(self) -> None:
+        """Double-quoted string literals parse as actual parameters."""
+        ast = parse('begin output("Hi") end')
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "proc_stmt")
 
     def test_procedure_call_as_statement(self) -> None:
         """A procedure call appears as a statement."""

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -71,6 +71,8 @@ All notable changes to this package will be documented in this file.
 - Added configurable type-check resource limits for maximum AST depth, block
   nesting depth, and procedure nesting depth so recursive semantic visitors
   reject hostile inputs with diagnostics before walking too deeply.
+- Accepted shared lexer front-door spellings for uppercase keywords/comments,
+  `<>` not-equal relations, and double-quoted string literals.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1719,7 +1719,7 @@ class AlgolTypeChecker:
         if expr.rule_name in {"expr_cmp", "relation"}:
             if any(
                 isinstance(child, Token)
-                and child.value in {"=", "!=", "<", "<=", ">", ">="}
+                and child.value in {"=", "!=", "<>", "<", "<=", ">", ">="}
                 for child in meaningful
             ):
                 return self._infer_comparison(expr, meaningful, scope)
@@ -3147,12 +3147,12 @@ class AlgolTypeChecker:
         if _is_numeric_type(left) and _is_numeric_type(right):
             return BOOLEAN
         if (
-            operator.value in {"=", "!="}
+            operator.value in {"=", "!=", "<>"}
             and left == right
             and left in {BOOLEAN, STRING}
         ):
             return BOOLEAN
-        if operator.value not in {"=", "!="}:
+        if operator.value not in {"=", "!=", "<>"}:
             actual = left if not _is_numeric_type(left) else right
             self._error(node, f"operator requires numeric operand, got {actual}")
             return ERROR

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -31,6 +31,39 @@ class TestAlgolTypeChecker:
         assert result.ok
         assert result.root_scope.children[0].symbols["result"].type_name == "integer"
 
+    def test_accepts_uppercase_keywords(self) -> None:
+        ast = parse_algol("BEGIN INTEGER result; result := 7 END")
+        result = check_algol(ast)
+
+        assert result.ok
+
+    def test_accepts_uppercase_comment(self) -> None:
+        ast = parse_algol("begin COMMENT setup; integer result; result := 7 end")
+        result = check_algol(ast)
+
+        assert result.ok
+
+    def test_accepts_comment_prefixed_identifier(self) -> None:
+        ast = parse_algol("begin integer commentary; commentary := 7 end")
+        result = check_algol(ast)
+
+        assert result.ok
+        assert "commentary" in result.root_scope.children[0].symbols
+
+    def test_accepts_angle_not_equal_operator(self) -> None:
+        ast = parse_algol(
+            "begin integer result; if 1 <> 2 then result := 7 else result := 0 end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+
+    def test_accepts_double_quoted_string_literal(self) -> None:
+        ast = parse_algol('begin string message; message := "Hi" end')
+        result = check_algol(ast)
+
+        assert result.ok
+
     def test_reports_undeclared_identifier(self) -> None:
         ast = parse_algol("begin integer result; result := missing end")
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -110,6 +110,8 @@ All notable changes to this package will be documented in this file.
   procedure calls, label and switch formals, multiple `for` element forms,
   parenthesized conditional designational expressions, numeric labels, boolean
   operators, real arithmetic, and output in one end-to-end WASM program.
+- Accepted uppercase and mixed-case keywords/comments, `<>` not-equal
+  relations, and double-quoted string literals through the full WASM pipeline.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,6 +18,8 @@ the current lane already supports a substantial ALGOL 60 surface:
 - `own` scalars and arrays with static lifetime
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
+- case-insensitive keywords and comments, `!=` or `<>` not-equal spelling, and
+  single- or double-quoted string literals
 - chained assignment, conditional expressions, tolerant trailing/repeated
   semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer or real exponents
@@ -39,7 +41,7 @@ the current lane already supports a substantial ALGOL 60 surface:
 - builtin `print(...)` / `output(...)` for integers, booleans, reals, strings,
   and string variables
 
-Within the repository's lowercase ASCII `algol60` grammar, the executable
+Within the repository's ASCII `algol60` grammar, the executable
 declaration, statement, expression, procedure, array, by-name, and designational
 surface is now implemented and covered by golden WASM fixtures. It is not a
 claim of historical whole-environment compatibility with every ALGOL system:

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -36,6 +36,34 @@ class TestAlgolWasmCompiler:
         result = pack_source("begin integer result; result := 1 + 2 * 3 end")
         assert len(result.binary) > 8
 
+    def test_uppercase_keywords_execute(self) -> None:
+        result = compile_source("BEGIN INTEGER result; result := 7 END")
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_uppercase_comment_is_ignored(self) -> None:
+        result = compile_source("begin COMMENT setup; integer result; result := 7 end")
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_comment_prefixed_identifier_is_not_skipped(self) -> None:
+        result = compile_source(
+            "begin integer result, commentary; commentary := 7; result := commentary end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_angle_not_equal_operator_executes(self) -> None:
+        result = compile_source(
+            "begin integer result; if 1 <> 2 then result := 7 else result := 0 end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_double_quoted_string_literal_writes_stdout(self) -> None:
+        result = compile_source('begin output("Hi") end')
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [0]
+        assert "".join(captured) == "Hi"
+
     def test_write_wasm_file(self, tmp_path: Path) -> None:
         out = tmp_path / "answer.wasm"
         result = write_wasm_file("begin integer result; result := 9 end", out)


### PR DESCRIPTION
## Summary
- normalize ALGOL keywords case-insensitively in the lexer wrapper without lowercasing identifiers or string literal contents
- broaden the source front door with case-insensitive `comment`, safe `comment` keyword boundaries, `<>` not-equal, and double-quoted string literals
- carry `<>` through type checking, IR lowering, and end-to-end WASM execution with parser/type-checker/IR/WASM coverage

## Verification
- `../algol-wasm-compiler/.venv/bin/python -m pytest tests/test_algol_lexer.py`
- `../algol-wasm-compiler/.venv/bin/python -m pytest tests/test_algol_parser.py`
- `../algol-wasm-compiler/.venv/bin/python -m pytest tests/test_algol_type_checker.py`
- `../algol-wasm-compiler/.venv/bin/python -m pytest tests/test_algol_ir_compiler.py`
- `bash BUILD` in `code/packages/python/algol-ir-compiler`
- `bash BUILD` in `code/packages/python/algol-type-checker`
- `bash BUILD` in `code/packages/python/algol-wasm-compiler` (193 passed)
- `git diff --check HEAD~1..HEAD`

## Security review
- Changed lines are limited to token normalization, comparison operator handling, tests, and docs.
- No new process execution, network access, file I/O, deserialization, or secret-handling paths were added.