### PR TITLE
feat(image-gpu-core): MX05 Phase 3 V4 — wire Profiler + SpecRouter into dispatch

### DIFF
--- a/code/packages/rust/image-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/image-gpu-core/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog — image-gpu-core
 
+## 0.4.0 — 2026-05-05
+
+### Added — MX05 Phase 3 V4 wiring
+
+- Each call to `pipeline::run_graph_with_constant_inputs` now drives
+  the MX05 specialisation pipeline end-to-end:
+    1. `Profiler::record_dispatch` bumps per-(graph, op) invocation
+       counters.
+    2. `SpecRouter::route` is consulted for every Compute op, with the
+       op's wire tag, output dtype, and target executor id.
+    3. The router's return is **discarded in V1** — `NoopSpecialiser`
+       declines every key.  The wiring is foundation for Phase 4
+       when a real specialiser arrives.
+- New public observation hooks:
+    - `image_gpu_core::profiler_observations()` — snapshot the
+      accumulated `ProfileObservation` set.  Useful for telemetry,
+      tests, and future phase 4 caller-side logic.
+    - `image_gpu_core::spec_cache_len()` — how many specialised
+      kernels are cached process-wide.  Always `0` while
+      `NoopSpecialiser` is installed.
+- Per-process `Profiler` and `SpecRouter` singletons via `OnceLock`
+  so the routing pipeline is set up once and amortised across all
+  filter invocations.
+
+### Tests (1 new)
+
+- `dispatch_drives_spec_router_pipeline` — gpu_invert produces a
+  visible bump in `profiler_observations`'s aggregate invocation
+  count.  Cache stays empty (NoopSpecialiser).
+
+### Notes
+
+- No behavioural change in the dispatch path itself.  Routing,
+  output bytes, and the `last_executor()` value are unchanged.
+- Phase 4 will install a backend-specific specialiser (e.g. an
+  MSL emitter that constant-folds bias values for an LLM bias-add
+  pattern).  When that lands, `spec_cache_len()` will start rising
+  and `route()` will start returning `Some(SpecialisedKernel)`s
+  that the dispatch path will consume — once `executor-protocol`
+  grows a way for backends to dispatch via a SpecKey-keyed kernel
+  handle.
+
 ## 0.3.0 — 2026-05-04
 
 ### Added

--- a/code/packages/rust/image-gpu-core/Cargo.toml
+++ b/code/packages/rust/image-gpu-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "image-gpu-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). Each operation is a MatrixIR graph dispatched through matrix-runtime; v0.3 wires the optional matrix-metal GPU backend behind a default-on feature flag, with transparent fallback to matrix-cpu on non-Apple targets."
+description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). Each operation is a MatrixIR graph dispatched through matrix-runtime; v0.3 wires the optional matrix-metal GPU backend behind a default-on feature flag, with transparent fallback to matrix-cpu on non-Apple targets. v0.4 wires the MX05 specialisation pipeline (Profiler + SpecRouter) into every dispatch — invocation counters and routing-decision observability are now live; the no-op specialiser declines all keys until Phase 4 lands a real one."
 
 [dependencies]
 matrix-ir         = { path = "../matrix-ir" }

--- a/code/packages/rust/image-gpu-core/src/lib.rs
+++ b/code/packages/rust/image-gpu-core/src/lib.rs
@@ -52,6 +52,14 @@ mod sergb;
 /// actually ran without changing the public function signatures.
 pub use pipeline::last_executor;
 
+/// MX05 Phase 3 V4 observation hooks.  After any successful filter
+/// dispatch, [`profiler_observations`] returns the accumulated
+/// per-(graph, op) invocation counters (and per-tensor stats once
+/// Phase 4 lands a real specialiser).  [`spec_cache_len`] reports
+/// how many specialised kernels are cached process-wide; always 0
+/// while the no-op specialiser is installed in V1.
+pub use pipeline::{profiler_observations, spec_cache_len};
+
 use matrix_ir::{DType, GraphBuilder, Shape};
 
 /// User-facing error type.  Compatible with v0.1's `GpuError` for ABI

--- a/code/packages/rust/image-gpu-core/src/pipeline.rs
+++ b/code/packages/rust/image-gpu-core/src/pipeline.rs
@@ -55,16 +55,17 @@
 //! the right transport, and handles `Transfer` itself.
 
 use crate::GpuError;
-use compute_ir::ComputeGraph;
+use compute_ir::{ComputeGraph, PlacedOp};
 #[cfg(feature = "metal-backend")]
-use compute_ir::{ExecutorId, PlacedOp, CPU_EXECUTOR};
+use compute_ir::{ExecutorId, CPU_EXECUTOR};
 use executor_protocol::{block_on, ExecutorRequest, ExecutorResponse, LocalTransport, Transport};
 use matrix_ir::{Graph, TensorId};
-use matrix_runtime::Runtime;
+use matrix_runtime::{
+    DefaultPolicy, NoopSpecialiser, Profiler, Runtime, SpecCache, SpecRouter,
+};
 use std::cell::Cell;
 #[cfg(feature = "metal-backend")]
 use std::collections::HashSet;
-#[cfg(feature = "metal-backend")]
 use std::sync::OnceLock;
 
 // ─────────────────────────── Last-executor reporting ───────────────────────────
@@ -125,6 +126,113 @@ fn metal_backend() -> Option<&'static MetalBackend> {
     .as_ref()
 }
 
+// ─────────────────────────── MX05 specialisation singletons ───────────────────────────
+//
+// MX05 Phase 1 / 2a / 3 V1 / V2 / V3 shipped the Profiler /
+// SpecialisationPolicy / SpecCache / SpecRouter machinery in
+// matrix-runtime.  Phase 3 V4 wires them up here so every
+// `run_graph_with_constant_inputs` call records an invocation
+// observation and asks the router whether to specialise each op.
+//
+// In V4 the answer is **always None** (the V1 backend doesn't yet
+// install a real `Specialiser`; we use `NoopSpecialiser` which
+// declines every key) — but the wiring is observable through the
+// public `profiler()` accessor and is foundation for Phase 4 when a
+// real specialiser arrives.
+//
+// Both singletons are lazy via `OnceLock`.  Constructing the SpecRouter
+// allocates a small SpecCache plus the policy + specialiser trait
+// objects; cheap, but doing it once instead of per-call keeps the
+// hot path tight.
+
+fn profiler() -> &'static Profiler {
+    static SLOT: OnceLock<Profiler> = OnceLock::new();
+    SLOT.get_or_init(Profiler::new)
+}
+
+fn spec_router() -> &'static SpecRouter {
+    static SLOT: OnceLock<SpecRouter> = OnceLock::new();
+    SLOT.get_or_init(|| {
+        SpecRouter::new(
+            Box::new(DefaultPolicy::new()),
+            SpecCache::default_capacity(),
+            // V1 of image-gpu-core ships the no-op specialiser.
+            // Phase 4 will swap in a backend-specific one (e.g. an
+            // MSL emitter that constant-folds bias values).
+            Box::new(NoopSpecialiser),
+        )
+    })
+}
+
+/// Snapshot the profile observation accumulated by this process so
+/// far.  Phase 3 V4's CLI demos and tests use this to confirm the
+/// specialisation pipeline is live (invocation counts climb across
+/// repeat calls; cache stays empty under `NoopSpecialiser`).
+///
+/// Returns the same data shape as
+/// [`matrix_runtime::Profiler::observations`] for callers that want
+/// to inspect specific ops.
+pub fn profiler_observations() -> Vec<matrix_runtime::ProfileObservation> {
+    profiler().observations()
+}
+
+/// How many specialised kernels the process-wide cache currently
+/// holds.  Always `0` while `NoopSpecialiser` is installed; Phase 4
+/// will see this rise as backends emit specialisations.
+pub fn spec_cache_len() -> usize {
+    spec_router().cache_len()
+}
+
+/// Drive the MX05 specialisation pipeline for one placed graph:
+///
+/// 1. Bump per-op invocation counters via `Profiler::record_dispatch`.
+/// 2. Build a `ProfileObservation` per Compute op and pass it to
+///    `SpecRouter::route` along with op metadata.  Discard the
+///    return — V1 always gets `None` from the no-op specialiser.
+///
+/// Pure observation work; no behavioural change to the dispatch
+/// itself.  Returns no value.
+fn drive_specialisation(placed: &ComputeGraph) {
+    let p = profiler();
+    p.record_dispatch(placed);
+
+    let r = spec_router();
+    let subhash = Profiler::subhash(placed);
+
+    // Observations() returns every cached observation; index by
+    // (subhash, op_index) so the per-op router calls below are O(n)
+    // total rather than O(n²).
+    let obs = p.observations();
+    let mut by_op: std::collections::HashMap<u32, &matrix_runtime::ProfileObservation> =
+        std::collections::HashMap::new();
+    for o in &obs {
+        if o.graph_subhash == subhash {
+            by_op.insert(o.op_index, o);
+        }
+    }
+
+    for (op_idx, pop) in placed.ops.iter().enumerate() {
+        if let PlacedOp::Compute { op: ir_op, executor, .. } = pop {
+            let key = op_idx as u32;
+            let observation = match by_op.get(&key) {
+                Some(o) => *o,
+                None => continue,
+            };
+            // Output dtype: look up in the placed graph's tensor
+            // table by the op's output tensor id.
+            let out_id = ir_op.output();
+            let out_dtype = match placed.tensor(out_id) {
+                Some(t) => t.dtype,
+                None => continue,
+            };
+            // Discard the return — V1 noop specialiser declines every
+            // key.  Phase 4 will use the returned `SpecialisedKernel`
+            // to dispatch a specialised kernel handle to the backend.
+            let _ = r.route(observation, ir_op.wire_tag(), out_dtype, executor.0);
+        }
+    }
+}
+
 // ─────────────────────────── Public entry point ───────────────────────────
 
 /// Plan and run a graph that has all its inputs embedded as constants
@@ -177,6 +285,14 @@ pub fn run_graph_with_constant_inputs(
 
 /// Dispatch a placed graph through a specific transport, then download
 /// the output and record the executor name as last-used.
+///
+/// Before forwarding to the transport, this function drives the MX05
+/// specialisation pipeline ([`drive_specialisation`]): per-op
+/// invocation counters climb, and the [`SpecRouter`] is asked
+/// whether each Compute op should specialise.  In V1 the answer is
+/// always None (the noop specialiser is installed) — Phase 4 will
+/// install a real specialiser and the same call site will start
+/// emitting kernels.
 fn dispatch_via(
     transport: &LocalTransport,
     placed: ComputeGraph,
@@ -184,6 +300,8 @@ fn dispatch_via(
     output_byte_count: usize,
     executor_name: &'static str,
 ) -> Result<Vec<u8>, GpuError> {
+    drive_specialisation(&placed);
+
     let output_residency = placed
         .outputs
         .iter()
@@ -393,6 +511,48 @@ mod tests {
         let exec = last_executor().expect("an executor name should be recorded");
         // CPU is always available; Metal may or may not be present.
         assert!(exec == "cpu" || exec == "metal", "unexpected: {}", exec);
+    }
+
+    /// MX05 Phase 3 V4 wiring smoke test.  Confirms that calling a
+    /// public op (gpu_invert) drives the SpecRouter pipeline:
+    /// observations accumulate, but the cache stays empty under
+    /// the no-op specialiser installed in V1.
+    #[test]
+    fn dispatch_drives_spec_router_pipeline() {
+        use crate::{gpu_invert, profiler_observations, spec_cache_len};
+        use pixel_container::PixelContainer;
+
+        let mut img = PixelContainer::new(2, 2);
+        img.fill(10, 20, 30, 255);
+
+        // Take a baseline.  The profiler is process-global so other
+        // tests in this file may have already populated it; capture
+        // the *delta* across this dispatch instead of asserting an
+        // absolute count.
+        let before: u64 = profiler_observations()
+            .iter()
+            .map(|o| o.invocation_count)
+            .sum();
+
+        let _ = gpu_invert(&img).unwrap();
+
+        let after: u64 = profiler_observations()
+            .iter()
+            .map(|o| o.invocation_count)
+            .sum();
+        assert!(
+            after > before,
+            "gpu_invert should bump at least one observation counter \
+             (before = {}, after = {})",
+            before,
+            after
+        );
+
+        // No-op specialiser declines every key, so the cache stays
+        // empty regardless of how many dispatches have happened.
+        // Phase 4 will see this number rise as backends emit
+        // specialisations.
+        assert_eq!(spec_cache_len(), 0);
     }
 }
 

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -242,6 +242,19 @@ The compile happens in a background worker thread so live dispatches
 aren't blocked.  Once ready, the specialised pipeline is inserted
 into the cache.
 
+> **Implementation status (Phase 3 V4 landed — image-gpu-core wired)**:
+> `image-gpu-core::pipeline::run_graph_with_constant_inputs` now
+> drives the full pipeline on every dispatch — `Profiler::record_dispatch`
+> updates invocation counters and `SpecRouter::route` is consulted
+> per Compute op.  Per-process singletons (`OnceLock`-backed Profiler
+> and SpecRouter with `NoopSpecialiser` installed) amortise setup
+> cost across calls.  Public hooks `image_gpu_core::profiler_observations()`
+> and `image_gpu_core::spec_cache_len()` make the wiring observable
+> from CLI demos and tests.  Phase 4 will install a backend-specific
+> `Specialiser` (matrix-cpu or matrix-metal emitting kernels with
+> constants folded in) and the route() return will start being
+> consumed by an extended executor-protocol.
+
 > **Implementation status (Phase 3 V3 landed)**: `SpecRouter` ships
 > in `matrix_runtime::router` and ties together the four pieces:
 > Profiler observations → policy → cache → specialiser, end-to-end.


### PR DESCRIPTION
## Summary

Ties the MX05 specialisation machinery from Phase 1/2a/3 V1/V2/V3 into the domain library that actually does the dispatching. Every call to `pipeline::run_graph_with_constant_inputs` now drives the full pipeline: invocation counters tick up, the SpecRouter is consulted per Compute op, the no-op specialiser declines every key (V1), and observations flow.

`image-gpu-core` v0.3.0 → v0.4.0.

## What this PR adds

- Per-process **`Profiler`** and **`SpecRouter`** singletons via `OnceLock` — setup amortised across all filter invocations.
- `dispatch_via` now calls `drive_specialisation(&placed)` before forwarding to the transport:
  1. `Profiler::record_dispatch(&placed)` bumps per-op invocation counters.
  2. For each Compute op: build a `ProfileObservation`, call `SpecRouter::route(observation, op_kind, output_dtype, backend_id)`, discard the return.

V1 always gets `None` back (NoopSpecialiser is installed); the wiring is foundation for Phase 4 when a backend installs a real `Specialiser`.

- New public observation hooks:
  - `profiler_observations() -> Vec<ProfileObservation>`
  - `spec_cache_len() -> usize`

These let CLI demos and tests confirm the pipeline is live. Phase 4's specialiser-emitted kernels will show up via these same hooks.

## Tests

1 new test — `dispatch_drives_spec_router_pipeline` — verifies gpu_invert produces a visible bump in the aggregate invocation count. Cache stays empty (NoopSpecialiser).

Total: **26 unit + 1 doc = 27 tests** (was 25 + 1 = 26).

## Regression check

`instagram-filters` routing on macOS unchanged after this PR:

```
  invert        → cpu     (small graph, planner picks CPU)
  greyscale     → metal   (sRGB + matmul, ships to GPU)
  sepia         → metal   (matmul-heavy, ships to GPU)
```

The dispatch path itself is unchanged; routing, output bytes, and the `last_executor()` value all match V0.3.0 behaviour. Only new behaviour: profiler counters climb across calls.

## Test plan

- [x] `cargo test -p image-gpu-core` — 26 + 1 tests pass
- [x] `cargo build` clean
- [x] `instagram-filters` routing unchanged on the dataset
- [x] Spec MX05 §"Specialised cache + dispatch routing" updated with V4 status
- [x] Security review passed in one round (existing OnceLock pattern reused; Mutex acquisition order is Profiler → SpecRouter, never nested; no DoS surface)

## What's next (Phase 4)

A backend installs a real `Specialiser` (matrix-cpu or matrix-metal emitting MSL/Rust kernels with constants folded in), and the route() return starts being consumed by the dispatch path. That needs an executor-protocol extension so a backend can be told "dispatch via specialised kernel handle X" instead of "dispatch this graph". Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)