### PR TITLE
Recover leading unquoted attribute value characters

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -103,6 +103,8 @@ documented in this file.
 - Unquoted attribute values now preserve unexpected characters such as `"`,
   `'`, `<`, `=`, and `` ` `` while reporting
   `unexpected-character-in-unquoted-attribute-value`.
+- Unexpected `<`, `=`, and `` ` `` characters immediately after an attribute
+  `=` now use the same unquoted attribute-value diagnostic recovery.
 - NULL characters in data/RCDATA/RAWTEXT/PLAINTEXT/CDATA/script data and
   attribute values now recover with `unexpected-null-character` and append
   U+FFFD.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -85,7 +85,8 @@ reconsume path, so jammed attributes such as `href="x"title=y` still recover
 while `=` and NULL characters receive their normal attribute-name diagnostics.
 Unquoted attribute values also preserve spec-defined unexpected characters
 such as `"`, `'`, `<`, `=`, and `` ` `` while reporting
-`unexpected-character-in-unquoted-attribute-value`.
+`unexpected-character-in-unquoted-attribute-value`, including when the first
+value character appears immediately after `=`.
 EOF inside ordinary start/end tag construction now reports the relevant
 EOF-in-tag diagnostic and drops the incomplete token instead of handing a
 partial tag to the future parser.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -3590,6 +3590,33 @@ actions = [
 
 [[transitions]]
 from = "before_attribute_value"
+matcher = { literal = "<" }
+to = "attribute_value_unquoted"
+actions = [
+  "parse_error(unexpected-character-in-unquoted-attribute-value)",
+  "append_attribute_value(current)",
+]
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = "=" }
+to = "attribute_value_unquoted"
+actions = [
+  "parse_error(unexpected-character-in-unquoted-attribute-value)",
+  "append_attribute_value(current)",
+]
+
+[[transitions]]
+from = "before_attribute_value"
+matcher = { literal = "`" }
+to = "attribute_value_unquoted"
+actions = [
+  "parse_error(unexpected-character-in-unquoted-attribute-value)",
+  "append_attribute_value(current)",
+]
+
+[[transitions]]
+from = "before_attribute_value"
 matcher = { anything = true }
 to = "attribute_value_unquoted"
 actions = ["append_attribute_value(current)"]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -8021,6 +8021,54 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "before_attribute_value".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("<".to_string())),
+            to: vec![
+                "attribute_value_unquoted".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-unquoted-attribute-value)".to_string(),
+                "append_attribute_value(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_value".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("=".to_string())),
+            to: vec![
+                "attribute_value_unquoted".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-unquoted-attribute-value)".to_string(),
+                "append_attribute_value(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_value".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("`".to_string())),
+            to: vec![
+                "attribute_value_unquoted".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-unquoted-attribute-value)".to_string(),
+                "append_attribute_value(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_value".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "attribute_value_unquoted".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -337,6 +337,53 @@ fn default_html_lexer_reports_unexpected_chars_in_unquoted_attribute_values() {
 }
 
 #[test]
+fn default_html_lexer_reports_first_unquoted_attribute_value_characters() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<a lt=<x eq==x tick=`x ok=value>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "lt".to_string(),
+                        value: "<x".to_string(),
+                    },
+                    Attribute {
+                        name: "eq".to_string(),
+                        value: "=x".to_string(),
+                    },
+                    Attribute {
+                        name: "tick".to_string(),
+                        value: "`x".to_string(),
+                    },
+                    Attribute {
+                        name: "ok".to_string(),
+                        value: "value".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == "unexpected-character-in-unquoted-attribute-value"
+            })
+            .count(),
+        3
+    );
+}
+
+#[test]
 fn default_html_lexer_reconsumes_missing_space_after_quoted_attributes() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Report unquoted attribute-value diagnostics for `<`, `=`, and backtick when they appear immediately after an attribute `=`.
- Mirror the authored HTML1 lexer state-machine update into the checked-in generated Rust table.
- Document the recovery behavior and add focused lexer coverage for first-character unquoted value recovery.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check