### PR TITLE
Close paragraphs before block starts

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -38,3 +38,5 @@ documented in this file.
   elements, preventing nested select-option DOMs when end tags are omitted.
 - Heading start tags now close open paragraphs and previous headings, avoiding
   nested heading DOMs when heading end tags are omitted.
+- Common block starts such as `div`, `ul`, and `table` now close open
+  paragraphs before insertion, preventing paragraph-nested block DOMs.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -25,7 +25,7 @@ This first slice intentionally starts small:
 - parser-approved initial tokenizer contexts for data-state documents and
   foreign-content CDATA or script-state fragments
 - simple implied end tags for `p`, `li`, `dt`, `dd`, `option`, `optgroup`,
-  and heading elements
+  heading elements, and paragraph/block boundaries
 - parser diagnostics for unmatched end tags
 
 Future batches can layer the full WHATWG HTML tree-construction insertion modes

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -378,6 +378,8 @@ impl HtmlParser {
         } else if is_heading_element(incoming_name) {
             self.pop_current_if(|name| name == "p");
             self.pop_current_if(is_heading_element);
+        } else if is_paragraph_boundary_element(incoming_name) {
+            self.pop_current_if(|name| name == "p");
         }
     }
 
@@ -590,6 +592,35 @@ fn is_heading_element(name: &str) -> bool {
     matches!(name, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
 }
 
+fn is_paragraph_boundary_element(name: &str) -> bool {
+    matches!(
+        name,
+        "address"
+            | "article"
+            | "aside"
+            | "blockquote"
+            | "details"
+            | "dialog"
+            | "div"
+            | "dl"
+            | "fieldset"
+            | "figcaption"
+            | "figure"
+            | "footer"
+            | "form"
+            | "header"
+            | "hr"
+            | "main"
+            | "menu"
+            | "nav"
+            | "ol"
+            | "pre"
+            | "section"
+            | "table"
+            | "ul"
+    )
+}
+
 fn is_void_element(name: &str) -> bool {
     matches!(
         name,
@@ -765,6 +796,46 @@ mod tests {
         let third = element(&body.children[3]);
         assert_eq!(third.name, "h3");
         assert_eq!(third.children, vec![Node::text("Three")]);
+    }
+
+    #[test]
+    fn closes_paragraphs_before_block_boundaries() {
+        let document = parse_html(
+            "<p>Intro<div>Block</div><p>Items<ul><li>One</ul><p>Table<table><tr><td>A</table>",
+        )
+        .unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 6);
+
+        let intro = element(&body.children[0]);
+        assert_eq!(intro.name, "p");
+        assert_eq!(intro.children, vec![Node::text("Intro")]);
+
+        let div = element(&body.children[1]);
+        assert_eq!(div.name, "div");
+        assert_eq!(div.children, vec![Node::text("Block")]);
+
+        let items = element(&body.children[2]);
+        assert_eq!(items.name, "p");
+        assert_eq!(items.children, vec![Node::text("Items")]);
+
+        let list = element(&body.children[3]);
+        assert_eq!(list.name, "ul");
+        assert_eq!(list.children.len(), 1);
+        let item = element(&list.children[0]);
+        assert_eq!(item.name, "li");
+        assert_eq!(item.children, vec![Node::text("One")]);
+
+        let table_intro = element(&body.children[4]);
+        assert_eq!(table_intro.name, "p");
+        assert_eq!(table_intro.children, vec![Node::text("Table")]);
+
+        let table = element(&body.children[5]);
+        assert_eq!(table.name, "table");
+        let tbody = element(&table.children[0]);
+        let row = element(&tbody.children[0]);
+        assert_eq!(element(&row.children[0]).children, vec![Node::text("A")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Close open paragraphs before common block starts such as `div`, `ul`, and `table`.
- Preserve existing list and table implied-structure recovery after the paragraph boundary closes.
- Document the paragraph/block boundary behavior and add DOM parser coverage.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check