### PR TITLE
Close omitted ruby annotation tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -40,3 +40,5 @@ documented in this file.
   nested heading DOMs when heading end tags are omitted.
 - Common block starts such as `div`, `ul`, and `table` now close open
   paragraphs before insertion, preventing paragraph-nested block DOMs.
+- Ruby annotation starts now close omitted `rb`, `rt`, `rp`, and `rtc` siblings,
+  preventing nested ruby annotation DOMs when end tags are omitted.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -25,7 +25,7 @@ This first slice intentionally starts small:
 - parser-approved initial tokenizer contexts for data-state documents and
   foreign-content CDATA or script-state fragments
 - simple implied end tags for `p`, `li`, `dt`, `dd`, `option`, `optgroup`,
-  heading elements, and paragraph/block boundaries
+  ruby annotations, heading elements, and paragraph/block boundaries
 - parser diagnostics for unmatched end tags
 
 Future batches can layer the full WHATWG HTML tree-construction insertion modes

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -375,6 +375,14 @@ impl HtmlParser {
         } else if incoming_name == "optgroup" {
             self.pop_current_if(|name| name == "option");
             self.pop_current_if(|name| name == "optgroup");
+        } else if incoming_name == "rb" {
+            self.pop_current_if(is_ruby_annotation_element);
+            self.pop_current_if(|name| name == "rtc");
+        } else if incoming_name == "rt" || incoming_name == "rp" {
+            self.pop_current_if(|name| name == "rb" || name == "rt" || name == "rp");
+        } else if incoming_name == "rtc" {
+            self.pop_current_if(|name| name == "rb" || name == "rt" || name == "rp");
+            self.pop_current_if(|name| name == "rtc");
         } else if is_heading_element(incoming_name) {
             self.pop_current_if(|name| name == "p");
             self.pop_current_if(is_heading_element);
@@ -592,6 +600,10 @@ fn is_heading_element(name: &str) -> bool {
     matches!(name, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
 }
 
+fn is_ruby_annotation_element(name: &str) -> bool {
+    matches!(name, "rb" | "rt" | "rp")
+}
+
 fn is_paragraph_boundary_element(name: &str) -> bool {
     matches!(
         name,
@@ -772,6 +784,50 @@ mod tests {
             element(&second_group.children[0]).children,
             vec![Node::text("Four")]
         );
+    }
+
+    #[test]
+    fn applies_ruby_annotation_implied_end_tags() {
+        let document = parse_html(
+            "<ruby><rb>漢<rt>kan<rb>字<rt>ji<rp>(fallback<rtc><rt>group<rtc><rt>group2</ruby>",
+        )
+        .unwrap();
+
+        let ruby = element(&body(&document).children[0]);
+        assert_eq!(ruby.name, "ruby");
+        assert_eq!(ruby.children.len(), 7);
+
+        let first_base = element(&ruby.children[0]);
+        assert_eq!(first_base.name, "rb");
+        assert_eq!(first_base.children, vec![Node::text("漢")]);
+
+        let first_text = element(&ruby.children[1]);
+        assert_eq!(first_text.name, "rt");
+        assert_eq!(first_text.children, vec![Node::text("kan")]);
+
+        let second_base = element(&ruby.children[2]);
+        assert_eq!(second_base.name, "rb");
+        assert_eq!(second_base.children, vec![Node::text("字")]);
+
+        let second_text = element(&ruby.children[3]);
+        assert_eq!(second_text.name, "rt");
+        assert_eq!(second_text.children, vec![Node::text("ji")]);
+
+        let fallback = element(&ruby.children[4]);
+        assert_eq!(fallback.name, "rp");
+        assert_eq!(fallback.children, vec![Node::text("(fallback")]);
+
+        let first_container = element(&ruby.children[5]);
+        assert_eq!(first_container.name, "rtc");
+        let grouped_text = element(&first_container.children[0]);
+        assert_eq!(grouped_text.name, "rt");
+        assert_eq!(grouped_text.children, vec![Node::text("group")]);
+
+        let second_container = element(&ruby.children[6]);
+        assert_eq!(second_container.name, "rtc");
+        let second_grouped_text = element(&second_container.children[0]);
+        assert_eq!(second_grouped_text.name, "rt");
+        assert_eq!(second_grouped_text.children, vec![Node::text("group2")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add lightweight implied-end recovery for omitted `rb`, `rt`, `rp`, and `rtc` ruby annotation tags.
- Keep adjacent ruby bases, annotations, fallbacks, and annotation containers as siblings instead of nested DOM nodes.
- Document the ruby annotation recovery behavior and add DOM parser coverage.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check