### PR TITLE
Broaden ALGOL WASM convergence fixtures

### DIFF
--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -56,28 +56,29 @@ the new value. Read-only expression thunks can also read array elements; helper
 bounds failures are reported back to the calling procedure before the normal
 frame and thunk-region unwind. Procedure calls inside read-only expression
 thunks are supported, including nested by-name descriptor allocation and runtime
-failure propagation from callees back to the by-name formal read. Stores through
-read-only expression thunks still raise targeted `CompileError` diagnostics
-until Phase 5 grows full store-helper coverage. The supported scalar by-name
-surface is covered by the WASM acceptance suite, including typed whole-array
-formals passed as descriptor pointers. `value` whole-array formals allocate a
-callee-local descriptor, bounds table, and element storage copy at procedure
-entry, so writes to the formal do not alias the caller's array. Label formals
-pass pending-goto targets, and switch formals pass descriptor closures that
-re-evaluate in the caller's declaring scope; these label/switch descriptor
-paths also cover `value` formals. Procedure formals pass descriptor closures
-containing the callee procedure id and static link; formal calls dispatch
-through generated helpers for statement calls and typed expression calls with
-scalar, whole-array, label, switch, or procedure arguments. The dispatch
-helpers pass scalar actual arguments as lazy storage pointers or thunk
-descriptors, evaluating them once for target `value` parameters and forwarding
-them directly for target by-name parameters. Whole-array, switch, and procedure
-actuals pass descriptor pointers, and label actuals pass label ids, so
-forwarded procedure formals keep the original environment in value, by-name,
-array, label, switch, or procedure mode. Real-valued formal procedure calls can
-accept integer-returning actual procedures and promote the dispatched result.
-Concrete procedure actuals forwarded through a formal procedure call retain
-enough type-checker metadata to validate nested procedure-parameter contracts.
+failure propagation from callees back to the by-name formal read. Assignable
+scalar and array-element actuals have storage/store-helper paths; non-assignable
+expression actuals remain read-only and are rejected if by-name flow analysis
+finds a write. The supported scalar by-name surface is covered by the WASM
+acceptance suite, including typed whole-array formals passed as descriptor
+pointers. `value` whole-array formals allocate a callee-local descriptor, bounds
+table, and element storage copy at procedure entry, so writes to the formal do
+not alias the caller's array. Label formals pass pending-goto targets, and
+switch formals pass descriptor closures that re-evaluate in the caller's
+declaring scope; these label/switch descriptor paths also cover `value`
+formals. Procedure formals pass descriptor closures containing the callee
+procedure id and static link; formal calls dispatch through generated helpers
+for statement calls and typed expression calls with scalar, whole-array, label,
+switch, or procedure arguments. The dispatch helpers pass scalar actual
+arguments as lazy storage pointers or thunk descriptors, evaluating them once
+for target `value` parameters and forwarding them directly for target by-name
+parameters. Whole-array, switch, and procedure actuals pass descriptor pointers,
+and label actuals pass label ids, so forwarded procedure formals keep the
+original environment in value, by-name, array, label, switch, or procedure mode.
+Real-valued formal procedure calls can accept integer-returning actual
+procedures and promote the dispatched result. Concrete procedure actuals
+forwarded through a formal procedure call retain enough type-checker metadata to
+validate nested procedure-parameter contracts.
 
 Direct `goto`/`go to` statements lower to ordinary IR `JUMP` instructions targeting
 generated ALGOL labels. Local jumps emit the jump directly. Direct nonlocal

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -124,6 +124,10 @@ All notable changes to this package will be documented in this file.
   procedure calls, label and switch formals, multiple `for` element forms,
   parenthesized conditional designational expressions, numeric labels, boolean
   operators, real arithmetic, and output in one end-to-end WASM program.
+- Added golden convergence fixtures for lexical recursion, procedure-formal
+  closures, nonlocal procedure `goto` unwind, dynamic multidimensional array
+  bounds, mixed writable by-name scalar types, and runtime bounds-guard
+  failure before output.
 - Accepted uppercase and mixed-case keywords/comments, `<>` not-equal
   relations, and double-quoted string literals through the full WASM pipeline.
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -142,6 +142,15 @@ local WASM runtime. Those fixtures cover:
 - switch dispatch, procedure-formal dispatch, and procedure-crossing `goto`
 - conditional expressions, chained assignment, and exponentiation in the same
   end-to-end program
+- lexical recursion with outer-frame mutation and fresh recursive frames
+- procedure-formal closure dispatch that preserves the actual procedure's
+  static link
+- nonlocal procedure `goto` that unwinds dynamic array storage before the
+  caller resumes at the target label
+- dynamic multidimensional array bounds captured at block entry
+- writable real, boolean, and string by-name scalar formals in one program
+- runtime bounds failure through the zero-result failure path before later
+  output executes
 - a full-surface convergence program combining `own` scalars and arrays,
   default-real arrays, nested and single-statement procedures, value and
   by-name procedure formals, label and switch formals, multiple `for` element

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/by-name-mixed-scalars.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/by-name-mixed-scalars.alg
@@ -1,0 +1,29 @@
+begin
+  integer result;
+  real r;
+  boolean b;
+  string s;
+
+  procedure setall(x, y, z);
+    real x;
+    boolean y;
+    string z;
+    begin
+      x := x + 0.5;
+      y := not y;
+      z := 'done'
+    end;
+
+  r := 1.5;
+  b := true;
+  s := 'todo';
+  setall(r, b, s);
+  if (r = 2.0) and (not b) and (s = 'done') then
+    result := 27
+  else
+    result := 0;
+
+  print('BYNAME');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/dynamic-array-bounds.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/dynamic-array-bounds.alg
@@ -1,0 +1,18 @@
+begin
+  integer result, lo, hi;
+
+  lo := 2;
+  hi := 4;
+  begin
+    integer array a[lo:hi, 1:2];
+    lo := 99;
+    hi := 100;
+    a[2, 1] := 21;
+    a[4, 2] := 42;
+    result := a[2, 1] + a[4, 2]
+  end;
+
+  print('DYNAMIC');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/nonlocal-unwind.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/nonlocal-unwind.alg
@@ -1,0 +1,27 @@
+begin
+  integer result, n;
+
+  procedure escape;
+    begin
+      integer array temp[1:n];
+      temp[n] := 7;
+      goto after
+    end;
+
+  result := 0;
+  n := 20;
+  escape;
+  result := 99;
+
+after:
+  n := 2;
+  begin
+    integer array next[1:n];
+    next[2] := 41;
+    result := next[2] + 1
+  end;
+
+  print('UNWIND');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/procedure-formal-closure.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/procedure-formal-closure.alg
@@ -1,0 +1,22 @@
+begin
+  integer result, base;
+
+  integer procedure addbase(x);
+    value x;
+    integer x;
+    addbase := base + x;
+
+  integer procedure applytwice(f, x);
+    value x;
+    integer f, x;
+    procedure f;
+    begin
+      applytwice := f(x) + f(x + 1)
+    end;
+
+  base := 10;
+  result := applytwice(addbase, 2);
+  print('FORMAL');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/recursive-lexical.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/recursive-lexical.alg
@@ -1,0 +1,20 @@
+begin
+  integer result, calls;
+
+  integer procedure fact(n);
+    value n;
+    integer n;
+    begin
+      calls := calls + 1;
+      if n <= 1 then
+        fact := 1
+      else
+        fact := n * fact(n - 1)
+    end;
+
+  calls := 0;
+  result := fact(5) + calls;
+  print('RECURSE');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/runtime-guards.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/runtime-guards.alg
@@ -1,0 +1,9 @@
+begin
+  integer result;
+  integer array a[1:2];
+
+  result := 7;
+  a[1] := 1;
+  result := a[3];
+  print('BAD')
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -30,6 +30,12 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="full-surface", result=[81], stdout="COMPLETE 81"),
     GoldenFixture(name="switch-actuals", result=[42], stdout="SWITCH 42"),
     GoldenFixture(name="typed-comparisons", result=[31], stdout="READY 31"),
+    GoldenFixture(name="recursive-lexical", result=[125], stdout="RECURSE 125"),
+    GoldenFixture(name="procedure-formal-closure", result=[25], stdout="FORMAL 25"),
+    GoldenFixture(name="nonlocal-unwind", result=[42], stdout="UNWIND 42"),
+    GoldenFixture(name="dynamic-array-bounds", result=[63], stdout="DYNAMIC 63"),
+    GoldenFixture(name="by-name-mixed-scalars", result=[27], stdout="BYNAME 27"),
+    GoldenFixture(name="runtime-guards", result=[0], stdout=""),
 )
 
 

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -1600,3 +1600,27 @@ Full ALGOL 60 to WASM is complete when:
 The final result should make ALGOL 60 a reference implementation for compiling
 block-scoped, procedure-heavy historical languages onto the repository's WASM
 stack.
+
+## Backend Portability Notes
+
+The same ALGOL semantic model can target managed virtual machines such as the
+JVM or CLR. ALGOL 60 is a statically compiled, lexically scoped language; it
+does not require garbage collection as part of the language definition. Most
+ordinary storage has block/procedure lifetime, and `own` declarations have
+static lifetime.
+
+A JVM or CLR backend would still benefit from the platform garbage collector for
+runtime descriptor objects, but that is an implementation convenience rather
+than an ALGOL semantic requirement. The reusable target-independent pieces are:
+
+- activation frames carrying static links or display entries
+- array descriptors with captured bounds, strides, and checked element access
+- procedure descriptors carrying code identity plus lexical environment
+- by-name thunk descriptors with separate eval/store behavior
+- label and switch descriptors for designational expressions
+- nonlocal `goto` lowering through frame unwind plus target dispatch
+
+For WASM these concepts live in linear memory and helper dispatch functions. For
+JVM or CLR they can become classes/records plus bytecode helpers, with nonlocal
+`goto` represented either as explicit continuation dispatch or as an internal
+exception used only to unwind to the target activation.


### PR DESCRIPTION
## Summary
- add six end-to-end ALGOL WASM golden fixtures for lexical recursion, procedure-formal closures, nonlocal unwind, dynamic multidimensional bounds, mixed by-name scalar writes, and runtime guard failure
- document the expanded fixture coverage and refresh stale by-name README wording
- add PL04 notes on JVM/CLR portability and why ALGOL does not require GC semantically

## Verification
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest tests/test_algol_wasm_fixtures.py -v --no-cov`
- `.venv/bin/python -m pytest tests/ -v`
- `git diff --check`
- security scan over touched ALGOL paths for subprocess/shell/eval/network/file-deletion patterns; only benign spec text `eval(thunk_descriptor_ptr) -> i32` matched
