### PR TITLE
Support multiple ALGOL statement labels

### DIFF
--- a/code/grammars/algol.grammar
+++ b/code/grammars/algol.grammar
@@ -120,18 +120,18 @@ proc_body    = block | statement ;
 # Statements
 # ---------------------------------------------------------------------------
 
-# Any statement may carry a label. Labels can be identifiers or integer literals.
-# Labels are the targets of goto statements.
+# Any statement may carry one or more labels. Labels can be identifiers or
+# integer literals. Labels are the targets of goto statements.
 #
-# The third alternative (label COLON alone) supports a standalone label at the
-# end of a block, e.g. `done:` immediately before `end`. This is equivalent to
-# a label on an empty/dummy statement — a common ALGOL 60 idiom for goto targets
+# The third alternative supports standalone labels at the end of a block, e.g.
+# `done:` or `done1: done2:` immediately before `end`. This is equivalent to
+# labels on an empty/dummy statement — a common ALGOL 60 idiom for goto targets
 # at the end of a block. Strictly, ALGOL 60 requires a statement after a label,
-# but most implementations accept a terminal label because the block's `end`
+# but most implementations accept terminal labels because the block's `end`
 # acts as the associated statement.
-statement    = [ label COLON ] unlabeled_stmt
-             | [ label COLON ] cond_stmt
-             | label COLON ;
+statement    = { label COLON } unlabeled_stmt
+             | { label COLON } cond_stmt
+             | label COLON { label COLON } ;
 
 label        = NAME | INTEGER_LIT ;
 

--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -143,18 +143,18 @@ proc_body    = block | statement ;
 # Statements
 # ---------------------------------------------------------------------------
 
-# Any statement may carry a label. Labels can be identifiers or integer literals.
-# Labels are the targets of goto statements.
+# Any statement may carry one or more labels. Labels can be identifiers or
+# integer literals. Labels are the targets of goto statements.
 #
-# The third alternative (label COLON alone) supports a standalone label at the
-# end of a block, e.g. `done:` immediately before `end`. This is equivalent to
-# a label on an empty/dummy statement — a common ALGOL 60 idiom for goto targets
+# The third alternative supports standalone labels at the end of a block, e.g.
+# `done:` or `done1: done2:` immediately before `end`. This is equivalent to
+# labels on an empty/dummy statement — a common ALGOL 60 idiom for goto targets
 # at the end of a block. Strictly, ALGOL 60 requires a statement after a label,
-# but most implementations accept a terminal label because the block's `end`
+# but most implementations accept terminal labels because the block's `end`
 # acts as the associated statement.
-statement    = [ label COLON ] unlabeled_stmt
-             | [ label COLON ] cond_stmt
-             | label COLON ;
+statement    = { label COLON } unlabeled_stmt
+             | { label COLON } cond_stmt
+             | label COLON { label COLON } ;
 
 label        = NAME | INTEGER_LIT ;
 

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -266,7 +266,7 @@ class AlgolIrCompiler:
         self.references: dict[tuple[int, str], ResolvedReference] = {}
         self.procedure_calls: dict[tuple[int, str], ResolvedProcedureCall] = {}
         self.array_accesses: dict[tuple[int, str], ResolvedArrayAccess] = {}
-        self.labels: dict[int, LabelDescriptor] = {}
+        self.labels_by_statement: dict[int, list[LabelDescriptor]] = {}
         self.labels_by_symbol: dict[int, LabelDescriptor] = {}
         self.labels_by_block_name: dict[tuple[int, str], LabelDescriptor] = {}
         self.gotos: dict[int, ResolvedGoto] = {}
@@ -347,10 +347,11 @@ class AlgolIrCompiler:
             (access.token_id, access.role): access
             for access in type_result.semantic.array_accesses
         }
-        self.labels = {
-            label.statement_node_id: label
-            for label in type_result.semantic.labels
-        }
+        self.labels_by_statement = {}
+        for label in type_result.semantic.labels:
+            self.labels_by_statement.setdefault(label.statement_node_id, []).append(
+                label
+            )
         self.labels_by_id = {
             label.label_id: label for label in type_result.semantic.labels
         }
@@ -1026,8 +1027,7 @@ class AlgolIrCompiler:
         self._label(end_label)
 
     def _compile_statement(self, statement: ASTNode, scope: _FrameScope) -> None:
-        label = self.labels.get(id(statement))
-        if label is not None:
+        for label in self.labels_by_statement.get(id(statement), ()):
             self._label(label.ir_label)
 
         inner = _statement_body(statement)

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -423,6 +423,26 @@ class TestAlgolIrCompiler:
 
         assert IrOp.JUMP in opcodes
 
+    def test_compiles_multiple_labels_on_one_statement(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "goto second; "
+                "first: second: result := 7 "
+                "end"
+            )
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+        algol_labels = [
+            label for label in labels if label.startswith("algol_label_")
+        ]
+
+        assert len(algol_labels) == 2
+
     def test_compiles_procedure_crossing_goto_with_pending_transfer(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -354,6 +354,42 @@ class TestGotoStatement:
         goto_nodes = find_nodes(ast, "goto_stmt")
         assert len(goto_nodes) == 1
 
+    def test_multiple_labels_on_statement(self) -> None:
+        """A statement may have more than one direct goto label."""
+        ast = parse(
+            "begin integer result; "
+            "first: second: result := 7 "
+            "end"
+        )
+        statement = next(
+            node
+            for node in find_nodes(ast, "statement")
+            if len([child for child in child_nodes(node) if child.rule_name == "label"])
+            == 2
+        )
+
+        assert [child.rule_name for child in child_nodes(statement)][:2] == [
+            "label",
+            "label",
+        ]
+
+    def test_multiple_terminal_labels(self) -> None:
+        """Multiple terminal labels may share the block-end dummy statement."""
+        ast = parse(
+            "begin integer result; "
+            "result := 1; "
+            "done1: done2: "
+            "end"
+        )
+        statement = next(
+            node
+            for node in find_nodes(ast, "statement")
+            if len([child for child in child_nodes(node) if child.rule_name == "label"])
+            == 2
+        )
+
+        assert all(child.rule_name == "label" for child in child_nodes(statement))
+
 
 # ---------------------------------------------------------------------------
 # For loop tests

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1137,8 +1137,7 @@ class AlgolTypeChecker:
         )
 
     def _collect_statement_labels(self, statement: ASTNode, scope: Scope) -> None:
-        label_node = _first_direct_node(statement, "label")
-        if label_node is not None:
+        for label_node in _direct_nodes(statement, "label"):
             label_token = _label_token(label_node)
             if label_token is not None:
                 self._declare_label(label_token, statement, scope)

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -197,6 +197,33 @@ class TestAlgolTypeChecker:
         assert result.semantic.labels[0].name == "10"
         assert result.semantic.gotos[0].target_name == "10"
 
+    def test_accepts_multiple_labels_on_one_statement(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "goto second; "
+            "first: second: result := 7 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert [label.name for label in result.semantic.labels] == ["first", "second"]
+        assert (
+            result.semantic.labels[0].statement_node_id
+            == result.semantic.labels[1].statement_node_id
+        )
+        assert result.semantic.gotos[0].target_name == "second"
+
+    def test_rejects_duplicate_labels_on_one_statement(self) -> None:
+        ast = parse_algol("begin integer result; done: done: result := 7 end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "label 'done' is already declared in this frame" in (
+            result.diagnostics[0].message
+        )
+
     def test_accepts_terminal_label_inside_compound_statement(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -738,6 +738,35 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_forward_goto_targets_second_label_on_statement(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "goto second; "
+            "first: second: result := 7 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_forward_goto_targets_first_label_on_shared_statement(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "goto first; "
+            "first: second: result := 8 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
+    def test_forward_goto_targets_multiple_terminal_labels(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "result := 3; "
+            "goto done2; "
+            "result := 99; "
+            "done1: done2: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [3]
+
     def test_backward_goto_runs_local_loop(self) -> None:
         result = compile_source(
             "begin integer result, i; "


### PR DESCRIPTION
Summary: extends ALGOL grammar support for multiple labels on one statement and terminal dummy statements; collects all direct statement labels in the type checker; emits every label attached to a statement in IR; adds parser, type-checker, IR, and WASM runtime coverage. Tests: parser suite, type-checker suite, IR compiler suite, full algol-wasm package suite, ruff, git diff --check, touched-file security scan.