### PR TITLE
Expose tokenizer state sets

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -217,3 +217,7 @@ documented in this file.
 - Added `HTML_SCRIPT_TOKENIZER_STATES` and `HtmlTokenizerState::is_script_substate()`
   so parser/conformance adapters can enumerate and validate every supported
   script entry state without duplicating lexer internals.
+- Added `HTML_TOKENIZER_STATES`, `HTML_FRAGMENT_TOKENIZER_STATES`, and
+  `HtmlTokenizerState::is_fragment_state()` so parser and fixture importers can
+  enumerate the full typed tokenizer-context surface without copying state
+  lists out of the lexer crate.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -163,6 +163,11 @@ strings. The accepted script entry states are also available as
 `HTML_SCRIPT_TOKENIZER_STATES`, and `HtmlTokenizerState::is_script_substate()`
 lets parser adapters validate user-selected fragment contexts before seeding a
 lexer.
+For importers and parser fragment APIs that need to enumerate the whole
+supported surface, `HTML_TOKENIZER_STATES` lists every parser-facing tokenizer
+entry state and `HTML_FRAGMENT_TOKENIZER_STATES` lists the non-data fragment
+states accepted by the wrapper. `HtmlTokenizerState::is_fragment_state()` keeps
+that validation centralized in the lexer package.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -40,6 +40,41 @@ pub enum HtmlTokenizerState {
     ScriptDataDoubleEscapedLessThanSign,
 }
 
+/// Tokenizer states that are valid parser-facing entry points.
+pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 14] = [
+    HtmlTokenizerState::Data,
+    HtmlTokenizerState::Rcdata,
+    HtmlTokenizerState::Rawtext,
+    HtmlTokenizerState::Plaintext,
+    HtmlTokenizerState::CdataSection,
+    HtmlTokenizerState::ScriptData,
+    HtmlTokenizerState::ScriptDataEscaped,
+    HtmlTokenizerState::ScriptDataEscapedDash,
+    HtmlTokenizerState::ScriptDataEscapedDashDash,
+    HtmlTokenizerState::ScriptDataEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscaped,
+    HtmlTokenizerState::ScriptDataDoubleEscapedDash,
+    HtmlTokenizerState::ScriptDataDoubleEscapedDashDash,
+    HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
+];
+
+/// Tokenizer states used for parser-controlled text or foreign-content fragments.
+pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 13] = [
+    HtmlTokenizerState::Rcdata,
+    HtmlTokenizerState::Rawtext,
+    HtmlTokenizerState::Plaintext,
+    HtmlTokenizerState::CdataSection,
+    HtmlTokenizerState::ScriptData,
+    HtmlTokenizerState::ScriptDataEscaped,
+    HtmlTokenizerState::ScriptDataEscapedDash,
+    HtmlTokenizerState::ScriptDataEscapedDashDash,
+    HtmlTokenizerState::ScriptDataEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscaped,
+    HtmlTokenizerState::ScriptDataDoubleEscapedDash,
+    HtmlTokenizerState::ScriptDataDoubleEscapedDashDash,
+    HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
+];
+
 /// Tokenizer states that are valid script-substate entry points.
 pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 9] = [
     HtmlTokenizerState::ScriptData,
@@ -79,6 +114,11 @@ impl HtmlTokenizerState {
     /// Return whether this state is a parser-approved script tokenizer substate.
     pub fn is_script_substate(self) -> bool {
         HTML_SCRIPT_TOKENIZER_STATES.contains(&self)
+    }
+
+    /// Return whether this state is a parser-approved fragment entry point.
+    pub fn is_fragment_state(self) -> bool {
+        HTML_FRAGMENT_TOKENIZER_STATES.contains(&self)
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,7 +1,8 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, html1_definition, html1_machine,
     html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment, Attribute,
-    HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token, HTML_SCRIPT_TOKENIZER_STATES,
+    HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token, HTML_FRAGMENT_TOKENIZER_STATES,
+    HTML_SCRIPT_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
 };
 use state_machine::END_INPUT;
 
@@ -4457,6 +4458,35 @@ fn parser_facing_context_maps_script_substates() {
         None
     );
     assert!(!HtmlTokenizerState::Rawtext.is_script_substate());
+}
+
+#[test]
+fn parser_facing_context_exposes_tokenizer_state_sets() {
+    assert_eq!(
+        HTML_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),
+        [
+            "data",
+            "rcdata",
+            "rawtext",
+            "plaintext",
+            "cdata_section",
+            "script_data",
+            "script_data_escaped",
+            "script_data_escaped_dash",
+            "script_data_escaped_dash_dash",
+            "script_data_escaped_less_than_sign",
+            "script_data_double_escaped",
+            "script_data_double_escaped_dash",
+            "script_data_double_escaped_dash_dash",
+            "script_data_double_escaped_less_than_sign",
+        ]
+    );
+    assert!(!HtmlTokenizerState::Data.is_fragment_state());
+
+    assert_eq!(&HTML_FRAGMENT_TOKENIZER_STATES, &HTML_TOKENIZER_STATES[1..]);
+    for state in HTML_FRAGMENT_TOKENIZER_STATES {
+        assert!(state.is_fragment_state());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `HTML_TOKENIZER_STATES` for the full parser-facing typed tokenizer state surface.
- Add `HTML_FRAGMENT_TOKENIZER_STATES` plus `HtmlTokenizerState::is_fragment_state()` for parser/fixture importer validation.
- Cover the state-set ordering and machine-state mappings in the parser-facing lexer tests and document the API.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check