### PR TITLE
Add grammar-tools compile CLI

### DIFF
--- a/code/packages/python/grammar-tools/BUILD
+++ b/code/packages/python/grammar-tools/BUILD
@@ -1,3 +1,3 @@
-python -m venv .venv --clear
-.venv/bin/pip install -e ".[dev]" --quiet
+uv venv --quiet --clear
+uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../cli-builder -e ".[dev]" --quiet
 .venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/grammar-tools/README.md
+++ b/code/packages/python/grammar-tools/README.md
@@ -110,3 +110,20 @@ warnings = validate_parser_grammar(parser_grammar, token_grammar.token_names())
 # Cross-validate both together
 issues = cross_validate(token_grammar, parser_grammar)
 ```
+
+## Compile Grammars
+
+The package can also embed parsed grammars into Python modules so runtimes can
+import native data structures instead of opening grammar files at startup.
+
+```bash
+cd code/grammars
+
+grammar-tools compile-tokens algol/algol60.tokens \
+  -o ../packages/python/algol-lexer/src/algol_lexer/_grammar.py
+
+grammar-tools compile-grammar algol/algol60.grammar \
+  -o ../packages/python/algol-parser/src/algol_parser/_grammar.py
+```
+
+Omit `-o` to write the generated module to stdout.

--- a/code/packages/python/grammar-tools/pyproject.toml
+++ b/code/packages/python/grammar-tools/pyproject.toml
@@ -25,8 +25,20 @@ classifiers = [
 Homepage = "https://github.com/adhithyan15/coding-adventures"
 Repository = "https://github.com/adhithyan15/coding-adventures"
 
+[project.scripts]
+grammar-tools = "grammar_tools.cli:main"
+
 [project.optional-dependencies]
+cli = [
+    "coding-adventures-graph",
+    "coding-adventures-directed-graph",
+    "coding-adventures-state-machine",
+    "coding-adventures-cli-builder",
+]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.uv.sources]
+coding-adventures-cli-builder = { path = "../cli-builder", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/grammar_tools"]

--- a/code/packages/python/grammar-tools/src/grammar_tools/__main__.py
+++ b/code/packages/python/grammar-tools/src/grammar_tools/__main__.py
@@ -1,0 +1,8 @@
+"""Allow ``python -m grammar_tools`` to run the CLI."""
+
+from __future__ import annotations
+
+from grammar_tools.cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/code/packages/python/grammar-tools/src/grammar_tools/cli.py
+++ b/code/packages/python/grammar-tools/src/grammar_tools/cli.py
@@ -1,0 +1,99 @@
+"""Command-line entry points for compiling grammar files."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from importlib.resources import as_file, files
+from pathlib import Path
+
+from cli_builder import (
+    HelpResult,
+    ParseErrors,
+    Parser,
+    ParseResult,
+    SpecError,
+    VersionResult,
+)
+
+from grammar_tools.compiler import compile_parser_grammar, compile_token_grammar
+from grammar_tools.parser_grammar import ParserGrammarError, parse_parser_grammar
+from grammar_tools.token_grammar import TokenGrammarError, parse_token_grammar
+
+_PROGRAM_NAME = "grammar-tools"
+_SPEC_RESOURCE = "grammar_tools_cli.json"
+
+
+def _write_generated(code: str, output: Path | None) -> None:
+    if output is None:
+        sys.stdout.write(code)
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(code, encoding="utf-8")
+
+
+def _compile_tokens(source: Path) -> str:
+    grammar = parse_token_grammar(source.read_text(encoding="utf-8"))
+    return compile_token_grammar(grammar, source.as_posix())
+
+
+def _compile_grammar(source: Path) -> str:
+    grammar = parse_parser_grammar(source.read_text(encoding="utf-8"))
+    return compile_parser_grammar(grammar, source.as_posix())
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the ``grammar-tools`` command-line interface."""
+    try:
+        parsed = _parse_cli_builder_args(argv)
+    except ParseErrors as exc:
+        print(f"{_PROGRAM_NAME}: {exc}", file=sys.stderr)
+        return 2
+    except SpecError as exc:
+        print(f"{_PROGRAM_NAME}: {exc}", file=sys.stderr)
+        return 2
+
+    if isinstance(parsed, HelpResult):
+        print(parsed.text)
+        return 0
+
+    if isinstance(parsed, VersionResult):
+        print(parsed.version)
+        return 0
+
+    return _compile_from_parse_result(parsed)
+
+
+def _parse_cli_builder_args(
+    argv: Sequence[str] | None,
+) -> ParseResult | HelpResult | VersionResult:
+    if argv is None:
+        cli_argv = [Path(sys.argv[0]).name, *sys.argv[1:]]
+    else:
+        cli_argv = [_PROGRAM_NAME, *argv]
+    spec_resource = files("grammar_tools").joinpath(_SPEC_RESOURCE)
+    with as_file(spec_resource) as spec_path:
+        return Parser(str(spec_path), cli_argv).parse()
+
+
+def _compile_from_parse_result(parsed: ParseResult) -> int:
+    command = parsed.command_path[-1]
+    if command not in {"compile-tokens", "compile-grammar"}:
+        print(f"{_PROGRAM_NAME}: expected a command", file=sys.stderr)
+        return 2
+
+    source = Path(str(parsed.arguments["source"]))
+    output = parsed.flags["output"]
+    output_path = Path(str(output)) if output is not None else None
+
+    try:
+        if command == "compile-tokens":
+            code = _compile_tokens(source)
+        else:
+            code = _compile_grammar(source)
+        _write_generated(code, output_path)
+    except (OSError, ParserGrammarError, TokenGrammarError) as exc:
+        print(f"{_PROGRAM_NAME}: {exc}", file=sys.stderr)
+        return 1
+
+    return 0

--- a/code/packages/python/grammar-tools/src/grammar_tools/compiler.py
+++ b/code/packages/python/grammar-tools/src/grammar_tools/compiler.py
@@ -234,6 +234,7 @@ def compile_token_grammar(grammar: TokenGrammar, source_file: str = "") -> str:
 
     return (
         "# AUTO-GENERATED FILE — DO NOT EDIT\n"
+        "# ruff: noqa: E501, F401\n"
         f"{source_line}"
         "# Regenerate with: grammar-tools compile-tokens <source.tokens>\n"
         "#\n"
@@ -241,7 +242,7 @@ def compile_token_grammar(grammar: TokenGrammar, source_file: str = "") -> str:
         "# Downstream packages import TOKEN_GRAMMAR directly instead of\n"
         "# reading and parsing the .tokens file at runtime.\n"
         "\n"
-        "from grammar_tools.token_grammar import PatternGroup, TokenDefinition, TokenGrammar\n"
+        "from grammar_tools.token_grammar import PatternGroup, TokenDefinition, TokenGrammar\n"  # noqa: E501
         "\n"
         "# fmt: off  # noqa: E501 — generated code may have long lines\n"
         "\n"
@@ -343,7 +344,9 @@ def _compile_element(element: GrammarElement, indent: str) -> str:
                 f"{indent}),",
             ])
 
-        case SeparatedRepetition(element=elem, separator=sep, at_least_one=at_least_one):
+        case SeparatedRepetition(
+            element=elem, separator=sep, at_least_one=at_least_one
+        ):
             elem_src = _compile_element(elem, i1)
             sep_src = _compile_element(sep, i1)
             return "\n".join([
@@ -412,6 +415,7 @@ def compile_parser_grammar(grammar: ParserGrammar, source_file: str = "") -> str
 
     return (
         "# AUTO-GENERATED FILE — DO NOT EDIT\n"
+        "# ruff: noqa: E501, F401\n"
         f"{source_line}"
         "# Regenerate with: grammar-tools compile-grammar <source.grammar>\n"
         "#\n"

--- a/code/packages/python/grammar-tools/src/grammar_tools/grammar_tools_cli.json
+++ b/code/packages/python/grammar-tools/src/grammar_tools/grammar_tools_cli.json
@@ -1,0 +1,62 @@
+{
+  "cli_builder_spec_version": "1.0",
+  "name": "grammar-tools",
+  "display_name": "grammar-tools",
+  "description": "Compile .tokens and .grammar files into Python modules.",
+  "version": "0.1.0",
+  "parsing_mode": "gnu",
+  "builtin_flags": {
+    "help": true,
+    "version": true
+  },
+  "commands": [
+    {
+      "id": "compile-tokens",
+      "name": "compile-tokens",
+      "description": "Compile a .tokens file into a Python TOKEN_GRAMMAR module.",
+      "flags": [
+        {
+          "id": "output",
+          "short": "o",
+          "long": "output",
+          "description": "Output Python module path. Defaults to stdout.",
+          "type": "path",
+          "value_name": "PY"
+        }
+      ],
+      "arguments": [
+        {
+          "id": "source",
+          "display_name": "SOURCE",
+          "description": ".tokens file to compile.",
+          "type": "file",
+          "required": true
+        }
+      ]
+    },
+    {
+      "id": "compile-grammar",
+      "name": "compile-grammar",
+      "description": "Compile a .grammar file into a Python PARSER_GRAMMAR module.",
+      "flags": [
+        {
+          "id": "output",
+          "short": "o",
+          "long": "output",
+          "description": "Output Python module path. Defaults to stdout.",
+          "type": "path",
+          "value_name": "PY"
+        }
+      ],
+      "arguments": [
+        {
+          "id": "source",
+          "display_name": "SOURCE",
+          "description": ".grammar file to compile.",
+          "type": "file",
+          "required": true
+        }
+      ]
+    }
+  ]
+}

--- a/code/packages/python/grammar-tools/tests/test_cli.py
+++ b/code/packages/python/grammar-tools/tests/test_cli.py
@@ -1,0 +1,105 @@
+"""Tests for the grammar-tools command-line compiler."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from grammar_tools.cli import main
+from grammar_tools.parser_grammar import ParserGrammar
+from grammar_tools.token_grammar import TokenGrammar
+
+
+def _exec_generated(path: Path, name: str) -> object:
+    namespace: dict[str, Any] = {}
+    exec(path.read_text(encoding="utf-8"), namespace)
+    return namespace[name]
+
+
+def test_compile_tokens_writes_python_module(tmp_path: Path) -> None:
+    source = tmp_path / "mini.tokens"
+    output = tmp_path / "mini_tokens.py"
+    source.write_text(
+        """
+NAME = /[a-z]+/
+EQUALS = "="
+
+keywords:
+  begin
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = main(["compile-tokens", str(source), "-o", str(output)])
+
+    loaded = _exec_generated(output, "TOKEN_GRAMMAR")
+    assert result == 0
+    assert isinstance(loaded, TokenGrammar)
+    assert loaded.token_names() == {"NAME", "EQUALS"}
+    assert loaded.keywords == ["begin"]
+
+
+def test_compile_grammar_writes_python_module(tmp_path: Path) -> None:
+    source = tmp_path / "mini.grammar"
+    output = tmp_path / "mini_grammar.py"
+    source.write_text("program = NAME ;", encoding="utf-8")
+
+    result = main(["compile-grammar", str(source), "-o", str(output)])
+
+    loaded = _exec_generated(output, "PARSER_GRAMMAR")
+    assert result == 0
+    assert isinstance(loaded, ParserGrammar)
+    assert [rule.name for rule in loaded.rules] == ["program"]
+
+
+def test_compile_tokens_writes_stdout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "mini.tokens"
+    source.write_text("NAME = /[a-z]+/", encoding="utf-8")
+
+    result = main(["compile-tokens", str(source)])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "TOKEN_GRAMMAR = TokenGrammar(" in captured.out
+    assert captured.err == ""
+
+
+def test_command_help_is_generated_by_cli_builder(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = main(["compile-tokens", "--help"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "compile-tokens" in captured.out
+    assert "Output Python module path" in captured.out
+    assert captured.err == ""
+
+
+def test_root_invocation_requires_command(capsys: pytest.CaptureFixture[str]) -> None:
+    result = main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert captured.out == ""
+    assert "expected a command" in captured.err
+
+
+def test_compile_grammar_reports_parse_errors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "broken.grammar"
+    source.write_text("program = NAME", encoding="utf-8")
+
+    result = main(["compile-grammar", str(source)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert "Expected SEMI" in captured.err

--- a/code/packages/python/grammar-tools/tests/test_compiler.py
+++ b/code/packages/python/grammar-tools/tests/test_compiler.py
@@ -31,26 +31,16 @@ from __future__ import annotations
 import textwrap
 from typing import Any
 
-import pytest
-
 from grammar_tools.compiler import compile_parser_grammar, compile_token_grammar
 from grammar_tools.parser_grammar import (
     Alternation,
-    GrammarRule,
     Literal,
-    Optional,
     ParserGrammar,
     Repetition,
-    RuleReference,
     Sequence,
     parse_parser_grammar,
 )
-from grammar_tools.token_grammar import (
-    PatternGroup,
-    TokenDefinition,
-    TokenGrammar,
-    parse_token_grammar,
-)
+from grammar_tools.token_grammar import TokenGrammar, parse_token_grammar
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -84,6 +74,7 @@ class TestCompileTokenGrammarOutput:
         grammar = TokenGrammar()
         code = compile_token_grammar(grammar)
         assert "DO NOT EDIT" in code
+        assert "# ruff: noqa: E501, F401" in code
 
     def test_header_contains_source_when_given(self) -> None:
         """Source filename appears in header when provided."""
@@ -296,6 +287,7 @@ class TestCompileParserGrammarOutput:
         grammar = ParserGrammar()
         code = compile_parser_grammar(grammar)
         assert "DO NOT EDIT" in code
+        assert "# ruff: noqa: E501, F401" in code
 
     def test_imports_parser_grammar_types(self) -> None:
         """Generated code imports the necessary types."""


### PR DESCRIPTION
## Summary
- add a cli_builder-powered `grammar-tools` console entry point with `compile-tokens` and `compile-grammar` commands
- package the CLI spec and support `python -m grammar_tools`
- make generated grammar modules include the ruff suppression header, and document reproducible ALGOL regeneration

## Tests
- `bash BUILD` in `code/packages/python/grammar-tools`
- `code/packages/python/grammar-tools/.venv/bin/python -m ruff check code/packages/python/grammar-tools/src/grammar_tools/cli.py code/packages/python/grammar-tools/src/grammar_tools/__main__.py code/packages/python/grammar-tools/src/grammar_tools/compiler.py code/packages/python/grammar-tools/tests/test_cli.py code/packages/python/grammar-tools/tests/test_compiler.py`
- `cd code/grammars && ../packages/python/grammar-tools/.venv/bin/grammar-tools compile-tokens algol/algol60.tokens -o /tmp/algol60_tokens_cli.py && cmp /tmp/algol60_tokens_cli.py ../packages/python/algol-lexer/src/algol_lexer/_grammar.py`
- `cd code/grammars && ../packages/python/grammar-tools/.venv/bin/grammar-tools compile-grammar algol/algol60.grammar -o /tmp/algol60_parser_cli.py && cmp /tmp/algol60_parser_cli.py ../packages/python/algol-parser/src/algol_parser/_grammar.py`
- `git diff --check`

## Security Review
- CLI only reads the requested grammar source and writes generated Python to stdout or the explicit `--output` path.
- No subprocess, shell, network, pickle/yaml, or dynamic execution is introduced in runtime code.
- Test-only `exec` is limited to validating generated code round trips from temporary fixtures.