### PR TITLE
feat(matrix-runtime): MX05 Phase 3 V3 — hot-path wiring (SpecRouter)

### DIFF
--- a/code/packages/rust/matrix-runtime/CHANGELOG.md
+++ b/code/packages/rust/matrix-runtime/CHANGELOG.md
@@ -3,6 +3,60 @@
 All notable changes to `matrix-runtime` are documented here.  The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.0] — 2026-05-05
+
+### Added — MX05 Phase 3 V3 (hot-path wiring)
+
+- New `router` module exporting **`SpecRouter`** — the glue that ties
+  Phases 1, 2a, 3 V1, and 3 V2 together end-to-end:
+    1. Asks the policy whether to specialise (`should_specialise`).
+       If no → returns `None`, caller uses the generic kernel.
+    2. Cache lookup via `SpecCache::get`.  Cache hit → return cached.
+    3. Cache miss → ask the backend's `Specialiser::specialise`.
+    4. If specialiser succeeds, cache and return.  If it declines,
+       return `None` without poisoning the cache (so a backend that
+       can't yet specialise this key but might later — e.g. JIT
+       compile pending — will get retried).
+- `SpecRouter::new(policy, cache, specialiser)` for explicit
+  composition; `cache_get` / `cache_insert` / `cache_len` /
+  `cache_clear` for direct cache access.
+- Internal cache is `Mutex`-guarded so a single router can be shared
+  across the dispatch threads of an executor.
+
+### Tests (11 new)
+
+- `cold_observation_returns_none_without_calling_specialiser`
+- `hot_observation_with_constant_input_round_trips_through_specialiser`
+- `second_call_hits_cache_and_does_not_call_specialiser`
+- `declining_specialiser_does_not_poison_cache`
+- `distinct_op_kinds_get_distinct_cache_entries`
+- `distinct_backends_get_distinct_cache_entries`
+- `cache_clear_drops_cached_kernels`
+- `noop_specialiser_yields_none_after_policy_fires`
+- `cache_eviction_means_specialiser_called_again`
+- `cache_get_directly_returns_inserted_kernel`
+- `cache_insert_directly_persists`
+
+Tests use a `CountingSpecialiser` (counts `specialise()` calls and
+emits a deterministic kernel) and a `DecliningSpecialiser` (always
+returns `None`) to exercise both branches of the routing decision.
+
+Total tests: 74 unit + 8 integration = 82 (was 63 + 8 = 71).
+
+### Notes
+
+- **No dispatch loop calls `SpecRouter` yet.**  Phase 3 V4 (next)
+  wires `image-gpu-core::pipeline` (and any other domain library
+  doing dispatch) to call `record_dispatch` followed by
+  `SpecRouter::route` for each compute op, falling back to the
+  generic kernel when route returns `None`.  This separation keeps
+  the V3 PR small enough to review and lets any backend's
+  `Specialiser` implementation land independently of the call-site
+  changes.
+- Image-filter routing on macOS unchanged: `invert` → CPU,
+  `greyscale` / `sepia` → Metal across the synthetic test-image
+  suite.
+
 ## [0.6.0] — 2026-05-05
 
 ### Added — MX05 Phase 3 V2 (specialisation policy)

--- a/code/packages/rust/matrix-runtime/Cargo.toml
+++ b/code/packages/rust/matrix-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-runtime"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "MX04 — the brain of the matrix execution layer. Planner, executor registry, and cost-model-driven placement. Lowers matrix-ir Graphs to compute-ir ComputeGraphs by routing each op to the cheapest available executor. v0.2 adds pass 2b (single-executor preference). v0.3 adds the MX05 Phase 1 profile sampler. v0.4 adds MX05 Phase 2a tensor-byte sampling. v0.5 adds MX05 Phase 3 V1: SpecKey, ShapeClass, RangeClass, Specialiser trait, and an LRU SpecCache — the data plumbing for per-backend specialised kernels. No specialisation policy yet; backends opt in by replacing NoopSpecialiser with their own impl. Zero external dependencies."
 license = "MIT"

--- a/code/packages/rust/matrix-runtime/src/lib.rs
+++ b/code/packages/rust/matrix-runtime/src/lib.rs
@@ -44,6 +44,7 @@ mod planner;
 mod policy;
 mod profile;
 mod registry;
+mod router;
 mod runtime;
 mod spec;
 
@@ -52,6 +53,7 @@ pub use planner::{plan, PlanError};
 pub use policy::{DefaultPolicy, SpecialisationPolicy};
 pub use profile::{ProfileObservation, Profiler, TensorObservation};
 pub use registry::{RegisteredExecutor, Registry};
+pub use router::SpecRouter;
 pub use runtime::{Runtime, RuntimeError};
 pub use spec::{
     NoopSpecialiser, RangeClass, ShapeClass, SpecCache, SpecKey, Specialiser, SpecialisedKernel,

--- a/code/packages/rust/matrix-runtime/src/router.rs
+++ b/code/packages/rust/matrix-runtime/src/router.rs
@@ -1,0 +1,397 @@
+//! Specialisation hot-path — Phase 3 V3 of MX05.
+//!
+//! Ties together the four moving parts that Phases 1, 2a, 3 V1, and
+//! 3 V2 each shipped in isolation:
+//!
+//! 1. [`Profiler`](crate::Profiler) — already accumulating per-op
+//!    invocation counters and per-tensor sample stats.
+//! 2. [`SpecialisationPolicy`] — already converting a
+//!    `ProfileObservation` into an `Option<SpecKey>`.
+//! 3. [`SpecCache`] — already caching `SpecialisedKernel`s by
+//!    `SpecKey` with bounded LRU eviction.
+//! 4. [`Specialiser`] — the backend's hook for emitting a kernel
+//!    given a key.
+//!
+//! [`SpecRouter`] is the glue.  Given a `ProfileObservation` and the
+//! op metadata, it:
+//!
+//! 1. Asks the policy whether to specialise (`should_specialise()`).
+//!    If no, returns `None` — caller uses the generic kernel.
+//! 2. Looks up the resulting `SpecKey` in `SpecCache::get()`.  Cache
+//!    hit → return the cached kernel.
+//! 3. On cache miss, asks the backend's specialiser to emit one
+//!    (`Specialiser::specialise()`).  If the specialiser declines
+//!    (returns `None`), the router does **not** poison the cache —
+//!    next call may try again, which is what we want when a backend
+//!    can't yet specialise this key but might later (e.g. JIT
+//!    compilation pending).  If the specialiser succeeds, cache the
+//!    result and return it.
+//!
+//! ## Why a separate `SpecRouter` rather than methods on `Profiler`
+//!
+//! Single-responsibility: `Profiler` records observations.
+//! `SpecRouter` makes routing decisions.  Decoupling lets a workload
+//! plug in a custom `Profiler` (e.g. one that observes via a
+//! different sampling strategy) without losing the routing
+//! infrastructure, and vice versa.  It also lets tests construct a
+//! router without needing a profiler at all — the router consumes
+//! observations as input data, regardless of where they came from.
+//!
+//! ## Phase 3 V3 status (this PR)
+//!
+//! Ships [`SpecRouter`] and the end-to-end wiring.  **No dispatch
+//! loop calls it yet** — `image-gpu-core` and friends will plug into
+//! this in Phase 3 V4 once we agree on where the call site lives
+//! (probably right after `record_dispatch` in
+//! `pipeline::run_graph_with_constant_inputs`).  For now the router
+//! is callable directly from tests and from any caller that already
+//! has an observation in hand.
+
+use crate::policy::SpecialisationPolicy;
+use crate::profile::ProfileObservation;
+use crate::spec::{SpecCache, Specialiser, SpecialisedKernel};
+use matrix_ir::DType;
+use std::sync::Mutex;
+
+/// Glue that drives the specialisation pipeline end-to-end.
+///
+/// Owns the policy, cache, and backend specialiser.  Internally
+/// guards the cache with a `Mutex` so a single router can be shared
+/// across the dispatch threads of an executor (they all want to
+/// consult the same cache).
+///
+/// Cheap to construct (no allocation beyond what the components
+/// already do).  Plays well with `Arc<SpecRouter>` for sharing.
+pub struct SpecRouter {
+    policy: Box<dyn SpecialisationPolicy>,
+    cache: Mutex<SpecCache>,
+    specialiser: Box<dyn Specialiser>,
+}
+
+impl SpecRouter {
+    /// Construct a router from explicit components.  The caller
+    /// supplies the policy, cache, and backend specialiser; useful
+    /// for tests and for backends that want to dial in their own
+    /// thresholds or LRU capacities.
+    pub fn new(
+        policy: Box<dyn SpecialisationPolicy>,
+        cache: SpecCache,
+        specialiser: Box<dyn Specialiser>,
+    ) -> Self {
+        SpecRouter {
+            policy,
+            cache: Mutex::new(cache),
+            specialiser,
+        }
+    }
+
+    /// Drive one routing decision.
+    ///
+    /// Returns `Some(SpecialisedKernel)` when both the policy fires
+    /// **and** the specialiser produces a kernel; `None` otherwise.
+    /// Callers that get `None` should fall back to the generic
+    /// kernel.
+    ///
+    /// Lock-acquire profile: one `Mutex` lock for the cache lookup +
+    /// (on miss) one `Mutex` lock to insert.  Cache hits are a single
+    /// lock-acquire pair.
+    pub fn route(
+        &self,
+        observation: &ProfileObservation,
+        op_kind: u8,
+        output_dtype: DType,
+        backend_id: u32,
+    ) -> Option<SpecialisedKernel> {
+        // Step 1: ask the policy.
+        let key = self
+            .policy
+            .should_specialise(observation, op_kind, output_dtype, backend_id)?;
+
+        // Step 2: cache lookup.
+        if let Some(hit) = self.cache_get(&key) {
+            return Some(hit);
+        }
+
+        // Step 3: cache miss → ask the backend specialiser.
+        let kernel = self.specialiser.specialise(&key)?;
+
+        // Step 4: cache the result for next time.
+        self.cache_insert(kernel.clone());
+        Some(kernel)
+    }
+
+    /// Read a kernel from the cache.  Returns `None` on miss.
+    pub fn cache_get(&self, key: &crate::spec::SpecKey) -> Option<SpecialisedKernel> {
+        let mut c = match self.cache.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        c.get(key)
+    }
+
+    /// Insert a kernel into the cache.  Evicts LRU if full.  Public
+    /// so backends that emit kernels eagerly (e.g. at startup) can
+    /// pre-populate.
+    pub fn cache_insert(&self, kernel: SpecialisedKernel) {
+        let mut c = match self.cache.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        c.insert(kernel);
+    }
+
+    /// Number of cached kernels.  Useful for tests; backends may
+    /// surface this in diagnostics.
+    pub fn cache_len(&self) -> usize {
+        let c = match self.cache.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        c.len()
+    }
+
+    /// Drop everything in the cache.  Useful when a backend-level
+    /// event invalidates emitted kernels (driver reset, library
+    /// recompile).
+    pub fn cache_clear(&self) {
+        let mut c = match self.cache.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        c.clear();
+    }
+}
+
+// ────────────────────────── tests ──────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::DefaultPolicy;
+    use crate::profile::TensorObservation;
+    use crate::spec::{NoopSpecialiser, RangeClass, ShapeClass, SpecKey};
+    use compute_ir::ExecutorId;
+    use matrix_ir::DType;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    fn obs(invocation_count: u64, tobs: Vec<TensorObservation>) -> ProfileObservation {
+        ProfileObservation {
+            graph_subhash: 0xCAFE,
+            op_index: 0,
+            invocation_count,
+            last_executor: ExecutorId(0),
+            tensor_observations: tobs,
+        }
+    }
+
+    fn t_in(min: f64, max: f64, samples: u64) -> TensorObservation {
+        TensorObservation {
+            slot: 0,
+            is_input: true,
+            observed_min: min,
+            observed_max: max,
+            observed_zeros: 0,
+            samples,
+        }
+    }
+
+    /// A test specialiser that counts calls and emits a deterministic
+    /// kernel for any key it sees.
+    struct CountingSpecialiser {
+        calls: Arc<AtomicUsize>,
+        next_handle: AtomicUsize,
+    }
+
+    impl CountingSpecialiser {
+        fn new(calls: Arc<AtomicUsize>) -> Self {
+            CountingSpecialiser {
+                calls,
+                next_handle: AtomicUsize::new(1),
+            }
+        }
+    }
+
+    impl Specialiser for CountingSpecialiser {
+        fn specialise(&self, key: &SpecKey) -> Option<SpecialisedKernel> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let handle = self.next_handle.fetch_add(1, Ordering::SeqCst) as u64;
+            Some(SpecialisedKernel {
+                key: key.clone(),
+                handle,
+                source_summary: format!("test_kernel_handle_{}", handle),
+            })
+        }
+    }
+
+    /// A specialiser that always declines.  Used to verify that
+    /// `route` returns `None` cleanly when the backend can't
+    /// specialise.
+    struct DecliningSpecialiser {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Specialiser for DecliningSpecialiser {
+        fn specialise(&self, _key: &SpecKey) -> Option<SpecialisedKernel> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            None
+        }
+    }
+
+    fn router_with_counting() -> (SpecRouter, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let r = SpecRouter::new(
+            Box::new(DefaultPolicy::new()),
+            SpecCache::default_capacity(),
+            Box::new(CountingSpecialiser::new(calls.clone())),
+        );
+        (r, calls)
+    }
+
+    fn router_with_declining() -> (SpecRouter, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let r = SpecRouter::new(
+            Box::new(DefaultPolicy::new()),
+            SpecCache::default_capacity(),
+            Box::new(DecliningSpecialiser {
+                calls: calls.clone(),
+            }),
+        );
+        (r, calls)
+    }
+
+    #[test]
+    fn cold_observation_returns_none_without_calling_specialiser() {
+        let (r, calls) = router_with_counting();
+        let cold = obs(10, vec![t_in(0.0, 1.0, 10)]);
+        assert!(r.route(&cold, 0x07, DType::F32, 1).is_none());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(r.cache_len(), 0);
+    }
+
+    #[test]
+    fn hot_observation_with_constant_input_round_trips_through_specialiser() {
+        let (r, calls) = router_with_counting();
+        let hot = obs(2000, vec![t_in(7.0, 7.0, 2000)]); // constant input
+        let k = r.route(&hot, 0x07, DType::F32, 1).unwrap();
+        assert!(matches!(k.key.range_class, RangeClass::Constant { .. }));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(r.cache_len(), 1);
+    }
+
+    #[test]
+    fn second_call_hits_cache_and_does_not_call_specialiser() {
+        let (r, calls) = router_with_counting();
+        let hot = obs(2000, vec![t_in(7.0, 7.0, 2000)]);
+        let k1 = r.route(&hot, 0x07, DType::F32, 1).unwrap();
+        let k2 = r.route(&hot, 0x07, DType::F32, 1).unwrap();
+        assert_eq!(k1.handle, k2.handle, "should be the cached kernel");
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "specialiser only called once");
+        assert_eq!(r.cache_len(), 1);
+    }
+
+    #[test]
+    fn declining_specialiser_does_not_poison_cache() {
+        let (r, calls) = router_with_declining();
+        let hot = obs(2000, vec![t_in(7.0, 7.0, 2000)]);
+        assert!(r.route(&hot, 0x07, DType::F32, 1).is_none());
+        assert!(r.route(&hot, 0x07, DType::F32, 1).is_none());
+        // Specialiser was asked twice (no cache poisoning).
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        // Nothing cached.
+        assert_eq!(r.cache_len(), 0);
+    }
+
+    #[test]
+    fn distinct_op_kinds_get_distinct_cache_entries() {
+        let (r, calls) = router_with_counting();
+        let hot = obs(2000, vec![t_in(7.0, 7.0, 2000)]);
+        let _ = r.route(&hot, 0x07, DType::F32, 1).unwrap();
+        let _ = r.route(&hot, 0x09, DType::F32, 1).unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(r.cache_len(), 2);
+    }
+
+    #[test]
+    fn distinct_backends_get_distinct_cache_entries() {
+        let (r, calls) = router_with_counting();
+        let hot = obs(2000, vec![t_in(7.0, 7.0, 2000)]);
+        let _ = r.route(&hot, 0x07, DType::F32, 1).unwrap();
+        let _ = r.route(&hot, 0x07, DType::F32, 2).unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(r.cache_len(), 2);
+    }
+
+    #[test]
+    fn cache_clear_drops_cached_kernels() {
+        let (r, _calls) = router_with_counting();
+        let hot = obs(2000, vec![t_in(7.0, 7.0, 2000)]);
+        let _ = r.route(&hot, 0x07, DType::F32, 1).unwrap();
+        assert_eq!(r.cache_len(), 1);
+        r.cache_clear();
+        assert_eq!(r.cache_len(), 0);
+    }
+
+    #[test]
+    fn noop_specialiser_yields_none_after_policy_fires() {
+        // Policy fires (constant input observed) but the noop
+        // specialiser declines, so route() returns None and the cache
+        // stays empty.
+        let r = SpecRouter::new(
+            Box::new(DefaultPolicy::new()),
+            SpecCache::default_capacity(),
+            Box::new(NoopSpecialiser),
+        );
+        let hot = obs(2000, vec![t_in(7.0, 7.0, 2000)]);
+        assert!(r.route(&hot, 0x07, DType::F32, 1).is_none());
+        assert_eq!(r.cache_len(), 0);
+    }
+
+    #[test]
+    fn cache_eviction_means_specialiser_called_again() {
+        // Capacity 1 cache: a second SpecKey evicts the first; the
+        // first then misses again on the third call.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let r = SpecRouter::new(
+            Box::new(DefaultPolicy::new()),
+            SpecCache::new(1),
+            Box::new(CountingSpecialiser::new(calls.clone())),
+        );
+        let hot1 = obs(2000, vec![t_in(7.0, 7.0, 2000)]);
+        let _ = r.route(&hot1, 0x07, DType::F32, 1).unwrap(); // calls = 1
+        let _ = r.route(&hot1, 0x09, DType::F32, 1).unwrap(); // calls = 2 (evicts first)
+        let _ = r.route(&hot1, 0x07, DType::F32, 1).unwrap(); // calls = 3 (re-emit)
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert_eq!(r.cache_len(), 1);
+    }
+
+    #[test]
+    fn cache_get_directly_returns_inserted_kernel() {
+        let (r, _calls) = router_with_counting();
+        let hot = obs(2000, vec![t_in(7.0, 7.0, 2000)]);
+        let kernel = r.route(&hot, 0x07, DType::F32, 1).unwrap();
+        let direct = r.cache_get(&kernel.key).unwrap();
+        assert_eq!(direct.handle, kernel.handle);
+    }
+
+    #[test]
+    fn cache_insert_directly_persists() {
+        let (r, _calls) = router_with_counting();
+        let key = SpecKey {
+            op_kind: 0x07,
+            dtype: DType::F32,
+            shape_class: ShapeClass::Dynamic,
+            range_class: RangeClass::Unknown,
+            backend_id: 1,
+        };
+        let kernel = SpecialisedKernel {
+            key: key.clone(),
+            handle: 999,
+            source_summary: "preloaded".into(),
+        };
+        r.cache_insert(kernel);
+        let got = r.cache_get(&key).unwrap();
+        assert_eq!(got.handle, 999);
+        assert_eq!(got.source_summary, "preloaded");
+    }
+}

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -242,6 +242,18 @@ The compile happens in a background worker thread so live dispatches
 aren't blocked.  Once ready, the specialised pipeline is inserted
 into the cache.
 
+> **Implementation status (Phase 3 V3 landed)**: `SpecRouter` ships
+> in `matrix_runtime::router` and ties together the four pieces:
+> Profiler observations → policy → cache → specialiser, end-to-end.
+> Cache lookup happens before the specialiser is invoked; cache miss
+> consults the specialiser; if the specialiser returns `Some`, the
+> kernel is cached for future calls; if it returns `None`, the cache
+> is **not** poisoned (so a backend that can't yet specialise but
+> might later gets retried).  Phase 3 V4 will wire `SpecRouter::route`
+> into the dispatch path inside `image-gpu-core::pipeline` (and any
+> other domain library that does dispatch), with the call site placed
+> right after `record_dispatch`.
+
 ### 5. Specialised cache + dispatch routing
 
 Each executor extends its existing pipeline cache:


### PR DESCRIPTION
## Summary

Builds on Phase 1 invocation counters (#2092), Phase 2a tensor-byte sampling (#2097), Phase 3 V1 SpecKey + cache (#2104), and Phase 3 V2 specialisation policy (#2107). **Phase 3 V3 ships the glue** that ties all four together as a single `SpecRouter`.

`matrix-runtime` v0.6.0 → v0.7.0. New `router` module exporting `SpecRouter`:

```rust
pub fn route(
    &self,
    observation: &ProfileObservation,
    op_kind: u8,
    output_dtype: DType,
    backend_id: u32,
) -> Option<SpecialisedKernel>
```

The four-step pipeline:

1. Ask `SpecialisationPolicy::should_specialise`. `None` → return `None` (caller uses generic kernel).
2. `SpecCache::get`. Cache hit → return cached kernel.
3. Cache miss → ask `Specialiser::specialise`.
4. Specialiser succeeds → cache and return. Specialiser declines → return `None` **without poisoning the cache** (so a backend that can't yet specialise but might later gets retried).

Internal cache is `Mutex`-guarded so a single router can be shared across an executor's dispatch threads.

## Why no dispatch wiring yet

Phase 3 V4 (next PR) wires `SpecRouter::route` into `image-gpu-core::pipeline` so domain libraries actually benefit from specialisation. Keeping the V3 PR data-only (no call-site changes) means:

1. The PR is small enough to review cleanly.
2. Backends' `Specialiser` implementations can land independently of the call-site changes.
3. The data shape of the routing decision can be validated against the test suite before we put it on the hot path.

## Tests

11 new tests using a `CountingSpecialiser` (counts calls, emits deterministic kernels) and a `DecliningSpecialiser` (always returns None) to exercise both branches of the routing decision: cache hit/miss, decline-doesn't-poison-cache, distinct op-kinds/backends getting distinct entries, eviction-causes-re-emission, direct cache access.

Total: **74 unit + 8 integration = 82 tests pass** (was 71).

## Regression check

`instagram-filters` routing on macOS unchanged after Phase 3 V3:

```
  invert        → cpu     (small graph, planner picks CPU)
  greyscale     → metal   (sRGB + matmul, ships to GPU)
  sepia         → metal   (matmul-heavy, ships to GPU)
```

## Test plan

- [x] `cargo test -p matrix-runtime` — 82 tests pass
- [x] `cargo build` clean
- [x] `instagram-filters` routing unchanged across the dataset
- [x] Spec MX05 §"Specialised cache + dispatch routing" updated with V3 status
- [x] Security review passed in one round (data-only; no FFI, no I/O, no `unsafe`; existing trait Send+Sync requirements carry over)

## Out of scope

- Dispatch-path wiring (Phase 3 V4)
- An actual specialising backend (Phase 4: e.g. matrix-metal emitting MSL kernels with constants folded in)
- Deoptimisation when a SpecKey's underlying assumption is invalidated (Phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)