### PR TITLE
Expand script substate fixtures

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -71,6 +71,8 @@ documented in this file.
 - Script-data double-escaped tokenizer states, so nested-looking
   `<script>...</script>` text inside escaped script comments does not
   prematurely emit the outer script end tag.
+- html5lib-style normalization and conformance coverage for seeded script
+  escaped/double-escaped dash, dash-dash, and less-than-sign substates.
 - Seeded CDATA section tokenizer-state support for future parser-controlled
   foreign-content tokenization, keeping markup and character references literal
   until the `]]>` delimiter returns the lexer to data state.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -134,12 +134,15 @@ the current recovery diagnostics for missing whitespace, missing identifier
 quotes, and abrupt identifier termination while preserving any recoverable
 public/system identifier text.
 The generated HTML1 machine also exposes `RCDATA`, `RAWTEXT`, `PLAINTEXT`,
-`CDATA section`, `script_data`, `script_data_escaped`, and
-`script_data_double_escaped` entry states for parser-controlled tokenizer
-submodes. The markup declaration path also recognizes `<![CDATA[` and enters
-the CDATA section state so the generated lexer can exercise that tokenizer
-subflow end to end; a future parser can still decide when that opener is valid
-for foreign-content contexts.
+`CDATA section`, `script_data`, `script_data_escaped`,
+`script_data_escaped_dash`, `script_data_escaped_dash_dash`,
+`script_data_escaped_less_than_sign`, `script_data_double_escaped`,
+`script_data_double_escaped_dash`, `script_data_double_escaped_dash_dash`, and
+`script_data_double_escaped_less_than_sign` entry states for parser-controlled
+tokenizer submodes. The markup declaration path also recognizes `<![CDATA[`
+and enters the CDATA section state so the generated lexer can exercise that
+tokenizer subflow end to end; a future parser can still decide when that opener
+is valid for foreign-content contexts.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 
@@ -166,11 +169,11 @@ fixture normalization logic to live forever inside the Rust tests.
 
 The normalized corpus now carries optional tokenizer-context metadata such as
 `initial_state` and `last_start_tag`, so upstream RCDATA, RAWTEXT, PLAINTEXT,
-CDATA section, script data, script data escaped, and script data double escaped
-cases can already live in the shared Venture fixture format. Current Rust
-conformance tests now seed that context into the generated lexer so the first
-non-data-state cases execute through the same static Rust wrapper as the
-data-state corpus.
+CDATA section, script data, script data escaped/dash/less-than substates, and
+script data double-escaped/dash/less-than substates can already live in the
+shared Venture fixture format. Current Rust conformance tests now seed that
+context into the generated lexer so non-data-state cases execute through the
+same static Rust wrapper as the data-state corpus.
 
 The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
 same schema rather than teaching the Rust harness to parse raw upstream files

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -99,7 +99,7 @@ fn fixture_manifests_parse() {
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 150);
+    assert_eq!(file.tests.len(), 156);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -159,12 +159,18 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "PLAINTEXT state".to_string(),
             "RAWTEXT state".to_string(),
             "RCDATA state".to_string(),
+            "Script data double escaped dash dash state".to_string(),
+            "Script data double escaped dash state".to_string(),
+            "Script data double escaped less-than sign state".to_string(),
             "Script data double escaped state".to_string(),
+            "Script data escaped dash dash state".to_string(),
+            "Script data escaped dash state".to_string(),
+            "Script data escaped less-than sign state".to_string(),
             "Script data escaped state".to_string(),
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 150);
+    assert_eq!(normalized.cases.len(), 156);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -263,7 +269,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 150);
+    assert_eq!(suite.cases.len(), 156);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;
@@ -339,7 +345,13 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
         Some("PLAINTEXT state") => case.last_start_tag.is_none(),
         Some("RCDATA state") => case.last_start_tag.is_some(),
         Some("RAWTEXT state") => case.last_start_tag.is_some(),
+        Some("Script data double escaped dash dash state") => case.last_start_tag.is_some(),
+        Some("Script data double escaped dash state") => case.last_start_tag.is_some(),
+        Some("Script data double escaped less-than sign state") => case.last_start_tag.is_some(),
         Some("Script data double escaped state") => case.last_start_tag.is_some(),
+        Some("Script data escaped dash dash state") => case.last_start_tag.is_some(),
+        Some("Script data escaped dash state") => case.last_start_tag.is_some(),
+        Some("Script data escaped less-than sign state") => case.last_start_tag.is_some(),
         Some("Script data escaped state") => case.last_start_tag.is_some(),
         Some("Script data state") => case.last_start_tag.is_some(),
         Some(_) => false,
@@ -405,7 +417,15 @@ fn machine_state_for_fixture(state: &str) -> &str {
         "PLAINTEXT state" => "plaintext",
         "RCDATA state" => "rcdata",
         "RAWTEXT state" => "rawtext",
+        "Script data double escaped dash dash state" => "script_data_double_escaped_dash_dash",
+        "Script data double escaped dash state" => "script_data_double_escaped_dash",
+        "Script data double escaped less-than sign state" => {
+            "script_data_double_escaped_less_than_sign"
+        }
         "Script data double escaped state" => "script_data_double_escaped",
+        "Script data escaped dash dash state" => "script_data_escaped_dash_dash",
+        "Script data escaped dash state" => "script_data_escaped_dash",
+        "Script data escaped less-than sign state" => "script_data_escaped_less_than_sign",
         "Script data escaped state" => "script_data_escaped",
         "Script data state" => "script_data",
         other => panic!("unsupported fixture state `{other}`"),

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -70,6 +70,16 @@ currently supports:
 - explicit `initialStates: ["Data state"]`
 - `initialStates: ["RCDATA state"]` together with `lastStartTag`
 - `initialStates: ["RAWTEXT state"]` together with `lastStartTag`
+- `initialStates: ["PLAINTEXT state"]`
+- `initialStates: ["CDATA section state"]`
+- `initialStates: ["Script data state"]` together with `lastStartTag`
+- `initialStates: ["Script data escaped state"]` together with `lastStartTag`
+- script escaped `dash`, `dash dash`, and `less-than sign` substates together
+  with `lastStartTag`
+- `initialStates: ["Script data double escaped state"]` together with
+  `lastStartTag`
+- script double-escaped `dash`, `dash dash`, and `less-than sign` substates
+  together with `lastStartTag`
 - `StartTag`, `EndTag`, `Character`, `Comment`, and `DOCTYPE` output tokens
 - html5lib start-tag self-closing booleans
 - named character references in data, RCDATA, and attribute values for the

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -10,7 +10,13 @@
     "PLAINTEXT state",
     "RAWTEXT state",
     "RCDATA state",
+    "Script data double escaped dash dash state",
+    "Script data double escaped dash state",
+    "Script data double escaped less-than sign state",
     "Script data double escaped state",
+    "Script data escaped dash dash state",
+    "Script data escaped dash state",
+    "Script data escaped less-than sign state",
     "Script data escaped state",
     "Script data state"
   ],
@@ -1769,6 +1775,82 @@
     },
     {
       "id": "html5lib-smoke-146",
+      "description": "script escaped dash state can resume escaped text and close script",
+      "input": "x</script>",
+      "tokens": [
+        "Text(data=x)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data escaped dash state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-147",
+      "description": "script escaped dash dash state exits escaped text on greater-than",
+      "input": ">plain</script>",
+      "tokens": [
+        "Text(data=>plain)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data escaped dash dash state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-148",
+      "description": "script escaped less-than sign state recognizes matching end tag",
+      "input": "/script>tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data escaped less-than sign state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-149",
+      "description": "script double escaped dash state keeps escaped end marker as text",
+      "input": "x</script>tail",
+      "tokens": [
+        "Text(data=x</script>tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data double escaped dash state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-150",
+      "description": "script double escaped dash dash state remains text after greater-than",
+      "input": ">still</script>text",
+      "tokens": [
+        "Text(data=>still</script>text)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data double escaped dash dash state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-151",
+      "description": "script double escaped less-than sign state exits before matching end tag",
+      "input": "/script>after</script>",
+      "tokens": [
+        "Text(data=/script>after)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data double escaped less-than sign state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-152",
       "description": "carriage return newline normalization",
       "input": "<p\r\nclass=x>one\rtwo\r\nthree</p>",
       "tokens": [
@@ -1780,7 +1862,7 @@
       "diagnostics": []
     },
     {
-      "id": "html5lib-smoke-147",
+      "id": "html5lib-smoke-153",
       "description": "eof drops partial start tag",
       "input": "<div class=\"open",
       "tokens": [
@@ -1791,7 +1873,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-148",
+      "id": "html5lib-smoke-154",
       "description": "eof drops partial end tag",
       "input": "</section class=x",
       "tokens": [
@@ -1804,7 +1886,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-149",
+      "id": "html5lib-smoke-155",
       "description": "eof drops attribute named reference start tag",
       "input": "<a href=&copy",
       "tokens": [
@@ -1816,7 +1898,7 @@
       ]
     },
     {
-      "id": "html5lib-smoke-150",
+      "id": "html5lib-smoke-156",
       "description": "eof drops attribute numeric reference start tag",
       "input": "<a href=&#x41",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -16,7 +16,25 @@ SUPPORTED_INITIAL_STATES = {
     "PLAINTEXT state",
     "RCDATA state",
     "RAWTEXT state",
+    "Script data double escaped dash dash state",
+    "Script data double escaped dash state",
+    "Script data double escaped less-than sign state",
     "Script data double escaped state",
+    "Script data escaped dash dash state",
+    "Script data escaped dash state",
+    "Script data escaped less-than sign state",
+    "Script data escaped state",
+    "Script data state",
+}
+
+SCRIPT_INITIAL_STATES = {
+    "Script data double escaped dash dash state",
+    "Script data double escaped dash state",
+    "Script data double escaped less-than sign state",
+    "Script data double escaped state",
+    "Script data escaped dash dash state",
+    "Script data escaped dash state",
+    "Script data escaped less-than sign state",
     "Script data escaped state",
     "Script data state",
 }
@@ -79,24 +97,16 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
         return False, f"unsupported initialStates={initial_states!r}"
 
     last_start_tag = test.get("lastStartTag")
-    if initial_states in (
-        ["RCDATA state"],
-        ["RAWTEXT state"],
-        ["Script data double escaped state"],
-        ["Script data escaped state"],
-        ["Script data state"],
-    ) and not isinstance(last_start_tag, str):
+    if (
+        initial_states
+        and initial_states[0] in {"RCDATA state", "RAWTEXT state", *SCRIPT_INITIAL_STATES}
+        and not isinstance(last_start_tag, str)
+    ):
         return False, f"{initial_states[0]} requires lastStartTag"
 
     if (
         initial_states
-        not in (
-            ["RCDATA state"],
-            ["RAWTEXT state"],
-            ["Script data double escaped state"],
-            ["Script data escaped state"],
-            ["Script data state"],
-        )
+        and initial_states[0] not in {"RCDATA state", "RAWTEXT state", *SCRIPT_INITIAL_STATES}
         and last_start_tag is not None
     ):
         return False, f"unsupported lastStartTag={last_start_tag!r}"

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -1784,6 +1784,106 @@
       ]
     },
     {
+      "description": "script escaped dash state can resume escaped text and close script",
+      "input": "x</script>",
+      "initialStates": [
+        "Script data escaped dash state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "x"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
+      "description": "script escaped dash dash state exits escaped text on greater-than",
+      "input": ">plain</script>",
+      "initialStates": [
+        "Script data escaped dash dash state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          ">plain"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
+      "description": "script escaped less-than sign state recognizes matching end tag",
+      "input": "/script>tail",
+      "initialStates": [
+        "Script data escaped less-than sign state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ]
+    },
+    {
+      "description": "script double escaped dash state keeps escaped end marker as text",
+      "input": "x</script>tail",
+      "initialStates": [
+        "Script data double escaped dash state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "x</script>tail"
+        ]
+      ]
+    },
+    {
+      "description": "script double escaped dash dash state remains text after greater-than",
+      "input": ">still</script>text",
+      "initialStates": [
+        "Script data double escaped dash dash state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          ">still</script>text"
+        ]
+      ]
+    },
+    {
+      "description": "script double escaped less-than sign state exits before matching end tag",
+      "input": "/script>after</script>",
+      "initialStates": [
+        "Script data double escaped less-than sign state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "/script>after"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
       "description": "carriage return newline normalization",
       "input": "<p\r\nclass=x>one\rtwo\r\nthree</p>",
       "output": [


### PR DESCRIPTION
## Summary
- Expand html5lib-style fixture normalization to accept seeded script escaped and double-escaped dash/dash-dash/less-than-sign substates.
- Add six raw smoke cases and regenerate the normalized Venture fixture corpus, bringing it to 156 executable cases.
- Wire the new upstream state names through Rust conformance metadata and document the importer coverage.

## Verification
- env PYTHONPYCACHEPREFIX=/tmp/pycache-html-lexer python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test conformance_test
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml --test html_lexer_test
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check