### PR TITLE
Recover HTML parser boundary contexts

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -47,3 +47,9 @@ documented in this file.
   paragraphs before insertion, preventing paragraph-nested block DOMs.
 - Ruby annotation starts now close omitted `rb`, `rt`, `rp`, and `rtc` siblings,
   preventing nested ruby annotation DOMs when end tags are omitted.
+- Repeated interactive formatting starts for `a`, `button`, and `nobr` now
+  close the previous open element before inserting the next one, avoiding
+  impossible nested interactive DOMs for common omitted-end-tag markup.
+- Nested `form` start tags are now ignored with a parser diagnostic while an
+  outer form remains open, keeping form-associated content in the existing form
+  instead of creating nested form DOMs.

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -50,6 +50,15 @@ documented in this file.
 - Repeated interactive formatting starts for `a`, `button`, and `nobr` now
   close the previous open element before inserting the next one, avoiding
   impossible nested interactive DOMs for common omitted-end-tag markup.
+- Repeated interactive starts now preserve the surrounding paragraph context
+  when they recover, so trailing text and later inline siblings stay under the
+  same paragraph instead of spilling to the body.
+- Paragraph boundary recovery now covers additional legacy and modern block
+  starts, including `button`, `center`, `dir`, `hgroup`, `search`, `listing`,
+  `xmp`, and `plaintext`.
+- Raw-text and plaintext block starts now close an open paragraph before
+  tokenizer handoff, keeping the resulting text-mode elements as paragraph
+  siblings.
 - Nested `form` start tags are now ignored with a parser diagnostic while an
   outer form remains open, keeping form-associated content in the existing form
   instead of creating nested form DOMs.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -29,9 +29,11 @@ This first slice intentionally starts small:
 - parser-approved initial tokenizer contexts for data-state documents and
   foreign-content CDATA or script-state fragments
 - simple implied end tags for `p`, `li`, `dt`, `dd`, `option`, `optgroup`,
-  ruby annotations, heading elements, and paragraph/block boundaries
+  ruby annotations, heading elements, legacy paragraph/block boundaries, and
+  raw-text block starts
 - interactive and form-boundary recovery for repeated `a`, `button`, and
-  `nobr` starts plus ignored nested `form` starts
+  `nobr` starts plus ignored nested `form` starts while preserving surrounding
+  paragraph/list context
 - parser diagnostics for unmatched end tags
 
 Future batches can layer the full WHATWG HTML tree-construction insertion modes

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -30,6 +30,8 @@ This first slice intentionally starts small:
   foreign-content CDATA or script-state fragments
 - simple implied end tags for `p`, `li`, `dt`, `dd`, `option`, `optgroup`,
   ruby annotations, heading elements, and paragraph/block boundaries
+- interactive and form-boundary recovery for repeated `a`, `button`, and
+  `nobr` starts plus ignored nested `form` starts
 - parser diagnostics for unmatched end tags
 
 Future batches can layer the full WHATWG HTML tree-construction insertion modes

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -721,32 +721,41 @@ fn is_ruby_annotation_element(name: &str) -> bool {
 }
 
 fn is_paragraph_boundary_element(name: &str) -> bool {
-    matches!(
-        name,
-        "address"
-            | "article"
-            | "aside"
-            | "blockquote"
-            | "details"
-            | "dialog"
-            | "div"
-            | "dl"
-            | "fieldset"
-            | "figcaption"
-            | "figure"
-            | "footer"
-            | "form"
-            | "header"
-            | "hr"
-            | "main"
-            | "menu"
-            | "nav"
-            | "ol"
-            | "pre"
-            | "section"
-            | "table"
-            | "ul"
-    )
+    const PARAGRAPH_BOUNDARY_ELEMENTS: &[&str] = &[
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "button",
+        "center",
+        "details",
+        "dialog",
+        "dir",
+        "div",
+        "dl",
+        "fieldset",
+        "figcaption",
+        "figure",
+        "footer",
+        "form",
+        "header",
+        "hgroup",
+        "hr",
+        "listing",
+        "main",
+        "menu",
+        "nav",
+        "ol",
+        "plaintext",
+        "pre",
+        "search",
+        "section",
+        "table",
+        "ul",
+        "xmp",
+    ];
+
+    PARAGRAPH_BOUNDARY_ELEMENTS.contains(&name)
 }
 
 fn is_void_element(name: &str) -> bool {
@@ -900,6 +909,145 @@ mod tests {
         let second_nobr = element(&body.children[5]);
         assert_eq!(second_nobr.name, "nobr");
         assert_eq!(second_nobr.children, vec![Node::text("B")]);
+    }
+
+    #[test]
+    fn preserves_surrounding_context_when_interactive_elements_repeat() {
+        let document = parse_html(
+            "<p>Lead <a href=one>One<a href=two>Two</a> tail<p>Next <nobr>A<nobr>B</nobr>",
+        )
+        .unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 2);
+
+        let first_paragraph = element(&body.children[0]);
+        assert_eq!(first_paragraph.name, "p");
+        assert_eq!(first_paragraph.children[0], Node::text("Lead "));
+
+        let first_anchor = element(&first_paragraph.children[1]);
+        assert_eq!(first_anchor.name, "a");
+        assert_eq!(first_anchor.attribute("href"), Some("one"));
+        assert_eq!(first_anchor.children, vec![Node::text("One")]);
+
+        let second_anchor = element(&first_paragraph.children[2]);
+        assert_eq!(second_anchor.name, "a");
+        assert_eq!(second_anchor.attribute("href"), Some("two"));
+        assert_eq!(second_anchor.children, vec![Node::text("Two")]);
+        assert_eq!(first_paragraph.children[3], Node::text(" tail"));
+
+        let second_paragraph = element(&body.children[1]);
+        assert_eq!(second_paragraph.name, "p");
+        assert_eq!(second_paragraph.children[0], Node::text("Next "));
+
+        let first_nobr = element(&second_paragraph.children[1]);
+        assert_eq!(first_nobr.name, "nobr");
+        assert_eq!(first_nobr.children, vec![Node::text("A")]);
+
+        let second_nobr = element(&second_paragraph.children[2]);
+        assert_eq!(second_nobr.name, "nobr");
+        assert_eq!(second_nobr.children, vec![Node::text("B")]);
+    }
+
+    #[test]
+    fn closes_paragraph_before_button_and_legacy_block_boundaries() {
+        let document = parse_html(
+            "<p>Button<button>Click<button>Again</button><p>Centered<center>Block</center><p>Search<search>Find</search><p>Heading<hgroup>Title</hgroup><p>Listing<listing>Block</listing><p>Directory<dir><li>Item",
+        )
+        .unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 13);
+
+        let button_intro = element(&body.children[0]);
+        assert_eq!(button_intro.name, "p");
+        assert_eq!(button_intro.children, vec![Node::text("Button")]);
+
+        let first_button = element(&body.children[1]);
+        assert_eq!(first_button.name, "button");
+        assert_eq!(first_button.children, vec![Node::text("Click")]);
+
+        let second_button = element(&body.children[2]);
+        assert_eq!(second_button.name, "button");
+        assert_eq!(second_button.children, vec![Node::text("Again")]);
+
+        let centered_intro = element(&body.children[3]);
+        assert_eq!(centered_intro.name, "p");
+        assert_eq!(centered_intro.children, vec![Node::text("Centered")]);
+
+        let center = element(&body.children[4]);
+        assert_eq!(center.name, "center");
+        assert_eq!(center.children, vec![Node::text("Block")]);
+
+        let search_intro = element(&body.children[5]);
+        assert_eq!(search_intro.name, "p");
+        assert_eq!(search_intro.children, vec![Node::text("Search")]);
+
+        let search = element(&body.children[6]);
+        assert_eq!(search.name, "search");
+        assert_eq!(search.children, vec![Node::text("Find")]);
+
+        let heading_intro = element(&body.children[7]);
+        assert_eq!(heading_intro.name, "p");
+        assert_eq!(heading_intro.children, vec![Node::text("Heading")]);
+
+        let hgroup = element(&body.children[8]);
+        assert_eq!(hgroup.name, "hgroup");
+        assert_eq!(hgroup.children, vec![Node::text("Title")]);
+
+        let listing_intro = element(&body.children[9]);
+        assert_eq!(listing_intro.name, "p");
+        assert_eq!(listing_intro.children, vec![Node::text("Listing")]);
+
+        let listing = element(&body.children[10]);
+        assert_eq!(listing.name, "listing");
+        assert_eq!(listing.children, vec![Node::text("Block")]);
+
+        let directory_intro = element(&body.children[11]);
+        assert_eq!(directory_intro.name, "p");
+        assert_eq!(directory_intro.children, vec![Node::text("Directory")]);
+
+        let directory = element(&body.children[12]);
+        assert_eq!(directory.name, "dir");
+        assert_eq!(directory.children.len(), 1);
+        let item = element(&directory.children[0]);
+        assert_eq!(item.name, "li");
+        assert_eq!(item.children, vec![Node::text("Item")]);
+    }
+
+    #[test]
+    fn closes_paragraphs_before_raw_text_block_boundaries() {
+        let document = parse_html("<p>Xmp<xmp>B <i>tag</i></xmp>").unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 2);
+
+        let xmp_intro = element(&body.children[0]);
+        assert_eq!(xmp_intro.name, "p");
+        assert_eq!(xmp_intro.children, vec![Node::text("Xmp")]);
+
+        let xmp = element(&body.children[1]);
+        assert_eq!(xmp.name, "xmp");
+        assert_eq!(xmp.children, vec![Node::text("B <i>tag</i>")]);
+    }
+
+    #[test]
+    fn closes_paragraph_before_plaintext_consumes_rest_of_document() {
+        let document = parse_html("<p>Before<plaintext>A <b>tag</b><p>still text").unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 2);
+
+        let paragraph = element(&body.children[0]);
+        assert_eq!(paragraph.name, "p");
+        assert_eq!(paragraph.children, vec![Node::text("Before")]);
+
+        let plaintext = element(&body.children[1]);
+        assert_eq!(plaintext.name, "plaintext");
+        assert_eq!(
+            plaintext.children,
+            vec![Node::text("A <b>tag</b><p>still text")]
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -246,6 +246,9 @@ impl HtmlParser {
         self.apply_document_shell_implied_contexts(&name);
         self.apply_table_implied_contexts(&name);
         self.apply_simple_implied_end_tags(&name);
+        if self.apply_interactive_implied_contexts(&name) {
+            return;
+        }
 
         let attributes: Vec<Attribute> = attributes
             .into_iter()
@@ -432,6 +435,49 @@ impl HtmlParser {
         } else if is_paragraph_boundary_element(incoming_name) {
             self.pop_current_if(|name| name == "p");
         }
+    }
+
+    fn apply_interactive_implied_contexts(&mut self, incoming_name: &str) -> bool {
+        match incoming_name {
+            "a" => {
+                self.close_open_element_silently("a");
+                false
+            }
+            "button" => {
+                self.close_open_element_silently("button");
+                false
+            }
+            "nobr" => {
+                self.close_open_element_silently("nobr");
+                false
+            }
+            "form" if self.has_open_element("form") => {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "nested-form-start-tag",
+                    "nested form start tag was ignored while a form element was already open",
+                ));
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn close_open_element_silently(&mut self, name: &str) -> bool {
+        let Some(index) = self
+            .open_elements
+            .iter()
+            .rposition(|path| element_at_path(&self.document, path).is_some_and(|n| n == name))
+        else {
+            return false;
+        };
+        self.open_elements.truncate(index);
+        true
+    }
+
+    fn has_open_element(&self, name: &str) -> bool {
+        self.open_elements
+            .iter()
+            .any(|path| element_at_path(&self.document, path).is_some_and(|n| n == name))
     }
 
     fn pop_current_if(&mut self, predicate: impl FnOnce(&str) -> bool) {
@@ -815,6 +861,80 @@ mod tests {
 
         assert_eq!(element(&body.children[1]).children, vec![Node::text("a")]);
         assert_eq!(element(&body.children[2]).children, vec![Node::text("b")]);
+    }
+
+    #[test]
+    fn closes_repeated_interactive_formatting_elements() {
+        let document = parse_html(
+            "<a href=one>One<a href=two>Two</a><button id=one>First<button id=two>Second</button><nobr>A<nobr>B</nobr>",
+        )
+        .unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 6);
+
+        let first_anchor = element(&body.children[0]);
+        assert_eq!(first_anchor.name, "a");
+        assert_eq!(first_anchor.attribute("href"), Some("one"));
+        assert_eq!(first_anchor.children, vec![Node::text("One")]);
+
+        let second_anchor = element(&body.children[1]);
+        assert_eq!(second_anchor.name, "a");
+        assert_eq!(second_anchor.attribute("href"), Some("two"));
+        assert_eq!(second_anchor.children, vec![Node::text("Two")]);
+
+        let first_button = element(&body.children[2]);
+        assert_eq!(first_button.name, "button");
+        assert_eq!(first_button.attribute("id"), Some("one"));
+        assert_eq!(first_button.children, vec![Node::text("First")]);
+
+        let second_button = element(&body.children[3]);
+        assert_eq!(second_button.name, "button");
+        assert_eq!(second_button.attribute("id"), Some("two"));
+        assert_eq!(second_button.children, vec![Node::text("Second")]);
+
+        let first_nobr = element(&body.children[4]);
+        assert_eq!(first_nobr.name, "nobr");
+        assert_eq!(first_nobr.children, vec![Node::text("A")]);
+
+        let second_nobr = element(&body.children[5]);
+        assert_eq!(second_nobr.name, "nobr");
+        assert_eq!(second_nobr.children, vec![Node::text("B")]);
+    }
+
+    #[test]
+    fn ignores_nested_form_start_tags() {
+        let output = parse_html_with_diagnostics(
+            "<form id=outer><div>One<form id=inner><input name=x></form><p>After",
+        )
+        .unwrap();
+
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "nested-form-start-tag",
+                "nested form start tag was ignored while a form element was already open"
+            )]
+        );
+
+        let body = body(&output.document);
+        assert_eq!(body.children.len(), 2);
+
+        let form = element(&body.children[0]);
+        assert_eq!(form.name, "form");
+        assert_eq!(form.attribute("id"), Some("outer"));
+        assert_eq!(form.children.len(), 1);
+
+        let div = element(&form.children[0]);
+        assert_eq!(div.name, "div");
+        assert_eq!(div.children[0], Node::text("One"));
+        let input = element(&div.children[1]);
+        assert_eq!(input.name, "input");
+        assert_eq!(input.attribute("name"), Some("x"));
+
+        let paragraph = element(&body.children[1]);
+        assert_eq!(paragraph.name, "p");
+        assert_eq!(paragraph.children, vec![Node::text("After")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- recover repeated interactive starts for anchors/buttons/nobr without nesting impossible interactive DOMs
- ignore nested form starts with a parser diagnostic while preserving outer form content
- expand paragraph boundary recovery for button, legacy block starts, search/hgroup, rawtext, and plaintext starts
- add parser tests for surrounding paragraph preservation, extended block boundaries, rawtext, plaintext, and nested forms

## Verification
- cargo fmt --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check