### PR TITLE
Add scripting-aware HTML lexer contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -207,3 +207,6 @@ documented in this file.
 - Added `apply_html_lex_context` so parser code can reconfigure an existing
   lexer with typed HTML context and clear stale text-mode tag context when
   returning to data-state lexing.
+- Added scripting-aware parser-facing text-mode context selection so `noscript`
+  can enter RAWTEXT when scripting is enabled and remain ordinary markup when
+  scripting is disabled.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -145,11 +145,13 @@ tokenizer subflow end to end; a future parser can still decide when that opener
 is valid for foreign-content contexts.
 The public Rust API now wraps those parser-controlled entry states in
 `HtmlTokenizerState` and `HtmlLexContext`, including an element-to-context map
-for `title`, `textarea`, raw-text elements, `script`, and `plaintext`. That
-lets the parser request a statically linked lexer in the right tokenizer mode
-without depending on generated machine-state strings. Parsers that keep one
-lexer alive can call `apply_html_lex_context` to move that lexer between data
-state and text-mode states while clearing stale last-start-tag context.
+for `title`, `textarea`, raw-text elements, `script`, and `plaintext`. A
+scripting-aware variant lets the parser decide whether `noscript` enters
+RAWTEXT or stays ordinary markup. That lets the parser request a statically
+linked lexer in the right tokenizer mode without depending on generated
+machine-state strings. Parsers that keep one lexer alive can call
+`apply_html_lex_context` to move that lexer between data state and text-mode
+states while clearing stale last-start-tag context.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -14,6 +14,13 @@ pub use state_machine_tokenizer::{
 mod generated_html1;
 mod generated_html_skeleton;
 
+/// Parser-facing scripting flag for tokenizer text-mode decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HtmlScriptingMode {
+    Enabled,
+    Disabled,
+}
+
 /// Parser-facing HTML tokenizer entry state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HtmlTokenizerState {
@@ -91,10 +98,20 @@ impl HtmlLexContext {
     /// submodes. It deliberately keeps foreign-content CDATA decisions out of
     /// the element map because those depend on tree-construction context.
     pub fn for_element_text(element_name: &str) -> Option<Self> {
+        Self::for_element_text_with_scripting(element_name, HtmlScriptingMode::Enabled)
+    }
+
+    /// Return the tokenizer context used for text after a start tag, including
+    /// scripting-sensitive `noscript` handling.
+    pub fn for_element_text_with_scripting(
+        element_name: &str,
+        scripting: HtmlScriptingMode,
+    ) -> Option<Self> {
         let name = element_name.to_ascii_lowercase();
         let state = match name.as_str() {
             "title" | "textarea" => HtmlTokenizerState::Rcdata,
             "iframe" | "noembed" | "noframes" | "style" | "xmp" => HtmlTokenizerState::Rawtext,
+            "noscript" if scripting == HtmlScriptingMode::Enabled => HtmlTokenizerState::Rawtext,
             "script" => HtmlTokenizerState::ScriptData,
             "plaintext" => HtmlTokenizerState::Plaintext,
             _ => return None,

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,7 +1,7 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, html1_definition, html1_machine,
     html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment, Attribute,
-    HtmlLexContext, HtmlTokenizerState, Token,
+    HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token,
 };
 use state_machine::END_INPUT;
 
@@ -4309,6 +4309,32 @@ fn parser_facing_context_maps_rawtext_elements() {
             },
             Token::Eof
         ]
+    );
+}
+
+#[test]
+fn parser_facing_context_maps_noscript_based_on_scripting_mode() {
+    let enabled =
+        HtmlLexContext::for_element_text_with_scripting("noscript", HtmlScriptingMode::Enabled)
+            .unwrap();
+
+    assert_eq!(enabled.initial_state, HtmlTokenizerState::Rawtext);
+    assert_eq!(enabled.last_start_tag.as_deref(), Some("noscript"));
+    assert_eq!(
+        lex_html_fragment("<p>&amp;</p></noscript>", &enabled).unwrap(),
+        vec![
+            Token::Text("<p>&amp;".to_string()),
+            Token::Text("</p>".to_string()),
+            Token::EndTag {
+                name: "noscript".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    assert_eq!(
+        HtmlLexContext::for_element_text_with_scripting("noscript", HtmlScriptingMode::Disabled),
+        None
     );
 }
 


### PR DESCRIPTION
## Summary
- Add `HtmlScriptingMode` and scripting-aware parser-facing text-mode context selection.
- Keep `noscript` in RAWTEXT when scripting is enabled, while leaving it as ordinary markup when scripting is disabled.
- Document the new parser-facing mode and add lexer coverage for both `noscript` paths.

## Verification
- `cargo test -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `git diff --check`