### PR TITLE
Handle form feed HTML lexer delimiters

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -177,6 +177,8 @@ documented in this file.
   and multi-integral aliases.
 - Completed semicolon-terminated WHATWG named-character-reference coverage with
   a final generated batch for the remaining aliases.
+- Treated form feed as an HTML ASCII-whitespace delimiter for script
+  double-escape boundaries and semicolonless legacy character references.
 - Added a WHATWG operator/shape named-reference batch covering circled
   operators, integrals, products, squares, lozenges, stars, suits, and symbols.
 - Added a WHATWG box-drawing named-reference batch covering double-line,

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -58,6 +58,9 @@ HTML tokenizer: text and RCDATA recover inputs such as `&copycat` as `©cat`
 with a missing-semicolon diagnostic, while attribute values preserve ambiguous
 ampersands like `&copycat` literally when the would-be reference is followed by
 an ASCII alphanumeric character or `=`.
+Form feed is treated as HTML ASCII whitespace in the generated delimiter
+paths, including script double-escape boundaries and semicolonless legacy named
+character references.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -1094,7 +1094,7 @@ actions = ["append_text(<)"]
 
 [[transitions]]
 from = "script_data_double_escape_start"
-matcher = { one_of = " \n\t\r/>" }
+matcher = { one_of = " \n\t\r\u000C/>" }
 to = "script_data_escaped"
 actions = [
   "append_text(current)",
@@ -1246,7 +1246,7 @@ consume = false
 
 [[transitions]]
 from = "script_data_double_escape_end"
-matcher = { one_of = " \n\t\r/>" }
+matcher = { one_of = " \n\t\r\u000C/>" }
 to = "script_data_double_escaped"
 actions = [
   "append_text(current)",
@@ -2848,7 +2848,7 @@ actions = [
 
 [[transitions]]
 from = "text_named_character_reference_copy"
-matcher = { one_of = " \n\t\r<>/\"'" }
+matcher = { one_of = " \n\t\r\u000C<>/\"'" }
 to = "data"
 consume = false
 actions = [
@@ -2965,7 +2965,7 @@ actions = [
 
 [[transitions]]
 from = "text_named_character_reference_nbsp"
-matcher = { one_of = " \n\t\r<>/\"'" }
+matcher = { one_of = " \n\t\r\u000C<>/\"'" }
 to = "data"
 consume = false
 actions = [
@@ -3056,7 +3056,7 @@ actions = [
 
 [[transitions]]
 from = "text_named_character_reference_reg"
-matcher = { one_of = " \n\t\r<>/\"'" }
+matcher = { one_of = " \n\t\r\u000C<>/\"'" }
 to = "data"
 consume = false
 actions = [
@@ -4783,7 +4783,7 @@ actions = [
 
 [[transitions]]
 from = "attribute_named_character_reference_copy"
-matcher = { one_of = " \n\t\r>/\"'" }
+matcher = { one_of = " \n\t\r\u000C>/\"'" }
 to = "attribute_value_unquoted"
 consume = false
 actions = [
@@ -4932,7 +4932,7 @@ actions = [
 
 [[transitions]]
 from = "attribute_named_character_reference_nbsp"
-matcher = { one_of = " \n\t\r>/\"'" }
+matcher = { one_of = " \n\t\r\u000C>/\"'" }
 to = "attribute_value_unquoted"
 consume = false
 actions = [
@@ -5046,7 +5046,7 @@ actions = [
 
 [[transitions]]
 from = "attribute_named_character_reference_reg"
-matcher = { one_of = " \n\t\r>/\"'" }
+matcher = { one_of = " \n\t\r\u000C>/\"'" }
 to = "attribute_value_unquoted"
 consume = false
 actions = [

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -2516,7 +2516,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_double_escape_start".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::OneOf(" \n\t\r/>".to_string())),
+            matcher: Some(MatcherDefinition::OneOf(" \n\t\r\u{C}/>".to_string())),
             to: vec![
                 "script_data_escaped".to_string(),
             ],
@@ -2884,7 +2884,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_double_escape_end".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::OneOf(" \n\t\r/>".to_string())),
+            matcher: Some(MatcherDefinition::OneOf(" \n\t\r\u{C}/>".to_string())),
             to: vec![
                 "script_data_double_escaped".to_string(),
             ],
@@ -6384,7 +6384,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "text_named_character_reference_copy".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::OneOf(" \n\t\r<>/\"'".to_string())),
+            matcher: Some(MatcherDefinition::OneOf(" \n\t\r\u{C}<>/\"'".to_string())),
             to: vec![
                 "data".to_string(),
             ],
@@ -6640,7 +6640,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "text_named_character_reference_nbsp".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::OneOf(" \n\t\r<>/\"'".to_string())),
+            matcher: Some(MatcherDefinition::OneOf(" \n\t\r\u{C}<>/\"'".to_string())),
             to: vec![
                 "data".to_string(),
             ],
@@ -6833,7 +6833,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "text_named_character_reference_reg".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::OneOf(" \n\t\r<>/\"'".to_string())),
+            matcher: Some(MatcherDefinition::OneOf(" \n\t\r\u{C}<>/\"'".to_string())),
             to: vec![
                 "data".to_string(),
             ],
@@ -10276,7 +10276,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "attribute_named_character_reference_copy".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::OneOf(" \n\t\r>/\"'".to_string())),
+            matcher: Some(MatcherDefinition::OneOf(" \n\t\r\u{C}>/\"'".to_string())),
             to: vec![
                 "attribute_value_unquoted".to_string(),
             ],
@@ -10540,7 +10540,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "attribute_named_character_reference_nbsp".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::OneOf(" \n\t\r>/\"'".to_string())),
+            matcher: Some(MatcherDefinition::OneOf(" \n\t\r\u{C}>/\"'".to_string())),
             to: vec![
                 "attribute_value_unquoted".to_string(),
             ],
@@ -10739,7 +10739,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "attribute_named_character_reference_reg".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::OneOf(" \n\t\r>/\"'".to_string())),
+            matcher: Some(MatcherDefinition::OneOf(" \n\t\r\u{C}>/\"'".to_string())),
             to: vec![
                 "attribute_value_unquoted".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 135);
+    assert_eq!(html1.cases.len(), 137);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 142);
+    assert_eq!(file.tests.len(), 144);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 142);
+    assert_eq!(normalized.cases.len(), 144);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 142);
+    assert_eq!(suite.cases.len(), 144);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -120,6 +120,8 @@ currently supports:
   character references
 - missing-semicolon recovery for legacy named character references `nbsp`,
   `copy`, and `reg` before delimiters and EOF
+- form-feed handling as an HTML ASCII-whitespace delimiter for script double
+  escape and semicolonless legacy named character references
 - generic named-character-reference scanning with literal fallback for unknown
   names
 - PUBLIC/SYSTEM DOCTYPE recovery diagnostics for missing whitespace, missing

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -1518,6 +1518,34 @@
         "Text(data=WHATWG remaining named refs 6 (rthree-zeetrf):⋌▹⊵▸⧎℞⤥;⤩✶⌢♯⨳⧤∣⌣⪪⪬⪬︀/⧄⌿∥⌣⋆¯♪⤦⤪⌖⎴⌕∴≈∼≈∼⤨⊤⌶⫱⫚⤩‴▵▿⊴≜⊵≜⧍⨻⏢ŧ≬ű▀⌜⌏◸⌝⌎◹▵▴⦧⫨⫩⊨⦜∝⊲⊳⊢∨⊻≚⋮||⊲∝⊳⦚⩟∧≙℘≀≀▽⟼⋻⨂△ℨ)",
         "EOF"
       ]
+    },
+    {
+      "id": "html-form-feed-legacy-reference-boundary",
+      "description": "Form feed is an ASCII-whitespace boundary for semicolonless legacy named references",
+      "input": "A&copy\fB&nbsp\f<a copy=&copy\freg=&reg\f>",
+      "tokens": [
+        "Text(data=A©\fB \f)",
+        "StartTag(name=a, attributes=[copy=©, reg=®], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ]
+    },
+    {
+      "id": "html-form-feed-script-double-escape-delimiter",
+      "description": "Form feed delimits script double-escape start and end keywords",
+      "initial_state": "Script data state",
+      "last_start_tag": "script",
+      "input": "<!-- <script\fx </script\f y --></script>",
+      "tokens": [
+        "Text(data=<!-- <script\fx </script\f y -->)",
+        "EndTag(name=script)",
+        "EOF"
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -1727,6 +1727,35 @@
         "EOF"
       ],
       "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-143",
+      "description": "form feed legacy named reference boundary",
+      "input": "A&copy\fB&nbsp\f<a copy=&copy\freg=&reg\f>",
+      "tokens": [
+        "Text(data=A\u00a9\fB\u00a0\f)",
+        "StartTag(name=a, attributes=[copy=\u00a9, reg=\u00ae], self_closing=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference",
+        "missing-semicolon-after-character-reference"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-144",
+      "description": "form feed script double escape delimiter",
+      "input": "<!-- <script\fx </script\f y --></script>",
+      "tokens": [
+        "Text(data=<!-- <script\fx </script\f y -->)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data state",
+      "last_start_tag": "script"
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -1720,6 +1720,64 @@
                       "WHATWG remaining named refs 6 (rthree-zeetrf):⋌▹⊵▸⧎℞⤥;⤩✶⌢♯⨳⧤∣⌣⪪⪬⪬︀/⧄⌿∥⌣⋆¯♪⤦⤪⌖⎴⌕∴≈∼≈∼⤨⊤⌶⫱⫚⤩‴▵▿⊴≜⊵≜⧍⨻⏢ŧ≬ű▀⌜⌏◸⌝⌎◹▵▴⦧⫨⫩⊨⦜∝⊲⊳⊢∨⊻≚⋮||⊲∝⊳⦚⩟∧≙℘≀≀▽⟼⋻⨂△ℨ"
                 ]
           ]
+    },
+    {
+      "description": "form feed legacy named reference boundary",
+      "input": "A&copy\fB&nbsp\f<a copy=&copy\freg=&reg\f>",
+      "output": [
+        [
+          "Character",
+          "A©\fB \f"
+        ],
+        [
+          "StartTag",
+          "a",
+          {
+            "copy": "©",
+            "reg": "®"
+          }
+        ]
+      ],
+      "errors": [
+        {
+          "code": "missing-semicolon-after-character-reference",
+          "line": 1,
+          "col": 7
+        },
+        {
+          "code": "missing-semicolon-after-character-reference",
+          "line": 1,
+          "col": 14
+        },
+        {
+          "code": "missing-semicolon-after-character-reference",
+          "line": 1,
+          "col": 28
+        },
+        {
+          "code": "missing-semicolon-after-character-reference",
+          "line": 1,
+          "col": 37
+        }
+      ]
+    },
+    {
+      "description": "form feed script double escape delimiter",
+      "input": "<!-- <script\fx </script\f y --></script>",
+      "initialStates": [
+        "Script data state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "<!-- <script\fx </script\f y -->"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -625,6 +625,48 @@ fn default_html_lexer_treats_form_feed_as_doctype_whitespace() {
 }
 
 #[test]
+fn default_html_lexer_treats_form_feed_as_legacy_reference_boundary() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("A&copy\u{000C}B&nbsp\u{000C}<a copy=&copy\u{000C}reg=&reg\u{000C}>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("A\u{00A9}\u{000C}B\u{00A0}\u{000C}".to_string()),
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "copy".to_string(),
+                        value: "\u{00A9}".to_string(),
+                    },
+                    Attribute {
+                        name: "reg".to_string(),
+                        value: "\u{00AE}".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == "missing-semicolon-after-character-reference"
+            })
+            .count(),
+        4
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_standalone_system_doctype_identifier() {
     let tokens = lex_html("<!DOCTYPE html SYSTEM \"about:legacy-compat\">").unwrap();
 
@@ -1865,6 +1907,29 @@ fn default_html_lexer_supports_script_data_double_escaped_text() {
         lexer.drain_tokens(),
         vec![
             Token::Text("<!-- <script>ignored </script> still escaped -->".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
+fn default_html_lexer_treats_form_feed_as_script_double_escape_delimiter() {
+    let mut lexer = create_html_lexer().unwrap();
+    lexer.set_initial_state("script_data").unwrap();
+    lexer.set_last_start_tag("script");
+
+    lexer
+        .push("<!-- <script\u{000C}x </script\u{000C} y --></script>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("<!-- <script\u{000C}x </script\u{000C} y -->".to_string()),
             Token::EndTag {
                 name: "script".to_string()
             },


### PR DESCRIPTION
## Summary
- Treat form feed as HTML ASCII whitespace for script double-escape start/end delimiters.
- Treat form feed as the semicolonless legacy named-reference boundary for copy, nbsp, and reg in text and unquoted attributes.
- Add direct Rust, html1 fixture, and html5lib smoke coverage plus docs/changelog notes.

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check