### PR TITLE
Harden WASI fd_write output bounds

### DIFF
--- a/code/packages/python/wasm-runtime/CHANGELOG.md
+++ b/code/packages/python/wasm-runtime/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to this package will be documented in this file.
 
 - `WasiHost.__init__` now accepts an optional `WasiConfig` as its first argument. Keyword-only `stdout`/`stderr` usage remains supported.
 - `WasiConfig` now accepts `stdin`, a byte-reader callable used by `fd_read`.
+- `WasiConfig` now exposes `max_fd_write_bytes_per_call` and
+  `max_fd_write_bytes_total`; `fd_write` validates guest iovec ranges before
+  forwarding output and returns `EINVAL` for invalid or over-budget writes.
 - Added `EINVAL = 28` constant for the invalid-argument errno code.
 
 ## [0.1.0] - 2026-04-05

--- a/code/packages/python/wasm-runtime/README.md
+++ b/code/packages/python/wasm-runtime/README.md
@@ -78,11 +78,18 @@ config = WasiConfig(
     stdin=lambda n: b"input"[:n],
     stdout=print,
     stderr=print,
+    max_fd_write_bytes_per_call=1 << 20,
+    max_fd_write_bytes_total=16 << 20,
     clock=SystemClock(),    # default: real OS clock
     random=SystemRandom(),  # default: OS CSPRNG via secrets module
 )
 host = WasiHost(config)
 ```
+
+`fd_write` validates iovec tables, guest buffer ranges, and the `nwritten`
+pointer before reading guest memory or forwarding output. Writes are capped per
+call and across the host lifetime by `WasiConfig` so untrusted modules cannot
+force unbounded host allocation or stdout/stderr traffic.
 
 #### Injecting a fake clock for testing
 

--- a/code/packages/python/wasm-runtime/src/wasm_runtime/wasi_host.py
+++ b/code/packages/python/wasm-runtime/src/wasm_runtime/wasi_host.py
@@ -82,6 +82,8 @@ _COMPILER_MATH_UNARY_F64: dict[str, Callable[[float], float]] = {
 _COMPILER_MATH_BINARY_F64: dict[str, Callable[[float, float], float]] = {
     "f64_pow": math.pow,
 }
+_DEFAULT_MAX_FD_WRITE_BYTES_PER_CALL = 1 << 20
+_DEFAULT_MAX_FD_WRITE_BYTES_TOTAL = 16 << 20
 
 
 def _math_result(fn: Callable[..., float], *args: float) -> WasmValue:
@@ -198,6 +200,10 @@ class WasiConfig:
     stdout  — callable that receives each piece of text written to fd 1.
               If None, output is silently discarded.
     stderr  — same but for fd 2.
+    max_fd_write_bytes_per_call
+            — maximum bytes one fd_write call may read from guest memory.
+    max_fd_write_bytes_total
+            — maximum bytes all fd_write calls may write through this host.
     clock   — WasiClock implementation.  Defaults to SystemClock (real time).
     random  — WasiRandom implementation.  Defaults to SystemRandom (OS CSPRNG).
     """
@@ -207,6 +213,8 @@ class WasiConfig:
     stdin: Callable[[int], bytes | bytearray | str | None] | None = None
     stdout: Callable[[str], None] | None = None
     stderr: Callable[[str], None] | None = None
+    max_fd_write_bytes_per_call: int = _DEFAULT_MAX_FD_WRITE_BYTES_PER_CALL
+    max_fd_write_bytes_total: int = _DEFAULT_MAX_FD_WRITE_BYTES_TOTAL
     clock: WasiClock = field(default_factory=SystemClock)
     random: WasiRandom = field(default_factory=SystemRandom)
 
@@ -298,6 +306,9 @@ class WasiHost:
         self._stdin = config.stdin or (lambda _n: b"")
         self._stdout = config.stdout or (lambda _t: None)
         self._stderr = config.stderr or (lambda _t: None)
+        self._max_fd_write_bytes_per_call = config.max_fd_write_bytes_per_call
+        self._max_fd_write_bytes_total = config.max_fd_write_bytes_total
+        self._fd_write_bytes_written = 0
         self._args = config.args
         self._env = config.env
         self._clock = config.clock
@@ -409,34 +420,40 @@ class WasiHost:
 
         def fd_write_impl(args: list[WasmValue]) -> list[WasmValue]:
             fd = args[0].value
-            iovs_ptr = args[1].value
+            iovs_ptr = args[1].value & 0xFFFFFFFF
             iovs_len = args[2].value
-            nwritten_ptr = args[3].value
+            nwritten_ptr = args[3].value & 0xFFFFFFFF
 
             if host._instance_memory is None:
                 return [i32(ENOSYS)]
+            if fd not in {1, 2}:
+                return [i32(EBADF)]
+            if iovs_len < 0:
+                return [i32(EINVAL)]
 
             mem = host._instance_memory
-            total_written = 0
+            plan = host._read_iovec_plan(mem, iovs_ptr, iovs_len)
+            if plan is None or not host._memory_range_is_valid(mem, nwritten_ptr, 4):
+                return [i32(EINVAL)]
 
-            for idx in range(iovs_len):
-                # Each iovec is 8 bytes: 4-byte ptr + 4-byte length.
-                buf_ptr = mem.load_i32(iovs_ptr + idx * 8) & 0xFFFFFFFF
-                buf_len = mem.load_i32(iovs_ptr + idx * 8 + 4) & 0xFFFFFFFF
+            total_written = sum(buf_len for _buf_ptr, buf_len in plan)
+            if total_written > host._max_fd_write_bytes_per_call:
+                return [i32(EINVAL)]
+            if (
+                host._fd_write_bytes_written + total_written
+                > host._max_fd_write_bytes_total
+            ):
+                return [i32(EINVAL)]
 
-                # Read individual bytes and decode as Latin-1 (1 byte → 1 char).
-                chars = []
-                for j in range(buf_len):
-                    chars.append(chr(mem.load_i32_8u(buf_ptr + j)))
-
-                text = "".join(chars)
-                total_written += buf_len
+            for buf_ptr, buf_len in plan:
+                text = host._read_latin1(mem, buf_ptr, buf_len)
 
                 if fd == 1:
                     host._stdout(text)
                 elif fd == 2:
                     host._stderr(text)
 
+            host._fd_write_bytes_written += total_written
             mem.store_i32(nwritten_ptr, total_written)
             return [i32(ESUCCESS)]
 
@@ -503,6 +520,36 @@ class WasiHost:
             ),
             fd_read_impl,
         )
+
+    def _read_iovec_plan(
+        self,
+        mem: LinearMemory,
+        iovs_ptr: int,
+        iovs_len: int,
+    ) -> list[tuple[int, int]] | None:
+        if not self._memory_range_is_valid(mem, iovs_ptr, iovs_len * 8):
+            return None
+        plan: list[tuple[int, int]] = []
+        for idx in range(iovs_len):
+            descriptor_ptr = iovs_ptr + idx * 8
+            buf_ptr = mem.load_i32(descriptor_ptr) & 0xFFFFFFFF
+            buf_len = mem.load_i32(descriptor_ptr + 4) & 0xFFFFFFFF
+            if not self._memory_range_is_valid(mem, buf_ptr, buf_len):
+                return None
+            plan.append((buf_ptr, buf_len))
+        return plan
+
+    def _memory_range_is_valid(
+        self,
+        mem: LinearMemory,
+        ptr: int,
+        length: int,
+    ) -> bool:
+        memory_size = mem.byte_length()
+        return length >= 0 and ptr <= memory_size and ptr + length <= memory_size
+
+    def _read_latin1(self, mem: LinearMemory, ptr: int, length: int) -> str:
+        return "".join(chr(mem.load_i32_8u(ptr + offset)) for offset in range(length))
 
     def _make_proc_exit(self) -> _HostFunc:
         """Build the proc_exit host function.

--- a/code/packages/python/wasm-runtime/tests/test_wasi.py
+++ b/code/packages/python/wasm-runtime/tests/test_wasi.py
@@ -14,6 +14,7 @@ from wasm_execution import LinearMemory, f64, i32
 
 from wasm_runtime.wasi_host import (
     EBADF,
+    EINVAL,
     ENOSYS,
     ESUCCESS,
     ProcExitError,
@@ -148,6 +149,84 @@ class TestFdWrite:
         func = host.resolve_function("wasi_snapshot_preview1", "fd_write")
         result = func.call([i32(1), i32(0), i32(0), i32(0)])
         assert result[0].value == ENOSYS
+
+    def test_fd_write_rejects_unknown_file_descriptor(self) -> None:
+        host, mem, captured = self._setup_memory_with_iovec("Nope")
+        func = host.resolve_function("wasi_snapshot_preview1", "fd_write")
+        mem.store_i32(200, 123)
+
+        result = func.call([i32(3), i32(0), i32(1), i32(200)])
+
+        assert result[0].value == EBADF
+        assert captured == []
+        assert mem.load_i32(200) == 123
+
+    def test_fd_write_rejects_out_of_bounds_iovec_table(self) -> None:
+        captured: list[str] = []
+        host = WasiHost(stdout=captured.append)
+        mem = LinearMemory(1)
+        host.set_memory(mem)
+        func = host.resolve_function("wasi_snapshot_preview1", "fd_write")
+
+        result = func.call([i32(1), i32(LinearMemory.PAGE_SIZE - 4), i32(1), i32(200)])
+
+        assert result[0].value == EINVAL
+        assert captured == []
+
+    def test_fd_write_prevalidates_all_buffers_before_output(self) -> None:
+        captured: list[str] = []
+        host = WasiHost(stdout=captured.append)
+        mem = LinearMemory(1)
+        host.set_memory(mem)
+        mem._data[100] = ord("A")
+        mem.store_i32(0, 100)
+        mem.store_i32(4, 1)
+        mem.store_i32(8, LinearMemory.PAGE_SIZE - 1)
+        mem.store_i32(12, 2)
+        func = host.resolve_function("wasi_snapshot_preview1", "fd_write")
+
+        result = func.call([i32(1), i32(0), i32(2), i32(200)])
+
+        assert result[0].value == EINVAL
+        assert captured == []
+
+    def test_fd_write_respects_per_call_output_budget(self) -> None:
+        captured: list[str] = []
+        host = WasiHost(
+            WasiConfig(stdout=captured.append, max_fd_write_bytes_per_call=4)
+        )
+        mem = LinearMemory(1)
+        host.set_memory(mem)
+        for offset, ch in enumerate("Hello"):
+            mem._data[100 + offset] = ord(ch)
+        mem.store_i32(0, 100)
+        mem.store_i32(4, 5)
+        func = host.resolve_function("wasi_snapshot_preview1", "fd_write")
+
+        result = func.call([i32(1), i32(0), i32(1), i32(200)])
+
+        assert result[0].value == EINVAL
+        assert captured == []
+
+    def test_fd_write_respects_total_output_budget(self) -> None:
+        captured: list[str] = []
+        host = WasiHost(WasiConfig(stdout=captured.append, max_fd_write_bytes_total=5))
+        mem = LinearMemory(1)
+        host.set_memory(mem)
+        for offset, ch in enumerate("Hello!"):
+            mem._data[100 + offset] = ord(ch)
+        mem.store_i32(0, 100)
+        mem.store_i32(4, 5)
+        func = host.resolve_function("wasi_snapshot_preview1", "fd_write")
+
+        first = func.call([i32(1), i32(0), i32(1), i32(200)])
+        mem.store_i32(0, 105)
+        mem.store_i32(4, 1)
+        second = func.call([i32(1), i32(0), i32(1), i32(204)])
+
+        assert first[0].value == ESUCCESS
+        assert second[0].value == EINVAL
+        assert captured == ["Hello"]
 
 
 class TestFdRead:

--- a/code/specs/PL04-algol60-full-wasm-runtime.md
+++ b/code/specs/PL04-algol60-full-wasm-runtime.md
@@ -1539,8 +1539,11 @@ checker's configurable AST-depth, block-depth, and procedure-depth checks. The
 runtime lowering already keeps frames, dynamic arrays, output, eval-thunk
 descriptors, and generated control/helper label state bounded. The pure-Python
 WASM runtime now also exposes a configurable instruction budget so embedders
-can cap nonterminating compiled programs at execution time; future convergence
-work should keep closing any remaining host-budget items against this list.
+can cap nonterminating compiled programs at execution time. Its WASI `fd_write`
+host path validates iovec tables, guest buffer ranges, and output budgets before
+forwarding stdout/stderr, so compiled ALGOL output has both guest-side and
+host-side bounds. Future convergence work should keep closing any remaining
+host-budget items against this list.
 
 ## Documentation Requirements
 


### PR DESCRIPTION
## Summary
- validate fd_write iovec tables, guest buffer ranges, and nwritten pointers before reading guest memory or forwarding stdout/stderr
- add configurable per-call and host-lifetime fd_write output budgets to WasiConfig
- document the runtime output boundary hardening in wasm-runtime docs and PL04

## Tests
- ../algol-wasm-compiler/.venv/bin/python -m pytest tests/test_wasi.py (28 passed; isolated coverage gate fails as expected)
- ../algol-wasm-compiler/.venv/bin/python -m pytest
- bash BUILD
- .venv/bin/python -m pytest (algol-wasm-compiler, 267 passed)
- ../algol-wasm-compiler/.venv/bin/python -m ruff check src/wasm_runtime/wasi_host.py tests/test_wasi.py
- git diff --check
- touched Python security scan: no matches
- touched docs/spec security scan: doc-only matches for PL04 thunk eval notation and README open() usage
