### PR TITLE
Honor nested ALGOL procedure actual writes

### DIFF
--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -2949,10 +2949,10 @@ class AlgolTypeChecker:
                         )
                         return False
                     if procedure_argument_id is not None:
-                        descriptor = self._procedure_descriptor_for_id(
+                        nested_descriptor = self._procedure_descriptor_for_id(
                             procedure_argument_id
                         )
-                        if descriptor is None:
+                        if nested_descriptor is None:
                             self._error(
                                 token,
                                 f"procedure parameter {parameter.name!r} passes a "
@@ -2961,7 +2961,7 @@ class AlgolTypeChecker:
                             return False
                         if not self._procedure_actual_satisfies_formal_shapes(
                             token,
-                            descriptor,
+                            nested_descriptor,
                             actual_parameter,
                         ):
                             return False
@@ -3012,8 +3012,13 @@ class AlgolTypeChecker:
                         f"{actual_parameter.type_name}",
                     )
                     return False
+                parameter_may_write = self._procedure_parameter_may_write_for_shape(
+                    descriptor,
+                    actual_parameter,
+                    shape,
+                )
                 if actual_parameter.mode == NAME and (
-                    actual_parameter.may_write and not argument_assignable
+                    parameter_may_write and not argument_assignable
                 ):
                     self._error(
                         token,
@@ -3024,6 +3029,62 @@ class AlgolTypeChecker:
                     return False
                 continue
         return True
+
+    def _procedure_parameter_may_write_for_shape(
+        self,
+        descriptor: ProcedureDescriptor,
+        parameter: ProcedureParameter,
+        shape: ProcedureFormalCallShape,
+    ) -> bool:
+        if (
+            parameter.kind != "scalar"
+            or parameter.mode != NAME
+            or not parameter.may_write
+        ):
+            return False
+        if parameter.write_reason != "transitive call":
+            return True
+
+        saw_formal_procedure_shape = False
+        for procedure_index, procedure_parameter in enumerate(descriptor.parameters):
+            if procedure_parameter.kind != "procedure":
+                continue
+            for nested_shape in procedure_parameter.procedure_call_shapes:
+                formal_names = _shape_argument_formal_names(nested_shape)
+                for argument_index, formal_name in enumerate(formal_names):
+                    if formal_name != parameter.name:
+                        continue
+                    saw_formal_procedure_shape = True
+                    if self._shape_procedure_argument_writes(
+                        shape,
+                        procedure_index,
+                        nested_shape,
+                        argument_index,
+                    ):
+                        return True
+        return not saw_formal_procedure_shape
+
+    def _shape_procedure_argument_writes(
+        self,
+        shape: ProcedureFormalCallShape,
+        procedure_argument_index: int,
+        nested_shape: ProcedureFormalCallShape,
+        nested_argument_index: int,
+    ) -> bool:
+        if procedure_argument_index >= len(shape.procedure_argument_ids):
+            return True
+        procedure_id = shape.procedure_argument_ids[procedure_argument_index]
+        if procedure_id is None:
+            return True
+        descriptor = self._procedure_descriptor_for_id(procedure_id)
+        if descriptor is None or nested_argument_index >= len(descriptor.parameters):
+            return True
+        parameter = descriptor.parameters[nested_argument_index]
+        return self._procedure_parameter_may_write_for_shape(
+            descriptor,
+            parameter,
+            nested_shape,
+        )
 
     def _procedure_descriptor_for_id(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -1520,6 +1520,45 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "actual expression is not assignable" in result.diagnostics[0].message
 
+    def test_accepts_procedure_actual_shape_when_nested_actual_reads(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure id(x); value x; integer x; begin id := x end; "
+            "integer procedure relay(g, y); integer g, y; procedure g; "
+            "begin relay := g(y) end; "
+            "procedure invoke(p); integer p; procedure p; "
+            "begin result := p(id, 3 + 4) end; "
+            "invoke(relay) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        relay = result.semantic.procedures[1]
+        assert relay.parameters[1].write_reason == "transitive call"
+
+    def test_rejects_procedure_actual_shape_when_nested_actual_writes(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure inc(x); integer x; "
+            "begin x := x + 1; inc := x end; "
+            "integer procedure relay(g, y); integer g, y; procedure g; "
+            "begin relay := g(y) end; "
+            "procedure invoke(p); integer p; procedure p; "
+            "begin result := p(inc, 3 + 4) end; "
+            "invoke(relay) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "non-assignable actual" in result.diagnostics[0].message
+
     def test_accepts_procedure_parameter_actual_with_array_element_by_name_formal(
         self,
     ) -> None:

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1433,6 +1433,37 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [44]
 
+    def test_formal_procedure_actual_shape_accepts_nested_read_only_actual(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure id(x); value x; integer x; begin id := x end; "
+            "integer procedure relay(g, y); integer g, y; procedure g; "
+            "begin relay := g(y) end; "
+            "procedure invoke(p); integer p; procedure p; "
+            "begin result := p(id, 3 + 4) end; "
+            "invoke(relay) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_formal_procedure_actual_shape_keeps_nested_writable_actual(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure inc(x); integer x; "
+            "begin x := x + 1; inc := x end; "
+            "integer procedure relay(g, y); integer g, y; procedure g; "
+            "begin relay := g(y) end; "
+            "procedure invoke(p); integer p; procedure p; "
+            "begin result := 3; result := p(inc, result) * 10 + result end; "
+            "invoke(relay) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [44]
+
     def test_real_procedure_parameter_accepts_integer_return_actual(self) -> None:
         result = compile_source(
             "begin integer result; real y; "


### PR DESCRIPTION
## Summary
- preserve enclosing procedure descriptors while validating nested formal procedure actuals
- teach procedure-actual shape validation to look through concrete nested procedure actuals before requiring assignability
- add type-checker and WASM runtime coverage for read-only nested actuals and writable nested actuals

## Tests
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/ -v (algol-type-checker)
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/ -v (algol-ir-compiler)
- .venv/bin/python -m pytest tests/ -v (algol-wasm-compiler)
- code/packages/python/algol-wasm-compiler/.venv/bin/python -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler
- git diff --check

## Security
- scanned touched files for subprocess, shell execution, eval/exec, unsafe YAML/pickle, network/socket, and destructive filesystem APIs; no matches