### PR TITLE
Add ALGOL typed by-name convergence fixture

### DIFF
--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -83,6 +83,9 @@ All notable changes to this package will be documented in this file.
   `real procedure f;` through the full WASM pipeline.
 - Executed conditional switch actuals through direct calls, forwarded switch
   formals, and formal procedure dispatch, with a golden end-to-end fixture.
+- Added a golden convergence fixture for real, boolean, and string by-name
+  actuals through scalar storage, array-element storage, expression thunks, and
+  formal-procedure forwarding.
 - Executed subscripted integer and real array elements as writable `for`
   statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -151,6 +151,8 @@ local WASM runtime. Those fixtures cover:
   caller resumes at the target label
 - dynamic multidimensional array bounds captured at block entry
 - writable real, boolean, and string by-name scalar formals in one program
+- real, boolean, and string by-name actuals through scalar storage,
+  array-element storage, expression thunks, and formal-procedure forwarding
 - runtime bounds failure through the zero-result failure path before later
   output executes
 - mixed `own` scalar and array storage for real, boolean, and string values,

--- a/code/packages/python/algol-wasm-compiler/tests/fixtures/noninteger-by-name.alg
+++ b/code/packages/python/algol-wasm-compiler/tests/fixtures/noninteger-by-name.alg
@@ -1,0 +1,104 @@
+begin
+  integer result;
+  real r;
+  real array reals[1:2];
+  boolean flag;
+  boolean array bools[1:2];
+  string word, seen;
+  string array words[1:2];
+
+  procedure bumpreal(x);
+    real x;
+    begin
+      x := x + 1.5
+    end;
+
+  real procedure readreal(x);
+    real x;
+    begin
+      r := r + 1.0;
+      readreal := x
+    end;
+
+  procedure flipbool(x);
+    boolean x;
+    begin
+      x := not x
+    end;
+
+  boolean procedure readbool(x);
+    boolean x;
+    begin
+      flag := not flag;
+      readbool := x
+    end;
+
+  procedure setstring(x);
+    string x;
+    begin
+      x := 'OK'
+    end;
+
+  string procedure readstring(x);
+    string x;
+    begin
+      word := 'LAZY';
+      readstring := x
+    end;
+
+  procedure applyreal(p, x);
+    procedure p;
+    real x;
+    begin
+      p(x)
+    end;
+
+  procedure applybool(p, x);
+    procedure p;
+    boolean x;
+    begin
+      p(x)
+    end;
+
+  procedure applystring(p, x);
+    procedure p;
+    string x;
+    begin
+      p(x)
+    end;
+
+  result := 0;
+
+  r := 1.0;
+  reals[1] := 2.0;
+  applyreal(bumpreal, r);
+  if r = 2.5 then result := result + 1 else result := 0;
+  applyreal(bumpreal, reals[1]);
+  if reals[1] = 3.5 then result := result + 10 else result := 0;
+  if readreal(r + reals[1]) = 7.0 then result := result + 100 else result := 0;
+
+  flag := true;
+  bools[1] := false;
+  applybool(flipbool, flag);
+  if not flag then result := result + 1000 else result := 0;
+  applybool(flipbool, bools[1]);
+  if bools[1] then result := result + 10000 else result := 0;
+  flag := false;
+  if readbool(flag) then result := result + 100000 else result := 0;
+
+  word := 'NO';
+  words[1] := 'WAIT';
+  applystring(setstring, word);
+  if word = 'OK' then result := result + 1000000 else result := 0;
+  applystring(setstring, words[1]);
+  if words[1] = 'OK' then result := result + 10000000 else result := 0;
+  word := 'EARLY';
+  seen := readstring(if true then word else 'NO');
+  if seen = 'LAZY' then result := result + 100000000 else result := 0;
+
+  print('TYPED');
+  output(' ');
+  print(seen);
+  output(' ');
+  print(result)
+end

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_fixtures.py
@@ -35,6 +35,11 @@ _GOLDEN_FIXTURES = (
     GoldenFixture(name="nonlocal-unwind", result=[42], stdout="UNWIND 42"),
     GoldenFixture(name="dynamic-array-bounds", result=[63], stdout="DYNAMIC 63"),
     GoldenFixture(name="by-name-mixed-scalars", result=[27], stdout="BYNAME 27"),
+    GoldenFixture(
+        name="noninteger-by-name",
+        result=[111111111],
+        stdout="TYPED LAZY 111111111",
+    ),
     GoldenFixture(name="runtime-guards", result=[0], stdout=""),
     GoldenFixture(name="storage-semantics", result=[737], stdout="STORAGE 737"),
     GoldenFixture(name="edge-semantics", result=[65], stdout="EDGE 65"),

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -111,6 +111,36 @@ _SURFACE_CASES = (
         stdout="YES 17",
     ),
     SurfaceCase(
+        name="typed-by-name-expression-actuals",
+        source="""
+            begin
+              integer result;
+              real r;
+              boolean flag;
+              string word;
+              real procedure readreal(x); real x;
+                begin r := r + 1.0; readreal := x end;
+              boolean procedure readbool(x); boolean x;
+                begin flag := not flag; readbool := x end;
+              string procedure readstring(x); string x;
+                begin word := 'LAZY'; readstring := x end;
+              result := 0;
+              r := 2.0;
+              if readreal(r + 0.5) = 3.5 then result := result + 3 else result := 0;
+              flag := false;
+              if readbool(flag) then result := result + 5 else result := 0;
+              word := 'EARLY';
+              if readstring(if true then word else 'NO') = 'LAZY' then
+                result := result + 7
+              else
+                result := 0;
+              print(result)
+            end
+        """,
+        result=[15],
+        stdout="15",
+    ),
+    SurfaceCase(
         name="nonlocal-switch-goto-unwinds-dynamic-storage",
         source="""
             begin


### PR DESCRIPTION
## Summary
- add a golden ALGOL fixture covering real, boolean, and string by-name actuals through scalar storage, array-element storage, expression thunks, and formal-procedure forwarding
- add a surface-audit case for typed by-name expression actual re-evaluation
- document the expanded convergence coverage

## Tests
- .venv/bin/python -m pytest tests/test_algol_wasm_fixtures.py -k noninteger-by-name (passes selected test; expected coverage gate fails for selected run)
- .venv/bin/python -m pytest tests/test_algol_wasm_surface_audit.py -k typed-by-name-expression-actuals (passes selected test; expected coverage gate fails for selected run)
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check tests/test_algol_wasm_fixtures.py tests/test_algol_wasm_surface_audit.py
- git diff --check

## Security review
- scanned touched files for subprocess, shell execution, eval/exec, unsafe serialization, network/file deletion, and permission-changing APIs; no matches