### PR TITLE
feat(symbolic-vm): Phase 30 — log/exp cancellation identities (v0.50.0)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.50.0 — 2026-05-05
+
+**Phase 30 — Algebraic `log` and `exp` cancellation identities.**
+
+Two new handlers override the `_elementary`-factory `Log` and `Exp` handlers
+from `handlers.py` via the standard `handlers.update(build_cas_handler_table())`
+mechanism.  All numeric fold behaviour is preserved.
+
+### `log_handler` (Phase 30, new function)
+
+New algebraic rules on top of the preserved numeric fold:
+
+- **`log(exp(x)) → x`**: Cancellation identity.  `exp` maps all of ℝ into ℝ⁺
+  and `log` is its exact inverse, so this holds for every real `x` without any
+  assumption.
+- **`log(x^n) → n * log(x)`**: Power rule.  Applied only when
+  `vm.assumptions.is_nonneg(x.name)` is True (prevents incorrect simplification
+  in the absence of positivity information).
+- **Guard for undefined inputs**: Negative or zero numeric arguments leave
+  the expression unevaluated (real-valued log is undefined there).
+
+### `exp_handler` (Phase 30, new function)
+
+New algebraic rules on top of the preserved numeric fold:
+
+- **`exp(log(x)) → x`**: Structural cancellation.  Any expression containing
+  `log(x)` already requires `x > 0` in the real domain, so `exp(log(x)) = x`
+  is always safe without an explicit assumption.
+- **`exp(n*log(x)) → x^n`**: Power form.  Recognises both `Mul(n, Log(x))`
+  and the commuted `Mul(Log(x), n)`, returning `Pow(x, n)`.  This simplifies
+  outputs of `logcontract`, `exponentialize`, and user-written expressions
+  like `exp(2*log(x))`.
+
+### Tests
+
+41 new tests in `tests/test_phase30.py` (total suite: 1558 tests, 82.29% coverage):
+
+- `TestPhase30_LogExpCancel` (6) — `log(exp(x))→x`, including compound args
+- `TestPhase30_ExpLogCancel` (7) — `exp(log(x))→x`, `exp(n*log(x))→x^n`
+- `TestPhase30_LogPower` (6) — power rule with/without assumption
+- `TestPhase30_LogNumeric` (5) — numeric fold, `log(1)→0`, negative guard
+- `TestPhase30_ExpNumeric` (5) — numeric fold, `exp(0)→1`
+- `TestPhase30_Regressions` (6) — Phase 29/28/3 regression checks
+- `TestPhase30_Macsyma` (6) — end-to-end MACSYMA surface syntax
+
 ## 0.49.0 — 2026-05-04
 
 **Phase 29 — Algebraic `abs` and `sqrt` simplification.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.49.0"
+version = "0.50.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -145,6 +145,8 @@ from polynomial import (
 from symbolic_ir import (
     ADD,
     DIV,
+    EXP,
+    LOG,
     MUL,
     NEG,
     POW,
@@ -2281,6 +2283,134 @@ def sqrt_handler(vm: VM, expr: IRApply) -> IRNode:
     return IRApply(expr.head, (arg,))
 
 
+def log_handler(vm: VM, expr: IRApply) -> IRNode:
+    """``Log(x)`` — natural logarithm with algebraic simplification.
+
+    This handler overrides the ``_elementary``-factory ``Log`` handler from
+    :mod:`symbolic_vm.handlers` (which was numeric-only) via the standard
+    ``handlers.update(build_cas_handler_table())`` mechanism.  All numeric
+    behaviour from the factory is preserved; algebraic rules are added on top.
+
+    Simplification rules
+    --------------------
+    1. **Special value**: ``Log(1) → 0``.
+
+    2. **Numeric fold**: positive integer / rational / float inputs are folded
+       via ``math.log``.  Negative or zero inputs are left unevaluated because
+       real-valued logarithm is undefined there.
+
+    3. **Cancellation** ``Log(Exp(x)) → x``:
+       ``exp`` maps all of ℝ into ℝ⁺, and ``log`` is its exact inverse, so
+       ``log(exp(x)) = x`` holds for every real ``x`` without any assumption.
+
+    4. **Power rule** ``Log(Pow(x, n)) → Mul(n, Log(x))``:
+       Requires ``vm.assumptions.is_nonneg(x.name)`` to be True, because
+       ``log(x^n) = n·log(x)`` only holds when ``x > 0`` (otherwise branch
+       cuts complicate the identity).
+
+    5. **Everything else**: leave unevaluated as ``Log(arg)``.
+
+    Examples::
+
+        log(1)          →  0
+        log(2.718…)     →  ≈ 1.0
+        log(exp(x))     →  x          (Phase 30)
+        log(exp(2*x))   →  2*x        (Phase 30)
+        # after assume(x > 0):
+        log(x^3)        →  Mul(3, Log(x))   (Phase 30)
+        # no assumption:
+        log(x^3)        →  Log(Pow(x, 3))   (unevaluated)
+    """
+    if len(expr.args) != 1:
+        return expr
+    arg = vm.eval(expr.args[0])
+    # Rule 1 + 2: numeric fold with special value and domain guard.
+    n = to_number(arg)
+    if n is not None:
+        if n == 1:
+            return IRInteger(0)
+        if n <= 0:
+            # log undefined for non-positive reals — leave unevaluated.
+            return IRApply(expr.head, (arg,))
+        return IRFloat(math.log(float(n)))
+    # Rule 3: log(exp(x)) = x  (cancellation, unconditional for real domain).
+    if isinstance(arg, IRApply) and arg.head == EXP and len(arg.args) == 1:
+        return arg.args[0]
+    # Rule 4: log(x^n) = n * log(x)  when x is known non-negative.
+    if isinstance(arg, IRApply) and arg.head == POW and len(arg.args) == 2:
+        base, exp_node = arg.args
+        if isinstance(base, IRSymbol) and vm.assumptions.is_nonneg(base.name) is True:
+            log_base = IRApply(LOG, (base,))
+            return IRApply(MUL, (exp_node, log_base))
+    # Rule 5: leave unevaluated.
+    return IRApply(expr.head, (arg,))
+
+
+def exp_handler(vm: VM, expr: IRApply) -> IRNode:
+    """``Exp(x)`` — natural exponential with algebraic simplification.
+
+    This handler overrides the ``_elementary``-factory ``Exp`` handler from
+    :mod:`symbolic_vm.handlers` (which was numeric-only) via the standard
+    ``handlers.update(build_cas_handler_table())`` mechanism.  All numeric
+    behaviour from the factory is preserved; algebraic rules are added on top.
+
+    Simplification rules
+    --------------------
+    1. **Special value**: ``Exp(0) → 1``.
+
+    2. **Numeric fold**: integer / rational / float inputs are folded via
+       ``math.exp``.
+
+    3. **Cancellation** ``Exp(Log(x)) → x``:
+       Any expression containing ``Log(x)`` already implies ``x > 0`` in the
+       real domain (log is only defined for positive arguments), so
+       ``exp(log(x)) = x`` is structurally safe — no explicit assumption needed.
+
+    4. **Power form** ``Exp(Mul(n, Log(x))) → Pow(x, n)`` (or the commuted
+       form ``Exp(Mul(Log(x), n))``):
+       ``e^{n·ln x} = x^n`` follows directly from the same domain argument as
+       Rule 3.  This simplifies outputs of ``logcontract``, ``exponentialize``,
+       and user-written expressions like ``exp(2*log(x))``.
+
+    5. **Everything else**: leave unevaluated as ``Exp(arg)``.
+
+    Examples::
+
+        exp(0)          →  1
+        exp(1.0)        →  ≈ 2.718
+        exp(log(x))     →  x           (Phase 30)
+        exp(2*log(x))   →  Pow(x, 2)   (Phase 30)
+        exp(log(x)*3)   →  Pow(x, 3)   (Phase 30, commuted Mul)
+    """
+    if len(expr.args) != 1:
+        return expr
+    arg = vm.eval(expr.args[0])
+    # Rule 1 + 2: numeric fold with exp(0) = 1 identity.
+    n = to_number(arg)
+    if n is not None:
+        if n == 0:
+            return IRInteger(1)
+        return IRFloat(math.exp(float(n)))
+    # Rule 3: exp(log(x)) = x  (structural cancellation).
+    if isinstance(arg, IRApply) and arg.head == LOG and len(arg.args) == 1:
+        return arg.args[0]
+    # Rule 4: exp(n * log(x)) = x^n  (both Mul orderings).
+    if isinstance(arg, IRApply) and arg.head == MUL and len(arg.args) == 2:
+        a, b = arg.args
+        # Check Mul(n, log(x)) and Mul(log(x), n).
+        log_node: IRApply | None = None
+        coeff: IRNode | None = None
+        if isinstance(a, IRApply) and a.head == LOG and len(a.args) == 1:
+            log_node, coeff = a, b
+        elif isinstance(b, IRApply) and b.head == LOG and len(b.args) == 1:
+            log_node, coeff = b, a
+        if log_node is not None and coeff is not None:
+            base = log_node.args[0]
+            return IRApply(POW, (base, coeff))
+    # Rule 5: leave unevaluated.
+    return IRApply(expr.head, (arg,))
+
+
 def cbrt_handler(_vm: VM, expr: IRApply) -> IRNode:
     """``Cbrt(x)`` → exact or numeric cube root.
 
@@ -2989,6 +3119,10 @@ def build_cas_handler_table() -> dict[str, Handler]:
         # Phase 29: overrides the _elementary-factory Sqrt in handlers.py,
         # adding algebraic rules (sqrt(x^{2k}) etc.) on top of numeric fold.
         "Sqrt": sqrt_handler,
+        # Phase 30: override _elementary-factory Log/Exp with cancellation
+        # and power-rule algebraic identities on top of numeric fold.
+        "Log": log_handler,
+        "Exp": exp_handler,
         "Cbrt": cbrt_handler,
         "Floor": floor_handler,
         "Ceiling": ceiling_handler,

--- a/code/packages/python/symbolic-vm/tests/test_phase30.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase30.py
@@ -1,0 +1,479 @@
+"""Phase 30 — Algebraic ``log`` and ``exp`` cancellation identities.
+
+Phase 30 adds two new handlers to ``symbolic-vm`` that override the numeric-only
+``_elementary``-factory ``Log`` and ``Exp`` handlers from ``handlers.py``:
+
+**log_handler new rules:**
+
+- ``Log(Exp(x))``         → ``x``             (cancellation, always safe for ℝ)
+- ``Log(Pow(x, n))``      → ``Mul(n, Log(x))``  (power rule, requires x ≥ 0 assumption)
+
+**exp_handler new rules:**
+
+- ``Exp(Log(x))``         → ``x``             (structural: log(x) requires x > 0)
+- ``Exp(Mul(n, Log(x)))`` → ``Pow(x, n)``     (power form; both Mul orderings)
+
+All numeric fold behaviour from the ``_elementary`` factory is preserved:
+``exp(0)→1``, ``log(1)→0``, float inputs, etc.
+
+Test structure
+--------------
+TestPhase30_LogExpCancel  — log(exp(x))→x, including nested/compound args
+TestPhase30_ExpLogCancel  — exp(log(x))→x, exp(n*log(x))→x^n
+TestPhase30_LogPower      — log(x^n)→n*log(x) assumption-aware
+TestPhase30_LogNumeric    — log(1)→0, log(e)≈1, negative/zero unevaluated
+TestPhase30_ExpNumeric    — exp(0)→1, exp(1.0)≈e, various numerics
+TestPhase30_Regressions   — Phase 29 abs/sqrt, Phase 28 assume, Phase 3
+TestPhase30_Macsyma       — end-to-end MACSYMA surface syntax
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from symbolic_ir import (
+    GREATER,
+    GREATER_EQUAL,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, SymbolicBackend
+
+# ── IR head constants ──────────────────────────────────────────────────────────
+
+LOG_HEAD = IRSymbol("Log")
+EXP_HEAD = IRSymbol("Exp")
+POW = IRSymbol("Pow")
+MUL = IRSymbol("Mul")
+ABS = IRSymbol("Abs")
+NEG = IRSymbol("Neg")
+ASSUME = IRSymbol("Assume")
+ADD = IRSymbol("Add")
+
+X = IRSymbol("x")
+Y = IRSymbol("y")
+
+ZERO = IRInteger(0)
+ONE = IRInteger(1)
+TWO = IRInteger(2)
+THREE = IRInteger(3)
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_vm() -> VM:
+    """Fresh VM with SymbolicBackend."""
+    return VM(SymbolicBackend())
+
+
+def _log(x: IRNode) -> IRApply:
+    return IRApply(LOG_HEAD, (x,))
+
+
+def _exp(x: IRNode) -> IRApply:
+    return IRApply(EXP_HEAD, (x,))
+
+
+def _pow(base: IRNode, exp: IRNode) -> IRApply:
+    return IRApply(POW, (base, exp))
+
+
+def _mul(a: IRNode, b: IRNode) -> IRApply:
+    return IRApply(MUL, (a, b))
+
+
+def _assume(pred: IRNode) -> IRApply:
+    return IRApply(ASSUME, (pred,))
+
+
+def _pos_pred(sym: IRSymbol) -> IRApply:
+    """Build ``x > 0`` predicate."""
+    return IRApply(GREATER, (sym, ZERO))
+
+
+def _nonneg_pred(sym: IRSymbol) -> IRApply:
+    """Build ``x >= 0`` predicate."""
+    return IRApply(GREATER_EQUAL, (sym, ZERO))
+
+
+# ── TestPhase30_LogExpCancel ───────────────────────────────────────────────────
+
+
+class TestPhase30_LogExpCancel:
+    """``log(exp(x)) = x`` — cancellation identity, always safe for real domain."""
+
+    def test_log_exp_symbol(self) -> None:
+        """log(exp(x)) → x (symbolic, no assumption needed)."""
+        vm = _make_vm()
+        result = vm.eval(_log(_exp(X)))
+        assert result == X
+
+    def test_log_exp_symbol_y(self) -> None:
+        """log(exp(y)) → y."""
+        vm = _make_vm()
+        assert vm.eval(_log(_exp(Y))) == Y
+
+    def test_log_exp_zero(self) -> None:
+        """log(exp(0)) → log(1) → 0  (numeric fold after exp)."""
+        vm = _make_vm()
+        result = vm.eval(_log(_exp(ZERO)))
+        assert result == ZERO
+
+    def test_log_exp_integer(self) -> None:
+        """log(exp(2)) → 2  (cancellation after exp folds to IRFloat,
+        or cancellation before numeric fold fires, depending on eval order).
+        Either the cancellation fires (result = 2) or we get float ≈ 2.0."""
+        vm = _make_vm()
+        result = vm.eval(_log(_exp(TWO)))
+        # Accept exact integer 2 or float ≈ 2.0
+        if isinstance(result, IRInteger):
+            assert result == TWO
+        else:
+            assert isinstance(result, IRFloat)
+            assert abs(result.value - 2.0) < 1e-10
+
+    def test_log_exp_neg_x(self) -> None:
+        """log(exp(-x)) → -x  (cancellation applies to negated symbol too)."""
+        vm = _make_vm()
+        result = vm.eval(_log(_exp(IRApply(NEG, (X,)))))
+        # -x evaluates first, then log(exp(-x)) → -x
+        assert isinstance(result, IRApply)
+        assert result.head == NEG
+        assert result.args[0] == X
+
+    def test_log_exp_mul(self) -> None:
+        """log(exp(2*x)) → 2*x  (compound argument)."""
+        vm = _make_vm()
+        two_x = _mul(TWO, X)
+        result = vm.eval(_log(_exp(two_x)))
+        # The inner 2*x stays as Mul(2,x) or may simplify — we just check
+        # that the outer log and exp cancel, leaving the inner intact
+        inner = vm.eval(two_x)
+        assert result == inner
+
+
+# ── TestPhase30_ExpLogCancel ───────────────────────────────────────────────────
+
+
+class TestPhase30_ExpLogCancel:
+    """``exp(log(x)) = x`` and ``exp(n*log(x)) = x^n``."""
+
+    def test_exp_log_symbol(self) -> None:
+        """exp(log(x)) → x  (structural: log(x) implies x > 0)."""
+        vm = _make_vm()
+        assert vm.eval(_exp(_log(X))) == X
+
+    def test_exp_log_symbol_y(self) -> None:
+        """exp(log(y)) → y."""
+        vm = _make_vm()
+        assert vm.eval(_exp(_log(Y))) == Y
+
+    def test_exp_log_integer(self) -> None:
+        """exp(log(3)) → 3  (cancellation before numeric fold fires)."""
+        vm = _make_vm()
+        result = vm.eval(_exp(_log(THREE)))
+        # Either exact 3 (if cancellation fires first) or float ≈ 3.0
+        if isinstance(result, IRInteger):
+            assert result == THREE
+        else:
+            assert isinstance(result, IRFloat)
+            assert abs(result.value - 3.0) < 1e-10
+
+    def test_exp_n_log_x_is_pow(self) -> None:
+        """exp(2*log(x)) → Pow(x, 2)."""
+        vm = _make_vm()
+        result = vm.eval(_exp(_mul(TWO, _log(X))))
+        assert isinstance(result, IRApply)
+        assert result.head == POW
+        assert result.args[0] == X
+        assert result.args[1] == TWO
+
+    def test_exp_log_x_n_commuted(self) -> None:
+        """exp(log(x)*3) → Pow(x, 3)  (commuted Mul order)."""
+        vm = _make_vm()
+        result = vm.eval(_exp(_mul(_log(X), THREE)))
+        assert isinstance(result, IRApply)
+        assert result.head == POW
+        assert result.args[0] == X
+        assert result.args[1] == THREE
+
+    def test_exp_n_log_y(self) -> None:
+        """exp(3*log(y)) → Pow(y, 3)."""
+        vm = _make_vm()
+        result = vm.eval(_exp(_mul(THREE, _log(Y))))
+        assert isinstance(result, IRApply)
+        assert result.head == POW
+        assert result.args[0] == Y
+        assert result.args[1] == THREE
+
+    def test_exp_log_structure(self) -> None:
+        """exp(log(x)) result is exactly X (not wrapped in anything)."""
+        vm = _make_vm()
+        result = vm.eval(_exp(_log(X)))
+        assert result == X
+        assert isinstance(result, IRSymbol)
+
+
+# ── TestPhase30_LogPower ───────────────────────────────────────────────────────
+
+
+class TestPhase30_LogPower:
+    """``log(x^n) = n * log(x)`` — assumption-aware power rule."""
+
+    def test_log_pow_with_pos_assumption(self) -> None:
+        """assume(x > 0); log(x^3) → Mul(3, Log(x))."""
+        vm = _make_vm()
+        vm.eval(_assume(_pos_pred(X)))
+        result = vm.eval(_log(_pow(X, THREE)))
+        assert isinstance(result, IRApply)
+        assert result.head == MUL
+        # Should be Mul(3, Log(x))
+        assert THREE in result.args
+        log_arg = [
+            a for a in result.args if isinstance(a, IRApply) and a.head == LOG_HEAD
+        ]
+        assert len(log_arg) == 1
+        assert log_arg[0].args[0] == X
+
+    def test_log_pow_with_nonneg_assumption(self) -> None:
+        """assume(x >= 0); log(x^2) → Mul(2, Log(x))."""
+        vm = _make_vm()
+        vm.eval(_assume(_nonneg_pred(X)))
+        result = vm.eval(_log(_pow(X, TWO)))
+        assert isinstance(result, IRApply)
+        assert result.head == MUL
+
+    def test_log_pow_no_assumption_unevaluated(self) -> None:
+        """log(x^3) → Log(Pow(x,3)) when no assumption — safety first."""
+        vm = _make_vm()
+        result = vm.eval(_log(_pow(X, THREE)))
+        assert isinstance(result, IRApply)
+        assert result.head == LOG_HEAD
+
+    def test_log_pow_y_no_assumption_unevaluated(self) -> None:
+        """log(y^2) → Log(Pow(y,2)) — no assumption about y."""
+        vm = _make_vm()
+        result = vm.eval(_log(_pow(Y, TWO)))
+        assert isinstance(result, IRApply)
+        assert result.head == LOG_HEAD
+
+    def test_log_pow_unrelated_assumption(self) -> None:
+        """assume(x > 0); log(y^3) → unevaluated (assumption is for x, not y)."""
+        vm = _make_vm()
+        vm.eval(_assume(_pos_pred(X)))
+        result = vm.eval(_log(_pow(Y, THREE)))
+        assert isinstance(result, IRApply)
+        assert result.head == LOG_HEAD
+
+    def test_log_pow_power_rule_coefficient(self) -> None:
+        """assume(x > 0); log(x^n) result contains n and log(x) as factors."""
+        vm = _make_vm()
+        vm.eval(_assume(_pos_pred(X)))
+        n = IRInteger(5)
+        result = vm.eval(_log(_pow(X, n)))
+        assert isinstance(result, IRApply)
+        assert result.head == MUL
+        assert n in result.args
+
+
+# ── TestPhase30_LogNumeric ─────────────────────────────────────────────────────
+
+
+class TestPhase30_LogNumeric:
+    """Numeric fold for ``Log`` — preserved from ``_elementary`` factory."""
+
+    def test_log_one(self) -> None:
+        """log(1) → 0."""
+        vm = _make_vm()
+        assert vm.eval(_log(ONE)) == ZERO
+
+    def test_log_e_approx(self) -> None:
+        """log(e) ≈ 1.0  (e = 2.718…)."""
+        vm = _make_vm()
+        result = vm.eval(_log(IRFloat(math.e)))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - 1.0) < 1e-12
+
+    def test_log_float(self) -> None:
+        """log(2.0) ≈ 0.693."""
+        vm = _make_vm()
+        result = vm.eval(_log(IRFloat(2.0)))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - math.log(2.0)) < 1e-12
+
+    def test_log_zero_unevaluated(self) -> None:
+        """log(0) → unevaluated (undefined in reals)."""
+        vm = _make_vm()
+        result = vm.eval(_log(ZERO))
+        assert isinstance(result, IRApply)
+        assert result.head == LOG_HEAD
+
+    def test_log_negative_unevaluated(self) -> None:
+        """log(-1) → unevaluated (undefined in reals)."""
+        vm = _make_vm()
+        result = vm.eval(_log(IRInteger(-1)))
+        assert isinstance(result, IRApply)
+        assert result.head == LOG_HEAD
+
+
+# ── TestPhase30_ExpNumeric ─────────────────────────────────────────────────────
+
+
+class TestPhase30_ExpNumeric:
+    """Numeric fold for ``Exp`` — preserved from ``_elementary`` factory."""
+
+    def test_exp_zero(self) -> None:
+        """exp(0) → 1."""
+        vm = _make_vm()
+        assert vm.eval(_exp(ZERO)) == ONE
+
+    def test_exp_one_float(self) -> None:
+        """exp(1.0) ≈ 2.718."""
+        vm = _make_vm()
+        result = vm.eval(_exp(IRFloat(1.0)))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - math.e) < 1e-12
+
+    def test_exp_neg_float(self) -> None:
+        """exp(-1.0) ≈ 0.368."""
+        vm = _make_vm()
+        result = vm.eval(_exp(IRFloat(-1.0)))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - math.exp(-1.0)) < 1e-12
+
+    def test_exp_integer_folds(self) -> None:
+        """exp(2) → IRFloat ≈ 7.389 (not a perfect integer, stays float)."""
+        vm = _make_vm()
+        result = vm.eval(_exp(TWO))
+        assert isinstance(result, IRFloat)
+        assert abs(result.value - math.exp(2.0)) < 1e-10
+
+    def test_exp_symbolic_unevaluated(self) -> None:
+        """exp(x) → Exp(x) unevaluated (x is symbolic, no special pattern)."""
+        vm = _make_vm()
+        result = vm.eval(_exp(X))
+        assert isinstance(result, IRApply)
+        assert result.head == EXP_HEAD
+
+
+# ── TestPhase30_Regressions ────────────────────────────────────────────────────
+
+
+class TestPhase30_Regressions:
+    """Ensure Phase 29 and earlier behaviour is fully preserved."""
+
+    def test_phase29_sqrt_x_squared(self) -> None:
+        """Phase 29: sqrt(x^2) → Abs(x)."""
+        SQRT_HEAD = IRSymbol("Sqrt")
+        vm = _make_vm()
+        result = vm.eval(IRApply(SQRT_HEAD, (_pow(X, TWO),)))
+        assert isinstance(result, IRApply)
+        assert result.head == ABS
+        assert result.args[0] == X
+
+    def test_phase29_abs_neg_x(self) -> None:
+        """Phase 29: abs(-x) → Abs(x)."""
+        vm = _make_vm()
+        result = vm.eval(IRApply(ABS, (IRApply(NEG, (X,)),)))
+        assert result == IRApply(ABS, (X,))
+
+    def test_phase28_abs_with_assumption(self) -> None:
+        """Phase 28: assume(x > 0); abs(x) → x."""
+        vm = _make_vm()
+        vm.eval(_assume(_pos_pred(X)))
+        assert vm.eval(IRApply(ABS, (X,))) == X
+
+    def test_phase3_cos_zero(self) -> None:
+        """Phase 3: cos(0) → 1 (elementary function regression)."""
+        COS = IRSymbol("Cos")
+        vm = _make_vm()
+        assert vm.eval(IRApply(COS, (ZERO,))) == ONE
+
+    def test_exp_zero_still_one(self) -> None:
+        """exp(0) = 1 preserved from _elementary factory baseline."""
+        vm = _make_vm()
+        assert vm.eval(_exp(ZERO)) == ONE
+
+    def test_log_one_still_zero(self) -> None:
+        """log(1) = 0 preserved from _elementary factory baseline."""
+        vm = _make_vm()
+        assert vm.eval(_log(ONE)) == ZERO
+
+
+# ── TestPhase30_Macsyma ────────────────────────────────────────────────────────
+
+
+class TestPhase30_Macsyma:
+    """End-to-end tests via MACSYMA surface syntax.
+
+    All tests skip gracefully when ``macsyma_runtime`` is not installed.
+    """
+
+    def _make_vm(self) -> VM:
+        pytest.importorskip(
+            "macsyma_runtime",
+            reason="macsyma-runtime not installed; skipping MACSYMA e2e test",
+        )
+        from macsyma_compiler.compiler import _STANDARD_FUNCTIONS  # noqa: PLC0415
+        from macsyma_runtime import MacsymaBackend  # noqa: PLC0415
+        from macsyma_runtime.name_table import (
+            extend_compiler_name_table,  # noqa: PLC0415
+        )
+
+        extend_compiler_name_table(_STANDARD_FUNCTIONS)
+        return VM(MacsymaBackend())
+
+    def _run(self, source: str, vm: VM) -> IRNode:
+        from macsyma_compiler import compile_macsyma  # noqa: PLC0415
+        from macsyma_parser import parse_macsyma  # noqa: PLC0415
+
+        ast = parse_macsyma(source + ";")
+        stmts = compile_macsyma(ast)
+        result: IRNode = ZERO
+        for stmt in stmts:
+            result = vm.eval(stmt)
+        return result
+
+    @pytest.fixture()
+    def vm(self) -> VM:
+        return self._make_vm()
+
+    def test_log_exp_x_macsyma(self, vm: VM) -> None:
+        """log(exp(x)) → x via MACSYMA surface syntax."""
+        result = self._run("log(exp(x))", vm)
+        assert result == X
+
+    def test_exp_log_x_macsyma(self, vm: VM) -> None:
+        """exp(log(x)) → x via MACSYMA surface syntax."""
+        result = self._run("exp(log(x))", vm)
+        assert result == X
+
+    def test_exp_2_log_x_macsyma(self, vm: VM) -> None:
+        """exp(2*log(x)) → x^2 via MACSYMA."""
+        result = self._run("exp(2*log(x))", vm)
+        assert isinstance(result, IRApply)
+        assert result.head == POW
+        assert result.args[0] == X
+        assert result.args[1] == TWO
+
+    def test_log_one_macsyma(self, vm: VM) -> None:
+        """log(1) → 0 via MACSYMA."""
+        result = self._run("log(1)", vm)
+        assert result == ZERO
+
+    def test_exp_zero_macsyma(self, vm: VM) -> None:
+        """exp(0) → 1 via MACSYMA."""
+        result = self._run("exp(0)", vm)
+        assert result == ONE
+
+    def test_log_x_cubed_with_assume_macsyma(self, vm: VM) -> None:
+        """assume(x > 0); log(x^3) → 3*log(x) via MACSYMA."""
+        self._run("assume(x > 0)", vm)
+        result = self._run("log(x^3)", vm)
+        assert isinstance(result, IRApply)
+        assert result.head == MUL

--- a/code/specs/phase30-log-exp-identities.md
+++ b/code/specs/phase30-log-exp-identities.md
@@ -1,0 +1,148 @@
+# Phase 30 — Algebraic `log` and `exp` Cancellation Identities
+
+## Context
+
+Phase 29 (merged as PR #2149) added algebraic rules for `abs` and `sqrt`.
+The elementary function handlers (`Log`, `Exp`) in `handlers.py` are still the
+pure `_elementary` factory — they only do numeric fold.  A CAS user rightly
+expects these simplifications to work:
+
+```
+log(exp(x))      →  x           [always true for real x]
+exp(log(x))      →  x           [structural: log(x) requires x > 0]
+log(x^n)         →  n*log(x)    [when x > 0 is known]
+exp(n*log(x))    →  x^n         [structural: inverse of log(x^n)]
+```
+
+Phase 30 adds two new handlers — `log_handler` and `exp_handler` — that
+override the `_elementary`-factory handlers via the same
+`handlers.update(build_cas_handler_table())` mechanism used in Phase 29 for
+`sqrt_handler`.
+
+---
+
+## Mathematical Rules
+
+### `log` identities
+
+| Pattern | Result | Condition | Reason |
+|---------|--------|-----------|--------|
+| `log(exp(x))` | `x` | none | `log` and `exp` are exact inverses over ℝ |
+| `log(Pow(x, n))` | `n * log(x)` | `x > 0` assumed | `log(x^n) = n·log(x)` |
+| Numeric fold | `IRFloat(math.log(n))` | `n > 0` | standard numeric eval |
+| Special value | `0` | `n == 1` | `log(1) = 0` |
+| Negative/zero arg | unevaluated | `n ≤ 0` | real log undefined |
+
+**Why `log(exp(x)) → x` is unconditional:**
+`exp` maps all of ℝ into ℝ⁺, and `log` is the exact inverse on ℝ⁺.
+So `log(exp(x)) = x` for every real `x` without any assumption.
+
+### `exp` identities
+
+| Pattern | Result | Condition | Reason |
+|---------|--------|-----------|--------|
+| `exp(log(x))` | `x` | structural | Any expr containing `log(x)` requires `x > 0`; `exp(log(x)) = x` |
+| `exp(Mul(n, log(x)))` | `Pow(x, n)` | structural | `e^(n·ln x) = x^n` (same domain argument) |
+| `exp(Mul(log(x), n))` | `Pow(x, n)` | structural | commuted arg order |
+| Numeric fold | `IRFloat(math.exp(n))` | any numeric `n` | standard numeric eval |
+| Special value | `1` | `n == 0` | `exp(0) = 1` |
+
+**Why `exp(log(x)) → x` is structural (no explicit assumption needed):**
+The sub-expression `log(x)` is only meaningful when `x > 0`. Therefore any
+surrounding `exp(log(x))` that the user wrote or the evaluator produced
+already carries an implicit positivity constraint.  Simplifying to `x` is
+safe under real-domain semantics.
+
+---
+
+## Files to Change
+
+All paths under `code/packages/python/symbolic-vm/`.
+
+| File | Change |
+|------|--------|
+| `code/specs/phase30-log-exp-identities.md` | **NEW** (this file) |
+| `src/symbolic_vm/cas_handlers.py` | Add `EXP`/`LOG` imports; add `exp_handler` + `log_handler`; register in `build_cas_handler_table()` |
+| `tests/test_phase30.py` | **NEW** ≥32 tests |
+| `CHANGELOG.md` | 0.50.0 entry |
+| `pyproject.toml` | Bump to 0.50.0 |
+
+No changes to `macsyma-runtime` (`log`/`exp` already in name table and
+`build_cas_handler_table()` from `symbolic_vm` is already included).
+No changes to `symbolic-ir` (no new IR heads).
+
+---
+
+## Implementation Details
+
+### Import additions
+
+```python
+# In the `from symbolic_ir import (` block:
+    EXP,
+    LOG,
+```
+
+### `log_handler`
+
+```python
+def log_handler(vm: VM, expr: IRApply) -> IRNode:
+    """``Log(x)`` — natural logarithm with algebraic simplification.
+
+    Rules:
+    1. Special value: log(1) = 0.
+    2. Numeric fold: log(n) for n > 0.
+    3. log(exp(x)) = x   (cancellation, always safe for real x).
+    4. log(x^n) = n*log(x)  when assume(x > 0) or assume(x >= 0) active.
+    5. Negative/zero numeric input: leave unevaluated (undefined in reals).
+    6. Everything else: unevaluated.
+    """
+```
+
+### `exp_handler`
+
+```python
+def exp_handler(vm: VM, expr: IRApply) -> IRNode:
+    """``Exp(x)`` — natural exponential with algebraic simplification.
+
+    Rules:
+    1. Special value: exp(0) = 1.
+    2. Numeric fold: exp(n) for any numeric n.
+    3. exp(log(x)) = x   (structural cancellation).
+    4. exp(n*log(x)) = x^n  (structural; covers both Mul(n,log) and Mul(log,n)).
+    5. Everything else: unevaluated.
+    """
+```
+
+---
+
+## Test Structure (`test_phase30.py`, ≥32 tests)
+
+| Class | Count | What is verified |
+|-------|-------|-----------------|
+| `TestPhase30_LogExpCancel` | 6 | `log(exp(x))→x`, `log(exp(0))→0`, `log(exp(2x))→2x` |
+| `TestPhase30_ExpLogCancel` | 6 | `exp(log(x))→x`, `exp(log(3))→3`, `exp(2*log(x))→x^2` |
+| `TestPhase30_LogPower` | 6 | `log(x^n)→n*log(x)` with assumption; odd/no-assumption stays unevaluated |
+| `TestPhase30_LogNumeric` | 5 | `log(1)→0`, `log(e)≈1`, `log(2.0)`, negative stays unevaluated |
+| `TestPhase30_ExpNumeric` | 5 | `exp(0)→1`, `exp(1.0)≈e`, `exp(-1.0)`, `exp(2)` |
+| `TestPhase30_Regressions` | 4 | Phase 29 abs/sqrt, Phase 28 assume/sign, Phase 3 cos(0) |
+| `TestPhase30_Macsyma` | 6 | `log(exp(x))`, `exp(log(x))`, `exp(2*log(x))`, `log(x^2)` via MACSYMA surface |
+
+---
+
+## Verification
+
+```bash
+cd code/packages/python/symbolic-vm
+.venv/bin/pytest tests/ -q          # ≥1549 tests, ≥80% coverage
+.venv/bin/ruff check src/ tests/    # zero errors
+```
+
+Spot-checks:
+```python
+# log(exp(x))        →  x
+# exp(log(x))        →  x
+# exp(2*log(x))      →  Pow(x, 2)
+# log(x^3) no assume →  Log(Pow(x, 3))  [unevaluated]
+# assume(x>0): log(x^3) →  Mul(3, Log(x))
+```


### PR DESCRIPTION
## Summary

- **`log(exp(x)) = x`** — unconditional real-domain cancellation (exp maps ℝ→ℝ⁺, log is its exact inverse)
- **`exp(log(x)) = x`** — structural cancellation (presence of `log(x)` already implies `x > 0`)
- **`log(x^n) = n*log(x)`** — assumption-aware rule, fires only when `x` is assumed non-negative
- **`exp(n*log(x)) = x^n`** — power form, checks both `Mul(n, Log(x))` and `Mul(Log(x), n)` orderings
- Numeric folding: `log(1) = 0`, `exp(0) = 1`, general float evaluation; domain guard on `log(≤0)`
- `log_handler` and `exp_handler` registered in `build_cas_handler_table()`, overriding the numeric-only `_elementary` factory defaults
- MACSYMA surface syntax wired: `log(exp(x))`, `exp(log(x))`, `exp(2*log(x))`, `simplify(log(x^2))` (with assumption)
- 41 new tests (total 1558 passing), 82.29% coverage; ruff clean

## Test plan

- [x] `pytest tests/ -q` — all 1558 tests pass, coverage 82.29% (≥80%)
- [x] `ruff check src/ tests/` — zero errors
- [x] Security review passed — no vulnerabilities found
- [x] MACSYMA e2e tests included (lazy-import via `pytest.importorskip`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)