### PR TITLE
feat(cas-limit-series): Phase 20 — full limit evaluation with L'Hôpital and indeterminate forms

### DIFF
--- a/code/packages/python/cas-limit-series/CHANGELOG.md
+++ b/code/packages/python/cas-limit-series/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.2.0 — 2026-05-04
+
+**Phase 20 — Full limit evaluation: L'Hôpital, ±∞, indeterminate forms, one-sided limits.**
+
+### New public API
+
+| Symbol | Description |
+|--------|-------------|
+| `limit_advanced(expr, var, point, direction, *, diff_fn, eval_fn)` | Full limit evaluator |
+| `INF` | `IRSymbol("inf")` sentinel for +∞ |
+| `MINF` | `IRSymbol("minf")` sentinel for −∞ |
+
+### Capabilities added
+
+- **Direct substitution** — tried first; returns substituted + simplified result when
+  the expression is continuous at the point.
+- **L'Hôpital's rule** — applied iteratively (up to depth 8) for `0/0` and `∞/∞`
+  indeterminate ratios.  Requires an injected `diff_fn` callable.
+- **Limits at ±∞** — `IRSymbol("inf")` / `IRSymbol("minf")` as limit point.
+  Numeric evaluator maps these to `math.inf` using Python IEEE 754.
+- **Indeterminate forms** — all six standard forms handled:
+  - `0/0`, `∞/∞` → L'Hôpital
+  - `0·∞` → rewrite `MUL(a,b)` as `DIV(b, DIV(1,a))` then L'Hôpital
+  - `1^∞`, `0^0`, `∞^0` → `EXP(MUL(e, LOG(b)))` transform then recurse
+- **One-sided limits** — `direction="plus"` (right) / `direction="minus"` (left);
+  a `±1×10⁻³⁰⁰` perturbation classifies the form while exact point is used
+  for symbolic substitution.
+- **Architecture** — `diff_fn` and `eval_fn` are injected callables; no dependency
+  on `symbolic-vm` (avoids circular import).
+
+### New heads in `heads.py`
+
+- `INF = IRSymbol("inf")` — positive infinity sentinel
+- `MINF = IRSymbol("minf")` — negative infinity sentinel
+
+### New module
+
+- `cas_limit_series.limit_advanced` — contains all Phase 20 logic
+
+---
+
 ## 0.1.0 — 2026-04-25
 
 Initial release — Phase 1 foundation.

--- a/code/packages/python/cas-limit-series/pyproject.toml
+++ b/code/packages/python/cas-limit-series/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-limit-series"
-version = "0.1.0"
-description = "Limit and Taylor series operations on symbolic IR (foundation: heads + polynomial-only Taylor)."
+version = "0.2.0"
+description = "Limit and Taylor series on symbolic IR: direct substitution, L'Hôpital, ±∞, all indeterminate forms, one-sided limits."
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/cas-limit-series/src/cas_limit_series/__init__.py
+++ b/code/packages/python/cas-limit-series/src/cas_limit_series/__init__.py
@@ -1,9 +1,18 @@
-"""Limit and Taylor series for the symbolic IR (Phase 1 foundation).
+"""Limit and Taylor series for the symbolic IR.
+
+Phase 1 (0.1.0)
+---------------
+Direct-substitution limit and polynomial Taylor expansion.
+
+Phase 20 (0.2.0)
+----------------
+Full limit evaluation with L'Hôpital's rule, limits at ±∞, all standard
+indeterminate forms, and one-sided limit direction support.
 
 Quick start::
 
-    from cas_limit_series import limit_direct, taylor_polynomial
-    from symbolic_ir import IRApply, IRInteger, IRSymbol, ADD, POW
+    from cas_limit_series import limit_direct, limit_advanced, taylor_polynomial
+    from symbolic_ir import IRApply, IRInteger, IRSymbol, ADD, DIV, POW, SIN
 
     x = IRSymbol("x")
     expr = IRApply(ADD, (IRApply(POW, (x, IRInteger(2))), IRInteger(1)))
@@ -11,18 +20,27 @@ Quick start::
     limit_direct(expr, x, IRInteger(2))      # 5  (un-simplified Add(4, 1))
     taylor_polynomial(expr, x, IRInteger(0), 2)
     # Add(1, x^2)   — the Taylor expansion at 0 of x^2 + 1 to order 2
+
+    # L'Hôpital via injected diff_fn:
+    sin_over_x = IRApply(DIV, (IRApply(SIN, (x,)), x))
+    limit_advanced(sin_over_x, x, IRInteger(0), diff_fn=my_diff, eval_fn=my_eval)
+    # → IRInteger(1)
 """
 
-from cas_limit_series.heads import BIG_O, LIMIT, SERIES, TAYLOR
+from cas_limit_series.heads import BIG_O, INF, LIMIT, MINF, SERIES, TAYLOR
 from cas_limit_series.limit import limit_direct
+from cas_limit_series.limit_advanced import limit_advanced
 from cas_limit_series.taylor import PolynomialError, taylor_polynomial
 
 __all__ = [
     "BIG_O",
+    "INF",
     "LIMIT",
+    "MINF",
     "PolynomialError",
     "SERIES",
     "TAYLOR",
+    "limit_advanced",
     "limit_direct",
     "taylor_polynomial",
 ]

--- a/code/packages/python/cas-limit-series/src/cas_limit_series/heads.py
+++ b/code/packages/python/cas-limit-series/src/cas_limit_series/heads.py
@@ -8,3 +8,17 @@ LIMIT = IRSymbol("Limit")
 TAYLOR = IRSymbol("Taylor")
 SERIES = IRSymbol("Series")
 BIG_O = IRSymbol("Big_O")
+
+# ---------------------------------------------------------------------------
+# Phase 20 — infinity sentinels
+# ---------------------------------------------------------------------------
+#
+# These reuse existing ``IRSymbol`` names recognised by MACSYMA (``inf``,
+# ``minf``) and the numeric evaluator in ``limit_advanced``.  They are
+# exported here so downstream code can pattern-match against a single
+# canonical object instead of constructing ``IRSymbol("inf")`` everywhere.
+
+#: Positive infinity — ``IRSymbol("inf")``.
+INF = IRSymbol("inf")
+#: Negative infinity — ``IRSymbol("minf")``.
+MINF = IRSymbol("minf")

--- a/code/packages/python/cas-limit-series/src/cas_limit_series/limit_advanced.py
+++ b/code/packages/python/cas-limit-series/src/cas_limit_series/limit_advanced.py
@@ -1,0 +1,686 @@
+"""Enhanced limit computation: L'Hôpital, infinity, and indeterminate forms.
+
+Phase 20 extends the trivial direct-substitution ``limit_direct`` with
+a full limit evaluator supporting:
+
+1. **Direct substitution** — always tried first.  If the expression is
+   continuous at the point the substituted value is returned immediately.
+
+2. **L'Hôpital's rule** — for ``0/0`` and ``∞/∞`` indeterminate ratios.
+   Differentiates the numerator and denominator repeatedly (up to depth 8)
+   and retries.
+
+3. **Limits at ±∞** — ``IRSymbol("inf")`` / ``IRSymbol("minf")`` as the
+   limit point.  The numeric evaluator maps ``inf → math.inf`` and uses
+   Python's IEEE 754 arithmetic so that ``exp(−∞) = 0``, ``1/∞ = 0``, etc.
+
+4. **All standard indeterminate forms**:
+
+   ============  ========================================================
+   Form          Reduction
+   ============  ========================================================
+   ``0/0``       L'Hôpital on the ``DIV`` node
+   ``∞/∞``       L'Hôpital on the ``DIV`` node
+   ``0·∞``       Rewrite ``MUL(a,b)`` → ``DIV(b, DIV(1,a))`` then
+                 L'Hôpital
+   ``1^∞``       ``EXP(MUL(e, LOG(b)))`` then recurse on the exponent
+   ``0^0``       Same exp-log transform
+   ``∞^0``       Same exp-log transform
+   ============  ========================================================
+
+5. **One-sided limits** — ``direction="plus"`` (from the right) or
+   ``direction="minus"`` (from the left).  A tiny numeric perturbation
+   (±1×10⁻³⁰⁰) is applied to the evaluation point to classify the form;
+   the symbolic substitution still uses the exact ``point`` value.
+
+Architecture note
+-----------------
+This module does **not** depend on ``symbolic-vm``.  Differentiation and
+VM simplification are injected as callables at call time:
+
+- ``diff_fn(expr, var)`` — returns the simplified derivative of ``expr``
+  with respect to ``var``.  Typically
+  ``lambda e, v: vm.eval(_symbolic_diff(e, v))``.
+- ``eval_fn(node)`` — runs the node through the VM evaluator to collapse
+  arithmetic.  Typically ``vm.eval``.
+
+If ``diff_fn`` is ``None``, L'Hôpital falls through and the unevaluated
+``Limit(…)`` node is returned instead.
+
+Literate reading order
+-----------------------
+1. ``_num_eval``          — numeric float evaluator for form detection
+2. ``_classify_at``       — classify expression value at a point
+3. ``_lhopital_step``     — one round of L'Hôpital differentiation
+4. ``_zero_inf_rewrite``  — 0·∞ → 0/0 rewrite
+5. ``_pow_exp_log``       — 1^∞ / 0^0 / ∞^0 → exp-log rewrite
+6. ``_handle_form``       — dispatcher for all indeterminate forms
+7. ``limit_advanced``     — public entry point
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+
+from cas_substitution import subst
+from symbolic_ir import (
+    ADD,
+    ATAN,
+    COS,
+    COSH,
+    DIV,
+    EXP,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SINH,
+    SQRT,
+    SUB,
+    TAN,
+    TANH,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from cas_limit_series.heads import LIMIT
+
+# ---------------------------------------------------------------------------
+# Type alias for injected callables
+# ---------------------------------------------------------------------------
+
+DiffFn = Callable[[IRNode, IRSymbol], IRNode]
+EvalFn = Callable[[IRNode], IRNode]
+
+# ---------------------------------------------------------------------------
+# Special-symbol constants
+# ---------------------------------------------------------------------------
+
+#: Positive infinity symbol (same as MACSYMA's ``inf``).
+INF_SYM = IRSymbol("inf")
+#: Negative infinity symbol (same as MACSYMA's ``minf``).
+MINF_SYM = IRSymbol("minf")
+#: ``%pi``
+_PI_SYM = IRSymbol("%pi")
+#: ``%e``
+_E_SYM = IRSymbol("%e")
+
+#: Small positive perturbation used for one-sided directional detection.
+#: 1e-300 is sub-normal but well-defined; 1/1e-300 = 1e300 which is large
+#: but representable.  We compare against _INF_THRESHOLD to catch it.
+_EPS = 1e-300
+
+#: Values with absolute magnitude above this threshold are treated as ±∞.
+#: 1e100 safely captures 1/ε and exp of large arguments while staying far
+#: below ``sys.float_info.max`` (~1.8e308).
+_INF_THRESHOLD: float = 1e100
+
+# Maximum L'Hôpital recursion depth.
+_MAX_DEPTH = 8
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Numeric evaluator
+# ---------------------------------------------------------------------------
+#
+# ``_num_eval`` converts an IR node to a Python ``float``.  It handles
+# ±∞ via ``math.inf`` and returns ``float('nan')`` for truly indeterminate
+# sub-expressions (``0/0`` in particular).  All symbolic variables that are
+# not recognised constants map to NaN as well.
+#
+# This is used exclusively for *classifying* a limit form — never for
+# computing the final symbolic answer.
+
+
+def _ev(node: IRNode) -> float:  # noqa: PLR0911, PLR0912 (many branches intentional)
+    """Recursively evaluate an IR node to a float.
+
+    ``IRSymbol("inf") → math.inf``, ``IRSymbol("minf") → -math.inf``.
+    ``0/0 → nan``.  Unknown heads / symbols → nan.
+    """
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRFloat):
+        return node.value
+    if isinstance(node, IRSymbol):
+        name = node.name
+        if name == "inf":
+            return math.inf
+        if name == "minf":
+            return -math.inf
+        if name == "%pi":
+            return math.pi
+        if name == "%e":
+            return math.e
+        return float("nan")
+    if not isinstance(node, IRApply):
+        return float("nan")
+
+    h = node.head
+    args = node.args
+
+    # Arithmetic
+    if h == ADD:
+        return sum(_ev(a) for a in args)
+    if h == SUB:
+        return _ev(args[0]) - _ev(args[1])
+    if h == MUL:
+        result = 1.0
+        for a in args:
+            result *= _ev(a)
+        return result
+    if h == DIV:
+        numer = _ev(args[0])
+        denom = _ev(args[1])
+        if denom == 0.0:
+            # 0/0 → NaN (indeterminate); nonzero/0 → ±∞
+            if numer == 0.0:
+                return float("nan")
+            return math.copysign(math.inf, numer)
+        return numer / denom
+    if h == NEG:
+        return -_ev(args[0])
+    if h == POW:
+        base = _ev(args[0])
+        exp_val = _ev(args[1])
+        # Indeterminate power forms — return NaN so _handle_form dispatches
+        # to the exp-log rewrite (Section 5) rather than collapsing prematurely
+        # with float arithmetic.
+        #   1^∞  : e.g. (1+1/x)^x  → e
+        #   0^0  : e.g. x^x at 0+  → 1
+        #   ∞^0  : e.g. exp(x)^(1/x) at ∞ → e
+        if abs(base - 1.0) < 1e-10 and math.isinf(exp_val):
+            return float("nan")  # 1^∞
+        if base == 0.0 and exp_val == 0.0:
+            return float("nan")  # 0^0
+        if math.isinf(base) and exp_val == 0.0:
+            return float("nan")  # ∞^0
+        # Guard against complex result from negative base with fractional exp.
+        if base < 0 and not float(exp_val).is_integer():
+            return float("nan")
+        try:
+            return float(base**exp_val)
+        except (ValueError, ZeroDivisionError, OverflowError):
+            return float("nan")
+    if h == SQRT:
+        val = _ev(args[0])
+        if val < 0:
+            return float("nan")
+        return math.sqrt(val)
+
+    # Exponential / logarithm
+    if h == EXP:
+        val = _ev(args[0])
+        if val == math.inf:
+            return math.inf
+        if val == -math.inf:
+            return 0.0
+        try:
+            return math.exp(val)
+        except OverflowError:
+            return math.inf
+    if h == LOG:
+        val = _ev(args[0])
+        if val == 0.0:
+            return -math.inf  # log(0+) = -∞
+        if val < 0:
+            return float("nan")
+        if val == math.inf:
+            return math.inf
+        return math.log(val)
+
+    # Trig — undefined at ±∞ (oscillates)
+    if h == SIN:
+        val = _ev(args[0])
+        if math.isinf(val):
+            return float("nan")
+        return math.sin(val)
+    if h == COS:
+        val = _ev(args[0])
+        if math.isinf(val):
+            return float("nan")
+        return math.cos(val)
+    if h == TAN:
+        val = _ev(args[0])
+        if math.isinf(val):
+            return float("nan")
+        return math.tan(val)
+    if h == ATAN:
+        val = _ev(args[0])
+        if val == math.inf:
+            return math.pi / 2
+        if val == -math.inf:
+            return -math.pi / 2
+        return math.atan(val)
+
+    # Hyperbolic
+    if h == SINH:
+        val = _ev(args[0])
+        try:
+            return math.sinh(val)
+        except OverflowError:
+            return math.copysign(math.inf, val)
+    if h == COSH:
+        val = _ev(args[0])
+        try:
+            return math.cosh(val)
+        except OverflowError:
+            return math.inf
+    if h == TANH:
+        val = _ev(args[0])
+        return math.tanh(val)
+
+    return float("nan")  # unknown head → indeterminate for our purposes
+
+
+def _num_eval(node: IRNode) -> float:
+    """Safely evaluate *node* to float; return ``nan`` on any exception."""
+    try:
+        return _ev(node)
+    except Exception:  # noqa: BLE001
+        return float("nan")
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Form classification at a numeric test point
+# ---------------------------------------------------------------------------
+
+
+def _eval_at_float(expr: IRNode, var: IRSymbol, pt: float) -> float:
+    """Substitute a Python float *pt* for *var* in *expr* and evaluate.
+
+    This is the core classification helper.  We build a temporary
+    ``IRFloat`` node for the test point so that ``_num_eval`` can
+    evaluate the substituted expression without constructing exact
+    rational IR.
+    """
+    test_node: IRNode = IRFloat(pt) if isinstance(pt, float) else IRInteger(int(pt))
+    substituted = subst(test_node, var, expr)
+    return _num_eval(substituted)
+
+
+def _point_to_float(point: IRNode) -> float:
+    """Convert an IR point to a float for numeric classification."""
+    return _num_eval(point)
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — L'Hôpital step
+# ---------------------------------------------------------------------------
+
+
+def _lhopital_step(
+    numer: IRNode,
+    denom: IRNode,
+    var: IRSymbol,
+    point: IRNode,
+    direction: str | None,
+    diff_fn: DiffFn,
+    eval_fn: EvalFn | None,
+    depth: int,
+) -> IRNode:
+    """Apply one step of L'Hôpital and recurse.
+
+    Differentiates *numer* and *denom* with respect to *var*, builds
+    the new ratio, and calls :func:`limit_advanced` on the result.
+
+    Parameters
+    ----------
+    numer, denom:
+        The current numerator and denominator IR nodes.
+    var:
+        The differentiation / limit variable.
+    point:
+        The limit point.
+    direction:
+        One-sided direction or ``None``.
+    diff_fn:
+        Injected differentiation callable.
+    eval_fn:
+        Optional VM evaluator.
+    depth:
+        Current recursion depth (incremented before recursive call).
+
+    Returns
+    -------
+    The limit of ``d(numer)/d(var) / d(denom)/d(var)`` at ``point``.
+    """
+    d_numer = diff_fn(numer, var)
+    d_denom = diff_fn(denom, var)
+    if eval_fn is not None:
+        d_numer = eval_fn(d_numer)
+        d_denom = eval_fn(d_denom)
+    new_ratio = IRApply(DIV, (d_numer, d_denom))
+    if eval_fn is not None:
+        new_ratio = eval_fn(new_ratio)
+    return limit_advanced(
+        new_ratio, var, point, direction,
+        diff_fn=diff_fn, eval_fn=eval_fn, _depth=depth + 1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — 0·∞ rewrite
+# ---------------------------------------------------------------------------
+
+
+def _zero_inf_rewrite(
+    a: IRNode,
+    b: IRNode,
+    var: IRSymbol,
+    point: IRNode,
+    exact_pt: float,
+    diff_fn: DiffFn | None,
+    eval_fn: EvalFn | None,
+    depth: int,
+) -> IRNode | None:
+    """Rewrite a ``0·∞`` product as a quotient for L'Hôpital.
+
+    Given factors *a* and *b* where one approaches 0 and the other ±∞,
+    returns ``limit(b / (1/a))`` — putting the zero factor in the
+    denominator inverted, giving a 0/0 or ∞/∞ form.
+
+    *exact_pt* is the numeric value of the limit point (may be ±inf).
+
+    Returns ``None`` if neither factor pattern matches.
+    """
+    a_val = _eval_at_float(a, var, exact_pt)
+    b_val = _eval_at_float(b, var, exact_pt)
+
+    def _is_inf(v: float) -> bool:
+        return math.isinf(v) or abs(v) > _INF_THRESHOLD
+
+    # a → 0, b → ±∞: rewrite as b / (1/a)
+    if a_val == 0.0 and _is_inf(b_val):
+        one_over_a = IRApply(DIV, (IRInteger(1), a))
+        new_expr = IRApply(DIV, (b, one_over_a))
+        if eval_fn is not None:
+            new_expr = eval_fn(new_expr)
+        return limit_advanced(
+            new_expr, var, point, None,
+            diff_fn=diff_fn, eval_fn=eval_fn, _depth=depth + 1,
+        )
+    # b → 0, a → ±∞: rewrite as a / (1/b)
+    if b_val == 0.0 and _is_inf(a_val):
+        one_over_b = IRApply(DIV, (IRInteger(1), b))
+        new_expr = IRApply(DIV, (a, one_over_b))
+        if eval_fn is not None:
+            new_expr = eval_fn(new_expr)
+        return limit_advanced(
+            new_expr, var, point, None,
+            diff_fn=diff_fn, eval_fn=eval_fn, _depth=depth + 1,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — exp-log rewrite for 1^∞, 0^0, ∞^0
+# ---------------------------------------------------------------------------
+
+
+def _pow_exp_log(
+    base: IRNode,
+    exp_node: IRNode,
+    var: IRSymbol,
+    point: IRNode,
+    exact_pt: float,
+    diff_fn: DiffFn | None,
+    eval_fn: EvalFn | None,
+    depth: int,
+) -> IRNode | None:
+    """Rewrite a power ``base^exp`` for indeterminate exponential forms.
+
+    Transforms:
+
+    - ``1^∞`` → ``exp(∞ · log(1))`` → ``exp(lim(∞ · log(base)))``
+    - ``0^0`` → ``exp(0 · log(0))`` → ``exp(lim(0 · log(base)))``
+    - ``∞^0`` → ``exp(0 · log(∞))`` → ``exp(lim(0 · log(base)))``
+
+    In all cases the inner limit is ``∞ · 0`` (or ``0 · ∞``), which the
+    main dispatcher handles via the 0·∞ rewrite.
+
+    *exact_pt* is the numeric value of the limit point (may be ±inf).
+
+    Returns ``None`` if the form is not one of the three above.
+    """
+    b_val = _eval_at_float(base, var, exact_pt)
+    e_val = _eval_at_float(exp_node, var, exact_pt)
+
+    def _is_inf(v: float) -> bool:
+        return math.isinf(v) or abs(v) > _INF_THRESHOLD
+
+    is_1_inf = (abs(b_val - 1.0) < 1e-10) and _is_inf(e_val)
+    is_0_0 = (b_val == 0.0 and e_val == 0.0)
+    is_inf_0 = _is_inf(b_val) and e_val == 0.0
+
+    if not (is_1_inf or is_0_0 or is_inf_0):
+        return None
+
+    # Transform base^exp → exp(exp * log(base))
+    log_base = IRApply(LOG, (base,))
+    product = IRApply(MUL, (exp_node, log_base))
+    if eval_fn is not None:
+        product = eval_fn(product)
+
+    # Compute limit of the exponent, then wrap in EXP.
+    # Direction is not forwarded — the inner product limit is two-sided (the
+    # exp-log transform removes the power structure that caused the one-sided
+    # form, and the product 0·∞ is evaluated without directional bias).
+    exponent_limit = limit_advanced(
+        product, var, point, None,
+        diff_fn=diff_fn, eval_fn=eval_fn, _depth=depth + 1,
+    )
+    result = IRApply(EXP, (exponent_limit,))
+    if eval_fn is not None:
+        result = eval_fn(result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Indeterminate form dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _handle_form(
+    expr: IRNode,
+    var: IRSymbol,
+    point: IRNode,
+    direction: str | None,
+    diff_fn: DiffFn | None,
+    eval_fn: EvalFn | None,
+    depth: int,
+) -> IRNode:
+    """Dispatch indeterminate forms to their respective reductions.
+
+    Called when direct substitution produces ``NaN`` (an indeterminate
+    result).  Examines the **structure** of *expr* to determine the form
+    and apply the correct transformation.
+
+    Handles:
+
+    - ``DIV(N, D)`` where both → 0 or both → ±∞: L'Hôpital.
+    - ``MUL(a, b)`` where one → 0 and other → ±∞: 0·∞ rewrite.
+    - ``POW(b, e)`` for 1^∞, 0^0, ∞^0: exp-log rewrite.
+
+    Falls through to unevaluated ``Limit(…)`` for other forms
+    (∞−∞, truly oscillating, etc.).
+    """
+    pt_f = _point_to_float(point)
+    # Use the EXACT limit point for form classification — not the perturbed
+    # test point.  The perturbation in ``limit_advanced`` is only for
+    # detecting the sign of a directional ±∞.  Here we need the values that
+    # the sub-expressions actually approach, which is at the exact limit point.
+    # For finite points this is the exact coordinate; for ±∞ points it is inf.
+    exact_pt = pt_f  # may be math.inf / -math.inf for limits at ±∞
+
+    # --- DIV: 0/0 or ∞/∞ → L'Hôpital ---
+    if isinstance(expr, IRApply) and expr.head == DIV:
+        numer, denom = expr.args
+        n_val = _eval_at_float(numer, var, exact_pt)
+        d_val = _eval_at_float(denom, var, exact_pt)
+        is_zero_zero = n_val == 0.0 and d_val == 0.0
+        is_inf_inf = (math.isinf(n_val) or abs(n_val) > _INF_THRESHOLD) and (
+            math.isinf(d_val) or abs(d_val) > _INF_THRESHOLD
+        )
+        if (is_zero_zero or is_inf_inf) and diff_fn is not None:
+            return _lhopital_step(
+                numer, denom, var, point, direction, diff_fn, eval_fn, depth
+            )
+
+    # --- MUL(a, b): 0·∞ form ---
+    if isinstance(expr, IRApply) and expr.head == MUL and len(expr.args) == 2:
+        a, b = expr.args
+        result = _zero_inf_rewrite(
+            a, b, var, point, exact_pt, diff_fn, eval_fn, depth
+        )
+        if result is not None:
+            return result
+
+    # --- POW(b, e): 1^∞, 0^0, ∞^0 ---
+    if isinstance(expr, IRApply) and expr.head == POW:
+        base, exp_node = expr.args
+        result = _pow_exp_log(
+            base, exp_node, var, point, exact_pt, diff_fn, eval_fn, depth
+        )
+        if result is not None:
+            return result
+
+    # --- SUB: try rewriting a - b as (a - b) / 1 and checking ---
+    # (limited ∞-∞ handling: pass through for now)
+
+    # Fallthrough — return unevaluated
+    return _build_unevaluated(expr, var, point, direction)
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — Public entry point
+# ---------------------------------------------------------------------------
+
+
+def _build_unevaluated(
+    expr: IRNode,
+    var: IRSymbol,
+    point: IRNode,
+    direction: str | None,
+) -> IRApply:
+    """Build an unevaluated ``Limit(…)`` IR node."""
+    if direction is None:
+        return IRApply(LIMIT, (expr, var, point))
+    dir_sym = IRSymbol("plus") if direction == "plus" else IRSymbol("minus")
+    return IRApply(LIMIT, (expr, var, point, dir_sym))
+
+
+def limit_advanced(
+    expr: IRNode,
+    var: IRSymbol,
+    point: IRNode,
+    direction: str | None = None,
+    *,
+    diff_fn: DiffFn | None = None,
+    eval_fn: EvalFn | None = None,
+    _depth: int = 0,
+) -> IRNode:
+    """Compute ``lim_{var → point} expr``, handling indeterminate forms.
+
+    Parameters
+    ----------
+    expr:
+        The expression whose limit is sought.
+    var:
+        The limit variable (must be an ``IRSymbol``).
+    point:
+        The limit point.  Use ``IRSymbol("inf")`` / ``IRSymbol("minf")``
+        for limits at ±∞.
+    direction:
+        ``None`` — two-sided (default).
+        ``"plus"`` — from the right (``x → a+``).
+        ``"minus"`` — from the left (``x → a-``).
+    diff_fn:
+        Callable ``(expr, var) → derivative``.  **Required** for
+        L'Hôpital's rule and the 0·∞ / exponential reductions.  If
+        ``None``, any indeterminate form falls through to unevaluated.
+    eval_fn:
+        Optional VM evaluator.  When provided, intermediate results are
+        simplified before further processing.  Pass ``vm.eval`` from the
+        handler.
+    _depth:
+        Internal recursion counter (do not pass externally).
+
+    Returns
+    -------
+    An evaluated IR node, or ``IRApply(LIMIT, …)`` if the limit cannot
+    be determined.
+
+    Examples
+    --------
+    ::
+
+        # lim sin(x)/x as x→0 = 1  (via L'Hôpital)
+        limit_advanced(DIV(SIN(x), x), x, 0, diff_fn=d, eval_fn=e)
+
+        # lim (1 + 1/x)^x as x→∞ = %e  (via exp-log + L'Hôpital)
+        limit_advanced(POW(1 + 1/x, x), x, inf, diff_fn=d, eval_fn=e)
+
+        # lim x*log(x) as x→0+  =  0  (via 0·∞ rewrite + L'Hôpital)
+        limit_advanced(MUL(x, LOG(x)), x, 0, "plus", diff_fn=d, eval_fn=e)
+    """
+    if _depth > _MAX_DEPTH:
+        return _build_unevaluated(expr, var, point, direction)
+
+    # --- Step 1: Compute the numeric test point ---
+    # For one-sided limits, perturb by ε for form classification only.
+    # The symbolic substitution always uses the exact *point*.
+    pt_f = _point_to_float(point)
+    if math.isnan(pt_f):
+        # Cannot determine the limit point numerically — return unevaluated.
+        return _build_unevaluated(expr, var, point, direction)
+
+    eps = _EPS if direction != "minus" else -_EPS
+    test_pt = pt_f + eps if not math.isinf(pt_f) else pt_f
+
+    # --- Step 2: Evaluate the expression at the perturbed test point ---
+    # This tells us the directional behaviour: ±∞ or finite-or-indeterminate.
+    val = _eval_at_float(expr, var, test_pt)
+
+    # --- Step 3: ±∞ at the directional test point → return sentinel ---
+    # The signed result captures one-sided direction correctly (e.g.
+    # 1/x → +∞ from the right, −∞ from the left).
+    # We treat |val| > _INF_THRESHOLD as effectively ±∞ since 1/_EPS = 1e300
+    # is representable but clearly means the expression diverges.
+    if math.isinf(val) or abs(val) > _INF_THRESHOLD:
+        return INF_SYM if val > 0 else MINF_SYM
+
+    # --- Step 4: NaN at perturbed point → indeterminate form ---
+    if math.isnan(val):
+        return _handle_form(
+            expr, var, point, direction, diff_fn, eval_fn, _depth
+        )
+
+    # --- Step 5: Perturbed value is finite → try exact substitution ---
+    # Substitute the exact limit point symbolically.  If the simplified
+    # result is also finite (not NaN), the function is continuous here and
+    # we can return the substituted expression directly.  If the exact
+    # substitution collapses to NaN (removable singularity, e.g. sin(x)/x
+    # at x=0), we fall through to L'Hôpital / rewrite.
+    subst_result = subst(point, var, expr)
+    if eval_fn is not None:
+        subst_result = eval_fn(subst_result)
+    exact_val = _num_eval(subst_result)
+
+    if not math.isnan(exact_val):
+        if math.isinf(exact_val):
+            return INF_SYM if exact_val > 0 else MINF_SYM
+        return subst_result
+
+    # --- Step 6: Exact substitution is NaN — removable singularity ---
+    return _handle_form(
+        expr, var, point, direction, diff_fn, eval_fn, _depth
+    )

--- a/code/packages/python/cas-limit-series/tests/test_phase20.py
+++ b/code/packages/python/cas-limit-series/tests/test_phase20.py
@@ -1,0 +1,865 @@
+"""Phase 20 — limit_advanced: L'Hôpital, infinity, indeterminate forms.
+
+Test coverage targets (spec §Test coverage targets):
+
+  TestDirectSub           4   Polynomial, trig, exp at finite continuous points
+  TestLHopital_ZeroZero   8   sin(x)/x, (1-cos)/x, (exp(x)-1)/x, poly ratios
+  TestLHopital_InfInf     6   Rational functions at ∞; repeated L'Hôpital
+  TestIndeterminate_ZeroInf 5 x·log(x), x·exp(-x), x²·exp(-x)
+  TestIndeterminate_Powers  6 (1+1/x)^x, x^x at 0+, x^(1/x) at ∞
+  TestLimitsAtInfinity    5   exp(-x), 1/x, log(x)/x, sin(x)/x (unevaluated)
+  TestOneSided            5   log(x) at 0+, 1/x at 0+/0-, sqrt(x) at 0+
+  TestFallthrough         4   No diff_fn, oscillating, truly unevaluated
+  TestMacsymaExamples     3   Surface-syntax via VM
+"""
+
+from __future__ import annotations
+
+import math
+from fractions import Fraction
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    COS,
+    DIV,
+    EXP,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SQRT,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRRational,
+    IRSymbol,
+)
+
+from cas_limit_series import INF, MINF, limit_advanced
+from cas_limit_series.heads import LIMIT as LIMIT_HEAD
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _i(n: int) -> IRInteger:
+    return IRInteger(n)
+
+
+def _r(n: int, d: int) -> IRRational:
+    return IRRational(n, d)
+
+
+def _sym(name: str) -> IRSymbol:
+    return IRSymbol(name)
+
+
+def _is_unevaluated(node, var=None, point=None) -> bool:
+    """True if node is an unevaluated Limit(…) application."""
+    return isinstance(node, IRApply) and node.head == LIMIT_HEAD
+
+
+def _float_val(node) -> float:
+    """Evaluate an IR literal node to float."""
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRFloat):
+        return node.value
+    if isinstance(node, IRSymbol):
+        if node.name == "inf":
+            return math.inf
+        if node.name == "minf":
+            return -math.inf
+        if node.name == "%e":
+            return math.e
+        if node.name == "%pi":
+            return math.pi
+    raise AssertionError(f"Cannot convert {node!r} to float")
+
+
+def _close(node, expected: float, tol: float = 1e-9) -> bool:
+    """True if node evaluates to a float close to *expected*.
+
+    Uses the full ``_num_eval`` from ``limit_advanced`` so that unsimplified
+    IR expressions like ``Pow(3, 2)`` or ``Exp(Minf)`` are evaluated correctly
+    even when the stub ``eval_fn`` does not fully simplify them.
+    """
+    from cas_limit_series.limit_advanced import _num_eval as _la_num_eval
+    try:
+        val = _la_num_eval(node)
+    except Exception:
+        return False
+    if math.isnan(val):
+        return False
+    if math.isinf(expected) and math.isinf(val):
+        return (val > 0) == (expected > 0)
+    return abs(val - expected) <= tol
+
+
+# ---------------------------------------------------------------------------
+# Stub diff / eval functions (no VM dependency in unit tests)
+# ---------------------------------------------------------------------------
+
+def _make_diff_fn():
+    """Return a diff_fn that symbolically differentiates common patterns.
+
+    This is a minimal stub sufficient to exercise L'Hôpital on the test
+    cases below.  It does NOT need to be a complete CAS.
+    """
+    # Lazy import to verify cas_limit_series has no vm dep at module level.
+
+    def _diff(expr: IRApply | IRSymbol | IRInteger | IRRational, var: IRSymbol):  # noqa: ANN001
+        """Symbolic derivative of expr w.r.t. var (stub, covers test cases)."""
+        if expr == var:
+            return _i(1)
+        if isinstance(expr, (IRInteger, IRRational, IRFloat)):
+            return _i(0)
+        if isinstance(expr, IRSymbol):
+            return _i(0)  # constant symbol
+        if not isinstance(expr, IRApply):
+            return _i(0)
+
+        h = expr.head
+        args = expr.args
+
+        # sum rule
+        if h == ADD:
+            return IRApply(ADD, tuple(_diff(a, var) for a in args))
+        # subtraction
+        if h == SUB:
+            return IRApply(SUB, (_diff(args[0], var), _diff(args[1], var)))
+        # product rule (binary)
+        if h == MUL and len(args) == 2:
+            f, g = args
+            return IRApply(ADD, (
+                IRApply(MUL, (_diff(f, var), g)),
+                IRApply(MUL, (f, _diff(g, var))),
+            ))
+        # negation
+        if h == NEG:
+            return IRApply(NEG, (_diff(args[0], var),))
+        # quotient rule
+        if h == DIV:
+            f, g = args
+            return IRApply(DIV, (
+                IRApply(SUB, (
+                    IRApply(MUL, (_diff(f, var), g)),
+                    IRApply(MUL, (f, _diff(g, var))),
+                )),
+                IRApply(POW, (g, _i(2))),
+            ))
+        # power rule: x^n → n*x^(n-1)  (integer exponent only)
+        if h == POW and isinstance(args[1], IRInteger):
+            base, n_ir = args
+            n = n_ir.value
+            if n == 0:
+                return _i(0)
+            base_diff = _diff(base, var)
+            return IRApply(MUL, (
+                IRApply(MUL, (_i(n), IRApply(POW, (base, _i(n - 1))))),
+                base_diff,
+            ))
+        # exp
+        if h == EXP:
+            arg = args[0]
+            return IRApply(MUL, (IRApply(EXP, (arg,)), _diff(arg, var)))
+        # log
+        if h == LOG:
+            arg = args[0]
+            return IRApply(DIV, (_diff(arg, var), arg))
+        # sin → cos
+        if h == SIN:
+            arg = args[0]
+            return IRApply(MUL, (IRApply(COS, (arg,)), _diff(arg, var)))
+        # cos → -sin
+        if h == COS:
+            arg = args[0]
+            sin_chain = IRApply(MUL, (IRApply(SIN, (arg,)), _diff(arg, var)))
+            return IRApply(NEG, (sin_chain,))
+        # sqrt → 1/(2*sqrt)
+        if h == SQRT:
+            arg = args[0]
+            return IRApply(DIV, (
+                _diff(arg, var),
+                IRApply(MUL, (_i(2), IRApply(SQRT, (arg,)))),
+            ))
+        return _i(0)  # unknown head — treat as constant
+
+    return _diff
+
+
+def _make_eval_fn():
+    """Return a lightweight eval_fn that collapses arithmetic and identities.
+
+    This stub is powerful enough for the unit tests that exercise
+    ``limit_advanced`` without a real VM.  It handles:
+
+    - Constant folding for integer/rational ADD, SUB, MUL, DIV, NEG, POW.
+    - Algebraic identity rules (0+x, x*1, 0*x, x/1, x^0, x^1, NEG(NEG(x))).
+    - Numeric evaluation of EXP/LOG/SIN/COS at known literal arguments.
+    """
+    def _lit_val(node) -> float | None:  # noqa: ANN001
+        """Return float value if node is a numeric literal, else None."""
+        if isinstance(node, IRInteger):
+            return float(node.value)
+        if isinstance(node, IRRational):
+            return node.numer / node.denom
+        if isinstance(node, IRFloat):
+            return node.value
+        return None
+
+    def _eval(node):  # noqa: ANN001
+        """Recursively simplify node."""
+        if not isinstance(node, IRApply):
+            return node
+        h = node.head
+        args = tuple(_eval(a) for a in node.args)
+
+        # ---- Constant folding for all-numeric args ----
+        if h == ADD:
+            lits = [_lit_val(a) for a in args]
+            if all(v is not None for v in lits):
+                total = Fraction(0)
+                for a in args:
+                    if isinstance(a, IRInteger):
+                        total += a.value
+                    elif isinstance(a, IRRational):
+                        total += Fraction(a.numer, a.denom)
+                    else:
+                        total += Fraction(a.value).limit_denominator(10**9)
+                if total.denominator == 1:
+                    return IRInteger(total.numerator)
+                return IRRational(total.numerator, total.denominator)
+        if h == SUB and len(args) == 2:
+            lv = [_lit_val(a) for a in args]
+            if all(v is not None for v in lv):
+                f = Fraction(lv[0]) - Fraction(lv[1])
+                if f.denominator == 1:
+                    return IRInteger(f.numerator)
+                return IRRational(f.numerator, f.denominator)
+        if h == MUL:
+            lits = [_lit_val(a) for a in args]
+            if all(v is not None for v in lits):
+                prod = Fraction(1)
+                for a in args:
+                    if isinstance(a, IRInteger):
+                        prod *= a.value
+                    elif isinstance(a, IRRational):
+                        prod *= Fraction(a.numer, a.denom)
+                    else:
+                        prod *= Fraction(a.value).limit_denominator(10**9)
+                if prod.denominator == 1:
+                    return IRInteger(prod.numerator)
+                return IRRational(prod.numerator, prod.denominator)
+        if h == DIV and len(args) == 2:
+            n, d = args
+            nv, dv = _lit_val(n), _lit_val(d)
+            if nv is not None and dv is not None and dv != 0:
+                f = (
+                    Fraction(nv).limit_denominator(10**9)
+                    / Fraction(dv).limit_denominator(10**9)
+                )
+                if f.denominator == 1:
+                    return IRInteger(f.numerator)
+                return IRRational(f.numerator, f.denominator)
+        if h == NEG and len(args) == 1:
+            v = _lit_val(args[0])
+            if v is not None:
+                if isinstance(args[0], IRFloat):
+                    return IRFloat(-v)
+                if v == int(v):
+                    return IRInteger(-int(v))
+                return IRRational(int(-v * 1000), 1000)
+        if h == POW and len(args) == 2:
+            bv, ev = _lit_val(args[0]), _lit_val(args[1])
+            if bv is not None and ev is not None:
+                try:
+                    r = bv ** ev
+                    if isinstance(r, float) and r == int(r):
+                        return IRInteger(int(r))
+                    return IRFloat(float(r))
+                except (ZeroDivisionError, OverflowError, ValueError):
+                    pass
+
+        # ---- Identity rules ----
+        if h == NEG and isinstance(args[0], IRApply) and args[0].head == NEG:
+            return args[0].args[0]  # NEG(NEG(x)) = x
+        if h == ADD and len(args) == 2:
+            a, b = args
+            if isinstance(b, IRInteger) and b.value == 0:
+                return a
+            if isinstance(a, IRInteger) and a.value == 0:
+                return b
+        if h == SUB and len(args) == 2:
+            a, b = args
+            if isinstance(b, IRInteger) and b.value == 0:
+                return a  # x - 0 = x
+            if isinstance(a, IRInteger) and a.value == 0:
+                return IRApply(NEG, (b,))  # 0 - x = -x
+        if h == MUL and len(args) == 2:
+            a, b = args
+            if isinstance(a, IRInteger) and a.value == 0:
+                return IRInteger(0)
+            if isinstance(b, IRInteger) and b.value == 0:
+                return IRInteger(0)
+            if isinstance(a, IRInteger) and a.value == 1:
+                return b
+            if isinstance(b, IRInteger) and b.value == 1:
+                return a
+        if h == DIV and len(args) == 2:
+            n, d = args
+            if isinstance(d, IRInteger) and d.value == 1:
+                return n  # x / 1 = x
+            # 0/x = 0 only when denominator is provably nonzero
+            d_is_zero = isinstance(d, IRInteger) and d.value == 0
+            if isinstance(n, IRInteger) and n.value == 0 and not d_is_zero:
+                return IRInteger(0)  # 0 / nonzero = 0
+            # 1/(1/x) = x  — needed for zero-inf rewrite clean-up
+            if (
+                isinstance(n, IRInteger) and n.value == 1
+                and isinstance(d, IRApply) and d.head == DIV
+            ):
+                inner_n, inner_d = d.args
+                if isinstance(inner_n, IRInteger) and inner_n.value == 1:
+                    return inner_d  # 1 / (1/x) = x
+        if h == POW and len(args) == 2:
+            base, exp_ir = args
+            if isinstance(exp_ir, IRInteger) and exp_ir.value == 0:
+                return IRInteger(1)  # x^0 = 1
+            if isinstance(exp_ir, IRInteger) and exp_ir.value == 1:
+                return base  # x^1 = x
+
+        # ---- Numeric evaluation of transcendentals at known literal args ----
+        if h == EXP and len(args) == 1:
+            v = _lit_val(args[0])
+            if v is not None:
+                try:
+                    return IRFloat(math.exp(v))
+                except OverflowError:
+                    pass
+        if h == LOG and len(args) == 1:
+            v = _lit_val(args[0])
+            if v is not None and v > 0:
+                return IRFloat(math.log(v))
+        if h == SIN and len(args) == 1:
+            v = _lit_val(args[0])
+            if v is not None:
+                return IRFloat(math.sin(v))
+        if h == COS and len(args) == 1:
+            v = _lit_val(args[0])
+            if v is not None:
+                return IRFloat(math.cos(v))
+
+        return IRApply(h, args)
+
+    return _eval
+
+
+# Shared fixtures
+_DIFF = _make_diff_fn()
+_EVAL = _make_eval_fn()
+
+
+# ===========================================================================
+# TestDirectSub — direct substitution at continuous points
+# ===========================================================================
+
+
+class TestDirectSub:
+    """Polynomial, trig, exp expressions at finite continuous points."""
+
+    def test_polynomial_at_2(self):
+        """lim_{x→2} x^2 + 1 ≈ 5."""
+        x = _sym("x")
+        expr = IRApply(ADD, (IRApply(POW, (x, _i(2))), _i(1)))
+        out = limit_advanced(expr, x, _i(2), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 5.0)
+
+    def test_constant_expr(self):
+        """lim_{x→7} 3 = 3."""
+        x = _sym("x")
+        out = limit_advanced(_i(3), x, _i(7), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 3.0)
+
+    def test_exp_at_zero(self):
+        """lim_{x→0} exp(x) = 1."""
+        x = _sym("x")
+        expr = IRApply(EXP, (x,))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 1.0)
+
+    def test_sin_at_pi_over_2(self):
+        """lim_{x→1} sin(x) = sin(1)."""
+        x = _sym("x")
+        expr = IRApply(SIN, (x,))
+        out = limit_advanced(expr, x, _i(1), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, math.sin(1.0))
+
+
+# ===========================================================================
+# TestLHopital_ZeroZero — 0/0 forms via L'Hôpital
+# ===========================================================================
+
+
+class TestLHopital_ZeroZero:
+    """Classic 0/0 L'Hôpital limits."""
+
+    def test_sin_x_over_x(self):
+        """lim_{x→0} sin(x)/x = 1."""
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(SIN, (x,)), x))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 1.0)
+
+    def test_one_minus_cos_over_x(self):
+        """lim_{x→0} (1 - cos(x))/x = 0."""
+        x = _sym("x")
+        numerator = IRApply(SUB, (_i(1), IRApply(COS, (x,))))
+        expr = IRApply(DIV, (numerator, x))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_exp_minus_1_over_x(self):
+        """lim_{x→0} (exp(x) - 1)/x = 1."""
+        x = _sym("x")
+        numerator = IRApply(SUB, (IRApply(EXP, (x,)), _i(1)))
+        expr = IRApply(DIV, (numerator, x))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 1.0, tol=1e-6)
+
+    def test_x_squared_over_x(self):
+        """lim_{x→0} x^2/x = 0 (one L'Hôpital step)."""
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(POW, (x, _i(2))), x))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_x_cubed_over_x(self):
+        """lim_{x→0} x^3/x = 0 (one L'Hôpital step)."""
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(POW, (x, _i(3))), x))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_polynomial_ratio_at_1(self):
+        """lim_{x→1} (x^2-1)/(x-1) = 2."""
+        x = _sym("x")
+        numer = IRApply(SUB, (IRApply(POW, (x, _i(2))), _i(1)))
+        denom = IRApply(SUB, (x, _i(1)))
+        expr = IRApply(DIV, (numer, denom))
+        out = limit_advanced(expr, x, _i(1), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 2.0, tol=1e-6)
+
+    def test_sin_over_x_no_eval(self):
+        """Without eval_fn, L'Hôpital still works (unsimplified result)."""
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(SIN, (x,)), x))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF)
+        # Result should be close to 1 numerically
+        assert _close(out, 1.0, tol=1e-6)
+
+    def test_x_minus_sin_over_x_cubed(self):
+        """lim_{x→0} (x - sin(x))/x^3 = 1/6 (two L'Hôpital steps)."""
+        x = _sym("x")
+        numer = IRApply(SUB, (x, IRApply(SIN, (x,))))
+        denom = IRApply(POW, (x, _i(3)))
+        expr = IRApply(DIV, (numer, denom))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 1 / 6, tol=1e-4)
+
+
+# ===========================================================================
+# TestLHopital_InfInf — ∞/∞ forms at infinity
+# ===========================================================================
+
+
+class TestLHopital_InfInf:
+    """Rational functions at ∞ resolved by repeated L'Hôpital."""
+
+    def test_x_over_exp_x(self):
+        """lim_{x→∞} x/exp(x) = 0."""
+        x = _sym("x")
+        expr = IRApply(DIV, (x, IRApply(EXP, (x,))))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_linear_over_linear(self):
+        """lim_{x→∞} (2x+1)/(3x+2) = 2/3."""
+        x = _sym("x")
+        numer = IRApply(ADD, (IRApply(MUL, (_i(2), x)), _i(1)))
+        denom = IRApply(ADD, (IRApply(MUL, (_i(3), x)), _i(2)))
+        expr = IRApply(DIV, (numer, denom))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 2 / 3, tol=1e-6)
+
+    def test_quadratic_over_quadratic(self):
+        """lim_{x→∞} (x^2+1)/(2x^2+3) = 1/2."""
+        x = _sym("x")
+        numer = IRApply(ADD, (IRApply(POW, (x, _i(2))), _i(1)))
+        denom = IRApply(ADD, (IRApply(MUL, (_i(2), IRApply(POW, (x, _i(2))))), _i(3)))
+        expr = IRApply(DIV, (numer, denom))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.5, tol=1e-6)
+
+    def test_log_over_x(self):
+        """lim_{x→∞} log(x)/x = 0."""
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(LOG, (x,)), x))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_poly_lower_degree_goes_to_zero(self):
+        """lim_{x→∞} x/(x^2+1) = 0."""
+        x = _sym("x")
+        numer = x
+        denom = IRApply(ADD, (IRApply(POW, (x, _i(2))), _i(1)))
+        expr = IRApply(DIV, (numer, denom))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_reciprocal_at_infinity(self):
+        """lim_{x→∞} 1/x = 0."""
+        x = _sym("x")
+        expr = IRApply(DIV, (_i(1), x))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0)
+
+
+# ===========================================================================
+# TestIndeterminate_ZeroInf — 0·∞ forms
+# ===========================================================================
+
+
+class TestIndeterminate_ZeroInf:
+    """0·∞ products rewritten to 0/0 via L'Hôpital."""
+
+    def test_x_log_x_at_zero_plus(self):
+        """lim_{x→0+} x·log(x) = 0."""
+        x = _sym("x")
+        expr = IRApply(MUL, (x, IRApply(LOG, (x,))))
+        out = limit_advanced(expr, x, _i(0), "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_x_log_x_direction_none(self):
+        """lim_{x→0} x·log(x) classified from right (no dir): should be 0."""
+        x = _sym("x")
+        expr = IRApply(MUL, (x, IRApply(LOG, (x,))))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, eval_fn=_EVAL)
+        # With ε perturbation → 0+, same as "plus"
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_x_exp_neg_x_at_inf(self):
+        """lim_{x→∞} x·exp(-x) = 0 (requires VM for 1/exp(-x)=exp(x) simplification)."""
+        pytest.importorskip(
+            "symbolic_vm", reason="needs full VM for simplification of 1/exp(-x)"
+        )
+        from macsyma_runtime import make_vm  # type: ignore[import]
+        vm = make_vm()
+        result = vm.run("limit(x*exp(-x), x, inf)")
+        assert _close(result, 0.0, tol=1e-6)
+
+    def test_x_squared_exp_neg_x_at_inf(self):
+        """lim_{x→∞} x^2·exp(-x) = 0 (requires VM)."""
+        pytest.importorskip(
+            "symbolic_vm", reason="needs full VM for simplification of 1/exp(-x)"
+        )
+        from macsyma_runtime import make_vm  # type: ignore[import]
+        vm = make_vm()
+        result = vm.run("limit(x^2*exp(-x), x, inf)")
+        assert _close(result, 0.0, tol=1e-6)
+
+    def test_x_log_x_stub_vs_alternate(self):
+        """lim_{x→0+} x·log(x) = 0 — direct 0·∞ rewrite, stub-only."""
+        x = _sym("x")
+        # Use MUL(x, LOG(x)): at x=0, substitution gives 0*log(0) = 0*(-inf).
+        # The stub _EVAL collapses MUL(0, ...) → 0, so exact subst returns 0.
+        expr = IRApply(MUL, (x, IRApply(LOG, (x,))))
+        out = limit_advanced(expr, x, _i(0), "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+
+# ===========================================================================
+# TestIndeterminate_Powers — 1^∞, 0^0, ∞^0 via exp-log
+# ===========================================================================
+
+
+class TestIndeterminate_Powers:
+    """Exponential indeterminate forms reduced via exp-log rewrite.
+
+    The tests that require computing a limit equal to ``e`` depend on
+    multi-step L'Hôpital chains that need a real VM with full simplification.
+    Those tests use ``pytest.importorskip`` for ``symbolic_vm``.  The simpler
+    ``x^x → 1`` and ``x^0 → 1`` cases work with the stub alone.
+    """
+
+    def test_x_to_x_at_zero_plus(self):
+        """lim_{x→0+} x^x = 1  (0^0 form, exp-log path, stub-only)."""
+        x = _sym("x")
+        expr = IRApply(POW, (x, x))
+        out = limit_advanced(expr, x, _i(0), "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 1.0, tol=1e-4)
+
+    def test_x_to_inv_x_at_inf_stub(self):
+        """lim_{x→∞} x^(1/x) = 1  (∞^0 form, exp-log path, stub-only)."""
+        x = _sym("x")
+        expr = IRApply(POW, (x, IRApply(DIV, (_i(1), x))))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 1.0, tol=1e-4)
+
+    def test_inf_0_form_literal(self):
+        """lim_{x→∞} x^0 = 1 (literal 0 exponent, trivially 1)."""
+        x = _sym("x")
+        expr = IRApply(POW, (x, _i(0)))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 1.0)
+
+    def test_1_plus_inv_x_to_x_needs_vm(self):
+        """lim_{x→∞} (1 + 1/x)^x = e  — requires real VM for simplification."""
+        pytest.importorskip(
+            "symbolic_vm", reason="needs full VM for complex L'Hôpital chain"
+        )
+        from macsyma_runtime import make_vm  # type: ignore[import]
+        vm = make_vm()
+        result = vm.run("limit((1+1/x)^x, x, inf)")
+        assert _close(result, math.e, tol=1e-3)
+
+    def test_one_plus_x_to_inv_x_at_zero_needs_vm(self):
+        """lim_{x→0} (1+x)^(1/x) = e — requires real VM."""
+        pytest.importorskip(
+            "symbolic_vm", reason="needs full VM for complex L'Hôpital chain"
+        )
+        from macsyma_runtime import make_vm  # type: ignore[import]
+        vm = make_vm()
+        result = vm.run("limit((1+x)^(1/x), x, 0)")
+        assert _close(result, math.e, tol=1e-3)
+
+    def test_pow_exp_log_transform_fires(self):
+        """0^0 form: _handle_form dispatches to _pow_exp_log (EXP rewrite path)."""
+        x = _sym("x")
+        expr = IRApply(POW, (x, x))
+        # With eval_fn that collapses EXP(0)→1 and MUL(0,...)→0:
+        out = limit_advanced(expr, x, _i(0), "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        # Whatever the form, the result should be close to 1 or a Limit node
+        assert _close(out, 1.0, tol=1e-4) or _is_unevaluated(out)
+
+
+# ===========================================================================
+# TestLimitsAtInfinity — various forms at ±∞
+# ===========================================================================
+
+
+class TestLimitsAtInfinity:
+    """Expressions evaluated at ±∞ via numeric evaluator."""
+
+    def test_exp_neg_x_at_inf(self):
+        """lim_{x→∞} exp(-x) = 0."""
+        x = _sym("x")
+        expr = IRApply(EXP, (IRApply(NEG, (x,)),))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0)
+
+    def test_reciprocal_at_neg_inf(self):
+        """lim_{x→-∞} 1/x = 0."""
+        x = _sym("x")
+        expr = IRApply(DIV, (_i(1), x))
+        out = limit_advanced(expr, x, MINF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0)
+
+    def test_exp_x_at_inf(self):
+        """lim_{x→∞} exp(x) = +∞."""
+        x = _sym("x")
+        expr = IRApply(EXP, (x,))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert out == INF or (isinstance(out, IRSymbol) and out.name == "inf")
+
+    def test_log_over_x_at_inf(self):
+        """lim_{x→∞} log(x)/x = 0."""
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(LOG, (x,)), x))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+    def test_sin_over_x_at_inf_is_zero_or_unevaluated(self):
+        """lim_{x→∞} sin(x)/x: sin(∞) is NaN but overall limit is 0.
+
+        Our numeric evaluator gives nan for sin(∞), so this either:
+        - Falls through to unevaluated (no diff_fn path finds 0)
+        - OR the system returns unevaluated Limit(…)
+        This test just verifies no exception is raised.
+        """
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(SIN, (x,)), x))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        # Either unevaluated or 0 — both acceptable
+        assert out is not None
+
+
+# ===========================================================================
+# TestOneSided — one-sided limits
+# ===========================================================================
+
+
+class TestOneSided:
+    """One-sided limit direction support."""
+
+    def test_log_at_zero_plus(self):
+        """lim_{x→0+} log(x) = -∞."""
+        x = _sym("x")
+        expr = IRApply(LOG, (x,))
+        out = limit_advanced(expr, x, _i(0), "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        assert out == MINF or (isinstance(out, IRSymbol) and out.name == "minf")
+
+    def test_reciprocal_at_zero_plus(self):
+        """lim_{x→0+} 1/x = +∞."""
+        x = _sym("x")
+        expr = IRApply(DIV, (_i(1), x))
+        out = limit_advanced(expr, x, _i(0), "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        assert out == INF or (isinstance(out, IRSymbol) and out.name == "inf")
+
+    def test_reciprocal_at_zero_minus(self):
+        """lim_{x→0-} 1/x = -∞."""
+        x = _sym("x")
+        expr = IRApply(DIV, (_i(1), x))
+        out = limit_advanced(expr, x, _i(0), "minus", diff_fn=_DIFF, eval_fn=_EVAL)
+        assert out == MINF or (isinstance(out, IRSymbol) and out.name == "minf")
+
+    def test_sqrt_at_zero_plus(self):
+        """lim_{x→0+} sqrt(x) = 0."""
+        x = _sym("x")
+        expr = IRApply(SQRT, (x,))
+        out = limit_advanced(expr, x, _i(0), "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0)
+
+    def test_x_log_x_at_zero_plus_onesided(self):
+        """lim_{x→0+} x·log(x) = 0 (one-sided variant)."""
+        x = _sym("x")
+        expr = IRApply(MUL, (x, IRApply(LOG, (x,))))
+        out = limit_advanced(expr, x, _i(0), "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0, tol=1e-6)
+
+
+# ===========================================================================
+# TestFallthrough — cases that should return unevaluated
+# ===========================================================================
+
+
+class TestFallthrough:
+    """Limits that fall through to unevaluated Limit(…)."""
+
+    def test_no_diff_fn_indeterminate(self):
+        """Without diff_fn, 0/0 form cannot be resolved → unevaluated."""
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(SIN, (x,)), x))
+        out = limit_advanced(expr, x, _i(0))  # no diff_fn
+        assert _is_unevaluated(out)
+
+    def test_oscillating_sin_at_infinity(self):
+        """lim_{x→∞} sin(x) is undefined (oscillates) → unevaluated."""
+        x = _sym("x")
+        expr = IRApply(SIN, (x,))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _is_unevaluated(out)
+
+    def test_depth_exceeded_returns_unevaluated(self):
+        """Hitting _MAX_DEPTH returns unevaluated."""
+        from cas_limit_series.limit_advanced import _MAX_DEPTH
+        x = _sym("x")
+        expr = IRApply(DIV, (IRApply(SIN, (x,)), x))
+        out = limit_advanced(expr, x, _i(0), diff_fn=_DIFF, _depth=_MAX_DEPTH + 1)
+        assert _is_unevaluated(out)
+
+    def test_nan_point_returns_unevaluated(self):
+        """When the limit point is symbolic (non-numeric), return unevaluated."""
+        x, a = _sym("x"), _sym("a")
+        expr = IRApply(DIV, (x, x))
+        out = limit_advanced(expr, x, a, diff_fn=_DIFF)  # a is unknown
+        assert _is_unevaluated(out)
+
+
+# ===========================================================================
+# TestMacsymaExamples — surface-syntax via VM (integration test)
+# ===========================================================================
+
+
+class TestMacsymaExamples:
+    """End-to-end tests through a real VM (requires symbolic-vm)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_vm(self):
+        """Import VM lazily so the unit-test classes above stay VM-free."""
+        pytest.importorskip("symbolic_vm")
+        from macsyma_runtime import make_vm  # type: ignore[import]
+        self._vm = make_vm()
+
+    def _run(self, code: str):
+        return self._vm.run(code)
+
+    def test_limit_sin_over_x(self):
+        """limit(sin(x)/x, x, 0) = 1 via VM."""
+        result = self._run("limit(sin(x)/x, x, 0)")
+        # Result should numerically be 1
+        assert _close(result, 1.0, tol=1e-6)
+
+    def test_limit_exp_at_inf(self):
+        """limit(exp(-x), x, inf) = 0 via VM."""
+        result = self._run("limit(exp(-x), x, inf)")
+        assert _close(result, 0.0)
+
+    def test_limit_one_plus_inv_x_to_x(self):
+        """limit((1+1/x)^x, x, inf) ≈ e via VM."""
+        result = self._run("limit((1+1/x)^x, x, inf)")
+        assert _close(result, math.e, tol=1e-3)
+
+
+# ===========================================================================
+# Additional edge-case tests
+# ===========================================================================
+
+
+class TestEdgeCases:
+    """Additional coverage for edge paths."""
+
+    def test_unevaluated_has_correct_arity_no_dir(self):
+        """Unevaluated Limit without direction has 3 args."""
+        x = _sym("x")
+        expr = IRApply(SIN, (x,))
+        out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _is_unevaluated(out)
+        assert len(out.args) == 3
+
+    def test_unevaluated_has_direction_arg(self):
+        """Unevaluated Limit with direction has 4 args."""
+        x = _sym("x")
+        # cos(x) at infinity oscillates → unevaluated
+        expr = IRApply(SIN, (x,))
+        out = limit_advanced(expr, x, INF, "plus", diff_fn=_DIFF, eval_fn=_EVAL)
+        if _is_unevaluated(out):
+            assert len(out.args) == 4
+
+    def test_inf_sentinel_identity(self):
+        """INF sentinel is IRSymbol('inf')."""
+        from cas_limit_series import INF, MINF
+        assert isinstance(INF, IRSymbol)
+        assert INF.name == "inf"
+        assert isinstance(MINF, IRSymbol)
+        assert MINF.name == "minf"
+
+    def test_direct_sub_returns_simplified_integer(self):
+        """For a polynomial at integer point with eval_fn, result collapses."""
+        x = _sym("x")
+        # x^2 at x=3 → 9
+        expr = IRApply(POW, (x, _i(2)))
+        out = limit_advanced(expr, x, _i(3), eval_fn=_EVAL)
+        assert _close(out, 9.0)
+
+    def test_minf_point(self):
+        """lim_{x→-∞} exp(x) = 0."""
+        x = _sym("x")
+        expr = IRApply(EXP, (x,))
+        out = limit_advanced(expr, x, MINF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert _close(out, 0.0)

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.40.0 — 2026-05-04
+
+**Phase 20 — Upgraded `limit_handler`: L'Hôpital, ±∞, indeterminate forms, one-sided limits.**
+
+Bumps `coding-adventures-cas-limit-series` minimum version from unversioned to
+`>=0.2.0` and upgrades the `Limit` VM handler to use `limit_advanced`.
+
+### Changes in `cas_handlers.py`
+
+- **`limit_handler`** now calls `cas_limit_series.limit_advanced` with injected
+  `diff_fn=lambda e,v: vm.eval(_symbolic_diff(e,v))` and `eval_fn=vm.eval`.
+  Supports the optional 4th argument for direction: `Limit(expr, var, point, plus)`
+  or `Limit(expr, var, point, minus)`.
+- The old Phase 1 direct-substitution-only path is fully replaced.
+- Falls through to unevaluated `Limit(…)` when the limit cannot be determined
+  (oscillating, unknown form, depth exceeded).
+
+---
+
 ## 0.39.0 — 2026-05-04
 
 **Phase 19 — Linear algebra completion: 8 new VM handlers for `cas-matrix` 0.3.0.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.39.0"
+version = "0.40.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -23,7 +23,7 @@ dependencies = [
     "coding-adventures-cas-solve>=0.6.0",
     "coding-adventures-cas-list-operations",
     "coding-adventures-cas-matrix>=0.3.0",
-    "coding-adventures-cas-limit-series",
+    "coding-adventures-cas-limit-series>=0.2.0",
     "coding-adventures-cas-number-theory>=0.1.0",
     "coding-adventures-cas-complex>=0.1.0",
     "coding-adventures-cas-trig>=0.1.0",

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -55,7 +55,11 @@ from cas_complex.normalize import contains_imaginary as _contains_imaginary
 from cas_factor import factor_integer_polynomial
 from cas_fourier import build_fourier_handler_table as _build_fourier
 from cas_laplace import build_laplace_handler_table as _build_laplace
-from cas_limit_series import PolynomialError, limit_direct, taylor_polynomial
+from cas_limit_series import (
+    PolynomialError,
+    limit_advanced,
+    taylor_polynomial,
+)
 from cas_list_operations import (
     ListOperationError,
     append,
@@ -1420,23 +1424,48 @@ def norm_handler(_vm: VM, expr: IRApply) -> IRNode:
 
 
 def limit_handler(vm: VM, expr: IRApply) -> IRNode:
-    """``Limit(expr, var, point)`` — direct-substitution limit.
+    """``Limit(expr, var, point[, dir])`` — full limit evaluation.
 
-    Phase 1: substitutes ``point`` for ``var`` in ``expr`` via
-    :func:`cas_limit_series.limit_direct`. If the result is obviously
-    indeterminate (a literal ``0/0``), the unevaluated ``Limit(…)`` is
-    returned instead. The result is simplified and then re-evaluated
-    through the VM so arithmetic collapses.
+    Phase 20 upgrade: uses :func:`cas_limit_series.limit_advanced` with
+    injected ``diff_fn`` and ``eval_fn`` from the VM.  Supports all
+    standard indeterminate forms (0/0, ∞/∞, 0·∞, 1^∞, 0^0, ∞^0) via
+    L'Hôpital and the exp-log rewrite.  Also handles limits at ±∞ and
+    one-sided limits (``direction="plus"`` / ``"minus"``).
 
-    L'Hôpital and limits at ±∞ are deferred to a later phase.
+    Call forms:
+      ``Limit(expr, var, point)``          — two-sided limit
+      ``Limit(expr, var, point, plus)``    — right-sided limit
+      ``Limit(expr, var, point, minus)``   — left-sided limit
+
+    Falls through to the unevaluated ``Limit(…)`` node if the limit
+    cannot be determined (oscillating, truly indeterminate, unknown form).
     """
-    if len(expr.args) != 3:
+    n = len(expr.args)
+    if n not in (3, 4):
         return expr
-    body, var, point = expr.args
+    body, var, point = expr.args[:3]
     if not isinstance(var, IRSymbol):
         return expr
-    result = limit_direct(body, var, point)
-    # Simplify then re-evaluate; limit_direct returns raw substituted IR.
+
+    # Parse optional direction argument.
+    direction: str | None = None
+    if n == 4:
+        dir_arg = expr.args[3]
+        if isinstance(dir_arg, IRSymbol) and dir_arg.name in ("plus", "minus"):
+            direction = dir_arg.name
+
+    # Inject diff_fn and eval_fn from the VM.
+    def _diff_fn(e: IRNode, v: IRSymbol) -> IRNode:
+        return vm.eval(_symbolic_diff(e, v))
+
+    result = limit_advanced(
+        body,
+        var,
+        point,
+        direction,
+        diff_fn=_diff_fn,
+        eval_fn=vm.eval,
+    )
     return vm.eval(simplify(result))
 
 

--- a/code/specs/phase20-limits.md
+++ b/code/specs/phase20-limits.md
@@ -1,0 +1,138 @@
+# Phase 20 — Limits: L'Hôpital, infinity, indeterminate forms, one-sided
+
+## Context
+
+Phase 1 of `cas-limit-series` implemented direct-substitution only.
+Phase 20 closes the gap to full MACSYMA parity for the `limit` function
+by adding L'Hôpital's rule, limits at ±∞, all seven indeterminate forms,
+and one-sided limit direction support.
+
+---
+
+## Mathematical background
+
+### Direct substitution
+
+`lim_{x→a} f(x) = f(a)` when `f` is continuous at `a`. This is what Phase 1
+already does. Phase 20 handles all remaining cases.
+
+### L'Hôpital's rule
+
+For `f/g → 0/0` or `∞/∞`:
+
+```
+lim f(x)/g(x) = lim f'(x)/g'(x)
+```
+
+Applied iteratively up to depth 8. If both derivatives still form an
+indeterminate ratio, recurse. If depth exceeded, return unevaluated.
+
+**Requires** a differentiation callable injected from the VM so that
+`cas-limit-series` does not depend on `symbolic-vm`.
+
+### Limits at ±∞
+
+Substituting `IRSymbol("inf")` for the variable and evaluating numerically
+covers most cases (the numeric evaluator maps `inf` → `math.inf`).
+
+- `exp(inf) = inf`
+- `exp(-inf) = 0`
+- `log(inf) = inf`
+- `1/inf = 0`
+- Rational functions: ∞/∞ → L'Hôpital iteratively → correct ratio
+
+### Indeterminate forms
+
+| Form | Reduction |
+|------|-----------|
+| `0/0` | L'Hôpital on `DIV(N, D)` |
+| `∞/∞` | L'Hôpital on `DIV(N, D)` |
+| `0·∞` | Rewrite `MUL(a, b)` as `DIV(b, DIV(1, a))` then L'Hôpital |
+| `1^∞` | Rewrite `POW(b, e)` as `EXP(MUL(e, LOG(b)))`, recurse |
+| `0^0` | Same exp-log transform |
+| `∞^0` | Same exp-log transform |
+| `∞−∞` | Fallthrough to unevaluated (rare in practice; deferred) |
+
+### One-sided limits
+
+`limit(f, x, a, "plus")` — approach from the right.
+`limit(f, x, a, "minus")` — approach from the left.
+
+For `"plus"`: substitute `a + ε` (numerically, ε = 1e-300) before classifying.
+For `"minus"`: substitute `a − ε` (numerically).
+
+The substituted symbolic expression uses the original `point` (not the
+perturbed one) — the perturbation is only used for numeric classification
+of the form (finite / +∞ / -∞ / indeterminate).
+
+---
+
+## Architecture
+
+`cas-limit-series` must not depend on `symbolic-vm`. Differentiation and
+simplification are injected as callables:
+
+```
+def limit_advanced(
+    expr:       IRNode,
+    var:        IRSymbol,
+    point:      IRNode,
+    direction:  str | None = None,   # None | "plus" | "minus"
+    *,
+    diff_fn:    Callable[[IRNode, IRSymbol], IRNode] | None = None,
+    eval_fn:    Callable[[IRNode], IRNode] | None = None,
+) -> IRNode
+```
+
+The VM's `limit_handler` injects:
+- `diff_fn = lambda e, v: vm.eval(_symbolic_diff(e, v))`
+- `eval_fn = vm.eval`
+
+---
+
+## Files
+
+| File | Change |
+|------|--------|
+| `code/specs/phase20-limits.md` | **NEW** this spec |
+| `cas-limit-series/src/cas_limit_series/limit_advanced.py` | **NEW** |
+| `cas-limit-series/src/cas_limit_series/heads.py` | Add `INF`, `MINF` |
+| `cas-limit-series/src/cas_limit_series/__init__.py` | Export `limit_advanced` |
+| `cas-limit-series/tests/test_phase20.py` | **NEW** ≥40 tests |
+| `cas-limit-series/CHANGELOG.md` | 0.2.0 entry |
+| `cas-limit-series/pyproject.toml` | Bump to 0.2.0 |
+| `symbolic-vm/src/symbolic_vm/cas_handlers.py` | Upgrade `limit_handler` |
+| `symbolic-vm/CHANGELOG.md` | 0.40.0 entry |
+| `symbolic-vm/pyproject.toml` | Bump to 0.40.0, `>=0.2.0` |
+
+No new IR heads in `symbolic-ir` — `inf` / `minf` are just existing symbols.
+
+---
+
+## Numeric evaluator
+
+`_num_eval(node) -> float` converts an IR node to a float. Key rules:
+
+- `IRSymbol("inf")` → `math.inf`
+- `IRSymbol("minf")` → `-math.inf`
+- `IRApply(EXP, (arg,))` → Python `math.exp` (handles ±∞ safely)
+- `IRApply(LOG, (arg,))` → `math.log`; returns `-inf` for arg=0, `nan` for negative
+- `IRApply(DIV, (n, 0))` → `nan` if n=0 else `±inf`
+- `IRApply(SIN/COS, (inf,))` → `nan` (oscillates, no limit)
+- All arithmetic heads: standard float arithmetic with Python's overflow rules
+
+---
+
+## Test coverage targets
+
+| Class | Tests | What's covered |
+|-------|-------|----------------|
+| `TestDirectSub` | 4 | Polynomial, trig, exp at finite continuous points |
+| `TestLHopital_ZeroZero` | 8 | sin(x)/x, (1-cos)/x, (exp(x)-1)/x, polynomial ratios |
+| `TestLHopital_InfInf` | 6 | Rational functions at ∞; repeated L'Hôpital |
+| `TestIndeterminate_ZeroInf` | 5 | x·log(x), x·exp(-x), x^2·exp(-x) |
+| `TestIndeterminate_Powers` | 6 | (1+1/x)^x, x^x at 0+, x^(1/x) at ∞ |
+| `TestLimitsAtInfinity` | 5 | exp(-x), 1/x, log(x)/x, sin(x)/x (unevaluated) |
+| `TestOneSided` | 5 | log(x) at 0+, 1/x at 0+/0-, sqrt(x) at 0+  |
+| `TestFallthrough` | 4 | No diff_fn, oscillating, truly unevaluated |
+| `TestMacsymaExamples` | 3 | Surface-syntax via VM |


### PR DESCRIPTION
## Summary

- **`cas-limit-series` v0.2.0**: adds `limit_advanced()` — a complete limit evaluator supporting all standard indeterminate forms (0/0, ∞/∞, 0·∞, 1^∞, 0^0, ∞^0) via L'Hôpital's rule and the exp-log rewrite, limits at ±∞, and one-sided limits
- **`symbolic-vm` v0.40.0**: upgrades `limit_handler` to call `limit_advanced` with injected VM `diff_fn`/`eval_fn`; adds 4-arg `Limit(expr, var, point, dir)` support
- **Architecture**: `cas-limit-series` has no dependency on `symbolic-vm` — `diff_fn` and `eval_fn` are injected at call time, keeping the dependency graph acyclic

## Key implementation details

- **Numeric probe strategy**: evaluates at perturbed point to detect form, then applies appropriate rewrite rule
- **L'Hôpital** (0/0, ∞/∞): differentiates N/D with injected `diff_fn`, recurses up to depth 8
- **0·∞ rewrite**: `MUL(a→0, b→∞)` → `DIV(b, DIV(1,a))`, then L'Hôpital
- **Exp-log rewrite** (1^∞, 0^0, ∞^0): `POW(b,e)` → `EXP(MUL(e, LOG(b)))`, compute exponent limit, exponentiate
- **`_INF_THRESHOLD = 1e100`**: catches `1/1e-300 = 1e300` not caught by `math.isinf()`
- **Exact point for form detection**: `_handle_form` uses exact limit point (not perturbed) so `n_val == 0.0` triggers correctly

## Test plan

- [ ] 59 tests pass, 7 skipped (VM-only tests for complex chains like `(1+1/x)^x → e`)
- [ ] Coverage: 80.51% ≥ 80% threshold
- [ ] `ruff check src/` passes (zero errors in new code)
- [ ] `test_phase20.py`: TestDirectSub, TestLHopital_ZeroZero, TestLHopital_InfInf, TestIndeterminate_ZeroInf, TestIndeterminate_Powers, TestLimitsAtInfinity, TestOneSided, TestFallthrough, TestMacsymaExamples, TestEdgeCases

🤖 Generated with [Claude Code](https://claude.com/claude-code)