### PR TITLE
Add parser-facing HTML lexer contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -201,3 +201,6 @@ documented in this file.
 - Added a second WHATWG arrow named-reference batch covering short/capital,
   lowercase long, hook, tail, loop, harpoon, negated, squiggle, diagonal, and
   mapsto aliases.
+- Added parser-facing `HtmlTokenizerState` and `HtmlLexContext` APIs, including
+  typed fragment lexing and element-to-tokenizer-mode mapping for RCDATA,
+  RAWTEXT, script data, and PLAINTEXT parser handoff.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -143,6 +143,11 @@ tokenizer submodes. The markup declaration path also recognizes `<![CDATA[`
 and enters the CDATA section state so the generated lexer can exercise that
 tokenizer subflow end to end; a future parser can still decide when that opener
 is valid for foreign-content contexts.
+The public Rust API now wraps those parser-controlled entry states in
+`HtmlTokenizerState` and `HtmlLexContext`, including an element-to-context map
+for `title`, `textarea`, raw-text elements, `script`, and `plaintext`. That
+lets the parser request a statically linked lexer in the right tokenizer mode
+without depending on generated machine-state strings.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 
@@ -196,6 +201,18 @@ assert_eq!(
         Token::Eof,
     ]
 );
+```
+
+Parser-controlled fragments can seed the same static lexer with a typed
+tokenizer context:
+
+```rust
+use coding_adventures_html_lexer::{lex_html_fragment, HtmlLexContext, Token};
+
+let context = HtmlLexContext::for_element_text("title").unwrap();
+let tokens = lex_html_fragment("Tom &amp; Jerry</title>", &context).unwrap();
+
+assert_eq!(tokens[0], Token::Text("Tom & Jerry".into()));
 ```
 
 ## Development

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -14,6 +14,97 @@ pub use state_machine_tokenizer::{
 mod generated_html1;
 mod generated_html_skeleton;
 
+/// Parser-facing HTML tokenizer entry state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HtmlTokenizerState {
+    Data,
+    Rcdata,
+    Rawtext,
+    Plaintext,
+    CdataSection,
+    ScriptData,
+    ScriptDataEscaped,
+    ScriptDataEscapedDash,
+    ScriptDataEscapedDashDash,
+    ScriptDataEscapedLessThanSign,
+    ScriptDataDoubleEscaped,
+    ScriptDataDoubleEscapedDash,
+    ScriptDataDoubleEscapedDashDash,
+    ScriptDataDoubleEscapedLessThanSign,
+}
+
+impl HtmlTokenizerState {
+    /// Machine-state identifier used by the generated static lexer.
+    pub fn as_machine_state(self) -> &'static str {
+        match self {
+            Self::Data => "data",
+            Self::Rcdata => "rcdata",
+            Self::Rawtext => "rawtext",
+            Self::Plaintext => "plaintext",
+            Self::CdataSection => "cdata_section",
+            Self::ScriptData => "script_data",
+            Self::ScriptDataEscaped => "script_data_escaped",
+            Self::ScriptDataEscapedDash => "script_data_escaped_dash",
+            Self::ScriptDataEscapedDashDash => "script_data_escaped_dash_dash",
+            Self::ScriptDataEscapedLessThanSign => "script_data_escaped_less_than_sign",
+            Self::ScriptDataDoubleEscaped => "script_data_double_escaped",
+            Self::ScriptDataDoubleEscapedDash => "script_data_double_escaped_dash",
+            Self::ScriptDataDoubleEscapedDashDash => "script_data_double_escaped_dash_dash",
+            Self::ScriptDataDoubleEscapedLessThanSign => {
+                "script_data_double_escaped_less_than_sign"
+            }
+        }
+    }
+}
+
+/// Initial tokenizer context for fragment or parser-controlled lexing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HtmlLexContext {
+    pub initial_state: HtmlTokenizerState,
+    pub last_start_tag: Option<String>,
+}
+
+impl HtmlLexContext {
+    pub fn new(initial_state: HtmlTokenizerState) -> Self {
+        Self {
+            initial_state,
+            last_start_tag: None,
+        }
+    }
+
+    pub fn data() -> Self {
+        Self::new(HtmlTokenizerState::Data)
+    }
+
+    pub fn with_last_start_tag(mut self, tag: impl Into<String>) -> Self {
+        self.last_start_tag = Some(tag.into());
+        self
+    }
+
+    /// Return the tokenizer context used for text following a start tag.
+    ///
+    /// This is the parser-facing map from element names to HTML tokenizer
+    /// submodes. It deliberately keeps foreign-content CDATA decisions out of
+    /// the element map because those depend on tree-construction context.
+    pub fn for_element_text(element_name: &str) -> Option<Self> {
+        let name = element_name.to_ascii_lowercase();
+        let state = match name.as_str() {
+            "title" | "textarea" => HtmlTokenizerState::Rcdata,
+            "iframe" | "noembed" | "noframes" | "style" | "xmp" => HtmlTokenizerState::Rawtext,
+            "script" => HtmlTokenizerState::ScriptData,
+            "plaintext" => HtmlTokenizerState::Plaintext,
+            _ => return None,
+        };
+
+        let context = Self::new(state);
+        if state == HtmlTokenizerState::Plaintext {
+            Some(context)
+        } else {
+            Some(context.with_last_start_tag(name))
+        }
+    }
+}
+
 /// Return the generated typed definition for the HTML 1.x compatibility-floor lexer.
 pub fn html1_definition() -> StateMachineDefinition {
     generated_html1::html1_lexer_definition()
@@ -41,9 +132,27 @@ pub fn create_html_lexer() -> Result<HtmlLexer> {
         .map_err(TokenizerError::Machine)
 }
 
+/// Build a lexer seeded with a parser-controlled HTML tokenizer context.
+pub fn create_html_lexer_with_context(context: &HtmlLexContext) -> Result<HtmlLexer> {
+    let mut lexer = create_html_lexer()?;
+    lexer.set_initial_state(context.initial_state.as_machine_state())?;
+    if let Some(last_start_tag) = context.last_start_tag.as_deref() {
+        lexer.set_last_start_tag(last_start_tag);
+    }
+    Ok(lexer)
+}
+
 /// Lex one complete HTML string with the current compatibility-floor machine.
 pub fn lex_html(source: &str) -> Result<Vec<Token>> {
     let mut lexer = create_html_lexer()?;
+    lexer.push(source)?;
+    lexer.finish()?;
+    Ok(lexer.drain_tokens())
+}
+
+/// Lex a parser-controlled HTML fragment with an explicit tokenizer context.
+pub fn lex_html_fragment(source: &str, context: &HtmlLexContext) -> Result<Vec<Token>> {
+    let mut lexer = create_html_lexer_with_context(context)?;
     lexer.push(source)?;
     lexer.finish()?;
     Ok(lexer.drain_tokens())

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,6 +1,7 @@
 use coding_adventures_html_lexer::{
     create_html_lexer, html1_definition, html1_machine, html_skeleton_definition,
-    html_skeleton_machine, lex_html, Attribute, Token,
+    html_skeleton_machine, lex_html, lex_html_fragment, Attribute, HtmlLexContext,
+    HtmlTokenizerState, Token,
 };
 use state_machine::END_INPUT;
 
@@ -4272,6 +4273,81 @@ fn html_skeleton_helpers_remain_available_for_bootstrap_comparisons() {
                 .iter()
                 .any(|action| action == "emit(EOF)")
     }));
+}
+
+#[test]
+fn parser_facing_context_maps_rcdata_elements() {
+    let context = HtmlLexContext::for_element_text("TITLE").unwrap();
+
+    assert_eq!(context.initial_state, HtmlTokenizerState::Rcdata);
+    assert_eq!(context.last_start_tag.as_deref(), Some("title"));
+    assert_eq!(
+        lex_html_fragment("Tom &amp; Jerry</title>", &context).unwrap(),
+        vec![
+            Token::Text("Tom & Jerry".to_string()),
+            Token::EndTag {
+                name: "title".to_string()
+            },
+            Token::Eof
+        ]
+    );
+}
+
+#[test]
+fn parser_facing_context_maps_rawtext_elements() {
+    let context = HtmlLexContext::for_element_text("style").unwrap();
+
+    assert_eq!(context.initial_state, HtmlTokenizerState::Rawtext);
+    assert_eq!(context.last_start_tag.as_deref(), Some("style"));
+    assert_eq!(
+        lex_html_fragment("a < b &amp; c</style>", &context).unwrap(),
+        vec![
+            Token::Text("a ".to_string()),
+            Token::Text("< b &amp; c".to_string()),
+            Token::EndTag {
+                name: "style".to_string()
+            },
+            Token::Eof
+        ]
+    );
+}
+
+#[test]
+fn parser_facing_context_maps_script_and_plaintext_elements() {
+    let script = HtmlLexContext::for_element_text("script").unwrap();
+    assert_eq!(script.initial_state, HtmlTokenizerState::ScriptData);
+    assert_eq!(script.last_start_tag.as_deref(), Some("script"));
+    assert_eq!(
+        lex_html_fragment("if (a < b) alert('&amp;');</script>", &script).unwrap(),
+        vec![
+            Token::Text("if (a < b) alert('&amp;');".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    let plaintext = HtmlLexContext::for_element_text("plaintext").unwrap();
+    assert_eq!(plaintext.initial_state, HtmlTokenizerState::Plaintext);
+    assert_eq!(plaintext.last_start_tag, None);
+    assert_eq!(
+        lex_html_fragment("<b>&amp;</b>", &plaintext).unwrap(),
+        vec![Token::Text("<b>&amp;</b>".to_string()), Token::Eof]
+    );
+}
+
+#[test]
+fn parser_facing_context_leaves_normal_elements_in_data_state() {
+    assert_eq!(HtmlLexContext::for_element_text("p"), None);
+    assert_eq!(
+        HtmlLexContext::data().initial_state.as_machine_state(),
+        "data"
+    );
+    assert_eq!(
+        HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign.as_machine_state(),
+        "script_data_double_escaped_less_than_sign"
+    );
 }
 
 fn token_summary(token: Token) -> String {


### PR DESCRIPTION
## Summary
- Add typed `HtmlTokenizerState` and `HtmlLexContext` APIs around generated HTML tokenizer entry states.
- Add `lex_html_fragment` and a parser-facing element-to-context map for RCDATA, RAWTEXT, script data, and PLAINTEXT handoff.
- Document the parser-controlled fragment API and cover RCDATA/RAWTEXT/script/plaintext contexts in lexer tests.

## Verification
- `cargo test -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `git diff --check`