### PR TITLE
fix(prolog): reject source query index for non-source modes

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -272,7 +272,8 @@ prolog-vm app.pl family.pl \
 
 Use `--values` to print raw answer values, omit `--query` to run a source-level
 `?-` directive by index, and use `--dialect iso` when the ISO parser profile is
-the desired frontend.
+the desired frontend. `--source-query-index` only applies to that single stored
+source-query mode and is rejected when another mode would ignore it.
 
 Use `--source-stdin` when editor integrations or shell pipelines should provide
 the source through stdin while query selection still comes from flags:

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -179,6 +179,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     dump_source_metadata = bool(flags["dump-source-metadata"])
     list_source_queries = bool(flags["list-source-queries"])
     values = bool(flags["values"])
+    source_query_index_explicit = "source-query-index" in result.explicit_flags
     if check and queries:
         msg = "--check cannot be combined with --query"
         raise ValueError(msg)
@@ -187,6 +188,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if check and values:
         msg = "--values cannot be combined with --check"
+        raise ValueError(msg)
+    if check and source_query_index_explicit:
+        msg = "--source-query-index cannot be combined with --check"
         raise ValueError(msg)
     if check and all_source_queries:
         msg = "--check cannot be combined with --all-source-queries"
@@ -205,6 +209,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_bytecode and values:
         msg = "--values cannot be combined with --dump-bytecode"
+        raise ValueError(msg)
+    if dump_bytecode and source_query_index_explicit:
+        msg = "--source-query-index cannot be combined with --dump-bytecode"
         raise ValueError(msg)
     if dump_bytecode and list_source_queries:
         msg = "--dump-bytecode cannot be combined with --list-source-queries"
@@ -226,6 +233,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_instructions and values:
         msg = "--values cannot be combined with --dump-instructions"
+        raise ValueError(msg)
+    if dump_instructions and source_query_index_explicit:
+        msg = "--source-query-index cannot be combined with --dump-instructions"
         raise ValueError(msg)
     if dump_instructions and dump_bytecode:
         msg = "--dump-instructions cannot be combined with --dump-bytecode"
@@ -250,6 +260,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_source_metadata and values:
         msg = "--values cannot be combined with --dump-source-metadata"
+        raise ValueError(msg)
+    if dump_source_metadata and source_query_index_explicit:
+        msg = "--source-query-index cannot be combined with --dump-source-metadata"
         raise ValueError(msg)
     if dump_source_metadata and dump_bytecode:
         msg = "--dump-source-metadata cannot be combined with --dump-bytecode"
@@ -281,6 +294,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if list_source_queries and values:
         msg = "--values cannot be combined with --list-source-queries"
         raise ValueError(msg)
+    if list_source_queries and source_query_index_explicit:
+        msg = "--source-query-index cannot be combined with --list-source-queries"
+        raise ValueError(msg)
     if list_source_queries and bool(flags["interactive"]):
         msg = "--list-source-queries cannot be combined with --interactive"
         raise ValueError(msg)
@@ -306,8 +322,17 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if all_source_queries and queries:
         msg = "--all-source-queries cannot be combined with --query"
         raise ValueError(msg)
+    if all_source_queries and source_query_index_explicit:
+        msg = "--source-query-index cannot be combined with --all-source-queries"
+        raise ValueError(msg)
     if all_source_queries and bool(flags["interactive"]):
         msg = "--all-source-queries cannot be combined with --interactive"
+        raise ValueError(msg)
+    if queries and source_query_index_explicit:
+        msg = "--source-query-index cannot be combined with --query"
+        raise ValueError(msg)
+    if bool(flags["interactive"]) and source_query_index_explicit:
+        msg = "--source-query-index cannot be combined with --interactive"
         raise ValueError(msg)
     if bool(flags["commit"]) and not queries:
         msg = "--commit requires at least one --query"

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -174,6 +174,39 @@ def test_cli_values_rejects_compile_only_modes(
     )
 
 
+@pytest.mark.parametrize(
+    ("mode_flags", "conflicting_flag"),
+    [
+        (["--query", "parent(homer, Who)"], "--query"),
+        (["--all-source-queries"], "--all-source-queries"),
+        (["--check"], "--check"),
+        (["--dump-bytecode"], "--dump-bytecode"),
+        (["--dump-instructions"], "--dump-instructions"),
+        (["--dump-source-metadata"], "--dump-source-metadata"),
+        (["--list-source-queries"], "--list-source-queries"),
+        (["--interactive"], "--interactive"),
+    ],
+)
+def test_cli_source_query_index_rejects_non_source_query_modes(
+    mode_flags: list[str],
+    conflicting_flag: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart). ?- parent(homer, Who).",
+        "--source-query-index",
+        "0",
+        *mode_flags,
+    ])
+
+    assert status == 2
+    assert (
+        f"--source-query-index cannot be combined with {conflicting_flag}"
+        in capsys.readouterr().err
+    )
+
+
 def test_cli_check_compiles_source_without_queries(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -135,6 +135,9 @@ embedded query.
 When `--all-source-queries` is set, each embedded `?-` query produces one result
 object with its `source_query_index`. The process exits with status 1 if any
 source query has no answers, matching repeated ad-hoc query scripts.
+`--source-query-index` only applies to single stored source-query execution and
+is rejected with ad-hoc, all-source-query, interactive, and compile-only modes
+rather than being ignored.
 
 When `--summary` is set for non-interactive query execution, text output
 appends one compact line with query, success, failure, and answer totals. JSONL


### PR DESCRIPTION
## Summary
- reject explicit --source-query-index when another CLI mode would ignore it
- cover ad-hoc, all-source-query, interactive, and compile-only mode conflicts
- document that source-query indexes only apply to single stored source-query execution

## Verification
- bash BUILD in prolog-vm-compiler
- .venv/bin/python -m ruff check . in prolog-vm-compiler
- .venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov in prolog-vm-compiler
- git diff --check
- /tmp/ca-build-tool-prolog-cli-source-index-query-modes -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-source-index-query-modes-build-plan.json