### PR TITLE
feat(matrix-runtime): MX05 Phase 1 — profile sampler (invocation counters)

### DIFF
--- a/code/packages/rust/matrix-runtime/CHANGELOG.md
+++ b/code/packages/rust/matrix-runtime/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes to `matrix-runtime` are documented here.  The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] — 2026-05-04
+
+### Added — MX05 Phase 1 (profile sampler)
+
+- New `profile` module exporting `Profiler`, `ProfileObservation`,
+  and `TensorObservation`.  Implements **Phase 1 of spec MX05** —
+  the observation infrastructure that future phases plug
+  specialisation into.
+- `Profiler::record_dispatch(placed: &ComputeGraph)` bumps a per-op
+  invocation counter for every `PlacedOp::Compute` in the graph,
+  keyed by a stable `(graph_subhash, op_index)` pair.  Counters
+  survive re-plans of the same matrix-ir Graph against different
+  executor topologies because the subhash deliberately ignores
+  residency-specific fields.
+- `Profiler::observations()` and
+  `Profiler::invocation_count(subhash, op_index)` expose the
+  counters; `Profiler::reset()` clears them between benchmark runs.
+- `TensorObservation` is reserved for Phase 2 (range / sparsity
+  sampling); Phase 1 always returns it empty.
+
+### Tests
+
+- 8 new tests in `profile::tests::*` covering empty-state behaviour,
+  counter monotonicity past the spec-mandated 1000-invocation
+  threshold, that non-Compute ops don't bump counters, that
+  `last_executor` updates correctly, that subhashes are
+  deterministic and that distinct graphs produce distinct subhashes,
+  and that observation count matches the number of distinct Compute
+  ops.
+
+### Notes
+
+- Phase 1 ships as a module inside `matrix-runtime` rather than its
+  own `matrix-profile` crate (per the eventual layout in spec
+  MX05).  We'll promote it to a separate crate when Phase 2 lands
+  real observation logic with its own dependency surface.
+
 ## [0.2.0] — 2026-05-04
 
 ### Added

--- a/code/packages/rust/matrix-runtime/Cargo.toml
+++ b/code/packages/rust/matrix-runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "matrix-runtime"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "MX04 — the brain of the matrix execution layer. Planner, executor registry, and cost-model-driven placement. Lowers matrix-ir Graphs to compute-ir ComputeGraphs by routing each op to the cheapest available executor. v0.2 adds pass 2b (single-executor preference) so chains of small ops can amortise up-front host→device transfer cost. Zero external dependencies."
+description = "MX04 — the brain of the matrix execution layer. Planner, executor registry, and cost-model-driven placement. Lowers matrix-ir Graphs to compute-ir ComputeGraphs by routing each op to the cheapest available executor. v0.2 adds pass 2b (single-executor preference) so chains of small ops can amortise up-front host→device transfer cost. v0.3 adds the MX05 Phase 1 profile sampler: per-(graph, op) invocation counters and an observation API ready for future profile-guided specialisation. Zero external dependencies."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/matrix-runtime/src/lib.rs
+++ b/code/packages/rust/matrix-runtime/src/lib.rs
@@ -41,11 +41,13 @@
 
 mod cost;
 mod planner;
+mod profile;
 mod registry;
 mod runtime;
 
 pub use cost::{compute_cost, estimate_flops, transfer_cost_ns};
 pub use planner::{plan, PlanError};
+pub use profile::{ProfileObservation, Profiler, TensorObservation};
 pub use registry::{RegisteredExecutor, Registry};
 pub use runtime::{Runtime, RuntimeError};
 

--- a/code/packages/rust/matrix-runtime/src/profile.rs
+++ b/code/packages/rust/matrix-runtime/src/profile.rs
@@ -1,0 +1,524 @@
+//! Profile sampler — Phase 1 of MX05 (tiered specialisation runtime).
+//!
+//! This module ships the **observation infrastructure** for
+//! profile-guided specialisation, without yet doing any specialisation.
+//! Future phases (2..5 per spec MX05) plug in:
+//!
+//! - dtype-range observation,
+//! - shape stability tracking,
+//! - constant-input detection,
+//! - per-backend specialiser hooks,
+//! - a SpecKey-keyed kernel cache,
+//! - and deoptimisation paths.
+//!
+//! For Phase 1 the only behavioural change is: the runtime can attach
+//! a [`Profiler`] that bumps an invocation counter for every Compute
+//! op the runtime sees in a placed graph.  Counters live in a
+//! `(graph_subhash, op_index) → u64` map.  Workloads that drive the
+//! same compiled graph many times produce monotonically-rising counts
+//! that downstream phases will observe and act on.
+//!
+//! ## Why ship the wrapper without the specialisation
+//!
+//! Two reasons:
+//!
+//! 1. The **interface shape** matters more than the algorithm.  Phases
+//!    2..5 need `Profiler` to be the right thing — observable through
+//!    a stable API, callable from inside a dispatch loop, cheap on the
+//!    hot path.  Shipping the wrapper now lets us validate that shape
+//!    on real graphs before we layer specialisation on top.
+//! 2. **Counter rollover testing.**  Real specialisation wakes up at
+//!    1000 invocations (per spec); the only way to exercise the
+//!    1000-invocation threshold today is via the counter API.  Future
+//!    PRs can add `should_specialise()` and a no-op `Specialiser`
+//!    trait without changing the counter machinery.
+//!
+//! ## Locality
+//!
+//! Spec MX05 §"Profile sampler" plans for an eventual `matrix-profile`
+//! crate.  In Phase 1 we keep the code inline in `matrix-runtime` to
+//! avoid premature crate-splitting; promote when Phase 2 lands real
+//! observation logic that wants its own dependency surface.
+
+use compute_ir::{ComputeGraph, ExecutorId, PlacedOp};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+// ────────────────────────── Public types ──────────────────────────
+
+/// A per-(graph, op-index) observation snapshot.  Phase 1 only
+/// populates `invocation_count`; later phases populate the rest.
+///
+/// Memory budget: ~64 bytes when `tensor_observations` is empty (the
+/// Phase 1 shape).  Phase 2 will bound the per-tensor stats to ≤ ~64
+/// bytes each so the structure stays small enough that we can afford
+/// one per (graph_subhash, op_index) pair without blowing the cache.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProfileObservation {
+    /// Identifies the compiled graph this observation belongs to.
+    /// In Phase 1 we use a deterministic hash over the placed graph's
+    /// op sequence (see [`Profiler::subhash`]); future phases may
+    /// refine this to ignore residency-only fields so that re-planning
+    /// the same matrix-ir Graph against a different executor topology
+    /// continues to share observations.
+    pub graph_subhash: u64,
+
+    /// Index of the op within `placed.ops` (after the
+    /// transfer-insertion pass).  Stable for a given graph.
+    pub op_index: u32,
+
+    /// Number of times the runtime saw this op dispatch.  Phase 1
+    /// only field; the downstream specialisation policy reads this.
+    pub invocation_count: u64,
+
+    /// The executor that ran this op the most recent time it was
+    /// observed.  Useful for routing specialisation work to the
+    /// right backend.
+    pub last_executor: ExecutorId,
+
+    /// Reserved for Phase 2: per-tensor min/max/sparsity observations.
+    /// Phase 1 leaves the vector empty.
+    pub tensor_observations: Vec<TensorObservation>,
+}
+
+/// Per-tensor running statistic.  Phase 1 leaves these empty; Phase 2
+/// fills them in via probabilistic sampling on the dispatch hot path
+/// (~1% sampling rate per the spec).
+///
+/// All fields are `f64` so we can carry both float and integer
+/// observations without a discriminator.  Bounded to a fixed size
+/// regardless of tensor numel — the whole point of sampling is that
+/// observation cost doesn't scale with tensor size.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TensorObservation {
+    /// Index into the op's input or output list.
+    pub slot: u32,
+    /// `true` for inputs, `false` for outputs.  Cheap discriminator
+    /// so a single `Vec<TensorObservation>` covers both directions.
+    pub is_input: bool,
+    /// Smallest scalar observed across all sampled invocations.
+    pub observed_min: f64,
+    /// Largest scalar observed across all sampled invocations.
+    pub observed_max: f64,
+    /// Count of zero scalars seen — sparsity hint.
+    pub observed_zeros: u64,
+    /// Total scalars sampled.  `observed_zeros / samples` gives the
+    /// estimated sparsity.
+    pub samples: u64,
+}
+
+/// Hot-path counter store.  Cheap clone (it's just an Arc-ish handle
+/// in disguise) so domain libraries can hold one and spread it across
+/// dispatch sites.
+///
+/// Internally guarded by a `Mutex` rather than per-cell atomics
+/// because Phase 1 cares about correctness over absolute throughput
+/// and the runtime already does heavier work (planning, transports)
+/// per invocation.  Phase 2 might refactor to atomics if benchmarks
+/// show the lock as a hot spot.
+pub struct Profiler {
+    inner: Mutex<ProfilerInner>,
+}
+
+struct ProfilerInner {
+    /// Per-(graph_subhash, op_index) invocation counters.
+    counters: HashMap<(u64, u32), u64>,
+    /// Per-(graph_subhash, op_index) → most-recently-observed executor.
+    last_executor: HashMap<(u64, u32), ExecutorId>,
+}
+
+impl Profiler {
+    /// Construct an empty profiler.
+    pub fn new() -> Self {
+        Profiler {
+            inner: Mutex::new(ProfilerInner {
+                counters: HashMap::new(),
+                last_executor: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Bump the per-op invocation counters for every `PlacedOp::Compute`
+    /// in `placed`.  Called by the dispatch path right before the
+    /// runtime hands the graph off to the transport(s).
+    ///
+    /// O(n) in the number of compute ops in the graph.  Lock-acquire
+    /// once per call; per-op work inside the lock is a HashMap entry
+    /// update (amortised O(1)).
+    ///
+    /// Phase 1 doesn't sample tensor observations.  Phase 2 will hook
+    /// in here with a probabilistic sampler that touches a small
+    /// number of bytes from each input on a small fraction of calls.
+    pub fn record_dispatch(&self, placed: &ComputeGraph) {
+        let key = subhash(placed);
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            // Mutex poisoning: keep going with the inner state we have.
+            // Counter accuracy is not a correctness invariant for
+            // anything in MX05 V1, so a missed bump is fine.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        for (op_idx, op) in placed.ops.iter().enumerate() {
+            if let PlacedOp::Compute { executor, .. } = op {
+                let map_key = (key, op_idx as u32);
+                *inner.counters.entry(map_key).or_insert(0) += 1;
+                inner.last_executor.insert(map_key, *executor);
+            }
+        }
+    }
+
+    /// Return the invocation count for a specific `(graph_subhash, op_index)`,
+    /// or 0 if no dispatch of that op has been observed yet.
+    pub fn invocation_count(&self, graph_subhash: u64, op_index: u32) -> u64 {
+        let inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        inner
+            .counters
+            .get(&(graph_subhash, op_index))
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Snapshot the full set of observations.  O(n) in counter map
+    /// size; cheap when the workload is a handful of compiled graphs.
+    pub fn observations(&self) -> Vec<ProfileObservation> {
+        let inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        inner
+            .counters
+            .iter()
+            .map(|(&(graph_subhash, op_index), &count)| ProfileObservation {
+                graph_subhash,
+                op_index,
+                invocation_count: count,
+                last_executor: inner
+                    .last_executor
+                    .get(&(graph_subhash, op_index))
+                    .copied()
+                    .unwrap_or(ExecutorId(u32::MAX)),
+                tensor_observations: Vec::new(),
+            })
+            .collect()
+    }
+
+    /// Reset all counters.  Useful between benchmark iterations and
+    /// for tests.  Does not affect any specialised kernels that may
+    /// have been emitted — those live in a separate cache that
+    /// future phases will manage.
+    pub fn reset(&self) {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        inner.counters.clear();
+        inner.last_executor.clear();
+    }
+
+    /// Compute the graph-subhash the profiler uses as a key.  Exposed
+    /// so callers (tests, future phases) can correlate
+    /// `ProfileObservation`s with the graphs they came from without
+    /// re-reading the same graph through the profiler.
+    pub fn subhash(graph: &ComputeGraph) -> u64 {
+        subhash(graph)
+    }
+}
+
+impl Default for Profiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ────────────────────────── subhash ──────────────────────────
+
+/// Deterministic hash of a `ComputeGraph`'s op-and-tensor structure,
+/// excluding residency-specific fields (buffer ids, exact executor
+/// ids).  Two placements of the same upstream `matrix_ir::Graph`
+/// against different executor topologies produce the same subhash, so
+/// observations carry across re-plans.
+///
+/// FNV-1a on a stable byte serialisation.  Not a cryptographic hash
+/// — collision-resistance only needs to survive an open-coded LRU
+/// cache lookup.
+fn subhash(graph: &ComputeGraph) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    fn feed_byte(b: u8, h: &mut u64) {
+        *h ^= b as u64;
+        *h = h.wrapping_mul(FNV_PRIME);
+    }
+    fn feed_le_u32(v: u32, h: &mut u64) {
+        for b in v.to_le_bytes() {
+            feed_byte(b, h);
+        }
+    }
+    fn feed_le_u64(v: u64, h: &mut u64) {
+        for b in v.to_le_bytes() {
+            feed_byte(b, h);
+        }
+    }
+
+    let mut h = FNV_OFFSET;
+
+    feed_le_u32(graph.ops.len() as u32, &mut h);
+    for (i, op) in graph.ops.iter().enumerate() {
+        feed_le_u32(i as u32, &mut h);
+        match op {
+            PlacedOp::Compute { op, .. } => {
+                // Op kind dominates; residency fields skipped on
+                // purpose so re-plans don't perturb the hash.
+                feed_byte(0, &mut h); // discriminator: Compute
+                feed_byte(op.wire_tag(), &mut h);
+                feed_le_u32(op.output().0, &mut h);
+                for input in op.inputs() {
+                    feed_le_u32(input.0, &mut h);
+                }
+                feed_byte(0xFF, &mut h); // sentinel
+            }
+            PlacedOp::Transfer { tensor, bytes, .. } => {
+                feed_byte(1, &mut h);
+                feed_le_u32(tensor.0, &mut h);
+                feed_le_u64(*bytes, &mut h);
+            }
+            PlacedOp::Alloc { bytes, .. } => {
+                feed_byte(2, &mut h);
+                feed_le_u64(*bytes, &mut h);
+            }
+            PlacedOp::Free { .. } => {
+                feed_byte(3, &mut h);
+            }
+        }
+    }
+    h
+}
+
+// ────────────────────────── Tests ──────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use compute_ir::{
+        BufferId, ComputeGraph, OpTiming, PlacedConstant, PlacedOp, PlacedTensor, Residency,
+        WIRE_FORMAT_VERSION, CPU_EXECUTOR,
+    };
+    use matrix_ir::{DType, Op, Shape, TensorId};
+
+    fn t(id: u32) -> TensorId {
+        TensorId(id)
+    }
+
+    fn r(executor: u32, buffer: u64) -> Residency {
+        Residency {
+            executor: ExecutorId(executor),
+            buffer: BufferId(buffer),
+        }
+    }
+
+    /// One-Compute-op graph: a Neg on a 4-element f32 input.
+    fn one_op_graph(executor: ExecutorId) -> ComputeGraph {
+        let shape = Shape::from(&[4]);
+        ComputeGraph {
+            format_version: WIRE_FORMAT_VERSION,
+            inputs: vec![],
+            outputs: vec![PlacedTensor {
+                id: t(1),
+                dtype: DType::F32,
+                shape: shape.clone(),
+                residency: r(executor.0, 1),
+            }],
+            constants: vec![PlacedConstant {
+                tensor: t(0),
+                bytes: vec![0; 16],
+                residency: r(executor.0, 0),
+            }],
+            ops: vec![PlacedOp::Compute {
+                op: Op::Neg {
+                    input: t(0),
+                    output: t(1),
+                },
+                executor,
+                timing: OpTiming { estimated_ns: 0 },
+            }],
+            tensors: vec![
+                PlacedTensor {
+                    id: t(0),
+                    dtype: DType::F32,
+                    shape: shape.clone(),
+                    residency: r(executor.0, 0),
+                },
+                PlacedTensor {
+                    id: t(1),
+                    dtype: DType::F32,
+                    shape,
+                    residency: r(executor.0, 1),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn empty_profiler_reports_zero() {
+        let p = Profiler::new();
+        let g = one_op_graph(CPU_EXECUTOR);
+        let key = Profiler::subhash(&g);
+        assert_eq!(p.invocation_count(key, 0), 0);
+    }
+
+    #[test]
+    fn record_dispatch_bumps_compute_op_counters() {
+        let p = Profiler::new();
+        let g = one_op_graph(CPU_EXECUTOR);
+        let key = Profiler::subhash(&g);
+
+        p.record_dispatch(&g);
+        assert_eq!(p.invocation_count(key, 0), 1);
+
+        p.record_dispatch(&g);
+        p.record_dispatch(&g);
+        assert_eq!(p.invocation_count(key, 0), 3);
+    }
+
+    #[test]
+    fn record_dispatch_ignores_non_compute_ops() {
+        let p = Profiler::new();
+        let mut g = one_op_graph(CPU_EXECUTOR);
+        // Inject Alloc/Free/Transfer.  None of these should bump a
+        // counter — only Compute ops do.
+        g.ops.insert(
+            0,
+            PlacedOp::Alloc {
+                residency: r(0, 99),
+                bytes: 16,
+            },
+        );
+        g.ops.push(PlacedOp::Free {
+            residency: r(0, 99),
+        });
+        g.ops.push(PlacedOp::Transfer {
+            tensor: t(1),
+            src: r(0, 1),
+            dst: r(1, 7),
+            bytes: 16,
+            timing: OpTiming { estimated_ns: 0 },
+        });
+
+        p.record_dispatch(&g);
+        let obs = p.observations();
+        assert_eq!(obs.len(), 1, "only the Compute op should produce an observation");
+        assert_eq!(obs[0].invocation_count, 1);
+    }
+
+    #[test]
+    fn last_executor_is_recorded() {
+        let p = Profiler::new();
+        let g_cpu = one_op_graph(CPU_EXECUTOR);
+        let g_metal = one_op_graph(ExecutorId(1));
+
+        // Same graph structure under different executors → same
+        // subhash (residency excluded by design), so observations
+        // collapse onto the same counter and `last_executor` flips
+        // to whichever was seen most recently.
+        assert_eq!(Profiler::subhash(&g_cpu), Profiler::subhash(&g_metal));
+
+        p.record_dispatch(&g_cpu);
+        let obs = &p.observations()[0];
+        assert_eq!(obs.last_executor, CPU_EXECUTOR);
+
+        p.record_dispatch(&g_metal);
+        let obs = &p.observations()[0];
+        assert_eq!(obs.last_executor, ExecutorId(1));
+        assert_eq!(obs.invocation_count, 2);
+    }
+
+    #[test]
+    fn reset_clears_counters() {
+        let p = Profiler::new();
+        let g = one_op_graph(CPU_EXECUTOR);
+        for _ in 0..5 {
+            p.record_dispatch(&g);
+        }
+        let key = Profiler::subhash(&g);
+        assert_eq!(p.invocation_count(key, 0), 5);
+
+        p.reset();
+        assert_eq!(p.invocation_count(key, 0), 0);
+        assert!(p.observations().is_empty());
+    }
+
+    #[test]
+    fn distinct_graphs_get_distinct_subhashes() {
+        let g1 = one_op_graph(CPU_EXECUTOR);
+
+        // Build a different graph: same shape, but Abs instead of Neg.
+        let mut g2 = one_op_graph(CPU_EXECUTOR);
+        g2.ops[0] = PlacedOp::Compute {
+            op: Op::Abs {
+                input: t(0),
+                output: t(1),
+            },
+            executor: CPU_EXECUTOR,
+            timing: OpTiming { estimated_ns: 0 },
+        };
+
+        assert_ne!(Profiler::subhash(&g1), Profiler::subhash(&g2));
+    }
+
+    #[test]
+    fn subhash_is_deterministic() {
+        let g = one_op_graph(CPU_EXECUTOR);
+        let h1 = Profiler::subhash(&g);
+        let h2 = Profiler::subhash(&g);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn many_invocations_climb_above_phase2_threshold() {
+        // Spec-mandated trigger threshold is 1000 invocations.  This
+        // test confirms the counter walks past it without overflow
+        // or miscounting.
+        let p = Profiler::new();
+        let g = one_op_graph(CPU_EXECUTOR);
+        let key = Profiler::subhash(&g);
+        for _ in 0..1500 {
+            p.record_dispatch(&g);
+        }
+        assert_eq!(p.invocation_count(key, 0), 1500);
+        // Sanity: well above the 1000 threshold the spec uses for
+        // first-tier specialisation.
+        assert!(p.invocation_count(key, 0) >= 1000);
+    }
+
+    #[test]
+    fn observations_count_matches_distinct_compute_ops() {
+        // Build a graph with two Compute ops.
+        let mut g = one_op_graph(CPU_EXECUTOR);
+        let extra_residency = r(0, 2);
+        g.ops.push(PlacedOp::Compute {
+            op: Op::Abs {
+                input: t(1),
+                output: t(2),
+            },
+            executor: CPU_EXECUTOR,
+            timing: OpTiming { estimated_ns: 0 },
+        });
+        g.tensors.push(PlacedTensor {
+            id: t(2),
+            dtype: DType::F32,
+            shape: Shape::from(&[4]),
+            residency: extra_residency,
+        });
+
+        let p = Profiler::new();
+        p.record_dispatch(&g);
+        let obs = p.observations();
+        assert_eq!(obs.len(), 2);
+        let key = Profiler::subhash(&g);
+        assert_eq!(p.invocation_count(key, 0), 1);
+        assert_eq!(p.invocation_count(key, 1), 1);
+    }
+}

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -95,6 +95,15 @@ Five new components, none of which require IR or protocol changes:
 
 ### 1. Profile sampler (matrix-profile crate)
 
+> **Implementation status (Phase 1 landed)**: shipped as the
+> `matrix_runtime::profile` module rather than as a separate
+> `matrix-profile` crate.  Promotion is deferred to Phase 2, where the
+> sampler grows real observation logic that benefits from its own
+> dependency surface.  Phase 1 only implements per-op invocation
+> counters and the `Profiler` / `ProfileObservation` /
+> `TensorObservation` data types; everything else in this section is
+> still future work.
+
 A new crate, `matrix-profile`, that owns the observation logic:
 
 - Per-dispatch counters keyed by `(graph_subhash, op_index)`.


### PR DESCRIPTION
## Summary

Ships **Phase 1 of MX05** (tiered profile-guided specialisation runtime): the **observation infrastructure** that future phases will plug specialisation into. No specialisation happens yet — Phase 1 only adds passive per-op invocation counters and the data types future phases will fill in.

## What this PR adds

- New `matrix_runtime::profile` module exporting `Profiler`, `ProfileObservation`, `TensorObservation`.
- `Profiler::record_dispatch(&ComputeGraph)` walks `placed.ops` and bumps an invocation counter for every `PlacedOp::Compute`, keyed by `(graph_subhash, op_index)`.
- `Profiler::invocation_count(...)`, `Profiler::observations()`, and `Profiler::reset()` for read access.
- A deterministic FNV-1a `subhash()` over the graph's op structure that **excludes residency-specific fields** — so re-planning the same matrix-ir Graph against a different executor topology continues to share observations.
- `TensorObservation` is reserved for Phase 2 (range / sparsity sampling); Phase 1 always returns it empty.

## Why ship the wrapper without the specialisation

1. **Interface shape matters more than the algorithm.** Phases 2..5 need `Profiler` to be the right thing — observable through a stable API, callable from inside a dispatch loop, cheap on the hot path. Shipping the wrapper now lets us validate that shape on real graphs before we layer specialisation on top.
2. **Counter rollover testing.** Real specialisation wakes up at 1000 invocations (per spec); the only way to exercise that threshold today is via the counter API. Tests confirm we walk past 1000 cleanly.

## Why a module, not a separate crate

Spec MX05 plans for an eventual `matrix-profile` crate. Phase 1 keeps the code inline in `matrix-runtime` to avoid premature crate-splitting; promotion lifts to Phase 2 when the sampler grows real observation logic that benefits from its own dependency surface. Spec MX05 §"Profile sampler" updated to record this.

## Out of scope (V1)

- SpecKey / Specialiser trait / SpecCache (Phase 1 just observes; these land in Phase 3)
- Probabilistic tensor-value sampling (Phase 2)
- Auto-narrowing `Cast` insertion (Phase 2)
- Constant folding into kernels (Phase 4)
- Deoptimisation (Phase 5)

## Test plan

- [x] `cargo test -p matrix-runtime` — 26 unit + 8 integration = **34 tests pass** (was 17+8=25)
- [x] 8 new `profile::tests::*` tests cover empty state, monotonic counter behaviour past the spec-mandated 1000-invocation threshold, that non-Compute ops don't bump counters, that `last_executor` updates correctly, that subhashes are deterministic and that distinct graphs produce distinct subhashes
- [x] No new warnings; clean `cargo build`
- [x] Security review passed in one round (passive bookkeeping; no new deps, no FFI, no `unsafe`, no filesystem, no network)

## Notes

- Branch is named `feat/mx04-multi-executor-coordinator` but the content is MX05 Phase 1 — the original auto-advance prompt defaulted to the V2 multi-executor coordinator, but that turned out to need protocol-level changes to support cross-executor `PlacedOp::Transfer` (the executors today expect single-executor graphs). MX05 Phase 1 was the next-most-concrete option from the priority list, and it's small enough to ship cleanly. The V2 coordinator is now blocked on a small executor-protocol extension that's better tackled as its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)