### PR TITLE
[codex] Show full neural training flow

### DIFF
--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
   neural-network graph and neural-graph-vm matrix plan path.
 - Added Paint VM SVG neural graph panels that show weights, bias edges,
   activations, and gradient updates while training runs advance.
+- Expanded the neural graph panels into a full learning-flow trace covering
+  forward prediction, error/loss calculation, gradients, and parameter updates.
 
 ## [0.1.0] - 2026-03-25
 

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -386,7 +386,14 @@ export function App() {
             </div>
           </section>
 
-          <LinearNetworkDiagram model={model} lastStep={lastStep} learningRate={learningRate} />
+          <LinearNetworkDiagram
+            model={model}
+            lastStep={lastStep}
+            learningRate={learningRate}
+            lossKind={lossKind}
+            samplePoint={selectedLab.points[0]!}
+            pointCount={selectedLab.points.length}
+          />
         </section>
 
         <aside className="controls metrics" aria-label="Training controls and metrics">

--- a/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
@@ -432,7 +432,8 @@ export function HiddenLayerWorkbench() {
         <HiddenNetworkDiagram
           example={example}
           state={state}
-          selectedInput={example.rows[selectedIndex]!.input}
+          selectedRow={example.rows[selectedIndex]!}
+          selectedIndex={selectedIndex}
           prediction={predictions[selectedIndex]!}
           lastStep={lastStep}
           learningRate={learningRate}

--- a/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
@@ -10,10 +10,11 @@ import {
 } from "@coding-adventures/paint-instructions";
 import type {
   HiddenLayerExample,
+  HiddenLayerExampleRow,
   HiddenLayerModelState,
   HiddenLayerStepResult,
 } from "./hidden-layer-examples.js";
-import type { ModelState, StepResult } from "./training.js";
+import type { LossKind, ModelState, StepResult, TrainingPoint } from "./training.js";
 
 const FONT_REF = "svg:ui-sans-serif@12";
 const MUTED = "#5d6d68";
@@ -23,6 +24,7 @@ const GREEN = "#237a57";
 const BLUE = "#2563eb";
 const RED = "#c2413b";
 const GOLD = "#b7791f";
+const VIOLET = "#6d5bd0";
 
 interface DiagramNode {
   readonly id: string;
@@ -37,16 +39,29 @@ export function LinearNetworkDiagram({
   model,
   lastStep,
   learningRate,
+  lossKind,
+  samplePoint,
+  pointCount,
 }: {
   model: ModelState;
   lastStep: StepResult | null;
   learningRate: number;
+  lossKind: LossKind;
+  samplePoint: TrainingPoint;
+  pointCount: number;
 }) {
   return (
     <NetworkPanel
-      title="Neural graph"
-      summary="Linear graph VM view"
-      svg={renderLinearNetworkSvg(model, lastStep, learningRate)}
+      title="Learning flow"
+      summary="Forward pass and gradient descent"
+      svg={renderLinearNetworkSvg(
+        model,
+        lastStep,
+        learningRate,
+        lossKind,
+        samplePoint,
+        pointCount,
+      )}
     />
   );
 }
@@ -54,14 +69,16 @@ export function LinearNetworkDiagram({
 export function HiddenNetworkDiagram({
   example,
   state,
-  selectedInput,
+  selectedRow,
+  selectedIndex,
   prediction,
   lastStep,
   learningRate,
 }: {
   example: HiddenLayerExample;
   state: HiddenLayerModelState;
-  selectedInput: readonly number[];
+  selectedRow: HiddenLayerExampleRow;
+  selectedIndex: number;
   prediction: number;
   lastStep: HiddenLayerStepResult | null;
   learningRate: number;
@@ -69,11 +86,12 @@ export function HiddenNetworkDiagram({
   return (
     <NetworkPanel
       title="Neural graph"
-      summary="Hidden layer graph VM view"
+      summary="Hidden layer learning flow"
       svg={renderHiddenNetworkSvg(
         example,
         state,
-        selectedInput,
+        selectedRow,
+        selectedIndex,
         prediction,
         lastStep,
         learningRate,
@@ -86,15 +104,26 @@ export function renderLinearNetworkSvg(
   model: ModelState,
   lastStep: StepResult | null,
   learningRate: number,
+  lossKind: LossKind = "mse",
+  samplePoint: TrainingPoint = { x: 0, y: 0 },
+  pointCount = 1,
 ): string {
-  const scene = makeLinearScene(model, lastStep, learningRate);
+  const scene = makeLinearScene(
+    model,
+    lastStep,
+    learningRate,
+    lossKind,
+    samplePoint,
+    pointCount,
+  );
   return renderToSvgString(scene);
 }
 
 export function renderHiddenNetworkSvg(
   example: HiddenLayerExample,
   state: HiddenLayerModelState,
-  selectedInput: readonly number[],
+  selectedRow: HiddenLayerExampleRow,
+  selectedIndex: number,
   prediction: number,
   lastStep: HiddenLayerStepResult | null,
   learningRate: number,
@@ -102,7 +131,8 @@ export function renderHiddenNetworkSvg(
   const scene = makeHiddenScene(
     example,
     state,
-    selectedInput,
+    selectedRow,
+    selectedIndex,
     prediction,
     lastStep,
     learningRate,
@@ -134,44 +164,76 @@ function makeLinearScene(
   model: ModelState,
   lastStep: StepResult | null,
   learningRate: number,
+  lossKind: LossKind,
+  samplePoint: TrainingPoint,
+  pointCount: number,
 ): PaintScene {
-  const width = 760;
-  const height = 280;
+  const width = 920;
+  const height = 520;
+  const runState = lastStep?.previousState ?? model;
+  const prediction = samplePoint.x * runState.weight + runState.bias;
+  const error = prediction - samplePoint.y;
+  const sampleLoss = lossKind === "mse" ? error * error : Math.abs(error);
   const input: DiagramNode = {
     id: "input",
     label: "x",
-    value: "input",
-    x: 120,
-    y: 130,
+    value: fmt(samplePoint.x),
+    x: 100,
+    y: 150,
     tone: "input",
   };
   const bias: DiagramNode = {
     id: "bias",
     label: "bias",
-    value: fmt(model.bias),
-    x: 120,
-    y: 214,
+    value: fmt(runState.bias),
+    x: 100,
+    y: 232,
     tone: "bias",
   };
   const sum: DiagramNode = {
     id: "sum",
     label: "sum",
     value: "x*w+b",
-    x: 378,
-    y: 130,
+    x: 318,
+    y: 150,
     tone: "hidden",
   };
   const output: DiagramNode = {
     id: "output",
     label: "pred",
-    value: "y",
-    x: 640,
-    y: 130,
+    value: fmt(prediction),
+    x: 540,
+    y: 150,
+    tone: "output",
+  };
+  const target: DiagramNode = {
+    id: "target",
+    label: "target",
+    value: fmt(samplePoint.y),
+    x: 540,
+    y: 232,
+    tone: "bias",
+  };
+  const lossNode: DiagramNode = {
+    id: "loss",
+    label: lossKind,
+    value: fmt(sampleLoss),
+    x: 760,
+    y: 190,
     tone: "output",
   };
 
   const dw = lastStep === null ? 0 : -learningRate * lastStep.gradientWeight;
   const db = lastStep === null ? 0 : -learningRate * lastStep.gradientBias;
+  const gradientText = lastStep === null
+    ? "waiting for first step"
+    : `dL/dw ${fmt(lastStep.gradientWeight)}  dL/db ${fmt(lastStep.gradientBias)}`;
+  const updateText = lastStep === null
+    ? "run Step to update weights"
+    : `w ${fmt(lastStep.previousState.weight)} -> ${fmt(model.weight)}`;
+  const biasUpdateText = lastStep === null
+    ? `lr ${fmt(learningRate)}`
+    : `b ${fmt(lastStep.previousState.bias)} -> ${fmt(model.bias)}`;
   const instructions: PaintInstruction[] = [
     paintRect(16, 16, width - 32, height - 32, {
       fill: PANEL,
@@ -179,16 +241,48 @@ function makeLinearScene(
       stroke_width: 1,
       corner_radius: 8,
     }),
-    ...edge(input, sum, model.weight, `w ${fmt(model.weight)}`),
-    ...edge(bias, sum, model.bias, `b ${fmt(model.bias)}`),
+    ...sectionLabel("1 forward pass", 36, 48),
+    ...edge(input, sum, runState.weight, `w ${fmt(runState.weight)}`),
+    ...edge(bias, sum, runState.bias, `b ${fmt(runState.bias)}`),
     ...edge(sum, output, 1, "linear"),
+    ...edge(output, lossNode, error, `err ${signed(error)}`, 0.56),
+    ...edge(target, lossNode, -1, "truth", 0.56),
     ...node(input),
     ...node(bias),
     ...node(sum),
     ...node(output),
-    ...text(`epoch ${model.epoch}`, 32, 48, 13, MUTED),
-    ...text(`dw ${signed(dw)}  db ${signed(db)}`, 32, 254, 13, MUTED),
-    ...text("line width follows |weight|; green is positive, red is negative", 380, 254, 12, MUTED),
+    ...node(target),
+    ...node(lossNode),
+    ...flowCard(36, 314, 152, "input batch", [
+      `${pointCount} rows`,
+      `sample x ${fmt(samplePoint.x)}`,
+      `target ${fmt(samplePoint.y)}`,
+    ], BLUE),
+    ...flowArrow(194, 360, 242, 360, BLUE, "feed"),
+    ...flowCard(252, 314, 158, "prediction", [
+      `yhat=x*w+b`,
+      `yhat ${fmt(prediction)}`,
+      "activation linear",
+    ], GREEN),
+    ...flowArrow(416, 360, 464, 360, BLUE, "compare"),
+    ...flowCard(474, 314, 162, "error + loss", [
+      `error ${signed(error)}`,
+      `${lossKind.toUpperCase()} ${fmt(sampleLoss)}`,
+      `batch loss ${fmt(lastStep?.previousLoss ?? sampleLoss)}`,
+    ], RED),
+    ...flowArrow(642, 360, 690, 360, RED, "differentiate"),
+    ...flowCard(700, 314, 184, "gradient descent", [
+      gradientText,
+      `dw step ${signed(dw)}`,
+      `db step ${signed(db)}`,
+    ], VIOLET),
+    ...flowArrow(792, 308, 792, 266, RED, "backprop"),
+    ...flowArrow(700, 266, 332, 210, RED, "apply update"),
+    ...text(updateText, 36, 488, 13, MUTED),
+    ...text(biasUpdateText, 252, 488, 13, MUTED),
+    ...text("parameter update: new = old - learningRate * gradient", 474, 488, 13, MUTED),
+    ...text(`epoch ${model.epoch}`, 36, 72, 13, MUTED),
+    ...text("line width follows |weight|; green is positive, red is negative", 476, 72, 12, MUTED),
   ];
 
   return paintScene(width, height, "#ffffff", instructions, {
@@ -199,13 +293,16 @@ function makeLinearScene(
 function makeHiddenScene(
   example: HiddenLayerExample,
   state: HiddenLayerModelState,
-  selectedInput: readonly number[],
+  selectedRow: HiddenLayerExampleRow,
+  selectedIndex: number,
   prediction: number,
   lastStep: HiddenLayerStepResult | null,
   learningRate: number,
 ): PaintScene {
-  const width = 820;
-  const height = 390;
+  const width = 920;
+  const height = 560;
+  const selectedInput = selectedRow.input;
+  const selectedError = prediction - selectedRow.target;
   const inputYs = verticalPositions(example.inputLabels.length, 82, 232);
   const hiddenYs = verticalPositions(example.hiddenCount, 54, 286);
   const inputNodes = example.inputLabels.map((label, index): DiagramNode => ({
@@ -236,8 +333,24 @@ function makeHiddenScene(
     id: "output",
     label: example.outputLabel,
     value: fmt(prediction),
-    x: 720,
+    x: 708,
     y: 170,
+    tone: "output",
+  };
+  const target: DiagramNode = {
+    id: "target",
+    label: "target",
+    value: fmt(selectedRow.target),
+    x: 708,
+    y: 252,
+    tone: "bias",
+  };
+  const lossNode: DiagramNode = {
+    id: "loss",
+    label: "mse",
+    value: fmt(selectedError * selectedError),
+    x: 834,
+    y: 212,
     tone: "output",
   };
 
@@ -248,8 +361,9 @@ function makeHiddenScene(
       stroke_width: 1,
       corner_radius: 8,
     }),
-    ...text(`epoch ${state.epoch}`, 32, 48, 13, MUTED),
-    ...text("weights update on every step", 628, 48, 13, MUTED),
+    ...sectionLabel("1 selected forward pass", 32, 48),
+    ...text(`epoch ${state.epoch}`, 32, 70, 13, MUTED),
+    ...text("weights update on every batch step", 630, 48, 13, MUTED),
   ];
 
   for (const [inputIndex, inputNode] of inputNodes.entries()) {
@@ -268,25 +382,136 @@ function makeHiddenScene(
   }
   instructions.push(
     ...edge(bias, output, state.parameters.outputBiases[0] ?? 0, fmt(state.parameters.outputBiases[0] ?? 0), 0.28),
+    ...edge(output, lossNode, selectedError, `err ${signed(selectedError)}`, 0.62),
+    ...edge(target, lossNode, -1, "truth", 0.62),
     ...inputNodes.flatMap(node),
     ...node(bias),
     ...hiddenNodes.flatMap(node),
     ...node(output),
+    ...node(target),
+    ...node(lossNode),
   );
 
   const inputShape = lastStep === null
     ? "input-hidden gradients waiting"
     : `input-hidden grad ${lastStep.step.inputToHiddenWeightGradients.length}x${lastStep.step.inputToHiddenWeightGradients[0]?.length ?? 0}`;
   const outputGrad = lastStep?.step.outputBiasGradients[0] ?? 0;
+  const outputDelta = lastStep?.step.outputDeltas[selectedIndex]?.[0] ?? 0;
+  const hiddenDeltaRow = lastStep?.step.hiddenDeltas[selectedIndex] ?? [];
+  const hiddenDelta = hiddenDeltaRow.length === 0
+    ? 0
+    : hiddenDeltaRow.reduce((max, value) => Math.max(max, Math.abs(value)), 0);
+  const hiddenUpdate = lastStep === null
+    ? "waiting for first step"
+    : `max hidden delta ${fmt(hiddenDelta)}`;
   instructions.push(
-    ...text(inputShape, 32, 356, 12, MUTED),
-    ...text(`output db ${signed(-learningRate * outputGrad)}`, 356, 356, 12, MUTED),
-    ...text("line width = |weight|", 620, 356, 12, MUTED),
+    ...sectionLabel("2 loss, deltas, and gradient descent", 32, 352),
+    ...flowCard(32, 382, 158, "input row", [
+      selectedRow.label,
+      `inputs ${selectedInput.map((value) => fmt(value)).join(", ")}`,
+      `target ${fmt(selectedRow.target)}`,
+    ], BLUE),
+    ...flowArrow(196, 428, 244, 428, BLUE, "forward"),
+    ...flowCard(254, 382, 162, "prediction", [
+      `hidden[${example.hiddenCount}]`,
+      `${example.outputLabel} ${fmt(prediction)}`,
+      `error ${signed(selectedError)}`,
+    ], GREEN),
+    ...flowArrow(422, 428, 470, 428, RED, "loss"),
+    ...flowCard(480, 382, 158, "mse + deltas", [
+      `row mse ${fmt(selectedError * selectedError)}`,
+      `output delta ${fmt(outputDelta)}`,
+      hiddenUpdate,
+    ], RED),
+    ...flowArrow(644, 428, 692, 428, RED, "gradients"),
+    ...flowCard(702, 382, 186, "parameter update", [
+      inputShape,
+      `hidden-output ${gradientShape(lastStep?.step.hiddenToOutputWeightGradients)}`,
+      `db out ${signed(-learningRate * outputGrad)}`,
+    ], VIOLET),
+    ...flowArrow(800, 376, 800, 330, RED, "backprop"),
+    ...flowArrow(708, 330, 430, 276, RED, "update matrices"),
+    ...text("new weights = old weights - learningRate * gradient", 32, 536, 13, MUTED),
+    ...text("line width = |weight|", 630, 536, 12, MUTED),
   );
 
   return paintScene(width, height, "#ffffff", instructions, {
     id: "hidden-neural-network-diagram",
   });
+}
+
+function sectionLabel(label: string, x: number, y: number): PaintInstruction[] {
+  return [
+    paintRect(x - 8, y - 17, Math.max(126, label.length * 8), 24, {
+      fill: "rgba(35, 122, 87, 0.1)",
+      stroke: "rgba(35, 122, 87, 0.18)",
+      stroke_width: 1,
+      corner_radius: 6,
+    }),
+    ...text(label, x, y, 13, GREEN),
+  ];
+}
+
+function flowCard(
+  x: number,
+  y: number,
+  width: number,
+  title: string,
+  lines: readonly string[],
+  color: string,
+): PaintInstruction[] {
+  const height = 126;
+  const instructions: PaintInstruction[] = [
+    paintRect(x, y, width, height, {
+      fill: "#ffffff",
+      stroke: "rgba(23, 32, 28, 0.12)",
+      stroke_width: 1,
+      corner_radius: 8,
+    }),
+    paintRect(x, y, width, 30, {
+      fill: "rgba(247, 248, 243, 0.95)",
+      stroke: "rgba(23, 32, 28, 0.08)",
+      stroke_width: 1,
+      corner_radius: 8,
+    }),
+    ...text(title, x + 12, y + 21, 12, color),
+  ];
+  for (const [index, line] of lines.entries()) {
+    instructions.push(...text(compactLine(line, width), x + 12, y + 54 + index * 22, 11, MUTED));
+  }
+  return instructions;
+}
+
+function flowArrow(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  color: string,
+  label: string,
+): PaintInstruction[] {
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+  const head = 9;
+  const left = angle + Math.PI * 0.82;
+  const right = angle - Math.PI * 0.82;
+  const labelX = x1 + (x2 - x1) * 0.5;
+  const labelY = y1 + (y2 - y1) * 0.5 - 7;
+
+  return [
+    paintLine(x1, y1, x2, y2, color, {
+      stroke_width: 2,
+      stroke_cap: "round",
+    }),
+    paintLine(x2, y2, x2 + Math.cos(left) * head, y2 + Math.sin(left) * head, color, {
+      stroke_width: 2,
+      stroke_cap: "round",
+    }),
+    paintLine(x2, y2, x2 + Math.cos(right) * head, y2 + Math.sin(right) * head, color, {
+      stroke_width: 2,
+      stroke_cap: "round",
+    }),
+    ...centerText(label, labelX, labelY, 10, color),
+  ];
 }
 
 function edge(
@@ -361,6 +586,13 @@ function verticalPositions(count: number, top: number, bottom: number): number[]
   return Array.from({ length: count }, (_, index) => top + (span * index) / (count - 1));
 }
 
+function gradientShape(rows: readonly (readonly number[])[] | undefined): string {
+  if (rows === undefined || rows.length === 0) {
+    return "0x0";
+  }
+  return `${rows.length}x${rows[0]?.length ?? 0}`;
+}
+
 function rawHidden(
   state: HiddenLayerModelState,
   input: readonly number[],
@@ -407,4 +639,12 @@ function fmt(value: number): string {
 
 function signed(value: number): string {
   return `${value >= 0 ? "+" : ""}${fmt(value)}`;
+}
+
+function compactLine(value: string, width: number): string {
+  const maxChars = Math.max(10, Math.floor(width / 7.2));
+  if (value.length <= maxChars) {
+    return value;
+  }
+  return `${value.slice(0, maxChars - 3)}...`;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/hidden-layer-examples.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/hidden-layer-examples.ts
@@ -43,6 +43,7 @@ export interface HiddenLayerModelState {
 }
 
 export interface HiddenLayerStepResult {
+  previousState: HiddenLayerModelState;
   state: HiddenLayerModelState;
   step: TwoLayerTrainingStep;
   loss: number;
@@ -136,6 +137,7 @@ export function trainHiddenStep(
   };
 
   return {
+    previousState: state,
     state: nextState,
     step,
     loss: hiddenLoss(example, nextState),

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -72,11 +72,15 @@ describe("training helpers", () => {
       { weight: 1.8, bias: 32, epoch: 3 },
       null,
       0.0005,
+      "mse",
+      { x: 0, y: 32 },
+      7,
     );
 
     expect(svg).toContain("<svg");
     expect(svg).toContain("<line");
     expect(svg).toContain("font-size");
+    expect(svg).toContain("gradient descent");
   });
 
   it("applies activation functions used by the lab preview", () => {
@@ -132,7 +136,8 @@ describe("training helpers", () => {
     const svg = renderHiddenNetworkSvg(
       example,
       initial,
-      example.rows[0]!.input,
+      example.rows[0]!,
+      0,
       0.42,
       null,
       example.defaultLearningRate,
@@ -141,6 +146,7 @@ describe("training helpers", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("<ellipse");
     expect(svg).toContain("<line");
+    expect(svg).toContain("parameter update");
   });
 
   it("moves downhill on XNOR and absolute value with batch updates", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.ts
@@ -16,6 +16,8 @@ export interface ModelState {
 }
 
 export interface StepResult {
+  previousState: ModelState;
+  previousLoss: number;
   state: ModelState;
   loss: number;
   mae: number;
@@ -94,6 +96,7 @@ export function trainStep(
   lossKind: LossKind,
 ): StepResult {
   const { gradientWeight, gradientBias } = gradients(points, state, lossKind);
+  const previousLoss = loss(points, state, lossKind);
   const nextState = {
     weight: state.weight - learningRate * gradientWeight,
     bias: state.bias - learningRate * gradientBias,
@@ -101,6 +104,8 @@ export function trainStep(
   };
 
   return {
+    previousState: state,
+    previousLoss,
     state: nextState,
     loss: loss(points, nextState, lossKind),
     mae: meanAbsoluteError(points, nextState),


### PR DESCRIPTION
## Summary

- expand the Paint VM network visualization into a full learning-flow trace
- show forward prediction, target comparison, error/loss calculation, gradient descent, and parameter updates for linear models
- show hidden-layer forward flow plus MSE, output deltas, gradient matrix shapes, and weight-update flow for hidden examples

## Validation

- npm test -- --run (code/programs/typescript/ml-learning-visualizer)
- npm run build (code/programs/typescript/ml-learning-visualizer)
- bash BUILD (code/programs/typescript/ml-learning-visualizer)
- ./build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/build-plan-visualizer-full-flow-main.json
- in-app browser smoke test confirmed the full-flow labels render and Step updates the flow values

## Notes

PR #1890 was merged while this follow-up was being built, so this branch is based on the latest origin/main and only contains the full-flow visualization layer.