### PR TITLE
Add tokenizer state lookup helpers

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -221,3 +221,6 @@ documented in this file.
   `HtmlTokenizerState::is_fragment_state()` so parser and fixture importers can
   enumerate the full typed tokenizer-context surface without copying state
   lists out of the lexer crate.
+- Added `HtmlTokenizerState::from_machine_state()` and
+  `HtmlTokenizerState::from_fragment_machine_state()` so parser/conformance code
+  can map generated machine-state identifiers back into typed tokenizer states.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -167,7 +167,11 @@ For importers and parser fragment APIs that need to enumerate the whole
 supported surface, `HTML_TOKENIZER_STATES` lists every parser-facing tokenizer
 entry state and `HTML_FRAGMENT_TOKENIZER_STATES` lists the non-data fragment
 states accepted by the wrapper. `HtmlTokenizerState::is_fragment_state()` keeps
-that validation centralized in the lexer package.
+that validation centralized in the lexer package. Code that starts from
+generated machine-state identifiers can use
+`HtmlTokenizerState::from_machine_state(...)` or
+`HtmlTokenizerState::from_fragment_machine_state(...)` to round-trip back to the
+typed API without copying raw state strings.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -111,6 +111,19 @@ impl HtmlTokenizerState {
         }
     }
 
+    /// Return the typed tokenizer state for a generated machine-state identifier.
+    pub fn from_machine_state(machine_state: &str) -> Option<Self> {
+        HTML_TOKENIZER_STATES
+            .iter()
+            .copied()
+            .find(|state| state.as_machine_state() == machine_state)
+    }
+
+    /// Return the typed fragment state for a generated machine-state identifier.
+    pub fn from_fragment_machine_state(machine_state: &str) -> Option<Self> {
+        Self::from_machine_state(machine_state).filter(|state| state.is_fragment_state())
+    }
+
     /// Return whether this state is a parser-approved script tokenizer substate.
     pub fn is_script_substate(self) -> bool {
         HTML_SCRIPT_TOKENIZER_STATES.contains(&self)

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -4483,6 +4483,30 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
     );
     assert!(!HtmlTokenizerState::Data.is_fragment_state());
 
+    for state in HTML_TOKENIZER_STATES {
+        assert_eq!(
+            HtmlTokenizerState::from_machine_state(state.as_machine_state()),
+            Some(state)
+        );
+    }
+    assert_eq!(
+        HtmlTokenizerState::from_machine_state("script data state"),
+        None
+    );
+    assert_eq!(HtmlTokenizerState::from_machine_state("bogus"), None);
+    assert_eq!(
+        HtmlTokenizerState::from_fragment_machine_state("data"),
+        None
+    );
+    assert_eq!(
+        HtmlTokenizerState::from_fragment_machine_state("rcdata"),
+        Some(HtmlTokenizerState::Rcdata)
+    );
+    assert_eq!(
+        HtmlTokenizerState::from_fragment_machine_state("script_data_escaped_dash_dash"),
+        Some(HtmlTokenizerState::ScriptDataEscapedDashDash)
+    );
+
     assert_eq!(&HTML_FRAGMENT_TOKENIZER_STATES, &HTML_TOKENIZER_STATES[1..]);
     for state in HTML_FRAGMENT_TOKENIZER_STATES {
         assert!(state.is_fragment_state());


### PR DESCRIPTION
## Summary
- Add `HtmlTokenizerState::from_machine_state(...)` for typed reverse lookup from generated machine-state identifiers.
- Add `HtmlTokenizerState::from_fragment_machine_state(...)` for parser/fixture importer validation of non-data fragment contexts.
- Extend parser-facing lexer tests and docs so state-set enumeration round-trips without copying raw strings.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check