### PR TITLE
Guard ALGOL array-bound procedure descriptor order

### DIFF
--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -40,6 +40,9 @@ All notable changes to this package will be documented in this file.
   completes.
 - Preserved array declaration-order semantics by relying on checker diagnostics
   for bounds that read later array descriptors.
+- Preserved indirect array declaration-order semantics by relying on checker
+  diagnostics for bounds that call procedures which may touch later array
+  descriptors.
 - Lowered integer array-element by-name actuals to tagged descriptors with
   generated eval/store helpers that re-compute the element address on every
   formal read or assignment.

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -36,7 +36,9 @@ Because the checker defers bound expression analysis until declaration
 registration completes, those lower/upper expressions can call later sibling
 typed procedures in the same block. Bound expressions may read earlier array
 descriptors, but same-block arrays declared later remain rejected before IR
-lowering because their descriptors do not exist at allocation time.
+lowering because their descriptors do not exist at allocation time. The same
+declaration-order guard is applied transitively through procedures called from
+bounds, while arrays local to those callees still lower normally.
 
 Expression lowering includes mixed integer/real arithmetic, boolean operators,
 comparisons, chained assignment targets, branch-selected conditional

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -1628,12 +1628,55 @@ class TestAlgolIrCompiler:
         assert "b@block0" in result.variable_slots
         assert "a@block0" in result.variable_slots
 
+    def test_compiles_prior_array_accesses_through_array_bound_procedures(
+        self,
+    ) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "integer array b[0:0]; integer array a[lower():lower()]; "
+                "integer procedure lower; begin lower := b[0] end; "
+                "b[0] := 0; a[0] := 9; result := a[0] "
+                "end"
+            )
+        )
+
+        assert "b@block0" in result.variable_slots
+        assert "a@block0" in result.variable_slots
+
     def test_rejects_later_array_accesses_in_array_bounds(self) -> None:
         with pytest.raises(CompileError, match="before its descriptor is allocated"):
             compile_algol(
                 parse_algol(
                     "begin integer result; integer array a[b[1]:b[1]]; "
                     "integer array b[1:1]; result := 0 end"
+                )
+            )
+
+    def test_rejects_later_array_accesses_through_array_bound_procedures(
+        self,
+    ) -> None:
+        with pytest.raises(CompileError, match="cannot call procedure 'lower'"):
+            compile_algol(
+                parse_algol(
+                    "begin integer result; integer array a[lower():lower()]; "
+                    "integer procedure lower; begin lower := b[0] end; "
+                    "integer array b[0:0]; result := 0 end"
+                )
+            )
+
+    def test_rejects_later_array_accesses_through_bound_formal_procedures(
+        self,
+    ) -> None:
+        with pytest.raises(CompileError, match="cannot call procedure 'wrapper'"):
+            compile_algol(
+                parse_algol(
+                    "begin integer result; "
+                    "integer array a[wrapper(reader):wrapper(reader)]; "
+                    "integer procedure wrapper(f); integer procedure f; "
+                    "begin wrapper := f end; "
+                    "integer procedure reader; begin reader := b[0] end; "
+                    "integer array b[0:0]; result := 0 end"
                 )
             )
 

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -54,6 +54,9 @@ All notable changes to this package will be documented in this file.
   block.
 - Rejected array bound expressions that read an array declared later in the
   same block, preserving declaration-order descriptor allocation semantics.
+- Rejected array bounds that call procedures whose reachable bodies may access
+  later same-block array descriptors before allocation, while still allowing
+  callee-local arrays and earlier descriptors.
 - Accepted integer-returning procedure actuals for real-valued formal
   procedure parameters, matching scalar integer-to-real promotion.
 - Accepted switch declaration entries that target labels in lexical parent

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -50,7 +50,10 @@ IR and WASM lowering stages. Array bound expressions are checked after the
 block's declaration signatures are registered, so bounds can call later sibling
 typed procedures in the same declaration part; direct array reads in bounds
 are still limited to descriptors already allocated earlier in declaration
-order.
+order. Procedure calls from bounds are checked through their reachable bodies
+for the same descriptor-order rule, while arrays local to the called procedures
+remain valid because those frames allocate their own descriptors during the
+call.
 Labels receive stable label descriptors and direct local `goto`/`go to` statements
 resolve to those descriptors. Direct nonlocal block `goto` statements resolve
 to outer active blocks, and procedure-crossing transfers resolve to pending

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -309,6 +309,8 @@ class ResolvedProcedureCall:
     line: int
     column: int
     parameter_symbol_id: int | None = None
+    procedure_argument_ids: tuple[int | None, ...] = ()
+    procedure_argument_formal_symbol_ids: tuple[int | None, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -423,6 +425,17 @@ class _PendingArrayBoundPair:
     lower: ASTNode
     upper: ASTNode
     visible_array_ids: frozenset[int]
+
+
+@dataclass(frozen=True)
+class _PendingArrayBoundProcedureCall:
+    """Procedure call from an array bound plus arrays allocated before it."""
+
+    bound: ASTNode
+    procedure_id: int
+    procedure_name: str
+    visible_array_ids: frozenset[int]
+    procedure_actuals: tuple[tuple[int, int], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -618,8 +631,9 @@ class AlgolTypeChecker:
                 if pending is not None:
                     pending_procedures.append(pending)
 
+        pending_array_bound_calls: list[_PendingArrayBoundProcedureCall] = []
         for pending in pending_array_bounds:
-            self._check_pending_array_bounds(pending)
+            pending_array_bound_calls.extend(self._check_pending_array_bounds(pending))
 
         for pending in pending_switches:
             self._check_pending_switch_declaration(pending)
@@ -628,6 +642,8 @@ class AlgolTypeChecker:
 
         for pending in pending_procedures:
             self._check_pending_procedure_body(pending)
+
+        self._check_array_bound_procedure_calls(pending_array_bound_calls)
 
         for child in _node_children(block):
             if child.rule_name == "statement":
@@ -696,7 +712,8 @@ class AlgolTypeChecker:
                 storage_class=STATIC,
             )
             if pending_array_bounds is None:
-                self._check_pending_array_bounds(pending)
+                bound_calls = self._check_pending_array_bounds(pending)
+                self._check_array_bound_procedure_calls(bound_calls)
             else:
                 pending_array_bounds.append(pending)
             return None
@@ -707,7 +724,8 @@ class AlgolTypeChecker:
                 storage_class="frame",
             )
             if pending_array_bounds is None:
-                self._check_pending_array_bounds(pending)
+                bound_calls = self._check_pending_array_bounds(pending)
+                self._check_array_bound_procedure_calls(bound_calls)
             else:
                 pending_array_bounds.append(pending)
             return None
@@ -879,10 +897,15 @@ class AlgolTypeChecker:
                 )
         return _PendingArrayBounds(scope=scope, bounds=tuple(pending_bounds))
 
-    def _check_pending_array_bounds(self, pending: _PendingArrayBounds) -> None:
+    def _check_pending_array_bounds(
+        self,
+        pending: _PendingArrayBounds,
+    ) -> list[_PendingArrayBoundProcedureCall]:
+        bound_calls: list[_PendingArrayBoundProcedureCall] = []
         for pair in pending.bounds:
             for bound in (pair.lower, pair.upper):
                 previous_access_count = len(self.resolved_array_accesses)
+                previous_call_count = len(self.resolved_procedure_calls)
                 bound_type = self._infer_expr(bound, pending.scope)
                 if bound_type != ERROR and bound_type != INTEGER:
                     self._error(bound, "array bounds must be integer")
@@ -893,6 +916,137 @@ class AlgolTypeChecker:
                             f"array bound cannot read array {access.name!r} "
                             "before its descriptor is allocated",
                         )
+                for call in self.resolved_procedure_calls[previous_call_count:]:
+                    if call.procedure_id >= 0:
+                        bound_calls.append(
+                            _PendingArrayBoundProcedureCall(
+                                bound=bound,
+                                procedure_id=call.procedure_id,
+                                procedure_name=call.name,
+                                visible_array_ids=pair.visible_array_ids,
+                                procedure_actuals=tuple(
+                                    self._procedure_actuals_for_call(call, {})
+                                ),
+                            )
+                        )
+        return bound_calls
+
+    def _check_array_bound_procedure_calls(
+        self,
+        pending_calls: list[_PendingArrayBoundProcedureCall],
+    ) -> None:
+        if not pending_calls:
+            return
+        owner_by_block = {
+            block.block_id: block.owner_procedure_id for block in self.semantic_blocks
+        }
+        for pending in pending_calls:
+            reachable_procedure_ids: set[int] = set()
+            procedure_actuals = dict(pending.procedure_actuals)
+            reachable_accesses = self._array_accesses_reachable_from_procedure(
+                pending.procedure_id,
+                owner_by_block,
+                reachable_procedure_ids,
+                procedure_actuals,
+            )
+            reported_arrays: set[int] = set()
+            for access in reachable_accesses:
+                if access.array_id in pending.visible_array_ids:
+                    continue
+                if access.array_id in reported_arrays:
+                    continue
+                descriptor = self._array_descriptor_for_id(access.array_id)
+                if descriptor is None:
+                    continue
+                if descriptor.storage_class == PARAMETER_STORAGE:
+                    continue
+                declaring_owner = owner_by_block.get(descriptor.declaring_block_id)
+                if declaring_owner in reachable_procedure_ids:
+                    continue
+                reported_arrays.add(access.array_id)
+                self._error(
+                    pending.bound,
+                    f"array bound cannot call procedure {pending.procedure_name!r} "
+                    f"because it may access array {access.name!r} before its "
+                    "descriptor is allocated",
+                )
+
+    def _array_accesses_reachable_from_procedure(
+        self,
+        procedure_id: int,
+        owner_by_block: dict[int, int | None],
+        seen: set[int],
+        procedure_actuals: dict[int, int],
+    ) -> list[ResolvedArrayAccess]:
+        if procedure_id in seen:
+            return []
+        seen.add(procedure_id)
+        accesses = [
+            access
+            for access in self.resolved_array_accesses
+            if owner_by_block.get(access.use_block_id) == procedure_id
+        ]
+        for call in self.resolved_procedure_calls:
+            if owner_by_block.get(call.use_block_id) != procedure_id:
+                continue
+            call_procedure_id = call.procedure_id
+            if call_procedure_id == -2 and call.parameter_symbol_id is not None:
+                call_procedure_id = procedure_actuals.get(call.parameter_symbol_id, -2)
+            if call_procedure_id < 0:
+                continue
+            nested_actuals = dict(procedure_actuals)
+            nested_actuals.update(
+                self._procedure_actuals_for_call(call, procedure_actuals)
+            )
+            accesses.extend(
+                self._array_accesses_reachable_from_procedure(
+                    call_procedure_id,
+                    owner_by_block,
+                    seen,
+                    nested_actuals,
+                )
+            )
+        return accesses
+
+    def _procedure_actuals_for_call(
+        self,
+        call: ResolvedProcedureCall,
+        enclosing_actuals: dict[int, int],
+    ) -> list[tuple[int, int]]:
+        descriptor = self._procedure_descriptor_for_id(call.procedure_id)
+        if descriptor is None:
+            return []
+        actuals: list[tuple[int, int]] = []
+        for index, parameter in enumerate(descriptor.parameters):
+            if parameter.kind != "procedure":
+                continue
+            actual_id = (
+                call.procedure_argument_ids[index]
+                if index < len(call.procedure_argument_ids)
+                else None
+            )
+            if actual_id is None and index < len(
+                call.procedure_argument_formal_symbol_ids
+            ):
+                formal_symbol_id = call.procedure_argument_formal_symbol_ids[index]
+                if formal_symbol_id is not None:
+                    actual_id = enclosing_actuals.get(formal_symbol_id)
+            if actual_id is not None:
+                actuals.append((parameter.symbol_id, actual_id))
+        return actuals
+
+    def _array_descriptor_for_id(
+        self,
+        array_id: int,
+    ) -> ArrayDescriptor | None:
+        return next(
+            (
+                array
+                for array in self.semantic_arrays
+                if array.array_id == array_id
+            ),
+            None,
+        )
 
     def _register_switch_declaration(
         self,
@@ -2254,25 +2408,47 @@ class AlgolTypeChecker:
             self.resolved_procedure_calls.append(call)
             return call
 
+        procedure_argument_ids: list[int | None] = []
+        procedure_argument_formal_symbol_ids: list[int | None] = []
         for argument, parameter in zip(arguments, descriptor.parameters, strict=False):
             if parameter.kind == ARRAY:
                 self._check_array_parameter_actual(argument, scope, parameter)
+                procedure_argument_ids.append(None)
+                procedure_argument_formal_symbol_ids.append(None)
                 continue
             if parameter.kind == LABEL:
                 self._check_label_parameter_actual(argument, scope, parameter)
+                procedure_argument_ids.append(None)
+                procedure_argument_formal_symbol_ids.append(None)
                 continue
             if parameter.kind == SWITCH:
                 self._check_switch_parameter_actual(argument, scope, parameter)
+                procedure_argument_ids.append(None)
+                procedure_argument_formal_symbol_ids.append(None)
                 continue
             if parameter.kind == "procedure":
-                self._check_procedure_parameter_actual(
+                actual_symbol = self._check_procedure_parameter_actual(
                     argument,
                     scope,
                     parameter,
                     call_descriptor=descriptor,
                     call_arguments=arguments,
                 )
+                procedure_argument_ids.append(
+                    actual_symbol.procedure_id
+                    if actual_symbol is not None
+                    and actual_symbol.kind == "procedure"
+                    else None
+                )
+                procedure_argument_formal_symbol_ids.append(
+                    actual_symbol.symbol_id
+                    if actual_symbol is not None
+                    and actual_symbol.kind == "procedure_parameter"
+                    else None
+                )
                 continue
+            procedure_argument_ids.append(None)
+            procedure_argument_formal_symbol_ids.append(None)
             actual_type = self._infer_expr(argument, scope)
             if actual_type != ERROR and not self._parameter_accepts_type(
                 parameter.mode,
@@ -2334,6 +2510,10 @@ class AlgolTypeChecker:
             line=name_token.line,
             column=name_token.column,
             parameter_symbol_id=descriptor.parameter_symbol_id,
+            procedure_argument_ids=tuple(procedure_argument_ids),
+            procedure_argument_formal_symbol_ids=tuple(
+                procedure_argument_formal_symbol_ids
+            ),
         )
         self.resolved_procedure_calls.append(call)
         return call

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -2101,6 +2101,19 @@ class TestAlgolTypeChecker:
             "b",
         ]
 
+    def test_accepts_prior_array_accesses_through_array_bound_procedures(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array b[0:0]; "
+            "integer array a[lower():lower()]; "
+            "integer procedure lower; begin lower := b[0] end; "
+            "b[0] := 0; a[0] := 5; result := a[0] end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+
     def test_rejects_later_array_accesses_in_array_bounds(self) -> None:
         ast = parse_algol(
             "begin integer result; integer array a[b[1]:b[1]]; "
@@ -2114,6 +2127,74 @@ class TestAlgolTypeChecker:
             in diagnostic.message
             for diagnostic in result.diagnostics
         )
+
+    def test_rejects_later_array_accesses_through_array_bound_procedures(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer array a[lower():lower()]; "
+            "integer procedure lower; begin lower := b[0] end; "
+            "integer array b[0:0]; result := 0 end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert any(
+            "array bound cannot call procedure 'lower' because it may access "
+            "array 'b' before its descriptor is allocated" in diagnostic.message
+            for diagnostic in result.diagnostics
+        )
+
+    def test_rejects_transitive_later_array_accesses_through_bound_procedures(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer array a[lower():lower()]; "
+            "integer procedure lower; begin lower := readb end; "
+            "integer procedure readb; begin readb := b[0] end; "
+            "integer array b[0:0]; result := 0 end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert any(
+            "array bound cannot call procedure 'lower' because it may access "
+            "array 'b' before its descriptor is allocated" in diagnostic.message
+            for diagnostic in result.diagnostics
+        )
+
+    def test_rejects_later_array_accesses_through_bound_formal_procedures(
+        self,
+    ) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "integer array a[wrapper(reader):wrapper(reader)]; "
+            "integer procedure wrapper(f); integer procedure f; "
+            "begin wrapper := f end; "
+            "integer procedure reader; begin reader := b[0] end; "
+            "integer array b[0:0]; result := 0 end"
+        )
+        result = check_algol(ast)
+
+        assert not result.ok
+        assert any(
+            "array bound cannot call procedure 'wrapper' because it may access "
+            "array 'b' before its descriptor is allocated" in diagnostic.message
+            for diagnostic in result.diagnostics
+        )
+
+    def test_accepts_bound_procedures_with_local_array_accesses(self) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array a[lower():lower()]; "
+            "integer procedure lower; "
+            "begin integer array local[0:0]; local[0] := 0; lower := local[0] end; "
+            "a[0] := 5; result := a[0] end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
 
     def test_accepts_default_real_array_declaration(self) -> None:
         ast = parse_algol("begin array a[1:3]; a[1] := 7 end")

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -98,6 +98,9 @@ All notable changes to this package will be documented in this file.
   entry.
 - Rejected array bounds that read arrays declared later in the same block while
   keeping earlier descriptor reads executable.
+- Rejected array bounds that call procedures whose reachable bodies may access
+  later same-block array descriptors before allocation, while keeping earlier
+  and callee-local descriptor reads executable.
 - Executed subscripted integer and real array elements as writable `for`
   statement control variables.
 - Rejected formal procedure forwarding when a concrete procedure argument does

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -18,7 +18,8 @@ the current lane already supports a substantial ALGOL 60 surface:
 - `own` scalars and arrays with static lifetime
 - arrays of `integer`, `boolean`, `real`, and `string` values with runtime
   bounds, including bounds that call later sibling typed procedures or read
-  previously allocated array descriptors, and checked element access
+  previously allocated array descriptors, indirect descriptor-order checking
+  through procedures called from bounds, and checked element access
 - case-insensitive keywords, comments, and standard builtins,
   `!=`/`<>`/`≠` not-equal spelling, ALGOL publication symbols such as `≤`,
   `≥`, `↑`, `×`, `÷`, `¬`, `∧`, `∨`, `⊃`, `≡`, and single- or double-quoted

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -1855,6 +1855,18 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
 
+    def test_prior_array_accesses_through_array_bound_procedures_execute(
+        self,
+    ) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer array b[0:0]; integer array a[lower():lower()]; "
+            "integer procedure lower; begin lower := b[0] end; "
+            "b[0] := 0; a[0] := 9; result := a[0] "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [9]
+
     def test_later_array_accesses_in_array_bounds_are_rejected(self) -> None:
         with pytest.raises(AlgolWasmError) as excinfo:
             compile_source(
@@ -1864,6 +1876,37 @@ class TestAlgolWasmCompiler:
 
         assert excinfo.value.stage == "type-check"
         assert "before its descriptor is allocated" in excinfo.value.message
+
+    def test_later_array_accesses_through_array_bound_procedures_are_rejected(
+        self,
+    ) -> None:
+        with pytest.raises(AlgolWasmError) as excinfo:
+            compile_source(
+                "begin integer result; integer array a[lower():lower()]; "
+                "integer procedure lower; begin lower := b[0] end; "
+                "integer array b[0:0]; result := 0 end"
+            )
+
+        assert excinfo.value.stage == "type-check"
+        assert "cannot call procedure 'lower'" in excinfo.value.message
+        assert "array 'b' before its descriptor is allocated" in excinfo.value.message
+
+    def test_later_array_accesses_through_bound_formal_procedures_are_rejected(
+        self,
+    ) -> None:
+        with pytest.raises(AlgolWasmError) as excinfo:
+            compile_source(
+                "begin integer result; "
+                "integer array a[wrapper(reader):wrapper(reader)]; "
+                "integer procedure wrapper(f); integer procedure f; "
+                "begin wrapper := f end; "
+                "integer procedure reader; begin reader := b[0] end; "
+                "integer array b[0:0]; result := 0 end"
+            )
+
+        assert excinfo.value.stage == "type-check"
+        assert "cannot call procedure 'wrapper'" in excinfo.value.message
+        assert "array 'b' before its descriptor is allocated" in excinfo.value.message
 
     def test_procedure_body_sees_later_block_declarations(self) -> None:
         result = compile_source(


### PR DESCRIPTION
## Summary
- reject ALGOL array bounds that call procedures whose reachable bodies may access later same-block array descriptors before allocation
- propagate direct procedure actuals through formal-procedure calls during bound safety analysis
- keep earlier descriptor reads and callee-local arrays executable, with type-checker, IR, and WASM coverage

## Tests
- bash BUILD (code/packages/python/algol-type-checker)
- bash BUILD (code/packages/python/algol-ir-compiler)
- bash BUILD (code/packages/python/algol-wasm-compiler)
- .venv/bin/python -m ruff check src tests (algol-type-checker)
- .venv/bin/python -m ruff check tests (algol-ir-compiler)
- .venv/bin/python -m ruff check tests (algol-wasm-compiler)
- git diff --check
- security scan: rg for eval/exec/subprocess/shell/network/file-write patterns in touched source/tests; only existing test name containing eval matched