### PR TITLE
feat(tw04-4f): BEAM multi-module lowering — each module → one .beam file

### DIFF
--- a/code/packages/python/ir-to-beam/CHANGELOG.md
+++ b/code/packages/python/ir-to-beam/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog — ir-to-beam
 
+## 0.5.0 — 2026-05-04 — TW04 Phase 4f (multi-module BEAM lowering)
+
+Extends the BEAM backend to support cross-module calls and correct
+GC-safe y-register initialisation.
+
+### Added — multi-module support (`BEAMBackendConfig` extensions)
+
+Three new fields on `BEAMBackendConfig`:
+
+| Field | Purpose |
+|---|---|
+| `extra_callable_labels: tuple[str, ...]` | Force-include exported functions as callable regions even when no local `CALL` targets them (dep-module exports called only from other modules). |
+| `call_register_count: int \| None` | API symmetry with CLR/JVM backends; ignored for BEAM (functions have per-declaration arities, not a fixed-width frame). |
+| `external_function_arities: dict[str, int]` | Maps cross-module call labels (e.g. `"a/math/add"`) to the actual remote arity (e.g. `2`). Required because BEAM's `call_ext N Mfa` encodes the arity in the MFA triple; a mismatch causes a loader or runtime crash. |
+
+### Added — cross-module CALL lowering (`_emit_call`)
+
+`IrOp.CALL IrLabel("a/math/add")` labels containing `/` are now
+lowered to `call_ext N import_idx` where `N` is the exact remote
+arity from `external_function_arities` and `import_idx` is the 0-based
+index into the module's `ImpT` table for the remote MFA
+`{a_math, add, N}`.
+
+`_discover_callable_names` now skips cross-module labels (they have
+no local `LABEL` instruction) and accepts `extra_callable_labels` to
+force-include dep-module exports.
+
+### Fixed — GC-safe y-register initialisation
+
+BEAM's garbage collector traces ALL allocated y-register slots as
+potential heap pointers.  Our compiler allocates a single flat frame
+of `max_reg_index + 1` y-slots per function but only writes a fraction
+of them (param slots and holding registers) before body code runs.
+Unwritten slots contain stack-word garbage; if any garbage value
+resembles a valid BEAM tagged heap pointer the GC follows it and
+corrupts the heap, causing non-deterministic SIGSEGV at recursion
+depth ≥ 4 when the first GC cycle fires inside a nested call stack.
+
+The fix: emit `move {atom,0}, y(i)` for every y-register slot
+immediately after `allocate`, before copying args and executing body
+code.  Atom 0 is nil (`[]`), a tagged immediate that is NOT a heap
+pointer — the GC can safely trace it.
+
+`erlc` (OTP 24+) uses `init_yregs` (opcode 172, Z-tagged list
+operand) for selective initialisation; we use the simpler `move`
+opcode which is available in all supported OTP versions and already
+handled by our encoder.
+
+Note: the abstract `allocate_zero` opcode (14 in `.S` format, 14 in
+`beam_opcodes:opname/1`) is NOT a valid binary BEAM opcode — the
+loader rejects it.  The old `init y_reg` opcode (17) with a Y-register
+operand is also rejected by the OTP 28 loader ("please re-compile with
+OTP 28 compiler").  Both were tested and discarded in favour of the
+`move` approach.
+
+### Added — new BEAM opcode constants
+
+`_OP_ALLOCATE_ZERO` (kept as documentation), `_OP_INIT` (17, kept as
+documentation), and the `BEAMTag` import already present in the
+encoder.
+
 ## 0.4.0 — 2026-04-30 — TW03 Phase 3d (BEAM heap primitives)
 
 Implements the BEAM-side lowering for the eight TW03 Phase 3a heap

--- a/code/packages/python/ir-to-beam/src/ir_to_beam/backend.py
+++ b/code/packages/python/ir-to-beam/src/ir_to_beam/backend.py
@@ -141,6 +141,42 @@ _OP_INT_CODE_END: Final[int] = 3
 _OP_CALL: Final[int] = 4
 _OP_CALL_EXT: Final[int] = 7         # call_ext arity import_idx  (preserves frame)
 _OP_ALLOCATE: Final[int] = 12
+# ``allocate_zero`` (opcode 13) is identical to ``allocate`` but
+# initialises every allocated y-register slot to nil (the atom []).
+# This is REQUIRED whenever the function body might trigger a GC
+# cycle before every y-register slot has been written with a valid
+# BEAM term.  BEAM's GC traces ALL allocated y-registers as potential
+# heap pointers — uninitialized slots that happen to contain
+# stack-word garbage can look like valid tagged pointers, causing the
+# GC to follow them and corrupt the heap (intermittent SIGSEGV).
+#
+# In our register layout the function body allocates a SINGLE flat
+# frame of size (max_reg_index + 1) y-slots and only populates a
+# fraction of them (y1 for halt-result, y2..y{arity+1} for params,
+# y10.. for holding registers).  The remaining slots (y0, y3..y9,
+# and any gap between params and holdings) are never explicitly
+# written before a potential GC trigger (e.g. inside a ``gc_bif``).
+# Using ``allocate_zero`` guarantees those slots are nil, which is
+# a valid BEAM term the GC can safely trace (it terminates as a
+# zero-length list).
+#
+# Without this fix, recursive functions inside dep modules called
+# via ``call_ext`` crash non-deterministically at depth ≥ 4 because
+# the unwritten y-slots in the CALLEE's frames contain garbage that
+# the GC mistakes for valid heap references.
+_OP_ALLOCATE_ZERO: Final[int] = 14   # allocate_zero Ystacksize LiveRegs
+# NOTE: opcode 14 (allocate_zero) is an *abstract* opcode number used in
+# the .S assembly format but it is NOT a valid binary BEAM opcode — the
+# actual binary loader rejects it.  Use ``_OP_INIT`` (opcode 17) to
+# initialise individual y-registers to nil instead.
+#
+# ``init y(i)`` — set y-register i to nil (the atom []).  Must be emitted
+# after ``allocate`` and before any GC-triggering instruction (gc_bif,
+# call, call_ext) to prevent the GC from tracing uninitialized y-slots as
+# potential heap pointers.  ``erlc`` uses ``init_yregs`` (a Z-tagged
+# compound instruction) for the same purpose; we fall back to the simpler
+# ``init`` opcode which initialises one slot at a time.
+_OP_INIT: Final[int] = 17            # init y_reg  (set to nil)
 _OP_TEST_HEAP: Final[int] = 16       # test_heap heap_need live  (heap reservation)
 _OP_DEALLOCATE: Final[int] = 18
 _OP_RETURN: Final[int] = 19
@@ -224,6 +260,36 @@ class BEAMBackendConfig:
     arity_overrides: dict[str, int] = field(default_factory=dict)
     y_register_count: int | None = None
     closure_free_var_counts: dict[str, int] = field(default_factory=dict)
+
+    # TW04 Phase 4f — multi-module support
+    # -------------------------------------
+    #
+    # ``extra_callable_labels`` force-includes exported function names as
+    # callable regions even when no local ``IrOp.CALL`` targets them.  This
+    # is needed for dep modules whose exported functions are only called from
+    # OTHER modules — the local module has no CALL to trigger discovery.
+    # Absent from the single-module API (where all callables are reachable
+    # locally via CALL).
+    extra_callable_labels: tuple[str, ...] = ()
+
+    # ``call_register_count`` is NOT used by the BEAM backend for remote calls
+    # (BEAM functions have individually declared arities, unlike CLR/JVM).
+    # This field is kept for API symmetry with the CLR backend but is ignored
+    # during cross-module lowering.  Local calls always use the locally
+    # declared arity from ``arity_overrides``.
+    call_register_count: int | None = None
+
+    # ``external_function_arities`` maps cross-module call labels to their
+    # actual remote function arity.  This is required for BEAM because
+    # ``call_ext N Mfa`` specifies the EXACT arity N that the remote function
+    # is exported with — unlike CLR where a fixed-width parameter frame is
+    # used for all calls.
+    #
+    # Example: ``"a/math/add"`` → 2 means emit ``call_ext 2 {a_math,add,2}``.
+    # If a label is absent (unlikely after compile_modules populates this),
+    # we fall back to 0 (which will cause a runtime badarg but at least won't
+    # corrupt the BEAM loader).
+    external_function_arities: dict[str, int] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -315,9 +381,13 @@ class _Builder:
 # ---------------------------------------------------------------------------
 
 
-def _discover_callable_names(program: IrProgram) -> set[str]:
+def _discover_callable_names(
+    program: IrProgram,
+    *,
+    extra_callable_labels: tuple[str, ...] = (),
+) -> set[str]:
     """All region names that are CALL or MAKE_CLOSURE targets,
-    plus the entry label.
+    plus the entry label and any ``extra_callable_labels``.
 
     Internal labels (``_else_0``, ``_endif_0``, etc.) are NOT
     callable — they're targets of branches/jumps within a single
@@ -329,18 +399,34 @@ def _discover_callable_names(program: IrProgram) -> set[str]:
     callable so it gets a func_info + label-target pair like
     regular functions, even though it's invoked indirectly via
     ``call_fun`` rather than ``call``.
+
+    TW04 Phase 4f — cross-module CALL targets
+    -----------------------------------------
+    Labels containing ``/`` (e.g. ``"a/math/add"``) are cross-module
+    call sites; they do NOT correspond to a local callable region in
+    this module.  We skip them here so the region-splitter doesn't
+    try to find a ``LABEL a/math/add`` instruction that doesn't exist.
+
+    ``extra_callable_labels`` (from ``BEAMBackendConfig``) force-adds
+    exported function names that are only called cross-module — they
+    have no local ``CALL`` site in the dep module's own IR.
     """
     callable_names: set[str] = {program.entry_label}
     for instr in program.instructions:
         if instr.opcode is IrOp.CALL:
             target = _operand_label(instr.operands[0], role="CALL target")
-            callable_names.add(target)
+            # Skip cross-module labels — they live in a remote module,
+            # not as a LABEL instruction in this program's IR.
+            if "/" not in target:
+                callable_names.add(target)
         elif instr.opcode is IrOp.MAKE_CLOSURE:
             # MAKE_CLOSURE dst, fn_label, num_captured, capt0, ...
             target = _operand_label(
                 instr.operands[1], role="MAKE_CLOSURE fn_label"
             )
             callable_names.add(target)
+    # Force-include exported functions only called cross-module.
+    callable_names.update(extra_callable_labels)
     return callable_names
 
 
@@ -665,6 +751,9 @@ def _emit_call(
     instr: IrInstruction,
     label_for: dict[str, int],
     arity_for: dict[str, int],
+    *,
+    call_arity: int,
+    remote_calls: dict[str, int],
 ) -> None:
     """Lower CALL with the Twig calling convention.
 
@@ -673,8 +762,66 @@ def _emit_call(
     ``move {y, 2+i}, {x, i}`` per arg before the ``call``, then
     one ``move {x, 0}, {y, 1}`` after to copy the return value
     back into the IR's ``_REG_HALT_RESULT`` slot.
+
+    TW04 Phase 4f — cross-module remote calls
+    -----------------------------------------
+    Labels containing ``/`` (e.g. ``"a/math/add"``) are cross-module
+    call sites.  They are lowered to ``call_ext N import_idx`` where
+    ``import_idx`` is the 0-based index into the ImpT table for the
+    remote MFA ``{a_math, add, N}``.
+
+    Unlike CLR/JVM which use a fixed-width parameter frame across all
+    calls, BEAM functions have individually declared arities.  The
+    ``call_ext N Mfa`` instruction encodes the arity N in BOTH the
+    instruction operand AND the MFA triple — they must match the remote
+    function's declaration exactly.
+
+    ``remote_calls`` maps a cross-module label (e.g. ``"a/math/add"``)
+    to its actual remote function arity (e.g. ``2``).  This dict comes
+    from ``BEAMBackendConfig.external_function_arities`` and is
+    populated by ``twig-beam-compiler``'s ``compile_modules``.
+    ``call_arity`` is only used as a fallback for labels absent from the
+    dict (which should not happen in a well-formed multi-module build).
     """
     target = _operand_label(instr.operands[0], role="CALL target")
+
+    # ── Cross-module remote call ──────────────────────────────────────
+    if "/" in target:
+        # Parse "a/math/add" → last segment is the function name;
+        # everything before the last "/" with "/" replaced by "_" is the
+        # Erlang module atom.  e.g. "a/math/add" → module="a_math", fn="add".
+        # "stdlib/io/write" → module="stdlib_io", fn="write".
+        last_slash = target.rfind("/")
+        beam_module_atom = target[:last_slash].replace("/", "_")
+        fn_atom = target[last_slash + 1 :]
+
+        # Look up the ACTUAL arity of the remote function.  This is critical:
+        # unlike CLR/JVM which use a fixed-width parameter frame, BEAM's
+        # ``call_ext N Mfa`` encodes the arity N in the MFA triple AND in the
+        # instruction prefix.  The arity must match the remote function's
+        # declaration exactly or BEAM will reject it at load-time / runtime.
+        #
+        # ``remote_calls`` is not used here; ``external_function_arities``
+        # on the config object is the authoritative source.  The caller
+        # (``lower_ir_to_beam``) passes it through via the closure over the
+        # ``config`` object captured in this function's kwargs.
+        remote_arity = remote_calls.get(target, call_arity)
+
+        # Stage ``remote_arity`` arguments: y{2+i} → x{i}.
+        for i in range(remote_arity):
+            builder.emit(_OP_MOVE, _y(_REG_PARAM_BASE + i), _x(i))
+
+        # Add the remote MFA to the import table and emit call_ext.
+        mod_atom_idx = builder.atoms.add(beam_module_atom)
+        fn_atom_idx = builder.atoms.add(fn_atom)
+        import_idx = builder.imports.add(mod_atom_idx, fn_atom_idx, remote_arity)
+        builder.emit(_OP_CALL_EXT, _u(remote_arity), _u(import_idx - 1))
+
+        # Result in x0 → IR HALT-result register y1.
+        builder.emit(_OP_MOVE, _x(0), _y(_REG_HALT_RESULT))
+        return
+
+    # ── Local call ───────────────────────────────────────────────────
     if target not in label_for:
         msg = (
             f"CALL target {target!r} has no corresponding LABEL — "
@@ -1141,7 +1288,9 @@ def lower_ir_to_beam(
     module_atom_idx = 1  # by construction, atoms[0] == config.module_name
     module_info_atom_idx = builder.atoms.add("module_info")
 
-    callable_names = _discover_callable_names(program)
+    callable_names = _discover_callable_names(
+        program, extra_callable_labels=config.extra_callable_labels
+    )
     regions = _split_callable_regions(program, callable_names)
     if not regions:
         raise BEAMBackendError(
@@ -1152,11 +1301,32 @@ def lower_ir_to_beam(
     # Simplest: one program-wide value (the highest IR register
     # index used anywhere + 1).  Wasteful for small functions but
     # correct.
+    local_max_reg = _max_register_index(program)
     y_reg_count = (
         config.y_register_count
         if config.y_register_count is not None
-        else _max_register_index(program) + 1
+        else local_max_reg + 1
     )
+
+    # TW04 Phase 4f: ``call_arity`` is the number of x-register slots
+    # staged at every local CALL site.  For a single-module build this
+    # equals the callee's declared arity (looked up per call site).
+    # For a multi-module build ``config.call_register_count`` supplies
+    # the global maximum so every cross-module callee's parameter window
+    # is wide enough.  When the config value is set we also use it as the
+    # floor for local calls (harmless — extra args are simply ignored).
+    #
+    # We derive the local floor from (max_reg_index - _REG_PARAM_BASE + 1)
+    # clipped to ≥ 0, then take max with config.call_register_count.
+    local_call_arity_floor = max(0, local_max_reg - _REG_PARAM_BASE + 1)
+    call_arity_override = config.call_register_count
+    # ``remote_calls`` maps cross-module label strings to their actual
+    # remote function arities.  Populated from
+    # ``BEAMBackendConfig.external_function_arities``.  Each entry
+    # ``"a/math/add" → 2`` tells ``_emit_call`` to emit
+    # ``call_ext 2 {a_math, add, 2}`` — the arity must match the
+    # remote function's declaration exactly.
+    remote_calls: dict[str, int] = dict(config.external_function_arities)
 
     # Pre-pass 2: allocate a BEAM label number for every IR label.
     # Callable regions get TWO each (one for the func_info opcode,
@@ -1213,6 +1383,15 @@ def lower_ir_to_beam(
         pp_import_idx = 0
         apply_import_idx = 0
 
+    # Compute the call_arity used for cross-module remote calls.
+    # This is the global maximum register count so remote callees
+    # always see a wide-enough parameter window.  For single-module
+    # programs this is just local_call_arity_floor.
+    effective_call_arity = max(
+        local_call_arity_floor,
+        call_arity_override if call_arity_override is not None else 0,
+    )
+
     # Pass 4: emit each region's prologue + body + epilogue.
     for name, body in regions:
         function_atom_idx = builder.atoms.add(name)
@@ -1227,7 +1406,35 @@ def lower_ir_to_beam(
 
         # Function entry: allocate y-register frame + copy args
         # from x-registers into the Twig param slots.
+        #
+        # After allocate, we emit ``move {atom,0}, y(i)`` for EVERY
+        # y-register slot to initialise it to nil (the empty list ``[]``,
+        # a safe BEAM tagged-immediate that is NOT a heap pointer).
+        #
+        # WHY: BEAM's GC traces ALL allocated y-register slots as potential
+        # heap pointers.  Uninitialized slots contain stack-word garbage
+        # that can look like valid tagged heap pointers, causing the GC to
+        # follow them and corrupt the heap.  The result is non-deterministic
+        # SIGSEGV when recursive functions inside dep modules are called via
+        # ``call_ext`` at recursion depth ≥ 4 (when the first GC cycle fires
+        # inside the nested call stack).
+        #
+        # ``erlc`` (OTP 24+) uses ``init_yregs`` (opcode 172, Z-tagged list
+        # operand) for selective nil-initialisation; we instead move the nil
+        # atom (atom index 0 = ``[]``) into every slot.  This is one
+        # ``move`` instruction per slot, harmlessly overwritten by the
+        # arg-copy loop that immediately follows.  ``move {atom,0}, y_i``
+        # is the same operation that ``LOAD_NIL`` lowers to in body code,
+        # so the encoder already handles it correctly.
+        #
+        # Note: in OTP 28 the old ``init y_reg`` opcode (17) with a Y-register
+        # operand is rejected by the loader ("please re-compile with OTP 28
+        # compiler") — hence we use ``move`` rather than ``init``.
         builder.emit(_OP_ALLOCATE, _u(y_reg_count), _u(arity_for[name]))
+        # Initialise ALL y-slots to nil so GC never traces an uninitialised
+        # slot.  Atom index 0 is the nil atom (``[]``) by BEAM convention.
+        for _yi in range(y_reg_count):
+            builder.emit(_OP_MOVE, BEAMOperand(BEAMTag.A, 0), _y(_yi))
         arity = arity_for[name]
         for i in range(arity):
             builder.emit(_OP_MOVE, _x(i), _y(_REG_PARAM_BASE + i))
@@ -1248,6 +1455,8 @@ def lower_ir_to_beam(
                 pp_import_idx=pp_import_idx,
                 apply_import_idx=apply_import_idx,
                 y_reg_count=y_reg_count,
+                call_arity=effective_call_arity,
+                remote_calls=remote_calls,
             )
 
         # Lifted lambdas MUST be exported because ``apply/3``
@@ -1323,6 +1532,8 @@ def _emit_body_instruction(
     pp_import_idx: int,
     apply_import_idx: int,
     y_reg_count: int,
+    call_arity: int,
+    remote_calls: dict[str, int],
 ) -> None:
     op = instr.opcode
     if op not in _HANDLERS:
@@ -1354,7 +1565,14 @@ def _emit_body_instruction(
         _emit_cmp(builder, instr)
         return
     if op is IrOp.CALL:
-        _emit_call(builder, instr, label_for, arity_for)
+        _emit_call(
+            builder,
+            instr,
+            label_for,
+            arity_for,
+            call_arity=call_arity,
+            remote_calls=remote_calls,
+        )
         return
     if op is IrOp.RET:
         _emit_return(builder, instr, y_reg_count=y_reg_count)

--- a/code/packages/python/twig-beam-compiler/CHANGELOG.md
+++ b/code/packages/python/twig-beam-compiler/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog — twig-beam-compiler
 
+## 0.5.0 — 2026-05-04 — TW04 Phase 4f (multi-module BEAM compilation)
+
+Implements multi-module BEAM lowering: each Twig module compiles to one
+`.beam` file; all `.beam` files are loaded in the same `erl` session so
+cross-module calls resolve at runtime.
+
+### New result types
+
+| Type | Description |
+|---|---|
+| `ModuleBeamCompileResult` | Per-module artefact: Twig name, Erlang atom, IR, `.beam` bytes, exports tuple. |
+| `MultiModuleBeamResult` | Aggregate: entry module, all `ModuleBeamCompileResult`s, entry beam module name. |
+| `MultiModuleBeamExecutionResult` | Compile result + `erl` subprocess stdout/stderr/returncode. |
+
+All three are frozen dataclasses.
+
+### New public API
+
+| Symbol | Description |
+|---|---|
+| `module_name_to_beam_module(name)` | Map `"a/math"` → `"a_math"` (replace `/` with `_`). |
+| `compile_modules(modules, entry_module, *, optimize=True)` | Compile a topologically ordered list of `ResolvedModule`s to BEAM. Skips the synthetic `host` module. Returns `MultiModuleBeamResult`. |
+| `run_modules(modules, entry_module, *, optimize=True, tmp_dir=None, timeout_seconds=30)` | Compile all modules, write `.beam` files to a temp dir, and invoke `erl -noshell -pa <dir> -eval '<loads> Result = <entry>:main(), erlang:halt(Result).'`. Returns `MultiModuleBeamExecutionResult`. |
+
+### Cross-module call semantics
+
+Unlike CLR/JVM (which use a fixed-width parameter frame for all calls),
+BEAM's `call_ext N Mfa` instruction encodes the remote function's EXACT
+arity in both the instruction prefix and the MFA triple.  The arity is
+tracked at two levels:
+
+1. `_Compiler._cross_module_arities` — records the call-site arity at
+   each cross-module `IrOp.CALL` (the caller knows how many args it passes).
+2. `compile_modules` seeds `all_external_arities` from dep module exports
+   by re-running `_Compiler` on each compiled dep module and reading
+   `_fn_params`; this gives the exact declared arity for each exported function.
+
+Both sources are merged into `BEAMBackendConfig.external_function_arities`
+before passing to `lower_ir_to_beam`.
+
+### `run_modules` — explicit module pre-loading
+
+`erl -pa <dir>` adds `.beam` files to the code path but does NOT
+guarantee auto-loading in `-noshell` mode before the first cross-module
+`call_ext` fires.  Without explicit pre-loading the VM crashes with
+`{undef, [{a_math, add, 2, []}]}` or SIGSEGV.  The `-eval` expression
+now emits one `{module,_} = code:load_file(<atom>)` call per compiled
+module (in compilation order, deps first) before invoking `main()`.
+
+### Fixed — GC-safe y-register initialisation (via `ir-to-beam` 0.5.0)
+
+Recursive dep-module functions called via `call_ext` crashed
+non-deterministically at recursion depth ≥ 4 because unwritten y-register
+slots in function frames contained stack-word garbage that the BEAM GC
+mistook for valid heap pointers.  The fix (`move {atom,0}, y(i)` for all
+slots after `allocate`) is in `ir-to-beam` 0.5.0.
+
+### Test additions (38 tests in `test_multi_module_beam.py`)
+
+- **`TestModuleNameToBeamModule`** — 7 unit tests for the name mapping.
+- **`TestCompileModulesStructure`** — 25 structural tests (no `erl` required):
+  result types, BEAM magic bytes, atom names, IR cross-module call presence,
+  export tuples, immutability, host-module exclusion, invalid entry raises.
+- **`TestRunModulesOnRealBeam`** — 6 runtime tests (gated with `@requires_beam`):
+  two-module `add` → 42, three-module chained calls → 15, `sub` → 7,
+  recursive `fact(5)` → 120, multiple calls same dep → 18, result type check.
+
 ## 0.4.0 — 2026-04-30 — TW03 Phase 3e (heap primitives from Twig source)
 
 Twig source containing `cons` / `car` / `cdr` / `null?` / `pair?` /

--- a/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/__init__.py
+++ b/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/__init__.py
@@ -1,6 +1,12 @@
 """``twig-beam-compiler`` — Twig source → ``.beam`` (real erl).
 
 See ``code/specs/BEAM01-twig-on-real-erl.md`` Phase 4.
+
+TW04 Phase 4f adds multi-module support: ``compile_modules`` lowers a
+topologically ordered list of ``ResolvedModule`` objects (from
+``twig.resolve_modules``) to individual ``.beam`` files; ``run_modules``
+writes them to a temp directory and invokes ``erl`` to execute the entry
+module's ``main()`` function.
 """
 
 from __future__ import annotations
@@ -9,9 +15,15 @@ from twig_beam_compiler.compiler import (
     BeamPackageError,
     BeamPackageResult,
     BeamRunResult,
+    ModuleBeamCompileResult,
+    MultiModuleBeamExecutionResult,
+    MultiModuleBeamResult,
+    compile_modules,
     compile_source,
     compile_to_ir,
     erl_available,
+    module_name_to_beam_module,
+    run_modules,
     run_source,
 )
 
@@ -19,8 +31,14 @@ __all__ = [
     "BeamPackageError",
     "BeamPackageResult",
     "BeamRunResult",
+    "ModuleBeamCompileResult",
+    "MultiModuleBeamExecutionResult",
+    "MultiModuleBeamResult",
+    "compile_modules",
     "compile_source",
     "compile_to_ir",
     "erl_available",
+    "module_name_to_beam_module",
+    "run_modules",
     "run_source",
 ]

--- a/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/compiler.py
+++ b/code/packages/python/twig-beam-compiler/src/twig_beam_compiler/compiler.py
@@ -95,6 +95,7 @@ from twig.ast_nodes import (
     VarRef,
 )
 from twig.free_vars import free_vars
+from twig.module_resolver import HOST_MODULE_NAME, ResolvedModule
 
 # ---------------------------------------------------------------------------
 # Result types
@@ -137,6 +138,92 @@ class BeamPackageError(TwigError):
         self.stage = stage
         self.message = message
         self.cause = cause
+
+
+# ---------------------------------------------------------------------------
+# TW04 Phase 4f — multi-module result types
+# ---------------------------------------------------------------------------
+#
+# Each Twig module compiles to one ``.beam`` file.  At runtime all files are
+# loaded into the same ``erl`` session — BEAM modules talk to each other via
+# plain remote-call MFAs (``a_math:add/2`` etc.) without any shared memory
+# trick.  The execution model is simpler than JVM (no shared TwigRuntime
+# register file) because BEAM already has per-process heaps and y-register
+# stacks that survive across calls.
+
+
+@dataclass(frozen=True)
+class ModuleBeamCompileResult:
+    """Compilation artefact for one module in a multi-module BEAM build.
+
+    Attributes
+    ----------
+    module_name:
+        The Twig module name (e.g. ``"a/math"``).
+    beam_module:
+        The Erlang module atom name (e.g. ``"a_math"``).  This is what
+        the ``.beam`` file declares as ``-module(a_math)`` and what the
+        caller uses in remote-call MFAs.
+    ir:
+        The optimised ``IrProgram`` that was lowered to ``beam_bytes``.
+    beam_bytes:
+        The raw ``.beam`` file bytes for this module.  Write these to
+        ``<beam_module>.beam`` and load with ``erl -pa <dir>``.
+    exports:
+        The Twig-level function names exported by this module's
+        ``(module ... (export ...))`` declaration.  Used by callers to
+        validate cross-module call sites and by the BEAM backend to
+        force-include those functions as callable regions.
+    """
+
+    module_name: str
+    beam_module: str
+    ir: IrProgram
+    beam_bytes: bytes
+    exports: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MultiModuleBeamResult:
+    """Aggregate result of compiling a set of Twig modules to BEAM.
+
+    Attributes
+    ----------
+    entry_module:
+        The Twig entry module name (e.g. ``"user/hello"``).
+    module_results:
+        One ``ModuleBeamCompileResult`` per compiled module, in the order
+        they were lowered.  Excludes the synthetic ``host`` module.
+    entry_beam_module:
+        The Erlang module atom for the entry module — used as the target
+        of the ``erl -eval '<entry>:main()'`` invocation.
+    """
+
+    entry_module: str
+    module_results: tuple[ModuleBeamCompileResult, ...]
+    entry_beam_module: str
+
+
+@dataclass(frozen=True)
+class MultiModuleBeamExecutionResult:
+    """Compile + real-``erl`` execution result for a multi-module program.
+
+    Attributes
+    ----------
+    compilation:
+        The full compilation result (all modules, all IR).
+    stdout:
+        Raw bytes written to stdout by the ``erl`` process.
+    stderr:
+        Raw bytes written to stderr by the ``erl`` process.
+    returncode:
+        The ``erl`` process exit code.
+    """
+
+    compilation: MultiModuleBeamResult
+    stdout: bytes
+    stderr: bytes
+    returncode: int
 
 
 # ---------------------------------------------------------------------------
@@ -245,6 +332,12 @@ class _Compiler:
         # emitted at the use site.
         self._lifted_lambdas: list[tuple[str, list[str], Lambda]] = []
         self._lambda_counter = 0
+        # TW04 Phase 4f: cross-module call arities.  Each time we emit a
+        # cross-module IrOp.CALL we record the actual call-site arity here.
+        # Unlike CLR/JVM, BEAM ``call_ext`` requires the EXACT arity of the
+        # remote function — so we track it at the call site where the caller
+        # knows how many arguments they are passing.
+        self._cross_module_arities: dict[str, int] = {}
 
     # ------------------------------------------------------------------
 
@@ -465,6 +558,36 @@ class _Compiler:
         # ``APPLY_CLOSURE`` and dispatches via ``erlang:apply/3``.
         if isinstance(expr.fn, VarRef):
             name = expr.fn.name
+
+            # TW04 Phase 4f: module-qualified cross-module call.
+            # Any name with an interior ``/`` (not at position 0 or
+            # the last character) is a cross-module reference, e.g.
+            # ``"a/math/add"`` or ``"stdlib/io/write"``.
+            # We emit each argument into a holding register, move them
+            # to the Twig param-slot registers (r2..rN), then emit
+            # ``IrOp.CALL IrLabel("a/math/add")``.  The BEAM backend
+            # detects the ``/`` in the label name and lowers this to a
+            # ``call_ext N a_math:add/N`` remote call.
+            #
+            # Note: ``host/*`` calls (``host/write-byte`` etc.) are not
+            # handled by the BEAM backend the same way as JVM/CLR — the
+            # BEAM frontend does not support host syscalls (they require
+            # a separate runtime not present in the BEAM version).
+            _slash = name.find("/")
+            if _slash > 0 and _slash < len(name) - 1:
+                # Cross-module call — emit args into param slots then CALL.
+                arg_regs_xm = [self._compile_expr(a, ctx) for a in expr.args]
+                for i, src in enumerate(arg_regs_xm):
+                    self._emit_move(IrRegister(_REG_PARAM_BASE + i), src)
+                self._emit(IrOp.CALL, IrLabel(name))
+                # Record the call-site arity for the BEAM backend.  Unlike
+                # CLR/JVM, BEAM call_ext must embed the EXACT remote arity
+                # in the MFA triple so the loader can find the function.
+                self._cross_module_arities[name] = len(expr.args)
+                dest = self._fresh_holding(ctx)
+                self._emit_move(dest, IrRegister(_REG_HALT_RESULT))
+                return dest
+
             if name in _V1_REJECTED_BUILTINS:
                 raise TwigCompileError(
                     f"builtin {name!r} is not yet supported by the BEAM "
@@ -792,6 +915,424 @@ def run_source(
             check=False,
         )
     return BeamRunResult(
+        compilation=compilation,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        returncode=proc.returncode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TW04 Phase 4f — multi-module public API
+# ---------------------------------------------------------------------------
+
+
+def module_name_to_beam_module(name: str) -> str:
+    """Map a Twig module name to its Erlang module atom name.
+
+    Erlang module names (atoms) may not contain ``/`` — it's not a
+    valid atom character without quoting, and BEAM module atoms map
+    directly to ``.beam`` filenames.  We replace every ``/`` with
+    ``_`` to produce a valid, lowercase Erlang atom.
+
+    The mapping is injective for all legal Twig module names:
+    distinct module names always yield distinct beam atoms.
+
+    Examples
+    --------
+    >>> module_name_to_beam_module("a/math")
+    'a_math'
+    >>> module_name_to_beam_module("user/hello")
+    'user_hello'
+    >>> module_name_to_beam_module("stdlib/io")
+    'stdlib_io'
+    >>> module_name_to_beam_module("mymodule")
+    'mymodule'
+    """
+    return name.replace("/", "_")
+
+
+def _compile_one_beam_module(
+    module: ResolvedModule,
+    *,
+    optimize: bool,
+    external_function_arities: dict[str, int],
+) -> tuple[ModuleBeamCompileResult, dict[str, int]]:
+    """Compile one ``ResolvedModule`` to a ``ModuleBeamCompileResult``.
+
+    This is the per-module lowering step for ``compile_modules``.  Each
+    module compiles independently.  Unlike CLR/JVM (which use a fixed-width
+    parameter frame for all calls), BEAM ``call_ext`` requires the exact
+    arity of the remote function — supplied via ``external_function_arities``.
+
+    Parameters
+    ----------
+    module:
+        The resolved Twig module to compile.
+    optimize:
+        Whether to run the IR optimizer before lowering.
+    external_function_arities:
+        Map of cross-module label → actual remote arity, e.g.
+        ``{"a/math/add": 2, "b/utils/double": 1}``.  Passed through to
+        ``BEAMBackendConfig`` so the backend emits the right MFA arity in
+        each ``call_ext`` instruction.
+
+    Returns
+    -------
+    tuple[ModuleBeamCompileResult, dict[str, int]]
+        The compiled artefact and this module's cross-module call arities
+        (from ``_Compiler._cross_module_arities``), so the caller can
+        accumulate them for the next module in the build.
+    """
+    beam_module = module_name_to_beam_module(module.name)
+
+    try:
+        compiler = _Compiler()
+        raw_ir = compiler.compile(module.program)
+    except TwigCompileError:
+        raise
+    except Exception as exc:  # pragma: no cover
+        raise BeamPackageError(
+            f"module:{module.name}:ir-emit", str(exc), exc
+        ) from exc
+
+    if optimize:
+        optimization = IrOptimizer.default_passes().optimize(raw_ir)
+        optimized_ir = optimization.program
+    else:
+        optimized_ir = raw_ir
+
+    # Gather closure data from the compiler (same as compile_source).
+    arity_overrides: dict[str, int] = {
+        name: len(params) for name, params in compiler._fn_params.items()  # noqa: SLF001
+    }
+    closure_free_var_counts: dict[str, int] = {}
+    for lifted_name, captures, lam in compiler._lifted_lambdas:  # noqa: SLF001
+        arity_overrides[lifted_name] = len(lam.params)
+        closure_free_var_counts[lifted_name] = len(captures)
+
+    # Exports declared in the (module ...) declaration.  These functions are
+    # only called from OTHER modules (no local CALL site), so they must be
+    # force-included as callable regions by the BEAM backend.
+    mod_decl = module.program.module
+    exports: tuple[str, ...] = tuple(mod_decl.exports) if mod_decl else ()
+
+    # Cross-module arities discovered in THIS module's source (from _Compiler).
+    # Add these to the external_function_arities dict for future callers.
+    this_module_xm_arities = dict(compiler._cross_module_arities)  # noqa: SLF001
+
+    try:
+        beam_module_obj = lower_ir_to_beam(
+            optimized_ir,
+            BEAMBackendConfig(
+                module_name=beam_module,
+                arity_overrides=arity_overrides,
+                closure_free_var_counts=closure_free_var_counts,
+                # Force-include exported functions so they become callable
+                # regions even when no local CALL targets them.
+                extra_callable_labels=exports,
+                # Cross-module call arities: maps "a/math/add" → 2 so the
+                # backend emits call_ext 2 {a_math,add,2} correctly.
+                external_function_arities=external_function_arities,
+            ),
+        )
+        beam_bytes = encode_beam(beam_module_obj)
+    except Exception as exc:
+        raise BeamPackageError(
+            f"module:{module.name}:lower-beam", str(exc), exc
+        ) from exc
+
+    result = ModuleBeamCompileResult(
+        module_name=module.name,
+        beam_module=beam_module,
+        ir=optimized_ir,
+        beam_bytes=beam_bytes,
+        exports=exports,
+    )
+    return result, this_module_xm_arities
+
+
+def _compute_global_call_register_count(
+    modules: list[ResolvedModule],
+    *,
+    optimize: bool,
+) -> int:
+    """Compute the global maximum ``call_register_count`` across all modules.
+
+    Each module's local maximum register index determines the number of
+    y-register slots its functions use.  The global maximum is the floor
+    for ALL module's call sites — including cross-module remote calls —
+    so that every callee's parameter window is wide enough.
+
+    This mirrors CLR's ``global_local_count`` computation.  The value is
+    ``max(max_reg_index + 1, _REG_PARAM_BASE)`` across all modules, with
+    a hard floor of ``_REG_PARAM_BASE`` (= 2) to guarantee at least the
+    return-value and one-parameter slots exist.
+
+    Parameters
+    ----------
+    modules:
+        All resolved modules (including ``host``, which is skipped).
+    optimize:
+        Whether the IR optimizer will run — must match the actual compile
+        so that register indices are consistent.
+
+    Returns
+    -------
+    int
+        The global call_register_count floor.
+    """
+    global_max = _REG_PARAM_BASE  # floor: at least 2 (halt-result + 1 param)
+
+    for module in modules:
+        if module.name == HOST_MODULE_NAME:
+            continue
+        try:
+            compiler = _Compiler()
+            raw_ir = compiler.compile(module.program)
+        except TwigCompileError:
+            raise
+        except Exception:  # pragma: no cover
+            continue
+
+        if optimize:
+            opt = IrOptimizer.default_passes().optimize(raw_ir)
+            ir = opt.program
+        else:
+            ir = raw_ir
+
+        for instr in ir.instructions:
+            for operand in instr.operands:
+                if isinstance(operand, IrRegister):
+                    # Only count param/holding registers; index 0 (scratch)
+                    # and 1 (halt-result) are always present.
+                    global_max = max(global_max, operand.index + 1)
+
+    return global_max
+
+
+def compile_modules(
+    modules: list[ResolvedModule],
+    entry_module: str,
+    *,
+    optimize: bool = True,
+) -> MultiModuleBeamResult:
+    """Compile a set of Twig modules to individual BEAM ``.beam`` files.
+
+    ``modules`` must be in topological order (deps before importers), as
+    returned by :func:`twig.resolve_modules`.  The synthetic ``host``
+    module is automatically skipped — the BEAM front-end does not support
+    host syscalls (write-byte / read-byte / exit); include only modules
+    with pure Twig logic.
+
+    Each non-``host`` module compiles to one ``.beam`` file.  All files
+    must be loaded into the same ``erl`` session for cross-module calls
+    to resolve.
+
+    Parameters
+    ----------
+    modules:
+        Topologically ordered list of resolved modules.
+    entry_module:
+        The Twig module name whose ``main`` function is the program's
+        entry point (invoked by ``erl -eval '<beam_module>:main()'``).
+    optimize:
+        Pass ``True`` (the default) to run the IR optimizer before
+        lowering each module.
+
+    Returns
+    -------
+    MultiModuleBeamResult
+        One ``ModuleBeamCompileResult`` per non-``host`` module.
+
+    Raises
+    ------
+    BeamPackageError
+        If any module fails to compile.
+    ValueError
+        If ``entry_module`` does not appear in ``modules``.
+    """
+    module_names = {m.name for m in modules}
+    if entry_module not in module_names:
+        raise ValueError(
+            f"entry_module {entry_module!r} not found in the provided "
+            f"module list.  Available: {sorted(module_names)}"
+        )
+
+    # Build the cross-module arities dict incrementally across modules.
+    # Unlike CLR/JVM (which use a fixed-width parameter frame), BEAM's
+    # ``call_ext`` requires the exact arity of the remote function.
+    #
+    # We compile modules in topological order (deps before importers).
+    # As each dep module compiles, it exposes its exported functions'
+    # arities.  These arities come from the dep module's ``arity_overrides``
+    # (which record each declared function's parameter count).  When the
+    # entry module compiles, it can look up "a/math/add" → 2 to emit the
+    # correct ``call_ext 2 {a_math, add, 2}`` instruction.
+    #
+    # We seed the dict with arities from dep module exports (computed below)
+    # and accumulate cross-module arities reported by each compiled module.
+    all_external_arities: dict[str, int] = {}
+
+    # Pre-pass: seed from dep module export arities.  Each dep module
+    # declares ``(define (add x y) ...)`` which the _Compiler records in
+    # ``_fn_params``.  We need those arities BEFORE compiling the entry
+    # module so the entry module's BEAMBackendConfig has them available.
+    #
+    # Strategy: compile each module in order.  When compiling a dep module,
+    # also record its exported function arities into all_external_arities
+    # so that subsequent (importer) modules see them.  Since topological
+    # order guarantees deps come before importers, this single pass suffices.
+
+    results: list[ModuleBeamCompileResult] = []
+    for module in modules:
+        if module.name == HOST_MODULE_NAME:
+            # The synthetic host module has no Twig source to lower to BEAM.
+            # Its exports (write-byte, etc.) are not supported by the BEAM
+            # front-end; skip silently.
+            continue
+        result, xm_arities = _compile_one_beam_module(
+            module,
+            optimize=optimize,
+            external_function_arities=all_external_arities,
+        )
+        results.append(result)
+        # Accumulate this module's cross-module call arities (for modules
+        # that import THIS module or call cross-module functions transitively).
+        all_external_arities.update(xm_arities)
+        # Also record the module's own exported function arities under the
+        # qualified key ``"<module_name>/<fn_name>"`` so that subsequent
+        # importer modules can find them.  The arity comes from the dep
+        # module's own IR labels which were compiled with the correct arity.
+        if result.exports:
+            # Re-derive arities from what we compiled.  The dep module's
+            # ``arity_overrides`` were passed to BEAM; we recover them here
+            # by re-scanning the IR for LABEL operands and counting param-slot
+            # moves in the function prologue.  Simpler: just re-compile
+            # a quick _Compiler pass to get fn_params.
+            try:
+                _scanner = _Compiler()
+                _scanner.compile(module.program)
+                for fn_name in result.exports:
+                    if fn_name in _scanner._fn_params:  # noqa: SLF001
+                        qualified = f"{module.name}/{fn_name}"
+                        all_external_arities[qualified] = len(
+                            _scanner._fn_params[fn_name]  # noqa: SLF001
+                        )
+            except TwigCompileError:
+                pass  # best-effort; compile step above will raise for real
+
+    return MultiModuleBeamResult(
+        entry_module=entry_module,
+        module_results=tuple(results),
+        entry_beam_module=module_name_to_beam_module(entry_module),
+    )
+
+
+def run_modules(
+    modules: list[ResolvedModule],
+    entry_module: str,
+    *,
+    optimize: bool = True,
+    tmp_dir: Path | None = None,
+    timeout_seconds: int = 30,
+) -> MultiModuleBeamExecutionResult:
+    """Compile a multi-module Twig program and execute it on real ``erl``.
+
+    Writes each module's ``.beam`` file to a temporary directory, then
+    invokes::
+
+        erl -noshell -pa <tmpdir> -eval '<entry_beam_module>:main()' \\
+            -eval 'erlang:halt()'
+
+    The entry module's ``main()`` function is expected to return an integer
+    which the ``erlang:halt()`` call uses as the process exit code.
+
+    Parameters
+    ----------
+    modules:
+        Topologically ordered list of resolved modules (from
+        :func:`twig.resolve_modules`).
+    entry_module:
+        The Twig module name whose ``main`` function is the entry point.
+    optimize:
+        Whether to run the IR optimizer before lowering.
+    tmp_dir:
+        Optional directory to write ``.beam`` files into.  If ``None``
+        a fresh ``tempfile.TemporaryDirectory`` is used and cleaned up
+        automatically.
+    timeout_seconds:
+        Maximum wall-clock time for the ``erl`` invocation.
+
+    Returns
+    -------
+    MultiModuleBeamExecutionResult
+        The compile result plus subprocess stdout/stderr/exit code.
+
+    Raises
+    ------
+    BeamPackageError
+        If any module fails to compile.
+    RuntimeError
+        If no ``erl`` binary is on PATH.
+    ValueError
+        If ``entry_module`` does not appear in ``modules``.
+    """
+    if not erl_available():
+        raise RuntimeError(
+            "No erl binary found on PATH.  "
+            "Install Erlang/OTP (e.g. `brew install erlang`) to run "
+            "multi-module Twig programs on BEAM."
+        )
+
+    compilation = compile_modules(modules, entry_module, optimize=optimize)
+    entry_beam = compilation.entry_beam_module
+
+    def _run_in(tmp: str) -> subprocess.CompletedProcess[bytes]:
+        """Write all .beam files and invoke erl."""
+        for mr in compilation.module_results:
+            beam_path = Path(tmp) / f"{mr.beam_module}.beam"
+            beam_path.write_bytes(mr.beam_bytes)
+        # Explicitly load EVERY compiled module before calling main().
+        #
+        # BEAM's ``-pa <dir>`` adds the directory to the code path, but
+        # lazy auto-loading on first remote-call is not reliable in
+        # ``-noshell`` mode when the target function is reached via a
+        # ``call_ext`` before any explicit ``code:load_file`` or
+        # ``code:ensure_loaded``.  In practice, calling the entry module
+        # before its deps are loaded causes a SIGSEGV (-11) or
+        # ``{undef,[{a_math,add,2,[]}]}`` crash.  The fix is simple:
+        # emit one ``{module,_} = code:load_file(<atom>)`` statement per
+        # module, in compilation order (deps first), before the
+        # ``main()`` call.  That guarantees all MFA imports are resolved
+        # at call_ext dispatch time.
+        #
+        # Note: ``code:load_file/1`` takes the module name as an atom
+        # (without quotes), which in Erlang's eval string means we write
+        # the bare atom name — exactly what ``mr.beam_module`` contains.
+        load_stmts = ", ".join(
+            f"{{module,_}} = code:load_file({mr.beam_module})"
+            for mr in compilation.module_results
+        )
+        eval_expr = (
+            f"{load_stmts},"
+            f" Result = {entry_beam}:main(),"
+            " erlang:halt(Result)."
+        )
+        return subprocess.run(
+            ["erl", "-noshell", "-pa", tmp, "-eval", eval_expr],
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+
+    if tmp_dir is not None:
+        proc = _run_in(str(tmp_dir))
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = _run_in(tmp)
+
+    return MultiModuleBeamExecutionResult(
         compilation=compilation,
         stdout=proc.stdout,
         stderr=proc.stderr,

--- a/code/packages/python/twig-beam-compiler/tests/test_multi_module_beam.py
+++ b/code/packages/python/twig-beam-compiler/tests/test_multi_module_beam.py
@@ -1,0 +1,495 @@
+"""Tests for TW04 Phase 4f — multi-module BEAM compilation.
+
+These tests verify that ``compile_modules`` and ``run_modules`` correctly:
+
+* Produce a ``MultiModuleBeamResult`` with one ``ModuleBeamCompileResult``
+  per non-``host`` Twig module.
+* Map module names to valid Erlang atom names (``"a/math"`` → ``"a_math"``).
+* Emit cross-module ``IrOp.CALL IrLabel("a/math/add")`` in the entry
+  module's IR so the BEAM backend lowers it to a remote ``call_ext``.
+* Actually run on the real ``erl`` runtime when available, yielding the
+  correct exit code (the Phase 4f acceptance criterion).
+
+Structural tests (the majority) require no BEAM runtime — they only inspect
+the compiled artefacts.  Runtime tests are gated behind ``@requires_beam``
+which skips them when ``erl`` is not on PATH.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from compiler_ir import IrLabel, IrOp
+from twig import resolve_modules
+
+from twig_beam_compiler import erl_available
+from twig_beam_compiler.compiler import (
+    ModuleBeamCompileResult,
+    MultiModuleBeamExecutionResult,
+    MultiModuleBeamResult,
+    compile_modules,
+    module_name_to_beam_module,
+    run_modules,
+)
+
+# ---------------------------------------------------------------------------
+# Skip marker for tests that require real erl
+# ---------------------------------------------------------------------------
+
+requires_beam = pytest.mark.skipif(
+    not erl_available(),
+    reason="erl not on PATH",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve(entry: str, search_dir: Path) -> list:
+    """Resolve entry module and its transitive imports from search_dir."""
+    return resolve_modules(entry, search_paths=[search_dir])
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def two_module_dir(tmp_path: Path) -> Path:
+    """Two-module acceptance-criterion program.
+
+    Files::
+
+        a/math.tw   — exports ``add`` and ``sub``
+        user/hello.tw — imports ``a/math``, evaluates ``(a/math/add 17 25)``
+
+    The result is 42, used as the ``erlang:halt(42)`` exit code.
+    """
+    (tmp_path / "a").mkdir()
+    (tmp_path / "user").mkdir()
+    (tmp_path / "a" / "math.tw").write_text(
+        "(module a/math (export add sub))\n"
+        "(define (add x y) (+ x y))\n"
+        "(define (sub x y) (- x y))\n"
+    )
+    (tmp_path / "user" / "hello.tw").write_text(
+        "(module user/hello (import a/math))\n"
+        "(a/math/add 17 25)\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def three_module_dir(tmp_path: Path) -> Path:
+    """Three-module program: ``a/math``, ``b/utils``, ``user/main``.
+
+    ``user/main`` calls both dep modules.  Final result = (5*2) + 5 = 15.
+    """
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "user").mkdir()
+    (tmp_path / "a" / "math.tw").write_text(
+        "(module a/math (export add))\n"
+        "(define (add x y) (+ x y))\n"
+    )
+    (tmp_path / "b" / "utils.tw").write_text(
+        "(module b/utils (export double))\n"
+        "(define (double x) (* x 2))\n"
+    )
+    (tmp_path / "user" / "main.tw").write_text(
+        "(module user/main (import a/math) (import b/utils))\n"
+        "(a/math/add (b/utils/double 5) 5)\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def single_dep_dir(tmp_path: Path) -> Path:
+    """Simple dep module with one function and an entry calling it."""
+    (tmp_path / "math").mkdir()
+    (tmp_path / "entry").mkdir()
+    (tmp_path / "math" / "ops.tw").write_text(
+        "(module math/ops (export square))\n"
+        "(define (square x) (* x x))\n"
+    )
+    (tmp_path / "entry" / "main.tw").write_text(
+        "(module entry/main (import math/ops))\n"
+        "(math/ops/square 7)\n"  # 49
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def recursive_dep_dir(tmp_path: Path) -> Path:
+    """Dep module with a recursive function (factorial), called by entry."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "user").mkdir()
+    (tmp_path / "a" / "math.tw").write_text(
+        "(module a/math (export fact))\n"
+        "(define (fact n) (if (= n 0) 1 (* n (fact (- n 1)))))\n"
+    )
+    (tmp_path / "user" / "main.tw").write_text(
+        "(module user/main (import a/math))\n"
+        "(a/math/fact 5)\n"  # 120
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def multi_call_dir(tmp_path: Path) -> Path:
+    """Entry module calls the dep module function multiple times."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "user").mkdir()
+    (tmp_path / "a" / "math.tw").write_text(
+        "(module a/math (export add))\n"
+        "(define (add x y) (+ x y))\n"
+    )
+    (tmp_path / "user" / "main.tw").write_text(
+        "(module user/main (import a/math))\n"
+        # (3+4) + (5+6) = 7 + 11 = 18
+        "(a/math/add (a/math/add 3 4) (a/math/add 5 6))\n"
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# module_name_to_beam_module
+# ---------------------------------------------------------------------------
+
+
+class TestModuleNameToBeamModule:
+    """``module_name_to_beam_module`` replaces ``/`` with ``_``."""
+
+    def test_single_slash(self) -> None:
+        assert module_name_to_beam_module("user/hello") == "user_hello"
+
+    def test_a_math(self) -> None:
+        assert module_name_to_beam_module("a/math") == "a_math"
+
+    def test_double_slash(self) -> None:
+        assert module_name_to_beam_module("a/b/c") == "a_b_c"
+
+    def test_no_slash(self) -> None:
+        assert module_name_to_beam_module("mymodule") == "mymodule"
+
+    def test_stdlib_io(self) -> None:
+        assert module_name_to_beam_module("stdlib/io") == "stdlib_io"
+
+    def test_user_main(self) -> None:
+        assert module_name_to_beam_module("user/main") == "user_main"
+
+    def test_b_utils(self) -> None:
+        assert module_name_to_beam_module("b/utils") == "b_utils"
+
+
+# ---------------------------------------------------------------------------
+# compile_modules — structural tests (no erl needed)
+# ---------------------------------------------------------------------------
+
+
+class TestCompileModulesStructure:
+    """``compile_modules`` returns a correctly structured result."""
+
+    def test_returns_multi_module_beam_result(
+        self, two_module_dir: Path
+    ) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        assert isinstance(result, MultiModuleBeamResult)
+
+    def test_two_module_results(self, two_module_dir: Path) -> None:
+        """Two real modules → two ``ModuleBeamCompileResult`` entries."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        # host is excluded; only a/math and user/hello
+        assert len(result.module_results) == 2
+
+    def test_entry_module_field(self, two_module_dir: Path) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        assert result.entry_module == "user/hello"
+
+    def test_entry_beam_module_field(self, two_module_dir: Path) -> None:
+        """``entry_beam_module`` is the Erlang atom for the entry module."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        assert result.entry_beam_module == "user_hello"
+
+    def test_host_module_excluded(self, two_module_dir: Path) -> None:
+        """The synthetic ``host`` module does not appear in module_results."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        names = [r.module_name for r in result.module_results]
+        assert "host" not in names
+
+    def test_module_results_are_frozen_dataclasses(
+        self, two_module_dir: Path
+    ) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        for mr in result.module_results:
+            assert isinstance(mr, ModuleBeamCompileResult)
+
+    def test_beam_bytes_are_nonempty(self, two_module_dir: Path) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        for mr in result.module_results:
+            assert len(mr.beam_bytes) > 0
+
+    def test_beam_files_start_with_for1_header(
+        self, two_module_dir: Path
+    ) -> None:
+        """BEAM files always start with the ``FOR1`` chunk header."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        for mr in result.module_results:
+            assert mr.beam_bytes[:4] == b"FOR1", (
+                f"Module {mr.module_name!r} .beam doesn't start with FOR1"
+            )
+
+    def test_module_names_present(self, two_module_dir: Path) -> None:
+        """Both ``a/math`` and ``user/hello`` appear in module_results."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        names = {r.module_name for r in result.module_results}
+        assert "a/math" in names
+        assert "user/hello" in names
+
+    def test_beam_module_atoms(self, two_module_dir: Path) -> None:
+        """``beam_module`` fields are correctly derived from module names."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        atoms = {r.beam_module for r in result.module_results}
+        assert "a_math" in atoms
+        assert "user_hello" in atoms
+
+    def test_dep_module_exports_in_result(
+        self, two_module_dir: Path
+    ) -> None:
+        """Dep module's ``exports`` tuple includes the declared exports."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        dep = next(r for r in result.module_results if r.module_name == "a/math")
+        assert "add" in dep.exports
+        assert "sub" in dep.exports
+
+    def test_cross_module_call_in_entry_ir(
+        self, two_module_dir: Path
+    ) -> None:
+        """Entry module IR contains ``IrOp.CALL IrLabel("a/math/add")``."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        entry_result = next(
+            r for r in result.module_results if r.module_name == "user/hello"
+        )
+        cross_calls = [
+            instr
+            for instr in entry_result.ir.instructions
+            if instr.opcode == IrOp.CALL
+            and isinstance(instr.operands[0], IrLabel)
+            and "/" in instr.operands[0].name
+        ]
+        assert len(cross_calls) >= 1
+        assert cross_calls[0].operands[0].name == "a/math/add"
+
+    def test_dep_module_ir_has_add_region(
+        self, two_module_dir: Path
+    ) -> None:
+        """Dep module IR contains LABEL instructions for ``add`` and ``sub``."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        dep = next(r for r in result.module_results if r.module_name == "a/math")
+        labels = [
+            instr.operands[0].name
+            for instr in dep.ir.instructions
+            if instr.opcode == IrOp.LABEL
+            and isinstance(instr.operands[0], IrLabel)
+        ]
+        assert "add" in labels
+        assert "sub" in labels
+
+    def test_three_module_results(self, three_module_dir: Path) -> None:
+        """Three-module compile yields three ModuleBeamCompileResult entries."""
+        modules = _resolve("user/main", three_module_dir)
+        result = compile_modules(modules, "user/main")
+        assert len(result.module_results) == 3
+
+    def test_invalid_entry_module_raises(self, two_module_dir: Path) -> None:
+        """Referencing a non-existent entry module raises ``ValueError``."""
+        modules = _resolve("user/hello", two_module_dir)
+        with pytest.raises(ValueError, match="entry_module"):
+            compile_modules(modules, "nonexistent/mod")
+
+    def test_beam_module_atom_for_three_modules(
+        self, three_module_dir: Path
+    ) -> None:
+        """All three modules have correct ``beam_module`` atom names."""
+        modules = _resolve("user/main", three_module_dir)
+        result = compile_modules(modules, "user/main")
+        atoms = {r.beam_module for r in result.module_results}
+        assert "a_math" in atoms
+        assert "b_utils" in atoms
+        assert "user_main" in atoms
+
+    def test_entry_beam_module_for_three_modules(
+        self, three_module_dir: Path
+    ) -> None:
+        modules = _resolve("user/main", three_module_dir)
+        result = compile_modules(modules, "user/main")
+        assert result.entry_beam_module == "user_main"
+
+    def test_dep_beam_bytes_contain_beam_magic(
+        self, single_dep_dir: Path
+    ) -> None:
+        """Each dep module's .beam file contains the BEAM chunk magic."""
+        modules = _resolve("entry/main", single_dep_dir)
+        result = compile_modules(modules, "entry/main")
+        dep = next(
+            r for r in result.module_results if r.module_name == "math/ops"
+        )
+        # BEAM chunk ID appears near the start of FOR1-wrapped BEAM files.
+        assert b"BEAM" in dep.beam_bytes[:20]
+
+    def test_multi_call_cross_module_ir(self, multi_call_dir: Path) -> None:
+        """Entry module with multiple cross-module calls has all in IR."""
+        modules = _resolve("user/main", multi_call_dir)
+        result = compile_modules(modules, "user/main")
+        entry = next(
+            r for r in result.module_results if r.module_name == "user/main"
+        )
+        cross_calls = [
+            instr
+            for instr in entry.ir.instructions
+            if instr.opcode == IrOp.CALL
+            and isinstance(instr.operands[0], IrLabel)
+            and "/" in instr.operands[0].name
+        ]
+        # (a/math/add 3 4), (a/math/add 5 6), then outer (a/math/add ...)
+        assert len(cross_calls) >= 2
+
+    def test_result_is_immutable(self, two_module_dir: Path) -> None:
+        """``MultiModuleBeamResult`` is a frozen dataclass."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        with pytest.raises((AttributeError, TypeError)):
+            result.entry_module = "mutated"  # type: ignore[misc]
+
+    def test_module_result_is_immutable(self, two_module_dir: Path) -> None:
+        """``ModuleBeamCompileResult`` is a frozen dataclass."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        mr = result.module_results[0]
+        with pytest.raises((AttributeError, TypeError)):
+            mr.module_name = "mutated"  # type: ignore[misc]
+
+    def test_module_results_is_tuple(self, two_module_dir: Path) -> None:
+        """``module_results`` is a tuple, not a list."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        assert isinstance(result.module_results, tuple)
+
+    def test_exports_is_tuple(self, two_module_dir: Path) -> None:
+        """``ModuleBeamCompileResult.exports`` is a tuple."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = compile_modules(modules, "user/hello")
+        for mr in result.module_results:
+            assert isinstance(mr.exports, tuple)
+
+    def test_recursive_dep_compiles(self, recursive_dep_dir: Path) -> None:
+        """A dep module with recursion compiles without error."""
+        modules = _resolve("user/main", recursive_dep_dir)
+        result = compile_modules(modules, "user/main")
+        names = {r.module_name for r in result.module_results}
+        assert "a/math" in names
+        assert "user/main" in names
+
+
+# ---------------------------------------------------------------------------
+# run_modules — end-to-end on real erl
+# ---------------------------------------------------------------------------
+
+
+class TestRunModulesOnRealBeam:
+    """Acceptance tests against the real ``erl`` runtime."""
+
+    @requires_beam
+    def test_two_module_add_returns_42(self, two_module_dir: Path) -> None:
+        """The headline Phase 4f acceptance criterion.
+
+        ``(a/math/add 17 25)`` in the entry module → exit code 42.
+        """
+        modules = _resolve("user/hello", two_module_dir)
+        result = run_modules(modules, "user/hello")
+        assert result.returncode == 42, (
+            f"Expected exit code 42, got {result.returncode}.\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    @requires_beam
+    def test_run_modules_returns_execution_result_type(
+        self, two_module_dir: Path
+    ) -> None:
+        modules = _resolve("user/hello", two_module_dir)
+        result = run_modules(modules, "user/hello")
+        assert isinstance(result, MultiModuleBeamExecutionResult)
+
+    @requires_beam
+    def test_three_module_result_15(self, three_module_dir: Path) -> None:
+        """Three-module program: ``(a/math/add (b/utils/double 5) 5)`` → 15."""
+        modules = _resolve("user/main", three_module_dir)
+        result = run_modules(modules, "user/main")
+        assert result.returncode == 15, (
+            f"Expected exit code 15, got {result.returncode}.\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    @requires_beam
+    def test_sub_from_dep_module(self, tmp_path: Path) -> None:
+        """Dep module's ``sub`` function: 10 - 3 = 7."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "user").mkdir()
+        (tmp_path / "a" / "math.tw").write_text(
+            "(module a/math (export sub))\n"
+            "(define (sub x y) (- x y))\n"
+        )
+        (tmp_path / "user" / "calc.tw").write_text(
+            "(module user/calc (import a/math))\n"
+            "(a/math/sub 10 3)\n"
+        )
+        modules = _resolve("user/calc", tmp_path)
+        result = run_modules(modules, "user/calc")
+        assert result.returncode == 7, result.stderr
+
+    @requires_beam
+    def test_recursive_fact_in_dep(self, recursive_dep_dir: Path) -> None:
+        """Recursion inside a dep module: ``fact(5)`` = 120."""
+        modules = _resolve("user/main", recursive_dep_dir)
+        result = run_modules(modules, "user/main")
+        assert result.returncode == 120, (
+            f"Expected 120, got {result.returncode}.\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    @requires_beam
+    def test_multi_calls_same_dep(self, multi_call_dir: Path) -> None:
+        """Entry calling dep function multiple times: (3+4)+(5+6) = 18."""
+        modules = _resolve("user/main", multi_call_dir)
+        result = run_modules(modules, "user/main")
+        assert result.returncode == 18, (
+            f"Expected 18, got {result.returncode}.\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    @requires_beam
+    def test_compilation_result_accessible(
+        self, two_module_dir: Path
+    ) -> None:
+        """``compilation`` field on execution result is populated."""
+        modules = _resolve("user/hello", two_module_dir)
+        result = run_modules(modules, "user/hello")
+        assert isinstance(result.compilation, MultiModuleBeamResult)
+        assert len(result.compilation.module_results) == 2

--- a/code/specs/TW04-phase4f-beam-module-lowering.md
+++ b/code/specs/TW04-phase4f-beam-module-lowering.md
@@ -1,0 +1,272 @@
+# TW04 Phase 4f — BEAM Multi-Module Lowering
+
+## Status: Shipped (2026-05-04)
+
+## Context
+
+Phase 4d shipped per-module JVM compilation: each Twig module compiles to its own
+`.class` file; cross-module `invokestatic` stitches them together at the JVM level.
+
+Phase 4e delivered the CLR equivalent: every real Twig module becomes a TypeDef row
+inside a single PE/CLI assembly.
+
+Phase 4f delivers the BEAM equivalent: every real Twig module (excluding the synthetic
+`host` module) compiles to its own **`.beam` file**.  All `.beam` files are loaded in
+the same `erl` session so cross-module `call_ext` instructions resolve at runtime.
+
+## BEAM multi-module architecture
+
+### Why one `.beam` file per module (not one file for all)?
+
+Unlike CLR — where cross-assembly calls require `AssemblyRef` + `MemberRef` tokens that
+the `cli-assembly-writer` did not support — BEAM's `call_ext` opcode natively addresses
+any `{Module, Function, Arity}` triple that is visible in the code path at runtime.
+There is no "import table" that must be pre-computed across all modules; the runtime
+resolves the MFA at the first call.  This makes one-file-per-module the natural mapping.
+
+### Module naming
+
+Twig module names use `/` as a namespace separator (e.g. `"a/math"`).  BEAM atom names
+must be valid Erlang atoms; `/` is illegal in an unquoted atom.  The mapping rule is:
+
+```
+"a/math"     → "a_math"
+"user/hello" → "user_hello"
+```
+
+`module_name_to_beam_module(name)` performs this substitution.
+
+### `.beam` file layout
+
+Each module produces one standard BEAM file:
+
+- **Module atom** — derived from the Twig module name via `module_name_to_beam_module`.
+- **Export table** — `main/0` for the entry module; each declared export for dep modules;
+  plus the mandatory `module_info/0` and `module_info/1` stubs.
+- **Import table** — one entry per unique cross-module call target encountered in the IR,
+  encoded as `{CallerAtom, FnAtom, Arity}`.
+- **Atom table** — module atom, all interned function-name atoms, all symbol-literal atoms.
+- **Code section** — BEAM binary instructions (see `ir-to-beam`).
+
+### Cross-module call semantics
+
+`IrOp.CALL IrLabel("a/math/add")` labels containing `/` are cross-module calls.  The
+label string encodes both the foreign module name and the function name:
+
+```
+"a/math/add"  →  module "a_math", function "add"
+```
+
+Unlike JVM/CLR — where all parameters are passed through a fixed-width call-register
+frame regardless of callee arity — BEAM's `call_ext N Mfa` encodes the callee's **exact
+arity** in both the instruction prefix (`N`) and the MFA triple.  A mismatch causes a
+loader crash or undefined-function error at runtime.
+
+Arity tracking therefore requires two sources:
+
+1. **Call-site arity** — recorded in `_Compiler._cross_module_arities` at each
+   cross-module `IrOp.CALL` site (the number of arguments the caller passes).
+2. **Declared arity** — obtained by re-running `_Compiler` on each compiled dep module
+   and reading `_fn_params`; this gives the exact declared parameter count for each
+   exported function.
+
+`compile_modules` merges both sources into `BEAMBackendConfig.external_function_arities`
+before passing the config to `lower_ir_to_beam`.
+
+## GC-safe y-register initialisation
+
+### The problem
+
+BEAM's garbage collector traces **all** allocated y-register slots as potential heap
+pointers.  Our compiler allocates a flat frame of `max_reg_index + 1` y-slots per
+function via `allocate K, N` but only writes a subset of them (param slots and holding
+registers) before body code runs.  Unwritten slots contain stack-word garbage.  If any
+garbage value resembles a valid BEAM tagged heap pointer, the GC follows it and corrupts
+the heap — causing non-deterministic SIGSEGV at recursion depth ≥ 4, when the first GC
+cycle fires inside a deeply nested call stack.
+
+### Approaches that failed
+
+| Approach | Why it failed |
+|----------|--------------|
+| `allocate_zero` (abstract opcode 14) | Abstract `.S` opcode 14 ≠ binary opcode 14. Binary opcode 14 = `allocate_heap` (3 operands). Loader returns `{error, badfile}`. |
+| `init y(i)` (opcode 17) | OTP 28 rejects `init` with Y-register operands: "please re-compile with an OTP 28 compiler". |
+| `init_yregs` (opcode 172) | The correct OTP 24+ replacement, but requires Z-tagged extended-list compact-term encoding that our encoder does not support. |
+
+### The fix
+
+Emit `move {atom, 0}, y(i)` for every y-register slot immediately after `allocate`,
+before copying function arguments and executing body code.
+
+Atom index 0 is the nil atom (`[]`) by BEAM convention — a tagged **immediate** that is
+NOT a heap pointer.  The GC can safely trace a nil slot without following a pointer chain.
+
+This uses only standard `move` opcodes already handled by our encoder and is valid across
+all supported OTP versions.
+
+```erlang
+%% Generated prologue for a function with 3 y-register slots:
+allocate 3, arity
+move {atom,0}, y(0)          %% nil-init slot 0
+move {atom,0}, y(1)          %% nil-init slot 1
+move {atom,0}, y(2)          %% nil-init slot 2
+move x(0), y(2)              %% copy first arg into param slot
+move x(1), y(3)              %% copy second arg into param slot
+...                          %% body code
+```
+
+## Explicit module pre-loading in `-noshell` mode
+
+`erl -pa <dir>` adds the directory to the code path but does NOT guarantee that all
+`.beam` files are auto-loaded before a `call_ext` fires.  In `-noshell` mode, the lazy
+code-loader may not have loaded a dep module by the time the entry module first calls
+into it, producing:
+
+```
+{undef,[{a_math,add,2,[]}]}
+```
+
+or (with GC corruption) an outright SIGSEGV.
+
+`run_modules` therefore constructs its `-eval` expression to explicitly load every module
+before invoking `main/0`:
+
+```erlang
+{module,_} = code:load_file(a_math),
+{module,_} = code:load_file(b_util),
+Result = user_hello:main(),
+erlang:halt(Result).
+```
+
+Modules are loaded in compilation order (deps before entry) so that inter-dep calls also
+resolve before the first cross-module dispatch.
+
+## New `BEAMBackendConfig` fields (ir-to-beam ≥ 0.5.0)
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `extra_callable_labels` | `tuple[str, ...]` | `()` | Force-include exported dep-module functions as callable regions even when no local `CALL` targets them |
+| `call_register_count` | `int \| None` | `None` | API symmetry with CLR/JVM backends; ignored for BEAM (per-declaration arities, not a fixed-width frame) |
+| `external_function_arities` | `dict[str, int]` | `{}` | Maps cross-module call labels (e.g. `"a/math/add"`) to the exact remote arity required for `call_ext N Mfa` |
+
+## New twig-beam-compiler API
+
+### `module_name_to_beam_module(name: str) → str`
+
+Maps a Twig module name to a BEAM module atom string by replacing `/` with `_`:
+
+```
+"user/hello" → "user_hello"
+"a/math"     → "a_math"
+```
+
+### `compile_modules(modules, entry_module, *, optimize=True) → MultiModuleBeamResult`
+
+Compiles a topologically ordered list of `ResolvedModule`s to BEAM.  Skips the synthetic
+`host` module.
+
+**Pass 1 (analysis)** — for each module in `[entry] + deps` order:
+  - Compile Twig source to IR (`_Compiler`)
+  - Optimize IR
+  - Record `_cross_module_arities` and `_fn_params` for arity resolution
+
+**Pass 2 (emission)** — for each module:
+  - Build `BEAMBackendConfig` with `extra_callable_labels` (module's exports),
+    `external_function_arities` (arities from both call-site and declared sources),
+    and the module's BEAM atom name
+  - Lower IR to `BEAMModule`
+  - Encode to `.beam` bytes
+
+Returns a `MultiModuleBeamResult` containing one `ModuleBeamCompileResult` per module.
+
+### `run_modules(modules, entry_module, *, optimize=True, tmp_dir=None, timeout_seconds=30) → MultiModuleBeamExecutionResult`
+
+Calls `compile_modules`, writes each `.beam` file to a temp directory, and invokes:
+
+```
+erl -noshell -pa <dir> -eval '<load_stmts> Result = <entry>:main(), erlang:halt(Result).'
+```
+
+where `<load_stmts>` are explicit `code:load_file` calls for every compiled module in
+compilation order.  Returns a `MultiModuleBeamExecutionResult` with the compile result
+plus stdout / stderr / returncode.
+
+Skips when `erl` is not on PATH (test decorator `@requires_beam`).
+
+## Result types
+
+All three result types are frozen dataclasses.
+
+### `ModuleBeamCompileResult`
+
+Per-module artefact produced by `compile_modules`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `twig_module_name` | `str` | Original Twig name (e.g. `"a/math"`) |
+| `beam_module` | `str` | BEAM atom string (e.g. `"a_math"`) |
+| `ir` | `IrProgram` | Optimized IR for this module |
+| `beam_bytes` | `bytes` | Encoded `.beam` file content |
+| `exports` | `tuple[str, ...]` | Exported Twig function names |
+
+### `MultiModuleBeamResult`
+
+Aggregate result from `compile_modules`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entry_module` | `str` | Twig name of the entry module |
+| `entry_beam_module` | `str` | BEAM atom of the entry module |
+| `module_results` | `tuple[ModuleBeamCompileResult, ...]` | One per compiled module |
+
+### `MultiModuleBeamExecutionResult`
+
+Result from `run_modules`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `compilation` | `MultiModuleBeamResult` | Full compile result |
+| `stdout` | `str` | Captured stdout from `erl` |
+| `stderr` | `str` | Captured stderr from `erl` |
+| `returncode` | `int` | Process exit code (= `erlang:halt/1` argument) |
+
+## Acceptance criteria
+
+End-to-end on real `erl`:
+
+```twig
+; Module a/math:
+(module a/math (export add))
+(define (add x y) (+ x y))
+
+; Module user/hello (entry, imports a/math):
+(module user/hello (import a/math))
+(define n (a/math/add 10 32))
+n   ; → exit code 42
+```
+
+```python
+result = run_modules(modules, entry_module="user/hello")
+assert result.returncode == 42
+```
+
+Recursive dep-module function (exercises GC-safe y-register initialisation):
+
+```twig
+; Module a/math:
+(module a/math (export fact))
+(define (fact n)
+  (if (= n 0) 1 (* n (fact (- n 1)))))
+
+; Entry module calls (a/math/fact 5) → 120
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `ir-to-beam/backend.py` | Add `extra_callable_labels`, `call_register_count`, `external_function_arities` to `BEAMBackendConfig`; cross-module CALL lowering in `_emit_call`; GC-safe y-register nil-initialisation after `allocate` |
+| `twig-beam-compiler/compiler.py` | Add `module_name_to_beam_module`, `compile_modules`, `run_modules`, result types; cross-module arity tracking in `_cross_module_arities`; explicit `code:load_file` pre-loading in `run_modules` |
+| `twig-beam-compiler/tests/test_multi_module_beam.py` | New: 38 unit + real-erl end-to-end tests |
+| `ir-to-beam/CHANGELOG.md` | v0.5.0 entry |
+| `twig-beam-compiler/CHANGELOG.md` | v0.5.0 entry |


### PR DESCRIPTION
## Summary

- Implements TW04 Phase 4f: every real Twig module (excluding the synthetic `host` module) compiles to its own `.beam` file; all `.beam` files are loaded in the same `erl` session so cross-module `call_ext` instructions resolve at runtime
- Adds `compile_modules` / `run_modules` to `twig-beam-compiler` with three new frozen-dataclass result types (`ModuleBeamCompileResult`, `MultiModuleBeamResult`, `MultiModuleBeamExecutionResult`)
- Extends `ir-to-beam` `BEAMBackendConfig` with `extra_callable_labels`, `call_register_count`, and `external_function_arities`; adds cross-module `call_ext` lowering in `_emit_call`
- Fixes a non-deterministic SIGSEGV at recursion depth ≥ 4 caused by the BEAM GC tracing uninitialized y-register slots as heap pointers — fixed by emitting `move {atom,0}, y(i)` for every y-slot immediately after `allocate`
- Fixes `run_modules` to explicitly `code:load_file` each dep module before calling `main()` in `-noshell` mode, preventing `{undef,[{mod,fn,arity,[]}]}` crashes
- 38 new tests in `test_multi_module_beam.py` (25 structural, 6 real-`erl` runtime, 7 name-mapping); full BEAM suite is 103 tests at 86% coverage; ruff clean

## Test plan

- [ ] `twig-beam-compiler` tests pass: `python -m pytest code/packages/python/twig-beam-compiler/tests/`
- [ ] `ir-to-beam` tests pass: `python -m pytest code/packages/python/ir-to-beam/tests/`
- [ ] Coverage ≥ 80% for both packages
- [ ] ruff clean on both packages
- [ ] Real-`erl` runtime tests (`@requires_beam`) pass when `erl` is on PATH: two-module add → 42, three-module chained calls → 15, sub → 7, recursive fact(5) → 120, multiple calls same dep → 18

🤖 Generated with [Claude Code](https://claude.com/claude-code)