### PR TITLE
Harden ALGOL edge convergence guards

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -54,6 +54,20 @@ class TestAlgolIrCompiler:
         assert IrOp.JUMP in opcodes
         assert opcodes.count(IrOp.STORE_WORD) >= 1
 
+    def test_compiles_boolean_and_string_conditional_expression_values(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; boolean ok; string word; "
+                "ok := if false then false else true; "
+                "word := if ok then 'YES' else 'NO'; "
+                "if ok and (word = 'YES') then result := 1 else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        assert opcodes.count(IrOp.BRANCH_Z) >= 2
+        assert opcodes.count(IrOp.STORE_WORD) >= 3
+
     def test_compiles_structured_if_labels(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1134,16 +1134,22 @@ class AlgolTypeChecker:
                 self._declare_label(label_token, statement, scope)
 
         body = _statement_body(statement)
-        if body is None or body.rule_name == "block":
+        if body is not None:
+            self._collect_nested_statement_labels(body, scope)
+
+    def _collect_nested_statement_labels(self, node: ASTNode, scope: Scope) -> None:
+        if node.rule_name == "block":
             return
-        for child in _node_children(body):
-            if child.rule_name == "statement":
-                self._collect_statement_labels(child, scope)
-            elif child.rule_name == "unlabeled_stmt":
-                nested = _first_ast_child(child)
-                if nested is not None and nested.rule_name != "block":
-                    for nested_statement in _direct_nodes(nested, "statement"):
-                        self._collect_statement_labels(nested_statement, scope)
+        if node.rule_name == "statement":
+            self._collect_statement_labels(node, scope)
+            return
+        if node.rule_name == "unlabeled_stmt":
+            nested = _first_ast_child(node)
+            if nested is not None:
+                self._collect_nested_statement_labels(nested, scope)
+            return
+        for child in _node_children(node):
+            self._collect_nested_statement_labels(child, scope)
 
     def _declare_label(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -197,6 +197,19 @@ class TestAlgolTypeChecker:
         assert result.semantic.labels[0].name == "10"
         assert result.semantic.gotos[0].target_name == "10"
 
+    def test_accepts_terminal_label_inside_compound_statement(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "begin result := 13; goto done; result := 0; done: end "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.labels[0].name == "done"
+        assert result.semantic.gotos[0].target_name == "done"
+
     def test_accepts_go_to_spelling(self) -> None:
         ast = parse_algol(
             "begin integer result; "
@@ -568,6 +581,17 @@ class TestAlgolTypeChecker:
             "begin integer result; real x; "
             "x := if false then 1 else 2.5; "
             "if x > 2.0 then result := 1 else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+        assert result.ok
+
+    def test_accepts_boolean_and_string_conditional_expressions(self) -> None:
+        ast = parse_algol(
+            "begin integer result; boolean ok; string word; "
+            "ok := if false then false else true; "
+            "word := if ok then 'YES' else 'NO'; "
+            "if ok and (word = 'YES') then result := 1 else result := 0 "
             "end"
         )
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -131,6 +131,9 @@ All notable changes to this package will be documented in this file.
 - Added storage-semantics convergence coverage for mixed `own` scalars and
   arrays, boolean/string `value` array copies, and value versus by-name loop
   control storage updates.
+- Added edge-semantics convergence coverage for boolean/string conditional
+  expressions, conditional subscripts, terminal labels, invalid switch indexes,
+  array element caps, and heap exhaustion guard behavior.
 - Accepted uppercase and mixed-case keywords/comments, `<>` not-equal
   relations, and double-quoted string literals through the full WASM pipeline.
 

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -153,6 +153,9 @@ local WASM runtime. Those fixtures cover:
   output executes
 - mixed `own` scalar and array storage for real, boolean, and string values,
   plus value-array copies and by-name loop-control storage behavior
+- boolean and string conditional values, conditional subscripts, terminal labels
+  on empty statements, invalid switch indexes, array element caps, and heap
+  exhaustion through the zero-result runtime guard path
 - a full-surface convergence program combining `own` scalars and arrays,
   default-real arrays, nested and single-statement procedures, value and
   by-name procedure formals, label and switch formals, multiple `for` element

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/edge-semantics.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/edge-semantics.alg
@@ -1,0 +1,27 @@
+begin
+  integer result, edgeScore, subscriptScore, labelScore;
+  boolean choose, ok;
+  string word;
+  integer array values[1:2];
+
+  choose := false;
+  ok := if choose then false else true;
+  word := if ok then 'YES' else 'NO';
+  if ok and (word = 'YES') then edgeScore := 11 else edgeScore := 0;
+
+  values[1] := 3;
+  values[2] := 5;
+  subscriptScore := values[if ok then 2 else 1] * 7;
+
+  begin
+    labelScore := 19;
+    goto finished;
+    labelScore := 0;
+    finished:
+  end;
+
+  result := edgeScore + subscriptScore + labelScore;
+  print('EDGE');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -193,6 +193,16 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_string_and_boolean_conditional_expressions_execute(self) -> None:
+        result = compile_source(
+            "begin integer result; boolean ok; string word; "
+            "ok := if false then false else true; "
+            "word := if ok then 'YES' else 'NO'; "
+            "if ok and (word = 'YES') then result := 7 else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
     def test_statement_lists_allow_trailing_and_repeated_semicolons(self) -> None:
         result = compile_source(
             "begin integer result; ; result := 1;; result := 2; end"
@@ -977,6 +987,14 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [11]
+
+    def test_switch_index_out_of_range_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result; switch exits := done; "
+            "goto exits[2]; result := 9; done: result := 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
 
     def test_procedure_parameter_statement_call_dispatches_actual(self) -> None:
         result = compile_source(
@@ -2074,6 +2092,14 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
+    def test_terminal_label_can_end_nested_block(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "begin result := 13; goto done; result := 0; done: end "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [13]
+
     def test_out_of_bounds_array_access_returns_zero(self) -> None:
         result = compile_source(
             "begin integer result; integer array a[1:2]; "
@@ -2155,5 +2181,20 @@ class TestAlgolWasmCompiler:
     def test_invalid_array_bounds_return_zero(self) -> None:
         result = compile_source(
             "begin integer result; integer array a[3:1]; result := 1 end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_array_allocation_element_cap_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result; integer array a[1:4097]; result := 1 end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_heap_exhaustion_returns_zero(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "real array a[1:4096], b[1:4096], c[1:4096]; "
+            "result := 1 "
+            "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -37,6 +37,7 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="by-name-mixed-scalars", result=[27], stdout="BYNAME 27"),
     GoldenFixture(name="runtime-guards", result=[0], stdout=""),
     GoldenFixture(name="storage-semantics", result=[737], stdout="STORAGE 737"),
+    GoldenFixture(name="edge-semantics", result=[65], stdout="EDGE 65"),
 )
 
 


### PR DESCRIPTION
## Summary
- fix ALGOL label collection so terminal labels nested inside compound statements are discovered without leaking labels from real nested blocks
- add edge-semantics golden fixture covering boolean/string conditional expressions, conditional subscripts, and terminal labels
- add runtime guard coverage for invalid switch indexes, array element caps, and heap exhaustion returning through the zero-result path

## Verification
- python -m pytest tests/ -v in code/packages/python/algol-type-checker
- python -m pytest tests/ -v in code/packages/python/algol-ir-compiler
- python -m pytest tests/ -v in code/packages/python/algol-wasm-compiler
- python -m ruff check ../algol-type-checker ../algol-ir-compiler .
- git diff --check
- rg security scan over touched files for process execution, shell, network, filesystem deletion, and unsafe deserialization patterns