### PR TITLE
Keep solidus in unquoted attribute values

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -235,3 +235,5 @@ documented in this file.
 - Added `HtmlTokenizerState::from_machine_state()` and
   `HtmlTokenizerState::from_fragment_machine_state()` so parser/conformance code
   can map generated machine-state identifiers back into typed tokenizer states.
+- Unquoted attribute values now keep solidus characters as value text, avoiding
+  false self-closing-tag recovery for URL-like values and trailing path slashes.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -87,6 +87,9 @@ Unquoted attribute values also preserve spec-defined unexpected characters
 such as `"`, `'`, `<`, `=`, and `` ` `` while reporting
 `unexpected-character-in-unquoted-attribute-value`, including when the first
 value character appears immediately after `=`.
+Solidus characters inside unquoted attribute values stay in the value, so
+URL-like markup such as `href=http://example.test/path` is not mistaken for a
+self-closing tag transition.
 EOF inside ordinary start/end tag construction now reports the relevant
 EOF-in-tag diagnostic and drops the incomplete token instead of handing a
 partial tag to the future parser.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -3828,8 +3828,8 @@ actions = ["commit_attribute_dedup"]
 [[transitions]]
 from = "attribute_value_unquoted"
 matcher = { literal = "/" }
-to = "self_closing_start_tag"
-actions = ["commit_attribute_dedup"]
+to = "attribute_value_unquoted"
+actions = ["append_attribute_value(current)"]
 
 [[transitions]]
 from = "attribute_value_unquoted"
@@ -7353,7 +7353,7 @@ tokens = [
 
 [[fixtures]]
 name = "mosaic-attributes-and-self-closing"
-input = "<IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1/>"
+input = "<IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1 />"
 tokens = [
   "StartTag(name=img, attributes=[src=mosaic.gif, alt=Splash, hidden=1], self_closing=true)",
   "EOF",

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -148,7 +148,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         FixtureDefinition {
             name: "mosaic-attributes-and-self-closing".to_string(),
-            input: "<IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1/>".to_string(),
+            input: "<IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1 />".to_string(),
             tokens: vec![
                 "StartTag(name=img, attributes=[src=mosaic.gif, alt=Splash, hidden=1], self_closing=true)".to_string(),
                 "EOF".to_string(),
@@ -8474,13 +8474,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Literal("/".to_string())),
             to: vec![
-                "self_closing_start_tag".to_string(),
+                "attribute_value_unquoted".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "commit_attribute_dedup".to_string(),
+                "append_attribute_value(current)".to_string(),
             ],
             consume: true,
         },

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -15,7 +15,7 @@
     },
     {
       "id": "mosaic-attributes-and-self-closing",
-      "input": "<IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1/>",
+      "input": "<IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1 />",
       "tokens": [
         "StartTag(name=img, attributes=[src=mosaic.gif, alt=Splash, hidden=1], self_closing=true)",
         "EOF"
@@ -994,7 +994,7 @@
       "input": "Text &notin &trade <a value=&notin legacy=&Agrave data=&copy/>",
       "tokens": [
         "Text(data=Text ¬in &trade )",
-        "StartTag(name=a, attributes=[value=&notin, legacy=À, data=©], self_closing=true)",
+        "StartTag(name=a, attributes=[value=&notin, legacy=À, data=©/], self_closing=false)",
         "EOF"
       ],
       "diagnostics": [

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -1303,7 +1303,7 @@
       "input": "Text &notin &trade <a value=&notin legacy=&Agrave data=&copy/>",
       "tokens": [
         "Text(data=Text \u00acin &trade )",
-        "StartTag(name=a, attributes=[value=&notin, legacy=\u00c0, data=\u00a9], self_closing=true)",
+        "StartTag(name=a, attributes=[value=&notin, legacy=\u00c0, data=\u00a9/], self_closing=false)",
         "EOF"
       ],
       "diagnostics": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -1314,7 +1314,7 @@
         ["Character", "Text "],
         ["Character", "\u00AC"],
         ["Character", "in &trade "],
-        ["StartTag", "a", {"value": "&notin", "legacy": "\u00C0", "data": "\u00A9"}, true]
+        ["StartTag", "a", {"value": "&notin", "legacy": "\u00C0", "data": "\u00A9/"}, false]
       ],
       "errors": [
         {"code": "missing-semicolon-after-character-reference", "line": 1, "col": 10},

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -98,7 +98,7 @@ fn default_html_lexer_drops_partial_attribute_references_at_eof() {
 #[test]
 fn default_html_lexer_supports_html1_attributes_comments_and_doctypes() {
     let tokens = lex_html(
-        "<!DOCTYPE HTML><IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1/>Before<!--note-->After",
+        "<!DOCTYPE HTML><IMG SRC=\"mosaic.gif\" ALT='Splash' hidden=1 />Before<!--note-->After",
     )
     .unwrap();
 
@@ -381,6 +381,49 @@ fn default_html_lexer_reports_first_unquoted_attribute_value_characters() {
             .count(),
         3
     );
+}
+
+#[test]
+fn default_html_lexer_keeps_solidus_in_unquoted_attribute_values() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer
+        .push("<a href=http://example.test/path data=a/b><img src=cat/>")
+        .unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::StartTag {
+                name: "a".to_string(),
+                attributes: vec![
+                    Attribute {
+                        name: "href".to_string(),
+                        value: "http://example.test/path".to_string(),
+                    },
+                    Attribute {
+                        name: "data".to_string(),
+                        value: "a/b".to_string(),
+                    },
+                ],
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "img".to_string(),
+                attributes: vec![Attribute {
+                    name: "src".to_string(),
+                    value: "cat/".to_string(),
+                }],
+                self_closing: false,
+            },
+            Token::Eof,
+        ]
+    );
+    assert!(!lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "unexpected-solidus-in-tag"));
 }
 
 #[test]
@@ -4076,10 +4119,10 @@ fn default_html_lexer_restricts_semicolonless_named_references_to_legacy_names()
                     },
                     Attribute {
                         name: "data".to_string(),
-                        value: "\u{00A9}".to_string(),
+                        value: "\u{00A9}/".to_string(),
                     },
                 ],
-                self_closing: true,
+                self_closing: false,
             },
             Token::Eof,
         ]


### PR DESCRIPTION
## Summary
- Treat `/` inside unquoted attribute values as value text instead of entering self-closing tag state.
- Keep real self-closing coverage by requiring whitespace before `/` after unquoted values in fixtures.
- Update HTML1 and html5lib-style fixtures plus direct lexer coverage for URL/path-shaped values.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check