### PR TITLE
feat(matrix-metal): Op::Broadcast support — completes the shape-op trio

### DIFF
--- a/code/packages/rust/matrix-metal/CHANGELOG.md
+++ b/code/packages/rust/matrix-metal/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog — matrix-metal
 
+## 0.3.0 — 2026-05-05
+
+### Added
+
+- **`Op::Broadcast` support.**  Completes the shape-op trio (Reshape
+  in #2077, Transpose in #2122, Broadcast now).  General N-D
+  axis-replication kernel up to rank 4 (matching this backend's
+  advertised `max_tensor_rank`).  Capability bitset now includes
+  tag 0x13.
+
+  The MSL kernel walks the output linearly: for each output element,
+  decomposes the linear index into an output multi-index using the
+  target dims, then builds the input multi-index by clamping each
+  size-1 input axis to index 0 and copying every non-broadcast axis
+  through.  Re-flattens with the input dims and reads.  Memory
+  access is **read-fan-in** — many output threads read the same
+  input element when broadcasting along a hot axis, which Metal
+  handles well via its texture cache on Apple Silicon.
+
+  The args struct (rank, output numel, in_dims[4], out_dims[4]) is
+  encoded as 40 bytes (rounded to 48 for MSL alignment) and passed
+  via `set_bytes`.
+
+  Edge cases:
+    - Rank 0 (scalar) is a no-op single-element copy.
+    - Rank > 4 returns an Err.
+    - Empty output (numel = 0) returns Ok without dispatching.
+    - Input rank ≠ output rank returns an Err.
+    - Input dim ≠ 1 and ≠ output dim is enforced at the matrix-ir
+      validator level; the kernel doesn't re-check.
+
+### Tests (2 new)
+
+- `broadcast_row_to_matrix_on_gpu` — `(1, 3) → (4, 3)` broadcast on axis 0.
+- `broadcast_column_to_matrix_on_gpu` — `(3, 1) → (3, 4)` broadcast on axis 1.
+
+Total: 10 integration tests (was 8).
+
+### Notes
+
+- All three V1 shape ops (Reshape, Transpose, Broadcast) now run on
+  Metal.  The capability filter no longer routes any pure shape op
+  to CPU, so future graphs that mix elementwise + matmul + arbitrary
+  shape ops can stay end-to-end on GPU under uniform-Metal placement.
+- ML-style "bias add" (`out = x + bias` where bias broadcasts across
+  the batch axis) is now expressible end-to-end on Metal.
+
 ## 0.2.0 — 2026-05-05
 
 ### Added

--- a/code/packages/rust/matrix-metal/Cargo.toml
+++ b/code/packages/rust/matrix-metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-metal"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "First real GPU executor for the matrix execution layer. Lowers a subset of MatrixIR ops to MSL kernels and dispatches via the metal-compute crate. Falls back to CPU automatically (via the planner's capability filter) for ops it doesn't yet support."
 license = "MIT"

--- a/code/packages/rust/matrix-metal/src/dispatch.rs
+++ b/code/packages/rust/matrix-metal/src/dispatch.rs
@@ -172,6 +172,15 @@ fn exec_compute(
             output,
         } => transpose_dispatch(ctx, graph, *input, perm, *output),
 
+        // Broadcast: replicate input across size-1 axes to match the
+        // declared target shape.  Single MSL kernel reads from the
+        // input by clamping size-1 axes to index 0.
+        Op::Broadcast {
+            input,
+            output,
+            ..
+        } => broadcast_dispatch(ctx, graph, *input, *output),
+
         _ => Err(format!(
             "matrix-metal V1 doesn't support op {}; the planner should have routed this to CPU",
             op_kind_name(op)
@@ -454,6 +463,117 @@ fn transpose_dispatch(
 /// buffer's bytes into the output buffer.  Same numel; only the shape
 /// metadata differs, and shapes are tracked at the graph level (not in
 /// the buffer itself), so a byte-level memcpy is the entire
+/// Broadcast: launch the generic axis-replication kernel.  Each
+/// input axis must equal the corresponding output (target) axis or be
+/// 1; the matrix-ir validator enforces this so we don't re-check it
+/// here at dispatch time.
+///
+/// V1 limit: rank ≤ 4, dtype F32 (matches `max_tensor_rank` and the
+/// V1 dtype set advertised in this backend's profile).  Out-of-range
+/// inputs return an error — defence in depth.
+fn broadcast_dispatch(
+    ctx: &mut DispatchCtx<'_>,
+    graph: &ComputeGraph,
+    input: TensorId,
+    output: TensorId,
+) -> Result<(), String> {
+    let in_t = graph
+        .tensor(input)
+        .ok_or_else(|| format!("broadcast input tensor {} not found", input.0))?;
+    let out_t = graph
+        .tensor(output)
+        .ok_or_else(|| format!("broadcast output tensor {} not found", output.0))?;
+    let in_residency = in_t.residency;
+    let out_residency = out_t.residency;
+    let rank = out_t.shape.rank();
+    if in_t.shape.rank() != rank {
+        return Err(format!(
+            "broadcast: input rank {} doesn't match output rank {}",
+            in_t.shape.rank(),
+            rank
+        ));
+    }
+    if rank == 0 {
+        // Scalar broadcast → single-element copy.
+        let n_bytes = in_t
+            .shape
+            .byte_size(in_t.dtype)
+            .ok_or_else(|| "broadcast scalar byte_size overflow".to_string())?;
+        if n_bytes == 0 {
+            return Ok(());
+        }
+        let data = ctx.buffers.read(in_residency.buffer, 0, n_bytes as usize)?;
+        if !ctx.buffers.contains(out_residency.buffer) {
+            ctx.buffers
+                .alloc(ctx.device, out_residency.buffer, n_bytes as usize)?;
+        }
+        ctx.buffers.write(out_residency.buffer, 0, &data)?;
+        return Ok(());
+    }
+    if rank > 4 {
+        return Err(format!(
+            "matrix-metal broadcast: rank {} exceeds the supported maximum of 4",
+            rank
+        ));
+    }
+
+    let numel = out_t
+        .shape
+        .numel()
+        .ok_or_else(|| "broadcast output numel overflow".to_string())? as u32;
+    if numel == 0 {
+        return Ok(());
+    }
+
+    let pipeline = ctx
+        .pipelines
+        .get("broadcast_f32")
+        .ok_or_else(|| "broadcast_f32 pipeline not in cache".to_string())?;
+
+    let in_buf_ptr = ctx.buffers.get(in_residency.buffer)? as *const _;
+    let out_buf_ptr = ctx.buffers.get(out_residency.buffer)? as *const _;
+    // SAFETY: we hold `&BufferStore` via ctx.buffers; both buffer
+    // references live for the dispatch call.  Same pattern as
+    // `unary_dispatch`.
+    let in_buf = unsafe { &*in_buf_ptr };
+    let out_buf = unsafe { &*out_buf_ptr };
+
+    // Encode BroadcastArgs.  Field order matches the MSL struct:
+    //   uint rank;
+    //   uint numel;
+    //   uint in_dims[4];
+    //   uint out_dims[4];
+    // Total: 10 × 4 = 40 bytes.  Round up to 48 (MSL alignment).
+    let mut args = [0u8; 48];
+    let mut off = 0usize;
+    let put_u32 = |v: u32, args: &mut [u8; 48], off: &mut usize| {
+        args[*off..*off + 4].copy_from_slice(&v.to_le_bytes());
+        *off += 4;
+    };
+    put_u32(rank as u32, &mut args, &mut off);
+    put_u32(numel, &mut args, &mut off);
+    for d in 0..4 {
+        let v = if d < rank { in_t.shape.dims[d] } else { 0 };
+        put_u32(v, &mut args, &mut off);
+    }
+    for d in 0..4 {
+        let v = if d < rank { out_t.shape.dims[d] } else { 0 };
+        put_u32(v, &mut args, &mut off);
+    }
+    let _ = off;
+
+    let tg = pipeline.preferred_threads_1d();
+
+    ctx.queue.dispatch(|enc| {
+        enc.set_pipeline(pipeline);
+        enc.set_buffer(in_buf, 0);
+        enc.set_buffer(out_buf, 1);
+        enc.set_bytes(&args, 2);
+        enc.dispatch_threads_1d(numel, tg);
+    });
+    Ok(())
+}
+
 /// implementation.
 ///
 /// V2 polish: matrix-metal could expose this as a `BlitCommandEncoder`

--- a/code/packages/rust/matrix-metal/src/kernels.rs
+++ b/code/packages/rust/matrix-metal/src/kernels.rs
@@ -159,6 +159,62 @@ kernel void transpose_f32(
 
     out[gid] = in[in_linear];
 }
+
+// ──────────────── broadcast (F32, general N-D, max rank 4) ────────────────
+//
+// Replicate input across size-1 axes to match `target_shape`.  Each
+// input axis must equal the corresponding target axis or be 1 (the
+// matrix-ir validator enforces this; we trust the validated graph).
+//
+// Walks the output linearly: for each output element, decompose its
+// linear index into a multi-index using the **target** dims, then
+// build the input multi-index by clamping each size-1 axis to index 0
+// and copying through every non-broadcast axis.  Re-flatten with the
+// input dims and read.
+//
+// The args struct mirrors the Transpose layout (rank, output numel,
+// in_dims[4], out_dims[4]) minus the perm field.  Memory access is
+// **read-fan-in**: many output threads can read the same input
+// element when broadcasting along a hot axis, which Metal handles
+// well via its texture cache on Apple Silicon.
+
+struct BroadcastArgs {
+    uint rank;
+    uint numel;
+    uint in_dims[4];
+    uint out_dims[4];
+};
+
+kernel void broadcast_f32(
+    device const float* in [[buffer(0)]],
+    device float* out [[buffer(1)]],
+    constant BroadcastArgs& args [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= args.numel) return;
+
+    // 1. Decompose `gid` (output linear index) into output multi-index.
+    uint out_idx[4] = {0u, 0u, 0u, 0u};
+    uint linear = gid;
+    for (int d = (int)args.rank - 1; d >= 0; --d) {
+        uint extent = args.out_dims[d];
+        out_idx[d] = linear % extent;
+        linear /= extent;
+    }
+
+    // 2. Build the input multi-index: clamp size-1 axes to index 0;
+    //    otherwise copy the output index across.  The validator
+    //    guarantees `in_dims[d] == 1 || in_dims[d] == out_dims[d]`.
+    uint in_linear = 0u;
+    uint stride = 1u;
+    for (int d = (int)args.rank - 1; d >= 0; --d) {
+        uint i = (args.in_dims[d] == 1u) ? 0u : out_idx[d];
+        in_linear += i * stride;
+        stride *= args.in_dims[d];
+    }
+
+    out[gid] = in[in_linear];
+}
 "#;
 
 /// Names of every kernel entry point in [`KERNELS_MSL`].  Used at
@@ -186,4 +242,6 @@ pub const KERNEL_ENTRY_POINTS: &[&str] = &[
     "matmul_f32",
     // transpose
     "transpose_f32",
+    // broadcast
+    "broadcast_f32",
 ];

--- a/code/packages/rust/matrix-metal/src/lib.rs
+++ b/code/packages/rust/matrix-metal/src/lib.rs
@@ -66,6 +66,7 @@ use metal_compute::{MetalCommandQueue, MetalComputePipeline, MetalDevice};
 /// - 0x07 Add, 0x08 Sub, 0x09 Mul, 0x0A Div, 0x0B Max, 0x0C Min, 0x0D Pow
 /// - 0x11 Reshape (metadata-only; implemented as a buffer memcpy in SSA)
 /// - 0x12 Transpose (general N-D permutation, max rank 4)
+/// - 0x13 Broadcast (general N-D size-1-axis replication, max rank 4)
 /// - 0x15 MatMul, 0x1B Const
 ///
 /// `Reshape` is included even though Metal has no shader for it: the
@@ -77,9 +78,10 @@ use metal_compute::{MetalCommandQueue, MetalComputePipeline, MetalDevice};
 /// by reversing the permutation.  Up to rank 4 (matching the
 /// `max_tensor_rank` field in this backend's profile).
 ///
-/// `Broadcast` (0x13) is *not* yet supported because it needs proper
-/// index expansion — strides become non-trivial when broadcasting
-/// across multiple axes.  Adding it is V2 work.
+/// `Broadcast` is implemented as a generic axis-replication kernel
+/// that reads each output element from the input by clamping each
+/// size-1 input axis to index 0 and copying every other axis through.
+/// Up to rank 4.
 fn supported_ops_bitset() -> u32 {
     let mut mask: u32 = 0;
     // Unary (0x00..=0x06).
@@ -90,9 +92,10 @@ fn supported_ops_bitset() -> u32 {
     for tag in 0x07..=0x0Du8 {
         mask |= 1u32 << tag;
     }
-    // Reshape (0x11), Transpose (0x12), MatMul (0x15), Const (0x1B).
+    // Reshape (0x11), Transpose (0x12), Broadcast (0x13), MatMul (0x15), Const (0x1B).
     mask |= 1u32 << 0x11;
     mask |= 1u32 << 0x12;
+    mask |= 1u32 << 0x13;
     mask |= 1u32 << 0x15;
     mask |= 1u32 << 0x1B;
     mask

--- a/code/packages/rust/matrix-metal/tests/integration.rs
+++ b/code/packages/rust/matrix-metal/tests/integration.rs
@@ -598,6 +598,165 @@ fn transpose_3d_perm_021_on_gpu() {
     );
 }
 
+// ─────────────────── 4d. Broadcast ───────────────────
+
+#[test]
+fn broadcast_row_to_matrix_on_gpu() {
+    // Input  (1 × 3):    [[10, 20, 30]]
+    // Target (4 × 3) → broadcasts axis 0:
+    //   [[10, 20, 30],
+    //    [10, 20, 30],
+    //    [10, 20, 30],
+    //    [10, 20, 30]]
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let in_bytes = f32_bytes(&[10.0, 20.0, 30.0]);
+    let in_shape = Shape::from(&[1, 3]);
+    let out_shape = Shape::from(&[4, 3]);
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: 3 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: 12 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::Broadcast {
+                    input: TensorId(1),
+                    target_shape: out_shape.clone(),
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::F32, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::F32, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+    let down = exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer: BufferId(2),
+        offset: 0,
+        len: 12 * 4,
+    });
+    let result = match down {
+        ExecutorResponse::BufferData { data, .. } => from_f32(&data),
+        other => panic!("download: {:?}", other),
+    };
+    assert_eq!(
+        result,
+        vec![10.0, 20.0, 30.0, 10.0, 20.0, 30.0, 10.0, 20.0, 30.0, 10.0, 20.0, 30.0]
+    );
+}
+
+#[test]
+fn broadcast_column_to_matrix_on_gpu() {
+    // Input  (3 × 1):    [[1], [2], [3]]
+    // Target (3 × 4) → broadcasts axis 1:
+    //   [[1, 1, 1, 1],
+    //    [2, 2, 2, 2],
+    //    [3, 3, 3, 3]]
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let in_bytes = f32_bytes(&[1.0, 2.0, 3.0]);
+    let in_shape = Shape::from(&[3, 1]);
+    let out_shape = Shape::from(&[3, 4]);
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: 3 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: 12 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::Broadcast {
+                    input: TensorId(1),
+                    target_shape: out_shape.clone(),
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::F32, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::F32, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+    let down = exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer: BufferId(2),
+        offset: 0,
+        len: 12 * 4,
+    });
+    let result = match down {
+        ExecutorResponse::BufferData { data, .. } => from_f32(&data),
+        other => panic!("download: {:?}", other),
+    };
+    assert_eq!(
+        result,
+        vec![1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0]
+    );
+}
+
 // ─────────────────── 5. Validation ───────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the third Metal-side shape op. All three V1 shape ops (**Reshape** in #2077, **Transpose** in #2122, **Broadcast** now) run on Metal end-to-end. The capability filter no longer routes any pure shape op to CPU.

`matrix-metal` v0.2.0 → v0.3.0.

## What this PR adds

A new `broadcast_f32` MSL kernel and `broadcast_dispatch` arm:

- General N-D axis-replication up to rank 4.
- Walks the output linearly: for each output element, decomposes the linear index into an output multi-index using the target dims, then builds the input multi-index by clamping each size-1 input axis to index 0 and copying every non-broadcast axis through.
- Read-fan-in memory access (many output threads read the same input element when broadcasting); Apple Silicon's texture cache handles this well.
- Args struct: `rank, numel, in_dims[4], out_dims[4]` = 40 bytes encoded LE in a 48-byte buffer.

Edge cases handled:
- Rank 0 — no-op single-element copy.
- Rank > 4 — Err (defence in depth).
- Empty output — Ok without dispatching.
- Rank mismatch — Err.

## Why this matters

ML-style "bias add" (`out = x + bias` where bias is `[1, k]` and broadcasts across the batch axis to match `[n, k]`) is now expressible **end-to-end on Metal** — both the broadcast and the elementwise add stay on GPU. Same pattern unlocks LayerNorm, normalisation, attention masks, and a wide swath of ML ops the V1 op set already covered but the V1 backend couldn't yet route to GPU.

## Tests

2 new integration tests:

- **`broadcast_row_to_matrix_on_gpu`** — `(1, 3) → (4, 3)` broadcast on axis 0.
- **`broadcast_column_to_matrix_on_gpu`** — `(3, 1) → (3, 4)` broadcast on axis 1.

Total: **10 integration tests** (was 8).

## Regression check

`instagram-filters` routing on macOS unchanged because none of its filters use `Op::Broadcast`:

```
  invert        → cpu     (small graph, planner picks CPU)
  greyscale     → metal   (sRGB + matmul, ships to GPU)
  sepia         → metal   (matmul-heavy, ships to GPU)
```

## Test plan

- [x] `cargo test -p matrix-metal` — 10 tests pass on macOS
- [x] `cargo build` clean (no new warnings)
- [x] `instagram-filters` routing unchanged
- [x] Security review passed in one round (existing buffer-aliasing pattern reused; the validator's input-dim invariant holds; index arithmetic bounded by the 16 MiB per-tensor cap)

## Out of scope

- F16 / I8 / I16 broadcast — V1 dtype set is F32 only on Metal.
- Specialised tiled kernels for common broadcast patterns (e.g. row-broadcast as a 2D dispatch) — V2 micro-optimisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)