### PR TITLE
feat(iir-type-checker): optional-typing spectrum checker and SSA inference engine

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -100,6 +100,7 @@ members = [
     "intel4004-simulator",
     "interrupt-handler",
     "interpreter-ir",
+    "iir-type-checker",
     "iir-coverage",
     "iir-coverage-json",
     "iir-coverage-lcov",

--- a/code/packages/rust/iir-type-checker/BUILD
+++ b/code/packages/rust/iir-type-checker/BUILD
@@ -1,0 +1,2 @@
+cargo build -p iir-type-checker
+cargo test -p iir-type-checker

--- a/code/packages/rust/iir-type-checker/CHANGELOG.md
+++ b/code/packages/rust/iir-type-checker/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — iir-type-checker
+
+## [0.1.0] — 2026-05-04
+
+### Added
+
+- `tier::TypingTier` enum — `Untyped`, `Partial(f32)`, `FullyTyped` with
+  `from_fraction()`, `is_fully_typed()`, `is_untyped()`, `typed_fraction()`,
+  and `Display` implementations.
+- `errors::TypeCheckError` and `TypeCheckWarning` with `ErrorKind` enum
+  (`InvalidType`, `TypeMismatch`, `ConditionNotBool`).
+- `report::TypeCheckReport` — bundles tier, typed_fraction, errors, warnings,
+  and inferred_types map.  Provides `ok()` and `summary()` helpers.
+- `check::check_module()` — read-only validation pass over an `IIRModule`:
+  validates `type_hint` strings, binary-op operand consistency, and branch
+  condition types.
+- `infer::infer_types_mut()` — mutating SSA-propagation inference pass:
+  R1–R8 rules for const literals, comparisons, arithmetic, bitwise, unary,
+  and SSA-copy instructions.  Multi-pass fixed-point convergence.
+- `infer_and_check()` — top-level convenience function: runs inference then
+  checking, returning a unified `TypeCheckReport` with `inferred_types` populated.
+- Comprehensive inline unit tests for all modules (60+ assertions).

--- a/code/packages/rust/iir-type-checker/Cargo.toml
+++ b/code/packages/rust/iir-type-checker/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "iir-type-checker"
+version = "0.1.0"
+edition = "2021"
+description = "Optional-typing spectrum checker and inference engine for InterpreterIR modules."
+license = "MIT"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+
+[dev-dependencies]

--- a/code/packages/rust/iir-type-checker/README.md
+++ b/code/packages/rust/iir-type-checker/README.md
@@ -1,0 +1,103 @@
+# `iir-type-checker`
+
+Optional-typing spectrum checker and inference engine for
+[InterpreterIR](../interpreter-ir) modules.
+
+## Overview
+
+The LANG pipeline's `type_hint` field on each `IIRInstr` is *optional*: it
+can be `"any"` (unknown, to be profiled) or a concrete type like `"u8"`,
+`"i64"`, `"bool"`, `"f64"`, or `"ref<T>"`.
+
+This crate answers two questions:
+
+1. **How typed is this module?** — classifies a module as `Untyped`,
+   `Partial(f%)`, or `FullyTyped`.
+2. **What types can we infer?** — fills in `"any"` hints for instructions
+   whose type is determinable from constants, comparisons, or SSA-propagated
+   arithmetic.
+
+## The typing spectrum
+
+```
+Untyped ─────────────────────────────────── FullyTyped
+(all "any")   Partial(0.3)  Partial(0.9)   (all concrete)
+
+Typical:       TypeScript,   Hack/PHP,      Tetrad, Algol,
+MRI Ruby,      Sorbet-Ruby   Dart, Swift    Oct, C
+Twig, Lisp
+```
+
+| Tier | AOT strategy | JIT strategy |
+|------|-------------|--------------|
+| `Untyped` | Link full `vm-runtime`; speculate from profile | Wait for profiling |
+| `Partial` | Compile typed functions; interpret untyped | JIT hot paths |
+| `FullyTyped` | Compile everything natively; skip `vm-runtime` | Specialise immediately |
+
+## Usage
+
+### Check an already-annotated module
+
+```rust
+use interpreter_ir::module::IIRModule;
+use iir_type_checker::check_module;
+
+let report = check_module(&module);
+println!("{}", report.summary()); // e.g. "tier=FullyTyped typed=100% errors=0 warnings=0 inferred=0"
+```
+
+### Infer types then check
+
+```rust
+use iir_type_checker::infer_and_check;
+
+let report = infer_and_check(&mut module);
+// module.functions[0].instructions[n].type_hint is now populated
+assert!(report.ok());
+```
+
+### Integration with JIT/AOT
+
+```rust
+// Before calling jit-core or aot-core, enrich the module:
+let report = iir_type_checker::infer_and_check(&mut module);
+
+// jit-core and aot-core read type_hint via IIRInstr::is_typed() /
+// effective_type() — they automatically benefit from the inferred hints.
+let bytes = aot_core.compile(&module)?;
+```
+
+## Inference rules
+
+| Rule | Trigger | Result |
+|------|---------|--------|
+| R1 const-int | `const dest, Int(n)` with `type_hint="any"` | `"i64"` |
+| R2 const-float | `const dest, Float(f)` | `"f64"` |
+| R3 const-bool | `const dest, Bool(b)` | `"bool"` |
+| R4 cmp-bool | `cmp_* dest, [a, b]` | `"bool"` (always) |
+| R5 arith-same | `add/sub/…` where both srcs have the same concrete type | same type |
+| R6 bitwise-same | `and/or/xor/shl/shr` with same-typed srcs | same type |
+| R7 unary-passthrough | `neg/not dest, [a]` where `a` is typed | same type as `a` |
+| R8 ssa-copy | `load_reg dest, [a]` where `a` is typed | same type as `a` |
+
+Inference is multi-pass (fixed-point) so SSA chains of arbitrary depth
+resolve correctly.
+
+## Validation errors
+
+| Error | Meaning |
+|-------|---------|
+| `InvalidType` | `type_hint` is not `"any"`, `"void"`, or a concrete type |
+| `TypeMismatch` | Binary op srcs have different concrete types |
+| `ConditionNotBool` | `jmp_if_true`/`jmp_if_false` condition is not `"bool"` |
+
+## Stack position
+
+```
+iir-type-checker
+    └── interpreter-ir    (IIRModule, IIRInstr, opcodes)
+
+Consumers:
+    jit-core              (reads type_hint via is_typed() / effective_type())
+    aot-core              (same)
+```

--- a/code/packages/rust/iir-type-checker/src/check.rs
+++ b/code/packages/rust/iir-type-checker/src/check.rs
@@ -1,0 +1,394 @@
+//! `check_module` — validation pass over an `IIRModule`.
+//!
+//! This pass **reads** the module but never modifies it.  It produces a
+//! [`TypeCheckReport`] that describes:
+//!
+//! - How typed the module is (its [`TypingTier`]).
+//! - Any type errors found (invalid type strings, mismatched operand types,
+//!   ill-typed branch conditions).
+//!
+//! The pass is deliberately **lenient with `"any"` instructions** — they
+//! produce neither errors nor warnings (they are simply untyped and counted
+//! in the fraction denominator).  Only instructions whose `type_hint` is
+//! not `"any"` and not a valid concrete type are flagged as `InvalidType`.
+//!
+//! # Algorithm
+//!
+//! For each function, for each instruction:
+//!
+//! 1. **Skip `"any"` instructions** — no validation, just count.
+//! 2. **Skip control-flow ops** (`jmp`, `jmp_if_*`, `label`, `ret_void`)
+//!    for the typed-fraction denominator: they carry no data type.
+//! 3. **Validate type_hint**: must be `"any"`, in `CONCRETE_TYPES`, or a
+//!    `ref<T>` form.
+//! 4. **Validate binary-op consistency**: if both source operands are bound
+//!    to variables with known concrete types (via a `src_types` map built
+//!    on the fly), and those types differ, emit `TypeMismatch`.
+//! 5. **Validate branch conditions**: for `jmp_if_true` / `jmp_if_false`,
+//!    the first source must be typed `"bool"` if typed at all.
+//!
+//! # Note on `src_types` propagation
+//!
+//! This pass builds a simple SSA map `dest → type_hint` as it walks
+//! instructions.  This lets it look up the type of a source variable when
+//! checking a later instruction.  The map only contains concrete types;
+//! `"any"` is excluded.
+
+use std::collections::HashMap;
+
+use interpreter_ir::module::IIRModule;
+use interpreter_ir::opcodes::{is_concrete_type, DYNAMIC_TYPE};
+use interpreter_ir::instr::Operand;
+
+use crate::errors::{ErrorKind, TypeCheckError};
+use crate::report::TypeCheckReport;
+
+// ---------------------------------------------------------------------------
+// Opcode classification helpers
+// ---------------------------------------------------------------------------
+
+/// Data-flow ops (have a destination register and a meaningful type).
+///
+/// Control-flow ops are excluded because their "type" is about the branch
+/// predicate, not a produced value, so they don't count toward the typed
+/// fraction.
+fn is_data_op(op: &str) -> bool {
+    !matches!(
+        op,
+        "jmp" | "jmp_if_true" | "jmp_if_false" | "label" | "ret_void"
+    )
+}
+
+/// Binary arithmetic/bitwise/comparison ops that require operand-type consistency.
+fn is_binary_data_op(op: &str) -> bool {
+    matches!(
+        op,
+        "add" | "sub" | "mul" | "div" | "mod"
+            | "and" | "or" | "xor" | "shl" | "shr"
+            | "cmp_eq" | "cmp_ne" | "cmp_lt" | "cmp_le" | "cmp_gt" | "cmp_ge"
+    )
+}
+
+/// Conditional branch ops that require a bool condition.
+fn is_conditional_branch(op: &str) -> bool {
+    matches!(op, "jmp_if_true" | "jmp_if_false")
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Validate the type annotations in `module` without modifying it.
+///
+/// Returns a [`TypeCheckReport`] describing the module's typing tier,
+/// any errors found, and any warnings.  The `inferred_types` field of the
+/// report is always empty — run [`crate::infer::infer_types_mut`] first
+/// if you want inference.
+///
+/// # Example
+///
+/// ```
+/// use interpreter_ir::module::IIRModule;
+/// use interpreter_ir::function::IIRFunction;
+/// use interpreter_ir::instr::{IIRInstr, Operand};
+/// use iir_type_checker::check::check_module;
+/// use iir_type_checker::tier::TypingTier;
+///
+/// // Fully-typed module: one const of type u8.
+/// let fn_ = IIRFunction::new(
+///     "main", vec![], "void",
+///     vec![
+///         IIRInstr::new("const", Some("x".into()), vec![Operand::Int(5)], "u8"),
+///         IIRInstr::new("ret_void", None, vec![], "void"),
+///     ],
+/// );
+/// let mut module = IIRModule::new("test", "tetrad");
+/// module.functions.push(fn_);
+/// let report = check_module(&module);
+/// assert!(report.ok());
+/// assert_eq!(report.tier, TypingTier::FullyTyped);
+/// ```
+pub fn check_module(module: &IIRModule) -> TypeCheckReport {
+    let mut errors: Vec<TypeCheckError> = Vec::new();
+    let mut total_data_instrs: usize = 0;
+    let mut typed_data_instrs: usize = 0;
+
+    for func in &module.functions {
+        // SSA map: dest variable → concrete type_hint (only concrete types stored).
+        let mut src_types: HashMap<String, String> = HashMap::new();
+
+        for (idx, instr) in func.instructions.iter().enumerate() {
+            let op = instr.op.as_str();
+            let type_hint = instr.type_hint.as_str();
+
+            // ── Count data-flow instructions ──────────────────────────────
+            if is_data_op(op) {
+                if instr.dest.is_some() {
+                    total_data_instrs += 1;
+                    if is_concrete_type(type_hint) {
+                        typed_data_instrs += 1;
+                    }
+                }
+            }
+
+            // ── Validate conditional-branch condition is bool (runs even for
+            //    "any" branch instructions because the first *source* variable
+            //    may be concretely typed) ──────────────────────────────────
+            if is_conditional_branch(op) && !instr.srcs.is_empty() {
+                let t = operand_type(&instr.srcs[0], &src_types);
+                if let Some(cond_type) = t {
+                    if cond_type != "bool" {
+                        errors.push(TypeCheckError {
+                            fn_name: func.name.clone(),
+                            instr_idx: idx,
+                            kind: ErrorKind::ConditionNotBool,
+                            message: format!(
+                                "op '{}': condition operand has type '{}', expected 'bool'",
+                                op, cond_type
+                            ),
+                        });
+                    }
+                }
+            }
+
+            // ── Skip untyped instructions — nothing more to validate ───────
+            if type_hint == DYNAMIC_TYPE {
+                continue;
+            }
+
+            // ── Validate the type_hint string itself ──────────────────────
+            if !is_concrete_type(type_hint) && type_hint != "void" {
+                errors.push(TypeCheckError {
+                    fn_name: func.name.clone(),
+                    instr_idx: idx,
+                    kind: ErrorKind::InvalidType,
+                    message: format!(
+                        "op '{}': type_hint '{}' is not 'any', 'void', or a concrete type",
+                        op, type_hint
+                    ),
+                });
+                // Don't attempt further checks — type is broken.
+                continue;
+            }
+
+            // ── Record the destination type for downstream instructions ───
+            if let Some(dest) = &instr.dest {
+                if is_concrete_type(type_hint) {
+                    src_types.insert(dest.clone(), type_hint.to_string());
+                }
+            }
+
+            // ── Validate binary-op operand consistency ────────────────────
+            if is_binary_data_op(op) && instr.srcs.len() >= 2 {
+                let t0 = operand_type(&instr.srcs[0], &src_types);
+                let t1 = operand_type(&instr.srcs[1], &src_types);
+                if let (Some(a), Some(b)) = (t0, t1) {
+                    if a != b {
+                        errors.push(TypeCheckError {
+                            fn_name: func.name.clone(),
+                            instr_idx: idx,
+                            kind: ErrorKind::TypeMismatch,
+                            message: format!(
+                                "op '{}': src[0] is '{}' but src[1] is '{}' — types must agree",
+                                op, a, b
+                            ),
+                        });
+                    }
+                }
+            }
+
+        }
+    }
+
+    let typed_fraction = if total_data_instrs == 0 {
+        0.0_f32
+    } else {
+        typed_data_instrs as f32 / total_data_instrs as f32
+    };
+
+    let mut report = TypeCheckReport::new(typed_fraction);
+    report.errors = errors;
+    report
+}
+
+/// Compute the typing tier fractions without producing errors (available for
+/// internal use by future modules in this crate).
+#[allow(dead_code)]
+pub(crate) fn measure_tier(module: &IIRModule) -> f32 {
+    let mut total = 0usize;
+    let mut typed = 0usize;
+    for func in &module.functions {
+        for instr in &func.instructions {
+            if is_data_op(instr.op.as_str()) && instr.dest.is_some() {
+                total += 1;
+                if is_concrete_type(instr.type_hint.as_str()) {
+                    typed += 1;
+                }
+            }
+        }
+    }
+    if total == 0 { 0.0 } else { typed as f32 / total as f32 }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Look up the concrete type of an operand in the SSA map.
+///
+/// Returns `None` if:
+/// - The operand is an immediate (not a variable reference).
+/// - The operand is a variable whose type is not yet in the map (untyped).
+fn operand_type<'a>(
+    operand: &Operand,
+    src_types: &'a HashMap<String, String>,
+) -> Option<&'a str> {
+    match operand {
+        Operand::Var(name) => src_types.get(name.as_str()).map(String::as_str),
+        Operand::Int(_) => None,    // immediates carry no SSA type
+        Operand::Float(_) => None,
+        Operand::Bool(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+
+    fn make_module(instrs: Vec<IIRInstr>) -> IIRModule {
+        let fn_ = IIRFunction::new("main", vec![], "void", instrs);
+        let mut m = IIRModule::new("test", "tetrad");
+        m.functions.push(fn_);
+        m
+    }
+
+    // ── Typed-fraction tests ──────────────────────────────────────────────
+
+    #[test]
+    fn empty_module_is_untyped() {
+        let module = IIRModule::new("empty", "tetrad");
+        let report = check_module(&module);
+        assert_eq!(report.tier, crate::tier::TypingTier::Untyped);
+        assert!(report.ok());
+    }
+
+    #[test]
+    fn ret_void_only_module_is_untyped() {
+        // ret_void has no dest; it should not count in the denominator.
+        let module = make_module(vec![
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = check_module(&module);
+        assert_eq!(report.tier, crate::tier::TypingTier::Untyped);
+        assert!(report.ok());
+    }
+
+    #[test]
+    fn single_typed_const_is_fully_typed() {
+        let module = make_module(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(1)], "u8"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = check_module(&module);
+        assert_eq!(report.tier, crate::tier::TypingTier::FullyTyped);
+        assert!(report.ok());
+    }
+
+    #[test]
+    fn mix_of_typed_and_untyped_is_partial() {
+        let module = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "u8"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(2)], "any"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = check_module(&module);
+        assert!(matches!(report.tier, crate::tier::TypingTier::Partial(_)));
+    }
+
+    // ── Validation tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn invalid_type_hint_produces_error() {
+        let module = make_module(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(1)], "integer"),
+        ]);
+        let report = check_module(&module);
+        assert!(!report.ok());
+        assert_eq!(report.errors[0].kind, ErrorKind::InvalidType);
+    }
+
+    #[test]
+    fn mismatched_binary_op_types_produce_error() {
+        // a: u8, b: f64 — add requires same types
+        let module = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "u8"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Float(1.0)], "f64"),
+            IIRInstr::new("add", Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "u8"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = check_module(&module);
+        assert!(!report.ok());
+        assert_eq!(report.errors[0].kind, ErrorKind::TypeMismatch);
+    }
+
+    #[test]
+    fn matching_binary_op_types_are_ok() {
+        let module = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "u8"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(2)], "u8"),
+            IIRInstr::new("add", Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "u8"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = check_module(&module);
+        assert!(report.ok(), "errors: {:?}", report.errors);
+    }
+
+    #[test]
+    fn conditional_branch_on_non_bool_produces_error() {
+        let module = make_module(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("jmp_if_true",
+                None,
+                vec![Operand::Var("x".into()), Operand::Var("L".into())],
+                "any"),
+            IIRInstr::new("label", None, vec![Operand::Var("L".into())], "void"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = check_module(&module);
+        assert!(!report.ok());
+        assert_eq!(report.errors[0].kind, ErrorKind::ConditionNotBool);
+    }
+
+    #[test]
+    fn conditional_branch_on_bool_is_ok() {
+        let module = make_module(vec![
+            IIRInstr::new("const", Some("cond".into()), vec![Operand::Bool(true)], "bool"),
+            IIRInstr::new("jmp_if_true",
+                None,
+                vec![Operand::Var("cond".into()), Operand::Var("L".into())],
+                "any"),
+            IIRInstr::new("label", None, vec![Operand::Var("L".into())], "void"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = check_module(&module);
+        assert!(report.ok(), "errors: {:?}", report.errors);
+    }
+
+    #[test]
+    fn untyped_binary_op_is_not_an_error() {
+        // When all srcs are "any", we can't validate — that's fine.
+        let module = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "any"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(2)], "any"),
+            IIRInstr::new("add", Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "any"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = check_module(&module);
+        assert!(report.ok());
+    }
+}

--- a/code/packages/rust/iir-type-checker/src/errors.rs
+++ b/code/packages/rust/iir-type-checker/src/errors.rs
@@ -1,0 +1,186 @@
+//! `TypeCheckError` and `TypeCheckWarning` — diagnostic types for IIR type checking.
+//!
+//! # Error vs warning
+//!
+//! | Kind | Category | Meaning |
+//! |------|----------|---------|
+//! | `InvalidType` | Error | `type_hint` is not `"any"`, not in `CONCRETE_TYPES`, and not a `ref<T>` |
+//! | `TypeMismatch` | Error | Two source operands with different concrete types feed a binary op |
+//! | `ConditionNotBool` | Error | `jmp_if_true` / `jmp_if_false` source has a non-`bool` concrete type |
+//! | `UntypedOperation` | Warning | All operands are `"any"`; inference could not resolve the type |
+//! | `ObservedTypeDivergence` | Warning | `type_hint` disagrees with `observed_type` from the profiler |
+//!
+//! Errors block specialised code-generation (the instruction must be treated
+//! as generic / call-runtime).  Warnings are informational; the compiler can
+//! still proceed.
+
+/// The category of a type-check error.
+///
+/// Variants are ordered from most severe to least so that consumers can
+/// compare `ErrorKind` values in match arms or ordering.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ErrorKind {
+    /// The `type_hint` string is not `"any"`, not in
+    /// [`interpreter_ir::opcodes::CONCRETE_TYPES`], and not a `ref<T>` string.
+    ///
+    /// # Example trigger
+    ///
+    /// ```text
+    /// IIRInstr { op: "add", type_hint: "integer", … }  // "integer" is invalid
+    /// ```
+    InvalidType,
+
+    /// Two source operands carry different concrete types and the operation
+    /// requires they agree (arithmetic, bitwise, most comparisons).
+    ///
+    /// # Example trigger
+    ///
+    /// ```text
+    /// const a, 3          ; type_hint = "u8"
+    /// const b, 3.0        ; type_hint = "f64"
+    /// add   c, [a, b]     ; type_hint = "u8" — mismatches b's "f64"
+    /// ```
+    TypeMismatch,
+
+    /// A `jmp_if_true` or `jmp_if_false` instruction has a source operand
+    /// with a concrete type other than `"bool"`.
+    ///
+    /// # Example trigger
+    ///
+    /// ```text
+    /// const x, 1          ; type_hint = "i64"
+    /// jmp_if_true [x], L  ; x is "i64", not "bool"
+    /// ```
+    ConditionNotBool,
+}
+
+impl std::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ErrorKind::InvalidType => write!(f, "InvalidType"),
+            ErrorKind::TypeMismatch => write!(f, "TypeMismatch"),
+            ErrorKind::ConditionNotBool => write!(f, "ConditionNotBool"),
+        }
+    }
+}
+
+/// A fatal type-checking error attached to a specific instruction.
+///
+/// # Example
+///
+/// ```
+/// use iir_type_checker::errors::{TypeCheckError, ErrorKind};
+///
+/// let e = TypeCheckError {
+///     fn_name: "main".into(),
+///     instr_idx: 2,
+///     kind: ErrorKind::TypeMismatch,
+///     message: "add: src types 'u8' and 'f64' disagree".into(),
+/// };
+/// assert_eq!(e.kind, ErrorKind::TypeMismatch);
+/// println!("{}", e);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeCheckError {
+    /// Name of the function containing the faulty instruction.
+    pub fn_name: String,
+
+    /// Zero-based index of the instruction within the function's instruction list.
+    pub instr_idx: usize,
+
+    /// The category of the error.
+    pub kind: ErrorKind,
+
+    /// Human-readable explanation suitable for printing to a developer.
+    pub message: String,
+}
+
+impl std::fmt::Display for TypeCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[{}] {}:{} — {}",
+            self.kind, self.fn_name, self.instr_idx, self.message
+        )
+    }
+}
+
+/// A non-fatal type-check warning attached to a specific instruction.
+///
+/// Warnings do not block code generation.  The compiler may emit a
+/// diagnostic and continue.
+///
+/// # Example
+///
+/// ```
+/// use iir_type_checker::errors::TypeCheckWarning;
+///
+/// let w = TypeCheckWarning {
+///     fn_name: "main".into(),
+///     instr_idx: 0,
+///     message: "all operands are 'any'; inference could not resolve type".into(),
+/// };
+/// println!("{}", w);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeCheckWarning {
+    /// Name of the function containing the instruction.
+    pub fn_name: String,
+
+    /// Zero-based index within the function's instruction list.
+    pub instr_idx: usize,
+
+    /// Human-readable description of the warning.
+    pub message: String,
+}
+
+impl std::fmt::Display for TypeCheckWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[warn] {}:{} — {}", self.fn_name, self.instr_idx, self.message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_kind_display() {
+        assert_eq!(ErrorKind::InvalidType.to_string(), "InvalidType");
+        assert_eq!(ErrorKind::TypeMismatch.to_string(), "TypeMismatch");
+        assert_eq!(ErrorKind::ConditionNotBool.to_string(), "ConditionNotBool");
+    }
+
+    #[test]
+    fn error_kind_ordering() {
+        // InvalidType is more severe than ConditionNotBool
+        assert!(ErrorKind::InvalidType < ErrorKind::ConditionNotBool);
+    }
+
+    #[test]
+    fn type_check_error_display() {
+        let e = TypeCheckError {
+            fn_name: "main".into(),
+            instr_idx: 3,
+            kind: ErrorKind::TypeMismatch,
+            message: "add: 'u8' vs 'f64'".into(),
+        };
+        let s = e.to_string();
+        assert!(s.contains("TypeMismatch"));
+        assert!(s.contains("main"));
+        assert!(s.contains("3"));
+    }
+
+    #[test]
+    fn type_check_warning_display() {
+        let w = TypeCheckWarning {
+            fn_name: "loop_body".into(),
+            instr_idx: 7,
+            message: "unresolved".into(),
+        };
+        let s = w.to_string();
+        assert!(s.contains("warn"));
+        assert!(s.contains("loop_body"));
+        assert!(s.contains("7"));
+    }
+}

--- a/code/packages/rust/iir-type-checker/src/infer.rs
+++ b/code/packages/rust/iir-type-checker/src/infer.rs
@@ -1,0 +1,367 @@
+//! Type-inference pass — populates `type_hint` on `IIRInstr` objects
+//! that currently carry `"any"`.
+//!
+//! # Design
+//!
+//! The inference pass is a **mutating SSA propagation** algorithm.  It
+//! works entirely at the `IIRModule` level, which means it sees the full
+//! definition of every function and can use SSA variable information from
+//! earlier instructions in the same function body.
+//!
+//! ## Inference rules (in precedence order)
+//!
+//! | Rule | Trigger | Inferred type |
+//! |------|---------|---------------|
+//! | **R1 const-int** | `const dest, Int(n)` with `type_hint = "any"` | `"i64"` |
+//! | **R2 const-float** | `const dest, Float(f)` with `type_hint = "any"` | `"f64"` |
+//! | **R3 const-bool** | `const dest, Bool(b)` with `type_hint = "any"` | `"bool"` |
+//! | **R4 cmp-bool** | `cmp_* dest, [a, b]` with `type_hint = "any"` | `"bool"` (comparisons always return bool) |
+//! | **R5 arith-same** | `add/sub/mul/div/mod dest, [a, b]` where both `a` and `b` are the same concrete type | same type |
+//! | **R6 bitwise-same** | `and/or/xor/shl/shr dest, [a, b]` with same-typed operands | same type |
+//! | **R7 unary-passthrough** | `neg/not dest, [a]` where `a` has a concrete type | same type as `a` |
+//! | **R8 ssa-copy** | `dest = src` (explicit copy or alias) where `src` is concrete | same type as `src` |
+//!
+//! ## Multi-pass propagation
+//!
+//! Rules R5–R8 depend on source types that may themselves be inferred.
+//! A single forward pass is therefore not sufficient — e.g. if `a` is
+//! inferred after the `add` that reads `a`.  The pass repeats until no
+//! new types are inferred (fixed-point iteration).  Typical programs
+//! converge in 2–3 passes.
+//!
+//! ## Returned map
+//!
+//! `infer_types_mut` returns a `HashMap<String, String>` of every variable
+//! it successfully annotated (dest name → inferred type).  This is
+//! included verbatim in the `inferred_types` field of
+//! [`TypeCheckReport`](crate::report::TypeCheckReport).
+
+use std::collections::HashMap;
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::module::IIRModule;
+use interpreter_ir::opcodes::{is_concrete_type, DYNAMIC_TYPE};
+
+// ---------------------------------------------------------------------------
+// Op category helpers
+// ---------------------------------------------------------------------------
+
+fn is_cmp_op(op: &str) -> bool {
+    matches!(
+        op,
+        "cmp_eq" | "cmp_ne" | "cmp_lt" | "cmp_le" | "cmp_gt" | "cmp_ge"
+    )
+}
+
+fn is_arith_op(op: &str) -> bool {
+    matches!(op, "add" | "sub" | "mul" | "div" | "mod")
+}
+
+fn is_bitwise_op(op: &str) -> bool {
+    matches!(op, "and" | "or" | "xor" | "shl" | "shr")
+}
+
+fn is_unary_op(op: &str) -> bool {
+    matches!(op, "neg" | "not")
+}
+
+// ---------------------------------------------------------------------------
+// Per-function inference
+// ---------------------------------------------------------------------------
+
+/// Infer types for one function's instructions.
+///
+/// Returns a `HashMap<dest_var, inferred_type>` for every instruction
+/// this call annotated (across all iterations).  The function's
+/// `IIRInstr` objects are mutated in place.
+fn infer_function(func: &mut IIRFunction) -> HashMap<String, String> {
+    // SSA map: dest var → concrete type.  Populated incrementally.
+    let mut env: HashMap<String, String> = HashMap::new();
+    let mut newly_inferred: HashMap<String, String> = HashMap::new();
+
+    // Seed env with already-typed instructions.
+    for instr in func.instructions.iter() {
+        if let Some(dest) = &instr.dest {
+            if is_concrete_type(instr.type_hint.as_str()) {
+                env.insert(dest.clone(), instr.type_hint.clone());
+            }
+        }
+    }
+
+    // Fixed-point: keep passing until no new inferences.
+    loop {
+        let mut changed = false;
+
+        for instr in func.instructions.iter_mut() {
+            // Only consider instructions that are currently untyped.
+            if instr.type_hint != DYNAMIC_TYPE {
+                continue;
+            }
+
+            let Some(dest) = instr.dest.as_ref() else {
+                continue; // void-result instruction — nothing to infer
+            };
+
+            let inferred = infer_single(instr, &env);
+
+            if let Some(ty) = inferred {
+                instr.type_hint = ty.clone();
+                env.insert(dest.clone(), ty.clone());
+                newly_inferred.insert(dest.clone(), ty);
+                changed = true;
+            }
+        }
+
+        if !changed {
+            break;
+        }
+    }
+
+    newly_inferred
+}
+
+/// Try to infer the type for a single instruction.
+///
+/// Returns `Some(type_string)` when a concrete type can be determined,
+/// `None` when the instruction remains unresolvable.
+fn infer_single(instr: &IIRInstr, env: &HashMap<String, String>) -> Option<String> {
+    let op = instr.op.as_str();
+
+    // R1–R3: constant literals ────────────────────────────────────────────
+    if op == "const" {
+        if let Some(src) = instr.srcs.first() {
+            return match src {
+                Operand::Int(_) => Some("i64".into()),
+                Operand::Float(_) => Some("f64".into()),
+                Operand::Bool(_) => Some("bool".into()),
+                Operand::Var(_) => None, // symbolic constant — can't infer
+            };
+        }
+    }
+
+    // R4: comparisons always produce bool ─────────────────────────────────
+    if is_cmp_op(op) {
+        return Some("bool".into());
+    }
+
+    // R5 / R6: binary arithmetic / bitwise — infer from same-typed srcs ──
+    if (is_arith_op(op) || is_bitwise_op(op)) && instr.srcs.len() >= 2 {
+        let t0 = resolve_operand_type(&instr.srcs[0], env);
+        let t1 = resolve_operand_type(&instr.srcs[1], env);
+        if let (Some(a), Some(b)) = (t0, t1) {
+            if a == b {
+                return Some(a.to_string());
+            }
+        }
+    }
+
+    // R7: unary passthrough ───────────────────────────────────────────────
+    if is_unary_op(op) {
+        if let Some(src) = instr.srcs.first() {
+            if let Some(ty) = resolve_operand_type(src, env) {
+                return Some(ty.to_string());
+            }
+        }
+    }
+
+    // R8: SSA copy (load_reg / store_reg with a variable source) ──────────
+    if op == "load_reg" || op == "store_reg" {
+        if let Some(Operand::Var(name)) = instr.srcs.first() {
+            if let Some(ty) = env.get(name.as_str()) {
+                return Some(ty.clone());
+            }
+        }
+    }
+
+    None
+}
+
+/// Resolve the concrete type of an operand using the SSA env.
+///
+/// - `Var(name)` → looks up `name` in env.
+/// - Immediates: `Int` → `"i64"`, `Float` → `"f64"`, `Bool` → `"bool"`.
+///
+/// Returns `None` when the variable is not yet typed.
+fn resolve_operand_type<'a>(
+    operand: &Operand,
+    env: &'a HashMap<String, String>,
+) -> Option<&'a str> {
+    match operand {
+        Operand::Var(name) => env.get(name.as_str()).map(String::as_str),
+        // Immediate literals have well-known types.
+        // We return static strings here; the caller converts to owned if needed.
+        Operand::Int(_) => Some("i64"),
+        Operand::Float(_) => Some("f64"),
+        Operand::Bool(_) => Some("bool"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Run the inference pass over every function in `module`, mutating
+/// `type_hint` on instructions that were previously `"any"`.
+///
+/// Returns a `HashMap<dest_var, inferred_type>` of **all** type hints
+/// that were added (across all functions in the module).  Variable names
+/// from different functions may collide; the map reflects the last write.
+/// Callers that need per-function granularity should call
+/// `infer_types_mut` themselves on individual functions.
+///
+/// # Example
+///
+/// ```
+/// use interpreter_ir::module::IIRModule;
+/// use interpreter_ir::function::IIRFunction;
+/// use interpreter_ir::instr::{IIRInstr, Operand};
+/// use iir_type_checker::infer::infer_types_mut;
+///
+/// let fn_ = IIRFunction::new(
+///     "main", vec![], "void",
+///     vec![
+///         IIRInstr::new("const", Some("x".into()), vec![Operand::Int(42)], "any"),
+///         IIRInstr::new("ret_void", None, vec![], "void"),
+///     ],
+/// );
+/// let mut module = IIRModule::new("test", "tetrad");
+/// module.functions.push(fn_);
+///
+/// let inferred = infer_types_mut(&mut module);
+/// assert_eq!(inferred.get("x").map(String::as_str), Some("i64"));
+/// // The module itself was mutated:
+/// assert_eq!(module.functions[0].instructions[0].type_hint, "i64");
+/// ```
+pub fn infer_types_mut(module: &mut IIRModule) -> HashMap<String, String> {
+    let mut all_inferred: HashMap<String, String> = HashMap::new();
+    for func in module.functions.iter_mut() {
+        let inferred = infer_function(func);
+        all_inferred.extend(inferred);
+    }
+    all_inferred
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+
+    fn make_module(instrs: Vec<IIRInstr>) -> IIRModule {
+        let fn_ = IIRFunction::new("main", vec![], "void", instrs);
+        let mut m = IIRModule::new("test", "tetrad");
+        m.functions.push(fn_);
+        m
+    }
+
+    // R1–R3: constant literals
+
+    #[test]
+    fn infer_const_int() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(42)], "any"),
+        ]);
+        let inf = infer_types_mut(&mut m);
+        assert_eq!(inf.get("x").map(String::as_str), Some("i64"));
+        assert_eq!(m.functions[0].instructions[0].type_hint, "i64");
+    }
+
+    #[test]
+    fn infer_const_float() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("f".into()), vec![Operand::Float(3.14)], "any"),
+        ]);
+        infer_types_mut(&mut m);
+        assert_eq!(m.functions[0].instructions[0].type_hint, "f64");
+    }
+
+    #[test]
+    fn infer_const_bool() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Bool(false)], "any"),
+        ]);
+        infer_types_mut(&mut m);
+        assert_eq!(m.functions[0].instructions[0].type_hint, "bool");
+    }
+
+    // R4: comparisons
+
+    #[test]
+    fn infer_cmp_eq_produces_bool() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "any"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(2)], "any"),
+            IIRInstr::new("cmp_eq", Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "any"),
+        ]);
+        infer_types_mut(&mut m);
+        assert_eq!(m.functions[0].instructions[2].type_hint, "bool");
+    }
+
+    // R5: arithmetic propagation
+
+    #[test]
+    fn infer_add_from_same_typed_srcs() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(3)], "any"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(4)], "any"),
+            IIRInstr::new("add", Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "any"),
+        ]);
+        infer_types_mut(&mut m);
+        // a and b both infer as i64, so c should also be i64
+        assert_eq!(m.functions[0].instructions[2].type_hint, "i64");
+    }
+
+    #[test]
+    fn infer_does_not_change_already_typed() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(1)], "u8"),
+        ]);
+        infer_types_mut(&mut m);
+        // Should not override explicitly-set u8
+        assert_eq!(m.functions[0].instructions[0].type_hint, "u8");
+    }
+
+    #[test]
+    fn infer_mismatched_arith_stays_any() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "any"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Float(1.0)], "any"),
+            IIRInstr::new("add", Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "any"),
+        ]);
+        infer_types_mut(&mut m);
+        // a infers i64, b infers f64 — they differ, so c stays "any"
+        assert_eq!(m.functions[0].instructions[2].type_hint, "any");
+    }
+
+    // R7: unary passthrough
+
+    #[test]
+    fn infer_neg_from_src_type() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(5)], "any"),
+            IIRInstr::new("neg", Some("b".into()), vec![Operand::Var("a".into())], "any"),
+        ]);
+        infer_types_mut(&mut m);
+        assert_eq!(m.functions[0].instructions[1].type_hint, "i64");
+    }
+
+    // Multi-pass (SSA chain)
+
+    #[test]
+    fn infer_chain_two_levels_deep() {
+        // a → b → c: only const a is typed directly from literal
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "any"),
+            IIRInstr::new("neg", Some("b".into()), vec![Operand::Var("a".into())], "any"),
+            IIRInstr::new("neg", Some("c".into()), vec![Operand::Var("b".into())], "any"),
+        ]);
+        infer_types_mut(&mut m);
+        assert_eq!(m.functions[0].instructions[0].type_hint, "i64");
+        assert_eq!(m.functions[0].instructions[1].type_hint, "i64");
+        assert_eq!(m.functions[0].instructions[2].type_hint, "i64");
+    }
+}

--- a/code/packages/rust/iir-type-checker/src/lib.rs
+++ b/code/packages/rust/iir-type-checker/src/lib.rs
@@ -1,0 +1,228 @@
+//! # `iir-type-checker` — optional-typing spectrum checker for InterpreterIR
+//!
+//! The LANG pipeline's `type_hint` field on each `IIRInstr` is *optional*.
+//! It can be:
+//!
+//! - `"any"` — the language frontend chose not to annotate this instruction;
+//!   the VM will profile it and the JIT will speculate.
+//! - A concrete type string (e.g. `"u8"`, `"i64"`, `"bool"`, `"f64"`,
+//!   `"ref<MyObj>"`) — the frontend knows the type statically.
+//!
+//! This crate provides:
+//!
+//! 1. **[`tier::TypingTier`]** — the three-way classification:
+//!    `Untyped` / `Partial(f32)` / `FullyTyped`.
+//! 2. **[`check::check_module`]** — validate the type annotations that are
+//!    already present (no mutation).
+//! 3. **[`infer::infer_types_mut`]** — infer `type_hint` for `"any"`
+//!    instructions using SSA-propagation rules.
+//! 4. **[`infer_and_check`]** — convenience: run inference first, then check.
+//!
+//! ## Integration with JIT and AOT
+//!
+//! Both `jit-core` and `aot-core` read `type_hint` via
+//! [`IIRInstr::is_typed`](interpreter_ir::instr::IIRInstr::is_typed) and
+//! [`IIRInstr::effective_type`](interpreter_ir::instr::IIRInstr::effective_type).
+//! Running `infer_and_check` before passing a module to either compiler
+//! automatically enriches these fields, enabling specialised code generation
+//! for instructions that were typed only through inference.
+//!
+//! ```text
+//! IIRModule (partially typed)
+//!     │
+//!     ├─ iir_type_checker::infer_and_check(&mut module)
+//!     │   ├─ infer_types_mut(&mut module)   ← fills in "any" hints
+//!     │   └─ check_module(&module)          ← validates the enriched module
+//!     │
+//!     ├─ jit_core::execute_with_jit(&module, …)   ← sees more typed hints → better CIR
+//!     └─ aot_core::AOTCore::compile(&module)       ← compiles more functions natively
+//! ```
+//!
+//! ## Quick start
+//!
+//! ```
+//! use interpreter_ir::module::IIRModule;
+//! use interpreter_ir::function::IIRFunction;
+//! use interpreter_ir::instr::{IIRInstr, Operand};
+//! use iir_type_checker::{infer_and_check, tier::TypingTier};
+//!
+//! // Build a module with an untyped integer constant.
+//! let fn_ = IIRFunction::new(
+//!     "main", vec![], "void",
+//!     vec![
+//!         IIRInstr::new("const", Some("x".into()), vec![Operand::Int(42)], "any"),
+//!         IIRInstr::new("const", Some("y".into()), vec![Operand::Int(1)],  "any"),
+//!         IIRInstr::new("add",   Some("z".into()),
+//!             vec![Operand::Var("x".into()), Operand::Var("y".into())], "any"),
+//!         IIRInstr::new("ret_void", None, vec![], "void"),
+//!     ],
+//! );
+//! let mut module = IIRModule::new("demo", "tetrad");
+//! module.functions.push(fn_);
+//!
+//! let report = infer_and_check(&mut module);
+//!
+//! // Inference filled in the types.
+//! assert_eq!(report.tier, TypingTier::FullyTyped);
+//! assert!(report.ok());
+//! assert_eq!(module.functions[0].instructions[0].type_hint, "i64"); // x
+//! assert_eq!(module.functions[0].instructions[2].type_hint, "i64"); // z = x + y
+//! ```
+
+pub mod check;
+pub mod errors;
+pub mod infer;
+pub mod report;
+pub mod tier;
+
+pub use check::check_module;
+pub use errors::{ErrorKind, TypeCheckError, TypeCheckWarning};
+pub use infer::infer_types_mut;
+pub use report::TypeCheckReport;
+pub use tier::TypingTier;
+
+use interpreter_ir::module::IIRModule;
+
+/// Run type inference followed by type checking.
+///
+/// This is the primary entry point for callers who want the full optional-typing
+/// pipeline:
+///
+/// 1. **Inference** — [`infer_types_mut`] populates `type_hint` for
+///    instructions that are currently `"any"` but whose type can be determined
+///    from constants, comparisons, or SSA-propagated arithmetic.
+///
+/// 2. **Checking** — [`check_module`] validates the enriched module and
+///    returns a [`TypeCheckReport`] with the [`TypingTier`], any errors, and
+///    the set of newly-inferred types.
+///
+/// The `inferred_types` field of the returned report maps destination variable
+/// names to the types that were **newly inferred** (i.e. instructions that
+/// were `"any"` before this call).
+///
+/// # Example
+///
+/// ```
+/// use interpreter_ir::module::IIRModule;
+/// use interpreter_ir::function::IIRFunction;
+/// use interpreter_ir::instr::{IIRInstr, Operand};
+/// use iir_type_checker::{infer_and_check, tier::TypingTier};
+///
+/// let fn_ = IIRFunction::new(
+///     "main", vec![], "void",
+///     vec![
+///         IIRInstr::new("const", Some("n".into()), vec![Operand::Int(7)], "any"),
+///         IIRInstr::new("ret_void", None, vec![], "void"),
+///     ],
+/// );
+/// let mut module = IIRModule::new("demo", "tetrad");
+/// module.functions.push(fn_);
+///
+/// let report = infer_and_check(&mut module);
+/// assert_eq!(report.tier, TypingTier::FullyTyped);
+/// assert!(report.ok());
+/// assert_eq!(report.inferred_types.get("n").map(String::as_str), Some("i64"));
+/// ```
+pub fn infer_and_check(module: &mut IIRModule) -> TypeCheckReport {
+    // Pass 1: infer types and annotate the module in place.
+    let newly_inferred = infer_types_mut(module);
+
+    // Pass 2: validate the now-enriched annotations.
+    let mut report = check_module(module);
+
+    // Attach the inferred-types map so callers know what was deduced.
+    report.inferred_types = newly_inferred;
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+
+    fn make_module(instrs: Vec<IIRInstr>) -> IIRModule {
+        let fn_ = IIRFunction::new("main", vec![], "void", instrs);
+        let mut m = IIRModule::new("test", "tetrad");
+        m.functions.push(fn_);
+        m
+    }
+
+    // ── infer_and_check integration tests ────────────────────────────────
+
+    #[test]
+    fn infer_and_check_empty_module() {
+        let mut m = IIRModule::new("empty", "tetrad");
+        let report = infer_and_check(&mut m);
+        assert!(report.ok());
+        assert_eq!(report.tier, TypingTier::Untyped);
+        assert!(report.inferred_types.is_empty());
+    }
+
+    #[test]
+    fn infer_and_check_populates_inferred_types() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(42)], "any"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = infer_and_check(&mut m);
+        assert!(report.ok());
+        assert!(report.inferred_types.contains_key("x"));
+        assert_eq!(report.inferred_types["x"], "i64");
+    }
+
+    #[test]
+    fn infer_and_check_mutates_module() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Float(1.0)], "any"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        infer_and_check(&mut m);
+        assert_eq!(m.functions[0].instructions[0].type_hint, "f64");
+    }
+
+    #[test]
+    fn infer_and_check_full_pipeline() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(3)], "any"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(4)], "any"),
+            IIRInstr::new("add", Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "any"),
+            IIRInstr::new("cmp_gt", Some("d".into()),
+                vec![Operand::Var("c".into()), Operand::Int(5)], "any"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = infer_and_check(&mut m);
+        assert!(report.ok(), "errors: {:?}", report.errors);
+        assert_eq!(report.tier, TypingTier::FullyTyped);
+        // a, b → i64; c → i64 (arith same); d → bool (cmp)
+        assert_eq!(m.functions[0].instructions[2].type_hint, "i64");
+        assert_eq!(m.functions[0].instructions[3].type_hint, "bool");
+    }
+
+    #[test]
+    fn infer_and_check_detects_invalid_type_after_inference() {
+        // Inject a bogus type that inference would not produce.
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(1)], "notatype"),
+        ]);
+        let report = infer_and_check(&mut m);
+        assert!(!report.ok());
+        assert_eq!(report.errors[0].kind, ErrorKind::InvalidType);
+    }
+
+    #[test]
+    fn infer_and_check_partially_typed_module() {
+        // One typed, one unresolvable-any instruction.
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "u8"),
+            // "load_mem" with a symbolic var src — can't infer
+            IIRInstr::new("load_mem", Some("b".into()),
+                vec![Operand::Var("ptr".into())], "any"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]);
+        let report = infer_and_check(&mut m);
+        assert!(report.ok());
+        assert!(matches!(report.tier, TypingTier::Partial(_)));
+    }
+}

--- a/code/packages/rust/iir-type-checker/src/report.rs
+++ b/code/packages/rust/iir-type-checker/src/report.rs
@@ -1,0 +1,186 @@
+//! `TypeCheckReport` — the result of a type-checking pass over an `IIRModule`.
+//!
+//! A `TypeCheckReport` is the complete answer to the question:
+//! "How typed is this module, and where are the problems?"
+//!
+//! It bundles:
+//!
+//! - The [`TypingTier`] classification (Untyped / Partial / FullyTyped).
+//! - Any [`TypeCheckError`]s (fatal — block optimised code-gen for the instruction).
+//! - Any [`TypeCheckWarning`]s (informational — code-gen proceeds).
+//! - A `HashMap<String, String>` of **inferred type annotations**: variable
+//!   names (destination registers) to the type the checker inferred for them.
+//!   Populated by [`crate::infer::infer_types_mut`] before checking; empty when
+//!   only [`crate::check::check_module`] is used.
+//!
+//! # Quick-start
+//!
+//! ```
+//! use interpreter_ir::module::IIRModule;
+//! use interpreter_ir::function::IIRFunction;
+//! use interpreter_ir::instr::{IIRInstr, Operand};
+//! use iir_type_checker::check::check_module;
+//! use iir_type_checker::tier::TypingTier;
+//!
+//! let fn_ = IIRFunction::new(
+//!     "main", vec![], "void",
+//!     vec![IIRInstr::new("ret_void", None, vec![], "void")],
+//! );
+//! let mut module = IIRModule::new("test", "tetrad");
+//! module.functions.push(fn_);
+//! let report = check_module(&module);
+//!
+//! assert!(report.errors.is_empty());
+//! assert_eq!(report.tier, TypingTier::Untyped); // ret_void has no data dest
+//! ```
+
+use std::collections::HashMap;
+
+use crate::errors::{TypeCheckError, TypeCheckWarning};
+use crate::tier::TypingTier;
+
+/// The complete type-check result for an [`IIRModule`](interpreter_ir::module::IIRModule).
+///
+/// Returned by [`crate::check::check_module`] and [`crate::infer_and_check`].
+#[derive(Debug, Clone)]
+pub struct TypeCheckReport {
+    /// The typing tier of the module: `Untyped`, `Partial(f)`, or `FullyTyped`.
+    pub tier: TypingTier,
+
+    /// The fraction of data-flow instructions (those with a `dest` register)
+    /// that carry a **concrete** `type_hint`.  This is always in `[0.0, 1.0]`
+    /// and agrees with `tier`:
+    ///
+    /// - `0.0` → `Untyped`
+    /// - `1.0` → `FullyTyped`
+    /// - `(0, 1)` → `Partial(typed_fraction)`
+    pub typed_fraction: f32,
+
+    /// Fatal errors that the type checker detected.
+    ///
+    /// Each error prevents optimised code generation for the affected
+    /// instruction.  The instruction will be compiled as a generic call-runtime
+    /// operation.  The compiler should not abort on non-empty errors — instead
+    /// it should degrade gracefully.
+    pub errors: Vec<TypeCheckError>,
+
+    /// Non-fatal warnings detected during type checking.
+    ///
+    /// Informational only.  The compiler should log these when run in
+    /// verbose / developer mode.
+    pub warnings: Vec<TypeCheckWarning>,
+
+    /// Types inferred by the inference pass for destination registers.
+    ///
+    /// Keys are destination variable names (e.g. `"v0"`, `"tmp_1"`);
+    /// values are concrete type strings (e.g. `"i64"`, `"bool"`).
+    ///
+    /// This map is empty when the module was already fully annotated
+    /// before checking, or when only [`crate::check::check_module`] was called
+    /// (no inference pass ran).
+    pub inferred_types: HashMap<String, String>,
+}
+
+impl TypeCheckReport {
+    /// Create an empty report with a given typed fraction.
+    pub(crate) fn new(typed_fraction: f32) -> Self {
+        TypeCheckReport {
+            tier: TypingTier::from_fraction(typed_fraction),
+            typed_fraction,
+            errors: Vec::new(),
+            warnings: Vec::new(),
+            inferred_types: HashMap::new(),
+        }
+    }
+
+    /// Return `true` if there are no fatal errors.
+    ///
+    /// ```
+    /// use interpreter_ir::module::IIRModule;
+    /// use interpreter_ir::function::IIRFunction;
+    /// use interpreter_ir::instr::{IIRInstr, Operand};
+    /// use iir_type_checker::check::check_module;
+    ///
+    /// let fn_ = IIRFunction::new(
+    ///     "main", vec![], "void",
+    ///     vec![IIRInstr::new("ret_void", None, vec![], "void")],
+    /// );
+    /// let mut module = IIRModule::new("t", "tetrad");
+    /// module.functions.push(fn_);
+    /// assert!(check_module(&module).ok());
+    /// ```
+    pub fn ok(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// Return a short summary string suitable for log output.
+    ///
+    /// ```
+    /// use interpreter_ir::module::IIRModule;
+    /// use interpreter_ir::function::IIRFunction;
+    /// use interpreter_ir::instr::{IIRInstr, Operand};
+    /// use iir_type_checker::check::check_module;
+    ///
+    /// let fn_ = IIRFunction::new(
+    ///     "main", vec![], "void",
+    ///     vec![IIRInstr::new("ret_void", None, vec![], "void")],
+    /// );
+    /// let mut module = IIRModule::new("t", "tetrad");
+    /// module.functions.push(fn_);
+    /// let report = check_module(&module);
+    /// let s = report.summary();
+    /// assert!(s.contains("errors=0"));
+    /// ```
+    pub fn summary(&self) -> String {
+        format!(
+            "tier={} typed={:.0}% errors={} warnings={} inferred={}",
+            self.tier,
+            self.typed_fraction * 100.0,
+            self.errors.len(),
+            self.warnings.len(),
+            self.inferred_types.len(),
+        )
+    }
+}
+
+impl std::fmt::Display for TypeCheckReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.summary())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_empty_report() {
+        let r = TypeCheckReport::new(0.0);
+        assert!(r.ok());
+        assert_eq!(r.tier, TypingTier::Untyped);
+        assert!(r.errors.is_empty());
+        assert!(r.warnings.is_empty());
+        assert!(r.inferred_types.is_empty());
+    }
+
+    #[test]
+    fn ok_is_false_when_errors_present() {
+        let mut r = TypeCheckReport::new(1.0);
+        r.errors.push(crate::errors::TypeCheckError {
+            fn_name: "f".into(),
+            instr_idx: 0,
+            kind: crate::errors::ErrorKind::InvalidType,
+            message: "bad".into(),
+        });
+        assert!(!r.ok());
+    }
+
+    #[test]
+    fn summary_contains_key_fields() {
+        let r = TypeCheckReport::new(0.5);
+        let s = r.summary();
+        assert!(s.contains("Partial"));
+        assert!(s.contains("errors=0"));
+        assert!(s.contains("warnings=0"));
+    }
+}

--- a/code/packages/rust/iir-type-checker/src/tier.rs
+++ b/code/packages/rust/iir-type-checker/src/tier.rs
@@ -1,0 +1,217 @@
+//! `TypingTier` — the three-way typing classification for an IIR module.
+//!
+//! # The optional-typing spectrum
+//!
+//! InterpreterIR's `type_hint` field on each `IIRInstr` can be either a
+//! **concrete type** (e.g. `"u8"`, `"bool"`) or the sentinel `"any"`.
+//! This gives a continuous spectrum:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                  Typing spectrum                                │
+//! │                                                                 │
+//! │  Untyped ──────────────────────────────────── FullyTyped       │
+//! │  (all "any")    Partial(0.3)    Partial(0.9)  (all concrete)   │
+//! │                                                                 │
+//! │  Typical:       Typical:        Typical:      Typical:         │
+//! │  MRI Ruby,      TypeScript,     Hack/PHP,     Tetrad, Algol,   │
+//! │  Twig, Lisp     Sorbet-Ruby     Dart, Swift   Oct, C           │
+//! └─────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! The tier drives compilation strategy:
+//!
+//! | Tier | AOT strategy | JIT strategy |
+//! |------|-------------|--------------|
+//! | `Untyped` | Link full `vm-runtime`; speculate from profile | Wait for profiling; speculate aggressively |
+//! | `Partial` | AOT-compile typed functions; interpret untyped | JIT hot paths; defer untyped to interpreter |
+//! | `FullyTyped` | AOT-compile everything; no `vm-runtime` link needed | Skip warmup; specialise immediately |
+
+/// The typing tier of an `IIRModule`.
+///
+/// Calculated by [`crate::check::measure_tier`] after scanning all
+/// `IIRInstr` objects in a module.
+///
+/// # Display
+///
+/// ```
+/// use iir_type_checker::tier::TypingTier;
+///
+/// assert_eq!(TypingTier::Untyped.to_string(), "Untyped");
+/// assert_eq!(TypingTier::Partial(0.5).to_string(), "Partial(50%)");
+/// assert_eq!(TypingTier::FullyTyped.to_string(), "FullyTyped");
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypingTier {
+    /// All instructions carry `type_hint = "any"`.
+    ///
+    /// Profile-guided speculation is the only path to specialised code.
+    /// At least one observation cycle is required before AOT/JIT can
+    /// emit typed CIR for any instruction.
+    Untyped,
+
+    /// Some instructions carry concrete type hints.
+    ///
+    /// The `f32` payload is the fraction of **data-flow** instructions
+    /// (i.e. instructions with a destination register) that carry a
+    /// concrete `type_hint`.  Control-flow instructions (`jmp`,
+    /// `jmp_if_*`, `label`, `ret_void`) are excluded from the count
+    /// because they never produce a typed value.
+    ///
+    /// - `0.0 < fraction < 1.0` always (boundary cases use `Untyped`
+    ///   and `FullyTyped`).
+    /// - Rounded to two decimal places for stable equality in tests.
+    Partial(f32),
+
+    /// Every data-flow instruction carries a concrete `type_hint`.
+    ///
+    /// No profiling is needed; AOT can compile the whole module without
+    /// linking `vm-runtime`.
+    FullyTyped,
+}
+
+impl TypingTier {
+    /// Classify a pre-computed `typed_fraction`.
+    ///
+    /// ```
+    /// use iir_type_checker::tier::TypingTier;
+    ///
+    /// assert_eq!(TypingTier::from_fraction(0.0), TypingTier::Untyped);
+    /// assert_eq!(TypingTier::from_fraction(1.0), TypingTier::FullyTyped);
+    /// let t = TypingTier::from_fraction(0.6);
+    /// assert!(matches!(t, TypingTier::Partial(_)));
+    /// ```
+    pub fn from_fraction(fraction: f32) -> Self {
+        if fraction <= 0.0 {
+            TypingTier::Untyped
+        } else if fraction >= 1.0 {
+            TypingTier::FullyTyped
+        } else {
+            // Round to two decimal places so tests comparing fractions
+            // are stable across floating-point arithmetic.
+            let rounded = (fraction * 100.0).round() / 100.0;
+            TypingTier::Partial(rounded)
+        }
+    }
+
+    /// Return `true` when AOT can compile every function without
+    /// relying on the runtime interpreter as a fallback.
+    ///
+    /// ```
+    /// use iir_type_checker::tier::TypingTier;
+    ///
+    /// assert!(TypingTier::FullyTyped.is_fully_typed());
+    /// assert!(!TypingTier::Untyped.is_fully_typed());
+    /// assert!(!TypingTier::Partial(0.9).is_fully_typed());
+    /// ```
+    pub fn is_fully_typed(&self) -> bool {
+        matches!(self, TypingTier::FullyTyped)
+    }
+
+    /// Return `true` when no static type information is available at all.
+    ///
+    /// ```
+    /// use iir_type_checker::tier::TypingTier;
+    ///
+    /// assert!(TypingTier::Untyped.is_untyped());
+    /// assert!(!TypingTier::Partial(0.1).is_untyped());
+    /// assert!(!TypingTier::FullyTyped.is_untyped());
+    /// ```
+    pub fn is_untyped(&self) -> bool {
+        matches!(self, TypingTier::Untyped)
+    }
+
+    /// Return the typed fraction in `[0.0, 1.0]`.
+    ///
+    /// ```
+    /// use iir_type_checker::tier::TypingTier;
+    ///
+    /// assert_eq!(TypingTier::Untyped.typed_fraction(), 0.0);
+    /// assert_eq!(TypingTier::FullyTyped.typed_fraction(), 1.0);
+    /// assert!((TypingTier::Partial(0.4).typed_fraction() - 0.4).abs() < 1e-4);
+    /// ```
+    pub fn typed_fraction(&self) -> f32 {
+        match self {
+            TypingTier::Untyped => 0.0,
+            TypingTier::FullyTyped => 1.0,
+            TypingTier::Partial(f) => *f,
+        }
+    }
+}
+
+impl std::fmt::Display for TypingTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypingTier::Untyped => write!(f, "Untyped"),
+            TypingTier::FullyTyped => write!(f, "FullyTyped"),
+            TypingTier::Partial(frac) => write!(f, "Partial({:.0}%)", frac * 100.0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_fraction_zero_is_untyped() {
+        assert_eq!(TypingTier::from_fraction(0.0), TypingTier::Untyped);
+    }
+
+    #[test]
+    fn from_fraction_one_is_fully_typed() {
+        assert_eq!(TypingTier::from_fraction(1.0), TypingTier::FullyTyped);
+    }
+
+    #[test]
+    fn from_fraction_negative_clamps_to_untyped() {
+        assert_eq!(TypingTier::from_fraction(-0.5), TypingTier::Untyped);
+    }
+
+    #[test]
+    fn from_fraction_over_one_clamps_to_fully_typed() {
+        assert_eq!(TypingTier::from_fraction(1.5), TypingTier::FullyTyped);
+    }
+
+    #[test]
+    fn partial_rounds_to_two_decimals() {
+        let t = TypingTier::from_fraction(0.666_666);
+        assert_eq!(t, TypingTier::Partial(0.67));
+    }
+
+    #[test]
+    fn display_untyped() {
+        assert_eq!(TypingTier::Untyped.to_string(), "Untyped");
+    }
+
+    #[test]
+    fn display_fully_typed() {
+        assert_eq!(TypingTier::FullyTyped.to_string(), "FullyTyped");
+    }
+
+    #[test]
+    fn display_partial() {
+        assert_eq!(TypingTier::Partial(0.5).to_string(), "Partial(50%)");
+    }
+
+    #[test]
+    fn typed_fraction_boundaries() {
+        assert_eq!(TypingTier::Untyped.typed_fraction(), 0.0);
+        assert_eq!(TypingTier::FullyTyped.typed_fraction(), 1.0);
+        assert!((TypingTier::Partial(0.3).typed_fraction() - 0.3).abs() < 1e-4);
+    }
+
+    #[test]
+    fn is_fully_typed_only_for_fullytyped() {
+        assert!(TypingTier::FullyTyped.is_fully_typed());
+        assert!(!TypingTier::Untyped.is_fully_typed());
+        assert!(!TypingTier::Partial(0.99).is_fully_typed());
+    }
+
+    #[test]
+    fn is_untyped_only_for_untyped() {
+        assert!(TypingTier::Untyped.is_untyped());
+        assert!(!TypingTier::FullyTyped.is_untyped());
+        assert!(!TypingTier::Partial(0.01).is_untyped());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `iir-type-checker` — the cross-cutting optional-typing system for the LANG VM chain
- Classifies modules as `Untyped` / `Partial(f%)` / `FullyTyped` via `TypingTier`
- Infers `type_hint` for `"any"` instructions using SSA-propagation (R1–R8 rules, multi-pass)
- Validates type consistency (InvalidType, TypeMismatch, ConditionNotBool errors)
- `infer_and_check(&mut module)` is the primary entry point; enriches IIR before JIT/AOT see it

## Typing spectrum covered

| Tier | AOT | JIT |
|------|-----|-----|
| `Untyped` | Link vm-runtime; speculate from profile | Wait for profiling |
| `Partial(f%)` | Compile typed fns; interpret untyped | JIT hot paths |
| `FullyTyped` | Compile everything natively | Specialise immediately |

## Test plan

- [ ] `cargo test -p iir-type-checker` → 43 unit tests + 14 doc-tests pass
- [ ] `cargo build -p iir-type-checker` → clean (no warnings)
- [ ] Verify tier classification for Untyped / Partial / FullyTyped modules
- [ ] Verify inference fills const-int → `"i64"`, const-bool → `"bool"`, cmp_* → `"bool"`
- [ ] Verify multi-pass SSA chain resolution (a → b → c all typed from one const)
- [ ] Verify branch condition check fires even for `"any"` branch instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)