### PR TITLE
feat(lang23-23e): Twig syntax — parse + emit refinement type annotations

### DIFF
--- a/code/grammars/twig.grammar
+++ b/code/grammars/twig.grammar
@@ -56,15 +56,48 @@ import_clause  = LPAREN "import" { NAME } RPAREN ;
 # function whose value is the value of the final expression.
 form = define | expr ;
 
-# (define name expr)              — value binding
-# (define (name args*) expr+)     — function-definition sugar
+# (define name expr)                                        — value binding
+# (define name : type_annotation expr)                       — annotated value binding
+# (define (name params*) expr+)                              — function-definition sugar
+# (define (name typed_param*) -> type_annotation expr+)      — annotated function (with return type)
 #
 # The two shapes share the leading "define" keyword.  The parser
 # distinguishes them by what follows: a NAME token starts the value
 # form, an LPAREN starts the function-sugar form.
+#
+# LANG23 PR 23-E — type annotation extensions:
+#   - A value binding may carry `: type_annotation` between the name and value.
+#   - Each function parameter may be a bare NAME or a parenthesised
+#     `(NAME : type_annotation)` typed parameter.
+#   - A function signature may carry `-> type_annotation` for the return type,
+#     given as a NAME (value `"->"`) followed by the annotation, INSIDE the
+#     signature parentheses after all parameters.
+#
+# ``->`` lexes as an ARROW token (defined in ``twig.tokens`` as an exact
+# literal that takes priority over the NAME pattern, since both ``-`` and
+# ``>`` appear in the NAME character class).  Using a dedicated ARROW token
+# rather than a NAME-with-special-value means the ``{ typed_param }``
+# repetition stops cleanly at ARROW without needing look-ahead into values.
 define = LPAREN "define" name_or_signature expr { expr } RPAREN ;
 
-name_or_signature = NAME | LPAREN NAME { NAME } RPAREN ;
+name_or_signature = NAME [ COLON type_annotation ]
+                  | LPAREN NAME { typed_param } [ ARROW type_annotation ] RPAREN ;
+
+# A typed_param is either a bare NAME (unannotated) or a parenthesised
+# `(NAME : type_annotation)` pair (LANG23-annotated).
+typed_param = LPAREN NAME COLON type_annotation RPAREN | NAME ;
+
+# type_annotation covers the LANG23 v1 predicate vocabulary:
+#   NAME                              — unrefined kind: ``int``, ``any``, ``bool``, etc.
+#   (Int lo hi)                       — Range: (Int lo hi) ≡ lo ≤ x < hi (exclusive upper)
+#   (Member int (v0 v1 ...))          — Membership: value must be one of the listed integers
+#
+# ``Name`` matches any NAME token; ``INTEGER`` matches the existing signed-integer
+# literal token.  The grammar-parser tries alternatives left-to-right; the two-integer
+# form must come before the bare-name fallback to prevent premature commitment.
+type_annotation = LPAREN NAME LPAREN { INTEGER } RPAREN RPAREN
+                | LPAREN NAME INTEGER INTEGER RPAREN
+                | NAME ;
 
 # An expression is one of:
 #   - an atom (literal or bare name reference)

--- a/code/grammars/twig.tokens
+++ b/code/grammars/twig.tokens
@@ -26,6 +26,33 @@
 LPAREN     = "("
 RPAREN     = ")"
 QUOTE      = "'"
+# COLON is used for refinement type annotations (LANG23 PR 23-E):
+#   (define x : (Int 0 128) 42)               ; value binding with range annotation
+#   (define (f (x : (Int 0 128))) body)        ; parameter annotation
+#   (define (f (x : int) -> (Int 0 256)) body) ; return-type annotation
+# The colon character is not in the NAME regex so it was previously a
+# lex error.  Promoting it to its own punctuation token lets the parser
+# grammar test for it with the string literal ``":"``.
+COLON      = ":"
+# ARROW is the return-type annotation marker for LANG23 PR 23-E.
+#
+# Without ARROW, ``->`` would lex as a NAME token (both ``-`` and ``>``
+# appear in the NAME character class).  That causes an ambiguity in the
+# grammar's ``{ typed_param }`` repetition: the loop eagerly consumes
+# ``->`` as a bare-NAME parameter, then tries to parse ``(Int 0 256)``
+# as another typed_param, and fails with "Expected COLON, got '0'".
+#
+# By defining ARROW as an exact literal *before* the NAME pattern, the
+# lexer commits to ARROW when it sees ``->``, leaving the grammar free
+# to use ``ARROW`` as a sentinel that ends the param list and begins the
+# optional return-type annotation.
+#
+# Trade-off: ``->`` is no longer a legal Twig identifier.  In practice
+# this is not a restriction — no Twig standard-library function or
+# user program uses ``->`` as a name.  If that ever changes, a
+# ``keywords``-style promotion can be added; for now a reserved token
+# is the simplest, safest approach.
+ARROW      = "->"
 
 # ---------------------------------------------------------------------------
 # Boolean literals

--- a/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — brainfuck-iir-compiler
 
+## [0.1.1] — 2026-05-04
+
+### Fixed (LANG23 PR 23-E compatibility)
+
+- `IIRFunction` struct literals in `compiler.rs` updated to include
+  `param_refinements: Vec::new()` and `return_refinement: None` after
+  `interpreter-ir` 0.2.0 added those fields.  No behavioural change.
+
 ## [0.1.0] — 2026-04-29
 
 ### Added

--- a/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
+++ b/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brainfuck-iir-compiler"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "BF04 — Brainfuck → InterpreterIR compiler and vm-core wrapper"
 license = "MIT"

--- a/code/packages/rust/brainfuck-iir-compiler/src/compiler.rs
+++ b/code/packages/rust/brainfuck-iir-compiler/src/compiler.rs
@@ -212,6 +212,8 @@ impl Compiler {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         }
     }
 

--- a/code/packages/rust/interpreter-ir/CHANGELOG.md
+++ b/code/packages/rust/interpreter-ir/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — interpreter-ir
 
+## [0.2.0] — 2026-05-04
+
+### Added (LANG23 PR 23-E — refinement annotation fields, additive/opt-in)
+
+- `param_refinements: Vec<Option<RefinedType>>` field on `IIRFunction`.  In
+  lockstep with `params` — `param_refinements[i]` is `Some(rt)` when param `i`
+  carries a LANG23 annotation, `None` otherwise.  Empty `Vec` (not a `Vec` of
+  `None`s) from callers that never set annotations, distinguishing "no LANG23"
+  from "every param annotated as Any".
+- `return_refinement: Option<RefinedType>` field on `IIRFunction`.  `Some(rt)`
+  when the function carries a `-> TypeAnnotation` return type, `None` when
+  unannotated.
+- `IIRFunction::new()` updated to include both new fields (default empty/`None`).
+- `Default` impl for `IIRFunction` — enables `IIRFunction { name: "f".into(), ..Default::default() }`
+  struct-update syntax in tests and incremental builders; eliminates the need
+  to list every field at every construction site when adding new optional fields.
+- `lang-refined-types` added as a dependency.
+- Doc-test in `function.rs` updated to include both new fields.
+- Serialisation (`serialise.rs`) struct literal updated.
+
+### Design note
+
+These fields are **additive and opt-in**: all existing callers leave them at
+their default empty/`None` values and see no behaviour change.  The refinement
+checker (`lang-refinement-checker`) reads these fields to discharge proof
+obligations without any changes to the instruction stream or the existing
+`type_hint` string mechanism (which continues to carry unrefined kind
+information for the JIT/profiler).
+
 ## [0.1.0] — 2026-04-27
 
 Initial Rust port of the Python `interpreter-ir` package (LANG01).

--- a/code/packages/rust/interpreter-ir/Cargo.toml
+++ b/code/packages/rust/interpreter-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpreter-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "InterpreterIR (IIR) — the bytecode for the LANG JIT/AOT pipeline"
 
@@ -9,3 +9,9 @@ name = "interpreter_ir"
 path = "src/lib.rs"
 
 [dependencies]
+# LANG23 PR 23-E: carry refinement type annotations on IIRFunction.
+# `lang-refined-types` provides `RefinedType` and `Predicate` — the structured
+# annotation that the refinement checker reads.  The dependency is optional at
+# the data level (all annotation fields are `Option<RefinedType>`), so crates
+# that never set annotations pay only the added struct size.
+lang-refined-types = { path = "../lang-refined-types" }

--- a/code/packages/rust/interpreter-ir/src/function.rs
+++ b/code/packages/rust/interpreter-ir/src/function.rs
@@ -35,11 +35,14 @@
 //!     feedback_slots: std::collections::HashMap::new(),
 //!     // No source positions known for hand-built fixtures — leave empty.
 //!     source_map: Vec::new(),
+//!     param_refinements: Vec::new(),
+//!     return_refinement: None,
 //! };
 //! assert_eq!(fn_.param_names(), vec!["a", "b"]);
 //! ```
 
 use std::collections::HashMap;
+use lang_refined_types::RefinedType;
 use crate::instr::IIRInstr;
 use crate::opcodes::is_concrete_type;
 use crate::source_loc::SourceLoc;
@@ -136,10 +139,47 @@ pub struct IIRFunction {
     /// genuinely unknown (legacy callers, hand-built test fixtures).
     /// Frontends that lower from a real AST should always populate it.
     pub source_map: Vec<SourceLoc>,
+
+    // -----------------------------------------------------------------------
+    // LANG23 PR 23-E — refinement type annotations (additive, opt-in)
+    // -----------------------------------------------------------------------
+    //
+    // These two fields carry the LANG23 refinement type annotations that
+    // frontends parse from source (e.g. `(define (f (x : (Int 0 128)) ...) ...)`).
+    // They are **additive and opt-in**: all existing callers leave them at
+    // their default `None`/empty values and see no behaviour change.
+    //
+    // The refinement checker (`lang-refinement-checker`) reads these fields to
+    // discharge proof obligations for annotated functions without any changes to
+    // the instruction stream or the existing `type_hint` string mechanism (which
+    // continues to carry unrefined kind information for the JIT/profiler).
+
+    /// Per-parameter refinement type annotations, in **lockstep** with [`Self::params`].
+    ///
+    /// `param_refinements[i] = Some(rt)` when parameter `i` carries a LANG23
+    /// annotation; `None` means the parameter is unannotated (i.e. behaves as
+    /// if its type is `RefinedType::unrefined(Kind::Any)`, the default).
+    ///
+    /// Frontends must keep this vec in lockstep with `params` — same length,
+    /// same order.  Callers that never set annotations leave this as an empty
+    /// `Vec` (not a `Vec` of `None`s) so the absence of annotations is
+    /// distinguishable from "every param annotated as Any".
+    pub param_refinements: Vec<Option<RefinedType>>,
+
+    /// Optional refinement type annotation for the function's return value.
+    ///
+    /// `Some(rt)` when the function signature carries a `-> TypeAnnotation`
+    /// return type (e.g. `(define (clamp-byte (x : int) -> (Int 0 256)) ...)`).
+    /// `None` means the return type is unannotated.
+    pub return_refinement: Option<RefinedType>,
 }
 
 impl IIRFunction {
     /// Create a new function with default profiling fields.
+    ///
+    /// The LANG23 annotation fields (`param_refinements`, `return_refinement`)
+    /// default to empty / `None`; frontends that lower refinement annotations
+    /// set them on the returned struct after calling `new`.
     pub fn new(
         name: impl Into<String>,
         params: Vec<(String, String)>,
@@ -156,6 +196,8 @@ impl IIRFunction {
             call_count: 0,
             feedback_slots: HashMap::new(),
             source_map: Vec::new(),
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         fn_.type_status = fn_.infer_type_status();
         fn_
@@ -206,6 +248,30 @@ impl IIRFunction {
             instr.op == "label"
                 && instr.srcs.first().and_then(|s| s.as_var()) == Some(label_name)
         })
+    }
+}
+
+impl Default for IIRFunction {
+    /// Constructs an `IIRFunction` with empty/sensible defaults for all fields.
+    ///
+    /// Useful with struct-update syntax (`IIRFunction { name: "f".into(), ..Default::default() }`)
+    /// in tests and in code that builds functions incrementally.  Existing code that
+    /// constructs `IIRFunction` with a full struct literal can alternatively just append
+    /// `param_refinements: Vec::new(), return_refinement: None,` for the LANG23 fields.
+    fn default() -> Self {
+        IIRFunction {
+            name: String::new(),
+            params: Vec::new(),
+            return_type: "any".into(),
+            instructions: Vec::new(),
+            register_count: 8,
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: HashMap::new(),
+            source_map: Vec::new(),
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        }
     }
 }
 

--- a/code/packages/rust/interpreter-ir/src/serialise.rs
+++ b/code/packages/rust/interpreter-ir/src/serialise.rs
@@ -335,6 +335,8 @@ fn deserialise_function(r: &mut Reader<'_>) -> Result<IIRFunction, DeserialiseEr
         call_count: 0,
         feedback_slots: std::collections::HashMap::new(),
         source_map: Vec::new(),
+        param_refinements: Vec::new(),
+        return_refinement: None,
     })
 }
 

--- a/code/packages/rust/twig-formatter/CHANGELOG.md
+++ b/code/packages/rust/twig-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — twig-formatter
 
+## [0.1.1] — 2026-05-04
+
+### Fixed (LANG23 PR 23-E compatibility)
+
+- `Define` struct literal in `format_define` updated to include the new
+  `type_annotation` field added by `twig-parser` 0.2.0.  The formatter
+  carries the annotation through unchanged (pretty-printing of annotated
+  defines is a future task — for now annotations are preserved in the
+  AST but not rendered in the formatted output).
+- `Lambda` struct literal in `format_lambda` updated to include
+  `param_annotations` and `return_annotation` fields.  Same policy:
+  annotations preserved, not rendered yet.
+
 ## [0.1.0] — 2026-04-30
 
 Initial release.  Canonical Twig pretty-printer.  The first

--- a/code/packages/rust/twig-formatter/Cargo.toml
+++ b/code/packages/rust/twig-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-formatter"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Canonical Twig pretty-printer.  AST -> format-doc Doc -> canonical source.  The prettier/rustfmt equivalent for the Twig authoring experience."
 

--- a/code/packages/rust/twig-formatter/src/lib.rs
+++ b/code/packages/rust/twig-formatter/src/lib.rs
@@ -479,6 +479,7 @@ mod tests {
         match f {
             Form::Define(d) => Form::Define(Define {
                 name: d.name.clone(),
+                type_annotation: d.type_annotation.clone(),
                 expr: strip_expr(&d.expr),
                 line: 0,
                 column: 0,
@@ -513,6 +514,8 @@ mod tests {
             }),
             Expr::Lambda(l) => Expr::Lambda(Lambda {
                 params: l.params.clone(),
+                param_annotations: l.param_annotations.clone(),
+                return_annotation: l.return_annotation.clone(),
                 body: l.body.iter().map(strip_expr).collect(),
                 line: 0,
                 column: 0,

--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — twig-ir-compiler
 
+## [0.2.0] — 2026-05-04
+
+### Added (LANG23 PR 23-E — emit RefinedType annotations into IIR)
+
+- `type_annotation_to_refined_type(ann: &TypeAnnotation) -> RefinedType`:
+  conversion function that bridges the parser's `TypeAnnotation` enum to
+  `lang-refined-types::RefinedType`.  Matches all five `TypeAnnotation` variants:
+  - `UnrefinedInt` → `RefinedType::unrefined(Kind::Int)`
+  - `UnrefinedBool` → `RefinedType::unrefined(Kind::Bool)`
+  - `Any` → `RefinedType::unrefined(Kind::Any)`
+  - `RangeInt { lo, hi }` → `RefinedType::refined(Kind::Int, Predicate::Range { lo, hi, inclusive_hi: false })`
+  - `MembershipInt { values }` → `RefinedType::refined(Kind::Int, Predicate::Membership { values })`
+- `compile_top_level_lambda` now populates `IIRFunction::param_refinements` and
+  `IIRFunction::return_refinement` from the `Lambda` node's annotation fields.
+- `lang-refined-types` added as a dependency.
+- Round-trip tests in `lib.rs` (PR 23-E section, 7 new tests):
+  - `ranged_int_param_annotation_round_trips_to_iir`
+  - `unrefined_int_param_annotation_round_trips`
+  - `return_annotation_round_trips_to_iir`
+  - `multiple_annotated_params_lockstep`
+  - `unannotated_function_has_no_refinement_fields`
+  - `annotation_does_not_change_existing_type_hints`
+  - `source_map_lockstep_holds_for_annotated_functions`
+
 ## [0.1.0] — 2026-04-29
 
 ### Added

--- a/code/packages/rust/twig-ir-compiler/Cargo.toml
+++ b/code/packages/rust/twig-ir-compiler/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "twig-ir-compiler"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler"
 
 [dependencies]
-twig-parser    = { path = "../twig-parser" }
-twig-lexer     = { path = "../twig-lexer" }
-interpreter-ir = { path = "../interpreter-ir" }
+twig-parser       = { path = "../twig-parser" }
+twig-lexer        = { path = "../twig-lexer" }
+interpreter-ir    = { path = "../interpreter-ir" }
+# LANG23 PR 23-E: convert parsed TypeAnnotation → RefinedType for IIR annotation fields.
+lang-refined-types = { path = "../lang-refined-types" }

--- a/code/packages/rust/twig-ir-compiler/README.md
+++ b/code/packages/rust/twig-ir-compiler/README.md
@@ -65,13 +65,34 @@ assert_eq!(module.entry_point.as_deref(), Some("main"));
 
 `interpreter_ir::Operand` has `Var`, `Int`, `Float`, `Bool` — no dedicated `String` variant. Where the IR semantically needs a string literal (e.g. the function name passed to `make_closure`), we materialise it via a `const` instruction whose source operand is `Operand::Var(literal_text)`. The `vm-core` `const` handler stores the literal verbatim. See the module-level comment in `src/compiler.rs` for the full rationale.
 
+## LANG23 PR 23-E: Refinement type annotation emission
+
+When a Twig function carries LANG23 annotation syntax, the compiler lowers it
+into the corresponding `IIRFunction` fields:
+
+```scheme
+; Both params and return type annotated:
+(define (clamp-byte (x : int) -> (Int 0 256)) x)
+```
+
+produces an `IIRFunction` where:
+- `params` = `[("x", "any")]` (unchanged — Twig is still dynamically typed)
+- `param_refinements` = `[Some(RefinedType::unrefined(Kind::Int))]`
+- `return_refinement` = `Some(RefinedType::refined(Kind::Int, Range(0, 256)))`
+
+The refinement checker (`lang-refinement-checker`) reads these fields to
+discharge proof obligations.  Callers that don't use LANG23 syntax see zero
+change — annotation fields default to empty/`None`.
+
 ## Tests
 
 ```bash
 cargo test -p twig-ir-compiler
 ```
 
-Coverage targets the same surface as the Python `tests/test_compiler.py`: every literal, every form, the apply-site dispatch decision, free-variable analysis (via the dedicated `free_vars` module's tests), top-level recursion, mutual recursion, error paths.
+56+ unit tests covering every literal, every form, apply-site dispatch, free-variable
+analysis, top-level recursion, mutual recursion, error paths, and 7 LANG23 round-trip
+tests verifying that annotations survive the parse → compile → IIR pipeline.
 
 ## Where it fits in the stack
 

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -66,13 +66,54 @@ use interpreter_ir::{
     module::IIRModule,
     SourceLoc,
 };
+use lang_refined_types::{Kind, Predicate, RefinedType};
 
 use twig_parser::{
-    Apply, Begin, BoolLit, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program, SymLit, VarRef,
+    Apply, Begin, BoolLit, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program, SymLit,
+    TypeAnnotation, VarRef,
 };
 
 use crate::errors::TwigCompileError;
 use crate::free_vars::free_vars;
+
+// ---------------------------------------------------------------------------
+// LANG23 PR 23-E — TypeAnnotation → RefinedType conversion
+// ---------------------------------------------------------------------------
+
+/// Convert a parsed [`TypeAnnotation`] into a [`RefinedType`] that the IIR
+/// carries and the refinement checker reads.
+///
+/// This is the bridge between the syntactic form (what the Twig parser
+/// produces) and the semantic form (what `lang-refinement-checker` understands).
+///
+/// # Mapping
+///
+/// | `TypeAnnotation`          | `RefinedType`                                       |
+/// |---------------------------|-----------------------------------------------------|
+/// | `UnrefinedInt`            | `RefinedType::unrefined(Kind::Int)`                 |
+/// | `Any`                     | `RefinedType::unrefined(Kind::Any)`                 |
+/// | `UnrefinedBool`           | `RefinedType::unrefined(Kind::Bool)`                |
+/// | `RangeInt { lo, hi }`     | `RefinedType::refined(Int, Range{lo,hi,excl_hi})`   |
+/// | `MembershipInt { values }`| `RefinedType::refined(Int, Membership{values})`     |
+fn type_annotation_to_refined_type(ann: &TypeAnnotation) -> RefinedType {
+    match ann {
+        TypeAnnotation::UnrefinedInt => RefinedType::unrefined(Kind::Int),
+        TypeAnnotation::Any => RefinedType::unrefined(Kind::Any),
+        TypeAnnotation::UnrefinedBool => RefinedType::unrefined(Kind::Bool),
+        TypeAnnotation::RangeInt { lo, hi } => RefinedType::refined(
+            Kind::Int,
+            Predicate::Range {
+                lo: Some(*lo),
+                hi: Some(*hi),
+                inclusive_hi: false, // Twig v1 always uses exclusive upper bound
+            },
+        ),
+        TypeAnnotation::MembershipInt { values } => RefinedType::refined(
+            Kind::Int,
+            Predicate::Membership { values: values.clone() },
+        ),
+    }
+}
 
 /// Maximum AST-nesting depth the compiler will descend.
 ///
@@ -297,6 +338,8 @@ impl Compiler {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: main_ctx.source_map,
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         self.functions.push(main_fn);
 
@@ -339,6 +382,19 @@ impl Compiler {
             .map(|p| (p.clone(), "any".to_string()))
             .collect();
 
+        // LANG23 PR 23-E — lower TypeAnnotation → RefinedType for every param
+        // and for the return type.  Unannotated params stay as `None`.
+        let param_refinements: Vec<Option<RefinedType>> = lam
+            .param_annotations
+            .iter()
+            .map(|ann| ann.as_ref().map(type_annotation_to_refined_type))
+            .collect();
+
+        let return_refinement: Option<RefinedType> = lam
+            .return_annotation
+            .as_ref()
+            .map(type_annotation_to_refined_type);
+
         self.functions.push(IIRFunction {
             name: name.to_string(),
             params,
@@ -349,6 +405,8 @@ impl Compiler {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: ctx.source_map,
+            param_refinements,
+            return_refinement,
         });
         Ok(())
     }
@@ -428,6 +486,8 @@ impl Compiler {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: inner.source_map,
+            param_refinements: Vec::new(),
+            return_refinement: None,
         });
 
         // 3. Emit `make_closure` at the call site.

--- a/code/packages/rust/twig-ir-compiler/src/lib.rs
+++ b/code/packages/rust/twig-ir-compiler/src/lib.rs
@@ -631,4 +631,151 @@ mod tests {
             "expected positions on both lines 1 and 2, got {lines_seen:?}",
         );
     }
+
+    // ---- PR 23-E: refinement type annotation round-trip ----------------
+    //
+    // These tests verify that LANG23 refinement annotations written in Twig
+    // source (`(x : (Int 0 128))`, `-> (Int 0 256)`) are:
+    //   1. Parsed into `TypeAnnotation` variants on the `Lambda`/`Define` nodes.
+    //   2. Lowered by the IR compiler into `param_refinements` / `return_refinement`
+    //      on the resulting `IIRFunction`.
+    //
+    // They do NOT test the refinement checker (that is `lang-refinement-checker`'s
+    // job).  They test only that the annotation survives the
+    // parse → compile → IIRFunction pipeline.
+
+    /// A function defined with a ranged-int parameter annotation should carry
+    /// a `Some(RefinedType)` in `param_refinements[0]` on the IIR function.
+    #[test]
+    fn ranged_int_param_annotation_round_trips_to_iir() {
+        use lang_refined_types::{Kind, Predicate, RefinedType};
+        // `(x : (Int 0 128))` means x ∈ [0, 128).
+        let src = "(define (clamp (x : (Int 0 128))) x)";
+        let m = compile_source(src, "test_23e").unwrap();
+        let f = m.functions.iter().find(|f| f.name == "clamp")
+            .expect("expected function named 'clamp'");
+        // `param_refinements` must be in lockstep with `params`.
+        assert_eq!(
+            f.param_refinements.len(), f.params.len(),
+            "param_refinements must be lockstep with params"
+        );
+        let rt = f.param_refinements[0]
+            .as_ref()
+            .expect("param 0 should have a refinement annotation");
+        let expected = RefinedType::refined(
+            Kind::Int,
+            Predicate::Range { lo: Some(0), hi: Some(128), inclusive_hi: false },
+        );
+        assert_eq!(rt, &expected, "param refinement should be Range(0,128)");
+    }
+
+    /// A function with an unrefined `int` type annotation on a parameter should
+    /// produce `RefinedType::unrefined(Kind::Int)` — not `None`.
+    #[test]
+    fn unrefined_int_param_annotation_round_trips() {
+        use lang_refined_types::{Kind, RefinedType};
+        let src = "(define (double (x : int)) (* x 2))";
+        let m = compile_source(src, "test_23e").unwrap();
+        let f = m.functions.iter().find(|f| f.name == "double").unwrap();
+        let rt = f.param_refinements[0].as_ref()
+            .expect("param 0 should be annotated as int");
+        assert_eq!(rt, &RefinedType::unrefined(Kind::Int));
+    }
+
+    /// A function with a return type annotation `-> (Int 0 256)` should have
+    /// `return_refinement = Some(RefinedType::refined(Kind::Int, Range(0,256)))`.
+    #[test]
+    fn return_annotation_round_trips_to_iir() {
+        use lang_refined_types::{Kind, Predicate, RefinedType};
+        let src = "(define (clamp-byte (x : int) -> (Int 0 256)) x)";
+        let m = compile_source(src, "test_23e").unwrap();
+        let f = m.functions.iter().find(|f| f.name == "clamp-byte").unwrap();
+        let rt = f.return_refinement.as_ref()
+            .expect("clamp-byte should have a return refinement");
+        let expected = RefinedType::refined(
+            Kind::Int,
+            Predicate::Range { lo: Some(0), hi: Some(256), inclusive_hi: false },
+        );
+        assert_eq!(rt, &expected);
+    }
+
+    /// A function with multiple annotated parameters (mixed refined and plain)
+    /// gets a lockstep `param_refinements` vector.
+    #[test]
+    fn multiple_annotated_params_lockstep() {
+        use lang_refined_types::{Kind, Predicate, RefinedType};
+        // lo is annotated; hi is unannotated (plain name without `:`).
+        let src = "(define (in-range (lo : (Int 0 100)) hi) (+ lo hi))";
+        let m = compile_source(src, "test_23e").unwrap();
+        let f = m.functions.iter().find(|f| f.name == "in-range").unwrap();
+        assert_eq!(f.params.len(), 2);
+        assert_eq!(f.param_refinements.len(), 2,
+            "lockstep: 2 params ⇒ 2 entries in param_refinements");
+        // param 0: annotated
+        let rt0 = f.param_refinements[0].as_ref().expect("lo should be annotated");
+        assert_eq!(
+            rt0,
+            &RefinedType::refined(
+                Kind::Int,
+                Predicate::Range { lo: Some(0), hi: Some(100), inclusive_hi: false },
+            )
+        );
+        // param 1: unannotated → None
+        assert!(f.param_refinements[1].is_none(), "hi should be None (unannotated)");
+    }
+
+    /// A function with NO annotations should have empty/None annotation fields.
+    ///
+    /// This is the opt-in contract: callers that don't use LANG23 annotations
+    /// see zero change in the IIR they receive.
+    #[test]
+    fn unannotated_function_has_no_refinement_fields() {
+        let src = "(define (add x y) (+ x y))";
+        let m = compile_source(src, "test_23e").unwrap();
+        let f = m.functions.iter().find(|f| f.name == "add").unwrap();
+        // Either empty (pre-LANG23 path) or all-None.
+        let all_none = f.param_refinements.iter().all(|r| r.is_none());
+        assert!(
+            f.param_refinements.is_empty() || all_none,
+            "unannotated function should have empty or all-None param_refinements"
+        );
+        assert!(f.return_refinement.is_none());
+    }
+
+    /// Parsing an annotated function does not change its `params` tuple —
+    /// the `type_hint` field of each param entry is still `"any"` (dynamic typing
+    /// is unchanged; refinements are carried in the parallel `param_refinements`
+    /// field, not in the existing `type_hint` strings).
+    #[test]
+    fn annotation_does_not_change_existing_type_hints() {
+        let src = "(define (f (x : (Int 0 10)) (y : int)) (+ x y))";
+        let m = compile_source(src, "test_23e").unwrap();
+        let f = m.functions.iter().find(|f| f.name == "f").unwrap();
+        for (_, type_hint) in &f.params {
+            assert_eq!(type_hint, "any",
+                "type_hint must remain 'any'; refinements live in param_refinements");
+        }
+        assert_eq!(f.return_type, "any");
+    }
+
+    /// The `source_map` lockstep invariant still holds for annotated functions —
+    /// adding annotations must not corrupt instruction count vs source_map.
+    #[test]
+    fn source_map_lockstep_holds_for_annotated_functions() {
+        let srcs = [
+            "(define (f (x : (Int 0 128))) x)",
+            "(define (g (x : int) -> (Int 0 256)) x)",
+            "(define (h (a : (Int 0 10)) (b : (Int 0 20)) -> (Int 0 30)) (+ a b))",
+        ];
+        for src in srcs {
+            let m = compile_source(src, "lockstep_23e").unwrap();
+            for f in &m.functions {
+                assert_eq!(
+                    f.source_map.len(), f.instructions.len(),
+                    "lockstep violated in fn {:?} for source {src:?}",
+                    f.name,
+                );
+            }
+        }
+    }
 }

--- a/code/packages/rust/twig-lexer/CHANGELOG.md
+++ b/code/packages/rust/twig-lexer/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — twig-lexer
 
+## [0.2.0] — 2026-05-04
+
+### Added (LANG23 PR 23-E — refinement type annotation tokens)
+
+- `COLON` token (`:`): promotes the colon character from a lex error to a
+  dedicated punctuation token, enabling `(x : (Int 0 128))` parameter
+  annotations and `(define x : (Int 0 128) val)` annotated value bindings.
+- `ARROW` token (`->`): exact-literal token that takes priority over the `NAME`
+  pattern in the lexer, preventing the return-type annotation marker from being
+  consumed as a bare-NAME parameter in `{ typed_param }` repetitions.  Without
+  this token, `(define (f (x : int) -> (Int 0 256)) body)` would fail with
+  "Expected COLON, got '0'".
+- Tests for `COLON` and `ARROW` token lexing, including boundary checks that
+  `-` alone still lexes as `NAME` (longest-match: `->` is ARROW, `-` is NAME).
+- Token-table documentation updated to include `COLON` and `ARROW` entries.
+
 ## [0.1.0] — 2026-04-29
 
 ### Added

--- a/code/packages/rust/twig-lexer/Cargo.toml
+++ b/code/packages/rust/twig-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-lexer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Twig (Lisp-precursor) lexer — thin wrapper over GrammarLexer; grammar is build-time-compiled to Rust via grammar_tools::codegen"
 build = "build.rs"

--- a/code/packages/rust/twig-lexer/README.md
+++ b/code/packages/rust/twig-lexer/README.md
@@ -15,6 +15,8 @@ Mirrors the same wrapper pattern used by every other Rust language frontend in t
 | `LPAREN`     | `LParen`       | `None`                | `"LPAREN"`           |
 | `RPAREN`     | `RParen`       | `None`                | `"RPAREN"`           |
 | `QUOTE`      | `Name`         | `Some("QUOTE")`       | `"QUOTE"`            |
+| `COLON`      | `Name`         | `Some("COLON")`       | `"COLON"`            |
+| `ARROW`      | `Name`         | `Some("ARROW")`       | `"ARROW"`            |
 | `BOOL_TRUE`  | `Name`         | `Some("BOOL_TRUE")`   | `"BOOL_TRUE"`        |
 | `BOOL_FALSE` | `Name`         | `Some("BOOL_FALSE")`  | `"BOOL_FALSE"`       |
 | `INTEGER`    | `Name`         | `Some("INTEGER")`     | `"INTEGER"`          |
@@ -23,6 +25,8 @@ Mirrors the same wrapper pattern used by every other Rust language frontend in t
 | (sentinel)   | `Eof`          | `None`                | `"EOF"`              |
 
 The seven Twig keywords (`define`, `lambda`, `let`, `if`, `begin`, `quote`, `nil`) are promoted from `NAME` to `KEYWORD` at lex time. Whitespace and `;`-to-end-of-line comments are silently skipped.
+
+**LANG23 PR 23-E additions:** `COLON` (`:`) and `ARROW` (`->`) are exact-literal tokens that take priority over the `NAME` pattern, enabling refinement type annotations in function signatures.  `->` is now reserved (it was previously a valid identifier but was never used in that role).
 
 ## Usage
 

--- a/code/packages/rust/twig-lexer/src/lib.rs
+++ b/code/packages/rust/twig-lexer/src/lib.rs
@@ -29,12 +29,18 @@
 //! | `LPAREN`     | `LParen`       | `None`                |
 //! | `RPAREN`     | `RParen`       | `None`                |
 //! | `QUOTE`      | `Name`         | `Some("QUOTE")`       |
+//! | `COLON`      | `Name`         | `Some("COLON")`       |
+//! | `ARROW`      | `Name`         | `Some("ARROW")`       |
 //! | `BOOL_TRUE`  | `Name`         | `Some("BOOL_TRUE")`   |
 //! | `BOOL_FALSE` | `Name`         | `Some("BOOL_FALSE")`  |
 //! | `INTEGER`    | `Number`       | `None`                |
 //! | `KEYWORD`    | `Keyword`      | `Some("KEYWORD")`     |
 //! | `NAME`       | `Name`         | `None`                |
 //! |              | `Eof`          | `None`                |
+//!
+//! `COLON` (`:`) and `ARROW` (`->`) are LANG23 PR 23-E additions that
+//! enable refinement type annotations in function signatures.  Both are
+//! exact-literal tokens that take priority over the `NAME` pattern.
 //!
 //! Whitespace and `;`-to-end-of-line comments are silently skipped — they
 //! never appear in the output.  Position tracking is 1-indexed.
@@ -137,11 +143,12 @@ pub fn create_twig_lexer(source: &str) -> GrammarLexer<'_> {
 /// # Errors
 ///
 /// Returns a [`LexerError`] if the source contains a character outside
-/// every token's valid set — most often a stray `@`, `~`, `:`, an
-/// ASCII control character, or non-ASCII Unicode.  Callers handling
-/// untrusted input MUST handle this `Err` case; the previous panicking
-/// version was a DoS vector (single-character adversarial inputs would
-/// abort the process).
+/// every token's valid set — most often a stray `@`, `~`, or an
+/// ASCII control character or non-ASCII Unicode.  (`:` is now a valid `COLON`
+/// token for LANG23 refinement annotations; `->` is a dedicated `ARROW` token.)
+/// Callers handling untrusted input MUST handle this `Err` case; the previous
+/// panicking version was a DoS vector (single-character adversarial inputs
+/// would abort the process).
 ///
 /// # Panics
 ///
@@ -318,6 +325,49 @@ mod tests {
         let src = "(eq? 'foo)";
         let kinds = type_names(src);
         assert_eq!(kinds, vec!["LPAREN", "NAME", "QUOTE", "NAME", "RPAREN"]);
+    }
+
+    // -- LANG23 PR 23-E: COLON and ARROW tokens --
+
+    /// `:` must lex as a COLON token (effective_type_name = "COLON"),
+    /// not as a NAME or a LexerError.
+    #[test]
+    fn colon_lexes_as_colon_token() {
+        let kinds = type_names(":");
+        assert_eq!(kinds, vec!["COLON"]);
+        let vals = values(":");
+        assert_eq!(vals, vec![":"]);
+    }
+
+    /// `->` must lex as a single ARROW token (effective_type_name = "ARROW").
+    /// Without the ARROW literal token, `->` would lex as NAME and
+    /// cause ambiguity inside `{ typed_param }` repetitions.
+    #[test]
+    fn arrow_lexes_as_arrow_token() {
+        let kinds = type_names("->");
+        assert_eq!(kinds, vec!["ARROW"]);
+        let vals = values("->");
+        assert_eq!(vals, vec!["->"]);
+    }
+
+    /// In a full annotated signature, all annotation tokens appear correctly.
+    /// Source: `(x : (Int 0 128)) -> (Int 0 256)`
+    /// Expected: LPAREN NAME COLON LPAREN NAME INTEGER INTEGER RPAREN RPAREN
+    ///           ARROW LPAREN NAME INTEGER INTEGER RPAREN
+    #[test]
+    fn annotation_tokens_in_sequence() {
+        let kinds = type_names("(x : (Int 0 128)) -> (Int 0 256)");
+        assert!(kinds.contains(&"COLON".to_string()), "COLON missing: {kinds:?}");
+        assert!(kinds.contains(&"ARROW".to_string()), "ARROW missing: {kinds:?}");
+    }
+
+    /// `-` alone (the subtraction operator) must still lex as NAME,
+    /// not as the ARROW prefix.  Longest-match: `->` is ARROW, `-`
+    /// alone remains NAME.
+    #[test]
+    fn bare_minus_still_name_after_arrow_token_added() {
+        assert_eq!(type_names("-"), vec!["NAME"]);
+        assert_eq!(values("-"), vec!["-"]);
     }
 
     // -- Adversarial input returns Err, not a panic --

--- a/code/packages/rust/twig-parser/CHANGELOG.md
+++ b/code/packages/rust/twig-parser/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog — twig-parser
 
+## [0.2.0] — 2026-05-04
+
+### Added (LANG23 PR 23-E — refinement type annotation syntax)
+
+- `TypeAnnotation` enum (`src/ast_nodes.rs`): bridges parsed Twig annotation
+  syntax to `lang-refined-types::RefinedType`.  Variants:
+  - `UnrefinedInt` — bare `int` annotation
+  - `UnrefinedBool` — bare `bool` annotation
+  - `Any` — bare `any` annotation
+  - `RangeInt { lo, hi }` — `(Int lo hi)` ≡ `lo ≤ x < hi`
+  - `MembershipInt { values }` — `(Member int (v0 v1 ...))` membership set
+- `Lambda` extended with `param_annotations: Vec<Option<TypeAnnotation>>` and
+  `return_annotation: Option<TypeAnnotation>` (lockstep with `params`; default
+  empty/`None` so all pre-LANG23 callers continue to compile without changes).
+- `Define` extended with `type_annotation: Option<TypeAnnotation>` for annotated
+  value bindings (`(define x : (Int 0 128) val)`).
+- `twig.grammar` extended with three new productions:
+  - `name_or_signature` — now supports typed params and optional `ARROW type_annotation`
+  - `typed_param` — bare `NAME` or `(NAME COLON type_annotation)`
+  - `type_annotation` — `NAME` | `(Int lo hi)` | `(Member int (vals...))`
+- `ast_extract.rs` additions:
+  - `extract_type_annotation(node)` — lowers a `type_annotation` grammar node
+    into a `TypeAnnotation` variant.
+  - `extract_fn_signature(sig_node)` — extracts fn name, param names, per-param
+    annotations, and optional return annotation from a `name_or_signature` CST node.
+  - `extract_typed_param(node)` — handles bare-NAME and annotated params.
+  - `extract_define` updated to handle annotated function defines and annotated
+    value bindings.
+  - `extract_lambda` updated to carry lockstep `param_annotations` (all `None`
+    for anonymous lambdas, preserving the invariant that `len(param_annotations)
+    == len(params)`).
+- `TypeAnnotation` re-exported from `lib.rs`.
+
+### Fixed
+
+- Return-type arrow (`->`) now lexes as a dedicated `ARROW` token (defined in
+  `twig.tokens` before the `NAME` pattern).  Previously `->` matched `NAME` and
+  was consumed by the `{ typed_param }` repetition before the optional return
+  annotation could be parsed, causing "Expected COLON, got '0'" errors on any
+  function with a `-> TypeAnnotation` return type.
+
 ## [0.1.0] — 2026-04-29
 
 ### Added

--- a/code/packages/rust/twig-parser/Cargo.toml
+++ b/code/packages/rust/twig-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Twig (Lisp-precursor) parser — thin wrapper over GrammarParser plus a typed-AST extractor; grammar is build-time-compiled to Rust via grammar_tools::codegen"
 build = "build.rs"

--- a/code/packages/rust/twig-parser/README.md
+++ b/code/packages/rust/twig-parser/README.md
@@ -8,13 +8,21 @@ Twig source --> [twig-lexer] --> tokens --> [twig-parser] --> AST --> [twig-ir-c
 
 Same pattern as every other Rust language frontend (`brainfuck`, `dartmouth-basic`, …) and as the Python [`twig` package](../../python/twig)'s `parser.py` + `ast_extract.py` pair.
 
-## Grammar (one screen, lives in `code/grammars/twig.grammar`)
+## Grammar (lives in `code/grammars/twig.grammar`)
 
 ```text
 program     = { form } ;
 form        = define | expr ;
 define      = LPAREN "define" name_or_signature expr { expr } RPAREN ;
-name_or_signature = NAME | LPAREN NAME { NAME } RPAREN ;
+
+; LANG23 PR 23-E: typed params + return annotation
+name_or_signature = NAME [ COLON type_annotation ]
+                  | LPAREN NAME { typed_param } [ ARROW type_annotation ] RPAREN ;
+typed_param = LPAREN NAME COLON type_annotation RPAREN | NAME ;
+type_annotation = LPAREN NAME LPAREN { INTEGER } RPAREN RPAREN  ; membership
+                | LPAREN NAME INTEGER INTEGER RPAREN             ; range
+                | NAME ;                                         ; bare kind
+
 expr        = atom | quoted | compound ;
 atom        = INTEGER | BOOL_TRUE | BOOL_FALSE | "nil" | NAME ;
 quoted      = QUOTE NAME ;
@@ -28,23 +36,44 @@ quote_form  = LPAREN "quote"  NAME RPAREN ;
 apply       = LPAREN expr { expr } RPAREN ;
 ```
 
+### LANG23 PR 23-E annotation syntax
+
+```scheme
+; Ranged int parameter: x must be in [0, 128)
+(define (clamp (x : (Int 0 128))) x)
+
+; Annotated parameter + annotated return type
+(define (clamp-byte (x : int) -> (Int 0 256)) x)
+
+; Mixed: first param annotated, second plain
+(define (in-range (lo : (Int 0 100)) hi) (+ lo hi))
+
+; Annotated value binding
+(define count : (Int 0 1000) 42)
+```
+
+`->` lexes as the dedicated `ARROW` token (not a `NAME`), so `{ typed_param }`
+stops cleanly at the arrow.  `COLON` (`:`) is likewise a dedicated token.
+Both take priority over `NAME` in the lexer via longest-match ordering.
+
 ## Typed AST
 
 The crate's `ast_extract` module walks the generic `GrammarASTNode` tree and lifts each meaningful subtree into one of these typed variants:
 
-| Type      | Used for                         |
-|-----------|----------------------------------|
-| `IntLit`  | `42`, `-7`                       |
-| `BoolLit` | `#t`, `#f`                       |
-| `NilLit`  | `nil`                            |
-| `SymLit`  | `'foo`, `(quote foo)`            |
-| `VarRef`  | `x`, `+`, `null?`                |
-| `If`      | `(if c t e)`                     |
-| `Let`     | `(let ((x 1)) body+)`            |
-| `Begin`   | `(begin e1 e2 ...)`              |
-| `Lambda`  | `(lambda (params) body+)`        |
-| `Apply`   | `(fn arg0 arg1 ...)`             |
-| `Define`  | `(define name expr)` (top-level) |
+| Type             | Used for                                        |
+|------------------|-------------------------------------------------|
+| `IntLit`         | `42`, `-7`                                      |
+| `BoolLit`        | `#t`, `#f`                                      |
+| `NilLit`         | `nil`                                           |
+| `SymLit`         | `'foo`, `(quote foo)`                           |
+| `VarRef`         | `x`, `+`, `null?`                               |
+| `If`             | `(if c t e)`                                    |
+| `Let`            | `(let ((x 1)) body+)`                           |
+| `Begin`          | `(begin e1 e2 ...)`                             |
+| `Lambda`         | `(lambda (params) body+)`                       |
+| `Apply`          | `(fn arg0 arg1 ...)`                            |
+| `Define`         | `(define name expr)` (top-level)                |
+| `TypeAnnotation` | LANG23: `int`, `(Int lo hi)`, `(Member int …)` |
 
 The function-sugar form `(define (f x) body+)` lowers to `Define { name: "f", expr: Lambda { params: ["x"], body } }` during extraction — downstream code only ever sees the lambda shape.  Both quote forms (`'foo` and `(quote foo)`) collapse to a single `SymLit`.
 
@@ -81,4 +110,4 @@ The `GrammarParser` is recursive (one stack frame per matched rule).  Pathologic
 cargo test -p twig-parser
 ```
 
-31 unit tests covering every form, the function-sugar lowering, multi-expression bodies, position tracking, and error/depth-cap paths.
+33 unit tests covering every form, the function-sugar lowering, multi-expression bodies, position tracking, error/depth-cap paths, and LANG23 annotation parsing.

--- a/code/packages/rust/twig-parser/src/ast_extract.rs
+++ b/code/packages/rust/twig-parser/src/ast_extract.rs
@@ -41,7 +41,7 @@ use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 
 use crate::ast_nodes::{
     Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program, SymLit,
-    VarRef,
+    TypeAnnotation, VarRef,
 };
 use crate::TwigParseError;
 
@@ -190,7 +190,121 @@ fn extract_form(node: &GrammarASTNode, depth: usize) -> Result<Form, TwigParseEr
 }
 
 // ---------------------------------------------------------------------------
+// LANG23 PR 23-E — type annotation extraction
+// ---------------------------------------------------------------------------
+
+/// Extract a LANG23 v1 [`TypeAnnotation`] from a `type_annotation` grammar node.
+///
+/// The grammar has three alternatives (tried in order):
+///
+/// 1. `LPAREN NAME LPAREN { INTEGER } RPAREN RPAREN`  — Membership:  `(Member int (1 2 3))`
+/// 2. `LPAREN NAME INTEGER INTEGER RPAREN`             — Range:       `(Int 0 256)`
+/// 3. `NAME`                                           — Unrefined:   `int`, `any`, `bool`
+///
+/// The function reads the concrete children of the node rather than the grammar
+/// rule name so it is robust to the extractor being called on any subtree that
+/// contains exactly one `type_annotation` child.
+fn extract_type_annotation(node: &GrammarASTNode) -> Result<TypeAnnotation, TwigParseError> {
+    let (line, column) = pos(node);
+
+    // Collect the flat children of this node (mix of tokens and sub-nodes).
+    // The grammar produces either:
+    //   Case A — bare NAME token (no parens): token list = [NAME]
+    //   Case B — (Name lo hi): LPAREN NAME INTEGER INTEGER RPAREN
+    //   Case C — (Name int (v…)): LPAREN NAME LPAREN { INTEGER } RPAREN RPAREN
+    let has_outer_paren = node.children.iter().any(|c| is_token_named(c, "LPAREN"));
+
+    if !has_outer_paren {
+        // Case A — bare kind name: `int`, `any`, `bool`, etc.
+        let name_tok = first_token_named(node, "NAME").ok_or_else(|| TwigParseError {
+            message: "type_annotation: expected kind name".into(),
+            line,
+            column,
+        })?;
+        return match name_tok.value.as_str() {
+            "int"  => Ok(TypeAnnotation::UnrefinedInt),
+            "any"  => Ok(TypeAnnotation::Any),
+            "bool" => Ok(TypeAnnotation::UnrefinedBool),
+            other  => Err(TwigParseError {
+                message: format!(
+                    "unknown type annotation name {:?}; \
+                     expected one of: int, any, bool, or a parenthesised form like (Int lo hi)",
+                    other
+                ),
+                line: name_tok.line,
+                column: name_tok.column,
+            }),
+        };
+    }
+
+    // Cases B and C — parenthesised predicate form.
+    // First NAME token is the predicate constructor: "Int", "Member", …
+    let name_tok = first_token_named(node, "NAME").ok_or_else(|| TwigParseError {
+        message: "type_annotation: parenthesised form missing constructor name".into(),
+        line,
+        column,
+    })?;
+    let all_ints: Vec<&Token> = tokens_named(node, "INTEGER");
+
+    match name_tok.value.as_str() {
+        "Int" => {
+            // (Int lo hi) — exactly two INTEGER tokens.
+            if all_ints.len() != 2 {
+                return Err(TwigParseError {
+                    message: format!(
+                        "(Int ...) expects exactly 2 integer bounds, got {}",
+                        all_ints.len()
+                    ),
+                    line,
+                    column,
+                });
+            }
+            let lo = parse_i128(all_ints[0])?;
+            let hi = parse_i128(all_ints[1])?;
+            Ok(TypeAnnotation::RangeInt { lo, hi })
+        }
+        "Member" => {
+            // (Member int (v0 v1 ...)) — name after "Member" is the kind (ignored in v1),
+            // then a parenthesised list of INTEGER tokens.
+            let values: Vec<i128> = all_ints
+                .iter()
+                .map(|t| parse_i128(t))
+                .collect::<Result<_, _>>()?;
+            Ok(TypeAnnotation::MembershipInt { values })
+        }
+        other => Err(TwigParseError {
+            message: format!(
+                "unknown parenthesised type annotation {:?}; \
+                 expected one of: Int, Member",
+                other
+            ),
+            line: name_tok.line,
+            column: name_tok.column,
+        }),
+    }
+}
+
+/// Parse an INTEGER token value as `i128`.  Surfaces a structured error
+/// rather than panicking when the value is out of range.
+fn parse_i128(tok: &Token) -> Result<i128, TwigParseError> {
+    tok.value.parse::<i128>().map_err(|_| TwigParseError {
+        message: format!(
+            "integer literal {:?} does not fit in i128 (annotation bound)",
+            tok.value
+        ),
+        line: tok.line,
+        column: tok.column,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // define = LPAREN "define" name_or_signature expr { expr } RPAREN
+//
+// name_or_signature = NAME [ COLON type_annotation ]
+//                   | LPAREN NAME { typed_param } [ NAME type_annotation ] RPAREN
+//
+// LANG23 PR 23-E: the signature may carry per-parameter type annotations
+// and/or a return-type annotation.
 // ---------------------------------------------------------------------------
 
 fn extract_define(node: &GrammarASTNode, depth: usize) -> Result<Define, TwigParseError> {
@@ -212,6 +326,9 @@ fn extract_define(node: &GrammarASTNode, depth: usize) -> Result<Define, TwigPar
             column,
         });
     }
+
+    // The body expressions are the expr children of the define node
+    // (i.e. all ast_children except the sig_node at index 0).
     let body_exprs: Vec<Expr> = children
         .iter()
         .skip(1)
@@ -225,28 +342,24 @@ fn extract_define(node: &GrammarASTNode, depth: usize) -> Result<Define, TwigPar
         });
     }
 
-    // Two shapes for the signature:
-    //   NAME                            — value-define
-    //   LPAREN NAME { NAME } RPAREN     — function-sugar
+    // ── Distinguish value-define vs function-sugar ───────────────────────
     //
-    // We distinguish them by whether the signature's children list
-    // contains an LPAREN token.  Multi-NAME signatures always have
-    // parens; single-NAME-without-parens signatures don't.
-    let name_toks = tokens_named(sig_node, "NAME");
-    if name_toks.is_empty() {
-        return Err(TwigParseError {
-            message: "(define ...) missing a name".into(),
-            line,
-            column,
-        });
-    }
+    // The signature node wraps one of:
+    //   NAME [ COLON type_annotation ]                          — value-define
+    //   LPAREN NAME { typed_param } [ NAME type_annotation ] RPAREN — fn-sugar
+    //
+    // We detect the function form by looking for an LPAREN token among the
+    // sig_node's *direct* children (i.e. the LPAREN that opens the param
+    // list, not any nested parens inside `typed_param` sub-nodes).
+
     let has_paren = sig_node
         .children
         .iter()
         .any(|c| is_token_named(c, "LPAREN"));
 
     if !has_paren {
-        // Plain (define name expr) — exactly one body expression.
+        // ── Value-define: (define name expr) or (define name : Type expr) ──
+
         if body_exprs.len() != 1 {
             return Err(TwigParseError {
                 message: "(define name expr) takes exactly one body expression — \
@@ -256,31 +369,207 @@ fn extract_define(node: &GrammarASTNode, depth: usize) -> Result<Define, TwigPar
                 column,
             });
         }
+        let name_tok = first_token_named(sig_node, "NAME").ok_or_else(|| TwigParseError {
+            message: "(define ...) missing a name".into(),
+            line,
+            column,
+        })?;
+
+        // Check for an optional `: type_annotation` sub-node.
+        let type_annotation = sig_node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "type_annotation" => Some(n),
+                _ => None,
+            })
+            .map(|ann_node| extract_type_annotation(ann_node))
+            .transpose()?;
+
         let expr = body_exprs.into_iter().next().unwrap();
         return Ok(Define {
-            name: name_toks[0].value.clone(),
+            name: name_tok.value.clone(),
+            type_annotation,
             expr,
             line,
             column,
         });
     }
 
-    // Function-sugar: (define (name args...) body+)
-    let fn_name = name_toks[0].value.clone();
-    let params: Vec<String> = name_toks[1..].iter().map(|t| t.value.clone()).collect();
-    let (sig_line, sig_col) = tok_pos(name_toks[0]);
+    // ── Function-sugar: (define (name typed_param...) body+) ────────────
+    //
+    // The sig_node's children (after stripping LPARENs/RPARENs) are:
+    //   NAME           — the function name (first NAME token in sig_node)
+    //   typed_param*   — zero or more sub-nodes (each is a typed_param)
+    //   ARROW? type_annotation?  — optional `->` arrow + return annotation
+    //                              (`->` is now a dedicated ARROW token, not a NAME)
+    //
+    // We walk sig_node's children in order:
+    //   1. Skip the outer LPAREN token.
+    //   2. Take the first NAME token as the function name.
+    //   3. For each following child:
+    //      - If it's a `typed_param` node → extract param name + optional annotation.
+    //      - If it's an ARROW token and the next sibling is a `type_annotation`
+    //        node → extract the return annotation.
+    //      - If it's RPAREN → stop.
+
+    let (fn_name, params, param_annotations, return_annotation) =
+        extract_fn_signature(sig_node)?;
+
+    let (sig_line, sig_col) = {
+        // Source position from the first NAME token (the fn name).
+        let name_tok = first_token_named(sig_node, "NAME").unwrap();
+        tok_pos(name_tok)
+    };
+
     let lam = Lambda {
         params,
+        param_annotations,
+        return_annotation,
         body: body_exprs,
         line: sig_line,
         column: sig_col,
     };
     Ok(Define {
         name: fn_name,
+        type_annotation: None, // function defines carry annotation inside Lambda
         expr: Expr::Lambda(lam),
         line,
         column,
     })
+}
+
+/// Walk the children of a `name_or_signature` node that has a leading LPAREN
+/// (i.e. the function-definition sugar form).  Returns
+/// `(fn_name, params, param_annotations, return_annotation)`.
+///
+/// Child structure (after the outer LPAREN has been matched by the grammar):
+/// ```text
+/// LPAREN  NAME  { typed_param }  [ NAME type_annotation ]  RPAREN
+/// ```
+/// - `LPAREN` and `RPAREN` are punctuation tokens — we skip them.
+/// - The first `NAME` token is the function name.
+/// - `typed_param` sub-nodes carry the parameters (each may or may not have
+///   a type annotation).
+/// - An optional trailing `ARROW type_annotation` pair encodes `-> RetType`.
+///
+/// `->` is now a dedicated ARROW token (not a NAME whose value happens to be
+/// `"->"`).  Defining ARROW as an exact literal before the NAME pattern in
+/// `twig.tokens` prevents the `{ typed_param }` repetition from consuming
+/// the arrow as a bare-NAME parameter, which previously caused a
+/// "Expected COLON, got '0'" parse error when the type annotation followed.
+fn extract_fn_signature(
+    sig_node: &GrammarASTNode,
+) -> Result<(String, Vec<String>, Vec<Option<TypeAnnotation>>, Option<TypeAnnotation>), TwigParseError> {
+    let (line, column) = pos(sig_node);
+
+    let mut fn_name: Option<String> = None;
+    let mut params: Vec<String> = Vec::new();
+    let mut param_annotations: Vec<Option<TypeAnnotation>> = Vec::new();
+    let mut return_annotation: Option<TypeAnnotation> = None;
+
+    // We need to peek ahead to detect the `-> type_annotation` trailer.
+    // Build a flat list of children so we can index into them.
+    let children: Vec<&ASTNodeOrToken> = sig_node.children.iter().collect();
+    let n = children.len();
+    let mut i = 0;
+
+    while i < n {
+        let child = children[i];
+        match child {
+            ASTNodeOrToken::Token(t) => {
+                let kind = t.effective_type_name();
+                match kind {
+                    "LPAREN" | "RPAREN" => { i += 1; } // punctuation — skip
+                    "KEYWORD" if t.value == "define" => { i += 1; } // in case define keyword leaks through
+                    "ARROW" => {
+                        // LANG23 PR 23-E: `->` is now a dedicated ARROW token
+                        // (was previously a NAME whose value == "->").
+                        // The next sibling must be a `type_annotation` sub-node.
+                        i += 1;
+                        if i < n {
+                            if let ASTNodeOrToken::Node(ann_node) = children[i] {
+                                if ann_node.rule_name == "type_annotation" {
+                                    return_annotation =
+                                        Some(extract_type_annotation(ann_node)?);
+                                    i += 1;
+                                    continue;
+                                }
+                            }
+                        }
+                        return Err(TwigParseError {
+                            message: "'->' in function signature must be followed by a type annotation".into(),
+                            line: t.line,
+                            column: t.column,
+                        });
+                    }
+                    "NAME" => {
+                        if fn_name.is_none() {
+                            // First NAME after the opening LPAREN → function name.
+                            fn_name = Some(t.value.clone());
+                            i += 1;
+                        } else {
+                            // A bare NAME parameter (unannotated).
+                            params.push(t.value.clone());
+                            param_annotations.push(None);
+                            i += 1;
+                        }
+                    }
+                    _ => { i += 1; }
+                }
+            }
+            ASTNodeOrToken::Node(n_node) => {
+                match n_node.rule_name.as_str() {
+                    "typed_param" => {
+                        let (param_name, ann) = extract_typed_param(n_node)?;
+                        params.push(param_name);
+                        param_annotations.push(ann);
+                        i += 1;
+                    }
+                    "type_annotation" => {
+                        // A standalone type_annotation without a preceding ARROW.
+                        // This should not normally appear at this level — skip it
+                        // to stay robust against future grammar extensions.
+                        i += 1;
+                    }
+                    _ => { i += 1; }
+                }
+            }
+        }
+    }
+
+    let fn_name = fn_name.ok_or_else(|| TwigParseError {
+        message: "(define ...) missing function name in signature".into(),
+        line,
+        column,
+    })?;
+    Ok((fn_name, params, param_annotations, return_annotation))
+}
+
+/// Extract one `typed_param` grammar node.
+///
+/// A `typed_param` is either:
+/// - `NAME` (bare, unannotated): returns `(name, None)`
+/// - `LPAREN NAME COLON type_annotation RPAREN` (annotated): returns `(name, Some(ann))`
+fn extract_typed_param(
+    node: &GrammarASTNode,
+) -> Result<(String, Option<TypeAnnotation>), TwigParseError> {
+    let (line, column) = pos(node);
+    let name_tok = first_token_named(node, "NAME").ok_or_else(|| TwigParseError {
+        message: "typed_param: missing parameter name".into(),
+        line,
+        column,
+    })?;
+    let ann = node
+        .children
+        .iter()
+        .find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "type_annotation" => Some(n),
+            _ => None,
+        })
+        .map(|ann_node| extract_type_annotation(ann_node))
+        .transpose()?;
+    Ok((name_tok.value.clone(), ann))
 }
 
 // ---------------------------------------------------------------------------
@@ -491,6 +780,10 @@ fn extract_lambda(node: &GrammarASTNode, depth: usize) -> Result<Lambda, TwigPar
     let (line, column) = pos(node);
     // Walk children left-to-right: collect NAMEs (params) before the
     // first nested `expr` ASTNode, then collect `expr` ASTNodes as body.
+    //
+    // Anonymous lambdas (`(lambda ...)`) do not support type annotations in
+    // the v1 grammar — only `define` function sugar does.  So `typed_param`
+    // sub-nodes will never appear here, and `param_annotations` is all None.
     let mut params: Vec<String> = Vec::new();
     let mut body: Vec<Expr> = Vec::new();
     let mut seen_first_expr = false;
@@ -515,7 +808,15 @@ fn extract_lambda(node: &GrammarASTNode, depth: usize) -> Result<Lambda, TwigPar
             column,
         });
     }
-    Ok(Lambda { params, body, line, column })
+    let param_count = params.len();
+    Ok(Lambda {
+        params,
+        param_annotations: vec![None; param_count], // anonymous lambdas are unannotated
+        return_annotation: None,
+        body,
+        line,
+        column,
+    })
 }
 
 fn extract_quote_form(node: &GrammarASTNode) -> Result<SymLit, TwigParseError> {

--- a/code/packages/rust/twig-parser/src/ast_nodes.rs
+++ b/code/packages/rust/twig-parser/src/ast_nodes.rs
@@ -17,11 +17,83 @@
 //! needs.  This is the same pattern used by the Python `twig` package's
 //! `ast_nodes.py` and `ast_extract.py`.
 //!
+//! ## LANG23 PR 23-E — refinement type annotations
+//!
+//! [`TypeAnnotation`] represents the LANG23 v1 predicate vocabulary as
+//! parsed from Twig source.  Annotations appear in two positions:
+//!
+//! - **Value bindings**: `(define x : (Int 0 128) 42)` — the annotation is
+//!   carried on [`Define::type_annotation`].
+//! - **Function parameters**: `(define (f (x : (Int 0 128))) ...)` — each
+//!   element of [`Lambda::param_annotations`] corresponds to the same-index
+//!   element of [`Lambda::params`].
+//! - **Return types**: `(define (f x -> (Int 0 256)) ...)` — the annotation
+//!   is on [`Lambda::return_annotation`].
+//!
+//! All annotation fields default to `None`, so unannotated code is unchanged.
+//!
 //! Source positions (`line` / `column`) are carried on every node so the
 //! IR compiler can emit position-tagged error messages.
 //!
 //! [`GrammarASTNode`]: parser::grammar_parser::GrammarASTNode
 //! [`Token`]: lexer::token::Token
+
+// ---------------------------------------------------------------------------
+// LANG23 PR 23-E — type annotations
+// ---------------------------------------------------------------------------
+
+/// A LANG23 v1 type annotation parsed from Twig source.
+///
+/// The annotation vocabulary is a strict subset of `lang_refined_types::Predicate`
+/// that the Twig parser can express syntactically.  The IR compiler converts
+/// these to [`lang_refined_types::RefinedType`] values when populating
+/// `IIRFunction::param_refinements` / `IIRFunction::return_refinement`.
+///
+/// # Syntax
+///
+/// | Twig syntax          | Variant                              | Semantics              |
+/// |----------------------|--------------------------------------|------------------------|
+/// | `int`                | `UnrefinedInt`                       | any integer            |
+/// | `any`                | `Any`                                | any value              |
+/// | `bool`               | `UnrefinedBool`                      | any boolean            |
+/// | `(Int lo hi)`        | `RangeInt { lo, hi }`                | `lo ≤ x < hi`          |
+/// | `(Member int (v…))`  | `MembershipInt { values }`           | `x ∈ {v₀, v₁, …}`    |
+///
+/// `RangeInt` always uses an *exclusive* upper bound (matching the spec's
+/// `(Int 0 256)` = `[0, 256)` convention).  No other bound combination is
+/// expressible in the v1 syntax.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeAnnotation {
+    /// Unrefined integer — any `int`-kinded value.
+    ///
+    /// Written as `int` in Twig source.  Lowers to
+    /// `RefinedType::unrefined(Kind::Int)`.
+    UnrefinedInt,
+
+    /// Unrefined `any` — the top type, admits any value.
+    ///
+    /// Written as `any` in Twig source.  Lowers to
+    /// `RefinedType::unrefined(Kind::Any)`.
+    Any,
+
+    /// Unrefined boolean — any `bool`-kinded value.
+    ///
+    /// Written as `bool` in Twig source.  Lowers to
+    /// `RefinedType::unrefined(Kind::Bool)`.
+    UnrefinedBool,
+
+    /// Integer range annotation: `(Int lo hi)`.
+    ///
+    /// Semantics: `lo ≤ x` and `x < hi` (exclusive upper bound).
+    /// Lowers to `RefinedType::refined(Kind::Int, Predicate::Range { lo: Some(lo), hi: Some(hi), inclusive_hi: false })`.
+    RangeInt { lo: i128, hi: i128 },
+
+    /// Integer membership annotation: `(Member int (v0 v1 ...))`.
+    ///
+    /// Semantics: `x ∈ {values}`.
+    /// Lowers to `RefinedType::refined(Kind::Int, Predicate::Membership { values })`.
+    MembershipInt { values: Vec<i128> },
+}
 
 // ---------------------------------------------------------------------------
 // Atoms
@@ -105,9 +177,26 @@ pub struct Begin {
 }
 
 /// `(lambda (params*) body+)` — anonymous function.
+///
+/// For anonymous lambdas (from the `(lambda ...)` form), `param_annotations`
+/// is all `None` and `return_annotation` is `None` — the v1 annotation
+/// syntax only applies to top-level `define` function sugar.  Fields are
+/// kept on the struct so the IR compiler can use the same lowering path for
+/// both annotated defines and unannotated lambdas.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Lambda {
     pub params: Vec<String>,
+    /// Per-parameter type annotation, in lockstep with `params`.
+    ///
+    /// `None` at position `i` means parameter `i` is unannotated.
+    /// Populated by the AST extractor when it encounters
+    /// `(define (f (x : TypeAnnotation) ...) ...)` function sugar.
+    pub param_annotations: Vec<Option<TypeAnnotation>>,
+    /// Optional return-type annotation.
+    ///
+    /// Populated by the extractor when the signature contains
+    /// `-> type_annotation` inside the parameter list parentheses.
+    pub return_annotation: Option<TypeAnnotation>,
     pub body: Vec<Expr>,
     pub line: usize,
     pub column: usize,
@@ -133,9 +222,20 @@ pub struct Apply {
 ///
 /// The function-sugar form `(define (f x) body)` is lowered to
 /// `Define { name: "f", expr: Lambda { ... } }` during AST extraction.
+///
+/// For LANG23 annotated value bindings like `(define x : (Int 0 128) 42)`,
+/// `type_annotation` holds the parsed annotation.  For function defines
+/// like `(define (f (x : (Int 0 128))) body)`, the annotation is embedded
+/// in the `Lambda` node (see [`Lambda::param_annotations`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Define {
     pub name: String,
+    /// LANG23 PR 23-E: optional type annotation for value bindings.
+    ///
+    /// `Some(ann)` when the source reads `(define x : ann value)`.
+    /// `None` for all unannotated defines and for function defines
+    /// (which carry their annotations in the nested `Lambda` node).
+    pub type_annotation: Option<TypeAnnotation>,
     pub expr: Expr,
     pub line: usize,
     pub column: usize,

--- a/code/packages/rust/twig-parser/src/lib.rs
+++ b/code/packages/rust/twig-parser/src/lib.rs
@@ -101,7 +101,7 @@ fn twig_parser_grammar() -> &'static ParserGrammar {
 pub use ast_extract::{extract_program, MAX_AST_DEPTH};
 pub use ast_nodes::{
     Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program, SymLit,
-    VarRef,
+    TypeAnnotation, VarRef,
 };
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/twig-semantic-tokens/CHANGELOG.md
+++ b/code/packages/rust/twig-semantic-tokens/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — twig-semantic-tokens
 
+## [0.1.1] — 2026-05-04
+
+### Fixed (LANG23 PR 23-E compatibility)
+
+- Pattern matching on `Lambda` in `semantic_tokens` updated to use `..` (struct
+  update syntax) to avoid exhaustive-field errors after `twig-parser` 0.2.0 added
+  `param_annotations` and `return_annotation` fields to `Lambda`.  No
+  behavioural change — annotation fields are not relevant to semantic-token
+  classification.
+
 ## [0.1.0] — 2026-04-30
 
 Initial release.  Semantic-token extraction for Twig — the second

--- a/code/packages/rust/twig-semantic-tokens/Cargo.toml
+++ b/code/packages/rust/twig-semantic-tokens/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-semantic-tokens"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Semantic-token extraction for Twig.  Walks a parsed Program and emits a typed token stream (keywords / identifiers / numbers / booleans / nil / quoted symbols) suitable for LSP semantic-tokens, syntax highlighters, and editor extensions."
 

--- a/code/packages/rust/twig-semantic-tokens/src/lib.rs
+++ b/code/packages/rust/twig-semantic-tokens/src/lib.rs
@@ -267,7 +267,7 @@ fn emit_expr(out: &mut Vec<SemanticToken>, expr: &Expr) {
                 emit_expr(out, e);
             }
         }
-        Expr::Lambda(Lambda { params, body, line, column }) => {
+        Expr::Lambda(Lambda { params, body, line, column, .. }) => {
             let l = u32_of(*line);
             let c = u32_of(*column);
             push_keyword(out, l, c.saturating_add(1), "lambda");

--- a/code/packages/rust/twig-vm/CHANGELOG.md
+++ b/code/packages/rust/twig-vm/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — twig-vm
 
+## [0.6.1] — 2026-05-04
+
+### Fixed (LANG23 PR 23-E compatibility)
+
+- Three `IIRFunction` struct literals in `dispatch.rs` test helpers
+  (`module_with_main`, and the two IC-slot inline-cache test helpers)
+  updated to include `param_refinements: Vec::new()` and
+  `return_refinement: None` after `interpreter-ir` 0.2.0 added those
+  fields to `IIRFunction`.  No behavioural change.
+
 ## [0.6.0] — 2026-04-30
 
 ### Added — PR 8 of LANG20: vm-core profiler

--- a/code/packages/rust/twig-vm/Cargo.toml
+++ b/code/packages/rust/twig-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-vm"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "LANG20 PRs 3–8 — TwigVM: compiles Twig source and dispatches the IIR end to end including closures, top-level value defines, quoted symbols, method-dispatch opcodes, persistent inline-cache slot machinery, and the V8-Ignition-style vm-core profiler"
 

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -1788,6 +1788,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let module = IIRModule {
             name: "test".into(),
@@ -1813,6 +1815,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let module = IIRModule {
             name: "test".into(),
@@ -1849,6 +1853,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let module = IIRModule {
             name: "test".into(),
@@ -1894,6 +1900,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let err = Frame::new(&f, &[]).unwrap_err();
         match err {
@@ -1927,6 +1935,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let err = build_label_index(&f).unwrap_err();
         match err {
@@ -1952,6 +1962,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         // Should succeed (clamped to MAX_REGISTERS_PER_FRAME).
         let frame = Frame::new(&f, &[]).expect("frame creation must not abort");
@@ -1980,6 +1992,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let idx = build_label_index(&f).unwrap();
         assert_eq!(idx.get("L1"), Some(&0));
@@ -2167,6 +2181,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let module = IIRModule {
             name: "test".into(),
@@ -2212,6 +2228,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let module = IIRModule {
             name: "test".into(),
@@ -2302,6 +2320,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         IIRModule {
             name: "test".into(),
@@ -2811,6 +2831,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let main_instrs = vec![
             IIRInstr::new("const", Some("o1".into()), vec![Operand::Int(1)], "any"),
@@ -2829,6 +2851,8 @@ mod tests {
             call_count: 0,
             feedback_slots: std::collections::HashMap::new(),
             source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
         };
         let module = IIRModule {
             name: "test".into(),


### PR DESCRIPTION
## Summary

LANG23 PR 23-E: end-to-end support for LANG23 refinement type annotations in the Twig (Lisp-precursor) pipeline — from source syntax through parse → IIR emission.

- **Grammar layer**: New `COLON` (`:`) and `ARROW` (`->`) tokens in `twig.tokens`; three new grammar productions (`name_or_signature`, `typed_param`, `type_annotation`) in `twig.grammar` for annotated params and return types.
- **twig-lexer 0.2.0**: COLON + ARROW tokens compiled at build time; 4 new tests.
- **twig-parser 0.2.0**: `TypeAnnotation` enum with 5 variants (`UnrefinedInt`, `Any`, `UnrefinedBool`, `RangeInt { lo, hi }`, `MembershipInt { values }`). `Lambda` gets `param_annotations` + `return_annotation` fields (lockstep with `params`); `Define` gets `type_annotation`. New `extract_type_annotation`, `extract_fn_signature`, `extract_typed_param` in `ast_extract.rs`.
- **interpreter-ir 0.2.0**: `IIRFunction` gets `param_refinements: Vec<Option<RefinedType>>` + `return_refinement: Option<RefinedType>` (additive/opt-in; `Default` impl added). `lang-refined-types` dep added.
- **twig-ir-compiler 0.2.0**: `type_annotation_to_refined_type()` bridges parse layer → IIR layer. 7 new round-trip tests verifying annotations survive parse → compile → IIRFunction.
- **Compatibility patches**: `twig-semantic-tokens` 0.1.1, `twig-formatter` 0.1.1, `twig-vm` 0.6.1, `brainfuck-iir-compiler` 0.1.1 — struct literal / pattern fixes only; no behaviour change.

**Key fix**: `->` now lexes as `ARROW` (not `NAME`), resolving "Expected COLON, got '0'" errors when return-type annotations followed the `{ typed_param }` repetition.

**Opt-in contract**: All existing callers see zero change — annotation fields default to empty/`None`.

## Test plan

- [x] `cargo test -p twig-lexer` — 22 tests (4 new: COLON/ARROW token lexing)
- [x] `cargo test -p twig-parser` — 33 tests
- [x] `cargo test -p interpreter-ir` — 46 tests
- [x] `cargo test -p twig-ir-compiler` — 56 tests (7 new: annotation round-trip)
- [x] `cargo test -p twig-semantic-tokens` — 24 tests
- [x] `cargo test -p twig-formatter` — 37 tests
- [x] `cargo test -p twig-vm` — 117 tests
- [x] `cargo test -p brainfuck-iir-compiler` — 8 tests
- [x] Workspace-wide test run: all non-pre-existing tests pass
- [x] Security review: no vulnerabilities in changed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)