### PR TITLE
Add ALGOL designator convergence fixture

### DIFF
--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -96,6 +96,8 @@ All notable changes to this package will be documented in this file.
 - Executed by-name switch formals through lazy switch descriptors, preserving
   conditional switch actual re-evaluation through direct and formal procedure
   calls while keeping `value switch` formals as call-time snapshots.
+- Added a golden designator fixture covering lazy versus value label and switch
+  formals across direct, forwarded, and formal procedure calls.
 - Executed recursive switch self-selection entries by routing recursive
   descriptor lookup through the switch-eval helper at runtime.
 - Executed the report-style `go to` spelling through the full parser,

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -140,6 +140,8 @@ local WASM runtime. Those fixtures cover:
 - mixed scalar and array computation with output
 - Jensen-style by-name procedure calls
 - switch dispatch, procedure-formal dispatch, and procedure-crossing `goto`
+- lazy versus value label and switch formals across direct, forwarded, and
+  formal-procedure calls
 - conditional expressions, chained assignment, and exponentiation in the same
   end-to-end program
 - lexical recursion with outer-frame mutation and fresh recursive frames

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/by-name-designators.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/by-name-designators.alg
@@ -1,0 +1,136 @@
+begin
+  integer result, flag;
+
+  switch swDirectNameLeft := labelSwitchDirectNameLeft;
+  switch swDirectNameRight := labelSwitchDirectNameRight;
+  switch swDirectValueLeft := labelSwitchDirectValueLeft;
+  switch swDirectValueRight := labelSwitchDirectValueRight;
+  switch swRelayLeft := labelSwitchRelayLeft;
+  switch swRelayRight := labelSwitchRelayRight;
+  switch swFormalNameLeft := labelSwitchFormalNameLeft;
+  switch swFormalNameRight := labelSwitchFormalNameRight;
+  switch swFormalValueLeft := labelSwitchFormalValueLeft;
+  switch swFormalValueRight := labelSwitchFormalValueRight;
+
+  procedure jumpName(target);
+    label target;
+    begin flag := 1; goto target end;
+
+  procedure jumpValue(target);
+    value target;
+    label target;
+    begin flag := 1; goto target end;
+
+  procedure relayLabel(target);
+    label target;
+    begin jumpName(target) end;
+
+  procedure invokeLabelName(p);
+    procedure p;
+    begin p(if flag = 0 then labelFormalNameLeft else labelFormalNameRight) end;
+
+  procedure invokeLabelValue(p);
+    procedure p;
+    begin p(if flag = 0 then labelFormalValueLeft else labelFormalValueRight) end;
+
+  procedure switchName(sw);
+    switch sw;
+    begin flag := 1; goto sw[1] end;
+
+  procedure switchValue(sw);
+    value sw;
+    switch sw;
+    begin flag := 1; goto sw[1] end;
+
+  procedure relaySwitch(sw);
+    switch sw;
+    begin switchName(sw) end;
+
+  procedure invokeSwitchName(p);
+    procedure p;
+    begin p(if flag = 0 then swFormalNameLeft else swFormalNameRight) end;
+
+  procedure invokeSwitchValue(p);
+    procedure p;
+    begin p(if flag = 0 then swFormalValueLeft else swFormalValueRight) end;
+
+  result := 0;
+
+  flag := 0;
+  jumpName(if flag = 0 then labelDirectNameLeft else labelDirectNameRight);
+labelDirectNameLeft:
+  goto afterLabelDirectName;
+labelDirectNameRight:
+  result := result + 1;
+afterLabelDirectName:
+  flag := 0;
+  jumpValue(if flag = 0 then labelDirectValueLeft else labelDirectValueRight);
+labelDirectValueLeft:
+  result := result + 10;
+  goto afterLabelDirectValue;
+labelDirectValueRight:
+  goto afterLabelDirectValue;
+afterLabelDirectValue:
+  flag := 0;
+  relayLabel(if flag = 0 then labelRelayLeft else labelRelayRight);
+labelRelayLeft:
+  goto afterLabelRelay;
+labelRelayRight:
+  result := result + 100;
+afterLabelRelay:
+  flag := 0;
+  invokeLabelName(jumpName);
+labelFormalNameLeft:
+  goto afterLabelFormalName;
+labelFormalNameRight:
+  result := result + 1000;
+afterLabelFormalName:
+  flag := 0;
+  invokeLabelValue(jumpValue);
+labelFormalValueLeft:
+  result := result + 10000;
+  goto afterLabelFormalValue;
+labelFormalValueRight:
+  goto afterLabelFormalValue;
+afterLabelFormalValue:
+  flag := 0;
+  switchName(if flag = 0 then swDirectNameLeft else swDirectNameRight);
+labelSwitchDirectNameLeft:
+  goto afterSwitchDirectName;
+labelSwitchDirectNameRight:
+  result := result + 100000;
+afterSwitchDirectName:
+  flag := 0;
+  switchValue(if flag = 0 then swDirectValueLeft else swDirectValueRight);
+labelSwitchDirectValueLeft:
+  result := result + 1000000;
+  goto afterSwitchDirectValue;
+labelSwitchDirectValueRight:
+  goto afterSwitchDirectValue;
+afterSwitchDirectValue:
+  flag := 0;
+  relaySwitch(if flag = 0 then swRelayLeft else swRelayRight);
+labelSwitchRelayLeft:
+  goto afterSwitchRelay;
+labelSwitchRelayRight:
+  result := result + 10000000;
+afterSwitchRelay:
+  flag := 0;
+  invokeSwitchName(switchName);
+labelSwitchFormalNameLeft:
+  goto afterSwitchFormalName;
+labelSwitchFormalNameRight:
+  result := result + 100000000;
+afterSwitchFormalName:
+  flag := 0;
+  invokeSwitchValue(switchValue);
+labelSwitchFormalValueLeft:
+  result := result + 1000000000;
+  goto afterSwitchFormalValue;
+labelSwitchFormalValueRight:
+  goto afterSwitchFormalValue;
+afterSwitchFormalValue:
+  print('DESIG');
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -38,6 +38,11 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="runtime-guards", result=[0], stdout=""),
     GoldenFixture(name="storage-semantics", result=[737], stdout="STORAGE 737"),
     GoldenFixture(name="edge-semantics", result=[65], stdout="EDGE 65"),
+    GoldenFixture(
+        name="by-name-designators",
+        result=[1111111111],
+        stdout="DESIG 1111111111",
+    ),
 )
 
 


### PR DESCRIPTION
## Summary
- add a golden ALGOL program that exercises lazy versus value label formals through direct, forwarded, and formal procedure calls
- cover the same lazy/value split for switch formals through direct, forwarded, and formal procedure dispatch
- document the new designator convergence coverage in the package README and changelog

## Tests
- .venv/bin/python -m pytest tests/test_algol_wasm_fixtures.py -k by-name-designators (selected test passed; coverage gate fails for -k-only run)
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check
- git diff --check
- touched-file security scan: rg -n "subprocess|os\.system|\beval\(|\bexec\(|pickle|yaml\.load|shell=True|requests|urllib|socket|chmod|chown|unlink|rmtree|open\(" ... (no matches)
