### PR TITLE
Expose script tokenizer state set

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -214,3 +214,6 @@ documented in this file.
   foreign-content tree construction without exposing raw machine-state strings.
 - Added typed parser-facing script substate contexts for script escaped and
   double-escaped tokenizer fixtures and future parser handoff.
+- Added `HTML_SCRIPT_TOKENIZER_STATES` and `HtmlTokenizerState::is_script_substate()`
+  so parser/conformance adapters can enumerate and validate every supported
+  script entry state without duplicating lexer internals.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -159,7 +159,10 @@ has confirmed the parser context.
 Script escaped and double-escaped substates are exposed through
 `HtmlLexContext::script_substate(...)`, giving parser and conformance callers a
 typed way to seed those script tokenizer subflows without raw machine-state
-strings.
+strings. The accepted script entry states are also available as
+`HTML_SCRIPT_TOKENIZER_STATES`, and `HtmlTokenizerState::is_script_substate()`
+lets parser adapters validate user-selected fragment contexts before seeding a
+lexer.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -40,6 +40,19 @@ pub enum HtmlTokenizerState {
     ScriptDataDoubleEscapedLessThanSign,
 }
 
+/// Tokenizer states that are valid script-substate entry points.
+pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 9] = [
+    HtmlTokenizerState::ScriptData,
+    HtmlTokenizerState::ScriptDataEscaped,
+    HtmlTokenizerState::ScriptDataEscapedDash,
+    HtmlTokenizerState::ScriptDataEscapedDashDash,
+    HtmlTokenizerState::ScriptDataEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscaped,
+    HtmlTokenizerState::ScriptDataDoubleEscapedDash,
+    HtmlTokenizerState::ScriptDataDoubleEscapedDashDash,
+    HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
+];
+
 impl HtmlTokenizerState {
     /// Machine-state identifier used by the generated static lexer.
     pub fn as_machine_state(self) -> &'static str {
@@ -61,6 +74,11 @@ impl HtmlTokenizerState {
                 "script_data_double_escaped_less_than_sign"
             }
         }
+    }
+
+    /// Return whether this state is a parser-approved script tokenizer substate.
+    pub fn is_script_substate(self) -> bool {
+        HTML_SCRIPT_TOKENIZER_STATES.contains(&self)
     }
 }
 
@@ -99,19 +117,10 @@ impl HtmlLexContext {
     /// future parser flows that need to resume script tokenization after
     /// already recognizing an escaped or double-escaped script section.
     pub fn script_substate(initial_state: HtmlTokenizerState) -> Option<Self> {
-        match initial_state {
-            HtmlTokenizerState::ScriptData
-            | HtmlTokenizerState::ScriptDataEscaped
-            | HtmlTokenizerState::ScriptDataEscapedDash
-            | HtmlTokenizerState::ScriptDataEscapedDashDash
-            | HtmlTokenizerState::ScriptDataEscapedLessThanSign
-            | HtmlTokenizerState::ScriptDataDoubleEscaped
-            | HtmlTokenizerState::ScriptDataDoubleEscapedDash
-            | HtmlTokenizerState::ScriptDataDoubleEscapedDashDash
-            | HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign => {
-                Some(Self::new(initial_state).with_last_start_tag("script"))
-            }
-            _ => None,
+        if initial_state.is_script_substate() {
+            Some(Self::new(initial_state).with_last_start_tag("script"))
+        } else {
+            None
         }
     }
 

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,7 +1,7 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, html1_definition, html1_machine,
     html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment, Attribute,
-    HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token,
+    HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token, HTML_SCRIPT_TOKENIZER_STATES,
 };
 use state_machine::END_INPUT;
 
@@ -4365,6 +4365,56 @@ fn parser_facing_context_maps_script_and_plaintext_elements() {
 
 #[test]
 fn parser_facing_context_maps_script_substates() {
+    let expected_script_substates = [
+        (HtmlTokenizerState::ScriptData, "script_data"),
+        (HtmlTokenizerState::ScriptDataEscaped, "script_data_escaped"),
+        (
+            HtmlTokenizerState::ScriptDataEscapedDash,
+            "script_data_escaped_dash",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedDashDash,
+            "script_data_escaped_dash_dash",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedLessThanSign,
+            "script_data_escaped_less_than_sign",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataDoubleEscaped,
+            "script_data_double_escaped",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataDoubleEscapedDash,
+            "script_data_double_escaped_dash",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataDoubleEscapedDashDash,
+            "script_data_double_escaped_dash_dash",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
+            "script_data_double_escaped_less_than_sign",
+        ),
+    ];
+    assert_eq!(
+        HTML_SCRIPT_TOKENIZER_STATES,
+        expected_script_substates.map(|(state, _)| state)
+    );
+
+    for (state, machine_state) in expected_script_substates {
+        assert!(state.is_script_substate());
+        assert_eq!(state.as_machine_state(), machine_state);
+
+        let context = HtmlLexContext::script_substate(state).unwrap();
+        assert_eq!(context.initial_state, state);
+        assert_eq!(context.last_start_tag.as_deref(), Some("script"));
+
+        let mut lexer = create_html_lexer().unwrap();
+        apply_html_lex_context(&mut lexer, &context).unwrap();
+        assert_eq!(lexer.current_state(), machine_state);
+    }
+
     let escaped =
         HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataEscapedDashDash).unwrap();
     assert_eq!(
@@ -4406,6 +4456,7 @@ fn parser_facing_context_maps_script_substates() {
         HtmlLexContext::script_substate(HtmlTokenizerState::Rawtext),
         None
     );
+    assert!(!HtmlTokenizerState::Rawtext.is_script_substate());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `HTML_SCRIPT_TOKENIZER_STATES` as the public enumerable set of parser-approved script tokenizer entry states.
- Add `HtmlTokenizerState::is_script_substate()` and reuse it inside `HtmlLexContext::script_substate(...)`.
- Expand parser-facing lexer tests so every script substate is validated through real lexer context application.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check