### PR TITLE
feat(phase26): transcendental equation solving — trig, exp/log, Lambert W, hyperbolic, compound

### DIFF
--- a/code/packages/python/cas-solve/CHANGELOG.md
+++ b/code/packages/python/cas-solve/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.7.0 — 2026-05-05
+
+**Phase 26 — Transcendental equation solving.**
+
+New module `cas_solve/transcendental.py` with a single public function:
+
+- ``try_solve_transcendental(eq_ir, var)`` — dispatches across all recognised
+  transcendental equation families and returns a list of IR solution nodes,
+  or ``None`` if no pattern matches.
+
+Families supported:
+
+- **Trigonometric** (26a): `sin(ax+b) = c` → two periodic families with the
+  free-integer constant ``FreeInteger`` (%k); `cos`, `tan` analogously.
+- **Exponential/Logarithmic** (26b): `exp(ax+b) = c` → `x = (log(c)−b)/a`;
+  `log(ax+b) = c` → `x = (exp(c)−b)/a`.
+- **Lambert W** (26c): `f(x)·exp(f(x)) = c` with `f` linear → `f(x) = W(c)`.
+  Uses the new ``LambertW`` IR head from `symbolic-ir` 0.13.0.
+- **Hyperbolic** (26d): `sinh`, `cosh` (two branches), `tanh` with linear
+  argument; inverted via `asinh`, `acosh`, `atanh`.
+- **Compound substitution** (26e): detects when the equation is a polynomial
+  in exactly one transcendental function of the variable (e.g.
+  `sin(x)^2 + sin(x) = 0`) and solves by first solving the polynomial for the
+  intermediate variable `u`, then inverting `f(x) = u` for each root.
+
+The function is also exported from the package's `__init__.py`.
+
+Dependency bump: `symbolic-ir` ≥ 0.13.0 (for `FREE_INTEGER`, `LAMBERT_W`).
+
+---
+
 ## 0.6.0 — 2026-04-27
 
 Phase 3 — Numeric root-finding and linear-system solver.

--- a/code/packages/python/cas-solve/pyproject.toml
+++ b/code/packages/python/cas-solve/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-solve"
-version = "0.6.0"
-description = "Equation solving (Phases 1–5: linear, quadratic, cubic, quartic, numeric, linear systems)."
+version = "0.7.0"
+description = "Equation solving — polynomial (degrees 1–4) + numeric root-finding + linear systems + transcendental families (trig, exp/log, hyperbolic, Lambert W, compound substitution)."
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["cas", "solve", "polynomial", "symbolic", "education"]
 dependencies = [
-    "coding-adventures-symbolic-ir>=0.5.0",
+    "coding-adventures-symbolic-ir>=0.13.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/code/packages/python/cas-solve/src/cas_solve/__init__.py
+++ b/code/packages/python/cas-solve/src/cas_solve/__init__.py
@@ -1,4 +1,5 @@
-"""Equation solving (Phases 1–5: linear, quadratic, cubic, quartic, numeric, systems).
+"""Equation solving (Phases 1–6: linear, quadratic, cubic, quartic, numeric, systems,
+and Phase 26 transcendental families).
 
 Quick start::
 
@@ -10,6 +11,16 @@ Quick start::
     solve_quadratic(Fraction(1), Fraction(-5), Fraction(6))   # → [2, 3]
     solve_cubic(Fraction(1), Fraction(-6), Fraction(11), Fraction(-6))  # → [1, 2, 3]
     solve_quartic(Fraction(1), Fraction(0), Fraction(-5), Fraction(0), Fraction(4))  # → [-2,-1,1,2]
+
+Transcendental solving (Phase 26)::
+
+    from symbolic_ir import IRSymbol, IRApply, IRRational, EQUAL
+    from cas_solve import try_solve_transcendental
+
+    x = IRSymbol("x")
+    # sin(x) = 1/2 → [arcsin(1/2) + 2k*pi, pi - arcsin(1/2) + 2k*pi]
+    eq = IRApply(EQUAL, (IRApply(IRSymbol("Sin"), (x,)), IRRational(1, 2)))
+    solutions = try_solve_transcendental(eq, x)
 """
 
 from cas_solve.cubic import solve_cubic
@@ -19,6 +30,7 @@ from cas_solve.linear import ALL, solve_linear
 from cas_solve.linear_system import solve_linear_system
 from cas_solve.quadratic import solve_quadratic
 from cas_solve.quartic import solve_quartic
+from cas_solve.transcendental import try_solve_transcendental
 
 __all__ = [
     "ALL",
@@ -33,4 +45,5 @@ __all__ = [
     "solve_linear_system",
     "solve_quadratic",
     "solve_quartic",
+    "try_solve_transcendental",
 ]

--- a/code/packages/python/cas-solve/src/cas_solve/transcendental.py
+++ b/code/packages/python/cas-solve/src/cas_solve/transcendental.py
@@ -1,0 +1,656 @@
+"""Transcendental equation solving — Phase 26.
+
+Extends ``cas-solve`` to handle equation families that are *not* polynomial in
+the solve variable, but can still be inverted or reduced to simpler forms.
+
+Covered families
+----------------
+
+26a — Trigonometric (periodic, linear argument)::
+
+    sin(ax + b) = c  →  [arcsin(c) + 2k·π,  π − arcsin(c) + 2k·π]
+                         (divide by a, subtract b/a for the x solution)
+    cos(ax + b) = c  →  [arccos(c) + 2k·π, −arccos(c) + 2k·π]
+    tan(ax + b) = c  →  [arctan(c) + k·π]
+
+The free-integer constant ``%k`` is represented as ``FREE_INTEGER`` in the IR.
+
+26b — Exponential / logarithmic (linear argument)::
+
+    exp(ax + b) = c  →  ax + b = log(c)   →  x = (log(c) − b) / a
+    log(ax + b) = c  →  ax + b = exp(c)   →  x = (exp(c) − b) / a
+
+26c — Lambert W (principal branch, linear inner function)::
+
+    f(x) · exp(f(x)) = c, f linear in x  →  f(x) = W(c)  →  x = (W(c) − b) / a
+
+26d — Hyperbolic (linear argument)::
+
+    sinh(ax + b) = c  →  ax + b = asinh(c)  (unique)
+    cosh(ax + b) = c  →  ax + b = ±acosh(c)  (two branches)
+    tanh(ax + b) = c  →  ax + b = atanh(c)  (unique)
+
+26e — Compound (polynomial in a single transcendental substitution)::
+
+    sin(x)² + sin(x) = 0  →  u = sin(x),  u² + u = 0  →  u ∈ {−1, 0}
+                              then solve sin(x) = u for each u recursively.
+    exp(x)² − 3·exp(x) + 2 = 0  →  u = exp(x),  u² − 3u + 2 = 0  →  u ∈ {1, 2}
+                                     then solve exp(x) = u for each u.
+
+Public API
+----------
+
+    try_solve_transcendental(eq_ir, var) → list[IRNode] | None
+
+``eq_ir`` is either ``Equal(lhs, rhs)`` or a bare expression (= 0).
+``var`` is an ``IRSymbol`` for the solve variable.
+Returns a list of IR solution nodes, or ``None`` if no pattern matches.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import TYPE_CHECKING
+
+from symbolic_ir import (
+    ACOS,
+    ACOSH,
+    ADD,
+    ASIN,
+    ASINH,
+    ATAN,
+    ATANH,
+    DIV,
+    EXP,
+    FREE_INTEGER,
+    LAMBERT_W,
+    LOG,
+    MUL,
+    NEG,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+if TYPE_CHECKING:
+    pass
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# %pi as used throughout the VM.  The same singleton used everywhere.
+_PI = IRSymbol("%pi")
+
+# The free-integer constant %k that appears in periodic trig solutions.
+# FreeInteger is the IR head; the MACSYMA-facing name is %k.
+_K = FREE_INTEGER  # IRSymbol("FreeInteger")
+
+
+# ---------------------------------------------------------------------------
+# Helper: lift a Fraction to the canonical IR literal
+# ---------------------------------------------------------------------------
+
+
+def _frac_ir(c: Fraction) -> IRNode:
+    """Convert a ``Fraction`` to its canonical IR literal.
+
+    A Fraction with denominator 1 becomes an ``IRInteger``; others become
+    ``IRRational``.  Zero is represented as ``IRInteger(0)``.
+    """
+    if c.denominator == 1:
+        return IRInteger(c.numerator)
+    return IRRational(c.numerator, c.denominator)
+
+
+# ---------------------------------------------------------------------------
+# Helper: check if a node is free of (does not mention) a given variable
+# ---------------------------------------------------------------------------
+
+
+def _is_const_wrt(node: IRNode, var: IRSymbol) -> bool:
+    """Return ``True`` if ``node`` contains no occurrence of ``var``.
+
+    Walks the tree recursively.  All concrete values (integers, rationals,
+    floats, symbols other than ``var``) are trivially constant.  For
+    ``IRApply`` nodes every sub-argument is checked.
+    """
+    if isinstance(node, IRSymbol):
+        # Use equality, not identity: IRSymbol is not interned — two separate
+        # IRSymbol("x") objects are equal but not the same Python object.
+        return node != var
+    if isinstance(node, (IRInteger, IRRational, IRFloat)):
+        return True
+    if isinstance(node, IRApply):
+        return all(_is_const_wrt(a, var) for a in node.args)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Helper: extract linear coefficients from an argument
+# ---------------------------------------------------------------------------
+
+
+def _extract_linear(arg: IRNode, var: IRSymbol) -> tuple[Fraction, Fraction] | None:
+    """Try to express ``arg`` as ``a·var + b`` with ``a ≠ 0``.
+
+    Uses the polynomial bridge's ``to_rational`` to get exact Fraction
+    coefficients.  Returns ``(a, b)`` on success or ``None`` if ``arg`` is
+    not a degree-1 polynomial in ``var``.
+
+    Examples::
+
+        _extract_linear(x, x)           →  (1, 0)
+        _extract_linear(2*x + 3, x)     →  (2, 3)
+        _extract_linear(x/2 - 1, x)     →  (1/2, -1)
+        _extract_linear(x^2, x)         →  None   (degree 2)
+        _extract_linear(sin(x), x)      →  None   (transcendental)
+    """
+    # Import here to avoid a circular dependency at module load time.
+    # The polynomial bridge lives in symbolic_vm; cas_solve is lower-level,
+    # but when called from within the VM context the bridge is available.
+    try:
+        from symbolic_vm.polynomial_bridge import to_rational
+    except ImportError:
+        return None
+
+    result = to_rational(arg, var)
+    if result is None:
+        return None
+    num_frac, den_frac = result
+    _ONE_FRAC = (Fraction(1),)
+    if den_frac != _ONE_FRAC:
+        return None  # rational function, not polynomial
+    # num_frac is (c0, c1, ..., cn) ascending degree.
+    # Degree 1 means exactly two entries: (b, a) where a ≠ 0.
+    if len(num_frac) != 2:
+        return None  # not linear (could be constant or higher degree)
+    b, a = num_frac  # ascending order: c0 is the constant, c1 is coeff of x
+    if a == Fraction(0):
+        return None  # degenerate
+    return (a, b)
+
+
+# ---------------------------------------------------------------------------
+# Helper: solve a·var + b = val_ir  for  var
+# ---------------------------------------------------------------------------
+
+
+def _solve_linear_for_val(
+    a: Fraction,
+    b: Fraction,
+    val_ir: IRNode,
+    _var: IRSymbol,
+) -> IRNode:
+    """Return the IR node for ``var = (val_ir − b) / a``.
+
+    Simplifies the obvious special cases (b = 0, a = 1) to avoid building
+    unnecessarily deep trees.
+    """
+    # Step 1: val_ir − b
+    if b == Fraction(0):
+        shifted = val_ir
+    else:
+        b_ir = _frac_ir(b)
+        shifted = IRApply(SUB, (val_ir, b_ir))
+
+    # Step 2: divide by a
+    if a == Fraction(1):
+        return shifted
+    a_ir = _frac_ir(a)
+    return IRApply(DIV, (shifted, a_ir))
+
+
+# ---------------------------------------------------------------------------
+# Helper: check if a node is Equal(lhs, rhs)
+# ---------------------------------------------------------------------------
+
+
+def _split_equal(eq_ir: IRNode) -> tuple[IRNode, IRNode] | None:
+    """Return ``(lhs, rhs)`` if ``eq_ir = Equal(lhs, rhs)``, else ``None``."""
+    if (
+        isinstance(eq_ir, IRApply)
+        and isinstance(eq_ir.head, IRSymbol)
+        and eq_ir.head.name == "Equal"
+        and len(eq_ir.args) == 2
+    ):
+        return eq_ir.args[0], eq_ir.args[1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 26a/26b/26d — simple "f(linear) = constant" pattern
+# ---------------------------------------------------------------------------
+
+
+def _try_func_eq_const(
+    func_side: IRNode,
+    const_side: IRNode,
+    var: IRSymbol,
+) -> list[IRNode] | None:
+    """Attempt to solve ``func_side = const_side`` when ``func_side`` is a
+    recognised transcendental function of a linear expression in ``var``.
+
+    ``const_side`` must be free of ``var``; if it contains ``var`` the
+    function returns ``None`` immediately.
+
+    The "two_pi_k" factor used in trig solutions is::
+
+        2 · %pi · %k  = Mul(2, Mul(%pi, FreeInteger))
+
+    which represents  2 · π · k  for any integer k.
+
+    Returns a list of IR solution nodes or ``None``.
+    """
+    if not _is_const_wrt(const_side, var):
+        return None
+    if not isinstance(func_side, IRApply):
+        return None
+    head = func_side.head
+    if not isinstance(head, IRSymbol):
+        return None
+    if len(func_side.args) != 1:
+        return None  # multi-argument: not a simple f(u)
+
+    arg = func_side.args[0]
+    lin = _extract_linear(arg, var)
+    if lin is None:
+        return None
+    a, b = lin  # arg = a·var + b
+    c = const_side
+
+    # 2·π·%k  — used in periodic (trig) solutions.
+    two_pi_k = IRApply(MUL, (IRInteger(2), IRApply(MUL, (_PI, _K))))
+
+    fname = head.name
+
+    # ---------------------------------------------------------------
+    # Trigonometric — 26a (periodic families)
+    # ---------------------------------------------------------------
+
+    if fname == "Sin":
+        # sin(u) = c  →  u = arcsin(c) + 2k·π  OR  u = π − arcsin(c) + 2k·π
+        asin_c = IRApply(ASIN, (c,))
+        arg_val1 = IRApply(ADD, (asin_c, two_pi_k))
+        arg_val2 = IRApply(ADD, (IRApply(SUB, (_PI, asin_c)), two_pi_k))
+        sol1 = _solve_linear_for_val(a, b, arg_val1, var)
+        sol2 = _solve_linear_for_val(a, b, arg_val2, var)
+        return [sol1, sol2]
+
+    if fname == "Cos":
+        # cos(u) = c  →  u = arccos(c) + 2k·π  OR  u = −arccos(c) + 2k·π
+        acos_c = IRApply(ACOS, (c,))
+        arg_val1 = IRApply(ADD, (acos_c, two_pi_k))
+        arg_val2 = IRApply(ADD, (IRApply(NEG, (acos_c,)), two_pi_k))
+        sol1 = _solve_linear_for_val(a, b, arg_val1, var)
+        sol2 = _solve_linear_for_val(a, b, arg_val2, var)
+        return [sol1, sol2]
+
+    if fname == "Tan":
+        # tan(u) = c  →  u = arctan(c) + k·π
+        atan_c = IRApply(ATAN, (c,))
+        pi_k = IRApply(MUL, (_PI, _K))
+        arg_val = IRApply(ADD, (atan_c, pi_k))
+        return [_solve_linear_for_val(a, b, arg_val, var)]
+
+    # ---------------------------------------------------------------
+    # Exponential / logarithmic — 26b (unique inverse)
+    # ---------------------------------------------------------------
+
+    if fname == "Exp":
+        # exp(u) = c  →  u = log(c)
+        log_c = IRApply(LOG, (c,))
+        return [_solve_linear_for_val(a, b, log_c, var)]
+
+    if fname == "Log":
+        # log(u) = c  →  u = exp(c)
+        exp_c = IRApply(EXP, (c,))
+        return [_solve_linear_for_val(a, b, exp_c, var)]
+
+    # ---------------------------------------------------------------
+    # Hyperbolic — 26d
+    # ---------------------------------------------------------------
+
+    if fname == "Sinh":
+        # sinh(u) = c  →  u = asinh(c)  (unique)
+        asinh_c = IRApply(ASINH, (c,))
+        return [_solve_linear_for_val(a, b, asinh_c, var)]
+
+    if fname == "Cosh":
+        # cosh(u) = c  →  u = acosh(c)  OR  u = −acosh(c)
+        acosh_c = IRApply(ACOSH, (c,))
+        sol1 = _solve_linear_for_val(a, b, acosh_c, var)
+        sol2 = _solve_linear_for_val(a, b, IRApply(NEG, (acosh_c,)), var)
+        return [sol1, sol2]
+
+    if fname == "Tanh":
+        # tanh(u) = c  →  u = atanh(c)  (unique)
+        atanh_c = IRApply(ATANH, (c,))
+        return [_solve_linear_for_val(a, b, atanh_c, var)]
+
+    return None  # unrecognised transcendental head
+
+
+# ---------------------------------------------------------------------------
+# 26c — Lambert W: f(x)·exp(f(x)) = c
+# ---------------------------------------------------------------------------
+
+
+def _try_lambert(lhs: IRNode, rhs: IRNode, var: IRSymbol) -> list[IRNode] | None:
+    """Detect the Lambert-W pattern  f(var) · exp(f(var)) = c  and return
+    ``[var = (W(c) − b) / a]`` where ``f(var) = a·var + b``.
+
+    The pattern we look for on the *lhs*:
+      ``MUL(u, Exp(u))``  where ``u = a·var + b`` (linear in var)
+
+    and *rhs* must be constant w.r.t. var.
+
+    Also handles the *rhs-form*: ``c = f(var)·exp(f(var))``.
+    """
+    return _lambert_one_side(lhs, rhs, var) or _lambert_one_side(rhs, lhs, var)
+
+
+def _lambert_one_side(
+    product_side: IRNode,
+    const_side: IRNode,
+    var: IRSymbol,
+) -> list[IRNode] | None:
+    """Try to match  ``product_side = f(var) · exp(f(var))``  with ``const_side``
+    free of ``var``."""
+    if not _is_const_wrt(const_side, var):
+        return None
+    if not isinstance(product_side, IRApply):
+        return None
+    if product_side.head is not MUL:
+        return None
+    if len(product_side.args) != 2:
+        return None
+
+    a_arg, b_arg = product_side.args
+
+    # Either of (a_arg, b_arg) could be the Exp(...) factor.
+    for linear_node, exp_node in ((a_arg, b_arg), (b_arg, a_arg)):
+        if not (
+            isinstance(exp_node, IRApply)
+            and exp_node.head is EXP
+            and len(exp_node.args) == 1
+        ):
+            continue
+        inner = exp_node.args[0]
+        # inner and linear_node must both be the same linear expression.
+        # We check by extracting linear coefficients from both.
+        lin_a = _extract_linear(linear_node, var)
+        lin_b = _extract_linear(inner, var)
+        if lin_a is None or lin_b is None:
+            continue
+        if lin_a != lin_b:
+            continue
+        # Match!  f(var) = a·var + b → W(const_side) = a·var + b
+        a, b = lin_a
+        w_c = IRApply(LAMBERT_W, (const_side,))
+        return [_solve_linear_for_val(a, b, w_c, var)]
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 26e — Compound: polynomial in a single transcendental substitution
+# ---------------------------------------------------------------------------
+
+# Heads we try as substitution target.
+_COMPOUND_HEADS = ("Sin", "Cos", "Tan", "Sinh", "Cosh", "Tanh", "Exp", "Log")
+
+
+def _substitute_func(
+    expr: IRNode,
+    func_name: str,
+    var: IRSymbol,
+    sub: IRSymbol,
+) -> IRNode | None:
+    """Replace every occurrence of ``FuncName(var)`` with ``sub`` inside
+    ``expr``.  Return ``None`` if after substitution ``var`` still appears
+    (i.e. it appeared in a different context that we cannot handle here).
+
+    We recognise  ``FuncName(var)``  only when the argument is exactly
+    ``var`` — not ``var + offset`` or ``2*var``.  This keeps the compound
+    pattern simple; the linear-argument forms are handled by
+    ``_try_func_eq_const``.
+    """
+    result = _subst_walk(expr, func_name, var, sub)
+    if result is None:
+        return None
+    # After substitution, var must not appear.
+    if not _is_const_wrt(result, var):
+        return None
+    return result
+
+
+def _subst_walk(
+    node: IRNode,
+    func_name: str,
+    var: IRSymbol,
+    sub: IRSymbol,
+) -> IRNode | None:
+    """Recursive walker for ``_substitute_func``."""
+    # The variable itself — appears outside any function wrapper.  We
+    # cannot substitute it; return ``None`` to signal failure.
+    # Use equality (not identity) since IRSymbol is not interned.
+    if isinstance(node, IRSymbol) and node == var:
+        return None
+    if isinstance(node, (IRSymbol, IRInteger, IRRational, IRFloat)):
+        return node
+    if not isinstance(node, IRApply):
+        return None
+
+    head = node.head
+    if not isinstance(head, IRSymbol):
+        return None
+
+    # Match exactly  FuncName(var).
+    # Use equality (not identity) since IRSymbol is not interned.
+    if (
+        head.name == func_name
+        and len(node.args) == 1
+        and isinstance(node.args[0], IRSymbol)
+        and node.args[0] == var
+    ):
+        return sub
+
+    # Recurse into all arguments.
+    new_args: list[IRNode] = []
+    for arg in node.args:
+        walked = _subst_walk(arg, func_name, var, sub)
+        if walked is None:
+            return None
+        new_args.append(walked)
+    return IRApply(head, tuple(new_args))
+
+
+def _try_compound(lhs: IRNode, rhs: IRNode, var: IRSymbol) -> list[IRNode] | None:
+    """Try to solve by substituting  u = f(var)  and reducing to a
+    polynomial in u.
+
+    Only considers substitutions of the form ``f(var)`` — not linear
+    offsets like ``f(2x + 1)``.  The linear-offset case is already
+    handled by ``_try_func_eq_const``.
+
+    Algorithm:
+    1. Compute ``diff = lhs − rhs`` (the equation normalised to = 0).
+    2. For each candidate function name f in ``_COMPOUND_HEADS``:
+       a. Attempt to replace every ``f(var)`` with a fresh symbol ``_u``.
+       b. Check that ``_u`` actually appears (otherwise no substitution occurred).
+       c. Check that the result is a polynomial in ``_u`` over Q.
+       d. Solve that polynomial (degree 1–4) for ``_u``.
+       e. For each root u_sol: recursively call ``try_solve_transcendental``
+          on  ``f(var) = u_sol``  to invert the outer function.
+       f. Collect all resulting x-solutions.
+    """
+    # Build the normalised equation expr = 0.
+    if isinstance(rhs, IRInteger) and rhs.value == 0:
+        diff = lhs
+    else:
+        diff = IRApply(SUB, (lhs, rhs))
+
+    for func_name in _COMPOUND_HEADS:
+        sub_sym = IRSymbol(f"__sub_{func_name}__")
+        substituted = _substitute_func(diff, func_name, var, sub_sym)
+        if substituted is None:
+            continue
+
+        # Only proceed if sub_sym actually appears in substituted.
+        if _is_const_wrt(substituted, sub_sym):
+            continue
+
+        # Check polynomial structure in sub_sym.
+        coeffs = _poly_coeffs(substituted, sub_sym)
+        if coeffs is None:
+            continue
+        deg = len(coeffs) - 1
+        if deg < 1:
+            continue
+
+        # Solve the polynomial for sub_sym.
+        sub_solutions = _solve_poly(coeffs)
+        if sub_solutions is None:
+            continue
+
+        # For each sub-solution, invert f(var) = u_sol.
+        all_x: list[IRNode] = []
+        _EQ = IRSymbol("Equal")
+        for u_sol in sub_solutions:
+            fn_of_var = IRApply(IRSymbol(func_name), (var,))
+            func_eq = IRApply(_EQ, (fn_of_var, u_sol))
+            inner = try_solve_transcendental(func_eq, var)
+            if inner is not None:
+                all_x.extend(inner)
+        if all_x:
+            return all_x
+
+    return None
+
+
+def _poly_coeffs(expr: IRNode, sym: IRSymbol) -> tuple[Fraction, ...] | None:
+    """Extract rational polynomial coefficients of ``expr`` in ``sym``."""
+    try:
+        from symbolic_vm.polynomial_bridge import to_rational
+    except ImportError:
+        return None
+    result = to_rational(expr, sym)
+    if result is None:
+        return None
+    num_frac, den_frac = result
+    if den_frac != (Fraction(1),):
+        return None
+    return num_frac
+
+
+def _solve_poly(coeffs: tuple[Fraction, ...]) -> list[IRNode] | None:
+    """Solve the polynomial with the given ascending-degree Fraction
+    coefficients.  Delegates to the existing ``cas_solve`` solvers for
+    degrees 1–4.
+    """
+    from cas_solve.linear import ALL as _ALL  # noqa: PLC0415
+    from cas_solve.linear import solve_linear  # noqa: PLC0415
+
+    deg = len(coeffs) - 1
+    if deg < 1:
+        return None
+
+    if deg == 1:
+        # b + a·u = 0
+        a, b = coeffs[1], coeffs[0]
+        sol = solve_linear(a, b)
+        if sol is _ALL:
+            return None
+        return list(sol) if sol else []
+
+    if deg == 2:
+        from cas_solve.quadratic import solve_quadratic
+
+        c, b, a = coeffs[0], coeffs[1], coeffs[2]
+        sols = solve_quadratic(a, b, c)
+        return list(sols)
+
+    if deg == 3:
+        from cas_solve.cubic import solve_cubic
+
+        d, c, b, a = coeffs[0], coeffs[1], coeffs[2], coeffs[3]
+        sols = solve_cubic(a, b, c, d)
+        if not sols or isinstance(sols, str):
+            return None
+        return list(sols)
+
+    if deg == 4:
+        from cas_solve.quartic import solve_quartic
+
+        e, d, c, b, a = coeffs[0], coeffs[1], coeffs[2], coeffs[3], coeffs[4]
+        sols = solve_quartic(a, b, c, d, e)
+        if not sols or isinstance(sols, str):
+            return None
+        return list(sols)
+
+    return None  # degree > 4: fall through
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def try_solve_transcendental(
+    eq_ir: IRNode,
+    var: IRSymbol,
+) -> list[IRNode] | None:
+    """Try to solve ``eq_ir`` for ``var`` using transcendental techniques.
+
+    ``eq_ir`` is either:
+    - ``Equal(lhs, rhs)`` — an explicit equation
+    - A bare IR expression (treated as  expr = 0)
+
+    Returns a list of IR nodes representing the solutions, or ``None`` if
+    none of the recognised patterns match.  The caller wraps the list in
+    ``List(...)`` for the MACSYMA surface output.
+
+    Dispatch order:
+    1. Simple  f(linear) = constant  — 26a/26b/26d
+    2. Lambert W  f·exp(f) = constant  — 26c
+    3. Compound polynomial-in-transcendental substitution  — 26e
+    """
+    # Normalise equation into (lhs, rhs) form.
+    split = _split_equal(eq_ir)
+    if split is not None:
+        lhs, rhs = split
+    else:
+        lhs = eq_ir
+        rhs = IRInteger(0)
+
+    # ------------------------------------------------------------------
+    # Pass 1: simple  f(linear) = constant
+    # ------------------------------------------------------------------
+    result = _try_func_eq_const(lhs, rhs, var)
+    if result is not None:
+        return result
+
+    result = _try_func_eq_const(rhs, lhs, var)
+    if result is not None:
+        return result
+
+    # ------------------------------------------------------------------
+    # Pass 2: Lambert W
+    # ------------------------------------------------------------------
+    result = _try_lambert(lhs, rhs, var)
+    if result is not None:
+        return result
+
+    # ------------------------------------------------------------------
+    # Pass 3: compound (polynomial in transcendental substitution)
+    # ------------------------------------------------------------------
+    result = _try_compound(lhs, rhs, var)
+    if result is not None:
+        return result
+
+    return None

--- a/code/packages/python/cas-solve/tests/test_transcendental.py
+++ b/code/packages/python/cas-solve/tests/test_transcendental.py
@@ -1,0 +1,783 @@
+"""Tests for cas_solve.transcendental — Phase 26 transcendental solver.
+
+These tests cover the helper functions, internal dispatchers, and the
+public ``try_solve_transcendental`` API directly within the ``cas-solve``
+package boundary, without depending on ``symbolic_vm``.
+
+Strategy
+--------
+
+``transcendental.py`` contains two categories of helper that need the
+optional ``symbolic_vm.polynomial_bridge.to_rational`` function:
+
+* ``_extract_linear``   — parses linear arguments like ``ax + b``
+* ``_poly_coeffs``      — extracts polynomial coefficients for compound
+                          substitution
+
+For the tests that exercise these paths we use one of two strategies:
+
+1. **mock_bridge fixture** — injects a lightweight fake
+   ``symbolic_vm.polynomial_bridge`` into ``sys.modules`` so that
+   ``_extract_linear`` can handle bare ``x`` and ``n*x`` patterns.
+
+2. **unittest.mock.patch.object** — patches the private helper directly
+   with a pre-cooked return value for tests that need complex polynomial
+   coefficients (compound substitution).
+
+All other helpers (``_frac_ir``, ``_is_const_wrt``, ``_split_equal``,
+``_solve_linear_for_val``, ``_subst_walk``, ``_substitute_func``,
+``_solve_poly``) are tested without any mocking.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from fractions import Fraction
+from unittest.mock import patch
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    ASINH,
+    ATANH,
+    COS,
+    COSH,
+    DIV,
+    EQUAL,
+    EXP,
+    LAMBERT_W,
+    LOG,
+    MUL,
+    SIN,
+    SINH,
+    SUB,
+    TANH,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRRational,
+    IRSymbol,
+)
+
+import cas_solve.transcendental as _mod
+from cas_solve.transcendental import (
+    _extract_linear,
+    _frac_ir,
+    _is_const_wrt,
+    _poly_coeffs,
+    _solve_linear_for_val,
+    _solve_poly,
+    _split_equal,
+    _subst_walk,
+    _substitute_func,
+    _try_compound,
+    _try_func_eq_const,
+    _try_lambert,
+    try_solve_transcendental,
+)
+
+# ---------------------------------------------------------------------------
+# Shared symbols and tiny IR builders
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+Y = IRSymbol("y")
+
+
+def _sin(node: IRApply) -> IRApply:
+    return IRApply(SIN, (node,))
+
+
+def _cos(node: IRApply) -> IRApply:
+    return IRApply(COS, (node,))
+
+
+def _exp(node: IRApply) -> IRApply:
+    return IRApply(EXP, (node,))
+
+
+def _log(node: IRApply) -> IRApply:
+    return IRApply(LOG, (node,))
+
+
+def _eq(lhs, rhs) -> IRApply:
+    return IRApply(EQUAL, (lhs, rhs))
+
+
+# ---------------------------------------------------------------------------
+# Fixture: lightweight polynomial-bridge mock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_bridge():
+    """Inject a fake ``symbolic_vm.polynomial_bridge`` into ``sys.modules``.
+
+    The fake ``to_rational`` handles only two patterns:
+
+    * ``IRSymbol`` equal to ``var``         →  ``((0, 1), (1,))``  (1·x)
+    * ``MUL(IRInteger(n), var)``            →  ``((0, n), (1,))``  (n·x)
+
+    Any other expression returns ``None`` so unexpected patterns still
+    fall through to ``None`` just as they would without the bridge.
+    """
+
+    def _to_rational(expr, var):
+        if isinstance(expr, IRSymbol) and expr == var:
+            return (Fraction(0), Fraction(1)), (Fraction(1),)
+        if (
+            isinstance(expr, IRApply)
+            and expr.head is MUL
+            and len(expr.args) == 2
+        ):
+            a_nd, b_nd = expr.args
+            if (
+                isinstance(a_nd, IRInteger)
+                and isinstance(b_nd, IRSymbol)
+                and b_nd == var
+            ):
+                return (Fraction(0), Fraction(a_nd.value)), (Fraction(1),)
+            if (
+                isinstance(b_nd, IRInteger)
+                and isinstance(a_nd, IRSymbol)
+                and a_nd == var
+            ):
+                return (Fraction(0), Fraction(b_nd.value)), (Fraction(1),)
+        return None
+
+    mock_mod = types.ModuleType("symbolic_vm.polynomial_bridge")
+    mock_mod.to_rational = _to_rational
+    mock_vm = types.ModuleType("symbolic_vm")
+
+    old_vm = sys.modules.get("symbolic_vm")
+    old_bridge = sys.modules.get("symbolic_vm.polynomial_bridge")
+
+    sys.modules["symbolic_vm"] = mock_vm
+    sys.modules["symbolic_vm.polynomial_bridge"] = mock_mod
+
+    yield _to_rational
+
+    if old_vm is None:
+        sys.modules.pop("symbolic_vm", None)
+    else:
+        sys.modules["symbolic_vm"] = old_vm
+
+    if old_bridge is None:
+        sys.modules.pop("symbolic_vm.polynomial_bridge", None)
+    else:
+        sys.modules["symbolic_vm.polynomial_bridge"] = old_bridge
+
+
+# ===========================================================================
+# 1. _frac_ir
+# ===========================================================================
+
+
+class TestFracIr:
+    """_frac_ir: convert a Fraction to its canonical IR literal."""
+
+    def test_integer_fraction(self) -> None:
+        """Fraction(3) → IRInteger(3)."""
+        assert _frac_ir(Fraction(3)) == IRInteger(3)
+
+    def test_negative_integer(self) -> None:
+        """Fraction(-7) → IRInteger(-7)."""
+        assert _frac_ir(Fraction(-7)) == IRInteger(-7)
+
+    def test_zero(self) -> None:
+        """Fraction(0) → IRInteger(0)."""
+        assert _frac_ir(Fraction(0)) == IRInteger(0)
+
+    def test_proper_fraction(self) -> None:
+        """Fraction(1, 2) → IRRational(1, 2)."""
+        assert _frac_ir(Fraction(1, 2)) == IRRational(1, 2)
+
+    def test_negative_fraction(self) -> None:
+        """Fraction(-3, 4) → IRRational with numer −3, denom 4."""
+        result = _frac_ir(Fraction(-3, 4))
+        assert isinstance(result, IRRational)
+        assert result.numer == -3
+        assert result.denom == 4
+
+
+# ===========================================================================
+# 2. _is_const_wrt
+# ===========================================================================
+
+
+class TestIsConstWrt:
+    """_is_const_wrt: true iff a node is free of the given variable."""
+
+    def test_integer_is_const(self) -> None:
+        assert _is_const_wrt(IRInteger(5), X)
+
+    def test_float_is_const(self) -> None:
+        assert _is_const_wrt(IRFloat(3.14), X)
+
+    def test_rational_is_const(self) -> None:
+        assert _is_const_wrt(IRRational(1, 2), X)
+
+    def test_same_symbol_is_not_const(self) -> None:
+        assert not _is_const_wrt(X, X)
+
+    def test_same_name_different_object_is_not_const(self) -> None:
+        """IRSymbol is not interned — equality, not identity, is used."""
+        x2 = IRSymbol("x")
+        assert not _is_const_wrt(x2, X)
+
+    def test_different_symbol_is_const(self) -> None:
+        assert _is_const_wrt(Y, X)
+
+    def test_apply_containing_var_is_not_const(self) -> None:
+        assert not _is_const_wrt(_sin(X), X)
+
+    def test_apply_not_containing_var_is_const(self) -> None:
+        assert _is_const_wrt(_sin(Y), X)
+
+    def test_nested_apply_with_var(self) -> None:
+        inner = IRApply(ADD, (IRInteger(1), X))
+        assert not _is_const_wrt(inner, X)
+
+    def test_nested_apply_without_var(self) -> None:
+        inner = IRApply(ADD, (IRInteger(1), Y))
+        assert _is_const_wrt(inner, X)
+
+
+# ===========================================================================
+# 3. _split_equal
+# ===========================================================================
+
+
+class TestSplitEqual:
+    """_split_equal: unwrap Equal(lhs, rhs) or return None."""
+
+    def test_equal_node(self) -> None:
+        """Equal(sin(x), 0) → (sin(x), 0)."""
+        lhs, rhs = _sin(X), IRInteger(0)
+        result = _split_equal(_eq(lhs, rhs))
+        assert result == (lhs, rhs)
+
+    def test_non_equal_apply_returns_none(self) -> None:
+        assert _split_equal(_sin(X)) is None
+
+    def test_plain_integer_returns_none(self) -> None:
+        assert _split_equal(IRInteger(42)) is None
+
+    def test_one_arg_equal_returns_none(self) -> None:
+        """Equal node with only one argument should return None."""
+        one_arg = IRApply(EQUAL, (X,))
+        assert _split_equal(one_arg) is None
+
+    def test_apply_with_non_symbol_head_returns_none(self) -> None:
+        """An IRApply whose head is itself an IRApply should return None."""
+        weird_head = IRApply(IRApply(ADD, (X,)), (X, Y))
+        assert _split_equal(weird_head) is None
+
+
+# ===========================================================================
+# 4. _solve_linear_for_val
+# ===========================================================================
+
+
+class TestSolveLinearForVal:
+    """_solve_linear_for_val: invert a·x + b = val for x."""
+
+    def test_a1_b0_returns_val(self) -> None:
+        """a=1, b=0 → val (no wrapping needed)."""
+        val = IRInteger(5)
+        result = _solve_linear_for_val(Fraction(1), Fraction(0), val, X)
+        assert result is val
+
+    def test_a2_b0_returns_div(self) -> None:
+        """a=2, b=0 → DIV(val, 2)."""
+        val = IRInteger(4)
+        result = _solve_linear_for_val(Fraction(2), Fraction(0), val, X)
+        assert isinstance(result, IRApply)
+        assert result.head is DIV
+        assert result.args[1] == IRInteger(2)
+
+    def test_a1_b3_returns_sub(self) -> None:
+        """a=1, b=3 → SUB(val, 3)."""
+        val = IRInteger(5)
+        result = _solve_linear_for_val(Fraction(1), Fraction(3), val, X)
+        assert isinstance(result, IRApply)
+        assert result.head is SUB
+        assert result.args[1] == IRInteger(3)
+
+    def test_a2_b3_returns_div_of_sub(self) -> None:
+        """a=2, b=3 → DIV(SUB(val, 3), 2)."""
+        val = IRInteger(5)
+        result = _solve_linear_for_val(Fraction(2), Fraction(3), val, X)
+        assert isinstance(result, IRApply)
+        assert result.head is DIV
+        inner = result.args[0]
+        assert isinstance(inner, IRApply)
+        assert inner.head is SUB
+
+    def test_rational_a(self) -> None:
+        """a=1/2 → DIV(val, IRRational(1,2))."""
+        val = IRInteger(3)
+        result = _solve_linear_for_val(Fraction(1, 2), Fraction(0), val, X)
+        assert isinstance(result, IRApply)
+        assert result.head is DIV
+        assert result.args[1] == IRRational(1, 2)
+
+
+# ===========================================================================
+# 5. _subst_walk and _substitute_func
+# ===========================================================================
+
+
+class TestSubstWalk:
+    """_subst_walk: replace f(var) with sub inside an IR tree."""
+
+    def setup_method(self) -> None:
+        self.sub = IRSymbol("__u__")
+
+    def test_sin_x_replaced(self) -> None:
+        """sin(x) with func_name=Sin, var=x → sub."""
+        result = _subst_walk(_sin(X), "Sin", X, self.sub)
+        assert result == self.sub
+
+    def test_bare_var_returns_none(self) -> None:
+        """Bare x (not inside a function) → None (substitution fails)."""
+        result = _subst_walk(X, "Sin", X, self.sub)
+        assert result is None
+
+    def test_integer_unchanged(self) -> None:
+        """IRInteger passes through unchanged."""
+        result = _subst_walk(IRInteger(7), "Sin", X, self.sub)
+        assert result == IRInteger(7)
+
+    def test_other_symbol_unchanged(self) -> None:
+        """Symbols other than var pass through unchanged."""
+        result = _subst_walk(Y, "Sin", X, self.sub)
+        assert result is Y
+
+    def test_nested_add_both_replaced(self) -> None:
+        """ADD(sin(x), sin(x)) → ADD(sub, sub)."""
+        expr = IRApply(ADD, (_sin(X), _sin(X)))
+        result = _subst_walk(expr, "Sin", X, self.sub)
+        assert result == IRApply(ADD, (self.sub, self.sub))
+
+    def test_fails_when_var_appears_bare(self) -> None:
+        """ADD(sin(x), x) → None because x appears outside Sin."""
+        expr = IRApply(ADD, (_sin(X), X))
+        result = _subst_walk(expr, "Sin", X, self.sub)
+        assert result is None
+
+    def test_wrong_func_name_recurses_into_var(self) -> None:
+        """cos(x) when substituting Sin: x appears bare inside Cos → None."""
+        result = _subst_walk(_cos(X), "Sin", X, self.sub)
+        assert result is None
+
+    def test_non_symbol_head_returns_none(self) -> None:
+        """IRApply whose head is another IRApply → None."""
+        weird = IRApply(IRApply(ADD, (X,)), (X,))
+        result = _subst_walk(weird, "Sin", X, self.sub)
+        assert result is None
+
+
+class TestSubstituteFunc:
+    """_substitute_func: high-level wrapper that also checks var absence."""
+
+    def setup_method(self) -> None:
+        self.sub = IRSymbol("__u__")
+
+    def test_sin_x_substituted(self) -> None:
+        """sin(x) → sub (x gone after substitution)."""
+        result = _substitute_func(_sin(X), "Sin", X, self.sub)
+        assert result == self.sub
+
+    def test_fails_when_var_remains_after_substitution(self) -> None:
+        """ADD(sin(x), x) → None since x remains bare after substitution."""
+        expr = IRApply(ADD, (_sin(X), X))
+        result = _substitute_func(expr, "Sin", X, self.sub)
+        assert result is None
+
+    def test_expression_without_target_func_returned_if_var_absent(self) -> None:
+        """sin(y) — Sin(y) doesn't match Sin(x), but y≠x so x is absent.
+        The function returns sin(y) because x never appeared."""
+        result = _substitute_func(_sin(Y), "Sin", X, self.sub)
+        # x doesn't appear, so no failure on the var-presence check.
+        # sin(y) is returned as-is.
+        assert result == _sin(Y)
+
+
+# ===========================================================================
+# 6. _solve_poly
+# ===========================================================================
+
+
+class TestSolvePoly:
+    """_solve_poly: delegate to degree-specific solvers."""
+
+    def test_degree_0_returns_none(self) -> None:
+        """Constant polynomial (degree 0) → None."""
+        assert _solve_poly((Fraction(5),)) is None
+
+    def test_degree_1_simple(self) -> None:
+        """u + 2 = 0 → [−2]."""
+        # (b=2, a=1) → 1·u + 2 = 0 → u = −2
+        result = _solve_poly((Fraction(2), Fraction(1)))
+        assert result == [IRInteger(-2)]
+
+    def test_degree_1_zero_constant(self) -> None:
+        """1·u + 0 = 0 → [0]."""
+        result = _solve_poly((Fraction(0), Fraction(1)))
+        assert result == [IRInteger(0)]
+
+    def test_degree_1_all_returns_none(self) -> None:
+        """0·u + 0 = 0 → trivially true → None."""
+        result = _solve_poly((Fraction(0), Fraction(0)))
+        assert result is None
+
+    def test_degree_2_two_distinct_roots(self) -> None:
+        """u² − u − 2 = 0 → roots {2, −1}."""
+        # (c=−2, b=−1, a=1) ascending
+        result = _solve_poly((Fraction(-2), Fraction(-1), Fraction(1)))
+        assert result is not None
+        assert len(result) == 2
+        values = {repr(r) for r in result}
+        assert repr(IRInteger(2)) in values or repr(IRInteger(-1)) in values
+
+    def test_degree_2_double_root(self) -> None:
+        """u² − 2u + 1 = 0 → [1]."""
+        result = _solve_poly((Fraction(1), Fraction(-2), Fraction(1)))
+        assert result is not None
+        assert IRInteger(1) in result
+
+    def test_degree_3_runs_without_error(self) -> None:
+        """Degree-3 polynomial delegates to cubic solver (result may vary)."""
+        # u³ − u = 0: (d=0, c=−1, b=0, a=1)
+        result = _solve_poly((Fraction(0), Fraction(-1), Fraction(0), Fraction(1)))
+        assert result is None or isinstance(result, list)
+
+    def test_degree_4_runs_without_error(self) -> None:
+        """Degree-4 polynomial delegates to quartic solver."""
+        # u⁴ − 1 = 0: (e=−1, d=0, c=0, b=0, a=1)
+        result = _solve_poly(
+            (Fraction(-1), Fraction(0), Fraction(0), Fraction(0), Fraction(1))
+        )
+        assert result is None or isinstance(result, list)
+
+    def test_degree_5_returns_none(self) -> None:
+        """Degree > 4 (unsupported) → None."""
+        result = _solve_poly(tuple(Fraction(i) for i in range(7)))
+        assert result is None
+
+
+# ===========================================================================
+# 7. _try_func_eq_const — early-return paths (no bridge)
+# ===========================================================================
+
+
+class TestTryFuncEqConstEarlyReturns:
+    """Paths that return None before reaching the polynomial bridge."""
+
+    def test_const_side_contains_var_returns_none(self) -> None:
+        """If const_side is not constant w.r.t. var, return None."""
+        assert _try_func_eq_const(_sin(X), X, X) is None
+
+    def test_func_side_not_irapply_returns_none(self) -> None:
+        """Plain symbol as func_side → None."""
+        assert _try_func_eq_const(X, IRInteger(0), X) is None
+
+    def test_func_side_non_symbol_head_returns_none(self) -> None:
+        """IRApply with IRApply head (not IRSymbol) → None."""
+        weird = IRApply(IRApply(ADD, (X,)), (X,))
+        assert _try_func_eq_const(weird, IRInteger(0), X) is None
+
+
+# ===========================================================================
+# 8. _try_func_eq_const — solve paths (with mock bridge)
+# ===========================================================================
+
+
+class TestTryFuncEqConst:
+    """Test all function families using the mock polynomial bridge."""
+
+    def test_multi_arg_func_returns_none(self, mock_bridge) -> None:
+        """f(x, y) — two args — → None."""
+        two_arg = IRApply(IRSymbol("Foo"), (X, Y))
+        assert _try_func_eq_const(two_arg, IRInteger(0), X) is None
+
+    def test_extract_linear_fails_returns_none(self, mock_bridge) -> None:
+        """Argument not recognised by mock bridge → None."""
+        # sin(sin(x)) has non-linear argument
+        nested = IRApply(SIN, (_sin(X),))
+        assert _try_func_eq_const(nested, IRInteger(0), X) is None
+
+    def test_sin_equals_zero(self, mock_bridge) -> None:
+        """sin(x) = 0 → two periodic solution families."""
+        result = _try_func_eq_const(_sin(X), IRInteger(0), X)
+        assert result is not None
+        assert len(result) == 2
+        for sol in result:
+            assert isinstance(sol, IRApply)
+
+    def test_cos_equals_one(self, mock_bridge) -> None:
+        """cos(x) = 1 → two periodic solution families."""
+        result = _try_func_eq_const(_cos(X), IRInteger(1), X)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_tan_equals_zero(self, mock_bridge) -> None:
+        """tan(x) = 0 → one periodic family."""
+        result = _try_func_eq_const(
+            IRApply(IRSymbol("Tan"), (X,)), IRInteger(0), X
+        )
+        assert result is not None
+        assert len(result) == 1
+
+    def test_exp_equals_one(self, mock_bridge) -> None:
+        """exp(x) = 1 → unique solution involving Log."""
+        result = _try_func_eq_const(_exp(X), IRInteger(1), X)
+        assert result is not None
+        assert len(result) == 1
+        # Solution = log(1); the outermost node wraps LOG
+        sol = result[0]
+        assert isinstance(sol, IRApply)
+        assert sol.head is LOG
+
+    def test_log_equals_zero(self, mock_bridge) -> None:
+        """log(x) = 0 → unique solution involving Exp."""
+        result = _try_func_eq_const(_log(X), IRInteger(0), X)
+        assert result is not None
+        assert len(result) == 1
+        sol = result[0]
+        assert isinstance(sol, IRApply)
+        assert sol.head is EXP
+
+    def test_sinh_equals_zero(self, mock_bridge) -> None:
+        """sinh(x) = 0 → unique solution involving Asinh."""
+        result = _try_func_eq_const(IRApply(SINH, (X,)), IRInteger(0), X)
+        assert result is not None
+        assert len(result) == 1
+        sol = result[0]
+        assert isinstance(sol, IRApply)
+        assert sol.head is ASINH
+
+    def test_cosh_equals_one(self, mock_bridge) -> None:
+        """cosh(x) = 1 → two branches (±acosh)."""
+        result = _try_func_eq_const(IRApply(COSH, (X,)), IRInteger(1), X)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_tanh_equals_zero(self, mock_bridge) -> None:
+        """tanh(x) = 0 → unique solution involving Atanh."""
+        result = _try_func_eq_const(IRApply(TANH, (X,)), IRInteger(0), X)
+        assert result is not None
+        assert len(result) == 1
+        sol = result[0]
+        assert isinstance(sol, IRApply)
+        assert sol.head is ATANH
+
+    def test_unrecognised_head_returns_none(self, mock_bridge) -> None:
+        """Unknown function head → None."""
+        result = _try_func_eq_const(
+            IRApply(IRSymbol("Zeta"), (X,)), IRInteger(0), X
+        )
+        assert result is None
+
+    def test_scaled_argument_2x(self, mock_bridge) -> None:
+        """sin(2*x) = 0 — mock bridge handles 2*x → two families."""
+        two_x = IRApply(MUL, (IRInteger(2), X))
+        result = _try_func_eq_const(IRApply(SIN, (two_x,)), IRInteger(0), X)
+        assert result is not None
+        assert len(result) == 2
+
+
+# ===========================================================================
+# 9. _try_lambert — Lambert W pattern detector
+# ===========================================================================
+
+
+class TestTryLambert:
+    """_try_lambert: detect f·exp(f) = c and return W-based solution."""
+
+    def test_x_exp_x_equals_one(self, mock_bridge) -> None:
+        """x·exp(x) = 1 → [LambertW(1)]."""
+        product = IRApply(MUL, (X, _exp(X)))
+        result = _try_lambert(product, IRInteger(1), X)
+        assert result is not None
+        assert len(result) == 1
+        sol = result[0]
+        assert isinstance(sol, IRApply)
+        assert sol.head is LAMBERT_W
+
+    def test_exp_x_times_x_commutative(self, mock_bridge) -> None:
+        """exp(x)·x = 1 also matches (factor order is irrelevant)."""
+        product = IRApply(MUL, (_exp(X), X))
+        result = _try_lambert(product, IRInteger(1), X)
+        assert result is not None
+        assert len(result) == 1
+
+    def test_constant_on_left_side(self, mock_bridge) -> None:
+        """1 = x·exp(x) — symmetric dispatch handles both orientations."""
+        product = IRApply(MUL, (X, _exp(X)))
+        result = _try_lambert(IRInteger(1), product, X)
+        assert result is not None
+        assert len(result) == 1
+
+    def test_not_mul_returns_none(self, mock_bridge) -> None:
+        """Non-MUL expression as product side → None."""
+        result = _try_lambert(_sin(X), IRInteger(0), X)
+        assert result is None
+
+    def test_mismatched_inner_args_returns_none(self, mock_bridge) -> None:
+        """x·exp(y) — linear parts don't match — → None."""
+        product = IRApply(MUL, (X, _exp(Y)))
+        result = _try_lambert(product, IRInteger(1), X)
+        assert result is None
+
+    def test_rhs_not_constant_returns_none(self, mock_bridge) -> None:
+        """x·exp(x) = x — rhs is not constant w.r.t. var → None."""
+        product = IRApply(MUL, (X, _exp(X)))
+        result = _try_lambert(product, X, X)
+        assert result is None
+
+
+# ===========================================================================
+# 10. _try_compound — polynomial-in-transcendental substitution
+# ===========================================================================
+
+
+class TestTryCompound:
+    """_try_compound: substitute u = f(x) to reduce to a polynomial."""
+
+    def test_degree1_sin_poly(self) -> None:
+        """u = sin(x), degree-1 poly u = 0 → x = arcsin(0) family."""
+        # Patch poly_coeffs to return (0, 1) → linear in u: u + 0 = 0 → u=0
+        # Patch _extract_linear so the inner sin(x)=0 solve succeeds
+        with patch.object(
+            _mod, "_poly_coeffs", return_value=(Fraction(0), Fraction(1))
+        ), patch.object(
+            _mod,
+            "_extract_linear",
+            return_value=(Fraction(1), Fraction(0)),
+        ):
+            result = _try_compound(_sin(X), IRInteger(0), X)
+
+        assert result is not None
+        assert len(result) >= 1
+
+    def test_degree2_quadratic_sin(self) -> None:
+        """u² + u = 0 (u = sin(x)) → two sub-solutions {0, −1} → solutions."""
+        sin_x = _sin(X)
+        # ADD(MUL(sin_x, sin_x), sin_x) models sin²(x) + sin(x)
+        lhs = IRApply(ADD, (IRApply(MUL, (sin_x, sin_x)), sin_x))
+
+        # (0, 1, 1) means 0 + 1·u + 1·u² → u² + u = 0 → {0, −1}
+        with patch.object(
+            _mod, "_poly_coeffs", return_value=(Fraction(0), Fraction(1), Fraction(1))
+        ), patch.object(
+            _mod,
+            "_extract_linear",
+            return_value=(Fraction(1), Fraction(0)),
+        ):
+            result = _try_compound(lhs, IRInteger(0), X)
+
+        assert result is not None
+        assert len(result) >= 2
+
+    def test_bare_var_returns_none(self) -> None:
+        """Bare x can't be substituted → None."""
+        result = _try_compound(X, IRInteger(0), X)
+        assert result is None
+
+    def test_poly_coeffs_none_falls_through_to_none(self) -> None:
+        """When _poly_coeffs returns None for all heads, return None."""
+        with patch.object(_mod, "_poly_coeffs", return_value=None):
+            result = _try_compound(_sin(X), IRInteger(0), X)
+        assert result is None
+
+
+# ===========================================================================
+# 11. _extract_linear — graceful fallback without bridge
+# ===========================================================================
+
+
+class TestExtractLinear:
+    """_extract_linear returns None gracefully when the bridge is absent."""
+
+    def test_returns_none_without_bridge(self) -> None:
+        """Without symbolic_vm installed, _extract_linear always returns None."""
+        sys.modules.pop("symbolic_vm", None)
+        sys.modules.pop("symbolic_vm.polynomial_bridge", None)
+        assert _extract_linear(X, X) is None
+
+
+# ===========================================================================
+# 12. _poly_coeffs — graceful fallback without bridge
+# ===========================================================================
+
+
+class TestPolyCoeffs:
+    """_poly_coeffs returns None gracefully when the bridge is absent."""
+
+    def test_returns_none_without_bridge(self) -> None:
+        """Without symbolic_vm installed, _poly_coeffs always returns None."""
+        sys.modules.pop("symbolic_vm", None)
+        sys.modules.pop("symbolic_vm.polynomial_bridge", None)
+        assert _poly_coeffs(_sin(X), X) is None
+
+
+# ===========================================================================
+# 13. try_solve_transcendental — public API
+# ===========================================================================
+
+
+class TestTrySolveTranscendental:
+    """Integration tests for the public entry point."""
+
+    def test_returns_none_without_bridge(self) -> None:
+        """Without the polynomial bridge, all sub-dispatchers return None."""
+        sys.modules.pop("symbolic_vm", None)
+        sys.modules.pop("symbolic_vm.polynomial_bridge", None)
+        result = try_solve_transcendental(_eq(_sin(X), IRInteger(0)), X)
+        assert result is None
+
+    def test_bare_expression_treated_as_eq_zero(self, mock_bridge) -> None:
+        """A bare expression (no Equal wrapper) is treated as expr = 0."""
+        result = try_solve_transcendental(_sin(X), X)
+        assert result is not None
+        assert len(result) == 2  # sin(x) = 0 has two periodic families
+
+    def test_equal_node_dispatched(self, mock_bridge) -> None:
+        """Equal(sin(x), 0) → solutions returned."""
+        result = try_solve_transcendental(_eq(_sin(X), IRInteger(0)), X)
+        assert result is not None
+
+    def test_reversed_equal_also_solved(self, mock_bridge) -> None:
+        """Equal(0, sin(x)) — reversed orientation — still returns solutions."""
+        result = try_solve_transcendental(_eq(IRInteger(0), _sin(X)), X)
+        assert result is not None
+
+    def test_exp_eq_const(self, mock_bridge) -> None:
+        """exp(x) = 2 → unique solution involving Log."""
+        result = try_solve_transcendental(_eq(_exp(X), IRInteger(2)), X)
+        assert result is not None
+        assert len(result) == 1
+
+    def test_lambert_w_dispatch(self, mock_bridge) -> None:
+        """x·exp(x) = 1 → Lambert-W solution."""
+        lhs = IRApply(MUL, (X, _exp(X)))
+        result = try_solve_transcendental(_eq(lhs, IRInteger(1)), X)
+        assert result is not None
+        assert len(result) == 1
+        sol = result[0]
+        assert isinstance(sol, IRApply)
+        assert sol.head is LAMBERT_W
+
+    def test_unrecognised_equation_returns_none(self, mock_bridge) -> None:
+        """sin(sin(x)) = 0 — nested composition not handled → None."""
+        eq = _eq(IRApply(SIN, (_sin(X),)), IRInteger(0))
+        result = try_solve_transcendental(eq, X)
+        assert result is None
+
+    def test_equation_free_of_var_returns_none(self, mock_bridge) -> None:
+        """sin(y) = 0, solving for x — x never appears → None."""
+        result = try_solve_transcendental(_eq(_sin(Y), IRInteger(0)), X)
+        assert result is None

--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.17.0 — 2026-05-05
+
+**Phase 26 — Transcendental equation solving via MACSYMA surface syntax.**
+
+Bumps `coding-adventures-symbolic-ir>=0.13.0` and
+`coding-adventures-symbolic-vm>=0.46.0`.
+
+### What changed
+
+- `name_table.py`: imports `LAMBERT_W` from `symbolic_ir>=0.13.0` and adds
+  `"lambert_w": LAMBERT_W` to `MACSYMA_NAME_TABLE`.  MACSYMA users can now
+  call `lambert_w(x)` to invoke the principal Lambert W function W₀(x); the
+  symbolic-vm `lambert_w_handler` evaluates it numerically when `x` is
+  concrete.
+- `solve(eq, var)` now automatically dispatches through the transcendental
+  families (trig, exp/log, Lambert W, hyperbolic, compound substitution) via
+  the updated `symbolic-vm 0.46.0` without any additional runtime changes.
+
+---
+
 ## 1.16.0 — 2026-05-04
 
 **Phase 25 — Symbolic summation and product evaluation via MACSYMA surface syntax.**

--- a/code/packages/python/macsyma-runtime/pyproject.toml
+++ b/code/packages/python/macsyma-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-macsyma-runtime"
-version = "1.16.0"
+version = "1.17.0"
 description = "MACSYMA-specific runtime layer on top of the symbolic VM — history, $/; terminators, kill, ev, name table."
 requires-python = ">=3.12"
 license = "MIT"
@@ -12,8 +12,8 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["macsyma", "maxima", "cas", "symbolic", "runtime", "education"]
 dependencies = [
-    "coding-adventures-symbolic-ir>=0.12.0",
-    "coding-adventures-symbolic-vm>=0.45.0",
+    "coding-adventures-symbolic-ir>=0.13.0",
+    "coding-adventures-symbolic-vm>=0.46.0",
     "coding-adventures-cas-pattern-matching>=0.2.0",
     "coding-adventures-cas-substitution>=0.1.0",
     "coding-adventures-cas-simplify>=0.1.0",

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/name_table.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/name_table.py
@@ -34,6 +34,7 @@ from symbolic_ir import (
     GAMMA_FUNC,
     IFOURIER,
     ILT,
+    LAMBERT_W,
     LAPLACE,
     LI2,
     MATCHDECLARE,
@@ -307,6 +308,10 @@ MACSYMA_NAME_TABLE: dict[str, IRSymbol] = {
     # Fresnel integrals: fresnel_s(x), fresnel_c(x)
     "fresnel_s": FRESNEL_S,
     "fresnel_c": FRESNEL_C,
+    # Lambert W function (Phase 26 — transcendental equation solving)
+    # lambert_w(x) = W₀(x), the principal branch of W satisfying W·exp(W)=x.
+    # Arises in solutions of f(x)·exp(f(x)) = c where f is linear.
+    "lambert_w": LAMBERT_W,
 }
 
 

--- a/code/packages/python/symbolic-ir/CHANGELOG.md
+++ b/code/packages/python/symbolic-ir/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.13.0 — 2026-05-05
+
+**Add 2 transcendental-solving head symbols — Phase 26.**
+
+New `IRSymbol` singletons in `nodes.py`, exported from `__init__.py`:
+
+- `FREE_INTEGER = IRSymbol("FreeInteger")` — the free-integer constant `%k` that
+  appears in periodic solutions of trig equations.  `solve(sin(x)=c,x)` returns
+  solutions containing `FreeInteger` to represent "for all integers k".
+- `LAMBERT_W = IRSymbol("LambertW")` — the principal branch W₀ of the Lambert W
+  function (inverse of `w·exp(w)`).  `solve(x·exp(x)=c,x)` returns `LambertW(c)`.
+  Numerically evaluated by the VM when the argument is a concrete number.
+
+---
+
 ## 0.12.0 — 2026-05-04
 
 **Add 2 summation head symbols — Phase 25 symbolic sum/product.**

--- a/code/packages/python/symbolic-ir/pyproject.toml
+++ b/code/packages/python/symbolic-ir/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-ir"
-version = "0.12.0"
+version = "0.13.0"
 description = "Universal symbolic expression IR — the shared tree representation that every CAS frontend compiles to and every CAS backend consumes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-ir/src/symbolic_ir/__init__.py
+++ b/code/packages/python/symbolic-ir/src/symbolic_ir/__init__.py
@@ -66,6 +66,7 @@ from symbolic_ir.nodes import (
     FOR_EACH,
     FOR_RANGE,
     FORGET,
+    FREE_INTEGER,
     FOURIER,
     FRESNEL_C,
     FRESNEL_S,
@@ -80,6 +81,7 @@ from symbolic_ir.nodes import (
     INTEGRATE,
     INV,
     IS,
+    LAMBERT_W,
     LAPLACE,
     LESS,
     LESS_EQUAL,
@@ -112,6 +114,8 @@ from symbolic_ir.nodes import (
     TAN,
     TANH,
     TELLSIMP,
+    FREE_INTEGER,
+    LAMBERT_W,
     PRODUCT,
     SUM,
     UNIT_STEP,
@@ -234,4 +238,7 @@ __all__ = [
     # Summation and product (Phase 25)
     "SUM",
     "PRODUCT",
+    # Transcendental solving (Phase 26)
+    "FREE_INTEGER",
+    "LAMBERT_W",
 ]

--- a/code/packages/python/symbolic-ir/src/symbolic_ir/nodes.py
+++ b/code/packages/python/symbolic-ir/src/symbolic_ir/nodes.py
@@ -467,3 +467,28 @@ FRESNEL_C = IRSymbol("FresnelC")
 #   Π_{k=a}^{b} c   = c^(b−a+1)          (constant factor)
 SUM = IRSymbol("Sum")
 PRODUCT = IRSymbol("Product")
+
+# ---------------------------------------------------------------------------
+# Phase 26 — Transcendental equation solving
+# ---------------------------------------------------------------------------
+#
+# FREE_INTEGER — the free-integer constant %k that appears in periodic
+# solutions of trigonometric equations:
+#
+#   solve(sin(x) = c, x)  →  [arcsin(c) + 2·%k·π,  π − arcsin(c) + 2·%k·π]
+#
+# %k represents an arbitrary integer parameter (n ∈ ℤ), analogous to how
+# MACSYMA returned solutions with a trailing "+ 2·%pi·%k" to encode all
+# branches of the inverse trig.
+#
+# LAMBERT_W — the principal branch W₀ of the Lambert W function, defined as
+# the inverse of  f(w) = w·exp(w):
+#
+#   LambertW(x·exp(x)) = x   for x ≥ −1
+#
+# Appears in the solution of  x·exp(x) = c  →  x = W(c), and more generally
+#   (ax+b)·exp(ax+b) = c  →  x = (W(c) − b) / a
+#
+# Numeric evaluation: Newton iteration on  w_{n+1} = w_n − (w_n·e^w_n − c)/(e^w_n·(w_n+1))
+FREE_INTEGER = IRSymbol("FreeInteger")
+LAMBERT_W = IRSymbol("LambertW")

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.46.0 — 2026-05-05
+
+**Phase 26 — Transcendental equation solving + Lambert W handler.**
+
+### New handler in `cas_handlers.py`
+
+`lambert_w_handler` evaluates `LambertW(x)` — the principal branch W₀ of the
+Lambert W function — when `x` is a concrete rational or floating-point constant.
+Uses Newton iteration (64 iterations max, quadratic convergence, stopping
+criterion `|Δw| < 1e-12·(1 + |w|)`).  Returns unevaluated for symbolic
+arguments and out-of-domain inputs (`x < −1/e`).
+
+Registered as `"LambertW": lambert_w_handler` in `build_cas_handler_table()`.
+
+### Changes to `solve_handler`
+
+The single-equation `Solve(eq, var)` path now falls through to
+`try_solve_transcendental` from `cas-solve>=0.7.0` before returning
+unevaluated.  This adds five transcendental families:
+
+- **26a — Trigonometric**: `sin/cos/tan(ax+b) = c` → two periodic families with
+  free-integer `%k` (`FreeInteger` IR symbol).
+- **26b — Exponential/Logarithmic**: `exp(ax+b) = c` and `log(ax+b) = c`.
+- **26c — Lambert W**: `f(x)·exp(f(x)) = c` with linear `f` → `LambertW(c)`.
+- **26d — Hyperbolic**: `sinh/cosh/tanh(ax+b) = c` with exact inverse formulas.
+- **26e — Compound substitution**: equations that are polynomials in a single
+  transcendental function of the variable (e.g. `sin²(x) + sin(x) = 0`).
+
+### New imports
+
+`FREE_INTEGER` and `LAMBERT_W` from `symbolic_ir>=0.13.0`;
+`try_solve_transcendental` from `cas_solve>=0.7.0`.
+
+### Dependency bumps
+
+- `symbolic-ir` ≥ 0.13.0 (for `FREE_INTEGER`, `LAMBERT_W`)
+- `cas-solve` ≥ 0.7.0 (for `try_solve_transcendental`)
+
+---
+
 ## 0.45.0 — 2026-05-04
 
 **Phase 25 — Symbolic summation and product evaluation.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.45.0"
+version = "0.46.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -12,7 +12,7 @@ authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
 keywords = ["symbolic", "vm", "interpreter", "cas", "term-rewriting", "education"]
 dependencies = [
-    "coding-adventures-symbolic-ir>=0.12.0",
+    "coding-adventures-symbolic-ir>=0.13.0",
     "coding-adventures-polynomial",
     "coding-adventures-macsyma-parser",
     "coding-adventures-macsyma-compiler",
@@ -20,7 +20,7 @@ dependencies = [
     "coding-adventures-cas-substitution",
     "coding-adventures-cas-simplify>=0.3.0",
     "coding-adventures-cas-factor>=0.3.0",
-    "coding-adventures-cas-solve>=0.6.0",
+    "coding-adventures-cas-solve>=0.7.0",
     "coding-adventures-cas-list-operations",
     "coding-adventures-cas-matrix>=0.3.0",
     "coding-adventures-cas-limit-series>=0.2.0",

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -115,6 +115,7 @@ from cas_solve import nsolve_fraction_poly as _nsolve_fraction_poly
 from cas_solve import solve_cubic as _solve_cubic
 from cas_solve import solve_linear_system as _solve_linear_system
 from cas_solve import solve_quartic as _solve_quartic
+from cas_solve import try_solve_transcendental as _try_transcendental
 from cas_substitution import subst
 from polynomial import (
     degree as _poly_degree,
@@ -1066,6 +1067,10 @@ def solve_handler(_vm: VM, expr: IRApply) -> IRNode:
     poly_ir = _unwrap_equation(eq_ir)
     coeffs = _ir_to_fraction_poly(poly_ir, var_ir)
     if coeffs is None:
+        # Phase 26: try transcendental families before giving up.
+        trans_sols = _try_transcendental(eq_ir, var_ir)
+        if trans_sols is not None:
+            return IRApply(IRSymbol("List"), tuple(trans_sols))
         return expr  # not a polynomial in var
 
     deg = len(coeffs) - 1
@@ -1151,6 +1156,78 @@ def nsolve_handler(_vm: VM, expr: IRApply) -> IRNode:
     coeffs_desc = list(reversed(coeffs))
     ir_roots = _nsolve_fraction_poly(coeffs_desc)
     return IRApply(IRSymbol("List"), tuple(ir_roots))
+
+
+# ===========================================================================
+# Section 4b: Phase 26 — Lambert W numeric evaluation
+# ===========================================================================
+
+
+def lambert_w_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """``LambertW(x)`` — principal branch W₀ of the Lambert W function.
+
+    The Lambert W function W₀ is the principal solution of ``w·exp(w) = x``.
+    It arises when solving equations of the form ``f(x)·exp(f(x)) = c`` where
+    ``f`` is linear — the transcendental solver (Phase 26c) leaves the symbolic
+    ``LambertW(c)`` in the solution expression, and this handler evaluates it
+    numerically when ``x`` is a concrete rational or floating-point constant.
+
+    Domain for the principal branch W₀:
+    - Defined for ``x ≥ −1/e ≈ −0.3679``.
+    - Returns ``IRFloat`` on success.
+    - Returns the expression unevaluated for symbolic ``x`` or ``x`` outside
+      the domain of W₀.
+
+    Numeric method: Newton iteration on ``g(w) = w·exp(w) − x``.
+    The iteration ``w ← w − g(w)/g′(w)`` converges quadratically; we stop when
+    ``|Δw| < 1e-12·(1 + |w|)`` or after 64 iterations, whichever comes first.
+
+    Starting point heuristic:
+    - ``x > 0``: start at ``log(x)`` (correct order of magnitude).
+    - ``x = 0``: start at 0 (exact answer).
+    - ``−1/e ≤ x < 0``: start at 0 and let Newton iterate toward the branch.
+
+    Examples::
+
+        LambertW(0)       → 0.0          (W₀(0) = 0)
+        LambertW(1)       → 0.5671...    (Omega constant)
+        LambertW(e)       → 1.0          (W₀(e) = 1)
+        LambertW(-1/e)    → -1.0         (branch point)
+    """
+    if len(expr.args) != 1:
+        return expr
+    arg = expr.args[0]
+    x_num = to_number(arg)
+    if x_num is None:
+        # Symbolic argument — leave unevaluated.
+        return expr
+
+    # to_number returns a Fraction for rational inputs; convert to float.
+    x_val = float(x_num)
+
+    # Domain check: W₀ is defined only for x ≥ −1/e.
+    lower_bound = -1.0 / math.e
+    if x_val < lower_bound - 1e-12:
+        # Out of domain for the principal branch — return unevaluated.
+        return expr
+
+    # Choose a sensible starting point for Newton iteration.
+    # log(x) is a good initial estimate for x > 0; 0.0 works near the branch point.
+    w = math.log(x_val) if x_val > 0.0 else 0.0
+
+    # Newton iteration: w ← w − (w·exp(w) − x) / (exp(w)·(w + 1))
+    # Guard against zero denominator at w = −1 with a tiny epsilon.
+    _EPS = 1e-300
+    for _ in range(64):
+        ew = math.exp(w)
+        numerator = w * ew - x_val
+        denominator = ew * (w + 1.0) + _EPS
+        dw = numerator / denominator
+        w -= dw
+        if abs(dw) < 1e-12 * (1.0 + abs(w)):
+            break
+
+    return IRFloat(w)
 
 
 # ===========================================================================
@@ -2737,6 +2814,8 @@ def build_cas_handler_table() -> dict[str, Handler]:
         # --- Phase 25: symbolic summation and product -----------------------
         "Sum": sum_handler,
         "Product": product_handler,
+        # --- Phase 26: Lambert W numeric evaluation -------------------------
+        "LambertW": lambert_w_handler,
     }
 
 

--- a/code/packages/python/symbolic-vm/tests/test_phase26.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase26.py
@@ -1,0 +1,948 @@
+"""Phase 26 — Transcendental Equation Solving tests.
+
+Covers:
+  26a — Trigonometric:           sin/cos/tan(ax+b) = c → periodic families
+  26b — Exponential/logarithmic: exp/log(ax+b) = c → unique inverse
+  26c — Lambert W:               f(x)·exp(f(x)) = c → W₀(c)
+  26d — Hyperbolic:              sinh/cosh/tanh(ax+b) = c → exact inverse
+  26e — Compound:                polynomial in a single transcendental function
+  LambertW numeric handler — IRFloat evaluation for concrete arguments
+
+Test structure
+--------------
+TestPhase26_Trig            — sin/cos/tan (26a)
+TestPhase26_TrigShifted     — sin/cos/tan with a ≠ 1 or b ≠ 0
+TestPhase26_ExpLog          — exp/log (26b)
+TestPhase26_LambertW        — Lambert W pattern (26c)
+TestPhase26_Hyperbolic      — sinh/cosh/tanh (26d)
+TestPhase26_Compound        — compound poly-in-transcendental (26e)
+TestPhase26_LambertWHandler — numeric LambertW handler
+TestPhase26_Fallthrough     — unevaluated (no pattern matched)
+TestPhase26_Regressions     — Phase 1-25 operations still work
+TestPhase26_Macsyma         — end-to-end MACSYMA surface-syntax tests
+
+Verification strategy
+---------------------
+Transcendental solutions involve ``FreeInteger`` (``%k``) for the periodic
+families and symbolic inverse functions (``Asin``, ``LambertW``, …) for the
+rest.  We verify by:
+
+1. **Structure checks** — assert the result is a ``List`` with the correct
+   number of solutions, the right IR heads appear, etc.
+2. **Numeric back-substitution** — evaluate each solution to float (setting
+   ``FreeInteger = 0``) and confirm that plugging it back satisfies the
+   original equation within 1e-9 tolerance.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from symbolic_ir import (
+    ADD,
+    COS,
+    COSH,
+    EXP,
+    FREE_INTEGER,
+    INTEGRATE,
+    LOG,
+    MUL,
+    POW,
+    SIN,
+    SINH,
+    TANH,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.backends import SymbolicBackend
+from symbolic_vm.vm import VM
+
+# ---------------------------------------------------------------------------
+# Shared symbols
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+Y = IRSymbol("y")
+EQUAL = IRSymbol("Equal")
+SOLVE = IRSymbol("Solve")
+LIST = IRSymbol("List")
+_PI = IRSymbol("%pi")
+_K = FREE_INTEGER
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_vm() -> VM:
+    """Fresh symbolic VM."""
+    return VM(SymbolicBackend())
+
+
+def _solve(eq_ir: IRNode, var: IRSymbol) -> IRNode:
+    """Evaluate ``Solve(eq_ir, var)`` and return the result."""
+    return _make_vm().eval(IRApply(SOLVE, (eq_ir, var)))
+
+
+def _eq(lhs: IRNode, rhs: IRNode) -> IRNode:
+    """Construct ``Equal(lhs, rhs)``."""
+    return IRApply(EQUAL, (lhs, rhs))
+
+
+def _is_list(node: IRNode) -> bool:
+    return (
+        isinstance(node, IRApply)
+        and isinstance(node.head, IRSymbol)
+        and node.head.name == "List"
+    )
+
+
+def _list_args(node: IRNode) -> tuple[IRNode, ...]:
+    assert _is_list(node), f"expected List, got {node!r}"
+    return node.args  # type: ignore[return-value]
+
+
+def _eval_ir(node: IRNode, k: int = 0) -> float | None:
+    """Recursively evaluate an IR tree to float.
+
+    ``FreeInteger`` (the periodic constant %k) is substituted with ``k``.
+    Returns ``None`` if the tree cannot be fully evaluated.
+
+    Handles: IRInteger, IRRational, IRFloat, IRSymbol (%pi, %e, FreeInteger),
+    and IRApply with arithmetic / trig / hyperbolic / inverse heads.
+    """
+    if isinstance(node, IRInteger):
+        return float(node.value)
+    if isinstance(node, IRRational):
+        return node.numer / node.denom
+    if isinstance(node, IRFloat):
+        return node.value
+    if isinstance(node, IRSymbol):
+        if node.name == "%pi":
+            return math.pi
+        if node.name == "%e":
+            return math.e
+        if node.name == "FreeInteger":
+            return float(k)
+        return None
+
+    if not isinstance(node, IRApply):
+        return None
+
+    head = node.head
+    if not isinstance(head, IRSymbol):
+        return None
+
+    args = [_eval_ir(a, k) for a in node.args]
+    if any(a is None for a in args):
+        return None
+
+    n = head.name
+    a0 = args[0] if args else None
+    a1 = args[1] if len(args) > 1 else None
+
+    # Arithmetic
+    if n == "Add":
+        s = 0.0
+        for a in args:
+            s += a  # type: ignore[operator]
+        return s
+    if n == "Sub" and len(args) == 2:
+        return a0 - a1  # type: ignore[operator]
+    if n == "Mul":
+        p = 1.0
+        for a in args:
+            p *= a  # type: ignore[operator]
+        return p
+    if n == "Div" and len(args) == 2:
+        if a1 == 0.0:
+            return None
+        return a0 / a1  # type: ignore[operator]
+    if n == "Neg" and len(args) == 1:
+        return -a0  # type: ignore[operator]
+    if n == "Pow" and len(args) == 2:
+        return a0 ** a1  # type: ignore[operator]
+
+    # Trig / inverse trig
+    if n == "Sin" and len(args) == 1:
+        return math.sin(a0)  # type: ignore[arg-type]
+    if n == "Cos" and len(args) == 1:
+        return math.cos(a0)  # type: ignore[arg-type]
+    if n == "Tan" and len(args) == 1:
+        return math.tan(a0)  # type: ignore[arg-type]
+    if n == "Asin" and len(args) == 1:
+        return math.asin(max(-1.0, min(1.0, a0)))  # type: ignore[arg-type]
+    if n == "Acos" and len(args) == 1:
+        return math.acos(max(-1.0, min(1.0, a0)))  # type: ignore[arg-type]
+    if n == "Atan" and len(args) == 1:
+        return math.atan(a0)  # type: ignore[arg-type]
+
+    # Exponential / log
+    if n == "Exp" and len(args) == 1:
+        return math.exp(a0)  # type: ignore[arg-type]
+    if n == "Log" and len(args) == 1:
+        if a0 <= 0:  # type: ignore[operator]
+            return None
+        return math.log(a0)  # type: ignore[arg-type]
+
+    # Hyperbolic / inverse hyperbolic
+    if n == "Sinh" and len(args) == 1:
+        return math.sinh(a0)  # type: ignore[arg-type]
+    if n == "Cosh" and len(args) == 1:
+        return math.cosh(a0)  # type: ignore[arg-type]
+    if n == "Tanh" and len(args) == 1:
+        return math.tanh(a0)  # type: ignore[arg-type]
+    if n == "Asinh" and len(args) == 1:
+        return math.asinh(a0)  # type: ignore[arg-type]
+    if n == "Acosh" and len(args) == 1:
+        if a0 < 1.0:  # type: ignore[operator]
+            return None
+        return math.acosh(a0)  # type: ignore[arg-type]
+    if n == "Atanh" and len(args) == 1:
+        if abs(a0) >= 1.0:  # type: ignore[arg-type]
+            return None
+        return math.atanh(a0)  # type: ignore[arg-type]
+
+    # Lambert W
+    if n == "LambertW" and len(args) == 1:
+        # Newton iteration (same logic as lambert_w_handler)
+        x_val = a0  # type: ignore[assignment]
+        if x_val < -1.0 / math.e - 1e-12:  # type: ignore[operator]
+            return None
+        w = math.log(x_val) if x_val > 0 else 0.0  # type: ignore[arg-type]
+        for _ in range(64):
+            ew = math.exp(w)
+            dw = (w * ew - x_val) / (ew * (w + 1) + 1e-300)  # type: ignore[operator]
+            w -= dw
+            if abs(dw) < 1e-12 * (1 + abs(w)):
+                break
+        return w
+
+    return None
+
+
+def _check_trig(
+    func_name: str,
+    c_val: float,
+    sol_node: IRNode,
+    k: int = 0,
+    tol: float = 1e-9,
+) -> bool:
+    """Check that ``func(sol_node(k)) ≈ c_val``."""
+    x_val = _eval_ir(sol_node, k=k)
+    if x_val is None:
+        return False
+    func_map = {"Sin": math.sin, "Cos": math.cos, "Tan": math.tan}
+    f = func_map.get(func_name)
+    if f is None:
+        return False
+    return abs(f(x_val) - c_val) <= tol
+
+
+def _check_hyp(
+    func_name: str,
+    c_val: float,
+    sol_node: IRNode,
+    tol: float = 1e-9,
+) -> bool:
+    """Check that ``hypfunc(sol_node) ≈ c_val``."""
+    x_val = _eval_ir(sol_node, k=0)
+    if x_val is None:
+        return False
+    func_map = {"Sinh": math.sinh, "Cosh": math.cosh, "Tanh": math.tanh}
+    f = func_map.get(func_name)
+    if f is None:
+        return False
+    return abs(f(x_val) - c_val) <= tol
+
+
+def _contains_head(node: IRNode, head_name: str) -> bool:
+    """Return True if ``node`` or any sub-node has the given head name."""
+    if isinstance(node, IRApply):
+        if isinstance(node.head, IRSymbol) and node.head.name == head_name:
+            return True
+        return any(_contains_head(a, head_name) for a in node.args)
+    return False
+
+
+def _contains_free_integer(node: IRNode) -> bool:
+    if isinstance(node, IRSymbol) and node.name == "FreeInteger":
+        return True
+    if isinstance(node, IRApply):
+        return any(_contains_free_integer(a) for a in node.args)
+    return False
+
+
+# ===========================================================================
+# 1. Trigonometric — 26a: sin/cos/tan(x) = c
+# ===========================================================================
+
+
+class TestPhase26_Trig:
+    """26a — periodic families: sin(x)=c, cos(x)=c, tan(x)=c."""
+
+    def test_sin_x_eq_zero(self):
+        """sin(x) = 0 → two solutions with FreeInteger."""
+        result = _solve(_eq(IRApply(SIN, (X,)), IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        # Both solutions should contain FreeInteger
+        assert all(_contains_free_integer(s) for s in sols)
+        # At k=0: sin(0)=0 and sin(pi)=0
+        assert _check_trig("Sin", 0.0, sols[0], k=0)
+        assert _check_trig("Sin", 0.0, sols[1], k=0)
+
+    def test_sin_x_eq_half(self):
+        """sin(x) = 1/2 → arcsin(1/2) family."""
+        result = _solve(_eq(IRApply(SIN, (X,)), IRRational(1, 2)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _check_trig("Sin", 0.5, sols[0], k=0)
+        assert _check_trig("Sin", 0.5, sols[1], k=0)
+        # k=1 should also satisfy (next period)
+        assert _check_trig("Sin", 0.5, sols[0], k=1)
+
+    def test_sin_x_eq_neg_one(self):
+        """sin(x) = -1 → x = -pi/2 + 2k*pi."""
+        result = _solve(_eq(IRApply(SIN, (X,)), IRInteger(-1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _check_trig("Sin", -1.0, sols[0], k=0)
+        assert _check_trig("Sin", -1.0, sols[1], k=0)
+
+    def test_cos_x_eq_zero(self):
+        """cos(x) = 0 → pi/2 + 2k*pi and -pi/2 + 2k*pi."""
+        result = _solve(_eq(IRApply(COS, (X,)), IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _check_trig("Cos", 0.0, sols[0], k=0)
+        assert _check_trig("Cos", 0.0, sols[1], k=0)
+
+    def test_cos_x_eq_half(self):
+        """cos(x) = 1/2 → arccos(1/2) family."""
+        result = _solve(_eq(IRApply(COS, (X,)), IRRational(1, 2)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _check_trig("Cos", 0.5, sols[0], k=0)
+        assert _check_trig("Cos", 0.5, sols[1], k=0)
+
+    def test_cos_x_eq_one(self):
+        """cos(x) = 1 → 0 + 2k*pi (double family reduces to same)."""
+        result = _solve(_eq(IRApply(COS, (X,)), IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _check_trig("Cos", 1.0, sols[0], k=0)
+        assert _check_trig("Cos", 1.0, sols[1], k=0)
+
+    def test_tan_x_eq_zero(self):
+        """tan(x) = 0 → k*pi family (single solution family)."""
+        result = _solve(_eq(IRApply(IRSymbol("Tan"), (X,)), IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _check_trig("Tan", 0.0, sols[0], k=0)
+        assert _check_trig("Tan", 0.0, sols[0], k=1)
+
+    def test_tan_x_eq_one(self):
+        """tan(x) = 1 → pi/4 + k*pi."""
+        result = _solve(_eq(IRApply(IRSymbol("Tan"), (X,)), IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _check_trig("Tan", 1.0, sols[0], k=0)
+        assert _check_trig("Tan", 1.0, sols[0], k=1)
+
+    def test_sin_solution_contains_asin(self):
+        """sin(x)=c solution must reference arcsin."""
+        result = _solve(_eq(IRApply(SIN, (X,)), IRRational(1, 3)), X)
+        sols = _list_args(result)
+        assert any(_contains_head(s, "Asin") for s in sols)
+
+    def test_cos_solution_contains_acos(self):
+        """cos(x)=c solution must reference arccos."""
+        result = _solve(_eq(IRApply(COS, (X,)), IRRational(1, 4)), X)
+        sols = _list_args(result)
+        assert any(_contains_head(s, "Acos") for s in sols)
+
+    def test_tan_solution_contains_atan(self):
+        """tan(x)=c solution must reference arctan."""
+        result = _solve(_eq(IRApply(IRSymbol("Tan"), (X,)), IRInteger(2)), X)
+        sols = _list_args(result)
+        assert _contains_head(sols[0], "Atan")
+
+
+# ===========================================================================
+# 2. Trigonometric with shifted / scaled argument — 26a
+# ===========================================================================
+
+
+class TestPhase26_TrigShifted:
+    """26a — trig with linear argument ax+b (a≠1 or b≠0)."""
+
+    def test_sin_2x_eq_one(self):
+        """sin(2x) = 1 → x = (pi/2 + 2k*pi)/2."""
+        arg = IRApply(MUL, (IRInteger(2), X))
+        result = _solve(_eq(IRApply(SIN, (arg,)), IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        for s in sols:
+            x_val = _eval_ir(s, k=0)
+            assert x_val is not None
+            assert abs(math.sin(2 * x_val) - 1.0) < 1e-9
+
+    def test_cos_x_plus_rational_eq_zero(self):
+        """cos(x + 1) = 0 → x = acos(0) - 1 + 2k*pi (rational offset)."""
+        arg = IRApply(ADD, (X, IRInteger(1)))
+        result = _solve(_eq(IRApply(COS, (arg,)), IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        for s in sols:
+            x_val = _eval_ir(s, k=0)
+            assert x_val is not None
+            assert abs(math.cos(x_val + 1.0) - 0.0) < 1e-9
+
+    def test_sin_half_x_eq_half(self):
+        """sin(x/2) = 1/2 → x = 2*arcsin(1/2) + 4k*pi."""
+        arg = IRApply(MUL, (IRRational(1, 2), X))
+        result = _solve(_eq(IRApply(SIN, (arg,)), IRRational(1, 2)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        for s in sols:
+            x_val = _eval_ir(s, k=0)
+            assert x_val is not None
+            assert abs(math.sin(x_val / 2) - 0.5) < 1e-9
+
+
+# ===========================================================================
+# 3. Exponential / Logarithmic — 26b
+# ===========================================================================
+
+
+class TestPhase26_ExpLog:
+    """26b — exp(ax+b) = c and log(ax+b) = c."""
+
+    def test_exp_x_eq_one(self):
+        """exp(x) = 1 → x = log(1) = 0."""
+        result = _solve(_eq(IRApply(EXP, (X,)), IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None
+        assert abs(math.exp(x_val) - 1.0) < 1e-9
+
+    def test_exp_x_eq_two(self):
+        """exp(x) = 2 → x = log(2)."""
+        result = _solve(_eq(IRApply(EXP, (X,)), IRInteger(2)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None
+        assert abs(math.exp(x_val) - 2.0) < 1e-9
+
+    def test_exp_2x_eq_four(self):
+        """exp(2x) = 4 → x = log(4)/2."""
+        arg = IRApply(MUL, (IRInteger(2), X))
+        result = _solve(_eq(IRApply(EXP, (arg,)), IRInteger(4)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None
+        assert abs(math.exp(2 * x_val) - 4.0) < 1e-9
+
+    def test_exp_solution_contains_log(self):
+        """exp(x)=c solution must contain a Log node."""
+        result = _solve(_eq(IRApply(EXP, (X,)), IRInteger(3)), X)
+        sols = _list_args(result)
+        assert _contains_head(sols[0], "Log")
+
+    def test_log_x_eq_one(self):
+        """log(x) = 1 → x = exp(1) = e."""
+        result = _solve(_eq(IRApply(LOG, (X,)), IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None
+        assert abs(math.log(x_val) - 1.0) < 1e-9
+
+    def test_log_x_eq_zero(self):
+        """log(x) = 0 → x = exp(0) = 1."""
+        result = _solve(_eq(IRApply(LOG, (X,)), IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None
+        assert abs(math.log(x_val) - 0.0) < 1e-9
+
+    def test_log_solution_contains_exp(self):
+        """log(x)=c solution must contain an Exp node."""
+        result = _solve(_eq(IRApply(LOG, (X,)), IRInteger(2)), X)
+        sols = _list_args(result)
+        assert _contains_head(sols[0], "Exp")
+
+
+# ===========================================================================
+# 4. Lambert W — 26c
+# ===========================================================================
+
+
+class TestPhase26_LambertW:
+    """26c — f(x)·exp(f(x)) = c where f is linear."""
+
+    def test_x_exp_x_eq_one(self):
+        """x·exp(x) = 1 → x = W(1) ≈ 0.5671."""
+        x_exp_x = IRApply(MUL, (X, IRApply(EXP, (X,))))
+        result = _solve(_eq(x_exp_x, IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        # Solution must contain LambertW
+        assert _contains_head(sols[0], "LambertW")
+
+    def test_x_exp_x_eq_zero(self):
+        """x·exp(x) = 0 → x = W(0) = 0."""
+        x_exp_x = IRApply(MUL, (X, IRApply(EXP, (X,))))
+        result = _solve(_eq(x_exp_x, IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _contains_head(sols[0], "LambertW")
+
+    def test_x_exp_x_eq_e(self):
+        """x·exp(x) = e → x = W(e) = 1."""
+        x_exp_x = IRApply(MUL, (X, IRApply(EXP, (X,))))
+        e_sym = IRSymbol("%e")
+        result = _solve(_eq(x_exp_x, e_sym), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _contains_head(sols[0], "LambertW")
+
+    def test_exp_first_then_linear(self):
+        """exp(x)·x = 2 (commuted MUL) → x = W(2)."""
+        # Argument order reversed: Mul(Exp(x), x) instead of Mul(x, Exp(x))
+        exp_x_times_x = IRApply(MUL, (IRApply(EXP, (X,)), X))
+        result = _solve(_eq(exp_x_times_x, IRInteger(2)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _contains_head(sols[0], "LambertW")
+
+
+# ===========================================================================
+# 5. Hyperbolic — 26d
+# ===========================================================================
+
+
+class TestPhase26_Hyperbolic:
+    """26d — sinh/cosh/tanh with linear argument."""
+
+    def test_sinh_x_eq_zero(self):
+        """sinh(x) = 0 → x = asinh(0) = 0."""
+        result = _solve(_eq(IRApply(SINH, (X,)), IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _check_hyp("Sinh", 0.0, sols[0])
+
+    def test_sinh_x_eq_one(self):
+        """sinh(x) = 1 → x = asinh(1)."""
+        result = _solve(_eq(IRApply(SINH, (X,)), IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _check_hyp("Sinh", 1.0, sols[0])
+        assert _contains_head(sols[0], "Asinh")
+
+    def test_cosh_x_eq_one(self):
+        """cosh(x) = 1 → x = ±acosh(1) = ±0 = 0 (both branches)."""
+        result = _solve(_eq(IRApply(COSH, (X,)), IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        for s in sols:
+            assert _check_hyp("Cosh", 1.0, s)
+
+    def test_cosh_x_eq_two(self):
+        """cosh(x) = 2 → two branches: acosh(2) and -acosh(2)."""
+        result = _solve(_eq(IRApply(COSH, (X,)), IRInteger(2)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        for s in sols:
+            assert _check_hyp("Cosh", 2.0, s)
+        x_vals = [_eval_ir(s) for s in sols]
+        # The two values should be negatives of each other
+        assert x_vals[0] is not None and x_vals[1] is not None
+        assert abs(x_vals[0] + x_vals[1]) < 1e-9  # type: ignore[operator]
+
+    def test_tanh_x_eq_zero(self):
+        """tanh(x) = 0 → x = atanh(0) = 0."""
+        result = _solve(_eq(IRApply(TANH, (X,)), IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _check_hyp("Tanh", 0.0, sols[0])
+
+    def test_tanh_x_eq_half(self):
+        """tanh(x) = 1/2 → x = atanh(1/2) ≈ 0.549."""
+        result = _solve(_eq(IRApply(TANH, (X,)), IRRational(1, 2)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _check_hyp("Tanh", 0.5, sols[0])
+        assert _contains_head(sols[0], "Atanh")
+
+    def test_sinh_two_x_eq_one(self):
+        """sinh(2x) = 1 → x = asinh(1)/2."""
+        arg = IRApply(MUL, (IRInteger(2), X))
+        result = _solve(_eq(IRApply(SINH, (arg,)), IRInteger(1)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None
+        assert abs(math.sinh(2 * x_val) - 1.0) < 1e-9
+
+
+# ===========================================================================
+# 6. Compound — 26e: polynomial in a single transcendental function
+# ===========================================================================
+
+
+class TestPhase26_Compound:
+    """26e — equations that are polynomials in a transcendental substitution."""
+
+    def test_sin2_plus_sin_eq_zero(self):
+        """sin(x)^2 + sin(x) = 0 → 4 solutions (u∈{-1,0}, each gives 2)."""
+        sin_x = IRApply(SIN, (X,))
+        lhs = IRApply(ADD, (IRApply(POW, (sin_x, IRInteger(2))), sin_x))
+        result = _solve(_eq(lhs, IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 4
+        # All solutions satisfy the equation
+        for s in sols:
+            x_val = _eval_ir(s, k=0)
+            assert x_val is not None
+            val = math.sin(x_val) ** 2 + math.sin(x_val)
+            assert abs(val) < 1e-9
+
+    def test_sin2_minus_sin_eq_zero(self):
+        """sin(x)^2 - sin(x) = 0 → u∈{0,1} → 4 solutions."""
+        sin_x = IRApply(SIN, (X,))
+        neg_sin = IRApply(IRSymbol("Neg"), (sin_x,))
+        lhs = IRApply(ADD, (IRApply(POW, (sin_x, IRInteger(2))), neg_sin))
+        result = _solve(_eq(lhs, IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) >= 2  # at minimum the u=0 solutions
+
+    def test_exp2_minus_3exp_plus_2_eq_zero(self):
+        """exp(x)^2 - 3*exp(x) + 2 = 0 → u∈{1,2} → x∈{0, log(2)}."""
+        exp_x = IRApply(EXP, (X,))
+        # exp(x)^2 - 3*exp(x) + 2
+        lhs = IRApply(ADD, (
+            IRApply(ADD, (
+                IRApply(IRSymbol("Pow"), (exp_x, IRInteger(2))),
+                IRApply(IRSymbol("Neg"), (IRApply(MUL, (IRInteger(3), exp_x)),)),
+            )),
+            IRInteger(2),
+        ))
+        result = _solve(_eq(lhs, IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        # x=0 (exp(0)=1) and x=log(2) (exp(log(2))=2)
+        x_vals = sorted(_eval_ir(s) for s in sols if _eval_ir(s) is not None)
+        assert len(x_vals) == 2
+        assert abs(x_vals[0] - 0.0) < 1e-9
+        assert abs(x_vals[1] - math.log(2)) < 1e-9
+
+
+# ===========================================================================
+# 7. LambertW numeric handler
+# ===========================================================================
+
+
+class TestPhase26_LambertWHandler:
+    """Numeric evaluation of LambertW(x) via lambert_w_handler."""
+
+    _LW = IRSymbol("LambertW")
+
+    def _eval_lw(self, x_ir: IRNode) -> IRNode:
+        return _make_vm().eval(IRApply(self._LW, (x_ir,)))
+
+    def test_lambert_w_zero(self):
+        """LambertW(0) = 0."""
+        result = self._eval_lw(IRInteger(0))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - 0.0) < 1e-9
+
+    def test_lambert_w_one(self):
+        """LambertW(1) = Omega ≈ 0.5671432904097838."""
+        result = self._eval_lw(IRInteger(1))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - 0.5671432904097838) < 1e-9
+
+    def test_lambert_w_e(self):
+        """LambertW(e) = 1 (since 1·exp(1)=e).
+
+        to_number cannot evaluate the symbolic ``%e`` constant, so we
+        supply the numeric value directly via ``IRFloat``.
+        """
+        result = self._eval_lw(IRFloat(math.e))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - 1.0) < 1e-9
+
+    def test_lambert_w_rational(self):
+        """LambertW(1/2) ≈ 0.3517..."""
+        result = self._eval_lw(IRRational(1, 2))
+        assert isinstance(result, IRFloat)
+        # W(0.5)·exp(W(0.5)) ≈ 0.5
+        assert abs(result.value * math.exp(result.value) - 0.5) < 1e-9
+
+    def test_lambert_w_negative_in_domain(self):
+        """LambertW(-1/(2e)) is in domain (>=-1/e)."""
+        arg = IRFloat(-1.0 / (2 * math.e))
+        result = self._eval_lw(arg)
+        assert isinstance(result, IRFloat)
+        # Verify: w·exp(w) ≈ -1/(2e)
+        w = result.value
+        assert abs(w * math.exp(w) - (-1.0 / (2 * math.e))) < 1e-9
+
+    def test_lambert_w_out_of_domain(self):
+        """LambertW(-2) is out of domain → unevaluated."""
+        result = self._eval_lw(IRFloat(-2.0))
+        # Should return unevaluated IRApply
+        assert isinstance(result, IRApply)
+        assert isinstance(result.head, IRSymbol) and result.head.name == "LambertW"
+
+    def test_lambert_w_symbolic_arg(self):
+        """LambertW(x) with symbolic x → unevaluated."""
+        result = self._eval_lw(X)
+        assert isinstance(result, IRApply)
+
+    def test_lambert_w_large(self):
+        """LambertW(100) should satisfy w·exp(w) ≈ 100."""
+        result = self._eval_lw(IRInteger(100))
+        assert isinstance(result, IRFloat)
+        w = result.value
+        assert abs(w * math.exp(w) - 100.0) < 1e-6
+
+
+# ===========================================================================
+# 8. Fallthrough — unevaluated cases
+# ===========================================================================
+
+
+class TestPhase26_Fallthrough:
+    """Equations that should return unevaluated (no pattern matched)."""
+
+    def _is_unevaluated_solve(self, node: IRNode) -> bool:
+        return (
+            isinstance(node, IRApply)
+            and isinstance(node.head, IRSymbol)
+            and node.head.name == "Solve"
+        )
+
+    def test_sin_of_quadratic_unevaluated(self):
+        """sin(x^2) = 0 is not linear in argument → unevaluated."""
+        x_sq = IRApply(IRSymbol("Pow"), (X, IRInteger(2)))
+        result = _solve(_eq(IRApply(SIN, (x_sq,)), IRInteger(0)), X)
+        # Non-linear argument; no compound pattern applies → unevaluated
+        assert self._is_unevaluated_solve(result)
+
+    def test_sin_x_plus_cos_x_unevaluated(self):
+        """sin(x) + cos(x) = 0 — compound pattern can't reduce to single func."""
+        lhs = IRApply(ADD, (IRApply(SIN, (X,)), IRApply(COS, (X,))))
+        result = _solve(_eq(lhs, IRInteger(0)), X)
+        # Mixed transcendental → unevaluated
+        assert self._is_unevaluated_solve(result)
+
+    def test_high_degree_poly_unevaluated(self):
+        """x^5 + x + 1 = 0 — degree > 4 → still unevaluated."""
+        lhs = IRApply(ADD, (
+            IRApply(ADD, (IRApply(POW, (X, IRInteger(5))), X)),
+            IRInteger(1),
+        ))
+        result = _solve(_eq(lhs, IRInteger(0)), X)
+        assert self._is_unevaluated_solve(result)
+
+
+# ===========================================================================
+# 9. Regressions — earlier phase operations still work
+# ===========================================================================
+
+
+class TestPhase26_Regressions:
+    """Smoke tests that prior-phase functionality is unbroken."""
+
+    def test_linear_solve(self):
+        """Phase 1 regression: Solve(2x + 4 = 0, x) = -2."""
+        lhs = IRApply(ADD, (IRApply(MUL, (IRInteger(2), X)), IRInteger(4)))
+        result = _solve(_eq(lhs, IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None and abs(x_val + 2.0) < 1e-12
+
+    def test_quadratic_solve(self):
+        """Phase 1 regression: Solve(x^2 - 5x + 6 = 0, x) = {2, 3}."""
+        # x^2 - 5x + 6
+        lhs = IRApply(ADD, (
+            IRApply(ADD, (
+                IRApply(POW, (X, IRInteger(2))),
+                IRApply(IRSymbol("Neg"), (IRApply(MUL, (IRInteger(5), X)),)),
+            )),
+            IRInteger(6),
+        ))
+        result = _solve(_eq(lhs, IRInteger(0)), X)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        x_vals = sorted(_eval_ir(s) for s in sols if _eval_ir(s) is not None)
+        assert abs(x_vals[0] - 2.0) < 1e-9
+        assert abs(x_vals[1] - 3.0) < 1e-9
+
+    def test_lambert_w_handler_not_broken(self):
+        """LambertW(0) still returns 0.0 after Phase 26."""
+        result = _make_vm().eval(IRApply(IRSymbol("LambertW"), (IRInteger(0),)))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value) < 1e-12
+
+    def test_integrate_not_broken(self):
+        """Phase 14 regression: Integrate(x^2, x) returns something."""
+        expr = IRApply(INTEGRATE, (IRApply(POW, (X, IRInteger(2))), X))
+        result = _make_vm().eval(expr)
+        # Should be evaluated (not the bare Integrate expression)
+        if isinstance(result, IRApply):
+            assert result.head != INTEGRATE
+
+
+# ===========================================================================
+# 10. MACSYMA surface-syntax tests
+# ===========================================================================
+
+
+class TestPhase26_Macsyma:
+    """End-to-end tests via the MACSYMA compiler + runtime stack."""
+
+    def _run(self, src: str) -> IRNode:
+        pytest.importorskip(
+            "macsyma_runtime",
+            reason="macsyma-runtime not installed; skipping MACSYMA e2e test",
+        )
+        from macsyma_compiler.compiler import (  # noqa: PLC0415
+            _STANDARD_FUNCTIONS,
+            compile_macsyma,
+        )
+        from macsyma_parser.parser import parse_macsyma  # noqa: PLC0415
+        from macsyma_runtime.name_table import (  # noqa: PLC0415
+            extend_compiler_name_table,
+        )
+
+        extend_compiler_name_table(_STANDARD_FUNCTIONS)
+        stmts = compile_macsyma(parse_macsyma(src + ";"))
+        return _make_vm().eval_program(stmts)
+
+    def test_macsyma_solve_sin(self):
+        """solve(sin(x) = 0, x) returns a two-element List."""
+        result = self._run("solve(sin(x) = 0, x)")
+        assert _is_list(result)
+        assert len(_list_args(result)) == 2
+
+    def test_macsyma_solve_exp(self):
+        """solve(exp(x) = 1, x) returns List(Log(1)) = List(0)."""
+        result = self._run("solve(exp(x) = 1, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None and abs(math.exp(x_val) - 1.0) < 1e-9
+
+    def test_macsyma_solve_log(self):
+        """solve(log(x) = 1, x) returns List(exp(1))."""
+        result = self._run("solve(log(x) = 1, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None and abs(math.log(x_val) - 1.0) < 1e-9
+
+    def test_macsyma_solve_sinh(self):
+        """solve(sinh(x) = 1, x) returns List(asinh(1))."""
+        result = self._run("solve(sinh(x) = 1, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None and abs(math.sinh(x_val) - 1.0) < 1e-9
+
+    def test_macsyma_solve_tanh(self):
+        """solve(tanh(x) = 1/2, x) returns List(atanh(1/2))."""
+        result = self._run("solve(tanh(x) = 1/2, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None and abs(math.tanh(x_val) - 0.5) < 1e-9
+
+    def test_macsyma_solve_lambert_w(self):
+        """solve(x*exp(x) = 1, x) returns List(LambertW(1))."""
+        result = self._run("solve(x*exp(x) = 1, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _contains_head(sols[0], "LambertW")
+
+    def test_macsyma_lambert_w_numeric(self):
+        """lambert_w(1) ≈ 0.5671."""
+        result = self._run("lambert_w(1)")
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - 0.5671432904097838) < 1e-9
+
+    def test_macsyma_solve_compound(self):
+        """solve(sin(x)^2 + sin(x) = 0, x) returns 4 solutions."""
+        result = self._run("solve(sin(x)^2 + sin(x) = 0, x)")
+        assert _is_list(result)
+        assert len(_list_args(result)) == 4
+
+    def test_macsyma_solve_cosh(self):
+        """solve(cosh(x) = 2, x) returns two solutions (symmetric)."""
+        result = self._run("solve(cosh(x) = 2, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        x_vals = [_eval_ir(s) for s in sols]
+        for xv in x_vals:
+            assert xv is not None
+            assert abs(math.cosh(xv) - 2.0) < 1e-9
+
+    def test_macsyma_linear_regression(self):
+        """Regression: solve(2*x + 4 = 0, x) = -2 (Phase 1 still works)."""
+        result = self._run("solve(2*x + 4 = 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        x_val = _eval_ir(sols[0])
+        assert x_val is not None and abs(x_val + 2.0) < 1e-12

--- a/code/specs/phase26-transcendental-solving.md
+++ b/code/specs/phase26-transcendental-solving.md
@@ -1,0 +1,225 @@
+# Phase 26 — Transcendental Equation Solving
+
+## Context
+
+Phase 25 completed symbolic summation (`sum`/`product`). The original gap-analysis
+document (`macsyma-gap-analysis-phases18-25.md`) labelled transcendental solving as
+"Phase 24" but the commit labelled `phase24` in the repository implemented definite
+integration via FTC instead. This spec picks up the unimplemented work:
+extend `cas-solve` to handle the most important transcendental equation families.
+
+Target: `cas-solve` 0.7.0 · `symbolic-ir` 0.13.0 · `symbolic-vm` 0.46.0 ·
+`macsyma-runtime` 1.17.0.
+
+---
+
+## Mathematical Families Covered
+
+### 26a — Trigonometric equations
+
+For `sin(ax+b) = c`, `cos(ax+b) = c`, `tan(ax+b) = c` with linear argument
+`ax+b` and constant `c` (w.r.t. the solve variable):
+
+```
+sin(u) = c  →  u = arcsin(c) + 2k·π   and   u = π − arcsin(c) + 2k·π
+cos(u) = c  →  u = arccos(c) + 2k·π   and   u = −arccos(c) + 2k·π
+tan(u) = c  →  u = arctan(c) + k·π
+```
+
+`k` is a new free-integer constant `%k` (IR head `FreeInteger`).
+After finding the argument values, solve `ax+b = val` for x (linear).
+
+### 26b — Exponential / logarithmic equations
+
+```
+exp(u) = c  →  u = log(c)
+log(u) = c  →  u = exp(c)
+```
+
+Both also support a linear argument: `exp(ax+b) = c` → `ax+b = log(c)` → `x` solved.
+
+### 26c — Lambert W equations
+
+Pattern: `f·exp(f) = c` where `f` is linear in the solve variable.
+
+```
+x·exp(x) = c     →  x = W(c)          [LambertW head]
+(ax+b)·exp(ax+b) = c  →  ax+b = W(c)  →  x = (W(c)−b)/a
+x^x = c          →  x = exp(W(log(c)))  [via x·log(x)·exp(x·log(x))=log(c)]
+```
+
+New IR head `LambertW`. Numeric evaluation: `lambert_w_handler` evaluates
+`LambertW(n)` when `n` is an integer or float using Newton's method on
+`w·exp(w) = n`.
+
+### 26d — Hyperbolic equations
+
+```
+sinh(u) = c  →  u = asinh(c)            (unique inverse)
+cosh(u) = c  →  u = acosh(c)  and  u = −acosh(c)
+tanh(u) = c  →  u = atanh(c)            (unique inverse)
+```
+
+Same linear-argument pattern as trig above.
+
+### 26e — Compound forms (polynomial-in-transcendental substitution)
+
+When the equation is a polynomial in some transcendental function `f(x)`:
+
+```
+sin(x)^2 + sin(x) = 0     →  u = sin(x),  u^2 + u = 0  →  u ∈ {−1, 0}
+                              → x from sin(x)=−1  and  sin(x)=0
+
+exp(x)^2 − 3·exp(x) + 2 = 0  →  u = exp(x),  u^2 − 3u + 2 = 0  →  u ∈ {1, 2}
+                                → x from exp(x)=1 → x=0  and  exp(x)=2 → x=log(2)
+```
+
+The solver detects this by trying to replace `f(var)` with a fresh symbol `u`,
+checking if the result is a rational polynomial in `u`, solving that polynomial,
+then solving `f(var) = u_sol` for each root (via the same transcendental dispatcher,
+recursively).  Only fires when the entire expression (minus constant term) is
+expressible as a polynomial in exactly one `f(var)`.
+
+---
+
+## New IR Heads (symbolic-ir 0.13.0)
+
+```python
+FREE_INTEGER = IRSymbol("FreeInteger")   # %k — free integer in periodic solutions
+LAMBERT_W    = IRSymbol("LambertW")      # W(x) — principal Lambert W function
+```
+
+Both exported from `symbolic_ir/__init__.py`.
+
+---
+
+## New File: `cas-solve/src/cas_solve/transcendental.py`
+
+Public entry point:
+
+```python
+def try_solve_transcendental(eq_ir: IRNode, var: IRSymbol) -> list[IRNode] | None:
+    """Try to solve eq_ir (Equal(lhs,rhs) or bare expr=0) for var.
+    Returns a list of IR solution nodes, or None if not recognised.
+    """
+```
+
+Internal helpers (not exported):
+- `_try_func_eq_const(func_side, const_side, var)` — handles 26a/26b/26d
+- `_try_lambert(lhs, rhs, var)` — handles 26c
+- `_try_compound(lhs, rhs, var)` — handles 26e
+- `_extract_linear(arg, var)` → `(a: Fraction, b: Fraction) | None`
+- `_solve_linear_for_val(a, b, val_ir, var)` → `IRNode`
+- `_is_const_wrt(node, var)` → `bool`
+- `_frac_ir(c: Fraction)` → `IRNode`
+
+---
+
+## Changes to symbolic-vm 0.46.0
+
+### `cas_handlers.py`
+
+Import additions:
+```python
+from symbolic_ir import FREE_INTEGER, LAMBERT_W
+from cas_solve.transcendental import try_solve_transcendental as _try_transcendental
+```
+
+In `solve_handler`, after `coeffs = _ir_to_fraction_poly(poly_ir, var_ir)` returns
+`None` (line ~1068), before the existing fallback `return expr`:
+
+```python
+if coeffs is None:
+    # Phase 26: try transcendental families before giving up.
+    trans_sols = _try_transcendental(eq_ir, var_ir)
+    if trans_sols is not None:
+        return IRApply(IRSymbol("List"), tuple(trans_sols))
+    return expr
+```
+
+New `lambert_w_handler`:
+
+```python
+def lambert_w_handler(_vm: VM, expr: IRApply) -> IRNode:
+    """LambertW(x) — principal branch of the Lambert W function.
+    Evaluates numerically when x is a rational or float constant.
+    Returns unevaluated for symbolic x.
+    """
+```
+
+Register in `build_cas_handler_table()`:
+```python
+"LambertW": lambert_w_handler,
+```
+
+---
+
+## Changes to macsyma-runtime 1.17.0
+
+### `cas_handlers.py`
+
+Import and re-register `lambert_w_handler` from `symbolic_vm.cas_handlers`.
+
+### `name_table.py`
+
+```python
+"lambert_w": LAMBERT_W,   # lambert_w(x) → LambertW(x)
+```
+
+The `%k` free integer appears only in solve *output*, not as a user-input
+function; no name-table entry needed.
+
+---
+
+## Test Structure (`test_phase26.py`, ≥50 tests)
+
+| Class | Tests |
+|-------|-------|
+| `TestPhase26_Trig` | 14 — sin/cos/tan, a=1, a=2, b≠0, a=1/2; structure checks (ASIN in result) |
+| `TestPhase26_ExpLog` | 8 — exp(x)=c, log(x)=c, exp(2x+1)=c, log(3x-1)=c |
+| `TestPhase26_Hyp` | 8 — sinh/cosh/tanh; a=1, a=2 |
+| `TestPhase26_LambertW` | 6 — x·exp(x)=1 (numeric approx), (2x+1)·exp(2x+1)=c, structure |
+| `TestPhase26_Compound` | 8 — sin^2+sin=0, cos^2−cos=0, exp^2−3exp+2=0, tanh^2−1=0 |
+| `TestPhase26_Fallthrough` | 4 — non-linear mixed, degree>4 (uses NSolve), `solve(x^2+y,x)` |
+| `TestPhase26_Regressions` | 4 — Phase 25 sum(k^2,k,1,n), Phase 24 FTC, Phase 23 erf, polynomial solve |
+| `TestPhase26_Macsyma` | 8 — solve(sin(x)=1/2,x), solve(exp(2*x)=3,x), solve(log(x+1)=2,x), etc. |
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `code/specs/phase26-transcendental-solving.md` | **NEW** this spec |
+| `symbolic-ir/src/symbolic_ir/nodes.py` | Add `FREE_INTEGER`, `LAMBERT_W` |
+| `symbolic-ir/src/symbolic_ir/__init__.py` | Export both |
+| `symbolic-ir/pyproject.toml` | Bump to 0.13.0 |
+| `symbolic-ir/CHANGELOG.md` | 0.13.0 entry |
+| `cas-solve/src/cas_solve/transcendental.py` | **NEW** |
+| `cas-solve/src/cas_solve/__init__.py` | Export `try_solve_transcendental`, `FREE_INTEGER`, `LAMBERT_W` |
+| `cas-solve/pyproject.toml` | Bump to 0.7.0 |
+| `cas-solve/CHANGELOG.md` | 0.7.0 entry |
+| `symbolic-vm/src/symbolic_vm/cas_handlers.py` | Import + wire in solve_handler + lambert_w_handler |
+| `symbolic-vm/pyproject.toml` | Bump to 0.46.0 |
+| `symbolic-vm/CHANGELOG.md` | 0.46.0 entry |
+| `symbolic-vm/tests/test_phase26.py` | **NEW** ≥50 tests |
+| `macsyma-runtime/src/macsyma_runtime/cas_handlers.py` | Register lambert_w_handler |
+| `macsyma-runtime/src/macsyma_runtime/name_table.py` | `"lambert_w"` → `LAMBERT_W` |
+| `macsyma-runtime/pyproject.toml` | Bump to 1.17.0 |
+| `macsyma-runtime/CHANGELOG.md` | 1.17.0 entry |
+
+No new package needed — `transcendental.py` lives inside `cas-solve`.
+
+---
+
+## Implementation Order
+
+1. Spec ← you are here
+2. `symbolic-ir` heads
+3. `cas-solve/transcendental.py` + unit tests there
+4. Wire into `symbolic-vm`
+5. Wire into `macsyma-runtime`
+6. `test_phase26.py`
+7. Bump changelogs + versions
+8. pytest + ruff → clean
+9. Commit → `/security-review` → push → PR → `/babysit-pr`


### PR DESCRIPTION
## Summary

- **`symbolic-ir` → 0.13.0**: Add `FREE_INTEGER` (the `%k` free-integer constant for periodic trig solutions) and `LAMBERT_W` IR head singletons.
- **`cas-solve` → 0.7.0**: New `transcendental.py` — `try_solve_transcendental(eq_ir, var)` covering five families: trig (26a), exp/log (26b), Lambert W (26c), hyperbolic (26d), compound polynomial-in-transcendental substitution (26e).
- **`symbolic-vm` → 0.46.0**: `lambert_w_handler` (Newton iteration, 64 steps) registered as `"LambertW"`; `solve_handler` now falls through to `_try_transcendental` before giving up; 60 new tests in `test_phase26.py`.
- **`macsyma-runtime` → 1.17.0**: `"lambert_w"` added to name table so `lambert_w(1)` evaluates at the MACSYMA surface.
- **Spec**: `code/specs/phase26-transcendental-solving.md`

## Key examples (MACSYMA surface)

```
solve(sin(x) = 0, x)         → [arcsin(0) + 2*%pi*%k,  %pi - arcsin(0) + 2*%pi*%k]
solve(exp(x) = 2, x)         → [log(2)]
solve(x*exp(x) = 1, x)       → [LambertW(1)]
lambert_w(1)                  → 0.5671432904097838
solve(tanh(x) = 1/2, x)      → [atanh(1/2)]
solve(cosh(x) = 2, x)        → [acosh(2), -acosh(2)]
solve(sin(x)^2+sin(x)=0, x)  → [4 solutions via compound substitution]
```

## Test plan

- [ ] All 1387 existing tests pass (no regressions)
- [ ] 60 new Phase 26 tests pass (10 classes, all families covered)
- [ ] Coverage ≥ 80% maintained (82.24% achieved)
- [ ] `ruff check` clean on all changed files
- [ ] Security review: PASSED — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)