### PR TITLE
feat(prolog): dump CLI instruction streams

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -285,6 +285,16 @@ Use `--check` to parse, load, compile, and initialize source without running a
 query. This is intended for CI and editor integrations that need to validate a
 Prolog file graph even when it does not contain embedded `?-` directives.
 
+Use `--dump-instructions` to compile source into the structured Logic VM
+instruction stream without executing queries. This is the best first diagnostic
+when checking what the Prolog loader emitted before bytecode lowering:
+
+```bash
+prolog-vm \
+  --source "parent(homer, bart). ?- parent(homer, Who)." \
+  --dump-instructions
+```
+
 Use `--dump-bytecode` to compile source into Logic bytecode and print the
 loader-bytecode disassembly without executing queries. This is useful when
 diagnosing convergence between the structured VM and the bytecode VM:

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -20,6 +20,15 @@ from cli_builder import (
 )
 from logic_bytecode import LogicBytecodeProgram, disassemble, disassemble_text
 from logic_engine import Atom, Compound, Disequality, LogicVar, Number, String, Term
+from logic_instructions import (
+    DynamicRelationDefInstruction,
+    FactInstruction,
+    InstructionProgram,
+    LogicInstruction,
+    QueryInstruction,
+    RelationDefInstruction,
+    RuleInstruction,
+)
 
 from prolog_vm_compiler.compiler import (
     CompiledPrologVMProgram,
@@ -62,6 +71,7 @@ class CliArgs:
     queries: tuple[str, ...]
     check: bool
     dump_bytecode: bool
+    dump_instructions: bool
     list_source_queries: bool
     source_query_index: int
     all_source_queries: bool
@@ -164,6 +174,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     all_source_queries = bool(flags["all-source-queries"])
     check = bool(flags["check"])
     dump_bytecode = bool(flags["dump-bytecode"])
+    dump_instructions = bool(flags["dump-instructions"])
     list_source_queries = bool(flags["list-source-queries"])
     if check and queries:
         msg = "--check cannot be combined with --query"
@@ -188,6 +199,24 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_bytecode and bool(flags["interactive"]):
         msg = "--dump-bytecode cannot be combined with --interactive"
+        raise ValueError(msg)
+    if dump_instructions and queries:
+        msg = "--dump-instructions cannot be combined with --query"
+        raise ValueError(msg)
+    if dump_instructions and check:
+        msg = "--dump-instructions cannot be combined with --check"
+        raise ValueError(msg)
+    if dump_instructions and dump_bytecode:
+        msg = "--dump-instructions cannot be combined with --dump-bytecode"
+        raise ValueError(msg)
+    if dump_instructions and list_source_queries:
+        msg = "--dump-instructions cannot be combined with --list-source-queries"
+        raise ValueError(msg)
+    if dump_instructions and all_source_queries:
+        msg = "--dump-instructions cannot be combined with --all-source-queries"
+        raise ValueError(msg)
+    if dump_instructions and bool(flags["interactive"]):
+        msg = "--dump-instructions cannot be combined with --interactive"
         raise ValueError(msg)
     if list_source_queries and queries:
         msg = "--list-source-queries cannot be combined with --query"
@@ -224,6 +253,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         queries=queries,
         check=check,
         dump_bytecode=dump_bytecode,
+        dump_instructions=dump_instructions,
         list_source_queries=list_source_queries,
         source_query_index=source_query_index,
         all_source_queries=all_source_queries,
@@ -365,6 +395,8 @@ def _required_int(value: object, *, name: str) -> int:
 def _run_cli(args: CliArgs) -> int:
     if args.check:
         return _run_check(args)
+    if args.dump_instructions:
+        return _run_dump_instructions(args)
     if args.dump_bytecode:
         return _run_dump_bytecode(args)
     if args.list_source_queries:
@@ -415,6 +447,12 @@ def _run_dump_bytecode(args: CliArgs) -> int:
     return 0
 
 
+def _run_dump_instructions(args: CliArgs) -> int:
+    compiled_program = _compile_source_program(args)
+    _print_instruction_dump(compiled_program.instructions, args=args)
+    return 0
+
+
 def _run_list_source_queries(args: CliArgs) -> int:
     compiled_program = _compile_source_program(args)
     _print_source_query_summary(compiled_program, args=args)
@@ -453,6 +491,65 @@ def _print_source_query_summary(
         "queries": query_summaries,
     }
     print(json.dumps(payload, sort_keys=True), file=output)
+
+
+def _print_instruction_dump(
+    program: InstructionProgram,
+    *,
+    args: CliArgs,
+    stdout: TextIO | None = None,
+) -> None:
+    output = sys.stdout if stdout is None else stdout
+    records = [
+        _instruction_dump_record(index, instruction)
+        for index, instruction in enumerate(program.instructions)
+    ]
+
+    if args.output_format == "text":
+        for record in records:
+            print(
+                f"{int(record['index']):04d}: {record['opcode']} {record['text']}",
+                file=output,
+            )
+        return
+
+    payload = {
+        "success": True,
+        "mode": "instructions",
+        "instruction_count": len(program.instructions),
+        "instructions": records,
+    }
+    print(json.dumps(payload, sort_keys=True), file=output)
+
+
+def _instruction_dump_record(
+    index: int,
+    instruction: LogicInstruction,
+) -> dict[str, object]:
+    return {
+        "index": index,
+        "opcode": instruction.opcode.value,
+        "text": _instruction_dump_text(instruction),
+    }
+
+
+def _instruction_dump_text(instruction: LogicInstruction) -> str:
+    if isinstance(
+        instruction,
+        RelationDefInstruction | DynamicRelationDefInstruction,
+    ):
+        return str(instruction.relation)
+    if isinstance(instruction, FactInstruction):
+        return str(instruction.head)
+    if isinstance(instruction, RuleInstruction):
+        return f"{instruction.head} :- {instruction.body}"
+    if isinstance(instruction, QueryInstruction):
+        if instruction.outputs is None:
+            return str(instruction.goal)
+        outputs = ", ".join(str(output) for output in instruction.outputs)
+        return f"{instruction.goal} -> {outputs}"
+    msg = f"unsupported instruction type {type(instruction).__name__}"
+    raise TypeError(msg)
 
 
 def _print_bytecode_dump(

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
@@ -43,6 +43,12 @@
       "type": "boolean"
     },
     {
+      "id": "dump-instructions",
+      "long": "dump-instructions",
+      "description": "Compile source to Logic VM instructions and print them without running queries.",
+      "type": "boolean"
+    },
+    {
       "id": "list-source-queries",
       "long": "list-source-queries",
       "description": "List embedded source-level ?- queries without running them.",

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -227,6 +227,68 @@ def test_cli_dump_bytecode_rejects_execution_modes(
     )
 
 
+def test_cli_dump_instructions_renders_instruction_stream(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        "--dump-instructions",
+    ])
+
+    assert status == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[0] == "0000: DEF_REL parent/2"
+    assert lines[1].startswith("0001: FACT parent(")
+    assert lines[2].startswith("0002: QUERY parent(")
+    assert " -> " in lines[2]
+
+
+def test_cli_dump_instructions_json_reports_instruction_records(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        "--dump-instructions",
+        "--format",
+        "json",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert status == 0
+    assert payload["success"] is True
+    assert payload["mode"] == "instructions"
+    assert payload["instruction_count"] == 3
+    assert payload["instructions"][0] == {
+        "index": 0,
+        "opcode": "DEF_REL",
+        "text": "parent/2",
+    }
+    assert payload["instructions"][1]["opcode"] == "FACT"
+    assert payload["instructions"][1]["text"].startswith("parent(")
+    assert payload["instructions"][2]["opcode"] == "QUERY"
+    assert " -> " in payload["instructions"][2]["text"]
+
+
+def test_cli_dump_instructions_rejects_execution_modes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--dump-instructions",
+        "--query",
+        "parent(homer, Who)",
+    ])
+
+    assert status == 2
+    assert "--dump-instructions cannot be combined with --query" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_lists_source_query_variables(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -13,6 +13,7 @@ The goal is practical usability:
 - run Prolog source piped through stdin
 - run a single `.pl` file or linked file graph
 - check that source parses, loads, compiles, and initializes without a query
+- dump structured Logic VM instructions for compile-only diagnostics
 - dump Logic bytecode disassembly for compile-only diagnostics
 - list embedded source-level `?-` query indexes and visible variables
 - run stored source-level `?-` queries by index
@@ -35,6 +36,8 @@ Important options:
   files.
 - `--query QUERY` runs an ad-hoc top-level query. It may be repeated.
 - `--check` parses, loads, compiles, and initializes without running a query.
+- `--dump-instructions` compiles to structured Logic VM instructions and emits
+  them without executing queries.
 - `--dump-bytecode` compiles to Logic bytecode and emits disassembly without
   executing queries.
 - `--list-source-queries` lists embedded `?-` query indexes and visible
@@ -101,6 +104,12 @@ JSON object per query result.
 When `--check` is set, JSON formats emit one success object with `mode:
 "check"`, `source_query_count`, `initialization_query_count`, `backend`, and
 whether initialization ran.
+
+When `--dump-instructions` is set, text output emits indexed structured
+instruction lines. JSON formats emit one success object with `mode:
+"instructions"`, `instruction_count`, and per-instruction records containing
+`index`, `opcode`, and rendered `text`. This mode is compile-only and mutually
+exclusive with query execution modes.
 
 When `--dump-bytecode` is set, text output emits bytecode disassembly lines.
 JSON formats emit one success object with `mode: "bytecode"`, pool counts, an
@@ -175,6 +184,7 @@ The CLI test coverage should prove:
 - inline source ad-hoc queries through bytecode
 - stdin source ad-hoc and stored source queries
 - query-free compile/check mode
+- structured instruction dump mode
 - bytecode disassembly dump mode
 - source query listing without execution
 - stored source-level queries from files


### PR DESCRIPTION
## Summary
- add `prolog-vm --dump-instructions` through the CLI builder spec as a compile-only diagnostic mode
- render structured Logic VM instruction lines in text output and instruction records in JSON formats
- document PR77 instruction dump behavior and cover text, JSON, and execution-mode validation

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-dump-instructions -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-dump-instructions-build-plan.json`