### PR TITLE
Support multi-argument ALGOL output builtins

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this package will be documented in this file.
   re-evaluates against the caller frame on every formal read.
 - Covered read-only boolean and string expression actuals through the same word
   eval-thunk path used by integer expressions.
+- Lowered multiple builtin `print`/`output` arguments in source order through
+  the existing guarded integer, boolean, real, and string output paths.
 - Lowered integer array-element by-name actuals to tagged descriptors with
   generated eval/store helpers that re-compute the element address on every
   formal read or assignment.

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -3915,31 +3915,31 @@ class AlgolIrCompiler:
 
     def _compile_builtin_output(self, node: ASTNode, scope: _FrameScope) -> int:
         actuals = _direct_nodes(_first_direct_node(node, "actual_params"), "expression")
-        if len(actuals) != 1:
-            raise CompileError("builtin output expects exactly 1 argument")
-        actual = actuals[0]
-        actual_type = self._expr_type(actual)
-        actual_reg = self._compile_expr(actual, scope)
-        saved_arg_reg: int | None = None
-        if self.next_reg > _VALUE_PARAM_BASE_REG:
-            saved_arg_reg = self._fresh_reg()
-            self._copy_reg(dst=saved_arg_reg, src=_VALUE_PARAM_BASE_REG)
-        if actual_type == _STRING_TYPE:
-            self._emit_output_string(actual_reg, scope)
-        elif actual_type == _BOOLEAN_TYPE:
-            self._emit_output_boolean(actual_reg, scope)
-        elif actual_type == _INTEGER_TYPE:
-            self._emit_output_integer(actual_reg, scope)
-        elif actual_type == _REAL_TYPE:
-            self._emit_output_real(actual_reg, scope)
-        else:
-            raise CompileError(
-                "builtin output currently supports integer, boolean, real, "
-                "and string"
-            )
+        if not actuals:
+            raise CompileError("builtin output expects at least 1 argument")
+        for actual in actuals:
+            actual_type = self._expr_type(actual)
+            actual_reg = self._compile_expr(actual, scope)
+            saved_arg_reg: int | None = None
+            if self.next_reg > _VALUE_PARAM_BASE_REG:
+                saved_arg_reg = self._fresh_reg()
+                self._copy_reg(dst=saved_arg_reg, src=_VALUE_PARAM_BASE_REG)
+            if actual_type == _STRING_TYPE:
+                self._emit_output_string(actual_reg, scope)
+            elif actual_type == _BOOLEAN_TYPE:
+                self._emit_output_boolean(actual_reg, scope)
+            elif actual_type == _INTEGER_TYPE:
+                self._emit_output_integer(actual_reg, scope)
+            elif actual_type == _REAL_TYPE:
+                self._emit_output_real(actual_reg, scope)
+            else:
+                raise CompileError(
+                    "builtin output currently supports integer, boolean, real, "
+                    "and string"
+                )
 
-        if saved_arg_reg is not None:
-            self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=saved_arg_reg)
+            if saved_arg_reg is not None:
+                self._copy_reg(dst=_VALUE_PARAM_BASE_REG, src=saved_arg_reg)
         return _ZERO_REG
 
     def _compile_builtin_numeric(

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -2256,6 +2256,31 @@ class TestAlgolIrCompiler:
         assert any(label.startswith("algol_label_output_bool_") for label in labels)
         assert len(syscalls) >= 4
 
+    def test_compiles_builtin_print_multiple_arguments_in_order(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; real x; boolean ok; string msg; "
+                "x := 1.5; ok := true; msg := 'Hi'; "
+                "print(msg, result + 1, ok, x); result := 1 end"
+            )
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+        syscalls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.SYSCALL
+        ]
+
+        assert any(label.startswith("algol_label_output_string_") for label in labels)
+        assert any(label.startswith("algol_label_output_int_") for label in labels)
+        assert any(label.startswith("algol_label_output_bool_") for label in labels)
+        assert any(label.startswith("algol_label_output_real_") for label in labels)
+        assert len(syscalls) >= 12
+
     def test_compiles_builtin_print_real_to_fixed_point_output(self) -> None:
         result = compile_algol(
             parse_algol("begin integer result; print(3.5); result := 1 end")

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to this package will be documented in this file.
 - Treated builtin `print`/`output` calls as read-only during by-name formal
   write analysis, so expression actuals remain valid when a formal is only
   printed.
+- Accepted one or more arguments to builtin `print`/`output` calls while
+  keeping numeric builtins strict about receiving exactly one argument.
 - Accepted integer-returning procedure actuals for real-valued formal
   procedure parameters, matching scalar integer-to-real promotion.
 - Accepted switch declaration entries that target labels in lexical parent

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -32,7 +32,8 @@ Procedure declarations receive semantic descriptors with generated function
 labels, parameter slots, value-vs-name parameter modes, conservative by-name
 write metadata, result slots for typed procedures, and resolved call sites
 carrying the static-link delta needed by code generation. Builtin output calls
-and standard numeric functions are resolved case-insensitively and treated as
+accept one or more scalar arguments, and standard numeric functions remain
+single-argument calls. Both are resolved case-insensitively and treated as
 read-only by the write analysis, so formals that are only printed or inspected
 can still accept expression actuals.
 No-argument procedure declarations and typed procedure expressions may use

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -2009,7 +2009,9 @@ class AlgolTypeChecker:
                 scope,
                 role=role,
             )
-        if len(arguments) != len(descriptor.parameters):
+        if descriptor.procedure_id != -1 and len(arguments) != len(
+            descriptor.parameters
+        ):
             self._error(
                 name_token,
                 f"procedure {name_token.value!r} expects "
@@ -2137,23 +2139,36 @@ class AlgolTypeChecker:
         *,
         role: str,
     ) -> str | None:
-        if not arguments:
-            return None
-        actual_type = self._infer_expr(arguments[0], scope)
         builtin_name = _builtin_name(name_token.value)
         if builtin_name in _OUTPUT_BUILTINS:
-            if actual_type != ERROR and actual_type not in {
-                INTEGER,
-                BOOLEAN,
-                REAL,
-                STRING,
-            }:
+            if not arguments:
                 self._error(
-                    arguments[0],
-                    f"builtin procedure {name_token.value!r} expects integer, "
-                    f"boolean, real, or string, got {actual_type}",
+                    name_token,
+                    f"procedure {name_token.value!r} expects at least 1 argument",
                 )
+                return None
+            for argument in arguments:
+                actual_type = self._infer_expr(argument, scope)
+                if actual_type != ERROR and actual_type not in {
+                    INTEGER,
+                    BOOLEAN,
+                    REAL,
+                    STRING,
+                }:
+                    self._error(
+                        argument,
+                        f"builtin procedure {name_token.value!r} expects integer, "
+                        f"boolean, real, or string, got {actual_type}",
+                    )
             return None
+        if len(arguments) != 1:
+            self._error(
+                name_token,
+                f"builtin function {name_token.value!r} expects 1 argument(s), "
+                f"got {len(arguments)}",
+            )
+            return ERROR
+        actual_type = self._infer_expr(arguments[0], scope)
         if actual_type != ERROR and not _is_numeric_type(actual_type):
             self._error(
                 arguments[0],

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -2497,6 +2497,34 @@ class TestAlgolTypeChecker:
 
         assert result.ok
 
+    def test_accepts_builtin_print_with_multiple_arguments(self) -> None:
+        ast = parse_algol(
+            "begin integer result; real x; boolean ok; string msg; "
+            "x := 1.5; ok := true; msg := 'Hi'; "
+            "print(msg, result + 1, ok, x); result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.procedure_calls[-1].label == "__algol_builtin_print"
+        assert result.semantic.procedure_calls[-1].argument_count == 4
+
+    def test_rejects_builtin_print_without_arguments(self) -> None:
+        ast = parse_algol("begin integer result; print(); result := 0 end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "expects at least 1 argument" in result.diagnostics[0].message
+
+    def test_rejects_numeric_builtin_with_multiple_arguments(self) -> None:
+        ast = parse_algol("begin integer result; result := abs(1, 2) end")
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert "expects 1 argument(s), got 2" in result.diagnostics[0].message
+
     def test_accepts_string_variable_declaration_and_assignment(self) -> None:
         ast = parse_algol("begin string msg; msg := 'Hi' end")
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -86,6 +86,9 @@ All notable changes to this package will be documented in this file.
 - Added a golden convergence fixture for real, boolean, and string by-name
   actuals through scalar storage, array-element storage, expression thunks, and
   formal-procedure forwarding.
+- Accepted multiple arguments to builtin `print(...)` / `output(...)`, emitting
+  each integer, boolean, real, or string argument in order through the same
+  guarded output path.
 - Executed subscripted integer and real array elements as writable `for`
   statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -41,8 +41,8 @@ the current lane already supports a substantial ALGOL 60 surface:
 - labels, local and nonlocal `goto`/`go to`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   recursive switch entries
-- builtin `print(...)` / `output(...)` for integers, booleans, reals, strings,
-  and string variables
+- builtin `print(...)` / `output(...)` for one or more integers, booleans,
+  reals, strings, and string variables
 
 Within the repository's ASCII `algol60` grammar, the executable
 declaration, statement, expression, procedure, array, by-name, and designational
@@ -97,6 +97,14 @@ captured_print: list[str] = []
 runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured_print.append)))
 assert runtime.load_and_run(print_only.binary, "_start", []) == [0]
 assert "".join(captured_print) == "Hi"
+
+captured_many: list[str] = []
+runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured_many.append)))
+multi_print = compile_source(
+    "begin integer result; print('Answer ', 40 + 2, ' ', true); result := 1 end"
+)
+assert runtime.load_and_run(multi_print.binary, "_start", []) == [1]
+assert "".join(captured_many) == "Answer 42 true"
 
 with_array = compile_source(
     "begin integer result; integer array a[1:3]; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -407,6 +407,19 @@ class TestAlgolWasmCompiler:
         assert runtime.load_and_run(result.binary, "_start", []) == [4]
         assert "".join(captured) == "3.500-0.125"
 
+    def test_builtin_print_multiple_arguments_writes_stdout_in_order(self) -> None:
+        result = compile_source(
+            "begin integer result; real x; boolean ok; string msg; "
+            "x := 1.5; ok := true; msg := 'Hi'; "
+            "print(msg, ' ', result + 1, ' ', ok, ' ', x); result := 6 "
+            "end"
+        )
+        captured: list[str] = []
+        runtime = WasmRuntime(host=WasiHost(config=WasiConfig(stdout=captured.append)))
+
+        assert runtime.load_and_run(result.binary, "_start", []) == [6]
+        assert "".join(captured) == "Hi 1 true 1.500"
+
     def test_builtin_print_infinite_real_returns_zero_without_stdout(self) -> None:
         result = compile_source(
             "begin integer result; real x; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -141,6 +141,24 @@ _SURFACE_CASES = (
         stdout="15",
     ),
     SurfaceCase(
+        name="multi-argument-output",
+        source="""
+            begin
+              integer result;
+              real x;
+              boolean ok;
+              string msg;
+              x := 1.5;
+              ok := true;
+              msg := 'IO';
+              result := 21;
+              print(msg, ' ', result, ' ', ok, ' ', x)
+            end
+        """,
+        result=[21],
+        stdout="IO 21 true 1.500",
+    ),
+    SurfaceCase(
         name="nonlocal-switch-goto-unwinds-dynamic-storage",
         source="""
             begin


### PR DESCRIPTION
## Summary
- allow ALGOL builtin print/output calls to accept one or more integer, boolean, real, or string arguments
- keep standard numeric builtins strict about exactly one argument
- lower each output argument in source order through the existing guarded output paths and add type-checker, IR, WASM, and surface-audit coverage

## Tests
- bash BUILD (code/packages/python/algol-type-checker)
- bash BUILD (code/packages/python/algol-ir-compiler)
- bash BUILD (code/packages/python/algol-wasm-compiler)
- ../algol-wasm-compiler/.venv/bin/python -m ruff check src/algol_type_checker/checker.py tests/test_algol_type_checker.py ../algol-ir-compiler/src/algol_ir_compiler/compiler.py ../algol-ir-compiler/tests/test_algol_ir_compiler.py ../algol-wasm-compiler/tests/test_algol_wasm_compiler.py ../algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
- git diff --check origin/main...HEAD

## Security review
- scanned touched files for subprocess, shell execution, eval/exec, unsafe serialization, network/file deletion, and permission-changing APIs; no matches