### PR TITLE
feat: add Prolog VM capability manifest

### DIFF
--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a public Prolog VM capability manifest and `prolog-vm --dump-capabilities`
+  so scripts and future planning can distinguish the completed PR00-PR77 core
+  track from deferred advanced dialect/runtime work.
 - Add end-to-end stress coverage for recursive search, modules, DCGs,
   arithmetic, collections, dynamic initialization, named answers, and expansion.
 - Add named answer helpers for source-level query results.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -247,6 +247,33 @@ assert [answer.as_dict() for answer in runtime.query("ancestor(homer, Who)")] ==
 ]
 ```
 
+## Capability Manifest
+
+The core Prolog-on-Logic-VM implementation track covers PR00 through PR77. The
+package exposes that as a machine-readable manifest so downstream tools and
+future implementation work can distinguish completed core functionality from
+deliberately deferred advanced dialect emulation:
+
+```python
+from prolog_vm_compiler import prolog_vm_capability_manifest
+
+manifest = prolog_vm_capability_manifest()
+
+assert manifest.status == "core-complete"
+assert manifest.dialects == ("iso", "swi")
+assert manifest.backends == ("structured", "bytecode")
+```
+
+The completed core batches cover frontend loading, directives, modules, file
+graphs, expansion, structured and bytecode VM execution, source/file/project
+runners, top-level query APIs, the CLI, CLP(FD), dynamic database behavior,
+exceptions, control, collections, term/text predicates, and reflection. The
+manifest also names the remaining advanced-dialect work that is intentionally
+outside the PR00-PR77 core: full external dialect emulation, tabling and
+well-founded negation, generalized attributed-variable/coroutining services,
+non-FD constraint domains, rich streams/I/O, foreign predicates, engines, and
+concurrency.
+
 ## CLI
 
 The package also exposes a `prolog-vm` command backed by the repo's declarative
@@ -258,6 +285,13 @@ prolog-vm \
   --source "parent(homer, bart). parent(homer, lisa)." \
   --query "parent(homer, Who)" \
   --backend bytecode
+```
+
+Use `--dump-capabilities` without source input to inspect the same support
+manifest from scripts or CI:
+
+```bash
+prolog-vm --dump-capabilities --format json
 ```
 
 For linked module projects, pass all entry files and the module context for

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/__init__.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/__init__.py
@@ -1,5 +1,12 @@
 """Compile loaded Prolog programs into standardized Logic VM instructions."""
 
+from prolog_vm_compiler.capabilities import (
+    PrologVMCapability,
+    PrologVMCapabilityManifest,
+    deferred_prolog_vm_capabilities,
+    prolog_vm_capabilities,
+    prolog_vm_capability_manifest,
+)
 from prolog_vm_compiler.compiler import (
     CompiledPrologVMProgram,
     PrologAnswer,
@@ -95,6 +102,8 @@ __all__ = [
     "__version__",
     "CompiledPrologVMProgram",
     "PrologAnswer",
+    "PrologVMCapability",
+    "PrologVMCapabilityManifest",
     "PrologVMBackend",
     "PrologVMInitializationError",
     "PrologVMRuntime",
@@ -130,9 +139,12 @@ __all__ = [
     "create_swi_prolog_project_file_runtime",
     "create_swi_prolog_project_runtime",
     "create_swi_prolog_vm_runtime",
+    "deferred_prolog_vm_capabilities",
     "load_compiled_prolog_backend_vm",
     "load_compiled_prolog_bytecode_vm",
     "load_compiled_prolog_vm",
+    "prolog_vm_capabilities",
+    "prolog_vm_capability_manifest",
     "query_iso_prolog_source",
     "query_iso_prolog_source_values",
     "query_prolog_file",

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
@@ -1,0 +1,241 @@
+"""Capability manifest for the Prolog-on-Logic-VM implementation track."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+type CapabilityStatus = Literal["complete", "deferred"]
+
+
+@dataclass(frozen=True, slots=True)
+class PrologVMCapability:
+    """One reviewable Prolog VM capability batch and its implementation status."""
+
+    id: str
+    title: str
+    status: CapabilityStatus
+    specs: tuple[str, ...]
+    packages: tuple[str, ...]
+    features: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation of this capability."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class PrologVMCapabilityManifest:
+    """Machine-readable summary of the finished core Prolog VM surface."""
+
+    track: str
+    status: str
+    dialects: tuple[str, ...]
+    backends: tuple[str, ...]
+    capabilities: tuple[PrologVMCapability, ...]
+    deferred_capabilities: tuple[PrologVMCapability, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation of the manifest."""
+
+        return {
+            "track": self.track,
+            "status": self.status,
+            "dialects": list(self.dialects),
+            "backends": list(self.backends),
+            "capabilities": [
+                capability.as_dict() for capability in self.capabilities
+            ],
+            "deferred_capabilities": [
+                capability.as_dict() for capability in self.deferred_capabilities
+            ],
+        }
+
+    @property
+    def complete_count(self) -> int:
+        """Return the number of completed core capability batches."""
+
+        return sum(
+            1 for capability in self.capabilities if capability.status == "complete"
+        )
+
+    @property
+    def deferred_count(self) -> int:
+        """Return the number of explicitly deferred advanced-dialect batches."""
+
+        return len(self.deferred_capabilities)
+
+
+def prolog_vm_capabilities() -> tuple[PrologVMCapability, ...]:
+    """Return the completed Prolog-on-Logic-VM capability batches."""
+
+    return (
+        PrologVMCapability(
+            id="frontend-loader",
+            title="Frontend, directives, modules, files, and expansion",
+            status="complete",
+            specs=tuple(f"PR{index:02d}" for index in range(0, 17)),
+            packages=(
+                "prolog-lexer",
+                "prolog-parser",
+                "iso-prolog-parser",
+                "swi-prolog-parser",
+                "prolog-operator-parser",
+                "prolog-loader",
+            ),
+            features=(
+                "ISO/SWI dialect profiles",
+                "operator declarations and operator-aware parsing",
+                "predicate registry and directive handling",
+                "module metadata, imports, exports, and qualification",
+                "file loading, include/consult resolution, and linked projects",
+                "DCG and expansion pipeline lowering",
+            ),
+        ),
+        PrologVMCapability(
+            id="vm-runtime",
+            title="Compiler, VM execution, runtime API, and initialization",
+            status="complete",
+            specs=tuple(f"PR{index:02d}" for index in range(17, 23)),
+            packages=(
+                "logic-instructions",
+                "logic-vm",
+                "logic-bytecode",
+                "logic-bytecode-vm",
+                "prolog-vm-compiler",
+            ),
+            features=(
+                "structured Logic VM instruction compilation",
+                "bytecode VM convergence path",
+                "source/file/project runtime creation",
+                "module-context top-level queries",
+                "initialization query slots and explicit initialization control",
+                "named answers and residual constraints",
+            ),
+        ),
+        PrologVMCapability(
+            id="stdlib-core",
+            title="Core Prolog stdlib and list/arithmetic compatibility",
+            status="complete",
+            specs=tuple(f"PR{index:02d}" for index in range(23, 30)),
+            packages=("logic-builtins", "prolog-loader", "prolog-vm-compiler"),
+            features=(
+                "list constructors, append/member/select/reverse predicates",
+                "length, sort, nth0/nth1, nth-rest, between, succ, and integer",
+                "source-level builtin adaptation through the VM path",
+            ),
+        ),
+        PrologVMCapability(
+            id="clpfd",
+            title="CLP(FD) modeling surface",
+            status="complete",
+            specs=tuple(f"PR{index:02d}" for index in range(30, 38)),
+            packages=("logic-core", "logic-engine", "logic-builtins"),
+            features=(
+                "finite-domain constraints and labeling",
+                "CLP(FD) infix syntax and nested arithmetic",
+                "labeling options",
+                "sum and scalar-product globals",
+                "modeling helpers, reification, and boolean constraints",
+            ),
+        ),
+        PrologVMCapability(
+            id="meta-control",
+            title="Meta-call, higher-order predicates, control, and exceptions",
+            status="complete",
+            specs=tuple(f"PR{index:02d}" for index in range(38, 48)),
+            packages=("logic-engine", "logic-builtins", "prolog-loader"),
+            features=(
+                "call/N and module-aware apply closures",
+                "maplist/include/exclude/foldl/apply-family predicates",
+                "term equality, dif/2, residual constraints, and aggregation stress",
+                "strict arithmetic errors, throw/catch, and cleanup control",
+            ),
+        ),
+        PrologVMCapability(
+            id="term-text-reflection",
+            title="Term, text, flags, and reflection predicates",
+            status="complete",
+            specs=tuple(f"PR{index:02d}" for index in range(48, 70)),
+            packages=("logic-builtins", "prolog-loader", "prolog-vm-compiler"),
+            features=(
+                "term variables, generality, hashes, shape, and unifiability",
+                "term read/write and write-option support",
+                "atom/string/number/char/code conversion and composition",
+                "current_op/current_atom/current_functor/current_predicate",
+                "branch-local Prolog flags",
+                "repeat, control aliases, and atom-number conversion",
+            ),
+        ),
+        PrologVMCapability(
+            id="convergence-tooling",
+            title="Dialect convergence, bytecode parity, runners, and CLI",
+            status="complete",
+            specs=tuple(f"PR{index:02d}" for index in range(70, 78)),
+            packages=("prolog-vm-compiler",),
+            features=(
+                "generic dialect-routed compile/run APIs",
+                "structured and bytecode backend selector",
+                "bytecode stress parity",
+                "source/file/project one-shot runner APIs",
+                "top-level query APIs",
+                "prolog-vm CLI with diagnostics, JSON/JSONL, summaries, and REPL",
+            ),
+        ),
+    )
+
+
+def deferred_prolog_vm_capabilities() -> tuple[PrologVMCapability, ...]:
+    """Return deliberately deferred work beyond the completed core track."""
+
+    return (
+        PrologVMCapability(
+            id="full-dialect-emulation",
+            title="Full external Prolog dialect emulation",
+            status="deferred",
+            specs=("PR02",),
+            packages=("future",),
+            features=(
+                "complete SWI/SICStus/GNU/XSB/YAP/Ciao compatibility modes",
+                "dialect-specific dicts, quasiquotations, packs, and extensions",
+            ),
+        ),
+        PrologVMCapability(
+            id="advanced-solver-services",
+            title="Advanced solver services",
+            status="deferred",
+            specs=("PR02",),
+            packages=("future",),
+            features=(
+                "tabling and well-founded negation",
+                "attributed variables and generalized coroutining",
+                "CHR and non-FD constraint domains",
+            ),
+        ),
+        PrologVMCapability(
+            id="host-runtime-services",
+            title="Host runtime services",
+            status="deferred",
+            specs=("PR02",),
+            packages=("future",),
+            features=(
+                "streams and rich file I/O",
+                "foreign predicates and host callbacks",
+                "engines, concurrency, and async integration",
+            ),
+        ),
+    )
+
+
+def prolog_vm_capability_manifest() -> PrologVMCapabilityManifest:
+    """Return the canonical capability manifest for this package."""
+
+    return PrologVMCapabilityManifest(
+        track="Prolog-on-Logic-VM core track PR00-PR77",
+        status="core-complete",
+        dialects=("iso", "swi"),
+        backends=("structured", "bytecode"),
+        capabilities=prolog_vm_capabilities(),
+        deferred_capabilities=deferred_prolog_vm_capabilities(),
+    )

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/cli.py
@@ -30,6 +30,10 @@ from logic_instructions import (
     RuleInstruction,
 )
 
+from prolog_vm_compiler.capabilities import (
+    PrologVMCapabilityManifest,
+    prolog_vm_capability_manifest,
+)
 from prolog_vm_compiler.compiler import (
     CompiledPrologVMProgram,
     PrologAnswer,
@@ -71,6 +75,7 @@ class CliArgs:
     queries: tuple[str, ...]
     check: bool
     dump_bytecode: bool
+    dump_capabilities: bool
     dump_instructions: bool
     dump_source_metadata: bool
     list_source_queries: bool
@@ -153,10 +158,65 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         name="--source-query-index",
     )
     interactive = bool(flags["interactive"])
+    all_source_queries = bool(flags["all-source-queries"])
+    check = bool(flags["check"])
+    dump_bytecode = bool(flags["dump-bytecode"])
+    dump_capabilities = bool(flags["dump-capabilities"])
+    dump_instructions = bool(flags["dump-instructions"])
+    dump_source_metadata = bool(flags["dump-source-metadata"])
+    list_source_queries = bool(flags["list-source-queries"])
+    values = bool(flags["values"])
+    summary = bool(flags["summary"])
+    source_query_index_explicit = "source-query-index" in result.explicit_flags
+    no_initialize_explicit = "no-initialize" in result.explicit_flags
 
     if limit is not None and limit < 0:
         msg = "--limit must be non-negative"
         raise ValueError(msg)
+    if dump_capabilities:
+        _validate_capability_dump_mode(
+            files=files,
+            source=source,
+            source_stdin=source_stdin,
+            queries=queries,
+            check=check,
+            dump_bytecode=dump_bytecode,
+            dump_instructions=dump_instructions,
+            dump_source_metadata=dump_source_metadata,
+            list_source_queries=list_source_queries,
+            source_query_index_explicit=source_query_index_explicit,
+            all_source_queries=all_source_queries,
+            query_module=query_module,
+            limit=limit,
+            values=values,
+            summary=summary,
+            commit=bool(flags["commit"]),
+            interactive=interactive,
+            no_initialize_explicit=no_initialize_explicit,
+        )
+        return CliArgs(
+            files=(),
+            source=None,
+            queries=(),
+            check=False,
+            dump_bytecode=False,
+            dump_capabilities=True,
+            dump_instructions=False,
+            dump_source_metadata=False,
+            list_source_queries=False,
+            source_query_index=source_query_index,
+            all_source_queries=False,
+            query_module=None,
+            limit=None,
+            dialect=_dialect(_required_string(flags["dialect"], name="--dialect")),
+            backend=_backend(_required_string(flags["backend"], name="--backend")),
+            values=False,
+            summary=False,
+            output_format=output_format,
+            commit=False,
+            interactive=False,
+            initialize=True,
+        )
     if source is not None and files:
         msg = "--source cannot be combined with file paths"
         raise ValueError(msg)
@@ -180,15 +240,6 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if query_module is not None and len(files) < 2:
         msg = "--query-module requires a project file graph"
         raise ValueError(msg)
-    all_source_queries = bool(flags["all-source-queries"])
-    check = bool(flags["check"])
-    dump_bytecode = bool(flags["dump-bytecode"])
-    dump_instructions = bool(flags["dump-instructions"])
-    dump_source_metadata = bool(flags["dump-source-metadata"])
-    list_source_queries = bool(flags["list-source-queries"])
-    values = bool(flags["values"])
-    source_query_index_explicit = "source-query-index" in result.explicit_flags
-    no_initialize_explicit = "no-initialize" in result.explicit_flags
     if check and queries:
         msg = "--check cannot be combined with --query"
         raise ValueError(msg)
@@ -321,7 +372,6 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
     if list_source_queries and interactive:
         msg = "--list-source-queries cannot be combined with --interactive"
         raise ValueError(msg)
-    summary = bool(flags["summary"])
     if summary and check:
         msg = "--summary cannot be combined with --check"
         raise ValueError(msg)
@@ -371,6 +421,7 @@ def _cli_args_from_result(result: ParseResult) -> CliArgs:
         queries=queries,
         check=check,
         dump_bytecode=dump_bytecode,
+        dump_capabilities=dump_capabilities,
         dump_instructions=dump_instructions,
         dump_source_metadata=dump_source_metadata,
         list_source_queries=list_source_queries,
@@ -401,6 +452,55 @@ def _requested_output_format(argv: Sequence[str] | None) -> CliOutputFormat:
         if value in {"text", "json", "jsonl"}:
             return cast("CliOutputFormat", value)
     return "text"
+
+
+def _validate_capability_dump_mode(
+    *,
+    files: tuple[Path, ...],
+    source: str | None,
+    source_stdin: bool,
+    queries: tuple[str, ...],
+    check: bool,
+    dump_bytecode: bool,
+    dump_instructions: bool,
+    dump_source_metadata: bool,
+    list_source_queries: bool,
+    source_query_index_explicit: bool,
+    all_source_queries: bool,
+    query_module: str | None,
+    limit: int | None,
+    values: bool,
+    summary: bool,
+    commit: bool,
+    interactive: bool,
+    no_initialize_explicit: bool,
+) -> None:
+    """Reject source/query modes for the source-free capability manifest."""
+
+    conflicts = (
+        ("--source", source is not None),
+        ("--source-stdin", source_stdin),
+        ("file paths", bool(files)),
+        ("--query", bool(queries)),
+        ("--check", check),
+        ("--dump-bytecode", dump_bytecode),
+        ("--dump-instructions", dump_instructions),
+        ("--dump-source-metadata", dump_source_metadata),
+        ("--list-source-queries", list_source_queries),
+        ("--source-query-index", source_query_index_explicit),
+        ("--all-source-queries", all_source_queries),
+        ("--query-module", query_module is not None),
+        ("--limit", limit is not None),
+        ("--values", values),
+        ("--summary", summary),
+        ("--commit", commit),
+        ("--interactive", interactive),
+        ("--no-initialize", no_initialize_explicit),
+    )
+    for flag, enabled in conflicts:
+        if enabled:
+            msg = f"--dump-capabilities cannot be combined with {flag}"
+            raise ValueError(msg)
 
 
 def _output_format_from_result(result: ParseResult) -> CliOutputFormat:
@@ -510,6 +610,8 @@ def _required_int(value: object, *, name: str) -> int:
 
 
 def _run_cli(args: CliArgs) -> int:
+    if args.dump_capabilities:
+        return _run_dump_capabilities(args)
     if args.check:
         return _run_check(args)
     if args.dump_instructions:
@@ -582,6 +684,48 @@ def _run_list_source_queries(args: CliArgs) -> int:
     compiled_program = _compile_source_program(args)
     _print_source_query_summary(compiled_program, args=args)
     return 0
+
+
+def _run_dump_capabilities(args: CliArgs) -> int:
+    _print_capability_manifest(prolog_vm_capability_manifest(), args=args)
+    return 0
+
+
+def _print_capability_manifest(
+    manifest: PrologVMCapabilityManifest,
+    *,
+    args: CliArgs,
+    stdout: TextIO | None = None,
+) -> None:
+    output = sys.stdout if stdout is None else stdout
+    if args.output_format == "text":
+        print(f"track: {manifest.track}", file=output)
+        print(f"status: {manifest.status}", file=output)
+        print(f"dialects: {', '.join(manifest.dialects)}", file=output)
+        print(f"backends: {', '.join(manifest.backends)}", file=output)
+        print(f"completed batches: {manifest.complete_count}", file=output)
+        for capability in manifest.capabilities:
+            spec_range = _spec_range_text(capability.specs)
+            print(f"- {capability.id}: {capability.title} ({spec_range})", file=output)
+        print(f"deferred advanced batches: {manifest.deferred_count}", file=output)
+        for capability in manifest.deferred_capabilities:
+            print(f"- {capability.id}: {capability.title}", file=output)
+        return
+
+    payload = {
+        "success": True,
+        "mode": "capabilities",
+        **manifest.as_dict(),
+    }
+    print(json.dumps(payload, sort_keys=True), file=output)
+
+
+def _spec_range_text(specs: tuple[str, ...]) -> str:
+    if not specs:
+        return "no specs"
+    if len(specs) == 1:
+        return specs[0]
+    return f"{specs[0]}-{specs[-1]}"
 
 
 def _source_query_records(
@@ -691,8 +835,9 @@ def _print_instruction_dump(
 
     if args.output_format == "text":
         for record in records:
+            record_index = cast("int", record["index"])
             print(
-                f"{int(record['index']):04d}: {record['opcode']} {record['text']}",
+                f"{record_index:04d}: {record['opcode']} {record['text']}",
                 file=output,
             )
         return

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/prolog_vm_cli.json
@@ -55,6 +55,12 @@
       "type": "boolean"
     },
     {
+      "id": "dump-capabilities",
+      "long": "dump-capabilities",
+      "description": "Print the supported Prolog VM capability manifest without loading source.",
+      "type": "boolean"
+    },
+    {
       "id": "list-source-queries",
       "long": "list-source-queries",
       "description": "List embedded source-level ?- queries without running them.",

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
@@ -1,0 +1,48 @@
+"""Tests for the Prolog VM capability manifest."""
+
+from __future__ import annotations
+
+from prolog_vm_compiler import (
+    deferred_prolog_vm_capabilities,
+    prolog_vm_capabilities,
+    prolog_vm_capability_manifest,
+)
+
+
+def test_manifest_marks_core_prolog_vm_track_complete() -> None:
+    manifest = prolog_vm_capability_manifest()
+
+    assert manifest.track == "Prolog-on-Logic-VM core track PR00-PR77"
+    assert manifest.status == "core-complete"
+    assert manifest.dialects == ("iso", "swi")
+    assert manifest.backends == ("structured", "bytecode")
+    assert manifest.complete_count == 7
+    assert manifest.deferred_count == 3
+
+
+def test_completed_capabilities_cover_pr00_through_pr77_once() -> None:
+    covered_specs = [
+        spec for capability in prolog_vm_capabilities() for spec in capability.specs
+    ]
+
+    assert covered_specs == [f"PR{index:02d}" for index in range(78)]
+
+
+def test_capability_manifest_is_json_serializable() -> None:
+    payload = prolog_vm_capability_manifest().as_dict()
+
+    assert payload["status"] == "core-complete"
+    assert payload["capabilities"][0]["id"] == "frontend-loader"
+    assert payload["capabilities"][-1]["id"] == "convergence-tooling"
+    assert payload["deferred_capabilities"][0]["status"] == "deferred"
+
+
+def test_deferred_capabilities_are_explicitly_advanced_dialect_work() -> None:
+    deferred = deferred_prolog_vm_capabilities()
+
+    assert {capability.id for capability in deferred} == {
+        "full-dialect-emulation",
+        "advanced-solver-services",
+        "host-runtime-services",
+    }
+    assert all(capability.status == "deferred" for capability in deferred)

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -12,6 +12,37 @@ import pytest
 from prolog_vm_compiler.cli import main
 
 
+def test_cli_dumps_capability_manifest_without_source(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main(["--dump-capabilities", "--format", "json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert status == 0
+    assert payload["success"] is True
+    assert payload["mode"] == "capabilities"
+    assert payload["status"] == "core-complete"
+    assert payload["dialects"] == ["iso", "swi"]
+    assert payload["backends"] == ["structured", "bytecode"]
+    assert payload["capabilities"][0]["specs"][0] == "PR00"
+    assert payload["capabilities"][-1]["specs"][-1] == "PR77"
+
+
+def test_cli_dump_capabilities_rejects_source_modes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = main([
+        "--dump-capabilities",
+        "--source",
+        "parent(homer, bart).",
+    ])
+
+    assert status == 2
+    assert "--dump-capabilities cannot be combined with --source" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_runs_inline_ad_hoc_query_with_bytecode_values(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/code/specs/PR02-prolog-dialects-and-vm-gap-analysis.md
+++ b/code/specs/PR02-prolog-dialects-and-vm-gap-analysis.md
@@ -17,6 +17,40 @@ explicit support.
 This document defines the dialect surface and the support gaps so future work
 can land in a few coherent batches rather than many tiny compatibility PRs.
 
+## Core Track Status
+
+As of the PR00-PR77 Prolog-on-Logic-VM track, the shared core is implemented
+through the parser, loader, expansion, VM compiler, structured VM runtime,
+bytecode VM runtime, source/file/project runner APIs, top-level query APIs, and
+the `prolog-vm` CLI.
+
+The core track is now treated as complete for practical ISO/SWI-subset work:
+
+- ISO and SWI dialect profiles route through one compile/run path.
+- Operator directives, module metadata, imports/exports, qualification,
+  include/consult resolution, DCGs, and expansion are covered.
+- Structured Logic VM execution and Logic bytecode VM execution share the same
+  compiled program model.
+- Source strings, single files, linked file graphs, and project runtimes can be
+  queried through embedded source queries or ad-hoc top-level queries.
+- Initialization directives, branch-local dynamic database updates, Prolog
+  flags, residual constraints, runtime errors, exceptions, cleanup control,
+  collections, higher-order predicates, term/text predicates, reflection, and
+  CLP(FD) modeling predicates are available through the VM path.
+- The CLI provides source/query execution, check mode, structured instruction
+  dumps, bytecode dumps, source-query metadata, all-query execution,
+  interactive mode, text/JSON/JSONL output, summaries, machine-readable
+  diagnostics, and a capability manifest.
+
+The package-level source of truth is `prolog_vm_capability_manifest()` and the
+matching `prolog-vm --dump-capabilities` CLI output. New work should update
+that manifest instead of reopening open-ended PR00-PR77 gap analysis.
+
+Remaining work in this document is advanced dialect and runtime emulation:
+full external Prolog dialect compatibility, tabling, attributed variables,
+generalized coroutining, CHR/non-FD constraint domains, rich stream/file I/O,
+foreign predicates, engines, concurrency, and async host integration.
+
 ## Current Project Surface
 
 Already present:
@@ -49,11 +83,13 @@ I/O predicates, flags, operators, DCGs, and common control constructs.
 Current support:
 
 - Good: terms, clauses, facts, rules, unification, conjunction, disjunction,
-  cut, equality, disequality, many term builtins, arithmetic builtins, some
-  database and introspection builtins.
-- Missing or incomplete: ISO operator declarations, directives, modules,
-  exceptions, streams/I/O, flags, complete arithmetic syntax, complete standard
-  predicate library, DCG expansion, consult/include, and complete error terms.
+  cut, equality, disequality, term builtins, arithmetic builtins, database and
+  introspection builtins, operator declarations, directives, modules,
+  exceptions, flags, CLP(FD), DCG expansion, consult/include, source/file
+  runners, bytecode parity, and machine-readable tooling.
+- Missing or incomplete for full ISO-system emulation: rich stream/file I/O,
+  full ISO standard-library breadth, every ISO error-term nuance, and
+  implementation-specific dialect services outside the shared core.
 
 ### Edinburgh, DEC-10, Quintus, SICStus Family
 
@@ -188,16 +224,10 @@ The current Logic VM can support:
 - source frontends that lower into existing `logic-engine` goals
 - loader-level tracing and validation
 
-The current Logic VM cannot yet support full dialect behavior for:
+The current Logic VM cannot yet support full external dialect behavior for:
 
-- module systems and module-sensitive predicate lookup
-- directive execution and compile-time expansion
-- operator declarations and per-dialect operator tables
-- DCG expansion
-- complete ISO standard predicate semantics and ISO error terms
-- stream and file I/O
-- exceptions
-- Prolog flags
+- complete ISO standard predicate semantics and every ISO error-term nuance
+- rich stream and file I/O
 - attributed variables
 - generalized coroutining
 - tabled execution and well-founded semantics
@@ -309,7 +339,12 @@ Add a solver mode or backend for tabled execution with:
 
 This is a major runtime feature and should be its own batch.
 
-## Proposed Implementation Batches
+## Historical Implementation Batches
+
+The original gap analysis proposed these implementation batches. PR00-PR77
+completed the core versions of Batches 1-5, added a broad Prolog stdlib and
+CLP(FD) compatibility layer, and delivered runner/CLI tooling. Batch 6 remains
+future advanced dialect work.
 
 ### Batch 1 - Grammar and Dialect Profile Foundation
 

--- a/code/specs/PR77-prolog-vm-cli.md
+++ b/code/specs/PR77-prolog-vm-cli.md
@@ -16,6 +16,7 @@ The goal is practical usability:
 - dump structured Logic VM instructions for compile-only diagnostics
 - dump Logic bytecode disassembly for compile-only diagnostics
 - dump source metadata for editor and CI manifest integrations
+- dump the Prolog VM capability manifest without loading source
 - list embedded source-level `?-` query indexes and visible variables
 - run stored source-level `?-` queries by index
 - run all stored source-level `?-` queries as an executable script
@@ -43,6 +44,8 @@ Important options:
   executing queries.
 - `--dump-source-metadata` emits dialect, query counts, instruction count, and
   embedded source-query variable metadata without executing queries.
+- `--dump-capabilities` emits the supported Prolog VM capability manifest
+  without loading source.
 - `--list-source-queries` lists embedded `?-` query indexes and visible
   variables without running them.
 - `--source-query-index INDEX` selects a stored source-level query when no
@@ -126,6 +129,13 @@ When `--dump-source-metadata` is set, JSON formats emit one success object with
 `instruction_count`, and a `source_queries` list containing zero-based `index`
 visible `variables`, and `vm_query_index` metadata. This mode is compile-only
 and mutually exclusive with query execution modes.
+
+When `--dump-capabilities` is set, JSON formats emit one success object with
+`mode: "capabilities"`, the core track status, supported dialects and backends,
+completed PR00-PR77 capability batches, and explicitly deferred advanced
+dialect/runtime batches. This mode is source-free and mutually exclusive with
+source input, query execution, compile-only source diagnostics, and query
+modifiers.
 
 When `--list-source-queries` is set, JSON formats emit one success object with
 `mode: "source_queries"`, `source_query_count`, and a `queries` list containing
@@ -217,6 +227,7 @@ The CLI test coverage should prove:
 - structured instruction dump mode
 - bytecode disassembly dump mode
 - source metadata dump mode
+- capability manifest dump mode
 - source query listing without execution
 - stored source-level queries from files
 - all source-level queries from files and inline source


### PR DESCRIPTION
## Summary

This is intentionally a larger finish/readiness batch rather than another one-edge-case PR.

- Add a public Prolog VM capability manifest that marks the PR00-PR77 core track as complete.
- Expose the manifest through `prolog-vm --dump-capabilities` for scripts and CI.
- Update README/changelog/specs so future work is framed as advanced dialect/runtime batches instead of endless core-gap PRs.
- Add manifest and CLI conformance coverage.

## Validation

- `.venv/bin/python -m ruff check src tests`
- `.venv/bin/python -m pytest tests/ -q`

## Notes

- `.venv/bin/python -m mypy src/prolog_vm_compiler` still reports the pre-existing `PrologQueryVM` protocol mismatch in `compiler.py` for structured vs bytecode VM state types. This PR removes the new CLI typing issue from that run, but does not change the older protocol shape.
