### PR TITLE
Check ALGOL generated grammar freshness

### DIFF
--- a/code/packages/python/algol-lexer/CHANGELOG.md
+++ b/code/packages/python/algol-lexer/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added a generated-grammar freshness test that recompiles
+  `code/grammars/algol/algol60.tokens` and verifies the committed Python token
+  grammar is current.
+
 ### Changed
 
 - Accepted uppercase and mixed-case ALGOL keywords in the wrapper without

--- a/code/packages/python/algol-lexer/tests/test_algol_lexer.py
+++ b/code/packages/python/algol-lexer/tests/test_algol_lexer.py
@@ -32,7 +32,11 @@ ALGOL 60 has several tokenization behaviors that differ from modern languages:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+from grammar_tools.compiler import compile_token_grammar
+from grammar_tools.token_grammar import parse_token_grammar
 from lexer import GrammarLexer, Token
 
 from algol_lexer import (
@@ -43,6 +47,13 @@ from algol_lexer import (
     tokenize_algol,
 )
 from algol_lexer._grammar import TOKEN_GRAMMAR
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SOURCE_TOKENS = _REPO_ROOT / "code/grammars/algol/algol60.tokens"
+_GENERATED_GRAMMAR = (
+    _REPO_ROOT
+    / "code/packages/python/algol-lexer/src/algol_lexer/_grammar.py"
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -109,6 +120,16 @@ class TestFactory:
         lexer = create_algol_lexer("begin end")
 
         assert lexer._grammar is TOKEN_GRAMMAR
+
+    def test_compiled_token_grammar_is_fresh(self) -> None:
+        """The committed Python token grammar matches the source grammar."""
+        source = _SOURCE_TOKENS.read_text(encoding="utf-8")
+        expected = compile_token_grammar(
+            parse_token_grammar(source),
+            "algol/algol60.tokens",
+        )
+
+        assert _GENERATED_GRAMMAR.read_text(encoding="utf-8") == expected
 
     def test_explicit_algol60_version_produces_tokens(self) -> None:
         """The supported version name can be passed explicitly."""

--- a/code/packages/python/algol-parser/CHANGELOG.md
+++ b/code/packages/python/algol-parser/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added a generated-grammar freshness test that recompiles
+  `code/grammars/algol/algol60.grammar` and verifies the committed Python parser
+  grammar is current.
+
 ### Changed
 
 - Type-specific conditional grammar rules now allow nested `if ... then ...

--- a/code/packages/python/algol-parser/tests/test_algol_parser.py
+++ b/code/packages/python/algol-parser/tests/test_algol_parser.py
@@ -31,7 +31,11 @@ The ALGOL 60 grammar differs from JSON in several important ways:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+from grammar_tools.compiler import compile_parser_grammar
+from grammar_tools.parser_grammar import parse_parser_grammar
 from lang_parser import ASTNode, GrammarParseError, GrammarParser
 from lexer import Token
 
@@ -43,6 +47,13 @@ from algol_parser import (
     resolve_version,
 )
 from algol_parser._grammar import PARSER_GRAMMAR
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SOURCE_GRAMMAR = _REPO_ROOT / "code/grammars/algol/algol60.grammar"
+_GENERATED_GRAMMAR = (
+    _REPO_ROOT
+    / "code/packages/python/algol-parser/src/algol_parser/_grammar.py"
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -112,6 +123,16 @@ class TestFactory:
         parser = create_algol_parser("begin end")
 
         assert parser._grammar is PARSER_GRAMMAR
+
+    def test_compiled_parser_grammar_is_fresh(self) -> None:
+        """The committed Python parser grammar matches the source grammar."""
+        source = _SOURCE_GRAMMAR.read_text(encoding="utf-8")
+        expected = compile_parser_grammar(
+            parse_parser_grammar(source),
+            "algol/algol60.grammar",
+        )
+
+        assert _GENERATED_GRAMMAR.read_text(encoding="utf-8") == expected
 
     def test_explicit_algol60_version_produces_ast(self) -> None:
         """The supported version name can be passed explicitly."""


### PR DESCRIPTION
## Summary
- add lexer and parser tests that recompile the source ALGOL grammars in memory
- compare the compiled output with the committed `_grammar.py` modules so stale generated tables fail in CI
- document the freshness guardrail in the lexer/parser changelogs

## Tests
- `uv venv --quiet --clear && uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../grammar-tools -e ../lexer -e '.[dev]' --quiet && .venv/bin/python -m pytest tests/test_algol_lexer.py -q`\n- `uv venv --quiet --clear && uv pip install -e ../graph -e ../directed-graph -e ../state-machine -e ../grammar-tools -e ../lexer -e ../parser -e ../algol-lexer -e '.[dev]' --quiet && .venv/bin/python -m pytest tests/test_algol_parser.py -q`\n- `.venv/bin/ruff check tests/test_algol_lexer.py`\n- `.venv/bin/ruff check tests/test_algol_parser.py`\n- `bash BUILD` in `code/packages/python/algol-wasm-compiler`\n- `git diff --check`\n\n## Security review\n- runtime compiler behavior is unchanged; the new checks live only in tests\n- tests read fixed repository grammar/generated-module paths and compile in memory\n- no subprocess, network access, dynamic imports, or generated-code execution was added