### PR TITLE
Add parser table structure recovery

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -24,3 +24,6 @@ documented in this file.
 - Parser-approved initial script tokenizer contexts for script data, escaped,
   dash/dash-dash, less-than, and double-escaped substates backed by the typed
   lexer script-substate context helper.
+- Initial table tree-construction recovery for omitted `tbody`/`tr` structure,
+  including implicit row groups for bare rows/cells and section closure when a
+  new table section starts.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -14,6 +14,7 @@ This first slice intentionally starts small:
 - void element handling
 - adjacent text merging
 - implied document shell creation for omitted `html`, `head`, and `body`
+- implied table `tbody` and `tr` creation for common omitted table structure
 - parser-controlled lexer handoff for `title`, `textarea`, RAWTEXT elements,
   `script`, and `plaintext`
 - parser options for scripting-sensitive tokenizer handoff, including

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -243,6 +243,7 @@ impl HtmlParser {
         attributes: Vec<LexerAttribute>,
         self_closing: bool,
     ) {
+        self.apply_table_implied_contexts(&name);
         self.apply_simple_implied_end_tags(&name);
 
         let attributes = attributes
@@ -292,6 +293,13 @@ impl HtmlParser {
         }
     }
 
+    fn append_implied_element(&mut self, name: &str) {
+        let child_index = self.append_node(Node::element(name.to_string(), Vec::new()));
+        let mut path = self.current_parent_path().to_vec();
+        path.push(child_index);
+        self.open_elements.push(path);
+    }
+
     fn close_element(&mut self, name: &str) {
         if let Some(index) = self
             .open_elements
@@ -306,6 +314,36 @@ impl HtmlParser {
             "unexpected-end-tag",
             format!("end tag `</{name}>` did not match an open element"),
         ));
+    }
+
+    fn apply_table_implied_contexts(&mut self, incoming_name: &str) {
+        match incoming_name {
+            "tbody" | "thead" | "tfoot" => {
+                self.pop_current_if(|name| name == "td" || name == "th");
+                self.pop_current_if(|name| name == "tr");
+                self.pop_current_if(is_table_section);
+            }
+            "tr" => {
+                self.pop_current_if(|name| name == "td" || name == "th");
+                self.pop_current_if(|name| name == "tr");
+                if self.current_element_is("table") {
+                    self.append_implied_element("tbody");
+                }
+            }
+            "td" | "th" => {
+                self.pop_current_if(|name| name == "td" || name == "th");
+                if self.current_element_is("table") {
+                    self.append_implied_element("tbody");
+                }
+                if self.current_element_is("tbody")
+                    || self.current_element_is("thead")
+                    || self.current_element_is("tfoot")
+                {
+                    self.append_implied_element("tr");
+                }
+            }
+            _ => {}
+        }
     }
 
     fn apply_simple_implied_end_tags(&mut self, incoming_name: &str) {
@@ -328,6 +366,16 @@ impl HtmlParser {
         if predicate(name) {
             self.open_elements.pop();
         }
+    }
+
+    fn current_element_is(&self, name: &str) -> bool {
+        self.current_element_name()
+            .is_some_and(|current| current == name)
+    }
+
+    fn current_element_name(&self) -> Option<&str> {
+        let path = self.open_elements.last()?;
+        element_at_path(&self.document, path)
     }
 
     fn current_parent_path(&self) -> &[usize] {
@@ -509,6 +557,10 @@ fn is_ignorable_before_body(node: &Node) -> bool {
     }
 }
 
+fn is_table_section(name: &str) -> bool {
+    matches!(name, "tbody" | "thead" | "tfoot")
+}
+
 fn is_void_element(name: &str) -> bool {
     matches!(
         name,
@@ -621,6 +673,63 @@ mod tests {
 
         assert_eq!(element(&body.children[1]).children, vec![Node::text("a")]);
         assert_eq!(element(&body.children[2]).children, vec![Node::text("b")]);
+    }
+
+    #[test]
+    fn synthesizes_table_body_and_row_for_omitted_table_structure() {
+        let document = parse_html("<table><td>A<td>B<tr><th>C</table>").unwrap();
+
+        let table = element(&body(&document).children[0]);
+        assert_eq!(table.name, "table");
+
+        let tbody = element(&table.children[0]);
+        assert_eq!(tbody.name, "tbody");
+        assert_eq!(tbody.children.len(), 2);
+
+        let first_row = element(&tbody.children[0]);
+        assert_eq!(first_row.name, "tr");
+        assert_eq!(element(&first_row.children[0]).name, "td");
+        assert_eq!(
+            element(&first_row.children[0]).children,
+            vec![Node::text("A")]
+        );
+        assert_eq!(element(&first_row.children[1]).name, "td");
+        assert_eq!(
+            element(&first_row.children[1]).children,
+            vec![Node::text("B")]
+        );
+
+        let second_row = element(&tbody.children[1]);
+        assert_eq!(second_row.name, "tr");
+        assert_eq!(element(&second_row.children[0]).name, "th");
+        assert_eq!(
+            element(&second_row.children[0]).children,
+            vec![Node::text("C")]
+        );
+    }
+
+    #[test]
+    fn closes_open_table_sections_when_new_sections_start() {
+        let document = parse_html("<table><tbody><tr><td>A<tfoot><tr><td>B</table>").unwrap();
+
+        let table = element(&body(&document).children[0]);
+        assert_eq!(table.children.len(), 2);
+
+        let tbody = element(&table.children[0]);
+        assert_eq!(tbody.name, "tbody");
+        let tbody_row = element(&tbody.children[0]);
+        assert_eq!(
+            element(&tbody_row.children[0]).children,
+            vec![Node::text("A")]
+        );
+
+        let tfoot = element(&table.children[1]);
+        assert_eq!(tfoot.name, "tfoot");
+        let tfoot_row = element(&tfoot.children[0]);
+        assert_eq!(
+            element(&tfoot_row.children[0]).children,
+            vec![Node::text("B")]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Synthesize implicit `tbody` and `tr` nodes for common omitted table row-group/row markup.
- Close open table cells, rows, and sections when new rows or sections begin in the lightweight DOM tree builder.
- Add DOM parser coverage for bare table cells and transitions from an unclosed `tbody` into `tfoot`.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check