### PR TITLE
Add scripting-aware HTML parser options

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -16,3 +16,6 @@ documented in this file.
   ordinary data-state markup.
 - Implied `html`, `head`, and `body` document shell normalization, including
   preservation of explicit shell attributes and legacy omitted-wrapper pages.
+- Scripting-aware parse options for parser-controlled tokenizer handoff, so
+  `noscript` becomes RAWTEXT with scripting enabled and ordinary fallback
+  markup with scripting disabled.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -16,6 +16,8 @@ This first slice intentionally starts small:
 - implied document shell creation for omitted `html`, `head`, and `body`
 - parser-controlled lexer handoff for `title`, `textarea`, RAWTEXT elements,
   `script`, and `plaintext`
+- parser options for scripting-sensitive tokenizer handoff, including
+  `noscript`
 - simple implied end tags for `p`, `li`, `dt`, and `dd`
 - parser diagnostics for unmatched end tags
 
@@ -26,7 +28,8 @@ onto the same DOM target. A separate adapter can project DOM into
 ## Usage
 
 ```rust
-use coding_adventures_html_parser::parse_html;
+use coding_adventures_html_lexer::HtmlScriptingMode;
+use coding_adventures_html_parser::{parse_html, parse_html_with_options, HtmlParseOptions};
 use dom_core::Node;
 
 let document = parse_html("<p>Hello <strong>Venture</strong></p>").unwrap();
@@ -35,4 +38,12 @@ match &document.children[0] {
     Node::Element(element) => assert_eq!(element.name, "html"),
     other => panic!("expected element, got {other:?}"),
 }
+
+let no_script_document = parse_html_with_options(
+    "<noscript><p>Fallback</p></noscript>",
+    HtmlParseOptions {
+        scripting: HtmlScriptingMode::Disabled,
+    },
+)
+.unwrap();
 ```

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7,10 +7,24 @@
 
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, Attribute as LexerAttribute, Diagnostic,
-    HtmlLexContext, HtmlLexer, Token, TokenizerError,
+    HtmlLexContext, HtmlLexer, HtmlScriptingMode, Token, TokenizerError,
 };
 use dom_core::{Attribute, Document, DocumentType, Node};
 use std::fmt;
+
+/// Parser options that influence tokenizer handoff and tree construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HtmlParseOptions {
+    pub scripting: HtmlScriptingMode,
+}
+
+impl Default for HtmlParseOptions {
+    fn default() -> Self {
+        Self {
+            scripting: HtmlScriptingMode::Enabled,
+        }
+    }
+}
 
 /// Parser result that keeps DOM output and diagnostics together.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,8 +79,24 @@ pub fn parse_html(source: &str) -> Result<Document, ParseError> {
 
 /// Parse a complete HTML string into a DOM document plus lexer/parser diagnostics.
 pub fn parse_html_with_diagnostics(source: &str) -> Result<ParseOutput, ParseError> {
+    parse_html_with_diagnostics_and_options(source, HtmlParseOptions::default())
+}
+
+/// Parse a complete HTML string into a DOM document with explicit parser options.
+pub fn parse_html_with_options(
+    source: &str,
+    options: HtmlParseOptions,
+) -> Result<Document, ParseError> {
+    Ok(parse_html_with_diagnostics_and_options(source, options)?.document)
+}
+
+/// Parse a complete HTML string into a DOM document plus diagnostics with explicit parser options.
+pub fn parse_html_with_diagnostics_and_options(
+    source: &str,
+    options: HtmlParseOptions,
+) -> Result<ParseOutput, ParseError> {
     let mut lexer = create_html_lexer()?;
-    let mut parser = HtmlParser::new();
+    let mut parser = HtmlParser::with_options(options);
 
     for ch in source.chars() {
         let mut buffer = [0; 4];
@@ -93,11 +123,19 @@ pub struct HtmlParser {
     document: Document,
     open_elements: Vec<Vec<usize>>,
     diagnostics: Vec<ParserDiagnostic>,
+    options: HtmlParseOptions,
 }
 
 impl HtmlParser {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_options(options: HtmlParseOptions) -> Self {
+        Self {
+            options,
+            ..Self::default()
+        }
     }
 
     pub fn parse_tokens(&mut self, tokens: impl IntoIterator<Item = Token>) -> Document {
@@ -248,11 +286,23 @@ impl HtmlParser {
         let path = self.current_parent_path().to_vec();
         children_at_path_mut(&mut self.document.children, &path)
     }
+
+    fn text_context_for_token(&self, token: &Token) -> Option<HtmlLexContext> {
+        match token {
+            Token::StartTag {
+                name, self_closing, ..
+            } if !self_closing && !is_void_element(name) => {
+                HtmlLexContext::for_element_text_with_scripting(name, self.options.scripting)
+            }
+            Token::EndTag { .. } => Some(HtmlLexContext::data()),
+            _ => None,
+        }
+    }
 }
 
 fn drain_parser_tokens(lexer: &mut HtmlLexer, parser: &mut HtmlParser) -> Result<(), ParseError> {
     for token in lexer.drain_tokens() {
-        let next_context = text_context_for_token(&token);
+        let next_context = parser.text_context_for_token(&token);
         parser.process_token(token);
 
         if let Some(context) = next_context {
@@ -261,16 +311,6 @@ fn drain_parser_tokens(lexer: &mut HtmlLexer, parser: &mut HtmlParser) -> Result
     }
 
     Ok(())
-}
-
-fn text_context_for_token(token: &Token) -> Option<HtmlLexContext> {
-    match token {
-        Token::StartTag {
-            name, self_closing, ..
-        } if !self_closing && !is_void_element(name) => HtmlLexContext::for_element_text(name),
-        Token::EndTag { .. } => Some(HtmlLexContext::data()),
-        _ => None,
-    }
 }
 
 fn element_at_path<'a>(document: &'a Document, path: &[usize]) -> Option<&'a str> {
@@ -561,6 +601,41 @@ mod tests {
         );
 
         let paragraph = element(&body(&document).children[0]);
+        assert_eq!(paragraph.children, vec![Node::text("x")]);
+    }
+
+    #[test]
+    fn parser_drives_noscript_rawtext_when_scripting_is_enabled() {
+        let document = parse_html("<noscript><p>&amp;</p></noscript><p>x</p>").unwrap();
+
+        let noscript = element(&head(&document).children[0]);
+        assert_eq!(noscript.name, "noscript");
+        assert_eq!(noscript.children, vec![Node::text("<p>&amp;</p>")]);
+
+        let paragraph = element(&body(&document).children[0]);
+        assert_eq!(paragraph.name, "p");
+        assert_eq!(paragraph.children, vec![Node::text("x")]);
+    }
+
+    #[test]
+    fn parser_parses_noscript_markup_when_scripting_is_disabled() {
+        let document = parse_html_with_options(
+            "<noscript><p>&amp;</p></noscript><p>x</p>",
+            HtmlParseOptions {
+                scripting: HtmlScriptingMode::Disabled,
+            },
+        )
+        .unwrap();
+
+        let noscript = element(&head(&document).children[0]);
+        assert_eq!(noscript.name, "noscript");
+
+        let fallback_paragraph = element(&noscript.children[0]);
+        assert_eq!(fallback_paragraph.name, "p");
+        assert_eq!(fallback_paragraph.children, vec![Node::text("&")]);
+
+        let paragraph = element(&body(&document).children[0]);
+        assert_eq!(paragraph.name, "p");
         assert_eq!(paragraph.children, vec![Node::text("x")]);
     }
 


### PR DESCRIPTION
## Summary
- Add `HtmlParseOptions` so parser-controlled tokenizer handoff can carry scripting mode.
- Thread the scripting option through incremental lexer draining and `noscript` context selection.
- Add DOM parser coverage for enabled-scripting RAWTEXT `noscript` and disabled-scripting fallback markup.

## Verification
- `cargo test -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `git diff --check`