### PR TITLE
Support ALGOL dummy statements

### DIFF
--- a/code/grammars/algol/algol60.grammar
+++ b/code/grammars/algol/algol60.grammar
@@ -146,15 +146,11 @@ proc_body    = block | statement ;
 # Any statement may carry one or more labels. Labels can be identifiers or
 # integer literals. Labels are the targets of goto statements.
 #
-# The third alternative supports standalone labels at the end of a block, e.g.
-# `done:` or `done1: done2:` immediately before `end`. This is equivalent to
-# labels on an empty/dummy statement — a common ALGOL 60 idiom for goto targets
-# at the end of a block. Strictly, ALGOL 60 requires a statement after a label,
-# but most implementations accept terminal labels because the block's `end`
-# acts as the associated statement.
+# `dummy_stmt` covers ALGOL 60's empty statement. The lookahead keeps it
+# zero-width, which lets semicolons remain statement separators while still
+# allowing empty bodies after `then`, `else`, `do`, or labels before `end`.
 statement    = { label COLON } unlabeled_stmt
-             | { label COLON } cond_stmt
-             | label COLON { label COLON } ;
+             | { label COLON } cond_stmt ;
 
 label        = NAME | INTEGER_LIT ;
 
@@ -167,11 +163,18 @@ label        = NAME | INTEGER_LIT ;
 # In C and Java, the else binds to the nearest if by convention (not grammar).
 # ALGOL requires explicit begin/end to make nesting unambiguous.
 unlabeled_stmt = assign_stmt
+               | dummy_stmt
                | goto_stmt
                | proc_stmt
                | compound_stmt
                | block
                | for_stmt ;
+
+# Dummy statement: consumes no tokens. It succeeds only when a statement
+# boundary follows, so invalid syntax does not disappear into a no-op.
+dummy_stmt   = &SEMICOLON
+             | &"end"
+             | &"else" ;
 
 # Conditional statement. The then-branch is unlabeled_stmt (excludes conditionals).
 # The else-branch is statement (includes conditionals, enabling if/then/else if chains).

--- a/code/packages/python/algol-ir-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-ir-compiler/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Changed
 
+- Lowered ALGOL dummy statements as no-op IR in `then`, `else`, `do`, and
+  terminal-label statement positions.
 - Lowered ALGOL scalar locals through planned activation-frame slots instead
   of source-variable virtual registers.
 - Added frame-memory metadata, frame header setup/teardown, static-link

--- a/code/packages/python/algol-ir-compiler/README.md
+++ b/code/packages/python/algol-ir-compiler/README.md
@@ -43,12 +43,12 @@ bounds, while arrays local to those callees still lower normally.
 Expression lowering includes mixed integer/real arithmetic, boolean operators,
 comparisons, chained assignment targets, branch-selected conditional
 expressions, nested conditional forms in type-specific arithmetic and Boolean
-contexts, and ALGOL-left-associative exponentiation. Integer exponents use the
-existing loop lowering, real bases with negative integer exponents use a
-reciprocal path, and real exponents lower through the imported real `pow`
-runtime with a domain-failure guard. Boolean `and`, `or`, and `impl` lower
-through short-circuiting control flow; `eqv` remains strict and evaluates both
-operands.
+contexts, zero-width dummy statements in control-flow positions, and
+ALGOL-left-associative exponentiation. Integer exponents use the existing loop
+lowering, real bases with negative integer exponents use a reciprocal path, and
+real exponents lower through the imported real `pow` runtime with a
+domain-failure guard. Boolean `and`, `or`, and `impl` lower through
+short-circuiting control flow; `eqv` remains strict and evaluates both operands.
 Standard numeric functions `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`,
 `arctan`, `ln`, and `exp` lower to existing integer/f64 comparison,
 arithmetic, conversion, native square-root IR, and imported standard real-math

--- a/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
+++ b/code/packages/python/algol-ir-compiler/src/algol_ir_compiler/compiler.py
@@ -1100,6 +1100,8 @@ class AlgolIrCompiler:
             return
         if inner.rule_name == "assign_stmt":
             self._compile_assignment(inner, scope)
+        elif inner.rule_name == "dummy_stmt":
+            return
         elif inner.rule_name == "for_stmt":
             self._compile_for(inner, scope)
         elif inner.rule_name == "compound_stmt":

--- a/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
+++ b/code/packages/python/algol-ir-compiler/tests/test_algol_ir_compiler.py
@@ -112,6 +112,26 @@ class TestAlgolIrCompiler:
         assert "if_0_else" in labels
         assert "if_0_end" in labels
 
+    def test_compiles_dummy_statements_in_control_positions(self) -> None:
+        result = compile_algol(
+            parse_algol(
+                "begin integer result, i; "
+                "if true then ; "
+                "if false then result := 1 else ; "
+                "for i := 1 step 1 until 1 do ; "
+                "done: "
+                "end"
+            )
+        )
+        labels = [
+            instr.operands[0].name
+            for instr in result.program.instructions
+            if instr.opcode == IrOp.LABEL
+        ]
+        assert any(label.startswith("algol_label_") for label in labels)
+        assert any(label.startswith("if_") for label in labels)
+        assert any(label.startswith("loop_") for label in labels)
+
     def test_compiles_for_loop_labels(self) -> None:
         result = compile_algol(
             parse_algol(

--- a/code/packages/python/algol-parser/CHANGELOG.md
+++ b/code/packages/python/algol-parser/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Type-specific conditional grammar rules now allow nested `if ... then ...
   else ...` forms in arithmetic bounds/subscripts, boolean conditions, and
   designational `goto` targets.
+- Added zero-width `dummy_stmt` parsing for ALGOL empty statements after
+  `then`, `else`, `do`, or labels before `end`.
 - Unified `expression` parsing now accepts ALGOL conditional expressions such
   as `if b then x else y` in assignment values and actual parameters.
 - Block and compound statement lists now tolerate repeated and trailing
@@ -38,13 +40,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   engine from `coding-adventures-parser`.
 - Full ALGOL 60 grammar coverage:
   - **Top level**: `program` → `block`
-  - **Block structure**: `BEGIN { declaration SEMICOLON } statement { SEMICOLON statement } END`
+  - **Block structure**:
+    `BEGIN { declaration SEMICOLON } { SEMICOLON } [ statement { SEMICOLON [ statement ] } ] END`
     enforces declaration-before-statement ordering at the grammar level.
-  - **Declarations**: `type_decl`, `array_decl` (with dynamic bounds),
-    `switch_decl`, `procedure_decl` (with `value`/`spec` parts)
+  - **Declarations**: `type_decl`, `own_decl`, `own_array_decl`, `array_decl`
+    (with dynamic bounds), `switch_decl`, `procedure_decl` (with
+    `value`/`spec` parts)
   - **Statements**: `assign_stmt` (chainable `:=`), `cond_stmt`
     (dangling-else-free), `for_stmt` (step/until, while, simple),
-    `goto_stmt`, `proc_stmt`, `compound_stmt`, `empty_stmt`
+    `goto_stmt`, `proc_stmt`, `compound_stmt`, `dummy_stmt`
   - **Arithmetic expressions**: full 5-level precedence hierarchy
     (`arith_expr` → `simple_arith` → `term` → `factor` → `primary`),
     conditional arithmetic expressions (`if b then x else y`),

--- a/code/packages/python/algol-parser/README.md
+++ b/code/packages/python/algol-parser/README.md
@@ -92,8 +92,8 @@ The parser covers the complete ALGOL 60 grammar:
 | Category | Rules |
 |----------|-------|
 | Top level | `program`, `block` |
-| Declarations | `type_decl`, `array_decl`, `switch_decl`, `procedure_decl` |
-| Statements | `assign_stmt`, `cond_stmt`, `for_stmt`, `goto_stmt` (`goto` or `go to`), `proc_stmt`, `compound_stmt`, `empty_stmt` |
+| Declarations | `type_decl`, `own_decl`, `own_array_decl`, `array_decl`, `switch_decl`, `procedure_decl` |
+| Statements | `assign_stmt`, `cond_stmt`, `for_stmt`, `goto_stmt` (`goto` or `go to`), `proc_stmt`, `compound_stmt`, `dummy_stmt` |
 | Arithmetic | `arith_expr`, `simple_arith`, `term`, `factor`, `primary` |
 | Boolean | `bool_expr`, `simple_bool`, `implication`, `bool_term`, `bool_factor`, `bool_secondary`, `bool_primary`, `relation` |
 | Designational | `desig_expr`, `simple_desig` |
@@ -103,6 +103,10 @@ Conditional arithmetic, Boolean, and designational expressions may nest in
 either branch, so type-specific contexts such as array bounds/subscripts,
 conditions, and `goto` targets accept the same nested conditional shape as
 ordinary assignment expressions.
+
+ALGOL dummy statements parse as zero-width `dummy_stmt` nodes at statement
+boundaries, so empty `then`, `else`, and `do` bodies preserve semicolon
+separator semantics instead of consuming the separator as part of the no-op.
 
 Procedure declarations and calls accept the report-style omitted-parentheses
 form for parameterless procedures as well as explicit empty parentheses, so

--- a/code/packages/python/algol-parser/src/algol_parser/parser.py
+++ b/code/packages/python/algol-parser/src/algol_parser/parser.py
@@ -187,7 +187,7 @@ def parse_algol(source: str, version: str = "algol60") -> ASTNode:
     - A block contains:
       - ``BEGIN`` token
       - Zero or more ``declaration`` nodes (each followed by SEMICOLON)
-      - One or more ``statement`` nodes (separated by SEMICOLONs)
+      - Zero or more ``statement`` nodes (separated by SEMICOLONs)
       - ``END`` token
 
     Statement node types (``rule_name`` values you will encounter):
@@ -198,7 +198,7 @@ def parse_algol(source: str, version: str = "algol60") -> ASTNode:
     - ``compound_stmt`` — begin/end with only statements (no declarations)
     - ``goto_stmt``   — goto with a designational expression
     - ``proc_stmt``   — procedure call as a statement
-    - ``empty_stmt``  — empty (bare semicolon or trailing)
+    - ``dummy_stmt``  — zero-width ALGOL dummy statement
     - ``block``       — nested block (introduces a new scope)
 
     Declaration node types:

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -109,8 +109,8 @@ class TestMinimalProgram:
           <statements>
         end
 
-    At least one statement is required. The empty statement (``empty_stmt``)
-    satisfies this requirement.
+    Empty programs are valid, and ALGOL dummy statements appear as zero-width
+    ``dummy_stmt`` nodes where a statement boundary supplies the no-op.
     """
 
     def test_minimal_program_root(self) -> None:
@@ -333,6 +333,18 @@ class TestIfStatement:
         )
         assert ast.rule_name == "program"
 
+    def test_if_then_dummy_statement(self) -> None:
+        """The then-branch may be ALGOL's zero-width dummy statement."""
+        ast = parse("begin integer x; if true then ; x := 1 end")
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "dummy_stmt")
+
+    def test_if_else_dummy_statement(self) -> None:
+        """The else-branch may also be a dummy statement."""
+        ast = parse("begin integer x; if false then x := 1 else ; end")
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "dummy_stmt")
+
 
 # ---------------------------------------------------------------------------
 # Goto statement tests
@@ -388,7 +400,9 @@ class TestGotoStatement:
             == 2
         )
 
-        assert all(child.rule_name == "label" for child in child_nodes(statement))
+        nodes = child_nodes(statement)
+        assert [child.rule_name for child in nodes[:2]] == ["label", "label"]
+        assert find_nodes(statement, "dummy_stmt")
 
 
 # ---------------------------------------------------------------------------
@@ -482,6 +496,12 @@ class TestForLoop:
         for_nodes = find_nodes(ast, "for_stmt")
         assert len(for_nodes) == 1
         assert find_nodes(for_nodes[0], "subscripts")
+
+    def test_dummy_statement_body(self) -> None:
+        """For-loop bodies may be empty dummy statements."""
+        ast = parse("begin integer i; for i := 1 do ; i := 2 end")
+        assert ast.rule_name == "program"
+        assert find_nodes(ast, "dummy_stmt")
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/algol-type-checker/CHANGELOG.md
+++ b/code/packages/python/algol-type-checker/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Accepted ALGOL dummy statements as semantic no-ops in `then`, `else`, `do`,
+  and terminal-label statement positions.
 - Added the PL04 phase-one semantic model with explicit semantic blocks,
   static-parent metadata, scalar frame layouts, and resolved variable
   references carrying lexical-depth and slot-offset information.

--- a/code/packages/python/algol-type-checker/README.md
+++ b/code/packages/python/algol-type-checker/README.md
@@ -15,9 +15,9 @@ function. Switch declarations, switch selections, and conditional designational
 
 The expression checker also accepts chained assignments, ALGOL conditional
 expressions, nested conditional forms in type-specific arithmetic, Boolean, and
-designational contexts, tolerant trailing/repeated semicolons from the parser,
-and left-associative exponentiation for numeric bases with integer or real
-exponents.
+designational contexts, zero-width dummy statements in control-flow positions,
+tolerant trailing/repeated semicolons from the parser, and left-associative
+exponentiation for numeric bases with integer or real exponents.
 Mixed integer/real conditional branches resolve to `real`; incompatible branch
 types are still rejected before IR lowering. Standard numeric functions
 `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`, `arctan`, `ln`, and `exp` are

--- a/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
+++ b/code/packages/python/algol-type-checker/src/algol_type_checker/checker.py
@@ -1577,6 +1577,8 @@ class AlgolTypeChecker:
             return
         if inner.rule_name == "assign_stmt":
             self._check_assignment(inner, scope)
+        elif inner.rule_name == "dummy_stmt":
+            return
         elif inner.rule_name == "for_stmt":
             self._check_for(inner, scope)
         elif inner.rule_name == "compound_stmt":

--- a/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
+++ b/code/packages/python/algol-type-checker/tests/test_algol_type_checker.py
@@ -519,6 +519,21 @@ class TestAlgolTypeChecker:
         )
         assert check_algol(ast).ok
 
+    def test_accepts_dummy_statements_in_control_positions(self) -> None:
+        ast = parse_algol(
+            "begin integer result, i; "
+            "if true then ; "
+            "if false then result := 1 else ; "
+            "for i := 1 do ; "
+            "done: "
+            "end"
+        )
+        result = check_algol(ast)
+
+        assert result.ok
+        assert result.semantic is not None
+        assert "done" in result.root_scope.children[0].symbols
+
     def test_accepts_boolean_implication_and_equivalence(self) -> None:
         ast = parse_algol(
             "begin integer result; "

--- a/code/packages/python/algol-wasm-compiler/CHANGELOG.md
+++ b/code/packages/python/algol-wasm-compiler/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Changed
 
+- Executed ALGOL dummy statements as no-ops in `then`, `else`, `do`, and
+  terminal-label statement positions.
 - Added `algol60-wasm run SOURCE` for shell-level source-to-WASM execution with
   stdout forwarding, optional `_start` result reporting, and a default WASM
   instruction budget.

--- a/code/packages/python/algol-wasm-compiler/README.md
+++ b/code/packages/python/algol-wasm-compiler/README.md
@@ -26,8 +26,9 @@ the current lane already supports a substantial ALGOL 60 surface:
   string literals
 - chained assignment, conditional expressions, including nested conditionals in
   bounds, subscripts, conditions, and designational targets, tolerant
-  trailing/repeated semicolons, numeric runtime failure guards, and
-  ALGOL-left-associative exponentiation for integer or real exponents
+  trailing/repeated semicolons, zero-width dummy statements in `then`, `else`,
+  and `do` bodies, numeric runtime failure guards, and ALGOL-left-associative
+  exponentiation for integer or real exponents
 - boolean `and`, `or`, and `impl` with short-circuiting RHS evaluation, plus
   strict `eqv`
 - standard numeric functions `abs`, `sign`, `entier`, `sqrt`, `sin`, `cos`,
@@ -176,9 +177,10 @@ local WASM runtime. Those fixtures cover:
   output executes
 - mixed `own` scalar and array storage for real, boolean, and string values,
   plus value-array copies and by-name loop-control storage behavior
-- boolean and string conditional values, conditional subscripts, terminal labels
-  on empty statements, invalid switch indexes, array element caps, and heap
-  exhaustion through the zero-result runtime guard path
+- boolean and string conditional values, conditional subscripts, dummy
+  statements in control-flow positions, terminal labels on empty statements,
+  invalid switch indexes, array element caps, and heap exhaustion through the
+  zero-result runtime guard path
 - real-to-integer and real-output edge cases that would otherwise trap on
   overflow, infinity, or NaN now return through the same zero-result guard path
 - a full-surface convergence program combining `own` scalars and arrays,

--- a/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
+++ b/code/packages/python/algol-wasm-compiler/tests/test_algol_wasm_surface_audit.py
@@ -151,6 +151,23 @@ _SURFACE_CASES = (
         result=[23],
     ),
     SurfaceCase(
+        name="dummy-statements-in-control-positions",
+        source="""
+            begin
+              integer result, i;
+              result := 0;
+              if true then ;
+              if false then result := 100 else ;
+              for i := 1 do ;
+              done:
+              result := result + i + 6;
+              print('DUMMY ', result)
+            end
+        """,
+        result=[7],
+        stdout="DUMMY 7",
+    ),
+    SurfaceCase(
         name="nested-conditional-type-contexts",
         source="""
             begin


### PR DESCRIPTION
## Summary
- Add zero-width `dummy_stmt` grammar support so ALGOL empty statements work after `then`, `else`, `do`, and terminal labels without consuming semicolon separators.
- Treat dummy statements as semantic and IR no-ops across the Python ALGOL type-checker and IR/WASM lane.
- Add parser, type-checker, IR, and WASM surface-audit coverage plus docs/changelog updates.

## Verification
- `code/packages/python/algol-wasm-compiler/.venv/bin/python -m pytest code/packages/python/algol-parser/tests/test_algol_parser.py -q`
- `bash BUILD` in `code/packages/python/algol-type-checker`
- `bash BUILD` in `code/packages/python/algol-ir-compiler`
- `bash BUILD` in `code/packages/python/algol-wasm-compiler`
- `code/packages/python/algol-wasm-compiler/.venv/bin/python -m ruff check code/packages/python/algol-parser code/packages/python/algol-type-checker code/packages/python/algol-ir-compiler code/packages/python/algol-wasm-compiler`
- `git diff --check`
- Security review: scanned touched source/tests for dynamic execution, subprocess/shell, network, serialization, and file-write primitives; only pre-existing switch-eval helper names matched, with no new risky paths.