### PR TITLE
Support ALGOL array-element for controls

### DIFF
--- a/code/grammars/algol.grammar
+++ b/code/grammars/algol.grammar
@@ -173,11 +173,11 @@ actual_params = expression { COMMA expression } ;
 
 # For loop with a list of for-elements. Elements are separated by commas.
 # Three element forms:
-#   step/until: for i := 1 step 1 until 10 do   (classic range loop)
-#   while:      for i := x while x > 0 do       (conditional advance)
-#   simple:     for i := 5 do                   (single value, executes once)
-# Multiple forms can be combined: for i := 1 step 1 until 5, 10, 20 do
-for_stmt     = "for" NAME ASSIGN for_list "do" statement ;
+#   step/until: for i := 1 step 1 until 10 do      (classic range loop)
+#   while:      for a[i] := x while x > 0 do       (conditional advance)
+#   simple:     for i := 5 do                      (single value, executes once)
+# Multiple forms can be combined: for a[1] := 1 step 1 until 5, 10, 20 do
+for_stmt     = "for" variable ASSIGN for_list "do" statement ;
 
 for_list     = for_elem { COMMA for_elem } ;
 

--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -200,11 +200,11 @@ actual_params = expression { COMMA expression } ;
 
 # For loop with a list of for-elements. Elements are separated by commas.
 # Three element forms:
-#   step/until: for i := 1 step 1 until 10 do   (classic range loop)
-#   while:      for i := x while x > 0 do       (conditional advance)
-#   simple:     for i := 5 do                   (single value, executes once)
-# Multiple forms can be combined: for i := 1 step 1 until 5, 10, 20 do
-for_stmt     = "for" NAME ASSIGN for_list "do" statement ;
+#   step/until: for i := 1 step 1 until 10 do      (classic range loop)
+#   while:      for a[i] := x while x > 0 do       (conditional advance)
+#   simple:     for i := 5 do                      (single value, executes once)
+# Multiple forms can be combined: for a[1] := 1 step 1 until 5, 10, 20 do
+for_stmt     = "for" variable ASSIGN for_list "do" statement ;
 
 for_list     = for_elem { COMMA for_elem } ;
 

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -79,6 +79,8 @@ All notable changes to this package will be documented in this file.
   to read or assign through the original argument.
 - Lowered whole-array arguments through formal procedure dispatchers by passing
   descriptor pointers to actual procedures that declare matching array formals.
+- Lowered subscripted integer and real array elements as writable `for`
+  statement control variables.
 - Lowered label, switch, and procedure arguments through formal procedure
   dispatchers by forwarding label ids and descriptor pointers.
 - Lowered report-style typed formal specifiers such as `integer array a;` and

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -224,6 +224,15 @@ class _ForElementPlan:
     check_label: str | None = None
 
 
+@dataclass(frozen=True)
+class _ForControlTarget:
+    """The lvalue controlled by an ALGOL for statement."""
+
+    type_name: str
+    reference: ResolvedReference | None = None
+    array_variable: ASTNode | None = None
+
+
 class AlgolIrCompiler:
     """Compile a typed ALGOL AST into the repository's register IR.
 
@@ -1574,13 +1583,77 @@ class AlgolIrCompiler:
                 self._compile_statement(child, scope)
         self._label(end_label)
 
-    def _compile_for(self, node: ASTNode, scope: _FrameScope) -> None:
-        loop_token = next(
-            (tok for tok in _direct_tokens(node) if tok.type_name == "NAME"), None
-        )
-        if loop_token is None:
+    def _for_control_target(self, node: ASTNode) -> _ForControlTarget:
+        variable = _first_direct_node(node, "variable")
+        name = _variable_head_name(variable)
+        if name is None:
             raise CompileError("for loop is missing its control variable")
-        loop_reference = self._require_reference(loop_token, "control")
+        if _variable_subscripts(variable):
+            access = self._require_array_access(name, "control")
+            return _ForControlTarget(
+                type_name=self.arrays[access.array_id].element_type,
+                array_variable=variable,
+            )
+        reference = self._require_reference(name, "control")
+        return _ForControlTarget(
+            type_name=reference.type_name,
+            reference=reference,
+        )
+
+    def _emit_load_for_control(
+        self, target: _ForControlTarget, scope: _FrameScope
+    ) -> int:
+        if target.reference is not None:
+            return self._emit_load_reference(target.reference, scope)
+        if target.array_variable is None:
+            raise CompileError("for loop control target is missing storage")
+        name = _variable_head_name(target.array_variable)
+        if name is None:
+            raise CompileError("array control target is missing a name")
+        access = self._require_array_access(name, "control")
+        data_pointer, byte_offset = self._compile_array_element_address(
+            target.array_variable,
+            scope,
+            role="control",
+        )
+        dst = self._fresh_reg()
+        self._emit_load_scalar_at_reg(
+            self.arrays[access.array_id].element_type,
+            dst,
+            data_pointer,
+            byte_offset,
+        )
+        return dst
+
+    def _emit_store_for_control(
+        self,
+        target: _ForControlTarget,
+        scope: _FrameScope,
+        value_reg: int,
+    ) -> None:
+        if target.reference is not None:
+            self._emit_store_reference(target.reference, scope, value_reg)
+            return
+        if target.array_variable is None:
+            raise CompileError("for loop control target is missing storage")
+        name = _variable_head_name(target.array_variable)
+        if name is None:
+            raise CompileError("array control target is missing a name")
+        access = self._require_array_access(name, "control")
+        data_pointer, byte_offset = self._compile_array_element_address(
+            target.array_variable,
+            scope,
+            role="control",
+        )
+        self._emit_store_scalar_at_reg(
+            self.arrays[access.array_id].element_type,
+            value_reg,
+            data_pointer,
+            byte_offset,
+        )
+
+    def _compile_for(self, node: ASTNode, scope: _FrameScope) -> None:
+        loop_target = self._for_control_target(node)
         body = _first_direct_node(node, "statement")
         elements = _direct_nodes(_first_direct_node(node, "for_list"), "for_elem")
         if not elements:
@@ -1590,7 +1663,7 @@ class AlgolIrCompiler:
         if len(elements) == 1:
             self._compile_single_for_element(
                 elements[0],
-                loop_reference=loop_reference,
+                loop_target=loop_target,
                 body=body,
                 scope=scope,
                 index=index,
@@ -1653,9 +1726,9 @@ class AlgolIrCompiler:
                 value = self._coerce_reg_to_type(
                     value,
                     self._expr_type(arith_nodes[0]),
-                    expected_type=loop_reference.type_name,
+                    expected_type=loop_target.type_name,
                 )
-                self._emit_store_reference(loop_reference, scope, value)
+                self._emit_store_for_control(loop_target, scope, value)
                 self._emit(
                     IrOp.LOAD_IMM,
                     IrRegister(active_element_reg),
@@ -1674,9 +1747,9 @@ class AlgolIrCompiler:
                 value = self._coerce_reg_to_type(
                     value,
                     self._expr_type(arith_nodes[0]),
-                    expected_type=loop_reference.type_name,
+                    expected_type=loop_target.type_name,
                 )
-                self._emit_store_reference(loop_reference, scope, value)
+                self._emit_store_for_control(loop_target, scope, value)
                 condition = self._compile_expr(bool_node, scope)
                 self._emit(
                     IrOp.BRANCH_Z,
@@ -1700,9 +1773,9 @@ class AlgolIrCompiler:
             start = self._coerce_reg_to_type(
                 start,
                 self._expr_type(arith_nodes[0]),
-                expected_type=loop_reference.type_name,
+                expected_type=loop_target.type_name,
             )
-            self._emit_store_reference(loop_reference, scope, start)
+            self._emit_store_for_control(loop_target, scope, start)
             self._emit(IrOp.JUMP, IrLabel(plan.check_label))
 
             self._label(plan.check_label)
@@ -1713,7 +1786,7 @@ class AlgolIrCompiler:
             self._emit_step_until_dispatch(
                 active_element_reg=active_element_reg,
                 dispatch_value=plan.dispatch_value,
-                loop_reference=loop_reference,
+                loop_target=loop_target,
                 loop_scope=scope,
                 step_value=step_value,
                 step_type=step_type,
@@ -1724,26 +1797,26 @@ class AlgolIrCompiler:
             )
 
             self._label(plan.advance_label)
-            current_value = self._emit_load_reference(loop_reference, scope)
+            current_value = self._emit_load_for_control(loop_target, scope)
             next_value = self._emit_numeric(
                 "+",
                 current_value,
-                loop_reference.type_name,
+                loop_target.type_name,
                 step_value,
                 step_type,
                 scope,
             )
             next_type = self._result_type_for_numeric_operator(
                 "+",
-                loop_reference.type_name,
+                loop_target.type_name,
                 step_type,
             )
             next_value = self._coerce_reg_to_type(
                 next_value,
                 next_type,
-                expected_type=loop_reference.type_name,
+                expected_type=loop_target.type_name,
             )
-            self._emit_store_reference(loop_reference, scope, next_value)
+            self._emit_store_for_control(loop_target, scope, next_value)
             self._emit(IrOp.JUMP, IrLabel(plan.check_label))
 
         self._label(body_label)
@@ -1762,7 +1835,7 @@ class AlgolIrCompiler:
         self,
         elem: ASTNode,
         *,
-        loop_reference: ResolvedReference,
+        loop_target: _ForControlTarget,
         body: ASTNode | None,
         scope: _FrameScope,
         index: int,
@@ -1774,9 +1847,9 @@ class AlgolIrCompiler:
             value = self._coerce_reg_to_type(
                 value,
                 self._expr_type(value_node),
-                expected_type=loop_reference.type_name,
+                expected_type=loop_target.type_name,
             )
-            self._emit_store_reference(loop_reference, scope, value)
+            self._emit_store_for_control(loop_target, scope, value)
             if body is not None:
                 self._compile_statement(body, scope)
             return
@@ -1793,9 +1866,9 @@ class AlgolIrCompiler:
             value = self._coerce_reg_to_type(
                 value,
                 self._expr_type(value_node),
-                expected_type=loop_reference.type_name,
+                expected_type=loop_target.type_name,
             )
-            self._emit_store_reference(loop_reference, scope, value)
+            self._emit_store_for_control(loop_target, scope, value)
             condition = self._compile_expr(condition_node, scope)
             self._emit(IrOp.BRANCH_Z, IrRegister(condition), IrLabel(end_label))
             if body is not None:
@@ -1815,9 +1888,9 @@ class AlgolIrCompiler:
         start = self._coerce_reg_to_type(
             start,
             self._expr_type(start_node),
-            expected_type=loop_reference.type_name,
+            expected_type=loop_target.type_name,
         )
-        self._emit_store_reference(loop_reference, scope, start)
+        self._emit_store_for_control(loop_target, scope, start)
 
         start_label = f"loop_{index}_start"
         body_label = f"loop_{index}_body"
@@ -1828,7 +1901,7 @@ class AlgolIrCompiler:
         limit_value = self._compile_expr(limit_node, scope)
         limit_type = self._expr_type(limit_node)
         self._emit_step_until_branch(
-            loop_reference=loop_reference,
+            loop_target=loop_target,
             loop_scope=scope,
             step_value=step_value,
             step_type=step_type,
@@ -1841,33 +1914,33 @@ class AlgolIrCompiler:
         self._label(body_label)
         if body is not None:
             self._compile_statement(body, scope)
-        current_value = self._emit_load_reference(loop_reference, scope)
+        current_value = self._emit_load_for_control(loop_target, scope)
         next_value = self._emit_numeric(
             "+",
             current_value,
-            loop_reference.type_name,
+            loop_target.type_name,
             step_value,
             step_type,
             scope,
         )
         next_type = self._result_type_for_numeric_operator(
             "+",
-            loop_reference.type_name,
+            loop_target.type_name,
             step_type,
         )
         next_value = self._coerce_reg_to_type(
             next_value,
             next_type,
-            expected_type=loop_reference.type_name,
+            expected_type=loop_target.type_name,
         )
-        self._emit_store_reference(loop_reference, scope, next_value)
+        self._emit_store_for_control(loop_target, scope, next_value)
         self._emit(IrOp.JUMP, IrLabel(start_label))
         self._label(end_label)
 
     def _emit_step_until_branch(
         self,
         *,
-        loop_reference: ResolvedReference,
+        loop_target: _ForControlTarget,
         loop_scope: _FrameScope,
         step_value: int,
         step_type: str,
@@ -1882,7 +1955,7 @@ class AlgolIrCompiler:
         negative_label = f"{label_prefix}_negative"
         compare_type = (
             _REAL_TYPE
-            if _REAL_TYPE in {loop_reference.type_name, limit_type}
+            if _REAL_TYPE in {loop_target.type_name, limit_type}
             else _INTEGER_TYPE
         )
         step_type_for_compare = self._result_type_for_numeric_operator(
@@ -1945,10 +2018,10 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(continue_label))
 
         self._label(positive_label)
-        loop_value = self._emit_load_reference(loop_reference, loop_scope)
+        loop_value = self._emit_load_for_control(loop_target, loop_scope)
         positive_loop = self._coerce_reg_to_type(
             loop_value,
-            loop_reference.type_name,
+            loop_target.type_name,
             expected_type=compare_type,
         )
         positive_limit = self._coerce_reg_to_type(
@@ -1979,10 +2052,10 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(continue_label))
 
         self._label(negative_label)
-        loop_value = self._emit_load_reference(loop_reference, loop_scope)
+        loop_value = self._emit_load_for_control(loop_target, loop_scope)
         negative_loop = self._coerce_reg_to_type(
             loop_value,
-            loop_reference.type_name,
+            loop_target.type_name,
             expected_type=compare_type,
         )
         negative_limit = self._coerce_reg_to_type(
@@ -2040,7 +2113,7 @@ class AlgolIrCompiler:
         *,
         active_element_reg: int,
         dispatch_value: int,
-        loop_reference: ResolvedReference,
+        loop_target: _ForControlTarget,
         loop_scope: _FrameScope,
         step_value: int,
         step_type: str,
@@ -2054,7 +2127,7 @@ class AlgolIrCompiler:
         negative_label = f"{continue_label}_{dispatch_value}_negative"
         compare_type = (
             _REAL_TYPE
-            if _REAL_TYPE in {loop_reference.type_name, limit_type}
+            if _REAL_TYPE in {loop_target.type_name, limit_type}
             else _INTEGER_TYPE
         )
         step_type_for_compare = self._result_type_for_numeric_operator(
@@ -2122,10 +2195,10 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(continue_label))
 
         self._label(positive_label)
-        loop_value = self._emit_load_reference(loop_reference, loop_scope)
+        loop_value = self._emit_load_for_control(loop_target, loop_scope)
         positive_loop = self._coerce_reg_to_type(
             loop_value,
-            loop_reference.type_name,
+            loop_target.type_name,
             expected_type=compare_type,
         )
         positive_limit = self._coerce_reg_to_type(
@@ -2161,10 +2234,10 @@ class AlgolIrCompiler:
         self._emit(IrOp.JUMP, IrLabel(continue_label))
 
         self._label(negative_label)
-        loop_value = self._emit_load_reference(loop_reference, loop_scope)
+        loop_value = self._emit_load_for_control(loop_target, loop_scope)
         negative_loop = self._coerce_reg_to_type(
             loop_value,
-            loop_reference.type_name,
+            loop_target.type_name,
             expected_type=compare_type,
         )
         negative_limit = self._coerce_reg_to_type(

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -128,6 +128,22 @@ class TestAlgolIrCompiler:
         assert IrOp.F64_CMP_LT in opcodes
         assert IrOp.F64_ADD in opcodes
 
+    def test_compiles_array_element_for_control_variable(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; integer array a[1:1]; "
+                "for a[1] := 1 step 1 until 3 do result := result + a[1] "
+                "end"
+            )
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+        assert any(label.endswith("_start") for label in labels)
+        assert any(label.endswith("_body") for label in labels)
+
     def test_compiles_own_scalar_to_static_storage(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-parser/CHANGELOG.md
+++ b/code/packages/python/algol-parser/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   operators through the shared lexer normalization layer.
 - Parsed report-style typed formal specifiers such as `integer array a;` and
   `real procedure f;` while preserving the existing split specifier spelling.
+- Parsed subscripted variables as `for` statement control variables.
 
 ## [0.1.0] — 2026-04-06
 

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -436,6 +436,17 @@ class TestForLoop:
         for_nodes = find_nodes(ast, "for_stmt")
         assert len(for_nodes) >= 1
 
+    def test_array_element_control_variable(self) -> None:
+        """For loops can use a subscripted variable as the control lvalue."""
+        ast = parse(
+            "begin integer result; integer array a[1:1]; "
+            "for a[1] := 1 step 1 until 3 do result := result + a[1] "
+            "end"
+        )
+        for_nodes = find_nodes(ast, "for_stmt")
+        assert len(for_nodes) == 1
+        assert find_nodes(for_nodes[0], "subscripts")
+
 
 # ---------------------------------------------------------------------------
 # Nested block tests

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -78,6 +78,8 @@ All notable changes to this package will be documented in this file.
   `<>` not-equal relations, and double-quoted string literals.
 - Accepted shared lexer front-door publication symbols for relations,
   exponentiation, and boolean operators.
+- Accepted subscripted integer and real array elements as `for` statement
+  control variables.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1529,14 +1529,29 @@ class AlgolTypeChecker:
                 self._check_statement(child, scope)
 
     def _check_for(self, node: ASTNode, scope: Scope) -> None:
-        loop_name = next(
-            (tok for tok in _direct_tokens(node) if tok.type_name == "NAME"), None
-        )
+        loop_variable = _first_direct_node(node, "variable")
+        loop_name = _variable_head_name(loop_variable)
         if loop_name is None:
             self._error(node, "for loop is missing its control variable")
             return
-        symbol = self._resolve_name(loop_name, scope, role="control")
-        loop_type = ERROR if symbol is None else symbol.type_name
+        if _variable_subscripts(loop_variable):
+            access = self._check_array_access(loop_variable, scope, role="control")
+            descriptor = (
+                next(
+                    (
+                        array
+                        for array in self.semantic_arrays
+                        if array.array_id == access.array_id
+                    ),
+                    None,
+                )
+                if access is not None
+                else None
+            )
+            loop_type = ERROR if descriptor is None else descriptor.element_type
+        else:
+            symbol = self._resolve_name(loop_name, scope, role="control")
+            loop_type = ERROR if symbol is None else symbol.type_name
         if loop_type != ERROR and loop_type not in {INTEGER, REAL}:
             self._error(loop_name, "for loop control variable must be integer or real")
 

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -579,6 +579,33 @@ class TestAlgolTypeChecker:
         )
         assert check_algol(ast).ok
 
+    def test_accepts_array_element_for_control_variable(self) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array a[1:1]; "
+            "for a[1] := 1 step 1 until 3 do result := result + a[1] "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert any(
+            access.role == "control" for access in result.semantic.array_accesses
+        )
+
+    def test_rejects_boolean_array_element_for_control_variable(self) -> None:
+        ast = parse_algol(
+            "begin integer result; boolean array flags[1:1]; "
+            "for flags[1] := 1 step 1 until 3 do result := result + 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "for loop control variable must be integer or real" in (
+            result.diagnostics[0].message
+        )
+
     def test_accepts_nested_block_scope(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -78,6 +78,8 @@ All notable changes to this package will be documented in this file.
   `real procedure f;` through the full WASM pipeline.
 - Executed conditional switch actuals through direct calls, forwarded switch
   formals, and formal procedure dispatch, with a golden end-to-end fixture.
+- Executed subscripted integer and real array elements as writable `for`
+  statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does
   not satisfy the nested procedure formal contract expected by the receiver.
 - Executed recursive switch self-selection entries by routing recursive

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -237,6 +237,15 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [3]
 
+    def test_array_element_for_control_variable_runs(self) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:1]; "
+            "result := 0; "
+            "for a[1] := 1 step 1 until 4 do result := result + a[1] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [10]
+
     def test_standard_numeric_builtin_functions_execute(self) -> None:
         result = compile_source(
             "begin integer result; real x, y; "


### PR DESCRIPTION
## Summary
- Parse ALGOL for-statement control variables as full variables, including subscripted array elements.
- Type-check integer/real array elements as writable for-control lvalues and reject nonnumeric array controls.
- Lower array-element controls through the existing checked array-address path for IR/WASM execution.

## Tests
- `python -m pytest tests/ -q` in `code/packages/python/algol-parser`
- `python -m pytest tests/ -q` in `code/packages/python/algol-type-checker`
- `python -m pytest tests/ -q` in `code/packages/python/algol-ir-compiler`
- `python -m pytest tests/ -q` in `code/packages/python/algol-wasm-compiler`
- `python -m ruff check ...` on touched Python files

## Security Review
- No new file, process, network, deserialization, or shell execution paths.
- Array-element controls reuse existing descriptor lookup, bounds checks, and runtime-failure guards.