### PR TITLE
Support call-site ALGOL formal by-name writes

### DIFF
--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from algol_type_checker import (
     ArrayDescriptor,
     LabelDescriptor,
     ProcedureDescriptor,
+    ProcedureFormalCallShape,
     ProcedureParameter,
     ResolvedArrayAccess,
     ResolvedGoto,
@@ -3165,10 +3166,22 @@ class AlgolIrCompiler:
                 f"procedure {procedure.name!r} expects "
                 f"{len(procedure.parameters)} argument(s), got {len(actuals)}"
             )
+        effective_parameters = [
+            replace(
+                parameter,
+                may_write=self._scalar_parameter_may_write_at_call(
+                    procedure,
+                    parameter,
+                    actuals,
+                    scope,
+                ),
+            )
+            for parameter in procedure.parameters
+        ]
         thunk_actuals = [
             (index, argument, parameter)
             for index, (argument, parameter) in enumerate(
-                zip(actuals, procedure.parameters, strict=True)
+                zip(actuals, effective_parameters, strict=True)
             )
             if parameter.kind not in {"array", "label", "switch", "procedure"}
             and parameter.mode == _NAME_MODE
@@ -3200,7 +3213,7 @@ class AlgolIrCompiler:
 
         arguments: list[int | None] = [None] * len(actuals)
         for index, (argument, parameter) in enumerate(
-            zip(actuals, procedure.parameters, strict=True)
+            zip(actuals, effective_parameters, strict=True)
         ):
             if parameter.kind == "array":
                 continue
@@ -3264,7 +3277,7 @@ class AlgolIrCompiler:
             )
         }
         for index, (argument, parameter) in enumerate(
-            zip(actuals, procedure.parameters, strict=True)
+            zip(actuals, effective_parameters, strict=True)
         ):
             if parameter.kind == "array":
                 arguments[index] = self._compile_array_actual_pointer(argument, scope)
@@ -3594,6 +3607,72 @@ class AlgolIrCompiler:
             argument_kinds.append("scalar")
             argument_types.append(self._expr_type(actual))
         return tuple(argument_kinds), tuple(argument_types)
+
+    def _scalar_parameter_may_write_at_call(
+        self,
+        procedure: ProcedureDescriptor,
+        parameter: ProcedureParameter,
+        actuals: list[ASTNode],
+        scope: _FrameScope,
+    ) -> bool:
+        if (
+            parameter.kind != "scalar"
+            or parameter.mode != _NAME_MODE
+            or not parameter.may_write
+        ):
+            return False
+        if parameter.write_reason != "transitive call":
+            return True
+
+        saw_formal_procedure_shape = False
+        for procedure_index, procedure_parameter in enumerate(procedure.parameters):
+            if procedure_parameter.kind != "procedure":
+                continue
+            for shape in procedure_parameter.procedure_call_shapes:
+                formal_names = _shape_argument_formal_names(shape)
+                for argument_index, formal_name in enumerate(formal_names):
+                    if formal_name != parameter.name:
+                        continue
+                    saw_formal_procedure_shape = True
+                    if procedure_index >= len(actuals):
+                        return True
+                    if self._procedure_actual_writes_shape_argument(
+                        actuals[procedure_index],
+                        scope,
+                        argument_index,
+                    ):
+                        return True
+        return not saw_formal_procedure_shape
+
+    def _procedure_actual_writes_shape_argument(
+        self,
+        argument: ASTNode,
+        scope: _FrameScope,
+        argument_index: int,
+    ) -> bool:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return True
+        name = _variable_name(variable)
+        if name is None:
+            return True
+        resolved = self._resolve_symbol_in_scope_chain(name.value, scope)
+        if resolved is None:
+            return True
+        symbol, _ = resolved
+        if symbol.kind == "procedure_parameter":
+            return True
+        if symbol.kind != "procedure" or symbol.procedure_id is None:
+            return True
+        procedure = self.procedures.get(symbol.procedure_id)
+        if procedure is None or argument_index >= len(procedure.parameters):
+            return True
+        parameter = procedure.parameters[argument_index]
+        return (
+            parameter.kind == "scalar"
+            and parameter.mode == _NAME_MODE
+            and parameter.may_write
+        )
 
     def _formal_array_argument_type(
         self,
@@ -7322,6 +7401,16 @@ def _procedure_parameter_type_satisfies(
     return _procedure_return_type_satisfies(
         expected_type=expected_type,
         actual_type=actual_type,
+    )
+
+
+def _shape_argument_formal_names(
+    shape: ProcedureFormalCallShape,
+) -> tuple[str | None, ...]:
+    if len(shape.argument_formal_names) >= len(shape.argument_types):
+        return shape.argument_formal_names
+    return shape.argument_formal_names + (None,) * (
+        len(shape.argument_types) - len(shape.argument_formal_names)
     )
 
 

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -225,6 +225,7 @@ class ProcedureFormalCallShape:
     argument_types: tuple[str, ...]
     argument_kinds: tuple[str, ...] = ()
     argument_assignable: tuple[bool, ...] = ()
+    argument_formal_names: tuple[str | None, ...] = ()
     procedure_argument_ids: tuple[int | None, ...] = ()
     return_type: str | None = None
 
@@ -2068,9 +2069,15 @@ class AlgolTypeChecker:
                     f"got {actual_type}",
                 )
                 continue
+            parameter_may_write = self._scalar_parameter_may_write_at_call(
+                descriptor,
+                parameter,
+                arguments,
+                scope,
+            )
             if (
                 parameter.mode == NAME
-                and parameter.may_write
+                and parameter_may_write
                 and (
                     not _is_assignable_actual(argument)
                     or self._resolved_bare_procedure_expression(argument) is not None
@@ -2082,7 +2089,7 @@ class AlgolTypeChecker:
                     "expression is not assignable",
                 )
                 continue
-            if parameter.mode == NAME and parameter.may_write:
+            if parameter.mode == NAME and parameter_may_write:
                 self._record_assignable_actual_write(argument, scope)
 
         if role == "expression" and descriptor.return_type is None:
@@ -2179,6 +2186,7 @@ class AlgolTypeChecker:
         argument_types: list[str] = []
         argument_kinds: list[str] = []
         argument_assignable: list[bool] = []
+        argument_formal_names: list[str | None] = []
         procedure_argument_ids: list[int | None] = []
         for argument in arguments:
             array_type = self._formal_array_argument_type(argument, scope)
@@ -2186,6 +2194,7 @@ class AlgolTypeChecker:
                 argument_types.append(array_type)
                 argument_kinds.append(ARRAY)
                 argument_assignable.append(False)
+                argument_formal_names.append(None)
                 procedure_argument_ids.append(None)
                 continue
             nonscalar = self._formal_nonscalar_argument_shape(argument, scope)
@@ -2194,6 +2203,7 @@ class AlgolTypeChecker:
                 argument_types.append(argument_type)
                 argument_kinds.append(argument_kind)
                 argument_assignable.append(False)
+                argument_formal_names.append(None)
                 procedure_argument_ids.append(procedure_id)
                 continue
             actual_type = self._infer_expr(argument, scope)
@@ -2202,6 +2212,9 @@ class AlgolTypeChecker:
             argument_assignable.append(
                 _is_assignable_actual(argument)
                 and self._resolved_bare_procedure_expression(argument) is None
+            )
+            argument_formal_names.append(
+                self._scalar_by_name_parameter_actual_name(argument, scope)
             )
             procedure_argument_ids.append(None)
             if argument_assignable[-1]:
@@ -2231,6 +2244,7 @@ class AlgolTypeChecker:
                     argument_types=tuple(argument_types),
                     argument_kinds=tuple(argument_kinds),
                     argument_assignable=tuple(argument_assignable),
+                    argument_formal_names=tuple(argument_formal_names),
                     procedure_argument_ids=tuple(procedure_argument_ids),
                     return_type=return_type if role == "expression" else None,
                 ),
@@ -2353,6 +2367,91 @@ class AlgolTypeChecker:
         if symbol.kind == "procedure_parameter" and symbol.type_name == "procedure":
             return "procedure", symbol.type_name, None
         return None
+
+    def _scalar_by_name_parameter_actual_name(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+    ) -> str | None:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return None
+        name = _variable_head_name(variable)
+        if name is None:
+            return None
+        resolved = scope.resolve_with_scope(name.value)
+        if resolved is None:
+            return None
+        symbol, _, _ = resolved
+        if symbol.kind == "parameter" and symbol.parameter_mode == NAME:
+            return symbol.name
+        return None
+
+    def _scalar_parameter_may_write_at_call(
+        self,
+        descriptor: ProcedureDescriptor,
+        parameter: ProcedureParameter,
+        arguments: list[ASTNode],
+        scope: Scope,
+    ) -> bool:
+        if (
+            parameter.kind != "scalar"
+            or parameter.mode != NAME
+            or not parameter.may_write
+        ):
+            return False
+        if parameter.write_reason != "transitive call":
+            return True
+
+        saw_formal_procedure_shape = False
+        for procedure_index, procedure_parameter in enumerate(descriptor.parameters):
+            if procedure_parameter.kind != "procedure":
+                continue
+            for shape in procedure_parameter.procedure_call_shapes:
+                formal_names = _shape_argument_formal_names(shape)
+                for argument_index, formal_name in enumerate(formal_names):
+                    if formal_name != parameter.name:
+                        continue
+                    saw_formal_procedure_shape = True
+                    if procedure_index >= len(arguments):
+                        return True
+                    if self._procedure_actual_writes_shape_argument(
+                        arguments[procedure_index],
+                        scope,
+                        argument_index,
+                    ):
+                        return True
+        return not saw_formal_procedure_shape
+
+    def _procedure_actual_writes_shape_argument(
+        self,
+        argument: ASTNode,
+        scope: Scope,
+        argument_index: int,
+    ) -> bool:
+        variable = _single_variable_expr(argument)
+        if variable is None or _variable_subscripts(variable):
+            return True
+        name = _variable_head_name(variable)
+        if name is None:
+            return True
+        resolved = scope.resolve_with_scope(name.value)
+        if resolved is None:
+            return True
+        symbol, _, _ = resolved
+        if symbol.kind == "procedure_parameter":
+            return True
+        if symbol.kind != "procedure" or symbol.procedure_id is None:
+            return True
+        descriptor = self._procedure_descriptor_for_id(symbol.procedure_id)
+        if descriptor is None or argument_index >= len(descriptor.parameters):
+            return True
+        parameter = descriptor.parameters[argument_index]
+        return (
+            parameter.kind == "scalar"
+            and parameter.mode == NAME
+            and parameter.may_write
+        )
 
     def _record_procedure_parameter_call_shape(
         self,
@@ -3615,6 +3714,16 @@ def _callee_may_write_argument(
         return True
     parameter = procedure.parameters[argument_index]
     return parameter.mode == NAME and parameter.may_write
+
+
+def _shape_argument_formal_names(
+    shape: ProcedureFormalCallShape,
+) -> tuple[str | None, ...]:
+    if len(shape.argument_formal_names) >= len(shape.argument_types):
+        return shape.argument_formal_names
+    return shape.argument_formal_names + (None,) * (
+        len(shape.argument_types) - len(shape.argument_formal_names)
+    )
 
 
 def _direct_block_declared_names(node: ASTNode) -> set[str]:

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -1437,6 +1437,45 @@ class TestAlgolTypeChecker:
         parameter = result.semantic.procedures[0].parameters[0]
         assert parameter.procedure_call_shapes[0].argument_assignable == (False,)
 
+    def test_accepts_forwarded_by_name_expression_when_procedure_actual_reads(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure id(x); value x; integer x; begin id := x end; "
+            "integer procedure apply(f, x); integer f, x; procedure f; "
+            "begin apply := f(x) end; "
+            "result := apply(id, 3 + 4) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        procedure_parameter = result.semantic.procedures[1].parameters[0]
+        scalar_parameter = result.semantic.procedures[1].parameters[1]
+        assert procedure_parameter.procedure_call_shapes[0].argument_formal_names == (
+            "x",
+        )
+        assert scalar_parameter.write_reason == "transitive call"
+
+    def test_rejects_forwarded_by_name_expression_when_procedure_actual_writes(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure inc(x); integer x; "
+            "begin x := x + 1; inc := x end; "
+            "integer procedure apply(f, x); integer f, x; procedure f; "
+            "begin apply := f(x) end; "
+            "result := apply(inc, 3 + 4) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "actual expression is not assignable" in result.diagnostics[0].message
+
     def test_accepts_procedure_parameter_actual_with_array_element_by_name_formal(
         self,
     ) -> None:

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1374,6 +1374,34 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
 
+    def test_formal_procedure_call_accepts_read_only_forwarded_expression(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure id(x); value x; integer x; begin id := x end; "
+            "integer procedure apply(f, x); integer f, x; procedure f; "
+            "begin apply := f(x) end; "
+            "result := apply(id, 3 + 4) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_formal_procedure_call_writes_forwarded_array_element_actual(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result, i; integer array a[1:1]; "
+            "integer procedure inc(x); integer x; "
+            "begin x := x + 1; inc := x end; "
+            "integer procedure apply(f, x); integer f, x; procedure f; "
+            "begin apply := f(x) end; "
+            "a[1] := 3; i := 1; "
+            "result := apply(inc, a[i]) * 10 + a[1] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [44]
+
     def test_real_procedure_parameter_accepts_integer_return_actual(self) -> None:
         result = compile_source(
             "begin integer result; real y; "


### PR DESCRIPTION
## Summary
- track which by-name formal a formal-procedure call forwards as a scalar argument
- make direct call checking distinguish read-only concrete procedure actuals from mutating ones
- make IR thunk/store-capability selection follow the same call-site write decision

## Tests
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/ -v (algol-type-checker)
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/ -v (algol-ir-compiler)
- .venv/bin/python -m pytest tests/ -v (algol-wasm-compiler)
- code/packages/python/algol-wasm-compiler/.venv/bin/python -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler
- git diff --check
- security scan: rg -n 'subprocess|os\.system|\beval\(|\bexec\(|pickle|yaml\.load|shell=True|requests|urllib|socket|chmod|chown|unlink|rmtree|open\(' touched files (no matches)