### PR TITLE
feat(prolog): list CLI source queries

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -278,6 +278,10 @@ Use `--check` to parse, load, compile, and initialize source without running a
 query. This is intended for CI and editor integrations that need to validate a
 Prolog file graph even when it does not contain embedded `?-` directives.
 
+Use `--list-source-queries` to inspect embedded `?-` directives before choosing
+what to run. Text output lists the zero-based query index and visible variables;
+JSON output emits the same metadata as a stable `source_queries` record.
+
 Use `--all-source-queries` when a source file contains several embedded `?-`
 queries and the CLI should run them as a script. The command prints or emits
 one result record per source query, sets `source_query_index` in JSON formats,

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -59,6 +59,7 @@ class CliArgs:
     source: str | None
     queries: tuple[str, ...]
     check: bool
+    list_source_queries: bool
     source_query_index: int
     all_source_queries: bool
     query_module: str | None
@@ -146,6 +147,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     all_source_queries = bool(flags["all-source-queries"])
     check = bool(flags["check"])
+    list_source_queries = bool(flags["list-source-queries"])
     if check and queries:
         msg = "--check cannot be combined with --query"
         raise ValueError(msg)
@@ -154,6 +156,18 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if check and bool(flags["interactive"]):
         msg = "--check cannot be combined with --interactive"
+        raise ValueError(msg)
+    if list_source_queries and queries:
+        msg = "--list-source-queries cannot be combined with --query"
+        raise ValueError(msg)
+    if list_source_queries and all_source_queries:
+        msg = "--list-source-queries cannot be combined with --all-source-queries"
+        raise ValueError(msg)
+    if list_source_queries and check:
+        msg = "--list-source-queries cannot be combined with --check"
+        raise ValueError(msg)
+    if list_source_queries and bool(flags["interactive"]):
+        msg = "--list-source-queries cannot be combined with --interactive"
         raise ValueError(msg)
     if all_source_queries and queries:
         msg = "--all-source-queries cannot be combined with --query"
@@ -167,6 +181,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         source=source,
         queries=queries,
         check=check,
+        list_source_queries=list_source_queries,
         source_query_index=source_query_index,
         all_source_queries=all_source_queries,
         query_module=query_module,
@@ -306,6 +321,8 @@ def _required_int(value: object, *, name: str) -> int:
 def _run_cli(args: CliArgs) -> int:
     if args.check:
         return _run_check(args)
+    if args.list_source_queries:
+        return _run_list_source_queries(args)
 
     if args.queries or args.interactive:
         runtime = _create_runtime(args)
@@ -343,6 +360,46 @@ def _run_check(args: CliArgs) -> int:
         run_compiled_prolog_initializations(compiled_program, backend=args.backend)
     _print_check_record(compiled_program, args=args)
     return 0
+
+
+def _run_list_source_queries(args: CliArgs) -> int:
+    compiled_program = _compile_source_program(args)
+    _print_source_query_summary(compiled_program, args=args)
+    return 0
+
+
+def _print_source_query_summary(
+    compiled_program: CompiledPrologVMProgram,
+    *,
+    args: CliArgs,
+    stdout: TextIO | None = None,
+) -> None:
+    output = sys.stdout if stdout is None else stdout
+    query_summaries = [
+        {
+            "index": index,
+            "variables": list(compiled_program.source_query_variable_names(index)),
+        }
+        for index in range(compiled_program.source_query_count)
+    ]
+
+    if args.output_format == "text":
+        if not query_summaries:
+            print("no source queries.", file=output)
+            return
+        for query in query_summaries:
+            variables = cast("list[str]", query["variables"])
+            variable_text = ", ".join(variables) if variables else "(no variables)"
+            print(f"query {query['index']}: {variable_text}", file=output)
+        return
+
+    payload = {
+        "success": True,
+        "mode": "source_queries",
+        "source_query_count": compiled_program.source_query_count,
+        "queries": query_summaries,
+    }
+    print(json.dumps(payload, sort_keys=True), file=output)
 
 
 def _print_check_record(

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
@@ -31,6 +31,12 @@
       "type": "boolean"
     },
     {
+      "id": "list-source-queries",
+      "long": "list-source-queries",
+      "description": "List embedded source-level ?- queries without running them.",
+      "type": "boolean"
+    },
+    {
       "id": "source-query-index",
       "long": "source-query-index",
       "description": "Zero-based source-level ?- query index to run when --query is absent.",

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -103,6 +103,63 @@ def test_cli_check_rejects_ad_hoc_queries(
     assert "--check cannot be combined with --query" in capsys.readouterr().err
 
 
+def test_cli_lists_source_query_variables(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who). ?- true.",
+        "--list-source-queries",
+    ])
+
+    assert status == 0
+    assert capsys.readouterr().out.splitlines() == [
+        "query 0: Who",
+        "query 1: (no variables)",
+    ]
+
+
+def test_cli_lists_source_query_variables_as_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        "--list-source-queries",
+        "--format",
+        "json",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert status == 0
+    assert payload == {
+        "mode": "source_queries",
+        "queries": [
+            {"index": 0, "variables": ["Who"]},
+        ],
+        "source_query_count": 1,
+        "success": True,
+    }
+
+
+def test_cli_list_source_queries_rejects_execution_modes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--list-source-queries",
+        "--query",
+        "parent(homer, Who)",
+    ])
+
+    assert status == 2
+    assert "--list-source-queries cannot be combined with --query" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_json_output_serializes_named_answers(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -12,6 +12,7 @@ The goal is practical usability:
 - run inline Prolog source through the structured VM or bytecode VM
 - run a single `.pl` file or linked file graph
 - check that source parses, loads, compiles, and initializes without a query
+- list embedded source-level `?-` query indexes and visible variables
 - run stored source-level `?-` queries by index
 - run all stored source-level `?-` queries as an executable script
 - run one or more ad-hoc top-level queries
@@ -29,6 +30,8 @@ Important options:
 - `--source SOURCE` loads inline source instead of files.
 - `--query QUERY` runs an ad-hoc top-level query. It may be repeated.
 - `--check` parses, loads, compiles, and initializes without running a query.
+- `--list-source-queries` lists embedded `?-` query indexes and visible
+  variables without running them.
 - `--source-query-index INDEX` selects a stored source-level query when no
   ad-hoc query is provided.
 - `--all-source-queries` runs every stored source-level query in order when no
@@ -77,6 +80,10 @@ JSON object per query result.
 When `--check` is set, JSON formats emit one success object with `mode:
 "check"`, `source_query_count`, `initialization_query_count`, `backend`, and
 whether initialization ran.
+
+When `--list-source-queries` is set, JSON formats emit one success object with
+`mode: "source_queries"`, `source_query_count`, and a `queries` list containing
+zero-based `index` and visible `variables` metadata for each embedded query.
 
 When `--all-source-queries` is set, each embedded `?-` query produces one result
 object with its `source_query_index`. The process exits with status 1 if any
@@ -135,6 +142,7 @@ The CLI test coverage should prove:
 
 - inline source ad-hoc queries through bytecode
 - query-free compile/check mode
+- source query listing without execution
 - stored source-level queries from files
 - all source-level queries from files and inline source
 - linked project file graphs with module-context queries


### PR DESCRIPTION
## Summary
- add `prolog-vm --list-source-queries` through the CLI builder spec
- list embedded `?-` query indexes and visible variables without executing source queries or initialization
- document PR77 metadata output and add text/JSON validation coverage

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-summary -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-summary-build-plan.json`