### PR TITLE
fix(prolog): reject json format for interactive CLI

### DIFF
--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -349,7 +349,9 @@ diagnostic modes such as `--check`, `--dump-instructions`, `--dump-bytecode`,
 `--dump-source-metadata`, and `--list-source-queries`.
 
 Use `--format json` for a machine-readable result object, or `--format jsonl`
-when repeated queries should stream one result record per line. JSON answers
+when repeated or interactive queries should stream one result record per line.
+Interactive mode rejects `--format json` because it cannot emit a single
+complete JSON document while reading an open-ended query stream. JSON answers
 preserve named bindings, raw values, compound terms, variables, and residual
 constraints without requiring callers to scrape the human text format:
 

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -147,6 +147,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     query_module = _optional_string(flags["query-module"])
     limit = _optional_int(flags["limit"])
     source_stdin = bool(flags["source-stdin"])
+    output_format = _output_format(_required_string(flags["format"], name="--format"))
     source_query_index = _required_int(
         flags["source-query-index"],
         name="--source-query-index",
@@ -339,6 +340,9 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if summary and interactive:
         msg = "--summary cannot be combined with --interactive"
         raise ValueError(msg)
+    if interactive and output_format == "json":
+        msg = "--format json cannot be combined with --interactive"
+        raise ValueError(msg)
     if all_source_queries and queries:
         msg = "--all-source-queries cannot be combined with --query"
         raise ValueError(msg)
@@ -378,9 +382,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         backend=_backend(_required_string(flags["backend"], name="--backend")),
         values=values,
         summary=summary,
-        output_format=_output_format(
-            _required_string(flags["format"], name="--format"),
-        ),
+        output_format=output_format,
         commit=bool(flags["commit"]),
         interactive=interactive,
         initialize=not bool(flags["no-initialize"]),

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -725,6 +725,23 @@ def test_cli_summary_rejects_interactive(
     )
 
 
+def test_cli_json_format_rejects_interactive(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--source",
+        "parent(homer, bart).",
+        "--interactive",
+        "--format",
+        "json",
+    ])
+
+    assert status == 2
+    assert "--format json cannot be combined with --interactive" in (
+        capsys.readouterr().err
+    )
+
+
 @pytest.mark.parametrize(
     "dump_flag",
     ["--dump-bytecode", "--dump-instructions", "--dump-source-metadata"],

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -199,6 +199,10 @@ prolog-vm family.pl --interactive --backend bytecode
 When stdin is a TTY, the loop prints a `?- ` prompt. Non-TTY input is quiet so
 the mode can be tested and scripted cleanly.
 
+Interactive mode may use text or JSONL output. It rejects `--format json`
+because an open-ended stdin query stream cannot be represented as one complete
+JSON document.
+
 If `--query` and `--interactive` are both supplied, the repeated query script
 runs first in the same runtime. With `--commit`, this gives callers a simple
 setup phase before entering the top-level loop.


### PR DESCRIPTION
## Summary
- reject --format json when interactive mode is selected because the query stream is open-ended
- preserve text and JSONL as valid interactive output formats
- document interactive machine-readable output expectations

## Verification
- bash BUILD in prolog-vm-compiler
- .venv/bin/python -m ruff check . in prolog-vm-compiler
- .venv/bin/python -m pytest tests/test_prolog_vm_cli.py -q --no-cov in prolog-vm-compiler
- git diff --check
- /tmp/ca-build-tool-prolog-cli-interactive-format-modes -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/prolog-cli-interactive-format-modes-build-plan.json