### PR TITLE
fix(constraint-dos): 5 algorithmic-complexity DoS guards for LANG23 refinement checker

### DIFF
--- a/code/packages/rust/constraint-core/CHANGELOG.md
+++ b/code/packages/rust/constraint-core/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog — constraint-core
 
+## [0.1.1] — 2026-05-04
+
+Security hardening — algorithmic-complexity DoS guards.  These fixes become
+necessary now that LANG23 PR 23-E lets user-written Twig refinement-type
+annotations flow into the solver without a prior sanitisation layer.
+
+### Fixed
+
+- **CNF clause-count ceiling** (`cnf_distribute`).  The naive OR-over-AND
+  distribution is exponential in the number of conjuncts inside each
+  disjunct.  An adversarial predicate with ~14 levels of OR-over-AND
+  could produce ≫ 10⁶ clauses and stall the process indefinitely.
+  `cnf_distribute` now accepts a `budget: &mut usize` parameter initialised
+  to `MAX_CNF_CLAUSES = 10_000` and returns `Err(String)` when the budget
+  hits zero.  `to_cnf()` propagates the error, changing its return type from
+  `Predicate` to `Result<Predicate, String>`.
+
+- **Depth guard** (`depth_of` + `MAX_PREDICATE_DEPTH`).  Deeply-nested
+  predicates could overflow the thread stack inside the mutually recursive
+  `to_nnf` / `cnf_distribute` / `simplify` passes.
+  - New public constant `MAX_PREDICATE_DEPTH = 500`.
+  - New public function `depth_of(p: &Predicate) -> usize` that measures
+    tree depth using saturating arithmetic (returns `usize::MAX` for trees
+    beyond the cap) so callers can reject over-deep input in O(n) without
+    themselves recursing deeply.
+  - Engines should call `depth_of(p) > MAX_PREDICATE_DEPTH` before passing
+    user-supplied predicates to any normalisation pass.
+
+### Added
+
+- 4 new unit tests: `cnf_budget_exceeded_returns_err`, `depth_of_atoms_is_zero`,
+  `depth_of_compound`, `depth_of_saturates_beyond_max`.
+
+### Migration
+
+Callers of `to_cnf()` must handle `Result`:
+
+```rust
+// before
+let cnf = predicate.to_cnf();
+// after
+let cnf = predicate.to_cnf().map_err(|e| /* handle budget exhaustion */)?;
+```
+
 ## [0.1.0] — 2026-04-30
 
 Initial release.  **LANG24 PR 24-A** — predicate AST + sort/logic/theory

--- a/code/packages/rust/constraint-core/src/lib.rs
+++ b/code/packages/rust/constraint-core/src/lib.rs
@@ -47,23 +47,19 @@
 //!
 //! ## Non-guarantees (caller responsibilities)
 //!
-//! - **Predicate depth.**  All recursive operations
-//!   ([`Predicate::to_nnf`], [`Predicate::to_cnf`],
-//!   [`Predicate::simplify`], [`Predicate::free_vars`],
-//!   [`infer_sort`], `Display::fmt`) recurse on the AST without an
-//!   explicit depth guard.  A maliciously deep `Predicate` can
-//!   overflow the thread stack.  Consumers ingesting predicates
-//!   from untrusted sources (refinement-type checkers reading
-//!   user code, SMT-LIB importers) must enforce a depth limit at
-//!   the boundary.  `constraint-engine` (PR 24-C) will provide
-//!   the canonical guarded entry point.
-//! - **CNF blow-up.**  [`Predicate::to_cnf`] uses naive
-//!   distribution, which is exponential in the worst case
-//!   (`O(2^n)` clauses for an `Or` of `n` `And`s).  Acceptable
-//!   for the small predicates that arise in refinement-type
-//!   checking; consumers handling untrusted predicates should
-//!   prefer Tseitin encoding (also forthcoming in
-//!   `constraint-engine`).
+//! - **Predicate depth.**  Most recursive operations
+//!   ([`Predicate::to_nnf`], [`Predicate::simplify`],
+//!   [`Predicate::free_vars`], [`infer_sort`], `Display::fmt`) recurse
+//!   on the AST without an explicit depth guard.  Consumers ingesting
+//!   predicates from untrusted sources must call [`depth_of`] and
+//!   reject predicates deeper than [`MAX_PREDICATE_DEPTH`] before
+//!   invoking these passes.  [`Predicate::to_cnf`] enforces an
+//!   internal clause-count ceiling and returns `Err` on overflow.
+//! - **CNF blow-up.**  [`Predicate::to_cnf`] now caps output at
+//!   [`MAX_CNF_CLAUSES`] clauses and returns `Err` if exceeded so
+//!   that callers can degrade to `Unknown`.  The underlying
+//!   distribution is still naïve (`O(2^n)` in the worst case);
+//!   Tseitin encoding is out of v1 scope.
 //! - **`Rational` range.**  [`Rational::new`] rejects `i128::MIN`
 //!   for either numerator or denominator (its magnitude can't be
 //!   represented as a positive `i128`).  Callers building
@@ -76,6 +72,22 @@
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Resource limits
+// ---------------------------------------------------------------------------
+
+/// Maximum number of CNF clauses [`Predicate::to_cnf`] may produce before
+/// aborting with `Err`.  Prevents unbounded memory allocation from
+/// exponential distribution of deeply nested Or-over-And predicates.
+pub const MAX_CNF_CLAUSES: usize = 10_000;
+
+/// Maximum predicate-AST depth that [`depth_of`] considers "safe" for
+/// recursive passes (`to_nnf`, `simplify`, `free_vars`, `infer_sort`, …).
+/// Callers must reject predicates deeper than this before invoking those
+/// passes.  Used by `constraint-engine`'s SAT tactic as its pre-flight
+/// guard.
+pub const MAX_PREDICATE_DEPTH: usize = 500;
 
 // ---------------------------------------------------------------------------
 // Sort
@@ -530,15 +542,19 @@ impl Predicate {
     /// Convert to **conjunctive normal form** (CNF) via NNF + naive
     /// distribution of `Or` over `And`.
     ///
+    /// Returns `Err(reason)` if the output would exceed
+    /// [`MAX_CNF_CLAUSES`] — the caller should degrade to
+    /// `SolverResult::Unknown` in that case rather than allocating
+    /// unbounded memory.
+    ///
     /// **Warning: exponential in the worst case.**  Naive
     /// distribution of an OR-of-N-ANDs blows up factorially.  For
     /// large predicates, use Tseitin-style rewriting (introduces
-    /// fresh bool vars) — out of v1 scope.  Callers should keep CNF
-    /// inputs small or arrange them in NNF and let the SAT tactic
-    /// drive its own clause learning.
-    pub fn to_cnf(self) -> Predicate {
+    /// fresh bool vars) — out of v1 scope.
+    pub fn to_cnf(self) -> Result<Predicate, String> {
         let nnf = self.to_nnf();
-        cnf_distribute(nnf)
+        let mut budget = MAX_CNF_CLAUSES;
+        cnf_distribute(nnf, &mut budget)
     }
 
     /// Apply local simplifications — constant folding, identity
@@ -690,49 +706,137 @@ fn free_vars_rec(p: &Predicate, out: &mut BTreeSet<String>, bound: &mut BTreeSet
     }
 }
 
-fn cnf_distribute(p: Predicate) -> Predicate {
+/// Return the maximum AST nesting depth of `p`.
+///
+/// The return value saturates at `MAX_PREDICATE_DEPTH + 1` once the
+/// tree is deeper than that — the result is therefore only precise for
+/// trees within the accepted range, but is always a correct signal for
+/// the `> MAX_PREDICATE_DEPTH` guard check:
+///
+/// ```rust
+/// # use constraint_core::{Predicate, depth_of, MAX_PREDICATE_DEPTH};
+/// let p = Predicate::Bool(true);
+/// assert!(depth_of(&p) <= MAX_PREDICATE_DEPTH);
+/// ```
+///
+/// Recursion is capped at `MAX_PREDICATE_DEPTH + 2` levels to avoid
+/// stack overflow while measuring — a tree deeper than the cap returns
+/// `usize::MAX` (saturating arithmetic).
+pub fn depth_of(p: &Predicate) -> usize {
+    fn go(p: &Predicate, remaining: usize) -> usize {
+        if remaining == 0 {
+            return usize::MAX; // deeper than the cap — saturate
+        }
+        match p {
+            Predicate::Bool(_) | Predicate::Var(_) | Predicate::Int(_)
+            | Predicate::Real(_) => 0,
+            Predicate::And(parts) | Predicate::Or(parts) | Predicate::Add(parts) => {
+                1_usize.saturating_add(
+                    parts.iter().map(|q| go(q, remaining - 1)).max().unwrap_or(0),
+                )
+            }
+            Predicate::Not(inner) | Predicate::Mul { term: inner, .. } => {
+                1_usize.saturating_add(go(inner, remaining - 1))
+            }
+            Predicate::Implies(a, b)
+            | Predicate::Iff(a, b)
+            | Predicate::Eq(a, b)
+            | Predicate::NEq(a, b)
+            | Predicate::Sub(a, b)
+            | Predicate::Le(a, b)
+            | Predicate::Lt(a, b)
+            | Predicate::Ge(a, b)
+            | Predicate::Gt(a, b) => {
+                1_usize.saturating_add(
+                    go(a, remaining - 1).max(go(b, remaining - 1)),
+                )
+            }
+            Predicate::Ite(c, t, e) => 1_usize.saturating_add(
+                go(c, remaining - 1)
+                    .max(go(t, remaining - 1))
+                    .max(go(e, remaining - 1)),
+            ),
+            Predicate::Forall { body, .. } | Predicate::Exists { body, .. } => {
+                1_usize.saturating_add(go(body, remaining - 1))
+            }
+            Predicate::Select { arr, idx } => 1_usize.saturating_add(
+                go(arr, remaining - 1).max(go(idx, remaining - 1)),
+            ),
+            Predicate::Store { arr, idx, val } => 1_usize.saturating_add(
+                go(arr, remaining - 1)
+                    .max(go(idx, remaining - 1))
+                    .max(go(val, remaining - 1)),
+            ),
+            Predicate::Apply { args, .. } => 1_usize.saturating_add(
+                args.iter().map(|q| go(q, remaining - 1)).max().unwrap_or(0),
+            ),
+        }
+    }
+    // Start with MAX_PREDICATE_DEPTH + 2 so that trees of depth exactly
+    // MAX_PREDICATE_DEPTH compute their true depth (no saturation).
+    go(p, MAX_PREDICATE_DEPTH + 2)
+}
+
+/// Budget-tracked CNF distribution.  Decrements `*budget` on each
+/// recursive call; returns `Err` when exhausted to prevent
+/// unbounded allocation.
+fn cnf_distribute(p: Predicate, budget: &mut usize) -> Result<Predicate, String> {
+    if *budget == 0 {
+        return Err(format!(
+            "CNF clause limit ({MAX_CNF_CLAUSES}) exceeded — \
+             predicate requires too many clauses for naive distribution; \
+             use Tseitin encoding or simplify before calling to_cnf"
+        ));
+    }
+    *budget -= 1;
+
     // Walk the NNF tree.  At an Or node: distribute over any And
     // child.  At an And node: just recurse and re-and the parts.
     // No top-level rewriting needed for atoms, comparisons, or
     // already-cnf-shaped subtrees.
     match p {
         Predicate::And(parts) => {
-            Predicate::and(parts.into_iter().map(cnf_distribute).collect())
+            let mut out = Vec::with_capacity(parts.len());
+            for part in parts {
+                out.push(cnf_distribute(part, budget)?);
+            }
+            Ok(Predicate::and(out))
         }
         Predicate::Or(parts) => {
             // Fully distribute by repeatedly cross-producting And children.
-            let parts: Vec<Predicate> = parts.into_iter().map(cnf_distribute).collect();
+            let mut dist_parts = Vec::with_capacity(parts.len());
+            for part in parts {
+                dist_parts.push(cnf_distribute(part, budget)?);
+            }
             // Find the first And in parts (if any).  If none, this Or is
             // already in CNF (it's a clause).
-            if let Some(and_idx) = parts.iter().position(|p| matches!(p, Predicate::And(_))) {
-                let and_parts = match &parts[and_idx] {
+            if let Some(and_idx) = dist_parts.iter().position(|p| matches!(p, Predicate::And(_))) {
+                let and_parts = match &dist_parts[and_idx] {
                     Predicate::And(v) => v.clone(),
                     _ => unreachable!(),
                 };
-                let rest: Vec<Predicate> = parts
+                let rest: Vec<Predicate> = dist_parts
                     .iter()
                     .enumerate()
                     .filter(|(i, _)| *i != and_idx)
                     .map(|(_, p)| p.clone())
                     .collect();
                 // (a ∧ b) ∨ rest  →  (a ∨ rest) ∧ (b ∨ rest)
-                let clauses: Vec<Predicate> = and_parts
-                    .into_iter()
-                    .map(|a| {
-                        let mut new_or = vec![a];
-                        new_or.extend(rest.clone());
-                        cnf_distribute(Predicate::or(new_or))
-                    })
-                    .collect();
-                Predicate::and(clauses)
+                let mut clauses = Vec::with_capacity(and_parts.len());
+                for a in and_parts {
+                    let mut new_or = vec![a];
+                    new_or.extend(rest.clone());
+                    clauses.push(cnf_distribute(Predicate::or(new_or), budget)?);
+                }
+                Ok(Predicate::and(clauses))
             } else {
-                Predicate::or(parts)
+                Ok(Predicate::or(dist_parts))
             }
         }
         // Atoms and other constructors stay as-is (they're either
         // atomic or contain no boolean structure to distribute over
         // in v1's scope).
-        other => other,
+        other => Ok(other),
     }
 }
 
@@ -1270,7 +1374,7 @@ mod tests {
         let b = Predicate::Var("b".into());
         let c = Predicate::Var("c".into());
         let p = Predicate::or(vec![Predicate::and(vec![a.clone(), b.clone()]), c.clone()]);
-        let cnf = p.to_cnf();
+        let cnf = p.to_cnf().expect("small predicate should not exceed CNF budget");
         match cnf {
             Predicate::And(clauses) => {
                 assert_eq!(clauses.len(), 2);
@@ -1287,7 +1391,7 @@ mod tests {
             Predicate::or(vec![vx(), vy()]),
             Predicate::not(vy()),
         ]);
-        let cnf = p.clone().to_cnf();
+        let cnf = p.clone().to_cnf().expect("small predicate should not exceed CNF budget");
         // Must remain shape-equivalent (And-of-Ors-or-atoms).
         match cnf {
             Predicate::And(parts) => {
@@ -1300,6 +1404,54 @@ mod tests {
             }
             _ => panic!("expected And"),
         }
+    }
+
+    #[test]
+    fn cnf_budget_exceeded_returns_err() {
+        // Build an Or of 15 2-element Ands — naive distribution produces
+        // 2^15 = 32 768 clauses, exceeding MAX_CNF_CLAUSES (10 000).
+        let arms: Vec<Predicate> = (0..15_u32)
+            .map(|i| {
+                Predicate::and(vec![
+                    Predicate::Var(format!("a{i}")),
+                    Predicate::Var(format!("b{i}")),
+                ])
+            })
+            .collect();
+        let p = Predicate::or(arms);
+        assert!(
+            p.to_cnf().is_err(),
+            "expected Err when CNF would exceed MAX_CNF_CLAUSES"
+        );
+    }
+
+    #[test]
+    fn depth_of_atoms_is_zero() {
+        assert_eq!(super::depth_of(&Predicate::Bool(true)), 0);
+        assert_eq!(super::depth_of(&Predicate::Int(42)), 0);
+        assert_eq!(super::depth_of(&Predicate::Var("x".into())), 0);
+    }
+
+    #[test]
+    fn depth_of_compound() {
+        let p = Predicate::and(vec![vx(), vy()]);
+        assert_eq!(super::depth_of(&p), 1);
+        let q = Predicate::not(p);
+        assert_eq!(super::depth_of(&q), 2);
+    }
+
+    #[test]
+    fn depth_of_saturates_beyond_max() {
+        // Build a 502-deep Not chain (MAX_PREDICATE_DEPTH + 2).
+        let mut p: Predicate = Predicate::Bool(true);
+        for _ in 0..502 {
+            p = Predicate::Not(Box::new(p));
+        }
+        let d = super::depth_of(&p);
+        assert!(
+            d > super::MAX_PREDICATE_DEPTH,
+            "expected depth > MAX_PREDICATE_DEPTH for a 502-deep tree, got {d}"
+        );
     }
 
     // ---------- Simplify ----------

--- a/code/packages/rust/constraint-engine/CHANGELOG.md
+++ b/code/packages/rust/constraint-engine/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — `constraint-engine`
 
+## 0.1.1 — 2026-05-04
+
+Security hardening — DoS guards on the SAT and LIA tactics.
+
+### Fixed
+
+- **SAT tactic: depth check before CNF conversion** (`sat.rs`).  The SAT
+  tactic now calls `depth_of(p) > MAX_PREDICATE_DEPTH` on every assertion
+  before invoking `to_cnf()`.  Predicates exceeding the depth limit return
+  `SolverResult::Unknown(…)` immediately rather than recursing into stack
+  overflow.  The `to_cnf()` call is also guarded via `Result` — a
+  `Err(budget_msg)` returns `Unknown(budget_msg)` so the engine degrades
+  gracefully to "can't decide" instead of panicking.
+
+- **LIA tactic: `neqs` changed from `Vec<i128>` to `HashSet<i128>`**
+  (`lia.rs`).  The candidate-filter step inside `eliminate_all` called
+  `neqs.contains(&candidate)` in a tight loop.  With `Vec`, O(n) membership
+  cost per candidate turned into O(n²) when a user supplied hundreds of
+  disequality constraints (e.g. `x ≠ 1, x ≠ 2, …, x ≠ k`).  `HashSet`
+  makes each `.contains()` O(1).
+
 ## 0.1.0 — 2026-05-04
 
 Initial release.  **LANG24 PR 24-C.**

--- a/code/packages/rust/constraint-engine/src/lia.rs
+++ b/code/packages/rust/constraint-engine/src/lia.rs
@@ -58,7 +58,7 @@
 //! for any realistic LANG23 predicate, so this is safe — the runtime
 //! check catches any case the solver gave up on).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use constraint_core::Predicate;
 
@@ -181,7 +181,8 @@ fn eliminate_all(
     // `ub` = tightest upper bound seen (initially +∞ = i128::MAX)
     let mut lb: Option<i128> = None; // None = −∞
     let mut ub: Option<i128> = None; // None = +∞
-    let mut neqs: Vec<i128> = Vec::new(); // x ≠ k constraints
+    // HashSet for O(1) membership test in the candidate-filter below.
+    let mut neqs: HashSet<i128> = HashSet::new(); // x ≠ k constraints
     let mut equalities: Vec<i128> = Vec::new(); // x = k constraints
 
     for constraint in constraints {
@@ -196,7 +197,7 @@ fn eliminate_all(
                 equalities.push(n);
             }
             BoundInfo::Disequality(n) => {
-                neqs.push(n);
+                neqs.insert(n);
             }
             BoundInfo::Irrelevant => {}
             BoundInfo::Unsatisfiable => return EliminationResult::Unsat,

--- a/code/packages/rust/constraint-engine/src/sat.rs
+++ b/code/packages/rust/constraint-engine/src/sat.rs
@@ -46,7 +46,7 @@
 
 use std::collections::HashMap;
 
-use constraint_core::Predicate;
+use constraint_core::{depth_of, Predicate, MAX_PREDICATE_DEPTH};
 
 use crate::{Model, SolverResult, Value};
 
@@ -98,10 +98,25 @@ impl SatTactic {
             return SolverResult::Sat(model);
         }
 
+        // Reject predicates that are too deep for the recursive passes
+        // (to_nnf, to_cnf, …) — a deeply nested tree can overflow the
+        // OS thread stack.
+        for p in assertions {
+            if depth_of(p) > MAX_PREDICATE_DEPTH {
+                return SolverResult::Unknown(format!(
+                    "predicate depth exceeds MAX_PREDICATE_DEPTH ({MAX_PREDICATE_DEPTH}); \
+                     refusing to recurse to avoid stack overflow"
+                ));
+            }
+        }
+
         // Convert every assertion to CNF and collect clauses.
         let mut clauses: Vec<Clause> = Vec::new();
         for p in assertions {
-            let cnf = p.clone().to_cnf();
+            let cnf = match p.clone().to_cnf() {
+                Ok(c) => c,
+                Err(reason) => return SolverResult::Unknown(reason),
+            };
             match collect_clauses(&cnf) {
                 Ok(new_clauses) => clauses.extend(new_clauses),
                 Err(reason) => return SolverResult::Unknown(reason),

--- a/code/packages/rust/lang-refined-types/CHANGELOG.md
+++ b/code/packages/rust/lang-refined-types/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — `lang-refined-types`
 
+## 0.1.1 — 2026-05-04
+
+Security hardening — allocation-free canonical sort for `Predicate`.
+
+### Fixed
+
+- **`Predicate::canonicalise()` used `format!("{:?}")` as a sort key**.
+  `And` / `Or` operands were sorted by comparing their `Debug` strings:
+  `parts.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")))`
+  This allocated two `String`s per comparison pair, giving O(n log n ×
+  average-predicate-size) allocation cost.  A `Membership { values }` with
+  k values, nested inside an `And`, produced a string proportional to k on
+  every comparison; a user who crafted an `And` of many such predicates
+  could trigger O(n² k) allocation.
+
+  **Fix**: implemented `PartialOrd + Ord` for `Predicate` using a
+  variant-tag discriminant (stable fixed order across variants) followed
+  by field-level lexicographic comparison — all allocation-free.
+  `canonicalise` now calls `parts.sort()` + `parts.dedup()`.
+
+### Added
+
+- `impl PartialOrd for Predicate` — delegates to `Ord`.
+- `impl Ord for Predicate` — tag-then-fields total order; uses existing
+  `Ord` impls on `VarId`, `CmpOp`, `Option<i128>`, `Vec<i128>`,
+  `Vec<Predicate>`, `Box<Predicate>`, `i128`, `String`.
+- 3 new unit tests: `canonicalise_and_is_order_independent`,
+  `canonicalise_or_is_order_independent`, `canonicalise_deduplicates`.
+
 ## 0.1.0 — 2026-05-04
 
 Initial release.  **LANG23 PR 23-A.**

--- a/code/packages/rust/lang-refined-types/src/predicate.rs
+++ b/code/packages/rust/lang-refined-types/src/predicate.rs
@@ -175,6 +175,72 @@ impl Hash for Predicate {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Ordering — required to replace the format!("{:?}")-based sort in
+// canonicalise with a proper, allocation-free comparison.
+// ---------------------------------------------------------------------------
+
+/// Return a numeric tag for each variant so different variants sort in a
+/// stable, arbitrary-but-fixed order.
+fn variant_tag(p: &Predicate) -> u8 {
+    match p {
+        Predicate::Range { .. }     => 0,
+        Predicate::Membership { .. } => 1,
+        Predicate::And(_)           => 2,
+        Predicate::Or(_)            => 3,
+        Predicate::Not(_)           => 4,
+        Predicate::LinearCmp { .. } => 5,
+        Predicate::Opaque { .. }    => 6,
+    }
+}
+
+impl PartialOrd for Predicate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Predicate {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+
+        // Compare by variant first for a stable total order.
+        let tag_ord = variant_tag(self).cmp(&variant_tag(other));
+        if tag_ord != Ordering::Equal {
+            return tag_ord;
+        }
+
+        // Same variant — compare fields lexicographically.
+        match (self, other) {
+            (
+                Predicate::Range { lo: lo1, hi: hi1, inclusive_hi: inc1 },
+                Predicate::Range { lo: lo2, hi: hi2, inclusive_hi: inc2 },
+            ) => lo1.cmp(lo2).then_with(|| hi1.cmp(hi2)).then_with(|| inc1.cmp(inc2)),
+
+            (Predicate::Membership { values: v1 }, Predicate::Membership { values: v2 }) => {
+                v1.cmp(v2)
+            }
+
+            // And and Or both carry Vec<Predicate> — recurse.
+            (Predicate::And(a), Predicate::And(b))
+            | (Predicate::Or(a), Predicate::Or(b)) => a.cmp(b),
+
+            (Predicate::Not(a), Predicate::Not(b)) => a.cmp(b),
+
+            (
+                Predicate::LinearCmp { coefs: c1, op: op1, rhs: rhs1 },
+                Predicate::LinearCmp { coefs: c2, op: op2, rhs: rhs2 },
+            ) => c1.cmp(c2).then_with(|| op1.cmp(op2)).then_with(|| rhs1.cmp(rhs2)),
+
+            (Predicate::Opaque { display: d1 }, Predicate::Opaque { display: d2 }) => d1.cmp(d2),
+
+            // The variant_tag check above guarantees same variant — this arm
+            // is unreachable but required to satisfy the exhaustiveness checker.
+            _ => Ordering::Equal,
+        }
+    }
+}
+
 impl Predicate {
     // -----------------------------------------------------------------------
     // Smart constructors
@@ -278,14 +344,14 @@ impl Predicate {
         match self {
             Predicate::And(parts) => {
                 let mut parts: Vec<_> = parts.into_iter().map(|p| p.canonicalise()).collect();
-                parts.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
-                parts.dedup_by(|a, b| a == b);
+                parts.sort();
+                parts.dedup();
                 Predicate::and(parts)
             }
             Predicate::Or(parts) => {
                 let mut parts: Vec<_> = parts.into_iter().map(|p| p.canonicalise()).collect();
-                parts.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
-                parts.dedup_by(|a, b| a == b);
+                parts.sort();
+                parts.dedup();
                 Predicate::or(parts)
             }
             Predicate::Membership { mut values } => {
@@ -829,6 +895,34 @@ mod tests {
         // Both simplify to Range { lo: 0, hi: 100 } after merge, so the
         // set should have 1 element.
         assert!(set.len() <= 2, "unexpected hash collision count: {}", set.len());
+    }
+
+    // ─── canonicalise / Ord ───────────────────────────────────────────────────
+
+    #[test]
+    fn canonicalise_and_is_order_independent() {
+        let p = Predicate::Range { lo: Some(0), hi: Some(10), inclusive_hi: true };
+        let q = Predicate::Membership { values: vec![5] };
+        let pq = Predicate::And(vec![p.clone(), q.clone()]).canonicalise();
+        let qp = Predicate::And(vec![q.clone(), p.clone()]).canonicalise();
+        assert_eq!(pq, qp);
+    }
+
+    #[test]
+    fn canonicalise_or_is_order_independent() {
+        let p = Predicate::Range { lo: Some(0), hi: Some(10), inclusive_hi: true };
+        let q = Predicate::Membership { values: vec![5] };
+        let pq = Predicate::Or(vec![p.clone(), q.clone()]).canonicalise();
+        let qp = Predicate::Or(vec![q.clone(), p.clone()]).canonicalise();
+        assert_eq!(pq, qp);
+    }
+
+    #[test]
+    fn canonicalise_deduplicates() {
+        let p = Predicate::Range { lo: Some(0), hi: Some(10), inclusive_hi: true };
+        let result = Predicate::And(vec![p.clone(), p.clone()]).canonicalise();
+        // After dedup the And collapses to the single element.
+        assert_eq!(result, p);
     }
 
     // ─── VarId / CmpOp ────────────────────────────────────────────────────────

--- a/code/packages/rust/twig-parser/CHANGELOG.md
+++ b/code/packages/rust/twig-parser/CHANGELOG.md
@@ -41,6 +41,26 @@
   annotation could be parsed, causing "Expected COLON, got '0'" errors on any
   function with a `-> TypeAnnotation` return type.
 
+## [0.1.1] — 2026-05-04
+
+Security hardening — parse-time cap for membership-set cardinality.
+
+### Added
+
+- **`MAX_MEMBERSHIP_INT_VALUES = 256`** public constant.  LANG23 PR 23-E
+  introduces `TypeAnnotation::MembershipInt { values }` which is lowered to
+  an Or-of-Eq predicate by `constraint-core`.  Each value becomes one CNF
+  clause in the SAT tactic; an uncapped list of 10 000+ values would blow
+  the CNF budget added in `constraint-core` 0.1.1 and could stress the LIA
+  tactic equally.  This constant is the canonical upper limit; PR 23-E's
+  `extract_type_annotation` calls `check_membership_int_count` (below) to
+  enforce it at parse time, before any lowering occurs.
+
+- **`check_membership_int_count(count, line, column) -> Result<(), TwigParseError>`**
+  public helper.  Returns `Err` with a descriptive message when `count`
+  exceeds `MAX_MEMBERSHIP_INT_VALUES`.  Re-exported from the crate root
+  alongside `MAX_MEMBERSHIP_INT_VALUES`.
+
 ## [0.1.0] — 2026-04-29
 
 ### Added

--- a/code/packages/rust/twig-parser/src/ast_extract.rs
+++ b/code/packages/rust/twig-parser/src/ast_extract.rs
@@ -52,6 +52,47 @@ use crate::TwigParseError;
 /// typical 2 MiB OS thread stack on macOS.
 pub const MAX_AST_DEPTH: usize = 256;
 
+/// Maximum number of integer values allowed in a `(Member int (...))`
+/// refinement-type annotation.
+///
+/// Each value lowers to one equality predicate in `constraint-core`,
+/// and all equalities are wrapped in an `Or`.  Naive CNF distribution
+/// of an `Or` of N `And`-wrapped equalities is O(2^N); even with the
+/// `MAX_CNF_CLAUSES` ceiling in `constraint-core`, a large membership
+/// set wastes significant work before the budget fires.  Capping at
+/// parse time is the cheapest defence.
+///
+/// 256 is generous for any realistic enum-style refinement (HTTP status
+/// codes, MIDI velocities, small finite domains) while preventing
+/// adversarial blowup.
+pub const MAX_MEMBERSHIP_INT_VALUES: usize = 256;
+
+/// Validate that a `(Member int (...))` annotation contains at most
+/// [`MAX_MEMBERSHIP_INT_VALUES`] values.
+///
+/// Called by the LANG23 PR 23-E annotation extractor before constructing
+/// `TypeAnnotation::MembershipInt { values }`.  Returns a parse error at
+/// `(line, column)` if `count` exceeds the limit.
+pub fn check_membership_int_count(
+    count: usize,
+    line: usize,
+    column: usize,
+) -> Result<(), crate::TwigParseError> {
+    if count > MAX_MEMBERSHIP_INT_VALUES {
+        Err(crate::TwigParseError {
+            message: format!(
+                "(Member ...) annotation has {count} values but the maximum is \
+                 {MAX_MEMBERSHIP_INT_VALUES}; split into smaller membership sets or \
+                 use a Range annotation instead"
+            ),
+            line,
+            column,
+        })
+    } else {
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Token helpers
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/twig-parser/src/lib.rs
+++ b/code/packages/rust/twig-parser/src/lib.rs
@@ -98,7 +98,9 @@ fn twig_parser_grammar() -> &'static ParserGrammar {
     TWIG_PARSER_GRAMMAR.get_or_init(generated_grammar::parser_grammar)
 }
 
-pub use ast_extract::{extract_program, MAX_AST_DEPTH};
+pub use ast_extract::{
+    check_membership_int_count, extract_program, MAX_AST_DEPTH, MAX_MEMBERSHIP_INT_VALUES,
+};
 pub use ast_nodes::{
     Apply, Begin, BoolLit, Define, Expr, Form, If, IntLit, Lambda, Let, NilLit, Program, SymLit,
     TypeAnnotation, VarRef,


### PR DESCRIPTION
## Summary

LANG23 PR 23-E opens a path for user-written Twig refinement annotations to
flow into the constraint solver.  Five latent algorithmic-complexity
vulnerabilities become exploitable once that path exists.  This PR closes all
five before 23-E ships, without touching the 23-E branch.

| # | Crate | Vulnerability | Fix |
|---|-------|---------------|-----|
| 1 | `constraint-core` | `cnf_distribute` exponential blowup — O(2ⁿ) clauses for OR-of-N-ANDs | Budget counter `MAX_CNF_CLAUSES = 10 000`; `to_cnf` returns `Result<Predicate, String>` |
| 2 | `constraint-core` + `constraint-engine` | Deep predicate tree → stack overflow in recursive passes | `depth_of()` with saturating cap; SAT tactic rejects depth > `MAX_PREDICATE_DEPTH = 500` with `Unknown` |
| 3 | `twig-parser` | `(Member int (v1 … vN))` with huge N fans out to N equalities, blowing CNF budget before it fires | `MAX_MEMBERSHIP_INT_VALUES = 256` + `check_membership_int_count()` validator for PR 23-E to call |
| 4 | `constraint-engine` | O(n²) candidate-filter in Cooper's algorithm when many disequality constraints present | `neqs: Vec<i128>` → `HashSet<i128>` for O(1) `.contains()` |
| 5 | `lang-refined-types` | `canonicalise` sorted via `format!("{:?}")` comparison — O(n log n × k) allocations, exploitable with large `Membership` sets | `impl Ord for Predicate` (variant-tag + field-level lexicographic); `parts.sort()` replaces `sort_by(…)` |

## Breaking change

`constraint_core::Predicate::to_cnf()` now returns `Result<Predicate, String>` instead of `Predicate`.  All callers must handle the `Err` case (degrade to `SolverResult::Unknown`).  The only in-tree caller is `constraint-engine/src/sat.rs`, which has been updated.

## Test plan

- [x] `cargo test -p constraint-core` — 46 tests pass, including 4 new DoS-regression tests
- [x] `cargo test -p constraint-engine` — 46 tests pass
- [x] `cargo test -p twig-parser` — 33 tests pass
- [x] `cargo test -p lang-refined-types` — 41 tests pass, including 3 new `canonicalise`/`Ord` tests
- [x] Security review: passed (no findings)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)