### PR TITLE
Add parser-facing CDATA lexer context

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -210,3 +210,5 @@ documented in this file.
 - Added scripting-aware parser-facing text-mode context selection so `noscript`
   can enter RAWTEXT when scripting is enabled and remain ordinary markup when
   scripting is disabled.
+- Added a typed parser-facing CDATA section context for future SVG/MathML
+  foreign-content tree construction without exposing raw machine-state strings.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -152,6 +152,10 @@ linked lexer in the right tokenizer mode without depending on generated
 machine-state strings. Parsers that keep one lexer alive can call
 `apply_html_lex_context` to move that lexer between data state and text-mode
 states while clearing stale last-start-tag context.
+Foreign-content CDATA is exposed as an explicit
+`HtmlLexContext::cdata_section()` helper rather than as an element-name mapping,
+so future SVG/MathML tree-construction logic can opt into CDATA only after it
+has confirmed the parser context.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -83,6 +83,16 @@ impl HtmlLexContext {
         Self::new(HtmlTokenizerState::Data)
     }
 
+    /// Return the tokenizer context for parser-approved foreign-content CDATA.
+    ///
+    /// HTML data-state markup only treats `<![CDATA[` specially when the parser
+    /// has entered a foreign-content integration point such as SVG or MathML.
+    /// Keeping this as an explicit context prevents element-name mapping from
+    /// pretending CDATA is valid in ordinary HTML content.
+    pub fn cdata_section() -> Self {
+        Self::new(HtmlTokenizerState::CdataSection)
+    }
+
     pub fn with_last_start_tag(mut self, tag: impl Into<String>) -> Self {
         self.last_start_tag = Some(tag.into());
         self

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -4371,6 +4371,25 @@ fn parser_facing_context_leaves_normal_elements_in_data_state() {
         HtmlLexContext::data().initial_state.as_machine_state(),
         "data"
     );
+    let cdata = HtmlLexContext::cdata_section();
+    assert_eq!(cdata.initial_state, HtmlTokenizerState::CdataSection);
+    assert_eq!(cdata.last_start_tag, None);
+    assert_eq!(
+        lex_html_fragment("<svg:title>&amp;</svg:title>]]><p>x</p>", &cdata).unwrap(),
+        vec![
+            Token::Text("<svg:title>&amp;</svg:title>".to_string()),
+            Token::StartTag {
+                name: "p".to_string(),
+                attributes: Vec::new(),
+                self_closing: false
+            },
+            Token::Text("x".to_string()),
+            Token::EndTag {
+                name: "p".to_string()
+            },
+            Token::Eof
+        ]
+    );
     assert_eq!(
         HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign.as_machine_state(),
         "script_data_double_escaped_less_than_sign"
@@ -4400,8 +4419,6 @@ fn parser_facing_context_can_reconfigure_an_existing_lexer() {
     apply_html_lex_context(&mut lexer, &HtmlLexContext::data()).unwrap();
     assert_eq!(lexer.current_state(), "data");
     lexer.push("<p>after</p>").unwrap();
-    lexer.finish().unwrap();
-
     assert_eq!(
         lexer.drain_tokens(),
         vec![
@@ -4413,9 +4430,18 @@ fn parser_facing_context_can_reconfigure_an_existing_lexer() {
             Token::Text("after".to_string()),
             Token::EndTag {
                 name: "p".to_string()
-            },
-            Token::Eof
+            }
         ]
+    );
+
+    apply_html_lex_context(&mut lexer, &HtmlLexContext::cdata_section()).unwrap();
+    assert_eq!(lexer.current_state(), "cdata_section");
+    lexer.push("<literal>&amp;]]>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![Token::Text("<literal>&amp;".to_string()), Token::Eof]
     );
 }
 


### PR DESCRIPTION
## Summary
- Add `HtmlLexContext::cdata_section()` as a typed parser-facing CDATA entry point.
- Keep CDATA out of element-name text-mode mapping while documenting the future SVG/MathML parser handoff.
- Extend lexer context tests to cover fragment lexing and live lexer reconfiguration through the CDATA context.

## Verification
- `cargo test -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `git diff --check`