### PR TITLE
fix(prolog): reject values for compile-only CLI modes

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -323,6 +323,10 @@ Use `--limit` on query-running modes to cap the number of answers printed per
 query. It is rejected for compile-only diagnostic modes because those modes do
 not enumerate answers.
 
+Use `--values` on query-running modes to print raw answer values instead of
+named bindings. It is rejected for compile-only diagnostic modes because those
+modes do not emit answer records.
+
 Use `--commit` only with one or more ad-hoc `--query` flags. It persists the
 first answer state from those query flags into later query flags or an
 interactive loop, but it is rejected when no ad-hoc query is supplied.

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -178,11 +178,15 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     dump_instructions = bool(flags["dump-instructions"])
     dump_source_metadata = bool(flags["dump-source-metadata"])
     list_source_queries = bool(flags["list-source-queries"])
+    values = bool(flags["values"])
     if check and queries:
         msg = "--check cannot be combined with --query"
         raise ValueError(msg)
     if check and limit is not None:
         msg = "--limit cannot be combined with --check"
+        raise ValueError(msg)
+    if check and values:
+        msg = "--values cannot be combined with --check"
         raise ValueError(msg)
     if check and all_source_queries:
         msg = "--check cannot be combined with --all-source-queries"
@@ -198,6 +202,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_bytecode and limit is not None:
         msg = "--limit cannot be combined with --dump-bytecode"
+        raise ValueError(msg)
+    if dump_bytecode and values:
+        msg = "--values cannot be combined with --dump-bytecode"
         raise ValueError(msg)
     if dump_bytecode and list_source_queries:
         msg = "--dump-bytecode cannot be combined with --list-source-queries"
@@ -216,6 +223,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_instructions and limit is not None:
         msg = "--limit cannot be combined with --dump-instructions"
+        raise ValueError(msg)
+    if dump_instructions and values:
+        msg = "--values cannot be combined with --dump-instructions"
         raise ValueError(msg)
     if dump_instructions and dump_bytecode:
         msg = "--dump-instructions cannot be combined with --dump-bytecode"
@@ -237,6 +247,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_source_metadata and limit is not None:
         msg = "--limit cannot be combined with --dump-source-metadata"
+        raise ValueError(msg)
+    if dump_source_metadata and values:
+        msg = "--values cannot be combined with --dump-source-metadata"
         raise ValueError(msg)
     if dump_source_metadata and dump_bytecode:
         msg = "--dump-source-metadata cannot be combined with --dump-bytecode"
@@ -264,6 +277,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if list_source_queries and limit is not None:
         msg = "--limit cannot be combined with --list-source-queries"
+        raise ValueError(msg)
+    if list_source_queries and values:
+        msg = "--values cannot be combined with --list-source-queries"
         raise ValueError(msg)
     if list_source_queries and bool(flags["interactive"]):
         msg = "--list-source-queries cannot be combined with --interactive"
@@ -312,7 +328,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         limit=limit,
         dialect=_dialect(_required_string(flags["dialect"], name="--dialect")),
         backend=_backend(_required_string(flags["backend"], name="--backend")),
-        values=bool(flags["values"]),
+        values=values,
         summary=summary,
         output_format=_output_format(
             _required_string(flags["format"], name="--format"),

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -147,6 +147,33 @@ def test_cli_limit_rejects_compile_only_modes(
     )
 
 
+@pytest.mark.parametrize(
+    "compile_only_flag",
+    [
+        "--check",
+        "--dump-bytecode",
+        "--dump-instructions",
+        "--dump-source-metadata",
+        "--list-source-queries",
+    ],
+)
+def test_cli_values_rejects_compile_only_modes(
+    compile_only_flag: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        compile_only_flag,
+        "--values",
+    ])
+
+    assert status == 2
+    assert f"--values cannot be combined with {compile_only_flag}" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_check_compiles_source_without_queries(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -54,7 +54,8 @@ Important options:
 - `--backend structured|bytecode` selects the VM backend.
 - `--dialect swi|iso` selects the frontend dialect profile.
 - `--limit N` caps the number of answers emitted per executed query.
-- `--values` prints raw result values instead of named bindings.
+- `--values` prints raw result values instead of named bindings for executed
+  queries.
 - `--summary` appends compact run totals for non-interactive query execution.
 - `--format text|json|jsonl` selects human text, one JSON document, or
   newline-delimited JSON records.
@@ -140,8 +141,8 @@ appends one compact line with query, success, failure, and answer totals. JSONL
 appends a final `mode: "summary"` record. JSON wraps result records in an object
 with `results`, `summary`, and aggregate `success` fields so downstream tools
 can consume both details and totals without re-counting. Compile-only modes
-reject query-execution modifiers such as `--limit` and `--summary` rather than
-silently ignoring them.
+reject query-execution modifiers such as `--limit`, `--values`, and `--summary`
+rather than silently ignoring them.
 
 Each result object includes:
 


### PR DESCRIPTION
## Summary
- reject --values when paired with compile-only CLI modes where answer formatting is ignored
- cover --check, dump modes, and source-query listing validation
- document that --values is only for query-running modes

## Verification
- bash BUILD in prolog-vm-compiler
- .venv/bin/python -m ruff check . in prolog-vm-compiler
- .venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov in prolog-vm-compiler
- git diff --check
- /tmp/ca-build-tool-prolog-cli-values-query-modes -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-values-query-modes-build-plan.json