### PR TITLE
feat(prolog): add CLI check mode

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -274,6 +274,10 @@ Use `--values` to print raw answer values, omit `--query` to run a source-level
 `?-` directive by index, and use `--dialect iso` when the ISO parser profile is
 the desired frontend.
 
+Use `--check` to parse, load, compile, and initialize source without running a
+query. This is intended for CI and editor integrations that need to validate a
+Prolog file graph even when it does not contain embedded `?-` directives.
+
 Use `--all-source-queries` when a source file contains several embedded `?-`
 queries and the CLI should run them as a script. The command prints or emits
 one result record per source query, sets `source_query_index` in JSON formats,

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -31,6 +31,7 @@ from prolog_vm_compiler.compiler import (
     create_prolog_file_runtime,
     create_prolog_project_file_runtime,
     create_prolog_source_vm_runtime,
+    run_compiled_prolog_initializations,
     run_compiled_prolog_query,
     run_compiled_prolog_query_answers,
     run_initialized_compiled_prolog_query,
@@ -57,6 +58,7 @@ class CliArgs:
     files: tuple[Path, ...]
     source: str | None
     queries: tuple[str, ...]
+    check: bool
     source_query_index: int
     all_source_queries: bool
     query_module: str | None
@@ -143,6 +145,16 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         msg = "provide --source or at least one Prolog file"
         raise ValueError(msg)
     all_source_queries = bool(flags["all-source-queries"])
+    check = bool(flags["check"])
+    if check and queries:
+        msg = "--check cannot be combined with --query"
+        raise ValueError(msg)
+    if check and all_source_queries:
+        msg = "--check cannot be combined with --all-source-queries"
+        raise ValueError(msg)
+    if check and bool(flags["interactive"]):
+        msg = "--check cannot be combined with --interactive"
+        raise ValueError(msg)
     if all_source_queries and queries:
         msg = "--all-source-queries cannot be combined with --query"
         raise ValueError(msg)
@@ -154,6 +166,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         files=files,
         source=source,
         queries=queries,
+        check=check,
         source_query_index=source_query_index,
         all_source_queries=all_source_queries,
         query_module=query_module,
@@ -291,6 +304,9 @@ def _required_int(value: object, *, name: str) -> int:
 
 
 def _run_cli(args: CliArgs) -> int:
+    if args.check:
+        return _run_check(args)
+
     if args.queries or args.interactive:
         runtime = _create_runtime(args)
         saw_failure = False
@@ -319,6 +335,36 @@ def _run_cli(args: CliArgs) -> int:
         args=args,
     )
     return 0 if results else 1
+
+
+def _run_check(args: CliArgs) -> int:
+    compiled_program = _compile_source_program(args)
+    if args.initialize:
+        run_compiled_prolog_initializations(compiled_program, backend=args.backend)
+    _print_check_record(compiled_program, args=args)
+    return 0
+
+
+def _print_check_record(
+    compiled_program: CompiledPrologVMProgram,
+    *,
+    args: CliArgs,
+    stdout: TextIO | None = None,
+) -> None:
+    output = sys.stdout if stdout is None else stdout
+    if args.output_format == "text":
+        print("ok.", file=output)
+        return
+
+    payload = {
+        "success": True,
+        "mode": "check",
+        "backend": args.backend,
+        "initialized": args.initialize,
+        "initialization_query_count": compiled_program.initialization_query_count,
+        "source_query_count": compiled_program.source_query_count,
+    }
+    print(json.dumps(payload, sort_keys=True), file=output)
 
 
 def _run_all_source_queries(args: CliArgs) -> int:

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
@@ -25,6 +25,12 @@
       "repeatable": true
     },
     {
+      "id": "check",
+      "long": "check",
+      "description": "Parse, load, compile, and optionally initialize without running a query.",
+      "type": "boolean"
+    },
+    {
       "id": "source-query-index",
       "long": "source-query-index",
       "description": "Zero-based source-level ?- query index to run when --query is absent.",

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -51,6 +51,58 @@ def test_cli_repeated_queries_share_committed_runtime_state(
     ]
 
 
+def test_cli_check_compiles_source_without_queries(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--check",
+    ])
+
+    assert status == 0
+    assert capsys.readouterr().out == "ok.\n"
+
+
+def test_cli_check_json_reports_query_counts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        ":- initialization(true). parent(homer, bart). ?- parent(homer, Who).",
+        "--check",
+        "--format",
+        "json",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert status == 0
+    assert payload == {
+        "backend": "structured",
+        "initialization_query_count": 1,
+        "initialized": True,
+        "mode": "check",
+        "source_query_count": 1,
+        "success": True,
+    }
+
+
+def test_cli_check_rejects_ad_hoc_queries(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--check",
+        "--query",
+        "parent(homer, Who)",
+    ])
+
+    assert status == 2
+    assert "--check cannot be combined with --query" in capsys.readouterr().err
+
+
 def test_cli_json_output_serializes_named_answers(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -11,6 +11,7 @@ The goal is practical usability:
 
 - run inline Prolog source through the structured VM or bytecode VM
 - run a single `.pl` file or linked file graph
+- check that source parses, loads, compiles, and initializes without a query
 - run stored source-level `?-` queries by index
 - run all stored source-level `?-` queries as an executable script
 - run one or more ad-hoc top-level queries
@@ -27,6 +28,7 @@ Important options:
 
 - `--source SOURCE` loads inline source instead of files.
 - `--query QUERY` runs an ad-hoc top-level query. It may be repeated.
+- `--check` parses, loads, compiles, and initializes without running a query.
 - `--source-query-index INDEX` selects a stored source-level query when no
   ad-hoc query is provided.
 - `--all-source-queries` runs every stored source-level query in order when no
@@ -71,6 +73,10 @@ Value = saved.
 JSON document for non-interactive scripts: a single result object for one query
 or a list of result objects for repeated queries. `--format jsonl` emits one
 JSON object per query result.
+
+When `--check` is set, JSON formats emit one success object with `mode:
+"check"`, `source_query_count`, `initialization_query_count`, `backend`, and
+whether initialization ran.
 
 When `--all-source-queries` is set, each embedded `?-` query produces one result
 object with its `source_query_index`. The process exits with status 1 if any
@@ -128,6 +134,7 @@ setup phase before entering the top-level loop.
 The CLI test coverage should prove:
 
 - inline source ad-hoc queries through bytecode
+- query-free compile/check mode
 - stored source-level queries from files
 - all source-level queries from files and inline source
 - linked project file graphs with module-context queries


### PR DESCRIPTION
## Summary
- add `prolog-vm --check` through the CLI builder spec for query-free source validation
- compile source/file/project inputs and run initialization directives by default without requiring embedded queries
- emit text or JSON check records with source/init query counts and document PR77 coverage

## Verification
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `bash BUILD` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-check -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-check-build-plan.json`