### PR TITLE
feat(matrix-metal): Op::Cast support (F32-output paths)

### DIFF
--- a/code/packages/rust/matrix-metal/CHANGELOG.md
+++ b/code/packages/rust/matrix-metal/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog — matrix-metal
 
+## 0.4.0 — 2026-05-05
+
+### Added
+
+- **`Op::Cast` support (F32 output paths only).**  Capability bitset
+  now includes tag 0x1A.
+
+  matrix-metal advertises `supported_dtypes = F32`, which constrains
+  the planner's capability filter to route only Casts whose **output**
+  dtype is F32 to us.  That leaves three input-dtype paths to handle:
+
+    - `F32 → F32` (degenerate identity cast)
+    - `U8 → F32` (widening conversion)
+    - `I32 → F32` (widening conversion)
+
+  Each is a one-line elementwise scalar cast.  MSL's implicit
+  conversions match Rust's `as` semantics for these widening paths
+  (no rounding mode ambiguity; every U8 and I32 value fits in F32
+  exactly or with at most one rounding step).
+
+  The other three Cast directions (`F32 → U8 / I32`, `U8 → I32`,
+  `I32 → U8`) need `supported_dtypes` to advertise U8 / I32 — and
+  that would also let the planner route U8/I32 elementwise ops to us
+  which we don't yet implement.  Keeping the dtype bitset at F32 only
+  means those casts stay on CPU; we ship the F32-output ones today.
+
+### Tests (3 new integration tests)
+
+- `cast_u8_to_f32_on_gpu` — `[0, 1, 200, 255]` (u8) → `[0.0, 1.0, 200.0, 255.0]` (f32).
+- `cast_i32_to_f32_on_gpu` — `[0, 1, -1, 1_000_000, i32::MIN]` (i32) → matching f32 values; verifies that the largest-magnitude path still round-trips correctly (i32::MIN is exactly representable in f32 with no rounding).
+- `cast_f32_to_f32_on_gpu_is_identity` — degenerate path; confirms PI and other arbitrary f32 values round-trip byte-exactly.
+
+Total integration tests: 13 (was 10).
+
+### Notes
+
+- Defence in depth: `cast_dispatch` returns Err if the planner ever
+  routes a non-F32-output cast to us (it shouldn't, given the
+  `supported_dtypes` bitset, but the runtime check guards against
+  planner bugs and future capability changes).
+- This unblocks ML graphs that use U8 image inputs and I32 index
+  buffers but produce F32 intermediates — e.g. `image-gpu-core`'s
+  current pattern of u8-pixels → f32-cast → matmul → u8-pack stays
+  on Metal for the **u8→f32** half (the f32→u8 pack still falls
+  back to CPU).
+
 ## 0.3.0 — 2026-05-05
 
 ### Added

--- a/code/packages/rust/matrix-metal/Cargo.toml
+++ b/code/packages/rust/matrix-metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-metal"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "First real GPU executor for the matrix execution layer. Lowers a subset of MatrixIR ops to MSL kernels and dispatches via the metal-compute crate. Falls back to CPU automatically (via the planner's capability filter) for ops it doesn't yet support."
 license = "MIT"

--- a/code/packages/rust/matrix-metal/src/dispatch.rs
+++ b/code/packages/rust/matrix-metal/src/dispatch.rs
@@ -181,6 +181,16 @@ fn exec_compute(
             ..
         } => broadcast_dispatch(ctx, graph, *input, *output),
 
+        // Cast: dtype conversion.  matrix-metal advertises only F32
+        // as a supported output dtype, so the planner only routes
+        // Casts whose output is F32 to us — three input paths to
+        // handle: U8→F32, I32→F32, F32→F32.
+        Op::Cast {
+            input,
+            dtype,
+            output,
+        } => cast_dispatch(ctx, graph, *input, *dtype, *output),
+
         _ => Err(format!(
             "matrix-metal V1 doesn't support op {}; the planner should have routed this to CPU",
             op_kind_name(op)
@@ -605,6 +615,69 @@ fn reshape_dispatch(
             .alloc(ctx.device, out_residency.buffer, n_bytes as usize)?;
     }
     ctx.buffers.write(out_residency.buffer, 0, &data)?;
+    Ok(())
+}
+
+/// Cast: dispatch a single-element-wise dtype conversion.  Only
+/// F32-output paths reach us (the planner's capability filter
+/// restricts on output dtype, and matrix-metal advertises F32 only).
+/// Three input dtypes are handled: F32, U8, I32.
+fn cast_dispatch(
+    ctx: &mut DispatchCtx<'_>,
+    graph: &ComputeGraph,
+    input: TensorId,
+    output_dtype: matrix_ir::DType,
+    output: TensorId,
+) -> Result<(), String> {
+    let in_t = graph
+        .tensor(input)
+        .ok_or_else(|| format!("cast input tensor {} not found", input.0))?;
+    let out_residency = lookup_residency(graph, output)?;
+    let n = in_t
+        .shape
+        .numel()
+        .ok_or_else(|| format!("cast input tensor {} numel overflow", input.0))?
+        as u32;
+    if n == 0 {
+        return Ok(());
+    }
+
+    // Defence in depth: matrix-metal only emits F32-output kernels;
+    // routing a non-F32-output cast to us indicates a planner bug.
+    if output_dtype != matrix_ir::DType::F32 {
+        return Err(format!(
+            "matrix-metal cast: unsupported output dtype {:?} (only F32 ships in V1)",
+            output_dtype
+        ));
+    }
+
+    let kernel_name = match in_t.dtype {
+        matrix_ir::DType::F32 => "cast_f32_to_f32",
+        matrix_ir::DType::U8 => "cast_u8_to_f32",
+        matrix_ir::DType::I32 => "cast_i32_to_f32",
+    };
+    let pipeline = ctx
+        .pipelines
+        .get(kernel_name)
+        .ok_or_else(|| format!("pipeline {} not in cache", kernel_name))?;
+
+    let in_buf_ptr = ctx.buffers.get(in_t.residency.buffer)? as *const _;
+    let out_buf_ptr = ctx.buffers.get(out_residency.buffer)? as *const _;
+    // SAFETY: see `unary_dispatch` — same pattern, both buffers live
+    // for the duration of the dispatch call via `&BufferStore`.
+    let in_buf = unsafe { &*in_buf_ptr };
+    let out_buf = unsafe { &*out_buf_ptr };
+
+    let n_bytes = n.to_le_bytes();
+    let tg = pipeline.preferred_threads_1d();
+
+    ctx.queue.dispatch(|enc| {
+        enc.set_pipeline(pipeline);
+        enc.set_buffer(in_buf, 0);
+        enc.set_buffer(out_buf, 1);
+        enc.set_bytes(&n_bytes, 2);
+        enc.dispatch_threads_1d(n, tg);
+    });
     Ok(())
 }
 

--- a/code/packages/rust/matrix-metal/src/kernels.rs
+++ b/code/packages/rust/matrix-metal/src/kernels.rs
@@ -215,6 +215,60 @@ kernel void broadcast_f32(
 
     out[gid] = in[in_linear];
 }
+
+// ──────────────── cast (F32 output) ────────────────
+//
+// Op::Cast specifies an output dtype.  matrix-metal advertises
+// `supported_dtypes = F32`, which constrains the planner's capability
+// filter to route only Casts whose **output** dtype is F32 to us.
+// That leaves three input-dtype paths to support:
+//
+//   - F32 → F32 (degenerate identity cast; rare but legal)
+//   - U8  → F32 (widening conversion)
+//   - I32 → F32 (widening conversion)
+//
+// The other three directions (anything → U8 / I32) need
+// `supported_dtypes` to advertise U8 / I32 — and that would also
+// let the planner route U8/I32 elementwise ops to us, which we
+// don't yet implement.  Keeping the dtype bitset at F32 means
+// those casts stay on CPU, and we can ship the F32-output ones
+// today.
+//
+// Each kernel is a one-line element-wise scalar cast.  MSL's
+// implicit conversions match Rust's `as` semantics for these
+// widening paths (no rounding mode ambiguity, no clamping to
+// worry about — every `u8` and `i32` value fits in `f32` exactly
+// or with at most one rounding step).
+
+kernel void cast_u8_to_f32(
+    device const uchar* in [[buffer(0)]],
+    device float* out [[buffer(1)]],
+    constant uint& n [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= n) return;
+    out[gid] = (float)in[gid];
+}
+
+kernel void cast_i32_to_f32(
+    device const int* in [[buffer(0)]],
+    device float* out [[buffer(1)]],
+    constant uint& n [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= n) return;
+    out[gid] = (float)in[gid];
+}
+
+kernel void cast_f32_to_f32(
+    device const float* in [[buffer(0)]],
+    device float* out [[buffer(1)]],
+    constant uint& n [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= n) return;
+    out[gid] = in[gid];
+}
 "#;
 
 /// Names of every kernel entry point in [`KERNELS_MSL`].  Used at
@@ -244,4 +298,8 @@ pub const KERNEL_ENTRY_POINTS: &[&str] = &[
     "transpose_f32",
     // broadcast
     "broadcast_f32",
+    // cast (F32 output paths only — see KERNELS_MSL comment)
+    "cast_u8_to_f32",
+    "cast_i32_to_f32",
+    "cast_f32_to_f32",
 ];

--- a/code/packages/rust/matrix-metal/src/lib.rs
+++ b/code/packages/rust/matrix-metal/src/lib.rs
@@ -67,7 +67,9 @@ use metal_compute::{MetalCommandQueue, MetalComputePipeline, MetalDevice};
 /// - 0x11 Reshape (metadata-only; implemented as a buffer memcpy in SSA)
 /// - 0x12 Transpose (general N-D permutation, max rank 4)
 /// - 0x13 Broadcast (general N-D size-1-axis replication, max rank 4)
-/// - 0x15 MatMul, 0x1B Const
+/// - 0x15 MatMul
+/// - 0x1A Cast (F32 output paths only — input may be F32/U8/I32)
+/// - 0x1B Const
 ///
 /// `Reshape` is included even though Metal has no shader for it: the
 /// SSA form of Reshape produces a fresh output tensor, so we treat it
@@ -92,11 +94,13 @@ fn supported_ops_bitset() -> u32 {
     for tag in 0x07..=0x0Du8 {
         mask |= 1u32 << tag;
     }
-    // Reshape (0x11), Transpose (0x12), Broadcast (0x13), MatMul (0x15), Const (0x1B).
+    // Reshape (0x11), Transpose (0x12), Broadcast (0x13), MatMul (0x15),
+    // Cast (0x1A), Const (0x1B).
     mask |= 1u32 << 0x11;
     mask |= 1u32 << 0x12;
     mask |= 1u32 << 0x13;
     mask |= 1u32 << 0x15;
+    mask |= 1u32 << 0x1A;
     mask |= 1u32 << 0x1B;
     mask
 }

--- a/code/packages/rust/matrix-metal/tests/integration.rs
+++ b/code/packages/rust/matrix-metal/tests/integration.rs
@@ -757,6 +757,231 @@ fn broadcast_column_to_matrix_on_gpu() {
     );
 }
 
+// ─────────────────── 4e. Cast ───────────────────
+
+#[test]
+fn cast_u8_to_f32_on_gpu() {
+    // Input  (u8, 4 elems): [0, 1, 200, 255]
+    // Output (f32, 4 elems): [0.0, 1.0, 200.0, 255.0]
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let in_bytes = vec![0u8, 1, 200, 255];
+    let n: u32 = 4;
+    let in_shape = Shape::from(&[n]);
+    let out_shape = in_shape.clone();
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: n as u64,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: (n * 4) as u64,
+            },
+            PlacedOp::Compute {
+                op: Op::Cast {
+                    input: TensorId(1),
+                    dtype: DType::F32,
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::U8, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::U8, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+    let down = exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer: BufferId(2),
+        offset: 0,
+        len: (n * 4) as u64,
+    });
+    let result = match down {
+        ExecutorResponse::BufferData { data, .. } => from_f32(&data),
+        other => panic!("download: {:?}", other),
+    };
+    assert_eq!(result, vec![0.0, 1.0, 200.0, 255.0]);
+}
+
+#[test]
+fn cast_i32_to_f32_on_gpu() {
+    // Input  (i32, 5 elems): [0, 1, -1, 1000000, -2147483648]
+    // Output (f32, 5 elems): same values, cast widening to f32
+    //                       (i32::MIN → -2147483648.0 exactly in f32)
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let mut in_bytes = Vec::with_capacity(5 * 4);
+    for v in &[0i32, 1, -1, 1_000_000, i32::MIN] {
+        in_bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    let n: u32 = 5;
+    let in_shape = Shape::from(&[n]);
+    let out_shape = in_shape.clone();
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: (n * 4) as u64,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: (n * 4) as u64,
+            },
+            PlacedOp::Compute {
+                op: Op::Cast {
+                    input: TensorId(1),
+                    dtype: DType::F32,
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::I32, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::I32, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+    let down = exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer: BufferId(2),
+        offset: 0,
+        len: (n * 4) as u64,
+    });
+    let result = match down {
+        ExecutorResponse::BufferData { data, .. } => from_f32(&data),
+        other => panic!("download: {:?}", other),
+    };
+    assert_eq!(result, vec![0.0, 1.0, -1.0, 1_000_000.0, i32::MIN as f32]);
+}
+
+#[test]
+fn cast_f32_to_f32_on_gpu_is_identity() {
+    // Degenerate identity cast.  Rare in practice but legal — confirm
+    // it round-trips bytes exactly.
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let in_bytes = f32_bytes(&[1.5, -2.5, 0.0, std::f32::consts::PI]);
+    let n: u32 = 4;
+    let in_shape = Shape::from(&[n]);
+    let out_shape = in_shape.clone();
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: (n * 4) as u64,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: (n * 4) as u64,
+            },
+            PlacedOp::Compute {
+                op: Op::Cast {
+                    input: TensorId(1),
+                    dtype: DType::F32,
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::F32, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::F32, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+    let down = exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer: BufferId(2),
+        offset: 0,
+        len: (n * 4) as u64,
+    });
+    let result = match down {
+        ExecutorResponse::BufferData { data, .. } => from_f32(&data),
+        other => panic!("download: {:?}", other),
+    };
+    assert_eq!(result, vec![1.5, -2.5, 0.0, std::f32::consts::PI]);
+}
+
 // ─────────────────── 5. Validation ───────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Adds `Op::Cast` (tag 0x1A) to `matrix-metal` for the three input dtypes that produce F32 outputs. matrix-metal advertises `supported_dtypes = F32` so the planner only routes Casts whose **output** is F32 to us — covering the `U8→F32` and `I32→F32` widening paths plus the degenerate `F32→F32` identity.

`matrix-metal` v0.3.0 → v0.4.0.

## What this PR adds

Three new one-line MSL kernels:

- `cast_u8_to_f32` — `uchar` input → `float` output
- `cast_i32_to_f32` — `int` input → `float` output
- `cast_f32_to_f32` — degenerate identity copy

Each kernel is a single elementwise scalar cast. MSL's implicit conversions match Rust's `as` semantics for these widening paths (every U8 and I32 value fits in F32 exactly or with at most one rounding step at the `i32::MIN` end).

The other three Cast directions (`F32→U8/I32`, `U8→I32`, `I32→U8`) need `supported_dtypes` to advertise U8/I32 — that would also let the planner route U8/I32 elementwise ops to us which we don't yet implement, so they stay on CPU until V2 dtype expansion.

`cast_dispatch` validates output dtype is F32 (defence in depth).

## Tests

3 new integration tests:

- **`cast_u8_to_f32_on_gpu`** — `[0, 1, 200, 255]` (u8) → `[0.0, 1.0, 200.0, 255.0]` (f32).
- **`cast_i32_to_f32_on_gpu`** — `[0, 1, -1, 1_000_000, i32::MIN]` (i32) → matching f32 values; verifies the largest-magnitude path round-trips correctly (`i32::MIN` is exactly representable in f32 with no rounding).
- **`cast_f32_to_f32_on_gpu_is_identity`** — confirms PI and other arbitrary f32 values round-trip byte-exactly.

Total: **13 integration tests** (was 10).

## Why this matters

Unblocks ML graphs that use U8 image inputs and I32 index buffers but produce F32 intermediates — a very common pattern. image-gpu-core's `u8-pixels → f32-cast → matmul → u8-pack` chain now stays on Metal for the `u8→f32` half (the `f32→u8` pack still falls back to CPU until V2 dtypes).

## Regression check

`instagram-filters` routing on macOS unchanged:

```
  invert        → cpu     (small graph, planner picks CPU)
  greyscale     → metal   (sRGB + matmul, ships to GPU)
  sepia         → metal   (matmul-heavy, ships to GPU)
```

The visible end-to-end speedup from this PR arrives once V2 dtype expansion ships and the f32→u8 pack also goes to GPU.

## Test plan

- [x] `cargo test -p matrix-metal` — 13 tests pass on macOS
- [x] `cargo build` clean
- [x] `instagram-filters` routing unchanged
- [x] Security review passed in one round

## Out of scope

- F32→U8, F32→I32, U8→I32, I32→U8 — need V2 dtype expansion (advertise U8/I32 in `supported_dtypes` AND ship corresponding elementwise kernels in those dtypes; otherwise the planner would route U8/I32 ops to us that we can't handle).
- Saturating semantics for narrowing F32→U8 (clamp to [0, 255]) — V2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)