### PR TITLE
feat(mips-r2000-simulator): Layer 07q — MIPS R2000 (1985) behavioral simulator

### DIFF
--- a/code/packages/python/mips-r2000-simulator/CHANGELOG.md
+++ b/code/packages/python/mips-r2000-simulator/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## [0.1.0] — 2026-05-04
+
+### Added
+
+- Initial implementation of `MIPSSimulator` — behavioral simulator for the MIPS R2000 (1985)
+- `MIPSState` frozen dataclass capturing complete CPU state (PC, 32 GPRs, HI, LO, 64 KB memory, halted flag)
+- Full SIM00 protocol compliance: `reset()`, `load()`, `step()`, `execute()`, `get_state()`
+- R-type instructions: SLL, SRL, SRA, SLLV, SRLV, SRAV, JR, JALR, MFHI, MTHI, MFLO, MTLO, MULT, MULTU, DIV, DIVU, ADD, ADDU, SUB, SUBU, AND, OR, XOR, NOR, SLT, SLTU
+- REGIMM instructions: BLTZ, BGEZ, BLTZAL, BGEZAL
+- I-type instructions: ADDI, ADDIU, SLTI, SLTIU, ANDI, ORI, XORI, LUI, LB, LH, LW, LBU, LHU, SB, SH, SW, BEQ, BNE, BLEZ, BGTZ
+- J-type instructions: J, JAL
+- HALT convention: SYSCALL (op=0, funct=0x0C) halts the simulator
+- BREAK (funct=0x0D) raises `ValueError` (software breakpoint)
+- Big-endian memory: LW/SW, LH/LHU/SH, LB/LBU/SB all use big-endian byte order
+- Misaligned access detection: LW/SW require 4-byte alignment; LH/SH require 2-byte alignment
+- Signed overflow detection: ADD, ADDI, SUB raise `ValueError` on overflow
+- Division-by-zero detection: DIV and DIVU raise `ValueError`
+- R0 always-zero invariant enforced in `_set_reg()`
+- `max_steps` guard in `execute()` (default 100,000) prevents infinite loops
+- 4 test modules: protocol compliance, per-instruction, end-to-end programs, edge cases
+- Spec: `code/specs/07q-mips-r2000-simulator.md`

--- a/code/packages/python/mips-r2000-simulator/README.md
+++ b/code/packages/python/mips-r2000-simulator/README.md
@@ -1,0 +1,71 @@
+# mips-r2000-simulator
+
+Behavioral simulator for the **MIPS R2000 (1985)** microprocessor — Layer 07q in the coding-adventures CPU simulator series.
+
+## What is the MIPS R2000?
+
+The MIPS R2000 is the first commercially successful RISC processor, designed by John Hennessy's team at Stanford University and manufactured by MIPS Computer Systems starting in 1985.  It proved that the "Reduced Instruction Set Computer" philosophy could outperform complex CISC designs in real workloads.
+
+Key facts:
+- **First commercial RISC processor** (1985)
+- Used in SGI IRIS workstations, DEC DECstations, PlayStation 1, PlayStation 2, Nintendo 64
+- Foundation of Patterson & Hennessy *Computer Organization and Design*
+- 32-bit word-addressable, big-endian
+- 32 general-purpose registers (R0 hardwired zero)
+- HI:LO registers for 64-bit multiply results and divide quotient/remainder
+- Fixed-width 32-bit instructions in three formats: R, I, J
+- Load-store architecture (only LW/SW variants touch memory)
+
+## How it fits in the stack
+
+This package implements the `Simulator[MIPSState]` protocol from `coding-adventures-simulator-protocol`.  It is purely behavioral — no cycle counting, no branch delay slots, no pipeline simulation.
+
+```
+coding-adventures-simulator-protocol  (SIM00 interface)
+└── coding-adventures-mips-r2000-simulator  (this package)
+```
+
+## Usage
+
+```python
+from mips_r2000_simulator import MIPSSimulator
+
+sim = MIPSSimulator()
+
+# Encode a simple program: ADDIU $t0, $zero, 42; HALT
+import struct
+ADDIU = struct.pack(">I", (0x09 << 26) | (0 << 21) | (8 << 16) | 42)
+HALT  = struct.pack(">I", 0x0000_000C)   # SYSCALL
+
+result = sim.execute(ADDIU + HALT)
+print(result.ok)        # True
+print(result.steps)     # 2
+print(sim._regs[8])     # 42  ($t0)
+```
+
+### Instruction formats
+
+```
+R-type:  [op:6=0][rs:5][rt:5][rd:5][shamt:5][funct:6]
+I-type:  [op:6][rs:5][rt:5][imm16:16]
+J-type:  [op:6][target26:26]
+```
+
+### HALT convention
+
+`SYSCALL` (opcode 0, funct 0x0C = `0x0000000C`) halts the simulator.  This matches real MIPS Linux convention where `$v0=4001` exits the process via SYSCALL.
+
+### Simplifications
+
+- **No branch delay slots** — branches take effect immediately
+- **64 KB memory** — PC and addresses wrap at 16 bits
+- **No CP0 / TLB** — exceptions raise Python `ValueError` instead
+- **No FPU (COP1)**
+
+## Development
+
+```bash
+uv venv .venv --quiet --no-project
+uv pip install --python .venv -e ../simulator-protocol -e .[dev] --quiet
+.venv/bin/python -m pytest
+```

--- a/code/packages/python/mips-r2000-simulator/pyproject.toml
+++ b/code/packages/python/mips-r2000-simulator/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-mips-r2000-simulator"
+version = "0.1.0"
+description = "Behavioral simulator for the MIPS R2000 (1985) — Layer 07q"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "coding-adventures-simulator-protocol",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mips_r2000_simulator"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=mips_r2000_simulator --cov-report=term-missing --cov-fail-under=80"
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "SIM"]
+ignore = ["E501", "E701", "E702"]

--- a/code/packages/python/mips-r2000-simulator/src/mips_r2000_simulator/__init__.py
+++ b/code/packages/python/mips-r2000-simulator/src/mips_r2000_simulator/__init__.py
@@ -1,0 +1,11 @@
+"""MIPS R2000 (1985) behavioral simulator — Layer 07q.
+
+Public exports:
+    MIPSSimulator  — the simulator class (implements Simulator[MIPSState])
+    MIPSState      — frozen CPU state snapshot dataclass
+"""
+
+from .simulator import MIPSSimulator
+from .state import MIPSState
+
+__all__ = ["MIPSSimulator", "MIPSState"]

--- a/code/packages/python/mips-r2000-simulator/src/mips_r2000_simulator/simulator.py
+++ b/code/packages/python/mips-r2000-simulator/src/mips_r2000_simulator/simulator.py
@@ -1,0 +1,681 @@
+"""MIPS R2000 (1985) behavioral simulator — Layer 07q.
+
+The MIPS R2000 is the first commercially successful RISC processor, designed by
+John Hennessy's team at Stanford and released by MIPS Computer Systems in 1985.
+It pioneered the "clean" 32-bit RISC philosophy that influenced virtually every
+subsequent processor architecture:
+
+  • 32 general-purpose 32-bit registers (R0 is hardwired zero)
+  • Fixed-width 32-bit instructions in three formats: R, I, J
+  • Load-store architecture — only LW/SW family touch memory
+  • Big-endian byte order (MIPS R2000 default)
+  • No condition codes — comparisons write to a GPR (SLT/SLTU)
+  • HI:LO registers for 64-bit multiply results and divide quotient/remainder
+
+Historical context:
+  Used in SGI IRIS workstations (1986), DEC DECstation (1989), Sony PlayStation 1,
+  PlayStation 2, Nintendo 64, and countless embedded controllers.  It is the
+  canonical example in Patterson & Hennessy's *Computer Organization and Design*.
+
+=============================================================================
+Implementation notes
+=============================================================================
+
+Branch delay slots
+──────────────────
+Real MIPS CPUs execute the instruction in the "delay slot" (immediately after
+a branch/jump) before the branch takes effect — a side-effect of the 5-stage
+pipeline's instruction fetch.  This simulator does NOT model delay slots.
+Branches and jumps take effect immediately.  Programs that rely on delay slot
+behavior will not work correctly here.
+
+Signed overflow
+───────────────
+ADD, ADDI, and SUB raise ValueError on 32-bit signed overflow, matching the
+hardware exception behavior.  Use ADDU, ADDIU, SUBU for wrapping arithmetic.
+
+Memory
+──────
+64 KB flat byte array (indices 0x0000–0xFFFF), big-endian.  PC and effective
+addresses are masked to 16 bits.  Misaligned LW/SW raise ValueError.
+
+HALT
+────
+SYSCALL (opcode 0, funct 0x0C) halts the simulator.  On real MIPS, SYSCALL
+traps to the OS kernel; here it is our clean "program done" sentinel, matching
+MIPS Linux convention where $v0=4001 exits the process.  BREAK (funct 0x0D)
+raises ValueError (software breakpoint / assertion failure).
+"""
+
+from __future__ import annotations
+
+from simulator_protocol import ExecutionResult, Simulator, StepTrace
+
+from .state import (
+    HALT_OPCODE_WORD,
+    MEM_SIZE,
+    NUM_REGS,
+    REG_RA,
+    MIPSState,
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _sext16(v: int) -> int:
+    """Sign-extend a 16-bit value to a signed Python int."""
+    v &= 0xFFFF
+    return v - 0x10000 if v >= 0x8000 else v
+
+
+def _as_signed32(v: int) -> int:
+    """Interpret an unsigned 32-bit value as a signed Python int."""
+    v &= 0xFFFF_FFFF
+    return v - 0x1_0000_0000 if v >= 0x8000_0000 else v
+
+
+def _as_unsigned32(v: int) -> int:
+    """Mask to 32 unsigned bits."""
+    return v & 0xFFFF_FFFF
+
+
+# ── Simulator ──────────────────────────────────────────────────────────────────
+
+class MIPSSimulator(Simulator[MIPSState]):
+    """Behavioral simulator for the MIPS R2000 microprocessor.
+
+    Public API (SIM00 protocol):
+        reset()            — return to power-on state
+        load(program)      — reset and copy bytes to memory at 0x0000
+        step()             — execute one instruction, return StepTrace
+        execute(program)   — run until HALT or max_steps, return ExecutionResult
+        get_state()        — return frozen MIPSState snapshot
+
+    Internal state:
+        _mem   : bytearray(MEM_SIZE)   — 64 KB flat big-endian memory
+        _regs  : list[int]             — 32 unsigned 32-bit registers
+        _hi    : int                   — HI special register
+        _lo    : int                   — LO special register
+        _pc    : int                   — program counter (16-bit modulo MEM_SIZE)
+        _halted: bool                  — True after SYSCALL
+    """
+
+    def __init__(self) -> None:
+        self._mem:    bytearray = bytearray(MEM_SIZE)
+        self._regs:   list[int] = [0] * NUM_REGS
+        self._hi:     int = 0
+        self._lo:     int = 0
+        self._pc:     int = 0
+        self._halted: bool = False
+        # reset() is called in __init__ to ensure invariants from the start;
+        # the bytearray is already zeroed, but reset() is the canonical path.
+
+    # ── Protocol: reset ───────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Return the CPU to power-on state.
+
+        Power-on state:
+          PC    = 0x0000
+          All GPRs = 0 (including R0, which is always 0 anyway)
+          HI, LO   = 0
+          Memory   = zeroed
+          halted   = False
+        """
+        self._mem[:] = bytearray(MEM_SIZE)
+        self._regs   = [0] * NUM_REGS
+        self._hi     = 0
+        self._lo     = 0
+        self._pc     = 0
+        self._halted = False
+
+    # ── Protocol: load ────────────────────────────────────────────────────────
+
+    def load(self, program: bytes) -> None:
+        """Reset and load program bytes into memory at address 0x0000.
+
+        The program must be a multiple of 4 bytes (one word per instruction)
+        and must fit within the 64 KB address space.
+
+        Args:
+            program: raw big-endian machine code
+
+        Raises:
+            ValueError: if len(program) > MEM_SIZE (64 KB)
+        """
+        if len(program) > MEM_SIZE:
+            msg = f"Program too large: {len(program)} bytes > {MEM_SIZE}"
+            raise ValueError(msg)
+        self.reset()
+        self._mem[:len(program)] = program
+
+    # ── Protocol: get_state ───────────────────────────────────────────────────
+
+    def get_state(self) -> MIPSState:
+        """Return a frozen snapshot of the current CPU state."""
+        return MIPSState(
+            pc     = self._pc,
+            regs   = tuple(self._regs),
+            hi     = self._hi,
+            lo     = self._lo,
+            memory = tuple(self._mem),
+            halted = self._halted,
+        )
+
+    # ── Protocol: step ────────────────────────────────────────────────────────
+
+    def step(self) -> StepTrace:
+        """Execute one instruction and return a StepTrace.
+
+        If the CPU is halted, returns a no-op HALT trace.
+        """
+        pc_before = self._pc
+        if self._halted:
+            return StepTrace(
+                pc_before   = pc_before,
+                pc_after    = pc_before,
+                mnemonic    = "HALT",
+                description = "HALT (already halted)",
+            )
+        mnemonic = self._execute_one()
+        return StepTrace(
+            pc_before   = pc_before,
+            pc_after    = self._pc,
+            mnemonic    = mnemonic,
+            description = f"{mnemonic} @ 0x{pc_before:04X}",
+        )
+
+    # ── Protocol: execute ─────────────────────────────────────────────────────
+
+    def execute(self, program: bytes, max_steps: int = 100_000) -> ExecutionResult:
+        """Load and run program until HALT or max_steps exceeded.
+
+        Args:
+            program:   raw big-endian machine code
+            max_steps: guard against infinite loops (default 100,000)
+
+        Returns:
+            ExecutionResult(halted, steps, traces, final_state, error)
+        """
+        self.load(program)
+        traces: list[StepTrace] = []
+        error: str | None = None
+        steps = 0
+        while not self._halted and steps < max_steps:
+            try:
+                trace = self.step()
+            except Exception as exc:  # noqa: BLE001
+                error = str(exc)
+                break
+            traces.append(trace)
+            steps += 1
+        if not self._halted and error is None:
+            error = f"max_steps ({max_steps}) exceeded"
+        return ExecutionResult(
+            halted      = self._halted,
+            steps       = steps,
+            traces      = traces,
+            final_state = self.get_state(),
+            error       = error,
+        )
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    def _fetch32(self) -> int:
+        """Fetch one 32-bit big-endian instruction from memory at PC, advance PC."""
+        addr = self._pc & (MEM_SIZE - 1)
+        # Bounds check: instruction fetch wraps within 64 KB
+        iw = (self._mem[addr]     << 24 |
+              self._mem[addr + 1] << 16 |
+              self._mem[addr + 2] <<  8 |
+              self._mem[addr + 3])
+        self._pc = (self._pc + 4) & (MEM_SIZE - 1)
+        return iw
+
+    def _set_reg(self, rd: int, val: int) -> None:
+        """Write to a GPR.  Writes to R0 are silently discarded."""
+        if rd != 0:
+            self._regs[rd] = val & 0xFFFF_FFFF
+
+    # ── Memory access ─────────────────────────────────────────────────────────
+
+    def _check_align(self, addr: int, size: int) -> None:
+        """Raise ValueError for misaligned memory access."""
+        if addr & (size - 1):
+            msg = (f"Misaligned {'word' if size == 4 else 'halfword'} access "
+                   f"at 0x{addr:04X} (addr & {size - 1} != 0)")
+            raise ValueError(msg)
+
+    def _mem_addr(self, base: int, offset: int) -> int:
+        """Compute effective address: (base + sext(offset)) & (MEM_SIZE - 1)."""
+        return (_as_unsigned32(_as_signed32(base) + offset)) & (MEM_SIZE - 1)
+
+    def _load_byte(self, addr: int) -> int:
+        """Load one byte from memory."""
+        return self._mem[addr & (MEM_SIZE - 1)]
+
+    def _load_half(self, addr: int) -> int:
+        """Load big-endian halfword from memory (2-byte aligned)."""
+        self._check_align(addr, 2)
+        a = addr & (MEM_SIZE - 1)
+        return (self._mem[a] << 8) | self._mem[a + 1]
+
+    def _load_word(self, addr: int) -> int:
+        """Load big-endian word from memory (4-byte aligned)."""
+        self._check_align(addr, 4)
+        a = addr & (MEM_SIZE - 1)
+        return (self._mem[a]     << 24 |
+                self._mem[a + 1] << 16 |
+                self._mem[a + 2] <<  8 |
+                self._mem[a + 3])
+
+    def _store_byte(self, addr: int, val: int) -> None:
+        """Store one byte to memory."""
+        self._mem[addr & (MEM_SIZE - 1)] = val & 0xFF
+
+    def _store_half(self, addr: int, val: int) -> None:
+        """Store big-endian halfword to memory (2-byte aligned)."""
+        self._check_align(addr, 2)
+        a = addr & (MEM_SIZE - 1)
+        self._mem[a]     = (val >> 8) & 0xFF
+        self._mem[a + 1] = val & 0xFF
+
+    def _store_word(self, addr: int, val: int) -> None:
+        """Store big-endian word to memory (4-byte aligned)."""
+        self._check_align(addr, 4)
+        a = addr & (MEM_SIZE - 1)
+        self._mem[a]     = (val >> 24) & 0xFF
+        self._mem[a + 1] = (val >> 16) & 0xFF
+        self._mem[a + 2] = (val >>  8) & 0xFF
+        self._mem[a + 3] = val & 0xFF
+
+    # =========================================================================
+    # Instruction execution
+    # =========================================================================
+
+    def _execute_one(self) -> str:  # noqa: C901 (complex dispatch table)
+        """Decode and execute one MIPS instruction.  Returns mnemonic string."""
+        iw = self._fetch32()
+
+        # Decode instruction fields
+        op     = (iw >> 26) & 0x3F   # opcode (bits 31:26)
+        rs     = (iw >> 21) & 0x1F   # source register 1 (bits 25:21)
+        rt     = (iw >> 16) & 0x1F   # source register 2 / branch condition (bits 20:16)
+        rd     = (iw >> 11) & 0x1F   # destination register (bits 15:11)
+        shamt  = (iw >>  6) & 0x1F   # shift amount (bits 10:6)
+        funct  = iw & 0x3F            # function code (bits 5:0)
+        imm16  = iw & 0xFFFF          # 16-bit immediate (bits 15:0)
+        simm   = _sext16(imm16)       # sign-extended immediate
+        target = iw & 0x03FF_FFFF     # 26-bit jump target (bits 25:0)
+
+        # ── HALT: SYSCALL ─────────────────────────────────────────────────────
+        # SYSCALL has op=0 and funct=0x0C.  Any SYSCALL halts the simulator.
+        if iw == HALT_OPCODE_WORD or (op == 0 and funct == 0x0C):
+            self._halted = True
+            return "HALT"
+
+        # ── NOP canonical encoding ────────────────────────────────────────────
+        # 0x00000000 = SLL $zero, $zero, 0 — the MIPS canonical NOP.  All MIPS
+        # assemblers and disassemblers display this as "NOP" rather than "SLL".
+        if iw == 0x0000_0000:
+            return "NOP"
+
+        # ── R-type (op == 0) ─────────────────────────────────────────────────
+        if op == 0:
+            return self._r_type(rs, rt, rd, shamt, funct)
+
+        # ── REGIMM (op == 1) ─────────────────────────────────────────────────
+        if op == 0x01:
+            return self._regimm(rs, rt, simm)
+
+        # ── J-type ───────────────────────────────────────────────────────────
+
+        # J addr  — unconditional jump
+        if op == 0x02:
+            # Target = (PC+4)[31:28] | (target26 << 2)
+            # Since PC was already advanced by _fetch32, self._pc == PC+4
+            self._pc = (self._pc & 0xF000) | ((target << 2) & 0xFFFF)
+            return "J"
+
+        # JAL addr  — jump and link ($ra = PC+4 before jump)
+        if op == 0x03:
+            ret_addr = self._pc   # _fetch32 already advanced PC to PC+4
+            self._pc = (self._pc & 0xF000) | ((target << 2) & 0xFFFF)
+            self._set_reg(REG_RA, ret_addr)
+            return "JAL"
+
+        # ── I-type branches ───────────────────────────────────────────────────
+
+        # BEQ rs, rt, offset  — branch if rs == rt
+        if op == 0x04:
+            if self._regs[rs] == self._regs[rt]:
+                self._pc = _as_unsigned32(self._pc + (simm << 2)) & (MEM_SIZE - 1)
+            return "BEQ"
+
+        # BNE rs, rt, offset  — branch if rs != rt
+        if op == 0x05:
+            if self._regs[rs] != self._regs[rt]:
+                self._pc = _as_unsigned32(self._pc + (simm << 2)) & (MEM_SIZE - 1)
+            return "BNE"
+
+        # BLEZ rs, offset  — branch if signed(rs) <= 0
+        if op == 0x06:
+            if _as_signed32(self._regs[rs]) <= 0:
+                self._pc = _as_unsigned32(self._pc + (simm << 2)) & (MEM_SIZE - 1)
+            return "BLEZ"
+
+        # BGTZ rs, offset  — branch if signed(rs) > 0
+        if op == 0x07:
+            if _as_signed32(self._regs[rs]) > 0:
+                self._pc = _as_unsigned32(self._pc + (simm << 2)) & (MEM_SIZE - 1)
+            return "BGTZ"
+
+        # ── I-type arithmetic / logic ─────────────────────────────────────────
+
+        # ADDI rt, rs, imm  — rt = rs + sext(imm); raises on signed overflow
+        if op == 0x08:
+            s = _as_signed32(self._regs[rs]) + simm
+            if s < -2**31 or s > 2**31 - 1:
+                msg = f"ADDI signed overflow: {_as_signed32(self._regs[rs])} + {simm}"
+                raise ValueError(msg)
+            self._set_reg(rt, _as_unsigned32(s))
+            return "ADDI"
+
+        # ADDIU rt, rs, imm  — rt = rs + sext(imm); wraps, no overflow check
+        if op == 0x09:
+            self._set_reg(rt, _as_unsigned32(self._regs[rs] + simm))
+            return "ADDIU"
+
+        # SLTI rt, rs, imm  — rt = (signed(rs) < signed(sext(imm))) ? 1 : 0
+        if op == 0x0A:
+            self._set_reg(rt, 1 if _as_signed32(self._regs[rs]) < simm else 0)
+            return "SLTI"
+
+        # SLTIU rt, rs, imm  — unsigned comparison; imm is still sign-extended
+        # but comparison is unsigned.  This is the MIPS spec behaviour.
+        if op == 0x0B:
+            self._set_reg(rt, 1 if self._regs[rs] < _as_unsigned32(simm) else 0)
+            return "SLTIU"
+
+        # ANDI rt, rs, imm  — zero-extend imm16, bitwise AND
+        if op == 0x0C:
+            self._set_reg(rt, self._regs[rs] & imm16)
+            return "ANDI"
+
+        # ORI rt, rs, imm  — zero-extend imm16, bitwise OR
+        if op == 0x0D:
+            self._set_reg(rt, self._regs[rs] | imm16)
+            return "ORI"
+
+        # XORI rt, rs, imm  — zero-extend imm16, bitwise XOR
+        if op == 0x0E:
+            self._set_reg(rt, self._regs[rs] ^ imm16)
+            return "XORI"
+
+        # LUI rt, imm  — load upper 16 bits; lower 16 bits zeroed
+        if op == 0x0F:
+            self._set_reg(rt, (imm16 << 16) & 0xFFFF_FFFF)
+            return "LUI"
+
+        # ── I-type loads ──────────────────────────────────────────────────────
+
+        # LB rt, offset(rs)  — load byte, sign-extend to 32 bits
+        if op == 0x20:
+            ea = self._mem_addr(self._regs[rs], simm)
+            byte = self._load_byte(ea)
+            # Sign-extend: if bit 7 set, fill upper 24 bits with 1s
+            self._set_reg(rt, _as_unsigned32(byte - 0x100 if byte >= 0x80 else byte))
+            return "LB"
+
+        # LH rt, offset(rs)  — load halfword, sign-extend
+        if op == 0x21:
+            ea = self._mem_addr(self._regs[rs], simm)
+            half = self._load_half(ea)
+            self._set_reg(rt, _as_unsigned32(half - 0x10000 if half >= 0x8000 else half))
+            return "LH"
+
+        # LW rt, offset(rs)  — load word (32-bit)
+        if op == 0x23:
+            ea = self._mem_addr(self._regs[rs], simm)
+            self._set_reg(rt, self._load_word(ea))
+            return "LW"
+
+        # LBU rt, offset(rs)  — load byte, zero-extend
+        if op == 0x24:
+            ea = self._mem_addr(self._regs[rs], simm)
+            self._set_reg(rt, self._load_byte(ea))
+            return "LBU"
+
+        # LHU rt, offset(rs)  — load halfword, zero-extend
+        if op == 0x25:
+            ea = self._mem_addr(self._regs[rs], simm)
+            self._set_reg(rt, self._load_half(ea))
+            return "LHU"
+
+        # ── I-type stores ─────────────────────────────────────────────────────
+
+        # SB rt, offset(rs)  — store least-significant byte
+        if op == 0x28:
+            ea = self._mem_addr(self._regs[rs], simm)
+            self._store_byte(ea, self._regs[rt])
+            return "SB"
+
+        # SH rt, offset(rs)  — store least-significant halfword
+        if op == 0x29:
+            ea = self._mem_addr(self._regs[rs], simm)
+            self._store_half(ea, self._regs[rt])
+            return "SH"
+
+        # SW rt, offset(rs)  — store word
+        if op == 0x2B:
+            ea = self._mem_addr(self._regs[rs], simm)
+            self._store_word(ea, self._regs[rt])
+            return "SW"
+
+        raise ValueError(f"Unknown opcode: 0x{op:02X} (instr=0x{iw:08X}) at PC=0x{(self._pc - 4) & 0xFFFF:04X}")
+
+    # ── R-type dispatch ───────────────────────────────────────────────────────
+
+    def _r_type(self, rs: int, rt: int, rd: int, shamt: int, funct: int) -> str:  # noqa: C901
+        """Handle all R-type instructions (op == 0), dispatched by funct."""
+
+        # SLL rd, rt, shamt  — logical left shift by immediate
+        if funct == 0x00:
+            self._set_reg(rd, (self._regs[rt] << shamt) & 0xFFFF_FFFF)
+            return "SLL"
+
+        # SRL rd, rt, shamt  — logical right shift by immediate (zero-fill)
+        if funct == 0x02:
+            self._set_reg(rd, self._regs[rt] >> shamt)
+            return "SRL"
+
+        # SRA rd, rt, shamt  — arithmetic right shift by immediate (sign-fill)
+        if funct == 0x03:
+            self._set_reg(rd, _as_unsigned32(_as_signed32(self._regs[rt]) >> shamt))
+            return "SRA"
+
+        # SLLV rd, rt, rs  — logical left shift by register (rs & 31)
+        if funct == 0x04:
+            self._set_reg(rd, (self._regs[rt] << (self._regs[rs] & 31)) & 0xFFFF_FFFF)
+            return "SLLV"
+
+        # SRLV rd, rt, rs  — logical right shift by register
+        if funct == 0x06:
+            self._set_reg(rd, self._regs[rt] >> (self._regs[rs] & 31))
+            return "SRLV"
+
+        # SRAV rd, rt, rs  — arithmetic right shift by register
+        if funct == 0x07:
+            self._set_reg(rd, _as_unsigned32(_as_signed32(self._regs[rt]) >> (self._regs[rs] & 31)))
+            return "SRAV"
+
+        # JR rs  — jump to register
+        if funct == 0x08:
+            self._pc = self._regs[rs] & (MEM_SIZE - 1)
+            return "JR"
+
+        # JALR rd, rs  — jump and link register; rd = PC+4 (already advanced)
+        if funct == 0x09:
+            ret_addr = self._pc  # _fetch32 advanced PC to next instruction
+            self._pc = self._regs[rs] & (MEM_SIZE - 1)
+            self._set_reg(rd, ret_addr)
+            return "JALR"
+
+        # BREAK  — software breakpoint (treated as program error, not HALT)
+        if funct == 0x0D:
+            pc_of_instr = (self._pc - 4) & (MEM_SIZE - 1)
+            raise ValueError(f"BREAK instruction at PC=0x{pc_of_instr:04X}")
+
+        # MFHI rd  — move from HI
+        if funct == 0x10:
+            self._set_reg(rd, self._hi)
+            return "MFHI"
+
+        # MTHI rs  — move to HI
+        if funct == 0x11:
+            self._hi = self._regs[rs]
+            return "MTHI"
+
+        # MFLO rd  — move from LO
+        if funct == 0x12:
+            self._set_reg(rd, self._lo)
+            return "MFLO"
+
+        # MTLO rs  — move to LO
+        if funct == 0x13:
+            self._lo = self._regs[rs]
+            return "MTLO"
+
+        # MULT rs, rt  — signed 32×32 → 64 multiply; HI:LO = result
+        if funct == 0x18:
+            product = _as_signed32(self._regs[rs]) * _as_signed32(self._regs[rt])
+            product &= 0xFFFF_FFFF_FFFF_FFFF   # keep 64 bits (Python int is unbounded)
+            self._lo = product & 0xFFFF_FFFF
+            self._hi = (product >> 32) & 0xFFFF_FFFF
+            return "MULT"
+
+        # MULTU rs, rt  — unsigned 32×32 → 64 multiply
+        if funct == 0x19:
+            product = self._regs[rs] * self._regs[rt]
+            self._lo = product & 0xFFFF_FFFF
+            self._hi = (product >> 32) & 0xFFFF_FFFF
+            return "MULTU"
+
+        # DIV rs, rt  — signed divide; LO = quotient, HI = remainder
+        if funct == 0x1A:
+            if self._regs[rt] == 0:
+                raise ValueError("DIV by zero")
+            a = _as_signed32(self._regs[rs])
+            b = _as_signed32(self._regs[rt])
+            # Python // truncates toward negative infinity; MIPS truncates toward zero.
+            q = int(a / b)          # truncate-toward-zero division
+            r = a - q * b
+            self._lo = _as_unsigned32(q)
+            self._hi = _as_unsigned32(r)
+            return "DIV"
+
+        # DIVU rs, rt  — unsigned divide
+        if funct == 0x1B:
+            if self._regs[rt] == 0:
+                raise ValueError("DIVU by zero")
+            self._lo = self._regs[rs] // self._regs[rt]
+            self._hi = self._regs[rs] %  self._regs[rt]
+            return "DIVU"
+
+        # ADD rd, rs, rt  — signed add; ValueError on overflow
+        if funct == 0x20:
+            s = _as_signed32(self._regs[rs]) + _as_signed32(self._regs[rt])
+            if s < -(2**31) or s > 2**31 - 1:
+                raise ValueError(f"ADD signed overflow: {_as_signed32(self._regs[rs])} + {_as_signed32(self._regs[rt])}")
+            self._set_reg(rd, _as_unsigned32(s))
+            return "ADD"
+
+        # ADDU rd, rs, rt  — unsigned add; wraps silently
+        if funct == 0x21:
+            self._set_reg(rd, _as_unsigned32(self._regs[rs] + self._regs[rt]))
+            return "ADDU"
+
+        # SUB rd, rs, rt  — signed subtract; ValueError on overflow
+        if funct == 0x22:
+            s = _as_signed32(self._regs[rs]) - _as_signed32(self._regs[rt])
+            if s < -(2**31) or s > 2**31 - 1:
+                raise ValueError("SUB signed overflow")
+            self._set_reg(rd, _as_unsigned32(s))
+            return "SUB"
+
+        # SUBU rd, rs, rt  — unsigned subtract; wraps silently
+        if funct == 0x23:
+            self._set_reg(rd, _as_unsigned32(self._regs[rs] - self._regs[rt]))
+            return "SUBU"
+
+        # AND rd, rs, rt  — bitwise AND
+        if funct == 0x24:
+            self._set_reg(rd, self._regs[rs] & self._regs[rt])
+            return "AND"
+
+        # OR rd, rs, rt  — bitwise OR
+        if funct == 0x25:
+            self._set_reg(rd, self._regs[rs] | self._regs[rt])
+            return "OR"
+
+        # XOR rd, rs, rt  — bitwise XOR
+        if funct == 0x26:
+            self._set_reg(rd, self._regs[rs] ^ self._regs[rt])
+            return "XOR"
+
+        # NOR rd, rs, rt  — bitwise NOR (complement of OR)
+        if funct == 0x27:
+            self._set_reg(rd, (~(self._regs[rs] | self._regs[rt])) & 0xFFFF_FFFF)
+            return "NOR"
+
+        # SLT rd, rs, rt  — set if signed(rs) < signed(rt)
+        if funct == 0x2A:
+            self._set_reg(rd, 1 if _as_signed32(self._regs[rs]) < _as_signed32(self._regs[rt]) else 0)
+            return "SLT"
+
+        # SLTU rd, rs, rt  — set if unsigned(rs) < unsigned(rt)
+        if funct == 0x2B:
+            self._set_reg(rd, 1 if self._regs[rs] < self._regs[rt] else 0)
+            return "SLTU"
+
+        pc_of_instr = (self._pc - 4) & (MEM_SIZE - 1)
+        raise ValueError(f"Unknown funct: 0x{funct:02X} at PC=0x{pc_of_instr:04X}")
+
+    # ── REGIMM dispatch ───────────────────────────────────────────────────────
+
+    def _regimm(self, rs: int, rt: int, simm: int) -> str:
+        """Handle REGIMM instructions (op == 1), dispatched by rt field."""
+        # Branch target: PC is already advanced past the instruction
+        target = _as_unsigned32(self._pc + (simm << 2)) & (MEM_SIZE - 1)
+
+        # BLTZ rs, offset  — branch if signed(rs) < 0
+        if rt == 0x00:
+            if _as_signed32(self._regs[rs]) < 0:
+                self._pc = target
+            return "BLTZ"
+
+        # BGEZ rs, offset  — branch if signed(rs) >= 0
+        if rt == 0x01:
+            if _as_signed32(self._regs[rs]) >= 0:
+                self._pc = target
+            return "BGEZ"
+
+        # BLTZAL rs, offset  — $ra = PC+4; branch if signed(rs) < 0
+        if rt == 0x10:
+            ret = self._pc  # already past instruction
+            self._set_reg(REG_RA, ret)
+            if _as_signed32(self._regs[rs]) < 0:
+                self._pc = target
+            return "BLTZAL"
+
+        # BGEZAL rs, offset  — $ra = PC+4; branch if signed(rs) >= 0
+        if rt == 0x11:
+            ret = self._pc
+            self._set_reg(REG_RA, ret)
+            if _as_signed32(self._regs[rs]) >= 0:
+                self._pc = target
+            return "BGEZAL"
+
+        pc_of_instr = (self._pc - 4) & (MEM_SIZE - 1)
+        raise ValueError(f"Unknown REGIMM rt: 0x{rt:02X} at PC=0x{pc_of_instr:04X}")

--- a/code/packages/python/mips-r2000-simulator/src/mips_r2000_simulator/state.py
+++ b/code/packages/python/mips-r2000-simulator/src/mips_r2000_simulator/state.py
@@ -1,0 +1,172 @@
+"""State snapshot for the MIPS R2000 simulator — Layer 07q.
+
+MIPSState is a frozen dataclass capturing the complete CPU state at a point
+in time.  Freezing it makes snapshots safe to pass around without copying.
+
+MIPS R2000 register file
+─────────────────────────
+  R0  ($zero)  — hardwired 0; writes are silently discarded
+  R1  ($at)    — assembler temporary
+  R2  ($v0)    — return value (also used for syscall number on Linux)
+  R3  ($v1)    — return value (second word)
+  R4  ($a0)    — argument 0
+  R5  ($a1)    — argument 1
+  R6  ($a2)    — argument 2
+  R7  ($a3)    — argument 3
+  R8–R15  ($t0–$t7) — caller-saved temporaries
+  R16–R23 ($s0–$s7) — callee-saved registers
+  R24–R25 ($t8–$t9) — more temporaries
+  R26–R27 ($k0–$k1) — kernel reserved
+  R28 ($gp) — global pointer
+  R29 ($sp) — stack pointer
+  R30 ($fp) — frame pointer (also called $s8)
+  R31 ($ra) — return address (set by JAL / JALR)
+
+Special registers
+─────────────────
+  HI — high 32 bits of MULT/MULTU; remainder of DIV/DIVU
+  LO — low  32 bits of MULT/MULTU; quotient  of DIV/DIVU
+  PC — 32-bit program counter (wraps modulo MEM_SIZE in simulator)
+
+Memory
+──────
+  65536 bytes flat, big-endian.  Programs load at address 0x0000.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+MEM_SIZE = 0x10000       # 64 KB flat address space for the simulator
+NUM_REGS = 32            # 32 general-purpose registers
+
+# HALT convention: SYSCALL (op=0, funct=0x0C) halts the simulator.
+# Encoding: all-zero high 20 bits + funct = 0b001100 = 0x0C
+# Big-endian bytes: [0x00, 0x00, 0x00, 0x0C]
+HALT_OPCODE_WORD: int = 0x0000_000C   # SYSCALL instruction word
+
+# Register aliases (by ABI convention)
+REG_ZERO = 0   # always zero
+REG_AT   = 1   # assembler temporary
+REG_V0   = 2   # return value / syscall number
+REG_V1   = 3   # second return value
+REG_A0   = 4   # argument 0
+REG_A1   = 5
+REG_A2   = 6
+REG_A3   = 7
+REG_T0   = 8   # temporaries
+REG_T1   = 9
+REG_T2   = 10
+REG_T3   = 11
+REG_T4   = 12
+REG_T5   = 13
+REG_T6   = 14
+REG_T7   = 15
+REG_S0   = 16  # saved registers
+REG_S1   = 17
+REG_S2   = 18
+REG_S3   = 19
+REG_S4   = 20
+REG_S5   = 21
+REG_S6   = 22
+REG_S7   = 23
+REG_T8   = 24
+REG_T9   = 25
+REG_K0   = 26
+REG_K1   = 27
+REG_GP   = 28  # global pointer
+REG_SP   = 29  # stack pointer
+REG_FP   = 30  # frame pointer
+REG_RA   = 31  # return address
+
+
+# ── State dataclass ────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class MIPSState:
+    """Immutable snapshot of the MIPS R2000 CPU state.
+
+    All integer fields are unsigned Python ints in the range [0, 2**32).
+    Signed interpretation is done by the simulator and helper functions, not
+    stored here.
+
+    Attributes:
+        pc     — 32-bit program counter (addresses modulo MEM_SIZE in sim)
+        regs   — 32 general-purpose registers, each unsigned 32-bit
+                 regs[0] is always 0 (R0/$zero)
+        hi     — HI special register (unsigned 32-bit)
+        lo     — LO special register (unsigned 32-bit)
+        memory — 65536 bytes of flat big-endian memory
+        halted — True once SYSCALL (our HALT sentinel) is executed
+    """
+
+    pc:     int
+    regs:   tuple[int, ...]
+    hi:     int
+    lo:     int
+    memory: tuple[int, ...]
+    halted: bool
+
+    # ── Convenience register properties ───────────────────────────────────────
+
+    @property
+    def zero(self) -> int:
+        """$zero — always 0."""
+        return 0
+
+    @property
+    def v0(self) -> int:
+        """$v0 — return value / syscall number (R2)."""
+        return self.regs[REG_V0]
+
+    @property
+    def v1(self) -> int:
+        """$v1 — second return value (R3)."""
+        return self.regs[REG_V1]
+
+    @property
+    def a0(self) -> int:
+        """$a0 — argument 0 (R4)."""
+        return self.regs[REG_A0]
+
+    @property
+    def a1(self) -> int:
+        """$a1 — argument 1 (R5)."""
+        return self.regs[REG_A1]
+
+    @property
+    def t0(self) -> int:
+        """$t0 — temporary 0 (R8)."""
+        return self.regs[REG_T0]
+
+    @property
+    def t1(self) -> int:
+        """$t1 — temporary 1 (R9)."""
+        return self.regs[REG_T1]
+
+    @property
+    def s0(self) -> int:
+        """$s0 — saved register 0 (R16)."""
+        return self.regs[REG_S0]
+
+    @property
+    def s1(self) -> int:
+        """$s1 — saved register 1 (R17)."""
+        return self.regs[REG_S1]
+
+    @property
+    def sp(self) -> int:
+        """$sp — stack pointer (R29)."""
+        return self.regs[REG_SP]
+
+    @property
+    def fp(self) -> int:
+        """$fp — frame pointer (R30)."""
+        return self.regs[REG_FP]
+
+    @property
+    def ra(self) -> int:
+        """$ra — return address (R31)."""
+        return self.regs[REG_RA]

--- a/code/packages/python/mips-r2000-simulator/tests/test_coverage.py
+++ b/code/packages/python/mips-r2000-simulator/tests/test_coverage.py
@@ -1,0 +1,419 @@
+"""Edge-case and coverage tests for the MIPS R2000 simulator.
+
+These tests target specific hardware behaviors, error conditions, and corner
+cases not exercised by the normal instruction flow tests.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from mips_r2000_simulator import MIPSSimulator
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def w32(v: int) -> bytes:
+    """Pack a 32-bit unsigned int as 4 big-endian bytes."""
+    return struct.pack(">I", v & 0xFFFF_FFFF)
+
+
+HALT = w32(0x0000_000C)   # SYSCALL
+NOP  = w32(0x0000_0000)   # SLL $zero,$zero,0
+
+
+def addiu(rt: int, rs: int, imm: int) -> bytes:
+    return w32((0x09 << 26) | (rs << 21) | (rt << 16) | (imm & 0xFFFF))
+
+
+def R(rs: int, rt: int, rd: int, shamt: int, funct: int) -> bytes:
+    return w32((rs << 21) | (rt << 16) | (rd << 11) | (shamt << 6) | funct)
+
+
+def I_instr(op: int, rs: int, rt: int, imm: int) -> bytes:
+    return w32((op << 26) | (rs << 21) | (rt << 16) | (imm & 0xFFFF))
+
+
+# ── R0 always zero ────────────────────────────────────────────────────────────
+
+class TestR0Immutable:
+    """Writing to R0 ($zero) must have no effect."""
+
+    def test_addiu_to_r0_discarded(self):
+        """ADDIU $zero, $zero, 42 — result discarded, R0 stays 0."""
+        prog = I_instr(0x09, 0, 0, 42) + HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[0] == 0
+
+    def test_addu_to_r0_discarded(self):
+        """ADDU $zero, $t0, $t1 — rd=0 discards the write."""
+        prog  = addiu(8, 0, 5)
+        prog += addiu(9, 0, 3)
+        prog += R(8, 9, 0, 0, 0x21)     # ADDU $zero, $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[0] == 0
+
+    def test_lui_to_r0_discarded(self):
+        """LUI $zero, 0xDEAD — discarded."""
+        prog = w32((0x0F << 26) | (0 << 21) | (0 << 16) | 0xDEAD) + HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[0] == 0
+
+
+# ── Signed overflow exceptions ────────────────────────────────────────────────
+
+class TestOverflow:
+
+    def test_add_overflow_raises(self):
+        """ADD raises ValueError on signed overflow (0x7FFFFFFF + 1)."""
+        # Load 0x7FFFFFFF into $t0 using LUI + ORI
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0x7FFF)   # LUI $t0, 0x7FFF
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xFFFF)   # ORI $t0,$t0,0xFFFF
+        prog += addiu(9, 0, 1)                                          # $t1 = 1
+        prog += R(8, 9, 10, 0, 0x20)    # ADD $t2, $t0, $t1 — OVERFLOW
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+        assert result.error is not None
+
+    def test_addi_overflow_raises(self):
+        """ADDI raises ValueError on signed overflow."""
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0x7FFF)
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xFFFF)   # $t0 = 0x7FFFFFFF
+        prog += I_instr(0x08, 8, 9, 1)  # ADDI $t1, $t0, 1 — overflow
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+    def test_sub_overflow_raises(self):
+        """SUB raises ValueError: -0x80000000 - 1 overflows."""
+        # Load 0x80000000 (most negative 32-bit int) via LUI
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0x8000)   # LUI $t0, 0x8000
+        prog += addiu(9, 0, 1)                                          # $t1 = 1
+        prog += R(8, 9, 10, 0, 0x22)    # SUB $t2, $t0, $t1 — overflow
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+    def test_addu_does_not_raise_on_overflow(self):
+        """ADDU silently wraps — no ValueError."""
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0x7FFF)
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xFFFF)   # 0x7FFFFFFF
+        prog += addiu(9, 0, 1)
+        prog += R(8, 9, 10, 0, 0x21)    # ADDU — wraps
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.ok
+        assert sim._regs[10] == 0x8000_0000
+
+    def test_subu_does_not_raise(self):
+        """SUBU 0 - 1 wraps to 0xFFFFFFFF — no ValueError."""
+        prog  = addiu(9, 0, 1)
+        prog += R(0, 9, 10, 0, 0x23)    # SUBU $t2, $zero, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.ok
+        assert sim._regs[10] == 0xFFFF_FFFF
+
+
+# ── Division by zero ──────────────────────────────────────────────────────────
+
+class TestDivisionErrors:
+
+    def test_div_by_zero_raises(self):
+        """DIV by zero raises ValueError."""
+        prog  = addiu(8, 0, 10)
+        prog += R(8, 0, 0, 0, 0x1A)     # DIV $t0, $zero
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+        assert result.error is not None
+
+    def test_divu_by_zero_raises(self):
+        """DIVU by zero raises ValueError."""
+        prog  = addiu(8, 0, 10)
+        prog += R(8, 0, 0, 0, 0x1B)     # DIVU $t0, $zero
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+
+# ── Misaligned memory access ──────────────────────────────────────────────────
+
+class TestMisalignment:
+
+    def test_lw_misaligned_raises(self):
+        """LW from odd address raises ValueError."""
+        prog  = addiu(8, 0, 1)          # $t0 = 1 (odd address)
+        prog += I_instr(0x23, 8, 9, 0)  # LW $t1, 0($t0) — misaligned
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+        assert result.error is not None
+
+    def test_sw_misaligned_raises(self):
+        """SW to odd address raises ValueError."""
+        prog  = addiu(8, 0, 3)          # addr 3 — misaligned
+        prog += addiu(9, 0, 42)
+        prog += I_instr(0x2B, 8, 9, 0)  # SW $t1, 0($t0)
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+    def test_lh_misaligned_raises(self):
+        """LH from odd address raises ValueError."""
+        prog  = addiu(8, 0, 1)
+        prog += I_instr(0x21, 8, 9, 0)  # LH $t1, 0($t0)
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+    def test_sh_misaligned_raises(self):
+        """SH to odd address raises ValueError."""
+        prog  = addiu(8, 0, 1)
+        prog += addiu(9, 0, 0xAB)
+        prog += I_instr(0x29, 8, 9, 0)  # SH $t1, 0($t0)
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+    def test_lb_any_addr_ok(self):
+        """LB works on any byte address (no alignment required)."""
+        prog  = addiu(8, 0, 1)          # odd address
+        prog += I_instr(0x20, 8, 9, 0)  # LB $t1, 0($t0)
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.ok
+
+    def test_sb_any_addr_ok(self):
+        """SB works on any byte address."""
+        prog  = addiu(8, 0, 1)
+        prog += addiu(9, 0, 0xAB)
+        prog += I_instr(0x28, 8, 9, 0)  # SB $t1, 0($t0)
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.ok
+
+
+# ── BREAK instruction ─────────────────────────────────────────────────────────
+
+class TestBreak:
+
+    def test_break_raises_value_error(self):
+        """BREAK (funct=0x0D) raises ValueError — software breakpoint."""
+        prog = w32(0x0000_000D) + HALT   # BREAK 0
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+        assert result.error is not None
+
+    def test_break_not_same_as_halt(self):
+        """BREAK stops execution with error, not clean HALT."""
+        prog = w32(0x0000_000D) + HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.halted    # HALT sentinel not set
+
+
+# ── Unknown opcode ────────────────────────────────────────────────────────────
+
+class TestUnknownOpcode:
+
+    def test_unknown_op_raises(self):
+        """An unimplemented opcode raises ValueError via execute()."""
+        # op=0x3F is unassigned in MIPS
+        prog = w32(0xFC00_0000) + HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+    def test_unknown_funct_raises(self):
+        """An unknown R-type funct raises ValueError."""
+        # op=0, funct=0x01 (unassigned)
+        prog = w32(0x0000_0001) + HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+    def test_unknown_regimm_raises(self):
+        """An unknown REGIMM rt field raises ValueError."""
+        # op=1, rt=0x05 (unassigned)
+        prog = w32((0x01 << 26) | (0 << 21) | (0x05 << 16)) + HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert not result.ok
+
+
+# ── Specific signed/unsigned semantics ───────────────────────────────────────
+
+class TestSignedUnsigned:
+
+    def test_sra_preserves_sign(self):
+        """SRA by 1 on 0x80000000 → 0xC0000000 (sign bit preserved)."""
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0x8000)  # LUI $t0,0x8000
+        prog += R(0, 8, 9, 1, 0x03)   # SRA $t1, $t0, 1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 0xC000_0000
+
+    def test_srl_no_sign_fill(self):
+        """SRL on 0x80000000 by 1 → 0x40000000 (zero fill, no sign)."""
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0x8000)
+        prog += R(0, 8, 9, 1, 0x02)   # SRL $t1, $t0, 1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 0x4000_0000
+
+    def test_lb_0x7f_positive(self):
+        """LB 0x7F → 127 (positive, no sign extension change)."""
+        prog  = addiu(8, 0, 0x200)
+        prog += addiu(9, 0, 0x7F)
+        prog += I_instr(0x28, 8, 9, 0)  # SB $t1, 0($t0)
+        prog += I_instr(0x20, 8, 10, 0) # LB $t2, 0($t0)
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0x7F
+
+    def test_lbu_0x80_no_sign_extension(self):
+        """LBU 0x80 → 128 (zero-extended, not -128)."""
+        prog  = addiu(8, 0, 0x300)
+        prog += w32((0x0D << 26) | (0 << 21) | (9 << 16) | 0x80)  # ORI $t1,0x80
+        prog += I_instr(0x28, 8, 9, 0)  # SB
+        prog += I_instr(0x24, 8, 10, 0) # LBU
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0x80
+
+    def test_sltiu_sign_extends_imm_then_compares_unsigned(self):
+        """SLTIU: imm is sign-extended to 32 bits, then compared as unsigned.
+
+        SLTIU $t1, $t0, 0xFFFF: 0xFFFF sign-extended = 0xFFFFFFFF.
+        If $t0 = 5: 5 < 0xFFFFFFFF (unsigned) → 1.
+        """
+        prog  = addiu(8, 0, 5)
+        prog += I_instr(0x0B, 8, 9, 0xFFFF)  # SLTIU $t1, $t0, -1 (0xFFFFFFFF unsigned)
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 1
+
+    def test_slti_vs_sltu_differ_for_negative(self):
+        """SLT and SLTU give different results for 0xFFFFFFFF.
+
+        Signed:   0xFFFFFFFF = -1 < 1 → SLT gives 1
+        Unsigned: 0xFFFFFFFF = large positive > 1 → SLTU gives 0
+        """
+        prog  = addiu(8, 0, 0xFFFF)     # $t0 = 0xFFFFFFFF (= -1 signed)
+        prog += addiu(9, 0, 1)           # $t1 = 1
+        prog += R(8, 9, 10, 0, 0x2A)    # SLT  $t2, $t0, $t1 → 1 (signed: -1 < 1)
+        prog += R(8, 9, 11, 0, 0x2B)    # SLTU $t3, $t0, $t1 → 0 (unsigned: 0xFFFFFFFF > 1)
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 1   # SLT
+        assert sim._regs[11] == 0   # SLTU
+
+    def test_mult_negative_numbers(self):
+        """MULT (-1) * (-1) = +1 (signed 32-bit × 32-bit → 64-bit result)."""
+        prog  = addiu(8, 0, 0xFFFF)     # -1
+        prog += addiu(9, 0, 0xFFFF)     # -1
+        prog += R(8, 9, 0, 0, 0x18)     # MULT $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._lo == 1
+        assert sim._hi == 0   # +1 fits in LO, HI = 0
+
+
+# ── max_steps guard ───────────────────────────────────────────────────────────
+
+class TestMaxSteps:
+
+    def test_max_steps_terminates(self):
+        """Infinite BEQ loop terminated by max_steps."""
+        loop = I_instr(0x04, 0, 0, 0xFFFF)   # BEQ $zero,$zero,-1 → PC-4 = forever
+        result = MIPSSimulator().execute(loop + HALT, max_steps=5)
+        assert not result.ok
+        assert result.steps == 5
+        assert "max_steps" in result.error
+
+    def test_max_steps_default_is_100000(self):
+        """Default max_steps is 100,000."""
+        import inspect
+        sig = inspect.signature(MIPSSimulator.execute)
+        assert sig.parameters["max_steps"].default == 100_000
+
+
+# ── Big-endian memory layout ──────────────────────────────────────────────────
+
+class TestBigEndian:
+
+    def test_sw_stores_big_endian(self):
+        """SW 0x12345678 at addr 0x100 → bytes [0x12, 0x34, 0x56, 0x78]."""
+        sim = MIPSSimulator()
+        sim.load(HALT)
+        sim._store_word(0x100, 0x1234_5678)
+        assert sim._mem[0x100] == 0x12
+        assert sim._mem[0x101] == 0x34
+        assert sim._mem[0x102] == 0x56
+        assert sim._mem[0x103] == 0x78
+
+    def test_lw_reads_big_endian(self):
+        """LW from address with bytes [0xDE, 0xAD, 0xBE, 0xEF] = 0xDEADBEEF."""
+        sim = MIPSSimulator()
+        sim.load(HALT)
+        sim._mem[0x200] = 0xDE
+        sim._mem[0x201] = 0xAD
+        sim._mem[0x202] = 0xBE
+        sim._mem[0x203] = 0xEF
+        assert sim._load_word(0x200) == 0xDEAD_BEEF
+
+
+# ── Instruction encoding ──────────────────────────────────────────────────────
+
+class TestInstructionEncoding:
+
+    def test_nop_canonical_mnemonic(self):
+        """NOP (0x00000000) reports mnemonic 'NOP' — the canonical MIPS disassembly."""
+        sim = MIPSSimulator()
+        sim.load(NOP + HALT)
+        trace = sim.step()
+        assert trace.mnemonic == "NOP"
+        assert sim._regs[0] == 0
+
+    def test_halt_mnemonic(self):
+        """SYSCALL instruction reports mnemonic 'HALT'."""
+        sim = MIPSSimulator()
+        sim.load(HALT)
+        trace = sim.step()
+        assert trace.mnemonic == "HALT"
+
+    def test_lui_andi_combine_for_upper_lower(self):
+        """LUI + ORI idiom loads a full 32-bit constant."""
+        # Load 0xDEADBEEF: LUI $t0, 0xDEAD; ORI $t0, $t0, 0xBEEF
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0xDEAD)  # LUI
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xBEEF)  # ORI
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 0xDEAD_BEEF

--- a/code/packages/python/mips-r2000-simulator/tests/test_instructions.py
+++ b/code/packages/python/mips-r2000-simulator/tests/test_instructions.py
@@ -1,0 +1,692 @@
+"""Per-instruction tests for the MIPS R2000 simulator.
+
+Every instruction variant is tested for correct register/memory effect and
+correct PC advancement.  Branch and jump instructions are tested for both
+taken and not-taken cases.
+
+MIPS instruction encoding reference:
+  R-type: [op:6=0][rs:5][rt:5][rd:5][shamt:5][funct:6]
+  I-type: [op:6][rs:5][rt:5][imm16:16]
+  J-type: [op:6][target26:26]
+"""
+
+from __future__ import annotations
+
+import struct
+
+from mips_r2000_simulator import MIPSSimulator
+from mips_r2000_simulator.state import REG_RA
+
+# ── Encoding helpers ──────────────────────────────────────────────────────────
+
+def w32(v: int) -> bytes:
+    """Pack a 32-bit unsigned int as 4 big-endian bytes."""
+    return struct.pack(">I", v & 0xFFFF_FFFF)
+
+
+# Frequently used instruction words
+HALT  = w32(0x0000_000C)   # SYSCALL
+NOP   = w32(0x0000_0000)   # SLL $zero,$zero,0
+
+
+def R(rs: int, rt: int, rd: int, shamt: int, funct: int) -> bytes:
+    """Build an R-type instruction word."""
+    return w32((rs << 21) | (rt << 16) | (rd << 11) | (shamt << 6) | funct)
+
+
+def mk_i(op: int, rs: int, rt: int, imm: int) -> bytes:
+    """Build an I-type instruction word."""
+    return w32((op << 26) | (rs << 21) | (rt << 16) | (imm & 0xFFFF))
+
+
+def J(op: int, target: int) -> bytes:
+    """Build a J-type instruction word."""
+    return w32((op << 26) | (target & 0x03FF_FFFF))
+
+
+def run1(instr: bytes) -> MIPSSimulator:
+    """Load and execute a single instruction followed by HALT."""
+    sim = MIPSSimulator()
+    sim.execute(instr + HALT)
+    return sim
+
+
+def run_with_reg(instr: bytes, reg: int, val: int) -> MIPSSimulator:
+    """Set a register via ADDIU, then run instruction + HALT."""
+    prog = mk_i(0x09, 0, reg, val) + instr + HALT   # ADDIU reg,$zero,val
+    sim = MIPSSimulator()
+    sim.execute(prog)
+    return sim
+
+
+# ── Shift instructions ────────────────────────────────────────────────────────
+
+class TestShifts:
+
+    def test_sll_by_4(self):
+        """SLL $t0, $t1, 4  — shift $t1 left by 4."""
+        # Set $t1 ($9) = 0x00000001, shift into $t0 ($8)
+        prog = mk_i(0x09, 0, 9, 1)           # ADDIU $t1, $zero, 1
+        prog += R(0, 9, 8, 4, 0x00)      # SLL $t0, $t1, 4
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 0x10
+
+    def test_srl_logical(self):
+        """SRL $t0, $t1, 4 — logical right shift (fills with zeros)."""
+        prog = mk_i(0x09, 0, 9, 0x00F0)     # ADDIU $t1, $zero, 0xF0
+        prog += R(0, 9, 8, 4, 0x02)      # SRL $t0, $t1, 4
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 0x0F
+
+    def test_sra_arithmetic_negative(self):
+        """SRA $t0, $t1, 4 — arithmetic shift preserves sign bit."""
+        # Load -16 (0xFFFFFFF0) into $t1, shift right 4 → -1 (0xFFFFFFFF)
+        # We can't directly load 0xFFFFFFF0 via ADDIU (only 16-bit), so use ADDIU of -16
+        prog = mk_i(0x09, 0, 9, 0xFFF0)     # ADDIU $t1, $zero, -16 (sext: 0xFFFFFFF0)
+        prog += R(0, 9, 8, 4, 0x03)      # SRA $t0, $t1, 4
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 0xFFFF_FFFF   # -1
+
+    def test_sra_positive_no_sign_fill(self):
+        """SRA on a positive value fills with zeros, same as SRL."""
+        prog = mk_i(0x09, 0, 9, 0x0010)     # ADDIU $t1, $zero, 16
+        prog += R(0, 9, 8, 2, 0x03)      # SRA $t0, $t1, 2
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 4
+
+    def test_sllv_by_register(self):
+        """SLLV $t0, $t1, $t2 — shift amount from register."""
+        prog  = mk_i(0x09, 0, 9, 1)         # ADDIU $t1, $zero, 1
+        prog += mk_i(0x09, 0, 10, 3)        # ADDIU $t2, $zero, 3 (shift by 3)
+        prog += R(10, 9, 8, 0, 0x04)     # SLLV $t0, $t1, $t2
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 8
+
+    def test_srlv_by_register(self):
+        """SRLV $t0, $t1, $t2."""
+        prog  = mk_i(0x09, 0, 9, 0x0040)   # ADDIU $t1, $zero, 64
+        prog += mk_i(0x09, 0, 10, 2)        # ADDIU $t2, $zero, 2
+        prog += R(10, 9, 8, 0, 0x06)     # SRLV $t0, $t1, $t2
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 16
+
+    def test_srav_by_register(self):
+        """SRAV $t0, $t1, $t2 — arithmetic shift by register."""
+        prog  = mk_i(0x09, 0, 9, 0xFF80)   # ADDIU $t1, $zero, -128 sext → 0xFFFFFF80
+        prog += mk_i(0x09, 0, 10, 3)        # ADDIU $t2, $zero, 3
+        prog += R(10, 9, 8, 0, 0x07)     # SRAV $t0, $t1, $t2
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        # -128 >> 3 = -16 = 0xFFFFFFF0
+        assert sim._regs[8] == 0xFFFF_FFF0
+
+
+# ── Jump / call instructions ──────────────────────────────────────────────────
+
+class TestJumps:
+
+    def test_jr_jumps_to_register(self):
+        """JR $ra — jump to address in $ra."""
+        # Load $ra = 8 (byte addr of HALT after two NOPs at 0 and 4)
+        # PC starts at 0: NOP(0), ADDIU $ra,0,8(4), JR $ra(8), ... HALT at 12
+        prog = NOP                                 # 0x00: NOP
+        prog += mk_i(0x09, 0, REG_RA, 12)            # 0x04: ADDIU $ra, $zero, 12
+        prog += R(REG_RA, 0, 0, 0, 0x08)          # 0x08: JR $ra
+        prog += NOP                                # 0x0C: NOP (would be skipped)
+        prog += HALT                               # 0x10: HALT - but we jump here
+        # Build: HALT at 0x0C
+        prog2 = NOP                                # 0x00
+        prog2 += mk_i(0x09, 0, REG_RA, 12)           # 0x04
+        prog2 += R(REG_RA, 0, 0, 0, 0x08)         # 0x08: JR $ra → PC = 12
+        prog2 += HALT                              # 0x0C: HALT (target)
+        sim = MIPSSimulator()
+        result = sim.execute(prog2)
+        assert result.ok
+        assert result.halted
+
+    def test_jalr_sets_return_address(self):
+        """JALR $ra, $t0 — sets $ra = PC+4 and jumps to $t0."""
+        # Put address 0x10 in $t0, then JALR
+        prog = bytearray(0x14)
+        # 0x00: ADDIU $t0, $zero, 0x10
+        struct.pack_into(">I", prog, 0x00, (0x09 << 26) | (0 << 21) | (8 << 16) | 0x10)
+        # 0x04: JALR $ra, $t0  (rd=31, rs=8, funct=0x09)
+        struct.pack_into(">I", prog, 0x04, (8 << 21) | (REG_RA << 11) | 0x09)
+        # 0x08: NOP (this would run if no jump)
+        struct.pack_into(">I", prog, 0x08, 0)
+        # 0x0C: NOP
+        struct.pack_into(">I", prog, 0x0C, 0)
+        # 0x10: HALT (jump target)
+        struct.pack_into(">I", prog, 0x10, 0x0000_000C)
+        sim = MIPSSimulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        # $ra should be 0x08 (return address = instruction after JALR)
+        assert sim._regs[REG_RA] == 0x08
+
+
+# ── HI / LO ───────────────────────────────────────────────────────────────────
+
+class TestHiLo:
+
+    def test_mthi_mfhi(self):
+        """MTHI / MFHI round-trip."""
+        prog  = mk_i(0x09, 0, 8, 0x1234)   # ADDIU $t0, $zero, 0x1234
+        prog += R(8, 0, 0, 0, 0x11)      # MTHI $t0
+        prog += R(0, 0, 9, 0, 0x10)      # MFHI $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 0x1234
+        assert sim._hi == 0x1234
+
+    def test_mtlo_mflo(self):
+        """MTLO / MFLO round-trip."""
+        prog  = mk_i(0x09, 0, 8, 0x5678)
+        prog += R(8, 0, 0, 0, 0x13)      # MTLO $t0
+        prog += R(0, 0, 9, 0, 0x12)      # MFLO $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 0x5678
+
+    def test_mult_result_in_hi_lo(self):
+        """MULT $t0, $t1 — 3 * 4 = 12 → LO=12, HI=0."""
+        prog  = mk_i(0x09, 0, 8, 3)
+        prog += mk_i(0x09, 0, 9, 4)
+        prog += R(8, 9, 0, 0, 0x18)      # MULT $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._lo == 12
+        assert sim._hi == 0
+
+    def test_multu_large(self):
+        """MULTU 0xFFFFFFFF × 0xFFFFFFFF — result spans HI:LO."""
+        # 0xFFFFFFFF * 0xFFFFFFFF = 0xFFFFFFFE_00000001
+        # Load 0xFFFFFFFF = -1 unsigned, using LUI + ORI
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0xFFFF)  # LUI $t0, 0xFFFF
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xFFFF)  # ORI $t0,$t0,0xFFFF
+        prog += w32((0x0F << 26) | (0 << 21) | (9 << 16) | 0xFFFF)  # LUI $t1, 0xFFFF
+        prog += w32((0x0D << 26) | (9 << 21) | (9 << 16) | 0xFFFF)  # ORI $t1,$t1,0xFFFF
+        prog += R(8, 9, 0, 0, 0x19)      # MULTU $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._lo == 0x0000_0001
+        assert sim._hi == 0xFFFF_FFFE
+
+    def test_divu_quotient_remainder(self):
+        """DIVU $t0, $t1 — 17 / 5 = quotient 3, remainder 2."""
+        prog  = mk_i(0x09, 0, 8, 17)
+        prog += mk_i(0x09, 0, 9, 5)
+        prog += R(8, 9, 0, 0, 0x1B)      # DIVU $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._lo == 3   # quotient
+        assert sim._hi == 2   # remainder
+
+    def test_div_signed(self):
+        """DIV $t0, $t1 — (-17) / 5 = quotient -3, remainder -2."""
+        prog  = mk_i(0x09, 0, 8, 0xFFEF)   # ADDIU $t0, $zero, -17 (sext: 0xFFFFFFEF)
+        prog += mk_i(0x09, 0, 9, 5)
+        prog += R(8, 9, 0, 0, 0x1A)      # DIV $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        # -17 / 5 = -3 remainder -2 (truncate toward zero)
+        assert sim._lo == 0xFFFF_FFFD   # -3 unsigned
+        assert sim._hi == 0xFFFF_FFFE   # -2 unsigned
+
+
+# ── ALU: ADD / ADDU / SUB / SUBU ─────────────────────────────────────────────
+
+class TestArithmetic:
+
+    def test_addu_no_overflow(self):
+        """ADDU $t2, $t0, $t1 — 10 + 20 = 30."""
+        prog  = mk_i(0x09, 0, 8, 10)
+        prog += mk_i(0x09, 0, 9, 20)
+        prog += R(8, 9, 10, 0, 0x21)     # ADDU $t2, $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 30
+
+    def test_addu_wraps_silently(self):
+        """ADDU wraps on 32-bit overflow without raising."""
+        # 0xFFFFFFFF + 1 = 0x00000000 with wrap
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0xFFFF)  # LUI $t0,0xFFFF
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xFFFF)  # ORI $t0,$t0,0xFFFF
+        prog += mk_i(0x09, 0, 9, 1)                                      # ADDIU $t1,0,1
+        prog += R(8, 9, 10, 0, 0x21)                                  # ADDU $t2,$t0,$t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0
+
+    def test_subu_basic(self):
+        """SUBU $t2, $t0, $t1 — 20 - 7 = 13."""
+        prog  = mk_i(0x09, 0, 8, 20)
+        prog += mk_i(0x09, 0, 9, 7)
+        prog += R(8, 9, 10, 0, 0x23)     # SUBU $t2, $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 13
+
+    def test_subu_wraps_to_large_positive(self):
+        """SUBU 0 - 1 wraps to 0xFFFFFFFF (large unsigned)."""
+        prog  = mk_i(0x09, 0, 9, 1)
+        prog += R(0, 9, 10, 0, 0x23)     # SUBU $t2, $zero, $t1 → 0 - 1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0xFFFF_FFFF
+
+
+# ── Logic ─────────────────────────────────────────────────────────────────────
+
+class TestLogic:
+
+    def test_and(self):
+        prog  = mk_i(0x09, 0, 8, 0xFF)
+        prog += mk_i(0x09, 0, 9, 0x0F)
+        prog += R(8, 9, 10, 0, 0x24)     # AND $t2, $t0, $t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0x0F
+
+    def test_or(self):
+        prog  = mk_i(0x09, 0, 8, 0xF0)
+        prog += mk_i(0x09, 0, 9, 0x0F)
+        prog += R(8, 9, 10, 0, 0x25)     # OR
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0xFF
+
+    def test_xor(self):
+        prog  = mk_i(0x09, 0, 8, 0xFF)
+        prog += mk_i(0x09, 0, 9, 0x0F)
+        prog += R(8, 9, 10, 0, 0x26)     # XOR
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0xF0
+
+    def test_nor(self):
+        """NOR $t2, $zero, $zero → 0xFFFFFFFF (NOT 0)."""
+        prog  = R(0, 0, 10, 0, 0x27)     # NOR $t2, $zero, $zero = ~(0|0)
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0xFFFF_FFFF
+
+    def test_nor_nonzero_inputs(self):
+        """NOR $t2, $t0, $t1 = ~(0xFF | 0x0F) = 0xFFFFFF00."""
+        prog  = mk_i(0x09, 0, 8, 0xFF)
+        prog += mk_i(0x09, 0, 9, 0x0F)
+        prog += R(8, 9, 10, 0, 0x27)
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0xFFFF_FF00
+
+
+# ── Set-less-than ─────────────────────────────────────────────────────────────
+
+class TestSetLessThan:
+
+    def test_slt_less(self):
+        """SLT: signed -1 < 1 → 1."""
+        prog  = mk_i(0x09, 0, 8, 0xFFFF)   # ADDIU $t0,$zero,-1 (signed)
+        prog += mk_i(0x09, 0, 9, 1)
+        prog += R(8, 9, 10, 0, 0x2A)    # SLT $t2,$t0,$t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 1
+
+    def test_slt_not_less(self):
+        """SLT: 5 < 3 → 0."""
+        prog  = mk_i(0x09, 0, 8, 5)
+        prog += mk_i(0x09, 0, 9, 3)
+        prog += R(8, 9, 10, 0, 0x2A)
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0
+
+    def test_sltu_unsigned_comparison(self):
+        """SLTU: 0xFFFFFFFF > 1 unsigned → 0 (large uint is NOT less than 1)."""
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0xFFFF)  # LUI
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xFFFF)  # ORI → 0xFFFFFFFF
+        prog += mk_i(0x09, 0, 9, 1)
+        prog += R(8, 9, 10, 0, 0x2B)    # SLTU $t2,$t0,$t1  (0xFFFFFFFF < 1?)
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 0       # No: 0xFFFFFFFF > 1 unsigned
+
+    def test_sltu_less(self):
+        """SLTU: 1 < 0xFFFFFFFF unsigned → 1."""
+        prog  = mk_i(0x09, 0, 8, 1)
+        prog += w32((0x0F << 26) | (0 << 21) | (9 << 16) | 0xFFFF)  # LUI $t1,0xFFFF
+        prog += w32((0x0D << 26) | (9 << 21) | (9 << 16) | 0xFFFF)  # ORI $t1,$t1,0xFFFF
+        prog += R(8, 9, 10, 0, 0x2B)    # SLTU $t2,$t0,$t1
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 1
+
+
+# ── I-type immediate ALU ──────────────────────────────────────────────────────
+
+class TestImmediateALU:
+
+    def test_addiu_positive(self):
+        prog = mk_i(0x09, 0, 8, 42) + HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 42
+
+    def test_addiu_negative(self):
+        """ADDIU with sign-extended negative immediate."""
+        prog = mk_i(0x09, 0, 8, 0xFFFF) + HALT  # -1
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 0xFFFF_FFFF
+
+    def test_addiu_wraps(self):
+        """ADDIU wraps on overflow (unlike ADDI)."""
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0x7FFF)  # LUI $t0, 0x7FFF
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xFFFF)  # ORI → 0x7FFFFFFF
+        prog += mk_i(0x09, 8, 8, 1)   # ADDIU $t0,$t0,1 → wraps to 0x80000000
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 0x8000_0000
+
+    def test_slti_signed(self):
+        """SLTI: signed -1 < 1 → 1."""
+        prog = mk_i(0x09, 0, 8, 0xFFFF) + mk_i(0x0A, 8, 9, 1) + HALT  # SLTI $t1,$t0,1
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 1
+
+    def test_sltiu_unsigned(self):
+        """SLTIU: treats immediate as unsigned (sign-extended but compared unsigned)."""
+        # 5 < 10 → 1
+        prog = mk_i(0x09, 0, 8, 5) + mk_i(0x0B, 8, 9, 10) + HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 1
+
+    def test_andi_zero_extend(self):
+        """ANDI zero-extends imm16 (no sign extension)."""
+        prog  = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0xFFFF)  # LUI $t0,0xFFFF
+        prog += w32((0x0D << 26) | (8 << 21) | (8 << 16) | 0xFFFF)  # ORI → 0xFFFFFFFF
+        prog += mk_i(0x0C, 8, 9, 0x00FF)   # ANDI $t1, $t0, 0xFF
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 0xFF     # upper 24 bits cleared
+
+    def test_ori_zero_extend(self):
+        """ORI zero-extends imm16."""
+        prog = mk_i(0x0D, 0, 9, 0xABCD) + HALT  # ORI $t1, $zero, 0xABCD
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 0xABCD
+
+    def test_xori(self):
+        prog = mk_i(0x09, 0, 8, 0xFF) + mk_i(0x0E, 8, 9, 0x0F) + HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 0xF0
+
+    def test_lui(self):
+        """LUI $t0, 0xDEAD — loads upper 16 bits, lower 16 bits are 0."""
+        prog = w32((0x0F << 26) | (0 << 21) | (8 << 16) | 0xDEAD) + HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[8] == 0xDEAD_0000
+
+
+# ── Branches ──────────────────────────────────────────────────────────────────
+
+class TestBranches:
+    """Branch target = (PC + 4) + sext(imm16) * 4.
+    Since PC is already advanced to PC+4 by _fetch32, the formula in the
+    simulator is: new_PC = self._pc + (simm << 2).
+    """
+
+    def _make_branch_skip(self, op: int, rs: int, rt: int, skip_offset: int) -> bytes:
+        """Build a branch that jumps over 'skip_offset' instructions if taken."""
+        # The branch is at addr 0, PC advances to 4.  If taken, target = 4 + skip_offset*4.
+        return mk_i(op, rs, rt, skip_offset)
+
+    def test_beq_taken(self):
+        """BEQ $t0, $t1, +1  — both zero, branch skips 1 instruction."""
+        # BEQ at 0x00: $zero==$zero → jump to PC+4+4 = 0x08; NOP at 0x04 (skipped); HALT at 0x08
+        prog  = mk_i(0x04, 0, 0, 1) + NOP + HALT   # BEQ $zero,$zero,+1; NOP; HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.ok
+        assert result.steps == 2   # BEQ + HALT (NOP skipped)
+
+    def test_beq_not_taken(self):
+        """BEQ $t0, $t1  — different values → not taken."""
+        prog  = mk_i(0x09, 0, 8, 1)    # ADDIU $t0,$zero,1
+        prog += mk_i(0x04, 8, 9, 5)    # BEQ $t0,$t1,+5  (t1=0 ≠ t0=1, not taken)
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.ok
+
+    def test_bne_taken(self):
+        """BNE $t0, $zero, +1  — $t0 != 0 → taken."""
+        prog  = mk_i(0x09, 0, 8, 1)    # ADDIU $t0,$zero,1
+        prog += mk_i(0x05, 8, 0, 1)    # BNE $t0,$zero,+1
+        prog += NOP                  # skipped if taken
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.steps == 3   # ADDIU + BNE + HALT
+
+    def test_bne_not_taken(self):
+        """BNE $zero, $zero, +1  — both zero → not taken."""
+        prog  = mk_i(0x05, 0, 0, 10)   # BNE $zero,$zero,+10 (not taken)
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.steps == 2   # BNE + HALT
+
+    def test_blez_taken_zero(self):
+        """BLEZ $zero, +1  — 0 <= 0 → taken."""
+        prog  = mk_i(0x06, 0, 0, 1)    # BLEZ $zero,+1
+        prog += NOP                  # skipped
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.steps == 2
+
+    def test_blez_taken_negative(self):
+        """BLEZ -5, +1  — negative → taken."""
+        prog  = mk_i(0x09, 0, 8, 0xFFFB)  # ADDIU $t0,-5
+        prog += mk_i(0x06, 8, 0, 1)        # BLEZ $t0,+1
+        prog += NOP
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.steps == 3   # ADDIU + BLEZ + HALT
+
+    def test_bgtz_taken(self):
+        """BGTZ $t0, +1  — positive → taken."""
+        prog  = mk_i(0x09, 0, 8, 5)
+        prog += mk_i(0x07, 8, 0, 1)    # BGTZ $t0,+1
+        prog += NOP
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.steps == 3   # ADDIU + BGTZ + HALT
+
+    def test_bgtz_not_taken_zero(self):
+        """BGTZ $zero, +1  — 0 is not > 0 → not taken."""
+        prog  = mk_i(0x07, 0, 0, 1) + HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.steps == 2
+
+    def test_bltz_taken(self):
+        """BLTZ $t0, +1  — negative → taken."""
+        prog  = mk_i(0x09, 0, 8, 0xFFFF)  # -1
+        prog += mk_i(0x01, 8, 0, 1)        # BLTZ $t0,+1
+        prog += NOP
+        prog += HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.steps == 3
+
+    def test_bgez_taken_zero(self):
+        """BGEZ $zero, +1  — 0 >= 0 → taken."""
+        prog  = mk_i(0x01, 0, 1, 1) + NOP + HALT   # BGEZ $zero,+1
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.steps == 2
+
+
+# ── Loads and Stores ──────────────────────────────────────────────────────────
+
+class TestLoadStore:
+
+    def _load_store_sim(self) -> MIPSSimulator:
+        """Return a fresh sim with some data in memory at 0x0100."""
+        sim = MIPSSimulator()
+        sim.reset()
+        return sim
+
+    def test_sw_lw_roundtrip(self):
+        """SW then LW: store 0xDEADBEEF at addr 0x0100, load it back."""
+        addr = 0x0100
+        sim = MIPSSimulator()
+        # Manually set register and store
+        sim.load(HALT)   # reset + load minimal program
+        sim._regs[8] = 0xDEAD_BEEF   # $t0 = value
+        sim._regs[9] = addr            # $t1 = address
+        sim._store_word(addr, 0xDEAD_BEEF)
+        loaded = sim._load_word(addr)
+        assert loaded == 0xDEAD_BEEF
+
+    def test_sb_lb_sign_extend(self):
+        """LB sign-extends 0xFF to 0xFFFFFFFF."""
+        sim = MIPSSimulator()
+        # Build program: SW then LB
+        addr = 0x0200
+        # Store byte 0xFF at addr, then LB to $t0
+        prog = bytearray(0x20)
+        # ADDIU $t1, $zero, addr
+        struct.pack_into(">I", prog, 0, (0x09 << 26) | (0 << 21) | (9 << 16) | addr)
+        # ADDIU $t0, $zero, 0xFF
+        struct.pack_into(">I", prog, 4, (0x09 << 26) | (0 << 21) | (8 << 16) | 0xFF)
+        # SB $t0, 0($t1)  — op=0x28, rs=9, rt=8, imm=0
+        struct.pack_into(">I", prog, 8, (0x28 << 26) | (9 << 21) | (8 << 16))
+        # LB $t2, 0($t1)  — op=0x20, rs=9, rt=10, imm=0
+        struct.pack_into(">I", prog, 12, (0x20 << 26) | (9 << 21) | (10 << 16))
+        # HALT
+        struct.pack_into(">I", prog, 16, 0x0000_000C)
+        sim = MIPSSimulator()
+        sim.execute(bytes(prog))
+        assert sim._regs[10] == 0xFFFF_FFFF   # sign-extended 0xFF
+
+    def test_lbu_zero_extend(self):
+        """LBU zero-extends 0xFF to 0x000000FF."""
+        addr = 0x0300
+        prog = bytearray(0x20)
+        struct.pack_into(">I", prog, 0, (0x09 << 26) | (0 << 21) | (9 << 16) | addr)
+        struct.pack_into(">I", prog, 4, (0x09 << 26) | (0 << 21) | (8 << 16) | 0xFF)
+        struct.pack_into(">I", prog, 8, (0x28 << 26) | (9 << 21) | (8 << 16))   # SB
+        struct.pack_into(">I", prog, 12, (0x24 << 26) | (9 << 21) | (10 << 16)) # LBU
+        struct.pack_into(">I", prog, 16, 0x0000_000C)  # HALT
+        sim = MIPSSimulator()
+        sim.execute(bytes(prog))
+        assert sim._regs[10] == 0xFF   # zero-extended
+
+    def test_sh_lh_sign_extend(self):
+        """LH sign-extends 0x8000 to 0xFFFF8000."""
+        addr = 0x0400
+        prog = bytearray(0x20)
+        struct.pack_into(">I", prog, 0, (0x09 << 26) | (0 << 21) | (9 << 16) | addr)
+        struct.pack_into(">I", prog, 4, (0x0F << 26) | (0 << 21) | (8 << 16) | 0x0000)
+        struct.pack_into(">I", prog, 8, (0x0D << 26) | (8 << 21) | (8 << 16) | 0x8000)  # ORI $t0,0x8000
+        struct.pack_into(">I", prog, 12, (0x29 << 26) | (9 << 21) | (8 << 16))   # SH $t0,0($t1)
+        struct.pack_into(">I", prog, 16, (0x21 << 26) | (9 << 21) | (10 << 16))  # LH $t2,0($t1)
+        struct.pack_into(">I", prog, 20, 0x0000_000C)
+        sim = MIPSSimulator()
+        sim.execute(bytes(prog))
+        assert sim._regs[10] == 0xFFFF_8000
+
+    def test_lhu_zero_extend(self):
+        """LHU zero-extends 0x8000 to 0x00008000."""
+        addr = 0x0500
+        prog = bytearray(0x24)
+        struct.pack_into(">I", prog, 0, (0x09 << 26) | (0 << 21) | (9 << 16) | addr)
+        struct.pack_into(">I", prog, 4, (0x0D << 26) | (0 << 21) | (8 << 16) | 0x8000)  # ORI $t0,0x8000
+        struct.pack_into(">I", prog, 8, (0x29 << 26) | (9 << 21) | (8 << 16))    # SH
+        struct.pack_into(">I", prog, 12, (0x25 << 26) | (9 << 21) | (10 << 16))  # LHU
+        struct.pack_into(">I", prog, 16, 0x0000_000C)
+        sim = MIPSSimulator()
+        sim.execute(bytes(prog))
+        assert sim._regs[10] == 0x8000
+
+
+# ── J-type jumps ──────────────────────────────────────────────────────────────
+
+class TestJType:
+
+    def test_j_absolute_jump(self):
+        """J target — jumps to (PC+4)[31:28] | (target << 2)."""
+        # Layout: NOP at 0, J to 8 at 4, NOP at 8 (skipped), HALT at 12
+        # But wait: J target = (PC+4)[31:28] | (target26 << 2)
+        # PC+4 = 0x0008 after fetch of J at addr 4.
+        # target26 for addr 0x000C: (0x000C >> 2) = 3
+        # (0x0008 & 0xF000) | (3 << 2) = 0x000C
+        prog  = NOP                              # 0x0000
+        prog += J(0x02, 3)                       # 0x0004: J to 0x000C
+        prog += NOP                              # 0x0008: skipped
+        prog += HALT                             # 0x000C: HALT
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.ok
+        assert result.steps == 3   # NOP + J + HALT (middle NOP skipped)
+
+    def test_jal_sets_ra(self):
+        """JAL sets $ra = PC+4 (return address)."""
+        # JAL to 0x0010; $ra should = 0x0008 (addr after JAL)
+        prog = bytearray(0x14)
+        struct.pack_into(">I", prog, 0x00, 0x0000_0000)                      # NOP
+        struct.pack_into(">I", prog, 0x04, (0x03 << 26) | 4)                 # JAL to 0x10
+        # (PC+4 after JAL at 0x04 = 0x08; target = 0x08 & 0xF000 | (4<<2) = 0x10)
+        struct.pack_into(">I", prog, 0x08, 0x0000_0000)                      # NOP (skipped)
+        struct.pack_into(">I", prog, 0x0C, 0x0000_0000)                      # NOP (skipped)
+        struct.pack_into(">I", prog, 0x10, 0x0000_000C)                      # HALT
+        sim = MIPSSimulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._regs[REG_RA] == 0x0008   # return addr = after JAL

--- a/code/packages/python/mips-r2000-simulator/tests/test_programs.py
+++ b/code/packages/python/mips-r2000-simulator/tests/test_programs.py
@@ -1,0 +1,507 @@
+"""End-to-end program tests for the MIPS R2000 simulator.
+
+Each test encodes a complete small program in MIPS machine code and verifies
+the final CPU/memory state.  These tests exercise instructions working together
+rather than in isolation.
+
+MIPS instruction encoding recap:
+  R-type: [op:6=0][rs:5][rt:5][rd:5][shamt:5][funct:6]
+  I-type: [op:6][rs:5][rt:5][imm16:16]
+  J-type: [op:6][target26:26]
+
+Branch target (no delay slots in this simulator):
+  target = self._pc + sext(imm16) * 4   (PC is already at PC+4 after fetch)
+
+All programs use big-endian encoding via struct.pack(">I", word).
+"""
+
+from __future__ import annotations
+
+import struct
+
+from mips_r2000_simulator import MIPSSimulator
+from mips_r2000_simulator.state import REG_RA, REG_SP
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def w32(v: int) -> bytes:
+    """Pack a 32-bit MIPS word as 4 big-endian bytes."""
+    return struct.pack(">I", v & 0xFFFF_FFFF)
+
+
+HALT  = w32(0x0000_000C)   # SYSCALL
+NOP   = w32(0x0000_0000)   # SLL $zero,$zero,0
+
+
+def addiu(rt: int, rs: int, imm: int) -> bytes:
+    """ADDIU rt, rs, imm  — op=9."""
+    return w32((0x09 << 26) | (rs << 21) | (rt << 16) | (imm & 0xFFFF))
+
+
+def addu(rd: int, rs: int, rt: int) -> bytes:
+    """ADDU rd, rs, rt  — R-type funct=0x21."""
+    return w32((rs << 21) | (rt << 16) | (rd << 11) | 0x21)
+
+
+def subu(rd: int, rs: int, rt: int) -> bytes:
+    """SUBU rd, rs, rt  — R-type funct=0x23."""
+    return w32((rs << 21) | (rt << 16) | (rd << 11) | 0x23)
+
+
+def bne(rs: int, rt: int, offset: int) -> bytes:
+    """BNE rs, rt, offset  — op=5.  offset in *instructions* (not bytes)."""
+    return w32((0x05 << 26) | (rs << 21) | (rt << 16) | (offset & 0xFFFF))
+
+
+def beq(rs: int, rt: int, offset: int) -> bytes:
+    """BEQ rs, rt, offset  — op=4."""
+    return w32((0x04 << 26) | (rs << 21) | (rt << 16) | (offset & 0xFFFF))
+
+
+def lw(rt: int, base: int, offset: int) -> bytes:
+    """LW rt, offset(base)  — op=0x23."""
+    return w32((0x23 << 26) | (base << 21) | (rt << 16) | (offset & 0xFFFF))
+
+
+def sw(rt: int, base: int, offset: int) -> bytes:
+    """SW rt, offset(base)  — op=0x2B."""
+    return w32((0x2B << 26) | (base << 21) | (rt << 16) | (offset & 0xFFFF))
+
+
+def lb(rt: int, base: int, offset: int) -> bytes:
+    """LB rt, offset(base)  — op=0x20 (sign-extend)."""
+    return w32((0x20 << 26) | (base << 21) | (rt << 16) | (offset & 0xFFFF))
+
+
+def sb(rt: int, base: int, offset: int) -> bytes:
+    """SB rt, offset(base)  — op=0x28."""
+    return w32((0x28 << 26) | (base << 21) | (rt << 16) | (offset & 0xFFFF))
+
+
+def slt(rd: int, rs: int, rt: int) -> bytes:
+    """SLT rd, rs, rt  — R-type funct=0x2A."""
+    return w32((rs << 21) | (rt << 16) | (rd << 11) | 0x2A)
+
+
+def mult(rs: int, rt: int) -> bytes:
+    """MULT rs, rt  — R-type funct=0x18."""
+    return w32((rs << 21) | (rt << 16) | 0x18)
+
+
+def mflo(rd: int) -> bytes:
+    """MFLO rd  — R-type funct=0x12."""
+    return w32((rd << 11) | 0x12)
+
+
+def mfhi(rd: int) -> bytes:
+    """MFHI rd  — R-type funct=0x10."""
+    return w32((rd << 11) | 0x10)
+
+
+def jal_to(pc_of_jal: int, target_addr: int) -> bytes:
+    """Build JAL instruction to jump from pc_of_jal to target_addr.
+
+    JAL target:  target_26 = target_addr >> 2  (low 26 bits of word address)
+    Actual jump: (PC+4)[31:28] | (target_26 << 2) — for small addresses this
+    just equals target_addr.
+    """
+    target26 = (target_addr >> 2) & 0x03FF_FFFF
+    return w32((0x03 << 26) | target26)
+
+
+def jr_ra() -> bytes:
+    """JR $ra  — R-type funct=0x08, rs=REG_RA=31."""
+    return w32((REG_RA << 21) | 0x08)
+
+
+# ── Programs ──────────────────────────────────────────────────────────────────
+
+class TestSumProgram:
+
+    def test_sum_1_to_10(self):
+        """Compute 1+2+…+10 = 55.
+
+        Register layout:
+          $t0 (8) = counter (starts 10, decrements to 0)
+          $t1 (9) = running sum (starts 0)
+
+        Program:
+          0x00: ADDIU $t0, $zero, 10   — counter = 10
+          0x04: ADDU  $t1, $t1, $t0   — sum += counter
+          0x08: ADDIU $t0, $t0, -1    — counter--
+          0x0C: BNE   $t0, $zero, -3  — if counter != 0, go back to 0x04
+          0x10: HALT
+
+        Branch at 0x0C: PC after fetch = 0x10; offset = -3 words → 0x10 + (-3*4) = 0x04 ✓
+        """
+        prog  = addiu(8, 0, 10)           # 0x00: $t0 = 10
+        prog += addu(9, 9, 8)             # 0x04: $t1 += $t0
+        prog += addiu(8, 8, 0xFFFF)       # 0x08: $t0-- (ADDIU $t0,$t0,-1)
+        prog += bne(8, 0, 0xFFFF - 2)     # 0x0C: BNE $t0,$zero,-3
+        prog += HALT                       # 0x10
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 55
+
+
+class TestMultiply:
+
+    def test_multiply_via_mult(self):
+        """7 × 6 = 42 using MULT instruction."""
+        prog  = addiu(8, 0, 7)
+        prog += addiu(9, 0, 6)
+        prog += mult(8, 9)
+        prog += mflo(10)
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[10] == 42
+
+    def test_multiply_by_repeated_addition(self):
+        """7 × 6 = 42 using a loop.
+
+          $t0 = multiplier (6)
+          $t1 = result (starts 0)
+          Loop: $t1 += 7; $t0--; BNE $t0,$zero,loop
+
+          0x00: ADDIU $t0, $zero, 6
+          0x04: ADDIU $t2, $zero, 7    — constant factor
+          0x08: ADDU  $t1, $t1, $t2   — loop: result += 7
+          0x0C: ADDIU $t0, $t0, -1    — counter--
+          0x10: BNE   $t0, $zero, -3  — PC=0x14; -3*4= -12; target=0x14-12=0x08 ✓
+          0x14: HALT
+        """
+        prog  = addiu(8, 0, 6)            # $t0 = 6
+        prog += addiu(10, 0, 7)           # $t2 = 7
+        prog += addu(9, 9, 10)            # loop top (0x08): $t1 += $t2
+        prog += addiu(8, 8, 0xFFFF)       # $t0--
+        prog += bne(8, 0, 0xFFFF - 2)     # BNE back 3 instrs
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 42
+
+    def test_factorial_5_via_mult(self):
+        """5! = 120 using MULT.
+
+        Strategy: start $t1=1; loop $t0=5 downto 1; each iter MULT $t1,$t0 → LO.
+
+          $t0 (8) = current multiplier (5 downto 1)
+          $t1 (9) = running product (start 1)
+
+          0x00: ADDIU $t0, $zero, 5
+          0x04: ADDIU $t1, $zero, 1
+          0x08: MULT  $t1, $t0          — loop top
+          0x0C: MFLO  $t1
+          0x10: ADDIU $t0, $t0, -1
+          0x14: BNE   $t0, $zero, -4   — PC=0x18; -4*4=-16; target=0x18-16=0x08 ✓
+          0x18: HALT
+        """
+        prog  = addiu(8, 0, 5)            # $t0 = 5
+        prog += addiu(9, 0, 1)            # $t1 = 1
+        prog += mult(9, 8)                # loop top (0x08): HI:LO = $t1 * $t0
+        prog += mflo(9)                   # $t1 = LO
+        prog += addiu(8, 8, 0xFFFF)       # $t0--
+        prog += bne(8, 0, 0xFFFF - 3)     # BNE back 4 instructions
+        prog += HALT
+        sim = MIPSSimulator()
+        sim.execute(prog)
+        assert sim._regs[9] == 120
+
+
+class TestMemoryPrograms:
+
+    def test_word_copy(self):
+        """Copy 4 words from memory[0x0100] to memory[0x0200].
+
+        Register layout:
+          $t0 (8) = source pointer
+          $t1 (9) = dest pointer
+          $t2 (10) = counter (4)
+          $t3 (11) = temp value
+
+          0x00: ADDIU $t0, $zero, 0x100
+          0x04: ADDIU $t1, $zero, 0x200
+          0x08: ADDIU $t2, $zero, 4
+          0x0C: LW    $t3, 0($t0)        — loop top
+          0x10: SW    $t3, 0($t1)
+          0x14: ADDIU $t0, $t0, 4
+          0x18: ADDIU $t1, $t1, 4
+          0x1C: ADDIU $t2, $t2, -1
+          0x20: BNE   $t2, $zero, -6    — PC=0x24; -6*4=-24; target=0x24-24=0x0C ✓
+          0x24: HALT
+        """
+        prog  = addiu(8, 0, 0x100)        # 0x00
+        prog += addiu(9, 0, 0x200)        # 0x04
+        prog += addiu(10, 0, 4)           # 0x08
+        prog += lw(11, 8, 0)             # 0x0C: loop top
+        prog += sw(11, 9, 0)             # 0x10
+        prog += addiu(8, 8, 4)           # 0x14
+        prog += addiu(9, 9, 4)           # 0x18
+        prog += addiu(10, 10, 0xFFFF)    # 0x1C: $t2--
+        prog += bne(10, 0, 0xFFFF - 5)   # 0x20: BNE back 6 instrs
+        prog += HALT                       # 0x24
+
+        sim = MIPSSimulator()
+        sim.load(prog)
+        # Manually write source data after load (load calls reset)
+        src = [0x11223344, 0xAABBCCDD, 0xDEADBEEF, 0x0BADF00D]
+        for i, val in enumerate(src):
+            sim._store_word(0x100 + i * 4, val)
+        while not sim._halted:
+            sim.step()
+        for i, val in enumerate(src):
+            assert sim._load_word(0x200 + i * 4) == val
+
+    def test_byte_copy(self):
+        """Copy 8 bytes from memory[0x0400] to memory[0x0500] using LB/SB.
+
+          $t0 = src (0x400), $t1 = dst (0x500), $t2 = count (8)
+
+          Loop:
+            LB  $t3, 0($t0)
+            SB  $t3, 0($t1)
+            ADDIU $t0, $t0, 1
+            ADDIU $t1, $t1, 1
+            ADDIU $t2, $t2, -1
+            BNE $t2, $zero, back_to_LB
+        """
+        prog  = addiu(8, 0, 0x400)
+        prog += addiu(9, 0, 0x500)
+        prog += addiu(10, 0, 8)
+        prog += lb(11, 8, 0)             # loop top (0x0C)
+        prog += sb(11, 9, 0)
+        prog += addiu(8, 8, 1)
+        prog += addiu(9, 9, 1)
+        prog += addiu(10, 10, 0xFFFF)
+        prog += bne(10, 0, 0xFFFF - 5)   # BNE back 6 instrs
+        prog += HALT
+
+        sim = MIPSSimulator()
+        sim.load(prog)
+        source = bytes(range(8))
+        for i, b in enumerate(source):
+            sim._mem[0x400 + i] = b
+        while not sim._halted:
+            sim.step()
+        for i, b in enumerate(source):
+            assert sim._mem[0x500 + i] == b
+
+
+class TestSubroutinePrograms:
+
+    def test_simple_subroutine(self):
+        """Call a subroutine that doubles $t0; verify $ra and result.
+
+        Main at 0x00; subroutine at 0x10.
+
+          0x00: ADDIU $t0, $zero, 7     — argument
+          0x04: JAL   0x10              — call double($t0)
+          0x08: HALT
+          (gap: 0x0C is skipped)
+          0x10: ADDU $t0, $t0, $t0     — $t0 = $t0 + $t0
+          0x14: JR   $ra               — return
+        """
+        prog = bytearray(0x18)
+        struct.pack_into(">I", prog, 0x00, (0x09 << 26) | (0 << 21) | (8 << 16) | 7)  # ADDIU $t0,7
+        # JAL to 0x10: target26 = 0x10 >> 2 = 4; (PC+4)=0x08; (0x08 & 0xF000)|(4<<2)=0x10 ✓
+        struct.pack_into(">I", prog, 0x04, (0x03 << 26) | 4)   # JAL 0x10
+        struct.pack_into(">I", prog, 0x08, 0x0000_000C)          # HALT
+        struct.pack_into(">I", prog, 0x0C, 0x0000_0000)          # NOP (padding)
+        # Subroutine at 0x10
+        struct.pack_into(">I", prog, 0x10, (8 << 21) | (8 << 16) | (8 << 11) | 0x21)  # ADDU $t0,$t0,$t0
+        struct.pack_into(">I", prog, 0x14, (REG_RA << 21) | 0x08)  # JR $ra
+        sim = MIPSSimulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._regs[8] == 14      # 7 * 2
+        assert sim._regs[REG_RA] == 0x08   # return address
+
+    def test_stack_balance_after_nested_calls(self):
+        """Nested call leaves stack pointer unchanged.
+
+        We use $sp to track a "manual" stack.  On a bare simulator reset,
+        $sp = 0.  We set $sp to 0x1000, call an outer subroutine that calls
+        an inner one.  After both return, $sp should still be 0x1000.
+
+        Here we use the standard convention:
+          ADDIU $sp, $sp, -4  ; push
+          SW $ra, 0($sp)      ; save $ra
+          ...
+          LW $ra, 0($sp)      ; restore $ra
+          ADDIU $sp, $sp, 4   ; pop
+          JR $ra              ; return
+
+        Main:
+          0x00: ADDIU $sp, $zero, 0x1000
+          0x04: JAL outer (0x20)
+          0x08: HALT
+
+        Outer at 0x20:
+          0x20: ADDIU $sp, $sp, -4
+          0x24: SW    $ra, 0($sp)
+          0x28: JAL inner (0x40)
+          0x2C: LW    $ra, 0($sp)
+          0x30: ADDIU $sp, $sp, 4
+          0x34: JR    $ra
+
+        Inner at 0x40:
+          0x40: NOP
+          0x44: JR    $ra
+        """
+        prog = bytearray(0x48)
+        # Main
+        struct.pack_into(">I", prog, 0x00, (0x09 << 26) | (0 << 21) | (REG_SP << 16) | 0x1000)  # ADDIU $sp,0x1000
+        struct.pack_into(">I", prog, 0x04, (0x03 << 26) | 8)    # JAL to 0x20 (8<<2=0x20)
+        struct.pack_into(">I", prog, 0x08, 0x0000_000C)           # HALT
+        # Pad gap 0x0C–0x1C
+        for off in range(0x0C, 0x20, 4):
+            struct.pack_into(">I", prog, off, 0)
+        # Outer at 0x20
+        struct.pack_into(">I", prog, 0x20, (0x09 << 26) | (REG_SP << 21) | (REG_SP << 16) | 0xFFFC)  # ADDIU $sp,$sp,-4
+        struct.pack_into(">I", prog, 0x24, (0x2B << 26) | (REG_SP << 21) | (REG_RA << 16) | 0)        # SW $ra, 0($sp)
+        struct.pack_into(">I", prog, 0x28, (0x03 << 26) | 16)   # JAL to 0x40 (16<<2=0x40)
+        struct.pack_into(">I", prog, 0x2C, (0x23 << 26) | (REG_SP << 21) | (REG_RA << 16) | 0)        # LW $ra, 0($sp)
+        struct.pack_into(">I", prog, 0x30, (0x09 << 26) | (REG_SP << 21) | (REG_SP << 16) | 4)        # ADDIU $sp,$sp,4
+        struct.pack_into(">I", prog, 0x34, (REG_RA << 21) | 0x08)   # JR $ra
+        # Pad 0x38–0x3C
+        for off in range(0x38, 0x40, 4):
+            struct.pack_into(">I", prog, off, 0)
+        # Inner at 0x40
+        struct.pack_into(">I", prog, 0x40, 0)                        # NOP
+        struct.pack_into(">I", prog, 0x44, (REG_RA << 21) | 0x08)   # JR $ra
+        sim = MIPSSimulator()
+        result = sim.execute(bytes(prog))
+        assert result.ok
+        assert sim._regs[REG_SP] == 0x1000
+
+
+class TestFibonacci:
+
+    def test_fibonacci_8_terms_in_memory(self):
+        """Store first 8 Fibonacci numbers in memory[0x0100–0x011F].
+
+        F = 1, 1, 2, 3, 5, 8, 13, 21 (word-sized)
+
+        Strategy: Iterate 6 times computing F[i] = F[i-2] + F[i-1].
+
+          $t0 = pointer to F[0]  (starts at 0x100)
+          $t1 = counter (6 iterations)
+          At each step: load F[i-2] from 0($t0), F[i-1] from 4($t0),
+                        sum into F[i] at 8($t0), then advance $t0 by 4.
+
+          0x00: ADDIU $t0, $zero, 0x100
+          0x04: SW    $zero, 0($t0)       — clear all 8 entries (via 8 SW nops)
+              Actually: store F[0]=1 and F[1]=1 first.
+          0x04: ADDIU $t2, $zero, 1
+          0x08: SW    $t2, 0($t0)         — F[0]=1
+          0x0C: SW    $t2, 4($t0)         — F[1]=1
+          0x10: ADDIU $t1, $zero, 6       — 6 more terms
+          Loop at 0x14:
+          0x14: LW    $t3, 0($t0)         — F[i-2]
+          0x18: LW    $t4, 4($t0)         — F[i-1]
+          0x1C: ADDU  $t5, $t3, $t4       — F[i]
+          0x20: SW    $t5, 8($t0)         — store F[i]
+          0x24: ADDIU $t0, $t0, 4         — advance pointer
+          0x28: ADDIU $t1, $t1, -1
+          0x2C: BNE   $t1, $zero, -6     — PC=0x30; -6*4=-24; target=0x30-24=0x18
+              Wait: loop top is at 0x14, so we need -7 to go back to 0x14
+              PC after BNE fetch = 0x30; offset = -7 → 0x30 - 28 = 0x14 ✓
+          0x30: HALT
+        """
+        prog  = addiu(8, 0, 0x100)        # 0x00: $t0 = 0x100
+        prog += addiu(10, 0, 1)           # 0x04: $t2 = 1
+        prog += sw(10, 8, 0)             # 0x08: mem[0x100] = 1 (F[0])
+        prog += sw(10, 8, 4)             # 0x0C: mem[0x104] = 1 (F[1])
+        prog += addiu(9, 0, 6)           # 0x10: $t1 = 6
+        prog += lw(11, 8, 0)             # 0x14: loop top — F[i-2]
+        prog += lw(12, 8, 4)             # 0x18: F[i-1]
+        prog += addu(13, 11, 12)          # 0x1C: F[i] = F[i-2]+F[i-1]
+        prog += sw(13, 8, 8)             # 0x20: mem[$t0+8] = F[i]
+        prog += addiu(8, 8, 4)           # 0x24: $t0 += 4
+        prog += addiu(9, 9, 0xFFFF)      # 0x28: $t1--
+        prog += bne(9, 0, 0xFFFF - 6)    # 0x2C: BNE back 7 instrs (to 0x14)
+        prog += HALT                       # 0x30
+
+        sim = MIPSSimulator()
+        result = sim.execute(prog)
+        assert result.ok
+        expected = [1, 1, 2, 3, 5, 8, 13, 21]
+        for i, v in enumerate(expected):
+            got = sim._load_word(0x100 + i * 4)
+            assert got == v, f"F[{i}]={got}, expected {v}"
+
+
+class TestSortProgram:
+
+    def test_bubble_sort_4_words(self):
+        """Bubble sort 4 words in memory using SLT + conditional swap.
+
+        Values at 0x0100: [40, 10, 30, 20] → sorted: [10, 20, 30, 40]
+
+        Simple selection sort for clarity:
+          Outer loop i: 0..3
+          Inner loop j: i+1..3
+          If mem[i] > mem[j]: swap
+
+        For simplicity we implement insertion sort in assembly using
+        a loop with SLT and BEQ (branch if already in order).
+
+        Actual program: a simple 3-pass bubble sort.
+        Pass 1: compare [0,1] [1,2] [2,3]
+        Pass 2: compare [0,1] [1,2] [2,3]
+        Pass 3: compare [0,1] [1,2] [2,3]
+
+        Hard-coded 3 passes × 3 compares = 9 compare-swap steps.
+
+        Each compare-swap at addr A and B (adjacent):
+          LW $s0, 0(A)
+          LW $s1, 4(A)
+          SLT $t0, $s1, $s0    — is mem[A+4] < mem[A]?
+          BEQ $t0, $zero, skip — if not, skip swap
+          SW $s1, 0(A)
+          SW $s0, 4(A)
+          skip:
+
+        We'll build this as a flat sequence for 3 passes.
+        """
+        BASE = 0x0100
+
+        def compare_swap(prog: bytearray, offset: int, a_ptr_reg: int) -> bytearray:
+            """Append compare-swap of mem[a_ptr_reg+offset] and mem[a_ptr_reg+offset+4]."""
+            # LW $s0, offset($ptr)
+            prog += lw(16, a_ptr_reg, offset)
+            # LW $s1, offset+4($ptr)
+            prog += lw(17, a_ptr_reg, offset + 4)
+            # SLT $t0, $s1, $s0  — is mem[offset+4] < mem[offset]?
+            prog += slt(8, 17, 16)
+            # BEQ $t0, $zero, +2  — skip the two SWs if already in order
+            prog += beq(8, 0, 2)
+            # SW $s1, offset($ptr)
+            prog += sw(17, a_ptr_reg, offset)
+            # SW $s0, offset+4($ptr)
+            prog += sw(16, a_ptr_reg, offset + 4)
+            # (fall through — no extra NOP needed, BEQ target is here+2*4 = after both SWs)
+            return prog
+
+        # Build program as bytearray
+        prog = b""
+        # Load BASE address into $t2 (10)
+        prog += addiu(10, 0, BASE)
+        # 3 passes × 3 adjacent compares
+        for _ in range(3):
+            for offset in [0, 4, 8]:
+                prog = compare_swap(prog, offset, 10)
+        prog += HALT
+
+        sim = MIPSSimulator()
+        sim.load(prog)
+        # Write unsorted data after load (reset zeroes memory)
+        unsorted = [40, 10, 30, 20]
+        for i, v in enumerate(unsorted):
+            sim._store_word(BASE + i * 4, v)
+        while not sim._halted:
+            sim.step()
+
+        result = [sim._load_word(BASE + i * 4) for i in range(4)]
+        assert result == [10, 20, 30, 40]

--- a/code/packages/python/mips-r2000-simulator/tests/test_protocol.py
+++ b/code/packages/python/mips-r2000-simulator/tests/test_protocol.py
@@ -1,0 +1,280 @@
+"""SIM00 protocol compliance tests for MIPSSimulator.
+
+Verifies that MIPSSimulator implements the Simulator[MIPSState] protocol
+correctly: reset(), load(), step(), execute(), get_state() all behave as
+specified.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+from simulator_protocol import ExecutionResult, Simulator, StepTrace
+
+from mips_r2000_simulator import MIPSSimulator, MIPSState
+
+# ── Encoding helpers ──────────────────────────────────────────────────────────
+
+def w32(v: int) -> bytes:
+    """Pack a 32-bit MIPS instruction as 4 big-endian bytes."""
+    return struct.pack(">I", v & 0xFFFF_FFFF)
+
+
+# HALT = SYSCALL  (op=0, funct=0x0C)
+HALT = w32(0x0000_000C)
+
+# NOP = SLL $zero, $zero, 0  (op=0, funct=0, shamt=0, rd=rt=rs=0)
+NOP = w32(0x0000_0000)
+
+
+def ADDIU_REG(rt: int, rs: int, imm: int) -> bytes:
+    """ADDIU rt, rs, imm  — op=9, no overflow."""
+    imm &= 0xFFFF
+    return w32((0x09 << 26) | (rs << 21) | (rt << 16) | imm)
+
+
+def ADDU(rd: int, rs: int, rt: int) -> bytes:
+    """ADDU rd, rs, rt  — R-type, funct=0x21."""
+    return w32((rs << 21) | (rt << 16) | (rd << 11) | 0x21)
+
+
+# ── Protocol compliance ───────────────────────────────────────────────────────
+
+class TestProtocolCompliance:
+    """MIPSSimulator must satisfy Simulator[MIPSState] structurally."""
+
+    def test_isinstance_simulator(self):
+        sim = MIPSSimulator()
+        assert isinstance(sim, Simulator)
+
+    def test_has_all_protocol_methods(self):
+        sim = MIPSSimulator()
+        assert callable(sim.reset)
+        assert callable(sim.load)
+        assert callable(sim.step)
+        assert callable(sim.execute)
+        assert callable(sim.get_state)
+
+    def test_execute_returns_execution_result(self):
+        sim = MIPSSimulator()
+        result = sim.execute(HALT)
+        assert isinstance(result, ExecutionResult)
+
+    def test_step_returns_step_trace(self):
+        sim = MIPSSimulator()
+        sim.load(NOP + HALT)
+        trace = sim.step()
+        assert isinstance(trace, StepTrace)
+
+    def test_get_state_returns_mips_state(self):
+        sim = MIPSSimulator()
+        state = sim.get_state()
+        assert isinstance(state, MIPSState)
+
+
+# ── Reset ─────────────────────────────────────────────────────────────────────
+
+class TestReset:
+    """reset() must return CPU to well-defined initial state."""
+
+    def test_reset_pc_is_zero(self):
+        sim = MIPSSimulator()
+        sim._pc = 0x1234
+        sim.reset()
+        assert sim._pc == 0x0000
+
+    def test_reset_all_regs_zero(self):
+        sim = MIPSSimulator()
+        sim._regs[8] = 0xDEAD
+        sim._regs[16] = 0xBEEF
+        sim.reset()
+        assert all(r == 0 for r in sim._regs)
+
+    def test_reset_hi_lo_zero(self):
+        sim = MIPSSimulator()
+        sim._hi = 0xFFFF
+        sim._lo = 0xFFFF
+        sim.reset()
+        assert sim._hi == 0
+        assert sim._lo == 0
+
+    def test_reset_memory_zeroed(self):
+        sim = MIPSSimulator()
+        sim._mem[0x100] = 0xAB
+        sim.reset()
+        assert sim._mem[0x100] == 0x00
+
+    def test_reset_clears_halted(self):
+        sim = MIPSSimulator()
+        sim._halted = True
+        sim.reset()
+        assert not sim._halted
+
+    def test_reset_via_get_state(self):
+        sim = MIPSSimulator()
+        state = sim.get_state()
+        assert state.pc == 0x0000
+        assert all(r == 0 for r in state.regs)
+        assert state.hi == 0
+        assert state.lo == 0
+        assert not state.halted
+
+
+# ── Load ──────────────────────────────────────────────────────────────────────
+
+class TestLoad:
+    """load() must reset and copy bytes to memory at 0x0000."""
+
+    def test_load_places_bytes_at_0(self):
+        sim = MIPSSimulator()
+        prog = bytes([0xAB, 0xCD, 0xEF, 0x12])
+        sim.load(prog)
+        assert sim._mem[0] == 0xAB
+        assert sim._mem[1] == 0xCD
+        assert sim._mem[2] == 0xEF
+        assert sim._mem[3] == 0x12
+
+    def test_load_sets_pc_to_zero(self):
+        sim = MIPSSimulator()
+        sim.load(HALT)
+        assert sim._pc == 0x0000
+
+    def test_load_raises_on_overflow(self):
+        sim = MIPSSimulator()
+        with pytest.raises(ValueError):
+            sim.load(bytes(65537))
+
+    def test_load_resets_before_loading(self):
+        sim = MIPSSimulator()
+        sim._regs[8] = 0xAB
+        sim.load(HALT)
+        assert sim._regs[8] == 0x00
+
+    def test_load_exactly_64k_ok(self):
+        sim = MIPSSimulator()
+        sim.load(bytes(65536))   # should not raise
+
+
+# ── Execute ───────────────────────────────────────────────────────────────────
+
+class TestExecute:
+    """execute() must run to HALT and populate ExecutionResult correctly."""
+
+    def test_execute_halt_immediately(self):
+        sim = MIPSSimulator()
+        result = sim.execute(HALT)
+        assert result.ok
+        assert result.halted
+        assert result.error is None
+        assert result.steps == 1
+
+    def test_execute_returns_traces(self):
+        sim = MIPSSimulator()
+        result = sim.execute(HALT)
+        assert len(result.traces) == 1
+        assert result.traces[0].mnemonic == "HALT"
+
+    def test_execute_max_steps_exceeded(self):
+        # BEQ $zero, $zero, -1 → infinite loop (offset -1 in words = -4 bytes)
+        # BEQ: op=4, rs=0, rt=0, imm=0xFFFF (-1 in 16-bit signed = -4 bytes)
+        loop = w32((0x04 << 26) | 0xFFFF)  # BEQ $zero,$zero,-4
+        result = MIPSSimulator().execute(loop + HALT, max_steps=10)
+        assert not result.ok
+        assert result.steps == 10
+        assert "max_steps" in result.error
+
+    def test_execute_sets_final_state(self):
+        sim = MIPSSimulator()
+        result = sim.execute(HALT)
+        assert isinstance(result.final_state, MIPSState)
+        assert result.final_state.halted
+
+    def test_execute_resets_before_running(self):
+        sim = MIPSSimulator()
+        sim._regs[8] = 0xDE
+        result = sim.execute(HALT)
+        assert result.final_state.regs[8] == 0
+
+    def test_execute_nop_then_halt(self):
+        result = MIPSSimulator().execute(NOP + HALT)
+        assert result.ok
+        assert result.steps == 2
+        assert result.traces[0].mnemonic == "NOP"
+        assert result.traces[1].mnemonic == "HALT"
+
+
+# ── GetState ──────────────────────────────────────────────────────────────────
+
+class TestGetState:
+    """get_state() must return an immutable snapshot."""
+
+    def test_get_state_is_frozen(self):
+        import dataclasses
+        sim = MIPSSimulator()
+        state = sim.get_state()
+        with pytest.raises((dataclasses.FrozenInstanceError, TypeError)):
+            state.pc = 0xFF   # type: ignore[misc]
+
+    def test_get_state_snapshot_not_mutated_by_step(self):
+        sim = MIPSSimulator()
+        sim.load(NOP + HALT)
+        state_before = sim.get_state()
+        sim.step()
+        state_after = sim.get_state()
+        assert state_before.pc == 0x0000
+        assert state_after.pc == 0x0004
+
+    def test_get_state_regs_is_tuple(self):
+        sim = MIPSSimulator()
+        state = sim.get_state()
+        assert isinstance(state.regs, tuple)
+        assert len(state.regs) == 32
+
+    def test_get_state_memory_is_tuple(self):
+        sim = MIPSSimulator()
+        state = sim.get_state()
+        assert isinstance(state.memory, tuple)
+        assert len(state.memory) == 65536
+
+    def test_get_state_r0_always_zero(self):
+        sim = MIPSSimulator()
+        state = sim.get_state()
+        assert state.regs[0] == 0
+
+
+# ── Step ──────────────────────────────────────────────────────────────────────
+
+class TestStep:
+    """step() must advance PC by 4 and return correct StepTrace."""
+
+    def test_step_nop_advances_pc_by_4(self):
+        sim = MIPSSimulator()
+        sim.load(NOP + HALT)
+        assert sim._pc == 0x0000
+        sim.step()
+        assert sim._pc == 0x0004
+
+    def test_step_on_halted_cpu_is_noop(self):
+        sim = MIPSSimulator()
+        sim.load(HALT)
+        sim.step()    # executes HALT
+        assert sim._halted
+        pc = sim._pc
+        trace = sim.step()   # should be no-op
+        assert sim._pc == pc
+        assert trace.mnemonic == "HALT"
+
+    def test_step_trace_pc_before_after(self):
+        sim = MIPSSimulator()
+        sim.load(NOP + HALT)
+        trace = sim.step()
+        assert trace.pc_before == 0x0000
+        assert trace.pc_after  == 0x0004
+
+    def test_step_4byte_instruction_advances_pc_by_4(self):
+        sim = MIPSSimulator()
+        # ADDIU $t0, $zero, 0x42  — 4-byte I-type
+        sim.load(ADDIU_REG(8, 0, 0x42) + HALT)
+        sim.step()
+        assert sim._pc == 0x0004

--- a/code/specs/07q-mips-r2000-simulator.md
+++ b/code/specs/07q-mips-r2000-simulator.md
@@ -1,0 +1,365 @@
+# Layer 07q — MIPS R2000 (1985) Behavioral Simulator
+
+## Overview
+
+The MIPS R2000 (1985) is the first commercially successful RISC processor and
+the machine that proved the "Reduced Instruction Set Computer" philosophy viable
+at scale.  Designed by John Hennessy and his Stanford team (later co-founders of
+MIPS Computer Systems), it shipped in SGI IRIS workstations and DEC DECstations,
+and its architecture spawned the MIPS family used in PlayStation 1, PlayStation 2,
+Nintendo 64, and countless embedded systems.
+
+MIPS stands for **Microprocessor without Interlocked Pipeline Stages**.  The name
+captures its design philosophy: a five-stage pipeline (IF→ID→EX→MEM→WB) with no
+hardware interlocks — the programmer (or compiler) is responsible for scheduling
+instructions to avoid data hazards, inserting NOP instructions when needed.
+
+**Historical significance:**
+- First commercial RISC processor (1985)
+- Foundation of Patterson & Hennessy *Computer Organization and Design* textbook
+- 32-bit word-addressable big-endian architecture
+- Used in PlayStation 1, PlayStation 2, Nintendo 64, Cisco routers, many more
+- Directly influenced later RISC designs including SPARC, PA-RISC, and Alpha
+
+---
+
+## Architecture
+
+### Registers
+
+| Name      | Number | ABI Role                        |
+|-----------|--------|---------------------------------|
+| $zero     | R0     | Hardwired zero (writes ignored) |
+| $at       | R1     | Assembler temporary             |
+| $v0–$v1   | R2–R3  | Return values                   |
+| $a0–$a3   | R4–R7  | Function arguments              |
+| $t0–$t7   | R8–R15 | Temporaries (caller-saved)      |
+| $s0–$s7   | R16–R23| Saved registers (callee-saved)  |
+| $t8–$t9   | R24–R25| More temporaries                |
+| $k0–$k1   | R26–R27| Kernel reserved                 |
+| $gp       | R28    | Global pointer                  |
+| $sp       | R29    | Stack pointer                   |
+| $fp ($s8) | R30    | Frame pointer                   |
+| $ra       | R31    | Return address (set by JAL)     |
+
+In addition to the 32 GPRs:
+
+| Name | Description                                     |
+|------|-------------------------------------------------|
+| PC   | 32-bit program counter                          |
+| HI   | High 32 bits of MULT/MULTU result; DIV remainder|
+| LO   | Low 32 bits of MULT/MULTU result; DIV quotient  |
+
+**R0 is always zero.** Any write to R0 is silently discarded.
+
+### Memory
+
+The MIPS R2000 addresses a 32-bit (4 GB) byte-addressed memory space.  The CPU
+is big-endian: multi-byte values are stored most-significant-byte first.
+
+For this simulator, we expose a flat **64 KB** memory array (addresses 0x0000–0xFFFF)
+for simplicity.  Programs are loaded at address 0x0000.  The PC wraps modulo 64 KB.
+
+Alignment rules:
+- **LW/SW**: address must be 4-byte aligned (addr & 3 == 0)
+- **LH/LHU/SH**: address must be 2-byte aligned (addr & 1 == 0)
+- **LB/LBU/SB**: no alignment requirement
+
+Misaligned accesses raise `ValueError`.
+
+### Instruction Formats
+
+All instructions are exactly 32 bits wide, enabling single-cycle fetch.
+
+```
+R-type:  [op:6][rs:5][rt:5][rd:5][shamt:5][funct:6]
+I-type:  [op:6][rs:5][rt:5][imm16:16]
+J-type:  [op:6][target26:26]
+```
+
+- **R-type** (op=0): ALU operations.  The `funct` field selects the operation.
+- **I-type**: loads, stores, branches, immediate ALU ops.  `imm16` is sign-extended
+  to 32 bits for arithmetic/memory instructions; zero-extended for ANDI/ORI/XORI.
+- **J-type**: unconditional jumps.  Target = `(PC+4)[31:28] | (target26 << 2)`.
+
+### Branch Target Calculation
+
+For branch instructions (BEQ, BNE, BLEZ, BGTZ, BLTZ, BGEZ, BLTZAL, BGEZAL):
+
+```
+target = (PC + 4) + (sign_extend16(imm16) << 2)
+```
+
+The `PC + 4` reflects the address of the *next* instruction (the delay slot on real
+hardware; in this simulator there are **no delay slots** — see Simplifications below).
+
+### Jump Target Calculation (J / JAL)
+
+```
+target = (PC + 4)[31:28] | (target26 << 2)
+```
+
+### HI:LO Registers
+
+MULT / MULTU compute a 64-bit product: HI holds bits 63:32, LO holds bits 31:0.
+DIV / DIVU compute quotient in LO and remainder in HI.
+
+---
+
+## Instruction Set
+
+### R-type (op = 0, decoded by funct)
+
+| Funct | Mnemonic | Operation                                   |
+|-------|----------|---------------------------------------------|
+| 0x00  | SLL      | rd = rt << shamt (logical)                  |
+| 0x02  | SRL      | rd = rt >> shamt (logical)                  |
+| 0x03  | SRA      | rd = rt >>> shamt (arithmetic)              |
+| 0x04  | SLLV     | rd = rt << (rs & 31)                        |
+| 0x06  | SRLV     | rd = rt >> (rs & 31) (logical)              |
+| 0x07  | SRAV     | rd = rt >>> (rs & 31) (arithmetic)          |
+| 0x08  | JR       | PC = rs                                     |
+| 0x09  | JALR     | rd = PC+4; PC = rs                          |
+| 0x0C  | SYSCALL  | **HALT sentinel** (see below)               |
+| 0x0D  | BREAK    | Raise ValueError (software breakpoint)      |
+| 0x10  | MFHI     | rd = HI                                     |
+| 0x11  | MTHI     | HI = rs                                     |
+| 0x12  | MFLO     | rd = LO                                     |
+| 0x13  | MTLO     | LO = rs                                     |
+| 0x18  | MULT     | HI:LO = signed(rs) × signed(rt)            |
+| 0x19  | MULTU    | HI:LO = unsigned(rs) × unsigned(rt)        |
+| 0x1A  | DIV      | LO = signed(rs)/signed(rt); HI = remainder |
+| 0x1B  | DIVU     | LO = unsigned(rs)/unsigned(rt); HI = rem   |
+| 0x20  | ADD      | rd = rs + rt (signed overflow → ValueError)|
+| 0x21  | ADDU     | rd = rs + rt (wraps, no overflow check)     |
+| 0x22  | SUB      | rd = rs − rt (signed overflow → ValueError)|
+| 0x23  | SUBU     | rd = rs − rt (wraps, no overflow check)     |
+| 0x24  | AND      | rd = rs & rt                                |
+| 0x25  | OR       | rd = rs \| rt                               |
+| 0x26  | XOR      | rd = rs ^ rt                                |
+| 0x27  | NOR      | rd = ~(rs \| rt)                            |
+| 0x2A  | SLT      | rd = (signed(rs) < signed(rt)) ? 1 : 0     |
+| 0x2B  | SLTU     | rd = (unsigned(rs) < unsigned(rt)) ? 1 : 0 |
+
+### REGIMM (op = 1, decoded by rt field)
+
+| rt   | Mnemonic | Operation                                                  |
+|------|----------|------------------------------------------------------------|
+| 0x00 | BLTZ     | if (signed(rs) < 0): PC = target                          |
+| 0x01 | BGEZ     | if (signed(rs) >= 0): PC = target                         |
+| 0x10 | BLTZAL   | $ra = PC+4; if (signed(rs) < 0): PC = target              |
+| 0x11 | BGEZAL   | $ra = PC+4; if (signed(rs) >= 0): PC = target             |
+
+### I-type and J-type (op ≥ 2)
+
+| op   | Mnemonic | Operation                                                   |
+|------|----------|-------------------------------------------------------------|
+| 0x02 | J        | PC = (PC+4)[31:28] \| (target26 << 2)                     |
+| 0x03 | JAL      | $ra = PC+4; PC = (PC+4)[31:28] \| (target26 << 2)         |
+| 0x04 | BEQ      | if (rs == rt): PC = target                                  |
+| 0x05 | BNE      | if (rs != rt): PC = target                                  |
+| 0x06 | BLEZ     | if (signed(rs) <= 0): PC = target                          |
+| 0x07 | BGTZ     | if (signed(rs) > 0): PC = target                           |
+| 0x08 | ADDI     | rt = rs + sext(imm16) (signed overflow → ValueError)       |
+| 0x09 | ADDIU    | rt = rs + sext(imm16) (wraps, no overflow check)           |
+| 0x0A | SLTI     | rt = (signed(rs) < signed(sext(imm16))) ? 1 : 0           |
+| 0x0B | SLTIU    | rt = (unsigned(rs) < unsigned(sext(imm16))) ? 1 : 0       |
+| 0x0C | ANDI     | rt = rs & zero_extend(imm16)                               |
+| 0x0D | ORI      | rt = rs \| zero_extend(imm16)                              |
+| 0x0E | XORI     | rt = rs ^ zero_extend(imm16)                               |
+| 0x0F | LUI      | rt = imm16 << 16 (loads upper 16 bits)                     |
+| 0x20 | LB       | rt = sign_extend(mem8[rs + sext(imm16)])                   |
+| 0x21 | LH       | rt = sign_extend(mem16[rs + sext(imm16)])                  |
+| 0x23 | LW       | rt = mem32[rs + sext(imm16)]                               |
+| 0x24 | LBU      | rt = zero_extend(mem8[rs + sext(imm16)])                   |
+| 0x25 | LHU      | rt = zero_extend(mem16[rs + sext(imm16)])                  |
+| 0x28 | SB       | mem8[rs + sext(imm16)] = rt[7:0]                           |
+| 0x29 | SH       | mem16[rs + sext(imm16)] = rt[15:0]                         |
+| 0x2B | SW       | mem32[rs + sext(imm16)] = rt                               |
+
+---
+
+## HALT Convention
+
+Opcode 0, funct 0x0C is `SYSCALL`.  On real MIPS, SYSCALL triggers a trap to
+the OS kernel.  In this simulator, **any SYSCALL instruction halts execution**
+and sets `halted=True`.  The mnemonic for StepTrace is `"HALT"`.
+
+```python
+HALT = bytes([0x00, 0x00, 0x00, 0x0C])  # SYSCALL (big-endian)
+```
+
+`BREAK` (funct=0x0D) raises `ValueError` (software breakpoint, signals a bug).
+
+---
+
+## Simplifications
+
+This is a **behavioral** simulator, not a cycle-accurate one:
+
+1. **No branch delay slots.** On real MIPS, the instruction immediately after a
+   branch (the "delay slot") executes unconditionally before the branch takes
+   effect.  This simulator does not model delay slots: branches take effect
+   immediately after the branch instruction, and the next instruction fetched
+   is at the branch target.  Programs must not rely on delay slot semantics.
+
+2. **No pipeline hazards.** Loads followed immediately by dependent instructions
+   work without inserting NOPs.
+
+3. **64 KB memory.** The 32-bit address space is modelled as a 64 KB flat array.
+   PC and addresses are masked to 16 bits.
+
+4. **No coprocessor 0 (CP0).** Exception vectors, TLB, and status registers are
+   not implemented.  Invalid operations raise Python `ValueError` rather than
+   trapping to an exception vector.
+
+5. **No floating point (COP1).** The FPU coprocessor is not implemented.
+
+6. **Signed overflow on ADD/ADDI/SUB raises ValueError.** Real MIPS raises a
+   hardware exception; here we raise `ValueError` with a descriptive message.
+   Use ADDU/ADDIU/SUBU for wrapping arithmetic.
+
+---
+
+## SIM00 Protocol
+
+```python
+class MIPSSimulator(Simulator[MIPSState]):
+    def reset(self) -> None: ...
+    def load(self, program: bytes) -> None: ...
+    def step(self) -> StepTrace: ...
+    def execute(self, program: bytes, max_steps: int = 100_000) -> ExecutionResult: ...
+    def get_state(self) -> MIPSState: ...
+```
+
+`MIPSState` is a `frozen=True` dataclass:
+
+```python
+@dataclass(frozen=True)
+class MIPSState:
+    pc:     int              # 32-bit program counter
+    regs:   tuple[int, ...]  # 32 unsigned 32-bit general-purpose registers
+    hi:     int              # HI register (unsigned 32-bit)
+    lo:     int              # LO register (unsigned 32-bit)
+    memory: tuple[int, ...]  # 65536 bytes
+    halted: bool
+```
+
+Convenience properties: `.sp` (R29), `.ra` (R31), `.v0` (R2), `.a0` (R4).
+
+---
+
+## Package Layout
+
+```
+code/packages/python/mips-r2000-simulator/
+├── pyproject.toml
+├── README.md
+├── CHANGELOG.md
+├── src/
+│   └── mips_r2000_simulator/
+│       ├── __init__.py       (exports MIPSSimulator, MIPSState)
+│       ├── py.typed
+│       ├── state.py          (MIPSState dataclass + constants)
+│       └── simulator.py      (MIPSSimulator — ~800 lines)
+└── tests/
+    ├── test_protocol.py      (SIM00 compliance)
+    ├── test_instructions.py  (per-instruction correctness)
+    ├── test_programs.py      (end-to-end programs)
+    └── test_coverage.py      (edge cases, overflow, alignment errors)
+```
+
+---
+
+## Design Notes
+
+### Why SYSCALL as HALT?
+
+SYSCALL is the natural OS-entry instruction on MIPS.  Using it as the HALT
+sentinel matches real MIPS Linux convention ($v0=4001 = SYS_exit), and keeps
+the opcode table semantically clean — there are no arbitrary "undefined" opcodes
+on MIPS (unlike x86's 0xF4 HALT or 8051's 0xA5).
+
+### Big-Endian Memory Layout
+
+MIPS R2000 is big-endian by default.  For a 32-bit value `0x12345678`:
+```
+addr+0: 0x12  (most significant)
+addr+1: 0x34
+addr+2: 0x56
+addr+3: 0x78  (least significant)
+```
+
+Programs encoded as `bytes([op_hi, op_mid_hi, op_mid_lo, op_lo])` are correct
+for big-endian MIPS.  For convenience, the test helper `w32(v)` packs a 32-bit
+instruction as 4 big-endian bytes.
+
+### R0 is Always Zero
+
+Writing to R0 is silently discarded.  This is enforced in `_set_reg()`:
+```python
+def _set_reg(self, rd: int, val: int) -> None:
+    if rd != 0:
+        self._regs[rd] = val & 0xFFFFFFFF
+```
+
+### SLT / SLTU Distinction
+
+`SLT` interprets both operands as signed 32-bit integers.
+`SLTU` interprets both as unsigned.  In particular, `SLTU $t0, $zero, $t1`
+tests whether $t1 is non-zero (since $zero=0 and unsigned(anything) ≥ 0).
+
+### Overflow on Signed Arithmetic
+
+ADD, ADDI, SUB raise `ValueError` on signed overflow (matching hardware trap
+behavior, useful for catching bugs).  ADDU, ADDIU, SUBU silently wrap.  This
+distinction is important: `ADDIU $sp, $sp, -8` for stack allocation should use
+ADDIU (or ADDU with a negated offset in register).
+
+---
+
+## Test Plan
+
+| Test module         | What it covers                                           |
+|---------------------|----------------------------------------------------------|
+| test_protocol.py    | isinstance, all 5 methods callable, return types         |
+| test_protocol.py    | reset() → PC=0, all regs=0, HI=LO=0, memory zeroed      |
+| test_protocol.py    | load() → places bytes, raises on overflow, resets first  |
+| test_protocol.py    | execute() → returns ExecutionResult with correct fields  |
+| test_protocol.py    | step() → returns StepTrace with pc_before/after          |
+| test_protocol.py    | get_state() → frozen, snapshot not mutated by step       |
+| test_instructions.py| All R-type: SLL, SRL, SRA, SLLV, SRLV, SRAV            |
+| test_instructions.py| JR, JALR (sets $ra)                                     |
+| test_instructions.py| MFHI, MFLO, MTHI, MTLO                                  |
+| test_instructions.py| MULT, MULTU (64-bit result in HI:LO)                    |
+| test_instructions.py| DIV, DIVU (quotient in LO, remainder in HI)             |
+| test_instructions.py| ADD (overflow raises), ADDU (wraps), SUB, SUBU          |
+| test_instructions.py| AND, OR, XOR, NOR                                       |
+| test_instructions.py| SLT, SLTU (signed vs unsigned comparison)               |
+| test_instructions.py| BLTZ, BGEZ, BLTZAL, BGEZAL (taken and not-taken)       |
+| test_instructions.py| J, JAL (target calculation)                             |
+| test_instructions.py| BEQ, BNE, BLEZ, BGTZ (all 4 conditions)                |
+| test_instructions.py| ADDI (overflow), ADDIU, SLTI, SLTIU, ANDI, ORI, XORI  |
+| test_instructions.py| LUI (upper 16 bits)                                     |
+| test_instructions.py| LB, LH, LW, LBU, LHU (sign/zero extension)             |
+| test_instructions.py| SB, SH, SW (byte-order in memory)                       |
+| test_programs.py    | Sum 1 to 10 using ADDU + BNE loop                       |
+| test_programs.py    | Factorial 5! using MULT                                  |
+| test_programs.py    | Fibonacci (8 terms) in memory                           |
+| test_programs.py    | Subroutine call/return using JAL/JR                      |
+| test_programs.py    | Byte copy loop via LB/SB                                |
+| test_programs.py    | Word copy loop via LW/SW                                |
+| test_coverage.py    | R0 always zero (write to R0 is no-op)                   |
+| test_coverage.py    | Misaligned LW/SW raises ValueError                      |
+| test_coverage.py    | Misaligned LH/SH raises ValueError                      |
+| test_coverage.py    | ADD signed overflow raises ValueError                    |
+| test_coverage.py    | DIV by zero raises ValueError                           |
+| test_coverage.py    | BREAK raises ValueError                                  |
+| test_coverage.py    | SLTU: 0xFFFFFFFF > 0x00000001 unsigned                  |
+| test_coverage.py    | SLT: -1 < 1 signed                                      |
+| test_coverage.py    | LB sign extension: 0xFF → -1 (0xFFFFFFFF)               |
+| test_coverage.py    | LBU zero extension: 0xFF → 255 (0x000000FF)             |
+| test_coverage.py    | NOR: ~(rs\|rt)                                          |
+| test_coverage.py    | SRA: arithmetic right shift preserves sign               |
+| test_coverage.py    | MULTU: 0xFFFFFFFF × 0xFFFFFFFF → correct HI:LO          |
+| test_coverage.py    | max_steps exceeded returns ok=False                      |


### PR DESCRIPTION
## Summary

- Add full behavioral simulator for the **MIPS R2000 (1985)** — the first commercial RISC processor, designed by John Hennessy's team at Stanford
- Implements the SIM00 `Simulator[MIPSState]` protocol (`reset`, `load`, `step`, `execute`, `get_state`)
- Covers all three instruction formats (R-type/funct dispatch, I-type, J-type) with 50+ instructions including MULT/DIV, branches, loads/stores, and subroutine instructions (JAL/JR/JALR)
- 130 tests, 93.27% coverage; ruff clean; security review passed

## Test plan

- [ ] CI Python build passes for `mips-r2000-simulator`
- [ ] All 130 tests pass (`test_protocol`, `test_instructions`, `test_programs`, `test_coverage`)
- [ ] Coverage ≥ 80% (actual: 93.27%)
- [ ] Ruff lint passes (0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)