### PR TITLE
feat(prolog): expose source query VM indexes

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -305,13 +305,14 @@ prolog-vm --source "parent(homer, bart). ?- parent(homer, Who)." --dump-bytecode
 
 Use `--dump-source-metadata` to compile source without executing it and emit a
 small manifest: dialect, initialization/source query counts, total VM queries,
-instruction count, and visible variables for each embedded source query. This is
-intended for editor and CI integrations that need a stable source manifest
-before selecting a query to run.
+instruction count, and visible variables plus VM query indexes for each embedded
+source query. This is intended for editor and CI integrations that need a stable
+source manifest before selecting a query to run.
 
 Use `--list-source-queries` to inspect embedded `?-` directives before choosing
-what to run. Text output lists the zero-based query index and visible variables;
-JSON output emits the same metadata as a stable `source_queries` record.
+what to run. Text output lists the zero-based source query index, VM query
+index, and visible variables; JSON output emits the same metadata as a stable
+`source_queries` record.
 
 Use `--all-source-queries` when a source file contains several embedded `?-`
 queries and the CLI should run them as a script. The command prints or emits

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -497,6 +497,7 @@ def _source_query_records(
     return [
         {
             "index": index,
+            "vm_query_index": compiled_program.source_query_vm_index(index),
             "variables": list(compiled_program.source_query_variable_names(index)),
         }
         for index in range(compiled_program.source_query_count)
@@ -530,7 +531,11 @@ def _print_source_metadata(
         for query in query_summaries:
             variables = cast("list[str]", query["variables"])
             variable_text = ", ".join(variables) if variables else "(none)"
-            print(f"query {query['index']} variables: {variable_text}", file=output)
+            print(
+                f"query {query['index']} "
+                f"(vm query {query['vm_query_index']}) variables: {variable_text}",
+                file=output,
+            )
         return
 
     payload = {
@@ -563,7 +568,11 @@ def _print_source_query_summary(
         for query in query_summaries:
             variables = cast("list[str]", query["variables"])
             variable_text = ", ".join(variables) if variables else "(no variables)"
-            print(f"query {query['index']}: {variable_text}", file=output)
+            print(
+                f"query {query['index']} "
+                f"(vm query {query['vm_query_index']}): {variable_text}",
+                file=output,
+            )
         return
 
     payload = {

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -309,8 +309,8 @@ def test_cli_dump_source_metadata_reports_query_counts(
         "instructions: 5",
     ]
     assert lines[5:] == [
-        "query 0 variables: Who",
-        "query 1 variables: (none)",
+        "query 0 (vm query 1) variables: Who",
+        "query 1 (vm query 2) variables: (none)",
     ]
 
 
@@ -337,8 +337,8 @@ def test_cli_dump_source_metadata_json_reports_source_queries(
         "mode": "source_metadata",
         "query_count": 3,
         "source_queries": [
-            {"index": 0, "variables": ["Who"]},
-            {"index": 1, "variables": []},
+            {"index": 0, "variables": ["Who"], "vm_query_index": 1},
+            {"index": 1, "variables": [], "vm_query_index": 2},
         ],
         "source_query_count": 2,
         "success": True,
@@ -373,8 +373,8 @@ def test_cli_lists_source_query_variables(
 
     assert status == 0
     assert capsys.readouterr().out.splitlines() == [
-        "query 0: Who",
-        "query 1: (no variables)",
+        "query 0 (vm query 0): Who",
+        "query 1 (vm query 1): (no variables)",
     ]
 
 
@@ -395,7 +395,7 @@ def test_cli_lists_source_query_variables_as_json(
     assert payload == {
         "mode": "source_queries",
         "queries": [
-            {"index": 0, "variables": ["Who"]},
+            {"index": 0, "variables": ["Who"], "vm_query_index": 0},
         ],
         "source_query_count": 1,
         "success": True,

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -122,12 +122,13 @@ compile-only and mutually exclusive with query execution modes.
 When `--dump-source-metadata` is set, JSON formats emit one success object with
 `mode: "source_metadata"`, `dialect`, `dialect_display_name`, query counts,
 `instruction_count`, and a `source_queries` list containing zero-based `index`
-and visible `variables` metadata. This mode is compile-only and mutually
-exclusive with query execution modes.
+visible `variables`, and `vm_query_index` metadata. This mode is compile-only
+and mutually exclusive with query execution modes.
 
 When `--list-source-queries` is set, JSON formats emit one success object with
 `mode: "source_queries"`, `source_query_count`, and a `queries` list containing
-zero-based `index` and visible `variables` metadata for each embedded query.
+zero-based `index`, `vm_query_index`, and visible `variables` metadata for each
+embedded query.
 
 When `--all-source-queries` is set, each embedded `?-` query produces one result
 object with its `source_query_index`. The process exits with status 1 if any


### PR DESCRIPTION
## Summary
- include `vm_query_index` in shared source-query metadata records for `--list-source-queries` and `--dump-source-metadata`
- show VM query indexes in text output so initialization-offset mappings are visible to humans too
- document the source-query-to-VM-query mapping in README and PR77

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-source-query-vm-index -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-source-query-vm-index-build-plan.json`