### PR TITLE
Refine forward ALGOL by-name write analysis

### DIFF
--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1711,6 +1711,25 @@ class TestAlgolIrCompiler:
         assert len(procedure_labels) == 2
         assert all(label in call_targets for label in procedure_labels)
 
+    def test_compiles_forward_read_only_by_name_expression_actual(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "procedure relay(x); integer x; begin emit(x) end; "
+                "procedure emit(y); integer y; begin result := y end; "
+                "relay(3 + 4) "
+                "end"
+            )
+        )
+        calls = [
+            instruction
+            for instruction in result.program.instructions
+            if instruction.opcode == IrOp.CALL
+        ]
+
+        assert len(calls) >= 2
+        assert "_fn_algol_eval_thunk" in result.procedure_signatures
+
     def test_compiles_boolean_value_procedure_call(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -288,7 +288,8 @@ class _PendingProcedureDeclaration:
     proc_scope: Scope
     body_inner: ASTNode
     procedure_depth: int
-    parameters: tuple[ProcedureParameter, ...]
+    formal_names: tuple[Token, ...]
+    value_names: frozenset[str]
 
 
 @dataclass(frozen=True)
@@ -574,6 +575,8 @@ class AlgolTypeChecker:
                 pending = self._check_declaration(child, scope)
                 if pending is not None:
                     pending_procedures.append(pending)
+
+        self._resolve_pending_procedure_write_reasons(pending_procedures)
 
         for pending in pending_procedures:
             self._check_pending_procedure_body(pending)
@@ -891,14 +894,6 @@ class AlgolTypeChecker:
         parameter_specs = _parameter_specs(node)
         body = _first_direct_node(node, "proc_body")
         body_inner = _first_ast_child(body) if body is not None else None
-        known_procedures = _unique_procedure_names(self.semantic_procedures)
-        write_reasons = _by_name_formal_write_reasons(
-            body_inner,
-            formal_names,
-            value_names,
-            known_procedures,
-            name_token.value,
-        )
         for formal in formal_names:
             mode = VALUE if formal.value in value_names else NAME
             parameter_spec = parameter_specs.get(formal.value, _ParameterSpec())
@@ -1083,16 +1078,8 @@ class AlgolTypeChecker:
                         symbol_id=param_symbol.symbol_id,
                         slot_offset=param_symbol.slot_offset,
                         kind=parameter_kind,
-                        may_write=(
-                            formal.value in write_reasons
-                            if parameter_kind == "scalar"
-                            else False
-                        ),
-                        write_reason=(
-                            write_reasons.get(formal.value)
-                            if parameter_kind == "scalar"
-                            else None
-                        ),
+                        may_write=False,
+                        write_reason=None,
                     )
                 )
 
@@ -1117,17 +1104,85 @@ class AlgolTypeChecker:
             proc_scope=proc_scope,
             body_inner=body_inner,
             procedure_depth=procedure_depth,
-            parameters=tuple(parameters),
+            formal_names=tuple(formal_names),
+            value_names=frozenset(value_names),
+        )
+
+    def _resolve_pending_procedure_write_reasons(
+        self,
+        pending_procedures: list[_PendingProcedureDeclaration],
+    ) -> None:
+        changed = True
+        while changed:
+            changed = False
+            known_procedures = _unique_procedure_names(self.semantic_procedures)
+            for pending in pending_procedures:
+                descriptor = self.semantic_procedures[pending.descriptor_index]
+                write_reasons = _by_name_formal_write_reasons(
+                    pending.body_inner,
+                    list(pending.formal_names),
+                    set(pending.value_names),
+                    known_procedures,
+                    descriptor.name,
+                )
+                updated_parameters = tuple(
+                    self._procedure_parameter_with_write_reason(
+                        parameter,
+                        write_reasons,
+                    )
+                    for parameter in descriptor.parameters
+                )
+                if updated_parameters != descriptor.parameters:
+                    self.semantic_procedures[pending.descriptor_index] = (
+                        ProcedureDescriptor(
+                            procedure_id=descriptor.procedure_id,
+                            name=descriptor.name,
+                            label=descriptor.label,
+                            declaring_block_id=descriptor.declaring_block_id,
+                            body_block_id=descriptor.body_block_id,
+                            body_node_id=descriptor.body_node_id,
+                            return_type=descriptor.return_type,
+                            parameters=updated_parameters,
+                            line=descriptor.line,
+                            column=descriptor.column,
+                        )
+                    )
+                    changed = True
+
+    def _procedure_parameter_with_write_reason(
+        self,
+        parameter: ProcedureParameter,
+        write_reasons: dict[str, str],
+    ) -> ProcedureParameter:
+        if parameter.kind != "scalar":
+            return parameter
+        write_reason = write_reasons.get(parameter.name)
+        may_write = write_reason is not None
+        if (
+            parameter.may_write == may_write
+            and parameter.write_reason == write_reason
+        ):
+            return parameter
+        return ProcedureParameter(
+            name=parameter.name,
+            type_name=parameter.type_name,
+            mode=parameter.mode,
+            symbol_id=parameter.symbol_id,
+            slot_offset=parameter.slot_offset,
+            kind=parameter.kind,
+            may_write=may_write,
+            write_reason=write_reason,
+            procedure_call_shapes=parameter.procedure_call_shapes,
         )
 
     def _check_pending_procedure_body(
         self,
         pending: _PendingProcedureDeclaration,
     ) -> None:
-        descriptor = pending.procedure
         previous_procedure_depth = self._procedure_nesting_depth
         self._procedure_nesting_depth = pending.procedure_depth
         try:
+            descriptor = self.semantic_procedures[pending.descriptor_index]
             if pending.body_inner.rule_name == "block":
                 self._check_block_contents(pending.body_inner, pending.proc_scope)
             else:
@@ -1135,7 +1190,7 @@ class AlgolTypeChecker:
                 self._check_statement(pending.body_inner, pending.proc_scope)
             updated_parameters = tuple(
                 self._procedure_parameter_with_call_shapes(parameter)
-                for parameter in pending.parameters
+                for parameter in descriptor.parameters
             )
             if updated_parameters != descriptor.parameters:
                 updated_descriptor = ProcedureDescriptor(

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -991,6 +991,38 @@ class TestAlgolTypeChecker:
             "odd",
         }
 
+    def test_forward_read_only_callee_keeps_by_name_formal_read_only(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure relay(x); integer x; begin emit(x) end; "
+            "procedure emit(y); integer y; begin print(y); result := y end; "
+            "relay(3 + 4) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        relay = result.semantic.procedures[0]
+        assert relay.parameters[0].name == "x"
+        assert not relay.parameters[0].may_write
+
+    def test_forward_writing_callee_marks_by_name_formal_writable(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "procedure relay(x); integer x; begin set(x) end; "
+            "procedure set(y); integer y; begin y := 9 end; "
+            "relay(3 + 4) "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert result.semantic is not None
+        relay = result.semantic.procedures[0]
+        assert relay.parameters[0].may_write
+        assert "by-name parameter 'x' is assigned" in result.diagnostics[0].message
+
     def test_accepts_bare_no_argument_typed_procedure_expression(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1811,6 +1811,16 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_forward_read_only_by_name_callee_accepts_expression_actual(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "procedure relay(x); integer x; begin emit(x) end; "
+            "procedure emit(y); integer y; begin result := y end; "
+            "relay(3 + 4) "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
     def test_procedure_body_sees_later_block_declarations(self) -> None:
         result = compile_source(
             "begin "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -69,6 +69,20 @@ _SURFACE_CASES = (
         stdout="FORWARD 12",
     ),
     SurfaceCase(
+        name="forward-read-only-by-name-expression-actual",
+        source="""
+            begin
+              integer result;
+              procedure relay(x); integer x; begin emit(x) end;
+              procedure emit(y); integer y; begin result := y end;
+              relay(3 + 4);
+              print(result)
+            end
+        """,
+        result=[7],
+        stdout="7",
+    ),
+    SurfaceCase(
         name="for-list-scalar-and-array-control",
         source="""
             begin


### PR DESCRIPTION
Summary:
- Recompute pending procedure by-name write metadata after all sibling procedure signatures are registered.
- Preserve read-only expression actuals when an earlier procedure calls a later read-only by-name procedure.
- Add type-checker, IR, WASM runtime, and surface-audit coverage for the forward read-only by-name case.

Tests:
- bash BUILD in code/packages/python/algol-type-checker
- bash BUILD in code/packages/python/algol-ir-compiler
- bash BUILD in code/packages/python/algol-wasm-compiler
- ruff check on touched files
- git diff --check

Security:
- Scanned touched files for process execution, eval/exec, network/file mutation APIs; only match was an existing test name containing eval.