### PR TITLE
feat(prolog): add unifiability predicates

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to this package will be documented in this file.
   and construction.
 - `acyclic_termo(term)` and `cyclic_termo(term)` for standard finite-term and
   rational-tree shape checks.
+- `unify_with_occurs_checko(left, right)` and
+  `unifiableo(left, right, unifier)` for explicit finite unification and
+  non-binding unifier inspection.
 - `term_hasho(term, hash)` and `term_hash_boundedo(term, depth, range, hash)`
   for deterministic structural term hashes.
 - `current_prolog_flago(name, value)` for enumerating read-only runtime flags

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -38,6 +38,8 @@ ordinary logic goal expressions.
   construction
 - `argo(index, term, value)`
 - `univo(term, parts)` for Prolog-style `=../2` term decomposition/construction
+- `unify_with_occurs_checko(left, right)` and `unifiableo(left, right, unifier)`
+  for finite unification and non-binding unifiability inspection
 - `copytermo(source, copy)`, `same_termo(left, right)`, and
   `not_same_termo(left, right)`
 - `term_variableso(term, variables)` and `numbervarso(term, start, end)` for
@@ -120,6 +122,8 @@ from logic_builtins import (
     groundo,
     acyclic_termo,
     cyclic_termo,
+    unifiableo,
+    unify_with_occurs_checko,
     ifthenelseo,
     includeo,
     integero,
@@ -436,6 +440,8 @@ and arity, while `compound_name_argumentso` and `compound_name_arityo` provide
 compound-only name/arguments and name/arity reflection. `acyclic_termo` and
 `cyclic_termo` expose standard finite-vs-rational-tree checks; today all
 ordinary engine terms are acyclic because the core term model is immutable.
+`unify_with_occurs_checko` exposes finite unification explicitly, while
+`unifiableo` reports a unifier list without binding the source terms.
 `copytermo` refreshes variables in a copied term, while `term_variableso`
 extracts the unique variables still present after reification, `term_hasho`
 gives variant-aware structural hashes for indexing and memoization, and

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -138,6 +138,8 @@ from logic_builtins.builtins import (
     termo_lto,
     throwo,
     trueo,
+    unifiableo,
+    unify_with_occurs_checko,
     univo,
     variant_termo,
     varo,
@@ -279,6 +281,8 @@ __all__ = [
     "throwo",
     "trueo",
     "univo",
+    "unifiableo",
+    "unify_with_occurs_checko",
     "varo",
     "variant_termo",
 ]

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -198,6 +198,8 @@ __all__ = [
     "throwo",
     "trueo",
     "univo",
+    "unifiableo",
+    "unify_with_occurs_checko",
     "varo",
     "not_variant_termo",
     "subsumes_termo",
@@ -446,6 +448,8 @@ _BUILTIN_PREDICATES: tuple[tuple[str, int], ...] = (
     ("throwo", 1),
     ("trueo", 0),
     ("univo", 2),
+    ("unifiableo", 3),
+    ("unify_with_occurs_checko", 2),
     ("varo", 1),
     ("not_variant_termo", 2),
     ("subsumes_termo", 2),
@@ -4676,6 +4680,61 @@ def term_variableso(term_value: object, variables: object) -> GoalExpr:
         )
 
     return native_goal(run, term_value, variables)
+
+
+def unify_with_occurs_checko(left: object, right: object) -> GoalExpr:
+    """Unify two terms using the engine's finite-term occurs check."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        left_term, right_term = args
+        yield from solve_from(program_value, eq(left_term, right_term), state)
+
+    return native_goal(run, left, right)
+
+
+def _unifier_equations(
+    left: Term,
+    right: Term,
+    before: State,
+    after: State,
+) -> list[Term]:
+    """Return first-occurrence equations added by a non-binding unifiability check."""
+
+    equations: list[Term] = []
+    for variable in _term_variables_in_order(term("$unifiable", left, right)):
+        if before.substitution.walk(variable) != variable:
+            continue
+        value = reify(variable, after.substitution)
+        if value != variable:
+            equations.append(term("=", variable, value))
+    return equations
+
+
+def unifiableo(left: object, right: object, unifier: object) -> GoalExpr:
+    """Describe how two terms can unify without binding the source terms."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        left_term, right_term, unifier_target = args
+        unified_state = next(
+            solve_from(program_value, eq(left_term, right_term), state),
+            None,
+        )
+        if unified_state is None:
+            return
+
+        equations = _unifier_equations(
+            _reified(left_term, state),
+            _reified(right_term, state),
+            state,
+            unified_state,
+        )
+        yield from solve_from(
+            program_value,
+            eq(unifier_target, logic_list(equations)),
+            state,
+        )
+
+    return native_goal(run, left, right, unifier)
 
 
 def numbervarso(term_value: object, start: object, end: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -152,6 +152,8 @@ from logic_builtins import (
     termo_lto,
     throwo,
     trueo,
+    unifiableo,
+    unify_with_occurs_checko,
     univo,
     variant_termo,
     varo,
@@ -2073,6 +2075,58 @@ class TestTermMetaprogrammingBuiltins:
             conj(eq(value, "tea"), acyclic_termo(term("pair", value, value))),
         ) == [result]
         assert solve_all(program(), result, cyclic_termo(term("box", value))) == []
+
+    def test_unify_with_occurs_checko_rejects_self_referential_terms(self) -> None:
+        value = var("Value")
+        marker = var("Marker")
+
+        assert solve_all(
+            program(),
+            value,
+            unify_with_occurs_checko(value, term("box", "tea")),
+        ) == [term("box", "tea")]
+        assert (
+            solve_all(
+                program(),
+                marker,
+                unify_with_occurs_checko(value, term("box", value)),
+            )
+            == []
+        )
+
+    def test_unifiableo_reports_bindings_without_applying_them(self) -> None:
+        left = var("Left")
+        right = var("Right")
+        unifier = var("Unifier")
+
+        answers = solve_all(
+            program(),
+            (left, right, unifier),
+            unifiableo(term("pair", left, left), term("pair", "tea", right), unifier),
+        )
+
+        assert answers == [
+            (
+                left,
+                right,
+                logic_list([
+                    term("=", left, atom("tea")),
+                    term("=", right, atom("tea")),
+                ]),
+            ),
+        ]
+
+    def test_unifiableo_fails_when_terms_cannot_unify(self) -> None:
+        unifier = var("Unifier")
+
+        assert (
+            solve_all(
+                program(),
+                unifier,
+                unifiableo(term("box", "tea"), term("box", "cake"), unifier),
+            )
+            == []
+        )
 
     def test_term_hasho_hashes_variants_alike_but_preserves_variable_shape(
         self,

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -64,6 +64,8 @@
 - adapt Prolog `compound_name_arguments/3` and `compound_name_arity/3` into
   compound-only term reflection goals
 - adapt Prolog `acyclic_term/1` and `cyclic_term/1` into term-shape goals
+- adapt Prolog `unifiable/3` and `unify_with_occurs_check/2` into explicit
+  finite unification goals
 - adapt Prolog `term_hash/2` and `term_hash/4` into deterministic structural
   hash goals
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -27,6 +27,8 @@ It keeps parsing side-effect free, then exposes helpers to:
   compound-only term reflection and construction
 - adapt `acyclic_term/1` and `cyclic_term/1` for source-level term-shape
   checks
+- adapt `unifiable/3` and `unify_with_occurs_check/2` for explicit finite
+  unification and non-binding unifier inspection
 - adapt `term_hash/2` and `term_hash/4` for stable source-level term hashes
 - adapt callable CLP(FD) forms such as `in/2`, `ins/2`, `#=/2`,
   `all_different/1`, and `labeling/2`

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -115,6 +115,8 @@ from logic_builtins import (
     termo_lto,
     throwo,
     trueo,
+    unifiableo,
+    unify_with_occurs_checko,
     univo,
     variant_termo,
     varo,
@@ -390,6 +392,10 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return argo(*args)
     if name == "=.." and goal.relation.arity == 2:
         return univo(*args)
+    if name == "unifiable" and goal.relation.arity == 3:
+        return unifiableo(*args)
+    if name == "unify_with_occurs_check" and goal.relation.arity == 2:
+        return unify_with_occurs_checko(*args)
     if name == "copy_term" and goal.relation.arity == 2:
         return copytermo(*args)
     if name == "term_variables" and goal.relation.arity == 2:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -840,6 +840,15 @@ class TestPrologGoalAdapter:
                 term("memo", atom("ok")),
                 term(".", atom("memo"), term(".", atom("ok"), atom("[]"))),
             ),
+            relation("unifiable", 3)(
+                term("box", LogicVar(id=92)),
+                term("box", atom("tea")),
+                LogicVar(id=93),
+            ),
+            relation("unify_with_occurs_check", 2)(
+                LogicVar(id=94),
+                term("box", atom("tea")),
+            ),
             relation("atom_chars", 2)(atom("tea"), logic_list(["t", "e", "a"])),
             relation("atom_codes", 2)(atom("tea"), logic_list([116, 101, 97])),
             relation("atom_concat", 3)(atom("tea"), atom("cup"), atom("teacup")),
@@ -1329,6 +1338,35 @@ class TestPrologGoalAdapter:
         assert len(template.args) == 2
         assert all(isinstance(argument, LogicVar) for argument in template.args)
         assert template.args[0] != template.args[1]
+
+    def test_adapt_prolog_goal_rewrites_unifiability_predicates(self) -> None:
+        parsed = parse_swi_query(
+            "?- unifiable(pair(X, X), pair(tea, Y), Unifier), "
+            "unify_with_occurs_check(Z, box(tea)).",
+        )
+
+        answers = solve_all(
+            program(),
+            (
+                parsed.variables["X"],
+                parsed.variables["Y"],
+                parsed.variables["Unifier"],
+                parsed.variables["Z"],
+            ),
+            adapt_prolog_goal(parsed.goal),
+        )
+
+        assert answers == [
+            (
+                parsed.variables["X"],
+                parsed.variables["Y"],
+                logic_list([
+                    term("=", parsed.variables["X"], atom("tea")),
+                    term("=", parsed.variables["Y"], atom("tea")),
+                ]),
+                term("box", "tea"),
+            ),
+        ]
 
     def test_adapt_prolog_goal_rewrites_term_hash_predicates(self) -> None:
         parsed = parse_swi_query(

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -69,6 +69,8 @@
   the VM path for compound-only term reflection.
 - Run Prolog `acyclic_term/1` and `cyclic_term/1` through the VM path for
   source-level term-shape checks.
+- Run Prolog `unifiable/3` and `unify_with_occurs_check/2` through the VM path
+  for explicit finite unification.
 - Run Prolog `term_hash/2` and `term_hash/4` through the VM path for
   deterministic structural term hashes.
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -150,6 +150,8 @@ The package includes end-to-end stress tests for:
 - compound reflection with `compound_name_arguments/3` and
   `compound_name_arity/3`
 - term-shape checks with `acyclic_term/1` and `cyclic_term/1`
+- explicit unifiability checks with `unifiable/3` and
+  `unify_with_occurs_check/2`
 - structural term hashing with `term_hash/2` and `term_hash/4`
 - runtime flag introspection and branch-local updates with
   `current_prolog_flag/2` and `set_prolog_flag/2`

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -181,6 +181,25 @@ class TestPrologVMStress:
         )
         assert answer["Result"] == atom("ok")
 
+    def test_unifiability_predicates_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            ?- unifiable(pair(X, X), pair(tea, Y), Unifier),
+               unify_with_occurs_check(Z, box(tea)),
+               \\+ unify_with_occurs_check(Bad, box(Bad)).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert len(answers) == 1
+        answer = answers[0].as_dict()
+        assert answer["Unifier"] == logic_list([
+            term("=", answer["X"], atom("tea")),
+            term("=", answer["Y"], atom("tea")),
+        ])
+        assert answer["Z"] == term("box", "tea")
+
     def test_term_variables_runs_through_vm(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR61-prolog-unifiability-predicates.md
+++ b/code/specs/PR61-prolog-unifiability-predicates.md
@@ -1,0 +1,44 @@
+# PR61: Prolog Unifiability Predicates
+
+## Goal
+
+Expose explicit source-level unifiability predicates on top of the Logic VM.
+This gives Prolog programs a way to ask how two terms can unify without
+necessarily mutating the caller's bindings, and a named finite-unification
+predicate that makes the engine's occurs-check behavior visible.
+
+## Scope
+
+The builtin and loader layers expose:
+
+```text
+unifiable/3
+unify_with_occurs_check/2
+```
+
+The VM path supports both through parser, loader adapter, compiler, and runtime
+execution.
+
+## Semantics
+
+This batch implements deterministic finite unifiability:
+
+- `unify_with_occurs_check(Left, Right)` unifies `Left` and `Right` using the
+  engine's finite-term occurs check.
+- Self-referential bindings such as `X = box(X)` fail under
+  `unify_with_occurs_check/2`.
+- `unifiable(Left, Right, Unifier)` succeeds when the two terms can unify and
+  unifies `Unifier` with a proper list of `Var = Value` equations.
+- `unifiable/3` does not bind the source terms. It computes the first
+  deterministic unifier in an isolated successor state, reifies each
+  first-occurrence source variable under that state, and reports only variables
+  that gained bindings.
+- Terms that cannot unify make `unifiable/3` fail.
+
+## Verification
+
+- `logic-builtins` tests cover finite unification, occurs-check rejection,
+  non-binding unifier extraction, and non-unifiable failure.
+- `prolog-loader` tests cover source-level adaptation for both predicates.
+- `prolog-vm-compiler` stress coverage runs both predicates end-to-end through
+  parser, loader, compiler, VM, and named-answer extraction.


### PR DESCRIPTION
## Summary
- add `unify_with_occurs_checko/2` and `unifiableo/3` to `logic-builtins`
- adapt source-level `unify_with_occurs_check/2` and `unifiable/3` through `prolog-loader`
- add VM stress coverage plus PR61 docs/spec notes for end-to-end unifiability behavior

## Verification
- `./.venv/bin/ruff check . --fix` in `logic-builtins`
- `bash BUILD` in `logic-builtins`
- `./.venv/bin/ruff check . --fix` in `prolog-loader`
- `bash BUILD` in `prolog-loader`
- `./.venv/bin/ruff check . --fix` in `prolog-vm-compiler`
- `bash BUILD` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-unifiability-build-plan.json`