### PR TITLE
Reconsume NULL tag-open recovery

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -133,6 +133,9 @@ documented in this file.
   incorrectly-opened bogus-comment recovery instead of empty-comment recovery.
 - Invalid tag-open characters now follow HTML recovery: stray `<` text is
   preserved and malformed end-tag openers recover as bogus comments.
+- NULL after `<` now reconsumes through data-state recovery, preserving both
+  `invalid-first-character-of-tag-name` and `unexpected-null-character`
+  diagnostics while emitting `<` followed by U+FFFD.
 - Missing-name DOCTYPE recovery now marks force-quirks mode for `<!DOCTYPE>`
   and whitespace-only DOCTYPE names.
 - DOCTYPE declarations cut off by EOF after a name now emit the current name

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -135,7 +135,9 @@ embedded NULL characters with U+FFFD before continuing in bogus-comment state.
 The tag-open states now only begin normal tags when the next character is an
 ASCII letter; stray less-than signs such as `a < b` remain text, and malformed
 end-tag openers such as `</3>` recover as bogus comments with a tokenizer
-diagnostic.
+diagnostic. A raw NULL after `<` follows the same invalid tag-open recovery
+before data-state NULL replacement, so both diagnostics are preserved while the
+text becomes `<` plus U+FFFD.
 DOCTYPE tokenization reports missing names and marks force-quirks mode for
 inputs such as `<!DOCTYPE>` and `<!DOCTYPE >`, and EOF recovery after a name
 or inside the `DOCTYPE` keyword emits a force-quirks token. Malformed

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -3189,10 +3189,10 @@ actions = [
 from = "tag_open"
 matcher = { literal = "\u0000" }
 to = "data"
+consume = false
 actions = [
-  "parse_error(unexpected-null-character)",
+  "parse_error(invalid-first-character-of-tag-name)",
   "append_text(<)",
-  "append_text_replacement",
 ]
 
 [[transitions]]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -7138,11 +7138,10 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "parse_error(unexpected-null-character)".to_string(),
+                "parse_error(invalid-first-character-of-tag-name)".to_string(),
                 "append_text(<)".to_string(),
-                "append_text_replacement".to_string(),
             ],
-            consume: true,
+            consume: false,
         },
         TransitionDefinition {
             from: "tag_open".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1366,6 +1366,31 @@ fn default_html_lexer_recovers_invalid_tag_open_as_text() {
 }
 
 #[test]
+fn default_html_lexer_reconsumes_null_tag_open_as_text() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("Before <\0 after").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Text("Before ".to_string()),
+            Token::Text("<\u{FFFD} after".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "invalid-first-character-of-tag-name"));
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "unexpected-null-character"));
+}
+
+#[test]
 fn default_html_lexer_recovers_invalid_end_tag_open_as_bogus_comment() {
     let mut lexer = create_html_lexer().unwrap();
 


### PR DESCRIPTION
## Summary
- Reconsume raw NULL after `<` through data-state recovery instead of handling it only in tag-open state.
- Preserve both `invalid-first-character-of-tag-name` and `unexpected-null-character` diagnostics while keeping emitted text as `<` plus U+FFFD.
- Keep the HTML1 TOML and checked-in generated machine in sync, with focused lexer coverage and docs.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check