### PR TITLE
fix(prolog): require query flags for committed CLI state

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -319,6 +319,10 @@ queries and the CLI should run them as a script. The command prints or emits
 one result record per source query, sets `source_query_index` in JSON formats,
 and exits nonzero if any embedded query has no answers.
 
+Use `--commit` only with one or more ad-hoc `--query` flags. It persists the
+first answer state from those query flags into later query flags or an
+interactive loop, but it is rejected when no ad-hoc query is supplied.
+
 Use `--summary` on non-interactive query runs when scripts, CI jobs, or editor
 integrations need compact totals. Text output appends one summary line, JSONL
 appends a summary record, and JSON wraps result records with summary metadata.

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -278,6 +278,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if all_source_queries and bool(flags["interactive"]):
         msg = "--all-source-queries cannot be combined with --interactive"
         raise ValueError(msg)
+    if bool(flags["commit"]) and not queries:
+        msg = "--commit requires at least one --query"
+        raise ValueError(msg)
 
     return CliArgs(
         files=files,

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -106,6 +106,19 @@ def test_cli_repeated_queries_share_committed_runtime_state(
     ]
 
 
+def test_cli_commit_requires_ad_hoc_query(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        "--commit",
+    ])
+
+    assert status == 2
+    assert "--commit requires at least one --query" in capsys.readouterr().err
+
+
 def test_cli_check_compiles_source_without_queries(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -58,7 +58,7 @@ Important options:
 - `--format text|json|jsonl` selects human text, one JSON document, or
   newline-delimited JSON records.
 - `--commit` persists the first answer state from each ad-hoc query into the
-  next query.
+  next query and is only valid when at least one `--query` is supplied.
 - `--interactive` starts a small top-level query loop after loading the source.
 - `--no-initialize` skips initialization directives.
 


### PR DESCRIPTION
## Summary
- reject `--commit` unless at least one ad-hoc `--query` flag is supplied
- keep committed state semantics scoped to repeated query scripts and query setup before interactive mode
- document the `--commit` requirement and add CLI validation coverage

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-commit-requires-query -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-commit-requires-query-build-plan.json`