### PR TITLE
Recover NULLs in malformed CDATA openers

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -116,6 +116,9 @@ documented in this file.
 - NULL characters in comments and bogus comments now recover with
   `unexpected-null-character` and append U+FFFD while preserving pending comment
   dashes.
+- NULL characters encountered while recovering malformed `<![CDATA` openers now
+  report `unexpected-null-character` and append U+FFFD before continuing as
+  bogus comments.
 - NULL characters in DOCTYPE names and quoted public/system identifiers now
   recover with `unexpected-null-character` and append U+FFFD.
 - NULL characters in script escaped and double-escaped substates now recover

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -130,7 +130,8 @@ declarations such as `<!>` emit an empty comment and return to normal data
 lexing, and EOF after `<!` emits the same empty bogus-comment recovery instead
 of preserving the opener as text. One-dash declaration openers such as `<!->`
 and `<!-x>` use that same bogus-comment recovery instead of being mistaken for
-normal empty-comment syntax.
+normal empty-comment syntax. Malformed `<![CDATA` opener recovery also replaces
+embedded NULL characters with U+FFFD before continuing in bogus-comment state.
 The tag-open states now only begin normal tags when the next character is an
 ASCII letter; stray less-than signs such as `a < b` remain text, and malformed
 end-tag openers such as `</3>` recover as bogus comments with a tokenizer

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -5290,6 +5290,17 @@ actions = [
 
 [[transitions]]
 from = "cdata_open_bracket"
+matcher = { literal = "\u0000" }
+to = "bogus_comment"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "create_comment",
+  "append_comment([)",
+  "append_comment_replacement",
+]
+
+[[transitions]]
+from = "cdata_open_bracket"
 matcher = { anything = true }
 to = "bogus_comment"
 actions = ["create_comment", "append_comment([)", "append_comment(current)"]
@@ -5314,6 +5325,17 @@ actions = [
 
 [[transitions]]
 from = "cdata_open_c"
+matcher = { literal = "\u0000" }
+to = "bogus_comment"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "create_comment",
+  "append_comment([C)",
+  "append_comment_replacement",
+]
+
+[[transitions]]
+from = "cdata_open_c"
 matcher = { anything = true }
 to = "bogus_comment"
 actions = ["create_comment", "append_comment([C)", "append_comment(current)"]
@@ -5334,6 +5356,17 @@ actions = [
   "append_comment([CD)",
   "emit_current_token",
   "emit(EOF)",
+]
+
+[[transitions]]
+from = "cdata_open_cd"
+matcher = { literal = "\u0000" }
+to = "bogus_comment"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "create_comment",
+  "append_comment([CD)",
+  "append_comment_replacement",
 ]
 
 [[transitions]]
@@ -5366,6 +5399,17 @@ actions = [
 
 [[transitions]]
 from = "cdata_open_cda"
+matcher = { literal = "\u0000" }
+to = "bogus_comment"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "create_comment",
+  "append_comment([CDA)",
+  "append_comment_replacement",
+]
+
+[[transitions]]
+from = "cdata_open_cda"
 matcher = { anything = true }
 to = "bogus_comment"
 actions = [
@@ -5394,6 +5438,17 @@ actions = [
 
 [[transitions]]
 from = "cdata_open_cdat"
+matcher = { literal = "\u0000" }
+to = "bogus_comment"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "create_comment",
+  "append_comment([CDAT)",
+  "append_comment_replacement",
+]
+
+[[transitions]]
+from = "cdata_open_cdat"
 matcher = { anything = true }
 to = "bogus_comment"
 actions = [
@@ -5418,6 +5473,17 @@ actions = [
   "append_comment([CDATA)",
   "emit_current_token",
   "emit(EOF)",
+]
+
+[[transitions]]
+from = "cdata_open_cdata"
+matcher = { literal = "\u0000" }
+to = "bogus_comment"
+actions = [
+  "parse_error(unexpected-null-character)",
+  "create_comment",
+  "append_comment([CDATA)",
+  "append_comment_replacement",
 ]
 
 [[transitions]]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -11231,6 +11231,24 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "cdata_open_bracket".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "create_comment".to_string(),
+                "append_comment([)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "cdata_open_bracket".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "bogus_comment".to_string(),
@@ -11276,6 +11294,24 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "cdata_open_c".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "create_comment".to_string(),
+                "append_comment([C)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "cdata_open_c".to_string(),
@@ -11329,6 +11365,24 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "cdata_open_cd".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "create_comment".to_string(),
+                "append_comment([CD)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "cdata_open_cd".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "bogus_comment".to_string(),
@@ -11374,6 +11428,24 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "cdata_open_cda".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "create_comment".to_string(),
+                "append_comment([CDA)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "cdata_open_cda".to_string(),
@@ -11427,6 +11499,24 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "cdata_open_cdat".to_string(),
             on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "create_comment".to_string(),
+                "append_comment([CDAT)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "cdata_open_cdat".to_string(),
+            on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
                 "bogus_comment".to_string(),
@@ -11472,6 +11562,24 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "emit(EOF)".to_string(),
             ],
             consume: false,
+        },
+        TransitionDefinition {
+            from: "cdata_open_cdata".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("\0".to_string())),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(unexpected-null-character)".to_string(),
+                "create_comment".to_string(),
+                "append_comment([CDATA)".to_string(),
+                "append_comment_replacement".to_string(),
+            ],
+            consume: true,
         },
         TransitionDefinition {
             from: "cdata_open_cdata".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -2393,6 +2393,28 @@ fn default_html_lexer_recovers_malformed_cdata_open_as_bogus_comment() {
 }
 
 #[test]
+fn default_html_lexer_replaces_null_in_malformed_cdata_openers() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("a<![CD\0>after").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("a".to_string()),
+            Token::Comment("[CD\u{FFFD}".to_string()),
+            Token::Text("after".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "unexpected-null-character"));
+}
+
+#[test]
 fn default_html_lexer_keeps_unclosed_cdata_brackets_as_text_at_eof() {
     let mut lexer = create_html_lexer().unwrap();
     lexer.set_initial_state("cdata_section").unwrap();


### PR DESCRIPTION
## Summary
- Add explicit NULL recovery while partially matching malformed `<![CDATA` openers before bogus-comment fallback.
- Keep `html1.lexer.states.toml` and the checked-in generated HTML1 machine in sync.
- Document the recovery and add unit coverage for U+FFFD replacement plus diagnostics.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check