### PR TITLE
Wrap bare table columns in colgroups

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -30,3 +30,5 @@ documented in this file.
 - Table caption and column-group boundary recovery so captions/colgroups close
   before following rows, cells, and table sections in the lightweight DOM tree
   builder.
+- Implied `colgroup` creation for bare `col` elements under tables, keeping
+  column metadata grouped before following row sections.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -15,6 +15,7 @@ This first slice intentionally starts small:
 - adjacent text merging
 - implied document shell creation for omitted `html`, `head`, and `body`
 - implied table `tbody` and `tr` creation for common omitted table structure
+- implied table `colgroup` creation for bare `col` elements
 - table caption/column-group boundary recovery before rows and sections
 - parser-controlled lexer handoff for `title`, `textarea`, RAWTEXT elements,
   `script`, and `plaintext`

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -326,6 +326,11 @@ impl HtmlParser {
                 self.pop_table_cell_row_and_section_contexts();
                 self.pop_current_if(|name| name == "caption" || name == "colgroup");
             }
+            "col" => {
+                if self.current_element_is("table") {
+                    self.append_implied_element("colgroup");
+                }
+            }
             "tr" => {
                 self.pop_current_if(|name| name == "td" || name == "th");
                 self.pop_current_if(|name| name == "tr");
@@ -788,6 +793,25 @@ mod tests {
             element(&element(&tbody.children[0]).children[0]).children,
             vec![Node::text("B")]
         );
+    }
+
+    #[test]
+    fn wraps_bare_table_columns_in_implied_colgroup() {
+        let document = parse_html("<table><col span=2><col><tr><td>A</table>").unwrap();
+
+        let table = element(&body(&document).children[0]);
+        assert_eq!(table.children.len(), 2);
+
+        let colgroup = element(&table.children[0]);
+        assert_eq!(colgroup.name, "colgroup");
+        assert_eq!(colgroup.children.len(), 2);
+        assert_eq!(element(&colgroup.children[0]).name, "col");
+        assert_eq!(element(&colgroup.children[0]).attribute("span"), Some("2"));
+        assert_eq!(element(&colgroup.children[1]).name, "col");
+
+        let tbody = element(&table.children[1]);
+        let row = element(&tbody.children[0]);
+        assert_eq!(element(&row.children[0]).children, vec![Node::text("A")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add parser table recovery for bare col elements by creating an implied colgroup under the current table.
- Keep consecutive bare columns grouped before following row-section recovery.
- Document the new lightweight table tree-construction behavior.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check