### PR TITLE
Support typed ALGOL formal specifiers

### DIFF
--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -120,10 +120,20 @@ formal_params = LPAREN ident_list RPAREN ;
 # re-evaluated every time the parameter is used inside the procedure body.
 value_part   = "value" ident_list SEMICOLON ;
 
-# spec_part declares what kind each parameter is (integer, real, array, etc.)
+# spec_part declares what kind each parameter is (integer, real, array, etc.).
+# Typed array/procedure specs accept report-style combined forms such as
+# `integer array a;` and `real procedure f;`. The older split spelling
+# `integer a; array a;` remains valid because repeated spec parts are merged by
+# the semantic checker.
 spec_part    = specifier ident_list SEMICOLON ;
 
-specifier    = "integer" | "real" | "boolean" | "string" | "array" | "label" | "switch" | "procedure" ;
+specifier    = type "array"
+             | type "procedure"
+             | "array"
+             | "label"
+             | "switch"
+             | "procedure"
+             | type ;
 
 proc_body    = block | statement ;
 

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -81,6 +81,8 @@ All notable changes to this package will be documented in this file.
   descriptor pointers to actual procedures that declare matching array formals.
 - Lowered label, switch, and procedure arguments through formal procedure
   dispatchers by forwarding label ids and descriptor pointers.
+- Lowered report-style typed formal specifiers such as `integer array a;` and
+  `real procedure f;` through the existing array/procedure formal paths.
 - Lowered conditional switch designator actuals by selecting and forwarding the
   chosen switch descriptor through concrete and formal procedure calls.
 - Preserved concrete procedure ids in formal procedure call-shape metadata so

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1099,6 +1099,21 @@ class TestAlgolIrCompiler:
             for instruction in calls
         )
 
+    def test_compiles_report_style_typed_array_parameter_specifier(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; integer array a[1:2]; "
+                "procedure first(xs); integer array xs; "
+                "begin result := xs[1] end; "
+                "a[1] := 9; first(a) "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert IrOp.LOAD_WORD in opcodes
+        assert IrOp.STORE_WORD in opcodes
+
     def test_compiles_procedure_parameter_call_with_label_argument(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -1262,6 +1277,24 @@ class TestAlgolIrCompiler:
             parse_algol(
                 "begin integer result; real y; "
                 "procedure invoke(f); real f; procedure f; "
+                "begin y := f(2); if y = 4 then result := 1 else result := 0 end; "
+                "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
+                "invoke(twice) "
+                "end"
+            )
+        )
+        signature = result.procedure_signatures[
+            "_fn_algol_call_procedure_f64_result_i32"
+        ]
+
+        assert signature.param_types == ("integer", "integer", "integer")
+        assert signature.return_type == "real"
+
+    def test_compiles_report_style_typed_procedure_parameter_specifier(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real y; "
+                "procedure invoke(f); real procedure f; "
                 "begin y := f(2); if y = 4 then result := 1 else result := 0 end; "
                 "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
                 "invoke(twice) "

--- a/code/packages/python/algol-parser/CHANGELOG.md
+++ b/code/packages/python/algol-parser/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and double-quoted string literals through the shared ALGOL lexer.
 - Parsed ALGOL publication symbols for relations, exponentiation, and boolean
   operators through the shared lexer normalization layer.
+- Parsed report-style typed formal specifiers such as `integer array a;` and
+  `real procedure f;` while preserving the existing split specifier spelling.
 
 ## [0.1.0] — 2026-04-06
 

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -683,6 +683,32 @@ class TestDeclarations:
         own_array_decl_nodes = find_nodes(ast, "own_array_decl")
         assert len(own_array_decl_nodes) >= 1
 
+    def test_report_style_typed_array_parameter_specifier(self) -> None:
+        """Formal parameters accept ``integer array`` as one specifier."""
+        ast = parse(
+            "begin integer result; integer array xs[1:1]; "
+            "procedure first(a); integer array a; begin result := a[1] end; "
+            "first(xs) "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "specifier")
+
+    def test_report_style_typed_procedure_parameter_specifier(self) -> None:
+        """Formal parameters accept ``real procedure`` as one specifier."""
+        ast = parse(
+            "begin integer result; "
+            "procedure invoke(f); real procedure f; "
+            "begin if f(2) = 4 then result := 1 else result := 0 end; "
+            "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
+            "invoke(twice) "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "specifier")
+
 
 # ---------------------------------------------------------------------------
 # Procedure call tests

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -53,6 +53,9 @@ All notable changes to this package will be documented in this file.
   procedure parameters, recording array argument call shapes for lowering.
 - Accepted procedure-valued actuals with label, switch, and procedure
   parameters for formal procedure parameters.
+- Accepted report-style typed formal specifiers such as `integer array a;` and
+  `real procedure f;`, merging them into the same semantic parameter metadata
+  as the older split spelling.
 - Validated nested procedure-parameter call-shape contracts when a formal
   procedure call forwards a concrete procedure actual.
 - Accepted conditional switch designator actuals for switch formals and formal

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -56,10 +56,13 @@ the semantic model, while later lowering packages now implement scalar
 call-by-name, typed whole-array formals, label formals, switch formals, and
 no-argument statement procedure formals. `value` whole-array parameters are
 also accepted and lowered as copy formals, while `value` label, switch, and
-procedure formals use copied ids or descriptors. Formal procedure parameters
-accept procedure-valued actuals with scalar `value` or by-name parameters and
-whole-array, label, switch, or procedure parameters, rejecting only call shapes
-that would pass a non-assignable actual to a written by-name parameter.
+procedure formals use copied ids or descriptors. Typed array and procedure
+formals accept both split specs such as `integer a; array a;` and report-style
+combined specs such as `integer array a;` or `real procedure f;`. Formal
+procedure parameters accept procedure-valued actuals with scalar `value` or
+by-name parameters and whole-array, label, switch, or procedure parameters,
+rejecting only call shapes that would pass a non-assignable actual to a written
+by-name parameter.
 Real-valued formal procedure parameters accept integer-returning procedure
 actuals via the same numeric promotion rule used by scalar calls. When a
 formal procedure call forwards a concrete procedure actual into another

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -3387,22 +3387,39 @@ def _parameter_specs(node: ASTNode) -> dict[str, _ParameterSpec]:
     specs: dict[str, _ParameterSpec] = {}
     for spec_part in _direct_nodes(node, "spec_part"):
         specifier = _first_direct_node(spec_part, "specifier")
-        specifier_name = _first_keyword_value(specifier) or ""
+        specifier_kind, specifier_type = _parameter_specifier(specifier)
         ident_list = _first_direct_node(spec_part, "ident_list")
         for token in _tokens(ident_list):
             if token.type_name == "NAME":
                 current = specs.get(token.value, _ParameterSpec())
-                if specifier_name in {INTEGER, BOOLEAN, REAL, STRING}:
-                    specs[token.value] = _ParameterSpec(
-                        kind=current.kind,
-                        type_name=specifier_name,
-                    )
-                elif specifier_name in {ARRAY, LABEL, SWITCH, "procedure"}:
-                    specs[token.value] = _ParameterSpec(
-                        kind=specifier_name,
-                        type_name=current.type_name,
-                    )
+                specs[token.value] = _ParameterSpec(
+                    kind=specifier_kind or current.kind,
+                    type_name=specifier_type or current.type_name,
+                )
     return specs
+
+
+def _parameter_specifier(node: ASTNode | None) -> tuple[str | None, str | None]:
+    values = [
+        token.value
+        for token in _tokens(node)
+        if token.type_name == "KEYWORD"
+    ]
+    type_name = next(
+        (value for value in values if value in {INTEGER, BOOLEAN, REAL, STRING}),
+        None,
+    )
+    if ARRAY in values:
+        return ARRAY, type_name
+    if "procedure" in values:
+        return "procedure", type_name
+    if LABEL in values:
+        return LABEL, None
+    if SWITCH in values:
+        return SWITCH, None
+    if type_name is not None:
+        return "scalar", type_name
+    return None, None
 
 
 def _label_token(node: ASTNode) -> Token | None:

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -1154,6 +1154,24 @@ class TestAlgolTypeChecker:
         assert parameter.type_name == "real"
         assert parameter.procedure_call_shapes[0].return_type == "real"
 
+    def test_accepts_report_style_typed_procedure_parameter_specifier(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real y; "
+            "procedure invoke(f); real procedure f; "
+            "begin y := f(2); if y = 4 then result := 1 else result := 0 end; "
+            "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
+            "invoke(twice) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "procedure"
+        assert parameter.type_name == "real"
+        assert parameter.procedure_call_shapes[0].return_type == "real"
+
     def test_accepts_typed_procedure_parameter_with_array_argument_actual(
         self,
     ) -> None:
@@ -1175,6 +1193,23 @@ class TestAlgolTypeChecker:
         assert shape.return_type == "integer"
         assert shape.argument_kinds == ("array",)
         assert shape.argument_types == ("integer",)
+
+    def test_accepts_report_style_typed_array_parameter_specifier(self) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array a[1:2]; "
+            "procedure first(xs); integer array xs; "
+            "begin result := xs[1] end; "
+            "first(a) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.kind == "array"
+        assert parameter.type_name == "integer"
+        assert any(access.role == "actual" for access in result.semantic.array_accesses)
 
     def test_accepts_integer_procedure_actual_for_real_procedure_parameter(
         self,

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -74,6 +74,8 @@ All notable changes to this package will be documented in this file.
   procedures, preserving descriptor aliasing and existing `value` array copies.
 - Executed formal procedure calls that forward label, switch, and procedure
   arguments to actual procedures.
+- Executed report-style typed formal specifiers such as `integer array a;` and
+  `real procedure f;` through the full WASM pipeline.
 - Executed conditional switch actuals through direct calls, forwarded switch
   formals, and formal procedure dispatch, with a golden end-to-end fixture.
 - Rejected formal procedure forwarding when a concrete procedure argument does

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -30,9 +30,10 @@ the current lane already supports a substantial ALGOL 60 surface:
   `arctan`, `ln`, and `exp`; non-native real math is imported through the
   runtime's `compiler_math` host ABI
 - value and by-name parameters, including Jensen-style expression thunks,
-  typed whole-array formals with copy or aliasing semantics, and formal
-  procedure calls that forward scalar, whole-array, label, switch, or
-  procedure arguments while validating nested procedure-formal contracts
+  typed whole-array formals with copy or aliasing semantics, report-style
+  combined specs like `integer array a;` and `real procedure f;`, and formal
+  procedure calls that forward scalar, whole-array, label, switch, or procedure
+  arguments while validating nested procedure-formal contracts
 - label, switch, and procedure formals in value or by-name mode
 - bare no-argument typed procedure names as expression calls, matching ALGOL's
   omitted-parentheses call syntax for parameterless procedures

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1031,6 +1031,16 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_report_style_typed_array_parameter_specifier_executes(self) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:2]; "
+            "procedure first(xs); integer array xs; "
+            "begin result := xs[1] end; "
+            "a[1] := 9; first(a) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
     def test_formal_procedure_array_argument_honors_value_array_copy(self) -> None:
         result = compile_source(
             "begin integer result; integer array a[1:2]; "
@@ -1135,6 +1145,17 @@ class TestAlgolWasmCompiler:
         result = compile_source(
             "begin integer result; real y; "
             "procedure invoke(f); real f; procedure f; "
+            "begin y := f(2); if y = 4 then result := 1 else result := 0 end; "
+            "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
+            "invoke(twice) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
+
+    def test_report_style_typed_procedure_parameter_specifier_executes(self) -> None:
+        result = compile_source(
+            "begin integer result; real y; "
+            "procedure invoke(f); real procedure f; "
             "begin y := f(2); if y = 4 then result := 1 else result := 0 end; "
             "real procedure twice(x); value x; real x; begin twice := x * 2 end; "
             "invoke(twice) "


### PR DESCRIPTION
## Summary
- parse report-style combined formal specifiers like `integer array a;` and `real procedure f;`
- merge combined specifiers into the same type-checker parameter metadata as existing split specs like `integer a; array a;`
- add parser, type-checker, IR, and WASM coverage for typed array and procedure formals plus docs/changelog updates

## Verification
- bash BUILD (algol-wasm-compiler): 196 passed
- pytest (algol-parser): 70 passed
- pytest (algol-type-checker): 153 passed
- pytest (algol-ir-compiler): 114 passed
- ruff check touched Python files: passed
- git diff --check: passed

## Security review
- Diff scan found no added process execution, network calls, file I/O, deserialization, or secret handling. Runtime change is limited to grammar recognition and semantic parameter-spec metadata merging.