### PR TITLE
feat(vmcond00): VMCOND00 Phase 1 — SYSCALL_CHECKED + BRANCH_ERR opcodes

### DIFF
--- a/code/packages/python/compiler-ir/CHANGELOG.md
+++ b/code/packages/python/compiler-ir/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [Unreleased]
 
+### Added — VMCOND00 Phase 1: SYSCALL_CHECKED and BRANCH_ERR opcodes
+
+Two new opcodes implementing the VMCOND00 Layer 1 result-value error protocol.
+Languages that opt in to this layer can invoke host syscalls without trapping
+and inspect the error code with a dedicated conditional branch.  The rest of
+the IR is unchanged — programs that don't use these opcodes are unaffected.
+
+- **`IrOp.SYSCALL_CHECKED` (64)** — Invoke a SYSCALL00-numbered host syscall
+  without trapping on errors.  Operand layout:
+  `SYSCALL_CHECKED n, arg_reg, val_dst, err_dst`
+  - `n`       — SYSCALL00 canonical syscall number (immediate)
+  - `arg_reg` — register holding the single argument
+  - `val_dst` — register to receive the success value (0 on error)
+  - `err_dst` — register to receive the error code: 0 ok, -1 EOF, <-1 negated errno
+
+- **`IrOp.BRANCH_ERR` (65)** — Branch to a label when an error register is
+  non-zero.  Operand layout: `BRANCH_ERR err_reg, label`.  Falls through when
+  `err_reg == 0` (success); jumps when `err_reg != 0` (syscall failed).
+
+The total opcode count grows from 64 → 66.  All existing opcode IDs (0–63)
+remain stable; serialized IR text files round-trip unchanged.
+
+These opcodes map to the **compiler IR** world (AOT compilation via
+`ir-to-jvm-class-file`, `ir-to-cil-bytecode`, `ir-to-beam`).  The
+interpreter IR (``interpreter-ir``) gets the corresponding ``syscall_checked``
+and ``branch_err`` string mnemonics in the same PR.
+
+**Spec reference:** VMCOND00 §3 Layer 1 — result values; SYSCALL00 §2.
+
+---
+
 ### Added — TW03 Phase 3a heap-primitive ops
 
 Eight new opcodes (55–62) introducing the cross-backend Lisp

--- a/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
+++ b/code/packages/python/compiler-ir/src/compiler_ir/opcodes.py
@@ -33,6 +33,7 @@ The opcodes are grouped by category:
   Closures:     MAKE_CLOSURE, APPLY_CLOSURE   (TW03 Phase 2)
   Heap:         MAKE_CONS, CAR, CDR, IS_NULL, IS_PAIR,
                 MAKE_SYMBOL, IS_SYMBOL, LOAD_NIL   (TW03 Phase 3)
+  Error-aware:  SYSCALL_CHECKED, BRANCH_ERR   (VMCOND00 Phase 1)
 
 Text Names
 ----------
@@ -409,6 +410,76 @@ class IrOp(IntEnum):
     # Appended after TW03 heap opcodes to preserve stable opcode values.
     #   F64_POW v1, v2, v3 → v1 = pow(v2, v3)
     F64_POW = 63
+
+    # ── VMCOND00 Phase 1 — checked syscall + error branch ────────────────
+    #
+    # These two opcodes implement the VMCOND00 Layer 1 result-value protocol:
+    # a syscall that can fail without trapping, and a conditional branch that
+    # detects the failure.  Together they let a language emit code like:
+    #
+    #     SYSCALL_CHECKED 2, arg_reg, val_dst, err_dst   ; read-byte
+    #     BRANCH_ERR err_dst, eof_handler                ; branch if err != 0
+    #     ; happy path here — val_dst holds the byte
+    #     ...
+    #   eof_handler:
+    #     ; error path — err_dst holds negated errno or -1 for EOF
+    #
+    # The protocol: SYSCALL_CHECKED runs the numbered host syscall (n=1..33
+    # from the SYSCALL00 canonical table), stores the success value in
+    # ``val_dst``, and stores a "sticky" error code in ``err_dst``
+    # (0 = success, -1 = EOF, <-1 = negated errno).  BRANCH_ERR reads
+    # ``err_dst`` and branches when it is non-zero — it NEVER branches when
+    # the syscall succeeded.
+    #
+    # Why two separate opcodes rather than one combined branch?
+    #
+    #   - Separation of concerns: the syscall opcode is purely a value-
+    #     producer; the branch is purely a control-flow decision.  This
+    #     mirrors LOAD_IMM / BRANCH_Z decomposition.
+    #   - Allows multiple BRANCH_ERR tests on the same ``err_dst`` (e.g.
+    #     branch on EOF vs. branch on write-error) by reusing the same
+    #     register.
+    #   - Backends that compile SYSCALL_CHECKED to native code can inline
+    #     the error flag into a hardware status register and collapse
+    #     BRANCH_ERR into a conditional jump with zero extra load.
+    #
+    # VMCOND00 SYSCALL01 extends these into SYSCALL_CONDITIONED which
+    # additionally calls back into the condition system; that is Phase 3.
+
+    # SYSCALL_CHECKED — run a numbered host syscall, capturing errors.
+    #
+    # Operand layout:
+    #   SYSCALL_CHECKED  n:imm  arg:reg  val_dst:reg  err_dst:reg
+    #
+    # where:
+    #   - ``n``       — the SYSCALL00 canonical syscall number (immediate)
+    #   - ``arg``     — the single argument register (conventions per syscall)
+    #   - ``val_dst`` — register to receive the success value (byte read,
+    #                   bytes written, etc.)  Set to 0 on error.
+    #   - ``err_dst`` — register to receive the error code: 0 on success,
+    #                   -1 on EOF, <-1 for negated errno.
+    #
+    # SYSCALL_CHECKED never traps — it always stores into both output
+    # registers and returns control to the next instruction.  The caller
+    # decides what to do with the error code.
+    SYSCALL_CHECKED = 64
+
+    # BRANCH_ERR — branch to a label when an error register is non-zero.
+    #
+    # Operand layout:
+    #   BRANCH_ERR  err_reg:reg  label:label
+    #
+    # where:
+    #   - ``err_reg`` — a register previously written by SYSCALL_CHECKED
+    #   - ``label``   — IR label to jump to when ``err_reg != 0``
+    #
+    # BRANCH_ERR is the companion to SYSCALL_CHECKED.  It behaves like
+    # BRANCH_NZ but is semantically typed as "this register holds an error
+    # code, not a general Boolean" — backends can use this typing hint when
+    # lowering to error-code registers or exception paths.
+    #
+    # Execution: if err_reg == 0 (success), fall through; otherwise jump.
+    BRANCH_ERR = 65
 
 
 # Canonical name → opcode mapping. Built from the enum at module load time.

--- a/code/packages/python/compiler-ir/tests/test_compiler_ir.py
+++ b/code/packages/python/compiler-ir/tests/test_compiler_ir.py
@@ -114,10 +114,12 @@ class TestIrOp:
         assert IrOp.IS_SYMBOL == 61
         assert IrOp.LOAD_NIL == 62
         assert IrOp.F64_POW == 63
+        assert IrOp.SYSCALL_CHECKED == 64
+        assert IrOp.BRANCH_ERR == 65
 
     def test_total_opcode_count(self) -> None:
-        """There are exactly 64 opcodes after heap primitives and f64 pow."""
-        assert len(IrOp) == 64
+        """There are exactly 66 opcodes after VMCOND00 Phase 1."""
+        assert len(IrOp) == 66
 
     def test_name_to_op_roundtrip(self) -> None:
         """NAME_TO_OP[op.name] == op for every opcode."""
@@ -1061,6 +1063,15 @@ class TestAllOpcodesPrintParse:
             IrOp.IS_SYMBOL:    [IrRegister(2), IrRegister(5)],
             # LOAD_NIL dst
             IrOp.LOAD_NIL:     [IrRegister(2)],
+            # SYSCALL_CHECKED n, arg_reg, val_dst, err_dst
+            IrOp.SYSCALL_CHECKED: [
+                IrImmediate(2),    # n = read-byte
+                IrRegister(0),     # arg (ignored for read-byte)
+                IrRegister(1),     # val_dst — byte read
+                IrRegister(2),     # err_dst — error code
+            ],
+            # BRANCH_ERR err_reg, label
+            IrOp.BRANCH_ERR:   [IrRegister(2), IrLabel("eof_handler")],
         }
         for idx, op in enumerate(IrOp):
             operands = operands_by_opcode[op]

--- a/code/packages/python/interpreter-ir/CHANGELOG.md
+++ b/code/packages/python/interpreter-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+### Added — VMCOND00 Phase 1: syscall_checked and branch_err opcodes
+
+Two new IIR string mnemonics implementing the VMCOND00 Layer 1 result-value
+error protocol in the interpreter IR world.
+
+- **`"syscall_checked"`** — Invoke a SYSCALL00-numbered host syscall without
+  trapping on errors.  IIR operand layout:
+  `srcs = [n (immediate int), arg_reg, val_dst, err_dst]`
+  Placed in **`SYSCALL_CHECKED_OPS`** (new frozenset) and **`SIDE_EFFECT_OPS`**
+  (it performs I/O).  Not in `VALUE_OPS` (two output slots in `srcs`, not a
+  single `dest`).
+
+- **`"branch_err"`** — Branch to a label when an error register is non-zero.
+  IIR operand layout: `srcs = [err_reg, label_str]`.
+  Added to **`BRANCH_OPS`** so live-variable analysis and control-flow passes
+  treat it as a conditional branch.  Falls through on `err_reg == 0`.
+
+**New export:** `SYSCALL_CHECKED_OPS: frozenset[str]` — exported from
+`interpreter_ir.__init__` alongside the other opcode-category frozensets.
+
+Programs that don't use these opcodes are fully unaffected — the new mnemonics
+never appear in their IIR.
+
+**Spec reference:** VMCOND00 §3 Layer 1; SYSCALL00 §2 canonical table.
+
+---
+
 ### Added — LANG16 PR1: heap / GC opcodes and ref<T> type encoding
 
 Schema-only foundation for the GC plug-in framework — vm-core, jit-core,

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/__init__.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/__init__.py
@@ -61,6 +61,7 @@ from interpreter_ir.opcodes import (
     REF_PREFIX,
     REF_SUFFIX,
     SIDE_EFFECT_OPS,
+    SYSCALL_CHECKED_OPS,
     VALUE_OPS,
     is_ref_type,
     make_ref_type,
@@ -100,6 +101,7 @@ __all__ = [
     "IO_OPS",
     "MEMORY_OPS",
     "SIDE_EFFECT_OPS",
+    "SYSCALL_CHECKED_OPS",
     "VALUE_OPS",
     # Type constants and helpers
     "CONCRETE_TYPES",

--- a/code/packages/python/interpreter-ir/src/interpreter_ir/opcodes.py
+++ b/code/packages/python/interpreter-ir/src/interpreter_ir/opcodes.py
@@ -90,7 +90,7 @@ CMP_OPS: frozenset[str] = frozenset(
 )
 
 BRANCH_OPS: frozenset[str] = frozenset(
-    {"jmp", "jmp_if_true", "jmp_if_false"}
+    {"jmp", "jmp_if_true", "jmp_if_false", "branch_err"}
 )
 
 CONTROL_OPS: frozenset[str] = frozenset(
@@ -147,10 +147,43 @@ VALUE_OPS: frozenset[str] = (
     ARITHMETIC_OPS | BITWISE_OPS | CMP_OPS | _VALUE_EXTRA | _HEAP_VALUE_OPS
 )
 
+# ---------------------------------------------------------------------------
+# VMCOND00 Phase 1 — checked syscall + error branch
+# ---------------------------------------------------------------------------
+#
+# ``syscall_checked`` invokes a SYSCALL00 host syscall by number and stores
+# both the success value and an error code into named registers.  It never
+# traps — errors are surfaced as a non-zero error register.
+#
+# ``branch_err`` is the companion branch: it jumps to a label when the error
+# register (populated by syscall_checked) is non-zero, and falls through on
+# success.  It lives in BRANCH_OPS so that live-variable analysis and
+# control-flow passes treat it as a conditional branch.
+#
+# IIR operand conventions:
+#
+#   syscall_checked:
+#     srcs = [n (immediate int), arg_reg, val_dst, err_dst]
+#     dest = None   (both output registers are named in srcs)
+#
+#   branch_err:
+#     srcs = [err_reg, label_str]
+#     dest = None
+#
+# The distinction from ``jmp_if_false`` / ``jmp_if_true`` is semantic:
+# ``branch_err`` explicitly documents that it consumes an *error code*, not
+# a Boolean condition.  Backends can exploit this typing to route to
+# exception-handling machinery rather than a plain conditional jump.
+#
+# Note: ``syscall_checked`` is in SIDE_EFFECT_OPS (it performs I/O) and NOT
+# in VALUE_OPS (it has two output slots in srcs, not a single dest).
+SYSCALL_CHECKED_OPS: frozenset[str] = frozenset({"syscall_checked"})
+
 # All ops that have side effects beyond producing a value.
 SIDE_EFFECT_OPS: frozenset[str] = (
     BRANCH_OPS
     | CONTROL_OPS
+    | SYSCALL_CHECKED_OPS
     | frozenset({"store_reg", "store_mem", "io_out", "type_assert"})
     | frozenset({"field_store", "safepoint"})
 )
@@ -173,5 +206,6 @@ ALL_OPS: frozenset[str] = (
     | IO_OPS
     | COERCION_OPS
     | HEAP_OPS
+    | SYSCALL_CHECKED_OPS
     | frozenset({"const"})
 )

--- a/code/packages/python/interpreter-ir/tests/test_interpreter_ir.py
+++ b/code/packages/python/interpreter-ir/tests/test_interpreter_ir.py
@@ -455,6 +455,49 @@ class TestOpcodeSets:
     def test_polymorphic_constant(self):
         assert POLYMORPHIC_TYPE == "polymorphic"
 
+    # VMCOND00 Phase 1 opcode additions
+    def test_branch_err_in_branch_ops(self):
+        """branch_err is a conditional branch — it must be in BRANCH_OPS."""
+        assert "branch_err" in BRANCH_OPS
+
+    def test_branch_err_in_side_effect_ops(self):
+        """branch_err has a side effect (it can redirect control flow)."""
+        assert "branch_err" in SIDE_EFFECT_OPS
+
+    def test_branch_err_in_all_ops(self):
+        assert "branch_err" in ALL_OPS
+
+    def test_syscall_checked_in_side_effect_ops(self):
+        """syscall_checked performs I/O — it is a side-effecting op."""
+        assert "syscall_checked" in SIDE_EFFECT_OPS
+
+    def test_syscall_checked_in_all_ops(self):
+        assert "syscall_checked" in ALL_OPS
+
+    def test_syscall_checked_not_in_value_ops(self):
+        """syscall_checked has two output slots in srcs, not a single dest.
+        It is not a value-producing op in the VALUE_OPS sense."""
+        assert "syscall_checked" not in VALUE_OPS
+
+    def test_syscall_checked_not_in_branch_ops(self):
+        """syscall_checked is a syscall, not a branch."""
+        assert "syscall_checked" not in BRANCH_OPS
+
+    def test_syscall_checked_ops_frozenset_exported(self):
+        """SYSCALL_CHECKED_OPS is exported from interpreter_ir."""
+        from interpreter_ir import SYSCALL_CHECKED_OPS  # noqa: PLC0415
+        assert "syscall_checked" in SYSCALL_CHECKED_OPS
+        assert isinstance(SYSCALL_CHECKED_OPS, frozenset)
+
+    def test_syscall_checked_ops_subset_of_side_effect_ops(self):
+        from interpreter_ir import SYSCALL_CHECKED_OPS  # noqa: PLC0415
+        assert SYSCALL_CHECKED_OPS.issubset(SIDE_EFFECT_OPS)
+
+    def test_all_ops_superset_includes_vmcond00(self):
+        """Extend the superset check to include the new VMCOND00 opcodes."""
+        from interpreter_ir import SYSCALL_CHECKED_OPS  # noqa: PLC0415
+        assert SYSCALL_CHECKED_OPS.issubset(ALL_OPS)
+
 
 # ===========================================================================
 # Serialisation tests

--- a/code/packages/python/vm-core/CHANGELOG.md
+++ b/code/packages/python/vm-core/CHANGELOG.md
@@ -6,6 +6,68 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added — VMCOND00 Phase 1: syscall_checked and branch_err dispatch + register_syscall API
+
+Implements VMCOND00 Layer 1 — the result-value error protocol — in the vm-core
+interpreter.  Languages that opt in can invoke numbered host syscalls without
+trapping and route control flow based on the error code, all without touching
+the condition system or allocating any handler objects.
+
+**New opcode handlers (in `dispatch.py`):**
+
+- **`handle_syscall_checked`** — Executes a SYSCALL00 canonical syscall by
+  number.  Looks up the implementation in `VMCore._syscall_table[n]`, calls it
+  with the resolved argument, and writes `(value, error_code)` into two named
+  registers.  Error convention: 0 = success, -1 = EOF, <-1 = negated errno.
+  The handler never raises Python exceptions: unknown syscall numbers return
+  `(0, -EINVAL)`; implementations that raise are caught and also return
+  `(0, -EINVAL)`.
+
+- **`handle_branch_err`** — Reads the error-code register and jumps to the
+  target label when it is non-zero.  Falls through when it is zero (success).
+  Does not record branch statistics (the check is a typed error test, not an
+  algorithmic conditional).
+
+Both handlers are registered in `STANDARD_OPCODES` under the string mnemonics
+`"syscall_checked"` and `"branch_err"`.
+
+**New public API on `VMCore`:**
+
+- **`register_syscall(n, impl)`** — Register a host implementation for
+  SYSCALL00 syscall number `n`.  `impl` must have signature
+  `(arg: int) -> (value: int, error_code: int)`.  `n` must be in `[1, 255]`
+  (the SYSCALL00 canonical range); a `ValueError` is raised for out-of-range
+  numbers.  See the docstring for the error-code convention and a complete
+  write-byte example.
+- **`unregister_syscall(n)`** — Remove a previously registered implementation.
+  No-op if `n` is not registered.
+- **`_syscall_table`** — Internal dict `{int: Callable}`.  Empty by default;
+  languages wire it up by calling `register_syscall`.  The VM is agnostic about
+  I/O strategy.
+
+**Security hardening:**
+
+- `register_syscall` validates that `n` is in `[1, 255]` before writing to
+  the table.  Syscall 0 is reserved by the ABI; numbers above 255 are outside
+  the canonical table.  Eager rejection surfaces programming errors at
+  registration time rather than silently diverging at dispatch time.
+
+**Test additions (`tests/test_vmcond00_phase1.py` — 26 new tests):**
+
+- `TestRegisterSyscall` — 11 tests: populate, overwrite, remove, no-op, empty
+  default, reject 0, reject >255, reject negative, accept boundary 1, accept
+  boundary 255.
+- `TestSyscallChecked` — 7 tests: success value, return value, EOF, errno, unknown
+  number → EINVAL, impl raises → EINVAL, arg forwarding.
+- `TestBranchErr` — 4 tests: branch on -1, branch on negated errno, branch on
+  positive non-zero, fall-through on 0.
+- `TestSyscallCheckedWithBranchErr` — 4 integration tests: full round-trip through
+  mock read-byte (success and EOF), unknown syscall → error path, two-syscall program.
+
+Coverage: 97.79% (233 tests pass).
+
+---
+
 ### Added — LANG18: Lightweight VM coverage mode
 
 - **`VMCore._coverage_mode` / `VMCore._coverage`** — two new internal fields that

--- a/code/packages/python/vm-core/src/vm_core/core.py
+++ b/code/packages/python/vm-core/src/vm_core/core.py
@@ -130,6 +130,21 @@ class VMCore:
         # JIT handlers — registered by jit-core after compilation.
         self._jit_handlers: dict[str, Callable[[list[Any]], Any]] = {}
 
+        # VMCOND00 Phase 1 — syscall dispatch table.
+        #
+        # Maps SYSCALL00 canonical syscall number (int) to an implementation
+        # callable ``(arg: int) -> (value: int, error_code: int)``.  The
+        # error_code convention follows SYSCALL00 Section 3: 0 on success,
+        # -1 on EOF, <-1 for negated errno.
+        #
+        # Language frontends and host environments register implementations
+        # via ``register_syscall``.  The dispatch handler falls back to
+        # EINVAL for unknown numbers — matching the C ABI contract.
+        #
+        # Default table is empty; languages must explicitly wire up the
+        # syscalls they use.  This keeps the VM agnostic about I/O strategy.
+        self._syscall_table: dict[int, Callable[[int], tuple[int, int]]] = {}
+
         # Execution state — reset between execute() calls.
         self._frames: list[VMFrame] = []
         self._module: IIRModule | None = None
@@ -408,6 +423,76 @@ class VMCore:
             vm.register_builtin("print", lambda args: print(*args))
         """
         self._builtins.register(name, fn)
+
+    def register_syscall(
+        self,
+        n: int,
+        impl: Callable[[int], tuple[int, int]],
+    ) -> None:
+        """Register a host implementation for SYSCALL00 syscall number ``n``.
+
+        The implementation receives the single argument register value and
+        returns a ``(value, error_code)`` pair following the SYSCALL00 error
+        convention (Section 3 of SYSCALL00 spec):
+
+        - ``(value, 0)``    — success; ``value`` is the result (bytes written,
+                               byte read, fd, …)
+        - ``(0, -1)``       — EOF (read operations only)
+        - ``(0, -errno)``   — error; errno is the POSIX error number (positive)
+
+        The implementation must NOT raise Python exceptions — wrap I/O in
+        try/except and return an error pair instead.  Any exception that
+        escapes will be caught by the dispatch handler and converted to
+        ``(0, EINVAL)`` with no further information.
+
+        Example — registering write-byte (syscall 1) backed by stdout::
+
+            import sys
+
+            def write_byte_impl(arg: int) -> tuple[int, int]:
+                try:
+                    sys.stdout.buffer.write(bytes([arg & 0xFF]))
+                    sys.stdout.buffer.flush()
+                    return (0, 0)
+                except OSError as e:
+                    return (0, -e.errno)
+
+            vm.register_syscall(1, write_byte_impl)
+
+        Parameters
+        ----------
+        n:
+            SYSCALL00 canonical syscall number (1 = write-byte, 2 = read-byte,
+            10 = exit, …).  Must be in the range [1, 255].
+        impl:
+            Callable ``(arg: int) -> (value: int, error_code: int)``.
+
+        Raises
+        ------
+        ValueError
+            If ``n`` is outside the valid SYSCALL00 range [1, 255].  Syscall 0
+            is reserved by the ABI and numbers above 255 are beyond the
+            canonical table, so both extremes are rejected to catch programming
+            errors early rather than at dispatch time.
+        """
+        if not (1 <= n <= 255):  # noqa: PLR2004 — magic numbers are the spec range
+            raise ValueError(
+                f"syscall number {n!r} is outside the valid range [1, 255]; "
+                "see SYSCALL00 §2 for the canonical table"
+            )
+        self._syscall_table[n] = impl
+
+    def unregister_syscall(self, n: int) -> None:
+        """Remove the registered implementation for syscall number ``n``.
+
+        No-op if the syscall is not registered.
+
+        Parameters
+        ----------
+        n:
+            SYSCALL00 canonical syscall number to remove.
+        """
+        self._syscall_table.pop(n, None)
 
     def register_jit_handler(
         self, fn_name: str, handler: Callable[[list[Any]], Any]

--- a/code/packages/python/vm-core/src/vm_core/dispatch.py
+++ b/code/packages/python/vm-core/src/vm_core/dispatch.py
@@ -691,6 +691,96 @@ def handle_call_builtin(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
     return result
 
 
+# ---------------------------------------------------------------------------
+# VMCOND00 Phase 1 — checked syscall + error branch
+# ---------------------------------------------------------------------------
+#
+# handle_syscall_checked
+# ----------------------
+# Executes a SYSCALL00-numbered host syscall without trapping on errors.
+# The handler looks up the syscall number (srcs[0]) in ``vm._syscall_table``,
+# resolves the argument register (srcs[1]), and calls the implementation.
+#
+# The implementation must return a ``(value: int, error_code: int)`` tuple:
+#   - value:      the success value (byte read, bytes written, fd, …).
+#                 Stored in the val_dst register (srcs[2]).  Set to 0 on error.
+#   - error_code: 0 on success, -1 on EOF, <-1 for negated errno.
+#                 Stored in the err_dst register (srcs[3]).
+#
+# If the syscall number is not registered, the handler stores 0 in val_dst
+# and EINVAL (−22) in err_dst — matching the C ABI in SYSCALL00 Section 4.
+#
+# handle_branch_err
+# -----------------
+# Conditional branch on a non-zero error register.  Behaves like
+# ``handle_jmp_if_false`` (branch when condition is falsy) but with the
+# polarity inverted: we branch when the error register is *non-zero* (i.e.,
+# the syscall failed).  Falls through when err_reg == 0 (success).
+#
+# Branch statistics are NOT recorded for branch_err because the branch is
+# not a general Boolean — it is a typed error-code check.  This keeps the
+# branch profiler's data focused on algorithmic branches (if-else, loops)
+# rather than syscall error paths.
+
+_EINVAL: int = -22  # negated EINVAL — matches POSIX errno 22
+
+
+def handle_syscall_checked(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    """Execute a numbered host syscall without trapping on errors.
+
+    Operand layout in ``instr.srcs``:
+      [0] n        — the SYSCALL00 canonical syscall number (immediate int)
+      [1] arg_reg  — register name holding the single argument
+      [2] val_dst  — register name to receive the success value (0 on error)
+      [3] err_dst  — register name to receive the error code (0 = ok,
+                     -1 = EOF, <-1 = negated errno)
+
+    The handler never raises — all errors are reported via err_dst.
+    """
+    n = int(instr.srcs[0])
+    arg = frame.resolve(instr.srcs[1])
+    val_dst = str(instr.srcs[2])
+    err_dst = str(instr.srcs[3])
+
+    impl = vm._syscall_table.get(n)
+    if impl is None:
+        # Unknown syscall number → EINVAL, no value.
+        frame.assign(val_dst, 0)
+        frame.assign(err_dst, _EINVAL)
+        return None
+
+    try:
+        value, error_code = impl(arg)
+    except Exception:  # noqa: BLE001 — syscall impls must not propagate Python exc
+        frame.assign(val_dst, 0)
+        frame.assign(err_dst, _EINVAL)
+        return None
+
+    frame.assign(val_dst, value)
+    frame.assign(err_dst, error_code)
+    return None
+
+
+def handle_branch_err(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> None:
+    """Branch to a label when an error register is non-zero.
+
+    Operand layout in ``instr.srcs``:
+      [0] err_reg — name of the error-code register (from syscall_checked)
+      [1] label   — IR label to jump to when err_reg != 0
+
+    Falls through (does not branch) when err_reg == 0 (success).
+
+    Unlike ``jmp_if_true`` / ``jmp_if_false``, branch_err does not record
+    branch statistics — it is a typed error-code test, not an algorithmic
+    conditional.
+    """
+    err = frame.resolve(instr.srcs[0])
+    if err != 0:
+        target_ip = frame.fn.label_index(str(instr.srcs[1]))
+        frame.ip = target_ip
+    return None
+
+
 # --- I/O ---
 
 def handle_io_in(vm: VMCore, frame: VMFrame, instr: IIRInstr) -> Any:
@@ -802,4 +892,7 @@ STANDARD_OPCODES: dict[str, Any] = {
     "io_out": handle_io_out,
     "cast": handle_cast,
     "type_assert": handle_type_assert,
+    # VMCOND00 Phase 1 — checked syscalls and error-code branches.
+    "syscall_checked": handle_syscall_checked,
+    "branch_err": handle_branch_err,
 }

--- a/code/packages/python/vm-core/tests/test_vmcond00_phase1.py
+++ b/code/packages/python/vm-core/tests/test_vmcond00_phase1.py
@@ -1,0 +1,447 @@
+"""Tests for VMCOND00 Phase 1 — syscall_checked and branch_err opcodes.
+
+VMCOND00 Phase 1 adds two new IIR opcodes to vm-core:
+
+    syscall_checked  n, arg_reg, val_dst, err_dst
+        Invoke host syscall n.  Store success value in val_dst and
+        error code (0 ok, -1 EOF, <-1 negated errno) in err_dst.
+        Never traps; all errors surface through err_dst.
+
+    branch_err  err_reg, label
+        Jump to label when err_reg != 0 (syscall failed).
+        Fall through when err_reg == 0 (success).
+
+Public API additions:
+
+    VMCore.register_syscall(n, impl)
+        Register (arg: int) -> (value: int, error_code: int) for syscall n.
+
+    VMCore.unregister_syscall(n)
+        Remove a previously registered syscall implementation.
+
+Coverage targets:
+  - All four branches of handle_syscall_checked:
+        (a) unknown syscall number → EINVAL
+        (b) impl raises Python exception → EINVAL
+        (c) success path
+        (d) error path (e.g. EOF)
+  - Both branches of handle_branch_err:
+        (a) err != 0 → branch taken
+        (b) err == 0 → fall-through
+  - register_syscall and unregister_syscall in VMCore.
+"""
+
+from __future__ import annotations
+
+import pytest
+from interpreter_ir import IIRFunction, IIRInstr, IIRModule
+
+from vm_core import VMCore
+
+# ---------------------------------------------------------------------------
+# Test helpers — same helpers used in test_vm_core.py
+# ---------------------------------------------------------------------------
+
+def _fn(
+    name: str,
+    params: list[tuple[str, str]],
+    *instrs: IIRInstr,
+    return_type: str = "any",
+) -> IIRFunction:
+    """Build an IIRFunction with auto-computed register_count."""
+    return IIRFunction(
+        name=name,
+        params=params,
+        return_type=return_type,
+        instructions=list(instrs),
+        register_count=max(8, len(params) + len(instrs)),
+    )
+
+
+def _mod(*fns: IIRFunction) -> IIRModule:
+    return IIRModule(name="test", functions=list(fns))
+
+
+def _i(op: str, dest: str | None = None, srcs: list | None = None,
+       type_hint: str = "any") -> IIRInstr:
+    return IIRInstr(op=op, dest=dest, srcs=srcs or [], type_hint=type_hint)
+
+
+# EINVAL negated — matches POSIX errno 22.
+_EINVAL = -22
+
+
+# ---------------------------------------------------------------------------
+# TestRegisterSyscall — VMCore.register_syscall / unregister_syscall
+# ---------------------------------------------------------------------------
+
+class TestRegisterSyscall:
+    """Test the public API for registering host syscall implementations."""
+
+    def test_register_syscall_populates_table(self) -> None:
+        """register_syscall stores the impl in _syscall_table under the number."""
+        vm = VMCore()
+        impl = lambda arg: (0, 0)  # noqa: E731
+        vm.register_syscall(1, impl)
+        assert vm._syscall_table[1] is impl
+
+    def test_register_multiple_syscalls(self) -> None:
+        """Multiple syscalls can be registered independently."""
+        vm = VMCore()
+        impl1 = lambda arg: (0, 0)  # noqa: E731
+        impl2 = lambda arg: (arg, 0)  # noqa: E731
+        vm.register_syscall(1, impl1)
+        vm.register_syscall(2, impl2)
+        assert vm._syscall_table[1] is impl1
+        assert vm._syscall_table[2] is impl2
+
+    def test_register_syscall_overwrite(self) -> None:
+        """Registering the same number twice replaces the previous impl."""
+        vm = VMCore()
+        impl_old = lambda arg: (0, 0)  # noqa: E731
+        impl_new = lambda arg: (1, 0)  # noqa: E731
+        vm.register_syscall(1, impl_old)
+        vm.register_syscall(1, impl_new)
+        assert vm._syscall_table[1] is impl_new
+
+    def test_unregister_syscall_removes_entry(self) -> None:
+        """unregister_syscall removes a registered impl."""
+        vm = VMCore()
+        vm.register_syscall(1, lambda arg: (0, 0))  # noqa: E731
+        vm.unregister_syscall(1)
+        assert 1 not in vm._syscall_table
+
+    def test_unregister_unregistered_is_noop(self) -> None:
+        """unregister_syscall on an unknown number is a safe no-op."""
+        vm = VMCore()
+        vm.unregister_syscall(999)  # must not raise
+
+    def test_syscall_table_empty_by_default(self) -> None:
+        """A fresh VMCore has no registered syscalls."""
+        vm = VMCore()
+        assert vm._syscall_table == {}
+
+    def test_register_syscall_rejects_zero(self) -> None:
+        """Syscall 0 is reserved by the ABI — register_syscall must reject it."""
+        vm = VMCore()
+        with pytest.raises(ValueError, match="outside the valid range"):
+            vm.register_syscall(0, lambda arg: (0, 0))  # noqa: E731
+
+    def test_register_syscall_rejects_above_255(self) -> None:
+        """Syscall numbers > 255 are beyond the canonical table and must be rejected."""
+        vm = VMCore()
+        with pytest.raises(ValueError, match="outside the valid range"):
+            vm.register_syscall(256, lambda arg: (0, 0))  # noqa: E731
+
+    def test_register_syscall_rejects_negative(self) -> None:
+        """Negative syscall numbers are not valid SYSCALL00 numbers."""
+        vm = VMCore()
+        with pytest.raises(ValueError, match="outside the valid range"):
+            vm.register_syscall(-1, lambda arg: (0, 0))  # noqa: E731
+
+    def test_register_syscall_accepts_boundary_255(self) -> None:
+        """Syscall 255 is at the upper boundary of the valid range."""
+        vm = VMCore()
+        impl = lambda arg: (0, 0)  # noqa: E731
+        vm.register_syscall(255, impl)
+        assert vm._syscall_table[255] is impl
+
+    def test_register_syscall_accepts_boundary_1(self) -> None:
+        """Syscall 1 is at the lower boundary of the valid range."""
+        vm = VMCore()
+        impl = lambda arg: (0, 0)  # noqa: E731
+        vm.register_syscall(1, impl)
+        assert vm._syscall_table[1] is impl
+
+
+# ---------------------------------------------------------------------------
+# TestSyscallChecked — handle_syscall_checked dispatch logic
+# ---------------------------------------------------------------------------
+
+class TestSyscallChecked:
+    """Test the syscall_checked opcode handler."""
+
+    def _run_syscall_checked(
+        self,
+        vm: VMCore,
+        n: int,
+        arg_value: int,
+    ) -> tuple[int, int]:
+        """Run a minimal program with syscall_checked; return (val, err)."""
+        #
+        # IIR program:
+        #   main:
+        #     const arg, <arg_value>
+        #     syscall_checked <n>, arg, val, err
+        #     ret val          ; return the success value for inspection
+        #
+        # We inspect err by running a second program or by reading the register
+        # directly after execution through a custom ret.  Simpler: return val
+        # and check err via a second helper.
+        #
+        # Actually, let's return a tuple via a builtin.  Even simpler:
+        # we build two separate programs and read both registers.
+        # Cleanest: encode both values into a single integer via val*1000+err
+        # — but that conflates negative numbers.
+        #
+        # Best: use a custom "pair" builtin that returns a Python tuple.
+        # The test inspects the tuple from the return value.
+        #
+        results: list[tuple[int, int]] = []
+
+        def capture_pair(args: list) -> int:
+            """Builtin that captures (val, err) and returns 0."""
+            results.append((int(args[0]), int(args[1])))
+            return 0
+
+        vm.register_builtin("_capture", capture_pair)
+
+        prog = _fn(
+            "main",
+            [],
+            _i("const", "arg", [arg_value]),
+            _i("syscall_checked", None, [n, "arg", "val", "err"]),
+            _i("call_builtin", "dummy", ["_capture", "val", "err"]),
+            _i("ret", None, ["dummy"]),
+        )
+        vm.execute(_mod(prog))
+        return results[0]
+
+    def test_success_path(self) -> None:
+        """A registered syscall that succeeds stores value and 0 in err_dst."""
+        vm = VMCore()
+        # Syscall 1 = write-byte; arg is the byte; returns (0, 0) on success.
+        vm.register_syscall(1, lambda arg: (0, 0))
+        val, err = self._run_syscall_checked(vm, 1, 65)
+        assert val == 0
+        assert err == 0
+
+    def test_success_with_return_value(self) -> None:
+        """Syscall 2 = read-byte; implementation returns (byte, 0) on success."""
+        vm = VMCore()
+        # Mock read-byte that always "reads" 42.
+        vm.register_syscall(2, lambda arg: (42, 0))
+        val, err = self._run_syscall_checked(vm, 2, 0)
+        assert val == 42
+        assert err == 0
+
+    def test_eof_path(self) -> None:
+        """Syscall returning (0, -1) encodes EOF; val=0, err=-1."""
+        vm = VMCore()
+        vm.register_syscall(2, lambda arg: (0, -1))
+        val, err = self._run_syscall_checked(vm, 2, 0)
+        assert val == 0
+        assert err == -1
+
+    def test_errno_path(self) -> None:
+        """Syscall returning (0, -5) encodes EIO; val=0, err=-5."""
+        vm = VMCore()
+        vm.register_syscall(2, lambda arg: (0, -5))
+        val, err = self._run_syscall_checked(vm, 2, 0)
+        assert val == 0
+        assert err == -5
+
+    def test_unknown_syscall_returns_einval(self) -> None:
+        """An unregistered syscall number stores 0, EINVAL in the output registers."""
+        vm = VMCore()  # no syscalls registered
+        val, err = self._run_syscall_checked(vm, 99, 0)
+        assert val == 0
+        assert err == _EINVAL
+
+    def test_impl_raises_exception_returns_einval(self) -> None:
+        """If the syscall impl raises, the handler catches it and stores EINVAL."""
+        vm = VMCore()
+
+        def exploding_syscall(arg: int) -> tuple[int, int]:
+            raise RuntimeError("I/O device on fire")  # noqa: EM101
+
+        vm.register_syscall(1, exploding_syscall)
+        val, err = self._run_syscall_checked(vm, 1, 0)
+        assert val == 0
+        assert err == _EINVAL
+
+    def test_arg_register_is_passed_to_impl(self) -> None:
+        """The resolved arg register value is forwarded to the syscall impl."""
+        received: list[int] = []
+
+        def recording_syscall(arg: int) -> tuple[int, int]:
+            received.append(arg)
+            return (0, 0)
+
+        vm = VMCore()
+        vm.register_syscall(1, recording_syscall)
+        self._run_syscall_checked(vm, 1, 65)
+        assert received == [65]
+
+
+# ---------------------------------------------------------------------------
+# TestBranchErr — handle_branch_err dispatch logic
+# ---------------------------------------------------------------------------
+
+class TestBranchErr:
+    """Test the branch_err opcode handler."""
+
+    def _run_branch_err_program(self, err_value: int) -> int:
+        """Run a branch_err program; return 1 if branch taken, 0 if fall-through."""
+        #
+        # IIR program:
+        #   main:
+        #     const err, <err_value>
+        #     branch_err err, error_path
+        #     const result, 0        ; fall-through → success path → return 0
+        #     ret result
+        #   label error_path
+        #     const result, 1        ; branch taken → error path → return 1
+        #     ret result
+        #
+        prog = _fn(
+            "main",
+            [],
+            _i("const", "err", [err_value]),
+            _i("branch_err", None, ["err", "error_path"]),
+            _i("const", "result", [0]),
+            _i("ret", None, ["result"]),
+            _i("label", None, ["error_path"]),
+            _i("const", "result", [1]),
+            _i("ret", None, ["result"]),
+        )
+        vm = VMCore()
+        return vm.execute(_mod(prog))
+
+    def test_branch_taken_on_nonzero_err(self) -> None:
+        """branch_err jumps when err_reg is -1 (EOF)."""
+        result = self._run_branch_err_program(-1)
+        assert result == 1  # branch was taken
+
+    def test_branch_taken_on_negative_errno(self) -> None:
+        """branch_err jumps when err_reg is a negated errno (e.g. -22)."""
+        result = self._run_branch_err_program(-22)
+        assert result == 1
+
+    def test_branch_taken_on_positive_nonzero(self) -> None:
+        """branch_err jumps for any non-zero value, not just negatives."""
+        result = self._run_branch_err_program(1)
+        assert result == 1
+
+    def test_fallthrough_on_zero_err(self) -> None:
+        """branch_err falls through (does NOT jump) when err_reg is 0."""
+        result = self._run_branch_err_program(0)
+        assert result == 0  # fell through
+
+
+# ---------------------------------------------------------------------------
+# TestSyscallCheckedWithBranchErr — integrated round-trip tests
+# ---------------------------------------------------------------------------
+
+class TestSyscallCheckedWithBranchErr:
+    """Integration tests: syscall_checked feeds branch_err for real control flow."""
+
+    def test_read_byte_success_reads_value(self) -> None:
+        """A mock read-byte syscall that succeeds routes through the happy path."""
+        vm = VMCore()
+        # Syscall 2 = read-byte; returns (byte=42, err=0) on success.
+        vm.register_syscall(2, lambda arg: (42, 0))
+
+        #
+        # main:
+        #   const arg, 0
+        #   syscall_checked 2, arg, val, err
+        #   branch_err err, eof_path
+        #   ret val           ; happy path — return the byte
+        # label eof_path
+        #   const minus_one, -1
+        #   ret minus_one     ; error path — return sentinel -1
+        #
+        prog = _fn(
+            "main",
+            [],
+            _i("const", "arg", [0]),
+            _i("syscall_checked", None, [2, "arg", "val", "err"]),
+            _i("branch_err", None, ["err", "eof_path"]),
+            _i("ret", None, ["val"]),
+            _i("label", None, ["eof_path"]),
+            _i("const", "minus_one", [-1]),
+            _i("ret", None, ["minus_one"]),
+        )
+        result = vm.execute(_mod(prog))
+        assert result == 42
+
+    def test_read_byte_eof_routes_to_error_path(self) -> None:
+        """A mock read-byte syscall that returns EOF routes through the error path."""
+        vm = VMCore()
+        # Syscall 2 = read-byte; EOF → (0, -1).
+        vm.register_syscall(2, lambda arg: (0, -1))
+
+        prog = _fn(
+            "main",
+            [],
+            _i("const", "arg", [0]),
+            _i("syscall_checked", None, [2, "arg", "val", "err"]),
+            _i("branch_err", None, ["err", "eof_path"]),
+            _i("ret", None, ["val"]),
+            _i("label", None, ["eof_path"]),
+            _i("const", "minus_one", [-1]),
+            _i("ret", None, ["minus_one"]),
+        )
+        result = vm.execute(_mod(prog))
+        assert result == -1  # reached eof_path
+
+    def test_unknown_syscall_routes_to_error_path(self) -> None:
+        """An unregistered syscall yields EINVAL which branches to the error path."""
+        vm = VMCore()  # no syscalls registered
+
+        prog = _fn(
+            "main",
+            [],
+            _i("const", "arg", [0]),
+            _i("syscall_checked", None, [99, "arg", "val", "err"]),
+            _i("branch_err", None, ["err", "err_path"]),
+            _i("ret", None, ["val"]),       # success (won't run)
+            _i("label", None, ["err_path"]),
+            _i("ret", None, ["err"]),       # return the error code
+        )
+        result = vm.execute(_mod(prog))
+        assert result == _EINVAL
+
+    def test_multiple_syscalls_with_branching(self) -> None:
+        """A program that writes a byte (success) then reads a byte (success)."""
+        written: list[int] = []
+        read_counter = [0]
+
+        def write_byte(arg: int) -> tuple[int, int]:
+            written.append(arg & 0xFF)
+            return (0, 0)
+
+        def read_byte(arg: int) -> tuple[int, int]:
+            read_counter[0] += 1
+            return (ord("X"), 0)
+
+        vm = VMCore()
+        vm.register_syscall(1, write_byte)
+        vm.register_syscall(2, read_byte)
+
+        #
+        # Write byte 65 ('A'), then read one byte.
+        # Both succeed; return the read byte.
+        #
+        prog = _fn(
+            "main",
+            [],
+            _i("const", "byte_to_write", [65]),
+            _i("syscall_checked", None, [1, "byte_to_write", "wval", "werr"]),
+            _i("branch_err", None, ["werr", "write_failed"]),
+            _i("const", "zero", [0]),
+            _i("syscall_checked", None, [2, "zero", "rval", "rerr"]),
+            _i("branch_err", None, ["rerr", "read_failed"]),
+            _i("ret", None, ["rval"]),
+            _i("label", None, ["write_failed"]),
+            _i("const", "neg1", [-1]),
+            _i("ret", None, ["neg1"]),
+            _i("label", None, ["read_failed"]),
+            _i("const", "neg2", [-2]),
+            _i("ret", None, ["neg2"]),
+        )
+        result = vm.execute(_mod(prog))
+        assert written == [65]
+        assert read_counter[0] == 1
+        assert result == ord("X")

--- a/code/specs/SYSCALL00-host-syscall-library.md
+++ b/code/specs/SYSCALL00-host-syscall-library.md
@@ -1,0 +1,387 @@
+# SYSCALL00 — Host Syscall Library
+
+**Status:** Draft  
+**Series:** SYSCALL  
+**Depends on:** LANG02 (vm-core), LANG05 (backend-protocol)  
+**Extended by:** SYSCALL01 (condition integration)
+
+---
+
+## 1. Purpose
+
+Every language that runs on the LANG VM chain eventually needs to interact with its
+host environment: write a byte to stdout, read a byte from stdin, exit the process,
+open a file. These operations differ across every execution context — native Linux,
+native macOS, WASM/WASI, browser WASM, JVM, CLR, BEAM — but the *calling language*
+should not have to know which host it is running on.
+
+`lang-syscall` is the answer: a single Rust crate that provides a numbered syscall
+table, a host-agnostic trait, and a set of platform backends, so that any LANG VM
+implementation can delegate host I/O through one uniform interface.
+
+**What this crate is:**
+- The canonical numbering for every host operation the LANG VM exposes.
+- A C-ABI entry point (`__lang_syscall`) for use by ahead-of-time compiled programs
+  that are statically linked against the library.
+- A `SyscallHost` Rust trait for use by the VM interpreter.
+- Platform backends: native libc, WASM/WASI, and a standard-I/O fallback.
+
+**What this crate is not:**
+- Anything JVM-backend-specific, CLR-backend-specific, or BEAM-backend-specific. Those
+  backends lower syscall opcodes to their own native calls at code-generation time.
+  The table in this spec is the numbering they must agree on; the Rust library is not
+  linked into those backends.
+- Anything to do with condition signaling. That is SYSCALL01, which layers on top.
+
+---
+
+## 2. Canonical Syscall Table
+
+This table is the single source of truth. Every backend — the Rust C-ABI, the Rust
+trait, the JVM bytecode emitter, the CLR bytecode emitter, the BEAM emitter, and the
+Python vm-core — must use the same numbers.
+
+Numbers are grouped in decades by category. Gaps are reserved for future use within
+the same category.
+
+### 2.1 I/O — stdout / stdin (1–9)
+
+| # | Name | Arg | Return | Description |
+|---|------|-----|--------|-------------|
+| 1 | `write-byte` | `u8` byte | `i64` (0 ok) | Write one byte to stdout |
+| 2 | `read-byte` | *(none, pass 0)* | `i64` byte or -1 on EOF | Read one byte from stdin |
+| 3 | `write-str` | `(ptr: *u8, len: usize)` encoded as `i64` | `i64` bytes written | Write `len` bytes from `ptr` to stdout |
+| 4–9 | *(reserved)* | | | |
+
+`write-str` packs the pointer and length into a single `i64` using the platform's
+pointer width. On 64-bit platforms the upper 32 bits are the pointer (truncated), lower
+32 are the length; this is a Phase 2 concern. Phase 1 only implements 1 and 2.
+
+EOF convention: `read-byte` returns `-1` (as an `i64`) on EOF, not `255`. The `255`
+convention in earlier Twig code was a byte-level sentinel; the syscall-level return is
+a full integer where `-1` is unambiguous.
+
+### 2.2 Process lifecycle (10–19)
+
+| # | Name | Arg | Return | Description |
+|---|------|-----|--------|-------------|
+| 10 | `exit` | `i32` code | *(never returns)* | Terminate the process |
+| 11–19 | *(reserved)* | | | |
+
+### 2.3 Threads (20–29)
+
+| # | Name | Arg | Return | Description |
+|---|------|-----|--------|-------------|
+| 20 | `thread-spawn` | fn pointer | `i64` handle | Spawn an OS thread |
+| 21 | `thread-join` | `i64` handle | `i64` result | Join a thread |
+| 22–29 | *(reserved)* | | | |
+
+Phase 3 work. The `fn pointer` encoding and thread handle format will be specified
+when implemented.
+
+### 2.4 Filesystem (30–39)
+
+| # | Name | Args | Return | Description |
+|---|------|------|--------|-------------|
+| 30 | `file-open` | path ptr+len, flags | `i64` fd or -errno | Open a file |
+| 31 | `file-read` | fd, buf ptr+len | `i64` n or -errno | Read from fd |
+| 32 | `file-write` | fd, buf ptr+len | `i64` n or -errno | Write to fd |
+| 33 | `file-close` | fd | `i64` (0 ok or -errno) | Close fd |
+| 34–39 | *(reserved)* | | | |
+
+Phase 2 work.
+
+---
+
+## 3. Error Return Convention
+
+The C ABI and the `SyscallHost` trait use a signed `i64` return for all syscalls:
+
+- **≥ 0**: success, return value (bytes written, bytes read, fd, …)
+- **-1**: EOF (for read operations only)
+- **< -1**: negated errno — e.g., `EPERM` → `-1`, `EIO` → `-5`, `EBADF` → `-9`
+
+The mapping of error names to numbers follows the platform-independent errno table
+defined in SYSCALL01 Section 10. The C ABI never panics; it returns error codes.
+Higher layers (SYSCALL01) turn those codes into conditions.
+
+For `exit` (syscall 10): the process terminates; the function never returns. The C ABI
+declares the return type as `!` (Rust) or `[[noreturn]]` (C). The VM trait returns `!`.
+
+---
+
+## 4. The C ABI
+
+The C ABI is a single entry point for use by ahead-of-time compiled programs:
+
+```c
+/* Declared in lang_syscall.h */
+int64_t __lang_syscall(uint32_t n, int64_t arg) __attribute__((noreturn_for_10));
+```
+
+In Rust:
+
+```rust
+/// The single C-ABI dispatch entry point.
+///
+/// `n` is the syscall number from the canonical table (Section 2).
+/// `arg` is a syscall-specific argument.  For write-byte, it is the byte
+/// value (low 8 bits used).  For read-byte, it is ignored (pass 0).
+/// For exit, it is the exit code.
+///
+/// Returns an i64 whose meaning is syscall-specific:
+/// - write-byte: 0 on success, negative errno on failure
+/// - read-byte:  the byte read (0..=255), -1 on EOF, negative errno on error
+/// - exit:       never returns
+///
+/// Unknown syscall numbers return -EINVAL (-22).
+#[unsafe(no_mangle)]
+pub extern "C" fn __lang_syscall(n: u32, arg: i64) -> i64 {
+    // dispatches to the active backend (feature-selected at compile time)
+}
+```
+
+One entry point rather than per-symbol exports (`__lang_write_byte`,
+`__lang_read_byte`, …) keeps the ABI surface minimal and matches exactly how the
+`SYSCALL <n> <arg>` IR opcode works — one call site regardless of which operation.
+Backends that emit native code only need to emit one call instruction and one constant.
+
+---
+
+## 5. The `SyscallHost` Rust Trait
+
+For the Rust VM interpreter, the syscall abstraction is a trait rather than a static
+function, so tests can substitute mock implementations and the VM can be embedded in
+environments where stdout is not a terminal.
+
+```rust
+/// Platform-agnostic host operations for the LANG VM interpreter.
+///
+/// Implementors provide the actual I/O operations; the VM interpreter
+/// holds a `Box<dyn SyscallHost>` and calls through it.
+///
+/// Phase 1: write-byte, read-byte, exit.
+/// Phase 2: write-str, file operations (added as default methods).
+/// SYSCALL01: conditioned variants added as a separate trait extension.
+pub trait SyscallHost: Send {
+    // ── Phase 1 ───────────────────────────────────────────────────────────
+
+    /// Write one byte to stdout.
+    ///
+    /// Returns `Ok(())` on success.  Returns `Err(errno)` on failure where
+    /// `errno` is a value from the platform-independent errno table
+    /// (SYSCALL01 §10).  The caller decides whether to trap or signal.
+    fn write_byte(&mut self, b: u8) -> Result<(), i32>;
+
+    /// Read one byte from stdin.
+    ///
+    /// Returns `Ok(Some(byte))` on success, `Ok(None)` on EOF,
+    /// `Err(errno)` on error.
+    fn read_byte(&mut self) -> Result<Option<u8>, i32>;
+
+    /// Terminate the process with the given exit code.  Never returns.
+    fn exit(&mut self, code: i32) -> !;
+
+    // ── Phase 2 (default impls return Err(ENOSYS)) ────────────────────────
+
+    /// Write bytes from a slice to stdout.
+    fn write_str(&mut self, bytes: &[u8]) -> Result<usize, i32> {
+        for &b in bytes {
+            self.write_byte(b)?;
+        }
+        Ok(bytes.len())
+    }
+}
+```
+
+The `Result<(), i32>` return — rather than `Result<(), SyscallError>` — keeps the
+trait object-safe and avoids an allocation on every call. The `i32` is an errno value
+from the canonical table. SYSCALL01 wraps this into condition objects.
+
+---
+
+## 6. Platform Backends
+
+### 6.1 `native` — libc (default)
+
+Selected when `cfg(not(target_arch = "wasm32"))`. Uses `libc::write` and `libc::read`
+directly via the `libc` crate.
+
+```rust
+pub struct NativeSyscallHost;
+
+impl SyscallHost for NativeSyscallHost {
+    fn write_byte(&mut self, b: u8) -> Result<(), i32> {
+        let ret = unsafe { libc::write(1, &b as *const u8 as *const _, 1) };
+        if ret == 1 { Ok(()) } else { Err(errno()) }
+    }
+
+    fn read_byte(&mut self) -> Result<Option<u8>, i32> {
+        let mut b = 0u8;
+        let ret = unsafe { libc::read(0, &mut b as *mut u8 as *mut _, 1) };
+        match ret {
+            1  => Ok(Some(b)),
+            0  => Ok(None),   // EOF
+            _  => Err(errno()),
+        }
+    }
+
+    fn exit(&mut self, code: i32) -> ! {
+        unsafe { libc::exit(code) }
+    }
+}
+```
+
+### 6.2 `wasi` — WASM/WASI preview 1
+
+Selected when `cfg(target_arch = "wasm32")` and feature `wasi` is enabled. Uses
+`wasi::fd_write`, `wasi::fd_read`, `wasi::proc_exit` from the `wasi` crate.
+
+```rust
+pub struct WasiSyscallHost;
+
+impl SyscallHost for WasiSyscallHost {
+    fn write_byte(&mut self, b: u8) -> Result<(), i32> {
+        let iov = wasi::Ciovec { buf: &b as *const u8, buf_len: 1 };
+        let n = wasi::fd_write(1, &[iov]).map_err(|e| e.raw() as i32)?;
+        if n == 1 { Ok(()) } else { Err(-libc::EIO) }
+    }
+    // ... read_byte, exit analogously
+}
+```
+
+### 6.3 `stdio` — Rust std::io (VM interpreter default)
+
+A portable implementation using Rust's `std::io::stdout()` and `std::io::stdin()`.
+Suitable for the Rust VM interpreter on any platform where `std` is available. This is
+the implementation `Box<dyn SyscallHost>` defaults to in tests and the interpreter.
+
+```rust
+pub struct StdioSyscallHost {
+    stdout: std::io::Stdout,
+    stdin:  std::io::Stdin,
+}
+
+impl Default for StdioSyscallHost {
+    fn default() -> Self {
+        Self { stdout: std::io::stdout(), stdin: std::io::stdin() }
+    }
+}
+
+impl SyscallHost for StdioSyscallHost {
+    fn write_byte(&mut self, b: u8) -> Result<(), i32> {
+        use std::io::Write;
+        self.stdout.write_all(&[b]).map_err(|e| os_error_to_errno(e))
+    }
+
+    fn read_byte(&mut self) -> Result<Option<u8>, i32> {
+        use std::io::Read;
+        let mut buf = [0u8; 1];
+        match self.stdin.read(&mut buf) {
+            Ok(0) => Ok(None),
+            Ok(_) => Ok(Some(buf[0])),
+            Err(e) => Err(os_error_to_errno(e)),
+        }
+    }
+
+    fn exit(&mut self, code: i32) -> ! {
+        std::process::exit(code)
+    }
+}
+```
+
+---
+
+## 7. Feature Flags
+
+```toml
+[features]
+default = ["native"]
+
+# Use libc for native platforms (Linux, macOS, Windows via MSVC libc)
+native = ["dep:libc"]
+
+# Use WASI preview 1 for wasm32 targets
+wasi = ["dep:wasi"]
+
+# Include the SyscallHost trait and StdioSyscallHost implementation.
+# Always compiled; this flag is a no-op but documents intent.
+vm = []
+
+# Disable std — requires the embedding host to supply all I/O.
+# Incompatible with `stdio`. Use with `native` or `wasi`.
+no-std = []
+```
+
+---
+
+## 8. Crate Layout
+
+```
+code/packages/rust/lang-syscall/
+├── Cargo.toml
+├── README.md
+├── CHANGELOG.md
+├── src/
+│   ├── lib.rs          — re-exports, __lang_syscall entry point, SyscallHost trait
+│   ├── table.rs        — pub const WRITE_BYTE: u32 = 1; … (canonical number table)
+│   ├── errno.rs        — platform-independent errno values (shared with SYSCALL01)
+│   ├── native.rs       — NativeSyscallHost  (#[cfg(not(target_arch = "wasm32"))])
+│   ├── wasi.rs         — WasiSyscallHost    (#[cfg(target_arch = "wasm32")])
+│   └── stdio.rs        — StdioSyscallHost   (always compiled when std is available)
+└── tests/
+    ├── test_write_byte.rs
+    ├── test_read_byte.rs
+    └── test_c_abi.rs
+```
+
+---
+
+## 9. Relationship to the Python vm-core
+
+The Python `vm-core` package (LANG02) dispatches `io_in` and `io_out` interpreter IR
+opcodes and `call_builtin "syscall"` calls through Python's `sys.stdout` / `sys.stdin`
+directly. The `lang-syscall` Rust crate **does not replace** the Python vm-core's I/O
+mechanism; the two coexist during the transition to the Rust port.
+
+What both share is the **syscall number table** (Section 2). When vm-core dispatches
+`call_builtin "syscall" 1 arg`, the number `1` is the same canonical number defined
+here. VMCOND00's `SYSCALL_CHECKED` opcode also uses these same numbers.
+
+The Rust `lang-syscall` crate becomes the sole I/O implementation once the Rust vm-core
+(the port of the Python vm-core) is complete. Until then, the Python and Rust
+implementations are parallel.
+
+---
+
+## 10. Security
+
+- `__lang_syscall` validates `n` against the known table before dispatching. Unknown
+  values return `-EINVAL` rather than invoking undefined behaviour.
+- `write-str` (syscall 3) will validate that the `ptr+len` pair is within the VM's
+  memory bounds before calling `libc::write`. Bounds checking is a Phase 2 concern.
+- No shell expansion, no `exec`, no spawning subprocesses. The table is intentionally
+  minimal; operations outside it are not accessible through this interface.
+
+---
+
+## 11. Phase Plan
+
+### Phase 1 — write-byte, read-byte, exit (this spec)
+- `lang-syscall` Rust crate with `StdioSyscallHost` and `NativeSyscallHost`
+- `__lang_syscall` C ABI (n=1,2,10 only)
+- `SyscallHost` trait with `write_byte`, `read_byte`, `exit`
+- `table.rs` constants: `WRITE_BYTE=1`, `READ_BYTE=2`, `EXIT=10`
+- Tests: write a byte and read it back via a pipe; exit code propagation
+
+### Phase 2 — write-str, file I/O
+- Syscalls 3, 30–33
+- `write_str` default method promoted to a real implementation
+- WASI backend completed
+- `errno.rs` populated with the full error code table
+
+### Phase 3 — Threads
+- Syscalls 20–21
+- POSIX `pthread_create` / `pthread_join` on native
+- WASM thread proposal on WASI (if available)
+- Goroutine-style scheduling is out of scope (see future LANG28)


### PR DESCRIPTION
## Summary

- **New spec** `code/specs/SYSCALL00-host-syscall-library.md` — documents the canonical syscall table (numbers 1–33), C ABI, SyscallHost Rust trait, and platform backends
- **compiler-ir**: Added `IrOp.SYSCALL_CHECKED = 64` and `IrOp.BRANCH_ERR = 65` to the AOT IR opcode enum (total: 66 opcodes)
- **interpreter-ir**: Added `"branch_err"` to `BRANCH_OPS`, new `SYSCALL_CHECKED_OPS` frozenset merged into `SIDE_EFFECT_OPS` and `ALL_OPS`, exported from `__init__.py`
- **vm-core**: New `VMCore.register_syscall(n, impl)` / `unregister_syscall(n)` API; `handle_syscall_checked` and `handle_branch_err` dispatch handlers; 26 new tests (233 total, 97.79% coverage)

Implements VMCOND00 Layer 1 — the result-value error protocol. Languages invoke numbered host syscalls (`syscall_checked`) without trapping and route control flow based on the error code (`branch_err`), all without touching the condition system or allocating handler objects.

Security: `register_syscall` validates `n ∈ [1, 255]` (raises `ValueError` for out-of-range numbers, catching misuse at registration time rather than dispatch time).

## Test plan

- [ ] compiler-ir: 114 tests pass, 95%+ coverage
- [ ] interpreter-ir: 150 tests pass, 100% coverage
- [ ] vm-core: 233 tests pass, 97.79% coverage (`test_vmcond00_phase1.py` adds 26 tests covering success/EOF/errno/EINVAL paths, boundary validation, and integration round-trips)
- [ ] Security review passed (no findings in this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)