### PR TITLE
Allow nested ALGOL conditional contexts

### DIFF
--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -240,10 +240,10 @@ for_elem     = arith_expr "step" arith_expr "until" arith_expr
 #     exponentiation (left-associative per ALGOL 60 report)
 #     primary (literal, call, variable, parenthesised expression)
 #
-# Only the `expression` rule (used in assignments and actual parameters)
-# needs the full unified hierarchy.  Rules used in type-specific contexts
-# (arith_expr for bounds/subscripts, bool_expr for conditionals) are
-# kept as-is.
+# The `expression` rule is the fully unified hierarchy used in assignments and
+# actual parameters.  Type-specific contexts still use arith_expr, bool_expr,
+# or desig_expr, but their conditional forms also recurse on the then branch so
+# nested conditionals work anywhere ALGOL accepts that value kind.
 expression   = "if" bool_expr "then" expression "else" expression
              | expr_eqv ;
 
@@ -268,7 +268,7 @@ expr_atom    = INTEGER_LIT
 # Arithmetic expression.
 # The conditional form (if b then x else y) produces a numeric value.
 # This is ALGOL's "conditional expression" — cleaner than C's ternary ?: operator.
-arith_expr   = "if" bool_expr "then" simple_arith "else" arith_expr
+arith_expr   = "if" bool_expr "then" arith_expr "else" arith_expr
              | simple_arith ;
 
 # Addition and subtraction. Optional leading sign handles unary + and -.
@@ -303,7 +303,7 @@ primary      = INTEGER_LIT
 #   and    — logical conjunction
 #   not    — logical negation (unary, highest precedence)
 # Then: relation (< = > etc.) and boolean primaries.
-bool_expr    = "if" bool_expr "then" simple_bool "else" bool_expr
+bool_expr    = "if" bool_expr "then" bool_expr "else" bool_expr
              | simple_bool ;
 
 simple_bool  = implication { "eqv" implication } ;
@@ -331,7 +331,7 @@ relation     = simple_arith ( EQ | NEQ | LT | LEQ | GT | GEQ ) simple_arith ;
 # Designational expression: used as the target of goto statements.
 # Resolves to a label — either a direct label, a switch subscript, or
 # a conditional jump (if b then label1 else label2).
-desig_expr   = "if" bool_expr "then" simple_desig "else" desig_expr
+desig_expr   = "if" bool_expr "then" desig_expr "else" desig_expr
              | simple_desig ;
 
 simple_desig = NAME LBRACKET arith_expr RBRACKET

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -64,6 +64,8 @@ All notable changes to this package will be documented in this file.
 - Lowered chained assignments, branch-selected conditional expressions, and
   ALGOL-left-associative exponentiation for numeric bases with integer or real
   exponents.
+- Lowered nested conditional expressions in type-specific arithmetic, Boolean,
+  and designational contexts, including nested conditional `goto` targets.
 - Lowered boolean `and`, `or`, and `impl` through short-circuiting control
   flow while keeping `eqv` strict.
 - Lowered bare no-argument typed procedure names as expression calls, including

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -42,8 +42,9 @@ bounds, while arrays local to those callees still lower normally.
 
 Expression lowering includes mixed integer/real arithmetic, boolean operators,
 comparisons, chained assignment targets, branch-selected conditional
-expressions, and ALGOL-left-associative exponentiation. Integer exponents use
-the existing loop lowering, real bases with negative integer exponents use a
+expressions, nested conditional forms in type-specific arithmetic and Boolean
+contexts, and ALGOL-left-associative exponentiation. Integer exponents use the
+existing loop lowering, real bases with negative integer exponents use a
 reciprocal path, and real exponents lower through the imported real `pow`
 runtime with a domain-failure guard. Boolean `and`, `or`, and `impl` lower
 through short-circuiting control flow; `eqv` remains strict and evaluates both
@@ -97,12 +98,13 @@ and stack-pointer restoration used by normal block exits before transferring
 control to the outer label. The downstream WASM backend's unstructured
 control-flow lowering handles forward, backward, and nonlocal block jumps.
 Local conditional designational expressions now lower as condition-controlled
-branch points that only evaluate the selected target. Local switch selections
-evaluate their integer index once, compare against one-based switch entries,
-and lower the chosen designational entry into the same jump path. Switch entries
-may target labels in lexical parent blocks or later sibling switch declarations;
-those entries unwind exited frames or propagate pending procedure-crossing gotos
-just like direct designational gotos. An out-of-range switch index follows the
+branch points that only evaluate the selected target, including nested
+conditional designational branches. Local switch selections evaluate their
+integer index once, compare against one-based switch entries, and lower the
+chosen designational entry into the same jump path. Switch entries may target
+labels in lexical parent blocks or later sibling switch declarations; those
+entries unwind exited frames or propagate pending procedure-crossing gotos just
+like direct designational gotos. An out-of-range switch index follows the
 existing runtime-failure path and returns `0`. Recursive switch self-selection
 lowers through the switch evaluation helper so finite recursive dispatch
 executes at runtime instead of expanding the descriptor at compile time.

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -1131,31 +1131,38 @@ class AlgolIrCompiler:
     ) -> None:
         if execution_scope is None:
             execution_scope = scope
-        if any(token.value == "if" for token in _direct_tokens(node)):
+        conditional = _conditional_designational_parts(node)
+        if conditional is not None:
+            bool_expr, then_desig, else_desig = conditional
             index = self._next_if_index()
             else_label = f"if_{index}_else"
-            bool_expr = _first_direct_node(node, "bool_expr")
-            if bool_expr is None:
-                raise CompileError("conditional designational is missing a condition")
             condition = self._compile_expr(bool_expr, scope)
             self._emit(IrOp.BRANCH_Z, IrRegister(condition), IrLabel(else_label))
-            then_desig = _first_direct_node(node, "simple_desig")
-            if then_desig is None:
-                raise CompileError("conditional designational is missing then target")
-            self._compile_simple_designational(
-                then_desig,
-                scope,
-                execution_scope=execution_scope,
-            )
+            if then_desig.rule_name == "simple_desig":
+                self._compile_simple_designational(
+                    then_desig,
+                    scope,
+                    execution_scope=execution_scope,
+                )
+            else:
+                self._compile_designational(
+                    then_desig,
+                    scope,
+                    execution_scope=execution_scope,
+                )
             self._label(else_label)
-            else_desig = _first_direct_node(node, "desig_expr")
-            if else_desig is None:
-                raise CompileError("conditional designational is missing else target")
-            self._compile_designational(
-                else_desig,
-                scope,
-                execution_scope=execution_scope,
-            )
+            if else_desig.rule_name == "simple_desig":
+                self._compile_simple_designational(
+                    else_desig,
+                    scope,
+                    execution_scope=execution_scope,
+                )
+            else:
+                self._compile_designational(
+                    else_desig,
+                    scope,
+                    execution_scope=execution_scope,
+                )
             return
 
         simple = _first_direct_node(node, "simple_desig")
@@ -1452,27 +1459,32 @@ class AlgolIrCompiler:
         node: ASTNode,
         scope: _FrameScope,
     ) -> int:
-        if any(token.value == "if" for token in _direct_tokens(node)):
+        conditional = _conditional_designational_parts(node)
+        if conditional is not None:
+            bool_expr, then_desig, else_desig = conditional
             index = self._next_if_index()
             else_label = f"if_{index}_else"
             end_label = f"if_{index}_end"
             result = self._fresh_reg()
-            bool_expr = _first_direct_node(node, "bool_expr")
-            if bool_expr is None:
-                raise CompileError("conditional designational is missing a condition")
             condition = self._compile_expr(bool_expr, scope)
             self._emit(IrOp.BRANCH_Z, IrRegister(condition), IrLabel(else_label))
-            then_desig = _first_direct_node(node, "simple_desig")
-            if then_desig is None:
-                raise CompileError("conditional designational is missing then target")
-            then_value = self._compile_simple_designational_value(then_desig, scope)
+            if then_desig.rule_name == "simple_desig":
+                then_value = self._compile_simple_designational_value(
+                    then_desig,
+                    scope,
+                )
+            else:
+                then_value = self._compile_designational_value(then_desig, scope)
             self._copy_reg(dst=result, src=then_value)
             self._emit(IrOp.JUMP, IrLabel(end_label))
             self._label(else_label)
-            else_desig = _first_direct_node(node, "desig_expr")
-            if else_desig is None:
-                raise CompileError("conditional designational is missing else target")
-            else_value = self._compile_designational_value(else_desig, scope)
+            if else_desig.rule_name == "simple_desig":
+                else_value = self._compile_simple_designational_value(
+                    else_desig,
+                    scope,
+                )
+            else:
+                else_value = self._compile_designational_value(else_desig, scope)
             self._copy_reg(dst=result, src=else_value)
             self._label(end_label)
             return result
@@ -7790,6 +7802,25 @@ def _meaningful_children(node: ASTNode) -> list[ASTNode | Token]:
 def _conditional_expression_parts(
     children: list[ASTNode | Token],
 ) -> tuple[ASTNode, ASTNode, ASTNode] | None:
+    first = children[0] if children else None
+    if not isinstance(first, Token) or first.value != "if":
+        return None
+    then_index = _keyword_child_index(children, "then")
+    else_index = _keyword_child_index(children, "else")
+    if then_index is None or else_index is None or then_index >= else_index:
+        return None
+    condition = _first_ast_child_between(children, 1, then_index)
+    then_expr = _first_ast_child_between(children, then_index + 1, else_index)
+    else_expr = _first_ast_child_between(children, else_index + 1, len(children))
+    if condition is None or then_expr is None or else_expr is None:
+        return None
+    return condition, then_expr, else_expr
+
+
+def _conditional_designational_parts(
+    node: ASTNode,
+) -> tuple[ASTNode, ASTNode, ASTNode] | None:
+    children = _meaningful_children(node)
     first = children[0] if children else None
     if not isinstance(first, Token) or first.value != "if":
         return None

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -68,6 +68,36 @@ class TestAlgolIrCompiler:
         assert opcodes.count(IrOp.BRANCH_Z) >= 2
         assert opcodes.count(IrOp.STORE_WORD) >= 3
 
+    def test_compiles_nested_conditionals_in_typed_contexts(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; integer array a[1:3]; "
+                "a[if true then if false then 1 else 2 else 3] := 9; "
+                "if if true then if false then false else true else false "
+                "then result := a[2] else result := 0 "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        assert opcodes.count(IrOp.BRANCH_Z) >= 3
+        assert IrOp.STORE_WORD in opcodes
+
+    def test_compiles_nested_conditional_designational_targets(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result; "
+                "goto if true then if false then left else right else fail; "
+                "left: result := 1; goto done; "
+                "right: result := 7; goto done; "
+                "fail: result := 0; "
+                "done: "
+                "end"
+            )
+        )
+        opcodes = [instr.opcode for instr in result.program.instructions]
+        assert opcodes.count(IrOp.BRANCH_Z) >= 2
+        assert IrOp.JUMP in opcodes
+
     def test_compiles_structured_if_labels(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-parser/CHANGELOG.md
+++ b/code/packages/python/algol-parser/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Type-specific conditional grammar rules now allow nested `if ... then ...
+  else ...` forms in arithmetic bounds/subscripts, boolean conditions, and
+  designational `goto` targets.
 - Unified `expression` parsing now accepts ALGOL conditional expressions such
   as `if b then x else y` in assignment values and actual parameters.
 - Block and compound statement lists now tolerate repeated and trailing

--- a/code/packages/python/algol-parser/README.md
+++ b/code/packages/python/algol-parser/README.md
@@ -27,7 +27,7 @@ including John Backus, Peter Naur, and Edsger Dijkstra. Its *Revised Report*
 ## How It Fits the Stack
 
 ```
-algol.grammar (grammar rules)        algol.tokens (token defs)
+algol/algol60.grammar (grammar rules)  algol/algol60.tokens (token defs)
       │                                     │
       ▼                                     ▼
 grammar_tools.parse_parser_grammar()   algol-lexer
@@ -98,6 +98,11 @@ The parser covers the complete ALGOL 60 grammar:
 | Boolean | `bool_expr`, `simple_bool`, `implication`, `bool_term`, `bool_factor`, `bool_secondary`, `bool_primary`, `relation` |
 | Designational | `desig_expr`, `simple_desig` |
 | Variables | `variable`, `subscripts`, `proc_call`, `ident_list` |
+
+Conditional arithmetic, Boolean, and designational expressions may nest in
+either branch, so type-specific contexts such as array bounds/subscripts,
+conditions, and `goto` targets accept the same nested conditional shape as
+ordinary assignment expressions.
 
 Procedure declarations and calls accept the report-style omitted-parentheses
 form for parameterless procedures as well as explicit empty parentheses, so

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -925,6 +925,52 @@ class TestMultipleStatements:
 
 
 # ---------------------------------------------------------------------------
+# Nested conditional context tests
+# ---------------------------------------------------------------------------
+
+
+class TestNestedConditionalContexts:
+    """Conditional values can nest in type-specific ALGOL contexts."""
+
+    def test_nested_arithmetic_conditional_in_bounds_and_subscripts(self) -> None:
+        ast = parse(
+            "begin integer result; "
+            "integer array a[1:if true then if false then 2 else 3 else 1]; "
+            "a[if true then if false then 1 else 2 else 3] := 9; "
+            "result := a[2] "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        assert len(find_nodes(ast, "arith_expr")) >= 4
+
+    def test_nested_boolean_conditional_in_condition(self) -> None:
+        ast = parse(
+            "begin integer result; "
+            "if if true then if false then false else true else false "
+            "then result := 1 else result := 0 "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        assert len(find_nodes(ast, "bool_expr")) >= 3
+
+    def test_nested_designational_conditional_in_goto(self) -> None:
+        ast = parse(
+            "begin integer result; "
+            "goto if true then if false then left else right else fail; "
+            "left: result := 1; goto done; "
+            "right: result := 7; goto done; "
+            "fail: result := 0; "
+            "done: "
+            "end"
+        )
+
+        assert ast.rule_name == "program"
+        assert len(find_nodes(ast, "desig_expr")) >= 3
+
+
+# ---------------------------------------------------------------------------
 # Error case tests
 # ---------------------------------------------------------------------------
 

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to this package will be documented in this file.
   designational branches guarded.
 - Added semantic checking for chained assignments, ALGOL conditional
   expressions, and numeric exponentiation with integer or real exponents.
+- Accepted nested ALGOL conditional expressions in type-specific arithmetic,
+  Boolean, and designational contexts such as subscripts, conditions, and
+  `goto` targets.
 - Added semantic resolution for bare no-argument typed procedure names used as
   expressions, while keeping written by-name actuals from treating those calls
   as assignable scalar storage.

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -14,8 +14,9 @@ function. Switch declarations, switch selections, and conditional designational
 `goto` forms are also supported.
 
 The expression checker also accepts chained assignments, ALGOL conditional
-expressions, tolerant trailing/repeated semicolons from the parser, and
-left-associative exponentiation for numeric bases with integer or real
+expressions, nested conditional forms in type-specific arithmetic, Boolean, and
+designational contexts, tolerant trailing/repeated semicolons from the parser,
+and left-associative exponentiation for numeric bases with integer or real
 exponents.
 Mixed integer/real conditional branches resolve to `real`; incompatible branch
 types are still rejected before IR lowering. Standard numeric functions

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1609,16 +1609,13 @@ class AlgolTypeChecker:
         allow_switch_selection: bool = True,
         active_switch_id: int | None = None,
     ) -> ResolvedGoto | None:
-        if any(token.value == "if" for token in _direct_tokens(node)):
-            bool_expr = _first_direct_node(node, "bool_expr")
-            cond_type = (
-                self._infer_expr(bool_expr, scope) if bool_expr is not None else ERROR
-            )
+        conditional = _conditional_designational_parts(node)
+        if conditional is not None:
+            bool_expr, then_desig, else_desig = conditional
+            cond_type = self._infer_expr(bool_expr, scope)
             if cond_type != ERROR and cond_type != BOOLEAN:
                 self._error(node, "conditional designational condition must be boolean")
-            then_desig = _first_direct_node(node, "simple_desig")
-            else_desig = _first_direct_node(node, "desig_expr")
-            if then_desig is not None:
+            if then_desig.rule_name == "simple_desig":
                 self._check_simple_designational(
                     then_desig,
                     scope,
@@ -1626,7 +1623,23 @@ class AlgolTypeChecker:
                     allow_switch_selection=allow_switch_selection,
                     active_switch_id=active_switch_id,
                 )
-            if else_desig is not None:
+            else:
+                self._check_designational(
+                    then_desig,
+                    scope,
+                    allow_nonlocal_label=allow_nonlocal_label,
+                    allow_switch_selection=allow_switch_selection,
+                    active_switch_id=active_switch_id,
+                )
+            if else_desig.rule_name == "simple_desig":
+                self._check_simple_designational(
+                    else_desig,
+                    scope,
+                    allow_nonlocal_label=allow_nonlocal_label,
+                    allow_switch_selection=allow_switch_selection,
+                    active_switch_id=active_switch_id,
+                )
+            else:
                 self._check_designational(
                     else_desig,
                     scope,
@@ -4021,6 +4034,25 @@ def _meaningful_children(node: ASTNode) -> list[ASTNode | Token]:
 def _conditional_expression_parts(
     children: list[ASTNode | Token],
 ) -> tuple[ASTNode, ASTNode, ASTNode] | None:
+    first = children[0] if children else None
+    if not isinstance(first, Token) or first.value != "if":
+        return None
+    then_index = _keyword_child_index(children, "then")
+    else_index = _keyword_child_index(children, "else")
+    if then_index is None or else_index is None or then_index >= else_index:
+        return None
+    condition = _first_ast_child_between(children, 1, then_index)
+    then_expr = _first_ast_child_between(children, then_index + 1, else_index)
+    else_expr = _first_ast_child_between(children, else_index + 1, len(children))
+    if condition is None or then_expr is None or else_expr is None:
+        return None
+    return condition, then_expr, else_expr
+
+
+def _conditional_designational_parts(
+    node: ASTNode,
+) -> tuple[ASTNode, ASTNode, ASTNode] | None:
+    children = _meaningful_children(node)
     first = children[0] if children else None
     if not isinstance(first, Token) or first.value != "if":
         return None

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -646,6 +646,30 @@ class TestAlgolTypeChecker:
         result = check_algol(ast)
         assert result.ok
 
+    def test_accepts_nested_conditional_expressions_in_typed_contexts(self) -> None:
+        ast = parse_algol(
+            "begin integer result; integer array a[1:3]; "
+            "a[if true then if false then 1 else 2 else 3] := 9; "
+            "if if true then if false then false else true else false "
+            "then result := a[2] else result := 0 "
+            "end"
+        )
+        result = check_algol(ast)
+        assert result.ok
+
+    def test_accepts_nested_conditional_designational_targets(self) -> None:
+        ast = parse_algol(
+            "begin integer result; "
+            "goto if true then if false then left else right else fail; "
+            "left: result := 1; goto done; "
+            "right: result := 7; goto done; "
+            "fail: result := 0; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+        assert result.ok
+
     def test_rejects_incompatible_conditional_expression_branches(self) -> None:
         ast = parse_algol(
             "begin integer result; result := if true then 1 else false end"

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -48,6 +48,9 @@ All notable changes to this package will be documented in this file.
 - Executed chained assignments, ALGOL-left-associative exponentiation with
   integer or real exponents, and branch-selected conditional expressions
   through the full WASM path.
+- Executed nested conditional expressions in arithmetic bounds/subscripts,
+  Boolean conditions, and designational `goto` targets through the full WASM
+  path.
 - Executed boolean `and`, `or`, and `impl` with short-circuiting RHS
   evaluation through the full WASM path, while keeping `eqv` strict.
 - Executed bare no-argument typed procedure names as expression calls,

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -24,8 +24,9 @@ the current lane already supports a substantial ALGOL 60 surface:
   `!=`/`<>`/`≠` not-equal spelling, ALGOL publication symbols such as `≤`,
   `≥`, `↑`, `×`, `÷`, `¬`, `∧`, `∨`, `⊃`, `≡`, and single- or double-quoted
   string literals
-- chained assignment, conditional expressions, tolerant trailing/repeated
-  semicolons, numeric runtime failure guards, and
+- chained assignment, conditional expressions, including nested conditionals in
+  bounds, subscripts, conditions, and designational targets, tolerant
+  trailing/repeated semicolons, numeric runtime failure guards, and
   ALGOL-left-associative exponentiation for integer or real exponents
 - boolean `and`, `or`, and `impl` with short-circuiting RHS evaluation, plus
   strict `eqv`
@@ -158,6 +159,8 @@ local WASM runtime. Those fixtures cover:
   formal-procedure calls
 - conditional expressions, chained assignment, and exponentiation in the same
   end-to-end program
+- nested conditional expressions in arithmetic bounds/subscripts, Boolean
+  conditions, and designational `goto` targets
 - lexical recursion with outer-frame mutation and fresh recursive frames
 - procedure-formal closure dispatch that preserves the actual procedure's
   static link

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_compiler.py
@@ -203,6 +203,29 @@ class TestAlgolWasmCompiler:
         )
         assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
 
+    def test_nested_conditionals_execute_in_typed_contexts(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "integer array a[1:if true then if false then 2 else 3 else 1]; "
+            "a[if true then if false then 1 else 2 else 3] := 11; "
+            "if if true then if false then false else true else false "
+            "then result := a[2] else result := 0 "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [11]
+
+    def test_nested_conditional_designational_goto_executes(self) -> None:
+        result = compile_source(
+            "begin integer result; "
+            "goto if true then if false then left else right else fail; "
+            "left: result := 1; goto done; "
+            "right: result := 7; goto done; "
+            "fail: result := 0; "
+            "done: "
+            "end"
+        )
+        assert WasmRuntime().load_and_run(result.binary, "_start", []) == [7]
+
     def test_statement_lists_allow_trailing_and_repeated_semicolons(self) -> None:
         result = compile_source(
             "begin integer result; ; result := 1;; result := 2; end"

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -151,6 +151,27 @@ _SURFACE_CASES = (
         result=[23],
     ),
     SurfaceCase(
+        name="nested-conditional-type-contexts",
+        source="""
+            begin
+              integer result;
+              integer array a[1:if true then if false then 2 else 3 else 1];
+              a[if true then if false then 1 else 2 else 3] := 11;
+              goto if true then if false then miss else hit else miss;
+            miss:
+              result := 0;
+              goto done;
+            hit:
+              if if true then if false then false else true else false then
+                result := a[2]
+              else
+                result := 0;
+            done:
+            end
+        """,
+        result=[11],
+    ),
+    SurfaceCase(
         name="typed-formal-procedure-dispatch",
         source="""
             begin


### PR DESCRIPTION
## Summary
- Let ALGOL type-specific conditional rules recurse in arithmetic, Boolean, and designational contexts.
- Update type-checker and IR designational handling so nested conditional `goto` targets can be checked, lowered, and executed.
- Add parser, semantic, IR, WASM, and surface-audit coverage for nested conditional bounds/subscripts, conditions, and designational targets.

## Verification
- `code/packages/python/algol-wasm-compiler/.venv/bin/python -m pytest code/packages/python/algol-parser/tests/ -v`
- `bash BUILD` in `code/packages/python/algol-type-checker`
- `bash BUILD` in `code/packages/python/algol-ir-compiler`
- `bash BUILD` in `code/packages/python/algol-wasm-compiler`
- `code/packages/python/algol-wasm-compiler/.venv/bin/python -m ruff check code/packages/python/algol-parser code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`

## Security review
- Focused scan over touched source/tests found no new dynamic execution, subprocess/shell, network, pickle, or file-write paths.
- The grammar change increases accepted conditional nesting only through existing parser recursion and existing semantic/runtime limits.