### PR TITLE
feat(matrix-runtime): MX05 Phase 2a — range observation (tensor-byte sampling)

### DIFF
--- a/code/packages/rust/matrix-runtime/CHANGELOG.md
+++ b/code/packages/rust/matrix-runtime/CHANGELOG.md
@@ -3,6 +3,59 @@
 All notable changes to `matrix-runtime` are documented here.  The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.0] — 2026-05-05
+
+### Added — MX05 Phase 2a (range observation)
+
+- `Profiler::sample_tensor(graph_subhash, op_index, slot, is_input,
+  dtype, bytes)` — accumulates per-(graph, op, slot, direction) running
+  statistics from raw bytes.  Bounded ≤ ~64 bytes of state regardless
+  of `bytes.len()`; work scales with the number of scalars passed in.
+  Supports F32, U8, I32 (the V1 dtype set).  F32 NaNs are skipped (do
+  not poison min/max) but are still counted as samples so sparsity
+  ratios stay honest.  Trailing partial scalars are silently
+  truncated, matching what dispatchers do.
+- `Profiler::tensor_observation(graph_subhash, op_index, slot,
+  is_input)` — read-back accessor for tests and policy code.
+- `Profiler::should_sample()` — counter-based sampling gate;
+  deterministic, returns `true` once per `sample_rate` calls.  Default
+  rate is 100 (≈ 1% sampling, matching the spec).
+- `Profiler::set_sample_rate(rate)` — tunes the gate.  Rate `0` means
+  "never sample", `1` means "always sample", anything in between gives
+  a 1/N hit rate.
+- `Profiler::observations()` now folds sampled `TensorObservation`s
+  into the matching `ProfileObservation`'s `tensor_observations`
+  vector, sorted inputs-before-outputs and by slot.
+- `Profiler::reset()` now also clears tensor observations and rewinds
+  the sample counter.
+
+### Tests (10 new)
+
+- `sample_tensor_f32_records_min_max_zeros`
+- `sample_tensor_u8_records_min_max_zeros`
+- `sample_tensor_i32_records_min_max_zeros`
+- `sample_tensor_accumulates_across_calls`
+- `sample_tensor_f32_skips_nan`
+- `sample_tensor_truncates_partial_trailing_scalar`
+- `observations_includes_tensor_observations`
+- `should_sample_at_default_rate_yields_one_in_hundred`
+- `should_sample_rate_one_always_yields_true`
+- `should_sample_rate_zero_never_yields_true`
+- `reset_clears_tensor_observations_and_sample_counter`
+- `observations_orders_tensor_observations_by_input_then_slot`
+
+Total tests: 38 unit + 8 integration = 46 (was 26 + 8 = 34).
+
+### Notes
+
+- No specialisation policy yet — Phase 2a only ships the data
+  plumbing.  The future Phase 2b (auto-narrow `Cast` insertion) and
+  Phase 3 (`SpecKey` / `Specialiser` trait) consume `tensor_observation`
+  output to decide which graphs / ops are worth specialising.
+- Image-filter routing on macOS is unchanged: `invert` → CPU,
+  `greyscale` / `sepia` → Metal across the synthetic test-image suite
+  (regression check).
+
 ## [0.3.0] — 2026-05-04
 
 ### Added — MX05 Phase 1 (profile sampler)

--- a/code/packages/rust/matrix-runtime/Cargo.toml
+++ b/code/packages/rust/matrix-runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "matrix-runtime"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "MX04 — the brain of the matrix execution layer. Planner, executor registry, and cost-model-driven placement. Lowers matrix-ir Graphs to compute-ir ComputeGraphs by routing each op to the cheapest available executor. v0.2 adds pass 2b (single-executor preference) so chains of small ops can amortise up-front host→device transfer cost. v0.3 adds the MX05 Phase 1 profile sampler: per-(graph, op) invocation counters and an observation API ready for future profile-guided specialisation. Zero external dependencies."
+description = "MX04 — the brain of the matrix execution layer. Planner, executor registry, and cost-model-driven placement. Lowers matrix-ir Graphs to compute-ir ComputeGraphs by routing each op to the cheapest available executor. v0.2 adds pass 2b (single-executor preference) so chains of small ops can amortise up-front host→device transfer cost. v0.3 adds the MX05 Phase 1 profile sampler: per-(graph, op) invocation counters. v0.4 adds MX05 Phase 2a: tensor-byte sampling for min/max/sparsity range observations, with a configurable sample rate ready for future profile-guided narrowing. Zero external dependencies."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/matrix-runtime/src/profile.rs
+++ b/code/packages/rust/matrix-runtime/src/profile.rs
@@ -41,6 +41,7 @@
 //! observation logic that wants its own dependency surface.
 
 use compute_ir::{ComputeGraph, ExecutorId, PlacedOp};
+use matrix_ir::DType;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -125,15 +126,31 @@ struct ProfilerInner {
     counters: HashMap<(u64, u32), u64>,
     /// Per-(graph_subhash, op_index) → most-recently-observed executor.
     last_executor: HashMap<(u64, u32), ExecutorId>,
+    /// Per-(graph_subhash, op_index, slot, is_input) tensor running
+    /// statistics.  Bounded ≤ ~64 bytes per entry; cardinality is
+    /// `(distinct compute ops × max input/output count)`, which is
+    /// tiny in practice — image-gpu-core's heaviest graph has ≤ 12
+    /// compute ops with ≤ 3 inputs each, so ≤ 36 entries per graph.
+    tensor_observations: HashMap<(u64, u32, u32, bool), TensorObservation>,
+    /// Sampling rate denominator — `1` means sample every dispatch,
+    /// `100` means roughly 1%.  See [`Profiler::set_sample_rate`].
+    sample_rate: u32,
+    /// Counter advanced by `should_sample`; modulo `sample_rate` decides
+    /// whether the current call should sample.  Deterministic so tests
+    /// don't depend on a PRNG.
+    sample_counter: u64,
 }
 
 impl Profiler {
-    /// Construct an empty profiler.
+    /// Construct an empty profiler with the default 1% sample rate.
     pub fn new() -> Self {
         Profiler {
             inner: Mutex::new(ProfilerInner {
                 counters: HashMap::new(),
                 last_executor: HashMap::new(),
+                tensor_observations: HashMap::new(),
+                sample_rate: 100,
+                sample_counter: 0,
             }),
         }
     }
@@ -183,11 +200,27 @@ impl Profiler {
 
     /// Snapshot the full set of observations.  O(n) in counter map
     /// size; cheap when the workload is a handful of compiled graphs.
+    ///
+    /// Per-tensor observations recorded via [`Self::sample_tensor`] are
+    /// folded into the matching `ProfileObservation::tensor_observations`
+    /// vector.
     pub fn observations(&self) -> Vec<ProfileObservation> {
         let inner = match self.inner.lock() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };
+        // Group tensor observations by (graph_subhash, op_index).
+        let mut grouped: HashMap<(u64, u32), Vec<TensorObservation>> = HashMap::new();
+        for ((graph_subhash, op_index, _slot, _is_input), obs) in inner.tensor_observations.iter() {
+            grouped
+                .entry((*graph_subhash, *op_index))
+                .or_default()
+                .push(obs.clone());
+        }
+        // Stable ordering: inputs before outputs, then by slot.
+        for v in grouped.values_mut() {
+            v.sort_by_key(|o| (!o.is_input, o.slot));
+        }
         inner
             .counters
             .iter()
@@ -200,15 +233,21 @@ impl Profiler {
                     .get(&(graph_subhash, op_index))
                     .copied()
                     .unwrap_or(ExecutorId(u32::MAX)),
-                tensor_observations: Vec::new(),
+                tensor_observations: grouped
+                    .remove(&(graph_subhash, op_index))
+                    .unwrap_or_default(),
             })
             .collect()
     }
 
-    /// Reset all counters.  Useful between benchmark iterations and
-    /// for tests.  Does not affect any specialised kernels that may
-    /// have been emitted — those live in a separate cache that
-    /// future phases will manage.
+    /// Reset all counters and tensor observations, and rewind the
+    /// sample counter.  Useful between benchmark iterations and for
+    /// tests.  Does not change the configured sample rate — call
+    /// [`Self::set_sample_rate`] afterwards if needed.
+    ///
+    /// Does not affect any specialised kernels that may have been
+    /// emitted — those live in a separate cache that future phases
+    /// will manage.
     pub fn reset(&self) {
         let mut inner = match self.inner.lock() {
             Ok(g) => g,
@@ -216,6 +255,167 @@ impl Profiler {
         };
         inner.counters.clear();
         inner.last_executor.clear();
+        inner.tensor_observations.clear();
+        inner.sample_counter = 0;
+    }
+
+    /// Set the sampling rate denominator.  `1` means sample every
+    /// call, `100` (the default) means roughly 1% of calls should
+    /// sample.  `0` is treated as "never sample" and is the only way
+    /// to disable sampling outright.
+    ///
+    /// Affects future calls to [`Self::should_sample`]; in-flight
+    /// observations already recorded are kept.
+    pub fn set_sample_rate(&self, rate: u32) {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        inner.sample_rate = rate;
+    }
+
+    /// Returns `true` when the caller should sample this dispatch's
+    /// tensor data.  Counter-based and deterministic — at rate `N`,
+    /// every `N`-th call returns `true`.  This avoids needing a PRNG
+    /// (which would pull in a dependency or fight with Rust's
+    /// deterministic-tests goal).
+    ///
+    /// Rate `0` always returns `false`; rate `1` always returns
+    /// `true`.
+    pub fn should_sample(&self) -> bool {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if inner.sample_rate == 0 {
+            return false;
+        }
+        let n = inner.sample_rate as u64;
+        let c = inner.sample_counter;
+        inner.sample_counter = inner.sample_counter.wrapping_add(1);
+        c % n == 0
+    }
+
+    /// Record a tensor-byte sample for a specific
+    /// `(graph_subhash, op_index, slot, is_input)` slot.
+    ///
+    /// Walks `bytes` interpreting them as scalars of `dtype` and
+    /// updates the running min / max / observed-zeros / samples
+    /// statistics in place.  Bounded ≤ 64 bytes of state regardless
+    /// of `bytes.len()`; the work is **O(bytes.len() / dtype.size_bytes())**
+    /// scalars per call.
+    ///
+    /// Callers are expected to gate this on [`Self::should_sample`]
+    /// to keep aggregate sampling overhead near the 1% target.  For
+    /// tests and benchmarks that want every value sampled, set the
+    /// rate to 1.
+    ///
+    /// Malformed `bytes` (length not a multiple of `dtype.size_bytes()`)
+    /// is silently truncated to a multiple — partial scalars at the
+    /// tail are dropped.  This matches what executors already do at
+    /// dispatch time.
+    pub fn sample_tensor(
+        &self,
+        graph_subhash: u64,
+        op_index: u32,
+        slot: u32,
+        is_input: bool,
+        dtype: DType,
+        bytes: &[u8],
+    ) {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        let key = (graph_subhash, op_index, slot, is_input);
+        let entry = inner.tensor_observations.entry(key).or_insert_with(|| {
+            TensorObservation {
+                slot,
+                is_input,
+                observed_min: f64::INFINITY,
+                observed_max: f64::NEG_INFINITY,
+                observed_zeros: 0,
+                samples: 0,
+            }
+        });
+
+        match dtype {
+            DType::F32 => {
+                let mut chunks = bytes.chunks_exact(4);
+                for chunk in &mut chunks {
+                    let v = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]) as f64;
+                    if v.is_nan() {
+                        // NaN propagates poorly through min/max; skip.
+                        // Counted as a sample so sparsity ratio stays
+                        // honest; not counted as a zero.
+                        entry.samples = entry.samples.saturating_add(1);
+                        continue;
+                    }
+                    if v < entry.observed_min {
+                        entry.observed_min = v;
+                    }
+                    if v > entry.observed_max {
+                        entry.observed_max = v;
+                    }
+                    if v == 0.0 {
+                        entry.observed_zeros = entry.observed_zeros.saturating_add(1);
+                    }
+                    entry.samples = entry.samples.saturating_add(1);
+                }
+            }
+            DType::U8 => {
+                for &b in bytes {
+                    let v = b as f64;
+                    if v < entry.observed_min {
+                        entry.observed_min = v;
+                    }
+                    if v > entry.observed_max {
+                        entry.observed_max = v;
+                    }
+                    if b == 0 {
+                        entry.observed_zeros = entry.observed_zeros.saturating_add(1);
+                    }
+                    entry.samples = entry.samples.saturating_add(1);
+                }
+            }
+            DType::I32 => {
+                let mut chunks = bytes.chunks_exact(4);
+                for chunk in &mut chunks {
+                    let v = i32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]) as f64;
+                    if v < entry.observed_min {
+                        entry.observed_min = v;
+                    }
+                    if v > entry.observed_max {
+                        entry.observed_max = v;
+                    }
+                    if v == 0.0 {
+                        entry.observed_zeros = entry.observed_zeros.saturating_add(1);
+                    }
+                    entry.samples = entry.samples.saturating_add(1);
+                }
+            }
+        }
+    }
+
+    /// Look up the running tensor-observation for a specific
+    /// `(graph_subhash, op_index, slot, is_input)`.  Returns `None`
+    /// if no sample has been recorded for that slot.
+    pub fn tensor_observation(
+        &self,
+        graph_subhash: u64,
+        op_index: u32,
+        slot: u32,
+        is_input: bool,
+    ) -> Option<TensorObservation> {
+        let inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        inner
+            .tensor_observations
+            .get(&(graph_subhash, op_index, slot, is_input))
+            .cloned()
     }
 
     /// Compute the graph-subhash the profiler uses as a key.  Exposed
@@ -491,6 +691,200 @@ mod tests {
         // Sanity: well above the 1000 threshold the spec uses for
         // first-tier specialisation.
         assert!(p.invocation_count(key, 0) >= 1000);
+    }
+
+    // ──────── Phase 2a: range observation tests ────────
+
+    fn f32_le(values: &[f32]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(values.len() * 4);
+        for &x in values {
+            v.extend_from_slice(&x.to_le_bytes());
+        }
+        v
+    }
+
+    fn i32_le(values: &[i32]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(values.len() * 4);
+        for &x in values {
+            v.extend_from_slice(&x.to_le_bytes());
+        }
+        v
+    }
+
+    #[test]
+    fn sample_tensor_f32_records_min_max_zeros() {
+        let p = Profiler::new();
+        let bytes = f32_le(&[1.0, -2.0, 0.0, 3.0, 0.0, -5.0]);
+        p.sample_tensor(0xABCD, 7, 0, true, DType::F32, &bytes);
+        let obs = p.tensor_observation(0xABCD, 7, 0, true).unwrap();
+        assert_eq!(obs.observed_min, -5.0);
+        assert_eq!(obs.observed_max, 3.0);
+        assert_eq!(obs.observed_zeros, 2);
+        assert_eq!(obs.samples, 6);
+    }
+
+    #[test]
+    fn sample_tensor_u8_records_min_max_zeros() {
+        let p = Profiler::new();
+        let bytes = vec![10u8, 0, 200, 0, 50, 250];
+        p.sample_tensor(0xABCD, 0, 0, true, DType::U8, &bytes);
+        let obs = p.tensor_observation(0xABCD, 0, 0, true).unwrap();
+        // Zero is a real value; min reflects it.  observed_zeros is
+        // a separate counter.
+        assert_eq!(obs.observed_min, 0.0);
+        assert_eq!(obs.observed_max, 250.0);
+        assert_eq!(obs.observed_zeros, 2);
+        assert_eq!(obs.samples, 6);
+    }
+
+    #[test]
+    fn sample_tensor_i32_records_min_max_zeros() {
+        let p = Profiler::new();
+        let bytes = i32_le(&[5, 0, -100, 250, 0, -1]);
+        p.sample_tensor(0xABCD, 0, 0, true, DType::I32, &bytes);
+        let obs = p.tensor_observation(0xABCD, 0, 0, true).unwrap();
+        assert_eq!(obs.observed_min, -100.0);
+        assert_eq!(obs.observed_max, 250.0);
+        assert_eq!(obs.observed_zeros, 2);
+        assert_eq!(obs.samples, 6);
+    }
+
+    #[test]
+    fn sample_tensor_accumulates_across_calls() {
+        let p = Profiler::new();
+        // First call: range [-2, 3], zeros 1.
+        p.sample_tensor(0xA, 0, 0, true, DType::F32, &f32_le(&[1.0, -2.0, 0.0, 3.0]));
+        // Second call extends both ends: range becomes [-7, 8], zeros 2.
+        p.sample_tensor(0xA, 0, 0, true, DType::F32, &f32_le(&[8.0, -7.0, 0.0]));
+        let obs = p.tensor_observation(0xA, 0, 0, true).unwrap();
+        assert_eq!(obs.observed_min, -7.0);
+        assert_eq!(obs.observed_max, 8.0);
+        assert_eq!(obs.observed_zeros, 2);
+        assert_eq!(obs.samples, 7);
+    }
+
+    #[test]
+    fn sample_tensor_f32_skips_nan() {
+        let p = Profiler::new();
+        let bytes = f32_le(&[1.0, f32::NAN, 2.0]);
+        p.sample_tensor(0xA, 0, 0, true, DType::F32, &bytes);
+        let obs = p.tensor_observation(0xA, 0, 0, true).unwrap();
+        // NaN doesn't poison min/max.
+        assert_eq!(obs.observed_min, 1.0);
+        assert_eq!(obs.observed_max, 2.0);
+        // But it's still counted as a sample (so sparsity ratios
+        // remain honest).
+        assert_eq!(obs.samples, 3);
+        assert_eq!(obs.observed_zeros, 0);
+    }
+
+    #[test]
+    fn sample_tensor_truncates_partial_trailing_scalar() {
+        let p = Profiler::new();
+        // 5 bytes, dtype F32 (4 bytes per scalar) → 1 valid scalar,
+        // trailing byte dropped silently.
+        let mut bytes = f32_le(&[2.5]);
+        bytes.push(0xFF);
+        p.sample_tensor(0xA, 0, 0, true, DType::F32, &bytes);
+        let obs = p.tensor_observation(0xA, 0, 0, true).unwrap();
+        assert_eq!(obs.observed_min, 2.5);
+        assert_eq!(obs.observed_max, 2.5);
+        assert_eq!(obs.samples, 1);
+    }
+
+    #[test]
+    fn observations_includes_tensor_observations() {
+        let p = Profiler::new();
+        let g = one_op_graph(CPU_EXECUTOR);
+        p.record_dispatch(&g);
+        let key = Profiler::subhash(&g);
+        p.sample_tensor(key, 0, 0, true, DType::F32, &f32_le(&[10.0, -10.0]));
+        p.sample_tensor(key, 0, 0, false, DType::F32, &f32_le(&[100.0, -100.0]));
+
+        let obs = p.observations();
+        assert_eq!(obs.len(), 1);
+        let tensor_obs = &obs[0].tensor_observations;
+        assert_eq!(tensor_obs.len(), 2);
+        // Inputs (is_input == true) come first by sort order.
+        assert!(tensor_obs[0].is_input);
+        assert_eq!(tensor_obs[0].observed_min, -10.0);
+        assert!(!tensor_obs[1].is_input);
+        assert_eq!(tensor_obs[1].observed_min, -100.0);
+    }
+
+    #[test]
+    fn should_sample_at_default_rate_yields_one_in_hundred() {
+        let p = Profiler::new();
+        // Default rate = 100.  In 100 calls, exactly 1 should return true
+        // (counter-based, so deterministic — first call returns true,
+        // then false 99 times, then true again, …).
+        let mut hits = 0;
+        for _ in 0..100 {
+            if p.should_sample() {
+                hits += 1;
+            }
+        }
+        assert_eq!(hits, 1, "expected exactly one hit per 100 calls at rate 100");
+    }
+
+    #[test]
+    fn should_sample_rate_one_always_yields_true() {
+        let p = Profiler::new();
+        p.set_sample_rate(1);
+        for _ in 0..50 {
+            assert!(p.should_sample());
+        }
+    }
+
+    #[test]
+    fn should_sample_rate_zero_never_yields_true() {
+        let p = Profiler::new();
+        p.set_sample_rate(0);
+        for _ in 0..50 {
+            assert!(!p.should_sample());
+        }
+    }
+
+    #[test]
+    fn reset_clears_tensor_observations_and_sample_counter() {
+        let p = Profiler::new();
+        p.set_sample_rate(1);
+        // Drive the sample counter forward.
+        for _ in 0..5 {
+            assert!(p.should_sample());
+        }
+        p.sample_tensor(0xA, 0, 0, true, DType::F32, &f32_le(&[1.0]));
+        assert!(p.tensor_observation(0xA, 0, 0, true).is_some());
+
+        p.reset();
+        assert!(p.tensor_observation(0xA, 0, 0, true).is_none());
+        // Sample counter rewound: at rate 1 every call still returns
+        // true so we can't tell, but at default rate we'd see the
+        // first call return true.  Re-set rate and check.
+        p.set_sample_rate(100);
+        assert!(p.should_sample(), "first call after reset should be a sample at rate 100");
+    }
+
+    #[test]
+    fn observations_orders_tensor_observations_by_input_then_slot() {
+        let p = Profiler::new();
+        let g = one_op_graph(CPU_EXECUTOR);
+        p.record_dispatch(&g);
+        let key = Profiler::subhash(&g);
+        // Insert in deliberately scrambled order; observations()
+        // should still return them grouped (inputs first, by slot).
+        p.sample_tensor(key, 0, 1, false, DType::F32, &f32_le(&[1.0]));
+        p.sample_tensor(key, 0, 0, true, DType::F32, &f32_le(&[2.0]));
+        p.sample_tensor(key, 0, 0, false, DType::F32, &f32_le(&[3.0]));
+        p.sample_tensor(key, 0, 1, true, DType::F32, &f32_le(&[4.0]));
+
+        let obs = &p.observations()[0];
+        let tobs = &obs.tensor_observations;
+        assert_eq!(tobs.len(), 4);
+        assert!(tobs[0].is_input && tobs[0].slot == 0);
+        assert!(tobs[1].is_input && tobs[1].slot == 1);
+        assert!(!tobs[2].is_input && tobs[2].slot == 0);
+        assert!(!tobs[3].is_input && tobs[3].slot == 1);
     }
 
     #[test]

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -95,14 +95,17 @@ Five new components, none of which require IR or protocol changes:
 
 ### 1. Profile sampler (matrix-profile crate)
 
-> **Implementation status (Phase 1 landed)**: shipped as the
-> `matrix_runtime::profile` module rather than as a separate
-> `matrix-profile` crate.  Promotion is deferred to Phase 2, where the
-> sampler grows real observation logic that benefits from its own
-> dependency surface.  Phase 1 only implements per-op invocation
-> counters and the `Profiler` / `ProfileObservation` /
-> `TensorObservation` data types; everything else in this section is
-> still future work.
+> **Implementation status (Phase 1 + Phase 2a landed)**: shipped as
+> the `matrix_runtime::profile` module rather than a separate
+> `matrix-profile` crate.  Phase 1 added per-op invocation counters
+> and the `Profiler` / `ProfileObservation` / `TensorObservation`
+> data types.  Phase 2a (this update) adds `Profiler::sample_tensor`,
+> `Profiler::tensor_observation`, `Profiler::should_sample`, and
+> `Profiler::set_sample_rate` — the data plumbing for range
+> observation.  No specialisation policy yet; that lands in Phase 2b
+> (auto-narrow Cast insertion) and Phase 3 (SpecKey + Specialiser
+> trait + cache).  Sampling is deterministic via a modulo counter
+> rather than a PRNG so tests stay reproducible.
 
 A new crate, `matrix-profile`, that owns the observation logic:
 


### PR DESCRIPTION
## Summary

Builds directly on the Phase 1 invocation-counter infrastructure landed in #2092. Phase 2a adds the **data plumbing** for profile-guided narrowing: tensor-byte sampling that accumulates per-(graph, op, slot, direction) min / max / zero-count / sample-count statistics. No specialisation policy yet — that's Phase 2b (auto-narrow Cast insertion) and Phase 3 (SpecKey + Specialiser trait + cache).

## What this PR adds

`matrix-runtime` v0.3.0 → v0.4.0:

- `Profiler::sample_tensor(graph_subhash, op_index, slot, is_input, dtype, bytes)` — parses raw bytes per dtype, accumulates running min/max/zeros/samples. Bounded ≤ ~64 bytes of state per slot.
- `Profiler::tensor_observation(...)` — read-back accessor.
- `Profiler::should_sample()` — counter-based deterministic gate. At rate `N`, returns `true` once per `N` calls. No PRNG, so tests stay reproducible.
- `Profiler::set_sample_rate(rate)` — tunes the gate; default is 100 (≈1% per spec).
- `Profiler::observations()` now folds sampled `TensorObservation`s into the matching `ProfileObservation`, sorted inputs-before-outputs.
- `Profiler::reset()` now clears tensor observations and rewinds the sample counter.

Edge cases handled:
- F32 NaN is skipped (not used for min/max) but still counted as a sample.
- Trailing partial scalars are silently truncated.
- All counters use `saturating_add` against malicious huge inputs.

## Why deterministic sampling instead of a PRNG

Per the spec MX05 §"Profile sampler", sampling rate is "default 1%". I considered `rand::random()` but that pulls in a dependency, fights Rust's deterministic-tests goal, and isn't actually needed: a modulo counter gives the same expected hit rate with reproducible behaviour. Tests assert exactly one hit per 100 calls at the default rate.

## Tests

12 new tests in `profile::tests::*` covering F32/U8/I32 byte parsing, NaN handling, partial-scalar truncation, accumulation across multiple calls, `should_sample` at rates 0/1/100, reset clearing tensor observations, and stable ordering of observations in the output.

Total: **38 unit + 8 integration = 46 tests pass** (was 34).

## Regression check

`instagram-filters` routing on macOS unchanged after Phase 2a:

```
  invert        → cpu     (small graph, planner picks CPU)
  greyscale     → metal   (sRGB + matmul, ships to GPU)
  sepia         → metal   (matmul-heavy, ships to GPU)
```

Sampling overhead is a `Mutex` acquire + a few HashMap entry updates — well below the planner / transport work per dispatch.

## Test plan

- [x] `cargo test -p matrix-runtime` — 46 tests pass
- [x] `cargo build` clean (no new warnings)
- [x] `instagram-filters` routing unchanged across the dataset
- [x] Spec MX05 §"Profile sampler" updated
- [x] Security review passed in one round

## Out of scope (V1)

- Specialisation policy / SpecKey / Specialiser trait / SpecCache (Phase 3)
- Auto-narrowing Cast insertion (Phase 2b)
- Constant folding into kernels (Phase 4)
- Deoptimisation (Phase 5)
- Promotion to a separate `matrix-profile` crate (Phase 2 lift, not yet)
- F16 / I8 / I16 dtypes (V1 dtype set is F32/U8/I32; narrowing to those that already exist is the immediate next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)