### PR TITLE
feat(prolog): read CLI source from stdin

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -274,6 +274,13 @@ Use `--values` to print raw answer values, omit `--query` to run a source-level
 `?-` directive by index, and use `--dialect iso` when the ISO parser profile is
 the desired frontend.
 
+Use `--source-stdin` when editor integrations or shell pipelines should provide
+the source through stdin while query selection still comes from flags:
+
+```bash
+cat family.pl | prolog-vm --source-stdin --query "parent(homer, Who)"
+```
+
 Use `--check` to parse, load, compile, and initialize source without running a
 query. This is intended for CI and editor integrations that need to validate a
 Prolog file graph even when it does not contain embedded `?-` directives.

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -132,6 +132,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     queries = _string_tuple(flags["query"])
     query_module = _optional_string(flags["query-module"])
     limit = _optional_int(flags["limit"])
+    source_stdin = bool(flags["source-stdin"])
     source_query_index = _required_int(
         flags["source-query-index"],
         name="--source-query-index",
@@ -143,6 +144,17 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if source is not None and files:
         msg = "--source cannot be combined with file paths"
         raise ValueError(msg)
+    if source_stdin and source is not None:
+        msg = "--source-stdin cannot be combined with --source"
+        raise ValueError(msg)
+    if source_stdin and files:
+        msg = "--source-stdin cannot be combined with file paths"
+        raise ValueError(msg)
+    if source_stdin and bool(flags["interactive"]):
+        msg = "--source-stdin cannot be combined with --interactive"
+        raise ValueError(msg)
+    if source_stdin:
+        source = sys.stdin.read()
     if source is None and not files:
         msg = "provide --source or at least one Prolog file"
         raise ValueError(msg)

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
@@ -17,6 +17,12 @@
       "value_name": "SOURCE"
     },
     {
+      "id": "source-stdin",
+      "long": "source-stdin",
+      "description": "Read Prolog source text from stdin instead of --source or file paths.",
+      "type": "boolean"
+    },
+    {
       "id": "query",
       "long": "query",
       "description": "Ad-hoc top-level query to run; may be repeated for a stateful query script.",

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -29,6 +29,61 @@ def test_cli_runs_inline_ad_hoc_query_with_bytecode_values(
     assert capsys.readouterr().out.splitlines() == ["bart.", "lisa."]
 
 
+def test_cli_reads_source_from_stdin_for_ad_hoc_queries(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO("parent(homer, bart). parent(homer, lisa)."),
+    )
+
+    status = main([
+        "--source-stdin",
+        "--query",
+        "parent(homer, Who)",
+        "--backend",
+        "bytecode",
+    ])
+
+    assert status == 0
+    assert capsys.readouterr().out.splitlines() == [
+        "Who = bart.",
+        "Who = lisa.",
+    ]
+
+
+def test_cli_reads_source_queries_from_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO("parent(homer, bart). ?- parent(homer, Who)."),
+    )
+
+    status = main(["--source-stdin"])
+
+    assert status == 0
+    assert capsys.readouterr().out == "Who = bart.\n"
+
+
+def test_cli_source_stdin_rejects_interactive_mode_without_reading_stdin(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source-stdin",
+        "--interactive",
+    ])
+
+    assert status == 2
+    assert "--source-stdin cannot be combined with --interactive" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_repeated_queries_share_committed_runtime_state(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -10,6 +10,7 @@ package for argument parsing.
 The goal is practical usability:
 
 - run inline Prolog source through the structured VM or bytecode VM
+- run Prolog source piped through stdin
 - run a single `.pl` file or linked file graph
 - check that source parses, loads, compiles, and initializes without a query
 - list embedded source-level `?-` query indexes and visible variables
@@ -29,6 +30,8 @@ prolog-vm [OPTIONS] [FILE...]
 Important options:
 
 - `--source SOURCE` loads inline source instead of files.
+- `--source-stdin` reads source text from stdin instead of `--source` or
+  files.
 - `--query QUERY` runs an ad-hoc top-level query. It may be repeated.
 - `--check` parses, loads, compiles, and initializes without running a query.
 - `--list-source-queries` lists embedded `?-` query indexes and visible
@@ -71,6 +74,19 @@ Expected output:
 true.
 Value = saved.
 ```
+
+## Pipeline Source Input
+
+`--source-stdin` reads Prolog source text from stdin before selecting the query
+mode. This lets editors, generated source pipelines, and shell scripts avoid
+temporary files while keeping execution on the same compiled VM path:
+
+```bash
+cat family.pl | prolog-vm --source-stdin --query "parent(homer, Who)"
+```
+
+Because `--interactive` also consumes stdin, the two modes are intentionally
+mutually exclusive.
 
 ## Machine-Readable Output
 
@@ -149,6 +165,7 @@ setup phase before entering the top-level loop.
 The CLI test coverage should prove:
 
 - inline source ad-hoc queries through bytecode
+- stdin source ad-hoc and stored source queries
 - query-free compile/check mode
 - source query listing without execution
 - stored source-level queries from files


### PR DESCRIPTION
## Summary
- add `prolog-vm --source-stdin` through the CLI builder spec for pipeline/editor source input
- route stdin source through the existing source/query execution path while rejecting stdin-consuming interactive mode
- document PR77 pipeline input and cover ad-hoc plus embedded source-query execution from stdin

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-source-stdin -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-source-stdin-build-plan.json`