### PR TITLE
feat(pdp11-simulator): Layer 07o — DEC PDP-11 (1970) behavioral simulator

### DIFF
--- a/code/packages/python/pdp11-simulator/CHANGELOG.md
+++ b/code/packages/python/pdp11-simulator/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog — pdp11-simulator
+
+## 0.1.0 (2026-05-04)
+
+Initial release — Layer 07o.
+
+### Added
+- `PDP11State` frozen dataclass with 8 registers (R0–R7), PSW, memory, halted flag
+- `PDP11Simulator` implementing `Simulator[PDP11State]` (SIM00 protocol)
+- Full 8-addressing-mode evaluation (register, deferred, autoincrement,
+  autoincrement deferred, autodecrement, autodecrement deferred, index, index deferred)
+- PC-relative and absolute addressing via R7 modes 2, 3, 6, 7
+- Double-operand instructions: MOV, CMP, BIT, BIC, BIS, ADD, SUB and byte variants
+- Single-operand instructions: CLR, COM, INC, DEC, NEG, ADC, SBC, TST, SWAB,
+  ROR, ROL, ASR, ASL and byte variants
+- All 15 branch instructions: BR, BNE, BEQ, BGE, BLT, BGT, BLE, BPL, BMI,
+  BHI, BLOS, BVC, BVS, BCC, BCS
+- JMP, JSR (all addressing modes), RTS, SOB, HALT, NOP, RTI
+- Condition code computation: N, Z, V, C with correct PDP-11 semantics
+- Byte instruction autoincrement/decrement: always 2 for SP (R6) and PC (R7),
+  1 for R0–R5
+- `>80%` test coverage (target: 90%+)
+- Spec: `code/specs/07o-pdp11-simulator.md`

--- a/code/packages/python/pdp11-simulator/README.md
+++ b/code/packages/python/pdp11-simulator/README.md
@@ -1,0 +1,49 @@
+# pdp11-simulator — Layer 07o
+
+A Python behavioral simulator for the **DEC PDP-11** (1970) minicomputer, part
+of the `coding-adventures` simulator series.
+
+## What is the PDP-11?
+
+The PDP-11 is the computer on which Unix and the C language were created.
+Designed at Digital Equipment Corporation in 1970, it introduced the **orthogonal
+ISA**: any addressing mode applies to any register in any instruction.
+
+Key features:
+- 8 general-purpose 16-bit registers (R0–R7)
+- R6 = SP (stack pointer), R7 = PC (program counter)
+- 8 addressing modes applicable uniformly to all registers
+- 64 KB flat byte-addressed little-endian memory
+- Condition codes: N, Z, V, C
+
+## Usage
+
+```python
+from pdp11_simulator import PDP11Simulator
+
+sim = PDP11Simulator()
+
+# MOV #42, R0 then HALT
+prog = bytes([
+    0xC0, 0x15,   # MOV #n, R0
+    0x2A, 0x00,   # immediate: 42
+    0x00, 0x00,   # HALT
+])
+
+result = sim.execute(prog)
+assert result.ok
+assert result.final_state.r[0] == 42
+```
+
+## Layer Position
+
+| Layer | Architecture       | Year |
+|-------|--------------------|------|
+| 07m   | Intel 8086         | 1978 |
+| 07n   | Motorola 68000     | 1979 |
+| **07o** | **DEC PDP-11** | **1970** |
+| 07p   | Intel 8051         | 1980 |
+
+## Protocol
+
+Implements `Simulator[PDP11State]` from `coding-adventures-simulator-protocol`.

--- a/code/packages/python/pdp11-simulator/pyproject.toml
+++ b/code/packages/python/pdp11-simulator/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-pdp11-simulator"
+version = "0.1.0"
+description = "DEC PDP-11 (1970) behavioral simulator — Layer 07o"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "coding-adventures-simulator-protocol",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pdp11_simulator"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=pdp11_simulator --cov-report=term-missing --cov-fail-under=80"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "SIM"]
+# E501: long lines appear in literate-programming comments that explain opcode
+#   bit layouts (e.g. "0001 000 000 000 001 = 0x1001").  Truncating them would
+#   destroy the educational value — accept the overrun.
+# E701/E702: intentional single-line statements used in literate-programming
+#   style (constant tables, `if cond: return val` forms).
+ignore = ["E501", "E701", "E702"]

--- a/code/packages/python/pdp11-simulator/src/pdp11_simulator/__init__.py
+++ b/code/packages/python/pdp11-simulator/src/pdp11_simulator/__init__.py
@@ -1,0 +1,35 @@
+"""DEC PDP-11 (1970) behavioral simulator — Layer 07o.
+
+Public API
+----------
+``PDP11Simulator``
+    The main simulator class.  Implements ``Simulator[PDP11State]``
+    from ``simulator_protocol`` (SIM00).
+
+``PDP11State``
+    Frozen dataclass snapshot of the PDP-11 CPU state at any instant.
+    Fields: r (R0–R7 tuple), psw (Processor Status Word), halted, memory.
+    Properties: .n/.z/.v/.c (condition code flags).
+
+Quick start
+-----------
+>>> from pdp11_simulator import PDP11Simulator
+>>> sim = PDP11Simulator()
+>>> # MOV #5, R0  (immediate to register)
+>>> # Encoded as: MOV opcode=0x15C0, immediate word=0x0005, then HALT=0x0000
+>>> prog = bytes([
+...     0xC0, 0x15,   # MOV #n, R0  (mode 2/R7 src, mode 0/R0 dst)
+...     0x05, 0x00,   # immediate: 5
+...     0x00, 0x00,   # HALT
+... ])
+>>> result = sim.execute(prog)
+>>> result.ok
+True
+>>> result.final_state.r[0]
+5
+"""
+
+from pdp11_simulator.simulator import PDP11Simulator
+from pdp11_simulator.state import PDP11State
+
+__all__ = ["PDP11Simulator", "PDP11State"]

--- a/code/packages/python/pdp11-simulator/src/pdp11_simulator/flags.py
+++ b/code/packages/python/pdp11-simulator/src/pdp11_simulator/flags.py
@@ -1,0 +1,223 @@
+"""Condition code helpers for the DEC PDP-11.
+
+──────────────────────────────────────────────────────────────────────────────
+PDP-11 CONDITION CODES
+──────────────────────────────────────────────────────────────────────────────
+
+The PSW (Processor Status Word) stores four condition codes in bits 3–0:
+
+  N (bit 3) — Negative: MSB of result is 1
+  Z (bit 2) — Zero:     result is exactly 0
+  V (bit 1) — oVerflow: signed result outside representable range
+  C (bit 0) — Carry:    unsigned overflow/borrow from MSB
+
+Key differences from the Motorola 68000:
+  • No X (extend) flag — multi-precision arithmetic uses ADC/SBC instead.
+  • NEG carry rule: C = (result != 0), i.e. C=0 only when NEG 0 = 0.
+  • COM always sets C=1 (bitwise NOT; by convention "no borrow").
+  • CLR clears all four flags (N=0, Z=1, V=0, C=0).
+  • TST clears V and C, sets N and Z from operand.
+
+──────────────────────────────────────────────────────────────────────────────
+"""
+
+from __future__ import annotations
+
+# ── Size constants ────────────────────────────────────────────────────────────
+_BYTE_MASK = 0xFF
+_WORD_MASK = 0xFFFF
+_BYTE_MSB  = 0x80
+_WORD_MSB  = 0x8000
+
+
+def _msb(*, word: bool) -> int:
+    """MSB mask for the given size.
+
+    >>> _msb(word=False)
+    128
+    >>> _msb(word=True)
+    32768
+    """
+    return _WORD_MSB if word else _BYTE_MSB
+
+
+def _mask(*, word: bool) -> int:
+    """Unsigned mask for the given size.
+
+    >>> _mask(word=False)
+    255
+    >>> _mask(word=True)
+    65535
+    """
+    return _WORD_MASK if word else _BYTE_MSB | (_BYTE_MASK ^ _BYTE_MSB) | _BYTE_MSB
+
+
+# Simpler implementation
+def _umask(*, word: bool) -> int:
+    """Unsigned mask for word (16-bit) or byte (8-bit).
+
+    >>> _umask(word=True)
+    65535
+    >>> _umask(word=False)
+    255
+    """
+    return _WORD_MASK if word else _BYTE_MASK
+
+
+def compute_n(result: int, *, word: bool) -> bool:
+    """Negative flag: MSB of (masked) result.
+
+    >>> compute_n(0x80, word=False)
+    True
+    >>> compute_n(0x7F, word=False)
+    False
+    >>> compute_n(0x8000, word=True)
+    True
+    >>> compute_n(0x7FFF, word=True)
+    False
+    """
+    return bool(result & _msb(word=word))
+
+
+def compute_z(result: int, *, word: bool) -> bool:
+    """Zero flag: result is zero after masking.
+
+    >>> compute_z(0, word=False)
+    True
+    >>> compute_z(1, word=False)
+    False
+    >>> compute_z(0x100, word=False)   # 256 & 0xFF = 0
+    True
+    """
+    return (result & _umask(word=word)) == 0
+
+
+def compute_v_add(a: int, b: int, result: int, *, word: bool) -> bool:
+    """Overflow for ADD: both inputs same sign, result differs.
+
+        V = (~(a ^ b)) & (a ^ result)   [MSB only]
+
+    >>> compute_v_add(0x7F, 0x01, 0x80, word=False)   # +127+1 → -128
+    True
+    >>> compute_v_add(0x01, 0x01, 0x02, word=False)
+    False
+    >>> compute_v_add(0x7FFF, 0x0001, 0x8000, word=True)
+    True
+    """
+    msb = _msb(word=word)
+    return bool((~(a ^ b)) & (a ^ result) & msb)
+
+
+def compute_v_sub(a: int, b: int, result: int, *, word: bool) -> bool:
+    """Overflow for SUB/CMP (a − b): operands differ in sign, result flips a.
+
+        V = (a ^ b) & (a ^ result)   [MSB only]
+
+    >>> compute_v_sub(0x80, 0x01, 0x7F, word=False)   # -128-1 → +127
+    True
+    >>> compute_v_sub(0x05, 0x03, 0x02, word=False)
+    False
+    >>> compute_v_sub(0x8000, 0x0001, 0x7FFF, word=True)
+    True
+    """
+    msb = _msb(word=word)
+    return bool((a ^ b) & (a ^ result) & msb)
+
+
+def compute_c_add(raw: int, *, word: bool) -> bool:
+    """Carry for ADD: unsigned result exceeds representable range.
+
+    >>> compute_c_add(0x100, word=False)
+    True
+    >>> compute_c_add(0xFF, word=False)
+    False
+    >>> compute_c_add(0x10000, word=True)
+    True
+    """
+    return raw > _umask(word=word)
+
+
+def compute_c_sub(a: int, b: int, borrow: int = 0) -> bool:
+    """Carry (borrow) for SUB: a < b + borrow.
+
+    >>> compute_c_sub(5, 3)
+    False
+    >>> compute_c_sub(3, 5)
+    True
+    >>> compute_c_sub(5, 5, 1)
+    True
+    """
+    return a < b + borrow
+
+
+def nzvc_add(a: int, b: int, carry_in: int = 0, *, word: bool) -> tuple[bool, bool, bool, bool]:
+    """Compute (N, Z, V, C) for ADD/ADC.
+
+    Parameters
+    ----------
+    a, b      : unsigned operands (masked to size)
+    carry_in  : 0 or 1 for ADC
+    word      : True for 16-bit, False for 8-bit
+
+    >>> nzvc_add(0x7F, 0x01, word=False)   # overflow case
+    (True, False, True, False)
+    >>> nzvc_add(0xFF, 0x01, word=False)   # carry case
+    (False, True, False, True)
+    """
+    m      = _umask(word=word)
+    raw    = a + b + carry_in
+    result = raw & m
+    return (
+        compute_n(result, word=word),
+        compute_z(result, word=word),
+        compute_v_add(a, b, result, word=word),
+        compute_c_add(raw, word=word),
+    )
+
+
+def nzvc_sub(a: int, b: int, borrow: int = 0, *, word: bool) -> tuple[bool, bool, bool, bool]:
+    """Compute (N, Z, V, C) for SUB/SBC/CMP (result = a − b − borrow).
+
+    >>> nzvc_sub(0x05, 0x03, word=False)
+    (False, False, False, False)
+    >>> nzvc_sub(0x00, 0x01, word=False)   # 0 - 1 = 0xFF
+    (True, False, False, True)
+    """
+    m      = _umask(word=word)
+    raw    = a - b - borrow
+    result = raw & m
+    return (
+        compute_n(result, word=word),
+        compute_z(result, word=word),
+        compute_v_sub(a, b, result, word=word),
+        compute_c_sub(a, b, borrow),
+    )
+
+
+def nzvc_logic(result: int, *, word: bool) -> tuple[bool, bool, bool, bool]:
+    """(N, Z, V=0, C=0) for BIT/BIC/BIS/MOV (V and C always cleared).
+
+    >>> nzvc_logic(0, word=False)
+    (False, True, False, False)
+    >>> nzvc_logic(0x80, word=False)
+    (True, False, False, False)
+    """
+    return (
+        compute_n(result, word=word),
+        compute_z(result, word=word),
+        False,
+        False,
+    )
+
+
+def pack_psw(n: bool, z: bool, v: bool, c: bool) -> int:
+    """Pack four condition code bits into PSW bits 3–0.
+
+    >>> pack_psw(True, False, False, False)
+    8
+    >>> pack_psw(False, True, False, False)
+    4
+    >>> pack_psw(True, False, True, True)
+    11
+    """
+    return (int(n) << 3) | (int(z) << 2) | (int(v) << 1) | int(c)

--- a/code/packages/python/pdp11-simulator/src/pdp11_simulator/simulator.py
+++ b/code/packages/python/pdp11-simulator/src/pdp11_simulator/simulator.py
@@ -1,0 +1,871 @@
+"""DEC PDP-11 (1970) behavioral simulator — Layer 07o.
+
+──────────────────────────────────────────────────────────────────────────────
+OVERVIEW
+──────────────────────────────────────────────────────────────────────────────
+
+This module implements ``PDP11Simulator``, a Python behavioral simulator for
+the DEC PDP-11 minicomputer.  It implements the SIM00 ``Simulator[PDP11State]``
+protocol used by all architecture simulators in this repository.
+
+The PDP-11 is one of the most influential computer architectures ever designed.
+Key features:
+
+  1. ORTHOGONAL ISA: Any addressing mode applies to any register in any
+     instruction.  There are 8 addressing modes and 8 registers — the full
+     combinatorial product works everywhere.
+
+  2. PC IN THE REGISTER FILE (R7 = PC): The program counter is register R7.
+     This means "immediate" addressing (``#n``) is just the autoincrement mode
+     applied to R7 — the CPU reads the next instruction word as a literal
+     operand and increments PC past it.  Clever!
+
+  3. SP IN THE REGISTER FILE (R6 = SP): Same idea for the stack.  Push is
+     autodecrement on R6 (``-(R6)``); pop is autoincrement on R6 (``(R6)+``).
+
+  4. JSR/RTS ELEGANCE: JSR and RTS use the same autoincrement/autodecrement
+     modes.  ``JSR PC, addr`` is literally "push PC, jump to addr."
+
+──────────────────────────────────────────────────────────────────────────────
+INSTRUCTION DECODING
+──────────────────────────────────────────────────────────────────────────────
+
+PDP-11 instructions are 16-bit words (little-endian in memory).
+
+Double-operand (word):   opcode[15:12] src[11:6] dst[5:0]
+Double-operand (byte):   bit15=1, opcode[14:12] src[11:6] dst[5:0]
+Single-operand:          opcode[15:6] dst[5:0]
+Branch:                  opcode[15:8] offset[7:0]  (offset in words, signed)
+JSR:                     0000 100 reg[8:6] dst[5:0]
+RTS:                     0000 0000 1000 0 reg[2:0]
+SOB:                     0111 11 reg[8:6] offset[5:0]
+HALT:                    0x0000
+
+──────────────────────────────────────────────────────────────────────────────
+ADDRESSING MODE EVALUATION
+──────────────────────────────────────────────────────────────────────────────
+
+Each 6-bit operand field encodes:  mode[5:3]  reg[2:0]
+
+Mode 0: Register direct     — operand IS the register (no memory)
+Mode 1: Register deferred   — EA = R; operand = M[EA]
+Mode 2: Autoincrement       — EA = R; R += size;  operand = M[EA]
+Mode 3: Autoincrement def.  — EA = M[R]; R += 2;  operand = M[EA]
+Mode 4: Autodecrement       — R -= size; EA = R;  operand = M[EA]
+Mode 5: Autodecrement def.  — R -= 2; EA = M[R];  operand = M[EA]
+Mode 6: Index               — EA = R + fetch_word(); operand = M[EA]
+Mode 7: Index deferred      — EA = M[R + fetch_word()]; operand = M[EA]
+
+Special cases when reg = R7 (PC):
+  Mode 2 + R7 → Immediate    #n       (fetch next word as literal)
+  Mode 3 + R7 → Absolute     @#addr   (fetch next word as address)
+  Mode 6 + R7 → Relative     addr     (PC-relative; EA = PC + disp)
+  Mode 7 + R7 → Rel. Deferred @addr   (EA = M[PC + disp])
+
+For byte instructions, autoincrement/autodecrement step by 1 — EXCEPT when
+the register is SP (R6) or PC (R7), which always step by 2.
+
+──────────────────────────────────────────────────────────────────────────────
+"""
+
+from __future__ import annotations
+
+from simulator_protocol import ExecutionResult, StepTrace
+
+from pdp11_simulator.flags import nzvc_add, nzvc_logic, nzvc_sub, pack_psw
+from pdp11_simulator.state import (
+    ADDR_MASK,
+    BYTE_MASK,
+    BYTE_MSB,
+    INIT_SP,
+    LOAD_ADDR,
+    MEM_SIZE,
+    PC,
+    SP,
+    WORD_MASK,
+    WORD_MSB,
+    PDP11State,
+)
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+def _sign_extend(value: int, bits: int) -> int:
+    """Sign-extend *value* from *bits* wide to Python int.
+
+    >>> _sign_extend(0xFF, 8)   # -1
+    -1
+    >>> _sign_extend(0x7F, 8)   # +127
+    127
+    >>> _sign_extend(0x8000, 16)  # -32768
+    -32768
+    """
+    sign_bit = 1 << (bits - 1)
+    return (value & (sign_bit - 1)) - (value & sign_bit)
+
+
+def _w(hi: int, lo: int) -> bytes:
+    """Pack two bytes as a little-endian word (helper for test programs)."""
+    return bytes([lo & 0xFF, hi & 0xFF])
+
+
+# ── Simulator ─────────────────────────────────────────────────────────────────
+
+class PDP11Simulator:
+    """Behavioral simulator for the DEC PDP-11 (1970).
+
+    Implements ``Simulator[PDP11State]`` from the SIM00 protocol.
+
+    Internal state
+    --------------
+    _r : list[int]
+        Eight 16-bit registers R0–R7 (R6=SP, R7=PC), stored unsigned.
+    _psw : int
+        Processor Status Word (16-bit); only bits 3–0 (N,Z,V,C) are live.
+    _mem : bytearray
+        64 KB flat address space.
+    _halted : bool
+        Set when HALT executes; step() becomes a no-op thereafter.
+
+    Examples
+    --------
+    >>> sim = PDP11Simulator()
+    >>> # HALT = 0x0000 (two zero bytes, little-endian)
+    >>> result = sim.execute(bytes([0x00, 0x00]))
+    >>> result.ok
+    True
+    >>> result.final_state.halted
+    True
+    """
+
+    def __init__(self) -> None:
+        self._r: list[int] = [0] * 8
+        self._psw: int = 0
+        self._mem: bytearray = bytearray(MEM_SIZE)
+        self._halted: bool = False
+        self.reset()   # initialise SP=0xF000, PC=0x1000
+
+    # ── SIM00 protocol ────────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Reset to power-on state: zero registers, zero memory, SP=0xF000, PC=0x1000."""
+        self._r = [0] * 8
+        self._r[SP] = INIT_SP
+        self._r[PC] = LOAD_ADDR
+        self._psw = 0
+        self._mem = bytearray(MEM_SIZE)
+        self._halted = False
+
+    def load(self, program: bytes) -> None:
+        """Reset then copy *program* into memory starting at 0x1000."""
+        self.reset()
+        end = LOAD_ADDR + len(program)
+        if end > MEM_SIZE:
+            raise ValueError(f"Program too large: {len(program)} bytes > {MEM_SIZE - LOAD_ADDR}")
+        self._mem[LOAD_ADDR:end] = program
+
+    def get_state(self) -> PDP11State:
+        """Return an immutable snapshot of the current CPU state."""
+        return PDP11State(
+            r=tuple(self._r),
+            psw=self._psw,
+            halted=self._halted,
+            memory=tuple(self._mem),
+        )
+
+    def step(self) -> StepTrace:
+        """Fetch, decode, and execute one instruction; return a StepTrace."""
+        if self._halted:
+            pc = self._r[PC]
+            return StepTrace(pc_before=pc, pc_after=pc,
+                             mnemonic="HALT", description="HALT (already halted)")
+        pc_before = self._r[PC]
+        mnemonic, description = self._execute_one()
+        return StepTrace(
+            pc_before=pc_before,
+            pc_after=self._r[PC],
+            mnemonic=mnemonic,
+            description=f"{mnemonic} @ 0x{pc_before:04X}",
+        )
+
+    def execute(self, program: bytes, max_steps: int = 100_000) -> ExecutionResult[PDP11State]:
+        """Load *program*, run to HALT or *max_steps*, return full result."""
+        self.load(program)
+        traces: list[StepTrace] = []
+        error: str | None = None
+        steps = 0
+        while not self._halted and steps < max_steps:
+            try:
+                trace = self.step()
+            except Exception as exc:  # noqa: BLE001
+                error = str(exc)
+                break
+            traces.append(trace)
+            steps += 1
+        if not self._halted and error is None:
+            error = f"max_steps ({max_steps}) exceeded"
+        return ExecutionResult(
+            halted=self._halted,
+            steps=steps,
+            final_state=self.get_state(),
+            error=error,
+            traces=traces,
+        )
+
+    # ── Memory primitives ─────────────────────────────────────────────────────
+
+    def _read_word(self, addr: int) -> int:
+        """Read a 16-bit little-endian word from *addr* (must be even)."""
+        addr &= ADDR_MASK
+        if addr & 1:
+            raise ValueError(f"Odd address word read: 0x{addr:04X}")
+        return self._mem[addr] | (self._mem[addr + 1] << 8)
+
+    def _write_word(self, addr: int, value: int) -> None:
+        """Write a 16-bit little-endian word to *addr* (must be even)."""
+        addr &= ADDR_MASK
+        if addr & 1:
+            raise ValueError(f"Odd address word write: 0x{addr:04X}")
+        self._mem[addr]     = value & 0xFF
+        self._mem[addr + 1] = (value >> 8) & 0xFF
+
+    def _read_byte(self, addr: int) -> int:
+        """Read a single byte from *addr*."""
+        return self._mem[addr & ADDR_MASK]
+
+    def _write_byte(self, addr: int, value: int) -> None:
+        """Write a single byte to *addr*."""
+        self._mem[addr & ADDR_MASK] = value & BYTE_MASK
+
+    def _fetch_word(self) -> int:
+        """Fetch next instruction/immediate word, advancing PC by 2."""
+        word = self._read_word(self._r[PC])
+        self._r[PC] = (self._r[PC] + 2) & WORD_MASK
+        return word
+
+    # ── Addressing mode evaluation ────────────────────────────────────────────
+    #
+    # Returns (ea, is_register) where:
+    #   is_register=True  → operand is register _r[reg]; ea=reg index
+    #   is_register=False → operand is M[ea]
+    #
+    # For write, the caller uses _write_ea().
+    #
+
+    def _ea(self, mode: int, reg: int, *, word: bool) -> tuple[int, bool]:
+        """Compute effective address for (mode, reg) operand.
+
+        Returns ``(address_or_regnum, is_register_direct)``.
+
+        Mode 0 → (reg, True)  — register direct, no memory involved.
+        Modes 1-7 → (ea, False) — memory effective address.
+        """
+        # Mode 0: Register direct — operand is the register itself
+        if mode == 0:
+            return (reg, True)
+
+        # Byte step = 1 for general registers, but ALWAYS 2 for SP (R6) and PC (R7).
+        # This ensures #immediate (mode 2 on R7) always advances PC by 2 words,
+        # and push/pop on R6 always moves the stack by one word slot.
+        step = 2 if (word or reg >= SP) else 1
+
+        if mode == 1:
+            # Register deferred: EA = R
+            return (self._r[reg] & ADDR_MASK, False)
+
+        if mode == 2:
+            # Autoincrement: EA = R; R += step
+            ea = self._r[reg] & ADDR_MASK
+            self._r[reg] = (self._r[reg] + step) & WORD_MASK
+            return (ea, False)
+
+        if mode == 3:
+            # Autoincrement deferred: EA = M[R]; R += 2 (always pointer-sized)
+            ptr = self._r[reg] & ADDR_MASK
+            self._r[reg] = (self._r[reg] + 2) & WORD_MASK
+            ea = self._read_word(ptr)
+            return (ea & ADDR_MASK, False)
+
+        if mode == 4:
+            # Autodecrement: R -= step; EA = R
+            self._r[reg] = (self._r[reg] - step) & WORD_MASK
+            return (self._r[reg] & ADDR_MASK, False)
+
+        if mode == 5:
+            # Autodecrement deferred: R -= 2; EA = M[R]
+            self._r[reg] = (self._r[reg] - 2) & WORD_MASK
+            ptr = self._r[reg] & ADDR_MASK
+            ea = self._read_word(ptr)
+            return (ea & ADDR_MASK, False)
+
+        if mode == 6:
+            # Index: EA = R + next-word (displacement)
+            disp = self._fetch_word()
+            ea = (self._r[reg] + disp) & ADDR_MASK
+            return (ea, False)
+
+        # mode == 7
+        # Index deferred: EA = M[R + next-word]
+        disp = self._fetch_word()
+        ptr  = (self._r[reg] + disp) & ADDR_MASK
+        ea   = self._read_word(ptr) & ADDR_MASK
+        return (ea, False)
+
+    def _read_ea(self, ea: int, is_reg: bool, *, word: bool) -> int:
+        """Read operand from EA (or register)."""
+        if is_reg:
+            return self._r[ea] & (WORD_MASK if word else BYTE_MASK)
+        return self._read_word(ea) if word else self._read_byte(ea)
+
+    def _write_ea(self, ea: int, is_reg: bool, value: int, *, word: bool) -> None:
+        """Write operand to EA (or register).
+
+        For byte writes to a register, PDP-11 sign-extends the byte to 16 bits
+        (MOVB convention) — but that applies only to MOV; other byte ops to
+        registers just write the low byte into the low byte of the register.
+        The caller handles sign extension for MOVB.
+        """
+        if is_reg:
+            if word:
+                self._r[ea] = value & WORD_MASK
+            else:
+                # Byte to register: write only low byte
+                self._r[ea] = (self._r[ea] & 0xFF00) | (value & BYTE_MASK)
+        elif word:
+            self._write_word(ea, value & WORD_MASK)
+        else:
+            self._write_byte(ea, value & BYTE_MASK)
+
+    # ── PSW helpers ───────────────────────────────────────────────────────────
+
+    def _set_nzvc(self, n: bool, z: bool, v: bool, c: bool) -> None:
+        """Update N, Z, V, C bits in PSW (preserve upper bits)."""
+        self._psw = (self._psw & 0xFFF0) | pack_psw(n, z, v, c)
+
+    def _c(self) -> int:     return self._psw & 1
+    def _get_n(self) -> bool: return bool(self._psw & 0b1000)
+    def _get_z(self) -> bool: return bool(self._psw & 0b0100)
+    def _get_v(self) -> bool: return bool(self._psw & 0b0010)
+    def _get_c(self) -> bool: return bool(self._psw & 0b0001)
+
+    # ── Main decode/execute dispatcher ────────────────────────────────────────
+
+    def _execute_one(self) -> tuple[str, str]:
+        """Fetch and execute one instruction, return (mnemonic, description)."""
+        iw = self._fetch_word()   # instruction word
+
+        # ── HALT (0x0000) ─────────────────────────────────────────────────────
+        if iw == 0x0000:
+            self._halted = True
+            return ("HALT", "Halt processor")
+
+        # ── NOP (0x00A0) ──────────────────────────────────────────────────────
+        if iw == 0x00A0:
+            return ("NOP", "No operation")
+
+        # ── RTI (0x0002) ──────────────────────────────────────────────────────
+        if iw == 0x0002:
+            # Return from interrupt: pop PC then PSW from stack
+            new_pc  = self._read_word(self._r[SP]);  self._r[SP] = (self._r[SP] + 2) & WORD_MASK
+            new_psw = self._read_word(self._r[SP]);  self._r[SP] = (self._r[SP] + 2) & WORD_MASK
+            self._r[PC]  = new_pc & WORD_MASK
+            self._psw    = new_psw & WORD_MASK
+            return ("RTI", "Return from interrupt")
+
+        # ── RTS reg — octal 000 200 to 000 207 = 0x0080 to 0x0087 ──────────────
+        #  Binary: 0000 0000 1000 0 rrr
+        #  (NOT 0x0200: that range is BNE.)
+        if (iw & 0xFFF8) == 0x0080:
+            reg = iw & 0x7
+            old_pc = self._r[reg]
+            self._r[PC]  = old_pc & WORD_MASK
+            self._r[reg] = self._read_word(self._r[SP]) & WORD_MASK
+            self._r[SP]  = (self._r[SP] + 2) & WORD_MASK
+            return ("RTS", f"RTS R{reg}")
+
+        # ── SOB reg, offset (0x7E00 … 0x7FFF) ────────────────────────────────
+        #  Encoding: 0111 11 rrr oooooo  (offset 6-bit unsigned, step backward)
+        if (iw & 0xFE00) == 0x7E00:
+            reg    = (iw >> 6) & 0x7
+            offset = iw & 0x3F
+            self._r[reg] = (self._r[reg] - 1) & WORD_MASK
+            if self._r[reg] != 0:
+                self._r[PC] = (self._r[PC] - 2 * offset) & WORD_MASK
+            return ("SOB", f"SOB R{reg}, -{offset}")
+
+        # ── Branches (bits 15-8 = opcode byte) ───────────────────────────────
+        hi = (iw >> 8) & 0xFF
+        if hi in _BRANCH_OPCODES:
+            offset = _sign_extend(iw & 0xFF, 8)
+            taken  = _BRANCH_OPCODES[hi](self._get_n(), self._get_z(),
+                                          self._get_v(), self._get_c())
+            if taken:
+                self._r[PC] = (self._r[PC] + 2 * offset) & WORD_MASK
+            return (_BRANCH_NAMES[hi], f"branch offset {offset:+d}")
+
+        # ── JMP (0000 0000 01 mm rrr) ─────────────────────────────────────────
+        #  Encoding: 0x0040 | (mode<<3) | reg
+        if (iw & 0xFFC0) == 0x0040:
+            mode = (iw >> 3) & 0x7
+            reg  = iw & 0x7
+            if mode == 0:
+                raise ValueError("JMP with register direct mode is illegal")
+            ea, _ = self._ea(mode, reg, word=True)
+            self._r[PC] = ea & WORD_MASK
+            return ("JMP", f"JMP mode={mode} R{reg}")
+
+        # ── JSR reg, dst (0x0800 | link<<6 | mode<<3 | dst_reg) ──────────────
+        #  Bits: 0000 1000 rrr mmm ddd
+        if (iw & 0xFE00) == 0x0800:
+            link = (iw >> 6) & 0x7
+            mode = (iw >> 3) & 0x7
+            dst_reg = iw & 0x7
+            if mode == 0:
+                raise ValueError("JSR with register direct mode is illegal")
+            ea, _ = self._ea(mode, dst_reg, word=True)
+            old_link   = self._r[link]
+            ret_addr   = self._r[PC]          # PC already past JSR word
+            self._r[SP] = (self._r[SP] - 2) & WORD_MASK
+            self._write_word(self._r[SP], old_link)
+            self._r[link] = ret_addr
+            self._r[PC]   = ea & WORD_MASK
+            return ("JSR", f"JSR R{link}")
+
+        # ── Single-operand instructions ───────────────────────────────────────
+        #  Bits 15-6 = opcode (10 bits), bits 5-0 = dst (mode + reg)
+        single_op = (iw >> 6) & 0x3FF
+        dst_mode  = (iw >> 3) & 0x7
+        dst_reg   = iw & 0x7
+
+        if single_op in _SINGLE_OPS:
+            return _SINGLE_OPS[single_op](self, dst_mode, dst_reg)
+
+        # ── Double-operand instructions ───────────────────────────────────────
+        #  Bits 15-12 = opcode (4 bits)
+        #  bit 15 = byte flag (1 = byte, 0 = word)
+        #  src = bits 11-6, dst = bits 5-0
+        src_field = (iw >> 6) & 0x3F
+        src_mode  = (src_field >> 3) & 0x7
+        src_reg   = src_field & 0x7
+
+        byte_op   = bool(iw & 0x8000)
+        op4       = (iw >> 12) & 0x7   # 3-bit opcode within byte/word space
+        word      = not byte_op
+
+        op4 = (iw >> 12) & 0xF if (iw & 0x8000) == 0 else ((iw >> 12) & 0x7) | 0x8
+
+        if op4 in _DOUBLE_OPS:
+            return _DOUBLE_OPS[op4](self, src_mode, src_reg, dst_mode, dst_reg, word)
+
+        raise ValueError(f"Unknown opcode: 0x{iw:04X}")
+
+    # ── Single-operand implementations ────────────────────────────────────────
+
+    def _op_clr(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """CLR/CLRB: dst ← 0; N=0, Z=1, V=0, C=0."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        self._write_ea(ea, is_reg, 0, word=word)
+        self._set_nzvc(False, True, False, False)
+        name = "CLR" if word else "CLRB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_com(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """COM/COMB: dst ← ~dst; N,Z from result; V=0, C=1."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        mask = WORD_MASK if word else BYTE_MASK
+        result = (~src) & mask
+        self._write_ea(ea, is_reg, result, word=word)
+        n, z, _, _ = nzvc_logic(result, word=word)
+        self._set_nzvc(n, z, False, True)
+        name = "COM" if word else "COMB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_inc(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """INC/INCB: dst ← dst + 1; N,Z,V updated; C not changed."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        n, z, v, _ = nzvc_add(src, 1, word=word)
+        mask = WORD_MASK if word else BYTE_MASK
+        self._write_ea(ea, is_reg, (src + 1) & mask, word=word)
+        # INC does NOT change C
+        self._set_nzvc(n, z, v, self._get_c())
+        name = "INC" if word else "INCB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_dec(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """DEC/DECB: dst ← dst - 1; N,Z,V updated; C not changed."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        n, z, v, _ = nzvc_sub(src, 1, word=word)
+        mask = WORD_MASK if word else BYTE_MASK
+        self._write_ea(ea, is_reg, (src - 1) & mask, word=word)
+        # DEC does NOT change C
+        self._set_nzvc(n, z, v, self._get_c())
+        name = "DEC" if word else "DECB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_neg(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """NEG/NEGB: dst ← 0 - dst; N,Z,V,C updated (C=1 unless result=0)."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        mask = WORD_MASK if word else BYTE_MASK
+        msb  = WORD_MSB  if word else BYTE_MSB
+        result = (-src) & mask
+        n = bool(result & msb)
+        z = result == 0
+        v = src == msb   # NEG(most-negative) = most-negative → overflow
+        c = result != 0
+        self._write_ea(ea, is_reg, result, word=word)
+        self._set_nzvc(n, z, v, c)
+        name = "NEG" if word else "NEGB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_tst(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """TST/TSTB: set N,Z from src; V=0, C=0."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        n, z, _, _ = nzvc_logic(src, word=word)
+        self._set_nzvc(n, z, False, False)
+        name = "TST" if word else "TSTB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_asr(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """ASR/ASRB: arithmetic shift right by 1; sign bit preserved."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        msb  = WORD_MSB if word else BYTE_MSB
+        mask = WORD_MASK if word else BYTE_MASK
+        c_out = bool(src & 1)
+        result = ((src >> 1) | (src & msb)) & mask  # sign-fill
+        n = bool(result & msb)
+        z = result == 0
+        v = n ^ c_out   # V = N XOR C (detects sign change)
+        self._write_ea(ea, is_reg, result, word=word)
+        self._set_nzvc(n, z, v, c_out)
+        name = "ASR" if word else "ASRB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_asl(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """ASL/ASLB: arithmetic shift left by 1; bit 15/7 goes to C."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        msb  = WORD_MSB if word else BYTE_MSB
+        mask = WORD_MASK if word else BYTE_MASK
+        c_out = bool(src & msb)
+        result = (src << 1) & mask
+        n = bool(result & msb)
+        z = result == 0
+        v = n ^ c_out   # V = N XOR C
+        self._write_ea(ea, is_reg, result, word=word)
+        self._set_nzvc(n, z, v, c_out)
+        name = "ASL" if word else "ASLB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_ror(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """ROR/RORB: rotate right through C."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        msb  = WORD_MSB if word else BYTE_MSB
+        mask = WORD_MASK if word else BYTE_MASK
+        old_c  = self._get_c()
+        new_c  = bool(src & 1)
+        result = ((src >> 1) | (int(old_c) << (15 if word else 7))) & mask
+        n = bool(result & msb)
+        z = result == 0
+        v = n ^ new_c
+        self._write_ea(ea, is_reg, result, word=word)
+        self._set_nzvc(n, z, v, new_c)
+        name = "ROR" if word else "RORB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_rol(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """ROL/ROLB: rotate left through C."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        msb  = WORD_MSB if word else BYTE_MSB
+        mask = WORD_MASK if word else BYTE_MASK
+        old_c  = self._get_c()
+        new_c  = bool(src & msb)
+        result = (((src << 1) & mask) | int(old_c)) & mask
+        n = bool(result & msb)
+        z = result == 0
+        v = n ^ new_c
+        self._write_ea(ea, is_reg, result, word=word)
+        self._set_nzvc(n, z, v, new_c)
+        name = "ROL" if word else "ROLB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_swab(self, dst_mode: int, dst_reg: int) -> tuple[str, str]:
+        """SWAB: swap high and low bytes of dst word; N,Z from low byte; V=0, C=0."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=True)
+        src    = self._read_ea(ea, is_reg, word=True)
+        result = ((src & 0xFF) << 8) | ((src >> 8) & 0xFF)
+        self._write_ea(ea, is_reg, result, word=True)
+        lo = result & 0xFF
+        n = bool(lo & BYTE_MSB)
+        z = lo == 0
+        self._set_nzvc(n, z, False, False)
+        return ("SWAB", f"SWAB mode={dst_mode} R{dst_reg}")
+
+    def _op_adc(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """ADC/ADCB: dst ← dst + C."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        carry_in = self._c()
+        n, z, v, c = nzvc_add(src, carry_in, word=word)
+        mask = WORD_MASK if word else BYTE_MASK
+        self._write_ea(ea, is_reg, (src + carry_in) & mask, word=word)
+        self._set_nzvc(n, z, v, c)
+        name = "ADC" if word else "ADCB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    def _op_sbc(self, dst_mode: int, dst_reg: int, *, word: bool) -> tuple[str, str]:
+        """SBC/SBCB: dst ← dst - C."""
+        ea, is_reg = self._ea(dst_mode, dst_reg, word=word)
+        src = self._read_ea(ea, is_reg, word=word)
+        carry_in = self._c()
+        n, z, v, c = nzvc_sub(src, carry_in, word=word)
+        mask = WORD_MASK if word else BYTE_MASK
+        self._write_ea(ea, is_reg, (src - carry_in) & mask, word=word)
+        self._set_nzvc(n, z, v, c)
+        name = "SBC" if word else "SBCB"
+        return (name, f"{name} mode={dst_mode} R{dst_reg}")
+
+    # ── Double-operand implementations ────────────────────────────────────────
+
+    def _op_mov(self, sm: int, sr: int, dm: int, dr: int, word: bool) -> tuple[str, str]:
+        """MOV/MOVB: dst ← src; N,Z from result; V=0, C unchanged."""
+        ea_s, is_reg_s = self._ea(sm, sr, word=word)
+        src = self._read_ea(ea_s, is_reg_s, word=word)
+        ea_d, is_reg_d = self._ea(dm, dr, word=word)
+        # MOVB to register: sign-extend byte to 16 bits
+        store_val = src
+        if not word and is_reg_d:
+            store_val = _sign_extend(src, 8) & WORD_MASK
+            self._r[ea_d] = store_val
+        else:
+            self._write_ea(ea_d, is_reg_d, src, word=word)
+        n, z, _, _ = nzvc_logic(src, word=word)
+        self._set_nzvc(n, z, False, self._get_c())
+        name = "MOV" if word else "MOVB"
+        return (name, f"{name} mode={sm},{dm}")
+
+    def _op_cmp(self, sm: int, sr: int, dm: int, dr: int, word: bool) -> tuple[str, str]:
+        """CMP/CMPB: src − dst (result discarded); set N,Z,V,C."""
+        ea_s, is_reg_s = self._ea(sm, sr, word=word)
+        src = self._read_ea(ea_s, is_reg_s, word=word)
+        ea_d, is_reg_d = self._ea(dm, dr, word=word)
+        dst = self._read_ea(ea_d, is_reg_d, word=word)
+        n, z, v, c = nzvc_sub(src, dst, word=word)
+        self._set_nzvc(n, z, v, c)
+        name = "CMP" if word else "CMPB"
+        return (name, f"{name} mode={sm},{dm}")
+
+    def _op_bit(self, sm: int, sr: int, dm: int, dr: int, word: bool) -> tuple[str, str]:
+        """BIT/BITB: src AND dst (result discarded); N,Z,V=0; C unchanged."""
+        ea_s, is_reg_s = self._ea(sm, sr, word=word)
+        src = self._read_ea(ea_s, is_reg_s, word=word)
+        ea_d, is_reg_d = self._ea(dm, dr, word=word)
+        dst = self._read_ea(ea_d, is_reg_d, word=word)
+        result = src & dst
+        n, z, _, _ = nzvc_logic(result, word=word)
+        self._set_nzvc(n, z, False, self._get_c())
+        name = "BIT" if word else "BITB"
+        return (name, f"{name} mode={sm},{dm}")
+
+    def _op_bic(self, sm: int, sr: int, dm: int, dr: int, word: bool) -> tuple[str, str]:
+        """BIC/BICB: dst ← dst AND NOT src; N,Z,V=0; C unchanged."""
+        ea_s, is_reg_s = self._ea(sm, sr, word=word)
+        src = self._read_ea(ea_s, is_reg_s, word=word)
+        ea_d, is_reg_d = self._ea(dm, dr, word=word)
+        dst = self._read_ea(ea_d, is_reg_d, word=word)
+        mask = WORD_MASK if word else BYTE_MASK
+        result = dst & (~src & mask)
+        self._write_ea(ea_d, is_reg_d, result, word=word)
+        n, z, _, _ = nzvc_logic(result, word=word)
+        self._set_nzvc(n, z, False, self._get_c())
+        name = "BIC" if word else "BICB"
+        return (name, f"{name} mode={sm},{dm}")
+
+    def _op_bis(self, sm: int, sr: int, dm: int, dr: int, word: bool) -> tuple[str, str]:
+        """BIS/BISB: dst ← dst OR src; N,Z,V=0; C unchanged."""
+        ea_s, is_reg_s = self._ea(sm, sr, word=word)
+        src = self._read_ea(ea_s, is_reg_s, word=word)
+        ea_d, is_reg_d = self._ea(dm, dr, word=word)
+        dst = self._read_ea(ea_d, is_reg_d, word=word)
+        result = dst | src
+        self._write_ea(ea_d, is_reg_d, result & (WORD_MASK if word else BYTE_MASK), word=word)
+        n, z, _, _ = nzvc_logic(result, word=word)
+        self._set_nzvc(n, z, False, self._get_c())
+        name = "BIS" if word else "BISB"
+        return (name, f"{name} mode={sm},{dm}")
+
+    def _op_add(self, sm: int, sr: int, dm: int, dr: int, word: bool) -> tuple[str, str]:
+        """ADD (word only): dst ← dst + src; N,Z,V,C set."""
+        ea_s, is_reg_s = self._ea(sm, sr, word=True)
+        src = self._read_ea(ea_s, is_reg_s, word=True)
+        ea_d, is_reg_d = self._ea(dm, dr, word=True)
+        dst = self._read_ea(ea_d, is_reg_d, word=True)
+        n, z, v, c = nzvc_add(dst, src, word=True)
+        self._write_ea(ea_d, is_reg_d, (dst + src) & WORD_MASK, word=True)
+        self._set_nzvc(n, z, v, c)
+        return ("ADD", f"ADD mode={sm},{dm}")
+
+    def _op_sub(self, sm: int, sr: int, dm: int, dr: int, word: bool) -> tuple[str, str]:
+        """SUB (word only): dst ← dst − src; N,Z,V,C set."""
+        ea_s, is_reg_s = self._ea(sm, sr, word=True)
+        src = self._read_ea(ea_s, is_reg_s, word=True)
+        ea_d, is_reg_d = self._ea(dm, dr, word=True)
+        dst = self._read_ea(ea_d, is_reg_d, word=True)
+        n, z, v, c = nzvc_sub(dst, src, word=True)
+        self._write_ea(ea_d, is_reg_d, (dst - src) & WORD_MASK, word=True)
+        self._set_nzvc(n, z, v, c)
+        return ("SUB", f"SUB mode={sm},{dm}")
+
+
+# ── Dispatch tables ───────────────────────────────────────────────────────────
+#
+# These tables are built after the class definition to reference the methods.
+# They map opcode numbers → bound methods.
+
+def _make_single_ops(sim_class):
+    """Build the single-operand dispatch table for PDP11Simulator."""
+    def _wrap_word(fn):
+        def wrapper(self, dm, dr): return fn(self, dm, dr, word=True)
+        return wrapper
+    def _wrap_byte(fn):
+        def wrapper(self, dm, dr): return fn(self, dm, dr, word=False)
+        return wrapper
+
+    return {
+        # SWAB: 0000 0000 11 mmm rrr → single_op bits 15-6 = 0x0003 (binary 0000000011)
+        0x003: lambda self, dm, dr: self._op_swab(dm, dr),
+        # CLR  0000 1000 0x  → 0x0200 >> 0 ...  single_op = (0x0200 >> 6) wait
+        # Let me compute: single_op = (iw >> 6) & 0x3FF
+        # CLR: iw = 0x0A00 | (mode<<3) | reg  → single_op = 0x0A00>>6 = 0x028
+        0x028: lambda self, dm, dr: self._op_clr(dm, dr, word=True),
+        # CLRB: iw = 0x8A00 → single_op = 0x8A00>>6 = 0x228
+        0x228: lambda self, dm, dr: self._op_clr(dm, dr, word=False),
+        # COM: iw = 0x0A40 → single_op = 0x0A40>>6 = 0x029
+        0x029: lambda self, dm, dr: self._op_com(dm, dr, word=True),
+        # COMB: iw = 0x8A40 → single_op = 0x229
+        0x229: lambda self, dm, dr: self._op_com(dm, dr, word=False),
+        # INC: iw = 0x0A80 → single_op = 0x02A
+        0x02A: lambda self, dm, dr: self._op_inc(dm, dr, word=True),
+        # INCB: iw = 0x8A80 → single_op = 0x22A
+        0x22A: lambda self, dm, dr: self._op_inc(dm, dr, word=False),
+        # DEC: iw = 0x0AC0 → single_op = 0x02B
+        0x02B: lambda self, dm, dr: self._op_dec(dm, dr, word=True),
+        # DECB: iw = 0x8AC0 → single_op = 0x22B
+        0x22B: lambda self, dm, dr: self._op_dec(dm, dr, word=False),
+        # NEG: iw = 0x0B00 → single_op = 0x02C
+        0x02C: lambda self, dm, dr: self._op_neg(dm, dr, word=True),
+        # NEGB: iw = 0x8B00 → single_op = 0x22C
+        0x22C: lambda self, dm, dr: self._op_neg(dm, dr, word=False),
+        # ADC: iw = 0x0B40 → single_op = 0x02D
+        0x02D: lambda self, dm, dr: self._op_adc(dm, dr, word=True),
+        # ADCB: iw = 0x8B40 → single_op = 0x22D
+        0x22D: lambda self, dm, dr: self._op_adc(dm, dr, word=False),
+        # SBC: iw = 0x0B80 → single_op = 0x02E
+        0x02E: lambda self, dm, dr: self._op_sbc(dm, dr, word=True),
+        # SBCB: iw = 0x8B80 → single_op = 0x22E
+        0x22E: lambda self, dm, dr: self._op_sbc(dm, dr, word=False),
+        # TST: iw = 0x0BC0 → single_op = 0x02F
+        0x02F: lambda self, dm, dr: self._op_tst(dm, dr, word=True),
+        # TSTB: iw = 0x8BC0 → single_op = 0x22F
+        0x22F: lambda self, dm, dr: self._op_tst(dm, dr, word=False),
+        # ROR:  octal 006000 = 0x0C00 → single_op = (0x0C00 >> 6) & 0x3FF = 0x030
+        0x030: lambda self, dm, dr: self._op_ror(dm, dr, word=True),
+        # RORB: bit15=1 → 0x8C00 → single_op = (0x8C00 >> 6) & 0x3FF = 0x230
+        0x230: lambda self, dm, dr: self._op_ror(dm, dr, word=False),
+        # ROL:  octal 006100 = 0x0C40 → single_op = 0x031
+        0x031: lambda self, dm, dr: self._op_rol(dm, dr, word=True),
+        # ROLB: 0x8C40 → single_op = 0x231
+        0x231: lambda self, dm, dr: self._op_rol(dm, dr, word=False),
+        # ASR:  octal 006200 = 0x0C80 → single_op = 0x032
+        0x032: lambda self, dm, dr: self._op_asr(dm, dr, word=True),
+        # ASRB: 0x8C80 → single_op = 0x232
+        0x232: lambda self, dm, dr: self._op_asr(dm, dr, word=False),
+        # ASL:  octal 006300 = 0x0CC0 → single_op = 0x033
+        0x033: lambda self, dm, dr: self._op_asl(dm, dr, word=True),
+        # ASLB: 0x8CC0 → single_op = 0x233
+        0x233: lambda self, dm, dr: self._op_asl(dm, dr, word=False),
+    }
+
+
+def _make_double_ops(sim_class):
+    """Build the double-operand dispatch table."""
+    return {
+        # op4 = 0x1 → MOV (word): iw bits 15-12 = 0001
+        0x1: lambda self, sm, sr, dm, dr, word: self._op_mov(sm, sr, dm, dr, True),
+        # op4 = 0x9 → MOVB (byte): bit15=1, bits 14-12 = 001
+        0x9: lambda self, sm, sr, dm, dr, word: self._op_mov(sm, sr, dm, dr, False),
+        # op4 = 0x2 → CMP
+        0x2: lambda self, sm, sr, dm, dr, word: self._op_cmp(sm, sr, dm, dr, True),
+        # op4 = 0xA → CMPB
+        0xA: lambda self, sm, sr, dm, dr, word: self._op_cmp(sm, sr, dm, dr, False),
+        # op4 = 0x3 → BIT
+        0x3: lambda self, sm, sr, dm, dr, word: self._op_bit(sm, sr, dm, dr, True),
+        # op4 = 0xB → BITB
+        0xB: lambda self, sm, sr, dm, dr, word: self._op_bit(sm, sr, dm, dr, False),
+        # op4 = 0x4 → BIC
+        0x4: lambda self, sm, sr, dm, dr, word: self._op_bic(sm, sr, dm, dr, True),
+        # op4 = 0xC → BICB
+        0xC: lambda self, sm, sr, dm, dr, word: self._op_bic(sm, sr, dm, dr, False),
+        # op4 = 0x5 → BIS
+        0x5: lambda self, sm, sr, dm, dr, word: self._op_bis(sm, sr, dm, dr, True),
+        # op4 = 0xD → BISB
+        0xD: lambda self, sm, sr, dm, dr, word: self._op_bis(sm, sr, dm, dr, False),
+        # op4 = 0x6 → ADD (word only)
+        0x6: lambda self, sm, sr, dm, dr, word: self._op_add(sm, sr, dm, dr, True),
+        # op4 = 0xE → SUB (word only): iw bits 15-12 = 1110
+        0xE: lambda self, sm, sr, dm, dr, word: self._op_sub(sm, sr, dm, dr, True),
+    }
+
+
+# ── Branch condition functions ────────────────────────────────────────────────
+#
+# Each function takes (n, z, v, c) and returns True if the branch is taken.
+
+def _br_always(n, z, v, c):  return True
+def _br_ne(n, z, v, c):      return not z
+def _br_eq(n, z, v, c):      return z
+def _br_ge(n, z, v, c):      return not (n ^ v)
+def _br_lt(n, z, v, c):      return n ^ v
+def _br_gt(n, z, v, c):      return not z and not (n ^ v)
+def _br_le(n, z, v, c):      return z or (n ^ v)
+def _br_pl(n, z, v, c):      return not n
+def _br_mi(n, z, v, c):      return n
+def _br_hi(n, z, v, c):      return not c and not z
+def _br_los(n, z, v, c):     return c or z
+def _br_vc(n, z, v, c):      return not v
+def _br_vs(n, z, v, c):      return v
+def _br_cc(n, z, v, c):      return not c
+def _br_cs(n, z, v, c):      return c
+
+# Maps opcode byte → (condition_fn, mnemonic)
+_BRANCH_TABLE: dict[int, tuple] = {
+    0x01: (_br_always, "BR"),
+    0x02: (_br_ne,     "BNE"),
+    0x03: (_br_eq,     "BEQ"),
+    0x04: (_br_ge,     "BGE"),
+    0x05: (_br_lt,     "BLT"),
+    0x06: (_br_gt,     "BGT"),
+    0x07: (_br_le,     "BLE"),
+    0x80: (_br_pl,     "BPL"),
+    0x81: (_br_mi,     "BMI"),
+    0x82: (_br_hi,     "BHI"),
+    0x83: (_br_los,    "BLOS"),
+    0x84: (_br_vc,     "BVC"),
+    0x85: (_br_vs,     "BVS"),
+    0x86: (_br_cc,     "BCC"),
+    0x87: (_br_cs,     "BCS"),
+}
+
+_BRANCH_OPCODES = {k: v[0] for k, v in _BRANCH_TABLE.items()}
+_BRANCH_NAMES   = {k: v[1] for k, v in _BRANCH_TABLE.items()}
+
+# ── Wire up dispatch tables ───────────────────────────────────────────────────
+
+_SINGLE_OPS = _make_single_ops(PDP11Simulator)
+_DOUBLE_OPS = _make_double_ops(PDP11Simulator)

--- a/code/packages/python/pdp11-simulator/src/pdp11_simulator/state.py
+++ b/code/packages/python/pdp11-simulator/src/pdp11_simulator/state.py
@@ -1,0 +1,146 @@
+"""State snapshot for the DEC PDP-11 (1970).
+
+──────────────────────────────────────────────────────────────────────────────
+THE MACHINE IN A NUTSHELL
+──────────────────────────────────────────────────────────────────────────────
+
+The DEC PDP-11 is the computer on which Unix was born.  Designed at Digital
+Equipment Corporation in 1970, it was a 16-bit minicomputer that introduced
+the concept of the *orthogonal ISA*: any addressing mode can be applied to
+any register in any instruction.  Eight 16-bit registers, eight addressing
+modes, and a beautifully uniform encoding that influenced every clean-ISA
+design that followed — including the Motorola 68000 and, through it, the MIPS
+and ARM architectures.
+
+Register file:
+
+  R0–R5   General-purpose 16-bit registers.  Fully symmetric: any ALU
+          operation can target any register with any addressing mode.
+
+  R6      SP — Stack Pointer.  Pre-decremented on push (``-(R6)``),
+          post-incremented on pop (``(R6)+``).  The PDP-11 hardware stack
+          grows downward, just like every major architecture since.
+
+  R7      PC — Program Counter.  The PC is in the general register file.
+          This means PC-relative addressing (``addr``, ``@addr``) and
+          immediate addressing (``#n``, ``@#addr``) are just the ordinary
+          autoincrement and index modes applied to R7.  There is no special
+          branch encoding — branches use a separate 8-bit signed offset.
+
+Processor Status Word (PSW), bits 3–0:
+
+  Bit 3: N — Negative; MSB of result
+  Bit 2: Z — Zero; result is zero
+  Bit 1: V — oVerflow; signed result out of range
+  Bit 0: C — Carry; unsigned overflow/borrow
+
+Memory:
+
+  64 KB flat byte-addressed little-endian address space.
+  Load address: 0x1000.  Initial SP: 0xF000.
+
+──────────────────────────────────────────────────────────────────────────────
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Size / mask constants ─────────────────────────────────────────────────────
+MEM_SIZE  = 65_536       # 64 KB — full 16-bit address space
+ADDR_MASK = 0xFFFF       # 16-bit address mask
+WORD_MASK = 0xFFFF       # 16-bit unsigned mask
+BYTE_MASK = 0xFF         # 8-bit unsigned mask
+WORD_MSB  = 0x8000       # MSB of 16-bit value
+BYTE_MSB  = 0x80         # MSB of 8-bit value
+
+LOAD_ADDR = 0x1000       # programs loaded at 0x1000
+INIT_SP   = 0xF000       # initial stack pointer
+
+# Register indices
+SP = 6   # R6 = stack pointer
+PC = 7   # R7 = program counter
+
+
+@dataclass(frozen=True)
+class PDP11State:
+    """Immutable snapshot of the DEC PDP-11 CPU state.
+
+    All register fields are unsigned 16-bit integers (0–65535).
+    The ``psw`` field stores the full Processor Status Word; bits 3–0 are
+    the condition codes N, Z, V, C.
+    ``memory`` is a 65536-byte tuple of the entire address space.
+
+    Attributes
+    ----------
+    r :
+        Eight 16-bit general-purpose registers as a tuple.
+        r[6] = SP (stack pointer), r[7] = PC (program counter).
+    psw :
+        16-bit Processor Status Word.  Bits 3–0 = N, Z, V, C.
+    halted :
+        True after a HALT instruction executes.
+    memory :
+        Full 64 KB address space as an immutable tuple of bytes.
+
+    Examples
+    --------
+    >>> import dataclasses
+    >>> mem = tuple([0] * 65536)
+    >>> s = PDP11State(r=(0,)*8, psw=0, halted=False, memory=mem)
+    >>> s.r[7]   # PC starts at 0
+    0
+    >>> s.n
+    False
+    """
+
+    r: tuple[int, ...]      # R0–R7 (length 8), each 0–65535
+    psw: int                # Processor Status Word (bits 3-0 = N,Z,V,C)
+    halted: bool
+    memory: tuple[int, ...]  # 65536 bytes
+
+    # ------------------------------------------------------------------
+    # Condition code properties (PSW bits 3–0)
+    # ------------------------------------------------------------------
+    #
+    #  Bit 3: N — Negative
+    #  Bit 2: Z — Zero
+    #  Bit 1: V — oVerflow
+    #  Bit 0: C — Carry
+    #
+
+    @property
+    def n(self) -> bool:
+        """Negative flag (PSW bit 3).
+
+        >>> PDP11State(r=(0,)*8, psw=0b1000, halted=False, memory=tuple([0]*65536)).n
+        True
+        """
+        return bool(self.psw & 0b1000)
+
+    @property
+    def z(self) -> bool:
+        """Zero flag (PSW bit 2).
+
+        >>> PDP11State(r=(0,)*8, psw=0b0100, halted=False, memory=tuple([0]*65536)).z
+        True
+        """
+        return bool(self.psw & 0b0100)
+
+    @property
+    def v(self) -> bool:
+        """Overflow flag (PSW bit 1).
+
+        >>> PDP11State(r=(0,)*8, psw=0b0010, halted=False, memory=tuple([0]*65536)).v
+        True
+        """
+        return bool(self.psw & 0b0010)
+
+    @property
+    def c(self) -> bool:
+        """Carry flag (PSW bit 0).
+
+        >>> PDP11State(r=(0,)*8, psw=0b0001, halted=False, memory=tuple([0]*65536)).c
+        True
+        """
+        return bool(self.psw & 0b0001)

--- a/code/packages/python/pdp11-simulator/tests/test_coverage.py
+++ b/code/packages/python/pdp11-simulator/tests/test_coverage.py
@@ -1,0 +1,497 @@
+"""Branch-coverage edge-case tests for PDP11Simulator.
+
+These tests target specific paths not covered by the primary test modules:
+mode 5/7 addressing, odd-address errors, byte-autoincrement PC/SP rules,
+flag helpers, state properties, and the flags module doctests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pdp11_simulator import PDP11Simulator, PDP11State
+from pdp11_simulator.flags import (
+    compute_c_sub,
+    compute_v_sub,
+    nzvc_add,
+    nzvc_logic,
+    nzvc_sub,
+    pack_psw,
+)
+from pdp11_simulator.state import INIT_SP, LOAD_ADDR, MEM_SIZE, PC, SP
+
+
+def _w(value: int) -> bytes:
+    return bytes([value & 0xFF, (value >> 8) & 0xFF])
+
+HALT = _w(0x0000)
+
+def _op(mode, reg): return (mode << 3) | reg
+def _mov(sm, sr, dm, dr): return _w(0x1000 | (_op(sm, sr) << 6) | _op(dm, dr))
+def _add(sm, sr, dm, dr): return _w(0x6000 | (_op(sm, sr) << 6) | _op(dm, dr))
+def _clr(mode, reg):      return _w(0x0A00 | _op(mode, reg))
+def _sob(reg, off):       return _w(0x7E00 | (reg << 6) | (off & 0x3F))
+def _rts(reg):            return _w(0x0080 | reg)   # octal 000 200
+def _jsr(link, mode, dst): return _w(0x0800 | (link << 6) | _op(mode, dst))
+
+
+# ── State / flags module tests ────────────────────────────────────────────────
+
+class TestFlagsModule:
+    def test_pack_psw_all_set(self):
+        assert pack_psw(True, True, True, True) == 0b1111
+
+    def test_pack_psw_all_clear(self):
+        assert pack_psw(False, False, False, False) == 0
+
+    def test_nzvc_add_zero_result(self):
+        n, z, v, c = nzvc_add(0xFF, 0x01, word=False)
+        assert not n and z and not v and c
+
+    def test_nzvc_sub_equal(self):
+        n, z, v, c = nzvc_sub(5, 5, word=True)
+        assert z and not n and not v and not c
+
+    def test_nzvc_logic_msb_set(self):
+        n, z, v, c = nzvc_logic(0x8000, word=True)
+        assert n and not z and not v and not c
+
+    def test_compute_v_sub_no_overflow(self):
+        assert not compute_v_sub(5, 3, 2, word=False)
+
+    def test_compute_c_sub_no_borrow(self):
+        assert not compute_c_sub(10, 5)
+
+
+class TestStateProperties:
+    def _state(self, psw: int) -> PDP11State:
+        return PDP11State(r=(0,)*8, psw=psw, halted=False, memory=tuple([0]*65536))
+
+    def test_n_flag(self):
+        assert self._state(0b1000).n
+        assert not self._state(0b0111).n
+
+    def test_z_flag(self):
+        assert self._state(0b0100).z
+        assert not self._state(0b1011).z
+
+    def test_v_flag(self):
+        assert self._state(0b0010).v
+        assert not self._state(0b1101).v
+
+    def test_c_flag(self):
+        assert self._state(0b0001).c
+        assert not self._state(0b1110).c
+
+    def test_state_constants(self):
+        assert MEM_SIZE == 65536
+        assert LOAD_ADDR == 0x1000
+        assert INIT_SP == 0xF000
+        assert SP == 6
+        assert PC == 7
+
+
+class TestMemoryErrors:
+    def test_odd_word_read_raises(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        with pytest.raises(ValueError, match="Odd address"):
+            sim._read_word(0x1001)
+
+    def test_odd_word_write_raises(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        with pytest.raises(ValueError, match="Odd address"):
+            sim._write_word(0x1003, 0x1234)
+
+
+class TestMode5AddressAutoDecrDeferred:
+    def test_mode5_autodec_deferred(self):
+        """Mode 5 (@-(Rn)): R-=2; EA=M[R]; operand=M[EA]."""
+        # Set up:
+        # M[0x2000] = 0x2100 (pointer stored here)
+        # M[0x2100] = 0xBEEF (data)
+        # R1 = 0x2002 (autodecrement → 0x2000)
+        # MOV @-(R1), R0 → R1=0x2000; EA=M[0x2000]=0x2100; R0=M[0x2100]=0xBEEF
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._mem[0x2000] = 0x00; sim._mem[0x2001] = 0x21  # 0x2100 LE
+        sim._mem[0x2100] = 0xEF; sim._mem[0x2101] = 0xBE  # 0xBEEF LE
+        sim._r[1] = 0x2002
+
+        # Load: MOV @-(R1), R0 = mode 5/R1 src, mode 0/R0 dst
+        sim._mem[LOAD_ADDR]   = 0x00 | _op(5, 1)  # low byte
+        sim._mem[LOAD_ADDR+1] = 0x14              # high byte: 0x1000 | (5<<9)|(1<<6) ...
+        # Let me compute correctly:
+        # MOV src dst = 0x1000 | (src_field << 6) | dst_field
+        # src_field = _op(5,1) = 0b101_001 = 0x29
+        # dst_field = _op(0,0) = 0
+        # iw = 0x1000 | (0x29 << 6) | 0 = 0x1000 | 0xA40 = 0x1A40
+        iw = 0x1000 | (_op(5, 1) << 6) | _op(0, 0)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0x00   # HALT
+        sim._mem[LOAD_ADDR+3] = 0x00
+
+        sim.step()   # MOV @-(R1), R0
+        assert sim._r[0] == 0xBEEF
+        assert sim._r[1] == 0x2000
+
+
+class TestMode7IndexDeferred:
+    def test_mode7_index_deferred(self):
+        """Mode 7 (@X(Rn)): EA = M[Rn + disp]; R0 = M[EA]."""
+        # R1 = 0x2000, disp = 4 → ptr_addr = 0x2004
+        # M[0x2004] = 0x2200 (points to data)
+        # M[0x2200] = 0x1234
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._mem[0x2004] = 0x00; sim._mem[0x2005] = 0x22  # 0x2200
+        sim._mem[0x2200] = 0x34; sim._mem[0x2201] = 0x12  # 0x1234
+        sim._r[1] = 0x2000
+
+        # MOV @4(R1), R0 = mode 7/R1 src, mode 0/R0 dst, followed by disp=4
+        iw = 0x1000 | (_op(7, 1) << 6) | _op(0, 0)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 4    # displacement low
+        sim._mem[LOAD_ADDR+3] = 0    # displacement high
+        sim._mem[LOAD_ADDR+4] = 0    # HALT
+        sim._mem[LOAD_ADDR+5] = 0
+
+        sim.step()
+        assert sim._r[0] == 0x1234
+
+
+class TestByteAutoIncrPCRule:
+    def test_byte_autoinc_sp_always_2(self):
+        """MOVB (SP)+, R0 should increment SP by 2 (not 1) because SP=R6."""
+        # Place a byte value at the stack and pop it with MOVB
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[6] = 0xF000
+        sim._mem[0xF000] = 0x42   # byte value at SP
+        sim._mem[0xF001] = 0x00
+
+        # MOVB (R6)+, R0  = mode 2/R6 src, mode 0/R0 dst  (byte version = 0x9000 base)
+        iw = 0x9000 | (_op(2, 6) << 6) | _op(0, 0)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+
+        sp_before = sim._r[6]
+        sim.step()
+        # SP should advance by 2 (not 1)
+        assert sim._r[6] == sp_before + 2
+
+    def test_byte_autoinc_normal_reg_steps_by_1(self):
+        """MOVB (R0)+, R1 should increment R0 by 1 (byte step) for non-SP/PC registers."""
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x2000
+        sim._mem[0x2000] = 0x55
+
+        # MOVB (R0)+, R1 = mode2/R0 src, mode0/R1 dst (byte)
+        iw = 0x9000 | (_op(2, 0) << 6) | _op(0, 1)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+
+        sim.step()
+        assert sim._r[0] == 0x2001   # incremented by 1 only
+
+
+class TestSOBEdgeCases:
+    def test_sob_at_zero_no_branch(self):
+        """SOB with R already 0 after decrement should not branch."""
+        sim = PDP11Simulator()
+        sim._r[1] = 1   # will decrement to 0
+        sim._r[7] = LOAD_ADDR
+
+        iw = 0x7E00 | (1 << 6) | 5   # SOB R1, offset=5
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0   # HALT
+        sim._mem[LOAD_ADDR+3] = 0
+
+        sim.step()   # SOB: R1 → 0, no branch
+        assert sim._r[1] == 0
+        assert sim._r[7] == LOAD_ADDR + 2   # falls through to HALT
+
+
+class TestExecuteErrorPath:
+    def test_execute_with_bad_opcode(self):
+        """execute() catches ValueError from bad opcode and sets error."""
+        sim = PDP11Simulator()
+        # JMP mode=0 (illegal) then HALT
+        iw = 0x0040 | _op(0, 0)  # JMP mode 0 (illegal)
+        prog = bytes([iw & 0xFF, (iw >> 8) & 0xFF]) + HALT
+        result = sim.execute(prog)
+        assert not result.ok
+        assert result.error is not None
+
+
+class TestRTSVariants:
+    def test_rts_with_link_register_not_pc(self):
+        """RTS R0: PC ← R0; R0 ← (SP)+."""
+        sim = PDP11Simulator()
+        sim.reset()
+        # Set R0 = return target (0x2000)
+        # Push 0xABCD onto stack as the old R0 value
+        sim._r[0]  = 0x2000     # return address in R0
+        sim._r[6]  = 0xEFFE     # SP - 2 already
+        sim._mem[0xEFFE] = 0xCD; sim._mem[0xEFFF] = 0xAB   # 0xABCD on stack
+
+        # Place RTS R0 at 0x1000
+        sim._mem[LOAD_ADDR]   = 0x80   # RTS R0 = 0x0080
+        sim._mem[LOAD_ADDR+1] = 0x00
+
+        sim._r[7] = LOAD_ADDR
+        sim.step()   # RTS R0
+
+        assert sim._r[7] == 0x2000   # PC ← old R0
+        assert sim._r[0] == 0xABCD   # R0 ← popped value
+        assert sim._r[6] == 0xF000   # SP restored
+
+
+class TestINCDECByteVariants:
+    def test_incb_memory(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._mem[0x2000] = 0x0A
+        sim._r[1] = 0x2000
+
+        iw = 0x8A80 | _op(1, 1)  # INCB (R1)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert sim._mem[0x2000] == 0x0B
+
+    def test_decb_memory(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._mem[0x2000] = 0x0A
+        sim._r[1] = 0x2000
+
+        iw = 0x8AC0 | _op(1, 1)  # DECB (R1)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert sim._mem[0x2000] == 0x09
+
+
+class TestAdcSbcByteVariants:
+    def test_adcb_with_carry(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x000A
+        sim._psw  = 0b0001   # C=1
+
+        iw = 0x8B40 | _op(0, 0)  # ADCB R0
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert (sim._r[0] & 0xFF) == 0x0B
+
+    def test_sbcb_with_carry(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x000A
+        sim._psw  = 0b0001   # C=1
+
+        iw = 0x8B80 | _op(0, 0)  # SBCB R0
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert (sim._r[0] & 0xFF) == 0x09
+
+
+class TestTstbCmpb:
+    def test_tstb_memory(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._mem[0x2000] = 0x00
+        sim._r[1] = 0x2000
+
+        iw = 0x8BC0 | _op(1, 1)  # TSTB (R1)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert sim._psw & 0b0100   # Z=1
+
+    def test_cmpb(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x0005
+        sim._r[1] = 0x0005
+
+        # CMPB R0, R1 = 0xA000 | (src << 6) | dst
+        iw = 0xA000 | (_op(0, 0) << 6) | _op(0, 1)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert sim._psw & 0b0100   # Z=1 (equal)
+
+
+class TestRolRorByteVariants:
+    def test_rolb_register(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x0001
+        sim._psw  = 0b0000
+
+        iw = 0x8C40 | _op(0, 0)  # ROLB R0  (octal 106100)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert (sim._r[0] & 0xFF) == 0x02
+        assert not (sim._psw & 1)   # C=0 (old bit7 of 0x01 = 0)
+
+    def test_asrb_sign_fill(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x0080   # byte = 0x80 = -128
+
+        iw = 0x8C80 | _op(0, 0)  # ASRB R0  (octal 106200)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        # ASRB 0x80: sign bit preserved → 0xC0
+        assert (sim._r[0] & 0xFF) == 0xC0
+
+    def test_aslb(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x0040
+
+        iw = 0x8CC0 | _op(0, 0)  # ASLB R0  (octal 106300)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert (sim._r[0] & 0xFF) == 0x80
+        assert not (sim._psw & 1)   # C=0 (old bit7 of 0x40 = 0)
+
+
+class TestBicBisBitByteVariants:
+    def test_bicb(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x00FF
+        sim._r[1] = 0x000F
+
+        # BICB R1, R0: R0 = R0 & ~R1 (byte) = 0xFF & ~0x0F = 0xF0
+        iw = 0xC000 | (_op(0, 1) << 6) | _op(0, 0)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert (sim._r[0] & 0xFF) == 0xF0
+
+    def test_bisb(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x000F
+        sim._r[1] = 0x00F0
+
+        # BISB R1, R0: R0 = R0 | R1 = 0xFF
+        iw = 0xD000 | (_op(0, 1) << 6) | _op(0, 0)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert (sim._r[0] & 0xFF) == 0xFF
+
+    def test_bitb(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x00FF
+        sim._r[1] = 0x0000
+
+        # BITB R1, R0: test = 0xFF & 0x00 = 0 → Z=1
+        iw = 0xB000 | (_op(0, 1) << 6) | _op(0, 0)
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert sim._psw & 0b0100   # Z=1
+
+
+class TestNegbComb:
+    def test_negb_zero(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x0000
+
+        iw = 0x8B00 | _op(0, 0)  # NEGB R0
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert (sim._r[0] & 0xFF) == 0
+        assert not (sim._psw & 1)   # C=0
+
+    def test_comb_register(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._r[0] = 0x00F0
+
+        iw = 0x8A40 | _op(0, 0)  # COMB R0
+        sim._mem[LOAD_ADDR]   = iw & 0xFF
+        sim._mem[LOAD_ADDR+1] = (iw >> 8) & 0xFF
+        sim._mem[LOAD_ADDR+2] = 0
+        sim._mem[LOAD_ADDR+3] = 0
+        sim._r[7] = LOAD_ADDR
+
+        sim.step()
+        assert (sim._r[0] & 0xFF) == 0x0F
+        assert sim._psw & 1   # C=1 always for COM

--- a/code/packages/python/pdp11-simulator/tests/test_instructions.py
+++ b/code/packages/python/pdp11-simulator/tests/test_instructions.py
@@ -1,0 +1,1136 @@
+"""Per-instruction correctness tests for PDP11Simulator.
+
+Each test targets a specific instruction or addressing mode.  Programs are
+assembled by hand using well-documented encodings.
+
+PDP-11 instruction encoding quick reference:
+  MOV  src, dst  = 0001 sss sss ddd ddd  (bits 15-12=0x1, src=11:6, dst=5:0)
+  ADD  src, dst  = 0110 sss sss ddd ddd  (bits 15-12=0x6)
+  SUB  src, dst  = 1110 sss sss ddd ddd  (bits 15-12=0xE)
+  CMP  src, dst  = 0010 sss sss ddd ddd  (bits 15-12=0x2)
+  BIS  src, dst  = 0101 sss sss ddd ddd  (bits 15-12=0x5)
+  BIC  src, dst  = 0100 sss sss ddd ddd  (bits 15-12=0x4)
+  BIT  src, dst  = 0011 sss sss ddd ddd  (bits 15-12=0x3)
+  MOVB src, dst  = 1001 sss sss ddd ddd  (bit 15=1, bits 14-12=0x1)
+  CLR  dst       = 0000 1010 00 mmm rrr  = 0x0A00 | (mode<<3) | reg
+  COM  dst       = 0000 1010 01 mmm rrr  = 0x0A40 ...
+  INC  dst       = 0000 1010 10 mmm rrr  = 0x0A80 ...
+  DEC  dst       = 0000 1010 11 mmm rrr  = 0x0AC0 ...
+  NEG  dst       = 0000 1011 00 mmm rrr  = 0x0B00 ...
+  ADC  dst       = 0000 1011 01 mmm rrr  = 0x0B40 ...
+  SBC  dst       = 0000 1011 10 mmm rrr  = 0x0B80 ...
+  TST  dst       = 0000 1011 11 mmm rrr  = 0x0BC0 ...
+  ROR  dst       = 0110 0000 00 mmm rrr  = 0x6000 ...
+  ROL  dst       = 0110 0000 01 mmm rrr  = 0x6040 ...
+  ASR  dst       = 0110 0000 10 mmm rrr  = 0x6080 ...
+  ASL  dst       = 0110 0000 11 mmm rrr  = 0x60C0 ...
+  SWAB dst       = 0000 0000 11 mmm rrr  = 0x00C0 ...
+  BR   offset    = 0000 0001 oooooooo    = 0x0100 | offset
+  BNE  offset    = 0000 0010 oooooooo
+  BEQ  offset    = 0000 0011 oooooooo
+  BGE  offset    = 0000 0100 oooooooo
+  BLT  offset    = 0000 0101 oooooooo
+  BGT  offset    = 0000 0110 oooooooo
+  BLE  offset    = 0000 0111 oooooooo
+  BPL  offset    = 1000 0000 oooooooo    = 0x8000 | offset
+  BMI  offset    = 1000 0001 oooooooo
+  BHI  offset    = 1000 0010 oooooooo
+  BLOS offset    = 1000 0011 oooooooo
+  BVC  offset    = 1000 0100 oooooooo
+  BVS  offset    = 1000 0101 oooooooo
+  BCC  offset    = 1000 0110 oooooooo
+  BCS  offset    = 1000 0111 oooooooo
+  JMP  dst       = 0000 0000 01 mmm rrr  = 0x0040 | (mode<<3) | reg
+  JSR  reg, dst  = 0000 1000 rrr mmm ddd = 0x0800 | (reg<<6) | (mode<<3) | dst
+  RTS  reg       = 0000 0000 1000 0 rrr  = 0x0200 | reg
+  SOB  reg, off  = 0111 11 rrr oooooo    = 0x7E00 | (reg<<6) | offset
+  HALT           = 0x0000
+  NOP            = 0x00A0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pdp11_simulator import PDP11Simulator, PDP11State
+
+
+def _w(value: int) -> bytes:
+    """Pack a 16-bit integer as little-endian word bytes."""
+    return bytes([value & 0xFF, (value >> 8) & 0xFF])
+
+HALT = _w(0x0000)
+NOP  = _w(0x00A0)
+
+def _run(prog: bytes) -> PDP11State:
+    """Run a program and return the final state."""
+    sim = PDP11Simulator()
+    result = sim.execute(prog)
+    assert result.ok, f"Simulation error: {result.error}"
+    return result.final_state
+
+
+# ── Helper: encode operand field (mode, reg) as 6-bit field ──────────────────
+def _op(mode: int, reg: int) -> int:
+    return (mode << 3) | reg
+
+def _mov(src_mode, src_reg, dst_mode, dst_reg) -> bytes:
+    """Encode MOV src, dst."""
+    return _w(0x1000 | (_op(src_mode, src_reg) << 6) | _op(dst_mode, dst_reg))
+
+def _add(src_mode, src_reg, dst_mode, dst_reg) -> bytes:
+    """Encode ADD src, dst."""
+    return _w(0x6000 | (_op(src_mode, src_reg) << 6) | _op(dst_mode, dst_reg))
+
+def _sub(src_mode, src_reg, dst_mode, dst_reg) -> bytes:
+    """Encode SUB src, dst."""
+    return _w(0xE000 | (_op(src_mode, src_reg) << 6) | _op(dst_mode, dst_reg))
+
+def _cmp(src_mode, src_reg, dst_mode, dst_reg) -> bytes:
+    """Encode CMP src, dst."""
+    return _w(0x2000 | (_op(src_mode, src_reg) << 6) | _op(dst_mode, dst_reg))
+
+def _bit(src_mode, src_reg, dst_mode, dst_reg) -> bytes:
+    return _w(0x3000 | (_op(src_mode, src_reg) << 6) | _op(dst_mode, dst_reg))
+
+def _bic(src_mode, src_reg, dst_mode, dst_reg) -> bytes:
+    return _w(0x4000 | (_op(src_mode, src_reg) << 6) | _op(dst_mode, dst_reg))
+
+def _bis(src_mode, src_reg, dst_mode, dst_reg) -> bytes:
+    return _w(0x5000 | (_op(src_mode, src_reg) << 6) | _op(dst_mode, dst_reg))
+
+def _movb(src_mode, src_reg, dst_mode, dst_reg) -> bytes:
+    return _w(0x9000 | (_op(src_mode, src_reg) << 6) | _op(dst_mode, dst_reg))
+
+def _clr(mode, reg)   -> bytes: return _w(0x0A00 | _op(mode, reg))
+def _com(mode, reg)   -> bytes: return _w(0x0A40 | _op(mode, reg))
+def _inc(mode, reg)   -> bytes: return _w(0x0A80 | _op(mode, reg))
+def _dec(mode, reg)   -> bytes: return _w(0x0AC0 | _op(mode, reg))
+def _neg(mode, reg)   -> bytes: return _w(0x0B00 | _op(mode, reg))
+def _adc(mode, reg)   -> bytes: return _w(0x0B40 | _op(mode, reg))
+def _sbc(mode, reg)   -> bytes: return _w(0x0B80 | _op(mode, reg))
+def _tst(mode, reg)   -> bytes: return _w(0x0BC0 | _op(mode, reg))
+def _ror(mode, reg)   -> bytes: return _w(0x0C00 | _op(mode, reg))  # octal 006000
+def _rol(mode, reg)   -> bytes: return _w(0x0C40 | _op(mode, reg))  # octal 006100
+def _asr(mode, reg)   -> bytes: return _w(0x0C80 | _op(mode, reg))  # octal 006200
+def _asl(mode, reg)   -> bytes: return _w(0x0CC0 | _op(mode, reg))  # octal 006300
+def _swab(mode, reg)  -> bytes: return _w(0x00C0 | _op(mode, reg))
+def _clrb(mode, reg)  -> bytes: return _w(0x8A00 | _op(mode, reg))
+def _comb(mode, reg)  -> bytes: return _w(0x8A40 | _op(mode, reg))
+def _incb(mode, reg)  -> bytes: return _w(0x8A80 | _op(mode, reg))
+def _decb(mode, reg)  -> bytes: return _w(0x8AC0 | _op(mode, reg))
+def _negb(mode, reg)  -> bytes: return _w(0x8B00 | _op(mode, reg))
+def _adcb(mode, reg)  -> bytes: return _w(0x8B40 | _op(mode, reg))
+def _sbcb(mode, reg)  -> bytes: return _w(0x8B80 | _op(mode, reg))
+def _tstb(mode, reg)  -> bytes: return _w(0x8BC0 | _op(mode, reg))
+def _rorb(mode, reg)  -> bytes: return _w(0x8C00 | _op(mode, reg))  # octal 106000
+def _rolb(mode, reg)  -> bytes: return _w(0x8C40 | _op(mode, reg))  # octal 106100
+def _asrb(mode, reg)  -> bytes: return _w(0x8C80 | _op(mode, reg))  # octal 106200
+def _aslb(mode, reg)  -> bytes: return _w(0x8CC0 | _op(mode, reg))  # octal 106300
+
+def _br(offset)   -> bytes: return _w(0x0100 | (offset & 0xFF))
+def _bne(offset)  -> bytes: return _w(0x0200 | (offset & 0xFF))
+def _beq(offset)  -> bytes: return _w(0x0300 | (offset & 0xFF))
+def _bge(offset)  -> bytes: return _w(0x0400 | (offset & 0xFF))
+def _blt(offset)  -> bytes: return _w(0x0500 | (offset & 0xFF))
+def _bgt(offset)  -> bytes: return _w(0x0600 | (offset & 0xFF))
+def _ble(offset)  -> bytes: return _w(0x0700 | (offset & 0xFF))
+def _bpl(offset)  -> bytes: return _w(0x8000 | (offset & 0xFF))
+def _bmi(offset)  -> bytes: return _w(0x8100 | (offset & 0xFF))
+def _bhi(offset)  -> bytes: return _w(0x8200 | (offset & 0xFF))
+def _blos(offset) -> bytes: return _w(0x8300 | (offset & 0xFF))
+def _bvc(offset)  -> bytes: return _w(0x8400 | (offset & 0xFF))
+def _bvs(offset)  -> bytes: return _w(0x8500 | (offset & 0xFF))
+def _bcc(offset)  -> bytes: return _w(0x8600 | (offset & 0xFF))
+def _bcs(offset)  -> bytes: return _w(0x8700 | (offset & 0xFF))
+
+def _jmp(mode, reg) -> bytes: return _w(0x0040 | _op(mode, reg))
+def _jsr(link, mode, dst_reg) -> bytes:
+    return _w(0x0800 | (link << 6) | _op(mode, dst_reg))
+def _rts(reg) -> bytes: return _w(0x0080 | reg)   # octal 000 200
+def _sob(reg, offset) -> bytes: return _w(0x7E00 | (reg << 6) | (offset & 0x3F))
+
+
+# ── MOV tests ─────────────────────────────────────────────────────────────────
+
+class TestMOV:
+    def test_mov_imm_to_r0(self):
+        # MOV #42, R0: src=mode2/R7 (immediate), dst=mode0/R0
+        prog = _mov(2, 7, 0, 0) + _w(42) + HALT
+        s = _run(prog)
+        assert s.r[0] == 42
+
+    def test_mov_r0_to_r1(self):
+        # Load R0=10 via immediate, then MOV R0, R1
+        prog = _mov(2, 7, 0, 0) + _w(10) + _mov(0, 0, 0, 1) + HALT
+        s = _run(prog)
+        assert s.r[1] == 10
+
+    def test_mov_clears_v_flag(self):
+        # MOV should always clear V
+        sim = PDP11Simulator()
+        sim._psw = 0b0010   # V=1
+        sim.load(_mov(2, 7, 0, 0) + _w(1) + HALT)
+        sim.execute(_mov(2, 7, 0, 0) + _w(1) + HALT)
+        state = sim.get_state()
+        assert not state.v
+
+    def test_mov_negative_sets_n(self):
+        # MOV #0x8000, R0 → N=1
+        prog = _mov(2, 7, 0, 0) + _w(0x8000) + HALT
+        s = _run(prog)
+        assert s.n
+        assert not s.z
+
+    def test_mov_zero_sets_z(self):
+        prog = _mov(2, 7, 0, 0) + _w(0) + HALT
+        s = _run(prog)
+        assert s.z
+        assert not s.n
+
+    def test_mov_to_memory(self):
+        # MOV R0, (R1): R0=0x1234, R1 points to some address
+        # Set up: MOV #0x1234, R0; MOV #0x2000, R1; MOV R0, (R1); HALT
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x1234)   # MOV #0x1234, R0
+            + _mov(2, 7, 0, 1) + _w(0x2000) # MOV #0x2000, R1
+            + _mov(0, 0, 1, 1)               # MOV R0, (R1)
+            + HALT
+        )
+        s = _run(prog)
+        word_at_2000 = s.memory[0x2000] | (s.memory[0x2001] << 8)
+        assert word_at_2000 == 0x1234
+
+    def test_mov_from_memory(self):
+        # Store 0x5678 at 0x2000, then MOV (R1), R0
+        sim = PDP11Simulator()
+        sim.reset()
+        sim._mem[0x2000] = 0x78
+        sim._mem[0x2001] = 0x56
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x2000)  # MOV #0x2000, R1
+            + _mov(1, 1, 0, 0)              # MOV (R1), R0
+            + HALT
+        )
+        sim.load(prog)
+        # Restore the memory data since load() zeros memory
+        sim._mem[0x2000] = 0x78
+        sim._mem[0x2001] = 0x56
+        # Use step-by-step
+        sim.step(); sim.step(); sim.step()
+        state = sim.get_state()
+        assert state.r[0] == 0x5678
+
+
+class TestMOVB:
+    def test_movb_imm_to_memory(self):
+        # MOVB #0xAB, (R1): store byte at R1
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x2000)   # MOV #0x2000, R1
+            + _movb(2, 7, 1, 1) + _w(0xAB)  # MOVB #0xAB, (R1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.memory[0x2000] == 0xAB
+
+    def test_movb_sign_extends_to_register(self):
+        # MOVB #0xFF, R0 → R0 should be 0xFFFF (sign extended)
+        prog = _movb(2, 7, 0, 0) + _w(0x00FF) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0xFFFF
+
+    def test_movb_positive_no_extend(self):
+        # MOVB #0x7F, R0 → R0 = 0x007F
+        prog = _movb(2, 7, 0, 0) + _w(0x007F) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x007F
+
+
+# ── ADD tests ─────────────────────────────────────────────────────────────────
+
+class TestADD:
+    def test_add_basic(self):
+        # ADD R0, R1: R0=3, R1=4 → R1=7
+        prog = (
+            _mov(2, 7, 0, 0) + _w(3)   # MOV #3, R0
+            + _mov(2, 7, 0, 1) + _w(4) # MOV #4, R1
+            + _add(0, 0, 0, 1)          # ADD R0, R1
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 7
+        assert not s.n and not s.z and not s.v and not s.c
+
+    def test_add_sets_carry(self):
+        # 0xFFFF + 1 = 0x10000 → C=1, Z=1
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0xFFFF)
+            + _mov(2, 7, 0, 1) + _w(1)
+            + _add(0, 0, 0, 1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 0
+        assert s.z
+        assert s.c
+
+    def test_add_sets_overflow(self):
+        # 0x7FFF + 1 = 0x8000 → V=1 (positive + positive = negative)
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x7FFF)
+            + _mov(2, 7, 0, 1) + _w(1)
+            + _add(0, 0, 0, 1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 0x8000
+        assert s.v
+        assert s.n
+
+    def test_add_sets_negative(self):
+        # ADD results in negative number
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x8000)  # -32768
+            + _mov(2, 7, 0, 1) + _w(0xFFFF) # -1
+            + _add(0, 0, 0, 1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 0x7FFF   # wraps
+        assert s.c
+
+
+# ── SUB tests ─────────────────────────────────────────────────────────────────
+
+class TestSUB:
+    def test_sub_basic(self):
+        # SUB R0, R1: dst=R1=10, src=R0=3 → R1 = 10-3 = 7
+        prog = (
+            _mov(2, 7, 0, 0) + _w(3)
+            + _mov(2, 7, 0, 1) + _w(10)
+            + _sub(0, 0, 0, 1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 7
+        assert not s.c
+
+    def test_sub_borrow(self):
+        # 3 - 5 = -2 (0xFFFE); C=1 (borrow)
+        prog = (
+            _mov(2, 7, 0, 0) + _w(5)
+            + _mov(2, 7, 0, 1) + _w(3)
+            + _sub(0, 0, 0, 1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 0xFFFE
+        assert s.c
+        assert s.n
+
+    def test_sub_overflow(self):
+        # 0x8000 - 1 = 0x7FFF → V=1 (neg minus pos = pos? no: neg minus pos)
+        # Actually: -32768 - 1 should underflow to +32767
+        prog = (
+            _mov(2, 7, 0, 0) + _w(1)
+            + _mov(2, 7, 0, 1) + _w(0x8000)
+            + _sub(0, 0, 0, 1)   # R1 = 0x8000 - 1 = 0x7FFF
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 0x7FFF
+        assert s.v
+
+
+# ── CMP tests ─────────────────────────────────────────────────────────────────
+
+class TestCMP:
+    def test_cmp_equal(self):
+        prog = (
+            _mov(2, 7, 0, 0) + _w(5)
+            + _mov(2, 7, 0, 1) + _w(5)
+            + _cmp(0, 0, 0, 1)   # CMP R0, R1 = R0 - R1 = 5-5=0
+            + HALT
+        )
+        s = _run(prog)
+        assert s.z
+        assert not s.n and not s.c
+
+    def test_cmp_less_than(self):
+        # CMP R0, R1 = R0 - R1; if R0=3, R1=5 → 3-5=-2 → N=1, C=1
+        prog = (
+            _mov(2, 7, 0, 0) + _w(3)
+            + _mov(2, 7, 0, 1) + _w(5)
+            + _cmp(0, 0, 0, 1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.n
+        assert s.c
+        assert not s.z
+
+    def test_cmp_does_not_modify_registers(self):
+        prog = (
+            _mov(2, 7, 0, 0) + _w(7)
+            + _mov(2, 7, 0, 1) + _w(3)
+            + _cmp(0, 0, 0, 1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 7   # untouched
+        assert s.r[1] == 3   # untouched
+
+
+# ── BIT / BIC / BIS tests ─────────────────────────────────────────────────────
+
+class TestBitOps:
+    def test_bit_nonzero(self):
+        # BIT #0xFF00, R0 with R0=0x0F0F → 0xFF00 & 0x0F0F = 0x0F00 → N=0, Z=0
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x0F0F)
+            + _bit(2, 7, 0, 0) + _w(0xFF00)
+            + HALT
+        )
+        s = _run(prog)
+        assert not s.z
+        assert not s.v
+        assert s.r[0] == 0x0F0F   # BIT doesn't modify dst
+
+    def test_bit_zero(self):
+        # BIT #0xFF00, R0 with R0=0x00FF → result=0 → Z=1
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x00FF)
+            + _bit(2, 7, 0, 0) + _w(0xFF00)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.z
+
+    def test_bic_clears_bits(self):
+        # BIC #0x000F, R0 with R0=0x00FF → R0 = 0x00FF & ~0x000F = 0x00F0
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x00FF)
+            + _bic(2, 7, 0, 0) + _w(0x000F)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 0x00F0
+
+    def test_bis_sets_bits(self):
+        # BIS #0x00F0, R0 with R0=0x000F → R0 = 0x00FF
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x000F)
+            + _bis(2, 7, 0, 0) + _w(0x00F0)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 0x00FF
+
+
+# ── Single-operand tests ──────────────────────────────────────────────────────
+
+class TestCLR:
+    def test_clr_register(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x1234) + _clr(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0
+        assert s.z and not s.n and not s.v and not s.c
+
+    def test_clrb_memory(self):
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x2000)
+            + _mov(2, 7, 0, 0) + _w(0x00AB)
+            + _mov(0, 0, 1, 1)              # MOV R0, (R1) — write 0x00AB to 0x2000
+            + _clrb(1, 1)                   # CLRB (R1) — zero the byte at 0x2000
+            + HALT
+        )
+        s = _run(prog)
+        assert s.memory[0x2000] == 0
+
+
+class TestCOM:
+    def test_com_register(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x0F0F) + _com(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0xF0F0
+        assert s.c   # COM always sets C
+
+    def test_com_zero_result(self):
+        prog = _mov(2, 7, 0, 0) + _w(0xFFFF) + _com(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0
+        assert s.z
+
+
+class TestINCDEC:
+    def test_inc(self):
+        prog = _mov(2, 7, 0, 0) + _w(5) + _inc(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 6
+
+    def test_inc_overflow(self):
+        # 0x7FFF + 1 = 0x8000 → V=1
+        prog = _mov(2, 7, 0, 0) + _w(0x7FFF) + _inc(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x8000
+        assert s.v
+
+    def test_inc_does_not_change_c(self):
+        sim = PDP11Simulator()
+        # load() resets PSW; set C=1 after loading
+        sim.load(_mov(2, 7, 0, 0) + _w(5) + _inc(0, 0) + HALT)
+        sim._psw = 0b0001   # C=1 (set after load so reset doesn't clear it)
+        sim.step(); sim.step(); sim.step()
+        assert sim._psw & 1   # C unchanged
+
+    def test_dec(self):
+        prog = _mov(2, 7, 0, 0) + _w(5) + _dec(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 4
+
+    def test_dec_underflow_overflow(self):
+        # 0x8000 - 1 = 0x7FFF → V=1
+        prog = _mov(2, 7, 0, 0) + _w(0x8000) + _dec(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x7FFF
+        assert s.v
+
+
+class TestNEG:
+    def test_neg_positive(self):
+        prog = _mov(2, 7, 0, 0) + _w(5) + _neg(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0xFFFB   # -5 = 0xFFFB
+        assert s.c   # C=1 (result != 0)
+
+    def test_neg_zero(self):
+        prog = _clr(0, 0) + _neg(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0
+        assert not s.c   # C=0 when result=0
+
+    def test_neg_most_negative(self):
+        # NEG 0x8000 = 0x8000; V=1
+        prog = _mov(2, 7, 0, 0) + _w(0x8000) + _neg(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x8000
+        assert s.v
+
+
+class TestTST:
+    def test_tst_positive(self):
+        prog = _mov(2, 7, 0, 0) + _w(42) + _tst(0, 0) + HALT
+        s = _run(prog)
+        assert not s.n and not s.z and not s.v and not s.c
+
+    def test_tst_negative(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x8000) + _tst(0, 0) + HALT
+        s = _run(prog)
+        assert s.n and not s.z
+
+    def test_tst_zero(self):
+        prog = _clr(0, 0) + _tst(0, 0) + HALT
+        s = _run(prog)
+        assert s.z and not s.n
+
+
+class TestSWAB:
+    def test_swab(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x1234) + _swab(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x3412
+
+    def test_swab_n_from_low_byte(self):
+        # SWAB 0x00FF → 0xFF00; N from low byte of result = 0x00 → N=0
+        prog = _mov(2, 7, 0, 0) + _w(0x00FF) + _swab(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0xFF00
+        assert not s.n   # N from low byte = 0x00
+
+    def test_swab_n_from_low_byte_set(self):
+        # SWAB 0xFF00 → 0x00FF; low byte = 0xFF → N=1
+        prog = _mov(2, 7, 0, 0) + _w(0xFF00) + _swab(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x00FF
+        assert s.n   # N from low byte = 0xFF → bit 7 set
+
+
+class TestADCSBC:
+    def test_adc_with_carry(self):
+        sim = PDP11Simulator()
+        sim.load(_mov(2, 7, 0, 0) + _w(5) + _adc(0, 0) + HALT)
+        sim._psw = 0b0001   # C=1 (set after load)
+        sim.step(); sim.step(); sim.step()
+        assert sim._r[0] == 6
+
+    def test_adc_without_carry(self):
+        prog = _mov(2, 7, 0, 0) + _w(5) + _adc(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 5   # 5 + 0 = 5
+
+    def test_sbc_with_carry(self):
+        sim = PDP11Simulator()
+        sim.load(_mov(2, 7, 0, 0) + _w(5) + _sbc(0, 0) + HALT)
+        sim._psw = 0b0001   # C=1 (set after load)
+        sim.step(); sim.step(); sim.step()
+        assert sim._r[0] == 4   # 5 - 1 = 4
+
+    def test_sbc_without_carry(self):
+        prog = _mov(2, 7, 0, 0) + _w(5) + _sbc(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 5   # 5 - 0 = 5
+
+
+# ── Shift and rotate tests ────────────────────────────────────────────────────
+
+class TestShifts:
+    def test_asr_word(self):
+        # ASR 0x0010 → 0x0008; C=0
+        prog = _mov(2, 7, 0, 0) + _w(0x0010) + _asr(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x0008
+        assert not s.c
+
+    def test_asr_preserves_sign(self):
+        # ASR 0x8000 → 0xC000 (sign bit replicated); C=0 (bit0=0)
+        prog = _mov(2, 7, 0, 0) + _w(0x8000) + _asr(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0xC000
+        assert not s.c
+
+    def test_asr_carry_from_bit0(self):
+        # ASR 0x0001 → 0x0000; C=1
+        prog = _mov(2, 7, 0, 0) + _w(0x0001) + _asr(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0
+        assert s.c
+        assert s.z
+
+    def test_asl_word(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x0001) + _asl(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x0002
+        assert not s.c
+
+    def test_asl_carry_from_msb(self):
+        # ASL 0x8000 → 0x0000; C=1
+        prog = _mov(2, 7, 0, 0) + _w(0x8000) + _asl(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0
+        assert s.c
+        assert s.z
+
+    def test_ror_with_carry(self):
+        sim = PDP11Simulator()
+        # ROR 0x0002 with C=1 → 0x8001; new C=0
+        sim.load(_mov(2, 7, 0, 0) + _w(0x0002) + _ror(0, 0) + HALT)
+        sim._psw = 0b0001   # C=1 (set after load)
+        sim.step(); sim.step(); sim.step()
+        assert sim._r[0] == 0x8001
+        assert not sim._psw & 1   # C=0 (old bit0 was 0)
+
+    def test_ror_without_carry(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x0001) + _ror(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x0000
+        assert s.c   # bit0 of original = 1 → new C=1
+
+    def test_rol_basic(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x0001) + _rol(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x0002
+        assert not s.c
+
+    def test_rol_msb_to_carry(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x8000) + _rol(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x0000
+        assert s.c
+
+
+# ── Branch tests ──────────────────────────────────────────────────────────────
+
+class TestBranches:
+    """Test all 15 branch conditions and both taken/not-taken paths."""
+
+    def _branch_test(self, branch_instr: bytes, taken: bool, setup: bytes = b"") -> PDP11State:
+        """
+        Layout at 0x1000:
+          setup (variable length)
+          branch over HALT (or fallthrough):
+            HALT          ← if branch NOT taken, lands here
+            NOP           ← 2 bytes of dead code
+            HALT          ← reached when branch IS taken
+        """
+        # If taken, branch skips 1 word (offset=1) over the first HALT
+        # If not taken, fall through to first HALT
+        # The branch offset=1 means: PC_after_fetch + 2*1 = branch_target
+        #   PC after fetch is at (start_of_branch + 2)
+        #   target = start_of_branch + 2 + 2 = start_of_branch + 4 = skip first HALT
+        prog = setup + branch_instr + HALT + NOP + HALT
+        s = _run(prog)
+        if taken:
+            # Should reach second HALT
+            return s
+        else:
+            # Should reach first HALT
+            return s
+
+    def test_br_always_taken(self):
+        # BR over next instruction
+        prog = _br(1) + NOP + _mov(2, 7, 0, 0) + _w(99) + HALT
+        # BR offset=1: skip 1 word (NOP), land on MOV
+        s = _run(prog)
+        assert s.r[0] == 99
+
+    def test_bne_taken_when_z_clear(self):
+        # CMP sets Z=0 → BNE taken
+        prog = (
+            _mov(2, 7, 0, 0) + _w(3)
+            + _mov(2, 7, 0, 1) + _w(5)
+            + _cmp(0, 0, 0, 1)          # 3 - 5 ≠ 0 → Z=0
+            + _bne(1)                   # skip HALT
+            + HALT
+            + _mov(2, 7, 0, 2) + _w(1) # R2 = 1 (reachable)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 1
+
+    def test_bne_not_taken_when_z_set(self):
+        # CMP equal → Z=1 → BNE NOT taken
+        prog = (
+            _mov(2, 7, 0, 0) + _w(5)
+            + _mov(2, 7, 0, 1) + _w(5)
+            + _cmp(0, 0, 0, 1)          # Z=1
+            + _bne(2)                   # NOT taken
+            + _mov(2, 7, 0, 2) + _w(42) # R2 = 42 (fallthrough)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 42   # fell through
+
+    def test_beq_taken(self):
+        prog = (
+            _clr(0, 0)
+            + _tst(0, 0)
+            + _beq(1)
+            + HALT
+            + _mov(2, 7, 0, 1) + _w(7)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 7
+
+    def test_bpl_taken_when_positive(self):
+        prog = (
+            _mov(2, 7, 0, 0) + _w(1)
+            + _tst(0, 0)
+            + _bpl(1)
+            + HALT
+            + _mov(2, 7, 0, 1) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 1
+
+    def test_bmi_taken_when_negative(self):
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x8000)
+            + _tst(0, 0)
+            + _bmi(1)
+            + HALT
+            + _mov(2, 7, 0, 1) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 1
+
+    def test_blt_taken_when_signed_less(self):
+        # CMP #5, R0 with R0=3: CMP src=5, dst=3; CMP does src-dst = 5-3 = 2 ≥ 0
+        # Actually CMP R0, R1 with R0=5, R1=7: 5-7 = -2 → N=1, V=0 → N^V=1 → BLT taken
+        prog = (
+            _mov(2, 7, 0, 0) + _w(5)
+            + _mov(2, 7, 0, 1) + _w(7)
+            + _cmp(0, 0, 0, 1)           # 5 - 7 = -2 → N=1
+            + _blt(1)                    # N^V = 1 → taken
+            + HALT
+            + _mov(2, 7, 0, 2) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 1
+
+    def test_bge_taken_when_greater_equal(self):
+        prog = (
+            _mov(2, 7, 0, 0) + _w(7)
+            + _mov(2, 7, 0, 1) + _w(5)
+            + _cmp(0, 0, 0, 1)           # 7-5 = 2 → N=0, V=0 → N^V=0 → BGE taken
+            + _bge(1)
+            + HALT
+            + _mov(2, 7, 0, 2) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 1
+
+    def test_bhi_taken(self):
+        # BHI: C=0 AND Z=0
+        prog = (
+            _mov(2, 7, 0, 0) + _w(7)
+            + _mov(2, 7, 0, 1) + _w(5)
+            + _cmp(0, 0, 0, 1)   # 7-5=2 → C=0, Z=0
+            + _bhi(1)
+            + HALT
+            + _mov(2, 7, 0, 2) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 1
+
+    def test_blos_taken(self):
+        # BLOS: C=1 OR Z=1  (lower or same unsigned)
+        prog = (
+            _mov(2, 7, 0, 0) + _w(5)
+            + _mov(2, 7, 0, 1) + _w(7)
+            + _cmp(0, 0, 0, 1)   # 5-7 → C=1
+            + _blos(1)
+            + HALT
+            + _mov(2, 7, 0, 2) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 1
+
+    def test_bcc_taken_when_carry_clear(self):
+        prog = _clr(0, 0) + _tst(0, 0) + _bcc(1) + HALT + _mov(2, 7, 0, 1) + _w(1) + HALT
+        s = _run(prog)
+        assert s.r[1] == 1
+
+    def test_bcs_taken_when_carry_set(self):
+        # NEG 1 → C=1
+        prog = (
+            _mov(2, 7, 0, 0) + _w(1)
+            + _neg(0, 0)
+            + _bcs(1)
+            + HALT
+            + _mov(2, 7, 0, 1) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[1] == 1
+
+    def test_bvc_taken_when_no_overflow(self):
+        prog = _clr(0, 0) + _tst(0, 0) + _bvc(1) + HALT + _mov(2, 7, 0, 1) + _w(1) + HALT
+        s = _run(prog)
+        assert s.r[1] == 1
+
+    def test_bvs_taken_when_overflow(self):
+        # 0x7FFF + 1 → V=1
+        prog = (
+            _mov(2, 7, 0, 0) + _w(0x7FFF)
+            + _mov(2, 7, 0, 1) + _w(1)
+            + _add(0, 0, 0, 1)
+            + _bvs(1)
+            + HALT
+            + _mov(2, 7, 0, 2) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 1
+
+    def test_bgt_taken(self):
+        prog = (
+            _mov(2, 7, 0, 0) + _w(10)
+            + _mov(2, 7, 0, 1) + _w(5)
+            + _cmp(0, 0, 0, 1)   # 10-5=5 > 0
+            + _bgt(1)
+            + HALT
+            + _mov(2, 7, 0, 2) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 1
+
+    def test_ble_taken_when_zero(self):
+        prog = (
+            _mov(2, 7, 0, 0) + _w(5)
+            + _mov(2, 7, 0, 1) + _w(5)
+            + _cmp(0, 0, 0, 1)   # Z=1
+            + _ble(1)
+            + HALT
+            + _mov(2, 7, 0, 2) + _w(1)
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 1
+
+
+# ── JMP tests ─────────────────────────────────────────────────────────────────
+
+class TestJMP:
+    def test_jmp_register_deferred(self):
+        # JMP (R1): R1 = address of HALT, so jump there
+        # Target = load_addr + offset where HALT lives
+        # Layout: MOV #addr, R1 | JMP (R1) | MOV #99, R0 (skipped) | HALT
+        # HALT is at offset 8 from start (3 words: MOV#, R1, JMP, then HALT)
+        # Actually: MOV #addr, R1 = 4 bytes + JMP(R1) = 2 bytes → HALT at 0x1006
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x1006)  # MOV #0x1006, R1  (4 bytes at 0x1000)
+            + _jmp(1, 1)                    # JMP (R1)         (2 bytes at 0x1004)
+            + _mov(2, 7, 0, 0) + _w(99)    # MOV #99, R0 — skipped (4 bytes at 0x1006? no)
+            + HALT                          # at 0x1006
+        )
+        # Wait: HALT is at 0x1006, but MOV occupies 0x1006-0x1009
+        # Let me recalculate:
+        # 0x1000: MOV #0x??, R1  (opcode 2 bytes + imm 2 bytes = 4 bytes)
+        # 0x1004: JMP (R1)       (2 bytes)
+        # 0x1006: MOV #99, R0    (4 bytes) — SKIP TARGET
+        # 0x100A: HALT
+        # We want to jump OVER MOV to HALT at 0x100A
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x100A)  # MOV #0x100A, R1
+            + _jmp(1, 1)                    # JMP (R1)
+            + _mov(2, 7, 0, 0) + _w(99)    # SKIPPED
+            + HALT                          # at 0x100A
+        )
+        s = _run(prog)
+        assert s.r[0] == 0   # skipped
+
+    def test_jmp_mode0_raises(self):
+        sim = PDP11Simulator()
+        sim.load(_jmp(0, 0) + HALT)
+        with pytest.raises(ValueError):
+            sim.step()
+
+
+# ── JSR / RTS tests ───────────────────────────────────────────────────────────
+
+class TestJSR:
+    def test_jsr_pc_and_rts(self):
+        # Layout:
+        # 0x1000: MOV #10, R0     (4 bytes)
+        # 0x1004: JSR PC, sub     (2 bytes — sub is relative or absolute)
+        # We use absolute addressing: JSR PC, @#sub_addr
+        # 0x1006: immediate = address of subroutine
+        # 0x1008: ADD R0, R0      (2 bytes) — skipped by JSR? no, executed after return
+        # 0x100A: HALT
+        # sub at 0x100C:
+        # 0x100C: ADD #1, R0? No, let's do: ADD R0, R0 (double R0)
+        # Actually let's do:
+        # sub: ADD R0, R0 | RTS PC | back: HALT
+        # 0x1000: MOV #5, R0      (4 bytes: 0x1000-0x1003)
+        # 0x1004: JSR PC, @#sub   (2 bytes: 0x1004; immediate 0x1006: 2 bytes = sub addr)
+        # Wait, JSR with mode 3 (absolute @#) takes an immediate word.
+        # 0x1004: JSR opcode word; 0x1006: sub address; → PC = sub_addr after JSR
+        # 0x1008: HALT  ← return address pushed by JSR
+        # sub at 0x100C:
+        # 0x100C: ADD R0, R0
+        # 0x100E: RTS PC
+        # Total: 16 bytes of program
+
+        # Layout:
+        # 0x1000: MOV #5, R0         (4 bytes: opcode+immediate)
+        # 0x1004: JSR PC, @#sub_addr (4 bytes: opcode+absolute address word)
+        # 0x1008: HALT               ← return address; execution resumes here after RTS
+        # sub at 0x100A:
+        # 0x100A: ADD R0, R0         (R0 becomes 10)
+        # 0x100C: RTS PC             (return to 0x1008 = HALT)
+        sub_addr = 0x100A
+        prog = (
+            _mov(2, 7, 0, 0) + _w(5)          # 0x1000: MOV #5, R0
+            + _jsr(7, 3, 7) + _w(sub_addr)    # 0x1004: JSR PC, @#0x100A
+            + HALT                              # 0x1008: return here
+            + _add(0, 0, 0, 0)                 # 0x100A: ADD R0, R0 (R0 = 10)
+            + _rts(7)                           # 0x100C: RTS PC
+        )
+        s = _run(prog)
+        assert s.r[0] == 10
+
+    def test_jsr_mode0_raises(self):
+        sim = PDP11Simulator()
+        sim.load(_jsr(7, 0, 0) + HALT)
+        with pytest.raises(ValueError):
+            sim.step()
+
+
+# ── SOB tests ─────────────────────────────────────────────────────────────────
+
+class TestSOB:
+    def test_sob_loop(self):
+        # Loop R2 times: ADD R0, R0 (double R0) each iteration
+        # Starting R0=1, R2=3 → R0 = 1 * 2^3 = 8
+        # Layout:
+        # 0x1000: MOV #1, R0   (4 bytes)
+        # 0x1004: MOV #3, R2   (4 bytes)
+        # 0x1008: ADD R0, R0   (2 bytes)  ← loop body
+        # 0x100A: SOB R2, 1    (2 bytes) → branch to 0x100A - 2 = 0x1008 when R2>0
+        # 0x100C: HALT
+        # 0x1000: MOV #1, R0         (4 bytes)
+        # 0x1004: MOV #3, R2         (4 bytes)
+        # 0x1008: ADD R0, R0         (2 bytes) ← loop body
+        # 0x100A: SOB R2, offset=2   (2 bytes); PC after fetch = 0x100C
+        #   branch target = 0x100C - 2*2 = 0x1008 ✓
+        # 0x100C: HALT
+        prog = (
+            _mov(2, 7, 0, 0) + _w(1)   # MOV #1, R0
+            + _mov(2, 7, 0, 2) + _w(3) # MOV #3, R2
+            + _add(0, 0, 0, 0)          # ADD R0, R0 (doubles R0)  ← 0x1008
+            + _sob(2, 2)                # SOB R2, 2 → target 0x100C - 4 = 0x1008 ✓
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 8    # 1 → 2 → 4 → 8
+
+    def test_sob_no_branch_at_zero(self):
+        # R2 starts at 1: decrement to 0 → no branch → fall through
+        prog = (
+            _mov(2, 7, 0, 2) + _w(1)  # MOV #1, R2
+            + _sob(2, 1)               # SOB R2 → R2=0, no branch
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[2] == 0
+
+
+# ── Addressing mode tests ─────────────────────────────────────────────────────
+
+class TestAddressingModes:
+    def test_mode0_register_direct(self):
+        # MOV R0, R1 (both mode 0)
+        prog = _mov(2, 7, 0, 0) + _w(42) + _mov(0, 0, 0, 1) + HALT
+        s = _run(prog)
+        assert s.r[1] == 42
+
+    def test_mode1_register_deferred(self):
+        # MOV (R1), R0: R1 points to address containing 0x1234
+        # We'll put 0x1234 at 0x2000
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x2000)   # R1 = 0x2000
+            + _mov(2, 7, 1, 1) + _w(0x1234) # MOV #0x1234, (R1) — write to 0x2000
+            + _mov(1, 1, 0, 0)               # MOV (R1), R0
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 0x1234
+
+    def test_mode2_autoincrement(self):
+        # MOV (R1)+, R0: read from R1, then R1 += 2
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x2000)
+            + _mov(2, 7, 1, 1) + _w(0xABCD)
+            + _mov(2, 1, 0, 0)               # MOV (R1)+, R0
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 0xABCD
+        assert s.r[1] == 0x2002   # incremented by 2
+
+    def test_mode4_autodecrement(self):
+        # MOV -(R1), R0: R1 -= 2, then read from R1
+        # Set up R1=0x2002, write 0x5678 to 0x2000
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x2004)
+            + _mov(2, 7, 1, 1) + _w(0x5678)  # write 0x5678 to 0x2004 wait...
+        )
+        # Let's be more explicit:
+        # 1. Set R1 = 0x2002
+        # 2. Write 0x9ABC to M[0x2000] via MOV #val, (R1) after setting R1=0x2000
+        # 3. Set R1 = 0x2002
+        # 4. MOV -(R1), R0 → R1=0x2000, read M[0x2000] = 0x9ABC
+        prog = (
+            _mov(2, 7, 0, 1) + _w(0x2000)  # R1 = 0x2000
+            + _mov(2, 7, 1, 1) + _w(0x9ABC) # M[0x2000] = 0x9ABC; R1 stays 0x2000
+        )
+        # Actually MOV (dst mode 1) doesn't auto-increment; need to think
+        # Use: MOV #val, @#addr (absolute addressing)
+        # mode 3/R7 = absolute addressing: EA = M[PC]; PC+=2
+        prog = (
+            _mov(2, 7, 3, 7) + _w(0x9ABC) + _w(0x2000)  # MOV #0x9ABC, @#0x2000
+            + _mov(2, 7, 0, 1) + _w(0x2002)              # R1 = 0x2002
+            + _mov(4, 1, 0, 0)                             # MOV -(R1), R0
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 0x9ABC
+        assert s.r[1] == 0x2000   # decremented to 0x2000
+
+    def test_mode6_index(self):
+        # MOV X(R1), R0: EA = R1 + next_word
+        # R1 = 0x2000, X = 4 → EA = 0x2004
+        prog = (
+            _mov(2, 7, 3, 7) + _w(0x1111) + _w(0x2004)  # M[0x2004] = 0x1111
+            + _mov(2, 7, 0, 1) + _w(0x2000)              # R1 = 0x2000
+            + _mov(6, 1, 0, 0) + _w(4)                    # MOV 4(R1), R0
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 0x1111
+
+    def test_mode3_autoincrement_deferred(self):
+        # MOV @(R1)+, R0: EA = M[R1]; R1 += 2; R0 = M[EA]
+        # R1 → 0x2000; M[0x2000] = 0x2004 (pointer); M[0x2004] = 0xABCD
+        prog = (
+            _mov(2, 7, 3, 7) + _w(0x2004) + _w(0x2000)  # M[0x2000] = 0x2004
+            + _mov(2, 7, 3, 7) + _w(0xABCD) + _w(0x2004) # M[0x2004] = 0xABCD
+            + _mov(2, 7, 0, 1) + _w(0x2000)               # R1 = 0x2000
+            + _mov(3, 1, 0, 0)                              # MOV @(R1)+, R0
+            + HALT
+        )
+        s = _run(prog)
+        assert s.r[0] == 0xABCD
+        assert s.r[1] == 0x2002   # autoincremented past the pointer word
+
+
+# ── Byte instructions ─────────────────────────────────────────────────────────
+
+class TestByteInstructions:
+    def test_clrb_register(self):
+        prog = _mov(2, 7, 0, 0) + _w(0xABCD) + _clrb(0, 0) + HALT
+        s = _run(prog)
+        # CLRB on register writes 0 to low byte: 0xABCD → 0xAB00
+        assert s.r[0] == 0xAB00
+
+    def test_incb_register(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x00FE) + _incb(0, 0) + HALT
+        s = _run(prog)
+        assert s.r[0] == 0x00FF
+
+    def test_asrb_byte(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x0010) + _asrb(0, 0) + HALT
+        s = _run(prog)
+        assert (s.r[0] & 0xFF) == 0x08
+
+    def test_rorb_byte(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x0001) + _rorb(0, 0) + HALT
+        s = _run(prog)
+        assert (s.r[0] & 0xFF) == 0
+        assert s.c
+
+    def test_negb_byte(self):
+        prog = _mov(2, 7, 0, 0) + _w(0x0001) + _negb(0, 0) + HALT
+        s = _run(prog)
+        assert (s.r[0] & 0xFF) == 0xFF
+
+
+# ── HALT and NOP ──────────────────────────────────────────────────────────────
+
+class TestHaltNop:
+    def test_halt_sets_halted(self):
+        sim = PDP11Simulator()
+        result = sim.execute(HALT)
+        assert result.final_state.halted
+
+    def test_nop_is_no_op(self):
+        prog = NOP + NOP + HALT
+        s = _run(prog)
+        # All registers zero (except SP and PC)
+        for i in range(6):
+            assert s.r[i] == 0
+
+    def test_unknown_opcode_raises(self):
+        sim = PDP11Simulator()
+        # 0x0800 with mode=0 is JSR with mode 0 which raises ValueError
+        sim.load(_jsr(7, 0, 0) + HALT)
+        with pytest.raises(ValueError):
+            sim.step()

--- a/code/packages/python/pdp11-simulator/tests/test_programs.py
+++ b/code/packages/python/pdp11-simulator/tests/test_programs.py
@@ -1,0 +1,409 @@
+"""Multi-instruction program tests for PDP11Simulator.
+
+Tests complete small programs to verify that instruction interactions,
+subroutine calls, and loops work correctly end-to-end.
+"""
+
+from __future__ import annotations
+
+from pdp11_simulator import PDP11Simulator, PDP11State
+
+
+def _w(value: int) -> bytes:
+    return bytes([value & 0xFF, (value >> 8) & 0xFF])
+
+HALT = _w(0x0000)
+
+def _op(mode: int, reg: int) -> int:
+    return (mode << 3) | reg
+
+def _mov(sm, sr, dm, dr): return _w(0x1000 | (_op(sm, sr) << 6) | _op(dm, dr))
+def _add(sm, sr, dm, dr): return _w(0x6000 | (_op(sm, sr) << 6) | _op(dm, dr))
+def _sub(sm, sr, dm, dr): return _w(0xE000 | (_op(sm, sr) << 6) | _op(dm, dr))
+def _cmp(sm, sr, dm, dr): return _w(0x2000 | (_op(sm, sr) << 6) | _op(dm, dr))
+def _clr(mode, reg):       return _w(0x0A00 | _op(mode, reg))
+def _inc(mode, reg):       return _w(0x0A80 | _op(mode, reg))
+def _dec(mode, reg):       return _w(0x0AC0 | _op(mode, reg))
+def _asl(mode, reg):       return _w(0x0CC0 | _op(mode, reg))  # octal 006300
+def _asr(mode, reg):       return _w(0x0C80 | _op(mode, reg))  # octal 006200
+def _bne(offset):          return _w(0x0200 | (offset & 0xFF))
+def _beq(offset):          return _w(0x0300 | (offset & 0xFF))
+def _blt(offset):          return _w(0x0500 | (offset & 0xFF))
+def _br(offset):           return _w(0x0100 | (offset & 0xFF))
+def _jsr(link, mode, dst): return _w(0x0800 | (link << 6) | _op(mode, dst))
+def _rts(reg):             return _w(0x0080 | reg)   # octal 000 200
+def _sob(reg, offset):     return _w(0x7E00 | (reg << 6) | (offset & 0x3F))
+
+
+def _run(prog: bytes) -> PDP11State:
+    sim = PDP11Simulator()
+    result = sim.execute(prog)
+    assert result.ok, f"Simulation error: {result.error}"
+    return result.final_state
+
+
+class TestArithmeticPrograms:
+    def test_sum_1_to_10(self):
+        """Compute sum 1+2+…+10 = 55 using a countdown loop.
+
+        Layout:
+          R0 = accumulator (sum)
+          R1 = loop counter (10 down to 1)
+
+          MOV #10, R1       ; counter = 10
+          CLR R0            ; sum = 0
+        loop:
+          ADD R1, R0        ; sum += counter
+          DEC R1            ; counter--
+          BNE loop          ; if counter != 0, repeat
+          HALT
+        """
+        prog = (
+            _mov(2, 7, 0, 1) + _w(10)  # MOV #10, R1
+            + _clr(0, 0)                # CLR R0
+            + _add(0, 1, 0, 0)          # ADD R1, R0   ← loop starts here (offset=3)
+            + _dec(0, 1)                # DEC R1
+            + _bne(0xFD)                # BNE -3 (3 words back = 6 bytes back)
+            + HALT
+        )
+        # Verify the offset: BNE is at offset 10 from program start.
+        # PC after fetching BNE = 0x100C.
+        # Loop body starts at 0x1008.
+        # EA = 0x100C + 2 * offset_signed
+        # We want EA = 0x1008 → offset = (0x1008 - 0x100C) / 2 = -4/2 = -2
+        # So offset byte = 0xFE (signed -2)
+        prog = (
+            _mov(2, 7, 0, 1) + _w(10)  # 0x1000: MOV #10, R1 (4 bytes)
+            + _clr(0, 0)                # 0x1004: CLR R0        (2 bytes)
+            + _add(0, 1, 0, 0)          # 0x1006: ADD R1, R0    (2 bytes) ← loop
+            + _dec(0, 1)                # 0x1008: DEC R1         (2 bytes)
+            + _bne(0xFE)                # 0x100A: BNE -2 → 0x100A+2 + 2*(-2) = 0x100C-4 = 0x1006? wait
+            + HALT
+        )
+        # Recalculate: PC after fetch of BNE word at 0x100A = 0x100C
+        # EA = 0x100C + 2 * sign_extend(0xFE, 8)
+        # sign_extend(0xFE, 8) = -2
+        # EA = 0x100C + 2*(-2) = 0x100C - 4 = 0x1008? That's DEC R1, not ADD R1,R0
+        # We want to branch back to ADD R1, R0 at 0x1006
+        # EA = 0x1006 → offset = (0x1006 - 0x100C) / 2 = -6/2 = -3
+        # offset byte = 0xFD
+        prog = (
+            _mov(2, 7, 0, 1) + _w(10)  # 0x1000: MOV #10, R1
+            + _clr(0, 0)                # 0x1004: CLR R0
+            + _add(0, 1, 0, 0)          # 0x1006: ADD R1, R0   ← loop top
+            + _dec(0, 1)                # 0x1008: DEC R1
+            + _bne(0xFD)                # 0x100A: BNE → 0x100C + 2*(-3) = 0x1006 ✓
+            + HALT                      # 0x100C
+        )
+        s = _run(prog)
+        assert s.r[0] == 55
+
+    def test_multiply_by_repeated_addition(self):
+        """5 * 7 = 35 via repeated addition.
+
+          R0 = result (accumulator)
+          R1 = 5 (one operand, counts down)
+          R2 = 7 (other operand, added each time)
+
+          MOV #5, R1
+          MOV #7, R2
+          CLR R0
+        loop:
+          ADD R2, R0
+          SOB R1, loop
+          HALT
+        """
+        # SOB R1, offset: decrement R1; if R1!=0 branch backward by offset words
+        # loop body (ADD + SOB) = 2 words = 4 bytes
+        # SOB offset = 2 (branch back over ADD = 1 word, SOB itself = 1 word → 2 words total)
+        # Wait: after SOB fetches, PC points past SOB. EA = PC - 2*offset.
+        # If SOB is at 0x100A, PC after fetch = 0x100C.
+        # ADD is at 0x1008. EA = 0x100C - 2*2 = 0x1008 ✓
+        prog = (
+            _mov(2, 7, 0, 1) + _w(5)   # 0x1000: MOV #5, R1
+            + _mov(2, 7, 0, 2) + _w(7) # 0x1004: MOV #7, R2
+            + _clr(0, 0)                # 0x1008: CLR R0
+            + _add(0, 2, 0, 0)          # 0x100A: ADD R2, R0  ← loop top
+            + _sob(1, 2)                # 0x100C: SOB R1, 2 → PC(0x100E) - 4 = 0x100A ✓
+            + HALT                      # 0x100E
+        )
+        s = _run(prog)
+        assert s.r[0] == 35
+
+    def test_power_of_2(self):
+        """Compute 2^8 = 256 by left-shifting.
+
+          R0 = 1
+          R1 = 8 (shift count)
+        loop:
+          ASL R0        (multiply by 2)
+          SOB R1, loop
+          HALT
+        """
+        prog = (
+            _mov(2, 7, 0, 0) + _w(1)   # MOV #1, R0
+            + _mov(2, 7, 0, 1) + _w(8) # MOV #8, R1
+            + _asl(0, 0)                # ASL R0  ← loop top (0x1008)
+            + _sob(1, 1)                # SOB R1, 1 → PC(0x100C) - 2 = 0x100A? wait
+        )
+        # ASL at 0x1008, SOB at 0x100A
+        # PC after SOB fetch = 0x100C
+        # EA = 0x100C - 2*2 = 0x1008 ✓ (offset=2)
+        prog = (
+            _mov(2, 7, 0, 0) + _w(1)   # 0x1000: MOV #1, R0
+            + _mov(2, 7, 0, 1) + _w(8) # 0x1004: MOV #8, R1
+            + _asl(0, 0)                # 0x1008: ASL R0
+            + _sob(1, 2)                # 0x100A: SOB R1, 2 → 0x100C - 4 = 0x1008 ✓
+            + HALT                      # 0x100C
+        )
+        s = _run(prog)
+        assert s.r[0] == 256
+
+
+class TestSubroutineCalls:
+    def test_simple_subroutine(self):
+        """Call a doubling subroutine and return.
+
+        Main:
+          MOV #7, R0
+          JSR PC, @#double_addr
+          HALT
+
+        double:
+          ADD R0, R0
+          RTS PC
+        """
+        # Layout:
+        # 0x1000: MOV #7, R0      (4 bytes)
+        # 0x1004: JSR PC, @#sub   (2 bytes opcode + 2 bytes absolute addr)
+        # 0x1008: HALT
+        # 0x100A: padding (2 bytes to align sub at 0x100C)
+        # 0x100A: ADD R0, R0      (2 bytes)
+        # 0x100C: RTS PC          (2 bytes)
+        sub_addr = 0x100A
+        prog = (
+            _mov(2, 7, 0, 0) + _w(7)          # 0x1000: MOV #7, R0
+            + _jsr(7, 3, 7) + _w(sub_addr)    # 0x1004: JSR PC, @#sub_addr
+            + HALT                              # 0x1008: return here
+            + _w(0)                             # 0x100A: padding
+            + _add(0, 0, 0, 0)                 # 0x100C: ADD R0, R0  ← sub
+            + _rts(7)                           # 0x100E: RTS PC
+        )
+        # Hmm, if sub_addr = 0x100A that's the NOP pad, not ADD.
+        # Let's recalculate: sub is ADD + RTS
+        # 0x1000: MOV #7, R0 = 4 bytes (0x1000-0x1003)
+        # 0x1004: JSR = 2 bytes + addr word = 4 bytes (0x1004-0x1007)
+        # 0x1008: HALT = 2 bytes
+        # sub at 0x100A:
+        sub_addr = 0x100A
+        prog = (
+            _mov(2, 7, 0, 0) + _w(7)          # 0x1000
+            + _jsr(7, 3, 7) + _w(sub_addr)    # 0x1004
+            + HALT                              # 0x1008
+            + _add(0, 0, 0, 0)                 # 0x100A: sub entry
+            + _rts(7)                           # 0x100C: RTS PC
+        )
+        s = _run(prog)
+        assert s.r[0] == 14
+
+    def test_nested_subroutine_calls(self):
+        """Nested calls: main calls double, double calls add1.
+
+        main:
+          MOV #3, R0
+          JSR PC, @#double    → R0 = 6
+          HALT
+
+        double:
+          JSR PC, @#add1      → R0 = R0 + 1
+          JSR PC, @#add1      → R0 = R0 + 1
+          RTS PC
+
+        add1:
+          INC R0
+          RTS PC
+        """
+        # Assemble carefully with correct addresses:
+        # 0x1000: MOV #3, R0         (4 bytes, ends 0x1003)
+        # 0x1004: JSR PC, @#double   (4 bytes, ends 0x1007)
+        # 0x1008: HALT               (2 bytes)
+        # double at 0x100A:
+        # 0x100A: JSR PC, @#add1     (4 bytes)
+        # 0x100E: JSR PC, @#add1     (4 bytes)
+        # 0x1012: RTS PC             (2 bytes)
+        # add1 at 0x1014:
+        # 0x1014: INC R0             (2 bytes)
+        # 0x1016: RTS PC             (2 bytes)
+
+        double_addr = 0x100A
+        add1_addr   = 0x1014
+
+        prog = (
+            _mov(2, 7, 0, 0) + _w(3)              # 0x1000
+            + _jsr(7, 3, 7) + _w(double_addr)     # 0x1004
+            + HALT                                  # 0x1008
+            + _jsr(7, 3, 7) + _w(add1_addr)       # 0x100A: double entry
+            + _jsr(7, 3, 7) + _w(add1_addr)       # 0x100E
+            + _rts(7)                               # 0x1012
+            + _inc(0, 0)                            # 0x1014: add1 entry
+            + _rts(7)                               # 0x1016
+        )
+        s = _run(prog)
+        assert s.r[0] == 5   # 3 + 1 + 1 = 5
+
+    def test_stack_balanced_after_call(self):
+        """Stack pointer must be restored after JSR/RTS."""
+        sub_addr = 0x1008
+        prog = (
+            _jsr(7, 3, 7) + _w(sub_addr)   # 0x1000: JSR PC, @#sub
+            + HALT                           # 0x1004
+            + _w(0)                          # 0x1006: padding
+            + _rts(7)                        # 0x1008: sub just returns
+        )
+        sim = PDP11Simulator()
+        result = sim.execute(prog)
+        assert result.ok
+        sp_before = 0xF000
+        assert result.final_state.r[6] == sp_before   # SP restored
+
+
+class TestMemoryPrograms:
+    def test_copy_array(self):
+        """Copy 4 words from src to dst using autoincrement.
+
+        Layout:
+          R0 = src pointer (autoincrement)
+          R1 = dst pointer (autoincrement)
+          R2 = count
+
+          MOV #src, R0
+          MOV #dst, R1
+          MOV #4, R2
+        loop:
+          MOV (R0)+, (R1)+
+          SOB R2, loop
+          HALT
+        """
+        # Data: src at 0x2000, dst at 0x2100
+        # But we need to write src data into memory before running.
+        # We'll use the program itself to set up src data.
+        # simpler: write src data using MOV #val, @#addr
+
+        src = 0x2000
+        dst = 0x2100
+
+        def _mov_abs(val, addr):
+            """MOV #val, @#addr"""
+            return _mov(2, 7, 3, 7) + _w(val) + _w(addr)
+
+        prog = (
+            _mov_abs(0x0001, src + 0)
+            + _mov_abs(0x0002, src + 2)
+            + _mov_abs(0x0003, src + 4)
+            + _mov_abs(0x0004, src + 6)
+            + _mov(2, 7, 0, 0) + _w(src)  # R0 = src
+            + _mov(2, 7, 0, 1) + _w(dst)  # R1 = dst
+            + _mov(2, 7, 0, 2) + _w(4)    # R2 = 4
+            + _mov(2, 0, 2, 1)             # MOV (R0)+, (R1)+  ← loop
+            + _sob(2, 1)                   # SOB R2, 1 → PC_after - 2 = loop
+            + HALT
+        )
+        # Let me figure out the addresses:
+        # Each _mov_abs = 6 bytes → 4 of them = 24 bytes (0x1000 to 0x1017)
+        # 0x1018: MOV #src, R0 (4 bytes)
+        # 0x101C: MOV #dst, R1 (4 bytes)
+        # 0x1020: MOV #4, R2   (4 bytes)
+        # 0x1024: MOV (R0)+,(R1)+  (2 bytes) ← loop
+        # 0x1026: SOB R2, 2    → PC(0x1028) - 2*2 = 0x1024 ✓ (offset=2)
+        # 0x1028: HALT
+        prog = (
+            _mov_abs(0x0001, src + 0)
+            + _mov_abs(0x0002, src + 2)
+            + _mov_abs(0x0003, src + 4)
+            + _mov_abs(0x0004, src + 6)
+            + _mov(2, 7, 0, 0) + _w(src)
+            + _mov(2, 7, 0, 1) + _w(dst)
+            + _mov(2, 7, 0, 2) + _w(4)
+            + _mov(2, 0, 2, 1)              # MOV (R0)+, (R1)+
+            + _sob(2, 2)
+            + HALT
+        )
+        s = _run(prog)
+        for i in range(4):
+            addr = dst + i * 2
+            word = s.memory[addr] | (s.memory[addr + 1] << 8)
+            assert word == i + 1, f"dst[{i}] = {word}, expected {i+1}"
+
+    def test_reverse_array(self):
+        """Reverse a 3-element array in place.
+
+        Use two pointers: left (autoincrement) and right (autodecrement).
+        Swap elements while left < right.
+
+        For simplicity, just hardcode the 3 swaps using MOV with deferred modes.
+        """
+        base = 0x2000
+        # Write [10, 20, 30] to memory
+        # Then swap element[0] and element[2], leaving element[1]
+
+        def _mov_abs(val, addr):
+            return _mov(2, 7, 3, 7) + _w(val) + _w(addr)
+
+        def _mov_mem2reg(addr, reg):
+            """MOV @#addr, Rn"""
+            return _mov(3, 7, 0, reg) + _w(addr)
+
+        def _mov_reg2mem(reg, addr):
+            """MOV Rn, @#addr"""
+            return _mov(0, reg, 3, 7) + _w(addr)
+
+        prog = (
+            _mov_abs(10, base + 0)
+            + _mov_abs(20, base + 2)
+            + _mov_abs(30, base + 4)
+            # Swap [0] and [2]: use R3 as temp
+            + _mov_mem2reg(base + 0, 3)   # R3 = M[base]
+            + _mov_mem2reg(base + 4, 4)   # R4 = M[base+4]
+            + _mov_reg2mem(4, base + 0)   # M[base] = R4
+            + _mov_reg2mem(3, base + 4)   # M[base+4] = R3
+            + HALT
+        )
+        s = _run(prog)
+        def word(a): return s.memory[a] | (s.memory[a+1] << 8)
+        assert word(base + 0) == 30
+        assert word(base + 2) == 20
+        assert word(base + 4) == 10
+
+
+class TestRTI:
+    def test_rti_restores_pc_and_psw(self):
+        """RTI pops PC then PSW from the stack.
+
+        We set up the stack manually then execute RTI.
+        Target: after RTI, PC = 0x1010, PSW = 0x000F (all flags set).
+        """
+        sim = PDP11Simulator()
+        sim.reset()
+        # Place RTI at 0x1000
+        sim._mem[0x1000] = 0x02   # RTI low byte
+        sim._mem[0x1001] = 0x00   # RTI high byte (0x0002)
+        # Place HALT at 0x1010 (return target)
+        sim._mem[0x1010] = 0x00
+        sim._mem[0x1011] = 0x00
+
+        # Set up stack: push PSW=0x000F then PC=0x1010
+        # Stack grows down; RTI pops PC first, then PSW
+        # So stack (from SP upward): PC=0x1010, PSW=0x000F
+        # push PSW first (lower address), then PC
+        sp = 0xF000 - 4
+        sim._r[6] = sp
+        sim._mem[sp]   = 0x10; sim._mem[sp+1] = 0x10   # PC = 0x1010 (low byte first)
+        sim._mem[sp+2] = 0x0F; sim._mem[sp+3] = 0x00   # PSW = 0x000F
+
+        sim._r[7] = 0x1000   # Execute RTI at 0x1000
+
+        sim.step()   # RTI
+
+        assert sim._r[7] == 0x1010
+        assert sim._psw == 0x000F
+        assert sim._r[6] == 0xF000  # SP restored

--- a/code/packages/python/pdp11-simulator/tests/test_protocol.py
+++ b/code/packages/python/pdp11-simulator/tests/test_protocol.py
@@ -1,0 +1,235 @@
+"""SIM00 protocol compliance tests for PDP11Simulator.
+
+Verifies that PDP11Simulator implements the Simulator[PDP11State] protocol
+correctly: reset(), load(), step(), execute(), get_state() all behave as
+specified.
+"""
+
+from __future__ import annotations
+
+import pytest
+from simulator_protocol import ExecutionResult, Simulator, StepTrace
+
+from pdp11_simulator import PDP11Simulator, PDP11State
+
+# ── Encoding helpers ──────────────────────────────────────────────────────────
+
+def _w(value: int) -> bytes:
+    """Pack a 16-bit value as a little-endian word."""
+    return bytes([value & 0xFF, (value >> 8) & 0xFF])
+
+HALT = _w(0x0000)   # HALT instruction
+
+# ── Protocol compliance ───────────────────────────────────────────────────────
+
+class TestProtocolCompliance:
+    """PDP11Simulator must satisfy Simulator[PDP11State] structurally."""
+
+    def test_isinstance_simulator(self):
+        sim = PDP11Simulator()
+        assert isinstance(sim, Simulator)
+
+    def test_has_all_protocol_methods(self):
+        sim = PDP11Simulator()
+        assert callable(sim.reset)
+        assert callable(sim.load)
+        assert callable(sim.step)
+        assert callable(sim.execute)
+        assert callable(sim.get_state)
+
+    def test_execute_returns_execution_result(self):
+        sim = PDP11Simulator()
+        result = sim.execute(HALT)
+        assert isinstance(result, ExecutionResult)
+
+    def test_step_returns_step_trace(self):
+        sim = PDP11Simulator()
+        sim.load(HALT)
+        trace = sim.step()
+        assert isinstance(trace, StepTrace)
+
+    def test_get_state_returns_pdp11state(self):
+        sim = PDP11Simulator()
+        state = sim.get_state()
+        assert isinstance(state, PDP11State)
+
+
+class TestReset:
+    """reset() must return CPU to well-defined initial state."""
+
+    def test_reset_clears_registers(self):
+        sim = PDP11Simulator()
+        sim._r[0] = 0xABCD
+        sim._r[3] = 0x1234
+        sim.reset()
+        assert sim._r[0] == 0
+        assert sim._r[3] == 0
+
+    def test_reset_sets_sp(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        assert sim._r[6] == 0xF000  # SP = R6
+
+    def test_reset_sets_pc(self):
+        sim = PDP11Simulator()
+        sim.reset()
+        assert sim._r[7] == 0x1000  # PC = R7
+
+    def test_reset_clears_psw(self):
+        sim = PDP11Simulator()
+        sim._psw = 0xFF
+        sim.reset()
+        assert sim._psw == 0
+
+    def test_reset_clears_memory(self):
+        sim = PDP11Simulator()
+        sim._mem[0x1000] = 0xAB
+        sim.reset()
+        assert sim._mem[0x1000] == 0
+
+    def test_reset_clears_halted(self):
+        sim = PDP11Simulator()
+        sim._halted = True
+        sim.reset()
+        assert not sim._halted
+
+    def test_reset_state_via_get_state(self):
+        sim = PDP11Simulator()
+        state = sim.get_state()
+        assert state.r[6] == 0xF000
+        assert state.r[7] == 0x1000
+        assert state.psw == 0
+        assert not state.halted
+
+
+class TestLoad:
+    """load() must reset and copy the program to 0x1000."""
+
+    def test_load_places_bytes_at_0x1000(self):
+        sim = PDP11Simulator()
+        prog = b'\xAB\xCD\xEF'
+        sim.load(prog)
+        assert sim._mem[0x1000] == 0xAB
+        assert sim._mem[0x1001] == 0xCD
+        assert sim._mem[0x1002] == 0xEF
+
+    def test_load_sets_pc_to_0x1000(self):
+        sim = PDP11Simulator()
+        sim.load(b'\x00\x00')
+        assert sim._r[7] == 0x1000
+
+    def test_load_raises_on_overflow(self):
+        sim = PDP11Simulator()
+        with pytest.raises(ValueError):
+            sim.load(bytes(65536))   # too large
+
+    def test_load_returns_state_reflecting_program(self):
+        sim = PDP11Simulator()
+        sim.load(HALT)
+        assert sim._mem[0x1000] == 0x00
+        assert sim._mem[0x1001] == 0x00
+
+
+class TestExecute:
+    """execute() must run to HALT and populate ExecutionResult correctly."""
+
+    def test_execute_halt_immediately(self):
+        sim = PDP11Simulator()
+        result = sim.execute(HALT)
+        assert result.ok
+        assert result.halted
+        assert result.error is None
+        assert result.steps == 1
+
+    def test_execute_returns_traces(self):
+        sim = PDP11Simulator()
+        result = sim.execute(HALT)
+        assert len(result.traces) == 1
+        assert result.traces[0].mnemonic == "HALT"
+
+    def test_execute_max_steps_exceeded(self):
+        sim = PDP11Simulator()
+        # BR 0 = infinite loop: opcode 0x01, offset 0xFF (-1 word → PC -= 2 → same instr)
+        # Wait: BR offset=-1 means branch to PC - 2, which is the BR itself
+        # Encoding: 0x01FE (opcode=0x01, offset=0xFE=-2? let's use 0xFF=-1)
+        # EA = PC_after_fetch + 2*offset  where offset = sign_extend(0xFF, 8) = -1
+        # PC after fetching BR word = 0x1002; EA = 0x1002 + 2*(-1) = 0x1000 → loops
+        loop = _w(0x01FF)   # BR -1 (loops back to itself)
+        result = sim.execute(loop + HALT, max_steps=10)
+        assert not result.ok
+        assert result.steps == 10
+        assert "max_steps" in result.error
+
+    def test_execute_sets_final_state(self):
+        sim = PDP11Simulator()
+        result = sim.execute(HALT)
+        assert isinstance(result.final_state, PDP11State)
+        assert result.final_state.halted
+
+    def test_execute_resets_before_running(self):
+        sim = PDP11Simulator()
+        sim._r[0] = 0xDEAD
+        result = sim.execute(HALT)
+        assert result.final_state.r[0] == 0
+
+
+class TestGetState:
+    """get_state() must return an immutable snapshot."""
+
+    def test_get_state_is_frozen(self):
+        import dataclasses
+        sim = PDP11Simulator()
+        state = sim.get_state()
+        with pytest.raises((dataclasses.FrozenInstanceError, TypeError)):
+            state.psw = 0xFF  # type: ignore[misc]
+
+    def test_get_state_snapshot_not_mutated_by_step(self):
+        sim = PDP11Simulator()
+        # NOP (0x00A0) then HALT
+        sim.load(_w(0x00A0) + HALT)
+        state_before = sim.get_state()
+        sim.step()   # execute NOP
+        state_after = sim.get_state()
+        # The snapshot taken before step should be unchanged
+        assert state_before.r[7] == 0x1000
+        assert state_after.r[7] == 0x1002
+
+    def test_get_state_memory_is_tuple(self):
+        sim = PDP11Simulator()
+        state = sim.get_state()
+        assert isinstance(state.memory, tuple)
+        assert len(state.memory) == 65536
+
+    def test_get_state_registers_is_tuple(self):
+        sim = PDP11Simulator()
+        state = sim.get_state()
+        assert isinstance(state.r, tuple)
+        assert len(state.r) == 8
+
+
+class TestStep:
+    """step() must advance PC and return correct StepTrace."""
+
+    def test_step_advances_pc_by_2(self):
+        sim = PDP11Simulator()
+        sim.load(_w(0x00A0) + HALT)   # NOP, HALT
+        assert sim._r[7] == 0x1000
+        sim.step()
+        assert sim._r[7] == 0x1002
+
+    def test_step_on_halted_cpu_is_noop(self):
+        sim = PDP11Simulator()
+        sim.load(HALT)
+        sim.step()     # executes HALT
+        assert sim._halted
+        pc = sim._r[7]
+        trace = sim.step()   # should be no-op
+        assert sim._r[7] == pc
+        assert trace.mnemonic == "HALT"
+
+    def test_step_trace_pc_before_after(self):
+        sim = PDP11Simulator()
+        sim.load(_w(0x00A0) + HALT)
+        trace = sim.step()
+        assert trace.pc_before == 0x1000
+        assert trace.pc_after  == 0x1002

--- a/code/specs/07o-pdp11-simulator.md
+++ b/code/specs/07o-pdp11-simulator.md
@@ -1,0 +1,675 @@
+# Spec 07o — DEC PDP-11 Behavioral Simulator
+
+## Overview
+
+The **DEC PDP-11** (1970) is a 16-bit minicomputer family designed at Digital
+Equipment Corporation (DEC) and represents one of the most influential computer
+architectures in history. While the Intel 4004 (1971) was launching the
+microprocessor revolution, the PDP-11 was already teaching a generation of
+engineers what elegant computer design looked like at the minicomputer scale.
+
+Historical milestones powered by the PDP-11:
+- **UNIX** (1970) — Ken Thompson and Dennis Ritchie wrote the first version of
+  Unix on a PDP-11/20 at Bell Labs. The C language was designed specifically
+  to be PDP-11-friendly; the fact that `int` defaults to the native word size
+  and that pointers and integers can be freely cast traces directly to the
+  PDP-11's architecture.
+- **C language** (1972) — Dennis Ritchie's C was created as a portable
+  alternative to PDP-11 assembly. The bitwise operators, the `++`/`--`
+  operators (inspired by PDP-11 autoincrement/autodecrement addressing), and
+  the memory model of C are deeply PDP-11-shaped.
+- **FORTRAN compilers, BASIC interpreters, early LISP** — the PDP-11 was the
+  platform of choice for language research in the 1970s.
+- **Eunice**, **RSTS/E**, **RT-11**, **RSX-11** — a rich ecosystem of
+  operating systems evolved on PDP-11 hardware.
+
+The PDP-11 was remarkable for introducing the concept of **orthogonal ISA**
+(independent instruction set architecture): any addressing mode can be
+applied to any operand of any instruction. This uniformity made the ISA far
+easier to learn, use, and compile for than contemporaries like the IBM 360 or
+Intel 8008.
+
+| Feature            | PDP-11 (1970)                    | Intel 8080 (1974, for comparison) |
+|--------------------|-----------------------------------|-------------------------------------|
+| Width              | 16-bit                            | 8-bit                               |
+| Registers          | 8 GPRs (R0-R7, incl. SP and PC)  | A + BC + DE + HL + SP (asymmetric) |
+| Addressing modes   | 8 (apply to **any** register)     | 5 (register-specific)               |
+| Memory model       | Flat 64 KB                        | Flat 64 KB                          |
+| Byte order         | Little-endian                     | Little-endian                       |
+| Byte ops           | Yes (MOVB, CLRB, etc.)            | Yes (8-bit accumulator)             |
+| PC in GPR file     | **Yes** (R7 = PC)                 | No                                  |
+| SP in GPR file     | **Yes** (R6 = SP)                 | No (separate SP)                    |
+| Auto-inc/dec       | Yes (register addressing modes)   | No (separate INX/DCX)               |
+
+The elegance of putting PC and SP in the general-purpose register file means
+that JSR and RTS are not special — they use the same autoincrement/autodecrement
+addressing modes as everything else. C's `++p` and `*p++` mirror PDP-11's
+`(Rn)+` (register deferred autoincrement) and `@(Rn)+` patterns exactly.
+
+This spec defines Layer **07o** — a Python behavioral simulator for the PDP-11
+following the SIM00 `Simulator[PDP11State]` protocol.
+
+---
+
+## Architecture
+
+### Registers
+
+The PDP-11 has **eight 16-bit general-purpose registers**: R0 through R7.
+By convention two have dedicated roles:
+
+| Name | Alias | Role |
+|------|-------|------|
+| R0   | —     | General-purpose |
+| R1   | —     | General-purpose |
+| R2   | —     | General-purpose |
+| R3   | —     | General-purpose |
+| R4   | —     | General-purpose |
+| R5   | —     | General-purpose (frame pointer by convention) |
+| R6   | SP    | Stack pointer — pre-decremented on push, post-incremented on pop |
+| R7   | PC    | Program counter — always points to the next instruction word to fetch |
+
+All registers are 16 bits wide. All arithmetic is modulo 2¹⁶. There is no
+sign extension on register write; the hardware stores exactly the 16 bits given.
+
+### Processor Status Word (PSW)
+
+The **Processor Status Word** is a 16-bit register with the following layout:
+
+```
+Bit: 15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+     [ Current mode ] [ Prev mode ] [ IPL (interrupt priority) ] T N Z V C
+```
+
+For this behavioral simulator we only track the four condition codes in bits
+3–0:
+
+| Bit | Flag | Name     | Set when…                                       |
+|-----|------|----------|-------------------------------------------------|
+|  3  |  N   | Negative | Result MSB is 1 (word bit 15, byte bit 7)       |
+|  2  |  Z   | Zero     | Result is exactly 0                             |
+|  1  |  V   | Overflow | Signed overflow occurred                        |
+|  0  |  C   | Carry    | Carry-out from MSB (unsigned overflow)          |
+
+The T (trap) bit and interrupt priority level (IPL) are not simulated.
+
+---
+
+## Addressing Modes
+
+The PDP-11's **eight addressing modes** are the heart of its orthogonality.
+Each instruction encodes its operand(s) as `(mode, register)` pairs using
+3 bits each — 6 bits total per operand:
+
+```
+Bits 5–3: mode (0–7)
+Bits 2–0: register (R0–R7)
+```
+
+### Mode Table
+
+| Mode | Assembly syntax | Name                     | Effective address (EA)                           |
+|------|----------------|--------------------------|--------------------------------------------------|
+|  0   | `Rn`           | Register                 | Operand is Rn itself (no memory access)          |
+|  1   | `(Rn)` or `@Rn`| Register deferred        | EA = Rn                                          |
+|  2   | `(Rn)+`        | Autoincrement            | EA = Rn; Rn += size (2 for word, 1 for byte)    |
+|  3   | `@(Rn)+`       | Autoincrement deferred   | EA = M[Rn]; Rn += 2 (always word pointer)       |
+|  4   | `-(Rn)`        | Autodecrement            | Rn -= size; EA = Rn                              |
+|  5   | `@-(Rn)`       | Autodecrement deferred   | Rn -= 2; EA = M[Rn]                             |
+|  6   | `X(Rn)`        | Index                    | EA = Rn + next-word (sign-extended); PC += 2     |
+|  7   | `@X(Rn)`       | Index deferred           | EA = M[Rn + next-word]; PC += 2                  |
+
+### PC-Relative Addressing (R7 special cases)
+
+Because R7 *is* the PC, the addressing modes applied to R7 produce the
+classic "immediate" and "absolute" syntaxes used in PDP-11 assembly:
+
+| Mode | Rn = R7 | Assembly sugar | Meaning                                    |
+|------|---------|----------------|--------------------------------------------|
+|  2   | R7=PC   | `#n`           | Immediate: operand is the next word        |
+|  3   | R7=PC   | `@#addr`       | Absolute: EA = next word (absolute address)|
+|  6   | R7=PC   | `addr`         | Relative: EA = PC + next-word displacement |
+|  7   | R7=PC   | `@addr`        | Relative deferred: EA = M[PC + disp]      |
+
+Since PC always points past the current instruction word *before* addressing
+is evaluated, `#n` simply reads the word at the current PC and advances it —
+which is exactly what mode 2 (autoincrement) does when applied to R7.
+
+### Stack conventions (R6 = SP)
+
+Mode 4 on R6: `-(SP)` — pre-decrement SP by 2, then write to M[SP]. **PUSH**.
+Mode 2 on R6: `(SP)+` — read from M[SP], then post-increment SP by 2. **POP**.
+
+JSR uses autodecrement to push the link register; RTS uses autoincrement to
+pop. These are not hard-wired stack operations — they are the same autoincrement/
+autodecrement mode that works on R0–R7.
+
+---
+
+## Instruction Set
+
+### Double-Operand Instructions (word)
+
+```
+Format: [  opcode(4)  |  src mode(3) | src reg(3) | dst mode(3) | dst reg(3)  ]
+Bits:    15          12  11          9  8          6  5          3  2          0
+```
+
+| Opcode | Mnemonic | Operation                          | Flags updated |
+|--------|----------|------------------------------------|---------------|
+| 0001   | MOV      | dst ← src                          | N, Z, V=0     |
+| 0010   | CMP      | src − dst (result discarded)       | N, Z, V, C    |
+| 0011   | BIT      | src AND dst (result discarded)     | N, Z, V=0     |
+| 0100   | BIC      | dst ← dst AND NOT src              | N, Z, V=0     |
+| 0101   | BIS      | dst ← dst OR src                   | N, Z, V=0     |
+| 0110   | ADD      | dst ← dst + src                    | N, Z, V, C    |
+
+### Double-Operand Instructions (byte)
+
+Byte instructions are encoded with bit 15 = 1 (adding 0x8000 to the word
+opcode):
+
+| Opcode | Mnemonic | Operation                          |
+|--------|----------|------------------------------------|
+| 1001   | MOVB     | dst (byte) ← src (byte); sign-extend when dst is register |
+| 1010   | CMPB     | src(B) − dst(B) (discarded)        |
+| 1011   | BITB     | src(B) AND dst(B) (discarded)      |
+| 1100   | BICB     | dst(B) ← dst(B) AND NOT src(B)    |
+| 1101   | BISB     | dst(B) ← dst(B) OR src(B)         |
+
+Note: there is no ADDB (byte add) in the PDP-11 ISA.
+
+### Single-Operand Instructions
+
+```
+Format: [    opcode(10)     | dst mode(3) | dst reg(3) ]
+Bits:    15               6   5          3   2         0
+```
+
+| Encoding   | Mnemonic | Operation                               | Flags |
+|------------|----------|-----------------------------------------|-------|
+| 0000 0011 0x | SWAB   | Swap bytes in dst word                  | N,Z,V=0,C=0 |
+| 0000 1000 0x | CLR    | dst ← 0                                 | N=0,Z=1,V=0,C=0 |
+| 0000 1000 1x | CLRB   | dst(byte) ← 0                           | N=0,Z=1,V=0,C=0 |
+| 0000 1001 0x | COM    | dst ← NOT dst                           | N,Z,V=0,C=1 |
+| 0000 1001 1x | COMB   | dst(byte) ← NOT dst(byte)               | N,Z,V=0,C=1 |
+| 0000 1010 0x | INC    | dst ← dst + 1                           | N,Z,V |
+| 0000 1010 1x | INCB   | dst(byte) ← dst(byte) + 1              | N,Z,V |
+| 0000 1011 0x | DEC    | dst ← dst − 1                           | N,Z,V |
+| 0000 1011 1x | DECB   | dst(byte) ← dst(byte) − 1              | N,Z,V |
+| 0000 1100 0x | NEG    | dst ← 0 − dst                           | N,Z,V,C |
+| 0000 1100 1x | NEGB   | dst(byte) ← 0 − dst(byte)              | N,Z,V,C |
+| 0000 1101 0x | ADC    | dst ← dst + C                           | N,Z,V,C |
+| 0000 1101 1x | ADCB   | dst(byte) ← dst(byte) + C             | N,Z,V,C |
+| 0000 1110 0x | SBC    | dst ← dst − C                           | N,Z,V,C |
+| 0000 1110 1x | SBCB   | dst(byte) ← dst(byte) − C             | N,Z,V,C |
+| 0000 1111 0x | TST    | src − 0 (flags only)                    | N,Z,V=0,C=0 |
+| 0000 1111 1x | TSTB   | src(byte) − 0 (flags only)             | N,Z,V=0,C=0 |
+| 0110 0000 0x | ROR    | Rotate right through C (word)           | N,Z,V,C |
+| 0110 0000 1x | RORB   | Rotate right through C (byte)           | N,Z,V,C |
+| 0110 0001 0x | ROL    | Rotate left through C (word)            | N,Z,V,C |
+| 0110 0001 1x | ROLB   | Rotate left through C (byte)            | N,Z,V,C |
+| 0110 0010 0x | ASR    | Arithmetic shift right (word)           | N,Z,V,C |
+| 0110 0010 1x | ASRB   | Arithmetic shift right (byte)           | N,Z,V,C |
+| 0110 0011 0x | ASL    | Arithmetic shift left (word)            | N,Z,V,C |
+| 0110 0011 1x | ASLB   | Arithmetic shift left (byte)            | N,Z,V,C |
+| 0110 1100 0x | SUB (single dst) | Not standard; see double-op  | —     |
+
+The `x` in the encoding column stands for the 6-bit operand field
+(mode × 8 + reg).
+
+### Control Flow
+
+#### Branches (8-bit signed offset, in words)
+
+```
+Format: [ opcode(8) | offset(8) ]
+Bits:    15        8  7        0
+```
+
+Offset is a **signed 8-bit integer** giving the number of *words* to jump
+relative to the next instruction (i.e., relative to PC after the branch
+word is fetched).  EA = PC + 2 × offset.
+
+| Opcode (hex) | Mnemonic | Condition             |
+|--------------|----------|-----------------------|
+| 0x0001       | BR       | Always                |
+| 0x0002       | BNE      | Z = 0                 |
+| 0x0003       | BEQ      | Z = 1                 |
+| 0x0004       | BGE      | N XOR V = 0           |
+| 0x0005       | BLT      | N XOR V = 1           |
+| 0x0006       | BGT      | Z = 0 AND (N XOR V) = 0 |
+| 0x0007       | BLE      | Z = 1 OR (N XOR V) = 1  |
+| 0x0100       | BPL      | N = 0                 |
+| 0x0101       | BMI      | N = 1                 |
+| 0x0102       | BHI      | C = 0 AND Z = 0       |
+| 0x0103       | BLOS     | C = 1 OR Z = 1        |
+| 0x0104       | BVC      | V = 0                 |
+| 0x0105       | BVS      | V = 1                 |
+| 0x0106       | BCC/BHIS | C = 0                 |
+| 0x0107       | BCS/BLO  | C = 1                 |
+
+#### Jump (JMP)
+
+```
+Encoding: 0000 0000 01 | mode(3) | reg(3)
+```
+
+JMP transfers control to the *effective address* computed from the given
+addressing mode. JMP with mode 0 (register direct) is illegal.
+
+#### Subroutine Calls (JSR / RTS)
+
+```
+JSR: 0000 1000 rr | mode(3) | reg(3)   (rr = link register number, 3 bits)
+RTS: 0000 0010 00 000 rrr               (rrr = link register, 3 bits)
+```
+
+**JSR reg, dst**:
+1. `-(SP)` ← reg  (push reg onto stack)
+2. reg ← PC       (link register gets return address)
+3. PC ← EA(dst)   (jump to subroutine)
+
+**RTS reg**:
+1. PC ← reg       (return to saved PC in link register)
+2. reg ← `(SP)+`  (pop saved link register from stack)
+
+The most common call convention is `JSR PC, addr` (link reg = R7 = PC):
+1. `-(SP)` ← PC   (push return address)
+2. PC ← PC        (link reg = PC, no-op since both are PC)
+3. PC ← EA        (jump to subroutine)
+
+And `RTS PC` simply pops SP into PC — equivalent to a normal subroutine
+return on any other architecture.
+
+#### SOB (Subtract One and Branch)
+
+```
+Encoding: 0111 11 | reg(3) | offset(6)
+```
+
+`SOB reg, label`: decrement reg; if reg ≠ 0, branch backward by offset words.
+Offset is a **6-bit unsigned** value subtracted from PC: EA = PC − 2 × offset.
+SOB always branches *backward*; it cannot branch forward.
+
+### Miscellaneous
+
+| Encoding (hex) | Mnemonic | Operation                                  |
+|----------------|----------|--------------------------------------------|
+| 0x0000         | HALT     | Halt the processor (simulator stop signal) |
+| 0x00A0–0x00A7  | CLN/CLZ/CLV/CLC/SEN/SEZ/SEV/SEC | Set/clear individual PSW flags |
+| 0x0004         | IOT      | I/O trap (not simulated)                   |
+| 0x0005         | RESET    | Bus reset (not simulated)                  |
+| 0x0006         | RTI      | Return from interrupt (not simulated)      |
+| 0x0007         | MFPT     | Move from processor type (not simulated)   |
+| 0x00A0         | NOP      | No operation (encoded as CLN+CLZ+CLV+CLC=0xA0)|
+
+The simulator recognizes NOP (0x00A0) as an alias; other unrecognized
+opcodes raise a Python `ValueError`.
+
+---
+
+## Memory Model
+
+- **Size**: 65 536 bytes (16-bit address space, byte-addressed).
+- **Layout**: flat; no segmentation.
+- **Word access**: always 16-bit, little-endian, must be word-aligned (even
+  address). Odd-address word access is a bus error on real hardware; the
+  simulator raises `ValueError`.
+- **Byte access**: any address, 8-bit.
+- **Load address**: programs are loaded starting at address `0x1000`.
+- **Stack**: grows *downward*. Initial SP (R6) = `0xF000`.
+
+---
+
+## Simulator Protocol (SIM00)
+
+```python
+from simulator_protocol import Simulator
+from pdp11_simulator import PDP11Simulator, PDP11State
+
+sim: Simulator[PDP11State] = PDP11Simulator()
+```
+
+### `PDP11State`
+
+A dataclass capturing the complete, serializable CPU state:
+
+```python
+@dataclass
+class PDP11State:
+    r: list[int]       # R0–R7 (len=8), each 16-bit unsigned
+    psw: int           # Processor Status Word, bits 3-0 = N,Z,V,C
+    memory: bytes      # Full 64 KB snapshot
+    halted: bool       # True if HALT was executed
+```
+
+### Protocol Methods
+
+| Method | Signature | Behaviour |
+|--------|-----------|-----------|
+| `reset` | `() → PDP11State` | Zero all registers; zero memory; R6=0xF000, R7=0x1000; PSW=0; halted=False |
+| `load`  | `(program: bytes) → PDP11State` | Reset then copy `program` into memory starting at 0x1000 |
+| `step`  | `() → PDP11State` | Fetch, decode, and execute one instruction; return new state |
+| `execute` | `(max_steps: int = 10_000) → PDP11State` | Loop calling `step()` until `halted=True` or `max_steps` reached |
+| `get_state` | `() → PDP11State` | Return current state snapshot without executing |
+
+---
+
+## Condition Code Rules
+
+### Standard word operations (MOV, ADD, SUB/CMP, etc.)
+
+```
+result_u = unsigned result (mod 2^16)
+result_s = signed result (as int16)
+
+N = (result_u >> 15) & 1
+Z = 1 if result_u == 0 else 0
+V = 1 if signed overflow else 0
+C = 1 if carry-out (unsigned overflow) else 0
+```
+
+**Signed overflow** for addition A + B = R:
+`V = 1 if (A and B have same sign) and (R has different sign)`
+
+**Signed overflow** for subtraction A − B = R (CMP computes src − dst):
+`V = 1 if (A and B have different sign) and (R has different sign from A)`
+
+### Byte operations (MOVB, CMPB, etc.)
+
+Same rules as word but using 8-bit values: N = bit 7, overflow compared over
+the range −128..127 / 0..255.
+
+When a byte result is stored to a **register** (mode 0), the byte is
+sign-extended to 16 bits before writing (e.g., MOVB #0xFF, R0 → R0 = 0xFFFF).
+When stored to **memory**, only the byte is written.
+
+### MOV / MOVB — V always cleared
+
+MOV and MOVB set N and Z from the result but always clear V. C is not
+modified by MOV/MOVB.
+
+### CLR / CLRB — all flags to known state
+
+CLR: N=0, Z=1, V=0, C=0. The value stored is 0.
+
+### COM / COMB — V=0, C=1
+
+COM sets N and Z from the complemented result, clears V, and always sets C.
+
+### NEG — C is set iff result ≠ 0
+
+`C = 0 if result == 0 else 1`.  V is set if the result is the most-negative
+value (word: 0x8000, byte: 0x80).
+
+### ADC / SBC — carry-in from C flag
+
+ADC: `dst ← dst + C_flag`.  SBC: `dst ← dst − C_flag`.
+These are used for multi-precision arithmetic.
+
+### Rotates (ROR / ROL)
+
+ROR word:
+```
+new_C = bit 0 of dst
+result = (dst >> 1) | (old_C << 15)
+```
+ROL word:
+```
+new_C = bit 15 of dst
+result = ((dst << 1) & 0xFFFF) | old_C
+```
+
+### ASR / ASL (arithmetic shifts)
+
+ASR word:
+```
+C = bit 0 of dst
+result = sign_extend(dst >> 1, 16)   # bit 15 is preserved (arithmetic)
+N, Z from result; V = N XOR C (after shift)
+```
+
+ASL word:
+```
+C = bit 15 of dst
+result = (dst << 1) & 0xFFFF
+N, Z from result; V = N XOR C (detects sign change)
+```
+
+### TST / TSTB
+
+Sets N and Z from the operand; always clears V and C.
+
+### SUB (double-operand)
+
+```
+Encoding: 1110 | src(6) | dst(6)
+result = dst − src
+```
+
+Sets N, Z, V, C. Note: CMP is `src − dst` (reversed) for historical reasons;
+SUB is `dst − src`.
+
+---
+
+## Instruction Encoding Quick Reference
+
+```
+Instruction word layout (16 bits, big-endian bit numbering):
+
+15  14  13  12  11  10   9   8   7   6   5   4   3   2   1   0
+ ╔══╦══╦══╦══╦══╦══╦══╦══╦══╦══╦══╦══╦══╦══╦══╦══╗
+ ║  op code fields     ║  src mode/reg  ║  dst mode/reg  ║
+ ╚══╩══╩══╩══╩══╩══╩══╩══╩══╩══╩══╩══╩══╩══╩══╩══╝
+
+Double-operand word instructions (bits 15-12 = 0001-0110):
+  [4-bit opcode][3-bit src mode][3-bit src reg][3-bit dst mode][3-bit dst reg]
+
+Double-operand byte instructions (bits 15-12 = 1001-1101):
+  same layout, byte semantics
+
+Single-operand instructions (bits 15-6 = opcode, bits 5-0 = dst):
+  [10-bit opcode][3-bit dst mode][3-bit dst reg]
+
+Branch instructions (bits 15-8 = opcode, bits 7-0 = signed offset in words):
+  [8-bit opcode][8-bit signed offset]
+
+JSR:  [0][0][0][1][0][0] [reg(3)] [mode(3)] [dst_reg(3)]
+RTS:  [0][0][0][0][0][0][1][0][0][0][0] [reg(3)]
+SOB:  [0][1][1][1][1][1] [reg(3)] [offset(6)]
+HALT: [0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]  = 0x0000
+NOP:  [0][0][0][0][0][0][0][0][1][0][1][0][0][0][0][0]  = 0x00A0
+```
+
+### Key encoding examples
+
+```
+MOV R0, R1          = 0001 000 000 000 001 = 0x0201   (nope — see below)
+                    ← Actually: 0001 | src=000 000 | dst=000 001
+                    = 0001_000_000_000_001 = 0x1001
+
+Wait — let's be precise. PDP-11 words are 16-bit, MSB first:
+  Bit 15-12 = opcode = 0001  → MOV
+  Bit 11-9  = src mode = 000 → Register direct
+  Bit 8-6   = src reg  = 000 → R0
+  Bit 5-3   = dst mode = 000 → Register direct
+  Bit 2-0   = dst reg  = 001 → R1
+
+  0001 000 000 000 001 = 0x1001  ✓
+
+ADD R2, R3          = 0110 000 010 000 011 = 0x60C3   (let's verify)
+  Bit 15-12 = 0110  → ADD
+  Bit 11-9  = 000   → src mode = register direct
+  Bit 8-6   = 010   → src reg  = R2
+  Bit 5-3   = 000   → dst mode = register direct
+  Bit 2-0   = 011   → dst reg  = R3
+  = 0110 000 010 000 011 = 0x60C3 ✗ — let's recount:
+  0110 = 6
+  000  = 0
+  010  = 2
+  000  = 0
+  011  = 3
+  = 0x6083  ✓  (0110 0000 1000 0011)
+
+MOV #5, R0          = MOV with src=mode2/R7 (immediate), dst=mode0/R0
+  0001 010 111 000 000 = 0x15C0, followed by word 0x0005
+
+HALT                = 0x0000
+
+JSR PC, addr        = 0000 1000 111 mode reg
+  Link reg = PC = R7 = 111
+  = 0000 1000 111 | dst(mode, reg)
+  JSR PC, @#0x1000 = 0x09FF followed by 0x1000   (mode=3/R7=absolute)
+  JSR PC, label    (PC-relative) = 0x09F7 followed by displacement word
+```
+
+The encoding can be tricky; test vectors in the test suite serve as the
+authoritative specification for corner cases.
+
+---
+
+## Halting
+
+The simulator halts when it executes a **HALT instruction** (opcode `0x0000`).
+The `halted` flag in `PDP11State` is set to `True` and `step()` becomes a
+no-op thereafter.
+
+Test programs conventionally end with `HALT` (2 bytes: `\x00\x00`).
+
+---
+
+## Implementation Notes
+
+### Memory representation
+
+Use a `bytearray` internally for efficient byte-addressable memory.
+Word reads: `memory[addr] | (memory[addr+1] << 8)` (little-endian).
+Word writes: `memory[addr] = value & 0xFF; memory[addr+1] = (value >> 8) & 0xFF`.
+
+### Addressing mode dispatch
+
+The addressing mode evaluator must handle two cases differently:
+
+1. **Mode 0 (register)**: the operand *is* the register value (for reads) or
+   the register itself (for writes). No memory address is computed.
+2. **Modes 1–7**: an effective address (EA) is computed; the operand is
+   `M[EA]` for reads and the store target for writes.
+
+Autoincrement/autodecrement must update the register **after** computing the
+EA (for increment) or **before** (for decrement).
+
+For byte instructions, autoincrement/autodecrement step by 1 byte; for word
+instructions they step by 2. Exception: when applied to PC (R7) or SP (R6),
+the step is always 2 (pointer-sized), even for byte instructions. This is
+the actual PDP-11 hardware behaviour and important for `#immediate` to work
+with byte instructions.
+
+### PC management
+
+At the start of each `step()`, fetch the 16-bit instruction word at R7 (PC)
+and increment PC by 2. Additional words (immediate values, index offsets)
+are fetched by mode evaluation which further increments PC.
+
+This means after decoding a two-word instruction (`MOV #5, R0` = opcode word
++ immediate word), PC will have advanced by 4.
+
+### JSR implementation
+
+```python
+# JSR reg, dst_ea
+old_reg = r[link_reg]
+r[SP] -= 2
+write_word(r[SP], old_reg)     # push old link reg
+r[link_reg] = r[PC]            # link reg ← return address (already advanced)
+r[PC] = dst_ea                 # jump
+```
+
+For `JSR PC, addr`: old_reg = PC (return address), link_reg = 7 (PC).
+Step 1: push old PC (return address) → `-(SP)` ← PC.
+Step 2: `PC ← PC` (no-op since link_reg=7 and we already saved PC).
+Step 3: `PC ← dst_ea` (jump).
+
+This is equivalent to the classic push-return-address + jump pattern.
+
+### RTS implementation
+
+```python
+# RTS reg
+r[PC] = r[link_reg]            # return to saved PC in link reg
+r[link_reg] = read_word(r[SP]) # pop old link reg from stack
+r[SP] += 2
+```
+
+For `RTS PC`: PC ← PC (the return address we saved in link register = PC,
+which was set by JSR), then PC ← pop. The net effect is `PC ← M[SP]; SP += 2`.
+
+---
+
+## Package Layout
+
+```
+code/packages/python/pdp11-simulator/
+├── pyproject.toml
+├── README.md
+├── CHANGELOG.md
+├── src/
+│   └── pdp11_simulator/
+│       ├── __init__.py          # public re-exports
+│       ├── state.py             # PDP11State dataclass
+│       ├── flags.py             # condition code helpers
+│       └── simulator.py         # PDP11Simulator class
+└── tests/
+    ├── test_protocol.py         # SIM00 protocol compliance
+    ├── test_instructions.py     # per-instruction correctness
+    ├── test_programs.py         # multi-instruction programs
+    └── test_coverage.py         # edge cases for branch coverage
+```
+
+---
+
+## Layer Position
+
+| Layer | Package                     | Architecture          | Year |
+|-------|-----------------------------|-----------------------|------|
+| 07h   | ibm-704-simulator           | IBM 704               | 1954 |
+| 07i   | intel-8080-simulator        | Intel 8080            | 1974 |
+| 07j   | mos-6502-simulator          | MOS Technology 6502   | 1975 |
+| 07k   | z80-simulator               | Zilog Z80             | 1976 |
+| 07l   | manchester-baby-simulator   | Manchester Baby (SSEM)| 1948 |
+| 07m   | intel-8086-simulator        | Intel 8086            | 1978 |
+| 07n   | motorola-68000-simulator    | Motorola 68000        | 1979 |
+| 07o   | **pdp11-simulator**         | **DEC PDP-11**        | **1970** |
+| 07p   | intel-8051-simulator        | Intel 8051            | 1980 |
+
+The PDP-11 is placed at 07o (after 68000 but note its year is 1970) for
+pedagogical reasons: the 68000's ISA was heavily *influenced by* the PDP-11,
+so understanding the PDP-11 after the 68000 illuminates the lineage. The
+orthogonal ISA, flat memory model, and autoincrement/autodecrement modes the
+68000 inherited from the PDP-11 become immediately clear.
+
+---
+
+## Test Verification Checklist
+
+The test suite must verify:
+
+1. **Protocol**: `reset()`, `load()`, `step()`, `execute()`, `get_state()` all
+   return valid `PDP11State`.
+2. **MOV word and byte**: register-to-register, immediate-to-register, register-
+   to-memory, memory-to-register; byte sign extension into registers.
+3. **ADD / SUB / CMP**: correct result, N/Z/V/C flags; overflow cases.
+4. **BIT / BIC / BIS**: bitwise operations, V always clear.
+5. **CLR / COM / NEG / INC / DEC**: single-operand, flags per table above.
+6. **ADC / SBC / TST / SWAB**: boundary and carry-in cases.
+7. **ASR / ASL / ROR / ROL**: shift and rotate, V = N XOR C, carry propagation.
+8. **Branches**: all 15 branch conditions, both taken and not-taken paths.
+9. **JMP**: all legal addressing modes (not mode 0).
+10. **JSR / RTS**: correct stack manipulation, correct return address.
+11. **SOB**: loop-down countdown, stops at zero.
+12. **HALT**: simulator halts; subsequent `step()` is no-op.
+13. **Addressing modes**: all 8 modes on a double-operand instruction.
+14. **PC-relative addressing**: immediate `#n`, absolute `@#addr`.
+15. **SP behavior**: push/pop via autodecrement/autoincrement on R6.
+16. **Byte vs word** autoincrement step size; SP/PC always step by 2.
+17. **Coverage**: ≥ 80% line coverage (target 90%+).


### PR DESCRIPTION
## Summary

- Implements a complete DEC PDP-11 (1970) behavioral simulator following the SIM00 `Simulator[PDP11State]` protocol
- The PDP-11 is the computer on which Unix and C were created; its orthogonal ISA (any mode × any register × any instruction) was the most influential architecture design of the 1970s
- Adds spec `code/specs/07o-pdp11-simulator.md` and package `code/packages/python/pdp11-simulator/`

## Architecture

- 8 GPRs where R6=SP and R7=PC (unified register file — defining feature of the orthogonal ISA)
- 64 KB flat little-endian address space, 16-bit words
- All 8 PDP-11 addressing modes: register, deferred, autoincrement, autoincrement deferred, autodecrement, autodecrement deferred, index, index deferred
- PC modes give immediate `#n`, absolute `@#n`, relative `label`, and relative-deferred `@label` for free
- Byte autoincrement rule: always 2 for SP (R6) and PC (R7), 1 for R0–R5

## Instructions

- Double-operand: MOV, CMP, BIT, BIC, BIS, ADD, SUB + byte variants
- Single-operand: CLR, COM, INC, DEC, NEG, ADC, SBC, TST, SWAB, ROR, ROL, ASR, ASL + byte variants
- 15 branches: BR, BNE, BEQ, BGE, BLT, BGT, BLE, BPL, BMI, BHI, BLOS, BVC, BVS, BCC, BCS
- Control: JMP, JSR (any addressing mode), RTS, SOB, HALT, NOP, RTI

## Test plan

- [x] 163 tests, 98.63% coverage
- [x] `test_protocol.py`: SIM00 protocol compliance (isinstance, reset, load, step, execute, get_state)
- [x] `test_instructions.py`: every instruction + addressing mode combination
- [x] `test_programs.py`: end-to-end programs (sum 1–10, multiply, power, subroutines, stack, memory copy, array reverse, RTI)
- [x] `test_coverage.py`: flag arithmetic, edge cases, odd-address traps, byte SP/PC autoincrement rules
- [x] `ruff check`: all checks passed
- [x] Security review: passed — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)