### PR TITLE
Reconsume unexpected solidus in start tags

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -190,6 +190,9 @@ documented in this file.
   after reporting EOF-in-tag diagnostics.
 - EOF inside attribute character-reference substates now also drops the partial
   start tag after preserving the relevant reference diagnostics.
+- Unexpected solidus recovery in start tags now reconsumes in
+  `before_attribute_name`, preserving attributes after malformed slash-space or
+  slash-NULL sequences.
 - Added a WHATWG operator/shape named-reference batch covering circled
   operators, integrals, products, squares, lozenges, stars, suits, and symbols.
 - Added a WHATWG box-drawing named-reference batch covering double-line,

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -76,6 +76,10 @@ reporting `absence-of-digits-in-numeric-character-reference`.
 Duplicate attributes recover with HTML semantics: the first attribute value is
 kept, later attributes with the same interpreted name are dropped, and a
 `duplicate-attribute` diagnostic is recorded.
+Unexpected solidus recovery inside start tags now reconsumes in
+`before_attribute_name`, so malformed inputs such as `<img/ src=x>` skip the
+space normally and continue parsing later attributes instead of folding the
+separator into an attribute name.
 Unquoted attribute values also preserve spec-defined unexpected characters
 such as `"`, `'`, `<`, `=`, and `` ` `` while reporting
 `unexpected-character-in-unquoted-attribute-value`.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -5105,11 +5105,10 @@ actions = [
 [[transitions]]
 from = "self_closing_start_tag"
 matcher = { anything = true }
-to = "attribute_name"
+to = "before_attribute_name"
+consume = false
 actions = [
   "parse_error(unexpected-solidus-in-tag)",
-  "start_attribute",
-  "append_attribute_name(current_lowercase)",
 ]
 
 [[transitions]]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -10897,17 +10897,15 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "attribute_name".to_string(),
+                "before_attribute_name".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(unexpected-solidus-in-tag)".to_string(),
-                "start_attribute".to_string(),
-                "append_attribute_name(current_lowercase)".to_string(),
             ],
-            consume: true,
+            consume: false,
         },
         TransitionDefinition {
             from: "markup_declaration_open".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -167,6 +167,58 @@ fn default_html_lexer_treats_form_feed_as_tag_whitespace() {
 }
 
 #[test]
+fn default_html_lexer_reconsumes_unexpected_solidus_before_attributes() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<img/ src=one><br//><hr/\0=x>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "img".to_string(),
+                attributes: vec![Attribute {
+                    name: "src".to_string(),
+                    value: "one".to_string(),
+                }],
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "br".to_string(),
+                attributes: Vec::new(),
+                self_closing: true,
+            },
+            Token::StartTag {
+                name: "hr".to_string(),
+                attributes: vec![Attribute {
+                    name: "\u{FFFD}".to_string(),
+                    value: "x".to_string(),
+                }],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-solidus-in-tag")
+            .count(),
+        3
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-null-character")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn default_html_lexer_normalizes_carriage_return_newlines() {
     let tokens = lex_html("<p\r\nclass=x>one\rtwo\r\nthree</p>").unwrap();
 


### PR DESCRIPTION
## Summary
- Reconsume unexpected characters after a start-tag solidus in before_attribute_name instead of consuming them as attribute-name data.
- Preserve attributes after malformed slash-space and slash-NULL sequences while keeping duplicate slash self-closing recovery intact.
- Document the tokenizer recovery behavior and add direct lexer coverage.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check