### PR TITLE
fix(prolog): reject query module outside project queries

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -261,7 +261,7 @@ prolog-vm \
 ```
 
 For linked module projects, pass all entry files and the module context for
-ad-hoc queries:
+ad-hoc or interactive top-level queries:
 
 ```bash
 prolog-vm app.pl family.pl \
@@ -269,6 +269,11 @@ prolog-vm app.pl family.pl \
   --query-module app \
   --backend bytecode
 ```
+
+`--query-module` only applies to project file graphs with `--query` or
+`--interactive`; it is rejected for inline source, single files, source-query
+execution, and compile-only diagnostics because those paths do not consume a
+module context.
 
 Use `--values` to print raw answer values, omit `--query` to run a source-level
 `?-` directive by index, and use `--dialect iso` when the ISO parser profile is

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -151,6 +151,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         flags["source-query-index"],
         name="--source-query-index",
     )
+    interactive = bool(flags["interactive"])
 
     if limit is not None and limit < 0:
         msg = "--limit must be non-negative"
@@ -164,13 +165,19 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if source_stdin and files:
         msg = "--source-stdin cannot be combined with file paths"
         raise ValueError(msg)
-    if source_stdin and bool(flags["interactive"]):
+    if source_stdin and interactive:
         msg = "--source-stdin cannot be combined with --interactive"
         raise ValueError(msg)
     if source_stdin:
         source = sys.stdin.read()
     if source is None and not files:
         msg = "provide --source or at least one Prolog file"
+        raise ValueError(msg)
+    if query_module is not None and source is not None:
+        msg = "--query-module requires a project file graph"
+        raise ValueError(msg)
+    if query_module is not None and len(files) < 2:
+        msg = "--query-module requires a project file graph"
         raise ValueError(msg)
     all_source_queries = bool(flags["all-source-queries"])
     check = bool(flags["check"])
@@ -195,7 +202,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if check and all_source_queries:
         msg = "--check cannot be combined with --all-source-queries"
         raise ValueError(msg)
-    if check and bool(flags["interactive"]):
+    if check and interactive:
         msg = "--check cannot be combined with --interactive"
         raise ValueError(msg)
     if dump_bytecode and queries:
@@ -219,7 +226,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if dump_bytecode and all_source_queries:
         msg = "--dump-bytecode cannot be combined with --all-source-queries"
         raise ValueError(msg)
-    if dump_bytecode and bool(flags["interactive"]):
+    if dump_bytecode and interactive:
         msg = "--dump-bytecode cannot be combined with --interactive"
         raise ValueError(msg)
     if dump_instructions and queries:
@@ -246,7 +253,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if dump_instructions and all_source_queries:
         msg = "--dump-instructions cannot be combined with --all-source-queries"
         raise ValueError(msg)
-    if dump_instructions and bool(flags["interactive"]):
+    if dump_instructions and interactive:
         msg = "--dump-instructions cannot be combined with --interactive"
         raise ValueError(msg)
     if dump_source_metadata and queries:
@@ -276,7 +283,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if dump_source_metadata and all_source_queries:
         msg = "--dump-source-metadata cannot be combined with --all-source-queries"
         raise ValueError(msg)
-    if dump_source_metadata and bool(flags["interactive"]):
+    if dump_source_metadata and interactive:
         msg = "--dump-source-metadata cannot be combined with --interactive"
         raise ValueError(msg)
     if list_source_queries and queries:
@@ -297,7 +304,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if list_source_queries and source_query_index_explicit:
         msg = "--source-query-index cannot be combined with --list-source-queries"
         raise ValueError(msg)
-    if list_source_queries and bool(flags["interactive"]):
+    if list_source_queries and interactive:
         msg = "--list-source-queries cannot be combined with --interactive"
         raise ValueError(msg)
     summary = bool(flags["summary"])
@@ -316,7 +323,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if summary and list_source_queries:
         msg = "--summary cannot be combined with --list-source-queries"
         raise ValueError(msg)
-    if summary and bool(flags["interactive"]):
+    if summary and interactive:
         msg = "--summary cannot be combined with --interactive"
         raise ValueError(msg)
     if all_source_queries and queries:
@@ -325,14 +332,17 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if all_source_queries and source_query_index_explicit:
         msg = "--source-query-index cannot be combined with --all-source-queries"
         raise ValueError(msg)
-    if all_source_queries and bool(flags["interactive"]):
+    if all_source_queries and interactive:
         msg = "--all-source-queries cannot be combined with --interactive"
         raise ValueError(msg)
     if queries and source_query_index_explicit:
         msg = "--source-query-index cannot be combined with --query"
         raise ValueError(msg)
-    if bool(flags["interactive"]) and source_query_index_explicit:
+    if interactive and source_query_index_explicit:
         msg = "--source-query-index cannot be combined with --interactive"
+        raise ValueError(msg)
+    if query_module is not None and not (queries or interactive):
+        msg = "--query-module requires --query or --interactive"
         raise ValueError(msg)
     if bool(flags["commit"]) and not queries:
         msg = "--commit requires at least one --query"
@@ -359,7 +369,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
             _required_string(flags["format"], name="--format"),
         ),
         commit=bool(flags["commit"]),
-        interactive=bool(flags["interactive"]),
+        interactive=interactive,
         initialize=not bool(flags["no-initialize"]),
     )
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -875,6 +875,93 @@ def test_cli_runs_project_file_graph_with_query_module(
     ]
 
 
+def test_cli_interactive_project_file_graph_uses_query_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    family_path = tmp_path / "family.pl"
+    family_path.write_text(
+        ":- module(family, [ancestor/2]).\n"
+        "ancestor(homer, bart).\n",
+        encoding="utf-8",
+    )
+    app_path = tmp_path / "app.pl"
+    app_path.write_text(
+        ":- module(app, []).\n"
+        ":- use_module(family, [ancestor/2]).\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO("ancestor(homer, Who)\nhalt.\n"))
+
+    status = main([
+        str(app_path),
+        str(family_path),
+        "--query-module",
+        "app",
+        "--interactive",
+        "--backend",
+        "bytecode",
+    ])
+
+    assert status == 0
+    assert capsys.readouterr().out == "Who = bart.\n"
+
+
+@pytest.mark.parametrize(
+    "mode_flag",
+    [
+        "--check",
+        "--dump-bytecode",
+        "--dump-instructions",
+        "--dump-source-metadata",
+        "--list-source-queries",
+        "--all-source-queries",
+    ],
+)
+def test_cli_query_module_rejects_non_query_modes(
+    tmp_path: Path,
+    mode_flag: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    family_path = tmp_path / "family.pl"
+    family_path.write_text("parent(homer, bart).\n", encoding="utf-8")
+    app_path = tmp_path / "app.pl"
+    app_path.write_text(":- module(app, []).\n", encoding="utf-8")
+
+    status = main([
+        str(app_path),
+        str(family_path),
+        "--query-module",
+        "app",
+        mode_flag,
+    ])
+
+    assert status == 2
+    assert "--query-module requires --query or --interactive" in (
+        capsys.readouterr().err
+    )
+
+
+def test_cli_query_module_rejects_non_project_inputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source_path = tmp_path / "family.pl"
+    source_path.write_text("parent(homer, bart).\n", encoding="utf-8")
+
+    status = main([
+        str(source_path),
+        "--query",
+        "parent(homer, Who)",
+        "--query-module",
+        "app",
+    ])
+
+    assert status == 2
+    assert "--query-module requires a project file graph" in capsys.readouterr().err
+
+
 def test_cli_help_is_generated_by_cli_builder(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -49,8 +49,8 @@ Important options:
   ad-hoc query is provided.
 - `--all-source-queries` runs every stored source-level query in order when no
   ad-hoc query is provided.
-- `--query-module MODULE` resolves ad-hoc project queries through a module's
-  imports.
+- `--query-module MODULE` resolves ad-hoc or interactive project queries
+  through a module's imports.
 - `--backend structured|bytecode` selects the VM backend.
 - `--dialect swi|iso` selects the frontend dialect profile.
 - `--limit N` caps the number of answers emitted per executed query.
@@ -138,6 +138,11 @@ source query has no answers, matching repeated ad-hoc query scripts.
 `--source-query-index` only applies to single stored source-query execution and
 is rejected with ad-hoc, all-source-query, interactive, and compile-only modes
 rather than being ignored.
+
+`--query-module` only applies to project file graphs in ad-hoc or interactive
+top-level query modes. Inline source, single-file input, source-query modes, and
+compile-only diagnostics reject it rather than silently ignoring the module
+context.
 
 When `--summary` is set for non-interactive query execution, text output
 appends one compact line with query, success, failure, and answer totals. JSONL


### PR DESCRIPTION
## Summary
- reject --query-module when inline source, single-file input, source-query modes, or compile-only diagnostics would ignore it
- keep project file-graph ad-hoc and interactive query-module use working
- document the query-module scope in the CLI README and PR77 spec

## Verification
- bash BUILD in prolog-vm-compiler
- .venv/bin/python -m ruff check . in prolog-vm-compiler
- .venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov in prolog-vm-compiler
- git diff --check
- /tmp/ca-build-tool-prolog-cli-query-module-modes -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-query-module-modes-build-plan.json