### PR TITLE
Add F# sql-csv-source package

### DIFF
--- a/code/packages/fsharp/sql-csv-source/.gitignore
+++ b/code/packages/fsharp/sql-csv-source/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+TestResults/
+coverage/

--- a/code/packages/fsharp/sql-csv-source/BUILD
+++ b/code/packages/fsharp/sql-csv-source/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlCsvSource.Tests/CodingAdventures.SqlCsvSource.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-csv-source/BUILD_windows
+++ b/code/packages/fsharp/sql-csv-source/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlCsvSource.Tests/CodingAdventures.SqlCsvSource.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-csv-source/CHANGELOG.md
+++ b/code/packages/fsharp/sql-csv-source/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add the F# CSV-backed data source adapter for the mini-sqlite execution engine.

--- a/code/packages/fsharp/sql-csv-source/CodingAdventures.SqlCsvSource.fsproj
+++ b/code/packages/fsharp/sql-csv-source/CodingAdventures.SqlCsvSource.fsproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SqlCsvSource.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>CSV-backed data source adapter for the F# SQL execution engine</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="SqlCsvSource.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../csv-parser/CodingAdventures.CsvParser.fsproj" />
+    <ProjectReference Include="../sql-execution-engine/CodingAdventures.SqlExecutionEngine.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-csv-source/README.md
+++ b/code/packages/fsharp/sql-csv-source/README.md
@@ -1,0 +1,24 @@
+# sql-csv-source (F#)
+
+CSV-backed data source adapter for the F# mini-sqlite execution engine.
+
+The package maps each `*.csv` file in a directory to a SQL table, parses rows
+with `CodingAdventures.CsvParser`, coerces scalar values into SQL-friendly F#
+values, and executes queries through `CodingAdventures.SqlExecutionEngine`.
+
+## Example
+
+```fsharp
+open CodingAdventures.SqlCsvSource.FSharp
+
+let result =
+    SqlCsvSource.executeCsv
+        "SELECT name FROM employees WHERE active = true ORDER BY name"
+        "data"
+```
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/fsharp/sql-csv-source/SqlCsvSource.fs
+++ b/code/packages/fsharp/sql-csv-source/SqlCsvSource.fs
@@ -1,0 +1,121 @@
+namespace CodingAdventures.SqlCsvSource.FSharp
+
+open System
+open System.Collections.Generic
+open System.Globalization
+open System.IO
+open System.Text
+open CodingAdventures.CsvParser
+open CodingAdventures.SqlExecutionEngine.FSharp
+
+module private CsvHeader =
+    let parse (source: string) =
+        let fields = ResizeArray<string>()
+        let field = StringBuilder()
+        let mutable quoted = false
+        let mutable afterQuote = false
+        let mutable index = 0
+        let mutable doneRecord = false
+
+        while index < source.Length && not doneRecord do
+            let ch = source[index]
+
+            if quoted then
+                if ch = '"' then
+                    if index + 1 < source.Length && source[index + 1] = '"' then
+                        field.Append('"') |> ignore
+                        index <- index + 1
+                    else
+                        quoted <- false
+                        afterQuote <- true
+                else
+                    field.Append(ch) |> ignore
+            elif ch = ',' then
+                fields.Add(field.ToString().Trim())
+                field.Clear() |> ignore
+                afterQuote <- false
+            elif ch = '"' && field.Length = 0 && not afterQuote then
+                quoted <- true
+            elif ch = '\n' || ch = '\r' then
+                doneRecord <- true
+            else
+                field.Append(ch) |> ignore
+
+            index <- index + 1
+
+        if quoted then
+            raise (InvalidDataException("unclosed quoted field in header"))
+
+        fields.Add(field.ToString().Trim())
+        fields |> Seq.filter (String.IsNullOrEmpty >> not) |> Seq.toArray
+
+type CsvDataSource(directory: string) =
+    member _.Directory = directory
+
+    new(directory: DirectoryInfo) = CsvDataSource(directory.FullName)
+
+    member private this.CsvPath(tableName: string) =
+        Path.Combine(this.Directory, tableName + ".csv")
+
+    member private this.ReadTable(tableName: string) =
+        try
+            File.ReadAllText(this.CsvPath tableName)
+        with
+        | :? FileNotFoundException as ex -> raise (SqlExecutionException("table not found: " + tableName, ex))
+        | :? DirectoryNotFoundException as ex -> raise (SqlExecutionException("table not found: " + tableName, ex))
+        | :? IOException as ex -> raise (SqlExecutionException("reading CSV table: " + tableName, ex))
+
+    member this.Schema(tableName: string) =
+        (this :> IDataSource).Schema(tableName)
+
+    member this.Scan(tableName: string) =
+        (this :> IDataSource).Scan(tableName)
+
+    static member Coerce(value: string) : obj =
+        if value = String.Empty then
+            null
+        else
+            match value.ToLowerInvariant() with
+            | "true" -> box true
+            | "false" -> box false
+            | _ ->
+                let mutable integer = 0L
+                if Int64.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, &integer) then
+                    box integer
+                else
+                    let mutable real = 0.0
+                    if Double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, &real) then
+                        box real
+                    else
+                        box value
+
+    interface IDataSource with
+        member this.Schema(tableName: string) =
+            let source = this.ReadTable tableName
+            try
+                CsvHeader.parse source
+            with ex ->
+                raise (SqlExecutionException("parsing CSV header for table " + tableName, ex))
+
+        member this.Scan(tableName: string) =
+            let source = this.ReadTable tableName
+            try
+                CsvParser.parseCsv source
+                |> Array.map (fun row ->
+                    let values = Dictionary<string, obj>(StringComparer.Ordinal)
+                    for entry in row do
+                        values[entry.Key] <- CsvDataSource.Coerce(entry.Value)
+                    values :> IReadOnlyDictionary<string, obj>)
+            with ex ->
+                raise (SqlExecutionException("parsing CSV for table " + tableName, ex))
+
+[<RequireQualifiedAccess>]
+module SqlCsvSource =
+    let csvDataSource (directory: string) =
+        CsvDataSource(directory)
+
+    let executeCsv (sql: string) (directory: string) =
+        SqlExecutionEngine.execute sql (CsvDataSource(directory))
+
+    let tryExecuteCsv (sql: string) (directory: string) =
+        SqlExecutionEngine.tryExecute sql (CsvDataSource(directory))

--- a/code/packages/fsharp/sql-csv-source/required_capabilities.json
+++ b/code/packages/fsharp/sql-csv-source/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/sql-csv-source",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads CSV data files from a user-supplied directory path to serve as SQL table data sources."
+    }
+  ],
+  "justification": "Reads CSV files from user-provided paths. No write, network, or process access needed."
+}

--- a/code/packages/fsharp/sql-csv-source/tests/CodingAdventures.SqlCsvSource.Tests/CodingAdventures.SqlCsvSource.Tests.fsproj
+++ b/code/packages/fsharp/sql-csv-source/tests/CodingAdventures.SqlCsvSource.Tests/CodingAdventures.SqlCsvSource.Tests.fsproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Exclude>[CodingAdventures.CsvParser]*,[CodingAdventures.SqlExecutionEngine]*</Exclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="SqlCsvSourceTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.SqlCsvSource.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="fixtures\*.csv" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-csv-source/tests/CodingAdventures.SqlCsvSource.Tests/SqlCsvSourceTests.fs
+++ b/code/packages/fsharp/sql-csv-source/tests/CodingAdventures.SqlCsvSource.Tests/SqlCsvSourceTests.fs
@@ -1,0 +1,138 @@
+namespace CodingAdventures.SqlCsvSource.Tests
+
+open System
+open System.IO
+open Xunit
+open CodingAdventures.SqlCsvSource.FSharp
+open CodingAdventures.SqlExecutionEngine.FSharp
+
+module SqlCsvSourceTests =
+    let private fixtures =
+        Path.Combine(AppContext.BaseDirectory, "fixtures")
+
+    [<Fact>]
+    let ``exposes schema in header order`` () =
+        let source = CsvDataSource(fixtures)
+
+        Assert.Equal<string array>([| "id"; "name"; "dept_id"; "salary"; "active" |], source.Schema("employees"))
+        Assert.Equal<string array>([| "id"; "name"; "budget" |], source.Schema("departments"))
+
+        let moduleSource = SqlCsvSource.csvDataSource fixtures
+        Assert.Equal<string array>([| "id"; "name"; "budget" |], moduleSource.Schema("departments"))
+
+        let directorySource = CsvDataSource(DirectoryInfo(fixtures))
+        Assert.Equal<string array>([| "id"; "name"; "dept_id"; "salary"; "active" |], directorySource.Schema("employees"))
+
+    [<Fact>]
+    let ``scans rows with coerced values`` () =
+        let rows = CsvDataSource(fixtures).Scan("employees")
+
+        Assert.Equal(4, rows.Length)
+        Assert.Equal<obj>(box 1L, rows[0].["id"])
+        Assert.Equal<obj>(box "Alice", rows[0].["name"])
+        Assert.Equal<obj>(box 90000L, rows[0].["salary"])
+        Assert.Equal<obj>(box true, rows[0].["active"])
+        Assert.Null(rows[3].["dept_id"])
+
+    [<Fact>]
+    let ``executes selects against csv files`` () =
+        let result =
+            SqlCsvSource.executeCsv
+                "SELECT name, salary FROM employees WHERE active = true AND salary > 70000 ORDER BY salary DESC"
+                fixtures
+
+        Assert.Equal<string array>([| "name"; "salary" |], result.Columns)
+        Assert.Equal<obj array>([| box "Alice"; box 90000L |], result.Rows[0])
+        Assert.Equal<obj array>([| box "Bob"; box 75000L |], result.Rows[1])
+
+    [<Fact>]
+    let ``supports null predicates`` () =
+        let result = SqlCsvSource.executeCsv "SELECT name FROM employees WHERE dept_id IS NULL" fixtures
+
+        Assert.Equal<obj array>([| box "Dave" |], result.Rows[0])
+
+    [<Fact>]
+    let ``supports joins across csv files`` () =
+        let result =
+            SqlCsvSource.executeCsv
+                """
+                SELECT e.name AS emp_name, d.name AS dept_name
+                FROM employees AS e
+                INNER JOIN departments AS d ON e.dept_id = d.id
+                ORDER BY e.id
+                """
+                fixtures
+
+        Assert.Equal<string array>([| "emp_name"; "dept_name" |], result.Columns)
+        Assert.Equal<obj array>([| box "Alice"; box "Engineering" |], result.Rows[0])
+        Assert.Equal<obj array>([| box "Bob"; box "Marketing" |], result.Rows[1])
+        Assert.Equal<obj array>([| box "Carol"; box "Engineering" |], result.Rows[2])
+
+    [<Fact>]
+    let ``supports grouping aggregates limit and offset`` () =
+        let result =
+            SqlCsvSource.executeCsv
+                "SELECT dept_id, COUNT(*) AS cnt FROM employees WHERE dept_id IS NOT NULL GROUP BY dept_id ORDER BY dept_id LIMIT 2"
+                fixtures
+
+        Assert.Equal<string array>([| "dept_id"; "cnt" |], result.Columns)
+        Assert.Equal<obj array>([| box 1L; box 2 |], result.Rows[0])
+        Assert.Equal<obj array>([| box 2L; box 1 |], result.Rows[1])
+
+    [<Fact>]
+    let ``reports missing tables through engine errors`` () =
+        let ex =
+            Assert.Throws<SqlExecutionException>(fun () ->
+                SqlCsvSource.executeCsv "SELECT * FROM no_such_table" fixtures |> ignore)
+
+        Assert.Contains("table not found: no_such_table", ex.Message)
+
+        let result = SqlCsvSource.tryExecuteCsv "SELECT * FROM no_such_table" fixtures
+        Assert.False(result.Ok)
+        Assert.True(result.Error.IsSome)
+
+        let missingDirectory = Path.Combine(fixtures, "missing")
+        let directoryEx =
+            Assert.Throws<SqlExecutionException>(fun () ->
+                CsvDataSource(missingDirectory).Schema("employees") |> ignore)
+
+        Assert.Contains("table not found: employees", directoryEx.Message)
+
+    [<Fact>]
+    let ``handles quoted headers and header parse errors`` () =
+        let directory =
+            Path.Combine(Path.GetTempPath(), "sql-csv-source-fsharp-" + Guid.NewGuid().ToString("N"))
+
+        Directory.CreateDirectory(directory) |> ignore
+
+        try
+            File.WriteAllText(
+                Path.Combine(directory, "people.csv"),
+                "\"display,name\",\"said \"\"hi\"\"\"\nAlice,yes\n")
+
+            let source = CsvDataSource(directory)
+            Assert.Equal<string array>([| "display,name"; "said \"hi\"" |], source.Schema("people"))
+
+            let rows = source.Scan("people")
+            Assert.Equal<obj>(box "Alice", rows[0].["display,name"])
+            Assert.Equal<obj>(box "yes", rows[0].["said \"hi\""])
+
+            File.WriteAllText(Path.Combine(directory, "broken.csv"), "\"unterminated,name\nAlice,yes\n")
+            let ex =
+                Assert.Throws<SqlExecutionException>(fun () ->
+                    source.Schema("broken") |> ignore)
+
+            Assert.Contains("parsing CSV header for table broken", ex.Message)
+        finally
+            Directory.Delete(directory, true)
+
+    [<Fact>]
+    let ``coerces scalar values`` () =
+        Assert.Null(CsvDataSource.Coerce(""))
+        Assert.Equal<obj>(box true, CsvDataSource.Coerce("TRUE"))
+        Assert.Equal<obj>(box false, CsvDataSource.Coerce("false"))
+        Assert.Equal<obj>(box 42L, CsvDataSource.Coerce("42"))
+        Assert.Equal<obj>(box -5L, CsvDataSource.Coerce("-5"))
+        Assert.Equal<obj>(box 3.14, CsvDataSource.Coerce("3.14"))
+        Assert.Equal<obj>(box "123abc", CsvDataSource.Coerce("123abc"))
+        Assert.IsType<string>(CsvDataSource.Coerce("hello")) |> ignore

--- a/code/packages/fsharp/sql-csv-source/tests/CodingAdventures.SqlCsvSource.Tests/fixtures/departments.csv
+++ b/code/packages/fsharp/sql-csv-source/tests/CodingAdventures.SqlCsvSource.Tests/fixtures/departments.csv
@@ -1,0 +1,3 @@
+id,name,budget
+1,Engineering,500000
+2,Marketing,200000

--- a/code/packages/fsharp/sql-csv-source/tests/CodingAdventures.SqlCsvSource.Tests/fixtures/employees.csv
+++ b/code/packages/fsharp/sql-csv-source/tests/CodingAdventures.SqlCsvSource.Tests/fixtures/employees.csv
@@ -1,0 +1,5 @@
+id,name,dept_id,salary,active
+1,Alice,1,90000,true
+2,Bob,2,75000,true
+3,Carol,1,95000,false
+4,Dave,,60000,true


### PR DESCRIPTION
## Summary
- port the mini-sqlite CSV data source adapter to F#
- wire the F# adapter to the existing F# csv-parser and sql-execution-engine packages
- add xUnit coverage for schemas, scans, type coercion, SELECT execution, joins, grouping, missing tables, quoted headers, and header parse errors

## Validation
- dotnet test tests\CodingAdventures.SqlCsvSource.Tests\CodingAdventures.SqlCsvSource.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
- git diff --check
- go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -language fsharp -emit-plan %TEMP%\mini-sqlite-sql-csv-source-fsharp-plan.json