### PR TITLE
Add reusable HTML lexer context application

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -204,3 +204,6 @@ documented in this file.
 - Added parser-facing `HtmlTokenizerState` and `HtmlLexContext` APIs, including
   typed fragment lexing and element-to-tokenizer-mode mapping for RCDATA,
   RAWTEXT, script data, and PLAINTEXT parser handoff.
+- Added `apply_html_lex_context` so parser code can reconfigure an existing
+  lexer with typed HTML context and clear stale text-mode tag context when
+  returning to data-state lexing.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -147,7 +147,9 @@ The public Rust API now wraps those parser-controlled entry states in
 `HtmlTokenizerState` and `HtmlLexContext`, including an element-to-context map
 for `title`, `textarea`, raw-text elements, `script`, and `plaintext`. That
 lets the parser request a statically linked lexer in the right tokenizer mode
-without depending on generated machine-state strings.
+without depending on generated machine-state strings. Parsers that keep one
+lexer alive can call `apply_html_lex_context` to move that lexer between data
+state and text-mode states while clearing stale last-start-tag context.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -81,6 +81,10 @@ impl HtmlLexContext {
         self
     }
 
+    pub fn is_data(&self) -> bool {
+        self.initial_state == HtmlTokenizerState::Data && self.last_start_tag.is_none()
+    }
+
     /// Return the tokenizer context used for text following a start tag.
     ///
     /// This is the parser-facing map from element names to HTML tokenizer
@@ -135,11 +139,19 @@ pub fn create_html_lexer() -> Result<HtmlLexer> {
 /// Build a lexer seeded with a parser-controlled HTML tokenizer context.
 pub fn create_html_lexer_with_context(context: &HtmlLexContext) -> Result<HtmlLexer> {
     let mut lexer = create_html_lexer()?;
+    apply_html_lex_context(&mut lexer, context)?;
+    Ok(lexer)
+}
+
+/// Move an existing lexer into a parser-controlled HTML tokenizer context.
+pub fn apply_html_lex_context(lexer: &mut HtmlLexer, context: &HtmlLexContext) -> Result<()> {
     lexer.set_initial_state(context.initial_state.as_machine_state())?;
     if let Some(last_start_tag) = context.last_start_tag.as_deref() {
         lexer.set_last_start_tag(last_start_tag);
+    } else {
+        lexer.clear_last_start_tag();
     }
-    Ok(lexer)
+    Ok(())
 }
 
 /// Lex one complete HTML string with the current compatibility-floor machine.

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,7 +1,7 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer, html1_definition, html1_machine, html_skeleton_definition,
-    html_skeleton_machine, lex_html, lex_html_fragment, Attribute, HtmlLexContext,
-    HtmlTokenizerState, Token,
+    apply_html_lex_context, create_html_lexer, html1_definition, html1_machine,
+    html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment, Attribute,
+    HtmlLexContext, HtmlTokenizerState, Token,
 };
 use state_machine::END_INPUT;
 
@@ -4340,6 +4340,7 @@ fn parser_facing_context_maps_script_and_plaintext_elements() {
 #[test]
 fn parser_facing_context_leaves_normal_elements_in_data_state() {
     assert_eq!(HtmlLexContext::for_element_text("p"), None);
+    assert!(HtmlLexContext::data().is_data());
     assert_eq!(
         HtmlLexContext::data().initial_state.as_machine_state(),
         "data"
@@ -4347,6 +4348,48 @@ fn parser_facing_context_leaves_normal_elements_in_data_state() {
     assert_eq!(
         HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign.as_machine_state(),
         "script_data_double_escaped_less_than_sign"
+    );
+}
+
+#[test]
+fn parser_facing_context_can_reconfigure_an_existing_lexer() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    apply_html_lex_context(
+        &mut lexer,
+        &HtmlLexContext::for_element_text("script").unwrap(),
+    )
+    .unwrap();
+    lexer.push("if (a < b)</script>").unwrap();
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("if (a < b)".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            }
+        ]
+    );
+
+    apply_html_lex_context(&mut lexer, &HtmlLexContext::data()).unwrap();
+    assert_eq!(lexer.current_state(), "data");
+    lexer.push("<p>after</p>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "p".to_string(),
+                attributes: Vec::new(),
+                self_closing: false
+            },
+            Token::Text("after".to_string()),
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Eof
+        ]
     );
 }
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6,8 +6,8 @@
 //! insertion-mode machinery on top of this DOM target.
 
 use coding_adventures_html_lexer::{
-    create_html_lexer, Attribute as LexerAttribute, Diagnostic, HtmlLexContext, HtmlLexer, Token,
-    TokenizerError,
+    apply_html_lex_context, create_html_lexer, Attribute as LexerAttribute, Diagnostic,
+    HtmlLexContext, HtmlLexer, Token, TokenizerError,
 };
 use dom_core::{Attribute, Document, DocumentType, Node};
 use std::fmt;
@@ -256,10 +256,7 @@ fn drain_parser_tokens(lexer: &mut HtmlLexer, parser: &mut HtmlParser) -> Result
         parser.process_token(token);
 
         if let Some(context) = next_context {
-            lexer.set_initial_state(context.initial_state.as_machine_state())?;
-            if let Some(last_start_tag) = context.last_start_tag {
-                lexer.set_last_start_tag(last_start_tag);
-            }
+            apply_html_lex_context(lexer, &context)?;
         }
     }
 

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -270,6 +270,11 @@ impl Tokenizer {
         self.last_start_tag = Some(tag.into());
     }
 
+    /// Clear the last emitted start-tag name used by tokenizer submodes.
+    pub fn clear_last_start_tag(&mut self) {
+        self.last_start_tag = None;
+    }
+
     /// Push one chunk of Unicode text into the tokenizer.
     pub fn push(&mut self, chunk: &str) -> Result<()> {
         if self.finished {


### PR DESCRIPTION
## Summary
- Add `apply_html_lex_context` so parser code can move an existing lexer between typed HTML tokenizer contexts.
- Clear stale `last_start_tag` context when returning to data/plaintext-style contexts via a new tokenizer primitive.
- Update the HTML parser to use the lexer-owned context helper instead of manually poking generated state names.

## Verification
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `git diff --check`