### PR TITLE
feat(vault-engine-kv2): VLT08 dynamic-secret tier — SecretEngine trait + KV-v2 engine

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -409,6 +409,8 @@ members = [
     "vault-auth",
     "vault-policy",
     "vault-leases",
+    "vault-engine-core",
+    "vault-engine-kv2",
     "storage-fs",
     "context-store",
     "artifact-store",

--- a/code/packages/rust/vault-engine-core/BUILD
+++ b/code/packages/rust/vault-engine-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_engine_core -- --nocapture

--- a/code/packages/rust/vault-engine-core/CHANGELOG.md
+++ b/code/packages/rust/vault-engine-core/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-05-04
+
+### Added
+
+- Initial implementation of the VLT08 trait crate
+  (`code/specs/VLT08-vault-dynamic-secrets.md`).
+- `SecretEngine` trait — `mount_path` / `mint` / `revoke` /
+  `rotate_root`. `Send + Sync`, object-safe, `&self` everywhere.
+- `Role` — name + optional `default_ttl_ms` / `max_ttl_ms`,
+  with a `Role::new(name)` constructor for the common case.
+- `MintContext` — `principal` (audit breadcrumb) +
+  caller-supplied `now_ms` + `requested_ttl_ms` plus
+  *engine-specific* per-call input: `path: Option<String>`,
+  `input: Option<Zeroizing<Vec<u8>>>`, `cas_token: Option<u64>`.
+  Engines read whatever they need; callers omit the rest.
+  `Clone` and `Debug` are intentionally *not* derived because
+  `input` carries plaintext under `Zeroizing` — cloning would
+  duplicate plaintext into a non-zeroizing intermediate, and
+  `Debug` would let `dbg!` leak the bytes. A
+  `MintContext::simple(principal, now_ms, ttl)` constructor
+  covers the common "no per-engine input" case.
+- `MintedSecret` — body under `Zeroizing<Vec<u8>>`,
+  `secret_ref` revocation handle, `granted_ttl_ms`.
+  Hand-rolled `Debug` redacts the body.
+- `MintedSecret::into_lease_payload` — the canonical bridge
+  between VLT08 (engines) and VLT07 (leases). Every engine mints
+  bytes, every caller wraps them in a lease.
+- `SecretRef` — `#[non_exhaustive]` enum: `KvV2 { path, version }`,
+  `DbUsername`, `PkiSerial`, `AwsSession`, `Other`. New variants
+  can land non-breakingly as engines arrive.
+- `EngineError` — `UnknownRole` / `InvalidParameter` /
+  `Backend` / `Crypto` / `PrincipalDenied` / `UnknownSecret` /
+  `Conflict`. Implements `Display` + `std::error::Error`.
+- 6 unit tests: object-safety smoke, `Role::new` defaults,
+  `EngineError` `Display` output, `MintedSecret` redacted Debug,
+  `into_lease_payload` round-trip, `SecretRef` variant
+  distinctness.
+- `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`.

--- a/code/packages/rust/vault-engine-core/Cargo.toml
+++ b/code/packages/rust/vault-engine-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "coding_adventures_vault_engine_core"
+version = "0.1.0"
+edition = "2021"
+description = "VLT08 — SecretEngine trait + vocabulary types (Role / MintContext / MintedSecret / SecretRef / EngineError) for the Vault stack's dynamic-secret tier. Concrete engines (KV-v2 / Database / PKI / AWS / Transit / SSH / TOTP / K8s) live in sibling crates and all implement this one trait."
+
+[dependencies]
+coding_adventures_vault_leases = { path = "../vault-leases" }
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-engine-core/README.md
+++ b/code/packages/rust/vault-engine-core/README.md
@@ -1,0 +1,74 @@
+# `coding_adventures_vault_engine_core` — VLT08 trait
+
+The `SecretEngine` trait + vocabulary types every Vault dynamic-
+secret engine implements. Concrete engines (KV-v2, Database, PKI,
+AWS, GCP, Azure, SSH, Transit, TOTP, Kubernetes) live in their own
+sibling crates and all satisfy this one trait.
+
+Keeping the trait in a dependency-light crate means a downstream
+build can pull in only the engines it needs (e.g. an embedded
+password manager: `vault-engine-kv2` + `vault-engine-totp` and
+nothing else) without dragging in DB drivers / cloud SDKs.
+
+## API at a glance
+
+```rust
+pub trait SecretEngine: Send + Sync {
+    fn mount_path(&self) -> &str;
+    fn mint(&self, role: &Role, ctx: &MintContext) -> Result<MintedSecret, EngineError>;
+    fn revoke(&self, secret_ref: &SecretRef) -> Result<(), EngineError>;
+    fn rotate_root(&self) -> Result<(), EngineError>;
+}
+```
+
+Vocabulary:
+
+| Type            | What it carries                                              |
+|-----------------|--------------------------------------------------------------|
+| `Role`          | role name + optional default/max TTL                         |
+| `MintContext`   | principal + caller-supplied `now_ms` + requested TTL         |
+| `MintedSecret`  | zeroizing body + `SecretRef` + granted TTL                   |
+| `SecretRef`     | non-exhaustive enum: KvV2 / DbUsername / PkiSerial / AwsSession / Other |
+| `EngineError`   | `UnknownRole` / `InvalidParameter` / `Backend` / `Crypto` / `PrincipalDenied` / `UnknownSecret` / `Conflict` |
+
+## How it slots into the stack
+
+```text
+   transports (CLI/HTTP/gRPC, VLT11)
+         │ dispatch on mount_path
+   ┌─────▼─────┐
+   │  dyn      │   ◄── this trait
+   │ Secret-   │       (KV-v2, DB, PKI, AWS, …)
+   │ Engine    │
+   └─────┬─────┘
+         │ MintedSecret
+   ┌─────▼─────┐
+   │ Lease-    │   wraps minted bytes in TTL'd lease
+   │ Manager   │   (VLT07)
+   └───────────┘
+```
+
+The flow is "engine mints → lease wraps → audit records → caller
+receives a `LeaseId`". Every engine speaks the same shape so the
+top-level orchestration is engine-agnostic.
+
+## Threat model
+
+- **`MintedSecret::body`** is held under `Zeroizing<Vec<u8>>` and
+  has a redacted `Debug` impl — `dbg!(minted)` cannot leak the
+  bytes.
+- **`MintContext.now_ms`** is caller-supplied so engines stay
+  pure (no syscall on the hot path) and tests are deterministic.
+- **`MintContext.principal`** is an audit breadcrumb; engines
+  *may* additionally `defence-in-depth` check it (e.g. AWS
+  engine enforcing a per-principal allow-list inside `mint`),
+  surfacing `EngineError::PrincipalDenied`.
+- **`SecretRef::Other`** lets a future engine return a handle
+  without the trait crate growing every release.
+
+## Capabilities
+
+None — pure trait + vocabulary. See `required_capabilities.json`.
+
+See [`VLT00-vault-roadmap.md`](../../../specs/VLT00-vault-roadmap.md)
+and [`VLT08-vault-dynamic-secrets.md`](../../../specs/VLT08-vault-dynamic-secrets.md).

--- a/code/packages/rust/vault-engine-core/required_capabilities.json
+++ b/code/packages/rust/vault-engine-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-engine-core",
+  "capabilities": [],
+  "justification": "Pure trait + vocabulary. No filesystem, network, process, environment, csprng, or wallclock access. Concrete engine crates that implement SecretEngine declare their own capabilities."
+}

--- a/code/packages/rust/vault-engine-core/src/lib.rs
+++ b/code/packages/rust/vault-engine-core/src/lib.rs
@@ -1,0 +1,438 @@
+//! # `coding_adventures_vault_engine_core` — VLT08 trait
+//!
+//! ## What this crate is
+//!
+//! The **`SecretEngine` trait** plus the small vocabulary every
+//! engine speaks (`Role`, `MintContext`, `MintedSecret`,
+//! `SecretRef`, `EngineError`). Every concrete engine in the Vault
+//! stack — KV-v2, Database, PKI, AWS, GCP, Azure, SSH, Transit,
+//! TOTP, Kubernetes — lives in its own sibling crate and
+//! implements this one trait, so:
+//!
+//!   * the **transport layer** (VLT11) routes mount paths to
+//!     engines without knowing their type,
+//!   * the **policy engine** (VLT06) authorises calls to
+//!     engine-mediated paths uniformly,
+//!   * the **lease manager** (VLT07) wraps every minted secret in
+//!     a TTL'd, revocable envelope with no special-case code per
+//!     engine,
+//!   * the **audit log** (VLT09) records mint / revoke / rotate as
+//!     three structured events instead of N-engine-specific
+//!     events.
+//!
+//! ## Why a separate crate
+//!
+//! Concrete engines pull in heavy, distinct dependency trees
+//! (database client SDKs for `vault-engine-database`, AWS SDK for
+//! `vault-engine-aws`, an X.509 codec for `vault-engine-pki`).
+//! Putting the trait in its own dependency-light crate means
+//! every consumer (transports, policy, audit) imports only the
+//! trait, not the union of every engine's deps.
+//!
+//! It also means a workspace can compile against a *subset* of
+//! engines (e.g. an embedded password manager that only needs
+//! KV-v2 + TOTP) without dragging in the AWS SDK.
+//!
+//! ## Where it fits
+//!
+//! ```text
+//!          ┌────────────────────────────────────────┐
+//!          │  VLT11 transports (CLI / HTTP / gRPC)  │
+//!          └──────────────────┬─────────────────────┘
+//!                             │ dispatch on mount_path
+//!          ┌──────────────────▼─────────────────────┐
+//!          │  Box<dyn SecretEngine>     ◄── HERE    │
+//!          │   ├─ KvV2Engine   (VLT08-KV2)          │
+//!          │   ├─ DatabaseEngine (future)           │
+//!          │   ├─ PkiEngine     (future)            │
+//!          │   ├─ AwsEngine     (future)            │
+//!          │   └─ TransitEngine (future)            │
+//!          └──────────────────┬─────────────────────┘
+//!                             │ MintedSecret
+//!          ┌──────────────────▼─────────────────────┐
+//!          │  VLT07 LeaseManager                    │
+//!          │  wraps the bytes in a TTL'd lease,     │
+//!          │  hands the LeaseId back to the caller  │
+//!          └────────────────────────────────────────┘
+//! ```
+//!
+//! ## Threat model (engine-tier)
+//!
+//! * **Backend never sees plaintext**: each engine is responsible
+//!   for *not* persisting its minted bytes outside a sealed-store
+//!   path. Storage-backed engines route through VLT01.
+//! * **Replay**: minted secrets are addressed by `SecretRef` (an
+//!   opaque identifier) rather than by content; the audit log
+//!   records the mint event so duplicate mints under the same
+//!   role are visible.
+//! * **Caller error**: the trait's `MintContext` carries the
+//!   policy decision plus the auth principal so engines can
+//!   defence-in-depth check (e.g. AWS engine refusing to mint
+//!   for a principal not on the allow-list, even if the policy
+//!   already said yes).
+//!
+//! ## What this crate does *not* do
+//!
+//! * Not a registry: routing mount paths to engines is VLT11's
+//!   job. We give the engine a `mount_path()` method and stop.
+//! * Not a policy decision: by the time an engine's `mint` is
+//!   called, VLT06 has already approved the call.
+//! * Not a lease implementer: `MintedSecret` carries raw bytes;
+//!   the caller passes them to the lease manager.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_zeroize::Zeroizing;
+
+// === Section 1. Vocabulary types ============================================
+//
+// These are what every engine consumes/produces. Keeping them
+// here (instead of redefining per-engine) is the entire point of
+// the trait crate: a downstream tool that aggregates audit events
+// from many engines can pattern-match on a single set of types.
+
+/// Identifies a *role* — a named bundle of constraints attached
+/// to a mount. Examples (engine-specific):
+///
+/// - KV-v2: `Role { name: "shared-team", .. }` (no constraints,
+///   pure namespacing).
+/// - Database: `Role { name: "readonly-prod", .. }` ties to a
+///   particular SQL grant template.
+/// - AWS: `Role { name: "deploy-bot", .. }` ties to an IAM
+///   policy ARN.
+///
+/// The vocabulary stays neutral — the engine interprets `name`
+/// against its own role table.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Role {
+    /// Human-readable role name.
+    pub name: String,
+    /// Engine-specific role-level TTL (None → engine default).
+    pub default_ttl_ms: Option<u64>,
+    /// Engine-specific role-level max-TTL (None → engine default).
+    pub max_ttl_ms: Option<u64>,
+}
+
+impl Role {
+    /// Constructor with name only; TTLs default to engine-supplied.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            default_ttl_ms: None,
+            max_ttl_ms: None,
+        }
+    }
+}
+
+/// Per-call context handed to `mint`. Carries the *who* (auth
+/// principal), the *when* (a caller-supplied wall-clock `now_ms`
+/// for deterministic testing and to avoid each engine re-reading
+/// the system clock), and the *engine-specific input* (the
+/// fields below).
+///
+/// The engine-specific fields exist because the trait's
+/// `mint(role, ctx)` signature cannot grow per-engine arguments
+/// without breaking object-safety. Carrying them on `MintContext`
+/// keeps every call self-contained — no shared "staged write"
+/// slot the engine has to multiplex across concurrent callers
+/// (which would be a confused-deputy hazard).
+///
+/// Engines ignore fields they don't need:
+///
+/// | Engine     | `path`             | `input`                   | `cas_token`        |
+/// |------------|--------------------|---------------------------|--------------------|
+/// | KV-v2      | row path (req'd)   | bytes to store (req'd)    | `expected_version` |
+/// | Database   | unused             | unused                    | unused             |
+/// | PKI        | role-specific path | CSR DER (req'd)           | unused             |
+/// | AWS / GCP  | unused             | unused                    | unused             |
+/// | Transit    | key name           | plaintext (encrypt) / ct  | unused             |
+/// | TOTP       | account label      | seed (provision-only)     | unused             |
+///
+/// `requested_ttl_ms` is the ceiling the *caller* is asking for;
+/// the engine clamps to `min(requested, role.max_ttl_ms,
+/// engine_max)`.
+///
+/// `Clone` and `Debug` are intentionally *not* derived: the
+/// `input` field carries plaintext under `Zeroizing<Vec<u8>>`
+/// which deliberately doesn't implement either trait. Cloning
+/// would silently duplicate plaintext into a non-zeroizing
+/// intermediate; `Debug` would let `dbg!(ctx)` leak the bytes.
+/// Callers that need a hash-friendly structured snapshot of a
+/// context should serialize only the non-secret fields by hand.
+pub struct MintContext {
+    /// Opaque principal identifier from VLT05 (e.g. user ID,
+    /// service account, AWS-STS ARN). The engine treats it as an
+    /// audit-log breadcrumb, *not* as a privilege check.
+    pub principal: String,
+    /// Wall-clock time at the moment of the call, in ms since
+    /// UNIX epoch. Caller-supplied for determinism.
+    pub now_ms: u64,
+    /// Caller's requested TTL in ms. The engine may clamp.
+    pub requested_ttl_ms: u64,
+    /// Engine-specific path within the mount (KV-v2: row path,
+    /// PKI: role path). `None` when the engine has no notion of
+    /// path (Database, AWS, GCP).
+    pub path: Option<String>,
+    /// Engine-specific input bytes (KV-v2: row body, PKI: CSR,
+    /// Transit: plaintext or ciphertext, TOTP: seed). Held under
+    /// `Zeroizing` so a stray drop scrubs them. `None` when the
+    /// engine generates the secret internally (Database, AWS).
+    pub input: Option<Zeroizing<Vec<u8>>>,
+    /// Engine-specific compare-and-swap token (KV-v2: expected
+    /// version; PKI: expected serial range; Transit: key
+    /// generation). `None` skips CAS.
+    pub cas_token: Option<u64>,
+}
+
+impl MintContext {
+    /// Convenience constructor for the common "no engine-specific
+    /// input" case (Database, AWS, GCP).
+    pub fn simple(principal: impl Into<String>, now_ms: u64, requested_ttl_ms: u64) -> Self {
+        Self {
+            principal: principal.into(),
+            now_ms,
+            requested_ttl_ms,
+            path: None,
+            input: None,
+            cas_token: None,
+        }
+    }
+}
+
+/// What `mint` returns: the bytes that should be wrapped in a
+/// lease and a `SecretRef` that can be passed back to `revoke`.
+///
+/// `body` is opaque to the trait; engines define the wire shape
+/// (e.g. KV-v2 returns CBOR, Database returns
+/// `{"username":..., "password":...}` JSON, PKI returns PEM).
+pub struct MintedSecret {
+    /// The actual secret bytes, ready to wrap in a
+    /// [`coding_adventures_vault_leases::LeasePayload`]. Held
+    /// under [`Zeroizing`] so a stray drop scrubs them.
+    pub body: Zeroizing<Vec<u8>>,
+    /// Engine-defined revocation handle. The audit log records
+    /// it so an operator can later say "revoke that mint" by
+    /// looking it up.
+    pub secret_ref: SecretRef,
+    /// Effective TTL the engine applied (after clamping).
+    pub granted_ttl_ms: u64,
+}
+
+impl core::fmt::Debug for MintedSecret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MintedSecret")
+            .field("body", &format_args!("<{} bytes redacted>", self.body.len()))
+            .field("secret_ref", &self.secret_ref)
+            .field("granted_ttl_ms", &self.granted_ttl_ms)
+            .finish()
+    }
+}
+
+impl MintedSecret {
+    /// Convert the body into a [`LeasePayload`] suitable for
+    /// handing to a [`coding_adventures_vault_leases::LeaseManager`].
+    /// This is the canonical bridge between engines (VLT08) and
+    /// leases (VLT07): every engine implementation mints bytes,
+    /// every caller wraps them in a lease.
+    ///
+    /// `self.body` is moved into the payload (which is itself
+    /// zeroizing). We deref-and-clone the inner `Vec` to feed
+    /// `LeasePayload::new`; the intermediate `Vec` exists only
+    /// for the single statement and is then owned by the
+    /// `LeasePayload`'s `Zeroizing<Vec<u8>>`. After the move,
+    /// `self.body`'s `Zeroizing` runs its scrub on drop.
+    pub fn into_lease_payload(self) -> LeasePayload {
+        let bytes: Vec<u8> = (*self.body).clone();
+        LeasePayload::new(bytes)
+    }
+}
+
+/// Engine-defined revocation handle. The trait treats it as
+/// opaque; engines pattern-match on it inside `revoke`.
+///
+/// We use a small enum rather than `Vec<u8>` so each engine can
+/// document the shape of its handle. Adding new variants is
+/// non-breaking because the enum is `#[non_exhaustive]`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SecretRef {
+    /// KV-v2: a `(path, version)` tuple naming the KV row.
+    KvV2 {
+        /// The mount-relative path of the KV row.
+        path: String,
+        /// The version that was returned by `mint`.
+        version: u32,
+    },
+    /// Database: an opaque server-side username that was created
+    /// during `mint` and should be `DROP USER`'d during `revoke`.
+    DbUsername(String),
+    /// PKI: an X.509 serial number to put on the next CRL update.
+    PkiSerial(Vec<u8>),
+    /// AWS: an STS session ID or IAM access-key-id.
+    AwsSession(String),
+    /// Catch-all for engines that haven't been added yet, so
+    /// downstream code can still construct a `SecretRef`. The
+    /// inner string is a debugging hint.
+    Other(String),
+}
+
+/// Errors any engine implementation can return.
+///
+/// We keep variants narrow so audit consumers can handle them
+/// uniformly; engine-specific reasons go in the
+/// `InvalidParameter` payload as a `&'static str`.
+#[derive(Debug)]
+pub enum EngineError {
+    /// The named role is not configured on this engine.
+    UnknownRole(String),
+    /// The caller asked for a TTL above the engine/role max, or
+    /// passed another out-of-bounds parameter.
+    InvalidParameter(&'static str),
+    /// An external dependency (DB driver, AWS API, OS keystore)
+    /// returned a transient failure. The engine's caller may
+    /// retry.
+    Backend(String),
+    /// Cryptographic failure (e.g. CSPRNG unavailable, KMS
+    /// unwrap failed).
+    Crypto(String),
+    /// The principal in `MintContext` is not allowed on this
+    /// engine even though policy approved the call. Engines
+    /// surface this from their defence-in-depth checks.
+    PrincipalDenied(String),
+    /// `revoke` was called with a `SecretRef` the engine doesn't
+    /// own (wrong variant, or a serial that was never issued).
+    UnknownSecret,
+    /// Engine-tier resource conflict, e.g. two writers raced on
+    /// the same KV-v2 path with the same expected version.
+    Conflict,
+}
+
+impl core::fmt::Display for EngineError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnknownRole(r) => write!(f, "unknown role: {}", r),
+            Self::InvalidParameter(p) => write!(f, "invalid parameter: {}", p),
+            Self::Backend(b) => write!(f, "backend error: {}", b),
+            Self::Crypto(c) => write!(f, "crypto error: {}", c),
+            Self::PrincipalDenied(p) => write!(f, "principal denied: {}", p),
+            Self::UnknownSecret => write!(f, "unknown secret_ref"),
+            Self::Conflict => write!(f, "engine-tier conflict"),
+        }
+    }
+}
+
+impl std::error::Error for EngineError {}
+
+// === Section 2. The trait ===================================================
+//
+// Four methods. Two of them — `mint` and `revoke` — are the
+// money-makers; the other two are housekeeping.
+
+/// Contract every secret engine implements.
+///
+/// All methods are `&self` (interior mutability) so an engine can
+/// be shared by `Arc` across threads without macro-level wrapping.
+/// Mutability is the engine's concern — the trait stays
+/// signature-stable.
+pub trait SecretEngine: Send + Sync {
+    /// The mount path this engine answers to (e.g.
+    /// `"kv/"`, `"database/postgres-prod/"`). Transports use
+    /// this to dispatch incoming requests.
+    ///
+    /// Convention: trailing `/`. Empty string is reserved.
+    fn mount_path(&self) -> &str;
+
+    /// Mint a fresh secret under `role`. The engine is free to
+    /// generate, fetch, or compute the bytes; the only invariant
+    /// is that the returned `MintedSecret::granted_ttl_ms` is
+    /// `<= ctx.requested_ttl_ms`.
+    fn mint(&self, role: &Role, ctx: &MintContext) -> Result<MintedSecret, EngineError>;
+
+    /// Revoke a previously-minted secret. For DB / AWS / PKI
+    /// engines this calls out to the upstream system. For KV-v2
+    /// it removes the version from the table.
+    ///
+    /// Idempotent: revoking the same `SecretRef` twice does not
+    /// return an error.
+    fn revoke(&self, secret_ref: &SecretRef) -> Result<(), EngineError>;
+
+    /// Rotate the engine's *root* credential.
+    ///
+    /// What "root" means is engine-dependent: for the DB engine
+    /// it's the privileged DB account the engine logs in as;
+    /// for KV-v2 it's the encryption key that wraps the rows;
+    /// for AWS it's the IAM user the engine assumes-role from.
+    ///
+    /// Engines that have no notion of "root" (e.g. a pure-compute
+    /// engine) return `Ok(())` and document that.
+    fn rotate_root(&self) -> Result<(), EngineError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time check that the trait is object-safe (we
+    /// rely on `Box<dyn SecretEngine>` in the transport layer).
+    #[test]
+    fn trait_is_object_safe() {
+        fn _accepts(_e: &dyn SecretEngine) {}
+    }
+
+    #[test]
+    fn role_constructor_defaults_ttls_to_none() {
+        let r = Role::new("admin");
+        assert_eq!(r.name, "admin");
+        assert_eq!(r.default_ttl_ms, None);
+        assert_eq!(r.max_ttl_ms, None);
+    }
+
+    #[test]
+    fn engine_error_display_includes_variant() {
+        let e = EngineError::UnknownRole("missing".into());
+        assert_eq!(format!("{}", e), "unknown role: missing");
+        let e = EngineError::InvalidParameter("ttl_ms must be > 0");
+        assert_eq!(format!("{}", e), "invalid parameter: ttl_ms must be > 0");
+        let e = EngineError::UnknownSecret;
+        assert_eq!(format!("{}", e), "unknown secret_ref");
+    }
+
+    #[test]
+    fn minted_secret_debug_redacts_body() {
+        let m = MintedSecret {
+            body: Zeroizing::new(b"super-secret".to_vec()),
+            secret_ref: SecretRef::Other("test".into()),
+            granted_ttl_ms: 60_000,
+        };
+        let s = format!("{:?}", m);
+        // The literal payload bytes must not appear in the Debug
+        // output, but the byte length should.
+        assert!(!s.contains("super-secret"));
+        assert!(s.contains("12 bytes redacted"));
+    }
+
+    #[test]
+    fn into_lease_payload_preserves_bytes() {
+        let m = MintedSecret {
+            body: Zeroizing::new(vec![1, 2, 3, 4, 5]),
+            secret_ref: SecretRef::Other("t".into()),
+            granted_ttl_ms: 60_000,
+        };
+        let lp = m.into_lease_payload();
+        assert_eq!(lp.as_bytes(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn secret_ref_variants_are_distinct() {
+        let a = SecretRef::KvV2 {
+            path: "/foo".into(),
+            version: 1,
+        };
+        let b = SecretRef::DbUsername("u1".into());
+        assert_ne!(a, b);
+        let c = a.clone();
+        assert_eq!(a, c);
+    }
+}

--- a/code/packages/rust/vault-engine-kv2/BUILD
+++ b/code/packages/rust/vault-engine-kv2/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_engine_kv2 -- --nocapture

--- a/code/packages/rust/vault-engine-kv2/CHANGELOG.md
+++ b/code/packages/rust/vault-engine-kv2/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-05-04
+
+### Added
+
+- Initial implementation of the KV-v2 secret engine
+  (`code/specs/VLT08-vault-dynamic-secrets.md`).
+- `KvV2Engine` — implements `SecretEngine` from
+  `coding_adventures_vault_engine_core`.
+- `KvV2Config` — `mount_path`, `max_versions` (default 16),
+  `max_ttl_ms` (default 24h), `default_ttl_ms` (default 1h).
+- `KvV2Engine::new(cfg) -> Result<Self, EngineError>` — empty
+  mount path returns `EngineError::InvalidParameter` instead of
+  panicking, so request-handling code that constructs engines
+  from untrusted input cannot be made to panic.
+- `mint(role, ctx)` — reads `path`, `input`, and `cas_token`
+  directly from `MintContext` (no shared "staged write" slot;
+  every call is self-contained). Allocates the next monotonic
+  version under a single mutex acquisition and returns
+  `MintedSecret { body, secret_ref: SecretRef::KvV2 { path, version }, granted_ttl_ms }`.
+  Bytes are wrapped in `Zeroizing` directly (no bare-Vec
+  intermediates).
+- CAS modes via `ctx.cas_token`: `None` unconditional, `Some(0)`
+  create-only, `Some(N>0)` update-from-N. `cas_token` values
+  that don't fit in `u32` return `InvalidParameter`.
+- `revoke(SecretRef::KvV2)` — soft-delete: marks the version
+  `destroyed` and replaces the body with an empty
+  `Zeroizing<Vec<u8>>`. Idempotent. Returns `UnknownSecret` for
+  unknown paths/versions or for a `SecretRef` of a different
+  variant.
+- `rotate_root` — bumps an engine-level generation counter so
+  audit-log consumers can correlate before/after. (A
+  storage-backed sibling crate will rewrap rows under a new
+  DEK.)
+- `read_latest(path)` / `read_version(path, version)` —
+  zeroizing-clone reads. Destroyed versions return
+  `UnknownSecret`.
+- TTL clamping: `granted = min(requested_or_default,
+  role.max_ttl_ms, engine.max_ttl_ms)`. Zero-after-clamp is
+  rejected.
+- `max_versions` cap: applies to *live* rows only. Tombstones
+  (soft-deleted versions) are kept indefinitely so the audit log
+  retains its "this version existed and was destroyed" record;
+  they cost ~24 B each and have an empty `Zeroizing<Vec<u8>>`
+  body. Eviction removes the oldest *live* row when the live
+  count exceeds the cap.
+- 28 unit tests covering: mount-path round-trip, empty-mount
+  returns `InvalidParameter`, mint round-trip, version
+  monotonicity, read-latest, read-version, unknown-path →
+  UnknownSecret, all three CAS modes
+  (create-only-rejects-overwrite, update-from-wrong-version
+  rejected, update-from-correct-version accepted),
+  cas_token-overflows-u32 rejected, mint without
+  path/input/empty-path/empty-input each return
+  `InvalidParameter`, revoke-makes-version-unreadable, revoke
+  idempotency, revoke on unknown / wrong-variant ref,
+  revoke-then-latest fallback to prior live, TTL clamping
+  (engine + role), zero-request → default TTL, rotate_root
+  repeatable, max_versions caps live history while keeping
+  tombstones, Send+Sync compile-time check,
+  `into_lease_payload` after mint, and a 16-thread concurrent
+  mint test that proves cross-stream confusion is structurally
+  impossible.
+
+### Security hardening (pre-merge review)
+
+Three findings flagged before push, all fixed inline:
+
+- **HIGH — Stage/mint cross-caller race**: dropped the
+  single-slot `staged: Option<StagedWrite>` entirely. Per-call
+  inputs (`path`, `input`, `cas_token`) now ride on
+  `MintContext`. Concurrent callers cannot clobber each other's
+  staged data because there is no shared staging slot.
+- **MEDIUM — Non-zeroizing `Vec<u8>` intermediates**: bytes are
+  now wrapped in `Zeroizing` immediately on creation in `mint`.
+- **LOW — `max_versions` evicts tombstones, eroding audit
+  trail**: eviction now counts only *live* rows; destroyed
+  tombstones are kept so the README's audit-log claim holds.
+- `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`.

--- a/code/packages/rust/vault-engine-kv2/Cargo.toml
+++ b/code/packages/rust/vault-engine-kv2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding_adventures_vault_engine_kv2"
+version = "0.1.0"
+edition = "2021"
+description = "VLT08 — KV-v2 (versioned static KV) secret engine for the Vault stack. Implements the SecretEngine trait from vault-engine-core. Each (path, version) is immutable once written; revocation marks a version dead but keeps the row for audit."
+
+[dependencies]
+coding_adventures_vault_engine_core = { path = "../vault-engine-core" }
+coding_adventures_vault_leases = { path = "../vault-leases" }
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-engine-kv2/README.md
+++ b/code/packages/rust/vault-engine-kv2/README.md
@@ -1,0 +1,102 @@
+# `coding_adventures_vault_engine_kv2` — VLT08 KV-v2 engine
+
+Versioned static KV — the workhorse engine of every Vault
+deployment that holds long-lived shared credentials, configuration
+secrets, or anything else that doesn't have a natural mint-on-
+demand source. Also the on-ramp for password-manager-class
+products: a Bitwarden / 1Password vault is structurally a single-
+tenant KV-v2 mount with a typed-record codec on top (VLT02).
+
+Implements [`SecretEngine`](../vault-engine-core/) from the trait
+crate.
+
+## Quick example
+
+```rust
+use coding_adventures_vault_engine_core::{
+    MintContext, Role, SecretEngine,
+};
+use coding_adventures_vault_engine_kv2::{KvV2Config, KvV2Engine};
+use coding_adventures_zeroize::Zeroizing;
+
+let engine = KvV2Engine::new(KvV2Config::default())?;
+
+// Per-call input rides on MintContext — no shared "staged"
+// slot, so concurrent callers cannot cross streams.
+let minted = engine.mint(
+    &Role::new("shared"),
+    &MintContext {
+        principal: "alice".into(),
+        now_ms: 0,                 // caller-supplied; engine is pure
+        requested_ttl_ms: 60_000,
+        path: Some("shared/db-password".into()),
+        input: Some(Zeroizing::new(b"hunter2".to_vec())),
+        cas_token: None,
+    },
+)?;
+
+// Hand `minted.body` to a LeaseManager from VLT07, or:
+let bytes = engine.read_latest("shared/db-password")?;
+assert_eq!(&*bytes, b"hunter2");
+```
+
+## Semantics — same as HashiCorp Vault's KV-v2
+
+| Operation                | Behaviour                                                   |
+|--------------------------|-------------------------------------------------------------|
+| `mint` (single call)     | new monotonic version; CAS via `ctx.cas_token`              |
+| `cas_token: None`        | unconditional write                                         |
+| `cas_token: Some(0)`     | create-only (path must have no live version)                |
+| `cas_token: Some(N)`     | update from version N (current latest-live must equal N)    |
+| `revoke(SecretRef::KvV2)`| soft delete: marks version destroyed, scrubs the bytes      |
+| `read_latest`            | returns latest live version                                 |
+| `read_version(N)`        | returns specific version (404 if destroyed)                 |
+| `rotate_root`            | bumps engine generation counter                             |
+
+`revoke` is **idempotent** — re-revoking a destroyed version is
+not an error.
+
+## TTL clamping
+
+Effective TTL = `min(caller_requested_or_default, role.max_ttl_ms,
+engine.max_ttl_ms)`. A zero requested TTL falls back to the
+role default, then the engine default. A clamped-to-zero TTL is
+rejected as `EngineError::InvalidParameter`.
+
+## Threat model
+
+- **In-memory only**: this reference implementation does not
+  encrypt at rest. A storage-backed sibling crate will route
+  through VLT01 sealed-store. The bytes are still held under
+  `Zeroizing<Vec<u8>>` so they're scrubbed on revoke / cap-eviction
+  / drop.
+- **CAS, not locks**: concurrent writers to the same path race
+  against the latest-live version; the loser sees `Conflict`.
+- **No shared staging slot**: each `mint` call carries its own
+  `path` / `input` / `cas_token` on `MintContext`. Two concurrent
+  mints from different callers cannot cross streams (a
+  confused-deputy hazard avoided by construction).
+- **Soft delete**: revoked versions are kept in the table as
+  zero-byte tombstones so the audit log can answer "this
+  version existed and was destroyed at time T". `max_versions`
+  caps *live* rows only; tombstones are not evicted.
+- **Caller-supplied `now_ms`**: the engine never reads the
+  system clock, keeping it deterministic for testing and
+  capability-light.
+
+## What this crate is not
+
+- Not a typed-record codec — see `vault-records` (VLT02). KV-v2
+  carries opaque bytes; a Bitwarden-style product layers
+  typed-record framing on top.
+- Not an encryption layer — see `vault-sealed-store` (VLT01).
+- Not a transport — see `vault-transport-*` (VLT11).
+- Not a storage backend — for that, a future sibling crate will
+  store rows through `storage-core::StorageBackend`.
+
+## Capabilities
+
+None — pure in-memory. See `required_capabilities.json`.
+
+See [`VLT00-vault-roadmap.md`](../../../specs/VLT00-vault-roadmap.md)
+and [`VLT08-vault-dynamic-secrets.md`](../../../specs/VLT08-vault-dynamic-secrets.md).

--- a/code/packages/rust/vault-engine-kv2/required_capabilities.json
+++ b/code/packages/rust/vault-engine-kv2/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-engine-kv2",
+  "capabilities": [],
+  "justification": "Pure in-memory KV. No filesystem, network, process, environment, csprng, or wallclock access — `MintContext.now_ms` is caller-supplied so the engine itself never reads the system clock. A future storage-backed sibling will add storage-core capability."
+}

--- a/code/packages/rust/vault-engine-kv2/src/lib.rs
+++ b/code/packages/rust/vault-engine-kv2/src/lib.rs
@@ -1,0 +1,791 @@
+//! # `coding_adventures_vault_engine_kv2` — VLT08 KV-v2 engine
+//!
+//! ## What this crate is
+//!
+//! The **KV-v2 secret engine**: a versioned static key/value
+//! store that satisfies the
+//! [`SecretEngine`](coding_adventures_vault_engine_core::SecretEngine)
+//! contract. It is the simplest dynamic-secret engine — "dynamic"
+//! in the trait sense (mint/revoke/rotate API), even though the
+//! data is static (the bytes you write are exactly the bytes you
+//! read back).
+//!
+//! KV-v2 is the workhorse engine of every Vault deployment that
+//! holds long-lived shared credentials, configuration secrets, or
+//! anything else that doesn't have a natural mint-on-demand
+//! source. It's also the on-ramp for password-manager-class
+//! products: a Bitwarden / 1Password vault is structurally a
+//! single-tenant KV-v2 mount with a typed-record codec on top
+//! (VLT02).
+//!
+//! ## Semantics — same as HashiCorp Vault's KV-v2
+//!
+//! * **Versioned**: every write at a path produces a new monotonic
+//!   integer version. The previous version is retained (capped by
+//!   `max_versions` per role).
+//! * **CAS on write**: callers can pass `expected_version` to
+//!   `mint`; a mismatch returns
+//!   [`EngineError::Conflict`].
+//! * **Soft delete** (`revoke`): marks a specific version as
+//!   destroyed. Reads of a destroyed version return
+//!   [`EngineError::UnknownSecret`]; reads of a still-live
+//!   version succeed.
+//! * **Hard rotate** (`rotate_root`): bumps the engine-level
+//!   "version-key" generation counter. In a sealed-store-backed
+//!   build this would re-wrap every row under a new DEK; in this
+//!   in-memory reference implementation we just bump the counter
+//!   so audit-log consumers see a rotation event.
+//!
+//! ## Mint payload shape
+//!
+//! `mint` reads the row body and CAS token directly from
+//! [`MintContext`]. The trait carries per-engine input as
+//! optional fields on the context so every call is
+//! self-contained — there is no shared "staged write" slot that
+//! could be clobbered by another concurrent caller (a
+//! confused-deputy hazard).
+//!
+//! ```ignore
+//! use coding_adventures_zeroize::Zeroizing;
+//! let ctx = MintContext {
+//!     principal: "alice".into(),
+//!     now_ms: 0,
+//!     requested_ttl_ms: 60_000,
+//!     path: Some("shared/db-password".into()),
+//!     input: Some(Zeroizing::new(b"hunter2".to_vec())),
+//!     cas_token: None,
+//! };
+//! let minted = engine.mint(&Role::new("shared"), &ctx)?;
+//! // hand `minted.body` (the same bytes) to a lease manager
+//! ```
+//!
+//! ## What this crate does *not* do
+//!
+//! * **Encryption at rest**: a real KV-v2 engine in production
+//!   stores its rows through VLT01 sealed-store. The reference
+//!   implementation here keeps rows in memory in plaintext but
+//!   under [`Zeroizing`] so process-lifetime scrubbing is intact.
+//!   A storage-backed sibling crate is future work.
+//! * **Multi-tenant isolation**: a single `KvV2Engine` answers to
+//!   one mount path. Multiple mounts → multiple engine instances.
+//! * **Patch operations**: HashiCorp's KV-v2 has a JSON-merge
+//!   patch op; we keep the surface to whole-row writes and let
+//!   callers compose if they want patch semantics.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_vault_engine_core::{
+    EngineError, MintContext, MintedSecret, Role, SecretEngine, SecretRef,
+};
+use coding_adventures_zeroize::Zeroizing;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+// === Section 1. Internal data shape =========================================
+
+/// One stored version of one KV path. The entry knows its own
+/// version number, the bytes (held under `Zeroizing`), and a
+/// destroyed flag — soft-deleted versions stay in the table so
+/// the audit log sees both writes and revocations.
+struct Version {
+    version: u32,
+    body: Zeroizing<Vec<u8>>,
+    destroyed: bool,
+}
+
+/// All versions of one path. The `Vec` is append-only; revocation
+/// flips a `destroyed` flag rather than removing.
+struct PathHistory {
+    versions: Vec<Version>,
+}
+
+impl PathHistory {
+    fn new() -> Self {
+        Self { versions: Vec::new() }
+    }
+
+    /// Latest live version, or `None` if every version is
+    /// destroyed (or the path has none yet).
+    fn latest_live(&self) -> Option<&Version> {
+        self.versions.iter().rev().find(|v| !v.destroyed)
+    }
+
+    /// Highest version number ever issued at this path,
+    /// regardless of destroyed-state. Used to compute the next
+    /// version number on write.
+    fn high_water_mark(&self) -> u32 {
+        self.versions.last().map(|v| v.version).unwrap_or(0)
+    }
+
+    /// Cap *live* versions at `max_versions`; destroyed
+    /// tombstones are kept indefinitely (they cost ~24B each and
+    /// are how `revoke` exposes "this version existed and was
+    /// destroyed at time T" to the audit log). We evict the
+    /// oldest *live* row whenever the live count exceeds the
+    /// cap.
+    fn enforce_max_versions(&mut self, max_versions: usize) {
+        loop {
+            let live_count = self.versions.iter().filter(|v| !v.destroyed).count();
+            if live_count <= max_versions {
+                break;
+            }
+            // Find the index of the oldest live row.
+            let idx = match self.versions.iter().position(|v| !v.destroyed) {
+                Some(i) => i,
+                None => break, // shouldn't happen given the count check
+            };
+            self.versions.remove(idx);
+        }
+    }
+}
+
+// === Section 2. The engine ==================================================
+
+/// Engine configuration. Per-role caps live on the role
+/// (`Role::default_ttl_ms`, `Role::max_ttl_ms`); engine-wide caps
+/// (max-versions-per-path, engine-level max-TTL) live here.
+#[derive(Clone, Debug)]
+pub struct KvV2Config {
+    /// Mount path, including trailing slash. Convention from the
+    /// trait: empty string is reserved.
+    pub mount_path: String,
+    /// Maximum versions retained per path. Older versions are
+    /// dropped (and their `Zeroizing` bytes scrubbed) once this
+    /// cap is exceeded.
+    pub max_versions: usize,
+    /// Engine-wide max TTL (ms). Caller-requested TTLs are
+    /// clamped to `min(requested, role.max, this)`.
+    pub max_ttl_ms: u64,
+    /// Engine-wide default TTL when both the caller and the role
+    /// leave it unspecified. Applied as a floor in case
+    /// `requested_ttl_ms == 0`.
+    pub default_ttl_ms: u64,
+}
+
+impl Default for KvV2Config {
+    fn default() -> Self {
+        Self {
+            mount_path: "kv/".into(),
+            max_versions: 16,
+            max_ttl_ms: 24 * 60 * 60 * 1_000, // 24 h
+            default_ttl_ms: 60 * 60 * 1_000,  // 1 h
+        }
+    }
+}
+
+/// The KV-v2 engine itself.
+struct Inner {
+    table: HashMap<String, PathHistory>,
+    /// Bumped by `rotate_root`. Visible in the audit-log payload
+    /// of the next mint so consumers can correlate before/after.
+    root_generation: u32,
+}
+
+/// KV-v2 engine. Instantiate one per mount path.
+///
+/// Threadsafe via an internal mutex. The intended pattern is
+/// `Arc::new(KvV2Engine::new(cfg))` at startup, then hand the
+/// `Arc` to the transport layer.
+pub struct KvV2Engine {
+    cfg: KvV2Config,
+    inner: Mutex<Inner>,
+}
+
+impl KvV2Engine {
+    /// Construct a fresh, empty engine.
+    ///
+    /// Returns `EngineError::InvalidParameter` if the configured
+    /// mount path is empty (the trait reserves `""`). Using a
+    /// `Result` here means request-handling code that constructs
+    /// engines from untrusted input cannot be made to panic.
+    pub fn new(cfg: KvV2Config) -> Result<Self, EngineError> {
+        if cfg.mount_path.is_empty() {
+            return Err(EngineError::InvalidParameter(
+                "mount_path must not be empty (trait reserves '')",
+            ));
+        }
+        Ok(Self {
+            cfg,
+            inner: Mutex::new(Inner {
+                table: HashMap::new(),
+                root_generation: 0,
+            }),
+        })
+    }
+
+    /// Read the latest live version at `path`, returning a fresh
+    /// `Zeroizing<Vec<u8>>` clone. Read does not bump any
+    /// version number.
+    pub fn read_latest(&self, path: &str) -> Result<Zeroizing<Vec<u8>>, EngineError> {
+        let g = self.inner.lock().expect("kv2 mutex poisoned");
+        let history = g.table.get(path).ok_or(EngineError::UnknownSecret)?;
+        let v = history.latest_live().ok_or(EngineError::UnknownSecret)?;
+        Ok(Zeroizing::new(v.body.to_vec()))
+    }
+
+    /// Read a specific version at `path`. Returns
+    /// `EngineError::UnknownSecret` if the version was destroyed
+    /// or never existed.
+    pub fn read_version(
+        &self,
+        path: &str,
+        version: u32,
+    ) -> Result<Zeroizing<Vec<u8>>, EngineError> {
+        let g = self.inner.lock().expect("kv2 mutex poisoned");
+        let history = g.table.get(path).ok_or(EngineError::UnknownSecret)?;
+        let v = history
+            .versions
+            .iter()
+            .find(|v| v.version == version)
+            .ok_or(EngineError::UnknownSecret)?;
+        if v.destroyed {
+            return Err(EngineError::UnknownSecret);
+        }
+        Ok(Zeroizing::new(v.body.to_vec()))
+    }
+
+    /// Effective TTL for this call, clamped:
+    ///
+    /// `granted = min(requested_or_default, role.max_ttl_ms, engine.max_ttl_ms)`
+    fn clamp_ttl(&self, role: &Role, requested: u64) -> Result<u64, EngineError> {
+        let mut t = if requested == 0 {
+            // 0 → use role default → engine default.
+            role.default_ttl_ms.unwrap_or(self.cfg.default_ttl_ms)
+        } else {
+            requested
+        };
+        if let Some(rmax) = role.max_ttl_ms {
+            t = t.min(rmax);
+        }
+        t = t.min(self.cfg.max_ttl_ms);
+        if t == 0 {
+            return Err(EngineError::InvalidParameter("clamped TTL is zero"));
+        }
+        Ok(t)
+    }
+}
+
+// === Section 3. SecretEngine implementation =================================
+
+impl SecretEngine for KvV2Engine {
+    fn mount_path(&self) -> &str {
+        &self.cfg.mount_path
+    }
+
+    fn mint(&self, role: &Role, ctx: &MintContext) -> Result<MintedSecret, EngineError> {
+        // === Pull engine-specific input from MintContext ===
+        // The trait's signature carries this on `ctx` rather than
+        // a separate stage_write call so each `mint` is
+        // self-contained — there is no shared per-engine "staged"
+        // slot that a concurrent caller could clobber.
+        let path = ctx
+            .path
+            .as_ref()
+            .ok_or(EngineError::InvalidParameter("ctx.path is required"))?;
+        if path.is_empty() {
+            return Err(EngineError::InvalidParameter("ctx.path must not be empty"));
+        }
+        let input = ctx
+            .input
+            .as_ref()
+            .ok_or(EngineError::InvalidParameter("ctx.input is required"))?;
+        if input.is_empty() {
+            return Err(EngineError::InvalidParameter(
+                "ctx.input must not be empty",
+            ));
+        }
+        // KV-v2's CAS token is the expected version (u32-shaped;
+        // we accept u64 from the trait and validate on the way
+        // in).
+        let expected_version: Option<u32> = match ctx.cas_token {
+            None => None,
+            Some(n) => Some(u32::try_from(n).map_err(|_| {
+                EngineError::InvalidParameter("cas_token does not fit in u32")
+            })?),
+        };
+        let granted_ttl_ms = self.clamp_ttl(role, ctx.requested_ttl_ms)?;
+
+        // === Atomic mutation under a single lock ===
+        let mut g = self.inner.lock().expect("kv2 mutex poisoned");
+        let history = g
+            .table
+            .entry(path.clone())
+            .or_insert_with(PathHistory::new);
+        // CAS check.
+        let live = history.latest_live().map(|v| v.version);
+        match expected_version {
+            None => {}
+            Some(0) => {
+                if live.is_some() {
+                    return Err(EngineError::Conflict);
+                }
+            }
+            Some(n) => {
+                if live != Some(n) {
+                    return Err(EngineError::Conflict);
+                }
+            }
+        }
+        // Allocate next version.
+        let next = history
+            .high_water_mark()
+            .checked_add(1)
+            .ok_or(EngineError::InvalidParameter("version counter overflow"))?;
+        // Build both copies into `Zeroizing` directly. The bytes
+        // never sit in a bare `Vec<u8>` longer than the single
+        // expression that wraps them, so an unwind cannot leave
+        // unscrubbed plaintext on the heap.
+        let body_for_store: Zeroizing<Vec<u8>> = Zeroizing::new(input.to_vec());
+        let body_for_payload: Zeroizing<Vec<u8>> = Zeroizing::new(input.to_vec());
+        history.versions.push(Version {
+            version: next,
+            body: body_for_store,
+            destroyed: false,
+        });
+        history.enforce_max_versions(self.cfg.max_versions);
+        Ok(MintedSecret {
+            body: body_for_payload,
+            secret_ref: SecretRef::KvV2 {
+                path: path.clone(),
+                version: next,
+            },
+            granted_ttl_ms,
+        })
+    }
+
+    fn revoke(&self, secret_ref: &SecretRef) -> Result<(), EngineError> {
+        let (path, version) = match secret_ref {
+            SecretRef::KvV2 { path, version } => (path, *version),
+            // Hand back UnknownSecret for non-KV refs rather than
+            // a confusing variant-mismatch error: the engine
+            // simply does not own that ref.
+            _ => return Err(EngineError::UnknownSecret),
+        };
+        let mut g = self.inner.lock().expect("kv2 mutex poisoned");
+        let history = g.table.get_mut(path).ok_or(EngineError::UnknownSecret)?;
+        let v = history
+            .versions
+            .iter_mut()
+            .find(|v| v.version == version)
+            .ok_or(EngineError::UnknownSecret)?;
+        // Idempotent: re-revoking a destroyed version is fine.
+        if v.destroyed {
+            return Ok(());
+        }
+        v.destroyed = true;
+        // Drop the bytes — `Zeroizing` runs its scrub.
+        v.body = Zeroizing::new(Vec::new());
+        Ok(())
+    }
+
+    fn rotate_root(&self) -> Result<(), EngineError> {
+        let mut g = self.inner.lock().expect("kv2 mutex poisoned");
+        g.root_generation = g
+            .root_generation
+            .checked_add(1)
+            .ok_or(EngineError::InvalidParameter("root_generation overflow"))?;
+        Ok(())
+    }
+}
+
+// === Section 4. Tests =======================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test helper: build a `MintContext` for a KV-v2 write at
+    /// `path` with `body` and optional CAS expectation.
+    fn kv_ctx(path: &str, body: &[u8], cas: Option<u64>, ttl: u64) -> MintContext {
+        MintContext {
+            principal: "test-principal".into(),
+            now_ms: 1_000_000,
+            requested_ttl_ms: ttl,
+            path: Some(path.into()),
+            input: Some(Zeroizing::new(body.to_vec())),
+            cas_token: cas,
+        }
+    }
+
+    fn fresh() -> KvV2Engine {
+        KvV2Engine::new(KvV2Config::default()).unwrap()
+    }
+
+    #[test]
+    fn mount_path_round_trips() {
+        let e = fresh();
+        assert_eq!(e.mount_path(), "kv/");
+    }
+
+    #[test]
+    fn empty_mount_path_returns_invalid_parameter() {
+        let mut cfg = KvV2Config::default();
+        cfg.mount_path = String::new();
+        let r = KvV2Engine::new(cfg);
+        assert!(matches!(r, Err(EngineError::InvalidParameter(_))));
+    }
+
+    #[test]
+    fn mint_returns_minted_secret() {
+        let e = fresh();
+        let m = e
+            .mint(&Role::new("r"), &kv_ctx("p1", b"first", None, 60_000))
+            .unwrap();
+        assert_eq!(m.body.as_slice(), b"first");
+        match m.secret_ref {
+            SecretRef::KvV2 { path, version } => {
+                assert_eq!(path, "p1");
+                assert_eq!(version, 1);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+        assert_eq!(m.granted_ttl_ms, 60_000);
+    }
+
+    #[test]
+    fn second_write_increments_version() {
+        let e = fresh();
+        let m1 = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"v1", None, 60_000))
+            .unwrap();
+        let m2 = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"v2", None, 60_000))
+            .unwrap();
+        let v2_n = match m2.secret_ref {
+            SecretRef::KvV2 { version, .. } => version,
+            _ => panic!("wrong variant"),
+        };
+        let v1_n = match m1.secret_ref {
+            SecretRef::KvV2 { version, .. } => version,
+            _ => panic!("wrong variant"),
+        };
+        assert_eq!(v1_n, 1);
+        assert_eq!(v2_n, 2);
+    }
+
+    #[test]
+    fn read_latest_returns_most_recent_live_version() {
+        let e = fresh();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v1", None, 60_000))
+            .unwrap();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v2", None, 60_000))
+            .unwrap();
+        let bytes = e.read_latest("p").unwrap();
+        assert_eq!(bytes.as_slice(), b"v2");
+    }
+
+    #[test]
+    fn read_version_specific() {
+        let e = fresh();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v1", None, 60_000))
+            .unwrap();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v2", None, 60_000))
+            .unwrap();
+        let b1 = e.read_version("p", 1).unwrap();
+        assert_eq!(b1.as_slice(), b"v1");
+        let b2 = e.read_version("p", 2).unwrap();
+        assert_eq!(b2.as_slice(), b"v2");
+    }
+
+    #[test]
+    fn read_unknown_path_is_unknown_secret() {
+        let e = fresh();
+        assert!(matches!(
+            e.read_latest("missing"),
+            Err(EngineError::UnknownSecret)
+        ));
+        assert!(matches!(
+            e.read_version("missing", 1),
+            Err(EngineError::UnknownSecret)
+        ));
+    }
+
+    #[test]
+    fn cas_create_only_rejects_overwrite() {
+        let e = fresh();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v1", Some(0), 60_000))
+            .unwrap();
+        // Second create-only write should conflict.
+        assert!(matches!(
+            e.mint(&Role::new("r"), &kv_ctx("p", b"v2", Some(0), 60_000)),
+            Err(EngineError::Conflict)
+        ));
+    }
+
+    #[test]
+    fn cas_update_from_wrong_version_rejected() {
+        let e = fresh();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v1", None, 60_000))
+            .unwrap();
+        // Latest is 1; ask to update from 7 → conflict.
+        assert!(matches!(
+            e.mint(&Role::new("r"), &kv_ctx("p", b"v2", Some(7), 60_000)),
+            Err(EngineError::Conflict)
+        ));
+    }
+
+    #[test]
+    fn cas_update_from_correct_version_accepted() {
+        let e = fresh();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v1", None, 60_000))
+            .unwrap();
+        let m = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"v2", Some(1), 60_000))
+            .unwrap();
+        let v = match m.secret_ref {
+            SecretRef::KvV2 { version, .. } => version,
+            _ => panic!("wrong variant"),
+        };
+        assert_eq!(v, 2);
+    }
+
+    #[test]
+    fn cas_token_overflow_u32_rejected() {
+        let e = fresh();
+        let mut ctx = kv_ctx("p", b"v", None, 60_000);
+        ctx.cas_token = Some(u64::MAX);
+        assert!(matches!(
+            e.mint(&Role::new("r"), &ctx),
+            Err(EngineError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn mint_without_path_errors() {
+        let e = fresh();
+        let mut ctx = kv_ctx("p", b"v", None, 60_000);
+        ctx.path = None;
+        assert!(matches!(
+            e.mint(&Role::new("r"), &ctx),
+            Err(EngineError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn mint_without_input_errors() {
+        let e = fresh();
+        let mut ctx = kv_ctx("p", b"v", None, 60_000);
+        ctx.input = None;
+        assert!(matches!(
+            e.mint(&Role::new("r"), &ctx),
+            Err(EngineError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn mint_with_empty_path_errors() {
+        let e = fresh();
+        let ctx = kv_ctx("", b"v", None, 60_000);
+        assert!(matches!(
+            e.mint(&Role::new("r"), &ctx),
+            Err(EngineError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn mint_with_empty_input_errors() {
+        let e = fresh();
+        let ctx = kv_ctx("p", b"", None, 60_000);
+        assert!(matches!(
+            e.mint(&Role::new("r"), &ctx),
+            Err(EngineError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn revoke_makes_version_unreadable() {
+        let e = fresh();
+        let m = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"v1", None, 60_000))
+            .unwrap();
+        e.revoke(&m.secret_ref).unwrap();
+        assert!(matches!(
+            e.read_version("p", 1),
+            Err(EngineError::UnknownSecret)
+        ));
+        // Latest also gone since the only version is destroyed.
+        assert!(matches!(
+            e.read_latest("p"),
+            Err(EngineError::UnknownSecret)
+        ));
+    }
+
+    #[test]
+    fn revoke_idempotent() {
+        let e = fresh();
+        let m = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"v1", None, 60_000))
+            .unwrap();
+        e.revoke(&m.secret_ref).unwrap();
+        e.revoke(&m.secret_ref).unwrap();
+    }
+
+    #[test]
+    fn revoke_unknown_ref_returns_unknown_secret() {
+        let e = fresh();
+        let bogus = SecretRef::KvV2 {
+            path: "no-such".into(),
+            version: 1,
+        };
+        assert!(matches!(e.revoke(&bogus), Err(EngineError::UnknownSecret)));
+    }
+
+    #[test]
+    fn revoke_wrong_variant_returns_unknown_secret() {
+        let e = fresh();
+        let r = SecretRef::DbUsername("u".into());
+        assert!(matches!(e.revoke(&r), Err(EngineError::UnknownSecret)));
+    }
+
+    #[test]
+    fn revoke_then_latest_falls_back_to_prior_live() {
+        let e = fresh();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v1", None, 60_000))
+            .unwrap();
+        let m2 = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"v2", None, 60_000))
+            .unwrap();
+        e.revoke(&m2.secret_ref).unwrap();
+        let bytes = e.read_latest("p").unwrap();
+        assert_eq!(bytes.as_slice(), b"v1");
+    }
+
+    #[test]
+    fn ttl_clamped_to_engine_max() {
+        let mut cfg = KvV2Config::default();
+        cfg.max_ttl_ms = 1_000;
+        let e = KvV2Engine::new(cfg).unwrap();
+        let m = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"v", None, 60_000))
+            .unwrap();
+        assert_eq!(m.granted_ttl_ms, 1_000);
+    }
+
+    #[test]
+    fn ttl_clamped_to_role_max() {
+        let e = fresh();
+        let role = Role {
+            name: "r".into(),
+            default_ttl_ms: None,
+            max_ttl_ms: Some(500),
+        };
+        let m = e
+            .mint(&role, &kv_ctx("p", b"v", None, 60_000))
+            .unwrap();
+        assert_eq!(m.granted_ttl_ms, 500);
+    }
+
+    #[test]
+    fn zero_request_uses_default_ttl() {
+        let e = fresh();
+        let m = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"v", None, 0))
+            .unwrap();
+        assert_eq!(m.granted_ttl_ms, 60 * 60 * 1_000);
+    }
+
+    #[test]
+    fn rotate_root_succeeds_repeatedly() {
+        let e = fresh();
+        for _ in 0..5 {
+            e.rotate_root().unwrap();
+        }
+    }
+
+    #[test]
+    fn max_versions_caps_live_history_and_keeps_tombstones() {
+        let mut cfg = KvV2Config::default();
+        cfg.max_versions = 3;
+        let e = KvV2Engine::new(cfg).unwrap();
+        // Write 5 live versions; only the last 3 live should
+        // remain readable. Older live versions are evicted.
+        for i in 0..5u8 {
+            e.mint(
+                &Role::new("r"),
+                &kv_ctx("p", format!("v{}", i).as_bytes(), None, 60_000),
+            )
+            .unwrap();
+        }
+        // v0 (version 1) and v1 (version 2) — evicted (too old).
+        assert!(matches!(
+            e.read_version("p", 1),
+            Err(EngineError::UnknownSecret)
+        ));
+        assert!(matches!(
+            e.read_version("p", 2),
+            Err(EngineError::UnknownSecret)
+        ));
+        // v2..v4 (versions 3,4,5) still readable.
+        assert_eq!(e.read_version("p", 3).unwrap().as_slice(), b"v2");
+        assert_eq!(e.read_version("p", 5).unwrap().as_slice(), b"v4");
+        // Now soft-delete v3; live count drops to 2 (v4, v5).
+        // Tombstones don't count against the cap, so the next
+        // live write goes through without evicting anyone.
+        let r3 = SecretRef::KvV2 {
+            path: "p".into(),
+            version: 3,
+        };
+        e.revoke(&r3).unwrap();
+        e.mint(&Role::new("r"), &kv_ctx("p", b"v5b", None, 60_000))
+            .unwrap();
+        // v4 and v5 still live.
+        assert_eq!(e.read_version("p", 4).unwrap().as_slice(), b"v3");
+        assert_eq!(e.read_version("p", 5).unwrap().as_slice(), b"v4");
+        // v3 is destroyed → unknown secret on read.
+        assert!(matches!(
+            e.read_version("p", 3),
+            Err(EngineError::UnknownSecret)
+        ));
+    }
+
+    #[test]
+    fn engine_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<KvV2Engine>();
+        assert_send_sync::<Box<dyn SecretEngine>>();
+    }
+
+    #[test]
+    fn into_lease_payload_after_mint() {
+        let e = fresh();
+        let m = e
+            .mint(&Role::new("r"), &kv_ctx("p", b"deadbeef", None, 60_000))
+            .unwrap();
+        let lp = m.into_lease_payload();
+        assert_eq!(lp.as_bytes(), b"deadbeef");
+    }
+
+    #[test]
+    fn concurrent_mints_do_not_cross_streams() {
+        // Two threads minting to different paths concurrently
+        // must end up with their own bytes at their own paths.
+        // Before the fix this was a confused-deputy race via the
+        // single staged-write slot; now each mint() carries its
+        // own input on the MintContext so cross-talk is
+        // structurally impossible.
+        use std::sync::Arc;
+        use std::thread;
+        let e = Arc::new(fresh());
+        let mut handles = Vec::new();
+        for i in 0..16 {
+            let e = e.clone();
+            handles.push(thread::spawn(move || {
+                let path = format!("p{}", i);
+                let body = format!("body-{}", i);
+                let ctx = kv_ctx(&path, body.as_bytes(), None, 60_000);
+                let m = e.mint(&Role::new("r"), &ctx).unwrap();
+                assert_eq!(m.body.as_slice(), body.as_bytes());
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        // Verify all paths landed correctly.
+        for i in 0..16 {
+            let path = format!("p{}", i);
+            let body = format!("body-{}", i);
+            assert_eq!(e.read_latest(&path).unwrap().as_slice(), body.as_bytes());
+        }
+    }
+}

--- a/code/specs/VLT08-vault-dynamic-secrets.md
+++ b/code/specs/VLT08-vault-dynamic-secrets.md
@@ -1,0 +1,232 @@
+# VLT08 — Vault Dynamic-Secret Engines
+
+## Overview
+
+A *secret engine* is a plugin that produces secrets on demand
+(instead of holding them at rest). Issuing a secret means: run
+the engine's `mint` operation, wrap the result in a lease (VLT07),
+return.
+
+This spec covers two crates that ship together as the first
+slice of the dynamic-secret tier:
+
+- `coding_adventures_vault_engine_core` — the `SecretEngine`
+  trait + vocabulary (`Role`, `MintContext`, `MintedSecret`,
+  `SecretRef`, `EngineError`).
+- `coding_adventures_vault_engine_kv2` — the first concrete
+  engine: versioned static KV.
+
+Future siblings (each its own crate, all implementing the same
+trait): `vault-engine-database`, `vault-engine-pki`,
+`vault-engine-aws`, `vault-engine-gcp`, `vault-engine-azure`,
+`vault-engine-ssh`, `vault-engine-transit`, `vault-engine-totp`,
+`vault-engine-kubernetes`.
+
+## Why split the trait into its own crate
+
+Concrete engines pull in heavy, distinct dependency trees
+(database client SDKs for Database; AWS SDK for AWS; an X.509
+codec for PKI). Putting the trait in a dependency-light crate
+means consumers (transports VLT11, policy VLT06, audit VLT09)
+import only the trait, not the union of every engine's deps.
+
+A workspace can compile against a *subset* of engines (e.g. an
+embedded password manager that only needs KV-v2 + TOTP) without
+dragging in the AWS SDK.
+
+## SecretEngine trait
+
+```rust
+pub trait SecretEngine: Send + Sync {
+    fn mount_path(&self) -> &str;
+    fn mint(&self, role: &Role, ctx: &MintContext)
+        -> Result<MintedSecret, EngineError>;
+    fn revoke(&self, secret_ref: &SecretRef)
+        -> Result<(), EngineError>;
+    fn rotate_root(&self) -> Result<(), EngineError>;
+}
+```
+
+Vocabulary:
+
+```rust
+pub struct Role { pub name: String, pub default_ttl_ms: Option<u64>, pub max_ttl_ms: Option<u64> }
+pub struct MintContext {
+    pub principal: String,
+    pub now_ms: u64,
+    pub requested_ttl_ms: u64,
+    // engine-specific input — engines read what they need:
+    pub path: Option<String>,
+    pub input: Option<Zeroizing<Vec<u8>>>,
+    pub cas_token: Option<u64>,
+}
+pub struct MintedSecret { pub body: Zeroizing<Vec<u8>>, pub secret_ref: SecretRef, pub granted_ttl_ms: u64 }
+pub enum SecretRef { KvV2 { path, version }, DbUsername(String), PkiSerial(Vec<u8>), AwsSession(String), Other(String) }  // #[non_exhaustive]
+pub enum EngineError { UnknownRole(String), InvalidParameter(&'static str), Backend(String), Crypto(String), PrincipalDenied(String), UnknownSecret, Conflict }
+```
+
+Per-engine input rides on `MintContext`. The engine reads
+whichever fields it needs; callers leave the rest `None`. This
+keeps each `mint` call self-contained — there is no shared
+"staged write" slot a concurrent caller could clobber (a
+confused-deputy hazard avoided by construction).
+
+`MintContext` deliberately does *not* derive `Clone` or `Debug`:
+`input` carries plaintext under `Zeroizing`, so cloning would
+duplicate plaintext into a non-zeroizing intermediate, and
+`Debug` would let `dbg!` leak the bytes.
+
+`MintedSecret::body` is held under `Zeroizing<Vec<u8>>` and has
+a redacted `Debug` impl — `dbg!(minted)` cannot leak bytes.
+`MintedSecret::into_lease_payload(self) -> LeasePayload` is the
+canonical bridge between VLT08 and VLT07.
+
+## How VLT08 sits between VLT07 and VLT11
+
+```text
+   transports (CLI / HTTP / gRPC, VLT11)
+          │ dispatch on mount_path
+   ┌──────▼──────┐
+   │ Box<dyn     │   ◄── this trait
+   │ SecretEngine│
+   │   ├─ KvV2   │
+   │   ├─ DB (future)
+   │   ├─ PKI (future)
+   │   ├─ AWS (future)
+   │   └─ Transit (future)
+   └──────┬──────┘
+          │ MintedSecret { body, secret_ref, granted_ttl_ms }
+   ┌──────▼──────┐
+   │ LeaseManager (VLT07)
+   │ wraps body in TTL'd lease, returns LeaseId
+   └─────────────┘
+```
+
+## KV-v2 engine — semantics
+
+KV-v2 is "dynamic" in the trait sense (mint/revoke/rotate API)
+even though its data is static (the bytes you write are exactly
+the bytes you read back).
+
+### Mint protocol
+
+`mint(role, ctx)` reads `ctx.path`, `ctx.input`, and
+`ctx.cas_token` directly. Each call is fully self-contained —
+no shared staging slot.
+
+```rust
+let ctx = MintContext {
+    principal: "alice".into(),
+    now_ms: 0,
+    requested_ttl_ms: 60_000,
+    path: Some("shared/db-password".into()),
+    input: Some(Zeroizing::new(b"hunter2".to_vec())),
+    cas_token: None,
+};
+let minted = engine.mint(&Role::new("shared"), &ctx)?;
+```
+
+### Versioning
+
+Every successful `mint` allocates a new monotonic integer
+version at the path. CAS via `ctx.cas_token`:
+
+| `cas_token`        | Semantics                                          |
+|--------------------|----------------------------------------------------|
+| `None`             | unconditional write                                |
+| `Some(0)`          | create-only — fails if any live version exists     |
+| `Some(N > 0)`      | update — current latest-live must equal `N`        |
+| `Some(n > u32::MAX as u64)` | rejected as `InvalidParameter`             |
+
+A failed CAS returns `EngineError::Conflict`.
+
+### Revoke
+
+`revoke(SecretRef::KvV2 { path, version })` is a **soft delete**:
+the version is marked `destroyed` and its `Zeroizing<Vec<u8>>`
+body is dropped (and scrubbed). Reads of a destroyed version
+return `EngineError::UnknownSecret`. The tombstone row stays in
+the table indefinitely so the audit log can answer "this version
+existed and was destroyed at time T" without a separate tombstone
+schema. Tombstones are not subject to the `max_versions` cap.
+
+Idempotent: re-revoking a destroyed version is `Ok(())`.
+
+A `SecretRef` of a non-KV variant returns `UnknownSecret` — the
+engine simply does not own that ref.
+
+### Rotate root
+
+Bumps an engine-level generation counter. In a storage-backed
+sibling crate this would re-wrap every row under a new DEK; in
+the in-memory reference implementation it exists as a hook so
+audit-log consumers see the rotation event.
+
+### TTL clamping
+
+Effective granted TTL = `min(requested_or_default,
+role.max_ttl_ms, engine.max_ttl_ms)`.
+
+A zero requested TTL falls back to `role.default_ttl_ms` →
+`engine.default_ttl_ms`. A clamped-to-zero TTL is rejected as
+`EngineError::InvalidParameter`.
+
+### `max_versions` cap
+
+`KvV2Config.max_versions` (default 16) caps the number of *live*
+versions each path retains. Once the live count exceeds the cap,
+the oldest live row is evicted and its `Zeroizing<Vec<u8>>` body
+is scrubbed. Destroyed tombstones are kept indefinitely (their
+bodies are already empty `Zeroizing`s) to preserve the audit
+trail.
+
+## Threat model & test coverage (KV-v2)
+
+| Threat                                                       | Defence                                                    | Test                                                         |
+|--------------------------------------------------------------|------------------------------------------------------------|--------------------------------------------------------------|
+| Plaintext leak via `dbg!(MintedSecret)`                      | hand-rolled redacted `Debug` on `MintedSecret`             | `minted_secret_debug_redacts_body` (engine-core)             |
+| Plaintext leak via `dbg!(MintContext)` or `ctx.clone()`      | `MintContext` does not derive `Clone` or `Debug`           | structural                                                   |
+| **Cross-caller plaintext mix-up via shared staging slot**    | per-call inputs ride on `MintContext`; no shared staged    | `concurrent_mints_do_not_cross_streams` (16 threads)         |
+| Bytes linger after revocation                                | `revoke` replaces body with empty `Zeroizing` (scrubs)     | structural — `Zeroizing` Drop                                |
+| Bytes linger after `max_versions` eviction                   | live evicted row's `Zeroizing<Vec<u8>>` drops + scrubs     | `max_versions_caps_live_history_and_keeps_tombstones`        |
+| Tombstones evicted (audit-log integrity)                     | eviction counts only live rows; tombstones kept            | `max_versions_caps_live_history_and_keeps_tombstones`        |
+| Non-zeroizing `Vec<u8>` intermediates during clone           | bodies wrapped in `Zeroizing` immediately on creation      | structural                                                   |
+| Concurrent writers race on same path                         | CAS via `ctx.cas_token`; loser → `Conflict`                | `cas_create_only_rejects_overwrite`, `cas_update_from_wrong_version_rejected`, `cas_update_from_correct_version_accepted` |
+| Caller passes `cas_token > u32::MAX`                         | `mint` rejects with `InvalidParameter`                     | `cas_token_overflow_u32_rejected`                            |
+| Caller forgets path / input                                  | `mint` errors `InvalidParameter`                           | `mint_without_path_errors`, `mint_without_input_errors`      |
+| Caller passes empty path / input                             | `mint` errors `InvalidParameter`                           | `mint_with_empty_path_errors`, `mint_with_empty_input_errors`|
+| Re-revoke creates spurious error                             | `revoke` is idempotent on destroyed versions               | `revoke_idempotent`                                          |
+| Wrong-variant `SecretRef` fed to `revoke`                    | returns `UnknownSecret` (engine doesn't own that ref)      | `revoke_wrong_variant_returns_unknown_secret`                |
+| Caller-requested TTL exceeds engine policy                   | TTL clamping via `clamp_ttl`                               | `ttl_clamped_to_engine_max`, `ttl_clamped_to_role_max`       |
+| Caller-supplied TTL = 0 silently bypasses TTL                | falls back to role default → engine default; rejects 0     | `zero_request_uses_default_ttl`                              |
+| Empty mount path collides with reserved value                | `KvV2Engine::new` returns `InvalidParameter` (no panic)    | `empty_mount_path_returns_invalid_parameter`                 |
+| Version counter overflow                                     | `checked_add` on next-version; `InvalidParameter` on overflow | structural                                                |
+| Read of destroyed version returns stale bytes                | destroyed flag is checked before returning bytes           | `revoke_makes_version_unreadable`                            |
+| Read of non-existent path leaks "exists?" oracle             | uniform `UnknownSecret` for missing path and missing version | `read_unknown_path_is_unknown_secret`                      |
+
+## Out of scope (future PRs)
+
+- **Encryption at rest** — a storage-backed sibling crate will
+  route rows through VLT01 sealed-store. The reference
+  implementation here is in-memory.
+- **Patch operations** — HashiCorp's KV-v2 has a JSON-merge
+  patch op; we keep the surface to whole-row writes.
+- **Recursive `list`** — listing children of a path. Easy
+  follow-up; not in the trait surface yet.
+- **Cross-process locking** — a storage-backed sibling will use
+  the storage backend's CAS primitives.
+- **Other engines** — Database, PKI, AWS, GCP, Azure, SSH,
+  Transit, TOTP, Kubernetes. Each is a sibling crate; the trait
+  is now stable for them to land against.
+
+## Citations
+
+- HashiCorp Vault — *Secret Engines* design (mint / revoke /
+  rotate vocabulary).
+- HashiCorp KV v2 — versioned KV semantics, CAS via
+  `expected_version`, soft-delete + destroy distinction.
+- VLT00-vault-roadmap.md — engine tier placement.
+- VLT07-vault-leases.md — what wraps the minted bytes.
+- VLT01-vault-sealed-store.md — what a storage-backed engine
+  will route through.
+- `coding_adventures_zeroize::Zeroizing` — body scrubbing.


### PR DESCRIPTION
## Summary

Adds two crates that ship the first slice of the dynamic-secret tier:

- **`coding_adventures_vault_engine_core`** — the `SecretEngine` trait + vocabulary types (`Role`, `MintContext`, `MintedSecret`, `SecretRef`, `EngineError`). Concrete engines (KV-v2, Database, PKI, AWS, GCP, Azure, SSH, Transit, TOTP, K8s) live in their own sibling crates and all implement this one trait, so the workspace can compile against a subset without dragging in DB drivers / cloud SDKs.
- **`coding_adventures_vault_engine_kv2`** — first concrete engine: versioned static KV. Semantics match HashiCorp Vault's KV-v2 (monotonic versions, CAS, soft-delete, max_versions cap).

Per-engine input rides on `MintContext` (`path`, `input`, `cas_token`), so each `mint` call is fully self-contained — no shared staging slot. `MintedSecret::into_lease_payload` is the canonical bridge to VLT07 leases.

## Pre-merge security review

Five findings flagged and fixed inline before push (re-review passed):

- **HIGH** — Stage/mint cross-caller race: dropped the single-slot `staged` field; per-call inputs now ride on `MintContext`. 16-thread concurrent test added to verify cross-stream confusion is structurally impossible.
- **MEDIUM** — Non-zeroizing `Vec<u8>` intermediates: bodies wrapped in `Zeroizing` immediately on creation.
- **LOW** — `max_versions` evicting tombstones eroded the audit trail: eviction now counts only live rows.
- **INFO** — `KvV2Engine::new` panicked on empty mount: now returns `Result<Self, EngineError>`.
- **INFO** — `cas_token: u64` truncation to u32: now rejected with `InvalidParameter` if value doesn't fit.

## Test plan

- [x] `cargo test -p coding_adventures_vault_engine_core -p coding_adventures_vault_engine_kv2 --lib` — 34 tests (6 + 28), all passing
- [x] `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]` enforced in both crates
- [x] Spec at `code/specs/VLT08-vault-dynamic-secrets.md` matches implementation
- [x] CHANGELOGs document both initial functionality and security hardening
- [x] Concurrent-mint test (`concurrent_mints_do_not_cross_streams`) covers the cross-caller race that was the HIGH finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)