### PR TITLE
Support explicit empty ALGOL procedure calls

### DIFF
--- a/code/grammars/algol.grammar
+++ b/code/grammars/algol.grammar
@@ -100,7 +100,9 @@ switch_list  = desig_expr { COMMA desig_expr } ;
 procedure_decl = [ type ] "procedure" NAME [ formal_params ] SEMICOLON
                  [ value_part ] { spec_part } proc_body ;
 
-formal_params = LPAREN ident_list RPAREN ;
+# Empty parentheses are accepted as a compatibility spelling for parameterless
+# procedures; the report-style spelling omits formal_params entirely.
+formal_params = LPAREN [ ident_list ] RPAREN ;
 
 # The VALUE declaration opts specific parameters into call-by-value semantics.
 # All parameters not listed here are call-by-name: the argument expression is
@@ -166,8 +168,8 @@ left_part    = variable ASSIGN ;
 goto_stmt    = "goto" desig_expr ;
 
 # Procedure call as a statement (return value, if any, is discarded).
-# Calls with no arguments omit the parentheses entirely.
-proc_stmt    = NAME [ LPAREN actual_params RPAREN ] ;
+# No-argument calls may use report-style bare names or explicit empty parens.
+proc_stmt    = NAME [ LPAREN [ actual_params ] RPAREN ] ;
 
 actual_params = expression { COMMA expression } ;
 
@@ -318,7 +320,7 @@ variable     = NAME [ LBRACKET subscripts RBRACKET ] ;
 
 subscripts   = arith_expr { COMMA arith_expr } ;
 
-# A procedure call with arguments. The no-argument form (proc_stmt with no parens)
-# is handled in the statement rules. Here we require parentheses — this form
-# is used when a procedure call appears inside an expression.
-proc_call    = NAME LPAREN actual_params RPAREN ;
+# A procedure call expression. No-argument calls may be written with empty
+# parentheses; bare no-argument typed procedure expressions are handled by
+# semantic analysis when a NAME resolves to a typed procedure.
+proc_call    = NAME LPAREN [ actual_params ] RPAREN ;

--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -113,7 +113,9 @@ switch_list  = desig_expr { COMMA desig_expr } ;
 procedure_decl = [ type ] "procedure" NAME [ formal_params ] SEMICOLON
                  [ value_part ] { spec_part } proc_body ;
 
-formal_params = LPAREN ident_list RPAREN ;
+# Empty parentheses are accepted as a compatibility spelling for parameterless
+# procedures; the report-style spelling omits formal_params entirely.
+formal_params = LPAREN [ ident_list ] RPAREN ;
 
 # The VALUE declaration opts specific parameters into call-by-value semantics.
 # All parameters not listed here are call-by-name: the argument expression is
@@ -193,8 +195,8 @@ goto_stmt    = "goto" desig_expr
              | "go" "to" desig_expr ;
 
 # Procedure call as a statement (return value, if any, is discarded).
-# Calls with no arguments omit the parentheses entirely.
-proc_stmt    = NAME [ LPAREN actual_params RPAREN ] ;
+# No-argument calls may use report-style bare names or explicit empty parens.
+proc_stmt    = NAME [ LPAREN [ actual_params ] RPAREN ] ;
 
 actual_params = expression { COMMA expression } ;
 
@@ -348,7 +350,7 @@ variable     = NAME [ LBRACKET subscripts RBRACKET ] ;
 
 subscripts   = arith_expr { COMMA arith_expr } ;
 
-# A procedure call with arguments. The no-argument form (proc_stmt with no parens)
-# is handled in the statement rules. Here we require parentheses — this form
-# is used when a procedure call appears inside an expression.
-proc_call    = NAME LPAREN actual_params RPAREN ;
+# A procedure call expression. No-argument calls may be written with empty
+# parentheses; bare no-argument typed procedure expressions are handled by
+# semantic analysis when a NAME resolves to a typed procedure.
+proc_call    = NAME LPAREN [ actual_params ] RPAREN ;

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -17,10 +17,11 @@ are allocated from the module frame stack, and typed procedures return through
 their procedure-name result slot. Integer and boolean procedure results flow
 through `v1`; real procedure results flow through the WASM backend's dedicated
 f64 result register, `v31`.
-Parameterless typed procedures can also be used by bare name in expression
-positions, following ALGOL's omitted-parentheses call syntax; read-only by-name
-actuals of that form lower through eval thunks so each formal read re-runs the
-procedure.
+Parameterless procedures may be declared and called with explicit empty
+parentheses, and typed procedures can still be used by bare name in expression
+positions, following ALGOL's
+omitted-parentheses call syntax; read-only by-name actuals of that form lower
+through eval thunks so each formal read re-runs the procedure.
 
 Integer arrays lower to frame-stored descriptors backed by a separate bounded
 ALGOL heap segment. The compiler evaluates integer lower/upper bounds once at

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1450,6 +1450,44 @@ class TestAlgolIrCompiler:
         assert calls[0].operands[0].name.startswith("_fn_algol_")
         assert result.procedure_signatures[calls[0].operands[0].name].param_count == 2
 
+    def test_compiles_explicit_empty_no_argument_typed_procedure_call(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer procedure seven(); begin seven := 7 end; "
+                "result := seven() "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert calls[0].operands[0].name.startswith("_fn_algol_")
+        assert result.procedure_signatures[calls[0].operands[0].name].param_count == 2
+
+    def test_compiles_explicit_empty_no_argument_statement_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure mark(); begin result := 9 end; "
+                "mark() "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert calls[0].operands[0].name.startswith("_fn_algol_")
+        assert result.procedure_signatures[calls[0].operands[0].name].param_count == 2
+
     def test_compiles_boolean_value_procedure_call(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-parser/README.md
+++ b/code/packages/python/algol-parser/README.md
@@ -99,6 +99,10 @@ The parser covers the complete ALGOL 60 grammar:
 | Designational | `desig_expr`, `simple_desig` |
 | Variables | `variable`, `subscripts`, `proc_call`, `ident_list` |
 
+Procedure declarations and calls accept the report-style omitted-parentheses
+form for parameterless procedures as well as explicit empty parentheses, so
+both `procedure p; p` and `procedure p(); p()` parse to zero-argument shapes.
+
 ## Development
 
 ```bash

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -740,10 +740,27 @@ class TestProcedureCall:
 
     def test_procedure_call_no_args(self) -> None:
         """Procedure call with no arguments (no parentheses)."""
-        # In a real ALGOL program, 'halt' would be a declared procedure.
-        # For parser testing, we just verify it parses as proc_stmt.
-        ast = parse("begin integer x; x := 1 end")
+        ast = parse("begin procedure halt; begin end; halt end")
         assert ast.rule_name == "program"
+        assert find_nodes(ast, "proc_stmt")
+
+    def test_procedure_call_explicit_empty_args(self) -> None:
+        """No-argument statement calls also accept explicit empty parens."""
+        ast = parse("begin procedure halt(); begin end; halt() end")
+        proc_nodes = find_nodes(ast, "proc_stmt")
+
+        assert ast.rule_name == "program"
+        assert len(proc_nodes) == 1
+        assert not find_nodes(proc_nodes[0], "actual_params")
+
+    def test_parameterless_procedure_declaration_explicit_empty_params(self) -> None:
+        """Parameterless declarations also accept explicit empty parens."""
+        ast = parse("begin procedure halt(); begin end; halt end")
+
+        assert ast.rule_name == "program"
+        formal_params = find_nodes(ast, "formal_params")
+        assert len(formal_params) == 1
+        assert not find_nodes(formal_params[0], "ident_list")
 
     def test_procedure_call_with_args(self) -> None:
         """Procedure call with arguments in parentheses."""
@@ -766,6 +783,20 @@ class TestProcedureCall:
             "begin integer n; output(n + 1) end"
         )
         assert ast.rule_name == "program"
+
+    def test_no_argument_procedure_call_expression(self) -> None:
+        """Typed procedure calls can use explicit empty parens in expressions."""
+        ast = parse(
+            "begin integer result; "
+            "integer procedure seven(); begin seven := 7 end; "
+            "result := seven() "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        proc_calls = find_nodes(ast, "proc_call")
+        assert len(proc_calls) == 1
+        assert not find_nodes(proc_calls[0], "actual_params")
 
     def test_procedure_call_in_relation_left_operand(self) -> None:
         """Procedure calls remain calls inside arithmetic relation operands."""

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -34,9 +34,10 @@ carrying the static-link delta needed by code generation. Builtin output calls
 and standard numeric functions are treated as read-only by the write analysis,
 so formals that are only printed or inspected can still accept expression
 actuals.
-Bare no-argument typed procedure names used in expressions are resolved as
-procedure calls, matching ALGOL's omitted-parentheses call syntax, while
-procedure result variables inside their own bodies still resolve as storage.
+No-argument procedure declarations and typed procedure expressions may use
+either explicit empty parentheses or bare procedure names, matching ALGOL's
+omitted-parentheses call syntax, while procedure result variables inside their
+own bodies still resolve as storage.
 Integer array declarations receive descriptor slots in their declaring frame,
 dimension metadata for lower/upper bound expressions, and resolved read/write
 accesses that preserve the static-link delta and subscript count needed by the

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -824,6 +824,27 @@ class TestAlgolTypeChecker:
             for reference in result.semantic.references
         )
 
+    def test_accepts_explicit_empty_no_argument_typed_procedure_expression(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure seven(); begin seven := 7 end; "
+            "result := seven() "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        call = next(
+            call
+            for call in result.semantic.procedure_calls
+            if call.name == "seven" and call.role == "expression"
+        )
+        assert call.argument_count == 0
+        assert call.return_type == "integer"
+
     def test_rejects_bare_typed_procedure_expression_with_required_argument(
         self,
     ) -> None:
@@ -876,6 +897,23 @@ class TestAlgolTypeChecker:
         assert result.ok
         assert result.semantic is not None
         call = result.semantic.procedure_calls[0]
+        assert call.role == "statement"
+        assert call.return_type is None
+
+    def test_accepts_explicit_empty_void_procedure_statement_call(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure mark(); begin result := 6 end; "
+            "mark() "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        call = result.semantic.procedure_calls[0]
+        assert call.name == "mark"
+        assert call.argument_count == 0
         assert call.role == "statement"
         assert call.return_type is None
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -35,8 +35,8 @@ the current lane already supports a substantial ALGOL 60 surface:
   procedure calls that forward scalar, whole-array, label, switch, or procedure
   arguments while validating nested procedure-formal contracts
 - label, switch, and procedure formals in value or by-name mode
-- bare no-argument typed procedure names as expression calls, matching ALGOL's
-  omitted-parentheses call syntax for parameterless procedures
+- explicit empty and bare no-argument procedure declarations/calls, matching
+  ALGOL's omitted-parentheses call syntax for parameterless procedures
 - labels, local and nonlocal `goto`/`go to`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   recursive switch entries

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/full-surface.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/full-surface.alg
@@ -13,7 +13,10 @@ begin
     integer x;
     inc := x + 1;
 
-  procedure bump;
+  integer procedure bonus();
+    begin bonus := 0 end;
+
+  procedure bump();
     begin counter := counter + 1; hits[counter] := counter end;
 
   integer procedure twice(x);
@@ -57,8 +60,8 @@ begin
   m[1, 2] := 6;
   m[2, 1] := 7;
   m[2, 2] := 8;
-  bump;
-  bump;
+  bump();
+  bump();
   total := fold(i, 1, 4, a[i] * i);
   total := total + apply(twice, hits[2]);
   total := total + entier(weights[2] * 10);
@@ -66,6 +69,7 @@ begin
   for i := 1, 3 step 1 until 4, 10 while loops < 3 do
     begin loops := loops + i end;
   total := total + loops;
+  total := total + bonus();
   switches := 0;
   jumpVia(route, fallback);
   switches := 99;

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1316,6 +1316,26 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_explicit_empty_no_argument_typed_procedure_expression_runs(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure seven(); begin seven := 7 end; "
+            "result := seven() "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_explicit_empty_no_argument_statement_call_runs(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure mark(); begin result := 9 end; "
+            "mark() "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
     def test_bare_procedure_expression_by_name_re_evaluates_each_read(self) -> None:
         result = compile_source(
             "begin integer result, calls; "


### PR DESCRIPTION
## Summary
- Accept explicit empty parentheses for parameterless ALGOL procedure declarations, statement calls, and typed procedure expression calls while preserving report-style omitted-parentheses forms.
- Add parser, type-checker, IR, and WASM coverage for `procedure p(); p()` and `integer procedure f(); f()`.
- Extend the full-surface golden fixture so the end-to-end WASM path exercises explicit empty procedure declarations and calls.

## Tests
- `python -m pytest tests/ -q` in `code/packages/python/algol-parser`
- `python -m pytest tests/ -q` in `code/packages/python/algol-type-checker`
- `python -m pytest tests/ -q` in `code/packages/python/algol-ir-compiler`
- `python -m pytest tests/ -q` in `code/packages/python/algol-wasm-compiler`
- `python -m ruff check ...` on touched Python test files

## Security Review
- Grammar-only language surface expansion plus tests/docs/fixture updates.
- No new file, process, network, deserialization, host import, or shell execution paths.
- Empty parameter/argument lists continue through the existing zero-argument semantic validation and procedure-call lowering paths.