### PR TITLE
feat(cas-matrix, symbolic-vm): Phase 19 — linear algebra completion (0.3.0 / 0.39.0)

### DIFF
--- a/code/packages/python/cas-matrix/BUILD
+++ b/code/packages/python/cas-matrix/BUILD
@@ -1,3 +1,3 @@
 uv venv --quiet --clear
-uv pip install -e ../symbolic-ir -e ".[dev]" --quiet
+uv pip install -e ../symbolic-ir -e ../cas-solve -e ".[dev]" --quiet
 .venv/bin/python -m pytest tests/ -v --tb=short

--- a/code/packages/python/cas-matrix/CHANGELOG.md
+++ b/code/packages/python/cas-matrix/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 0.3.0 — 2026-05-04
+
+**Phase 19 — Linear algebra completion: eigenvalues, eigenvectors, char poly,
+LU decomposition, null/col/row spaces, and matrix norms.**
+
+New module ``eigenvalues.py``:
+
+- ``char_poly_coeffs(M)`` — returns coefficients of ``det(λI − A)`` as a
+  ``list[Fraction]`` in ascending-power order.  Uses polynomial-valued
+  cofactor expansion with exact ``Fraction`` arithmetic throughout.
+- ``charpoly(M, lam)`` — same, but returns the polynomial as an IR expression
+  tree in the symbol ``lam``.
+- ``eigenvalues(M)`` — returns ``List(List(λ₁, m₁), List(λ₂, m₂), …)`` where
+  each inner ``List`` is the eigenvalue and its algebraic multiplicity.
+  Dispatches to ``cas-solve`` for linear (1×1) through quartic (4×4);
+  raises ``MatrixError`` for n > 4.  Multiplicity is determined via the
+  derivative test on the characteristic polynomial.  Complex conjugate pairs
+  are correctly distinguished using Python complex arithmetic.
+- ``eigenvectors(M)`` — returns ``List(List(λ, m, List(v₁, …)), …)``.
+  Exact null-space basis vectors are provided for rational eigenvalues;
+  complex or irrational eigenvalues yield an empty ``List()`` for their
+  vector group.
+
+New module ``subspaces.py``:
+
+- ``nullspace(M)`` — ``List(v₁, v₂, …)`` of n×1 column-vector bases for
+  the null space of M.  Returns ``List()`` for full column-rank matrices.
+- ``columnspace(M)`` — ``List(c₁, c₂, …)`` of m×1 column-vector bases,
+  taken from the pivot columns of the original matrix (not the RREF).
+- ``rowspace(M)`` — ``List(r₁, r₂, …)`` of 1×n row-vector bases, taken
+  from the non-zero rows of the RREF.
+
+New module ``lu.py``:
+
+- ``lu_decompose(M)`` — Doolittle LU with partial pivoting.  Returns
+  ``List(L, U, P)`` where ``P·M = L·U``.  L is unit lower-triangular, U
+  is upper-triangular, P is a permutation matrix.  Exact ``Fraction``
+  arithmetic throughout.  Raises ``MatrixError`` for non-square, singular,
+  or symbolic input.
+
+New module ``norms.py``:
+
+- ``norm(M)`` — Euclidean (L²) norm of a column or row vector.  Raises
+  ``MatrixError`` for a non-vector matrix (use the ``"frobenius"`` flag).
+- ``norm(M, "frobenius")`` — Frobenius norm of any matrix.  Returns an
+  exact ``IRInteger`` / ``IRRational`` when the sum of squares is a perfect
+  rational square; otherwise returns ``IRApply(SQRT, (sum_of_squares,))``.
+
+New IR head sentinels in ``heads.py``:
+
+- ``EIGENVALUES``, ``EIGENVECTORS``, ``CHARPOLY``
+- ``LU``, ``NULLSPACE``, ``COLUMNSPACE``, ``ROWSPACE``
+- ``NORM``
+
+All new functions and sentinels are re-exported from the package root.
+
+Dependency added: ``coding-adventures-cas-solve>=0.6.0`` (used by
+``eigenvalues()`` to solve the characteristic polynomial).
+
+---
+
 ## 0.2.0 — 2026-04-28
 
 **Group E — Row reduction and rank for numeric matrices.**

--- a/code/packages/python/cas-matrix/pyproject.toml
+++ b/code/packages/python/cas-matrix/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-matrix"
-version = "0.2.0"
-description = "First-class symbolic matrices for the symbolic IR — Matrix, Dot, Transpose, Determinant, Inverse, Rank, RowReduce."
+version = "0.3.0"
+description = "First-class symbolic matrices for the symbolic IR — eigenvalues, eigenvectors, char poly, LU decomp, null/col/row spaces, norms, and core matrix ops."
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
@@ -13,6 +13,7 @@ readme = "README.md"
 keywords = ["cas", "matrix", "linear-algebra", "symbolic", "ir", "education"]
 dependencies = [
     "coding-adventures-symbolic-ir>=0.5.0",
+    "coding-adventures-cas-solve>=0.6.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/cas-matrix/src/cas_matrix/__init__.py
+++ b/code/packages/python/cas-matrix/src/cas_matrix/__init__.py
@@ -10,6 +10,20 @@ Quick start::
     determinant(M)  # un-simplified IR; pass through cas_simplify to reduce
     rank(M)         # IRInteger(2)
     row_reduce(M)   # identity matrix (RREF)
+
+Phase 19 additions::
+
+    from cas_matrix import (
+        eigenvalues, eigenvectors, charpoly,
+        lu_decompose, nullspace, columnspace, rowspace, norm,
+    )
+
+    A = matrix([[IRInteger(1), IRInteger(2)],
+                [IRInteger(2), IRInteger(1)]])
+    eigenvalues(A)   # List(List(-1, 1), List(3, 1))
+    eigenvectors(A)  # List(List(-1, 1, List(v1)), List(3, 1, List(v2)))
+    lu_decompose(A)  # List(L, U, P) — Doolittle with partial pivoting
+    nullspace(A)     # List() — A has full rank
 """
 
 from cas_matrix.arithmetic import (
@@ -23,20 +37,30 @@ from cas_matrix.arithmetic import (
     zero_matrix,
 )
 from cas_matrix.determinant import determinant, inverse
+from cas_matrix.eigenvalues import char_poly_coeffs, charpoly, eigenvalues, eigenvectors
 from cas_matrix.heads import (
+    CHARPOLY,
+    COLUMNSPACE,
     DETERMINANT,
     DIMENSIONS,
     DOT,
+    EIGENVALUES,
+    EIGENVECTORS,
     IDENTITY_MATRIX,
     INVERSE,
     LIST,
+    LU,
     MATRIX,
+    NORM,
+    NULLSPACE,
     RANK,
     ROW_REDUCE,
+    ROWSPACE,
     TRACE,
     TRANSPOSE,
     ZERO_MATRIX,
 )
+from cas_matrix.lu import lu_decompose
 from cas_matrix.matrix import (
     MatrixError,
     dimensions,
@@ -46,38 +70,67 @@ from cas_matrix.matrix import (
     num_cols,
     num_rows,
 )
+from cas_matrix.norms import norm
 from cas_matrix.rowreduce import rank, row_reduce
+from cas_matrix.subspaces import columnspace, nullspace, rowspace
 
 __all__ = [
+    # Heads
+    "CHARPOLY",
+    "COLUMNSPACE",
     "DETERMINANT",
     "DIMENSIONS",
     "DOT",
+    "EIGENVALUES",
+    "EIGENVECTORS",
     "IDENTITY_MATRIX",
     "INVERSE",
     "LIST",
+    "LU",
     "MATRIX",
-    "MatrixError",
+    "NORM",
+    "NULLSPACE",
     "RANK",
     "ROW_REDUCE",
+    "ROWSPACE",
     "TRACE",
     "TRANSPOSE",
     "ZERO_MATRIX",
-    "add_matrices",
-    "determinant",
+    # Errors
+    "MatrixError",
+    # Construction / query
     "dimensions",
-    "dot",
     "get_entry",
     "identity_matrix",
-    "inverse",
     "is_matrix",
     "matrix",
     "num_cols",
     "num_rows",
-    "rank",
-    "row_reduce",
+    "zero_matrix",
+    # Arithmetic
+    "add_matrices",
+    "dot",
     "scalar_multiply",
     "sub_matrices",
     "trace",
     "transpose",
-    "zero_matrix",
+    # Determinant / inverse
+    "determinant",
+    "inverse",
+    # Row operations
+    "rank",
+    "row_reduce",
+    # Phase 19 — eigenvalues / eigenvectors / charpoly
+    "char_poly_coeffs",
+    "charpoly",
+    "eigenvalues",
+    "eigenvectors",
+    # Phase 19 — LU
+    "lu_decompose",
+    # Phase 19 — subspaces
+    "columnspace",
+    "nullspace",
+    "rowspace",
+    # Phase 19 — norm
+    "norm",
 ]

--- a/code/packages/python/cas-matrix/src/cas_matrix/eigenvalues.py
+++ b/code/packages/python/cas-matrix/src/cas_matrix/eigenvalues.py
@@ -1,0 +1,888 @@
+"""Eigenvalues, eigenvectors, and characteristic polynomial.
+
+This module implements three closely related operations for square
+matrices with rational entries.
+
+Characteristic polynomial
+-------------------------
+The characteristic polynomial of an n×n matrix A is:
+
+    charpoly(A, λ) = det(λI − A)
+
+It is a monic polynomial of degree n whose roots are exactly the
+eigenvalues of A (with multiplicity).
+
+Algorithm
+~~~~~~~~~
+Each entry of the matrix (λI − A) is a *polynomial in λ*:
+
+- Diagonal position (i, i): ``λ − aᵢᵢ``  →  coefficients ``[−aᵢᵢ, 1]``
+- Off-diagonal (i, j):       ``−aᵢⱼ``    →  coefficients ``[−aᵢⱼ]``
+
+Polynomials are represented as ``list[Fraction]`` in ascending power
+order: ``p[k]`` is the coefficient of ``λ^k``.
+
+The determinant is computed by the same cofactor expansion used by
+:mod:`cas_matrix.determinant`, but now operating on polynomial-valued
+entries rather than IR nodes.  The result is a list of Fraction
+coefficients.
+
+Eigenvalues
+-----------
+Once the characteristic polynomial ``c₀ + c₁λ + … + cₙλⁿ = 0`` is in
+hand, its roots give the eigenvalues.  We delegate root-finding to
+``cas_solve``:
+
+- n = 1: ``solve_linear``
+- n = 2: ``solve_quadratic``
+- n = 3: ``solve_cubic``
+- n = 4: ``solve_quartic``
+- n > 4: return ``None`` (unevaluated; numerical root-finding not in scope)
+
+The return format matches MACSYMA's ``eigenvalues`` output:
+``List(List(λ₁, m₁), List(λ₂, m₂), …)`` where ``mᵢ`` is the
+algebraic multiplicity.
+
+Multiplicities are computed by comparing eigenvalue IR nodes numerically
+at a single test point (same strategy used in cas-ode's exactness check).
+Two eigenvalues are considered equal when their floating-point
+evaluations agree to within ``1e-9``.
+
+Eigenvectors
+------------
+For each eigenvalue λᵢ:
+
+1. If λᵢ can be evaluated to a Fraction (i.e., it is ``IRInteger`` or
+   ``IRRational``): form the matrix B = A − λᵢI, run RREF, extract the
+   null-space basis.
+2. Otherwise (irrational / complex eigenvalue): return ``List()`` for
+   that eigenvalue's vector list — symbolic null-space computation is
+   out of scope for Phase 19.
+
+The null-space basis is computed from the RREF:
+
+- Free columns = non-pivot columns.
+- For each free column j: build a vector v where v[j]=1, v[free_k]=0
+  (k≠j), and v[pivot_col_c] = −RREF[pivot_row_c, j].
+
+Each eigenvector is returned as a column-vector ``Matrix`` IR node.
+
+Literate reading order
+-----------------------
+1. ``_poly_*``  — polynomial-coefficient arithmetic helpers
+2. ``_det_poly`` — cofactor determinant on polynomial entries
+3. ``char_poly_coeffs`` — build characteristic polynomial coefficients
+4. ``charpoly`` — IR form for the user (Add/Mul/Pow tree)
+5. ``_eval_eigenvalue_float`` — numeric evaluation for multiplicity
+6. ``eigenvalues`` — characteristic polynomial → roots → grouped list
+7. ``_ir_to_fraction`` — convert IRInteger/IRRational to Fraction
+8. ``_null_space_fractions`` — RREF-based null-space computation
+9. ``eigenvectors`` — per-eigenvalue null-space basis
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from cas_solve.cubic import solve_cubic
+from cas_solve.linear import solve_linear
+from cas_solve.quadratic import solve_quadratic
+from symbolic_ir import (
+    ADD,
+    DIV,
+    MUL,
+    NEG,
+    POW,
+    SUB,
+    IRApply,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from cas_matrix.matrix import MatrixError, matrix, num_cols, num_rows
+from cas_matrix.rowreduce import _frac_to_ir, _matrix_to_fractions
+
+# ---------------------------------------------------------------------------
+# Section 1 — Polynomial arithmetic helpers
+# ---------------------------------------------------------------------------
+#
+# A polynomial p(λ) is stored as a list of Fraction values where p[k] is the
+# coefficient of λ^k.  The list is "dense" — every power from 0 to deg(p) is
+# present (some coefficients may be zero).
+#
+# Why lists of Fractions instead of dicts or symbolic IR?  Because we only
+# ever evaluate characteristic polynomials of *rational* matrices (the only
+# kind our row-reduction routines support).  Keeping everything in exact
+# Fraction arithmetic avoids any interaction with the VM evaluator and makes
+# the code self-contained.
+
+
+def _poly_add(p: list[Fraction], q: list[Fraction]) -> list[Fraction]:
+    """Add two polynomials coefficient-by-coefficient.
+
+    If the lists differ in length the shorter one is treated as padded
+    with zeros on the right.
+
+    Parameters
+    ----------
+    p, q:
+        Coefficient lists in ascending power order.
+
+    Returns
+    -------
+    Coefficient list of p + q.
+
+    Examples
+    --------
+    ::
+
+        _poly_add([1, 2], [3])        # [4, 2]  (1+3 + 2*λ)
+        _poly_add([1], [0, 1])        # [1, 1]  (1 + λ)
+    """
+    n = max(len(p), len(q))
+    return [
+        (p[i] if i < len(p) else Fraction(0))
+        + (q[i] if i < len(q) else Fraction(0))
+        for i in range(n)
+    ]
+
+
+def _poly_neg(p: list[Fraction]) -> list[Fraction]:
+    """Negate every coefficient.
+
+    Parameters
+    ----------
+    p:
+        Coefficient list.
+
+    Returns
+    -------
+    ``[−p[0], −p[1], …]``.
+    """
+    return [-c for c in p]
+
+
+def _poly_sub(p: list[Fraction], q: list[Fraction]) -> list[Fraction]:
+    """Subtract q from p (coefficient-by-coefficient).
+
+    Equivalent to ``_poly_add(p, _poly_neg(q))``.
+
+    Parameters
+    ----------
+    p, q:
+        Coefficient lists in ascending power order.
+
+    Returns
+    -------
+    Coefficient list of p − q.
+    """
+    return _poly_add(p, _poly_neg(q))
+
+
+def _poly_mul(p: list[Fraction], q: list[Fraction]) -> list[Fraction]:
+    """Multiply two polynomials.
+
+    Uses the standard O(n·m) convolution.  Returns ``[0]`` if either
+    input is empty.
+
+    Parameters
+    ----------
+    p, q:
+        Coefficient lists in ascending power order.
+
+    Returns
+    -------
+    Coefficient list of p · q with degree deg(p) + deg(q).
+
+    Examples
+    --------
+    ::
+
+        # (λ − 1)(λ − 2) = λ² − 3λ + 2
+        _poly_mul([-1, 1], [-2, 1])   # [2, -3, 1]
+    """
+    if not p or not q:
+        return [Fraction(0)]
+    result = [Fraction(0)] * (len(p) + len(q) - 1)
+    for i, a in enumerate(p):
+        for j, b in enumerate(q):
+            result[i + j] += a * b
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Cofactor determinant on polynomial-valued entries
+# ---------------------------------------------------------------------------
+#
+# This mirrors the cofactor expansion in ``cas_matrix.determinant._det`` but
+# operates on polynomial lists rather than IR nodes.  The recursion is:
+#
+#   det(M) = sum_j  (−1)^j * M[0,j] * det(minor(M,0,j))
+#
+# where M[0,j] is now a polynomial and det(minor) is also a polynomial.
+# Multiplying two polynomials gives the correct convolution of coefficients.
+
+
+def _det_poly(
+    rows: list[list[list[Fraction]]],
+) -> list[Fraction]:
+    """Compute det of a polynomial-valued matrix via cofactor expansion.
+
+    Each entry ``rows[i][j]`` is a coefficient list (ascending powers of λ).
+    Returns the coefficient list of the resulting determinant polynomial.
+
+    The algorithm is identical to :func:`cas_matrix.determinant._det` but
+    uses ``_poly_mul``, ``_poly_add``, ``_poly_sub`` instead of IR operations.
+
+    Complexity: O(n!) — suitable for n ≤ 6.
+
+    Parameters
+    ----------
+    rows:
+        Square list-of-lists; each inner element is a polynomial (list of
+        Fraction).
+
+    Returns
+    -------
+    Coefficient list of ``det(rows)``.
+    """
+    n = len(rows)
+    if n == 0:
+        return [Fraction(1)]  # det of 0×0 matrix is 1 by convention
+    if n == 1:
+        return list(rows[0][0])
+    if n == 2:
+        # det([[a,b],[c,d]]) = a*d - b*c
+        a, b = rows[0][0], rows[0][1]
+        c, d = rows[1][0], rows[1][1]
+        return _poly_sub(_poly_mul(a, d), _poly_mul(b, c))
+    result: list[Fraction] = [Fraction(0)]
+    for j, entry in enumerate(rows[0]):
+        # Build the minor: delete row 0 and column j.
+        minor = [
+            [rows[r][col] for col in range(n) if col != j]
+            for r in range(1, n)
+        ]
+        sub = _det_poly(minor)
+        product = _poly_mul(entry, sub)
+        if j % 2 == 0:
+            result = _poly_add(result, product)
+        else:
+            result = _poly_sub(result, product)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Characteristic polynomial computation
+# ---------------------------------------------------------------------------
+
+
+def char_poly_coeffs(M: IRNode) -> list[Fraction]:
+    """Return the coefficients of the characteristic polynomial det(λI − A).
+
+    The characteristic polynomial is:
+
+        p(λ) = det(λI − A) = λⁿ + cₙ₋₁λⁿ⁻¹ + … + c₁λ + c₀
+
+    Note that the convention here is ``det(λI − A)`` (not ``det(A − λI)``),
+    which gives a **monic** polynomial (leading coefficient = +1).
+
+    Parameters
+    ----------
+    M:
+        Square matrix IR node with ``IRInteger`` / ``IRRational`` entries.
+
+    Returns
+    -------
+    Ascending-power coefficient list ``[c₀, c₁, …, cₙ]`` where
+    ``p(λ) = Σ cₖ λᵏ``.
+
+    Raises
+    ------
+    MatrixError
+        If ``M`` is not square or has symbolic entries.
+
+    Examples
+    --------
+    ::
+
+        A = matrix([[IRInteger(1), IRInteger(2)],
+                    [IRInteger(2), IRInteger(1)]])
+        char_poly_coeffs(A)   # [Fraction(-3), Fraction(-2), Fraction(1)]
+        # i.e. λ² − 2λ − 3 = (λ−3)(λ+1)
+    """
+    n = num_rows(M)
+    if n != num_cols(M):
+        raise MatrixError(
+            f"char_poly_coeffs: matrix must be square, got "
+            f"{n}×{num_cols(M)}"
+        )
+    frows = _matrix_to_fractions(M)
+
+    # Build polynomial-valued entries of (λI − A):
+    #   diagonal:    λ − aᵢᵢ  →  [−aᵢᵢ, 1]
+    #   off-diagonal: −aᵢⱼ    →  [−aᵢⱼ]
+    poly_rows: list[list[list[Fraction]]] = []
+    for i in range(n):
+        row: list[list[Fraction]] = []
+        for j in range(n):
+            if i == j:
+                # λ - aᵢᵢ
+                row.append([-frows[i][j], Fraction(1)])
+            else:
+                # -aᵢⱼ
+                row.append([-frows[i][j]])
+        poly_rows.append(row)
+
+    return _det_poly(poly_rows)
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — IR form of characteristic polynomial
+# ---------------------------------------------------------------------------
+
+
+def _frac_to_ir_local(f: Fraction) -> IRNode:
+    """Convert Fraction to canonical IR literal (local helper)."""
+    if f.denominator == 1:
+        return IRInteger(f.numerator)
+    return IRRational(f.numerator, f.denominator)
+
+
+def charpoly(M: IRNode, lam: IRSymbol) -> IRNode:
+    """Return the characteristic polynomial ``det(λI − A)`` as an IR tree.
+
+    The result is an ``Add``/``Mul``/``Pow`` expression in the symbol
+    ``lam``.  Coefficients are ``IRInteger`` or ``IRRational``.
+
+    Parameters
+    ----------
+    M:
+        Square matrix with rational entries.
+    lam:
+        The symbolic variable for the polynomial (e.g. ``IRSymbol("lambda")``).
+
+    Returns
+    -------
+    An IR expression representing the characteristic polynomial.
+
+    Raises
+    ------
+    MatrixError
+        If ``M`` is not square or has symbolic entries.
+
+    Examples
+    --------
+    ::
+
+        A = matrix([[IRInteger(4), IRInteger(2)],
+                    [IRInteger(1), IRInteger(3)]])
+        lam = IRSymbol("lambda")
+        charpoly(A, lam)
+        # (lambda^2 - 7*lambda + 10)
+        # i.e. (λ−5)(λ−2)
+    """
+    coeffs = char_poly_coeffs(M)
+    # Build the polynomial as an IR Add tree:
+    #   c₀ + c₁·λ + c₂·λ² + … + cₙ·λⁿ
+    terms: list[IRNode] = []
+    for k, c in enumerate(coeffs):
+        if c == 0:
+            continue
+        if k == 0:
+            # constant term
+            terms.append(_frac_to_ir_local(c))
+        elif k == 1:
+            # c·λ
+            c_ir = _frac_to_ir_local(c)
+            if c == Fraction(1):
+                terms.append(lam)
+            else:
+                terms.append(IRApply(MUL, (c_ir, lam)))
+        else:
+            # c·λ^k
+            power = IRApply(POW, (lam, IRInteger(k)))
+            c_ir = _frac_to_ir_local(c)
+            if c == Fraction(1):
+                terms.append(power)
+            else:
+                terms.append(IRApply(MUL, (c_ir, power)))
+    if not terms:
+        return IRInteger(0)
+    if len(terms) == 1:
+        return terms[0]
+    # Fold into a left-associative Add tree.
+    result = terms[0]
+    for t in terms[1:]:
+        result = IRApply(ADD, (result, t))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Numeric eigenvalue evaluation for multiplicity grouping
+# ---------------------------------------------------------------------------
+#
+# After the polynomial solver returns a list of IR roots, we need to group
+# equal roots and count multiplicity.  The solvers *deduplicate* repeated
+# roots: ``solve_quadratic(1, -4, 4)`` returns ``[2]`` (one root), not
+# ``[2, 2]``.  So we cannot rely on the solver's list length alone.
+#
+# Strategy:
+# 1. Group returned roots by float proximity (tol 1e-9).
+# 2. For each distinct group, use the **derivative test** on the char poly
+#    to determine the true algebraic multiplicity: the multiplicity of root
+#    r is the order of vanishing of p at r (the smallest k such that
+#    p^(k)(r) ≠ 0).
+# 3. Assign the derivative-test multiplicity to each group.
+#
+# This correctly handles ``solve_quadratic`` returning one root for disc=0
+# (multiplicity 2) and the trivial case of all distinct roots (all mult=1).
+
+
+def _multiplicity_float(coeffs: list[Fraction], root_float: float) -> int:
+    """Determine the algebraic multiplicity of a root using the derivative test.
+
+    The algebraic multiplicity of a root r in polynomial p(λ) is the largest
+    integer m such that (λ − r)^m divides p(λ).  Equivalently, it is the
+    order of vanishing: the smallest k for which p^(k)(r) ≠ 0.
+
+    We evaluate p and its successive derivatives numerically at ``root_float``.
+
+    Parameters
+    ----------
+    coeffs:
+        Ascending-power coefficient list [c₀, c₁, …, cₙ] of the characteristic
+        polynomial (Fraction values).
+    root_float:
+        Float approximation of the root.
+
+    Returns
+    -------
+    The algebraic multiplicity (≥ 1 if root_float is actually a root).
+    """
+    tol = 1e-4  # looser than grouping tolerance — numerical derivatives drift
+
+    def eval_poly(c: list[float], x: float) -> float:
+        return sum(c[k] * x**k for k in range(len(c)))
+
+    def deriv_coeffs(c: list[float]) -> list[float]:
+        """Return derivative coefficient list (descending one degree)."""
+        if len(c) <= 1:
+            return [0.0]
+        return [(k + 1) * c[k + 1] for k in range(len(c) - 1)]
+
+    current = [float(c) for c in coeffs]
+    mult = 0
+    # Count how many successive derivatives vanish at root_float.
+    while len(current) > 1 and abs(eval_poly(current, root_float)) < tol:
+        mult += 1
+        current = deriv_coeffs(current)
+    return max(mult, 1)  # at least 1 (it's a root)
+
+
+_TEST_POINT = 1.7
+
+
+def _eval_eigenvalue_complex(root: IRNode) -> complex:
+    """Evaluate an eigenvalue IR node to a complex number for grouping.
+
+    Handles all output formats of cas_solve: IRInteger, IRRational, complex
+    nodes with ``%i``, roots with ``Sqrt``, and Add/Sub/Mul/Div/Neg trees.
+
+    Parameters
+    ----------
+    root:
+        An eigenvalue IR node as returned by ``solve_linear``,
+        ``solve_quadratic``, ``solve_cubic``, or ``solve_quartic``.
+
+    Returns
+    -------
+    A complex approximation.  Complex eigenvalues like ``0 + 1j`` and
+    ``0 - 1j`` receive distinct values so they are *not* grouped together.
+    """
+    # Using complex arithmetic lets us distinguish conjugate pairs (+i vs -i)
+    # which both evaluate to 0.0 if only the real part is kept.
+    I_UNIT = IRSymbol("%i")
+    SQRT_SYM = IRSymbol("Sqrt")
+    from symbolic_ir import SQRT  # standard head
+
+    def ev(node: IRNode) -> complex:
+        if isinstance(node, IRInteger):
+            return complex(node.value)
+        if isinstance(node, IRRational):
+            return complex(node.numer / node.denom)
+        if isinstance(node, IRSymbol):
+            if node == I_UNIT:
+                return 1j
+            return 0.0 + 0j  # unknown symbol
+        if not isinstance(node, IRApply):
+            return 0.0 + 0j
+        h = node.head
+        args = node.args
+        if h == ADD:
+            return sum(ev(a) for a in args)
+        if h == SUB:
+            return ev(args[0]) - ev(args[1])
+        if h == MUL:
+            r: complex = 1.0 + 0j
+            for a in args:
+                r *= ev(a)
+            return r
+        if h == DIV:
+            d = ev(args[1])
+            return ev(args[0]) / d if d != 0 else 1e18 + 0j
+        if h == NEG:
+            return -ev(args[0])
+        if h in (SQRT, SQRT_SYM):
+            val = ev(args[0])
+            if val.imag == 0 and val.real >= 0:
+                return complex(val.real**0.5)
+            return 0.0 + 0j  # complex sqrt — rare; map to 0 to avoid grouping
+        if h == POW:
+            base = ev(args[0])
+            exp_val = ev(args[1])
+            try:
+                return base**exp_val
+            except (ValueError, ZeroDivisionError):
+                return 0.0 + 0j
+        return 0.0 + 0j  # unknown head
+
+    return ev(root)
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Eigenvalues
+# ---------------------------------------------------------------------------
+
+
+def eigenvalues(M: IRNode) -> IRApply:
+    """Compute the eigenvalues of a square rational matrix.
+
+    Computes the characteristic polynomial, finds its roots via the
+    appropriate polynomial solver (linear through quartic), groups equal
+    roots by multiplicity, and returns them in MACSYMA's format:
+
+        ``List(List(λ₁, m₁), List(λ₂, m₂), …)``
+
+    where ``mᵢ`` is the algebraic multiplicity (how many times ``λᵢ``
+    appears as a root).
+
+    Parameters
+    ----------
+    M:
+        Square matrix with ``IRInteger`` / ``IRRational`` entries.
+
+    Returns
+    -------
+    An IR ``List`` of ``List`` pairs, each pair being
+    ``[eigenvalue_IR, multiplicity_IRInteger]``.
+
+    Raises
+    ------
+    MatrixError
+        If ``M`` is not square or has symbolic entries.
+    ValueError
+        If the matrix is larger than 4×4 (solvers only go up to quartic).
+
+    Examples
+    --------
+    ::
+
+        eigenvalues(matrix([[IRInteger(1), IRInteger(2)],
+                             [IRInteger(2), IRInteger(1)]]))
+        # List(List(-1, 1), List(3, 1))
+
+        eigenvalues(matrix([[IRInteger(2), IRInteger(0)],
+                             [IRInteger(0), IRInteger(2)]]))
+        # List(List(2, 2))
+    """
+    n = num_rows(M)
+    if n != num_cols(M):
+        raise MatrixError(f"eigenvalues: non-square matrix {n}×{num_cols(M)}")
+    if n > 4:
+        raise MatrixError(
+            "eigenvalues: matrix larger than 4×4 not supported "
+            "(eigenvalue computation requires degree >4 polynomial solver)"
+        )
+
+    coeffs = char_poly_coeffs(M)
+    # coeffs = [c₀, c₁, …, cₙ] with cₙ = 1 (monic)
+    # The polynomial is c₀ + c₁λ + … + cₙλⁿ
+    # The solvers expect DESCENDING order: solve_quadratic(a, b, c) for aλ²+bλ+c
+
+    LIST_HEAD = IRSymbol("List")
+
+    # Dispatch to the correct solver based on n.
+    if n == 1:
+        # cₙ λ + c₀ = 0  →  c₁ λ + c₀ = 0
+        roots_or_str = solve_linear(coeffs[1], coeffs[0])
+    elif n == 2:
+        # c₂λ² + c₁λ + c₀ = 0
+        roots_or_str = solve_quadratic(coeffs[2], coeffs[1], coeffs[0])
+    elif n == 3:
+        # c₃λ³ + c₂λ² + c₁λ + c₀ = 0
+        roots_or_str = solve_cubic(coeffs[3], coeffs[2], coeffs[1], coeffs[0])
+    else:
+        # n == 4: c₄λ⁴ + c₃λ³ + c₂λ² + c₁λ + c₀ = 0
+        from cas_solve.quartic import solve_quartic as _solve_quartic
+        roots_or_str = _solve_quartic(
+            coeffs[4], coeffs[3], coeffs[2], coeffs[1], coeffs[0]
+        )
+
+    # solve_* return either a list of IR nodes or the string "all"
+    # (the "all" case means 0=0, impossible for an n≥1 char poly).
+    if isinstance(roots_or_str, str) or not roots_or_str:
+        # Degenerate: empty or "all" — return unevaluated.
+        return IRApply(IRSymbol("Eigenvalues"), (M,))
+
+    roots: list[IRNode] = list(roots_or_str)
+
+    # Group equal roots by complex proximity.  Using complex values (not just
+    # real parts) correctly distinguishes conjugate pairs like +i and −i that
+    # both have real part 0.  The solvers deduplicate repeated roots
+    # (solve_quadratic returns one root for disc=0), so we use the derivative
+    # test on the char poly to determine true algebraic multiplicity.
+    tol = 1e-9
+    cvals = [_eval_eigenvalue_complex(r) for r in roots]
+    used = [False] * len(roots)
+    groups: list[tuple[IRNode, float]] = []   # (representative_root, real_val)
+    for i, r in enumerate(roots):
+        if used[i]:
+            continue
+        used[i] = True
+        for j in range(i + 1, len(roots)):
+            if not used[j] and abs(cvals[i] - cvals[j]) < tol:
+                used[j] = True
+        groups.append((r, cvals[i].real))
+
+    # Compute algebraic multiplicity via derivative test on the char poly.
+    final_groups: list[tuple[IRNode, int]] = []
+    for root_ir, root_float in groups:
+        mult = _multiplicity_float(coeffs, root_float)
+        final_groups.append((root_ir, mult))
+
+    # Build List(List(λ₁, m₁), …)
+    pair_nodes = tuple(
+        IRApply(LIST_HEAD, (lam, IRInteger(mult)))
+        for lam, mult in final_groups
+    )
+    return IRApply(LIST_HEAD, pair_nodes)
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Helper: convert IR leaf to Fraction (or None)
+# ---------------------------------------------------------------------------
+
+
+def _ir_to_fraction(node: IRNode) -> Fraction | None:
+    """Return the Fraction value of an IRInteger or IRRational, else None.
+
+    Used to detect whether an eigenvalue can be substituted exactly into
+    the matrix for eigenvector computation.
+
+    Parameters
+    ----------
+    node:
+        An IR node.
+
+    Returns
+    -------
+    ``Fraction`` if the node is a pure rational literal, ``None`` otherwise.
+    """
+    if isinstance(node, IRInteger):
+        return Fraction(node.value)
+    if isinstance(node, IRRational):
+        return Fraction(node.numer, node.denom)
+    # Negation of a rational
+    if (
+        isinstance(node, IRApply)
+        and node.head == NEG
+        and len(node.args) == 1
+    ):
+        inner = _ir_to_fraction(node.args[0])
+        return -inner if inner is not None else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Null-space computation from RREF
+# ---------------------------------------------------------------------------
+
+
+def _null_space_fractions(A: list[list[Fraction]]) -> list[list[Fraction]]:
+    """Compute the null space of a rational matrix via RREF.
+
+    Parameters
+    ----------
+    A:
+        Row-major list of lists of Fraction, shape m×n.
+
+    Returns
+    -------
+    A list of column vectors (each a ``list[Fraction]`` of length n).
+    If A has full column rank, returns ``[]`` (trivial null space).
+
+    Algorithm
+    ---------
+    1. Perform RREF on A (Gauss-Jordan over Q).
+    2. Identify pivot column indices.
+    3. Free columns = non-pivot columns.
+    4. For each free column j build basis vector v (length n):
+       - ``v[j] = 1``
+       - ``v[free_k] = 0`` for every other free column k
+       - ``v[pivot_col_for_row_r] = −RREF[r, j]`` for each pivot row r
+
+    Examples
+    --------
+    ::
+
+        # A = [[1,2,3],[4,5,6]] → RREF = [[1,0,-1],[0,1,2]]
+        # pivot cols 0, 1; free col 2
+        # basis vector: v[2]=1, v[1]=-2, v[0]=1 → [1,-2,1]
+        _null_space_fractions([[...], [...]])
+        # [[Fraction(1), Fraction(-2), Fraction(1)]]
+    """
+    if not A or not A[0]:
+        return []
+
+    m = len(A)
+    n = len(A[0])
+    # Work on a copy so we don't mutate the caller's data.
+    rref = [row[:] for row in A]
+
+    pivot_cols: list[int] = []  # pivot_cols[r] = column index of pivot in row r
+    pivot_row = 0
+    for col in range(n):
+        # Find a non-zero entry in this column at or below pivot_row.
+        pivot_pos: int | None = None
+        for r in range(pivot_row, m):
+            if rref[r][col] != 0:
+                pivot_pos = r
+                break
+        if pivot_pos is None:
+            continue
+        # Swap pivot row up.
+        if pivot_pos != pivot_row:
+            rref[pivot_row], rref[pivot_pos] = rref[pivot_pos], rref[pivot_row]
+        # Normalise pivot to 1.
+        pv = rref[pivot_row][col]
+        rref[pivot_row] = [x / pv for x in rref[pivot_row]]
+        # Eliminate all other entries in this column.
+        for r in range(m):
+            if r != pivot_row:
+                factor = rref[r][col]
+                if factor != 0:
+                    rref[r] = [rref[r][c] - factor * rref[pivot_row][c]
+                               for c in range(n)]
+        pivot_cols.append(col)
+        pivot_row += 1
+
+    pivot_col_set = set(pivot_cols)
+    free_cols = [c for c in range(n) if c not in pivot_col_set]
+
+    if not free_cols:
+        return []  # trivial null space
+
+    # Build a dict: pivot column → the row it lives in.
+    pivot_col_to_row: dict[int, int] = {col: r for r, col in enumerate(pivot_cols)}
+
+    basis: list[list[Fraction]] = []
+    for j in free_cols:
+        # Basis vector for free column j.
+        v = [Fraction(0)] * n
+        v[j] = Fraction(1)
+        for pcol, prow in pivot_col_to_row.items():
+            v[pcol] = -rref[prow][j]
+        basis.append(v)
+
+    return basis
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Eigenvectors
+# ---------------------------------------------------------------------------
+
+
+def eigenvectors(M: IRNode) -> IRApply:
+    """Compute eigenvalues and eigenvectors of a square rational matrix.
+
+    Returns a list of triples, one per distinct eigenvalue:
+
+        ``List(List(λ₁, m₁, List(v₁, v₂, …)), …)``
+
+    where ``vᵢ`` are column-vector ``Matrix`` IR nodes spanning the
+    eigenspace for ``λ₁``.
+
+    For eigenvalues that are irrational or complex (i.e., not plain
+    ``IRInteger`` / ``IRRational``), the eigenvector list for that
+    eigenvalue is ``List()`` — symbolic null-space computation is out
+    of scope for Phase 19.
+
+    Parameters
+    ----------
+    M:
+        Square matrix with ``IRInteger`` / ``IRRational`` entries.
+
+    Returns
+    -------
+    IR ``List`` of triples as described above.
+
+    Raises
+    ------
+    MatrixError
+        If M is not square, has symbolic entries, or is larger than 4×4.
+
+    Examples
+    --------
+    ::
+
+        eigenvectors(matrix([[IRInteger(1), IRInteger(2)],
+                              [IRInteger(2), IRInteger(1)]]))
+        # List(
+        #   List(-1, 1, List(Matrix([[-1],[1]]))),
+        #   List( 3, 1, List(Matrix([[ 1],[1]])))
+        # )
+    """
+    n = num_rows(M)
+    LIST_HEAD = IRSymbol("List")
+
+    # Reuse eigenvalues to get the grouping.
+    eigs = eigenvalues(M)
+    if eigs.head != LIST_HEAD:
+        # eigenvalues returned unevaluated — propagate
+        return IRApply(IRSymbol("Eigenvectors"), (M,))
+
+    frows = _matrix_to_fractions(M)
+    triples: list[IRNode] = []
+
+    for pair in eigs.args:
+        lam_ir, mult_ir = pair.args[0], pair.args[1]
+
+        lam_frac = _ir_to_fraction(lam_ir)
+        if lam_frac is None:
+            # Irrational / complex — can't do exact null space.
+            triple = IRApply(LIST_HEAD, (lam_ir, mult_ir, IRApply(LIST_HEAD, ())))
+            triples.append(triple)
+            continue
+
+        # Build B = A − λI with Fraction entries.
+        B = [
+            [frows[i][j] - (lam_frac if i == j else Fraction(0)) for j in range(n)]
+            for i in range(n)
+        ]
+
+        basis = _null_space_fractions(B)
+
+        # Convert each basis vector to a column-vector Matrix IR node.
+        vec_nodes: list[IRNode] = []
+        for vec in basis:
+            col_ir = matrix([[_frac_to_ir(v)] for v in vec])
+            vec_nodes.append(col_ir)
+
+        vec_list = IRApply(LIST_HEAD, tuple(vec_nodes))
+        triple = IRApply(LIST_HEAD, (lam_ir, mult_ir, vec_list))
+        triples.append(triple)
+
+    return IRApply(LIST_HEAD, tuple(triples))

--- a/code/packages/python/cas-matrix/src/cas_matrix/heads.py
+++ b/code/packages/python/cas-matrix/src/cas_matrix/heads.py
@@ -16,5 +16,15 @@ TRACE = IRSymbol("Trace")
 RANK = IRSymbol("Rank")
 ROW_REDUCE = IRSymbol("RowReduce")
 
+# Phase 19 — eigenvalues / eigenvectors / LU / subspaces / norm / charpoly
+EIGENVALUES = IRSymbol("Eigenvalues")
+EIGENVECTORS = IRSymbol("Eigenvectors")
+CHARPOLY = IRSymbol("CharPoly")
+LU = IRSymbol("LU")
+NULLSPACE = IRSymbol("NullSpace")
+COLUMNSPACE = IRSymbol("ColumnSpace")
+ROWSPACE = IRSymbol("RowSpace")
+NORM = IRSymbol("Norm")
+
 # Re-exported for convenience.
 LIST = IRSymbol("List")

--- a/code/packages/python/cas-matrix/src/cas_matrix/lu.py
+++ b/code/packages/python/cas-matrix/src/cas_matrix/lu.py
@@ -1,0 +1,199 @@
+"""LU decomposition with partial pivoting (Doolittle algorithm).
+
+Given an n×n matrix A, LU decomposition finds:
+
+    P · A = L · U
+
+where:
+
+- **P** is a permutation matrix (rows of the identity, reordered).
+- **L** is lower-triangular with 1s on the main diagonal.
+- **U** is upper-triangular.
+
+Any non-singular square matrix has an LU decomposition (possibly requiring
+row exchanges, hence P).
+
+Why partial pivoting?
+---------------------
+Without pivoting, the algorithm fails on matrices with a zero in the
+pivot position even though the matrix itself is non-singular (e.g.
+[[0, 1], [1, 0]]).  Partial pivoting selects the row with the largest
+absolute value in the current column as the pivot, which both avoids
+division-by-zero and improves numerical stability.
+
+Since we work with exact Fraction arithmetic, "stability" is not strictly
+required — but pivoting avoids degenerate cases where an intermediate U[k,k]
+is 0 while the overall matrix is invertible.
+
+Doolittle algorithm
+-------------------
+Initialise:
+
+    P = identity, L = identity, U = copy of A (as Fractions)
+
+For each column k (k = 0 … n-1):
+
+  1. **Pivot search**: find row p ≥ k with the largest |U[p, k]|.
+  2. **Row swap**: swap rows k and p in U and P; also swap the already-
+     filled part of L (columns 0 … k-1) in rows k and p.
+  3. **Doolittle step**: for each row i > k:
+        factor = U[i,k] / U[k,k]
+        L[i,k] = factor
+        U[i,:] -= factor * U[k,:]
+
+After the loop, U has been reduced to upper-triangular form, L contains
+the multipliers, and P records all row swaps.
+
+Correctness check: P @ A == L @ U (entry-by-entry equality over Q).
+
+Singular matrices
+-----------------
+If U[k,k] == 0 even after pivoting, the matrix is singular.  A
+``MatrixError`` is raised.
+
+Literate reading order
+-----------------------
+1. ``_identity_fractions``  — build an n×n identity as Fractions
+2. ``_fracs_to_matrix``     — convert Fraction matrix to IR Matrix
+3. ``lu_decompose``         — the main LU algorithm
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from symbolic_ir import IRApply, IRNode, IRSymbol
+
+from cas_matrix.matrix import MatrixError, matrix, num_cols, num_rows
+from cas_matrix.rowreduce import _frac_to_ir, _matrix_to_fractions
+
+# ---------------------------------------------------------------------------
+# Section 1 — Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _identity_fractions(n: int) -> list[list[Fraction]]:
+    """Return an n×n identity matrix as a list-of-lists of Fraction.
+
+    Parameters
+    ----------
+    n:
+        Matrix dimension.
+
+    Returns
+    -------
+    ``I[i][j] = Fraction(1)`` if i==j else ``Fraction(0)``.
+    """
+    return [
+        [Fraction(1) if i == j else Fraction(0) for j in range(n)]
+        for i in range(n)
+    ]
+
+
+def _fracs_to_matrix(frows: list[list[Fraction]]) -> IRApply:
+    """Convert a list-of-lists of Fraction to a Matrix IR node.
+
+    Parameters
+    ----------
+    frows:
+        Row-major matrix; each entry is a ``Fraction``.
+
+    Returns
+    -------
+    ``Matrix`` IR node with ``IRInteger`` / ``IRRational`` entries.
+    """
+    return matrix([[_frac_to_ir(f) for f in row] for row in frows])
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — LU decomposition
+# ---------------------------------------------------------------------------
+
+
+def lu_decompose(M: IRNode) -> IRApply:
+    """Compute the LU decomposition of a square rational matrix.
+
+    Returns a ``List(L, U, P)`` IR node where:
+
+    - ``L`` is lower-triangular with 1s on the diagonal.
+    - ``U`` is upper-triangular.
+    - ``P`` is a permutation matrix.
+    - ``P · A = L · U`` (exact over Q).
+
+    Parameters
+    ----------
+    M:
+        Square matrix with ``IRInteger`` / ``IRRational`` entries.
+
+    Returns
+    -------
+    ``IRApply(List, (L, U, P))`` — three ``Matrix`` IR nodes.
+
+    Raises
+    ------
+    MatrixError
+        If M is not square, has symbolic entries, or is singular
+        (zero pivot after partial pivoting).
+
+    Examples
+    --------
+    ::
+
+        A = matrix([[IRInteger(2), IRInteger(1)],
+                    [IRInteger(1), IRInteger(3)]])
+        L, U, P = lu_decompose(A).args
+        # L = [[1, 0], [1/2, 1]]
+        # U = [[2, 1], [0, 5/2]]
+        # P = [[1, 0], [0, 1]]  (no row swap needed)
+
+        A2 = matrix([[IRInteger(0), IRInteger(1)],
+                     [IRInteger(1), IRInteger(0)]])
+        # Requires pivoting: P swaps rows
+        L2, U2, P2 = lu_decompose(A2).args
+        # P2 = [[0,1],[1,0]]
+        # L2 = [[1,0],[0,1]]
+        # U2 = [[1,0],[0,1]]
+    """
+    n = num_rows(M)
+    if n != num_cols(M):
+        raise MatrixError(f"lu_decompose: matrix must be square, got {n}×{num_cols(M)}")
+
+    U = _matrix_to_fractions(M)   # will become upper-triangular
+    L = _identity_fractions(n)    # will accumulate multipliers
+    P = _identity_fractions(n)    # permutation matrix
+
+    for k in range(n):
+        # Step 1: partial pivoting — find row p >= k with max |U[p, k]|
+        best_row = k
+        best_val = abs(U[k][k])
+        for r in range(k + 1, n):
+            if abs(U[r][k]) > best_val:
+                best_val = abs(U[r][k])
+                best_row = r
+
+        if best_row != k:
+            # Swap rows k and best_row in U and P.
+            U[k], U[best_row] = U[best_row], U[k]
+            P[k], P[best_row] = P[best_row], P[k]
+            # Swap the already-filled part of L (columns 0 … k-1).
+            for c in range(k):
+                L[k][c], L[best_row][c] = L[best_row][c], L[k][c]
+
+        pivot = U[k][k]
+        if pivot == 0:
+            raise MatrixError(
+                f"lu_decompose: singular matrix (zero pivot at column {k})"
+            )
+
+        # Step 2: eliminate entries below the pivot (Doolittle step).
+        for i in range(k + 1, n):
+            factor = U[i][k] / pivot
+            L[i][k] = factor
+            for c in range(k, n):
+                U[i][c] -= factor * U[k][c]
+
+    LIST_HEAD = IRSymbol("List")
+    return IRApply(
+        LIST_HEAD,
+        (_fracs_to_matrix(L), _fracs_to_matrix(U), _fracs_to_matrix(P)),
+    )

--- a/code/packages/python/cas-matrix/src/cas_matrix/norms.py
+++ b/code/packages/python/cas-matrix/src/cas_matrix/norms.py
@@ -1,0 +1,185 @@
+"""Matrix and vector norms.
+
+This module provides two norm computations:
+
+1. **Euclidean (L²) norm** for column vectors: ``‖v‖ = √(Σ vᵢ²)``
+2. **Frobenius norm** for matrices: ``‖A‖_F = √(Σᵢⱼ aᵢⱼ²)``
+
+Both are computed exactly over the rationals.  If the sum of squares is
+a perfect square (numerator and denominator are both perfect squares of
+integers), the result is returned as ``IRInteger`` or ``IRRational``.
+Otherwise the result is ``IRApply(SQRT, (sum_of_squares,))``.
+
+Vector vs matrix
+----------------
+A "column vector" is defined as an m×1 matrix.  A row vector (1×n) is
+also accepted.  For any other matrix shape, a second argument ``"frobenius"``
+must be provided.
+
+API
+---
+``norm(M)``               — Euclidean norm of a column/row vector.
+``norm(M, "frobenius")``  — Frobenius norm of any matrix.
+
+Both fall through (return the unevaluated ``Norm(…)`` node) when:
+
+- Entries are symbolic (not ``IRInteger``/``IRRational``).
+- A matrix is passed without the ``"frobenius"`` flag.
+- The input is not a valid matrix.
+
+Literate reading order
+-----------------------
+1. ``_sum_of_squares``  — exact Fraction sum
+2. ``_sqrt_fraction``   — exact square root or SQRT IR node
+3. ``norm``             — main public function
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from math import isqrt
+
+from symbolic_ir import SQRT, IRApply, IRNode
+
+from cas_matrix.matrix import MatrixError, _rows_of, num_cols, num_rows
+from cas_matrix.rowreduce import _entry_to_fraction, _frac_to_ir
+
+# ---------------------------------------------------------------------------
+# Section 1 — Sum of squares
+# ---------------------------------------------------------------------------
+
+
+def _sum_of_squares(entries: list[Fraction]) -> Fraction:
+    """Return the exact sum of squares of a list of Fraction values.
+
+    Parameters
+    ----------
+    entries:
+        Flat list of matrix entries already converted to Fraction.
+
+    Returns
+    -------
+    ``Σ eᵢ²`` as a ``Fraction``.
+    """
+    return sum(e * e for e in entries)
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Exact square root or SQRT IR node
+# ---------------------------------------------------------------------------
+
+
+def _isqrt_fraction(f: Fraction) -> Fraction | None:
+    """Return the exact square root of f if f is a perfect square, else None.
+
+    A fraction p/q is a perfect square when both p and q are perfect squares
+    of integers.
+
+    Parameters
+    ----------
+    f:
+        A non-negative Fraction.
+
+    Returns
+    -------
+    ``Fraction(√p, √q)`` if both are perfect squares, else ``None``.
+    """
+    p, q = f.numerator, f.denominator
+    if p < 0 or q < 0:
+        return None
+    sp = isqrt(p)
+    sq = isqrt(q)
+    if sp * sp == p and sq * sq == q:
+        return Fraction(sp, sq)
+    return None
+
+
+def _sqrt_fraction(total: Fraction) -> IRNode:
+    """Return the exact IR representation of √total.
+
+    Parameters
+    ----------
+    total:
+        A non-negative Fraction (the sum of squares).
+
+    Returns
+    -------
+    ``IRInteger`` or ``IRRational`` if total is a perfect square; otherwise
+    ``IRApply(SQRT, (total_ir,))``.
+    """
+    exact = _isqrt_fraction(total)
+    if exact is not None:
+        return _frac_to_ir(exact)
+    return IRApply(SQRT, (_frac_to_ir(total),))
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Public norm function
+# ---------------------------------------------------------------------------
+
+
+def norm(M: IRNode, kind: str | None = None) -> IRNode:
+    """Compute the Euclidean or Frobenius norm of a matrix.
+
+    Parameters
+    ----------
+    M:
+        A ``Matrix`` IR node with ``IRInteger`` / ``IRRational`` entries.
+    kind:
+        ``None`` (default) — Euclidean norm of a column or row vector.
+        ``"frobenius"`` — Frobenius norm of any matrix.
+
+    Returns
+    -------
+    An IR node representing the norm:
+
+    - ``IRInteger`` or ``IRRational`` if the sum of squares is a perfect
+      square (exact integer/rational result).
+    - ``IRApply(SQRT, (sum_of_squares_ir,))`` otherwise.
+
+    Raises
+    ------
+    MatrixError
+        If entries are symbolic, or if kind is None and M is not a vector.
+        If kind is unknown.
+
+    Examples
+    --------
+    ::
+
+        # Euclidean norm of [3, 4]:  √(9+16) = √25 = 5
+        v = matrix([[IRInteger(3)], [IRInteger(4)]])
+        norm(v)  # IRInteger(5)
+
+        # Frobenius norm of [[1,1],[1,1]]:  √(1+1+1+1) = √4 = 2
+        A = matrix([[IRInteger(1), IRInteger(1)],
+                    [IRInteger(1), IRInteger(1)]])
+        norm(A, "frobenius")  # IRInteger(2)
+
+        # Non-perfect square: √2
+        v2 = matrix([[IRInteger(1)], [IRInteger(1)]])
+        norm(v2)
+        # IRApply(SQRT, (IRInteger(2),))
+    """
+    if kind is not None and kind != "frobenius":
+        raise MatrixError(f"norm: unknown norm kind {kind!r}; use 'frobenius' or None")
+
+    rows = _rows_of(M)
+    nr = num_rows(M)
+    nc = num_cols(M)
+
+    if kind is None and nc != 1 and nr != 1:
+        # Euclidean vector norm: M must be m×1 or 1×n.
+        raise MatrixError(
+            "norm: Euclidean norm requires a column or row vector "
+            f"(got {nr}×{nc}); use norm(M, 'frobenius') for matrices"
+        )
+
+    # Flatten all entries and convert to Fraction.
+    flat: list[Fraction] = []
+    for row in rows:
+        for entry in row:
+            flat.append(_entry_to_fraction(entry))
+
+    total = _sum_of_squares(flat)
+    return _sqrt_fraction(total)

--- a/code/packages/python/cas-matrix/src/cas_matrix/rowreduce.py
+++ b/code/packages/python/cas-matrix/src/cas_matrix/rowreduce.py
@@ -55,7 +55,6 @@ from symbolic_ir import IRApply, IRInteger, IRNode, IRRational
 
 from cas_matrix.matrix import MatrixError, _rows_of, matrix
 
-
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------

--- a/code/packages/python/cas-matrix/src/cas_matrix/subspaces.py
+++ b/code/packages/python/cas-matrix/src/cas_matrix/subspaces.py
@@ -1,0 +1,273 @@
+"""Null space, column space, and row space via RREF.
+
+All three subspace operations derive from the reduced row echelon form
+(RREF) of the input matrix, computed by
+:func:`cas_matrix.rowreduce.row_reduce`.
+
+Null space
+----------
+The null space of an m×n matrix A is the set of all vectors v such that
+Av = 0.  Its basis is found from the RREF of A:
+
+- **Pivot columns** (leading-1 columns): correspond to "basic" variables.
+- **Free columns** (non-pivot): correspond to "free" variables.
+
+For each free column j, assign free variable j the value 1 and all other
+free variables the value 0.  The basic variables are then determined by
+back-substitution from the RREF rows.  This gives one basis vector per
+free variable.
+
+Column space
+------------
+The column space (image) of A is the span of its columns.  Its basis
+consists of the **pivot columns of the original A** (not of the RREF) —
+because column operations can change the column space, but RREF row
+operations preserve column-space membership.
+
+Row space
+---------
+The row space of A is the span of its rows.  Its basis consists of the
+**non-zero rows of the RREF** — because row operations preserve the row
+space.
+
+Return format
+-------------
+All three functions return a ``List(v₁, v₂, …)`` of column-vector (or
+row-vector) ``Matrix`` IR nodes.  An empty ``List()`` signals a trivial
+subspace.
+
+Literate reading order
+-----------------------
+1. ``_rref_pivot_cols``  — extract pivot column indices from RREF
+2. ``nullspace``         — null-space basis
+3. ``columnspace``       — column-space basis
+4. ``rowspace``          — row-space basis
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from symbolic_ir import IRApply, IRNode, IRSymbol
+
+from cas_matrix.eigenvalues import _null_space_fractions
+from cas_matrix.matrix import _rows_of, matrix, num_rows
+from cas_matrix.rowreduce import _frac_to_ir, _matrix_to_fractions
+
+# ---------------------------------------------------------------------------
+# Section 1 — Internal helper: extract pivot columns from RREF
+# ---------------------------------------------------------------------------
+
+
+def _rref_pivot_info(
+    frows: list[list[Fraction]],
+) -> tuple[list[int], list[list[Fraction]]]:
+    """Compute RREF of a Fraction matrix and return pivot column indices + RREF.
+
+    Parameters
+    ----------
+    frows:
+        Row-major list-of-lists of Fraction, shape m×n.
+
+    Returns
+    -------
+    A tuple ``(pivot_cols, rref_rows)`` where:
+
+    - ``pivot_cols[r]`` is the column index of the pivot in row r.
+    - ``rref_rows`` is the matrix in reduced row echelon form.
+
+    Only rows that actually contain a pivot are represented in
+    ``pivot_cols``.
+    """
+    if not frows or not frows[0]:
+        return [], frows
+    m = len(frows)
+    n = len(frows[0])
+    rref = [row[:] for row in frows]
+    pivot_cols: list[int] = []
+    pivot_row = 0
+    for col in range(n):
+        pivot_pos: int | None = None
+        for r in range(pivot_row, m):
+            if rref[r][col] != 0:
+                pivot_pos = r
+                break
+        if pivot_pos is None:
+            continue
+        if pivot_pos != pivot_row:
+            rref[pivot_row], rref[pivot_pos] = rref[pivot_pos], rref[pivot_row]
+        pv = rref[pivot_row][col]
+        rref[pivot_row] = [x / pv for x in rref[pivot_row]]
+        for r in range(m):
+            if r != pivot_row:
+                factor = rref[r][col]
+                if factor != 0:
+                    rref[r] = [rref[r][c] - factor * rref[pivot_row][c]
+                               for c in range(n)]
+        pivot_cols.append(col)
+        pivot_row += 1
+    return pivot_cols, rref
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Null space
+# ---------------------------------------------------------------------------
+
+
+def nullspace(M: IRNode) -> IRApply:
+    """Return a basis for the null space (kernel) of matrix M.
+
+    The null space of an m×n matrix A is:
+        ``null(A) = {v ∈ ℝⁿ : Av = 0}``
+
+    Its dimension is n − rank(A) (the "nullity").
+
+    Algorithm
+    ---------
+    1. Compute RREF(A).
+    2. Identify free columns (non-pivot columns).
+    3. For each free column j build a basis vector v:
+       - ``v[j] = 1``
+       - ``v[free_k] = 0`` for all other free columns k
+       - ``v[pivot_col] = −RREF[pivot_row, j]``
+
+    Parameters
+    ----------
+    M:
+        An m×n matrix with ``IRInteger`` / ``IRRational`` entries.
+
+    Returns
+    -------
+    ``List(v₁, v₂, …)`` where each ``vᵢ`` is an n×1 column-vector
+    ``Matrix`` IR node.  Returns ``List()`` for a full-column-rank matrix
+    (trivial null space).
+
+    Raises
+    ------
+    MatrixError
+        If M is not a valid matrix or has symbolic entries.
+
+    Examples
+    --------
+    ::
+
+        # [[1,2,3],[4,5,6]] → RREF [[1,0,-1],[0,1,2]],
+        # free col 2: v = [1, -2, 1]
+        nullspace(matrix([[1,2,3],[4,5,6]]))
+        # List(Matrix([[1],[-2],[1]]))
+    """
+    LIST_HEAD = IRSymbol("List")
+    frows = _matrix_to_fractions(M)
+    basis = _null_space_fractions(frows)
+    vec_nodes = [
+        matrix([[_frac_to_ir(v)] for v in vec])
+        for vec in basis
+    ]
+    return IRApply(LIST_HEAD, tuple(vec_nodes))
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Column space
+# ---------------------------------------------------------------------------
+
+
+def columnspace(M: IRNode) -> IRApply:
+    """Return a basis for the column space (image) of matrix M.
+
+    The column space is the span of the columns of A.  The basis consists
+    of the pivot columns of the **original** A (not the RREF).
+
+    Why original columns and not RREF pivot columns?  Row operations
+    preserve which columns are linearly independent (and thus which columns
+    span the column space), but they change the actual column vectors.
+    The original pivot columns retain their geometric meaning.
+
+    Parameters
+    ----------
+    M:
+        An m×n matrix with ``IRInteger`` / ``IRRational`` entries.
+
+    Returns
+    -------
+    ``List(c₁, c₂, …)`` where each ``cᵢ`` is an m×1 column-vector
+    ``Matrix`` IR node.
+
+    Raises
+    ------
+    MatrixError
+        If M is not a valid matrix or has symbolic entries.
+
+    Examples
+    --------
+    ::
+
+        # [[1,2],[2,4]] → RREF [[1,2],[0,0]], pivot col 0
+        # column space basis: original column 0 = [1,2]
+        columnspace(matrix([[1,2],[2,4]]))
+        # List(Matrix([[1],[2]]))
+    """
+    LIST_HEAD = IRSymbol("List")
+    frows = _matrix_to_fractions(M)
+    pivot_cols, _ = _rref_pivot_info(frows)
+
+    # Extract the corresponding columns from the *original* IR matrix.
+    orig_rows = _rows_of(M)
+    m = num_rows(M)
+
+    col_nodes: list[IRNode] = []
+    for c in pivot_cols:
+        # Build column c as an m×1 matrix of the original entries.
+        col = matrix([[orig_rows[r][c]] for r in range(m)])
+        col_nodes.append(col)
+
+    return IRApply(LIST_HEAD, tuple(col_nodes))
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Row space
+# ---------------------------------------------------------------------------
+
+
+def rowspace(M: IRNode) -> IRApply:
+    """Return a basis for the row space of matrix M.
+
+    The row space is the span of the rows of A.  Its basis is the set of
+    **non-zero rows of the RREF** — row operations preserve the row space,
+    so the non-zero RREF rows form an orthonormal-like basis (pivots at 1,
+    everything else reduced).
+
+    Parameters
+    ----------
+    M:
+        An m×n matrix with ``IRInteger`` / ``IRRational`` entries.
+
+    Returns
+    -------
+    ``List(r₁, r₂, …)`` where each ``rᵢ`` is a 1×n row-vector
+    ``Matrix`` IR node.
+
+    Raises
+    ------
+    MatrixError
+        If M is not a valid matrix or has symbolic entries.
+
+    Examples
+    --------
+    ::
+
+        # [[1,2,3],[4,5,6]] → RREF [[1,0,-1],[0,1,2]]
+        # both rows are non-zero
+        rowspace(matrix([[1,2,3],[4,5,6]]))
+        # List(Matrix([[1,0,-1]]), Matrix([[0,1,2]]))
+    """
+    LIST_HEAD = IRSymbol("List")
+    frows = _matrix_to_fractions(M)
+    _, rref = _rref_pivot_info(frows)
+
+    row_nodes: list[IRNode] = []
+    for row in rref:
+        if any(x != 0 for x in row):
+            ir_row = [_frac_to_ir(x) for x in row]
+            row_nodes.append(matrix([ir_row]))
+
+    return IRApply(LIST_HEAD, tuple(row_nodes))

--- a/code/packages/python/cas-matrix/tests/test_phase19.py
+++ b/code/packages/python/cas-matrix/tests/test_phase19.py
@@ -1,0 +1,813 @@
+"""Phase 19 tests — eigenvalues, eigenvectors, LU, subspaces, norm, charpoly.
+
+This file validates the six new operations added to cas-matrix 0.3.0:
+
+- ``charpoly`` — characteristic polynomial as IR expression
+- ``eigenvalues`` — eigenvalue list with algebraic multiplicity
+- ``eigenvectors`` — eigenspace bases
+- ``lu_decompose`` — LU with partial pivoting (P·A = L·U)
+- ``nullspace`` / ``columnspace`` / ``rowspace`` — subspace bases
+- ``norm`` — Euclidean and Frobenius norms
+"""
+
+from __future__ import annotations
+
+import pytest
+from symbolic_ir import ADD, IRApply, IRInteger, IRRational, IRSymbol
+
+from cas_matrix import (
+    MatrixError,
+    charpoly,
+    columnspace,
+    eigenvalues,
+    eigenvectors,
+    identity_matrix,
+    lu_decompose,
+    matrix,
+    norm,
+    nullspace,
+    rowspace,
+    zero_matrix,
+)
+from cas_matrix.eigenvalues import char_poly_coeffs
+from cas_matrix.matrix import _rows_of, num_cols, num_rows
+from cas_matrix.rowreduce import _entry_to_fraction
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _i(n: int) -> IRInteger:
+    return IRInteger(n)
+
+
+def _r(p: int, q: int) -> IRRational:
+    return IRRational(p, q)
+
+
+def _mat(*rows):
+    """Build a Matrix from int rows."""
+    return matrix([[_i(v) for v in row] for row in rows])
+
+
+def _entries(M):
+    """Extract (numer, denom) pairs from a Matrix for easy assertion."""
+    result = []
+    for row in _rows_of(M):
+        result.append([
+            (e.value, 1) if isinstance(e, IRInteger)
+            else (e.numer, e.denom)
+            for e in row
+        ])
+    return result
+
+
+def _eval_ir(node, x: float = 1.5) -> float:
+    """Numerically evaluate an IR node (for polynomial/eigenvalue checks)."""
+    from symbolic_ir import (
+        DIV,
+        MUL,
+        NEG,
+        POW,
+        SQRT,
+        SUB,
+        IRApply,
+        IRInteger,
+        IRRational,
+        IRSymbol,
+    )
+    LAM = IRSymbol("lambda")
+
+    def ev(n):
+        if isinstance(n, IRInteger):
+            return float(n.value)
+        if isinstance(n, IRRational):
+            return n.numer / n.denom
+        if isinstance(n, IRSymbol):
+            if n == LAM:
+                return x
+            return 0.0
+        if not isinstance(n, IRApply):
+            return 0.0
+        h, args = n.head, n.args
+        if h == ADD:
+            return sum(ev(a) for a in args)
+        if h == SUB:
+            return ev(args[0]) - ev(args[1])
+        if h == MUL:
+            r = 1.0
+            for a in args:
+                r *= ev(a)
+            return r
+        if h == DIV:
+            d = ev(args[1])
+            return ev(args[0]) / d if d else 1e18
+        if h == NEG:
+            return -ev(args[0])
+        if h == POW:
+            try:
+                return ev(args[0]) ** ev(args[1])
+            except (ValueError, ZeroDivisionError):
+                return 0.0
+        if h == SQRT:
+            v = ev(args[0])
+            return v**0.5 if v >= 0 else 0.0
+        return 0.0
+
+    return ev(node)
+
+
+def _is_lower_triangular(M) -> bool:
+    """Check that M is lower triangular (all entries above diagonal are 0)."""
+    rows = _rows_of(M)
+    n = len(rows)
+    for i in range(n):
+        for j in range(i + 1, n):
+            e = rows[i][j]
+            if isinstance(e, IRInteger) and e.value != 0:
+                return False
+            if isinstance(e, IRRational) and e.numer != 0:
+                return False
+    return True
+
+
+def _is_upper_triangular(M) -> bool:
+    """Check that M is upper triangular (all entries below diagonal are 0)."""
+    rows = _rows_of(M)
+    n = len(rows)
+    for i in range(n):
+        for j in range(0, i):
+            e = rows[i][j]
+            if isinstance(e, IRInteger) and e.value != 0:
+                return False
+            if isinstance(e, IRRational) and e.numer != 0:
+                return False
+    return True
+
+
+def _diagonal(M):
+    """Return diagonal entries as (numer, denom) pairs."""
+    rows = _rows_of(M)
+    result = []
+    for i, row in enumerate(rows):
+        e = row[i]
+        if isinstance(e, IRInteger):
+            result.append((e.value, 1))
+        else:
+            result.append((e.numer, e.denom))
+    return result
+
+
+def _mat_mul_fracs(A_rows, B_rows):
+    """Fraction matrix multiply: returns list-of-lists of Fraction."""
+    m, k = len(A_rows), len(A_rows[0])
+    n = len(B_rows[0])
+    return [
+        [sum(A_rows[i][p] * B_rows[p][j] for p in range(k)) for j in range(n)]
+        for i in range(m)
+    ]
+
+
+def _ir_mat_to_fracs(M):
+    """Extract matrix entries as Fractions."""
+    from cas_matrix.rowreduce import _entry_to_fraction
+    return [[_entry_to_fraction(e) for e in row] for row in _rows_of(M)]
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Characteristic polynomial
+# ---------------------------------------------------------------------------
+
+
+class TestPhase19_CharPoly:
+    """charpoly(A, λ) returns det(λI − A) as an IR polynomial in λ."""
+
+    def test_1x1(self):
+        A = _mat([5])
+        lam = IRSymbol("lambda")
+        cp = charpoly(A, lam)
+        # char poly = λ − 5; evaluate at λ=7: 7-5=2
+        assert abs(_eval_ir(cp, 7.0) - 2.0) < 1e-9
+
+    def test_2x2_integer(self):
+        # [[1,2],[2,1]]: char poly = (λ-1)²-4 = λ²-2λ-3
+        A = _mat([1, 2], [2, 1])
+        lam = IRSymbol("lambda")
+        cp = charpoly(A, lam)
+        # At λ=3: 9-6-3=0 (root); at λ=-1: 1+2-3=0 (root)
+        assert abs(_eval_ir(cp, 3.0)) < 1e-9
+        assert abs(_eval_ir(cp, -1.0)) < 1e-9
+        # At λ=0: -3
+        assert abs(_eval_ir(cp, 0.0) - (-3.0)) < 1e-9
+
+    def test_2x2_rational_entries(self):
+        # [[1/2, 1],[0, 2]]: char poly = (λ-1/2)(λ-2) = λ²-5/2·λ+1
+        A = matrix([[_r(1, 2), _i(1)], [_i(0), _i(2)]])
+        lam = IRSymbol("lambda")
+        cp = charpoly(A, lam)
+        # At λ=1/2 and λ=2: should be roots
+        assert abs(_eval_ir(cp, 0.5)) < 1e-9
+        assert abs(_eval_ir(cp, 2.0)) < 1e-9
+
+    def test_2x2_identity(self):
+        # identity: char poly = (λ-1)² = λ²-2λ+1
+        A = identity_matrix(2)
+        lam = IRSymbol("lambda")
+        cp = charpoly(A, lam)
+        # At λ=1: root; at λ=2: 4-4+1=1
+        assert abs(_eval_ir(cp, 1.0)) < 1e-9
+        assert abs(_eval_ir(cp, 2.0) - 1.0) < 1e-9
+
+    def test_3x3_diagonal(self):
+        # diag(1,3,5): char poly = (λ-1)(λ-3)(λ-5)
+        D = _mat([1, 0, 0], [0, 3, 0], [0, 0, 5])
+        lam = IRSymbol("lambda")
+        cp = charpoly(D, lam)
+        assert abs(_eval_ir(cp, 1.0)) < 1e-9
+        assert abs(_eval_ir(cp, 3.0)) < 1e-9
+        assert abs(_eval_ir(cp, 5.0)) < 1e-9
+        # Non-roots should be non-zero
+        assert abs(_eval_ir(cp, 2.0)) > 0.5
+
+    def test_3x3_general(self):
+        # [[2,1,0],[1,2,1],[0,1,2]]: tridiagonal
+        A = _mat([2, 1, 0], [1, 2, 1], [0, 1, 2])
+        lam = IRSymbol("lambda")
+        cp = charpoly(A, lam)
+        # Roots are 2-√2, 2, 2+√2  (≈ 0.586, 2, 3.414)
+        assert abs(_eval_ir(cp, 2.0)) < 1e-9
+        assert abs(_eval_ir(cp, 2 - 2**0.5)) < 1e-6
+        assert abs(_eval_ir(cp, 2 + 2**0.5)) < 1e-6
+
+    def test_char_poly_coeffs_2x2(self):
+        from fractions import Fraction
+        A = _mat([1, 2], [2, 1])
+        coeffs = char_poly_coeffs(A)
+        # det(λI-A) = λ²-2λ-3 → [−3, −2, 1]
+        assert coeffs == [Fraction(-3), Fraction(-2), Fraction(1)]
+
+    def test_non_square_raises(self):
+        A = _mat([1, 2, 3], [4, 5, 6])
+        lam = IRSymbol("lambda")
+        with pytest.raises(MatrixError):
+            charpoly(A, lam)
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Eigenvalues
+# ---------------------------------------------------------------------------
+
+
+class TestPhase19_Eigenvalues:
+    """eigenvalues(A) → List(List(λ, m), …)."""
+
+    def _get_eig_pairs(self, M):
+        """Return list of (float_val, int_mult) from eigenvalues(M)."""
+        eigs = eigenvalues(M)
+        assert isinstance(eigs, IRApply)
+        pairs = []
+        for pair in eigs.args:
+            lam_ir, mult_ir = pair.args
+            pairs.append((_eval_ir(lam_ir, 0.0), mult_ir.value))
+        return pairs
+
+    def test_1x1(self):
+        A = _mat([7])
+        pairs = self._get_eig_pairs(A)
+        assert len(pairs) == 1
+        assert abs(pairs[0][0] - 7.0) < 1e-9
+        assert pairs[0][1] == 1
+
+    def test_2x2_integer_distinct(self):
+        # [[1,2],[2,1]]: eigs -1, 3
+        A = _mat([1, 2], [2, 1])
+        pairs = sorted(self._get_eig_pairs(A))
+        assert abs(pairs[0][0] - (-1.0)) < 1e-9
+        assert pairs[0][1] == 1
+        assert abs(pairs[1][0] - 3.0) < 1e-9
+        assert pairs[1][1] == 1
+
+    def test_2x2_repeated_eigenvalue(self):
+        # [[2,0],[0,2]]: eig 2 with multiplicity 2
+        A = _mat([2, 0], [0, 2])
+        pairs = self._get_eig_pairs(A)
+        assert len(pairs) == 1
+        assert abs(pairs[0][0] - 2.0) < 1e-9
+        assert pairs[0][1] == 2
+
+    def test_2x2_rational_eigenvalue(self):
+        # [[1/2, 0],[0, 3]]: eigs 1/2 and 3
+        A = matrix([[_r(1, 2), _i(0)], [_i(0), _i(3)]])
+        pairs = sorted(self._get_eig_pairs(A))
+        assert abs(pairs[0][0] - 0.5) < 1e-9
+        assert abs(pairs[1][0] - 3.0) < 1e-9
+
+    def test_3x3_diagonal(self):
+        D = _mat([1, 0, 0], [0, 3, 0], [0, 0, 5])
+        pairs = sorted(self._get_eig_pairs(D))
+        assert len(pairs) == 3
+        expected = [(1.0, 1), (3.0, 1), (5.0, 1)]
+        for (pv, pm), (ev, em) in zip(pairs, expected, strict=False):
+            assert abs(pv - ev) < 1e-9
+            assert pm == em
+
+    def test_3x3_repeated(self):
+        # [[3,0,0],[0,3,0],[0,0,5]]: eig 3 (mult 2) and 5 (mult 1)
+        A = _mat([3, 0, 0], [0, 3, 0], [0, 0, 5])
+        pairs = sorted(self._get_eig_pairs(A))
+        assert len(pairs) == 2
+        assert abs(pairs[0][0] - 3.0) < 1e-9
+        assert pairs[0][1] == 2
+        assert abs(pairs[1][0] - 5.0) < 1e-9
+        assert pairs[1][1] == 1
+
+    def test_sum_of_multiplicities_equals_n(self):
+        """Total multiplicity must equal matrix dimension."""
+        for A in [
+            _mat([1, 2], [2, 1]),          # 2x2 distinct
+            _mat([2, 0], [0, 2]),           # 2x2 repeated
+            _mat([1, 0, 0], [0, 3, 0], [0, 0, 5]),  # 3x3 distinct
+        ]:
+            n = num_rows(A)
+            eigs = eigenvalues(A)
+            total = sum(pair.args[1].value for pair in eigs.args)
+            assert total == n, f"Total multiplicity {total} ≠ {n}"
+
+    def test_2x2_complex_eigenvalues(self):
+        # [[0,-1],[1,0]]: char poly = λ²+1, roots ±i
+        A = _mat([0, -1], [1, 0])
+        eigs = eigenvalues(A)
+        # Should return 2 eigenvalues (complex)
+        assert isinstance(eigs, IRApply)
+        assert len(eigs.args) == 2
+        # Sum of multiplicities = 2
+        total = sum(pair.args[1].value for pair in eigs.args)
+        assert total == 2
+
+    def test_4x4_diagonal(self):
+        D = _mat([1, 0, 0, 0], [0, 2, 0, 0], [0, 0, 3, 0], [0, 0, 0, 4])
+        pairs = sorted(self._get_eig_pairs(D))
+        assert len(pairs) == 4
+        for i, (pv, pm) in enumerate(pairs):
+            assert abs(pv - (i + 1)) < 1e-9
+            assert pm == 1
+
+    def test_5x5_raises(self):
+        A = _mat([1, 0, 0, 0, 0],
+                 [0, 1, 0, 0, 0],
+                 [0, 0, 1, 0, 0],
+                 [0, 0, 0, 1, 0],
+                 [0, 0, 0, 0, 1])
+        with pytest.raises(MatrixError):
+            eigenvalues(A)
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Eigenvectors
+# ---------------------------------------------------------------------------
+
+
+class TestPhase19_Eigenvectors:
+    """eigenvectors(A) → List(List(λ, m, List(v₁, v₂, …)), …)."""
+
+    def test_2x2_distinct_eigenvalues(self):
+        # [[1,2],[2,1]]: eigs -1, 3
+        A = _mat([1, 2], [2, 1])
+        evecs = eigenvectors(A)
+        assert isinstance(evecs, IRApply)
+        triples = evecs.args
+        assert len(triples) == 2  # two distinct eigenvalues
+        # Each triple has 3 args: (lam, mult, vec_list)
+        for triple in triples:
+            lam_ir, mult_ir, vec_list = triple.args
+            assert isinstance(mult_ir, IRInteger)
+            # Each eigenvector list should have at least one vector.
+            assert len(vec_list.args) >= 1
+
+    def test_eigenvector_satisfies_Av_equals_lam_v(self):
+        # For [[3,1],[0,3]], eig λ=3 (repeated), verify A·v = 3·v
+        A = _mat([3, 1], [0, 3])
+        evecs = eigenvectors(A)
+        for triple in evecs.args:
+            lam_ir, mult_ir, vec_list = triple.args
+            lam_frac = _entry_to_fraction(lam_ir)
+            if lam_frac is None:
+                continue
+            for v_mat in vec_list.args:
+                # Compute A·v and λ·v entry by entry using Fractions.
+                from cas_matrix.rowreduce import _entry_to_fraction as etf
+                A_f = [[etf(e) for e in row] for row in _rows_of(A)]
+                v_f = [etf(_rows_of(v_mat)[r][0]) for r in range(len(A_f))]
+                Av = [sum(A_f[i][j] * v_f[j] for j in range(len(v_f)))
+                      for i in range(len(A_f))]
+                lv = [lam_frac * v_f[i] for i in range(len(v_f))]
+                for a, b in zip(Av, lv, strict=False):
+                    assert abs(float(a - b)) < 1e-9
+
+    def test_2x2_repeated_eigenvalue_gives_2_vectors(self):
+        # [[2,0],[0,2]]: eig 2 (mult 2), eigenspace is all of R²
+        A = _mat([2, 0], [0, 2])
+        evecs = eigenvectors(A)
+        assert len(evecs.args) == 1  # one eigenvalue
+        triple = evecs.args[0]
+        lam_ir, mult_ir, vec_list = triple.args
+        assert lam_ir == _i(2)
+        assert mult_ir.value == 2
+        assert len(vec_list.args) == 2  # two basis vectors
+
+    def test_3x3_diagonal_standard_basis(self):
+        # diag(1,3,5): eigenvectors are standard basis vectors
+        D = _mat([1, 0, 0], [0, 3, 0], [0, 0, 5])
+        evecs = eigenvectors(D)
+        assert len(evecs.args) == 3
+        # Collect all eigenvectors — should form identity columns
+        all_vecs = []
+        for triple in evecs.args:
+            vec_list = triple.args[2]
+            for v in vec_list.args:
+                col = [_entry_to_fraction(row[0]) for row in _rows_of(v)]
+                all_vecs.append(col)
+        # Sort by first non-zero entry
+        all_vecs.sort(key=lambda v: next(x for x in v if x != 0))
+        from fractions import Fraction
+        expected = [
+            [Fraction(1), Fraction(0), Fraction(0)],
+            [Fraction(0), Fraction(1), Fraction(0)],
+            [Fraction(0), Fraction(0), Fraction(1)],
+        ]
+        for got, exp in zip(all_vecs, expected, strict=False):
+            for g, e in zip(got, exp, strict=False):
+                assert g == e
+
+    def test_eigenvectors_are_column_vectors(self):
+        """Eigenvectors must be n×1 matrices."""
+        A = _mat([1, 2], [2, 1])
+        evecs = eigenvectors(A)
+        for triple in evecs.args:
+            vec_list = triple.args[2]
+            for v in vec_list.args:
+                assert num_rows(v) == 2
+                assert num_cols(v) == 1
+
+    def test_irrational_eigenvalue_gets_empty_vector_list(self):
+        # [[0,1],[-1,0]]: char poly = λ²+1, complex eigenvalues
+        A = _mat([0, 1], [-1, 0])
+        evecs = eigenvectors(A)
+        for triple in evecs.args:
+            vec_list = triple.args[2]
+            # Complex eigenvalue → empty vector list
+            assert len(vec_list.args) == 0
+
+    def test_structure_format(self):
+        """Result is List(List(λ, m, List(…)), …)."""
+        A = _mat([2, 0], [0, 3])
+        evecs = eigenvectors(A)
+        assert isinstance(evecs, IRApply)
+        assert evecs.head == IRSymbol("List")
+        for triple in evecs.args:
+            assert isinstance(triple, IRApply)
+            assert len(triple.args) == 3  # λ, m, vec_list
+
+    def test_defective_matrix(self):
+        # [[3,1],[0,3]]: eig λ=3 (mult 2 algebraic, geom 1 — defective)
+        A = _mat([3, 1], [0, 3])
+        evecs = eigenvectors(A)
+        assert len(evecs.args) == 1  # one eigenvalue
+        lam_ir, mult_ir, vec_list = evecs.args[0].args
+        # Algebraic multiplicity = 2
+        assert mult_ir.value == 2
+        # Geometric multiplicity = 1 (only one linearly independent eigenvector)
+        assert len(vec_list.args) == 1
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — LU decomposition
+# ---------------------------------------------------------------------------
+
+
+class TestPhase19_LU:
+    """lu_decompose(A) → List(L, U, P) with P·A = L·U."""
+
+    def _verify_lu(self, A):
+        """Assert that P·A = L·U holds entry-by-entry."""
+        L, U, P = lu_decompose(A).args
+        assert _is_lower_triangular(L), "L must be lower triangular"
+        assert _is_upper_triangular(U), "U must be upper triangular"
+        # L has 1s on diagonal
+        assert all(v == (1, 1) for v in _diagonal(L)), "L diagonal must be 1"
+        # Check P·A = L·U numerically
+        A_f = _ir_mat_to_fracs(A)
+        L_f = _ir_mat_to_fracs(L)
+        U_f = _ir_mat_to_fracs(U)
+        P_f = _ir_mat_to_fracs(P)
+        PA = _mat_mul_fracs(P_f, A_f)
+        LU_prod = _mat_mul_fracs(L_f, U_f)
+        for i, row in enumerate(PA):
+            for j, val in enumerate(row):
+                assert abs(float(val - LU_prod[i][j])) < 1e-10, \
+                    f"P·A ≠ L·U at ({i},{j})"
+
+    def test_2x2_no_pivoting(self):
+        # [[2,1],[1,3]]: no row swap needed
+        A = _mat([2, 1], [1, 3])
+        L, U, P = lu_decompose(A).args
+        self._verify_lu(A)
+        # P should be identity
+        assert _entries(P) == [[(1, 1), (0, 1)], [(0, 1), (1, 1)]]
+
+    def test_2x2_requires_pivoting(self):
+        # [[0,1],[1,0]]: first column starts with 0 → must pivot
+        A = _mat([0, 1], [1, 0])
+        L, U, P = lu_decompose(A).args
+        self._verify_lu(A)
+        # P should be [[0,1],[1,0]]
+        assert _entries(P) == [[(0, 1), (1, 1)], [(1, 1), (0, 1)]]
+
+    def test_3x3_general(self):
+        A = _mat([2, 1, 1], [4, 3, 3], [8, 7, 9])
+        self._verify_lu(A)
+
+    def test_3x3_identity(self):
+        Id = identity_matrix(3)
+        L, U, P = lu_decompose(Id).args
+        self._verify_lu(Id)
+        # L, U, P all equal identity
+        assert _entries(L) == _entries(Id)
+        assert _entries(U) == _entries(Id)
+        assert _entries(P) == _entries(Id)
+
+    def test_rational_entries(self):
+        A = matrix([[_r(1, 2), _i(1)], [_i(1), _r(1, 2)]])
+        self._verify_lu(A)
+
+    def test_singular_raises(self):
+        # Singular matrix: all zeros
+        Z = zero_matrix(2, 2)
+        with pytest.raises(MatrixError):
+            lu_decompose(Z)
+
+    def test_non_square_raises(self):
+        A = _mat([1, 2, 3], [4, 5, 6])
+        with pytest.raises(MatrixError):
+            lu_decompose(A)
+
+    def test_returns_list_of_three_matrices(self):
+        A = _mat([1, 2], [3, 4])
+        result = lu_decompose(A)
+        assert isinstance(result, IRApply)
+        assert len(result.args) == 3
+        L, U, P = result.args
+        assert num_rows(L) == num_cols(L) == 2
+        assert num_rows(U) == num_cols(U) == 2
+        assert num_rows(P) == num_cols(P) == 2
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Subspaces
+# ---------------------------------------------------------------------------
+
+
+class TestPhase19_Subspaces:
+    """nullspace, columnspace, rowspace via RREF."""
+
+    # --- nullspace ---
+
+    def test_nullspace_full_rank_is_empty(self):
+        Id = identity_matrix(3)
+        ns = nullspace(Id)
+        assert len(ns.args) == 0
+
+    def test_nullspace_singular_2x2(self):
+        # [[1,2],[2,4]]: rank 1, nullspace dimension 1
+        A = _mat([1, 2], [2, 4])
+        ns = nullspace(A)
+        assert len(ns.args) == 1
+        # The null vector v satisfies A·v = 0
+        from fractions import Fraction
+
+        from cas_matrix.rowreduce import _entry_to_fraction as etf
+        A_f = [[etf(e) for e in row] for row in _rows_of(A)]
+        v = ns.args[0]
+        v_f = [etf(_rows_of(v)[r][0]) for r in range(2)]
+        Av = [sum(A_f[i][j] * v_f[j] for j in range(2)) for i in range(2)]
+        for entry in Av:
+            assert entry == Fraction(0)
+
+    def test_nullspace_2_free_variables(self):
+        # [[1,2,3],[4,5,6]]: rank 2, nullity 1
+        A = _mat([1, 2, 3], [4, 5, 6])
+        ns = nullspace(A)
+        assert len(ns.args) == 1  # one free variable (col 2)
+        # RREF: [[1,0,-1],[0,1,2]], free col 2
+        # v = [1, -2, 1]
+        v = ns.args[0]
+        # v[0]=1, v[1]=-2, v[2]=1
+        from fractions import Fraction
+
+        from cas_matrix.rowreduce import _entry_to_fraction as etf
+        v_f = [etf(_rows_of(v)[r][0]) for r in range(3)]
+        assert v_f[2] == Fraction(1)  # free variable = 1
+        # A·v should be 0
+        A_f = [[etf(e) for e in row] for row in _rows_of(A)]
+        Av = [sum(A_f[i][j] * v_f[j] for j in range(3)) for i in range(2)]
+        for entry in Av:
+            assert entry == Fraction(0)
+
+    def test_nullspace_zero_matrix_full_null(self):
+        # Zero matrix: entire space is null space
+        Z = zero_matrix(2, 3)
+        ns = nullspace(Z)
+        # 2×3 zero matrix: rank 0, nullity 3
+        assert len(ns.args) == 3
+
+    # --- columnspace ---
+
+    def test_columnspace_full_rank(self):
+        # 2×2 identity: columnspace is R² (both columns)
+        A = identity_matrix(2)
+        cs = columnspace(A)
+        assert len(cs.args) == 2
+
+    def test_columnspace_rank_deficient(self):
+        # [[1,2],[2,4]]: rank 1, col space = span of col 0
+        A = _mat([1, 2], [2, 4])
+        cs = columnspace(A)
+        assert len(cs.args) == 1
+        # The single basis vector should be col 0: [1, 2]
+        col = cs.args[0]
+        col_entries = [_entry_to_fraction(row[0]) for row in _rows_of(col)]
+        from fractions import Fraction
+        assert col_entries[0] == Fraction(1)
+        assert col_entries[1] == Fraction(2)
+
+    def test_columnspace_vectors_are_column_vectors(self):
+        A = _mat([1, 2, 3], [4, 5, 6])
+        cs = columnspace(A)
+        for col in cs.args:
+            assert num_rows(col) == 2
+            assert num_cols(col) == 1
+
+    # --- rowspace ---
+
+    def test_rowspace_full_rank(self):
+        A = identity_matrix(2)
+        rs = rowspace(A)
+        assert len(rs.args) == 2
+
+    def test_rowspace_rank_deficient(self):
+        # [[1,2,3],[2,4,6]]: rank 1, row space = one non-zero RREF row
+        A = _mat([1, 2, 3], [2, 4, 6])
+        rs = rowspace(A)
+        assert len(rs.args) == 1
+
+    def test_rowspace_general_3x4(self):
+        # [[1,2,3,4],[0,1,2,3],[0,0,0,1]]: rank 3
+        A = _mat([1, 2, 3, 4], [0, 1, 2, 3], [0, 0, 0, 1])
+        rs = rowspace(A)
+        assert len(rs.args) == 3
+
+    def test_rowspace_vectors_are_row_vectors(self):
+        A = _mat([1, 2, 3], [4, 5, 6])
+        rs = rowspace(A)
+        for row_vec in rs.args:
+            assert num_rows(row_vec) == 1
+            assert num_cols(row_vec) == 3
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Norm
+# ---------------------------------------------------------------------------
+
+
+class TestPhase19_Norm:
+    """norm(v) — Euclidean; norm(A, 'frobenius') — Frobenius."""
+
+    def test_345_vector_gives_5(self):
+        # [3, 4]: ‖v‖ = √(9+16) = √25 = 5
+        v = matrix([[_i(3)], [_i(4)]])
+        result = norm(v)
+        assert isinstance(result, IRInteger)
+        assert result.value == 5
+
+    def test_euclidean_non_perfect_square(self):
+        # [1, 1]: ‖v‖ = √2
+        v = matrix([[_i(1)], [_i(1)]])
+        result = norm(v)
+        # Should be Sqrt(2) = IRApply(SQRT, (IRInteger(2),))
+        from symbolic_ir import SQRT
+        assert isinstance(result, IRApply)
+        assert result.head == SQRT
+
+    def test_frobenius_perfect_square(self):
+        # [[1,1],[1,1]]: ‖A‖_F = √(1+1+1+1) = √4 = 2
+        A = _mat([1, 1], [1, 1])
+        result = norm(A, "frobenius")
+        assert isinstance(result, IRInteger)
+        assert result.value == 2
+
+    def test_frobenius_3x3_identity(self):
+        # ‖I_3‖_F = √3
+        Id = identity_matrix(3)
+        result = norm(Id, "frobenius")
+        from symbolic_ir import SQRT
+        assert isinstance(result, IRApply)
+        assert result.head == SQRT
+
+    def test_row_vector_norm(self):
+        # Row vector [3, 4]: ‖v‖ = 5
+        v = matrix([[_i(3), _i(4)]])
+        result = norm(v)
+        assert isinstance(result, IRInteger)
+        assert result.value == 5
+
+    def test_rational_entries(self):
+        # [3/5, 4/5]: ‖v‖ = √(9/25 + 16/25) = √(25/25) = 1
+        v = matrix([[_r(3, 5)], [_r(4, 5)]])
+        result = norm(v)
+        assert isinstance(result, IRInteger)
+        assert result.value == 1
+
+    def test_norm_matrix_without_frobenius_raises(self):
+        # Passing a non-vector without 'frobenius' flag should raise.
+        A = _mat([1, 2], [3, 4])
+        with pytest.raises(MatrixError):
+            norm(A)
+
+    def test_unknown_norm_kind_raises(self):
+        A = _mat([1, 2], [3, 4])
+        with pytest.raises(MatrixError):
+            norm(A, "spectral")
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Fallthrough and error cases
+# ---------------------------------------------------------------------------
+
+
+class TestPhase19_Fallthrough:
+    """Operations that should raise MatrixError for invalid inputs."""
+
+    def test_eigenvalues_non_square_raises(self):
+        A = _mat([1, 2, 3], [4, 5, 6])
+        with pytest.raises(MatrixError):
+            eigenvalues(A)
+
+    def test_eigenvectors_5x5_raises(self):
+        I5 = identity_matrix(5)
+        with pytest.raises(MatrixError):
+            eigenvectors(I5)
+
+    def test_lu_singular_raises(self):
+        # All-zero row → singular at first pivot column
+        A = _mat([0, 0], [0, 0])
+        with pytest.raises(MatrixError):
+            lu_decompose(A)
+
+    def test_symbolic_entry_eigenvalues_raises(self):
+        A = matrix([[IRSymbol("a"), _i(1)], [_i(0), _i(2)]])
+        with pytest.raises(MatrixError):
+            eigenvalues(A)
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Regressions (Phase 0.2.0 ops still work)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase19_Regressions:
+    """Ensure Phase 0.2.0 operations are unaffected."""
+
+    def test_rank_still_works(self):
+        from cas_matrix import rank
+        M = _mat([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        assert rank(M) == _i(2)
+
+    def test_row_reduce_still_works(self):
+        from cas_matrix import row_reduce
+        M = _mat([1, 2], [3, 4])
+        R = row_reduce(M)
+        e = _entries(R)
+        assert e[0][0] == (1, 1) and e[1][1] == (1, 1)
+
+    def test_determinant_still_works(self):
+        from cas_matrix import determinant
+        M = _mat([1, 2], [3, 4])
+        d = determinant(M)
+        # det = 1*4 - 2*3 = -2; result is unsimplified IR
+        # Just check it's non-trivial IR
+        assert d is not None
+
+    def test_inverse_still_works(self):
+        from cas_matrix import inverse
+        I2 = identity_matrix(2)
+        inv = inverse(I2)
+        # inv of identity is identity
+        assert num_rows(inv) == 2
+
+    def test_trace_still_works(self):
+        from cas_matrix import trace
+        A = _mat([1, 2], [3, 4])
+        t = trace(A)
+        # trace = 1 + 4 = Add(1, 4) — unsimplified
+        assert t is not None

--- a/code/packages/python/cas-matrix/tests/test_rowreduce.py
+++ b/code/packages/python/cas-matrix/tests/test_rowreduce.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from symbolic_ir import IRInteger, IRRational
 
 from cas_matrix import (
@@ -14,7 +13,6 @@ from cas_matrix import (
     row_reduce,
     zero_matrix,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -116,8 +114,8 @@ class TestRank:
 
 class TestRowReduce:
     def test_identity_2x2_unchanged(self):
-        I = identity_matrix(2)
-        R = row_reduce(I)
+        Id = identity_matrix(2)
+        R = row_reduce(Id)
         assert _entries(R) == [[(1, 1), (0, 1)], [(0, 1), (1, 1)]]
 
     def test_2x2_full_rank(self):

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.39.0 — 2026-05-04
+
+**Phase 19 — Linear algebra completion: 8 new VM handlers for `cas-matrix` 0.3.0.**
+
+Bumps `coding-adventures-cas-matrix` minimum version from `>=0.2.0` to
+`>=0.3.0` and wires in handlers for all six new linear algebra operations
+added in `cas-matrix` 0.3.0.
+
+### New VM handlers in `cas_handlers.py`
+
+| Handler | Expression form | Returns |
+|---------|-----------------|---------|
+| `eigenvalues_handler` | `Eigenvalues(M)` | `List(List(λ₁,m₁), …)` — eigenvalue/multiplicity pairs |
+| `eigenvectors_handler` | `Eigenvectors(M)` | `List(List(λ,m,List(v₁,…)), …)` — eigenvalue + basis vectors |
+| `charpoly_handler` | `CharPoly(M, λ)` | IR polynomial `det(λI−M)` in the given symbol |
+| `lu_handler` | `LU(M)` | `List(L, U, P)` from Doolittle partial-pivoting decomposition |
+| `nullspace_handler` | `NullSpace(M)` | `List(v₁,…)` of n×1 null-space basis column vectors |
+| `columnspace_handler` | `ColumnSpace(M)` | `List(c₁,…)` of m×1 column-space basis vectors |
+| `rowspace_handler` | `RowSpace(M)` | `List(r₁,…)` of 1×n row-space basis vectors |
+| `norm_handler` | `Norm(v)` or `Norm(M, frobenius)` | Euclidean or Frobenius norm |
+
+All handlers fall through to the unevaluated `IRApply` on `MatrixError` (symbolic
+entries, wrong shape, size > 4×4 for eigenvalue routines, etc.).
+
+`CharPoly` requires the second argument to be an `IRSymbol` naming the variable.
+`Norm` with `frobenius` keyword accepts `IRSymbol("frobenius")` as the kind argument.
+
+### Fallthrough semantics
+
+All eight handlers return the original unevaluated `expr` on any `MatrixError`,
+matching the pattern used by `rank_handler`, `row_reduce_handler`, and the other
+existing matrix handlers.
+
+---
+
 ## 0.38.0 — 2026-04-29
 
 **Phase 18 — `cas-ode` 0.2.0 dependency bump (Bernoulli · Exact · Non-homogeneous 2nd-order).**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.38.0"
+version = "0.39.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -22,7 +22,7 @@ dependencies = [
     "coding-adventures-cas-factor>=0.3.0",
     "coding-adventures-cas-solve>=0.6.0",
     "coding-adventures-cas-list-operations",
-    "coding-adventures-cas-matrix>=0.2.0",
+    "coding-adventures-cas-matrix>=0.3.0",
     "coding-adventures-cas-limit-series",
     "coding-adventures-cas-number-theory>=0.1.0",
     "coding-adventures-cas-complex>=0.1.0",

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -40,7 +40,6 @@ from fractions import Fraction
 from typing import TYPE_CHECKING
 
 from cas_algebraic import build_alg_factor_handler_table as _build_algebraic
-from cas_multivariate import build_multivariate_handler_table as _build_multivariate
 from cas_complex import IMAGINARY_UNIT as _IMAGINARY_UNIT
 from cas_complex import build_complex_handler_table as _build_complex
 from cas_complex.handlers import (
@@ -73,19 +72,28 @@ from cas_list_operations import (
 )
 from cas_matrix import (
     MatrixError,
+    charpoly,
+    columnspace,
     determinant,
     dimensions,
     dot,
+    eigenvalues,
+    eigenvectors,
     identity_matrix,
     inverse,
+    lu_decompose,
     matrix,
+    norm,
+    nullspace,
     rank,
     row_reduce,
+    rowspace,
     trace,
     transpose,
     zero_matrix,
 )
 from cas_mnewton import build_mnewton_handler_table as _build_mnewton
+from cas_multivariate import build_multivariate_handler_table as _build_multivariate
 from cas_number_theory.handlers import build_number_theory_handler_table as _build_nt
 from cas_ode import build_ode_handler_table as _build_ode
 from cas_simplify import canonical, simplify
@@ -1248,6 +1256,164 @@ def row_reduce_handler(_vm: VM, expr: IRApply) -> IRNode:
         return expr
 
 
+def eigenvalues_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``Eigenvalues(M)`` → ``List(List(λ₁, m₁), List(λ₂, m₂), …)``.
+
+    Each inner ``List`` contains the eigenvalue followed by its algebraic
+    multiplicity.  Dispatches to ``cas-solve`` (linear through quartic) for
+    the characteristic polynomial.  Falls through on:
+
+    - Non-square or non-matrix input.
+    - Matrix larger than 4×4 (higher-degree char poly not supported).
+    - Symbolic entries (cannot form rational char poly).
+    """
+    if len(expr.args) != 1:
+        return expr
+    try:
+        return eigenvalues(expr.args[0])
+    except MatrixError:
+        return expr
+
+
+def eigenvectors_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``Eigenvectors(M)`` → ``List(List(λ, m, List(v₁, …)), …)``.
+
+    For each eigenvalue, returns its multiplicity and null-space basis vectors
+    for ``(A − λI)``.  Eigenvectors are returned as n×1 column-vector
+    ``Matrix`` nodes.
+
+    Exact null spaces are computed only for rational eigenvalues.  Complex or
+    irrational eigenvalues yield an empty ``List()`` for their vector group —
+    the pair ``(λ, m)`` is still included so callers know the eigenvalue
+    exists.
+
+    Falls through on non-square / symbolic / >4×4 input.
+    """
+    if len(expr.args) != 1:
+        return expr
+    try:
+        return eigenvectors(expr.args[0])
+    except MatrixError:
+        return expr
+
+
+def charpoly_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``CharPoly(M, λ)`` → ``det(λI − M)`` as an IR polynomial in λ.
+
+    The second argument must be an ``IRSymbol`` naming the variable.  Falls
+    through on non-square input, symbolic matrix entries, or wrong arity.
+    """
+    if len(expr.args) != 2:
+        return expr
+    mat_node, lam_node = expr.args
+    if not isinstance(lam_node, IRSymbol):
+        return expr
+    try:
+        return charpoly(mat_node, lam_node)
+    except MatrixError:
+        return expr
+
+
+def lu_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``LU(M)`` → ``List(L, U, P)`` from Doolittle LU decomposition.
+
+    Returns the three matrices such that ``P·M = L·U``:
+
+    - ``L`` — unit lower-triangular (1s on diagonal).
+    - ``U`` — upper-triangular.
+    - ``P`` — permutation matrix encoding the row-swap history.
+
+    Falls through on non-square, singular, or symbolic input.
+    """
+    if len(expr.args) != 1:
+        return expr
+    try:
+        return lu_decompose(expr.args[0])
+    except MatrixError:
+        return expr
+
+
+def nullspace_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``NullSpace(M)`` → ``List(v₁, v₂, …)`` — null-space basis.
+
+    Each ``vᵢ`` is an n×1 column-vector ``Matrix`` node.  Returns
+    ``List()`` (empty) when M has full column rank.  Falls through on
+    symbolic entries or non-matrix input.
+    """
+    if len(expr.args) != 1:
+        return expr
+    try:
+        return nullspace(expr.args[0])
+    except MatrixError:
+        return expr
+
+
+def columnspace_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``ColumnSpace(M)`` → ``List(c₁, c₂, …)`` — column-space basis.
+
+    Basis vectors are the pivot columns of the **original** matrix M (not
+    the RREF), each returned as an m×1 column-vector ``Matrix`` node.
+    Falls through on symbolic entries or non-matrix input.
+    """
+    if len(expr.args) != 1:
+        return expr
+    try:
+        return columnspace(expr.args[0])
+    except MatrixError:
+        return expr
+
+
+def rowspace_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``RowSpace(M)`` → ``List(r₁, r₂, …)`` — row-space basis.
+
+    Basis vectors are the non-zero rows of the RREF of M, each returned as
+    a 1×n row-vector ``Matrix`` node.  Falls through on symbolic entries or
+    non-matrix input.
+    """
+    if len(expr.args) != 1:
+        return expr
+    try:
+        return rowspace(expr.args[0])
+    except MatrixError:
+        return expr
+
+
+def norm_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``Norm(M)`` or ``Norm(M, "frobenius")`` → matrix/vector norm.
+
+    One-argument form computes the **Euclidean** (L²) norm of a column or
+    row vector.  Raises (falls through) for a general matrix.
+
+    Two-argument form requires the second argument to be the string literal
+    ``IRSymbol("frobenius")`` and computes the **Frobenius** norm of any
+    matrix.
+
+    Returns:
+
+    - ``IRInteger`` or ``IRRational`` when the sum of squares is a perfect
+      rational square (exact result).
+    - ``IRApply(SQRT, (sum_of_squares,))`` otherwise.
+
+    Falls through on symbolic entries, wrong arity, or unknown norm kind.
+    """
+    if len(expr.args) == 1:
+        try:
+            return norm(expr.args[0])
+        except MatrixError:
+            return expr
+    if len(expr.args) == 2:
+        kind_node = expr.args[1]
+        # Accept IRSymbol("frobenius") as the norm kind string.
+        if not isinstance(kind_node, IRSymbol):
+            return expr
+        kind_str = str(kind_node.name)
+        try:
+            return norm(expr.args[0], kind_str)
+        except MatrixError:
+            return expr
+    return expr
+
+
 # ===========================================================================
 # Section 7: cas_limit_series handlers
 # ===========================================================================
@@ -1814,6 +1980,14 @@ def build_cas_handler_table() -> dict[str, Handler]:
         "ZeroMatrix": zero_matrix_handler,
         "Rank": rank_handler,
         "RowReduce": row_reduce_handler,
+        "Eigenvalues": eigenvalues_handler,
+        "Eigenvectors": eigenvectors_handler,
+        "CharPoly": charpoly_handler,
+        "LU": lu_handler,
+        "NullSpace": nullspace_handler,
+        "ColumnSpace": columnspace_handler,
+        "RowSpace": rowspace_handler,
+        "Norm": norm_handler,
         # --- cas_limit_series -----------------------------------------------
         "Limit": limit_handler,
         "Taylor": taylor_handler,

--- a/code/specs/phase19-linear-algebra.md
+++ b/code/specs/phase19-linear-algebra.md
@@ -1,0 +1,333 @@
+# Phase 19 — Linear Algebra Completion
+
+**Package**: `cas-matrix` → 0.3.0  
+**VM**: `symbolic-vm` → 0.39.0  
+**Branch**: `claude/phase19-linear-algebra`
+
+---
+
+## Background
+
+`cas-matrix` 0.2.0 shipped the foundational matrix operations: construction,
+arithmetic, determinant, inverse, trace, rank, and row-reduction.  Phase 19
+adds the five most practically important higher-level operations that
+historical MACSYMA exposed through its `eigenvalues`, `eigenvectors`, `lu`,
+`nullspace`, `columnspace`, `rowspace`, `charpoly`, and `norm` functions.
+
+---
+
+## 19a — Characteristic polynomial (`charpoly`)
+
+```
+charpoly(A, λ)  →  det(λI − A)  as a polynomial expression in λ
+```
+
+**Algorithm**: polynomial-valued cofactor expansion.
+
+Each entry of the matrix `(λI − A)` is:
+- Diagonal position `(i,i)`: `λ − aᵢᵢ`, represented as `[−aᵢᵢ, 1]`
+  (ascending-power coefficient list).
+- Off-diagonal `(i,j)`: `−aᵢⱼ`, represented as `[−aᵢⱼ]`.
+
+Determinant is computed by the same cofactor recurrence on these
+polynomial coefficient lists. Result: `[c₀, c₁, …, cₙ]` with
+`charpoly(λ) = c₀ + c₁λ + … + cₙλⁿ`.
+
+The IR form returned to the user is an Add/Mul/Pow tree built from the
+coefficients and the user-supplied `λ` symbol.
+
+Supported for any `n×n` matrix with rational (IRInteger/IRRational) entries.
+
+**MACSYMA example**:
+```
+charpoly(matrix([1,2],[3,4]), lambda)
+→ Equal(lambda^2 - 5*lambda - 2, 0)   [traditional form]
+or simply the polynomial expression: lambda^2 - 5*lambda - 2
+```
+
+---
+
+## 19b — Eigenvalues (`eigenvalues`)
+
+```
+eigenvalues(A)  →  List(List(λ₁,m₁), List(λ₂,m₂), …)
+```
+
+**Algorithm**:
+1. Compute `char_poly_coeffs(A)` — Fraction coefficient list.
+2. Find roots by delegating to `cas_solve`:
+   - n=1: `solve_linear`
+   - n=2: `solve_quadratic`
+   - n=3: `solve_cubic`
+   - n=4: `solve_quartic`
+   - n>4: return unevaluated
+3. Collect equal roots and count multiplicity.
+4. Return `List(List(λ₁, m₁), …)`.
+
+Eigenvalues may be rational, irrational (containing `Sqrt`), or complex
+(containing `%i`), matching the output of the underlying solvers.
+
+**MACSYMA example**:
+```
+eigenvalues(matrix([1,2],[2,1]))  →  List(List(-1, 1), List(3, 1))
+eigenvalues(matrix([2,0],[0,2]))  →  List(List(2, 2))
+```
+
+---
+
+## 19c — Eigenvectors (`eigenvectors`)
+
+```
+eigenvectors(A)  →  List(List(λ₁, m₁, List(v₁, v₂, …)), …)
+```
+
+For each eigenvalue `λᵢ`:
+1. If `λᵢ` is rational: form `B = A − λᵢI` with Fraction entries.
+2. RREF(`B`) → identify free variable columns (non-pivot columns).
+3. For each free variable: set that free variable to 1, all others to 0,
+   back-substitute to get the eigenvector.
+4. Return eigenvectors as column-vector `Matrix` IR nodes.
+
+If `λᵢ` is irrational/complex (IR expression, not a plain Fraction): the
+eigenvector computation is omitted — return an empty `List()` for that
+eigenvalue's vector list.
+
+**MACSYMA example**:
+```
+eigenvectors(matrix([1,2],[2,1]))
+→  List(List(-1, 1, List(Matrix([-1],[1]))),
+        List( 3, 1, List(Matrix([ 1],[1]))))
+```
+
+---
+
+## 19d — LU decomposition (`lu`)
+
+```
+lu(A)  →  List(L, U, P)
+```
+
+Doolittle algorithm with **partial pivoting**:
+- `P` is a permutation matrix (rows are identity rows reordered).
+- `L` is lower-triangular with 1s on the main diagonal.
+- `U` is upper-triangular.
+- `P·A = L·U`.
+
+All arithmetic uses `Fraction` — exact, no floating point.
+
+Supported for `n×n` matrices with rational entries. Singular matrices
+(zero pivot even after partial pivoting) raise `MatrixError`.
+
+**MACSYMA example**:
+```
+lu(matrix([2,1],[1,3]))  →  List(L, U, P)
+```
+
+---
+
+## 19e — Subspace bases (`nullspace`, `columnspace`, `rowspace`)
+
+All three derive from the RREF computed by `row_reduce`.
+
+### `nullspace(A)` — null space of A
+1. RREF(`A`) → identify free columns (non-pivot columns).
+2. For each free column `j`: build basis vector `v` where:
+   - `v[j] = 1`
+   - `v[free_k] = 0` for every other free column `k ≠ j`
+   - `v[pivot_row_for_col_c] = −RREF[pivot_row, j]` for every pivot column `c`
+3. Return `List(v₁, v₂, …)` where each `vᵢ` is a column-vector Matrix.
+4. If A has full column rank: return `List()` (trivial null space).
+
+### `columnspace(A)` — column space of A
+1. RREF(`A`) → identify pivot column indices.
+2. Return corresponding columns of the **original** `A` (not RREF) as
+   column-vector Matrices.
+3. Return `List(c₁, c₂, …)`.
+
+### `rowspace(A)` — row space of A
+1. RREF(`A`) → extract non-zero rows.
+2. Return those rows as row-vector Matrices.
+3. Return `List(r₁, r₂, …)`.
+
+**MACSYMA examples**:
+```
+nullspace(matrix([1,2,3],[4,5,6]))   →  List(Matrix([1],[-2],[1]))
+columnspace(matrix([1,2],[2,4]))     →  List(Matrix([1],[2]))
+rowspace(matrix([1,2,3],[4,5,6]))    →  List(Matrix([1,0,-1]), Matrix([0,1,2]))
+```
+
+---
+
+## 19f — Matrix and vector norm (`norm`)
+
+```
+norm(v)           →  Euclidean norm √(Σ vᵢ²)  for a column-vector Matrix
+norm(A, "frobenius")  →  Frobenius norm √(Σ aᵢⱼ²)  for a matrix
+```
+
+Result is an `IRInteger` or `IRRational` if the sum of squares is a perfect
+square, otherwise `IRApply(SQRT, (sum_of_squares,))`.
+
+`norm` without a second argument on a non-vector falls through to unevaluated.
+
+**MACSYMA example**:
+```
+norm(matrix([3],[4]))     →  5          (Euclidean: sqrt(9+16) = 5)
+norm(matrix([1,1],[1,1]), "frobenius")  →  2   (sqrt(4) = 2)
+```
+
+---
+
+## Implementation plan
+
+### New files in `cas-matrix`
+
+| File | Content |
+|------|---------|
+| `eigenvalues.py` | `char_poly_coeffs`, `eigenvalues`, `eigenvectors`, `charpoly` |
+| `subspaces.py` | `nullspace`, `columnspace`, `rowspace` |
+| `lu.py` | `lu_decompose` (returns `(L, U, P)` as IR Matrix triples) |
+| `norms.py` | `norm` |
+
+### New IR heads
+
+Added to `heads.py`:
+```python
+EIGENVALUES  = IRSymbol("Eigenvalues")
+EIGENVECTORS = IRSymbol("Eigenvectors")
+CHARPOLY     = IRSymbol("CharPoly")
+LU           = IRSymbol("LU")
+NULLSPACE    = IRSymbol("NullSpace")
+COLUMNSPACE  = IRSymbol("ColumnSpace")
+ROWSPACE     = IRSymbol("RowSpace")
+NORM         = IRSymbol("Norm")
+```
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `cas-matrix/src/cas_matrix/eigenvalues.py` | NEW |
+| `cas-matrix/src/cas_matrix/subspaces.py` | NEW |
+| `cas-matrix/src/cas_matrix/lu.py` | NEW |
+| `cas-matrix/src/cas_matrix/norms.py` | NEW |
+| `cas-matrix/src/cas_matrix/heads.py` | Add 8 new heads |
+| `cas-matrix/src/cas_matrix/__init__.py` | Add all new exports |
+| `cas-matrix/tests/test_phase19.py` | NEW ≥ 50 tests |
+| `cas-matrix/CHANGELOG.md` | 0.3.0 entry |
+| `cas-matrix/pyproject.toml` | Bump to 0.3.0; add `cas-solve>=0.6.0` dep |
+| `symbolic-vm/src/symbolic_vm/cas_handlers.py` | 8 new handlers + registration |
+| `symbolic-vm/CHANGELOG.md` | 0.39.0 entry |
+| `symbolic-vm/pyproject.toml` | Bump to 0.39.0; `cas-matrix>=0.3.0` |
+
+---
+
+## Polynomial arithmetic for `char_poly_coeffs`
+
+A polynomial is represented as `list[Fraction]` where `p[k]` is the
+coefficient of `λ^k`.  Arithmetic:
+
+```python
+def _poly_add(p, q):
+    n = max(len(p), len(q))
+    return [p[i] if i >= len(q) else
+            q[i] if i >= len(p) else
+            p[i] + q[i] for i in range(n)]
+
+def _poly_sub(p, q):
+    return _poly_add(p, [-c for c in q])
+
+def _poly_mul(p, q):
+    if not p or not q: return [Fraction(0)]
+    result = [Fraction(0)] * (len(p) + len(q) - 1)
+    for i, a in enumerate(p):
+        for j, b in enumerate(q):
+            result[i + j] += a * b
+    return result
+
+def _poly_neg(p):
+    return [-c for c in p]
+```
+
+Cofactor expansion on the polynomial-valued matrix `(λI − A)`:
+```python
+def _det_poly(rows):  # rows: list[list[list[Fraction]]]
+    n = len(rows)
+    if n == 0: return [Fraction(1)]
+    if n == 1: return list(rows[0][0])
+    if n == 2:
+        a, b, c, d = rows[0][0], rows[0][1], rows[1][0], rows[1][1]
+        return _poly_sub(_poly_mul(a, d), _poly_mul(b, c))
+    result = [Fraction(0)]
+    for j, entry in enumerate(rows[0]):
+        minor = [[rows[r][c] for c in range(n) if c != j]
+                 for r in range(1, n)]
+        sub = _det_poly(minor)
+        product = _poly_mul(entry, sub)
+        result = _poly_add(result, product) if j % 2 == 0 \
+                 else _poly_sub(result, product)
+    return result
+```
+
+Entry construction for `(λI − A)`:
+```python
+# diagonal: [−aᵢᵢ, 1]  (= λ − aᵢᵢ)
+# off-diag: [−aᵢⱼ]
+```
+
+---
+
+## Null-space algorithm in detail
+
+Given RREF `R` of an `m×n` matrix `A`:
+
+1. Identify pivot columns: column `c` is a pivot column if `R[pivot_count, c] == 1`
+   and all entries above/below that position are 0.
+2. Free columns = all non-pivot columns.
+3. For each free column `j`:
+   - Initialise solution vector `v` of length `n` to all zeros.
+   - Set `v[j] = 1`.
+   - For each pivot column `c` with pivot in row `r`:
+     `v[c] = −R[r, j]`
+4. Return `v` as a column-vector Matrix.
+
+---
+
+## LU algorithm
+
+Doolittle factorisation with partial pivoting on an `n×n` Fraction matrix:
+
+```
+P, L, U initialised: P = I_n, L = I_n, U = copy of A
+
+for k = 0..n-1:
+    # Partial pivoting: find row with max |U[i,k]| for i >= k
+    pivot = argmax |U[i,k]| for i in [k, n)
+    swap rows k and pivot in U and P; swap rows k and pivot in L's
+    completed part (columns 0..k-1)
+
+    # Doolittle step
+    for i = k+1..n-1:
+        factor = U[i,k] / U[k,k]
+        L[i,k] = factor
+        U[i,:] -= factor * U[k,:]
+```
+
+Returns `(L_IR, U_IR, P_IR)` as Matrix IR nodes.
+
+---
+
+## Test matrix
+
+| Class | Tests | Validates |
+|-------|-------|-----------|
+| `TestPhase19_CharPoly` | 8 | 1×1, 2×2 (rational/integer), 3×3, 4×4, coefficient values |
+| `TestPhase19_Eigenvalues` | 10 | 1×1, 2×2 integer, 2×2 rational, diagonal 3×3, repeated eigenvalue, complex roots |
+| `TestPhase19_Eigenvectors` | 8 | 2×2 simple, 3×3 diagonal, repeated eigenvalue (2D eigenspace) |
+| `TestPhase19_LU` | 8 | 2×2, 3×3, identity, requires pivoting, L lower/U upper checks |
+| `TestPhase19_Subspaces` | 10 | nullspace (1 free var, 2 free vars, trivial), columnspace, rowspace |
+| `TestPhase19_Norm` | 6 | vector 3-4-5, vector non-perfect-square, Frobenius perfect, non-perfect |
+| `TestPhase19_Fallthrough` | 4 | symbolic entries, non-square for eigenvalues, n>4, singular LU |
+| `TestPhase19_Regressions` | 5 | Rank, RowReduce, Determinant, Inverse, Trace still work |
+
+Total: ≥ 59 tests.


### PR DESCRIPTION
## Summary

- **`cas-matrix` 0.3.0**: Six new modules completing the linear algebra suite — eigenvalues/eigenvectors, characteristic polynomial, LU decomposition, null/column/row spaces, and matrix/vector norms. All exact arithmetic over rationals (Python `Fraction`). 114 tests, 92.81% coverage.
- **`symbolic-vm` 0.39.0**: 8 new VM handlers (`Eigenvalues`, `Eigenvectors`, `CharPoly`, `LU`, `NullSpace`, `ColumnSpace`, `RowSpace`, `Norm`) wired into `build_cas_handler_table()`. All follow the graceful fall-through contract.

### New functions in `cas-matrix`

| Module | Function | What it does |
|--------|----------|--------------|
| `eigenvalues.py` | `char_poly_coeffs(M)` | `det(λI−A)` as `list[Fraction]` via poly-valued cofactor expansion |
| `eigenvalues.py` | `charpoly(M, lam)` | Same as IR expression tree |
| `eigenvalues.py` | `eigenvalues(M)` | `List(List(λ,m),…)` via `cas-solve` dispatch (1×1–4×4) |
| `eigenvalues.py` | `eigenvectors(M)` | `List(List(λ,m,List(v1,…)),…)`; exact null spaces for rational eigenvalues |
| `subspaces.py` | `nullspace(M)` | `List` of n×1 null-space basis vectors |
| `subspaces.py` | `columnspace(M)` | `List` of pivot columns from original M |
| `subspaces.py` | `rowspace(M)` | `List` of non-zero rows from RREF |
| `lu.py` | `lu_decompose(M)` | `List(L, U, P)` — Doolittle + partial pivoting, exact |
| `norms.py` | `norm(M[, "frobenius"])` | Euclidean or Frobenius norm; exact or `SQRT(…)` |

### Design notes

- **Polynomial-in-λ determinant**: Characteristic polynomial uses `list[Fraction]` coefficient lists for polynomial arithmetic — avoids VM evaluator interaction, enables direct delegation to `cas-solve` solvers.
- **Multiplicity via derivative test**: Solvers deduplicate repeated roots; multiplicity determined by evaluating successive derivatives of the char poly at the root.
- **Complex eigenvalue grouping**: Python `complex` arithmetic used to correctly distinguish conjugate pairs (+i vs -i) during grouping.
- **Null-space reuse**: `_null_space_fractions` in `eigenvalues.py` shared by both `eigenvectors()` and `subspaces.nullspace()`.

## Test plan

- [x] `cas-matrix` tests: 114 passing, 92.81% coverage (>80% required)
- [x] `symbolic-vm` tests: 1109 passing, 85.13% coverage (>80% required)
- [x] `ruff check src/ tests/` — zero errors on all modified files
- [x] Security review passed (no vulnerabilities found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)