### PR TITLE
feat(matrix-runtime): implement MX04 planner, registry, cost model

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -287,6 +287,7 @@ members = [
     "gpu-runtime",
     "image-gpu-core",
     "matrix-ir",
+    "matrix-runtime",
     "metal-compute",
     "paint-metal",
     "paint-vm-direct2d-c",

--- a/code/packages/rust/matrix-runtime/BUILD
+++ b/code/packages/rust/matrix-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p matrix-runtime -- --nocapture

--- a/code/packages/rust/matrix-runtime/BUILD_windows
+++ b/code/packages/rust/matrix-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p matrix-runtime -- --nocapture

--- a/code/packages/rust/matrix-runtime/CHANGELOG.md
+++ b/code/packages/rust/matrix-runtime/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to `matrix-runtime` are documented here.  The
+format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-05-04
+
+Initial release.  Implements spec MX04 V1.
+
+### Renamed from `compute-runtime`
+
+The spec MX04 originally named this crate `compute-runtime`, but that
+name was already taken by the G05 GPU-runtime simulator (Vulkan-inspired
+device-discovery / command-recording crate).  Renamed to `matrix-runtime`
+to disambiguate.  Specs MX00–MX04 updated.
+
+### Added
+
+- **`Runtime`** — the public API surface.  Owns a registry, exposes
+  `plan()` (lower MatrixIR → ComputeIR), `register()`, `set_healthy()`,
+  `update_profile()`, `executors()`.
+- **`Registry`** — `Vec`-backed list of `RegisteredExecutor` records,
+  indexed by `ExecutorId`.  CPU pre-registered at `ExecutorId(0)` via
+  `Registry::with_cpu()`.
+- **`RegisteredExecutor`** — `id`, `kind`, `profile`, `healthy` plus
+  `supports_op()` / `supports_dtype()` capability bitset accessors.
+- **`plan()`** — the four-pass planner:
+  1. Capability filter
+  2. Greedy cost minimisation
+  3. Transfer insertion
+  4. Lifetime annotation (`Alloc` before first use, `Free` after last use)
+- **Cost model** — `estimate_flops()`, `estimate_matmul_flops()`,
+  `transfer_cost_ns()`, `compute_cost()`.  Coarse but ordinally correct.
+- **`PlanError`** — `InvalidGraph`, `NoCapableExecutor`, `EmptyRegistry`,
+  `UndefinedTensor`.
+- **`RuntimeError`** — wraps `PlanError` plus future execution errors.
+
+### Behaviours that fall out of the cost model
+
+- **Small ops stay on CPU** — transfer cost exceeds GPU speedup.
+- **Large ops ship to GPU** — GPU speedup exceeds transfer cost.
+- **Capability fallback** — ops with unsupported dtypes fall back
+  to CPU automatically.
+- **Health-aware placement** — unhealthy executors are filtered.
+- **Monotonic threshold** — slower PCIe makes the GPU threshold higher.
+
+All without any special-case logic.
+
+### Test coverage: 21 tests passing
+
+- 8 integration tests (CPU-only no-transfers, small-add-stays-on-CPU,
+  large-matmul-ships-to-GPU, unsupported-dtype-falls-back-to-CPU,
+  unhealthy-executor-skipped, empty-runtime-errors,
+  cost-model-threshold-monotonic, plan-function-with-registry)
+- 13 unit tests across cost / registry / runtime / planner modules
+
+### Constraints
+
+- Zero external dependencies.  Only `matrix-ir`, `compute-ir`, and
+  `executor-protocol` (path-only).
+- Pure planning logic.  No I/O — execution is delegated to executor
+  crates via the `Transport` from `executor-protocol`.
+
+### Out of scope (V1, deferred to V2)
+
+- End-to-end `run()` — depends on the first executor crate.
+- Graph caching.
+- Cost-model auto-tuning via microbenchmarks.
+- Speculative execution.
+- Within-graph parallelism.

--- a/code/packages/rust/matrix-runtime/Cargo.toml
+++ b/code/packages/rust/matrix-runtime/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "matrix-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "MX04 — the brain of the matrix execution layer. Planner, executor registry, and cost-model-driven placement. Lowers matrix-ir Graphs to compute-ir ComputeGraphs by routing each op to the cheapest available executor. Zero external dependencies."
+license = "MIT"
+
+[dependencies]
+matrix-ir         = { path = "../matrix-ir" }
+compute-ir        = { path = "../compute-ir" }
+executor-protocol = { path = "../executor-protocol" }

--- a/code/packages/rust/matrix-runtime/README.md
+++ b/code/packages/rust/matrix-runtime/README.md
@@ -1,0 +1,168 @@
+# matrix-runtime
+
+The brain of the matrix execution layer.  Planner, executor registry,
+and cost-model-driven placement.
+
+This is the implementation of spec **MX04** (originally proposed as
+`compute-runtime`; renamed because that name was already taken by the
+G05 GPU-runtime simulator).  See:
+
+- [`code/specs/MX04-compute-runtime.md`](../../specs/MX04-compute-runtime.md) — contract
+- [`code/specs/MX00-matrix-execution-overview.md`](../../specs/MX00-matrix-execution-overview.md) — architecture
+
+## What this crate does
+
+Lowers `matrix_ir::Graph` to `compute_ir::ComputeGraph` by routing each
+op to the cheapest available executor.
+
+```
+   matrix-ir   →   [matrix-runtime planner]   →   compute-ir   →   executors
+```
+
+The planner is a four-pass algorithm:
+
+1. **Capability filter** — for each op, find executors that support
+   it (op kind + dtype).  Fall back to CPU if none.
+2. **Greedy cost minimisation** — pick the executor with the lowest
+   `compute + transfer-in` cost for each op in topological order.
+3. **Transfer insertion** — insert `PlacedOp::Transfer` whenever an
+   input's residency doesn't match its consumer's executor.
+4. **Lifetime annotation** — `Alloc` before first use, `Free` after
+   last use.
+
+## Worked example
+
+```rust
+use matrix_ir::{DType, GraphBuilder, Shape};
+use matrix_runtime::{Runtime, BackendProfile};
+
+let cpu = BackendProfile {
+    kind: "cpu".to_string(),
+    supported_ops: 0xFFFF_FFFF, supported_dtypes: 0x07,
+    gflops_f32: 40, gflops_u8: 40, gflops_i32: 40,
+    host_to_device_bw: 100, device_to_host_bw: 100, device_internal_bw: 100,
+    launch_overhead_ns: 0, transport_latency_ns: 0,
+    on_device_mib: 8 * 1024, max_tensor_rank: 16, max_dim: u32::MAX,
+};
+let mut rt = Runtime::new(cpu);
+
+let gpu = BackendProfile {
+    kind: "gpu".to_string(),
+    gflops_f32: 5_000, /* …125× faster… */
+    host_to_device_bw: 10, /* …slow PCIe… */
+    ..rt.executors()[0].profile.clone()
+};
+rt.register("gpu", gpu);
+
+// Build a graph
+let mut g = GraphBuilder::new();
+let a = g.input(DType::F32, Shape::from(&[4096, 4096]));
+let b = g.input(DType::F32, Shape::from(&[4096, 4096]));
+let c = g.matmul(&a, &b);
+g.output(&c);
+let g = g.build().unwrap();
+
+// Plan — large matmul ships to GPU
+let placed = rt.plan(&g).unwrap();
+print!("{}", placed.dump());
+```
+
+## Cost-model-driven routing
+
+Each backend exposes a `BackendProfile` (re-exported from
+`executor-protocol`):
+
+- Compute throughput (GFLOPS per dtype)
+- Transfer bandwidth (host↔device)
+- Launch overhead, transport latency
+- Capability bitsets (op kind, dtype)
+
+The planner naturally:
+
+- Keeps small ops on CPU (transfer cost > GPU speedup).
+- Ships large ops to GPU (GPU speedup > transfer cost).
+- Falls back to CPU when a backend can't handle an op (capability
+  mismatch).
+- Skips unhealthy executors.
+
+These behaviours are all consequences of one cost function — no
+special-case logic.
+
+## Inspectable
+
+`ComputeGraph::dump()` shows every transfer with its estimated cost.
+The planner's reasoning is visible:
+
+```
+ComputeGraph (format v1, 2 inputs, 1 outputs, 11 ops)
+  inputs:
+    t0: f32 [4096, 4096]   @ exec 0 buf 0
+    t1: f32 [4096, 4096]   @ exec 0 buf 1
+  ops:
+    [00]  alloc            buf 2 @ exec 1   (64.0 MiB)
+    [01]  transfer t0      exec 0 buf 0  ->  exec 1 buf 2   (64.0 MiB, ≈ 6.4 ms)
+    [02]  alloc            buf 3 @ exec 1   (64.0 MiB)
+    [03]  transfer t1      exec 0 buf 1  ->  exec 1 buf 3   (64.0 MiB, ≈ 6.4 ms)
+    [04]  alloc            buf 4 @ exec 1   (64.0 MiB)
+    [05]  compute  matmul  exec 1 t0 t1 -> t2   (≈ 27 ms)
+    ...
+```
+
+## V1 scope
+
+V1 ships **the planner** and **the registry**.  The end-to-end execution
+path (driving `ComputeGraph`s through transports to executors and
+collecting outputs) lands when the first executor crate (`matrix-cpu`)
+arrives.  The `Runtime` API exposes:
+
+- `Runtime::new(cpu_profile)` — bootstrap with CPU fallback
+- `Runtime::register(kind, profile)` — add an executor
+- `Runtime::plan(graph)` — lower MatrixIR to ComputeIR
+- `Runtime::set_healthy(id, healthy)` — mark unhealthy executors
+- `Runtime::update_profile(id, profile)` — refresh on `ProfileUpdated`
+- `Runtime::executors()` — inspect the registry
+
+## Testing
+
+```
+cargo test -p matrix-runtime
+```
+
+Test methodology (per spec MX04 §"Test methodology"):
+
+- **Synthetic-profile tests** — register mock executors with hand-set
+  profiles, plan small graphs, assert placement decisions.
+- **CPU-only round-trip** — assert no transfers are inserted for
+  CPU-only graphs.
+- **Multi-executor planning** — small ops stay on CPU, large ops ship
+  to GPU.
+- **Capability fallback** — i32 op falls back to CPU when GPU lacks
+  i32 support.
+- **Health tracking** — unhealthy executor is skipped.
+- **Cost-model monotonicity** — slower PCIe means GPU is harder to
+  reach.
+
+## Zero dependencies
+
+```
+$ cargo tree -p matrix-runtime
+matrix-runtime v0.1.0
+├── compute-ir v0.1.0
+│   └── matrix-ir v0.1.0
+├── executor-protocol v0.1.0
+│   ├── compute-ir v0.1.0
+│   └── matrix-ir v0.1.0
+└── matrix-ir v0.1.0
+```
+
+Only the upstream matrix-execution-layer crates as path deps.
+
+## Out of scope (V1)
+
+Reserved for later:
+
+- **End-to-end `run()`** — wires transports into the runtime; lands with `matrix-cpu`.
+- **Graph caching** — re-planning every call is fine for V1; V2 caches `(graph_hash, registry_hash)`.
+- **Auto-tuning** — V2 microbenchmarks per (op, shape, dtype).
+- **Speculative execution** — V2 runs small graphs on multiple executors.
+- **Within-graph parallelism** — V1 executes ops in topological order.

--- a/code/packages/rust/matrix-runtime/required_capabilities.json
+++ b/code/packages/rust/matrix-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/matrix-runtime",
+  "capabilities": [],
+  "justification": "Pure planning logic (capability filter, cost minimisation, transfer insertion, lifetime annotation). No filesystem, network, process, or environment access — those are delegated to executor transports."
+}

--- a/code/packages/rust/matrix-runtime/src/cost.rs
+++ b/code/packages/rust/matrix-runtime/src/cost.rs
@@ -1,0 +1,250 @@
+//! Cost model — `estimate_flops`, `transfer_cost_ns`, `compute_cost`.
+//!
+//! See spec MX04 §"The planner algorithm" for the algorithm and
+//! §"BackendProfile" for the model.
+//!
+//! The cost model is **deliberately small**.  Real GPU performance is
+//! shape-dependent and cache-dependent; a faithful model would need
+//! microbenchmarks per (op, shape, dtype).  V1's position: a coarse
+//! model with good defaults beats none, and the planner only needs
+//! ordinal correctness — pick the cheapest backend, not the exact ns.
+
+use executor_protocol::BackendProfile;
+use matrix_ir::{DType, Op, Shape, Tensor};
+
+/// Estimate the number of floating-point ops a single execution of
+/// `op` performs.
+///
+/// Rough rules:
+///
+/// | Op kind | flops |
+/// |---------|-------|
+/// | Elementwise unary (Neg, Abs, Cast) | numel(output) |
+/// | Transcendental (Sqrt, Exp, Log, Tanh, Recip) | 5 × numel |
+/// | Elementwise binary (Add, Sub, Mul, Div, Max, Min) | numel(output) |
+/// | Pow | 5 × numel(output) |
+/// | MatMul `[m, k] × [k, n]` | 2 × m × k × n |
+/// | Reductions | numel(input) |
+/// | Reshape, Transpose, Broadcast | numel(output) (memory cost dominates) |
+/// | Comparison, Where | numel(output) |
+/// | Const | 0 |
+pub fn estimate_flops(op: &Op, output_shape: Option<&Shape>, input_shape: Option<&Shape>) -> u64 {
+    // Most variants only need output numel.  We default to 0 if the
+    // caller couldn't supply a shape — the planner won't make bad
+    // decisions because all backends will see the same 0.
+    let out_numel = output_shape.and_then(|s| s.numel()).unwrap_or(0);
+    let in_numel = input_shape.and_then(|s| s.numel()).unwrap_or(out_numel);
+
+    match op {
+        // Cheap elementwise.
+        Op::Neg { .. } | Op::Abs { .. } | Op::Cast { .. } => out_numel,
+        Op::Add { .. } | Op::Sub { .. } | Op::Mul { .. } | Op::Div { .. }
+        | Op::Max { .. } | Op::Min { .. } => out_numel,
+        Op::Equal { .. } | Op::Less { .. } | Op::Greater { .. } | Op::Where { .. } => out_numel,
+        // Transcendentals — count as 5 ops to reflect the typical
+        // hardware latency of pow/exp/log instructions.
+        Op::Sqrt { .. }
+        | Op::Exp { .. }
+        | Op::Log { .. }
+        | Op::Tanh { .. }
+        | Op::Recip { .. }
+        | Op::Pow { .. } => out_numel.saturating_mul(5),
+        // Reductions: cost is proportional to input numel.
+        Op::ReduceSum { .. } | Op::ReduceMax { .. } | Op::ReduceMean { .. } => in_numel,
+        // Shape ops: memory traffic, not flops, but we count one op
+        // per output element so the planner sees a non-zero cost.
+        Op::Reshape { .. } | Op::Transpose { .. } | Op::Broadcast { .. } => out_numel,
+        // MatMul: caller must supply both input shapes via `input_shape`.
+        Op::MatMul { .. } => {
+            // Without per-input shape access at this level, fall back
+            // to output numel × 2 × an estimated k=64 for graphs
+            // where the full shape isn't reachable.  In practice the
+            // planner calls `estimate_matmul_flops` directly.
+            out_numel.saturating_mul(128)
+        }
+        // Const: just an upload, no compute work.
+        Op::Const { .. } => 0,
+    }
+}
+
+/// Specialised matmul flop count: `2 × m × k × n` for `[m, k] × [k, n]`.
+pub fn estimate_matmul_flops(a: &Tensor, b: &Tensor) -> u64 {
+    if a.shape.rank() != 2 || b.shape.rank() != 2 {
+        return 0;
+    }
+    let m = a.shape.dims[0] as u64;
+    let k = a.shape.dims[1] as u64;
+    let n = b.shape.dims[1] as u64;
+    2u64.saturating_mul(m)
+        .saturating_mul(k)
+        .saturating_mul(n)
+}
+
+/// Estimate the time (in nanoseconds) to transfer `bytes` between
+/// the runtime host memory and an executor with the given profile.
+///
+/// `direction == "in"` → host-to-device; `"out"` → device-to-host;
+/// any other string → device-internal (for ops that produce output
+/// on the same device that consumed inputs).
+pub fn transfer_cost_ns(bytes: u64, profile: &BackendProfile, direction: TransferDirection) -> u64 {
+    let bw = match direction {
+        TransferDirection::HostToDevice => profile.host_to_device_bw,
+        TransferDirection::DeviceToHost => profile.device_to_host_bw,
+        TransferDirection::DeviceInternal => profile.device_internal_bw,
+    };
+    if bw == 0 {
+        // Zero bandwidth means "transfer is impossible" — return a
+        // huge cost so the planner picks somewhere else.
+        return u64::MAX / 2;
+    }
+    // bytes / (bytes per ns) = ns.  Add the transport latency
+    // (zero for in-process).
+    let xfer_ns = bytes / bw as u64;
+    xfer_ns.saturating_add(profile.transport_latency_ns as u64)
+}
+
+/// Direction of a host↔device transfer.  Used by [`transfer_cost_ns`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum TransferDirection {
+    /// Runtime host memory → executor.
+    HostToDevice,
+    /// Executor → runtime host memory.
+    DeviceToHost,
+    /// Executor → another executor (device-to-device).  V1 routes
+    /// through the runtime, so this is the sum of DeviceToHost +
+    /// HostToDevice elsewhere; this variant exists for V2 peer-to-peer.
+    DeviceInternal,
+}
+
+/// The cost (in nanoseconds) of running `op` on `executor` given the
+/// executor's profile and the dtype.  Includes:
+///
+/// - Compute: `flops × 1e9 / GFLOPS-rate-for-dtype`
+/// - Launch overhead
+/// - Transport latency (per-request RTT)
+///
+/// The caller is responsible for adding transfer-in costs for inputs
+/// not already resident on the executor — this function only models
+/// the on-executor work.
+pub fn compute_cost(flops: u64, dtype: DType, profile: &BackendProfile) -> u64 {
+    let gflops = match dtype {
+        DType::F32 => profile.gflops_f32,
+        DType::U8 => profile.gflops_u8,
+        DType::I32 => profile.gflops_i32,
+    };
+    if gflops == 0 {
+        // Backend doesn't support this dtype — return effectively
+        // infinity so the planner picks elsewhere.
+        return u64::MAX / 2;
+    }
+    // ns = flops / (gflops * 1e9 / 1e9) = flops / gflops
+    // (gflops here is "billion ops per second" scaled to "ops per
+    // nanosecond" if we treat the unit consistently).
+    let compute_ns = flops / gflops as u64;
+    compute_ns
+        .saturating_add(profile.launch_overhead_ns as u64)
+        .saturating_add(profile.transport_latency_ns as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_ir::TensorId;
+
+    fn cpu_profile() -> BackendProfile {
+        BackendProfile {
+            kind: "cpu".to_string(),
+            supported_ops: 0xFFFF_FFFF,
+            supported_dtypes: 0x07,
+            gflops_f32: 40,         // 40 GFLOPS
+            gflops_u8: 40,
+            gflops_i32: 40,
+            host_to_device_bw: 100, // bytes/ns; effectively no transfer cost
+            device_to_host_bw: 100,
+            device_internal_bw: 100,
+            launch_overhead_ns: 0,
+            transport_latency_ns: 0,
+            on_device_mib: 8 * 1024,
+            max_tensor_rank: 16,
+            max_dim: u32::MAX,
+        }
+    }
+
+    fn gpu_profile() -> BackendProfile {
+        BackendProfile {
+            kind: "gpu".to_string(),
+            supported_ops: 0xFFFF_FFFF,
+            supported_dtypes: 0x07,
+            gflops_f32: 5_000,
+            gflops_u8: 2_500,
+            gflops_i32: 2_500,
+            host_to_device_bw: 10,  // bytes/ns = 10 GB/s
+            device_to_host_bw: 10,
+            device_internal_bw: 500,
+            launch_overhead_ns: 1_000,
+            transport_latency_ns: 0,
+            on_device_mib: 16 * 1024,
+            max_tensor_rank: 8,
+            max_dim: 65535,
+        }
+    }
+
+    #[test]
+    fn small_add_cheaper_on_cpu() {
+        // 1024-elem f32 add: numel = 1024, bytes = 4096.
+        let flops = 1024;
+        let cpu_ns = compute_cost(flops, DType::F32, &cpu_profile())
+            + transfer_cost_ns(4096, &cpu_profile(), TransferDirection::HostToDevice);
+        let gpu_ns = compute_cost(flops, DType::F32, &gpu_profile())
+            + 2 * transfer_cost_ns(4096, &gpu_profile(), TransferDirection::HostToDevice);
+        // CPU should win.
+        assert!(cpu_ns < gpu_ns, "CPU {} should beat GPU {}", cpu_ns, gpu_ns);
+    }
+
+    #[test]
+    fn large_matmul_cheaper_on_gpu() {
+        // 4096×4096 f32 matmul: 2 × 4096^3 = 137_438_953_472 flops.
+        let a = Tensor::new(TensorId(0), DType::F32, Shape::from(&[4096, 4096]));
+        let b = Tensor::new(TensorId(1), DType::F32, Shape::from(&[4096, 4096]));
+        let flops = estimate_matmul_flops(&a, &b);
+        // 64 MiB per tensor.
+        let bytes = 4096u64 * 4096 * 4;
+
+        let cpu_ns = compute_cost(flops, DType::F32, &cpu_profile());
+        let gpu_ns = compute_cost(flops, DType::F32, &gpu_profile())
+            + 2 * transfer_cost_ns(bytes, &gpu_profile(), TransferDirection::HostToDevice);
+        // GPU should win even with 2 transfers.
+        assert!(gpu_ns < cpu_ns, "GPU {} should beat CPU {}", gpu_ns, cpu_ns);
+    }
+
+    #[test]
+    fn unsupported_dtype_returns_huge_cost() {
+        let p = BackendProfile {
+            gflops_f32: 0, // unsupported
+            ..cpu_profile()
+        };
+        let cost = compute_cost(1000, DType::F32, &p);
+        assert!(cost > 1_000_000_000, "unsupported dtype should be huge");
+    }
+
+    #[test]
+    fn estimate_flops_for_each_op_kind() {
+        let s = Shape::from(&[10, 10]); // numel = 100
+        let neg = Op::Neg {
+            input: TensorId(0),
+            output: TensorId(1),
+        };
+        let exp = Op::Exp {
+            input: TensorId(0),
+            output: TensorId(1),
+        };
+        let add = Op::Add {
+            lhs: TensorId(0),
+            rhs: TensorId(1),
+            output: TensorId(2),
+        };
+        assert_eq!(estimate_flops(&neg, Some(&s), None), 100);
+        assert_eq!(estimate_flops(&exp, Some(&s), None), 500);
+        assert_eq!(estimate_flops(&add, Some(&s), None), 100);
+    }
+}

--- a/code/packages/rust/matrix-runtime/src/lib.rs
+++ b/code/packages/rust/matrix-runtime/src/lib.rs
@@ -1,0 +1,59 @@
+//! # `matrix-runtime` — Planner, Registry, Cost Model
+//!
+//! The brain of the matrix execution layer.  Implements **spec MX04**.
+//!
+//! See:
+//! - [`code/specs/MX04-compute-runtime.md`] — this crate's contract
+//! - [`code/specs/MX00-matrix-execution-overview.md`] — architecture
+//! - [`code/specs/MX01-matrix-ir.md`] — the upper IR
+//! - [`code/specs/MX02-compute-ir.md`] — the lower IR
+//! - [`code/specs/MX03-executor-protocol.md`] — wire protocol
+//!
+//! ## What this crate does
+//!
+//! 1. **Owns the registry** of available executors and their capabilities.
+//! 2. **Lowers `MatrixIR`** to `ComputeIR` via the planner: a
+//!    four-pass algorithm (capability filter, greedy cost
+//!    minimisation, transfer insertion, lifetime annotation).
+//! 3. **Exposes a `Runtime` API** that domain libraries call.
+//!
+//! V1 ships the **planner** as the load-bearing piece.  Execution
+//! (driving ComputeGraphs through transports to executors and
+//! collecting outputs) is left as a seam: the runtime exposes
+//! `plan()` for inspection and `executors()` for registry access;
+//! the actual `run()` end-to-end loop lands when the first executor
+//! crate (`matrix-cpu`) lands.
+//!
+//! ## Naming
+//!
+//! Originally proposed as `compute-runtime` in spec MX04; renamed to
+//! `matrix-runtime` to avoid colliding with the existing G05 GPU
+//! runtime simulator already in the workspace under that name.
+//!
+//! ## Zero dependencies
+//!
+//! Per the MX00 zero-dependency mandate, this crate uses only
+//! `core`, `alloc`, `std`, and the upstream matrix-execution-layer
+//! crates (`matrix-ir`, `compute-ir`, `executor-protocol`).  No
+//! external crates.
+
+#![warn(rust_2018_idioms)]
+
+mod cost;
+mod planner;
+mod registry;
+mod runtime;
+
+pub use cost::{compute_cost, estimate_flops, transfer_cost_ns};
+pub use planner::{plan, PlanError};
+pub use registry::{RegisteredExecutor, Registry};
+pub use runtime::{Runtime, RuntimeError};
+
+// Re-export BackendProfile from executor-protocol so callers don't
+// need a separate import.
+pub use executor_protocol::BackendProfile;
+
+/// The CPU executor's id — always-available fallback.  Same as
+/// [`compute_ir::CPU_EXECUTOR`] but re-exported here for callers
+/// that only depend on `matrix-runtime`.
+pub use compute_ir::CPU_EXECUTOR;

--- a/code/packages/rust/matrix-runtime/src/planner.rs
+++ b/code/packages/rust/matrix-runtime/src/planner.rs
@@ -1,0 +1,449 @@
+//! The planner.  Lowers `matrix_ir::Graph` to `compute_ir::ComputeGraph`
+//! using the registry's `BackendProfile`s.
+//!
+//! Algorithm (per spec MX04 §"The planner algorithm"):
+//!
+//! 1. **Capability filter** — for each op, set of executors that can run it.
+//! 2. **Greedy cost minimisation** — for each op in topological order,
+//!    pick the executor that minimises (compute + transfer-in) cost.
+//! 3. **Transfer insertion** — walk placed ops, insert
+//!    `PlacedOp::Transfer` whenever an input's residency doesn't
+//!    match the op's executor.
+//! 4. **Lifetime annotation** — insert `Alloc` before first use and
+//!    `Free` after last use of each non-input/non-output buffer.
+
+use crate::cost::{compute_cost, estimate_flops, estimate_matmul_flops, transfer_cost_ns, TransferDirection};
+use crate::registry::Registry;
+use compute_ir::{
+    BufferId, ComputeGraph, ExecutorId, OpTiming, PlacedConstant, PlacedOp, PlacedTensor, Residency,
+    CPU_EXECUTOR,
+};
+use matrix_ir::{Graph, Op, TensorId};
+use std::collections::{HashMap, HashSet};
+
+/// Errors produced by [`plan`].
+#[derive(Clone, Debug)]
+pub enum PlanError {
+    /// The input matrix-ir graph fails its own validator.
+    InvalidGraph(matrix_ir::IrError),
+    /// No executor (not even the CPU fallback) supports an op.
+    NoCapableExecutor { op_index: u32 },
+    /// The registry has no executors registered (not even CPU).
+    EmptyRegistry,
+    /// An op references a tensor not in the graph.
+    UndefinedTensor { op_index: u32, tensor: TensorId },
+}
+
+impl From<matrix_ir::IrError> for PlanError {
+    fn from(e: matrix_ir::IrError) -> Self {
+        PlanError::InvalidGraph(e)
+    }
+}
+
+/// Lower a `matrix_ir::Graph` to a `compute_ir::ComputeGraph`,
+/// routing each op to the cheapest available executor.
+///
+/// The output graph is **not** automatically validated; callers may
+/// call `result.validate()` to catch any inconsistencies (a planner
+/// bug if it ever returns Err).
+pub fn plan(graph: &Graph, registry: &Registry) -> Result<ComputeGraph, PlanError> {
+    graph.validate()?;
+    if registry.healthy().is_empty() {
+        return Err(PlanError::EmptyRegistry);
+    }
+
+    // ──────── Pass 1: capability filter ────────
+    //
+    // For each op, collect the set of executors that can run it
+    // (correct op kind + correct dtype).  Falls back to CPU if no
+    // specialised executor takes it.
+    let mut candidates: Vec<Vec<ExecutorId>> = Vec::with_capacity(graph.ops.len());
+    for (i, op) in graph.ops.iter().enumerate() {
+        let dtype = output_dtype_of(graph, op).ok_or(PlanError::UndefinedTensor {
+            op_index: i as u32,
+            tensor: op.output(),
+        })?;
+        let cs: Vec<ExecutorId> = registry
+            .healthy()
+            .iter()
+            .filter(|e| e.supports_op(op.wire_tag()) && e.supports_dtype(dtype.wire_tag()))
+            .map(|e| e.id)
+            .collect();
+        let cs = if cs.is_empty() {
+            // CPU fallback if it's healthy and registered.
+            if registry.get(CPU_EXECUTOR).map(|e| e.healthy).unwrap_or(false) {
+                vec![CPU_EXECUTOR]
+            } else {
+                return Err(PlanError::NoCapableExecutor { op_index: i as u32 });
+            }
+        } else {
+            cs
+        };
+        candidates.push(cs);
+    }
+
+    // ──────── Pass 2: greedy cost minimisation ────────
+    //
+    // Track each tensor's *current* residency as we walk the ops in
+    // topological order.  Initially:
+    //   - Inputs are on CPU (host) — buffer ids assigned sequentially.
+    //   - Constants are on CPU as well.
+    let mut residency: HashMap<TensorId, Residency> = HashMap::new();
+    let mut next_buffer_id_per_executor: HashMap<ExecutorId, u64> = HashMap::new();
+    let next_buf = |exec: ExecutorId,
+                        m: &mut HashMap<ExecutorId, u64>|
+     -> BufferId {
+        let next = m.entry(exec).or_insert(0);
+        let id = BufferId(*next);
+        *next += 1;
+        id
+    };
+
+    // Place inputs and constants on CPU at sequentially-assigned buffer ids.
+    for inp in &graph.inputs {
+        let b = next_buf(CPU_EXECUTOR, &mut next_buffer_id_per_executor);
+        residency.insert(
+            inp.id,
+            Residency {
+                executor: CPU_EXECUTOR,
+                buffer: b,
+            },
+        );
+    }
+    for c in &graph.constants {
+        let b = next_buf(CPU_EXECUTOR, &mut next_buffer_id_per_executor);
+        residency.insert(
+            c.tensor.id,
+            Residency {
+                executor: CPU_EXECUTOR,
+                buffer: b,
+            },
+        );
+    }
+
+    // Choose an executor for each op.
+    let mut placement: Vec<ExecutorId> = Vec::with_capacity(graph.ops.len());
+    for (i, op) in graph.ops.iter().enumerate() {
+        let dtype = output_dtype_of(graph, op).ok_or(PlanError::UndefinedTensor {
+            op_index: i as u32,
+            tensor: op.output(),
+        })?;
+        let flops = flops_for(graph, op);
+        let mut best = candidates[i][0];
+        let mut best_cost = u64::MAX;
+        for &exec_id in &candidates[i] {
+            let exec = registry.get(exec_id).expect("candidate is in registry");
+            let mut cost = compute_cost(flops, dtype, &exec.profile);
+            for input in op.inputs() {
+                if let Some(r) = residency.get(&input) {
+                    if r.executor != exec_id {
+                        // We'd need to transfer the input.  Bytes =
+                        // numel × dtype size.
+                        let bytes = bytes_for_tensor(graph, input).unwrap_or(0);
+                        cost = cost.saturating_add(transfer_cost_ns(
+                            bytes,
+                            &exec.profile,
+                            TransferDirection::HostToDevice,
+                        ));
+                    }
+                }
+            }
+            if cost < best_cost {
+                best_cost = cost;
+                best = exec_id;
+            }
+        }
+        placement.push(best);
+        // Output of this op now lives on `best`, with a fresh buffer.
+        let b = next_buf(best, &mut next_buffer_id_per_executor);
+        residency.insert(
+            op.output(),
+            Residency {
+                executor: best,
+                buffer: b,
+            },
+        );
+    }
+
+    // ──────── Pass 3: transfer insertion + Pass 4: lifetime annotation ────────
+    //
+    // Walk ops in order, emitting:
+    //   - Alloc for any newly-used buffer
+    //   - Transfer for inputs not yet on the op's executor
+    //   - Compute (or Const for matrix-ir Const ops) at the chosen executor
+    //   - Free for buffers whose last use is this op
+    //
+    // For lifetime tracking we precompute first-use and last-use of
+    // each TensorId across ops + outputs.
+    let last_use = compute_last_use(graph);
+    let mut current_residency: HashMap<TensorId, Residency> = HashMap::new();
+    let mut allocated: HashSet<Residency> = HashSet::new();
+    let mut placed_ops: Vec<PlacedOp> = Vec::new();
+
+    // Inputs and constants are pre-allocated on CPU.
+    for inp in &graph.inputs {
+        let r = residency.get(&inp.id).copied().unwrap();
+        allocated.insert(r);
+        current_residency.insert(inp.id, r);
+    }
+    for c in &graph.constants {
+        let r = residency.get(&c.tensor.id).copied().unwrap();
+        allocated.insert(r);
+        current_residency.insert(c.tensor.id, r);
+    }
+
+    for (i, op) in graph.ops.iter().enumerate() {
+        let exec = placement[i];
+
+        // Transfer each input not already on `exec`.
+        for input in op.inputs() {
+            let cur = *current_residency.get(&input).expect("input residency known");
+            if cur.executor != exec {
+                // Allocate destination buffer on `exec` if not already.
+                let dst_b = next_buf(exec, &mut next_buffer_id_per_executor);
+                let dst = Residency {
+                    executor: exec,
+                    buffer: dst_b,
+                };
+                let bytes = bytes_for_tensor(graph, input).unwrap_or(0);
+                placed_ops.push(PlacedOp::Alloc {
+                    residency: dst,
+                    bytes,
+                });
+                allocated.insert(dst);
+                let exec_profile = &registry.get(exec).expect("exec in registry").profile;
+                let est_xfer_ns = transfer_cost_ns(
+                    bytes,
+                    exec_profile,
+                    TransferDirection::HostToDevice,
+                );
+                placed_ops.push(PlacedOp::Transfer {
+                    tensor: input,
+                    src: cur,
+                    dst,
+                    bytes,
+                    timing: OpTiming {
+                        estimated_ns: est_xfer_ns,
+                    },
+                });
+                current_residency.insert(input, dst);
+            }
+        }
+
+        // Allocate output buffer on `exec`.
+        let out_residency = *residency.get(&op.output()).expect("output residency");
+        let bytes = bytes_for_tensor(graph, op.output()).unwrap_or(0);
+        if !allocated.contains(&out_residency) {
+            placed_ops.push(PlacedOp::Alloc {
+                residency: out_residency,
+                bytes,
+            });
+            allocated.insert(out_residency);
+        }
+
+        // The op itself.
+        let dtype =
+            output_dtype_of(graph, op).expect("dtype known after capability pass");
+        let flops = flops_for(graph, op);
+        let exec_profile = &registry.get(exec).expect("exec in registry").profile;
+        let est_compute_ns = compute_cost(flops, dtype, exec_profile);
+        placed_ops.push(PlacedOp::Compute {
+            op: op.clone(),
+            executor: exec,
+            timing: OpTiming {
+                estimated_ns: est_compute_ns,
+            },
+        });
+        current_residency.insert(op.output(), out_residency);
+
+        // Free any tensor whose last use is this op AND that isn't a
+        // graph output we still need to expose.
+        for input in op.inputs() {
+            if last_use.get(&input).copied() == Some(i) && !graph.outputs.contains(&input) {
+                if let Some(r) = current_residency.remove(&input) {
+                    placed_ops.push(PlacedOp::Free { residency: r });
+                    allocated.remove(&r);
+                }
+            }
+        }
+    }
+
+    // Build output PlacedTensor list with end-of-graph residency.
+    let outputs: Vec<PlacedTensor> = graph
+        .outputs
+        .iter()
+        .map(|id| {
+            let t = graph.tensor(*id).expect("output tensor exists");
+            let r = current_residency
+                .get(id)
+                .copied()
+                .or_else(|| residency.get(id).copied())
+                .unwrap_or(Residency {
+                    executor: CPU_EXECUTOR,
+                    buffer: BufferId(0),
+                });
+            PlacedTensor {
+                id: t.id,
+                dtype: t.dtype,
+                shape: t.shape.clone(),
+                residency: r,
+            }
+        })
+        .collect();
+
+    // Build inputs PlacedTensor list.
+    let inputs: Vec<PlacedTensor> = graph
+        .inputs
+        .iter()
+        .map(|t| PlacedTensor {
+            id: t.id,
+            dtype: t.dtype,
+            shape: t.shape.clone(),
+            residency: *residency.get(&t.id).expect("input residency"),
+        })
+        .collect();
+
+    // Build constants list with assigned residency.
+    let constants: Vec<PlacedConstant> = graph
+        .constants
+        .iter()
+        .map(|c| PlacedConstant {
+            tensor: c.tensor.id,
+            bytes: c.bytes.clone(),
+            residency: *residency.get(&c.tensor.id).expect("constant residency"),
+        })
+        .collect();
+
+    // Tensors table — birth residency for each tensor.
+    let tensors: Vec<PlacedTensor> = graph
+        .tensors
+        .iter()
+        .map(|t| PlacedTensor {
+            id: t.id,
+            dtype: t.dtype,
+            shape: t.shape.clone(),
+            residency: *residency.get(&t.id).unwrap_or(&Residency {
+                executor: CPU_EXECUTOR,
+                buffer: BufferId(0),
+            }),
+        })
+        .collect();
+
+    Ok(ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs,
+        outputs,
+        constants,
+        ops: placed_ops,
+        tensors,
+    })
+}
+
+// ──────────────── helpers ────────────────
+
+fn output_dtype_of(graph: &Graph, op: &Op) -> Option<matrix_ir::DType> {
+    graph.tensor(op.output()).map(|t| t.dtype)
+}
+
+fn bytes_for_tensor(graph: &Graph, id: TensorId) -> Option<u64> {
+    let t = graph.tensor(id)?;
+    t.shape.byte_size(t.dtype)
+}
+
+fn flops_for(graph: &Graph, op: &Op) -> u64 {
+    let out_shape = graph.tensor(op.output()).map(|t| &t.shape);
+    let in_shape = match op {
+        Op::ReduceSum { input, .. }
+        | Op::ReduceMax { input, .. }
+        | Op::ReduceMean { input, .. } => graph.tensor(*input).map(|t| &t.shape),
+        _ => out_shape,
+    };
+    match op {
+        Op::MatMul { a, b, .. } => {
+            // We have full Tensor metadata in the graph table.
+            let ta = graph.tensor(*a);
+            let tb = graph.tensor(*b);
+            match (ta, tb) {
+                (Some(ta), Some(tb)) => estimate_matmul_flops(ta, tb),
+                _ => 0,
+            }
+        }
+        _ => estimate_flops(op, out_shape, in_shape),
+    }
+}
+
+fn compute_last_use(graph: &Graph) -> HashMap<TensorId, usize> {
+    let mut last: HashMap<TensorId, usize> = HashMap::new();
+    for (i, op) in graph.ops.iter().enumerate() {
+        for input in op.inputs() {
+            last.insert(input, i);
+        }
+    }
+    last
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::Registry;
+    use executor_protocol::BackendProfile;
+    use matrix_ir::{DType, GraphBuilder, Shape};
+
+    fn cpu_only_registry() -> Registry {
+        let (r, _) = Registry::with_cpu(BackendProfile {
+            kind: "cpu".to_string(),
+            supported_ops: 0xFFFF_FFFF,
+            supported_dtypes: 0x07,
+            gflops_f32: 40,
+            gflops_u8: 40,
+            gflops_i32: 40,
+            host_to_device_bw: 100,
+            device_to_host_bw: 100,
+            device_internal_bw: 100,
+            launch_overhead_ns: 0,
+            transport_latency_ns: 0,
+            on_device_mib: 8 * 1024,
+            max_tensor_rank: 16,
+            max_dim: u32::MAX,
+        });
+        r
+    }
+
+    #[test]
+    fn cpu_only_simple_graph() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        let b = g.input(DType::F32, Shape::from(&[3]));
+        let c = g.add(&a, &b);
+        g.output(&c);
+        let g = g.build().unwrap();
+
+        let r = cpu_only_registry();
+        let plan_g = plan(&g, &r).expect("planner");
+        plan_g.validate().expect("planned graph validates");
+
+        // All ops should be Compute on CPU plus alloc.  No transfers.
+        let transfer_count = plan_g
+            .ops
+            .iter()
+            .filter(|o| matches!(o, PlacedOp::Transfer { .. }))
+            .count();
+        assert_eq!(transfer_count, 0);
+        for op in &plan_g.ops {
+            if let PlacedOp::Compute { executor, .. } = op {
+                assert_eq!(*executor, CPU_EXECUTOR);
+            }
+        }
+    }
+
+    #[test]
+    fn empty_registry_errors() {
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        g.output(&a);
+        let g = g.build().unwrap();
+
+        let r = Registry::new();
+        assert!(matches!(plan(&g, &r), Err(PlanError::EmptyRegistry)));
+    }
+}

--- a/code/packages/rust/matrix-runtime/src/registry.rs
+++ b/code/packages/rust/matrix-runtime/src/registry.rs
@@ -1,0 +1,200 @@
+//! Executor registry — a list of `(ExecutorId, BackendProfile)` plus
+//! a transport handle for each.
+//!
+//! V1 registry is a simple `Vec`-backed structure indexed by
+//! `ExecutorId`.  The CPU executor (`CPU_EXECUTOR = ExecutorId(0)`)
+//! is always present.
+
+use compute_ir::{ExecutorId, CPU_EXECUTOR};
+use executor_protocol::BackendProfile;
+
+/// Public summary of a registered executor.  The transport handle
+/// itself is held internally by the [`Registry`] but not exposed here
+/// because it requires the `Transport` trait that some callers don't
+/// want to depend on.
+#[derive(Clone, Debug)]
+pub struct RegisteredExecutor {
+    /// The id assigned at registration time.
+    pub id: ExecutorId,
+    /// Free-form kind tag ("cpu", "metal", "cuda", …).
+    pub kind: String,
+    /// Capability + cost profile.
+    pub profile: BackendProfile,
+    /// Whether the executor passed its most recent heartbeat.  V1
+    /// only updates this through [`Registry::set_healthy`]; future
+    /// versions will wire it to event streams.
+    pub healthy: bool,
+}
+
+impl RegisteredExecutor {
+    /// True iff the executor supports the given matrix-ir op tag.
+    pub fn supports_op(&self, op_tag: u8) -> bool {
+        if op_tag >= 32 {
+            return false;
+        }
+        self.profile.supported_ops & (1u32 << op_tag) != 0
+    }
+
+    /// True iff the executor supports the given dtype tag.
+    pub fn supports_dtype(&self, dtype_tag: u8) -> bool {
+        if dtype_tag >= 8 {
+            return false;
+        }
+        self.profile.supported_dtypes & (1u8 << dtype_tag) != 0
+    }
+}
+
+/// The registry.
+///
+/// V1 owns just `RegisteredExecutor` records; transport wiring lives
+/// at the runtime layer (see [`Runtime`](crate::Runtime)) so the
+/// planner can be tested without the async machinery.
+#[derive(Default)]
+pub struct Registry {
+    executors: Vec<RegisteredExecutor>,
+}
+
+impl Registry {
+    /// Construct an empty registry.  Callers typically register the
+    /// CPU executor first via [`Self::register`].
+    pub fn new() -> Self {
+        Registry {
+            executors: Vec::new(),
+        }
+    }
+
+    /// Convenience constructor that pre-registers a CPU executor with
+    /// the supplied profile under [`CPU_EXECUTOR`].  Returns the new
+    /// registry plus the assigned id (which is always `CPU_EXECUTOR`).
+    pub fn with_cpu(cpu_profile: BackendProfile) -> (Self, ExecutorId) {
+        let mut r = Registry::new();
+        let id = r.register("cpu".to_string(), cpu_profile);
+        debug_assert_eq!(id, CPU_EXECUTOR);
+        (r, id)
+    }
+
+    /// Register a new executor.  Returns the assigned [`ExecutorId`].
+    /// Ids are assigned monotonically starting from 0; the first call
+    /// should always be the CPU executor so it lands on
+    /// [`CPU_EXECUTOR`].
+    pub fn register(&mut self, kind: String, profile: BackendProfile) -> ExecutorId {
+        let id = ExecutorId(self.executors.len() as u32);
+        self.executors.push(RegisteredExecutor {
+            id,
+            kind,
+            profile,
+            healthy: true,
+        });
+        id
+    }
+
+    /// Mark an executor as healthy or unhealthy.  Unhealthy executors
+    /// are filtered out by the planner.
+    pub fn set_healthy(&mut self, id: ExecutorId, healthy: bool) {
+        if let Some(e) = self.executors.get_mut(id.0 as usize) {
+            e.healthy = healthy;
+        }
+    }
+
+    /// Replace an executor's profile (e.g. after a `ProfileUpdated`
+    /// event).
+    pub fn update_profile(&mut self, id: ExecutorId, profile: BackendProfile) {
+        if let Some(e) = self.executors.get_mut(id.0 as usize) {
+            e.profile = profile;
+        }
+    }
+
+    /// Look up an executor by id.
+    pub fn get(&self, id: ExecutorId) -> Option<&RegisteredExecutor> {
+        self.executors.get(id.0 as usize)
+    }
+
+    /// All registered executors, healthy or not.
+    pub fn all(&self) -> &[RegisteredExecutor] {
+        &self.executors
+    }
+
+    /// Healthy executors only — what the planner sees.
+    pub fn healthy(&self) -> Vec<&RegisteredExecutor> {
+        self.executors.iter().filter(|e| e.healthy).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(kind: &str, ops: u32, dtypes: u8) -> BackendProfile {
+        BackendProfile {
+            kind: kind.to_string(),
+            supported_ops: ops,
+            supported_dtypes: dtypes,
+            gflops_f32: 100,
+            gflops_u8: 100,
+            gflops_i32: 100,
+            host_to_device_bw: 10,
+            device_to_host_bw: 10,
+            device_internal_bw: 100,
+            launch_overhead_ns: 0,
+            transport_latency_ns: 0,
+            on_device_mib: 1024,
+            max_tensor_rank: 8,
+            max_dim: 65535,
+        }
+    }
+
+    #[test]
+    fn cpu_registers_at_zero() {
+        let (_r, id) = Registry::with_cpu(p("cpu", 0xFFFF_FFFF, 0x07));
+        assert_eq!(id, CPU_EXECUTOR);
+    }
+
+    #[test]
+    fn supports_op_bitset() {
+        let executor = RegisteredExecutor {
+            id: ExecutorId(0),
+            kind: "test".to_string(),
+            profile: p("test", 0b101, 0xFF),
+            healthy: true,
+        };
+        assert!(executor.supports_op(0));
+        assert!(!executor.supports_op(1));
+        assert!(executor.supports_op(2));
+        assert!(!executor.supports_op(3));
+        // Out-of-range tag returns false.
+        assert!(!executor.supports_op(32));
+    }
+
+    #[test]
+    fn supports_dtype_bitset() {
+        let executor = RegisteredExecutor {
+            id: ExecutorId(0),
+            kind: "test".to_string(),
+            profile: p("test", 0xFFFF_FFFF, 0b011),
+            healthy: true,
+        };
+        assert!(executor.supports_dtype(0)); // F32
+        assert!(executor.supports_dtype(1)); // U8
+        assert!(!executor.supports_dtype(2)); // I32
+        assert!(!executor.supports_dtype(8));
+    }
+
+    #[test]
+    fn unhealthy_filtered_from_healthy_list() {
+        let mut r = Registry::new();
+        let id = r.register("cpu".to_string(), p("cpu", 0xFFFF_FFFF, 0x07));
+        assert_eq!(r.healthy().len(), 1);
+        r.set_healthy(id, false);
+        assert_eq!(r.healthy().len(), 0);
+        assert_eq!(r.all().len(), 1);
+    }
+
+    #[test]
+    fn update_profile_changes_capabilities() {
+        let mut r = Registry::new();
+        let id = r.register("cpu".to_string(), p("cpu", 0, 0));
+        assert!(!r.get(id).unwrap().supports_op(0));
+        r.update_profile(id, p("cpu", 0xFFFF_FFFF, 0x07));
+        assert!(r.get(id).unwrap().supports_op(0));
+    }
+}

--- a/code/packages/rust/matrix-runtime/src/runtime.rs
+++ b/code/packages/rust/matrix-runtime/src/runtime.rs
@@ -1,0 +1,148 @@
+//! `Runtime` — the public API surface domain libraries call.
+//!
+//! V1 ships the planner and registry surface.  The execution loop
+//! (driving `ComputeGraph`s through transports and collecting outputs)
+//! is left as a seam: callers can call `runtime.plan(graph)` to get a
+//! `ComputeGraph` and inspect or hand-execute it.  The `run()` end-to-end
+//! method lands when the first executor crate (`matrix-cpu`) is in.
+
+use crate::planner::{plan, PlanError};
+use crate::registry::{RegisteredExecutor, Registry};
+use compute_ir::{ComputeGraph, ExecutorId};
+use executor_protocol::BackendProfile;
+use matrix_ir::Graph;
+
+/// Errors produced by the runtime API.  Wraps both planner and
+/// registry errors plus future execution-path errors.
+#[derive(Clone, Debug)]
+pub enum RuntimeError {
+    /// No executor available for the operation.
+    NoExecutorAvailable,
+    /// Planner refused the graph.
+    Plan(PlanError),
+    /// Underlying matrix-ir validation failure.
+    InvalidGraph(matrix_ir::IrError),
+}
+
+impl From<PlanError> for RuntimeError {
+    fn from(e: PlanError) -> Self {
+        RuntimeError::Plan(e)
+    }
+}
+
+impl From<matrix_ir::IrError> for RuntimeError {
+    fn from(e: matrix_ir::IrError) -> Self {
+        RuntimeError::InvalidGraph(e)
+    }
+}
+
+/// The runtime — owns a [`Registry`] and exposes [`plan`] and
+/// [`executors`] to callers.
+pub struct Runtime {
+    registry: Registry,
+}
+
+impl Runtime {
+    /// Construct a runtime with the always-available CPU executor.
+    /// The CPU profile must be supplied by the caller (typically a
+    /// short host-machine calibration; spec MX04 §"CPU executor").
+    pub fn new(cpu_profile: BackendProfile) -> Self {
+        let (registry, _) = Registry::with_cpu(cpu_profile);
+        Runtime { registry }
+    }
+
+    /// Construct a runtime with no executors (not even CPU).  Mostly
+    /// useful for testing the empty-registry code path.
+    pub fn empty() -> Self {
+        Runtime {
+            registry: Registry::new(),
+        }
+    }
+
+    /// Register an additional executor.  Returns its assigned id.
+    pub fn register(&mut self, kind: impl Into<String>, profile: BackendProfile) -> ExecutorId {
+        self.registry.register(kind.into(), profile)
+    }
+
+    /// Mark an executor as healthy/unhealthy.  Unhealthy executors
+    /// are skipped by the planner.
+    pub fn set_healthy(&mut self, id: ExecutorId, healthy: bool) {
+        self.registry.set_healthy(id, healthy);
+    }
+
+    /// Replace an executor's profile (e.g. on a `ProfileUpdated` event).
+    pub fn update_profile(&mut self, id: ExecutorId, profile: BackendProfile) {
+        self.registry.update_profile(id, profile);
+    }
+
+    /// All registered executors.
+    pub fn executors(&self) -> &[RegisteredExecutor] {
+        self.registry.all()
+    }
+
+    /// Plan a `matrix_ir::Graph` to a `ComputeGraph`.  Pure — no
+    /// execution.
+    pub fn plan(&self, graph: &Graph) -> Result<ComputeGraph, RuntimeError> {
+        Ok(plan(graph, &self.registry)?)
+    }
+
+    /// Borrow the underlying registry for advanced inspection.
+    pub fn registry(&self) -> &Registry {
+        &self.registry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_ir::{DType, GraphBuilder, Shape};
+
+    fn cpu_profile() -> BackendProfile {
+        BackendProfile {
+            kind: "cpu".to_string(),
+            supported_ops: 0xFFFF_FFFF,
+            supported_dtypes: 0x07,
+            gflops_f32: 40,
+            gflops_u8: 40,
+            gflops_i32: 40,
+            host_to_device_bw: 100,
+            device_to_host_bw: 100,
+            device_internal_bw: 100,
+            launch_overhead_ns: 0,
+            transport_latency_ns: 0,
+            on_device_mib: 8 * 1024,
+            max_tensor_rank: 16,
+            max_dim: u32::MAX,
+        }
+    }
+
+    #[test]
+    fn runtime_with_cpu_plans_simple_graph() {
+        let rt = Runtime::new(cpu_profile());
+        assert_eq!(rt.executors().len(), 1);
+
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        let b = g.input(DType::F32, Shape::from(&[3]));
+        let c = g.add(&a, &b);
+        g.output(&c);
+        let g = g.build().unwrap();
+
+        let placed = rt.plan(&g).expect("plan");
+        placed.validate().expect("placed validates");
+    }
+
+    #[test]
+    fn empty_runtime_fails_to_plan() {
+        let rt = Runtime::empty();
+        let mut g = GraphBuilder::new();
+        let a = g.input(DType::F32, Shape::from(&[3]));
+        g.output(&a);
+        let g = g.build().unwrap();
+
+        assert!(matches!(
+            rt.plan(&g),
+            Err(RuntimeError::Plan(PlanError::EmptyRegistry))
+        ));
+    }
+}

--- a/code/packages/rust/matrix-runtime/tests/integration.rs
+++ b/code/packages/rust/matrix-runtime/tests/integration.rs
@@ -1,0 +1,328 @@
+//! Integration tests for `matrix-runtime`.  Per spec MX04 §"Test methodology".
+//!
+//! 1. **Synthetic-profile tests** — register mock executors with hand-set
+//!    profiles, plan small graphs, assert placement decisions match
+//!    expectations.  Drives the planner without any real GPU.
+//! 2. **CPU-only round-trip** — `plan` a CPU-only graph, assert the
+//!    placed graph validates and uses only CPU.
+//! 3. **Multi-executor planning** — register CPU + a mock GPU, vary
+//!    the GPU's profile, assert the planner crosses the expected
+//!    threshold between "stay on CPU" and "ship to GPU".
+//! 4. **Transfer insertion** — graphs that mix supported and
+//!    unsupported ops; assert the planner inserts transfers.
+//! 5. **Heartbeat / unhealthy** — mark an executor unhealthy mid-test;
+//!    assert subsequent plans skip it.
+
+use compute_ir::{ExecutorId, PlacedOp, CPU_EXECUTOR};
+use executor_protocol::BackendProfile;
+use matrix_ir::{DType, GraphBuilder, Op, Shape};
+use matrix_runtime::{plan, BackendProfile as _, Registry, Runtime, RuntimeError};
+
+fn cpu_default() -> BackendProfile {
+    BackendProfile {
+        kind: "cpu".to_string(),
+        supported_ops: 0xFFFF_FFFF,
+        supported_dtypes: 0x07,
+        gflops_f32: 40,
+        gflops_u8: 40,
+        gflops_i32: 40,
+        host_to_device_bw: 100,
+        device_to_host_bw: 100,
+        device_internal_bw: 100,
+        launch_overhead_ns: 0,
+        transport_latency_ns: 0,
+        on_device_mib: 8 * 1024,
+        max_tensor_rank: 16,
+        max_dim: u32::MAX,
+    }
+}
+
+fn fast_gpu() -> BackendProfile {
+    BackendProfile {
+        kind: "gpu".to_string(),
+        supported_ops: 0xFFFF_FFFF,
+        supported_dtypes: 0x07,
+        gflops_f32: 5_000, // 125× faster than CPU
+        gflops_u8: 2_500,
+        gflops_i32: 2_500,
+        host_to_device_bw: 10, // Slow PCIe
+        device_to_host_bw: 10,
+        device_internal_bw: 500,
+        launch_overhead_ns: 1_000,
+        transport_latency_ns: 0,
+        on_device_mib: 16 * 1024,
+        max_tensor_rank: 8,
+        max_dim: 65535,
+    }
+}
+
+fn limited_gpu_no_i32() -> BackendProfile {
+    BackendProfile {
+        // Supports f32 + u8 but NOT i32.
+        supported_dtypes: 0b011,
+        ..fast_gpu()
+    }
+}
+
+// ─────────────────── 2. CPU-only round-trip ───────────────────
+
+#[test]
+fn cpu_only_no_transfers() {
+    let rt = Runtime::new(cpu_default());
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[3]));
+    let b = g.input(DType::F32, Shape::from(&[3]));
+    let c = g.add(&a, &b);
+    g.output(&c);
+    let g = g.build().unwrap();
+
+    let placed = rt.plan(&g).expect("plan");
+    placed.validate().expect("validates");
+
+    let transfers = placed
+        .ops
+        .iter()
+        .filter(|o| matches!(o, PlacedOp::Transfer { .. }))
+        .count();
+    assert_eq!(transfers, 0, "no transfers for CPU-only graph");
+}
+
+// ─────────────────── 3. Multi-executor planning ───────────────────
+
+#[test]
+fn small_add_stays_on_cpu_with_gpu_available() {
+    // Tiny add (4 elements) — transfer overhead exceeds GPU speedup.
+    let mut rt = Runtime::new(cpu_default());
+    rt.register("gpu", fast_gpu());
+
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[4]));
+    let b = g.input(DType::F32, Shape::from(&[4]));
+    let c = g.add(&a, &b);
+    g.output(&c);
+    let g = g.build().unwrap();
+
+    let placed = rt.plan(&g).expect("plan");
+    placed.validate().expect("validates");
+
+    // Find the compute op for the add.
+    let add_executor = placed.ops.iter().find_map(|o| match o {
+        PlacedOp::Compute {
+            op: Op::Add { .. },
+            executor,
+            ..
+        } => Some(*executor),
+        _ => None,
+    });
+    assert_eq!(
+        add_executor,
+        Some(CPU_EXECUTOR),
+        "small add should stay on CPU"
+    );
+}
+
+#[test]
+fn large_matmul_ships_to_gpu() {
+    // 4096×4096 matmul — GPU wins despite transfer cost.
+    let mut rt = Runtime::new(cpu_default());
+    let gpu_id = rt.register("gpu", fast_gpu());
+
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[4096, 4096]));
+    let b = g.input(DType::F32, Shape::from(&[4096, 4096]));
+    let c = g.matmul(&a, &b);
+    g.output(&c);
+    let g = g.build().unwrap();
+
+    let placed = rt.plan(&g).expect("plan");
+    placed.validate().expect("validates");
+
+    let mm_executor = placed.ops.iter().find_map(|o| match o {
+        PlacedOp::Compute {
+            op: Op::MatMul { .. },
+            executor,
+            ..
+        } => Some(*executor),
+        _ => None,
+    });
+    assert_eq!(mm_executor, Some(gpu_id), "large matmul should ship to GPU");
+
+    // Should have inserted transfers for both matmul inputs.
+    let transfer_count = placed
+        .ops
+        .iter()
+        .filter(|o| matches!(o, PlacedOp::Transfer { .. }))
+        .count();
+    assert!(
+        transfer_count >= 2,
+        "expected at least 2 transfers for matmul inputs, got {}",
+        transfer_count
+    );
+}
+
+// ─────────────────── 4. Transfer insertion / capability ───────────────────
+
+#[test]
+fn unsupported_dtype_falls_back_to_cpu() {
+    // GPU profile that doesn't support i32; even a giant int32 op
+    // must stay on CPU.
+    let mut rt = Runtime::new(cpu_default());
+    rt.register("gpu_no_i32", limited_gpu_no_i32());
+
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::I32, Shape::from(&[1024, 1024]));
+    let b = g.input(DType::I32, Shape::from(&[1024, 1024]));
+    let c = g.add(&a, &b);
+    g.output(&c);
+    let g = g.build().unwrap();
+
+    let placed = rt.plan(&g).expect("plan");
+    placed.validate().expect("validates");
+
+    let add_executor = placed.ops.iter().find_map(|o| match o {
+        PlacedOp::Compute {
+            op: Op::Add { .. },
+            executor,
+            ..
+        } => Some(*executor),
+        _ => None,
+    });
+    assert_eq!(
+        add_executor,
+        Some(CPU_EXECUTOR),
+        "i32 op must fall back to CPU when GPU lacks i32 support"
+    );
+}
+
+// ─────────────────── 5. Health ───────────────────
+
+#[test]
+fn unhealthy_executor_skipped() {
+    let mut rt = Runtime::new(cpu_default());
+    let gpu_id = rt.register("gpu", fast_gpu());
+    rt.set_healthy(gpu_id, false);
+
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[4096, 4096]));
+    let b = g.input(DType::F32, Shape::from(&[4096, 4096]));
+    let c = g.matmul(&a, &b);
+    g.output(&c);
+    let g = g.build().unwrap();
+
+    let placed = rt.plan(&g).expect("plan");
+    placed.validate().expect("validates");
+
+    let mm_executor = placed.ops.iter().find_map(|o| match o {
+        PlacedOp::Compute {
+            op: Op::MatMul { .. },
+            executor,
+            ..
+        } => Some(*executor),
+        _ => None,
+    });
+    // GPU is unhealthy → falls back to CPU even though the matmul is huge.
+    assert_eq!(
+        mm_executor,
+        Some(CPU_EXECUTOR),
+        "unhealthy GPU should be skipped"
+    );
+}
+
+// ─────────────────── Empty registry ───────────────────
+
+#[test]
+fn empty_runtime_errors() {
+    let rt = Runtime::empty();
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[3]));
+    g.output(&a);
+    let g = g.build().unwrap();
+
+    assert!(matches!(
+        rt.plan(&g),
+        Err(RuntimeError::Plan(matrix_runtime::PlanError::EmptyRegistry))
+    ));
+}
+
+// ─────────────────── Cost-model threshold ───────────────────
+
+/// Vary the GPU's transfer bandwidth and assert the planner threshold
+/// behaves monotonically — slower transfers mean ops have to be even
+/// bigger to ship to GPU.
+#[test]
+fn cost_model_threshold_monotonic() {
+    let mut g = GraphBuilder::new();
+    // 256x256 matmul — borderline workload.
+    let a = g.input(DType::F32, Shape::from(&[256, 256]));
+    let b = g.input(DType::F32, Shape::from(&[256, 256]));
+    let c = g.matmul(&a, &b);
+    g.output(&c);
+    let g = g.build().unwrap();
+
+    // Fast PCIe: GPU should win.
+    let mut rt_fast = Runtime::new(cpu_default());
+    let gpu_fast = rt_fast.register(
+        "gpu_fast",
+        BackendProfile {
+            host_to_device_bw: 100, // very fast
+            device_to_host_bw: 100,
+            ..fast_gpu()
+        },
+    );
+    let placed_fast = rt_fast.plan(&g).expect("plan");
+    let fast_uses_gpu = placed_fast.ops.iter().any(|o| {
+        matches!(
+            o,
+            PlacedOp::Compute {
+                op: Op::MatMul { .. },
+                executor,
+                ..
+            } if *executor == gpu_fast
+        )
+    });
+
+    // Tiny PCIe: GPU should NOT win.
+    let mut rt_slow = Runtime::new(cpu_default());
+    let gpu_slow = rt_slow.register(
+        "gpu_slow",
+        BackendProfile {
+            host_to_device_bw: 1, // crawl
+            device_to_host_bw: 1,
+            ..fast_gpu()
+        },
+    );
+    let placed_slow = rt_slow.plan(&g).expect("plan");
+    let slow_uses_gpu = placed_slow.ops.iter().any(|o| {
+        matches!(
+            o,
+            PlacedOp::Compute {
+                op: Op::MatMul { .. },
+                executor,
+                ..
+            } if *executor == gpu_slow
+        )
+    });
+
+    // The fast-PCIe case must be at least as GPU-favouring as the slow case.
+    assert!(
+        fast_uses_gpu || !slow_uses_gpu,
+        "monotonicity broken: fast={} slow={}",
+        fast_uses_gpu, slow_uses_gpu
+    );
+}
+
+// ─────────────────── plan() function exposed ───────────────────
+
+#[test]
+fn plan_function_works_with_registry() {
+    let (mut r, _) = Registry::with_cpu(cpu_default());
+    let _ = r.register("aux".to_string(), fast_gpu());
+    let mut g = GraphBuilder::new();
+    let a = g.input(DType::F32, Shape::from(&[8]));
+    let b = g.input(DType::F32, Shape::from(&[8]));
+    let _ = g.add(&a, &b);
+    let g = g.build().unwrap();
+
+    let placed = plan(&g, &r).expect("plan");
+    placed.validate().expect("validates");
+}

--- a/code/specs/MX00-matrix-execution-overview.md
+++ b/code/specs/MX00-matrix-execution-overview.md
@@ -69,7 +69,7 @@ bytes.  The discipline is identical.
 | **MX01** | `matrix-ir` | Pure tensor algebra IR.  Domain libraries emit this. |
 | **MX02** | `compute-ir` | Placed IR with explicit devices and `Transfer` ops. |
 | **MX03** | `executor-protocol` | Wire format, message types, `Transport` trait. |
-| **MX04** | `compute-runtime` | Planner, backend registry, cost model. |
+| **MX04** | `matrix-runtime` | Planner, backend registry, cost model. |
 
 A backend (CPU, Metal, CUDA, …) is then a thin crate that implements the
 executor side of the protocol.  V1 ships:

--- a/code/specs/MX04-compute-runtime.md
+++ b/code/specs/MX04-compute-runtime.md
@@ -1,14 +1,21 @@
-# MX04 — `compute-runtime`: Planner, Registry, Cost Model
+# MX04 — `matrix-runtime`: Planner, Registry, Cost Model
 
 ## Status
 
-Draft — V1 specification.  Read [MX00](MX00-matrix-execution-overview.md),
+Draft — V1 specification.
+
+> **Naming note**: this crate was originally proposed as `compute-runtime`,
+> but that name was already taken by the G05 GPU-runtime simulator
+> (Vulkan-inspired device-discovery / command-recording crate).  The
+> matrix-execution-layer crate ships as **`matrix-runtime`** to
+> avoid the workspace conflict.  All references to `compute-runtime`
+> in MX00–MX04 have been updated.  Read [MX00](MX00-matrix-execution-overview.md),
 [MX01](MX01-matrix-ir.md), [MX02](MX02-compute-ir.md), and
 [MX03](MX03-executor-protocol.md) first.
 
 ## Purpose
 
-`compute-runtime` is the **brain** of the matrix execution layer.  It:
+`matrix-runtime` is the **brain** of the matrix execution layer.  It:
 
 1. **Owns the registry** of available executors and their capabilities.
 2. **Lowers `MatrixIR` to `ComputeIR`** by running the planner.
@@ -313,7 +320,7 @@ fn block_on<F: Future>(mut f: F) -> F::Output {
 
 This is sufficient because `LocalTransport` resolves immediately.  Network
 transports will require a real reactor; that lands in the transport
-crates themselves, not in `compute-runtime`.
+crates themselves, not in `matrix-runtime`.
 
 ## CPU executor
 
@@ -353,7 +360,7 @@ pub enum PlanError {
 
 ## Test methodology
 
-`compute-runtime` ships:
+`matrix-runtime` ships:
 
 1. **Synthetic-profile tests** — register mock executors with hand-set
    profiles, plan small graphs, assert placement decisions match


### PR DESCRIPTION
## Summary

Fourth and final implementation crate of the matrix execution layer. Implements **spec MX04** — the brain of the layer.

Lowers \`matrix_ir::Graph\` to \`compute_ir::ComputeGraph\` by routing each op to the cheapest available executor, using a four-pass planner.

## Naming note

Spec MX04 originally proposed \`compute-runtime\` as the crate name, but that name was already taken by the G05 GPU-runtime simulator (Vulkan-inspired device-discovery / command-recording crate). Renamed to **\`matrix-runtime\`** to disambiguate. Specs MX00 and MX04 updated.

## What's in this crate

| Module | Purpose |
|--------|---------|
| \`runtime.rs\` | \`Runtime\`, \`RuntimeError\` — public API |
| \`registry.rs\` | \`Registry\`, \`RegisteredExecutor\` |
| \`planner.rs\` | The four-pass planner |
| \`cost.rs\` | \`estimate_flops\`, \`transfer_cost_ns\`, \`compute_cost\` |

## The four-pass planner

1. **Capability filter** — for each op, find executors that support it (op kind + dtype). Fall back to CPU if none.
2. **Greedy cost minimisation** — pick the executor with the lowest \`compute + transfer-in\` cost per op in topological order.
3. **Transfer insertion** — insert \`PlacedOp::Transfer\` whenever an input's residency doesn't match its consumer's executor.
4. **Lifetime annotation** — \`Alloc\` before first use, \`Free\` after last use.

## Cost-model-driven routing

Each backend exposes a \`BackendProfile\` (re-exported from \`executor-protocol\`). The planner naturally:

- **Small ops stay on CPU** (transfer cost > GPU speedup)
- **Large ops ship to GPU** (GPU speedup > transfer cost)
- **Capability fallback** (unsupported dtype → CPU)
- **Health-aware placement** (unhealthy executors skipped)
- **Monotonic threshold** (slower PCIe makes GPU harder to reach)

All without any special-case logic. One cost function, multiple correct behaviours.

## Worked example

A 4096×4096 matmul with CPU + GPU available:

\`\`\`
ComputeGraph (format v1, 2 inputs, 1 outputs, 11 ops)
  inputs:
    t0: f32 [4096, 4096]   @ exec 0 buf 0
    t1: f32 [4096, 4096]   @ exec 0 buf 1
  ops:
    [00]  alloc            buf 2 @ exec 1   (64.0 MiB)
    [01]  transfer t0      exec 0 buf 0  ->  exec 1 buf 2   (64.0 MiB, ≈ 6.4 ms)
    [02]  alloc            buf 3 @ exec 1   (64.0 MiB)
    [03]  transfer t1      exec 0 buf 1  ->  exec 1 buf 3   (64.0 MiB, ≈ 6.4 ms)
    [04]  alloc            buf 4 @ exec 1   (64.0 MiB)
    [05]  compute  matmul  exec 1 t0 t1 -> t2   (≈ 27 ms)
    ...
\`\`\`

A small 4-element add with the same setup stays on CPU because the GPU transfer overhead (microseconds) exceeds the GPU compute speedup.

## V1 scope

V1 ships **the planner** and **the registry**. The end-to-end execution path (driving \`ComputeGraph\`s through transports to executors and collecting outputs) lands when the first executor crate (\`matrix-cpu\`) arrives.

The \`Runtime\` API exposes:
- \`Runtime::new(cpu_profile)\` — bootstrap with CPU fallback
- \`Runtime::register(kind, profile)\` — add an executor
- \`Runtime::plan(graph)\` — lower MatrixIR to ComputeIR
- \`Runtime::set_healthy(id, healthy)\` — mark unhealthy executors
- \`Runtime::update_profile(id, profile)\` — refresh on \`ProfileUpdated\`

## Test coverage: 21 tests passing

- 8 integration tests:
  - \`cpu_only_no_transfers\` — CPU-only graphs have no transfers
  - \`small_add_stays_on_cpu_with_gpu_available\` — transfer cost wins
  - \`large_matmul_ships_to_gpu\` — GPU wins, transfers inserted
  - \`unsupported_dtype_falls_back_to_cpu\` — capability fallback
  - \`unhealthy_executor_skipped\` — health filter
  - \`empty_runtime_errors\` — no executors → clean error
  - \`cost_model_threshold_monotonic\` — slower PCIe → GPU harder to reach
  - \`plan_function_works_with_registry\` — direct \`plan()\` usage
- 13 unit tests across cost / registry / runtime / planner

## Zero dependencies confirmed

\`\`\`
\$ cargo tree -p matrix-runtime
matrix-runtime v0.1.0
├── compute-ir v0.1.0
│   └── matrix-ir v0.1.0
├── executor-protocol v0.1.0
│   ├── compute-ir v0.1.0
│   └── matrix-ir v0.1.0
└── matrix-ir v0.1.0
\`\`\`

Only the upstream matrix-execution-layer crates as path deps.

## Security review: PASSED

No \`unsafe\` code, no FFI, no I/O. All arithmetic uses saturating ops or has explicit zero-divisor guards. Bit-shift inputs are range-checked. The threat model (a malicious matrix-ir Graph) is mitigated by upstream validation.

## What's next

This completes the layer's planning surface. Next:
- **\`matrix-cpu\`** — first executor crate; CPU reference implementation supporting every op on every dtype
- **One GPU executor** (Metal or CUDA) demonstrating the lowering pipeline
- **End-to-end \`Runtime::run()\`** that wires the planner output through transports
- **Migrate \`image-gpu-core\`** to emit \`MatrixIR\` instead of hand-written shaders

## Test plan

- [x] \`cargo build -p matrix-runtime\` — passes
- [x] \`cargo test -p matrix-runtime\` — 21 passing
- [x] \`cargo tree -p matrix-runtime\` — only path deps
- [x] Security review — passed
- [ ] CI matrix (ubuntu / macos / windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)