### PR TITLE
feat(vault-import-export): VLT15 portable bundle + Importer trait (final layer)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -425,6 +425,7 @@ members = [
     "vault-revisions",
     "vault-search",
     "vault-attachments",
+    "vault-import-export",
     "storage-fs",
     "context-store",
     "artifact-store",

--- a/code/packages/rust/vault-import-export/BUILD
+++ b/code/packages/rust/vault-import-export/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_import_export -- --nocapture

--- a/code/packages/rust/vault-import-export/CHANGELOG.md
+++ b/code/packages/rust/vault-import-export/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-05-04
+
+### Added
+
+- Initial implementation of VLT15
+  (`code/specs/VLT15-vault-import-export.md`).
+- `PortableBundle` — top-level container with
+  `version: u32` + `records: Vec<PortableRecord>`.
+- `PortableRecord` — `kind / title / username / password /
+  url / notes / totp_seed / tags / custom_fields`. Sensitive
+  fields (`password`, `totp_seed`, every `custom_fields`
+  value) held under `Zeroizing<String>`. Hand-rolled `Debug`
+  redacts each sensitive field. Hand-rolled `Clone` since
+  `Zeroizing<String>` doesn't derive it.
+- `PortableRecordKind` — `#[non_exhaustive]` enum with five
+  known variants (`Login`, `SecureNote`, `Card`, `SshKey`,
+  `Totp`) + `Custom(String)` escape hatch.
+- `Importer` trait — `Send + Sync`, object-safe, with
+  `name()` + `import(&[u8]) -> Result<Vec<PortableRecord>>`.
+- `PassthroughImporter` — reference adapter that round-trips
+  the canonical bundle. Used by upper-tier integration tests.
+- `export_to_bundle(records)` — hand-rolled deterministic JSON
+  writer. `BTreeMap`-iteration sorted custom-field keys,
+  fixed key order at every level, U+2028 / U+2029 escaped so
+  output embedded in `<script>` is JS-safe.
+- `import_from_bundle(bytes)` — hand-rolled strict JSON
+  reader. Rejects unknown root keys, unknown record keys,
+  unknown `kind` strings, trailing input, raw control chars
+  inside strings, oversize fields, oversize record / tag /
+  custom-field counts, and unsupported bundle versions.
+- `ImportError` — `Decode` / `TooLarge` / `InvalidParameter`
+  / `UnsupportedVersion(u32)` / `Adapter(String)`.
+- 29 unit tests covering: round-trip of one login,
+  round-trip of all five known kinds + a custom kind,
+  deterministic export, passthrough importer round-trip,
+  empty title rejection, oversize field / records / tags /
+  custom-fields rejection, empty Custom kind label
+  rejection, decoder rejection of unknown root key, unknown
+  record key, unsupported version, trailing bytes, unknown
+  kind value, oversize bundle bytes, raw control chars in
+  strings, escape-character round-trip, U+2028 / U+2029
+  round-trip, password / TOTP / custom-field redaction in
+  Debug, Send + Sync compile-time check, empty bundle
+  round-trip.
+- `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`.
+
+### Security hardening (pre-merge review)
+
+Three findings flagged before push, all fixed inline:
+
+- **HIGH** — `read_string` mis-decoded multi-byte UTF-8: a
+  previous byte-by-byte `b as char` push would silently
+  rewrite `é` (UTF-8 `0xC3 0xA9`) as two Latin-1 chars
+  `U+00C3 U+00A9` instead of one `U+00E9`. For a password
+  manager importing a Bitwarden/1Password export with
+  non-ASCII passwords, this would silently corrupt the
+  password and lock the user out of accounts. Fix:
+  accumulate raw bytes through the loop and run a single
+  `String::from_utf8` at the closing quote, rejecting
+  malformed UTF-8 with `Decode("invalid UTF-8 in string")`.
+  New regression test
+  `round_trip_preserves_unicode_passwords` exercises
+  passwords containing German, Japanese, Cyrillic, Greek,
+  emoji, and Vietnamese diacritics.
+- **LOW** — Permissive comma handling: missing or trailing
+  commas at the bundle and record levels were silently
+  accepted ("JSON parsing differences" attack surface).
+  Tightened: between fields requires a comma, no trailing
+  comma before `}`. Four new regression tests.
+- **LOW** — Leading zeros in `read_u32` (`0123` → 123). RFC
+  8259 forbids leading zeros on integer literals; rejected
+  with `Decode("leading zero in number")`. New regression
+  test `reject_leading_zero_in_version`.
+
+### Bounds
+
+`MAX_RECORDS = 100_000`, `MAX_FIELD_LEN = 64 KiB`,
+`MAX_BUNDLE_LEN = 256 MiB`, `MAX_TAGS_PER_RECORD = 64`,
+`MAX_CUSTOM_FIELDS_PER_RECORD = 64`, `BUNDLE_VERSION = 1`.
+
+### Out of scope (future PRs)
+
+- **Format adapters** — sibling crates per external format
+  (`vault-import-bitwarden`, `vault-import-keepass`, etc).
+- **Recipient list at export** — VLT04 wraps DEKs at export
+  time; this crate hands plaintext records to the host which
+  applies VLT04 before persistence.
+- **Streaming reader** — current API is `&[u8] -> Bundle`;
+  for very large bundles (~hundreds of MiB) a streaming
+  reader / writer is future work.
+- **Schema validation** — VLT02 typed-record validation runs
+  on the host's import path after `import_from_bundle`
+  returns. This crate enforces only structural bounds.
+- **Compression** — host's responsibility before / after
+  serialisation.

--- a/code/packages/rust/vault-import-export/Cargo.toml
+++ b/code/packages/rust/vault-import-export/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "coding_adventures_vault_import_export"
+version = "0.1.0"
+edition = "2021"
+description = "VLT15 — import/export tier for the Vault stack. Defines the PortableBundle (versioned JSON) + Importer/Exporter traits + PassthroughImporter reference. Format adapters (.1pux, Bitwarden JSON, KeePassXC .kdbx, LastPass CSV, age, gpg, SOPS) ship as sibling crates."
+
+[dependencies]
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-import-export/README.md
+++ b/code/packages/rust/vault-import-export/README.md
@@ -1,0 +1,116 @@
+# `coding_adventures_vault_import_export` — VLT15
+
+The import/export tier of the Vault stack. Defines the
+**versioned portable JSON bundle** that vaults emit on
+`vault export` and read on `vault import`, plus an `Importer`
+trait that format adapters implement and a hand-rolled JSON
+codec.
+
+Format adapters land as **sibling crates** (per VLT00 §VLT15):
+
+- `vault-import-1password`  — `.1pux`
+- `vault-import-bitwarden`  — Bitwarden JSON
+- `vault-import-keepass`    — KeePassXC `.kdbx`
+- `vault-import-lastpass`   — LastPass CSV
+- `vault-import-chrome`     — Chrome / Edge CSV
+- `vault-import-firefox`    — Firefox CSV
+- `vault-import-age`        — age files
+- `vault-import-gpg`        — GnuPG files
+- `vault-import-sops`       — SOPS files
+
+## Quick example
+
+```rust
+use coding_adventures_vault_import_export::{
+    export_to_bundle, import_from_bundle, PassthroughImporter,
+    PortableRecord, PortableRecordKind,
+};
+use coding_adventures_zeroize::Zeroizing;
+use std::collections::BTreeMap;
+
+let records = vec![PortableRecord {
+    kind: PortableRecordKind::Login,
+    title: "GitHub".into(),
+    username: Some("alice".into()),
+    password: Some(Zeroizing::new("hunter2".into())),
+    url: Some("https://github.com".into()),
+    notes: None,
+    totp_seed: None,
+    tags: vec!["work".into()],
+    custom_fields: BTreeMap::new(),
+}];
+
+let bytes = export_to_bundle(&records)?;     // canonical JSON
+let bundle = import_from_bundle(&bytes)?;
+assert_eq!(bundle.records, records);
+```
+
+## Wire format (versioned)
+
+```json
+{
+  "version": 1,
+  "records": [
+    {
+      "kind": "login",
+      "title": "GitHub",
+      "username": "alice",
+      "password": "hunter2",
+      "url": "https://github.com",
+      "tags": ["work"]
+    },
+    {
+      "kind": {"custom": "workflow"},
+      "title": "deploy steps",
+      "notes": "ssh ; deploy ; bless"
+    }
+  ]
+}
+```
+
+`kind` is a string for known kinds (`login`, `secure_note`,
+`card`, `ssh_key`, `totp`) or `{"custom": "<label>"}` for the
+escape hatch. The reader rejects unknown root keys, unknown
+record keys, unknown `kind` strings, and trailing input.
+
+## Threat model
+
+- **Plaintext crosses the trust boundary here.** Every
+  import/export operation is a user-driven ceremony — host
+  prompts, warns, and times out. This crate provides the byte
+  transformation; it does not decide whether to do it.
+- **Sensitive fields are zeroized.** `password`, `totp_seed`,
+  and every `custom_fields` value are held under
+  `Zeroizing<String>` so dropping a `PortableRecord` scrubs
+  the bytes. `Debug` for `PortableRecord` is hand-rolled to
+  redact each sensitive field.
+- **Strict reader.** Unknown root keys → `Decode`; unknown
+  record keys → `Decode`; trailing bytes → `Decode`; unknown
+  bundle version → `UnsupportedVersion(v)`. A peer producing
+  a future bundle cannot smuggle data through a v1 reader.
+- **Bounded sizes.** `MAX_RECORDS = 100_000`,
+  `MAX_FIELD_LEN = 64 KiB`, `MAX_BUNDLE_LEN = 256 MiB`,
+  `MAX_TAGS_PER_RECORD = 64`,
+  `MAX_CUSTOM_FIELDS_PER_RECORD = 64`. Both reader and writer
+  enforce all five.
+- **Deterministic export.** Same input → same bytes
+  (`BTreeMap` sorted custom-field keys, fixed key order at
+  every level, U+2028 / U+2029 escaped). Reproducible exports
+  are a documented property.
+
+## What this crate is NOT
+
+- Not a sealing layer — VLT01 seals the records before they
+  reach the vault.
+- Not a recipient list — VLT04 wraps DEKs at export time.
+- Not a CSV parser — sibling crates handle each external
+  format.
+- Not a `serde_json` user — the codec is hand-rolled in one
+  file so the wire format is auditable in one place.
+
+## Capabilities
+
+None — pure parser + writer. See `required_capabilities.json`.
+
+See [`VLT00-vault-roadmap.md`](../../../specs/VLT00-vault-roadmap.md)
+and [`VLT15-vault-import-export.md`](../../../specs/VLT15-vault-import-export.md).

--- a/code/packages/rust/vault-import-export/required_capabilities.json
+++ b/code/packages/rust/vault-import-export/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-import-export",
+  "capabilities": [],
+  "justification": "Pure data-structure layer + hand-rolled JSON codec. No filesystem, network, process, environment, csprng, or wallclock access. Format adapter sibling crates (vault-import-bitwarden, vault-import-keepass, etc) declare their own capabilities."
+}

--- a/code/packages/rust/vault-import-export/src/lib.rs
+++ b/code/packages/rust/vault-import-export/src/lib.rs
@@ -1,0 +1,1215 @@
+//! # `coding_adventures_vault_import_export` — VLT15
+//!
+//! ## What this crate is
+//!
+//! The **import/export tier** of the Vault stack. Defines:
+//!
+//!   * a versioned [`PortableBundle`] format — the canonical
+//!     interchange shape between vaults and external tools,
+//!   * the [`Importer`] trait every adapter implements,
+//!   * a [`PassthroughImporter`] reference that round-trips the
+//!     portable bundle (so the test suite for upper layers has
+//!     something to talk to without booting the real adapters),
+//!   * an `export_to_bundle` writer and `import_from_bundle`
+//!     reader that produce / consume the canonical JSON.
+//!
+//! Format adapters land as **sibling crates**:
+//!
+//!   - `vault-import-1password`  — `.1pux`
+//!   - `vault-import-bitwarden`  — Bitwarden JSON
+//!   - `vault-import-keepass`    — KeePassXC `.kdbx`
+//!   - `vault-import-lastpass`   — LastPass CSV
+//!   - `vault-import-chrome`     — Chrome / Edge CSV
+//!   - `vault-import-firefox`    — Firefox CSV
+//!   - `vault-import-age`        — age files
+//!   - `vault-import-gpg`        — GnuPG files
+//!   - `vault-import-sops`       — SOPS files
+//!
+//! Each adapter is its own dependency-light crate so a vault
+//! using only Bitwarden import doesn't pull in the KDBX parser.
+//!
+//! ## Why this layer is "ceremony"
+//!
+//! Import/export is the one place in the Vault stack where
+//! **plaintext crosses the trust boundary**:
+//!
+//!   * On *import*, plaintext arrives from the user (a file
+//!     they exported from a competing product). The crate sees
+//!     it before VLT01 sealing happens; the host is responsible
+//!     for sealing immediately and then scrubbing the
+//!     intermediate.
+//!   * On *export*, plaintext leaves the vault. VLT01-sealed
+//!     bytes are decrypted just to be repackaged into the
+//!     portable format. Same scrub rule applies.
+//!
+//! Because of this, all import/export operations are documented
+//! as **explicit user-driven ceremonies**: the host UI prompts,
+//! warns, and times out. This crate gives you the byte
+//! transformation; it does not decide whether to do it.
+//!
+//! ## Threat model
+//!
+//! * **Untrusted import bytes**. The reader is strict: bounded
+//!   record count, bounded per-field byte length, bounded total
+//!   bundle size, JSON parser is hand-rolled (no serde) and
+//!   refuses unknown root keys. A malicious input cannot
+//!   over-allocate by inflating any single number.
+//! * **Plaintext residue**. Every secret-shaped field
+//!   (`password`, `totp_seed`, `custom_fields` values) is held
+//!   under [`Zeroizing`] so dropping a `PortableRecord`
+//!   scrubs the bytes. Non-secret fields (`title`, `username`,
+//!   `url`, `notes`) are not zeroizing — they're considered
+//!   metadata.
+//! * **Field-name confusion**. The portable JSON only carries a
+//!   well-known set of field names (`kind`, `title`, `username`,
+//!   `password`, `url`, `notes`, `totp_seed`, `tags`,
+//!   `custom_fields`). Unknown keys are rejected so a peer
+//!   producing a v2 bundle can't sneak data through a v1
+//!   reader as opaque "extra" fields.
+//! * **PortableRecordKind opacity**. The kind is an
+//!   `#[non_exhaustive]` enum with `Custom(String)` for
+//!   forward-compatibility; the kind string is bounded.
+//! * **Round-trip determinism**. `export_to_bundle` produces
+//!   deterministic JSON (sorted custom-field keys, fixed key
+//!   order at every level) so a vault re-exported produces
+//!   identical bytes to a previous export of the same content.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_zeroize::Zeroizing;
+use std::collections::BTreeMap;
+
+// === Section 1. Bounds =====================================================
+
+/// Maximum number of records in one bundle.
+pub const MAX_RECORDS: usize = 100_000;
+/// Maximum bytes per individual field.
+pub const MAX_FIELD_LEN: usize = 64 * 1024;
+/// Maximum bytes for the entire bundle's serialized form.
+pub const MAX_BUNDLE_LEN: usize = 256 * 1024 * 1024;
+/// Maximum tags per record.
+pub const MAX_TAGS_PER_RECORD: usize = 64;
+/// Maximum custom fields per record.
+pub const MAX_CUSTOM_FIELDS_PER_RECORD: usize = 64;
+/// Bundle format version we produce. Readers accept this and
+/// (in future) lower compatible versions.
+pub const BUNDLE_VERSION: u32 = 1;
+
+// === Section 2. Vocabulary types ===========================================
+
+/// Versioned portable bundle. Top-level container.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortableBundle {
+    /// Format version. Always [`BUNDLE_VERSION`] for newly
+    /// produced bundles.
+    pub version: u32,
+    /// All records in the bundle. Order is significant for
+    /// reproducible exports but not semantically meaningful;
+    /// the host application sorts on display.
+    pub records: Vec<PortableRecord>,
+}
+
+/// One record. Field meanings:
+///
+/// | Field          | Sensitive? | Notes                                       |
+/// |----------------|------------|---------------------------------------------|
+/// | `kind`         | no         | typed-record kind (login, note, …)          |
+/// | `title`        | no         | display name                                |
+/// | `username`     | no         | account / email / handle                    |
+/// | `password`     | YES        | held under `Zeroizing<String>`              |
+/// | `url`          | no         | site URL                                    |
+/// | `notes`        | no         | freeform notes                              |
+/// | `totp_seed`    | YES        | held under `Zeroizing<String>`              |
+/// | `tags`         | no         | flat string tags                            |
+/// | `custom_fields`| YES        | each value held under `Zeroizing<String>`   |
+///
+/// `Debug` is hand-rolled to redact every sensitive field.
+/// `Clone` is hand-rolled because `Zeroizing<String>` does not
+/// derive `Clone` — cloning produces a fresh `Zeroizing<String>`
+/// per sensitive field, so each copy is independently scrubbed
+/// on drop.
+pub struct PortableRecord {
+    /// Typed-record kind.
+    pub kind: PortableRecordKind,
+    /// Display title.
+    pub title: String,
+    /// Optional username / handle.
+    pub username: Option<String>,
+    /// Optional password. Held under `Zeroizing` so a stray
+    /// drop scrubs the bytes.
+    pub password: Option<Zeroizing<String>>,
+    /// Optional URL.
+    pub url: Option<String>,
+    /// Optional freeform notes (treated as non-sensitive).
+    pub notes: Option<String>,
+    /// Optional TOTP seed (Base32 / OTPAuth URI). Sensitive.
+    pub totp_seed: Option<Zeroizing<String>>,
+    /// Free-form tags (case-sensitive strings).
+    pub tags: Vec<String>,
+    /// Caller-defined extra fields. Each value is treated as
+    /// sensitive (held under `Zeroizing`). Keys are sorted on
+    /// export for deterministic output.
+    pub custom_fields: BTreeMap<String, Zeroizing<String>>,
+}
+
+impl Clone for PortableRecord {
+    fn clone(&self) -> Self {
+        Self {
+            kind: self.kind.clone(),
+            title: self.title.clone(),
+            username: self.username.clone(),
+            password: self.password.as_ref().map(|p| Zeroizing::new((**p).clone())),
+            url: self.url.clone(),
+            notes: self.notes.clone(),
+            totp_seed: self
+                .totp_seed
+                .as_ref()
+                .map(|s| Zeroizing::new((**s).clone())),
+            tags: self.tags.clone(),
+            custom_fields: self
+                .custom_fields
+                .iter()
+                .map(|(k, v)| (k.clone(), Zeroizing::new((**v).clone())))
+                .collect(),
+        }
+    }
+}
+
+impl core::fmt::Debug for PortableRecord {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PortableRecord")
+            .field("kind", &self.kind)
+            .field("title", &self.title)
+            .field("username", &self.username)
+            .field(
+                "password",
+                &self
+                    .password
+                    .as_ref()
+                    .map(|p| format!("<{}-char redacted>", p.len())),
+            )
+            .field("url", &self.url)
+            .field("notes", &self.notes)
+            .field(
+                "totp_seed",
+                &self
+                    .totp_seed
+                    .as_ref()
+                    .map(|s| format!("<{}-char redacted>", s.len())),
+            )
+            .field("tags", &self.tags)
+            .field(
+                "custom_fields",
+                &format_args!("<{} keys, values redacted>", self.custom_fields.len()),
+            )
+            .finish()
+    }
+}
+
+impl PartialEq for PortableRecord {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+            && self.title == other.title
+            && self.username == other.username
+            && self.password.as_ref().map(|p| &**p) == other.password.as_ref().map(|p| &**p)
+            && self.url == other.url
+            && self.notes == other.notes
+            && self.totp_seed.as_ref().map(|p| &**p)
+                == other.totp_seed.as_ref().map(|p| &**p)
+            && self.tags == other.tags
+            && self.custom_fields.len() == other.custom_fields.len()
+            && self
+                .custom_fields
+                .iter()
+                .zip(other.custom_fields.iter())
+                .all(|(a, b)| a.0 == b.0 && **a.1 == **b.1)
+    }
+}
+impl Eq for PortableRecord {}
+
+/// Typed-record kinds. `#[non_exhaustive]` so future kinds land
+/// non-breakingly. Unknown wire kinds become `Custom(label)` so
+/// a v1 reader doesn't crash on a v2 producer's new type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PortableRecordKind {
+    /// Login: username + password (+ optional TOTP).
+    Login,
+    /// Secure note (notes-only).
+    SecureNote,
+    /// Payment card.
+    Card,
+    /// SSH private key.
+    SshKey,
+    /// Standalone TOTP seed.
+    Totp,
+    /// Catch-all for kinds the v1 wire doesn't enumerate. The
+    /// inner string is a short label.
+    Custom(String),
+}
+
+/// Errors produced by the reader / writer.
+#[derive(Debug)]
+pub enum ImportError {
+    /// JSON syntax error or malformed bundle structure.
+    Decode(&'static str),
+    /// Caller-supplied bundle exceeds a documented bound.
+    TooLarge(&'static str),
+    /// Caller passed a malformed value (oversize / control
+    /// chars / empty required field).
+    InvalidParameter(&'static str),
+    /// Bundle version is not supported.
+    UnsupportedVersion(u32),
+    /// Adapter-specific failure (wrapped string).
+    Adapter(String),
+}
+
+impl core::fmt::Display for ImportError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Decode(s) => write!(f, "decode error: {}", s),
+            Self::TooLarge(s) => write!(f, "too large: {}", s),
+            Self::InvalidParameter(s) => write!(f, "invalid parameter: {}", s),
+            Self::UnsupportedVersion(v) => write!(f, "unsupported bundle version: {}", v),
+            Self::Adapter(s) => write!(f, "adapter error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for ImportError {}
+
+// === Section 3. Importer trait ==============================================
+
+/// What every adapter implements. `Send + Sync` so a single
+/// adapter instance can be shared across threads.
+pub trait Importer: Send + Sync {
+    /// Stable name used by the CLI to dispatch:
+    /// `vault import --from <name> <file>`.
+    fn name(&self) -> &str;
+    /// Convert source-format bytes into a list of
+    /// `PortableRecord`s. The host then either passes the
+    /// list straight to the vault (sealing each one) or
+    /// re-serialises it as a portable bundle for the user.
+    fn import(&self, input: &[u8]) -> Result<Vec<PortableRecord>, ImportError>;
+}
+
+/// Reference implementation: reads a portable bundle and
+/// returns its records. Useful as the round-trip path the
+/// other tests exercise.
+pub struct PassthroughImporter;
+
+impl Importer for PassthroughImporter {
+    fn name(&self) -> &str {
+        "vault-portable"
+    }
+    fn import(&self, input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
+        let bundle = import_from_bundle(input)?;
+        Ok(bundle.records)
+    }
+}
+
+// === Section 4. Validation =================================================
+
+fn validate_field_str(s: &str, what: &'static str) -> Result<(), ImportError> {
+    if s.len() > MAX_FIELD_LEN {
+        return Err(ImportError::TooLarge(what));
+    }
+    Ok(())
+}
+
+fn validate_record(rec: &PortableRecord) -> Result<(), ImportError> {
+    validate_field_str(&rec.title, "title")?;
+    if rec.title.is_empty() {
+        return Err(ImportError::InvalidParameter("title must not be empty"));
+    }
+    if let Some(u) = &rec.username {
+        validate_field_str(u, "username")?;
+    }
+    if let Some(p) = &rec.password {
+        validate_field_str(p, "password")?;
+    }
+    if let Some(u) = &rec.url {
+        validate_field_str(u, "url")?;
+    }
+    if let Some(n) = &rec.notes {
+        validate_field_str(n, "notes")?;
+    }
+    if let Some(t) = &rec.totp_seed {
+        validate_field_str(t, "totp_seed")?;
+    }
+    if rec.tags.len() > MAX_TAGS_PER_RECORD {
+        return Err(ImportError::TooLarge("tags per record"));
+    }
+    for tag in &rec.tags {
+        validate_field_str(tag, "tag")?;
+    }
+    if rec.custom_fields.len() > MAX_CUSTOM_FIELDS_PER_RECORD {
+        return Err(ImportError::TooLarge("custom fields per record"));
+    }
+    for (k, v) in &rec.custom_fields {
+        validate_field_str(k, "custom field key")?;
+        validate_field_str(v, "custom field value")?;
+    }
+    if let PortableRecordKind::Custom(label) = &rec.kind {
+        validate_field_str(label, "kind label")?;
+        if label.is_empty() {
+            return Err(ImportError::InvalidParameter("Custom kind label must not be empty"));
+        }
+    }
+    Ok(())
+}
+
+// === Section 5. Hand-rolled JSON encoder ===================================
+//
+// We avoid pulling in serde so the crate stays dep-light and
+// the wire format is auditable in one file. The encoder is a
+// total function over the bounded vocabulary; the decoder is
+// strict (no unknown keys).
+
+fn json_escape(s: &str, out: &mut String) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+fn write_record(rec: &PortableRecord, out: &mut String) {
+    out.push('{');
+    // kind
+    out.push_str("\"kind\":");
+    write_kind(&rec.kind, out);
+    // title
+    out.push_str(",\"title\":");
+    json_escape(&rec.title, out);
+    // username
+    if let Some(u) = &rec.username {
+        out.push_str(",\"username\":");
+        json_escape(u, out);
+    }
+    if let Some(p) = &rec.password {
+        out.push_str(",\"password\":");
+        json_escape(p, out);
+    }
+    if let Some(u) = &rec.url {
+        out.push_str(",\"url\":");
+        json_escape(u, out);
+    }
+    if let Some(n) = &rec.notes {
+        out.push_str(",\"notes\":");
+        json_escape(n, out);
+    }
+    if let Some(t) = &rec.totp_seed {
+        out.push_str(",\"totp_seed\":");
+        json_escape(t, out);
+    }
+    if !rec.tags.is_empty() {
+        out.push_str(",\"tags\":[");
+        for (i, t) in rec.tags.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            json_escape(t, out);
+        }
+        out.push(']');
+    }
+    if !rec.custom_fields.is_empty() {
+        out.push_str(",\"custom_fields\":{");
+        // BTreeMap iteration order is sorted by key, which gives
+        // us deterministic output.
+        for (i, (k, v)) in rec.custom_fields.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            json_escape(k, out);
+            out.push(':');
+            json_escape(v, out);
+        }
+        out.push('}');
+    }
+    out.push('}');
+}
+
+fn write_kind(k: &PortableRecordKind, out: &mut String) {
+    match k {
+        PortableRecordKind::Login => out.push_str("\"login\""),
+        PortableRecordKind::SecureNote => out.push_str("\"secure_note\""),
+        PortableRecordKind::Card => out.push_str("\"card\""),
+        PortableRecordKind::SshKey => out.push_str("\"ssh_key\""),
+        PortableRecordKind::Totp => out.push_str("\"totp\""),
+        PortableRecordKind::Custom(label) => {
+            // Wire shape: {"custom":"<label>"}. Two-level so a
+            // v1 reader doesn't confuse it with a known kind.
+            out.push_str("{\"custom\":");
+            json_escape(label, out);
+            out.push('}');
+        }
+    }
+}
+
+/// Serialize a bundle to its canonical JSON form.
+pub fn export_to_bundle(records: &[PortableRecord]) -> Result<Vec<u8>, ImportError> {
+    if records.len() > MAX_RECORDS {
+        return Err(ImportError::TooLarge("MAX_RECORDS"));
+    }
+    for rec in records {
+        validate_record(rec)?;
+    }
+    let mut out = String::with_capacity(64 + records.len() * 128);
+    out.push_str("{\"version\":");
+    out.push_str(&BUNDLE_VERSION.to_string());
+    out.push_str(",\"records\":[");
+    for (i, rec) in records.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        write_record(rec, &mut out);
+    }
+    out.push_str("]}");
+    if out.len() > MAX_BUNDLE_LEN {
+        return Err(ImportError::TooLarge("MAX_BUNDLE_LEN"));
+    }
+    Ok(out.into_bytes())
+}
+
+// === Section 6. Hand-rolled JSON decoder ===================================
+//
+// The decoder is *strict*: unknown root keys, unknown record
+// keys, and trailing input are all rejected. Bounded inputs at
+// every step.
+
+struct Reader<'a> {
+    s: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(s: &'a [u8]) -> Self {
+        Self { s, pos: 0 }
+    }
+    fn peek(&self) -> Option<u8> {
+        self.s.get(self.pos).copied()
+    }
+    fn bump(&mut self) -> Option<u8> {
+        let b = self.peek()?;
+        self.pos += 1;
+        Some(b)
+    }
+    fn skip_ws(&mut self) {
+        while let Some(b) = self.peek() {
+            if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+    fn expect_byte(&mut self, b: u8, msg: &'static str) -> Result<(), ImportError> {
+        self.skip_ws();
+        if self.bump() != Some(b) {
+            return Err(ImportError::Decode(msg));
+        }
+        Ok(())
+    }
+    fn read_string(&mut self) -> Result<String, ImportError> {
+        self.skip_ws();
+        if self.bump() != Some(b'"') {
+            return Err(ImportError::Decode("expected `\"`"));
+        }
+        // Accumulate raw bytes (with escapes already decoded
+        // into their UTF-8 byte form). At the end we run a
+        // single `String::from_utf8` over the whole buffer so
+        // multi-byte UTF-8 codepoints are decoded correctly —
+        // a previous byte-by-byte `b as char` push would
+        // mis-decode `é` (UTF-8 0xC3 0xA9) as two Latin-1
+        // chars `U+00C3 U+00A9` instead of one `U+00E9`,
+        // silently corrupting any imported plaintext that
+        // contained non-ASCII characters not pre-escaped by
+        // the producer.
+        let mut buf: Vec<u8> = Vec::new();
+        loop {
+            let b = self.bump().ok_or(ImportError::Decode("unterminated string"))?;
+            if buf.len() > MAX_FIELD_LEN {
+                return Err(ImportError::TooLarge("string field"));
+            }
+            match b {
+                b'"' => {
+                    return String::from_utf8(buf)
+                        .map_err(|_| ImportError::Decode("invalid UTF-8 in string"))
+                }
+                b'\\' => {
+                    let c = self.bump().ok_or(ImportError::Decode("bad escape"))?;
+                    match c {
+                        b'"' => buf.push(b'"'),
+                        b'\\' => buf.push(b'\\'),
+                        b'/' => buf.push(b'/'),
+                        b'n' => buf.push(b'\n'),
+                        b'r' => buf.push(b'\r'),
+                        b't' => buf.push(b'\t'),
+                        b'b' => buf.push(0x08),
+                        b'f' => buf.push(0x0C),
+                        b'u' => {
+                            let mut hex = [0u8; 4];
+                            for slot in hex.iter_mut() {
+                                *slot = self.bump().ok_or(ImportError::Decode("short \\u escape"))?;
+                            }
+                            let cp = u32_from_hex4(&hex)
+                                .ok_or(ImportError::Decode("bad \\u hex"))?;
+                            let c = char::from_u32(cp)
+                                .ok_or(ImportError::Decode("bad codepoint"))?;
+                            // Encode the codepoint as UTF-8
+                            // bytes into the buffer.
+                            let mut tmp = [0u8; 4];
+                            let s = c.encode_utf8(&mut tmp);
+                            buf.extend_from_slice(s.as_bytes());
+                        }
+                        _ => return Err(ImportError::Decode("unknown escape")),
+                    }
+                }
+                b => {
+                    // Reject raw control characters; they MUST
+                    // be \u-escaped per JSON.
+                    if b < 0x20 {
+                        return Err(ImportError::Decode("unescaped control char in string"));
+                    }
+                    // Push the raw byte; UTF-8 validation is
+                    // deferred until the closing quote so
+                    // multi-byte codepoints survive intact.
+                    buf.push(b);
+                }
+            }
+        }
+    }
+    fn read_u32(&mut self) -> Result<u32, ImportError> {
+        self.skip_ws();
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            if b.is_ascii_digit() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.pos == start {
+            return Err(ImportError::Decode("expected digits"));
+        }
+        // RFC 8259 forbids leading zeros on integer literals
+        // (`0123` is not valid JSON, even though `u32::parse`
+        // would accept it). Reject so two parsers can't disagree
+        // about field values.
+        if self.pos - start > 1 && self.s[start] == b'0' {
+            return Err(ImportError::Decode("leading zero in number"));
+        }
+        let s = core::str::from_utf8(&self.s[start..self.pos])
+            .map_err(|_| ImportError::Decode("non-ASCII number"))?;
+        s.parse::<u32>().map_err(|_| ImportError::Decode("bad u32"))
+    }
+    fn at_eof(&mut self) -> bool {
+        self.skip_ws();
+        self.pos >= self.s.len()
+    }
+}
+
+fn u32_from_hex4(bytes: &[u8; 4]) -> Option<u32> {
+    let mut out = 0u32;
+    for b in bytes {
+        let v = match *b {
+            b'0'..=b'9' => (b - b'0') as u32,
+            b'a'..=b'f' => (b - b'a' + 10) as u32,
+            b'A'..=b'F' => (b - b'A' + 10) as u32,
+            _ => return None,
+        };
+        out = (out << 4) | v;
+    }
+    Some(out)
+}
+
+fn read_kind(r: &mut Reader<'_>) -> Result<PortableRecordKind, ImportError> {
+    r.skip_ws();
+    match r.peek() {
+        Some(b'"') => {
+            let s = r.read_string()?;
+            Ok(match s.as_str() {
+                "login" => PortableRecordKind::Login,
+                "secure_note" => PortableRecordKind::SecureNote,
+                "card" => PortableRecordKind::Card,
+                "ssh_key" => PortableRecordKind::SshKey,
+                "totp" => PortableRecordKind::Totp,
+                _ => return Err(ImportError::Decode("unknown kind value")),
+            })
+        }
+        Some(b'{') => {
+            // {"custom":"<label>"}
+            r.bump(); // consume '{'
+            let key = r.read_string()?;
+            if key != "custom" {
+                return Err(ImportError::Decode("unknown object kind key"));
+            }
+            r.expect_byte(b':', "expected `:` after `custom`")?;
+            let label = r.read_string()?;
+            r.expect_byte(b'}', "expected `}` after Custom kind")?;
+            Ok(PortableRecordKind::Custom(label))
+        }
+        _ => Err(ImportError::Decode("kind must be a string or `{custom:...}`")),
+    }
+}
+
+fn read_record(r: &mut Reader<'_>) -> Result<PortableRecord, ImportError> {
+    r.expect_byte(b'{', "expected `{` at record start")?;
+    let mut kind: Option<PortableRecordKind> = None;
+    let mut title: Option<String> = None;
+    let mut username: Option<String> = None;
+    let mut password: Option<Zeroizing<String>> = None;
+    let mut url: Option<String> = None;
+    let mut notes: Option<String> = None;
+    let mut totp_seed: Option<Zeroizing<String>> = None;
+    let mut tags: Vec<String> = Vec::new();
+    let mut custom_fields: BTreeMap<String, Zeroizing<String>> = BTreeMap::new();
+    let mut first = true;
+    loop {
+        r.skip_ws();
+        if r.peek() == Some(b'}') {
+            r.bump();
+            break;
+        }
+        if !first {
+            // Strict JSON: between fields we require a comma
+            // and only a comma. Permissive parsers (accepting
+            // missing commas) are a "JSON parsing differences"
+            // attack surface — two consumers seeing different
+            // record contents.
+            r.expect_byte(b',', "expected `,` or `}` between record fields")?;
+            r.skip_ws();
+            // Trailing comma before `}` is also forbidden.
+            if r.peek() == Some(b'}') {
+                return Err(ImportError::Decode("trailing comma before `}`"));
+            }
+        }
+        first = false;
+        let key = r.read_string()?;
+        r.expect_byte(b':', "expected `:` after key")?;
+        match key.as_str() {
+            "kind" => kind = Some(read_kind(r)?),
+            "title" => title = Some(r.read_string()?),
+            "username" => username = Some(r.read_string()?),
+            "password" => password = Some(Zeroizing::new(r.read_string()?)),
+            "url" => url = Some(r.read_string()?),
+            "notes" => notes = Some(r.read_string()?),
+            "totp_seed" => totp_seed = Some(Zeroizing::new(r.read_string()?)),
+            "tags" => {
+                r.expect_byte(b'[', "expected `[` for tags array")?;
+                loop {
+                    r.skip_ws();
+                    if r.peek() == Some(b']') {
+                        r.bump();
+                        break;
+                    }
+                    if !tags.is_empty() {
+                        r.expect_byte(b',', "expected `,` between tags")?;
+                        r.skip_ws();
+                    }
+                    if tags.len() >= MAX_TAGS_PER_RECORD {
+                        return Err(ImportError::TooLarge("tags per record"));
+                    }
+                    tags.push(r.read_string()?);
+                }
+            }
+            "custom_fields" => {
+                r.expect_byte(b'{', "expected `{` for custom_fields")?;
+                loop {
+                    r.skip_ws();
+                    if r.peek() == Some(b'}') {
+                        r.bump();
+                        break;
+                    }
+                    if !custom_fields.is_empty() {
+                        r.expect_byte(b',', "expected `,` between custom fields")?;
+                        r.skip_ws();
+                    }
+                    if custom_fields.len() >= MAX_CUSTOM_FIELDS_PER_RECORD {
+                        return Err(ImportError::TooLarge("custom fields per record"));
+                    }
+                    let k = r.read_string()?;
+                    r.expect_byte(b':', "expected `:` in custom field")?;
+                    let v = Zeroizing::new(r.read_string()?);
+                    custom_fields.insert(k, v);
+                }
+            }
+            _ => return Err(ImportError::Decode("unknown record key")),
+        }
+        // Loop top will require a comma or `}` next.
+    }
+    let kind = kind.ok_or(ImportError::Decode("record missing `kind`"))?;
+    let title = title.ok_or(ImportError::Decode("record missing `title`"))?;
+    let rec = PortableRecord {
+        kind,
+        title,
+        username,
+        password,
+        url,
+        notes,
+        totp_seed,
+        tags,
+        custom_fields,
+    };
+    validate_record(&rec)?;
+    Ok(rec)
+}
+
+/// Parse a portable bundle from bytes. Strict: unknown
+/// top-level keys → `Decode`; unknown record keys → `Decode`;
+/// trailing bytes → `Decode`.
+pub fn import_from_bundle(bytes: &[u8]) -> Result<PortableBundle, ImportError> {
+    if bytes.len() > MAX_BUNDLE_LEN {
+        return Err(ImportError::TooLarge("MAX_BUNDLE_LEN"));
+    }
+    let mut r = Reader::new(bytes);
+    r.expect_byte(b'{', "expected `{` at bundle start")?;
+    let mut version: Option<u32> = None;
+    let mut records: Option<Vec<PortableRecord>> = None;
+    let mut first = true;
+    loop {
+        r.skip_ws();
+        if r.peek() == Some(b'}') {
+            r.bump();
+            break;
+        }
+        if !first {
+            r.expect_byte(b',', "expected `,` or `}` between bundle keys")?;
+            r.skip_ws();
+            if r.peek() == Some(b'}') {
+                return Err(ImportError::Decode("trailing comma before `}`"));
+            }
+        }
+        first = false;
+        let key = r.read_string()?;
+        r.expect_byte(b':', "expected `:` after key")?;
+        match key.as_str() {
+            "version" => version = Some(r.read_u32()?),
+            "records" => {
+                r.expect_byte(b'[', "expected `[` for records")?;
+                let mut recs: Vec<PortableRecord> = Vec::new();
+                loop {
+                    r.skip_ws();
+                    if r.peek() == Some(b']') {
+                        r.bump();
+                        break;
+                    }
+                    if !recs.is_empty() {
+                        r.expect_byte(b',', "expected `,` between records")?;
+                        r.skip_ws();
+                    }
+                    if recs.len() >= MAX_RECORDS {
+                        return Err(ImportError::TooLarge("MAX_RECORDS"));
+                    }
+                    recs.push(read_record(&mut r)?);
+                }
+                records = Some(recs);
+            }
+            _ => return Err(ImportError::Decode("unknown bundle key")),
+        }
+        // Loop top will require a comma or `}` next.
+    }
+    let version = version.ok_or(ImportError::Decode("bundle missing `version`"))?;
+    if version != BUNDLE_VERSION {
+        return Err(ImportError::UnsupportedVersion(version));
+    }
+    let records = records.ok_or(ImportError::Decode("bundle missing `records`"))?;
+    if !r.at_eof() {
+        return Err(ImportError::Decode("trailing bytes after bundle"));
+    }
+    Ok(PortableBundle { version, records })
+}
+
+// === Section 7. Tests ======================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn login(title: &str, user: &str, pw: &str) -> PortableRecord {
+        PortableRecord {
+            kind: PortableRecordKind::Login,
+            title: title.into(),
+            username: Some(user.into()),
+            password: Some(Zeroizing::new(pw.into())),
+            url: Some("https://example.com".into()),
+            notes: None,
+            totp_seed: None,
+            tags: vec!["work".into()],
+            custom_fields: BTreeMap::new(),
+        }
+    }
+
+    // --- Round-trip ---
+
+    #[test]
+    fn roundtrip_one_login() {
+        let r = login("GitHub", "alice", "hunter2");
+        let bytes = export_to_bundle(&[r.clone()]).unwrap();
+        let bundle = import_from_bundle(&bytes).unwrap();
+        assert_eq!(bundle.version, BUNDLE_VERSION);
+        assert_eq!(bundle.records.len(), 1);
+        assert_eq!(bundle.records[0], r);
+    }
+
+    #[test]
+    fn roundtrip_all_kinds() {
+        let mut card_fields = BTreeMap::new();
+        card_fields.insert("number".to_string(), Zeroizing::new("4111-1111-1111-1111".to_string()));
+        card_fields.insert("cvv".to_string(), Zeroizing::new("123".to_string()));
+        let recs = vec![
+            login("github", "alice", "hunter2"),
+            PortableRecord {
+                kind: PortableRecordKind::SecureNote,
+                title: "wifi password".into(),
+                username: None,
+                password: None,
+                url: None,
+                notes: Some("LongAndStrong-2024".into()),
+                totp_seed: None,
+                tags: vec![],
+                custom_fields: BTreeMap::new(),
+            },
+            PortableRecord {
+                kind: PortableRecordKind::Card,
+                title: "amex".into(),
+                username: None,
+                password: None,
+                url: None,
+                notes: None,
+                totp_seed: None,
+                tags: vec![],
+                custom_fields: card_fields,
+            },
+            PortableRecord {
+                kind: PortableRecordKind::Totp,
+                title: "AWS root".into(),
+                username: None,
+                password: None,
+                url: None,
+                notes: None,
+                totp_seed: Some(Zeroizing::new("JBSWY3DPEHPK3PXP".into())),
+                tags: vec![],
+                custom_fields: BTreeMap::new(),
+            },
+            PortableRecord {
+                kind: PortableRecordKind::Custom("workflow".into()),
+                title: "deploy steps".into(),
+                username: None,
+                password: None,
+                url: None,
+                notes: Some("ssh ; deploy ; bless".into()),
+                totp_seed: None,
+                tags: vec!["ops".into()],
+                custom_fields: BTreeMap::new(),
+            },
+        ];
+        let bytes = export_to_bundle(&recs).unwrap();
+        let bundle = import_from_bundle(&bytes).unwrap();
+        assert_eq!(bundle.records, recs);
+    }
+
+    #[test]
+    fn deterministic_export() {
+        // Same input → identical output bytes (BTreeMap iteration
+        // and the writer's fixed key order make this true).
+        let r = login("github", "alice", "hunter2");
+        let bytes_a = export_to_bundle(&[r.clone()]).unwrap();
+        let bytes_b = export_to_bundle(&[r]).unwrap();
+        assert_eq!(bytes_a, bytes_b);
+    }
+
+    #[test]
+    fn passthrough_importer_works() {
+        let r = login("github", "alice", "hunter2");
+        let bytes = export_to_bundle(&[r.clone()]).unwrap();
+        let imp = PassthroughImporter;
+        assert_eq!(imp.name(), "vault-portable");
+        let recs = imp.import(&bytes).unwrap();
+        assert_eq!(recs, vec![r]);
+    }
+
+    // --- Validation ---
+
+    #[test]
+    fn reject_empty_title() {
+        let mut r = login("github", "alice", "hunter2");
+        r.title.clear();
+        let res = export_to_bundle(&[r]);
+        assert!(matches!(res, Err(ImportError::InvalidParameter(_))));
+    }
+
+    #[test]
+    fn reject_oversize_field() {
+        let mut r = login("github", "alice", "hunter2");
+        r.notes = Some("x".repeat(MAX_FIELD_LEN + 1));
+        let res = export_to_bundle(&[r]);
+        assert!(matches!(res, Err(ImportError::TooLarge(_))));
+    }
+
+    #[test]
+    fn reject_too_many_records() {
+        let r = login("github", "alice", "hunter2");
+        let recs = vec![r; MAX_RECORDS + 1];
+        let res = export_to_bundle(&recs);
+        assert!(matches!(res, Err(ImportError::TooLarge(_))));
+    }
+
+    #[test]
+    fn reject_too_many_tags() {
+        let mut r = login("github", "alice", "hunter2");
+        r.tags = (0..(MAX_TAGS_PER_RECORD + 1)).map(|i| format!("t{}", i)).collect();
+        let res = export_to_bundle(&[r]);
+        assert!(matches!(res, Err(ImportError::TooLarge(_))));
+    }
+
+    #[test]
+    fn reject_too_many_custom_fields() {
+        let mut r = login("github", "alice", "hunter2");
+        r.custom_fields = (0..(MAX_CUSTOM_FIELDS_PER_RECORD + 1))
+            .map(|i| (format!("k{}", i), Zeroizing::new("v".to_string())))
+            .collect();
+        let res = export_to_bundle(&[r]);
+        assert!(matches!(res, Err(ImportError::TooLarge(_))));
+    }
+
+    #[test]
+    fn reject_empty_custom_kind_label() {
+        let r = PortableRecord {
+            kind: PortableRecordKind::Custom("".into()),
+            title: "x".into(),
+            username: None,
+            password: None,
+            url: None,
+            notes: None,
+            totp_seed: None,
+            tags: vec![],
+            custom_fields: BTreeMap::new(),
+        };
+        let res = export_to_bundle(&[r]);
+        assert!(matches!(res, Err(ImportError::InvalidParameter(_))));
+    }
+
+    // --- Decoder strictness ---
+
+    #[test]
+    fn reject_unknown_root_key() {
+        let bytes = b"{\"version\":1,\"records\":[],\"zomg\":42}";
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_unknown_record_key() {
+        let bytes = b"{\"version\":1,\"records\":[{\"kind\":\"login\",\"title\":\"x\",\"frobnicate\":\"y\"}]}";
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_unsupported_version() {
+        let bytes = b"{\"version\":999,\"records\":[]}";
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::UnsupportedVersion(999))));
+    }
+
+    #[test]
+    fn reject_trailing_bytes() {
+        let r = login("github", "alice", "hunter2");
+        let mut bytes = export_to_bundle(&[r]).unwrap();
+        bytes.extend_from_slice(b"\n//garbage");
+        let res = import_from_bundle(&bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_unknown_kind_value() {
+        let bytes = b"{\"version\":1,\"records\":[{\"kind\":\"frobnicate\",\"title\":\"x\"}]}";
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_oversize_bundle_bytes() {
+        // Build a payload that exceeds MAX_BUNDLE_LEN by being
+        // a giant string field (cheap to construct via the
+        // import path).
+        let big = vec![0u8; MAX_BUNDLE_LEN + 1];
+        let res = import_from_bundle(&big);
+        assert!(matches!(res, Err(ImportError::TooLarge(_))));
+    }
+
+    #[test]
+    fn reject_unescaped_control_char() {
+        let bytes = b"{\"version\":1,\"records\":[{\"kind\":\"login\",\"title\":\"a\nb\"}]}";
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn round_trip_preserves_escaped_characters() {
+        let r = PortableRecord {
+            kind: PortableRecordKind::Login,
+            title: "weird \"quoted\" \n title".into(),
+            username: Some("alice\\bob".into()),
+            password: Some(Zeroizing::new("p\"a's".into())),
+            url: None,
+            notes: Some("line1\nline2".into()),
+            totp_seed: None,
+            tags: vec![],
+            custom_fields: BTreeMap::new(),
+        };
+        let bytes = export_to_bundle(&[r.clone()]).unwrap();
+        let bundle = import_from_bundle(&bytes).unwrap();
+        assert_eq!(bundle.records[0], r);
+    }
+
+    #[test]
+    fn round_trip_preserves_u2028_u2029() {
+        let r = PortableRecord {
+            kind: PortableRecordKind::Login,
+            title: "a\u{2028}b\u{2029}c".into(),
+            username: None,
+            password: None,
+            url: None,
+            notes: None,
+            totp_seed: None,
+            tags: vec![],
+            custom_fields: BTreeMap::new(),
+        };
+        let bytes = export_to_bundle(&[r.clone()]).unwrap();
+        // U+2028 / U+2029 escaped on the wire (so JS embedding
+        // is safe) but read back to original chars.
+        let s = std::str::from_utf8(&bytes).unwrap();
+        assert!(s.contains("\\u2028"));
+        let bundle = import_from_bundle(&bytes).unwrap();
+        assert_eq!(bundle.records[0], r);
+    }
+
+    // --- Redaction ---
+
+    #[test]
+    fn record_debug_redacts_password_and_totp() {
+        let mut fields = BTreeMap::new();
+        fields.insert("api_key".to_string(), Zeroizing::new("super-secret-key".to_string()));
+        let r = PortableRecord {
+            kind: PortableRecordKind::Login,
+            title: "github".into(),
+            username: Some("alice".into()),
+            password: Some(Zeroizing::new("hunter2".into())),
+            url: None,
+            notes: None,
+            totp_seed: Some(Zeroizing::new("JBSWY3DPEHPK3PXP".into())),
+            tags: vec![],
+            custom_fields: fields,
+        };
+        let s = format!("{:?}", r);
+        assert!(!s.contains("hunter2"));
+        assert!(!s.contains("JBSWY3DPEHPK3PXP"));
+        assert!(!s.contains("super-secret-key"));
+        assert!(s.contains("redacted"));
+    }
+
+    // --- Send + Sync ---
+
+    #[test]
+    fn importer_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PassthroughImporter>();
+        assert_send_sync::<Box<dyn Importer>>();
+    }
+
+    // --- UTF-8 / strictness ---
+
+    #[test]
+    fn round_trip_preserves_unicode_passwords() {
+        // Regression test for the silent UTF-8 corruption bug:
+        // a previous byte-by-byte `b as char` push would split
+        // `é` (UTF-8 0xC3 0xA9) into two Latin-1 chars.
+        let r = PortableRecord {
+            kind: PortableRecordKind::Login,
+            title: "Bücher / 日本語 / Café 🦀".into(),
+            username: Some("alice@éxample.com".into()),
+            password: Some(Zeroizing::new("naïve-Päßwôrd-日本-🔑".into())),
+            url: None,
+            notes: Some("ñoño / αβγ".into()),
+            totp_seed: None,
+            tags: vec!["密码".into(), "café".into()],
+            custom_fields: BTreeMap::new(),
+        };
+        let bytes = export_to_bundle(&[r.clone()]).unwrap();
+        let bundle = import_from_bundle(&bytes).unwrap();
+        assert_eq!(bundle.records[0], r);
+    }
+
+    #[test]
+    fn reject_missing_comma_between_record_fields() {
+        let bytes = br#"{"version":1,"records":[{"kind":"login" "title":"x"}]}"#;
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_missing_comma_between_bundle_keys() {
+        let bytes = br#"{"version":1 "records":[]}"#;
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_trailing_comma_in_record() {
+        let bytes = br#"{"version":1,"records":[{"kind":"login","title":"x",}]}"#;
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_trailing_comma_in_bundle() {
+        let bytes = br#"{"version":1,"records":[],}"#;
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_leading_zero_in_version() {
+        let bytes = br#"{"version":01,"records":[]}"#;
+        let res = import_from_bundle(bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn reject_invalid_utf8_in_string() {
+        // Build raw bytes with a malformed UTF-8 sequence
+        // (continuation byte without a leading byte).
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(br#"{"version":1,"records":[{"kind":"login","title":""#);
+        bytes.push(0xC3); // start of 2-byte UTF-8
+        // missing continuation byte; instead close the string
+        bytes.extend_from_slice(br#""}]}"#);
+        let res = import_from_bundle(&bytes);
+        assert!(matches!(res, Err(ImportError::Decode(_))));
+    }
+
+    // --- Empty bundle ---
+
+    #[test]
+    fn empty_bundle_round_trips() {
+        let bytes = export_to_bundle(&[]).unwrap();
+        let bundle = import_from_bundle(&bytes).unwrap();
+        assert!(bundle.records.is_empty());
+    }
+}

--- a/code/specs/VLT15-vault-import-export.md
+++ b/code/specs/VLT15-vault-import-export.md
@@ -1,0 +1,169 @@
+# VLT15 — Vault Import / Export
+
+## Overview
+
+The import/export tier of the Vault stack. Defines:
+
+- a versioned **portable JSON bundle** — the canonical
+  interchange shape between vaults and external tools,
+- the [`Importer`] trait every adapter implements,
+- a [`PassthroughImporter`] reference that reads the bundle
+  itself,
+- `export_to_bundle` / `import_from_bundle` — hand-rolled JSON
+  writer/reader that produces / consumes the canonical bytes.
+
+Format adapters land as **sibling crates** (per VLT00 §VLT15):
+
+- `vault-import-1password` — `.1pux`
+- `vault-import-bitwarden` — Bitwarden JSON
+- `vault-import-keepass` — KeePassXC `.kdbx`
+- `vault-import-lastpass` — LastPass CSV
+- `vault-import-chrome` / `vault-import-firefox` — browser CSV
+- `vault-import-age` / `vault-import-gpg` / `vault-import-sops`
+
+Each is dependency-light so a vault using only Bitwarden
+import doesn't pull in the KDBX parser.
+
+Implementation lives at `code/packages/rust/vault-import-export/`.
+
+## Why this layer is "ceremony"
+
+Import/export is the one place in the Vault stack where
+**plaintext crosses the trust boundary**:
+
+- On *import*, plaintext arrives from the user (a file they
+  exported from a competing product). The crate sees it
+  before VLT01 sealing happens; the host is responsible for
+  sealing immediately and scrubbing the intermediate.
+- On *export*, plaintext leaves the vault. VLT01-sealed bytes
+  are decrypted just to be repackaged into the portable
+  format. Same scrub rule applies.
+
+All import/export operations are documented as
+**explicit user-driven ceremonies**: the host UI prompts,
+warns, and times out. This crate gives you the byte
+transformation; it does not decide whether to do it.
+
+## Wire format (versioned)
+
+```json
+{
+  "version": 1,
+  "records": [
+    {
+      "kind": "login",
+      "title": "GitHub",
+      "username": "alice",
+      "password": "hunter2",
+      "url": "https://github.com",
+      "notes": null,
+      "totp_seed": null,
+      "tags": ["work"],
+      "custom_fields": {}
+    },
+    {
+      "kind": {"custom": "workflow"},
+      "title": "deploy steps",
+      "notes": "ssh ; deploy ; bless"
+    }
+  ]
+}
+```
+
+Known `kind` values: `login`, `secure_note`, `card`,
+`ssh_key`, `totp`. Unknown wire kinds become
+`{"custom": "<label>"}`.
+
+Optional fields are simply omitted on the wire (and `None` in
+the Rust type). The reader rejects unknown root keys,
+unknown record keys, raw control chars in strings, and
+trailing input.
+
+## Public API
+
+```rust
+pub struct PortableBundle { pub version: u32, pub records: Vec<PortableRecord> }
+pub struct PortableRecord {
+    pub kind: PortableRecordKind,
+    pub title: String,
+    pub username: Option<String>,
+    pub password: Option<Zeroizing<String>>,    // sensitive
+    pub url: Option<String>,
+    pub notes: Option<String>,
+    pub totp_seed: Option<Zeroizing<String>>,   // sensitive
+    pub tags: Vec<String>,
+    pub custom_fields: BTreeMap<String, Zeroizing<String>>,  // sensitive values
+}
+
+pub enum PortableRecordKind {                   // #[non_exhaustive]
+    Login, SecureNote, Card, SshKey, Totp, Custom(String),
+}
+
+pub trait Importer: Send + Sync {
+    fn name(&self) -> &str;
+    fn import(&self, input: &[u8]) -> Result<Vec<PortableRecord>, ImportError>;
+}
+
+pub struct PassthroughImporter;
+
+pub fn export_to_bundle(records: &[PortableRecord]) -> Result<Vec<u8>, ImportError>;
+pub fn import_from_bundle(bytes: &[u8]) -> Result<PortableBundle, ImportError>;
+
+pub enum ImportError {
+    Decode(&'static str),
+    TooLarge(&'static str),
+    InvalidParameter(&'static str),
+    UnsupportedVersion(u32),
+    Adapter(String),
+}
+```
+
+## Bounds
+
+| Constant                          | Value         |
+|-----------------------------------|---------------|
+| `MAX_RECORDS`                     | 100,000       |
+| `MAX_FIELD_LEN`                   | 64 KiB        |
+| `MAX_BUNDLE_LEN`                  | 256 MiB       |
+| `MAX_TAGS_PER_RECORD`             | 64            |
+| `MAX_CUSTOM_FIELDS_PER_RECORD`    | 64            |
+| `BUNDLE_VERSION`                  | 1             |
+
+## Threat model & test coverage
+
+| Threat                                                | Defence                                              | Test                                                |
+|------------------------------------------------------|-------------------------------------------------------|-----------------------------------------------------|
+| Untrusted bytes inflate any single number             | bounded reader at every step                          | `reject_oversize_bundle_bytes`, `reject_oversize_field`, `reject_too_many_tags`, `reject_too_many_custom_fields`, `reject_too_many_records` |
+| Peer producer adds new top-level key                  | strict reader: unknown root key → `Decode`            | `reject_unknown_root_key`                           |
+| Peer producer adds new record key                     | strict reader: unknown record key → `Decode`          | `reject_unknown_record_key`                         |
+| Bundle version mismatch                               | `UnsupportedVersion(v)`                                | `reject_unsupported_version`                        |
+| Trailing-bytes injection                              | reader requires EOF                                    | `reject_trailing_bytes`                             |
+| Raw control chars in string fields                    | reader requires JSON-escape                            | `reject_unescaped_control_char`                     |
+| `dbg!(record)` leaks password / TOTP / custom values  | hand-rolled redacted `Debug`                           | `record_debug_redacts_password_and_totp`            |
+| Plaintext residue after drop                          | `Zeroizing<String>` on every sensitive field           | structural — `Drop` runs scrub                      |
+| JSON output broken in `<script>` (U+2028 / U+2029)    | `json_escape` emits ` ` / ` `                | `round_trip_preserves_u2028_u2029`                  |
+| Determinism for reproducible exports                  | `BTreeMap` sorted keys + fixed top-level key order     | `deterministic_export`                              |
+| **Multi-byte UTF-8 silently corrupted on import**       | accumulate bytes through the loop; `String::from_utf8` at close | `round_trip_preserves_unicode_passwords`           |
+| **Permissive comma handling (parser differential)**    | strict separator: comma between fields, no trailing comma | `reject_missing_comma_between_record_fields`, `reject_missing_comma_between_bundle_keys`, `reject_trailing_comma_in_record`, `reject_trailing_comma_in_bundle` |
+| Leading zeros on number literals                       | RFC 8259 — rejected by `read_u32`                       | `reject_leading_zero_in_version`                    |
+| Malformed UTF-8 in input string                        | `String::from_utf8` validation at close                 | `reject_invalid_utf8_in_string`                     |
+
+## Out of scope (future PRs)
+
+- Format adapters (sibling crates per external format).
+- Recipient list at export — VLT04 wraps DEKs.
+- Streaming reader for very large bundles.
+- Schema validation — VLT02 runs on the host's import path
+  after `import_from_bundle`.
+- Compression — host's responsibility.
+
+## Citations
+
+- VLT00-vault-roadmap.md — VLT15 placement.
+- 1Password 1PUX, Bitwarden JSON, KeePassXC KDBX, LastPass
+  CSV — external formats covered by sibling adapter crates.
+- VLT01-vault-sealed-store — the layer the host runs each
+  imported record through before persistence.
+- VLT02-vault-records — typed-record schema validation runs
+  here.
+- VLT04-vault-recipients — wraps DEKs at export time.


### PR DESCRIPTION
## Summary

Adds `coding_adventures_vault_import_export` — the **final layer** of the VLT00 16-layer queue. Defines the versioned `PortableBundle`, `PortableRecord` (with `Zeroizing<String>` on every sensitive field), the `Importer` trait, a `PassthroughImporter` reference, and a hand-rolled strict JSON codec (no serde dep).

Format adapters (`vault-import-bitwarden`, `vault-import-keepass`, `vault-import-lastpass`, etc) ship as sibling crates per the roadmap.

**With this PR the original 16-layer Vault stack is shipped:** SSS01, CBR01, STR01, VLT00..VLT15, plus VLT-CH.

## Pre-merge security review

Three findings fixed inline:

- **HIGH** — `read_string` silently corrupted multi-byte UTF-8: `é` (`0xC3 0xA9`) was being read as two Latin-1 chars (`U+00C3 U+00A9`) via `b as char`. For a password manager importing a Bitwarden export with non-ASCII passwords this is silent password corruption → user locked out. Fix: accumulate raw bytes, validate via `String::from_utf8` at the closing quote, reject malformed UTF-8.
- **LOW** — Permissive comma handling (missing/trailing commas silently accepted at bundle + record levels). "JSON parsing differences" attack surface. Tightened to strict separator semantics.
- **LOW** — Leading zeros in `read_u32` (`0123` → 123). RFC 8259 forbids; rejected.

## Test plan

- [x] `cargo test -p coding_adventures_vault_import_export --lib` — 29 tests, all passing
- [x] `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`
- [x] Spec at `code/specs/VLT15-vault-import-export.md` (new)
- [x] CHANGELOG documents both initial functionality and security hardening
- [x] Seven new tests guard the security fixes directly (Unicode round-trip, missing/trailing commas at both levels, leading zero version, invalid UTF-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)