### PR TITLE
feat(prolog): summarize CLI query runs

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -287,6 +287,10 @@ queries and the CLI should run them as a script. The command prints or emits
 one result record per source query, sets `source_query_index` in JSON formats,
 and exits nonzero if any embedded query has no answers.
 
+Use `--summary` on non-interactive query runs when scripts, CI jobs, or editor
+integrations need compact totals. Text output appends one summary line, JSONL
+appends a summary record, and JSON wraps result records with summary metadata.
+
 Use `--format json` for a machine-readable result object, or `--format jsonl`
 when repeated queries should stream one result record per line. JSON answers
 preserve named bindings, raw values, compound terms, variables, and residual

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -67,6 +67,7 @@ class CliArgs:
     dialect: CliDialect
     backend: PrologVMBackend
     values: bool
+    summary: bool
     output_format: CliOutputFormat
     commit: bool
     interactive: bool
@@ -169,6 +170,16 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if list_source_queries and bool(flags["interactive"]):
         msg = "--list-source-queries cannot be combined with --interactive"
         raise ValueError(msg)
+    summary = bool(flags["summary"])
+    if summary and check:
+        msg = "--summary cannot be combined with --check"
+        raise ValueError(msg)
+    if summary and list_source_queries:
+        msg = "--summary cannot be combined with --list-source-queries"
+        raise ValueError(msg)
+    if summary and bool(flags["interactive"]):
+        msg = "--summary cannot be combined with --interactive"
+        raise ValueError(msg)
     if all_source_queries and queries:
         msg = "--all-source-queries cannot be combined with --query"
         raise ValueError(msg)
@@ -189,6 +200,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         dialect=_dialect(_required_string(flags["dialect"], name="--dialect")),
         backend=_backend(_required_string(flags["backend"], name="--backend")),
         values=bool(flags["values"]),
+        summary=summary,
         output_format=_output_format(
             _required_string(flags["format"], name="--format"),
         ),
@@ -686,16 +698,64 @@ def _print_result_records(
                 values=args.values,
                 stdout=output,
             )
+        if args.summary:
+            _print_summary_text(_summary_record(records), stdout=output)
         return
 
     json_records = [_json_record(record) for record in records]
     if args.output_format == "jsonl" or streaming:
         for record in json_records:
             print(json.dumps(record, sort_keys=True), file=output)
+        if args.summary:
+            print(json.dumps(_summary_record(records), sort_keys=True), file=output)
         return
 
     payload: object = json_records[0] if len(json_records) == 1 else json_records
+    if args.summary:
+        payload = {
+            "results": json_records,
+            "summary": _summary_record(records),
+            "success": all(bool(record["success"]) for record in records),
+        }
     print(json.dumps(payload, sort_keys=True), file=output)
+
+
+def _summary_record(records: Sequence[dict[str, object]]) -> dict[str, object]:
+    query_count = len(records)
+    failed_query_count = sum(1 for record in records if not bool(record["success"]))
+    answer_count = sum(
+        len(
+            cast(
+                "list[PrologAnswer] | list[Term | tuple[Term, ...]]",
+                record["results"],
+            ),
+        )
+        for record in records
+    )
+    return {
+        "success": failed_query_count == 0,
+        "mode": "summary",
+        "query_count": query_count,
+        "succeeded_query_count": query_count - failed_query_count,
+        "failed_query_count": failed_query_count,
+        "answer_count": answer_count,
+    }
+
+
+def _print_summary_text(
+    summary: dict[str, object],
+    *,
+    stdout: TextIO | None = None,
+) -> None:
+    output = sys.stdout if stdout is None else stdout
+    print(
+        "summary: "
+        f"queries={summary['query_count']}, "
+        f"succeeded={summary['succeeded_query_count']}, "
+        f"failed={summary['failed_query_count']}, "
+        f"answers={summary['answer_count']}.",
+        file=output,
+    )
 
 
 def _result_record(

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
@@ -89,6 +89,12 @@
       "type": "boolean"
     },
     {
+      "id": "summary",
+      "long": "summary",
+      "description": "Emit a final query-run summary after non-interactive execution.",
+      "type": "boolean"
+    },
+    {
       "id": "format",
       "long": "format",
       "description": "Output format for query results.",

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -243,6 +243,102 @@ def test_cli_repeated_queries_report_script_failure(
     ]
 
 
+def test_cli_summary_reports_noninteractive_text_counts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--query",
+        "parent(homer, Who)",
+        "--query",
+        "parent(marge, Who)",
+        "--summary",
+    ])
+
+    assert status == 1
+    assert capsys.readouterr().out.splitlines() == [
+        "Who = bart.",
+        "false.",
+        "summary: queries=2, succeeded=1, failed=1, answers=1.",
+    ]
+
+
+def test_cli_json_summary_wraps_query_results(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who). ?- parent(marge, Who).",
+        "--all-source-queries",
+        "--summary",
+        "--format",
+        "json",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert status == 1
+    assert payload["success"] is False
+    assert payload["summary"] == {
+        "answer_count": 1,
+        "failed_query_count": 1,
+        "mode": "summary",
+        "query_count": 2,
+        "succeeded_query_count": 1,
+        "success": False,
+    }
+    assert payload["results"][0]["source_query_index"] == 0
+    assert payload["results"][1]["source_query_index"] == 1
+
+
+def test_cli_jsonl_summary_appends_summary_record(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--query",
+        "parent(homer, Who)",
+        "--query",
+        "parent(marge, Who)",
+        "--format",
+        "jsonl",
+        "--summary",
+    ])
+
+    records = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+    ]
+
+    assert status == 1
+    assert records[-1] == {
+        "answer_count": 1,
+        "failed_query_count": 1,
+        "mode": "summary",
+        "query_count": 2,
+        "succeeded_query_count": 1,
+        "success": False,
+    }
+
+
+def test_cli_summary_rejects_interactive(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--summary",
+        "--interactive",
+    ])
+
+    assert status == 2
+    assert "--summary cannot be combined with --interactive" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_interactive_loop_runs_queries_from_stdin(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -17,6 +17,7 @@ The goal is practical usability:
 - run all stored source-level `?-` queries as an executable script
 - run one or more ad-hoc top-level queries
 - preserve state across repeated queries when explicitly requested
+- emit opt-in run summaries for scripts and CI
 - provide a small stdin-driven interactive loop
 
 ## Public Command
@@ -41,6 +42,7 @@ Important options:
 - `--backend structured|bytecode` selects the VM backend.
 - `--dialect swi|iso` selects the frontend dialect profile.
 - `--values` prints raw result values instead of named bindings.
+- `--summary` appends compact run totals for non-interactive query execution.
 - `--format text|json|jsonl` selects human text, one JSON document, or
   newline-delimited JSON records.
 - `--commit` persists the first answer state from each ad-hoc query into the
@@ -88,6 +90,12 @@ zero-based `index` and visible `variables` metadata for each embedded query.
 When `--all-source-queries` is set, each embedded `?-` query produces one result
 object with its `source_query_index`. The process exits with status 1 if any
 source query has no answers, matching repeated ad-hoc query scripts.
+
+When `--summary` is set for non-interactive query execution, text output
+appends one compact line with query, success, failure, and answer totals. JSONL
+appends a final `mode: "summary"` record. JSON wraps result records in an object
+with `results`, `summary`, and aggregate `success` fields so downstream tools
+can consume both details and totals without re-counting.
 
 Each result object includes:
 
@@ -150,6 +158,7 @@ The CLI test coverage should prove:
 - no-solution exit behavior
 - JSON and JSONL machine-readable output
 - JSON and JSONL machine-readable diagnostics
+- opt-in query run summaries
 - repeated query scripts with committed runtime state
 - interactive stdin query handling
 - committed setup queries before interactive mode


### PR DESCRIPTION
## Summary
- add `prolog-vm --summary` through the CLI builder spec for non-interactive query runs
- append compact text/JSONL summary records and wrap JSON results with query/answer counts
- document PR77 summary output and add CLI coverage for successful and failing query scripts

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-run-summary -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-run-summary-build-plan.json`