### PR TITLE
Add ALGOL WASM run command

### DIFF
--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this package will be documented in this file.
 
 ### Changed
 
+- Added `algol60-wasm run SOURCE` for shell-level source-to-WASM execution with
+  stdout forwarding, optional `_start` result reporting, and a default WASM
+  instruction budget.
 - Added the `algol60-wasm` command and `python -m algol_wasm_compiler` entry
   point for compiling ALGOL source files into `.wasm` modules from the shell.
 - Compiled ALGOL programs now execute scalar variables through frame-backed

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -67,6 +67,7 @@ host process.
 ```bash
 algol60-wasm program.alg -o program.wasm
 python -m algol_wasm_compiler program.alg
+algol60-wasm run program.alg --print-result
 ```
 
 When `-o` is omitted, the compiler writes next to the source file with a
@@ -74,6 +75,12 @@ When `-o` is omitted, the compiler writes next to the source file with a
 `cli-builder` package, and compiler diagnostics are reported without Python
 tracebacks using the same source-size, parse, type-check, IR, WASM validation,
 and encoding stages as the Python API.
+
+The `run` command compiles in memory and executes the generated module's
+`_start` export through the local WASM runtime. Program output is forwarded to
+stdout, `--print-result` writes `_start` return values to stderr, and
+`--max-instructions` applies a host instruction budget so nonterminating ALGOL
+programs fail with an explicit runtime diagnostic.
 
 ```python
 from algol_wasm_compiler import compile_source

--- a/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/algol60_wasm_cli.json
+++ b/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/algol60_wasm_cli.json
@@ -34,5 +34,37 @@
       "type": "file",
       "required": true
     }
+  ],
+  "commands": [
+    {
+      "id": "run",
+      "name": "run",
+      "description": "Compile an ALGOL 60 source file in memory and run its WASM _start export.",
+      "flags": [
+        {
+          "id": "max-instructions",
+          "long": "max-instructions",
+          "description": "Maximum WASM instructions to execute before trapping.",
+          "type": "integer",
+          "value_name": "COUNT",
+          "default": 1000000
+        },
+        {
+          "id": "print-result",
+          "long": "print-result",
+          "description": "Print the _start return values to stderr after program output.",
+          "type": "boolean"
+        }
+      ],
+      "arguments": [
+        {
+          "id": "source",
+          "display_name": "SOURCE",
+          "description": "ALGOL 60 source file to compile and run.",
+          "type": "file",
+          "required": true
+        }
+      ]
+    }
   ]
 }

--- a/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/cli.py
+++ b/code/packages/python/algol-wasm-compiler/src/algol_wasm_compiler/cli.py
@@ -15,6 +15,14 @@ from cli_builder import (
     SpecError,
     VersionResult,
 )
+from wasm_execution import TrapError
+from wasm_runtime import (
+    ProcExitError,
+    WasiConfig,
+    WasiHost,
+    WasmExecutionLimits,
+    WasmRuntime,
+)
 
 from algol_wasm_compiler.compiler import (
     MAX_SOURCE_LENGTH,
@@ -24,6 +32,7 @@ from algol_wasm_compiler.compiler import (
 
 _PROGRAM_NAME = "algol60-wasm"
 _SPEC_RESOURCE = "algol60_wasm_cli.json"
+_DEFAULT_ENTRYPOINT = "_start"
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -45,6 +54,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if isinstance(parsed, VersionResult):
         print(parsed.version)
         return 0
+
+    if parsed.command_path[-1] == "run":
+        return _run_from_parse_result(parsed)
 
     return _compile_from_parse_result(parsed)
 
@@ -80,6 +92,66 @@ def _compile_from_parse_result(parsed: ParseResult) -> int:
     if not bool(parsed.flags["quiet"]):
         print(output_path)
     return 0
+
+
+def _run_from_parse_result(parsed: ParseResult) -> int:
+    source_path = Path(str(parsed.arguments["source"]))
+
+    try:
+        max_instructions = _max_instructions(parsed)
+        source = _read_source_file(source_path)
+        compiled = AlgolWasmCompiler().compile_source(source)
+        result = _run_wasm(compiled.binary, max_instructions=max_instructions)
+    except AlgolWasmError as exc:
+        print(f"{_PROGRAM_NAME}: {exc}", file=sys.stderr)
+        return 1
+    except TrapError as exc:
+        print(f"{_PROGRAM_NAME}: [run] {exc}", file=sys.stderr)
+        return 1
+    except ProcExitError as exc:
+        return exc.exit_code
+
+    if bool(parsed.flags["print-result"]):
+        print(f"result: {_format_result(result)}", file=sys.stderr)
+    return 0
+
+
+def _max_instructions(parsed: ParseResult) -> int:
+    max_instructions = int(parsed.flags["max-instructions"])
+    if max_instructions < 1:
+        raise AlgolWasmError(
+            "run",
+            "--max-instructions must be at least 1",
+        )
+    return max_instructions
+
+
+def _run_wasm(binary: bytes, *, max_instructions: int) -> list[int | float]:
+    host = WasiHost(
+        config=WasiConfig(
+            stdout=_write_stdout,
+            stderr=_write_stderr,
+        )
+    )
+    runtime = WasmRuntime(
+        host=host,
+        limits=WasmExecutionLimits(max_instructions=max_instructions),
+    )
+    return runtime.load_and_run(binary, _DEFAULT_ENTRYPOINT, [])
+
+
+def _format_result(values: list[int | float]) -> str:
+    if not values:
+        return "<none>"
+    return " ".join(str(value) for value in values)
+
+
+def _write_stdout(text: str) -> None:
+    sys.stdout.write(text)
+
+
+def _write_stderr(text: str) -> None:
+    sys.stderr.write(text)
 
 
 def _read_source_file(source_path: Path) -> str:

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_cli.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_cli.py
@@ -10,6 +10,8 @@ from wasm_runtime import WasmRuntime
 from algol_wasm_compiler import MAX_SOURCE_LENGTH
 from algol_wasm_compiler.cli import main
 
+_FIXTURE_DIR = Path(__file__).with_name("fixtures")
+
 
 def test_cli_compiles_source_file_to_explicit_output(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -77,7 +79,9 @@ def test_cli_uses_cli_builder_help(capsys: pytest.CaptureFixture[str]) -> None:
 
     captured = capsys.readouterr()
     assert "USAGE" in captured.out
-    assert "algol60-wasm [OPTIONS] <SOURCE>" in captured.out
+    assert "algol60-wasm [OPTIONS] [COMMAND] <SOURCE>" in captured.out
+    assert "COMMANDS" in captured.out
+    assert "run" in captured.out
     assert "GLOBAL OPTIONS" in captured.out
     assert captured.err == ""
 
@@ -90,3 +94,74 @@ def test_cli_reports_cli_builder_parse_errors(
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "algol60-wasm: error[unknown_flag]" in captured.err
+
+
+def test_cli_run_executes_compiled_program_without_writing_wasm(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_path = tmp_path / "run.alg"
+    output_path = tmp_path / "run.wasm"
+    source_path.write_text(
+        "begin integer result; result := 7; "
+        "print('RUN'); output(' '); print(result) end"
+    )
+
+    assert main(["run", str(source_path)]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == "RUN 7"
+    assert captured.err == ""
+    assert not output_path.exists()
+
+
+def test_cli_run_executes_full_surface_fixture_in_python_wasm_runtime(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_path = tmp_path / "full-surface.alg"
+    source_path.write_text((_FIXTURE_DIR / "full-surface.alg").read_text())
+
+    assert main(["run", str(source_path), "--print-result"]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == "COMPLETE 81"
+    assert captured.err == "result: 81\n"
+
+
+def test_cli_run_can_print_start_result(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_path = tmp_path / "result.alg"
+    source_path.write_text("begin integer result; result := 9 end")
+
+    assert main(["run", str(source_path), "--print-result"]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "result: 9\n"
+
+
+def test_cli_run_reports_instruction_budget_traps(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_path = tmp_path / "spin.alg"
+    source_path.write_text("begin loop: goto loop end")
+
+    assert main(["run", str(source_path), "--max-instructions", "32"]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "algol60-wasm: [run]" in captured.err
+    assert "instruction budget exhausted" in captured.err
+
+
+def test_cli_run_rejects_nonpositive_instruction_budget(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_path = tmp_path / "budget.alg"
+    source_path.write_text("begin integer result; result := 1 end")
+
+    assert main(["run", str(source_path), "--max-instructions", "0"]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "algol60-wasm: [run] --max-instructions must be at least 1" in captured.err


### PR DESCRIPTION
## Summary
- Add an `algol60-wasm run SOURCE` CLI Builder subcommand that compiles ALGOL source in memory and runs the generated WASM `_start` export.
- Execute via the repository's Python `WasmRuntime`/`WasiHost`, forwarding program stdout/stderr and enforcing a default instruction budget.
- Add `--print-result` and `--max-instructions`, plus CLI tests that prove the full-surface ALGOL fixture runs end to end in the Python WASM runtime.

## Verification
- `uv venv --quiet --clear`
- `uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../grammar-tools -e ../cli-builder -e ../lexer -e ../parser -e ../algol-lexer -e ../algol-parser -e ../algol-type-checker -e ../compiler-ir -e ../algol-ir-compiler -e ../virtual-machine -e ../wasm-leb128 -e ../wasm-types -e ../wasm-opcodes -e ../wasm-module-parser -e ../wasm-validator -e ../wasm-execution -e ../wasm-runtime -e ../wasm-module-encoder -e ../ir-to-wasm-compiler -e ../ir-to-wasm-validator -e '.[dev]' --quiet`
- `.venv/bin/python -m ruff check src/algol_wasm_compiler tests/test_algol_wasm_cli.py`
- `.venv/bin/python -m pytest tests/test_algol_wasm_cli.py --no-cov -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/algol60-wasm run <temp>/full-surface.alg --print-result` -> stdout `COMPLETE 81`, stderr `result: 81`
- `uv build --wheel --out-dir /tmp/algol-wasm-run-wheel-check`
- `./build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`

## Security review
- No shell execution, subprocess spawning, network access, unsafe deserialization, or dynamic code execution was added.
- `run` uses the existing Python WASM runtime with `WasmExecutionLimits(max_instructions=...)`, defaulting to 1,000,000 instructions and rejecting non-positive limits.
- Source file reads still pass through the existing `MAX_SOURCE_LENGTH` guard before parsing.
