### PR TITLE
specs: MX00-MX04 matrix execution layer (tensor IR, compute IR, executor protocol, runtime)

### DIFF
--- a/code/specs/MX00-matrix-execution-overview.md
+++ b/code/specs/MX00-matrix-execution-overview.md
@@ -1,0 +1,199 @@
+# MX00 — Matrix Execution Layer: Architecture Overview
+
+## Status
+
+Draft — V1 specification.  This document is the umbrella for the four
+sub-specs MX01–MX04.  No code lands until all five specs are accepted.
+
+## Why this layer exists
+
+Today the repo has a real-GPU compute stack (`metal-compute`, `cuda-compute`,
+`gpu-runtime`, `image-gpu-core`) that hand-writes one shader per backend per
+operation.  That works, but it does not scale.
+
+Three forces converge on a different shape:
+
+1. **Neural-network track.**  NN layers (dense, conv, normalisation, attention)
+   are tensor algebra.  The same primitives that make image transforms fast on
+   a GPU make NN training fast on a GPU.  Writing them once, in one vocabulary,
+   is the only way both tracks are maintainable.
+
+2. **Backend explosion.**  Metal and CUDA are not enough.  We want to be able
+   to target Vulkan, OpenGL compute, OpenCL, WebGPU, and eventually
+   special-purpose ASICs.  Hand-writing every operation per backend is N×M
+   work where N is operations and M is backends.  The IR collapses that to
+   N + M.
+
+3. **Memory transfer cost.**  GPUs are fast at compute and slow at host↔device
+   transfers.  A scheduler that does not see the whole graph cannot fuse
+   passes or avoid round trips.  The IR makes transfers visible so they can be
+   minimised.
+
+The matrix execution layer is the **narrow waist** between domain libraries
+(image processing, neural networks, signal processing, BLAS) and hardware
+backends (Metal, CUDA, Vulkan, OpenGL, OpenCL, WebGPU, CPU, future ASICs):
+
+```
+  image-ops     nn-layers    fft     blas     [your code]
+       \      |      |      |      |
+        v     v      v      v      v
+       ───   MatrixIR  (the tensor algebra bytecode)   ───
+                          |
+                       planner
+                          |
+                          v
+       ───   ComputeIR  (placed graph: devices, transfers)   ───
+                          |
+                  executor-protocol
+                          |
+                          v
+        cpu     metal    cuda    vulkan    opengl    wgpu    asic
+```
+
+Domain libraries above emit `MatrixIR`.  The planner lowers `MatrixIR` to
+`ComputeIR` by assigning ops to backends, weighing compute cost against
+transfer cost.  Backends, near or far, are reached through the
+`executor-protocol`, a transport-pluggable wire format that works in-process,
+over a socket, over ZeroMQ, over NATS, or anywhere else bytes can flow.
+
+The contract is:  *anything that crosses the boundary between the runtime
+and an executor must be a serializable message*.  Nothing — closures, trait
+objects, callbacks, borrowed references — crosses except as bytes.  The
+local case is "the wire is a function call."  The remote case uses real
+bytes.  The discipline is identical.
+
+## The four specs
+
+| Spec | Crate | Purpose |
+|------|-------|---------|
+| **MX01** | `matrix-ir` | Pure tensor algebra IR.  Domain libraries emit this. |
+| **MX02** | `compute-ir` | Placed IR with explicit devices and `Transfer` ops. |
+| **MX03** | `executor-protocol` | Wire format, message types, `Transport` trait. |
+| **MX04** | `compute-runtime` | Planner, backend registry, cost model. |
+
+A backend (CPU, Metal, CUDA, …) is then a thin crate that implements the
+executor side of the protocol.  V1 ships:
+
+- `matrix-cpu` — reference executor, supports every op, the always-available
+  fallback.
+- One GPU executor (Metal **or** CUDA — implementer's choice, the other
+  follows in V1.1).
+- `matrix-transport-local` — in-process transport (function calls).
+
+V1 is **deliberately small**.  Things explicitly out of scope and reserved
+for later:
+
+- Network transports (TCP, ZMQ, NATS) — *designed for*, not shipped.
+- Multi-host / cluster execution.
+- Multi-GPU on the same host.
+- Fusion of consecutive ops into one kernel.
+- Conv2d, pooling, FFT as structured primitives — composable from the V1
+  op set, optimised structured forms come later.
+- Dynamic shapes — V1 is static-shape only.
+- Autograd — the IR makes a backward pass possible later, not in V1.
+
+## Zero-dependency mandate
+
+All five new crates have **no external dependencies**.  They use only
+`core`, `alloc`, and `std`.  No `serde`, no `bincode`, no `postcard`, no
+`tokio`, no `async-std`, no `futures`, no `libloading`, no `bytemuck`.
+
+Concrete consequences:
+
+- **Wire format** is hand-rolled (varint + length-prefixed bytes + tagged
+  unions).  Format spec is written in MX03 and is implementation-agnostic;
+  a Python or JavaScript client could implement the same bytes from the
+  spec alone.
+- **Async** uses a hand-rolled minimal `block_on` (~50 lines, single-threaded
+  poll loop with a no-op waker) for the local transport.  Future network
+  transports get their own minimal poll loops; we do not depend on a
+  general-purpose async runtime.
+- **Hashing** for kernel cache keys uses `std::collections::hash_map::DefaultHasher`
+  (SipHash, in std).
+- **GPU bindings** reuse the existing `objc-bridge` and `cuda-compute`
+  `DynLib` machinery, both already zero-dep.
+
+Every new crate's `Cargo.toml` has an empty `[dependencies]` section.  CI
+enforces this with a check that fails the build if any of the five crates
+gain an external dependency.
+
+## Design discipline: information does not leak
+
+Several things stay strictly above the matrix execution layer and are not
+allowed to influence its design:
+
+- **"Image" and "channel"** — an image is a rank-3 `[H, W, 4]` u8 tensor.
+  The matrix layer sees a rank-3 u8 tensor.  Channels-last vs channels-first
+  is the image library's decision.
+- **"Batch" and "feature"** — a neural-network activation is a tensor.  The
+  matrix layer sees a tensor.  Batch dimension is the NN library's
+  decision.
+- **"Time" and "frequency"** — a spectrogram is a rank-2 tensor.  The
+  matrix layer sees a rank-2 tensor.
+
+This is the narrow-waist principle: the IR's vocabulary is *only* tensor
+algebra.  Domain semantics live above the line.  Hardware semantics live
+below the line.  Information flows through the IR as shape and dtype, not
+as labels.
+
+## Correctness model
+
+Every operation in the V1 op set has a **CPU reference implementation** in
+`matrix-cpu`.  The cross-backend test harness runs the same `MatrixIR`
+graph on every available backend and asserts that results match within a
+declared tolerance.  Tolerances are dtype-specific:
+
+- f32 results: `|a - b| <= 1e-5 * max(|a|, |b|, 1)` (relative + absolute mix)
+- f16 results: `|a - b| <= 1e-3 * max(|a|, |b|, 1)`
+- u8 / i32 / i64 results: bit-exact
+
+When an op is added to the IR, three things happen in lockstep:
+
+1. The op gains a CPU reference in `matrix-cpu`.
+2. Each existing backend gains a lowering for the op (or returns
+   `Unsupported`, which falls through to CPU).
+3. A test fixture exercising the op is added to the cross-backend harness.
+
+This is the rule that keeps the layer honest as it grows.
+
+## Execution model
+
+A graph runs in three phases:
+
+```
+build:   user code constructs a MatrixIR graph
+plan:    runtime lowers MatrixIR to ComputeIR using backend profiles
+run:     runtime ships ComputeIR to executors via the transport
+```
+
+The build phase is synchronous and cheap.  The plan phase is synchronous
+and runs the cost model.  The run phase is asynchronous because a network
+transport will eventually need it; for V1 it is async-typed but local
+execution returns immediately-ready futures.
+
+## Open questions deferred to implementation
+
+These do not block specification acceptance but will need decisions when
+code starts:
+
+1. **Trait surface for an executor** — should the executor implement a
+   trait directly, or only the message protocol?  Leaning protocol-only,
+   because that enforces the discipline.
+2. **Buffer aliasing** — when can two `BufferId`s refer to the same
+   memory?  V1 says never.  V2 may relax for in-place ops.
+3. **Versioning** — the wire format includes a version byte.  How do we
+   handle version mismatches?  V1: hard error.  V2: per-message
+   compatibility shims.
+
+## Reading order
+
+To understand the layer end-to-end, read the specs in order:
+
+1. **MX00** (this document) — context and constraints.
+2. **MX01** — what `MatrixIR` is and what ops it has.
+3. **MX02** — how `ComputeIR` differs and what placement means.
+4. **MX03** — how runtime and executors talk to each other.
+5. **MX04** — how the planner works and how backends register.
+
+Each sub-spec assumes the reader has read this overview and the specs
+before it.

--- a/code/specs/MX01-matrix-ir.md
+++ b/code/specs/MX01-matrix-ir.md
@@ -1,0 +1,413 @@
+# MX01 — `matrix-ir`: The Tensor Algebra IR
+
+## Status
+
+Draft — V1 specification.  Read [MX00](MX00-matrix-execution-overview.md) first.
+
+## Purpose
+
+`matrix-ir` is the upper IR — what domain libraries (image processing, NN
+layers, signal processing, BLAS) emit when they want computation done.  It
+describes *what* to compute as a directed acyclic graph of tensor algebra
+operations.  It says nothing about *where* that computation happens; that is
+`compute-ir`'s job (MX02).
+
+This crate is **pure data** — types, builders, validators, serialisers.
+It performs no computation, allocates no GPU memory, and depends on no
+backend.  It can be compiled and exercised on any platform without a GPU.
+
+## Design principles
+
+1. **Tensor algebra only.**  The vocabulary contains shapes, dtypes, and
+   mathematical operations.  No "image", no "batch", no "channel".  Domain
+   labels live above this layer.
+
+2. **Static shapes.**  Every tensor's shape is known at graph build time.
+   Dynamic shapes are a V2 problem.
+
+3. **SSA over tensors.**  Each tensor produced by an op gets a fresh
+   `TensorId`.  Tensors are immutable values; ops never mutate.  This is
+   what makes residency tracking and dead-code elimination tractable
+   downstream.
+
+4. **Closed under serialisation.**  Every value in the IR — `Tensor`,
+   `Op`, `Graph` — has a defined wire form.  Backends, including remote
+   ones, see the same bytes.
+
+5. **No external dependencies.**  `core` + `alloc` + `std` only.
+
+## Core types
+
+```rust
+pub struct TensorId(pub u32);
+pub struct OpId(pub u32);
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DType {
+    F32,
+    U8,
+    I32,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Shape {
+    /// Dimensions in row-major / leftmost-major order.  Empty Vec means scalar.
+    pub dims: Vec<u32>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Tensor {
+    pub id:    TensorId,
+    pub dtype: DType,
+    pub shape: Shape,
+}
+
+/// A graph is a topologically-ordered sequence of ops plus their input
+/// constants and declared inputs/outputs.
+pub struct Graph {
+    pub inputs:    Vec<Tensor>,        // tensors supplied by the caller at run time
+    pub outputs:   Vec<TensorId>,      // tensors the caller wants back
+    pub ops:       Vec<Op>,            // topologically ordered
+    pub tensors:   Vec<Tensor>,        // every tensor referenced, including outputs of ops
+    pub constants: Vec<Constant>,      // literal data baked into the graph
+}
+
+pub struct Constant {
+    pub tensor: TensorId,
+    pub bytes:  Vec<u8>,               // dtype-encoded little-endian
+}
+```
+
+`f16` and `i64` are deferred to V2.  `bool` is represented as `U8` (0 or 1)
+to keep the dtype set small.  This is consistent with how WebGPU and most
+shader languages model booleans on tensors.
+
+## V1 op set
+
+The V1 op set is **27 operations**, chosen to span elementwise math, reductions,
+shape manipulation, linear algebra, comparison, selection, type conversion,
+and constants.  Anything an image filter, a neural-network layer, or a signal
+processing pipeline does at the tensor level decomposes into this set.
+
+### Elementwise unary (7)
+
+```rust
+Neg(Tensor) -> Tensor       // -x
+Abs(Tensor) -> Tensor       // |x|
+Sqrt(Tensor) -> Tensor      // sqrt(x)
+Exp(Tensor) -> Tensor       // e^x
+Log(Tensor) -> Tensor       // ln(x)
+Tanh(Tensor) -> Tensor      // tanh(x)
+Recip(Tensor) -> Tensor     // 1 / x
+```
+
+Output shape and dtype match input.  `Sqrt`, `Log`, `Recip` produce
+implementation-defined results on out-of-domain inputs (NaN / Inf for
+floats; backend-defined for ints, generally division-by-zero traps).
+
+### Elementwise binary (7)
+
+```rust
+Add (Tensor, Tensor) -> Tensor
+Sub (Tensor, Tensor) -> Tensor
+Mul (Tensor, Tensor) -> Tensor
+Div (Tensor, Tensor) -> Tensor
+Max (Tensor, Tensor) -> Tensor
+Min (Tensor, Tensor) -> Tensor
+Pow (Tensor, Tensor) -> Tensor
+```
+
+Both inputs must have the same dtype and the same shape.  Implicit
+broadcasting is **not allowed** in V1 — callers must insert explicit
+`Broadcast` ops.  This keeps the IR's semantics narrow and shifts the
+broadcasting decision (and the memory cost it implies) up to the
+domain library or the optimiser, where it belongs.
+
+### Reductions (3)
+
+```rust
+ReduceSum (Tensor, axes: Vec<u32>, keep_dims: bool) -> Tensor
+ReduceMax (Tensor, axes: Vec<u32>, keep_dims: bool) -> Tensor
+ReduceMean(Tensor, axes: Vec<u32>, keep_dims: bool) -> Tensor
+```
+
+Reduces over the given axes.  If `keep_dims` is false, the reduced axes
+are removed from the shape; if true, they are kept as size-1.  Empty `axes`
+means reduce-all (scalar output unless `keep_dims`).
+
+`ReduceMean` for integer dtypes uses integer division (truncation toward
+zero); use `Cast` to f32 first if you want fractional results.
+
+### Shape manipulation (3)
+
+```rust
+Reshape (Tensor, new_shape: Shape) -> Tensor
+Transpose(Tensor, perm: Vec<u32>) -> Tensor
+Broadcast(Tensor, target_shape: Shape) -> Tensor
+```
+
+`Reshape` requires `new_shape.numel() == input.shape.numel()`.  `Transpose`
+requires `perm` to be a permutation of `0..rank`.  `Broadcast` requires
+that each dimension of the input either equals the corresponding target
+dimension or is 1 (in which case it is replicated).
+
+### Linear algebra (1)
+
+```rust
+MatMul(a: Tensor, b: Tensor) -> Tensor
+```
+
+Both inputs must be rank-2 with matching inner dimensions: `a` is `[m, k]`,
+`b` is `[k, n]`, output is `[m, n]`.  Both must have the same float dtype
+(f32 in V1).  Higher-rank batched matmul is composed by reshaping or by
+loop-emitting in the domain library, **not** baked into V1.
+
+### Comparison (3)
+
+```rust
+Equal  (Tensor, Tensor) -> Tensor   // dtype = U8, value 0 or 1
+Less   (Tensor, Tensor) -> Tensor   // dtype = U8, value 0 or 1
+Greater(Tensor, Tensor) -> Tensor   // dtype = U8, value 0 or 1
+```
+
+Inputs must have matching shapes and dtypes.  Output dtype is always U8.
+
+### Selection (1)
+
+```rust
+Where(predicate: Tensor, true_value: Tensor, false_value: Tensor) -> Tensor
+```
+
+`predicate` must have dtype U8.  All three inputs must have matching
+shapes.  `true_value` and `false_value` must have matching dtype, which
+becomes the output dtype.  Equivalent to a per-element `predicate ? t : f`.
+
+### Type conversion (1)
+
+```rust
+Cast(Tensor, dtype: DType) -> Tensor
+```
+
+Numerical conversion.  Float-to-int truncates toward zero; int-to-float
+is exact for U8 and I32 within f32 range.
+
+### Constants (1)
+
+```rust
+Const(constant_id: u32) -> Tensor
+```
+
+Materialises a tensor from the graph's `constants` table.  The shape and
+dtype are taken from the constant's declared `Tensor`.  Literal data lives
+in `Graph.constants` rather than being inlined into ops, both to keep ops
+small and to allow the planner to share constant buffers between ops.
+
+## Op enum
+
+All 27 ops are encoded as a single Rust enum:
+
+```rust
+pub enum Op {
+    // Elementwise unary
+    Neg   { input: TensorId, output: TensorId },
+    Abs   { input: TensorId, output: TensorId },
+    Sqrt  { input: TensorId, output: TensorId },
+    Exp   { input: TensorId, output: TensorId },
+    Log   { input: TensorId, output: TensorId },
+    Tanh  { input: TensorId, output: TensorId },
+    Recip { input: TensorId, output: TensorId },
+
+    // Elementwise binary
+    Add { lhs: TensorId, rhs: TensorId, output: TensorId },
+    Sub { lhs: TensorId, rhs: TensorId, output: TensorId },
+    Mul { lhs: TensorId, rhs: TensorId, output: TensorId },
+    Div { lhs: TensorId, rhs: TensorId, output: TensorId },
+    Max { lhs: TensorId, rhs: TensorId, output: TensorId },
+    Min { lhs: TensorId, rhs: TensorId, output: TensorId },
+    Pow { lhs: TensorId, rhs: TensorId, output: TensorId },
+
+    // Reductions
+    ReduceSum  { input: TensorId, axes: Vec<u32>, keep_dims: bool, output: TensorId },
+    ReduceMax  { input: TensorId, axes: Vec<u32>, keep_dims: bool, output: TensorId },
+    ReduceMean { input: TensorId, axes: Vec<u32>, keep_dims: bool, output: TensorId },
+
+    // Shape
+    Reshape   { input: TensorId, new_shape: Shape, output: TensorId },
+    Transpose { input: TensorId, perm: Vec<u32>, output: TensorId },
+    Broadcast { input: TensorId, target_shape: Shape, output: TensorId },
+
+    // LinAlg
+    MatMul { a: TensorId, b: TensorId, output: TensorId },
+
+    // Comparison
+    Equal   { lhs: TensorId, rhs: TensorId, output: TensorId },
+    Less    { lhs: TensorId, rhs: TensorId, output: TensorId },
+    Greater { lhs: TensorId, rhs: TensorId, output: TensorId },
+
+    // Selection
+    Where { predicate: TensorId, true_value: TensorId, false_value: TensorId, output: TensorId },
+
+    // Conversion
+    Cast { input: TensorId, dtype: DType, output: TensorId },
+
+    // Constants
+    Const { constant: u32, output: TensorId },
+}
+```
+
+Each op carries the `output: TensorId` it produces, even though it could
+be inferred positionally.  This is for two reasons:
+
+1. **Round-trip stability.**  Serialising and deserialising preserves the
+   exact `TensorId` numbering, which is what tests assert against.
+2. **Validation locality.**  A validator can check op-by-op without
+   walking back through the graph to recompute output ids.
+
+## Builder API
+
+Constructing graphs by hand is verbose and error-prone.  `matrix-ir`
+exposes a builder that allocates tensor ids, infers shapes, validates as
+it goes, and produces a `Graph`:
+
+```rust
+pub struct GraphBuilder { /* ... */ }
+
+impl GraphBuilder {
+    pub fn new() -> Self;
+
+    pub fn input(&mut self, dtype: DType, shape: Shape) -> Tensor;
+    pub fn constant(&mut self, dtype: DType, shape: Shape, bytes: Vec<u8>) -> Tensor;
+
+    pub fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor;
+    pub fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor;
+    pub fn matmul(&mut self, a: &Tensor, b: &Tensor) -> Tensor;
+    // ... one method per op ...
+
+    pub fn output(&mut self, t: &Tensor);
+    pub fn build(self) -> Result<Graph, IrError>;
+}
+```
+
+Example — a simple `y = relu(x @ w + b)` layer:
+
+```rust
+let mut g = GraphBuilder::new();
+let x = g.input(DType::F32, Shape::from(&[1, 784]));
+let w = g.input(DType::F32, Shape::from(&[784, 128]));
+let b = g.input(DType::F32, Shape::from(&[1, 128]));
+
+let xw    = g.matmul(&x, &w);
+let xwb   = g.add(&xw, &b);
+let zero  = g.constant(DType::F32, Shape::from(&[1, 128]), vec![0u8; 128 * 4]);
+let y     = g.max(&xwb, &zero);   // ReLU = max(x, 0)
+
+g.output(&y);
+let graph = g.build().unwrap();
+```
+
+Note how the graph is shape-explicit (no implicit broadcasting; `b` is
+already `[1, 128]` to match `xw`).
+
+## Validation
+
+`Graph::validate()` runs a structural and semantic check:
+
+### Structural rules
+
+1. Every `TensorId` referenced by an op exists in `Graph.tensors`.
+2. Every constant referenced by `Const` exists in `Graph.constants` and
+   the constant's `Tensor.id` matches its index.
+3. The `output` of each op equals the next unallocated `TensorId` at the
+   time the op runs (single-assignment).
+4. Ops are topologically ordered: every input of op N is produced by an
+   op `<N` or is a graph input or constant.
+5. Every `output` listed in `Graph.outputs` has been produced by some op.
+
+### Semantic rules (per op)
+
+For each op, the validator checks that input shapes and dtypes satisfy
+the op's contract and that the declared output `Tensor` matches what the
+op would produce.  Mismatches raise `IrError::ShapeMismatch { op_index,
+expected, actual }` or `IrError::DTypeMismatch { ... }`.
+
+Examples:
+
+- `Add { lhs, rhs, output }`: lhs and rhs must have identical shape and
+  dtype; output must equal that shape and dtype.
+- `MatMul { a, b, output }`: both rank-2; `a.shape[1] == b.shape[0]`;
+  output shape `[a.shape[0], b.shape[1]]`; output dtype matches inputs.
+- `Reshape { input, new_shape, output }`: `new_shape.numel() ==
+  input.shape.numel()`; output dtype matches input.
+
+The validator is exhaustive — every op variant has a check.  Adding an
+op without adding a check is a compile error because the validator
+match expression has no default arm.
+
+### Constant rules
+
+For each `Constant`:
+
+1. `bytes.len() == tensor.shape.numel() * tensor.dtype.size_bytes()`.
+2. Bytes are little-endian dtype-encoded.
+
+## Wire format
+
+`Graph` is serialisable to a versioned binary blob.  The layout is defined
+in MX03 §"Wire format primitives" and §"Graph serialisation"; this spec
+guarantees only that the bytes round-trip:
+
+```
+Graph::to_bytes() -> Vec<u8>
+Graph::from_bytes(&[u8]) -> Result<Graph, IrError>
+```
+
+The wire format is **versioned**.  V1 produces format version 1; readers
+that see a higher version error rather than silently reinterpret.
+
+## Test methodology
+
+`matrix-ir` ships its own test suite covering:
+
+1. **Builder + validate**: construct ~30 representative graphs (one per op
+   plus combinations) and assert `validate()` accepts them.
+2. **Validator rejection**: construct deliberately malformed graphs (shape
+   mismatch, dangling tensor id, non-permutation transpose, …) and assert
+   the validator names the right error.
+3. **Wire round-trip**: every graph in the suite is serialised, deserialised,
+   and asserted equal to the original.
+4. **Coverage gate**: a meta-test asserts that the suite touches every
+   variant of `Op`, fails the build if a variant is missed.
+
+Coverage target: **100%** of the public API.  This crate is small and
+pure; nothing should be untested.
+
+## Out of scope (for V1)
+
+Reserved for later versions, with notes on how V1 leaves room:
+
+- **Dynamic shapes** — V2 introduces `Dim::Static(u32)` vs `Dim::Symbolic(SymId)`.
+  V1's `Shape` becomes a special case where every `Dim` is `Static`.
+- **f16, bf16, i64, complex64** — adding to `DType` is additive.  Existing
+  ops gain new dtype combinations as backends grow capability.
+- **Conv2d, Pool, Softmax, LayerNorm, Attention as primitives** — V2.  V1
+  composes them from the existing op set.  Backends can pattern-match later.
+- **CustomKernel escape hatch** — a Op variant carrying per-backend source.
+  Deliberately omitted from V1 to force the IR to express enough.
+- **Autograd** — V2 adds a transformation pass that builds a backward graph
+  from a forward graph.  V1's SSA structure makes this clean.
+- **Implicit broadcasting on binary ops** — V2.  V1 forces explicit
+  `Broadcast` to keep the IR's semantics minimal.
+
+## Open questions
+
+1. Should the builder validate eagerly (each `add()` call returns
+   `Result<Tensor, IrError>`) or only at `build()` time?  Eager catches
+   errors at the call site; lazy keeps the API ergonomic.  V1 leans
+   **eager via panics** in debug, lazy `build()` in release — matches how
+   most builders in this repo work.
+2. Should `Const` carry the bytes inline (in the Op) or by reference into
+   `Graph.constants`?  Currently by reference; the alternative inflates
+   `Op` and complicates serialisation.  Sticking with by-reference.
+3. Is `Pow` in V1 worth it?  It is the only V1 op whose backend lowering
+   is annoying (transcendental, often emits a library call).  Keeping it
+   because gamma correction in image processing needs it.

--- a/code/specs/MX02-compute-ir.md
+++ b/code/specs/MX02-compute-ir.md
@@ -1,0 +1,337 @@
+# MX02 — `compute-ir`: The Placed Compute Graph
+
+## Status
+
+Draft — V1 specification.  Read [MX00](MX00-matrix-execution-overview.md)
+and [MX01](MX01-matrix-ir.md) first.
+
+## Purpose
+
+`compute-ir` is the **lower IR** — what the planner produces from
+`MatrixIR` and what executors consume.  It carries the same dataflow
+shape as `MatrixIR` but adds three things that `MatrixIR` deliberately
+lacks:
+
+1. **Placement.**  Every op carries an `ExecutorId` saying which executor
+   runs it.
+2. **Residency.**  Every tensor carries a `Residency`: which executor's
+   memory holds it, under what `BufferId`.
+3. **Explicit transfers.**  When an op needs an input that lives on a
+   different executor than the op runs on, a `Transfer` op moves it.
+   Transfers are first-class graph nodes, not implicit machinery.
+
+This split is the load-bearing piece of the layer's design.  By forcing
+memory movement to be an op in the graph rather than a side-effect of
+execution, the cost of every transfer is *visible* — to the planner that
+inserts them, to the user that inspects the graph, and to the executor
+that performs them.
+
+This crate is **pure data**, like `matrix-ir`.  It defines structures and
+serialisation; it does not execute graphs.  Execution lives in
+`compute-runtime` and the executors.
+
+## Relationship to `matrix-ir`
+
+`compute-ir` reuses `matrix-ir`'s `DType`, `Shape`, `Tensor`, and the
+27-op vocabulary.  What it adds is the placement and transfer machinery
+wrapped around them.  Visually:
+
+```
+MatrixIR::Op::Add { lhs, rhs, output }
+                       |
+                  planner lowers
+                       v
+ComputeIR::PlacedOp {
+    op: Op::Add { lhs, rhs, output },
+    executor: ExecutorId(2),       // "run this on executor #2"
+    estimated_ns: 1_400,           // planner's cost estimate, kept for telemetry
+}
+```
+
+Plus, between ops that span executors, the planner inserts:
+
+```
+ComputeIR::PlacedOp {
+    op: TransferOp::Transfer { src_buffer, dst_buffer, bytes },
+    executor: ExecutorId::Runtime, // transfers are coordinated by the runtime
+    estimated_ns: 8_000,
+}
+```
+
+## Core types
+
+```rust
+pub struct ExecutorId(pub u32);    // 0 is reserved for the CPU fallback.
+pub struct BufferId(pub u64);      // unique within an executor.
+pub struct KernelId(pub u64);      // unique within an executor.
+
+#[derive(Clone, Debug)]
+pub struct Residency {
+    pub executor: ExecutorId,
+    pub buffer:   BufferId,
+}
+
+/// A tensor in the placed graph carries its dtype, shape, and current
+/// residency.  Residency may change across ops as the planner inserts
+/// transfers.
+#[derive(Clone, Debug)]
+pub struct PlacedTensor {
+    pub id:        TensorId,           // same id space as matrix-ir
+    pub dtype:     DType,
+    pub shape:     Shape,
+    pub residency: Residency,
+}
+
+#[derive(Clone, Debug)]
+pub enum PlacedOp {
+    /// A normal compute op, lowered as-is from MatrixIR.
+    Compute {
+        op:            matrix_ir::Op,
+        executor:      ExecutorId,
+        estimated_ns:  u64,
+    },
+
+    /// Move bytes between executors.  src and dst residencies must
+    /// reference the same logical tensor (same dtype, same shape).
+    Transfer {
+        tensor:        TensorId,
+        src:           Residency,
+        dst:           Residency,
+        bytes:         u64,
+        estimated_ns:  u64,
+    },
+
+    /// Allocate a buffer for a tensor whose residency was just decided.
+    /// Issued before the first op that reads/writes the buffer.
+    Alloc {
+        residency:     Residency,
+        bytes:         u64,
+    },
+
+    /// Release a buffer.  Issued after the tensor's last use.
+    Free {
+        residency:     Residency,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct ComputeGraph {
+    pub format_version: u32,           // wire format version, currently 1.
+
+    /// Inputs the runtime will receive at run time, with residency assigned
+    /// (typically the host / executor 0).
+    pub inputs:   Vec<PlacedTensor>,
+
+    /// Outputs the runtime will return, with the residency they end on.
+    /// The runtime inserts download transfers if a caller wants them on
+    /// the host.
+    pub outputs:  Vec<PlacedTensor>,
+
+    /// Constants, with residency assigned.  May be replicated across
+    /// executors when the planner expects multiple readers.
+    pub constants: Vec<PlacedConstant>,
+
+    /// Topologically ordered ops.  The order is honoured during execution.
+    pub ops: Vec<PlacedOp>,
+
+    /// Per-tensor metadata, indexed by TensorId.  Useful for inspection
+    /// and for downloading specific intermediates during debugging.
+    pub tensors: Vec<PlacedTensor>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PlacedConstant {
+    pub tensor:    TensorId,
+    pub bytes:     Vec<u8>,
+    pub residency: Residency,           // where the constant must be uploaded.
+}
+```
+
+`ExecutorId(0)` is by convention the CPU executor and is always present.
+Other ids are assigned by the registry as backends register themselves.
+The runtime is not itself an executor; transfers are coordinated by the
+runtime but executed by the source and destination executors via
+`Download` and `Upload` protocol messages (see MX03).
+
+## Lowering: `MatrixIR` → `ComputeIR`
+
+The planner (specified in MX04) takes a `MatrixIR::Graph` and a registry
+of available executors with their `BackendProfile`s, and produces a
+`ComputeIR::ComputeGraph`.  The lowering is conceptually a four-pass
+algorithm:
+
+1. **Capability filter.**  For each op, compute the set of executors that
+   support it (correct dtype, correct shape rank, correct op kind).  If
+   none do, fall back to `ExecutorId(0)` (CPU).
+
+2. **Cost minimisation.**  For each op in topological order, pick the
+   executor that minimises the sum of:
+   - Compute cost (op kind × input size × FLOPS rate).
+   - Transfer-in cost for any inputs not already resident on that
+     executor.
+   - Transfer-out cost (deferred — only counted if the next consumer
+     would otherwise force it).
+   - Kernel launch overhead.
+
+   This is greedy per-op; it is not globally optimal but is cheap and
+   produces good plans for the workloads we care about.
+
+3. **Transfer insertion.**  Walk the placed ops in order.  For each input
+   whose current residency does not match the op's executor, insert a
+   `Transfer` op before it and update the input's residency.
+
+4. **Lifetime annotation.**  Compute first-use and last-use of each
+   tensor.  Insert `Alloc` before first use and `Free` after last use.
+   This is purely an optimisation; executors that ignore `Free` still
+   produce correct results, just with more memory pressure.
+
+The cost model and the planner's algorithm are the subject of MX04.  This
+spec only defines the output shape — a `ComputeGraph` that any executor
+can consume.
+
+## Validation
+
+`ComputeGraph::validate()` enforces:
+
+### Structural
+
+1. The underlying `Op`s satisfy `matrix-ir`'s validation (shape and dtype
+   contracts).
+2. Every `TensorId` referenced by `PlacedOp` exists in `tensors`.
+3. Every `BufferId` referenced is preceded by an `Alloc` and not
+   followed by a `Free` until after its last use.
+4. Every `Transfer.src` matches the most recent residency assigned to
+   that `TensorId`; every `Transfer.dst` becomes the new residency.
+5. Every input to a `Compute` op has a residency equal to the op's
+   `executor`.
+
+### Cost annotations
+
+1. Every `estimated_ns` is finite and non-negative.  (The planner is
+   allowed to estimate `0` for ops whose cost is below its resolution
+   threshold; this is informational.)
+
+The validator runs in O(N) over the op list and is invoked by the runtime
+before executing any graph.  Invalid graphs are a planner bug — they
+should never reach an executor.
+
+## The `Transfer` op in detail
+
+A transfer moves a tensor between two residencies.  In the wire protocol,
+it decomposes into two cooperating executor-protocol messages:
+
+- The runtime sends `DownloadBuffer(buffer_id)` to the source executor,
+  receives `BufferData`.
+- The runtime sends `UploadBuffer(...)` to the destination executor.
+
+In V1 the runtime acts as the data path between executors.  This is a
+deliberate simplification: it keeps the executor protocol simple (no
+peer-to-peer mode), at the cost of an extra hop through the runtime's
+host memory.  V2 may add direct executor-to-executor transfer when both
+support it (for example two CUDA executors on different GPUs).
+
+## Replicated constants
+
+Constants are read-only.  When the planner predicts that multiple
+executors will read the same constant, it can place a copy on each via
+multiple `PlacedConstant` entries with different `residency` values.  V1
+ships a simple policy: a constant is replicated if and only if multiple
+executors read it directly.  More refined policies (size-aware,
+hot/cold) are V2.
+
+## Wire format
+
+`ComputeGraph` is serialisable to bytes via the same primitives MX03
+defines for the executor protocol.  This is what the runtime ships to a
+remote executor as part of a `Dispatch` message.  Round-trip equality is
+guaranteed:
+
+```
+ComputeGraph::to_bytes() -> Vec<u8>
+ComputeGraph::from_bytes(&[u8]) -> Result<ComputeGraph, IrError>
+```
+
+The format is versioned (`format_version` field).  Mismatched versions
+are a hard error in V1.
+
+## Inspection
+
+A goal of having an explicit placed graph is that it should be readable.
+The crate exposes:
+
+```rust
+impl ComputeGraph {
+    /// Pretty-print the graph as text, one op per line, with executor
+    /// assignments and estimated costs.  Useful for debugging the planner.
+    pub fn dump(&self) -> String;
+}
+```
+
+Sample output:
+
+```
+ComputeGraph (format v1, 4 inputs, 1 output, 11 ops)
+  inputs:
+    t0: f32 [1, 784]   @ executor 0 buf 1
+    t1: f32 [784, 128] @ executor 0 buf 2
+    t2: f32 [1, 128]   @ executor 0 buf 3
+  ops:
+    [00]  alloc            buf 4 @ exec 1   (3.0 KiB)
+    [01]  transfer t1      exec 0 buf 2  ->  exec 1 buf 4   (≈ 80 µs)
+    [02]  alloc            buf 5 @ exec 1   (3.1 KiB)
+    [03]  transfer t0      exec 0 buf 1  ->  exec 1 buf 5   (≈ 0.8 µs)
+    [04]  compute  matmul  exec 1 t0 t1 -> t3                 (≈ 12 µs)
+    [05]  alloc            buf 6 @ exec 1   (512 B)
+    [06]  transfer t2      exec 0 buf 3  ->  exec 1 buf 6   (≈ 5.1 µs)
+    [07]  compute  add     exec 1 t3 t2 -> t4                 (≈ 1.0 µs)
+    [08]  compute  max     exec 1 t4 c0 -> t5                 (≈ 1.0 µs)  // ReLU
+    [09]  transfer t5      exec 1 buf 7  ->  exec 0 buf 8   (≈ 5.1 µs)
+    [10]  free             buf 4, 5, 6, 7 @ exec 1
+  outputs:
+    t5: f32 [1, 128]   @ executor 0 buf 8
+```
+
+This is a teaching artifact as much as a debugging tool.  A user looking
+at the dump can see exactly where their compute time goes — and can
+weigh adding a transfer-amortising `Broadcast` placement, or choosing a
+different executor, against the visible numbers.
+
+## Test methodology
+
+`compute-ir` ships:
+
+1. **Hand-built graphs** for each op variant, validated.
+2. **Wire round-trip** for every test graph.
+3. **`dump()` golden tests** — small graphs whose pretty-printed form is
+   asserted byte-for-byte against checked-in fixtures.  This catches
+   accidental layout changes.
+
+Planner-driven tests live in `compute-runtime` (MX04), where they have a
+mock registry to drive cost-based decisions deterministically.
+
+## Out of scope (V1)
+
+- **In-place ops / aliasing.**  Two `BufferId`s referring to the same
+  bytes.  V1 says every op produces a fresh buffer.  V2 adds an
+  `aliases: BufferId` field to `Alloc` to enable in-place updates where
+  safe.
+- **Streams / async dispatch.**  V1 executes ops in declared order with
+  full synchronisation.  V2 introduces dependency edges so independent
+  ops can run concurrently.
+- **Multi-host coordination.**  V2.
+- **Fusion groups.**  V2 introduces a `FusionGroup { ops: Vec<usize> }`
+  variant that asks the executor to lower a sub-DAG to one kernel.
+
+## Open questions
+
+1. Should `Alloc` and `Free` be implicit (the executor manages buffers
+   itself based on first/last use) or explicit (the runtime issues them)?
+   V1 says explicit because it makes memory pressure visible in the
+   graph.  Worth revisiting if explicit lifetime tracking becomes a
+   maintenance burden.
+2. Is `BufferId` 64-bit overkill?  Probably yes; 32-bit gives 4B buffers
+   per executor lifetime which is plenty.  Keeping 64-bit anyway because
+   a wire format change to widen later would be painful.
+3. Should `Transfer` carry a checksum?  Useful for network transports
+   where corruption is possible.  V1 does not; transports that need it
+   add it at their layer.

--- a/code/specs/MX03-executor-protocol.md
+++ b/code/specs/MX03-executor-protocol.md
@@ -1,0 +1,430 @@
+# MX03 — `executor-protocol`: Wire Format and Transport
+
+## Status
+
+Draft — V1 specification.  Read [MX00](MX00-matrix-execution-overview.md),
+[MX01](MX01-matrix-ir.md), and [MX02](MX02-compute-ir.md) first.
+
+## Purpose
+
+`executor-protocol` defines the **wire-level contract** between the
+runtime and an executor.  It has two parts:
+
+1. **Message types** — the fixed set of requests an executor can answer
+   and responses it can produce.
+2. **Wire format** — the byte-level encoding of those messages, hand-rolled
+   from primitives (varint, length-prefixed bytes, tagged unions).
+
+Plus the `Transport` trait that abstracts how messages are physically
+delivered (function call, socket, queue, …).
+
+The unifying principle, restated:  *anything that crosses from runtime to
+executor goes as bytes.*  Local executors run the same code path as
+remote ones; in-process is just one transport implementation.
+
+This crate has zero external dependencies.
+
+## Why a hand-rolled wire format
+
+The repo's principle is no third-party dependencies.  Existing
+serialisation crates (`serde`, `bincode`, `postcard`, `rmp`) are off the
+table.  In return:
+
+- The format is **transparent** — every byte's meaning is documented in
+  this spec.  A Python or JavaScript or Go client can be written from
+  the spec alone, with no port of a Rust crate.
+- The format is **versioned at the wire level**, not at the type level.
+  Each message starts with a one-byte format version; adding fields is a
+  format-version bump that old readers can detect and reject.
+- The format is **small** — varints for integers, length-prefixed bytes
+  for variable-length data.  No schema descriptors, no field names, no
+  reflection.
+
+Trade-offs we accept:
+
+- We hand-roll one encoder/decoder per type.  Tedious; mitigated by a
+  small primitives module shared by every type.
+- Adding a field to a message requires a coordinated wire-format update.
+  This is fine for V1 where the message set is small and stable.
+
+## Wire format primitives
+
+Every value in the protocol is built from six primitives.  All
+multi-byte integers are little-endian.
+
+### `u8`, `u16`, `u32`, `u64`
+
+Fixed-width little-endian integers.  Used for short, well-bounded
+fields where the cost of varint encoding is not worth its compression.
+
+### Varint (`uv64`)
+
+Unsigned 64-bit varint.  Bytes encode 7 bits each, low-order first; the
+top bit of each byte signals "more bytes follow".
+
+```
+encode(0)         -> [0x00]
+encode(1)         -> [0x01]
+encode(127)       -> [0x7F]
+encode(128)       -> [0x80, 0x01]
+encode(300)       -> [0xAC, 0x02]
+encode(2^32 - 1)  -> [0xFF, 0xFF, 0xFF, 0xFF, 0x0F]
+```
+
+A reader that sees more than 10 bytes without the high bit clearing
+fails the message.  This bounds varint cost.
+
+### Bytes (`bytes`)
+
+Variable-length octet string.  Layout: varint `length`, then `length`
+raw bytes.
+
+### String (`str`)
+
+UTF-8 string.  Layout: identical to `bytes`.  Decoders validate UTF-8;
+invalid sequences fail the message.
+
+### Tagged union (`enum`)
+
+Layout: varint `tag` followed by the variant's payload.  Tags are
+assigned by this spec for each enum and never change once assigned;
+new variants get new tags at the end.
+
+### Array (`vec<T>`)
+
+Layout: varint `len` followed by `len` instances of `T`.
+
+## Encoding `matrix-ir` types
+
+Cross-references for MX01 types.  The format applies to anything in
+`matrix-ir` and `compute-ir` that needs to travel.
+
+```
+DType (u8 tag):
+  0x00 = F32
+  0x01 = U8
+  0x02 = I32
+  (V2: 0x03 = F16, 0x04 = I64)
+
+Shape:
+  varint dim_count, then dim_count u32 dims
+
+TensorId:           u32
+OpId:               u32
+ExecutorId:         u32
+BufferId:           u64
+KernelId:           u64
+
+Tensor:
+  TensorId | DType | Shape
+
+Op (tagged union, see MX01 §"Op enum" for the variants):
+  varint op_tag | variant payload
+
+Constant:
+  TensorId | bytes
+```
+
+The tag-to-op mapping for V1 is fixed:
+
+```
+0x00 Neg          0x07 Add          0x0E ReduceSum     0x15 MatMul
+0x01 Abs          0x08 Sub          0x0F ReduceMax     0x16 Equal
+0x02 Sqrt         0x09 Mul          0x10 ReduceMean    0x17 Less
+0x03 Exp          0x0A Div          0x11 Reshape       0x18 Greater
+0x04 Log          0x0B Max          0x12 Transpose     0x19 Where
+0x05 Tanh         0x0C Min          0x13 Broadcast     0x1A Cast
+0x06 Recip        0x0D Pow                             0x1B Const
+```
+
+Tags `0x1C` and beyond are reserved for V2 ops.
+
+## Message types
+
+The protocol has two enums: `ExecutorRequest` (runtime → executor) and
+`ExecutorResponse` (executor → runtime).  Plus an `ExecutorEvent` enum for
+unsolicited push messages (heartbeats, lost-buffer notifications).
+
+```rust
+pub enum ExecutorRequest {
+    /// Executor announces itself to the runtime registry.
+    Register {
+        protocol_version: u32,        // 1 in V1
+        executor_kind:    String,     // "cpu", "metal", "cuda", "vulkan", ...
+        profile:          BackendProfile,
+    },
+
+    /// Compile a kernel from source.  The executor caches by hash.
+    PrepareKernel {
+        kernel_id:  KernelId,         // assigned by runtime
+        source:     KernelSource,
+    },
+
+    /// Allocate a buffer.  The executor returns the BufferId in the response.
+    AllocBuffer {
+        bytes: u64,
+    },
+
+    /// Upload bytes from runtime memory into an allocated buffer.
+    UploadBuffer {
+        buffer:  BufferId,
+        offset:  u64,
+        data:    Vec<u8>,
+    },
+
+    /// Run a placed graph (or graph slice) end-to-end on this executor.
+    /// All inputs must already be resident; all outputs will be left
+    /// resident on this executor unless the graph itself contains
+    /// download transfers.
+    Dispatch {
+        job_id:  u64,
+        graph:   compute_ir::ComputeGraph,
+    },
+
+    /// Read bytes from a buffer back into runtime memory.
+    DownloadBuffer {
+        buffer: BufferId,
+        offset: u64,
+        len:    u64,
+    },
+
+    /// Release a buffer.  After this, the BufferId is invalid.
+    FreeBuffer {
+        buffer: BufferId,
+    },
+
+    /// Cancel an in-flight job.  Best-effort.
+    CancelJob {
+        job_id: u64,
+    },
+
+    /// Liveness probe.
+    Heartbeat,
+
+    /// Graceful shutdown — executor flushes outstanding work and
+    /// stops accepting new requests.
+    Shutdown,
+}
+
+pub enum ExecutorResponse {
+    Registered     { executor_id: ExecutorId },
+    KernelReady    { kernel_id:   KernelId },
+    BufferAllocated{ buffer:      BufferId },
+    BufferUploaded { buffer:      BufferId },
+    DispatchDone   { job_id:      u64, timings: Vec<OpTiming> },
+    BufferData     { buffer:      BufferId, data: Vec<u8> },
+    BufferFreed,
+    Cancelled      { job_id:      u64 },
+    Alive          { profile:     BackendProfile },
+    ShuttingDown,
+    Error          { code: ErrorCode, message: String, job_id: Option<u64> },
+}
+
+pub enum ExecutorEvent {
+    /// Executor lost a buffer (out-of-memory, device reset).  The runtime
+    /// must drop its residency tracking for this BufferId.
+    BufferLost { buffer: BufferId, reason: String },
+
+    /// Executor's profile changed (e.g. a different process started
+    /// using the GPU).  The runtime should re-evaluate.
+    ProfileUpdated { profile: BackendProfile },
+
+    /// Executor is going away.
+    ShuttingDown,
+}
+
+pub struct OpTiming {
+    pub op_index: u32,
+    pub ns:       u64,
+}
+```
+
+`KernelSource` is a tagged union over the per-backend source strings:
+
+```rust
+pub enum KernelSource {
+    Msl       { code: String, entry: String },   // Metal
+    CudaC     { code: String, entry: String },   // CUDA
+    Glsl      { code: String, entry: String },   // OpenGL / Vulkan-via-glslangValidator
+    SpirV     { bytes: Vec<u8>, entry: String }, // Vulkan / WebGPU
+    Wgsl      { code: String, entry: String },   // WebGPU
+    OpenClC   { code: String, entry: String },   // OpenCL
+    Native    { backend: String, blob: Vec<u8> },// catch-all for ASIC IR / proprietary
+}
+```
+
+`Native` is the escape hatch for backends whose source language doesn't
+fit the named variants.  V1 only ever produces `Msl`, `CudaC`, and
+(for the CPU executor) emits no kernels at all — its dispatch is direct
+Rust function calls per op.
+
+`BackendProfile` is defined in MX04 §"BackendProfile"; for the wire
+format it is a struct of `u32`/`u64`/`String` fields.
+
+`ErrorCode` is a `u16` enum; values `0x00–0x7F` reserved for protocol
+errors, `0x80–0xFF` reserved for executor-specific.
+
+## Wire layout: top-level frame
+
+Every protocol message — request, response, or event — is wrapped in
+the same outer frame:
+
+```
+Frame:
+  u8           format_version       // 0x01 in V1
+  u8           message_kind         // 0=Request, 1=Response, 2=Event
+  u64          correlation_id       // request id; responses echo it; events use 0
+  uv64         payload_length
+  payload_length raw bytes:
+    varint     variant_tag
+    variant payload
+```
+
+Why a frame:
+
+- **Versioning at the byte level.**  A V2 reader that sees a V3 frame
+  errors immediately rather than misinterpreting the payload.
+- **Multiplexing.**  A single transport carries multiple in-flight
+  requests; correlation ids match responses to their requests.
+- **Self-delimitation.**  `payload_length` lets a stream-oriented
+  transport (TCP, Unix socket) frame messages without another layer.
+
+## The `Transport` trait
+
+```rust
+#[async_trait_internal]
+pub trait Transport: Send + Sync {
+    /// Send a request, await its response.  Correlation ids are managed
+    /// inside the Transport.
+    async fn request(&self, req: ExecutorRequest) -> Result<ExecutorResponse, TransportError>;
+
+    /// Subscribe to events from this transport's executor.  The runtime
+    /// owns the event consumer and dispatches events to listeners.
+    fn events(&self) -> EventStream;
+}
+
+pub type EventStream = Box<dyn AsyncIterator<Item = ExecutorEvent> + Send + Unpin>;
+```
+
+`async_trait_internal` is a hand-rolled in-crate macro (no external
+dependency on `async-trait`) that desugars `async fn` in traits to a
+boxed `Future`.
+
+`AsyncIterator` is `core::async_iter::AsyncIterator` (when stabilised) or
+a hand-rolled equivalent built on `core::future::Future` and `Pin`.  V1
+ships the hand-rolled version and switches to the std trait when it
+stabilises.
+
+### `LocalTransport`
+
+The only V1-shipped transport.  Implementation:
+
+- Holds a direct reference to an executor's request handler — `fn handle(req: ExecutorRequest) -> ExecutorResponse`.
+- `request()` calls `handle()` synchronously and returns a ready future.
+- In **debug builds**: serialises the request to bytes, deserialises,
+  invokes `handle()`, then serialises and deserialises the response.
+  This catches "I accidentally put a non-serializable type in the
+  protocol" bugs immediately.
+- In **release builds**: skips the round-trip.
+
+Tests in CI run debug builds, so the discipline is exercised on every PR.
+
+### Future transports (designed for, not shipped in V1)
+
+- **`UnixSocketTransport`** — frames over a Unix domain socket.  Uses
+  `std::os::unix::net::UnixStream`.  Length-prefixed framing per
+  §"Wire layout".
+- **`TcpTransport`** — frames over a TCP connection.  Same framing.
+- **`ZmqTransport`** — assumes `REQ`/`REP` or `DEALER`/`ROUTER` on the
+  underlying socket.  Each protocol frame is one ZMQ message.
+- **`NatsTransport`** — pub/sub.  Requests publish to `dispatch.<executor>`
+  subjects; responses publish to ephemeral reply subjects.  Enables
+  work-stealing setups with many subscribers.
+
+Each future transport is its own crate (`matrix-transport-unix`,
+`matrix-transport-tcp`, …) with its own zero-dep stack.  None of them
+land in V1; this spec lists them so the protocol design accommodates
+them.
+
+## Buffer transport policy
+
+V1 buffer transport is **always through the protocol**:
+
+- A 4-MiB tensor takes a `UploadBuffer` request with 4 MiB of `data`.
+  Locally, that bytes vector is moved (no copy in release builds; one
+  copy in debug builds for the round-trip test).
+- The same path is exercised by network transports unchanged.
+
+V2 may add a zero-copy fast path for `LocalTransport` that hands raw
+buffer pointers across without going through `Vec<u8>`.  V1 prefers
+uniform code paths so the local executor exercises the same protocol
+that remote executors will.
+
+## Kernel cache
+
+The executor caches compiled kernels by content hash.  Cache key:
+SipHash (`std::collections::hash_map::DefaultHasher`) of `KernelSource`
+bytes.  Hits skip compilation.
+
+When the runtime issues `PrepareKernel` for a kernel the executor
+already has cached, the executor still returns `KernelReady` quickly
+without re-compiling.  This is transparent to the runtime.
+
+## Error model
+
+Errors propagate from executor to runtime as `ExecutorResponse::Error
+{ code, message, job_id }`.  Categories:
+
+- **Protocol errors** (codes `0x00–0x1F`): malformed frame, unknown
+  variant, unsupported version.  Always fatal for the connection.
+- **Resource errors** (`0x20–0x3F`): out-of-memory, device lost.  May
+  be recoverable; the runtime decides.
+- **Compilation errors** (`0x40–0x5F`): kernel source rejected.  Does
+  not invalidate other state.
+- **Runtime errors** (`0x60–0x7F`): kernel produced NaN, dispatch
+  exceeded timeout.  Per-job, does not invalidate the executor.
+- **Executor-specific** (`0x80–0xFF`): backend-defined.
+
+Every error carries a UTF-8 `message` for diagnostics.  Messages are
+not security-sensitive; they may contain file names and line numbers.
+
+## Test methodology
+
+`executor-protocol` ships:
+
+1. **Wire round-trip** — every variant of every enum is encoded,
+   decoded, and asserted equal.  Generated by a macro that walks the
+   variants exhaustively; missing a variant is a compile error.
+2. **Truncation tests** — every wire form is asserted to fail cleanly
+   when the input is truncated by 1 byte at every position.  No panics,
+   no UB, only `Err(TruncatedMessage)`.
+3. **Forward-compat tests** — frames with `format_version` 2 are
+   asserted to fail with `UnsupportedVersion` rather than misinterpret.
+4. **Frame fuzzing** — a fixed-seed PRNG generates 100k random byte
+   strings and asserts the decoder never panics, only returns `Err`.
+5. **Local transport** — round-trip asserts that every supported
+   request type produces the expected response when the executor is a
+   trivial echo implementation.
+
+Coverage target: **100%** of the public API.
+
+## Out of scope (V1)
+
+- **Compression.**  Buffers are sent raw.  V2 may add `Compressed { codec, bytes }`.
+- **Encryption / authentication.**  Local transport doesn't need it.
+  V2 transports that cross trust boundaries add it at their layer.
+- **Streaming buffers.**  Large buffers are sent as one message.  V2
+  may add `BufferChunk` for very large tensors.
+- **Bidirectional flow control.**  V1 has no backpressure.  V2 transports
+  add it at their layer.
+
+## Open questions
+
+1. Should we have a `Ping` separate from `Heartbeat`?  They overlap.
+   V1 has only `Heartbeat` (returns `Alive { profile }`).
+2. Should `Error` carry a structured `details: bytes` field as well as
+   the human message?  Useful for richer error reporting.  V1 says no;
+   V2 may add it.
+3. Should `OpTiming` be optional in `DispatchDone`?  Some backends can't
+   measure per-op time without overhead.  V1 leaves it always present
+   but allows `ns: 0` to mean "unmeasured".

--- a/code/specs/MX04-compute-runtime.md
+++ b/code/specs/MX04-compute-runtime.md
@@ -1,0 +1,415 @@
+# MX04 — `compute-runtime`: Planner, Registry, Cost Model
+
+## Status
+
+Draft — V1 specification.  Read [MX00](MX00-matrix-execution-overview.md),
+[MX01](MX01-matrix-ir.md), [MX02](MX02-compute-ir.md), and
+[MX03](MX03-executor-protocol.md) first.
+
+## Purpose
+
+`compute-runtime` is the **brain** of the matrix execution layer.  It:
+
+1. **Owns the registry** of available executors and their capabilities.
+2. **Lowers `MatrixIR` to `ComputeIR`** by running the planner.
+3. **Drives execution** by sending `ExecutorRequest`s through transports
+   and collecting `ExecutorResponse`s.
+4. **Exposes the runtime API** that domain libraries call.
+
+It depends only on `matrix-ir`, `compute-ir`, and `executor-protocol` —
+plus `core`, `alloc`, and `std`.  It depends on no specific executor or
+transport implementation; those are looked up through the registry.
+
+## Public API
+
+```rust
+pub struct Runtime { /* ... */ }
+
+impl Runtime {
+    /// Construct a runtime with the always-available CPU executor.
+    /// Additional executors are added via `register`.
+    pub fn new() -> Self;
+
+    /// Register an executor reachable through the given transport.
+    /// Returns the assigned ExecutorId.
+    pub fn register(
+        &mut self,
+        transport: Box<dyn Transport>,
+    ) -> Result<ExecutorId, RuntimeError>;
+
+    /// Plan a graph: lower MatrixIR to ComputeIR using the current
+    /// registry.  Pure; no execution.
+    pub fn plan(&self, graph: &matrix_ir::Graph) -> Result<compute_ir::ComputeGraph, PlanError>;
+
+    /// Plan and execute.  Returns output tensors as host-side bytes
+    /// keyed by output TensorId.
+    pub fn run(
+        &self,
+        graph:  &matrix_ir::Graph,
+        inputs: HashMap<TensorId, Vec<u8>>,
+    ) -> Result<HashMap<TensorId, Vec<u8>>, RuntimeError>;
+
+    /// Inspect the registry.
+    pub fn executors(&self) -> &[RegisteredExecutor];
+}
+
+pub struct RegisteredExecutor {
+    pub id:       ExecutorId,
+    pub kind:     String,            // "cpu", "metal", "cuda", ...
+    pub profile:  BackendProfile,
+    pub healthy:  bool,
+}
+```
+
+The split between `plan` and `run` exists so users can inspect
+placement decisions without paying for execution.  This is a teaching
+affordance and a debugging affordance.
+
+## `BackendProfile`
+
+A profile is what a backend tells the registry about itself.  It is
+data — no behaviour — so it can travel over the wire (executors
+running in another process advertise themselves through `Register`
+messages, as defined in MX03).
+
+```rust
+pub struct BackendProfile {
+    pub kind: String,                       // "cpu" | "metal" | "cuda" | ...
+
+    /// Capability bitset: which Op variants are supported, indexed by
+    /// the V1 op tags from MX03.  A 0 bit means "fall back to CPU".
+    pub supported_ops: u32,                 // 27 ops fit in 32 bits.
+
+    /// Which dtypes are supported.  Bit i corresponds to DType discriminant i.
+    pub supported_dtypes: u8,
+
+    /// Compute throughput, peak, in floating-point ops per nanosecond.
+    pub gflops_f32: u32,                    // 1 = 1 GFLOPS, scaled.
+    pub gflops_u8:  u32,
+    pub gflops_i32: u32,
+
+    /// Memory bandwidth, in bytes per nanosecond.
+    pub host_to_device_bw: u32,             // bytes / ns
+    pub device_to_host_bw: u32,
+    pub device_internal_bw: u32,            // for on-device tensor ops
+
+    /// Fixed overhead per dispatched op, in nanoseconds.
+    pub launch_overhead_ns: u32,
+
+    /// Network latency for the transport carrying this executor, in
+    /// nanoseconds.  0 for in-process transports.
+    pub transport_latency_ns: u32,
+
+    /// Working-set capacity, in megabytes.
+    pub on_device_mib: u32,
+
+    /// Maximum tensor rank this backend supports.  4 is conservative for
+    /// most real backends; unlimited (= 16) is fine for CPU.
+    pub max_tensor_rank: u8,
+
+    /// Maximum size of any single dimension.  GPUs typically cap dispatches
+    /// at 65535 threadgroups in some axis; this surfaces that limit.
+    pub max_dim: u32,
+}
+```
+
+The cost model is **deliberately small**.  Real GPU performance is
+shape-dependent and cache-dependent, and a faithful model would require
+microbenchmarks per (op, shape, dtype) triple.  V1 takes the position
+that a coarse model with good defaults beats no model, and that the
+planner only needs ordinal correctness — pick the cheapest backend, not
+the exact nanosecond count.
+
+The CPU executor defaults to a measured profile from the host machine
+(detected at `Runtime::new` startup via a 100 ms calibration loop).
+Other executors return a built-in profile from their crate, possibly
+refined at startup with on-device microbenchmarks.
+
+## The planner algorithm
+
+Inputs:
+
+- `Graph` (from `matrix-ir`)
+- `[(ExecutorId, BackendProfile, healthy)]` registry snapshot
+
+Output:
+
+- `ComputeGraph` (from `compute-ir`)
+
+Algorithm:
+
+```
+fn plan(graph, registry):
+    # Pass 1: capability filter — for each op, set of executors that can run it
+    candidates: HashMap<OpIndex, Vec<ExecutorId>> = ...
+    for (i, op) in graph.ops:
+        candidates[i] = registry
+            .filter(profile.supports_op(op.tag))
+            .filter(profile.supports_dtype(op.dtype))
+            .filter(profile.supports_shape(op.output_shape))
+            .ids()
+        if candidates[i].is_empty():
+            candidates[i] = [CPU_EXECUTOR]      # always available
+
+    # Pass 2: greedy cost minimisation, in topological order
+    placement: HashMap<OpIndex, ExecutorId> = ...
+    residency: HashMap<TensorId, ExecutorId> = ...   # initially: inputs on host (cpu)
+
+    for (i, op) in graph.ops:
+        best_cost = INF
+        best_exec = candidates[i][0]
+        for exec_id in candidates[i]:
+            cost = compute_cost(op, exec_id, residency, registry)
+            if cost < best_cost:
+                best_cost = cost
+                best_exec = exec_id
+        placement[i] = best_exec
+        residency[op.output] = best_exec
+
+    # Pass 3: transfer insertion
+    placed_ops: Vec<PlacedOp> = ...
+    current_residency: HashMap<TensorId, ExecutorId> = inputs_residency.clone()
+
+    for (i, op) in graph.ops:
+        target = placement[i]
+        for input in op.inputs():
+            if current_residency[input] != target:
+                placed_ops.push(Transfer { input, src: current_residency[input], dst: target, ... })
+                current_residency[input] = target
+        placed_ops.push(Compute { op, executor: target, estimated_ns: ... })
+        current_residency[op.output] = target
+
+    # Pass 4: lifetime annotation
+    for (i, op) in placed_ops:
+        for input in op.inputs():
+            if last_use(input) == i:
+                placed_ops.push_after(i, Free { residency: ... })
+    insert_allocs_at_first_use(placed_ops)
+
+    return ComputeGraph { ops: placed_ops, ... }
+```
+
+`compute_cost` is the core cost function:
+
+```
+fn compute_cost(op, exec_id, residency, registry):
+    p = registry[exec_id].profile
+
+    # Compute cost
+    flops = estimate_flops(op)
+    compute_ns = flops * 1_000_000_000 / p.gflops_for(op.dtype)
+    compute_ns += p.launch_overhead_ns
+    compute_ns += p.transport_latency_ns
+
+    # Transfer cost
+    transfer_ns = 0
+    for input in op.inputs():
+        if residency[input] != exec_id:
+            bytes = input.shape.numel() * input.dtype.size_bytes()
+            transfer_ns += bytes / bandwidth(residency[input], exec_id, registry)
+
+    return compute_ns + transfer_ns
+```
+
+`estimate_flops` is a small lookup table per op kind:
+
+| Op | flops |
+|----|------|
+| Add, Sub, Mul, Div, Max, Min | `numel(output)` |
+| Pow | `5 * numel(output)` (log + mul + exp roughly) |
+| Sqrt, Recip, Tanh, Exp, Log | `5 * numel(output)` |
+| Neg, Abs, Cast | `numel(output)` |
+| MatMul | `2 * m * k * n` |
+| ReduceSum, ReduceMax, ReduceMean | `numel(input)` |
+| Reshape, Transpose, Broadcast | `numel(output)` (memory cost dominates) |
+| Equal, Less, Greater | `numel(output)` |
+| Where | `numel(output)` |
+| Const | `0` (just an upload) |
+
+Transfer cost uses `BackendProfile.host_to_device_bw` for runtime↔executor
+transfers and (when the same executor is involved) `device_internal_bw`.
+For executor-to-executor transfers, V1 routes through the runtime's host
+memory, so cost is `bytes / source.device_to_host_bw + bytes / dest.host_to_device_bw`.
+
+### Worked example (the example from MX00)
+
+A 4096x4096 f32 matmul with both inputs in host memory:
+
+```
+CPU (40 GFLOPS, 0 transfer cost — already on host):
+    flops = 2 * 4096^3 = 137 GFLOPS
+    compute_ns = 137e9 / 40 = 3.4e9 ns = 3.4 s
+    transfer_ns = 0
+    total = 3.4 s
+
+Metal (5 TFLOPS f32, host→device 10 GB/s):
+    flops = 137 GFLOPS
+    compute_ns = 137e9 / 5000 = 27e6 ns = 27 ms
+    transfer_ns = 2 * 64 MiB / 10 GB/s = 13.4 ms (in)
+                  + 64 MiB / 10 GB/s = 6.7 ms (out, paid by next consumer)
+    total ≈ 40 ms
+
+Winner: Metal.
+```
+
+A 1024x1024 f32 add:
+
+```
+CPU:
+    flops = 1M, compute_ns = 25 µs, transfer = 0
+    total = 25 µs
+
+Metal:
+    flops = 1M, compute_ns = 200 ns + 1 µs launch
+    transfer_ns = 2 * 4 MiB / 10 GB/s = 800 µs
+    total ≈ 800 µs
+
+Winner: CPU.
+```
+
+Both decisions fall out of one cost function, no special cases.
+
+## Registry mechanics
+
+The registry maintains `(ExecutorId, Box<dyn Transport>, BackendProfile,
+healthy)` for each executor.  Lookups are O(1).  Transports report
+events through `Transport::events()`; the runtime's event loop reacts
+to:
+
+- **`BufferLost`** — drop residency tracking for the affected buffer.
+  If a graph in flight depended on it, the graph fails with
+  `RuntimeError::BufferLost` and the caller can retry.
+- **`ProfileUpdated`** — refresh the profile in the registry.  Future
+  plans will see the new numbers.
+- **`ShuttingDown`** — mark the executor unhealthy.  Plans skip it.
+
+The runtime polls `Heartbeat` periodically (default: 1 second).  An
+executor that misses three consecutive heartbeats is marked unhealthy
+and skipped.  V1 does not auto-reconnect; the user calls `register`
+again with a fresh transport.
+
+## Async runtime
+
+`Runtime::run` is synchronous in V1's API surface but built on async
+internals.  The protocol's `Transport::request` returns a `Future`,
+which `Runtime::run` resolves with a hand-rolled `block_on`:
+
+```rust
+fn block_on<F: Future>(mut f: F) -> F::Output {
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut pinned = unsafe { Pin::new_unchecked(&mut f) };
+    loop {
+        match pinned.as_mut().poll(&mut cx) {
+            Poll::Ready(out) => return out,
+            Poll::Pending    => {
+                // V1 single-threaded: spin-yield until the LocalTransport completes
+                std::thread::yield_now();
+            }
+        }
+    }
+}
+```
+
+This is sufficient because `LocalTransport` resolves immediately.  Network
+transports will require a real reactor; that lands in the transport
+crates themselves, not in `compute-runtime`.
+
+## CPU executor
+
+`compute-cpu` is a separate crate, but its profile and registration are
+specified here because the runtime depends on it.  At `Runtime::new`:
+
+1. Construct a `CpuExecutor` with a `LocalTransport` wrapper.
+2. Run a 100 ms calibration: time `1024 * 1024` f32 adds and a 256x256
+   f32 matmul.  Derive `gflops_f32`, `host_to_device_bw`, etc.
+3. `register(transport)` the CPU executor.  By convention it gets
+   `ExecutorId(0)`.
+
+The CPU executor supports **every op** in the V1 set on **every dtype**
+(f32, u8, i32).  This is what makes it the safety net.  Its
+implementation is straight-line Rust, single-threaded in V1; SIMD and
+multi-threading are V2 optimisations.
+
+## Errors
+
+```rust
+pub enum RuntimeError {
+    NoExecutorAvailable,
+    BufferLost { buffer: BufferId },
+    Plan(PlanError),
+    Transport(TransportError),
+    Executor { code: ErrorCode, message: String },
+    InvalidGraph(matrix_ir::IrError),
+    InvalidPlan(compute_ir::IrError),
+}
+
+pub enum PlanError {
+    UnsupportedOp { op_index: u32, reason: String },
+    UnsupportedDtype { op_index: u32, dtype: DType },
+    InconsistentShape { op_index: u32, expected: Shape, actual: Shape },
+}
+```
+
+## Test methodology
+
+`compute-runtime` ships:
+
+1. **Synthetic-profile tests** — register mock executors with hand-set
+   profiles, plan small graphs, assert placement decisions match
+   expectations.  Drives the planner without any real GPU.
+2. **CPU-only round-trip** — `run` a graph through only the CPU
+   executor, assert outputs match a hand-computed reference.
+3. **Multi-executor planning** — register CPU + a mock GPU, vary the
+   GPU's profile, assert the planner crosses the expected threshold
+   between "stay on CPU" and "ship to GPU" as the cost model varies.
+4. **Transfer insertion** — graphs that mix supported and unsupported
+   ops; assert the planner inserts transfers and falls back to CPU for
+   unsupported ops.
+5. **Heartbeat / unhealthy** — kill a mock executor mid-flight; assert
+   subsequent plans skip it and existing plans error cleanly.
+6. **`plan` golden tests** — small graphs whose `ComputeGraph::dump()`
+   form is asserted byte-for-byte against fixtures.  Catches accidental
+   planner regressions.
+
+Coverage target: **95%+**.  The async machinery is harder to cover
+exhaustively but the planner and registry must be.
+
+## Backend implementation guide
+
+For an executor crate (e.g. `matrix-cpu`, `matrix-metal`):
+
+1. Implement the `ExecutorRequest` handler — a single function
+   `handle(req) -> response` with internal state for buffers and
+   compiled kernels.
+2. Construct a `BackendProfile` describing capabilities and costs.
+3. Provide a `register(runtime: &mut Runtime)` helper that wraps the
+   handler in a `LocalTransport` and calls `runtime.register`.
+
+The backend never sees `MatrixIR` directly — only `ComputeGraph`s in
+`Dispatch` requests.  This means a backend can be added without
+touching `matrix-ir`, only `compute-ir`.
+
+## Out of scope (V1)
+
+- **Graph caching.**  Re-planning every call is fine for V1.  V2 caches
+  `(graph_hash, registry_hash) -> ComputeGraph`.
+- **Cost-model auto-tuning.**  V2 may run microbenchmarks per (op,
+  shape, dtype) triple and refine `BackendProfile` over time.
+- **Speculative execution.**  V2 may run small graphs on multiple
+  executors in parallel and use the first to finish.
+- **Job parallelism within a single graph.**  V1 executes ops in
+  declared topological order.  V2 dispatches independent ops
+  concurrently.
+
+## Open questions
+
+1. Should the planner emit warnings (e.g. "this graph is dominated by
+   transfers; consider keeping intermediates on the GPU") as a
+   first-class output of `plan`?  Useful but additive; can land in V2.
+2. Is the calibration step worth its 100 ms cost on every `Runtime::new`?
+   Alternative: a one-time calibration cached in `~/.cache/`.  V1
+   chooses the simple path: re-calibrate every startup.
+3. How does `register` handle two executors with overlapping
+   capabilities (e.g. iGPU + dGPU)?  V1: both register, both are
+   considered, planner picks per-op.  No special preference logic.


### PR DESCRIPTION
## Summary

Introduces five specification documents (MX00-MX04) for a unified **matrix execution layer** — the foundation that the neural network, image processing, and signal processing tracks will all sit on top of.

The layer is a **narrow waist**: domain libraries above emit `MatrixIR` (pure tensor algebra), the runtime lowers it to `ComputeIR` (with explicit device placement and transfers), and backends below execute it via a transport-pluggable protocol.

## What's in each spec

| Spec | Purpose |
|------|---------|
| **MX00** | Architecture overview, layer diagram, zero-dependency mandate, V1 scope |
| **MX01** | `matrix-ir` — pure tensor algebra IR with 27 ops and 3 dtypes (f32, u8, i32) |
| **MX02** | `compute-ir` — placed graph with explicit `Residency`, `Transfer`, `Alloc`, `Free` ops |
| **MX03** | `executor-protocol` — hand-rolled wire format, message types, `Transport` trait |
| **MX04** | `compute-runtime` — planner algorithm, backend registry, cost model |

## Key design decisions

1. **Two-level IR**. `MatrixIR` is location-agnostic (what to compute). `ComputeIR` is the placed form (where, on which executor, with which transfers). The planner is the bridge.

2. **Cost-model-driven routing**. Each backend exposes a `BackendProfile` with FLOPS rates, transfer bandwidth, launch overhead, and capability bitsets. The planner greedily picks the cheapest executor per op, naturally keeping small ops on CPU and shipping large ones to GPU.

3. **Transport-pluggable protocol**. The runtime ↔ executor boundary is a serializable wire protocol. V1 ships only `LocalTransport` (in-process), but the design accommodates TCP, Unix sockets, ZMQ, NATS without redesign — remote executors look identical to the planner.

4. **Information does not leak**. The IR's vocabulary is pure tensor algebra. No "image", "channel", "batch", "feature" — those are domain labels above the line. An RGBA image is just a `[H, W, 4]` u8 tensor; channels-last vs channels-first is the image library's call, not the matrix layer's.

5. **Zero external dependencies**. Every new crate uses only `core` + `alloc` + `std`. Hand-rolled binary wire format, hand-rolled minimal `block_on`, SipHash from `std::collections`. No `serde`, no async runtime, no `libloading`.

6. **CPU is the safety net**. The CPU executor supports every op on every dtype, becoming the always-available fallback when a backend can't handle something.

## V1 scope (deliberately small)

Ships:
- `matrix-ir`, `compute-ir`, `executor-protocol`, `compute-runtime`
- `matrix-cpu` reference executor
- One GPU executor (Metal or CUDA)
- `matrix-transport-local`

Out of scope, designed for: network transports, multi-host, multi-GPU, fusion, conv2d as a primitive, dynamic shapes, autograd.

## Why this matters

- **Image processing** today writes one shader per backend per op (5 image ops × 3 backends = 15 hand-written kernels). With the IR, image ops emit `MatrixIR` once and lower automatically to any backend.
- **NN layers** in flight share the same execution path. A `Linear` layer is `matmul + add + activation` in `MatrixIR` — the same vocabulary the image library uses.
- **Memory transfer cost** becomes visible: `ComputeGraph::dump()` shows every transfer with its estimated cost, making placement decisions inspectable rather than magic.

## Test plan

This PR is specs only — no code lands until all five are accepted. After merge:

- [ ] Implement `matrix-ir` crate with builder + validator + wire round-trip tests
- [ ] Implement `compute-ir` crate with placement representation + dump + golden tests  
- [ ] Implement `executor-protocol` crate with wire codec + truncation + fuzz tests
- [ ] Implement `compute-runtime` crate with planner + synthetic-profile tests
- [ ] Implement `matrix-cpu` reference executor with cross-backend test fixtures
- [ ] Implement first GPU executor (Metal or CUDA)
- [ ] Migrate `image-gpu-core` to emit `MatrixIR` instead of hand-written shaders

🤖 Generated with [Claude Code](https://claude.com/claude-code)