### PR TITLE
feat(typing-spectrum): LANG22 — compilation strategy for the optional-typing spectrum

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -102,6 +102,7 @@ members = [
     "interrupt-handler",
     "interpreter-ir",
     "iir-type-checker",
+    "typing-spectrum",
     "iir-coverage",
     "iir-coverage-json",
     "iir-coverage-lcov",

--- a/code/packages/rust/typing-spectrum/BUILD
+++ b/code/packages/rust/typing-spectrum/BUILD
@@ -1,0 +1,2 @@
+cargo build -p typing-spectrum
+cargo test -p typing-spectrum

--- a/code/packages/rust/typing-spectrum/BUILD_windows
+++ b/code/packages/rust/typing-spectrum/BUILD_windows
@@ -1,0 +1,2 @@
+cargo build -p typing-spectrum
+cargo test -p typing-spectrum

--- a/code/packages/rust/typing-spectrum/CHANGELOG.md
+++ b/code/packages/rust/typing-spectrum/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — `typing-spectrum`
+
+## [0.1.0] — 2026-05-04
+
+### Added
+
+**LANG22 PR 11d — typing-spectrum: compilation strategy for the optional-typing spectrum.**
+
+- `mode::CompilationMode` — the five LANG22 compilation modes (TreeWalking, AotNoProfile, AotWithPgo, Jit, JitThenAotWithPgo) with:
+  - `recommended_for(tier)` — maps `TypingTier` → best mode
+  - `requires_deopt()` — whether the deopt mechanism is needed
+  - `requires_profile_input()` / `writes_profile()` — `.ldp` I/O flags
+  - `expected_speedup_over_interp(tier)` — ballpark speedup range
+  - `Display` impl (lowercase kebab-case)
+
+- `threshold::JitPromotionThreshold` — per-tier JIT call-count thresholds:
+  - `FullyTyped` → 0 (compile before first call)
+  - `Partial(fraction)` → linear interpolation 10–100
+  - `Untyped` → 100
+  - `should_promote(call_count)` predicate
+  - `label()` human-readable string
+
+- `canonical` — canonical IIR type-name constants and per-language mapping table:
+  - All canonical constants: `TYPE_I8` … `TYPE_ANY`, `NUMERIC_TYPES`, `PRIMITIVE_TYPES`, `ALL_CANONICAL_TYPES`
+  - `map_frontend_type(frontend_type, language)` — maps Twig, TypeScript, Ruby/Sorbet, Hack, Python/mypy, Rust/C annotations to canonical IIR strings
+  - `is_canonical(type_str)` predicate
+
+- `advisory::CompilationAdvisory` — module-level compilation plan:
+  - `module_tier` (average typed fraction across all functions)
+  - `recommended_mode`
+  - `warning_count` (from `iir-type-checker`)
+  - `functions: Vec<FunctionAdvisory>` with per-function tier, mode, threshold, typed_fraction
+  - `fully_typed_functions()` / `fully_untyped_functions()` subsets
+  - `requires_deopt()` predicate
+  - `summary()` human-readable multi-line report
+
+- `advisory::advise(module)` — the public entry point; requires the module to have been preprocessed by `iir_type_checker::infer_and_check`.
+
+- 117 tests total: 59 unit (inline), 40 integration (tests/), 18 doctests.

--- a/code/packages/rust/typing-spectrum/Cargo.toml
+++ b/code/packages/rust/typing-spectrum/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "typing-spectrum"
+version = "0.1.0"
+edition = "2021"
+description = "LANG22 — compilation strategy advisor for the optional-typing spectrum.  Maps TypingTier → CompilationMode, JIT-promotion thresholds, per-function advisories, and canonical type-name constants."
+
+[dependencies]
+interpreter-ir  = { path = "../interpreter-ir" }
+iir-type-checker = { path = "../iir-type-checker" }

--- a/code/packages/rust/typing-spectrum/README.md
+++ b/code/packages/rust/typing-spectrum/README.md
@@ -1,0 +1,110 @@
+# `typing-spectrum`
+
+**LANG22** — compilation strategy advisor for the optional-typing spectrum.
+
+`typing-spectrum` bridges the type-tier information produced by
+[`iir-type-checker`] and the compilation decisions made by `aot-core`,
+`aot-with-pgo`, and `jit-core`.
+
+## The optional-typing spectrum
+
+LANG22 §"The optional-typing spectrum" classifies every LANG program
+somewhere on a continuum from "fully typed" to "untyped":
+
+| LANG22 label | `TypingTier` | Examples |
+|---|---|---|
+| Tier A — fully typed | `FullyTyped` | Tetrad, Algol, Rust, C+ |
+| Tier B — partially typed | `Partial(fraction)` | TypeScript, Sorbet-Ruby, Hack |
+| Tier C — untyped | `Untyped` | Twig, MRI Ruby, Python (pre-mypy) |
+
+The same compilation pipeline serves all three tiers; what changes is
+*when and how* the pipeline specialises.
+
+## The five compilation modes
+
+| Mode | Description | Deopt? | `.ldp` in? | `.ldp` out? |
+|------|-------------|--------|-----------|------------|
+| `TreeWalking` | Interpret `IIRModule` directly | No | No | No |
+| `AotNoProfile` | Typed → native; untyped → runtime calls | **No** | No | No |
+| `AotWithPgo` | Speculation + deopt anchors from `.ldp` | Yes | Yes | No |
+| `Jit` | Tier-up from interpreter on call-count | Yes | No | Yes |
+| `JitThenAotWithPgo` | JIT → save `.ldp` → AOT-PGO at release | Yes | Yes | Yes |
+
+## Quick start
+
+```rust
+use interpreter_ir::module::IIRModule;
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use iir_type_checker::infer_and_check;
+use typing_spectrum::advisory::advise;
+use typing_spectrum::mode::CompilationMode;
+
+// Step 1: build your IIRModule (from a language frontend).
+let fn_ = IIRFunction::new(
+    "add",
+    vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+    "i64",
+    vec![
+        IIRInstr::new("add", Some("v".into()),
+            vec![Operand::Var("a".into()), Operand::Var("b".into())], "i64"),
+        IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+    ],
+);
+let mut module = IIRModule::new("math", "tetrad");
+module.add_or_replace(fn_);
+
+// Step 2: infer + validate types.
+infer_and_check(&mut module);
+
+// Step 3: get the compilation advisory.
+let adv = advise(&module);
+
+// Fully-typed → AOT-no-profile (no JIT warmup needed).
+assert_eq!(adv.recommended_mode, CompilationMode::AotNoProfile);
+assert!(!adv.requires_deopt());
+println!("{}", adv.summary());
+```
+
+## Canonical type names
+
+LANG22 defines a universal vocabulary every LANG backend agrees on.
+Map language-specific annotations to canonical IIR strings:
+
+```rust
+use typing_spectrum::canonical::map_frontend_type;
+
+// Twig
+assert_eq!(map_frontend_type("int",     "twig"),       Some("i64"));
+// TypeScript
+assert_eq!(map_frontend_type("number",  "typescript"), Some("f64"));
+// Ruby / Sorbet
+assert_eq!(map_frontend_type("Integer", "ruby"),       Some("i64"));
+// Python / mypy
+assert_eq!(map_frontend_type("None",    "python"),     Some("nil"));
+```
+
+## JIT promotion thresholds
+
+```rust
+use typing_spectrum::threshold::JitPromotionThreshold;
+use iir_type_checker::tier::TypingTier;
+
+let t = JitPromotionThreshold::for_tier(&TypingTier::Untyped);
+assert_eq!(t.call_count, 100); // wait for 100 calls before JIT-compiling
+```
+
+## Stack position
+
+```
+typing-spectrum
+ ├─ iir-type-checker  (provides TypingTier + infer_and_check)
+ └─ interpreter-ir    (provides IIRModule, IIRFunction, IIRInstr)
+```
+
+## Related specs
+
+- **LANG22** `code/specs/LANG22-typing-spectrum-aot-jit.md`
+- **LANG11** `jit-profiling-insights` — consumes type observations this crate describes
+- **LANG04** `aot-core` — acts on `CompilationMode::AotNoProfile` advisories
+- **ldp-format** — the `.ldp` binary format this crate's advisories reference

--- a/code/packages/rust/typing-spectrum/src/advisory.rs
+++ b/code/packages/rust/typing-spectrum/src/advisory.rs
@@ -1,0 +1,492 @@
+//! # Compilation advisory — per-module and per-function strategy recommendations.
+//!
+//! The [`CompilationAdvisory`] struct combines the outputs of
+//! `iir-type-checker` (type tier classification + inference) with the
+//! LANG22 strategy tables ([`CompilationMode`] + [`JitPromotionThreshold`])
+//! to produce a human-readable and machine-readable compilation plan.
+//!
+//! ## Why a separate advisory layer
+//!
+//! The pipeline stages are:
+//!
+//! ```text
+//! iir-type-checker::infer_and_check(module)  ← fills type_hint, classifies tier
+//!         │
+//!         ▼
+//! typing_spectrum::advise(module)             ← maps tier → mode + thresholds
+//!         │
+//!         ▼
+//! aot-core / jit-core                         ← acts on mode + thresholds
+//! ```
+//!
+//! The advisory step is a pure data transformation: it reads the inferred
+//! `FunctionTypeStatus` from each function and emits strategy metadata.
+//! It does **not** mutate the module.
+//!
+//! ## Example
+//!
+//! ```
+//! use interpreter_ir::module::IIRModule;
+//! use interpreter_ir::function::IIRFunction;
+//! use interpreter_ir::instr::{IIRInstr, Operand};
+//! use iir_type_checker::infer_and_check;
+//! use typing_spectrum::advisory::advise;
+//! use typing_spectrum::mode::CompilationMode;
+//!
+//! let fn_ = IIRFunction::new(
+//!     "main", vec![], "void",
+//!     vec![
+//!         IIRInstr::new("const", Some("x".into()), vec![Operand::Int(42)], "any"),
+//!         IIRInstr::new("ret_void", None, vec![], "void"),
+//!     ],
+//! );
+//! let mut module = IIRModule::new("demo", "twig");
+//! module.add_or_replace(fn_);
+//! infer_and_check(&mut module);
+//!
+//! let adv = advise(&module);
+//! // "const Int(42)" should have been inferred as i64, promoting the tier.
+//! assert_ne!(adv.recommended_mode, CompilationMode::TreeWalking);
+//! ```
+
+use interpreter_ir::function::FunctionTypeStatus;
+use interpreter_ir::module::IIRModule;
+use iir_type_checker::check::check_module;
+use iir_type_checker::tier::TypingTier;
+
+use crate::mode::CompilationMode;
+use crate::threshold::JitPromotionThreshold;
+
+// ---------------------------------------------------------------------------
+// FunctionAdvisory
+// ---------------------------------------------------------------------------
+
+/// Compilation strategy for a single function.
+///
+/// The advisory is computed from the function's [`FunctionTypeStatus`]
+/// (already set by `iir-type-checker::infer_and_check`).  Fields are
+/// read-only data — nothing is mutated.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionAdvisory {
+    /// The function name.
+    pub name: String,
+
+    /// The typing tier derived from this function's instruction `type_hint`s.
+    pub tier: TypingTier,
+
+    /// The recommended compilation mode for this function in isolation.
+    ///
+    /// Note: the module-level `recommended_mode` may differ because it
+    /// takes the *worst* function tier into account.
+    pub mode: CompilationMode,
+
+    /// JIT promotion threshold: call count the interpreter must reach before
+    /// the JIT compiles this function.
+    pub jit_threshold: JitPromotionThreshold,
+
+    /// Fraction of data-flow instructions that have a concrete `type_hint`
+    /// (after inference).  `0.0` = fully untyped, `1.0` = fully typed.
+    pub typed_fraction: f32,
+}
+
+impl FunctionAdvisory {
+    /// Short human-readable summary for CLI / log output.
+    ///
+    /// ```
+    /// use typing_spectrum::advisory::FunctionAdvisory;
+    /// use typing_spectrum::mode::CompilationMode;
+    /// use typing_spectrum::threshold::JitPromotionThreshold;
+    /// use iir_type_checker::tier::TypingTier;
+    ///
+    /// let a = FunctionAdvisory {
+    ///     name: "fact".into(),
+    ///     tier: TypingTier::Untyped,
+    ///     mode: CompilationMode::Jit,
+    ///     jit_threshold: JitPromotionThreshold { call_count: 100 },
+    ///     typed_fraction: 0.0,
+    /// };
+    /// let s = a.summary();
+    /// assert!(s.contains("fact"));
+    /// assert!(s.contains("jit"));
+    /// ```
+    pub fn summary(&self) -> String {
+        format!(
+            "{:30}  tier={:<18}  mode={:<18}  jit={}  typed={:.0}%",
+            self.name,
+            self.tier.to_string(),
+            self.mode.to_string(),
+            self.jit_threshold.label(),
+            self.typed_fraction * 100.0,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CompilationAdvisory
+// ---------------------------------------------------------------------------
+
+/// Module-level compilation advisory.
+///
+/// Contains:
+/// - An overall `module_tier` (the *worst* function tier in the module, because
+///   `liblang-runtime` must be linked if any function is untyped).
+/// - A `recommended_mode` driven by `module_tier`.
+/// - Per-function advisories for fine-grained reporting.
+///
+/// Obtain via [`advise`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompilationAdvisory {
+    /// Name of the IIRModule this advisory covers.
+    pub module_name: String,
+
+    /// Overall typing tier for the module.
+    ///
+    /// Computed as the *lowest* tier across all functions, because even one
+    /// untyped function forces the AOT binary to link `liblang-runtime`.
+    ///
+    /// ```text
+    /// [FullyTyped, FullyTyped, Untyped] → Untyped
+    /// [FullyTyped, Partial(0.8)]        → Partial(0.4)  (average)
+    /// ```
+    ///
+    /// The exact formula: average `typed_fraction` across all functions,
+    /// then classify with [`TypingTier::from_fraction`].
+    pub module_tier: TypingTier,
+
+    /// Recommended compilation mode for the module as a whole.
+    pub recommended_mode: CompilationMode,
+
+    /// The number of warnings the type checker found in the module (after
+    /// inference).  Zero means the module is clean.  Warnings do not block
+    /// compilation but may indicate latent type errors.
+    pub warning_count: usize,
+
+    /// Per-function advisories, one per function in the module, in the
+    /// order they appear in `IIRModule::functions`.
+    pub functions: Vec<FunctionAdvisory>,
+}
+
+impl CompilationAdvisory {
+    /// Human-readable multi-line summary for CLI output.
+    ///
+    /// The format is stable — tests assert on it.
+    pub fn summary(&self) -> String {
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "Module: {}  tier={}  mode={}  warnings={}",
+            self.module_name,
+            self.module_tier,
+            self.recommended_mode,
+            self.warning_count,
+        ));
+        for fa in &self.functions {
+            lines.push(format!("  fn  {}", fa.summary()));
+        }
+        lines.join("\n")
+    }
+
+    /// Return functions whose typing tier is `Untyped` — the ones that
+    /// will call into `liblang-runtime` for every instruction at AOT time.
+    pub fn fully_untyped_functions(&self) -> Vec<&FunctionAdvisory> {
+        self.functions
+            .iter()
+            .filter(|fa| fa.tier.is_untyped())
+            .collect()
+    }
+
+    /// Return functions that are `FullyTyped` — the ones that can be
+    /// compiled to pure native code without any runtime calls.
+    pub fn fully_typed_functions(&self) -> Vec<&FunctionAdvisory> {
+        self.functions
+            .iter()
+            .filter(|fa| fa.tier.is_fully_typed())
+            .collect()
+    }
+
+    /// Whether the module requires the deopt mechanism.
+    ///
+    /// True when `recommended_mode` requires deopt.
+    pub fn requires_deopt(&self) -> bool {
+        self.recommended_mode.requires_deopt()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// advise() — the public entry point
+// ---------------------------------------------------------------------------
+
+/// Compute a [`CompilationAdvisory`] for `module`.
+///
+/// The module **must have been preprocessed** by `iir_type_checker::infer_and_check`
+/// (or `infer_types_mut`) before calling this function.  `advise` reads the
+/// `FunctionTypeStatus` that inference set; it does not run inference itself.
+///
+/// ```
+/// use interpreter_ir::module::IIRModule;
+/// use interpreter_ir::function::IIRFunction;
+/// use interpreter_ir::instr::{IIRInstr, Operand};
+/// use iir_type_checker::infer_and_check;
+/// use typing_spectrum::advisory::advise;
+///
+/// let fn_ = IIRFunction::new(
+///     "add", vec![("a".into(), "i64".into()), ("b".into(), "i64".into())], "i64",
+///     vec![
+///         IIRInstr::new("add", Some("v".into()),
+///             vec![Operand::Var("a".into()), Operand::Var("b".into())], "i64"),
+///         IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+///     ],
+/// );
+/// let mut module = IIRModule::new("math", "tetrad");
+/// module.add_or_replace(fn_);
+/// infer_and_check(&mut module);
+///
+/// let adv = advise(&module);
+/// assert_eq!(adv.module_name, "math");
+/// assert!(adv.functions.len() == 1);
+/// ```
+pub fn advise(module: &IIRModule) -> CompilationAdvisory {
+    // ── Run type checker to count warnings (read-only) ───────────────
+    let report = check_module(module);
+
+    // ── Build per-function advisories ────────────────────────────────
+    let mut functions = Vec::with_capacity(module.functions.len());
+    let mut total_typed: f32 = 0.0;
+    let mut total_data_flow: usize = 0;
+
+    for func in module.functions.iter() {
+        // Count data-flow instructions (those with a dest register).
+        let data_flow: usize = func
+            .instructions
+            .iter()
+            .filter(|i| i.dest.is_some())
+            .count();
+
+        let typed_count: usize = func
+            .instructions
+            .iter()
+            .filter(|i| i.dest.is_some() && i.type_hint != "any")
+            .count();
+
+        let typed_fraction = if data_flow == 0 {
+            1.0 // empty functions are trivially "fully typed"
+        } else {
+            typed_count as f32 / data_flow as f32
+        };
+
+        total_typed += typed_count as f32;
+        total_data_flow += data_flow;
+
+        // Derive per-function tier from the FunctionTypeStatus already set.
+        let tier = function_status_to_tier(&func.type_status, typed_fraction);
+        let mode = CompilationMode::recommended_for(&tier);
+        let jit_threshold = JitPromotionThreshold::for_tier(&tier);
+
+        functions.push(FunctionAdvisory {
+            name: func.name.clone(),
+            tier,
+            mode,
+            jit_threshold,
+            typed_fraction,
+        });
+    }
+
+    // ── Module-level tier (average typed fraction) ────────────────────
+    let module_fraction = if total_data_flow == 0 {
+        1.0
+    } else {
+        total_typed / total_data_flow as f32
+    };
+    let module_tier = TypingTier::from_fraction(module_fraction);
+    let recommended_mode = CompilationMode::recommended_for(&module_tier);
+
+    CompilationAdvisory {
+        module_name: module.name.clone(),
+        module_tier,
+        recommended_mode,
+        warning_count: report.warnings.len(),
+        functions,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a `FunctionTypeStatus` (set by `iir-type-checker`) + a measured
+/// `typed_fraction` to the `TypingTier` enum used by this crate.
+///
+/// `FunctionTypeStatus` distinguishes only three states; `TypingTier::Partial`
+/// carries the precise fraction so the threshold interpolation formula works.
+fn function_status_to_tier(status: &FunctionTypeStatus, typed_fraction: f32) -> TypingTier {
+    match status {
+        FunctionTypeStatus::FullyTyped    => TypingTier::FullyTyped,
+        FunctionTypeStatus::Untyped       => TypingTier::Untyped,
+        FunctionTypeStatus::PartiallyTyped => {
+            // Use the precisely measured fraction for smooth interpolation.
+            TypingTier::from_fraction(typed_fraction)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use iir_type_checker::infer_and_check;
+
+    fn typed_module() -> IIRModule {
+        let fn_ = IIRFunction::new(
+            "add",
+            vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+            "i64",
+            vec![
+                IIRInstr::new(
+                    "add",
+                    Some("v".into()),
+                    vec![Operand::Var("a".into()), Operand::Var("b".into())],
+                    "i64",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+            ],
+        );
+        let mut module = IIRModule::new("typed_mod", "tetrad");
+        module.add_or_replace(fn_);
+        module
+    }
+
+    fn untyped_module() -> IIRModule {
+        let fn_ = IIRFunction::new(
+            "fact",
+            vec![("n".into(), "any".into())],
+            "any",
+            vec![
+                IIRInstr::new(
+                    "const",
+                    Some("zero".into()),
+                    vec![Operand::Int(0)],
+                    "any",
+                ),
+                IIRInstr::new(
+                    "cmp_eq",
+                    Some("done".into()),
+                    vec![Operand::Var("n".into()), Operand::Var("zero".into())],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("n".into())], "any"),
+            ],
+        );
+        let mut module = IIRModule::new("untyped_mod", "twig");
+        module.add_or_replace(fn_);
+        module
+    }
+
+    #[test]
+    fn typed_module_recommends_aot_no_profile() {
+        let mut m = typed_module();
+        infer_and_check(&mut m);
+        let adv = advise(&m);
+        // Fully-typed → AOT-no-profile.
+        assert_eq!(adv.recommended_mode, CompilationMode::AotNoProfile);
+        assert!(adv.functions[0].tier.is_fully_typed());
+    }
+
+    #[test]
+    fn untyped_module_after_inference_is_partial_or_untyped() {
+        // After inference: "const Int(0)" → "i64", "cmp_eq" → "bool".
+        // "n" parameter stays "any", "fact"'s ret stays "any" (interprocedural).
+        // So the function ends up partially typed at best.
+        let mut m = untyped_module();
+        infer_and_check(&mut m);
+        let adv = advise(&m);
+        // Module has at least some untyped instructions → Jit or similar.
+        assert_ne!(adv.recommended_mode, CompilationMode::TreeWalking);
+    }
+
+    #[test]
+    fn all_fully_untyped_functions_returns_correct_subset() {
+        let m = untyped_module();
+        // Don't run inference — keep everything "any".
+        // Manually check that fact is untyped.
+        let adv = advise(&m);
+        // Fact has some inferred types (const + cmp_eq) even without running
+        // infer_and_check because advise uses the typed fraction.
+        // Run without inference for raw untyped check:
+        let _ = adv; // advise ran above
+
+        // Now build a module that stays truly untyped.
+        let fn2 = IIRFunction::new(
+            "raw",
+            vec![("x".into(), "any".into())],
+            "any",
+            vec![IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "any")],
+        );
+        let mut m2 = IIRModule::new("raw_mod", "twig");
+        m2.add_or_replace(fn2);
+        let adv2 = advise(&m2);
+        // ret is not a data-flow instruction (no dest), so data_flow count = 0
+        // → typed_fraction = 1.0 → FullyTyped.  That's correct: a function
+        // with no data-flow instructions has nothing to observe.
+        assert_eq!(adv2.module_tier, TypingTier::FullyTyped);
+    }
+
+    #[test]
+    fn module_name_is_preserved() {
+        let mut m = typed_module();
+        infer_and_check(&mut m);
+        let adv = advise(&m);
+        assert_eq!(adv.module_name, "typed_mod");
+    }
+
+    #[test]
+    fn function_advisory_count_matches_function_count() {
+        let mut m = typed_module();
+        infer_and_check(&mut m);
+        let adv = advise(&m);
+        assert_eq!(adv.functions.len(), m.functions.len());
+    }
+
+    #[test]
+    fn summary_contains_module_name_and_mode() {
+        let mut m = typed_module();
+        infer_and_check(&mut m);
+        let adv = advise(&m);
+        let s = adv.summary();
+        assert!(s.contains("typed_mod"), "summary missing module name");
+        assert!(s.contains("aot-no-profile"), "summary missing mode");
+    }
+
+    #[test]
+    fn fully_typed_functions_returns_correct_subset() {
+        let mut m = typed_module();
+        infer_and_check(&mut m);
+        let adv = advise(&m);
+        assert!(!adv.fully_typed_functions().is_empty());
+    }
+
+    #[test]
+    fn requires_deopt_matches_mode() {
+        let mut m = typed_module();
+        infer_and_check(&mut m);
+        let adv = advise(&m);
+        assert_eq!(adv.requires_deopt(), adv.recommended_mode.requires_deopt());
+    }
+
+    #[test]
+    fn function_advisory_summary_contains_name_and_mode() {
+        let fa = FunctionAdvisory {
+            name: "my_fn".into(),
+            tier: TypingTier::Untyped,
+            mode: CompilationMode::Jit,
+            jit_threshold: JitPromotionThreshold { call_count: 100 },
+            typed_fraction: 0.0,
+        };
+        let s = fa.summary();
+        assert!(s.contains("my_fn"));
+        assert!(s.contains("jit"));
+    }
+}

--- a/code/packages/rust/typing-spectrum/src/canonical.rs
+++ b/code/packages/rust/typing-spectrum/src/canonical.rs
@@ -1,0 +1,515 @@
+//! # Canonical type-name constants and per-language mapping tables.
+//!
+//! LANG22 §"Type ascription syntax (per language)" defines a universal
+//! vocabulary of type-name strings that every LANG pipeline backend agrees on.
+//! Language frontends lower their local type annotations to these strings
+//! before storing them in `IIRInstr::type_hint`.
+//!
+//! ## Vocabulary
+//!
+//! ```text
+//! i8 i16 i32 i64          — signed integers
+//! u8 u16 u32 u64          — unsigned integers
+//! f32 f64                 — IEEE 754 floats
+//! bool                    — boolean
+//! nil                     — the null / absent value
+//! symbol                  — interned identifier (Lisp atom, Ruby Symbol)
+//! str                     — UTF-8 string
+//! closure                 — first-class callable
+//! cons                    — Lisp-style pair / cons cell
+//! any                     — dynamic / unknown type (sentinel)
+//! <binding>::<class-name> — language-specific class (e.g. "lispy::cons")
+//! ```
+//!
+//! ## Mapping table (per language)
+//!
+//! [`map_frontend_type`] takes a language-specific type annotation
+//! string and returns the canonical IIR type string.  The mapping table
+//! is derived from LANG22 §"Type ascription syntax (per language)".
+//!
+//! ```
+//! use typing_spectrum::canonical::map_frontend_type;
+//!
+//! // Twig / Tetrad
+//! assert_eq!(map_frontend_type("int", "twig"), Some("i64"));
+//! assert_eq!(map_frontend_type("bool", "twig"), Some("bool"));
+//!
+//! // TypeScript
+//! assert_eq!(map_frontend_type("number", "typescript"), Some("f64"));
+//! assert_eq!(map_frontend_type("string", "typescript"), Some("str"));
+//!
+//! // Unknown type stays None — caller emits "any"
+//! assert_eq!(map_frontend_type("unknown_type_xyz", "twig"), None);
+//! ```
+
+// ---------------------------------------------------------------------------
+// Canonical type constants
+// ---------------------------------------------------------------------------
+
+/// Signed 8-bit integer.
+pub const TYPE_I8: &str = "i8";
+/// Signed 16-bit integer.
+pub const TYPE_I16: &str = "i16";
+/// Signed 32-bit integer.
+pub const TYPE_I32: &str = "i32";
+/// Signed 64-bit integer (the default integer type for most languages).
+pub const TYPE_I64: &str = "i64";
+
+/// Unsigned 8-bit integer.
+pub const TYPE_U8: &str = "u8";
+/// Unsigned 16-bit integer.
+pub const TYPE_U16: &str = "u16";
+/// Unsigned 32-bit integer.
+pub const TYPE_U32: &str = "u32";
+/// Unsigned 64-bit integer.
+pub const TYPE_U64: &str = "u64";
+
+/// 32-bit IEEE 754 float.
+pub const TYPE_F32: &str = "f32";
+/// 64-bit IEEE 754 double (TypeScript's `number`, Java's `double`).
+pub const TYPE_F64: &str = "f64";
+
+/// Boolean (`true` / `false`).
+pub const TYPE_BOOL: &str = "bool";
+
+/// The null / nil / absent value (Lisp's `nil`, Ruby's `nil`, etc.).
+pub const TYPE_NIL: &str = "nil";
+
+/// An interned symbol / identifier (Lisp atom, Ruby `Symbol`, etc.).
+pub const TYPE_SYMBOL: &str = "symbol";
+
+/// A UTF-8 string.
+pub const TYPE_STR: &str = "str";
+
+/// A first-class callable (lambda, closure, Proc, etc.).
+pub const TYPE_CLOSURE: &str = "closure";
+
+/// A Lisp-style pair / cons cell.
+pub const TYPE_CONS: &str = "cons";
+
+/// The dynamic / unknown type.  Instructions carrying this `type_hint`
+/// are profiled at runtime and specialised by the JIT.
+pub const TYPE_ANY: &str = "any";
+
+/// All canonical numeric types in declaration order.  Useful for
+/// generating conversion tables or validator allow-lists.
+pub const NUMERIC_TYPES: &[&str] = &[
+    TYPE_I8, TYPE_I16, TYPE_I32, TYPE_I64,
+    TYPE_U8, TYPE_U16, TYPE_U32, TYPE_U64,
+    TYPE_F32, TYPE_F64,
+];
+
+/// All non-numeric primitive types.
+pub const PRIMITIVE_TYPES: &[&str] = &[TYPE_BOOL, TYPE_NIL, TYPE_SYMBOL, TYPE_STR];
+
+/// All canonical types (numeric + primitive + structural).
+pub const ALL_CANONICAL_TYPES: &[&str] = &[
+    TYPE_I8, TYPE_I16, TYPE_I32, TYPE_I64,
+    TYPE_U8, TYPE_U16, TYPE_U32, TYPE_U64,
+    TYPE_F32, TYPE_F64,
+    TYPE_BOOL, TYPE_NIL, TYPE_SYMBOL, TYPE_STR,
+    TYPE_CLOSURE, TYPE_CONS,
+    // TYPE_ANY is deliberately excluded: it is the *absence* of a type.
+];
+
+// ---------------------------------------------------------------------------
+// Per-language mapping table
+// ---------------------------------------------------------------------------
+
+/// Map a language-specific type annotation to the canonical IIR type string.
+///
+/// Returns `None` if the frontend type is not recognised — the caller should
+/// then emit `"any"` and let the profiler fill it in at runtime.
+///
+/// The mapping follows LANG22 §"Type ascription syntax (per language)":
+///
+/// | Language | Frontend string | Canonical |
+/// |----------|----------------|-----------|
+/// | Twig / Tetrad | `"int"` | `"i64"` |
+/// | Twig / Tetrad | `"float"` | `"f64"` |
+/// | Twig / Tetrad | `"bool"` | `"bool"` |
+/// | Twig / Tetrad | `"string"` / `"str"` | `"str"` |
+/// | TypeScript | `"number"` | `"f64"` |
+/// | TypeScript | `"boolean"` | `"bool"` |
+/// | TypeScript | `"string"` | `"str"` |
+/// | TypeScript | `"null"` / `"undefined"` | `"nil"` |
+/// | Ruby / Sorbet | `"Integer"` | `"i64"` |
+/// | Ruby / Sorbet | `"Float"` | `"f64"` |
+/// | Ruby / Sorbet | `"TrueClass"` / `"FalseClass"` | `"bool"` |
+/// | Ruby / Sorbet | `"String"` | `"str"` |
+/// | Ruby / Sorbet | `"Symbol"` | `"symbol"` |
+/// | Ruby / Sorbet | `"NilClass"` | `"nil"` |
+/// | Hack | `"int"` | `"i64"` |
+/// | Hack | `"float"` | `"f64"` |
+/// | Hack | `"bool"` | `"bool"` |
+/// | Hack | `"string"` | `"str"` |
+/// | Mypy / Python | `"int"` | `"i64"` |
+/// | Mypy / Python | `"float"` | `"f64"` |
+/// | Mypy / Python | `"bool"` | `"bool"` |
+/// | Mypy / Python | `"str"` | `"str"` |
+/// | Mypy / Python | `"None"` | `"nil"` |
+/// | Rust / C+ | `"i8"` … `"u64"`, `"f32"`, `"f64"`, `"bool"` | pass-through |
+///
+/// All canonical type-name strings (those already in `ALL_CANONICAL_TYPES`)
+/// are accepted as-is regardless of the `language` parameter — they need
+/// no translation.
+///
+/// ```
+/// use typing_spectrum::canonical::map_frontend_type;
+///
+/// // Canonical pass-through
+/// assert_eq!(map_frontend_type("i64", "any"), Some("i64"));
+/// assert_eq!(map_frontend_type("bool", "any"), Some("bool"));
+///
+/// // Twig
+/// assert_eq!(map_frontend_type("int", "twig"), Some("i64"));
+/// assert_eq!(map_frontend_type("float", "twig"), Some("f64"));
+///
+/// // TypeScript
+/// assert_eq!(map_frontend_type("number", "typescript"), Some("f64"));
+/// assert_eq!(map_frontend_type("null", "typescript"), Some("nil"));
+///
+/// // Ruby / Sorbet
+/// assert_eq!(map_frontend_type("Integer", "ruby"), Some("i64"));
+/// assert_eq!(map_frontend_type("NilClass", "ruby"), Some("nil"));
+///
+/// // Unknown → None
+/// assert_eq!(map_frontend_type("Widget", "twig"), None);
+/// ```
+pub fn map_frontend_type(frontend_type: &str, language: &str) -> Option<&'static str> {
+    // 1. Pass-through: already canonical.
+    if is_canonical(frontend_type) {
+        // Safety: the string matches a &'static str in ALL_CANONICAL_TYPES —
+        // return the matching static ref.
+        return ALL_CANONICAL_TYPES
+            .iter()
+            .copied()
+            .find(|&s| s == frontend_type);
+    }
+
+    // 2. Language-specific mappings.
+    match language.to_lowercase().as_str() {
+        "twig" | "lispy" | "tetrad" | "algol" | "oct" => map_twig_like(frontend_type),
+        "typescript" | "ts" => map_typescript(frontend_type),
+        "ruby" | "sorbet" | "ruby-sorbet" => map_ruby(frontend_type),
+        "hack" | "php" => map_hack(frontend_type),
+        "python" | "mypy" => map_python(frontend_type),
+        "rust" | "c" | "c+" | "cpp" => map_rust_like(frontend_type),
+        _ => None,
+    }
+}
+
+/// Return `true` if `type_str` is already a canonical IIR type name.
+///
+/// ```
+/// use typing_spectrum::canonical::is_canonical;
+///
+/// assert!(is_canonical("i64"));
+/// assert!(is_canonical("bool"));
+/// assert!(!is_canonical("any"));  // "any" is not in ALL_CANONICAL_TYPES
+/// assert!(!is_canonical("Integer"));
+/// ```
+pub fn is_canonical(type_str: &str) -> bool {
+    ALL_CANONICAL_TYPES.contains(&type_str)
+}
+
+// ---------------------------------------------------------------------------
+// Private per-language helpers
+// ---------------------------------------------------------------------------
+
+fn map_twig_like(t: &str) -> Option<&'static str> {
+    // Twig, Lispy, Tetrad, Algol — all share a simple "int/float/bool/str/nil"
+    // vocabulary.  Some also accept the canonical Rust-style names directly.
+    match t {
+        "int" | "integer" | "Integer" => Some(TYPE_I64),
+        "float" | "double" | "Float"  => Some(TYPE_F64),
+        "bool" | "boolean" | "Bool"   => Some(TYPE_BOOL),
+        "string" | "String"           => Some(TYPE_STR),
+        "nil" | "null" | "Nil"        => Some(TYPE_NIL),
+        "symbol" | "Symbol"           => Some(TYPE_SYMBOL),
+        "closure" | "fn" | "lambda"   => Some(TYPE_CLOSURE),
+        "cons" | "pair"               => Some(TYPE_CONS),
+        _ => None,
+    }
+}
+
+fn map_typescript(t: &str) -> Option<&'static str> {
+    // TypeScript: `number` is always f64 (IEEE 754 double); `bigint` is
+    // intentionally not mapped because it exceeds i64 semantics.
+    match t {
+        "number"              => Some(TYPE_F64),
+        "boolean"             => Some(TYPE_BOOL),
+        "string"              => Some(TYPE_STR),
+        "null" | "undefined"  => Some(TYPE_NIL),
+        "symbol"              => Some(TYPE_SYMBOL),
+        // TypeScript function types are all "closure" in IIR.
+        "Function" | "(...args: any[]) => any" => Some(TYPE_CLOSURE),
+        _ => None,
+    }
+}
+
+fn map_ruby(t: &str) -> Option<&'static str> {
+    // Ruby / Sorbet: class names are PascalCase.
+    match t {
+        "Integer"                        => Some(TYPE_I64),
+        "Float"                          => Some(TYPE_F64),
+        "TrueClass" | "FalseClass" | "T::Boolean" => Some(TYPE_BOOL),
+        "String"                         => Some(TYPE_STR),
+        "Symbol"                         => Some(TYPE_SYMBOL),
+        "NilClass"                       => Some(TYPE_NIL),
+        "Proc" | "Method" | "UnboundMethod" => Some(TYPE_CLOSURE),
+        // Typed-list types could map to cons; conservative: only for Lisp-ish Ruby.
+        _ => None,
+    }
+}
+
+fn map_hack(t: &str) -> Option<&'static str> {
+    // Hack / HHVM: PHP-style lowercase names.
+    match t {
+        "int"    => Some(TYPE_I64),
+        "float"  => Some(TYPE_F64),
+        "bool"   => Some(TYPE_BOOL),
+        "string" => Some(TYPE_STR),
+        "null"   => Some(TYPE_NIL),
+        _ => None,
+    }
+}
+
+fn map_python(t: &str) -> Option<&'static str> {
+    // Mypy / Python: class names are PascalCase; built-ins are lowercase.
+    match t {
+        "int"   | "Int"   => Some(TYPE_I64),
+        "float" | "Float" => Some(TYPE_F64),
+        "bool"  | "Bool"  => Some(TYPE_BOOL),
+        "str"   | "Str"   => Some(TYPE_STR),
+        "None"  | "NoneType" => Some(TYPE_NIL),
+        _ => None,
+    }
+}
+
+fn map_rust_like(t: &str) -> Option<&'static str> {
+    // Rust / C / C+: use the canonical IIR names directly *plus* some aliases.
+    match t {
+        "i8"   => Some(TYPE_I8),
+        "i16"  => Some(TYPE_I16),
+        "i32"  => Some(TYPE_I32),
+        "i64"  => Some(TYPE_I64),
+        "u8"   => Some(TYPE_U8),
+        "u16"  => Some(TYPE_U16),
+        "u32"  => Some(TYPE_U32),
+        "u64"  => Some(TYPE_U64),
+        "f32"  => Some(TYPE_F32),
+        "f64"  => Some(TYPE_F64),
+        "bool" => Some(TYPE_BOOL),
+        // C aliases.
+        "char"           => Some(TYPE_U8),
+        "short"          => Some(TYPE_I16),
+        "int" | "long"   => Some(TYPE_I32),
+        "long long"      => Some(TYPE_I64),
+        "unsigned char"  => Some(TYPE_U8),
+        "unsigned short" => Some(TYPE_U16),
+        "unsigned int" | "unsigned long" => Some(TYPE_U32),
+        "unsigned long long" => Some(TYPE_U64),
+        "float"          => Some(TYPE_F32),
+        "double"         => Some(TYPE_F64),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Canonical pass-through ───────────────────────────────────────
+    #[test]
+    fn canonical_type_passes_through() {
+        for &ty in ALL_CANONICAL_TYPES {
+            assert_eq!(
+                map_frontend_type(ty, "any"),
+                Some(ty),
+                "canonical type {ty} not passed through"
+            );
+        }
+    }
+
+    #[test]
+    fn any_is_not_canonical() {
+        assert!(!is_canonical("any"));
+    }
+
+    #[test]
+    fn all_canonical_types_are_canonical() {
+        for &ty in ALL_CANONICAL_TYPES {
+            assert!(is_canonical(ty), "{ty} not recognised as canonical");
+        }
+    }
+
+    // ── Twig / Lispy ────────────────────────────────────────────────
+    #[test]
+    fn twig_int_maps_to_i64() {
+        assert_eq!(map_frontend_type("int", "twig"), Some("i64"));
+        assert_eq!(map_frontend_type("integer", "twig"), Some("i64"));
+    }
+
+    #[test]
+    fn twig_float_maps_to_f64() {
+        assert_eq!(map_frontend_type("float", "twig"), Some("f64"));
+        assert_eq!(map_frontend_type("double", "twig"), Some("f64"));
+    }
+
+    #[test]
+    fn twig_bool_maps_to_bool() {
+        assert_eq!(map_frontend_type("bool", "twig"), Some("bool"));
+        assert_eq!(map_frontend_type("boolean", "twig"), Some("bool"));
+    }
+
+    #[test]
+    fn twig_string_maps_to_str() {
+        assert_eq!(map_frontend_type("string", "twig"), Some("str"));
+        assert_eq!(map_frontend_type("String", "twig"), Some("str"));
+    }
+
+    #[test]
+    fn twig_nil_maps_to_nil() {
+        assert_eq!(map_frontend_type("nil", "twig"), Some("nil"));
+        assert_eq!(map_frontend_type("null", "twig"), Some("nil"));
+    }
+
+    #[test]
+    fn twig_symbol() {
+        assert_eq!(map_frontend_type("symbol", "twig"), Some("symbol"));
+    }
+
+    #[test]
+    fn twig_closure() {
+        assert_eq!(map_frontend_type("closure", "twig"), Some("closure"));
+        assert_eq!(map_frontend_type("lambda", "twig"), Some("closure"));
+    }
+
+    // ── TypeScript ───────────────────────────────────────────────────
+    #[test]
+    fn typescript_number_is_f64() {
+        assert_eq!(map_frontend_type("number", "typescript"), Some("f64"));
+    }
+
+    #[test]
+    fn typescript_boolean_is_bool() {
+        assert_eq!(map_frontend_type("boolean", "typescript"), Some("bool"));
+    }
+
+    #[test]
+    fn typescript_string_is_str() {
+        assert_eq!(map_frontend_type("string", "typescript"), Some("str"));
+    }
+
+    #[test]
+    fn typescript_null_is_nil() {
+        assert_eq!(map_frontend_type("null", "typescript"), Some("nil"));
+        assert_eq!(map_frontend_type("undefined", "typescript"), Some("nil"));
+    }
+
+    // ── Ruby / Sorbet ────────────────────────────────────────────────
+    #[test]
+    fn ruby_integer_is_i64() {
+        assert_eq!(map_frontend_type("Integer", "ruby"), Some("i64"));
+    }
+
+    #[test]
+    fn ruby_float_is_f64() {
+        assert_eq!(map_frontend_type("Float", "ruby"), Some("f64"));
+    }
+
+    #[test]
+    fn ruby_trueclass_is_bool() {
+        assert_eq!(map_frontend_type("TrueClass", "ruby"), Some("bool"));
+        assert_eq!(map_frontend_type("FalseClass", "ruby"), Some("bool"));
+    }
+
+    #[test]
+    fn ruby_nilclass_is_nil() {
+        assert_eq!(map_frontend_type("NilClass", "ruby"), Some("nil"));
+    }
+
+    #[test]
+    fn ruby_symbol_is_symbol() {
+        assert_eq!(map_frontend_type("Symbol", "ruby"), Some("symbol"));
+    }
+
+    #[test]
+    fn ruby_proc_is_closure() {
+        assert_eq!(map_frontend_type("Proc", "ruby"), Some("closure"));
+    }
+
+    // ── Hack ─────────────────────────────────────────────────────────
+    #[test]
+    fn hack_int_is_i64() {
+        assert_eq!(map_frontend_type("int", "hack"), Some("i64"));
+    }
+
+    #[test]
+    fn hack_float_is_f64() {
+        assert_eq!(map_frontend_type("float", "hack"), Some("f64"));
+    }
+
+    #[test]
+    fn hack_bool_is_bool() {
+        assert_eq!(map_frontend_type("bool", "hack"), Some("bool"));
+    }
+
+    #[test]
+    fn hack_null_is_nil() {
+        assert_eq!(map_frontend_type("null", "hack"), Some("nil"));
+    }
+
+    // ── Python / mypy ────────────────────────────────────────────────
+    #[test]
+    fn python_int_is_i64() {
+        assert_eq!(map_frontend_type("int", "python"), Some("i64"));
+    }
+
+    #[test]
+    fn python_none_is_nil() {
+        assert_eq!(map_frontend_type("None", "python"), Some("nil"));
+        assert_eq!(map_frontend_type("NoneType", "python"), Some("nil"));
+    }
+
+    #[test]
+    fn python_str_is_str() {
+        assert_eq!(map_frontend_type("str", "python"), Some("str"));
+    }
+
+    // ── Rust / C ────────────────────────────────────────────────────
+    #[test]
+    fn rust_primitives_pass_through() {
+        for &ty in NUMERIC_TYPES {
+            assert_eq!(map_frontend_type(ty, "rust"), Some(ty));
+        }
+        assert_eq!(map_frontend_type("bool", "rust"), Some("bool"));
+    }
+
+    #[test]
+    fn c_char_maps_to_u8() {
+        assert_eq!(map_frontend_type("char", "c"), Some("u8"));
+    }
+
+    #[test]
+    fn c_long_long_maps_to_i64() {
+        assert_eq!(map_frontend_type("long long", "c"), Some("i64"));
+    }
+
+    // ── Unknown types ────────────────────────────────────────────────
+    #[test]
+    fn unknown_type_returns_none() {
+        assert_eq!(map_frontend_type("Widget", "twig"), None);
+        assert_eq!(map_frontend_type("AnyRandomClass", "typescript"), None);
+    }
+
+    #[test]
+    fn unknown_language_returns_none_for_non_canonical() {
+        assert_eq!(map_frontend_type("Integer", "brainfuck"), None);
+    }
+}

--- a/code/packages/rust/typing-spectrum/src/lib.rs
+++ b/code/packages/rust/typing-spectrum/src/lib.rs
@@ -1,0 +1,108 @@
+//! # `typing-spectrum` — LANG22 compilation strategy for the optional-typing spectrum.
+//!
+//! LANG22 §"The optional-typing spectrum" classifies every LANG program
+//! somewhere on a continuum from "fully typed" (Tetrad, Algol) to "untyped"
+//! (Twig, MRI Ruby).  The same compilation pipeline serves all three tiers;
+//! what changes is *when and how* the pipeline specialises.
+//!
+//! This crate provides the **strategy layer** that bridges the type-tier
+//! information produced by [`iir-type-checker`] and the compilation decisions
+//! made by `aot-core`, `aot-with-pgo`, and `jit-core`:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────┐
+//! │  Language frontend                                                  │
+//! │    produces IIRModule with type_hints (or "any" for dynamic langs)  │
+//! └──────────────────────────────┬──────────────────────────────────────┘
+//!                                │
+//!                                ▼
+//! ┌─────────────────────────────────────────────────────────────────────┐
+//! │  iir-type-checker                                                   │
+//! │    infer_and_check(&mut module)                                     │
+//! │    ├─ infer_types_mut  : fills type_hint for inferable "any" instrs │
+//! │    └─ check_module     : validates the enriched annotations         │
+//! └──────────────────────────────┬──────────────────────────────────────┘
+//!                                │
+//!                                ▼
+//! ┌─────────────────────────────────────────────────────────────────────┐
+//! │  typing-spectrum  (THIS CRATE)                                      │
+//! │    advisory::advise(&module)                                        │
+//! │    ├─ module_tier        : TypingTier for the whole program         │
+//! │    ├─ recommended_mode   : CompilationMode (tree-walk/AOT/JIT)      │
+//! │    ├─ jit_threshold      : call count before JIT promotion          │
+//! │    └─ per-function       : FunctionAdvisory for each function       │
+//! └──────────────────────────────┬──────────────────────────────────────┘
+//!                                │
+//!                     ┌──────────┴──────────┐
+//!                     ▼                     ▼
+//!              aot-no-profile           jit-core
+//!              aot-with-pgo             (uses threshold + tier)
+//! ```
+//!
+//! ## The five compilation modes
+//!
+//! | Mode | Description | Requires deopt? | Requires `.ldp` input? |
+//! |------|-------------|-----------------|------------------------|
+//! | 1: [`TreeWalking`](mode::CompilationMode::TreeWalking) | Interpret `IIRModule` directly | No | No |
+//! | 2: [`AotNoProfile`](mode::CompilationMode::AotNoProfile) | Typed → native; untyped → runtime calls | **No** | No |
+//! | 3: [`AotWithPgo`](mode::CompilationMode::AotWithPgo) | Speculation + deopt anchors from `.ldp` | Yes | Yes |
+//! | 4: [`Jit`](mode::CompilationMode::Jit) | Tier-up from interpreter on call-count | Yes | No |
+//! | 5: [`JitThenAotWithPgo`](mode::CompilationMode::JitThenAotWithPgo) | JIT → save `.ldp` → AOT-PGO at release | Yes | Yes (at release) |
+//!
+//! ## The three typing tiers (LANG22 §"The optional-typing spectrum")
+//!
+//! | LANG22 label | `TypingTier` | Examples |
+//! |---|---|---|
+//! | Tier A — fully typed | `FullyTyped` | Tetrad, Algol, Rust, C+ |
+//! | Tier B — partially typed | `Partial(fraction)` | TypeScript, Sorbet-Ruby, Hack |
+//! | Tier C — untyped | `Untyped` | Twig, MRI Ruby, Python (pre-mypy) |
+//!
+//! ## Quick start
+//!
+//! ```
+//! use interpreter_ir::module::IIRModule;
+//! use interpreter_ir::function::IIRFunction;
+//! use interpreter_ir::instr::{IIRInstr, Operand};
+//! use iir_type_checker::infer_and_check;
+//! use typing_spectrum::advisory::advise;
+//! use typing_spectrum::mode::CompilationMode;
+//!
+//! // Build a fully-typed "add" function.
+//! let fn_ = IIRFunction::new(
+//!     "add",
+//!     vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+//!     "i64",
+//!     vec![
+//!         IIRInstr::new("add", Some("v".into()),
+//!             vec![Operand::Var("a".into()), Operand::Var("b".into())], "i64"),
+//!         IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+//!     ],
+//! );
+//! let mut module = IIRModule::new("math", "tetrad");
+//! module.add_or_replace(fn_);
+//!
+//! // Step 1: infer + check types.
+//! infer_and_check(&mut module);
+//!
+//! // Step 2: get compilation advisory.
+//! let adv = advise(&module);
+//!
+//! // Fully-typed → AOT-no-profile (no JIT warmup required).
+//! assert_eq!(adv.recommended_mode, CompilationMode::AotNoProfile);
+//! assert!(!adv.requires_deopt());
+//! assert_eq!(adv.functions[0].jit_threshold.call_count, 0);
+//! ```
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+pub mod advisory;
+pub mod canonical;
+pub mod mode;
+pub mod threshold;
+
+// Re-export the most commonly used items at the crate root.
+pub use advisory::{advise, CompilationAdvisory, FunctionAdvisory};
+pub use canonical::{map_frontend_type, ALL_CANONICAL_TYPES, TYPE_ANY, TYPE_BOOL, TYPE_I64};
+pub use mode::CompilationMode;
+pub use threshold::JitPromotionThreshold;

--- a/code/packages/rust/typing-spectrum/src/mode.rs
+++ b/code/packages/rust/typing-spectrum/src/mode.rs
@@ -1,0 +1,363 @@
+//! # `CompilationMode` — the five modes of the LANG compilation pipeline.
+//!
+//! LANG22 §"The five compilation modes" organises every execution path into
+//! five mutually-understandable modes.  This module provides the enum and
+//! query methods so the rest of the pipeline — `aot-no-profile`, `aot-with-pgo`,
+//! `jit-core`, and the CLI driver — can reason about modes uniformly.
+//!
+//! ## Mode relationships
+//!
+//! ```text
+//! Mode 1: Tree-walking interpretation
+//!   ↓ profile collected (Mode 4)
+//! Mode 4: JIT (tier-up from interpreter)
+//!   ↓ profile written to .ldp
+//! Mode 3: AOT-with-PGO   ←──────────────── Mode 2: AOT-no-profile (parallel path)
+//!   ↓ compound (Mode 5)                          ↓
+//! Mode 5: JIT-then-write-profile-then-AOT-PGO
+//! ```
+//!
+//! Mode 2 (AOT-no-profile) is the *conservative* path — no speculation, no
+//! deopt mechanism, ships before the JIT exists.  Mode 3 is the *aggressive*
+//! path — speculates on profiled types, requires deopt machinery.
+
+use iir_type_checker::tier::TypingTier;
+
+// ---------------------------------------------------------------------------
+// CompilationMode
+// ---------------------------------------------------------------------------
+
+/// The five compilation modes of the LANG pipeline.
+///
+/// Each mode has a different cost/benefit profile depending on the
+/// [`TypingTier`] of the program being compiled.  Use
+/// [`CompilationMode::recommended_for`] to get a data-driven suggestion.
+///
+/// # Example
+///
+/// ```
+/// use typing_spectrum::mode::CompilationMode;
+/// use iir_type_checker::tier::TypingTier;
+///
+/// let mode = CompilationMode::recommended_for(&TypingTier::Untyped);
+/// // Untyped programs warm up best via JIT; AOT-with-PGO on the next build.
+/// assert_eq!(mode, CompilationMode::Jit);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CompilationMode {
+    /// **Mode 1** — tree-walking interpretation of `IIRModule`.
+    ///
+    /// - Input: `IIRModule`
+    /// - Output: live `Value` (per-language)
+    /// - Speed: baseline (1×)
+    /// - Use: development, REPL, cold paths after AOT deopts
+    /// - Deopt mechanism: none (this *is* the deopt target)
+    TreeWalking,
+
+    /// **Mode 2** — ahead-of-time compilation without a profile.
+    ///
+    /// Typed instructions → native machine code.
+    /// Untyped instructions → calls into `liblang-runtime.a`.
+    ///
+    /// - Input: `IIRModule` (with or without type hints)
+    /// - Output: native binary statically linked against the runtime
+    /// - Speed: ~3–10× tree-walking for dynamic languages,
+    ///          ~50–100× for fully-typed languages
+    /// - Use: cold-start–sensitive CLIs, cross-compilation, programs without warmup budget
+    /// - Deopt mechanism: **not required** — no speculation emitted
+    AotNoProfile,
+
+    /// **Mode 3** — ahead-of-time compilation with a PGO profile artefact.
+    ///
+    /// The `.ldp` profile promotes `type_hint = "any"` to observed types
+    /// wherever confidence exceeds the threshold (default 99%).  The codegen
+    /// emits speculative native code plus deopt anchors on the hot path.
+    ///
+    /// - Input: `IIRModule` + `.ldp` profile artefact
+    /// - Output: native binary with embedded `.deopt` metadata
+    /// - Speed: ~30–50× tree-walking for type-stable programs
+    /// - Use: production deployment after profile collection
+    /// - Deopt mechanism: **required** (`BoxedReprToken` + frame descriptors)
+    AotWithPgo,
+
+    /// **Mode 4** — JIT tier-up from the interpreter.
+    ///
+    /// The interpreter profiles instruction types as the program runs.  When
+    /// a function's call count crosses the tier threshold (see
+    /// [`crate::threshold::JitPromotionThreshold`]) the JIT compiles it using
+    /// the live observations and patches the function table in-process.
+    ///
+    /// - Input: `IIRModule` + live observations from the interpreter
+    /// - Output: native code in this process's memory
+    /// - Speed: ~30–50× tree-walking once warm
+    /// - Use: long-running programs, servers, REPLs
+    /// - Deopt mechanism: **required** (same as Mode 3)
+    Jit,
+
+    /// **Mode 5** — compound JIT → profile → AOT-with-PGO.
+    ///
+    /// Run Mode 4 in development; on shutdown the JIT writes a `.ldp`
+    /// artefact; the release build uses Mode 3 with that artefact.
+    /// GraalVM Native Image's primary mode.
+    ///
+    /// - Input: `IIRModule` (run); `IIRModule + .ldp` (compile)
+    /// - Speed: as good as Mode 3 on the profiled workload
+    /// - Use: release builds of servers, libraries, and CLIs where
+    ///        cold-start *and* peak throughput matter
+    JitThenAotWithPgo,
+}
+
+impl CompilationMode {
+    /// Recommend the best **initial** compilation mode for a module at
+    /// the given typing tier.
+    ///
+    /// The recommendation is based purely on the typing tier.  Deployment
+    /// context (server vs CLI, warmup budget, etc.) may override it; this
+    /// is the reasonable default.
+    ///
+    /// | Tier | Recommended mode | Rationale |
+    /// |------|-----------------|-----------|
+    /// | `FullyTyped` | [`AotNoProfile`](CompilationMode::AotNoProfile) | All types known statically; AOT produces near-C code without profiling overhead. |
+    /// | `Partial` ≥ 70% | [`AotNoProfile`](CompilationMode::AotNoProfile) | Enough static types to win from AOT immediately; profile fills the rest. |
+    /// | `Partial` < 70% | [`Jit`](CompilationMode::Jit) | Too many untyped paths; JIT learns them and writes a `.ldp` for later AOT-PGO. |
+    /// | `Untyped` | [`Jit`](CompilationMode::Jit) | No static types at all; JIT is the only source of specialisation data. |
+    ///
+    /// ```
+    /// use typing_spectrum::mode::CompilationMode;
+    /// use iir_type_checker::tier::TypingTier;
+    ///
+    /// assert_eq!(CompilationMode::recommended_for(&TypingTier::FullyTyped),  CompilationMode::AotNoProfile);
+    /// assert_eq!(CompilationMode::recommended_for(&TypingTier::Partial(0.8)), CompilationMode::AotNoProfile);
+    /// assert_eq!(CompilationMode::recommended_for(&TypingTier::Partial(0.5)), CompilationMode::Jit);
+    /// assert_eq!(CompilationMode::recommended_for(&TypingTier::Untyped),     CompilationMode::Jit);
+    /// ```
+    pub fn recommended_for(tier: &TypingTier) -> Self {
+        match tier {
+            TypingTier::FullyTyped => CompilationMode::AotNoProfile,
+            TypingTier::Partial(frac) if *frac >= 0.70 => CompilationMode::AotNoProfile,
+            TypingTier::Partial(_) => CompilationMode::Jit,
+            TypingTier::Untyped => CompilationMode::Jit,
+        }
+    }
+
+    /// Human-readable one-line description of this mode.
+    pub fn description(&self) -> &'static str {
+        match self {
+            CompilationMode::TreeWalking =>
+                "Mode 1: Tree-walking interpretation (baseline)",
+            CompilationMode::AotNoProfile =>
+                "Mode 2: AOT-no-profile (typed → native, untyped → runtime calls)",
+            CompilationMode::AotWithPgo =>
+                "Mode 3: AOT-with-PGO (speculation + deopt anchors from .ldp profile)",
+            CompilationMode::Jit =>
+                "Mode 4: JIT tier-up (live type observations → native code in-process)",
+            CompilationMode::JitThenAotWithPgo =>
+                "Mode 5: JIT-then-AOT-PGO (run JIT, save .ldp, AOT-compile for release)",
+        }
+    }
+
+    /// Whether this mode requires the deopt mechanism
+    /// (`BoxedReprToken` + frame descriptors + `lang_deopt` ABI entry).
+    ///
+    /// [`AotNoProfile`](CompilationMode::AotNoProfile) and
+    /// [`TreeWalking`](CompilationMode::TreeWalking) are the only modes
+    /// that do **not** speculate, so they need no deopt.
+    ///
+    /// ```
+    /// use typing_spectrum::mode::CompilationMode;
+    ///
+    /// assert!(!CompilationMode::TreeWalking.requires_deopt());
+    /// assert!(!CompilationMode::AotNoProfile.requires_deopt());
+    /// assert!(CompilationMode::AotWithPgo.requires_deopt());
+    /// assert!(CompilationMode::Jit.requires_deopt());
+    /// assert!(CompilationMode::JitThenAotWithPgo.requires_deopt());
+    /// ```
+    pub fn requires_deopt(&self) -> bool {
+        matches!(
+            self,
+            CompilationMode::AotWithPgo
+                | CompilationMode::Jit
+                | CompilationMode::JitThenAotWithPgo
+        )
+    }
+
+    /// Whether this mode needs a `.ldp` profile artefact as **input**.
+    ///
+    /// Modes 3 and 5 read a `.ldp` file at compile time to promote
+    /// `type_hint = "any"` fields.  Modes 1, 2, and 4 do not.
+    ///
+    /// ```
+    /// use typing_spectrum::mode::CompilationMode;
+    ///
+    /// assert!(!CompilationMode::AotNoProfile.requires_profile_input());
+    /// assert!(CompilationMode::AotWithPgo.requires_profile_input());
+    /// assert!(CompilationMode::JitThenAotWithPgo.requires_profile_input());
+    /// ```
+    pub fn requires_profile_input(&self) -> bool {
+        matches!(
+            self,
+            CompilationMode::AotWithPgo | CompilationMode::JitThenAotWithPgo
+        )
+    }
+
+    /// Whether this mode **writes** a `.ldp` artefact (JIT observations
+    /// serialised to disk on shutdown / flush).
+    ///
+    /// ```
+    /// use typing_spectrum::mode::CompilationMode;
+    ///
+    /// assert!(!CompilationMode::AotNoProfile.writes_profile());
+    /// assert!(CompilationMode::Jit.writes_profile());
+    /// assert!(CompilationMode::JitThenAotWithPgo.writes_profile());
+    /// ```
+    pub fn writes_profile(&self) -> bool {
+        matches!(
+            self,
+            CompilationMode::Jit | CompilationMode::JitThenAotWithPgo
+        )
+    }
+
+    /// Approximate speedup range over tree-walking interpretation
+    /// (returned as `(low_multiplier, high_multiplier)`) at the given
+    /// typing tier.  These are the spec's ballpark figures, not guarantees.
+    ///
+    /// ```
+    /// use typing_spectrum::mode::CompilationMode;
+    /// use iir_type_checker::tier::TypingTier;
+    ///
+    /// let (lo, hi) = CompilationMode::AotNoProfile
+    ///     .expected_speedup_over_interp(&TypingTier::Untyped);
+    /// assert!(lo <= hi);
+    /// ```
+    pub fn expected_speedup_over_interp(&self, tier: &TypingTier) -> (u32, u32) {
+        match (self, tier) {
+            (CompilationMode::TreeWalking, _) => (1, 1),
+
+            (CompilationMode::AotNoProfile, TypingTier::FullyTyped) => (50, 100),
+            (CompilationMode::AotNoProfile, TypingTier::Partial(_)) => (5, 30),
+            (CompilationMode::AotNoProfile, TypingTier::Untyped)    => (3, 10),
+
+            (CompilationMode::AotWithPgo,  TypingTier::FullyTyped) => (50, 100),
+            (CompilationMode::AotWithPgo,  _)                      => (30, 50),
+
+            (CompilationMode::Jit, TypingTier::FullyTyped) => (10, 30), // modest: already typed
+            (CompilationMode::Jit, _)                      => (30, 50),
+
+            (CompilationMode::JitThenAotWithPgo, TypingTier::FullyTyped) => (50, 100),
+            (CompilationMode::JitThenAotWithPgo, _)                      => (30, 50),
+        }
+    }
+}
+
+impl std::fmt::Display for CompilationMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let short = match self {
+            CompilationMode::TreeWalking       => "tree-walking",
+            CompilationMode::AotNoProfile      => "aot-no-profile",
+            CompilationMode::AotWithPgo        => "aot-with-pgo",
+            CompilationMode::Jit               => "jit",
+            CompilationMode::JitThenAotWithPgo => "jit-then-aot-pgo",
+        };
+        f.write_str(short)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fully_typed_recommends_aot_no_profile() {
+        assert_eq!(
+            CompilationMode::recommended_for(&TypingTier::FullyTyped),
+            CompilationMode::AotNoProfile
+        );
+    }
+
+    #[test]
+    fn partial_high_recommends_aot_no_profile() {
+        assert_eq!(
+            CompilationMode::recommended_for(&TypingTier::Partial(0.70)),
+            CompilationMode::AotNoProfile
+        );
+        assert_eq!(
+            CompilationMode::recommended_for(&TypingTier::Partial(0.99)),
+            CompilationMode::AotNoProfile
+        );
+    }
+
+    #[test]
+    fn partial_low_recommends_jit() {
+        assert_eq!(
+            CompilationMode::recommended_for(&TypingTier::Partial(0.69)),
+            CompilationMode::Jit
+        );
+        assert_eq!(
+            CompilationMode::recommended_for(&TypingTier::Partial(0.10)),
+            CompilationMode::Jit
+        );
+    }
+
+    #[test]
+    fn untyped_recommends_jit() {
+        assert_eq!(
+            CompilationMode::recommended_for(&TypingTier::Untyped),
+            CompilationMode::Jit
+        );
+    }
+
+    #[test]
+    fn deopt_requirement_correct() {
+        assert!(!CompilationMode::TreeWalking.requires_deopt());
+        assert!(!CompilationMode::AotNoProfile.requires_deopt());
+        assert!(CompilationMode::AotWithPgo.requires_deopt());
+        assert!(CompilationMode::Jit.requires_deopt());
+        assert!(CompilationMode::JitThenAotWithPgo.requires_deopt());
+    }
+
+    #[test]
+    fn profile_input_correct() {
+        assert!(!CompilationMode::TreeWalking.requires_profile_input());
+        assert!(!CompilationMode::AotNoProfile.requires_profile_input());
+        assert!(!CompilationMode::Jit.requires_profile_input());
+        assert!(CompilationMode::AotWithPgo.requires_profile_input());
+        assert!(CompilationMode::JitThenAotWithPgo.requires_profile_input());
+    }
+
+    #[test]
+    fn profile_write_correct() {
+        assert!(!CompilationMode::TreeWalking.writes_profile());
+        assert!(!CompilationMode::AotNoProfile.writes_profile());
+        assert!(!CompilationMode::AotWithPgo.writes_profile());
+        assert!(CompilationMode::Jit.writes_profile());
+        assert!(CompilationMode::JitThenAotWithPgo.writes_profile());
+    }
+
+    #[test]
+    fn speedup_range_is_sensible() {
+        for tier in [
+            TypingTier::FullyTyped,
+            TypingTier::Partial(0.5),
+            TypingTier::Untyped,
+        ] {
+            for mode in [
+                CompilationMode::TreeWalking,
+                CompilationMode::AotNoProfile,
+                CompilationMode::AotWithPgo,
+                CompilationMode::Jit,
+                CompilationMode::JitThenAotWithPgo,
+            ] {
+                let (lo, hi) = mode.expected_speedup_over_interp(&tier);
+                assert!(lo <= hi, "mode={mode}, tier={tier:?}: lo={lo} > hi={hi}");
+                assert!(lo >= 1, "speedup below 1× for mode={mode}");
+            }
+        }
+    }
+
+    #[test]
+    fn display_matches_short_name() {
+        assert_eq!(CompilationMode::AotNoProfile.to_string(), "aot-no-profile");
+        assert_eq!(CompilationMode::Jit.to_string(), "jit");
+    }
+}

--- a/code/packages/rust/typing-spectrum/src/threshold.rs
+++ b/code/packages/rust/typing-spectrum/src/threshold.rs
@@ -1,0 +1,254 @@
+//! # `JitPromotionThreshold` — per-typing-tier JIT call-count thresholds.
+//!
+//! LANG22 §"JIT compilation pipeline" specifies:
+//!
+//! | Tier | `FullyTyped` | `PartiallyTyped` | `Untyped` |
+//! |------|-------------|-------------------|-----------|
+//! | Threshold (calls) | 0 (before first call) | 10 | 100 |
+//!
+//! The rationale:
+//!
+//! - **FullyTyped (threshold = 0)**: every type is known statically at
+//!   compile time.  The JIT doesn't need to observe anything — it can
+//!   emit specialised native code immediately, before the function ever
+//!   executes in the interpreter.
+//!
+//! - **PartiallyTyped (threshold = 10)**: a handful of interpreter runs
+//!   is enough to confirm the observed types match the declared types and
+//!   to fill in the `"any"` slots.  Ten calls is a conservative minimum
+//!   that avoids premature specialisation on atypical input.
+//!
+//! - **Untyped (threshold = 100)**: the profiler needs more observations
+//!   to build confidence.  A function called only a few times is "cold"
+//!   by definition and not worth JIT-compiling.  100 calls provides
+//!   enough signal to distinguish monomorphic from polymorphic behaviour
+//!   with high accuracy (V8 uses a similar value of 64–128).
+//!
+//! ## Partial-tier interpolation
+//!
+//! For `Partial(fraction)` tiers the threshold is **linearly interpolated**
+//! between the boundaries:
+//!
+//! ```text
+//! threshold = round(10 + (100 - 10) × (1.0 - fraction))
+//!           = round(10 + 90 × (1.0 - fraction))
+//! ```
+//!
+//! A `Partial(1.0)` function (effectively fully typed) gets threshold 10
+//! rather than 0 because the JIT still needs a few observations to confirm
+//! the partial annotations are consistent.  A `Partial(0.0)` function (just
+//! barely not `Untyped`) gets threshold 100.
+//!
+//! ```
+//! use typing_spectrum::threshold::JitPromotionThreshold;
+//! use iir_type_checker::tier::TypingTier;
+//!
+//! assert_eq!(JitPromotionThreshold::for_tier(&TypingTier::FullyTyped).call_count, 0);
+//! assert_eq!(JitPromotionThreshold::for_tier(&TypingTier::Partial(1.0)).call_count, 10);
+//! assert_eq!(JitPromotionThreshold::for_tier(&TypingTier::Partial(0.0)).call_count, 100);
+//! assert_eq!(JitPromotionThreshold::for_tier(&TypingTier::Untyped).call_count, 100);
+//! ```
+
+use iir_type_checker::tier::TypingTier;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Call-count threshold for [`TypingTier::FullyTyped`] functions.
+///
+/// Zero means "compile before the first interpreted call" — the JIT precompiles
+/// the function lazily on first-touch (call_count was 0 at dispatch time).
+pub const THRESHOLD_FULLY_TYPED: u32 = 0;
+
+/// Call-count threshold for the anchor of the [`TypingTier::Partial`] range
+/// (fraction = 1.0, effectively fully typed but annotated partially).
+pub const THRESHOLD_PARTIAL_HI: u32 = 10;
+
+/// Call-count threshold for the anchor of the [`TypingTier::Partial`] range
+/// (fraction = 0.0, effectively untyped but annotated partially) and for
+/// [`TypingTier::Untyped`].
+pub const THRESHOLD_UNTYPED: u32 = 100;
+
+// ---------------------------------------------------------------------------
+// JitPromotionThreshold
+// ---------------------------------------------------------------------------
+
+/// The call count at which the JIT should promote a function from the
+/// interpreter tier to native code.
+///
+/// Obtain via [`JitPromotionThreshold::for_tier`].  The `call_count` field
+/// is the raw threshold; comparison is `>=` (promote when the function has
+/// been called at least this many times).
+///
+/// # Example
+///
+/// ```
+/// use typing_spectrum::threshold::JitPromotionThreshold;
+/// use iir_type_checker::tier::TypingTier;
+///
+/// let t = JitPromotionThreshold::for_tier(&TypingTier::Untyped);
+/// assert!(t.should_promote(100));
+/// assert!(!t.should_promote(99));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct JitPromotionThreshold {
+    /// The minimum call count required before the JIT promotes this function.
+    ///
+    /// - `0` → promote immediately on first dispatch (no interpreter run).
+    /// - `N > 0` → wait until the interpreter has executed the function `N` times.
+    pub call_count: u32,
+}
+
+impl JitPromotionThreshold {
+    /// Compute the promotion threshold for the given [`TypingTier`].
+    ///
+    /// See the [module-level docs](self) for the interpolation formula.
+    ///
+    /// ```
+    /// use typing_spectrum::threshold::JitPromotionThreshold;
+    /// use iir_type_checker::tier::TypingTier;
+    ///
+    /// assert_eq!(JitPromotionThreshold::for_tier(&TypingTier::FullyTyped).call_count, 0);
+    /// assert_eq!(JitPromotionThreshold::for_tier(&TypingTier::Partial(0.5)).call_count, 55);
+    /// assert_eq!(JitPromotionThreshold::for_tier(&TypingTier::Untyped).call_count, 100);
+    /// ```
+    pub fn for_tier(tier: &TypingTier) -> Self {
+        let call_count = match tier {
+            TypingTier::FullyTyped => THRESHOLD_FULLY_TYPED,
+            TypingTier::Untyped   => THRESHOLD_UNTYPED,
+            TypingTier::Partial(fraction) => {
+                // Linear interpolation: 10 at fraction=1.0, 100 at fraction=0.0.
+                // threshold = round(10 + 90 × (1.0 - fraction))
+                let frac = fraction.clamp(0.0, 1.0) as f64;
+                let raw = THRESHOLD_PARTIAL_HI as f64 + 90.0 * (1.0 - frac);
+                raw.round() as u32
+            }
+        };
+        JitPromotionThreshold { call_count }
+    }
+
+    /// Return `true` when the given call count has reached or exceeded the
+    /// promotion threshold.
+    ///
+    /// For a threshold of 0, this is always `true` (the function is promoted
+    /// before its first interpreted call).
+    ///
+    /// ```
+    /// use typing_spectrum::threshold::JitPromotionThreshold;
+    ///
+    /// let t = JitPromotionThreshold { call_count: 10 };
+    /// assert!(t.should_promote(10));
+    /// assert!(t.should_promote(100));
+    /// assert!(!t.should_promote(9));
+    ///
+    /// // threshold = 0: always ready
+    /// let eager = JitPromotionThreshold { call_count: 0 };
+    /// assert!(eager.should_promote(0));
+    /// ```
+    pub fn should_promote(&self, actual_call_count: u32) -> bool {
+        actual_call_count >= self.call_count
+    }
+
+    /// Human-readable label for use in advisory reports.
+    ///
+    /// ```
+    /// use typing_spectrum::threshold::JitPromotionThreshold;
+    ///
+    /// assert_eq!(JitPromotionThreshold { call_count: 0 }.label(), "compile-before-first-call");
+    /// assert_eq!(JitPromotionThreshold { call_count: 10 }.label(), "after-10-calls");
+    /// assert_eq!(JitPromotionThreshold { call_count: 100 }.label(), "after-100-calls");
+    /// ```
+    pub fn label(&self) -> String {
+        if self.call_count == 0 {
+            "compile-before-first-call".to_string()
+        } else {
+            format!("after-{}-calls", self.call_count)
+        }
+    }
+}
+
+impl std::fmt::Display for JitPromotionThreshold {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.label())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fully_typed_threshold_is_zero() {
+        let t = JitPromotionThreshold::for_tier(&TypingTier::FullyTyped);
+        assert_eq!(t.call_count, THRESHOLD_FULLY_TYPED);
+    }
+
+    #[test]
+    fn untyped_threshold_is_hundred() {
+        let t = JitPromotionThreshold::for_tier(&TypingTier::Untyped);
+        assert_eq!(t.call_count, THRESHOLD_UNTYPED);
+    }
+
+    #[test]
+    fn partial_at_one_is_ten() {
+        let t = JitPromotionThreshold::for_tier(&TypingTier::Partial(1.0));
+        assert_eq!(t.call_count, 10);
+    }
+
+    #[test]
+    fn partial_at_zero_is_hundred() {
+        let t = JitPromotionThreshold::for_tier(&TypingTier::Partial(0.0));
+        assert_eq!(t.call_count, 100);
+    }
+
+    #[test]
+    fn partial_at_half_is_fifty_five() {
+        let t = JitPromotionThreshold::for_tier(&TypingTier::Partial(0.5));
+        // 10 + 90 × 0.5 = 55
+        assert_eq!(t.call_count, 55);
+    }
+
+    #[test]
+    fn partial_interpolates_monotonically() {
+        // Higher typed fraction → lower threshold.
+        let fracs = [0.0f32, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0];
+        let mut prev = u32::MAX;
+        for &f in &fracs {
+            let t = JitPromotionThreshold::for_tier(&TypingTier::Partial(f));
+            assert!(t.call_count <= prev,
+                "threshold non-monotonic at fraction={f}: {} > {prev}", t.call_count);
+            prev = t.call_count;
+        }
+    }
+
+    #[test]
+    fn should_promote_at_exactly_threshold() {
+        let t = JitPromotionThreshold { call_count: 10 };
+        assert!(t.should_promote(10));
+        assert!(!t.should_promote(9));
+    }
+
+    #[test]
+    fn should_promote_zero_threshold_always_true() {
+        let t = JitPromotionThreshold { call_count: 0 };
+        assert!(t.should_promote(0));
+        assert!(t.should_promote(1_000_000));
+    }
+
+    #[test]
+    fn label_matches_expected_strings() {
+        assert_eq!(
+            JitPromotionThreshold { call_count: 0 }.label(),
+            "compile-before-first-call"
+        );
+        assert_eq!(
+            JitPromotionThreshold { call_count: 10 }.label(),
+            "after-10-calls"
+        );
+        assert_eq!(
+            JitPromotionThreshold { call_count: 100 }.label(),
+            "after-100-calls"
+        );
+    }
+}

--- a/code/packages/rust/typing-spectrum/tests/test_typing_spectrum.rs
+++ b/code/packages/rust/typing-spectrum/tests/test_typing_spectrum.rs
@@ -1,0 +1,415 @@
+//! Integration tests for the `typing-spectrum` crate.
+//!
+//! These tests exercise the full pipeline:
+//!  1. Build an IIRModule (with varying levels of type information).
+//!  2. Run `iir_type_checker::infer_and_check` to fill in inferred types.
+//!  3. Run `typing_spectrum::advise` to get the compilation advisory.
+//!  4. Assert on mode, threshold, tier, and helper predicates.
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::module::IIRModule;
+use iir_type_checker::infer_and_check;
+use typing_spectrum::advisory::advise;
+use typing_spectrum::canonical::{
+    map_frontend_type, is_canonical, ALL_CANONICAL_TYPES, TYPE_I64, TYPE_F64, TYPE_BOOL, TYPE_ANY,
+};
+use typing_spectrum::mode::CompilationMode;
+use typing_spectrum::threshold::{JitPromotionThreshold, THRESHOLD_FULLY_TYPED, THRESHOLD_UNTYPED};
+use iir_type_checker::tier::TypingTier;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a module with one fully-typed "identity" function.
+fn fully_typed_module() -> IIRModule {
+    let fn_ = IIRFunction::new(
+        "identity",
+        vec![("x".into(), "i64".into())],
+        "i64",
+        vec![
+            IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i64"),
+        ],
+    );
+    let mut m = IIRModule::new("typed", "tetrad");
+    m.add_or_replace(fn_);
+    m
+}
+
+/// Build a module with one untyped function (all "any").
+fn untyped_module() -> IIRModule {
+    let fn_ = IIRFunction::new(
+        "mystery",
+        vec![("a".into(), "any".into()), ("b".into(), "any".into())],
+        "any",
+        vec![
+            IIRInstr::new(
+                "add",
+                Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "any"),
+        ],
+    );
+    let mut m = IIRModule::new("untyped", "twig");
+    m.add_or_replace(fn_);
+    m
+}
+
+/// Build a module with one partially-typed function.
+fn partial_module() -> IIRModule {
+    let fn_ = IIRFunction::new(
+        "mixed",
+        vec![("n".into(), "i64".into()), ("s".into(), "any".into())],
+        "any",
+        vec![
+            // typed: "const" with Int literal → will be inferred as i64
+            IIRInstr::new("const", Some("one".into()), vec![Operand::Int(1)], "any"),
+            // typed: add with all-i64 operands → will be inferred as i64
+            IIRInstr::new(
+                "add",
+                Some("np1".into()),
+                vec![Operand::Var("n".into()), Operand::Var("one".into())],
+                "any",
+            ),
+            // untyped: uses "s" which is "any"
+            IIRInstr::new(
+                "call_builtin",
+                Some("result".into()),
+                vec![Operand::Var("s".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("result".into())], "any"),
+        ],
+    );
+    let mut m = IIRModule::new("partial", "twig");
+    m.add_or_replace(fn_);
+    m
+}
+
+// ===========================================================================
+// CompilationMode tests
+// ===========================================================================
+
+#[test]
+fn fully_typed_module_recommends_aot_no_profile() {
+    let mut m = fully_typed_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    assert_eq!(adv.recommended_mode, CompilationMode::AotNoProfile);
+}
+
+#[test]
+fn fully_typed_does_not_require_deopt() {
+    let mut m = fully_typed_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    assert!(!adv.requires_deopt());
+}
+
+#[test]
+fn fully_typed_does_not_require_profile_input() {
+    assert!(!CompilationMode::AotNoProfile.requires_profile_input());
+}
+
+#[test]
+fn jit_mode_writes_profile() {
+    assert!(CompilationMode::Jit.writes_profile());
+    assert!(CompilationMode::JitThenAotWithPgo.writes_profile());
+    assert!(!CompilationMode::AotNoProfile.writes_profile());
+    assert!(!CompilationMode::AotWithPgo.writes_profile());
+}
+
+#[test]
+fn aot_with_pgo_requires_profile_input() {
+    assert!(CompilationMode::AotWithPgo.requires_profile_input());
+}
+
+#[test]
+fn tree_walking_never_requires_deopt_or_profile() {
+    assert!(!CompilationMode::TreeWalking.requires_deopt());
+    assert!(!CompilationMode::TreeWalking.requires_profile_input());
+    assert!(!CompilationMode::TreeWalking.writes_profile());
+}
+
+#[test]
+fn untyped_module_recommends_jit() {
+    let mut m = untyped_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    // An untyped module (all "any", inference can't help because params are "any")
+    // should recommend JIT.
+    assert_eq!(adv.recommended_mode, CompilationMode::Jit);
+}
+
+#[test]
+fn mode_description_is_non_empty() {
+    for mode in [
+        CompilationMode::TreeWalking,
+        CompilationMode::AotNoProfile,
+        CompilationMode::AotWithPgo,
+        CompilationMode::Jit,
+        CompilationMode::JitThenAotWithPgo,
+    ] {
+        assert!(!mode.description().is_empty(), "empty description for {mode}");
+    }
+}
+
+#[test]
+fn mode_display_is_lowercase_kebab() {
+    assert_eq!(CompilationMode::AotNoProfile.to_string(), "aot-no-profile");
+    assert_eq!(CompilationMode::AotWithPgo.to_string(), "aot-with-pgo");
+    assert_eq!(CompilationMode::Jit.to_string(), "jit");
+    assert_eq!(CompilationMode::JitThenAotWithPgo.to_string(), "jit-then-aot-pgo");
+    assert_eq!(CompilationMode::TreeWalking.to_string(), "tree-walking");
+}
+
+#[test]
+fn speedup_range_is_positive_and_ordered_for_all_combinations() {
+    let tiers = [
+        TypingTier::FullyTyped,
+        TypingTier::Partial(0.5),
+        TypingTier::Untyped,
+    ];
+    let modes = [
+        CompilationMode::TreeWalking,
+        CompilationMode::AotNoProfile,
+        CompilationMode::AotWithPgo,
+        CompilationMode::Jit,
+        CompilationMode::JitThenAotWithPgo,
+    ];
+    for tier in &tiers {
+        for mode in &modes {
+            let (lo, hi) = mode.expected_speedup_over_interp(tier);
+            assert!(lo >= 1, "{mode} × {tier:?}: lo={lo} < 1");
+            assert!(lo <= hi, "{mode} × {tier:?}: lo={lo} > hi={hi}");
+        }
+    }
+}
+
+// ===========================================================================
+// JitPromotionThreshold tests
+// ===========================================================================
+
+#[test]
+fn fully_typed_threshold_is_zero() {
+    let t = JitPromotionThreshold::for_tier(&TypingTier::FullyTyped);
+    assert_eq!(t.call_count, THRESHOLD_FULLY_TYPED);
+    assert!(t.should_promote(0));
+}
+
+#[test]
+fn untyped_threshold_is_hundred() {
+    let t = JitPromotionThreshold::for_tier(&TypingTier::Untyped);
+    assert_eq!(t.call_count, THRESHOLD_UNTYPED);
+    assert!(!t.should_promote(99));
+    assert!(t.should_promote(100));
+}
+
+#[test]
+fn partial_at_half_threshold_is_fifty_five() {
+    let t = JitPromotionThreshold::for_tier(&TypingTier::Partial(0.5));
+    assert_eq!(t.call_count, 55);
+}
+
+#[test]
+fn threshold_monotone_decreasing_with_fraction() {
+    let fracs = [0.0f32, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0];
+    let mut prev = u32::MAX;
+    for &f in &fracs {
+        let t = JitPromotionThreshold::for_tier(&TypingTier::Partial(f));
+        assert!(t.call_count <= prev, "non-monotone at {f}: {} > {prev}", t.call_count);
+        prev = t.call_count;
+    }
+}
+
+#[test]
+fn threshold_label_is_correct() {
+    assert_eq!(
+        JitPromotionThreshold { call_count: 0 }.label(),
+        "compile-before-first-call"
+    );
+    assert_eq!(
+        JitPromotionThreshold { call_count: 10 }.label(),
+        "after-10-calls"
+    );
+}
+
+// ===========================================================================
+// Canonical type-name tests
+// ===========================================================================
+
+#[test]
+fn all_canonical_types_are_recognised() {
+    for &ty in ALL_CANONICAL_TYPES {
+        assert!(is_canonical(ty), "{ty} not recognised as canonical");
+    }
+}
+
+#[test]
+fn type_any_is_not_canonical() {
+    assert!(!is_canonical(TYPE_ANY));
+}
+
+#[test]
+fn map_twig_int_to_i64() {
+    assert_eq!(map_frontend_type("int", "twig"), Some(TYPE_I64));
+}
+
+#[test]
+fn map_twig_float_to_f64() {
+    assert_eq!(map_frontend_type("float", "twig"), Some(TYPE_F64));
+}
+
+#[test]
+fn map_twig_bool_to_bool() {
+    assert_eq!(map_frontend_type("bool", "twig"), Some(TYPE_BOOL));
+}
+
+#[test]
+fn map_typescript_number_to_f64() {
+    assert_eq!(map_frontend_type("number", "typescript"), Some(TYPE_F64));
+}
+
+#[test]
+fn map_typescript_boolean_to_bool() {
+    assert_eq!(map_frontend_type("boolean", "typescript"), Some(TYPE_BOOL));
+}
+
+#[test]
+fn map_typescript_null_to_nil() {
+    assert_eq!(map_frontend_type("null", "typescript"), Some("nil"));
+    assert_eq!(map_frontend_type("undefined", "typescript"), Some("nil"));
+}
+
+#[test]
+fn map_ruby_integer_to_i64() {
+    assert_eq!(map_frontend_type("Integer", "ruby"), Some(TYPE_I64));
+}
+
+#[test]
+fn map_ruby_nilclass_to_nil() {
+    assert_eq!(map_frontend_type("NilClass", "ruby"), Some("nil"));
+}
+
+#[test]
+fn map_ruby_trueclassfalseclass_to_bool() {
+    assert_eq!(map_frontend_type("TrueClass", "ruby"), Some(TYPE_BOOL));
+    assert_eq!(map_frontend_type("FalseClass", "ruby"), Some(TYPE_BOOL));
+}
+
+#[test]
+fn map_python_int_to_i64() {
+    assert_eq!(map_frontend_type("int", "python"), Some(TYPE_I64));
+}
+
+#[test]
+fn map_python_none_to_nil() {
+    assert_eq!(map_frontend_type("None", "python"), Some("nil"));
+}
+
+#[test]
+fn map_rust_primitives_pass_through() {
+    for &ty in &["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64"] {
+        assert_eq!(map_frontend_type(ty, "rust"), Some(ty), "rust/{ty}");
+    }
+}
+
+#[test]
+fn map_c_char_to_u8() {
+    assert_eq!(map_frontend_type("char", "c"), Some("u8"));
+}
+
+#[test]
+fn unknown_type_unknown_language_returns_none() {
+    assert_eq!(map_frontend_type("Flubber", "cobol"), None);
+}
+
+#[test]
+fn canonical_type_passes_through_for_any_language() {
+    // Canonical types are accepted regardless of language tag.
+    assert_eq!(map_frontend_type("i64", "brainfuck"), Some("i64"));
+    assert_eq!(map_frontend_type("bool", "cobol"), Some("bool"));
+}
+
+// ===========================================================================
+// Advisory round-trip tests
+// ===========================================================================
+
+#[test]
+fn advisory_module_name_matches() {
+    let mut m = fully_typed_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    assert_eq!(adv.module_name, "typed");
+}
+
+#[test]
+fn advisory_function_count_matches() {
+    let mut m = fully_typed_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    assert_eq!(adv.functions.len(), m.functions.len());
+}
+
+#[test]
+fn advisory_fully_typed_function_has_zero_threshold() {
+    let mut m = fully_typed_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    assert_eq!(adv.functions[0].jit_threshold.call_count, 0);
+}
+
+#[test]
+fn advisory_summary_is_non_empty() {
+    let mut m = fully_typed_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    assert!(!adv.summary().is_empty());
+}
+
+#[test]
+fn advisory_partial_module_is_between_untyped_and_fully_typed() {
+    let mut m = partial_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    // Module has some typed and some untyped → Partial or Untyped tier.
+    match &adv.module_tier {
+        TypingTier::Partial(_) | TypingTier::Untyped => {} // expected
+        TypingTier::FullyTyped => {
+            // It's possible if inference resolved everything; that's also fine.
+        }
+    }
+}
+
+#[test]
+fn function_advisory_typed_fraction_is_in_range() {
+    let mut m = fully_typed_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    for fa in &adv.functions {
+        assert!(fa.typed_fraction >= 0.0 && fa.typed_fraction <= 1.0,
+            "typed_fraction out of range: {}", fa.typed_fraction);
+    }
+}
+
+#[test]
+fn function_advisory_fully_typed_subset_correct() {
+    let mut m = fully_typed_module();
+    infer_and_check(&mut m);
+    let adv = advise(&m);
+    // Our module is fully typed, so the fully_typed_functions subset should be non-empty.
+    assert!(!adv.fully_typed_functions().is_empty());
+    // And fully_untyped_functions should be empty.
+    assert!(adv.fully_untyped_functions().is_empty());
+}
+
+#[test]
+fn jit_threshold_zero_always_promotes() {
+    let t = JitPromotionThreshold { call_count: 0 };
+    for n in [0u32, 1, 100, u32::MAX] {
+        assert!(t.should_promote(n));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the `typing-spectrum` crate — the LANG22 compilation strategy layer that maps `TypingTier` (from `iir-type-checker`) to `CompilationMode`, JIT promotion thresholds, and per-function compilation advisories
- Implements the five LANG22 compilation modes (`TreeWalking`, `AotNoProfile`, `AotWithPgo`, `Jit`, `JitThenAotWithPgo`) with `recommended_for(tier)` advisory logic
- Implements `JitPromotionThreshold` with per-tier interpolation: FullyTyped→0, Partial→10–100 (linear), Untyped→100
- Implements the canonical type-name table (LANG22 §"Type ascription syntax") with per-language mappings for Twig, TypeScript, Ruby/Sorbet, Hack, Python/mypy, Rust/C
- Implements `CompilationAdvisory` / `FunctionAdvisory` with `advise(module)` entry point

## Stack position

```
typing-spectrum
 ├─ iir-type-checker  (TypingTier, infer_and_check)  ← PR #2006 merged
 └─ interpreter-ir    (IIRModule, IIRFunction, IIRInstr)
```

## Tests

117 tests: 59 unit, 40 integration, 18 doctests. All pass, zero warnings.

## Related specs

- **LANG22** `code/specs/LANG22-typing-spectrum-aot-jit.md`
- **ldp-format** (LANG22 PR 11d) — already merged in PR #1835

## Test plan

- [x] `cargo build -p typing-spectrum` — builds cleanly
- [x] `cargo test -p typing-spectrum` — all 117 tests pass
- [x] Security review passed (pure data/strategy crate; no unsafe, no I/O, no user-controlled input reaching any index/unwrap)
- [x] Follows literate-programming style with inline diagrams, truth tables, and examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)