### PR TITLE
Normalize HTML carriage return newlines

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -179,6 +179,8 @@ documented in this file.
   a final generated batch for the remaining aliases.
 - Treated form feed as an HTML ASCII-whitespace delimiter for script
   double-escape boundaries and semicolonless legacy character references.
+- Enabled HTML input-stream newline preprocessing in the Rust wrapper, so CRLF
+  pairs and bare carriage returns tokenize as LF.
 - EOF inside ordinary start/end tag construction now drops the partial token
   after reporting EOF-in-tag diagnostics.
 - EOF inside attribute character-reference substates now also drops the partial

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -61,6 +61,9 @@ an ASCII alphanumeric character or `=`.
 Form feed is treated as HTML ASCII whitespace in the generated delimiter
 paths, including script double-escape boundaries and semicolonless legacy named
 character references.
+The Rust HTML wrapper also enables input-stream newline preprocessing, so CRLF
+pairs and bare carriage returns are tokenized as LF while source offsets still
+advance across the original bytes.
 Numeric character references report invalid-code-point diagnostics and recover
 with the HTML replacement/remapping rules for null, surrogate, out-of-range,
 noncharacter, and Windows-1252 control references.

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -37,7 +37,7 @@ pub fn html_skeleton_machine() -> std::result::Result<EffectfulStateMachine, Str
 /// Build a Rust HTML lexer over the statically linked HTML 1.x compatibility floor.
 pub fn create_html_lexer() -> Result<HtmlLexer> {
     html1_machine()
-        .map(HtmlLexer::new)
+        .map(|machine| HtmlLexer::new(machine).with_normalized_carriage_returns())
         .map_err(TokenizerError::Machine)
 }
 

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -92,14 +92,14 @@ fn fixture_manifests_parse() {
     assert_eq!(html1.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(html1.suite, "html1");
     assert!(!html1.description.is_empty());
-    assert_eq!(html1.cases.len(), 141);
+    assert_eq!(html1.cases.len(), 142);
 }
 
 #[test]
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 148);
+    assert_eq!(file.tests.len(), 149);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -164,7 +164,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 148);
+    assert_eq!(normalized.cases.len(), 149);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -239,7 +239,7 @@ fn html1_conformance_cases_match_generated_machine() {
     let suite = load_suite(HTML1_FIXTURES);
     run_fixture_suite(&suite, |case| {
         let mut lexer = html1_machine()
-            .map(HtmlLexer::new)
+            .map(|machine| HtmlLexer::new(machine).with_normalized_carriage_returns())
             .map_err(|error| error.to_string())?;
         configure_lexer_for_case(&mut lexer, case).map_err(|error| format!("{error:?}"))?;
         Ok(lexer)
@@ -263,7 +263,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 148);
+    assert_eq!(suite.cases.len(), 149);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;
@@ -279,7 +279,7 @@ fn normalized_html5lib_cases_match_generated_html1_machine() {
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = html1_machine()
-            .map(HtmlLexer::new)
+            .map(|machine| HtmlLexer::new(machine).with_normalized_carriage_returns())
             .map_err(|error| error.to_string())?;
         configure_lexer_for_case(&mut lexer, case).map_err(|error| format!("{error:?}"))?;
         Ok(lexer)

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -122,6 +122,7 @@ currently supports:
   `copy`, and `reg` before delimiters and EOF
 - form-feed handling as an HTML ASCII-whitespace delimiter for script double
   escape and semicolonless legacy named character references
+- CRLF and bare-CR input-stream newline preprocessing before tokenization
 - EOF recovery for unfinished ordinary start and end tags, ensuring partial
   tokens are dropped before the parser sees them
 - EOF recovery for unfinished attribute character references, including named

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -1548,6 +1548,17 @@
       ]
     },
     {
+      "id": "html-carriage-return-newline-normalization",
+      "description": "CRLF and bare CR normalize to LF before HTML tokenization",
+      "input": "<p\r\nclass=x>one\rtwo\r\nthree</p>",
+      "tokens": [
+        "StartTag(name=p, attributes=[class=x], self_closing=false)",
+        "Text(data=one\ntwo\nthree)",
+        "EndTag(name=p)",
+        "EOF"
+      ]
+    },
+    {
       "id": "html-eof-drops-partial-start-tag",
       "description": "EOF in an unfinished start tag drops the partial token",
       "input": "<div class=\"open",

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -1759,6 +1759,18 @@
     },
     {
       "id": "html5lib-smoke-145",
+      "description": "carriage return newline normalization",
+      "input": "<p\r\nclass=x>one\rtwo\r\nthree</p>",
+      "tokens": [
+        "StartTag(name=p, attributes=[class=x], self_closing=false)",
+        "Text(data=one\ntwo\nthree)",
+        "EndTag(name=p)",
+        "EOF"
+      ],
+      "diagnostics": []
+    },
+    {
+      "id": "html5lib-smoke-146",
       "description": "eof drops partial start tag",
       "input": "<div class=\"open",
       "tokens": [
@@ -1769,7 +1781,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-146",
+      "id": "html5lib-smoke-147",
       "description": "eof drops partial end tag",
       "input": "</section class=x",
       "tokens": [
@@ -1782,7 +1794,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-147",
+      "id": "html5lib-smoke-148",
       "description": "eof drops attribute named reference start tag",
       "input": "<a href=&copy",
       "tokens": [
@@ -1794,7 +1806,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-148",
+      "id": "html5lib-smoke-149",
       "description": "eof drops attribute numeric reference start tag",
       "input": "<a href=&#x41",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -1780,6 +1780,27 @@
       ]
     },
     {
+      "description": "carriage return newline normalization",
+      "input": "<p\r\nclass=x>one\rtwo\r\nthree</p>",
+      "output": [
+        [
+          "StartTag",
+          "p",
+          {
+            "class": "x"
+          }
+        ],
+        [
+          "Character",
+          "one\ntwo\nthree"
+        ],
+        [
+          "EndTag",
+          "p"
+        ]
+      ]
+    },
+    {
       "description": "eof drops partial start tag",
       "input": "<div class=\"open",
       "output": [],

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -165,6 +165,30 @@ fn default_html_lexer_treats_form_feed_as_tag_whitespace() {
 }
 
 #[test]
+fn default_html_lexer_normalizes_carriage_return_newlines() {
+    let tokens = lex_html("<p\r\nclass=x>one\rtwo\r\nthree</p>").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::StartTag {
+                name: "p".to_string(),
+                attributes: vec![Attribute {
+                    name: "class".to_string(),
+                    value: "x".to_string(),
+                }],
+                self_closing: false,
+            },
+            Token::Text("one\ntwo\nthree".to_string()),
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_reports_and_drops_duplicate_attributes() {
     let mut lexer = create_html_lexer().unwrap();
 

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -38,3 +38,5 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
   out-of-range, noncharacter, and Windows-1252 control references.
 - Expanded the built-in HTML named-character-reference table with the remaining
   HTML4-era `alefsym` and `oline` math references.
+- Added opt-in CRLF/bare-CR newline normalization for wrapper packages that
+  need HTML input-stream preprocessing before transition matching.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -126,6 +126,11 @@ The runtime also exposes context-seeding helpers such as
 packages can execute HTML submodes like RCDATA without loading definition files
 at runtime.
 
+Wrapper packages can opt into HTML-style input-stream newline preprocessing
+with `Tokenizer::with_normalized_carriage_returns`. That maps CRLF pairs and
+bare carriage returns to a single LF before transition matching while keeping
+raw byte/scalar offsets moving across skipped LF bytes.
+
 ## Development
 
 ```bash

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -203,6 +203,8 @@ pub struct Tokenizer {
     trace: Vec<TokenizerTraceEntry>,
     position: SourcePosition,
     max_steps_per_input: usize,
+    normalize_carriage_returns: bool,
+    skip_line_feed_after_carriage_return: bool,
     finished: bool,
 }
 
@@ -222,6 +224,8 @@ impl Tokenizer {
             trace: Vec::new(),
             position: SourcePosition::default(),
             max_steps_per_input: 64,
+            normalize_carriage_returns: false,
+            skip_line_feed_after_carriage_return: false,
             finished: false,
         }
     }
@@ -229,6 +233,16 @@ impl Tokenizer {
     /// Set the per-input step limit used to catch non-consuming transition loops.
     pub fn with_max_steps_per_input(mut self, limit: usize) -> Self {
         self.max_steps_per_input = limit.max(1);
+        self
+    }
+
+    /// Normalize CRLF and bare CR input-stream newlines to LF before tokenizing.
+    ///
+    /// HTML tokenization runs over a preprocessed input stream where `\r\n`
+    /// and bare `\r` are exposed to the tokenizer as a single `\n`. This is
+    /// opt-in so non-HTML tokenizer profiles can keep exact source code points.
+    pub fn with_normalized_carriage_returns(mut self) -> Self {
+        self.normalize_carriage_returns = true;
         self
     }
 
@@ -263,7 +277,7 @@ impl Tokenizer {
         }
 
         for ch in chunk.chars() {
-            self.process_code_point(ch)?;
+            self.process_source_code_point(ch)?;
         }
         Ok(())
     }
@@ -273,6 +287,7 @@ impl Tokenizer {
         if self.finished {
             return Ok(());
         }
+        self.skip_line_feed_after_carriage_return = false;
 
         for _ in 0..self.max_steps_per_input {
             let before = self.position;
@@ -346,7 +361,29 @@ impl Tokenizer {
         self.diagnostics.clear();
         self.trace.clear();
         self.position = SourcePosition::default();
+        self.skip_line_feed_after_carriage_return = false;
         self.finished = false;
+    }
+
+    fn process_source_code_point(&mut self, ch: char) -> Result<()> {
+        if !self.normalize_carriage_returns {
+            return self.process_code_point(ch);
+        }
+
+        if self.skip_line_feed_after_carriage_return {
+            self.skip_line_feed_after_carriage_return = false;
+            if ch == '\n' {
+                self.advance_skipped_line_feed_after_carriage_return();
+                return Ok(());
+            }
+        }
+
+        if ch == '\r' {
+            self.skip_line_feed_after_carriage_return = true;
+            return self.process_code_point('\n');
+        }
+
+        self.process_code_point(ch)
     }
 
     fn process_code_point(&mut self, ch: char) -> Result<()> {
@@ -1277,6 +1314,11 @@ impl Tokenizer {
         } else {
             self.position.column += 1;
         }
+    }
+
+    fn advance_skipped_line_feed_after_carriage_return(&mut self) {
+        self.position.byte_offset += '\n'.len_utf8();
+        self.position.char_offset += 1;
     }
 }
 

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -50,6 +50,42 @@ fn tokenizer_bounds_non_consuming_transition_loops() {
 }
 
 #[test]
+fn tokenizer_preserves_carriage_returns_by_default() {
+    let mut tokenizer = text_tokenizer();
+
+    tokenizer.push("a\r\nb\rc\n").unwrap();
+    tokenizer.finish().unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Text("a\r\nb\rc\n".to_string()), Token::Eof]
+    );
+    assert_eq!(tokenizer.position().byte_offset, 7);
+    assert_eq!(tokenizer.position().char_offset, 7);
+    assert_eq!(tokenizer.position().line, 3);
+    assert_eq!(tokenizer.position().column, 1);
+}
+
+#[test]
+fn tokenizer_can_normalize_carriage_returns_across_chunks() {
+    let mut tokenizer = text_tokenizer().with_normalized_carriage_returns();
+
+    tokenizer.push("a\r").unwrap();
+    tokenizer.push("\nb\rc").unwrap();
+    tokenizer.push("\n").unwrap();
+    tokenizer.finish().unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Text("a\nb\nc\n".to_string()), Token::Eof]
+    );
+    assert_eq!(tokenizer.position().byte_offset, 7);
+    assert_eq!(tokenizer.position().char_offset, 7);
+    assert_eq!(tokenizer.position().line, 4);
+    assert_eq!(tokenizer.position().column, 1);
+}
+
+#[test]
 fn tokenizer_builds_start_tag_attributes_and_self_closing_markers() {
     let mut tokenizer = Tokenizer::new(
         EffectfulStateMachine::new(
@@ -2050,6 +2086,25 @@ fn tokenizer_supports_rcdata_end_tag_candidate_fallback_action() {
         mismatch.drain_tokens(),
         vec![Token::Text("Hello</style>".to_string()), Token::Eof]
     );
+}
+
+fn text_tokenizer() -> Tokenizer {
+    Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["data", "done"]),
+            HashSet::new(),
+            vec![
+                EffectfulTransition::new("data", EffectfulMatcher::Any, "data")
+                    .with_effects(&["append_text(current)"]),
+                EffectfulTransition::new("data", EffectfulMatcher::End, "done")
+                    .with_effects(&["flush_text", "emit(EOF)"])
+                    .consuming(false),
+            ],
+            "data".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    )
 }
 
 fn set(values: &[&str]) -> HashSet<String> {


### PR DESCRIPTION
## Summary
- Add opt-in CRLF and bare-CR normalization to the tokenizer runtime while keeping raw behavior as the default.
- Enable HTML input-stream newline preprocessing in the Rust HTML lexer wrapper and generated-machine conformance path.
- Add runtime, direct lexer, html1, and html5lib-style fixture coverage for CRLF and bare-CR normalization.

## Verification
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml
- git diff --check