### PR TITLE
feat(intel8051-simulator): Layer 07p — Intel 8051 (1980) behavioral simulator

### DIFF
--- a/code/packages/python/intel8051-simulator/CHANGELOG.md
+++ b/code/packages/python/intel8051-simulator/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — intel8051-simulator
+
+## 0.1.0 (2026-05-04)
+
+Initial release — Layer 07p.
+
+### Added
+- `I8051State` frozen dataclass with full Harvard memory model:
+  256-byte internal RAM (includes SFRs at 0x80–0xFF), 64 KB code memory,
+  64 KB external data memory
+- PSW flag properties: `.cy`, `.ac`, `.ov`, `.parity`, `.bank`
+- `I8051Simulator` implementing `Simulator[I8051State]` (SIM00 protocol)
+- All 8051 addressing modes: register, direct, register-indirect (@Ri),
+  immediate (#data), indexed (MOVC @A+DPTR, @A+PC), external (MOVX)
+- Four register banks (bank 0–3 via PSW.RS1:RS0)
+- Bit-addressable memory area (RAM 0x20–0x2F) and SFR bit addressing
+- Double-operand data transfer: MOV in all 16 source/destination combinations,
+  MOVX @DPTR/@Ri, MOVC @A+DPTR/@A+PC, PUSH/POP, XCH, XCHD
+- Arithmetic: ADD, ADDC, SUBB (with borrow), INC/DEC (no flags), MUL AB,
+  DIV AB, DA A (BCD decimal adjust)
+- Logic: ANL, ORL, XRL (all forms), CLR A, CPL A, RL/RR/RLC/RRC/SWAP A
+- Bit manipulation: CLR/SETB/CPL C, CLR/SETB/CPL bit, ANL/ORL C,bit,
+  ANL/ORL C,/bit, MOV C,bit, MOV bit,C
+- Branches: JZ, JNZ, JC, JNC, JB, JNB, JBC, CJNE (4 forms), DJNZ (2 forms)
+- Jumps: LJMP, AJMP (11-bit page-relative), SJMP, JMP @A+DPTR
+- Subroutines: LCALL, ACALL, RET, RETI, NOP
+- HALT sentinel: opcode 0xA5 (undefined on real 8051)
+- Parity (PSW.P) automatically recomputed after every ACC change
+- Spec: `code/specs/07p-intel-8051-simulator.md`

--- a/code/packages/python/intel8051-simulator/README.md
+++ b/code/packages/python/intel8051-simulator/README.md
@@ -1,0 +1,93 @@
+# intel8051-simulator — Layer 07p
+
+A Python behavioral simulator for the **Intel 8051** (MCS-51, 1980)
+microcontroller, part of the `coding-adventures` simulator series.
+
+## What is the 8051?
+
+The Intel 8051 is the most-manufactured CPU architecture in history, with
+over **20 billion units produced**.  Introduced in 1980 as Intel's first
+single-chip microcontroller, it integrated CPU + RAM + ROM + I/O ports +
+timers + serial port on a single die — defining the microcontroller as a
+product category.
+
+The 8051 uses a **Harvard architecture**: code memory and data memory are
+separate address spaces accessed via separate buses.  This allows instruction
+fetch and data access to occur simultaneously.
+
+## Features implemented
+
+- Full Harvard memory model: 64 KB code, 256-byte internal RAM (including
+  SFRs at 0x80–0xFF), 64 KB external data memory
+- All 8051 addressing modes: register, direct, register-indirect, immediate,
+  indexed (MOVC), external (MOVX)
+- Complete instruction set: data transfer, arithmetic, logic, bit manipulation,
+  branches (JZ/JNZ/JC/JNC/JB/JNB/JBC/CJNE/DJNZ), unconditional jumps
+  (LJMP/AJMP/SJMP/JMP @A+DPTR), subroutines (LCALL/ACALL/RET/RETI)
+- Four register banks (selected via PSW.RS1:RS0)
+- Bit-addressable RAM area (0x20–0x2F) and bit-addressable SFRs
+- All PSW flags: CY, AC, OV, P (parity auto-recomputed after every ACC change)
+- SIM00 protocol: `Simulator[I8051State]`
+
+## Usage
+
+```python
+from intel8051_simulator import I8051Simulator
+
+sim = I8051Simulator()
+
+# Encode a small program: sum 1+2+3 = 6
+program = bytes([
+    0x78, 0x03,    # MOV R0, #3
+    0x28,          # ADD A, R0  (loop top)
+    0xD8, 0xFD,    # DJNZ R0, -3
+    0xA5,          # HALT
+])
+
+result = sim.execute(program)
+print(result.ok)           # True
+print(sim._iram[0xE0])    # 6  (accumulator = 1+2+3)
+```
+
+## Architecture in brief
+
+| Feature          | Value                                      |
+|------------------|--------------------------------------------|
+| Architecture     | Harvard (separate code/data buses)          |
+| Data width       | 8-bit                                      |
+| Address width    | 16-bit (code + xdata), 8-bit (iram)        |
+| Internal RAM     | 256 bytes (128 general + 128 SFR)          |
+| External data    | 64 KB (XDATA via MOVX)                     |
+| Code memory      | 64 KB                                      |
+| Register banks   | 4 (R0–R7 each, selected by PSW)            |
+| Flags            | CY, AC, F0, OV, P (in PSW SFR)            |
+| Bit-addressable  | RAM 0x20–0x2F, bit-addressable SFRs        |
+| HALT sentinel    | Opcode 0xA5 (undefined on real hardware)   |
+
+## Package layout
+
+```
+src/intel8051_simulator/
+├── __init__.py      # exports: I8051Simulator, I8051State
+├── state.py         # I8051State frozen dataclass + SFR constants
+├── flags.py         # add8_flags, sub8_flags, da_flags arithmetic helpers
+└── simulator.py     # I8051Simulator implementation
+tests/
+├── test_protocol.py    # SIM00 compliance
+├── test_instructions.py # per-instruction tests
+├── test_programs.py    # end-to-end programs
+└── test_coverage.py    # edge cases and flag arithmetic
+```
+
+## How it fits in the stack
+
+This is Layer 07p in the `coding-adventures` simulator series:
+
+```
+07d  Intel 4004 (1971)   — first commercial microprocessor
+07i  Intel 8080 (1974)   — 8-bit general-purpose CPU
+07m  Intel 8086 (1978)   — 16-bit, ancestor of x86
+07p  Intel 8051 (1980)   — 8-bit microcontroller (this package)
+```
+
+See `code/specs/07p-intel-8051-simulator.md` for the full specification.

--- a/code/packages/python/intel8051-simulator/pyproject.toml
+++ b/code/packages/python/intel8051-simulator/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-intel8051-simulator"
+version = "0.1.0"
+description = "Intel 8051 (MCS-51, 1980) behavioral simulator — Layer 07p"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = [
+    "intel", "8051", "mcs-51", "microcontroller", "simulator",
+    "harvard-architecture", "embedded", "education", "computer-science",
+]
+dependencies = ["coding-adventures-simulator-protocol"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/intel8051_simulator"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=intel8051_simulator --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/intel8051_simulator"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "SIM"]
+ignore = ["E501", "E701", "E702"]

--- a/code/packages/python/intel8051-simulator/src/intel8051_simulator/__init__.py
+++ b/code/packages/python/intel8051-simulator/src/intel8051_simulator/__init__.py
@@ -1,0 +1,11 @@
+"""Intel 8051 (MCS-51, 1980) behavioral simulator — Layer 07p.
+
+Public exports:
+    I8051Simulator  — the simulator class (implements Simulator[I8051State])
+    I8051State      — frozen CPU state snapshot dataclass
+"""
+
+from .simulator import I8051Simulator
+from .state import I8051State
+
+__all__ = ["I8051Simulator", "I8051State"]

--- a/code/packages/python/intel8051-simulator/src/intel8051_simulator/flags.py
+++ b/code/packages/python/intel8051-simulator/src/intel8051_simulator/flags.py
@@ -1,0 +1,138 @@
+"""Arithmetic flag helpers for the Intel 8051.
+
+The 8051 flag model differs from the PDP-11 in one important way: the
+carry flag is also the borrow flag for subtraction (SUBB).  When the
+hardware performs A - B - CY, if a borrow is generated the carry flag is
+SET (not cleared).  This is the opposite of "carry = no borrow" convention
+used by x86.  In other words:
+
+    CY = 1  ↔  a borrow occurred (unsigned underflow)
+    CY = 0  ↔  no borrow (result is non-negative)
+
+Because of this, SUBB must be tested for CY to detect "A < B + old_CY".
+
+Flag bits in the returned tuple are always plain Python booleans (or ints 0/1).
+All helpers work on 8-bit values only.
+
+Truth table for ADD8 carry / overflow:
+    Carry:    result > 0xFF  (treat inputs as unsigned 8-bit)
+    AuxCarry: (a & 0x0F) + (b & 0x0F) + cin > 0x0F
+    Overflow: (both inputs positive, result negative)
+              OR (both negative, result positive)
+              where "sign" = bit 7 of the 8-bit value
+"""
+
+from __future__ import annotations
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _parity(val: int) -> int:
+    """Return 1 if val (8-bit) has an odd number of 1 bits (odd parity → P=1).
+
+    The 8051 PSW.P is the EVEN-parity bit: P=1 when ACC has an odd number of
+    1s, making the 9-bit value {P, ACC} have even parity.
+    """
+    v = val & 0xFF
+    v ^= v >> 4
+    v ^= v >> 2
+    v ^= v >> 1
+    return v & 1
+
+
+# ── 8-bit addition ─────────────────────────────────────────────────────────────
+
+def add8_flags(a: int, b: int, cin: int = 0) -> tuple[int, int, int, int, int]:
+    """Compute A + B + cin and return (result8, CY, AC, OV, P).
+
+    Args:
+        a:   8-bit addend (0–255)
+        b:   8-bit addend (0–255)
+        cin: carry-in (0 or 1), used by ADDC
+
+    Returns:
+        (result, cy, ac, ov, p)
+        result — 8-bit sum (bits 7:0 of the full sum)
+        cy     — 1 if unsigned overflow (carry out of bit 7)
+        ac     — 1 if carry from bit 3 to bit 4
+        ov     — 1 if signed overflow (wrong-sign result)
+        p      — even-parity of result (1 if odd popcount)
+    """
+    a8, b8 = a & 0xFF, b & 0xFF
+    full  = a8 + b8 + cin
+    result = full & 0xFF
+    cy = 1 if full > 0xFF else 0
+    ac = 1 if (a8 & 0x0F) + (b8 & 0x0F) + cin > 0x0F else 0
+    # Signed overflow: both operands have same sign but result has different sign
+    sa, sb, sr = a8 >> 7, b8 >> 7, result >> 7
+    ov = 1 if (sa == sb) and (sr != sa) else 0
+    p  = _parity(result)
+    return result, cy, ac, ov, p
+
+
+# ── 8-bit subtraction ──────────────────────────────────────────────────────────
+
+def sub8_flags(a: int, b: int, borrow: int = 0) -> tuple[int, int, int, int, int]:
+    """Compute A - B - borrow (SUBB) and return (result8, CY, AC, OV, P).
+
+    CY (borrow out) = 1 when unsigned underflow occurs, i.e. when
+    a < (b + borrow) treating all as 8-bit unsigned.
+
+    AC (auxiliary borrow) = 1 when a borrow propagated from bit 3 to bit 4,
+    i.e. (a & 0x0F) < (b & 0x0F) + borrow.
+
+    OV = 1 when signed overflow: subtracting a negative from a positive gives
+    a negative result, or subtracting a positive from a negative gives a
+    positive result.
+
+    Args:
+        a:      8-bit minuend
+        b:      8-bit subtrahend
+        borrow: old carry (CY) fed into SUBB
+    """
+    a8, b8 = a & 0xFF, b & 0xFF
+    full   = a8 - b8 - borrow
+    result = full & 0xFF
+    cy = 1 if full < 0 else 0
+    ac = 1 if (a8 & 0x0F) < (b8 & 0x0F) + borrow else 0
+    # Signed overflow: subtracting a negative (b with sign=1) from positive a
+    # gives negative result, or positive b from negative a gives positive result
+    sa, sb, sr = a8 >> 7, b8 >> 7, result >> 7
+    ov = 1 if (sa != sb) and (sr == sb) else 0
+    p  = _parity(result)
+    return result, cy, ac, ov, p
+
+
+# ── Decimal adjust ─────────────────────────────────────────────────────────────
+
+def da_flags(a: int, cy_in: int, ac_in: int) -> tuple[int, int, int]:
+    """Decimal-adjust A after BCD ADD/ADDC.  Returns (result, CY, P).
+
+    The DA A instruction corrects the binary sum of two BCD digits into
+    a valid BCD result.  The algorithm (from the 8051 datasheet):
+
+    Step 1: if (A[3:0] > 9) OR AC == 1: add 6 to A
+    Step 2: if (A[7:4] > 9) OR CY == 1: add 0x60 to A; set CY
+
+    Note: the adjustment is done on a potentially intermediate value where
+    step 1 may have already modified bits 7:4.
+
+    Args:
+        a:     8-bit accumulator value after ADD/ADDC
+        cy_in: carry flag coming into DA A
+        ac_in: auxiliary carry coming into DA A
+
+    Returns:
+        (result, new_cy, new_p)
+    """
+    a8 = a & 0xFF
+    new_cy = cy_in
+
+    if (a8 & 0x0F) > 9 or ac_in:
+        a8 = (a8 + 0x06) & 0xFF
+
+    if (a8 >> 4) > 9 or cy_in:
+        a8 = (a8 + 0x60) & 0xFF
+        new_cy = 1
+
+    result = a8 & 0xFF
+    return result, new_cy, _parity(result)

--- a/code/packages/python/intel8051-simulator/src/intel8051_simulator/simulator.py
+++ b/code/packages/python/intel8051-simulator/src/intel8051_simulator/simulator.py
@@ -1,0 +1,1217 @@
+"""Intel 8051 (MCS-51) behavioral simulator — Layer 07p.
+
+The 8051 is a Harvard-architecture microcontroller introduced by Intel in 1980.
+It is the most-manufactured CPU architecture in history, with over 20 billion
+units produced.  Its key innovations:
+  - Single-chip integration of CPU + RAM + ROM + I/O + timers + serial port
+  - Harvard architecture: separate code and data buses for simultaneous fetch
+  - Bit-addressable memory area: individual bits in RAM can be set/cleared
+  - Four register banks switchable via the PSW, enabling fast interrupt context
+
+This simulator implements the SIM00 protocol: Simulator[I8051State].
+
+=============================================================================
+Architecture recap (see spec for full details)
+=============================================================================
+
+Memory spaces
+─────────────
+  _code   : 64 KB Harvard code memory (read-only by CPU instructions)
+  _iram   : 256 bytes internal RAM, split as:
+                0x00–0x7F  general RAM (register banks, bit area, scratch)
+                0x80–0xFF  SFRs (Special Function Registers)
+  _xdata  : 64 KB external data memory (accessed via MOVX)
+
+Registers (all stored in _iram as SFRs or implicitly in _pc)
+─────────────────────────────────────────────────────────────
+  PC       16-bit, stored as self._pc (NOT in iram)
+  ACC      iram[0xE0]
+  B        iram[0xF0]
+  SP       iram[0x81]     reset value: 0x07
+  DPH:DPL  iram[0x83:0x82]
+  PSW      iram[0xD0]     bits: CY AC F0 RS1 RS0 OV - P
+
+Register bank selection (PSW bits 4:3)
+  Bank 0 → iram[0x00–0x07]
+  Bank 1 → iram[0x08–0x0F]
+  Bank 2 → iram[0x10–0x17]
+  Bank 3 → iram[0x18–0x1F]
+
+=============================================================================
+Encoding notes — how to read the instruction tables below
+=============================================================================
+
+The 8051 opcode byte fully encodes the instruction form.  Many instructions
+come in "families" that share 5 high bits and use the 3 low bits to select
+the operand:
+
+    0x28 + n  → ADD A, Rn      (n = 0–7)
+    0xE8 + n  → MOV A, Rn
+    0xF8 + n  → MOV Rn, A
+    etc.
+
+Two-register indirect instructions use a 1-bit field for the pointer (Ri
+can only be R0 or R1):
+
+    0xE6 + i  → MOV A, @Ri    (i = 0 or 1)
+    0xE2 + i  → MOVX A, @Ri
+
+Branch instructions carry a signed 8-bit offset byte; the target is
+PC_after_fetch + rel8  (where PC_after_fetch = PC of instruction + instr_len).
+
+=============================================================================
+HALT convention
+=============================================================================
+
+Opcode 0xA5 is "undefined" on real 8051 hardware.  This simulator uses it
+as a HALT sentinel (as specified in spec 07p).  Executing 0xA5 sets _halted=True
+and returns a StepTrace with mnemonic="HALT".
+"""
+
+from __future__ import annotations
+
+from simulator_protocol import ExecutionResult, Simulator, StepTrace
+
+from .flags import add8_flags, da_flags, sub8_flags
+from .state import (
+    CODE_SIZE,
+    HALT_OPCODE,
+    IRAM_SIZE,
+    PSW_AC,
+    PSW_CY,
+    PSW_OV,
+    PSW_P,
+    SFR_ACC,
+    SFR_B,
+    SFR_DPH,
+    SFR_DPL,
+    SFR_P0,
+    SFR_P1,
+    SFR_P2,
+    SFR_P3,
+    SFR_PSW,
+    SFR_SP,
+    XDATA_SIZE,
+    I8051State,
+)
+
+# ── Type alias ─────────────────────────────────────────────────────────────────
+
+_Mem = bytearray
+
+
+class I8051Simulator(Simulator[I8051State]):
+    """Behavioral simulator for the Intel 8051 microcontroller.
+
+    Public API (SIM00 protocol):
+        reset()            — return to power-on state
+        load(program)      — reset and copy bytes to code memory at 0x0000
+        step()             — execute one instruction, return StepTrace
+        execute(program)   — run until HALT or max_steps, return ExecutionResult
+        get_state()        — return frozen I8051State snapshot
+    """
+
+    def __init__(self) -> None:
+        self._code:  _Mem = bytearray(CODE_SIZE)
+        self._iram:  _Mem = bytearray(IRAM_SIZE)
+        self._xdata: _Mem = bytearray(XDATA_SIZE)
+        self._pc:    int  = 0
+        self._halted: bool = False
+        self.reset()
+
+    # ── Protocol: reset ───────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Return the CPU to power-on state.
+
+        Hardware reset state (8051 datasheet):
+          PC = 0x0000
+          SP = 0x07
+          P0–P3 = 0xFF  (all port latches high)
+          All other SFRs = 0x00
+          IRAM content: undefined (zeroed in simulator)
+          Code/xdata memory: preserved (only changed by load())
+        """
+        self._iram[:] = bytearray(IRAM_SIZE)
+        self._pc      = 0x0000
+        self._halted  = False
+        # SP = 0x07 at reset
+        self._iram[SFR_SP] = 0x07
+        # Port latches = 0xFF at reset
+        for port_sfr in (SFR_P0, SFR_P1, SFR_P2, SFR_P3):
+            self._iram[port_sfr] = 0xFF
+
+    # ── Protocol: load ────────────────────────────────────────────────────────
+
+    def load(self, program: bytes) -> None:
+        """Reset and load program bytes into code memory starting at 0x0000.
+
+        Args:
+            program: raw machine code bytes
+
+        Raises:
+            ValueError: if len(program) > 65536
+        """
+        if len(program) > CODE_SIZE:
+            msg = f"Program too large: {len(program)} bytes > {CODE_SIZE}"
+            raise ValueError(msg)
+        self.reset()
+        self._code[:len(program)] = program
+
+    # ── Protocol: get_state ───────────────────────────────────────────────────
+
+    def get_state(self) -> I8051State:
+        """Return a frozen snapshot of the current CPU state."""
+        return I8051State(
+            pc     = self._pc,
+            iram   = tuple(self._iram),
+            xdata  = tuple(self._xdata),
+            code   = tuple(self._code),
+            halted = self._halted,
+        )
+
+    # ── Protocol: step ────────────────────────────────────────────────────────
+
+    def step(self) -> StepTrace:
+        """Execute one instruction and return a StepTrace.
+
+        If the CPU is halted, returns a no-op trace without advancing PC.
+        """
+        pc_before = self._pc
+        if self._halted:
+            return StepTrace(
+                pc_before   = pc_before,
+                pc_after    = pc_before,
+                mnemonic    = "HALT",
+                description = "HALT (already halted)",
+            )
+        mnemonic = self._execute_one()
+        return StepTrace(
+            pc_before   = pc_before,
+            pc_after    = self._pc,
+            mnemonic    = mnemonic,
+            description = f"{mnemonic} @ 0x{pc_before:04X}",
+        )
+
+    # ── Protocol: execute ─────────────────────────────────────────────────────
+
+    def execute(self, program: bytes, max_steps: int = 100_000) -> ExecutionResult:
+        """Load and run program until HALT or max_steps exceeded.
+
+        Args:
+            program:   raw machine code
+            max_steps: guard against infinite loops
+
+        Returns:
+            ExecutionResult with halted, steps, traces, final_state, error
+        """
+        self.load(program)
+        traces: list[StepTrace] = []
+        error: str | None = None
+        steps = 0
+        while not self._halted and steps < max_steps:
+            try:
+                trace = self.step()
+            except Exception as exc:  # noqa: BLE001
+                error = str(exc)
+                break
+            traces.append(trace)
+            steps += 1
+        if not self._halted and error is None:
+            error = f"max_steps ({max_steps}) exceeded"
+        return ExecutionResult(
+            halted      = self._halted,
+            steps       = steps,
+            traces      = traces,
+            final_state = self.get_state(),
+            error       = error,
+        )
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _fetch8(self) -> int:
+        """Fetch one byte from code memory at PC and advance PC."""
+        b = self._code[self._pc & 0xFFFF]
+        self._pc = (self._pc + 1) & 0xFFFF
+        return b
+
+    def _fetch16(self) -> int:
+        """Fetch two bytes (big-endian) from code memory and advance PC by 2."""
+        hi = self._fetch8()
+        lo = self._fetch8()
+        return (hi << 8) | lo
+
+    def _rn_addr(self, n: int) -> int:
+        """Return the IRAM address of Rn in the current register bank."""
+        bank = (self._iram[SFR_PSW] >> 3) & 0x3
+        return bank * 8 + (n & 0x7)
+
+    def _rn(self, n: int) -> int:
+        """Read register Rn from the current register bank."""
+        return self._iram[self._rn_addr(n)]
+
+    def _set_rn(self, n: int, val: int) -> None:
+        """Write register Rn in the current register bank."""
+        self._iram[self._rn_addr(n)] = val & 0xFF
+
+    def _dptr(self) -> int:
+        """Read 16-bit DPTR = DPH:DPL."""
+        return (self._iram[SFR_DPH] << 8) | self._iram[SFR_DPL]
+
+    def _set_dptr(self, val: int) -> None:
+        """Write 16-bit DPTR."""
+        self._iram[SFR_DPH] = (val >> 8) & 0xFF
+        self._iram[SFR_DPL] = val & 0xFF
+
+    def _acc(self) -> int:
+        """Read ACC."""
+        return self._iram[SFR_ACC]
+
+    def _set_acc(self, val: int) -> None:
+        """Write ACC and update parity bit in PSW."""
+        self._iram[SFR_ACC] = val & 0xFF
+        self._update_parity()
+
+    def _update_parity(self) -> None:
+        """Recompute PSW.P from ACC (even parity: P=1 if odd popcount)."""
+        a = self._iram[SFR_ACC]
+        a ^= a >> 4; a ^= a >> 2; a ^= a >> 1
+        if a & 1:
+            self._iram[SFR_PSW] |= PSW_P
+        else:
+            self._iram[SFR_PSW] &= ~PSW_P & 0xFF
+
+    def _cy(self) -> int:
+        """Return carry flag (0 or 1)."""
+        return 1 if self._iram[SFR_PSW] & PSW_CY else 0
+
+    def _set_flags(self, cy: int, ac: int, ov: int) -> None:
+        """Update CY, AC, OV in PSW.  P is updated separately via _set_acc."""
+        psw = self._iram[SFR_PSW]
+        psw &= ~(PSW_CY | PSW_AC | PSW_OV) & 0xFF
+        if cy: psw |= PSW_CY
+        if ac: psw |= PSW_AC
+        if ov: psw |= PSW_OV
+        self._iram[SFR_PSW] = psw
+
+    # ── Direct / indirect IRAM access ─────────────────────────────────────────
+
+    def _direct_read(self, addr: int) -> int:
+        """Read a byte using direct addressing.
+
+        0x00–0x7F → internal lower RAM
+        0x80–0xFF → SFR space (same iram array)
+        """
+        return self._iram[addr & 0xFF]
+
+    def _direct_write(self, addr: int, val: int) -> None:
+        """Write a byte using direct addressing."""
+        self._iram[addr & 0xFF] = val & 0xFF
+        # If ACC was written directly, update parity
+        if (addr & 0xFF) == SFR_ACC:
+            self._update_parity()
+
+    def _indirect_read(self, ri: int) -> int:
+        """Read a byte using register-indirect addressing (@Ri).
+
+        On the 8051 base model, @Ri can only address 0x00–0x7F.
+        Values 0x80–0xFF are undefined; we raise ValueError.
+        """
+        addr = self._iram[self._rn_addr(ri & 1)]
+        if addr > 0x7F:
+            msg = f"Indirect address 0x{addr:02X} ≥ 0x80 (undefined on 8051)"
+            raise ValueError(msg)
+        return self._iram[addr]
+
+    def _indirect_write(self, ri: int, val: int) -> None:
+        """Write a byte using register-indirect addressing (@Ri)."""
+        addr = self._iram[self._rn_addr(ri & 1)]
+        if addr > 0x7F:
+            msg = f"Indirect address 0x{addr:02X} ≥ 0x80 (undefined on 8051)"
+            raise ValueError(msg)
+        self._iram[addr] = val & 0xFF
+
+    # ── Bit addressing ─────────────────────────────────────────────────────────
+
+    # Bit-addressable SFRs: only SFRs whose address is a multiple of 8 within
+    # the range 0x80–0xFF.  The standard set:
+    _BIT_ADDRESSABLE_SFRS = frozenset({
+        0x80, 0x88, 0x90, 0x98, 0xA0, 0xA8, 0xB0, 0xB8, 0xC0, 0xC8,
+        0xD0, 0xD8, 0xE0, 0xE8, 0xF0, 0xF8,
+    })
+
+    def _bit_addr(self, bit: int) -> tuple[int, int]:
+        """Resolve a bit address to (iram_byte_addr, bit_position).
+
+        Bit addresses 0x00–0x7F → iram bytes 0x20–0x2F (RAM bit area)
+        Bit addresses 0x80–0xFF → SFR bits (byte = bit & 0xF8, pos = bit & 7)
+
+        Returns (byte_addr, bit_pos) where byte_addr is an index into _iram
+        and bit_pos is 0–7 (0 = LSB).
+        """
+        bit &= 0xFF
+        if bit < 0x80:
+            byte_addr = 0x20 + (bit >> 3)
+            bit_pos   = bit & 0x7
+        else:
+            byte_addr = bit & 0xF8
+            bit_pos   = bit & 0x7
+        return byte_addr, bit_pos
+
+    def _read_bit(self, bit: int) -> int:
+        """Read one bit from the bit-addressable space. Returns 0 or 1."""
+        addr, pos = self._bit_addr(bit)
+        return (self._iram[addr] >> pos) & 1
+
+    def _write_bit(self, bit: int, val: int) -> None:
+        """Write one bit into the bit-addressable space."""
+        addr, pos = self._bit_addr(bit)
+        if val:
+            self._iram[addr] |= (1 << pos)
+        else:
+            self._iram[addr] &= ~(1 << pos) & 0xFF
+        # If ACC bit was changed, update parity
+        if addr == SFR_ACC:
+            self._update_parity()
+
+    # ── Stack ─────────────────────────────────────────────────────────────────
+
+    def _push8(self, val: int) -> None:
+        """Push one byte onto the stack (SP++; iram[SP] = val)."""
+        sp = (self._iram[SFR_SP] + 1) & 0xFF
+        self._iram[SFR_SP] = sp
+        self._iram[sp] = val & 0xFF
+
+    def _pop8(self) -> int:
+        """Pop one byte from the stack (val = iram[SP]; SP--)."""
+        sp = self._iram[SFR_SP]
+        val = self._iram[sp]
+        self._iram[SFR_SP] = (sp - 1) & 0xFF
+        return val
+
+    def _push_pc(self) -> None:
+        """Push 16-bit PC onto stack (low byte first, then high byte)."""
+        self._push8(self._pc & 0xFF)
+        self._push8((self._pc >> 8) & 0xFF)
+
+    def _pop_pc(self) -> None:
+        """Pop 16-bit PC from stack (high byte first, then low byte)."""
+        hi = self._pop8()
+        lo = self._pop8()
+        self._pc = (hi << 8) | lo
+
+    # =========================================================================
+    # Instruction execution
+    # =========================================================================
+
+    def _execute_one(self) -> str:  # noqa: C901 (complex but table-driven)
+        """Decode and execute one instruction.  Returns mnemonic string."""
+        opcode = self._fetch8()
+
+        # ── HALT sentinel ────────────────────────────────────────────────────
+        if opcode == HALT_OPCODE:  # 0xA5 reserved/undefined
+            self._halted = True
+            return "HALT"
+
+        # ── NOP ──────────────────────────────────────────────────────────────
+        if opcode == 0x00:
+            return "NOP"
+
+        # ── Data transfer ─────────────────────────────────────────────────────
+
+        # MOV A, Rn  (0xE8–0xEF)
+        if 0xE8 <= opcode <= 0xEF:
+            self._set_acc(self._rn(opcode & 7))
+            return f"MOV A,R{opcode & 7}"
+
+        # MOV A, dir  (0xE5)
+        if opcode == 0xE5:
+            d = self._fetch8()
+            self._set_acc(self._direct_read(d))
+            return "MOV A,dir"
+
+        # MOV A, @Ri  (0xE6–0xE7)
+        if opcode in (0xE6, 0xE7):
+            self._set_acc(self._indirect_read(opcode & 1))
+            return f"MOV A,@R{opcode & 1}"
+
+        # MOV A, #imm  (0x74)
+        if opcode == 0x74:
+            self._set_acc(self._fetch8())
+            return "MOV A,#imm"
+
+        # MOV Rn, A  (0xF8–0xFF)
+        if 0xF8 <= opcode <= 0xFF:
+            self._set_rn(opcode & 7, self._acc())
+            return f"MOV R{opcode & 7},A"
+
+        # MOV Rn, dir  (0xA8–0xAF)
+        if 0xA8 <= opcode <= 0xAF:
+            d = self._fetch8()
+            self._set_rn(opcode & 7, self._direct_read(d))
+            return f"MOV R{opcode & 7},dir"
+
+        # MOV Rn, #imm  (0x78–0x7F)
+        if 0x78 <= opcode <= 0x7F:
+            self._set_rn(opcode & 7, self._fetch8())
+            return f"MOV R{opcode & 7},#imm"
+
+        # MOV dir, A  (0xF5)
+        if opcode == 0xF5:
+            d = self._fetch8()
+            self._direct_write(d, self._acc())
+            return "MOV dir,A"
+
+        # MOV dir, Rn  (0x88–0x8F)
+        if 0x88 <= opcode <= 0x8F:
+            d = self._fetch8()
+            self._direct_write(d, self._rn(opcode & 7))
+            return f"MOV dir,R{opcode & 7}"
+
+        # MOV dir, dir2  (0x85) — note: src=byte2, dst=byte3
+        if opcode == 0x85:
+            src = self._fetch8()
+            dst = self._fetch8()
+            self._direct_write(dst, self._direct_read(src))
+            return "MOV dir,dir"
+
+        # MOV dir, @Ri  (0x86–0x87)
+        if opcode in (0x86, 0x87):
+            d = self._fetch8()
+            self._direct_write(d, self._indirect_read(opcode & 1))
+            return f"MOV dir,@R{opcode & 1}"
+
+        # MOV dir, #imm  (0x75)
+        if opcode == 0x75:
+            d   = self._fetch8()
+            imm = self._fetch8()
+            self._direct_write(d, imm)
+            return "MOV dir,#imm"
+
+        # MOV @Ri, A  (0xF6–0xF7)
+        if opcode in (0xF6, 0xF7):
+            self._indirect_write(opcode & 1, self._acc())
+            return f"MOV @R{opcode & 1},A"
+
+        # MOV @Ri, dir  (0xA6–0xA7)
+        if opcode in (0xA6, 0xA7):
+            d = self._fetch8()
+            self._indirect_write(opcode & 1, self._direct_read(d))
+            return f"MOV @R{opcode & 1},dir"
+
+        # MOV @Ri, #imm  (0x76–0x77)
+        if opcode in (0x76, 0x77):
+            self._indirect_write(opcode & 1, self._fetch8())
+            return f"MOV @R{opcode & 1},#imm"
+
+        # MOV DPTR, #imm16  (0x90)
+        if opcode == 0x90:
+            self._set_dptr(self._fetch16())
+            return "MOV DPTR,#imm16"
+
+        # MOVC A, @A+DPTR  (0x93)
+        if opcode == 0x93:
+            ea = (self._acc() + self._dptr()) & 0xFFFF
+            self._set_acc(self._code[ea])
+            return "MOVC A,@A+DPTR"
+
+        # MOVC A, @A+PC  (0x83)
+        if opcode == 0x83:
+            ea = (self._acc() + self._pc) & 0xFFFF  # _pc already advanced past 0x83
+            self._set_acc(self._code[ea])
+            return "MOVC A,@A+PC"
+
+        # MOVX A, @Ri  (0xE2–0xE3)
+        if opcode in (0xE2, 0xE3):
+            addr = self._rn(opcode & 1)
+            self._set_acc(self._xdata[addr])
+            return f"MOVX A,@R{opcode & 1}"
+
+        # MOVX A, @DPTR  (0xE0)
+        if opcode == 0xE0:
+            self._set_acc(self._xdata[self._dptr()])
+            return "MOVX A,@DPTR"
+
+        # MOVX @Ri, A  (0xF2–0xF3)
+        if opcode in (0xF2, 0xF3):
+            self._xdata[self._rn(opcode & 1)] = self._acc()
+            return f"MOVX @R{opcode & 1},A"
+
+        # MOVX @DPTR, A  (0xF0)
+        if opcode == 0xF0:
+            self._xdata[self._dptr()] = self._acc()
+            return "MOVX @DPTR,A"
+
+        # PUSH dir  (0xC0)
+        if opcode == 0xC0:
+            d = self._fetch8()
+            self._push8(self._direct_read(d))
+            return "PUSH"
+
+        # POP dir  (0xD0)
+        if opcode == 0xD0:
+            d = self._fetch8()
+            self._direct_write(d, self._pop8())
+            return "POP"
+
+        # XCH A, Rn  (0xC8–0xCF)
+        if 0xC8 <= opcode <= 0xCF:
+            n  = opcode & 7
+            a  = self._acc()
+            rn = self._rn(n)
+            self._set_acc(rn)
+            self._set_rn(n, a)
+            return f"XCH A,R{n}"
+
+        # XCH A, dir  (0xC5)
+        if opcode == 0xC5:
+            d   = self._fetch8()
+            a   = self._acc()
+            mem = self._direct_read(d)
+            self._set_acc(mem)
+            self._direct_write(d, a)
+            return "XCH A,dir"
+
+        # XCH A, @Ri  (0xC6–0xC7)
+        if opcode in (0xC6, 0xC7):
+            i   = opcode & 1
+            a   = self._acc()
+            mem = self._indirect_read(i)
+            self._set_acc(mem)
+            self._indirect_write(i, a)
+            return f"XCH A,@R{i}"
+
+        # XCHD A, @Ri  (0xD6–0xD7)
+        if opcode in (0xD6, 0xD7):
+            i   = opcode & 1
+            a   = self._acc()
+            mem = self._indirect_read(i)
+            swapped_a   = (a & 0xF0) | (mem & 0x0F)
+            swapped_mem = (mem & 0xF0) | (a & 0x0F)
+            self._set_acc(swapped_a)
+            self._indirect_write(i, swapped_mem)
+            return f"XCHD A,@R{i}"
+
+        # ── Arithmetic ────────────────────────────────────────────────────────
+
+        # ADD A, Rn  (0x28–0x2F)
+        if 0x28 <= opcode <= 0x2F:
+            r, cy, ac, ov, p = add8_flags(self._acc(), self._rn(opcode & 7))
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return f"ADD A,R{opcode & 7}"
+
+        # ADD A, dir  (0x25)
+        if opcode == 0x25:
+            d = self._fetch8()
+            r, cy, ac, ov, p = add8_flags(self._acc(), self._direct_read(d))
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return "ADD A,dir"
+
+        # ADD A, @Ri  (0x26–0x27)
+        if opcode in (0x26, 0x27):
+            r, cy, ac, ov, p = add8_flags(self._acc(), self._indirect_read(opcode & 1))
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return f"ADD A,@R{opcode & 1}"
+
+        # ADD A, #imm  (0x24)
+        if opcode == 0x24:
+            r, cy, ac, ov, p = add8_flags(self._acc(), self._fetch8())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return "ADD A,#imm"
+
+        # ADDC A, Rn  (0x38–0x3F)
+        if 0x38 <= opcode <= 0x3F:
+            r, cy, ac, ov, p = add8_flags(self._acc(), self._rn(opcode & 7), self._cy())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return f"ADDC A,R{opcode & 7}"
+
+        # ADDC A, dir  (0x35)
+        if opcode == 0x35:
+            d = self._fetch8()
+            r, cy, ac, ov, p = add8_flags(self._acc(), self._direct_read(d), self._cy())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return "ADDC A,dir"
+
+        # ADDC A, @Ri  (0x36–0x37)
+        if opcode in (0x36, 0x37):
+            r, cy, ac, ov, p = add8_flags(self._acc(), self._indirect_read(opcode & 1), self._cy())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return f"ADDC A,@R{opcode & 1}"
+
+        # ADDC A, #imm  (0x34)
+        if opcode == 0x34:
+            r, cy, ac, ov, p = add8_flags(self._acc(), self._fetch8(), self._cy())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return "ADDC A,#imm"
+
+        # SUBB A, Rn  (0x98–0x9F)
+        if 0x98 <= opcode <= 0x9F:
+            r, cy, ac, ov, p = sub8_flags(self._acc(), self._rn(opcode & 7), self._cy())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return f"SUBB A,R{opcode & 7}"
+
+        # SUBB A, dir  (0x95)
+        if opcode == 0x95:
+            d = self._fetch8()
+            r, cy, ac, ov, p = sub8_flags(self._acc(), self._direct_read(d), self._cy())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return "SUBB A,dir"
+
+        # SUBB A, @Ri  (0x96–0x97)
+        if opcode in (0x96, 0x97):
+            r, cy, ac, ov, p = sub8_flags(self._acc(), self._indirect_read(opcode & 1), self._cy())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return f"SUBB A,@R{opcode & 1}"
+
+        # SUBB A, #imm  (0x94)
+        if opcode == 0x94:
+            r, cy, ac, ov, p = sub8_flags(self._acc(), self._fetch8(), self._cy())
+            self._iram[SFR_ACC] = r
+            self._set_flags(cy, ac, ov)
+            self._update_parity()
+            return "SUBB A,#imm"
+
+        # INC A  (0x04)
+        if opcode == 0x04:
+            self._iram[SFR_ACC] = (self._acc() + 1) & 0xFF
+            self._update_parity()
+            return "INC A"
+
+        # INC Rn  (0x08–0x0F)
+        if 0x08 <= opcode <= 0x0F:
+            n = opcode & 7
+            self._set_rn(n, (self._rn(n) + 1) & 0xFF)
+            return f"INC R{n}"
+
+        # INC dir  (0x05)
+        if opcode == 0x05:
+            d = self._fetch8()
+            self._direct_write(d, (self._direct_read(d) + 1) & 0xFF)
+            return "INC dir"
+
+        # INC @Ri  (0x06–0x07)
+        if opcode in (0x06, 0x07):
+            i = opcode & 1
+            self._indirect_write(i, (self._indirect_read(i) + 1) & 0xFF)
+            return f"INC @R{i}"
+
+        # INC DPTR  (0xA3)
+        if opcode == 0xA3:
+            self._set_dptr((self._dptr() + 1) & 0xFFFF)
+            return "INC DPTR"
+
+        # DEC A  (0x14)
+        if opcode == 0x14:
+            self._iram[SFR_ACC] = (self._acc() - 1) & 0xFF
+            self._update_parity()
+            return "DEC A"
+
+        # DEC Rn  (0x18–0x1F)
+        if 0x18 <= opcode <= 0x1F:
+            n = opcode & 7
+            self._set_rn(n, (self._rn(n) - 1) & 0xFF)
+            return f"DEC R{n}"
+
+        # DEC dir  (0x15)
+        if opcode == 0x15:
+            d = self._fetch8()
+            self._direct_write(d, (self._direct_read(d) - 1) & 0xFF)
+            return "DEC dir"
+
+        # DEC @Ri  (0x16–0x17)
+        if opcode in (0x16, 0x17):
+            i = opcode & 1
+            self._indirect_write(i, (self._indirect_read(i) - 1) & 0xFF)
+            return f"DEC @R{i}"
+
+        # MUL AB  (0xA4)  — B:A = A × B (unsigned 8×8→16)
+        if opcode == 0xA4:
+            product = self._acc() * self._iram[SFR_B]
+            self._iram[SFR_ACC] = product & 0xFF
+            self._iram[SFR_B]   = (product >> 8) & 0xFF
+            # CY = 0 always; OV = 1 if product > 0xFF (i.e. B ≠ 0 after)
+            ov = 1 if (product >> 8) != 0 else 0
+            self._set_flags(0, 0, ov)
+            self._update_parity()
+            return "MUL AB"
+
+        # DIV AB  (0x84)  — A = quotient, B = remainder; OV if B=0 before
+        if opcode == 0x84:
+            divisor = self._iram[SFR_B]
+            if divisor == 0:
+                self._set_flags(0, 0, 1)  # OV = 1, CY = 0
+                # ACC and B are undefined; leave unchanged per some implementations
+            else:
+                q = self._acc() // divisor
+                r = self._acc() % divisor
+                self._iram[SFR_ACC] = q & 0xFF
+                self._iram[SFR_B]   = r & 0xFF
+                self._set_flags(0, 0, 0)
+            self._update_parity()
+            return "DIV AB"
+
+        # DA A  (0xD4)  — decimal adjust after BCD addition
+        if opcode == 0xD4:
+            cy_in = self._cy()
+            ac_in = 1 if self._iram[SFR_PSW] & PSW_AC else 0
+            result, new_cy, new_p = da_flags(self._acc(), cy_in, ac_in)
+            self._iram[SFR_ACC] = result
+            psw = self._iram[SFR_PSW]
+            if new_cy:
+                psw |= PSW_CY
+            else:
+                psw &= ~PSW_CY & 0xFF
+            if new_p:
+                psw |= PSW_P
+            else:
+                psw &= ~PSW_P & 0xFF
+            self._iram[SFR_PSW] = psw
+            return "DA A"
+
+        # ── Logic ─────────────────────────────────────────────────────────────
+
+        # ANL A, Rn  (0x58–0x5F)
+        if 0x58 <= opcode <= 0x5F:
+            self._set_acc(self._acc() & self._rn(opcode & 7))
+            return f"ANL A,R{opcode & 7}"
+
+        # ANL A, dir  (0x55)
+        if opcode == 0x55:
+            d = self._fetch8()
+            self._set_acc(self._acc() & self._direct_read(d))
+            return "ANL A,dir"
+
+        # ANL A, @Ri  (0x56–0x57)
+        if opcode in (0x56, 0x57):
+            self._set_acc(self._acc() & self._indirect_read(opcode & 1))
+            return f"ANL A,@R{opcode & 1}"
+
+        # ANL A, #imm  (0x54)
+        if opcode == 0x54:
+            self._set_acc(self._acc() & self._fetch8())
+            return "ANL A,#imm"
+
+        # ANL dir, A  (0x52)
+        if opcode == 0x52:
+            d = self._fetch8()
+            self._direct_write(d, self._direct_read(d) & self._acc())
+            return "ANL dir,A"
+
+        # ANL dir, #imm  (0x53)
+        if opcode == 0x53:
+            d   = self._fetch8()
+            imm = self._fetch8()
+            self._direct_write(d, self._direct_read(d) & imm)
+            return "ANL dir,#imm"
+
+        # ORL A, Rn  (0x48–0x4F)
+        if 0x48 <= opcode <= 0x4F:
+            self._set_acc(self._acc() | self._rn(opcode & 7))
+            return f"ORL A,R{opcode & 7}"
+
+        # ORL A, dir  (0x45)
+        if opcode == 0x45:
+            d = self._fetch8()
+            self._set_acc(self._acc() | self._direct_read(d))
+            return "ORL A,dir"
+
+        # ORL A, @Ri  (0x46–0x47)
+        if opcode in (0x46, 0x47):
+            self._set_acc(self._acc() | self._indirect_read(opcode & 1))
+            return f"ORL A,@R{opcode & 1}"
+
+        # ORL A, #imm  (0x44)
+        if opcode == 0x44:
+            self._set_acc(self._acc() | self._fetch8())
+            return "ORL A,#imm"
+
+        # ORL dir, A  (0x42)
+        if opcode == 0x42:
+            d = self._fetch8()
+            self._direct_write(d, self._direct_read(d) | self._acc())
+            return "ORL dir,A"
+
+        # ORL dir, #imm  (0x43)
+        if opcode == 0x43:
+            d   = self._fetch8()
+            imm = self._fetch8()
+            self._direct_write(d, self._direct_read(d) | imm)
+            return "ORL dir,#imm"
+
+        # XRL A, Rn  (0x68–0x6F)
+        if 0x68 <= opcode <= 0x6F:
+            self._set_acc(self._acc() ^ self._rn(opcode & 7))
+            return f"XRL A,R{opcode & 7}"
+
+        # XRL A, dir  (0x65)
+        if opcode == 0x65:
+            d = self._fetch8()
+            self._set_acc(self._acc() ^ self._direct_read(d))
+            return "XRL A,dir"
+
+        # XRL A, @Ri  (0x66–0x67)
+        if opcode in (0x66, 0x67):
+            self._set_acc(self._acc() ^ self._indirect_read(opcode & 1))
+            return f"XRL A,@R{opcode & 1}"
+
+        # XRL A, #imm  (0x64)
+        if opcode == 0x64:
+            self._set_acc(self._acc() ^ self._fetch8())
+            return "XRL A,#imm"
+
+        # XRL dir, A  (0x62)
+        if opcode == 0x62:
+            d = self._fetch8()
+            self._direct_write(d, self._direct_read(d) ^ self._acc())
+            return "XRL dir,A"
+
+        # XRL dir, #imm  (0x63)
+        if opcode == 0x63:
+            d   = self._fetch8()
+            imm = self._fetch8()
+            self._direct_write(d, self._direct_read(d) ^ imm)
+            return "XRL dir,#imm"
+
+        # CLR A  (0xE4)
+        if opcode == 0xE4:
+            self._set_acc(0)
+            return "CLR A"
+
+        # CPL A  (0xF4)
+        if opcode == 0xF4:
+            self._set_acc(~self._acc() & 0xFF)
+            return "CPL A"
+
+        # RL A  (0x23) — rotate left, no carry
+        if opcode == 0x23:
+            a = self._acc()
+            self._set_acc(((a << 1) | (a >> 7)) & 0xFF)
+            return "RL A"
+
+        # RLC A  (0x33) — rotate left through carry
+        if opcode == 0x33:
+            a   = self._acc()
+            new_cy = a >> 7
+            self._set_acc(((a << 1) | self._cy()) & 0xFF)
+            if new_cy:
+                self._iram[SFR_PSW] |= PSW_CY
+            else:
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            return "RLC A"
+
+        # RR A  (0x03) — rotate right, no carry
+        if opcode == 0x03:
+            a = self._acc()
+            self._set_acc(((a >> 1) | (a << 7)) & 0xFF)
+            return "RR A"
+
+        # RRC A  (0x13) — rotate right through carry
+        if opcode == 0x13:
+            a   = self._acc()
+            new_cy = a & 1
+            self._set_acc(((a >> 1) | (self._cy() << 7)) & 0xFF)
+            if new_cy:
+                self._iram[SFR_PSW] |= PSW_CY
+            else:
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            return "RRC A"
+
+        # SWAP A  (0xC4) — swap nibbles, no flag changes
+        if opcode == 0xC4:
+            a = self._acc()
+            self._iram[SFR_ACC] = ((a << 4) | (a >> 4)) & 0xFF
+            # SWAP does NOT update parity (no logical change, just nibble reorder)
+            return "SWAP A"
+
+        # ── Bit operations ────────────────────────────────────────────────────
+
+        # CLR C  (0xC3)
+        if opcode == 0xC3:
+            self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            return "CLR C"
+
+        # CLR bit  (0xC2)
+        if opcode == 0xC2:
+            self._write_bit(self._fetch8(), 0)
+            return "CLR bit"
+
+        # SETB C  (0xD3)
+        if opcode == 0xD3:
+            self._iram[SFR_PSW] |= PSW_CY
+            return "SETB C"
+
+        # SETB bit  (0xD2)
+        if opcode == 0xD2:
+            self._write_bit(self._fetch8(), 1)
+            return "SETB bit"
+
+        # CPL C  (0xB3)
+        if opcode == 0xB3:
+            self._iram[SFR_PSW] ^= PSW_CY
+            return "CPL C"
+
+        # CPL bit  (0xB2)
+        if opcode == 0xB2:
+            bit = self._fetch8()
+            self._write_bit(bit, 1 - self._read_bit(bit))
+            return "CPL bit"
+
+        # ANL C, bit  (0x82)
+        if opcode == 0x82:
+            bit = self._fetch8()
+            if not self._read_bit(bit):
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            return "ANL C,bit"
+
+        # ANL C, /bit  (0xB0)
+        if opcode == 0xB0:
+            bit = self._fetch8()
+            if self._read_bit(bit):    # /bit = complement
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            return "ANL C,/bit"
+
+        # ORL C, bit  (0x72)
+        if opcode == 0x72:
+            bit = self._fetch8()
+            if self._read_bit(bit):
+                self._iram[SFR_PSW] |= PSW_CY
+            return "ORL C,bit"
+
+        # ORL C, /bit  (0xA0)
+        if opcode == 0xA0:
+            bit = self._fetch8()
+            if not self._read_bit(bit):
+                self._iram[SFR_PSW] |= PSW_CY
+            return "ORL C,/bit"
+
+        # MOV C, bit  (0xA2)
+        if opcode == 0xA2:
+            bit = self._fetch8()
+            if self._read_bit(bit):
+                self._iram[SFR_PSW] |= PSW_CY
+            else:
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            return "MOV C,bit"
+
+        # MOV bit, C  (0x92)
+        if opcode == 0x92:
+            self._write_bit(self._fetch8(), self._cy())
+            return "MOV bit,C"
+
+        # ── Jumps ─────────────────────────────────────────────────────────────
+
+        # LJMP addr16  (0x02)
+        if opcode == 0x02:
+            self._pc = self._fetch16()
+            return "LJMP"
+
+        # SJMP rel  (0x80)
+        if opcode == 0x80:
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100   # sign-extend
+            self._pc = (self._pc + rel) & 0xFFFF
+            return "SJMP"
+
+        # JMP @A+DPTR  (0x73)
+        if opcode == 0x73:
+            self._pc = (self._acc() + self._dptr()) & 0xFFFF
+            return "JMP @A+DPTR"
+
+        # AJMP  — opcode pattern: a10:a9:a8:0:0:0:0:1  (bits 7:5 = addr[10:8], bits 4:0 = 00001)
+        if (opcode & 0x1F) == 0x01:
+            addr11_hi = (opcode >> 5) & 0x7
+            addr11_lo = self._fetch8()
+            self._pc = (self._pc & 0xF800) | (addr11_hi << 8) | addr11_lo
+            return "AJMP"
+
+        # JZ rel  (0x60)
+        if opcode == 0x60:
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            if self._acc() == 0:
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "JZ"
+
+        # JNZ rel  (0x70)
+        if opcode == 0x70:
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            if self._acc() != 0:
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "JNZ"
+
+        # JC rel  (0x40)
+        if opcode == 0x40:
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            if self._cy():
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "JC"
+
+        # JNC rel  (0x50)
+        if opcode == 0x50:
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            if not self._cy():
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "JNC"
+
+        # JB bit, rel  (0x20)
+        if opcode == 0x20:
+            bit = self._fetch8()
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            if self._read_bit(bit):
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "JB"
+
+        # JNB bit, rel  (0x30)
+        if opcode == 0x30:
+            bit = self._fetch8()
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            if not self._read_bit(bit):
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "JNB"
+
+        # JBC bit, rel  (0x10)
+        if opcode == 0x10:
+            bit = self._fetch8()
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            if self._read_bit(bit):
+                self._write_bit(bit, 0)
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "JBC"
+
+        # CJNE A, dir, rel  (0xB5)
+        if opcode == 0xB5:
+            d   = self._fetch8()
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            val = self._direct_read(d)
+            if self._acc() < val:
+                self._iram[SFR_PSW] |= PSW_CY
+            else:
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            if self._acc() != val:
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "CJNE A,dir"
+
+        # CJNE A, #imm, rel  (0xB4)
+        if opcode == 0xB4:
+            imm = self._fetch8()
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            if self._acc() < imm:
+                self._iram[SFR_PSW] |= PSW_CY
+            else:
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            if self._acc() != imm:
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "CJNE A,#imm"
+
+        # CJNE Rn, #imm, rel  (0xB8–0xBF)
+        if 0xB8 <= opcode <= 0xBF:
+            n   = opcode & 7
+            imm = self._fetch8()
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            rn = self._rn(n)
+            if rn < imm:
+                self._iram[SFR_PSW] |= PSW_CY
+            else:
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            if rn != imm:
+                self._pc = (self._pc + rel) & 0xFFFF
+            return f"CJNE R{n},#imm"
+
+        # CJNE @Ri, #imm, rel  (0xB6–0xB7)
+        if opcode in (0xB6, 0xB7):
+            i   = opcode & 1
+            imm = self._fetch8()
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            mem = self._indirect_read(i)
+            if mem < imm:
+                self._iram[SFR_PSW] |= PSW_CY
+            else:
+                self._iram[SFR_PSW] &= ~PSW_CY & 0xFF
+            if mem != imm:
+                self._pc = (self._pc + rel) & 0xFFFF
+            return f"CJNE @R{i},#imm"
+
+        # DJNZ Rn, rel  (0xD8–0xDF)
+        if 0xD8 <= opcode <= 0xDF:
+            n   = opcode & 7
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            val = (self._rn(n) - 1) & 0xFF
+            self._set_rn(n, val)
+            if val != 0:
+                self._pc = (self._pc + rel) & 0xFFFF
+            return f"DJNZ R{n}"
+
+        # DJNZ dir, rel  (0xD5)
+        if opcode == 0xD5:
+            d   = self._fetch8()
+            rel = self._fetch8()
+            if rel >= 0x80: rel -= 0x100
+            val = (self._direct_read(d) - 1) & 0xFF
+            self._direct_write(d, val)
+            if val != 0:
+                self._pc = (self._pc + rel) & 0xFFFF
+            return "DJNZ dir"
+
+        # ── Subroutines ───────────────────────────────────────────────────────
+
+        # LCALL addr16  (0x12)
+        if opcode == 0x12:
+            addr = self._fetch16()
+            self._push_pc()
+            self._pc = addr
+            return "LCALL"
+
+        # ACALL  — pattern: a10:a9:a8:1:0:0:1:0  (bits 7:5 = addr[10:8], bits 4:0 = 10010)
+        if (opcode & 0x1F) == 0x11:
+            addr11_hi = (opcode >> 5) & 0x7
+            addr11_lo = self._fetch8()
+            self._push_pc()
+            self._pc = (self._pc & 0xF800) | (addr11_hi << 8) | addr11_lo
+            return "ACALL"
+
+        # RET  (0x22)
+        if opcode == 0x22:
+            self._pop_pc()
+            return "RET"
+
+        # RETI  (0x32) — same as RET for behavioral sim (no interrupt controller)
+        if opcode == 0x32:
+            self._pop_pc()
+            return "RETI"
+
+        raise ValueError(f"Unknown opcode: 0x{opcode:02X} at PC=0x{(self._pc - 1) & 0xFFFF:04X}")

--- a/code/packages/python/intel8051-simulator/src/intel8051_simulator/state.py
+++ b/code/packages/python/intel8051-simulator/src/intel8051_simulator/state.py
@@ -1,0 +1,141 @@
+"""I8051State — frozen snapshot of the Intel 8051 CPU state.
+
+The 8051 has a Harvard architecture: code memory, internal RAM (which includes
+Special Function Registers at 0x80–0xFF), and external data memory are all
+separate address spaces.  The state captures all three along with the
+architectural registers.
+
+Memory layout of internal RAM (iram, 256 bytes):
+    0x00–0x1F  — 4 register banks (each 8 bytes, R0–R7)
+    0x20–0x2F  — bit-addressable area (128 individually-addressable bits)
+    0x30–0x7F  — general scratchpad RAM
+    0x80–0xFF  — Special Function Registers (SFRs)
+
+PSW (Program Status Word) bit layout:
+    Bit 7 = CY  (carry)
+    Bit 6 = AC  (auxiliary carry, bit 3→4)
+    Bit 5 = F0  (user flag)
+    Bit 4 = RS1 (register bank select, high bit)
+    Bit 3 = RS0 (register bank select, low bit)
+    Bit 2 = OV  (overflow / division error)
+    Bit 1 = —   (reserved, always 0)
+    Bit 0 = P   (parity of ACC, even parity)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+CODE_SIZE  = 65536   # Harvard code-memory space (64 KB)
+XDATA_SIZE = 65536   # External data-memory space (64 KB)
+IRAM_SIZE  = 256     # Internal RAM + SFR space (256 bytes)
+
+# SFR addresses (absolute, i.e. direct-address indices into iram)
+SFR_P0   = 0x80
+SFR_SP   = 0x81
+SFR_DPL  = 0x82
+SFR_DPH  = 0x83
+SFR_PCON = 0x87
+SFR_TCON = 0x88
+SFR_TMOD = 0x89
+SFR_TL0  = 0x8A
+SFR_TL1  = 0x8B
+SFR_TH0  = 0x8C
+SFR_TH1  = 0x8D
+SFR_P1   = 0x90
+SFR_SCON = 0x98
+SFR_SBUF = 0x99
+SFR_P2   = 0xA0
+SFR_IE   = 0xA8
+SFR_P3   = 0xB0
+SFR_IP   = 0xB8
+SFR_PSW  = 0xD0
+SFR_ACC  = 0xE0
+SFR_B    = 0xF0
+
+# Reset values for port latches (all 0xFF on real hardware)
+PORT_RESET = 0xFF
+
+# PSW bit masks
+PSW_CY  = 0x80
+PSW_AC  = 0x40
+PSW_F0  = 0x20
+PSW_RS1 = 0x10
+PSW_RS0 = 0x08
+PSW_OV  = 0x04
+PSW_P   = 0x01
+
+# HALT sentinel opcode (0xA5 is undefined/reserved on real 8051)
+HALT_OPCODE = 0xA5
+
+
+# ── State dataclass ────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class I8051State:
+    """Immutable snapshot of the full 8051 architectural state.
+
+    All mutable simulator state is copied into Python immutables (int, tuple)
+    so that a stored snapshot is never affected by subsequent execution.
+    """
+
+    pc:     int               # 16-bit program counter
+    iram:   tuple[int, ...]   # 256 bytes: lower RAM + SFRs at 0x80+
+    xdata:  tuple[int, ...]   # 65536 bytes of external data memory
+    code:   tuple[int, ...]   # 65536 bytes of code memory (Harvard)
+    halted: bool
+
+    # Convenience: expose architectural registers as direct properties
+    # rather than requiring callers to index iram[SFR_xxx].
+
+    @property
+    def acc(self) -> int:
+        """Accumulator (SFR 0xE0)."""
+        return self.iram[SFR_ACC]
+
+    @property
+    def b(self) -> int:
+        """B register (SFR 0xF0)."""
+        return self.iram[SFR_B]
+
+    @property
+    def sp(self) -> int:
+        """Stack pointer (SFR 0x81)."""
+        return self.iram[SFR_SP]
+
+    @property
+    def dptr(self) -> int:
+        """16-bit data pointer = DPH:DPL (SFRs 0x83:0x82)."""
+        return (self.iram[SFR_DPH] << 8) | self.iram[SFR_DPL]
+
+    @property
+    def psw(self) -> int:
+        """Program status word (SFR 0xD0)."""
+        return self.iram[SFR_PSW]
+
+    @property
+    def cy(self) -> bool:
+        """Carry flag (PSW bit 7)."""
+        return bool(self.iram[SFR_PSW] & PSW_CY)
+
+    @property
+    def ac(self) -> bool:
+        """Auxiliary carry flag (PSW bit 6)."""
+        return bool(self.iram[SFR_PSW] & PSW_AC)
+
+    @property
+    def ov(self) -> bool:
+        """Overflow / division-error flag (PSW bit 2)."""
+        return bool(self.iram[SFR_PSW] & PSW_OV)
+
+    @property
+    def parity(self) -> bool:
+        """Even-parity flag of ACC (PSW bit 0)."""
+        return bool(self.iram[SFR_PSW] & PSW_P)
+
+    @property
+    def bank(self) -> int:
+        """Active register bank (0–3) from PSW RS1:RS0."""
+        return (self.iram[SFR_PSW] >> 3) & 0x3

--- a/code/packages/python/intel8051-simulator/tests/test_coverage.py
+++ b/code/packages/python/intel8051-simulator/tests/test_coverage.py
@@ -1,0 +1,414 @@
+"""Edge-case and coverage tests for the Intel 8051 simulator.
+
+Tests that specifically target:
+  - Flags module (add8_flags, sub8_flags, da_flags, parity)
+  - State module (properties, constants)
+  - Boundary conditions (SP wrap, bit addressing extremes)
+  - Register bank switching
+  - Indirect addressing edge cases
+  - Unknown opcode raises ValueError
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from intel8051_simulator import I8051Simulator
+from intel8051_simulator.flags import add8_flags, da_flags, sub8_flags
+from intel8051_simulator.state import (
+    SFR_ACC,
+    SFR_B,
+    SFR_DPH,
+    SFR_DPL,
+    SFR_PSW,
+    SFR_SP,
+)
+
+HALT = bytes([0xA5])
+
+
+# ── Flags module unit tests ───────────────────────────────────────────────────
+
+class TestAdd8Flags:
+    def test_no_overflow_no_carry(self):
+        result, cy, ac, ov, p = add8_flags(0x10, 0x20)
+        assert result == 0x30
+        assert cy == 0
+        assert ac == 0
+        assert ov == 0
+
+    def test_unsigned_carry(self):
+        result, cy, ac, ov, p = add8_flags(0xFF, 0x01)
+        assert result == 0x00
+        assert cy == 1
+
+    def test_auxiliary_carry(self):
+        _, cy, ac, ov, p = add8_flags(0x08, 0x08)
+        assert ac == 1
+        assert cy == 0
+
+    def test_signed_overflow_pos_pos(self):
+        # 0x7F + 0x01 = 0x80 (positive + positive = negative)
+        _, cy, ac, ov, p = add8_flags(0x7F, 0x01)
+        assert ov == 1
+        assert cy == 0
+
+    def test_signed_overflow_neg_neg(self):
+        # 0x80 + 0x80 = 0x00 with carry (negative + negative = positive)
+        result, cy, ac, ov, p = add8_flags(0x80, 0x80)
+        assert result == 0x00
+        assert cy == 1
+        assert ov == 1
+
+    def test_carry_in_addc(self):
+        result, cy, ac, ov, p = add8_flags(0x01, 0x01, 1)
+        assert result == 3
+
+    def test_carry_triggers_carry_out(self):
+        # 0xFF + 0x00 + 1 = 0x100 → result=0, cy=1
+        result, cy, ac, ov, p = add8_flags(0xFF, 0x00, 1)
+        assert result == 0x00
+        assert cy == 1
+
+    def test_parity_odd_bits(self):
+        # 0x01 has 1 set bit → odd → p=1
+        _, cy, ac, ov, p = add8_flags(0x00, 0x01)
+        assert p == 1
+
+    def test_parity_even_bits(self):
+        # 0x03 has 2 set bits → even → p=0
+        _, cy, ac, ov, p = add8_flags(0x00, 0x03)
+        assert p == 0
+
+
+class TestSub8Flags:
+    def test_no_borrow(self):
+        # 0x10 - 0x05 = 0x0B; no borrow out (cy=0)
+        # AC: low nibble 0x0 < 0x5, so a borrow from bit4 occurs → AC=1
+        result, cy, ac, ov, p = sub8_flags(0x10, 0x05)
+        assert result == 0x0B
+        assert cy == 0
+        assert ac == 1   # auxiliary borrow: low nibble 0 < 5
+
+    def test_borrow(self):
+        result, cy, ac, ov, p = sub8_flags(0x00, 0x01)
+        assert result == 0xFF
+        assert cy == 1
+
+    def test_borrow_propagated(self):
+        # 0x05 - 0x05 - 1 = -1 → borrow
+        result, cy, ac, ov, p = sub8_flags(0x05, 0x05, 1)
+        assert result == 0xFF
+        assert cy == 1
+
+    def test_aux_borrow(self):
+        # 0x10 - 0x01 → low nibble: 0 < 1 → AC=1
+        _, cy, ac, ov, p = sub8_flags(0x10, 0x01)
+        assert ac == 1
+
+    def test_signed_overflow_sub(self):
+        # 0x80 - 0x01 = 0x7F; negative - positive = positive → OV=1
+        _, cy, ac, ov, p = sub8_flags(0x80, 0x01)
+        assert ov == 1
+
+
+class TestDaFlags:
+    def test_no_adjust_needed(self):
+        # 0x35 is valid BCD (3, 5) and sum was clean
+        result, new_cy, new_p = da_flags(0x35, 0, 0)
+        assert result == 0x35
+
+    def test_low_nibble_correction(self):
+        # 0x0A → low nibble >9 → add 6 → 0x10
+        result, new_cy, new_p = da_flags(0x0A, 0, 0)
+        assert result == 0x10
+
+    def test_high_nibble_correction(self):
+        # 0xA0 → high nibble >9 → add 0x60 → 0x00, CY=1
+        result, new_cy, new_p = da_flags(0xA0, 0, 0)
+        assert result == 0x00
+        assert new_cy == 1
+
+    def test_ac_triggers_low_correction(self):
+        result, new_cy, new_p = da_flags(0x09, 0, 1)   # AC=1 → add 6 → 0x0F
+        assert result == 0x0F
+
+    def test_cy_triggers_high_correction(self):
+        result, new_cy, new_p = da_flags(0x10, 1, 0)   # CY_in=1 → add 0x60
+        assert result == 0x70
+        assert new_cy == 1
+
+
+# ── State properties ──────────────────────────────────────────────────────────
+
+class TestI8051StateProperties:
+    def test_acc_property(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_ACC] = 0xAB
+        state = sim.get_state()
+        assert state.acc == 0xAB
+
+    def test_b_property(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_B] = 0xCD
+        state = sim.get_state()
+        assert state.b == 0xCD
+
+    def test_sp_property(self):
+        sim = I8051Simulator()
+        state = sim.get_state()
+        assert state.sp == 0x07
+
+    def test_dptr_property(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_DPH] = 0x12
+        sim._iram[SFR_DPL] = 0x34
+        state = sim.get_state()
+        assert state.dptr == 0x1234
+
+    def test_psw_property(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_PSW] = 0x80
+        state = sim.get_state()
+        assert state.psw == 0x80
+        assert state.cy
+
+    def test_ov_property(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_PSW] = 0x04
+        state = sim.get_state()
+        assert state.ov
+
+    def test_parity_property(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_PSW] = 0x01
+        state = sim.get_state()
+        assert state.parity
+
+    def test_bank_property_default(self):
+        sim = I8051Simulator()
+        state = sim.get_state()
+        assert state.bank == 0
+
+    def test_bank_property_bank2(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_PSW] = 0x10   # RS1=1, RS0=0 → bank 2
+        state = sim.get_state()
+        assert state.bank == 2
+
+
+# ── Register bank switching ───────────────────────────────────────────────────
+
+class TestRegisterBanks:
+    def test_bank0_r0_at_0x00(self):
+        sim = I8051Simulator()
+        # Bank 0 (default): R0 = iram[0x00]
+        sim._iram[0x00] = 0xAA
+        assert sim._rn(0) == 0xAA
+
+    def test_bank1_r0_at_0x08(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_PSW] = 0x08   # RS0=1 → bank 1
+        sim._iram[0x08] = 0xBB
+        assert sim._rn(0) == 0xBB
+
+    def test_bank2_r0_at_0x10(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_PSW] = 0x10   # RS1=1 → bank 2
+        sim._iram[0x10] = 0xCC
+        assert sim._rn(0) == 0xCC
+
+    def test_bank3_r7_at_0x1f(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_PSW] = 0x18   # RS1=RS0=1 → bank 3
+        sim._iram[0x1F] = 0xDD
+        assert sim._rn(7) == 0xDD
+
+    def test_switch_bank_via_mov_psw(self):
+        # MOV PSW, #0x08 (bank 1); then use R0
+        prog = bytes([
+            0x75, SFR_PSW, 0x08,   # MOV PSW, #0x08 → bank 1
+            0x78, 0x42,             # MOV R0, #0x42 (bank 1, iram[0x08])
+            0xA5,
+        ])
+        sim = I8051Simulator()
+        sim.execute(prog)
+        assert sim._iram[0x08] == 0x42   # bank 1 R0
+
+
+# ── Bit addressing ────────────────────────────────────────────────────────────
+
+class TestBitAddressing:
+    def test_ram_bit_0(self):
+        """Bit 0x00 → byte 0x20, bit 0."""
+        sim = I8051Simulator()
+        assert sim._bit_addr(0x00) == (0x20, 0)
+
+    def test_ram_bit_7(self):
+        """Bit 0x07 → byte 0x20, bit 7."""
+        sim = I8051Simulator()
+        assert sim._bit_addr(0x07) == (0x20, 7)
+
+    def test_ram_bit_8(self):
+        """Bit 0x08 → byte 0x21, bit 0."""
+        sim = I8051Simulator()
+        assert sim._bit_addr(0x08) == (0x21, 0)
+
+    def test_ram_bit_127(self):
+        """Bit 0x7F → byte 0x2F, bit 7 (last RAM bit)."""
+        sim = I8051Simulator()
+        assert sim._bit_addr(0x7F) == (0x2F, 7)
+
+    def test_sfr_bit_0x80(self):
+        """Bit 0x80 → SFR byte 0x80 (P0), bit 0."""
+        sim = I8051Simulator()
+        assert sim._bit_addr(0x80) == (0x80, 0)
+
+    def test_sfr_acc_bit_0xe0(self):
+        """Bit 0xE0 → SFR 0xE0 (ACC), bit 0."""
+        sim = I8051Simulator()
+        assert sim._bit_addr(0xE0) == (0xE0, 0)
+
+    def test_write_and_read_bit(self):
+        sim = I8051Simulator()
+        sim._write_bit(0x05, 1)
+        assert sim._read_bit(0x05) == 1
+        sim._write_bit(0x05, 0)
+        assert sim._read_bit(0x05) == 0
+
+    def test_write_sfr_bit_updates_psw(self):
+        """Writing bit 0xD7 (PSW.7 = CY) via bit write."""
+        sim = I8051Simulator()
+        sim._write_bit(0xD7, 1)
+        assert sim._iram[SFR_PSW] & 0x80
+
+
+# ── Indirect addressing boundaries ───────────────────────────────────────────
+
+class TestIndirectAddressing:
+    def test_indirect_at_0x7f_ok(self):
+        sim = I8051Simulator()
+        sim._iram[0x00] = 0x7F   # R0 = 0x7F (max valid indirect address)
+        sim._iram[0x7F] = 0xAB
+        assert sim._indirect_read(0) == 0xAB
+
+    def test_indirect_at_0x80_raises(self):
+        sim = I8051Simulator()
+        sim._iram[0x00] = 0x80   # R0 = 0x80 (invalid on 8051)
+        with pytest.raises(ValueError, match="0x80"):
+            sim._indirect_read(0)
+
+    def test_indirect_write_at_0x80_raises(self):
+        sim = I8051Simulator()
+        sim._iram[0x00] = 0x80
+        with pytest.raises(ValueError):
+            sim._indirect_write(0, 0x42)
+
+
+# ── Stack behavior ────────────────────────────────────────────────────────────
+
+class TestStack:
+    def test_push_increases_sp(self):
+        sim = I8051Simulator()
+        sim._push8(0xAB)
+        assert sim._iram[SFR_SP] == 0x08
+        assert sim._iram[0x08] == 0xAB
+
+    def test_pop_decreases_sp(self):
+        sim = I8051Simulator()
+        sim._push8(0xCD)
+        val = sim._pop8()
+        assert val == 0xCD
+        assert sim._iram[SFR_SP] == 0x07
+
+    def test_push_pc_pop_pc(self):
+        sim = I8051Simulator()
+        sim._pc = 0x1234
+        sim._push_pc()
+        sim._pc = 0x0000
+        sim._pop_pc()
+        assert sim._pc == 0x1234
+
+    def test_sp_wraps_on_overflow(self):
+        """SP wraps around 0xFF → 0x00 (bytearray, 8-bit)."""
+        sim = I8051Simulator()
+        sim._iram[SFR_SP] = 0xFF
+        sim._push8(0xAA)
+        assert sim._iram[SFR_SP] == 0x00
+
+
+# ── Parity recomputation ──────────────────────────────────────────────────────
+
+class TestParityRecomputation:
+    def test_parity_updated_after_mov_a(self):
+        """Parity must be updated whenever ACC changes."""
+        sim = I8051Simulator()
+        sim.execute(bytes([0x74, 0x01]) + HALT)   # A=1 → 1 bit → P=1
+        assert sim._iram[SFR_PSW] & 0x01
+
+    def test_parity_updated_after_anl(self):
+        sim = I8051Simulator()
+        sim.execute(bytes([0x74, 0x03, 0x54, 0x01]) + HALT)  # A=3; ANL A,#1 → A=1 (P=1)
+        assert sim._iram[SFR_PSW] & 0x01
+
+    def test_parity_updated_via_direct_write_to_acc(self):
+        """MOV SFR_ACC, A should update parity via _direct_write."""
+        sim = I8051Simulator()
+        prog = bytes([0x74, 0x03,             # MOV A, #3  (P=0)
+                      0xF5, SFR_ACC]) + HALT   # MOV dir(ACC), A  — redundant but valid
+        sim.execute(prog)
+        assert not (sim._iram[SFR_PSW] & 0x01)  # 0x03 has 2 bits → P=0
+
+
+# ── Unknown opcode ────────────────────────────────────────────────────────────
+
+class TestUnknownOpcode:
+    def test_illegal_indirect_in_execute_returns_error(self):
+        """Indirect address ≥ 0x80 should surface as an error in ExecutionResult.
+
+        0x01 (AJMP) IS defined on 8051.  We test the error path by setting R0
+        to an invalid indirect address (0x80) and executing MOV A, @R0.
+        """
+        # MOV R0, #0x80; MOV A, @R0 → illegal indirect addr
+        result = I8051Simulator().execute(bytes([0x78, 0x80, 0xE6]) + HALT)
+        assert not result.ok
+        assert result.error is not None
+
+    def test_illegal_indirect_in_step_raises(self):
+        """Step raises ValueError when @Ri points to ≥ 0x80."""
+        sim = I8051Simulator()
+        sim.load(bytes([0x78, 0x80,   # MOV R0, #0x80
+                        0xE6]) + HALT)  # MOV A, @R0
+        sim.step()   # MOV R0, #0x80
+        with pytest.raises(ValueError, match="0x80"):
+            sim.step()   # MOV A, @R0 → should raise
+
+
+# ── DEC dir and INC @Ri forms ─────────────────────────────────────────────────
+
+class TestDecIncForms:
+    def test_dec_at_ri(self):
+        # MOV R0, #0x30; MOV @R0, #0x10 (via 0x76 #0x10); DEC @R0
+        prog = bytes([0x78, 0x30, 0x76, 0x10, 0x16]) + HALT
+        sim = I8051Simulator()
+        sim.execute(prog)
+        assert sim._iram[0x30] == 0x0F
+
+    def test_inc_at_ri(self):
+        prog = bytes([0x78, 0x30, 0x76, 0x10, 0x06]) + HALT
+        sim = I8051Simulator()
+        sim.execute(prog)
+        assert sim._iram[0x30] == 0x11
+
+
+# ── CPL bit ───────────────────────────────────────────────────────────────────
+
+class TestCplBit:
+    def test_cpl_bit_in_sfr_acc(self):
+        """CPL bit 0xE0 toggles ACC bit 0 and updates parity."""
+        sim = I8051Simulator()
+        sim.load(bytes([0x74, 0x00,   # CLR A
+                        0xB2, 0xE0]) + HALT)  # CPL bit 0xE0 (ACC.0)
+        sim.execute(bytes([0x74, 0x00, 0xB2, 0xE0]) + HALT)
+        assert sim._iram[SFR_ACC] & 0x01   # bit 0 should be 1
+        assert sim._iram[SFR_PSW] & 0x01   # parity updated (1 set bit → P=1)

--- a/code/packages/python/intel8051-simulator/tests/test_instructions.py
+++ b/code/packages/python/intel8051-simulator/tests/test_instructions.py
@@ -1,0 +1,834 @@
+"""Per-instruction tests for the Intel 8051 simulator.
+
+Encoding constants (from spec 07p):
+  MOV A, #imm       0x74 imm
+  MOV A, dir        0xE5 dir
+  MOV A, @Ri        0xE6+i
+  MOV A, Rn         0xE8+n
+  MOV Rn, A         0xF8+n
+  MOV Rn, #imm      0x78+n imm
+  MOV dir, A        0xF5 dir
+  MOV dir, Rn       0x88+n dir
+  MOV dir, dir2     0x85 src dst
+  MOV dir, @Ri      0x86+i dir
+  MOV dir, #imm     0x75 dir imm
+  MOV @Ri, A        0xF6+i
+  MOV @Ri, dir      0xA6+i dir
+  MOV @Ri, #imm     0x76+i imm
+  MOV DPTR, #imm16  0x90 hi lo
+  MOVC A, @A+DPTR   0x93
+  MOVC A, @A+PC     0x83
+  MOVX A, @Ri       0xE2+i
+  MOVX A, @DPTR     0xE0
+  MOVX @Ri, A       0xF2+i
+  MOVX @DPTR, A     0xF0
+  PUSH dir          0xC0 dir
+  POP dir           0xD0 dir
+  XCH A, Rn         0xC8+n
+  XCH A, dir        0xC5 dir
+  XCH A, @Ri        0xC6+i
+  XCHD A, @Ri       0xD6+i
+  ADD A, Rn         0x28+n
+  ADD A, dir        0x25 dir
+  ADD A, @Ri        0x26+i
+  ADD A, #imm       0x24 imm
+  ADDC A, #imm      0x34 imm
+  SUBB A, #imm      0x94 imm
+  INC A             0x04
+  INC Rn            0x08+n
+  INC dir           0x05 dir
+  INC DPTR          0xA3
+  DEC A             0x14
+  DEC Rn            0x18+n
+  MUL AB            0xA4
+  DIV AB            0x84
+  DA A              0xD4
+  ANL A, #imm       0x54 imm
+  ORL A, #imm       0x44 imm
+  XRL A, #imm       0x64 imm
+  CLR A             0xE4
+  CPL A             0xF4
+  RL A              0x23
+  RLC A             0x33
+  RR A              0x03
+  RRC A             0x13
+  SWAP A            0xC4
+  CLR C             0xC3
+  CLR bit           0xC2 bit
+  SETB C            0xD3
+  SETB bit          0xD2 bit
+  CPL C             0xB3
+  ANL C, bit        0x82 bit
+  ORL C, bit        0x72 bit
+  MOV C, bit        0xA2 bit
+  MOV bit, C        0x92 bit
+  LJMP addr16       0x02 hi lo
+  SJMP rel          0x80 rel
+  JMP @A+DPTR       0x73
+  JZ rel            0x60 rel
+  JNZ rel           0x70 rel
+  JC rel            0x40 rel
+  JNC rel           0x50 rel
+  JB bit, rel       0x20 bit rel
+  JNB bit, rel      0x30 bit rel
+  JBC bit, rel      0x10 bit rel
+  CJNE A, #imm, rel 0xB4 imm rel
+  CJNE Rn, #imm,rel 0xB8+n imm rel
+  DJNZ Rn, rel      0xD8+n rel
+  DJNZ dir, rel     0xD5 dir rel
+  LCALL addr16      0x12 hi lo
+  RET               0x22
+  NOP               0x00
+  HALT              0xA5  (sentinel)
+"""
+
+from __future__ import annotations
+
+from intel8051_simulator import I8051Simulator
+from intel8051_simulator.state import SFR_ACC, SFR_B, SFR_DPH, SFR_DPL, SFR_PSW, SFR_SP
+
+HALT = bytes([0xA5])
+
+
+def run(prog: bytes) -> I8051Simulator:
+    """Helper: execute program and return simulator in final state."""
+    sim = I8051Simulator()
+    sim.execute(prog)
+    return sim
+
+
+# ── Data transfer ─────────────────────────────────────────────────────────────
+
+class TestMOV:
+    def test_mov_a_imm(self):
+        sim = run(bytes([0x74, 0x42]) + HALT)   # MOV A, #0x42
+        assert sim._iram[SFR_ACC] == 0x42
+
+    def test_mov_a_r0(self):
+        # MOV R0, #5; MOV A, R0
+        prog = bytes([0x78, 0x05, 0xE8]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x05
+
+    def test_mov_a_r3(self):
+        prog = bytes([0x7B, 0x7F, 0xEB]) + HALT  # MOV R3, #0x7F; MOV A, R3
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x7F
+
+    def test_mov_a_dir(self):
+        sim = I8051Simulator()
+        sim.load(bytes([0xE5, 0x30]) + HALT)   # MOV A, 0x30
+        sim._iram[0x30] = 0xAB
+        sim.step(); sim.step(); sim.step()
+        assert sim._iram[SFR_ACC] == 0xAB
+
+    def test_mov_a_at_r0(self):
+        sim = I8051Simulator()
+        # Set R0=0x30, set iram[0x30]=0x55, then MOV A, @R0
+        sim.load(bytes([0x78, 0x30,   # MOV R0, #0x30
+                        0xE6]) + HALT)  # MOV A, @R0
+        sim._iram[0x30] = 0x55
+        for _ in range(3): sim.step()
+        assert sim._iram[SFR_ACC] == 0x55
+
+    def test_mov_rn_a(self):
+        # MOV A, #0xAB; MOV R5, A
+        prog = bytes([0x74, 0xAB, 0xFD]) + HALT
+        sim = run(prog)
+        assert sim._rn(5) == 0xAB
+
+    def test_mov_rn_imm(self):
+        prog = bytes([0x7C, 0x99]) + HALT   # MOV R4, #0x99
+        sim = run(prog)
+        assert sim._rn(4) == 0x99
+
+    def test_mov_rn_dir(self):
+        sim = I8051Simulator()
+        sim.load(bytes([0xAC, 0x30]) + HALT)   # MOV R4, 0x30
+        sim._iram[0x30] = 0x12
+        for _ in range(2): sim.step()
+        assert sim._rn(4) == 0x12
+
+    def test_mov_dir_a(self):
+        # MOV A, #0xBC; MOV 0x40, A
+        prog = bytes([0x74, 0xBC, 0xF5, 0x40]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x40] == 0xBC
+
+    def test_mov_dir_rn(self):
+        # MOV R2, #0xDE; MOV 0x50, R2
+        prog = bytes([0x7A, 0xDE, 0x8A, 0x50]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x50] == 0xDE
+
+    def test_mov_dir_dir(self):
+        # MOV 0x50, #0x11; MOV 0x51, 0x50   (src=0x50, dst=0x51)
+        prog = bytes([0x75, 0x50, 0x11,    # MOV 0x50, #0x11
+                      0x85, 0x50, 0x51]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x51] == 0x11
+
+    def test_mov_dir_imm(self):
+        prog = bytes([0x75, 0x35, 0xCC]) + HALT   # MOV 0x35, #0xCC
+        sim = run(prog)
+        assert sim._iram[0x35] == 0xCC
+
+    def test_mov_at_ri_a(self):
+        # Set R0=0x30; MOV A, #0xAA; MOV @R0, A
+        prog = bytes([0x78, 0x30, 0x74, 0xAA, 0xF6]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x30] == 0xAA
+
+    def test_mov_at_ri_imm(self):
+        # MOV R0, #0x32; MOV @R0, #0x77
+        prog = bytes([0x78, 0x32, 0x76, 0x77]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x32] == 0x77
+
+    def test_mov_dptr_imm16(self):
+        prog = bytes([0x90, 0x12, 0x34]) + HALT   # MOV DPTR, #0x1234
+        sim = run(prog)
+        assert sim._iram[SFR_DPH] == 0x12
+        assert sim._iram[SFR_DPL] == 0x34
+
+
+class TestMOVX:
+    def test_movx_a_at_dptr(self):
+        sim = I8051Simulator()
+        sim.load(bytes([0x90, 0x10, 0x00,   # MOV DPTR, #0x1000
+                        0xE0]) + HALT)        # MOVX A, @DPTR
+        sim._xdata[0x1000] = 0x9F
+        for _ in range(3): sim.step()
+        assert sim._iram[SFR_ACC] == 0x9F
+
+    def test_movx_at_dptr_a(self):
+        prog = bytes([0x74, 0x55,             # MOV A, #0x55
+                      0x90, 0x20, 0x00,       # MOV DPTR, #0x2000
+                      0xF0]) + HALT           # MOVX @DPTR, A
+        sim = run(prog)
+        assert sim._xdata[0x2000] == 0x55
+
+    def test_movx_a_at_ri(self):
+        sim = I8051Simulator()
+        sim.load(bytes([0x78, 0x08,    # MOV R0, #0x08
+                        0xE2]) + HALT)  # MOVX A, @R0
+        sim._xdata[0x08] = 0xBB
+        for _ in range(3): sim.step()
+        assert sim._iram[SFR_ACC] == 0xBB
+
+    def test_movx_at_ri_a(self):
+        prog = bytes([0x74, 0xCC,      # MOV A, #0xCC
+                      0x78, 0x10,      # MOV R0, #0x10
+                      0xF2]) + HALT    # MOVX @R0, A
+        sim = run(prog)
+        assert sim._xdata[0x10] == 0xCC
+
+
+class TestMOVC:
+    def test_movc_a_at_a_plus_dptr(self):
+        # MOV A, #2; MOV DPTR, #0x100; MOVC A, @A+DPTR  → code[0x102]
+        prog = bytes([0x74, 0x02,          # MOV A, #2
+                      0x90, 0x01, 0x00,    # MOV DPTR, #0x100
+                      0x93]) + HALT        # MOVC A, @A+DPTR
+        sim = I8051Simulator()
+        sim.load(prog)
+        sim._code[0x0102] = 0x77
+        for _ in range(4): sim.step()
+        assert sim._iram[SFR_ACC] == 0x77
+
+    def test_movc_a_at_a_plus_pc(self):
+        # MOVC A, @A+PC reads code[PC_after_0x83 + A]
+        # Encode: MOV A, #1; MOVC A, @A+PC → PC after 0x83 = 4; reads code[5]
+        prog = bytearray([0x74, 0x01,   # 0x00: MOV A, #1  (2 bytes)
+                          0x83,          # 0x02: MOVC A, @A+PC; PC becomes 0x03; EA=0x03+1=0x04
+                          0xA5,          # 0x03: HALT (will halt)
+                          0xFF])         # 0x04: lookup value
+        # Wait: after MOVC fetch, PC=0x03; A=1; EA=0x03+1=0x04 → code[4]=0xFF
+        prog[4] = 0xEE
+        sim = I8051Simulator()
+        sim.load(bytes(prog))
+        sim.step()   # MOV A, #1
+        sim.step()   # MOVC A, @A+PC
+        assert sim._iram[SFR_ACC] == 0xEE
+
+
+class TestPushPop:
+    def test_push_pop_roundtrip(self):
+        # MOV A, #0xAB; MOV 0x30, A; PUSH 0x30; POP 0x31
+        prog = bytes([0x74, 0xAB,   # MOV A, #0xAB
+                      0xF5, 0x30,   # MOV 0x30, A
+                      0xC0, 0x30,   # PUSH 0x30
+                      0xD0, 0x31]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x31] == 0xAB
+        assert sim._iram[SFR_SP] == 0x07   # SP returned to initial value
+
+    def test_push_increments_sp(self):
+        prog = bytes([0x75, 0x30, 0x42,   # MOV 0x30, #0x42
+                      0xC0, 0x30]) + HALT  # PUSH 0x30
+        sim = run(prog)
+        assert sim._iram[SFR_SP] == 0x08   # 0x07 → 0x08
+
+
+class TestXCH:
+    def test_xch_a_rn(self):
+        # MOV A, #0x11; MOV R2, #0x22; XCH A, R2
+        prog = bytes([0x74, 0x11, 0x7A, 0x22, 0xCA]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x22
+        assert sim._rn(2) == 0x11
+
+    def test_xch_a_dir(self):
+        # MOV A,#0xAA; MOV 0x30,#0xBB; XCH A,0x30 → A=0xBB, iram[0x30]=0xAA
+        prog = bytes([0x74, 0xAA, 0x75, 0x30, 0xBB, 0xC5, 0x30]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xBB
+        assert sim._iram[0x30] == 0xAA
+
+    def test_xchd_nibble_swap(self):
+        # MOV A, #0xAF; MOV R0, #0x30; MOV @R0, #0x5B; XCHD A, @R0
+        # A.lo=F ↔ [0x30].lo=B → A=0xAB, [0x30]=0x5F
+        prog = bytes([0x74, 0xAF,    # MOV A, #0xAF
+                      0x78, 0x30,    # MOV R0, #0x30
+                      0x76, 0x5B,    # MOV @R0, #0x5B
+                      0xD6]) + HALT  # XCHD A, @R0
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xAB
+        assert sim._iram[0x30] == 0x5F
+
+
+# ── Arithmetic ────────────────────────────────────────────────────────────────
+
+class TestADD:
+    def test_add_a_rn_no_carry(self):
+        prog = bytes([0x74, 0x10, 0x78, 0x20, 0x28]) + HALT  # A=0x10; R0=0x20; ADD A,R0
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x30
+        assert not (sim._iram[SFR_PSW] & 0x80)   # CY=0
+
+    def test_add_a_imm_carry(self):
+        prog = bytes([0x74, 0xFF, 0x24, 0x01]) + HALT  # A=0xFF; ADD A,#1
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x00
+        assert sim._iram[SFR_PSW] & 0x80   # CY=1
+
+    def test_add_a_dir(self):
+        # MOV 0x30,#5; MOV A,#0x10; ADD A,0x30 → A=0x15
+        prog = bytes([0x75, 0x30, 0x05, 0x74, 0x10, 0x25, 0x30]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x15
+
+    def test_addc_uses_carry(self):
+        # A=0x01, CY=1; ADDC A, #0x01 → A=3
+        sim = I8051Simulator()
+        sim.load(bytes([0x74, 0x01, 0x34, 0x01]) + HALT)
+        sim._iram[SFR_PSW] |= 0x80  # set CY before load (load resets — must set after)
+        sim.load(bytes([0x74, 0x01, 0x34, 0x01]) + HALT)
+        sim._iram[SFR_PSW] |= 0x80   # set CY after load
+        sim.step(); sim.step(); sim.step()
+        assert sim._iram[SFR_ACC] == 3
+
+    def test_add_auxiliary_carry(self):
+        # 0x08 + 0x08 = 0x10; AC = carry from bit 3 to 4 → 1
+        prog = bytes([0x74, 0x08, 0x24, 0x08]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x40   # AC=1
+
+    def test_add_overflow(self):
+        # 0x7F + 0x01 = 0x80; signed overflow (positive + positive = negative)
+        prog = bytes([0x74, 0x7F, 0x24, 0x01]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x04   # OV=1
+
+
+class TestSUBB:
+    def test_subb_basic(self):
+        prog = bytes([0x74, 0x10, 0x94, 0x05]) + HALT  # A=0x10; SUBB A,#5 (CY=0)
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x0B
+        assert not (sim._iram[SFR_PSW] & 0x80)   # no borrow
+
+    def test_subb_borrow(self):
+        prog = bytes([0x74, 0x00, 0x94, 0x01]) + HALT  # A=0; SUBB A,#1 → borrow
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xFF
+        assert sim._iram[SFR_PSW] & 0x80   # CY=1 (borrow)
+
+    def test_subb_uses_carry(self):
+        sim = I8051Simulator()
+        sim.load(bytes([0x74, 0x05, 0x94, 0x02]) + HALT)  # A=5; SUBB A,#2
+        sim._iram[SFR_PSW] |= 0x80   # CY=1 (borrow in)
+        sim.step(); sim.step(); sim.step()
+        assert sim._iram[SFR_ACC] == 2  # 5 - 2 - 1 = 2
+
+
+class TestINCDEC:
+    def test_inc_a_no_flags(self):
+        prog = bytes([0x74, 0x05, 0x04]) + HALT  # MOV A,#5; INC A
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 6
+        assert sim._iram[SFR_PSW] == 0  # no flags changed
+
+    def test_inc_a_wraps(self):
+        prog = bytes([0x74, 0xFF, 0x04]) + HALT  # MOV A,#0xFF; INC A
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x00
+        assert not (sim._iram[SFR_PSW] & 0x80)  # no CY set by INC
+
+    def test_inc_rn(self):
+        prog = bytes([0x7A, 0x09, 0x0A]) + HALT  # MOV R2,#9; INC R2
+        sim = run(prog)
+        assert sim._rn(2) == 10
+
+    def test_dec_a(self):
+        prog = bytes([0x74, 0x05, 0x14]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 4
+
+    def test_dec_rn(self):
+        prog = bytes([0x79, 0x03, 0x19]) + HALT  # MOV R1,#3; DEC R1
+        sim = run(prog)
+        assert sim._rn(1) == 2
+
+    def test_inc_dptr(self):
+        prog = bytes([0x90, 0x00, 0xFF, 0xA3]) + HALT  # MOV DPTR,#0xFF; INC DPTR
+        sim = run(prog)
+        assert sim._iram[SFR_DPH] == 0x01
+        assert sim._iram[SFR_DPL] == 0x00
+
+    def test_inc_dir(self):
+        prog = bytes([0x75, 0x30, 0x0A, 0x05, 0x30]) + HALT  # MOV 0x30,#10; INC 0x30
+        sim = run(prog)
+        assert sim._iram[0x30] == 11
+
+    def test_dec_dir(self):
+        prog = bytes([0x75, 0x30, 0x05, 0x15, 0x30]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x30] == 4
+
+
+class TestMulDiv:
+    def test_mul_ab(self):
+        # A=0x12, B=0x10; MUL AB → product=0x0120; A=0x20, B=0x01
+        prog = bytes([0x74, 0x12,    # MOV A, #0x12
+                      0x75, SFR_B, 0x10,  # MOV B, #0x10
+                      0xA4]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x20
+        assert sim._iram[SFR_B]   == 0x01
+        assert sim._iram[SFR_PSW] & 0x04   # OV=1 (B≠0 after, product>0xFF)
+        assert not (sim._iram[SFR_PSW] & 0x80)  # CY=0 always
+
+    def test_mul_small(self):
+        # A=2, B=3; product=6; A=6, B=0; OV=0
+        prog = bytes([0x74, 0x02,
+                      0x75, SFR_B, 0x03,
+                      0xA4]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 6
+        assert sim._iram[SFR_B]   == 0
+        assert not (sim._iram[SFR_PSW] & 0x04)   # OV=0
+
+    def test_div_ab(self):
+        # A=17, B=5; quotient=3, remainder=2
+        prog = bytes([0x74, 17,
+                      0x75, SFR_B, 5,
+                      0x84]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 3
+        assert sim._iram[SFR_B]   == 2
+        assert not (sim._iram[SFR_PSW] & 0x04)   # OV=0
+        assert not (sim._iram[SFR_PSW] & 0x80)   # CY=0
+
+    def test_div_by_zero(self):
+        # B=0; OV should be set
+        prog = bytes([0x74, 0x10,
+                      0x75, SFR_B, 0x00,
+                      0x84]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x04   # OV=1
+        assert not (sim._iram[SFR_PSW] & 0x80)   # CY=0
+
+
+class TestDA:
+    def test_da_corrects_bcd(self):
+        # 0x28 + 0x47 = 0x6F; DA → adds 6 to low nibble → 0x75 (BCD 75)
+        prog = bytes([0x74, 0x28, 0x24, 0x47, 0xD4]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x75
+
+    def test_da_with_carry(self):
+        # 0x58 + 0x46 = 0x9E; DA → adds 0x66 → 0x04, CY=1 (BCD 104)
+        prog = bytes([0x74, 0x58, 0x24, 0x46, 0xD4]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x04
+        assert sim._iram[SFR_PSW] & 0x80   # CY=1
+
+
+# ── Logic ─────────────────────────────────────────────────────────────────────
+
+class TestLogic:
+    def test_anl_a_imm(self):
+        prog = bytes([0x74, 0xFF, 0x54, 0x0F]) + HALT  # A=0xFF; ANL A,#0x0F
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x0F
+
+    def test_orl_a_imm(self):
+        prog = bytes([0x74, 0x00, 0x44, 0xF0]) + HALT  # A=0; ORL A,#0xF0
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xF0
+
+    def test_xrl_a_imm(self):
+        prog = bytes([0x74, 0xFF, 0x64, 0x0F]) + HALT  # A=0xFF; XRL A,#0x0F
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xF0
+
+    def test_clr_a(self):
+        prog = bytes([0x74, 0xAB, 0xE4]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0
+
+    def test_cpl_a(self):
+        prog = bytes([0x74, 0x0F, 0xF4]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xF0
+
+    def test_anl_dir_a(self):
+        # MOV 0x30,#0xFF; MOV A,#0x0F; ANL 0x30,A → 0x30=0x0F
+        prog = bytes([0x75, 0x30, 0xFF, 0x74, 0x0F, 0x52, 0x30]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x30] == 0x0F
+
+    def test_orl_dir_imm(self):
+        prog = bytes([0x75, 0x30, 0x0F, 0x43, 0x30, 0xF0]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x30] == 0xFF
+
+    def test_xrl_dir_a(self):
+        # MOV 0x30,#0xFF; MOV A,#0xAA; XRL 0x30,A → 0x30=0x55
+        prog = bytes([0x75, 0x30, 0xFF, 0x74, 0xAA, 0x62, 0x30]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x30] == 0x55
+
+
+class TestRotate:
+    def test_rl_a(self):
+        prog = bytes([0x74, 0x81, 0x23]) + HALT  # A=0x81; RL A → 0x03
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x03
+
+    def test_rr_a(self):
+        prog = bytes([0x74, 0x81, 0x03]) + HALT  # A=0x81; RR A → 0xC0
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xC0
+
+    def test_rlc_a_no_carry(self):
+        # A=0x40, CY=0; RLC → A=0x80, CY=0
+        prog = bytes([0xC3, 0x74, 0x40, 0x33]) + HALT  # CLR C; MOV A,#0x40; RLC A
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x80
+        assert not (sim._iram[SFR_PSW] & 0x80)
+
+    def test_rlc_a_with_carry(self):
+        # A=0x80, CY=0; RLC → A=0x00, CY=1
+        prog = bytes([0xC3, 0x74, 0x80, 0x33]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x00
+        assert sim._iram[SFR_PSW] & 0x80   # CY=1
+
+    def test_rrc_a(self):
+        # A=0x01, CY=0; RRC → A=0x00, CY=1
+        prog = bytes([0xC3, 0x74, 0x01, 0x13]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x00
+        assert sim._iram[SFR_PSW] & 0x80   # CY=1
+
+    def test_swap_a(self):
+        prog = bytes([0x74, 0xAB, 0xC4]) + HALT  # A=0xAB; SWAP → 0xBA
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xBA
+
+
+# ── Bit manipulation ──────────────────────────────────────────────────────────
+
+class TestBit:
+    def test_setb_c(self):
+        prog = bytes([0xD3]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x80
+
+    def test_clr_c(self):
+        prog = bytes([0xD3, 0xC3]) + HALT  # SETB C; CLR C
+        sim = run(prog)
+        assert not (sim._iram[SFR_PSW] & 0x80)
+
+    def test_cpl_c(self):
+        prog = bytes([0xD3, 0xB3]) + HALT  # SETB C; CPL C
+        sim = run(prog)
+        assert not (sim._iram[SFR_PSW] & 0x80)
+
+    def test_setb_bit_in_ram(self):
+        # Bit 0x00 → byte 0x20, bit 0; SETB 0x00
+        prog = bytes([0xD2, 0x00]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x20] & 0x01
+
+    def test_clr_bit_in_ram(self):
+        sim = I8051Simulator()
+        sim.load(bytes([0xC2, 0x00]) + HALT)
+        sim._iram[0x20] = 0xFF
+        sim.execute(bytes([0xC2, 0x00]) + HALT)
+        assert not (sim._iram[0x20] & 0x01)
+
+    def test_cpl_bit(self):
+        prog = bytes([0xD2, 0x04, 0xB2, 0x04]) + HALT  # SETB bit4; CPL bit4
+        sim = run(prog)
+        # bit4 = byte 0x20, bit4 position → bit 4 of byte 0x20
+        assert not (sim._iram[0x20] & (1 << 4))
+
+    def test_mov_c_bit(self):
+        # SETB bit3; MOV C, bit3 → CY=1
+        prog = bytes([0xD2, 0x03, 0xA2, 0x03]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x80
+
+    def test_mov_bit_c(self):
+        # SETB C; MOV bit5, C
+        prog = bytes([0xD3, 0x92, 0x05]) + HALT
+        sim = run(prog)
+        assert sim._iram[0x20] & (1 << 5)
+
+    def test_anl_c_bit_both_set(self):
+        # SETB C; SETB bit0; ANL C,bit0 → CY stays 1
+        prog = bytes([0xD3, 0xD2, 0x00, 0x82, 0x00]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x80
+
+    def test_anl_c_bit_bit_clear(self):
+        # SETB C; CLR bit0; ANL C,bit0 → CY=0
+        prog = bytes([0xD3, 0xC2, 0x00, 0x82, 0x00]) + HALT
+        sim = run(prog)
+        assert not (sim._iram[SFR_PSW] & 0x80)
+
+    def test_orl_c_bit(self):
+        # CLR C; SETB bit0; ORL C,bit0 → CY=1
+        prog = bytes([0xC3, 0xD2, 0x00, 0x72, 0x00]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x80
+
+    def test_anl_c_notbit(self):
+        # SETB C; SETB bit0; ANL C, /bit0 → CY = CY & ~bit0 = 1 & 0 = 0
+        prog = bytes([0xD3, 0xD2, 0x00, 0xB0, 0x00]) + HALT
+        sim = run(prog)
+        assert not (sim._iram[SFR_PSW] & 0x80)
+
+    def test_orl_c_notbit(self):
+        # CLR C; CLR bit0; ORL C, /bit0 → CY = CY | ~bit0 = 0 | 1 = 1
+        prog = bytes([0xC3, 0xC2, 0x00, 0xA0, 0x00]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x80
+
+
+# ── Branches ─────────────────────────────────────────────────────────────────
+
+class TestBranch:
+    def test_ljmp(self):
+        # LJMP 0x0010 → then MOV A,#0x42 → HALT at 0x0013
+        prog = bytearray(0x20)
+        prog[0] = 0x02; prog[1] = 0x00; prog[2] = 0x10   # LJMP 0x0010
+        prog[0x10] = 0x74; prog[0x11] = 0x42              # MOV A,#0x42
+        prog[0x12] = 0xA5                                  # HALT
+        sim = I8051Simulator().execute.__self__ if False else I8051Simulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._iram[SFR_ACC] == 0x42
+
+    def test_sjmp_forward(self):
+        # SJMP +2 (skip 2 bytes); NOP; NOP; MOV A,#0x55
+        prog = bytes([0x80, 0x02,    # SJMP +2 (skip 2 bytes: 0x02 and 0x03)
+                      0x74, 0x00,    # MOV A,#0 (skipped)
+                      0x74, 0x55]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x55
+
+    def test_sjmp_backward(self):
+        # Start at 0x00; MOV A,#0; SJMP to 0x00 (offset=-4 from after sjmp)
+        # After SJMP fetch PC=0x04; rel=-4 → 0x04 + (-4) = 0x00 → infinite loop
+        # But with max_steps=5 it stops
+        loop = bytes([0x74, 0x00,    # 0x00: MOV A,#0
+                      0x80, 0xFC]) + HALT  # 0x02: SJMP -4 (loops)
+        result = I8051Simulator().execute(loop, max_steps=5)
+        assert not result.ok  # max_steps exceeded
+
+    def test_jz_taken(self):
+        prog = bytes([0xE4, 0x60, 0x02, 0x74, 0xFF]) + HALT  # CLR A; JZ +2 skip bad; HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0   # 0xFF was skipped
+
+    def test_jz_not_taken(self):
+        prog = bytes([0x74, 0x01, 0x60, 0x02, 0xE4]) + bytes([0x74, 0x55]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x55
+
+    def test_jnz_taken(self):
+        # A=1; JNZ +1 → skip CLR A (1 byte at 0x04) → land at MOV A,#0x55 (0x05)
+        prog = bytes([0x74, 0x01,   # 0x00: MOV A,#1
+                      0x70, 0x01,   # 0x02: JNZ +1 (skip 0x04: CLR A)
+                      0xE4,         # 0x04: CLR A (skipped)
+                      0x74, 0x55])  + HALT  # 0x05: MOV A,#0x55
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x55
+
+    def test_jc_taken(self):
+        # A=0xFF; ADD A,#1 (sets CY); JC +2 skip; MOV A,#0; → final A=0
+        prog = bytes([0x74, 0xFF, 0x24, 0x01, 0x40, 0x02, 0x74, 0x00]) + HALT
+        # JC taken → skip MOV A,#0 → A stays 0 from addition
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x00
+
+    def test_jnc_taken(self):
+        prog = bytes([0xC3, 0x50, 0x02, 0x74, 0xFF]) + HALT  # CLR C; JNC +2 skip; →HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x00  # 0xFF was skipped
+
+    def test_jb_taken(self):
+        # SETB bit0; JB bit0, +2 (skip MOV A,#0xFF)
+        prog = bytes([0xD2, 0x00, 0x20, 0x00, 0x02, 0x74, 0xFF]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x00
+
+    def test_jnb_taken(self):
+        # CLR bit0; JNB bit0, +2 (skip MOV A,#0xFF)
+        prog = bytes([0xC2, 0x00, 0x30, 0x00, 0x02, 0x74, 0xFF]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x00
+
+    def test_jbc_clears_bit_when_taken(self):
+        # SETB bit0; JBC bit0, +2; MOV A,#0xFF; HALT — bit0 must be cleared after JBC
+        prog = bytes([0xD2, 0x00, 0x10, 0x00, 0x02, 0x74, 0xFF]) + HALT
+        sim = run(prog)
+        assert not (sim._iram[0x20] & 0x01)
+        assert sim._iram[SFR_ACC] == 0x00   # skip happened
+
+    def test_cjne_a_imm_taken(self):
+        # A=5; CJNE A,#10,+2 → taken (skip MOV A,#0xFF)
+        prog = bytes([0x74, 0x05, 0xB4, 0x0A, 0x02, 0x74, 0xFF]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x05
+
+    def test_cjne_a_imm_not_taken(self):
+        # A=10; CJNE A,#10,+2 → not taken → execute MOV A,#0xFF
+        prog = bytes([0x74, 0x0A, 0xB4, 0x0A, 0x02, 0x74, 0xFF]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xFF
+
+    def test_cjne_sets_cy_when_less(self):
+        # A=3; CJNE A,#5,rel → CY=1 (3<5)
+        prog = bytes([0x74, 0x03, 0xB4, 0x05, 0x00]) + HALT  # rel=0 → stay
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x80   # CY=1
+
+    def test_cjne_rn_imm(self):
+        # R0=3; CJNE R0,#3,+2 → not taken (equal) → fall through to MOV A,#0xAA
+        prog = bytes([0x78, 0x03, 0xB8, 0x03, 0x02, 0x74, 0x00, 0x74, 0xAA]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0xAA
+
+    def test_djnz_rn(self):
+        # R0=3; loop: DEC via DJNZ back to MOV A each iter; A accumulates
+        # MOV R0,#3; Loop: INC A; DJNZ R0, Loop
+        # loop is at offset 2 from start; DJNZ at offset 4
+        # After DJNZ fetch (PC=6); rel = 2-6 = -4 signed → 0xFC
+        prog = bytes([0x78, 0x03,    # 0x00: MOV R0,#3
+                      0x04,          # 0x02: INC A
+                      0xD8, 0xFD]) + HALT  # 0x03: DJNZ R0,-3 → 0x05+(-3)=0x02
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 3
+
+    def test_djnz_dir(self):
+        # MOV 0x30,#2; Loop(0x03): INC A; DJNZ 0x30, Loop
+        # DJNZ dir at 0x04: after fetch PC=0x07; rel=-4 → 0xFC → target=0x03 ✓
+        prog = bytes([0x75, 0x30, 0x02,    # 0x00: MOV 0x30, #2
+                      0x04,                # 0x03: INC A  (loop top)
+                      0xD5, 0x30, 0xFC]) + HALT  # 0x04: DJNZ 0x30, -4 (to 0x03)
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 2
+
+    def test_jmp_at_a_plus_dptr(self):
+        # MOV DPTR,#0x10; MOV A,#2; JMP @A+DPTR → PC=0x12; MOV A,#0x55 at 0x12
+        prog = bytearray(0x20)
+        prog[0] = 0x90; prog[1] = 0x00; prog[2] = 0x10   # MOV DPTR, #0x10
+        prog[3] = 0x74; prog[4] = 0x02                    # MOV A, #2
+        prog[5] = 0x73                                     # JMP @A+DPTR → 0x12
+        prog[0x12] = 0x74; prog[0x13] = 0x55              # MOV A, #0x55
+        prog[0x14] = 0xA5                                  # HALT
+        sim = I8051Simulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._iram[SFR_ACC] == 0x55
+
+
+# ── Subroutines ───────────────────────────────────────────────────────────────
+
+class TestSubroutines:
+    def test_lcall_ret(self):
+        # at 0x00: MOV A,#0; LCALL 0x10; (A should become 0x42 from sub)
+        # at 0x10: MOV A,#0x42; RET
+        prog = bytearray(0x20)
+        prog[0] = 0x74; prog[1] = 0x00   # MOV A, #0
+        prog[2] = 0x12; prog[3] = 0x00; prog[4] = 0x10   # LCALL 0x0010
+        prog[5] = 0xA5   # HALT
+        prog[0x10] = 0x74; prog[0x11] = 0x42   # MOV A, #0x42
+        prog[0x12] = 0x22   # RET
+        sim = I8051Simulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._iram[SFR_ACC] == 0x42
+        assert sim._iram[SFR_SP] == 0x07   # SP restored
+
+    def test_nested_lcall_ret(self):
+        # Outer call at 0x00; inner call at 0x10; leaf at 0x20
+        prog = bytearray(0x30)
+        prog[0] = 0x12; prog[1] = 0x00; prog[2] = 0x10   # LCALL 0x10
+        prog[3] = 0xA5   # HALT
+        prog[0x10] = 0x12; prog[0x11] = 0x00; prog[0x12] = 0x20  # LCALL 0x20
+        prog[0x13] = 0x22   # RET from outer sub
+        prog[0x20] = 0x74; prog[0x21] = 0x77   # MOV A, #0x77
+        prog[0x22] = 0x22   # RET from leaf
+        sim = I8051Simulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._iram[SFR_ACC] == 0x77
+        assert sim._iram[SFR_SP] == 0x07
+
+    def test_reti_acts_like_ret(self):
+        prog = bytearray(0x20)
+        prog[0] = 0x12; prog[1] = 0x00; prog[2] = 0x10   # LCALL 0x10
+        prog[3] = 0xA5   # HALT
+        prog[0x10] = 0x74; prog[0x11] = 0x55   # MOV A, #0x55
+        prog[0x12] = 0x32   # RETI
+        sim = I8051Simulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._iram[SFR_ACC] == 0x55
+
+
+# ── Parity ────────────────────────────────────────────────────────────────────
+
+class TestParity:
+    def test_parity_one_bit(self):
+        # A=0x01 (1 set bit → odd → P=1)
+        prog = bytes([0x74, 0x01]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_PSW] & 0x01   # P=1
+
+    def test_parity_two_bits(self):
+        # A=0x03 (2 set bits → even → P=0)
+        prog = bytes([0x74, 0x03]) + HALT
+        sim = run(prog)
+        assert not (sim._iram[SFR_PSW] & 0x01)
+
+    def test_parity_zero(self):
+        prog = bytes([0xE4]) + HALT  # CLR A → P=0
+        sim = run(prog)
+        assert not (sim._iram[SFR_PSW] & 0x01)

--- a/code/packages/python/intel8051-simulator/tests/test_programs.py
+++ b/code/packages/python/intel8051-simulator/tests/test_programs.py
@@ -1,0 +1,307 @@
+"""End-to-end program tests for the Intel 8051 simulator.
+
+Each test encodes a complete small program in 8051 machine code and verifies
+the final CPU/memory state.  These tests exercise the instructions working
+together rather than in isolation.
+
+8051 registers used by programs:
+  R0–R7  — working registers (bank 0, addresses 0x00–0x07)
+  A      — accumulator (SFR 0xE0)
+  B      — secondary register (SFR 0xF0)
+  DPTR   — 16-bit data pointer (SFR 0x82/0x83)
+  SP     — stack pointer (SFR 0x81), reset value 0x07
+
+Label resolution: all programs here use absolute addresses because the
+machine code is assembled by hand.  Branch offsets are signed 8-bit values
+relative to PC-after-instruction.  For a 2-byte branch instruction (opcode +
+rel) at address A, target = (A + 2) + rel.
+"""
+
+from __future__ import annotations
+
+from intel8051_simulator import I8051Simulator
+from intel8051_simulator.state import SFR_ACC, SFR_PSW, SFR_SP
+
+HALT = bytes([0xA5])
+
+
+def run(prog: bytes) -> I8051Simulator:
+    sim = I8051Simulator()
+    sim.execute(prog)
+    return sim
+
+
+# ── Arithmetic programs ───────────────────────────────────────────────────────
+
+class TestSumProgram:
+    def test_sum_1_to_10(self):
+        """Compute 1+2+…+10 = 55 using DJNZ.
+
+        Register layout:
+          R0 = counter (10 down to 1)
+          A  = running sum (starts 0)
+
+        Program (each line is one instruction):
+          0x00: MOV R0, #10      (0x78 0x0A)
+          0x02: ADD A, R0        (0x28)        — A += R0
+          0x03: DJNZ R0, -3      (0xD8 0xFD)  — R0--; if R0≠0 goto 0x02
+          0x05: HALT             (0xA5)
+
+        PC after DJNZ fetch = 0x05; rel=0xFD=-3; target=0x05-3=0x02 ✓
+        """
+        prog = bytes([
+            0x78, 0x0A,    # 0x00: MOV R0, #10
+            0x28,          # 0x02: ADD A, R0
+            0xD8, 0xFD,    # 0x03: DJNZ R0, -3 (to 0x02)
+            0xA5,          # 0x05: HALT
+        ])
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 55
+
+    def test_sum_bytes_in_iram(self):
+        """Sum 4 bytes stored at iram[0x30–0x33].
+
+        Uses indirect addressing: R0 as pointer, R1 as counter.
+
+        Layout:
+          0x00: MOV R0, #0x30     — pointer
+          0x02: MOV R1, #4        — counter
+          0x04: ADD A, @R0        — A += [R0]
+          0x05: INC R0            — advance pointer
+          0x06: DJNZ R1, -4      — R1--; if ≠0 goto 0x04
+          0x08: HALT
+        """
+        prog = bytes([
+            0x78, 0x30,    # 0x00: MOV R0, #0x30
+            0x79, 0x04,    # 0x02: MOV R1, #4
+            0x26,          # 0x04: ADD A, @R0
+            0x08,          # 0x05: INC R0
+            0xD9, 0xFC,    # 0x06: DJNZ R1, -4 (to 0x04)
+            0xA5,          # 0x08: HALT
+        ])
+        sim = I8051Simulator()
+        sim.load(prog)
+        # Set iram data AFTER load() (load calls reset which zeroes iram)
+        sim._iram[0x30] = 10
+        sim._iram[0x31] = 20
+        sim._iram[0x32] = 30
+        sim._iram[0x33] = 40
+        # Step through manually (don't call execute() which would call load/reset again)
+        while not sim._halted:
+            sim.step()
+        assert sim._iram[SFR_ACC] == 100
+
+
+class TestMultiply:
+    def test_multiply_by_repeated_addition(self):
+        """Multiply 7 × 6 = 42 using repeated addition.
+
+        R0 = multiplier (6)
+        A  = result, start 0
+        Loop: A += 7; DJNZ R0 back
+
+          0x00: MOV R0, #6
+          0x02: ADD A, #7
+          0x04: DJNZ R0, -4  (target: 0x04+2-4=0x02)
+          0x06: HALT
+        """
+        prog = bytes([
+            0x78, 0x06,    # MOV R0, #6
+            0x24, 0x07,    # ADD A, #7
+            0xD8, 0xFC,    # DJNZ R0, -4
+            0xA5,
+        ])
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 42
+
+    def test_mul_ab_factorial_5(self):
+        """Compute 5! = 120 using MUL AB.
+
+        Strategy: accumulate in B, then move to A each step.
+          A=1*2=2; A=2*3=6; A=6*4=24; A=24*5=120
+        But MUL AB does B:A = A*B, and our result fits in A (120 < 256).
+
+          0x00: MOV A, #1
+          0x02: MOV B, #2; MUL AB  → A=2, B=0
+          0x06: MOV B, #3; MUL AB  → A=6
+          0x0A: MOV B, #4; MUL AB  → A=24
+          0x0E: MOV B, #5; MUL AB  → A=120
+          0x12: HALT
+        """
+        from intel8051_simulator.state import SFR_B as B_SFR
+        prog = bytes([
+            0x74, 0x01,              # MOV A, #1
+            0x75, B_SFR, 0x02, 0xA4, # MOV B,#2; MUL AB
+            0x75, B_SFR, 0x03, 0xA4, # MOV B,#3; MUL AB
+            0x75, B_SFR, 0x04, 0xA4, # MOV B,#4; MUL AB
+            0x75, B_SFR, 0x05, 0xA4, # MOV B,#5; MUL AB
+            0xA5,
+        ])
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 120
+
+
+class TestStringCopy:
+    def test_copy_bytes_via_xdata(self):
+        """Copy 4 bytes from xdata[0x100] to xdata[0x200].
+
+        Uses MOVX with @Ri (R0=src, R1=dst, R2=count).
+        R0 and R1 are 8-bit, so src/dst must be in 0x00–0xFF.
+        Use xdata[0x00–0x03] → xdata[0x10–0x13].
+
+          0x00: MOV R0, #0x00       — src pointer
+          0x02: MOV R1, #0x10       — dst pointer
+          0x04: MOV R2, #4          — count
+          0x06: MOVX A, @R0         — A = xdata[R0]
+          0x07: MOVX @R1, A         — xdata[R1] = A
+          0x08: INC R0
+          0x09: INC R1
+          0x0A: DJNZ R2, -6  (to 0x06)
+          0x0C: HALT
+        """
+        prog = bytes([
+            0x78, 0x00,    # MOV R0, #0
+            0x79, 0x10,    # MOV R1, #0x10
+            0x7A, 0x04,    # MOV R2, #4
+            0xE2,          # MOVX A, @R0
+            0xF3,          # MOVX @R1, A
+            0x08,          # INC R0
+            0x09,          # INC R1
+            0xDA, 0xFA,    # DJNZ R2, -6 (PC=0x0C; 0x0C-6=0x06)
+            0xA5,
+        ])
+        sim = I8051Simulator()
+        sim.load(prog)
+        for i in range(4):
+            sim._xdata[i] = 0x10 + i
+        sim.execute(prog)
+        for i in range(4):
+            assert sim._xdata[0x10 + i] == 0x10 + i
+
+
+class TestSubroutinePrograms:
+    def test_simple_subroutine(self):
+        """Call a subroutine that doubles A.
+
+        Main at 0x00; subroutine at 0x10.
+          0x00: MOV A, #7
+          0x02: LCALL 0x10
+          0x05: HALT
+          (skips 0x05–0x0F)
+          0x10: ADD A, A  — but ADD A,A not in ISA; use ADD A,Rn
+                Actually: MOV R0,A; ADD A,R0  → double
+          0x10: MOV R0, A    (0xF8)
+          0x11: ADD A, R0   (0x28)
+          0x12: RET
+        """
+        prog = bytearray(0x20)
+        prog[0x00] = 0x74; prog[0x01] = 0x07   # MOV A, #7
+        prog[0x02] = 0x12; prog[0x03] = 0x00; prog[0x04] = 0x10  # LCALL 0x10
+        prog[0x05] = 0xA5   # HALT
+        prog[0x10] = 0xF8   # MOV R0, A
+        prog[0x11] = 0x28   # ADD A, R0
+        prog[0x12] = 0x22   # RET
+        sim = I8051Simulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._iram[SFR_ACC] == 14
+
+    def test_stack_balance(self):
+        """Nested call/return must leave SP at initial value (0x07)."""
+        prog = bytearray(0x30)
+        # Outer call
+        prog[0x00] = 0x12; prog[0x01] = 0x00; prog[0x02] = 0x10
+        prog[0x03] = 0xA5   # HALT
+        # Subroutine at 0x10: calls inner at 0x20, returns
+        prog[0x10] = 0x12; prog[0x11] = 0x00; prog[0x12] = 0x20
+        prog[0x13] = 0x22   # RET
+        # Inner at 0x20
+        prog[0x20] = 0x04   # INC A
+        prog[0x21] = 0x22   # RET
+        sim = I8051Simulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._iram[SFR_SP] == 0x07
+
+
+class TestFibonacci:
+    def test_fibonacci_8_terms(self):
+        """Store first 8 Fibonacci numbers in iram[0x30–0x37].
+
+        F = 1,1,2,3,5,8,13,21
+
+        Strategy: use R0/R1 as current/next; R2 as loop counter.
+          Store results to increasing addresses.
+
+          0x00: MOV 0x30, #1    — F[0]=1
+          0x03: MOV 0x31, #1    — F[1]=1
+          0x06: MOV R0, #0x30   — pointer to prev-prev
+          0x08: MOV R1, #0x31   — pointer to prev
+          0x0A: MOV R2, #6      — 6 more terms
+          Loop at 0x0C:
+          0x0C: MOV A, @R0      — A = F[i-2]
+          0x0D: ADD A, @R1      — A += F[i-1] = F[i]
+          0x0E: INC R0          — advance prev-prev pointer
+          0x0F: INC R1          — advance prev pointer
+          0x10: MOV @R1, A      — store F[i] (R1 now points at F[i])
+                Wait: R1 was at F[i-1] and we incremented it, so it now points
+                at F[i] (the next slot) — correct!
+          0x11: DJNZ R2, -7  (to 0x0C)
+          0x13: HALT
+        """
+        prog = bytes([
+            0x75, 0x30, 0x01,   # 0x00: MOV 0x30, #1
+            0x75, 0x31, 0x01,   # 0x03: MOV 0x31, #1
+            0x78, 0x30,         # 0x06: MOV R0, #0x30
+            0x79, 0x31,         # 0x08: MOV R1, #0x31
+            0x7A, 0x06,         # 0x0A: MOV R2, #6
+            # Loop top at 0x0C:
+            0xE4,               # 0x0C: CLR A        — reset accumulator each iteration
+            0x26,               # 0x0D: ADD A, @R0   — A = F[i-2]
+            0x27,               # 0x0E: ADD A, @R1   — A = F[i-2] + F[i-1] = F[i]
+            0x08,               # 0x0F: INC R0       — prev-prev pointer advances
+            0x09,               # 0x10: INC R1       — prev pointer advances (now points at F[i] slot)
+            0xF7,               # 0x11: MOV @R1, A   — store F[i]
+            0xDA, 0xF8,         # 0x12: DJNZ R2, -8 (PC=0x14; 0x14-8=0x0C) ✓
+            0xA5,               # 0x14: HALT
+        ])
+        sim = I8051Simulator()
+        result = sim.execute(prog)
+        assert result.ok
+        expected = [1, 1, 2, 3, 5, 8, 13, 21]
+        for i, v in enumerate(expected):
+            assert sim._iram[0x30 + i] == v, f"F[{i}]={sim._iram[0x30+i]}, expected {v}"
+
+
+class TestBCDAddition:
+    def test_bcd_add_two_digits(self):
+        """Add BCD 28 + 47 = 75 using DA A."""
+        prog = bytes([0x74, 0x28, 0x24, 0x47, 0xD4]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x75   # BCD 75
+
+    def test_bcd_add_with_carry_propagation(self):
+        """Add BCD 56 + 78 = 134.  Result in A=0x34, CY=1."""
+        prog = bytes([0x74, 0x56, 0x24, 0x78, 0xD4]) + HALT
+        sim = run(prog)
+        assert sim._iram[SFR_ACC] == 0x34
+        assert sim._iram[SFR_PSW] & 0x80   # CY=1 → hundreds digit is 1
+
+
+class TestLookupTable:
+    def test_movc_lookup_table(self):
+        """Read a 4-entry lookup table from code memory using MOVC A,@A+DPTR.
+
+        Table at code[0x10]: [10, 20, 30, 40]
+        Test: A=2; DPTR=0x10; MOVC A,@A+DPTR → A = code[0x12] = 30
+        """
+        prog = bytearray(0x20)
+        prog[0x00] = 0x74; prog[0x01] = 0x02   # MOV A, #2
+        prog[0x02] = 0x90; prog[0x03] = 0x00; prog[0x04] = 0x10  # MOV DPTR, #0x10
+        prog[0x05] = 0x93   # MOVC A, @A+DPTR
+        prog[0x06] = 0xA5   # HALT
+        prog[0x10] = 10; prog[0x11] = 20; prog[0x12] = 30; prog[0x13] = 40
+        sim = I8051Simulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._iram[SFR_ACC] == 30

--- a/code/packages/python/intel8051-simulator/tests/test_protocol.py
+++ b/code/packages/python/intel8051-simulator/tests/test_protocol.py
@@ -1,0 +1,275 @@
+"""SIM00 protocol compliance tests for I8051Simulator.
+
+Verifies that I8051Simulator implements the Simulator[I8051State] protocol
+correctly: reset(), load(), step(), execute(), get_state() all behave as
+specified.
+"""
+
+from __future__ import annotations
+
+import pytest
+from simulator_protocol import ExecutionResult, Simulator, StepTrace
+
+from intel8051_simulator import I8051Simulator, I8051State
+from intel8051_simulator.state import SFR_ACC, SFR_P0, SFR_P1, SFR_P2, SFR_P3, SFR_SP
+
+# ── Encoding helpers ──────────────────────────────────────────────────────────
+
+HALT = bytes([0xA5])   # HALT sentinel
+NOP  = bytes([0x00])   # NOP
+
+
+def MOV_A_IMM(v: int) -> bytes:
+    """MOV A, #v — load immediate into accumulator."""
+    return bytes([0x74, v])
+
+
+# ── Protocol compliance ───────────────────────────────────────────────────────
+
+class TestProtocolCompliance:
+    """I8051Simulator must satisfy Simulator[I8051State] structurally."""
+
+    def test_isinstance_simulator(self):
+        sim = I8051Simulator()
+        assert isinstance(sim, Simulator)
+
+    def test_has_all_protocol_methods(self):
+        sim = I8051Simulator()
+        assert callable(sim.reset)
+        assert callable(sim.load)
+        assert callable(sim.step)
+        assert callable(sim.execute)
+        assert callable(sim.get_state)
+
+    def test_execute_returns_execution_result(self):
+        sim = I8051Simulator()
+        result = sim.execute(HALT)
+        assert isinstance(result, ExecutionResult)
+
+    def test_step_returns_step_trace(self):
+        sim = I8051Simulator()
+        sim.load(NOP + HALT)
+        trace = sim.step()
+        assert isinstance(trace, StepTrace)
+
+    def test_get_state_returns_i8051state(self):
+        sim = I8051Simulator()
+        state = sim.get_state()
+        assert isinstance(state, I8051State)
+
+
+# ── Reset ─────────────────────────────────────────────────────────────────────
+
+class TestReset:
+    """reset() must return CPU to well-defined initial state."""
+
+    def test_reset_pc_is_zero(self):
+        sim = I8051Simulator()
+        sim._pc = 0x1234
+        sim.reset()
+        assert sim._pc == 0x0000
+
+    def test_reset_sp_is_0x07(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_SP] = 0xFF
+        sim.reset()
+        assert sim._iram[SFR_SP] == 0x07
+
+    def test_reset_acc_is_zero(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_ACC] = 0xAB
+        sim.reset()
+        assert sim._iram[SFR_ACC] == 0x00
+
+    def test_reset_psw_is_zero(self):
+        sim = I8051Simulator()
+        sim._iram[0xD0] = 0xFF
+        sim.reset()
+        assert sim._iram[0xD0] == 0x00
+
+    def test_reset_ports_are_0xff(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_P0] = 0x00
+        sim._iram[SFR_P1] = 0x00
+        sim.reset()
+        assert sim._iram[SFR_P0] == 0xFF
+        assert sim._iram[SFR_P1] == 0xFF
+        assert sim._iram[SFR_P2] == 0xFF
+        assert sim._iram[SFR_P3] == 0xFF
+
+    def test_reset_clears_halted(self):
+        sim = I8051Simulator()
+        sim._halted = True
+        sim.reset()
+        assert not sim._halted
+
+    def test_reset_iram_zeroed(self):
+        sim = I8051Simulator()
+        sim._iram[0x30] = 0xAB
+        sim.reset()
+        assert sim._iram[0x30] == 0x00
+
+    def test_reset_via_get_state(self):
+        sim = I8051Simulator()
+        state = sim.get_state()
+        assert state.pc == 0x0000
+        assert state.sp == 0x07
+        assert state.psw == 0x00
+        assert not state.halted
+
+
+# ── Load ──────────────────────────────────────────────────────────────────────
+
+class TestLoad:
+    """load() must reset and copy bytes to code memory at 0x0000."""
+
+    def test_load_places_bytes_at_0(self):
+        sim = I8051Simulator()
+        prog = bytes([0xAB, 0xCD, 0xEF])
+        sim.load(prog)
+        assert sim._code[0] == 0xAB
+        assert sim._code[1] == 0xCD
+        assert sim._code[2] == 0xEF
+
+    def test_load_sets_pc_to_zero(self):
+        sim = I8051Simulator()
+        sim.load(HALT)
+        assert sim._pc == 0x0000
+
+    def test_load_raises_on_overflow(self):
+        sim = I8051Simulator()
+        with pytest.raises(ValueError):
+            sim.load(bytes(65537))
+
+    def test_load_resets_before_loading(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_ACC] = 0xAB
+        sim.load(HALT)
+        assert sim._iram[SFR_ACC] == 0x00
+
+    def test_load_exactly_64k_ok(self):
+        sim = I8051Simulator()
+        sim.load(bytes(65536))   # should not raise
+
+
+# ── Execute ───────────────────────────────────────────────────────────────────
+
+class TestExecute:
+    """execute() must run to HALT and populate ExecutionResult correctly."""
+
+    def test_execute_halt_immediately(self):
+        sim = I8051Simulator()
+        result = sim.execute(HALT)
+        assert result.ok
+        assert result.halted
+        assert result.error is None
+        assert result.steps == 1
+
+    def test_execute_returns_traces(self):
+        sim = I8051Simulator()
+        result = sim.execute(HALT)
+        assert len(result.traces) == 1
+        assert result.traces[0].mnemonic == "HALT"
+
+    def test_execute_max_steps_exceeded(self):
+        # SJMP -2 loops forever (offset = 0xFE → signed = -2 → branch back to self)
+        loop = bytes([0x80, 0xFE])   # SJMP rel=-2 (infinite loop)
+        result = I8051Simulator().execute(loop + HALT, max_steps=10)
+        assert not result.ok
+        assert result.steps == 10
+        assert "max_steps" in result.error
+
+    def test_execute_sets_final_state(self):
+        sim = I8051Simulator()
+        result = sim.execute(HALT)
+        assert isinstance(result.final_state, I8051State)
+        assert result.final_state.halted
+
+    def test_execute_resets_before_running(self):
+        sim = I8051Simulator()
+        sim._iram[SFR_ACC] = 0xDE
+        result = sim.execute(HALT)
+        assert result.final_state.acc == 0
+
+    def test_execute_nop_then_halt(self):
+        result = I8051Simulator().execute(NOP + HALT)
+        assert result.ok
+        assert result.steps == 2
+        assert result.traces[0].mnemonic == "NOP"
+        assert result.traces[1].mnemonic == "HALT"
+
+
+# ── GetState ──────────────────────────────────────────────────────────────────
+
+class TestGetState:
+    """get_state() must return an immutable snapshot."""
+
+    def test_get_state_is_frozen(self):
+        import dataclasses
+        sim = I8051Simulator()
+        state = sim.get_state()
+        with pytest.raises((dataclasses.FrozenInstanceError, TypeError)):
+            state.pc = 0xFF   # type: ignore[misc]
+
+    def test_get_state_snapshot_not_mutated_by_step(self):
+        sim = I8051Simulator()
+        sim.load(NOP + HALT)
+        state_before = sim.get_state()
+        sim.step()
+        state_after = sim.get_state()
+        assert state_before.pc == 0x0000
+        assert state_after.pc == 0x0001
+
+    def test_get_state_iram_is_tuple(self):
+        sim = I8051Simulator()
+        state = sim.get_state()
+        assert isinstance(state.iram, tuple)
+        assert len(state.iram) == 256
+
+    def test_get_state_code_is_tuple(self):
+        sim = I8051Simulator()
+        state = sim.get_state()
+        assert isinstance(state.code, tuple)
+        assert len(state.code) == 65536
+
+    def test_get_state_xdata_is_tuple(self):
+        sim = I8051Simulator()
+        state = sim.get_state()
+        assert isinstance(state.xdata, tuple)
+        assert len(state.xdata) == 65536
+
+
+# ── Step ──────────────────────────────────────────────────────────────────────
+
+class TestStep:
+    """step() must advance PC and return correct StepTrace."""
+
+    def test_step_nop_advances_pc_by_1(self):
+        sim = I8051Simulator()
+        sim.load(NOP + HALT)
+        assert sim._pc == 0x0000
+        sim.step()
+        assert sim._pc == 0x0001
+
+    def test_step_on_halted_cpu_is_noop(self):
+        sim = I8051Simulator()
+        sim.load(HALT)
+        sim.step()    # executes HALT
+        assert sim._halted
+        pc = sim._pc
+        trace = sim.step()   # should be no-op
+        assert sim._pc == pc
+        assert trace.mnemonic == "HALT"
+
+    def test_step_trace_pc_before_after(self):
+        sim = I8051Simulator()
+        sim.load(NOP + HALT)
+        trace = sim.step()
+        assert trace.pc_before == 0x0000
+        assert trace.pc_after  == 0x0001
+
+    def test_step_2byte_instruction_advances_pc_by_2(self):
+        sim = I8051Simulator()
+        sim.load(bytes([0x74, 0x42]) + HALT)   # MOV A, #0x42
+        sim.step()
+        assert sim._pc == 0x0002

--- a/code/specs/07p-intel-8051-simulator.md
+++ b/code/specs/07p-intel-8051-simulator.md
@@ -1,0 +1,765 @@
+# Spec 07p — Intel 8051 Behavioral Simulator
+
+## Overview
+
+The **Intel 8051** (MCS-51, 1980) is an 8-bit microcontroller — Intel's first
+single-chip computer — and one of the most successful and widely manufactured
+silicon designs in history. Designed at Intel's Santa Clara facility, the 8051
+combined a CPU, RAM, ROM, timers, serial port, and I/O ports on a single chip.
+In doing so it defined the microcontroller as a product category.
+
+Historical milestones powered by the 8051:
+
+- **Intel MCS-51 family** (1980) — the original 8051, 8052, 8031, 8032 variants
+  established the architecture and split ROM-internal vs ROM-external variants
+- **Embedded systems everywhere** — industrial controllers, keyboards, modems,
+  printers, medical devices, toys, automotive engine management units
+- **Philips/NXP 80C51** — CMOS variant became a long-lived commodity part
+  widely used in embedded systems through the 2010s
+- **AT89S52** (Atmel, later Microchip) — a popular modern 8051-compatible
+  part still sold today as a learning platform
+- **Estimated production: > 20 billion units** — the 8051 ISA has been
+  implemented by more companies and fabricated in more units than any other
+  microprocessor architecture. It is genuinely the most-produced CPU design
+  in history.
+
+### Why the 8051 was revolutionary
+
+Before the 8051, building an embedded controller required a CPU chip, a
+separate RAM chip, a ROM chip, an I/O peripheral chip, and glue logic — a
+full printed circuit board just for a simple controller. The 8051 put all of
+this onto one package:
+
+| Feature              | External solution (pre-8051) | 8051 (single chip)          |
+|----------------------|------------------------------|-----------------------------|
+| CPU core             | Separate chip (e.g., 8080)   | Integrated                  |
+| Program memory       | Separate EPROM               | 4 KB internal ROM           |
+| Data memory          | Separate SRAM                | 128 bytes internal RAM      |
+| I/O ports            | Peripheral chip (e.g., 8255) | 32 bits over 4 ports (P0–P3)|
+| Serial port (UART)   | Separate USART chip          | Integrated full-duplex UART |
+| Timers               | Separate timer/counter chip  | 2 × 16-bit timers           |
+| Interrupt controller | Separate chip (e.g., 8259)   | Integrated (6 sources)      |
+
+This integration reduced BOM cost, board area, and power consumption by an
+order of magnitude, enabling an entirely new class of embedded product.
+
+The 8051 also introduced the **Harvard architecture** to the microcontroller
+world — separate address spaces for program (code) memory and data memory,
+allowing the CPU to fetch the next instruction and read data simultaneously.
+This differs from the von Neumann (Princeton) architecture used by most
+desktop processors, where code and data share one address space.
+
+This spec defines Layer **07p** — a Python behavioral simulator for the 8051
+following the SIM00 `Simulator[I8051State]` protocol.
+
+---
+
+## Architecture
+
+### Memory spaces
+
+The 8051 has **four distinct memory spaces**, each with independent address
+ranges and access semantics. This multiplicity is the defining characteristic
+of the 8051 and the most important thing to understand before studying its ISA.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     8051 Memory Map                                     │
+│                                                                         │
+│  Code Memory (64 KB, Harvard)    Data Memory (internal, 256 B)         │
+│  ┌─────────────────────────┐     ┌─────────────────────┐               │
+│  │  0x0000 – 0xFFFF        │     │  0x00 – 0x1F (32 B) │ Register banks│
+│  │  (external ROM/EPROM)   │     │  0x20 – 0x2F (16 B) │ Bit-addressable│
+│  │  0x0000 – 0x0FFF        │     │  0x30 – 0x7F (80 B) │ Scratch RAM   │
+│  │  (internal ROM, 4 KB)   │     │  0x80 – 0xFF (128 B)│ SFRs          │
+│  └─────────────────────────┘     └─────────────────────┘               │
+│                                                                         │
+│  External Data (XDATA, 64 KB)    Bit Space (128 bits)                  │
+│  ┌─────────────────────────┐     ┌─────────────────────┐               │
+│  │  0x0000 – 0xFFFF        │     │  bit 0x00 – 0x7F    │               │
+│  │  accessed via MOVX      │     │  (internal RAM 0x20)│               │
+│  └─────────────────────────┘     └─────────────────────┘               │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+#### Internal data memory (256 bytes)
+
+The 128-byte lower half (0x00–0x7F) is directly accessible by all data-memory
+instructions. The upper half (0x80–0xFF) is the **Special Function Register
+(SFR)** space — each address in this range is a hardware register, not RAM.
+Accessing 0x80–0xFF with a direct address hits the SFRs; accessing the same
+numeric range with an indirect address (@R0 / @R1) hits a second, separate
+upper RAM bank available on the 8052.
+
+#### Register banks
+
+The lower 32 bytes of internal RAM are divided into four 8-byte **register
+banks** (bank 0–3). Each bank provides 8 working registers named R0–R7.
+The active bank is selected by bits RS1:RS0 in the PSW. At reset, bank 0 is
+active (R0=0x00, R1=0x01, …, R7=0x07 in RAM).
+
+```
+Address  Bank 0  Bank 1  Bank 2  Bank 3
+0x00     R0      –       –       –
+0x01     R1      –       –       –
+...      ...
+0x07     R7      –       –       –
+0x08     –       R0      –       –
+...      ...
+0x0F     –       R7      –       –
+0x10     –       –       R0      –
+...      ...
+0x17     –       –       R7      –
+0x18     –       –       –       R0
+...      ...
+0x1F     –       –       –       R7
+```
+
+#### Bit-addressable area
+
+Internal RAM bytes 0x20–0x2F provide 128 individually addressable bits,
+numbered bit 0x00 (LSB of byte 0x20) through bit 0x7F (MSB of byte 0x2F).
+The SETB, CLR, CPL, MOV C,bit, MOV bit,C, JB, JNB, JBC instructions all
+operate on this 128-bit space plus the SFR bit addresses (0x80–0xFF).
+
+---
+
+### Registers
+
+#### Accumulator (ACC / A)
+
+The **accumulator** is the primary working register. It is the implicit
+source and/or destination for most arithmetic and logical operations. It
+occupies SFR address 0xE0 and is individually bit-addressable (bits ACC.0
+through ACC.7 map to SFR bits 0xE0–0xE7).
+
+#### B register
+
+The **B register** (SFR 0xF0) is the secondary operand for MUL AB and DIV
+AB. After MUL, the high byte of the 16-bit product is stored in B (low byte
+in A). After DIV, the remainder is stored in B (quotient in A). It is
+bit-addressable.
+
+#### Data pointer (DPTR)
+
+The **data pointer** is a 16-bit register formed by two 8-bit SFRs:
+- DPH (SFR 0x83) — high byte
+- DPL (SFR 0x82) — low byte
+
+DPTR is used as a 16-bit pointer for accessing external data memory (MOVX
+@DPTR) and code memory (MOVC A,@A+DPTR). It is the only 16-bit register on
+the 8051.
+
+#### Stack pointer (SP)
+
+The **stack pointer** (SFR 0x81) is an 8-bit register pointing into
+internal RAM. At reset, SP=0x07. The stack grows upward: PUSH increments SP
+then writes; POP reads then decrements SP. Unlike x86, the stack lives in
+internal RAM and is only 256 bytes deep at most. Practical stack depth is
+limited by the need to not overwrite register banks and bit-addressable area.
+
+#### Program counter (PC)
+
+The **program counter** (not in SFR space) is a 16-bit register pointing
+into code memory. At reset, PC=0x0000.
+
+#### Program status word (PSW)
+
+The **PSW** (SFR 0xD0) is an 8-bit status register. It is bit-addressable.
+
+```
+Bit  7    6    5    4    3    2    1    0
+     CY   AC   F0   RS1  RS0  OV   –    P
+```
+
+| Bit  | Name | Description                                                    |
+|------|------|----------------------------------------------------------------|
+| PSW.7| CY   | Carry flag. Set by addition carry-out, subtraction borrow.    |
+| PSW.6| AC   | Auxiliary carry. Carry from bit 3 to bit 4 (BCD arithmetic).  |
+| PSW.5| F0   | User-defined flag. No hardware effect.                         |
+| PSW.4| RS1  | Register bank select bit 1.                                    |
+| PSW.3| RS0  | Register bank select bit 0.                                    |
+| PSW.2| OV   | Overflow flag. Set by signed overflow or DIV by zero.         |
+| PSW.1| –    | Reserved (always 0).                                           |
+| PSW.0| P    | Parity flag. Even parity of ACC (hardware-computed).          |
+
+Register bank selection:
+
+| RS1 | RS0 | Active bank | RAM addresses |
+|-----|-----|-------------|---------------|
+|  0  |  0  | Bank 0      | 0x00–0x07     |
+|  0  |  1  | Bank 1      | 0x08–0x0F     |
+|  1  |  0  | Bank 2      | 0x10–0x17     |
+|  1  |  1  | Bank 3      | 0x18–0x1F     |
+
+---
+
+### Special function registers (SFRs)
+
+Addresses 0x80–0xFF in the direct-addressed data space are SFRs. The 8051
+defines 21 SFRs; addresses not listed are reserved (reads return 0xFF on
+real hardware). Our simulator implements the subset relevant to a behavioral
+simulation:
+
+| Address | Name | Reset | Description                          |
+|---------|------|-------|--------------------------------------|
+| 0x80    | P0   | 0xFF  | Port 0 latch                         |
+| 0x81    | SP   | 0x07  | Stack pointer                        |
+| 0x82    | DPL  | 0x00  | DPTR low byte                        |
+| 0x83    | DPH  | 0x00  | DPTR high byte                       |
+| 0x87    | PCON | 0x00  | Power control                        |
+| 0x88    | TCON | 0x00  | Timer/counter control                |
+| 0x89    | TMOD | 0x00  | Timer/counter mode                   |
+| 0x8A    | TL0  | 0x00  | Timer 0 low byte                     |
+| 0x8B    | TL1  | 0x00  | Timer 1 low byte                     |
+| 0x8C    | TH0  | 0x00  | Timer 0 high byte                    |
+| 0x8D    | TH1  | 0x00  | Timer 1 high byte                    |
+| 0x90    | P1   | 0xFF  | Port 1 latch                         |
+| 0x98    | SCON | 0x00  | Serial control                       |
+| 0x99    | SBUF | 0x00  | Serial data buffer                   |
+| 0xA0    | P2   | 0xFF  | Port 2 latch                         |
+| 0xA8    | IE   | 0x00  | Interrupt enable                     |
+| 0xB0    | P3   | 0xFF  | Port 3 latch                         |
+| 0xB8    | IP   | 0x00  | Interrupt priority                   |
+| 0xD0    | PSW  | 0x00  | Program status word                  |
+| 0xE0    | ACC  | 0x00  | Accumulator                          |
+| 0xF0    | B    | 0x00  | B register                           |
+
+The simulator treats SFR reads and writes as direct accesses to the internal
+SFR array (sfr[addr - 0x80]). Parity (PSW.P) is automatically recomputed
+after every operation that changes ACC.
+
+---
+
+## Addressing modes
+
+The 8051 supports 5 addressing modes. Each instruction specifies exactly
+which modes it accepts; unlike the PDP-11 orthogonal ISA, modes are hard-
+coded per opcode, not a field.
+
+### 1. Register addressing
+
+The operand is one of R0–R7 in the currently active register bank. The
+register number is encoded in the 3 low bits of the opcode.
+
+```
+ADD A, R2    ; A = A + R2
+```
+
+### 2. Direct addressing (dir)
+
+The operand is a byte at a directly specified 8-bit address. Addresses
+0x00–0x7F access internal RAM; addresses 0x80–0xFF access SFRs.
+
+```
+MOV A, 0x30  ; A = iram[0x30]
+MOV A, PSW   ; A = sfr[PSW]    (PSW = 0xD0)
+```
+
+### 3. Register-indirect addressing (@Ri)
+
+The operand is a byte in internal RAM pointed to by R0 or R1 (only these
+two are indirect pointers). For 8052 extended RAM (0x80–0xFF data), indirect
+addressing 0x80–0xFF reaches the upper 128 bytes of RAM (not SFRs).
+
+```
+MOV A, @R0   ; A = iram[R0]
+```
+
+### 4. Immediate addressing (#data)
+
+The operand is an 8-bit constant following the opcode byte in code memory.
+For 16-bit loads (MOV DPTR, #data16), a 16-bit immediate follows.
+
+```
+MOV A, #42   ; A = 42
+MOV DPTR, #0x8000  ; DPTR = 0x8000
+```
+
+### 5. Indexed addressing (@A+DPTR or @A+PC)
+
+Used only by MOVC (move code byte). The effective address is A + DPTR or
+A + PC (after the MOVC instruction's fetch). This provides read-only lookup
+table access into code memory.
+
+```
+MOVC A, @A+DPTR  ; A = code_memory[A + DPTR]
+```
+
+For external data memory (MOVX):
+
+```
+MOVX A, @DPTR    ; A = xdata[DPTR]
+MOVX @DPTR, A    ; xdata[DPTR] = A
+MOVX A, @Ri      ; A = xdata[Ri]  (8-bit address, high byte from P2)
+MOVX @Ri, A      ; xdata[Ri] = A
+```
+
+---
+
+## Instruction set
+
+### Encoding format
+
+The 8051 uses a single-byte opcode. Most instructions are 1, 2, or 3 bytes:
+
+- **1-byte**: opcode only (e.g., `NOP`, `CLR A`, `ADD A,R0`)
+- **2-byte**: opcode + operand (e.g., `ADD A,#imm8`, `ADD A,dir`)
+- **3-byte**: opcode + operand1 + operand2 (e.g., `MOV dir,dir`, `CJNE A,#imm8,rel`)
+
+Branch instructions use **relative** (signed 8-bit) or **absolute** 11-bit /
+16-bit offsets:
+
+- **SJMP / Jcc**: 8-bit signed relative offset (–128 to +127 from next PC)
+- **AJMP / ACALL**: 11-bit absolute address within current 2 KB page
+- **LJMP / LCALL**: 16-bit absolute address
+- **RET / RETI**: return from subroutine / interrupt
+
+### Data transfer
+
+| Mnemonic           | Encoding  | Bytes | Operation                              |
+|--------------------|-----------|-------|----------------------------------------|
+| MOV A, Rn          | 0xE8+n    | 1     | A ← Rn                                |
+| MOV A, dir         | 0xE5      | 2     | A ← iram[dir] or sfr[dir]             |
+| MOV A, @Ri         | 0xE6+i    | 1     | A ← iram[Ri]                          |
+| MOV A, #imm        | 0x74      | 2     | A ← imm                               |
+| MOV Rn, A          | 0xF8+n    | 1     | Rn ← A                                |
+| MOV Rn, dir        | 0xA8+n    | 2     | Rn ← iram[dir]                        |
+| MOV Rn, #imm       | 0x78+n    | 2     | Rn ← imm                              |
+| MOV dir, A         | 0xF5      | 2     | iram[dir] ← A                         |
+| MOV dir, Rn        | 0x88+n    | 2     | iram[dir] ← Rn                        |
+| MOV dir, dir2      | 0x85      | 3     | iram[dir] ← iram[dir2]  (src,dst order)|
+| MOV dir, @Ri       | 0x86+i    | 2     | iram[dir] ← iram[Ri]                  |
+| MOV dir, #imm      | 0x75      | 3     | iram[dir] ← imm                       |
+| MOV @Ri, A         | 0xF6+i    | 1     | iram[Ri] ← A                          |
+| MOV @Ri, dir       | 0xA6+i    | 2     | iram[Ri] ← iram[dir]                  |
+| MOV @Ri, #imm      | 0x76+i    | 2     | iram[Ri] ← imm                        |
+| MOV DPTR, #imm16   | 0x90      | 3     | DPTR ← imm16                          |
+| MOVC A, @A+DPTR    | 0x93      | 1     | A ← code[A + DPTR]                    |
+| MOVC A, @A+PC      | 0x83      | 1     | A ← code[A + PC]  (PC = addr after)   |
+| MOVX A, @Ri        | 0xE2+i    | 1     | A ← xdata[Ri]                         |
+| MOVX A, @DPTR      | 0xE0      | 1     | A ← xdata[DPTR]                       |
+| MOVX @Ri, A        | 0xF2+i    | 1     | xdata[Ri] ← A                         |
+| MOVX @DPTR, A      | 0xF0      | 1     | xdata[DPTR] ← A                       |
+| PUSH dir           | 0xC0      | 2     | SP++; iram[SP] ← iram[dir]            |
+| POP dir            | 0xD0      | 2     | iram[dir] ← iram[SP]; SP--            |
+| XCH A, Rn          | 0xC8+n    | 1     | A ↔ Rn                                |
+| XCH A, dir         | 0xC5      | 2     | A ↔ iram[dir]                         |
+| XCH A, @Ri         | 0xC6+i    | 1     | A ↔ iram[Ri]                          |
+| XCHD A, @Ri        | 0xD6+i    | 1     | Low nibble of A ↔ low nibble of iram[Ri]|
+
+**Note on MOV dir,dir2 operand order**: The encoding is `0x85 src dst`, so
+the second byte is source and third byte is destination. This is unusual among
+8-bit CPUs.
+
+### Arithmetic
+
+| Mnemonic           | Encoding  | Bytes | Operation                              |
+|--------------------|-----------|-------|----------------------------------------|
+| ADD A, Rn          | 0x28+n    | 1     | A ← A + Rn; set CY,AC,OV,P            |
+| ADD A, dir         | 0x25      | 2     | A ← A + iram[dir]                     |
+| ADD A, @Ri         | 0x26+i    | 1     | A ← A + iram[Ri]                      |
+| ADD A, #imm        | 0x24      | 2     | A ← A + imm                           |
+| ADDC A, Rn         | 0x38+n    | 1     | A ← A + Rn + CY; set CY,AC,OV,P      |
+| ADDC A, dir        | 0x35      | 2     | A ← A + iram[dir] + CY               |
+| ADDC A, @Ri        | 0x36+i    | 1     | A ← A + iram[Ri] + CY               |
+| ADDC A, #imm       | 0x34      | 2     | A ← A + imm + CY                     |
+| SUBB A, Rn         | 0x98+n    | 1     | A ← A – Rn – CY; set CY,AC,OV,P     |
+| SUBB A, dir        | 0x95      | 2     | A ← A – iram[dir] – CY              |
+| SUBB A, @Ri        | 0x96+i    | 1     | A ← A – iram[Ri] – CY              |
+| SUBB A, #imm       | 0x94      | 2     | A ← A – imm – CY                    |
+| INC A              | 0x04      | 1     | A ← A + 1 (no flags updated)         |
+| INC Rn             | 0x08+n    | 1     | Rn ← Rn + 1 (no flags)              |
+| INC dir            | 0x05      | 2     | iram[dir] ← iram[dir] + 1 (no flags)|
+| INC @Ri            | 0x06+i    | 1     | iram[Ri] ← iram[Ri] + 1             |
+| INC DPTR           | 0xA3      | 1     | DPTR ← DPTR + 1 (16-bit, no flags)  |
+| DEC A              | 0x14      | 1     | A ← A – 1 (no flags)                |
+| DEC Rn             | 0x18+n    | 1     | Rn ← Rn – 1 (no flags)             |
+| DEC dir            | 0x15      | 2     | iram[dir] ← iram[dir] – 1           |
+| DEC @Ri            | 0x16+i    | 1     | iram[Ri] ← iram[Ri] – 1            |
+| MUL AB             | 0xA4      | 1     | B:A ← A × B (unsigned); CY=0; OV= B≠0|
+| DIV AB             | 0x84      | 1     | A ← A ÷ B (quotient); B ← remainder  |
+|                    |           |       | CY=0; OV=1 if B=0 (division by zero) |
+| DA A               | 0xD4      | 1     | Decimal adjust A after BCD ADD        |
+
+**INC/DEC flag behavior**: INC and DEC do **not** modify any PSW flags. This
+is unlike most other architectures and a common source of bugs. To test the
+result of INC/DEC, use `CJNE A, #val, label` or a separate `JZ`/`JNZ` via
+`ANL A, A` or similar.
+
+**DA A (Decimal Adjust)**: After ADD/ADDC of two BCD bytes, DA A corrects
+the result to valid BCD:
+- If low nibble > 9 or AC=1: add 0x06
+- If high nibble > 9 or CY=1: add 0x60 and set CY
+
+### Logic
+
+| Mnemonic           | Encoding  | Bytes | Operation                              |
+|--------------------|-----------|-------|----------------------------------------|
+| ANL A, Rn          | 0x58+n    | 1     | A ← A & Rn; set P                     |
+| ANL A, dir         | 0x55      | 2     | A ← A & iram[dir]                     |
+| ANL A, @Ri         | 0x56+i    | 1     | A ← A & iram[Ri]                      |
+| ANL A, #imm        | 0x54      | 2     | A ← A & imm                           |
+| ANL dir, A         | 0x52      | 2     | iram[dir] ← iram[dir] & A             |
+| ANL dir, #imm      | 0x53      | 3     | iram[dir] ← iram[dir] & imm           |
+| ORL A, Rn          | 0x48+n    | 1     | A ← A | Rn                            |
+| ORL A, dir         | 0x45      | 2     | A ← A | iram[dir]                     |
+| ORL A, @Ri         | 0x46+i    | 1     | A ← A | iram[Ri]                     |
+| ORL A, #imm        | 0x44      | 2     | A ← A | imm                           |
+| ORL dir, A         | 0x42      | 2     | iram[dir] ← iram[dir] | A             |
+| ORL dir, #imm      | 0x43      | 3     | iram[dir] ← iram[dir] | imm           |
+| XRL A, Rn          | 0x68+n    | 1     | A ← A ^ Rn                            |
+| XRL A, dir         | 0x65      | 2     | A ← A ^ iram[dir]                     |
+| XRL A, @Ri         | 0x66+i    | 1     | A ← A ^ iram[Ri]                      |
+| XRL A, #imm        | 0x64      | 2     | A ← A ^ imm                           |
+| XRL dir, A         | 0x62      | 2     | iram[dir] ← iram[dir] ^ A             |
+| XRL dir, #imm      | 0x63      | 3     | iram[dir] ← iram[dir] ^ imm           |
+| CLR A              | 0xE4      | 1     | A ← 0; P ← 0                         |
+| CPL A              | 0xF4      | 1     | A ← ~A; update P                     |
+| RL A               | 0x23      | 1     | A ← (A << 1) | (A >> 7)  (rotate left, no CY)|
+| RLC A              | 0x33      | 1     | {CY,A} ← {A,CY}  (rotate left through carry)|
+| RR A               | 0x03      | 1     | A ← (A >> 1) | (A << 7)  (rotate right)|
+| RRC A              | 0x13      | 1     | {A,CY} ← {CY,A}  (rotate right through carry)|
+| SWAP A             | 0xC4      | 1     | A[7:4] ↔ A[3:0]  (swap nibbles)      |
+
+### Bit manipulation
+
+The 8051 is one of the few architectures with a dedicated bit-manipulation
+instruction set. This is essential for I/O port control (setting individual
+pins) and flag manipulation.
+
+| Mnemonic           | Encoding  | Bytes | Operation                              |
+|--------------------|-----------|-------|----------------------------------------|
+| CLR C              | 0xC3      | 1     | CY ← 0                                |
+| CLR bit            | 0xC2      | 2     | bit_addr ← 0                          |
+| SETB C             | 0xD3      | 1     | CY ← 1                                |
+| SETB bit           | 0xD2      | 2     | bit_addr ← 1                          |
+| CPL C              | 0xB3      | 1     | CY ← ~CY                              |
+| CPL bit            | 0xB2      | 2     | bit_addr ← ~bit_addr                  |
+| ANL C, bit         | 0x82      | 2     | CY ← CY & bit_addr                   |
+| ANL C, /bit        | 0xB0      | 2     | CY ← CY & ~bit_addr                  |
+| ORL C, bit         | 0x72      | 2     | CY ← CY | bit_addr                   |
+| ORL C, /bit        | 0xA0      | 2     | CY ← CY | ~bit_addr                  |
+| MOV C, bit         | 0xA2      | 2     | CY ← bit_addr                        |
+| MOV bit, C         | 0x92      | 2     | bit_addr ← CY                        |
+
+**Bit address resolution**:
+- Bit addresses 0x00–0x7F → RAM bytes 0x20–0x2F (bit N is byte 0x20+(N>>3), bit (N&7))
+- Bit addresses 0x80–0xFF → SFR bits (only bit-addressable SFRs: ACC=0xE0,
+  B=0xF0, PSW=0xD0, TCON=0x88, SCON=0x98, IE=0xA8, IP=0xB8, P0=0x80,
+  P1=0x90, P2=0xA0, P3=0xB0)
+  For these, bit N → SFR at (N & 0xF8), bit position (N & 0x07)
+
+### Branching and control flow
+
+#### Unconditional jumps
+
+| Mnemonic           | Encoding        | Bytes | Operation                           |
+|--------------------|-----------------|-------|-------------------------------------|
+| LJMP addr16        | 0x02 hi lo      | 3     | PC ← addr16                        |
+| AJMP addr11        | *(a10:a9:a8)*01 | 2     | PC[10:0] ← addr11; PC[15:11] unchanged|
+| SJMP rel           | 0x80 rel        | 2     | PC ← PC + 2 + rel (signed 8-bit)   |
+| JMP @A+DPTR        | 0x73            | 1     | PC ← A + DPTR                      |
+
+**AJMP encoding**: The 5 high bits of the first byte are `a10:a9:a8:0:0:0:0:1`.
+That is, opcode = `(addr11 >> 3) & 0xE0 | 0x01`. This gives page-relative
+jumps within each 2 KB block: addr11 replaces the low 11 bits of PC; the
+upper 5 bits remain unchanged (same 2 KB page).
+
+#### Conditional jumps
+
+All conditional jumps are 2 bytes: opcode + signed 8-bit offset. Target =
+PC_after_fetch + rel = (PC_of_instruction + 2) + rel.
+
+| Mnemonic           | Encoding  | Condition                              |
+|--------------------|-----------|----------------------------------------|
+| JZ rel             | 0x60      | Jump if A = 0                         |
+| JNZ rel            | 0x70      | Jump if A ≠ 0                         |
+| JC rel             | 0x40      | Jump if CY = 1                        |
+| JNC rel            | 0x50      | Jump if CY = 0                        |
+| JB bit, rel        | 0x20      | Jump if bit = 1  (3-byte)             |
+| JNB bit, rel       | 0x30      | Jump if bit = 0  (3-byte)             |
+| JBC bit, rel       | 0x10      | Jump if bit = 1, then clear bit (3-byte)|
+
+#### Compare-and-branch (CJNE)
+
+| Mnemonic              | Encoding  | Bytes | Operation                          |
+|-----------------------|-----------|-------|------------------------------------|
+| CJNE A, dir, rel      | 0xB5      | 3     | if A ≠ dir: branch; CY = A < dir  |
+| CJNE A, #imm, rel     | 0xB4      | 3     | if A ≠ imm: branch; CY = A < imm  |
+| CJNE Rn, #imm, rel    | 0xB8+n    | 3     | if Rn ≠ imm: branch; CY = Rn < imm|
+| CJNE @Ri, #imm, rel   | 0xB6+i    | 3     | if [Ri] ≠ imm: branch             |
+
+CJNE sets CY = 1 if the first operand is less than the second (unsigned
+comparison); it does not modify any other flags.
+
+#### Decrement-and-branch (DJNZ)
+
+| Mnemonic           | Encoding  | Bytes | Operation                           |
+|--------------------|-----------|-------|-------------------------------------|
+| DJNZ Rn, rel       | 0xD8+n    | 2     | Rn--; if Rn ≠ 0: branch            |
+| DJNZ dir, rel      | 0xD5      | 3     | iram[dir]--; if ≠ 0: branch        |
+
+DJNZ does **not** modify PSW flags (like INC/DEC). The branch offset is
+relative to the byte after the instruction (PC + 2 for Rn form, PC + 3 for
+dir form).
+
+#### Subroutines
+
+| Mnemonic           | Encoding        | Bytes | Operation                           |
+|--------------------|-----------------|-------|-------------------------------------|
+| LCALL addr16       | 0x12 hi lo      | 3     | SP+=2; iram[SP-1]=PCH; iram[SP]=PCL; PC=addr16|
+| ACALL addr11       | *(a10:a9:a8)*10 | 2     | SP+=2; push PC+2; PC[10:0]=addr11  |
+| RET                | 0x22            | 1     | PCL=iram[SP]; PCH=iram[SP-1]; SP-=2|
+| RETI               | 0x32            | 1     | like RET, also re-enables interrupt level|
+| NOP                | 0x00            | 1     | No operation                       |
+
+**LCALL stack layout** (grows upward, SP starts at 0x07):
+```
+Before: SP = N
+After push:
+  iram[N+1] = PC_low  (address of instruction after LCALL)
+  iram[N+2] = PC_high
+  SP = N + 2
+```
+RET reverses: reads iram[SP] as PC_high, iram[SP-1] as PC_low, decrements SP by 2.
+
+---
+
+## Condition flag summary
+
+| Instruction group | CY | AC | OV | P  |
+|-------------------|----|----|----|-----|
+| ADD, ADDC         | ✓  | ✓  | ✓  | ✓  |
+| SUBB              | ✓  | ✓  | ✓  | ✓  |
+| MUL AB            | 0  | –  | *  | ✓  |
+| DIV AB            | 0  | –  | *  | ✓  |
+| INC, DEC          | –  | –  | –  | –  |
+| DJNZ              | –  | –  | –  | –  |
+| ANL, ORL, XRL, CLR, CPL | – | – | – | ✓ |
+| RL, RLC, RR, RRC  | *  | –  | –  | ✓  |
+| DA A              | *  | –  | –  | ✓  |
+| CJNE              | *  | –  | –  | –  |
+| CLR C / SETB C / CPL C | * | – | – | – |
+| MOV/MOV bit/SETB/CLR bit | – | – | – | – |
+
+(✓ = updated, – = unchanged, 0 = cleared, * = specific rule above)
+
+**Parity** (PSW.P) is always the even parity of ACC (1 if ACC has odd number
+of 1-bits). It is updated whenever ACC changes. This is a hardware-computed
+bit in the real chip.
+
+---
+
+## HALT convention
+
+The real 8051 has no HALT instruction. In this simulator, executing opcode
+`0xA5` (undefined/reserved on real hardware) is the HALT sentinel that stops
+execution and sets `halted=True`. Programs are terminated with `0xA5` in the
+same way PDP-11 programs terminate with `0x0000`.
+
+---
+
+## SIM00 protocol implementation
+
+The simulator implements `Simulator[I8051State]` from `simulator_protocol`.
+
+### `I8051State` (frozen dataclass)
+
+```python
+@dataclass(frozen=True)
+class I8051State:
+    pc:     int               # 16-bit program counter
+    acc:    int               # accumulator (8-bit)
+    b:      int               # B register (8-bit)
+    sp:     int               # stack pointer (8-bit)
+    dptr:   int               # 16-bit data pointer
+    psw:    int               # program status word (8-bit)
+    iram:   tuple[int, ...]   # 256 bytes of internal RAM (includes SFRs at 0x80+)
+    xdata:  tuple[int, ...]   # 65536 bytes of external data memory
+    code:   tuple[int, ...]   # 65536 bytes of code memory
+    halted: bool
+
+    @property
+    def cy(self) -> bool: return bool((self.psw >> 7) & 1)
+    @property
+    def ac(self) -> bool: return bool((self.psw >> 6) & 1)
+    @property
+    def ov(self) -> bool: return bool((self.psw >> 2) & 1)
+    @property
+    def parity(self) -> bool: return bool(self.psw & 1)
+    @property
+    def bank(self) -> int: return (self.psw >> 3) & 0x3
+```
+
+### Reset state
+
+| Register | Value   | Rationale                               |
+|----------|---------|-----------------------------------------|
+| PC       | 0x0000  | 8051 always starts at address 0         |
+| ACC      | 0x00    | undefined at reset, 0 by convention     |
+| B        | 0x00    |                                         |
+| SP       | 0x07    | 8051 hardware reset default             |
+| DPTR     | 0x0000  |                                         |
+| PSW      | 0x00    | Bank 0, CY=0, AC=0, OV=0, P=0          |
+| P0–P3    | 0xFF    | All port latches = 0xFF at reset        |
+| All IRAM | 0x00    | Zeroed (simulator convention)           |
+| All XDATA| 0x00    | Zeroed                                  |
+
+### `load(program: bytes) → None`
+
+1. Call `reset()`.
+2. Copy `program` bytes into `_code[0:len(program)]`. Raises `ValueError` if
+   `len(program) > 65536`.
+3. PC remains 0x0000.
+
+### `step() → StepTrace`
+
+1. If `_halted`: return a `StepTrace` with `mnemonic="HALT"`, `pc_before=pc`,
+   `pc_after=pc` (no-op).
+2. Fetch opcode byte at `_code[pc]`, increment PC.
+3. Decode, fetch additional operand bytes (incrementing PC).
+4. Execute: update `_iram`, `_xdata`, `_code`, PSW, SP, DPTR, ACC, B, PC.
+5. Recompute parity: `PSW.P = popcount(ACC) & 1`.
+6. Return `StepTrace(pc_before, pc_after, mnemonic, state_after=get_state())`.
+
+### `execute(program, max_steps=100_000) → ExecutionResult`
+
+1. Call `load(program)`.
+2. Loop: call `step()` up to `max_steps` times.
+3. If `_halted`: return `ExecutionResult(ok=True, halted=True, steps=n, ...)`.
+4. If `max_steps` exceeded: return `ExecutionResult(ok=False, error="max_steps exceeded")`.
+5. On exception: return `ExecutionResult(ok=False, error=str(e))`.
+
+---
+
+## Package layout
+
+```
+code/packages/python/intel8051-simulator/
+├── pyproject.toml
+├── README.md
+├── CHANGELOG.md
+└── src/
+    └── intel8051_simulator/
+        ├── __init__.py        # exports: I8051Simulator, I8051State
+        ├── py.typed
+        ├── state.py           # I8051State frozen dataclass + constants
+        ├── flags.py           # arithmetic helpers: add8_flags, sub8_flags, da_flags
+        └── simulator.py       # I8051Simulator implementation
+tests/
+    ├── test_protocol.py       # SIM00 compliance
+    ├── test_instructions.py   # per-instruction + per-mode coverage
+    ├── test_programs.py       # end-to-end programs
+    └── test_coverage.py       # edge cases, flags, DA, MUL/DIV
+```
+
+---
+
+## Design notes
+
+### Why no timers or interrupts?
+
+The real 8051 includes hardware timers, a serial port, and a 6-source
+interrupt controller. These are inherently time-based and event-driven —
+simulating them faithfully requires either cycle-accurate timing or an event
+loop. This simulator is a **behavioral instruction-set simulator**, not a
+cycle-accurate or peripheral-accurate simulator. Timers and interrupts are
+omitted to keep the implementation focused and testable; the SFR addresses
+for TCON, TMOD, TL0, TH0, TL1, TH1, SCON, SBUF, IE, IP are modeled as
+plain readable/writable bytes with no side effects.
+
+### Harvard architecture in the simulator
+
+In the real 8051, code memory and data memory are physically separate buses.
+In the simulator they are two separate Python bytearrays:
+- `_code`: 64 KB code memory (loaded by `load()`)
+- `_iram`: 256 bytes internal RAM (+ SFR mirror at 0x80–0xFF)
+- `_xdata`: 64 KB external data memory
+
+MOVC accesses `_code`; MOVX accesses `_xdata`; all other data operations
+access `_iram`. This clean separation matches the real hardware model.
+
+### SFR aliasing
+
+Internal RAM addresses 0x00–0x7F and SFR addresses 0x80–0xFF are both stored
+in `_iram[0:256]`. Direct addressing (dir byte in instruction) accesses
+`_iram[dir]` for any address. Indirect addressing via @R0/@R1 with R0/R1 ≥
+0x80 would access the upper 128-byte RAM of the 8052; in the 8051 base model
+this behavior is undefined — the simulator raises `ValueError` for indirect
+addresses ≥ 0x80.
+
+After any instruction that modifies ACC, the simulator recomputes PSW.P
+(even parity). This matches hardware behavior where P is always live.
+
+### Register bank abstraction
+
+`_r(n)` returns the IRAM address of register Rn in the current bank:
+
+```python
+def _r(self, n: int) -> int:
+    """IRAM address of Rn in the current register bank."""
+    bank = (self._iram[0xD0] >> 3) & 0x3  # PSW RS1:RS0
+    return bank * 8 + n
+```
+
+This means reading R3 in bank 2 reads `_iram[2*8 + 3] = _iram[19]`.
+
+---
+
+## Test plan
+
+### test_protocol.py — SIM00 compliance
+- `isinstance(sim, Simulator)`
+- All 5 protocol methods callable
+- `execute` returns `ExecutionResult`
+- `step` returns `StepTrace`
+- `get_state` returns `I8051State`
+- `reset`: PC=0, SP=7, PSW=0, IRAM zeroed, ports=0xFF
+- `load`: bytes at code[0], PC=0, raises on overflow
+- `get_state` is frozen, memory is tuple, registers field present
+
+### test_instructions.py — per-instruction
+- **Data transfer**: MOV A/Rn/dir/@Ri/#imm in all combinations
+- **MOV dir,dir2**: byte order (src=byte2, dst=byte3)
+- **PUSH/POP**: SP increments, stack round-trip
+- **XCH/XCHD**: swap semantics
+- **Arithmetic**: ADD/ADDC carry chain, overflow detection, DA A BCD cases
+- **SUBB**: borrow propagation, CY/AC/OV
+- **MUL AB**: B:A product, OV set if B≠0
+- **DIV AB**: quotient in A, remainder in B, OV on div-by-zero
+- **INC/DEC**: no flag modification confirmed
+- **Logic**: ANL/ORL/XRL all operand forms
+- **RL/RRC/RLC/RR**: bit rotation including carry thread
+- **Bit ops**: CLR/SETB/CPL C and bit, ANL/ORL C,bit and C,/bit
+- **Branches**: JZ/JNZ/JC/JNC forward and backward
+- **JB/JNB/JBC**: bit test with clear
+- **CJNE**: not-equal branch + CY unsigned comparison
+- **DJNZ**: count-down loop
+- **LJMP/SJMP/JMP @A+DPTR**: all jump forms
+- **LCALL/RET**: call/return stack integrity
+
+### test_programs.py — end-to-end
+- Sum 1–10 using DJNZ loop
+- Multiply using repeated addition
+- String copy: MOVX loop copying bytes from xdata src→dst
+- Bubble sort 8 bytes in IRAM
+- Fibonacci (first 8 terms)
+- Factorial (5! using MUL AB)
+- BCD addition (DA A usage)
+- Nested subroutine calls, stack balance
+
+### test_coverage.py — edge cases
+- BCD arithmetic: DA A after ADD of two BCD bytes
+- MUL AB overflow (product > 0xFF)
+- DIV by zero (OV flag)
+- CJNE CY flag: A < imm vs A ≥ imm
+- DJNZ exact boundary (counts from 1 → 0 vs 0 → 255)
+- Register bank switching (PSW.RS1:RS0)
+- Bit address resolution for both RAM area and SFR area
+- MOVC @A+DPTR lookup table
+- MOVC @A+PC lookup table
+- XCHD nibble swap
+- Parity recomputation on every ACC change
+- SP wrap-around (push 128 items)
+- SJMP backward branch (negative offset)


### PR DESCRIPTION
## Summary

- Implements a complete behavioral simulator for the Intel MCS-51 (8051) microcontroller — the most-manufactured CPU architecture in history (20B+ units)
- Harvard architecture with separate 64 KB code/data buses, 256-byte internal RAM (lower RAM + SFRs), and 64 KB external data memory
- All 256 opcodes handled: data transfer, arithmetic (MUL/DIV/DA), logic, bit operations, jumps, conditional branches, and subroutine calls/returns

## Architecture features

- Four switchable register banks (R0–R7 × 4, selected via PSW.RS1:RS0)
- Bit-addressable memory area (iram 0x20–0x2F + SFR bit addresses)
- Full PSW flag set: CY, AC, OV, P (parity auto-updated after every ACC write)
- AJMP/ACALL 11-bit page-relative addressing (8 variants each via opcode pattern)
- HALT sentinel on opcode 0xA5 (undefined/reserved on real hardware)
- Implements `Simulator[I8051State]` from the SIM00 protocol

## Test coverage

- 200 tests, 86.10% coverage across 4 test modules:
  - `test_protocol.py` — SIM00 protocol compliance, reset/load/execute/step/get_state
  - `test_instructions.py` — every instruction variant with flag behavior verification
  - `test_coverage.py` — edge cases: parity, OV, AC, DA A BCD, bit operations
  - `test_programs.py` — end-to-end programs: sum 1–10, multiply, 5! via MUL AB, Fibonacci (8 terms), BCD addition, lookup table, subroutines with stack balance, xdata copy

## Test plan
- [ ] CI passes all 200 pytest tests
- [ ] ruff linting clean
- [ ] Coverage ≥ 80% (currently 86.10%)
- [ ] Spec `code/specs/07p-intel-8051-simulator.md` committed alongside implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)