### PR TITLE
Support forward ALGOL switch declarations

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -32,6 +32,9 @@ All notable changes to this package will be documented in this file.
   the existing guarded integer, boolean, real, and string output paths.
 - Lowered direct calls to sibling procedures declared later in the same block,
   including mutually recursive typed procedures now resolved by the checker.
+- Lowered switch entries that select later sibling switch declarations now
+  that the checker resolves switch designational lists after declaration
+  registration.
 - Lowered integer array-element by-name actuals to tagged descriptors with
   generated eval/store helpers that re-compute the element address on every
   formal read or assignment.

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -93,12 +93,12 @@ Local conditional designational expressions now lower as condition-controlled
 branch points that only evaluate the selected target. Local switch selections
 evaluate their integer index once, compare against one-based switch entries,
 and lower the chosen designational entry into the same jump path. Switch entries
-may target labels in lexical parent blocks; those entries unwind exited frames
-or propagate pending procedure-crossing gotos just like direct designational
-gotos. An out-of-range switch index follows the existing runtime-failure path
-and returns `0`. Recursive switch self-selection lowers through the switch
-evaluation helper so finite recursive dispatch executes at runtime instead of
-expanding the descriptor at compile time.
+may target labels in lexical parent blocks or later sibling switch declarations;
+those entries unwind exited frames or propagate pending procedure-crossing gotos
+just like direct designational gotos. An out-of-range switch index follows the
+existing runtime-failure path and returns `0`. Recursive switch self-selection
+lowers through the switch evaluation helper so finite recursive dispatch
+executes at runtime instead of expanding the descriptor at compile time.
 
 This phase keeps ALGOL frame memory and its 32-byte runtime state bounded to
 one 64 KiB WASM page, and keeps array descriptors plus element storage inside a

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -603,6 +603,26 @@ class TestAlgolIrCompiler:
         assert any(label.startswith("switch_0_1_next") for label in labels)
         assert any(label.startswith("switch_1_1_next") for label in labels)
 
+    def test_compiles_forward_nested_switch_selection_entry(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "switch outer := inner[1]; "
+                "switch inner := done; "
+                "goto outer[1]; "
+                "done: result := 5 "
+                "end"
+            )
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+
+        assert any(label.startswith("switch_0_1_next") for label in labels)
+        assert any(label.startswith("switch_1_1_next") for label in labels)
+
     def test_compiles_self_recursive_switch_selection_entry(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -47,6 +47,8 @@ All notable changes to this package will be documented in this file.
 - Registered all procedure signatures in a block before checking procedure
   bodies, allowing forward sibling procedure calls and mutually recursive
   typed procedures.
+- Registered switch names before checking switch designational lists, allowing
+  switch entries to target later sibling switch declarations in the same block.
 - Accepted integer-returning procedure actuals for real-valued formal
   procedure parameters, matching scalar integer-to-real promotion.
 - Accepted switch declaration entries that target labels in lexical parent

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -54,7 +54,8 @@ label ids that later lowering can propagate through calls. Switch declarations
 receive stable descriptors whose entries point at checked designational
 expressions, including entries that target labels in lexical parent blocks, and
 switch selection use sites resolve to their chosen switch symbol, including
-recursive self-selection inside switch entries.
+later sibling switch declarations and recursive self-selection inside switch
+entries.
 
 Unsupported ALGOL 60 features are reported as diagnostics instead of being
 silently accepted by the compiled pipeline. By-name parameters are accepted in

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -396,6 +396,19 @@ class SwitchDescriptor:
 
 
 @dataclass(frozen=True)
+class _PendingSwitchDeclaration:
+    """A switch name whose designational list still needs semantic checking."""
+
+    switch_id: int
+    name: str
+    scope: Scope
+    symbol_id: int
+    entries: tuple[ASTNode, ...]
+    line: int
+    column: int
+
+
+@dataclass(frozen=True)
 class ResolvedSwitchSelection:
     """A switch subscript occurrence after semantic lookup."""
 
@@ -569,12 +582,22 @@ class AlgolTypeChecker:
             if child.rule_name == "statement":
                 self._collect_statement_labels(child, scope)
 
+        pending_switches: list[_PendingSwitchDeclaration] = []
         pending_procedures: list[_PendingProcedureDeclaration] = []
         for child in _node_children(block):
             if child.rule_name == "declaration":
+                inner = _first_ast_child(child)
+                if inner is not None and inner.rule_name == "switch_decl":
+                    pending = self._register_switch_declaration(inner, scope)
+                    if pending is not None:
+                        pending_switches.append(pending)
+                    continue
                 pending = self._check_declaration(child, scope)
                 if pending is not None:
                     pending_procedures.append(pending)
+
+        for pending in pending_switches:
+            self._check_pending_switch_declaration(pending)
 
         self._resolve_pending_procedure_write_reasons(pending_procedures)
 
@@ -646,7 +669,9 @@ class AlgolTypeChecker:
             self._check_array_declaration(inner, scope, storage_class="frame")
             return None
         if inner.rule_name == "switch_decl":
-            self._check_switch_declaration(inner, scope)
+            pending = self._register_switch_declaration(inner, scope)
+            if pending is not None:
+                self._check_pending_switch_declaration(pending)
             return None
         if inner.rule_name != "type_decl":
             self._error(inner, f"{inner.rule_name} declarations are not supported yet")
@@ -801,14 +826,18 @@ class AlgolTypeChecker:
                     )
                 )
 
-    def _check_switch_declaration(self, node: ASTNode, scope: Scope) -> None:
+    def _register_switch_declaration(
+        self,
+        node: ASTNode,
+        scope: Scope,
+    ) -> _PendingSwitchDeclaration | None:
         name_token = next(
             (token for token in _direct_tokens(node) if token.type_name == "NAME"),
             None,
         )
         if name_token is None:
             self._error(node, "switch declaration is missing a name")
-            return
+            return None
 
         switch_id = self._next_switch_id
         self._next_switch_id += 1
@@ -828,7 +857,7 @@ class AlgolTypeChecker:
                 name_token,
                 f"{name_token.value!r} is already declared in this scope",
             )
-            return
+            return None
         self._next_symbol_id += 1
         self.semantic_symbols.append(symbol)
 
@@ -836,24 +865,38 @@ class AlgolTypeChecker:
         entries = _direct_nodes(switch_list, "desig_expr")
         if not entries:
             self._error(node, "switch declaration requires at least one entry")
-            return
-        for entry in entries:
+            return None
+        return _PendingSwitchDeclaration(
+            switch_id=switch_id,
+            name=name_token.value,
+            scope=scope,
+            symbol_id=symbol.symbol_id,
+            entries=tuple(entries),
+            line=name_token.line,
+            column=name_token.column,
+        )
+
+    def _check_pending_switch_declaration(
+        self,
+        pending: _PendingSwitchDeclaration,
+    ) -> None:
+        for entry in pending.entries:
             self._check_designational(
                 entry,
-                scope,
+                pending.scope,
                 allow_nonlocal_label=True,
                 allow_switch_selection=True,
-                active_switch_id=switch_id,
+                active_switch_id=pending.switch_id,
             )
         self.semantic_switches.append(
             SwitchDescriptor(
-                switch_id=switch_id,
-                name=name_token.value,
-                declaring_block_id=scope.block_id,
-                symbol_id=symbol.symbol_id,
-                entry_node_ids=tuple(id(entry) for entry in entries),
-                line=name_token.line,
-                column=name_token.column,
+                switch_id=pending.switch_id,
+                name=pending.name,
+                declaring_block_id=pending.scope.block_id,
+                symbol_id=pending.symbol_id,
+                entry_node_ids=tuple(id(entry) for entry in pending.entries),
+                line=pending.line,
+                column=pending.column,
             )
         )
 

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -330,6 +330,28 @@ class TestAlgolTypeChecker:
         assert result.semantic.switch_selections[0].name == "s"
         assert result.semantic.gotos[0].target_name == "switch designational expression"
 
+    def test_accepts_forward_switch_declaration_entry(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "switch first := second[1]; "
+            "switch second := done; "
+            "goto first[1]; "
+            "done: result := 5 "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert [switch.name for switch in result.semantic.switches] == [
+            "first",
+            "second",
+        ]
+        assert [selection.name for selection in result.semantic.switch_selections] == [
+            "second",
+            "first",
+        ]
+
     def test_rejects_missing_switch_designational_goto(self) -> None:
         ast = parse_algol("begin integer result; goto s[1] end")
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -92,6 +92,8 @@ All notable changes to this package will be documented in this file.
 - Executed forward sibling procedure calls and mutually recursive typed
   procedures by registering a block's procedure signatures before checking any
   procedure body.
+- Executed switch entries that select later sibling switch declarations,
+  including forward switch lists that use later typed procedure predicates.
 - Executed subscripted integer and real array elements as writable `for`
   statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -40,6 +40,8 @@ the current lane already supports a substantial ALGOL 60 surface:
   ALGOL's omitted-parentheses call syntax for parameterless procedures
 - forward sibling procedure calls and mutually recursive typed procedures
   within a block's declaration part
+- switch entries that select later sibling switch declarations within the same
+  declaration part
 - labels, local and nonlocal `goto`/`go to`, switch designators, and conditional
   designational expressions, including nonlocal branches and nested
   recursive switch entries
@@ -178,8 +180,8 @@ local WASM runtime. Those fixtures cover:
   forms, parenthesized conditional designational expressions, numeric labels,
   boolean operators, real arithmetic, and output
 - a surface-audit matrix for publication notation, procedure-call spellings,
-  forward procedure visibility, loop forms, typed formal procedures, value
-  array copies, nonlocal switch/goto cleanup, and programs without the
+  forward procedure and switch visibility, loop forms, typed formal procedures,
+  value array copies, nonlocal switch/goto cleanup, and programs without the
   `result` compatibility scalar
 
 ## Dependencies

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -931,6 +931,20 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [2]
 
+    def test_forward_switch_declaration_entry_dispatches_through_later_switch(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "switch outer := inner[1]; "
+            "switch inner := done; "
+            "goto outer[1]; "
+            "result := 99; "
+            "done: result := 5 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
+
     def test_self_recursive_switch_selection_entry_dispatches_at_runtime(
         self,
     ) -> None:

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -83,6 +83,27 @@ _SURFACE_CASES = (
         stdout="7",
     ),
     SurfaceCase(
+        name="forward-switch-declaration-visibility",
+        source="""
+            begin
+              integer result;
+              switch outer := if ready() then inner[1] else fail;
+              switch inner := done;
+              boolean procedure ready; begin ready := true end;
+              goto outer[1];
+            fail:
+              result := 0;
+              goto finish;
+            done:
+              result := 13;
+            finish:
+              print('SWITCH ', result)
+            end
+        """,
+        result=[13],
+        stdout="SWITCH 13",
+    ),
+    SurfaceCase(
         name="for-list-scalar-and-array-control",
         source="""
             begin


### PR DESCRIPTION
## Summary
- Register switch names before checking their designational lists so entries can select later sibling switches in the same declaration part.
- Add type-checker, IR, WASM runtime, and surface-audit coverage for forward switch visibility, including a switch list that calls a later typed procedure predicate.
- Document the convergence in the ALGOL type-checker, IR, and WASM package docs/changelogs.

## Verification
- Focused pytest for the new type-checker, IR, WASM, and surface-audit cases with `--no-cov`.
- `bash BUILD` in `code/packages/python/algol-type-checker`.
- `bash BUILD` in `code/packages/python/algol-ir-compiler`.
- `bash BUILD` in `code/packages/python/algol-wasm-compiler`.
- Ruff on touched Python files.
- `git diff --check`.
- Security review with `rg` over touched files for subprocess, shell, eval/exec, unsafe YAML, networking, chmod/chown/delete APIs; only an existing test name containing `eval` matched.