### PR TITLE
Remap forwarded ALGOL procedure call shapes

### DIFF
--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -2048,7 +2048,13 @@ class AlgolTypeChecker:
                 self._check_switch_parameter_actual(argument, scope, parameter)
                 continue
             if parameter.kind == "procedure":
-                self._check_procedure_parameter_actual(argument, scope, parameter)
+                self._check_procedure_parameter_actual(
+                    argument,
+                    scope,
+                    parameter,
+                    call_descriptor=descriptor,
+                    call_arguments=arguments,
+                )
                 continue
             actual_type = self._infer_expr(argument, scope)
             if actual_type != ERROR and not self._parameter_accepts_type(
@@ -2701,6 +2707,9 @@ class AlgolTypeChecker:
         argument: ASTNode,
         scope: Scope,
         parameter: ProcedureParameter,
+        *,
+        call_descriptor: ProcedureDescriptor | None = None,
+        call_arguments: list[ASTNode] | None = None,
     ) -> Symbol | None:
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
@@ -2725,7 +2734,15 @@ class AlgolTypeChecker:
         symbol, _, _ = resolved
         if symbol.kind == "procedure_parameter":
             for shape in parameter.procedure_call_shapes:
-                self._record_procedure_parameter_call_shape(symbol.symbol_id, shape)
+                self._record_procedure_parameter_call_shape(
+                    symbol.symbol_id,
+                    self._remap_forwarded_procedure_call_shape(
+                        shape,
+                        call_descriptor=call_descriptor,
+                        call_arguments=call_arguments,
+                        scope=scope,
+                    ),
+                )
             return symbol
         if symbol.kind != "procedure" or symbol.procedure_id is None:
             self._error(
@@ -2751,6 +2768,50 @@ class AlgolTypeChecker:
         ):
             return None
         return symbol
+
+    def _remap_forwarded_procedure_call_shape(
+        self,
+        shape: ProcedureFormalCallShape,
+        *,
+        call_descriptor: ProcedureDescriptor | None,
+        call_arguments: list[ASTNode] | None,
+        scope: Scope,
+    ) -> ProcedureFormalCallShape:
+        if call_descriptor is None or call_arguments is None:
+            return shape
+
+        remapped_names: list[str | None] = []
+        for formal_name in _shape_argument_formal_names(shape):
+            if formal_name is None:
+                remapped_names.append(None)
+                continue
+            parameter_index = next(
+                (
+                    index
+                    for index, parameter in enumerate(call_descriptor.parameters)
+                    if parameter.name == formal_name
+                ),
+                None,
+            )
+            if parameter_index is None or parameter_index >= len(call_arguments):
+                remapped_names.append(None)
+                continue
+            remapped_names.append(
+                self._scalar_by_name_parameter_actual_name(
+                    call_arguments[parameter_index],
+                    scope,
+                )
+            )
+
+        return ProcedureFormalCallShape(
+            role=shape.role,
+            argument_types=shape.argument_types,
+            argument_kinds=shape.argument_kinds,
+            argument_assignable=shape.argument_assignable,
+            argument_formal_names=tuple(remapped_names),
+            procedure_argument_ids=shape.procedure_argument_ids,
+            return_type=shape.return_type,
+        )
 
     def _procedure_actual_satisfies_formal_shapes(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -1476,6 +1476,50 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "actual expression is not assignable" in result.diagnostics[0].message
 
+    def test_remaps_forwarded_by_name_formal_through_procedure_wrapper(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure id(x); value x; integer x; begin id := x end; "
+            "integer procedure apply(f, x); integer f, x; procedure f; "
+            "begin apply := f(x) end; "
+            "integer procedure relay(g, y); integer g, y; procedure g; "
+            "begin relay := apply(g, y) end; "
+            "result := relay(id, 3 + 4) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        relay_procedure = result.semantic.procedures[2]
+        procedure_parameter = relay_procedure.parameters[0]
+        scalar_parameter = relay_procedure.parameters[1]
+        assert procedure_parameter.procedure_call_shapes[0].argument_formal_names == (
+            "y",
+        )
+        assert scalar_parameter.write_reason == "transitive call"
+
+    def test_rejects_wrapped_forwarded_by_name_expression_when_actual_writes(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure inc(x); integer x; "
+            "begin x := x + 1; inc := x end; "
+            "integer procedure apply(f, x); integer f, x; procedure f; "
+            "begin apply := f(x) end; "
+            "integer procedure relay(g, y); integer g, y; procedure g; "
+            "begin relay := apply(g, y) end; "
+            "result := relay(inc, 3 + 4) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "actual expression is not assignable" in result.diagnostics[0].message
+
     def test_accepts_procedure_parameter_actual_with_array_element_by_name_formal(
         self,
     ) -> None:

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1402,6 +1402,37 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [44]
 
+    def test_wrapped_formal_procedure_call_accepts_read_only_expression(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure id(x); value x; integer x; begin id := x end; "
+            "integer procedure apply(f, x); integer f, x; procedure f; "
+            "begin apply := f(x) end; "
+            "integer procedure relay(g, y); integer g, y; procedure g; "
+            "begin relay := apply(g, y) end; "
+            "result := relay(id, 3 + 4) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_wrapped_formal_procedure_call_keeps_writable_actual_path(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure inc(x); integer x; "
+            "begin x := x + 1; inc := x end; "
+            "integer procedure apply(f, x); integer f, x; procedure f; "
+            "begin apply := f(x) end; "
+            "integer procedure relay(g, y); integer g, y; procedure g; "
+            "begin relay := apply(g, y) end; "
+            "result := 3; result := relay(inc, result) * 10 + result "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [44]
+
     def test_real_procedure_parameter_accepts_integer_return_actual(self) -> None:
         result = compile_source(
             "begin integer result; real y; "


### PR DESCRIPTION
## Summary
- remap formal-procedure call-shape metadata when one procedure parameter is forwarded through another concrete procedure call
- allow wrapped higher-order by-name reads such as relay(id, 3 + 4)
- keep mutating procedure actuals rejected for non-assignable forwarded expressions and keep writable actual paths executing end to end

## Tests
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/ -v (algol-type-checker)
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/ -v (algol-ir-compiler)
- .venv/bin/python -m pytest tests/ -v (algol-wasm-compiler)
- code/packages/python/algol-wasm-compiler/.venv/bin/python -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler
- git diff --check
- security scan: rg -n 'subprocess|os\.system|\beval\(|\bexec\(|pickle|yaml\.load|shell=True|requests|urllib|socket|chmod|chown|unlink|rmtree|open\(' touched files (no matches)