### PR TITLE
feat(prolog): add current_op reflection

### DIFF
--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -144,6 +144,7 @@ from logic_engine import (
     goal_from_term,
     logic_list,
     native_goal,
+    num,
     reify,
     relation,
     solve_from,
@@ -165,7 +166,7 @@ from logic_stdlib import (
     selecto,
     sorto,
 )
-from prolog_core import expand_dcg_phrase
+from prolog_core import OperatorTable, expand_dcg_phrase
 from prolog_parser import PrologParseError
 from swi_prolog_parser import parse_swi_term
 
@@ -177,7 +178,11 @@ _VARIABLE_RE = re.compile(r"^(?:[A-Z_][A-Za-z0-9_]*)$")
 type IndicatorBuilder = Callable[[Term, Term], GoalExpr]
 
 
-def adapt_prolog_goal(goal: GoalExpr) -> GoalExpr:
+def adapt_prolog_goal(
+    goal: GoalExpr,
+    *,
+    operator_table: OperatorTable | None = None,
+) -> GoalExpr:
     """Adapt parsed Prolog builtin calls into executable runtime goals.
 
     Goals with no builtin mapping are returned unchanged, so ordinary predicate
@@ -185,14 +190,24 @@ def adapt_prolog_goal(goal: GoalExpr) -> GoalExpr:
     """
 
     if isinstance(goal, RelationCall):
-        return _adapt_relation_call(goal)
+        return _adapt_relation_call(goal, operator_table=operator_table)
     if isinstance(goal, ConjExpr):
-        return conj(*(adapt_prolog_goal(child) for child in goal.goals))
+        return conj(
+            *(
+                adapt_prolog_goal(child, operator_table=operator_table)
+                for child in goal.goals
+            ),
+        )
     if isinstance(goal, DisjExpr):
-        if_then_else = _adapt_if_then_else(goal)
+        if_then_else = _adapt_if_then_else(goal, operator_table=operator_table)
         if if_then_else is not None:
             return if_then_else
-        return disj(*(adapt_prolog_goal(child) for child in goal.goals))
+        return disj(
+            *(
+                adapt_prolog_goal(child, operator_table=operator_table)
+                for child in goal.goals
+            ),
+        )
     if isinstance(goal, NeqExpr):
         # Prolog \=/2 is immediate non-unifiability, unlike the engine's
         # delayed disequality constraint.
@@ -200,12 +215,16 @@ def adapt_prolog_goal(goal: GoalExpr) -> GoalExpr:
     if isinstance(goal, FreshExpr):
         return FreshExpr(
             template_vars=goal.template_vars,
-            body=adapt_prolog_goal(goal.body),
+            body=adapt_prolog_goal(goal.body, operator_table=operator_table),
         )
     return goal
 
 
-def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
+def _adapt_relation_call(
+    goal: RelationCall,
+    *,
+    operator_table: OperatorTable | None,
+) -> GoalExpr:
     name = goal.relation.symbol.name
     args = goal.args
 
@@ -344,8 +363,8 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
             extended_call = _extend_callable_term(args[0], args[1:])
             if extended_call is None:
                 return calltermo(args[0], *args[1:])
-            return _adapt_callable_goal(extended_call)
-        return _adapt_callable_goal(args[0])
+            return _adapt_callable_goal(extended_call, operator_table=operator_table)
+        return _adapt_callable_goal(args[0], operator_table=operator_table)
     if name == "phrase" and goal.relation.arity == 2:
         try:
             return calltermo(expand_dcg_phrase(args[0], args[1]))
@@ -357,42 +376,52 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         except TypeError:
             return goal
     if name == "once" and goal.relation.arity == 1:
-        return onceo(_adapt_callable_goal(args[0]))
+        return onceo(_adapt_callable_goal(args[0], operator_table=operator_table))
     if name == "throw" and goal.relation.arity == 1:
         return throwo(args[0])
     if name == "catch" and goal.relation.arity == 3:
         return catcho(
-            _adapt_callable_goal(args[0]),
+            _adapt_callable_goal(args[0], operator_table=operator_table),
             args[1],
-            _adapt_callable_goal(args[2]),
+            _adapt_callable_goal(args[2], operator_table=operator_table),
         )
     if name == _IF_THEN and goal.relation.arity == 2:
-        return iftheno(_adapt_callable_goal(args[0]), _adapt_callable_goal(args[1]))
+        return iftheno(
+            _adapt_callable_goal(args[0], operator_table=operator_table),
+            _adapt_callable_goal(args[1], operator_table=operator_table),
+        )
     if name in {"not", "\\+"} and goal.relation.arity == 1:
-        return noto(_adapt_callable_goal(args[0]))
+        return noto(_adapt_callable_goal(args[0], operator_table=operator_table))
     if name == "findall" and goal.relation.arity == 3:
         return findallo(
             args[0],
-            _adapt_collection_goal(args[1]),
+            _adapt_collection_goal(args[1], operator_table=operator_table),
             args[2],
             scope=args[1],
         )
     if name == "bagof" and goal.relation.arity == 3:
         return bagofo(
             args[0],
-            _adapt_collection_goal(args[1]),
+            _adapt_collection_goal(args[1], operator_table=operator_table),
             args[2],
             scope=args[1],
         )
     if name == "setof" and goal.relation.arity == 3:
         return setofo(
             args[0],
-            _adapt_collection_goal(args[1]),
+            _adapt_collection_goal(args[1], operator_table=operator_table),
             args[2],
             scope=args[1],
         )
     if name == "forall" and goal.relation.arity == 2:
-        return forallo(_adapt_callable_goal(args[0]), _adapt_callable_goal(args[1]))
+        return forallo(
+            _adapt_callable_goal(args[0], operator_table=operator_table),
+            _adapt_callable_goal(args[1], operator_table=operator_table),
+        )
+    if name == "current_op" and goal.relation.arity == 3:
+        if operator_table is None:
+            return goal
+        return _current_op_goal(operator_table, *args)
     if name == "labeling" and goal.relation.arity == 2:
         return labeling_optionso(args[0], args[1])
     if name == "label" and goal.relation.arity == 1:
@@ -513,6 +542,32 @@ def _adapt_relation_call(goal: RelationCall) -> GoalExpr:
         return goal if property_goal is None else property_goal
 
     return goal
+
+
+def _current_op_goal(
+    operator_table: OperatorTable,
+    precedence: object,
+    associativity: object,
+    name: object,
+) -> GoalExpr:
+    def run(
+        program_value: Program,
+        state: State,
+        args: tuple[Term, ...],
+    ) -> Iterator[State]:
+        precedence_target, associativity_target, name_target = args
+        for spec in operator_table.operators:
+            yield from solve_from(
+                program_value,
+                conj(
+                    eq(precedence_target, num(spec.precedence)),
+                    eq(associativity_target, atom(spec.associativity)),
+                    eq(name_target, atom(spec.symbol)),
+                ),
+                state,
+            )
+
+    return native_goal(run, precedence, associativity, name)
 
 
 def _term_to_atom_goal(term_value: object, atom_value: object) -> GoalExpr:
@@ -961,7 +1016,11 @@ def _adapt_fd_ins(targets: Term, domain: Term) -> GoalExpr | None:
     return conj(*(fd_ino(item, domain) for item in items))
 
 
-def _adapt_if_then_else(goal: DisjExpr) -> GoalExpr | None:
+def _adapt_if_then_else(
+    goal: DisjExpr,
+    *,
+    operator_table: OperatorTable | None,
+) -> GoalExpr | None:
     if len(goal.goals) != 2:
         return None
     condition_then, else_goal = goal.goals
@@ -973,23 +1032,37 @@ def _adapt_if_then_else(goal: DisjExpr) -> GoalExpr | None:
         return None
     condition, then_goal = condition_then.args
     return ifthenelseo(
-        _adapt_callable_goal(condition),
-        _adapt_callable_goal(then_goal),
-        adapt_prolog_goal(else_goal),
+        _adapt_callable_goal(condition, operator_table=operator_table),
+        _adapt_callable_goal(then_goal, operator_table=operator_table),
+        adapt_prolog_goal(else_goal, operator_table=operator_table),
     )
 
 
-def _adapt_callable_goal(term_value: Term) -> GoalExpr:
+def _adapt_callable_goal(
+    term_value: Term,
+    *,
+    operator_table: OperatorTable | None = None,
+) -> GoalExpr:
     try:
-        return adapt_prolog_goal(goal_from_term(term_value))
+        return adapt_prolog_goal(
+            goal_from_term(term_value),
+            operator_table=operator_table,
+        )
     except TypeError:
         return calltermo(term_value)
 
 
-def _adapt_collection_goal(term_value: Term) -> GoalExpr:
+def _adapt_collection_goal(
+    term_value: Term,
+    *,
+    operator_table: OperatorTable | None = None,
+) -> GoalExpr:
     """Adapt the executable side of a collector goal, stripping ``^/2`` scopes."""
 
-    return _adapt_callable_goal(_strip_collection_existentials(term_value))
+    return _adapt_callable_goal(
+        _strip_collection_existentials(term_value),
+        operator_table=operator_table,
+    )
 
 
 def _strip_collection_existentials(term_value: Term) -> Term:

--- a/code/packages/python/prolog-loader/src/prolog_loader/loader.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/loader.py
@@ -470,10 +470,14 @@ def run_prolog_initialization_goals(
 ) -> State:
     """Run initialization directives with the shared Prolog builtin adapter."""
 
+    operator_table = getattr(loaded_source, "operator_table", None)
     return run_initialization_goals(
         loaded_source,
         state=state,
-        goal_adapter=adapt_prolog_goal,
+        goal_adapter=lambda goal_value: adapt_prolog_goal(
+            goal_value,
+            operator_table=operator_table,
+        ),
     )
 
 

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -1149,6 +1149,24 @@ class TestPrologGoalAdapter:
             logic_list(["bart", "lisa", "maggie"]),
         ]
 
+    def test_adapt_prolog_goal_enumerates_loaded_operator_table(self) -> None:
+        loaded = load_swi_prolog_source(
+            """
+            :- op(500, yfx, ++).
+            ?- current_op(500, Type, '++').
+            """,
+        )
+        query = loaded.queries[0]
+
+        adapted = adapt_prolog_goal(
+            query.goal,
+            operator_table=loaded.operator_table,
+        )
+
+        assert solve_all(loaded.program, query.variables["Type"], adapted) == [
+            atom("yfx"),
+        ]
+
     def test_adapt_prolog_goal_rewrites_if_then_else_control(self) -> None:
         parsed = parse_swi_query(
             "?- ((X = first ; X = second) -> Result = X ; Result = none).",

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/compiler.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/compiler.py
@@ -155,7 +155,11 @@ class PrologVMRuntime:
         parsed_query = self._parse_query(source)
         if self.query_rewriter is not None:
             parsed_query = self.query_rewriter(parsed_query)
-        goal = _adapt_goal(parsed_query.goal, adapt_builtins=self.adapt_builtins)
+        goal = _adapt_goal(
+            parsed_query.goal,
+            adapt_builtins=self.adapt_builtins,
+            operator_table=self.operator_table,
+        )
         outputs = tuple(parsed_query.variables.values())
         proof_states = solve_from(self.vm.assembled_program(), goal, self.state)
 
@@ -229,6 +233,7 @@ def compile_loaded_prolog_source(
         loaded_source.initialization_goals,
         loaded_source.program,
         adapt_builtins=adapt_builtins,
+        operator_table=loaded_source.operator_table,
     )
 
 
@@ -245,6 +250,7 @@ def compile_loaded_prolog_project(
         loaded_project.initialization_goals,
         loaded_project.program,
         adapt_builtins=adapt_builtins,
+        operator_table=_project_operator_table(loaded_project),
     )
 
 
@@ -531,17 +537,30 @@ def _compile_loaded_prolog(
     program_value: Program,
     *,
     adapt_builtins: bool,
+    operator_table: OperatorTable | None = None,
 ) -> CompiledPrologVMProgram:
     adapted_clauses = tuple(
-        _adapt_clause(clause_value, adapt_builtins=adapt_builtins)
+        _adapt_clause(
+            clause_value,
+            adapt_builtins=adapt_builtins,
+            operator_table=operator_table,
+        )
         for clause_value in clauses
     )
     adapted_initialization_goals = tuple(
-        _adapt_goal(goal_value, adapt_builtins=adapt_builtins)
+        _adapt_goal(
+            goal_value,
+            adapt_builtins=adapt_builtins,
+            operator_table=operator_table,
+        )
         for goal_value in initialization_goals
     )
     adapted_source_queries = tuple(
-        _adapt_query(query_value, adapt_builtins=adapt_builtins)
+        _adapt_query(
+            query_value,
+            adapt_builtins=adapt_builtins,
+            operator_table=operator_table,
+        )
         for query_value in source_queries
     )
 
@@ -592,27 +611,46 @@ def _compile_loaded_prolog(
     )
 
 
-def _adapt_clause(clause_value: Clause, *, adapt_builtins: bool) -> Clause:
+def _adapt_clause(
+    clause_value: Clause,
+    *,
+    adapt_builtins: bool,
+    operator_table: OperatorTable | None,
+) -> Clause:
     if clause_value.body is None:
         return clause_value
     return Clause(
         head=clause_value.head,
-        body=_adapt_goal(clause_value.body, adapt_builtins=adapt_builtins),
+        body=_adapt_goal(
+            clause_value.body,
+            adapt_builtins=adapt_builtins,
+            operator_table=operator_table,
+        ),
     )
 
 
-def _adapt_goal(goal_value: GoalExpr, *, adapt_builtins: bool) -> GoalExpr:
+def _adapt_goal(
+    goal_value: GoalExpr,
+    *,
+    adapt_builtins: bool,
+    operator_table: OperatorTable | None,
+) -> GoalExpr:
     if not adapt_builtins:
         return goal_value
-    return adapt_prolog_goal(goal_value)
+    return adapt_prolog_goal(goal_value, operator_table=operator_table)
 
 
-def _adapt_query(query_value: ParsedQuery, *, adapt_builtins: bool) -> ParsedQuery:
+def _adapt_query(
+    query_value: ParsedQuery,
+    *,
+    adapt_builtins: bool,
+    operator_table: OperatorTable | None,
+) -> ParsedQuery:
     goal_value = query_value.goal
     if not adapt_builtins:
         return query_value
     return ParsedQuery(
-        goal=adapt_prolog_goal(goal_value),
+        goal=adapt_prolog_goal(goal_value, operator_table=operator_table),
         variables=query_value.variables,
     )
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_compiler.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_compiler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from logic_engine import atom, relation
+from logic_engine import atom, num, relation
 from logic_instructions import (
     DynamicRelationDefInstruction,
     FactInstruction,
@@ -16,6 +16,7 @@ from prolog_vm_compiler import (
     __version__,
     compile_swi_prolog_project,
     compile_swi_prolog_source,
+    create_swi_prolog_vm_runtime,
     load_compiled_prolog_vm,
     run_compiled_prolog_queries,
     run_compiled_prolog_query,
@@ -127,6 +128,29 @@ class TestPrologVMCompiler:
         )
 
         assert run_compiled_prolog_query(compiled) == [()]
+
+    def test_compiles_current_op_against_loaded_operator_table(self) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            :- op(500, yfx, ++).
+            ?- current_op(P, Type, '++').
+            """,
+        )
+
+        assert run_compiled_prolog_query(compiled) == [
+            (num(500), atom("yfx")),
+        ]
+
+    def test_runtime_current_op_uses_ad_hoc_query_operator_table(self) -> None:
+        runtime = create_swi_prolog_vm_runtime(
+            """
+            :- op(450, xfx, <=>).
+            """,
+        )
+
+        assert runtime.query_values("?- current_op(P, Type, '<=>').") == [
+            (num(450), atom("xfx")),
+        ]
 
     def test_preserves_initialization_queries_before_source_queries(self) -> None:
         compiled = compile_swi_prolog_source(

--- a/code/specs/PR63-prolog-current-op-reflection.md
+++ b/code/specs/PR63-prolog-current-op-reflection.md
@@ -1,0 +1,31 @@
+# PR63: Prolog Operator Reflection
+
+## Status
+
+Implemented for the Python Prolog loader and Logic VM compiler path.
+
+## Goal
+
+Expose loaded Prolog operator declarations through `current_op/3` so source
+programs and ad-hoc VM queries can inspect the same operator table that the
+parser used.
+
+## Behavior
+
+- `current_op(Precedence, Type, Name)` enumerates every operator declaration in
+  the active source operator table.
+- `Precedence` is unified with a numeric term.
+- `Type` is unified with the associativity atom, such as `xfx`, `xfy`, `yfx`,
+  `fx`, `fy`, `xf`, or `yf`.
+- `Name` is unified with the operator atom.
+- Custom `op/3` directives are visible after loading, compiling, and running
+  through the Logic VM.
+- Ad-hoc VM runtime queries use the loaded source operator table, so later
+  queries can reflect custom operators declared by the source.
+
+## Layering
+
+The operator table remains parser and loader metadata. The Prolog goal adapter
+receives that table explicitly when source is lowered into executable VM goals,
+which keeps the Logic VM instruction format independent of Prolog-specific
+parser state while still making operator reflection executable.


### PR DESCRIPTION
## Summary
- Thread loaded Prolog operator tables through builtin adaptation and VM compilation.
- Implement `current_op/3` over the active parser/operator table, including custom `op/3` declarations.
- Add loader and VM compiler/runtime coverage plus PR63 spec notes.

## Verification
- `./.venv/bin/ruff check . --fix` in `code/packages/python/prolog-loader`
- `./.venv/bin/ruff check . --fix` in `code/packages/python/prolog-vm-compiler`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `git diff --check HEAD~1 HEAD`
- `/tmp/ca-build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-current-op-build-plan.json`