### PR TITLE
Add parser initial tokenizer contexts

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -19,3 +19,5 @@ documented in this file.
 - Scripting-aware parse options for parser-controlled tokenizer handoff, so
   `noscript` becomes RAWTEXT with scripting enabled and ordinary fallback
   markup with scripting disabled.
+- Parser-approved initial tokenizer contexts, including foreign-content CDATA
+  section fragments backed by the typed lexer CDATA context.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -18,6 +18,8 @@ This first slice intentionally starts small:
   `script`, and `plaintext`
 - parser options for scripting-sensitive tokenizer handoff, including
   `noscript`
+- parser-approved initial tokenizer contexts for data-state documents and
+  foreign-content CDATA fragments
 - simple implied end tags for `p`, `li`, `dt`, and `dd`
 - parser diagnostics for unmatched end tags
 
@@ -29,7 +31,9 @@ onto the same DOM target. A separate adapter can project DOM into
 
 ```rust
 use coding_adventures_html_lexer::HtmlScriptingMode;
-use coding_adventures_html_parser::{parse_html, parse_html_with_options, HtmlParseOptions};
+use coding_adventures_html_parser::{
+    parse_html, parse_html_with_options, HtmlInitialTokenizerContext, HtmlParseOptions,
+};
 use dom_core::Node;
 
 let document = parse_html("<p>Hello <strong>Venture</strong></p>").unwrap();
@@ -43,6 +47,16 @@ let no_script_document = parse_html_with_options(
     "<noscript><p>Fallback</p></noscript>",
     HtmlParseOptions {
         scripting: HtmlScriptingMode::Disabled,
+        ..HtmlParseOptions::default()
+    },
+)
+.unwrap();
+
+let foreign_cdata_fragment = parse_html_with_options(
+    "<svg:title>&amp;</svg:title>]]>",
+    HtmlParseOptions {
+        initial_tokenizer_context: HtmlInitialTokenizerContext::ForeignContentCdataSection,
+        ..HtmlParseOptions::default()
     },
 )
 .unwrap();

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -16,12 +16,30 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HtmlParseOptions {
     pub scripting: HtmlScriptingMode,
+    pub initial_tokenizer_context: HtmlInitialTokenizerContext,
 }
 
 impl Default for HtmlParseOptions {
     fn default() -> Self {
         Self {
             scripting: HtmlScriptingMode::Enabled,
+            initial_tokenizer_context: HtmlInitialTokenizerContext::Data,
+        }
+    }
+}
+
+/// Initial tokenizer context for parser-approved document or fragment parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HtmlInitialTokenizerContext {
+    Data,
+    ForeignContentCdataSection,
+}
+
+impl HtmlInitialTokenizerContext {
+    fn lex_context(self) -> HtmlLexContext {
+        match self {
+            Self::Data => HtmlLexContext::data(),
+            Self::ForeignContentCdataSection => HtmlLexContext::cdata_section(),
         }
     }
 }
@@ -96,6 +114,7 @@ pub fn parse_html_with_diagnostics_and_options(
     options: HtmlParseOptions,
 ) -> Result<ParseOutput, ParseError> {
     let mut lexer = create_html_lexer()?;
+    apply_html_lex_context(&mut lexer, &options.initial_tokenizer_context.lex_context())?;
     let mut parser = HtmlParser::with_options(options);
 
     for ch in source.chars() {
@@ -623,6 +642,7 @@ mod tests {
             "<noscript><p>&amp;</p></noscript><p>x</p>",
             HtmlParseOptions {
                 scripting: HtmlScriptingMode::Disabled,
+                ..HtmlParseOptions::default()
             },
         )
         .unwrap();
@@ -635,6 +655,27 @@ mod tests {
         assert_eq!(fallback_paragraph.children, vec![Node::text("&")]);
 
         let paragraph = element(&body(&document).children[0]);
+        assert_eq!(paragraph.name, "p");
+        assert_eq!(paragraph.children, vec![Node::text("x")]);
+    }
+
+    #[test]
+    fn parser_can_start_in_foreign_content_cdata_context() {
+        let document = parse_html_with_options(
+            "<svg:title>&amp;</svg:title>]]><p>x</p>",
+            HtmlParseOptions {
+                initial_tokenizer_context: HtmlInitialTokenizerContext::ForeignContentCdataSection,
+                ..HtmlParseOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            body(&document).children[0],
+            Node::text("<svg:title>&amp;</svg:title>")
+        );
+
+        let paragraph = element(&body(&document).children[1]);
         assert_eq!(paragraph.name, "p");
         assert_eq!(paragraph.children, vec![Node::text("x")]);
     }


### PR DESCRIPTION
## Summary
- Add `HtmlInitialTokenizerContext` to parser options for explicit data-state vs parser-approved foreign-content CDATA starts.
- Seed the lexer from parser options before streaming input so typed CDATA context can flow into DOM parsing.
- Add DOM parser coverage for a foreign-content CDATA fragment returning to ordinary data-state markup.

## Verification
- `cargo test -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `git diff --check`