### PR TITLE
Cover ALGOL own storage convergence

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -176,6 +176,30 @@ class TestAlgolIrCompiler:
         ]
         assert load_addr_labels.count("__algol_static") >= 2
 
+    def test_compiles_own_real_boolean_and_string_scalars_to_static_storage(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin own real scale; own boolean ready; own string marker; "
+                "integer result; "
+                "scale := 1.5; ready := true; marker := 'OK'; result := 1 "
+                "end"
+            )
+        )
+        data_labels = [decl.label for decl in result.program.data]
+        load_addr_labels = [
+            instr.operands[1].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LOAD_ADDR and len(instr.operands) == 2
+        ]
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert "__algol_static" in data_labels
+        assert load_addr_labels.count("__algol_static") >= 3
+        assert IrOp.STORE_F64 in opcodes
+        assert IrOp.STORE_WORD in opcodes
+
     def test_compiles_own_array_descriptor_to_static_storage(self) -> None:
         result = compile_algol(
             parse_algol(
@@ -193,6 +217,33 @@ class TestAlgolIrCompiler:
 
         assert "__algol_static" in data_labels
         assert load_addr_labels.count("__algol_static") >= 2
+
+    def test_compiles_own_real_boolean_and_string_array_descriptors_to_static_storage(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin own real array totals[1:1]; "
+                "own boolean array flags[1:1]; "
+                "own string array labels[1:1]; "
+                "integer result; "
+                "totals[1] := 1.5; flags[1] := true; labels[1] := 'OK'; "
+                "result := 1 "
+                "end"
+            )
+        )
+        data_labels = [decl.label for decl in result.program.data]
+        load_addr_labels = [
+            instr.operands[1].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LOAD_ADDR and len(instr.operands) == 2
+        ]
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert "__algol_static" in data_labels
+        assert load_addr_labels.count("__algol_static") >= 3
+        assert IrOp.STORE_F64 in opcodes
+        assert IrOp.STORE_WORD in opcodes
 
     def test_compiles_array_allocation_with_zero_fill_loop(self) -> None:
         result = compile_algol(

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -781,6 +781,31 @@ class TestAlgolTypeChecker:
         assert all(ref.storage_class == "static" for ref in [*reads, *writes])
         assert all(ref.lexical_depth_delta == 1 for ref in [*reads, *writes])
 
+    def test_own_real_boolean_and_string_scalars_use_static_storage(self) -> None:
+        ast = parse_algol(
+            "begin own real scale; own boolean ready; own string marker; "
+            "integer result; "
+            "scale := 1.5; ready := true; marker := 'OK'; result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        symbols = {symbol.name: symbol for symbol in result.semantic.symbols}
+        assert symbols["scale"].storage_class == "static"
+        assert symbols["scale"].slot_offset == 0
+        assert symbols["scale"].slot_size == FRAME_REAL_SIZE
+        assert symbols["ready"].storage_class == "static"
+        assert symbols["ready"].slot_offset == FRAME_REAL_SIZE
+        assert symbols["ready"].slot_size == FRAME_WORD_SIZE
+        assert symbols["marker"].storage_class == "static"
+        assert symbols["marker"].slot_offset == FRAME_REAL_SIZE + FRAME_WORD_SIZE
+        assert symbols["marker"].slot_size == FRAME_WORD_SIZE
+        assert result.semantic.root_block is not None
+        layout = result.semantic.root_block.frame_layout
+        assert [slot.name for slot in layout.slots] == ["result"]
+
     def test_own_array_uses_static_descriptor_storage(self) -> None:
         ast = parse_algol(
             "begin own integer array counts[1:2]; integer result; "
@@ -801,6 +826,38 @@ class TestAlgolTypeChecker:
         assert counts.slot_offset == 0
         assert counts.slot_size == 4
         assert descriptor.storage_class == "static"
+        assert result.semantic.root_block is not None
+        layout = result.semantic.root_block.frame_layout
+        assert [slot.name for slot in layout.slots] == ["result"]
+
+    def test_own_real_boolean_and_string_arrays_use_static_descriptors(self) -> None:
+        ast = parse_algol(
+            "begin own real array totals[1:1]; "
+            "own boolean array flags[1:1]; "
+            "own string array labels[1:1]; "
+            "integer result; "
+            "totals[1] := 1.5; flags[1] := true; labels[1] := 'OK'; "
+            "result := 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        symbols = {symbol.name: symbol for symbol in result.semantic.symbols}
+        arrays = {array.name: array for array in result.semantic.arrays}
+        assert symbols["totals"].storage_class == "static"
+        assert symbols["totals"].slot_offset == 0
+        assert arrays["totals"].storage_class == "static"
+        assert arrays["totals"].element_type == "real"
+        assert symbols["flags"].storage_class == "static"
+        assert symbols["flags"].slot_offset == FRAME_WORD_SIZE
+        assert arrays["flags"].storage_class == "static"
+        assert arrays["flags"].element_type == "boolean"
+        assert symbols["labels"].storage_class == "static"
+        assert symbols["labels"].slot_offset == FRAME_WORD_SIZE * 2
+        assert arrays["labels"].storage_class == "static"
+        assert arrays["labels"].element_type == "string"
         assert result.semantic.root_block is not None
         layout = result.semantic.root_block.frame_layout
         assert [slot.name for slot in layout.slots] == ["result"]

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -128,6 +128,9 @@ All notable changes to this package will be documented in this file.
   closures, nonlocal procedure `goto` unwind, dynamic multidimensional array
   bounds, mixed writable by-name scalar types, and runtime bounds-guard
   failure before output.
+- Added storage-semantics convergence coverage for mixed `own` scalars and
+  arrays, boolean/string `value` array copies, and value versus by-name loop
+  control storage updates.
 - Accepted uppercase and mixed-case keywords/comments, `<>` not-equal
   relations, and double-quoted string literals through the full WASM pipeline.
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -151,6 +151,8 @@ local WASM runtime. Those fixtures cover:
 - writable real, boolean, and string by-name scalar formals in one program
 - runtime bounds failure through the zero-result failure path before later
   output executes
+- mixed `own` scalar and array storage for real, boolean, and string values,
+  plus value-array copies and by-name loop-control storage behavior
 - a full-surface convergence program combining `own` scalars and arrays,
   default-real arrays, nested and single-statement procedures, value and
   by-name procedure formals, label and switch formals, multiple `for` element

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/storage-semantics.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/storage-semantics.alg
@@ -1,0 +1,87 @@
+begin
+  integer result, ownScore, copyScore, controlScore, i, j;
+  boolean array flags[1:1];
+  string array words[1:1];
+
+  procedure tick;
+    begin
+      own real scalar;
+      own boolean seen;
+      own string marker;
+      own real array totals[1:1];
+      own boolean array ready[1:1];
+      own string array labels[1:1];
+
+      if not seen then
+        begin
+          scalar := 1.5;
+          seen := true;
+          marker := 'OK';
+          totals[1] := 2.5;
+          ready[1] := true;
+          labels[1] := 'ARR';
+          ownScore := ownScore + 1
+        end
+      else
+        begin
+          scalar := scalar + 1.0;
+          totals[1] := totals[1] + 1.0;
+          if seen and ready[1] and (marker = 'OK') and (labels[1] = 'ARR') and
+             (scalar > 2.0) and (totals[1] > 3.0) then
+            ownScore := ownScore + 20
+          else
+            ownScore := 0
+        end
+    end;
+
+  procedure mutate(flagCopy, wordCopy);
+    value flagCopy, wordCopy;
+    boolean flagCopy;
+    string wordCopy;
+    array flagCopy, wordCopy;
+    begin
+      flagCopy[1] := false;
+      wordCopy[1] := 'copy';
+      if (not flagCopy[1]) and (wordCopy[1] = 'copy') then
+        copyScore := copyScore + 3
+      else
+        copyScore := 0
+    end;
+
+  procedure runByName(k);
+    integer k;
+    begin
+      for k := 1 step 1 until 3 do controlScore := controlScore + k
+    end;
+
+  procedure runByValue(k);
+    value k;
+    integer k;
+    begin
+      for k := 1 step 1 until 3 do controlScore := controlScore + k
+    end;
+
+  ownScore := 0;
+  copyScore := 0;
+  controlScore := 0;
+  tick;
+  tick;
+
+  flags[1] := true;
+  words[1] := 'orig';
+  mutate(flags, words);
+  if flags[1] and (words[1] = 'orig') then copyScore := copyScore + 4
+  else copyScore := 0;
+
+  i := 0;
+  runByName(i);
+  controlScore := controlScore * 10 + i;
+  j := 9;
+  runByValue(j);
+  controlScore := controlScore * 10 + j;
+
+  result := ownScore + copyScore + controlScore;
+  print('STORAGE');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -471,6 +471,65 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [12]
 
+    def test_own_real_boolean_and_string_scalars_persist_across_calls(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure tick; "
+            "begin own real scalar; own boolean seen; own string marker; "
+            "if not seen then "
+            "begin scalar := 1.5; seen := true; marker := 'OK'; result := 1 end "
+            "else "
+            "begin scalar := scalar + 1.0; "
+            "if seen and (marker = 'OK') and (scalar > 2.0) then result := 7 "
+            "else result := 0 "
+            "end "
+            "end; "
+            "tick; tick "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_own_real_boolean_and_string_arrays_persist_across_calls(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure tick; "
+            "begin own real array totals[1:1]; "
+            "own boolean array ready[1:1]; "
+            "own string array labels[1:1]; "
+            "if not ready[1] then "
+            "begin totals[1] := 2.5; ready[1] := true; "
+            "labels[1] := 'ARR'; result := 1 end "
+            "else "
+            "begin totals[1] := totals[1] + 1.0; "
+            "if ready[1] and (labels[1] = 'ARR') and (totals[1] > 3.0) "
+            "then result := 8 else result := 0 "
+            "end "
+            "end; "
+            "tick; tick "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
+    def test_for_control_by_name_writes_caller_storage(self) -> None:
+        result = compile_source(
+            "begin integer result, i; "
+            "procedure run(k); integer k; "
+            "begin for k := 1 step 1 until 3 do result := result + k end; "
+            "i := 0; result := 0; run(i); result := result * 10 + i "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [64]
+
+    def test_for_control_value_parameter_does_not_write_caller_storage(self) -> None:
+        result = compile_source(
+            "begin integer result, i; "
+            "procedure run(k); value k; integer k; "
+            "begin for k := 1 step 1 until 3 do result := result + k end; "
+            "i := 9; result := 0; run(i); result := result * 10 + i "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [69]
+
     def test_boolean_variable_assignment_drives_condition(self) -> None:
         result = compile_source(
             "begin integer result; "
@@ -1498,6 +1557,26 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
+    def test_boolean_and_string_value_array_parameters_copy_without_aliasing(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin boolean array flags[1:1]; string array words[1:1]; "
+            "integer result; "
+            "procedure mutate(flagCopy, wordCopy); "
+            "value flagCopy, wordCopy; "
+            "boolean flagCopy; string wordCopy; array flagCopy, wordCopy; "
+            "begin flagCopy[1] := false; wordCopy[1] := 'copy'; "
+            "if (not flagCopy[1]) and (wordCopy[1] = 'copy') "
+            "then result := 10 else result := 0 "
+            "end; "
+            "flags[1] := true; words[1] := 'orig'; mutate(flags, words); "
+            "if flags[1] and (words[1] = 'orig') then result := result + 1 "
+            "else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [11]
 
     def test_array_parameter_runtime_dimension_mismatch_returns_from_callee(
         self,

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -36,6 +36,7 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="dynamic-array-bounds", result=[63], stdout="DYNAMIC 63"),
     GoldenFixture(name="by-name-mixed-scalars", result=[27], stdout="BYNAME 27"),
     GoldenFixture(name="runtime-guards", result=[0], stdout=""),
+    GoldenFixture(name="storage-semantics", result=[737], stdout="STORAGE 737"),
 )
 
 


### PR DESCRIPTION
## Summary
- add a storage-semantics golden fixture covering mixed own scalar and array storage, boolean/string value array copies, and value versus by-name loop control updates
- add focused type checker, IR compiler, and WASM compiler coverage for non-integer own storage semantics
- document the new convergence fixture coverage in the ALGOL WASM README and changelog

## Verification
- python -m pytest tests/ -v in code/packages/python/algol-type-checker
- python -m pytest tests/ -v in code/packages/python/algol-ir-compiler
- python -m pytest tests/ -v in code/packages/python/algol-wasm-compiler
- python -m ruff check ../algol-type-checker ../algol-ir-compiler .
- git diff --cached --check
- rg security scan over touched files for process execution, shell, network, filesystem deletion, and unsafe deserialization patterns