### PR TITLE
fix(prolog): reject summaries for dump-only CLI modes

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -322,6 +322,9 @@ and exits nonzero if any embedded query has no answers.
 Use `--summary` on non-interactive query runs when scripts, CI jobs, or editor
 integrations need compact totals. Text output appends one summary line, JSONL
 appends a summary record, and JSON wraps result records with summary metadata.
+Because it summarizes query execution, `--summary` is rejected for compile-only
+diagnostic modes such as `--check`, `--dump-instructions`, `--dump-bytecode`,
+`--dump-source-metadata`, and `--list-source-queries`.
 
 Use `--format json` for a machine-readable result object, or `--format jsonl`
 when repeated queries should stream one result record per line. JSON answers

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -257,6 +257,15 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if summary and check:
         msg = "--summary cannot be combined with --check"
         raise ValueError(msg)
+    if summary and dump_bytecode:
+        msg = "--summary cannot be combined with --dump-bytecode"
+        raise ValueError(msg)
+    if summary and dump_instructions:
+        msg = "--summary cannot be combined with --dump-instructions"
+        raise ValueError(msg)
+    if summary and dump_source_metadata:
+        msg = "--summary cannot be combined with --dump-source-metadata"
+        raise ValueError(msg)
     if summary and list_source_queries:
         msg = "--summary cannot be combined with --list-source-queries"
         raise ValueError(msg)

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -598,6 +598,27 @@ def test_cli_summary_rejects_interactive(
     )
 
 
+@pytest.mark.parametrize(
+    "dump_flag",
+    ["--dump-bytecode", "--dump-instructions", "--dump-source-metadata"],
+)
+def test_cli_summary_rejects_compile_only_dump_modes(
+    dump_flag: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        dump_flag,
+        "--summary",
+    ])
+
+    assert status == 2
+    assert f"--summary cannot be combined with {dump_flag}" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_interactive_loop_runs_queries_from_stdin(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -138,7 +138,8 @@ When `--summary` is set for non-interactive query execution, text output
 appends one compact line with query, success, failure, and answer totals. JSONL
 appends a final `mode: "summary"` record. JSON wraps result records in an object
 with `results`, `summary`, and aggregate `success` fields so downstream tools
-can consume both details and totals without re-counting.
+can consume both details and totals without re-counting. Compile-only modes
+reject `--summary` rather than silently ignoring it.
 
 Each result object includes:
 


### PR DESCRIPTION
## Summary
- reject `--summary` when paired with compile-only dump modes instead of silently ignoring it
- cover `--dump-bytecode`, `--dump-instructions`, and `--dump-source-metadata` validation
- document that summaries are query-execution-only

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-reject-dump-summary -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-reject-dump-summary-build-plan.json`