### PR TITLE
Add typed script lexer substate contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -212,3 +212,5 @@ documented in this file.
   scripting is disabled.
 - Added a typed parser-facing CDATA section context for future SVG/MathML
   foreign-content tree construction without exposing raw machine-state strings.
+- Added typed parser-facing script substate contexts for script escaped and
+  double-escaped tokenizer fixtures and future parser handoff.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -156,6 +156,10 @@ Foreign-content CDATA is exposed as an explicit
 `HtmlLexContext::cdata_section()` helper rather than as an element-name mapping,
 so future SVG/MathML tree-construction logic can opt into CDATA only after it
 has confirmed the parser context.
+Script escaped and double-escaped substates are exposed through
+`HtmlLexContext::script_substate(...)`, giving parser and conformance callers a
+typed way to seed those script tokenizer subflows without raw machine-state
+strings.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -93,6 +93,28 @@ impl HtmlLexContext {
         Self::new(HtmlTokenizerState::CdataSection)
     }
 
+    /// Return a script tokenizer substate context for parser-approved fragments.
+    ///
+    /// These substates are useful for html5lib/WPT-style fixtures and for
+    /// future parser flows that need to resume script tokenization after
+    /// already recognizing an escaped or double-escaped script section.
+    pub fn script_substate(initial_state: HtmlTokenizerState) -> Option<Self> {
+        match initial_state {
+            HtmlTokenizerState::ScriptData
+            | HtmlTokenizerState::ScriptDataEscaped
+            | HtmlTokenizerState::ScriptDataEscapedDash
+            | HtmlTokenizerState::ScriptDataEscapedDashDash
+            | HtmlTokenizerState::ScriptDataEscapedLessThanSign
+            | HtmlTokenizerState::ScriptDataDoubleEscaped
+            | HtmlTokenizerState::ScriptDataDoubleEscapedDash
+            | HtmlTokenizerState::ScriptDataDoubleEscapedDashDash
+            | HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign => {
+                Some(Self::new(initial_state).with_last_start_tag("script"))
+            }
+            _ => None,
+        }
+    }
+
     pub fn with_last_start_tag(mut self, tag: impl Into<String>) -> Self {
         self.last_start_tag = Some(tag.into());
         self

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -4364,6 +4364,51 @@ fn parser_facing_context_maps_script_and_plaintext_elements() {
 }
 
 #[test]
+fn parser_facing_context_maps_script_substates() {
+    let escaped =
+        HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataEscapedDashDash).unwrap();
+    assert_eq!(
+        escaped.initial_state,
+        HtmlTokenizerState::ScriptDataEscapedDashDash
+    );
+    assert_eq!(escaped.last_start_tag.as_deref(), Some("script"));
+    assert_eq!(
+        lex_html_fragment("x</script>", &escaped).unwrap(),
+        vec![
+            Token::Text("x".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    let double_escaped =
+        HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign)
+            .unwrap();
+    assert_eq!(
+        double_escaped.initial_state,
+        HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign
+    );
+    assert_eq!(double_escaped.last_start_tag.as_deref(), Some("script"));
+    assert_eq!(
+        lex_html_fragment("/script>tail</script>", &double_escaped).unwrap(),
+        vec![
+            Token::Text("/script>tail".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    assert_eq!(
+        HtmlLexContext::script_substate(HtmlTokenizerState::Rawtext),
+        None
+    );
+}
+
+#[test]
 fn parser_facing_context_leaves_normal_elements_in_data_state() {
     assert_eq!(HtmlLexContext::for_element_text("p"), None);
     assert!(HtmlLexContext::data().is_data());


### PR DESCRIPTION
## Summary
- Add `HtmlLexContext::script_substate(...)` for parser/conformance callers that need typed script substate entry points.
- Support script data, escaped, dash/dash-dash/less-than, and double-escaped substates while rejecting non-script states.
- Add fragment tests for escaped and double-escaped seeded script contexts and document the API.

## Verification
- `cargo test -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `git diff --check`