### PR TITLE
Add C# sql-backend package

### DIFF
--- a/code/packages/csharp/sql-backend/BUILD
+++ b/code/packages/csharp/sql-backend/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlBackend.Tests/CodingAdventures.SqlBackend.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sql-backend/BUILD_windows
+++ b/code/packages/csharp/sql-backend/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlBackend.Tests/CodingAdventures.SqlBackend.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/sql-backend/CHANGELOG.md
+++ b/code/packages/csharp/sql-backend/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add the C# sql-backend package with the portable backend contract and in-memory reference implementation.

--- a/code/packages/csharp/sql-backend/CodingAdventures.SqlBackend.csproj
+++ b/code/packages/csharp/sql-backend/CodingAdventures.SqlBackend.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SqlBackend.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pluggable SQL backend abstractions and in-memory reference backend for C#</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sql-backend/README.md
+++ b/code/packages/csharp/sql-backend/README.md
@@ -1,0 +1,15 @@
+# csharp/sql-backend
+
+Pluggable SQL backend abstractions and an in-memory reference backend for C#.
+
+This package ports the Python `sql-backend` contract into C#: schema metadata,
+row iterators, positioned cursors, typed backend errors, DDL/DML operations,
+simple index descriptors, rowid scans, and transaction snapshots.
+
+## Usage
+
+```csharp
+var backend = new InMemoryBackend();
+backend.CreateTable("users", new[] { new ColumnDef("id", "INTEGER", PrimaryKey: true) }, false);
+backend.Insert("users", new Row { ["id"] = 1 });
+```

--- a/code/packages/csharp/sql-backend/SqlBackend.cs
+++ b/code/packages/csharp/sql-backend/SqlBackend.cs
@@ -1,0 +1,848 @@
+using System.Globalization;
+
+namespace CodingAdventures.SqlBackend;
+
+/// <summary>Opaque transaction handle issued by a backend.</summary>
+public readonly record struct TransactionHandle(int Value);
+
+/// <summary>Helpers for the portable SQL value set.</summary>
+public static class SqlValues
+{
+    public static bool IsSqlValue(object? value)
+        => value is null or bool or string or byte[] || IsInteger(value) || IsReal(value);
+
+    public static string TypeName(object? value)
+    {
+        if (value is null)
+        {
+            return "NULL";
+        }
+
+        if (value is bool)
+        {
+            return "BOOLEAN";
+        }
+
+        if (IsInteger(value))
+        {
+            return "INTEGER";
+        }
+
+        if (IsReal(value))
+        {
+            return "REAL";
+        }
+
+        if (value is string)
+        {
+            return "TEXT";
+        }
+
+        if (value is byte[])
+        {
+            return "BLOB";
+        }
+
+        throw new ArgumentException($"not a SQL value: {value.GetType().Name}", nameof(value));
+    }
+
+    internal static int Compare(object? left, object? right)
+    {
+        var rank = Rank(left).CompareTo(Rank(right));
+        if (rank != 0)
+        {
+            return rank;
+        }
+
+        return left switch
+        {
+            null => 0,
+            bool leftBool => leftBool.CompareTo((bool)right!),
+            string leftText => string.CompareOrdinal(leftText, (string)right!),
+            byte[] leftBytes => CompareBytes(leftBytes, (byte[])right!),
+            _ when IsNumeric(left) && IsNumeric(right)
+                => Convert.ToDouble(left, CultureInfo.InvariantCulture)
+                    .CompareTo(Convert.ToDouble(right, CultureInfo.InvariantCulture)),
+            _ => string.CompareOrdinal(left.ToString(), right?.ToString()),
+        };
+    }
+
+    private static int Rank(object? value)
+    {
+        if (value is null)
+        {
+            return 0;
+        }
+
+        if (value is bool)
+        {
+            return 1;
+        }
+
+        if (IsNumeric(value))
+        {
+            return 2;
+        }
+
+        if (value is string)
+        {
+            return 3;
+        }
+
+        if (value is byte[])
+        {
+            return 4;
+        }
+
+        return 5;
+    }
+
+    private static int CompareBytes(IReadOnlyList<byte> left, IReadOnlyList<byte> right)
+    {
+        var length = Math.Min(left.Count, right.Count);
+        for (var i = 0; i < length; i++)
+        {
+            var cmp = left[i].CompareTo(right[i]);
+            if (cmp != 0)
+            {
+                return cmp;
+            }
+        }
+
+        return left.Count.CompareTo(right.Count);
+    }
+
+    private static bool IsNumeric(object? value) => IsInteger(value) || IsReal(value);
+
+    private static bool IsInteger(object? value)
+        => value is byte or sbyte or short or ushort or int or uint or long or ulong;
+
+    private static bool IsReal(object? value) => value is float or double;
+}
+
+/// <summary>A mutable row keyed by column name.</summary>
+public sealed class Row : Dictionary<string, object?>
+{
+    public Row()
+        : base(StringComparer.OrdinalIgnoreCase)
+    {
+    }
+
+    public Row(IEnumerable<KeyValuePair<string, object?>> values)
+        : this()
+    {
+        foreach (var (key, value) in values)
+        {
+            this[key] = value;
+        }
+    }
+
+    public Row Copy() => new(this);
+}
+
+/// <summary>Lazy iterator over backend rows.</summary>
+public interface IRowIterator
+{
+    Row? Next();
+    void Close();
+}
+
+/// <summary>Iterator that remembers the current row for positioned DML.</summary>
+public interface ICursor : IRowIterator
+{
+    Row? CurrentRow { get; }
+}
+
+/// <summary>Row iterator backed by a materialized list.</summary>
+public sealed class ListRowIterator(IEnumerable<Row> rows) : IRowIterator
+{
+    private readonly IReadOnlyList<Row> _rows = rows.ToArray();
+    private int _index;
+    private bool _closed;
+
+    public Row? Next()
+    {
+        if (_closed || _index >= _rows.Count)
+        {
+            return null;
+        }
+
+        return _rows[_index++].Copy();
+    }
+
+    public void Close() => _closed = true;
+}
+
+/// <summary>List-backed cursor used by the in-memory backend.</summary>
+public sealed class ListCursor(IList<Row> rows) : ICursor
+{
+    private readonly IList<Row> _rows = rows;
+    private int _index = -1;
+    private Row? _current;
+    private bool _closed;
+
+    public Row? CurrentRow => _current?.Copy();
+
+    internal int CurrentIndex => _index;
+
+    public Row? Next()
+    {
+        if (_closed)
+        {
+            return null;
+        }
+
+        _index++;
+        if (_index >= _rows.Count)
+        {
+            _current = null;
+            return null;
+        }
+
+        _current = _rows[_index];
+        return _current.Copy();
+    }
+
+    public void Close() => _closed = true;
+
+    internal bool IsBackedBy(IList<Row> rows) => ReferenceEquals(_rows, rows);
+
+    internal void AdjustAfterDelete()
+    {
+        _index--;
+        _current = null;
+    }
+}
+
+/// <summary>One column in a table schema.</summary>
+public sealed record ColumnDef(
+    string Name,
+    string TypeName,
+    bool NotNull = false,
+    bool PrimaryKey = false,
+    bool Unique = false,
+    bool Autoincrement = false,
+    object? DefaultValue = null,
+    bool HasDefault = false,
+    object? CheckExpression = null,
+    object? ForeignKey = null)
+{
+    public bool EffectiveNotNull => NotNull || PrimaryKey;
+    public bool EffectiveUnique => Unique || PrimaryKey;
+
+    public static ColumnDef WithDefault(
+        string name,
+        string typeName,
+        object? defaultValue,
+        bool notNull = false,
+        bool primaryKey = false,
+        bool unique = false,
+        bool autoincrement = false)
+        => new(name, typeName, notNull, primaryKey, unique, autoincrement, defaultValue, HasDefault: true);
+}
+
+/// <summary>Definition of a trigger stored by a backend.</summary>
+public sealed record TriggerDef(string Name, string Table, string Timing, string Event, string Body);
+
+/// <summary>Definition of a backend-managed index.</summary>
+public sealed record IndexDef
+{
+    public IndexDef(string name, string table, IReadOnlyList<string>? columns = null, bool unique = false, bool auto = false)
+    {
+        Name = name;
+        Table = table;
+        Columns = columns?.ToArray() ?? Array.Empty<string>();
+        Unique = unique;
+        Auto = auto;
+    }
+
+    public string Name { get; init; }
+    public string Table { get; init; }
+    public IReadOnlyList<string> Columns { get; init; }
+    public bool Unique { get; init; }
+    public bool Auto { get; init; }
+}
+
+public abstract class BackendError(string message) : Exception(message);
+
+public sealed class TableNotFound(string table) : BackendError($"table not found: '{table}'")
+{
+    public string Table { get; } = table;
+}
+
+public sealed class TableAlreadyExists(string table) : BackendError($"table already exists: '{table}'")
+{
+    public string Table { get; } = table;
+}
+
+public sealed class ColumnNotFound(string table, string column) : BackendError($"column not found: '{table}.{column}'")
+{
+    public string Table { get; } = table;
+    public string Column { get; } = column;
+}
+
+public sealed class ColumnAlreadyExists(string table, string column) : BackendError($"column already exists: '{table}.{column}'")
+{
+    public string Table { get; } = table;
+    public string Column { get; } = column;
+}
+
+public sealed class ConstraintViolation(string table, string column, string detail)
+    : BackendError(detail)
+{
+    public string Table { get; } = table;
+    public string Column { get; } = column;
+}
+
+public sealed class Unsupported(string operation) : BackendError($"unsupported operation: {operation}")
+{
+    public string Operation { get; } = operation;
+}
+
+public sealed class Internal(string detail) : BackendError(detail);
+
+public sealed class IndexAlreadyExists(string index) : BackendError($"index already exists: '{index}'")
+{
+    public string Index { get; } = index;
+}
+
+public sealed class IndexNotFound(string index) : BackendError($"index not found: '{index}'")
+{
+    public string Index { get; } = index;
+}
+
+public sealed class TriggerAlreadyExists(string trigger) : BackendError($"trigger already exists: '{trigger}'")
+{
+    public string Trigger { get; } = trigger;
+}
+
+public sealed class TriggerNotFound(string trigger) : BackendError($"trigger not found: '{trigger}'")
+{
+    public string Trigger { get; } = trigger;
+}
+
+/// <summary>Pluggable interface every SQL data source implements.</summary>
+public abstract class Backend
+{
+    public abstract IReadOnlyList<string> Tables();
+    public abstract IReadOnlyList<ColumnDef> Columns(string table);
+    public abstract IRowIterator Scan(string table);
+    public abstract void Insert(string table, Row row);
+    public abstract void Update(string table, ICursor cursor, IReadOnlyDictionary<string, object?> assignments);
+    public abstract void Delete(string table, ICursor cursor);
+    public abstract void CreateTable(string table, IReadOnlyList<ColumnDef> columns, bool ifNotExists);
+    public abstract void DropTable(string table, bool ifExists);
+    public abstract void AddColumn(string table, ColumnDef column);
+    public abstract void CreateIndex(IndexDef index);
+    public abstract void DropIndex(string name, bool ifExists = false);
+    public abstract IReadOnlyList<IndexDef> ListIndexes(string? table = null);
+    public abstract IEnumerable<int> ScanIndex(
+        string indexName,
+        IReadOnlyList<object?>? lo,
+        IReadOnlyList<object?>? hi,
+        bool loInclusive = true,
+        bool hiInclusive = true);
+
+    public abstract IRowIterator ScanByRowIds(string table, IReadOnlyList<int> rowids);
+    public abstract TransactionHandle BeginTransaction();
+    public abstract void Commit(TransactionHandle handle);
+    public abstract void Rollback(TransactionHandle handle);
+
+    public virtual TransactionHandle? CurrentTransaction() => null;
+    public virtual void CreateSavepoint(string name) => throw new Unsupported("savepoints");
+    public virtual void ReleaseSavepoint(string name) => throw new Unsupported("savepoints");
+    public virtual void RollbackToSavepoint(string name) => throw new Unsupported("savepoints");
+    public virtual void CreateTrigger(TriggerDef defn) => throw new Unsupported("triggers");
+    public virtual void DropTrigger(string name, bool ifExists = false) => throw new Unsupported("triggers");
+    public virtual IReadOnlyList<TriggerDef> ListTriggers(string table) => Array.Empty<TriggerDef>();
+}
+
+public interface ISchemaProvider
+{
+    IReadOnlyList<string> Columns(string table);
+}
+
+public static class BackendAdapters
+{
+    public static ISchemaProvider AsSchemaProvider(Backend backend) => new BackendSchemaProvider(backend);
+
+    private sealed class BackendSchemaProvider(Backend backend) : ISchemaProvider
+    {
+        public IReadOnlyList<string> Columns(string table) => backend.Columns(table).Select(column => column.Name).ToArray();
+    }
+}
+
+/// <summary>Reference in-memory backend with DDL, DML, indexes, and transactions.</summary>
+public sealed class InMemoryBackend : Backend
+{
+    private readonly Dictionary<string, TableState> _tables = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, IndexDef> _indexes = new(StringComparer.OrdinalIgnoreCase);
+    private Snapshot? _snapshot;
+    private int _nextHandle = 1;
+    private TransactionHandle? _activeHandle;
+
+    public static InMemoryBackend FromTables(
+        IReadOnlyDictionary<string, (IReadOnlyList<ColumnDef> Columns, IReadOnlyList<Row> Rows)> tables)
+    {
+        var backend = new InMemoryBackend();
+        foreach (var (name, table) in tables)
+        {
+            backend._tables[name] = new TableState(table.Columns, table.Rows.Select(row => row.Copy()));
+        }
+
+        return backend;
+    }
+
+    public override IReadOnlyList<string> Tables() => _tables.Keys.ToArray();
+
+    public override IReadOnlyList<ColumnDef> Columns(string table) => RequireTable(table).Columns.ToArray();
+
+    public override IRowIterator Scan(string table) => new ListRowIterator(RequireTable(table).Rows);
+
+    public ListCursor OpenCursor(string table) => new(RequireTable(table).Rows);
+
+    public override void Insert(string table, Row row)
+    {
+        var state = RequireTable(table);
+        var normalized = ApplyDefaults(table, state, row);
+        CheckUnknownColumns(table, state, normalized);
+        CheckNotNull(table, state, normalized);
+        CheckUnique(table, state, normalized, ignoreIndex: null);
+        state.Rows.Add(normalized);
+    }
+
+    public override void Update(string table, ICursor cursor, IReadOnlyDictionary<string, object?> assignments)
+    {
+        var state = RequireTable(table);
+        var listCursor = RequireListCursor(table, state, cursor);
+        var index = listCursor.CurrentIndex;
+        if (index < 0 || index >= state.Rows.Count)
+        {
+            throw new Unsupported("cursor has no current row");
+        }
+
+        var updated = state.Rows[index].Copy();
+        foreach (var (column, value) in assignments)
+        {
+            updated[CanonicalColumn(table, state, column)] = value;
+        }
+
+        CheckNotNull(table, state, updated);
+        CheckUnique(table, state, updated, ignoreIndex: index);
+        state.Rows[index] = updated;
+    }
+
+    public override void Delete(string table, ICursor cursor)
+    {
+        var state = RequireTable(table);
+        var listCursor = RequireListCursor(table, state, cursor);
+        var index = listCursor.CurrentIndex;
+        if (index < 0 || index >= state.Rows.Count)
+        {
+            throw new Unsupported("cursor has no current row");
+        }
+
+        state.Rows.RemoveAt(index);
+        listCursor.AdjustAfterDelete();
+    }
+
+    public override void CreateTable(string table, IReadOnlyList<ColumnDef> columns, bool ifNotExists)
+    {
+        if (_tables.ContainsKey(table))
+        {
+            if (ifNotExists)
+            {
+                return;
+            }
+
+            throw new TableAlreadyExists(table);
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var column in columns)
+        {
+            if (!seen.Add(column.Name))
+            {
+                throw new ColumnAlreadyExists(table, column.Name);
+            }
+        }
+
+        _tables[table] = new TableState(columns, Array.Empty<Row>());
+    }
+
+    public override void DropTable(string table, bool ifExists)
+    {
+        if (!_tables.Remove(table))
+        {
+            if (ifExists)
+            {
+                return;
+            }
+
+            throw new TableNotFound(table);
+        }
+
+        foreach (var index in _indexes.Values.Where(index => Same(index.Table, table)).Select(index => index.Name).ToArray())
+        {
+            _indexes.Remove(index);
+        }
+    }
+
+    public override void AddColumn(string table, ColumnDef column)
+    {
+        var state = RequireTable(table);
+        if (state.Columns.Any(existing => Same(existing.Name, column.Name)))
+        {
+            throw new ColumnAlreadyExists(table, column.Name);
+        }
+
+        if (column.EffectiveNotNull && !column.HasDefault)
+        {
+            throw new ConstraintViolation(table, column.Name, $"NOT NULL constraint failed: {table}.{column.Name}");
+        }
+
+        state.Columns.Add(column);
+        foreach (var row in state.Rows)
+        {
+            row[column.Name] = column.HasDefault ? column.DefaultValue : null;
+        }
+    }
+
+    public override void CreateIndex(IndexDef index)
+    {
+        if (_indexes.ContainsKey(index.Name))
+        {
+            throw new IndexAlreadyExists(index.Name);
+        }
+
+        var state = RequireTable(index.Table);
+        foreach (var column in index.Columns)
+        {
+            _ = CanonicalColumn(index.Table, state, column);
+        }
+
+        if (index.Unique)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var row in state.Rows)
+            {
+                var key = IndexKey(state, row, index.Columns);
+                if (key.Any(value => value is null))
+                {
+                    continue;
+                }
+
+                if (!seen.Add(SerializeKey(key)))
+                {
+                    throw new ConstraintViolation(index.Table, string.Join(",", index.Columns), $"UNIQUE constraint failed: {index.Name}");
+                }
+            }
+        }
+
+        _indexes[index.Name] = CloneIndex(index);
+    }
+
+    public override void DropIndex(string name, bool ifExists = false)
+    {
+        if (_indexes.Remove(name))
+        {
+            return;
+        }
+
+        if (!ifExists)
+        {
+            throw new IndexNotFound(name);
+        }
+    }
+
+    public override IReadOnlyList<IndexDef> ListIndexes(string? table = null)
+        => _indexes.Values
+            .Where(index => table is null || Same(index.Table, table))
+            .Select(CloneIndex)
+            .ToArray();
+
+    public override IEnumerable<int> ScanIndex(
+        string indexName,
+        IReadOnlyList<object?>? lo,
+        IReadOnlyList<object?>? hi,
+        bool loInclusive = true,
+        bool hiInclusive = true)
+    {
+        if (!_indexes.TryGetValue(indexName, out var index))
+        {
+            throw new IndexNotFound(indexName);
+        }
+
+        var state = RequireTable(index.Table);
+        var keyed = state.Rows
+            .Select((row, rowid) => (Key: IndexKey(state, row, index.Columns), Rowid: rowid))
+            .OrderBy(item => item.Key, KeyComparer.Instance)
+            .ThenBy(item => item.Rowid)
+            .ToArray();
+
+        foreach (var item in keyed)
+        {
+            if (lo is not null)
+            {
+                var cmp = ComparePrefix(item.Key, lo);
+                if (cmp < 0 || (cmp == 0 && !loInclusive))
+                {
+                    continue;
+                }
+            }
+
+            if (hi is not null)
+            {
+                var cmp = ComparePrefix(item.Key, hi);
+                if (cmp > 0 || (cmp == 0 && !hiInclusive))
+                {
+                    yield break;
+                }
+            }
+
+            yield return item.Rowid;
+        }
+    }
+
+    public override IRowIterator ScanByRowIds(string table, IReadOnlyList<int> rowids)
+    {
+        var state = RequireTable(table);
+        var rows = rowids.Where(rowid => rowid >= 0 && rowid < state.Rows.Count).Select(rowid => state.Rows[rowid]);
+        return new ListRowIterator(rows);
+    }
+
+    public override TransactionHandle BeginTransaction()
+    {
+        if (_activeHandle is not null)
+        {
+            throw new Unsupported("nested transactions");
+        }
+
+        var handle = new TransactionHandle(_nextHandle++);
+        _snapshot = Capture();
+        _activeHandle = handle;
+        return handle;
+    }
+
+    public override void Commit(TransactionHandle handle)
+    {
+        RequireActive(handle);
+        _snapshot = null;
+        _activeHandle = null;
+    }
+
+    public override void Rollback(TransactionHandle handle)
+    {
+        RequireActive(handle);
+        if (_snapshot is not null)
+        {
+            Restore(_snapshot);
+        }
+
+        _snapshot = null;
+        _activeHandle = null;
+    }
+
+    public override TransactionHandle? CurrentTransaction() => _activeHandle;
+
+    private TableState RequireTable(string table)
+    {
+        if (!_tables.TryGetValue(table, out var state))
+        {
+            throw new TableNotFound(table);
+        }
+
+        return state;
+    }
+
+    private static ListCursor RequireListCursor(string table, TableState state, ICursor cursor)
+    {
+        if (cursor is not ListCursor listCursor || !listCursor.IsBackedBy(state.Rows))
+        {
+            throw new Unsupported($"foreign cursor for table {table}");
+        }
+
+        return listCursor;
+    }
+
+    private static Row ApplyDefaults(string table, TableState state, Row row)
+    {
+        var normalized = row.Copy();
+        foreach (var column in state.Columns)
+        {
+            if (!normalized.ContainsKey(column.Name))
+            {
+                normalized[column.Name] = column.HasDefault ? column.DefaultValue : null;
+            }
+        }
+
+        CheckUnknownColumns(table, state, normalized);
+        return normalized;
+    }
+
+    private static void CheckUnknownColumns(string table, TableState state, Row row)
+    {
+        foreach (var column in row.Keys)
+        {
+            if (!state.Columns.Any(existing => Same(existing.Name, column)))
+            {
+                throw new ColumnNotFound(table, column);
+            }
+        }
+    }
+
+    private static void CheckNotNull(string table, TableState state, Row row)
+    {
+        foreach (var column in state.Columns.Where(column => column.EffectiveNotNull))
+        {
+            if (!row.TryGetValue(column.Name, out var value) || value is null)
+            {
+                throw new ConstraintViolation(table, column.Name, $"NOT NULL constraint failed: {table}.{column.Name}");
+            }
+        }
+    }
+
+    private static void CheckUnique(string table, TableState state, Row row, int? ignoreIndex)
+    {
+        foreach (var column in state.Columns.Where(column => column.EffectiveUnique))
+        {
+            if (!row.TryGetValue(column.Name, out var value) || value is null)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < state.Rows.Count; i++)
+            {
+                if (ignoreIndex == i)
+                {
+                    continue;
+                }
+
+                if (state.Rows[i].TryGetValue(column.Name, out var existing) && Equals(existing, value))
+                {
+                    var label = column.PrimaryKey ? "PRIMARY KEY" : "UNIQUE";
+                    throw new ConstraintViolation(table, column.Name, $"{label} constraint failed: {table}.{column.Name}");
+                }
+            }
+        }
+    }
+
+    private static string CanonicalColumn(string table, TableState state, string column)
+    {
+        foreach (var candidate in state.Columns)
+        {
+            if (Same(candidate.Name, column))
+            {
+                return candidate.Name;
+            }
+        }
+
+        throw new ColumnNotFound(table, column);
+    }
+
+    private static IReadOnlyList<object?> IndexKey(TableState state, Row row, IReadOnlyList<string> columns)
+        => columns.Select(column => row.GetValueOrDefault(CanonicalColumn("", state, column))).ToArray();
+
+    private static int ComparePrefix(IReadOnlyList<object?> key, IReadOnlyList<object?> bound)
+    {
+        for (var i = 0; i < bound.Count; i++)
+        {
+            var cmp = SqlValues.Compare(i < key.Count ? key[i] : null, bound[i]);
+            if (cmp != 0)
+            {
+                return cmp;
+            }
+        }
+
+        return 0;
+    }
+
+    private static string SerializeKey(IEnumerable<object?> key)
+        => string.Join("\u001f", key.Select(value => value switch
+        {
+            null => "NULL",
+            byte[] bytes => Convert.ToBase64String(bytes),
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "",
+        }));
+
+    private Snapshot Capture()
+        => new(
+            _tables.ToDictionary(pair => pair.Key, pair => pair.Value.Clone(), StringComparer.OrdinalIgnoreCase),
+            _indexes.ToDictionary(pair => pair.Key, pair => CloneIndex(pair.Value), StringComparer.OrdinalIgnoreCase));
+
+    private void Restore(Snapshot snapshot)
+    {
+        _tables.Clear();
+        foreach (var (name, table) in snapshot.Tables)
+        {
+            _tables[name] = table.Clone();
+        }
+
+        _indexes.Clear();
+        foreach (var (name, index) in snapshot.Indexes)
+        {
+            _indexes[name] = CloneIndex(index);
+        }
+    }
+
+    private void RequireActive(TransactionHandle handle)
+    {
+        if (_activeHandle is null)
+        {
+            throw new Unsupported("no active transaction");
+        }
+
+        if (_activeHandle.Value != handle)
+        {
+            throw new Unsupported("stale transaction handle");
+        }
+    }
+
+    private static bool Same(string left, string right) => string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+
+    private static IndexDef CloneIndex(IndexDef index)
+        => new(index.Name, index.Table, index.Columns.ToArray(), index.Unique, index.Auto);
+
+    private sealed class TableState
+    {
+        public TableState(IReadOnlyList<ColumnDef> columns, IEnumerable<Row> rows)
+        {
+            Columns = columns.ToList();
+            Rows = rows.Select(row => row.Copy()).ToList();
+        }
+
+        public List<ColumnDef> Columns { get; }
+        public List<Row> Rows { get; }
+
+        public TableState Clone() => new(Columns.ToArray(), Rows.Select(row => row.Copy()));
+    }
+
+    private sealed record Snapshot(
+        Dictionary<string, TableState> Tables,
+        Dictionary<string, IndexDef> Indexes);
+
+    private sealed class KeyComparer : IComparer<IReadOnlyList<object?>>
+    {
+        public static readonly KeyComparer Instance = new();
+
+        public int Compare(IReadOnlyList<object?>? x, IReadOnlyList<object?>? y)
+        {
+            if (x is null || y is null)
+            {
+                return x is null ? y is null ? 0 : -1 : 1;
+            }
+
+            var length = Math.Min(x.Count, y.Count);
+            for (var i = 0; i < length; i++)
+            {
+                var cmp = SqlValues.Compare(x[i], y[i]);
+                if (cmp != 0)
+                {
+                    return cmp;
+                }
+            }
+
+            return x.Count.CompareTo(y.Count);
+        }
+    }
+}

--- a/code/packages/csharp/sql-backend/required_capabilities.json
+++ b/code/packages/csharp/sql-backend/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/sql-backend",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/sql-backend/tests/CodingAdventures.SqlBackend.Tests/CodingAdventures.SqlBackend.Tests.csproj
+++ b/code/packages/csharp/sql-backend/tests/CodingAdventures.SqlBackend.Tests/CodingAdventures.SqlBackend.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.SqlBackend.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/sql-backend/tests/CodingAdventures.SqlBackend.Tests/SqlBackendTests.cs
+++ b/code/packages/csharp/sql-backend/tests/CodingAdventures.SqlBackend.Tests/SqlBackendTests.cs
@@ -1,0 +1,328 @@
+namespace CodingAdventures.SqlBackend.Tests;
+
+internal static class TestBackends
+{
+    public static InMemoryBackend MakeUsers()
+    {
+        var backend = new InMemoryBackend();
+        backend.CreateTable(
+            "users",
+            new[]
+            {
+                new ColumnDef("id", "INTEGER", PrimaryKey: true),
+                new ColumnDef("name", "TEXT", NotNull: true),
+                new ColumnDef("age", "INTEGER"),
+                new ColumnDef("email", "TEXT", Unique: true),
+            },
+            ifNotExists: false);
+        backend.Insert("users", new Row { ["id"] = 1, ["name"] = "Alice", ["age"] = 30, ["email"] = "alice@example.com" });
+        backend.Insert("users", new Row { ["id"] = 2, ["name"] = "Bob", ["age"] = 25, ["email"] = "bob@example.com" });
+        backend.Insert("users", new Row { ["id"] = 3, ["name"] = "Carol", ["age"] = null, ["email"] = null });
+        return backend;
+    }
+}
+
+public sealed class SqlValueTests
+{
+    [Fact]
+    public void TypeNamesMatchPortableValueSet()
+    {
+        Assert.Equal("NULL", SqlValues.TypeName(null));
+        Assert.Equal("BOOLEAN", SqlValues.TypeName(true));
+        Assert.Equal("INTEGER", SqlValues.TypeName(42));
+        Assert.Equal("REAL", SqlValues.TypeName(1.5));
+        Assert.Equal("TEXT", SqlValues.TypeName("hello"));
+        Assert.Equal("BLOB", SqlValues.TypeName(new byte[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void RejectsNonSqlValues()
+    {
+        Assert.False(SqlValues.IsSqlValue(new object()));
+        Assert.Throws<ArgumentException>(() => SqlValues.TypeName(new object()));
+    }
+}
+
+public sealed class RowIteratorTests
+{
+    [Fact]
+    public void ListRowIteratorReturnsCopies()
+    {
+        var rows = new[] { new Row { ["id"] = 1, ["name"] = "alice" } };
+        var iterator = new ListRowIterator(rows);
+        var first = iterator.Next();
+
+        Assert.NotNull(first);
+        first["name"] = "mutated";
+        Assert.Equal("alice", rows[0]["name"]);
+        Assert.Null(iterator.Next());
+    }
+
+    [Fact]
+    public void ListCursorTracksCurrentRow()
+    {
+        var rows = new List<Row> { new() { ["id"] = 1 }, new() { ["id"] = 2 } };
+        var cursor = new ListCursor(rows);
+
+        Assert.Null(cursor.CurrentRow);
+        Assert.Equal(1, cursor.Next()?["id"]);
+        Assert.Equal(1, cursor.CurrentRow?["id"]);
+        Assert.Equal(2, cursor.Next()?["id"]);
+        cursor.Close();
+        Assert.Null(cursor.Next());
+    }
+}
+
+public sealed class SchemaTests
+{
+    [Fact]
+    public void ColumnFlagsExposeEffectiveConstraints()
+    {
+        var pk = new ColumnDef("id", "INTEGER", PrimaryKey: true);
+        var unique = new ColumnDef("email", "TEXT", Unique: true);
+        var withNullDefault = ColumnDef.WithDefault("middle", "TEXT", null);
+
+        Assert.True(pk.EffectiveNotNull);
+        Assert.True(pk.EffectiveUnique);
+        Assert.False(unique.EffectiveNotNull);
+        Assert.True(unique.EffectiveUnique);
+        Assert.True(withNullDefault.HasDefault);
+        Assert.Null(withNullDefault.DefaultValue);
+    }
+
+    [Fact]
+    public void SchemaProviderAdapterReturnsColumnNames()
+    {
+        var backend = TestBackends.MakeUsers();
+        var schema = BackendAdapters.AsSchemaProvider(backend);
+
+        Assert.Equal(new[] { "id", "name", "age", "email" }, schema.Columns("users"));
+        Assert.Throws<TableNotFound>(() => schema.Columns("missing"));
+    }
+}
+
+public sealed class InMemoryBackendTests
+{
+    [Fact]
+    public void TablesAndColumnsExposeSchema()
+    {
+        var backend = TestBackends.MakeUsers();
+
+        Assert.Contains("users", backend.Tables());
+        Assert.Equal("name", backend.Columns("users")[1].Name);
+        Assert.Throws<TableNotFound>(() => backend.Columns("missing"));
+    }
+
+    [Fact]
+    public void ScanYieldsRowsInInsertionOrder()
+    {
+        var backend = TestBackends.MakeUsers();
+        usingIterator(backend.Scan("users"), rows =>
+        {
+            Assert.Equal(new object?[] { 1, 2, 3 }, rows.Select(row => row["id"]).ToArray());
+        });
+    }
+
+    [Fact]
+    public void InsertAppliesDefaultsAndRejectsUnknownColumns()
+    {
+        var backend = new InMemoryBackend();
+        backend.CreateTable(
+            "items",
+            new[]
+            {
+                new ColumnDef("id", "INTEGER", PrimaryKey: true),
+                ColumnDef.WithDefault("status", "TEXT", "active"),
+            },
+            ifNotExists: false);
+
+        backend.Insert("items", new Row { ["id"] = 1 });
+        Assert.Throws<ColumnNotFound>(() => backend.Insert("items", new Row { ["id"] = 2, ["ghost"] = "x" }));
+
+        usingIterator(backend.Scan("items"), rows =>
+        {
+            Assert.Equal("active", rows.Single()["status"]);
+        });
+    }
+
+    [Fact]
+    public void InsertEnforcesPrimaryKeyAndUniqueConstraints()
+    {
+        var backend = TestBackends.MakeUsers();
+
+        Assert.Throws<ConstraintViolation>(() => backend.Insert("users", new Row
+        {
+            ["id"] = 1,
+            ["name"] = "duplicate",
+            ["age"] = 99,
+            ["email"] = "dup@example.com",
+        }));
+
+        Assert.Throws<ConstraintViolation>(() => backend.Insert("users", new Row
+        {
+            ["id"] = 4,
+            ["name"] = "duplicate",
+            ["age"] = 99,
+            ["email"] = "alice@example.com",
+        }));
+    }
+
+    [Fact]
+    public void UniqueColumnsAllowMultipleNulls()
+    {
+        var backend = new InMemoryBackend();
+        backend.CreateTable(
+            "users",
+            new[] { new ColumnDef("id", "INTEGER", PrimaryKey: true), new ColumnDef("email", "TEXT", Unique: true) },
+            ifNotExists: false);
+
+        backend.Insert("users", new Row { ["id"] = 1, ["email"] = null });
+        backend.Insert("users", new Row { ["id"] = 2, ["email"] = null });
+
+        usingIterator(backend.Scan("users"), rows => Assert.Equal(2, rows.Count));
+    }
+
+    [Fact]
+    public void PositionedUpdateAndDeleteUseCursor()
+    {
+        var backend = TestBackends.MakeUsers();
+        var cursor = backend.OpenCursor("users");
+        Assert.Equal(1, cursor.Next()?["id"]);
+
+        backend.Update("users", cursor, new Dictionary<string, object?> { ["name"] = "ALICE" });
+        Assert.Equal("ALICE", backend.OpenCursor("users").Next()?["name"]);
+
+        backend.Delete("users", cursor);
+        Assert.Equal(2, backend.OpenCursor("users").Next()?["id"]);
+    }
+
+    [Fact]
+    public void UpdateRejectsInvalidCursorAndUnknownColumns()
+    {
+        var backend = TestBackends.MakeUsers();
+        var cursor = backend.OpenCursor("users");
+
+        Assert.Throws<Unsupported>(() => backend.Update("users", cursor, new Dictionary<string, object?> { ["name"] = "x" }));
+
+        cursor.Next();
+        Assert.Throws<ColumnNotFound>(() => backend.Update("users", cursor, new Dictionary<string, object?> { ["ghost"] = "x" }));
+        Assert.Throws<Unsupported>(() => backend.Update("users", new FakeCursor(), new Dictionary<string, object?>()));
+    }
+
+    [Fact]
+    public void CreateDropAndAddColumnImplementDdl()
+    {
+        var backend = new InMemoryBackend();
+        backend.CreateTable("t", new[] { new ColumnDef("id", "INTEGER") }, ifNotExists: false);
+        backend.CreateTable("t", Array.Empty<ColumnDef>(), ifNotExists: true);
+        Assert.Throws<TableAlreadyExists>(() => backend.CreateTable("t", Array.Empty<ColumnDef>(), ifNotExists: false));
+
+        backend.AddColumn("t", ColumnDef.WithDefault("status", "TEXT", "new"));
+        backend.Insert("t", new Row { ["id"] = 1 });
+        usingIterator(backend.Scan("t"), rows => Assert.Equal("new", rows.Single()["status"]));
+
+        Assert.Throws<ColumnAlreadyExists>(() => backend.AddColumn("t", new ColumnDef("status", "TEXT")));
+        Assert.Throws<ConstraintViolation>(() => backend.AddColumn("t", new ColumnDef("must_have", "TEXT", NotNull: true)));
+
+        backend.DropTable("t", ifExists: false);
+        backend.DropTable("t", ifExists: true);
+        Assert.Throws<TableNotFound>(() => backend.DropTable("t", ifExists: false));
+    }
+
+    [Fact]
+    public void TransactionsCommitAndRollback()
+    {
+        var backend = TestBackends.MakeUsers();
+        var handle = backend.BeginTransaction();
+        backend.Insert("users", new Row { ["id"] = 4, ["name"] = "Dave", ["age"] = 41, ["email"] = "dave@example.com" });
+        backend.Rollback(handle);
+        usingIterator(backend.Scan("users"), rows => Assert.DoesNotContain(rows, row => Equals(row["id"], 4)));
+
+        var committed = backend.BeginTransaction();
+        backend.Insert("users", new Row { ["id"] = 4, ["name"] = "Dave", ["age"] = 41, ["email"] = "dave@example.com" });
+        backend.Commit(committed);
+        usingIterator(backend.Scan("users"), rows => Assert.Contains(rows, row => Equals(row["id"], 4)));
+    }
+
+    [Fact]
+    public void TransactionsRejectNestedAndStaleHandles()
+    {
+        var backend = TestBackends.MakeUsers();
+        var first = backend.BeginTransaction();
+
+        Assert.Equal(first, backend.CurrentTransaction());
+        Assert.Throws<Unsupported>(() => backend.BeginTransaction());
+        backend.Commit(first);
+        Assert.Throws<Unsupported>(() => backend.Commit(first));
+    }
+
+    [Fact]
+    public void IndexesCanBeListedScannedAndDropped()
+    {
+        var backend = TestBackends.MakeUsers();
+        backend.CreateIndex(new IndexDef("idx_age", "users", new[] { "age" }));
+
+        Assert.Equal("idx_age", backend.ListIndexes("users").Single().Name);
+        var rowids = backend.ScanIndex("idx_age", new object?[] { 25 }, new object?[] { 30 }).ToArray();
+        Assert.Equal(new[] { 1, 0 }, rowids);
+
+        usingIterator(backend.ScanByRowIds("users", rowids), rows =>
+        {
+            Assert.Equal(new object?[] { 2, 1 }, rows.Select(row => row["id"]).ToArray());
+        });
+
+        backend.DropIndex("idx_age");
+        Assert.Empty(backend.ListIndexes());
+        Assert.Throws<IndexNotFound>(() => backend.DropIndex("idx_age"));
+        backend.DropIndex("idx_age", ifExists: true);
+    }
+
+    [Fact]
+    public void IndexCreationValidatesInputs()
+    {
+        var backend = TestBackends.MakeUsers();
+        backend.CreateIndex(new IndexDef("idx_email", "users", new[] { "email" }, unique: true));
+
+        Assert.Throws<IndexAlreadyExists>(() => backend.CreateIndex(new IndexDef("idx_email", "users", new[] { "email" })));
+        Assert.Throws<TableNotFound>(() => backend.CreateIndex(new IndexDef("bad_table", "missing", new[] { "id" })));
+        Assert.Throws<ColumnNotFound>(() => backend.CreateIndex(new IndexDef("bad_column", "users", new[] { "missing" })));
+        Assert.Throws<IndexNotFound>(() => backend.ScanIndex("missing", null, null).ToArray());
+    }
+
+    [Fact]
+    public void DefaultSavepointsAndTriggersExposeOptionalOperations()
+    {
+        var backend = TestBackends.MakeUsers();
+
+        Assert.Throws<Unsupported>(() => backend.CreateSavepoint("s1"));
+        Assert.Throws<Unsupported>(() => backend.CreateTrigger(new TriggerDef("tr", "users", "AFTER", "INSERT", "SELECT 1")));
+        Assert.Empty(backend.ListTriggers("users"));
+    }
+
+    private static void usingIterator(IRowIterator iterator, Action<IReadOnlyList<Row>> assertions)
+    {
+        var rows = new List<Row>();
+        try
+        {
+            while (iterator.Next() is { } row)
+            {
+                rows.Add(row);
+            }
+
+            assertions(rows);
+        }
+        finally
+        {
+            iterator.Close();
+        }
+    }
+
+    private sealed class FakeCursor : ICursor
+    {
+        public Row? CurrentRow => null;
+        public Row? Next() => null;
+        public void Close()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port the Python sql-backend contract into a C# package
- add row iterators, positioned cursors, schema/index metadata, typed backend errors, and an in-memory backend
- cover DDL, DML, defaults, constraints, indexes, rowid scans, transaction snapshots, and optional-operation defaults

## Validation
- dotnet test tests/CodingAdventures.SqlBackend.Tests/CodingAdventures.SqlBackend.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -language csharp -emit-plan C:\Users\adhit\AppData\Local\Temp\mini-sqlite-sql-backend-csharp-plan.json