### PR TITLE
Add Go sql-backend package

### DIFF
--- a/code/packages/go/sql-backend/BUILD
+++ b/code/packages/go/sql-backend/BUILD
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/sql-backend/BUILD_windows
+++ b/code/packages/go/sql-backend/BUILD_windows
@@ -1,0 +1,1 @@
+go test ./... -v -cover

--- a/code/packages/go/sql-backend/CHANGELOG.md
+++ b/code/packages/go/sql-backend/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add the Go sql-backend package with the portable backend contract and in-memory reference implementation.

--- a/code/packages/go/sql-backend/README.md
+++ b/code/packages/go/sql-backend/README.md
@@ -1,0 +1,21 @@
+# go/sql-backend
+
+Pluggable SQL backend abstractions and an in-memory reference backend for Go.
+
+This package ports the Python `sql-backend` contract: SQL values, row
+iterators, positioned cursors, schema metadata, typed backend errors, DDL/DML
+operations, index descriptors, rowid scans, transactions, savepoints, triggers,
+and version fields.
+
+## Usage
+
+```go
+backend := sqlbackend.NewInMemoryBackend()
+err := backend.CreateTable("users", []sqlbackend.ColumnDef{
+    {Name: "id", TypeName: "INTEGER", PrimaryKey: true},
+}, false)
+if err != nil {
+    return err
+}
+return backend.Insert("users", sqlbackend.Row{"id": int64(1)})
+```

--- a/code/packages/go/sql-backend/backend.go
+++ b/code/packages/go/sql-backend/backend.go
@@ -1,0 +1,1189 @@
+// Package sqlbackend defines the pluggable storage boundary for the SQL stack.
+package sqlbackend
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// Row is one table row, keyed by column name.
+type Row map[string]any
+
+// TransactionHandle identifies an active transaction.
+type TransactionHandle int
+
+// IsSQLValue reports whether value is in the portable SQL value set.
+func IsSQLValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	switch value.(type) {
+	case bool, string, []byte:
+		return true
+	case int, int8, int16, int32, int64:
+		return true
+	case uint, uint8, uint16, uint32, uint64:
+		return true
+	case float32:
+		return !math.IsNaN(float64(value.(float32))) && !math.IsInf(float64(value.(float32)), 0)
+	case float64:
+		return !math.IsNaN(value.(float64)) && !math.IsInf(value.(float64), 0)
+	default:
+		return false
+	}
+}
+
+// SQLTypeName returns the SQL storage class name for value.
+func SQLTypeName(value any) (string, error) {
+	if value == nil {
+		return "NULL", nil
+	}
+	switch value.(type) {
+	case bool:
+		return "BOOLEAN", nil
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return "INTEGER", nil
+	case float32, float64:
+		if !IsSQLValue(value) {
+			return "", fmt.Errorf("not a SQL value: %T", value)
+		}
+		return "REAL", nil
+	case string:
+		return "TEXT", nil
+	case []byte:
+		return "BLOB", nil
+	default:
+		return "", fmt.Errorf("not a SQL value: %T", value)
+	}
+}
+
+// CompareSQLValues compares two SQL values using the package's stable ordering.
+func CompareSQLValues(left any, right any) (int, error) {
+	if !IsSQLValue(left) {
+		return 0, fmt.Errorf("not a SQL value: %T", left)
+	}
+	if !IsSQLValue(right) {
+		return 0, fmt.Errorf("not a SQL value: %T", right)
+	}
+	leftRank := valueRank(left)
+	rightRank := valueRank(right)
+	if leftRank != rightRank {
+		return sign(leftRank - rightRank), nil
+	}
+	if left == nil {
+		return 0, nil
+	}
+	switch l := left.(type) {
+	case bool:
+		r := right.(bool)
+		return sign(boolInt(l) - boolInt(r)), nil
+	case string:
+		r := right.(string)
+		return strings.Compare(l, r), nil
+	case []byte:
+		return bytes.Compare(l, right.([]byte)), nil
+	default:
+		lf, lok := numericAsFloat(left)
+		rf, rok := numericAsFloat(right)
+		if lok && rok {
+			return signFloat(lf - rf), nil
+		}
+	}
+	return 0, nil
+}
+
+func valueRank(value any) int {
+	if value == nil {
+		return 0
+	}
+	switch value.(type) {
+	case bool:
+		return 1
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return 2
+	case string:
+		return 3
+	case []byte:
+		return 4
+	default:
+		return 5
+	}
+}
+
+// RowIterator streams rows one at a time.
+type RowIterator interface {
+	Next() (Row, bool)
+	Close()
+}
+
+// Cursor is a row iterator that can identify its current row for DML.
+type Cursor interface {
+	RowIterator
+	CurrentRow() (Row, bool)
+}
+
+// ListRowIterator is a copy-on-read iterator over an in-memory row slice.
+type ListRowIterator struct {
+	rows   []Row
+	index  int
+	closed bool
+}
+
+func NewListRowIterator(rows []Row) *ListRowIterator {
+	return &ListRowIterator{rows: copyRows(rows)}
+}
+
+func (it *ListRowIterator) Next() (Row, bool) {
+	if it.closed || it.index >= len(it.rows) {
+		return nil, false
+	}
+	row := copyRow(it.rows[it.index])
+	it.index++
+	return row, true
+}
+
+func (it *ListRowIterator) Close() {
+	it.closed = true
+}
+
+// ListCursor is the in-memory positioned cursor implementation.
+type ListCursor struct {
+	table   *tableState
+	index   int
+	current Row
+	closed  bool
+}
+
+func NewListCursor(rows []Row) *ListCursor {
+	return &ListCursor{table: &tableState{rows: rows}, index: -1}
+}
+
+func (c *ListCursor) Next() (Row, bool) {
+	if c.closed {
+		return nil, false
+	}
+	c.index++
+	if c.index >= len(c.table.rows) {
+		c.current = nil
+		return nil, false
+	}
+	c.current = c.table.rows[c.index]
+	return copyRow(c.current), true
+}
+
+func (c *ListCursor) Close() {
+	c.closed = true
+}
+
+func (c *ListCursor) CurrentRow() (Row, bool) {
+	if c.current == nil {
+		return nil, false
+	}
+	return copyRow(c.current), true
+}
+
+func (c *ListCursor) currentIndex() int {
+	return c.index
+}
+
+func (c *ListCursor) isBackedBy(table *tableState) bool {
+	return c.table == table
+}
+
+func (c *ListCursor) adjustAfterDelete() {
+	c.index--
+	c.current = nil
+}
+
+// ColumnDef describes one table column.
+type ColumnDef struct {
+	Name            string
+	TypeName        string
+	NotNull         bool
+	PrimaryKey      bool
+	Unique          bool
+	Autoincrement   bool
+	DefaultValue    any
+	HasDefault      bool
+	CheckExpression any
+	ForeignKey      any
+}
+
+func (c ColumnDef) EffectiveNotNull() bool {
+	return c.NotNull || c.PrimaryKey
+}
+
+func (c ColumnDef) EffectiveUnique() bool {
+	return c.Unique || c.PrimaryKey
+}
+
+func (c ColumnDef) clone() ColumnDef {
+	c.DefaultValue = copyValue(c.DefaultValue)
+	return c
+}
+
+// IndexDef describes one backend index.
+type IndexDef struct {
+	Name    string
+	Table   string
+	Columns []string
+	Unique  bool
+	Auto    bool
+}
+
+func (d IndexDef) clone() IndexDef {
+	d.Columns = append([]string{}, d.Columns...)
+	return d
+}
+
+// TriggerDef stores a trigger definition.
+type TriggerDef struct {
+	Name   string
+	Table  string
+	Timing string
+	Event  string
+	Body   string
+}
+
+// BackendError marks expected backend failures.
+type BackendError interface {
+	error
+	backendError()
+}
+
+type TableNotFound struct{ Table string }
+
+func (e *TableNotFound) Error() string { return fmt.Sprintf("table not found: %q", e.Table) }
+func (e *TableNotFound) backendError() {}
+
+type TableAlreadyExists struct{ Table string }
+
+func (e *TableAlreadyExists) Error() string { return fmt.Sprintf("table already exists: %q", e.Table) }
+func (e *TableAlreadyExists) backendError() {}
+
+type ColumnNotFound struct {
+	Table  string
+	Column string
+}
+
+func (e *ColumnNotFound) Error() string {
+	return fmt.Sprintf("column not found: %q.%q", e.Table, e.Column)
+}
+func (e *ColumnNotFound) backendError() {}
+
+type ColumnAlreadyExists struct {
+	Table  string
+	Column string
+}
+
+func (e *ColumnAlreadyExists) Error() string {
+	return fmt.Sprintf("column already exists: %q.%q", e.Table, e.Column)
+}
+func (e *ColumnAlreadyExists) backendError() {}
+
+type ConstraintViolation struct {
+	Table   string
+	Column  string
+	Message string
+}
+
+func (e *ConstraintViolation) Error() string { return e.Message }
+func (e *ConstraintViolation) backendError() {}
+
+type Unsupported struct{ Operation string }
+
+func (e *Unsupported) Error() string { return "operation not supported: " + e.Operation }
+func (e *Unsupported) backendError() {}
+
+type Internal struct{ Message string }
+
+func (e *Internal) Error() string { return e.Message }
+func (e *Internal) backendError() {}
+
+type IndexAlreadyExists struct{ Index string }
+
+func (e *IndexAlreadyExists) Error() string { return fmt.Sprintf("index already exists: %q", e.Index) }
+func (e *IndexAlreadyExists) backendError() {}
+
+type IndexNotFound struct{ Index string }
+
+func (e *IndexNotFound) Error() string { return fmt.Sprintf("index not found: %q", e.Index) }
+func (e *IndexNotFound) backendError() {}
+
+type TriggerAlreadyExists struct{ Trigger string }
+
+func (e *TriggerAlreadyExists) Error() string {
+	return fmt.Sprintf("trigger already exists: %q", e.Trigger)
+}
+func (e *TriggerAlreadyExists) backendError() {}
+
+type TriggerNotFound struct{ Trigger string }
+
+func (e *TriggerNotFound) Error() string { return fmt.Sprintf("trigger not found: %q", e.Trigger) }
+func (e *TriggerNotFound) backendError() {}
+
+// Backend is the storage interface used by the SQL VM and related packages.
+type Backend interface {
+	Tables() []string
+	Columns(table string) ([]ColumnDef, error)
+	Scan(table string) (RowIterator, error)
+	Insert(table string, row Row) error
+	Update(table string, cursor Cursor, assignments Row) error
+	Delete(table string, cursor Cursor) error
+	CreateTable(table string, columns []ColumnDef, ifNotExists bool) error
+	DropTable(table string, ifExists bool) error
+	AddColumn(table string, column ColumnDef) error
+	CreateIndex(index IndexDef) error
+	DropIndex(name string, ifExists bool) error
+	ListIndexes(table string) []IndexDef
+	ScanIndex(indexName string, lo []any, hi []any, loInclusive bool, hiInclusive bool) ([]int, error)
+	ScanByRowids(table string, rowids []int) (RowIterator, error)
+	BeginTransaction() (TransactionHandle, error)
+	Commit(handle TransactionHandle) error
+	Rollback(handle TransactionHandle) error
+}
+
+type SchemaProvider interface {
+	ColumnNames(table string) ([]string, error)
+}
+
+func BackendAsSchemaProvider(backend Backend) SchemaProvider {
+	return backendSchemaProvider{backend: backend}
+}
+
+type backendSchemaProvider struct{ backend Backend }
+
+func (p backendSchemaProvider) ColumnNames(table string) ([]string, error) {
+	columns, err := p.backend.Columns(table)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(columns))
+	for i, column := range columns {
+		names[i] = column.Name
+	}
+	return names, nil
+}
+
+type tableState struct {
+	name    string
+	columns []ColumnDef
+	rows    []Row
+}
+
+func (t *tableState) copy() *tableState {
+	return &tableState{
+		name:    t.name,
+		columns: copyColumns(t.columns),
+		rows:    copyRows(t.rows),
+	}
+}
+
+// InMemoryBackend is the reference Backend implementation.
+type InMemoryBackend struct {
+	tables          map[string]*tableState
+	tableOrder      []string
+	indexes         map[string]IndexDef
+	indexOrder      []string
+	triggers        map[string]TriggerDef
+	triggersByTable map[string][]TriggerDef
+	snapshot        *snapshotState
+	savepoints      []savepoint
+	activeHandle    *TransactionHandle
+	nextHandle      TransactionHandle
+	userVersion     uint32
+	schemaVersion   uint32
+}
+
+func NewInMemoryBackend() *InMemoryBackend {
+	return &InMemoryBackend{
+		tables:          map[string]*tableState{},
+		indexes:         map[string]IndexDef{},
+		triggers:        map[string]TriggerDef{},
+		triggersByTable: map[string][]TriggerDef{},
+		nextHandle:      1,
+	}
+}
+
+func NewInMemoryBackendFromTables(tables map[string]struct {
+	Columns []ColumnDef
+	Rows    []Row
+}) *InMemoryBackend {
+	backend := NewInMemoryBackend()
+	for name, table := range tables {
+		key := normalizeName(name)
+		backend.tables[key] = &tableState{name: name, columns: copyColumns(table.Columns), rows: copyRows(table.Rows)}
+		backend.tableOrder = append(backend.tableOrder, key)
+	}
+	sort.SliceStable(backend.tableOrder, func(i, j int) bool {
+		return backend.tables[backend.tableOrder[i]].name < backend.tables[backend.tableOrder[j]].name
+	})
+	return backend
+}
+
+func (b *InMemoryBackend) Tables() []string {
+	names := make([]string, 0, len(b.tableOrder))
+	for _, key := range b.tableOrder {
+		if table := b.tables[key]; table != nil {
+			names = append(names, table.name)
+		}
+	}
+	return names
+}
+
+func (b *InMemoryBackend) Columns(table string) ([]ColumnDef, error) {
+	state, err := b.requireTable(table)
+	if err != nil {
+		return nil, err
+	}
+	return copyColumns(state.columns), nil
+}
+
+func (b *InMemoryBackend) Scan(table string) (RowIterator, error) {
+	state, err := b.requireTable(table)
+	if err != nil {
+		return nil, err
+	}
+	return NewListRowIterator(state.rows), nil
+}
+
+func (b *InMemoryBackend) OpenCursor(table string) (*ListCursor, error) {
+	state, err := b.requireTable(table)
+	if err != nil {
+		return nil, err
+	}
+	return &ListCursor{table: state, index: -1}, nil
+}
+
+func (b *InMemoryBackend) Insert(table string, row Row) error {
+	state, err := b.requireTable(table)
+	if err != nil {
+		return err
+	}
+	normalized, err := b.normalizeRow(table, state, row)
+	if err != nil {
+		return err
+	}
+	if err := checkNotNull(table, state, normalized); err != nil {
+		return err
+	}
+	if err := checkUnique(table, state, normalized, -1); err != nil {
+		return err
+	}
+	state.rows = append(state.rows, normalized)
+	return nil
+}
+
+func (b *InMemoryBackend) Update(table string, cursor Cursor, assignments Row) error {
+	state, err := b.requireTable(table)
+	if err != nil {
+		return err
+	}
+	listCursor, err := requireListCursor(table, state, cursor)
+	if err != nil {
+		return err
+	}
+	idx := listCursor.currentIndex()
+	if idx < 0 || idx >= len(state.rows) {
+		return &Unsupported{Operation: "update without current row"}
+	}
+	updated := copyRow(state.rows[idx])
+	for name, value := range assignments {
+		if !IsSQLValue(value) {
+			return fmt.Errorf("not a SQL value: %T", value)
+		}
+		canonical, err := canonicalColumn(table, state, name)
+		if err != nil {
+			return err
+		}
+		updated[canonical] = copyValue(value)
+	}
+	if err := checkNotNull(table, state, updated); err != nil {
+		return err
+	}
+	if err := checkUnique(table, state, updated, idx); err != nil {
+		return err
+	}
+	state.rows[idx] = updated
+	return nil
+}
+
+func (b *InMemoryBackend) Delete(table string, cursor Cursor) error {
+	state, err := b.requireTable(table)
+	if err != nil {
+		return err
+	}
+	listCursor, err := requireListCursor(table, state, cursor)
+	if err != nil {
+		return err
+	}
+	idx := listCursor.currentIndex()
+	if idx < 0 || idx >= len(state.rows) {
+		return &Unsupported{Operation: "delete without current row"}
+	}
+	state.rows = append(state.rows[:idx], state.rows[idx+1:]...)
+	listCursor.adjustAfterDelete()
+	return nil
+}
+
+func (b *InMemoryBackend) CreateTable(table string, columns []ColumnDef, ifNotExists bool) error {
+	key := normalizeName(table)
+	if _, ok := b.tables[key]; ok {
+		if ifNotExists {
+			return nil
+		}
+		return &TableAlreadyExists{Table: table}
+	}
+	seen := map[string]struct{}{}
+	for _, column := range columns {
+		columnKey := normalizeName(column.Name)
+		if _, ok := seen[columnKey]; ok {
+			return &ColumnAlreadyExists{Table: table, Column: column.Name}
+		}
+		seen[columnKey] = struct{}{}
+	}
+	b.tables[key] = &tableState{name: table, columns: copyColumns(columns)}
+	b.tableOrder = append(b.tableOrder, key)
+	b.bumpSchemaVersion()
+	return nil
+}
+
+func (b *InMemoryBackend) DropTable(table string, ifExists bool) error {
+	key := normalizeName(table)
+	if _, ok := b.tables[key]; !ok {
+		if ifExists {
+			return nil
+		}
+		return &TableNotFound{Table: table}
+	}
+	delete(b.tables, key)
+	b.tableOrder = removeString(b.tableOrder, key)
+	b.deleteIndexesForTable(table)
+	b.deleteTriggersForTable(table)
+	b.bumpSchemaVersion()
+	return nil
+}
+
+func (b *InMemoryBackend) AddColumn(table string, column ColumnDef) error {
+	state, err := b.requireTable(table)
+	if err != nil {
+		return err
+	}
+	if _, err := canonicalColumn(table, state, column.Name); err == nil {
+		return &ColumnAlreadyExists{Table: table, Column: column.Name}
+	}
+	if len(state.rows) > 0 && column.EffectiveNotNull() && !column.HasDefault {
+		return &ConstraintViolation{
+			Table:   table,
+			Column:  column.Name,
+			Message: fmt.Sprintf("NOT NULL constraint failed: %s.%s", table, column.Name),
+		}
+	}
+	cloned := column.clone()
+	state.columns = append(state.columns, cloned)
+	for _, row := range state.rows {
+		if cloned.HasDefault {
+			row[cloned.Name] = copyValue(cloned.DefaultValue)
+		} else {
+			row[cloned.Name] = nil
+		}
+	}
+	b.bumpSchemaVersion()
+	return nil
+}
+
+func (b *InMemoryBackend) CreateIndex(index IndexDef) error {
+	key := normalizeName(index.Name)
+	if _, ok := b.indexes[key]; ok {
+		return &IndexAlreadyExists{Index: index.Name}
+	}
+	state, err := b.requireTable(index.Table)
+	if err != nil {
+		return err
+	}
+	for _, column := range index.Columns {
+		if _, err := canonicalColumn(index.Table, state, column); err != nil {
+			return err
+		}
+	}
+	b.indexes[key] = index.clone()
+	b.indexOrder = append(b.indexOrder, key)
+	b.bumpSchemaVersion()
+	return nil
+}
+
+func (b *InMemoryBackend) DropIndex(name string, ifExists bool) error {
+	key := normalizeName(name)
+	if _, ok := b.indexes[key]; !ok {
+		if ifExists {
+			return nil
+		}
+		return &IndexNotFound{Index: name}
+	}
+	delete(b.indexes, key)
+	b.indexOrder = removeString(b.indexOrder, key)
+	b.bumpSchemaVersion()
+	return nil
+}
+
+func (b *InMemoryBackend) ListIndexes(table string) []IndexDef {
+	indexes := []IndexDef{}
+	for _, key := range b.indexOrder {
+		index, ok := b.indexes[key]
+		if !ok {
+			continue
+		}
+		if table == "" || sameName(index.Table, table) {
+			indexes = append(indexes, index.clone())
+		}
+	}
+	return indexes
+}
+
+func (b *InMemoryBackend) ScanIndex(indexName string, lo []any, hi []any, loInclusive bool, hiInclusive bool) ([]int, error) {
+	index, ok := b.indexes[normalizeName(indexName)]
+	if !ok {
+		return nil, &IndexNotFound{Index: indexName}
+	}
+	state, err := b.requireTable(index.Table)
+	if err != nil {
+		return nil, err
+	}
+	keyed := make([]keyedRow, 0, len(state.rows))
+	for rowid, row := range state.rows {
+		key := make([]any, len(index.Columns))
+		for i, column := range index.Columns {
+			canonical, err := canonicalColumn(index.Table, state, column)
+			if err != nil {
+				return nil, err
+			}
+			key[i] = row[canonical]
+		}
+		keyed = append(keyed, keyedRow{key: key, rowid: rowid})
+	}
+	sort.SliceStable(keyed, func(i, j int) bool {
+		cmp, _ := compareKey(keyed[i].key, keyed[j].key)
+		if cmp == 0 {
+			return keyed[i].rowid < keyed[j].rowid
+		}
+		return cmp < 0
+	})
+	rowids := []int{}
+	for _, row := range keyed {
+		if lo != nil {
+			cmp, err := comparePrefix(row.key, lo)
+			if err != nil {
+				return nil, err
+			}
+			if cmp < 0 || (cmp == 0 && !loInclusive) {
+				continue
+			}
+		}
+		if hi != nil {
+			cmp, err := comparePrefix(row.key, hi)
+			if err != nil {
+				return nil, err
+			}
+			if cmp > 0 || (cmp == 0 && !hiInclusive) {
+				break
+			}
+		}
+		rowids = append(rowids, row.rowid)
+	}
+	return rowids, nil
+}
+
+func (b *InMemoryBackend) ScanByRowids(table string, rowids []int) (RowIterator, error) {
+	state, err := b.requireTable(table)
+	if err != nil {
+		return nil, err
+	}
+	rows := []Row{}
+	for _, rowid := range rowids {
+		if rowid >= 0 && rowid < len(state.rows) {
+			rows = append(rows, state.rows[rowid])
+		}
+	}
+	return NewListRowIterator(rows), nil
+}
+
+func (b *InMemoryBackend) BeginTransaction() (TransactionHandle, error) {
+	if b.activeHandle != nil {
+		return 0, &Unsupported{Operation: "nested transactions"}
+	}
+	handle := b.nextHandle
+	b.nextHandle++
+	b.snapshot = b.captureSnapshot()
+	b.activeHandle = &handle
+	return handle, nil
+}
+
+func (b *InMemoryBackend) Commit(handle TransactionHandle) error {
+	if err := b.requireActive(handle); err != nil {
+		return err
+	}
+	b.snapshot = nil
+	b.activeHandle = nil
+	b.savepoints = nil
+	return nil
+}
+
+func (b *InMemoryBackend) Rollback(handle TransactionHandle) error {
+	if err := b.requireActive(handle); err != nil {
+		return err
+	}
+	if b.snapshot != nil {
+		b.restoreSnapshot(b.snapshot)
+	}
+	b.snapshot = nil
+	b.activeHandle = nil
+	b.savepoints = nil
+	return nil
+}
+
+func (b *InMemoryBackend) CurrentTransaction() (TransactionHandle, bool) {
+	if b.activeHandle == nil {
+		return 0, false
+	}
+	return *b.activeHandle, true
+}
+
+func (b *InMemoryBackend) CreateSavepoint(name string) error {
+	if b.activeHandle == nil {
+		if _, err := b.BeginTransaction(); err != nil {
+			return err
+		}
+	}
+	b.savepoints = append(b.savepoints, savepoint{name: name, snapshot: b.captureSnapshot()})
+	return nil
+}
+
+func (b *InMemoryBackend) ReleaseSavepoint(name string) error {
+	idx := b.findSavepoint(name)
+	if idx < 0 {
+		return &Unsupported{Operation: fmt.Sprintf("RELEASE %q: no such savepoint", name)}
+	}
+	b.savepoints = b.savepoints[:idx]
+	return nil
+}
+
+func (b *InMemoryBackend) RollbackToSavepoint(name string) error {
+	idx := b.findSavepoint(name)
+	if idx < 0 {
+		return &Unsupported{Operation: fmt.Sprintf("ROLLBACK TO %q: no such savepoint", name)}
+	}
+	b.restoreSnapshot(b.savepoints[idx].snapshot)
+	b.savepoints = b.savepoints[:idx+1]
+	return nil
+}
+
+func (b *InMemoryBackend) CreateTrigger(trigger TriggerDef) error {
+	key := normalizeName(trigger.Name)
+	if _, ok := b.triggers[key]; ok {
+		return &TriggerAlreadyExists{Trigger: trigger.Name}
+	}
+	b.triggers[key] = trigger
+	tableKey := normalizeName(trigger.Table)
+	b.triggersByTable[tableKey] = append(b.triggersByTable[tableKey], trigger)
+	return nil
+}
+
+func (b *InMemoryBackend) DropTrigger(name string, ifExists bool) error {
+	key := normalizeName(name)
+	trigger, ok := b.triggers[key]
+	if !ok {
+		if ifExists {
+			return nil
+		}
+		return &TriggerNotFound{Trigger: name}
+	}
+	delete(b.triggers, key)
+	tableKey := normalizeName(trigger.Table)
+	triggers := b.triggersByTable[tableKey]
+	kept := triggers[:0]
+	for _, candidate := range triggers {
+		if !sameName(candidate.Name, name) {
+			kept = append(kept, candidate)
+		}
+	}
+	if len(kept) == 0 {
+		delete(b.triggersByTable, tableKey)
+	} else {
+		b.triggersByTable[tableKey] = kept
+	}
+	return nil
+}
+
+func (b *InMemoryBackend) ListTriggers(table string) []TriggerDef {
+	triggers := b.triggersByTable[normalizeName(table)]
+	return append([]TriggerDef{}, triggers...)
+}
+
+func (b *InMemoryBackend) GetUserVersion() uint32 {
+	return b.userVersion
+}
+
+func (b *InMemoryBackend) SetUserVersion(value int64) error {
+	if value < 0 || value > 0xffffffff {
+		return fmt.Errorf("user_version must fit in u32, got %d", value)
+	}
+	b.userVersion = uint32(value)
+	return nil
+}
+
+func (b *InMemoryBackend) GetSchemaVersion() uint32 {
+	return b.schemaVersion
+}
+
+func (b *InMemoryBackend) requireTable(table string) (*tableState, error) {
+	state := b.tables[normalizeName(table)]
+	if state == nil {
+		return nil, &TableNotFound{Table: table}
+	}
+	return state, nil
+}
+
+func (b *InMemoryBackend) normalizeRow(table string, state *tableState, row Row) (Row, error) {
+	normalized := Row{}
+	for name, value := range row {
+		if !IsSQLValue(value) {
+			return nil, fmt.Errorf("not a SQL value: %T", value)
+		}
+		canonical, err := canonicalColumn(table, state, name)
+		if err != nil {
+			return nil, err
+		}
+		normalized[canonical] = copyValue(value)
+	}
+	for _, column := range state.columns {
+		if _, ok := normalized[column.Name]; !ok {
+			if column.HasDefault {
+				normalized[column.Name] = copyValue(column.DefaultValue)
+			} else {
+				normalized[column.Name] = nil
+			}
+		}
+	}
+	return normalized, nil
+}
+
+func (b *InMemoryBackend) requireActive(handle TransactionHandle) error {
+	if b.activeHandle == nil {
+		return &Unsupported{Operation: "no active transaction"}
+	}
+	if *b.activeHandle != handle {
+		return &Unsupported{Operation: "stale transaction handle"}
+	}
+	return nil
+}
+
+func (b *InMemoryBackend) captureSnapshot() *snapshotState {
+	return &snapshotState{
+		tables:          copyTableMap(b.tables),
+		tableOrder:      append([]string{}, b.tableOrder...),
+		indexes:         copyIndexMap(b.indexes),
+		indexOrder:      append([]string{}, b.indexOrder...),
+		triggers:        copyTriggerMap(b.triggers),
+		triggersByTable: copyTriggersByTable(b.triggersByTable),
+		userVersion:     b.userVersion,
+		schemaVersion:   b.schemaVersion,
+	}
+}
+
+func (b *InMemoryBackend) restoreSnapshot(snapshot *snapshotState) {
+	b.tables = copyTableMap(snapshot.tables)
+	b.tableOrder = append([]string{}, snapshot.tableOrder...)
+	b.indexes = copyIndexMap(snapshot.indexes)
+	b.indexOrder = append([]string{}, snapshot.indexOrder...)
+	b.triggers = copyTriggerMap(snapshot.triggers)
+	b.triggersByTable = copyTriggersByTable(snapshot.triggersByTable)
+	b.userVersion = snapshot.userVersion
+	b.schemaVersion = snapshot.schemaVersion
+}
+
+func (b *InMemoryBackend) findSavepoint(name string) int {
+	for i := len(b.savepoints) - 1; i >= 0; i-- {
+		if b.savepoints[i].name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func (b *InMemoryBackend) deleteIndexesForTable(table string) {
+	for key, index := range b.indexes {
+		if sameName(index.Table, table) {
+			delete(b.indexes, key)
+			b.indexOrder = removeString(b.indexOrder, key)
+		}
+	}
+}
+
+func (b *InMemoryBackend) deleteTriggersForTable(table string) {
+	tableKey := normalizeName(table)
+	for key, trigger := range b.triggers {
+		if sameName(trigger.Table, table) {
+			delete(b.triggers, key)
+		}
+	}
+	delete(b.triggersByTable, tableKey)
+}
+
+func (b *InMemoryBackend) bumpSchemaVersion() {
+	b.schemaVersion++
+}
+
+type snapshotState struct {
+	tables          map[string]*tableState
+	tableOrder      []string
+	indexes         map[string]IndexDef
+	indexOrder      []string
+	triggers        map[string]TriggerDef
+	triggersByTable map[string][]TriggerDef
+	userVersion     uint32
+	schemaVersion   uint32
+}
+
+type savepoint struct {
+	name     string
+	snapshot *snapshotState
+}
+
+type keyedRow struct {
+	key   []any
+	rowid int
+}
+
+func requireListCursor(table string, state *tableState, cursor Cursor) (*ListCursor, error) {
+	listCursor, ok := cursor.(*ListCursor)
+	if !ok || !listCursor.isBackedBy(state) {
+		return nil, &Unsupported{Operation: fmt.Sprintf("foreign cursor for table %s", table)}
+	}
+	return listCursor, nil
+}
+
+func canonicalColumn(table string, state *tableState, column string) (string, error) {
+	for _, candidate := range state.columns {
+		if sameName(candidate.Name, column) {
+			return candidate.Name, nil
+		}
+	}
+	return "", &ColumnNotFound{Table: table, Column: column}
+}
+
+func checkNotNull(table string, state *tableState, row Row) error {
+	for _, column := range state.columns {
+		if column.EffectiveNotNull() && row[column.Name] == nil {
+			return &ConstraintViolation{
+				Table:   table,
+				Column:  column.Name,
+				Message: fmt.Sprintf("NOT NULL constraint failed: %s.%s", table, column.Name),
+			}
+		}
+	}
+	return nil
+}
+
+func checkUnique(table string, state *tableState, row Row, ignoreIndex int) error {
+	for _, column := range state.columns {
+		if !column.EffectiveUnique() {
+			continue
+		}
+		value := row[column.Name]
+		if value == nil {
+			continue
+		}
+		for i, existing := range state.rows {
+			if i == ignoreIndex {
+				continue
+			}
+			equal, err := sqlValuesEqual(existing[column.Name], value)
+			if err != nil {
+				return err
+			}
+			if equal {
+				label := "UNIQUE"
+				if column.PrimaryKey {
+					label = "PRIMARY KEY"
+				}
+				return &ConstraintViolation{
+					Table:   table,
+					Column:  column.Name,
+					Message: fmt.Sprintf("%s constraint failed: %s.%s", label, table, column.Name),
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func sqlValuesEqual(left any, right any) (bool, error) {
+	if !IsSQLValue(left) || !IsSQLValue(right) {
+		return false, fmt.Errorf("not a SQL value")
+	}
+	if lb, ok := left.([]byte); ok {
+		rb, ok := right.([]byte)
+		return ok && bytes.Equal(lb, rb), nil
+	}
+	cmp, err := CompareSQLValues(left, right)
+	return cmp == 0, err
+}
+
+func compareKey(left []any, right []any) (int, error) {
+	limit := min(len(left), len(right))
+	for i := 0; i < limit; i++ {
+		cmp, err := CompareSQLValues(left[i], right[i])
+		if err != nil {
+			return 0, err
+		}
+		if cmp != 0 {
+			return cmp, nil
+		}
+	}
+	return sign(len(left) - len(right)), nil
+}
+
+func comparePrefix(key []any, bound []any) (int, error) {
+	for i := range bound {
+		var value any
+		if i < len(key) {
+			value = key[i]
+		}
+		cmp, err := CompareSQLValues(value, bound[i])
+		if err != nil {
+			return 0, err
+		}
+		if cmp != 0 {
+			return cmp, nil
+		}
+	}
+	return 0, nil
+}
+
+func copyRow(row Row) Row {
+	out := Row{}
+	for key, value := range row {
+		out[key] = copyValue(value)
+	}
+	return out
+}
+
+func copyRows(rows []Row) []Row {
+	out := make([]Row, len(rows))
+	for i, row := range rows {
+		out[i] = copyRow(row)
+	}
+	return out
+}
+
+func copyColumns(columns []ColumnDef) []ColumnDef {
+	out := make([]ColumnDef, len(columns))
+	for i, column := range columns {
+		out[i] = column.clone()
+	}
+	return out
+}
+
+func copyValue(value any) any {
+	if blob, ok := value.([]byte); ok {
+		return append([]byte{}, blob...)
+	}
+	return value
+}
+
+func copyTableMap(source map[string]*tableState) map[string]*tableState {
+	out := map[string]*tableState{}
+	for key, table := range source {
+		out[key] = table.copy()
+	}
+	return out
+}
+
+func copyIndexMap(source map[string]IndexDef) map[string]IndexDef {
+	out := map[string]IndexDef{}
+	for key, index := range source {
+		out[key] = index.clone()
+	}
+	return out
+}
+
+func copyTriggerMap(source map[string]TriggerDef) map[string]TriggerDef {
+	out := map[string]TriggerDef{}
+	for key, trigger := range source {
+		out[key] = trigger
+	}
+	return out
+}
+
+func copyTriggersByTable(source map[string][]TriggerDef) map[string][]TriggerDef {
+	out := map[string][]TriggerDef{}
+	for key, triggers := range source {
+		out[key] = append([]TriggerDef{}, triggers...)
+	}
+	return out
+}
+
+func normalizeName(name string) string {
+	return strings.ToLower(name)
+}
+
+func sameName(left string, right string) bool {
+	return normalizeName(left) == normalizeName(right)
+}
+
+func removeString(values []string, value string) []string {
+	out := values[:0]
+	for _, candidate := range values {
+		if candidate != value {
+			out = append(out, candidate)
+		}
+	}
+	return out
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func sign(value int) int {
+	switch {
+	case value < 0:
+		return -1
+	case value > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func signFloat(value float64) int {
+	switch {
+	case value < 0:
+		return -1
+	case value > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func numericAsFloat(value any) (float64, bool) {
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float64(v.Int()), true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return float64(v.Uint()), true
+	case reflect.Float32, reflect.Float64:
+		return v.Convert(reflect.TypeOf(float64(0))).Float(), true
+	default:
+		return 0, false
+	}
+}

--- a/code/packages/go/sql-backend/backend_test.go
+++ b/code/packages/go/sql-backend/backend_test.go
@@ -1,0 +1,477 @@
+package sqlbackend
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestSQLValues(t *testing.T) {
+	cases := []struct {
+		value any
+		name  string
+	}{
+		{nil, "NULL"},
+		{true, "BOOLEAN"},
+		{42, "INTEGER"},
+		{int64(42), "INTEGER"},
+		{3.5, "REAL"},
+		{"hi", "TEXT"},
+		{[]byte{1, 2}, "BLOB"},
+	}
+	for _, tc := range cases {
+		if !IsSQLValue(tc.value) {
+			t.Fatalf("IsSQLValue(%#v) = false", tc.value)
+		}
+		got, err := SQLTypeName(tc.value)
+		if err != nil {
+			t.Fatalf("SQLTypeName(%#v) failed: %v", tc.value, err)
+		}
+		if got != tc.name {
+			t.Fatalf("SQLTypeName(%#v) = %q, want %q", tc.value, got, tc.name)
+		}
+	}
+	if IsSQLValue(math.NaN()) {
+		t.Fatal("NaN should not be a SQL value")
+	}
+	if _, err := SQLTypeName(struct{}{}); err == nil {
+		t.Fatal("SQLTypeName accepted non-SQL value")
+	}
+	assertCompareLess(t, nil, int64(0))
+	assertCompareLess(t, true, int64(0))
+	assertCompareLess(t, int64(2), "2")
+	assertCompareLess(t, []byte{1}, []byte{1, 2})
+}
+
+func TestIteratorsReturnCopies(t *testing.T) {
+	blob := []byte{1, 2}
+	it := NewListRowIterator([]Row{{"id": int64(1), "blob": blob}})
+	row, ok := it.Next()
+	if !ok || row["id"] != int64(1) {
+		t.Fatalf("Next = %#v, %v", row, ok)
+	}
+	row["blob"].([]byte)[0] = 9
+	if blob[0] != 1 {
+		t.Fatalf("iterator leaked blob mutation, got %d", blob[0])
+	}
+	if _, ok := it.Next(); ok {
+		t.Fatal("iterator returned extra row")
+	}
+	it.Close()
+	if _, ok := it.Next(); ok {
+		t.Fatal("closed iterator returned row")
+	}
+
+	rows := []Row{{"id": int64(1)}, {"id": int64(2)}}
+	cursor := NewListCursor(rows)
+	if _, ok := cursor.CurrentRow(); ok {
+		t.Fatal("fresh cursor has current row")
+	}
+	row, ok = cursor.Next()
+	if !ok || row["id"] != int64(1) {
+		t.Fatalf("cursor Next = %#v, %v", row, ok)
+	}
+	current, ok := cursor.CurrentRow()
+	if !ok || current["id"] != int64(1) {
+		t.Fatalf("CurrentRow = %#v, %v", current, ok)
+	}
+	current["id"] = int64(99)
+	if rows[0]["id"] != int64(1) {
+		t.Fatal("cursor current row was not copied")
+	}
+	cursor.Close()
+	if _, ok := cursor.Next(); ok {
+		t.Fatal("closed cursor returned row")
+	}
+}
+
+func TestSchemaAdapter(t *testing.T) {
+	backend := users(t)
+	names, err := BackendAsSchemaProvider(backend).ColumnNames("users")
+	if err != nil {
+		t.Fatalf("ColumnNames failed: %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"id", "name", "age", "email"}) {
+		t.Fatalf("ColumnNames = %#v", names)
+	}
+	if _, err := BackendAsSchemaProvider(backend).ColumnNames("missing"); !isErr[*TableNotFound](err) {
+		t.Fatalf("ColumnNames missing error = %T %v", err, err)
+	}
+}
+
+func TestTablesColumnsScanAndFixtures(t *testing.T) {
+	backend := users(t)
+	if got := backend.Tables(); !reflect.DeepEqual(got, []string{"users"}) {
+		t.Fatalf("Tables = %#v", got)
+	}
+	columns, err := backend.Columns("USERS")
+	if err != nil {
+		t.Fatalf("Columns failed: %v", err)
+	}
+	if columns[1].Name != "name" {
+		t.Fatalf("Columns[1] = %#v", columns[1])
+	}
+	rows := collect(t, mustScan(t, backend, "users"))
+	if got := rowValues(rows, "id"); !reflect.DeepEqual(got, []any{int64(1), int64(2), int64(3)}) {
+		t.Fatalf("scan ids = %#v", got)
+	}
+
+	fixture := NewInMemoryBackendFromTables(map[string]struct {
+		Columns []ColumnDef
+		Rows    []Row
+	}{
+		"logs": {
+			Columns: []ColumnDef{{Name: "id", TypeName: "INTEGER"}},
+			Rows:    []Row{{"id": int64(1)}},
+		},
+	})
+	if got := collect(t, mustScan(t, fixture, "logs")); !reflect.DeepEqual(got, []Row{{"id": int64(1)}}) {
+		t.Fatalf("fixture rows = %#v", got)
+	}
+}
+
+func TestInsertDefaultsAndConstraints(t *testing.T) {
+	backend := NewInMemoryBackend()
+	err := backend.CreateTable("items", []ColumnDef{
+		{Name: "id", TypeName: "INTEGER", PrimaryKey: true},
+		{Name: "status", TypeName: "TEXT", DefaultValue: "active", HasDefault: true},
+	}, false)
+	if err != nil {
+		t.Fatalf("CreateTable failed: %v", err)
+	}
+	if err := backend.Insert("items", Row{"id": int64(1)}); err != nil {
+		t.Fatalf("Insert failed: %v", err)
+	}
+	if got := collect(t, mustScan(t, backend, "items"))[0]["status"]; got != "active" {
+		t.Fatalf("default status = %#v", got)
+	}
+	if err := backend.Insert("items", Row{"id": int64(2), "ghost": "x"}); !isErr[*ColumnNotFound](err) {
+		t.Fatalf("unknown column error = %T %v", err, err)
+	}
+	if err := backend.Insert("items", Row{"id": math.NaN()}); err == nil {
+		t.Fatal("Insert accepted NaN")
+	}
+
+	backend = users(t)
+	if err := backend.Insert("users", Row{"id": int64(1), "name": "Dup", "age": int64(9), "email": "dup@example.com"}); !isErr[*ConstraintViolation](err) {
+		t.Fatalf("duplicate primary key error = %T %v", err, err)
+	}
+	if err := backend.Insert("users", Row{"id": int64(4), "name": nil, "age": int64(9), "email": "dup@example.com"}); !isErr[*ConstraintViolation](err) {
+		t.Fatalf("not null error = %T %v", err, err)
+	}
+	if err := backend.Insert("users", Row{"id": int64(4), "name": "Dup", "age": int64(9), "email": "alice@example.com"}); !isErr[*ConstraintViolation](err) {
+		t.Fatalf("unique error = %T %v", err, err)
+	}
+}
+
+func TestUniqueAllowsMultipleNulls(t *testing.T) {
+	backend := NewInMemoryBackend()
+	must(t, backend.CreateTable("users", []ColumnDef{
+		{Name: "id", TypeName: "INTEGER", PrimaryKey: true},
+		{Name: "email", TypeName: "TEXT", Unique: true},
+	}, false))
+	must(t, backend.Insert("users", Row{"id": int64(1), "email": nil}))
+	must(t, backend.Insert("users", Row{"id": int64(2), "email": nil}))
+	rows := collect(t, mustScan(t, backend, "users"))
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d", len(rows))
+	}
+}
+
+func TestUpdateAndDeletePositionedRows(t *testing.T) {
+	backend := users(t)
+	cursor, err := backend.OpenCursor("users")
+	if err != nil {
+		t.Fatalf("OpenCursor failed: %v", err)
+	}
+	row, ok := cursor.Next()
+	if !ok || row["id"] != int64(1) {
+		t.Fatalf("cursor first row = %#v, %v", row, ok)
+	}
+	if err := backend.Update("users", cursor, Row{"NAME": "ALICE"}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	check := collect(t, mustScan(t, backend, "users"))[0]
+	if check["name"] != "ALICE" {
+		t.Fatalf("updated name = %#v", check["name"])
+	}
+	if err := backend.Update("users", cursor, Row{"missing": "x"}); !isErr[*ColumnNotFound](err) {
+		t.Fatalf("missing assignment error = %T %v", err, err)
+	}
+	if err := backend.Delete("users", cursor); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if got := collect(t, mustScan(t, backend, "users"))[0]["id"]; got != int64(2) {
+		t.Fatalf("first row after delete = %#v", got)
+	}
+	if err := backend.Update("users", cursor, Row{"name": "x"}); !isErr[*Unsupported](err) {
+		t.Fatalf("stale cursor update error = %T %v", err, err)
+	}
+	if err := backend.Delete("users", NewListCursor(nil)); !isErr[*Unsupported](err) {
+		t.Fatalf("foreign cursor delete error = %T %v", err, err)
+	}
+}
+
+func TestDDL(t *testing.T) {
+	backend := NewInMemoryBackend()
+	must(t, backend.CreateTable("t", []ColumnDef{{Name: "id", TypeName: "INTEGER"}}, false))
+	must(t, backend.CreateTable("T", nil, true))
+	if err := backend.CreateTable("t", nil, false); !isErr[*TableAlreadyExists](err) {
+		t.Fatalf("duplicate table error = %T %v", err, err)
+	}
+	if err := backend.CreateTable("dupe", []ColumnDef{{Name: "id"}, {Name: "ID"}}, false); !isErr[*ColumnAlreadyExists](err) {
+		t.Fatalf("duplicate column error = %T %v", err, err)
+	}
+	must(t, backend.Insert("t", Row{"id": int64(1)}))
+	must(t, backend.AddColumn("t", ColumnDef{Name: "status", TypeName: "TEXT", DefaultValue: "new", HasDefault: true}))
+	if got := collect(t, mustScan(t, backend, "t"))[0]["status"]; got != "new" {
+		t.Fatalf("backfilled status = %#v", got)
+	}
+	if err := backend.AddColumn("t", ColumnDef{Name: "status"}); !isErr[*ColumnAlreadyExists](err) {
+		t.Fatalf("duplicate add column error = %T %v", err, err)
+	}
+	if err := backend.AddColumn("t", ColumnDef{Name: "required", NotNull: true}); !isErr[*ConstraintViolation](err) {
+		t.Fatalf("required add column error = %T %v", err, err)
+	}
+	must(t, backend.DropTable("t", false))
+	must(t, backend.DropTable("t", true))
+	if err := backend.DropTable("t", false); !isErr[*TableNotFound](err) {
+		t.Fatalf("drop missing error = %T %v", err, err)
+	}
+}
+
+func TestTransactionsAndSavepoints(t *testing.T) {
+	backend := users(t)
+	handle, err := backend.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	must(t, backend.Insert("users", Row{"id": int64(4), "name": "Dave", "age": int64(41), "email": "dave@example.com"}))
+	must(t, backend.Rollback(handle))
+	if containsID(t, backend, int64(4)) {
+		t.Fatal("rollback kept inserted row")
+	}
+
+	committed, err := backend.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	must(t, backend.Insert("users", Row{"id": int64(4), "name": "Dave", "age": int64(41), "email": "dave@example.com"}))
+	must(t, backend.Commit(committed))
+	if !containsID(t, backend, int64(4)) {
+		t.Fatal("commit lost inserted row")
+	}
+	active, err := backend.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	if got, ok := backend.CurrentTransaction(); !ok || got != active {
+		t.Fatalf("CurrentTransaction = %v, %v", got, ok)
+	}
+	if _, err := backend.BeginTransaction(); !isErr[*Unsupported](err) {
+		t.Fatalf("nested transaction error = %T %v", err, err)
+	}
+	must(t, backend.Commit(active))
+	if err := backend.Commit(active); !isErr[*Unsupported](err) {
+		t.Fatalf("stale commit error = %T %v", err, err)
+	}
+
+	handle, err = backend.BeginTransaction()
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	must(t, backend.CreateSavepoint("s1"))
+	must(t, backend.Insert("users", Row{"id": int64(5), "name": "Eve", "age": int64(22), "email": "eve@example.com"}))
+	must(t, backend.RollbackToSavepoint("s1"))
+	if containsID(t, backend, int64(5)) {
+		t.Fatal("rollback to savepoint kept row")
+	}
+	must(t, backend.ReleaseSavepoint("s1"))
+	if err := backend.ReleaseSavepoint("s1"); !isErr[*Unsupported](err) {
+		t.Fatalf("release missing savepoint error = %T %v", err, err)
+	}
+	must(t, backend.Commit(handle))
+
+	must(t, backend.CreateSavepoint("implicit"))
+	if _, ok := backend.CurrentTransaction(); !ok {
+		t.Fatal("implicit savepoint did not begin transaction")
+	}
+	current, _ := backend.CurrentTransaction()
+	must(t, backend.Rollback(current))
+}
+
+func TestIndexes(t *testing.T) {
+	backend := users(t)
+	must(t, backend.CreateIndex(IndexDef{Name: "idx_age", Table: "users", Columns: []string{"age"}}))
+	indexes := backend.ListIndexes("USERS")
+	if len(indexes) != 1 || indexes[0].Name != "idx_age" {
+		t.Fatalf("ListIndexes = %#v", indexes)
+	}
+	rowids, err := backend.ScanIndex("idx_age", []any{int64(25)}, []any{int64(30)}, true, true)
+	if err != nil {
+		t.Fatalf("ScanIndex failed: %v", err)
+	}
+	if !reflect.DeepEqual(rowids, []int{1, 0}) {
+		t.Fatalf("rowids = %#v", rowids)
+	}
+	it, err := backend.ScanByRowids("users", rowids)
+	if err != nil {
+		t.Fatalf("ScanByRowids failed: %v", err)
+	}
+	rows := collect(t, it)
+	if got := rowValues(rows, "id"); !reflect.DeepEqual(got, []any{int64(2), int64(1)}) {
+		t.Fatalf("scan by rowids = %#v", got)
+	}
+	must(t, backend.DropIndex("idx_age", false))
+	if got := backend.ListIndexes(""); len(got) != 0 {
+		t.Fatalf("indexes after drop = %#v", got)
+	}
+	if err := backend.DropIndex("idx_age", false); !isErr[*IndexNotFound](err) {
+		t.Fatalf("drop missing index error = %T %v", err, err)
+	}
+	must(t, backend.DropIndex("idx_age", true))
+}
+
+func TestIndexValidation(t *testing.T) {
+	backend := users(t)
+	must(t, backend.CreateIndex(IndexDef{Name: "idx_email", Table: "users", Columns: []string{"email"}, Unique: true}))
+	if err := backend.CreateIndex(IndexDef{Name: "IDX_EMAIL", Table: "users", Columns: []string{"email"}}); !isErr[*IndexAlreadyExists](err) {
+		t.Fatalf("duplicate index error = %T %v", err, err)
+	}
+	if err := backend.CreateIndex(IndexDef{Name: "idx_missing", Table: "missing", Columns: []string{"id"}}); !isErr[*TableNotFound](err) {
+		t.Fatalf("missing table index error = %T %v", err, err)
+	}
+	if err := backend.CreateIndex(IndexDef{Name: "idx_bad", Table: "users", Columns: []string{"missing"}}); !isErr[*ColumnNotFound](err) {
+		t.Fatalf("missing column index error = %T %v", err, err)
+	}
+	if _, err := backend.ScanIndex("missing", nil, nil, true, true); !isErr[*IndexNotFound](err) {
+		t.Fatalf("scan missing index error = %T %v", err, err)
+	}
+}
+
+func TestTriggersAndVersions(t *testing.T) {
+	backend := users(t)
+	if backend.GetSchemaVersion() == 0 {
+		t.Fatal("schema version was not bumped by CreateTable")
+	}
+	must(t, backend.SetUserVersion(7))
+	if backend.GetUserVersion() != 7 {
+		t.Fatalf("user version = %d", backend.GetUserVersion())
+	}
+	if err := backend.SetUserVersion(-1); err == nil {
+		t.Fatal("SetUserVersion accepted negative value")
+	}
+	trigger := TriggerDef{Name: "tr_users_ai", Table: "users", Timing: "AFTER", Event: "INSERT", Body: "SELECT 1"}
+	must(t, backend.CreateTrigger(trigger))
+	if got := backend.ListTriggers("USERS"); !reflect.DeepEqual(got, []TriggerDef{trigger}) {
+		t.Fatalf("ListTriggers = %#v", got)
+	}
+	if err := backend.CreateTrigger(trigger); !isErr[*TriggerAlreadyExists](err) {
+		t.Fatalf("duplicate trigger error = %T %v", err, err)
+	}
+	must(t, backend.DropTrigger("TR_USERS_AI", false))
+	if got := backend.ListTriggers("users"); len(got) != 0 {
+		t.Fatalf("triggers after drop = %#v", got)
+	}
+	if err := backend.DropTrigger("tr_users_ai", false); !isErr[*TriggerNotFound](err) {
+		t.Fatalf("drop missing trigger error = %T %v", err, err)
+	}
+	must(t, backend.DropTrigger("tr_users_ai", true))
+}
+
+func TestDropTableRemovesOwnedIndexesAndTriggers(t *testing.T) {
+	backend := users(t)
+	must(t, backend.CreateIndex(IndexDef{Name: "idx_age", Table: "users", Columns: []string{"age"}}))
+	must(t, backend.CreateTrigger(TriggerDef{Name: "tr_users_ai", Table: "users", Timing: "AFTER", Event: "INSERT", Body: "SELECT 1"}))
+	must(t, backend.DropTable("users", false))
+	if len(backend.ListIndexes("")) != 0 {
+		t.Fatal("drop table kept index")
+	}
+	if len(backend.ListTriggers("users")) != 0 {
+		t.Fatal("drop table kept trigger")
+	}
+}
+
+func users(t *testing.T) *InMemoryBackend {
+	t.Helper()
+	backend := NewInMemoryBackend()
+	must(t, backend.CreateTable("users", []ColumnDef{
+		{Name: "id", TypeName: "INTEGER", PrimaryKey: true},
+		{Name: "name", TypeName: "TEXT", NotNull: true},
+		{Name: "age", TypeName: "INTEGER"},
+		{Name: "email", TypeName: "TEXT", Unique: true},
+	}, false))
+	must(t, backend.Insert("users", Row{"id": int64(1), "name": "Alice", "age": int64(30), "email": "alice@example.com"}))
+	must(t, backend.Insert("users", Row{"id": int64(2), "name": "Bob", "age": int64(25), "email": "bob@example.com"}))
+	must(t, backend.Insert("users", Row{"id": int64(3), "name": "Carol", "age": nil, "email": nil}))
+	return backend
+}
+
+func collect(t *testing.T, iterator RowIterator) []Row {
+	t.Helper()
+	defer iterator.Close()
+	rows := []Row{}
+	for {
+		row, ok := iterator.Next()
+		if !ok {
+			return rows
+		}
+		rows = append(rows, row)
+	}
+}
+
+func mustScan(t *testing.T, backend *InMemoryBackend, table string) RowIterator {
+	t.Helper()
+	iterator, err := backend.Scan(table)
+	return mustIterator(t, iterator, err)
+}
+
+func mustIterator(t *testing.T, iterator RowIterator, err error) RowIterator {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("iterator failed: %v", err)
+	}
+	return iterator
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func isErr[T error](err error) bool {
+	var target T
+	return errors.As(err, &target)
+}
+
+func rowValues(rows []Row, column string) []any {
+	out := make([]any, len(rows))
+	for i, row := range rows {
+		out[i] = row[column]
+	}
+	return out
+}
+
+func containsID(t *testing.T, backend *InMemoryBackend, id int64) bool {
+	t.Helper()
+	for _, row := range collect(t, mustScan(t, backend, "users")) {
+		if row["id"] == id {
+			return true
+		}
+	}
+	return false
+}
+
+func assertCompareLess(t *testing.T, left any, right any) {
+	t.Helper()
+	cmp, err := CompareSQLValues(left, right)
+	if err != nil {
+		t.Fatalf("CompareSQLValues failed: %v", err)
+	}
+	if cmp >= 0 {
+		t.Fatalf("CompareSQLValues(%#v, %#v) = %d, want < 0", left, right, cmp)
+	}
+}

--- a/code/packages/go/sql-backend/go.mod
+++ b/code/packages/go/sql-backend/go.mod
@@ -1,0 +1,3 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/sql-backend
+
+go 1.23

--- a/code/packages/go/sql-backend/required_capabilities.json
+++ b/code/packages/go/sql-backend/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "capabilities": []
+}


### PR DESCRIPTION
## Summary
- port the Python sql-backend contract into a Go package
- add SQL value helpers, row iterators, positioned cursors, schema/index/trigger metadata, typed backend errors, transactions, savepoints, version fields, and an in-memory backend
- cover the backend surface with Go conformance-style tests

## Validation
- go test ./... -v -cover
- go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -language go -emit-plan C:\Users\adhit\AppData\Local\Temp\mini-sqlite-sql-backend-go-plan.json