### PR TITLE
[codex] Correct ML visualizer flow arrows

### DIFF
--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   activations, and gradient updates while training runs advance.
 - Expanded the neural graph panels into a full learning-flow trace covering
   forward prediction, error/loss calculation, gradients, and parameter updates.
+- Corrected the learning-flow arrows so forward edges point into each node and
+  loss feedback folds into a lower update loop instead of crossing the graph.
 
 ## [0.1.0] - 2026-03-25
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this package will be documented in this file.
   forward prediction, error/loss calculation, gradients, and parameter updates.
 - Corrected the learning-flow arrows so forward edges point into each node and
   loss feedback folds into a lower update loop instead of crossing the graph.
+- Fixed hidden-layer example switching so each selected example resets the
+  model state before the neural graph VM sees the new input shape.
 
 ## [0.1.0] - 2026-03-25
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this package will be documented in this file.
   loss feedback folds into a lower update loop instead of crossing the graph.
 - Fixed hidden-layer example switching so each selected example resets the
   model state before the neural graph VM sees the new input shape.
+- Added a hidden-layer depth slider for the neural examples so the same
+  dataset can be retrained with deeper feed-forward networks.
 
 ## [0.1.0] - 2026-03-25
 

--- a/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
@@ -334,6 +334,17 @@ export function HiddenLayerWorkbench() {
     setIsRunning(false);
   }
 
+  function selectExample(nextExample: HiddenLayerExample): void {
+    const initial = createInitialHiddenState(nextExample);
+    setSelectedId(nextExample.id);
+    setLearningRate(nextExample.defaultLearningRate);
+    setState(initial);
+    setHistory([hiddenHistoryPoint(nextExample, initial)]);
+    setLastStep(null);
+    setSelectedIndex(0);
+    setIsRunning(false);
+  }
+
   useEffect(() => {
     if (!isRunning) {
       return undefined;
@@ -369,7 +380,7 @@ export function HiddenLayerWorkbench() {
               className={item.id === example.id ? "lab-button lab-button--active" : "lab-button"}
               key={item.id}
               type="button"
-              onClick={() => setSelectedId(item.id)}
+              onClick={() => selectExample(item)}
             >
               <span>{item.title}</span>
               <small>{item.category}</small>

--- a/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
@@ -13,7 +13,8 @@ import {
   type HiddenLayerModelState,
   type HiddenLayerStepResult,
 } from "./hidden-layer-examples.js";
-import { predictTwoLayerWithVm } from "./neural-vm.js";
+import { gradientShape } from "./layered-network.js";
+import { predictLayeredWithVm } from "./neural-vm.js";
 import { HiddenNetworkDiagram } from "./NetworkDiagram.js";
 
 interface HiddenChartFrame {
@@ -58,6 +59,10 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+function hiddenLayerLabel(count: number): string {
+  return `${count} hidden layer${count === 1 ? "" : "s"}`;
+}
+
 function xScale(value: number, chart: HiddenChartFrame): number {
   const width = chart.width - chart.padLeft - chart.padRight;
   return chart.padLeft + ((value - chart.xMin) / (chart.xMax - chart.xMin)) * width;
@@ -92,7 +97,7 @@ function makeCurvePath(example: HiddenLayerExample, state: HiddenLayerModelState
     const x = CURVE_CHART.xMin + (index / 120) * (CURVE_CHART.xMax - CURVE_CHART.xMin);
     return x;
   });
-  const predictions = predictTwoLayerWithVm(
+  const predictions = predictLayeredWithVm(
     samples.map((x) => [x]),
     state.parameters,
     {
@@ -136,7 +141,7 @@ function makeSurfaceCells(example: HiddenLayerExample, state: HiddenLayerModelSt
     }
   }
 
-  const predictions = predictTwoLayerWithVm(inputs, state.parameters, {
+  const predictions = predictLayeredWithVm(inputs, state.parameters, {
     inputNames: example.inputLabels,
     outputNames: [example.outputLabel],
   }).predictions;
@@ -292,6 +297,7 @@ export function HiddenLayerWorkbench() {
   const [lastStep, setLastStep] = useState<HiddenLayerStepResult | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
+  const hiddenLayerCount = state.hiddenLayerCount;
 
   useEffect(() => {
     const initial = createInitialHiddenState(example);
@@ -307,6 +313,7 @@ export function HiddenLayerWorkbench() {
   const loss = useMemo(() => hiddenLoss(example, state), [example, state]);
   const mae = useMemo(() => hiddenMeanAbsoluteError(example, state), [example, state]);
   const trace = useMemo(() => traceHiddenExample(example, state, selectedIndex), [example, selectedIndex, state]);
+  const outputGradient = lastStep?.step.weightGradients[lastStep.step.weightGradients.length - 1];
 
   function record(result: HiddenLayerStepResult): void {
     setState(result.state);
@@ -327,7 +334,7 @@ export function HiddenLayerWorkbench() {
   }
 
   function reset(): void {
-    const initial = createInitialHiddenState(example);
+    const initial = createInitialHiddenState(example, hiddenLayerCount);
     setState(initial);
     setHistory([hiddenHistoryPoint(example, initial)]);
     setLastStep(null);
@@ -340,6 +347,19 @@ export function HiddenLayerWorkbench() {
     setLearningRate(nextExample.defaultLearningRate);
     setState(initial);
     setHistory([hiddenHistoryPoint(nextExample, initial)]);
+    setLastStep(null);
+    setSelectedIndex(0);
+    setIsRunning(false);
+  }
+
+  function changeHiddenLayerCount(value: number): void {
+    const nextCount = Math.max(
+      example.hiddenLayerMin,
+      Math.min(example.hiddenLayerMax, Math.round(value)),
+    );
+    const initial = createInitialHiddenState(example, nextCount);
+    setState(initial);
+    setHistory([hiddenHistoryPoint(example, initial)]);
     setLastStep(null);
     setSelectedIndex(0);
     setIsRunning(false);
@@ -396,7 +416,7 @@ export function HiddenLayerWorkbench() {
             <h2>{example.title}</h2>
             <p>{example.summary}</p>
           </div>
-          <div className="lab-chip">{example.hiddenCount} hidden</div>
+          <div className="lab-chip">{hiddenLayerCount} layers / {example.hiddenCount} neurons</div>
         </div>
 
         <section className="chart-panel chart-panel--hidden" aria-label="Hidden-layer chart">
@@ -427,16 +447,18 @@ export function HiddenLayerWorkbench() {
             <strong>{formatNumber(predictions[selectedIndex]!, 3)} / {formatNumber(example.rows[selectedIndex]!.target, 3)}</strong>
           </div>
           <div className="hidden-neuron-grid">
-            {trace.layers[0]!.neurons.map((neuron, index) => (
-              <div className="neuron-tile" key={neuron.neuron}>
-                <span>h{index + 1}</span>
-                <strong>{formatNumber(neuron.output, 3)}</strong>
-                <i style={{ width: `${clamp(neuron.output, 0, 1) * 100}%` }} />
-              </div>
-            ))}
+            {trace.layers
+              .filter((layer) => layer.layer.startsWith("hidden"))
+              .flatMap((layer, layerIndex) => layer.neurons.map((neuron, neuronIndex) => (
+                <div className="neuron-tile" key={neuron.neuron}>
+                  <span>h{layerIndex + 1}.{neuronIndex + 1}</span>
+                  <strong>{formatNumber(neuron.output, 3)}</strong>
+                  <i style={{ width: `${clamp(neuron.output, 0, 1) * 100}%` }} />
+                </div>
+              )))}
           </div>
           <div className="trace-equation">
-            <code>{example.inputLabels.join(", ")} {"->"} hidden[{example.hiddenCount}] {"->"} {example.outputLabel}</code>
+            <code>{example.inputLabels.join(", ")} {"->"} {hiddenLayerCount} x hidden[{example.hiddenCount}] {"->"} {example.outputLabel}</code>
           </div>
         </section>
 
@@ -452,6 +474,26 @@ export function HiddenLayerWorkbench() {
       </section>
 
       <aside className="controls metrics" aria-label="Hidden-layer controls">
+        <label className="field">
+          <span>Hidden layers</span>
+          <input
+            type="range"
+            min={example.hiddenLayerMin}
+            max={example.hiddenLayerMax}
+            step="1"
+            value={hiddenLayerCount}
+            onChange={(event) => changeHiddenLayerCount(Number(event.target.value))}
+          />
+          <input
+            type="number"
+            min={example.hiddenLayerMin}
+            max={example.hiddenLayerMax}
+            step="1"
+            value={hiddenLayerCount}
+            onChange={(event) => changeHiddenLayerCount(Number(event.target.value))}
+          />
+        </label>
+
         <label className="field">
           <span>Learning rate</span>
           <input
@@ -514,8 +556,9 @@ export function HiddenLayerWorkbench() {
 
         <div className="gradients">
           <span>Last gradient shape</span>
-          <code>input-hidden {lastStep === null ? "0x0" : `${lastStep.step.inputToHiddenWeightGradients.length}x${lastStep.step.inputToHiddenWeightGradients[0]!.length}`}</code>
-          <code>hidden-output {lastStep === null ? "0x0" : `${lastStep.step.hiddenToOutputWeightGradients.length}x${lastStep.step.hiddenToOutputWeightGradients[0]!.length}`}</code>
+          <code>{hiddenLayerLabel(hiddenLayerCount)}</code>
+          <code>input-hidden {gradientShape(lastStep?.step.weightGradients[0])}</code>
+          <code>hidden-output {gradientShape(outputGradient)}</code>
         </div>
 
         <div className="lesson">

--- a/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
@@ -14,6 +14,7 @@ import type {
   HiddenLayerModelState,
   HiddenLayerStepResult,
 } from "./hidden-layer-examples.js";
+import { forwardLayered } from "./layered-network.js";
 import type { LossKind, ModelState, StepResult, TrainingPoint } from "./training.js";
 
 const FONT_REF = "svg:ui-sans-serif@12";
@@ -312,8 +313,11 @@ function makeHiddenScene(
   const height = 720;
   const selectedInput = selectedRow.input;
   const selectedError = prediction - selectedRow.target;
+  const forward = forwardLayered([selectedInput], state.parameters);
+  const hiddenLayers = state.parameters.layers.slice(0, -1);
+  const outputLayer = state.parameters.layers[state.parameters.layers.length - 1]!;
   const inputYs = verticalPositions(example.inputLabels.length, 82, 232);
-  const hiddenYs = verticalPositions(example.hiddenCount, 54, 286);
+  const hiddenXs = horizontalPositions(hiddenLayers.length, 246, 594);
   const inputNodes = example.inputLabels.map((label, index): DiagramNode => ({
     id: `input-${index}`,
     label,
@@ -330,14 +334,18 @@ function makeHiddenScene(
     y: 318,
     tone: "bias",
   };
-  const hiddenNodes = Array.from({ length: example.hiddenCount }, (_, index): DiagramNode => ({
-    id: `hidden-${index}`,
-    label: `h${index + 1}`,
-    value: fmt(sigmoid(rawHidden(state, selectedInput, index))),
-    x: 392,
-    y: hiddenYs[index]!,
-    tone: "hidden",
-  }));
+  const hiddenNodeLayers = hiddenLayers.map((layer, layerIndex) => {
+    const hiddenYs = verticalPositions(layer.biases.length, 54, 286);
+    return layer.biases.map((_, unit): DiagramNode => ({
+      id: `hidden-${layerIndex}-${unit}`,
+      label: `h${layerIndex + 1}.${unit + 1}`,
+      value: fmt(forward.activationsByLayer[layerIndex]![0]![unit] ?? 0),
+      x: hiddenXs[layerIndex]!,
+      y: hiddenYs[unit]!,
+      tone: "hidden",
+    }));
+  });
+  const lastHiddenNodes = hiddenNodeLayers[hiddenNodeLayers.length - 1] ?? [];
   const output: DiagramNode = {
     id: "output",
     label: example.outputLabel,
@@ -375,27 +383,37 @@ function makeHiddenScene(
     ...text("weights update on every batch step", 630, 48, 13, MUTED),
   ];
 
-  for (const [inputIndex, inputNode] of inputNodes.entries()) {
-    for (const [hiddenIndex, hiddenNode] of hiddenNodes.entries()) {
-      const weight = state.parameters.inputToHiddenWeights[inputIndex]![hiddenIndex]!;
-      instructions.push(...edge(inputNode, hiddenNode, weight, fmt(weight), 0.34));
+  for (const [layerIndex, hiddenNodes] of hiddenNodeLayers.entries()) {
+    const layer = hiddenLayers[layerIndex]!;
+    const previousNodes = layerIndex === 0 ? inputNodes : hiddenNodeLayers[layerIndex - 1]!;
+    for (const [previousIndex, previousNode] of previousNodes.entries()) {
+      for (const [unit, hiddenNode] of hiddenNodes.entries()) {
+        const weight = layer.weights[previousIndex]![unit]!;
+        const shouldLabel = layerIndex === 0 && hiddenLayers.length <= 2 && hiddenNodes.length <= 8;
+        instructions.push(...edge(previousNode, hiddenNode, weight, shouldLabel ? fmt(weight) : "", 0.34));
+      }
     }
   }
-  for (const [hiddenIndex, hiddenNode] of hiddenNodes.entries()) {
-    const biasWeight = state.parameters.hiddenBiases[hiddenIndex]!;
-    instructions.push(...edge(bias, hiddenNode, biasWeight, fmt(biasWeight), 0.26));
+  for (const [layerIndex, hiddenNodes] of hiddenNodeLayers.entries()) {
+    const layer = hiddenLayers[layerIndex]!;
+    for (const [unit, hiddenNode] of hiddenNodes.entries()) {
+      const biasWeight = layer.biases[unit]!;
+      const shouldLabel = layerIndex === 0 && hiddenLayers.length === 1 && hiddenNodes.length <= 8;
+      instructions.push(...edge(bias, hiddenNode, biasWeight, shouldLabel ? fmt(biasWeight) : "", 0.26));
+    }
   }
-  for (const [hiddenIndex, hiddenNode] of hiddenNodes.entries()) {
-    const weight = state.parameters.hiddenToOutputWeights[hiddenIndex]![0]!;
-    instructions.push(...edge(hiddenNode, output, weight, fmt(weight), 0.42));
+  for (const [hiddenIndex, hiddenNode] of lastHiddenNodes.entries()) {
+    const weight = outputLayer.weights[hiddenIndex]![0]!;
+    const shouldLabel = hiddenLayers.length <= 2 && lastHiddenNodes.length <= 8;
+    instructions.push(...edge(hiddenNode, output, weight, shouldLabel ? fmt(weight) : "", 0.42));
   }
   instructions.push(
-    ...edge(bias, output, state.parameters.outputBiases[0] ?? 0, fmt(state.parameters.outputBiases[0] ?? 0), 0.28),
+    ...edge(bias, output, outputLayer.biases[0] ?? 0, hiddenLayers.length === 1 ? fmt(outputLayer.biases[0] ?? 0) : "", 0.28),
     ...edge(output, lossNode, selectedError, `err ${signed(selectedError)}`, 0.62),
     ...edge(target, lossNode, -1, "truth", 0.62),
     ...inputNodes.flatMap(node),
     ...node(bias),
-    ...hiddenNodes.flatMap(node),
+    ...hiddenNodeLayers.flatMap((nodes) => nodes.flatMap(node)),
     ...node(output),
     ...node(target),
     ...node(lossNode),
@@ -403,13 +421,16 @@ function makeHiddenScene(
 
   const inputShape = lastStep === null
     ? "input-hidden gradients waiting"
-    : `dL/dW ${lastStep.step.inputToHiddenWeightGradients.length}x${lastStep.step.inputToHiddenWeightGradients[0]?.length ?? 0}`;
-  const outputGrad = lastStep?.step.outputBiasGradients[0] ?? 0;
-  const outputDelta = lastStep?.step.outputDeltas[selectedIndex]?.[0] ?? 0;
-  const hiddenDeltaRow = lastStep?.step.hiddenDeltas[selectedIndex] ?? [];
-  const hiddenDelta = hiddenDeltaRow.length === 0
+    : `dL/dW1 ${gradientShape(lastStep.step.weightGradients[0])}`;
+  const lastGradient = lastStep?.step.weightGradients[lastStep.step.weightGradients.length - 1];
+  const outputGrad = lastStep?.step.biasGradients[lastStep.step.biasGradients.length - 1]?.[0] ?? 0;
+  const outputDelta = lastStep?.step.deltas[lastStep.step.deltas.length - 1]?.[selectedIndex]?.[0] ?? 0;
+  const hiddenDeltaValues = lastStep?.step.deltas
+    .slice(0, -1)
+    .flatMap((layerDeltas) => layerDeltas[selectedIndex] ?? []) ?? [];
+  const hiddenDelta = hiddenDeltaValues.length === 0
     ? 0
-    : hiddenDeltaRow.reduce((max, value) => Math.max(max, Math.abs(value)), 0);
+    : hiddenDeltaValues.reduce((max, value) => Math.max(max, Math.abs(value)), 0);
   const hiddenUpdate = lastStep === null
     ? "waiting for first step"
     : `max hidden delta ${fmt(hiddenDelta)}`;
@@ -422,7 +443,7 @@ function makeHiddenScene(
     ], BLUE),
     ...flowArrow(196, 448, 244, 448, BLUE, "forward"),
     ...flowCard(254, 402, 162, "prediction", [
-      `hidden[${example.hiddenCount}]`,
+      `${state.hiddenLayerCount} x hidden[${example.hiddenCount}]`,
       `${example.outputLabel} ${fmt(prediction)}`,
       `error ${signed(selectedError)}`,
     ], GREEN),
@@ -435,20 +456,20 @@ function makeHiddenScene(
     ...flowArrow(559, 528, 559, 550, RED, ""),
     ...flowCard(480, 550, 186, "gradient matrices", [
       inputShape,
-      `dL/dV ${gradientShape(lastStep?.step.hiddenToOutputWeightGradients)}`,
+      `dL/dW${state.parameters.layers.length} ${gradientShape(lastGradient)}`,
       `db out ${signed(-learningRate * outputGrad)}`,
     ], VIOLET),
     ...flowArrow(470, 596, 422, 596, VIOLET, "apply lr"),
     ...flowCard(254, 550, 162, "parameter update", [
       `lr ${fmt(learningRate)}`,
-      "W, V, and b move",
+      `${state.parameters.layers.length} weight matrices`,
       "next batch uses them",
     ], VIOLET),
     ...flowArrow(244, 596, 196, 596, VIOLET, "store"),
     ...flowCard(32, 550, 158, "model state", [
       `epoch ${state.epoch}`,
-      `${example.hiddenCount} hidden neurons`,
-      `row ${selectedIndex + 1}`,
+      `${state.hiddenLayerCount} hidden layers`,
+      `${example.hiddenCount} neurons/layer`,
     ], BLUE),
     ...text("new weights = old weights - learningRate * gradient", 32, 696, 13, MUTED),
     ...text("line width = |weight|", 630, 696, 12, MUTED),
@@ -562,16 +583,19 @@ function edge(
   const color = weight >= 0 ? GREEN : RED;
   const width = Math.min(7, 1.4 + Math.abs(weight) * 0.75);
   const { x1, y1, x2, y2 } = shortenSegment(from.x, from.y, to.x, to.y, 33, 36);
-  return [
+  const instructions: PaintInstruction[] = [
     ...arrowWithLabel(x1, y1, x2, y2, color, "", width),
-    paintRect(midX - 28, midY - 14, 56, 20, {
+  ];
+  if (label.length > 0) {
+    instructions.push(paintRect(midX - 28, midY - 14, 56, 20, {
       fill: "rgba(255, 255, 255, 0.86)",
       stroke: "rgba(23, 32, 28, 0.08)",
       stroke_width: 1,
       corner_radius: 5,
-    }),
-    ...centerText(label, midX, midY + 4, 10, color),
-  ];
+    }));
+    instructions.push(...centerText(label, midX, midY + 4, 10, color));
+  }
+  return instructions;
 }
 
 function shortenSegment(
@@ -644,32 +668,19 @@ function verticalPositions(count: number, top: number, bottom: number): number[]
   return Array.from({ length: count }, (_, index) => top + (span * index) / (count - 1));
 }
 
+function horizontalPositions(count: number, left: number, right: number): number[] {
+  if (count <= 1) {
+    return [(left + right) / 2];
+  }
+  const span = right - left;
+  return Array.from({ length: count }, (_, index) => left + (span * index) / (count - 1));
+}
+
 function gradientShape(rows: readonly (readonly number[])[] | undefined): string {
   if (rows === undefined || rows.length === 0) {
     return "0x0";
   }
   return `${rows.length}x${rows[0]?.length ?? 0}`;
-}
-
-function rawHidden(
-  state: HiddenLayerModelState,
-  input: readonly number[],
-  hiddenIndex: number,
-): number {
-  let raw = state.parameters.hiddenBiases[hiddenIndex] ?? 0;
-  for (const [inputIndex, value] of input.entries()) {
-    raw += value * (state.parameters.inputToHiddenWeights[inputIndex]?.[hiddenIndex] ?? 0);
-  }
-  return raw;
-}
-
-function sigmoid(value: number): number {
-  if (value >= 0) {
-    const z = Math.exp(-value);
-    return 1 / (1 + z);
-  }
-  const z = Math.exp(value);
-  return z / (1 + z);
 }
 
 function nodeFill(tone: DiagramNode["tone"]): string {

--- a/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
@@ -169,7 +169,7 @@ function makeLinearScene(
   pointCount: number,
 ): PaintScene {
   const width = 920;
-  const height = 520;
+  const height = 650;
   const runState = lastStep?.previousState ?? model;
   const prediction = samplePoint.x * runState.weight + runState.bias;
   const error = prediction - samplePoint.y;
@@ -253,34 +253,43 @@ function makeLinearScene(
     ...node(output),
     ...node(target),
     ...node(lossNode),
-    ...flowCard(36, 314, 152, "input batch", [
+    ...sectionLabel("2 folded training loop", 36, 292),
+    ...flowCard(36, 322, 152, "input batch", [
       `${pointCount} rows`,
       `sample x ${fmt(samplePoint.x)}`,
       `target ${fmt(samplePoint.y)}`,
     ], BLUE),
-    ...flowArrow(194, 360, 242, 360, BLUE, "feed"),
-    ...flowCard(252, 314, 158, "prediction", [
+    ...flowArrow(194, 368, 242, 368, BLUE, "feed"),
+    ...flowCard(252, 322, 158, "prediction", [
       `yhat=x*w+b`,
       `yhat ${fmt(prediction)}`,
       "activation linear",
     ], GREEN),
-    ...flowArrow(416, 360, 464, 360, BLUE, "compare"),
-    ...flowCard(474, 314, 162, "error + loss", [
+    ...flowArrow(416, 368, 464, 368, BLUE, "compare"),
+    ...flowCard(474, 322, 162, "error + loss", [
       `error ${signed(error)}`,
       `${lossKind.toUpperCase()} ${fmt(sampleLoss)}`,
       `batch loss ${fmt(lastStep?.previousLoss ?? sampleLoss)}`,
     ], RED),
-    ...flowArrow(642, 360, 690, 360, RED, "differentiate"),
-    ...flowCard(700, 314, 184, "gradient descent", [
+    ...flowArrow(555, 448, 555, 470, RED, ""),
+    ...flowCard(474, 470, 184, "gradient descent", [
       gradientText,
       `dw step ${signed(dw)}`,
       `db step ${signed(db)}`,
     ], VIOLET),
-    ...flowArrow(792, 308, 792, 266, RED, "backprop"),
-    ...flowArrow(700, 266, 332, 210, RED, "apply update"),
-    ...text(updateText, 36, 488, 13, MUTED),
-    ...text(biasUpdateText, 252, 488, 13, MUTED),
-    ...text("parameter update: new = old - learningRate * gradient", 474, 488, 13, MUTED),
+    ...flowArrow(464, 516, 416, 516, VIOLET, "apply lr"),
+    ...flowCard(252, 470, 158, "parameter update", [
+      updateText,
+      biasUpdateText,
+      "next run uses them",
+    ], VIOLET),
+    ...flowArrow(242, 516, 194, 516, VIOLET, "store"),
+    ...flowCard(36, 470, 152, "model state", [
+      `w ${fmt(model.weight)}`,
+      `b ${fmt(model.bias)}`,
+      `epoch ${model.epoch}`,
+    ], BLUE),
+    ...text("parameter update: new = old - learningRate * gradient", 474, 626, 13, MUTED),
     ...text(`epoch ${model.epoch}`, 36, 72, 13, MUTED),
     ...text("line width follows |weight|; green is positive, red is negative", 476, 72, 12, MUTED),
   ];
@@ -300,7 +309,7 @@ function makeHiddenScene(
   learningRate: number,
 ): PaintScene {
   const width = 920;
-  const height = 560;
+  const height = 720;
   const selectedInput = selectedRow.input;
   const selectedError = prediction - selectedRow.target;
   const inputYs = verticalPositions(example.inputLabels.length, 82, 232);
@@ -394,7 +403,7 @@ function makeHiddenScene(
 
   const inputShape = lastStep === null
     ? "input-hidden gradients waiting"
-    : `input-hidden grad ${lastStep.step.inputToHiddenWeightGradients.length}x${lastStep.step.inputToHiddenWeightGradients[0]?.length ?? 0}`;
+    : `dL/dW ${lastStep.step.inputToHiddenWeightGradients.length}x${lastStep.step.inputToHiddenWeightGradients[0]?.length ?? 0}`;
   const outputGrad = lastStep?.step.outputBiasGradients[0] ?? 0;
   const outputDelta = lastStep?.step.outputDeltas[selectedIndex]?.[0] ?? 0;
   const hiddenDeltaRow = lastStep?.step.hiddenDeltas[selectedIndex] ?? [];
@@ -405,34 +414,44 @@ function makeHiddenScene(
     ? "waiting for first step"
     : `max hidden delta ${fmt(hiddenDelta)}`;
   instructions.push(
-    ...sectionLabel("2 loss, deltas, and gradient descent", 32, 352),
-    ...flowCard(32, 382, 158, "input row", [
+    ...sectionLabel("2 folded loss + update loop", 32, 370),
+    ...flowCard(32, 402, 158, "input row", [
       selectedRow.label,
       `inputs ${selectedInput.map((value) => fmt(value)).join(", ")}`,
       `target ${fmt(selectedRow.target)}`,
     ], BLUE),
-    ...flowArrow(196, 428, 244, 428, BLUE, "forward"),
-    ...flowCard(254, 382, 162, "prediction", [
+    ...flowArrow(196, 448, 244, 448, BLUE, "forward"),
+    ...flowCard(254, 402, 162, "prediction", [
       `hidden[${example.hiddenCount}]`,
       `${example.outputLabel} ${fmt(prediction)}`,
       `error ${signed(selectedError)}`,
     ], GREEN),
-    ...flowArrow(422, 428, 470, 428, RED, "loss"),
-    ...flowCard(480, 382, 158, "mse + deltas", [
+    ...flowArrow(422, 448, 470, 448, RED, "loss"),
+    ...flowCard(480, 402, 158, "mse + deltas", [
       `row mse ${fmt(selectedError * selectedError)}`,
       `output delta ${fmt(outputDelta)}`,
       hiddenUpdate,
     ], RED),
-    ...flowArrow(644, 428, 692, 428, RED, "gradients"),
-    ...flowCard(702, 382, 186, "parameter update", [
+    ...flowArrow(559, 528, 559, 550, RED, ""),
+    ...flowCard(480, 550, 186, "gradient matrices", [
       inputShape,
-      `hidden-output ${gradientShape(lastStep?.step.hiddenToOutputWeightGradients)}`,
+      `dL/dV ${gradientShape(lastStep?.step.hiddenToOutputWeightGradients)}`,
       `db out ${signed(-learningRate * outputGrad)}`,
     ], VIOLET),
-    ...flowArrow(800, 376, 800, 330, RED, "backprop"),
-    ...flowArrow(708, 330, 430, 276, RED, "update matrices"),
-    ...text("new weights = old weights - learningRate * gradient", 32, 536, 13, MUTED),
-    ...text("line width = |weight|", 630, 536, 12, MUTED),
+    ...flowArrow(470, 596, 422, 596, VIOLET, "apply lr"),
+    ...flowCard(254, 550, 162, "parameter update", [
+      `lr ${fmt(learningRate)}`,
+      "W, V, and b move",
+      "next batch uses them",
+    ], VIOLET),
+    ...flowArrow(244, 596, 196, 596, VIOLET, "store"),
+    ...flowCard(32, 550, 158, "model state", [
+      `epoch ${state.epoch}`,
+      `${example.hiddenCount} hidden neurons`,
+      `row ${selectedIndex + 1}`,
+    ], BLUE),
+    ...text("new weights = old weights - learningRate * gradient", 32, 696, 13, MUTED),
+    ...text("line width = |weight|", 630, 696, 12, MUTED),
   );
 
   return paintScene(width, height, "#ffffff", instructions, {
@@ -490,28 +509,45 @@ function flowArrow(
   color: string,
   label: string,
 ): PaintInstruction[] {
+  return arrowWithLabel(x1, y1, x2, y2, color, label, 2);
+}
+
+function arrowWithLabel(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  color: string,
+  label: string,
+  strokeWidth: number,
+  labelOffset = 0.5,
+  labelDy = -7,
+): PaintInstruction[] {
   const angle = Math.atan2(y2 - y1, x2 - x1);
   const head = 9;
   const left = angle + Math.PI * 0.82;
   const right = angle - Math.PI * 0.82;
-  const labelX = x1 + (x2 - x1) * 0.5;
-  const labelY = y1 + (y2 - y1) * 0.5 - 7;
+  const labelX = x1 + (x2 - x1) * labelOffset;
+  const labelY = y1 + (y2 - y1) * labelOffset + labelDy;
 
-  return [
+  const instructions: PaintInstruction[] = [
     paintLine(x1, y1, x2, y2, color, {
-      stroke_width: 2,
+      stroke_width: strokeWidth,
       stroke_cap: "round",
     }),
     paintLine(x2, y2, x2 + Math.cos(left) * head, y2 + Math.sin(left) * head, color, {
-      stroke_width: 2,
+      stroke_width: strokeWidth,
       stroke_cap: "round",
     }),
     paintLine(x2, y2, x2 + Math.cos(right) * head, y2 + Math.sin(right) * head, color, {
-      stroke_width: 2,
+      stroke_width: strokeWidth,
       stroke_cap: "round",
     }),
-    ...centerText(label, labelX, labelY, 10, color),
   ];
+  if (label.length > 0) {
+    instructions.push(...centerText(label, labelX, labelY, 10, color));
+  }
+  return instructions;
 }
 
 function edge(
@@ -525,11 +561,9 @@ function edge(
   const midY = from.y + (to.y - from.y) * labelOffset;
   const color = weight >= 0 ? GREEN : RED;
   const width = Math.min(7, 1.4 + Math.abs(weight) * 0.75);
+  const { x1, y1, x2, y2 } = shortenSegment(from.x, from.y, to.x, to.y, 33, 36);
   return [
-    paintLine(from.x, from.y, to.x, to.y, color, {
-      stroke_width: width,
-      stroke_cap: "round",
-    }),
+    ...arrowWithLabel(x1, y1, x2, y2, color, "", width),
     paintRect(midX - 28, midY - 14, 56, 20, {
       fill: "rgba(255, 255, 255, 0.86)",
       stroke: "rgba(23, 32, 28, 0.08)",
@@ -538,6 +572,30 @@ function edge(
     }),
     ...centerText(label, midX, midY + 4, 10, color),
   ];
+}
+
+function shortenSegment(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  startOffset: number,
+  endOffset: number,
+): { x1: number; y1: number; x2: number; y2: number } {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const length = Math.hypot(dx, dy);
+  if (length === 0) {
+    return { x1, y1, x2, y2 };
+  }
+  const ux = dx / length;
+  const uy = dy / length;
+  return {
+    x1: x1 + ux * startOffset,
+    y1: y1 + uy * startOffset,
+    x2: x2 - ux * endOffset,
+    y2: y2 - uy * endOffset,
+  };
 }
 
 function node(nodeData: DiagramNode): PaintInstruction[] {

--- a/code/programs/typescript/ml-learning-visualizer/src/hidden-layer-examples.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/hidden-layer-examples.ts
@@ -1,13 +1,16 @@
-import {
-  createSeededParameters,
-  trainOneEpochTwoLayer,
-  traceExampleTwoLayer,
-  type ExampleTrace,
-  type MatrixData,
-  type TwoLayerParameters,
-  type TwoLayerTrainingStep,
+import type {
+  ExampleTrace,
+  MatrixData,
 } from "coding-adventures-two-layer-network/src/index";
-import { predictTwoLayerWithVm } from "./neural-vm.js";
+import {
+  createSeededLayeredParameters,
+  hiddenLayerCount,
+  trainOneEpochLayered,
+  traceExampleLayered,
+  type LayeredParameters,
+  type LayeredTrainingStep,
+} from "./layered-network.js";
+import { predictLayeredWithVm } from "./neural-vm.js";
 
 export type HiddenLayerChartKind = "curve" | "surface" | "table";
 
@@ -28,6 +31,9 @@ export interface HiddenLayerExample {
   outputLabel: string;
   rows: HiddenLayerExampleRow[];
   hiddenCount: number;
+  defaultHiddenLayerCount: number;
+  hiddenLayerMin: number;
+  hiddenLayerMax: number;
   initialScale: number;
   seed: number;
   defaultLearningRate: number;
@@ -38,14 +44,15 @@ export interface HiddenLayerExample {
 }
 
 export interface HiddenLayerModelState {
-  parameters: TwoLayerParameters;
+  parameters: LayeredParameters;
   epoch: number;
+  hiddenLayerCount: number;
 }
 
 export interface HiddenLayerStepResult {
   previousState: HiddenLayerModelState;
   state: HiddenLayerModelState;
-  step: TwoLayerTrainingStep;
+  step: LayeredTrainingStep;
   loss: number;
   mae: number;
 }
@@ -56,9 +63,24 @@ export interface HiddenLayerHistoryPoint {
   mae: number;
 }
 
-function makeExample(args: Omit<HiddenLayerExample, "learningRateMin" | "learningRateMax" | "learningRateStep">): HiddenLayerExample {
+type HiddenLayerExampleArgs =
+  Omit<
+    HiddenLayerExample,
+    | "defaultHiddenLayerCount"
+    | "hiddenLayerMin"
+    | "hiddenLayerMax"
+    | "learningRateMin"
+    | "learningRateMax"
+    | "learningRateStep"
+  >
+  & Partial<Pick<HiddenLayerExample, "defaultHiddenLayerCount" | "hiddenLayerMin" | "hiddenLayerMax">>;
+
+function makeExample(args: HiddenLayerExampleArgs): HiddenLayerExample {
   return {
     ...args,
+    defaultHiddenLayerCount: args.defaultHiddenLayerCount ?? 1,
+    hiddenLayerMin: args.hiddenLayerMin ?? 1,
+    hiddenLayerMax: args.hiddenLayerMax ?? 4,
     learningRateMin: args.defaultLearningRate / 20,
     learningRateMax: args.defaultLearningRate * 8,
     learningRateStep: args.defaultLearningRate / 20,
@@ -77,12 +99,21 @@ export function exampleTargets(example: HiddenLayerExample): MatrixData {
   return targetRows(example);
 }
 
-export function createInitialHiddenState(example: HiddenLayerExample): HiddenLayerModelState {
+export function createInitialHiddenState(
+  example: HiddenLayerExample,
+  hiddenLayers = example.defaultHiddenLayerCount,
+): HiddenLayerModelState {
+  const hiddenLayerTotal = Math.max(
+    example.hiddenLayerMin,
+    Math.min(example.hiddenLayerMax, Math.round(hiddenLayers)),
+  );
   return {
     epoch: 0,
-    parameters: createSeededParameters(
+    hiddenLayerCount: hiddenLayerTotal,
+    parameters: createSeededLayeredParameters(
       example.inputLabels.length,
       example.hiddenCount,
+      hiddenLayerTotal,
       1,
       example.seed,
       example.initialScale,
@@ -91,7 +122,7 @@ export function createInitialHiddenState(example: HiddenLayerExample): HiddenLay
 }
 
 export function predictHidden(example: HiddenLayerExample, state: HiddenLayerModelState): number[] {
-  return predictTwoLayerWithVm(exampleInputs(example), state.parameters, {
+  return predictLayeredWithVm(exampleInputs(example), state.parameters, {
     inputNames: example.inputLabels,
     outputNames: [example.outputLabel],
   }).predictions.map((row) => row[0]!);
@@ -125,7 +156,7 @@ export function trainHiddenStep(
   state: HiddenLayerModelState,
   learningRate: number,
 ): HiddenLayerStepResult {
-  const step = trainOneEpochTwoLayer(
+  const step = trainOneEpochLayered(
     exampleInputs(example),
     targetRows(example),
     state.parameters,
@@ -133,6 +164,7 @@ export function trainHiddenStep(
   );
   const nextState = {
     epoch: state.epoch + 1,
+    hiddenLayerCount: hiddenLayerCount(step.nextParameters),
     parameters: step.nextParameters,
   };
 
@@ -167,7 +199,7 @@ export function traceHiddenExample(
   rowIndex: number,
 ): ExampleTrace {
   return {
-    ...traceExampleTwoLayer(
+    ...traceExampleLayered(
       [example.rows[rowIndex]!.input],
       state.parameters,
       0,

--- a/code/programs/typescript/ml-learning-visualizer/src/layered-network.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/layered-network.ts
@@ -1,0 +1,413 @@
+import { Matrix } from "matrix/src/matrix";
+import type {
+  ActivationName,
+  ExampleTrace,
+  LayerTrace,
+  MatrixData,
+  NeuronTrace,
+} from "coding-adventures-two-layer-network/src/index";
+
+export interface LayerParameters {
+  readonly name: string;
+  readonly weights: MatrixData;
+  readonly biases: number[];
+  readonly activation: ActivationName;
+}
+
+export interface LayeredParameters {
+  readonly layers: readonly LayerParameters[];
+}
+
+export interface LayeredForwardPass {
+  readonly rawByLayer: MatrixData[];
+  readonly activationsByLayer: MatrixData[];
+  readonly predictions: MatrixData;
+}
+
+export interface LayeredTrainingStep extends LayeredForwardPass {
+  readonly errors: MatrixData;
+  readonly deltas: MatrixData[];
+  readonly weightGradients: MatrixData[];
+  readonly biasGradients: number[][];
+  readonly nextParameters: LayeredParameters;
+  readonly loss: number;
+}
+
+function cloneMatrix(rows: MatrixData): MatrixData {
+  return rows.map((row) => [...row]);
+}
+
+function cloneLayer(layer: LayerParameters): LayerParameters {
+  return {
+    name: layer.name,
+    weights: cloneMatrix(layer.weights),
+    biases: [...layer.biases],
+    activation: layer.activation,
+  };
+}
+
+function validateMatrix(name: string, rows: MatrixData): { rows: number; cols: number } {
+  if (rows.length === 0 || rows[0] === undefined || rows[0].length === 0) {
+    throw new Error(`${name} must have at least one row and one column`);
+  }
+  const cols = rows[0].length;
+  for (const row of rows) {
+    if (row.length !== cols) {
+      throw new Error(`${name} must be rectangular`);
+    }
+  }
+  return { rows: rows.length, cols };
+}
+
+function makeRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+function centered(random: () => number, scale: number): number {
+  return (random() * 2 - 1) * scale;
+}
+
+function addBiases(rows: MatrixData, biases: number[]): MatrixData {
+  return rows.map((row) => row.map((value, col) => value + biases[col]!));
+}
+
+function columnSums(rows: MatrixData): number[] {
+  const width = rows[0]?.length ?? 0;
+  const sums = Array(width).fill(0);
+  for (const row of rows) {
+    for (let col = 0; col < width; col += 1) {
+      sums[col] += row[col]!;
+    }
+  }
+  return sums;
+}
+
+function meanSquaredError(errors: MatrixData): number {
+  let total = 0;
+  let count = 0;
+  for (const row of errors) {
+    for (const error of row) {
+      total += error * error;
+      count += 1;
+    }
+  }
+  return count === 0 ? 0 : total / count;
+}
+
+function rowLoss(errors: readonly number[]): number {
+  if (errors.length === 0) {
+    return 0;
+  }
+  return errors.reduce((total, error) => total + error * error, 0) / errors.length;
+}
+
+function activateValue(value: number, activation: ActivationName): number {
+  switch (activation) {
+    case "linear":
+      return value;
+    case "sigmoid":
+      if (value >= 0) {
+        const z = Math.exp(-value);
+        return 1 / (1 + z);
+      }
+      {
+        const z = Math.exp(value);
+        return z / (1 + z);
+      }
+    case "tanh":
+      return Math.tanh(value);
+    case "relu":
+      return Math.max(0, value);
+  }
+}
+
+function activationDerivative(rawValue: number, activatedValue: number, activation: ActivationName): number {
+  switch (activation) {
+    case "linear":
+      return 1;
+    case "sigmoid":
+      return activatedValue * (1 - activatedValue);
+    case "tanh":
+      return 1 - activatedValue * activatedValue;
+    case "relu":
+      return rawValue > 0 ? 1 : 0;
+  }
+}
+
+function applyActivation(rows: MatrixData, activation: ActivationName): MatrixData {
+  return rows.map((row) => row.map((value) => activateValue(value, activation)));
+}
+
+function activationGradient(raw: MatrixData, activated: MatrixData, activation: ActivationName): MatrixData {
+  return raw.map((row, rowIndex) => row.map((value, colIndex) => (
+    activationDerivative(value, activated[rowIndex]![colIndex]!, activation)
+  )));
+}
+
+function elementwiseMultiply(left: MatrixData, right: MatrixData): MatrixData {
+  return left.map((row, rowIndex) => row.map((value, colIndex) => value * right[rowIndex]![colIndex]!));
+}
+
+function subtractScaled(matrix: MatrixData, gradients: MatrixData, learningRate: number): MatrixData {
+  return new Matrix(matrix).subtract(new Matrix(gradients).scale(learningRate)).data;
+}
+
+function subtractScaledVector(values: readonly number[], gradients: readonly number[], learningRate: number): number[] {
+  return values.map((value, index) => value - learningRate * gradients[index]!);
+}
+
+function validateLayer(layer: LayerParameters, inputCount: number, layerIndex: number): void {
+  const shape = validateMatrix(`${layer.name} weights`, layer.weights);
+  if (shape.rows !== inputCount) {
+    throw new Error(`${layer.name} weight row count must match previous layer width`);
+  }
+  if (shape.cols !== layer.biases.length) {
+    throw new Error(`${layer.name} weight columns must match bias count`);
+  }
+  if (layer.biases.length === 0) {
+    throw new Error(`${layer.name} must have at least one neuron`);
+  }
+  for (const row of layer.weights) {
+    for (const value of row) {
+      if (!Number.isFinite(value)) {
+        throw new Error(`${layer.name} weights must be finite`);
+      }
+    }
+  }
+  for (const value of layer.biases) {
+    if (!Number.isFinite(value)) {
+      throw new Error(`${layer.name} biases must be finite`);
+    }
+  }
+  if (layerIndex < 0) {
+    throw new Error("layer index must be non-negative");
+  }
+}
+
+export function createSeededLayeredParameters(
+  inputCount: number,
+  hiddenWidth: number,
+  hiddenLayerCount: number,
+  outputCount: number,
+  seed = 7,
+  scale = 1,
+): LayeredParameters {
+  if (hiddenLayerCount < 1) {
+    throw new Error("hiddenLayerCount must be at least one");
+  }
+  const random = makeRandom(seed);
+  const layers: LayerParameters[] = [];
+  let previousWidth = inputCount;
+
+  for (let layerIndex = 0; layerIndex < hiddenLayerCount; layerIndex += 1) {
+    const layerScale = hiddenLayerCount === 1 ? scale : scale / Math.sqrt(Math.max(1, previousWidth));
+    layers.push({
+      name: `hidden${layerIndex + 1}`,
+      weights: Array.from({ length: previousWidth }, () => (
+        Array.from({ length: hiddenWidth }, () => centered(random, layerScale))
+      )),
+      biases: Array.from({ length: hiddenWidth }, () => centered(random, layerScale)),
+      activation: "sigmoid",
+    });
+    previousWidth = hiddenWidth;
+  }
+
+  const outputScale = hiddenLayerCount === 1 ? scale : scale / Math.sqrt(Math.max(1, previousWidth));
+  layers.push({
+    name: "output",
+    weights: Array.from({ length: previousWidth }, () => (
+      Array.from({ length: outputCount }, () => centered(random, outputScale))
+    )),
+    biases: Array.from({ length: outputCount }, () => centered(random, outputScale)),
+    activation: "sigmoid",
+  });
+
+  return { layers };
+}
+
+export function forwardLayered(
+  inputs: MatrixData,
+  parameters: LayeredParameters,
+): LayeredForwardPass {
+  const inputShape = validateMatrix("inputs", inputs);
+  if (parameters.layers.length === 0) {
+    throw new Error("layered network must have at least one layer");
+  }
+
+  const rawByLayer: MatrixData[] = [];
+  const activationsByLayer: MatrixData[] = [];
+  let current = inputs;
+  let previousWidth = inputShape.cols;
+
+  for (const [layerIndex, layer] of parameters.layers.entries()) {
+    validateLayer(layer, previousWidth, layerIndex);
+    const raw = addBiases(new Matrix(current).dot(new Matrix(layer.weights)).data, layer.biases);
+    const activated = applyActivation(raw, layer.activation);
+    rawByLayer.push(raw);
+    activationsByLayer.push(activated);
+    current = activated;
+    previousWidth = layer.biases.length;
+  }
+
+  return {
+    rawByLayer,
+    activationsByLayer,
+    predictions: activationsByLayer[activationsByLayer.length - 1]!,
+  };
+}
+
+export function trainOneEpochLayered(
+  inputs: MatrixData,
+  targets: MatrixData,
+  parameters: LayeredParameters,
+  learningRate: number,
+): LayeredTrainingStep {
+  const inputShape = validateMatrix("inputs", inputs);
+  const targetShape = validateMatrix("targets", targets);
+  if (inputShape.rows !== targetShape.rows) {
+    throw new Error("inputs and targets must have the same number of rows");
+  }
+
+  const forward = forwardLayered(inputs, parameters);
+  const predictionShape = validateMatrix("predictions", forward.predictions);
+  if (predictionShape.cols !== targetShape.cols) {
+    throw new Error("prediction width must match target width");
+  }
+
+  const errors = new Matrix(forward.predictions).subtract(new Matrix(targets)).data;
+  const scale = 2 / (targetShape.rows * targetShape.cols);
+  const lossGradient = errors.map((row) => row.map((error) => scale * error));
+  const deltas: MatrixData[] = Array(parameters.layers.length);
+  const lastLayerIndex = parameters.layers.length - 1;
+  deltas[lastLayerIndex] = elementwiseMultiply(
+    lossGradient,
+    activationGradient(
+      forward.rawByLayer[lastLayerIndex]!,
+      forward.activationsByLayer[lastLayerIndex]!,
+      parameters.layers[lastLayerIndex]!.activation,
+    ),
+  );
+
+  for (let layerIndex = lastLayerIndex - 1; layerIndex >= 0; layerIndex -= 1) {
+    const downstreamErrors = new Matrix(deltas[layerIndex + 1]!)
+      .dot(new Matrix(parameters.layers[layerIndex + 1]!.weights).transpose())
+      .data;
+    deltas[layerIndex] = elementwiseMultiply(
+      downstreamErrors,
+      activationGradient(
+        forward.rawByLayer[layerIndex]!,
+        forward.activationsByLayer[layerIndex]!,
+        parameters.layers[layerIndex]!.activation,
+      ),
+    );
+  }
+
+  const weightGradients: MatrixData[] = [];
+  const biasGradients: number[][] = [];
+  const nextLayers = parameters.layers.map((layer, layerIndex) => {
+    const previousActivations = layerIndex === 0
+      ? inputs
+      : forward.activationsByLayer[layerIndex - 1]!;
+    const layerDeltas = deltas[layerIndex]!;
+    const weightGradient = new Matrix(previousActivations).transpose().dot(new Matrix(layerDeltas)).data;
+    const biasGradient = columnSums(layerDeltas);
+    weightGradients.push(weightGradient);
+    biasGradients.push(biasGradient);
+
+    return {
+      ...cloneLayer(layer),
+      weights: subtractScaled(layer.weights, weightGradient, learningRate),
+      biases: subtractScaledVector(layer.biases, biasGradient, learningRate),
+    };
+  });
+
+  return {
+    ...forward,
+    errors,
+    deltas,
+    weightGradients,
+    biasGradients,
+    nextParameters: { layers: nextLayers },
+    loss: meanSquaredError(errors),
+  };
+}
+
+export function traceExampleLayered(
+  inputs: MatrixData,
+  parameters: LayeredParameters,
+  exampleIndex = 0,
+  target?: number[],
+): ExampleTrace {
+  const forward = forwardLayered(inputs, parameters);
+  if (exampleIndex < 0 || exampleIndex >= inputs.length) {
+    throw new Error("exampleIndex must refer to an input row");
+  }
+  const inputRow = inputs[exampleIndex]!;
+  const predictionRow = forward.predictions[exampleIndex]!;
+  if (target !== undefined && target.length !== predictionRow.length) {
+    throw new Error("target width must match prediction width");
+  }
+
+  let trainingDeltas: MatrixData[] | undefined;
+  let error: number[] | undefined;
+  let loss: number | undefined;
+  if (target !== undefined) {
+    error = predictionRow.map((prediction, output) => prediction - target[output]!);
+    loss = rowLoss(error);
+    trainingDeltas = trainOneEpochLayered([inputRow], [target], parameters, 0).deltas;
+  }
+
+  const layers: LayerTrace[] = parameters.layers.map((layer, layerIndex) => {
+    const previousValues = layerIndex === 0
+      ? inputRow
+      : forward.activationsByLayer[layerIndex - 1]![exampleIndex]!;
+    const sourcePrefix = layerIndex === 0
+      ? "input"
+      : parameters.layers[layerIndex - 1]!.name;
+    const rawRow = forward.rawByLayer[layerIndex]![exampleIndex]!;
+    const outputRow = forward.activationsByLayer[layerIndex]![exampleIndex]!;
+    const neurons: NeuronTrace[] = outputRow.map((output, unit) => ({
+      neuron: `${layer.name}[${unit}]`,
+      incoming: previousValues.map((value, previousUnit) => {
+        const weight = layer.weights[previousUnit]![unit]!;
+        return {
+          source: `${sourcePrefix}[${previousUnit}]`,
+          value,
+          weight,
+          contribution: value * weight,
+        };
+      }),
+      bias: layer.biases[unit]!,
+      rawSum: rawRow[unit]!,
+      activation: layer.activation,
+      output,
+      delta: trainingDeltas?.[layerIndex]?.[0]?.[unit],
+    }));
+    return { layer: layer.name, neurons };
+  });
+
+  return {
+    exampleIndex,
+    inputs: [...inputRow],
+    target: target === undefined ? undefined : [...target],
+    prediction: [...predictionRow],
+    error,
+    loss,
+    layers,
+  };
+}
+
+export function hiddenLayerCount(parameters: LayeredParameters): number {
+  return Math.max(0, parameters.layers.length - 1);
+}
+
+export function gradientShape(rows: readonly (readonly number[])[] | undefined): string {
+  if (rows === undefined || rows.length === 0) {
+    return "0x0";
+  }
+  return `${rows.length}x${rows[0]?.length ?? 0}`;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/neural-vm.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/neural-vm.ts
@@ -12,6 +12,7 @@ import type {
   MatrixData,
   TwoLayerParameters,
 } from "coding-adventures-two-layer-network/src/index";
+import type { LayeredParameters } from "./layered-network.js";
 
 export interface LinearGraphParameters {
   readonly weight: number;
@@ -28,6 +29,10 @@ export interface LinearVmRun extends VmRunMetadata {
 }
 
 export interface TwoLayerVmRun extends VmRunMetadata {
+  readonly predictions: MatrixData;
+}
+
+export interface LayeredVmRun extends VmRunMetadata {
   readonly predictions: MatrixData;
 }
 
@@ -97,6 +102,60 @@ export function predictTwoLayerWithVm(
         outputNames,
       },
     ],
+  });
+  const bytecode = compileNeuralNetworkToBytecode(network);
+  const matrixPlan = compileBytecodeToMatrixPlan(bytecode);
+  const matrixInputs = Object.fromEntries(
+    inputNames.map((name, inputIndex) => [
+      name,
+      inputs.map((row) => row[inputIndex] ?? 0),
+    ]),
+  );
+  const result = runNeuralMatrixForward(matrixPlan, matrixInputs);
+  const predictions = inputs.map((_, rowIndex) => (
+    outputNames.map((name) => result.outputs[name]?.[rowIndex] ?? 0)
+  ));
+
+  return {
+    predictions,
+    bytecodeInstructionCount: bytecode.functions[0]?.instructions.length ?? 0,
+    matrixInstructionCount: matrixPlan.instructions.length,
+  };
+}
+
+export function predictLayeredWithVm(
+  inputs: MatrixData,
+  parameters: LayeredParameters,
+  options: {
+    readonly inputNames?: readonly string[];
+    readonly outputNames?: readonly string[];
+  } = {},
+): LayeredVmRun {
+  const firstLayer = parameters.layers[0];
+  const lastLayer = parameters.layers[parameters.layers.length - 1];
+  if (firstLayer === undefined || lastLayer === undefined) {
+    throw new Error("layered VM prediction requires at least one layer");
+  }
+  const inputCount = inputs[0]?.length ?? firstLayer.weights.length;
+  const outputCount = lastLayer.biases.length;
+  const inputNames = options.inputNames ?? Array.from(
+    { length: inputCount },
+    (_, index) => `input${index}`,
+  );
+  const outputNames = options.outputNames ?? Array.from(
+    { length: outputCount },
+    (_, index) => (outputCount === 1 ? "prediction" : `output${index}`),
+  );
+  const network = createFeedForwardNetwork({
+    name: "ml-learning-layered-visualizer",
+    inputNames,
+    layers: parameters.layers.map((layer, layerIndex) => ({
+      name: layer.name,
+      weights: layer.weights,
+      biases: layer.biases,
+      activation: toGraphActivation(layer.activation),
+      outputNames: layerIndex === parameters.layers.length - 1 ? outputNames : undefined,
+    })),
   });
   const bytecode = compileNeuralNetworkToBytecode(network);
   const matrixPlan = compileBytecodeToMatrixPlan(bytecode);

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { forwardTwoLayer } from "coding-adventures-two-layer-network/src/index";
 import { activate } from "./activation.js";
+import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import {
   CELSIUS_DATASET,
   fitLinearClosedForm,
@@ -147,6 +150,16 @@ describe("training helpers", () => {
     expect(svg).toContain("<ellipse");
     expect(svg).toContain("<line");
     expect(svg).toContain("parameter update");
+  });
+
+  it("renders every hidden-layer example in the workbench", () => {
+    render(React.createElement(HiddenLayerWorkbench));
+
+    for (const example of HIDDEN_LAYER_EXAMPLES) {
+      fireEvent.click(screen.getByRole("button", { name: `${example.title} ${example.category}` }));
+      expect(screen.getByRole("heading", { name: example.title })).toBeTruthy();
+      expect(screen.getByLabelText("Neuron trace")).toBeTruthy();
+    }
   });
 
   it("moves downhill on XNOR and absolute value with batch updates", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { forwardTwoLayer } from "coding-adventures-two-layer-network/src/index";
 import { activate } from "./activation.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
+import { forwardLayered } from "./layered-network.js";
 import {
   CELSIUS_DATASET,
   fitLinearClosedForm,
@@ -20,7 +20,7 @@ import {
   trainHiddenStep,
   trainHiddenSteps,
 } from "./hidden-layer-examples.js";
-import { predictLinearWithVm, predictTwoLayerWithVm } from "./neural-vm.js";
+import { predictLayeredWithVm, predictLinearWithVm } from "./neural-vm.js";
 import { renderHiddenNetworkSvg, renderLinearNetworkSvg } from "./NetworkDiagram.js";
 
 describe("training helpers", () => {
@@ -112,17 +112,28 @@ describe("training helpers", () => {
 
       expect(Number.isFinite(step.loss)).toBe(true);
       expect(step.state.epoch).toBe(1);
-      expect(step.step.inputToHiddenWeightGradients).toHaveLength(example.inputLabels.length);
-      expect(step.step.hiddenToOutputWeightGradients).toHaveLength(example.hiddenCount);
+      expect(step.step.weightGradients[0]).toHaveLength(example.inputLabels.length);
+      expect(step.step.weightGradients[step.step.weightGradients.length - 1]).toHaveLength(example.hiddenCount);
     }
+  });
+
+  it("trains a hidden-layer example with additional hidden layers", () => {
+    const example = HIDDEN_LAYER_EXAMPLES[0]!;
+    const initial = createInitialHiddenState(example, 3);
+    const step = trainHiddenStep(example, initial, example.defaultLearningRate);
+
+    expect(initial.hiddenLayerCount).toBe(3);
+    expect(initial.parameters.layers).toHaveLength(4);
+    expect(step.step.weightGradients).toHaveLength(4);
+    expect(Number.isFinite(step.loss)).toBe(true);
   });
 
   it("matches hidden-layer visualizer predictions with the shared graph VM", () => {
     const example = HIDDEN_LAYER_EXAMPLES[0]!;
     const initial = createInitialHiddenState(example);
     const inputs = example.rows.map((row) => row.input);
-    const direct = forwardTwoLayer(inputs, initial.parameters).predictions;
-    const vm = predictTwoLayerWithVm(inputs, initial.parameters, {
+    const direct = forwardLayered(inputs, initial.parameters).predictions;
+    const vm = predictLayeredWithVm(inputs, initial.parameters, {
       inputNames: example.inputLabels,
       outputNames: [example.outputLabel],
     });
@@ -160,6 +171,17 @@ describe("training helpers", () => {
       expect(screen.getByRole("heading", { name: example.title })).toBeTruthy();
       expect(screen.getByLabelText("Neuron trace")).toBeTruthy();
     }
+  });
+
+  it("lets the hidden-layer workbench increase network depth", () => {
+    render(React.createElement(HiddenLayerWorkbench));
+    const depthControls = screen.getAllByLabelText("Hidden layers");
+
+    fireEvent.change(depthControls[0]!, { target: { value: "3" } });
+    fireEvent.click(screen.getByRole("button", { name: "Step" }));
+
+    expect(screen.getAllByText("3 hidden layers").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("3 x hidden[3]").length).toBeGreaterThan(0);
   });
 
   it("moves downhill on XNOR and absolute value with batch updates", () => {


### PR DESCRIPTION
## Summary

- Make the neural graph edges directional with arrowheads that stop at node boundaries.
- Replace the long crossing feedback arrows with a folded lower training loop.
- Show loss flowing into gradients, gradients into parameter updates, and updated model state feeding the next run for both linear and hidden-layer views.
- Fix hidden-layer example switching so the workbench resets model state before the neural graph VM renders examples with different input widths.
- Add a Hidden layers slider that retrains the hidden examples with deeper feed-forward networks while still lowering forward prediction through the neural graph VM matrix path.

## Validation

- `npm test -- --run` in `code/programs/typescript/ml-learning-visualizer`
- `npm run build` in `code/programs/typescript/ml-learning-visualizer`
- `bash BUILD` in `code/programs/typescript/ml-learning-visualizer`
- `./build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/build-plan-visualizer-hidden-depth.json`
- In-app browser smoke test confirmed XNOR, Absolute Value, Piecewise Pricing, Circle Classifier, Two Moons, and Interaction Features all switch and render the folded neural graph without console errors.
- In-app browser smoke test changed the Hidden layers control to 3 and 4, stepped training, and confirmed the neural graph panel updated to the deeper network without console errors.

## Notes

The hidden-layer crash happened because changing examples briefly rendered a new example definition with the previous example's parameter matrix. The selector now resets the state, learning rate, history, selected row, and running flag in the same event as the selected example id change.

The depth slider uses a new generic layered trainer for backpropagation across multiple hidden layers. Forward prediction still goes through `createFeedForwardNetwork()` -> neural graph bytecode -> matrix plan so the visualizer keeps exercising the graph-to-matrix path.