### PR TITLE
Report unexpected attribute name characters

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -110,6 +110,9 @@ documented in this file.
   U+FFFD.
 - NULL characters in tag names and attribute names now recover with
   `unexpected-null-character` and append U+FFFD.
+- Quote and less-than characters in attribute names now report
+  `unexpected-character-in-attribute-name` while preserving the character in
+  the recovered emitted attribute name.
 - NULL characters in comments and bogus comments now recover with
   `unexpected-null-character` and append U+FFFD while preserving pending comment
   dashes.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -99,6 +99,9 @@ behavior the future parser will expect from the lexer/tokenizer boundary.
 Tag names and attribute names now use the same recovery shape, so a raw NULL in
 markup names becomes U+FFFD and records `unexpected-null-character` instead of
 leaking the raw code point into emitted tokens.
+Unexpected quote and less-than characters in attribute names are preserved in
+the emitted name while reporting `unexpected-character-in-attribute-name`,
+including before, during, and after attribute-name parsing.
 Comments and bogus comments also replace raw NULL characters with U+FFFD while
 recording `unexpected-null-character`, including dash-sensitive comment end
 substates that must preserve their pending `-` or `--` text first.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -3367,6 +3367,36 @@ actions = [
 
 [[transitions]]
 from = "before_attribute_name"
+matcher = { literal = "\"" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-character-in-attribute-name)",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "'" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-character-in-attribute-name)",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "before_attribute_name"
+matcher = { literal = "<" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-character-in-attribute-name)",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "before_attribute_name"
 matcher = { anything = true }
 to = "attribute_name"
 actions = ["start_attribute", "append_attribute_name(current_lowercase)"]
@@ -3431,6 +3461,33 @@ to = "attribute_name"
 actions = [
   "parse_error(unexpected-null-character)",
   "append_attribute_name_replacement",
+]
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = "\"" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-character-in-attribute-name)",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = "'" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-character-in-attribute-name)",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "attribute_name"
+matcher = { literal = "<" }
+to = "attribute_name"
+actions = [
+  "parse_error(unexpected-character-in-attribute-name)",
+  "append_attribute_name(current_lowercase)",
 ]
 
 [[transitions]]
@@ -3501,6 +3558,39 @@ actions = [
   "parse_error(unexpected-null-character)",
   "start_attribute",
   "append_attribute_name_replacement",
+]
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "\"" }
+to = "attribute_name"
+actions = [
+  "commit_attribute_dedup",
+  "parse_error(unexpected-character-in-attribute-name)",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "'" }
+to = "attribute_name"
+actions = [
+  "commit_attribute_dedup",
+  "parse_error(unexpected-character-in-attribute-name)",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
+]
+
+[[transitions]]
+from = "after_attribute_name"
+matcher = { literal = "<" }
+to = "attribute_name"
+actions = [
+  "commit_attribute_dedup",
+  "parse_error(unexpected-character-in-attribute-name)",
+  "start_attribute",
+  "append_attribute_name(current_lowercase)",
 ]
 
 [[transitions]]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -7529,6 +7529,57 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "before_attribute_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\"".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "start_attribute".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("'".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "start_attribute".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("<".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "start_attribute".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "before_attribute_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "attribute_name".to_string(),
@@ -7687,6 +7738,54 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "attribute_name".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\"".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("'".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("<".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "attribute_name".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "attribute_name".to_string(),
@@ -7840,6 +7939,60 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "parse_error(unexpected-null-character)".to_string(),
                 "start_attribute".to_string(),
                 "append_attribute_name_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\"".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "commit_attribute_dedup".to_string(),
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "start_attribute".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("'".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "commit_attribute_dedup".to_string(),
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "start_attribute".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "after_attribute_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("<".to_string())),
+            to: vec![
+                "attribute_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "commit_attribute_dedup".to_string(),
+                "parse_error(unexpected-character-in-attribute-name)".to_string(),
+                "start_attribute".to_string(),
+                "append_attribute_name(current_lowercase)".to_string(),
             ],
             consume: true,
         },

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -384,6 +384,51 @@ fn default_html_lexer_reports_first_unquoted_attribute_value_characters() {
 }
 
 #[test]
+fn default_html_lexer_reports_unexpected_attribute_name_characters() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<a \"pre=1 mid'dle=2 done <tail=3>").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "\"pre".to_string(),
+                        value: "1".to_string(),
+                    },
+                    Attribute {
+                        name: "mid'dle".to_string(),
+                        value: "2".to_string(),
+                    },
+                    Attribute {
+                        name: "done".to_string(),
+                        value: String::new(),
+                    },
+                    Attribute {
+                        name: "<tail".to_string(),
+                        value: "3".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "unexpected-character-in-attribute-name")
+            .count(),
+        3
+    );
+}
+
+#[test]
 fn default_html_lexer_reconsumes_missing_space_after_quoted_attributes() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Report `unexpected-character-in-attribute-name` for quote and less-than characters before, during, and after attribute-name parsing.
- Mirror the authored HTML1 lexer state-machine update into the checked-in generated Rust table.
- Document the recovery behavior and add focused lexer coverage for malformed attribute names.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check