### PR TITLE
Support forward ALGOL procedure declarations

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to this package will be documented in this file.
   eval-thunk path used by integer expressions.
 - Lowered multiple builtin `print`/`output` arguments in source order through
   the existing guarded integer, boolean, real, and string output paths.
+- Lowered direct calls to sibling procedures declared later in the same block,
+  including mutually recursive typed procedures now resolved by the checker.
 - Lowered integer array-element by-name actuals to tagged descriptors with
   generated eval/store helpers that re-compute the element address on every
   formal read or assignment.

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -16,7 +16,10 @@ Calls pass an explicit static link followed by value arguments, procedure frames
 are allocated from the module frame stack, and typed procedures return through
 their procedure-name result slot. Integer and boolean procedure results flow
 through `v1`; real procedure results flow through the WASM backend's dedicated
-f64 result register, `v31`.
+f64 result register, `v31`. Because the type checker registers all procedure
+signatures in a block before checking procedure bodies, direct calls can target
+procedures declared later in the same block and typed procedures can be
+mutually recursive.
 Parameterless procedures may be declared and called with explicit empty
 parentheses, and typed procedures can still be used by bare name in expression
 positions, following ALGOL's

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1660,6 +1660,57 @@ class TestAlgolIrCompiler:
         assert calls[0].operands[0].name.startswith("_fn_algol_")
         assert result.procedure_signatures[calls[0].operands[0].name].param_count == 2
 
+    def test_compiles_forward_sibling_procedure_call(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure first; begin second end; "
+                "procedure second; begin result := 7 end; "
+                "first "
+                "end"
+            )
+        )
+        labels = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.LABEL
+        ]
+        calls = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert any(label.endswith("_first") for label in labels)
+        assert any(label.endswith("_second") for label in labels)
+        assert len(calls) == 2
+
+    def test_compiles_mutually_recursive_typed_procedures(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer procedure even(n); value n; integer n; "
+                "begin if n = 0 then even := 1 else even := odd(n - 1) end; "
+                "integer procedure odd(n); value n; integer n; "
+                "begin if n = 0 then odd := 0 else odd := even(n - 1) end; "
+                "result := odd(5) "
+                "end"
+            )
+        )
+        procedure_labels = [
+            label
+            for label in result.procedure_signatures
+            if label.startswith("_fn_algol_")
+        ]
+        call_targets = [
+            instruction.operands[0].name
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert len(procedure_labels) == 2
+        assert all(label in call_targets for label in procedure_labels)
+
     def test_compiles_boolean_value_procedure_call(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -44,6 +44,9 @@ All notable changes to this package will be documented in this file.
   printed.
 - Accepted one or more arguments to builtin `print`/`output` calls while
   keeping numeric builtins strict about receiving exactly one argument.
+- Registered all procedure signatures in a block before checking procedure
+  bodies, allowing forward sibling procedure calls and mutually recursive
+  typed procedures.
 - Accepted integer-returning procedure actuals for real-valued formal
   procedure parameters, matching scalar integer-to-real promotion.
 - Accepted switch declaration entries that target labels in lexical parent

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -31,11 +31,14 @@ static links a later WASM lowering pass must walk.
 Procedure declarations receive semantic descriptors with generated function
 labels, parameter slots, value-vs-name parameter modes, conservative by-name
 write metadata, result slots for typed procedures, and resolved call sites
-carrying the static-link delta needed by code generation. Builtin output calls
-accept one or more scalar arguments, and standard numeric functions remain
-single-argument calls. Both are resolved case-insensitively and treated as
-read-only by the write analysis, so formals that are only printed or inspected
-can still accept expression actuals.
+carrying the static-link delta needed by code generation. A block's procedure
+signatures are registered before any procedure body is checked, so sibling
+procedures can call declarations that appear later in the same block and
+typed procedures can be mutually recursive. Builtin output calls accept one or
+more scalar arguments, and standard numeric functions remain single-argument
+calls. Both are resolved case-insensitively and treated as read-only by the
+write analysis, so formals that are only printed or inspected can still accept
+expression actuals.
 No-argument procedure declarations and typed procedure expressions may use
 either explicit empty parentheses or bare procedure names, matching ALGOL's
 omitted-parentheses call syntax, while procedure result variables inside their

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -280,6 +280,18 @@ class ProcedureDescriptor:
 
 
 @dataclass(frozen=True)
+class _PendingProcedureDeclaration:
+    """A procedure signature whose body still needs semantic checking."""
+
+    procedure: ProcedureDescriptor
+    descriptor_index: int
+    proc_scope: Scope
+    body_inner: ASTNode
+    procedure_depth: int
+    parameters: tuple[ProcedureParameter, ...]
+
+
+@dataclass(frozen=True)
 class ResolvedProcedureCall:
     """A procedure occurrence after lexical lookup has selected a descriptor."""
 
@@ -556,9 +568,15 @@ class AlgolTypeChecker:
             if child.rule_name == "statement":
                 self._collect_statement_labels(child, scope)
 
+        pending_procedures: list[_PendingProcedureDeclaration] = []
         for child in _node_children(block):
             if child.rule_name == "declaration":
-                self._check_declaration(child, scope)
+                pending = self._check_declaration(child, scope)
+                if pending is not None:
+                    pending_procedures.append(pending)
+
+        for pending in pending_procedures:
+            self._check_pending_procedure_body(pending)
 
         for child in _node_children(block):
             if child.rule_name == "statement":
@@ -605,30 +623,34 @@ class AlgolTypeChecker:
         )
         return scope
 
-    def _check_declaration(self, declaration: ASTNode, scope: Scope) -> None:
+    def _check_declaration(
+        self,
+        declaration: ASTNode,
+        scope: Scope,
+    ) -> _PendingProcedureDeclaration | None:
         inner = _first_ast_child(declaration)
         if inner is None:
-            return
+            return None
         if inner.rule_name == "procedure_decl":
-            self._check_procedure_declaration(inner, scope)
-            return
+            return self._check_procedure_declaration(inner, scope)
         if inner.rule_name == "own_decl":
             self._check_scalar_declaration(inner, scope, storage_class=STATIC)
-            return
+            return None
         if inner.rule_name == "own_array_decl":
             self._check_array_declaration(inner, scope, storage_class=STATIC)
-            return
+            return None
         if inner.rule_name == "array_decl":
             self._check_array_declaration(inner, scope, storage_class="frame")
-            return
+            return None
         if inner.rule_name == "switch_decl":
             self._check_switch_declaration(inner, scope)
-            return
+            return None
         if inner.rule_name != "type_decl":
             self._error(inner, f"{inner.rule_name} declarations are not supported yet")
-            return
+            return None
 
         self._check_scalar_declaration(inner, scope, storage_class="frame")
+        return None
 
     def _check_scalar_declaration(
         self,
@@ -832,11 +854,15 @@ class AlgolTypeChecker:
             )
         )
 
-    def _check_procedure_declaration(self, node: ASTNode, scope: Scope) -> None:
+    def _check_procedure_declaration(
+        self,
+        node: ASTNode,
+        scope: Scope,
+    ) -> _PendingProcedureDeclaration | None:
         name_token = _procedure_name(node)
         if name_token is None:
             self._error(node, "procedure declaration is missing a name")
-            return
+            return None
 
         procedure_depth = self._procedure_nesting_depth + 1
         if procedure_depth > self.limits.max_procedure_nesting_depth:
@@ -845,7 +871,7 @@ class AlgolTypeChecker:
                 f"procedure nesting depth {procedure_depth} exceeds configured "
                 f"limit {self.limits.max_procedure_nesting_depth}",
             )
-            return
+            return None
 
         return_type = _procedure_return_type(node)
         if return_type is not None and return_type not in {
@@ -858,7 +884,7 @@ class AlgolTypeChecker:
                 name_token,
                 f"{return_type} procedure results are not supported yet",
             )
-            return
+            return None
 
         formal_names = _formal_parameter_names(node)
         value_names = _value_parameter_names(node)
@@ -929,13 +955,13 @@ class AlgolTypeChecker:
                 name_token,
                 f"{name_token.value!r} is already declared in this scope",
             )
-            return
+            return None
         self._next_symbol_id += 1
         self.semantic_symbols.append(procedure_symbol)
 
         if body_inner is None:
             self._error(node, "procedure declaration is missing a body")
-            return
+            return None
 
         body_depth = scope.depth + 1 if scope.depth >= 0 else 0
         if body_depth > self.limits.max_block_nesting_depth:
@@ -944,7 +970,7 @@ class AlgolTypeChecker:
                 f"block nesting depth {body_depth} exceeds configured limit "
                 f"{self.limits.max_block_nesting_depth}",
             )
-            return
+            return None
 
         proc_scope = self._new_block_scope(
             scope,
@@ -1085,20 +1111,34 @@ class AlgolTypeChecker:
         descriptor_index = len(self.semantic_procedures)
         self.semantic_procedures.append(descriptor)
 
+        return _PendingProcedureDeclaration(
+            procedure=descriptor,
+            descriptor_index=descriptor_index,
+            proc_scope=proc_scope,
+            body_inner=body_inner,
+            procedure_depth=procedure_depth,
+            parameters=tuple(parameters),
+        )
+
+    def _check_pending_procedure_body(
+        self,
+        pending: _PendingProcedureDeclaration,
+    ) -> None:
+        descriptor = pending.procedure
         previous_procedure_depth = self._procedure_nesting_depth
-        self._procedure_nesting_depth = procedure_depth
+        self._procedure_nesting_depth = pending.procedure_depth
         try:
-            if body_inner.rule_name == "block":
-                self._check_block_contents(body_inner, proc_scope)
+            if pending.body_inner.rule_name == "block":
+                self._check_block_contents(pending.body_inner, pending.proc_scope)
             else:
-                self._collect_statement_labels(body_inner, proc_scope)
-                self._check_statement(body_inner, proc_scope)
+                self._collect_statement_labels(pending.body_inner, pending.proc_scope)
+                self._check_statement(pending.body_inner, pending.proc_scope)
             updated_parameters = tuple(
                 self._procedure_parameter_with_call_shapes(parameter)
-                for parameter in parameters
+                for parameter in pending.parameters
             )
             if updated_parameters != descriptor.parameters:
-                self.semantic_procedures[descriptor_index] = ProcedureDescriptor(
+                updated_descriptor = ProcedureDescriptor(
                     procedure_id=descriptor.procedure_id,
                     name=descriptor.name,
                     label=descriptor.label,
@@ -1110,6 +1150,7 @@ class AlgolTypeChecker:
                     line=descriptor.line,
                     column=descriptor.column,
                 )
+                self.semantic_procedures[pending.descriptor_index] = updated_descriptor
         finally:
             self._procedure_nesting_depth = previous_procedure_depth
 

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -934,6 +934,63 @@ class TestAlgolTypeChecker:
         assert body_block.scope.symbols["inc"].kind == "procedure_result"
         assert body_block.scope.symbols["x"].kind == "parameter"
 
+    def test_procedure_body_can_call_later_sibling_procedure(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure first; begin second end; "
+            "procedure second; begin result := 7 end; "
+            "first "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        calls = [call.name for call in result.semantic.procedure_calls]
+        assert calls == ["second", "first"]
+
+    def test_procedure_body_can_reference_later_block_declarations(self) -> None:
+        ast = parse_algol(
+            "begin "
+            "procedure set; begin result := 7 end; "
+            "integer result; "
+            "switch route := done; "
+            "procedure jump; begin goto route[1] end; "
+            "set; jump; "
+            "done: result := result + 1 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        references = {(ref.name, ref.role) for ref in result.semantic.references}
+        assert ("result", "write") in references
+        assert result.semantic.switch_selections[0].name == "route"
+
+    def test_accepts_mutually_recursive_typed_procedures(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer procedure even(n); value n; integer n; "
+            "begin if n = 0 then even := 1 else even := odd(n - 1) end; "
+            "integer procedure odd(n); value n; integer n; "
+            "begin if n = 0 then odd := 0 else odd := even(n - 1) end; "
+            "result := odd(5) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert [procedure.name for procedure in result.semantic.procedures] == [
+            "even",
+            "odd",
+        ]
+        assert {call.name for call in result.semantic.procedure_calls} == {
+            "even",
+            "odd",
+        }
+
     def test_accepts_bare_no_argument_typed_procedure_expression(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -89,6 +89,9 @@ All notable changes to this package will be documented in this file.
 - Accepted multiple arguments to builtin `print(...)` / `output(...)`, emitting
   each integer, boolean, real, or string argument in order through the same
   guarded output path.
+- Executed forward sibling procedure calls and mutually recursive typed
+  procedures by registering a block's procedure signatures before checking any
+  procedure body.
 - Executed subscripted integer and real array elements as writable `for`
   statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -38,6 +38,8 @@ the current lane already supports a substantial ALGOL 60 surface:
 - label, switch, and procedure formals in value or by-name mode
 - explicit empty and bare no-argument procedure declarations/calls, matching
   ALGOL's omitted-parentheses call syntax for parameterless procedures
+- forward sibling procedure calls and mutually recursive typed procedures
+  within a block's declaration part
 - labels, local and nonlocal `goto`/`go to`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   recursive switch entries
@@ -176,8 +178,9 @@ local WASM runtime. Those fixtures cover:
   forms, parenthesized conditional designational expressions, numeric labels,
   boolean operators, real arithmetic, and output
 - a surface-audit matrix for publication notation, procedure-call spellings,
-  loop forms, typed formal procedures, value array copies, nonlocal switch/goto
-  cleanup, and programs without the `result` compatibility scalar
+  forward procedure visibility, loop forms, typed formal procedures, value
+  array copies, nonlocal switch/goto cleanup, and programs without the
+  `result` compatibility scalar
 
 ## Dependencies
 

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1801,6 +1801,29 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [6]
 
+    def test_forward_sibling_procedure_call_executes(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure first; begin second end; "
+            "procedure second; begin result := 7 end; "
+            "first "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
+    def test_procedure_body_sees_later_block_declarations(self) -> None:
+        result = compile_source(
+            "begin "
+            "procedure set; begin result := 7 end; "
+            "integer result; "
+            "switch route := done; "
+            "procedure jump; begin goto route[1] end; "
+            "set; jump; "
+            "done: result := result + 1 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [8]
+
     def test_value_parameter_assignment_does_not_write_back(self) -> None:
         result = compile_source(
             "begin integer result, y; "
@@ -2374,6 +2397,18 @@ class TestAlgolWasmCompiler:
             "end"
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [120]
+
+    def test_mutually_recursive_typed_procedures_execute(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer procedure even(n); value n; integer n; "
+            "begin if n = 0 then even := 1 else even := odd(n - 1) end; "
+            "integer procedure odd(n); value n; integer n; "
+            "begin if n = 0 then odd := 0 else odd := even(n - 1) end; "
+            "result := odd(5) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [1]
 
     def test_runaway_recursion_hits_bounded_frame_stack(self) -> None:
         result = compile_source(

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -52,6 +52,23 @@ _SURFACE_CASES = (
         result=[8],
     ),
     SurfaceCase(
+        name="forward-procedure-declaration-visibility",
+        source="""
+            begin
+              procedure first; begin second end;
+              integer result;
+              switch route := done;
+              procedure second; begin result := 12; goto route[1] end;
+              first;
+              result := 0;
+            done:
+              print('FORWARD ', result)
+            end
+        """,
+        result=[12],
+        stdout="FORWARD 12",
+    ),
+    SurfaceCase(
         name="for-list-scalar-and-array-control",
         source="""
             begin


### PR DESCRIPTION
## Summary
- register a block's ALGOL procedure signatures before checking any procedure bodies
- allow procedure bodies to call sibling procedures declared later in the same block and support mutually recursive typed procedures
- add type-checker, IR, WASM, and surface-audit coverage for forward procedure visibility and later block declarations

## Tests
- bash BUILD (code/packages/python/algol-type-checker)
- bash BUILD (code/packages/python/algol-ir-compiler)
- bash BUILD (code/packages/python/algol-wasm-compiler)
- ../algol-wasm-compiler/.venv/bin/python -m ruff check src/algol_type_checker/checker.py tests/test_algol_type_checker.py ../algol-ir-compiler/tests/test_algol_ir_compiler.py ../algol-wasm-compiler/tests/test_algol_wasm_compiler.py ../algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
- git diff --check

## Security review
- scanned touched code, tests, and docs for subprocess, shell execution, eval/exec, unsafe serialization, networking, file deletion, and permission-changing APIs; no matches