### PR TITLE
Close captions before bare table columns

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -32,3 +32,5 @@ documented in this file.
   builder.
 - Implied `colgroup` creation for bare `col` elements under tables, keeping
   column metadata grouped before following row sections.
+- Caption boundary recovery before bare `col` elements, so captions close
+  before implied column groups are created.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -16,7 +16,8 @@ This first slice intentionally starts small:
 - implied document shell creation for omitted `html`, `head`, and `body`
 - implied table `tbody` and `tr` creation for common omitted table structure
 - implied table `colgroup` creation for bare `col` elements
-- table caption/column-group boundary recovery before rows and sections
+- table caption/column-group boundary recovery before bare columns, rows, and
+  sections
 - parser-controlled lexer handoff for `title`, `textarea`, RAWTEXT elements,
   `script`, and `plaintext`
 - parser options for scripting-sensitive tokenizer handoff, including

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -327,6 +327,7 @@ impl HtmlParser {
                 self.pop_current_if(|name| name == "caption" || name == "colgroup");
             }
             "col" => {
+                self.pop_current_if(|name| name == "caption");
                 if self.current_element_is("table") {
                     self.append_implied_element("colgroup");
                 }
@@ -810,6 +811,27 @@ mod tests {
         assert_eq!(element(&colgroup.children[1]).name, "col");
 
         let tbody = element(&table.children[1]);
+        let row = element(&tbody.children[0]);
+        assert_eq!(element(&row.children[0]).children, vec![Node::text("A")]);
+    }
+
+    #[test]
+    fn closes_caption_before_bare_table_columns() {
+        let document = parse_html("<table><caption>Cap<col><tr><td>A</table>").unwrap();
+
+        let table = element(&body(&document).children[0]);
+        assert_eq!(table.children.len(), 3);
+
+        let caption = element(&table.children[0]);
+        assert_eq!(caption.name, "caption");
+        assert_eq!(caption.children, vec![Node::text("Cap")]);
+
+        let colgroup = element(&table.children[1]);
+        assert_eq!(colgroup.name, "colgroup");
+        assert_eq!(colgroup.children.len(), 1);
+        assert_eq!(element(&colgroup.children[0]).name, "col");
+
+        let tbody = element(&table.children[2]);
         let row = element(&tbody.children[0]);
         assert_eq!(element(&row.children[0]).children, vec![Node::text("A")]);
     }


### PR DESCRIPTION
## Summary
- Close an open table caption before handling a bare col start tag.
- Reuse the existing implied colgroup path so caption text, column metadata, and row content remain separate siblings.
- Document the expanded table boundary recovery and add DOM coverage.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check