### PR TITLE
Support forward ALGOL array bound analysis

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -35,6 +35,9 @@ All notable changes to this package will be documented in this file.
 - Lowered switch entries that select later sibling switch declarations now
   that the checker resolves switch designational lists after declaration
   registration.
+- Lowered array bounds whose expressions call later sibling typed procedures
+  now that the checker defers bound analysis until declaration registration
+  completes.
 - Lowered integer array-element by-name actuals to tagged descriptors with
   generated eval/store helpers that re-compute the element address on every
   formal read or assignment.

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -32,6 +32,9 @@ block entry, stores row-major stride metadata beside the descriptor, and emits
 checked element loads/stores through the descriptor. Block and procedure exits
 restore the heap pointer to the activation's entry mark, so dynamic arrays keep
 ALGOL block lifetime instead of leaking through loops or recursive calls.
+Because the checker defers bound expression analysis until declaration
+registration completes, those lower/upper expressions can call later sibling
+typed procedures in the same block.
 
 Expression lowering includes mixed integer/real arithmetic, boolean operators,
 comparisons, chained assignment targets, branch-selected conditional

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1599,6 +1599,22 @@ class TestAlgolIrCompiler:
         assert opcodes.count(IrOp.MUL) >= 4
         assert opcodes.count(IrOp.CMP_GT) >= 6
 
+    def test_compiles_forward_procedure_calls_in_array_bounds(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer array a[lower():upper()]; "
+                "integer procedure lower; begin lower := 0 end; "
+                "integer procedure upper; begin upper := 0 end; "
+                "a[0] := 5; result := a[0] "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+
+        assert opcodes.count(IrOp.CALL) >= 2
+        assert "a@block0" in result.variable_slots
+
     def test_compiles_integer_value_procedure_call(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -49,6 +49,9 @@ All notable changes to this package will be documented in this file.
   typed procedures.
 - Registered switch names before checking switch designational lists, allowing
   switch entries to target later sibling switch declarations in the same block.
+- Deferred array-bound expression checking until after sibling declaration
+  registration, allowing bounds to call later typed procedures in the same
+  block.
 - Accepted integer-returning procedure actuals for real-valued formal
   procedure parameters, matching scalar integer-to-real promotion.
 - Accepted switch declaration entries that target labels in lexical parent

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -46,7 +46,9 @@ own bodies still resolve as storage.
 Integer array declarations receive descriptor slots in their declaring frame,
 dimension metadata for lower/upper bound expressions, and resolved read/write
 accesses that preserve the static-link delta and subscript count needed by the
-IR and WASM lowering stages.
+IR and WASM lowering stages. Array bound expressions are checked after the
+block's declaration signatures are registered, so bounds can call later sibling
+typed procedures in the same declaration part.
 Labels receive stable label descriptors and direct local `goto`/`go to` statements
 resolve to those descriptors. Direct nonlocal block `goto` statements resolve
 to outer active blocks, and procedure-crossing transfers resolve to pending

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -409,6 +409,14 @@ class _PendingSwitchDeclaration:
 
 
 @dataclass(frozen=True)
+class _PendingArrayBounds:
+    """Array bound expressions to check after sibling declarations are visible."""
+
+    scope: Scope
+    bounds: tuple[tuple[ASTNode, ASTNode], ...]
+
+
+@dataclass(frozen=True)
 class ResolvedSwitchSelection:
     """A switch subscript occurrence after semantic lookup."""
 
@@ -582,6 +590,7 @@ class AlgolTypeChecker:
             if child.rule_name == "statement":
                 self._collect_statement_labels(child, scope)
 
+        pending_array_bounds: list[_PendingArrayBounds] = []
         pending_switches: list[_PendingSwitchDeclaration] = []
         pending_procedures: list[_PendingProcedureDeclaration] = []
         for child in _node_children(block):
@@ -592,9 +601,16 @@ class AlgolTypeChecker:
                     if pending is not None:
                         pending_switches.append(pending)
                     continue
-                pending = self._check_declaration(child, scope)
+                pending = self._check_declaration(
+                    child,
+                    scope,
+                    pending_array_bounds=pending_array_bounds,
+                )
                 if pending is not None:
                     pending_procedures.append(pending)
+
+        for pending in pending_array_bounds:
+            self._check_pending_array_bounds(pending)
 
         for pending in pending_switches:
             self._check_pending_switch_declaration(pending)
@@ -653,6 +669,8 @@ class AlgolTypeChecker:
         self,
         declaration: ASTNode,
         scope: Scope,
+        *,
+        pending_array_bounds: list[_PendingArrayBounds] | None = None,
     ) -> _PendingProcedureDeclaration | None:
         inner = _first_ast_child(declaration)
         if inner is None:
@@ -663,10 +681,26 @@ class AlgolTypeChecker:
             self._check_scalar_declaration(inner, scope, storage_class=STATIC)
             return None
         if inner.rule_name == "own_array_decl":
-            self._check_array_declaration(inner, scope, storage_class=STATIC)
+            pending = self._register_array_declaration(
+                inner,
+                scope,
+                storage_class=STATIC,
+            )
+            if pending_array_bounds is None:
+                self._check_pending_array_bounds(pending)
+            else:
+                pending_array_bounds.append(pending)
             return None
         if inner.rule_name == "array_decl":
-            self._check_array_declaration(inner, scope, storage_class="frame")
+            pending = self._register_array_declaration(
+                inner,
+                scope,
+                storage_class="frame",
+            )
+            if pending_array_bounds is None:
+                self._check_pending_array_bounds(pending)
+            else:
+                pending_array_bounds.append(pending)
             return None
         if inner.rule_name == "switch_decl":
             pending = self._register_switch_declaration(inner, scope)
@@ -732,13 +766,13 @@ class AlgolTypeChecker:
         symbol.slot_size = FRAME_WORD_SIZE
         self._next_static_offset += FRAME_WORD_SIZE
 
-    def _check_array_declaration(
+    def _register_array_declaration(
         self,
         node: ASTNode,
         scope: Scope,
         *,
         storage_class: str,
-    ) -> None:
+    ) -> _PendingArrayBounds:
         type_node = _first_direct_node(node, "type")
         element_type = (
             _first_keyword_value(type_node) if type_node is not None else REAL
@@ -748,8 +782,9 @@ class AlgolTypeChecker:
                 node,
                 f"{element_type} arrays are not supported yet",
             )
-            return
+            return _PendingArrayBounds(scope=scope, bounds=())
 
+        pending_bounds: list[tuple[ASTNode, ASTNode]] = []
         for segment in _direct_nodes(node, "array_segment"):
             bound_pairs = _direct_nodes(segment, "bound_pair")
             if not bound_pairs:
@@ -769,14 +804,13 @@ class AlgolTypeChecker:
                 if len(bounds) != 2:
                     self._error(bound_pair, "array bounds must be lower:upper pairs")
                     continue
-                for bound in bounds:
-                    bound_type = self._infer_expr(bound, scope)
-                    if bound_type != ERROR and bound_type != INTEGER:
-                        self._error(bound, "array bounds must be integer")
+                lower_bound = bounds[0]
+                upper_bound = bounds[1]
+                pending_bounds.append((lower_bound, upper_bound))
                 dimensions.append(
                     ArrayDimension(
-                        lower_node_id=id(bounds[0]),
-                        upper_node_id=id(bounds[1]),
+                        lower_node_id=id(lower_bound),
+                        upper_node_id=id(upper_bound),
                     )
                 )
 
@@ -825,6 +859,14 @@ class AlgolTypeChecker:
                         column=name_token.column,
                     )
                 )
+        return _PendingArrayBounds(scope=scope, bounds=tuple(pending_bounds))
+
+    def _check_pending_array_bounds(self, pending: _PendingArrayBounds) -> None:
+        for lower_bound, upper_bound in pending.bounds:
+            for bound in (lower_bound, upper_bound):
+                bound_type = self._infer_expr(bound, pending.scope)
+                if bound_type != ERROR and bound_type != INTEGER:
+                    self._error(bound, "array bounds must be integer")
 
     def _register_switch_declaration(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -2067,6 +2067,25 @@ class TestAlgolTypeChecker:
             "read",
         ]
 
+    def test_accepts_forward_procedure_calls_in_array_bounds(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer array a[lower():upper()]; "
+            "integer procedure lower; begin lower := 0 end; "
+            "integer procedure upper; begin upper := 0 end; "
+            "a[0] := 5; result := a[0] "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert result.semantic.arrays[0].name == "a"
+        assert [call.name for call in result.semantic.procedure_calls[:2]] == [
+            "lower",
+            "upper",
+        ]
+
     def test_accepts_default_real_array_declaration(self) -> None:
         ast = parse_algol("begin array a[1:3]; a[1] := 7 end")
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -94,6 +94,8 @@ All notable changes to this package will be documented in this file.
   procedure body.
 - Executed switch entries that select later sibling switch declarations,
   including forward switch lists that use later typed procedure predicates.
+- Executed array bounds that call later sibling typed procedures at block
+  entry.
 - Executed subscripted integer and real array elements as writable `for`
   statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -17,7 +17,8 @@ the current lane already supports a substantial ALGOL 60 surface:
 - `integer`, `boolean`, `real`, and `string` scalar values
 - `own` scalars and arrays with static lifetime
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
-  bounds and checked element access
+  bounds, including bounds that call later sibling typed procedures, and
+  checked element access
 - case-insensitive keywords, comments, and standard builtins,
   `!=`/`<>`/`≠` not-equal spelling, ALGOL publication symbols such as `≤`,
   `≥`, `↑`, `×`, `÷`, `¬`, `∧`, `∨`, `⊃`, `≡`, and single- or double-quoted
@@ -161,7 +162,8 @@ local WASM runtime. Those fixtures cover:
   static link
 - nonlocal procedure `goto` that unwinds dynamic array storage before the
   caller resumes at the target label
-- dynamic multidimensional array bounds captured at block entry
+- dynamic multidimensional array bounds captured at block entry, including
+  bounds that call later sibling typed procedures
 - writable real, boolean, and string by-name scalar formals in one program
 - real, boolean, and string by-name actuals through scalar storage,
   array-element storage, expression thunks, and formal-procedure forwarding
@@ -180,9 +182,9 @@ local WASM runtime. Those fixtures cover:
   forms, parenthesized conditional designational expressions, numeric labels,
   boolean operators, real arithmetic, and output
 - a surface-audit matrix for publication notation, procedure-call spellings,
-  forward procedure and switch visibility, loop forms, typed formal procedures,
-  value array copies, nonlocal switch/goto cleanup, and programs without the
-  `result` compatibility scalar
+  forward procedure, switch, and array-bound visibility, loop forms, typed
+  formal procedures, value array copies, nonlocal switch/goto cleanup, and
+  programs without the `result` compatibility scalar
 
 ## Dependencies
 

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1835,6 +1835,17 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_forward_procedure_calls_in_array_bounds_execute(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer array a[lower():upper()]; "
+            "integer procedure lower; begin lower := 0 end; "
+            "integer procedure upper; begin upper := 0 end; "
+            "a[0] := 5; result := a[0] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
+
     def test_procedure_body_sees_later_block_declarations(self) -> None:
         result = compile_source(
             "begin "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -104,6 +104,23 @@ _SURFACE_CASES = (
         stdout="SWITCH 13",
     ),
     SurfaceCase(
+        name="forward-array-bound-visibility",
+        source="""
+            begin
+              integer result;
+              integer array a[lower():upper()];
+              integer procedure lower; begin lower := 0 end;
+              integer procedure upper; begin upper := 1 end;
+              a[0] := 5;
+              a[1] := 8;
+              result := a[0] + a[1];
+              print('ARRAY ', result)
+            end
+        """,
+        result=[13],
+        stdout="ARRAY 13",
+    ),
+    SurfaceCase(
         name="for-list-scalar-and-array-control",
         source="""
             begin


### PR DESCRIPTION
## Summary
- defer ALGOL array-bound expression checking until sibling declarations are registered
- allow bounds to call later sibling typed procedures while preserving descriptor metadata and block-entry runtime allocation
- add type-checker, IR, WASM, and surface-audit coverage for forward procedure calls in array bounds

## Verification
- bash BUILD (algol-type-checker)
- bash BUILD (algol-ir-compiler)
- bash BUILD (algol-wasm-compiler)
- ruff check on touched Python files
- git diff --check
- security scan over touched files for subprocess/shell/eval/exec/network/file-removal APIs; only existing eval-named test matched