### PR TITLE
feat(phase27): polynomial inequality solving — cas-solve 0.8.0, symbolic-vm 0.47.0

### DIFF
--- a/code/packages/python/cas-solve/CHANGELOG.md
+++ b/code/packages/python/cas-solve/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.8.0 — 2026-05-05
+
+**Phase 27 — Polynomial inequality solving.**
+
+New module `cas_solve/inequality.py` with one public function:
+
+- ``try_solve_inequality(ineq_ir, var)`` — solves polynomial inequalities
+  ``p(x) op 0`` (op ∈ {<, >, ≤, ≥}) for degrees 1–4 with rational
+  coefficients.
+
+**Algorithm**: normalise to ``f = lhs − rhs``, extract polynomial coefficients
+via `symbolic_vm.polynomial_bridge.to_rational` (deferred import), find real
+roots numerically (Durand-Kerner) with exact rational roots for degrees 1–2,
+perform sign analysis in each interval between roots, and build the solution as
+a list of IR comparison conditions.
+
+**Output IR format**:
+
+| Solution | IR form |
+|----------|---------|
+| ``(−∞, a)`` | ``Less(x, a)`` |
+| ``[a, +∞)`` | ``GreaterEqual(x, a)`` |
+| ``(a, b)`` | ``And(Greater(x,a), Less(x,b))`` |
+| ``[a, b]`` | ``And(GreaterEqual(x,a), LessEqual(x,b))`` |
+| all reals | ``GreaterEqual(IRInteger(0), IRInteger(0))`` |
+| no solution | ``[]`` (empty list) |
+
+**New export**: `try_solve_inequality` added to `cas_solve/__init__.py`.
+
+---
+
 ## 0.7.0 — 2026-05-05
 
 **Phase 26 — Transcendental equation solving.**

--- a/code/packages/python/cas-solve/pyproject.toml
+++ b/code/packages/python/cas-solve/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-solve"
-version = "0.7.0"
-description = "Equation solving — polynomial (degrees 1–4) + numeric root-finding + linear systems + transcendental families (trig, exp/log, hyperbolic, Lambert W, compound substitution)."
+version = "0.8.0"
+description = "Equation solving — polynomial (degrees 1–4) + numeric root-finding + linear systems + transcendental families + polynomial inequality solving."
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/cas-solve/src/cas_solve/__init__.py
+++ b/code/packages/python/cas-solve/src/cas_solve/__init__.py
@@ -1,5 +1,5 @@
 """Equation solving (Phases 1–6: linear, quadratic, cubic, quartic, numeric, systems,
-and Phase 26 transcendental families).
+Phase 26 transcendental families, and Phase 27 polynomial inequality solving).
 
 Quick start::
 
@@ -30,6 +30,7 @@ from cas_solve.linear import ALL, solve_linear
 from cas_solve.linear_system import solve_linear_system
 from cas_solve.quadratic import solve_quadratic
 from cas_solve.quartic import solve_quartic
+from cas_solve.inequality import try_solve_inequality
 from cas_solve.transcendental import try_solve_transcendental
 
 __all__ = [
@@ -45,5 +46,6 @@ __all__ = [
     "solve_linear_system",
     "solve_quadratic",
     "solve_quartic",
+    "try_solve_inequality",
     "try_solve_transcendental",
 ]

--- a/code/packages/python/cas-solve/src/cas_solve/inequality.py
+++ b/code/packages/python/cas-solve/src/cas_solve/inequality.py
@@ -1,0 +1,451 @@
+"""Polynomial inequality solving in one real variable — Phase 27.
+
+Solves inequalities of the form ``p(x) op 0`` (or equivalently
+``lhs op rhs`` normalised to ``lhs − rhs op 0``) where ``op`` is one of
+``<``, ``>``, ``≤``, ``≥`` and ``p(x)`` is a polynomial of degree 1–4
+with rational coefficients.
+
+Algorithm
+---------
+
+1.  **Normalise direction** — compute ``f = lhs − rhs`` and record
+    ``want_positive`` (``True`` for ``>`` / ``≥``) and ``strict`` (``True``
+    for ``<`` / ``>``).
+
+2.  **Extract polynomial** — use ``symbolic_vm.polynomial_bridge.to_rational``
+    (deferred import; falls back to ``None`` when the bridge is absent).
+
+3.  **Find real roots numerically** — convert the ascending-degree Fraction
+    coefficients to a descending-degree float list and call
+    ``nsolve_poly`` from :mod:`cas_solve.durand_kerner`.  Filter roots
+    to those whose imaginary part is negligible (``|Im| < 1e-8``).
+
+    For degrees 1 and 2 the exact Fraction roots are also computed so that
+    the IR output is exact (``IRInteger`` / ``IRRational``) rather than
+    ``IRFloat``.
+
+4.  **Sign analysis** — for each open interval between consecutive real
+    roots evaluate ``f`` at the midpoint (or at ``root − 1`` / ``root + 1``
+    for unbounded outer intervals) and record the sign.
+
+5.  **Build result** — collect all intervals where the sign satisfies the
+    desired condition.  Roots are included in non-strict inequalities and
+    excluded in strict ones.  Each interval becomes one IR node:
+
+    * ``Less(x, a)``                          — ``(−∞, a)``
+    * ``LessEqual(x, a)``                     — ``(−∞, a]``
+    * ``Greater(x, a)``                       — ``(a, +∞)``
+    * ``GreaterEqual(x, a)``                  — ``[a, +∞)``
+    * ``And(Greater(x, a), Less(x, b))``      — ``(a, b)``
+    * ``And(GreaterEqual(x, a), LessEqual(x, b))`` — ``[a, b]``
+    * (mixed open/closed variants similarly)
+    * ``GreaterEqual(IRInteger(0), IRInteger(0))`` — all reals (trivially
+      true condition, returned when the solution is the entire real line)
+    * ``[]`` (empty list) — no real solutions
+
+Public API
+----------
+
+    try_solve_inequality(ineq_ir, var) → list[IRNode] | None
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import TYPE_CHECKING
+
+from symbolic_ir import (
+    AND,
+    GREATER,
+    GREATER_EQUAL,
+    LESS,
+    LESS_EQUAL,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+if TYPE_CHECKING:
+    pass
+
+# ---------------------------------------------------------------------------
+# IR construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _frac_ir(c: Fraction) -> IRNode:
+    """Fraction → IRInteger (denom 1) or IRRational."""
+    if c.denominator == 1:
+        return IRInteger(c.numerator)
+    return IRRational(c.numerator, c.denominator)
+
+
+def _make_less(x: IRSymbol, a: IRNode, strict: bool) -> IRNode:
+    """Return ``Less(x, a)`` or ``LessEqual(x, a)``."""
+    head = LESS if strict else LESS_EQUAL
+    return IRApply(head, (x, a))
+
+
+def _make_greater(x: IRSymbol, a: IRNode, strict: bool) -> IRNode:
+    """Return ``Greater(x, a)`` or ``GreaterEqual(x, a)``."""
+    head = GREATER if strict else GREATER_EQUAL
+    return IRApply(head, (x, a))
+
+
+def _make_interval(
+    x: IRSymbol,
+    lo: IRNode | None,
+    hi: IRNode | None,
+    lo_strict: bool,
+    hi_strict: bool,
+) -> IRNode:
+    """Return the condition node for one interval.
+
+    ``lo = None`` means unbounded below; ``hi = None`` means unbounded above.
+
+    Examples::
+
+        _make_interval(x, None, a, True, True)    →  Less(x, a)
+        _make_interval(x, a, None, False, True)   →  GreaterEqual(x, a)
+        _make_interval(x, a, b, True, False)      →  And(Greater(x,a), LessEqual(x,b))
+    """
+    if lo is None and hi is None:
+        # All reals — represented as a trivially-true condition.
+        return IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))
+    if lo is None:
+        return _make_less(x, hi, hi_strict)  # type: ignore[arg-type]
+    if hi is None:
+        return _make_greater(x, lo, lo_strict)
+    lo_cond = _make_greater(x, lo, lo_strict)
+    hi_cond = _make_less(x, hi, hi_strict)
+    return IRApply(AND, (lo_cond, hi_cond))
+
+
+# ---------------------------------------------------------------------------
+# Polynomial evaluation helpers
+# ---------------------------------------------------------------------------
+
+
+def _poly_eval_float(coeffs_asc: tuple[Fraction, ...], x_val: float) -> float:
+    """Evaluate the polynomial at ``x_val``.
+
+    ``coeffs_asc`` is in ascending degree order: ``(c₀, c₁, …, cₙ)``
+    so that ``p(x) = c₀ + c₁·x + … + cₙ·xⁿ``.
+    Horner's method applied in reverse (descending traversal).
+    """
+    result = 0.0
+    for c in reversed(coeffs_asc):
+        result = result * x_val + float(c)
+    return result
+
+
+def _sign_of(val: float) -> int:
+    """Return +1, 0, or -1."""
+    if abs(val) < 1e-9:
+        return 0
+    return 1 if val > 0 else -1
+
+
+# ---------------------------------------------------------------------------
+# Exact root extraction for degrees 1–2
+# ---------------------------------------------------------------------------
+
+
+def _exact_roots_deg1(coeffs: tuple[Fraction, ...]) -> list[Fraction]:
+    """Return the one rational root of a degree-1 polynomial."""
+    b, a = coeffs[0], coeffs[1]  # ascending: c₀ = b, c₁ = a
+    if a == Fraction(0):
+        return []
+    return [-b / a]
+
+
+def _exact_roots_deg2(coeffs: tuple[Fraction, ...]) -> list[Fraction] | None:
+    """Return exact Fraction roots of a degree-2 polynomial.
+
+    Returns ``None`` if the discriminant is not a perfect square (irrational
+    roots) — the caller then falls back to numerical roots only.
+
+    Returns ``[]`` if the discriminant is negative (no real roots).
+    """
+    c, b, a = coeffs[0], coeffs[1], coeffs[2]  # ascending
+    disc = b * b - Fraction(4) * a * c
+    if disc < 0:
+        return []
+    if disc == 0:
+        return [-b / (Fraction(2) * a)]
+    # Try to extract integer sqrt of disc numerator/denominator.
+    import math  # noqa: PLC0415
+
+    n, d = disc.numerator, disc.denominator
+    sqrt_n = math.isqrt(n)
+    sqrt_d = math.isqrt(d)
+    if sqrt_n * sqrt_n == n and sqrt_d * sqrt_d == d:
+        sqrt_disc = Fraction(sqrt_n, sqrt_d)
+        two_a = Fraction(2) * a
+        r1 = (-b + sqrt_disc) / two_a
+        r2 = (-b - sqrt_disc) / two_a
+        roots = sorted([r1, r2])
+        return roots
+    return None  # irrational roots → caller uses floats
+
+
+# ---------------------------------------------------------------------------
+# Numeric real-root finding
+# ---------------------------------------------------------------------------
+
+
+def _real_roots_numeric(coeffs_asc: tuple[Fraction, ...]) -> list[float]:
+    """Find real roots numerically using Durand-Kerner.
+
+    ``coeffs_asc`` is in ascending degree order.
+    Returns sorted list of real roots (imaginary-part threshold: 1e-8).
+    """
+    # nsolve_poly wants *descending* order.
+    coeffs_desc = [float(c) for c in reversed(coeffs_asc)]
+    try:
+        from cas_solve.durand_kerner import nsolve_poly  # noqa: PLC0415
+    except ImportError:
+        return []
+    roots_complex = nsolve_poly(coeffs_desc)
+    real_roots = [r.real for r in roots_complex if abs(r.imag) < 1e-8]
+    return sorted(real_roots)
+
+
+# ---------------------------------------------------------------------------
+# Root → exact IR node conversion
+# ---------------------------------------------------------------------------
+
+
+def _float_to_ir(val: float) -> IRNode:
+    """Convert a float root to IR.  Use IRFloat (not IRRational) for
+    irrational values; the caller may later replace with exact form."""
+    return IRFloat(val)
+
+
+def _frac_roots_to_ir(frac_roots: list[Fraction]) -> list[IRNode]:
+    return [_frac_ir(r) for r in frac_roots]
+
+
+# ---------------------------------------------------------------------------
+# Core sign-analysis function
+# ---------------------------------------------------------------------------
+
+
+def _solve_poly_ineq(
+    coeffs_asc: tuple[Fraction, ...],
+    want_positive: bool,
+    strict: bool,
+    var: IRSymbol,
+    exact_roots_ir: list[IRNode] | None,
+    numeric_roots: list[float],
+) -> list[IRNode]:
+    """Build the solution list given polynomial coefficients and roots.
+
+    ``exact_roots_ir``: if provided, these IR nodes (sorted ascending by
+    float value) are used as the boundary points in the output conditions.
+    If ``None``, ``IRFloat`` nodes are used.
+
+    ``numeric_roots``: float values of real roots (sorted ascending) —
+    used for sign testing and interval boundaries when exact form is absent.
+    """
+    # Build parallel lists of (float_value, ir_node) for each root.
+    if exact_roots_ir is not None and len(exact_roots_ir) == len(numeric_roots):
+        boundary_ir = exact_roots_ir
+    else:
+        # Fall back to IRFloat for boundaries.
+        boundary_ir = [_float_to_ir(r) for r in numeric_roots]
+
+    n_roots = len(numeric_roots)
+    # Deduplicate numerically-close roots (within 1e-6 of each other).
+    if n_roots >= 2:
+        deduped_floats: list[float] = [numeric_roots[0]]
+        deduped_ir: list[IRNode] = [boundary_ir[0]]
+        for i in range(1, n_roots):
+            if numeric_roots[i] - deduped_floats[-1] > 1e-6:
+                deduped_floats.append(numeric_roots[i])
+                deduped_ir.append(boundary_ir[i])
+        numeric_roots = deduped_floats
+        boundary_ir = deduped_ir
+        n_roots = len(numeric_roots)
+
+    # Build test points: one per open interval between boundaries.
+    # Intervals: (−∞, r₀), (r₀, r₁), …, (rₙ₋₁, +∞)
+    def test_point(i: int) -> float:
+        """Mid-point of interval i (0-based).
+
+        Interval 0 is (−∞, r₀), interval n_roots is (rₙ₋₁, +∞).
+        """
+        if n_roots == 0:
+            return 0.0
+        if i == 0:
+            return numeric_roots[0] - 1.0
+        if i == n_roots:
+            return numeric_roots[-1] + 1.0
+        return (numeric_roots[i - 1] + numeric_roots[i]) / 2.0
+
+    n_intervals = n_roots + 1
+    result: list[IRNode] = []
+
+    for i in range(n_intervals):
+        tp = test_point(i)
+        sign = _sign_of(_poly_eval_float(coeffs_asc, tp))
+
+        # Does this interval satisfy the inequality?
+        satisfies = (sign > 0) if want_positive else (sign < 0)
+        if not satisfies:
+            continue
+
+        # Build the interval condition.
+        lo_ir = boundary_ir[i - 1] if i > 0 else None
+        hi_ir = boundary_ir[i] if i < n_roots else None
+
+        # Strict boundary: open ends; non-strict boundary: closed ends.
+        lo_strict = strict
+        hi_strict = strict
+
+        result.append(_make_interval(var, lo_ir, hi_ir, lo_strict, hi_strict))
+
+    # Handle non-strict: roots where f = 0 also satisfy f ≥ 0 or f ≤ 0.
+    # These are automatically captured because:
+    #   • For a simple root, the adjacent intervals have opposite signs, and
+    #     at least one satisfies the inequality.  The root is the boundary of
+    #     a half-open (strict) interval — but we need to INCLUDE the root for
+    #     non-strict.  That happens because we set lo_strict/hi_strict = strict
+    #     (which is False for non-strict), so we already generate closed
+    #     intervals that include the root.
+    # Nothing extra to do here.
+
+    # Degenerate result: if every interval satisfied (all reals).
+    #
+    # We can only collapse to "all reals" when the **roots themselves** are
+    # also part of the solution:
+    #
+    #   • No roots (n_roots == 0): the polynomial never crosses zero, so
+    #     the entire real line is trivially included in the open intervals.
+    #   • Non-strict inequality (not strict): f = 0 satisfies both f ≥ 0
+    #     and f ≤ 0, so the roots are included already.
+    #
+    # For a STRICT inequality with at least one root we must NOT collapse:
+    # e.g. (x−1)² > 0 is satisfied on (−∞,1) and (1,+∞) — all open
+    # intervals — but NOT at x = 1 where f = 0.  The correct output is
+    # [Less(x, 1), Greater(x, 1)], not the all-reals sentinel.
+    if len(result) == n_intervals and (n_roots == 0 or not strict):
+        # All intervals included → solution is the entire real line.
+        # Return a single trivially-true condition.
+        return [IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))]
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def try_solve_inequality(
+    ineq_ir: IRNode,
+    var: IRSymbol,
+) -> list[IRNode] | None:
+    """Try to solve a polynomial inequality in one real variable.
+
+    ``ineq_ir`` must be ``IRApply`` with head in
+    ``{Less, Greater, LessEqual, GreaterEqual}``.
+
+    Returns a list of condition IR nodes (each representing one disjoint
+    interval in the solution set), or ``None`` if the pattern is not
+    recognised or the polynomial bridge is unavailable.
+
+    Special return values:
+
+    * ``[]``   — no real solutions.
+    * ``[GreaterEqual(0, 0)]``  — the entire real line is the solution.
+    """
+    # --- Validate structure ---
+    if not isinstance(ineq_ir, IRApply):
+        return None
+    head = ineq_ir.head
+    if not isinstance(head, IRSymbol):
+        return None
+    if head.name not in {"Less", "Greater", "LessEqual", "GreaterEqual"}:
+        return None
+    if len(ineq_ir.args) != 2:
+        return None
+
+    lhs, rhs = ineq_ir.args
+    fname = head.name
+    want_positive = fname in {"Greater", "GreaterEqual"}
+    strict = fname in {"Less", "Greater"}
+
+    # --- Build f = lhs − rhs ---
+    if isinstance(rhs, IRInteger) and rhs.value == 0:
+        f_ir = lhs
+    elif isinstance(lhs, IRInteger) and lhs.value == 0:
+        # 0 op rhs  →  invert and use −rhs op 0 (flip direction)
+        # This is rare; we rewrite as rhs op' 0 instead.
+        # 0 > rhs  ↔  rhs < 0  →  swap sides, flip op
+        # Rather than rewrite: just negate by setting f = rhs and flipping.
+        f_ir = rhs
+        want_positive = not want_positive
+    else:
+        f_ir = IRApply(SUB, (lhs, rhs))
+
+    # --- Extract polynomial coefficients ---
+    try:
+        from symbolic_vm.polynomial_bridge import to_rational  # noqa: PLC0415
+    except ImportError:
+        return None
+
+    result = to_rational(f_ir, var)
+    if result is None:
+        return None
+    num_frac, den_frac = result
+    if den_frac != (Fraction(1),):
+        return None  # rational function, not polynomial
+    coeffs = num_frac  # ascending degree
+
+    deg = len(coeffs) - 1
+    if deg < 1:
+        # Constant polynomial: either always true or always false.
+        const_val = float(coeffs[0]) if coeffs else 0.0
+        sign = _sign_of(const_val)
+        satisfies = (sign > 0) if want_positive else (sign < 0)
+        if satisfies:
+            return [IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))]
+        # strict/non-strict doesn't matter for a constant
+        # (0 op 0 gives all reals for non-strict, no sol for strict)
+        if not strict and sign == 0:
+            return [IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))]
+        return []
+
+    if deg > 4:
+        return None  # unsupported degree
+
+    # --- Find exact roots (for deg 1–2) and numeric roots ---
+    exact_ir: list[IRNode] | None = None
+    numeric: list[float] = []
+
+    if deg == 1:
+        frac_roots = _exact_roots_deg1(coeffs)
+        exact_ir = _frac_roots_to_ir(frac_roots)
+        numeric = [float(r) for r in frac_roots]
+
+    elif deg == 2:
+        frac_roots = _exact_roots_deg2(coeffs)
+        if frac_roots is not None:
+            exact_ir = _frac_roots_to_ir(frac_roots)
+            numeric = [float(r) for r in frac_roots]
+        else:
+            # Irrational roots — use Durand-Kerner.
+            numeric = _real_roots_numeric(coeffs)
+            exact_ir = None  # will use IRFloat boundaries
+
+    else:
+        # deg 3 or 4: always use numeric roots.
+        numeric = _real_roots_numeric(coeffs)
+        exact_ir = None
+
+    return _solve_poly_ineq(coeffs, want_positive, strict, var, exact_ir, numeric)

--- a/code/packages/python/cas-solve/tests/test_inequality.py
+++ b/code/packages/python/cas-solve/tests/test_inequality.py
@@ -1,0 +1,856 @@
+"""Tests for cas_solve.inequality — Phase 27 polynomial inequality solving.
+
+These tests exercise every code path within ``inequality.py`` without
+depending on ``symbolic_vm`` (which is *not* in cas-solve's dependency list).
+
+Strategy
+--------
+
+The module under test calls ``symbolic_vm.polynomial_bridge.to_rational``
+via a **deferred import** inside ``try_solve_inequality``.  We inject a fake
+``symbolic_vm.polynomial_bridge`` module into ``sys.modules`` so that the
+import succeeds with a controlled ``to_rational``.  The fixture
+``patch_bridge(coeffs)`` accepts ascending-degree Fraction coefficients and
+makes ``to_rational`` return them for *any* expression — this lets us test
+the sign-analysis and interval-building logic independently of the actual
+polynomial bridge.
+
+For the pure helper functions (``_frac_ir``, ``_poly_eval_float``, etc.) and
+the core algorithm (``_solve_poly_ineq``), no mocking is needed at all.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from contextlib import contextmanager
+from fractions import Fraction
+
+import pytest
+from symbolic_ir import (
+    AND,
+    GREATER,
+    GREATER_EQUAL,
+    LESS,
+    LESS_EQUAL,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRRational,
+    IRSymbol,
+)
+
+from cas_solve.inequality import (
+    _exact_roots_deg1,
+    _exact_roots_deg2,
+    _frac_ir,
+    _make_interval,
+    _poly_eval_float,
+    _sign_of,
+    _solve_poly_ineq,
+    try_solve_inequality,
+)
+
+# ---------------------------------------------------------------------------
+# Shared symbols
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+ZERO = IRInteger(0)
+ONE = IRInteger(1)
+
+# ---------------------------------------------------------------------------
+# Bridge-patching context manager
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def patch_bridge(coeffs_asc: tuple):
+    """Patch polynomial_bridge so ``to_rational`` returns *coeffs_asc*.
+
+    The coefficients are converted to Fraction automatically.
+    ``den`` is always ``(Fraction(1),)`` — polynomial (not rational function).
+    """
+    fracs = tuple(Fraction(c) for c in coeffs_asc)
+
+    def _to_rational(expr, var):  # noqa: ARG001
+        return fracs, (Fraction(1),)
+
+    mock_mod = types.ModuleType("symbolic_vm.polynomial_bridge")
+    mock_mod.to_rational = _to_rational
+    mock_vm = types.ModuleType("symbolic_vm")
+
+    old_vm = sys.modules.get("symbolic_vm")
+    old_bridge = sys.modules.get("symbolic_vm.polynomial_bridge")
+
+    sys.modules["symbolic_vm"] = mock_vm
+    sys.modules["symbolic_vm.polynomial_bridge"] = mock_mod
+
+    try:
+        yield
+    finally:
+        if old_vm is None:
+            sys.modules.pop("symbolic_vm", None)
+        else:
+            sys.modules["symbolic_vm"] = old_vm
+
+        if old_bridge is None:
+            sys.modules.pop("symbolic_vm.polynomial_bridge", None)
+        else:
+            sys.modules["symbolic_vm.polynomial_bridge"] = old_bridge
+
+
+@contextmanager
+def patch_bridge_none():
+    """Patch polynomial_bridge so ``to_rational`` always returns ``None``."""
+    mock_mod = types.ModuleType("symbolic_vm.polynomial_bridge")
+    mock_mod.to_rational = lambda expr, var: None  # noqa: ARG005
+
+    old_bridge = sys.modules.get("symbolic_vm.polynomial_bridge")
+    old_vm = sys.modules.get("symbolic_vm")
+
+    sys.modules["symbolic_vm"] = types.ModuleType("symbolic_vm")
+    sys.modules["symbolic_vm.polynomial_bridge"] = mock_mod
+
+    try:
+        yield
+    finally:
+        if old_vm is None:
+            sys.modules.pop("symbolic_vm", None)
+        else:
+            sys.modules["symbolic_vm"] = old_vm
+
+        if old_bridge is None:
+            sys.modules.pop("symbolic_vm.polynomial_bridge", None)
+        else:
+            sys.modules["symbolic_vm.polynomial_bridge"] = old_bridge
+
+
+def _ineq(head, lhs=None, rhs=None):
+    """Build a simple IRApply inequality node.
+
+    ``head`` is one of LESS, GREATER, LESS_EQUAL, GREATER_EQUAL.
+    ``lhs`` defaults to ``X``; ``rhs`` defaults to ``ZERO``.
+    """
+    lhs = lhs if lhs is not None else X
+    rhs = rhs if rhs is not None else ZERO
+    return IRApply(head, (lhs, rhs))
+
+
+# ===========================================================================
+# 1. _frac_ir
+# ===========================================================================
+
+
+class TestFracIr:
+    """_frac_ir: Fraction → IRInteger or IRRational."""
+
+    def test_whole_positive(self) -> None:
+        assert _frac_ir(Fraction(3)) == IRInteger(3)
+
+    def test_whole_negative(self) -> None:
+        assert _frac_ir(Fraction(-7)) == IRInteger(-7)
+
+    def test_zero(self) -> None:
+        assert _frac_ir(Fraction(0)) == IRInteger(0)
+
+    def test_proper_fraction(self) -> None:
+        assert _frac_ir(Fraction(1, 2)) == IRRational(1, 2)
+
+    def test_negative_fraction(self) -> None:
+        result = _frac_ir(Fraction(-3, 4))
+        assert isinstance(result, IRRational)
+        assert result.numer == -3
+        assert result.denom == 4
+
+    def test_improper_fraction_reduces(self) -> None:
+        # Fraction(6, 3) = Fraction(2) → should give IRInteger(2)
+        assert _frac_ir(Fraction(6, 3)) == IRInteger(2)
+
+
+# ===========================================================================
+# 2. _poly_eval_float
+# ===========================================================================
+
+
+class TestPolyEvalFloat:
+    """_poly_eval_float: Horner evaluation with ascending-degree coefficients."""
+
+    def test_constant(self) -> None:
+        """p(x) = 5 → always 5."""
+        coeffs = (Fraction(5),)
+        assert _poly_eval_float(coeffs, 0.0) == pytest.approx(5.0)
+        assert _poly_eval_float(coeffs, 3.7) == pytest.approx(5.0)
+
+    def test_linear(self) -> None:
+        """p(x) = -1 + x → p(1) = 0, p(2) = 1."""
+        coeffs = (Fraction(-1), Fraction(1))
+        assert _poly_eval_float(coeffs, 1.0) == pytest.approx(0.0)
+        assert _poly_eval_float(coeffs, 2.0) == pytest.approx(1.0)
+
+    def test_quadratic(self) -> None:
+        """p(x) = x² - 1 → p(1) = 0, p(0) = -1, p(-1) = 0."""
+        coeffs = (Fraction(-1), Fraction(0), Fraction(1))
+        assert _poly_eval_float(coeffs, 1.0) == pytest.approx(0.0)
+        assert _poly_eval_float(coeffs, 0.0) == pytest.approx(-1.0)
+        assert _poly_eval_float(coeffs, -1.0) == pytest.approx(0.0)
+
+    def test_cubic(self) -> None:
+        """p(x) = x³ - x = x(x-1)(x+1) → p(0)=0, p(2)=6."""
+        coeffs = (Fraction(0), Fraction(-1), Fraction(0), Fraction(1))
+        assert _poly_eval_float(coeffs, 0.0) == pytest.approx(0.0)
+        assert _poly_eval_float(coeffs, 2.0) == pytest.approx(6.0)
+        assert _poly_eval_float(coeffs, -1.0) == pytest.approx(0.0)
+
+
+# ===========================================================================
+# 3. _sign_of
+# ===========================================================================
+
+
+class TestSignOf:
+    """_sign_of: returns +1, 0, or -1."""
+
+    def test_positive(self) -> None:
+        assert _sign_of(3.5) == 1
+
+    def test_negative(self) -> None:
+        assert _sign_of(-0.5) == -1
+
+    def test_near_zero(self) -> None:
+        """Values within 1e-9 of zero count as zero."""
+        assert _sign_of(0.0) == 0
+        assert _sign_of(5e-10) == 0
+        assert _sign_of(-5e-10) == 0
+
+    def test_small_positive(self) -> None:
+        assert _sign_of(1e-8) == 1
+
+
+# ===========================================================================
+# 4. _exact_roots_deg1
+# ===========================================================================
+
+
+class TestExactRootsDeg1:
+    """_exact_roots_deg1: exact rational root of ax + b = 0."""
+
+    def test_simple(self) -> None:
+        """x - 1 = 0 → x = 1."""
+        root = _exact_roots_deg1((Fraction(-1), Fraction(1)))
+        assert root == [Fraction(1)]
+
+    def test_rational_root(self) -> None:
+        """2x + 3 = 0 → x = -3/2."""
+        root = _exact_roots_deg1((Fraction(3), Fraction(2)))
+        assert root == [Fraction(-3, 2)]
+
+    def test_zero_coefficient(self) -> None:
+        """If leading coefficient is zero, no root (constant)."""
+        roots = _exact_roots_deg1((Fraction(5), Fraction(0)))
+        assert roots == []
+
+    def test_negative_slope(self) -> None:
+        """-3x + 6 = 0 → x = 2."""
+        root = _exact_roots_deg1((Fraction(6), Fraction(-3)))
+        assert root == [Fraction(2)]
+
+
+# ===========================================================================
+# 5. _exact_roots_deg2
+# ===========================================================================
+
+
+class TestExactRootsDeg2:
+    """_exact_roots_deg2: exact rational roots of ax² + bx + c = 0."""
+
+    def test_two_integer_roots(self) -> None:
+        """x² - 3x + 2 = 0 → {1, 2}."""
+        roots = _exact_roots_deg2((Fraction(2), Fraction(-3), Fraction(1)))
+        assert roots == [Fraction(1), Fraction(2)]
+
+    def test_double_root(self) -> None:
+        """x² - 2x + 1 = 0 → {1} (double)."""
+        roots = _exact_roots_deg2((Fraction(1), Fraction(-2), Fraction(1)))
+        assert roots == [Fraction(1)]
+
+    def test_no_real_roots(self) -> None:
+        """x² + 1 = 0 → [] (no real roots)."""
+        roots = _exact_roots_deg2((Fraction(1), Fraction(0), Fraction(1)))
+        assert roots == []
+
+    def test_irrational_roots(self) -> None:
+        """x² - 2 = 0 → irrational, returns None."""
+        roots = _exact_roots_deg2((Fraction(-2), Fraction(0), Fraction(1)))
+        assert roots is None
+
+    def test_symmetric_roots(self) -> None:
+        """x² - 1 = 0 → {-1, 1}."""
+        roots = _exact_roots_deg2((Fraction(-1), Fraction(0), Fraction(1)))
+        assert roots == [Fraction(-1), Fraction(1)]
+
+
+# ===========================================================================
+# 6. _make_interval
+# ===========================================================================
+
+
+class TestMakeInterval:
+    """_make_interval: construct the correct IR interval condition."""
+
+    def test_unbounded_below_strict(self) -> None:
+        """(−∞, a) → Less(x, a)."""
+        result = _make_interval(X, None, ONE, True, True)
+        assert result == IRApply(LESS, (X, ONE))
+
+    def test_unbounded_below_nonstrict(self) -> None:
+        """(−∞, a] → LessEqual(x, a)."""
+        result = _make_interval(X, None, ONE, False, False)
+        assert result == IRApply(LESS_EQUAL, (X, ONE))
+
+    def test_unbounded_above_strict(self) -> None:
+        """(a, +∞) → Greater(x, a)."""
+        result = _make_interval(X, ONE, None, True, True)
+        assert result == IRApply(GREATER, (X, ONE))
+
+    def test_unbounded_above_nonstrict(self) -> None:
+        """[a, +∞) → GreaterEqual(x, a)."""
+        result = _make_interval(X, ONE, None, False, False)
+        assert result == IRApply(GREATER_EQUAL, (X, ONE))
+
+    def test_bounded_strict(self) -> None:
+        """(a, b) → And(Greater(x, a), Less(x, b))."""
+        a, b = IRInteger(-1), IRInteger(1)
+        result = _make_interval(X, a, b, True, True)
+        expected = IRApply(AND, (IRApply(GREATER, (X, a)), IRApply(LESS, (X, b))))
+        assert result == expected
+
+    def test_bounded_nonstrict(self) -> None:
+        """[a, b] → And(GreaterEqual(x, a), LessEqual(x, b))."""
+        a, b = IRInteger(1), IRInteger(2)
+        result = _make_interval(X, a, b, False, False)
+        expected = IRApply(
+            AND,
+            (IRApply(GREATER_EQUAL, (X, a)), IRApply(LESS_EQUAL, (X, b))),
+        )
+        assert result == expected
+
+    def test_both_none_all_reals(self) -> None:
+        """(−∞, +∞) → GreaterEqual(0, 0)."""
+        result = _make_interval(X, None, None, True, True)
+        assert result == IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))
+
+    def test_bounded_mixed(self) -> None:
+        """(a, b] → And(Greater(x, a), LessEqual(x, b))."""
+        a, b = IRInteger(-3), IRInteger(3)
+        result = _make_interval(X, a, b, True, False)  # lo strict, hi nonstrict
+        expected = IRApply(
+            AND,
+            (IRApply(GREATER, (X, a)), IRApply(LESS_EQUAL, (X, b))),
+        )
+        assert result == expected
+
+
+# ===========================================================================
+# 7. _solve_poly_ineq — core algorithm (no mocking needed)
+# ===========================================================================
+
+
+class TestSolvePolyIneqCore:
+    """_solve_poly_ineq: sign analysis + interval construction.
+
+    This tests the heart of the inequality solver by passing coefficients
+    and pre-computed roots directly, bypassing the polynomial bridge and
+    root-finding layers.
+    """
+
+    # Shorthand for "exact_roots_ir built from fractions"
+    @staticmethod
+    def _ir(fracs: list[Fraction]) -> list:
+        return [_frac_ir(f) for f in fracs]
+
+    def test_linear_greater(self) -> None:
+        """x - 1 > 0 → [Greater(x, 1)]."""
+        coeffs = (Fraction(-1), Fraction(1))
+        roots_f = [Fraction(1)]
+        roots_n = [1.0]
+        result = _solve_poly_ineq(
+            coeffs, want_positive=True, strict=True, var=X,
+            exact_roots_ir=self._ir(roots_f),
+            numeric_roots=roots_n,
+        )
+        assert len(result) == 1
+        assert result[0] == IRApply(GREATER, (X, IRInteger(1)))
+
+    def test_linear_less_equal(self) -> None:
+        """x - 1 <= 0 → [LessEqual(x, 1)]."""
+        coeffs = (Fraction(-1), Fraction(1))
+        roots_f = [Fraction(1)]
+        roots_n = [1.0]
+        result = _solve_poly_ineq(
+            coeffs, want_positive=False, strict=False, var=X,
+            exact_roots_ir=self._ir(roots_f),
+            numeric_roots=roots_n,
+        )
+        assert len(result) == 1
+        assert result[0] == IRApply(LESS_EQUAL, (X, IRInteger(1)))
+
+    def test_quad_two_roots_greater(self) -> None:
+        """x² - 1 > 0 → [Less(x, -1), Greater(x, 1)]."""
+        coeffs = (Fraction(-1), Fraction(0), Fraction(1))
+        roots_f = [Fraction(-1), Fraction(1)]
+        roots_n = [-1.0, 1.0]
+        result = _solve_poly_ineq(
+            coeffs, want_positive=True, strict=True, var=X,
+            exact_roots_ir=self._ir(roots_f),
+            numeric_roots=roots_n,
+        )
+        assert len(result) == 2
+        assert result[0] == IRApply(LESS, (X, IRInteger(-1)))
+        assert result[1] == IRApply(GREATER, (X, IRInteger(1)))
+
+    def test_quad_two_roots_greater_equal(self) -> None:
+        """x² - 1 >= 0 → [LessEqual(x, -1), GreaterEqual(x, 1)]."""
+        coeffs = (Fraction(-1), Fraction(0), Fraction(1))
+        roots_f = [Fraction(-1), Fraction(1)]
+        roots_n = [-1.0, 1.0]
+        result = _solve_poly_ineq(
+            coeffs, want_positive=True, strict=False, var=X,
+            exact_roots_ir=self._ir(roots_f),
+            numeric_roots=roots_n,
+        )
+        assert len(result) == 2
+        assert result[0] == IRApply(LESS_EQUAL, (X, IRInteger(-1)))
+        assert result[1] == IRApply(GREATER_EQUAL, (X, IRInteger(1)))
+
+    def test_quad_interval_less(self) -> None:
+        """x² - 1 < 0 → [And(Greater(x,-1), Less(x,1))]."""
+        coeffs = (Fraction(-1), Fraction(0), Fraction(1))
+        roots_f = [Fraction(-1), Fraction(1)]
+        roots_n = [-1.0, 1.0]
+        result = _solve_poly_ineq(
+            coeffs, want_positive=False, strict=True, var=X,
+            exact_roots_ir=self._ir(roots_f),
+            numeric_roots=roots_n,
+        )
+        assert len(result) == 1
+        inner = result[0]
+        assert isinstance(inner, IRApply) and inner.head is AND
+        lo, hi = inner.args
+        assert lo == IRApply(GREATER, (X, IRInteger(-1)))
+        assert hi == IRApply(LESS, (X, IRInteger(1)))
+
+    def test_quad_interval_less_equal(self) -> None:
+        """x² - 3x + 2 <= 0 → [And(GreaterEqual(x,1), LessEqual(x,2))]."""
+        coeffs = (Fraction(2), Fraction(-3), Fraction(1))
+        roots_f = [Fraction(1), Fraction(2)]
+        roots_n = [1.0, 2.0]
+        result = _solve_poly_ineq(
+            coeffs, want_positive=False, strict=False, var=X,
+            exact_roots_ir=self._ir(roots_f),
+            numeric_roots=roots_n,
+        )
+        assert len(result) == 1
+        inner = result[0]
+        assert isinstance(inner, IRApply) and inner.head is AND
+        lo, hi = inner.args
+        assert lo == IRApply(GREATER_EQUAL, (X, IRInteger(1)))
+        assert hi == IRApply(LESS_EQUAL, (X, IRInteger(2)))
+
+    def test_all_reals_trivially_true(self) -> None:
+        """x² + 1 > 0 — no real roots, always positive → all reals."""
+        coeffs = (Fraction(1), Fraction(0), Fraction(1))
+        result = _solve_poly_ineq(
+            coeffs, want_positive=True, strict=True, var=X,
+            exact_roots_ir=[],
+            numeric_roots=[],
+        )
+        assert len(result) == 1
+        assert result[0] == IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))
+
+    def test_no_solution(self) -> None:
+        """x² + 1 < 0 — no real roots, never negative → empty list."""
+        coeffs = (Fraction(1), Fraction(0), Fraction(1))
+        result = _solve_poly_ineq(
+            coeffs, want_positive=False, strict=True, var=X,
+            exact_roots_ir=[],
+            numeric_roots=[],
+        )
+        assert result == []
+
+    def test_double_root_strict_two_intervals(self) -> None:
+        """(x-1)² > 0 — double root at 1; f>0 except at the root itself.
+
+        _solve_poly_ineq sees two open intervals (−∞,1) and (1,+∞) both
+        positive.  Result: [Less(x,1), Greater(x,1)].
+        """
+        coeffs = (Fraction(1), Fraction(-2), Fraction(1))
+        roots_f = [Fraction(1)]
+        roots_n = [1.0]
+        result = _solve_poly_ineq(
+            coeffs, want_positive=True, strict=True, var=X,
+            exact_roots_ir=self._ir(roots_f),
+            numeric_roots=roots_n,
+        )
+        # Both open intervals satisfy the strict inequality.
+        assert len(result) == 2
+
+    def test_double_root_nonstrict_all_reals(self) -> None:
+        """(x-1)² >= 0 — always non-negative → all reals sentinel."""
+        coeffs = (Fraction(1), Fraction(-2), Fraction(1))
+        roots_f = [Fraction(1)]
+        roots_n = [1.0]
+        result = _solve_poly_ineq(
+            coeffs, want_positive=True, strict=False, var=X,
+            exact_roots_ir=self._ir(roots_f),
+            numeric_roots=roots_n,
+        )
+        assert len(result) == 1
+        assert result[0] == IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))
+
+    def test_float_boundaries_when_no_exact(self) -> None:
+        """When exact_roots_ir=None, boundaries become IRFloat."""
+        coeffs = (Fraction(-2), Fraction(0), Fraction(1))  # x²-2 > 0
+        # exact roots are irrational → pass None to force IRFloat boundaries
+        import math
+        sqrt2 = math.sqrt(2)
+        roots_n = sorted([-sqrt2, sqrt2])
+        result = _solve_poly_ineq(
+            coeffs, want_positive=True, strict=True, var=X,
+            exact_roots_ir=None,
+            numeric_roots=roots_n,
+        )
+        assert len(result) == 2
+        # Boundaries should be IRFloat (not IRInteger/IRRational)
+        lo_cond = result[0]  # Less(x, -√2)
+        assert isinstance(lo_cond, IRApply) and lo_cond.head is LESS
+        assert isinstance(lo_cond.args[1], IRFloat)
+
+
+# ===========================================================================
+# 8. try_solve_inequality — full integration via mock bridge
+# ===========================================================================
+
+
+class TestLinearIneq:
+    """try_solve_inequality: linear polynomial x + b op 0."""
+
+    def test_x_minus_1_greater(self) -> None:
+        """x - 1 > 0 → [Greater(x, 1)]."""
+        # coeffs for x - 1: ascending (c0=-1, c1=1)
+        with patch_bridge((-1, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result == [IRApply(GREATER, (X, IRInteger(1)))]
+
+    def test_x_minus_1_greater_equal(self) -> None:
+        """x - 1 >= 0 → [GreaterEqual(x, 1)]."""
+        with patch_bridge((-1, 1)):
+            result = try_solve_inequality(_ineq(GREATER_EQUAL), X)
+        assert result == [IRApply(GREATER_EQUAL, (X, IRInteger(1)))]
+
+    def test_x_minus_1_less(self) -> None:
+        """x - 1 < 0 → [Less(x, 1)]."""
+        with patch_bridge((-1, 1)):
+            result = try_solve_inequality(_ineq(LESS), X)
+        assert result == [IRApply(LESS, (X, IRInteger(1)))]
+
+    def test_x_minus_1_less_equal(self) -> None:
+        """x - 1 <= 0 → [LessEqual(x, 1)]."""
+        with patch_bridge((-1, 1)):
+            result = try_solve_inequality(_ineq(LESS_EQUAL), X)
+        assert result == [IRApply(LESS_EQUAL, (X, IRInteger(1)))]
+
+    def test_rational_root(self) -> None:
+        """2x + 3 < 0 → [Less(x, -3/2)]."""
+        # ascending: (3, 2) → root at -3/2
+        with patch_bridge((3, 2)):
+            result = try_solve_inequality(_ineq(LESS), X)
+        assert result is not None
+        assert len(result) == 1
+        node = result[0]
+        assert isinstance(node, IRApply) and node.head is LESS
+        assert node.args[1] == IRRational(-3, 2)
+
+    def test_negative_slope(self) -> None:
+        """-x + 2 > 0 → root at 2; positive for x<2 → [Less(x, 2)]."""
+        # ascending: (2, -1) → root at 2
+        with patch_bridge((2, -1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result == [IRApply(LESS, (X, IRInteger(2)))]
+
+
+class TestQuadIneqTwoRoots:
+    """Quadratic polynomial with two distinct rational roots."""
+
+    def test_x2_minus_1_greater(self) -> None:
+        """x² - 1 > 0 → [Less(x,-1), Greater(x,1)]."""
+        with patch_bridge((-1, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0] == IRApply(LESS, (X, IRInteger(-1)))
+        assert result[1] == IRApply(GREATER, (X, IRInteger(1)))
+
+    def test_x2_minus_1_greater_equal(self) -> None:
+        """x² - 1 >= 0 → [LessEqual(x,-1), GreaterEqual(x,1)]."""
+        with patch_bridge((-1, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER_EQUAL), X)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0] == IRApply(LESS_EQUAL, (X, IRInteger(-1)))
+        assert result[1] == IRApply(GREATER_EQUAL, (X, IRInteger(1)))
+
+    def test_x2_minus_1_less(self) -> None:
+        """x² - 1 < 0 → [And(Greater(x,-1), Less(x,1))]."""
+        with patch_bridge((-1, 0, 1)):
+            result = try_solve_inequality(_ineq(LESS), X)
+        assert result is not None
+        assert len(result) == 1
+        inner = result[0]
+        assert inner.head is AND
+        assert inner.args[0] == IRApply(GREATER, (X, IRInteger(-1)))
+        assert inner.args[1] == IRApply(LESS, (X, IRInteger(1)))
+
+    def test_x2_minus_1_less_equal(self) -> None:
+        """x² - 1 <= 0 → [And(GreaterEqual(x,-1), LessEqual(x,1))]."""
+        with patch_bridge((-1, 0, 1)):
+            result = try_solve_inequality(_ineq(LESS_EQUAL), X)
+        assert result is not None
+        assert len(result) == 1
+        inner = result[0]
+        assert inner.head is AND
+        assert inner.args[0] == IRApply(GREATER_EQUAL, (X, IRInteger(-1)))
+        assert inner.args[1] == IRApply(LESS_EQUAL, (X, IRInteger(1)))
+
+    def test_x2_minus_3x_plus_2_less_equal(self) -> None:
+        """x² - 3x + 2 <= 0 → [And(GreaterEqual(x,1), LessEqual(x,2))]."""
+        with patch_bridge((2, -3, 1)):
+            result = try_solve_inequality(_ineq(LESS_EQUAL), X)
+        assert result is not None
+        assert len(result) == 1
+        inner = result[0]
+        assert inner.head is AND
+        assert inner.args[0] == IRApply(GREATER_EQUAL, (X, IRInteger(1)))
+        assert inner.args[1] == IRApply(LESS_EQUAL, (X, IRInteger(2)))
+
+    def test_x2_minus_3x_plus_2_less(self) -> None:
+        """x² - 3x + 2 < 0 → [And(Greater(x,1), Less(x,2))]."""
+        with patch_bridge((2, -3, 1)):
+            result = try_solve_inequality(_ineq(LESS), X)
+        assert result is not None
+        assert len(result) == 1
+        inner = result[0]
+        assert inner.head is AND
+        assert inner.args[0] == IRApply(GREATER, (X, IRInteger(1)))
+        assert inner.args[1] == IRApply(LESS, (X, IRInteger(2)))
+
+
+class TestQuadIneqDoubleRoot:
+    """Quadratic with a double root: (x-1)² = x² - 2x + 1."""
+
+    def test_double_root_strict(self) -> None:
+        """(x-1)² > 0 → two open half-lines (x<1 and x>1)."""
+        with patch_bridge((1, -2, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result is not None
+        # Both intervals (−∞,1) and (1,+∞) satisfy the strict inequality.
+        assert len(result) == 2
+
+    def test_double_root_nonstrict(self) -> None:
+        """(x-1)² >= 0 → all reals (trivially true)."""
+        with patch_bridge((1, -2, 1)):
+            result = try_solve_inequality(_ineq(GREATER_EQUAL), X)
+        assert result == [IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))]
+
+
+class TestQuadIneqNoRoots:
+    """Quadratic with no real roots: x² + 1."""
+
+    def test_always_positive(self) -> None:
+        """x² + 1 > 0 → all reals."""
+        with patch_bridge((1, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result == [IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))]
+
+    def test_never_negative(self) -> None:
+        """x² + 1 < 0 → empty list."""
+        with patch_bridge((1, 0, 1)):
+            result = try_solve_inequality(_ineq(LESS), X)
+        assert result == []
+
+    def test_nonstrict_always_true(self) -> None:
+        """x² + 1 >= 0 → all reals."""
+        with patch_bridge((1, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER_EQUAL), X)
+        assert result == [IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))]
+
+
+class TestHighDegree:
+    """Higher-degree polynomials (degrees 3 and 4) use numeric roots."""
+
+    def test_cubic_x3_minus_x_greater(self) -> None:
+        """x³ - x = x(x-1)(x+1) > 0 → two positive intervals."""
+        # ascending: (0, -1, 0, 1)
+        with patch_bridge((0, -1, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result is not None
+        # Roots: -1, 0, 1.  Positive on (-1,0) and (1,+∞).
+        assert len(result) == 2
+
+    def test_quartic_x4_minus_1_greater(self) -> None:
+        """x⁴ - 1 > 0 → two outer intervals."""
+        # ascending: (-1, 0, 0, 0, 1)
+        with patch_bridge((-1, 0, 0, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_quartic_boundaries_are_ir_float(self) -> None:
+        """x⁴ - 1 > 0: boundaries come from numeric solver → IRFloat."""
+        with patch_bridge((-1, 0, 0, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result is not None
+        # The outer Less(x, a) condition should have IRFloat boundary.
+        lo_cond = result[0]
+        assert isinstance(lo_cond, IRApply)
+        boundary = lo_cond.args[1]
+        assert isinstance(boundary, IRFloat)
+
+
+# ===========================================================================
+# 9. Constant polynomial edge cases
+# ===========================================================================
+
+
+class TestConstantPolynomial:
+    """Degree-0 polynomials: always true or always false."""
+
+    def test_positive_constant_greater(self) -> None:
+        """f = 5 > 0 → always satisfied → all reals."""
+        # Bridge returns a constant (degree 0)
+        with patch_bridge((5,)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result == [IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))]
+
+    def test_negative_constant_greater(self) -> None:
+        """f = -3 > 0 → never satisfied → []."""
+        with patch_bridge((-3,)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result == []
+
+    def test_zero_constant_nonstrict(self) -> None:
+        """f = 0 >= 0 → all reals (0 >= 0 is true)."""
+        with patch_bridge((0,)):
+            result = try_solve_inequality(_ineq(GREATER_EQUAL), X)
+        assert result == [IRApply(GREATER_EQUAL, (IRInteger(0), IRInteger(0)))]
+
+    def test_zero_constant_strict(self) -> None:
+        """f = 0 > 0 → never satisfied (0 is not strictly positive)."""
+        with patch_bridge((0,)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result == []
+
+
+# ===========================================================================
+# 10. Fallthrough / None cases
+# ===========================================================================
+
+
+class TestFallthrough:
+    """Cases that should return None (unsupported or unrecognised)."""
+
+    def test_non_ir_apply(self) -> None:
+        """Non-IRApply input → None."""
+        assert try_solve_inequality(IRInteger(1), X) is None
+
+    def test_equal_head_unsupported(self) -> None:
+        """An Equal(...) IR node is not an inequality → None."""
+        from symbolic_ir import EQUAL
+
+        eq_node = IRApply(EQUAL, (X, IRInteger(0)))
+        assert try_solve_inequality(eq_node, X) is None
+
+    def test_wrong_arg_count(self) -> None:
+        """Inequality with 3 args (malformed) → None."""
+        node = IRApply(GREATER, (X, IRInteger(0), IRInteger(1)))
+        assert try_solve_inequality(node, X) is None
+
+    def test_bridge_unavailable(self) -> None:
+        """If polynomial bridge is not installed, return None."""
+        # Remove bridge from sys.modules if present.
+        old_bridge = sys.modules.pop("symbolic_vm.polynomial_bridge", None)
+        old_vm = sys.modules.pop("symbolic_vm", None)
+        try:
+            result = try_solve_inequality(_ineq(GREATER), X)
+            assert result is None
+        finally:
+            if old_vm is not None:
+                sys.modules["symbolic_vm"] = old_vm
+            if old_bridge is not None:
+                sys.modules["symbolic_vm.polynomial_bridge"] = old_bridge
+
+    def test_bridge_returns_none(self) -> None:
+        """If to_rational returns None (non-polynomial), return None."""
+        with patch_bridge_none():
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result is None
+
+    def test_degree_above_4(self) -> None:
+        """Degree-5 polynomial → None (unsupported)."""
+        # ascending: (1, 0, 0, 0, 0, 1) — x^5 + 1
+        with patch_bridge((1, 0, 0, 0, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result is None
+
+    def test_lhs_zero_form(self) -> None:
+        """0 > x — lhs is 0, rhs is x; direction is flipped internally.
+
+        0 > x  ↔  x < 0, so f_ir = x, want_positive flipped to False.
+        Bridge returns ascending (0, 1) for x → root at 0 → Less(x, 0).
+        """
+        node = IRApply(GREATER, (IRInteger(0), X))
+        with patch_bridge((0, 1)):
+            result = try_solve_inequality(node, X)
+        assert result is not None
+        assert len(result) == 1
+        assert result[0] == IRApply(LESS, (X, IRInteger(0)))
+
+    def test_irrational_quadratic_via_try_solve(self) -> None:
+        """x² - 2 > 0 — irrational roots force numeric path in try_solve_inequality.
+
+        Ascending coeffs: (-2, 0, 1) → irrational roots ±√2.
+        Result: two outer intervals with IRFloat boundaries.
+        """
+        with patch_bridge((-2, 0, 1)):
+            result = try_solve_inequality(_ineq(GREATER), X)
+        assert result is not None
+        assert len(result) == 2
+        # Boundaries must be IRFloat (irrational)
+        lo_cond = result[0]
+        assert isinstance(lo_cond, IRApply) and lo_cond.head is LESS
+        assert isinstance(lo_cond.args[1], IRFloat)
+
+    def test_rational_function_rejected(self) -> None:
+        """to_rational returning non-trivial denominator → None."""
+        # Return a rational function (1+x)/(1+x²)
+        mock_mod = types.ModuleType("symbolic_vm.polynomial_bridge")
+        mock_mod.to_rational = lambda e, v: (  # noqa: ARG005
+            (Fraction(1), Fraction(1)),
+            (Fraction(1), Fraction(0), Fraction(1)),
+        )
+        old_bridge = sys.modules.get("symbolic_vm.polynomial_bridge")
+        old_vm = sys.modules.get("symbolic_vm")
+        sys.modules["symbolic_vm"] = types.ModuleType("symbolic_vm")
+        sys.modules["symbolic_vm.polynomial_bridge"] = mock_mod
+        try:
+            result = try_solve_inequality(_ineq(GREATER), X)
+            assert result is None
+        finally:
+            if old_vm is None:
+                sys.modules.pop("symbolic_vm", None)
+            else:
+                sys.modules["symbolic_vm"] = old_vm
+            if old_bridge is None:
+                sys.modules.pop("symbolic_vm.polynomial_bridge", None)
+            else:
+                sys.modules["symbolic_vm.polynomial_bridge"] = old_bridge

--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.18.0 — 2026-05-05
+
+**Phase 27 — Polynomial inequality solving via MACSYMA surface syntax.**
+
+`solve(p(x) op c, x)` (op ∈ {<, >, ≤, ≥}) now returns a list of interval
+conditions via the upgraded `symbolic-vm` 0.47.0.  No changes to the
+runtime layer itself — this is a dependency bump.
+
+```macsyma
+solve(x - 1 > 0, x)           →  [x > 1]
+solve(x^2 - 1 < 0, x)         →  [and(x > -1, x < 1)]
+solve(x^2 + 1 > 0, x)         →  [0 >= 0]
+```
+
+Dependency bump: `symbolic-vm` ≥ 0.47.0 (was ≥ 0.46.0).
+
+---
+
 ## 1.17.0 — 2026-05-05
 
 **Phase 26 — Transcendental equation solving via MACSYMA surface syntax.**

--- a/code/packages/python/macsyma-runtime/pyproject.toml
+++ b/code/packages/python/macsyma-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-macsyma-runtime"
-version = "1.17.0"
+version = "1.18.0"
 description = "MACSYMA-specific runtime layer on top of the symbolic VM — history, $/; terminators, kill, ev, name table."
 requires-python = ">=3.12"
 license = "MIT"
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["macsyma", "maxima", "cas", "symbolic", "runtime", "education"]
 dependencies = [
     "coding-adventures-symbolic-ir>=0.13.0",
-    "coding-adventures-symbolic-vm>=0.46.0",
+    "coding-adventures-symbolic-vm>=0.47.0",
     "coding-adventures-cas-pattern-matching>=0.2.0",
     "coding-adventures-cas-substitution>=0.1.0",
     "coding-adventures-cas-simplify>=0.1.0",

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.47.0 — 2026-05-05
+
+**Phase 27 — Polynomial inequality solving.**
+
+`solve_handler` in `cas_handlers.py` now dispatches polynomial inequalities
+``p(x) op 0`` (op ∈ {<, >, ≤, ≥}) to the new `cas_solve.try_solve_inequality`
+function before falling through to equation solving.
+
+- Inequality heads (`Less`, `Greater`, `LessEqual`, `GreaterEqual`) are
+  detected immediately after the system-form check, before `_unwrap_equation`
+  is called (which would strip the comparison head).
+- `cas_solve>=0.8.0` is now required (was `>=0.7.0`).
+- New import: `from cas_solve import try_solve_inequality as _try_inequality`.
+
+**Surface syntax** (via MACSYMA):
+
+```
+solve(x - 1 > 0, x)          →  [x > 1]
+solve(x^2 - 1 < 0, x)        →  [and(x > -1, x < 1)]
+solve(x^2 - 3*x + 2 <= 0, x) →  [and(x >= 1, x <= 2)]
+solve(x^2 + 1 > 0, x)        →  [0 >= 0]  (all reals)
+solve(x^2 + 1 < 0, x)        →  []        (no solution)
+```
+
+---
+
 ## 0.46.0 — 2026-05-05
 
 **Phase 26 — Transcendental equation solving + Lambert W handler.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.46.0"
+version = "0.47.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -20,7 +20,7 @@ dependencies = [
     "coding-adventures-cas-substitution",
     "coding-adventures-cas-simplify>=0.3.0",
     "coding-adventures-cas-factor>=0.3.0",
-    "coding-adventures-cas-solve>=0.7.0",
+    "coding-adventures-cas-solve>=0.8.0",
     "coding-adventures-cas-list-operations",
     "coding-adventures-cas-matrix>=0.3.0",
     "coding-adventures-cas-limit-series>=0.2.0",

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -115,6 +115,7 @@ from cas_solve import nsolve_fraction_poly as _nsolve_fraction_poly
 from cas_solve import solve_cubic as _solve_cubic
 from cas_solve import solve_linear_system as _solve_linear_system
 from cas_solve import solve_quartic as _solve_quartic
+from cas_solve import try_solve_inequality as _try_inequality
 from cas_solve import try_solve_transcendental as _try_transcendental
 from cas_substitution import subst
 from polynomial import (
@@ -1063,6 +1064,20 @@ def solve_handler(_vm: VM, expr: IRApply) -> IRNode:
     # -----------------------------------------------------------------
     if not isinstance(var_ir, IRSymbol):
         return expr
+
+    # -----------------------------------------------------------------
+    # Phase 27 — Polynomial inequality solving
+    # Dispatch before polynomial extraction: inequalities are not
+    # equations and _unwrap_equation would strip the comparison head.
+    # -----------------------------------------------------------------
+    if (
+        isinstance(eq_ir, IRApply)
+        and isinstance(eq_ir.head, IRSymbol)
+        and eq_ir.head.name in {"Less", "Greater", "LessEqual", "GreaterEqual"}
+    ):
+        ineq_sols = _try_inequality(eq_ir, var_ir)
+        if ineq_sols is not None:
+            return IRApply(IRSymbol("List"), tuple(ineq_sols))
 
     poly_ir = _unwrap_equation(eq_ir)
     coeffs = _ir_to_fraction_poly(poly_ir, var_ir)

--- a/code/packages/python/symbolic-vm/tests/test_phase27.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase27.py
@@ -1,0 +1,685 @@
+"""Phase 27 — Polynomial Inequality Solving integration tests.
+
+Tests the full pipeline from ``Solve(inequality, var)`` through
+``solve_handler`` → ``_try_inequality`` → ``cas_solve.try_solve_inequality``.
+
+Test structure
+--------------
+TestPhase27_Linear          — degree-1 inequalities (x op c)
+TestPhase27_QuadTwoRoots    — quadratic with two distinct rational roots
+TestPhase27_QuadDoubleRoot  — quadratic with a double root
+TestPhase27_QuadNoRoots     — quadratic with no real roots (all reals / empty)
+TestPhase27_HighDegree      — cubic and quartic polynomials
+TestPhase27_Normalisation   — lhs op rhs with non-zero rhs (normalised f=lhs-rhs)
+TestPhase27_Fallthrough     — inequalities that fall back to unevaluated
+TestPhase27_Regressions     — Phase 1–26 features still work correctly
+TestPhase27_Macsyma         — end-to-end MACSYMA surface-syntax tests
+
+Verification strategy
+---------------------
+
+For each solution list we verify:
+
+1. **Structure** — result is a ``List``, has the expected number of elements,
+   and each element has the expected IR head.
+2. **Numeric back-check** — for boundary conditions we evaluate both a point
+   inside the solution interval and a point outside it to confirm the
+   original polynomial has the right sign.
+"""
+
+from __future__ import annotations
+
+import pytest
+from symbolic_ir import (
+    GREATER,
+    GREATER_EQUAL,
+    LESS,
+    LESS_EQUAL,
+    MUL,
+    POW,
+    SUB,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm.backends import SymbolicBackend
+from symbolic_vm.vm import VM
+
+# ---------------------------------------------------------------------------
+# Shared symbols / constants
+# ---------------------------------------------------------------------------
+
+X = IRSymbol("x")
+ZERO = IRInteger(0)
+ONE = IRInteger(1)
+SOLVE = IRSymbol("Solve")
+LIST = IRSymbol("List")
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+def _solve(ineq_ir: IRNode, var: IRSymbol = X) -> IRNode:
+    """Evaluate ``Solve(ineq_ir, var)`` and return the result."""
+    return _make_vm().eval(IRApply(SOLVE, (ineq_ir, var)))
+
+
+def _is_list(node: IRNode) -> bool:
+    return (
+        isinstance(node, IRApply)
+        and isinstance(node.head, IRSymbol)
+        and node.head.name == "List"
+    )
+
+
+def _list_args(node: IRNode) -> tuple[IRNode, ...]:
+    assert _is_list(node), f"Expected List, got {node!r}"
+    assert isinstance(node, IRApply)
+    return node.args
+
+
+def _ineq(head: IRSymbol, lhs: IRNode = X, rhs: IRNode = ZERO) -> IRApply:
+    """Build a simple ``head(lhs, rhs)`` comparison node."""
+    return IRApply(head, (lhs, rhs))
+
+
+def _sub(a: IRNode, b: IRNode) -> IRApply:
+    return IRApply(SUB, (a, b))
+
+
+def _pow(base: IRNode, exp: IRNode) -> IRApply:
+    return IRApply(POW, (base, exp))
+
+
+def _mul(a: IRNode, b: IRNode) -> IRApply:
+    return IRApply(MUL, (a, b))
+
+
+def _head_name(node: IRNode) -> str | None:
+    """Return the head name of an IRApply, or None."""
+    if isinstance(node, IRApply) and isinstance(node.head, IRSymbol):
+        return node.head.name
+    return None
+
+
+def _is_all_reals(node: IRNode) -> bool:
+    """True iff node is the ``GreaterEqual(0, 0)`` all-reals sentinel."""
+    return (
+        isinstance(node, IRApply)
+        and isinstance(node.head, IRSymbol)
+        and node.head.name == "GreaterEqual"
+        and len(node.args) == 2
+        and isinstance(node.args[0], IRInteger)
+        and node.args[0].value == 0
+        and isinstance(node.args[1], IRInteger)
+        and node.args[1].value == 0
+    )
+
+
+def _boundary_value(cond: IRNode) -> float | None:
+    """Extract the boundary float value from a simple comparison condition.
+
+    Handles ``Less(x, a)``, ``LessEqual(x, a)``,
+    ``Greater(x, a)``, ``GreaterEqual(x, a)`` where ``a`` is numeric.
+    Returns ``None`` for non-simple conditions.
+    """
+    if not isinstance(cond, IRApply):
+        return None
+    if _head_name(cond) not in {"Less", "Greater", "LessEqual", "GreaterEqual"}:
+        return None
+    if len(cond.args) != 2:
+        return None
+    boundary = cond.args[1]
+    if isinstance(boundary, IRInteger):
+        return float(boundary.value)
+    if isinstance(boundary, IRRational):
+        return boundary.numer / boundary.denom
+    if isinstance(boundary, IRFloat):
+        return boundary.value
+    return None
+
+
+# ===========================================================================
+# 1. Linear inequalities
+# ===========================================================================
+
+
+class TestPhase27_Linear:
+    """Degree-1 polynomial inequalities with exact rational boundaries."""
+
+    def test_x_minus_1_greater(self) -> None:
+        """x - 1 > 0  →  [Greater(x, 1)]."""
+        result = _solve(_ineq(GREATER, _sub(X, ONE)))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "Greater"
+        assert _boundary_value(sols[0]) == pytest.approx(1.0)
+
+    def test_x_minus_1_greater_equal(self) -> None:
+        """x - 1 >= 0  →  [GreaterEqual(x, 1)]."""
+        result = _solve(_ineq(GREATER_EQUAL, _sub(X, ONE)))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "GreaterEqual"
+
+    def test_x_minus_1_less(self) -> None:
+        """x - 1 < 0  →  [Less(x, 1)]."""
+        result = _solve(_ineq(LESS, _sub(X, ONE)))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "Less"
+
+    def test_x_minus_1_less_equal(self) -> None:
+        """x - 1 <= 0  →  [LessEqual(x, 1)]."""
+        result = _solve(_ineq(LESS_EQUAL, _sub(X, ONE)))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "LessEqual"
+
+    def test_rational_root_boundary(self) -> None:
+        """2x + 3 > 0: root at x = -3/2.
+
+        The boundary should be an exact ``IRRational``.
+        """
+        # Build 2x + 3
+        two_x = _mul(IRInteger(2), X)
+        two_x_plus_3 = IRApply(
+            IRSymbol("Add"), (two_x, IRInteger(3))
+        )
+        result = _solve(_ineq(GREATER, two_x_plus_3))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        b = _boundary_value(sols[0])
+        assert b is not None
+        assert b == pytest.approx(-1.5)  # -3/2
+
+    def test_boundary_exact_integer(self) -> None:
+        """x - 5 < 0: boundary is the exact integer 5."""
+        f = _sub(X, IRInteger(5))
+        result = _solve(_ineq(LESS, f))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "Less"
+        node = sols[0]
+        assert isinstance(node, IRApply)
+        assert isinstance(node.args[1], IRInteger)
+        assert node.args[1].value == 5
+
+
+# ===========================================================================
+# 2. Quadratic — two distinct rational roots
+# ===========================================================================
+
+
+class TestPhase27_QuadTwoRoots:
+    """x² - (a+b)x + ab = 0 → roots a, b; four inequality directions."""
+
+    # x² - 1 = (x-1)(x+1), roots ±1
+    _X2_MINUS_1 = _sub(_pow(X, IRInteger(2)), ONE)
+
+    def test_x2_minus_1_greater(self) -> None:
+        """x² - 1 > 0  →  [Less(x, -1), Greater(x, 1)]."""
+        result = _solve(_ineq(GREATER, self._X2_MINUS_1))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _head_name(sols[0]) == "Less"   # x < -1
+        assert _head_name(sols[1]) == "Greater"  # x > 1
+        assert _boundary_value(sols[0]) == pytest.approx(-1.0)
+        assert _boundary_value(sols[1]) == pytest.approx(1.0)
+
+    def test_x2_minus_1_greater_equal(self) -> None:
+        """x² - 1 >= 0  →  [LessEqual(x, -1), GreaterEqual(x, 1)]."""
+        result = _solve(_ineq(GREATER_EQUAL, self._X2_MINUS_1))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _head_name(sols[0]) == "LessEqual"
+        assert _head_name(sols[1]) == "GreaterEqual"
+
+    def test_x2_minus_1_less(self) -> None:
+        """x² - 1 < 0  →  [And(Greater(x,-1), Less(x,1))]."""
+        result = _solve(_ineq(LESS, self._X2_MINUS_1))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        inner = sols[0]
+        assert _head_name(inner) == "And"
+        assert isinstance(inner, IRApply)
+        lo, hi = inner.args
+        assert _head_name(lo) == "Greater"
+        assert _head_name(hi) == "Less"
+        assert _boundary_value(lo) == pytest.approx(-1.0)
+        assert _boundary_value(hi) == pytest.approx(1.0)
+
+    def test_x2_minus_1_less_equal(self) -> None:
+        """x² - 1 <= 0  →  [And(GreaterEqual(x,-1), LessEqual(x,1))]."""
+        result = _solve(_ineq(LESS_EQUAL, self._X2_MINUS_1))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        inner = sols[0]
+        assert _head_name(inner) == "And"
+        assert isinstance(inner, IRApply)
+        lo, hi = inner.args
+        assert _head_name(lo) == "GreaterEqual"
+        assert _head_name(hi) == "LessEqual"
+
+    def test_x2_minus_3x_plus_2_less_equal(self) -> None:
+        """x²-3x+2 <= 0 → And(GreaterEqual(x,1), LessEqual(x,2))."""
+        # Build x^2 - 3x + 2 = Sub(Sub(x^2, 3x), -2)
+        x2 = _pow(X, IRInteger(2))
+        three_x = _mul(IRInteger(3), X)
+        # Sub(Sub(x^2, 3x), -2) = x^2 - 3x - (-2) = x^2 - 3x + 2  ✓
+        f2 = _sub(_sub(x2, three_x), IRInteger(-2))
+        result = _solve(_ineq(LESS_EQUAL, f2))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        inner = sols[0]
+        assert _head_name(inner) == "And"
+        assert isinstance(inner, IRApply)
+        lo, hi = inner.args
+        assert _head_name(lo) == "GreaterEqual"
+        assert _head_name(hi) == "LessEqual"
+        assert _boundary_value(lo) == pytest.approx(1.0)
+        assert _boundary_value(hi) == pytest.approx(2.0)
+
+    def test_boundary_points_numeric(self) -> None:
+        """x² - 1 > 0: verify that x=-2 satisfies and x=0 does not."""
+        result = _solve(_ineq(GREATER, self._X2_MINUS_1))
+        sols = _list_args(result)
+        # sols[0] is Less(x, -1): x=-2 satisfies, x=0 does not
+        cond0 = sols[0]
+        b0 = _boundary_value(cond0)
+        assert b0 == pytest.approx(-1.0)
+        # p(-2) = 4 - 1 = 3 > 0  ✓
+        assert (-2.0) ** 2 - 1 > 0
+        # p(0) = -1 < 0  (not in solution)
+        assert 0.0**2 - 1 < 0
+
+
+# ===========================================================================
+# 3. Quadratic — double root
+# ===========================================================================
+
+
+class TestPhase27_QuadDoubleRoot:
+    """(x - 1)² = x² - 2x + 1."""
+
+    # (x-1)^2 = x^2 - 2x + 1
+    @staticmethod
+    def _f() -> IRApply:
+        x2 = _pow(X, IRInteger(2))
+        two_x = _mul(IRInteger(2), X)
+        return _sub(_sub(x2, two_x), IRInteger(-1))  # x^2 - 2x - (-1) = x^2 - 2x + 1
+
+    def test_strict_gives_two_half_lines(self) -> None:
+        """(x-1)² > 0  →  [Less(x,1), Greater(x,1)]."""
+        result = _solve(_ineq(GREATER, self._f()))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _head_name(sols[0]) == "Less"
+        assert _head_name(sols[1]) == "Greater"
+        # Both boundary values are 1.
+        assert _boundary_value(sols[0]) == pytest.approx(1.0)
+        assert _boundary_value(sols[1]) == pytest.approx(1.0)
+
+    def test_nonstrict_all_reals(self) -> None:
+        """(x-1)² >= 0  →  all reals (trivially satisfied)."""
+        result = _solve(_ineq(GREATER_EQUAL, self._f()))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _is_all_reals(sols[0])
+
+
+# ===========================================================================
+# 4. Quadratic — no real roots
+# ===========================================================================
+
+
+class TestPhase27_QuadNoRoots:
+    """x² + 1 has no real roots: always positive."""
+
+    # x^2 + 1
+    _X2_PLUS_1 = IRApply(
+        IRSymbol("Add"), (_pow(X, IRInteger(2)), ONE)
+    )
+
+    def test_always_positive_greater(self) -> None:
+        """x² + 1 > 0  →  all reals."""
+        result = _solve(_ineq(GREATER, self._X2_PLUS_1))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _is_all_reals(sols[0])
+
+    def test_always_positive_greater_equal(self) -> None:
+        """x² + 1 >= 0  →  all reals."""
+        result = _solve(_ineq(GREATER_EQUAL, self._X2_PLUS_1))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _is_all_reals(sols[0])
+
+    def test_never_negative_less(self) -> None:
+        """x² + 1 < 0  →  empty list."""
+        result = _solve(_ineq(LESS, self._X2_PLUS_1))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 0
+
+    def test_never_negative_less_equal(self) -> None:
+        """x² + 1 <= 0  →  empty list."""
+        result = _solve(_ineq(LESS_EQUAL, self._X2_PLUS_1))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 0
+
+
+# ===========================================================================
+# 5. Higher-degree polynomials (numeric roots → IRFloat boundaries)
+# ===========================================================================
+
+
+class TestPhase27_HighDegree:
+    """Cubic and quartic inequalities; boundaries are IRFloat."""
+
+    def test_cubic_three_roots_greater(self) -> None:
+        """x³ - x = x(x-1)(x+1) > 0 → two positive intervals.
+
+        Roots: -1, 0, 1.  Positive on (-1, 0) ∪ (1, +∞).
+        """
+        # x^3 - x = Mul(x, Sub(Pow(x,2), 1)) but we build it as
+        # Sub(Pow(x,3), x)
+        x3 = _pow(X, IRInteger(3))
+        f = _sub(x3, X)
+        result = _solve(_ineq(GREATER, f))
+        assert _is_list(result)
+        sols = _list_args(result)
+        # Two positive intervals
+        assert len(sols) == 2
+
+    def test_quartic_two_outer_intervals_greater(self) -> None:
+        """x⁴ - 1 > 0  →  two outer half-line intervals."""
+        x4 = _pow(X, IRInteger(4))
+        f = _sub(x4, ONE)
+        result = _solve(_ineq(GREATER, f))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+
+    def test_quartic_boundaries_numeric(self) -> None:
+        """x⁴ - 1 > 0: boundaries come from numeric solver → IRFloat."""
+        x4 = _pow(X, IRInteger(4))
+        f = _sub(x4, ONE)
+        result = _solve(_ineq(GREATER, f))
+        sols = _list_args(result)
+        assert len(sols) == 2
+        # Both conditions should have float boundaries
+        b0 = _boundary_value(sols[0])
+        b1 = _boundary_value(sols[1])
+        assert b0 is not None
+        assert b1 is not None
+        # Roots of x^4 - 1 = 0 are ±1 (but found numerically)
+        assert abs(b0 - (-1.0)) < 1e-4
+        assert abs(b1 - 1.0) < 1e-4
+
+    def test_cubic_less_three_intervals(self) -> None:
+        """x³ - x < 0  →  two negative intervals: (-∞,-1) ∪ (0,1)."""
+        x3 = _pow(X, IRInteger(3))
+        f = _sub(x3, X)
+        result = _solve(_ineq(LESS, f))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+
+
+# ===========================================================================
+# 6. Normalisation: lhs op rhs with non-zero rhs
+# ===========================================================================
+
+
+class TestPhase27_Normalisation:
+    """Inequality in form ``lhs op rhs`` with rhs ≠ 0."""
+
+    def test_x_greater_than_3(self) -> None:
+        """x > 3  (rhs is 3, not 0) → normalised to x-3 > 0 → [Greater(x, 3)]."""
+        # Greater(x, 3)
+        result = _solve(IRApply(GREATER, (X, IRInteger(3))))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "Greater"
+        assert _boundary_value(sols[0]) == pytest.approx(3.0)
+
+    def test_x_less_than_negative_2(self) -> None:
+        """x < -2 → [Less(x, -2)]."""
+        result = _solve(IRApply(LESS, (X, IRInteger(-2))))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "Less"
+        assert _boundary_value(sols[0]) == pytest.approx(-2.0)
+
+    def test_lhs_rhs_both_nonzero(self) -> None:
+        """x² > 1 means x²-1 > 0 → [Less(x,-1), Greater(x,1)]."""
+        result = _solve(IRApply(GREATER, (_pow(X, IRInteger(2)), ONE)))
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+
+
+# ===========================================================================
+# 7. Fallthrough cases (unevaluated)
+# ===========================================================================
+
+
+class TestPhase27_Fallthrough:
+    """Inequalities that should return unevaluated (not a List of solutions)."""
+
+    def test_non_polynomial_transcendental(self) -> None:
+        """sin(x) > 0 is transcendental — not a polynomial → unevaluated."""
+        from symbolic_ir import SIN  # noqa: PLC0415
+
+        sin_x = IRApply(SIN, (X,))
+        result = _solve(IRApply(GREATER, (sin_x, ZERO)))
+        # Should return the unevaluated Solve(...) node
+        assert not _is_list(result)
+
+    def test_equal_head_not_dispatched(self) -> None:
+        """Solve(Equal(x, 1), x) still uses the equation solver, not inequality."""
+        from symbolic_ir import EQUAL  # noqa: PLC0415
+
+        eq = IRApply(EQUAL, (X, ONE))
+        result = _solve(eq)
+        # Should succeed via equation solver giving List(1)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+
+
+# ===========================================================================
+# 8. Regression — earlier phases still work
+# ===========================================================================
+
+
+class TestPhase27_Regressions:
+    """Inequality wiring must not break earlier Solve paths."""
+
+    def test_linear_equation_solve(self) -> None:
+        """solve(x - 3 = 0, x) → [3] (Phase 1)."""
+        from symbolic_ir import EQUAL  # noqa: PLC0415
+
+        eq = IRApply(EQUAL, (_sub(X, IRInteger(3)), ZERO))
+        result = _solve(eq)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+
+    def test_quadratic_equation_solve(self) -> None:
+        """solve(x² - 5x + 6 = 0, x) → [2, 3] (Phase 1)."""
+        from symbolic_ir import EQUAL  # noqa: PLC0415
+
+        x2 = _pow(X, IRInteger(2))
+        five_x = _mul(IRInteger(5), X)
+        f = _sub(_sub(x2, five_x), IRInteger(-6))  # x^2 - 5x + 6
+        eq = IRApply(EQUAL, (f, ZERO))
+        result = _solve(eq)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+
+    def test_system_solve_still_works(self) -> None:
+        """Solve([x+y=3, x-y=1], [x,y]) → [x=2, y=1] (Phase 3)."""
+        from symbolic_ir import EQUAL  # noqa: PLC0415
+
+        Y = IRSymbol("y")
+        e1 = IRApply(EQUAL, (IRApply(IRSymbol("Add"), (X, Y)), IRInteger(3)))
+        e2 = IRApply(EQUAL, (IRApply(SUB, (X, Y)), ONE))
+        eq_list = IRApply(LIST, (e1, e2))
+        var_list = IRApply(LIST, (X, Y))
+        result = _make_vm().eval(IRApply(SOLVE, (eq_list, var_list)))
+        assert _is_list(result)
+
+    def test_transcendental_equation_still_works(self) -> None:
+        """solve(exp(x) = 1, x) → [log(1)] = [0] (Phase 26)."""
+        from symbolic_ir import EQUAL, EXP  # noqa: PLC0415
+
+        eq = IRApply(EQUAL, (IRApply(EXP, (X,)), ONE))
+        result = _solve(eq)
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+
+
+# ===========================================================================
+# 9. MACSYMA surface-syntax tests
+# ===========================================================================
+
+
+class TestPhase27_Macsyma:
+    """End-to-end via MACSYMA parser → compiler → symbolic VM."""
+
+    def _run(self, src: str) -> IRNode:
+        pytest.importorskip(
+            "macsyma_runtime",
+            reason="macsyma-runtime not installed; skipping MACSYMA e2e test",
+        )
+        from macsyma_compiler.compiler import (  # noqa: PLC0415
+            _STANDARD_FUNCTIONS,
+            compile_macsyma,
+        )
+        from macsyma_parser.parser import parse_macsyma  # noqa: PLC0415
+        from macsyma_runtime.name_table import (  # noqa: PLC0415
+            extend_compiler_name_table,
+        )
+
+        extend_compiler_name_table(_STANDARD_FUNCTIONS)
+        stmts = compile_macsyma(parse_macsyma(src + ";"))
+        return _make_vm().eval_program(stmts)
+
+    def test_macsyma_linear_greater(self) -> None:
+        """solve(x - 1 > 0, x) → List(Greater(x, 1))."""
+        result = self._run("solve(x - 1 > 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "Greater"
+
+    def test_macsyma_linear_less_equal(self) -> None:
+        """solve(2*x + 4 <= 0, x) → List(LessEqual(x, -2))."""
+        result = self._run("solve(2*x + 4 <= 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "LessEqual"
+        assert _boundary_value(sols[0]) == pytest.approx(-2.0)
+
+    def test_macsyma_quad_two_outer(self) -> None:
+        """solve(x^2 - 1 > 0, x) → List(Less(x,-1), Greater(x,1))."""
+        result = self._run("solve(x^2 - 1 > 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+        assert _head_name(sols[0]) == "Less"
+        assert _head_name(sols[1]) == "Greater"
+
+    def test_macsyma_quad_interval(self) -> None:
+        """solve(x^2 - 1 < 0, x) → List(And(Greater(x,-1), Less(x,1)))."""
+        result = self._run("solve(x^2 - 1 < 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _head_name(sols[0]) == "And"
+
+    def test_macsyma_quad_roots_1_2(self) -> None:
+        """solve(x^2 - 3*x + 2 <= 0, x) → And(GreaterEqual(x,1), LessEqual(x,2))."""
+        result = self._run("solve(x^2 - 3*x + 2 <= 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        inner = sols[0]
+        assert _head_name(inner) == "And"
+        assert isinstance(inner, IRApply)
+        lo, hi = inner.args
+        assert _head_name(lo) == "GreaterEqual"
+        assert _head_name(hi) == "LessEqual"
+        assert _boundary_value(lo) == pytest.approx(1.0)
+        assert _boundary_value(hi) == pytest.approx(2.0)
+
+    def test_macsyma_all_reals(self) -> None:
+        """solve(x^2 + 1 > 0, x) → all reals."""
+        result = self._run("solve(x^2 + 1 > 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _is_all_reals(sols[0])
+
+    def test_macsyma_no_solution(self) -> None:
+        """solve(x^2 + 1 < 0, x) → empty list."""
+        result = self._run("solve(x^2 + 1 < 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 0
+
+    def test_macsyma_double_root_nonstrict(self) -> None:
+        """solve((x-1)^2 >= 0, x) → all reals."""
+        # (x-1)^2 = x^2 - 2*x + 1
+        result = self._run("solve(x^2 - 2*x + 1 >= 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 1
+        assert _is_all_reals(sols[0])
+
+    def test_macsyma_double_root_strict(self) -> None:
+        """solve((x-1)^2 > 0, x) → two open half-lines."""
+        result = self._run("solve(x^2 - 2*x + 1 > 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2
+
+    def test_macsyma_regression_equation_still_works(self) -> None:
+        """solve(x^2-5*x+6=0, x) → [2,3]; inequality wiring must not break equations."""
+        result = self._run("solve(x^2 - 5*x + 6 = 0, x)")
+        assert _is_list(result)
+        sols = _list_args(result)
+        assert len(sols) == 2

--- a/code/specs/phase27-inequality-solving.md
+++ b/code/specs/phase27-inequality-solving.md
@@ -1,0 +1,208 @@
+# Phase 27 — Polynomial Inequality Solving
+
+## Motivation
+
+After Phase 26 (transcendental equation solving), the CAS can solve polynomial
+equations up to degree 4 and a broad range of transcendental equations.  The
+natural complement is **inequality solving**: given a polynomial expression and a
+strict or non-strict comparison with a constant, find all real values of the
+variable that satisfy the condition.
+
+```
+solve(x^2 - 1 > 0, x)          →  [x < -1, x > 1]
+solve(x^2 - 3*x + 2 <= 0, x)   →  [and(x >= 1, x <= 2)]
+solve(2*x + 5 < 0, x)          →  [x < -5/2]
+```
+
+This is Phase 27 of the symbolic-vm roadmap.
+
+---
+
+## Scope
+
+### Supported
+
+* Polynomial inequalities of degree 1–4 with rational coefficients:
+  `p(x) > 0`, `p(x) >= 0`, `p(x) < 0`, `p(x) <= 0`
+* The right-hand side need not be zero; `p(x) > q(x)` is handled by
+  normalising to `p(x) − q(x) > 0` before analysis.
+* `solve(ineq, x)` surface syntax via MACSYMA (no new compiler changes needed).
+
+### Not covered in this phase
+
+* Polynomial degree > 4.
+* Transcendental inequalities (`sin(x) > 0`).
+* System of inequalities (multiple constraints simultaneously).
+* Complex-valued polynomials.
+
+---
+
+## Mathematical Algorithm
+
+### Step 1 — Normalise direction
+
+Given `lhs op rhs` (op ∈ {<, >, ≤, ≥}):
+
+```
+f(x) = lhs − rhs
+```
+
+Determine the desired sign from `op`:
+
+| op  | want_sign | strict |
+|-----|-----------|--------|
+| `>` | positive  | yes    |
+| `>=`| positive  | no     |
+| `<` | negative  | yes    |
+| `<=`| negative  | no     |
+
+### Step 2 — Extract polynomial
+
+Use `symbolic_vm.polynomial_bridge.to_rational(f, x)` to extract the
+ascending-degree rational coefficient tuple `(c₀, c₁, …, cₙ)`.
+
+Fall through to unevaluated if `f` is not a polynomial in `x`.
+
+### Step 3 — Find real roots numerically
+
+Convert ascending-degree tuple to descending-degree float coefficients
+and call `cas_solve.durand_kerner.nsolve_poly`.  Filter roots where
+`|Im(r)| < 1e-8` to obtain the real roots `r₁ ≤ r₂ ≤ … ≤ rₙ`.
+
+For degrees 1–2, also extract exact Fraction roots (for exact IR output).
+For degrees 3–4, use the numeric roots as boundary points and reconstruct
+their exact IR form from the symbolic solvers (`solve_cubic`, `solve_quartic`)
+where possible; otherwise emit `IRFloat`.
+
+### Step 4 — Sign analysis
+
+Create the boundary sequence:
+
+```
+−∞  r₁  r₂  …  rₙ  +∞
+```
+
+For each open interval `(rᵢ, rᵢ₊₁)` pick the midpoint as test point.
+For the unbounded intervals use `r₁ − 1` and `rₙ + 1`.
+
+Evaluate `f` at the test point using Horner's rule on the float coefficients.
+Record the sign: `+1`, `0`, or `−1`.
+
+### Step 5 — Build solution set
+
+The solution is the union of all intervals where the sign matches
+`want_sign`.
+
+**Boundary treatment**:
+* Strict inequality: roots themselves are excluded (they are zeroes of f).
+* Non-strict inequality: roots are included (f = 0 satisfies f ≥ 0 and f ≤ 0).
+
+**Interval representations** (x is the variable IR symbol, a < b are roots
+expressed as IR nodes):
+
+| Interval            | IR form                                     |
+|---------------------|---------------------------------------------|
+| `(−∞, a)`           | `Less(x, a)`                                |
+| `(−∞, a]`           | `LessEqual(x, a)`                           |
+| `(a, +∞)`           | `Greater(x, a)`                             |
+| `[a, +∞)`           | `GreaterEqual(x, a)`                        |
+| `(a, b)`            | `And(Greater(x, a), Less(x, b))`            |
+| `[a, b]`            | `And(GreaterEqual(x, a), LessEqual(x, b))`  |
+| `(a, b]`            | `And(Greater(x, a), LessEqual(x, b))`       |
+| `[a, b)`            | `And(GreaterEqual(x, a), Less(x, b))`       |
+| entire real line    | `GreaterEqual(IRInteger(0), IRInteger(0))`  |
+| empty set           | `[]` (empty list returned to solve_handler) |
+
+**IR heads used**: `LESS`, `GREATER`, `LESS_EQUAL`, `GREATER_EQUAL`, `AND`
+(all already defined in `symbolic_ir`).
+
+---
+
+## Public API
+
+New module `cas_solve/inequality.py`, one public function:
+
+```python
+def try_solve_inequality(
+    ineq_ir: IRNode,
+    var: IRSymbol,
+) -> list[IRNode] | None:
+    """Try to solve a polynomial inequality in one variable.
+
+    ineq_ir must be IRApply with head in {Less, Greater, LessEqual, GreaterEqual}.
+    Returns a list of condition IR nodes (each representing one disjoint interval),
+    or None if the pattern is not recognised / the polynomial bridge is unavailable.
+
+    An empty list means no real solutions exist.
+    A list containing GreaterEqual(0, 0) means all reals are solutions.
+    """
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `code/specs/phase27-inequality-solving.md` | NEW (this file) |
+| `cas-solve/src/cas_solve/inequality.py` | NEW |
+| `cas-solve/src/cas_solve/__init__.py` | export `try_solve_inequality` |
+| `cas-solve/tests/test_inequality.py` | NEW (≥28 tests) |
+| `cas-solve/pyproject.toml` | 0.7.0 → 0.8.0 |
+| `cas-solve/CHANGELOG.md` | 0.8.0 entry |
+| `symbolic-vm/src/symbolic_vm/cas_handlers.py` | inequality dispatch in `solve_handler` |
+| `symbolic-vm/tests/test_phase27.py` | NEW (≥20 tests) |
+| `symbolic-vm/pyproject.toml` | 0.46.0 → 0.47.0; cas-solve ≥ 0.8.0 |
+| `symbolic-vm/CHANGELOG.md` | 0.47.0 entry |
+| `macsyma-runtime/pyproject.toml` | 1.17.0 → 1.18.0; symbolic-vm ≥ 0.47.0 |
+| `macsyma-runtime/CHANGELOG.md` | 1.18.0 entry |
+
+No changes to `symbolic-ir` (no new IR heads) or `macsyma-compiler`
+(no new surface syntax; `solve` already exists).
+
+---
+
+## Examples
+
+```macsyma
+solve(x - 1 > 0, x);             →  [x > 1]
+solve(x - 1 >= 0, x);            →  [x >= 1]
+solve(x^2 - 1 > 0, x);           →  [x < -1, x > 1]
+solve(x^2 - 1 >= 0, x);          →  [x <= -1, x >= 1]
+solve(x^2 - 1 < 0, x);           →  [and(x > -1, x < 1)]
+solve(x^2 - 1 <= 0, x);          →  [and(x >= -1, x <= 1)]
+solve(x^2 - 3*x + 2 <= 0, x);    →  [and(x >= 1, x <= 2)]
+solve(x^2 - 2*x + 1 > 0, x);     →  [x < 1, x > 1]   (double root)
+solve(x^2 + 1 > 0, x);           →  [0 >= 0]          (all reals)
+solve(x^2 + 1 < 0, x);           →  []                (no solution)
+```
+
+---
+
+## Test Plan (`test_inequality.py` — ≥28 tests)
+
+| Class | Tests |
+|-------|-------|
+| `TestLinearIneq` | x>1, x>=1, x<1, x<=1, negative slope, shifted |
+| `TestQuadIneqTwoRoots` | x²-1>0, x²-1>=0, x²-1<0, x²-1<=0, x²-3x+2<0, x²-3x+2<=0 |
+| `TestQuadIneqDoubleRoot` | (x-1)²>0, (x-1)²>=0 (all reals) |
+| `TestQuadIneqNoRoots` | x²+1>0 (all reals), x²+1<0 (empty) |
+| `TestHighDegree` | cubic/quartic: x³-x>0, x⁴-1>0 |
+| `TestFallthrough` | non-polynomial arg → None, Equal head → None |
+
+---
+
+## Verification Spot-checks
+
+```python
+# Linear
+try_solve_inequality(Greater(Sub(x, 1), Zero), x) == [Greater(x, One)]
+
+# Quadratic, two roots
+result = try_solve_inequality(Greater(Sub(Pow(x,2), One), Zero), x)
+# result should contain Less(x, -1) and Greater(x, 1)
+
+# Quadratic, interval
+result = try_solve_inequality(LessEqual(Sub(Sub(Pow(x,2),Mul(3,x)),Neg(2)), Zero), x)
+# should contain And(GreaterEqual(x, 1), LessEqual(x, 2))
+```


### PR DESCRIPTION
## Summary

- **New module** `cas_solve/inequality.py` with `try_solve_inequality(ineq_ir, var)` — solves polynomial inequalities `p(x) op 0` (op ∈ {<, >, ≤, ≥}) for degrees 1–4
- **Wired into** `symbolic_vm.cas_handlers.solve_handler` — dispatches before equation unwrapping so the comparison head is preserved
- **MACSYMA surface syntax** works end-to-end: `solve(x^2 - 1 < 0, x)` → `[and(x > -1, x < 1)]`
- **Version bumps**: cas-solve 0.7→0.8.0, symbolic-vm 0.46→0.47.0, macsyma-runtime 1.17→1.18.0

## Algorithm

1. Validate inequality head (`Less`/`Greater`/`LessEqual`/`GreaterEqual`)
2. Normalise to `f = lhs − rhs`
3. Extract polynomial coefficients via `polynomial_bridge.to_rational`
4. Find real roots — exact `Fraction` for degrees 1–2; Durand-Kerner numeric for degrees 3–4
5. Sign analysis at interval midpoints → build IR conditions

## Examples

```macsyma
solve(x - 1 > 0, x)           →  [x > 1]
solve(x^2 - 1 < 0, x)         →  [and(x > -1, x < 1)]
solve(x^2 - 3*x + 2 <= 0, x)  →  [and(x >= 1, x <= 2)]
solve(x^2 + 1 > 0, x)         →  [0 >= 0]   (all reals)
solve(x^2 + 1 < 0, x)         →  []          (no solution)
solve((x-1)^2 > 0, x)         →  [x < 1, x > 1]   (double root — not all reals)
```

## Test plan

- [ ] `cas-solve/tests/test_inequality.py` — 75 tests, 98% module coverage, 91.26% total
- [ ] `symbolic-vm/tests/test_phase27.py` — 41 integration tests (IR-level + MACSYMA)
- [ ] All 1428 symbolic-vm tests pass, 82.25% coverage
- [ ] `ruff check` clean on all new/modified files
- [ ] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)