### PR TITLE
Forward formal ALGOL procedure actuals

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -89,6 +89,9 @@ All notable changes to this package will be documented in this file.
   chosen switch descriptor through concrete and formal procedure calls.
 - Preserved concrete procedure ids in formal procedure call-shape metadata so
   nested procedure-parameter contracts are checked before IR lowering.
+- Lowered formal procedure parameters passed as procedure arguments to another
+  formal procedure call, preserving the forwarded procedure descriptor instead
+  of treating the bare formal name as a scalar expression.
 - Lowered recursive switch self-selection through runtime switch-eval descriptor
   dispatch rather than compile-time descriptor expansion.
 - Lowered `go to` statements through the same direct and designational goto

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -3731,7 +3731,7 @@ class AlgolIrCompiler:
             ):
                 return None
             return "procedure", symbol.type_name
-        if symbol.kind == "procedure_parameter" and symbol.type_name == "procedure":
+        if symbol.kind == "procedure_parameter":
             return "procedure", symbol.type_name
         return None
 

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1328,6 +1328,29 @@ class TestAlgolIrCompiler:
             == ("integer", "integer", "integer")
         )
 
+    def test_compiles_formal_procedure_parameter_as_procedure_argument(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer procedure id(x); value x; integer x; begin id := x end; "
+                "integer procedure relay1(g, y); integer g, y; procedure g; "
+                "begin relay1 := g(y) end; "
+                "integer procedure relay2(p, h, z); integer p, h, z; "
+                "procedure p, h; begin relay2 := p(h, z) end; "
+                "procedure invoke(q); integer q; procedure q; "
+                "begin result := q(relay1, id, 3 + 4) end; "
+                "invoke(relay2) "
+                "end"
+            )
+        )
+
+        assert (
+            result.procedure_signatures[
+                "_fn_algol_call_procedure_i32_result_procedure_i32_i32"
+            ].param_types
+            == ("integer", "integer", "integer", "integer")
+        )
+
     def test_compiles_value_procedure_parameter_call_with_value_argument(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -58,6 +58,9 @@ All notable changes to this package will be documented in this file.
   as the older split spelling.
 - Validated nested procedure-parameter call-shape contracts when a formal
   procedure call forwards a concrete procedure actual.
+- Validated nested procedure-parameter call-shape contracts when a formal
+  procedure call forwards another formal procedure parameter and resolves the
+  eventual concrete procedure actual through the enclosing call shape.
 - Accepted conditional switch designator actuals for switch formals and formal
   procedure call-shape recording.
 - Accepted recursive switch self-selection entries so terminating recursive

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -231,6 +231,15 @@ class ProcedureFormalCallShape:
 
 
 @dataclass(frozen=True)
+class _ProcedureShapeContext:
+    """Maps forwarded formal procedure names to an enclosing call shape."""
+
+    descriptor: ProcedureDescriptor
+    shape: ProcedureFormalCallShape
+    parent: _ProcedureShapeContext | None = None
+
+
+@dataclass(frozen=True)
 class ProcedureParameter:
     """A procedure parameter planned as a frame slot in an activation."""
 
@@ -2205,11 +2214,16 @@ class AlgolTypeChecker:
                 continue
             nonscalar = self._formal_nonscalar_argument_shape(argument, scope)
             if nonscalar is not None:
-                argument_kind, argument_type, procedure_id = nonscalar
+                (
+                    argument_kind,
+                    argument_type,
+                    procedure_id,
+                    formal_name,
+                ) = nonscalar
                 argument_types.append(argument_type)
                 argument_kinds.append(argument_kind)
                 argument_assignable.append(False)
-                argument_formal_names.append(None)
+                argument_formal_names.append(formal_name)
                 procedure_argument_ids.append(procedure_id)
                 continue
             actual_type = self._infer_expr(argument, scope)
@@ -2309,7 +2323,7 @@ class AlgolTypeChecker:
         self,
         argument: ASTNode,
         scope: Scope,
-    ) -> tuple[str, str, int | None] | None:
+    ) -> tuple[str, str, int | None, str | None] | None:
         if self._check_label_designational_actual(
             argument,
             scope,
@@ -2324,7 +2338,7 @@ class AlgolTypeChecker:
                 report=True,
                 record=True,
             )
-            return LABEL, LABEL, None
+            return LABEL, LABEL, None, None
 
         if self._check_switch_designator_actual(
             argument,
@@ -2338,7 +2352,7 @@ class AlgolTypeChecker:
                 parameter_name="procedure argument",
                 report=True,
             )
-            return SWITCH, SWITCH, None
+            return SWITCH, SWITCH, None, None
 
         variable = _single_variable_expr(argument)
         if variable is None or _variable_subscripts(variable):
@@ -2351,9 +2365,9 @@ class AlgolTypeChecker:
             return None
         symbol, _, _ = resolved
         if symbol.kind == LABEL:
-            return LABEL, LABEL, None
+            return LABEL, LABEL, None, None
         if symbol.kind == SWITCH:
-            return SWITCH, SWITCH, None
+            return SWITCH, SWITCH, None, None
         if symbol.kind == "procedure":
             descriptor = next(
                 (
@@ -2369,9 +2383,9 @@ class AlgolTypeChecker:
                 and not descriptor.parameters
             ):
                 return None
-            return "procedure", symbol.type_name, symbol.procedure_id
-        if symbol.kind == "procedure_parameter" and symbol.type_name == "procedure":
-            return "procedure", symbol.type_name, None
+            return "procedure", symbol.type_name, symbol.procedure_id, None
+        if symbol.kind == "procedure_parameter":
+            return "procedure", symbol.type_name, None, symbol.name
         return None
 
     def _scalar_by_name_parameter_actual_name(
@@ -3016,6 +3030,7 @@ class AlgolTypeChecker:
                     descriptor,
                     actual_parameter,
                     shape,
+                    context=None,
                 )
                 if actual_parameter.mode == NAME and (
                     parameter_may_write and not argument_assignable
@@ -3035,6 +3050,8 @@ class AlgolTypeChecker:
         descriptor: ProcedureDescriptor,
         parameter: ProcedureParameter,
         shape: ProcedureFormalCallShape,
+        *,
+        context: _ProcedureShapeContext | None,
     ) -> bool:
         if (
             parameter.kind != "scalar"
@@ -3056,34 +3073,80 @@ class AlgolTypeChecker:
                         continue
                     saw_formal_procedure_shape = True
                     if self._shape_procedure_argument_writes(
+                        descriptor,
                         shape,
                         procedure_index,
                         nested_shape,
                         argument_index,
+                        context=context,
                     ):
                         return True
         return not saw_formal_procedure_shape
 
     def _shape_procedure_argument_writes(
         self,
+        shape_descriptor: ProcedureDescriptor,
         shape: ProcedureFormalCallShape,
         procedure_argument_index: int,
         nested_shape: ProcedureFormalCallShape,
         nested_argument_index: int,
+        *,
+        context: _ProcedureShapeContext | None,
     ) -> bool:
-        if procedure_argument_index >= len(shape.procedure_argument_ids):
-            return True
-        procedure_id = shape.procedure_argument_ids[procedure_argument_index]
+        procedure_id = self._resolve_shape_procedure_argument_id(
+            shape,
+            procedure_argument_index,
+            context,
+        )
         if procedure_id is None:
             return True
         descriptor = self._procedure_descriptor_for_id(procedure_id)
         if descriptor is None or nested_argument_index >= len(descriptor.parameters):
             return True
         parameter = descriptor.parameters[nested_argument_index]
+        nested_context = _ProcedureShapeContext(
+            descriptor=shape_descriptor,
+            shape=shape,
+            parent=context,
+        )
         return self._procedure_parameter_may_write_for_shape(
             descriptor,
             parameter,
             nested_shape,
+            context=nested_context,
+        )
+
+    def _resolve_shape_procedure_argument_id(
+        self,
+        shape: ProcedureFormalCallShape,
+        procedure_argument_index: int,
+        context: _ProcedureShapeContext | None,
+    ) -> int | None:
+        if procedure_argument_index >= len(shape.procedure_argument_ids):
+            return None
+        procedure_id = shape.procedure_argument_ids[procedure_argument_index]
+        if procedure_id is not None:
+            return procedure_id
+        formal_names = _shape_argument_formal_names(shape)
+        if procedure_argument_index >= len(formal_names):
+            return None
+        formal_name = formal_names[procedure_argument_index]
+        if formal_name is None or context is None:
+            return None
+        parameter_index = next(
+            (
+                index
+                for index, parameter in enumerate(context.descriptor.parameters)
+                if parameter.kind == "procedure" and parameter.name == formal_name
+            ),
+            None,
+        )
+        if parameter_index is None:
+            return None
+        return self._resolve_shape_procedure_argument_id(
+            context.shape,
+            parameter_index,
+            context.parent,
         )
 
     def _procedure_descriptor_for_id(

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -1559,6 +1559,51 @@ class TestAlgolTypeChecker:
         assert not result.ok
         assert "non-assignable actual" in result.diagnostics[0].message
 
+    def test_accepts_forwarded_formal_procedure_actual_shape_when_nested_actual_reads(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure id(x); value x; integer x; begin id := x end; "
+            "integer procedure relay1(g, y); integer g, y; procedure g; "
+            "begin relay1 := g(y) end; "
+            "integer procedure relay2(p, h, z); integer p, h, z; "
+            "procedure p, h; begin relay2 := p(h, z) end; "
+            "procedure invoke(q); integer q; procedure q; "
+            "begin result := q(relay1, id, 3 + 4) end; "
+            "invoke(relay2) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        relay2 = result.semantic.procedures[2]
+        shape = relay2.parameters[0].procedure_call_shapes[0]
+        assert shape.argument_kinds == ("procedure", "scalar")
+        assert shape.argument_formal_names == ("h", "z")
+
+    def test_rejects_forwarded_formal_procedure_actual_shape_when_nested_actual_writes(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure inc(x); integer x; "
+            "begin x := x + 1; inc := x end; "
+            "integer procedure relay1(g, y); integer g, y; procedure g; "
+            "begin relay1 := g(y) end; "
+            "integer procedure relay2(p, h, z); integer p, h, z; "
+            "procedure p, h; begin relay2 := p(h, z) end; "
+            "procedure invoke(q); integer q; procedure q; "
+            "begin result := q(relay1, inc, 3 + 4) end; "
+            "invoke(relay2) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "non-assignable actual" in result.diagnostics[0].message
+
     def test_accepts_procedure_parameter_actual_with_array_element_by_name_formal(
         self,
     ) -> None:

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -87,6 +87,9 @@ All notable changes to this package will be documented in this file.
   statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does
   not satisfy the nested procedure formal contract expected by the receiver.
+- Executed formal procedure calls that forward another formal procedure
+  parameter as a procedure argument, including read-only expression actuals and
+  writable by-name actuals through the final concrete procedure.
 - Executed recursive switch self-selection entries by routing recursive
   descriptor lookup through the switch-eval helper at runtime.
 - Executed the report-style `go to` spelling through the full parser,

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1464,6 +1464,42 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [44]
 
+    def test_formal_procedure_forwards_formal_procedure_actual_read_only(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure id(x); value x; integer x; begin id := x end; "
+            "integer procedure relay1(g, y); integer g, y; procedure g; "
+            "begin relay1 := g(y) end; "
+            "integer procedure relay2(p, h, z); integer p, h, z; "
+            "procedure p, h; begin relay2 := p(h, z) end; "
+            "procedure invoke(q); integer q; procedure q; "
+            "begin result := q(relay1, id, 3 + 4) end; "
+            "invoke(relay2) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_formal_procedure_forwards_formal_procedure_actual_writable(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure inc(x); integer x; "
+            "begin x := x + 1; inc := x end; "
+            "integer procedure relay1(g, y); integer g, y; procedure g; "
+            "begin relay1 := g(y) end; "
+            "integer procedure relay2(p, h, z); integer p, h, z; "
+            "procedure p, h; begin relay2 := p(h, z) end; "
+            "procedure invoke(q); integer q; procedure q; "
+            "begin result := 3; "
+            "result := q(relay1, inc, result) * 10 + result end; "
+            "invoke(relay2) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [44]
+
     def test_real_procedure_parameter_accepts_integer_return_actual(self) -> None:
         result = compile_source(
             "begin integer result; real y; "


### PR DESCRIPTION
## Summary
- record formal procedure argument names in formal-call shapes so higher-order forwarding can resolve the eventual concrete procedure actual
- classify bare formal procedure parameters as procedure arguments in IR formal dispatch, preserving descriptor forwarding
- add type-checker, IR, and WASM runtime coverage for three-level formal procedure forwarding with read-only expression actuals and writable by-name actuals

## Tests
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/ -v (algol-type-checker)
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/ -v (algol-ir-compiler)
- .venv/bin/python -m pytest tests/ -v (algol-wasm-compiler)
- code/packages/python/algol-wasm-compiler/.venv/bin/python -m ruff check code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler
- git diff --check

## Security
- scanned touched code/tests/changelogs for subprocess, shell execution, eval/exec, unsafe YAML/pickle, network/socket, and destructive filesystem APIs; no matches