### PR TITLE
Drop partial HTML tags at EOF

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -179,6 +179,8 @@ documented in this file.
   a final generated batch for the remaining aliases.
 - Treated form feed as an HTML ASCII-whitespace delimiter for script
   double-escape boundaries and semicolonless legacy character references.
+- EOF inside ordinary start/end tag construction now drops the partial token
+  after reporting EOF-in-tag diagnostics.
 - Added a WHATWG operator/shape named-reference batch covering circled
   operators, integrals, products, squares, lozenges, stars, suits, and symbols.
 - Added a WHATWG box-drawing named-reference batch covering double-line,

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -72,6 +72,9 @@ kept, later attributes with the same interpreted name are dropped, and a
 Unquoted attribute values also preserve spec-defined unexpected characters
 such as `"`, `'`, `<`, `=`, and `` ` `` while reporting
 `unexpected-character-in-unquoted-attribute-value`.
+EOF inside ordinary start/end tag construction now reports the relevant
+EOF-in-tag diagnostic and drops the incomplete token instead of handing a
+partial tag to the future parser.
 NULL characters in data/RCDATA/RAWTEXT/PLAINTEXT/CDATA/script data, script
 escaped/double-escaped states, and attribute values recover by reporting
 `unexpected-null-character` and appending U+FFFD, matching the replacement

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -3282,7 +3282,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag-name-state)",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -3351,7 +3351,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -3420,8 +3420,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute_dedup",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -3489,8 +3488,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute_dedup",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -3567,8 +3565,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute_dedup",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -3610,8 +3607,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute_dedup",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -3653,8 +3649,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute_dedup",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -3732,8 +3727,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "commit_attribute_dedup",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -5108,7 +5102,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -5135,7 +5129,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-tag)",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -7160,7 +7154,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-end-tag-name-state)",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -7189,7 +7183,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-end-tag-name-state)",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 
@@ -7247,7 +7241,7 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-end-tag-name-state)",
-  "emit_current_token",
+  "discard_current_token",
   "emit(EOF)",
 ]
 

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -7346,7 +7346,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag-name-state)".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -7504,7 +7504,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -7663,8 +7663,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute_dedup".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -7821,8 +7820,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute_dedup".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -7982,8 +7980,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute_dedup".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -8063,8 +8060,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute_dedup".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -8144,8 +8140,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute_dedup".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -8316,8 +8311,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "commit_attribute_dedup".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -10874,7 +10868,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -10924,7 +10918,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-tag)".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -15028,7 +15022,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-end-tag-name-state)".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -15090,7 +15084,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-end-tag-name-state)".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,
@@ -15225,7 +15219,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-end-tag-name-state)".to_string(),
-                "emit_current_token".to_string(),
+                "discard_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
             consume: false,

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 137);
+    assert_eq!(html1.cases.len(), 139);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 144);
+    assert_eq!(file.tests.len(), 146);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 144);
+    assert_eq!(normalized.cases.len(), 146);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 144);
+    assert_eq!(suite.cases.len(), 146);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -122,6 +122,8 @@ currently supports:
   `copy`, and `reg` before delimiters and EOF
 - form-feed handling as an HTML ASCII-whitespace delimiter for script double
   escape and semicolonless legacy named character references
+- EOF recovery for unfinished ordinary start and end tags, ensuring partial
+  tokens are dropped before the parser sees them
 - generic named-character-reference scanning with literal fallback for unknown
   names
 - PUBLIC/SYSTEM DOCTYPE recovery diagnostics for missing whitespace, missing

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -1546,6 +1546,30 @@
         "EndTag(name=script)",
         "EOF"
       ]
+    },
+    {
+      "id": "html-eof-drops-partial-start-tag",
+      "description": "EOF in an unfinished start tag drops the partial token",
+      "input": "<div class=\"open",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-tag"
+      ]
+    },
+    {
+      "id": "html-eof-drops-partial-end-tag",
+      "description": "EOF in an unfinished ordinary end tag drops the partial token",
+      "input": "</section class=x",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name",
+        "end-tag-with-attributes",
+        "eof-in-end-tag-name-state"
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -1756,6 +1756,30 @@
       "diagnostics": [],
       "initial_state": "Script data state",
       "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-145",
+      "description": "eof drops partial start tag",
+      "input": "<div class=\"open",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [
+        "eof-in-tag"
+      ]
+    },
+    {
+      "id": "html5lib-smoke-146",
+      "description": "eof drops partial end tag",
+      "input": "</section class=x",
+      "tokens": [
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name",
+        "end-tag-with-attributes",
+        "eof-in-end-tag-name-state"
+      ]
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -1778,6 +1778,40 @@
           "script"
         ]
       ]
+    },
+    {
+      "description": "eof drops partial start tag",
+      "input": "<div class=\"open",
+      "output": [],
+      "errors": [
+        {
+          "code": "eof-in-tag",
+          "line": 1,
+          "col": 17
+        }
+      ]
+    },
+    {
+      "description": "eof drops partial end tag",
+      "input": "</section class=x",
+      "output": [],
+      "errors": [
+        {
+          "code": "unexpected-whitespace-after-end-tag-name",
+          "line": 1,
+          "col": 10
+        },
+        {
+          "code": "end-tag-with-attributes",
+          "line": 1,
+          "col": 11
+        },
+        {
+          "code": "eof-in-end-tag-name-state",
+          "line": 1,
+          "col": 18
+        }
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -26,6 +26,34 @@ fn default_html_lexer_still_lexes_basic_text_tags_and_eof() {
 }
 
 #[test]
+fn default_html_lexer_drops_partial_start_tag_at_eof() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<div class=\"open").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(lexer.drain_tokens(), vec![Token::Eof]);
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "eof-in-tag"));
+}
+
+#[test]
+fn default_html_lexer_drops_partial_end_tag_at_eof() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("</section class=x").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(lexer.drain_tokens(), vec![Token::Eof]);
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "eof-in-end-tag-name-state"));
+}
+
+#[test]
 fn default_html_lexer_supports_html1_attributes_comments_and_doctypes() {
     let tokens = lex_html(
         "<!DOCTYPE HTML><IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1/>Before<!--note-->After",


### PR DESCRIPTION
## Summary
- Drop incomplete ordinary start/end tag tokens when EOF arrives inside tag construction.
- Keep parser-facing EOF recovery aligned with HTML tokenizer behavior by reporting EOF-in-tag diagnostics without emitting partial tags.
- Add direct Rust tests plus html1 and html5lib-style fixture coverage.

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html1_authoring_test
- cargo check --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check