### PR TITLE
feat(matrix-metal): Op::ReduceSum / ReduceMax / ReduceMean (single-axis)

### DIFF
--- a/code/packages/rust/matrix-metal/CHANGELOG.md
+++ b/code/packages/rust/matrix-metal/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog — matrix-metal
 
+## 0.5.0 — 2026-05-05
+
+### Added
+
+- **`Op::ReduceSum / ReduceMax / ReduceMean` support** for **single-
+  axis** F32 reductions.  Capability bitset now includes tags 0x0E,
+  0x0F, 0x10.
+
+  Three new MSL kernels (`reduce_sum_f32`, `reduce_max_f32`,
+  `reduce_mean_f32`) share a `REDUCE_F32_BODY` macro that:
+
+    1. Decomposes `gid` into an output multi-index using `out_dims`.
+    2. Builds a template input multi-index, skipping/adjusting the
+       reduced axis based on `keep_dims`.
+    3. Sweeps `i = 0..reduce_size`, slotting `i` into the reduce-axis
+       position and accumulating.
+    4. Writes the result (sum: as-is; max: starting from `-INFINITY`;
+       mean: divided by `reduce_size`).
+
+  Supports `keep_dims = true` and `keep_dims = false`.  Up to rank 4
+  (matching this backend's advertised `max_tensor_rank`).
+
+  **Multi-axis reductions** (`axes.len() > 1`) return an Err at
+  dispatch time with a clear message — the runtime can either surface
+  the error or decompose into a chain of single-axis reductions.
+  Decomposition is V2 work.
+
+### Tests (4 new integration tests)
+
+- `reduce_sum_axis1_on_gpu` — `[[1,2,3],[4,5,6]]` reduce-sum axis 1 → `[6, 15]`.
+- `reduce_max_axis0_keep_dims_on_gpu` — `[[1,5,3],[4,2,6]]` reduce-max axis 0 with keep_dims → `[[4, 5, 6]]`.
+- `reduce_mean_axis1_on_gpu` — `[[2,4,6,8],[1,3,5,7]]` reduce-mean axis 1 → `[5.0, 4.0]`.
+- `reduce_multi_axis_returns_error` — verifies V1 multi-axis attempt fails cleanly with a "single-axis" error message so the runtime can fall back.
+
+Total integration tests: 17 (was 13).
+
+### Notes
+
+- The kernels are thread-per-output-element with sequential reads
+  along the reduce axis.  Performance is suboptimal for very long
+  reduce axes (no tree reduction within a threadgroup); fine for
+  the rank-2/3/4 reduce sizes typical in image / ML graphs (hundreds
+  to thousands).  V2 polish: tile-and-tree reduction kernels.
+- Reduction completes the V1 elementwise+reduction op set on Metal.
+  Combined with shape ops (Reshape/Transpose/Broadcast in 0.1.1–
+  0.3.0) and casts (0.4.0), matrix-metal now handles the bulk of
+  ML-style F32 graph patterns end-to-end.
+
 ## 0.4.0 — 2026-05-05
 
 ### Added

--- a/code/packages/rust/matrix-metal/Cargo.toml
+++ b/code/packages/rust/matrix-metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-metal"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "First real GPU executor for the matrix execution layer. Lowers a subset of MatrixIR ops to MSL kernels and dispatches via the metal-compute crate. Falls back to CPU automatically (via the planner's capability filter) for ops it doesn't yet support."
 license = "MIT"

--- a/code/packages/rust/matrix-metal/src/dispatch.rs
+++ b/code/packages/rust/matrix-metal/src/dispatch.rs
@@ -191,6 +191,27 @@ fn exec_compute(
             output,
         } => cast_dispatch(ctx, graph, *input, *dtype, *output),
 
+        // Reductions: V1 supports single-axis only.  Multi-axis errors
+        // at dispatch time and the runtime falls back to CPU.
+        Op::ReduceSum {
+            input,
+            axes,
+            keep_dims,
+            output,
+        } => reduce_dispatch(ctx, graph, "reduce_sum_f32", *input, axes, *keep_dims, *output),
+        Op::ReduceMax {
+            input,
+            axes,
+            keep_dims,
+            output,
+        } => reduce_dispatch(ctx, graph, "reduce_max_f32", *input, axes, *keep_dims, *output),
+        Op::ReduceMean {
+            input,
+            axes,
+            keep_dims,
+            output,
+        } => reduce_dispatch(ctx, graph, "reduce_mean_f32", *input, axes, *keep_dims, *output),
+
         _ => Err(format!(
             "matrix-metal V1 doesn't support op {}; the planner should have routed this to CPU",
             op_kind_name(op)
@@ -677,6 +698,128 @@ fn cast_dispatch(
         enc.set_buffer(out_buf, 1);
         enc.set_bytes(&n_bytes, 2);
         enc.dispatch_threads_1d(n, tg);
+    });
+    Ok(())
+}
+
+/// Reduction (sum/max/mean) over a single axis.
+///
+/// V1 only supports single-axis reductions because the kernels are
+/// thread-per-output-element and the args struct hardcodes one
+/// `reduce_axis` field.  Multi-axis reductions (`axes.len() > 1`)
+/// return Err — the runtime can either:
+///
+///   - Surface the error to the caller, or
+///   - Decompose the multi-axis reduce into a chain of single-axis
+///     reductions before dispatching (V2 work).
+///
+/// The MSL kernel (`reduce_{sum,max,mean}_f32`) does the actual
+/// arithmetic; this Rust function packs the args struct, validates
+/// inputs, and launches the kernel.
+fn reduce_dispatch(
+    ctx: &mut DispatchCtx<'_>,
+    graph: &ComputeGraph,
+    kernel_name: &str,
+    input: TensorId,
+    axes: &[u32],
+    keep_dims: bool,
+    output: TensorId,
+) -> Result<(), String> {
+    let in_t = graph
+        .tensor(input)
+        .ok_or_else(|| format!("reduce input tensor {} not found", input.0))?;
+    let out_t = graph
+        .tensor(output)
+        .ok_or_else(|| format!("reduce output tensor {} not found", output.0))?;
+    let out_residency = out_t.residency;
+    let in_residency = in_t.residency;
+
+    if axes.len() != 1 {
+        return Err(format!(
+            "matrix-metal {}: V1 supports single-axis reduce only, got {} axes",
+            kernel_name,
+            axes.len()
+        ));
+    }
+    let reduce_axis = axes[0] as usize;
+    let rank_in = in_t.shape.rank();
+    if rank_in == 0 || rank_in > 4 {
+        return Err(format!(
+            "matrix-metal {}: input rank {} out of range (1..=4)",
+            kernel_name, rank_in
+        ));
+    }
+    if reduce_axis >= rank_in {
+        return Err(format!(
+            "matrix-metal {}: axis {} out of range for rank-{} input",
+            kernel_name, reduce_axis, rank_in
+        ));
+    }
+    let reduce_size = in_t.shape.dims[reduce_axis];
+
+    let numel_out = out_t
+        .shape
+        .numel()
+        .ok_or_else(|| "reduce output numel overflow".to_string())? as u32;
+    if numel_out == 0 {
+        return Ok(());
+    }
+
+    let pipeline = ctx
+        .pipelines
+        .get(kernel_name)
+        .ok_or_else(|| format!("pipeline {} not in cache", kernel_name))?;
+
+    let in_buf_ptr = ctx.buffers.get(in_residency.buffer)? as *const _;
+    let out_buf_ptr = ctx.buffers.get(out_residency.buffer)? as *const _;
+    // SAFETY: see `unary_dispatch`.
+    let in_buf = unsafe { &*in_buf_ptr };
+    let out_buf = unsafe { &*out_buf_ptr };
+
+    // Encode ReduceArgs.  Field order matches the MSL struct:
+    //   uint rank_in;
+    //   uint reduce_axis;
+    //   uint reduce_size;
+    //   uint keep_dims;
+    //   uint numel_out;
+    //   uint in_dims[4];
+    //   uint out_dims[4];
+    // Total: 5 + 4 + 4 = 13 uints = 52 bytes.  Round up to 64 for
+    // MSL alignment.
+    let mut args = [0u8; 64];
+    let mut off = 0usize;
+    let put_u32 = |v: u32, args: &mut [u8; 64], off: &mut usize| {
+        args[*off..*off + 4].copy_from_slice(&v.to_le_bytes());
+        *off += 4;
+    };
+    put_u32(rank_in as u32, &mut args, &mut off);
+    put_u32(reduce_axis as u32, &mut args, &mut off);
+    put_u32(reduce_size, &mut args, &mut off);
+    put_u32(if keep_dims { 1 } else { 0 }, &mut args, &mut off);
+    put_u32(numel_out, &mut args, &mut off);
+    for d in 0..4 {
+        let v = if d < rank_in { in_t.shape.dims[d] } else { 0 };
+        put_u32(v, &mut args, &mut off);
+    }
+    let rank_out = out_t.shape.rank();
+    for d in 0..4 {
+        let v = if d < rank_out {
+            out_t.shape.dims[d]
+        } else {
+            0
+        };
+        put_u32(v, &mut args, &mut off);
+    }
+    let _ = off;
+
+    let tg = pipeline.preferred_threads_1d();
+
+    ctx.queue.dispatch(|enc| {
+        enc.set_pipeline(pipeline);
+        enc.set_buffer(in_buf, 0);
+        enc.set_buffer(out_buf, 1);
+        enc.set_bytes(&args, 2);
+        enc.dispatch_threads_1d(numel_out, tg);
     });
     Ok(())
 }

--- a/code/packages/rust/matrix-metal/src/kernels.rs
+++ b/code/packages/rust/matrix-metal/src/kernels.rs
@@ -216,6 +216,128 @@ kernel void broadcast_f32(
     out[gid] = in[in_linear];
 }
 
+// ──────────────── reductions (F32, single axis, max rank 4) ────────────────
+//
+// V1 supports **single-axis** reduction.  Multi-axis reductions
+// (`axes.len() > 1`) fall back to CPU via a dispatch-time Err — the
+// planner can route them to us based on the capability bitset, but
+// the dispatch refuses and the runtime escalates.  V2 will lift this
+// by either decomposing multi-axis reduce into a chain of single-axis
+// kernels or by writing a rank-N reduce kernel directly.
+//
+// Each output element corresponds to a multi-index in the output
+// space.  The kernel:
+//
+//   1. Decomposes its `gid` into an output multi-index using `out_dims`.
+//   2. Builds a template input multi-index from the output one,
+//      inserting/skipping the reduced axis based on `keep_dims`.
+//   3. Sweeps `i = 0..reduce_size`, slotting `i` into the reduce-axis
+//      position and accumulating the input value.
+//   4. Writes the accumulator out (sum: as-is; mean: divide by
+//      `reduce_size`; max: starts the accumulator at -INFINITY).
+//
+// Performance is suboptimal — there's no tree reduction within a
+// threadgroup, so each thread does `reduce_size` reads sequentially.
+// Fine for the rank-2/3/4 reduction sizes typical in image / ML
+// graphs (hundreds to thousands).  V2 polish: tile-and-tree reduction
+// for very large reduce axes.
+
+struct ReduceArgs {
+    uint rank_in;
+    uint reduce_axis;
+    uint reduce_size;
+    uint keep_dims;     // 0 or 1
+    uint numel_out;
+    uint in_dims[4];
+    uint out_dims[4];
+};
+
+// Helper that walks both `args.out_dims` (which has rank
+// `keep_dims ? rank_in : rank_in - 1`) and rebuilds the input
+// multi-index template, returning a flat input offset for `i` slotted
+// into `args.reduce_axis`.  The MSL compiler inlines this body into
+// each kernel; sharing it via a function keeps the three reduce
+// variants bit-identical except for the accumulator.
+//
+// This helper is defined inside each kernel below (MSL doesn't expose
+// device-function inlining as cleanly across kernels), but the
+// algorithm above is the conceptual model.
+
+#define REDUCE_F32_BODY(INIT, ACC_EXPR, FINAL_EXPR) \
+    if (gid >= args.numel_out) return; \
+    /* Decompose gid into output multi-index. */ \
+    uint out_idx[4] = {0u, 0u, 0u, 0u}; \
+    uint linear = gid; \
+    uint rank_out = (args.keep_dims != 0u) ? args.rank_in : (args.rank_in - 1u); \
+    for (int d = (int)rank_out - 1; d >= 0; --d) { \
+        uint extent = args.out_dims[d]; \
+        out_idx[d] = linear % extent; \
+        linear /= extent; \
+    } \
+    /* Build input multi-index template, skipping/adjusting reduce axis. */ \
+    uint in_idx[4] = {0u, 0u, 0u, 0u}; \
+    if (args.keep_dims != 0u) { \
+        for (uint d = 0; d < args.rank_in; ++d) { \
+            in_idx[d] = (d == args.reduce_axis) ? 0u : out_idx[d]; \
+        } \
+    } else { \
+        uint o = 0u; \
+        for (uint d = 0; d < args.rank_in; ++d) { \
+            if (d == args.reduce_axis) { \
+                in_idx[d] = 0u; \
+            } else { \
+                in_idx[d] = out_idx[o]; \
+                o += 1u; \
+            } \
+        } \
+    } \
+    /* Sweep over reduce axis. */ \
+    float acc = INIT; \
+    for (uint i = 0u; i < args.reduce_size; ++i) { \
+        in_idx[args.reduce_axis] = i; \
+        uint flat = 0u; \
+        uint stride = 1u; \
+        for (int d = (int)args.rank_in - 1; d >= 0; --d) { \
+            flat += in_idx[d] * stride; \
+            stride *= args.in_dims[d]; \
+        } \
+        float x = in[flat]; \
+        acc = ACC_EXPR; \
+    } \
+    out[gid] = FINAL_EXPR;
+
+kernel void reduce_sum_f32(
+    device const float* in [[buffer(0)]],
+    device float* out [[buffer(1)]],
+    constant ReduceArgs& args [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    REDUCE_F32_BODY(0.0f, acc + x, acc)
+}
+
+kernel void reduce_max_f32(
+    device const float* in [[buffer(0)]],
+    device float* out [[buffer(1)]],
+    constant ReduceArgs& args [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    // Initial value: -INFINITY so any real element beats it.  An
+    // empty reduce (reduce_size = 0) leaves -INFINITY in the output;
+    // matrix-cpu's reference behaviour matches.
+    REDUCE_F32_BODY(-INFINITY, max(acc, x), acc)
+}
+
+kernel void reduce_mean_f32(
+    device const float* in [[buffer(0)]],
+    device float* out [[buffer(1)]],
+    constant ReduceArgs& args [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    // Mean = sum / reduce_size.  Reduce-size 0 gives NaN; matches
+    // matrix-cpu's behaviour of dividing by zero on an empty reduction.
+    REDUCE_F32_BODY(0.0f, acc + x, acc / (float)args.reduce_size)
+}
+
 // ──────────────── cast (F32 output) ────────────────
 //
 // Op::Cast specifies an output dtype.  matrix-metal advertises
@@ -302,4 +424,8 @@ pub const KERNEL_ENTRY_POINTS: &[&str] = &[
     "cast_u8_to_f32",
     "cast_i32_to_f32",
     "cast_f32_to_f32",
+    // reductions (F32, single-axis, max rank 4)
+    "reduce_sum_f32",
+    "reduce_max_f32",
+    "reduce_mean_f32",
 ];

--- a/code/packages/rust/matrix-metal/src/lib.rs
+++ b/code/packages/rust/matrix-metal/src/lib.rs
@@ -64,6 +64,7 @@ use metal_compute::{MetalCommandQueue, MetalComputePipeline, MetalDevice};
 /// Op tags from `matrix_ir::Op::wire_tag()`:
 /// - 0x00 Neg, 0x01 Abs, 0x02 Sqrt, 0x03 Exp, 0x04 Log, 0x05 Tanh, 0x06 Recip
 /// - 0x07 Add, 0x08 Sub, 0x09 Mul, 0x0A Div, 0x0B Max, 0x0C Min, 0x0D Pow
+/// - 0x0E ReduceSum, 0x0F ReduceMax, 0x10 ReduceMean (single-axis only in V1)
 /// - 0x11 Reshape (metadata-only; implemented as a buffer memcpy in SSA)
 /// - 0x12 Transpose (general N-D permutation, max rank 4)
 /// - 0x13 Broadcast (general N-D size-1-axis replication, max rank 4)
@@ -94,6 +95,13 @@ fn supported_ops_bitset() -> u32 {
     for tag in 0x07..=0x0Du8 {
         mask |= 1u32 << tag;
     }
+    // Reductions (0x0E..=0x10): ReduceSum, ReduceMax, ReduceMean.
+    // Single-axis only in V1; multi-axis is dispatched but errors at
+    // run time so the runtime can fall back.  Decompose-into-chain
+    // is V2 work.
+    mask |= 1u32 << 0x0E;
+    mask |= 1u32 << 0x0F;
+    mask |= 1u32 << 0x10;
     // Reshape (0x11), Transpose (0x12), Broadcast (0x13), MatMul (0x15),
     // Cast (0x1A), Const (0x1B).
     mask |= 1u32 << 0x11;

--- a/code/packages/rust/matrix-metal/tests/integration.rs
+++ b/code/packages/rust/matrix-metal/tests/integration.rs
@@ -982,6 +982,303 @@ fn cast_f32_to_f32_on_gpu_is_identity() {
     assert_eq!(result, vec![1.5, -2.5, 0.0, std::f32::consts::PI]);
 }
 
+// ─────────────────── 4f. Reduce ───────────────────
+
+#[test]
+fn reduce_sum_axis1_on_gpu() {
+    // Input  (2 × 3):    [[1, 2, 3],
+    //                     [4, 5, 6]]
+    // Reduce axis 1, keep_dims = false → output shape [2]
+    //   Output: [1+2+3, 4+5+6] = [6.0, 15.0]
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let in_bytes = f32_bytes(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let in_shape = Shape::from(&[2, 3]);
+    let out_shape = Shape::from(&[2]);
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: 6 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: 2 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::ReduceSum {
+                    input: TensorId(1),
+                    axes: vec![1],
+                    keep_dims: false,
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::F32, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::F32, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+    let down = exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer: BufferId(2),
+        offset: 0,
+        len: 2 * 4,
+    });
+    let result = match down {
+        ExecutorResponse::BufferData { data, .. } => from_f32(&data),
+        other => panic!("download: {:?}", other),
+    };
+    assert_eq!(result, vec![6.0, 15.0]);
+}
+
+#[test]
+fn reduce_max_axis0_keep_dims_on_gpu() {
+    // Input  (2 × 3):    [[1, 5, 3],
+    //                     [4, 2, 6]]
+    // Reduce axis 0, keep_dims = true → output shape [1, 3]
+    //   Output: [[max(1,4), max(5,2), max(3,6)]] = [[4.0, 5.0, 6.0]]
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let in_bytes = f32_bytes(&[1.0, 5.0, 3.0, 4.0, 2.0, 6.0]);
+    let in_shape = Shape::from(&[2, 3]);
+    let out_shape = Shape::from(&[1, 3]);
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: 6 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: 3 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::ReduceMax {
+                    input: TensorId(1),
+                    axes: vec![0],
+                    keep_dims: true,
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::F32, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::F32, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+    let down = exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer: BufferId(2),
+        offset: 0,
+        len: 3 * 4,
+    });
+    let result = match down {
+        ExecutorResponse::BufferData { data, .. } => from_f32(&data),
+        other => panic!("download: {:?}", other),
+    };
+    assert_eq!(result, vec![4.0, 5.0, 6.0]);
+}
+
+#[test]
+fn reduce_mean_axis1_on_gpu() {
+    // Input  (2 × 4):    [[2, 4, 6, 8],
+    //                     [1, 3, 5, 7]]
+    // Reduce axis 1, keep_dims = false → output shape [2]
+    //   Output: [(2+4+6+8)/4, (1+3+5+7)/4] = [5.0, 4.0]
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let in_bytes = f32_bytes(&[2.0, 4.0, 6.0, 8.0, 1.0, 3.0, 5.0, 7.0]);
+    let in_shape = Shape::from(&[2, 4]);
+    let out_shape = Shape::from(&[2]);
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: 8 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: 2 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::ReduceMean {
+                    input: TensorId(1),
+                    axes: vec![1],
+                    keep_dims: false,
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::F32, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::F32, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+    let down = exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer: BufferId(2),
+        offset: 0,
+        len: 2 * 4,
+    });
+    let result = match down {
+        ExecutorResponse::BufferData { data, .. } => from_f32(&data),
+        other => panic!("download: {:?}", other),
+    };
+    assert_eq!(result, vec![5.0, 4.0]);
+}
+
+#[test]
+fn reduce_multi_axis_returns_error() {
+    // V1 only supports single-axis reduction.  Confirm a multi-axis
+    // attempt fails cleanly with an Error response (so the runtime
+    // can fall back to CPU).
+    let exec = match make_executor() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let in_bytes = f32_bytes(&[1.0, 2.0, 3.0, 4.0]);
+    let in_shape = Shape::from(&[2, 2]);
+    let out_shape = Shape::from(&[]); // reduce over both axes
+
+    let g = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: vec![],
+        outputs: vec![placed_metal(2, DType::F32, out_shape.clone(), metal_buf(2))],
+        constants: vec![PlacedConstant {
+            tensor: TensorId(0),
+            bytes: in_bytes,
+            residency: metal_buf(0),
+        }],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: metal_buf(1),
+                bytes: 4 * 4,
+            },
+            PlacedOp::Compute {
+                op: Op::Const {
+                    constant: 0,
+                    output: TensorId(1),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+            PlacedOp::Alloc {
+                residency: metal_buf(2),
+                bytes: 4,
+            },
+            PlacedOp::Compute {
+                op: Op::ReduceSum {
+                    input: TensorId(1),
+                    axes: vec![0, 1], // multi-axis — V2
+                    keep_dims: false,
+                    output: TensorId(2),
+                },
+                executor: METAL_ID,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors: vec![
+            placed_metal(0, DType::F32, in_shape.clone(), metal_buf(0)),
+            placed_metal(1, DType::F32, in_shape, metal_buf(1)),
+            placed_metal(2, DType::F32, out_shape, metal_buf(2)),
+        ],
+    };
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph: g }) {
+        ExecutorResponse::Error { message, .. } => {
+            assert!(
+                message.contains("single-axis"),
+                "expected single-axis error, got: {}",
+                message
+            );
+        }
+        other => panic!("expected Error for multi-axis reduce, got {:?}", other),
+    }
+}
+
 // ─────────────────── 5. Validation ───────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the reduction op trio (tags 0x0E, 0x0F, 0x10) to `matrix-metal`, **single-axis only**. Reduction completes the V1 elementwise + reduction op set on Metal — combined with shape ops (Reshape #2077, Transpose #2122, Broadcast #2126), casts (#2146), and elementwise ops (#2060), matrix-metal now handles the bulk of ML-style F32 graph patterns end-to-end.

`matrix-metal` v0.4.0 → v0.5.0.

## What this PR adds

Three new MSL kernels — `reduce_sum_f32`, `reduce_max_f32`, `reduce_mean_f32` — sharing a `REDUCE_F32_BODY` macro that:

1. Decomposes `gid` into an output multi-index using `out_dims`.
2. Builds a template input multi-index, skipping/adjusting the reduced axis based on `keep_dims`.
3. Sweeps `i = 0..reduce_size`, slotting `i` into the reduce-axis position and accumulating.
4. Writes the result (sum: as-is; max: starting from `-INFINITY`; mean: divided by `reduce_size`).

Supports `keep_dims = true` and `keep_dims = false`. Up to rank 4.

`reduce_dispatch` validates:
- `axes.len() == 1` (multi-axis returns Err so runtime can fall back)
- `rank ∈ 1..=4`
- `axis < rank`

Multi-axis decomposition into a chain of single-axis reductions is V2 work.

## Tests

4 new integration tests covering:

- **`reduce_sum_axis1_on_gpu`** — `[[1,2,3],[4,5,6]]` reduce-sum axis 1 → `[6, 15]`.
- **`reduce_max_axis0_keep_dims_on_gpu`** — `[[1,5,3],[4,2,6]]` reduce-max axis 0 with keep_dims → `[[4, 5, 6]]`.
- **`reduce_mean_axis1_on_gpu`** — `[[2,4,6,8],[1,3,5,7]]` reduce-mean axis 1 → `[5.0, 4.0]`.
- **`reduce_multi_axis_returns_error`** — verifies V1 multi-axis attempt fails cleanly with a "single-axis" error so the runtime can fall back.

Total: **17 integration tests** (was 13).

## Performance notes

Kernels are thread-per-output-element with sequential reads along the reduce axis. No tree reduction within a threadgroup — suboptimal for very long reduce axes but fine for the rank-2/3/4 reduce sizes typical in image / ML graphs (hundreds to thousands). V2 polish: tile-and-tree reduction kernels.

## Regression check

`instagram-filters` routing on macOS unchanged:

```
  invert        → cpu     (small graph, planner picks CPU)
  greyscale     → metal   (sRGB + matmul, ships to GPU)
  sepia         → metal   (matmul-heavy, ships to GPU)
```

image-gpu-core's filters don't currently use Op::Reduce, so the new capability advertises but doesn't perturb existing routing.

## Test plan

- [x] `cargo test -p matrix-metal` — 17 tests pass on macOS
- [x] `cargo build` clean
- [x] `instagram-filters` routing unchanged
- [x] Security review passed in one round (existing buffer-aliasing pattern reused; index arithmetic bounded by 16 MiB per-tensor cap; multi-axis fails-safe)

## Out of scope

- Multi-axis reduction (V2: decompose into a chain of single-axis kernels).
- Tile-and-tree reduction within a threadgroup (V2 micro-optimisation for large reduce axes).
- F16 / I8 / I16 reduction (V1 dtype set is F32 only on Metal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)