### PR TITLE
feat(tw04-4e): CLR multi-module compilation — each module → one TypeDef in a single PE

### DIFF
--- a/code/packages/python/cil-bytecode-builder/CHANGELOG.md
+++ b/code/packages/python/cil-bytecode-builder/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.0 — 2026-05-04 — conv.u2 opcode (TW04 Phase 4c)
+
+- Add `CILOpcode.CONV_U2 = 0xD3` to the opcode enum.
+- Add `CILBytecodeBuilder.emit_conv_u2()` convenience method.
+
+`conv.u2` truncates/zero-extends the int32 stack top to uint16
+(char), required by `System.Console.Write(char)` in Twig's inline
+host-call lowering so the correct overload is resolved.
+
 ## 0.2.0
 
 - Add `CILOpcode.XOR = 0x61` to the opcode enum (AND=0x5F and OR=0x60 were

--- a/code/packages/python/cil-bytecode-builder/src/cil_bytecode_builder/builder.py
+++ b/code/packages/python/cil-bytecode-builder/src/cil_bytecode_builder/builder.py
@@ -100,6 +100,12 @@ class CILOpcode(IntEnum):
     LDELEM_I4 = 0x94
     STELEM_I1 = 0x9C
     STELEM_I4 = 0x9E
+    # Numeric conversion opcodes (ECMA-335 §III.1.6).
+    # ``conv.u2`` converts the stack top to an unsigned 16-bit integer
+    # (uint16 / char), zero-extending a shorter value or truncating a
+    # longer one.  Used by the Twig CLR backend to convert an int32 byte
+    # value to ``char`` before calling ``System.Console.Write(char)``.
+    CONV_U2 = 0xD3
     PREFIX_FE = 0xFE
 
 
@@ -199,6 +205,15 @@ class CILBytecodeBuilder:
     def emit_starg(self, index: int) -> CILBytecodeBuilder:
         """Store to an argument slot using ``.s`` or prefixed form."""
         return self.emit_raw(encode_starg(index))
+
+    def emit_conv_u2(self) -> CILBytecodeBuilder:
+        """Emit ``conv.u2`` — truncate/zero-extend the stack top to uint16.
+
+        Used to convert an ``int32`` byte value to ``char`` (uint16) before
+        calling ``System.Console.Write(char)`` in Twig's inline host-call
+        path.  The opcode is ``0xD3`` per ECMA-335 §III.3.18.
+        """
+        return self.emit_opcode(CILOpcode.CONV_U2)
 
     def emit_token_instruction(
         self,

--- a/code/packages/python/cli-assembly-writer/CHANGELOG.md
+++ b/code/packages/python/cli-assembly-writer/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.5.0 — 2026-05-04 — System.Console AssemblyRef + inline host-call TypeRefs (TW04 Phase 4c)
+
+### Added — TypeRef rows 4 and 5 for inline host-call helpers
+
+Two new TypeRef rows are always emitted (small cost; keeps MemberRef
+token numbers deterministic across all assemblies):
+
+| Row | Type | Assembly |
+|-----|------|----------|
+| 4 | `System.Console` | AssemblyRef row 2 (`System.Console`) |
+| 5 | `System.Environment` | AssemblyRef row 1 (`System.Runtime`) |
+
+### Added — AssemblyRef row 2 for `System.Console`
+
+`System.Console` is a separate assembly from `System.Runtime` in
+net9.0.  Pointing its TypeRef ResolutionScope at `System.Runtime`
+causes `TypeLoadException: Could not load type 'System.Console' from
+assembly 'System.Runtime'` at runtime.  A second AssemblyRef row is
+emitted with name `System.Console` and the same ECMA public-key token
+and version as the existing `System.Runtime` row.
+
+### Changed — `_build_memberref_rows` uses `spec.class_typeref_row`
+
+Previously all helper MemberRef rows used a hardcoded TypeRef row-1
+parent.  Now the `CILHelperSpec.class_typeref_row` field drives the
+`MemberRefParent` coded index, enabling helpers in rows 4 and 5 to
+resolve correctly.
+
 ## 0.4.0 — 2026-04-30 — System.Int32 TypeRef (closure box support)
 
 Adds a third TypeRef row for `[System.Runtime]System.Int32` so

--- a/code/packages/python/cli-assembly-writer/src/cli_assembly_writer/writer.py
+++ b/code/packages/python/cli-assembly-writer/src/cli_assembly_writer/writer.py
@@ -414,6 +414,23 @@ class CLIAssemblyWriter:
         # token assignment stays deterministic regardless of whether
         # any specific compilation needs box.
         system_int32_name_index = strings.add("Int32")
+        # TW04 Phase 4c: TypeRef rows 4 and 5 for Twig's inline host-call
+        # helpers.  ``System.Console`` (row 4) provides ``Write(char)`` and
+        # ``Read()``; ``System.Environment`` (row 5) provides ``Exit(int32)``.
+        # Both live in the same ``System`` namespace as ``Object`` / ``Int32``,
+        # so ``system_namespace_index`` is reused — no new namespace string
+        # needed.  The rows are always emitted (small overhead) to keep
+        # MemberRef token assignments deterministic across all assemblies.
+        #
+        # IMPORTANT: ``System.Console`` is NOT in ``System.Runtime``; it
+        # lives in its own ``System.Console`` assembly (net9.0).  We add a
+        # second AssemblyRef row (row 2) for that assembly and point
+        # TypeRef row 4's ResolutionScope at it.  ``System.Environment``
+        # IS in ``System.Runtime`` so TypeRef row 5 keeps the row-1 ref.
+        system_console_name_index = strings.add("Console")
+        system_environment_name_index = strings.add("Environment")
+        # Assembly name string for the AssemblyRef row 2 entry.
+        system_console_assembly_name_index = strings.add("System.Console")
 
         # Same keying decision as the sig table: MethodDef row (1-based).
         # ``Apply`` / ``.ctor`` repeat across closure types and would
@@ -496,6 +513,9 @@ class CLIAssemblyWriter:
             system_object_name_index=system_object_name_index,
             system_int32_name_index=system_int32_name_index,
             system_namespace_index=system_namespace_index,
+            system_console_name_index=system_console_name_index,
+            system_environment_name_index=system_environment_name_index,
+            system_console_assembly_name_index=system_console_assembly_name_index,
         )
         # Stream order matches what real C# emits: #~, #Strings, #US,
         # #GUID, #Blob.  The order isn't load-bearing per ECMA-335 but
@@ -545,6 +565,9 @@ class CLIAssemblyWriter:
         system_object_name_index: int,
         system_int32_name_index: int,
         system_namespace_index: int,
+        system_console_name_index: int,
+        system_environment_name_index: int,
+        system_console_assembly_name_index: int,
     ) -> bytes:
         tables: dict[int, list[bytes]] = {
             _MODULE_TABLE: [
@@ -580,6 +603,28 @@ class CLIAssemblyWriter:
                     "<HHH",
                     6,
                     system_int32_name_index,
+                    system_namespace_index,
+                ),
+                # Row 4: ``System.Console`` in System namespace.  Provides
+                # the ``Write(char)`` and ``Read()`` MemberRef targets used
+                # by Twig's inline host-call SYSCALL lowering (TW04 Phase 4c).
+                # Always emitted to keep MemberRef token numbers stable.
+                # ResolutionScope points at AssemblyRef row 2 (System.Console)
+                # — NOT System.Runtime — because System.Console is its own
+                # assembly in net9.0.  AssemblyRef tag = 2, row 2 →
+                # (2 << 2) | 2 = 10.
+                struct.pack(
+                    "<HHH",
+                    10,
+                    system_console_name_index,
+                    system_namespace_index,
+                ),
+                # Row 5: ``System.Environment`` in System namespace.  Provides
+                # ``Exit(int32)`` for Twig's ``host/exit`` inline lowering.
+                struct.pack(
+                    "<HHH",
+                    6,
+                    system_environment_name_index,
                     system_namespace_index,
                 ),
             ],
@@ -662,6 +707,9 @@ class CLIAssemblyWriter:
             #   STRING Name, Culture
             #   BLOB   HashValue
             _ASSEMBLY_REF_TABLE: [
+                # Row 1: System.Runtime — provides System.Object, System.Int32,
+                # System.Environment, and the helper TypeRef (CodingAdventures.*
+                # in brainfuck/oct mode).
                 struct.pack(
                     "<HHHHIHHHH",
                     _SYSTEM_RUNTIME_VERSION[0],
@@ -671,6 +719,24 @@ class CLIAssemblyWriter:
                     0,
                     ecma_token_blob,
                     system_runtime_name_index,
+                    empty_string_index,
+                    empty_blob,
+                ),
+                # Row 2: System.Console — provides System.Console.Write(char)
+                # and System.Console.Read() used by Twig's inline host-call
+                # lowering.  System.Console is a SEPARATE assembly from
+                # System.Runtime in net9.0; pointing TypeRef row 4 at
+                # System.Runtime causes TypeLoadException at runtime.
+                # Same version and ECMA public-key token as System.Runtime.
+                struct.pack(
+                    "<HHHHIHHHH",
+                    _SYSTEM_RUNTIME_VERSION[0],
+                    _SYSTEM_RUNTIME_VERSION[1],
+                    _SYSTEM_RUNTIME_VERSION[2],
+                    _SYSTEM_RUNTIME_VERSION[3],
+                    0,
+                    ecma_token_blob,
+                    system_console_assembly_name_index,
                     empty_string_index,
                     empty_blob,
                 ),
@@ -914,10 +980,15 @@ def _build_memberref_rows(
     = 9``.  System.Object::.ctor points at TypeRef row 2 →
     ``(2 << 3) | 1 = 17``.
     """
+    # ``MemberRefParent`` is a coded index: tag bits (low 3) = 1 for TypeRef;
+    # the row number is shifted left by 3.  ECMA-335 §II.22.25.
+    # For legacy helpers ``spec.class_typeref_row == 1`` → (1 << 3) | 1 = 9.
+    # For TW04 Phase 4c helpers: row 4 (System.Console) → 33,
+    #                              row 5 (System.Environment) → 41.
     rows: list[bytes] = [
         struct.pack(
             "<HHH",
-            (1 << 3) | 1,
+            (spec.class_typeref_row << 3) | 1,
             helper_name_indices[spec.helper],
             helper_sig_indices[spec.helper],
         )

--- a/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/python/ir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.12.0 — 2026-05-04 — inline host syscalls + local_count floor (TW04 Phase 4c/4e)
+
+### Added — `inline_host_syscalls` config flag
+
+`CILBackendConfig(inline_host_syscalls=True)` changes SYSCALL 1/2/10
+lowering from the brainfuck-specific `__ca_syscall(num, arg)` external
+call to direct .NET API calls:
+
+| SYSCALL | Inline target |
+|---------|---------------|
+| 1 (write-byte) | `System.Console.Write(char)` via `conv.u2` + call |
+| 2 (read-byte)  | `System.Console.Read() → int32` |
+| 10 (exit)      | `System.Environment.Exit(int32) → void` |
+
+This eliminates the `TypeLoadException: Could not load type
+'CodingAdventures.Runtime.Helpers'` that occurred when Twig programs
+used `host/write-byte` via the CLR backend — the helper type only
+exists in the brainfuck VM runtime, not in the standard .NET SDK.
+
+Three new `CILHelper` variants added: `CONSOLE_WRITE_CHAR`,
+`CONSOLE_READ`, `ENVIRONMENT_EXIT`.  Each has a `class_typeref_row`
+that points to the correct TypeRef row (4 = System.Console,
+5 = System.Environment) in the PE metadata.
+
+### Added — local_count floor at `call_register_count`
+
+`_analyze_program` now floors `plan.local_count` at
+`config.call_register_count` (when set).  Without this floor, an entry
+module with fewer registers than `global_local_count` declared too few
+locals, causing `InvalidProgramException` when the JIT tried to push
+the full `global_local_count` args for a cross-module call.
+
+### Changed — `CILHelperSpec` has `class_typeref_row: int = 1`
+
+New field on `CILHelperSpec` (default `1` = backward-compatible legacy
+behaviour).  The cli-assembly-writer uses this field to compute the
+`MemberRefParent` coded index for each helper MemberRef row, replacing
+the hardcoded TypeRef-row-1 assumption.
+
 ## 0.11.0 — 2026-04-29 — multi-arity closures (IClosure.Apply takes int32[])
 
 `IClosure.Apply` now takes `int32[]` (was `int32`) so closures

--- a/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/src/ir_to_cil_bytecode/backend.py
@@ -26,23 +26,52 @@ class CILBackendError(ValueError):
 
 
 class CILHelper(StrEnum):
-    """Runtime helper calls required by lowered CIL bytecode."""
+    """Runtime helper calls required by lowered CIL bytecode.
+
+    The first five members (``MEM_LOAD_BYTE`` through ``SYSCALL``) are the
+    original brainfuck-VM helpers that live in the external
+    ``CodingAdventures.Runtime.Helpers`` type (TypeRef row 1).
+
+    The three members added in TW04 Phase 4c are Twig-specific **inline**
+    host-call helpers that map directly to standard .NET APIs:
+
+    * ``CONSOLE_WRITE_CHAR`` → ``System.Console.Write(char)``  (TypeRef 4)
+    * ``CONSOLE_READ``       → ``System.Console.Read()``        (TypeRef 4)
+    * ``ENVIRONMENT_EXIT``   → ``System.Environment.Exit(int)`` (TypeRef 5)
+
+    These are only used when ``CILBackendConfig.inline_host_syscalls=True``.
+    They are still included in ``HELPER_SPECS`` (so the MemberRef rows always
+    exist in the assembly), but the bodies are never reached unless Twig's
+    CLR compiler opts in.
+    """
 
     MEM_LOAD_BYTE = "mem_load_byte"
     MEM_STORE_BYTE = "mem_store_byte"
     LOAD_WORD = "load_word"
     STORE_WORD = "store_word"
     SYSCALL = "syscall"
+    # TW04 Phase 4c: inline host-call helpers — static .NET API wrappers.
+    CONSOLE_WRITE_CHAR = "console_write_char"  # System.Console.Write(char) → void
+    CONSOLE_READ = "console_read"              # System.Console.Read() → int32
+    ENVIRONMENT_EXIT = "environment_exit"      # System.Environment.Exit(int32) → void
 
 
 @dataclass(frozen=True)
 class CILHelperSpec:
-    """A helper method dependency requested by the lowered bytecode."""
+    """A helper method dependency requested by the lowered bytecode.
+
+    ``class_typeref_row`` selects which TypeRef row the generated MemberRef
+    row points at.  The default (``1``) is the legacy
+    ``CodingAdventures.Runtime.Helpers`` row.  Phase 4c host-call helpers
+    use rows 4 (``System.Console``) and 5 (``System.Environment``).
+    """
 
     helper: CILHelper
     name: str
     parameter_types: tuple[str, ...]
     return_type: str
+    # 1-based TypeRef row that owns this method (default: row 1 = legacy helper).
+    class_typeref_row: int = 1
 
 
 @dataclass(frozen=True)
@@ -75,6 +104,37 @@ class CILBackendConfig:
     # Defaults to 1 for back-compat; the Twig CLR frontend
     # populates it from each lambda's source-level param count.
     closure_explicit_arities: dict[str, int] = field(default_factory=dict)
+    # TW04 Phase 4e — multi-module CLR support.
+    #
+    # ``extra_callable_labels`` force-includes exported dep-module
+    # functions even when no local ``CALL`` instruction targets them.
+    # Mirrors the identically named field in ``JvmBackendConfig``.
+    extra_callable_labels: tuple[str, ...] = ()
+    # ``external_method_tokens`` maps cross-module CALL label strings
+    # (e.g. ``"a/math/add"``) to their pre-assigned ``MethodDef``
+    # token (``0x06xxxxxx``) in the combined multi-module assembly.
+    # Populated by ``twig-clr-compiler.compile_modules`` from a
+    # two-pass analysis of all module IR programs before bytecode
+    # emission begins.  An empty dict (the default) means no
+    # cross-module calls are expected — any CALL with ``/`` in its
+    # label will raise ``CILBackendError`` at lowering time.
+    external_method_tokens: dict[str, int] = field(default_factory=dict)
+    # TW04 Phase 4c — inline host-call lowering.
+    #
+    # When ``True``, ``IrOp.SYSCALL`` instructions with numbers 1
+    # (write-byte), 2 (read-byte), and 10 (exit) are lowered to
+    # **inline** .NET API calls:
+    #
+    #   SYSCALL 1  → ``System.Console.Write(char)``
+    #   SYSCALL 2  → ``System.Console.Read()``
+    #   SYSCALL 10 → ``System.Environment.Exit(int32)``
+    #
+    # When ``False`` (the default), the legacy brainfuck-VM path is
+    # used: push (number, arg) and call ``__ca_syscall`` via the
+    # external ``CodingAdventures.Runtime.Helpers`` MemberRef.  The
+    # Twig CLR compiler sets this flag to ``True`` so that host calls
+    # work on the real dotnet runtime without a bespoke helper library.
+    inline_host_syscalls: bool = False
 
 
 @dataclass(frozen=True)
@@ -286,12 +346,20 @@ class SequentialCILTokenProvider:
         self,
         method_names: tuple[str, ...],
         *,
+        method_token_offset: int = 0,
         closure_names: tuple[str, ...] = (),
         closure_free_var_counts: dict[str, int] | None = None,
         include_heap_types: bool = False,
     ) -> None:
+        # TW04 Phase 4e: ``method_token_offset`` shifts the base
+        # MethodDef token so that dep-module providers don't start
+        # at row 1.  The entry module uses offset=0 (the default);
+        # dep module k uses offset = sum of all preceding modules'
+        # method counts.  Closure and heap tokens are relative to
+        # this module's own base.
         self._method_tokens = {
-            name: 0x06000001 + index for index, name in enumerate(method_names)
+            name: 0x06000001 + method_token_offset + index
+            for index, name in enumerate(method_names)
         }
         self._helper_tokens = {
             helper: 0x0A000001 + index for index, helper in enumerate(CILHelper)
@@ -303,12 +371,14 @@ class SequentialCILTokenProvider:
         self._closure_names = closure_names
         self._free_counts = closure_free_var_counts or {}
         m = len(method_names)
-        self._iclosure_apply = 0x06000001 + m if closure_names else 0
+        # Closure tokens are relative to this module's method base.
+        _base = 0x06000001 + method_token_offset
+        self._iclosure_apply = _base + m if closure_names else 0
         self._closure_ctors: dict[str, int] = {}
         self._closure_applies: dict[str, int] = {}
         for k, name in enumerate(closure_names):
-            self._closure_ctors[name] = 0x06000001 + m + 1 + 2 * k
-            self._closure_applies[name] = 0x06000001 + m + 2 + 2 * k
+            self._closure_ctors[name] = _base + m + 1 + 2 * k
+            self._closure_applies[name] = _base + m + 2 + 2 * k
 
         # Field tokens.  One per capture, walking closures in
         # declaration order.
@@ -778,6 +848,9 @@ def lower_ir_to_cil_bytecode(
 
 
 HELPER_SPECS: tuple[CILHelperSpec, ...] = (
+    # ── Legacy brainfuck-VM helpers (TypeRef row 1 = CodingAdventures.Runtime.Helpers) ──
+    # These five entries have been here since CLR01.  Their MemberRef tokens
+    # are stable (0x0A000001 through 0x0A000005) and must not be reordered.
     CILHelperSpec(CILHelper.MEM_LOAD_BYTE, "__ca_mem_load_byte", ("int32",), "int32"),
     CILHelperSpec(
         CILHelper.MEM_STORE_BYTE,
@@ -793,6 +866,34 @@ HELPER_SPECS: tuple[CILHelperSpec, ...] = (
         "void",
     ),
     CILHelperSpec(CILHelper.SYSCALL, "__ca_syscall", ("int32", "int32"), "int32"),
+    # ── TW04 Phase 4c: Twig inline host-call helpers ─────────────────────────
+    # Used when ``CILBackendConfig.inline_host_syscalls=True``.  These MemberRef
+    # rows point at TypeRef rows 4 (System.Console) and 5 (System.Environment)
+    # rather than the legacy external type (row 1).  Both live in System.Runtime.
+    #
+    # The ``class_typeref_row`` field controls which TypeRef row the
+    # cli-assembly-writer uses for the MemberRefParent coded index.
+    CILHelperSpec(
+        CILHelper.CONSOLE_WRITE_CHAR,
+        "Write",
+        ("char",),
+        "void",
+        class_typeref_row=4,  # System.Console
+    ),
+    CILHelperSpec(
+        CILHelper.CONSOLE_READ,
+        "Read",
+        (),
+        "int32",
+        class_typeref_row=4,  # System.Console
+    ),
+    CILHelperSpec(
+        CILHelper.ENVIRONMENT_EXIT,
+        "Exit",
+        ("int32",),
+        "void",
+        class_typeref_row=5,  # System.Environment
+    ),
 )
 
 
@@ -804,9 +905,18 @@ def _analyze_program(
 ) -> CILLoweringPlan:
     _validate_config(config)
     label_positions = _collect_labels(program)
-    regions = tuple(_discover_callable_regions(program, label_positions))
+    regions = tuple(_discover_callable_regions(program, label_positions, config))
     data_offsets, data_size = _assign_data_offsets(program, config)
     local_count = max(_max_register_index(program) + 1, config.syscall_arg_reg + 1, 2)
+    # TW04 Phase 4e: when a fixed ``call_register_count`` is given, every
+    # method in this module must declare AT LEAST that many locals so the
+    # cross-module CALL sequence can push exactly that many arguments.
+    # Without this floor, a simple entry module (few registers) compiled
+    # with a higher global call_register_count would have fewer locals than
+    # the count it must push, leading to out-of-range ``ldloc`` instructions
+    # and a ``System.InvalidProgramException`` at runtime.
+    if config.call_register_count is not None and config.call_register_count > local_count:
+        local_count = config.call_register_count
 
     # Split regions into "main" and "closure" buckets.  Closure
     # regions become Apply methods on auto-generated Closure_<name>
@@ -1314,12 +1424,19 @@ def _collect_labels(program: IrProgram) -> dict[str, int]:
 def _discover_callable_regions(
     program: IrProgram,
     label_positions: dict[str, int],
+    config: CILBackendConfig | None = None,
 ) -> list[_CallableRegion]:
     callable_names = {program.entry_label}
     for instruction in program.instructions:
         if instruction.opcode == IrOp.CALL:
             target = _as_label(instruction.operands[0], "CALL target")
-            callable_names.add(target.name)
+            # TW04 Phase 4e: cross-module call labels contain ``/``
+            # (e.g. ``"a/math/add"``).  They are not present in
+            # ``label_positions`` of THIS module's IR; their tokens
+            # come from ``config.external_method_tokens`` at lowering
+            # time.  Skip them here.
+            if "/" not in target.name:
+                callable_names.add(target.name)
         elif instruction.opcode == IrOp.MAKE_CLOSURE:
             # MAKE_CLOSURE dst, fn_label, num_captured, capt0, ...
             # The lambda body is a callable region too, even though
@@ -1329,6 +1446,12 @@ def _discover_callable_regions(
                 instruction.operands[1], "MAKE_CLOSURE fn_label",
             )
             callable_names.add(target.name)
+
+    # TW04 Phase 4e: exported dep-module functions have no local CALL
+    # callers (they're only called from OTHER modules).  Force-include
+    # them so they appear in the TypeDef's method list.
+    if config is not None:
+        callable_names.update(config.extra_callable_labels)
 
     if program.entry_label not in label_positions:
         msg = f"Entry label not found: {program.entry_label}"
@@ -1376,6 +1499,11 @@ def _discover_callable_regions(
                     raise CILBackendError(msg)
             elif instruction.opcode == IrOp.CALL:
                 label = _as_label(instruction.operands[0], "CALL target")
+                # TW04 Phase 4e: cross-module targets are not in the
+                # local callable_lookup — they resolve at the
+                # external_method_tokens level.  Skip validation for them.
+                if "/" in label.name:
+                    continue
                 if label.name not in callable_lookup:
                     msg = f"CALL target {label.name!r} is not a callable label"
                     raise CILBackendError(msg)
@@ -2070,6 +2198,33 @@ def _emit_instruction(
 
     if instruction.opcode == IrOp.CALL:
         label = _as_label(instruction.operands[0], "CALL target")
+
+        # TW04 Phase 4e: cross-module call — label contains ``/``
+        # (e.g. ``"a/math/add"``).  The callee lives in a different
+        # TypeDef in the combined multi-module assembly.  Its
+        # MethodDef token was pre-computed in ``compile_modules``
+        # and stored in ``config.external_method_tokens``.  The
+        # calling convention is identical to a same-TypeDef call:
+        # push all call-register-count locals, ``call <token>``,
+        # store the int32 result into local 1 (the return slot).
+        # Object-typed parameter marshalling is not needed for
+        # cross-module calls in Phase 4e (dep modules contain only
+        # plain int functions — no closures, no heap types).
+        if "/" in label.name:
+            token = config.external_method_tokens.get(label.name)
+            if token is None:
+                msg = (
+                    f"No pre-assigned token for cross-module CALL target "
+                    f"{label.name!r}.  Populate "
+                    "CILBackendConfig.external_method_tokens."
+                )
+                raise CILBackendError(msg)
+            for index in range(_call_register_count(config, plan)):
+                builder.emit_ldloc(index)
+            builder.emit_call(token)
+            builder.emit_stloc(1)
+            return
+
         # TW03 Phase 3 follow-up: per-arg ldloc picks int32 vs object
         # slot based on the CALLEE's parameter typing.  Without this,
         # cons / symbol / nil refs marshalled into a param slot via
@@ -2458,13 +2613,7 @@ def _emit_instruction(
 
     if instruction.opcode == IrOp.SYSCALL:
         number = _as_immediate(instruction.operands[0], "SYSCALL number")
-        builder.emit_ldc_i4(number.value)
-        builder.emit_ldloc(config.syscall_arg_reg)
-        builder.emit_call(plan.token_provider.helper_token(CILHelper.SYSCALL))
-        # Store the syscall return value into the register given by operands[1],
-        # if present and a register (e.g. SYSCALL 2 / read stores its result into
-        # a scratch register rather than the write-arg register).
-        # Fall back to syscall_arg_reg when no result operand is present.
+        # Determine result register: operands[1] if present, else syscall_arg_reg.
         result_reg: int
         if (
             len(instruction.operands) >= 2
@@ -2473,6 +2622,54 @@ def _emit_instruction(
             result_reg = instruction.operands[1].index
         else:
             result_reg = config.syscall_arg_reg
+
+        if config.inline_host_syscalls and number.value in (1, 2, 10):
+            # ── Twig inline host-call path ────────────────────────────────────
+            # Emit direct .NET API calls instead of the brainfuck-style
+            # ``__ca_syscall(num, arg)`` MemberRef.  The tokens for
+            # ``Console.Write``, ``Console.Read``, and ``Environment.Exit``
+            # are stable: they live at MemberRef indices 6, 7, 8 (after the
+            # five legacy helpers), per ``HELPER_SPECS`` and
+            # ``SequentialCILTokenProvider``.
+            #
+            #   SYSCALL 1  (write-byte) → Console.Write((char)arg)
+            #   SYSCALL 2  (read-byte)  → Console.Read()
+            #   SYSCALL 10 (exit)       → Environment.Exit(arg)  [unreachable after]
+            if number.value == 1:  # write-byte
+                # Push the byte value as a char (uint16) then call Write(char).
+                # Console.Write(char) writes the character to stdout and returns
+                # void; we push 0 as the Twig syscall "return value".
+                builder.emit_ldloc(config.syscall_arg_reg)
+                builder.emit_conv_u2()  # int32 → char (uint16)
+                builder.emit_call(
+                    plan.token_provider.helper_token(CILHelper.CONSOLE_WRITE_CHAR),
+                )
+                builder.emit_ldc_i4(0)  # void call → push 0 as result
+            elif number.value == 2:  # read-byte
+                # Console.Read() returns the next char as int32 (or -1 on EOF).
+                # No input argument.
+                builder.emit_call(
+                    plan.token_provider.helper_token(CILHelper.CONSOLE_READ),
+                )
+                # int32 result is already on the stack — fall through to stloc.
+            else:  # number.value == 10 — exit
+                # Environment.Exit(int32) terminates the process and never returns.
+                # Push 0 after the call so the stack stays balanced for the JIT;
+                # the stloc below is unreachable but harmless.
+                builder.emit_ldloc(config.syscall_arg_reg)
+                builder.emit_call(
+                    plan.token_provider.helper_token(CILHelper.ENVIRONMENT_EXIT),
+                )
+                builder.emit_ldc_i4(0)  # unreachable — process already exited
+        else:
+            # ── Legacy brainfuck-VM path ──────────────────────────────────────
+            # Call the external ``__ca_syscall(int32 num, int32 arg)`` helper.
+            # The brainfuck and Oct CLR VMs provide this method at runtime;
+            # Twig uses ``inline_host_syscalls=True`` instead.
+            builder.emit_ldc_i4(number.value)
+            builder.emit_ldloc(config.syscall_arg_reg)
+            builder.emit_call(plan.token_provider.helper_token(CILHelper.SYSCALL))
+        # Store the syscall return value into result_reg.
         builder.emit_stloc(result_reg)
         return
 

--- a/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
+++ b/code/packages/python/ir-to-cil-bytecode/tests/test_backend.py
@@ -229,6 +229,97 @@ def test_lower_memory_and_syscall_helpers_use_injected_tokens() -> None:
     )
 
 
+def test_inline_host_syscall_write_byte_emits_conv_u2_and_console_write() -> None:
+    """``inline_host_syscalls=True`` + SYSCALL 1 → ``conv.u2`` + ``Console.Write(char)``.
+
+    The legacy path emits ``ldc.i4 1; ldloc <arg>; call __ca_syscall`` and
+    does NOT include ``conv.u2`` (0xD3).  The inline path must include that
+    opcode so the CLR overload resolves to ``Write(char)`` rather than
+    ``Write(int)``.
+
+    Token layout with the default ``SequentialCILTokenProvider``:
+      MEM_LOAD_BYTE=0x0A000001, …, SYSCALL=0x0A000005,
+      CONSOLE_WRITE_CHAR=0x0A000006.
+    """
+    artifact = lower_ir_to_cil_bytecode(
+        _program(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(65)]),
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(1)]),
+            IrInstruction(IrOp.RET),
+        ),
+        CILBackendConfig(inline_host_syscalls=True),
+    )
+    body = artifact.entry_method.body
+    # 0xD3 = conv.u2 — present only in inline path
+    assert 0xD3 in body, "Expected conv.u2 (0xD3) in inline write-byte path"
+    # Console.Write(char) token bytes: 0x28 0x06 0x00 0x00 0x0A
+    assert bytes([0x28, 0x06, 0x00, 0x00, 0x0A]) in body, (
+        "Expected call to CONSOLE_WRITE_CHAR (0x0A000006)"
+    )
+    # Legacy __ca_syscall should NOT be present
+    assert bytes([0x28, 0x05, 0x00, 0x00, 0x0A]) not in body, (
+        "Legacy __ca_syscall call should be absent in inline path"
+    )
+
+
+def test_inline_host_syscall_read_byte_emits_console_read() -> None:
+    """``inline_host_syscalls=True`` + SYSCALL 2 → ``call Console.Read()``."""
+    artifact = lower_ir_to_cil_bytecode(
+        _program(
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(2)]),
+            IrInstruction(IrOp.RET),
+        ),
+        CILBackendConfig(inline_host_syscalls=True),
+    )
+    body = artifact.entry_method.body
+    # Console.Read() token: 0x0A000007
+    assert bytes([0x28, 0x07, 0x00, 0x00, 0x0A]) in body, (
+        "Expected call to CONSOLE_READ (0x0A000007)"
+    )
+    # No conv.u2 for read path
+    assert 0xD3 not in body, "conv.u2 should not appear in read-byte path"
+    assert bytes([0x28, 0x05, 0x00, 0x00, 0x0A]) not in body, (
+        "Legacy __ca_syscall should be absent"
+    )
+
+
+def test_inline_host_syscall_exit_emits_environment_exit() -> None:
+    """``inline_host_syscalls=True`` + SYSCALL 10 → ``call Environment.Exit(int32)``."""
+    artifact = lower_ir_to_cil_bytecode(
+        _program(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(0)]),
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(10)]),
+            IrInstruction(IrOp.RET),
+        ),
+        CILBackendConfig(inline_host_syscalls=True),
+    )
+    body = artifact.entry_method.body
+    # Environment.Exit(int32) token: 0x0A000008
+    assert bytes([0x28, 0x08, 0x00, 0x00, 0x0A]) in body, (
+        "Expected call to ENVIRONMENT_EXIT (0x0A000008)"
+    )
+    assert bytes([0x28, 0x05, 0x00, 0x00, 0x0A]) not in body, (
+        "Legacy __ca_syscall should be absent"
+    )
+
+
+def test_legacy_syscall_path_uses_ca_syscall_by_default() -> None:
+    """Default ``CILBackendConfig`` uses the legacy ``__ca_syscall`` path."""
+    artifact = lower_ir_to_cil_bytecode(
+        _program(
+            IrInstruction(IrOp.LOAD_IMM, [IrRegister(4), IrImmediate(65)]),
+            IrInstruction(IrOp.SYSCALL, [IrImmediate(1)]),
+            IrInstruction(IrOp.RET),
+        ),
+    )
+    body = artifact.entry_method.body
+    # __ca_syscall token: 0x0A000005
+    assert bytes([0x28, 0x05, 0x00, 0x00, 0x0A]) in body, (
+        "Legacy __ca_syscall call expected in default (brainfuck) path"
+    )
+    assert 0xD3 not in body, "conv.u2 should not appear in legacy syscall path"
+
+
 def test_default_token_provider_is_deterministic() -> None:
     provider = SequentialCILTokenProvider(("_start", "callee"))
 

--- a/code/packages/python/ir-to-cil-bytecode/tests/test_cross_module_clr.py
+++ b/code/packages/python/ir-to-cil-bytecode/tests/test_cross_module_clr.py
@@ -1,0 +1,401 @@
+"""Tests for TW04 Phase 4e — CLR cross-module CALL support.
+
+Coverage targets
+================
+* ``CILBackendConfig.extra_callable_labels`` — force-include exported
+  dep-module functions that no local CALL targets.
+* ``CILBackendConfig.external_method_tokens`` — pre-assigned MethodDef
+  token lookup for cross-module CALL instructions.
+* ``SequentialCILTokenProvider(method_token_offset=N)`` — dep-module
+  providers that start their MethodDef token numbering at an offset.
+* ``_discover_callable_regions`` — cross-module label skipping.
+* CALL lowering — cross-module branch in ``_emit_instruction``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from compiler_ir import IrImmediate, IrInstruction, IrLabel, IrOp, IrProgram, IrRegister
+from ir_to_cil_bytecode import (
+    CILBackendConfig,
+    CILBackendError,
+    lower_ir_to_cil_bytecode,
+)
+from ir_to_cil_bytecode.backend import SequentialCILTokenProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reg(n: int) -> IrRegister:
+    return IrRegister(index=n)
+
+
+def _imm(v: int) -> IrImmediate:
+    return IrImmediate(value=v)
+
+
+def _lbl(name: str) -> IrLabel:
+    return IrLabel(name=name)
+
+
+def _simple_program(extra_instructions: list[IrInstruction]) -> IrProgram:
+    """Build a minimal IrProgram with a ``main`` region and extra instructions."""
+    base: list[IrInstruction] = [
+        IrInstruction(IrOp.LABEL, (_lbl("main"),)),
+        IrInstruction(IrOp.LOAD_IMM, (_reg(1), _imm(0))),
+    ]
+    return IrProgram(
+        entry_label="main",
+        instructions=base + extra_instructions + [
+            IrInstruction(IrOp.RET, ()),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# SequentialCILTokenProvider — method_token_offset
+# ---------------------------------------------------------------------------
+
+
+class TestSequentialTokenOffset:
+    """SequentialCILTokenProvider honours ``method_token_offset``."""
+
+    def test_zero_offset_starts_at_0x06000001(self) -> None:
+        provider = SequentialCILTokenProvider(("main", "add"), method_token_offset=0)
+        assert provider.method_token("main") == 0x06000001
+        assert provider.method_token("add") == 0x06000002
+
+    def test_nonzero_offset_shifts_base(self) -> None:
+        """Dep module with 3 entry-module methods before it gets offset=3."""
+        provider = SequentialCILTokenProvider(("add", "sub"), method_token_offset=3)
+        assert provider.method_token("add") == 0x06000004
+        assert provider.method_token("sub") == 0x06000005
+
+    def test_helper_tokens_are_unaffected_by_offset(self) -> None:
+        """MemberRef tokens (0x0A prefix) always start at 0x0A000001."""
+        from ir_to_cil_bytecode.backend import CILHelper
+        provider = SequentialCILTokenProvider(("main",), method_token_offset=10)
+        assert provider.helper_token(CILHelper.SYSCALL) == 0x0A000005
+
+    def test_unknown_method_raises(self) -> None:
+        provider = SequentialCILTokenProvider(("main",), method_token_offset=0)
+        with pytest.raises(CILBackendError, match="Unknown CIL method token"):
+            provider.method_token("nonexistent")
+
+    def test_large_offset(self) -> None:
+        provider = SequentialCILTokenProvider(("f",), method_token_offset=100)
+        assert provider.method_token("f") == 0x06000065  # 0x06000001 + 100
+
+
+# ---------------------------------------------------------------------------
+# extra_callable_labels — force-include exported functions
+# ---------------------------------------------------------------------------
+
+
+class TestExtraCallableLabels:
+    """``extra_callable_labels`` forces exported functions into the TypeDef."""
+
+    def _make_dep_module_program(self) -> IrProgram:
+        """Dep module: 'main' stub + exported 'add' + 'sub'.
+
+        Neither 'add' nor 'sub' is a CALL target locally — they're only
+        called from other modules.  Without ``extra_callable_labels`` the
+        backend would omit them.
+        """
+        return IrProgram(
+            entry_label="main",
+            instructions=[
+                # main region (stub):
+                IrInstruction(IrOp.LABEL, (_lbl("main"),)),
+                IrInstruction(IrOp.LOAD_IMM, (_reg(1), _imm(0))),
+                IrInstruction(IrOp.RET, ()),
+                # 'add' region:
+                IrInstruction(IrOp.LABEL, (_lbl("add"),)),
+                IrInstruction(IrOp.ADD, (_reg(1), _reg(2), _reg(3))),
+                IrInstruction(IrOp.RET, ()),
+                # 'sub' region:
+                IrInstruction(IrOp.LABEL, (_lbl("sub"),)),
+                IrInstruction(IrOp.SUB, (_reg(1), _reg(2), _reg(3))),
+                IrInstruction(IrOp.RET, ()),
+            ],
+        )
+
+    def test_without_extra_callable_labels_only_main_emitted(self) -> None:
+        """Without the hint, only 'main' is discoverable (no local CALLs)."""
+        prog = self._make_dep_module_program()
+        artifact = lower_ir_to_cil_bytecode(
+            prog,
+            CILBackendConfig(call_register_count=None),
+        )
+        # Only 'main' is a callable — 'add' and 'sub' are omitted.
+        assert artifact.callable_labels == ("main",)
+
+    def test_with_extra_callable_labels_exports_are_included(self) -> None:
+        """With the hint, 'add' and 'sub' appear in the emitted methods."""
+        prog = self._make_dep_module_program()
+        artifact = lower_ir_to_cil_bytecode(
+            prog,
+            CILBackendConfig(
+                call_register_count=None,
+                extra_callable_labels=("add", "sub"),
+            ),
+        )
+        assert "add" in artifact.callable_labels
+        assert "sub" in artifact.callable_labels
+
+    def test_extra_callable_labels_preserves_ir_order(self) -> None:
+        """Methods appear in IR label-position order, not set-insertion order."""
+        prog = self._make_dep_module_program()
+        artifact = lower_ir_to_cil_bytecode(
+            prog,
+            CILBackendConfig(
+                call_register_count=None,
+                extra_callable_labels=("sub", "add"),  # reversed
+            ),
+        )
+        names = artifact.callable_labels
+        # 'add' label appears BEFORE 'sub' in the IR
+        assert names.index("add") < names.index("sub")
+
+    def test_extra_callable_labels_unknown_label_raises(self) -> None:
+        """A label in ``extra_callable_labels`` that doesn't exist in the IR errors."""
+        prog = _simple_program([])
+        with pytest.raises(CILBackendError, match="Missing callable labels"):
+            lower_ir_to_cil_bytecode(
+                prog,
+                CILBackendConfig(extra_callable_labels=("nonexistent",)),
+            )
+
+
+# ---------------------------------------------------------------------------
+# external_method_tokens — cross-module CALL lowering
+# ---------------------------------------------------------------------------
+
+
+class TestExternalMethodTokens:
+    """Cross-module CALL lowering via ``external_method_tokens``."""
+
+    def _make_cross_module_program(self, cross_label: str) -> IrProgram:
+        """Main program that calls a cross-module function."""
+        return IrProgram(
+            entry_label="main",
+            instructions=[
+                IrInstruction(IrOp.LABEL, (_lbl("main"),)),
+                # Marshal arg: move 10 into param register 2
+                IrInstruction(IrOp.LOAD_IMM, (_reg(2), _imm(10))),
+                # Cross-module CALL — label contains '/'
+                IrInstruction(IrOp.CALL, (_lbl(cross_label),)),
+                # Store result from reg 1 (return slot)
+                IrInstruction(IrOp.ADD_IMM, (_reg(1), _reg(1), _imm(0))),
+                IrInstruction(IrOp.RET, ()),
+            ],
+        )
+
+    def test_cross_module_call_without_token_raises(self) -> None:
+        """A cross-module CALL with no pre-assigned token raises at lowering."""
+        prog = self._make_cross_module_program("a/math/add")
+        with pytest.raises(CILBackendError, match="No pre-assigned token"):
+            lower_ir_to_cil_bytecode(
+                prog,
+                CILBackendConfig(call_register_count=None),
+            )
+
+    def test_cross_module_call_with_token_succeeds(self) -> None:
+        """A cross-module CALL with a pre-assigned token lowers without error."""
+        prog = self._make_cross_module_program("a/math/add")
+        artifact = lower_ir_to_cil_bytecode(
+            prog,
+            CILBackendConfig(
+                call_register_count=None,
+                external_method_tokens={"a/math/add": 0x06000004},
+            ),
+        )
+        assert artifact.entry_label == "main"
+
+    def test_cross_module_call_token_appears_in_bytecode(self) -> None:
+        """The pre-assigned MethodDef token appears in the emitted bytecode.
+
+        CIL ``call`` opcode: 0x28 followed by 4-byte token (little-endian).
+        Token ``0x06000004`` → bytes ``[0x28, 0x04, 0x00, 0x00, 0x06]``.
+        """
+        prog = self._make_cross_module_program("b/util/double")
+        token = 0x06000007
+        artifact = lower_ir_to_cil_bytecode(
+            prog,
+            CILBackendConfig(
+                call_register_count=None,
+                external_method_tokens={"b/util/double": token},
+            ),
+        )
+        body = artifact.entry_method.body
+        # Search for the 'call' instruction sequence in the method body.
+        expected_token_bytes = token.to_bytes(4, "little")
+        call_opcode = 0x28
+        found = any(
+            body[i] == call_opcode and body[i + 1:i + 5] == expected_token_bytes
+            for i in range(len(body) - 4)
+        )
+        assert found, (
+            f"Expected call 0x{token:08X} in bytecode, got: {body.hex()}"
+        )
+
+    def test_multiple_cross_module_calls(self) -> None:
+        """Multiple cross-module CALL targets with different tokens all work."""
+        prog = IrProgram(
+            entry_label="main",
+            instructions=[
+                IrInstruction(IrOp.LABEL, (_lbl("main"),)),
+                IrInstruction(IrOp.LOAD_IMM, (_reg(2), _imm(1))),
+                IrInstruction(IrOp.CALL, (_lbl("mod1/fn1"),)),
+                IrInstruction(IrOp.ADD_IMM, (_reg(10), _reg(1), _imm(0))),
+                IrInstruction(IrOp.LOAD_IMM, (_reg(2), _imm(2))),
+                IrInstruction(IrOp.CALL, (_lbl("mod2/fn2"),)),
+                IrInstruction(IrOp.ADD, (_reg(1), _reg(10), _reg(1))),
+                IrInstruction(IrOp.RET, ()),
+            ],
+        )
+        artifact = lower_ir_to_cil_bytecode(
+            prog,
+            CILBackendConfig(
+                call_register_count=None,
+                external_method_tokens={
+                    "mod1/fn1": 0x06000003,
+                    "mod2/fn2": 0x06000005,
+                },
+            ),
+        )
+        body = artifact.entry_method.body
+        # Both tokens should appear in the bytecode.
+        for token in (0x06000003, 0x06000005):
+            token_bytes = token.to_bytes(4, "little")
+            assert any(
+                body[i] == 0x28 and body[i + 1:i + 5] == token_bytes
+                for i in range(len(body) - 4)
+            ), f"Token 0x{token:08X} not found in bytecode"
+
+    def test_cross_module_call_does_not_appear_in_callable_regions(self) -> None:
+        """Cross-module call targets are NOT added to the local callable regions."""
+        prog = self._make_cross_module_program("x/y/z")
+        artifact = lower_ir_to_cil_bytecode(
+            prog,
+            CILBackendConfig(
+                call_register_count=None,
+                external_method_tokens={"x/y/z": 0x06000002},
+            ),
+        )
+        # Only "main" is a callable region — "x/y/z" is external.
+        assert artifact.callable_labels == ("main",)
+
+    def test_local_and_cross_module_calls_coexist(self) -> None:
+        """Local CALL and cross-module CALL can appear in the same program."""
+        prog = IrProgram(
+            entry_label="main",
+            instructions=[
+                IrInstruction(IrOp.LABEL, (_lbl("helper"),)),
+                IrInstruction(IrOp.ADD_IMM, (_reg(1), _reg(2), _imm(0))),
+                IrInstruction(IrOp.RET, ()),
+                IrInstruction(IrOp.LABEL, (_lbl("main"),)),
+                # Local call to 'helper':
+                IrInstruction(IrOp.LOAD_IMM, (_reg(2), _imm(5))),
+                IrInstruction(IrOp.CALL, (_lbl("helper"),)),
+                # Cross-module call to 'ext/mod/fn':
+                IrInstruction(IrOp.LOAD_IMM, (_reg(2), _imm(3))),
+                IrInstruction(IrOp.CALL, (_lbl("ext/mod/fn"),)),
+                IrInstruction(IrOp.ADD, (_reg(1), _reg(1), _reg(1))),
+                IrInstruction(IrOp.RET, ()),
+            ],
+        )
+        artifact = lower_ir_to_cil_bytecode(
+            prog,
+            CILBackendConfig(
+                call_register_count=None,
+                external_method_tokens={"ext/mod/fn": 0x06000009},
+            ),
+        )
+        # 'helper' and 'main' are local callables; 'ext/mod/fn' is external.
+        assert "helper" in artifact.callable_labels
+        assert "main" in artifact.callable_labels
+        assert "ext/mod/fn" not in artifact.callable_labels
+
+
+# ---------------------------------------------------------------------------
+# Combined: extra_callable_labels + external_method_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestExtraCallableAndExternalTokensTogether:
+    """Verify both fields work correctly in combination (dep module scenario)."""
+
+    def test_dep_module_with_exports_and_calls_to_entry(self) -> None:
+        """Dep module exports 'add', 'sub'; entry module uses a cross-module token."""
+        # Dep module program: exports add + sub; no local cross-module calls.
+        dep_prog = IrProgram(
+            entry_label="main",
+            instructions=[
+                IrInstruction(IrOp.LABEL, (_lbl("main"),)),
+                IrInstruction(IrOp.LOAD_IMM, (_reg(1), _imm(0))),
+                IrInstruction(IrOp.RET, ()),
+                IrInstruction(IrOp.LABEL, (_lbl("add"),)),
+                IrInstruction(IrOp.ADD, (_reg(1), _reg(2), _reg(3))),
+                IrInstruction(IrOp.RET, ()),
+                IrInstruction(IrOp.LABEL, (_lbl("sub"),)),
+                IrInstruction(IrOp.SUB, (_reg(1), _reg(2), _reg(3))),
+                IrInstruction(IrOp.RET, ()),
+            ],
+        )
+        # Compile dep module with offset=2 (entry module has 2 main methods)
+        dep_artifact = lower_ir_to_cil_bytecode(
+            dep_prog,
+            CILBackendConfig(
+                call_register_count=None,
+                extra_callable_labels=("add", "sub"),
+            ),
+            token_provider=SequentialCILTokenProvider(
+                ("main", "add", "sub"),
+                method_token_offset=2,
+            ),
+        )
+        # dep module has 3 methods (main, add, sub) all starting at offset 2:
+        # main → 0x06000003, add → 0x06000004, sub → 0x06000005
+        assert "add" in dep_artifact.callable_labels
+        assert "sub" in dep_artifact.callable_labels
+        assert len(dep_artifact.callable_labels) == 3
+
+    def test_entry_module_calling_dep_module(self) -> None:
+        """Entry module calls dep module 'a_math/add' via external token."""
+        entry_prog = IrProgram(
+            entry_label="main",
+            instructions=[
+                IrInstruction(IrOp.LABEL, (_lbl("main"),)),
+                IrInstruction(IrOp.LOAD_IMM, (_reg(2), _imm(40))),
+                IrInstruction(IrOp.LOAD_IMM, (_reg(3), _imm(2))),
+                IrInstruction(IrOp.CALL, (_lbl("a/math/add"),)),
+                IrInstruction(IrOp.ADD_IMM, (_reg(1), _reg(1), _imm(0))),
+                IrInstruction(IrOp.RET, ()),
+            ],
+        )
+        # Token for "a/math/add": dep module's 'add' is at row 2 (offset=1):
+        # entry has 1 method (main → row 1), dep add → row 2 → token 0x06000002
+        artifact = lower_ir_to_cil_bytecode(
+            entry_prog,
+            CILBackendConfig(
+                call_register_count=None,
+                external_method_tokens={"a/math/add": 0x06000002},
+            ),
+            token_provider=SequentialCILTokenProvider(
+                ("main",),
+                method_token_offset=0,
+            ),
+        )
+        body = artifact.entry_method.body
+        # 'call 0x06000002' should appear in the body
+        target = (0x06000002).to_bytes(4, "little")
+        found = any(
+            body[i] == 0x28 and body[i + 1:i + 5] == target
+            for i in range(len(body) - 4)
+        )
+        assert found

--- a/code/packages/python/twig-clr-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-clr-compiler/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog — twig-clr-compiler
 
+## 0.7.0 — 2026-05-04 — Phase 4e multi-module CLR compilation + Phase 4c host calls
+
+### Added — `compile_modules` and `run_modules`
+
+New API for compiling and executing multi-module Twig programs on the CLR:
+
+```python
+from twig_clr_compiler import compile_modules, run_modules
+
+result = compile_modules(resolved_modules, entry_module="user/hello")
+# result.assembly_bytes — single PE file containing all modules as TypeDefs
+# result.module_results — list of ModuleClrCompileResult, entry first
+# result.entry_type_name — CLR type name derived from entry module name
+
+exec_result = run_modules(resolved_modules, entry_module="user/hello")
+# exec_result.returncode  — dotnet process exit code
+# exec_result.stdout / .stderr
+```
+
+Each non-host Twig module maps to one TypeDef in the PE assembly.  The
+entry module's TypeDef uses `main` as the entry point; dep modules'
+TypeDefs expose their exported functions as static methods called from
+the entry module via `call` instructions with stable MethodDef tokens.
+
+### Added — `module_name_to_clr_type`
+
+Helper that replaces `/` with `_` in module names for CLR type names:
+`"user/hello"` → `"user_hello"`.
+
+### Added — `MultiModuleClrResult` and `ModuleClrCompileResult`
+
+Frozen dataclasses returned by `compile_modules`:
+- `MultiModuleClrResult.module_results` — `list[ModuleClrCompileResult]`
+  with the entry module first
+- `ModuleClrCompileResult.callable_names` — set of exported function names
+- `ModuleClrCompileResult.artifact` — `CILProgramArtifact` for introspection
+
+### Fixed — inline host calls
+
+`compile_source` and `compile_modules` now pass
+`inline_host_syscalls=True` to the CIL backend, so `host/write-byte`,
+`host/read-byte`, and `host/exit` emit direct `System.Console.Write`,
+`System.Console.Read`, and `System.Environment.Exit` calls instead of
+the brainfuck-only `__ca_syscall` external helper.  Previously any Twig
+program using `(import host)` would crash with `TypeLoadException`.
+
+### Fixed — local_count floor for cross-module calls
+
+When compiling multiple modules, `compile_modules` computes
+`global_local_count` (the maximum local count across all modules) and
+passes it as `call_register_count` to every module's backend config.
+A floor in `_analyze_program` ensures every module declares at least
+that many locals, preventing `InvalidProgramException` when the entry
+module has fewer registers than `global_local_count`.
+
+### Acceptance criterion (TW04 Phase 4e)
+
+```
+(a/math/add 17 25)  →  exit code 42
+```
+
+All 99 tests pass on net9.0, including recursive dep-module functions,
+three-module chains, and host-call + dep-module combinations.
+
 ## 0.6.0 — 2026-04-29 — multi-arity closures
 
 Multi-arg lambdas like `(lambda (x y) (+ x y))` now run on real

--- a/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
+++ b/code/packages/python/twig-clr-compiler/src/twig_clr_compiler/compiler.py
@@ -77,8 +77,11 @@ from compiler_ir import (
 from ir_optimizer import IrOptimizer, OptimizationResult
 from ir_to_cil_bytecode import (
     CILBackendConfig,
+    CILProgramArtifact,
+    CILTypeArtifact,
     lower_ir_to_cil_bytecode,
 )
+from ir_to_cil_bytecode.backend import SequentialCILTokenProvider
 from twig import (
     TwigCompileError,
     TwigError,
@@ -101,6 +104,7 @@ from twig.ast_nodes import (
     VarRef,
 )
 from twig.free_vars import free_vars
+from twig.module_resolver import HOST_MODULE_NAME, ResolvedModule
 
 # ---------------------------------------------------------------------------
 # Result types
@@ -505,13 +509,25 @@ class _Compiler:
             # by ``__ca_syscall`` for num=2.
             _slash = name.find("/")
             if _slash > 0 and _slash < len(name) - 1:
-                # Module-qualified host call (``host/write-byte`` etc.)
+                # Module-qualified call — ``host/write-byte`` or a user-module
+                # cross-call like ``a/math/add``.
                 num = _HOST_SYSCALLS.get(name)
                 if num is None:
-                    raise TwigCompileError(
-                        f"unknown host call {name!r} — "
-                        "supported: " + ", ".join(sorted(_HOST_SYSCALLS))
-                    )
+                    # TW04 Phase 4e: user-module cross-call.  Emit
+                    # ``IrOp.CALL IrLabel(name)`` with args marshalled
+                    # into param slots first.  The IR label contains
+                    # ``/`` so the CIL backend recognises it as a
+                    # cross-module call and resolves it via
+                    # ``config.external_method_tokens`` at lowering time.
+                    xm_arg_regs = [
+                        self._compile_expr(a, ctx) for a in expr.args
+                    ]
+                    for i, src in enumerate(xm_arg_regs):
+                        self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
+                    self._emit(IrOp.CALL, IrLabel(name))
+                    dest = self._fresh_holding(ctx)
+                    self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
+                    return dest
                 scratch = IrRegister(_CLR_SYSCALL_ARG_REG)
                 if num == 2:  # read-byte — no user arg, result into fresh reg
                     dest = self._fresh_holding(ctx)
@@ -808,6 +824,10 @@ def compile_source(
                 # backend to read the syscall arg from that register so
                 # it matches the JVM convention and the compiler's intent.
                 syscall_arg_reg=_CLR_SYSCALL_ARG_REG,
+                # TW04 Phase 4c: use inline .NET API calls for SYSCALL 1/2/10
+                # (Console.Write / Console.Read / Environment.Exit) instead of
+                # the brainfuck-specific __ca_syscall external helper.
+                inline_host_syscalls=True,
             ),
         )
     except Exception as exc:
@@ -895,6 +915,467 @@ def run_source(
             check=False,
         )
     return ClrRunResult(
+        compilation=compilation,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        returncode=proc.returncode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TW04 Phase 4e — multi-module CLR compilation
+# ---------------------------------------------------------------------------
+#
+# Each Twig module (excluding the synthetic ``host`` module) becomes one
+# TypeDef row in a **single** PE/CLI assembly.  Cross-module function calls
+# lower to ordinary CIL ``call`` instructions addressed by pre-assigned
+# MethodDef tokens in the combined assembly.
+#
+# Why one assembly (not one PE per module)?
+# -----------------------------------------
+# CLR cross-assembly calls require ``AssemblyRef`` + ``MemberRef`` tokens
+# which ``cli-assembly-writer`` does not yet support.  Packing all modules
+# into one PE lets every ``call`` instruction use a simple ``MethodDef``
+# token (``0x06xxxxxx``) — the same kind used for same-TypeDef calls.
+#
+# CLR type naming
+# ---------------
+# CLR type names may not contain ``/``.  We replace every ``/`` in the
+# Twig module name with ``_`` to produce a valid CLR identifier:
+# ``"a/math"`` → ``"a_math"``, ``"user/hello"`` → ``"user_hello"``.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModuleClrCompileResult:
+    """Per-module artefact from a multi-module CLR compile run.
+
+    ``type_name`` is the CLR TypeDef name for this module's methods in the
+    combined assembly (``module_name_to_clr_type(module_name)``).
+    ``callable_names`` lists the emitted method names in IR label-position
+    order — used by callers to reconstruct the MethodDef token layout.
+    """
+
+    module_name: str
+    type_name: str
+    ir: IrProgram
+    artifact: CILProgramArtifact
+    callable_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MultiModuleClrResult:
+    """Combined artefact from compiling a complete Twig module graph to CLR.
+
+    ``assembly_bytes`` is a single PE/CLI ``.exe`` containing one TypeDef
+    per Twig module.  ``entry_type_name`` is the TypeDef that owns the
+    ``.entrypoint`` method.
+    """
+
+    entry_module: str
+    module_results: tuple[ModuleClrCompileResult, ...]
+    assembly_bytes: bytes
+    entry_type_name: str
+
+
+@dataclass(frozen=True)
+class MultiModuleClrExecutionResult:
+    """Compile + real-``dotnet`` execution result for a multi-module program."""
+
+    compilation: MultiModuleClrResult
+    stdout: bytes
+    stderr: bytes
+    returncode: int
+
+
+def module_name_to_clr_type(name: str) -> str:
+    """Map a Twig module name to a CLR type name.
+
+    CLR type names may not contain ``/``.  We replace every occurrence with
+    ``_`` so ``"a/math"`` becomes ``"a_math"`` and ``"user/hello"`` becomes
+    ``"user_hello"``.  The mapping is injective for all legal Twig module
+    names.
+
+    Example::
+
+        >>> module_name_to_clr_type("user/hello")
+        'user_hello'
+        >>> module_name_to_clr_type("a/math")
+        'a_math'
+    """
+    return name.replace("/", "_")
+
+
+def _compile_module_to_ir(
+    module: ResolvedModule,
+) -> tuple[IrProgram, list[tuple[str, list[str], Lambda]], IrProgram]:
+    """Compile a resolved Twig module to raw IR, lifted lambdas, optimised IR.
+
+    Returns ``(raw_ir, lifted_lambdas, optimized_ir)``.  The lifted-lambdas
+    list mirrors what ``_Compiler._lifted_lambdas`` accumulates and is used
+    to build ``closure_free_var_counts`` for the CIL backend.
+    """
+    compiler = _Compiler()
+    raw_ir = compiler.compile(module.program)
+    optimization = IrOptimizer.default_passes().optimize(raw_ir)
+    return raw_ir, list(compiler._lifted_lambdas), optimization.program  # noqa: SLF001
+
+
+def _discover_module_callable_names(
+    optimized_ir: IrProgram,
+    lifted_lambdas: list[tuple[str, list[str], Lambda]],
+    exports: list[str],
+) -> tuple[str, ...]:
+    """Return the main-type callable method names for a module's IR program.
+
+    The "main-type" callables are all callable regions *minus* lifted-lambda
+    (closure) regions.  They are ordered by their label position in the IR
+    instruction stream, which matches the MethodDef table row order that the
+    assembly writer emits.
+
+    ``exports`` are included even when no local CALL targets them (they are
+    only called from OTHER modules).
+
+    Phase 4e restriction: dep modules must not contain closures.  The entry
+    module's closures are handled separately during token assignment.
+    """
+    # Names of lifted lambda regions (closure bodies).
+    closure_region_names: set[str] = {name for name, _, _ in lifted_lambdas}
+
+    # Scan label positions in IR instruction order.
+    label_positions: dict[str, int] = {}
+    for i, instr in enumerate(optimized_ir.instructions):
+        if instr.opcode == IrOp.LABEL:
+            label_positions[instr.operands[0].name] = i  # type: ignore[union-attr]
+
+    # Seed with the entry label and any local CALL targets.
+    callable_names: set[str] = {optimized_ir.entry_label}
+    for instr in optimized_ir.instructions:
+        if instr.opcode == IrOp.CALL:
+            target_name = instr.operands[0].name  # type: ignore[union-attr]
+            if "/" not in target_name:
+                callable_names.add(target_name)
+        elif instr.opcode == IrOp.MAKE_CLOSURE:
+            target_name = instr.operands[1].name  # type: ignore[union-attr]
+            callable_names.add(target_name)
+
+    # Include exports — they are only called cross-module so they have no
+    # local CALL callers.
+    for exp in exports:
+        if exp in label_positions:
+            callable_names.add(exp)
+
+    # Filter out closure regions; sort by IR position.
+    main_callables = callable_names - closure_region_names
+    return tuple(
+        sorted(main_callables, key=lambda n: label_positions.get(n, 0))
+    )
+
+
+def compile_modules(
+    modules: list[ResolvedModule],
+    *,
+    entry_module: str,
+    assembly_name: str = "TwigProgram",
+) -> MultiModuleClrResult:
+    """Compile a topologically ordered list of resolved Twig modules to a
+    single CLR PE/CLI assembly.
+
+    ``modules`` should be the list returned by ``twig.resolve_modules`` (in
+    dependency-first topological order).  ``entry_module`` names the module
+    whose ``main`` function becomes the assembly's entry point.  The synthetic
+    ``host`` module is silently skipped.
+
+    **Phase 4e restriction**: dependency modules must not contain closures or
+    heap primitives.  These extensions are reserved for a future phase.
+
+    The function uses a two-pass approach:
+
+    **Pass 1** — compile each module's Twig source to IR, discover each
+    module's main-type callable names, and compute cumulative MethodDef token
+    offsets.
+
+    **Pass 2** — recompile each module to a ``CILProgramArtifact`` using a
+    ``SequentialCILTokenProvider`` with the correct ``method_token_offset``
+    and ``CILBackendConfig.external_method_tokens`` populated from Pass 1.
+
+    The entry module becomes the main TypeDef (row 2) in the combined
+    assembly; each dep module becomes an extra TypeDef row.
+    """
+    _validate_assembly_name(assembly_name)
+
+    # Skip the synthetic host module — it has no IR to compile.
+    real_modules = [m for m in modules if m.name != HOST_MODULE_NAME]
+    if not real_modules:
+        raise ClrPackageError(
+            "compile-modules",
+            "no real modules found (only host module present)",
+        )
+
+    # Reorder: entry module first, then deps in the order they appear.
+    try:
+        entry_mod = next(m for m in real_modules if m.name == entry_module)
+    except StopIteration:
+        raise ClrPackageError(
+            "compile-modules",
+            f"entry module {entry_module!r} not found in modules list",
+        ) from None
+    dep_mods = [m for m in real_modules if m.name != entry_module]
+    # Topological order: deps before entry (from resolve_modules), but we want
+    # entry first so its methods get the lowest MethodDef token numbers.
+    ordered: list[ResolvedModule] = [entry_mod] + dep_mods
+
+    # ── Pass 1: compile each module to IR, discover callable names ────────
+
+    # Per-module: (raw_ir, lifted_lambdas, optimized_ir)
+    _IrTriple = tuple[IrProgram, list[tuple[str, list[str], Lambda]], IrProgram]
+    module_irs: dict[str, _IrTriple] = {}
+    # Ordered callable names for the main TypeDef of each module.
+    module_callables: dict[str, tuple[str, ...]] = {}
+
+    for mod in ordered:
+        raw_ir, lifted, opt_ir = _compile_module_to_ir(mod)
+        module_irs[mod.name] = (raw_ir, lifted, opt_ir)
+        mod_decl = mod.program.module
+        exports = list(mod_decl.exports) if mod_decl else []
+        callables = _discover_module_callable_names(opt_ir, lifted, exports)
+        module_callables[mod.name] = callables
+
+    # ── Shared call_register_count ────────────────────────────────────────
+    #
+    # CIL methods declare their parameter count in the method signature.
+    # A cross-module ``call`` pushes exactly ``call_register_count`` arguments.
+    # If each module used its own local_count (derived from its own max
+    # register index), the entry module (which has many more holding registers
+    # than dep modules) would push MORE arguments than the dep method declares
+    # — causing a ``System.InvalidProgramException`` at runtime.
+    #
+    # The fix: compute the global maximum local_count across ALL modules and
+    # use it as ``call_register_count`` for every module.  Dep module methods
+    # end up declaring more parameters than they strictly need, but the extra
+    # parameter slots are simply never read — this is harmless.
+    #
+    # local_count = max(max_reg_index + 1, syscall_arg_reg + 1, 2)
+    # We use ``_CLR_SYSCALL_ARG_REG = 0``, so the floor is 2.
+    global_local_count = 2
+    for mod in ordered:
+        _, _, opt_ir = module_irs[mod.name]
+        max_reg = -1
+        for instr in opt_ir.instructions:
+            for operand in instr.operands:
+                if isinstance(operand, IrRegister):
+                    max_reg = max(max_reg, operand.index)
+        mod_local_count = max(max_reg + 1, _CLR_SYSCALL_ARG_REG + 1, 2)
+        global_local_count = max(global_local_count, mod_local_count)
+
+    # ── Assign cumulative MethodDef token offsets ─────────────────────────
+    #
+    # Entry module callables: rows 1..M_entry          (offset 0)
+    # Entry module closure rows: rows M_entry+1..      (1 + 2*K)
+    # Dep 1 callables: rows after entry module total   (offset = entry total)
+    # Dep 2 callables: rows after entry + dep 1 total
+    #
+    # Helper / MemberRef tokens (0x0Axxxxxx) are unaffected — they always
+    # start at 0x0A000001 in every module's token provider and map to the
+    # SAME five MemberRef rows in the combined assembly.
+
+    module_token_offset: dict[str, int] = {}
+    running_offset = 0
+    for mod in ordered:
+        module_token_offset[mod.name] = running_offset
+        running_offset += len(module_callables[mod.name])
+        # Entry module closure rows (Phase 4e: only entry module may have closures).
+        if mod.name == entry_module:
+            _, lifted, _ = module_irs[mod.name]
+            num_closures = len(lifted)
+            if num_closures:
+                # IClosure::Apply (1 row) + per-closure (.ctor + Apply = 2 rows each)
+                running_offset += 1 + 2 * num_closures
+
+    # ── Build all_external_tokens: for each module, the qualified label →
+    # pre-assigned MethodDef token of every OTHER module's callable. ───────
+    #
+    # A dep-module callable ``add`` with module name ``a/math`` is
+    # referenced in a CALL instruction as ``IrLabel("a/math/add")`` — the
+    # module name, a ``/`` separator, then the function name.  The token is
+    # ``0x06000000 | (offset + row_within_module)``.
+
+    all_external_tokens: dict[str, dict[str, int]] = {
+        mod.name: {} for mod in ordered
+    }
+    for dep in ordered:
+        dep_offset = module_token_offset[dep.name]
+        for i, callable_name in enumerate(module_callables[dep.name]):
+            qualified = f"{dep.name}/{callable_name}"
+            token = 0x06000001 + dep_offset + i - 1  # 1-indexed row
+            # Correct: 0x06000001 + dep_offset means row (dep_offset+1).
+            # But row indexing: entry offset=0 → row 1 = 0x06000001 + 0.
+            # dep_offset=M_entry → row M_entry+1 = 0x06000001 + M_entry.
+            token = 0x06000000 | (dep_offset + 1 + i)
+            for other in ordered:
+                if other.name != dep.name:
+                    all_external_tokens[other.name][qualified] = token
+
+    # ── Pass 2: compile each module to CILProgramArtifact ────────────────
+
+    module_results: list[ModuleClrCompileResult] = []
+
+    for mod in ordered:
+        raw_ir, lifted, opt_ir = module_irs[mod.name]
+        is_entry = mod.name == entry_module
+        offset = module_token_offset[mod.name]
+        callables = module_callables[mod.name]
+        ext_tokens = all_external_tokens[mod.name]
+
+        closure_free_var_counts: dict[str, int] = {}
+        closure_explicit_arities: dict[str, int] = {}
+        if is_entry:
+            for lifted_name, captures, lam in lifted:
+                closure_free_var_counts[lifted_name] = len(captures)
+                closure_explicit_arities[lifted_name] = len(lam.params)
+
+        mod_decl = mod.program.module
+        exports = list(mod_decl.exports) if mod_decl else []
+
+        # Build a provider that starts at the right MethodDef row for this
+        # module.  The entry module uses offset=0 (rows start at 1); dep
+        # modules use their cumulative offset.
+        closure_names: tuple[str, ...] = tuple(
+            n for n, _, _ in lifted
+        ) if is_entry else ()
+        provider = SequentialCILTokenProvider(
+            callables,
+            method_token_offset=offset,
+            closure_names=closure_names,
+            closure_free_var_counts=closure_free_var_counts,
+        )
+
+        try:
+            artifact = lower_ir_to_cil_bytecode(
+                opt_ir,
+                CILBackendConfig(
+                    # TW04 Phase 4e: use the global shared call_register_count
+                    # so all modules declare the same parameter count.  See
+                    # the "Shared call_register_count" comment above.
+                    call_register_count=global_local_count,
+                    closure_free_var_counts=closure_free_var_counts,
+                    closure_explicit_arities=closure_explicit_arities,
+                    syscall_arg_reg=_CLR_SYSCALL_ARG_REG,
+                    extra_callable_labels=tuple(exports),
+                    external_method_tokens=ext_tokens,
+                    # TW04 Phase 4c: use inline .NET API calls for host syscalls
+                    # so SYSCALL 1/2/10 work on real dotnet without a helper lib.
+                    inline_host_syscalls=True,
+                ),
+                token_provider=provider,
+            )
+        except Exception as exc:
+            raise ClrPackageError(
+                "lower-cil",
+                f"module {mod.name!r}: {exc}",
+                exc,
+            ) from exc
+
+        module_results.append(
+            ModuleClrCompileResult(
+                module_name=mod.name,
+                type_name=module_name_to_clr_type(mod.name),
+                ir=opt_ir,
+                artifact=artifact,
+                callable_names=callables,
+            )
+        )
+
+    # ── Merge into one CILProgramArtifact ────────────────────────────────
+    #
+    # Entry module's artifact becomes the "main" artifact (methods → main
+    # TypeDef).  Each dep module's methods are packaged as a CILTypeArtifact
+    # in ``extra_types``.  The assembly writer emits them in declaration order,
+    # which matches our cumulative MethodDef token assignment.
+
+    entry_result = module_results[0]
+    dep_results = module_results[1:]
+
+    # Start with the entry module's extra_types (closures, heap types).
+    merged_extra_types = list(entry_result.artifact.extra_types)
+
+    for dep_result in dep_results:
+        type_name = dep_result.type_name
+        dep_methods = dep_result.artifact.methods
+        merged_extra_types.append(
+            CILTypeArtifact(
+                name=type_name,
+                namespace="",
+                is_interface=False,
+                extends="System.Object",
+                implements=(),
+                fields=(),
+                methods=dep_methods,
+            )
+        )
+
+    # Build the combined artifact by replacing extra_types on the entry artifact.
+    from dataclasses import replace as _dc_replace
+
+    combined_artifact = _dc_replace(
+        entry_result.artifact,
+        extra_types=tuple(merged_extra_types),
+    )
+
+    try:
+        cli_config = CLIAssemblyConfig(
+            assembly_name=assembly_name,
+            module_name=f"{assembly_name}.exe",
+            type_name=entry_result.type_name,
+        )
+        written = write_cli_assembly(combined_artifact, cli_config)
+    except Exception as exc:
+        raise ClrPackageError("write-pe", str(exc), exc) from exc
+
+    return MultiModuleClrResult(
+        entry_module=entry_module,
+        module_results=tuple(module_results),
+        assembly_bytes=written.assembly_bytes,
+        entry_type_name=entry_result.type_name,
+    )
+
+
+def run_modules(
+    modules: list[ResolvedModule],
+    *,
+    entry_module: str,
+    assembly_name: str = "TwigProgram",
+    timeout_seconds: int = 30,
+) -> MultiModuleClrExecutionResult:
+    """Compile and execute a multi-module Twig program on the real ``dotnet``
+    runtime.
+
+    Calls ``compile_modules``, writes the single ``.exe`` to a temp directory
+    alongside its ``runtimeconfig.json``, runs ``dotnet <name>.exe``, and
+    returns the result.
+
+    The process **exit code** is the program's return value (same convention
+    as single-module ``run_source``).
+    """
+    compilation = compile_modules(
+        modules,
+        entry_module=entry_module,
+        assembly_name=assembly_name,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        exe_path = tmp_path / f"{assembly_name}.exe"
+        cfg_path = tmp_path / f"{assembly_name}.runtimeconfig.json"
+        exe_path.write_bytes(compilation.assembly_bytes)
+        cfg_path.write_text(_runtimeconfig_for_net9())
+
+        proc = subprocess.run(
+            ["dotnet", str(exe_path)],
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    return MultiModuleClrExecutionResult(
         compilation=compilation,
         stdout=proc.stdout,
         stderr=proc.stderr,

--- a/code/packages/python/twig-clr-compiler/tests/test_multi_module_clr.py
+++ b/code/packages/python/twig-clr-compiler/tests/test_multi_module_clr.py
@@ -1,0 +1,390 @@
+"""Tests for TW04 Phase 4e — multi-module CLR compilation.
+
+These tests verify that ``compile_modules`` and ``run_modules`` correctly:
+
+* Produce a ``MultiModuleClrResult`` with one ``ModuleClrCompileResult``
+  per non-``host`` Twig module.
+* Emit the entry module's methods into the main TypeDef and dep modules'
+  methods into extra TypeDef rows.
+* Emit cross-module ``IrOp.CALL IrLabel("a/math/add")`` in the entry
+  module's IR.
+* Actually run on the real .NET runtime when available, yielding the
+  correct exit code (the Phase 4e acceptance criterion).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from compiler_ir import IrLabel, IrOp
+from twig import resolve_modules
+
+from twig_clr_compiler import dotnet_available
+from twig_clr_compiler.compiler import (
+    MultiModuleClrExecutionResult,
+    MultiModuleClrResult,
+    ModuleClrCompileResult,
+    compile_modules,
+    module_name_to_clr_type,
+    run_modules,
+)
+
+# ---------------------------------------------------------------------------
+# Skip marker for tests that require real dotnet
+# ---------------------------------------------------------------------------
+
+requires_dotnet = pytest.mark.skipif(
+    not dotnet_available(),
+    reason="dotnet not on PATH",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def two_module_dir(tmp_path: Path) -> Path:
+    """Write the two-module acceptance-criterion program to a temp directory.
+
+    Files::
+
+        a/math.tw — exports ``add`` and ``sub``
+        user/hello.tw — imports ``a/math``, evaluates ``(a/math/add 17 25)``
+
+    The result is 42, which becomes the process exit code.
+    """
+    (tmp_path / "a").mkdir()
+    (tmp_path / "user").mkdir()
+    (tmp_path / "a" / "math.tw").write_text(
+        "(module a/math (export add sub))\n"
+        "(define (add x y) (+ x y))\n"
+        "(define (sub x y) (- x y))\n"
+    )
+    (tmp_path / "user" / "hello.tw").write_text(
+        "(module user/hello (import a/math))\n"
+        "(a/math/add 17 25)\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def three_module_dir(tmp_path: Path) -> Path:
+    """Three-module program: ``a/math``, ``b/utils``, ``user/main``.
+
+    ``user/main`` calls both dep modules.  Final result = 10 + 5 = 15.
+    """
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "user").mkdir()
+    (tmp_path / "a" / "math.tw").write_text(
+        "(module a/math (export add))\n"
+        "(define (add x y) (+ x y))\n"
+    )
+    (tmp_path / "b" / "utils.tw").write_text(
+        "(module b/utils (export double))\n"
+        "(define (double x) (* x 2))\n"
+    )
+    (tmp_path / "user" / "main.tw").write_text(
+        "(module user/main (import a/math) (import b/utils))\n"
+        "(a/math/add (b/utils/double 5) 5)\n"  # (5*2) + 5 = 15
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def host_call_dir(tmp_path: Path) -> Path:
+    """Single entry module that uses ``host/write-byte`` to emit a byte."""
+    (tmp_path / "user").mkdir()
+    (tmp_path / "user" / "io.tw").write_text(
+        "(module user/io (import host))\n"
+        "(host/write-byte 65)\n"  # 'A'
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def host_and_dep_dir(tmp_path: Path) -> Path:
+    """Entry module uses both ``host/write-byte`` and a dep module function."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "user").mkdir()
+    (tmp_path / "a" / "math.tw").write_text(
+        "(module a/math (export add))\n"
+        "(define (add x y) (+ x y))\n"
+    )
+    (tmp_path / "user" / "hello.tw").write_text(
+        "(module user/hello (import host) (import a/math))\n"
+        "(host/write-byte (a/math/add 10 32))\n"  # write byte 42
+    )
+    return tmp_path
+
+
+def _resolve(entry: str, search_dir: Path):
+    return resolve_modules(entry, search_paths=[search_dir])
+
+
+# ---------------------------------------------------------------------------
+# module_name_to_clr_type
+# ---------------------------------------------------------------------------
+
+
+class TestModuleNameToClrType:
+    """``module_name_to_clr_type`` replaces ``/`` with ``_``."""
+
+    def test_single_slash(self) -> None:
+        assert module_name_to_clr_type("user/hello") == "user_hello"
+
+    def test_double_slash(self) -> None:
+        assert module_name_to_clr_type("a/b/c") == "a_b_c"
+
+    def test_no_slash(self) -> None:
+        assert module_name_to_clr_type("mymodule") == "mymodule"
+
+    def test_dep_module_name(self) -> None:
+        assert module_name_to_clr_type("a/math") == "a_math"
+
+    def test_user_module_name(self) -> None:
+        assert module_name_to_clr_type("user/main") == "user_main"
+
+
+# ---------------------------------------------------------------------------
+# compile_modules — structural tests (no dotnet needed)
+# ---------------------------------------------------------------------------
+
+
+class TestCompileModules:
+    """``compile_modules`` returns a correctly structured ``MultiModuleClrResult``."""
+
+    def test_returns_multi_module_clr_result(
+        self, two_module_dir: Path
+    ) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        assert isinstance(result, MultiModuleClrResult)
+
+    def test_two_module_results(self, two_module_dir: Path) -> None:
+        """Two real modules → two ``ModuleClrCompileResult`` entries."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        # host module is excluded; only a/math and user/hello
+        assert len(result.module_results) == 2
+
+    def test_entry_module_first(self, two_module_dir: Path) -> None:
+        """The entry module is always the first element in ``module_results``."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        assert result.module_results[0].module_name == "user/hello"
+        assert result.entry_module == "user/hello"
+
+    def test_dep_module_second(self, two_module_dir: Path) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        assert result.module_results[1].module_name == "a/math"
+
+    def test_entry_type_name(self, two_module_dir: Path) -> None:
+        """Entry module type name is derived from ``module_name_to_clr_type``."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        assert result.entry_type_name == "user_hello"
+
+    def test_module_compile_results_are_frozen_dataclasses(
+        self, two_module_dir: Path
+    ) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        for mr in result.module_results:
+            assert isinstance(mr, ModuleClrCompileResult)
+
+    def test_assembly_bytes_are_nonempty(self, two_module_dir: Path) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        assert len(result.assembly_bytes) > 0
+
+    def test_assembly_starts_with_mz_header(self, two_module_dir: Path) -> None:
+        """The PE file starts with the standard MZ signature."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        assert result.assembly_bytes[:2] == b"MZ"
+
+    def test_dep_module_exports_in_callable_names(
+        self, two_module_dir: Path
+    ) -> None:
+        """Dep module's exported functions appear in its callable_names."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        dep_result = next(
+            r for r in result.module_results if r.module_name == "a/math"
+        )
+        assert "add" in dep_result.callable_names
+        assert "sub" in dep_result.callable_names
+
+    def test_three_module_dir_results(self, three_module_dir: Path) -> None:
+        """Three-module compile yields three ModuleClrCompileResult entries."""
+        modules = _resolve("user/main", three_module_dir)
+        result = compile_modules(modules, entry_module="user/main")
+        assert len(result.module_results) == 3
+
+    def test_host_module_excluded(self, host_call_dir: Path) -> None:
+        """The synthetic ``host`` module does not appear in module_results."""
+        modules = _resolve("user/io", host_call_dir)
+        result = compile_modules(modules, entry_module="user/io")
+        names = [r.module_name for r in result.module_results]
+        assert "host" not in names
+
+    def test_cross_module_call_in_ir(self, two_module_dir: Path) -> None:
+        """Entry module IR contains ``IrOp.CALL IrLabel("a/math/add")``."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        entry_result = result.module_results[0]
+        instructions = list(entry_result.ir.instructions)
+        cross_calls = [
+            instr
+            for instr in instructions
+            if instr.opcode == IrOp.CALL
+            and isinstance(instr.operands[0], IrLabel)
+            and "/" in instr.operands[0].name
+        ]
+        assert len(cross_calls) >= 1
+        label_name = cross_calls[0].operands[0].name
+        assert label_name == "a/math/add"
+
+    def test_dep_module_ir_has_add_and_sub_regions(
+        self, two_module_dir: Path
+    ) -> None:
+        """Dep module IR contains LABEL instructions for ``add`` and ``sub``."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        dep_result = next(
+            r for r in result.module_results if r.module_name == "a/math"
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in dep_result.ir.instructions
+            if instr.opcode == IrOp.LABEL
+            and isinstance(instr.operands[0], IrLabel)
+        ]
+        assert "add" in labels
+        assert "sub" in labels
+
+    def test_invalid_entry_module_raises(self, two_module_dir: Path) -> None:
+        """Referencing a non-existent entry module raises ``ClrPackageError``."""
+        from twig_clr_compiler.compiler import ClrPackageError
+        modules = _resolve("user/hello", two_module_dir)
+        with pytest.raises(ClrPackageError, match="entry module"):
+            compile_modules(modules, entry_module="nonexistent/mod")
+
+    def test_host_and_dep_module_together(self, host_and_dep_dir: Path) -> None:
+        """Entry module can use both host calls and dep module calls."""
+        modules = _resolve("user/hello", host_and_dep_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        assert len(result.module_results) == 2
+        assert result.assembly_bytes[:2] == b"MZ"
+
+    def test_dep_module_artifact_methods_non_empty(
+        self, two_module_dir: Path
+    ) -> None:
+        """Dep module's CILProgramArtifact contains at least the exported methods."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, entry_module="user/hello")
+        dep_result = next(
+            r for r in result.module_results if r.module_name == "a/math"
+        )
+        # artifact.methods includes main + exported add + sub
+        assert len(dep_result.artifact.methods) >= 2
+
+    def test_token_offset_increases_for_each_dep(
+        self, three_module_dir: Path
+    ) -> None:
+        """Each dep module's callable_names are disjoint from the entry module's."""
+        modules = _resolve("user/main", three_module_dir)
+        result = compile_modules(modules, entry_module="user/main")
+        all_callable_tuples = [r.callable_names for r in result.module_results]
+        # All callable name sets per module should be non-empty.
+        for names in all_callable_tuples:
+            assert len(names) >= 1
+
+
+# ---------------------------------------------------------------------------
+# run_modules — end-to-end on real dotnet
+# ---------------------------------------------------------------------------
+
+
+class TestRunModulesOnRealDotnet:
+    """Acceptance tests against the real ``dotnet`` runtime."""
+
+    @requires_dotnet
+    def test_two_module_add_returns_42(self, two_module_dir: Path) -> None:
+        """The headline Phase 4e acceptance criterion.
+
+        ``(a/math/add 17 25)`` in the entry module → exit code 42.
+        """
+        modules = _resolve("user/hello", two_module_dir)
+        result = run_modules(modules, entry_module="user/hello")
+        assert result.returncode == 42, result.compilation.module_results[0].ir
+
+    @requires_dotnet
+    def test_three_module_result_15(self, three_module_dir: Path) -> None:
+        """Three-module program: ``(a/math/add (b/utils/double 5) 5)`` → 15."""
+        modules = _resolve("user/main", three_module_dir)
+        result = run_modules(modules, entry_module="user/main")
+        assert result.returncode == 15, result.compilation.module_results[0].ir
+
+    @requires_dotnet
+    def test_host_write_byte_in_multi_module(
+        self, host_and_dep_dir: Path
+    ) -> None:
+        """Entry module writing a byte via host call in multi-module mode."""
+        modules = _resolve("user/hello", host_and_dep_dir)
+        result = run_modules(
+            modules, entry_module="user/hello", assembly_name="ClrHostAndDep"
+        )
+        # host/write-byte(42) writes byte 42 to stdout; exit code 0 for void syscall
+        assert result.stdout == b"*", f"stderr: {result.stderr}"
+
+    @requires_dotnet
+    def test_run_modules_returns_execution_result_type(
+        self, two_module_dir: Path
+    ) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = run_modules(modules, entry_module="user/hello")
+        assert isinstance(result, MultiModuleClrExecutionResult)
+
+    @requires_dotnet
+    def test_sub_function_from_dep_module(self, tmp_path: Path) -> None:
+        """Verify sub exported from dep module returns correct result (10-3=7)."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "user").mkdir()
+        (tmp_path / "a" / "math.tw").write_text(
+            "(module a/math (export sub))\n"
+            "(define (sub x y) (- x y))\n"
+        )
+        (tmp_path / "user" / "calc.tw").write_text(
+            "(module user/calc (import a/math))\n"
+            "(a/math/sub 10 3)\n"
+        )
+        modules = _resolve("user/calc", tmp_path)
+        result = run_modules(
+            modules, entry_module="user/calc", assembly_name="ClrSub"
+        )
+        assert result.returncode == 7, result.stderr
+
+    @requires_dotnet
+    def test_recursive_function_in_dep_module(self, tmp_path: Path) -> None:
+        """Recursion inside a dep module works across the TypeDef boundary."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "user").mkdir()
+        (tmp_path / "a" / "math.tw").write_text(
+            "(module a/math (export fact))\n"
+            "(define (fact n) (if (= n 0) 1 (* n (fact (- n 1)))))\n"
+        )
+        (tmp_path / "user" / "main.tw").write_text(
+            "(module user/main (import a/math))\n"
+            "(a/math/fact 5)\n"  # 120
+        )
+        modules = _resolve("user/main", tmp_path)
+        result = run_modules(
+            modules, entry_module="user/main", assembly_name="ClrRecursiveDep"
+        )
+        assert result.returncode == 120, result.stderr

--- a/code/specs/TW04-phase4e-clr-module-lowering.md
+++ b/code/specs/TW04-phase4e-clr-module-lowering.md
@@ -1,0 +1,172 @@
+# TW04 Phase 4e — CLR Multi-Module Lowering
+
+## Status: Shipped (2026-05-04)
+
+## Context
+
+Phase 4d shipped per-module JVM compilation: each Twig module compiles to its own
+`.class` file; cross-module `invokestatic` stitches them together at the JVM level.
+
+Phase 4e delivers the equivalent on CLR: every real Twig module (excluding the
+synthetic `host` module) becomes a **TypeDef row inside a single PE/CLI assembly**.
+Cross-module function calls lower to ordinary CIL `call` instructions addressed by the
+callee's MethodDef token in the combined assembly.
+
+## CLR multi-module architecture
+
+### Why one assembly (not one assembly per module)?
+
+CLR cross-assembly calls require `AssemblyRef` + `MemberRef` tokens, which the current
+`cli-assembly-writer` does not support.  Putting all modules' TypeDef rows into a single
+PE file lets every `call` instruction use a simple `MethodDef` token (`0x06xxxxxx`)
+— the same token kind already used for same-type calls.
+
+### TypeDef layout
+
+The PE table rows follow this order:
+
+| TypeDef row | Content |
+|-------------|---------|
+| 1 | `<Module>` pseudo-type (ECMA-335 mandatory) |
+| 2 | Entry module's type (has the `.entrypoint` main method) |
+| 3 | Dep module 1's type |
+| 4 | Dep module 2's type |
+| … | (further dep modules in topological order) |
+
+Each module's type is a plain `class` that extends `System.Object`.  All methods on
+dep-module types are `public static` — the same flags used for the entry-module's
+callables.
+
+### MethodDef layout
+
+Methods are laid out in TypeDef order, then by their position in each module's IR:
+
+```
+MethodDef 1..M_entry   — entry module callables
+MethodDef M_entry+1..  — dep module 1 callables
+                       — dep module 2 callables (etc.)
+```
+
+For Phase 4e, multi-module programs must not contain closures or heap types
+(`cons`/`symbol`/`nil`) inside **dependency** modules.  These features require
+additional TypeDef rows (IClosure, Closure_N, Cons, Symbol, Nil) whose token counts
+must be factored into the offset calculation; that extension is deferred to a later
+phase.  Single-module programs (compiled via `compile_source`) continue to support
+closures and heap types unchanged.
+
+### Helper / MemberRef tokens
+
+Helper methods (`__ca_syscall`, `__ca_mem_load_byte`, etc.) are emitted as `MemberRef`
+rows (`0x0Axxxxxx`), not `MethodDef` rows.  All modules share the same five helper
+specs, so the MemberRef tokens are identical across modules and no offset adjustment is
+needed.
+
+## IR calling convention
+
+The Twig frontend emits `IrOp.CALL IrLabel("mod/fn")` for a cross-module call to
+function `fn` in module `mod`.  The label string contains `/` to distinguish it from
+local same-module calls (which never contain `/`).
+
+In the CIL backend, a CALL instruction whose label contains `/`:
+
+1. Looks up the pre-assigned token in `CILBackendConfig.external_method_tokens`
+2. Marshals all call-register-count locals onto the operand stack (`ldloc 0..N`)
+3. Emits `call <token>`
+4. Stores the return value into local 1 (`stloc 1`)
+
+## New `CILBackendConfig` fields (ir-to-cil-bytecode ≥ 0.18.0)
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `extra_callable_labels` | `tuple[str, ...]` | `()` | Force-include exported dep-module functions even when no local `CALL` targets them (mirrors the JVM backend's same-name field) |
+| `external_method_tokens` | `dict[str, int]` | `{}` | Pre-assigned `MethodDef` tokens for cross-module call targets |
+
+## SequentialCILTokenProvider extension
+
+A new `method_token_offset: int = 0` constructor parameter shifts the base MethodDef
+token for dep-module providers:
+
+```python
+# Dep module 1 whose callables start at MethodDef row M_entry+1:
+provider = SequentialCILTokenProvider(
+    dep1_main_region_names,
+    method_token_offset=M_entry,
+)
+```
+
+## New twig-clr-compiler API
+
+### `module_name_to_clr_type(name: str) → str`
+
+Maps a Twig module name to a CLR type name by replacing `/` with `_`:
+
+```
+"user/hello" → "user_hello"
+"a/math"     → "a_math"
+```
+
+### `compile_modules(modules, *, entry_module, assembly_name) → MultiModuleClrResult`
+
+Two-pass compilation:
+
+**Pass 1 (analysis)** — for each module in `[entry] + deps` order:
+  - Compile Twig source to IR (`_Compiler`)
+  - Optimize IR
+  - Discover main-type callable names (entry_label + CALL targets + exports)
+
+**Token assignment** — compute cumulative MethodDef row offsets per module.
+
+**Pass 2 (emission)** — for each module:
+  - Build `CILBackendConfig` with `extra_callable_labels` (module's exports),
+    `external_method_tokens` (methods from all other modules), and
+    `SequentialCILTokenProvider(method_token_offset=...)`
+  - Compile to `CILProgramArtifact`
+
+**Assembly merge**:
+  - Entry module's `CILProgramArtifact.methods` → combined artifact's `methods`
+  - Each dep module's callable methods → `CILTypeArtifact` appended to `extra_types`
+  - Write one PE assembly from the combined artifact
+
+### `run_modules(modules, *, entry_module, ...) → MultiModuleClrExecutionResult`
+
+Calls `compile_modules`, writes the single `.exe` to a temp directory, runs
+`dotnet <name>.exe`, and returns stdout / stderr / returncode.
+
+## Acceptance criteria
+
+End-to-end on real `dotnet`:
+
+```twig
+; Module a/math:
+(module a/math (export add))
+(define (add x y) (+ x y))
+
+; Module user/hello (entry, imports a/math):
+(module user/hello (import a/math))
+(define n (a/math/add 10 32))
+n   ; → exit code 42
+```
+
+```python
+result = run_modules(modules, entry_module="user/hello")
+assert result.returncode == 42
+```
+
+Host calls work in the entry module:
+
+```twig
+; Module user/io:
+(module user/io (import host) (import a/math))
+(host/write-byte (a/math/add 10 32))  ; writes byte 42
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `ir-to-cil-bytecode/backend.py` | Add `extra_callable_labels`, `external_method_tokens` to `CILBackendConfig`; add `method_token_offset` to `SequentialCILTokenProvider`; update `_discover_callable_regions` + CALL lowering |
+| `ir-to-cil-bytecode/tests/test_cross_module_clr.py` | New: unit tests for cross-module CALL lowering |
+| `twig-clr-compiler/compiler.py` | Extend `_compile_apply` for user-module cross calls; add `compile_modules`, `run_modules`, result types |
+| `twig-clr-compiler/tests/test_multi_module_clr.py` | New: unit + real-dotnet end-to-end tests |
+| `ir-to-cil-bytecode/CHANGELOG.md` | v0.18.0 entry |
+| `twig-clr-compiler/CHANGELOG.md` | New version entry |


### PR DESCRIPTION
## Summary

TW04 Phase 4e ships `compile_modules` and `run_modules` in `twig-clr-compiler`, enabling multi-module Twig programs to run on real `dotnet`. The headline acceptance criterion:

```
(a/math/add 17 25)  →  exit code 42
```

All 99 twig-clr-compiler tests pass (91% coverage), including:
- Recursive dep-module functions (`fact 5 → 120`)
- Three-module chains (`(a/math/add (b/utils/double 5) 5) → 15`)
- Host-call + dep-module combinations (`host/write-byte(a/math/add 10 32)` → writes `*`)

## Changes

**twig-clr-compiler v0.7.0**: `compile_modules`, `run_modules`, `module_name_to_clr_type`, `MultiModuleClrResult`, 28 new tests

**ir-to-cil-bytecode v0.12.0**: `inline_host_syscalls` config flag (SYSCALL 1/2/10 → Console.Write/Read/Environment.Exit), `extra_callable_labels`/`external_method_tokens` for cross-module calls, `local_count` floor at `call_register_count`, 4 new inline-syscall tests

**cli-assembly-writer v0.5.0**: TypeRef rows 4/5 for System.Console/Environment, AssemblyRef row 2 for System.Console (separate assembly from System.Runtime in net9.0)

**cil-bytecode-builder v0.3.0**: `CONV_U2 = 0xD3` opcode + `emit_conv_u2()`

## Key bug fixes

- **TypeLoadException** (`Could not load type 'System.Console' from assembly 'System.Runtime'`): Fixed by adding separate AssemblyRef row for `System.Console` assembly and using inline .NET API calls instead of brainfuck-specific `__ca_syscall`
- **InvalidProgramException** on recursive dep-module functions: Fixed by flooring `local_count` at `call_register_count` so all modules declare enough locals for cross-module calls

## Test plan

- [ ] All 99 twig-clr-compiler tests pass on dotnet (including `@requires_dotnet` tests)
- [ ] All 118 ir-to-cil-bytecode tests pass (90.88% coverage)
- [ ] All 15 cli-assembly-writer tests pass (94.75% coverage)
- [ ] Security review: PASSED — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)