### PR TITLE
feat(matrix-ir): implement MX01 tensor algebra IR

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -280,6 +280,7 @@ members = [
     "cuda-compute",
     "gpu-runtime",
     "image-gpu-core",
+    "matrix-ir",
     "metal-compute",
     "paint-metal",
     "paint-vm-direct2d-c",

--- a/code/packages/rust/matrix-ir/BUILD
+++ b/code/packages/rust/matrix-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p matrix-ir -- --nocapture

--- a/code/packages/rust/matrix-ir/BUILD_windows
+++ b/code/packages/rust/matrix-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p matrix-ir -- --nocapture

--- a/code/packages/rust/matrix-ir/CHANGELOG.md
+++ b/code/packages/rust/matrix-ir/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to `matrix-ir` are documented here.  The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-05-04
+
+Initial release.  Implements spec MX01 V1.
+
+### Added
+
+- `TensorId`, `OpId`, `DType`, `Shape`, `Tensor` — the value-plane primitives.
+- `Op` — 27-variant enum covering:
+  - Elementwise unary: Neg, Abs, Sqrt, Exp, Log, Tanh, Recip
+  - Elementwise binary: Add, Sub, Mul, Div, Max, Min, Pow
+  - Reductions: ReduceSum, ReduceMax, ReduceMean
+  - Shape: Reshape, Transpose, Broadcast
+  - Linear algebra: MatMul (rank-2)
+  - Comparison: Equal, Less, Greater
+  - Selection: Where
+  - Conversion: Cast
+  - Constants: Const
+- `Graph` — the aggregate computation, with structural and semantic
+  validation via `Graph::validate()`.
+- `Constant` — literal-data tensors stored in `Graph.constants`.
+- `GraphBuilder` — ergonomic builder that allocates ids, infers shapes,
+  and validates eagerly (panics with clear messages on misuse).
+- Hand-rolled binary wire format per spec MX03 §"Wire format primitives":
+  varint, length-prefixed bytes, tagged unions.  `Graph::to_bytes()` /
+  `Graph::from_bytes()` round-trip without loss; encoding is
+  deterministic.
+- `IrError` — comprehensive error type covering structural,
+  semantic, and wire-format failures.
+
+### Constraints
+
+- Zero external dependencies (only `core`, `alloc`, `std`).  CI gates
+  this; the dependency section in `Cargo.toml` is intentionally empty.
+- No execution.  This crate is pure data; computation happens elsewhere
+  in the matrix execution layer.
+
+### Test coverage
+
+- 9 builder-and-validate integration tests over representative graphs
+  (single op groups, multi-op chains, full ReLU layer).
+- 11 validator-rejection integration tests covering `UndefinedTensor`,
+  `ShapeMismatch`, `DTypeMismatch`, `InvalidPermutation`,
+  `NumelMismatch`, `InvalidBroadcast`, `NonU8Predicate`,
+  `UndefinedOutput`, `ConstantByteLength`, `TensorIdMismatch`,
+  `InvalidAxis`.
+- 7 wire round-trip integration tests with determinism check.
+- 1 coverage-gate test asserting every `Op` variant is exercised; the
+  test fails to compile or fails its assertion if a future variant is
+  added without inclusion.
+- Per-module unit tests for tensor primitives, op metadata, builder
+  helpers, validator rules, and wire codec primitives (varint
+  round-trip, oversized varint rejection, truncation handling, version
+  rejection).

--- a/code/packages/rust/matrix-ir/Cargo.toml
+++ b/code/packages/rust/matrix-ir/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "matrix-ir"
+version = "0.1.0"
+edition = "2021"
+description = "MX01 — pure tensor algebra IR. The upper IR that domain libraries (image processing, neural networks, signal processing) emit when they want computation done. Static-shape, SSA over tensors, zero external dependencies."
+license = "MIT"
+
+[dependencies]
+# No dependencies.  This crate is core/alloc/std only.
+# See specs/MX00 for the zero-dependency mandate.

--- a/code/packages/rust/matrix-ir/README.md
+++ b/code/packages/rust/matrix-ir/README.md
@@ -1,0 +1,137 @@
+# matrix-ir
+
+Pure tensor algebra IR — the upper IR of the matrix execution layer.
+
+This is the implementation of spec **MX01**.  See:
+
+- [`code/specs/MX00-matrix-execution-overview.md`](../../specs/MX00-matrix-execution-overview.md) — architecture
+- [`code/specs/MX01-matrix-ir.md`](../../specs/MX01-matrix-ir.md) — the IR contract
+
+## What it is
+
+`matrix-ir` is a pure data-plane crate that defines:
+
+- `TensorId`, `OpId`, `DType`, `Shape`, `Tensor` — the value plane
+- `Op` — a 27-variant enum covering elementwise math, reductions, shape
+  ops, matmul, comparison, selection, conversion, and constants
+- `Graph`, `Constant` — the aggregate computation
+- `GraphBuilder` — an ergonomic builder that allocates ids, infers
+  shapes, and validates eagerly
+- `Graph::validate()` — structural and semantic checks
+- `Graph::to_bytes()` / `Graph::from_bytes()` — versioned binary wire
+  format that round-trips without loss
+
+There is **no execution** in this crate.  Execution lives in
+`compute-runtime` and the executor crates (CPU, Metal, CUDA, …).
+`matrix-ir` is pure data — easy to reason about, easy to test, easy
+to serialise to a remote executor.
+
+## Where it sits
+
+```
+  domain libraries:   image-ops    nn-layers    fft    blas
+                          \  |       |     |    |
+                           v  v      v     v    v
+                       ───   matrix-ir   ───              ← this crate
+                                  |
+                              planner
+                                  |
+                                  v
+                       ───   compute-ir   ───
+                                  |
+                          executor-protocol
+                                  |
+                                  v
+                          cpu / metal / cuda / wgpu / asic
+```
+
+Domain libraries (image processing, neural-network layers, signal
+processing, BLAS) construct `matrix-ir` graphs to describe what they
+want computed.  The runtime lowers them to a placed `compute-ir` and
+ships them to executors.
+
+## A worked example
+
+```rust
+use matrix_ir::{DType, GraphBuilder, Shape};
+
+let mut g = GraphBuilder::new();
+let x = g.input(DType::F32, Shape::from(&[1, 4]));
+let w = g.input(DType::F32, Shape::from(&[4, 2]));
+let b = g.input(DType::F32, Shape::from(&[1, 2]));
+let zero = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+
+let xw    = g.matmul(&x, &w);
+let xwb   = g.add(&xw, &b);
+let y     = g.max(&xwb, &zero);    // ReLU = max(x, 0)
+g.output(&y);
+
+let graph = g.build().unwrap();
+graph.validate().unwrap();
+
+// Serialise for transport over a wire (or for caching)
+let bytes = graph.to_bytes();
+let same  = matrix_ir::Graph::from_bytes(&bytes).unwrap();
+assert_eq!(graph, same);
+```
+
+## V1 op set (27 ops)
+
+| Group | Ops |
+|------|------|
+| Elementwise unary | Neg, Abs, Sqrt, Exp, Log, Tanh, Recip |
+| Elementwise binary | Add, Sub, Mul, Div, Max, Min, Pow |
+| Reductions | ReduceSum, ReduceMax, ReduceMean |
+| Shape | Reshape, Transpose, Broadcast |
+| Linear algebra | MatMul (rank-2 only in V1) |
+| Comparison | Equal, Less, Greater (output dtype is U8) |
+| Selection | Where |
+| Conversion | Cast |
+| Constants | Const |
+
+V1 dtypes: `F32`, `U8`, `I32`.  `F16` and `I64` are reserved in the
+wire format for V2.
+
+## Design principles
+
+1. **Tensor algebra only.**  No "image", "channel", "batch", "feature".
+   Domain labels live above this layer.  An RGBA image is a `[H, W, 4]`
+   u8 tensor; whether dim 2 means "channels" is the image library's
+   business.
+2. **Static shapes.**  V1 only.  V2 introduces symbolic shapes.
+3. **SSA over tensors.**  Each tensor produced by an op gets a fresh
+   `TensorId`; tensors are immutable.  This makes downstream residency
+   tracking and dead-code elimination tractable.
+4. **Closed under serialisation.**  Every value has a defined wire
+   form.  Local and remote executors see the same bytes.
+5. **Zero external dependencies.**  Only `core`, `alloc`, `std`.
+
+## Testing
+
+```
+cargo test -p matrix-ir
+```
+
+Test methodology (per spec MX01 §"Test methodology"):
+
+1. Builder + validate over representative graphs (one per op group plus
+   combinations).
+2. Validator rejection over deliberately malformed graphs, asserting
+   the right `IrError` variant fires.
+3. Wire round-trip — every test graph is serialised, deserialised, and
+   asserted equal to the original; encoding is asserted deterministic.
+4. Coverage gate — meta-test asserts every `Op` variant is exercised.
+
+## Out of scope (V1)
+
+Reserved for later versions:
+
+- Dynamic shapes
+- f16 / bf16 / i64 / complex64
+- Conv2d / Pool / Softmax / LayerNorm as primitives (composed from V1
+  ops in the meantime)
+- Custom-kernel escape hatch
+- Autograd
+- Implicit broadcasting on binary ops
+
+See spec MX01 §"Out of scope" for the migration plan for each.

--- a/code/packages/rust/matrix-ir/required_capabilities.json
+++ b/code/packages/rust/matrix-ir/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/matrix-ir",
+  "capabilities": [],
+  "justification": "Pure data structures (tensor IR, graph builder, validator, serializer). No filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/matrix-ir/src/builder.rs
+++ b/code/packages/rust/matrix-ir/src/builder.rs
@@ -1,0 +1,709 @@
+//! Ergonomic graph construction.
+//!
+//! `GraphBuilder` allocates [`TensorId`]s densely, infers output shapes
+//! from inputs, performs eager shape-and-dtype checks (panicking with a
+//! clear message on misuse), and produces a [`Graph`] when [`build`] is
+//! called.
+//!
+//! The eager-panic behaviour is intentional: in this builder a
+//! mismatched shape is a programmer error, not a runtime input — the
+//! sooner it's surfaced the better.  Production code that wants
+//! per-call results can use the lower-level constructors directly.
+//!
+//! [`build`]: GraphBuilder::build
+//! [`TensorId`]: crate::TensorId
+
+use crate::graph::{Constant, Graph};
+use crate::op::Op;
+use crate::tensor::{DType, Shape, Tensor, TensorId};
+use crate::validate::IrError;
+
+/// Ergonomic builder for [`Graph`].  See module-level docs.
+pub struct GraphBuilder {
+    inputs: Vec<Tensor>,
+    outputs: Vec<TensorId>,
+    ops: Vec<Op>,
+    tensors: Vec<Tensor>,
+    constants: Vec<Constant>,
+}
+
+impl Default for GraphBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GraphBuilder {
+    /// Construct an empty builder.
+    pub fn new() -> Self {
+        GraphBuilder {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            ops: Vec::new(),
+            tensors: Vec::new(),
+            constants: Vec::new(),
+        }
+    }
+
+    /// Allocate the next [`TensorId`] and register the tensor.
+    fn alloc(&mut self, dtype: DType, shape: Shape) -> Tensor {
+        let id = TensorId(self.tensors.len() as u32);
+        let t = Tensor::new(id, dtype, shape);
+        self.tensors.push(t.clone());
+        t
+    }
+
+    /// Declare a new graph input.  The returned [`Tensor`] has a fresh
+    /// id; the input is also recorded in [`Graph::inputs`] in the order
+    /// declared.
+    pub fn input(&mut self, dtype: DType, shape: Shape) -> Tensor {
+        let t = self.alloc(dtype, shape);
+        self.inputs.push(t.clone());
+        t
+    }
+
+    /// Declare a constant.  `bytes` must be `shape.numel() *
+    /// dtype.size_bytes()` long, dtype-encoded little-endian.  Panics
+    /// on mismatch.
+    pub fn constant(&mut self, dtype: DType, shape: Shape, bytes: Vec<u8>) -> Tensor {
+        let expected = shape
+            .byte_size(dtype)
+            .expect("constant byte_size overflows u64") as usize;
+        assert_eq!(
+            bytes.len(),
+            expected,
+            "constant bytes length {} != expected {} ({} elems × {} bytes)",
+            bytes.len(),
+            expected,
+            shape.numel().unwrap_or(0),
+            dtype.size_bytes()
+        );
+        let t = self.alloc(dtype, shape);
+        let c_idx = self.constants.len() as u32;
+        self.constants.push(Constant {
+            tensor: t.clone(),
+            bytes,
+        });
+        let out = self.alloc(t.dtype, t.shape.clone());
+        self.ops.push(Op::Const {
+            constant: c_idx,
+            output: out.id,
+        });
+        out
+    }
+
+    /// Mark a tensor as a graph output.  The same tensor may be marked
+    /// multiple times, though the validator does not require it.
+    pub fn output(&mut self, t: &Tensor) {
+        self.outputs.push(t.id);
+    }
+
+    // ──────────── elementwise unary helpers ────────────
+
+    fn unary(&mut self, input: &Tensor, op_ctor: fn(TensorId, TensorId) -> Op) -> Tensor {
+        let out = self.alloc(input.dtype, input.shape.clone());
+        self.ops.push(op_ctor(input.id, out.id));
+        out
+    }
+
+    /// `-x`.
+    pub fn neg(&mut self, t: &Tensor) -> Tensor {
+        self.unary(t, |i, o| Op::Neg {
+            input: i,
+            output: o,
+        })
+    }
+    /// `|x|`.
+    pub fn abs(&mut self, t: &Tensor) -> Tensor {
+        self.unary(t, |i, o| Op::Abs {
+            input: i,
+            output: o,
+        })
+    }
+    /// `sqrt(x)`.  Float-only.
+    pub fn sqrt(&mut self, t: &Tensor) -> Tensor {
+        assert_float(t.dtype, "sqrt");
+        self.unary(t, |i, o| Op::Sqrt {
+            input: i,
+            output: o,
+        })
+    }
+    /// `e^x`.  Float-only.
+    pub fn exp(&mut self, t: &Tensor) -> Tensor {
+        assert_float(t.dtype, "exp");
+        self.unary(t, |i, o| Op::Exp {
+            input: i,
+            output: o,
+        })
+    }
+    /// `ln(x)`.  Float-only.
+    pub fn log(&mut self, t: &Tensor) -> Tensor {
+        assert_float(t.dtype, "log");
+        self.unary(t, |i, o| Op::Log {
+            input: i,
+            output: o,
+        })
+    }
+    /// `tanh(x)`.  Float-only.
+    pub fn tanh(&mut self, t: &Tensor) -> Tensor {
+        assert_float(t.dtype, "tanh");
+        self.unary(t, |i, o| Op::Tanh {
+            input: i,
+            output: o,
+        })
+    }
+    /// `1/x`.  Float-only.
+    pub fn recip(&mut self, t: &Tensor) -> Tensor {
+        assert_float(t.dtype, "recip");
+        self.unary(t, |i, o| Op::Recip {
+            input: i,
+            output: o,
+        })
+    }
+
+    // ──────────── elementwise binary helpers ────────────
+
+    fn binary(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        op_ctor: fn(TensorId, TensorId, TensorId) -> Op,
+        op_name: &'static str,
+    ) -> Tensor {
+        assert_eq!(
+            lhs.dtype, rhs.dtype,
+            "{}: dtype mismatch ({} vs {})",
+            op_name, lhs.dtype, rhs.dtype
+        );
+        assert_eq!(
+            lhs.shape, rhs.shape,
+            "{}: shape mismatch ({} vs {})",
+            op_name, lhs.shape, rhs.shape
+        );
+        let out = self.alloc(lhs.dtype, lhs.shape.clone());
+        self.ops.push(op_ctor(lhs.id, rhs.id, out.id));
+        out
+    }
+
+    /// Elementwise `lhs + rhs`.
+    pub fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        self.binary(lhs, rhs, |l, r, o| Op::Add { lhs: l, rhs: r, output: o }, "add")
+    }
+    /// Elementwise `lhs - rhs`.
+    pub fn sub(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        self.binary(lhs, rhs, |l, r, o| Op::Sub { lhs: l, rhs: r, output: o }, "sub")
+    }
+    /// Elementwise `lhs * rhs`.
+    pub fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        self.binary(lhs, rhs, |l, r, o| Op::Mul { lhs: l, rhs: r, output: o }, "mul")
+    }
+    /// Elementwise `lhs / rhs`.  Float-only.
+    pub fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        assert_float(lhs.dtype, "div");
+        self.binary(lhs, rhs, |l, r, o| Op::Div { lhs: l, rhs: r, output: o }, "div")
+    }
+    /// Elementwise `max(lhs, rhs)`.
+    pub fn max(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        self.binary(lhs, rhs, |l, r, o| Op::Max { lhs: l, rhs: r, output: o }, "max")
+    }
+    /// Elementwise `min(lhs, rhs)`.
+    pub fn min(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        self.binary(lhs, rhs, |l, r, o| Op::Min { lhs: l, rhs: r, output: o }, "min")
+    }
+    /// Elementwise `lhs ^ rhs`.  Float-only.
+    pub fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        assert_float(lhs.dtype, "pow");
+        self.binary(lhs, rhs, |l, r, o| Op::Pow { lhs: l, rhs: r, output: o }, "pow")
+    }
+
+    // ──────────── reductions ────────────
+
+    fn reduce(
+        &mut self,
+        input: &Tensor,
+        axes: Vec<u32>,
+        keep_dims: bool,
+        ctor: fn(TensorId, Vec<u32>, bool, TensorId) -> Op,
+        op_name: &'static str,
+    ) -> Tensor {
+        let rank = input.shape.rank() as u32;
+        for &a in &axes {
+            assert!(a < rank, "{}: axis {} out of range (rank {})", op_name, a, rank);
+        }
+        let out_shape = reduce_shape(&input.shape, &axes, keep_dims);
+        let out = self.alloc(input.dtype, out_shape);
+        self.ops.push(ctor(input.id, axes, keep_dims, out.id));
+        out
+    }
+
+    /// Sum reduction over `axes`.  Empty axes = reduce all.
+    pub fn reduce_sum(&mut self, input: &Tensor, axes: Vec<u32>, keep_dims: bool) -> Tensor {
+        self.reduce(
+            input,
+            axes,
+            keep_dims,
+            |i, ax, kd, o| Op::ReduceSum {
+                input: i,
+                axes: ax,
+                keep_dims: kd,
+                output: o,
+            },
+            "reduce_sum",
+        )
+    }
+    /// Max reduction over `axes`.
+    pub fn reduce_max(&mut self, input: &Tensor, axes: Vec<u32>, keep_dims: bool) -> Tensor {
+        self.reduce(
+            input,
+            axes,
+            keep_dims,
+            |i, ax, kd, o| Op::ReduceMax {
+                input: i,
+                axes: ax,
+                keep_dims: kd,
+                output: o,
+            },
+            "reduce_max",
+        )
+    }
+    /// Mean reduction over `axes`.
+    pub fn reduce_mean(&mut self, input: &Tensor, axes: Vec<u32>, keep_dims: bool) -> Tensor {
+        self.reduce(
+            input,
+            axes,
+            keep_dims,
+            |i, ax, kd, o| Op::ReduceMean {
+                input: i,
+                axes: ax,
+                keep_dims: kd,
+                output: o,
+            },
+            "reduce_mean",
+        )
+    }
+
+    // ──────────── shape ────────────
+
+    /// Reshape to `new_shape`.  Total element count must match.
+    pub fn reshape(&mut self, input: &Tensor, new_shape: Shape) -> Tensor {
+        assert_eq!(
+            input.shape.numel(),
+            new_shape.numel(),
+            "reshape: numel mismatch (input {} new {})",
+            input.shape,
+            new_shape
+        );
+        let out = self.alloc(input.dtype, new_shape.clone());
+        self.ops.push(Op::Reshape {
+            input: input.id,
+            new_shape,
+            output: out.id,
+        });
+        out
+    }
+
+    /// Transpose by permutation.  `perm` must be a permutation of `0..rank`.
+    pub fn transpose(&mut self, input: &Tensor, perm: Vec<u32>) -> Tensor {
+        assert_eq!(
+            perm.len(),
+            input.shape.rank(),
+            "transpose: perm length {} != rank {}",
+            perm.len(),
+            input.shape.rank()
+        );
+        let mut seen = vec![false; perm.len()];
+        for &p in &perm {
+            let p = p as usize;
+            assert!(p < seen.len(), "transpose: perm value {} out of range", p);
+            assert!(!seen[p], "transpose: perm contains duplicate {}", p);
+            seen[p] = true;
+        }
+        let new_dims: Vec<u32> = perm
+            .iter()
+            .map(|&p| input.shape.dims[p as usize])
+            .collect();
+        let out = self.alloc(input.dtype, Shape { dims: new_dims });
+        self.ops.push(Op::Transpose {
+            input: input.id,
+            perm,
+            output: out.id,
+        });
+        out
+    }
+
+    /// Broadcast to `target_shape`.  Each dim of input must equal the
+    /// corresponding target dim or be 1.
+    pub fn broadcast(&mut self, input: &Tensor, target_shape: Shape) -> Tensor {
+        assert_eq!(
+            input.shape.rank(),
+            target_shape.rank(),
+            "broadcast: rank mismatch ({} vs {})",
+            input.shape,
+            target_shape
+        );
+        for (i, (&inp, &tgt)) in input
+            .shape
+            .dims
+            .iter()
+            .zip(target_shape.dims.iter())
+            .enumerate()
+        {
+            assert!(
+                inp == tgt || inp == 1,
+                "broadcast: dim {} of input ({}) is not 1 and does not match target ({})",
+                i,
+                inp,
+                tgt
+            );
+        }
+        let out = self.alloc(input.dtype, target_shape.clone());
+        self.ops.push(Op::Broadcast {
+            input: input.id,
+            target_shape,
+            output: out.id,
+        });
+        out
+    }
+
+    // ──────────── linear algebra ────────────
+
+    /// 2D matrix multiply.  `a: [m,k]` × `b: [k,n]` → `[m,n]`.
+    pub fn matmul(&mut self, a: &Tensor, b: &Tensor) -> Tensor {
+        assert_eq!(a.dtype, b.dtype, "matmul: dtype mismatch");
+        assert_eq!(a.shape.rank(), 2, "matmul: lhs rank must be 2");
+        assert_eq!(b.shape.rank(), 2, "matmul: rhs rank must be 2");
+        let (m, k1) = (a.shape.dims[0], a.shape.dims[1]);
+        let (k2, n) = (b.shape.dims[0], b.shape.dims[1]);
+        assert_eq!(
+            k1, k2,
+            "matmul: inner dims mismatch ({} vs {})",
+            k1, k2
+        );
+        let out = self.alloc(a.dtype, Shape::from(&[m, n]));
+        self.ops.push(Op::MatMul {
+            a: a.id,
+            b: b.id,
+            output: out.id,
+        });
+        out
+    }
+
+    // ──────────── comparison ────────────
+
+    fn compare(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        ctor: fn(TensorId, TensorId, TensorId) -> Op,
+        op_name: &'static str,
+    ) -> Tensor {
+        assert_eq!(
+            lhs.dtype, rhs.dtype,
+            "{}: dtype mismatch",
+            op_name
+        );
+        assert_eq!(
+            lhs.shape, rhs.shape,
+            "{}: shape mismatch",
+            op_name
+        );
+        let out = self.alloc(DType::U8, lhs.shape.clone());
+        self.ops.push(ctor(lhs.id, rhs.id, out.id));
+        out
+    }
+
+    /// Elementwise `lhs == rhs`.  Output is U8 (0 or 1).
+    pub fn equal(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        self.compare(
+            lhs,
+            rhs,
+            |l, r, o| Op::Equal { lhs: l, rhs: r, output: o },
+            "equal",
+        )
+    }
+    /// Elementwise `lhs < rhs`.
+    pub fn less(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        self.compare(
+            lhs,
+            rhs,
+            |l, r, o| Op::Less { lhs: l, rhs: r, output: o },
+            "less",
+        )
+    }
+    /// Elementwise `lhs > rhs`.
+    pub fn greater(&mut self, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+        self.compare(
+            lhs,
+            rhs,
+            |l, r, o| Op::Greater { lhs: l, rhs: r, output: o },
+            "greater",
+        )
+    }
+
+    // ──────────── selection ────────────
+
+    /// Per-element `predicate ? true_value : false_value`.
+    pub fn where_(&mut self, predicate: &Tensor, t: &Tensor, f: &Tensor) -> Tensor {
+        assert_eq!(predicate.dtype, DType::U8, "where: predicate must be u8");
+        assert_eq!(predicate.shape, t.shape, "where: predicate/true_value shape mismatch");
+        assert_eq!(t.shape, f.shape, "where: true_value/false_value shape mismatch");
+        assert_eq!(t.dtype, f.dtype, "where: true_value/false_value dtype mismatch");
+        let out = self.alloc(t.dtype, t.shape.clone());
+        self.ops.push(Op::Where {
+            predicate: predicate.id,
+            true_value: t.id,
+            false_value: f.id,
+            output: out.id,
+        });
+        out
+    }
+
+    // ──────────── conversion ────────────
+
+    /// Numerical conversion to `dtype`.
+    pub fn cast(&mut self, input: &Tensor, dtype: DType) -> Tensor {
+        let out = self.alloc(dtype, input.shape.clone());
+        self.ops.push(Op::Cast {
+            input: input.id,
+            dtype,
+            output: out.id,
+        });
+        out
+    }
+
+    /// Finalise the builder, returning a [`Graph`].  Runs structural
+    /// validation; semantic validation (per-op shape/dtype checks)
+    /// happens lazily in [`Graph::validate`](crate::Graph::validate).
+    pub fn build(self) -> Result<Graph, IrError> {
+        let g = Graph {
+            inputs: self.inputs,
+            outputs: self.outputs,
+            ops: self.ops,
+            tensors: self.tensors,
+            constants: self.constants,
+        };
+        // Always do a structural-and-semantic validate so that build()
+        // returning Ok is a strong guarantee.
+        g.validate()?;
+        Ok(g)
+    }
+}
+
+fn assert_float(dt: DType, op_name: &'static str) {
+    assert!(
+        matches!(dt, DType::F32),
+        "{}: dtype must be a float (got {})",
+        op_name,
+        dt
+    );
+}
+
+/// Compute the output shape of a reduction.
+///
+/// - If `keep_dims` is true: reduced axes become size 1.
+/// - If `keep_dims` is false: reduced axes are removed.
+/// - Empty `axes` means reduce-all (scalar output unless `keep_dims`,
+///   in which case all dims become 1).
+pub(crate) fn reduce_shape(input: &Shape, axes: &[u32], keep_dims: bool) -> Shape {
+    if axes.is_empty() {
+        // Reduce all.
+        if keep_dims {
+            Shape {
+                dims: vec![1; input.rank()],
+            }
+        } else {
+            Shape::scalar()
+        }
+    } else {
+        let mut out = Vec::with_capacity(input.rank());
+        for (i, &d) in input.dims.iter().enumerate() {
+            let i = i as u32;
+            if axes.contains(&i) {
+                if keep_dims {
+                    out.push(1);
+                }
+            } else {
+                out.push(d);
+            }
+        }
+        Shape { dims: out }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_relu_layer() {
+        let mut g = GraphBuilder::new();
+        let x = g.input(DType::F32, Shape::from(&[1, 4]));
+        let w = g.input(DType::F32, Shape::from(&[4, 2]));
+        let b = g.input(DType::F32, Shape::from(&[1, 2]));
+        let zero = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+
+        let xw = g.matmul(&x, &w);
+        let xwb = g.add(&xw, &b);
+        let y = g.max(&xwb, &zero);
+
+        g.output(&y);
+        let graph = g.build().expect("graph should validate");
+
+        // Expected ops: Const (from constant()), MatMul, Add, Max => 4 ops.
+        assert_eq!(graph.ops.len(), 4);
+        assert_eq!(graph.outputs, vec![y.id]);
+        assert_eq!(graph.inputs.len(), 3);
+        assert_eq!(graph.constants.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "shape mismatch")]
+    fn add_shape_mismatch_panics() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        let b = g.input(DType::F32, Shape::from(&[4]));
+        let _ = g.add(&a, &b);
+    }
+
+    #[test]
+    #[should_panic(expected = "dtype mismatch")]
+    fn add_dtype_mismatch_panics() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        let b = g.input(DType::I32, Shape::from(&[3]));
+        let _ = g.add(&a, &b);
+    }
+
+    #[test]
+    #[should_panic(expected = "dtype must be a float")]
+    fn sqrt_on_int_panics() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::I32, Shape::from(&[3]));
+        let _ = g.sqrt(&a);
+    }
+
+    #[test]
+    fn reshape_numel_check() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let r = g.reshape(&a, Shape::from(&[6]));
+        assert_eq!(r.shape, Shape::from(&[6]));
+    }
+
+    #[test]
+    #[should_panic(expected = "numel mismatch")]
+    fn reshape_numel_mismatch_panics() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let _ = g.reshape(&a, Shape::from(&[5]));
+    }
+
+    #[test]
+    fn transpose_reorders_dims() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3, 4]));
+        let r = g.transpose(&a, vec![2, 0, 1]);
+        assert_eq!(r.shape, Shape::from(&[4, 2, 3]));
+    }
+
+    #[test]
+    #[should_panic(expected = "perm contains duplicate")]
+    fn transpose_duplicate_perm_panics() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let _ = g.transpose(&a, vec![0, 0]);
+    }
+
+    #[test]
+    fn broadcast_basic() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[1, 3]));
+        let r = g.broadcast(&a, Shape::from(&[4, 3]));
+        assert_eq!(r.shape, Shape::from(&[4, 3]));
+    }
+
+    #[test]
+    #[should_panic(expected = "broadcast")]
+    fn broadcast_incompatible_panics() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let _ = g.broadcast(&a, Shape::from(&[4, 3]));
+    }
+
+    #[test]
+    fn matmul_shape_inference() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let b = g.input(DType::F32, Shape::from(&[3, 4]));
+        let r = g.matmul(&a, &b);
+        assert_eq!(r.shape, Shape::from(&[2, 4]));
+    }
+
+    #[test]
+    #[should_panic(expected = "inner dims mismatch")]
+    fn matmul_inner_mismatch_panics() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let b = g.input(DType::F32, Shape::from(&[5, 4]));
+        let _ = g.matmul(&a, &b);
+    }
+
+    #[test]
+    fn comparison_yields_u8() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        let b = g.input(DType::F32, Shape::from(&[3]));
+        let r = g.equal(&a, &b);
+        assert_eq!(r.dtype, DType::U8);
+    }
+
+    #[test]
+    fn where_basic() {
+        let mut g = GraphBuilder::new();
+        let p = g.input(DType::U8, Shape::from(&[3]));
+        let t = g.input(DType::F32, Shape::from(&[3]));
+        let f = g.input(DType::F32, Shape::from(&[3]));
+        let r = g.where_(&p, &t, &f);
+        assert_eq!(r.dtype, DType::F32);
+        assert_eq!(r.shape, Shape::from(&[3]));
+    }
+
+    #[test]
+    fn cast_changes_dtype_keeps_shape() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 2]));
+        let r = g.cast(&a, DType::I32);
+        assert_eq!(r.dtype, DType::I32);
+        assert_eq!(r.shape, Shape::from(&[2, 2]));
+    }
+
+    #[test]
+    fn reduce_sum_keepdims() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3, 4]));
+        let r = g.reduce_sum(&a, vec![1], false);
+        assert_eq!(r.shape, Shape::from(&[2, 4]));
+        let r2 = g.reduce_sum(&a, vec![1], true);
+        assert_eq!(r2.shape, Shape::from(&[2, 1, 4]));
+    }
+
+    #[test]
+    fn reduce_all_to_scalar() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[2, 3]));
+        let r = g.reduce_sum(&a, vec![], false);
+        assert_eq!(r.shape, Shape::scalar());
+    }
+
+    #[test]
+    fn reduce_shape_helper() {
+        let s = reduce_shape(&Shape::from(&[2, 3, 4]), &[1], false);
+        assert_eq!(s, Shape::from(&[2, 4]));
+        let s = reduce_shape(&Shape::from(&[2, 3, 4]), &[1], true);
+        assert_eq!(s, Shape::from(&[2, 1, 4]));
+        let s = reduce_shape(&Shape::from(&[2, 3]), &[], true);
+        assert_eq!(s, Shape::from(&[1, 1]));
+        let s = reduce_shape(&Shape::from(&[2, 3]), &[], false);
+        assert_eq!(s, Shape::scalar());
+    }
+}

--- a/code/packages/rust/matrix-ir/src/graph.rs
+++ b/code/packages/rust/matrix-ir/src/graph.rs
@@ -1,0 +1,103 @@
+//! The `Graph` aggregate — a complete tensor-algebra computation.
+//!
+//! See spec MX01 §"Core types" for the definition.
+
+use crate::op::Op;
+use crate::tensor::{Tensor, TensorId};
+
+/// A literal-data tensor baked into a graph.  Materialised at run time
+/// via [`Op::Const`].
+///
+/// Bytes are stored in dtype-encoded little-endian.  For example, a
+/// scalar f32 constant `3.14` is stored as `[0xC3, 0xF5, 0x48, 0x40]`.
+///
+/// The validator checks that `bytes.len() == tensor.shape.numel() *
+/// tensor.dtype.size_bytes()`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Constant {
+    /// The tensor the constant produces.  Its [`TensorId`] is the
+    /// output id of the [`Op::Const`] that materialises it.
+    pub tensor: Tensor,
+    /// Dtype-encoded little-endian bytes.
+    pub bytes: Vec<u8>,
+}
+
+/// A complete computation in `matrix-ir` form.
+///
+/// A graph carries:
+/// - [`inputs`](Self::inputs) — tensors the caller supplies at run time.
+/// - [`outputs`](Self::outputs) — tensors the caller receives back.
+/// - [`ops`](Self::ops) — topologically-ordered operations.
+/// - [`tensors`](Self::tensors) — every tensor referenced anywhere,
+///   indexed by [`TensorId`].
+/// - [`constants`](Self::constants) — literal-data tensors.
+///
+/// Graphs are typically constructed via [`GraphBuilder`](crate::GraphBuilder)
+/// rather than by hand.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Graph {
+    /// Tensors supplied by the caller at run time.  Their `TensorId`s
+    /// must be the lowest contiguous block (0..N) within the graph.
+    pub inputs: Vec<Tensor>,
+
+    /// Tensors the caller wants back.  Each must be produced by an op
+    /// or be an input or constant.
+    pub outputs: Vec<TensorId>,
+
+    /// Operations in topological order.  Op `i` may reference any
+    /// tensor produced by op `j < i`, plus inputs and constants.
+    pub ops: Vec<Op>,
+
+    /// Every tensor referenced anywhere in the graph.  The vec is
+    /// indexed by `TensorId` (i.e. `tensors[t.0 as usize]` is the
+    /// tensor with id `t`).
+    pub tensors: Vec<Tensor>,
+
+    /// Literal-data tensors.  Indexed by [`Op::Const`]'s `constant`
+    /// field.
+    pub constants: Vec<Constant>,
+}
+
+impl Graph {
+    /// Look up a tensor by id.  Returns `None` if the id is out of range.
+    pub fn tensor(&self, id: TensorId) -> Option<&Tensor> {
+        self.tensors.get(id.0 as usize)
+    }
+
+    /// Number of tensors in the graph (counting every defined value:
+    /// inputs, constants, op outputs).
+    pub fn num_tensors(&self) -> usize {
+        self.tensors.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tensor::{DType, Shape};
+
+    fn empty() -> Graph {
+        Graph {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            ops: Vec::new(),
+            tensors: Vec::new(),
+            constants: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn lookup_out_of_range_returns_none() {
+        let g = empty();
+        assert!(g.tensor(TensorId(42)).is_none());
+    }
+
+    #[test]
+    fn lookup_in_range_returns_tensor() {
+        let mut g = empty();
+        let t = Tensor::new(TensorId(0), DType::F32, Shape::from(&[3]));
+        g.tensors.push(t.clone());
+        assert_eq!(g.tensor(TensorId(0)), Some(&t));
+        assert_eq!(g.num_tensors(), 1);
+    }
+}

--- a/code/packages/rust/matrix-ir/src/lib.rs
+++ b/code/packages/rust/matrix-ir/src/lib.rs
@@ -1,0 +1,76 @@
+//! # `matrix-ir` — The Tensor Algebra IR
+//!
+//! `matrix-ir` is the upper IR of the matrix execution layer.  Domain
+//! libraries (image processing, neural-network layers, signal processing,
+//! BLAS) emit `matrix-ir` graphs that describe *what* to compute as a
+//! directed acyclic graph of tensor algebra operations.  This crate says
+//! nothing about *where* the computation happens; that is `compute-ir`'s
+//! job (spec MX02).
+//!
+//! See `code/specs/MX01-matrix-ir.md` for the full specification and
+//! `code/specs/MX00-matrix-execution-overview.md` for the architecture
+//! context.
+//!
+//! ## What lives here
+//!
+//! - [`Tensor`], [`Shape`], [`DType`] — the data plane.
+//! - [`Op`] — the 27-variant operation enum.
+//! - [`Graph`], [`Constant`] — a complete computation.
+//! - [`GraphBuilder`] — an ergonomic builder that allocates tensor ids,
+//!   infers output shapes, and constructs a [`Graph`] step by step.
+//! - [`validate`](Graph::validate) — structural and semantic checks.
+//! - [`to_bytes`](Graph::to_bytes) / [`from_bytes`](Graph::from_bytes) —
+//!   versioned binary wire format that round-trips without loss.
+//!
+//! ## A worked example
+//!
+//! Construct a single-layer `y = relu(x @ w + b)` graph:
+//!
+//! ```
+//! use matrix_ir::{DType, GraphBuilder, Shape};
+//!
+//! let mut g = GraphBuilder::new();
+//! let x = g.input(DType::F32, Shape::from(&[1, 4]));
+//! let w = g.input(DType::F32, Shape::from(&[4, 2]));
+//! let b = g.input(DType::F32, Shape::from(&[1, 2]));
+//!
+//! // Tiny zero constant for ReLU = max(x, 0).  Bytes are dtype-encoded LE.
+//! let zero = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+//!
+//! let xw    = g.matmul(&x, &w);
+//! let xwb   = g.add(&xw, &b);
+//! let y     = g.max(&xwb, &zero);
+//!
+//! g.output(&y);
+//! let graph = g.build().unwrap();
+//! graph.validate().unwrap();
+//! // Const (from constant()) + matmul + add + max = 4 ops
+//! assert_eq!(graph.ops.len(), 4);
+//! ```
+//!
+//! ## Zero dependencies
+//!
+//! Per the spec MX00 zero-dependency mandate, this crate uses only
+//! `core`, `alloc`, and `std`.  No `serde`, no `bincode`, no `postcard`,
+//! no async runtime.  The wire format is hand-rolled per spec MX03 and
+//! is implementation-agnostic — any language with bytes can implement
+//! a compatible encoder/decoder from the spec alone.
+
+#![warn(rust_2018_idioms)]
+
+mod tensor;
+mod op;
+mod graph;
+mod builder;
+mod validate;
+mod wire;
+
+pub use tensor::{DType, OpId, Shape, Tensor, TensorId};
+pub use op::Op;
+pub use graph::{Constant, Graph};
+pub use builder::GraphBuilder;
+pub use validate::IrError;
+
+/// Wire format version produced by this crate's `to_bytes`.  Readers that
+/// see a different version on the wire fail rather than misinterpret.
+pub const WIRE_FORMAT_VERSION: u32 = 1;

--- a/code/packages/rust/matrix-ir/src/op.rs
+++ b/code/packages/rust/matrix-ir/src/op.rs
@@ -1,0 +1,457 @@
+//! The 27-variant op enum.
+//!
+//! Each op carries `output: TensorId` even though it could be inferred
+//! positionally.  This serves two purposes:
+//!
+//! 1. **Round-trip stability**: serialising and deserialising preserves
+//!    the exact `TensorId` numbering, which tests assert against.
+//! 2. **Validation locality**: a validator can check op-by-op without
+//!    walking back through the graph to recompute output ids.
+//!
+//! The wire tag for each variant is fixed by spec MX03 §"Encoding
+//! `matrix-ir` types" and never changes.  V2 ops get tags `0x1C` and
+//! beyond.
+
+use crate::tensor::{DType, Shape, TensorId};
+
+/// One operation node in a tensor algebra graph.
+///
+/// Variants are grouped:
+/// - **Elementwise unary** (7): Neg, Abs, Sqrt, Exp, Log, Tanh, Recip
+/// - **Elementwise binary** (7): Add, Sub, Mul, Div, Max, Min, Pow
+/// - **Reductions** (3): ReduceSum, ReduceMax, ReduceMean
+/// - **Shape** (3): Reshape, Transpose, Broadcast
+/// - **Linear algebra** (1): MatMul
+/// - **Comparison** (3): Equal, Less, Greater
+/// - **Selection** (1): Where
+/// - **Conversion** (1): Cast
+/// - **Constants** (1): Const
+///
+/// Total: 27 ops.  See spec MX01 §"V1 op set" for the contract on each.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Op {
+    // ──────────── elementwise unary ────────────
+    /// `-x`, elementwise.  Output shape and dtype match input.
+    Neg { input: TensorId, output: TensorId },
+    /// `|x|`, elementwise.  Output shape and dtype match input.
+    Abs { input: TensorId, output: TensorId },
+    /// `sqrt(x)`, elementwise.  Output dtype must be a float (F32 in V1).
+    Sqrt { input: TensorId, output: TensorId },
+    /// `e^x`, elementwise.  Float-only.
+    Exp { input: TensorId, output: TensorId },
+    /// `ln(x)`, elementwise.  Float-only.
+    Log { input: TensorId, output: TensorId },
+    /// `tanh(x)`, elementwise.  Float-only.
+    Tanh { input: TensorId, output: TensorId },
+    /// `1/x`, elementwise.  Float-only.
+    Recip { input: TensorId, output: TensorId },
+
+    // ──────────── elementwise binary ────────────
+    /// `lhs + rhs`, elementwise.  Inputs must have identical shape and dtype.
+    Add { lhs: TensorId, rhs: TensorId, output: TensorId },
+    /// `lhs - rhs`.
+    Sub { lhs: TensorId, rhs: TensorId, output: TensorId },
+    /// `lhs * rhs`.
+    Mul { lhs: TensorId, rhs: TensorId, output: TensorId },
+    /// `lhs / rhs`.  Float-only in V1; integer division reserved for V2.
+    Div { lhs: TensorId, rhs: TensorId, output: TensorId },
+    /// `max(lhs, rhs)`.
+    Max { lhs: TensorId, rhs: TensorId, output: TensorId },
+    /// `min(lhs, rhs)`.
+    Min { lhs: TensorId, rhs: TensorId, output: TensorId },
+    /// `lhs ^ rhs`.  Float-only.
+    Pow { lhs: TensorId, rhs: TensorId, output: TensorId },
+
+    // ──────────── reductions ────────────
+    /// Sum over the given axes.  If `keep_dims` is false, reduced axes
+    /// are removed; if true, they remain as size-1.  Empty `axes` means
+    /// reduce-all.
+    ReduceSum {
+        input: TensorId,
+        axes: Vec<u32>,
+        keep_dims: bool,
+        output: TensorId,
+    },
+    /// Max over axes.  Same axis semantics as ReduceSum.
+    ReduceMax {
+        input: TensorId,
+        axes: Vec<u32>,
+        keep_dims: bool,
+        output: TensorId,
+    },
+    /// Mean over axes.  For integer dtypes this uses integer division
+    /// (truncation toward zero).
+    ReduceMean {
+        input: TensorId,
+        axes: Vec<u32>,
+        keep_dims: bool,
+        output: TensorId,
+    },
+
+    // ──────────── shape ────────────
+    /// Reshape to `new_shape`.  Total element count must match.
+    Reshape {
+        input: TensorId,
+        new_shape: Shape,
+        output: TensorId,
+    },
+    /// Transpose by the given permutation.  `perm` must be a permutation
+    /// of `0..rank`.
+    Transpose {
+        input: TensorId,
+        perm: Vec<u32>,
+        output: TensorId,
+    },
+    /// Broadcast to `target_shape`.  Each dim of input must equal the
+    /// corresponding target dim or be 1.
+    Broadcast {
+        input: TensorId,
+        target_shape: Shape,
+        output: TensorId,
+    },
+
+    // ──────────── linear algebra ────────────
+    /// 2D matrix multiplication.  `a` is `[m, k]`, `b` is `[k, n]`,
+    /// output is `[m, n]`.  Both inputs share dtype.
+    MatMul {
+        a: TensorId,
+        b: TensorId,
+        output: TensorId,
+    },
+
+    // ──────────── comparison ────────────
+    /// Elementwise `lhs == rhs`.  Output dtype is U8 (0 or 1).
+    Equal { lhs: TensorId, rhs: TensorId, output: TensorId },
+    /// Elementwise `lhs < rhs`.  Output dtype is U8.
+    Less { lhs: TensorId, rhs: TensorId, output: TensorId },
+    /// Elementwise `lhs > rhs`.  Output dtype is U8.
+    Greater { lhs: TensorId, rhs: TensorId, output: TensorId },
+
+    // ──────────── selection ────────────
+    /// Elementwise `predicate ? true_value : false_value`.
+    /// `predicate` must be U8.  All shapes must match.  Output dtype
+    /// matches `true_value`/`false_value`.
+    Where {
+        predicate: TensorId,
+        true_value: TensorId,
+        false_value: TensorId,
+        output: TensorId,
+    },
+
+    // ──────────── conversion ────────────
+    /// Numerical conversion to the target dtype.  Float-to-int
+    /// truncates toward zero.
+    Cast {
+        input: TensorId,
+        dtype: DType,
+        output: TensorId,
+    },
+
+    // ──────────── constants ────────────
+    /// Materialise a constant from the graph's constant table.  The
+    /// `constant` field is the index into `Graph.constants`.
+    Const { constant: u32, output: TensorId },
+}
+
+impl Op {
+    /// The wire-format tag for this op variant.  Stable across versions
+    /// per spec MX03.
+    pub const fn wire_tag(&self) -> u8 {
+        match self {
+            Op::Neg { .. } => 0x00,
+            Op::Abs { .. } => 0x01,
+            Op::Sqrt { .. } => 0x02,
+            Op::Exp { .. } => 0x03,
+            Op::Log { .. } => 0x04,
+            Op::Tanh { .. } => 0x05,
+            Op::Recip { .. } => 0x06,
+            Op::Add { .. } => 0x07,
+            Op::Sub { .. } => 0x08,
+            Op::Mul { .. } => 0x09,
+            Op::Div { .. } => 0x0A,
+            Op::Max { .. } => 0x0B,
+            Op::Min { .. } => 0x0C,
+            Op::Pow { .. } => 0x0D,
+            Op::ReduceSum { .. } => 0x0E,
+            Op::ReduceMax { .. } => 0x0F,
+            Op::ReduceMean { .. } => 0x10,
+            Op::Reshape { .. } => 0x11,
+            Op::Transpose { .. } => 0x12,
+            Op::Broadcast { .. } => 0x13,
+            Op::MatMul { .. } => 0x15,
+            Op::Equal { .. } => 0x16,
+            Op::Less { .. } => 0x17,
+            Op::Greater { .. } => 0x18,
+            Op::Where { .. } => 0x19,
+            Op::Cast { .. } => 0x1A,
+            Op::Const { .. } => 0x1B,
+        }
+    }
+
+    /// The output tensor id this op produces.
+    pub const fn output(&self) -> TensorId {
+        match *self {
+            Op::Neg { output, .. } => output,
+            Op::Abs { output, .. } => output,
+            Op::Sqrt { output, .. } => output,
+            Op::Exp { output, .. } => output,
+            Op::Log { output, .. } => output,
+            Op::Tanh { output, .. } => output,
+            Op::Recip { output, .. } => output,
+            Op::Add { output, .. } => output,
+            Op::Sub { output, .. } => output,
+            Op::Mul { output, .. } => output,
+            Op::Div { output, .. } => output,
+            Op::Max { output, .. } => output,
+            Op::Min { output, .. } => output,
+            Op::Pow { output, .. } => output,
+            Op::ReduceSum { output, .. } => output,
+            Op::ReduceMax { output, .. } => output,
+            Op::ReduceMean { output, .. } => output,
+            Op::Reshape { output, .. } => output,
+            Op::Transpose { output, .. } => output,
+            Op::Broadcast { output, .. } => output,
+            Op::MatMul { output, .. } => output,
+            Op::Equal { output, .. } => output,
+            Op::Less { output, .. } => output,
+            Op::Greater { output, .. } => output,
+            Op::Where { output, .. } => output,
+            Op::Cast { output, .. } => output,
+            Op::Const { output, .. } => output,
+        }
+    }
+
+    /// Iterate over the input tensor ids referenced by this op (excluding
+    /// constants, which are looked up via index).  Order is variant-defined.
+    ///
+    /// Returns a small Vec to keep the API simple; an iterator could be
+    /// added if profiling shows allocation pressure.
+    pub fn inputs(&self) -> Vec<TensorId> {
+        match self {
+            Op::Neg { input, .. }
+            | Op::Abs { input, .. }
+            | Op::Sqrt { input, .. }
+            | Op::Exp { input, .. }
+            | Op::Log { input, .. }
+            | Op::Tanh { input, .. }
+            | Op::Recip { input, .. } => vec![*input],
+
+            Op::Add { lhs, rhs, .. }
+            | Op::Sub { lhs, rhs, .. }
+            | Op::Mul { lhs, rhs, .. }
+            | Op::Div { lhs, rhs, .. }
+            | Op::Max { lhs, rhs, .. }
+            | Op::Min { lhs, rhs, .. }
+            | Op::Pow { lhs, rhs, .. }
+            | Op::Equal { lhs, rhs, .. }
+            | Op::Less { lhs, rhs, .. }
+            | Op::Greater { lhs, rhs, .. } => vec![*lhs, *rhs],
+
+            Op::ReduceSum { input, .. }
+            | Op::ReduceMax { input, .. }
+            | Op::ReduceMean { input, .. }
+            | Op::Reshape { input, .. }
+            | Op::Transpose { input, .. }
+            | Op::Broadcast { input, .. }
+            | Op::Cast { input, .. } => vec![*input],
+
+            Op::MatMul { a, b, .. } => vec![*a, *b],
+
+            Op::Where {
+                predicate,
+                true_value,
+                false_value,
+                ..
+            } => vec![*predicate, *true_value, *false_value],
+
+            Op::Const { .. } => Vec::new(),
+        }
+    }
+
+    /// True iff this op is one of the seven elementwise-unary variants.
+    /// Useful for downstream optimisers (fusion, etc.).
+    pub const fn is_elementwise_unary(&self) -> bool {
+        matches!(
+            self,
+            Op::Neg { .. }
+                | Op::Abs { .. }
+                | Op::Sqrt { .. }
+                | Op::Exp { .. }
+                | Op::Log { .. }
+                | Op::Tanh { .. }
+                | Op::Recip { .. }
+        )
+    }
+
+    /// True iff this op is one of the seven elementwise-binary variants.
+    pub const fn is_elementwise_binary(&self) -> bool {
+        matches!(
+            self,
+            Op::Add { .. }
+                | Op::Sub { .. }
+                | Op::Mul { .. }
+                | Op::Div { .. }
+                | Op::Max { .. }
+                | Op::Min { .. }
+                | Op::Pow { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All 27 op tags must be unique.  This guards against typos in the
+    /// `wire_tag` match arms.
+    #[test]
+    fn wire_tags_are_unique() {
+        let ops = sample_one_per_variant();
+        let mut tags: Vec<u8> = ops.iter().map(|o| o.wire_tag()).collect();
+        tags.sort();
+        let len_before = tags.len();
+        tags.dedup();
+        assert_eq!(
+            tags.len(),
+            len_before,
+            "duplicate wire tag in Op enum: {:?}",
+            tags
+        );
+        // 27 variants in V1.
+        assert_eq!(len_before, 27);
+    }
+
+    #[test]
+    fn output_method_returns_declared_output() {
+        let op = Op::Add {
+            lhs: TensorId(1),
+            rhs: TensorId(2),
+            output: TensorId(7),
+        };
+        assert_eq!(op.output(), TensorId(7));
+    }
+
+    #[test]
+    fn inputs_method_returns_referenced_tensors() {
+        let op = Op::MatMul {
+            a: TensorId(1),
+            b: TensorId(2),
+            output: TensorId(3),
+        };
+        assert_eq!(op.inputs(), vec![TensorId(1), TensorId(2)]);
+
+        let op = Op::Where {
+            predicate: TensorId(1),
+            true_value: TensorId(2),
+            false_value: TensorId(3),
+            output: TensorId(4),
+        };
+        assert_eq!(
+            op.inputs(),
+            vec![TensorId(1), TensorId(2), TensorId(3)]
+        );
+
+        let op = Op::Const {
+            constant: 0,
+            output: TensorId(0),
+        };
+        assert_eq!(op.inputs(), Vec::<TensorId>::new());
+    }
+
+    #[test]
+    fn elementwise_classifiers() {
+        let neg = Op::Neg {
+            input: TensorId(0),
+            output: TensorId(1),
+        };
+        let add = Op::Add {
+            lhs: TensorId(0),
+            rhs: TensorId(1),
+            output: TensorId(2),
+        };
+        let mm = Op::MatMul {
+            a: TensorId(0),
+            b: TensorId(1),
+            output: TensorId(2),
+        };
+        assert!(neg.is_elementwise_unary());
+        assert!(!neg.is_elementwise_binary());
+        assert!(add.is_elementwise_binary());
+        assert!(!add.is_elementwise_unary());
+        assert!(!mm.is_elementwise_unary());
+        assert!(!mm.is_elementwise_binary());
+    }
+
+    /// Helper: produce one op of each variant for exhaustive coverage tests.
+    pub(crate) fn sample_one_per_variant() -> Vec<Op> {
+        let t = |n: u32| TensorId(n);
+        vec![
+            Op::Neg { input: t(0), output: t(1) },
+            Op::Abs { input: t(0), output: t(1) },
+            Op::Sqrt { input: t(0), output: t(1) },
+            Op::Exp { input: t(0), output: t(1) },
+            Op::Log { input: t(0), output: t(1) },
+            Op::Tanh { input: t(0), output: t(1) },
+            Op::Recip { input: t(0), output: t(1) },
+            Op::Add { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Sub { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Mul { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Div { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Max { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Min { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Pow { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::ReduceSum {
+                input: t(0),
+                axes: vec![1],
+                keep_dims: false,
+                output: t(1),
+            },
+            Op::ReduceMax {
+                input: t(0),
+                axes: vec![1],
+                keep_dims: false,
+                output: t(1),
+            },
+            Op::ReduceMean {
+                input: t(0),
+                axes: vec![1],
+                keep_dims: false,
+                output: t(1),
+            },
+            Op::Reshape {
+                input: t(0),
+                new_shape: Shape::from(&[6]),
+                output: t(1),
+            },
+            Op::Transpose {
+                input: t(0),
+                perm: vec![1, 0],
+                output: t(1),
+            },
+            Op::Broadcast {
+                input: t(0),
+                target_shape: Shape::from(&[2, 3]),
+                output: t(1),
+            },
+            Op::MatMul { a: t(0), b: t(1), output: t(2) },
+            Op::Equal { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Less { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Greater { lhs: t(0), rhs: t(1), output: t(2) },
+            Op::Where {
+                predicate: t(0),
+                true_value: t(1),
+                false_value: t(2),
+                output: t(3),
+            },
+            Op::Cast {
+                input: t(0),
+                dtype: DType::I32,
+                output: t(1),
+            },
+            Op::Const {
+                constant: 0,
+                output: t(0),
+            },
+        ]
+    }
+}

--- a/code/packages/rust/matrix-ir/src/tensor.rs
+++ b/code/packages/rust/matrix-ir/src/tensor.rs
@@ -1,0 +1,262 @@
+//! Tensor identity, dtype, and shape — the value-plane primitives of the
+//! IR.  See spec MX01 §"Core types".
+
+use core::fmt;
+
+/// A unique identifier for a tensor produced by an op or supplied as an
+/// input/constant.  Allocated densely starting at 0 by [`GraphBuilder`].
+///
+/// We use a 32-bit id rather than a 64-bit one because:
+/// - Real graphs have thousands, not billions, of tensors — 32 bits is
+///   ~4 billion which is wildly more than any practical graph.
+/// - The wire format is smaller (4 bytes vs 8), and tensor ids appear
+///   many times per graph.
+///
+/// [`GraphBuilder`]: crate::GraphBuilder
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct TensorId(pub u32);
+
+/// A unique identifier for an op within a graph.  Currently only used
+/// for diagnostics and round-trip stability — ops are ordered by their
+/// position in [`Graph::ops`](crate::Graph::ops).
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct OpId(pub u32);
+
+/// The element type of a tensor.
+///
+/// V1 supports three dtypes:
+/// - [`DType::F32`] — IEEE 754 single-precision float, 4 bytes
+/// - [`DType::U8`]  — unsigned 8-bit integer, also used for booleans
+///   (0 or 1) since shader languages typically don't have bool tensors
+/// - [`DType::I32`] — signed 32-bit integer, 4 bytes
+///
+/// `f16`, `bf16`, `i64`, `complex64` are deferred to V2.  The wire
+/// format reserves tags `0x03` and `0x04` for `F16` and `I64`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum DType {
+    /// IEEE 754 binary32.
+    F32,
+    /// Unsigned 8-bit.
+    U8,
+    /// Signed 32-bit.
+    I32,
+}
+
+impl DType {
+    /// The size of a single element in bytes.
+    ///
+    /// | DType | size |
+    /// |-------|------|
+    /// | F32   | 4    |
+    /// | U8    | 1    |
+    /// | I32   | 4    |
+    pub const fn size_bytes(self) -> usize {
+        match self {
+            DType::F32 => 4,
+            DType::U8 => 1,
+            DType::I32 => 4,
+        }
+    }
+
+    /// The wire-format tag for this dtype.  See spec MX03 §"Encoding
+    /// `matrix-ir` types".
+    pub const fn wire_tag(self) -> u8 {
+        match self {
+            DType::F32 => 0x00,
+            DType::U8 => 0x01,
+            DType::I32 => 0x02,
+        }
+    }
+
+    /// Decode a wire-format tag back into a [`DType`].  Returns `None`
+    /// for unknown or reserved tags.
+    pub const fn from_wire_tag(tag: u8) -> Option<DType> {
+        match tag {
+            0x00 => Some(DType::F32),
+            0x01 => Some(DType::U8),
+            0x02 => Some(DType::I32),
+            // 0x03 reserved for F16, 0x04 reserved for I64
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DType::F32 => f.write_str("f32"),
+            DType::U8 => f.write_str("u8"),
+            DType::I32 => f.write_str("i32"),
+        }
+    }
+}
+
+/// The shape of a tensor — its dimensions in row-major / leftmost-major
+/// order.  A scalar has empty `dims`; a vector has one dim; a matrix
+/// has two; and so on up to whatever rank the graph is built with
+/// (validators downstream may cap rank for backend support).
+///
+/// V1 shapes are **fully static** — every dimension is a concrete `u32`.
+/// V2 introduces symbolic dimensions for dynamic shapes; V1's `Shape`
+/// is the special case where every dim is concrete.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Shape {
+    /// Dimensions in leftmost-major order.  Empty `Vec` means scalar.
+    pub dims: Vec<u32>,
+}
+
+impl Shape {
+    /// Construct a shape from a slice.  Convenience for tests and
+    /// builder usage.
+    pub fn from(dims: &[u32]) -> Self {
+        Shape {
+            dims: dims.to_vec(),
+        }
+    }
+
+    /// Construct a scalar shape (rank 0, empty dims).
+    pub fn scalar() -> Self {
+        Shape { dims: Vec::new() }
+    }
+
+    /// The rank of the shape — the number of dimensions.  Scalar = 0.
+    pub fn rank(&self) -> usize {
+        self.dims.len()
+    }
+
+    /// The total number of elements in this shape — the product of all
+    /// dims, or `1` for a scalar.
+    ///
+    /// Returns `None` if the product overflows `u64`.  Real shapes never
+    /// overflow `u64`; this primarily protects against malicious input
+    /// from deserialization.
+    pub fn numel(&self) -> Option<u64> {
+        let mut acc: u64 = 1;
+        for &d in &self.dims {
+            acc = acc.checked_mul(d as u64)?;
+        }
+        Some(acc)
+    }
+
+    /// The total byte size of a tensor with this shape and dtype.
+    /// Returns `None` on overflow.
+    pub fn byte_size(&self, dtype: DType) -> Option<u64> {
+        self.numel()?
+            .checked_mul(dtype.size_bytes() as u64)
+    }
+}
+
+impl fmt::Display for Shape {
+    /// Format as `[d0, d1, d2]` (or `[]` for scalar).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        for (i, d) in self.dims.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{}", d)?;
+        }
+        f.write_str("]")
+    }
+}
+
+/// A tensor — an immutable value with identity, dtype, and shape.
+///
+/// Tensors are produced by ops, supplied as graph inputs, or
+/// materialised from constants.  They carry no data themselves; the
+/// data flows through buffers in the lower IR (`compute-ir`).
+///
+/// In SSA form, every tensor has exactly one defining op (or is an
+/// input or constant).
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Tensor {
+    /// The unique identifier for this tensor within its graph.
+    pub id: TensorId,
+    /// The element type.
+    pub dtype: DType,
+    /// The static shape.
+    pub shape: Shape,
+}
+
+impl Tensor {
+    /// Construct a tensor.  Mostly useful for tests; production code
+    /// builds tensors via [`GraphBuilder`](crate::GraphBuilder).
+    pub fn new(id: TensorId, dtype: DType, shape: Shape) -> Self {
+        Tensor { id, dtype, shape }
+    }
+}
+
+impl fmt::Display for Tensor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "t{} {} {}", self.id.0, self.dtype, self.shape)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dtype_size_bytes_matches_spec() {
+        assert_eq!(DType::F32.size_bytes(), 4);
+        assert_eq!(DType::U8.size_bytes(), 1);
+        assert_eq!(DType::I32.size_bytes(), 4);
+    }
+
+    #[test]
+    fn dtype_wire_tag_round_trips() {
+        for dt in [DType::F32, DType::U8, DType::I32] {
+            let tag = dt.wire_tag();
+            assert_eq!(DType::from_wire_tag(tag), Some(dt));
+        }
+    }
+
+    #[test]
+    fn dtype_from_unknown_tag_returns_none() {
+        assert_eq!(DType::from_wire_tag(0xFF), None);
+        // Reserved-for-V2 tags also return None in V1.
+        assert_eq!(DType::from_wire_tag(0x03), None);
+        assert_eq!(DType::from_wire_tag(0x04), None);
+    }
+
+    #[test]
+    fn shape_scalar() {
+        let s = Shape::scalar();
+        assert_eq!(s.rank(), 0);
+        assert_eq!(s.numel(), Some(1));
+        assert_eq!(s.byte_size(DType::F32), Some(4));
+    }
+
+    #[test]
+    fn shape_numel() {
+        let s = Shape::from(&[2, 3, 4]);
+        assert_eq!(s.rank(), 3);
+        assert_eq!(s.numel(), Some(24));
+        assert_eq!(s.byte_size(DType::F32), Some(96));
+        assert_eq!(s.byte_size(DType::U8), Some(24));
+    }
+
+    #[test]
+    fn shape_overflow_protection() {
+        // Two huge dims that overflow u64 when multiplied.
+        let s = Shape::from(&[u32::MAX, u32::MAX]);
+        // u32::MAX * u32::MAX = ~1.8e19, just under u64::MAX (~1.8e19).
+        // The third dim would push it over.
+        let s = Shape {
+            dims: vec![u32::MAX, u32::MAX, 2],
+        };
+        assert_eq!(s.numel(), None, "should detect overflow");
+    }
+
+    #[test]
+    fn shape_display() {
+        assert_eq!(format!("{}", Shape::from(&[1, 2, 3])), "[1, 2, 3]");
+        assert_eq!(format!("{}", Shape::scalar()), "[]");
+    }
+
+    #[test]
+    fn tensor_display() {
+        let t = Tensor::new(TensorId(7), DType::F32, Shape::from(&[2, 2]));
+        assert_eq!(format!("{}", t), "t7 f32 [2, 2]");
+    }
+}

--- a/code/packages/rust/matrix-ir/src/validate.rs
+++ b/code/packages/rust/matrix-ir/src/validate.rs
@@ -1,0 +1,605 @@
+//! Structural and semantic validation of [`Graph`]s.
+//!
+//! See spec MX01 §"Validation".  The validator runs in O(N) over the op
+//! list and is invoked by [`GraphBuilder::build`](crate::GraphBuilder::build)
+//! and may also be called explicitly via [`Graph::validate`].
+//!
+//! Every variant of [`Op`](crate::Op) has an explicit match arm.  Adding
+//! a new variant without adding a check is a compile error because the
+//! match has no default arm.
+
+use crate::builder::reduce_shape;
+use crate::graph::Graph;
+use crate::op::Op;
+use crate::tensor::{DType, Shape, Tensor, TensorId};
+
+/// Errors produced by [`Graph::validate`] and related code.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum IrError {
+    /// A `TensorId` referenced by an op is out of range of `Graph.tensors`.
+    UndefinedTensor {
+        op_index: u32,
+        tensor: TensorId,
+    },
+    /// Two inputs that should have matching shapes do not.
+    ShapeMismatch {
+        op_index: u32,
+        expected: Shape,
+        actual: Shape,
+    },
+    /// Two inputs that should have matching dtypes do not.
+    DTypeMismatch {
+        op_index: u32,
+        expected: DType,
+        actual: DType,
+    },
+    /// The op's declared output tensor disagrees with what its inputs imply.
+    OutputMismatch {
+        op_index: u32,
+        expected: Tensor,
+        actual: Tensor,
+    },
+    /// A constant's bytes length does not match its declared shape × dtype.
+    ConstantByteLength {
+        constant_index: u32,
+        expected: usize,
+        actual: usize,
+    },
+    /// A constant's table index references a constant that doesn't exist.
+    UndefinedConstant {
+        op_index: u32,
+        constant: u32,
+    },
+    /// A `Const` op's tensor table index doesn't match its constant
+    /// table tensor id.
+    ConstantTensorMismatch {
+        op_index: u32,
+        constant_index: u32,
+    },
+    /// A reduction or shape op got an axis or perm value out of range.
+    InvalidAxis {
+        op_index: u32,
+        axis: u32,
+        rank: u32,
+    },
+    /// A transpose perm is not a permutation of `0..rank`.
+    InvalidPermutation { op_index: u32, perm: Vec<u32> },
+    /// A reshape would change the element count.
+    NumelMismatch {
+        op_index: u32,
+        expected: u64,
+        actual: u64,
+    },
+    /// A broadcast tries to expand a non-1 dim.
+    InvalidBroadcast {
+        op_index: u32,
+        from: Shape,
+        to: Shape,
+    },
+    /// A matmul received an input with the wrong rank.
+    BadMatMulRank {
+        op_index: u32,
+        which: &'static str, // "a" or "b"
+        rank: u32,
+    },
+    /// An op requires a float dtype and got a non-float.
+    NonFloatDType {
+        op_index: u32,
+        op_name: &'static str,
+        dtype: DType,
+    },
+    /// `Where` predicate must be U8.
+    NonU8Predicate { op_index: u32, dtype: DType },
+    /// An output listed in `Graph.outputs` is not defined.
+    UndefinedOutput { tensor: TensorId },
+    /// A `Tensor` in `Graph.tensors` has an id that doesn't match its
+    /// position in the vector.
+    TensorIdMismatch { position: u32, declared: TensorId },
+    /// A graph input's id is out of range.
+    InputOutOfRange { tensor: TensorId },
+    /// An op produces an output that is not the next-allocated id.
+    NonContiguousOutput {
+        op_index: u32,
+        expected: TensorId,
+        actual: TensorId,
+    },
+    /// Wire-format error: unexpected end of input.
+    WireUnexpectedEof,
+    /// Wire-format error: invalid UTF-8 in a string field.
+    WireInvalidUtf8,
+    /// Wire-format error: format version is not supported by this reader.
+    WireUnsupportedVersion(u32),
+    /// Wire-format error: an op or dtype tag is not in the known set.
+    WireUnknownTag { what: &'static str, tag: u64 },
+    /// Wire-format error: a varint is more than 10 bytes (would overflow u64).
+    WireOversizedVarint,
+    /// Wire-format error: trailing bytes after a complete graph.
+    WireTrailingBytes,
+}
+
+impl Graph {
+    /// Validate the graph end-to-end.  Returns `Ok(())` if valid,
+    /// `Err(IrError)` describing the first violation otherwise.
+    pub fn validate(&self) -> Result<(), IrError> {
+        // ──── Tensor table consistency ────
+        for (i, t) in self.tensors.iter().enumerate() {
+            if t.id.0 as usize != i {
+                return Err(IrError::TensorIdMismatch {
+                    position: i as u32,
+                    declared: t.id,
+                });
+            }
+        }
+
+        // ──── Inputs reference real tensors ────
+        for inp in &self.inputs {
+            if inp.id.0 as usize >= self.tensors.len() {
+                return Err(IrError::InputOutOfRange { tensor: inp.id });
+            }
+        }
+
+        // ──── Constants ────
+        for (ci, c) in self.constants.iter().enumerate() {
+            let expected = c
+                .tensor
+                .shape
+                .byte_size(c.tensor.dtype)
+                .ok_or(IrError::ConstantByteLength {
+                    constant_index: ci as u32,
+                    expected: usize::MAX,
+                    actual: c.bytes.len(),
+                })? as usize;
+            if c.bytes.len() != expected {
+                return Err(IrError::ConstantByteLength {
+                    constant_index: ci as u32,
+                    expected,
+                    actual: c.bytes.len(),
+                });
+            }
+        }
+
+        // ──── Single-assignment + per-op semantic checks ────
+        // Walk ops in declared order.  Track which tensor ids have been
+        // produced (or are inputs/constants) so we can confirm SSA and
+        // topological ordering simultaneously.
+        let mut defined: Vec<bool> = vec![false; self.tensors.len()];
+        for inp in &self.inputs {
+            defined[inp.id.0 as usize] = true;
+        }
+        for c in &self.constants {
+            defined[c.tensor.id.0 as usize] = true;
+        }
+
+        for (i, op) in self.ops.iter().enumerate() {
+            let i = i as u32;
+            for input in op.inputs() {
+                let idx = input.0 as usize;
+                if idx >= self.tensors.len() {
+                    return Err(IrError::UndefinedTensor {
+                        op_index: i,
+                        tensor: input,
+                    });
+                }
+                if !defined[idx] {
+                    // A tensor that exists in the table but hasn't been
+                    // produced yet means out-of-order ops.
+                    return Err(IrError::UndefinedTensor {
+                        op_index: i,
+                        tensor: input,
+                    });
+                }
+            }
+
+            self.check_op_semantics(i, op)?;
+
+            // Mark output as defined.
+            let out = op.output();
+            if (out.0 as usize) >= self.tensors.len() {
+                return Err(IrError::UndefinedTensor {
+                    op_index: i,
+                    tensor: out,
+                });
+            }
+            defined[out.0 as usize] = true;
+        }
+
+        // ──── Outputs are all defined ────
+        for &out in &self.outputs {
+            let idx = out.0 as usize;
+            if idx >= self.tensors.len() || !defined[idx] {
+                return Err(IrError::UndefinedOutput { tensor: out });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Per-op semantic check.  Each variant validates that input shapes
+    /// and dtypes satisfy its contract and that the declared output is
+    /// what those inputs imply.
+    fn check_op_semantics(&self, i: u32, op: &Op) -> Result<(), IrError> {
+        match op {
+            // ──── elementwise unary ────
+            Op::Neg { input, output }
+            | Op::Abs { input, output } => {
+                let inp = self.must_tensor(i, *input)?;
+                self.expect_output(i, *output, &inp.dtype, &inp.shape)?;
+                Ok(())
+            }
+            Op::Sqrt { input, output }
+            | Op::Exp { input, output }
+            | Op::Log { input, output }
+            | Op::Tanh { input, output }
+            | Op::Recip { input, output } => {
+                let inp = self.must_tensor(i, *input)?;
+                if inp.dtype != DType::F32 {
+                    return Err(IrError::NonFloatDType {
+                        op_index: i,
+                        op_name: op_name(op),
+                        dtype: inp.dtype,
+                    });
+                }
+                self.expect_output(i, *output, &inp.dtype, &inp.shape)?;
+                Ok(())
+            }
+
+            // ──── elementwise binary (non-float-required) ────
+            Op::Add { lhs, rhs, output }
+            | Op::Sub { lhs, rhs, output }
+            | Op::Mul { lhs, rhs, output }
+            | Op::Max { lhs, rhs, output }
+            | Op::Min { lhs, rhs, output } => {
+                self.check_elem_binary(i, *lhs, *rhs, *output, false)?;
+                Ok(())
+            }
+            // ──── elementwise binary (float-required) ────
+            Op::Div { lhs, rhs, output }
+            | Op::Pow { lhs, rhs, output } => {
+                self.check_elem_binary(i, *lhs, *rhs, *output, true)?;
+                Ok(())
+            }
+
+            // ──── reductions ────
+            Op::ReduceSum {
+                input,
+                axes,
+                keep_dims,
+                output,
+            }
+            | Op::ReduceMax {
+                input,
+                axes,
+                keep_dims,
+                output,
+            }
+            | Op::ReduceMean {
+                input,
+                axes,
+                keep_dims,
+                output,
+            } => {
+                let inp = self.must_tensor(i, *input)?;
+                let rank = inp.shape.rank() as u32;
+                for &a in axes {
+                    if a >= rank {
+                        return Err(IrError::InvalidAxis {
+                            op_index: i,
+                            axis: a,
+                            rank,
+                        });
+                    }
+                }
+                let expected_shape = reduce_shape(&inp.shape, axes, *keep_dims);
+                self.expect_output(i, *output, &inp.dtype, &expected_shape)?;
+                Ok(())
+            }
+
+            // ──── shape ────
+            Op::Reshape {
+                input,
+                new_shape,
+                output,
+            } => {
+                let inp = self.must_tensor(i, *input)?;
+                let in_n = inp.shape.numel().unwrap_or(0);
+                let out_n = new_shape.numel().unwrap_or(0);
+                if in_n != out_n {
+                    return Err(IrError::NumelMismatch {
+                        op_index: i,
+                        expected: in_n,
+                        actual: out_n,
+                    });
+                }
+                self.expect_output(i, *output, &inp.dtype, new_shape)?;
+                Ok(())
+            }
+            Op::Transpose {
+                input,
+                perm,
+                output,
+            } => {
+                let inp = self.must_tensor(i, *input)?;
+                if perm.len() != inp.shape.rank() {
+                    return Err(IrError::InvalidPermutation {
+                        op_index: i,
+                        perm: perm.clone(),
+                    });
+                }
+                let mut seen = vec![false; perm.len()];
+                for &p in perm {
+                    let p = p as usize;
+                    if p >= seen.len() || seen[p] {
+                        return Err(IrError::InvalidPermutation {
+                            op_index: i,
+                            perm: perm.clone(),
+                        });
+                    }
+                    seen[p] = true;
+                }
+                let expected_dims: Vec<u32> = perm
+                    .iter()
+                    .map(|&p| inp.shape.dims[p as usize])
+                    .collect();
+                self.expect_output(
+                    i,
+                    *output,
+                    &inp.dtype,
+                    &Shape { dims: expected_dims },
+                )?;
+                Ok(())
+            }
+            Op::Broadcast {
+                input,
+                target_shape,
+                output,
+            } => {
+                let inp = self.must_tensor(i, *input)?;
+                if inp.shape.rank() != target_shape.rank() {
+                    return Err(IrError::InvalidBroadcast {
+                        op_index: i,
+                        from: inp.shape.clone(),
+                        to: target_shape.clone(),
+                    });
+                }
+                for (a, b) in inp.shape.dims.iter().zip(target_shape.dims.iter()) {
+                    if !(a == b || *a == 1) {
+                        return Err(IrError::InvalidBroadcast {
+                            op_index: i,
+                            from: inp.shape.clone(),
+                            to: target_shape.clone(),
+                        });
+                    }
+                }
+                self.expect_output(i, *output, &inp.dtype, target_shape)?;
+                Ok(())
+            }
+
+            // ──── linalg ────
+            Op::MatMul { a, b, output } => {
+                let ta = self.must_tensor(i, *a)?;
+                let tb = self.must_tensor(i, *b)?;
+                if ta.shape.rank() != 2 {
+                    return Err(IrError::BadMatMulRank {
+                        op_index: i,
+                        which: "a",
+                        rank: ta.shape.rank() as u32,
+                    });
+                }
+                if tb.shape.rank() != 2 {
+                    return Err(IrError::BadMatMulRank {
+                        op_index: i,
+                        which: "b",
+                        rank: tb.shape.rank() as u32,
+                    });
+                }
+                if ta.dtype != tb.dtype {
+                    return Err(IrError::DTypeMismatch {
+                        op_index: i,
+                        expected: ta.dtype,
+                        actual: tb.dtype,
+                    });
+                }
+                let (m, k1) = (ta.shape.dims[0], ta.shape.dims[1]);
+                let (k2, n) = (tb.shape.dims[0], tb.shape.dims[1]);
+                if k1 != k2 {
+                    return Err(IrError::ShapeMismatch {
+                        op_index: i,
+                        expected: Shape::from(&[k1, n]),
+                        actual: Shape::from(&[k2, n]),
+                    });
+                }
+                self.expect_output(i, *output, &ta.dtype, &Shape::from(&[m, n]))?;
+                Ok(())
+            }
+
+            // ──── comparison ────
+            Op::Equal { lhs, rhs, output }
+            | Op::Less { lhs, rhs, output }
+            | Op::Greater { lhs, rhs, output } => {
+                let l = self.must_tensor(i, *lhs)?;
+                let r = self.must_tensor(i, *rhs)?;
+                if l.dtype != r.dtype {
+                    return Err(IrError::DTypeMismatch {
+                        op_index: i,
+                        expected: l.dtype,
+                        actual: r.dtype,
+                    });
+                }
+                if l.shape != r.shape {
+                    return Err(IrError::ShapeMismatch {
+                        op_index: i,
+                        expected: l.shape.clone(),
+                        actual: r.shape.clone(),
+                    });
+                }
+                self.expect_output(i, *output, &DType::U8, &l.shape)?;
+                Ok(())
+            }
+
+            // ──── selection ────
+            Op::Where {
+                predicate,
+                true_value,
+                false_value,
+                output,
+            } => {
+                let p = self.must_tensor(i, *predicate)?;
+                let t = self.must_tensor(i, *true_value)?;
+                let f = self.must_tensor(i, *false_value)?;
+                if p.dtype != DType::U8 {
+                    return Err(IrError::NonU8Predicate {
+                        op_index: i,
+                        dtype: p.dtype,
+                    });
+                }
+                if p.shape != t.shape {
+                    return Err(IrError::ShapeMismatch {
+                        op_index: i,
+                        expected: t.shape.clone(),
+                        actual: p.shape.clone(),
+                    });
+                }
+                if t.shape != f.shape {
+                    return Err(IrError::ShapeMismatch {
+                        op_index: i,
+                        expected: t.shape.clone(),
+                        actual: f.shape.clone(),
+                    });
+                }
+                if t.dtype != f.dtype {
+                    return Err(IrError::DTypeMismatch {
+                        op_index: i,
+                        expected: t.dtype,
+                        actual: f.dtype,
+                    });
+                }
+                self.expect_output(i, *output, &t.dtype, &t.shape)?;
+                Ok(())
+            }
+
+            // ──── conversion ────
+            Op::Cast {
+                input,
+                dtype,
+                output,
+            } => {
+                let inp = self.must_tensor(i, *input)?;
+                self.expect_output(i, *output, dtype, &inp.shape)?;
+                Ok(())
+            }
+
+            // ──── constants ────
+            Op::Const { constant, output } => {
+                let c = self.constants.get(*constant as usize).ok_or(
+                    IrError::UndefinedConstant {
+                        op_index: i,
+                        constant: *constant,
+                    },
+                )?;
+                let out = self.must_tensor(i, *output)?;
+                if c.tensor.dtype != out.dtype || c.tensor.shape != out.shape {
+                    return Err(IrError::ConstantTensorMismatch {
+                        op_index: i,
+                        constant_index: *constant,
+                    });
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn must_tensor(&self, op_index: u32, id: TensorId) -> Result<&Tensor, IrError> {
+        self.tensors
+            .get(id.0 as usize)
+            .ok_or(IrError::UndefinedTensor {
+                op_index,
+                tensor: id,
+            })
+    }
+
+    /// Verify that the declared output tensor matches `(dtype, shape)`.
+    fn expect_output(
+        &self,
+        op_index: u32,
+        out_id: TensorId,
+        dtype: &DType,
+        shape: &Shape,
+    ) -> Result<(), IrError> {
+        let out = self.must_tensor(op_index, out_id)?;
+        if &out.dtype != dtype || &out.shape != shape {
+            return Err(IrError::OutputMismatch {
+                op_index,
+                expected: Tensor::new(out_id, *dtype, shape.clone()),
+                actual: out.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn check_elem_binary(
+        &self,
+        i: u32,
+        lhs: TensorId,
+        rhs: TensorId,
+        output: TensorId,
+        require_float: bool,
+    ) -> Result<(), IrError> {
+        let l = self.must_tensor(i, lhs)?;
+        let r = self.must_tensor(i, rhs)?;
+        if l.dtype != r.dtype {
+            return Err(IrError::DTypeMismatch {
+                op_index: i,
+                expected: l.dtype,
+                actual: r.dtype,
+            });
+        }
+        if l.shape != r.shape {
+            return Err(IrError::ShapeMismatch {
+                op_index: i,
+                expected: l.shape.clone(),
+                actual: r.shape.clone(),
+            });
+        }
+        if require_float && l.dtype != DType::F32 {
+            return Err(IrError::NonFloatDType {
+                op_index: i,
+                op_name: "binary-float-op",
+                dtype: l.dtype,
+            });
+        }
+        self.expect_output(i, output, &l.dtype, &l.shape)?;
+        Ok(())
+    }
+}
+
+fn op_name(op: &Op) -> &'static str {
+    match op {
+        Op::Neg { .. } => "neg",
+        Op::Abs { .. } => "abs",
+        Op::Sqrt { .. } => "sqrt",
+        Op::Exp { .. } => "exp",
+        Op::Log { .. } => "log",
+        Op::Tanh { .. } => "tanh",
+        Op::Recip { .. } => "recip",
+        Op::Add { .. } => "add",
+        Op::Sub { .. } => "sub",
+        Op::Mul { .. } => "mul",
+        Op::Div { .. } => "div",
+        Op::Max { .. } => "max",
+        Op::Min { .. } => "min",
+        Op::Pow { .. } => "pow",
+        Op::ReduceSum { .. } => "reduce_sum",
+        Op::ReduceMax { .. } => "reduce_max",
+        Op::ReduceMean { .. } => "reduce_mean",
+        Op::Reshape { .. } => "reshape",
+        Op::Transpose { .. } => "transpose",
+        Op::Broadcast { .. } => "broadcast",
+        Op::MatMul { .. } => "matmul",
+        Op::Equal { .. } => "equal",
+        Op::Less { .. } => "less",
+        Op::Greater { .. } => "greater",
+        Op::Where { .. } => "where",
+        Op::Cast { .. } => "cast",
+        Op::Const { .. } => "const",
+    }
+}

--- a/code/packages/rust/matrix-ir/src/wire.rs
+++ b/code/packages/rust/matrix-ir/src/wire.rs
@@ -247,6 +247,27 @@ fn encode_op(op: &Op, w: &mut Writer<'_>) {
 
 // ─────────────────────────── decoder ───────────────────────────
 
+/// Cap a pre-allocation against what the input could possibly contain.
+///
+/// `n` is the attacker-supplied count.  `min_elem_bytes` is the smallest
+/// number of payload bytes any single element of this kind can occupy.
+/// `remaining` is the number of bytes still in the input buffer.
+///
+/// We return `min(n, remaining / min_elem_bytes)`.  This means an
+/// attacker who claims `n = 2^60` but only sends 50 bytes can make us
+/// allocate at most `50 / min_elem_bytes` slots — bounded by what the
+/// input could actually fill.  Push() will still grow the Vec further
+/// when the legitimate data exceeds the cap, but the initial allocation
+/// can no longer be amplified arbitrarily.
+fn bounded_capacity(n: u64, min_elem_bytes: usize, remaining: usize) -> usize {
+    let max_possible = remaining / min_elem_bytes.max(1);
+    if n > max_possible as u64 {
+        max_possible
+    } else {
+        n as usize
+    }
+}
+
 pub(crate) struct Reader<'a> {
     buf: &'a [u8],
     pos: usize,
@@ -258,11 +279,23 @@ impl<'a> Reader<'a> {
     }
 
     fn need(&self, n: usize) -> Result<(), IrError> {
-        if self.pos + n > self.buf.len() {
+        // checked_add guards against pos+n overflowing usize on 32-bit
+        // targets when n was decoded from an attacker-controlled varint.
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or(IrError::WireUnexpectedEof)?;
+        if end > self.buf.len() {
             Err(IrError::WireUnexpectedEof)
         } else {
             Ok(())
         }
+    }
+
+    /// Bytes remaining after the cursor.  Used by the bounded-capacity
+    /// helper to cap pre-allocations against the actual payload size.
+    pub(crate) fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
     }
 
     pub(crate) fn u8(&mut self) -> Result<u8, IrError> {
@@ -296,7 +329,13 @@ impl<'a> Reader<'a> {
     }
 
     pub(crate) fn bytes(&mut self) -> Result<Vec<u8>, IrError> {
-        let len = self.uv64()? as usize;
+        let len_u64 = self.uv64()?;
+        // On 32-bit targets, a u64 length can exceed usize::MAX; reject
+        // explicitly rather than silently truncating with `as usize`.
+        if len_u64 > usize::MAX as u64 {
+            return Err(IrError::WireUnexpectedEof);
+        }
+        let len = len_u64 as usize;
         self.need(len)?;
         let v = self.buf[self.pos..self.pos + len].to_vec();
         self.pos += len;
@@ -318,32 +357,44 @@ pub(crate) fn decode_graph(buf: &[u8]) -> Result<Graph, IrError> {
         return Err(IrError::WireUnsupportedVersion(version));
     }
 
-    let n_tensors = r.uv64()? as usize;
-    let mut tensors = Vec::with_capacity(n_tensors);
+    // Each pre-allocation is capped against the bytes still available
+    // in the buffer, so an attacker cannot amplify a small payload into
+    // a huge initial Vec allocation.  Min element sizes:
+    //   - Tensor:    u32 id (4) + u8 dtype (1) + uv64 rank (≥1) = 6 bytes
+    //   - TensorId:  u32 = 4 bytes
+    //   - Op:        u8 tag (≥1) — the smallest var, Const, is 9 bytes
+    //   - Constant:  Tensor (6) + uv64 byte_length (≥1) = 7 bytes
+    let n_tensors = r.uv64()?;
+    let cap = bounded_capacity(n_tensors, 6, r.remaining());
+    let mut tensors = Vec::with_capacity(cap);
     for _ in 0..n_tensors {
         tensors.push(decode_tensor(&mut r)?);
     }
 
-    let n_inputs = r.uv64()? as usize;
-    let mut inputs = Vec::with_capacity(n_inputs);
+    let n_inputs = r.uv64()?;
+    let cap = bounded_capacity(n_inputs, 6, r.remaining());
+    let mut inputs = Vec::with_capacity(cap);
     for _ in 0..n_inputs {
         inputs.push(decode_tensor(&mut r)?);
     }
 
-    let n_outputs = r.uv64()? as usize;
-    let mut outputs = Vec::with_capacity(n_outputs);
+    let n_outputs = r.uv64()?;
+    let cap = bounded_capacity(n_outputs, 4, r.remaining());
+    let mut outputs = Vec::with_capacity(cap);
     for _ in 0..n_outputs {
         outputs.push(TensorId(r.u32()?));
     }
 
-    let n_ops = r.uv64()? as usize;
-    let mut ops = Vec::with_capacity(n_ops);
+    let n_ops = r.uv64()?;
+    let cap = bounded_capacity(n_ops, 1, r.remaining());
+    let mut ops = Vec::with_capacity(cap);
     for _ in 0..n_ops {
         ops.push(decode_op(&mut r)?);
     }
 
-    let n_constants = r.uv64()? as usize;
-    let mut constants = Vec::with_capacity(n_constants);
+    let n_constants = r.uv64()?;
+    let cap = bounded_capacity(n_constants, 7, r.remaining());
+    let mut constants = Vec::with_capacity(cap);
     for _ in 0..n_constants {
         constants.push(decode_constant(&mut r)?);
     }
@@ -373,8 +424,10 @@ fn decode_tensor(r: &mut Reader<'_>) -> Result<Tensor, IrError> {
 }
 
 fn decode_shape(r: &mut Reader<'_>) -> Result<Shape, IrError> {
-    let n = r.uv64()? as usize;
-    let mut dims = Vec::with_capacity(n);
+    let n = r.uv64()?;
+    // Each dim is u32 = 4 bytes.
+    let cap = bounded_capacity(n, 4, r.remaining());
+    let mut dims = Vec::with_capacity(cap);
     for _ in 0..n {
         dims.push(r.u32()?);
     }
@@ -487,8 +540,10 @@ fn decode_op(r: &mut Reader<'_>) -> Result<Op, IrError> {
         }
         0x12 => {
             let input = TensorId(r.u32()?);
-            let n = r.uv64()? as usize;
-            let mut perm = Vec::with_capacity(n);
+            let n = r.uv64()?;
+            // Each perm element is u32 = 4 bytes.
+            let cap = bounded_capacity(n, 4, r.remaining());
+            let mut perm = Vec::with_capacity(cap);
             for _ in 0..n {
                 perm.push(r.u32()?);
             }
@@ -568,8 +623,10 @@ fn decode_reduction(
     ctor: fn(TensorId, Vec<u32>, bool, TensorId) -> Op,
 ) -> Result<Op, IrError> {
     let input = TensorId(r.u32()?);
-    let n_axes = r.uv64()? as usize;
-    let mut axes = Vec::with_capacity(n_axes);
+    let n_axes = r.uv64()?;
+    // Each axis is u32 = 4 bytes.
+    let cap = bounded_capacity(n_axes, 4, r.remaining());
+    let mut axes = Vec::with_capacity(cap);
     for _ in 0..n_axes {
         axes.push(r.u32()?);
     }
@@ -590,9 +647,25 @@ impl Graph {
     }
 
     /// Deserialise a graph from bytes.  The bytes must consist of
-    /// exactly one graph; trailing bytes are an error.  The decoded
-    /// graph is *not* automatically validated; call [`Graph::validate`]
-    /// if you want semantic checks.
+    /// exactly one graph; trailing bytes are an error.
+    ///
+    /// # Security note
+    ///
+    /// `from_bytes` performs **structural** decoding only — it does
+    /// not call [`Graph::validate`].  When deserialising untrusted
+    /// input (e.g. a remote executor's wire payload):
+    ///
+    /// 1. Cap the size of `buf` *before* calling this function.  A
+    ///    sensible default for V1 is `16 MiB`; tune up only if real
+    ///    workloads need more.  Without a cap the decoder still
+    ///    terminates in linear time (`Vec::with_capacity` is bounded
+    ///    against the input length, and the per-element loop fails
+    ///    fast on truncation), but a 1 GB legitimate-looking payload
+    ///    will allocate 1 GB.
+    /// 2. Always call [`Graph::validate`] on the result before using
+    ///    it.  An attacker can construct a structurally-decodable
+    ///    graph that fails semantic checks (e.g. constant byte length
+    ///    not matching declared shape).
     pub fn from_bytes(buf: &[u8]) -> Result<Graph, IrError> {
         decode_graph(buf)
     }

--- a/code/packages/rust/matrix-ir/src/wire.rs
+++ b/code/packages/rust/matrix-ir/src/wire.rs
@@ -1,0 +1,640 @@
+//! Hand-rolled binary wire format for [`Graph`].
+//!
+//! See spec MX03 §"Wire format primitives".  The format is implementation-
+//! agnostic; this is just the Rust encoder/decoder.  A Python or
+//! JavaScript port that follows the spec produces interchangeable bytes.
+//!
+//! ## Primitives
+//!
+//! | name   | encoding |
+//! |--------|----------|
+//! | `u8`   | 1 byte |
+//! | `u16`  | 2 bytes LE |
+//! | `u32`  | 4 bytes LE |
+//! | `u64`  | 8 bytes LE |
+//! | `uv64` | varint, 7 bits/byte, top bit means "more bytes follow" |
+//! | `bytes`| `uv64` length + raw bytes |
+//! | `str`  | `bytes`, validated UTF-8 |
+//! | `enum` | `uv64` tag + variant payload |
+//! | `vec<T>` | `uv64` count + count instances of T |
+//!
+//! ## Top-level `Graph` layout
+//!
+//! ```text
+//! u32         format_version              // = WIRE_FORMAT_VERSION
+//! vec<Tensor> tensors
+//! vec<Tensor> inputs                       // (full Tensor records)
+//! vec<TensorId> outputs                    // u32 ids
+//! vec<Op>      ops
+//! vec<Constant> constants
+//! ```
+//!
+//! No frame header / no payload length — the caller supplies a slice
+//! and we either parse it all or fail.  The MX03 message-level frame
+//! lives in `executor-protocol` and adds versioning and length
+//! prefixing on top of this.
+
+use crate::graph::{Constant, Graph};
+use crate::op::Op;
+use crate::tensor::{DType, Shape, Tensor, TensorId};
+use crate::validate::IrError;
+use crate::WIRE_FORMAT_VERSION;
+
+// ─────────────────────────── encoder ───────────────────────────
+
+/// Streaming writer that appends to a `Vec<u8>`.  Owns no state beyond
+/// the buffer; encoding is straight-line append.
+pub(crate) struct Writer<'a> {
+    out: &'a mut Vec<u8>,
+}
+
+impl<'a> Writer<'a> {
+    pub(crate) fn new(out: &'a mut Vec<u8>) -> Self {
+        Writer { out }
+    }
+
+    pub(crate) fn u8(&mut self, v: u8) {
+        self.out.push(v);
+    }
+    pub(crate) fn u32(&mut self, v: u32) {
+        self.out.extend_from_slice(&v.to_le_bytes());
+    }
+    pub(crate) fn u64(&mut self, v: u64) {
+        self.out.extend_from_slice(&v.to_le_bytes());
+    }
+    /// LEB128-style unsigned varint.
+    pub(crate) fn uv64(&mut self, mut v: u64) {
+        while v >= 0x80 {
+            self.out.push(((v as u8) & 0x7F) | 0x80);
+            v >>= 7;
+        }
+        self.out.push(v as u8);
+    }
+    pub(crate) fn bytes(&mut self, b: &[u8]) {
+        self.uv64(b.len() as u64);
+        self.out.extend_from_slice(b);
+    }
+}
+
+/// Encode a complete graph into bytes.  Round-trips with [`decode_graph`].
+pub(crate) fn encode_graph(g: &Graph, out: &mut Vec<u8>) {
+    let mut w = Writer::new(out);
+    w.u32(WIRE_FORMAT_VERSION);
+
+    // tensors
+    w.uv64(g.tensors.len() as u64);
+    for t in &g.tensors {
+        encode_tensor(t, &mut w);
+    }
+
+    // inputs (full Tensor records)
+    w.uv64(g.inputs.len() as u64);
+    for t in &g.inputs {
+        encode_tensor(t, &mut w);
+    }
+
+    // outputs (ids only)
+    w.uv64(g.outputs.len() as u64);
+    for id in &g.outputs {
+        w.u32(id.0);
+    }
+
+    // ops
+    w.uv64(g.ops.len() as u64);
+    for op in &g.ops {
+        encode_op(op, &mut w);
+    }
+
+    // constants
+    w.uv64(g.constants.len() as u64);
+    for c in &g.constants {
+        encode_constant(c, &mut w);
+    }
+}
+
+fn encode_tensor(t: &Tensor, w: &mut Writer<'_>) {
+    w.u32(t.id.0);
+    w.u8(t.dtype.wire_tag());
+    encode_shape(&t.shape, w);
+}
+
+fn encode_shape(s: &Shape, w: &mut Writer<'_>) {
+    w.uv64(s.dims.len() as u64);
+    for &d in &s.dims {
+        w.u32(d);
+    }
+}
+
+fn encode_constant(c: &Constant, w: &mut Writer<'_>) {
+    encode_tensor(&c.tensor, w);
+    w.bytes(&c.bytes);
+}
+
+fn encode_op(op: &Op, w: &mut Writer<'_>) {
+    w.u8(op.wire_tag());
+    match op {
+        Op::Neg { input, output }
+        | Op::Abs { input, output }
+        | Op::Sqrt { input, output }
+        | Op::Exp { input, output }
+        | Op::Log { input, output }
+        | Op::Tanh { input, output }
+        | Op::Recip { input, output } => {
+            w.u32(input.0);
+            w.u32(output.0);
+        }
+        Op::Add { lhs, rhs, output }
+        | Op::Sub { lhs, rhs, output }
+        | Op::Mul { lhs, rhs, output }
+        | Op::Div { lhs, rhs, output }
+        | Op::Max { lhs, rhs, output }
+        | Op::Min { lhs, rhs, output }
+        | Op::Pow { lhs, rhs, output }
+        | Op::Equal { lhs, rhs, output }
+        | Op::Less { lhs, rhs, output }
+        | Op::Greater { lhs, rhs, output } => {
+            w.u32(lhs.0);
+            w.u32(rhs.0);
+            w.u32(output.0);
+        }
+        Op::ReduceSum {
+            input,
+            axes,
+            keep_dims,
+            output,
+        }
+        | Op::ReduceMax {
+            input,
+            axes,
+            keep_dims,
+            output,
+        }
+        | Op::ReduceMean {
+            input,
+            axes,
+            keep_dims,
+            output,
+        } => {
+            w.u32(input.0);
+            w.uv64(axes.len() as u64);
+            for &a in axes {
+                w.u32(a);
+            }
+            w.u8(if *keep_dims { 1 } else { 0 });
+            w.u32(output.0);
+        }
+        Op::Reshape {
+            input,
+            new_shape,
+            output,
+        } => {
+            w.u32(input.0);
+            encode_shape(new_shape, w);
+            w.u32(output.0);
+        }
+        Op::Transpose {
+            input,
+            perm,
+            output,
+        } => {
+            w.u32(input.0);
+            w.uv64(perm.len() as u64);
+            for &p in perm {
+                w.u32(p);
+            }
+            w.u32(output.0);
+        }
+        Op::Broadcast {
+            input,
+            target_shape,
+            output,
+        } => {
+            w.u32(input.0);
+            encode_shape(target_shape, w);
+            w.u32(output.0);
+        }
+        Op::MatMul { a, b, output } => {
+            w.u32(a.0);
+            w.u32(b.0);
+            w.u32(output.0);
+        }
+        Op::Where {
+            predicate,
+            true_value,
+            false_value,
+            output,
+        } => {
+            w.u32(predicate.0);
+            w.u32(true_value.0);
+            w.u32(false_value.0);
+            w.u32(output.0);
+        }
+        Op::Cast {
+            input,
+            dtype,
+            output,
+        } => {
+            w.u32(input.0);
+            w.u8(dtype.wire_tag());
+            w.u32(output.0);
+        }
+        Op::Const { constant, output } => {
+            w.u32(*constant);
+            w.u32(output.0);
+        }
+    }
+}
+
+// ─────────────────────────── decoder ───────────────────────────
+
+pub(crate) struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    pub(crate) fn new(buf: &'a [u8]) -> Self {
+        Reader { buf, pos: 0 }
+    }
+
+    fn need(&self, n: usize) -> Result<(), IrError> {
+        if self.pos + n > self.buf.len() {
+            Err(IrError::WireUnexpectedEof)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn u8(&mut self) -> Result<u8, IrError> {
+        self.need(1)?;
+        let v = self.buf[self.pos];
+        self.pos += 1;
+        Ok(v)
+    }
+
+    pub(crate) fn u32(&mut self) -> Result<u32, IrError> {
+        self.need(4)?;
+        let v = u32::from_le_bytes(self.buf[self.pos..self.pos + 4].try_into().unwrap());
+        self.pos += 4;
+        Ok(v)
+    }
+
+    /// Read an unsigned varint (LEB128).  Bounded at 10 bytes to prevent
+    /// pathological inputs from causing unbounded reads.
+    pub(crate) fn uv64(&mut self) -> Result<u64, IrError> {
+        let mut acc: u64 = 0;
+        let mut shift = 0u32;
+        for _ in 0..10 {
+            let b = self.u8()?;
+            acc |= ((b & 0x7F) as u64) << shift;
+            if b & 0x80 == 0 {
+                return Ok(acc);
+            }
+            shift += 7;
+        }
+        Err(IrError::WireOversizedVarint)
+    }
+
+    pub(crate) fn bytes(&mut self) -> Result<Vec<u8>, IrError> {
+        let len = self.uv64()? as usize;
+        self.need(len)?;
+        let v = self.buf[self.pos..self.pos + len].to_vec();
+        self.pos += len;
+        Ok(v)
+    }
+
+    pub(crate) fn at_end(&self) -> bool {
+        self.pos == self.buf.len()
+    }
+}
+
+/// Decode a complete graph from bytes.  Errors out if the input is
+/// truncated, contains unknown tags, or has trailing bytes after a
+/// successful parse.
+pub(crate) fn decode_graph(buf: &[u8]) -> Result<Graph, IrError> {
+    let mut r = Reader::new(buf);
+    let version = r.u32()?;
+    if version != WIRE_FORMAT_VERSION {
+        return Err(IrError::WireUnsupportedVersion(version));
+    }
+
+    let n_tensors = r.uv64()? as usize;
+    let mut tensors = Vec::with_capacity(n_tensors);
+    for _ in 0..n_tensors {
+        tensors.push(decode_tensor(&mut r)?);
+    }
+
+    let n_inputs = r.uv64()? as usize;
+    let mut inputs = Vec::with_capacity(n_inputs);
+    for _ in 0..n_inputs {
+        inputs.push(decode_tensor(&mut r)?);
+    }
+
+    let n_outputs = r.uv64()? as usize;
+    let mut outputs = Vec::with_capacity(n_outputs);
+    for _ in 0..n_outputs {
+        outputs.push(TensorId(r.u32()?));
+    }
+
+    let n_ops = r.uv64()? as usize;
+    let mut ops = Vec::with_capacity(n_ops);
+    for _ in 0..n_ops {
+        ops.push(decode_op(&mut r)?);
+    }
+
+    let n_constants = r.uv64()? as usize;
+    let mut constants = Vec::with_capacity(n_constants);
+    for _ in 0..n_constants {
+        constants.push(decode_constant(&mut r)?);
+    }
+
+    if !r.at_end() {
+        return Err(IrError::WireTrailingBytes);
+    }
+
+    Ok(Graph {
+        inputs,
+        outputs,
+        ops,
+        tensors,
+        constants,
+    })
+}
+
+fn decode_tensor(r: &mut Reader<'_>) -> Result<Tensor, IrError> {
+    let id = TensorId(r.u32()?);
+    let dtype_tag = r.u8()?;
+    let dtype = DType::from_wire_tag(dtype_tag).ok_or(IrError::WireUnknownTag {
+        what: "dtype",
+        tag: dtype_tag as u64,
+    })?;
+    let shape = decode_shape(r)?;
+    Ok(Tensor::new(id, dtype, shape))
+}
+
+fn decode_shape(r: &mut Reader<'_>) -> Result<Shape, IrError> {
+    let n = r.uv64()? as usize;
+    let mut dims = Vec::with_capacity(n);
+    for _ in 0..n {
+        dims.push(r.u32()?);
+    }
+    Ok(Shape { dims })
+}
+
+fn decode_constant(r: &mut Reader<'_>) -> Result<Constant, IrError> {
+    let tensor = decode_tensor(r)?;
+    let bytes = r.bytes()?;
+    Ok(Constant { tensor, bytes })
+}
+
+fn decode_op(r: &mut Reader<'_>) -> Result<Op, IrError> {
+    let tag = r.u8()?;
+    match tag {
+        // unary
+        0x00 => Ok(Op::Neg {
+            input: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x01 => Ok(Op::Abs {
+            input: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x02 => Ok(Op::Sqrt {
+            input: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x03 => Ok(Op::Exp {
+            input: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x04 => Ok(Op::Log {
+            input: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x05 => Ok(Op::Tanh {
+            input: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x06 => Ok(Op::Recip {
+            input: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        // binary
+        0x07 => Ok(Op::Add {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x08 => Ok(Op::Sub {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x09 => Ok(Op::Mul {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x0A => Ok(Op::Div {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x0B => Ok(Op::Max {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x0C => Ok(Op::Min {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x0D => Ok(Op::Pow {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        // reductions
+        0x0E => decode_reduction(r, |i, ax, kd, o| Op::ReduceSum {
+            input: i,
+            axes: ax,
+            keep_dims: kd,
+            output: o,
+        }),
+        0x0F => decode_reduction(r, |i, ax, kd, o| Op::ReduceMax {
+            input: i,
+            axes: ax,
+            keep_dims: kd,
+            output: o,
+        }),
+        0x10 => decode_reduction(r, |i, ax, kd, o| Op::ReduceMean {
+            input: i,
+            axes: ax,
+            keep_dims: kd,
+            output: o,
+        }),
+        // shape
+        0x11 => {
+            let input = TensorId(r.u32()?);
+            let new_shape = decode_shape(r)?;
+            let output = TensorId(r.u32()?);
+            Ok(Op::Reshape {
+                input,
+                new_shape,
+                output,
+            })
+        }
+        0x12 => {
+            let input = TensorId(r.u32()?);
+            let n = r.uv64()? as usize;
+            let mut perm = Vec::with_capacity(n);
+            for _ in 0..n {
+                perm.push(r.u32()?);
+            }
+            let output = TensorId(r.u32()?);
+            Ok(Op::Transpose {
+                input,
+                perm,
+                output,
+            })
+        }
+        0x13 => {
+            let input = TensorId(r.u32()?);
+            let target_shape = decode_shape(r)?;
+            let output = TensorId(r.u32()?);
+            Ok(Op::Broadcast {
+                input,
+                target_shape,
+                output,
+            })
+        }
+        // 0x14 reserved
+        0x15 => Ok(Op::MatMul {
+            a: TensorId(r.u32()?),
+            b: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x16 => Ok(Op::Equal {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x17 => Ok(Op::Less {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x18 => Ok(Op::Greater {
+            lhs: TensorId(r.u32()?),
+            rhs: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x19 => Ok(Op::Where {
+            predicate: TensorId(r.u32()?),
+            true_value: TensorId(r.u32()?),
+            false_value: TensorId(r.u32()?),
+            output: TensorId(r.u32()?),
+        }),
+        0x1A => {
+            let input = TensorId(r.u32()?);
+            let dtype_tag = r.u8()?;
+            let dtype = DType::from_wire_tag(dtype_tag).ok_or(
+                IrError::WireUnknownTag {
+                    what: "dtype",
+                    tag: dtype_tag as u64,
+                },
+            )?;
+            let output = TensorId(r.u32()?);
+            Ok(Op::Cast {
+                input,
+                dtype,
+                output,
+            })
+        }
+        0x1B => Ok(Op::Const {
+            constant: r.u32()?,
+            output: TensorId(r.u32()?),
+        }),
+        unknown => Err(IrError::WireUnknownTag {
+            what: "op",
+            tag: unknown as u64,
+        }),
+    }
+}
+
+fn decode_reduction(
+    r: &mut Reader<'_>,
+    ctor: fn(TensorId, Vec<u32>, bool, TensorId) -> Op,
+) -> Result<Op, IrError> {
+    let input = TensorId(r.u32()?);
+    let n_axes = r.uv64()? as usize;
+    let mut axes = Vec::with_capacity(n_axes);
+    for _ in 0..n_axes {
+        axes.push(r.u32()?);
+    }
+    let keep_dims = r.u8()? != 0;
+    let output = TensorId(r.u32()?);
+    Ok(ctor(input, axes, keep_dims, output))
+}
+
+// ─────────────────────────── public API ───────────────────────────
+
+impl Graph {
+    /// Serialise the graph to bytes.  See spec MX03 for the byte
+    /// layout.  Round-trips with [`from_bytes`](Graph::from_bytes).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(64);
+        encode_graph(self, &mut out);
+        out
+    }
+
+    /// Deserialise a graph from bytes.  The bytes must consist of
+    /// exactly one graph; trailing bytes are an error.  The decoded
+    /// graph is *not* automatically validated; call [`Graph::validate`]
+    /// if you want semantic checks.
+    pub fn from_bytes(buf: &[u8]) -> Result<Graph, IrError> {
+        decode_graph(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn varint_round_trip() {
+        for v in [0u64, 1, 127, 128, 300, 16384, u32::MAX as u64, u64::MAX] {
+            let mut buf = Vec::new();
+            Writer::new(&mut buf).uv64(v);
+            let mut r = Reader::new(&buf);
+            assert_eq!(r.uv64().unwrap(), v);
+            assert!(r.at_end());
+        }
+    }
+
+    #[test]
+    fn varint_oversized_errors() {
+        // 11 bytes all with continuation bit -> WireOversizedVarint
+        let buf = vec![0xFF; 11];
+        let mut r = Reader::new(&buf);
+        assert!(matches!(r.uv64(), Err(IrError::WireOversizedVarint)));
+    }
+
+    #[test]
+    fn truncation_returns_eof() {
+        // u32 needs 4 bytes; supplying 3 should fail.
+        let buf = vec![0u8; 3];
+        let mut r = Reader::new(&buf);
+        assert!(matches!(r.u32(), Err(IrError::WireUnexpectedEof)));
+    }
+
+    #[test]
+    fn decode_unsupported_version_errors() {
+        // Encode a fake header with a future version.
+        let mut buf = Vec::new();
+        Writer::new(&mut buf).u32(99);
+        let result = decode_graph(&buf);
+        assert!(matches!(result, Err(IrError::WireUnsupportedVersion(99))));
+    }
+}

--- a/code/packages/rust/matrix-ir/tests/integration.rs
+++ b/code/packages/rust/matrix-ir/tests/integration.rs
@@ -533,6 +533,70 @@ fn round_trip_cast() {
 
 // ─────────────────── 4. Coverage gate ───────────────────
 
+// ─────────────────── Wire decoder hardening ───────────────────
+
+/// A varint claiming `n_tensors = u64::MAX` with no actual data must
+/// not OOM the process.  The decoder caps Vec::with_capacity against
+/// remaining buffer bytes, so the allocation is bounded and the loop
+/// short-circuits via WireUnexpectedEof.
+#[test]
+fn decoder_amplification_attack_is_bounded() {
+    // Format version (4 bytes) + 10-byte uv64 of u64::MAX.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&matrix_ir::WIRE_FORMAT_VERSION.to_le_bytes());
+    // Encode u64::MAX as varint (10 bytes).
+    let mut v = u64::MAX;
+    while v >= 0x80 {
+        buf.push(((v as u8) & 0x7F) | 0x80);
+        v >>= 7;
+    }
+    buf.push(v as u8);
+    // Now we claim n_tensors = u64::MAX but supplied no tensor data.
+    // The decoder must NOT pre-allocate Vec<Tensor>(u64::MAX) — it
+    // should bound capacity against remaining=0 and fail fast.
+    let result = Graph::from_bytes(&buf);
+    assert!(matches!(result, Err(IrError::WireUnexpectedEof)));
+}
+
+/// Truncating a valid encoding at every byte position must produce a
+/// clean error, never a panic.
+#[test]
+fn truncation_at_every_position_does_not_panic() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[2, 3]));
+    let _ = g.neg(&x);
+    let g = g.build().unwrap();
+    let bytes = g.to_bytes();
+
+    for cut in 0..bytes.len() {
+        let truncated = &bytes[..cut];
+        // Must return Err, never panic.
+        let _ = Graph::from_bytes(truncated);
+    }
+}
+
+/// Random byte fuzzing — feed deterministic random bytes into the
+/// decoder and assert it never panics.  This is a smoke test, not a
+/// proof; a real fuzzer would catch more.
+#[test]
+fn fuzz_random_bytes_do_not_panic() {
+    // Simple linear congruential RNG so the test is deterministic and
+    // depends on no external crates.  Per the zero-dependency mandate.
+    let mut state: u64 = 0xCAFEBABE_DEADBEEF;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        state
+    };
+    for _ in 0..1024 {
+        let len = (next() & 0xFF) as usize;
+        let buf: Vec<u8> = (0..len).map(|_| (next() & 0xFF) as u8).collect();
+        // Must return some Result, never panic.
+        let _ = Graph::from_bytes(&buf);
+    }
+}
+
+// ─────────────────── 4. Coverage gate ───────────────────
+
 /// Build a graph that exercises every Op variant.  This serves as the
 /// coverage gate — if a future variant is added without being included
 /// here, the test fails (because we count distinct wire tags and assert

--- a/code/packages/rust/matrix-ir/tests/integration.rs
+++ b/code/packages/rust/matrix-ir/tests/integration.rs
@@ -1,0 +1,593 @@
+//! Integration tests for `matrix-ir`.  Covers:
+//!
+//! 1. **Builder + validate** — representative graphs constructed via the
+//!    builder, validated structurally and semantically.
+//! 2. **Validator rejection** — deliberately malformed graphs, asserted
+//!    to fail with the expected `IrError` variant.
+//! 3. **Wire round-trip** — every graph in the suite is serialised,
+//!    deserialised, asserted equal to the original.
+//! 4. **Coverage gate** — meta-test that confirms the integration suite
+//!    exercises every `Op` variant.
+//!
+//! See spec MX01 §"Test methodology".
+
+use matrix_ir::{Constant, DType, Graph, GraphBuilder, IrError, Op, Shape, Tensor, TensorId};
+
+// ─────────────────── 1. Builder + validate ───────────────────
+
+#[test]
+fn elementwise_unary_chain() {
+    // y = log(exp(neg(abs(x))))
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[4]));
+    let a = g.abs(&x);
+    let b = g.neg(&a);
+    let c = g.exp(&b);
+    let d = g.log(&c);
+    g.output(&d);
+    let g = g.build().unwrap();
+    g.validate().unwrap();
+    assert_eq!(g.ops.len(), 4);
+}
+
+#[test]
+fn elementwise_binary_each() {
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[3]));
+    let b = g.input(DType::F32, Shape::from(&[3]));
+    let _ = g.add(&a, &b);
+    let _ = g.sub(&a, &b);
+    let _ = g.mul(&a, &b);
+    let _ = g.div(&a, &b);
+    let _ = g.max(&a, &b);
+    let _ = g.min(&a, &b);
+    let _ = g.pow(&a, &b);
+    let g = g.build().unwrap();
+    assert_eq!(g.ops.len(), 7);
+    g.validate().unwrap();
+}
+
+#[test]
+fn reduction_each() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[2, 3, 4]));
+    let _ = g.reduce_sum(&x, vec![1], false);
+    let _ = g.reduce_max(&x, vec![1], true);
+    let _ = g.reduce_mean(&x, vec![], false);
+    let g = g.build().unwrap();
+    g.validate().unwrap();
+}
+
+#[test]
+fn shape_ops_each() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[2, 3]));
+    let r = g.reshape(&x, Shape::from(&[6]));
+    let _ = g.reshape(&r, Shape::from(&[6, 1]));
+    let _ = g.transpose(&x, vec![1, 0]);
+    let _ = g.broadcast(&x, Shape::from(&[2, 3]));
+    let g = g.build().unwrap();
+    g.validate().unwrap();
+}
+
+#[test]
+fn matmul_chain() {
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[3, 4]));
+    let b = g.input(DType::F32, Shape::from(&[4, 5]));
+    let c = g.input(DType::F32, Shape::from(&[5, 2]));
+    let ab = g.matmul(&a, &b);
+    let abc = g.matmul(&ab, &c);
+    g.output(&abc);
+    let g = g.build().unwrap();
+    g.validate().unwrap();
+    assert_eq!(g.tensor(abc.id).unwrap().shape, Shape::from(&[3, 2]));
+}
+
+#[test]
+fn comparison_and_where() {
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[3]));
+    let b = g.input(DType::F32, Shape::from(&[3]));
+    let lt = g.less(&a, &b);
+    let _ = g.equal(&a, &b);
+    let _ = g.greater(&a, &b);
+    let r = g.where_(&lt, &a, &b);
+    g.output(&r);
+    let g = g.build().unwrap();
+    g.validate().unwrap();
+    assert_eq!(g.tensor(r.id).unwrap().dtype, DType::F32);
+}
+
+#[test]
+fn cast_round_trip() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[3]));
+    let xi = g.cast(&x, DType::I32);
+    let _ = g.cast(&xi, DType::F32);
+    let g = g.build().unwrap();
+    g.validate().unwrap();
+}
+
+#[test]
+fn constant_basic() {
+    let mut g = GraphBuilder::new();
+    let _ = g.constant(DType::F32, Shape::from(&[2]), vec![0u8; 8]);
+    let g = g.build().unwrap();
+    g.validate().unwrap();
+    assert_eq!(g.constants.len(), 1);
+}
+
+#[test]
+fn relu_layer_full() {
+    // y = relu(x @ w + b) over [1, 4] inputs.
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[1, 4]));
+    let w = g.input(DType::F32, Shape::from(&[4, 2]));
+    let b = g.input(DType::F32, Shape::from(&[1, 2]));
+    let zero = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+    let xw = g.matmul(&x, &w);
+    let xwb = g.add(&xw, &b);
+    let y = g.max(&xwb, &zero);
+    g.output(&y);
+    let g = g.build().unwrap();
+    g.validate().unwrap();
+}
+
+// ─────────────────── 2. Validator rejection ───────────────────
+
+/// Manually construct a graph with a deliberately broken op so we can
+/// exercise the validator's rejection paths.  These cases bypass the
+/// builder's eager checks.
+fn make_graph(tensors: Vec<Tensor>, ops: Vec<Op>, outputs: Vec<TensorId>) -> Graph {
+    Graph {
+        inputs: Vec::new(),
+        outputs,
+        ops,
+        tensors,
+        constants: Vec::new(),
+    }
+}
+
+#[test]
+fn rejects_undefined_tensor_input() {
+    let g = make_graph(
+        vec![Tensor::new(TensorId(0), DType::F32, Shape::from(&[3]))],
+        vec![Op::Neg {
+            input: TensorId(99),
+            output: TensorId(0),
+        }],
+        vec![],
+    );
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::UndefinedTensor { tensor: TensorId(99), .. })
+    ));
+}
+
+#[test]
+fn rejects_shape_mismatch_in_add() {
+    let g = make_graph(
+        vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[4])),
+            Tensor::new(TensorId(2), DType::F32, Shape::from(&[3])),
+        ],
+        vec![Op::Add {
+            lhs: TensorId(0),
+            rhs: TensorId(1),
+            output: TensorId(2),
+        }],
+        vec![],
+    );
+    // Inputs 0/1 aren't defined as inputs, so we'll fail on UndefinedTensor first.
+    // Construct as graph inputs instead.
+    let g = Graph {
+        inputs: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[4])),
+        ],
+        outputs: vec![],
+        ops: vec![Op::Add {
+            lhs: TensorId(0),
+            rhs: TensorId(1),
+            output: TensorId(2),
+        }],
+        tensors: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[4])),
+            Tensor::new(TensorId(2), DType::F32, Shape::from(&[3])),
+        ],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::ShapeMismatch { .. })
+    ));
+}
+
+#[test]
+fn rejects_dtype_mismatch_in_add() {
+    let g = Graph {
+        inputs: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(1), DType::I32, Shape::from(&[3])),
+        ],
+        outputs: vec![],
+        ops: vec![Op::Add {
+            lhs: TensorId(0),
+            rhs: TensorId(1),
+            output: TensorId(2),
+        }],
+        tensors: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(1), DType::I32, Shape::from(&[3])),
+            Tensor::new(TensorId(2), DType::F32, Shape::from(&[3])),
+        ],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::DTypeMismatch { .. })
+    ));
+}
+
+#[test]
+fn rejects_matmul_inner_mismatch() {
+    let g = Graph {
+        inputs: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3, 4])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[5, 6])),
+        ],
+        outputs: vec![],
+        ops: vec![Op::MatMul {
+            a: TensorId(0),
+            b: TensorId(1),
+            output: TensorId(2),
+        }],
+        tensors: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3, 4])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[5, 6])),
+            Tensor::new(TensorId(2), DType::F32, Shape::from(&[3, 6])),
+        ],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::ShapeMismatch { .. })
+    ));
+}
+
+#[test]
+fn rejects_invalid_perm() {
+    let g = Graph {
+        inputs: vec![Tensor::new(TensorId(0), DType::F32, Shape::from(&[2, 3]))],
+        outputs: vec![],
+        ops: vec![Op::Transpose {
+            input: TensorId(0),
+            perm: vec![0, 0],
+            output: TensorId(1),
+        }],
+        tensors: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[2, 3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[2, 2])),
+        ],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::InvalidPermutation { .. })
+    ));
+}
+
+#[test]
+fn rejects_reshape_numel_mismatch() {
+    let g = Graph {
+        inputs: vec![Tensor::new(TensorId(0), DType::F32, Shape::from(&[2, 3]))],
+        outputs: vec![],
+        ops: vec![Op::Reshape {
+            input: TensorId(0),
+            new_shape: Shape::from(&[7]),
+            output: TensorId(1),
+        }],
+        tensors: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[2, 3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[7])),
+        ],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::NumelMismatch { .. })
+    ));
+}
+
+#[test]
+fn rejects_invalid_broadcast() {
+    let g = Graph {
+        inputs: vec![Tensor::new(TensorId(0), DType::F32, Shape::from(&[2, 3]))],
+        outputs: vec![],
+        ops: vec![Op::Broadcast {
+            input: TensorId(0),
+            target_shape: Shape::from(&[5, 3]),
+            output: TensorId(1),
+        }],
+        tensors: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[2, 3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[5, 3])),
+        ],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::InvalidBroadcast { .. })
+    ));
+}
+
+#[test]
+fn rejects_non_u8_predicate_in_where() {
+    let g = Graph {
+        inputs: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(2), DType::F32, Shape::from(&[3])),
+        ],
+        outputs: vec![],
+        ops: vec![Op::Where {
+            predicate: TensorId(0),
+            true_value: TensorId(1),
+            false_value: TensorId(2),
+            output: TensorId(3),
+        }],
+        tensors: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(2), DType::F32, Shape::from(&[3])),
+            Tensor::new(TensorId(3), DType::F32, Shape::from(&[3])),
+        ],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::NonU8Predicate { .. })
+    ));
+}
+
+#[test]
+fn rejects_undefined_output() {
+    let g = Graph {
+        inputs: vec![],
+        outputs: vec![TensorId(99)],
+        ops: vec![],
+        tensors: vec![],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::UndefinedOutput { tensor: TensorId(99) })
+    ));
+}
+
+#[test]
+fn rejects_constant_byte_length_mismatch() {
+    let g = Graph {
+        inputs: vec![],
+        outputs: vec![],
+        ops: vec![],
+        tensors: vec![Tensor::new(TensorId(0), DType::F32, Shape::from(&[2]))],
+        constants: vec![Constant {
+            tensor: Tensor::new(TensorId(0), DType::F32, Shape::from(&[2])),
+            // Should be 8 bytes (2 × f32) but we supplied 5.
+            bytes: vec![0u8; 5],
+        }],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::ConstantByteLength {
+            expected: 8,
+            actual: 5,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn rejects_tensor_id_mismatch() {
+    let g = Graph {
+        inputs: vec![],
+        outputs: vec![],
+        ops: vec![],
+        tensors: vec![Tensor::new(TensorId(7), DType::F32, Shape::from(&[1]))],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::TensorIdMismatch { .. })
+    ));
+}
+
+#[test]
+fn rejects_reduction_axis_out_of_range() {
+    let g = Graph {
+        inputs: vec![Tensor::new(TensorId(0), DType::F32, Shape::from(&[2, 3]))],
+        outputs: vec![],
+        ops: vec![Op::ReduceSum {
+            input: TensorId(0),
+            axes: vec![5],
+            keep_dims: false,
+            output: TensorId(1),
+        }],
+        tensors: vec![
+            Tensor::new(TensorId(0), DType::F32, Shape::from(&[2, 3])),
+            Tensor::new(TensorId(1), DType::F32, Shape::from(&[2, 3])),
+        ],
+        constants: vec![],
+    };
+    assert!(matches!(
+        g.validate(),
+        Err(IrError::InvalidAxis { axis: 5, .. })
+    ));
+}
+
+// ─────────────────── 3. Wire round-trip ───────────────────
+
+fn round_trip(g: &Graph) {
+    let bytes = g.to_bytes();
+    let decoded = Graph::from_bytes(&bytes).expect("decode should succeed");
+    assert_eq!(&decoded, g, "round-trip changed the graph");
+    // And the bytes must be deterministic.
+    let bytes2 = decoded.to_bytes();
+    assert_eq!(bytes, bytes2, "encoding is not deterministic");
+}
+
+#[test]
+fn round_trip_relu_layer() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[1, 4]));
+    let w = g.input(DType::F32, Shape::from(&[4, 2]));
+    let b = g.input(DType::F32, Shape::from(&[1, 2]));
+    let zero = g.constant(DType::F32, Shape::from(&[1, 2]), vec![0u8; 8]);
+    let xw = g.matmul(&x, &w);
+    let xwb = g.add(&xw, &b);
+    let y = g.max(&xwb, &zero);
+    g.output(&y);
+    let g = g.build().unwrap();
+    round_trip(&g);
+}
+
+#[test]
+fn round_trip_all_unary() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[3]));
+    let _ = g.neg(&x);
+    let _ = g.abs(&x);
+    let _ = g.sqrt(&x);
+    let _ = g.exp(&x);
+    let _ = g.log(&x);
+    let _ = g.tanh(&x);
+    let _ = g.recip(&x);
+    let g = g.build().unwrap();
+    round_trip(&g);
+}
+
+#[test]
+fn round_trip_all_binary() {
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[3]));
+    let b = g.input(DType::F32, Shape::from(&[3]));
+    let _ = g.add(&a, &b);
+    let _ = g.sub(&a, &b);
+    let _ = g.mul(&a, &b);
+    let _ = g.div(&a, &b);
+    let _ = g.max(&a, &b);
+    let _ = g.min(&a, &b);
+    let _ = g.pow(&a, &b);
+    let g = g.build().unwrap();
+    round_trip(&g);
+}
+
+#[test]
+fn round_trip_reductions() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[2, 3, 4]));
+    let _ = g.reduce_sum(&x, vec![1], false);
+    let _ = g.reduce_max(&x, vec![0, 2], true);
+    let _ = g.reduce_mean(&x, vec![], false);
+    let g = g.build().unwrap();
+    round_trip(&g);
+}
+
+#[test]
+fn round_trip_shape_ops() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[2, 3]));
+    let _ = g.reshape(&x, Shape::from(&[6]));
+    let _ = g.transpose(&x, vec![1, 0]);
+    let _ = g.broadcast(&x, Shape::from(&[2, 3]));
+    let g = g.build().unwrap();
+    round_trip(&g);
+}
+
+#[test]
+fn round_trip_comparison_and_where() {
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[3]));
+    let b = g.input(DType::F32, Shape::from(&[3]));
+    let lt = g.less(&a, &b);
+    let _ = g.equal(&a, &b);
+    let _ = g.greater(&a, &b);
+    let _ = g.where_(&lt, &a, &b);
+    let g = g.build().unwrap();
+    round_trip(&g);
+}
+
+#[test]
+fn round_trip_cast() {
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[3]));
+    let _ = g.cast(&x, DType::I32);
+    let _ = g.cast(&x, DType::U8);
+    let g = g.build().unwrap();
+    round_trip(&g);
+}
+
+// ─────────────────── 4. Coverage gate ───────────────────
+
+/// Build a graph that exercises every Op variant.  This serves as the
+/// coverage gate — if a future variant is added without being included
+/// here, the test fails (because we count distinct wire tags and assert
+/// the count matches).
+#[test]
+fn coverage_every_variant() {
+    // Build a graph that uses every variant.  We don't validate it as a
+    // semantically-correct graph; we just check that one of every wire
+    // tag is present.
+    let mut g = GraphBuilder::new();
+    let x = g.input(DType::F32, Shape::from(&[2, 3]));
+    let y = g.input(DType::F32, Shape::from(&[2, 3]));
+    let p = g.input(DType::U8, Shape::from(&[2, 3]));
+    let _ = g.constant(DType::F32, Shape::from(&[2]), vec![0u8; 8]); // emits Const
+    let _ = g.neg(&x);
+    let _ = g.abs(&x);
+    let _ = g.sqrt(&x);
+    let _ = g.exp(&x);
+    let _ = g.log(&x);
+    let _ = g.tanh(&x);
+    let _ = g.recip(&x);
+    let _ = g.add(&x, &y);
+    let _ = g.sub(&x, &y);
+    let _ = g.mul(&x, &y);
+    let _ = g.div(&x, &y);
+    let _ = g.max(&x, &y);
+    let _ = g.min(&x, &y);
+    let _ = g.pow(&x, &y);
+    let _ = g.reduce_sum(&x, vec![0], false);
+    let _ = g.reduce_max(&x, vec![0], false);
+    let _ = g.reduce_mean(&x, vec![0], false);
+    let _ = g.reshape(&x, Shape::from(&[6]));
+    let _ = g.transpose(&x, vec![1, 0]);
+    let _ = g.broadcast(&x, Shape::from(&[2, 3]));
+    let mat_a = g.input(DType::F32, Shape::from(&[2, 3]));
+    let mat_b = g.input(DType::F32, Shape::from(&[3, 2]));
+    let _ = g.matmul(&mat_a, &mat_b);
+    let _ = g.equal(&x, &y);
+    let _ = g.less(&x, &y);
+    let _ = g.greater(&x, &y);
+    let _ = g.where_(&p, &x, &y);
+    let _ = g.cast(&x, DType::I32);
+    let g = g.build().unwrap();
+
+    // Collect distinct wire tags.
+    let mut tags: Vec<u8> = g.ops.iter().map(|op| op.wire_tag()).collect();
+    tags.sort();
+    tags.dedup();
+
+    // V1 has 27 op variants.  If a variant is added without updating
+    // this test, this assertion fires.
+    assert_eq!(
+        tags.len(),
+        27,
+        "coverage gate: not every Op variant exercised; tags = {:?}",
+        tags
+    );
+}


### PR DESCRIPTION
## Summary

First implementation crate of the matrix execution layer (MX00-MX04 specs merged in #2003). Implements **spec MX01** — the pure tensor algebra IR that domain libraries (image processing, neural networks, signal processing, BLAS) emit when they want computation done.

Pure data plane only — types, builder, validator, hand-rolled binary wire format. **No execution. Zero external dependencies** (`core`/`alloc`/`std` only).

## What's in this crate

| Module | Purpose |
|--------|---------|
| `tensor.rs` | `TensorId`, `OpId`, `DType` (F32/U8/I32), `Shape`, `Tensor` |
| `op.rs` | 27-variant `Op` enum |
| `graph.rs` | `Graph` aggregate + `Constant` |
| `builder.rs` | `GraphBuilder` with eager shape/dtype inference |
| `validate.rs` | Structural + semantic validation, 17 distinct `IrError` variants |
| `wire.rs` | Hand-rolled binary serialization per MX03 §"Wire format primitives" |

## V1 op set (27 ops)

| Group | Ops |
|-------|-----|
| Elementwise unary | Neg, Abs, Sqrt, Exp, Log, Tanh, Recip |
| Elementwise binary | Add, Sub, Mul, Div, Max, Min, Pow |
| Reductions | ReduceSum, ReduceMax, ReduceMean |
| Shape | Reshape, Transpose, Broadcast |
| Linear algebra | MatMul (rank-2) |
| Comparison | Equal, Less, Greater (output U8) |
| Selection | Where |
| Conversion | Cast |
| Constants | Const |

## Security hardening

The wire decoder accepts untrusted bytes (network executors send wire-encoded graphs). Two rounds of security review surfaced and fixed:

- **HIGH**: `Vec::with_capacity` from attacker-controlled varint sizes was unbounded — could OOM the process with a 12-byte payload claiming `u64::MAX` entries. Now all 8 length-prefixed allocation sites use a `bounded_capacity` helper that caps capacity against `remaining_bytes / min_element_bytes`.
- **MEDIUM**: `Reader::need` used unchecked `pos + n` addition. Now uses `checked_add` to prevent overflow on 32-bit targets.
- **MEDIUM**: `bytes()` silently truncated `u64` lengths to `usize` on 32-bit. Now explicitly rejects.
- **LOW**: `from_bytes` documented as structural-only with a security note recommending caller-side size caps + `validate()` calls.

Plus three new tests:
- `decoder_amplification_attack_is_bounded` — `u64::MAX` count with no payload, asserts `WireUnexpectedEof` not OOM
- `truncation_at_every_position_does_not_panic` — every byte offset truncated, asserts no panic
- `fuzz_random_bytes_do_not_panic` — 1024 deterministic PRNG iterations, asserts no panic

## Test coverage

```
cargo test -p matrix-ir
test result: ok. 33 passed; 0 failed
```

- 9 builder+validate tests
- 11 validator-rejection tests across error variants
- 7 wire round-trip tests with determinism check
- 3 wire decoder hardening tests (above)
- 1 coverage gate asserting every `Op` variant is exercised
- Per-module unit tests for tensor/op/builder/wire primitives

## Zero dependencies confirmed

```
$ cargo tree -p matrix-ir
matrix-ir v0.1.0
```

No external crates. Hand-rolled wire format (varint + length-prefixed bytes + tagged unions) per the spec.

## What's next

Per the MX00 roadmap, the next crates after this lands:
- `compute-ir` (MX02) — placed graph with explicit residency and transfers
- `executor-protocol` (MX03) — wire format, message types, Transport trait
- `compute-runtime` (MX04) — planner, registry, cost model
- `matrix-cpu` reference executor
- One GPU executor (Metal or CUDA)

## Test plan

- [x] `cargo build -p matrix-ir` — passes
- [x] `cargo test -p matrix-ir` — 33 passing
- [x] `cargo tree -p matrix-ir` — zero external deps confirmed
- [ ] CI matrix (ubuntu / macos / windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)