### PR TITLE
feat(prolog): add source runner helpers

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -22,14 +22,17 @@ It is the bridge between the Prolog frontend stack and the Logic VM:
   `run_compiled_prolog_bytecode_query(...)`
 - select either the structured VM or bytecode VM through shared APIs with
   `backend="structured"` or `backend="bytecode"`
+- run source text directly through one-shot helpers such as
+  `run_prolog_source_query(...)` when callers do not need to keep the compiled
+  program around
 
 ## Quick Start
 
 ```python
 from logic_engine import atom
-from prolog_vm_compiler import compile_swi_prolog_source, run_compiled_prolog_query
+from prolog_vm_compiler import run_swi_prolog_source_query
 
-compiled = compile_swi_prolog_source(
+answers = run_swi_prolog_source_query(
     """
     parent(homer, bart).
     parent(homer, lisa).
@@ -40,7 +43,7 @@ compiled = compile_swi_prolog_source(
     """,
 )
 
-assert run_compiled_prolog_query(compiled) == [atom("bart"), atom("lisa")]
+assert answers == [atom("bart"), atom("lisa")]
 ```
 
 Use the generic dialect-routed entry point when the caller should choose the
@@ -48,9 +51,9 @@ frontend policy explicitly:
 
 ```python
 from logic_engine import atom
-from prolog_vm_compiler import compile_prolog_source, run_compiled_prolog_query
+from prolog_vm_compiler import run_prolog_source_query
 
-compiled = compile_prolog_source(
+answers = run_prolog_source_query(
     """
     parent(homer, bart).
     ?- parent(homer, Who).
@@ -58,8 +61,11 @@ compiled = compile_prolog_source(
     dialect="iso",
 )
 
-assert run_compiled_prolog_query(compiled) == [atom("bart")]
+assert answers == [atom("bart")]
 ```
+
+When you want to reuse a compiled program, keep using
+`compile_swi_prolog_source(...)` plus `run_compiled_prolog_query(...)`.
 
 ## Bytecode VM Path
 
@@ -68,21 +74,19 @@ on the lower opcode runtime instead of stopping at `logic-instructions`:
 
 ```python
 from logic_engine import atom
-from prolog_vm_compiler import compile_swi_prolog_source, run_compiled_prolog_query
+from prolog_vm_compiler import run_swi_prolog_source_query
 
-compiled = compile_swi_prolog_source(
+answers = run_swi_prolog_source_query(
     """
     parent(homer, bart).
     parent(homer, lisa).
 
     ?- parent(homer, Who).
     """,
+    backend="bytecode",
 )
 
-assert run_compiled_prolog_query(compiled, backend="bytecode") == [
-    atom("bart"),
-    atom("lisa"),
-]
+assert answers == [atom("bart"), atom("lisa")]
 ```
 
 Stateful bytecode runtimes mirror the structured VM runtime helpers:

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/__init__.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/__init__.py
@@ -53,6 +53,12 @@ from prolog_vm_compiler.compiler import (
     run_initialized_compiled_prolog_bytecode_query_answers,
     run_initialized_compiled_prolog_query,
     run_initialized_compiled_prolog_query_answers,
+    run_iso_prolog_source_query,
+    run_iso_prolog_source_query_answers,
+    run_prolog_source_query,
+    run_prolog_source_query_answers,
+    run_swi_prolog_source_query,
+    run_swi_prolog_source_query_answers,
 )
 
 __all__ = [
@@ -109,6 +115,12 @@ __all__ = [
     "run_initialized_compiled_prolog_query_answers",
     "run_initialized_compiled_prolog_bytecode_query",
     "run_initialized_compiled_prolog_bytecode_query_answers",
+    "run_iso_prolog_source_query",
+    "run_iso_prolog_source_query_answers",
+    "run_prolog_source_query",
+    "run_prolog_source_query_answers",
+    "run_swi_prolog_source_query",
+    "run_swi_prolog_source_query_answers",
 ]
 
 __version__ = "0.1.0"

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/compiler.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/compiler.py
@@ -349,6 +349,158 @@ def compile_iso_prolog_source(
     )
 
 
+def run_prolog_source_query(
+    source: str,
+    source_query_index: int = 0,
+    limit: int | None = None,
+    *,
+    dialect: PrologDialect = "swi",
+    initialize: bool = False,
+    adapt_builtins: bool = True,
+    backend: PrologVMBackend = "structured",
+) -> list[Term | tuple[Term, ...]]:
+    """Parse, compile, and run one source query through the selected backend."""
+
+    compiled_program = compile_prolog_source(
+        source,
+        dialect=dialect,
+        adapt_builtins=adapt_builtins,
+    )
+    if initialize:
+        return run_initialized_compiled_prolog_query(
+            compiled_program,
+            source_query_index,
+            limit,
+            backend=backend,
+        )
+    return run_compiled_prolog_query(
+        compiled_program,
+        source_query_index,
+        limit,
+        backend=backend,
+    )
+
+
+def run_prolog_source_query_answers(
+    source: str,
+    source_query_index: int = 0,
+    limit: int | None = None,
+    *,
+    dialect: PrologDialect = "swi",
+    initialize: bool = False,
+    adapt_builtins: bool = True,
+    backend: PrologVMBackend = "structured",
+) -> list[PrologAnswer]:
+    """Parse, compile, and run one source query with named bindings."""
+
+    compiled_program = compile_prolog_source(
+        source,
+        dialect=dialect,
+        adapt_builtins=adapt_builtins,
+    )
+    if initialize:
+        return run_initialized_compiled_prolog_query_answers(
+            compiled_program,
+            source_query_index,
+            limit,
+            backend=backend,
+        )
+    return run_compiled_prolog_query_answers(
+        compiled_program,
+        source_query_index,
+        limit,
+        backend=backend,
+    )
+
+
+def run_swi_prolog_source_query(
+    source: str,
+    source_query_index: int = 0,
+    limit: int | None = None,
+    *,
+    initialize: bool = False,
+    adapt_builtins: bool = True,
+    backend: PrologVMBackend = "structured",
+) -> list[Term | tuple[Term, ...]]:
+    """Parse, compile, and run one SWI-compatible source query."""
+
+    return run_prolog_source_query(
+        source,
+        source_query_index,
+        limit,
+        dialect="swi",
+        initialize=initialize,
+        adapt_builtins=adapt_builtins,
+        backend=backend,
+    )
+
+
+def run_swi_prolog_source_query_answers(
+    source: str,
+    source_query_index: int = 0,
+    limit: int | None = None,
+    *,
+    initialize: bool = False,
+    adapt_builtins: bool = True,
+    backend: PrologVMBackend = "structured",
+) -> list[PrologAnswer]:
+    """Parse, compile, and run one SWI-compatible query with named bindings."""
+
+    return run_prolog_source_query_answers(
+        source,
+        source_query_index,
+        limit,
+        dialect="swi",
+        initialize=initialize,
+        adapt_builtins=adapt_builtins,
+        backend=backend,
+    )
+
+
+def run_iso_prolog_source_query(
+    source: str,
+    source_query_index: int = 0,
+    limit: int | None = None,
+    *,
+    initialize: bool = False,
+    adapt_builtins: bool = True,
+    backend: PrologVMBackend = "structured",
+) -> list[Term | tuple[Term, ...]]:
+    """Parse, compile, and run one ISO/Core source query."""
+
+    return run_prolog_source_query(
+        source,
+        source_query_index,
+        limit,
+        dialect="iso",
+        initialize=initialize,
+        adapt_builtins=adapt_builtins,
+        backend=backend,
+    )
+
+
+def run_iso_prolog_source_query_answers(
+    source: str,
+    source_query_index: int = 0,
+    limit: int | None = None,
+    *,
+    initialize: bool = False,
+    adapt_builtins: bool = True,
+    backend: PrologVMBackend = "structured",
+) -> list[PrologAnswer]:
+    """Parse, compile, and run one ISO/Core query with named bindings."""
+
+    return run_prolog_source_query_answers(
+        source,
+        source_query_index,
+        limit,
+        dialect="iso",
+        initialize=initialize,
+        adapt_builtins=adapt_builtins,
+        backend=backend,
+    )
+
+
 def compile_prolog_file(
     path: str | Path,
     *,

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_compiler.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_compiler.py
@@ -34,6 +34,10 @@ from prolog_vm_compiler import (
     run_compiled_prolog_query_answers,
     run_initialized_compiled_prolog_bytecode_query_answers,
     run_initialized_compiled_prolog_query_answers,
+    run_iso_prolog_source_query,
+    run_prolog_source_query,
+    run_prolog_source_query_answers,
+    run_swi_prolog_source_query_answers,
 )
 
 
@@ -179,6 +183,64 @@ class TestPrologVMCompiler:
             {"Who": atom("bart")},
             {"Who": atom("lisa")},
         ]
+
+    def test_one_shot_source_runner_uses_selected_backend(self) -> None:
+        source = """
+        parent(homer, bart).
+        parent(homer, lisa).
+
+        ?- parent(homer, Who).
+        """
+
+        assert run_prolog_source_query(source, backend="structured") == [
+            atom("bart"),
+            atom("lisa"),
+        ]
+        assert run_prolog_source_query(source, backend="bytecode") == [
+            atom("bart"),
+            atom("lisa"),
+        ]
+
+    def test_one_shot_source_runner_returns_named_answers(self) -> None:
+        answers = run_prolog_source_query_answers(
+            """
+            parent(homer, bart).
+            parent(homer, lisa).
+
+            ?- parent(homer, Who).
+            """,
+            backend="bytecode",
+        )
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"Who": atom("bart")},
+            {"Who": atom("lisa")},
+        ]
+
+    def test_one_shot_source_runner_can_run_initializations(self) -> None:
+        answers = run_swi_prolog_source_query_answers(
+            """
+            :- initialization(dynamic(seen/1)).
+            :- initialization(assertz(seen(alpha))).
+
+            ?- seen(Name).
+            """,
+            initialize=True,
+            backend="bytecode",
+        )
+
+        assert [answer.as_dict() for answer in answers] == [
+            {"Name": atom("alpha")},
+        ]
+
+    def test_one_shot_iso_runner_uses_iso_dialect(self) -> None:
+        assert run_iso_prolog_source_query(
+            """
+            parent(homer, bart).
+            ?- parent(homer, Who).
+            """,
+            backend="bytecode",
+        ) == [atom("bart")]
 
     def test_compiles_linked_module_project_before_vm_execution(self) -> None:
         compiled = compile_swi_prolog_project(

--- a/code/specs/PR74-prolog-source-runner-api.md
+++ b/code/specs/PR74-prolog-source-runner-api.md
@@ -1,0 +1,49 @@
+# PR74: Prolog Source Runner API
+
+## Goal
+
+Make the Prolog library path pleasant for one-shot Python use.
+
+Earlier PRs made the Prolog frontend compile to both structured and bytecode VM
+backends. This PR adds source-level helpers so callers can go directly from a
+Prolog source string to answers without manually compiling first.
+
+## Scope
+
+- Add `run_prolog_source_query(...)` for raw tuple/singleton values.
+- Add `run_prolog_source_query_answers(...)` for named `PrologAnswer` values.
+- Add SWI and ISO convenience wrappers.
+- Preserve backend selection through the same `backend="structured"` and
+  `backend="bytecode"` option.
+- Support optional initialization execution before the selected source query.
+
+## Examples
+
+```python
+from logic_engine import atom
+from prolog_vm_compiler import run_swi_prolog_source_query
+
+answers = run_swi_prolog_source_query(
+    """
+    parent(homer, bart).
+    parent(homer, lisa).
+    ?- parent(homer, Who).
+    """,
+    backend="bytecode",
+)
+
+assert answers == [atom("bart"), atom("lisa")]
+```
+
+## Acceptance
+
+- One-shot source helpers produce the same answers as compile-then-run helpers.
+- Named answer helpers preserve source variable names.
+- Initialization directives can seed dynamic state before a one-shot query.
+- ISO and SWI convenience wrappers route through the correct dialect profiles.
+
+## Future Direction
+
+File and project one-shot runners can follow the same shape if callers want a
+non-stateful API for consulted file graphs. Stateful runtime helpers remain the
+right abstraction for repeated top-level queries.


### PR DESCRIPTION
## Summary
- add one-shot source runner helpers for raw values and named Prolog answers
- support SWI and ISO convenience wrappers plus backend selection for structured or bytecode execution
- support optional initialization execution before one-shot queries
- document PR74 and update README quick-start examples

## Validation
- bash BUILD in code/packages/python/prolog-vm-compiler
- ruff check src tests in code/packages/python/prolog-vm-compiler
- git diff --check
- ca-build-tool build-plan validation