### PR TITLE
[codex] add interactive hardware Board VM specs

### DIFF
--- a/code/specs/BVM00-board-vm-architecture.md
+++ b/code/specs/BVM00-board-vm-architecture.md
@@ -1,0 +1,304 @@
+# BVM00 - Board VM Architecture
+
+## Overview
+
+Board VM is an interactive runtime for physical microcontroller boards. It lets
+a host program connect to a board over UART, USB CDC, BLE, TCP, or another byte
+transport, upload compact bytecode, inspect board capabilities, run commands,
+and later eject the explored behavior into a standalone firmware image.
+
+The core idea is deliberately split in two:
+
+1. The **IR and protocol are portable**. A Python client, Ruby client, Java
+   client, Lua client, JS client, or CLI all produce the same binary messages
+   and the same bytecode.
+2. The **runtime adapter is board-specific**. Arduino Uno, Arduino Nano 33,
+   RP2040, ESP32, MBed, and other boards expose different pins, timers, PWM
+   channels, storage limits, and flashing tools. Each board port maps the
+   portable VM calls onto its real hardware.
+
+This spec uses the name **Board VM** to avoid confusion with
+`hardware-vm.md`, which is the HDL event-driven simulator for Verilog/VHDL.
+Board VM talks to real physical boards.
+
+## Goals
+
+- Make hardware development feel interactive: connect, type, run, observe,
+  adjust.
+- Keep the wire protocol language-agnostic and transport-agnostic.
+- Keep the board runtime small enough for constrained microcontrollers.
+- Support a useful first end-to-end flow: blink a GPIO pin interactively, then
+  eject it as a stored program.
+- Make later features obvious: PWM motors, ADC sensors, I2C/SPI devices,
+  sound, events, streaming logs, and board-specific drivers.
+
+## Non-Goals
+
+- It is not a full JavaScript, Python, Ruby, or Lua interpreter on the board.
+  Host languages are clients that compile or encode portable operations.
+- It is not a replacement for Rust/C/C++ firmware for performance-critical
+  loops.
+- It does not hide board limits. The board reports what it can do, and host
+  SDKs must adapt to that report.
+- It is not tied to Arduino. Arduino is the first likely target because it is
+  accessible, not because the protocol depends on it.
+
+## Layer Position
+
+```
+Host language SDKs
+  JS / Python / Ruby / Java / Lua / CLI
+        |
+        v
+Board VM protocol and bytecode IR
+        |
+        v
+Transport: UART / USB CDC / BLE / TCP / WebSerial
+        |
+        v
+Board VM runtime in Rust
+        |
+        v
+Board adapter: Arduino / MBed / RP2040 / ESP32 / ...
+        |
+        v
+Physical pins, timers, buses, sensors, motors, speakers
+```
+
+Board VM sits beside the existing VM and simulator work in the repository, but
+its output target is a live microcontroller rather than a local software
+simulator.
+
+## Package Map
+
+The initial implementation should be split into small packages so the portable
+pieces can be reused by every board and every host language.
+
+| Package | Role | Target |
+|---|---|---|
+| `board-vm-protocol` | Frame codec, message types, errors, golden vectors | Rust `no_std` + host use |
+| `board-vm-ir` | Bytecode instruction format, decoder, validator | Rust `no_std` |
+| `board-vm-runtime` | Interpreter, handle table, command loop | Rust `no_std` |
+| `board-vm-host` | Reference CLI/REPL and uploader | Desktop Rust |
+| `board-vm-arduino-*` | Board-specific HAL adapter and firmware package | Embedded Rust |
+| `board-vm-conformance` | Shared protocol and bytecode test vectors | Host tests |
+
+Later language SDK packages should depend on the specification and test vectors,
+not on one another:
+
+```
+board-vm-js
+board-vm-python
+board-vm-ruby
+board-vm-java
+board-vm-lua
+```
+
+## Concepts
+
+### Board Descriptor
+
+Every connected board reports a descriptor before accepting programs:
+
+```
+BoardDescriptor:
+  protocol_version: u16
+  board_id: string
+  runtime_id: string
+  max_frame_payload: u16
+  max_program_bytes: u32
+  max_stack_values: u8
+  max_handles: u8
+  transports: list[TransportKind]
+  capabilities: list[CapabilityDescriptor]
+```
+
+The descriptor is the host's source of truth. If a board does not report PWM,
+the host SDK must not offer PWM on that connection except as an unsupported
+operation that fails before upload.
+
+### Capabilities
+
+A capability is a stable, portable operation family exposed by the board:
+
+| Capability | Example operation | Board mapping |
+|---|---|---|
+| `gpio.digital` | configure pin, write pin, read pin | pin registers / HAL GPIO |
+| `time.sleep` | sleep or yield for milliseconds | timer peripheral / RTOS delay |
+| `pwm.output` | set duty cycle and frequency | timer channel |
+| `adc.input` | sample analog input | ADC peripheral |
+| `i2c.master` | write/read I2C transactions | I2C peripheral |
+| `serial.log` | stream text or binary logs | current transport or extra UART |
+| `program.store` | save bytecode for boot | flash / EEPROM / filesystem |
+
+Capabilities are not permissions in the security sense for the first version.
+They are a compact feature contract between host and board.
+
+### Resource Handles
+
+Host and bytecode programs do not directly own hardware. They own handles:
+
+```
+pin 13 as GPIO output -> handle 1
+PWM on pin 5          -> handle 2
+I2C bus 0             -> handle 3
+```
+
+Handles keep the bytecode compact and allow the runtime to validate lifetime,
+pin conflicts, and board-specific resource allocation.
+
+### Interactive Mode
+
+Interactive mode is optimized for quick iteration:
+
+1. Host connects and performs `HELLO`.
+2. Host asks for board capabilities.
+3. User enters a command in a REPL or SDK call.
+4. Host compiles that command to one small bytecode program or direct control
+   message.
+5. Board executes it and returns a result, event, log, or error.
+
+Interactive mode is allowed to be slower because UART round trips are in the
+loop. It is for exploration and inspection.
+
+### Stored Program Mode
+
+Stored program mode is optimized for standalone behavior:
+
+1. Host uploads a bytecode module.
+2. Runtime validates it against the board descriptor and resource limits.
+3. Host asks the board to store the module if supported.
+4. Board boots into the VM and runs the stored module without the host.
+
+If a board cannot write flash or EEPROM safely from the runtime, the host can
+instead generate a firmware image with the VM and bytecode embedded.
+
+### Eject
+
+Eject converts an interactive session into standalone firmware. There are two
+eject forms:
+
+| Form | Use when | Output |
+|---|---|---|
+| Store on device | Board supports persistent program storage | Bytecode written to flash/EEPROM |
+| Build firmware | Board requires host-side flashing | Runtime firmware with embedded bytecode |
+
+The same bytecode module should work in both forms. The difference is where the
+module is stored and how it is launched.
+
+## Public API
+
+The architectural API is a package-level contract rather than a single class.
+The first Rust crates should expose these shapes.
+
+```rust
+pub struct BoardDescriptor {
+    pub protocol_version: u16,
+    pub board_id: &'static str,
+    pub runtime_id: &'static str,
+    pub max_frame_payload: u16,
+    pub max_program_bytes: u32,
+    pub max_stack_values: u8,
+    pub max_handles: u8,
+    pub capabilities: &'static [CapabilityDescriptor],
+}
+
+pub struct CapabilityDescriptor {
+    pub id: u16,
+    pub name: &'static str,
+    pub version: u8,
+    pub flags: u16,
+}
+
+pub trait BoardRuntime {
+    fn descriptor(&self) -> BoardDescriptor;
+    fn reset_vm(&mut self) -> VmResult<()>;
+    fn upload_chunk(&mut self, program_id: u16, offset: u32, bytes: &[u8]) -> VmResult<()>;
+    fn run_program(&mut self, program_id: u16, budget: RunBudget) -> VmResult<RunReport>;
+    fn store_program(&mut self, program_id: u16, slot: u8) -> VmResult<()>;
+}
+```
+
+Board-specific crates implement hardware traits consumed by `board-vm-runtime`:
+
+```rust
+pub trait GpioHal {
+    fn open_output(&mut self, pin: PinId, initial: Level) -> VmResult<Handle>;
+    fn write(&mut self, handle: Handle, level: Level) -> VmResult<()>;
+    fn read(&mut self, handle: Handle) -> VmResult<Level>;
+}
+
+pub trait ClockHal {
+    fn now_ms(&self) -> u32;
+    fn sleep_ms(&mut self, ms: u16) -> VmResult<()>;
+}
+```
+
+## Data Flow
+
+Interactive command:
+
+```
+Host expression
+  -> host SDK operation
+  -> Board VM bytecode or control message
+  -> protocol frame
+  -> transport bytes
+  -> board runtime
+  -> HAL capability call
+  -> physical hardware state
+  -> response frame
+```
+
+Ejected program:
+
+```
+Host session history or source file
+  -> bytecode module
+  -> validate against BoardDescriptor
+  -> store on board OR embed in firmware
+  -> board reset
+  -> VM boot
+  -> physical hardware behavior
+```
+
+## Error Model
+
+Errors must be structured and portable:
+
+| Error | Meaning |
+|---|---|
+| `UnsupportedCapability` | Host requested a capability the board did not advertise |
+| `InvalidFrame` | Frame could not be decoded or failed CRC |
+| `InvalidBytecode` | Program failed validation |
+| `StackOverflow` | Program exceeded configured stack depth |
+| `StackUnderflow` | Instruction needed values that were not present |
+| `HandleNotFound` | Program referenced a missing or closed resource |
+| `ResourceBusy` | Pin, timer, bus, or storage slot is already owned |
+| `BudgetExceeded` | Program exceeded instruction or time budget |
+| `BoardFault` | HAL reported a board-specific hardware failure |
+
+Error responses should include the request id, error code, bytecode offset when
+available, and a compact message string when space permits.
+
+## Test Strategy
+
+- Protocol golden vectors: exact bytes for every control message.
+- Bytecode golden vectors: exact decode and validation for every instruction.
+- Fake board runtime: run bytecode against an in-memory GPIO/timer HAL.
+- Loopback transport: host sends frames through an in-memory transport and
+  receives board responses.
+- Blink MVP: fake board observes pin 13 high, sleep, low, sleep in order.
+- Hardware smoke test: supported Arduino board blinks onboard LED after upload.
+- Eject smoke test: reboot board and verify stored blink program starts.
+
+## Future Extensions
+
+- PWM motors with frequency, duty cycle, direction pins, and ramping.
+- ADC streaming and threshold events.
+- I2C and SPI device descriptors for sensors.
+- Sound/tone generation over PWM or DAC.
+- Event subscriptions for pin changes and sensor updates.
+- Debugging support: step, break, inspect stack, inspect handles.
+- Capability schemas generated into host SDKs.
+- Static verifier for programs that should be safe to run forever.

--- a/code/specs/BVM01-board-vm-protocol.md
+++ b/code/specs/BVM01-board-vm-protocol.md
@@ -1,0 +1,410 @@
+# BVM01 - Board VM Binary Protocol
+
+## Overview
+
+The Board VM protocol is the language-neutral binary contract between a host and
+a board runtime. It is designed for byte streams such as UART, but it can also
+run over packet transports such as BLE, TCP, USB bulk endpoints, or WebSerial.
+
+The protocol has two layers:
+
+1. **Transport framing**: turns unreliable byte streams into bounded frames with
+   length, request ids, and CRC protection.
+2. **Message payloads**: describe board discovery, capability reports, program
+   upload, execution, logging, events, and errors.
+
+The payloads are intentionally small and schema-like. Language SDKs should be
+thin wrappers around the same messages, not bespoke remote-control APIs.
+
+## Layer Position
+
+```
+Host SDK / CLI / REPL
+        |
+        v
+BVM01 binary protocol
+        |
+        v
+Transport adapter: UART / USB CDC / BLE / TCP / WebSerial
+        |
+        v
+Board VM runtime
+        |
+        v
+Board HAL
+```
+
+The protocol depends on BVM02 for bytecode payloads but does not depend on any
+specific host language or board.
+
+## Encoding Rules
+
+All multi-byte fixed-width integers are little-endian.
+
+Variable-length unsigned integers use ULEB128:
+
+```
+0..127        -> one byte
+128..16383    -> two bytes
+16384..2^21-1 -> three bytes
+```
+
+Strings are encoded as:
+
+```
+len: uleb128
+bytes: UTF-8, no trailing NUL
+```
+
+Byte arrays are encoded as:
+
+```
+len: uleb128
+bytes
+```
+
+Boolean values are one byte:
+
+```
+0x00 = false
+0x01 = true
+```
+
+Unknown enum values must be rejected with `UnsupportedValue`, not silently
+coerced.
+
+## Transport Frame
+
+For byte-stream transports, every frame is COBS encoded and terminated with
+`0x00`.
+
+```
+wire_frame:
+  cobs(raw_frame || crc16_le) 0x00
+
+raw_frame:
+  version: u8
+  flags: u8
+  message_type: u8
+  request_id: u16
+  payload_len: uleb128
+  payload: bytes[payload_len]
+
+crc16_le:
+  CRC-16/CCITT-FALSE over raw_frame
+```
+
+COBS gives the receiver a reliable frame boundary and lets it recover after
+garbage bytes. The terminating zero byte is not part of the CRC.
+
+Packet transports may omit COBS if the packet layer already preserves message
+boundaries, but they must preserve the same `raw_frame || crc16_le` bytes.
+
+### Version
+
+Version is a single byte for v1:
+
+```
+0x01 = Board VM protocol v1
+```
+
+Future incompatible revisions use a new version byte. Hosts must fail the
+handshake if the board reports no mutually supported version.
+
+### Flags
+
+```
+bit 0: response_required
+bit 1: is_response
+bit 2: is_error_response
+bit 3: compressed_payload
+bits 4..7: reserved, must be 0
+```
+
+Compression is reserved for larger future payloads. v1 senders must not set
+`compressed_payload`.
+
+### Request ID
+
+`request_id` correlates responses with requests. The host allocates nonzero
+request ids. The board copies the id into the response. `0` is reserved for
+unsolicited events and logs.
+
+At most one request may be in flight on boards that do not advertise
+`transport.pipelining`. Hosts must assume no pipelining until the capability is
+reported.
+
+## Message Types
+
+| Type | Name | Direction | Payload |
+|---:|---|---|---|
+| `0x01` | `HELLO` | host -> board | `Hello` |
+| `0x02` | `HELLO_ACK` | board -> host | `HelloAck` |
+| `0x03` | `CAPS_QUERY` | host -> board | empty |
+| `0x04` | `CAPS_REPORT` | board -> host | `CapsReport` |
+| `0x05` | `PROGRAM_BEGIN` | host -> board | `ProgramBegin` |
+| `0x06` | `PROGRAM_CHUNK` | host -> board | `ProgramChunk` |
+| `0x07` | `PROGRAM_END` | host -> board | `ProgramEnd` |
+| `0x08` | `RUN` | host -> board | `RunRequest` |
+| `0x09` | `RUN_REPORT` | board -> host | `RunReport` |
+| `0x0A` | `STOP` | host -> board | empty |
+| `0x0B` | `RESET_VM` | host -> board | empty |
+| `0x0C` | `STORE_PROGRAM` | host -> board | `StoreProgram` |
+| `0x0D` | `RUN_STORED` | host -> board | `RunStored` |
+| `0x0E` | `READ_STATE` | host -> board | `ReadState` |
+| `0x0F` | `STATE_REPORT` | board -> host | `StateReport` |
+| `0x10` | `SUBSCRIBE` | host -> board | `Subscribe` |
+| `0x11` | `EVENT` | board -> host | `Event` |
+| `0x12` | `LOG` | board -> host | `Log` |
+| `0x13` | `ERROR` | board -> host | `ErrorPayload` |
+| `0x14` | `PING` | either | `Ping` |
+| `0x15` | `PONG` | either | `Pong` |
+
+Message types `0x80..0xFF` are board-vendor extensions. A portable host SDK
+must not require them for core behavior.
+
+## Payloads
+
+### `Hello`
+
+```
+min_version: u8
+max_version: u8
+host_name: string
+host_nonce: u32
+```
+
+The board replies with the selected version and echoes the nonce.
+
+### `HelloAck`
+
+```
+selected_version: u8
+board_name: string
+runtime_name: string
+host_nonce: u32
+board_nonce: u32
+max_frame_payload: u16
+```
+
+### `CapsReport`
+
+```
+board_id: string
+runtime_id: string
+max_program_bytes: u32
+max_stack_values: u8
+max_handles: u8
+supports_store_program: bool
+capability_count: uleb128
+capabilities: CapabilityDescriptor[capability_count]
+```
+
+`CapabilityDescriptor`:
+
+```
+id: u16
+version: u8
+flags: u16
+name: string
+```
+
+Capability reports include both bytecode-callable operations and protocol-level
+runtime features. The `flags` field identifies which kind a descriptor is:
+
+```
+bit 0: bytecode_callable
+bit 1: protocol_feature
+bit 2: board_metadata
+bits 3..15: reserved
+```
+
+Portable bytecode-callable ids below `0x1000` are assigned by BVM02. Portable
+protocol feature ids use `0x7000..0x7FFF`. IDs at or above `0x8000` are
+board-vendor extensions.
+
+Initial protocol feature ids:
+
+| ID | Name | Meaning |
+|---:|---|---|
+| `0x7001` | `program.ram_exec` | upload and run volatile bytecode programs |
+| `0x7002` | `program.store` | store bytecode in board nonvolatile memory |
+| `0x7003` | `transport.pipelining` | more than one request may be in flight |
+
+### `ProgramBegin`
+
+```
+program_id: u16
+format: u8        # 0x01 = BVM bytecode module
+total_len: u32
+program_crc32: u32
+```
+
+The board allocates or clears a temporary upload buffer for `program_id`.
+
+### `ProgramChunk`
+
+```
+program_id: u16
+offset: u32
+bytes: byte_array
+```
+
+Chunks may be retransmitted. The board must treat a retransmit of identical
+bytes at the same offset as success.
+
+### `ProgramEnd`
+
+```
+program_id: u16
+```
+
+The board validates length, CRC, and bytecode structure. A successful response
+means the program is ready to run from volatile storage.
+
+### `RunRequest`
+
+```
+program_id: u16
+flags: u8
+instruction_budget: u32
+time_budget_ms: u32
+```
+
+Flags:
+
+```
+bit 0: reset_vm_before_run
+bit 1: keep_handles_after_run
+bit 2: background_run
+bits 3..7: reserved
+```
+
+Interactive commands normally set `reset_vm_before_run`. Long-running stored
+programs normally use `background_run`.
+
+### `RunReport`
+
+```
+program_id: u16
+status: u8
+instructions_executed: u32
+elapsed_ms: u32
+stack_depth: u8
+open_handles: u8
+return_count: uleb128
+returns: Value[return_count]
+```
+
+Status:
+
+| Value | Name | Meaning |
+|---:|---|---|
+| `0x00` | `halted` | Program reached `HALT` |
+| `0x01` | `running` | Program is still running in background |
+| `0x02` | `stopped` | Program stopped by host |
+| `0x03` | `budget_exceeded` | Instruction or time budget expired |
+| `0x04` | `faulted` | Program halted with an error |
+
+### `StoreProgram`
+
+```
+program_id: u16
+slot: u8
+boot_policy: u8
+```
+
+Boot policy:
+
+```
+0x00 = store only, do not run at boot
+0x01 = run at boot after runtime initialization
+0x02 = run at boot only if no host connects during grace period
+```
+
+### `ErrorPayload`
+
+```
+code: u16
+request_id: u16
+program_id: u16
+bytecode_offset: u32
+message: string
+```
+
+If no program or bytecode offset applies, `program_id` is `0xFFFF` and
+`bytecode_offset` is `0xFFFFFFFF`.
+
+## Value Encoding
+
+`Value` is used in run returns, state reports, and events.
+
+```
+tag: u8
+payload: depends on tag
+```
+
+| Tag | Type | Payload |
+|---:|---|---|
+| `0x00` | `unit` | empty |
+| `0x01` | `bool` | u8 |
+| `0x02` | `u8` | u8 |
+| `0x03` | `u16` | u16 |
+| `0x04` | `u32` | u32 |
+| `0x05` | `i16` | i16 |
+| `0x06` | `handle` | u16 |
+| `0x07` | `bytes` | byte_array |
+| `0x08` | `string` | string |
+
+The first MVP should only require `unit`, `bool`, `u8`, `u16`, and `handle`.
+
+## Error Codes
+
+| Code | Name |
+|---:|---|
+| `0x0001` | `InvalidFrame` |
+| `0x0002` | `UnsupportedVersion` |
+| `0x0003` | `UnsupportedMessage` |
+| `0x0004` | `PayloadTooLarge` |
+| `0x0005` | `BadCrc` |
+| `0x0100` | `UnsupportedCapability` |
+| `0x0101` | `ResourceBusy` |
+| `0x0102` | `HandleNotFound` |
+| `0x0200` | `InvalidProgram` |
+| `0x0201` | `InvalidBytecode` |
+| `0x0202` | `StackOverflow` |
+| `0x0203` | `StackUnderflow` |
+| `0x0204` | `BudgetExceeded` |
+| `0x0300` | `StorageUnavailable` |
+| `0x0301` | `StorageFull` |
+| `0x0400` | `BoardFault` |
+
+## Flow Control
+
+The board advertises `max_frame_payload` during `HELLO_ACK`. The host must keep
+encoded payloads at or below that value. For larger bytecode modules, the host
+uses `PROGRAM_CHUNK`.
+
+If the board is busy running a foreground program, it may return `BoardBusy`.
+If the board is running a background program, it must still accept `STOP`,
+`PING`, and `READ_STATE` unless it has faulted.
+
+## Test Strategy
+
+- Encode/decode golden vectors for every payload.
+- CRC failure test with one flipped payload bit.
+- COBS recovery test with garbage bytes before a valid frame.
+- Request id round-trip tests.
+- Max payload boundary tests.
+- Retransmitted `PROGRAM_CHUNK` tests.
+- Unknown message and unknown enum tests.
+- Cross-language conformance: every SDK encodes the same payload to identical
+  bytes before COBS and CRC.
+
+## Future Extensions
+
+- Authenticated sessions for wireless transports.
+- Optional payload compression for large constant tables.
+- Multiplexed request streams for boards with RTOS support.
+- Binary trace streaming for instruction-level debugging.
+- Negotiated vendor extension schemas.

--- a/code/specs/BVM02-board-vm-bytecode-ir.md
+++ b/code/specs/BVM02-board-vm-bytecode-ir.md
@@ -1,0 +1,285 @@
+# BVM02 - Board VM Bytecode IR
+
+## Overview
+
+Board VM bytecode is the portable instruction format executed by the board
+runtime. It is compact, deterministic, and independent of host language and
+board family.
+
+The bytecode is intentionally not a general-purpose language runtime. It is a
+small stack machine with capability calls. Host SDKs can expose friendly APIs in
+JS, Python, Ruby, Java, Lua, or a CLI, but all of them lower to the same
+bytecode bytes.
+
+## Layer Position
+
+```
+Host expression or REPL command
+        |
+        v
+BVM02 bytecode module
+        |
+        v
+BVM01 protocol upload
+        |
+        v
+board-vm-runtime interpreter
+        |
+        v
+board HAL capability call
+```
+
+## Design Principles
+
+- **Small interpreter**: one-byte opcodes, simple immediates, bounded stack.
+- **Portable hardware access**: hardware is reached through capability calls,
+  not board registers.
+- **Ahead-of-run validation**: reject malformed bytecode before execution.
+- **Bounded execution**: instruction and time budgets prevent host lockout.
+- **Stable bytes**: the same source operation should encode identically in every
+  host SDK.
+
+## Module Format
+
+The protocol can upload raw instruction bytes for tiny interactive commands, but
+stored programs use a bytecode module:
+
+```
+magic: 4 bytes       # ASCII "BVM1"
+version: u8          # 0x01
+flags: u8
+max_stack: u8
+reserved: u8         # must be 0
+code_len: uleb128
+code: bytes[code_len]
+const_len: uleb128
+const_pool: bytes[const_len]
+```
+
+Flags:
+
+```
+bit 0: program_may_run_forever
+bit 1: program_uses_events
+bit 2: program_requests_persistent_handles
+bits 3..7: reserved
+```
+
+The first MVP can set `const_len = 0` and use inline immediates only.
+
+## Execution Model
+
+The VM state contains:
+
+```
+ip: u32                    # instruction pointer into code
+stack: Value[max_stack]    # operand stack
+handles: HandleTable       # runtime-owned resources
+halted: bool
+last_error: Option<VmError>
+```
+
+Instructions either:
+
+- mutate the stack,
+- change `ip`,
+- call a capability,
+- halt.
+
+The VM is cooperative. A capability call such as `time.sleep_ms` may yield to
+the board runtime. Long-running programs must not block protocol handling
+forever on boards that support background execution.
+
+## Value Types
+
+The VM value set is deliberately small:
+
+| Type | Storage | Use |
+|---|---|---|
+| `unit` | no payload | no result |
+| `bool` | 1 byte | digital levels, conditions |
+| `u8` | 1 byte | small immediates, modes |
+| `u16` | 2 bytes | pins, handles, milliseconds |
+| `u32` | 4 bytes | counters, timestamps |
+| `i16` | 2 bytes | signed sensor values |
+| `handle` | 2 bytes | resources opened by capabilities |
+
+The MVP should implement `unit`, `bool`, `u8`, `u16`, and `handle`.
+
+## Core Opcodes
+
+| Opcode | Mnemonic | Operands | Stack Effect |
+|---:|---|---|---|
+| `0x00` | `HALT` | none | stop execution |
+| `0x01` | `NOP` | none | no change |
+| `0x10` | `PUSH_FALSE` | none | `-> bool` |
+| `0x11` | `PUSH_TRUE` | none | `-> bool` |
+| `0x12` | `PUSH_U8` | `u8` | `-> u8` |
+| `0x13` | `PUSH_U16` | `u16_le` | `-> u16` |
+| `0x14` | `PUSH_U32` | `u32_le` | `-> u32` |
+| `0x15` | `PUSH_I16` | `i16_le` | `-> i16` |
+| `0x20` | `DUP` | none | `a -> a a` |
+| `0x21` | `DROP` | none | `a ->` |
+| `0x22` | `SWAP` | none | `a b -> b a` |
+| `0x23` | `OVER` | none | `a b -> a b a` |
+| `0x30` | `JUMP_S8` | `i8` | branch relative to next ip |
+| `0x31` | `JUMP_IF_FALSE_S8` | `i8` | `bool ->` |
+| `0x32` | `JUMP_IF_TRUE_S8` | `i8` | `bool ->` |
+| `0x40` | `CALL_U8` | `capability_id: u8` | capability-defined |
+| `0x41` | `CALL_U16` | `capability_id: u16_le` | capability-defined |
+| `0x50` | `RETURN_TOP` | none | return top stack value to host, then halt |
+
+Opcodes `0x80..0xFF` are reserved for future compact aliases and board-vendor
+extensions. Portable bytecode must not require vendor opcodes.
+
+## Portable Capability IDs
+
+Capability calls are typed stack calls. Each call specifies its arguments and
+returns in this spec. If the stack contains the wrong types, execution fails
+with `TypeMismatch`.
+
+### GPIO
+
+| ID | Name | Args | Returns |
+|---:|---|---|---|
+| `0x01` | `gpio.open` | `pin: u16/u8`, `mode: u8` | `handle` |
+| `0x02` | `gpio.write` | `handle`, `level: bool` | `unit` |
+| `0x03` | `gpio.read` | `handle` | `bool` |
+| `0x04` | `gpio.close` | `handle` | `unit` |
+
+GPIO modes:
+
+| Value | Mode |
+|---:|---|
+| `0x00` | input |
+| `0x01` | output |
+| `0x02` | input_pullup |
+| `0x03` | input_pulldown |
+
+### Time
+
+| ID | Name | Args | Returns |
+|---:|---|---|---|
+| `0x10` | `time.sleep_ms` | `duration_ms: u16` | `unit` |
+| `0x11` | `time.now_ms` | none | `u32` |
+
+### PWM
+
+PWM is not required for the blink MVP, but its ids are reserved early so host
+SDKs can grow without renumbering.
+
+| ID | Name | Args | Returns |
+|---:|---|---|---|
+| `0x20` | `pwm.open` | `pin: u16/u8`, `frequency_hz: u16` | `handle` |
+| `0x21` | `pwm.set_duty_u16` | `handle`, `duty: u16` | `unit` |
+| `0x22` | `pwm.close` | `handle` | `unit` |
+
+### Program
+
+| ID | Name | Args | Returns |
+|---:|---|---|---|
+| `0x70` | `program.emit_event` | `event_id: u16`, `value` | `unit` |
+| `0x71` | `program.log_u16` | `value: u16` | `unit` |
+
+## Validation
+
+Before execution, the runtime validates:
+
+- Every opcode is known.
+- Every immediate operand is fully present.
+- Every jump target lands on an instruction boundary.
+- Reserved flag bits are zero.
+- Declared `max_stack` is within the board descriptor.
+- Static stack analysis proves no unconditional underflow.
+- Capability ids are either advertised by the board or rejected.
+
+Static stack analysis may be conservative. If the validator cannot prove a
+program is safe, it may reject the program even if it would happen to run.
+
+## Blink Bytecode Example
+
+This bytecode opens pin 13 as output, then blinks forever with 250 ms high and
+250 ms low.
+
+```
+12 0D       PUSH_U8 13
+12 01       PUSH_U8 1              # GPIO output
+40 01       CALL_U8 gpio.open      # -> handle
+20          DUP                    # loop_start
+11          PUSH_TRUE
+40 02       CALL_U8 gpio.write
+13 FA 00    PUSH_U16 250
+40 10       CALL_U8 time.sleep_ms
+20          DUP
+10          PUSH_FALSE
+40 02       CALL_U8 gpio.write
+13 FA 00    PUSH_U16 250
+40 10       CALL_U8 time.sleep_ms
+30 EC       JUMP_S8 -20            # back to loop_start
+```
+
+Raw bytes:
+
+```
+12 0D 12 01 40 01 20 11 40 02 13 FA 00 40 10 20
+10 40 02 13 FA 00 40 10 30 EC
+```
+
+The only board-specific detail is whether logical pin 13 maps to an actual LED.
+If the board reports a different onboard LED pin, the host should substitute
+that pin before upload.
+
+## Public API
+
+```rust
+pub enum Op {
+    Halt,
+    Nop,
+    PushFalse,
+    PushTrue,
+    PushU8(u8),
+    PushU16(u16),
+    PushU32(u32),
+    PushI16(i16),
+    Dup,
+    Drop,
+    Swap,
+    Over,
+    JumpS8(i8),
+    JumpIfFalseS8(i8),
+    JumpIfTrueS8(i8),
+    CallU8(u8),
+    CallU16(u16),
+    ReturnTop,
+}
+
+pub struct Module<'a> {
+    pub flags: u8,
+    pub max_stack: u8,
+    pub code: &'a [u8],
+    pub const_pool: &'a [u8],
+}
+
+pub fn decode_next(code: &[u8], ip: usize) -> Result<(Op, usize), DecodeError>;
+pub fn validate(module: &Module, caps: &CapabilitySet) -> Result<(), ValidateError>;
+```
+
+## Test Strategy
+
+- Decode every opcode and operand width.
+- Reject truncated immediates.
+- Reject jumps into the middle of an instruction.
+- Reject unknown opcodes.
+- Validate stack effects for straight-line programs.
+- Validate stack effects across conditional branches.
+- Execute blink bytecode on a fake board and assert ordered GPIO operations.
+- Golden byte tests for host SDKs.
+
+## Future Extensions
+
+- `CALL_COMPACT_0..63` opcodes that encode common capability ids in one byte.
+- Event wait instructions for pin interrupts and sensor thresholds.
+- Small local variables for loops without stack juggling.
+- Constant pool entries for strings and byte arrays.
+- Signed arithmetic and fixed-point helpers.
+- Program sections for debug symbols and source maps.

--- a/code/specs/BVM03-board-vm-rust-runtime.md
+++ b/code/specs/BVM03-board-vm-rust-runtime.md
@@ -1,0 +1,292 @@
+# BVM03 - Board VM Rust Runtime
+
+## Overview
+
+The Board VM Rust runtime is the firmware-side implementation of the protocol
+and bytecode interpreter. It is written as `no_std` Rust so the same core can
+run on constrained microcontrollers and richer embedded platforms.
+
+The runtime owns:
+
+- protocol frame receive/send,
+- bytecode upload buffers,
+- bytecode validation,
+- the interpreter loop,
+- resource handle tables,
+- dispatch from portable capability ids to board HAL traits,
+- optional stored-program boot.
+
+Board-specific crates provide the actual HAL implementation and flashing/eject
+packaging.
+
+## Layer Position
+
+```
+BVM01 protocol frames
+        |
+        v
+board-vm-runtime
+        |
+        +--> BVM02 bytecode decoder/interpreter
+        +--> handle table
+        +--> capability dispatch
+        |
+        v
+Board HAL adapter
+        |
+        v
+Physical board peripherals
+```
+
+## Runtime Crates
+
+| Crate | Purpose |
+|---|---|
+| `board-vm-protocol` | frame parser, payload encoder/decoder |
+| `board-vm-ir` | bytecode module parser, decoder, validator |
+| `board-vm-runtime` | VM state, run loop, capability dispatch |
+| `board-vm-arduino-uno` | AVR/Arduino Uno adapter, if Rust target support is viable |
+| `board-vm-rp2040` | RP2040 adapter |
+| `board-vm-esp32` | ESP32 adapter |
+| `board-vm-mbed-*` | MBed-style board adapters |
+
+If a classic AVR Arduino is awkward for Rust or too constrained for the first
+vertical slice, the architecture should still support it later. The first
+implemented board may be whichever gift board and Rust target are practical.
+
+## Memory Model
+
+The runtime must run without heap allocation by default. Board ports choose
+static buffer sizes at compile time:
+
+```rust
+pub struct RuntimeConfig {
+    pub max_frame_payload: usize,
+    pub max_program_bytes: usize,
+    pub max_stack_values: usize,
+    pub max_handles: usize,
+    pub max_log_bytes: usize,
+}
+```
+
+The runtime stores:
+
+```
+rx_frame_buffer: [u8; max_frame_payload]
+tx_frame_buffer: [u8; max_frame_payload]
+program_buffer: [u8; max_program_bytes]
+stack: [Value; max_stack_values]
+handles: [HandleSlot; max_handles]
+```
+
+Boards with a heap may opt into dynamic buffers later, but tests must cover the
+fixed-buffer path.
+
+## HAL Traits
+
+The runtime should depend on narrow traits rather than a specific embedded HAL.
+
+```rust
+pub trait Transport {
+    fn read_byte(&mut self) -> nb::Result<u8, TransportError>;
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), TransportError>;
+}
+
+pub trait Gpio {
+    fn open(&mut self, pin: PinId, mode: GpioMode) -> VmResult<HandleToken>;
+    fn write(&mut self, token: HandleToken, level: Level) -> VmResult<()>;
+    fn read(&mut self, token: HandleToken) -> VmResult<Level>;
+    fn close(&mut self, token: HandleToken) -> VmResult<()>;
+}
+
+pub trait Clock {
+    fn now_ms(&self) -> u32;
+    fn sleep_ms(&mut self, ms: u16) -> VmResult<()>;
+}
+
+pub trait ProgramStore {
+    fn is_available(&self) -> bool;
+    fn write_slot(&mut self, slot: u8, module: &[u8]) -> VmResult<()>;
+    fn read_slot(&mut self, slot: u8, out: &mut [u8]) -> VmResult<usize>;
+    fn boot_slot(&self) -> Option<u8>;
+}
+```
+
+`HandleToken` is private to the board adapter. The portable VM only sees compact
+`Handle` ids.
+
+## Capability Dispatch
+
+The interpreter dispatches `CALL_U8` and `CALL_U16` through a capability table.
+
+```
+CALL_U8 0x01 -> gpio.open
+CALL_U8 0x02 -> gpio.write
+CALL_U8 0x10 -> time.sleep_ms
+```
+
+Each handler:
+
+1. Checks stack types and count.
+2. Pops arguments.
+3. Resolves portable handles to board tokens.
+4. Calls the HAL trait.
+5. Pushes the result, if any.
+6. Converts HAL errors into portable VM errors.
+
+Board ports may omit handlers for unsupported capabilities. The descriptor must
+match the registered handlers.
+
+## Handle Table
+
+The handle table maps portable handles to board resources:
+
+```rust
+pub struct HandleSlot {
+    pub generation: u8,
+    pub kind: HandleKind,
+    pub token: HandleToken,
+    pub open: bool,
+}
+
+pub struct Handle {
+    pub index: u8,
+    pub generation: u8,
+}
+```
+
+Generation counters prevent stale handles from accidentally controlling a newly
+opened resource in the same slot.
+
+When a program ends:
+
+- Interactive runs close non-persistent handles unless `keep_handles_after_run`
+  was requested.
+- Stored programs keep handles until they halt, fault, or are stopped.
+- `RESET_VM` closes all handles.
+
+## Main Loop
+
+The firmware main loop is transport-driven:
+
+```
+loop:
+  poll transport for complete frame
+  if frame available:
+    decode protocol frame
+    dispatch message
+    send response
+
+  if background program is running:
+    run a small instruction slice
+    process yielded sleeps/events
+```
+
+Boards without background execution can run only foreground programs and return
+`UnsupportedCapability` or `BoardBusy` for background requests.
+
+## Instruction Budget
+
+Every run has an instruction budget. The runtime decrements it after each
+decoded instruction. If the budget reaches zero, foreground execution returns
+`BudgetExceeded`.
+
+Stored programs that are intended to run forever must either:
+
+- run as background tasks with periodic yields, or
+- be compiled into a firmware image where the board's normal watchdog policy
+  applies.
+
+## Boot Sequence
+
+```
+reset vector
+  -> board HAL init
+  -> transport init
+  -> Board VM runtime init
+  -> optional host grace period
+  -> if stored boot program exists and no host interrupts:
+       validate and run stored program
+     else:
+       enter command loop
+```
+
+The grace period lets a host recover a board with a bad stored program.
+
+## Eject Packaging
+
+There are two implementation paths.
+
+### Stored Bytecode
+
+If `ProgramStore` is available:
+
+1. Host uploads a validated module.
+2. Host sends `STORE_PROGRAM(slot, boot_policy)`.
+3. Runtime writes bytes to nonvolatile storage.
+4. On reset, runtime loads the slot and runs the module.
+
+### Embedded Firmware
+
+If runtime storage is unavailable or unsafe:
+
+1. Host builds a board-specific firmware package.
+2. The bytecode module is embedded as a static byte array.
+3. Board flashing tool installs the firmware.
+4. Runtime starts the embedded module at boot.
+
+The embedded path is also useful when a project is ready to become a normal
+firmware artifact.
+
+## Public API
+
+```rust
+pub struct Runtime<B: BoardHal, T: Transport, const CFG: RuntimeConfig> {
+    board: B,
+    transport: T,
+    vm: VmState<CFG>,
+}
+
+pub trait BoardHal {
+    type Gpio: Gpio;
+    type Clock: Clock;
+    type Store: ProgramStore;
+
+    fn descriptor(&self) -> BoardDescriptor;
+    fn gpio(&mut self) -> &mut Self::Gpio;
+    fn clock(&mut self) -> &mut Self::Clock;
+    fn store(&mut self) -> &mut Self::Store;
+}
+
+impl<B, T, const CFG: RuntimeConfig> Runtime<B, T, CFG>
+where
+    B: BoardHal,
+    T: Transport,
+{
+    pub fn poll(&mut self) -> RuntimePollResult;
+    pub fn run_slice(&mut self, max_instructions: u16) -> VmResult<RunSliceReport>;
+    pub fn reset_vm(&mut self) -> VmResult<()>;
+}
+```
+
+The exact const-generic syntax may change during implementation if stable Rust
+or embedded targets make another shape cleaner.
+
+## Test Strategy
+
+- Unit test VM execution with fake GPIO and fake clock.
+- Unit test handle generation and stale handle rejection.
+- Unit test capability descriptor matches registered handlers.
+- Unit test foreground and background run budget behavior.
+- Protocol integration test with in-memory transport.
+- Recovery test: bad stored program can be bypassed during host grace period.
+- Board smoke test: blink onboard LED.
+
+## Future Extensions
+
+- RTOS integration for true background tasks.
+- Interrupt-backed event subscriptions.
+- DMA-backed serial transports for high-throughput logging.
+- Persistent handle declarations for long-lived peripherals.
+- Firmware image generator for popular boards.
+- Board self-test command for pins, timers, and storage.

--- a/code/specs/BVM04-board-vm-host-sdks.md
+++ b/code/specs/BVM04-board-vm-host-sdks.md
@@ -1,0 +1,276 @@
+# BVM04 - Board VM Host SDKs
+
+## Overview
+
+Board VM is useful only if it feels natural from many programming languages.
+The host SDK contract defines how JS, Python, Ruby, Java, Lua, and CLI clients
+talk to the same board through the same binary protocol and bytecode IR.
+
+The SDKs are language-native at the surface, but boring underneath:
+
+```
+language API -> shared operation model -> BVM bytecode/protocol -> transport
+```
+
+The board must not know which language produced the bytes.
+
+## Layer Position
+
+```
+User code in JS / Python / Ruby / Java / Lua
+        |
+        v
+Language-specific SDK facade
+        |
+        v
+Shared BVM client model
+        |
+        v
+BVM01 protocol + BVM02 bytecode
+        |
+        v
+Serial / WebSerial / BLE / TCP
+        |
+        v
+Board VM runtime
+```
+
+## SDK Layers
+
+Each SDK should be split internally into five layers.
+
+| Layer | Responsibility |
+|---|---|
+| Transport | Open/read/write bytes for serial, WebSerial, BLE, TCP, etc. |
+| Codec | Encode/decode BVM01 frames and payloads |
+| Client | Request/response, timeouts, retries, board descriptor cache |
+| Compiler | Turn high-level operations into BVM02 bytecode |
+| Facade | Language-native `board.gpio(13).output()` style API |
+
+Only the facade should feel different across languages. The codec and compiler
+must be validated by shared golden vectors.
+
+## Reference API Shape
+
+The language-specific spelling can vary, but the conceptual API should be the
+same.
+
+```typescript
+const board = await BoardVm.connect({ path: "/dev/tty.usbmodem101" });
+const led = await board.gpio(13).output();
+
+await led.high();
+await board.sleepMs(250);
+await led.low();
+
+await board.eject("blink", async program => {
+  const led = await program.gpio(13).output();
+  while (true) {
+    await led.high();
+    await program.sleepMs(250);
+    await led.low();
+    await program.sleepMs(250);
+  }
+});
+```
+
+Equivalent Python:
+
+```python
+board = await BoardVm.connect(path="/dev/tty.usbmodem101")
+led = await board.gpio(13).output()
+
+await led.high()
+await board.sleep_ms(250)
+await led.low()
+```
+
+Equivalent Ruby:
+
+```ruby
+board = BoardVm.connect(path: "/dev/tty.usbmodem101")
+led = board.gpio(13).output
+
+led.high
+board.sleep_ms(250)
+led.low
+```
+
+All three examples must eventually encode the same operations.
+
+## REPL Contract
+
+The first CLI REPL can be line-oriented:
+
+```
+bvm> connect /dev/tty.usbmodem101
+connected arduino-uno runtime=bvm-rust-0.1
+bvm> caps
+bvm> gpio 13 output
+handle 1
+bvm> write 1 high
+ok
+bvm> sleep 250
+ok
+bvm> write 1 low
+ok
+bvm> eject blink examples/blink.bvm
+stored slot 0 boot=run
+```
+
+The REPL is not the protocol. It is a friendly host client that uses the same
+messages and bytecode as every SDK.
+
+## Board Discovery
+
+SDKs should support explicit and assisted connection.
+
+Explicit:
+
+```
+connect(path="/dev/tty.usbmodem101", baud=115200)
+```
+
+Assisted:
+
+```
+discover()
+  -> list serial ports
+  -> try HELLO on likely ports
+  -> return BoardDescriptor entries
+```
+
+Discovery must be conservative. It should not spam arbitrary serial devices
+with long messages. A single short `HELLO` with timeout is acceptable.
+
+## Golden Vectors
+
+The repository should contain shared fixtures:
+
+```
+code/fixtures/board-vm/protocol/
+  hello.json
+  hello.raw.hex
+  caps-report.json
+  caps-report.raw.hex
+
+code/fixtures/board-vm/bytecode/
+  blink.json
+  blink.hex
+  gpio-write-high.json
+  gpio-write-high.hex
+```
+
+Every SDK must prove:
+
+1. JSON model -> bytes equals `.hex`.
+2. bytes -> JSON model equals `.json`.
+3. High-level blink builder -> `blink.hex`.
+
+This is the mechanism that keeps Ruby, Python, JS, Java, Lua, and Rust honest.
+
+## Eject Contract
+
+An SDK can eject in three ways, depending on board support and host tooling:
+
+| Eject mode | Requirement | SDK action |
+|---|---|---|
+| `store` | board reports `supports_store_program` | upload module and send `STORE_PROGRAM` |
+| `firmware` | board package supports firmware generation | emit or flash runtime + embedded module |
+| `artifact` | user wants files only | write bytecode module and manifest |
+
+The eject manifest:
+
+```json
+{
+  "format": "board-vm-eject-v1",
+  "board_id": "arduino-uno",
+  "runtime": "board-vm-rust",
+  "program": "blink.bvm",
+  "bytecode_sha256": "...",
+  "capabilities": ["gpio.digital@1", "time.sleep@1"],
+  "entry": "main"
+}
+```
+
+SDKs must validate the program against the board descriptor before ejecting.
+
+## Error Handling
+
+Every SDK maps protocol errors to language-native exceptions or result types,
+but preserves:
+
+```
+code
+name
+request_id
+program_id
+bytecode_offset
+message
+```
+
+High-level APIs should fail early where possible. If the board does not report
+PWM, `board.pwm(...)` should fail before sending bytecode.
+
+## Concurrency
+
+The protocol does not require pipelining in v1. SDKs should serialize requests
+unless the board descriptor reports `transport.pipelining`.
+
+Language-specific async support:
+
+| Language | Default |
+|---|---|
+| JS/TypeScript | Promise-based |
+| Python | asyncio first, sync wrapper optional |
+| Ruby | sync first, fiber support later |
+| Java | blocking client first, CompletableFuture later |
+| Lua | sync first |
+| Rust host | sync client first, async feature later |
+
+## Public API
+
+The conceptual client interface:
+
+```rust
+pub trait BoardVmClient {
+    fn connect(target: ConnectTarget) -> Result<Self, ConnectError>
+    where
+        Self: Sized;
+
+    fn descriptor(&self) -> &BoardDescriptor;
+    fn upload(&mut self, program: BytecodeModule) -> Result<ProgramId, ClientError>;
+    fn run(&mut self, program: ProgramId, options: RunOptions) -> Result<RunReport, ClientError>;
+    fn store(&mut self, program: ProgramId, slot: u8, boot: BootPolicy) -> Result<(), ClientError>;
+    fn reset_vm(&mut self) -> Result<(), ClientError>;
+}
+```
+
+The high-level hardware facade:
+
+```rust
+pub trait BoardFacade {
+    fn gpio(&mut self, pin: u16) -> GpioBuilder;
+    fn sleep_ms(&mut self, ms: u16) -> Result<(), ClientError>;
+    fn compile_program<F>(&mut self, build: F) -> Result<BytecodeModule, CompileError>;
+}
+```
+
+## Test Strategy
+
+- Golden protocol vectors in every SDK.
+- Golden bytecode vectors in every SDK.
+- Fake transport tests for request/response and timeouts.
+- Descriptor-driven unsupported-operation tests.
+- REPL smoke tests using a fake board.
+- Cross-language parity test: JS, Python, Ruby, Java, Lua builders all emit the
+  same blink bytecode.
+
+## Future Extensions
+
+- Generated SDK codecs from a compact schema.
+- Browser WebSerial client.
+- Notebook integrations for Python and JS.
+- Graphical pin explorer.
+- Timeline view of events/logs returned by the board.
+- Source maps from host code to bytecode offsets for debugging.

--- a/code/specs/BVM05-board-vm-blink-mvp.md
+++ b/code/specs/BVM05-board-vm-blink-mvp.md
@@ -1,0 +1,318 @@
+# BVM05 - Board VM Blink MVP
+
+## Overview
+
+The blink MVP is the first end-to-end Board VM scenario. It proves the whole
+idea with the smallest useful hardware behavior:
+
+1. Connect to a board.
+2. Query capabilities.
+3. Upload bytecode that controls a GPIO pin.
+4. Run it and observe an LED blink.
+5. Eject it so the board can blink without the host.
+
+This is the vertical slice that turns the architecture from a nice idea into a
+thing that breathes.
+
+## Scope
+
+In scope:
+
+- One supported board.
+- One transport, preferably USB serial / UART.
+- `HELLO`, `CAPS_QUERY`, bytecode upload, `RUN`, and one eject path.
+- GPIO output.
+- Millisecond sleep.
+- Fake-board tests.
+- One hardware smoke test.
+
+Out of scope for this MVP:
+
+- PWM.
+- ADC.
+- I2C/SPI.
+- Event subscriptions.
+- Multi-language SDKs beyond the reference host.
+- Full graphical app.
+- Secure wireless pairing.
+
+## Required Capabilities
+
+The target board must advertise:
+
+| Capability | ID | Required operation |
+|---|---:|---|
+| `gpio.digital` | `0x01..0x04` | open output and write level |
+| `time.sleep` | `0x10` | sleep for milliseconds |
+| `program.ram_exec` | `0x7001` | upload and run bytecode |
+
+For eject, it must support at least one:
+
+| Eject support | Mechanism |
+|---|---|
+| `program.store` (`0x7002`) | store bytecode in nonvolatile memory |
+| firmware embedding | host builds runtime with embedded bytecode |
+
+## User Story
+
+CLI flow:
+
+```
+$ bvm connect /dev/tty.usbmodem101
+connected board=arduino runtime=board-vm-rust protocol=1
+
+bvm> caps
+gpio.digital@1
+time.sleep@1
+program.ram_exec@1
+program.store@1
+
+bvm> blink 13 --high-ms 250 --low-ms 250
+uploaded program 1, 26 code bytes
+running
+
+bvm> eject blink --slot 0 --boot run
+stored program 1 in slot 0
+```
+
+After reset, the board blinks the same LED without the host attached.
+
+## Protocol Flow
+
+### 1. Handshake
+
+Host sends `HELLO`:
+
+```
+min_version = 1
+max_version = 1
+host_name = "board-vm-host"
+host_nonce = random u32
+```
+
+Board replies `HELLO_ACK`:
+
+```
+selected_version = 1
+board_name = "<board id>"
+runtime_name = "board-vm-rust"
+host_nonce = echoed
+board_nonce = random u32
+max_frame_payload = board-specific
+```
+
+### 2. Capabilities
+
+Host sends `CAPS_QUERY`.
+
+Board replies with at least:
+
+```
+gpio.digital@1
+time.sleep@1
+program.ram_exec@1
+```
+
+If there is a known onboard LED, the board descriptor should include it:
+
+```
+metadata:
+  onboard_led_pin: 13
+  pin_numbering: "arduino-digital"
+```
+
+The first version may expose this metadata as a descriptor extension string
+until BVM01 grows a formal metadata section.
+
+### 3. Upload Blink Program
+
+Host builds the BVM02 bytecode:
+
+```
+12 0D       PUSH_U8 13
+12 01       PUSH_U8 1
+40 01       CALL_U8 gpio.open
+20          DUP
+11          PUSH_TRUE
+40 02       CALL_U8 gpio.write
+13 FA 00    PUSH_U16 250
+40 10       CALL_U8 time.sleep_ms
+20          DUP
+10          PUSH_FALSE
+40 02       CALL_U8 gpio.write
+13 FA 00    PUSH_U16 250
+40 10       CALL_U8 time.sleep_ms
+30 EC       JUMP_S8 -20
+```
+
+Raw code bytes:
+
+```
+12 0D 12 01 40 01 20 11 40 02 13 FA 00 40 10 20
+10 40 02 13 FA 00 40 10 30 EC
+```
+
+For upload, the host wraps the code in a BVM1 module with
+`program_may_run_forever` set, `max_stack = 4`, and an empty constant pool.
+That full module is 36 bytes:
+
+```
+42 56 4D 31 01 01 04 00 1A
+12 0D 12 01 40 01 20 11 40 02 13 FA 00 40 10 20
+10 40 02 13 FA 00 40 10 30 EC
+00
+```
+
+Host sends:
+
+```
+PROGRAM_BEGIN(program_id=1, format=BVM_MODULE, total_len=36, crc32=...)
+PROGRAM_CHUNK(program_id=1, offset=0, bytes=module)
+PROGRAM_END(program_id=1)
+```
+
+The board validates and acknowledges the program.
+
+### 4. Run
+
+Host sends:
+
+```
+RUN(
+  program_id = 1,
+  flags = background_run | reset_vm_before_run,
+  instruction_budget = 1000,
+  time_budget_ms = 0
+)
+```
+
+`time_budget_ms = 0` means no wall-clock limit for background execution.
+
+Board replies:
+
+```
+RUN_REPORT(
+  status = running,
+  instructions_executed = small nonzero count,
+  open_handles = 1
+)
+```
+
+The LED should now blink.
+
+### 5. Stop
+
+Host sends `STOP`.
+
+Board closes the GPIO handle, stops the program, and replies with a final
+`RUN_REPORT(status=stopped)`.
+
+### 6. Eject
+
+If the board supports storage:
+
+```
+STORE_PROGRAM(program_id=1, slot=0, boot_policy=run_at_boot)
+```
+
+If the board does not support storage, the host creates a firmware artifact:
+
+```
+blink/
+  manifest.json
+  blink.bvm
+  firmware.<board-specific extension>
+```
+
+## Fake Board Expected Trace
+
+Running the blink bytecode for one loop on a fake board should produce:
+
+```
+gpio.open(pin=13, mode=output) -> handle 1
+gpio.write(handle=1, level=true)
+time.sleep_ms(250)
+gpio.write(handle=1, level=false)
+time.sleep_ms(250)
+jump(loop_start)
+```
+
+For tests, the fake clock should not actually sleep. It records requested
+durations and advances virtual time.
+
+## Implementation Milestones
+
+### Milestone 1: bytecode only
+
+- Implement BVM02 decoder.
+- Implement fake runtime with GPIO and clock.
+- Execute blink bytecode in memory.
+- Assert fake trace.
+
+### Milestone 2: protocol loopback
+
+- Implement BVM01 raw frame codec.
+- Implement COBS + CRC.
+- Upload blink over in-memory transport.
+- Run blink against fake board through request/response messages.
+
+### Milestone 3: hardware foreground
+
+- Flash runtime firmware manually.
+- Connect over serial.
+- Handshake and capability query.
+- Upload one-shot GPIO high/low programs.
+
+### Milestone 4: hardware background blink
+
+- Upload the 26-byte blink loop.
+- Run in background.
+- Verify board still responds to `PING` and `STOP`.
+
+### Milestone 5: eject
+
+- Store bytecode on board, or generate embedded firmware.
+- Reset board.
+- Verify blink starts without host commands.
+
+## Public Test Fixtures
+
+Create:
+
+```
+code/fixtures/board-vm/bytecode/blink.hex
+code/fixtures/board-vm/bytecode/blink.json
+code/fixtures/board-vm/protocol/run-blink-session.json
+```
+
+`blink.json`:
+
+```json
+{
+  "name": "blink",
+  "pin": 13,
+  "high_ms": 250,
+  "low_ms": 250,
+  "code_hex": "120d120140012011400213fa0040102010400213fa00401030ec",
+  "module_hex": "42564d31010104001a120d120140012011400213fa0040102010400213fa00401030ec00"
+}
+```
+
+## Done Criteria
+
+- Clean repo build/tests for the new Rust packages.
+- Fake-board blink test passes.
+- Protocol loopback blink test passes.
+- A supported physical board blinks an LED through uploaded bytecode.
+- `STOP` recovers control without reflashing.
+- Eject path produces either stored boot behavior or a flashable firmware
+  artifact.
+- Specs BVM00 through BVM05 are updated with any discoveries from hardware.
+
+## Future Extensions
+
+- `motor` helper built on GPIO + PWM.
+- `tone` helper built on PWM.
+- `watch` command for pin-change events.
+- Browser REPL using WebSerial.
+- Multi-language SDK parity for blink.

--- a/code/specs/README.md
+++ b/code/specs/README.md
@@ -38,6 +38,16 @@ Specs are numbered **top-down** — from the user-facing language down to silico
 | 10-pipeline | Pipeline Orchestrator | Chains all layers together |
 | 11-html-visualizer | HTML Visualizer | Renders pipeline output as HTML |
 
+**Interactive hardware specs**:
+| # | Spec | Purpose |
+|---|------|---------|
+| BVM00 | Board VM Architecture | Interactive physical-board runtime and package map |
+| BVM01 | Board VM Binary Protocol | Compact transport-agnostic host/board protocol |
+| BVM02 | Board VM Bytecode IR | Portable bytecode and capability calls |
+| BVM03 | Board VM Rust Runtime | `no_std` firmware runtime and board HAL contract |
+| BVM04 | Board VM Host SDKs | Language-agnostic SDK and REPL contract |
+| BVM05 | Board VM Blink MVP | First end-to-end Arduino-style blink scenario |
+
 ## Spec Template
 
 Each spec follows this structure:


### PR DESCRIPTION
## Summary

Adds the initial Board VM specification family for interactive physical-board development:

- architecture and package map for a portable IR plus board-specific Rust runtime
- compact binary host/board protocol over UART-style transports
- portable bytecode IR with GPIO/time capability calls
- `no_std` Rust runtime and HAL contract
- language-agnostic host SDK/REPL contract
- concrete blink MVP with exact bytecode, protocol flow, fake-board trace, and eject criteria

## Why

This captures the resurrected hardware REPL idea as specs before implementation, with the protocol as the product and host languages as thin clients.

## Validation

- `git diff --cached --check`
- `git diff --check`
- ASCII scan over the new BVM spec files

No code tests were run; this PR is documentation/specification only.