### PR TITLE
fix(prolog): reject limits for compile-only CLI modes

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -319,6 +319,10 @@ queries and the CLI should run them as a script. The command prints or emits
 one result record per source query, sets `source_query_index` in JSON formats,
 and exits nonzero if any embedded query has no answers.
 
+Use `--limit` on query-running modes to cap the number of answers printed per
+query. It is rejected for compile-only diagnostic modes because those modes do
+not enumerate answers.
+
 Use `--commit` only with one or more ad-hoc `--query` flags. It persists the
 first answer state from those query flags into later query flags or an
 interactive loop, but it is rejected when no ad-hoc query is supplied.

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -181,6 +181,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if check and queries:
         msg = "--check cannot be combined with --query"
         raise ValueError(msg)
+    if check and limit is not None:
+        msg = "--limit cannot be combined with --check"
+        raise ValueError(msg)
     if check and all_source_queries:
         msg = "--check cannot be combined with --all-source-queries"
         raise ValueError(msg)
@@ -192,6 +195,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_bytecode and check:
         msg = "--dump-bytecode cannot be combined with --check"
+        raise ValueError(msg)
+    if dump_bytecode and limit is not None:
+        msg = "--limit cannot be combined with --dump-bytecode"
         raise ValueError(msg)
     if dump_bytecode and list_source_queries:
         msg = "--dump-bytecode cannot be combined with --list-source-queries"
@@ -207,6 +213,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_instructions and check:
         msg = "--dump-instructions cannot be combined with --check"
+        raise ValueError(msg)
+    if dump_instructions and limit is not None:
+        msg = "--limit cannot be combined with --dump-instructions"
         raise ValueError(msg)
     if dump_instructions and dump_bytecode:
         msg = "--dump-instructions cannot be combined with --dump-bytecode"
@@ -225,6 +234,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_source_metadata and check:
         msg = "--dump-source-metadata cannot be combined with --check"
+        raise ValueError(msg)
+    if dump_source_metadata and limit is not None:
+        msg = "--limit cannot be combined with --dump-source-metadata"
         raise ValueError(msg)
     if dump_source_metadata and dump_bytecode:
         msg = "--dump-source-metadata cannot be combined with --dump-bytecode"
@@ -249,6 +261,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if list_source_queries and check:
         msg = "--list-source-queries cannot be combined with --check"
+        raise ValueError(msg)
+    if list_source_queries and limit is not None:
+        msg = "--limit cannot be combined with --list-source-queries"
         raise ValueError(msg)
     if list_source_queries and bool(flags["interactive"]):
         msg = "--list-source-queries cannot be combined with --interactive"

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -119,6 +119,34 @@ def test_cli_commit_requires_ad_hoc_query(
     assert "--commit requires at least one --query" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "compile_only_flag",
+    [
+        "--check",
+        "--dump-bytecode",
+        "--dump-instructions",
+        "--dump-source-metadata",
+        "--list-source-queries",
+    ],
+)
+def test_cli_limit_rejects_compile_only_modes(
+    compile_only_flag: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        compile_only_flag,
+        "--limit",
+        "1",
+    ])
+
+    assert status == 2
+    assert f"--limit cannot be combined with {compile_only_flag}" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_check_compiles_source_without_queries(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -53,6 +53,7 @@ Important options:
   imports.
 - `--backend structured|bytecode` selects the VM backend.
 - `--dialect swi|iso` selects the frontend dialect profile.
+- `--limit N` caps the number of answers emitted per executed query.
 - `--values` prints raw result values instead of named bindings.
 - `--summary` appends compact run totals for non-interactive query execution.
 - `--format text|json|jsonl` selects human text, one JSON document, or
@@ -139,7 +140,8 @@ appends one compact line with query, success, failure, and answer totals. JSONL
 appends a final `mode: "summary"` record. JSON wraps result records in an object
 with `results`, `summary`, and aggregate `success` fields so downstream tools
 can consume both details and totals without re-counting. Compile-only modes
-reject `--summary` rather than silently ignoring it.
+reject query-execution modifiers such as `--limit` and `--summary` rather than
+silently ignoring them.
 
 Each result object includes:
 


### PR DESCRIPTION
## Summary
- reject `--limit` when paired with compile-only CLI modes where answer limiting is ignored
- cover `--check`, dump modes, and source-query listing validation
- document that `--limit` is only for query-running modes

## Verification
- `bash BUILD` in `prolog-vm-compiler`
- `.venv/bin/python -m ruff check .` in `prolog-vm-compiler`
- `.venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov` in `prolog-vm-compiler`
- `git diff --check`
- `/tmp/ca-build-tool-prolog-cli-limit-query-modes -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-limit-query-modes-build-plan.json`