### PR TITLE
Guard ALGOL real truncation edges

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -105,6 +105,9 @@ All notable changes to this package will be documented in this file.
 - Lowered real exponentiation to integer-to-real promotion and the imported
   `F64_POW` IR opcode, with NaN results routed through the runtime-failure
   path.
+- Guarded real-to-integer truncation before emitting `I32_TRUNC_FROM_F64`, so
+  oversized, infinite, or NaN real values return through ALGOL's runtime
+  failure path instead of leaking WASM traps or host exceptions.
 - Added configurable generated-state limits for eval thunks, conditional label
   sets, loop label sets, switch dispatch states, and output helper label sets,
   with targeted `CompileError` diagnostics when lowering would exceed them.

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -104,7 +104,9 @@ before the WASM data encoder can materialize the memory image, dynamic
 procedure recursion stops at the bounded frame stack, and invalid array bounds,
 out-of-bounds subscripts, integer `div`/`mod` by zero or signed divide
 overflow, real division by zero, zero-real-base negative exponentiation,
-oversized arrays, negative `sqrt` arguments, or heap exhaustion return `0`.
+real-to-integer conversions outside the WASM `i32.trunc_f64_s` domain,
+non-finite real output, oversized arrays, negative `sqrt` arguments, or heap
+exhaustion return `0`.
 The lowering pass also has configurable generated-state limits for eval thunks,
 conditional label sets, loop label sets, switch dispatch states, and output
 helper label sets. Callers can pass `IrCompilerLimits` to `compile_algol` or

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -107,6 +107,7 @@ _BOOLEAN_TYPE = "boolean"
 _REAL_TYPE = "real"
 _STRING_TYPE = "string"
 _I32_MIN = -(1 << 31)
+_I32_MAX_EXCLUSIVE = 1 << 31
 _I32_NEG_ONE = -1
 _STRING_DESCRIPTOR_LENGTH_OFFSET = 0
 _STRING_DESCRIPTOR_DATA_POINTER_OFFSET = 4
@@ -3699,7 +3700,7 @@ class AlgolIrCompiler:
         if call.label == _BUILTIN_ABS_LABEL:
             return self._emit_builtin_abs(value, actual_type)
         if call.label == _BUILTIN_ENTIER_LABEL:
-            return self._emit_builtin_entier(value, actual_type)
+            return self._emit_builtin_entier(value, actual_type, scope)
         if call.label == _BUILTIN_SIGN_LABEL:
             return self._emit_builtin_sign(value, actual_type)
         if call.label == _BUILTIN_SQRT_LABEL:
@@ -3756,7 +3757,12 @@ class AlgolIrCompiler:
         self._label(end_label)
         return result
 
-    def _emit_builtin_entier(self, value: int, actual_type: str) -> int:
+    def _emit_builtin_entier(
+        self,
+        value: int,
+        actual_type: str,
+        scope: _FrameScope,
+    ) -> int:
         if actual_type == _INTEGER_TYPE:
             result = self._fresh_reg()
             self._copy_reg(dst=result, src=value)
@@ -3768,7 +3774,7 @@ class AlgolIrCompiler:
         maybe_adjust_label = f"builtin_entier_{index}_maybe_adjust"
         end_label = f"builtin_entier_{index}_end"
         result = self._fresh_reg()
-        self._emit(IrOp.I32_TRUNC_FROM_F64, IrRegister(result), IrRegister(value))
+        self._emit_checked_i32_trunc_from_f64(result, value, scope)
         negative = self._fresh_reg()
         self._emit(
             IrOp.F64_CMP_LT,
@@ -4147,6 +4153,7 @@ class AlgolIrCompiler:
         positive_label = f"algol_label_output_real_{index}_positive"
         normalized_label = f"algol_label_output_real_{index}_normalized"
         no_carry_label = f"algol_label_output_real_{index}_no_carry"
+        no_sign_label = f"algol_label_output_real_{index}_no_sign"
 
         zero_f64 = self._const_f64_reg(0.0)
         abs_reg = self._fresh_reg()
@@ -4162,7 +4169,6 @@ class AlgolIrCompiler:
             IrRegister(negative_reg),
             IrLabel(positive_label),
         )
-        self._emit_output_chars("-", scope)
         self._emit(
             IrOp.F64_SUB,
             IrRegister(abs_reg),
@@ -4175,11 +4181,7 @@ class AlgolIrCompiler:
         self._label(normalized_label)
 
         integer_part_reg = self._fresh_reg()
-        self._emit(
-            IrOp.I32_TRUNC_FROM_F64,
-            IrRegister(integer_part_reg),
-            IrRegister(abs_reg),
-        )
+        self._emit_checked_i32_trunc_from_f64(integer_part_reg, abs_reg, scope)
         integer_part_f64 = self._coerce_reg_to_type(
             integer_part_reg,
             _INTEGER_TYPE,
@@ -4240,6 +4242,13 @@ class AlgolIrCompiler:
         )
         self._label(no_carry_label)
 
+        self._emit(
+            IrOp.BRANCH_Z,
+            IrRegister(negative_reg),
+            IrLabel(no_sign_label),
+        )
+        self._emit_output_chars("-", scope)
+        self._label(no_sign_label)
         self._emit_output_integer(integer_part_reg, scope)
         self._emit_output_chars(".", scope)
         self._emit_output_three_digits(fraction_digits_reg, scope)
@@ -4300,6 +4309,42 @@ class AlgolIrCompiler:
                 IrRegister(ascii_zero_reg),
             )
             self._emit_output_reg(ascii_reg, scope)
+
+    def _emit_checked_i32_trunc_from_f64(
+        self,
+        dst_reg: int,
+        value_reg: int,
+        scope: _FrameScope,
+    ) -> None:
+        nan_reg = self._fresh_reg()
+        too_low_reg = self._fresh_reg()
+        too_high_reg = self._fresh_reg()
+        self._emit(
+            IrOp.F64_CMP_NE,
+            IrRegister(nan_reg),
+            IrRegister(value_reg),
+            IrRegister(value_reg),
+        )
+        self._emit_runtime_failure_guard(nan_reg, scope)
+        self._emit(
+            IrOp.F64_CMP_LT,
+            IrRegister(too_low_reg),
+            IrRegister(value_reg),
+            IrRegister(self._const_f64_reg(float(_I32_MIN))),
+        )
+        self._emit_runtime_failure_guard(too_low_reg, scope)
+        self._emit(
+            IrOp.F64_CMP_GE,
+            IrRegister(too_high_reg),
+            IrRegister(value_reg),
+            IrRegister(self._const_f64_reg(float(_I32_MAX_EXCLUSIVE))),
+        )
+        self._emit_runtime_failure_guard(too_high_reg, scope)
+        self._emit(
+            IrOp.I32_TRUNC_FROM_F64,
+            IrRegister(dst_reg),
+            IrRegister(value_reg),
+        )
 
     def _emit_extract_integer_digit(
         self,

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -107,6 +107,9 @@ All notable changes to this package will be documented in this file.
   `0` through the ALGOL runtime failure path.
 - Executed real exponentiation through the `compiler_math` `f64_pow` import,
   including integer-base promotion and domain failures returning `0`.
+- Returned `0` for out-of-range, infinite, or NaN real values reaching
+  `entier` or fixed-format real output, preventing host/WASM conversion
+  exceptions from escaping end-to-end execution.
 - Added a standard-real-math golden fixture covering imported real math,
   real exponentiation, and output in one end-to-end program.
 - Added a convergence golden fixture that combines conditional expressions,

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -156,6 +156,8 @@ local WASM runtime. Those fixtures cover:
 - boolean and string conditional values, conditional subscripts, terminal labels
   on empty statements, invalid switch indexes, array element caps, and heap
   exhaustion through the zero-result runtime guard path
+- real-to-integer and real-output edge cases that would otherwise trap on
+  overflow, infinity, or NaN now return through the same zero-result guard path
 - a full-surface convergence program combining `own` scalars and arrays,
   default-real arrays, nested and single-statement procedures, value and
   by-name procedure formals, label and switch formals, multiple `for` element

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -332,6 +332,35 @@ class TestAlgolWasmCompiler:
             result.binary, "_start", []
         ) == [0]
 
+    def test_entier_out_of_i32_range_returns_zero_without_trapping(self) -> None:
+        result = compile_source(
+            "begin integer result; result := entier(1.0E100) end"
+        )
+
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_entier_nan_returns_zero_without_trapping(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := (1.0E308 * 10.0) * 0.0; "
+            "result := entier(x) "
+            "end"
+        )
+
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [0]
+
+    def test_entier_keeps_i32_boundary_floor_semantics(self) -> None:
+        result = compile_source(
+            "begin integer result, floor, top; "
+            "floor := entier(-2147483647.5) + 2147483647; "
+            "top := entier(2147483647.9); "
+            "if (floor = -1) and (top = 2147483647) "
+            "then result := 7 else result := 0 "
+            "end"
+        )
+
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
     def test_builtin_print_string_literal_writes_stdout(self) -> None:
         result = compile_source("begin integer result; print('Hi'); result := 7 end")
         captured: list[str] = []
@@ -377,6 +406,50 @@ class TestAlgolWasmCompiler:
 
         assert runtime.load_and_run(result.binary, "_start", []) == [4]
         assert "".join(captured) == "3.500-0.125"
+
+    def test_builtin_print_infinite_real_returns_zero_without_stdout(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := 1.0E308 * 10.0; "
+            "print(x); "
+            "result := 7 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [0]
+        assert "".join(captured) == ""
+
+    def test_builtin_print_negative_infinite_real_writes_no_partial_sign(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := 0.0 - (1.0E308 * 10.0); "
+            "print(x); "
+            "result := 7 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [0]
+        assert "".join(captured) == ""
+
+    def test_builtin_print_nan_real_returns_zero_without_stdout(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; "
+            "x := (1.0E308 * 10.0) * 0.0; "
+            "print(x); "
+            "result := 7 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [0]
+        assert "".join(captured) == ""
 
     def test_string_variable_assignment_and_output_write_stdout(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- add checked f64-to-i32 truncation in the ALGOL IR compiler before emitting `I32_TRUNC_FROM_F64`
- route oversized, infinite, and NaN real values from `entier` and fixed-format real output through the normal zero-result runtime-failure path
- make failed negative real output all-or-nothing so no partial minus sign reaches stdout before the guard returns
- document the new real conversion/output guard coverage

## Verification
- targeted ALGOL WASM regression tests for `entier`, NaN/infinity, boundary floor behavior, and real output
- python -m pytest tests/ -v in code/packages/python/algol-ir-compiler: 120 passed
- python -m pytest tests/ -v in code/packages/python/algol-wasm-compiler: 237 passed
- python -m ruff check code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler
- git diff --check
- rg security scan over touched files for process execution, shell, network, filesystem deletion, and unsafe deserialization patterns