### PR TITLE
Support richer ALGOL source notation

### DIFF
--- a/code/grammars/algol.tokens
+++ b/code/grammars/algol.tokens
@@ -11,13 +11,14 @@
 # No column restrictions (unlike Fortran 77 and COBOL, which were punched-card-based).
 #
 # Character set note: The ALGOL 60 report used mathematical typographic symbols
-# (≤, ≥, ≠, ↑, ∧, ∨, ¬, ⊃, ≡) that could not be printed on real hardware of the era.
-# Every hardware implementation mapped these to ASCII sequences. This grammar uses
-# the ASCII conventions that became standard.
+# (≤, ≥, ≠, ↑, ×, ÷, ∧, ∨, ¬, ⊃, ≡) that could not be printed on real
+# hardware of the era. Every hardware implementation mapped these to ASCII
+# sequences. This grammar accepts both the publication symbols and the ASCII
+# conventions that became standard.
 #
 # Key ordering rules (first match wins):
 #   :=  must come before  :   (ASSIGN before COLON)
-#   **  must come before  *   (POWER before STAR)
+#   **  must come before  * and ×   (POWER before STAR)
 #   <=  must come before  <   (LEQ before LT)
 #   >=  must come before  >   (GEQ before GT)
 #   !=  must come before any single-char use of !
@@ -74,8 +75,10 @@ NEQ         = "!="
 
 PLUS        = "+"
 MINUS       = "-"
-STAR        = "*"
-SLASH       = "/"
+# Multiplication and real division. The publication symbols normalize to the
+# same token values as the ASCII spellings in the ALGOL lexer wrapper.
+STAR        = /\*|×/
+SLASH       = /\/|÷/
 
 # Caret: alternative to ** for exponentiation.
 # Both ^ and ** produce different token kinds so the parser can treat them

--- a/code/grammars/algol/algol60.tokens
+++ b/code/grammars/algol/algol60.tokens
@@ -11,13 +11,14 @@
 # No column restrictions (unlike Fortran 77 and COBOL, which were punched-card-based).
 #
 # Character set note: The ALGOL 60 report used mathematical typographic symbols
-# (≤, ≥, ≠, ↑, ∧, ∨, ¬, ⊃, ≡) that could not be printed on real hardware of the era.
-# Every hardware implementation mapped these to ASCII sequences. This grammar uses
-# the ASCII conventions that became standard.
+# (≤, ≥, ≠, ↑, ×, ÷, ∧, ∨, ¬, ⊃, ≡) that could not be printed on real
+# hardware of the era. Every hardware implementation mapped these to ASCII
+# sequences. This grammar accepts both the publication symbols and the ASCII
+# conventions that became standard.
 #
 # Key ordering rules (first match wins):
 #   :=  must come before  :   (ASSIGN before COLON)
-#   **  must come before  *   (POWER before STAR)
+#   **  must come before  * and ×   (POWER before STAR)
 #   <= and ≤ must come before  <   (LEQ before LT)
 #   >= and ≥ must come before  >   (GEQ before GT)
 #   !=, <>, and ≠ must come before any single-char use of !, <, or >
@@ -84,8 +85,10 @@ EQV_SYM     = "≡"
 
 PLUS        = "+"
 MINUS       = "-"
-STAR        = "*"
-SLASH       = "/"
+# Multiplication and real division. The publication symbols normalize to the
+# same token values as the ASCII spellings in the ALGOL lexer wrapper.
+STAR        = /\*|×/
+SLASH       = /\/|÷/
 
 # Caret: alternative to ** for exponentiation. The ALGOL publication uparrow
 # is normalized to the same token/value shape as caret.

--- a/code/packages/python/algol-lexer/CHANGELOG.md
+++ b/code/packages/python/algol-lexer/CHANGELOG.md
@@ -14,8 +14,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Accepted `COMMENT`/mixed-case `comment` as comment starters while preserving
   identifiers such as `commentary` through keyword-boundary matching.
 - Accepted `<>` as an alternate ASCII spelling for ALGOL not-equal.
-- Accepted ALGOL publication symbols `≤`, `≥`, `≠`, `↑`, `∧`, `∨`, `¬`, `⊃`,
-  and `≡`, normalizing them to the existing ASCII or keyword token values.
+- Accepted ALGOL publication symbols `≤`, `≥`, `≠`, `↑`, `×`, `÷`, `∧`, `∨`,
+  `¬`, `⊃`, and `≡`, normalizing them to the existing ASCII or keyword token
+  values.
 - Accepted double-quoted string literals in addition to single-quoted strings.
 
 ## [0.1.0] — 2026-04-06

--- a/code/packages/python/algol-lexer/README.md
+++ b/code/packages/python/algol-lexer/README.md
@@ -125,8 +125,8 @@ matching is done after normalizing to lowercase.
 
 ALGOL 60 publication symbols normalize to the same token values as the ASCII or
 word spellings used by the parser and compiler: `≤` to `<=`, `≥` to `>=`, `≠`
-to `!=`, `↑` to `^`, and `¬`, `∧`, `∨`, `⊃`, `≡` to `not`, `and`, `or`,
-`impl`, `eqv`.
+to `!=`, `↑` to `^`, `×` to `*`, `÷` to `/`, and `¬`, `∧`, `∨`, `⊃`, `≡`
+to `not`, `and`, `or`, `impl`, `eqv`.
 
 ### String Literals
 

--- a/code/packages/python/algol-lexer/src/algol_lexer/tokenizer.py
+++ b/code/packages/python/algol-lexer/src/algol_lexer/tokenizer.py
@@ -177,6 +177,8 @@ _SYMBOLIC_OPERATOR_VALUES = {
     "GEQ": {"≥": ">="},
     "NEQ": {"≠": "!="},
     "CARET": {"↑": "^"},
+    "STAR": {"×": "*"},
+    "SLASH": {"÷": "/"},
 }
 
 
@@ -254,9 +256,9 @@ def create_algol_lexer(source: str, version: str = "algol60") -> GrammarLexer:
       token ``beginning`` does not match the keyword ``begin``.
     - **Case insensitivity**: ``BEGIN``, ``Begin``, and ``begin`` all produce
       the same token kind. The grammar normalizes to lowercase.
-    - **Publication symbols**: ``≤``, ``≥``, ``≠``, ``↑``, ``∧``, ``∨``,
-      ``¬``, ``⊃``, and ``≡`` normalize to the same token stream as their
-      ASCII or word spellings.
+    - **Publication symbols**: ``≤``, ``≥``, ``≠``, ``↑``, ``×``, ``÷``,
+      ``∧``, ``∨``, ``¬``, ``⊃``, and ``≡`` normalize to the same token
+      stream as their ASCII or word spellings.
     - **Comment skipping**: ``comment text;`` is consumed without emitting
       any token, and the keyword is matched case-insensitively.
     - **Operator ordering**: ``:=`` is matched before ``:``, ``**`` before
@@ -304,7 +306,8 @@ def tokenize_algol(source: str, version: str = "algol60") -> list[Token]:
     - **ASSIGN** (``:=``), **POWER** (``**``), **CARET** (``^`` or ``↑``)
     - **LEQ** (``<=`` or ``≤``), **GEQ** (``>=`` or ``≥``),
       **NEQ** (``!=``, ``<>``, or ``≠``)
-    - **PLUS**, **MINUS**, **STAR**, **SLASH**, **EQ**, **LT**, **GT**
+    - **PLUS**, **MINUS**, **STAR** (``*`` or ``×``), **SLASH** (``/`` or
+      ``÷``), **EQ**, **LT**, **GT**
 
     Delimiters:
     - **LPAREN**, **RPAREN**, **LBRACKET**, **RBRACKET**

--- a/code/packages/python/algol-lexer/tests/test_algol_lexer.py
+++ b/code/packages/python/algol-lexer/tests/test_algol_lexer.py
@@ -260,6 +260,11 @@ class TestOperators:
         assert token_types("↑") == ["CARET"]
         assert token_values("↑") == ["^"]
 
+    def test_publication_symbol_multiply_and_divide(self) -> None:
+        """``×`` and ``÷`` normalize to ASCII arithmetic operators."""
+        assert token_types("× ÷") == ["STAR", "SLASH"]
+        assert token_values("× ÷") == ["*", "/"]
+
     def test_leq(self) -> None:
         """``<=`` is a single LEQ token, not LT EQ."""
         types = token_types("<=")

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -71,13 +71,15 @@ All notable changes to this package will be documented in this file.
 - Accepted standard real builtin functions `sin`, `cos`, `arctan`, `ln`, and
   `exp`, returning `real` for integer or real arguments while preserving
   read-only by-name analysis.
+- Resolved standard numeric and output builtins case-insensitively while
+  preserving normal identifier casing for user declarations.
 - Added configurable type-check resource limits for maximum AST depth, block
   nesting depth, and procedure nesting depth so recursive semantic visitors
   reject hostile inputs with diagnostics before walking too deeply.
 - Accepted shared lexer front-door spellings for uppercase keywords/comments,
   `<>` not-equal relations, and double-quoted string literals.
 - Accepted shared lexer front-door publication symbols for relations,
-  exponentiation, and boolean operators.
+  exponentiation, multiplication, real division, and boolean operators.
 - Accepted subscripted integer and real array elements as `for` statement
   control variables.
 

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -20,7 +20,8 @@ exponents.
 Mixed integer/real conditional branches resolve to `real`; incompatible branch
 types are still rejected before IR lowering. Standard numeric functions
 `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`, `arctan`, `ln`, and `exp` are
-resolved as read-only builtins with integer/real argument validation.
+resolved case-insensitively as read-only builtins with integer/real argument
+validation.
 
 The checker also builds the first ALGOL 60 full-runtime semantic model. Each
 source block receives a stable block id, lexical depth, static-parent id, and a
@@ -31,9 +32,9 @@ Procedure declarations receive semantic descriptors with generated function
 labels, parameter slots, value-vs-name parameter modes, conservative by-name
 write metadata, result slots for typed procedures, and resolved call sites
 carrying the static-link delta needed by code generation. Builtin output calls
-and standard numeric functions are treated as read-only by the write analysis,
-so formals that are only printed or inspected can still accept expression
-actuals.
+and standard numeric functions are resolved case-insensitively and treated as
+read-only by the write analysis, so formals that are only printed or inspected
+can still accept expression actuals.
 No-argument procedure declarations and typed procedure expressions may use
 either explicit empty parentheses or bare procedure names, matching ALGOL's
 omitted-parentheses call syntax, while procedure result variables inside their

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -41,6 +41,14 @@ _NUMERIC_BUILTINS = {"abs"} | set(_FIXED_RETURN_NUMERIC_BUILTINS)
 _READ_ONLY_BUILTINS = _OUTPUT_BUILTINS | _NUMERIC_BUILTINS
 
 
+def _builtin_name(name: str | None) -> str | None:
+    """Return the canonical builtin spelling for a source-level callee name."""
+    if name is None:
+        return None
+    canonical = name.lower()
+    return canonical if canonical in _READ_ONLY_BUILTINS else None
+
+
 @dataclass(frozen=True)
 class Diagnostic:
     """A stage-friendly type-checking diagnostic."""
@@ -2006,7 +2014,7 @@ class AlgolTypeChecker:
                 )
             call = ResolvedProcedureCall(
                 token_id=id(name_token),
-                name=name_token.value,
+                name=descriptor.name,
                 role=role,
                 procedure_id=descriptor.procedure_id,
                 label=descriptor.label,
@@ -2105,7 +2113,8 @@ class AlgolTypeChecker:
         if not arguments:
             return None
         actual_type = self._infer_expr(arguments[0], scope)
-        if name_token.value in _OUTPUT_BUILTINS:
+        builtin_name = _builtin_name(name_token.value)
+        if builtin_name in _OUTPUT_BUILTINS:
             if actual_type != ERROR and actual_type not in {
                 INTEGER,
                 BOOLEAN,
@@ -2125,10 +2134,10 @@ class AlgolTypeChecker:
                 f"got {actual_type}",
             )
             return ERROR
-        if name_token.value == "abs":
+        if builtin_name == "abs":
             return actual_type
-        if name_token.value in _FIXED_RETURN_NUMERIC_BUILTINS:
-            return _FIXED_RETURN_NUMERIC_BUILTINS[name_token.value]
+        if builtin_name in _FIXED_RETURN_NUMERIC_BUILTINS:
+            return _FIXED_RETURN_NUMERIC_BUILTINS[builtin_name]
         return ERROR
 
     def _resolved_bare_procedure_expression(
@@ -2891,17 +2900,18 @@ class AlgolTypeChecker:
         token: Token,
         scope: Scope,
     ) -> tuple[ProcedureDescriptor, Scope, int] | None:
-        if token.value not in _READ_ONLY_BUILTINS:
+        builtin_name = _builtin_name(token.value)
+        if builtin_name is None:
             return None
         return_type = None
-        if token.value == "abs":
+        if builtin_name == "abs":
             return_type = INTEGER
-        elif token.value in _FIXED_RETURN_NUMERIC_BUILTINS:
-            return_type = _FIXED_RETURN_NUMERIC_BUILTINS[token.value]
+        elif builtin_name in _FIXED_RETURN_NUMERIC_BUILTINS:
+            return_type = _FIXED_RETURN_NUMERIC_BUILTINS[builtin_name]
         descriptor = ProcedureDescriptor(
             procedure_id=-1,
-            name=token.value,
-            label=f"__algol_builtin_{token.value}",
+            name=builtin_name,
+            label=f"__algol_builtin_{builtin_name}",
             declaring_block_id=scope.block_id,
             body_block_id=scope.block_id,
             body_node_id=-1,
@@ -3592,7 +3602,7 @@ def _callee_may_write_argument(
 ) -> bool:
     if callee_name is None:
         return True
-    if callee_name in _READ_ONLY_BUILTINS:
+    if _builtin_name(callee_name) is not None:
         return False
     procedure = known_procedures.get(callee_name)
     if procedure is None or argument_index >= len(procedure.parameters):

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -515,6 +515,31 @@ class TestAlgolTypeChecker:
         assert calls["ln"] == "real"
         assert calls["exp"] == "real"
 
+    def test_accepts_mixed_case_standard_builtin_functions(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real root; "
+            "root := Sqrt(9); "
+            "result := ABS(0 - 3) + Sign(root) + Entier(root) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        labels = {
+            call.label
+            for call in result.semantic.procedure_calls
+        }
+        names = {
+            call.name
+            for call in result.semantic.procedure_calls
+        }
+        assert {"abs", "sign", "entier", "sqrt"} <= names
+        assert "__algol_builtin_abs" in labels
+        assert "__algol_builtin_sign" in labels
+        assert "__algol_builtin_entier" in labels
+        assert "__algol_builtin_sqrt" in labels
+
     def test_rejects_boolean_actual_for_numeric_builtin_function(self) -> None:
         ast = parse_algol("begin integer result; result := abs(false) end")
         result = check_algol(ast)
@@ -1759,6 +1784,24 @@ class TestAlgolTypeChecker:
         ast = parse_algol(
             "begin integer result; "
             "procedure emit(s); string s; begin print(s); result := 7 end; "
+            "emit('Hi') "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        parameter = result.semantic.procedures[0].parameters[0]
+        assert parameter.type_name == "string"
+        assert parameter.mode == "name"
+        assert not parameter.may_write
+
+    def test_mixed_case_builtin_output_is_read_only_for_by_name_formal(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure emit(s); string s; begin PRINT(s); result := 7 end; "
             "emit('Hi') "
             "end"
         )

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -87,7 +87,10 @@ All notable changes to this package will be documented in this file.
 - Executed the report-style `go to` spelling through the full parser,
   type-checker, IR, and WASM pipeline.
 - Executed normalized ALGOL publication symbols for relations, exponentiation,
-  and boolean operators through the full WASM pipeline.
+  multiplication, real division, and boolean operators through the full WASM
+  pipeline.
+- Executed mixed-case standard numeric and output builtins through the full
+  WASM pipeline.
 - Executed standard numeric builtin functions `abs`, `sign`, and `entier`
   through the full parser, type-checker, IR, and WASM pipeline.
 - Executed standard real builtin function `sqrt` through the full parser,

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,9 +18,10 @@ the current lane already supports a substantial ALGOL 60 surface:
 - `own` scalars and arrays with static lifetime
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds and checked element access
-- case-insensitive keywords and comments, `!=`/`<>`/`≠` not-equal spelling,
-  ALGOL publication symbols such as `≤`, `≥`, `↑`, `¬`, `∧`, `∨`, `⊃`, `≡`,
-  and single- or double-quoted string literals
+- case-insensitive keywords, comments, and standard builtins,
+  `!=`/`<>`/`≠` not-equal spelling, ALGOL publication symbols such as `≤`,
+  `≥`, `↑`, `×`, `÷`, `¬`, `∧`, `∨`, `⊃`, `≡`, and single- or double-quoted
+  string literals
 - chained assignment, conditional expressions, tolerant trailing/repeated
   semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer or real exponents

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -256,6 +256,23 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [17]
 
+    def test_mixed_case_standard_builtin_functions_execute(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := SQRT(9); "
+            "result := ABS(0 - 7) + SIGN(x) + ENTIER(x) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [11]
+
+    def test_publication_multiply_and_divide_execute(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "result := 6 × 7 + entier(8 ÷ 2) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [46]
+
     def test_entier_floors_positive_and_negative_reals(self) -> None:
         result = compile_source(
             "begin integer result; real x; "
@@ -307,6 +324,14 @@ class TestAlgolWasmCompiler:
 
     def test_builtin_print_string_literal_writes_stdout(self) -> None:
         result = compile_source("begin integer result; print('Hi'); result := 7 end")
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [7]
+        assert "".join(captured) == "Hi"
+
+    def test_mixed_case_builtin_output_writes_stdout(self) -> None:
+        result = compile_source("begin integer result; PRINT('Hi'); result := 7 end")
         captured: list[str] = []
         runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
 


### PR DESCRIPTION
## Summary
- Accept ALGOL publication `×` and `÷` arithmetic symbols in both ALGOL token grammar locations, normalizing them to `*` and `/` before parser/type-checker/IR lowering.
- Resolve standard numeric and output builtins case-insensitively while preserving ordinary identifier casing for user symbols.
- Add lexer, type-checker, and WASM acceptance coverage for manuscript-style arithmetic and mixed-case builtins.

## Tests
- `python -m pytest tests/ -q` in `code/packages/python/algol-lexer`
- `python -m pytest tests/ -q` in `code/packages/python/algol-parser`
- `python -m pytest tests/ -q` in `code/packages/python/algol-type-checker`
- `python -m pytest tests/ -q` in `code/packages/python/algol-ir-compiler`
- `python -m pytest tests/ -q` in `code/packages/python/algol-wasm-compiler`
- `python -m ruff check ...` on touched Python files

## Security Review
- No new file, process, network, deserialization, host import, or shell execution paths.
- The existing token-grammar file read remains unchanged; the new symbols normalize inside the existing lexer post-processing pass.
- Builtin case folding only applies after ordinary procedure resolution fails and only for the existing read-only builtin set.