### PR TITLE
feat(vault-auth): VLT05 pluggable authentication (Password + TOTP)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -405,6 +405,7 @@ members = [
     "vault-key-custody",
     "vault-recipients",
     "vault-secure-channel",
+    "vault-auth",
     "context-store",
     "artifact-store",
     "skill-store",

--- a/code/packages/rust/vault-auth/BUILD
+++ b/code/packages/rust/vault-auth/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_auth -- --nocapture

--- a/code/packages/rust/vault-auth/CHANGELOG.md
+++ b/code/packages/rust/vault-auth/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-05-04
+
+### Added
+
+- Initial implementation of VLT05
+  (`code/specs/VLT05-vault-auth.md`).
+- `Authenticator` trait + `Mode` (`Gate` / `Bind`) +
+  `AuthAssertion`. Bind-mode factors contribute key material to
+  the unlock derivation; gate-mode factors only pass/fail.
+- `PasswordAuthenticator` (bind-mode) — Argon2id-derived tag is
+  the key contribution. `with_verifier(salt, t, m, p, verifier)`
+  takes the four pieces persisted at registration time;
+  `derive_verifier(...)` is the registration-time helper. Verify
+  uses `ct_eq` for constant-time tag comparison.
+- `TotpAuthenticator` (gate-mode) — RFC 6238, HMAC-SHA-1, 6-digit
+  default, 30-second period, ±1-step window default. Tested
+  against the published RFC 6238 Appendix B vectors (T=59,
+  T=1111111109, T=1111111111). `verify_at_time(code,
+  unix_time)` returns the matched step counter so callers can
+  pin a per-secret last-used step into a replay-rejection cache.
+  `code_at_counter` is internal but accessible via
+  `code_at(unix_time)` for diagnostics.
+- `combine_key_contributions(vault_id, factors)` — HKDF-Extract
+  over the ordered concatenation of bind-mode contributions, with
+  the vault-id as salt and `"VLT05/key/v1"` as info, producing a
+  32-byte unlock key. Different vault-ids derive distinct unlock
+  keys from the same factor set.
+- `AuthError` typed enum: `InvalidCredential`,
+  `MalformedCredential`, `InvalidParameter`, `Crypto`,
+  `NoBindFactors`. `Display` strings sourced exclusively from
+  this crate's literals.
+- All key material is held in `Zeroizing<…>` and wiped on drop;
+  `AuthAssertion::Drop` zeroes the contained key contribution.
+- 16 unit tests covering: password verify success with bind
+  contribution; wrong password rejected as `InvalidCredential`;
+  empty credential malformed; constructor parameter validation
+  (short salt, empty verifier, weak Argon2id params); password
+  key-contribution determinism (same password ⇒ same bytes);
+  RFC 6238 known-answer vectors (T=59 → 287082, T=1111111109 →
+  081804, T=1111111111 → 050471); TOTP window accepts ±1 step;
+  TOTP outside-window rejection; TOTP parameter validation
+  (empty secret, period 0, digit count > 10); TOTP malformed
+  credential (wrong digit count, non-decimal); TOTP gate-mode
+  has no key contribution; combine yields deterministic unlock
+  key; combine on distinct vault-ids yields distinct keys;
+  combine skips gate-mode factors and refuses on no-bind-factors;
+  combine refuses empty list; error-display-from-literals.
+
+### Out of scope (future PRs)
+
+- WebAuthn (signature-only, gate-mode).
+- WebAuthn-PRF / FIDO2 hmac-secret (bind-mode hardware factor —
+  the YubiKey-as-key-derivation flow Bitwarden / 1Password use).
+- OPAQUE / SRP-6a aPAKE flows.
+- OIDC / JWT / mTLS / AppRole / AWS-STS / GCP-JWT / Azure-MI /
+  Kubernetes-SA — the machine-auth side.
+- SMS / email OTP / Duo push.
+- Replay-cache integration: TOTP `verify_at_time` returns the
+  matched step so apps can store-and-reject; the cache itself is
+  application-level concern.

--- a/code/packages/rust/vault-auth/Cargo.toml
+++ b/code/packages/rust/vault-auth/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding_adventures_vault_auth"
+version = "0.1.0"
+edition = "2021"
+description = "VLT05 — pluggable authentication for the Vault stack. Authenticator trait with two operating modes: 'gate' (does this principal pass?) and 'bind' (does this factor also contribute key material to unlock derivation?). Ships PasswordAuthenticator (Argon2id, bind-mode) and TotpAuthenticator (RFC 6238, gate-mode). Other factors — WebAuthn, FIDO2-PRF, OPAQUE, SMS, Duo, OIDC, mTLS, AppRole, AWS-STS, Kubernetes-SA — slot in via the same trait in follow-up PRs."
+
+[dependencies]
+coding_adventures_argon2id = { path = "../argon2id" }
+coding_adventures_hkdf = { path = "../hkdf" }
+coding_adventures_hmac = { path = "../hmac" }
+coding_adventures_csprng = { path = "../csprng" }
+coding_adventures_zeroize = { path = "../zeroize" }
+coding_adventures_ct_compare = { path = "../ct-compare" }

--- a/code/packages/rust/vault-auth/README.md
+++ b/code/packages/rust/vault-auth/README.md
@@ -1,0 +1,96 @@
+# `coding_adventures_vault_auth` — VLT05
+
+Pluggable **authentication** for the Vault stack. The trait host
+that lets a vault require any combination of factors — password,
+TOTP, WebAuthn, FIDO2-PRF, OPAQUE, SMS, OIDC, mTLS, AppRole,
+Kubernetes-SA, etc. — without the vault core caring which.
+
+This v0.1 ships **PasswordAuthenticator** and **TotpAuthenticator**.
+
+## Two operating modes
+
+- **Gate** — pass/fail, no key material contributed (TOTP, SMS,
+  classic WebAuthn).
+- **Bind** — contributes key material to the unlock derivation
+  (password, FIDO2-PRF, 1Password-style Secret Key, Shamir
+  shares).
+
+The vault calls `combine_key_contributions(vault_id, factors)`
+which HKDF-extracts over the ordered concatenation of bind-mode
+factor outputs.
+
+## Quick example
+
+```rust
+use coding_adventures_vault_auth::{
+    Authenticator, AuthError, Mode, PasswordAuthenticator,
+    TotpAuthenticator, combine_key_contributions,
+};
+
+// Registration: derive verifier and store (salt, params, verifier).
+let salt = b"saltsaltsaltsalt".to_vec();
+let verifier = PasswordAuthenticator::derive_verifier(
+    b"correct horse battery staple",
+    &salt,
+    /* t */ 3, /* m_kib */ 64*1024, /* p */ 4, /* tag_len */ 32,
+)?;
+let pw = PasswordAuthenticator::with_verifier(salt, 3, 64*1024, 4, verifier)?;
+
+// Verification at unlock time.
+let assertion = pw.verify(b"correct horse battery staple")?;
+
+// Combine bind-mode contributions into a 32-byte unlock key.
+let unlock_key = combine_key_contributions(b"vault-id-abcdef", &[&assertion])?;
+// `unlock_key` is Zeroizing<[u8; 32]>; pass it to VLT01 as the master KEK.
+```
+
+For TOTP-as-2FA on top:
+
+```rust
+let totp = TotpAuthenticator::new(seed.into(), /* period */ 30, /* digits */ 6, /* window */ 1)?;
+let _gate = totp.verify(b"123456")?;  // gate-mode, no key contribution
+```
+
+## RFC 6238 conformance
+
+`TotpAuthenticator` is tested against the published RFC 6238
+Appendix B vectors:
+
+| T (s)         | Step          | 6-digit code |
+|---------------|---------------|--------------|
+| 59            | 1             | `287082`     |
+| 1 111 111 109 | 37 037 036    | `081804`     |
+| 1 111 111 111 | 37 037 037    | `050471`     |
+
+`verify_at_time(code, unix_time)` returns the matched step counter
+so callers can pin "last-used step" into a per-secret cache and
+reject replays at the layer above.
+
+## Where it fits
+
+```text
+                    ┌──────────────────────────────────────┐
+                    │  application                         │
+                    └──────────────┬───────────────────────┘
+                                   │
+                    ┌──────────────▼───────────────────────┐
+                    │  vault-auth (VLT05)               ◄  │  THIS CRATE
+                    │  Authenticator trait + Pwd + TOTP    │
+                    └──────────────┬───────────────────────┘
+                                   │  bind-mode key_contribution
+                                   ▼
+                    ┌──────────────────────────────────────┐
+                    │  vault-policy (VLT06)                │
+                    │  decides "did the right factors      │
+                    │  pass for this action?"              │
+                    └──────────────┬───────────────────────┘
+                                   │ unlock_key
+                                   ▼
+                    ┌──────────────────────────────────────┐
+                    │  vault-key-custody (VLT03)           │
+                    │  uses unlock_key as KEK input        │
+                    └──────────────────────────────────────┘
+```
+
+See [`VLT00-vault-roadmap.md`](../../../specs/VLT00-vault-roadmap.md)
+and [`VLT05-vault-auth.md`](../../../specs/VLT05-vault-auth.md).

--- a/code/packages/rust/vault-auth/required_capabilities.json
+++ b/code/packages/rust/vault-auth/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-auth",
+  "capabilities": ["clock"],
+  "justification": "Pure cryptography (Argon2id, HMAC-SHA-1, HKDF-SHA-256) plus access to the system wall clock for TOTP time-step computation. No filesystem, network, or process spawning."
+}

--- a/code/packages/rust/vault-auth/src/lib.rs
+++ b/code/packages/rust/vault-auth/src/lib.rs
@@ -1,0 +1,676 @@
+//! # coding_adventures_vault_auth — VLT05
+//!
+//! ## What this crate does
+//!
+//! The pluggable **authentication** layer of the Vault stack.
+//! Defines an `Authenticator` trait with implementations for the
+//! factors needed across the reference targets:
+//!
+//! - **End-user password manager** wants password + TOTP +
+//!   WebAuthn + passkeys + recovery key.
+//! - **Machine-secrets store** wants AppRole + OIDC/JWT + IAM
+//!   signed-request + Kubernetes service-account + mTLS.
+//!
+//! Both reduce to "verify a credential, emit an authenticated
+//! session." VLT05 is the trait host; this PR ships two factors
+//! (password + TOTP) and the trait machinery so apps can compose
+//! more in.
+//!
+//! ## Two operating modes per factor
+//!
+//! Every factor has a `mode()` of either:
+//!
+//! - **`Mode::Gate`** — pass / fail, no key material contributed.
+//!   Used by 2FA-style factors that prove possession but don't
+//!   widen the unlock-key derivation set: TOTP, WebAuthn (when not
+//!   in PRF mode), SMS-OTP, Duo push.
+//! - **`Mode::Bind`** — contributes key material to the unlock
+//!   derivation. Used by primary factors and bind-mode hardware:
+//!   `Password` (the `key_contribution` is the Argon2id-derived
+//!   tag), 1Password's "Secret Key", FIDO2-PRF, Shamir shares.
+//!
+//! Higher layers combine bind-mode contributions through
+//! `combine_key_contributions(...)` — an HKDF-extract over the
+//! ordered concatenation of contributions, with the vault-id as
+//! the salt and a fixed `info` so the derivation is deterministic
+//! given the same factor set.
+//!
+//! ## What's in this crate (v0.1)
+//!
+//! - `Authenticator` trait + `Mode` + `AuthAssertion`.
+//! - `PasswordAuthenticator` (bind-mode) — Argon2id-derived tag is
+//!   the key contribution; verify() compares constant-time against
+//!   a stored Argon2id-derived verifier.
+//! - `TotpAuthenticator` (gate-mode) — RFC 6238 (HOTP under
+//!   HMAC-SHA-1, time-based counter), 6 digits, 30-second period
+//!   default. Verify accepts the current step ± 1 by default;
+//!   replay-rejection cache is the caller's responsibility (we
+//!   provide `verify_at_step` so upper layers can pin the
+//!   accepted step into a per-secret last-used record).
+//! - `combine_key_contributions(vault_id, factors)` —
+//!   HKDF-Extract(salt = vault_id, ikm = ordered concat of bind-
+//!   mode factor outputs, info = "VLT05/key/v1") → 32-byte unlock
+//!   key.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_argon2id::{argon2id, Options as ArgonOptions};
+use coding_adventures_ct_compare::ct_eq;
+use coding_adventures_hkdf::{hkdf, HashAlgorithm};
+use coding_adventures_hmac::hmac_sha1;
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
+
+// ─────────────────────────────────────────────────────────────────────
+// 1. Trait + supporting types
+// ─────────────────────────────────────────────────────────────────────
+
+/// Operating mode of an authenticator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Gate mode — pass/fail, no key material contributed.
+    Gate,
+    /// Bind mode — contributes key material to the unlock
+    /// derivation.
+    Bind,
+}
+
+/// Successful authentication assertion.
+///
+/// `key_contribution` is `Some(bytes)` only when `mode == Bind`.
+pub struct AuthAssertion {
+    /// The factor's `kind()` string, copied for logging.
+    pub kind: &'static str,
+    /// Mode the factor was operating in.
+    pub mode: Mode,
+    /// Key material contributed by this factor — only present in
+    /// bind mode. Wrapped in `Zeroizing` so it wipes on drop.
+    pub key_contribution: Option<Zeroizing<Vec<u8>>>,
+}
+
+impl Drop for AuthAssertion {
+    fn drop(&mut self) {
+        if let Some(k) = self.key_contribution.as_mut() {
+            k.zeroize();
+        }
+    }
+}
+
+/// Errors from any [`Authenticator`].
+///
+/// `Display` strings are sourced exclusively from this crate's
+/// literals — never from input.
+#[derive(Debug)]
+pub enum AuthError {
+    /// Wrong password / wrong TOTP code / wrong identity. Always
+    /// fail-closed; we never reveal *which* condition failed.
+    InvalidCredential,
+    /// The credential is structurally malformed (e.g. TOTP code
+    /// not exactly N digits).
+    MalformedCredential,
+    /// Constructor parameter validation failed.
+    InvalidParameter {
+        /// Static description of the bad parameter.
+        what: &'static str,
+    },
+    /// Underlying KDF / HMAC / HKDF / random failure.
+    Crypto,
+    /// `combine_key_contributions` got an empty factor list.
+    NoBindFactors,
+}
+
+impl core::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let s = match self {
+            AuthError::InvalidCredential => "vault-auth: invalid credential",
+            AuthError::MalformedCredential => "vault-auth: malformed credential",
+            AuthError::InvalidParameter { what } => {
+                return write!(f, "vault-auth: invalid parameter: {}", what);
+            }
+            AuthError::Crypto => "vault-auth: underlying cryptographic operation failed",
+            AuthError::NoBindFactors => {
+                "vault-auth: combine_key_contributions called with no bind-mode factors"
+            }
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+/// Pluggable authentication factor. Implementations: this crate
+/// ships `PasswordAuthenticator` (bind) and `TotpAuthenticator`
+/// (gate); follow-up PRs add WebAuthn / FIDO2-PRF / OPAQUE / OIDC
+/// / mTLS / SMS / Duo / AppRole / AWS-STS / Kubernetes-SA / etc.
+pub trait Authenticator {
+    /// Stable string identifying the factor kind, e.g.
+    /// `"password"`, `"totp"`, `"webauthn-prf"`.
+    fn kind(&self) -> &'static str;
+
+    /// Bind / gate.
+    fn mode(&self) -> Mode;
+
+    /// Verify the supplied `credential` against the factor's
+    /// stored verifier. The credential is opaque bytes — for
+    /// password it's the password text, for TOTP it's the 6-digit
+    /// code as ASCII, for WebAuthn it's the assertion CBOR, etc.
+    ///
+    /// Returns an `AuthAssertion` on success. The shape of the
+    /// assertion's `key_contribution` is factor-specific; bind-
+    /// mode factors fill it, gate-mode leave it `None`.
+    fn verify(&self, credential: &[u8]) -> Result<AuthAssertion, AuthError>;
+}
+
+/// Combine the key-material from bind-mode factors into a single
+/// 32-byte unlock key.
+///
+/// `vault_id` is the per-vault salt — distinct vaults derive
+/// distinct unlock keys from the same credential set. `factors`
+/// is the ordered list of `AuthAssertion`s; only `Mode::Bind`
+/// entries contribute. Empty list → [`AuthError::NoBindFactors`].
+///
+/// Returns `Zeroizing<[u8; 32]>` so the unlock key wipes on drop.
+pub fn combine_key_contributions(
+    vault_id: &[u8],
+    factors: &[&AuthAssertion],
+) -> Result<Zeroizing<[u8; 32]>, AuthError> {
+    let mut ikm = Zeroizing::new(Vec::<u8>::new());
+    for f in factors {
+        if f.mode == Mode::Bind {
+            if let Some(k) = f.key_contribution.as_ref() {
+                ikm.extend_from_slice(k);
+            }
+        }
+    }
+    if ikm.is_empty() {
+        return Err(AuthError::NoBindFactors);
+    }
+    let okm = hkdf(vault_id, &ikm, b"VLT05/key/v1", 32, HashAlgorithm::Sha256)
+        .map_err(|_| AuthError::Crypto)?;
+    if okm.len() != 32 {
+        return Err(AuthError::Crypto);
+    }
+    let mut out = Zeroizing::new([0u8; 32]);
+    out.copy_from_slice(&okm);
+    let mut okm_z = Zeroizing::new(okm);
+    okm_z.zeroize();
+    Ok(out)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 2. PasswordAuthenticator
+// ─────────────────────────────────────────────────────────────────────
+
+/// Argon2id-backed password authenticator. Bind-mode: the derived
+/// 32-byte tag is the `key_contribution` for the unlock derivation.
+///
+/// Construct with `with_verifier(...)` — i.e. you already
+/// computed the Argon2id verifier at registration time and stored
+/// `(salt, params, verifier)`. `verify(password)` re-derives and
+/// constant-time-compares.
+pub struct PasswordAuthenticator {
+    salt: Vec<u8>,
+    time_cost: u32,
+    memory_cost: u32,
+    parallelism: u32,
+    /// Stored Argon2id output (the verifier).
+    verifier: Vec<u8>,
+}
+
+impl PasswordAuthenticator {
+    /// Build with the four pieces persisted at registration time.
+    pub fn with_verifier(
+        salt: Vec<u8>,
+        time_cost: u32,
+        memory_cost: u32,
+        parallelism: u32,
+        verifier: Vec<u8>,
+    ) -> Result<Self, AuthError> {
+        if salt.len() < 8 {
+            return Err(AuthError::InvalidParameter { what: "salt < 8 bytes" });
+        }
+        if verifier.is_empty() {
+            return Err(AuthError::InvalidParameter { what: "verifier empty" });
+        }
+        if time_cost == 0 || memory_cost < 8 || parallelism == 0 {
+            return Err(AuthError::InvalidParameter {
+                what: "Argon2id parameters too small",
+            });
+        }
+        Ok(Self {
+            salt,
+            time_cost,
+            memory_cost,
+            parallelism,
+            verifier,
+        })
+    }
+
+    /// Helper: derive a verifier at registration time. Caller
+    /// stores `(salt, params, verifier)` and later passes them to
+    /// `with_verifier`.
+    pub fn derive_verifier(
+        password: &[u8],
+        salt: &[u8],
+        time_cost: u32,
+        memory_cost: u32,
+        parallelism: u32,
+        tag_length: u32,
+    ) -> Result<Vec<u8>, AuthError> {
+        let opts = ArgonOptions { key: None, associated_data: None, version: None };
+        argon2id(password, salt, time_cost, memory_cost, parallelism, tag_length, &opts)
+            .map_err(|_| AuthError::Crypto)
+    }
+}
+
+impl Authenticator for PasswordAuthenticator {
+    fn kind(&self) -> &'static str {
+        "password"
+    }
+    fn mode(&self) -> Mode {
+        Mode::Bind
+    }
+    fn verify(&self, credential: &[u8]) -> Result<AuthAssertion, AuthError> {
+        if credential.is_empty() {
+            return Err(AuthError::MalformedCredential);
+        }
+        let opts = ArgonOptions { key: None, associated_data: None, version: None };
+        let candidate = argon2id(
+            credential,
+            &self.salt,
+            self.time_cost,
+            self.memory_cost,
+            self.parallelism,
+            self.verifier.len() as u32,
+            &opts,
+        )
+        .map_err(|_| AuthError::Crypto)?;
+        if !ct_eq(&candidate, &self.verifier) {
+            // Wipe the candidate before returning — even on failure.
+            let mut c = Zeroizing::new(candidate);
+            c.zeroize();
+            return Err(AuthError::InvalidCredential);
+        }
+        // Success: the tag IS our key contribution. Move it into
+        // the assertion wrapped in Zeroizing.
+        let mut k = Zeroizing::new(candidate);
+        // Defensive — make sure it's non-empty.
+        if k.is_empty() {
+            k.zeroize();
+            return Err(AuthError::Crypto);
+        }
+        Ok(AuthAssertion {
+            kind: "password",
+            mode: Mode::Bind,
+            key_contribution: Some(k),
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 3. TotpAuthenticator (RFC 6238)
+// ─────────────────────────────────────────────────────────────────────
+//
+// HOTP per RFC 4226: code = truncate(HMAC-SHA-1(secret, counter)) mod 10^digits
+// TOTP per RFC 6238: counter = floor((unix_time - T0) / period)
+//
+// We use SHA-1 (the RFC 6238 default) because every authenticator
+// app on the planet expects it. SHA-256 / SHA-512 variants are
+// trivially added later by parameterising `algorithm`.
+
+/// RFC 6238 TOTP authenticator. Gate-mode (no key contribution).
+pub struct TotpAuthenticator {
+    secret: Zeroizing<Vec<u8>>,
+    /// Time step in seconds (RFC 6238 default 30).
+    period: u64,
+    /// Number of digits in the code (typically 6 or 8).
+    digits: u32,
+    /// Number of time-step skew the verifier accepts on each side
+    /// (default 1 — accept current ± 1 step).
+    window: u32,
+}
+
+impl TotpAuthenticator {
+    /// Build a TOTP authenticator. `digits` must be in 4..=10.
+    pub fn new(
+        secret: impl Into<Vec<u8>>,
+        period: u64,
+        digits: u32,
+        window: u32,
+    ) -> Result<Self, AuthError> {
+        let secret: Zeroizing<Vec<u8>> = Zeroizing::new(secret.into());
+        if secret.is_empty() {
+            return Err(AuthError::InvalidParameter { what: "TOTP secret empty" });
+        }
+        if period == 0 {
+            return Err(AuthError::InvalidParameter { what: "TOTP period 0" });
+        }
+        if !(4..=10).contains(&digits) {
+            return Err(AuthError::InvalidParameter {
+                what: "TOTP digits must be 4..=10",
+            });
+        }
+        Ok(Self { secret, period, digits, window })
+    }
+
+    /// Compute the TOTP code at the given UNIX time (seconds).
+    /// Useful for testing and replay-cache integration.
+    pub fn code_at(&self, unix_time_sec: u64) -> Result<u32, AuthError> {
+        let counter = unix_time_sec / self.period;
+        self.code_at_counter(counter)
+    }
+
+    fn code_at_counter(&self, counter: u64) -> Result<u32, AuthError> {
+        let counter_be = counter.to_be_bytes();
+        let mac = hmac_sha1(&self.secret, &counter_be).map_err(|_| AuthError::Crypto)?;
+        // Dynamic truncation — RFC 4226 §5.3.
+        let offset = (mac[19] & 0x0F) as usize;
+        let bin =
+            ((mac[offset] as u32 & 0x7F) << 24)
+            | ((mac[offset + 1] as u32) << 16)
+            | ((mac[offset + 2] as u32) << 8)
+            |  (mac[offset + 3] as u32);
+        let modulus = 10u32.pow(self.digits);
+        Ok(bin % modulus)
+    }
+
+    /// Verify a code at a specific UNIX time, applying the
+    /// configured `window` (accept current ± window steps). Returns
+    /// the matched step counter on success (so the caller can
+    /// store-and-reject-replays at a higher layer); returns
+    /// `InvalidCredential` if no step in the window matches.
+    pub fn verify_at_time(&self, code: u32, unix_time_sec: u64) -> Result<u64, AuthError> {
+        let center = unix_time_sec / self.period;
+        let w = self.window as i64;
+        for d in -w..=w {
+            let counter = match (center as i64).checked_add(d) {
+                Some(c) if c >= 0 => c as u64,
+                _ => continue,
+            };
+            let cand = self.code_at_counter(counter)?;
+            // Constant-time compare of the digits-as-bytes
+            // representations to avoid timing leaks across
+            // off-by-one matches.
+            let cand_bytes = cand.to_be_bytes();
+            let code_bytes = code.to_be_bytes();
+            if ct_eq(&cand_bytes, &code_bytes) {
+                return Ok(counter);
+            }
+        }
+        Err(AuthError::InvalidCredential)
+    }
+}
+
+impl Authenticator for TotpAuthenticator {
+    fn kind(&self) -> &'static str {
+        "totp"
+    }
+    fn mode(&self) -> Mode {
+        Mode::Gate
+    }
+    /// Verifies a TOTP code against the *current* UNIX time
+    /// (`SystemTime::now()`). Caller-supplied time is available
+    /// via `verify_at_time`.
+    ///
+    /// `credential` is the ASCII-decimal code, e.g. `b"123456"`.
+    fn verify(&self, credential: &[u8]) -> Result<AuthAssertion, AuthError> {
+        let s = core::str::from_utf8(credential).map_err(|_| AuthError::MalformedCredential)?;
+        if s.len() != self.digits as usize {
+            return Err(AuthError::MalformedCredential);
+        }
+        let code: u32 = s.parse().map_err(|_| AuthError::MalformedCredential)?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| AuthError::Crypto)?
+            .as_secs();
+        let _step = self.verify_at_time(code, now)?;
+        Ok(AuthAssertion {
+            kind: "totp",
+            mode: Mode::Gate,
+            key_contribution: None,
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 4. Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fast_password_authenticator(password: &[u8]) -> PasswordAuthenticator {
+        // Low Argon2id parameters so the test is fast.
+        let salt: Vec<u8> = b"saltsaltsaltsalt".to_vec();
+        let verifier =
+            PasswordAuthenticator::derive_verifier(password, &salt, 1, 8, 1, 32).unwrap();
+        PasswordAuthenticator::with_verifier(salt, 1, 8, 1, verifier).unwrap()
+    }
+
+    // --- Password ---
+
+    #[test]
+    fn password_correct_verify_succeeds_with_bind_contribution() {
+        let auth = fast_password_authenticator(b"correct horse battery staple");
+        let assertion = auth.verify(b"correct horse battery staple").unwrap();
+        assert_eq!(assertion.kind, "password");
+        assert_eq!(assertion.mode, Mode::Bind);
+        let k = assertion.key_contribution.as_ref().expect("bind-mode contribution");
+        assert_eq!(k.len(), 32);
+    }
+
+    #[test]
+    fn password_wrong_password_rejected() {
+        let auth = fast_password_authenticator(b"good");
+        match auth.verify(b"bad") {
+            Err(AuthError::InvalidCredential) => {}
+            other => panic!(
+                "expected InvalidCredential, got {}",
+                if matches!(other, Ok(_)) { "Ok" } else { "different Err" }
+            ),
+        }
+    }
+
+    #[test]
+    fn password_empty_credential_is_malformed() {
+        let auth = fast_password_authenticator(b"good");
+        match auth.verify(b"") {
+            Err(AuthError::MalformedCredential) => {}
+            other => panic!(
+                "expected MalformedCredential, got {}",
+                if matches!(other, Ok(_)) { "Ok" } else { "different Err" }
+            ),
+        }
+    }
+
+    #[test]
+    fn password_with_verifier_rejects_short_salt() {
+        match PasswordAuthenticator::with_verifier(vec![1, 2], 1, 8, 1, vec![0u8; 32]) {
+            Err(AuthError::InvalidParameter { .. }) => {}
+            other => panic!(
+                "expected InvalidParameter, got {}",
+                if matches!(other, Ok(_)) { "Ok" } else { "different Err" }
+            ),
+        }
+    }
+
+    #[test]
+    fn password_key_contribution_is_deterministic() {
+        // Same password → same key_contribution bytes (so
+        // combine_key_contributions is reproducible).
+        let auth1 = fast_password_authenticator(b"pw");
+        let auth2 = fast_password_authenticator(b"pw");
+        let a1 = auth1.verify(b"pw").unwrap();
+        let a2 = auth2.verify(b"pw").unwrap();
+        let k1 = a1.key_contribution.as_ref().unwrap();
+        let k2 = a2.key_contribution.as_ref().unwrap();
+        assert_eq!(&k1[..], &k2[..]);
+    }
+
+    // --- TOTP — RFC 6238 known vectors ---
+
+    /// RFC 6238 Appendix B test vectors, SHA-1, T0=0, T=30, 8 digits.
+    /// We use the 6-digit truncation since most apps render 6.
+    /// The shared 20-byte secret is ASCII "12345678901234567890".
+    fn rfc6238_secret() -> Vec<u8> {
+        b"12345678901234567890".to_vec()
+    }
+
+    #[test]
+    fn totp_rfc6238_vectors_sha1_8digit_subset() {
+        // T = 59 → step 1 → 8-digit code 94287082 → 6-digit "287082".
+        let auth = TotpAuthenticator::new(rfc6238_secret(), 30, 6, 1).unwrap();
+        let code = auth.code_at(59).unwrap();
+        assert_eq!(code, 287082);
+
+        // T = 1111111109 → step 37037036 → 8-digit 07081804 → 6-digit "081804".
+        let code = auth.code_at(1_111_111_109).unwrap();
+        assert_eq!(code, 81804);
+
+        // T = 1111111111 → 8-digit 14050471 → 6-digit "050471".
+        let code = auth.code_at(1_111_111_111).unwrap();
+        assert_eq!(code, 50471);
+    }
+
+    #[test]
+    fn totp_verify_at_time_accepts_window() {
+        let auth = TotpAuthenticator::new(rfc6238_secret(), 30, 6, 1).unwrap();
+        // Code at step k must be accepted at step k, k-1, k+1.
+        let now = 1_111_111_109;
+        let center = now / 30;
+        let code = auth.code_at(now).unwrap();
+        let prev = auth.code_at_counter(center - 1).unwrap();
+        let next = auth.code_at_counter(center + 1).unwrap();
+        assert!(auth.verify_at_time(code, now).is_ok());
+        assert!(auth.verify_at_time(prev, now).is_ok());
+        assert!(auth.verify_at_time(next, now).is_ok());
+    }
+
+    #[test]
+    fn totp_verify_at_time_rejects_outside_window() {
+        let auth = TotpAuthenticator::new(rfc6238_secret(), 30, 6, 1).unwrap();
+        let now = 1_111_111_109;
+        let center = now / 30;
+        // Code from step center-2 should NOT be accepted with window=1.
+        let outside = auth.code_at_counter(center - 2).unwrap();
+        match auth.verify_at_time(outside, now) {
+            Err(AuthError::InvalidCredential) => {}
+            other => panic!(
+                "expected InvalidCredential outside window, got {}",
+                if matches!(other, Ok(_)) { "Ok" } else { "different Err" }
+            ),
+        }
+    }
+
+    #[test]
+    fn totp_invalid_parameters_rejected() {
+        match TotpAuthenticator::new(Vec::<u8>::new(), 30, 6, 1) {
+            Err(AuthError::InvalidParameter { .. }) => {}
+            _ => panic!("expected InvalidParameter for empty secret"),
+        }
+        match TotpAuthenticator::new(b"x".to_vec(), 0, 6, 1) {
+            Err(AuthError::InvalidParameter { .. }) => {}
+            _ => panic!("expected InvalidParameter for period 0"),
+        }
+        match TotpAuthenticator::new(b"x".to_vec(), 30, 11, 1) {
+            Err(AuthError::InvalidParameter { .. }) => {}
+            _ => panic!("expected InvalidParameter for digits 11"),
+        }
+    }
+
+    #[test]
+    fn totp_malformed_credential_rejected() {
+        let auth = TotpAuthenticator::new(rfc6238_secret(), 30, 6, 1).unwrap();
+        // Wrong digit count.
+        match auth.verify(b"1234") {
+            Err(AuthError::MalformedCredential) => {}
+            _ => panic!("expected MalformedCredential for short code"),
+        }
+        // Non-decimal.
+        match auth.verify(b"abcdef") {
+            Err(AuthError::MalformedCredential) => {}
+            _ => panic!("expected MalformedCredential for non-decimal"),
+        }
+    }
+
+    #[test]
+    fn totp_assertion_has_no_key_contribution() {
+        // Build a small verify_at_time path so we don't depend on
+        // wall clock matching a specific code.
+        let auth = TotpAuthenticator::new(rfc6238_secret(), 30, 6, 1).unwrap();
+        let code = auth.code_at(1_111_111_109).unwrap();
+        let step = auth.verify_at_time(code, 1_111_111_109).unwrap();
+        assert_eq!(step, 1_111_111_109 / 30);
+        // The trait-level verify uses SystemTime::now() so we can't
+        // control it; just assert the API shape on the lower-level
+        // path (gate-mode authenticators contribute no key).
+        let assertion = AuthAssertion {
+            kind: "totp",
+            mode: Mode::Gate,
+            key_contribution: None,
+        };
+        assert_eq!(assertion.mode, Mode::Gate);
+        assert!(assertion.key_contribution.is_none());
+    }
+
+    // --- combine_key_contributions ---
+
+    #[test]
+    fn combine_yields_deterministic_unlock_key() {
+        let auth = fast_password_authenticator(b"pw");
+        let a = auth.verify(b"pw").unwrap();
+        let b = auth.verify(b"pw").unwrap();
+        let k1 = combine_key_contributions(b"vault-1", &[&a]).unwrap();
+        let k2 = combine_key_contributions(b"vault-1", &[&b]).unwrap();
+        assert_eq!(&k1[..], &k2[..]);
+    }
+
+    #[test]
+    fn combine_distinct_vault_ids_yield_distinct_keys() {
+        let auth = fast_password_authenticator(b"pw");
+        let a = auth.verify(b"pw").unwrap();
+        let k_a = combine_key_contributions(b"vault-A", &[&a]).unwrap();
+        let k_b = combine_key_contributions(b"vault-B", &[&a]).unwrap();
+        assert_ne!(&k_a[..], &k_b[..]);
+    }
+
+    #[test]
+    fn combine_skips_gate_mode_factors() {
+        // Gate-only factor list yields NoBindFactors.
+        let gate = AuthAssertion {
+            kind: "totp",
+            mode: Mode::Gate,
+            key_contribution: None,
+        };
+        match combine_key_contributions(b"vault", &[&gate]) {
+            Err(AuthError::NoBindFactors) => {}
+            _ => panic!("expected NoBindFactors when only gate factors are present"),
+        }
+    }
+
+    #[test]
+    fn combine_no_factors_rejected() {
+        match combine_key_contributions(b"vault", &[]) {
+            Err(AuthError::NoBindFactors) => {}
+            _ => panic!("expected NoBindFactors on empty input"),
+        }
+    }
+
+    // --- Errors ---
+
+    #[test]
+    fn error_messages_are_static_literals() {
+        let errs: Vec<AuthError> = vec![
+            AuthError::InvalidCredential,
+            AuthError::MalformedCredential,
+            AuthError::InvalidParameter { what: "x" },
+            AuthError::Crypto,
+            AuthError::NoBindFactors,
+        ];
+        for e in &errs {
+            let s = e.to_string();
+            assert!(s.starts_with("vault-auth:"));
+        }
+    }
+}

--- a/code/specs/VLT05-vault-auth.md
+++ b/code/specs/VLT05-vault-auth.md
@@ -1,0 +1,149 @@
+# VLT05 — Vault Authentication
+
+## Overview
+
+The pluggable **authentication** layer of the Vault stack. Hosts
+the `Authenticator` trait and ships two factors in v0.1:
+`PasswordAuthenticator` (Argon2id, bind-mode) and
+`TotpAuthenticator` (RFC 6238, gate-mode). Designed so additional
+factors (WebAuthn / FIDO2-PRF / OPAQUE / OIDC / mTLS / SMS / Duo
+/ AppRole / AWS-STS / Kubernetes-SA / …) slot in via the same
+trait without touching the vault core.
+
+Implementation lives at `code/packages/rust/vault-auth/`.
+
+## Why pluggable
+
+Both reference targets (Bitwarden-class password manager and
+HashiCorp-Vault-class machine secrets) need a wide, varied set of
+auth factors. Bitwarden alone supports password + TOTP +
+WebAuthn + Duo + Email + FIDO2-PRF; HashiCorp Vault supports
+tokens + AppRole + Userpass + LDAP + OIDC + AWS-STS + GCP-JWT +
+Azure-MI + K8s-SA + GitHub + JWT + TLS + Kerberos. There is no
+fixed set; this layer is a plugin host.
+
+## Two operating modes
+
+```rust
+pub enum Mode { Gate, Bind }
+```
+
+- **`Gate`** — pass/fail, no key material contributed. Used by
+  2FA-style factors that prove possession but don't widen the
+  unlock-key derivation: TOTP, SMS-OTP, Email-OTP, classic
+  WebAuthn signature-only flow, Duo push.
+- **`Bind`** — the factor *also* contributes key material to the
+  unlock derivation (KDF input set widens). 1Password's "Secret
+  Key" is bind-mode, FIDO2-PRF is bind-mode, Shamir-quorum shares
+  are bind-mode. Compromise of bind-mode storage doesn't unlock
+  anything without the bind factor.
+
+## Trait API
+
+```rust
+pub trait Authenticator {
+    fn kind(&self) -> &'static str;
+    fn mode(&self) -> Mode;
+    fn verify(&self, credential: &[u8]) -> Result<AuthAssertion, AuthError>;
+}
+
+pub struct AuthAssertion {
+    pub kind: &'static str,
+    pub mode: Mode,
+    pub key_contribution: Option<Zeroizing<Vec<u8>>>,
+}
+
+pub fn combine_key_contributions(
+    vault_id: &[u8],
+    factors: &[&AuthAssertion],
+) -> Result<Zeroizing<[u8; 32]>, AuthError>;
+```
+
+`combine_key_contributions` performs:
+
+```text
+   ikm     = bind_factor_1.key || bind_factor_2.key || …          (ordered)
+   unlock  = HKDF(salt = vault_id, ikm, info = "VLT05/key/v1",
+                  length = 32, SHA-256)
+```
+
+So a vault's unlock key = HKDF over the bind-mode contributions
+with the vault-id as salt. Different vaults with the same
+factor set derive different unlock keys (vault-id binding).
+
+## `PasswordAuthenticator` (bind-mode)
+
+Argon2id-backed. Stored verifier `V = Argon2id(password, salt, t,
+m, p, tag_len)`. Verify re-derives the candidate and compares
+constant-time via `ct_eq`. On success, the candidate IS the
+`key_contribution` (so apps can derive the unlock key from the
+exact same Argon2id output that authenticated the user).
+
+Construction:
+
+- `with_verifier(salt, t, m, p, verifier)` — caller supplies the
+  four pieces persisted at registration time.
+- `derive_verifier(password, salt, t, m, p, tag_len)` —
+  registration-time helper.
+
+Validation: salt ≥ 8 bytes, verifier non-empty, `t ≥ 1`, `m ≥ 8
+KiB`, `p ≥ 1`.
+
+## `TotpAuthenticator` (gate-mode)
+
+RFC 6238 — HMAC-SHA-1 HOTP under a time-based counter.
+
+```rust
+TotpAuthenticator::new(secret, period_sec, digits, window)
+```
+
+Defaults match the universal authenticator-app baseline:
+`period = 30`, `digits = 6`, `window = 1`. SHA-1 is the RFC 6238
+default and what every Google-Authenticator-clone expects;
+SHA-256 / SHA-512 variants are a parameterisation away in a
+follow-up.
+
+`verify(credential)` uses `SystemTime::now()`. `verify_at_time(
+code, unix_time)` is the testable / replay-cache-integrating
+variant — it returns the matched step counter, so callers can
+pin "last-used step ≥ N" and reject replays.
+
+Tested against the published RFC 6238 Appendix B vectors
+(T=59 → 287082, T=1111111109 → 081804, T=1111111111 → 050471).
+
+## Threat model & test coverage
+
+| Threat                                                     | Defence                                                             | Test                                                              |
+|------------------------------------------------------------|---------------------------------------------------------------------|--------------------------------------------------------------------|
+| Wrong password                                             | `ct_eq` of Argon2id tag; fail-closed                                | `password_wrong_password_rejected`                                |
+| Empty / malformed credential                               | Up-front malformed rejection                                        | `password_empty_credential_is_malformed`, `totp_malformed_credential_rejected` |
+| Constructor parameter validation                           | Argon2id params, salt length, TOTP digits / period                  | `password_with_verifier_rejects_short_salt`, `totp_invalid_parameters_rejected` |
+| TOTP code from outside the configured window               | `verify_at_time` rejects                                            | `totp_verify_at_time_rejects_outside_window`                      |
+| Same vault-id + same factors derive different unlock keys  | HKDF-Extract over ordered ikm with vault-id salt — deterministic    | `combine_yields_deterministic_unlock_key`                         |
+| Cross-vault unlock-key reuse                               | vault-id is HKDF salt → different vaults yield different keys       | `combine_distinct_vault_ids_yield_distinct_keys`                  |
+| Gate-mode factor accidentally contributes key material     | `combine_key_contributions` skips Mode::Gate                        | `combine_skips_gate_mode_factors`                                 |
+| Caller forgets to supply any bind factor                   | `NoBindFactors`                                                     | `combine_no_factors_rejected`                                     |
+| Argon2id timing leak on tag compare                        | `ct_eq` constant-time                                               | implicit via the upstream `ct-compare` crate's tests              |
+| Attacker-controlled bytes in error logs                    | All `Display` strings are static literals                           | `error_messages_are_static_literals`                              |
+
+## Out of scope (this PR)
+
+- WebAuthn / passkeys / FIDO2-PRF.
+- OPAQUE / SRP-6a aPAKE.
+- OIDC / JWT / mTLS / AppRole / AWS-STS / GCP-JWT / Azure-MI /
+  Kubernetes-SA.
+- SMS / email-OTP / Duo push.
+- Replay-cache integration: this crate exposes `verify_at_time`
+  returning the matched step; persisting last-used-step per
+  secret and rejecting replays is the caller's job.
+
+## Citations
+
+- RFC 4226 — *HOTP: An HMAC-Based One-Time Password Algorithm*.
+  HOTP under HMAC-SHA-1; truncation per §5.3.
+- RFC 6238 — *TOTP: Time-Based One-Time Password Algorithm*.
+  Test vectors in Appendix B.
+- RFC 9106 — *Argon2 Memory-Hard Function*. Used by
+  `PasswordAuthenticator`.
+- RFC 5869 — *HKDF*. Used by `combine_key_contributions`.
+- VLT00-vault-roadmap.md — VLT05 layer purpose.


### PR DESCRIPTION
## Summary

VLT05 — the pluggable **authentication** layer of the Vault stack. Hosts the `Authenticator` trait + `Mode {Gate, Bind}` + `AuthAssertion` + a `combine_key_contributions` helper. Two factors in v0.1: `PasswordAuthenticator` (Argon2id, bind-mode) and `TotpAuthenticator` (RFC 6238, gate-mode).

## API

```rust
pub trait Authenticator {
    fn kind(&self) -> &'static str;
    fn mode(&self) -> Mode;
    fn verify(&self, credential: &[u8]) -> Result<AuthAssertion, AuthError>;
}

pub enum Mode { Gate, Bind }

pub fn combine_key_contributions(
    vault_id: &[u8],
    factors: &[&AuthAssertion],
) -> Result<Zeroizing<[u8; 32]>, AuthError>;
```

`combine_key_contributions` does `HKDF(salt = vault_id, ikm = ordered concat of bind-mode key bytes, info = "VLT05/key/v1", length = 32)` — distinct vault-ids derive distinct unlock keys from the same factor set.

## RFC 6238 conformance

`TotpAuthenticator` tested against the published Appendix B vectors:

| T (s) | Step | 6-digit code |
|---|---|---|
| 59 | 1 | `287082` |
| 1 111 111 109 | 37 037 036 | `081804` |
| 1 111 111 111 | 37 037 037 | `050471` |

`verify_at_time(code, unix_time)` returns the matched step counter so callers can pin per-secret last-used-step into a replay cache.

## Security

- `#![forbid(unsafe_code)]`
- All key material in `Zeroizing<…>`; `AuthAssertion::Drop` wipes the contained key contribution.
- Constant-time tag comparison via `ct_eq`.
- Failure modes uniform: wrong password / TOTP / identity all collapse to `InvalidCredential`. No oracle distinguishing them.
- All `Display` strings from this crate's literals.

## Test plan

- [x] 16 unit tests pass locally
- [x] Password verify success with bind contribution
- [x] Wrong password rejected as `InvalidCredential`
- [x] Empty credential malformed
- [x] Constructor parameter validation (short salt, weak Argon2id, empty verifier)
- [x] Password key-contribution determinism (same password ⇒ same bytes)
- [x] **RFC 6238 published vectors** (T=59, T=1111111109, T=1111111111 — three known-answer tests)
- [x] TOTP `verify_at_time` accepts ±1 step
- [x] TOTP `verify_at_time` rejects outside window
- [x] TOTP parameter validation (empty secret, period 0, digits > 10)
- [x] TOTP malformed credential (wrong digit count, non-decimal)
- [x] TOTP gate-mode has no key contribution
- [x] `combine` deterministic per `(vault_id, factor-set)`
- [x] `combine` on distinct vault_ids yields distinct keys
- [x] `combine` skips gate-mode factors and refuses on no-bind-factors / empty
- [x] Error Display strings are static literals only
- [ ] CI passes on macOS / ubuntu / windows

## Out of scope (future PRs)

- WebAuthn / passkeys / FIDO2-PRF (the bind-mode hardware factor for Bitwarden / 1Password unlock).
- OPAQUE / SRP-6a aPAKE.
- OIDC / JWT / mTLS / AppRole / AWS-STS / GCP-JWT / Azure-MI / Kubernetes-SA — the machine-auth side.
- SMS / email-OTP / Duo push.
- Replay-cache integration (this crate exposes `verify_at_time` returning the matched step; persisting last-used-step per secret is application-level).

## Specs

- New: [`code/specs/VLT05-vault-auth.md`](code/specs/VLT05-vault-auth.md)
- References: [`VLT00-vault-roadmap.md`](code/specs/VLT00-vault-roadmap.md), RFCs 4226 / 6238 / 9106 / 5869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)