### PR TITLE
Expand HTML lexer fixture state convergence

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -238,6 +238,19 @@ documented in this file.
 - Added `HTML_SCRIPT_TOKENIZER_STATES` and `HtmlTokenizerState::is_script_substate()`
   so parser/conformance adapters can enumerate and validate every supported
   script entry state without duplicating lexer internals.
+- Expanded typed parser-facing tokenizer states to include intermediate
+  text-like html5lib/WPT entry points: RCDATA/RAWTEXT less-than, CDATA
+  bracket/end, script less-than, script escape-start, and script double-escape
+  start/end states.
+- Added html5lib fixture-label round-tripping through
+  `HtmlTokenizerState::as_html5lib_state` and
+  `HtmlTokenizerState::from_html5lib_state`, plus centralized
+  `requires_last_start_tag` validation for conformance importers.
+- Expanded the html5lib smoke importer to support multi-state raw cases by
+  generating stable per-state Venture fixture IDs instead of skipping the whole
+  upstream entry.
+- Added normalized html5lib-style coverage for intermediate CDATA, RCDATA,
+  RAWTEXT, script escape, and script double-escape seeded states.
 - Added `HTML_TOKENIZER_STATES`, `HTML_FRAGMENT_TOKENIZER_STATES`, and
   `HtmlTokenizerState::is_fragment_state()` so parser and fixture importers can
   enumerate the full typed tokenizer-context surface without copying state

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -160,10 +160,12 @@ The generated HTML1 machine also exposes `RCDATA`, `RAWTEXT`, `PLAINTEXT`,
 `script_data_escaped_less_than_sign`, `script_data_double_escaped`,
 `script_data_double_escaped_dash`, `script_data_double_escaped_dash_dash`, and
 `script_data_double_escaped_less_than_sign` entry states for parser-controlled
-tokenizer submodes. The markup declaration path also recognizes `<![CDATA[`
-and enters the CDATA section state so the generated lexer can exercise that
-tokenizer subflow end to end; a future parser can still decide when that opener
-is valid for foreign-content contexts.
+tokenizer submodes, plus intermediate RCDATA/RAWTEXT less-than, CDATA
+bracket/end, script less-than, escape-start, and double-escape start/end states
+used by html5lib/WPT-style tokenizer fixtures. The markup declaration path also
+recognizes `<![CDATA[` and enters the CDATA section state so the generated lexer
+can exercise that tokenizer subflow end to end; a future parser can still decide
+when that opener is valid for foreign-content contexts.
 The public Rust API now wraps those parser-controlled entry states in
 `HtmlTokenizerState` and `HtmlLexContext`, including an element-to-context map
 for `title`, `textarea`, raw-text elements, `script`, and `plaintext`. A
@@ -189,10 +191,11 @@ supported surface, `HTML_TOKENIZER_STATES` lists every parser-facing tokenizer
 entry state and `HTML_FRAGMENT_TOKENIZER_STATES` lists the non-data fragment
 states accepted by the wrapper. `HtmlTokenizerState::is_fragment_state()` keeps
 that validation centralized in the lexer package. Code that starts from
-generated machine-state identifiers can use
-`HtmlTokenizerState::from_machine_state(...)` or
-`HtmlTokenizerState::from_fragment_machine_state(...)` to round-trip back to the
-typed API without copying raw state strings.
+generated machine-state identifiers or html5lib fixture labels can use
+`HtmlTokenizerState::from_machine_state(...)`,
+`HtmlTokenizerState::from_fragment_machine_state(...)`, or
+`HtmlTokenizerState::from_html5lib_state(...)` to round-trip back to the typed
+API without copying raw state strings.
 `html-skeleton.lexer.states.toml` remains in the crate as a smaller bootstrap
 machine for comparisons and narrow debugging.
 
@@ -224,6 +227,10 @@ script data double-escaped/dash/less-than substates can already live in the
 shared Venture fixture format. Current Rust conformance tests now seed that
 context into the generated lexer so non-data-state cases execute through the
 same static Rust wrapper as the data-state corpus.
+The importer also expands supported multi-state html5lib entries into stable
+per-state Venture cases and now covers intermediate text-like states such as
+RCDATA/RAWTEXT less-than, CDATA bracket/end, script less-than, script
+escape-start, and script double-escape start/end.
 
 The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
 same schema rather than teaching the Rust harness to parse raw upstream files

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -26,66 +26,98 @@ pub enum HtmlScriptingMode {
 pub enum HtmlTokenizerState {
     Data,
     Rcdata,
+    RcdataLessThanSign,
     Rawtext,
+    RawtextLessThanSign,
     Plaintext,
     CdataSection,
+    CdataSectionBracket,
+    CdataSectionEnd,
     ScriptData,
+    ScriptDataLessThanSign,
+    ScriptDataEscapeStart,
+    ScriptDataEscapeStartDash,
     ScriptDataEscaped,
     ScriptDataEscapedDash,
     ScriptDataEscapedDashDash,
     ScriptDataEscapedLessThanSign,
+    ScriptDataDoubleEscapeStart,
     ScriptDataDoubleEscaped,
     ScriptDataDoubleEscapedDash,
     ScriptDataDoubleEscapedDashDash,
     ScriptDataDoubleEscapedLessThanSign,
+    ScriptDataDoubleEscapeEnd,
 }
 
 /// Tokenizer states that are valid parser-facing entry points.
-pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 14] = [
+pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 23] = [
     HtmlTokenizerState::Data,
     HtmlTokenizerState::Rcdata,
+    HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::Rawtext,
+    HtmlTokenizerState::RawtextLessThanSign,
     HtmlTokenizerState::Plaintext,
     HtmlTokenizerState::CdataSection,
+    HtmlTokenizerState::CdataSectionBracket,
+    HtmlTokenizerState::CdataSectionEnd,
     HtmlTokenizerState::ScriptData,
+    HtmlTokenizerState::ScriptDataLessThanSign,
+    HtmlTokenizerState::ScriptDataEscapeStart,
+    HtmlTokenizerState::ScriptDataEscapeStartDash,
     HtmlTokenizerState::ScriptDataEscaped,
     HtmlTokenizerState::ScriptDataEscapedDash,
     HtmlTokenizerState::ScriptDataEscapedDashDash,
     HtmlTokenizerState::ScriptDataEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscapeStart,
     HtmlTokenizerState::ScriptDataDoubleEscaped,
     HtmlTokenizerState::ScriptDataDoubleEscapedDash,
     HtmlTokenizerState::ScriptDataDoubleEscapedDashDash,
     HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscapeEnd,
 ];
 
 /// Tokenizer states used for parser-controlled text or foreign-content fragments.
-pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 13] = [
+pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 22] = [
     HtmlTokenizerState::Rcdata,
+    HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::Rawtext,
+    HtmlTokenizerState::RawtextLessThanSign,
     HtmlTokenizerState::Plaintext,
     HtmlTokenizerState::CdataSection,
+    HtmlTokenizerState::CdataSectionBracket,
+    HtmlTokenizerState::CdataSectionEnd,
     HtmlTokenizerState::ScriptData,
+    HtmlTokenizerState::ScriptDataLessThanSign,
+    HtmlTokenizerState::ScriptDataEscapeStart,
+    HtmlTokenizerState::ScriptDataEscapeStartDash,
     HtmlTokenizerState::ScriptDataEscaped,
     HtmlTokenizerState::ScriptDataEscapedDash,
     HtmlTokenizerState::ScriptDataEscapedDashDash,
     HtmlTokenizerState::ScriptDataEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscapeStart,
     HtmlTokenizerState::ScriptDataDoubleEscaped,
     HtmlTokenizerState::ScriptDataDoubleEscapedDash,
     HtmlTokenizerState::ScriptDataDoubleEscapedDashDash,
     HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscapeEnd,
 ];
 
 /// Tokenizer states that are valid script-substate entry points.
-pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 9] = [
+pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 14] = [
     HtmlTokenizerState::ScriptData,
+    HtmlTokenizerState::ScriptDataLessThanSign,
+    HtmlTokenizerState::ScriptDataEscapeStart,
+    HtmlTokenizerState::ScriptDataEscapeStartDash,
     HtmlTokenizerState::ScriptDataEscaped,
     HtmlTokenizerState::ScriptDataEscapedDash,
     HtmlTokenizerState::ScriptDataEscapedDashDash,
     HtmlTokenizerState::ScriptDataEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscapeStart,
     HtmlTokenizerState::ScriptDataDoubleEscaped,
     HtmlTokenizerState::ScriptDataDoubleEscapedDash,
     HtmlTokenizerState::ScriptDataDoubleEscapedDashDash,
     HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
+    HtmlTokenizerState::ScriptDataDoubleEscapeEnd,
 ];
 
 impl HtmlTokenizerState {
@@ -94,20 +126,60 @@ impl HtmlTokenizerState {
         match self {
             Self::Data => "data",
             Self::Rcdata => "rcdata",
+            Self::RcdataLessThanSign => "rcdata_less_than_sign",
             Self::Rawtext => "rawtext",
+            Self::RawtextLessThanSign => "rawtext_less_than_sign",
             Self::Plaintext => "plaintext",
             Self::CdataSection => "cdata_section",
+            Self::CdataSectionBracket => "cdata_section_bracket",
+            Self::CdataSectionEnd => "cdata_section_end",
             Self::ScriptData => "script_data",
+            Self::ScriptDataLessThanSign => "script_data_less_than_sign",
+            Self::ScriptDataEscapeStart => "script_data_escape_start",
+            Self::ScriptDataEscapeStartDash => "script_data_escape_start_dash",
             Self::ScriptDataEscaped => "script_data_escaped",
             Self::ScriptDataEscapedDash => "script_data_escaped_dash",
             Self::ScriptDataEscapedDashDash => "script_data_escaped_dash_dash",
             Self::ScriptDataEscapedLessThanSign => "script_data_escaped_less_than_sign",
+            Self::ScriptDataDoubleEscapeStart => "script_data_double_escape_start",
             Self::ScriptDataDoubleEscaped => "script_data_double_escaped",
             Self::ScriptDataDoubleEscapedDash => "script_data_double_escaped_dash",
             Self::ScriptDataDoubleEscapedDashDash => "script_data_double_escaped_dash_dash",
             Self::ScriptDataDoubleEscapedLessThanSign => {
                 "script_data_double_escaped_less_than_sign"
             }
+            Self::ScriptDataDoubleEscapeEnd => "script_data_double_escape_end",
+        }
+    }
+
+    /// html5lib tokenizer fixture state label for this parser-facing state.
+    pub fn as_html5lib_state(self) -> &'static str {
+        match self {
+            Self::Data => "Data state",
+            Self::Rcdata => "RCDATA state",
+            Self::RcdataLessThanSign => "RCDATA less-than sign state",
+            Self::Rawtext => "RAWTEXT state",
+            Self::RawtextLessThanSign => "RAWTEXT less-than sign state",
+            Self::Plaintext => "PLAINTEXT state",
+            Self::CdataSection => "CDATA section state",
+            Self::CdataSectionBracket => "CDATA section bracket state",
+            Self::CdataSectionEnd => "CDATA section end state",
+            Self::ScriptData => "Script data state",
+            Self::ScriptDataLessThanSign => "Script data less-than sign state",
+            Self::ScriptDataEscapeStart => "Script data escape start state",
+            Self::ScriptDataEscapeStartDash => "Script data escape start dash state",
+            Self::ScriptDataEscaped => "Script data escaped state",
+            Self::ScriptDataEscapedDash => "Script data escaped dash state",
+            Self::ScriptDataEscapedDashDash => "Script data escaped dash dash state",
+            Self::ScriptDataEscapedLessThanSign => "Script data escaped less-than sign state",
+            Self::ScriptDataDoubleEscapeStart => "Script data double escape start state",
+            Self::ScriptDataDoubleEscaped => "Script data double escaped state",
+            Self::ScriptDataDoubleEscapedDash => "Script data double escaped dash state",
+            Self::ScriptDataDoubleEscapedDashDash => "Script data double escaped dash dash state",
+            Self::ScriptDataDoubleEscapedLessThanSign => {
+                "Script data double escaped less-than sign state"
+            }
+            Self::ScriptDataDoubleEscapeEnd => "Script data double escape end state",
         }
     }
 
@@ -117,6 +189,14 @@ impl HtmlTokenizerState {
             .iter()
             .copied()
             .find(|state| state.as_machine_state() == machine_state)
+    }
+
+    /// Return the typed tokenizer state for a standard html5lib fixture label.
+    pub fn from_html5lib_state(html5lib_state: &str) -> Option<Self> {
+        HTML_TOKENIZER_STATES
+            .iter()
+            .copied()
+            .find(|state| state.as_html5lib_state() == html5lib_state)
     }
 
     /// Return the typed fragment state for a generated machine-state identifier.
@@ -132,6 +212,14 @@ impl HtmlTokenizerState {
     /// Return whether this state is a parser-approved fragment entry point.
     pub fn is_fragment_state(self) -> bool {
         HTML_FRAGMENT_TOKENIZER_STATES.contains(&self)
+    }
+
+    /// Return whether a seeded state needs the parser's last-start-tag context.
+    pub fn requires_last_start_tag(self) -> bool {
+        matches!(
+            self,
+            Self::Rcdata | Self::RcdataLessThanSign | Self::Rawtext | Self::RawtextLessThanSign
+        ) || self.is_script_substate()
     }
 }
 

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -1,5 +1,6 @@
 use coding_adventures_html_lexer::{
-    create_html_lexer, html1_machine, html_skeleton_machine, Attribute, HtmlLexer, Token,
+    apply_html_lex_context, create_html_lexer, html1_machine, html_skeleton_machine, Attribute,
+    HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -99,7 +100,7 @@ fn fixture_manifests_parse() {
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 160);
+    assert_eq!(file.tests.len(), 169);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -160,23 +161,32 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
     assert_eq!(
         normalized.supported_initial_states,
         vec![
+            "CDATA section bracket state".to_string(),
+            "CDATA section end state".to_string(),
             "CDATA section state".to_string(),
             "Data state".to_string(),
             "PLAINTEXT state".to_string(),
+            "RAWTEXT less-than sign state".to_string(),
             "RAWTEXT state".to_string(),
+            "RCDATA less-than sign state".to_string(),
             "RCDATA state".to_string(),
+            "Script data double escape end state".to_string(),
+            "Script data double escape start state".to_string(),
             "Script data double escaped dash dash state".to_string(),
             "Script data double escaped dash state".to_string(),
             "Script data double escaped less-than sign state".to_string(),
             "Script data double escaped state".to_string(),
+            "Script data escape start dash state".to_string(),
+            "Script data escape start state".to_string(),
             "Script data escaped dash dash state".to_string(),
             "Script data escaped dash state".to_string(),
             "Script data escaped less-than sign state".to_string(),
             "Script data escaped state".to_string(),
+            "Script data less-than sign state".to_string(),
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 160);
+    assert_eq!(normalized.cases.len(), 170);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -292,7 +302,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 160);
+    assert_eq!(suite.cases.len(), 170);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;
@@ -363,21 +373,13 @@ fn unsupported_runtime_cases(normalized: &Html5libNormalizedSuite) -> Vec<Fixtur
 
 fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
     match case.initial_state.as_deref() {
-        None | Some("Data state") => case.last_start_tag.is_none(),
-        Some("CDATA section state") => case.last_start_tag.is_none(),
-        Some("PLAINTEXT state") => case.last_start_tag.is_none(),
-        Some("RCDATA state") => case.last_start_tag.is_some(),
-        Some("RAWTEXT state") => case.last_start_tag.is_some(),
-        Some("Script data double escaped dash dash state") => case.last_start_tag.is_some(),
-        Some("Script data double escaped dash state") => case.last_start_tag.is_some(),
-        Some("Script data double escaped less-than sign state") => case.last_start_tag.is_some(),
-        Some("Script data double escaped state") => case.last_start_tag.is_some(),
-        Some("Script data escaped dash dash state") => case.last_start_tag.is_some(),
-        Some("Script data escaped dash state") => case.last_start_tag.is_some(),
-        Some("Script data escaped less-than sign state") => case.last_start_tag.is_some(),
-        Some("Script data escaped state") => case.last_start_tag.is_some(),
-        Some("Script data state") => case.last_start_tag.is_some(),
-        Some(_) => false,
+        None => case.last_start_tag.is_none(),
+        Some(initial_state) => {
+            let Some(state) = HtmlTokenizerState::from_html5lib_state(initial_state) else {
+                return false;
+            };
+            state.requires_last_start_tag() == case.last_start_tag.is_some()
+        }
     }
 }
 
@@ -424,35 +426,16 @@ fn configure_lexer_for_case(
     lexer: &mut HtmlLexer,
     case: &FixtureCase,
 ) -> coding_adventures_html_lexer::Result<()> {
-    if let Some(initial_state) = case.initial_state.as_deref() {
-        lexer.set_initial_state(machine_state_for_fixture(initial_state))?;
-    }
+    let initial_state = case
+        .initial_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+        .unwrap_or(HtmlTokenizerState::Data);
+    let mut context = HtmlLexContext::new(initial_state);
     if let Some(last_start_tag) = case.last_start_tag.as_deref() {
-        lexer.set_last_start_tag(last_start_tag);
+        context = context.with_last_start_tag(last_start_tag);
     }
-    Ok(())
-}
-
-fn machine_state_for_fixture(state: &str) -> &str {
-    match state {
-        "Data state" => "data",
-        "CDATA section state" => "cdata_section",
-        "PLAINTEXT state" => "plaintext",
-        "RCDATA state" => "rcdata",
-        "RAWTEXT state" => "rawtext",
-        "Script data double escaped dash dash state" => "script_data_double_escaped_dash_dash",
-        "Script data double escaped dash state" => "script_data_double_escaped_dash",
-        "Script data double escaped less-than sign state" => {
-            "script_data_double_escaped_less_than_sign"
-        }
-        "Script data double escaped state" => "script_data_double_escaped",
-        "Script data escaped dash dash state" => "script_data_escaped_dash_dash",
-        "Script data escaped dash state" => "script_data_escaped_dash",
-        "Script data escaped less-than sign state" => "script_data_escaped_less_than_sign",
-        "Script data escaped state" => "script_data_escaped",
-        "Script data state" => "script_data",
-        other => panic!("unsupported fixture state `{other}`"),
-    }
+    apply_html_lex_context(lexer, &context)
 }
 
 fn token_summary(token: Token) -> String {

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -72,14 +72,21 @@ currently supports:
 - `initialStates: ["RAWTEXT state"]` together with `lastStartTag`
 - `initialStates: ["PLAINTEXT state"]`
 - `initialStates: ["CDATA section state"]`
+- CDATA section `bracket` and `end` substates
 - `initialStates: ["Script data state"]` together with `lastStartTag`
+- script `less-than sign`, `escape start`, and `escape start dash` substates
+  together with `lastStartTag`
 - `initialStates: ["Script data escaped state"]` together with `lastStartTag`
 - script escaped `dash`, `dash dash`, and `less-than sign` substates together
   with `lastStartTag`
+- script double-escape `start` and `end` substates together with
+  `lastStartTag`
 - `initialStates: ["Script data double escaped state"]` together with
   `lastStartTag`
 - script double-escaped `dash`, `dash dash`, and `less-than sign` substates
   together with `lastStartTag`
+- multi-state html5lib fixture entries for supported states, expanded into
+  stable per-state Venture fixture cases
 - `StartTag`, `EndTag`, `Character`, `Comment`, and `DOCTYPE` output tokens
 - html5lib start-tag self-closing booleans
 - named character references in data, RCDATA, and attribute values for the

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -5,19 +5,28 @@
   "source": "upstream-html5lib-smoke.test",
   "generator": "normalize_html5lib_fixtures.py",
   "supported_initial_states": [
+    "CDATA section bracket state",
+    "CDATA section end state",
     "CDATA section state",
     "Data state",
     "PLAINTEXT state",
+    "RAWTEXT less-than sign state",
     "RAWTEXT state",
+    "RCDATA less-than sign state",
     "RCDATA state",
+    "Script data double escape end state",
+    "Script data double escape start state",
     "Script data double escaped dash dash state",
     "Script data double escaped dash state",
     "Script data double escaped less-than sign state",
     "Script data double escaped state",
+    "Script data escape start dash state",
+    "Script data escape start state",
     "Script data escaped dash dash state",
     "Script data escaped dash state",
     "Script data escaped less-than sign state",
     "Script data escaped state",
+    "Script data less-than sign state",
     "Script data state"
   ],
   "cases": [
@@ -1960,6 +1969,129 @@
         "missing-semicolon-after-character-reference",
         "eof-in-tag"
       ]
+    },
+    {
+      "id": "html5lib-smoke-161",
+      "description": "cdata bracket state emits pending bracket at eof",
+      "input": "",
+      "tokens": [
+        "Text(data=])",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "CDATA section bracket state"
+    },
+    {
+      "id": "html5lib-smoke-162",
+      "description": "cdata end state closes on delimiter and returns to data",
+      "input": ">after",
+      "tokens": [
+        "Text(data=after)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "CDATA section end state"
+    },
+    {
+      "id": "html5lib-smoke-163",
+      "description": "rcdata less-than state recovers literal less-than before references",
+      "input": "b &amp;",
+      "tokens": [
+        "Text(data=<b &)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA less-than sign state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-164",
+      "description": "rawtext less-than state recovers literal less-than",
+      "input": "b &amp;",
+      "tokens": [
+        "Text(data=<b &amp;)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT less-than sign state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-165",
+      "description": "script less-than state enters escaped text then closes script",
+      "input": "!-->tail</script>",
+      "tokens": [
+        "Text(data=<!-->tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data less-than sign state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-166-1",
+      "description": "script escape start states recover to script data on ordinary text",
+      "input": "x</script>",
+      "tokens": [
+        "Text(data=x)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data escape start state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-166-2",
+      "description": "script escape start states recover to script data on ordinary text",
+      "input": "x</script>",
+      "tokens": [
+        "Text(data=x)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data escape start dash state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-167",
+      "description": "script double escape start state enters double escaped script text",
+      "input": "script>inside</script>after</script>",
+      "tokens": [
+        "Text(data=script>inside</script>after)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data double escape start state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-168",
+      "description": "script double escape end state exits before matching end tag",
+      "input": "script>after</script>",
+      "tokens": [
+        "Text(data=script>after)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data double escape end state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-169",
+      "description": "script less-than state emits pending less-than at eof",
+      "input": "",
+      "tokens": [
+        "Text(data=<)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data less-than sign state",
+      "last_start_tag": "script"
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -12,30 +12,48 @@ from typing import Any
 
 SUPPORTED_INITIAL_STATES = {
     "CDATA section state",
+    "CDATA section bracket state",
+    "CDATA section end state",
     "Data state",
     "PLAINTEXT state",
     "RCDATA state",
+    "RCDATA less-than sign state",
     "RAWTEXT state",
+    "RAWTEXT less-than sign state",
+    "Script data double escape end state",
+    "Script data double escape start state",
     "Script data double escaped dash dash state",
     "Script data double escaped dash state",
     "Script data double escaped less-than sign state",
     "Script data double escaped state",
+    "Script data escape start dash state",
+    "Script data escape start state",
     "Script data escaped dash dash state",
     "Script data escaped dash state",
     "Script data escaped less-than sign state",
     "Script data escaped state",
+    "Script data less-than sign state",
     "Script data state",
 }
 
-SCRIPT_INITIAL_STATES = {
+LAST_START_TAG_INITIAL_STATES = {
+    "RCDATA state",
+    "RCDATA less-than sign state",
+    "RAWTEXT state",
+    "RAWTEXT less-than sign state",
+    "Script data double escape end state",
+    "Script data double escape start state",
     "Script data double escaped dash dash state",
     "Script data double escaped dash state",
     "Script data double escaped less-than sign state",
     "Script data double escaped state",
+    "Script data escape start dash state",
+    "Script data escape start state",
     "Script data escaped dash dash state",
     "Script data escaped dash state",
     "Script data escaped less-than sign state",
     "Script data escaped state",
+    "Script data less-than sign state",
     "Script data state",
 }
 
@@ -71,7 +89,14 @@ def main() -> int:
             )
             continue
 
-        normalized_cases.append(normalize_case(index, test))
+        initial_states = test.get("initialStates", [])
+        if len(initial_states) <= 1:
+            normalized_cases.append(
+                normalize_case(index, test, initial_states[0] if initial_states else None)
+            )
+        else:
+            for variant, initial_state in enumerate(initial_states, start=1):
+                normalized_cases.append(normalize_case(index, test, initial_state, variant))
 
     normalized = {
         "format": "venture-html-lexer-fixtures/v1",
@@ -90,25 +115,19 @@ def main() -> int:
 
 def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     initial_states = test.get("initialStates", [])
-    if len(initial_states) > 1:
-        return False, f"unsupported initialStates={initial_states!r}"
-
-    if initial_states and initial_states[0] not in SUPPORTED_INITIAL_STATES:
+    if any(initial_state not in SUPPORTED_INITIAL_STATES for initial_state in initial_states):
         return False, f"unsupported initialStates={initial_states!r}"
 
     last_start_tag = test.get("lastStartTag")
-    if (
-        initial_states
-        and initial_states[0] in {"RCDATA state", "RAWTEXT state", *SCRIPT_INITIAL_STATES}
-        and not isinstance(last_start_tag, str)
-    ):
-        return False, f"{initial_states[0]} requires lastStartTag"
+    needs_last_start_tag = [
+        initial_state
+        for initial_state in initial_states
+        if initial_state in LAST_START_TAG_INITIAL_STATES
+    ]
+    if needs_last_start_tag and not isinstance(last_start_tag, str):
+        return False, f"{needs_last_start_tag[0]} requires lastStartTag"
 
-    if (
-        initial_states
-        and initial_states[0] not in {"RCDATA state", "RAWTEXT state", *SCRIPT_INITIAL_STATES}
-        and last_start_tag is not None
-    ):
+    if last_start_tag is not None and len(needs_last_start_tag) != len(initial_states):
         return False, f"unsupported lastStartTag={last_start_tag!r}"
 
     for token in test.get("output", []):
@@ -119,7 +138,9 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     return True, ""
 
 
-def normalize_case(index: int, test: dict[str, Any]) -> dict[str, Any]:
+def normalize_case(
+    index: int, test: dict[str, Any], initial_state: str | None, variant: int | None = None
+) -> dict[str, Any]:
     tokens: list[str] = []
     pending_text = ""
 
@@ -162,22 +183,27 @@ def normalize_case(index: int, test: dict[str, Any]) -> dict[str, Any]:
     tokens.append("EOF")
 
     normalized = {
-        "id": f"html5lib-smoke-{index}",
+        "id": normalized_case_id(index, variant),
         "description": test.get("description", f"case {index}"),
         "input": test["input"],
         "tokens": tokens,
         "diagnostics": [error["code"] for error in test.get("errors", [])],
     }
 
-    initial_states = test.get("initialStates", [])
-    if initial_states:
-        normalized["initial_state"] = initial_states[0]
+    if initial_state is not None:
+        normalized["initial_state"] = initial_state
 
     last_start_tag = test.get("lastStartTag")
     if last_start_tag is not None:
         normalized["last_start_tag"] = last_start_tag
 
     return normalized
+
+
+def normalized_case_id(index: int, variant: int | None) -> str:
+    if variant is None:
+        return f"html5lib-smoke-{index}"
+    return f"html5lib-smoke-{index}-{variant}"
 
 
 def normalize_start_tag(token: list[Any]) -> str:

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -2014,6 +2014,147 @@
           "col": 14
         }
       ]
+    },
+    {
+      "description": "cdata bracket state emits pending bracket at eof",
+      "input": "",
+      "initialStates": [
+        "CDATA section bracket state"
+      ],
+      "output": [
+        [
+          "Character",
+          "]"
+        ]
+      ]
+    },
+    {
+      "description": "cdata end state closes on delimiter and returns to data",
+      "input": ">after",
+      "initialStates": [
+        "CDATA section end state"
+      ],
+      "output": [
+        [
+          "Character",
+          "after"
+        ]
+      ]
+    },
+    {
+      "description": "rcdata less-than state recovers literal less-than before references",
+      "input": "b &amp;",
+      "initialStates": [
+        "RCDATA less-than sign state"
+      ],
+      "lastStartTag": "title",
+      "output": [
+        [
+          "Character",
+          "<b &"
+        ]
+      ]
+    },
+    {
+      "description": "rawtext less-than state recovers literal less-than",
+      "input": "b &amp;",
+      "initialStates": [
+        "RAWTEXT less-than sign state"
+      ],
+      "lastStartTag": "style",
+      "output": [
+        [
+          "Character",
+          "<b &amp;"
+        ]
+      ]
+    },
+    {
+      "description": "script less-than state enters escaped text then closes script",
+      "input": "!-->tail</script>",
+      "initialStates": [
+        "Script data less-than sign state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "<!-->tail"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
+      "description": "script escape start states recover to script data on ordinary text",
+      "input": "x</script>",
+      "initialStates": [
+        "Script data escape start state",
+        "Script data escape start dash state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "x"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
+      "description": "script double escape start state enters double escaped script text",
+      "input": "script>inside</script>after</script>",
+      "initialStates": [
+        "Script data double escape start state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "script>inside</script>after"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
+      "description": "script double escape end state exits before matching end tag",
+      "input": "script>after</script>",
+      "initialStates": [
+        "Script data double escape end state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "script>after"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
+      "description": "script less-than state emits pending less-than at eof",
+      "input": "",
+      "initialStates": [
+        "Script data less-than sign state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "<"
+        ]
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -4870,6 +4870,18 @@ fn parser_facing_context_maps_script_and_plaintext_elements() {
 fn parser_facing_context_maps_script_substates() {
     let expected_script_substates = [
         (HtmlTokenizerState::ScriptData, "script_data"),
+        (
+            HtmlTokenizerState::ScriptDataLessThanSign,
+            "script_data_less_than_sign",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapeStart,
+            "script_data_escape_start",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapeStartDash,
+            "script_data_escape_start_dash",
+        ),
         (HtmlTokenizerState::ScriptDataEscaped, "script_data_escaped"),
         (
             HtmlTokenizerState::ScriptDataEscapedDash,
@@ -4882,6 +4894,10 @@ fn parser_facing_context_maps_script_substates() {
         (
             HtmlTokenizerState::ScriptDataEscapedLessThanSign,
             "script_data_escaped_less_than_sign",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataDoubleEscapeStart,
+            "script_data_double_escape_start",
         ),
         (
             HtmlTokenizerState::ScriptDataDoubleEscaped,
@@ -4898,6 +4914,10 @@ fn parser_facing_context_maps_script_substates() {
         (
             HtmlTokenizerState::ScriptDataDoubleEscapedLessThanSign,
             "script_data_double_escaped_less_than_sign",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataDoubleEscapeEnd,
+            "script_data_double_escape_end",
         ),
     ];
     assert_eq!(
@@ -4969,18 +4989,27 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
         [
             "data",
             "rcdata",
+            "rcdata_less_than_sign",
             "rawtext",
+            "rawtext_less_than_sign",
             "plaintext",
             "cdata_section",
+            "cdata_section_bracket",
+            "cdata_section_end",
             "script_data",
+            "script_data_less_than_sign",
+            "script_data_escape_start",
+            "script_data_escape_start_dash",
             "script_data_escaped",
             "script_data_escaped_dash",
             "script_data_escaped_dash_dash",
             "script_data_escaped_less_than_sign",
+            "script_data_double_escape_start",
             "script_data_double_escaped",
             "script_data_double_escaped_dash",
             "script_data_double_escaped_dash_dash",
             "script_data_double_escaped_less_than_sign",
+            "script_data_double_escape_end",
         ]
     );
     assert!(!HtmlTokenizerState::Data.is_fragment_state());
@@ -5013,6 +5042,103 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
     for state in HTML_FRAGMENT_TOKENIZER_STATES {
         assert!(state.is_fragment_state());
     }
+
+    for state in HTML_TOKENIZER_STATES {
+        assert_eq!(
+            HtmlTokenizerState::from_html5lib_state(state.as_html5lib_state()),
+            Some(state)
+        );
+    }
+    assert_eq!(
+        HtmlTokenizerState::from_html5lib_state("Script data double escape start state"),
+        Some(HtmlTokenizerState::ScriptDataDoubleEscapeStart)
+    );
+    assert_eq!(HtmlTokenizerState::from_html5lib_state("Bogus state"), None);
+
+    assert!(HtmlTokenizerState::RcdataLessThanSign.requires_last_start_tag());
+    assert!(HtmlTokenizerState::RawtextLessThanSign.requires_last_start_tag());
+    assert!(HtmlTokenizerState::ScriptDataEscapeStart.requires_last_start_tag());
+    assert!(!HtmlTokenizerState::CdataSectionEnd.requires_last_start_tag());
+}
+
+#[test]
+fn parser_facing_context_seeds_intermediate_text_states() {
+    let cdata_bracket = HtmlLexContext::new(HtmlTokenizerState::CdataSectionBracket);
+    assert_eq!(
+        lex_html_fragment("", &cdata_bracket).unwrap(),
+        vec![Token::Text("]".to_string()), Token::Eof]
+    );
+
+    let cdata_end = HtmlLexContext::new(HtmlTokenizerState::CdataSectionEnd);
+    assert_eq!(
+        lex_html_fragment(">after", &cdata_end).unwrap(),
+        vec![Token::Text("after".to_string()), Token::Eof]
+    );
+
+    let rcdata_less_than =
+        HtmlLexContext::new(HtmlTokenizerState::RcdataLessThanSign).with_last_start_tag("title");
+    assert_eq!(
+        lex_html_fragment("b &amp;</title>", &rcdata_less_than).unwrap(),
+        vec![
+            Token::Text("<b &".to_string()),
+            Token::EndTag {
+                name: "title".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    let rawtext_less_than =
+        HtmlLexContext::new(HtmlTokenizerState::RawtextLessThanSign).with_last_start_tag("style");
+    assert_eq!(
+        lex_html_fragment("b &amp;</style>", &rawtext_less_than).unwrap(),
+        vec![
+            Token::Text("<b &amp;".to_string()),
+            Token::EndTag {
+                name: "style".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    let script_less_than =
+        HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataLessThanSign).unwrap();
+    assert_eq!(
+        lex_html_fragment("!-->tail</script>", &script_less_than).unwrap(),
+        vec![
+            Token::Text("<!-->tail".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    let double_escape_start =
+        HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataDoubleEscapeStart).unwrap();
+    assert_eq!(
+        lex_html_fragment("script>inside</script>after</script>", &double_escape_start).unwrap(),
+        vec![
+            Token::Text("script>inside</script>after".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    let double_escape_end =
+        HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataDoubleEscapeEnd).unwrap();
+    assert_eq!(
+        lex_html_fragment("script>after</script>", &double_escape_end).unwrap(),
+        vec![
+            Token::Text("script>after".to_string()),
+            Token::EndTag {
+                name: "script".to_string()
+            },
+            Token::Eof
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Expand typed parser-facing tokenizer states to include intermediate RCDATA/RAWTEXT less-than, CDATA bracket/end, script less-than, escape-start, and double-escape start/end entry points.
- Add html5lib fixture-label round-tripping and centralized last-start-tag validation for conformance importers/adapters.
- Teach the html5lib smoke normalizer to expand supported multi-state upstream cases into stable per-state Venture fixtures.
- Add normalized html5lib-style coverage and direct Rust tests for intermediate seeded tokenizer states.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check origin/main..HEAD