### PR TITLE
feat(prolog): dump CLI source metadata

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -303,6 +303,12 @@ diagnosing convergence between the structured VM and the bytecode VM:
 prolog-vm --source "parent(homer, bart). ?- parent(homer, Who)." --dump-bytecode
 ```
 
+Use `--dump-source-metadata` to compile source without executing it and emit a
+small manifest: dialect, initialization/source query counts, total VM queries,
+instruction count, and visible variables for each embedded source query. This is
+intended for editor and CI integrations that need a stable source manifest
+before selecting a query to run.
+
 Use `--list-source-queries` to inspect embedded `?-` directives before choosing
 what to run. Text output lists the zero-based query index and visible variables;
 JSON output emits the same metadata as a stable `source_queries` record.

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -72,6 +72,7 @@ class CliArgs:
     check: bool
     dump_bytecode: bool
     dump_instructions: bool
+    dump_source_metadata: bool
     list_source_queries: bool
     source_query_index: int
     all_source_queries: bool
@@ -175,6 +176,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     check = bool(flags["check"])
     dump_bytecode = bool(flags["dump-bytecode"])
     dump_instructions = bool(flags["dump-instructions"])
+    dump_source_metadata = bool(flags["dump-source-metadata"])
     list_source_queries = bool(flags["list-source-queries"])
     if check and queries:
         msg = "--check cannot be combined with --query"
@@ -218,6 +220,27 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if dump_instructions and bool(flags["interactive"]):
         msg = "--dump-instructions cannot be combined with --interactive"
         raise ValueError(msg)
+    if dump_source_metadata and queries:
+        msg = "--dump-source-metadata cannot be combined with --query"
+        raise ValueError(msg)
+    if dump_source_metadata and check:
+        msg = "--dump-source-metadata cannot be combined with --check"
+        raise ValueError(msg)
+    if dump_source_metadata and dump_bytecode:
+        msg = "--dump-source-metadata cannot be combined with --dump-bytecode"
+        raise ValueError(msg)
+    if dump_source_metadata and dump_instructions:
+        msg = "--dump-source-metadata cannot be combined with --dump-instructions"
+        raise ValueError(msg)
+    if dump_source_metadata and list_source_queries:
+        msg = "--dump-source-metadata cannot be combined with --list-source-queries"
+        raise ValueError(msg)
+    if dump_source_metadata and all_source_queries:
+        msg = "--dump-source-metadata cannot be combined with --all-source-queries"
+        raise ValueError(msg)
+    if dump_source_metadata and bool(flags["interactive"]):
+        msg = "--dump-source-metadata cannot be combined with --interactive"
+        raise ValueError(msg)
     if list_source_queries and queries:
         msg = "--list-source-queries cannot be combined with --query"
         raise ValueError(msg)
@@ -254,6 +277,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         check=check,
         dump_bytecode=dump_bytecode,
         dump_instructions=dump_instructions,
+        dump_source_metadata=dump_source_metadata,
         list_source_queries=list_source_queries,
         source_query_index=source_query_index,
         all_source_queries=all_source_queries,
@@ -399,6 +423,8 @@ def _run_cli(args: CliArgs) -> int:
         return _run_dump_instructions(args)
     if args.dump_bytecode:
         return _run_dump_bytecode(args)
+    if args.dump_source_metadata:
+        return _run_dump_source_metadata(args)
     if args.list_source_queries:
         return _run_list_source_queries(args)
 
@@ -453,10 +479,72 @@ def _run_dump_instructions(args: CliArgs) -> int:
     return 0
 
 
+def _run_dump_source_metadata(args: CliArgs) -> int:
+    compiled_program = _compile_source_program(args)
+    _print_source_metadata(compiled_program, args=args)
+    return 0
+
+
 def _run_list_source_queries(args: CliArgs) -> int:
     compiled_program = _compile_source_program(args)
     _print_source_query_summary(compiled_program, args=args)
     return 0
+
+
+def _source_query_records(
+    compiled_program: CompiledPrologVMProgram,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "index": index,
+            "variables": list(compiled_program.source_query_variable_names(index)),
+        }
+        for index in range(compiled_program.source_query_count)
+    ]
+
+
+def _print_source_metadata(
+    compiled_program: CompiledPrologVMProgram,
+    *,
+    args: CliArgs,
+    stdout: TextIO | None = None,
+) -> None:
+    output = sys.stdout if stdout is None else stdout
+    profile = compiled_program.dialect_profile
+    dialect_name = args.dialect if profile is None else profile.name
+    dialect_display_name = dialect_name if profile is None else profile.display_name
+    query_summaries = _source_query_records(compiled_program)
+
+    if args.output_format == "text":
+        print(f"dialect: {dialect_display_name}", file=output)
+        print(
+            f"initialization queries: {compiled_program.initialization_query_count}",
+            file=output,
+        )
+        print(f"source queries: {compiled_program.source_query_count}", file=output)
+        print(f"total queries: {compiled_program.query_count}", file=output)
+        print(
+            f"instructions: {len(compiled_program.instructions.instructions)}",
+            file=output,
+        )
+        for query in query_summaries:
+            variables = cast("list[str]", query["variables"])
+            variable_text = ", ".join(variables) if variables else "(none)"
+            print(f"query {query['index']} variables: {variable_text}", file=output)
+        return
+
+    payload = {
+        "success": True,
+        "mode": "source_metadata",
+        "dialect": dialect_name,
+        "dialect_display_name": dialect_display_name,
+        "instruction_count": len(compiled_program.instructions.instructions),
+        "initialization_query_count": compiled_program.initialization_query_count,
+        "source_query_count": compiled_program.source_query_count,
+        "query_count": compiled_program.query_count,
+        "source_queries": query_summaries,
+    }
+    print(json.dumps(payload, sort_keys=True), file=output)
 
 
 def _print_source_query_summary(
@@ -466,13 +554,7 @@ def _print_source_query_summary(
     stdout: TextIO | None = None,
 ) -> None:
     output = sys.stdout if stdout is None else stdout
-    query_summaries = [
-        {
-            "index": index,
-            "variables": list(compiled_program.source_query_variable_names(index)),
-        }
-        for index in range(compiled_program.source_query_count)
-    ]
+    query_summaries = _source_query_records(compiled_program)
 
     if args.output_format == "text":
         if not query_summaries:

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
@@ -49,6 +49,12 @@
       "type": "boolean"
     },
     {
+      "id": "dump-source-metadata",
+      "long": "dump-source-metadata",
+      "description": "Compile source and print dialect, query, instruction, and source-query metadata without running queries.",
+      "type": "boolean"
+    },
+    {
       "id": "list-source-queries",
       "long": "list-source-queries",
       "description": "List embedded source-level ?- queries without running them.",

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -289,6 +289,79 @@ def test_cli_dump_instructions_rejects_execution_modes(
     )
 
 
+def test_cli_dump_source_metadata_reports_query_counts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        ":- initialization(true). parent(homer, bart). "
+        "?- parent(homer, Who). ?- true.",
+        "--dump-source-metadata",
+    ])
+
+    assert status == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[:5] == [
+        "dialect: SWI-Prolog",
+        "initialization queries: 1",
+        "source queries: 2",
+        "total queries: 3",
+        "instructions: 5",
+    ]
+    assert lines[5:] == [
+        "query 0 variables: Who",
+        "query 1 variables: (none)",
+    ]
+
+
+def test_cli_dump_source_metadata_json_reports_source_queries(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        ":- initialization(true). parent(homer, bart). "
+        "?- parent(homer, Who). ?- true.",
+        "--dump-source-metadata",
+        "--format",
+        "json",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert status == 0
+    assert payload == {
+        "dialect": "swi",
+        "dialect_display_name": "SWI-Prolog",
+        "initialization_query_count": 1,
+        "instruction_count": 5,
+        "mode": "source_metadata",
+        "query_count": 3,
+        "source_queries": [
+            {"index": 0, "variables": ["Who"]},
+            {"index": 1, "variables": []},
+        ],
+        "source_query_count": 2,
+        "success": True,
+    }
+
+
+def test_cli_dump_source_metadata_rejects_execution_modes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--dump-source-metadata",
+        "--query",
+        "parent(homer, Who)",
+    ])
+
+    assert status == 2
+    assert "--dump-source-metadata cannot be combined with --query" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_lists_source_query_variables(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -15,6 +15,7 @@ The goal is practical usability:
 - check that source parses, loads, compiles, and initializes without a query
 - dump structured Logic VM instructions for compile-only diagnostics
 - dump Logic bytecode disassembly for compile-only diagnostics
+- dump source metadata for editor and CI manifest integrations
 - list embedded source-level `?-` query indexes and visible variables
 - run stored source-level `?-` queries by index
 - run all stored source-level `?-` queries as an executable script
@@ -40,6 +41,8 @@ Important options:
   them without executing queries.
 - `--dump-bytecode` compiles to Logic bytecode and emits disassembly without
   executing queries.
+- `--dump-source-metadata` emits dialect, query counts, instruction count, and
+  embedded source-query variable metadata without executing queries.
 - `--list-source-queries` lists embedded `?-` query indexes and visible
   variables without running them.
 - `--source-query-index INDEX` selects a stored source-level query when no
@@ -116,6 +119,12 @@ JSON formats emit one success object with `mode: "bytecode"`, pool counts, an
 `instruction_count`, and structured disassembly `lines`. This mode is
 compile-only and mutually exclusive with query execution modes.
 
+When `--dump-source-metadata` is set, JSON formats emit one success object with
+`mode: "source_metadata"`, `dialect`, `dialect_display_name`, query counts,
+`instruction_count`, and a `source_queries` list containing zero-based `index`
+and visible `variables` metadata. This mode is compile-only and mutually
+exclusive with query execution modes.
+
 When `--list-source-queries` is set, JSON formats emit one success object with
 `mode: "source_queries"`, `source_query_count`, and a `queries` list containing
 zero-based `index` and visible `variables` metadata for each embedded query.
@@ -186,6 +195,7 @@ The CLI test coverage should prove:
 - query-free compile/check mode
 - structured instruction dump mode
 - bytecode disassembly dump mode
+- source metadata dump mode
 - source query listing without execution
 - stored source-level queries from files
 - all source-level queries from files and inline source


### PR DESCRIPTION
## Summary
- add `prolog-vm --dump-source-metadata` through the CLI builder spec as a compile-only source manifest mode
- emit dialect, query counts, instruction count, and source-query variable metadata in text and JSON formats
- document PR77 source metadata behavior and cover text, JSON, and execution-mode validation

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-dump-source-metadata -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-dump-source-metadata-build-plan.json`