### PR TITLE
Support ALGOL publication symbols

### DIFF
--- a/code/grammars/algol/algol60.tokens
+++ b/code/grammars/algol/algol60.tokens
@@ -18,9 +18,9 @@
 # Key ordering rules (first match wins):
 #   :=  must come before  :   (ASSIGN before COLON)
 #   **  must come before  *   (POWER before STAR)
-#   <=  must come before  <   (LEQ before LT)
-#   >=  must come before  >   (GEQ before GT)
-#   != and <> must come before any single-char use of !, <, or >
+#   <= and ≤ must come before  <   (LEQ before LT)
+#   >= and ≥ must come before  >   (GEQ before GT)
+#   !=, <>, and ≠ must come before any single-char use of !, <, or >
 #   REAL_LIT must come before INTEGER_LIT (decimal/exponent before plain digits)
 
 # ---------------------------------------------------------------------------
@@ -64,11 +64,19 @@ ASSIGN      = ":="
 # ** must come before * so "**" is not lexed as STAR STAR.
 POWER       = "**"
 
-# Relational operators (ASCII for ≤, ≥, ≠). Not-equal accepts both the modern
-# C-like spelling and the common ALGOL/Pascal-style angle spelling.
-LEQ         = "<="
-GEQ         = ">="
-NEQ         = /!=|<>/
+# Relational operators. The wrapper normalizes the publication symbols to the
+# same values as the ASCII spellings.
+LEQ         = /<=|≤/
+GEQ         = />=|≥/
+NEQ         = /!=|<>|≠/
+
+# Publication-symbol boolean operators. The ALGOL lexer wrapper normalizes
+# these to the same keyword values as their word forms.
+NOT_SYM     = "¬"
+AND_SYM     = "∧"
+OR_SYM      = "∨"
+IMPL_SYM    = "⊃"
+EQV_SYM     = "≡"
 
 # ---------------------------------------------------------------------------
 # Single-character operators
@@ -79,10 +87,9 @@ MINUS       = "-"
 STAR        = "*"
 SLASH       = "/"
 
-# Caret: alternative to ** for exponentiation.
-# Both ^ and ** produce different token kinds so the parser can treat them
-# identically (both map to the exponentiation operator).
-CARET       = "^"
+# Caret: alternative to ** for exponentiation. The ALGOL publication uparrow
+# is normalized to the same token/value shape as caret.
+CARET       = /\^|↑/
 
 # Equality test (not assignment — ALGOL uses := for that).
 EQ          = "="

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -89,6 +89,8 @@ All notable changes to this package will be documented in this file.
   dispatch rather than compile-time descriptor expansion.
 - Lowered `go to` statements through the same direct and designational goto
   paths as the compact `goto` spelling.
+- Lowered normalized ALGOL publication symbols for relations, exponentiation,
+  and boolean operators through the existing ASCII/keyword operator paths.
 - Lowered standard numeric builtin functions `abs`, `sign`, and `entier` using
   existing integer/f64 IR operations.
 - Lowered standard real builtin function `sqrt` to integer-to-real promotion,

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -772,6 +772,24 @@ class TestAlgolIrCompiler:
         opcodes = [instr.opcode for instr in result.program.instructions]
         assert IrOp.CMP_NE in opcodes
 
+    def test_compiles_publication_symbol_operators(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "if (2 ↑ 3 = 8) ∧ (3 ≤ 4) ∧ (5 ≥ 5) ∧ (1 ≠ 2) "
+                "∧ (¬ false) ∧ (true ⊃ true) ∧ (true ≡ true) "
+                "then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.MUL in opcodes
+        assert IrOp.CMP_EQ in opcodes
+        assert IrOp.CMP_NE in opcodes
+        assert IrOp.CMP_GT in opcodes
+        assert IrOp.CMP_LT in opcodes
+
     def test_compiles_nested_block(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-lexer/CHANGELOG.md
+++ b/code/packages/python/algol-lexer/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Accepted `COMMENT`/mixed-case `comment` as comment starters while preserving
   identifiers such as `commentary` through keyword-boundary matching.
 - Accepted `<>` as an alternate ASCII spelling for ALGOL not-equal.
+- Accepted ALGOL publication symbols `≤`, `≥`, `≠`, `↑`, `∧`, `∨`, `¬`, `⊃`,
+  and `≡`, normalizing them to the existing ASCII or keyword token values.
 - Accepted double-quoted string literals in addition to single-quoted strings.
 
 ## [0.1.0] — 2026-04-06

--- a/code/packages/python/algol-lexer/README.md
+++ b/code/packages/python/algol-lexer/README.md
@@ -84,8 +84,8 @@ tokens = lexer.tokenize()
 | Arithmetic | `DIV`, `MOD` |
 | Values | `INTEGER_LIT`, `REAL_LIT`, `STRING_LIT`, `IDENT` |
 | Assignment | `ASSIGN` (`:=`) |
-| Exponentiation | `POWER` (`**`), `CARET` (`^`) |
-| Relational | `EQ` (`=`), `NEQ` (`!=`, `<>`), `LT` (`<`), `GT` (`>`), `LEQ` (`<=`), `GEQ` (`>=`) |
+| Exponentiation | `POWER` (`**`), `CARET` (`^`, `↑`) |
+| Relational | `EQ` (`=`), `NEQ` (`!=`, `<>`, `≠`), `LT` (`<`), `GT` (`>`), `LEQ` (`<=`, `≤`), `GEQ` (`>=`, `≥`) |
 | Arithmetic | `PLUS` (`+`), `MINUS` (`-`), `STAR` (`*`), `SLASH` (`/`) |
 | Delimiters | `LPAREN`, `RPAREN`, `LBRACKET`, `RBRACKET`, `SEMICOLON`, `COMMA`, `COLON` |
 
@@ -120,6 +120,13 @@ identifiers.
 
 `BEGIN`, `Begin`, and `begin` all produce the same `BEGIN` token. Keyword
 matching is done after normalizing to lowercase.
+
+### Publication Symbols
+
+ALGOL 60 publication symbols normalize to the same token values as the ASCII or
+word spellings used by the parser and compiler: `≤` to `<=`, `≥` to `>=`, `≠`
+to `!=`, `↑` to `^`, and `¬`, `∧`, `∨`, `⊃`, `≡` to `not`, `and`, `or`,
+`impl`, `eqv`.
 
 ### String Literals
 

--- a/code/packages/python/algol-lexer/src/algol_lexer/tokenizer.py
+++ b/code/packages/python/algol-lexer/src/algol_lexer/tokenizer.py
@@ -67,12 +67,13 @@ Value tokens:
 Multi-character operators (must match before their single-char prefixes):
 - ``ASSIGN``  — ``:=``  (ALGOL separates assignment from equality — no C-style bugs)
 - ``POWER``   — ``**``  (exponentiation, Fortran convention)
-- ``LEQ``     — ``<=``
-- ``GEQ``     — ``>=``
-- ``NEQ``     — ``!=`` or ``<>``
+- ``LEQ``     — ``<=`` or ``≤``
+- ``GEQ``     — ``>=`` or ``≥``
+- ``NEQ``     — ``!=``, ``<>``, or ``≠``
 
 Single-character operators:
-- ``PLUS``, ``MINUS``, ``STAR``, ``SLASH``, ``CARET``, ``EQ``, ``LT``, ``GT``
+- ``PLUS``, ``MINUS``, ``STAR``, ``SLASH``, ``CARET`` (``^`` or ``↑``),
+  ``EQ``, ``LT``, ``GT``
 
 Delimiters:
 - ``LPAREN``, ``RPAREN``, ``LBRACKET``, ``RBRACKET``
@@ -163,6 +164,21 @@ from lexer import GrammarLexer, Token, TokenType
 GRAMMAR_DIR = Path(__file__).parent.parent.parent.parent.parent.parent / "grammars"
 VALID_VERSIONS = {"algol60"}
 
+_SYMBOLIC_KEYWORDS = {
+    "NOT_SYM": "not",
+    "AND_SYM": "and",
+    "OR_SYM": "or",
+    "IMPL_SYM": "impl",
+    "EQV_SYM": "eqv",
+}
+
+_SYMBOLIC_OPERATOR_VALUES = {
+    "LEQ": {"≤": "<="},
+    "GEQ": {"≥": ">="},
+    "NEQ": {"≠": "!="},
+    "CARET": {"↑": "^"},
+}
+
 
 def resolve_tokens_path(version: str = "algol60") -> Path:
     """Resolve a supported ALGOL token grammar path."""
@@ -172,33 +188,51 @@ def resolve_tokens_path(version: str = "algol60") -> Path:
     return GRAMMAR_DIR / "algol" / f"{version}.tokens"
 
 
-def _normalize_case_insensitive_keywords(
+def _replace_token(token: Token, *, type_: TokenType | str, value: str) -> Token:
+    return Token(
+        type=type_,
+        value=value,
+        line=token.line,
+        column=token.column,
+        flags=token.flags,
+    )
+
+
+def _normalize_algol_tokens(
     tokens: list[Token],
     keywords: set[str],
 ) -> list[Token]:
-    """Promote ALGOL keywords without lowercasing the whole source stream."""
+    """Normalize ALGOL keywords and publication symbols after tokenization."""
     normalized: list[Token] = []
     for token in tokens:
+        symbolic_keyword = _SYMBOLIC_KEYWORDS.get(token.type_name)
+        if symbolic_keyword is not None:
+            normalized.append(
+                _replace_token(
+                    token,
+                    type_=TokenType.KEYWORD,
+                    value=symbolic_keyword,
+                )
+            )
+            continue
+
+        symbolic_operator = _SYMBOLIC_OPERATOR_VALUES.get(token.type_name, {}).get(
+            token.value
+        )
+        if symbolic_operator is not None:
+            normalized.append(
+                _replace_token(token, type_=token.type, value=symbolic_operator)
+            )
+            continue
+
         value = token.value.lower()
         if token.type in (TokenType.NAME, "NAME") and value in keywords:
             normalized.append(
-                Token(
-                    type=TokenType.KEYWORD,
-                    value=value,
-                    line=token.line,
-                    column=token.column,
-                    flags=token.flags,
-                )
+                _replace_token(token, type_=TokenType.KEYWORD, value=value)
             )
         elif token.type in (TokenType.KEYWORD, "KEYWORD") and value in keywords:
             normalized.append(
-                Token(
-                    type=token.type,
-                    value=value,
-                    line=token.line,
-                    column=token.column,
-                    flags=token.flags,
-                )
+                _replace_token(token, type_=token.type, value=value)
             )
         else:
             normalized.append(token)
@@ -220,6 +254,9 @@ def create_algol_lexer(source: str, version: str = "algol60") -> GrammarLexer:
       token ``beginning`` does not match the keyword ``begin``.
     - **Case insensitivity**: ``BEGIN``, ``Begin``, and ``begin`` all produce
       the same token kind. The grammar normalizes to lowercase.
+    - **Publication symbols**: ``≤``, ``≥``, ``≠``, ``↑``, ``∧``, ``∨``,
+      ``¬``, ``⊃``, and ``≡`` normalize to the same token stream as their
+      ASCII or word spellings.
     - **Comment skipping**: ``comment text;`` is consumed without emitting
       any token, and the keyword is matched case-insensitively.
     - **Operator ordering**: ``:=`` is matched before ``:``, ``**`` before
@@ -244,9 +281,7 @@ def create_algol_lexer(source: str, version: str = "algol60") -> GrammarLexer:
     grammar = parse_token_grammar(resolve_tokens_path(version).read_text())
     lexer = GrammarLexer(source, grammar)
     keyword_set = {keyword.lower() for keyword in grammar.keywords}
-    lexer.add_post_tokenize(
-        lambda tokens: _normalize_case_insensitive_keywords(tokens, keyword_set)
-    )
+    lexer.add_post_tokenize(lambda tokens: _normalize_algol_tokens(tokens, keyword_set))
     return lexer
 
 
@@ -266,8 +301,9 @@ def tokenize_algol(source: str, version: str = "algol60") -> list[Token]:
     - **IDENT**       — identifiers not matching any keyword
 
     Operators:
-    - **ASSIGN** (``:=``), **POWER** (``**``), **CARET** (``^``)
-    - **LEQ** (``<=``), **GEQ** (``>=``), **NEQ** (``!=`` or ``<>``)
+    - **ASSIGN** (``:=``), **POWER** (``**``), **CARET** (``^`` or ``↑``)
+    - **LEQ** (``<=`` or ``≤``), **GEQ** (``>=`` or ``≥``),
+      **NEQ** (``!=``, ``<>``, or ``≠``)
     - **PLUS**, **MINUS**, **STAR**, **SLASH**, **EQ**, **LT**, **GT**
 
     Delimiters:

--- a/code/packages/python/algol-lexer/tests/test_algol_lexer.py
+++ b/code/packages/python/algol-lexer/tests/test_algol_lexer.py
@@ -32,15 +32,19 @@ ALGOL 60 has several tokenization behaviors that differ from modern languages:
 
 from __future__ import annotations
 
-import pytest
-
-from algol_lexer import create_algol_lexer, tokenize_algol
 from lexer import GrammarLexer, Token
 
+from algol_lexer import create_algol_lexer, tokenize_algol
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def token_type_name(token: Token) -> str:
+    """Return a token type name for either enum-backed or string tokens."""
+    token_type = token.type
+    return token_type if isinstance(token_type, str) else token_type.name
 
 
 def token_types(source: str) -> list[str]:
@@ -48,10 +52,10 @@ def token_types(source: str) -> list[str]:
     tokens = tokenize_algol(source)
     return [
         t.value.upper()
-        if (t.type if isinstance(t.type, str) else t.type.name) == "KEYWORD"
-        else (t.type if isinstance(t.type, str) else t.type.name)
+        if token_type_name(t) == "KEYWORD"
+        else token_type_name(t)
         for t in tokens
-        if (t.type if isinstance(t.type, str) else t.type.name) != "EOF"
+        if token_type_name(t) != "EOF"
     ]
 
 
@@ -61,7 +65,7 @@ def token_values(source: str) -> list[str]:
     return [
         t.value
         for t in tokens
-        if (t.type if isinstance(t.type, str) else t.type.name) != "EOF"
+        if token_type_name(t) != "EOF"
     ]
 
 
@@ -83,8 +87,7 @@ class TestFactory:
         lexer = create_algol_lexer("begin integer x; x := 42 end")
         tokens = lexer.tokenize()
         assert len(tokens) >= 2  # at least something + EOF
-        last_type = tokens[-1].type if isinstance(tokens[-1].type, str) else tokens[-1].type.name
-        assert last_type == "EOF"
+        assert token_type_name(tokens[-1]) == "EOF"
 
 
 # ---------------------------------------------------------------------------
@@ -174,9 +177,8 @@ class TestKeywords:
 class TestBooleanKeywords:
     """Tests for ALGOL 60 boolean operator keywords.
 
-    ALGOL 60 uses words for all boolean operators — no ``&&``, ``||``, ``!``.
-    This makes programs more readable to non-programmers (the original goal
-    was to create a language readable by scientists and mathematicians).
+    The lexer accepts both word spellings and ALGOL publication symbols, then
+    normalizes the symbols to the same keyword values as the words.
 
     Operator precedence (lowest to highest):
         eqv   — logical equivalence (a eqv b = a ↔ b)
@@ -216,6 +218,11 @@ class TestBooleanKeywords:
         types = token_types("not and or impl eqv")
         assert types == ["NOT", "AND", "OR", "IMPL", "EQV"]
 
+    def test_publication_symbol_boolean_operators(self) -> None:
+        """Publication-symbol booleans normalize to keyword spellings."""
+        assert token_types("¬ ∧ ∨ ⊃ ≡") == ["NOT", "AND", "OR", "IMPL", "EQV"]
+        assert token_values("¬ ∧ ∨ ⊃ ≡") == ["not", "and", "or", "impl", "eqv"]
+
 
 # ---------------------------------------------------------------------------
 # Operator tests
@@ -228,8 +235,8 @@ class TestOperators:
     Key design facts:
     - ``:=`` is ASSIGN (not ``:`` + ``=`` — the multi-char match fires first)
     - ``**`` is POWER (not ``*`` + ``*``)
-    - ``<=`` is LEQ, ``>=`` is GEQ, ``!=`` and ``<>`` are NEQ
-    - ``^`` is CARET (alternative exponentiation, same precedence as ``**``)
+    - ``<=``/``≤`` are LEQ, ``>=``/``≥`` are GEQ, ``!=``/``<>``/``≠`` are NEQ
+    - ``^``/``↑`` are CARET (alternative exponentiation, same precedence as ``**``)
     - ``=`` is EQ (equality test, NOT assignment)
     """
 
@@ -248,15 +255,30 @@ class TestOperators:
         types = token_types("^")
         assert types == ["CARET"]
 
+    def test_publication_symbol_caret(self) -> None:
+        """``↑`` normalizes to the existing CARET exponentiation token."""
+        assert token_types("↑") == ["CARET"]
+        assert token_values("↑") == ["^"]
+
     def test_leq(self) -> None:
         """``<=`` is a single LEQ token, not LT EQ."""
         types = token_types("<=")
         assert types == ["LEQ"]
 
+    def test_publication_symbol_leq(self) -> None:
+        """``≤`` normalizes to the existing LEQ operator value."""
+        assert token_types("≤") == ["LEQ"]
+        assert token_values("≤") == ["<="]
+
     def test_geq(self) -> None:
         """``>=`` is a single GEQ token, not GT EQ."""
         types = token_types(">=")
         assert types == ["GEQ"]
+
+    def test_publication_symbol_geq(self) -> None:
+        """``≥`` normalizes to the existing GEQ operator value."""
+        assert token_types("≥") == ["GEQ"]
+        assert token_values("≥") == [">="]
 
     def test_neq(self) -> None:
         """``!=`` is a single NEQ token."""
@@ -267,6 +289,11 @@ class TestOperators:
         """``<>`` is also accepted as an ALGOL/Pascal-style NEQ token."""
         types = token_types("<>")
         assert types == ["NEQ"]
+
+    def test_publication_symbol_neq(self) -> None:
+        """``≠`` normalizes to the existing NEQ operator value."""
+        assert token_types("≠") == ["NEQ"]
+        assert token_values("≠") == ["!="]
 
     def test_eq(self) -> None:
         """``=`` is EQ (equality), not assignment."""
@@ -295,8 +322,19 @@ class TestOperators:
 
     def test_all_relational_operators(self) -> None:
         """All six relational operators tokenize correctly."""
-        types = token_types("< <= = != <> >= >")
-        assert types == ["LT", "LEQ", "EQ", "NEQ", "NEQ", "GEQ", "GT"]
+        types = token_types("< <= ≤ = != <> ≠ >= ≥ >")
+        assert types == [
+            "LT",
+            "LEQ",
+            "LEQ",
+            "EQ",
+            "NEQ",
+            "NEQ",
+            "NEQ",
+            "GEQ",
+            "GEQ",
+            "GT",
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -514,7 +552,8 @@ class TestCommentSkipping:
         x := 1; comment this sets x;
         y := 2
 
-    the lexer sees: IDENT ASSIGN INTEGER_LIT SEMICOLON [comment skipped] IDENT ASSIGN INTEGER_LIT
+    the lexer sees: IDENT ASSIGN INTEGER_LIT SEMICOLON [comment skipped]
+    IDENT ASSIGN INTEGER_LIT
 
     Wait — the semicolon before 'comment' is emitted as SEMICOLON. Then the
     'comment...' pattern consumes 'comment this sets x;' as a skip. So
@@ -839,19 +878,16 @@ class TestEOF:
         """Token list always ends with EOF."""
         tokens = tokenize_algol("x := 1")
         last = tokens[-1]
-        eof_name = last.type if isinstance(last.type, str) else last.type.name
-        assert eof_name == "EOF"
+        assert token_type_name(last) == "EOF"
 
     def test_empty_input_has_eof(self) -> None:
         """Empty input still produces an EOF token."""
         tokens = tokenize_algol("")
         assert len(tokens) == 1
-        eof_name = tokens[0].type if isinstance(tokens[0].type, str) else tokens[0].type.name
-        assert eof_name == "EOF"
+        assert token_type_name(tokens[0]) == "EOF"
 
     def test_whitespace_only_has_eof(self) -> None:
         """Input with only whitespace produces just EOF."""
         tokens = tokenize_algol("   \t\n  ")
         assert len(tokens) == 1
-        eof_name = tokens[0].type if isinstance(tokens[0].type, str) else tokens[0].type.name
-        assert eof_name == "EOF"
+        assert token_type_name(tokens[0]) == "EOF"

--- a/code/packages/python/algol-parser/CHANGELOG.md
+++ b/code/packages/python/algol-parser/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   addition to the compact `goto` spelling.
 - Parsed uppercase and mixed-case keywords/comments, `<>` not-equal relations,
   and double-quoted string literals through the shared ALGOL lexer.
+- Parsed ALGOL publication symbols for relations, exponentiation, and boolean
+  operators through the shared lexer normalization layer.
 
 ## [0.1.0] — 2026-04-06
 

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -261,6 +261,11 @@ class TestArithmeticExpression:
         ast = parse("begin real x; x := 2 ^ 10 end")
         assert ast.rule_name == "program"
 
+    def test_uparrow_exponentiation(self) -> None:
+        """Publication uparrow exponentiation parses through CARET."""
+        ast = parse("begin real x; x := 2 ↑ 10 end")
+        assert ast.rule_name == "program"
+
     def test_conditional_expression_assignment(self) -> None:
         """ALGOL conditional expressions can appear as assignment values."""
         ast = parse("begin integer x; x := if true then 1 else 2 end")
@@ -307,6 +312,17 @@ class TestIfStatement:
         ast = parse("begin integer x; if x <> 0 then x := 1 end")
         assert ast.rule_name == "program"
         assert find_nodes(ast, "relation")
+
+    def test_if_with_publication_symbol_relations(self) -> None:
+        """Publication relation symbols parse as normalized relations."""
+        ast = parse(
+            "begin integer x; "
+            "if (2 ↑ 3 = 8) ∧ (3 ≤ 4) ∧ (5 ≥ 5) ∧ (1 ≠ 2) "
+            "then x := 1 else x := 0 "
+            "end"
+        )
+        assert ast.rule_name == "program"
+        assert len(find_nodes(ast, "relation")) >= 4
 
     def test_if_with_boolean_operators(self) -> None:
         """Conditional with AND and NOT in the boolean expression."""
@@ -484,9 +500,8 @@ class TestBooleanExpression:
         and    (logical conjunction)
         not    (logical negation, unary prefix)
 
-    ALGOL 60 uses words for all boolean operators, not symbols.
-    This makes programs readable by mathematicians and scientists —
-    the original audience for the language.
+    The compiler accepts both word spellings and publication symbols for these
+    boolean operators, normalizing symbols before parsing.
     """
 
     def test_and_expression(self) -> None:
@@ -553,6 +568,29 @@ class TestBooleanExpression:
             for node in eqv_nodes
             for token in child_tokens(node)
         )
+
+    def test_publication_symbol_boolean_expression(self) -> None:
+        """Boolean publication symbols normalize to parser keyword values."""
+        ast = parse(
+            "begin integer x; "
+            "if (¬ false) ∧ (true ∨ false) ∧ (true ⊃ true) "
+            "∧ (true ≡ true) "
+            "then x := 1 else x := 0 "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        all_token_values: list[str] = []
+
+        def collect_token_values(node: ASTNode) -> None:
+            for child in node.children:
+                if isinstance(child, Token):
+                    all_token_values.append(child.value)
+                else:
+                    collect_token_values(child)
+
+        collect_token_values(ast)
+        assert {"not", "and", "or", "impl", "eqv"} <= set(all_token_values)
 
     def test_or_binds_tighter_than_implication(self) -> None:
         """``or`` should parse inside the left operand of ``impl``."""

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -73,6 +73,8 @@ All notable changes to this package will be documented in this file.
   reject hostile inputs with diagnostics before walking too deeply.
 - Accepted shared lexer front-door spellings for uppercase keywords/comments,
   `<>` not-equal relations, and double-quoted string literals.
+- Accepted shared lexer front-door publication symbols for relations,
+  exponentiation, and boolean operators.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -58,6 +58,18 @@ class TestAlgolTypeChecker:
 
         assert result.ok
 
+    def test_accepts_publication_symbol_operators(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "if (2 ↑ 3 = 8) ∧ (3 ≤ 4) ∧ (5 ≥ 5) ∧ (1 ≠ 2) "
+            "∧ (¬ false) ∧ (true ⊃ true) ∧ (true ≡ true) "
+            "then result := 7 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+
     def test_accepts_double_quoted_string_literal(self) -> None:
         ast = parse_algol('begin string message; message := "Hi" end')
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -82,6 +82,8 @@ All notable changes to this package will be documented in this file.
   descriptor lookup through the switch-eval helper at runtime.
 - Executed the report-style `go to` spelling through the full parser,
   type-checker, IR, and WASM pipeline.
+- Executed normalized ALGOL publication symbols for relations, exponentiation,
+  and boolean operators through the full WASM pipeline.
 - Executed standard numeric builtin functions `abs`, `sign`, and `entier`
   through the full parser, type-checker, IR, and WASM pipeline.
 - Executed standard real builtin function `sqrt` through the full parser,

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,8 +18,9 @@ the current lane already supports a substantial ALGOL 60 surface:
 - `own` scalars and arrays with static lifetime
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
-- case-insensitive keywords and comments, `!=` or `<>` not-equal spelling, and
-  single- or double-quoted string literals
+- case-insensitive keywords and comments, `!=`/`<>`/`≠` not-equal spelling,
+  ALGOL publication symbols such as `≤`, `≥`, `↑`, `¬`, `∧`, `∨`, `⊃`, `≡`,
+  and single- or double-quoted string literals
 - chained assignment, conditional expressions, tolerant trailing/repeated
   semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer or real exponents
@@ -46,9 +47,9 @@ declaration, statement, expression, procedure, array, by-name, and designational
 surface is now implemented and covered by golden WASM fixtures. It is not a
 claim of historical whole-environment compatibility with every ALGOL system:
 the package intentionally keeps the observable I/O surface to `print(...)` /
-`output(...)`, uses the bundled token spelling rather than typographic ALGOL
-publication notation, and applies explicit source, semantic, generated-state,
-memory, and host execution limits for untrusted programs.
+`output(...)`, supports the bundled ASCII spelling plus common ALGOL
+publication-symbol notation, and applies explicit source, semantic,
+generated-state, memory, and host execution limits for untrusted programs.
 
 The convenience APIs reject source strings larger than 256 KiB before parsing.
 The downstream type checker also enforces configurable AST, block-nesting, and

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -46,13 +46,24 @@ class TestAlgolWasmCompiler:
 
     def test_comment_prefixed_identifier_is_not_skipped(self) -> None:
         result = compile_source(
-            "begin integer result, commentary; commentary := 7; result := commentary end"
+            "begin integer result, commentary; commentary := 7; "
+            "result := commentary end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
     def test_angle_not_equal_operator_executes(self) -> None:
         result = compile_source(
             "begin integer result; if 1 <> 2 then result := 7 else result := 0 end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_publication_symbol_operators_execute(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "if (2 ↑ 3 = 8) ∧ (3 ≤ 4) ∧ (5 ≥ 5) ∧ (1 ≠ 2) "
+            "∧ (¬ false) ∧ (true ⊃ true) ∧ (true ≡ true) "
+            "then result := 7 else result := 0 "
+            "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 


### PR DESCRIPTION
## Summary
- accept ALGOL publication symbols in the token grammar for relations, exponentiation, and boolean operators
- normalize those symbols to existing ASCII/keyword values in the lexer wrapper so parser, type-checker, IR, and WASM paths reuse existing semantics
- add coverage across lexer, parser, type-checker, IR, and WASM, plus docs/changelog updates

## Verification
- bash BUILD (algol-wasm-compiler): 194 passed
- pytest (algol-lexer): 104 passed
- pytest (algol-parser): 68 passed
- pytest (algol-type-checker): 151 passed
- pytest (algol-ir-compiler): 112 passed
- ruff check touched Python files: passed
- git diff --check: passed

## Security review
- Diff scan found no added process execution, network calls, file I/O, deserialization, or secret handling. Runtime change is limited to token normalization before the existing compiler pipeline.