### PR TITLE
Reconsume quoted attribute recovery

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -193,6 +193,9 @@ documented in this file.
 - Unexpected solidus recovery in start tags now reconsumes in
   `before_attribute_name`, preserving attributes after malformed slash-space or
   slash-NULL sequences.
+- Missing-whitespace recovery after quoted attribute values now reconsumes in
+  `before_attribute_name`, preserving jammed attributes while still reporting
+  secondary `=` or NULL attribute-name diagnostics.
 - Added a WHATWG operator/shape named-reference batch covering circled
   operators, integrals, products, squares, lozenges, stars, suits, and symbols.
 - Added a WHATWG box-drawing named-reference batch covering double-line,

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -80,6 +80,9 @@ Unexpected solidus recovery inside start tags now reconsumes in
 `before_attribute_name`, so malformed inputs such as `<img/ src=x>` skip the
 space normally and continue parsing later attributes instead of folding the
 separator into an attribute name.
+Unexpected characters immediately after quoted attribute values use the same
+reconsume path, so jammed attributes such as `href="x"title=y` still recover
+while `=` and NULL characters receive their normal attribute-name diagnostics.
 Unquoted attribute values also preserve spec-defined unexpected characters
 such as `"`, `'`, `<`, `=`, and `` ` `` while reporting
 `unexpected-character-in-unquoted-attribute-value`.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -5078,11 +5078,10 @@ actions = [
 [[transitions]]
 from = "after_attribute_value_quoted"
 matcher = { anything = true }
-to = "attribute_name"
+to = "before_attribute_name"
+consume = false
 actions = [
   "parse_error(missing-whitespace-between-attributes)",
-  "start_attribute",
-  "append_attribute_name(current_lowercase)",
 ]
 
 [[transitions]]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -10847,17 +10847,15 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "attribute_name".to_string(),
+                "before_attribute_name".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(missing-whitespace-between-attributes)".to_string(),
-                "start_attribute".to_string(),
-                "append_attribute_name(current_lowercase)".to_string(),
             ],
-            consume: true,
+            consume: false,
         },
         TransitionDefinition {
             from: "self_closing_start_tag".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -337,6 +337,77 @@ fn default_html_lexer_reports_unexpected_chars_in_unquoted_attribute_values() {
 }
 
 #[test]
+fn default_html_lexer_reconsumes_missing_space_after_quoted_attributes() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("<a first=\"1\"second=2 eq=\"x\"==y null=\"z\"\0=w>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "first".to_string(),
+                        value: "1".to_string(),
+                    },
+                    Attribute {
+                        name: "second".to_string(),
+                        value: "2".to_string(),
+                    },
+                    Attribute {
+                        name: "eq".to_string(),
+                        value: "x".to_string(),
+                    },
+                    Attribute {
+                        name: "=".to_string(),
+                        value: "y".to_string(),
+                    },
+                    Attribute {
+                        name: "null".to_string(),
+                        value: "z".to_string(),
+                    },
+                    Attribute {
+                        name: "\u{FFFD}".to_string(),
+                        value: "w".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "missing-whitespace-between-attributes")
+            .count(),
+        3
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-equals-before-attribute-name")
+            .count(),
+        1
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-null-character")
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn default_html_lexer_replaces_null_characters_in_text_and_attributes() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Reconsume unexpected characters after quoted attribute values in before_attribute_name after reporting missing whitespace.
- Preserve jammed attribute recovery while letting = and NULL receive their normal attribute-name diagnostics.
- Update the authored and generated lexer definitions plus docs and regression coverage.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check