### PR TITLE
[codex] Visualize neural graph VM training

### DIFF
--- a/code/packages/typescript/matrix/CHANGELOG.md
+++ b/code/packages/typescript/matrix/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the TypeScript matrix package will be documented here.
 
+## Unreleased
+
+### Changed
+- Exposed `src/matrix.ts` as the package module entry so Vite/browser builds
+  can bundle the Matrix implementation as ESM.
+
 ## [1.1.0] - 2026-04-04
 
 ### Added

--- a/code/packages/typescript/matrix/package.json
+++ b/code/packages/typescript/matrix/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Pure ML Matrix dimensional operations",
   "main": "dist/matrix.js",
+  "module": "src/matrix.ts",
   "types": "dist/matrix.d.ts",
   "scripts": {
     "build": "tsc",

--- a/code/packages/typescript/neural-network/CHANGELOG.md
+++ b/code/packages/typescript/neural-network/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added `createFeedForwardNetwork()` for authoring matrix-shaped feed-forward
+  networks from input names, layer weights, biases, activations, and output names.
 - Added a `constant` primitive for scalar bias or literal nodes.
 - Added `createXorNetwork()` as an explicit hidden-layer graph example.
 

--- a/code/packages/typescript/neural-network/src/index.ts
+++ b/code/packages/typescript/neural-network/src/index.ts
@@ -5,10 +5,13 @@ export {
   addInput,
   addOutput,
   addWeightedSum,
+  createFeedForwardNetwork,
   createNeuralGraph,
   createNeuralNetwork,
   createXorNetwork,
   type ActivationKind,
+  type FeedForwardLayer,
+  type FeedForwardNetworkOptions,
   type NeuralGraph,
   type WeightedInput,
 } from "./neural-network.js";

--- a/code/packages/typescript/neural-network/src/neural-network.ts
+++ b/code/packages/typescript/neural-network/src/neural-network.ts
@@ -13,6 +13,20 @@ export interface WeightedInput {
   readonly properties?: GraphPropertyBag;
 }
 
+export interface FeedForwardLayer {
+  readonly name?: string;
+  readonly weights: readonly (readonly number[])[];
+  readonly biases: readonly number[];
+  readonly activation?: ActivationKind;
+  readonly outputNames?: readonly string[];
+}
+
+export interface FeedForwardNetworkOptions {
+  readonly name?: string;
+  readonly inputNames: readonly string[];
+  readonly layers: readonly FeedForwardLayer[];
+}
+
 export class NeuralNetwork {
   readonly graph: NeuralGraph;
 
@@ -72,6 +86,106 @@ export class NeuralNetwork {
 
 export function createNeuralNetwork(name?: string): NeuralNetwork {
   return new NeuralNetwork(name);
+}
+
+export function createFeedForwardNetwork(
+  options: FeedForwardNetworkOptions
+): NeuralNetwork {
+  if (options.inputNames.length === 0) {
+    throw new Error("feed-forward network must have at least one input");
+  }
+  if (options.layers.length === 0) {
+    throw new Error("feed-forward network must have at least one layer");
+  }
+
+  const network = createNeuralNetwork(options.name);
+  const biasNode = "bias";
+  network.constant(biasNode, 1, { "nn.role": "bias" });
+
+  let previousNodes = options.inputNames.map((inputName, index) => {
+    const node = `input_${index}`;
+    network.input(node, inputName, {
+      "nn.layer": "input",
+      "nn.index": index,
+    });
+    return node;
+  });
+
+  for (const [layerIndex, layer] of options.layers.entries()) {
+    const layerName = layer.name ?? `layer_${layerIndex}`;
+    validateFeedForwardLayer(layer, previousNodes.length, layerName);
+
+    const nextNodes: string[] = [];
+    for (let unit = 0; unit < layer.biases.length; unit += 1) {
+      const sumNode = `${layerName}_${unit}_sum`;
+      const activationNode = `${layerName}_${unit}`;
+      network
+        .weightedSum(
+          sumNode,
+          [
+            ...previousNodes.map((node, inputIndex) => ({
+              from: node,
+              weight: layer.weights[inputIndex]![unit],
+              edgeId: `${node}_to_${sumNode}`,
+              properties: {
+                "nn.trainable": true,
+                "nn.layer": layerName,
+              },
+            })),
+            {
+              from: biasNode,
+              weight: layer.biases[unit],
+              edgeId: `${biasNode}_to_${sumNode}`,
+              properties: {
+                "nn.trainable": true,
+                "nn.role": "bias_weight",
+                "nn.layer": layerName,
+              },
+            },
+          ],
+          {
+            "nn.layer": layerName,
+            "nn.index": unit,
+            "nn.role": "weighted_sum",
+          }
+        )
+        .activation(
+          activationNode,
+          sumNode,
+          layer.activation ?? "none",
+          {
+            "nn.layer": layerName,
+            "nn.index": unit,
+            "nn.role": "activation",
+          },
+          `${sumNode}_to_${activationNode}`
+        );
+      nextNodes.push(activationNode);
+    }
+
+    if (layerIndex === options.layers.length - 1) {
+      for (const [unit, node] of nextNodes.entries()) {
+        const outputName = layer.outputNames?.[unit] ?? (
+          nextNodes.length === 1 ? "prediction" : `output${unit}`
+        );
+        network.output(
+          `${layerName}_${unit}_out`,
+          node,
+          outputName,
+          {
+            "nn.layer": layerName,
+            "nn.index": unit,
+            "nn.role": "output",
+          },
+          `${node}_to_${layerName}_${unit}_out`
+        );
+      }
+    }
+
+    previousNodes = nextNodes;
+  }
+
+  return network;
 }
 
 export function createNeuralGraph(name?: string): NeuralGraph {
@@ -200,4 +314,42 @@ export function addOutput(
     "nn.output": outputName,
   });
   return graph.addEdge(input, node, 1.0, {}, edgeId);
+}
+
+function validateFeedForwardLayer(
+  layer: FeedForwardLayer,
+  inputCount: number,
+  layerName: string
+): void {
+  if (layer.biases.length === 0) {
+    throw new Error(`${layerName} must have at least one unit`);
+  }
+  if (layer.weights.length !== inputCount) {
+    throw new Error(
+      `${layerName} weight row count must match previous layer width`
+    );
+  }
+  if (
+    layer.outputNames !== undefined &&
+    layer.outputNames.length !== layer.biases.length
+  ) {
+    throw new Error(`${layerName} output name count must match unit count`);
+  }
+  for (const [rowIndex, row] of layer.weights.entries()) {
+    if (row.length !== layer.biases.length) {
+      throw new Error(
+        `${layerName} weight row ${rowIndex} width must match bias count`
+      );
+    }
+    for (const value of row) {
+      if (!Number.isFinite(value)) {
+        throw new Error(`${layerName} weights must be finite`);
+      }
+    }
+  }
+  for (const value of layer.biases) {
+    if (!Number.isFinite(value)) {
+      throw new Error(`${layerName} biases must be finite`);
+    }
+  }
 }

--- a/code/packages/typescript/neural-network/tests/neural-network.test.ts
+++ b/code/packages/typescript/neural-network/tests/neural-network.test.ts
@@ -6,6 +6,7 @@ import {
   addInput,
   addOutput,
   addWeightedSum,
+  createFeedForwardNetwork,
   createNeuralGraph,
   createNeuralNetwork,
   createXorNetwork,
@@ -101,5 +102,51 @@ describe("neural-network primitives", () => {
       weight: -30,
     });
     expect(network.graph.topologicalSort()).toContain("out");
+  });
+
+  it("authors generic feed-forward layers from matrices", () => {
+    const network = createFeedForwardNetwork({
+      name: "tiny-feed-forward",
+      inputNames: ["x0", "x1"],
+      layers: [
+        {
+          name: "hidden",
+          weights: [
+            [0.5, -0.25],
+            [0.75, 0.1],
+          ],
+          biases: [0.2, -0.3],
+          activation: "sigmoid",
+        },
+        {
+          name: "output",
+          weights: [
+            [1.25],
+            [-0.9],
+          ],
+          biases: [0.05],
+          activation: "none",
+          outputNames: ["score"],
+        },
+      ],
+    });
+
+    expect(network.graph.nodeProperties("hidden_0")).toMatchObject({
+      "nn.op": "activation",
+      "nn.activation": "sigmoid",
+      "nn.layer": "hidden",
+    });
+    expect(network.graph.nodeProperties("output_0_out")).toMatchObject({
+      "nn.op": "output",
+      "nn.output": "score",
+    });
+    expect(network.graph.edgeProperties("input_1_to_hidden_0_sum")).toMatchObject({
+      weight: 0.75,
+      "nn.trainable": true,
+    });
+    expect(network.graph.edgeProperties("bias_to_output_0_sum")).toMatchObject({
+      weight: 0.05,
+      "nn.role": "bias_weight",
+    });
   });
 });

--- a/code/packages/typescript/paint-vm-svg/CHANGELOG.md
+++ b/code/packages/typescript/paint-vm-svg/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — @coding-adventures/paint-vm-svg
 
+## Unreleased
+
+### Added
+
+- Added SVG `PaintText` handling so graph visualizers can render browser-shaped
+  labels instead of manually positioned glyph runs.
+
 ## [0.1.0] — 2026-04-03
 
 ### Added

--- a/code/packages/typescript/paint-vm-svg/src/index.ts
+++ b/code/packages/typescript/paint-vm-svg/src/index.ts
@@ -48,11 +48,11 @@ export const VERSION = "0.1.0";
 
 import { PaintVM, ExportNotSupportedError } from "@coding-adventures/paint-vm";
 import type {
-  PaintInstruction,
   PaintRect,
   PaintEllipse,
   PaintPath,
   PaintGlyphRun,
+  PaintText,
   PaintGroup,
   PaintLayer,
   PaintLine,
@@ -438,6 +438,44 @@ function handleGlyphRun(instr: PaintGlyphRun, ctx: SvgContext): void {
   );
 }
 
+const TEXT_ANCHOR_ALLOWLIST = new Set(["start", "middle", "end"]);
+
+function handleText(instr: PaintText, ctx: SvgContext): void {
+  const anchor = textAlignToAnchor(instr.text_align);
+  const anchorAttr = anchor !== "start" ? ` text-anchor="${anchor}"` : "";
+  ctx.elements.push(
+    `<text${idAttr(instr.id)} x="${safeNum(instr.x, "text.x")}" y="${safeNum(instr.y, "text.y")}" font-family="${escAttr(fontFamilyFromRef(instr.font_ref))}" font-size="${safeNum(instr.font_size, "text.font_size")}" fill="${escAttr(instr.fill)}"${anchorAttr}>${escText(instr.text)}</text>`,
+  );
+}
+
+function textAlignToAnchor(align: PaintText["text_align"]): string {
+  switch (align) {
+    case "center":
+      return "middle";
+    case "end":
+      return "end";
+    case "start":
+    case undefined:
+      return "start";
+    default: {
+      const maybeAnchor = String(align);
+      return TEXT_ANCHOR_ALLOWLIST.has(maybeAnchor) ? maybeAnchor : "start";
+    }
+  }
+}
+
+function fontFamilyFromRef(fontRef: string): string {
+  if (fontRef.startsWith("svg:") || fontRef.startsWith("canvas:")) {
+    const descriptor = fontRef.slice(fontRef.indexOf(":") + 1);
+    const atIndex = descriptor.indexOf("@");
+    return descriptor.slice(0, atIndex === -1 ? undefined : atIndex) || "sans-serif";
+  }
+  if (fontRef.startsWith("css:")) {
+    return fontRef.slice("css:".length) || "sans-serif";
+  }
+  return fontRef || "sans-serif";
+}
+
 function handleGroup(
   instr: PaintGroup,
   ctx: SvgContext,
@@ -597,7 +635,7 @@ function handleImage(instr: PaintImage, ctx: SvgContext): void {
 /**
  * Create a fully configured PaintVM<SvgContext> for SVG string output.
  *
- * The returned VM has handlers registered for all 10 instruction kinds.
+ * The returned VM has handlers registered for all instruction kinds.
  * Call renderToSvgString(scene) as a convenience wrapper, or use the VM
  * directly if you need to register additional custom handlers.
  */
@@ -627,6 +665,9 @@ export function createSvgVM(): PaintVM<SvgContext> {
   });
   vm.register("glyph_run", (instr, ctx) => {
     if (instr.kind === "glyph_run") handleGlyphRun(instr as PaintGlyphRun, ctx);
+  });
+  vm.register("text", (instr, ctx) => {
+    if (instr.kind === "text") handleText(instr as PaintText, ctx);
   });
   vm.register("group", (instr, ctx, vm) => {
     if (instr.kind === "group") handleGroup(instr as PaintGroup, ctx, vm);

--- a/code/packages/typescript/paint-vm-svg/tests/paint-vm-svg.test.ts
+++ b/code/packages/typescript/paint-vm-svg/tests/paint-vm-svg.test.ts
@@ -11,6 +11,7 @@ import {
   paintClip,
   paintGradient,
   paintImage,
+  paintText,
   type PaintScene,
   type PixelContainer,
 } from "@coding-adventures/paint-instructions";
@@ -492,6 +493,37 @@ describe("PaintGlyphRun → SVG <text>", () => {
       ]),
     );
     expect(svg).toContain('fill="#000000"');
+  });
+});
+
+// ============================================================================
+// PaintText → <text>
+// ============================================================================
+
+describe("PaintText → SVG <text>", () => {
+  it("emits native SVG text with font family and content escaping", () => {
+    const svg = renderToSvgString(
+      paintScene(200, 200, "transparent", [
+        paintText(12, 48, "A < B & C", "svg:Inter@16", 16, "#111111"),
+      ]),
+    );
+    expect(svg).toContain("<text");
+    expect(svg).toContain('x="12"');
+    expect(svg).toContain('y="48"');
+    expect(svg).toContain('font-family="Inter"');
+    expect(svg).toContain('font-size="16"');
+    expect(svg).toContain("A &lt; B &amp; C");
+  });
+
+  it("maps centered text alignment to SVG text-anchor middle", () => {
+    const svg = renderToSvgString(
+      paintScene(200, 200, "transparent", [
+        paintText(100, 48, "centered", "svg:Inter@16", 16, "#111111", {
+          text_align: "center",
+        }),
+      ]),
+    );
+    expect(svg).toContain('text-anchor="middle"');
   });
 });
 

--- a/code/programs/typescript/ml-learning-visualizer/BUILD
+++ b/code/programs/typescript/ml-learning-visualizer/BUILD
@@ -2,6 +2,13 @@ set -eu
 
 (cd ../../../packages/typescript/directed-graph && npm install)
 (cd ../../../packages/typescript/matrix && npm install)
+(cd ../../../packages/typescript/multi-directed-graph && npm install)
+(cd ../../../packages/typescript/neural-network && npm install)
+(cd ../../../packages/typescript/neural-graph-vm && npm install)
+(cd ../../../packages/typescript/pixel-container && npm install)
+(cd ../../../packages/typescript/paint-instructions && npm install)
+(cd ../../../packages/typescript/paint-vm && npm install)
+(cd ../../../packages/typescript/paint-vm-svg && npm install)
 (cd ../../../packages/typescript/two-layer-network && npm install)
 (cd ../../../packages/typescript/state-machine && npm install)
 (cd ../../../packages/typescript/grammar-tools && npm install)

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Routed linear and hidden-layer visualizer predictions through the shared
+  neural-network graph and neural-graph-vm matrix plan path.
+- Added Paint VM SVG neural graph panels that show weights, bias edges,
+  activations, and gradient updates while training runs advance.
+
 ## [0.1.0] - 2026-03-25
 
 ### Added

--- a/code/programs/typescript/ml-learning-visualizer/package-lock.json
+++ b/code/programs/typescript/ml-learning-visualizer/package-lock.json
@@ -10,6 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/lattice-transpiler": "file:../../../packages/typescript/lattice-transpiler",
+        "@coding-adventures/neural-graph-vm": "file:../../../packages/typescript/neural-graph-vm",
+        "@coding-adventures/neural-network": "file:../../../packages/typescript/neural-network",
+        "@coding-adventures/paint-instructions": "file:../../../packages/typescript/paint-instructions",
+        "@coding-adventures/paint-vm": "file:../../../packages/typescript/paint-vm",
+        "@coding-adventures/paint-vm-svg": "file:../../../packages/typescript/paint-vm-svg",
         "coding-adventures-two-layer-network": "file:../../../packages/typescript/two-layer-network",
         "matrix": "file:../../../packages/typescript/matrix",
         "react": "^19.0.0",
@@ -55,6 +60,74 @@
         "jest": "^29.0.0",
         "ts-jest": "^29.0.0",
         "typescript": "^5.0.0"
+      }
+    },
+    "../../../packages/typescript/neural-graph-vm": {
+      "name": "@coding-adventures/neural-graph-vm",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/multi-directed-graph": "file:../multi-directed-graph",
+        "@coding-adventures/neural-network": "file:../neural-network",
+        "matrix": "file:../matrix"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/neural-network": {
+      "name": "@coding-adventures/neural-network",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/multi-directed-graph": "file:../multi-directed-graph"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/paint-instructions": {
+      "name": "@coding-adventures/paint-instructions",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/pixel-container": "file:../pixel-container"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/paint-vm": {
+      "name": "@coding-adventures/paint-vm",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/paint-vm-svg": {
+      "name": "@coding-adventures/paint-vm-svg",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/paint-instructions": "file:../paint-instructions",
+        "@coding-adventures/paint-vm": "file:../paint-vm"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
       }
     },
     "../../../packages/typescript/two-layer-network": {
@@ -416,6 +489,26 @@
     },
     "node_modules/@coding-adventures/lattice-transpiler": {
       "resolved": "../../../packages/typescript/lattice-transpiler",
+      "link": true
+    },
+    "node_modules/@coding-adventures/neural-graph-vm": {
+      "resolved": "../../../packages/typescript/neural-graph-vm",
+      "link": true
+    },
+    "node_modules/@coding-adventures/neural-network": {
+      "resolved": "../../../packages/typescript/neural-network",
+      "link": true
+    },
+    "node_modules/@coding-adventures/paint-instructions": {
+      "resolved": "../../../packages/typescript/paint-instructions",
+      "link": true
+    },
+    "node_modules/@coding-adventures/paint-vm": {
+      "resolved": "../../../packages/typescript/paint-vm",
+      "link": true
+    },
+    "node_modules/@coding-adventures/paint-vm-svg": {
+      "resolved": "../../../packages/typescript/paint-vm-svg",
       "link": true
     },
     "node_modules/@csstools/color-helpers": {

--- a/code/programs/typescript/ml-learning-visualizer/package.json
+++ b/code/programs/typescript/ml-learning-visualizer/package.json
@@ -13,6 +13,11 @@
   },
   "dependencies": {
     "@coding-adventures/lattice-transpiler": "file:../../../packages/typescript/lattice-transpiler",
+    "@coding-adventures/neural-graph-vm": "file:../../../packages/typescript/neural-graph-vm",
+    "@coding-adventures/neural-network": "file:../../../packages/typescript/neural-network",
+    "@coding-adventures/paint-instructions": "file:../../../packages/typescript/paint-instructions",
+    "@coding-adventures/paint-vm": "file:../../../packages/typescript/paint-vm",
+    "@coding-adventures/paint-vm-svg": "file:../../../packages/typescript/paint-vm-svg",
     "coding-adventures-two-layer-network": "file:../../../packages/typescript/two-layer-network",
     "matrix": "file:../../../packages/typescript/matrix",
     "react": "^19.0.0",

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
+import { LinearNetworkDiagram } from "./NetworkDiagram.js";
 import {
   loss,
   meanAbsoluteError,
@@ -102,10 +103,11 @@ function yScale(value: number, chart: ChartFrame): number {
 function linePath(state: ModelState, chart: ChartFrame): string {
   const x1 = chart.xMin;
   const x2 = chart.xMax;
-  return `M ${xScale(x1, chart)} ${yScale(state.weight * x1 + state.bias, chart)} L ${xScale(
+  const [y1, y2] = predictions([{ x: x1, y: 0 }, { x: x2, y: 0 }], state);
+  return `M ${xScale(x1, chart)} ${yScale(y1 ?? 0, chart)} L ${xScale(
     x2,
     chart,
-  )} ${yScale(state.weight * x2 + state.bias, chart)}`;
+  )} ${yScale(y2 ?? 0, chart)}`;
 }
 
 function historyPath(history: HistoryPoint[]): string {
@@ -383,6 +385,8 @@ export function App() {
               <span><i className="legend-line legend-line--ideal" />Best fit</span>
             </div>
           </section>
+
+          <LinearNetworkDiagram model={model} lastStep={lastStep} learningRate={learningRate} />
         </section>
 
         <aside className="controls metrics" aria-label="Training controls and metrics">

--- a/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
@@ -13,7 +13,8 @@ import {
   type HiddenLayerModelState,
   type HiddenLayerStepResult,
 } from "./hidden-layer-examples.js";
-import { forwardTwoLayer } from "coding-adventures-two-layer-network/src/index";
+import { predictTwoLayerWithVm } from "./neural-vm.js";
+import { HiddenNetworkDiagram } from "./NetworkDiagram.js";
 
 interface HiddenChartFrame {
   width: number;
@@ -86,14 +87,25 @@ function hiddenHistoryPath(history: HiddenLayerHistoryPoint[]): string {
     .join(" ");
 }
 
-function makeCurvePath(state: HiddenLayerModelState): string {
+function makeCurvePath(example: HiddenLayerExample, state: HiddenLayerModelState): string {
   const samples = Array.from({ length: 121 }, (_, index) => {
     const x = CURVE_CHART.xMin + (index / 120) * (CURVE_CHART.xMax - CURVE_CHART.xMin);
-    const prediction = forwardTwoLayer([[x]], state.parameters).predictions[0]![0]!;
-    return [x, prediction] as const;
+    return x;
+  });
+  const predictions = predictTwoLayerWithVm(
+    samples.map((x) => [x]),
+    state.parameters,
+    {
+      inputNames: example.inputLabels,
+      outputNames: [example.outputLabel],
+    },
+  ).predictions.map((row) => row[0] ?? 0);
+
+  const points = samples.map((x, index) => {
+    return [x, predictions[index] ?? 0] as const;
   });
 
-  return samples
+  return points
     .map(([x, y], index) => {
       const command = index === 0 ? "M" : "L";
       return `${command} ${xScale(x, CURVE_CHART).toFixed(2)} ${yScale(y, CURVE_CHART).toFixed(2)}`;
@@ -103,6 +115,7 @@ function makeCurvePath(state: HiddenLayerModelState): string {
 
 function makeSurfaceCells(example: HiddenLayerExample, state: HiddenLayerModelState): Array<{ x: number; y: number; value: number }> {
   const cells: Array<{ x: number; y: number; value: number }> = [];
+  const inputs: number[][] = [];
   const divisions = 26;
   const xValues = example.rows.map((row) => row.input[0]!);
   const yValues = example.rows.map((row) => row.input[1]!);
@@ -117,12 +130,21 @@ function makeSurfaceCells(example: HiddenLayerExample, state: HiddenLayerModelSt
     for (let x = 0; x < divisions; x += 1) {
       const inputX = xMin - xPad + (x / (divisions - 1)) * (xMax - xMin + xPad * 2);
       const inputY = yMin - yPad + (y / (divisions - 1)) * (yMax - yMin + yPad * 2);
-      const value = forwardTwoLayer([[inputX, inputY]], state.parameters).predictions[0]![0]!;
+      inputs.push([inputX, inputY]);
+      const value = 0;
       cells.push({ x, y, value });
     }
   }
 
-  return cells;
+  const predictions = predictTwoLayerWithVm(inputs, state.parameters, {
+    inputNames: example.inputLabels,
+    outputNames: [example.outputLabel],
+  }).predictions;
+
+  return cells.map((cell, index) => ({
+    ...cell,
+    value: predictions[index]?.[0] ?? 0,
+  }));
 }
 
 function CurveChart({ example, state, predictions }: { example: HiddenLayerExample; state: HiddenLayerModelState; predictions: number[] }) {
@@ -147,7 +169,7 @@ function CurveChart({ example, state, predictions }: { example: HiddenLayerExamp
           </g>
         );
       })}
-      <path className="hidden-curve" d={makeCurvePath(state)} />
+      <path className="hidden-curve" d={makeCurvePath(example, state)} />
       {example.rows.map((row, index) => {
         const px = xScale(row.input[0]!, CURVE_CHART);
         const targetY = yScale(row.target, CURVE_CHART);
@@ -406,6 +428,15 @@ export function HiddenLayerWorkbench() {
             <code>{example.inputLabels.join(", ")} {"->"} hidden[{example.hiddenCount}] {"->"} {example.outputLabel}</code>
           </div>
         </section>
+
+        <HiddenNetworkDiagram
+          example={example}
+          state={state}
+          selectedInput={example.rows[selectedIndex]!.input}
+          prediction={predictions[selectedIndex]!}
+          lastStep={lastStep}
+          learningRate={learningRate}
+        />
       </section>
 
       <aside className="controls metrics" aria-label="Hidden-layer controls">

--- a/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
@@ -1,0 +1,410 @@
+import { renderToSvgString } from "@coding-adventures/paint-vm-svg";
+import {
+  paintEllipse,
+  paintLine,
+  paintRect,
+  paintScene,
+  paintText,
+  type PaintInstruction,
+  type PaintScene,
+} from "@coding-adventures/paint-instructions";
+import type {
+  HiddenLayerExample,
+  HiddenLayerModelState,
+  HiddenLayerStepResult,
+} from "./hidden-layer-examples.js";
+import type { ModelState, StepResult } from "./training.js";
+
+const FONT_REF = "svg:ui-sans-serif@12";
+const MUTED = "#5d6d68";
+const PANEL = "#ffffff";
+const LINE = "rgba(23, 32, 28, 0.16)";
+const GREEN = "#237a57";
+const BLUE = "#2563eb";
+const RED = "#c2413b";
+const GOLD = "#b7791f";
+
+interface DiagramNode {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+  readonly x: number;
+  readonly y: number;
+  readonly tone: "input" | "hidden" | "output" | "bias";
+}
+
+export function LinearNetworkDiagram({
+  model,
+  lastStep,
+  learningRate,
+}: {
+  model: ModelState;
+  lastStep: StepResult | null;
+  learningRate: number;
+}) {
+  return (
+    <NetworkPanel
+      title="Neural graph"
+      summary="Linear graph VM view"
+      svg={renderLinearNetworkSvg(model, lastStep, learningRate)}
+    />
+  );
+}
+
+export function HiddenNetworkDiagram({
+  example,
+  state,
+  selectedInput,
+  prediction,
+  lastStep,
+  learningRate,
+}: {
+  example: HiddenLayerExample;
+  state: HiddenLayerModelState;
+  selectedInput: readonly number[];
+  prediction: number;
+  lastStep: HiddenLayerStepResult | null;
+  learningRate: number;
+}) {
+  return (
+    <NetworkPanel
+      title="Neural graph"
+      summary="Hidden layer graph VM view"
+      svg={renderHiddenNetworkSvg(
+        example,
+        state,
+        selectedInput,
+        prediction,
+        lastStep,
+        learningRate,
+      )}
+    />
+  );
+}
+
+export function renderLinearNetworkSvg(
+  model: ModelState,
+  lastStep: StepResult | null,
+  learningRate: number,
+): string {
+  const scene = makeLinearScene(model, lastStep, learningRate);
+  return renderToSvgString(scene);
+}
+
+export function renderHiddenNetworkSvg(
+  example: HiddenLayerExample,
+  state: HiddenLayerModelState,
+  selectedInput: readonly number[],
+  prediction: number,
+  lastStep: HiddenLayerStepResult | null,
+  learningRate: number,
+): string {
+  const scene = makeHiddenScene(
+    example,
+    state,
+    selectedInput,
+    prediction,
+    lastStep,
+    learningRate,
+  );
+  return renderToSvgString(scene);
+}
+
+function NetworkPanel({
+  title,
+  summary,
+  svg,
+}: {
+  title: string;
+  summary: string;
+  svg: string;
+}) {
+  return (
+    <section className="network-panel" aria-label={summary}>
+      <div className="history__topline">
+        <span>{title}</span>
+        <strong>{summary}</strong>
+      </div>
+      <div className="network-svg" dangerouslySetInnerHTML={{ __html: svg }} />
+    </section>
+  );
+}
+
+function makeLinearScene(
+  model: ModelState,
+  lastStep: StepResult | null,
+  learningRate: number,
+): PaintScene {
+  const width = 760;
+  const height = 280;
+  const input: DiagramNode = {
+    id: "input",
+    label: "x",
+    value: "input",
+    x: 120,
+    y: 130,
+    tone: "input",
+  };
+  const bias: DiagramNode = {
+    id: "bias",
+    label: "bias",
+    value: fmt(model.bias),
+    x: 120,
+    y: 214,
+    tone: "bias",
+  };
+  const sum: DiagramNode = {
+    id: "sum",
+    label: "sum",
+    value: "x*w+b",
+    x: 378,
+    y: 130,
+    tone: "hidden",
+  };
+  const output: DiagramNode = {
+    id: "output",
+    label: "pred",
+    value: "y",
+    x: 640,
+    y: 130,
+    tone: "output",
+  };
+
+  const dw = lastStep === null ? 0 : -learningRate * lastStep.gradientWeight;
+  const db = lastStep === null ? 0 : -learningRate * lastStep.gradientBias;
+  const instructions: PaintInstruction[] = [
+    paintRect(16, 16, width - 32, height - 32, {
+      fill: PANEL,
+      stroke: LINE,
+      stroke_width: 1,
+      corner_radius: 8,
+    }),
+    ...edge(input, sum, model.weight, `w ${fmt(model.weight)}`),
+    ...edge(bias, sum, model.bias, `b ${fmt(model.bias)}`),
+    ...edge(sum, output, 1, "linear"),
+    ...node(input),
+    ...node(bias),
+    ...node(sum),
+    ...node(output),
+    ...text(`epoch ${model.epoch}`, 32, 48, 13, MUTED),
+    ...text(`dw ${signed(dw)}  db ${signed(db)}`, 32, 254, 13, MUTED),
+    ...text("line width follows |weight|; green is positive, red is negative", 380, 254, 12, MUTED),
+  ];
+
+  return paintScene(width, height, "#ffffff", instructions, {
+    id: "linear-neural-network-diagram",
+  });
+}
+
+function makeHiddenScene(
+  example: HiddenLayerExample,
+  state: HiddenLayerModelState,
+  selectedInput: readonly number[],
+  prediction: number,
+  lastStep: HiddenLayerStepResult | null,
+  learningRate: number,
+): PaintScene {
+  const width = 820;
+  const height = 390;
+  const inputYs = verticalPositions(example.inputLabels.length, 82, 232);
+  const hiddenYs = verticalPositions(example.hiddenCount, 54, 286);
+  const inputNodes = example.inputLabels.map((label, index): DiagramNode => ({
+    id: `input-${index}`,
+    label,
+    value: fmt(selectedInput[index] ?? 0),
+    x: 86,
+    y: inputYs[index]!,
+    tone: "input",
+  }));
+  const bias: DiagramNode = {
+    id: "bias",
+    label: "bias",
+    value: "1",
+    x: 86,
+    y: 318,
+    tone: "bias",
+  };
+  const hiddenNodes = Array.from({ length: example.hiddenCount }, (_, index): DiagramNode => ({
+    id: `hidden-${index}`,
+    label: `h${index + 1}`,
+    value: fmt(sigmoid(rawHidden(state, selectedInput, index))),
+    x: 392,
+    y: hiddenYs[index]!,
+    tone: "hidden",
+  }));
+  const output: DiagramNode = {
+    id: "output",
+    label: example.outputLabel,
+    value: fmt(prediction),
+    x: 720,
+    y: 170,
+    tone: "output",
+  };
+
+  const instructions: PaintInstruction[] = [
+    paintRect(16, 16, width - 32, height - 32, {
+      fill: PANEL,
+      stroke: LINE,
+      stroke_width: 1,
+      corner_radius: 8,
+    }),
+    ...text(`epoch ${state.epoch}`, 32, 48, 13, MUTED),
+    ...text("weights update on every step", 628, 48, 13, MUTED),
+  ];
+
+  for (const [inputIndex, inputNode] of inputNodes.entries()) {
+    for (const [hiddenIndex, hiddenNode] of hiddenNodes.entries()) {
+      const weight = state.parameters.inputToHiddenWeights[inputIndex]![hiddenIndex]!;
+      instructions.push(...edge(inputNode, hiddenNode, weight, fmt(weight), 0.34));
+    }
+  }
+  for (const [hiddenIndex, hiddenNode] of hiddenNodes.entries()) {
+    const biasWeight = state.parameters.hiddenBiases[hiddenIndex]!;
+    instructions.push(...edge(bias, hiddenNode, biasWeight, fmt(biasWeight), 0.26));
+  }
+  for (const [hiddenIndex, hiddenNode] of hiddenNodes.entries()) {
+    const weight = state.parameters.hiddenToOutputWeights[hiddenIndex]![0]!;
+    instructions.push(...edge(hiddenNode, output, weight, fmt(weight), 0.42));
+  }
+  instructions.push(
+    ...edge(bias, output, state.parameters.outputBiases[0] ?? 0, fmt(state.parameters.outputBiases[0] ?? 0), 0.28),
+    ...inputNodes.flatMap(node),
+    ...node(bias),
+    ...hiddenNodes.flatMap(node),
+    ...node(output),
+  );
+
+  const inputShape = lastStep === null
+    ? "input-hidden gradients waiting"
+    : `input-hidden grad ${lastStep.step.inputToHiddenWeightGradients.length}x${lastStep.step.inputToHiddenWeightGradients[0]?.length ?? 0}`;
+  const outputGrad = lastStep?.step.outputBiasGradients[0] ?? 0;
+  instructions.push(
+    ...text(inputShape, 32, 356, 12, MUTED),
+    ...text(`output db ${signed(-learningRate * outputGrad)}`, 356, 356, 12, MUTED),
+    ...text("line width = |weight|", 620, 356, 12, MUTED),
+  );
+
+  return paintScene(width, height, "#ffffff", instructions, {
+    id: "hidden-neural-network-diagram",
+  });
+}
+
+function edge(
+  from: DiagramNode,
+  to: DiagramNode,
+  weight: number,
+  label: string,
+  labelOffset = 0.5,
+): PaintInstruction[] {
+  const midX = from.x + (to.x - from.x) * labelOffset;
+  const midY = from.y + (to.y - from.y) * labelOffset;
+  const color = weight >= 0 ? GREEN : RED;
+  const width = Math.min(7, 1.4 + Math.abs(weight) * 0.75);
+  return [
+    paintLine(from.x, from.y, to.x, to.y, color, {
+      stroke_width: width,
+      stroke_cap: "round",
+    }),
+    paintRect(midX - 28, midY - 14, 56, 20, {
+      fill: "rgba(255, 255, 255, 0.86)",
+      stroke: "rgba(23, 32, 28, 0.08)",
+      stroke_width: 1,
+      corner_radius: 5,
+    }),
+    ...centerText(label, midX, midY + 4, 10, color),
+  ];
+}
+
+function node(nodeData: DiagramNode): PaintInstruction[] {
+  const fill = nodeFill(nodeData.tone);
+  return [
+    paintEllipse(nodeData.x, nodeData.y, 28, 28, {
+      fill,
+      stroke: "#ffffff",
+      stroke_width: 3,
+    }),
+    paintEllipse(nodeData.x, nodeData.y, 31, 31, {
+      stroke: LINE,
+      stroke_width: 1,
+    }),
+    ...centerText(nodeData.label, nodeData.x, nodeData.y - 3, 11, "#ffffff"),
+    ...centerText(nodeData.value, nodeData.x, nodeData.y + 12, 10, "#ffffff"),
+  ];
+}
+
+function text(
+  value: string,
+  x: number,
+  y: number,
+  fontSize: number,
+  fill: string,
+  align: "start" | "center" | "end" = "start",
+): PaintInstruction[] {
+  return [paintText(x, y, value, FONT_REF, fontSize, fill, { text_align: align })];
+}
+
+function centerText(
+  value: string,
+  x: number,
+  y: number,
+  fontSize: number,
+  fill: string,
+): PaintInstruction[] {
+  return text(value, x, y, fontSize, fill, "center");
+}
+
+function verticalPositions(count: number, top: number, bottom: number): number[] {
+  if (count <= 1) {
+    return [(top + bottom) / 2];
+  }
+  const span = bottom - top;
+  return Array.from({ length: count }, (_, index) => top + (span * index) / (count - 1));
+}
+
+function rawHidden(
+  state: HiddenLayerModelState,
+  input: readonly number[],
+  hiddenIndex: number,
+): number {
+  let raw = state.parameters.hiddenBiases[hiddenIndex] ?? 0;
+  for (const [inputIndex, value] of input.entries()) {
+    raw += value * (state.parameters.inputToHiddenWeights[inputIndex]?.[hiddenIndex] ?? 0);
+  }
+  return raw;
+}
+
+function sigmoid(value: number): number {
+  if (value >= 0) {
+    const z = Math.exp(-value);
+    return 1 / (1 + z);
+  }
+  const z = Math.exp(value);
+  return z / (1 + z);
+}
+
+function nodeFill(tone: DiagramNode["tone"]): string {
+  switch (tone) {
+    case "input":
+      return BLUE;
+    case "hidden":
+      return GREEN;
+    case "output":
+      return GOLD;
+    case "bias":
+      return "#6d5bd0";
+  }
+}
+
+function fmt(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  if (Math.abs(value) >= 10) {
+    return value.toFixed(1);
+  }
+  return value.toFixed(2);
+}
+
+function signed(value: number): string {
+  return `${value >= 0 ? "+" : ""}${fmt(value)}`;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/hidden-layer-examples.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/hidden-layer-examples.ts
@@ -1,6 +1,5 @@
 import {
   createSeededParameters,
-  forwardTwoLayer,
   trainOneEpochTwoLayer,
   traceExampleTwoLayer,
   type ExampleTrace,
@@ -8,6 +7,7 @@ import {
   type TwoLayerParameters,
   type TwoLayerTrainingStep,
 } from "coding-adventures-two-layer-network/src/index";
+import { predictTwoLayerWithVm } from "./neural-vm.js";
 
 export type HiddenLayerChartKind = "curve" | "surface" | "table";
 
@@ -90,7 +90,10 @@ export function createInitialHiddenState(example: HiddenLayerExample): HiddenLay
 }
 
 export function predictHidden(example: HiddenLayerExample, state: HiddenLayerModelState): number[] {
-  return forwardTwoLayer(exampleInputs(example), state.parameters).predictions.map((row) => row[0]!);
+  return predictTwoLayerWithVm(exampleInputs(example), state.parameters, {
+    inputNames: example.inputLabels,
+    outputNames: [example.outputLabel],
+  }).predictions.map((row) => row[0]!);
 }
 
 export function hiddenLoss(example: HiddenLayerExample, state: HiddenLayerModelState): number {

--- a/code/programs/typescript/ml-learning-visualizer/src/neural-vm.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/neural-vm.ts
@@ -1,0 +1,123 @@
+import {
+  createFeedForwardNetwork,
+  type ActivationKind,
+} from "@coding-adventures/neural-network";
+import {
+  compileBytecodeToMatrixPlan,
+  compileNeuralNetworkToBytecode,
+  runNeuralMatrixForward,
+} from "@coding-adventures/neural-graph-vm";
+import type {
+  ActivationName,
+  MatrixData,
+  TwoLayerParameters,
+} from "coding-adventures-two-layer-network/src/index";
+
+export interface LinearGraphParameters {
+  readonly weight: number;
+  readonly bias: number;
+}
+
+export interface VmRunMetadata {
+  readonly bytecodeInstructionCount: number;
+  readonly matrixInstructionCount: number;
+}
+
+export interface LinearVmRun extends VmRunMetadata {
+  readonly predictions: number[];
+}
+
+export interface TwoLayerVmRun extends VmRunMetadata {
+  readonly predictions: MatrixData;
+}
+
+export function predictLinearWithVm(
+  xs: readonly number[],
+  parameters: LinearGraphParameters,
+): LinearVmRun {
+  const network = createFeedForwardNetwork({
+    name: "ml-learning-linear-visualizer",
+    inputNames: ["x"],
+    layers: [
+      {
+        name: "output",
+        weights: [[parameters.weight]],
+        biases: [parameters.bias],
+        activation: "none",
+        outputNames: ["prediction"],
+      },
+    ],
+  });
+  const bytecode = compileNeuralNetworkToBytecode(network);
+  const matrixPlan = compileBytecodeToMatrixPlan(bytecode);
+  const result = runNeuralMatrixForward(matrixPlan, { x: xs });
+
+  return {
+    predictions: result.outputs.prediction ?? [],
+    bytecodeInstructionCount: bytecode.functions[0]?.instructions.length ?? 0,
+    matrixInstructionCount: matrixPlan.instructions.length,
+  };
+}
+
+export function predictTwoLayerWithVm(
+  inputs: MatrixData,
+  parameters: TwoLayerParameters,
+  options: {
+    readonly inputNames?: readonly string[];
+    readonly outputNames?: readonly string[];
+    readonly hiddenActivation?: ActivationName;
+    readonly outputActivation?: ActivationName;
+  } = {},
+): TwoLayerVmRun {
+  const inputCount = inputs[0]?.length ?? parameters.inputToHiddenWeights.length;
+  const outputCount = parameters.outputBiases.length;
+  const inputNames = options.inputNames ?? Array.from(
+    { length: inputCount },
+    (_, index) => `input${index}`,
+  );
+  const outputNames = options.outputNames ?? Array.from(
+    { length: outputCount },
+    (_, index) => (outputCount === 1 ? "prediction" : `output${index}`),
+  );
+  const network = createFeedForwardNetwork({
+    name: "ml-learning-hidden-visualizer",
+    inputNames,
+    layers: [
+      {
+        name: "hidden",
+        weights: parameters.inputToHiddenWeights,
+        biases: parameters.hiddenBiases,
+        activation: toGraphActivation(options.hiddenActivation ?? "sigmoid"),
+      },
+      {
+        name: "output",
+        weights: parameters.hiddenToOutputWeights,
+        biases: parameters.outputBiases,
+        activation: toGraphActivation(options.outputActivation ?? "sigmoid"),
+        outputNames,
+      },
+    ],
+  });
+  const bytecode = compileNeuralNetworkToBytecode(network);
+  const matrixPlan = compileBytecodeToMatrixPlan(bytecode);
+  const matrixInputs = Object.fromEntries(
+    inputNames.map((name, inputIndex) => [
+      name,
+      inputs.map((row) => row[inputIndex] ?? 0),
+    ]),
+  );
+  const result = runNeuralMatrixForward(matrixPlan, matrixInputs);
+  const predictions = inputs.map((_, rowIndex) => (
+    outputNames.map((name) => result.outputs[name]?.[rowIndex] ?? 0)
+  ));
+
+  return {
+    predictions,
+    bytecodeInstructionCount: bytecode.functions[0]?.instructions.length ?? 0,
+    matrixInstructionCount: matrixPlan.instructions.length,
+  };
+}
+
+function toGraphActivation(activation: ActivationName): ActivationKind {
+  return activation === "linear" ? "none" : activation;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -175,7 +175,8 @@ h2 {
 .chart-panel,
 .metrics,
 .lab-intro,
-.trace-panel {
+.trace-panel,
+.network-panel {
   @include surface;
 }
 
@@ -575,13 +576,31 @@ h2 {
 .lesson,
 .activation-panel,
 .source-panel,
-.trace-panel {
+.trace-panel,
+.network-panel {
   display: grid;
   gap: 6px;
 }
 
 .trace-panel {
   padding: 14px;
+}
+
+.network-panel {
+  padding: 14px;
+}
+
+.network-svg {
+  width: 100%;
+  overflow: hidden;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.network-svg svg {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 .lesson p,

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { forwardTwoLayer } from "coding-adventures-two-layer-network/src/index";
 import { activate } from "./activation.js";
 import {
   CELSIUS_DATASET,
@@ -16,6 +17,8 @@ import {
   trainHiddenStep,
   trainHiddenSteps,
 } from "./hidden-layer-examples.js";
+import { predictLinearWithVm, predictTwoLayerWithVm } from "./neural-vm.js";
+import { renderHiddenNetworkSvg, renderLinearNetworkSvg } from "./NetworkDiagram.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -56,6 +59,26 @@ describe("training helpers", () => {
     expect(fit.bias).toBeCloseTo(1);
   });
 
+  it("runs linear predictions through the neural graph VM", () => {
+    const result = predictLinearWithVm([0, 10, 100], { weight: 1.8, bias: 32 });
+
+    expect(result.predictions).toEqual([32, 50, 212]);
+    expect(result.bytecodeInstructionCount).toBeGreaterThan(0);
+    expect(result.matrixInstructionCount).toBeGreaterThan(0);
+  });
+
+  it("renders a Paint VM neural graph view for the linear model", () => {
+    const svg = renderLinearNetworkSvg(
+      { weight: 1.8, bias: 32, epoch: 3 },
+      null,
+      0.0005,
+    );
+
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("<line");
+    expect(svg).toContain("font-size");
+  });
+
   it("applies activation functions used by the lab preview", () => {
     expect(activate(-2, "relu")).toBe(0);
     expect(activate(-2, "leakyRelu")).toBeCloseTo(-0.2);
@@ -85,6 +108,39 @@ describe("training helpers", () => {
       expect(step.step.inputToHiddenWeightGradients).toHaveLength(example.inputLabels.length);
       expect(step.step.hiddenToOutputWeightGradients).toHaveLength(example.hiddenCount);
     }
+  });
+
+  it("matches hidden-layer visualizer predictions with the shared graph VM", () => {
+    const example = HIDDEN_LAYER_EXAMPLES[0]!;
+    const initial = createInitialHiddenState(example);
+    const inputs = example.rows.map((row) => row.input);
+    const direct = forwardTwoLayer(inputs, initial.parameters).predictions;
+    const vm = predictTwoLayerWithVm(inputs, initial.parameters, {
+      inputNames: example.inputLabels,
+      outputNames: [example.outputLabel],
+    });
+
+    expect(vm.predictions).toHaveLength(direct.length);
+    for (const [index, row] of direct.entries()) {
+      expect(vm.predictions[index]![0]).toBeCloseTo(row[0]!);
+    }
+  });
+
+  it("renders a Paint VM neural graph view for hidden-layer examples", () => {
+    const example = HIDDEN_LAYER_EXAMPLES[0]!;
+    const initial = createInitialHiddenState(example);
+    const svg = renderHiddenNetworkSvg(
+      example,
+      initial,
+      example.rows[0]!.input,
+      0.42,
+      null,
+      example.defaultLearningRate,
+    );
+
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("<ellipse");
+    expect(svg).toContain("<line");
   });
 
   it("moves downhill on XNOR and absolute value with batch updates", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.ts
@@ -1,3 +1,5 @@
+import { predictLinearWithVm } from "./neural-vm.js";
+
 export type LossKind = "mse" | "mae";
 
 export interface TrainingPoint {
@@ -32,11 +34,11 @@ export const CELSIUS_DATASET: TrainingPoint[] = [
 ];
 
 export function predict(x: number, state: ModelState): number {
-  return state.weight * x + state.bias;
+  return predictLinearWithVm([x], state).predictions[0] ?? 0;
 }
 
 export function predictions(points: TrainingPoint[], state: ModelState): number[] {
-  return points.map((point) => predict(point.x, state));
+  return predictLinearWithVm(points.map((point) => point.x), state).predictions;
 }
 
 export function loss(points: TrainingPoint[], state: ModelState, lossKind: LossKind): number {


### PR DESCRIPTION
## Summary

- route the ML learning visualizer predictions through the shared neural-network graph and neural-graph-vm matrix plan path
- add Paint VM SVG neural graph panels for the linear and hidden-layer workbenches so weights, biases, activations, and gradient updates are visible during training
- add SVG PaintText handling so browser visualizers render text with native SVG text while keeping PaintGlyphRun available for native renderer paths

## Validation

- npm test -- --run (code/packages/typescript/neural-network)
- npm run build (code/packages/typescript/neural-network)
- npm test -- --run (code/packages/typescript/neural-graph-vm)
- npm run build (code/packages/typescript/neural-graph-vm)
- npm run build (code/packages/typescript/matrix)
- npm test -- --run (code/packages/typescript/paint-vm-svg)
- npm run build (code/packages/typescript/paint-vm-svg)
- bash BUILD (code/programs/typescript/ml-learning-visualizer)
- ./build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/build-plan-visualizer-painttext.json
- in-app browser smoke test confirmed the network SVG renders PaintText text elements with zero tspans/glyph-run labels

## Notes

The previous branch PR was already merged, so this is a fresh follow-up branch based on the latest origin/main.