### PR TITLE
feat(prolog): dump CLI bytecode disassembly

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -285,6 +285,14 @@ Use `--check` to parse, load, compile, and initialize source without running a
 query. This is intended for CI and editor integrations that need to validate a
 Prolog file graph even when it does not contain embedded `?-` directives.
 
+Use `--dump-bytecode` to compile source into Logic bytecode and print the
+loader-bytecode disassembly without executing queries. This is useful when
+diagnosing convergence between the structured VM and the bytecode VM:
+
+```bash
+prolog-vm --source "parent(homer, bart). ?- parent(homer, Who)." --dump-bytecode
+```
+
 Use `--list-source-queries` to inspect embedded `?-` directives before choosing
 what to run. Text output lists the zero-based query index and visible variables;
 JSON output emits the same metadata as a stable `source_queries` record.

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -18,6 +18,7 @@ from cli_builder import (
     ParseResult,
     VersionResult,
 )
+from logic_bytecode import LogicBytecodeProgram, disassemble, disassemble_text
 from logic_engine import Atom, Compound, Disequality, LogicVar, Number, String, Term
 
 from prolog_vm_compiler.compiler import (
@@ -28,6 +29,7 @@ from prolog_vm_compiler.compiler import (
     compile_prolog_file,
     compile_prolog_project_from_files,
     compile_prolog_source,
+    compile_prolog_to_bytecode,
     create_prolog_file_runtime,
     create_prolog_project_file_runtime,
     create_prolog_source_vm_runtime,
@@ -59,6 +61,7 @@ class CliArgs:
     source: str | None
     queries: tuple[str, ...]
     check: bool
+    dump_bytecode: bool
     list_source_queries: bool
     source_query_index: int
     all_source_queries: bool
@@ -160,6 +163,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     all_source_queries = bool(flags["all-source-queries"])
     check = bool(flags["check"])
+    dump_bytecode = bool(flags["dump-bytecode"])
     list_source_queries = bool(flags["list-source-queries"])
     if check and queries:
         msg = "--check cannot be combined with --query"
@@ -169,6 +173,21 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if check and bool(flags["interactive"]):
         msg = "--check cannot be combined with --interactive"
+        raise ValueError(msg)
+    if dump_bytecode and queries:
+        msg = "--dump-bytecode cannot be combined with --query"
+        raise ValueError(msg)
+    if dump_bytecode and check:
+        msg = "--dump-bytecode cannot be combined with --check"
+        raise ValueError(msg)
+    if dump_bytecode and list_source_queries:
+        msg = "--dump-bytecode cannot be combined with --list-source-queries"
+        raise ValueError(msg)
+    if dump_bytecode and all_source_queries:
+        msg = "--dump-bytecode cannot be combined with --all-source-queries"
+        raise ValueError(msg)
+    if dump_bytecode and bool(flags["interactive"]):
+        msg = "--dump-bytecode cannot be combined with --interactive"
         raise ValueError(msg)
     if list_source_queries and queries:
         msg = "--list-source-queries cannot be combined with --query"
@@ -204,6 +223,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         source=source,
         queries=queries,
         check=check,
+        dump_bytecode=dump_bytecode,
         list_source_queries=list_source_queries,
         source_query_index=source_query_index,
         all_source_queries=all_source_queries,
@@ -345,6 +365,8 @@ def _required_int(value: object, *, name: str) -> int:
 def _run_cli(args: CliArgs) -> int:
     if args.check:
         return _run_check(args)
+    if args.dump_bytecode:
+        return _run_dump_bytecode(args)
     if args.list_source_queries:
         return _run_list_source_queries(args)
 
@@ -386,6 +408,13 @@ def _run_check(args: CliArgs) -> int:
     return 0
 
 
+def _run_dump_bytecode(args: CliArgs) -> int:
+    compiled_program = _compile_source_program(args)
+    bytecode = compile_prolog_to_bytecode(compiled_program)
+    _print_bytecode_dump(bytecode, args=args)
+    return 0
+
+
 def _run_list_source_queries(args: CliArgs) -> int:
     compiled_program = _compile_source_program(args)
     _print_source_query_summary(compiled_program, args=args)
@@ -422,6 +451,41 @@ def _print_source_query_summary(
         "mode": "source_queries",
         "source_query_count": compiled_program.source_query_count,
         "queries": query_summaries,
+    }
+    print(json.dumps(payload, sort_keys=True), file=output)
+
+
+def _print_bytecode_dump(
+    bytecode: LogicBytecodeProgram,
+    *,
+    args: CliArgs,
+    stdout: TextIO | None = None,
+) -> None:
+    output = sys.stdout if stdout is None else stdout
+    if args.output_format == "text":
+        text = disassemble_text(bytecode)
+        if text:
+            print(text, file=output)
+        return
+
+    lines = [
+        {
+            "index": line.index,
+            "opcode": line.opcode,
+            "operand": line.operand,
+            "comment": line.comment,
+        }
+        for line in disassemble(bytecode)
+    ]
+    payload = {
+        "success": True,
+        "mode": "bytecode",
+        "instruction_count": len(bytecode.instructions),
+        "relation_pool_count": len(bytecode.relation_pool),
+        "fact_pool_count": len(bytecode.fact_pool),
+        "rule_pool_count": len(bytecode.rule_pool),
+        "query_pool_count": len(bytecode.query_pool),
+        "lines": lines,
     }
     print(json.dumps(payload, sort_keys=True), file=output)
 

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
@@ -37,6 +37,12 @@
       "type": "boolean"
     },
     {
+      "id": "dump-bytecode",
+      "long": "dump-bytecode",
+      "description": "Compile source to Logic bytecode and print disassembly without running queries.",
+      "type": "boolean"
+    },
+    {
       "id": "list-source-queries",
       "long": "list-source-queries",
       "description": "List embedded source-level ?- queries without running them.",

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -158,6 +158,75 @@ def test_cli_check_rejects_ad_hoc_queries(
     assert "--check cannot be combined with --query" in capsys.readouterr().err
 
 
+def test_cli_dump_bytecode_renders_disassembly(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        "--dump-bytecode",
+    ])
+
+    assert status == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[0] == "0000: EMIT_RELATION 0 ; parent/2"
+    assert "EMIT_FACT" in lines[1]
+    assert "EMIT_QUERY" in lines[2]
+    assert lines[-1] == "0003: HALT"
+
+
+def test_cli_dump_bytecode_json_reports_pools_and_lines(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        "--dump-bytecode",
+        "--format",
+        "json",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert status == 0
+    assert payload["success"] is True
+    assert payload["mode"] == "bytecode"
+    assert payload["instruction_count"] == 4
+    assert payload["relation_pool_count"] == 1
+    assert payload["fact_pool_count"] == 1
+    assert payload["rule_pool_count"] == 0
+    assert payload["query_pool_count"] == 1
+    assert payload["lines"][0] == {
+        "comment": "parent/2",
+        "index": 0,
+        "opcode": "EMIT_RELATION",
+        "operand": 0,
+    }
+    assert payload["lines"][-1] == {
+        "comment": None,
+        "index": 3,
+        "opcode": "HALT",
+        "operand": None,
+    }
+
+
+def test_cli_dump_bytecode_rejects_execution_modes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--dump-bytecode",
+        "--query",
+        "parent(homer, Who)",
+    ])
+
+    assert status == 2
+    assert "--dump-bytecode cannot be combined with --query" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_lists_source_query_variables(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -13,6 +13,7 @@ The goal is practical usability:
 - run Prolog source piped through stdin
 - run a single `.pl` file or linked file graph
 - check that source parses, loads, compiles, and initializes without a query
+- dump Logic bytecode disassembly for compile-only diagnostics
 - list embedded source-level `?-` query indexes and visible variables
 - run stored source-level `?-` queries by index
 - run all stored source-level `?-` queries as an executable script
@@ -34,6 +35,8 @@ Important options:
   files.
 - `--query QUERY` runs an ad-hoc top-level query. It may be repeated.
 - `--check` parses, loads, compiles, and initializes without running a query.
+- `--dump-bytecode` compiles to Logic bytecode and emits disassembly without
+  executing queries.
 - `--list-source-queries` lists embedded `?-` query indexes and visible
   variables without running them.
 - `--source-query-index INDEX` selects a stored source-level query when no
@@ -98,6 +101,11 @@ JSON object per query result.
 When `--check` is set, JSON formats emit one success object with `mode:
 "check"`, `source_query_count`, `initialization_query_count`, `backend`, and
 whether initialization ran.
+
+When `--dump-bytecode` is set, text output emits bytecode disassembly lines.
+JSON formats emit one success object with `mode: "bytecode"`, pool counts, an
+`instruction_count`, and structured disassembly `lines`. This mode is
+compile-only and mutually exclusive with query execution modes.
 
 When `--list-source-queries` is set, JSON formats emit one success object with
 `mode: "source_queries"`, `source_query_count`, and a `queries` list containing
@@ -167,6 +175,7 @@ The CLI test coverage should prove:
 - inline source ad-hoc queries through bytecode
 - stdin source ad-hoc and stored source queries
 - query-free compile/check mode
+- bytecode disassembly dump mode
 - source query listing without execution
 - stored source-level queries from files
 - all source-level queries from files and inline source


### PR DESCRIPTION
## Summary
- add `prolog-vm --dump-bytecode` through the CLI builder spec as a compile-only diagnostic mode
- render Logic bytecode disassembly in text output and structured bytecode metadata in JSON formats
- document PR77 bytecode dump behavior and cover text, JSON, and execution-mode validation

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-dump-bytecode -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-dump-bytecode-build-plan.json`