### PR TITLE
fix(prolog): reject no-initialize for diagnostics

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -333,6 +333,10 @@ Use `--values` on query-running modes to print raw answer values instead of
 named bindings. It is rejected for compile-only diagnostic modes because those
 modes do not emit answer records.
 
+Use `--no-initialize` with `--check` or query-running modes when initialization
+directives should not run. It is rejected for dump and source-query listing
+diagnostics because those modes never run initialization directives.
+
 Use `--commit` only with one or more ad-hoc `--query` flags. It persists the
 first answer state from those query flags into later query flags or an
 interactive loop, but it is rejected when no ad-hoc query is supplied.

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -187,6 +187,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     list_source_queries = bool(flags["list-source-queries"])
     values = bool(flags["values"])
     source_query_index_explicit = "source-query-index" in result.explicit_flags
+    no_initialize_explicit = "no-initialize" in result.explicit_flags
     if check and queries:
         msg = "--check cannot be combined with --query"
         raise ValueError(msg)
@@ -220,6 +221,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if dump_bytecode and source_query_index_explicit:
         msg = "--source-query-index cannot be combined with --dump-bytecode"
         raise ValueError(msg)
+    if dump_bytecode and no_initialize_explicit:
+        msg = "--no-initialize cannot be combined with --dump-bytecode"
+        raise ValueError(msg)
     if dump_bytecode and list_source_queries:
         msg = "--dump-bytecode cannot be combined with --list-source-queries"
         raise ValueError(msg)
@@ -243,6 +247,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_instructions and source_query_index_explicit:
         msg = "--source-query-index cannot be combined with --dump-instructions"
+        raise ValueError(msg)
+    if dump_instructions and no_initialize_explicit:
+        msg = "--no-initialize cannot be combined with --dump-instructions"
         raise ValueError(msg)
     if dump_instructions and dump_bytecode:
         msg = "--dump-instructions cannot be combined with --dump-bytecode"
@@ -270,6 +277,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if dump_source_metadata and source_query_index_explicit:
         msg = "--source-query-index cannot be combined with --dump-source-metadata"
+        raise ValueError(msg)
+    if dump_source_metadata and no_initialize_explicit:
+        msg = "--no-initialize cannot be combined with --dump-source-metadata"
         raise ValueError(msg)
     if dump_source_metadata and dump_bytecode:
         msg = "--dump-source-metadata cannot be combined with --dump-bytecode"
@@ -303,6 +313,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         raise ValueError(msg)
     if list_source_queries and source_query_index_explicit:
         msg = "--source-query-index cannot be combined with --list-source-queries"
+        raise ValueError(msg)
+    if list_source_queries and no_initialize_explicit:
+        msg = "--no-initialize cannot be combined with --list-source-queries"
         raise ValueError(msg)
     if list_source_queries and interactive:
         msg = "--list-source-queries cannot be combined with --interactive"

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -175,6 +175,32 @@ def test_cli_values_rejects_compile_only_modes(
 
 
 @pytest.mark.parametrize(
+    "diagnostic_flag",
+    [
+        "--dump-bytecode",
+        "--dump-instructions",
+        "--dump-source-metadata",
+        "--list-source-queries",
+    ],
+)
+def test_cli_no_initialize_rejects_non_initializing_diagnostic_modes(
+    diagnostic_flag: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        ":- initialization(true). parent(homer, bart). ?- parent(homer, Who).",
+        diagnostic_flag,
+        "--no-initialize",
+    ])
+
+    assert status == 2
+    assert f"--no-initialize cannot be combined with {diagnostic_flag}" in (
+        capsys.readouterr().err
+    )
+
+
+@pytest.mark.parametrize(
     ("mode_flags", "conflicting_flag"),
     [
         (["--query", "parent(homer, Who)"], "--query"),

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -144,6 +144,10 @@ top-level query modes. Inline source, single-file input, source-query modes, and
 compile-only diagnostics reject it rather than silently ignoring the module
 context.
 
+`--no-initialize` only applies to `--check` and query-running modes. Dump and
+source-query listing diagnostics reject it because they compile and inspect
+source without running initialization directives.
+
 When `--summary` is set for non-interactive query execution, text output
 appends one compact line with query, success, failure, and answer totals. JSONL
 appends a final `mode: "summary"` record. JSON wraps result records in an object


### PR DESCRIPTION
## Summary
- reject --no-initialize for dump and source-query listing diagnostics where initialization never runs
- cover bytecode, instruction, source-metadata, and source-query listing modes
- document that --no-initialize only applies to --check and query-running modes

## Verification
- bash BUILD in prolog-vm-compiler
- .venv/bin/python -m ruff check . in prolog-vm-compiler
- .venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov in prolog-vm-compiler
- git diff --check
- /tmp/ca-build-tool-prolog-cli-no-initialize-diagnostic-modes -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-no-initialize-diagnostic-modes-build-plan.json