### PR TITLE
[codex] Add WebGPU neural matrix backend

### DIFF
--- a/code/packages/typescript/neural-graph-vm/src/index.ts
+++ b/code/packages/typescript/neural-graph-vm/src/index.ts
@@ -17,10 +17,13 @@ export {
 } from "./neural-graph-vm.js";
 
 export {
+  AsyncTypeScriptMatrixBackend,
   TypeScriptMatrixBackend,
   compileBytecodeToMatrixPlan,
   runNeuralMatrixForward,
+  runNeuralMatrixForwardAsync,
   runNeuralMatrixForwardScalars,
+  type AsyncNeuralMatrixBackend,
   type MatrixBackend,
   type NeuralMatrixForwardResult,
   type NeuralMatrixInputValue,
@@ -30,3 +33,13 @@ export {
   type NeuralMatrixPlanOpcode,
   type NeuralMatrixPlanTerm,
 } from "./matrix-plan.js";
+
+export {
+  WebGpuMatrixBackend,
+  createWebGpuMatrixBackend,
+  getNavigatorGpu,
+  type WebGpuActivationName,
+  type WebGpuLike,
+  type WebGpuMatrix,
+  type WebGpuMatrixBackendOptions,
+} from "./webgpu-matrix-backend.js";

--- a/code/packages/typescript/neural-graph-vm/src/matrix-plan.ts
+++ b/code/packages/typescript/neural-graph-vm/src/matrix-plan.ts
@@ -61,6 +61,16 @@ export interface MatrixBackend<M> {
   toColumn(matrix: M): number[];
 }
 
+export interface AsyncNeuralMatrixBackend<M> {
+  column(values: readonly number[]): M | Promise<M>;
+  constant(value: number, rows: number, cols?: number): M | Promise<M>;
+  add(left: M, right: M): M | Promise<M>;
+  scale(matrix: M, scalar: number): M | Promise<M>;
+  activate(matrix: M, activation: string): M | Promise<M>;
+  toColumn(matrix: M): number[] | Promise<number[]>;
+  dispose?(matrix: M): void | Promise<void>;
+}
+
 export class TypeScriptMatrixBackend implements MatrixBackend<Matrix> {
   fromRows(rows: readonly (readonly number[])[]): Matrix {
     return new Matrix(cloneRows(rows));
@@ -103,6 +113,34 @@ export class TypeScriptMatrixBackend implements MatrixBackend<Matrix> {
       );
     }
     return matrix.data.map((row) => row[0]);
+  }
+}
+
+export class AsyncTypeScriptMatrixBackend implements AsyncNeuralMatrixBackend<Matrix> {
+  private readonly backend = new TypeScriptMatrixBackend();
+
+  column(values: readonly number[]): Matrix {
+    return this.backend.column(values);
+  }
+
+  constant(value: number, rows: number, cols = 1): Matrix {
+    return this.backend.constant(value, rows, cols);
+  }
+
+  add(left: Matrix, right: Matrix): Matrix {
+    return this.backend.add(left, right);
+  }
+
+  scale(matrix: Matrix, scalar: number): Matrix {
+    return this.backend.scale(matrix, scalar);
+  }
+
+  activate(matrix: Matrix, activation: string): Matrix {
+    return this.backend.map(matrix, (value) => applyNeuralActivation(value, activation));
+  }
+
+  toColumn(matrix: Matrix): number[] {
+    return this.backend.toColumn(matrix);
   }
 }
 
@@ -233,6 +271,108 @@ export function compileBytecodeToMatrixPlan(
     sourceBytecodeVersion: module.version,
     instructions,
   };
+}
+
+export function runNeuralMatrixForwardAsync(
+  plan: NeuralMatrixPlan,
+  inputs: NeuralMatrixInputs
+): Promise<NeuralMatrixForwardResult>;
+export function runNeuralMatrixForwardAsync<M>(
+  plan: NeuralMatrixPlan,
+  inputs: NeuralMatrixInputs,
+  backend: AsyncNeuralMatrixBackend<M>
+): Promise<NeuralMatrixForwardResult>;
+export async function runNeuralMatrixForwardAsync<M>(
+  plan: NeuralMatrixPlan,
+  inputs: NeuralMatrixInputs,
+  backend?: AsyncNeuralMatrixBackend<M>
+): Promise<NeuralMatrixForwardResult> {
+  const matrixBackend = backend
+    ?? new AsyncTypeScriptMatrixBackend() as unknown as AsyncNeuralMatrixBackend<M>;
+  const batchSize = inferBatchSize(inputs);
+  const values = new Map<string, M>();
+  const tracked = new Set<M>();
+  const outputs: Record<string, number[]> = {};
+
+  const track = (matrix: M): M => {
+    tracked.add(matrix);
+    return matrix;
+  };
+
+  try {
+    for (const instruction of plan.instructions) {
+      switch (instruction.op) {
+        case "LOAD_INPUT_MATRIX": {
+          const dst = requirePlanDst(instruction);
+          const inputName = instruction.inputName ?? instruction.sourceNode ?? dst;
+          values.set(
+            dst,
+            track(await matrixBackend.column(readInputColumn(inputs, inputName, batchSize)))
+          );
+          break;
+        }
+        case "LOAD_CONST_MATRIX": {
+          const dst = requirePlanDst(instruction);
+          values.set(
+            dst,
+            track(await matrixBackend.constant(instruction.value ?? 0, batchSize))
+          );
+          break;
+        }
+        case "WEIGHTED_SUM_MATRIX": {
+          const dst = requirePlanDst(instruction);
+          const terms = instruction.terms ?? [];
+          let result: M | undefined;
+          for (const term of terms) {
+            const weighted = track(
+              await matrixBackend.scale(readMatrixValue(values, term.sourceValue), term.weight)
+            );
+            result = result === undefined
+              ? weighted
+              : track(await matrixBackend.add(result, weighted));
+          }
+          values.set(dst, result ?? track(await matrixBackend.constant(0, batchSize)));
+          break;
+        }
+        case "ACTIVATE_MATRIX": {
+          const dst = requirePlanDst(instruction);
+          values.set(
+            dst,
+            track(
+              await matrixBackend.activate(
+                readMatrixValue(values, instruction.input),
+                instruction.activation ?? "relu"
+              )
+            )
+          );
+          break;
+        }
+        case "STORE_OUTPUT_MATRIX": {
+          const outputName = instruction.outputName ?? "output";
+          outputs[outputName] = await matrixBackend.toColumn(
+            readMatrixValue(values, instruction.input)
+          );
+          break;
+        }
+      }
+    }
+
+    return {
+      outputs,
+      values: Object.fromEntries(
+        await Promise.all(
+          [...values.entries()].map(async ([valueId, matrix]) => [
+            valueId,
+            await matrixBackend.toColumn(matrix),
+          ])
+        )
+      ),
+    };
+  } finally {
+    if (matrixBackend.dispose !== undefined) {
+      await Promise.all([...tracked].map((matrix) => matrixBackend.dispose!(matrix)));
+    }
+  }
 }
 
 export function runNeuralMatrixForward(

--- a/code/packages/typescript/neural-graph-vm/src/webgpu-matrix-backend.ts
+++ b/code/packages/typescript/neural-graph-vm/src/webgpu-matrix-backend.ts
@@ -1,0 +1,525 @@
+import type { AsyncNeuralMatrixBackend } from "./matrix-plan.js";
+
+const GPU_BUFFER_USAGE = {
+  MAP_READ: 0x0001,
+  COPY_SRC: 0x0004,
+  COPY_DST: 0x0008,
+  STORAGE: 0x0080,
+} as const;
+
+const GPU_MAP_MODE = {
+  READ: 0x0001,
+} as const;
+
+const GPU_SHADER_STAGE = {
+  COMPUTE: 0x0004,
+} as const;
+
+const WORKGROUP_SIZE = 64;
+
+export type WebGpuActivationName = "none" | "relu" | "sigmoid" | "tanh";
+
+export interface WebGpuMatrix {
+  readonly rows: number;
+  readonly cols: number;
+  readonly length: number;
+  readonly byteLength: number;
+  readonly buffer: GpuBufferLike;
+  readonly scratch?: readonly GpuBufferLike[];
+}
+
+export interface WebGpuMatrixBackendOptions {
+  readonly powerPreference?: "low-power" | "high-performance";
+}
+
+export interface WebGpuLike {
+  requestAdapter(
+    options?: WebGpuMatrixBackendOptions
+  ): Promise<GpuAdapterLike | null> | GpuAdapterLike | null;
+}
+
+interface GpuAdapterLike {
+  requestDevice(): Promise<GpuDeviceLike> | GpuDeviceLike;
+}
+
+interface GpuQueueLike {
+  writeBuffer(
+    buffer: GpuBufferLike,
+    bufferOffset: number,
+    data: ArrayBuffer | ArrayBufferView,
+    dataOffset?: number,
+    size?: number
+  ): void;
+  submit(commandBuffers: readonly unknown[]): void;
+  onSubmittedWorkDone?(): Promise<void>;
+}
+
+interface GpuDeviceLike {
+  readonly queue: GpuQueueLike;
+  createBuffer(descriptor: {
+    readonly label?: string;
+    readonly size: number;
+    readonly usage: number;
+    readonly mappedAtCreation?: boolean;
+  }): GpuBufferLike;
+  createShaderModule(descriptor: { readonly label?: string; readonly code: string }): unknown;
+  createBindGroupLayout(descriptor: {
+    readonly label?: string;
+    readonly entries: readonly GpuBindGroupLayoutEntryLike[];
+  }): unknown;
+  createPipelineLayout(descriptor: {
+    readonly label?: string;
+    readonly bindGroupLayouts: readonly unknown[];
+  }): unknown;
+  createComputePipeline(descriptor: {
+    readonly label?: string;
+    readonly layout: unknown;
+    readonly compute: { readonly module: unknown; readonly entryPoint: string };
+  }): unknown;
+  createBindGroup(descriptor: {
+    readonly label?: string;
+    readonly layout: unknown;
+    readonly entries: readonly GpuBindGroupEntryLike[];
+  }): unknown;
+  createCommandEncoder(descriptor?: { readonly label?: string }): GpuCommandEncoderLike;
+}
+
+interface GpuBindGroupLayoutEntryLike {
+  readonly binding: number;
+  readonly visibility: number;
+  readonly buffer: { readonly type: "read-only-storage" | "storage" };
+}
+
+interface GpuBindGroupEntryLike {
+  readonly binding: number;
+  readonly resource: { readonly buffer: GpuBufferLike };
+}
+
+interface GpuCommandEncoderLike {
+  beginComputePass(descriptor?: { readonly label?: string }): GpuComputePassEncoderLike;
+  copyBufferToBuffer(
+    source: GpuBufferLike,
+    sourceOffset: number,
+    destination: GpuBufferLike,
+    destinationOffset: number,
+    size: number
+  ): void;
+  finish(): unknown;
+}
+
+interface GpuComputePassEncoderLike {
+  setPipeline(pipeline: unknown): void;
+  setBindGroup(index: number, bindGroup: unknown): void;
+  dispatchWorkgroups(workgroupCountX: number): void;
+  end(): void;
+}
+
+interface GpuBufferLike {
+  mapAsync(mode: number, offset?: number, size?: number): Promise<void> | void;
+  getMappedRange(offset?: number, size?: number): ArrayBuffer | ArrayBufferView;
+  unmap(): void;
+  destroy?(): void;
+}
+
+export class WebGpuMatrixBackend implements AsyncNeuralMatrixBackend<WebGpuMatrix> {
+  private readonly unaryLayout: unknown;
+  private readonly binaryLayout: unknown;
+  private readonly scalePipeline: unknown;
+  private readonly addPipeline: unknown;
+  private readonly activationPipeline: unknown;
+
+  private constructor(private readonly device: GpuDeviceLike) {
+    this.unaryLayout = this.device.createBindGroupLayout({
+      label: "neural-matrix-unary-layout",
+      entries: [
+        storageBinding(0, "read-only-storage"),
+        storageBinding(1, "read-only-storage"),
+        storageBinding(2, "storage"),
+      ],
+    });
+    this.binaryLayout = this.device.createBindGroupLayout({
+      label: "neural-matrix-binary-layout",
+      entries: [
+        storageBinding(0, "read-only-storage"),
+        storageBinding(1, "read-only-storage"),
+        storageBinding(2, "storage"),
+      ],
+    });
+    this.scalePipeline = this.createPipeline("neural-matrix-scale", SCALE_SHADER, this.unaryLayout);
+    this.addPipeline = this.createPipeline("neural-matrix-add", ADD_SHADER, this.binaryLayout);
+    this.activationPipeline = this.createPipeline(
+      "neural-matrix-activation",
+      ACTIVATION_SHADER,
+      this.unaryLayout
+    );
+  }
+
+  static async create(
+    gpu: WebGpuLike,
+    options: WebGpuMatrixBackendOptions = {}
+  ): Promise<WebGpuMatrixBackend> {
+    const adapter = await gpu.requestAdapter(options);
+    if (adapter === null) {
+      throw new Error("WebGPU is available, but no adapter was returned");
+    }
+    return new WebGpuMatrixBackend(await adapter.requestDevice());
+  }
+
+  static async createFromNavigator(
+    options: WebGpuMatrixBackendOptions = {}
+  ): Promise<WebGpuMatrixBackend | null> {
+    const gpu = getNavigatorGpu();
+    if (gpu === undefined) {
+      return null;
+    }
+    return WebGpuMatrixBackend.create(gpu, options);
+  }
+
+  static isNavigatorAvailable(): boolean {
+    return getNavigatorGpu() !== undefined;
+  }
+
+  async fromRows(rows: readonly (readonly number[])[]): Promise<WebGpuMatrix> {
+    const rowCount = rows.length;
+    const colCount = rows[0]?.length ?? 0;
+    const data = new Float32Array(rowCount * colCount);
+    rows.forEach((row, rowIndex) => {
+      if (row.length !== colCount) {
+        throw new Error("All WebGPU matrix rows must have the same column count");
+      }
+      row.forEach((value, colIndex) => {
+        data[rowIndex * colCount + colIndex] = value;
+      });
+    });
+    return this.upload(data, rowCount, colCount, "neural-matrix-rows");
+  }
+
+  async toRows(matrix: WebGpuMatrix): Promise<number[][]> {
+    const values = await this.download(matrix);
+    return Array.from({ length: matrix.rows }, (_, rowIndex) => (
+      Array.from(
+        values.slice(rowIndex * matrix.cols, rowIndex * matrix.cols + matrix.cols)
+      )
+    ));
+  }
+
+  column(values: readonly number[]): WebGpuMatrix {
+    return this.upload(new Float32Array(values), values.length, 1, "neural-matrix-column");
+  }
+
+  constant(value: number, rows: number, cols = 1): WebGpuMatrix {
+    return this.upload(
+      new Float32Array(rows * cols).fill(value),
+      rows,
+      cols,
+      "neural-matrix-constant"
+    );
+  }
+
+  add(left: WebGpuMatrix, right: WebGpuMatrix): WebGpuMatrix {
+    assertSameShape(left, right);
+    const output = this.createOutput(left.rows, left.cols, "neural-matrix-add-output");
+    this.runBinary(this.addPipeline, left, right, output, "neural-matrix-add-pass");
+    return output;
+  }
+
+  scale(matrix: WebGpuMatrix, scalar: number): WebGpuMatrix {
+    const scalarBuffer = this.uploadParameter(new Float32Array([scalar]), "neural-matrix-scale-value");
+    const output = this.createOutput(
+      matrix.rows,
+      matrix.cols,
+      "neural-matrix-scale-output",
+      [scalarBuffer]
+    );
+    this.runUnary(this.scalePipeline, matrix, scalarBuffer, output, "neural-matrix-scale-pass");
+    return output;
+  }
+
+  activate(matrix: WebGpuMatrix, activation: string): WebGpuMatrix {
+    const activationBuffer = this.uploadParameter(
+      new Uint32Array([activationCode(activation)]),
+      "neural-matrix-activation-code"
+    );
+    const output = this.createOutput(
+      matrix.rows,
+      matrix.cols,
+      "neural-matrix-activation-output",
+      [activationBuffer]
+    );
+    this.runUnary(
+      this.activationPipeline,
+      matrix,
+      activationBuffer,
+      output,
+      "neural-matrix-activation-pass"
+    );
+    return output;
+  }
+
+  async toColumn(matrix: WebGpuMatrix): Promise<number[]> {
+    if (matrix.cols !== 1) {
+      throw new Error(`Expected a single-column WebGPU matrix, got ${matrix.cols} columns`);
+    }
+    return Array.from(await this.download(matrix));
+  }
+
+  dispose(matrix: WebGpuMatrix): void {
+    matrix.buffer.destroy?.();
+    matrix.scratch?.forEach((buffer) => buffer.destroy?.());
+  }
+
+  private createPipeline(label: string, code: string, layout: unknown): unknown {
+    const module = this.device.createShaderModule({ label: `${label}-shader`, code });
+    const pipelineLayout = this.device.createPipelineLayout({
+      label: `${label}-pipeline-layout`,
+      bindGroupLayouts: [layout],
+    });
+    return this.device.createComputePipeline({
+      label,
+      layout: pipelineLayout,
+      compute: { module, entryPoint: "main" },
+    });
+  }
+
+  private upload(
+    data: Float32Array,
+    rows: number,
+    cols: number,
+    label: string
+  ): WebGpuMatrix {
+    const byteLength = matrixByteLength(data.length);
+    const buffer = this.device.createBuffer({
+      label,
+      size: byteLength,
+      usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_SRC | GPU_BUFFER_USAGE.COPY_DST,
+    });
+    if (data.length > 0) {
+      this.device.queue.writeBuffer(buffer, 0, data);
+    }
+    return { rows, cols, length: data.length, byteLength, buffer };
+  }
+
+  private uploadParameter(data: Float32Array | Uint32Array, label: string): GpuBufferLike {
+    const buffer = this.device.createBuffer({
+      label,
+      size: matrixByteLength(data.length),
+      usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST,
+    });
+    this.device.queue.writeBuffer(buffer, 0, data);
+    return buffer;
+  }
+
+  private createOutput(
+    rows: number,
+    cols: number,
+    label: string,
+    scratch: readonly GpuBufferLike[] = []
+  ): WebGpuMatrix {
+    const length = rows * cols;
+    const byteLength = matrixByteLength(length);
+    const buffer = this.device.createBuffer({
+      label,
+      size: byteLength,
+      usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_SRC | GPU_BUFFER_USAGE.COPY_DST,
+    });
+    return { rows, cols, length, byteLength, buffer, scratch };
+  }
+
+  private runBinary(
+    pipeline: unknown,
+    left: WebGpuMatrix,
+    right: WebGpuMatrix,
+    output: WebGpuMatrix,
+    label: string
+  ): void {
+    const bindGroup = this.device.createBindGroup({
+      label: `${label}-bind-group`,
+      layout: this.binaryLayout,
+      entries: [
+        bufferBinding(0, left.buffer),
+        bufferBinding(1, right.buffer),
+        bufferBinding(2, output.buffer),
+      ],
+    });
+    this.dispatch(pipeline, bindGroup, output.length, label);
+  }
+
+  private runUnary(
+    pipeline: unknown,
+    input: WebGpuMatrix,
+    parameterBuffer: GpuBufferLike,
+    output: WebGpuMatrix,
+    label: string
+  ): void {
+    const bindGroup = this.device.createBindGroup({
+      label: `${label}-bind-group`,
+      layout: this.unaryLayout,
+      entries: [
+        bufferBinding(0, input.buffer),
+        bufferBinding(1, parameterBuffer),
+        bufferBinding(2, output.buffer),
+      ],
+    });
+    this.dispatch(pipeline, bindGroup, output.length, label);
+  }
+
+  private dispatch(
+    pipeline: unknown,
+    bindGroup: unknown,
+    length: number,
+    label: string
+  ): void {
+    const encoder = this.device.createCommandEncoder({ label: `${label}-encoder` });
+    const pass = encoder.beginComputePass({ label });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(Math.max(1, Math.ceil(length / WORKGROUP_SIZE)));
+    pass.end();
+    this.device.queue.submit([encoder.finish()]);
+  }
+
+  private async download(matrix: WebGpuMatrix): Promise<Float32Array> {
+    const staging = this.device.createBuffer({
+      label: "neural-matrix-readback",
+      size: matrix.byteLength,
+      usage: GPU_BUFFER_USAGE.MAP_READ | GPU_BUFFER_USAGE.COPY_DST,
+    });
+    const encoder = this.device.createCommandEncoder({ label: "neural-matrix-readback-encoder" });
+    encoder.copyBufferToBuffer(matrix.buffer, 0, staging, 0, matrix.byteLength);
+    this.device.queue.submit([encoder.finish()]);
+    await this.device.queue.onSubmittedWorkDone?.();
+    await staging.mapAsync(GPU_MAP_MODE.READ, 0, matrix.byteLength);
+    const range = staging.getMappedRange(0, matrix.byteLength);
+    const bytes = ArrayBuffer.isView(range)
+      ? new Uint8Array(range.buffer, range.byteOffset, range.byteLength)
+      : new Uint8Array(range);
+    const copy = bytes.slice(0, matrix.length * Float32Array.BYTES_PER_ELEMENT);
+    const values = new Float32Array(copy.buffer, copy.byteOffset, matrix.length);
+    const result = new Float32Array(values);
+    staging.unmap();
+    staging.destroy?.();
+    return result;
+  }
+}
+
+export function getNavigatorGpu(): WebGpuLike | undefined {
+  return (globalThis as typeof globalThis & {
+    navigator?: { readonly gpu?: WebGpuLike };
+  }).navigator?.gpu;
+}
+
+export async function createWebGpuMatrixBackend(
+  options: WebGpuMatrixBackendOptions = {}
+): Promise<WebGpuMatrixBackend | null> {
+  return WebGpuMatrixBackend.createFromNavigator(options);
+}
+
+function storageBinding(
+  binding: number,
+  type: "read-only-storage" | "storage"
+): GpuBindGroupLayoutEntryLike {
+  return {
+    binding,
+    visibility: GPU_SHADER_STAGE.COMPUTE,
+    buffer: { type },
+  };
+}
+
+function bufferBinding(binding: number, buffer: GpuBufferLike): GpuBindGroupEntryLike {
+  return {
+    binding,
+    resource: { buffer },
+  };
+}
+
+function matrixByteLength(length: number): number {
+  return Math.max(Float32Array.BYTES_PER_ELEMENT, length * Float32Array.BYTES_PER_ELEMENT);
+}
+
+function assertSameShape(left: WebGpuMatrix, right: WebGpuMatrix): void {
+  if (left.rows !== right.rows || left.cols !== right.cols) {
+    throw new Error(
+      `WebGPU matrix shape mismatch: ${left.rows}x${left.cols} vs ${right.rows}x${right.cols}`
+    );
+  }
+}
+
+function activationCode(activation: string): number {
+  switch (activation) {
+    case "none":
+    case "linear":
+      return 0;
+    case "relu":
+      return 1;
+    case "sigmoid":
+      return 2;
+    case "tanh":
+      return 3;
+    default:
+      throw new Error(`Unsupported WebGPU activation: ${activation}`);
+  }
+}
+
+const ADD_SHADER = `
+@group(0) @binding(0) var<storage, read> left_values: array<f32>;
+@group(0) @binding(1) var<storage, read> right_values: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output_values: array<f32>;
+
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let index = global_id.x;
+  if (index >= arrayLength(&output_values)) {
+    return;
+  }
+  output_values[index] = left_values[index] + right_values[index];
+}
+`;
+
+const SCALE_SHADER = `
+@group(0) @binding(0) var<storage, read> input_values: array<f32>;
+@group(0) @binding(1) var<storage, read> scalar_values: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output_values: array<f32>;
+
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let index = global_id.x;
+  if (index >= arrayLength(&output_values)) {
+    return;
+  }
+  output_values[index] = input_values[index] * scalar_values[0];
+}
+`;
+
+const ACTIVATION_SHADER = `
+@group(0) @binding(0) var<storage, read> input_values: array<f32>;
+@group(0) @binding(1) var<storage, read> activation_values: array<u32>;
+@group(0) @binding(2) var<storage, read_write> output_values: array<f32>;
+
+fn apply_activation(value: f32, activation: u32) -> f32 {
+  switch activation {
+    case 1u: {
+      return max(value, 0.0);
+    }
+    case 2u: {
+      return 1.0 / (1.0 + exp(-value));
+    }
+    case 3u: {
+      let doubled = clamp(2.0 * value, -40.0, 40.0);
+      let exponent = exp(doubled);
+      return (exponent - 1.0) / (exponent + 1.0);
+    }
+    default: {
+      return value;
+    }
+  }
+}
+
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let index = global_id.x;
+  if (index >= arrayLength(&output_values)) {
+    return;
+  }
+  output_values[index] = apply_activation(input_values[index], activation_values[0]);
+}
+`;

--- a/code/packages/typescript/neural-graph-vm/tests/neural-graph-vm.test.ts
+++ b/code/packages/typescript/neural-graph-vm/tests/neural-graph-vm.test.ts
@@ -18,7 +18,9 @@ import {
   runNeuralBytecodeForward,
   runNeuralBytecodeForwardWithTrace,
   runNeuralMatrixForward,
+  runNeuralMatrixForwardAsync,
   runNeuralMatrixForwardScalars,
+  type AsyncNeuralMatrixBackend,
   type MatrixBackend,
 } from "../src/index.js";
 
@@ -186,6 +188,62 @@ describe("neural graph vm", () => {
     expect(calls).toContain("scale");
     expect(calls).toContain("add");
     expect(calls).toContain("map");
+  });
+
+  it("runs matrix plans against an async backend interface", async () => {
+    const calls: string[] = [];
+    const backend: AsyncNeuralMatrixBackend<number[]> = {
+      async column(values) {
+        calls.push("column");
+        return [...values];
+      },
+      async constant(value, rows) {
+        calls.push("constant");
+        return Array(rows).fill(value);
+      },
+      async add(left, right) {
+        calls.push("add");
+        return left.map((value, index) => value + right[index]);
+      },
+      async scale(matrix, scalar) {
+        calls.push("scale");
+        return matrix.map((value) => value * scalar);
+      },
+      async activate(matrix, activation) {
+        calls.push(`activate:${activation}`);
+        return matrix.map((value) => Math.max(0, value));
+      },
+      async toColumn(matrix) {
+        calls.push("toColumn");
+        return [...matrix];
+      },
+    };
+    const bytecode = compileNeuralGraphToBytecode(makeTinyWeightedSumGraph());
+    const plan = compileBytecodeToMatrixPlan(bytecode);
+    const result = await runNeuralMatrixForwardAsync(
+      plan,
+      { x0: [4, 8], x1: [8, 16] },
+      backend
+    );
+
+    expect(result.outputs).toEqual({ prediction: [6, 13] });
+    expect(calls).toContain("scale");
+    expect(calls).toContain("add");
+    expect(calls).toContain("activate:relu");
+  });
+
+  it("runs async matrix plans through the default CPU backend", async () => {
+    const bytecode = compileNeuralNetworkToBytecode(createXorNetwork());
+    const plan = compileBytecodeToMatrixPlan(bytecode);
+    const result = await runNeuralMatrixForwardAsync(plan, {
+      x0: [0, 0, 1, 1],
+      x1: [0, 1, 0, 1],
+    });
+
+    expect(result.outputs.prediction[0]).toBeLessThan(0.01);
+    expect(result.outputs.prediction[1]).toBeGreaterThan(0.99);
+    expect(result.outputs.prediction[2]).toBeGreaterThan(0.99);
+    expect(result.outputs.prediction[3]).toBeLessThan(0.01);
   });
 
   it("supports negative weighted sums through relu", () => {

--- a/code/packages/typescript/neural-graph-vm/tests/neural-graph-vm.test.ts
+++ b/code/packages/typescript/neural-graph-vm/tests/neural-graph-vm.test.ts
@@ -19,10 +19,252 @@ import {
   runNeuralBytecodeForwardWithTrace,
   runNeuralMatrixForward,
   runNeuralMatrixForwardAsync,
+  WebGpuMatrixBackend,
   runNeuralMatrixForwardScalars,
   type AsyncNeuralMatrixBackend,
   type MatrixBackend,
+  type WebGpuLike,
 } from "../src/index.js";
+
+const FLOAT_BYTES = Float32Array.BYTES_PER_ELEMENT;
+
+class FakeGpuBuffer {
+  readonly bytes: Uint8Array;
+  destroyed = false;
+
+  constructor(size: number) {
+    this.bytes = new Uint8Array(size);
+  }
+
+  mapAsync(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  getMappedRange(offset = 0, size = this.bytes.byteLength - offset): Uint8Array {
+    return this.bytes.slice(offset, offset + size);
+  }
+
+  unmap(): void {
+    // Fake buffers expose a copied mapped range, so unmap has no work to do.
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+  }
+}
+
+interface FakeBindGroup {
+  readonly entries: readonly {
+    readonly binding: number;
+    readonly resource: { readonly buffer: FakeGpuBuffer };
+  }[];
+}
+
+interface FakePipeline {
+  readonly label: string;
+}
+
+interface FakeCommandBuffer {
+  readonly copies: readonly {
+    readonly source: FakeGpuBuffer;
+    readonly sourceOffset: number;
+    readonly destination: FakeGpuBuffer;
+    readonly destinationOffset: number;
+    readonly size: number;
+  }[];
+}
+
+class FakeGpuDevice {
+  readonly queue = {
+    writeBuffer: (
+      buffer: FakeGpuBuffer,
+      bufferOffset: number,
+      data: ArrayBuffer | ArrayBufferView
+    ): void => {
+      const bytes = data instanceof ArrayBuffer
+        ? new Uint8Array(data)
+        : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+      buffer.bytes.set(bytes, bufferOffset);
+    },
+    submit: (commands: readonly FakeCommandBuffer[]): void => {
+      for (const command of commands) {
+        for (const copy of command.copies) {
+          bufferCopy(copy.source, copy.sourceOffset, copy.destination, copy.destinationOffset, copy.size);
+        }
+      }
+    },
+    onSubmittedWorkDone: (): Promise<void> => Promise.resolve(),
+  };
+
+  createBuffer(descriptor: { readonly size: number }): FakeGpuBuffer {
+    return new FakeGpuBuffer(descriptor.size);
+  }
+
+  createShaderModule(): object {
+    return {};
+  }
+
+  createBindGroupLayout(): object {
+    return {};
+  }
+
+  createPipelineLayout(): object {
+    return {};
+  }
+
+  createComputePipeline(descriptor: { readonly label?: string }): FakePipeline {
+    return { label: descriptor.label ?? "" };
+  }
+
+  createBindGroup(descriptor: { readonly entries: FakeBindGroup["entries"] }): FakeBindGroup {
+    return { entries: descriptor.entries };
+  }
+
+  createCommandEncoder(): FakeCommandEncoder {
+    return new FakeCommandEncoder();
+  }
+}
+
+class FakeCommandEncoder {
+  private readonly copies: FakeCommandBuffer["copies"][number][] = [];
+
+  beginComputePass(): FakeComputePass {
+    return new FakeComputePass();
+  }
+
+  copyBufferToBuffer(
+    source: FakeGpuBuffer,
+    sourceOffset: number,
+    destination: FakeGpuBuffer,
+    destinationOffset: number,
+    size: number
+  ): void {
+    this.copies.push({ source, sourceOffset, destination, destinationOffset, size });
+  }
+
+  finish(): FakeCommandBuffer {
+    return { copies: [...this.copies] };
+  }
+}
+
+class FakeComputePass {
+  private pipeline: FakePipeline | undefined;
+  private bindGroup: FakeBindGroup | undefined;
+
+  setPipeline(pipeline: FakePipeline): void {
+    this.pipeline = pipeline;
+  }
+
+  setBindGroup(_index: number, bindGroup: FakeBindGroup): void {
+    this.bindGroup = bindGroup;
+  }
+
+  dispatchWorkgroups(): void {
+    if (this.pipeline === undefined || this.bindGroup === undefined) {
+      throw new Error("Fake compute pass was dispatched before setup");
+    }
+    runFakeKernel(this.pipeline, this.bindGroup);
+  }
+
+  end(): void {
+    // The fake pass computes during dispatch so tests can stay synchronous.
+  }
+}
+
+class FakeGpuAdapter {
+  constructor(private readonly device: FakeGpuDevice) {}
+
+  requestDevice(): FakeGpuDevice {
+    return this.device;
+  }
+}
+
+class FakeGpu implements WebGpuLike {
+  readonly device = new FakeGpuDevice();
+
+  requestAdapter(): FakeGpuAdapter {
+    return new FakeGpuAdapter(this.device);
+  }
+}
+
+function bufferCopy(
+  source: FakeGpuBuffer,
+  sourceOffset: number,
+  destination: FakeGpuBuffer,
+  destinationOffset: number,
+  size: number
+): void {
+  destination.bytes.set(
+    source.bytes.slice(sourceOffset, sourceOffset + size),
+    destinationOffset
+  );
+}
+
+function runFakeKernel(pipeline: FakePipeline, bindGroup: FakeBindGroup): void {
+  const buffers = new Map(
+    bindGroup.entries.map((entry) => [entry.binding, entry.resource.buffer])
+  );
+  const input = readFloatBuffer(requireFakeBuffer(buffers, 0));
+  const parameter = requireFakeBuffer(buffers, 1);
+  const outputBuffer = requireFakeBuffer(buffers, 2);
+  const output = new Float32Array(outputBuffer.bytes.buffer);
+
+  if (pipeline.label.includes("add")) {
+    const right = readFloatBuffer(parameter);
+    for (let index = 0; index < output.length; index += 1) {
+      output[index] = (input[index] ?? 0) + (right[index] ?? 0);
+    }
+    return;
+  }
+
+  if (pipeline.label.includes("scale")) {
+    const scalar = readFloatBuffer(parameter)[0] ?? 0;
+    for (let index = 0; index < output.length; index += 1) {
+      output[index] = (input[index] ?? 0) * scalar;
+    }
+    return;
+  }
+
+  if (pipeline.label.includes("activation")) {
+    const activation = new Uint32Array(parameter.bytes.buffer)[0] ?? 0;
+    for (let index = 0; index < output.length; index += 1) {
+      output[index] = fakeActivation(input[index] ?? 0, activation);
+    }
+    return;
+  }
+
+  throw new Error(`Unknown fake WebGPU pipeline: ${pipeline.label}`);
+}
+
+function requireFakeBuffer(
+  buffers: ReadonlyMap<number, FakeGpuBuffer>,
+  binding: number
+): FakeGpuBuffer {
+  const buffer = buffers.get(binding);
+  if (buffer === undefined) {
+    throw new Error(`Missing fake WebGPU binding ${binding}`);
+  }
+  return buffer;
+}
+
+function readFloatBuffer(buffer: FakeGpuBuffer): Float32Array {
+  return new Float32Array(buffer.bytes.buffer, 0, buffer.bytes.byteLength / FLOAT_BYTES);
+}
+
+function fakeActivation(value: number, activation: number): number {
+  switch (activation) {
+    case 1:
+      return Math.max(value, 0);
+    case 2:
+      return 1 / (1 + Math.exp(-value));
+    case 3: {
+      const exponent = Math.exp(Math.min(40, Math.max(-40, 2 * value)));
+      return (exponent - 1) / (exponent + 1);
+    }
+    default:
+      return value;
+  }
+}
 
 function makeTinyWeightedSumGraph(): NeuralGraph {
   const graph = createNeuralGraph("tiny-weighted-sum");
@@ -240,6 +482,48 @@ describe("neural graph vm", () => {
       x1: [0, 1, 0, 1],
     });
 
+    expect(result.outputs.prediction[0]).toBeLessThan(0.01);
+    expect(result.outputs.prediction[1]).toBeGreaterThan(0.99);
+    expect(result.outputs.prediction[2]).toBeGreaterThan(0.99);
+    expect(result.outputs.prediction[3]).toBeLessThan(0.01);
+  });
+
+  it("runs matrix plans through the WebGPU backend contract", async () => {
+    const backend = await WebGpuMatrixBackend.create(new FakeGpu());
+    const bytecode = compileNeuralGraphToBytecode(makeTinyWeightedSumGraph());
+    const plan = compileBytecodeToMatrixPlan(bytecode);
+    const result = await runNeuralMatrixForwardAsync(
+      plan,
+      { x0: [4, 8], x1: [8, 16] },
+      backend
+    );
+
+    expect(result.outputs).toEqual({ prediction: [6, 13] });
+    expect(result.values).toMatchObject({
+      v0: [1, 1],
+      v1: [4, 8],
+      v2: [8, 16],
+    });
+  });
+
+  it("runs sigmoid networks and row conversion through the WebGPU backend", async () => {
+    const backend = await WebGpuMatrixBackend.create(new FakeGpu());
+    const rows = await backend.toRows(await backend.fromRows([
+      [1, 2],
+      [3, 4],
+    ]));
+    const bytecode = compileNeuralNetworkToBytecode(createXorNetwork());
+    const plan = compileBytecodeToMatrixPlan(bytecode);
+    const result = await runNeuralMatrixForwardAsync(
+      plan,
+      { x0: [0, 0, 1, 1], x1: [0, 1, 0, 1] },
+      backend
+    );
+
+    expect(rows).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
     expect(result.outputs.prediction[0]).toBeLessThan(0.01);
     expect(result.outputs.prediction[1]).toBeGreaterThan(0.99);
     expect(result.outputs.prediction[2]).toBeGreaterThan(0.99);

--- a/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/HiddenLayerWorkbench.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   HIDDEN_LAYER_EXAMPLES,
   createInitialHiddenState,
+  exampleInputs,
   hiddenHistoryPoint,
   hiddenLoss,
   hiddenMeanAbsoluteError,
@@ -14,7 +15,12 @@ import {
   type HiddenLayerStepResult,
 } from "./hidden-layer-examples.js";
 import { gradientShape } from "./layered-network.js";
-import { predictLayeredWithVm } from "./neural-vm.js";
+import {
+  canUseWebGpuMatrixBackend,
+  predictLayeredWithBestMatrixBackend,
+  predictLayeredWithVm,
+  type MatrixExecutionBackend,
+} from "./neural-vm.js";
 import { HiddenNetworkDiagram } from "./NetworkDiagram.js";
 
 interface HiddenChartFrame {
@@ -44,6 +50,25 @@ const CURVE_CHART: HiddenChartFrame = {
 };
 
 const SURFACE_SIZE = 460;
+
+interface SurfaceCell {
+  readonly x: number;
+  readonly y: number;
+  readonly value: number;
+}
+
+interface SurfaceGrid {
+  readonly cells: readonly SurfaceCell[];
+  readonly inputs: number[][];
+}
+
+interface HiddenPredictionBundle {
+  readonly rowPredictions: number[];
+  readonly curvePath: string;
+  readonly surfaceCells: readonly SurfaceCell[];
+  readonly backend: MatrixExecutionBackend;
+  readonly fallbackReason?: string;
+}
 
 function formatNumber(value: number, digits = 3): string {
   if (!Number.isFinite(value)) {
@@ -92,20 +117,14 @@ function hiddenHistoryPath(history: HiddenLayerHistoryPoint[]): string {
     .join(" ");
 }
 
-function makeCurvePath(example: HiddenLayerExample, state: HiddenLayerModelState): string {
-  const samples = Array.from({ length: 121 }, (_, index) => {
+function makeCurveSamples(): number[] {
+  return Array.from({ length: 121 }, (_, index) => {
     const x = CURVE_CHART.xMin + (index / 120) * (CURVE_CHART.xMax - CURVE_CHART.xMin);
     return x;
   });
-  const predictions = predictLayeredWithVm(
-    samples.map((x) => [x]),
-    state.parameters,
-    {
-      inputNames: example.inputLabels,
-      outputNames: [example.outputLabel],
-    },
-  ).predictions.map((row) => row[0] ?? 0);
+}
 
+function makeCurvePathFromPredictions(samples: readonly number[], predictions: readonly number[]): string {
   const points = samples.map((x, index) => {
     return [x, predictions[index] ?? 0] as const;
   });
@@ -118,8 +137,22 @@ function makeCurvePath(example: HiddenLayerExample, state: HiddenLayerModelState
     .join(" ");
 }
 
-function makeSurfaceCells(example: HiddenLayerExample, state: HiddenLayerModelState): Array<{ x: number; y: number; value: number }> {
-  const cells: Array<{ x: number; y: number; value: number }> = [];
+function makeCurvePath(example: HiddenLayerExample, state: HiddenLayerModelState): string {
+  const samples = makeCurveSamples();
+  const predictions = predictLayeredWithVm(
+    samples.map((x) => [x]),
+    state.parameters,
+    {
+      inputNames: example.inputLabels,
+      outputNames: [example.outputLabel],
+    },
+  ).predictions.map((row) => row[0] ?? 0);
+
+  return makeCurvePathFromPredictions(samples, predictions);
+}
+
+function makeSurfaceGrid(example: HiddenLayerExample): SurfaceGrid {
+  const cells: SurfaceCell[] = [];
   const inputs: number[][] = [];
   const divisions = 26;
   const xValues = example.rows.map((row) => row.input[0]!);
@@ -141,18 +174,68 @@ function makeSurfaceCells(example: HiddenLayerExample, state: HiddenLayerModelSt
     }
   }
 
-  const predictions = predictLayeredWithVm(inputs, state.parameters, {
+  return { cells, inputs };
+}
+
+function makeSurfaceCells(example: HiddenLayerExample, state: HiddenLayerModelState): readonly SurfaceCell[] {
+  const grid = makeSurfaceGrid(example);
+  const predictions = predictLayeredWithVm(grid.inputs, state.parameters, {
     inputNames: example.inputLabels,
     outputNames: [example.outputLabel],
   }).predictions;
 
-  return cells.map((cell, index) => ({
+  return grid.cells.map((cell, index) => ({
     ...cell,
     value: predictions[index]?.[0] ?? 0,
   }));
 }
 
-function CurveChart({ example, state, predictions }: { example: HiddenLayerExample; state: HiddenLayerModelState; predictions: number[] }) {
+function makePredictionBundleSync(example: HiddenLayerExample, state: HiddenLayerModelState): HiddenPredictionBundle {
+  return {
+    rowPredictions: predictHidden(example, state),
+    curvePath: example.chartKind === "curve" ? makeCurvePath(example, state) : "",
+    surfaceCells: example.chartKind === "surface" ? makeSurfaceCells(example, state) : [],
+    backend: "cpu",
+  };
+}
+
+async function makePredictionBundleAsync(
+  example: HiddenLayerExample,
+  state: HiddenLayerModelState,
+): Promise<HiddenPredictionBundle> {
+  const rowInputs = exampleInputs(example);
+  const curveSamples = example.chartKind === "curve" ? makeCurveSamples() : [];
+  const curveInputs = curveSamples.map((x) => [x]);
+  const surfaceGrid = example.chartKind === "surface" ? makeSurfaceGrid(example) : { cells: [], inputs: [] };
+  const allInputs = [
+    ...rowInputs,
+    ...curveInputs,
+    ...surfaceGrid.inputs,
+  ];
+  const run = await predictLayeredWithBestMatrixBackend(allInputs, state.parameters, {
+    inputNames: example.inputLabels,
+    outputNames: [example.outputLabel],
+  });
+  const values = run.predictions.map((row) => row[0] ?? 0);
+  const rowPredictions = values.slice(0, rowInputs.length);
+  const curvePredictions = values.slice(rowInputs.length, rowInputs.length + curveInputs.length);
+  const surfacePredictions = values.slice(rowInputs.length + curveInputs.length);
+
+  return {
+    rowPredictions,
+    curvePath: curveSamples.length > 0
+      ? makeCurvePathFromPredictions(curveSamples, curvePredictions)
+      : "",
+    surfaceCells: surfaceGrid.cells.map((cell, index) => ({
+      ...cell,
+      value: surfacePredictions[index] ?? 0,
+    })),
+    backend: run.backend,
+    fallbackReason: run.fallbackReason,
+  };
+}
+
+function CurveChart({ example, curvePath, predictions }: { example: HiddenLayerExample; curvePath: string; predictions: number[] }) {
   return (
     <svg viewBox={`0 0 ${CURVE_CHART.width} ${CURVE_CHART.height}`} role="img" aria-label={`${example.title} hidden-layer curve`}>
       <rect
@@ -174,7 +257,7 @@ function CurveChart({ example, state, predictions }: { example: HiddenLayerExamp
           </g>
         );
       })}
-      <path className="hidden-curve" d={makeCurvePath(example, state)} />
+      <path className="hidden-curve" d={curvePath} />
       {example.rows.map((row, index) => {
         const px = xScale(row.input[0]!, CURVE_CHART);
         const targetY = yScale(row.target, CURVE_CHART);
@@ -193,14 +276,13 @@ function CurveChart({ example, state, predictions }: { example: HiddenLayerExamp
   );
 }
 
-function SurfaceChart({ example, state, predictions, selectedIndex, onSelect }: {
+function SurfaceChart({ example, cells, predictions, selectedIndex, onSelect }: {
   example: HiddenLayerExample;
-  state: HiddenLayerModelState;
+  cells: readonly SurfaceCell[];
   predictions: number[];
   selectedIndex: number;
   onSelect: (index: number) => void;
 }) {
-  const cells = makeSurfaceCells(example, state);
   const divisions = Math.sqrt(cells.length);
   const cellSize = SURFACE_SIZE / divisions;
   const xValues = example.rows.map((row) => row.input[0]!);
@@ -309,11 +391,44 @@ export function HiddenLayerWorkbench() {
     setIsRunning(false);
   }, [example]);
 
-  const predictions = useMemo(() => predictHidden(example, state), [example, state]);
+  const fallbackBundle = useMemo(() => makePredictionBundleSync(example, state), [example, state]);
+  const [acceleratedBundle, setAcceleratedBundle] = useState<HiddenPredictionBundle | null>(null);
+  const predictionBundle = acceleratedBundle ?? fallbackBundle;
+  const predictions = predictionBundle.rowPredictions;
   const loss = useMemo(() => hiddenLoss(example, state), [example, state]);
   const mae = useMemo(() => hiddenMeanAbsoluteError(example, state), [example, state]);
   const trace = useMemo(() => traceHiddenExample(example, state, selectedIndex), [example, selectedIndex, state]);
   const outputGradient = lastStep?.step.weightGradients[lastStep.step.weightGradients.length - 1];
+  const backendLabel = predictionBundle.backend === "webgpu" ? "WebGPU" : "CPU";
+
+  useEffect(() => {
+    let cancelled = false;
+    setAcceleratedBundle(null);
+    if (!canUseWebGpuMatrixBackend()) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    makePredictionBundleAsync(example, state)
+      .then((bundle) => {
+        if (!cancelled) {
+          setAcceleratedBundle(bundle);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setAcceleratedBundle({
+            ...fallbackBundle,
+            fallbackReason: error instanceof Error ? error.message : "Matrix backend failed",
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [example, fallbackBundle, state]);
 
   function record(result: HiddenLayerStepResult): void {
     setState(result.state);
@@ -420,11 +535,17 @@ export function HiddenLayerWorkbench() {
         </div>
 
         <section className="chart-panel chart-panel--hidden" aria-label="Hidden-layer chart">
-          {example.chartKind === "curve" && <CurveChart example={example} state={state} predictions={predictions} />}
+          {example.chartKind === "curve" && (
+            <CurveChart
+              example={example}
+              curvePath={predictionBundle.curvePath}
+              predictions={predictions}
+            />
+          )}
           {example.chartKind === "surface" && (
             <SurfaceChart
               example={example}
-              state={state}
+              cells={predictionBundle.surfaceCells}
               predictions={predictions}
               selectedIndex={selectedIndex}
               onSelect={setSelectedIndex}
@@ -532,6 +653,10 @@ export function HiddenLayerWorkbench() {
         <div className="metric">
           <span>Average error</span>
           <strong>{formatNumber(mae, 3)}</strong>
+        </div>
+        <div className="metric" title={predictionBundle.fallbackReason}>
+          <span>Matrix backend</span>
+          <strong>{backendLabel}</strong>
         </div>
 
         <div className="history">

--- a/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/NetworkDiagram.tsx
@@ -26,6 +26,18 @@ const BLUE = "#2563eb";
 const RED = "#c2413b";
 const GOLD = "#b7791f";
 const VIOLET = "#6d5bd0";
+const EDGE_PALETTE = [
+  "#2563eb",
+  "#237a57",
+  "#b7791f",
+  "#6d5bd0",
+  "#c2413b",
+  "#0f766e",
+  "#be185d",
+  "#7c3aed",
+  "#ca8a04",
+  "#0284c7",
+];
 
 interface DiagramNode {
   readonly id: string;
@@ -309,20 +321,38 @@ function makeHiddenScene(
   lastStep: HiddenLayerStepResult | null,
   learningRate: number,
 ): PaintScene {
-  const width = 920;
-  const height = 720;
   const selectedInput = selectedRow.input;
   const selectedError = prediction - selectedRow.target;
   const forward = forwardLayered([selectedInput], state.parameters);
   const hiddenLayers = state.parameters.layers.slice(0, -1);
   const outputLayer = state.parameters.layers[state.parameters.layers.length - 1]!;
-  const inputYs = verticalPositions(example.inputLabels.length, 82, 232);
-  const hiddenXs = horizontalPositions(hiddenLayers.length, 246, 594);
+  const maxLayerWidth = Math.max(
+    example.inputLabels.length,
+    outputLayer.biases.length,
+    ...hiddenLayers.map((layer) => layer.biases.length),
+  );
+  const networkTop = 106;
+  const nodeGap = 66;
+  const networkBottom = Math.max(318, networkTop + Math.max(1, maxLayerWidth - 1) * nodeGap);
+  const flowTop = networkBottom + 92;
+  const height = flowTop + 344;
+  const inputX = 96;
+  const hiddenStartX = 290;
+  const layerGap = 190;
+  const hiddenEndX = hiddenStartX + Math.max(0, hiddenLayers.length - 1) * layerGap;
+  const outputX = hiddenEndX + 210;
+  const lossX = outputX + 150;
+  const width = Math.max(1080, lossX + 98);
+  const inputYs = verticalPositions(example.inputLabels.length, networkTop, networkBottom);
+  const hiddenXs = hiddenLayers.map((_, layerIndex) => hiddenStartX + layerIndex * layerGap);
+  const outputY = networkTop + (networkBottom - networkTop) * 0.42;
+  const targetY = outputY + 86;
+  const lossY = outputY + 42;
   const inputNodes = example.inputLabels.map((label, index): DiagramNode => ({
     id: `input-${index}`,
     label,
     value: fmt(selectedInput[index] ?? 0),
-    x: 86,
+    x: inputX,
     y: inputYs[index]!,
     tone: "input",
   }));
@@ -330,12 +360,12 @@ function makeHiddenScene(
     id: "bias",
     label: "bias",
     value: "1",
-    x: 86,
-    y: 318,
+    x: inputX,
+    y: networkBottom + 56,
     tone: "bias",
   };
   const hiddenNodeLayers = hiddenLayers.map((layer, layerIndex) => {
-    const hiddenYs = verticalPositions(layer.biases.length, 54, 286);
+    const hiddenYs = verticalPositions(layer.biases.length, networkTop, networkBottom);
     return layer.biases.map((_, unit): DiagramNode => ({
       id: `hidden-${layerIndex}-${unit}`,
       label: `h${layerIndex + 1}.${unit + 1}`,
@@ -350,24 +380,24 @@ function makeHiddenScene(
     id: "output",
     label: example.outputLabel,
     value: fmt(prediction),
-    x: 708,
-    y: 170,
+    x: outputX,
+    y: outputY,
     tone: "output",
   };
   const target: DiagramNode = {
     id: "target",
     label: "target",
     value: fmt(selectedRow.target),
-    x: 708,
-    y: 252,
+    x: outputX,
+    y: targetY,
     tone: "bias",
   };
   const lossNode: DiagramNode = {
     id: "loss",
     label: "mse",
     value: fmt(selectedError * selectedError),
-    x: 834,
-    y: 212,
+    x: lossX,
+    y: lossY,
     tone: "output",
   };
 
@@ -380,7 +410,7 @@ function makeHiddenScene(
     }),
     ...sectionLabel("1 selected forward pass", 32, 48),
     ...text(`epoch ${state.epoch}`, 32, 70, 13, MUTED),
-    ...text("weights update on every batch step", 630, 48, 13, MUTED),
+    ...text("edge color follows source node; line width follows |weight|", width - 412, 48, 13, MUTED),
   ];
 
   for (const [layerIndex, hiddenNodes] of hiddenNodeLayers.entries()) {
@@ -390,7 +420,14 @@ function makeHiddenScene(
       for (const [unit, hiddenNode] of hiddenNodes.entries()) {
         const weight = layer.weights[previousIndex]![unit]!;
         const shouldLabel = layerIndex === 0 && hiddenLayers.length <= 2 && hiddenNodes.length <= 8;
-        instructions.push(...edge(previousNode, hiddenNode, weight, shouldLabel ? fmt(weight) : "", 0.34));
+        instructions.push(...edge(
+          previousNode,
+          hiddenNode,
+          weight,
+          shouldLabel ? fmt(weight) : "",
+          0.34,
+          edgeColorForNode(previousNode.id),
+        ));
       }
     }
   }
@@ -399,16 +436,37 @@ function makeHiddenScene(
     for (const [unit, hiddenNode] of hiddenNodes.entries()) {
       const biasWeight = layer.biases[unit]!;
       const shouldLabel = layerIndex === 0 && hiddenLayers.length === 1 && hiddenNodes.length <= 8;
-      instructions.push(...edge(bias, hiddenNode, biasWeight, shouldLabel ? fmt(biasWeight) : "", 0.26));
+      instructions.push(...edge(
+        bias,
+        hiddenNode,
+        biasWeight,
+        shouldLabel ? fmt(biasWeight) : "",
+        0.26,
+        edgeColorForNode(`bias-${layerIndex}`),
+      ));
     }
   }
   for (const [hiddenIndex, hiddenNode] of lastHiddenNodes.entries()) {
     const weight = outputLayer.weights[hiddenIndex]![0]!;
     const shouldLabel = hiddenLayers.length <= 2 && lastHiddenNodes.length <= 8;
-    instructions.push(...edge(hiddenNode, output, weight, shouldLabel ? fmt(weight) : "", 0.42));
+    instructions.push(...edge(
+      hiddenNode,
+      output,
+      weight,
+      shouldLabel ? fmt(weight) : "",
+      0.42,
+      edgeColorForNode(hiddenNode.id),
+    ));
   }
   instructions.push(
-    ...edge(bias, output, outputLayer.biases[0] ?? 0, hiddenLayers.length === 1 ? fmt(outputLayer.biases[0] ?? 0) : "", 0.28),
+    ...edge(
+      bias,
+      output,
+      outputLayer.biases[0] ?? 0,
+      hiddenLayers.length === 1 ? fmt(outputLayer.biases[0] ?? 0) : "",
+      0.28,
+      edgeColorForNode("bias-output"),
+    ),
     ...edge(output, lossNode, selectedError, `err ${signed(selectedError)}`, 0.62),
     ...edge(target, lossNode, -1, "truth", 0.62),
     ...inputNodes.flatMap(node),
@@ -434,45 +492,48 @@ function makeHiddenScene(
   const hiddenUpdate = lastStep === null
     ? "waiting for first step"
     : `max hidden delta ${fmt(hiddenDelta)}`;
+  const cardStartX = 32;
+  const cardY = flowTop + 32;
+  const cardY2 = flowTop + 180;
   instructions.push(
-    ...sectionLabel("2 folded loss + update loop", 32, 370),
-    ...flowCard(32, 402, 158, "input row", [
+    ...sectionLabel("2 folded loss + update loop", cardStartX, flowTop),
+    ...flowCard(cardStartX, cardY, 158, "input row", [
       selectedRow.label,
       `inputs ${selectedInput.map((value) => fmt(value)).join(", ")}`,
       `target ${fmt(selectedRow.target)}`,
     ], BLUE),
-    ...flowArrow(196, 448, 244, 448, BLUE, "forward"),
-    ...flowCard(254, 402, 162, "prediction", [
+    ...flowArrow(cardStartX + 164, cardY + 46, cardStartX + 212, cardY + 46, BLUE, "forward"),
+    ...flowCard(cardStartX + 222, cardY, 162, "prediction", [
       `${state.hiddenLayerCount} x hidden[${example.hiddenCount}]`,
       `${example.outputLabel} ${fmt(prediction)}`,
       `error ${signed(selectedError)}`,
     ], GREEN),
-    ...flowArrow(422, 448, 470, 448, RED, "loss"),
-    ...flowCard(480, 402, 158, "mse + deltas", [
+    ...flowArrow(cardStartX + 390, cardY + 46, cardStartX + 438, cardY + 46, RED, "loss"),
+    ...flowCard(cardStartX + 448, cardY, 158, "mse + deltas", [
       `row mse ${fmt(selectedError * selectedError)}`,
       `output delta ${fmt(outputDelta)}`,
       hiddenUpdate,
     ], RED),
-    ...flowArrow(559, 528, 559, 550, RED, ""),
-    ...flowCard(480, 550, 186, "gradient matrices", [
+    ...flowArrow(cardStartX + 527, cardY + 126, cardStartX + 527, cardY2, RED, ""),
+    ...flowCard(cardStartX + 448, cardY2, 186, "gradient matrices", [
       inputShape,
       `dL/dW${state.parameters.layers.length} ${gradientShape(lastGradient)}`,
       `db out ${signed(-learningRate * outputGrad)}`,
     ], VIOLET),
-    ...flowArrow(470, 596, 422, 596, VIOLET, "apply lr"),
-    ...flowCard(254, 550, 162, "parameter update", [
+    ...flowArrow(cardStartX + 438, cardY2 + 46, cardStartX + 390, cardY2 + 46, VIOLET, "apply lr"),
+    ...flowCard(cardStartX + 222, cardY2, 162, "parameter update", [
       `lr ${fmt(learningRate)}`,
       `${state.parameters.layers.length} weight matrices`,
       "next batch uses them",
     ], VIOLET),
-    ...flowArrow(244, 596, 196, 596, VIOLET, "store"),
-    ...flowCard(32, 550, 158, "model state", [
+    ...flowArrow(cardStartX + 212, cardY2 + 46, cardStartX + 164, cardY2 + 46, VIOLET, "store"),
+    ...flowCard(cardStartX, cardY2, 158, "model state", [
       `epoch ${state.epoch}`,
       `${state.hiddenLayerCount} hidden layers`,
       `${example.hiddenCount} neurons/layer`,
     ], BLUE),
-    ...text("new weights = old weights - learningRate * gradient", 32, 696, 13, MUTED),
-    ...text("line width = |weight|", 630, 696, 12, MUTED),
+    ...text("new weights = old weights - learningRate * gradient", cardStartX, height - 24, 13, MUTED),
+    ...text("scroll the graph to inspect larger networks", width - 336, height - 24, 12, MUTED),
   );
 
   return paintScene(width, height, "#ffffff", instructions, {
@@ -577,10 +638,11 @@ function edge(
   weight: number,
   label: string,
   labelOffset = 0.5,
+  colorOverride?: string,
 ): PaintInstruction[] {
   const midX = from.x + (to.x - from.x) * labelOffset;
   const midY = from.y + (to.y - from.y) * labelOffset;
-  const color = weight >= 0 ? GREEN : RED;
+  const color = colorOverride ?? (weight >= 0 ? GREEN : RED);
   const width = Math.min(7, 1.4 + Math.abs(weight) * 0.75);
   const { x1, y1, x2, y2 } = shortenSegment(from.x, from.y, to.x, to.y, 33, 36);
   const instructions: PaintInstruction[] = [
@@ -596,6 +658,14 @@ function edge(
     instructions.push(...centerText(label, midX, midY + 4, 10, color));
   }
   return instructions;
+}
+
+function edgeColorForNode(nodeId: string): string {
+  let hash = 0;
+  for (let index = 0; index < nodeId.length; index += 1) {
+    hash = (hash * 31 + nodeId.charCodeAt(index)) >>> 0;
+  }
+  return EDGE_PALETTE[hash % EDGE_PALETTE.length]!;
 }
 
 function shortenSegment(
@@ -666,14 +736,6 @@ function verticalPositions(count: number, top: number, bottom: number): number[]
   }
   const span = bottom - top;
   return Array.from({ length: count }, (_, index) => top + (span * index) / (count - 1));
-}
-
-function horizontalPositions(count: number, left: number, right: number): number[] {
-  if (count <= 1) {
-    return [(left + right) / 2];
-  }
-  const span = right - left;
-  return Array.from({ length: count }, (_, index) => left + (span * index) / (count - 1));
 }
 
 function gradientShape(rows: readonly (readonly number[])[] | undefined): string {

--- a/code/programs/typescript/ml-learning-visualizer/src/neural-vm.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/neural-vm.ts
@@ -3,9 +3,13 @@ import {
   type ActivationKind,
 } from "@coding-adventures/neural-network";
 import {
+  WebGpuMatrixBackend,
   compileBytecodeToMatrixPlan,
   compileNeuralNetworkToBytecode,
   runNeuralMatrixForward,
+  runNeuralMatrixForwardAsync,
+  type NeuralMatrixInputs,
+  type NeuralMatrixPlan,
 } from "@coding-adventures/neural-graph-vm";
 import type {
   ActivationName,
@@ -24,6 +28,8 @@ export interface VmRunMetadata {
   readonly matrixInstructionCount: number;
 }
 
+export type MatrixExecutionBackend = "cpu" | "webgpu";
+
 export interface LinearVmRun extends VmRunMetadata {
   readonly predictions: number[];
 }
@@ -34,6 +40,11 @@ export interface TwoLayerVmRun extends VmRunMetadata {
 
 export interface LayeredVmRun extends VmRunMetadata {
   readonly predictions: MatrixData;
+}
+
+export interface AcceleratedLayeredVmRun extends LayeredVmRun {
+  readonly backend: MatrixExecutionBackend;
+  readonly fallbackReason?: string;
 }
 
 export function predictLinearWithVm(
@@ -131,6 +142,79 @@ export function predictLayeredWithVm(
     readonly outputNames?: readonly string[];
   } = {},
 ): LayeredVmRun {
+  const compiled = compileLayeredMatrixPlan(inputs, parameters, options);
+  const result = runNeuralMatrixForward(compiled.matrixPlan, compiled.matrixInputs);
+  const predictions = collectMatrixPredictions(inputs, compiled.outputNames, result.outputs);
+
+  return {
+    predictions,
+    bytecodeInstructionCount: compiled.bytecodeInstructionCount,
+    matrixInstructionCount: compiled.matrixInstructionCount,
+  };
+}
+
+export async function predictLayeredWithBestMatrixBackend(
+  inputs: MatrixData,
+  parameters: LayeredParameters,
+  options: {
+    readonly inputNames?: readonly string[];
+    readonly outputNames?: readonly string[];
+  } = {},
+): Promise<AcceleratedLayeredVmRun> {
+  const compiled = compileLayeredMatrixPlan(inputs, parameters, options);
+  const gpuProbe = await getWebGpuBackendProbe();
+
+  if (gpuProbe.backend !== null) {
+    const result = await runNeuralMatrixForwardAsync(
+      compiled.matrixPlan,
+      compiled.matrixInputs,
+      gpuProbe.backend,
+    );
+    return {
+      predictions: collectMatrixPredictions(inputs, compiled.outputNames, result.outputs),
+      bytecodeInstructionCount: compiled.bytecodeInstructionCount,
+      matrixInstructionCount: compiled.matrixInstructionCount,
+      backend: "webgpu",
+    };
+  }
+
+  const result = runNeuralMatrixForward(compiled.matrixPlan, compiled.matrixInputs);
+  return {
+    predictions: collectMatrixPredictions(inputs, compiled.outputNames, result.outputs),
+    bytecodeInstructionCount: compiled.bytecodeInstructionCount,
+    matrixInstructionCount: compiled.matrixInstructionCount,
+    backend: "cpu",
+    fallbackReason: gpuProbe.reason,
+  };
+}
+
+export function canUseWebGpuMatrixBackend(): boolean {
+  return WebGpuMatrixBackend.isNavigatorAvailable();
+}
+
+interface LayeredMatrixCompilation {
+  readonly matrixPlan: NeuralMatrixPlan;
+  readonly matrixInputs: NeuralMatrixInputs;
+  readonly outputNames: readonly string[];
+  readonly bytecodeInstructionCount: number;
+  readonly matrixInstructionCount: number;
+}
+
+interface WebGpuBackendProbe {
+  readonly backend: WebGpuMatrixBackend | null;
+  readonly reason?: string;
+}
+
+let webGpuBackendProbe: Promise<WebGpuBackendProbe> | undefined;
+
+function compileLayeredMatrixPlan(
+  inputs: MatrixData,
+  parameters: LayeredParameters,
+  options: {
+    readonly inputNames?: readonly string[];
+    readonly outputNames?: readonly string[];
+  },
+): LayeredMatrixCompilation {
   const firstLayer = parameters.layers[0];
   const lastLayer = parameters.layers[parameters.layers.length - 1];
   if (firstLayer === undefined || lastLayer === undefined) {
@@ -165,16 +249,52 @@ export function predictLayeredWithVm(
       inputs.map((row) => row[inputIndex] ?? 0),
     ]),
   );
-  const result = runNeuralMatrixForward(matrixPlan, matrixInputs);
-  const predictions = inputs.map((_, rowIndex) => (
-    outputNames.map((name) => result.outputs[name]?.[rowIndex] ?? 0)
-  ));
-
   return {
-    predictions,
+    matrixPlan,
+    matrixInputs,
+    outputNames,
     bytecodeInstructionCount: bytecode.functions[0]?.instructions.length ?? 0,
     matrixInstructionCount: matrixPlan.instructions.length,
   };
+}
+
+function collectMatrixPredictions(
+  inputs: MatrixData,
+  outputNames: readonly string[],
+  outputs: Record<string, readonly number[]>,
+): MatrixData {
+  return inputs.map((_, rowIndex) => (
+    outputNames.map((name) => outputs[name]?.[rowIndex] ?? 0)
+  ));
+}
+
+async function getWebGpuBackendProbe(): Promise<WebGpuBackendProbe> {
+  webGpuBackendProbe ??= createWebGpuBackendProbe();
+  return webGpuBackendProbe;
+}
+
+async function createWebGpuBackendProbe(): Promise<WebGpuBackendProbe> {
+  if (!WebGpuMatrixBackend.isNavigatorAvailable()) {
+    return {
+      backend: null,
+      reason: "WebGPU is not exposed by this browser",
+    };
+  }
+
+  try {
+    const backend = await WebGpuMatrixBackend.createFromNavigator({
+      powerPreference: "high-performance",
+    });
+    return {
+      backend,
+      reason: backend === null ? "WebGPU is not exposed by this browser" : undefined,
+    };
+  } catch (error) {
+    return {
+      backend: null,
+      reason: error instanceof Error ? error.message : "WebGPU initialization failed",
+    };
+  }
 }
 
 function toGraphActivation(activation: ActivationName): ActivationKind {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -592,14 +592,16 @@ h2 {
 
 .network-svg {
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   border-radius: 8px;
   background: #ffffff;
 }
 
 .network-svg svg {
   display: block;
-  width: 100%;
+  width: auto;
+  min-width: 100%;
+  max-width: none;
   height: auto;
 }
 


### PR DESCRIPTION
## Summary

- Add an async neural matrix backend contract and default async CPU runner alongside the existing synchronous matrix path.
- Implement a browser WebGPU matrix backend with WGSL kernels for scale, add, and activation, plus GPU readback/disposal for batched forward prediction.
- Wire the hidden-layer visualizer to prefer WebGPU for batched row, curve, and surface predictions when `navigator.gpu` is available, with CPU fallback otherwise.
- Expand the neural graph Paint VM layout so deeper hidden-layer networks get a larger scrollable canvas, and color hidden graph edges by source node.

## Validation

- `npm test` in `code/packages/typescript/neural-graph-vm`
- `npm run build` in `code/packages/typescript/neural-graph-vm`
- `npm test` in `code/programs/typescript/ml-learning-visualizer`
- `npm run build` in `code/programs/typescript/ml-learning-visualizer`
- In-app browser smoke test on `http://127.0.0.1:5174/coding-adventures/ml-learning/`: switched to Hidden Layer mode, set hidden layers to 4, confirmed Matrix backend reports WebGPU, larger graph SVG is scrollable, and console errors are absent.

## Notes

`npx tsc --noEmit` from the visualizer package still reports pre-existing cross-package TypeScript issues in Lattice/parser/two-layer-network packages; this change's local TypeScript errors were cleared and the targeted package builds pass.