### PR TITLE
feat(sql-vm/codegen): add LAG, LEAD, NTILE, PERCENT_RANK, CUME_DIST, NTH_VALUE window functions

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [1.18.0] - 2026-05-04
+
+### Added
+
+- **LAG / LEAD window functions** — `LAG(col [, offset [, default]])` and
+  `LEAD(col [, offset [, default]])` are now fully supported end-to-end.
+  The adapter (`adapter.py`) extracts `exprs[1:]` from the `value_list`
+  grammar node into `WindowFuncExpr.extra_args`; codegen normalises these
+  to an `(offset, default)` pair; the VM evaluates the offset-lookback or
+  lookahead within each ordered partition.
+- **NTILE(n) window function** — `NTILE(n)` divides each partition into `n`
+  numbered buckets (1..n) using the standard `divmod` distribution rule.
+  The integer literal `n` is parsed as the sole argument to NTILE.
+- **PERCENT_RANK() window function** — `PERCENT_RANK()` computes
+  `(rank − 1) / (N − 1)`.  Argument-free; only `OVER (ORDER BY ...)` is
+  required.  Returns `0.0` for single-row partitions.
+- **CUME_DIST() window function** — `CUME_DIST()` computes the cumulative
+  distribution fraction for each row's peer group.  Also argument-free.
+- **NTH_VALUE(col, n) window function** — `NTH_VALUE(col, n)` returns the
+  value of `col` at the n-th row (1-indexed) of the partition.  Returns
+  `NULL` when the partition has fewer than n rows.
+- **Negated literal folding in window extra args** (codegen) — SQL expressions
+  like `LAG(col, 1, -1)` where `-1` is parsed as `UnaryExpr(NEG, Literal(1))`
+  are now constant-folded to `-1` by the codegen `_literal_val` helper,
+  making negative default values work correctly.
+
 ## [1.17.0] - 2026-05-04
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.17.0"
+version = "1.18.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1228,9 +1228,13 @@ def _window_func_call(node: ASTNode, state: _PlaceholderCounter) -> WindowFuncEx
 
     Supported functions and their arg requirements:
 
-    - Arg-free (no argument):   ROW_NUMBER, RANK, DENSE_RANK
+    - Arg-free (no argument):   ROW_NUMBER, RANK, DENSE_RANK, PERCENT_RANK, CUME_DIST
     - COUNT(*) (star arg):      COUNT — maps to "count_star"
     - Single-arg:               SUM, COUNT(col), AVG, MIN, MAX, FIRST_VALUE, LAST_VALUE
+    - Literal-arg:              NTILE(n) — n is an integer constant
+    - Multi-arg:                LAG(col [, offset [, default]]),
+                                LEAD(col [, offset [, default]]),
+                                NTH_VALUE(col, n)
 
     All function names are normalised to lower-case.
     """
@@ -1242,6 +1246,7 @@ def _window_func_call(node: ASTNode, state: _PlaceholderCounter) -> WindowFuncEx
     star = any(_is_token(c, type_="STAR") for c in node.children)
     vl = _maybe_child(node, "value_list")
     arg: Expr | None = None
+    extra_args_tuple: tuple[Expr, ...] = ()
 
     if star:
         # COUNT(*) OVER (...) → func="count_star", arg=None
@@ -1250,6 +1255,12 @@ def _window_func_call(node: ASTNode, state: _PlaceholderCounter) -> WindowFuncEx
         exprs = [c for c in vl.children if isinstance(c, ASTNode) and c.rule_name == "expr"]
         if exprs:
             arg = _expr(exprs[0], state)
+            # Multi-argument functions (LAG, LEAD, NTH_VALUE) carry extra args
+            # beyond the first column reference.  We thread them through as a
+            # tuple so the planner and codegen can normalise them into the
+            # proper (offset, default) / (n,) shapes.
+            if len(exprs) > 1:
+                extra_args_tuple = tuple(_expr(e, state) for e in exprs[1:])
     # Arg-free ranking functions keep func_name as-is (row_number, rank, dense_rank).
 
     # Extract the window_spec node.
@@ -1292,6 +1303,7 @@ def _window_func_call(node: ASTNode, state: _PlaceholderCounter) -> WindowFuncEx
         arg=arg,
         partition_by=tuple(partition_exprs),
         order_by=tuple(order_keys),
+        extra_args=extra_args_tuple,
     )
 
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_window_extended.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_window_extended.py
@@ -1,0 +1,499 @@
+"""
+Tier-3 integration tests — Extended window functions
+=====================================================
+
+End-to-end tests for window functions added in the second increment:
+LAG, LEAD, NTILE, PERCENT_RANK, CUME_DIST, NTH_VALUE.
+
+All tests exercise the full pipeline: SQL string → parser → adapter →
+planner → codegen → VM → result via ``mini_sqlite.connect(":memory:")``.
+
+Data set
+--------
+Five employees in two departments, ordered by salary within each dept:
+
+    id  name   dept   salary
+    1   Alice  eng    90000
+    2   Bob    eng    80000
+    3   Carol  sales  70000
+    4   Dave   sales  75000
+    5   Eve    eng    85000
+
+When sorted by salary ASC within eng: Bob 80k, Eve 85k, Alice 90k
+When sorted by salary ASC within sales: Carol 70k, Dave 75k
+"""
+
+from __future__ import annotations
+
+import mini_sqlite
+
+
+def _conn():
+    """Return a fresh in-memory connection with the employees table pre-loaded."""
+    con = mini_sqlite.connect(":memory:")
+    con.execute(
+        "CREATE TABLE employees (id INTEGER, name TEXT, dept TEXT, salary INTEGER)"
+    )
+    con.executemany(
+        "INSERT INTO employees VALUES (?, ?, ?, ?)",
+        [
+            (1, "Alice", "eng",   90000),
+            (2, "Bob",   "eng",   80000),
+            (3, "Carol", "sales", 70000),
+            (4, "Dave",  "sales", 75000),
+            (5, "Eve",   "eng",   85000),
+        ],
+    )
+    return con
+
+
+# ---------------------------------------------------------------------------
+# LAG
+# ---------------------------------------------------------------------------
+
+
+class TestLagEndToEnd:
+    def test_lag_default_offset_partitioned(self):
+        """LAG(salary) OVER (PARTITION BY dept ORDER BY salary) — one row back."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   LAG(salary) OVER (PARTITION BY dept ORDER BY salary) AS prev_sal
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        # eng sorted ASC: Bob 80k→NULL, Eve 85k→80k, Alice 90k→85k
+        assert by_name["Bob"] is None
+        assert by_name["Eve"] == 80000
+        assert by_name["Alice"] == 85000
+        # sales sorted ASC: Carol 70k→NULL, Dave 75k→70k
+        assert by_name["Carol"] is None
+        assert by_name["Dave"] == 70000
+
+    def test_lag_explicit_offset_2(self):
+        """LAG(salary, 2) skips two positions back."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, salary,
+                   LAG(salary, 2) OVER (PARTITION BY dept ORDER BY salary) AS lag2
+            FROM employees
+            WHERE dept = 'eng'
+            ORDER BY salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[2] for r in rows}
+        # eng: Bob 80k→NULL, Eve 85k→NULL, Alice 90k→80k
+        assert by_name["Bob"] is None
+        assert by_name["Eve"] is None
+        assert by_name["Alice"] == 80000
+
+    def test_lag_with_explicit_default(self):
+        """LAG(salary, 1, -1) uses -1 when no preceding row exists."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   LAG(salary, 1, -1) OVER (PARTITION BY dept ORDER BY salary) AS prev
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        assert by_name["Bob"] == -1      # first in eng partition → default
+        assert by_name["Carol"] == -1    # first in sales partition → default
+        assert by_name["Alice"] == 85000
+
+    def test_lag_global_no_partition(self):
+        """LAG(id, 1) over all rows with no PARTITION BY."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT id,
+                   LAG(id, 1) OVER (ORDER BY id) AS prev_id
+            FROM employees
+            ORDER BY id
+            """
+        ).fetchall()
+        by_id = {r[0]: r[1] for r in rows}
+        assert by_id[1] is None
+        assert by_id[2] == 1
+        assert by_id[5] == 4
+
+
+# ---------------------------------------------------------------------------
+# LEAD
+# ---------------------------------------------------------------------------
+
+
+class TestLeadEndToEnd:
+    def test_lead_default_offset_partitioned(self):
+        """LEAD(salary) OVER (PARTITION BY dept ORDER BY salary) — one row ahead."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   LEAD(salary) OVER (PARTITION BY dept ORDER BY salary) AS next_sal
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        # eng ASC: Bob→85k, Eve→90k, Alice→NULL
+        assert by_name["Bob"] == 85000
+        assert by_name["Eve"] == 90000
+        assert by_name["Alice"] is None
+        # sales ASC: Carol→75k, Dave→NULL
+        assert by_name["Carol"] == 75000
+        assert by_name["Dave"] is None
+
+    def test_lead_explicit_offset_2(self):
+        """LEAD(salary, 2) looks two rows ahead."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, salary,
+                   LEAD(salary, 2) OVER (PARTITION BY dept ORDER BY salary) AS lead2
+            FROM employees
+            WHERE dept = 'eng'
+            ORDER BY salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[2] for r in rows}
+        # eng: Bob→90k, Eve→NULL, Alice→NULL
+        assert by_name["Bob"] == 90000
+        assert by_name["Eve"] is None
+        assert by_name["Alice"] is None
+
+    def test_lead_with_default(self):
+        """LEAD(salary, 1, 0) fills boundary rows with 0."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   LEAD(salary, 1, 0) OVER (PARTITION BY dept ORDER BY salary) AS nxt
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        assert by_name["Alice"] == 0    # last in eng → default
+        assert by_name["Dave"] == 0     # last in sales → default
+
+
+# ---------------------------------------------------------------------------
+# NTILE
+# ---------------------------------------------------------------------------
+
+
+class TestNtileEndToEnd:
+    def test_ntile_3_global(self):
+        """NTILE(3) over all 5 rows: 2+2+1 distribution."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT id, NTILE(3) OVER (ORDER BY id) AS bucket
+            FROM employees
+            ORDER BY id
+            """
+        ).fetchall()
+        by_id = {r[0]: r[1] for r in rows}
+        # ids 1-5 sorted: bucket 1→{1,2}, bucket 2→{3,4}, bucket 3→{5}
+        assert by_id[1] == 1
+        assert by_id[2] == 1
+        assert by_id[3] == 2
+        assert by_id[4] == 2
+        assert by_id[5] == 3
+
+    def test_ntile_2_partitioned(self):
+        """NTILE(2) within each dept partition."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   NTILE(2) OVER (PARTITION BY dept ORDER BY salary) AS bucket
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        # eng (3 rows, 2 buckets): Bob→1, Eve→1, Alice→2
+        assert by_name["Bob"] == 1
+        assert by_name["Eve"] == 1
+        assert by_name["Alice"] == 2
+        # sales (2 rows, 2 buckets): Carol→1, Dave→2
+        assert by_name["Carol"] == 1
+        assert by_name["Dave"] == 2
+
+    def test_ntile_1_bucket_all_same(self):
+        """NTILE(1): every row is in bucket 1."""
+        con = _conn()
+        rows = con.execute(
+            "SELECT NTILE(1) OVER (ORDER BY id) AS b FROM employees"
+        ).fetchall()
+        assert all(r[0] == 1 for r in rows)
+
+    def test_ntile_larger_than_rows(self):
+        """NTILE(10) with 5 rows: each row gets its own bucket 1..5."""
+        con = _conn()
+        rows = con.execute(
+            "SELECT id, NTILE(10) OVER (ORDER BY id) AS b FROM employees ORDER BY id"
+        ).fetchall()
+        buckets = [r[1] for r in rows]
+        assert buckets == [1, 2, 3, 4, 5]
+
+
+# ---------------------------------------------------------------------------
+# PERCENT_RANK
+# ---------------------------------------------------------------------------
+
+
+class TestPercentRankEndToEnd:
+    def test_percent_rank_global_unique(self):
+        """5 distinct salaries → PERCENT_RANK values 0, 0.25, 0.5, 0.75, 1.0."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT salary,
+                   PERCENT_RANK() OVER (ORDER BY salary) AS pr
+            FROM employees
+            ORDER BY salary
+            """
+        ).fetchall()
+        prs = [r[1] for r in rows]
+        expected = [0.0, 0.25, 0.5, 0.75, 1.0]
+        for got, exp in zip(prs, expected, strict=True):
+            assert abs(got - exp) < 1e-9, f"Expected {exp}, got {got}"
+
+    def test_percent_rank_partitioned(self):
+        """PERCENT_RANK within each dept."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   PERCENT_RANK() OVER (PARTITION BY dept ORDER BY salary) AS pr
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        # eng (3 rows): Bob→0.0, Eve→0.5, Alice→1.0
+        assert abs(by_name["Bob"] - 0.0) < 1e-9
+        assert abs(by_name["Eve"] - 0.5) < 1e-9
+        assert abs(by_name["Alice"] - 1.0) < 1e-9
+        # sales (2 rows): Carol→0.0, Dave→1.0
+        assert abs(by_name["Carol"] - 0.0) < 1e-9
+        assert abs(by_name["Dave"] - 1.0) < 1e-9
+
+    def test_percent_rank_with_ties(self):
+        """Tied rows share the same PERCENT_RANK."""
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t (v INTEGER)")
+        con.executemany("INSERT INTO t VALUES (?)", [(1,), (1,), (2,)])
+        rows = con.execute(
+            "SELECT v, PERCENT_RANK() OVER (ORDER BY v) AS pr FROM t ORDER BY v"
+        ).fetchall()
+        # v=1 tie at rank 1: PR = 0/2 = 0.0; v=2 at rank 3: PR = 2/2 = 1.0
+        prs_by_v = {r[0]: r[1] for r in rows}
+        assert abs(prs_by_v[1] - 0.0) < 1e-9
+        assert abs(prs_by_v[2] - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# CUME_DIST
+# ---------------------------------------------------------------------------
+
+
+class TestCumeDistEndToEnd:
+    def test_cume_dist_global_unique(self):
+        """5 distinct salaries → CUME_DIST values 0.2, 0.4, 0.6, 0.8, 1.0."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT salary,
+                   CUME_DIST() OVER (ORDER BY salary) AS cd
+            FROM employees
+            ORDER BY salary
+            """
+        ).fetchall()
+        cds = [r[1] for r in rows]
+        expected = [0.2, 0.4, 0.6, 0.8, 1.0]
+        for got, exp in zip(cds, expected, strict=True):
+            assert abs(got - exp) < 1e-9
+
+    def test_cume_dist_partitioned(self):
+        """CUME_DIST within each dept."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   CUME_DIST() OVER (PARTITION BY dept ORDER BY salary) AS cd
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        # eng (3 rows): Bob→1/3, Eve→2/3, Alice→1.0
+        assert abs(by_name["Bob"]   - 1/3) < 1e-9
+        assert abs(by_name["Eve"]   - 2/3) < 1e-9
+        assert abs(by_name["Alice"] - 1.0) < 1e-9
+        # sales (2 rows): Carol→0.5, Dave→1.0
+        assert abs(by_name["Carol"] - 0.5) < 1e-9
+        assert abs(by_name["Dave"]  - 1.0) < 1e-9
+
+    def test_cume_dist_with_ties(self):
+        """Tied rows share the peer-group endpoint."""
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t (v INTEGER)")
+        con.executemany("INSERT INTO t VALUES (?)", [(1,), (1,), (3,)])
+        rows = con.execute(
+            "SELECT v, CUME_DIST() OVER (ORDER BY v) AS cd FROM t ORDER BY v"
+        ).fetchall()
+        # v=1 (tie group ends at pos 2 / 3 rows) → cd = 2/3
+        # v=3 → cd = 3/3 = 1.0
+        v1 = [r[1] for r in rows if r[0] == 1]
+        v3 = [r[1] for r in rows if r[0] == 3]
+        assert all(abs(cd - 2/3) < 1e-9 for cd in v1)
+        assert all(abs(cd - 1.0) < 1e-9 for cd in v3)
+
+
+# ---------------------------------------------------------------------------
+# NTH_VALUE
+# ---------------------------------------------------------------------------
+
+
+class TestNthValueEndToEnd:
+    def test_nth_value_first(self):
+        """NTH_VALUE(salary, 1) == FIRST_VALUE(salary)."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   NTH_VALUE(salary, 1) OVER (PARTITION BY dept ORDER BY salary) AS nth
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        # First in eng (salary ASC) = Bob = 80000
+        assert by_name["Bob"] == 80000
+        assert by_name["Eve"] == 80000
+        assert by_name["Alice"] == 80000
+        # First in sales = Carol = 70000
+        assert by_name["Carol"] == 70000
+        assert by_name["Dave"] == 70000
+
+    def test_nth_value_second(self):
+        """NTH_VALUE(salary, 2): the second row in each partition."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT name, dept, salary,
+                   NTH_VALUE(salary, 2) OVER (PARTITION BY dept ORDER BY salary) AS nth
+            FROM employees
+            ORDER BY dept, salary
+            """
+        ).fetchall()
+        by_name = {r[0]: r[3] for r in rows}
+        # eng 2nd = Eve = 85000
+        assert by_name["Bob"] == 85000
+        assert by_name["Eve"] == 85000
+        assert by_name["Alice"] == 85000
+        # sales 2nd = Dave = 75000
+        assert by_name["Carol"] == 75000
+        assert by_name["Dave"] == 75000
+
+    def test_nth_value_beyond_partition_returns_null(self):
+        """NTH_VALUE(salary, 99) returns NULL (beyond partition size)."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT NTH_VALUE(salary, 99) OVER (PARTITION BY dept ORDER BY salary) AS nth
+            FROM employees
+            """
+        ).fetchall()
+        assert all(r[0] is None for r in rows)
+
+    def test_nth_value_global(self):
+        """NTH_VALUE(salary, 3) over all rows (no partition) = the 3rd smallest salary."""
+        con = _conn()
+        rows = con.execute(
+            """
+            SELECT salary,
+                   NTH_VALUE(salary, 3) OVER (ORDER BY salary) AS nth
+            FROM employees
+            ORDER BY salary
+            """
+        ).fetchall()
+        # All salaries ASC: 70000, 75000, 80000, 85000, 90000 → 3rd = 80000
+        assert all(r[1] == 80000 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Parser / adapter — grammar accepts new function names
+# ---------------------------------------------------------------------------
+
+
+class TestNewFunctionsParseAndAdapt:
+    def test_lag_parses(self):
+        """Parser accepts LAG(col, n) OVER (...)."""
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t (x INTEGER)")
+        con.execute("INSERT INTO t VALUES (1)")
+        rows = con.execute(
+            "SELECT LAG(x, 1) OVER (ORDER BY x) FROM t"
+        ).fetchall()
+        assert rows == [(None,)]
+
+    def test_lead_parses(self):
+        """Parser accepts LEAD(col) OVER (...)."""
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t (x INTEGER)")
+        con.execute("INSERT INTO t VALUES (1)")
+        rows = con.execute(
+            "SELECT LEAD(x) OVER (ORDER BY x) FROM t"
+        ).fetchall()
+        assert rows == [(None,)]
+
+    def test_ntile_parses(self):
+        """Parser accepts NTILE(n) OVER (ORDER BY ...)."""
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t (x INTEGER)")
+        con.execute("INSERT INTO t VALUES (1)")
+        rows = con.execute(
+            "SELECT NTILE(2) OVER (ORDER BY x) FROM t"
+        ).fetchall()
+        assert rows == [(1,)]
+
+    def test_percent_rank_parses(self):
+        """Parser accepts PERCENT_RANK() OVER (ORDER BY ...)."""
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t (x INTEGER)")
+        con.execute("INSERT INTO t VALUES (42)")
+        rows = con.execute(
+            "SELECT PERCENT_RANK() OVER (ORDER BY x) FROM t"
+        ).fetchall()
+        assert rows == [(0.0,)]
+
+    def test_cume_dist_parses(self):
+        """Parser accepts CUME_DIST() OVER (ORDER BY ...)."""
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t (x INTEGER)")
+        con.execute("INSERT INTO t VALUES (42)")
+        rows = con.execute(
+            "SELECT CUME_DIST() OVER (ORDER BY x) FROM t"
+        ).fetchall()
+        assert rows == [(1.0,)]
+
+    def test_nth_value_parses(self):
+        """Parser accepts NTH_VALUE(col, n) OVER (ORDER BY ...)."""
+        con = mini_sqlite.connect(":memory:")
+        con.execute("CREATE TABLE t (x INTEGER)")
+        con.execute("INSERT INTO t VALUES (7)")
+        rows = con.execute(
+            "SELECT NTH_VALUE(x, 1) OVER (ORDER BY x) FROM t"
+        ).fetchall()
+        assert rows == [(7,)]

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [1.11.0] - 2026-05-04
+
+### Added
+
+- **New `WinFunc` enum values** (`ir.py`) — `LAG`, `LEAD`, `NTH_VALUE`,
+  `NTILE`, `PERCENT_RANK`, `CUME_DIST` added to the `WinFunc` enumeration.
+- **`extra_args` field on `WinFuncSpec`** (`ir.py`) — `tuple[object, ...]`
+  that carries literal constants for multi-argument window functions:
+  - `LAG` / `LEAD` → `(offset: int, default: SqlValue)` (always 2 elements)
+  - `NTILE` → `(n: int,)` — the bucket count
+  - `NTH_VALUE` → `(n: int,)` — the 1-indexed row position
+  - `PERCENT_RANK`, `CUME_DIST` → `()` (empty, no extra args needed)
+- **Extended `_WIN_FUNC_MAP`** (`compiler.py`) — the mapping now includes
+  all six new functions.
+- **Rewritten `_to_ir_win_spec`** (`compiler.py`) — converts planner-level
+  `WindowFuncSpec` to IR `WinFuncSpec`, handling each function's unique
+  argument shape:
+  - `LAG`/`LEAD` — normalises `extra_args` to exactly `(offset, default)`,
+    defaulting to `(1, None)` when arguments are omitted.
+  - `NTILE` — the literal bucket count in `arg_expr` is moved to
+    `extra_args` and `arg_col` is set to `None` (NTILE has no column arg).
+  - `NTH_VALUE` — column is `arg_col`; `n` is `extra_args[0]`.
+  - `PERCENT_RANK`, `CUME_DIST` — no `arg_col` or `extra_args`.
+  - Negated-literal folding: `UnaryExpr(NEG, Literal(n))` (produced by
+    the parser for `-1`, `-2`, …) is constant-folded to `-n` inside
+    `_literal_val` so that `LAG(col, 1, -1)` works correctly.
+
 ## [1.10.0] - 2026-05-04
 
 ### Added

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.10.0"
+version = "1.11.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -1559,6 +1559,14 @@ def _to_ir_win_spec(spec: PlanWindowFuncSpec) -> WinFuncSpec:
             f"got {type(e).__name__}"
         )
 
+    # Contexts whose value must be a non-boolean integer (offset / bucket-count
+    # / row-number).  Floats are silently truncated by int(), which masks user
+    # errors; strings would cause a ValueError deep in the VM, leaking internal
+    # state in the traceback.  We reject both up front at compile time.
+    _INT_REQUIRED_CTXS = frozenset(
+        {"LAG/LEAD offset", "NTILE n", "NTH_VALUE n"}
+    )
+
     def _literal_val(e: Expr, ctx: str) -> object:
         """Extract a Python constant from a Literal node.
 
@@ -1566,21 +1574,45 @@ def _to_ir_win_spec(spec: PlanWindowFuncSpec) -> WinFuncSpec:
         literal (``-1``) as ``UnaryExpr(NEG, Literal(1))`` rather than
         ``Literal(-1)``.  Only the unary-minus case is folded; all other
         expression types raise ``UnsupportedNode``.
+
+        For contexts listed in ``_INT_REQUIRED_CTXS`` (offsets, bucket counts,
+        row indices) the extracted value must be a plain Python ``int`` (bool
+        excluded).  Non-integer literals — strings, floats, bytes — raise
+        ``UnsupportedNode`` rather than propagating to the VM where they would
+        either truncate silently (float) or crash with a leaky ``ValueError``
+        (str/bytes).
         """
+        raw: object
         if isinstance(e, Literal):
-            return e.value
-        if (
+            raw = e.value
+        elif (
             isinstance(e, UnaryExpr)
             and e.op == AstUnaryOp.NEG
             and isinstance(e.operand, Literal)
         ):
             v = e.operand.value
             if isinstance(v, (int, float)):
-                return -v
-        raise UnsupportedNode(
-            f"window function extra argument ({ctx}) must be a literal constant, "
-            f"got {type(e).__name__}"
-        )
+                raw = -v
+            else:
+                raise UnsupportedNode(
+                    f"window function extra argument ({ctx}) must be a literal "
+                    f"constant, got negated {type(v).__name__}"
+                )
+        else:
+            raise UnsupportedNode(
+                f"window function extra argument ({ctx}) must be a literal constant, "
+                f"got {type(e).__name__}"
+            )
+
+        # bools are a subclass of int in Python; SQL has no boolean literals
+        # for numeric arguments, so reject them too.
+        if ctx in _INT_REQUIRED_CTXS and (not isinstance(raw, int) or isinstance(raw, bool)):
+            raise UnsupportedNode(
+                f"window function argument ({ctx}) must be an integer literal, "
+                f"got {type(raw).__name__!r} value {raw!r}"
+            )
+
+        return raw
 
     # --- Partition / order columns ---
     partition_cols = tuple(_col_name(e) for e in spec.partition_by)

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -1519,16 +1519,32 @@ _WIN_FUNC_MAP: dict[str, WinFunc] = {
     "max": WinFunc.MAX,
     "first_value": WinFunc.FIRST_VALUE,
     "last_value": WinFunc.LAST_VALUE,
+    # Offset / navigation functions (SQL:2003)
+    "lag": WinFunc.LAG,
+    "lead": WinFunc.LEAD,
+    "nth_value": WinFunc.NTH_VALUE,
+    "ntile": WinFunc.NTILE,
+    "percent_rank": WinFunc.PERCENT_RANK,
+    "cume_dist": WinFunc.CUME_DIST,
 }
 
 
 def _to_ir_win_spec(spec: PlanWindowFuncSpec) -> WinFuncSpec:
     """Convert a planner-level WindowFuncSpec to an IR WinFuncSpec.
 
-    All expression arguments in the planner spec are expected to be simple
-    :class:`Column` nodes — the planner ensures dependency columns are
-    present in the inner projection with matching names.  Complex
-    sub-expressions are not supported in this release.
+    Primary column arguments (``arg_expr``) must be :class:`Column` references
+    — the planner ensures dependency columns are present in the inner projection
+    with matching names.
+
+    Extra scalar arguments (``extra_args``) must be :class:`Literal` nodes
+    that evaluate to Python primitives at codegen time.  The VM reads them from
+    ``WinFuncSpec.extra_args`` rather than from the result-row buffer.
+
+    LAG / LEAD defaults when extra_args are omitted
+    -------------------------------------------------
+    ``LAG(col)``         → offset=1, default=None
+    ``LAG(col, 2)``      → offset=2, default=None
+    ``LAG(col, 2, 0)``   → offset=2, default=0
     """
     func_key = spec.func.lower()
     ir_func = _WIN_FUNC_MAP.get(func_key)
@@ -1543,12 +1559,77 @@ def _to_ir_win_spec(spec: PlanWindowFuncSpec) -> WinFuncSpec:
             f"got {type(e).__name__}"
         )
 
-    arg_col: str | None = None
-    if spec.arg_expr is not None:
-        arg_col = _col_name(spec.arg_expr)
+    def _literal_val(e: Expr, ctx: str) -> object:
+        """Extract a Python constant from a Literal node.
 
+        Also handles the common case where the parser produces a negated
+        literal (``-1``) as ``UnaryExpr(NEG, Literal(1))`` rather than
+        ``Literal(-1)``.  Only the unary-minus case is folded; all other
+        expression types raise ``UnsupportedNode``.
+        """
+        if isinstance(e, Literal):
+            return e.value
+        if (
+            isinstance(e, UnaryExpr)
+            and e.op == AstUnaryOp.NEG
+            and isinstance(e.operand, Literal)
+        ):
+            v = e.operand.value
+            if isinstance(v, (int, float)):
+                return -v
+        raise UnsupportedNode(
+            f"window function extra argument ({ctx}) must be a literal constant, "
+            f"got {type(e).__name__}"
+        )
+
+    # --- Partition / order columns ---
     partition_cols = tuple(_col_name(e) for e in spec.partition_by)
     order_cols = tuple((_col_name(e), desc) for e, desc in spec.order_by)
+
+    # --- Extra scalar arguments + primary arg_col ---
+    # NTILE is special: its first (and only) argument is the bucket-count
+    # literal, NOT a column reference.  We handle it here, before the generic
+    # ``arg_col = _col_name(spec.arg_expr)`` path which would wrongly call
+    # _col_name on a Literal and raise UnsupportedNode.
+    extra: tuple[object, ...]
+    arg_col: str | None = None
+
+    if ir_func in (WinFunc.LAG, WinFunc.LEAD):
+        # Primary arg is a column reference.
+        if spec.arg_expr is not None:
+            arg_col = _col_name(spec.arg_expr)
+        # Normalise to exactly 2 extra slots: (offset, default_value).
+        # SQL: LAG(col [, offset [, default]])
+        offset_val: object = 1         # default offset
+        default_val: object = None     # default replacement
+        if len(spec.extra_args) >= 1:
+            offset_val = _literal_val(spec.extra_args[0], "LAG/LEAD offset")
+        if len(spec.extra_args) >= 2:
+            default_val = _literal_val(spec.extra_args[1], "LAG/LEAD default")
+        extra = (offset_val, default_val)
+
+    elif ir_func == WinFunc.NTILE:
+        # NTILE(n): arg_expr holds the Literal(n) — it is not a column.
+        # Move n into extra_args and leave arg_col as None.
+        if spec.arg_expr is None:
+            raise UnsupportedNode("NTILE requires a bucket-count argument")
+        n_val = _literal_val(spec.arg_expr, "NTILE n")
+        arg_col = None          # NTILE has no column arg
+        extra = (n_val,)
+
+    elif ir_func == WinFunc.NTH_VALUE:
+        # NTH_VALUE(col, n): col is the primary arg; n is in extra_args[0].
+        if spec.arg_expr is not None:
+            arg_col = _col_name(spec.arg_expr)
+        if not spec.extra_args:
+            raise UnsupportedNode("NTH_VALUE requires two arguments: NTH_VALUE(col, n)")
+        extra = (_literal_val(spec.extra_args[0], "NTH_VALUE n"),)
+
+    else:
+        # All other functions: primary arg is an optional column reference.
+        if spec.arg_expr is not None:
+            arg_col = _col_name(spec.arg_expr)
+        extra = ()
 
     return WinFuncSpec(
         func=ir_func,
@@ -1556,4 +1637,5 @@ def _to_ir_win_spec(spec: PlanWindowFuncSpec) -> WinFuncSpec:
         partition_cols=partition_cols,
         order_cols=order_cols,
         result_col=spec.alias,
+        extra_args=extra,
     )

--- a/code/packages/python/sql-codegen/src/sql_codegen/ir.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/ir.py
@@ -884,6 +884,13 @@ class WinFunc(Enum):
     MAX = "MAX"
     FIRST_VALUE = "FIRST_VALUE"
     LAST_VALUE = "LAST_VALUE"
+    # Offset / navigation functions (SQL:2003)
+    LAG = "LAG"           # LAG(col [, offset=1 [, default=NULL]])
+    LEAD = "LEAD"         # LEAD(col [, offset=1 [, default=NULL]])
+    NTH_VALUE = "NTH_VALUE"   # NTH_VALUE(col, n) — value from nth row in window
+    NTILE = "NTILE"       # NTILE(n) — distribute rows into n numbered buckets
+    PERCENT_RANK = "PERCENT_RANK"  # (rank-1)/(rows-1) — relative rank 0..1
+    CUME_DIST = "CUME_DIST"        # cumulative distribution 0..1
 
 
 @dataclass(frozen=True, slots=True)
@@ -920,6 +927,13 @@ class WinFuncSpec:
     partition_cols: tuple[str, ...]
     order_cols: tuple[tuple[str, bool], ...]
     result_col: str
+    extra_args: tuple[object, ...] = ()
+    # Meaning by function:
+    # LAG / LEAD  → extra_args = (offset: int, default: SqlValue)
+    #               offset defaults to 1, default to None if omitted.
+    # NTH_VALUE   → extra_args = (n: int,)   — 1-indexed row position
+    # NTILE       → extra_args = (n: int,)   — number of buckets
+    # PERCENT_RANK, CUME_DIST, and all others → extra_args = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/sql-codegen/tests/test_window.py
+++ b/code/packages/python/sql-codegen/tests/test_window.py
@@ -1,0 +1,389 @@
+"""
+Window function codegen tests — _to_ir_win_spec and ComputeWindowFunctions emission.
+
+These tests verify that ``compile(WindowAgg(...))`` emits a
+``ComputeWindowFunctions`` instruction whose ``WinFuncSpec`` objects have the
+correct ``func``, ``arg_col``, ``partition_cols``, ``order_cols``,
+``result_col``, and ``extra_args`` values.
+
+Coverage targets
+----------------
+- compiler.py: _to_ir_win_spec — all branches for LAG, LEAD, NTILE,
+  NTH_VALUE, PERCENT_RANK, CUME_DIST, plus error paths
+- ir.py: WinFunc enum values for the new functions
+"""
+
+from __future__ import annotations
+
+import pytest
+from sql_planner import (
+    Column,
+    Literal,
+    Project,
+    ProjectionItem,
+    Scan,
+    WindowAgg,
+)
+from sql_planner.plan import WindowFuncSpec as PlanWindowFuncSpec
+
+from sql_codegen import ComputeWindowFunctions, WinFunc, compile
+from sql_codegen.errors import UnsupportedNode
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _compile_window(
+    specs: list[PlanWindowFuncSpec], output_cols: list[str]
+) -> ComputeWindowFunctions:
+    """Compile a WindowAgg plan and return its ComputeWindowFunctions instruction."""
+    col_items = tuple(
+        ProjectionItem(expr=Column("t", c), alias=None)
+        for c in ["a", "b", "c"]
+    )
+    inner = Project(input=Scan(table="t", alias="t"), items=col_items)
+    plan = WindowAgg(
+        input=inner,
+        specs=tuple(specs),
+        output_cols=tuple(output_cols),
+    )
+    prog = compile(plan)
+    cwf = [i for i in prog.instructions if isinstance(i, ComputeWindowFunctions)]
+    assert len(cwf) == 1, f"Expected exactly 1 ComputeWindowFunctions, got {len(cwf)}"
+    return cwf[0]
+
+
+def _col(name: str) -> Column:
+    return Column(table="t", col=name)
+
+
+# ---------------------------------------------------------------------------
+# LAG
+# ---------------------------------------------------------------------------
+
+
+class TestLagCodegen:
+    def test_lag_no_extra_args_normalises_to_offset1_defaultnull(self) -> None:
+        """LAG(col) with no explicit offset/default → extra_args=(1, None)."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("a"),
+            partition_by=(_col("b"),),
+            order_by=((_col("c"), False),),
+            alias="prev_a",
+            extra_args=(),
+        )
+        cwf = _compile_window([spec], ["a", "b", "c", "prev_a"])
+        assert len(cwf.specs) == 1
+        ws = cwf.specs[0]
+        assert ws.func == WinFunc.LAG
+        assert ws.arg_col == "a"
+        assert ws.partition_cols == ("b",)
+        assert ws.order_cols == (("c", False),)
+        assert ws.result_col == "prev_a"
+        assert ws.extra_args == (1, None)
+
+    def test_lag_with_offset(self) -> None:
+        """LAG(col, 3) → extra_args=(3, None)."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=((_col("c"), False),),
+            alias="lag3",
+            extra_args=(Literal(3),),
+        )
+        cwf = _compile_window([spec], ["a", "c", "lag3"])
+        ws = cwf.specs[0]
+        assert ws.func == WinFunc.LAG
+        assert ws.extra_args == (3, None)
+
+    def test_lag_with_offset_and_default(self) -> None:
+        """LAG(col, 2, -1) → extra_args=(2, -1)."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=((_col("c"), False),),
+            alias="lag2",
+            extra_args=(Literal(2), Literal(-1)),
+        )
+        cwf = _compile_window([spec], ["a", "c", "lag2"])
+        ws = cwf.specs[0]
+        assert ws.extra_args == (2, -1)
+
+    def test_lag_desc_order(self) -> None:
+        """LAG with DESC order_by sets order_col desc flag correctly."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=((_col("c"), True),),  # DESC
+            alias="l",
+            extra_args=(Literal(1), Literal(None)),
+        )
+        cwf = _compile_window([spec], ["a", "c", "l"])
+        ws = cwf.specs[0]
+        assert ws.order_cols == (("c", True),)
+
+
+# ---------------------------------------------------------------------------
+# LEAD
+# ---------------------------------------------------------------------------
+
+
+class TestLeadCodegen:
+    def test_lead_no_extra_args_normalises(self) -> None:
+        """LEAD(col) with no offset/default → extra_args=(1, None)."""
+        spec = PlanWindowFuncSpec(
+            func="lead",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=((_col("c"), False),),
+            alias="next_a",
+            extra_args=(),
+        )
+        cwf = _compile_window([spec], ["a", "c", "next_a"])
+        ws = cwf.specs[0]
+        assert ws.func == WinFunc.LEAD
+        assert ws.extra_args == (1, None)
+
+    def test_lead_with_offset_and_default(self) -> None:
+        """LEAD(col, 2, 0) → extra_args=(2, 0)."""
+        spec = PlanWindowFuncSpec(
+            func="lead",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=((_col("c"), False),),
+            alias="l",
+            extra_args=(Literal(2), Literal(0)),
+        )
+        cwf = _compile_window([spec], ["a", "c", "l"])
+        ws = cwf.specs[0]
+        assert ws.extra_args == (2, 0)
+
+
+# ---------------------------------------------------------------------------
+# NTILE
+# ---------------------------------------------------------------------------
+
+
+class TestNtileCodegen:
+    def test_ntile_moves_literal_arg_to_extra_args(self) -> None:
+        """NTILE(4): bucket count moves from arg_expr to extra_args=(4,), arg_col=None."""
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=Literal(4),
+            partition_by=(_col("b"),),
+            order_by=((_col("c"), False),),
+            alias="bucket",
+            extra_args=(),
+        )
+        cwf = _compile_window([spec], ["b", "c", "bucket"])
+        ws = cwf.specs[0]
+        assert ws.func == WinFunc.NTILE
+        assert ws.arg_col is None          # literal bucket count, not a column
+        assert ws.extra_args == (4,)
+        assert ws.partition_cols == ("b",)
+
+    def test_ntile_missing_arg_raises(self) -> None:
+        """NTILE with arg_expr=None raises UnsupportedNode."""
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=None,
+            partition_by=(),
+            order_by=(),
+            alias="bucket",
+            extra_args=(),
+        )
+        with pytest.raises(UnsupportedNode, match="NTILE requires a bucket-count argument"):
+            _compile_window([spec], ["bucket"])
+
+    def test_ntile_non_literal_arg_raises(self) -> None:
+        """NTILE(col) — a column reference as bucket count — raises UnsupportedNode."""
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=_col("a"),        # column, not a literal
+            partition_by=(),
+            order_by=(),
+            alias="bucket",
+            extra_args=(),
+        )
+        with pytest.raises(UnsupportedNode):
+            _compile_window([spec], ["a", "bucket"])
+
+
+# ---------------------------------------------------------------------------
+# NTH_VALUE
+# ---------------------------------------------------------------------------
+
+
+class TestNthValueCodegen:
+    def test_nth_value_col_and_n(self) -> None:
+        """NTH_VALUE(col, 3): col → arg_col, 3 → extra_args=(3,)."""
+        spec = PlanWindowFuncSpec(
+            func="nth_value",
+            arg_expr=_col("a"),
+            partition_by=(_col("b"),),
+            order_by=((_col("c"), False),),
+            alias="nth",
+            extra_args=(Literal(3),),
+        )
+        cwf = _compile_window([spec], ["a", "b", "c", "nth"])
+        ws = cwf.specs[0]
+        assert ws.func == WinFunc.NTH_VALUE
+        assert ws.arg_col == "a"
+        assert ws.extra_args == (3,)
+
+    def test_nth_value_missing_n_raises(self) -> None:
+        """NTH_VALUE with no extra_args raises UnsupportedNode."""
+        spec = PlanWindowFuncSpec(
+            func="nth_value",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=(),
+            alias="nth",
+            extra_args=(),            # missing n
+        )
+        with pytest.raises(UnsupportedNode, match="NTH_VALUE requires two arguments"):
+            _compile_window([spec], ["a", "nth"])
+
+    def test_nth_value_non_literal_n_raises(self) -> None:
+        """NTH_VALUE(col, other_col) raises because n must be a literal."""
+        spec = PlanWindowFuncSpec(
+            func="nth_value",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=(),
+            alias="nth",
+            extra_args=(_col("b"),),   # column ref instead of literal
+        )
+        with pytest.raises(UnsupportedNode):
+            _compile_window([spec], ["a", "b", "nth"])
+
+
+# ---------------------------------------------------------------------------
+# PERCENT_RANK and CUME_DIST
+# ---------------------------------------------------------------------------
+
+
+class TestPercentRankCumeDistCodegen:
+    def test_percent_rank_no_extra_args(self) -> None:
+        """PERCENT_RANK: arg_col=None, extra_args=() always."""
+        spec = PlanWindowFuncSpec(
+            func="percent_rank",
+            arg_expr=None,
+            partition_by=(_col("b"),),
+            order_by=((_col("c"), False),),
+            alias="pr",
+            extra_args=(),
+        )
+        cwf = _compile_window([spec], ["b", "c", "pr"])
+        ws = cwf.specs[0]
+        assert ws.func == WinFunc.PERCENT_RANK
+        assert ws.arg_col is None
+        assert ws.extra_args == ()
+
+    def test_cume_dist_no_extra_args(self) -> None:
+        """CUME_DIST: arg_col=None, extra_args=() always."""
+        spec = PlanWindowFuncSpec(
+            func="cume_dist",
+            arg_expr=None,
+            partition_by=(),
+            order_by=((_col("c"), True),),
+            alias="cd",
+            extra_args=(),
+        )
+        cwf = _compile_window([spec], ["c", "cd"])
+        ws = cwf.specs[0]
+        assert ws.func == WinFunc.CUME_DIST
+        assert ws.arg_col is None
+        assert ws.extra_args == ()
+        assert ws.order_cols == (("c", True),)
+
+
+# ---------------------------------------------------------------------------
+# Multiple specs in one WindowAgg
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleWindowSpecCodegen:
+    def test_lag_and_lead_in_same_node(self) -> None:
+        """Two window specs with different functions in a single ComputeWindowFunctions."""
+        spec_lag = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=((_col("c"), False),),
+            alias="prev_a",
+            extra_args=(),
+        )
+        spec_lead = PlanWindowFuncSpec(
+            func="lead",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=((_col("c"), False),),
+            alias="next_a",
+            extra_args=(),
+        )
+        cwf = _compile_window([spec_lag, spec_lead], ["a", "c", "prev_a", "next_a"])
+        assert len(cwf.specs) == 2
+        funcs = {ws.func for ws in cwf.specs}
+        assert funcs == {WinFunc.LAG, WinFunc.LEAD}
+
+    def test_ntile_and_percent_rank_together(self) -> None:
+        """NTILE and PERCENT_RANK can coexist in the same WindowAgg."""
+        spec_nt = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=Literal(5),
+            partition_by=(),
+            order_by=((_col("c"), False),),
+            alias="bucket",
+            extra_args=(),
+        )
+        spec_pr = PlanWindowFuncSpec(
+            func="percent_rank",
+            arg_expr=None,
+            partition_by=(),
+            order_by=((_col("c"), False),),
+            alias="pr",
+            extra_args=(),
+        )
+        cwf = _compile_window([spec_nt, spec_pr], ["c", "bucket", "pr"])
+        assert len(cwf.specs) == 2
+        nt_spec = next(ws for ws in cwf.specs if ws.func == WinFunc.NTILE)
+        assert nt_spec.extra_args == (5,)
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestWindowCodegenErrors:
+    def test_unknown_window_function_raises(self) -> None:
+        """Compiling an unknown window function name raises UnsupportedNode."""
+        spec = PlanWindowFuncSpec(
+            func="funky_unknown_fn",
+            arg_expr=None,
+            partition_by=(),
+            order_by=(),
+            alias="x",
+            extra_args=(),
+        )
+        with pytest.raises(UnsupportedNode, match="unknown window function"):
+            _compile_window([spec], ["x"])
+
+    def test_lag_extra_arg_non_literal_raises(self) -> None:
+        """LAG extra arg that is not a Literal raises UnsupportedNode."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=(),
+            alias="l",
+            extra_args=(_col("b"),),   # column ref, not literal
+        )
+        with pytest.raises(UnsupportedNode, match="LAG/LEAD offset"):
+            _compile_window([spec], ["a", "b", "l"])

--- a/code/packages/python/sql-codegen/tests/test_window.py
+++ b/code/packages/python/sql-codegen/tests/test_window.py
@@ -387,3 +387,68 @@ class TestWindowCodegenErrors:
         )
         with pytest.raises(UnsupportedNode, match="LAG/LEAD offset"):
             _compile_window([spec], ["a", "b", "l"])
+
+    def test_lag_string_offset_raises(self) -> None:
+        """LAG(col, 'two') — string offset — must be rejected at compile time."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=(),
+            alias="l",
+            extra_args=(Literal("two"),),
+        )
+        with pytest.raises(UnsupportedNode, match="integer literal"):
+            _compile_window([spec], ["a", "l"])
+
+    def test_lag_float_offset_raises(self) -> None:
+        """LAG(col, 1.5) — float offset — must be rejected at compile time."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=(),
+            alias="l",
+            extra_args=(Literal(1.5),),
+        )
+        with pytest.raises(UnsupportedNode, match="integer literal"):
+            _compile_window([spec], ["a", "l"])
+
+    def test_ntile_string_n_raises(self) -> None:
+        """NTILE('three') — string bucket count — must be rejected at compile time."""
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=Literal("three"),
+            partition_by=(),
+            order_by=(),
+            alias="t",
+            extra_args=(),
+        )
+        with pytest.raises(UnsupportedNode, match="integer literal"):
+            _compile_window([spec], ["t"])
+
+    def test_ntile_float_n_raises(self) -> None:
+        """NTILE(3.7) — float bucket count — must be rejected at compile time."""
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=Literal(3.7),
+            partition_by=(),
+            order_by=(),
+            alias="t",
+            extra_args=(),
+        )
+        with pytest.raises(UnsupportedNode, match="integer literal"):
+            _compile_window([spec], ["t"])
+
+    def test_nth_value_string_n_raises(self) -> None:
+        """NTH_VALUE(col, 'one') — string row index — must be rejected at compile time."""
+        spec = PlanWindowFuncSpec(
+            func="nth_value",
+            arg_expr=_col("a"),
+            partition_by=(),
+            order_by=(),
+            alias="nv",
+            extra_args=(Literal("one"),),
+        )
+        with pytest.raises(UnsupportedNode, match="integer literal"):
+            _compile_window([spec], ["a", "nv"])

--- a/code/packages/python/sql-planner/CHANGELOG.md
+++ b/code/packages/python/sql-planner/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.17.0] - 2026-05-04
+
+### Added
+
+- **`extra_args` field on `WindowFuncExpr`** (`expr.py`) — carries zero or
+  more additional literal expressions beyond the primary column argument.
+  Used by multi-argument window functions: `LAG(col, offset, default)`,
+  `LEAD(col, offset, default)`, `NTH_VALUE(col, n)`.
+- **`extra_args` field on `WindowFuncSpec`** (`plan.py`) — same semantics
+  as `WindowFuncExpr.extra_args`, carried through the plan representation
+  so the codegen can extract literal constants at compile time.
+- **`extra_args` propagation in the planner** (`planner.py`) — `_resolve`
+  now recursively resolves all `extra_args` expressions, and
+  `WindowFuncSpec` construction in `_plan_select` passes `extra_args`
+  through from the source expression.
+
 ## [0.16.0] - 2026-05-04
 
 ### Added

--- a/code/packages/python/sql-planner/pyproject.toml
+++ b/code/packages/python/sql-planner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-planner"
-version = "0.16.0"
+version = "0.17.0"
 description = "Translates a structured SQL AST into a Logical Plan Tree of relational-algebra nodes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-planner/src/sql_planner/expr.py
+++ b/code/packages/python/sql-planner/src/sql_planner/expr.py
@@ -412,6 +412,19 @@ class WindowFuncExpr:
     order_by:
         Tuple of ``(expr, descending)`` sort keys within each partition.
         Required for ranking functions; optional for aggregating functions.
+    extra_args:
+        Additional constant arguments after the primary column argument.
+        Used by offset functions that take more than one argument:
+
+        - ``LAG(col, offset, default)``  → extra_args = (Literal(offset), Literal(default))
+        - ``LEAD(col, offset, default)`` → extra_args = (Literal(offset), Literal(default))
+        - ``NTILE(n)``                   → arg=Literal(n), extra_args = ()
+        - ``NTH_VALUE(col, n)``          → extra_args = (Literal(n),)
+        - ``PERCENT_RANK()``,  ``CUME_DIST()`` → arg=None, extra_args = ()
+
+        The planner resolves these through ``_resolve()`` just like any
+        other expression (they are typically ``Literal`` nodes and pass
+        through unchanged).
 
     Lifecycle
     ---------
@@ -424,6 +437,7 @@ class WindowFuncExpr:
     arg: Expr | None                           # None for arg-free funcs
     partition_by: tuple[Expr, ...] = ()
     order_by: tuple[tuple[Expr, bool], ...] = ()  # (expr, descending)
+    extra_args: tuple[Expr, ...] = ()          # LAG/LEAD offset+default, NTILE n, NTH_VALUE n
 
 
 # The type union every non-specialized consumer should match on. Order

--- a/code/packages/python/sql-planner/src/sql_planner/plan.py
+++ b/code/packages/python/sql-planner/src/sql_planner/plan.py
@@ -575,6 +575,7 @@ class WindowFuncSpec:
     partition_by: tuple[Expr, ...]
     order_by: tuple[tuple[Expr, bool], ...]
     alias: str
+    extra_args: tuple[Expr, ...] = ()   # LAG/LEAD offset+default; NTH_VALUE n
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/sql-planner/src/sql_planner/planner.py
+++ b/code/packages/python/sql-planner/src/sql_planner/planner.py
@@ -277,6 +277,7 @@ def _plan_select(
                     partition_by=wf.partition_by,
                     order_by=wf.order_by,
                     alias=alias,
+                    extra_args=wf.extra_args,
                 )
             )
 
@@ -678,7 +679,7 @@ def _resolve(
             resolved_op = _resolve(op, scope, schema, outer_scope)  # type: ignore[arg-type]
             inner_plan = _plan_select(stmt, schema, outer_scope=scope)  # type: ignore[arg-type]
             return NotInSubquery(operand=resolved_op, query=inner_plan)
-        case WindowFuncExpr(func, arg, partition_by, order_by):
+        case WindowFuncExpr(func, arg, partition_by, order_by, extra_args):
             new_arg = _resolve(arg, scope, schema, outer_scope) if arg is not None else None
             new_partition_by = tuple(
                 _resolve(e, scope, schema, outer_scope) for e in partition_by
@@ -686,11 +687,15 @@ def _resolve(
             new_order_by = tuple(
                 (_resolve(e, scope, schema, outer_scope), desc) for e, desc in order_by
             )
+            new_extra_args = tuple(
+                _resolve(e, scope, schema, outer_scope) for e in extra_args
+            )
             return WindowFuncExpr(
                 func=func,
                 arg=new_arg,
                 partition_by=new_partition_by,
                 order_by=new_order_by,
+                extra_args=new_extra_args,
             )
     raise AmbiguousColumn(column="<internal>", tables=[])  # unreachable
 

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.11.0 — 2026-05-04
+
+### Added
+
+- **LAG window function** (`vm.py`) — `_do_compute_window` now handles
+  `WinFunc.LAG`: returns the value of `arg_col` from the row `offset`
+  positions before the current row in the sorted partition.  Returns
+  `default_val` (from `extra_args[1]`) when no prior row exists at that
+  distance.  Offset and default are taken from `spec.extra_args = (offset,
+  default)`, normalised to `(1, None)` by the codegen if omitted.
+- **LEAD window function** (`vm.py`) — mirror of LAG, looks ahead by
+  `offset` positions instead of behind.
+- **NTILE window function** (`vm.py`) — `WinFunc.NTILE` divides the
+  partition into `n` approximately equal numbered buckets (1..n).
+  Distribution matches SQLite and PostgreSQL: `q, r = divmod(len, n)`;
+  the first `r` buckets get `q+1` rows, the remaining `n-r` get `q` rows.
+  `n` is taken from `spec.extra_args[0]`.
+- **PERCENT_RANK window function** (`vm.py`) — `WinFunc.PERCENT_RANK`
+  computes `(rank − 1) / (N − 1)` where rank is the SQL RANK() value and
+  N is the partition size.  Returns `0.0` when `N == 1` (avoids division
+  by zero).
+- **CUME_DIST window function** (`vm.py`) — `WinFunc.CUME_DIST` computes
+  the cumulative distribution as `(end-of-peer-group index + 1) / N`.
+  Tied rows share the same peer-group endpoint so they all receive the
+  same value.
+- **NTH_VALUE window function** (`vm.py`) — `WinFunc.NTH_VALUE` returns
+  the value of `arg_col` at the n-th row (1-indexed) of the partition.
+  Rows beyond the partition size return `NULL`.  `n` is taken from
+  `spec.extra_args[0]`.
+
 ## 1.10.0 — 2026-05-04
 
 ### Added

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.10.0"
+version = "1.11.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -1451,8 +1451,15 @@ def _do_compute_window(ins: ComputeWindowFunctions, st: _VmState) -> None:
                 #
                 # extra_args = (n: int,) set by codegen.
                 (n_buckets_raw,) = spec.extra_args if spec.extra_args else (1,)
-                n_buckets = max(1, int(n_buckets_raw))  # type: ignore[arg-type]
                 total = len(partition)
+                # Cap n_buckets to the partition size to prevent a DoS where a
+                # caller specifies NTILE(1_000_000_000) on a tiny partition,
+                # forcing the outer loop to run billions of iterations for no
+                # useful work.  SQL semantics are unaffected: if n > N then
+                # every row gets its own bucket (1..N) and empty buckets are
+                # simply never emitted, which is exactly what capping achieves.
+                raw_n = max(1, int(n_buckets_raw))  # type: ignore[arg-type]
+                n_buckets = min(raw_n, total) if total > 0 else 1
                 q, r = divmod(total, n_buckets)
                 # Build a bucket boundary list: bucket k (1-indexed) ends at
                 # the index computed below.

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -1546,7 +1546,13 @@ def _do_compute_window(ins: ComputeWindowFunctions, st: _VmState) -> None:
                 #
                 # extra_args = (n: int,) — 1-indexed.
                 (n_raw,) = spec.extra_args if spec.extra_args else (1,)
-                n_idx = int(n_raw) - 1  # type: ignore[arg-type]  # convert to 0-indexed
+                # Defense-in-depth: codegen already rejects non-integer n, but
+                # guard here too so a hand-crafted WinFuncSpec fails cleanly.
+                if not isinstance(n_raw, int) or isinstance(n_raw, bool):
+                    raise RuntimeError(
+                        f"NTH_VALUE n must be an integer, got {type(n_raw).__name__!r}"
+                    )
+                n_idx = n_raw - 1  # convert to 0-indexed
                 if 0 <= n_idx < len(partition) and arg_col:
                     nth_val: SqlValue = partition[n_idx].get(arg_col)
                 else:

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -1420,7 +1420,14 @@ def _do_compute_window(ins: ComputeWindowFunctions, st: _VmState) -> None:
                 # These are normalised to exactly two elements by the codegen
                 # compiler, so we can unpack directly.
                 offset_val, default_val = spec.extra_args if spec.extra_args else (1, None)
-                offset_int = int(offset_val) if offset_val is not None else 1  # type: ignore[arg-type]
+                # Defense-in-depth: codegen already rejects non-integer offsets,
+                # but guard here too so a hand-crafted WinFuncSpec can't cause a
+                # leaky ValueError deep in the VM.
+                if not isinstance(offset_val, int) or isinstance(offset_val, bool):
+                    raise RuntimeError(
+                        f"LAG offset must be an integer, got {type(offset_val).__name__!r}"
+                    )
+                offset_int = offset_val
                 for i, row in enumerate(partition):
                     src_idx = i - offset_int
                     if 0 <= src_idx < len(partition) and arg_col:
@@ -1432,7 +1439,11 @@ def _do_compute_window(ins: ComputeWindowFunctions, st: _VmState) -> None:
                 # LEAD(col, offset=1, default=None): mirror of LAG, but looks
                 # *ahead* instead of behind.  Row i fetches from row i+offset.
                 offset_val, default_val = spec.extra_args if spec.extra_args else (1, None)
-                offset_int = int(offset_val) if offset_val is not None else 1  # type: ignore[arg-type]
+                if not isinstance(offset_val, int) or isinstance(offset_val, bool):
+                    raise RuntimeError(
+                        f"LEAD offset must be an integer, got {type(offset_val).__name__!r}"
+                    )
+                offset_int = offset_val
                 for i, row in enumerate(partition):
                     src_idx = i + offset_int
                     if 0 <= src_idx < len(partition) and arg_col:
@@ -1452,13 +1463,18 @@ def _do_compute_window(ins: ComputeWindowFunctions, st: _VmState) -> None:
                 # extra_args = (n: int,) set by codegen.
                 (n_buckets_raw,) = spec.extra_args if spec.extra_args else (1,)
                 total = len(partition)
+                # Defense-in-depth type guard (codegen already enforces int).
+                if not isinstance(n_buckets_raw, int) or isinstance(n_buckets_raw, bool):
+                    raise RuntimeError(
+                        f"NTILE n must be an integer, got {type(n_buckets_raw).__name__!r}"
+                    )
                 # Cap n_buckets to the partition size to prevent a DoS where a
                 # caller specifies NTILE(1_000_000_000) on a tiny partition,
                 # forcing the outer loop to run billions of iterations for no
                 # useful work.  SQL semantics are unaffected: if n > N then
                 # every row gets its own bucket (1..N) and empty buckets are
                 # simply never emitted, which is exactly what capping achieves.
-                raw_n = max(1, int(n_buckets_raw))  # type: ignore[arg-type]
+                raw_n = max(1, n_buckets_raw)
                 n_buckets = min(raw_n, total) if total > 0 else 1
                 q, r = divmod(total, n_buckets)
                 # Build a bucket boundary list: bucket k (1-indexed) ends at

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -1410,6 +1410,127 @@ def _do_compute_window(ins: ComputeWindowFunctions, st: _VmState) -> None:
                 for row in partition:
                     row[result_col] = last
 
+            elif func == WinFunc.LAG:
+                # LAG(col, offset=1, default=None): return the value of ``col``
+                # from the row that is ``offset`` positions *before* the current
+                # row within the partition (ordered by order_cols).  Rows with
+                # no preceding peer at that distance return ``default``.
+                #
+                # extra_args = (offset: int, default: SqlValue)
+                # These are normalised to exactly two elements by the codegen
+                # compiler, so we can unpack directly.
+                offset_val, default_val = spec.extra_args if spec.extra_args else (1, None)
+                offset_int = int(offset_val) if offset_val is not None else 1  # type: ignore[arg-type]
+                for i, row in enumerate(partition):
+                    src_idx = i - offset_int
+                    if 0 <= src_idx < len(partition) and arg_col:
+                        row[result_col] = partition[src_idx].get(arg_col)
+                    else:
+                        row[result_col] = default_val
+
+            elif func == WinFunc.LEAD:
+                # LEAD(col, offset=1, default=None): mirror of LAG, but looks
+                # *ahead* instead of behind.  Row i fetches from row i+offset.
+                offset_val, default_val = spec.extra_args if spec.extra_args else (1, None)
+                offset_int = int(offset_val) if offset_val is not None else 1  # type: ignore[arg-type]
+                for i, row in enumerate(partition):
+                    src_idx = i + offset_int
+                    if 0 <= src_idx < len(partition) and arg_col:
+                        row[result_col] = partition[src_idx].get(arg_col)
+                    else:
+                        row[result_col] = default_val
+
+            elif func == WinFunc.NTILE:
+                # NTILE(n): divide the partition into n approximately equal
+                # buckets and assign each row a bucket number 1..n.
+                #
+                # Distribution rule (matches SQLite and PostgreSQL):
+                #   q, r = divmod(len(partition), n)
+                # The first r buckets have q+1 rows; the remaining n-r buckets
+                # have q rows.  Rows are numbered from 1.
+                #
+                # extra_args = (n: int,) set by codegen.
+                (n_buckets_raw,) = spec.extra_args if spec.extra_args else (1,)
+                n_buckets = max(1, int(n_buckets_raw))  # type: ignore[arg-type]
+                total = len(partition)
+                q, r = divmod(total, n_buckets)
+                # Build a bucket boundary list: bucket k (1-indexed) ends at
+                # the index computed below.
+                row_idx = 0
+                for bucket in range(1, n_buckets + 1):
+                    bucket_size = q + (1 if bucket <= r else 0)
+                    for _ in range(bucket_size):
+                        if row_idx < total:
+                            partition[row_idx][result_col] = bucket
+                            row_idx += 1
+
+            elif func == WinFunc.PERCENT_RANK:
+                # PERCENT_RANK: (rank − 1) / (N − 1) where rank is the RANK()
+                # value and N is the partition size.
+                # Special case: if N == 1, every row gets 0.0 (division by zero
+                # is avoided; the only row is trivially first).
+                n = len(partition)
+                if n <= 1:
+                    for row in partition:
+                        row[result_col] = 0.0
+                else:
+                    # Reuse the RANK computation — two consecutive rows share a
+                    # rank when their order-key values are identical.
+                    rank = 1
+                    for i, row in enumerate(partition):
+                        if i == 0:
+                            rank = 1
+                        else:
+                            prev = partition[i - 1]
+                            prev_key = _order_vals(prev, spec.order_cols)
+                            cur_key = _order_vals(row, spec.order_cols)
+                            if prev_key != cur_key:
+                                rank = i + 1
+                        row[result_col] = (rank - 1) / (n - 1)
+
+            elif func == WinFunc.CUME_DIST:
+                # CUME_DIST: (number of rows whose order key ≤ current row's
+                # order key) / N.  Two rows with the same order key get the
+                # same CUME_DIST value (the *last* position in the tie group).
+                #
+                # Equivalently: for each row find the *last* row with an equal
+                # order key (i.e. the end of the peer group) and compute
+                # (end_index + 1) / N.
+                n = len(partition)
+                i = 0
+                while i < n:
+                    # Find the end of the current peer group (all rows with
+                    # the same order-key values).
+                    j = i
+                    while j + 1 < n and (
+                        _order_vals(partition[j], spec.order_cols)
+                        == _order_vals(partition[j + 1], spec.order_cols)
+                    ):
+                        j += 1
+                    # Rows i..j all belong to the same peer group.
+                    cd = (j + 1) / n
+                    for k in range(i, j + 1):
+                        partition[k][result_col] = cd
+                    i = j + 1
+
+            elif func == WinFunc.NTH_VALUE:
+                # NTH_VALUE(col, n): return the value of ``col`` at the n-th
+                # row (1-indexed) of the partition.  Rows before the n-th row
+                # also receive that value (the window frame logically grows as
+                # each row is processed, but in our materialised model we simply
+                # broadcast the n-th value to all rows).  If the partition has
+                # fewer than n rows, return NULL.
+                #
+                # extra_args = (n: int,) — 1-indexed.
+                (n_raw,) = spec.extra_args if spec.extra_args else (1,)
+                n_idx = int(n_raw) - 1  # type: ignore[arg-type]  # convert to 0-indexed
+                if 0 <= n_idx < len(partition) and arg_col:
+                    nth_val: SqlValue = partition[n_idx].get(arg_col)
+                else:
+                    nth_val = None
+                for row in partition:
+                    row[result_col] = nth_val
+
     # Project rows to output_cols and rebuild tuples.
     out_cols = ins.output_cols
     st.result.rows = [

--- a/code/packages/python/sql-vm/tests/test_tier4_window_extended.py
+++ b/code/packages/python/sql-vm/tests/test_tier4_window_extended.py
@@ -682,3 +682,74 @@ class TestEdgeCases:
         _do_compute_window(instr, state)  # type: ignore[arg-type]
         # With n=1 (default from empty extra_args), every row lands in bucket 1.
         assert all(r[1] == 1 for r in state.result.rows)
+
+    def test_lag_vm_guard_rejects_string_offset(self) -> None:
+        """Defense-in-depth: LAG handler raises RuntimeError for non-int offset.
+
+        The codegen already rejects this at compile time; this test reaches the
+        VM-level guard via a hand-crafted WinFuncSpec to ensure the guard is
+        exercised and does not emit a leaky ValueError.
+        """
+        import types
+
+        import pytest
+        from sql_codegen import ComputeWindowFunctions
+        from sql_codegen.ir import WinFunc, WinFuncSpec
+
+        from sql_vm.result import _MutableResult
+        from sql_vm.vm import _do_compute_window
+
+        spec_ir = WinFuncSpec(
+            func=WinFunc.LAG,
+            arg_col="salary",
+            partition_cols=(),
+            order_cols=(("id", False),),
+            result_col="prev_sal",
+            extra_args=("two", None),   # string offset — invalid
+        )
+        instr = ComputeWindowFunctions(
+            specs=(spec_ir,),
+            output_cols=("id", "salary", "prev_sal"),
+        )
+        result_buf = _MutableResult(
+            columns=("id", "salary"),
+            rows=[(1, 100), (2, 200)],
+        )
+        state = types.SimpleNamespace(result=result_buf)
+        with pytest.raises(RuntimeError, match="LAG offset must be an integer"):
+            _do_compute_window(instr, state)  # type: ignore[arg-type]
+
+    def test_ntile_vm_guard_rejects_string_n(self) -> None:
+        """Defense-in-depth: NTILE handler raises RuntimeError for non-int n.
+
+        As with the LAG guard above, codegen prevents this in practice; we
+        drive the VM directly to confirm the defensive check is reachable.
+        """
+        import types
+
+        import pytest
+        from sql_codegen import ComputeWindowFunctions
+        from sql_codegen.ir import WinFunc, WinFuncSpec
+
+        from sql_vm.result import _MutableResult
+        from sql_vm.vm import _do_compute_window
+
+        spec_ir = WinFuncSpec(
+            func=WinFunc.NTILE,
+            arg_col=None,
+            partition_cols=(),
+            order_cols=(("id", False),),
+            result_col="bucket",
+            extra_args=("three",),  # string bucket count — invalid
+        )
+        instr = ComputeWindowFunctions(
+            specs=(spec_ir,),
+            output_cols=("id", "bucket"),
+        )
+        result_buf = _MutableResult(
+            columns=("id",),
+            rows=[(1,), (2,), (3,)],
+        )
+        state = types.SimpleNamespace(result=result_buf)
+        with pytest.raises(RuntimeError, match="NTILE n must be an integer"):
+            _do_compute_window(instr, state)  # type: ignore[arg-type]

--- a/code/packages/python/sql-vm/tests/test_tier4_window_extended.py
+++ b/code/packages/python/sql-vm/tests/test_tier4_window_extended.py
@@ -753,3 +753,34 @@ class TestEdgeCases:
         state = types.SimpleNamespace(result=result_buf)
         with pytest.raises(RuntimeError, match="NTILE n must be an integer"):
             _do_compute_window(instr, state)  # type: ignore[arg-type]
+
+    def test_nth_value_vm_guard_rejects_string_n(self) -> None:
+        """Defense-in-depth: NTH_VALUE handler raises RuntimeError for non-int n."""
+        import types
+
+        import pytest
+        from sql_codegen import ComputeWindowFunctions
+        from sql_codegen.ir import WinFunc, WinFuncSpec
+
+        from sql_vm.result import _MutableResult
+        from sql_vm.vm import _do_compute_window
+
+        spec_ir = WinFuncSpec(
+            func=WinFunc.NTH_VALUE,
+            arg_col="salary",
+            partition_cols=(),
+            order_cols=(("id", False),),
+            result_col="nv",
+            extra_args=("two",),  # string row index — invalid
+        )
+        instr = ComputeWindowFunctions(
+            specs=(spec_ir,),
+            output_cols=("id", "salary", "nv"),
+        )
+        result_buf = _MutableResult(
+            columns=("id", "salary"),
+            rows=[(1, 100), (2, 200)],
+        )
+        state = types.SimpleNamespace(result=result_buf)
+        with pytest.raises(RuntimeError, match="NTH_VALUE n must be an integer"):
+            _do_compute_window(instr, state)  # type: ignore[arg-type]

--- a/code/packages/python/sql-vm/tests/test_tier4_window_extended.py
+++ b/code/packages/python/sql-vm/tests/test_tier4_window_extended.py
@@ -1,0 +1,684 @@
+"""
+Extended window function VM tests — LAG, LEAD, NTILE, PERCENT_RANK, CUME_DIST, NTH_VALUE.
+
+These are integration tests running the full pipeline (LogicalPlan →
+codegen → VM) and verifying the new window function branches added to
+``_do_compute_window`` in vm.py.
+
+Data set (re-used throughout)
+------------------------------
+Five employees in two departments, ordered here for reference:
+
+    id  name   dept   salary
+    1   Alice  eng    90000
+    2   Bob    eng    80000
+    3   Carol  sales  70000
+    4   Dave   sales  75000
+    5   Eve    eng    85000
+
+When sorted by salary ASC within each dept:
+
+    eng:   Bob 80000, Eve 85000, Alice 90000
+    sales: Carol 70000, Dave 75000
+
+Coverage targets
+----------------
+- vm.py: WinFunc.LAG, WinFunc.LEAD, WinFunc.NTILE,
+         WinFunc.PERCENT_RANK, WinFunc.CUME_DIST, WinFunc.NTH_VALUE
+"""
+
+from __future__ import annotations
+
+from sql_backend.in_memory import InMemoryBackend
+from sql_backend.schema import ColumnDef
+from sql_codegen import compile
+from sql_planner import (
+    Column,
+    Literal,
+    Project,
+    ProjectionItem,
+    Scan,
+    WindowAgg,
+)
+from sql_planner.plan import WindowFuncSpec as PlanWindowFuncSpec
+
+from sql_vm import execute
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _backend() -> InMemoryBackend:
+    """Create an in-memory backend pre-loaded with the five-row employees table."""
+    be = InMemoryBackend()
+    be.create_table(
+        "employees",
+        [
+            ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+            ColumnDef(name="name", type_name="TEXT"),
+            ColumnDef(name="dept", type_name="TEXT"),
+            ColumnDef(name="salary", type_name="INTEGER"),
+        ],
+        False,
+    )
+    for row in [
+        {"id": 1, "name": "Alice", "dept": "eng",   "salary": 90000},
+        {"id": 2, "name": "Bob",   "dept": "eng",   "salary": 80000},
+        {"id": 3, "name": "Carol", "dept": "sales", "salary": 70000},
+        {"id": 4, "name": "Dave",  "dept": "sales", "salary": 75000},
+        {"id": 5, "name": "Eve",   "dept": "eng",   "salary": 85000},
+    ]:
+        be.insert("employees", row)
+    return be
+
+
+def _run(
+    specs: list[PlanWindowFuncSpec],
+    select_cols: list[str],
+    output_cols: list[str],
+) -> list[tuple]:
+    """Build a WindowAgg plan, compile, execute, and return result rows."""
+    be = _backend()
+    col_items = tuple(
+        ProjectionItem(expr=Column(table="e", col=c), alias=None)
+        for c in select_cols
+    )
+    inner = Project(
+        input=Scan(table="employees", alias="e"),
+        items=col_items,
+    )
+    plan = WindowAgg(
+        input=inner,
+        specs=tuple(specs),
+        output_cols=tuple(output_cols),
+    )
+    prog = compile(plan)
+    return execute(prog, be).rows
+
+
+# Shorthand column factory (table="employees" matches the Scan alias scope used
+# in PlanWindowFuncSpec partition_by / order_by).
+def _col(name: str) -> Column:
+    return Column(table="employees", col=name)
+
+
+# ---------------------------------------------------------------------------
+# LAG
+# ---------------------------------------------------------------------------
+
+
+class TestLag:
+    """LAG(col [, offset=1 [, default=NULL]]) looks back in an ordered partition."""
+
+    def test_lag_default_offset(self) -> None:
+        """LAG with no explicit offset defaults to 1 (previous row)."""
+        # Partition by dept, order by salary ASC.
+        # eng sorted: Bob 80000, Eve 85000, Alice 90000
+        #   → lag(salary): NULL, 80000, 85000
+        # sales sorted: Carol 70000, Dave 75000
+        #   → lag(salary): NULL, 70000
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="prev_sal",
+            extra_args=(Literal(1), Literal(None)),
+        )
+        rows = _run([spec], ["dept", "name", "salary"], ["dept", "name", "salary", "prev_sal"])
+
+        eng = {r[1]: r[3] for r in rows if r[0] == "eng"}
+        assert eng["Bob"] is None       # first in partition
+        assert eng["Eve"] == 80000      # previous was Bob
+        assert eng["Alice"] == 85000    # previous was Eve
+
+        sales = {r[1]: r[3] for r in rows if r[0] == "sales"}
+        assert sales["Carol"] is None   # first in partition
+        assert sales["Dave"] == 70000   # previous was Carol
+
+    def test_lag_offset_2(self) -> None:
+        """LAG with offset=2 skips one intermediate row."""
+        # eng sorted by salary ASC: Bob(80k), Eve(85k), Alice(90k)
+        # lag(salary, 2): NULL, NULL, 80000
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="lag2",
+            extra_args=(Literal(2), Literal(None)),
+        )
+        rows = _run([spec], ["dept", "name", "salary"], ["dept", "name", "salary", "lag2"])
+        eng = sorted(
+            [(r[2], r[3]) for r in rows if r[0] == "eng"],
+            key=lambda x: x[0],
+        )
+        # eng by salary: 80000→None, 85000→None, 90000→80000
+        assert eng[0] == (80000, None)
+        assert eng[1] == (85000, None)
+        assert eng[2] == (90000, 80000)
+
+    def test_lag_with_default(self) -> None:
+        """LAG with a non-NULL default fills boundary rows instead of NULL."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="prev_sal",
+            extra_args=(Literal(1), Literal(-1)),
+        )
+        rows = _run([spec], ["dept", "name", "salary"], ["dept", "name", "salary", "prev_sal"])
+        eng = {r[1]: r[3] for r in rows if r[0] == "eng"}
+        assert eng["Bob"] == -1         # first row uses the default
+        assert eng["Eve"] == 80000
+
+    def test_lag_global_no_partition(self) -> None:
+        """LAG over all rows with no PARTITION BY — single global partition."""
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("id"),
+            partition_by=(),
+            order_by=((_col("id"), False),),
+            alias="prev_id",
+            extra_args=(Literal(1), Literal(None)),
+        )
+        rows = _run([spec], ["id"], ["id", "prev_id"])
+        # Ordered by id: 1→None, 2→1, 3→2, 4→3, 5→4
+        by_id = {r[0]: r[1] for r in rows}
+        assert by_id[1] is None
+        assert by_id[2] == 1
+        assert by_id[5] == 4
+
+
+# ---------------------------------------------------------------------------
+# LEAD
+# ---------------------------------------------------------------------------
+
+
+class TestLead:
+    """LEAD(col [, offset=1 [, default=NULL]]) looks forward in an ordered partition."""
+
+    def test_lead_default_offset(self) -> None:
+        """LEAD with no explicit offset defaults to 1 (next row)."""
+        # eng sorted by salary ASC: Bob 80000, Eve 85000, Alice 90000
+        # lead(salary): 85000, 90000, NULL
+        spec = PlanWindowFuncSpec(
+            func="lead",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="next_sal",
+            extra_args=(Literal(1), Literal(None)),
+        )
+        rows = _run([spec], ["dept", "name", "salary"], ["dept", "name", "salary", "next_sal"])
+        eng = {r[1]: r[3] for r in rows if r[0] == "eng"}
+        assert eng["Bob"] == 85000      # next is Eve
+        assert eng["Eve"] == 90000      # next is Alice
+        assert eng["Alice"] is None     # last in partition
+
+    def test_lead_offset_2(self) -> None:
+        """LEAD with offset=2 skips one row ahead."""
+        spec = PlanWindowFuncSpec(
+            func="lead",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="lead2",
+            extra_args=(Literal(2), Literal(None)),
+        )
+        rows = _run([spec], ["dept", "name", "salary"], ["dept", "name", "salary", "lead2"])
+        eng = sorted(
+            [(r[2], r[3]) for r in rows if r[0] == "eng"],
+            key=lambda x: x[0],
+        )
+        # eng by salary: 80000→90000, 85000→None, 90000→None
+        assert eng[0] == (80000, 90000)
+        assert eng[1] == (85000, None)
+        assert eng[2] == (90000, None)
+
+    def test_lead_with_default(self) -> None:
+        """LEAD with a non-NULL default fills boundary rows."""
+        spec = PlanWindowFuncSpec(
+            func="lead",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="next_sal",
+            extra_args=(Literal(1), Literal(0)),
+        )
+        rows = _run([spec], ["dept", "name", "salary"], ["dept", "name", "salary", "next_sal"])
+        eng = {r[1]: r[3] for r in rows if r[0] == "eng"}
+        assert eng["Alice"] == 0        # last row uses the default
+
+
+# ---------------------------------------------------------------------------
+# NTILE
+# ---------------------------------------------------------------------------
+
+
+class TestNtile:
+    """NTILE(n) distributes rows into n buckets numbered 1..n."""
+
+    def test_ntile_3_buckets_global(self) -> None:
+        """5 rows into 3 buckets: buckets 1,2 get 2 rows each; bucket 3 gets 1.
+
+        Distribution: q, r = divmod(5, 3) → q=1, r=2
+        Bucket 1: 2 rows, Bucket 2: 2 rows, Bucket 3: 1 row.
+        """
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=Literal(3),
+            partition_by=(),
+            order_by=((_col("id"), False),),
+            alias="bucket",
+            extra_args=(),
+        )
+        rows = _run([spec], ["id"], ["id", "bucket"])
+        by_bucket: dict[int, list[int]] = {}
+        for id_val, bucket in rows:
+            by_bucket.setdefault(bucket, []).append(id_val)
+        assert set(by_bucket.keys()) == {1, 2, 3}
+        assert len(by_bucket[1]) == 2
+        assert len(by_bucket[2]) == 2
+        assert len(by_bucket[3]) == 1
+
+    def test_ntile_2_buckets_partitioned(self) -> None:
+        """NTILE(2) within each department.
+
+        eng (3 rows): q, r = divmod(3, 2) → q=1, r=1
+                      bucket 1: 2 rows, bucket 2: 1 row
+        sales (2 rows): q, r = divmod(2, 2) → q=1, r=0
+                        bucket 1: 1 row, bucket 2: 1 row
+        """
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=Literal(2),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="bucket",
+            extra_args=(),
+        )
+        rows = _run([spec], ["dept", "salary"], ["dept", "salary", "bucket"])
+        eng_rows = sorted([(r[1], r[2]) for r in rows if r[0] == "eng"])
+        # eng sorted by salary ASC: 80000 → b1, 85000 → b1, 90000 → b2
+        assert eng_rows[0][1] == 1
+        assert eng_rows[1][1] == 1
+        assert eng_rows[2][1] == 2
+
+    def test_ntile_larger_than_partition(self) -> None:
+        """NTILE(10) with only 2 rows: each row gets a distinct bucket 1..2.
+
+        When n > partition_size, max(1, n) buckets but only partition_size
+        of them are filled. Row i gets bucket i+1.
+        """
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=Literal(10),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="bucket",
+            extra_args=(),
+        )
+        rows = _run([spec], ["dept", "salary"], ["dept", "salary", "bucket"])
+        sales = sorted([(r[1], r[2]) for r in rows if r[0] == "sales"])
+        # 2 rows into 10 buckets: Carol→1, Dave→2
+        assert sales[0][1] == 1
+        assert sales[1][1] == 2
+
+    def test_ntile_1_bucket(self) -> None:
+        """NTILE(1): every row goes into bucket 1."""
+        spec = PlanWindowFuncSpec(
+            func="ntile",
+            arg_expr=Literal(1),
+            partition_by=(),
+            order_by=((_col("id"), False),),
+            alias="bucket",
+            extra_args=(),
+        )
+        rows = _run([spec], ["id"], ["id", "bucket"])
+        assert all(r[1] == 1 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# PERCENT_RANK
+# ---------------------------------------------------------------------------
+
+
+class TestPercentRank:
+    """PERCENT_RANK: (rank - 1) / (N - 1), range [0.0, 1.0]."""
+
+    def test_percent_rank_global_unique_order(self) -> None:
+        """5 distinct salaries → percent_rank values are 0, 0.25, 0.5, 0.75, 1.
+
+        Salaries sorted ASC: 70000, 75000, 80000, 85000, 90000
+        """
+        spec = PlanWindowFuncSpec(
+            func="percent_rank",
+            arg_expr=None,
+            partition_by=(),
+            order_by=((_col("salary"), False),),
+            alias="pr",
+            extra_args=(),
+        )
+        rows = _run([spec], ["salary"], ["salary", "pr"])
+        by_salary = {r[0]: r[1] for r in rows}
+        assert abs(by_salary[70000] - 0.0) < 1e-9
+        assert abs(by_salary[75000] - 0.25) < 1e-9
+        assert abs(by_salary[80000] - 0.5) < 1e-9
+        assert abs(by_salary[85000] - 0.75) < 1e-9
+        assert abs(by_salary[90000] - 1.0) < 1e-9
+
+    def test_percent_rank_with_ties(self) -> None:
+        """Tied rows share the same PERCENT_RANK value.
+
+        dept is the order key: 3 eng rows tie at rank 1, 2 sales rows tie at rank 4.
+        N=5, so: eng → (1-1)/(5-1)=0.0; sales → (4-1)/(5-1)=0.75
+        """
+        spec = PlanWindowFuncSpec(
+            func="percent_rank",
+            arg_expr=None,
+            partition_by=(),
+            order_by=((_col("dept"), False),),  # "eng" < "sales" lexicographically
+            alias="pr",
+            extra_args=(),
+        )
+        rows = _run([spec], ["dept"], ["dept", "pr"])
+        eng_vals = {r[1] for r in rows if r[0] == "eng"}
+        sales_vals = {r[1] for r in rows if r[0] == "sales"}
+        assert len(eng_vals) == 1
+        assert abs(list(eng_vals)[0] - 0.0) < 1e-9
+        assert len(sales_vals) == 1
+        assert abs(list(sales_vals)[0] - 0.75) < 1e-9
+
+    def test_percent_rank_single_row_partition(self) -> None:
+        """A partition with a single row always returns 0.0 (N=1 special case)."""
+        # Split into per-employee partitions (id is unique → each partition has 1 row).
+        spec = PlanWindowFuncSpec(
+            func="percent_rank",
+            arg_expr=None,
+            partition_by=(_col("id"),),
+            order_by=((_col("salary"), False),),
+            alias="pr",
+            extra_args=(),
+        )
+        rows = _run([spec], ["id"], ["id", "pr"])
+        assert all(r[1] == 0.0 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# CUME_DIST
+# ---------------------------------------------------------------------------
+
+
+class TestCumeDist:
+    """CUME_DIST: (position of last peer row + 1) / N, range (0, 1]."""
+
+    def test_cume_dist_global_unique(self) -> None:
+        """5 distinct salaries → cume_dist = 0.2, 0.4, 0.6, 0.8, 1.0."""
+        spec = PlanWindowFuncSpec(
+            func="cume_dist",
+            arg_expr=None,
+            partition_by=(),
+            order_by=((_col("salary"), False),),
+            alias="cd",
+            extra_args=(),
+        )
+        rows = _run([spec], ["salary"], ["salary", "cd"])
+        by_salary = sorted(rows, key=lambda r: r[0])
+        expected = [0.2, 0.4, 0.6, 0.8, 1.0]
+        for (sal, cd), exp in zip(by_salary, expected, strict=True):
+            assert abs(cd - exp) < 1e-9, f"salary={sal}: expected {exp}, got {cd}"
+
+    def test_cume_dist_with_ties(self) -> None:
+        """Tied rows share the peer-group end position.
+
+        Order by dept ASC: 3 eng rows in peer group ending at pos 3 → cd=0.6;
+                           2 sales rows ending at pos 5 → cd=1.0.
+        """
+        spec = PlanWindowFuncSpec(
+            func="cume_dist",
+            arg_expr=None,
+            partition_by=(),
+            order_by=((_col("dept"), False),),
+            alias="cd",
+            extra_args=(),
+        )
+        rows = _run([spec], ["dept"], ["dept", "cd"])
+        eng_vals = {r[1] for r in rows if r[0] == "eng"}
+        sales_vals = {r[1] for r in rows if r[0] == "sales"}
+        assert len(eng_vals) == 1 and abs(list(eng_vals)[0] - 0.6) < 1e-9
+        assert len(sales_vals) == 1 and abs(list(sales_vals)[0] - 1.0) < 1e-9
+
+    def test_cume_dist_partitioned(self) -> None:
+        """CUME_DIST within each department partition.
+
+        eng (3 rows, order by salary ASC): 80000→1/3, 85000→2/3, 90000→1.0
+        sales (2 rows): 70000→0.5, 75000→1.0
+        """
+        spec = PlanWindowFuncSpec(
+            func="cume_dist",
+            arg_expr=None,
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="cd",
+            extra_args=(),
+        )
+        rows = _run([spec], ["dept", "salary"], ["dept", "salary", "cd"])
+        eng = sorted([(r[1], r[2]) for r in rows if r[0] == "eng"])
+        assert abs(eng[0][1] - 1 / 3) < 1e-9
+        assert abs(eng[1][1] - 2 / 3) < 1e-9
+        assert abs(eng[2][1] - 1.0) < 1e-9
+
+        sales = sorted([(r[1], r[2]) for r in rows if r[0] == "sales"])
+        assert abs(sales[0][1] - 0.5) < 1e-9
+        assert abs(sales[1][1] - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# NTH_VALUE
+# ---------------------------------------------------------------------------
+
+
+class TestNthValue:
+    """NTH_VALUE(col, n): value of col at the n-th row (1-indexed) of the partition."""
+
+    def test_nth_value_first_row(self) -> None:
+        """NTH_VALUE(salary, 1) == FIRST_VALUE(salary)."""
+        spec = PlanWindowFuncSpec(
+            func="nth_value",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="nth",
+            extra_args=(Literal(1),),
+        )
+        rows = _run([spec], ["dept", "salary"], ["dept", "salary", "nth"])
+        eng = {r[2] for r in rows if r[0] == "eng"}
+        # Lowest salary in eng is 80000 (Bob), sorted ASC
+        assert eng == {80000}
+
+    def test_nth_value_second_row(self) -> None:
+        """NTH_VALUE(salary, 2) returns the 2nd-smallest salary in each partition."""
+        spec = PlanWindowFuncSpec(
+            func="nth_value",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="nth",
+            extra_args=(Literal(2),),
+        )
+        rows = _run([spec], ["dept", "salary"], ["dept", "salary", "nth"])
+        eng = {r[2] for r in rows if r[0] == "eng"}
+        # eng sorted ASC: Bob 80000, Eve 85000, Alice 90000  → 2nd = 85000
+        assert eng == {85000}
+
+        sales = {r[2] for r in rows if r[0] == "sales"}
+        # sales sorted ASC: Carol 70000, Dave 75000  → 2nd = 75000
+        assert sales == {75000}
+
+    def test_nth_value_beyond_partition_size(self) -> None:
+        """NTH_VALUE with n > partition size returns NULL for all rows."""
+        spec = PlanWindowFuncSpec(
+            func="nth_value",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="nth",
+            extra_args=(Literal(99),),
+        )
+        rows = _run([spec], ["dept", "salary"], ["dept", "salary", "nth"])
+        assert all(r[2] is None for r in rows)
+
+    def test_nth_value_global_no_partition(self) -> None:
+        """NTH_VALUE(salary, 3) over all 5 rows (no partition) → the 3rd smallest."""
+        spec = PlanWindowFuncSpec(
+            func="nth_value",
+            arg_expr=_col("salary"),
+            partition_by=(),
+            order_by=((_col("salary"), False),),
+            alias="nth",
+            extra_args=(Literal(3),),
+        )
+        rows = _run([spec], ["salary"], ["salary", "nth"])
+        # All 5 salaries ASC: 70000, 75000, 80000, 85000, 90000  → 3rd = 80000
+        assert all(r[1] == 80000 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and combinations
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_lag_single_row_partition(self) -> None:
+        """A single-row partition always has LAG = default (NULL if unspecified)."""
+        # Partition by id (each id is unique → 1 row per partition).
+        spec = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("salary"),
+            partition_by=(_col("id"),),
+            order_by=((_col("salary"), False),),
+            alias="prev_sal",
+            extra_args=(Literal(1), Literal(None)),
+        )
+        rows = _run([spec], ["id", "salary"], ["id", "salary", "prev_sal"])
+        # Every partition has 1 row → no predecessor → all NULL.
+        assert all(r[2] is None for r in rows)
+
+    def test_lead_single_row_partition(self) -> None:
+        """A single-row partition always has LEAD = default (NULL if unspecified)."""
+        spec = PlanWindowFuncSpec(
+            func="lead",
+            arg_expr=_col("salary"),
+            partition_by=(_col("id"),),
+            order_by=((_col("salary"), False),),
+            alias="next_sal",
+            extra_args=(Literal(1), Literal(None)),
+        )
+        rows = _run([spec], ["id", "salary"], ["id", "salary", "next_sal"])
+        assert all(r[2] is None for r in rows)
+
+    def test_lag_and_lead_combined(self) -> None:
+        """LAG and LEAD can run in the same WindowAgg node without interfering."""
+        spec_lag = PlanWindowFuncSpec(
+            func="lag",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="prev_sal",
+            extra_args=(Literal(1), Literal(None)),
+        )
+        spec_lead = PlanWindowFuncSpec(
+            func="lead",
+            arg_expr=_col("salary"),
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="next_sal",
+            extra_args=(Literal(1), Literal(None)),
+        )
+        rows = _run(
+            [spec_lag, spec_lead],
+            ["dept", "salary"],
+            ["dept", "salary", "prev_sal", "next_sal"],
+        )
+        # eng sorted ASC: Bob 80000, Eve 85000, Alice 90000
+        eng = sorted([(r[1], r[2], r[3]) for r in rows if r[0] == "eng"])
+        assert eng[0] == (80000, None, 85000)   # Bob: no prev, next=Eve
+        assert eng[1] == (85000, 80000, 90000)  # Eve: prev=Bob, next=Alice
+        assert eng[2] == (90000, 85000, None)   # Alice: prev=Eve, no next
+
+    def test_percent_rank_and_cume_dist_together(self) -> None:
+        """PERCENT_RANK and CUME_DIST produce complementary values in the same node."""
+        spec_pr = PlanWindowFuncSpec(
+            func="percent_rank",
+            arg_expr=None,
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="pr",
+            extra_args=(),
+        )
+        spec_cd = PlanWindowFuncSpec(
+            func="cume_dist",
+            arg_expr=None,
+            partition_by=(_col("dept"),),
+            order_by=((_col("salary"), False),),
+            alias="cd",
+            extra_args=(),
+        )
+        rows = _run(
+            [spec_pr, spec_cd],
+            ["dept", "salary"],
+            ["dept", "salary", "pr", "cd"],
+        )
+        # eng sorted ASC: Bob 80000, Eve 85000, Alice 90000 (N=3)
+        # percent_rank: 0, 0.5, 1.0
+        # cume_dist:    1/3, 2/3, 1.0
+        eng = sorted([(r[1], r[2], r[3]) for r in rows if r[0] == "eng"])
+        assert abs(eng[0][1] - 0.0) < 1e-9
+        assert abs(eng[1][1] - 0.5) < 1e-9
+        assert abs(eng[2][1] - 1.0) < 1e-9
+        assert abs(eng[0][2] - 1 / 3) < 1e-9
+        assert abs(eng[1][2] - 2 / 3) < 1e-9
+        assert abs(eng[2][2] - 1.0) < 1e-9
+
+    def test_ntile_no_extra_args_in_ir_defaults_to_1(self) -> None:
+        """NTILE WinFuncSpec with empty extra_args: VM uses n=max(1,1)=1 fallback.
+
+        This exercises the defensive ``(n_buckets_raw,) = spec.extra_args if
+        spec.extra_args else (1,)`` branch in the VM's NTILE handler.  That
+        branch is only reachable by constructing the IR directly (the codegen
+        always populates extra_args for NTILE), so we drive the VM's
+        _do_compute_window helper directly on a hand-built _MutableResult.
+        """
+        import types
+
+        from sql_codegen import ComputeWindowFunctions
+        from sql_codegen.ir import WinFunc, WinFuncSpec
+
+        from sql_vm.result import _MutableResult
+        from sql_vm.vm import _do_compute_window
+
+        spec_ir = WinFuncSpec(
+            func=WinFunc.NTILE,
+            arg_col=None,
+            partition_cols=(),
+            order_cols=(("id", False),),
+            result_col="bucket",
+            extra_args=(),    # empty → VM should default to n=1
+        )
+        instr = ComputeWindowFunctions(
+            specs=(spec_ir,),
+            output_cols=("id", "bucket"),
+        )
+        # _do_compute_window only reads st.result.columns and st.result.rows,
+        # so a SimpleNamespace with those two attributes is sufficient.
+        result_buf = _MutableResult(
+            columns=("id",),
+            rows=[(1,), (2,), (3,)],
+        )
+        state = types.SimpleNamespace(result=result_buf)
+        _do_compute_window(instr, state)  # type: ignore[arg-type]
+        # With n=1 (default from empty extra_args), every row lands in bucket 1.
+        assert all(r[1] == 1 for r in state.result.rows)


### PR DESCRIPTION
## Summary

- **sql-planner**: Added `extra_args: tuple[Expr, ...]` field to `WindowFuncExpr` and `WindowFuncSpec` to carry literal arguments beyond the primary column (needed for LAG/LEAD offset+default, NTILE bucket count, NTH_VALUE row index)
- **sql-codegen**: Implemented all 6 new `WinFunc` enum values in `_to_ir_win_spec`; added `_literal_val` helper with `_INT_REQUIRED_CTXS` that rejects non-integer literals (strings, floats) at compile time for offset/n arguments
- **sql-vm**: Implemented all 6 new window function branches in `_do_compute_window`, plus defense-in-depth integer type guards that raise `RuntimeError` (not leaky `ValueError`) for hand-crafted `WinFuncSpec` objects that bypass codegen
- **mini-sqlite**: Adapter updated to extract `extra_args` from multi-argument window function calls

## Security fixes (3 rounds of review)
1. **NTILE DoS** (MEDIUM): Capped `n_buckets` to `min(raw_n, total)` — prevents billion-iteration loops on tiny partitions
2. **Type confusion at compile time** (MEDIUM): `_literal_val` now rejects string/float literals for offset/n arguments with a clear `UnsupportedNode` before they reach the VM
3. **Missing NTH_VALUE VM guard** (LOW): Added the same `isinstance` defense-in-depth guard to `NTH_VALUE` that was present in `LAG`, `LEAD`, and `NTILE`

## Tests added
- `sql-vm/tests/test_tier4_window_extended.py` — 29 tests (26 functional + 3 VM-guard error paths)
- `sql-codegen/tests/test_window.py` — 23 tests (18 original + 5 security error paths)
- `mini-sqlite/tests/test_tier3_window_extended.py` — 27 end-to-end SQL tests

## Coverage
| Package | Coverage |
|---------|----------|
| sql-vm | 82.4% ✅ |
| sql-codegen | 83.2% ✅ |
| mini-sqlite | 91.5% ✅ |
| sql-planner | (unchanged) |

## Test plan
- [ ] `pytest code/packages/python/sql-vm/tests/ -v` — 462 passed
- [ ] `pytest code/packages/python/sql-codegen/tests/ -v` — 80 passed
- [ ] `pytest code/packages/python/mini-sqlite/tests/ -v` — 711 passed
- [ ] All packages pass `ruff check` with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)