### PR TITLE
Preserve ALGOL array bound declaration order

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this package will be documented in this file.
 - Lowered array bounds whose expressions call later sibling typed procedures
   now that the checker defers bound analysis until declaration registration
   completes.
+- Preserved array declaration-order semantics by relying on checker diagnostics
+  for bounds that read later array descriptors.
 - Lowered integer array-element by-name actuals to tagged descriptors with
   generated eval/store helpers that re-compute the element address on every
   formal read or assignment.

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -34,7 +34,9 @@ restore the heap pointer to the activation's entry mark, so dynamic arrays keep
 ALGOL block lifetime instead of leaking through loops or recursive calls.
 Because the checker defers bound expression analysis until declaration
 registration completes, those lower/upper expressions can call later sibling
-typed procedures in the same block.
+typed procedures in the same block. Bound expressions may read earlier array
+descriptors, but same-block arrays declared later remain rejected before IR
+lowering because their descriptors do not exist at allocation time.
 
 Expression lowering includes mixed integer/real arithmetic, boolean operators,
 comparisons, chained assignment targets, branch-selected conditional

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1615,6 +1615,28 @@ class TestAlgolIrCompiler:
         assert opcodes.count(IrOp.CALL) >= 2
         assert "a@block0" in result.variable_slots
 
+    def test_compiles_prior_array_accesses_in_array_bounds(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer array b[1:1]; integer array a[b[1]:b[1]]; "
+                "a[0] := 9; result := a[0] "
+                "end"
+            )
+        )
+
+        assert "b@block0" in result.variable_slots
+        assert "a@block0" in result.variable_slots
+
+    def test_rejects_later_array_accesses_in_array_bounds(self) -> None:
+        with pytest.raises(CompileError, match="before its descriptor is allocated"):
+            compile_algol(
+                parse_algol(
+                    "begin integer result; integer array a[b[1]:b[1]]; "
+                    "integer array b[1:1]; result := 0 end"
+                )
+            )
+
     def test_compiles_integer_value_procedure_call(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -52,6 +52,8 @@ All notable changes to this package will be documented in this file.
 - Deferred array-bound expression checking until after sibling declaration
   registration, allowing bounds to call later typed procedures in the same
   block.
+- Rejected array bound expressions that read an array declared later in the
+  same block, preserving declaration-order descriptor allocation semantics.
 - Accepted integer-returning procedure actuals for real-valued formal
   procedure parameters, matching scalar integer-to-real promotion.
 - Accepted switch declaration entries that target labels in lexical parent

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -48,7 +48,9 @@ dimension metadata for lower/upper bound expressions, and resolved read/write
 accesses that preserve the static-link delta and subscript count needed by the
 IR and WASM lowering stages. Array bound expressions are checked after the
 block's declaration signatures are registered, so bounds can call later sibling
-typed procedures in the same declaration part.
+typed procedures in the same declaration part; direct array reads in bounds
+are still limited to descriptors already allocated earlier in declaration
+order.
 Labels receive stable label descriptors and direct local `goto`/`go to` statements
 resolve to those descriptors. Direct nonlocal block `goto` statements resolve
 to outer active blocks, and procedure-crossing transfers resolve to pending

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -413,7 +413,16 @@ class _PendingArrayBounds:
     """Array bound expressions to check after sibling declarations are visible."""
 
     scope: Scope
-    bounds: tuple[tuple[ASTNode, ASTNode], ...]
+    bounds: tuple[_PendingArrayBoundPair, ...]
+
+
+@dataclass(frozen=True)
+class _PendingArrayBoundPair:
+    """One array dimension bound pair plus arrays allocated before it."""
+
+    lower: ASTNode
+    upper: ASTNode
+    visible_array_ids: frozenset[int]
 
 
 @dataclass(frozen=True)
@@ -784,7 +793,7 @@ class AlgolTypeChecker:
             )
             return _PendingArrayBounds(scope=scope, bounds=())
 
-        pending_bounds: list[tuple[ASTNode, ASTNode]] = []
+        pending_bounds: list[_PendingArrayBoundPair] = []
         for segment in _direct_nodes(node, "array_segment"):
             bound_pairs = _direct_nodes(segment, "bound_pair")
             if not bound_pairs:
@@ -799,6 +808,9 @@ class AlgolTypeChecker:
                 continue
 
             dimensions: list[ArrayDimension] = []
+            visible_array_ids = frozenset(
+                array.array_id for array in self.semantic_arrays
+            )
             for bound_pair in bound_pairs:
                 bounds = _direct_nodes(bound_pair, "arith_expr")
                 if len(bounds) != 2:
@@ -806,7 +818,13 @@ class AlgolTypeChecker:
                     continue
                 lower_bound = bounds[0]
                 upper_bound = bounds[1]
-                pending_bounds.append((lower_bound, upper_bound))
+                pending_bounds.append(
+                    _PendingArrayBoundPair(
+                        lower=lower_bound,
+                        upper=upper_bound,
+                        visible_array_ids=visible_array_ids,
+                    )
+                )
                 dimensions.append(
                     ArrayDimension(
                         lower_node_id=id(lower_bound),
@@ -862,11 +880,19 @@ class AlgolTypeChecker:
         return _PendingArrayBounds(scope=scope, bounds=tuple(pending_bounds))
 
     def _check_pending_array_bounds(self, pending: _PendingArrayBounds) -> None:
-        for lower_bound, upper_bound in pending.bounds:
-            for bound in (lower_bound, upper_bound):
+        for pair in pending.bounds:
+            for bound in (pair.lower, pair.upper):
+                previous_access_count = len(self.resolved_array_accesses)
                 bound_type = self._infer_expr(bound, pending.scope)
                 if bound_type != ERROR and bound_type != INTEGER:
                     self._error(bound, "array bounds must be integer")
+                for access in self.resolved_array_accesses[previous_access_count:]:
+                    if access.array_id not in pair.visible_array_ids:
+                        self._error(
+                            bound,
+                            f"array bound cannot read array {access.name!r} "
+                            "before its descriptor is allocated",
+                        )
 
     def _register_switch_declaration(
         self,

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -2086,6 +2086,35 @@ class TestAlgolTypeChecker:
             "upper",
         ]
 
+    def test_accepts_prior_array_accesses_in_array_bounds(self) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array b[1:1]; "
+            "integer array a[b[1]:b[1]]; result := 0 end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert [array.name for array in result.semantic.arrays] == ["b", "a"]
+        assert [access.name for access in result.semantic.array_accesses] == [
+            "b",
+            "b",
+        ]
+
+    def test_rejects_later_array_accesses_in_array_bounds(self) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array a[b[1]:b[1]]; "
+            "integer array b[1:1]; result := 0 end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert any(
+            "array bound cannot read array 'b' before its descriptor is allocated"
+            in diagnostic.message
+            for diagnostic in result.diagnostics
+        )
+
     def test_accepts_default_real_array_declaration(self) -> None:
         ast = parse_algol("begin array a[1:3]; a[1] := 7 end")
         result = check_algol(ast)

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -96,6 +96,8 @@ All notable changes to this package will be documented in this file.
   including forward switch lists that use later typed procedure predicates.
 - Executed array bounds that call later sibling typed procedures at block
   entry.
+- Rejected array bounds that read arrays declared later in the same block while
+  keeping earlier descriptor reads executable.
 - Executed subscripted integer and real array elements as writable `for`
   statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -17,8 +17,8 @@ the current lane already supports a substantial ALGOL 60 surface:
 - `integer`, `boolean`, `real`, and `string` scalar values
 - `own` scalars and arrays with static lifetime
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
-  bounds, including bounds that call later sibling typed procedures, and
-  checked element access
+  bounds, including bounds that call later sibling typed procedures or read
+  previously allocated array descriptors, and checked element access
 - case-insensitive keywords, comments, and standard builtins,
   `!=`/`<>`/`≠` not-equal spelling, ALGOL publication symbols such as `≤`,
   `≥`, `↑`, `×`, `÷`, `¬`, `∧`, `∨`, `⊃`, `≡`, and single- or double-quoted
@@ -163,7 +163,8 @@ local WASM runtime. Those fixtures cover:
 - nonlocal procedure `goto` that unwinds dynamic array storage before the
   caller resumes at the target label
 - dynamic multidimensional array bounds captured at block entry, including
-  bounds that call later sibling typed procedures
+  bounds that call later sibling typed procedures while preserving array
+  declaration order
 - writable real, boolean, and string by-name scalar formals in one program
 - real, boolean, and string by-name actuals through scalar storage,
   array-element storage, expression thunks, and formal-procedure forwarding
@@ -182,9 +183,9 @@ local WASM runtime. Those fixtures cover:
   forms, parenthesized conditional designational expressions, numeric labels,
   boolean operators, real arithmetic, and output
 - a surface-audit matrix for publication notation, procedure-call spellings,
-  forward procedure, switch, and array-bound visibility, loop forms, typed
-  formal procedures, value array copies, nonlocal switch/goto cleanup, and
-  programs without the `result` compatibility scalar
+  forward procedure, switch, array-bound visibility, array-bound declaration
+  order, loop forms, typed formal procedures, value array copies, nonlocal
+  switch/goto cleanup, and programs without the `result` compatibility scalar
 
 ## Dependencies
 

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1846,6 +1846,25 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [5]
 
+    def test_prior_array_accesses_in_array_bounds_execute(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer array b[1:1]; integer array a[b[1]:b[1]]; "
+            "a[0] := 9; result := a[0] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
+    def test_later_array_accesses_in_array_bounds_are_rejected(self) -> None:
+        with pytest.raises(AlgolWasmError) as excinfo:
+            compile_source(
+                "begin integer result; integer array a[b[1]:b[1]]; "
+                "integer array b[1:1]; result := 0 end"
+            )
+
+        assert excinfo.value.stage == "type-check"
+        assert "before its descriptor is allocated" in excinfo.value.message
+
     def test_procedure_body_sees_later_block_declarations(self) -> None:
         result = compile_source(
             "begin "

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -121,6 +121,21 @@ _SURFACE_CASES = (
         stdout="ARRAY 13",
     ),
     SurfaceCase(
+        name="array-bound-declaration-order",
+        source="""
+            begin
+              integer result;
+              integer array b[0:0];
+              integer array a[b[0]:b[0]];
+              a[0] := 21;
+              result := a[0];
+              print('ORDER ', result)
+            end
+        """,
+        result=[21],
+        stdout="ORDER 21",
+    ),
+    SurfaceCase(
         name="for-list-scalar-and-array-control",
         source="""
             begin


### PR DESCRIPTION
## Summary
- Track which array descriptors are allocated before each array-bound expression is checked.
- Allow bounds to read earlier array descriptors while rejecting same-block arrays declared later, avoiding allocation-time descriptor reads before initialization.
- Add type-checker, IR, WASM, and surface-audit coverage for declaration-order array bounds.

## Verification
- bash BUILD (algol-type-checker)
- bash BUILD (algol-ir-compiler)
- bash BUILD (algol-wasm-compiler)
- focused array-bounds pytest runs for type-checker, IR, WASM, and surface audit
- ruff check on touched Python files
- git diff --check
- security scan over touched files for subprocess/shell/eval/exec/network/file-removal APIs; only existing eval-named test matched