### PR TITLE
feat(prolog): group bagof and setof collections

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -63,6 +63,9 @@ All notable changes to this package will be documented in this file.
 
 ### Fixed
 
+- `bagofo(...)` and `setofo(...)` now implement Prolog-style free-variable
+  grouping and `^/2` existential scopes when their goal scope is representable
+  as a callable term.
 - `iftheno(...)` and `ifthenelseo(...)` now preserve rule-local variable
   freshening when their condition and branches can be represented as callable
   terms.

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -424,7 +424,10 @@ enumerate concrete assignments.
 
 Collections are observations over a nested proof search. `findallo` succeeds
 with an empty list when the inner goal fails, while `bagofo` and `setofo` fail
-for empty collections.
+for empty collections. `bagofo` and `setofo` also group answers by free
+variables in the collection goal, matching the core Prolog behavior behind
+queries such as `bagof(Child, parent(Parent, Child), Children)`. Variables
+marked by `^/2` are treated as existential and do not create separate groups.
 
 Advanced control is intentionally honest about the solver. `cuto()` is real
 solver-level cut, not `onceo` in disguise: it prunes choicepoints made before it

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -1662,6 +1662,73 @@ def _collect_template_values(
     ]
 
 
+def _strip_existential_quantifiers(scope: Term) -> tuple[tuple[LogicVar, ...], Term]:
+    """Return variables marked existential by Prolog ``^/2`` collection syntax."""
+
+    variables: list[LogicVar] = []
+    seen: set[LogicVar] = set()
+    current = scope
+    while (
+        isinstance(current, Compound)
+        and current.functor.namespace is None
+        and current.functor.name == "^"
+        and len(current.args) == 2
+    ):
+        quantified, current = current.args
+        for variable in _term_variables_in_order(quantified):
+            if variable not in seen:
+                seen.add(variable)
+                variables.append(variable)
+    return tuple(variables), current
+
+
+def _collection_free_variables(
+    template: Term,
+    scope: Term,
+    state: State,
+) -> tuple[LogicVar, ...]:
+    """Return unquantified goal variables that group ``bagof``/``setof``."""
+
+    reified_template = _reified(template, state)
+    reified_scope = _reified(scope, state)
+    existential_vars, scoped_goal = _strip_existential_quantifiers(reified_scope)
+    template_vars = set(_term_variables_in_order(reified_template))
+    existential_set = set(existential_vars)
+    return tuple(
+        variable
+        for variable in _term_variables_in_order(scoped_goal)
+        if variable not in template_vars and variable not in existential_set
+    )
+
+
+def _group_sort_key(key: tuple[Term, ...]) -> tuple[object, ...]:
+    """Return a deterministic standard-term-order-ish key for one group."""
+
+    return tuple(_term_sort_key(item) for item in key)
+
+
+def _collect_template_groups(
+    program_value: Program,
+    state: State,
+    template: Term,
+    goal: GoalExpr,
+    scope: Term | None,
+) -> list[tuple[tuple[Term, ...], list[Term]]]:
+    """Collect template values, grouped by free variables when a scope exists."""
+
+    if scope is None:
+        values = _collect_template_values(program_value, state, template, goal)
+        return [((), values)] if values else []
+
+    free_vars = _collection_free_variables(template, scope, state)
+    groups: dict[tuple[Term, ...], list[Term]] = {}
+    for inner_state in solve_from(program_value, goal, state):
+        key = tuple(reify(variable, inner_state.substitution) for variable in free_vars)
+        value = reify(template, inner_state.substitution)
+        groups.setdefault(key, []).append(value)
+    return sorted(groups.items(), key=lambda item: _group_sort_key(item[0]))
+
+
 def _unify_collection(
     program_value: Program,
     state: State,
@@ -1673,7 +1740,65 @@ def _unify_collection(
     yield from solve_from(program_value, eq(results, logic_list(values)), state)
 
 
-def findallo(template: object, goal: object, results: object) -> GoalExpr:
+def _unify_collection_group(
+    program_value: Program,
+    state: State,
+    results: Term,
+    values: list[Term],
+    free_vars: tuple[LogicVar, ...],
+    key: tuple[Term, ...],
+) -> Iterator[State]:
+    """Unify one grouped bag/set answer from the outer collection state."""
+
+    bindings = [
+        eq(variable, value)
+        for variable, value in zip(free_vars, key, strict=True)
+    ]
+    yield from solve_from(
+        program_value,
+        conj(*bindings, eq(results, logic_list(values))),
+        state,
+    )
+
+
+def _unify_grouped_collection(
+    program_value: Program,
+    state: State,
+    template: Term,
+    results: Term,
+    groups: list[tuple[tuple[Term, ...], list[Term]]],
+    scope: Term | None,
+    *,
+    unique: bool,
+) -> Iterator[State]:
+    """Unify bag/set groups, binding grouping variables per outer answer."""
+
+    if not groups:
+        return
+    free_vars = (
+        ()
+        if scope is None
+        else _collection_free_variables(template, scope, state)
+    )
+    for key, values in groups:
+        group_values = _unique_sorted_terms(values) if unique else values
+        yield from _unify_collection_group(
+            program_value,
+            state,
+            results,
+            group_values,
+            free_vars,
+            key,
+        )
+
+
+def findallo(
+    template: object,
+    goal: object,
+    results: object,
+    *,
+    scope: Term | None = None,
+) -> GoalExpr:
     """Collect every solution of `goal` into `results`, preserving proof order."""
 
     called_goal = _as_goal(goal)
@@ -1688,7 +1813,10 @@ def findallo(template: object, goal: object, results: object) -> GoalExpr:
         ) -> Iterator[State]:
             template_term, called_goal_term, results_term = args
             try:
-                reified_goal = goal_from_term(_reified(called_goal_term, state))
+                _, scoped_goal = _strip_existential_quantifiers(
+                    _reified(called_goal_term, state),
+                )
+                reified_goal = goal_from_term(scoped_goal)
             except TypeError:
                 return
             values = _collect_template_values(
@@ -1714,11 +1842,18 @@ def findallo(template: object, goal: object, results: object) -> GoalExpr:
     return native_goal(run, template, results)
 
 
-def bagofo(template: object, goal: object, results: object) -> GoalExpr:
-    """Collect a non-empty proof-order bag of solutions."""
+def bagofo(
+    template: object,
+    goal: object,
+    results: object,
+    *,
+    scope: Term | None = None,
+) -> GoalExpr:
+    """Collect a non-empty proof-order bag, grouped by free variables."""
 
     called_goal = _as_goal(goal)
     goal_term = _goal_term_or_none(called_goal)
+    goal_scope = goal_term if scope is None else scope
 
     if goal_term is not None:
 
@@ -1729,86 +1864,117 @@ def bagofo(template: object, goal: object, results: object) -> GoalExpr:
         ) -> Iterator[State]:
             template_term, called_goal_term, results_term = args
             try:
-                reified_goal = goal_from_term(_reified(called_goal_term, state))
+                _, scoped_goal = _strip_existential_quantifiers(
+                    _reified(called_goal_term, state),
+                )
+                reified_goal = goal_from_term(scoped_goal)
             except TypeError:
                 return
-            values = _collect_template_values(
+            groups = _collect_template_groups(
                 program_value,
                 state,
                 template_term,
                 reified_goal,
+                goal_scope,
             )
-            if not values:
-                return
-            yield from _unify_collection(program_value, state, results_term, values)
-
-        return native_goal(run_terms, template, goal_term, results)
-
-    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
-        template_term, results_term = args
-        values = _collect_template_values(
-            program_value,
-            state,
-            template_term,
-            called_goal,
-        )
-        if not values:
-            return
-        yield from _unify_collection(program_value, state, results_term, values)
-
-    return native_goal(run, template, results)
-
-
-def setofo(template: object, goal: object, results: object) -> GoalExpr:
-    """Collect a non-empty sorted set of solutions."""
-
-    called_goal = _as_goal(goal)
-    goal_term = _goal_term_or_none(called_goal)
-
-    if goal_term is not None:
-
-        def run_terms(
-            program_value: Program,
-            state: State,
-            args: NativeArgs,
-        ) -> Iterator[State]:
-            template_term, called_goal_term, results_term = args
-            try:
-                reified_goal = goal_from_term(_reified(called_goal_term, state))
-            except TypeError:
-                return
-            values = _collect_template_values(
+            yield from _unify_grouped_collection(
                 program_value,
                 state,
                 template_term,
-                reified_goal,
-            )
-            if not values:
-                return
-            yield from _unify_collection(
-                program_value,
-                state,
                 results_term,
-                _unique_sorted_terms(values),
+                groups,
+                goal_scope,
+                unique=False,
             )
 
         return native_goal(run_terms, template, goal_term, results)
 
     def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
         template_term, results_term = args
-        values = _collect_template_values(
+        groups = _collect_template_groups(
             program_value,
             state,
             template_term,
             called_goal,
+            goal_scope,
         )
-        if not values:
-            return
-        yield from _unify_collection(
+        yield from _unify_grouped_collection(
             program_value,
             state,
+            template_term,
             results_term,
-            _unique_sorted_terms(values),
+            groups,
+            goal_scope,
+            unique=False,
+        )
+
+    return native_goal(run, template, results)
+
+
+def setofo(
+    template: object,
+    goal: object,
+    results: object,
+    *,
+    scope: Term | None = None,
+) -> GoalExpr:
+    """Collect a non-empty sorted set, grouped by free variables."""
+
+    called_goal = _as_goal(goal)
+    goal_term = _goal_term_or_none(called_goal)
+    goal_scope = goal_term if scope is None else scope
+
+    if goal_term is not None:
+
+        def run_terms(
+            program_value: Program,
+            state: State,
+            args: NativeArgs,
+        ) -> Iterator[State]:
+            template_term, called_goal_term, results_term = args
+            try:
+                _, scoped_goal = _strip_existential_quantifiers(
+                    _reified(called_goal_term, state),
+                )
+                reified_goal = goal_from_term(scoped_goal)
+            except TypeError:
+                return
+            groups = _collect_template_groups(
+                program_value,
+                state,
+                template_term,
+                reified_goal,
+                goal_scope,
+            )
+            yield from _unify_grouped_collection(
+                program_value,
+                state,
+                template_term,
+                results_term,
+                groups,
+                goal_scope,
+                unique=True,
+            )
+
+        return native_goal(run_terms, template, goal_term, results)
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        template_term, results_term = args
+        groups = _collect_template_groups(
+            program_value,
+            state,
+            template_term,
+            called_goal,
+            goal_scope,
+        )
+        yield from _unify_grouped_collection(
+            program_value,
+            state,
+            template_term,
+            results_term,
+            groups,
+            goal_scope,
+            unique=True,
         )
 
     return native_goal(run, template, results)

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -409,6 +409,26 @@ class TestCollectionBuiltins:
         ) == [logic_list(["tea", "tea"])]
         assert solve_all(program(), results, bagofo(item, fail(), results)) == []
 
+    def test_bagofo_groups_by_free_goal_variables(self) -> None:
+        parent = relation("parent", 2)
+        parent_name = var("Parent")
+        child = var("Child")
+        children = var("Children")
+        family = program(
+            fact(parent("homer", "bart")),
+            fact(parent("homer", "lisa")),
+            fact(parent("marge", "maggie")),
+        )
+
+        assert solve_all(
+            family,
+            (parent_name, children),
+            bagofo(child, parent(parent_name, child), children),
+        ) == [
+            (atom("homer"), logic_list(["bart", "lisa"])),
+            (atom("marge"), logic_list(["maggie"])),
+        ]
+
     def test_setofo_removes_duplicates_and_sorts_terms(self) -> None:
         item = var("Item")
         results = var("Results")
@@ -428,6 +448,27 @@ class TestCollectionBuiltins:
             ),
         ) == [logic_list([2, "apple", "pear"])]
         assert solve_all(program(), results, setofo(item, fail(), results)) == []
+
+    def test_setofo_groups_and_sorts_each_group(self) -> None:
+        score = relation("score", 2)
+        player = var("Player")
+        value = var("Value")
+        scores = var("Scores")
+        scoreboard = program(
+            fact(score("homer", 2)),
+            fact(score("homer", 1)),
+            fact(score("homer", 2)),
+            fact(score("marge", 3)),
+        )
+
+        assert solve_all(
+            scoreboard,
+            (player, scores),
+            setofo(value, score(player, value), scores),
+        ) == [
+            (atom("homer"), logic_list([1, 2])),
+            (atom("marge"), logic_list([3])),
+        ]
 
     def test_collectors_compose_with_arithmetic_predicates(self) -> None:
         raw = var("Raw")

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -68,6 +68,8 @@
   finite unification goals
 - adapt Prolog `term_hash/2` and `term_hash/4` into deterministic structural
   hash goals
+- preserve raw collection goal scopes for `bagof/3` and `setof/3`, enabling
+  source-level free-variable grouping and `^/2` existential quantification
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -44,6 +44,8 @@ It keeps parsing side-effect free, then exposes helpers to:
 - rewrite explicit `module:goal` qualification during linking, including common
   meta-goal forms like `call/1..8`, apply-family closures, `once/1`, `not/1`,
   `\\+/1`, and `phrase/2,3`
+- preserve raw `bagof/3` and `setof/3` goal scopes so the runtime can group by
+  free variables and honor `^/2` existential quantifiers
 - adapt Prolog control constructs such as `->/2` and
   `(If -> Then ; Else)` into executable builtin goals
 - adapt common list predicates such as `member/2`, `append/3`, `select/3`,

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -371,11 +371,26 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
     if name in {"not", "\\+"} and goal.relation.arity == 1:
         return noto(_adapt_callable_goal(args[0]))
     if name == "findall" and goal.relation.arity == 3:
-        return findallo(args[0], _adapt_callable_goal(args[1]), args[2])
+        return findallo(
+            args[0],
+            _adapt_collection_goal(args[1]),
+            args[2],
+            scope=args[1],
+        )
     if name == "bagof" and goal.relation.arity == 3:
-        return bagofo(args[0], _adapt_callable_goal(args[1]), args[2])
+        return bagofo(
+            args[0],
+            _adapt_collection_goal(args[1]),
+            args[2],
+            scope=args[1],
+        )
     if name == "setof" and goal.relation.arity == 3:
-        return setofo(args[0], _adapt_callable_goal(args[1]), args[2])
+        return setofo(
+            args[0],
+            _adapt_collection_goal(args[1]),
+            args[2],
+            scope=args[1],
+        )
     if name == "forall" and goal.relation.arity == 2:
         return forallo(_adapt_callable_goal(args[0]), _adapt_callable_goal(args[1]))
     if name == "labeling" and goal.relation.arity == 2:
@@ -969,6 +984,24 @@ def _adapt_callable_goal(term_value: Term) -> GoalExpr:
         return adapt_prolog_goal(goal_from_term(term_value))
     except TypeError:
         return calltermo(term_value)
+
+
+def _adapt_collection_goal(term_value: Term) -> GoalExpr:
+    """Adapt the executable side of a collector goal, stripping ``^/2`` scopes."""
+
+    return _adapt_callable_goal(_strip_collection_existentials(term_value))
+
+
+def _strip_collection_existentials(term_value: Term) -> Term:
+    current = term_value
+    while (
+        isinstance(current, Compound)
+        and current.functor.namespace is None
+        and current.functor.name == "^"
+        and len(current.args) == 2
+    ):
+        current = current.args[1]
+    return current
 
 
 def _extend_callable_term(

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -19,6 +19,7 @@ from logic_engine import (
     conj,
     disj,
     eq,
+    fact,
     fresh,
     logic_list,
     num,
@@ -1117,6 +1118,36 @@ class TestPrologGoalAdapter:
         assert isinstance(adapted, ConjExpr)
         assert isinstance(adapted.goals[1], DisjExpr)
         assert isinstance(adapted.goals[2], FreshExpr)
+
+    def test_adapt_prolog_goal_preserves_collection_grouping_scope(self) -> None:
+        parent = relation("parent", 2)
+        family = program(
+            fact(parent("homer", "bart")),
+            fact(parent("homer", "lisa")),
+            fact(parent("marge", "maggie")),
+        )
+        grouped = parse_swi_query(
+            "?- bagof(Child, parent(Parent, Child), Children).",
+        )
+        existential = parse_swi_query(
+            "?- bagof(Child, Parent^parent(Parent, Child), Children).",
+        )
+
+        assert solve_all(
+            family,
+            (grouped.variables["Parent"], grouped.variables["Children"]),
+            adapt_prolog_goal(grouped.goal),
+        ) == [
+            (atom("homer"), logic_list(["bart", "lisa"])),
+            (atom("marge"), logic_list(["maggie"])),
+        ]
+        assert solve_all(
+            family,
+            existential.variables["Children"],
+            adapt_prolog_goal(existential.goal),
+        ) == [
+            logic_list(["bart", "lisa", "maggie"]),
+        ]
 
     def test_adapt_prolog_goal_rewrites_if_then_else_control(self) -> None:
         parsed = parse_swi_query(

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -73,6 +73,8 @@
   for explicit finite unification.
 - Run Prolog `term_hash/2` and `term_hash/4` through the VM path for
   deterministic structural term hashes.
+- Run grouped `bagof/3` and `setof/3` through the VM path, including `^/2`
+  existential scopes inside collection goals.
 
 ## 0.1.0
 

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -161,6 +161,8 @@ The package includes end-to-end stress tests for:
   puzzles
 - CLP(FD) labeling options such as descending value order
 - collection predicates such as `findall/3`, `bagof/3`, and `setof/3`
+- Prolog-style `bagof/3` and `setof/3` grouping by free variables, including
+  `^/2` existential scopes
 - common list predicates such as `member/2`, `append/3`, `length/2`,
   `sort/2`, `msort/2`, `nth0/3`, `nth1/3`, `nth0/4`, and `nth1/4`
 - dynamic predicates seeded by initialization directives

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -547,6 +547,49 @@ class TestPrologVMStress:
         ]
         assert run_compiled_prolog_query(failure) == []
 
+    def test_grouped_bagof_setof_and_existentials_run_through_vm(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            parent(homer, bart).
+            parent(homer, lisa).
+            parent(marge, maggie).
+            score(homer, 2).
+            score(homer, 1).
+            score(homer, 2).
+            score(marge, 3).
+
+            ?- bagof(Child, parent(Parent, Child), Children),
+               setof(Score, score(Parent, Score), Scores),
+               bagof(AnyChild, AnyParent^parent(AnyParent, AnyChild), AllChildren).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        rows = [answer.as_dict() for answer in answers]
+        assert [
+            {
+                "Parent": row["Parent"],
+                "Children": row["Children"],
+                "Scores": row["Scores"],
+                "AllChildren": row["AllChildren"],
+            }
+            for row in rows
+        ] == [
+            {
+                "Parent": atom("homer"),
+                "Children": logic_list(["bart", "lisa"]),
+                "Scores": logic_list([1, 2]),
+                "AllChildren": logic_list(["bart", "lisa", "maggie"]),
+            },
+            {
+                "Parent": atom("marge"),
+                "Children": logic_list(["maggie"]),
+                "Scores": logic_list([3]),
+                "AllChildren": logic_list(["bart", "lisa", "maggie"]),
+            },
+        ]
+
     def test_higher_order_list_predicates_run_through_vm(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR62-prolog-grouped-collections.md
+++ b/code/specs/PR62-prolog-grouped-collections.md
@@ -1,0 +1,62 @@
+# PR62: Prolog Grouped Collections
+
+## Goal
+
+Move `bagof/3` and `setof/3` from simple collection helpers to Prolog-style
+grouped collectors on the Logic VM path.
+
+Real Prolog programs rely on the distinction between:
+
+- collecting all answers with `findall/3`
+- collecting one answer list per free-variable group with `bagof/3`
+- collecting one sorted unique answer list per free-variable group with
+  `setof/3`
+
+## Scope
+
+This batch updates:
+
+```text
+logic-builtins
+prolog-loader
+prolog-vm-compiler
+```
+
+## Semantics
+
+`bagof(Template, Goal, Bag)` now:
+
+- runs `Goal` as a nested proof search
+- finds variables that occur in `Goal` but not in `Template`
+- treats those free variables as grouping keys
+- yields one outer solution per group
+- binds each grouping variable to its group key
+- preserves duplicate template values and proof order inside each bag
+
+`setof(Template, Goal, Set)` uses the same grouping rules, then deduplicates
+and sorts each group's template values by the runtime's deterministic term
+ordering.
+
+`Var^Goal` scopes inside `bagof/3` and `setof/3` mark variables existential.
+Existential variables participate in the nested proof search but do not create
+separate groups.
+
+`findall/3` remains the all-solutions collector and does not group.
+
+## Loader Contract
+
+The loader keeps both views of a collection goal:
+
+- the adapted executable goal, so source builtins like `member/2` still run
+  through the existing builtin adapter
+- the raw goal scope, so the collector can inspect source variables and `^/2`
+  quantifiers
+
+## Verification
+
+- `logic-builtins` covers grouped `bagofo` and grouped sorted `setofo`.
+- `prolog-loader` proves parsed `bagof/3` keeps grouping scope and honors
+  `^/2` existential quantification.
+- `prolog-vm-compiler` runs grouped `bagof/3`, grouped `setof/3`, and
+  existential collection end to end through SWI-style source, loader
+  adaptation, compilation, and VM execution.


### PR DESCRIPTION
## Summary
- add Prolog-style free-variable grouping for `bagofo`/`setofo`
- preserve raw `bagof/3` and `setof/3` goal scopes in the loader so `^/2` existential quantifiers work through source adaptation
- add PR62 docs plus end-to-end VM stress coverage for grouped bags, grouped sets, and existential collection

## Verification
- `./.venv/bin/ruff check . --fix` in `logic-builtins`
- `./.venv/bin/ruff check . --fix` in `prolog-loader`
- `./.venv/bin/ruff check . --fix` in `prolog-vm-compiler`
- `bash BUILD` in `logic-builtins`
- `bash BUILD` in `prolog-loader`
- `bash BUILD` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-grouped-collections-build-plan.json`