### PR TITLE
Expand HTML lexer end-tag-open convergence

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -264,3 +264,7 @@ documented in this file.
   include resumable RCDATA/RAWTEXT/script end-tag-open states, giving parser and
   conformance callers standard labels for end-tag handoff points that do not
   require pre-seeded current-token internals.
+- Expanded end-tag-open convergence coverage across RCDATA, RAWTEXT, script
+  data, and escaped script data, including EOF literalization, mismatched end
+  tag text recovery, and matching whitespace/attribute/trailing-solidus
+  diagnostics in both direct lexer tests and html5lib-style fixtures.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -232,7 +232,10 @@ The importer also expands supported multi-state html5lib entries into stable
 per-state Venture cases and now covers intermediate text-like states such as
 RCDATA/RAWTEXT less-than and end-tag-open, CDATA bracket/end, script less-than
 and end-tag-open, script escape-start, script escaped end-tag-open, and script
-double-escape start/end.
+double-escape start/end. End-tag-open fixtures now cover matching tags,
+mismatched tags that must remain literal text, EOF recovery that preserves the
+pending `</`, and matching end-tag diagnostics for whitespace, attributes, and
+trailing solidus.
 
 The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
 same schema rather than teaching the Rust harness to parse raw upstream files

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -100,7 +100,7 @@ fn fixture_manifests_parse() {
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 173);
+    assert_eq!(file.tests.len(), 185);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -190,7 +190,7 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
             "Script data state".to_string()
         ]
     );
-    assert_eq!(normalized.cases.len(), 174);
+    assert_eq!(normalized.cases.len(), 186);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -306,7 +306,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 174);
+    assert_eq!(suite.cases.len(), 186);
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -167,6 +167,9 @@ script submodes, CDATA bracket/end states, and resumable end-tag-open states
 stay in the generated corpus with `initial_state` / `last_start_tag` metadata
 and are seeded into the Rust wrapper at test time, while still unsupported
 upstream states remain recorded under `skipped` instead of being discarded.
+End-tag-open coverage intentionally exercises matching, mismatched, EOF, and
+diagnostic recovery paths so parser/tokenizer handoff regressions show up in the
+shared fixture corpus instead of only in narrow unit tests.
 
 To regenerate the normalized corpus:
 

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -2139,6 +2139,166 @@
     },
     {
       "id": "html5lib-smoke-173",
+      "description": "rcdata end tag open state emits literal opener at eof",
+      "input": "",
+      "tokens": [
+        "Text(data=</)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA end tag open state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-174",
+      "description": "rawtext end tag open state emits literal opener at eof",
+      "input": "",
+      "tokens": [
+        "Text(data=</)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT end tag open state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-175",
+      "description": "script data end tag open state emits literal opener at eof",
+      "input": "",
+      "tokens": [
+        "Text(data=</)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data end tag open state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-176",
+      "description": "script escaped end tag open state emits literal opener at eof",
+      "input": "",
+      "tokens": [
+        "Text(data=</)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data escaped end tag open state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-177",
+      "description": "rcdata end tag open state keeps mismatched end tag text",
+      "input": "style>text</title>",
+      "tokens": [
+        "Text(data=</style>text)",
+        "EndTag(name=title)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA end tag open state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-178",
+      "description": "rawtext end tag open state keeps mismatched end tag text",
+      "input": "title>tail</style>",
+      "tokens": [
+        "Text(data=</title>tail)",
+        "EndTag(name=style)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT end tag open state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-179",
+      "description": "script data end tag open state keeps mismatched end tag text",
+      "input": "style>tail</script>",
+      "tokens": [
+        "Text(data=</style>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data end tag open state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-180",
+      "description": "script escaped end tag open state keeps mismatched end tag text",
+      "input": "style>tail</script>",
+      "tokens": [
+        "Text(data=</style>tail)",
+        "EndTag(name=script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data escaped end tag open state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-181",
+      "description": "rcdata end tag open state reports matching end tag attributes",
+      "input": "title class=x>after",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "initial_state": "RCDATA end tag open state",
+      "last_start_tag": "title"
+    },
+    {
+      "id": "html5lib-smoke-182",
+      "description": "rawtext end tag open state reports matching end tag whitespace",
+      "input": "style >tail",
+      "tokens": [
+        "EndTag(name=style)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "initial_state": "RAWTEXT end tag open state",
+      "last_start_tag": "style"
+    },
+    {
+      "id": "html5lib-smoke-183",
+      "description": "script data end tag open state reports matching trailing solidus",
+      "input": "script/>tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "initial_state": "Script data end tag open state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-184",
+      "description": "script escaped end tag open state reports matching end tag attributes",
+      "input": "script class=x>tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "initial_state": "Script data escaped end tag open state",
+      "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-185",
       "description": "script less-than state emits pending less-than at eof",
       "input": "",
       "tokens": [

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -2215,6 +2215,234 @@
       ]
     },
     {
+      "description": "rcdata end tag open state emits literal opener at eof",
+      "input": "",
+      "initialStates": [
+        "RCDATA end tag open state"
+      ],
+      "lastStartTag": "title",
+      "output": [
+        [
+          "Character",
+          "</"
+        ]
+      ]
+    },
+    {
+      "description": "rawtext end tag open state emits literal opener at eof",
+      "input": "",
+      "initialStates": [
+        "RAWTEXT end tag open state"
+      ],
+      "lastStartTag": "style",
+      "output": [
+        [
+          "Character",
+          "</"
+        ]
+      ]
+    },
+    {
+      "description": "script data end tag open state emits literal opener at eof",
+      "input": "",
+      "initialStates": [
+        "Script data end tag open state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "</"
+        ]
+      ]
+    },
+    {
+      "description": "script escaped end tag open state emits literal opener at eof",
+      "input": "",
+      "initialStates": [
+        "Script data escaped end tag open state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "</"
+        ]
+      ]
+    },
+    {
+      "description": "rcdata end tag open state keeps mismatched end tag text",
+      "input": "style>text</title>",
+      "initialStates": [
+        "RCDATA end tag open state"
+      ],
+      "lastStartTag": "title",
+      "output": [
+        [
+          "Character",
+          "</style>text"
+        ],
+        [
+          "EndTag",
+          "title"
+        ]
+      ]
+    },
+    {
+      "description": "rawtext end tag open state keeps mismatched end tag text",
+      "input": "title>tail</style>",
+      "initialStates": [
+        "RAWTEXT end tag open state"
+      ],
+      "lastStartTag": "style",
+      "output": [
+        [
+          "Character",
+          "</title>tail"
+        ],
+        [
+          "EndTag",
+          "style"
+        ]
+      ]
+    },
+    {
+      "description": "script data end tag open state keeps mismatched end tag text",
+      "input": "style>tail</script>",
+      "initialStates": [
+        "Script data end tag open state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "</style>tail"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
+      "description": "script escaped end tag open state keeps mismatched end tag text",
+      "input": "style>tail</script>",
+      "initialStates": [
+        "Script data escaped end tag open state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "Character",
+          "</style>tail"
+        ],
+        [
+          "EndTag",
+          "script"
+        ]
+      ]
+    },
+    {
+      "description": "rcdata end tag open state reports matching end tag attributes",
+      "input": "title class=x>after",
+      "initialStates": [
+        "RCDATA end tag open state"
+      ],
+      "lastStartTag": "title",
+      "output": [
+        [
+          "EndTag",
+          "title"
+        ],
+        [
+          "Character",
+          "after"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-attributes",
+          "line": 1,
+          "col": 14
+        }
+      ]
+    },
+    {
+      "description": "rawtext end tag open state reports matching end tag whitespace",
+      "input": "style >tail",
+      "initialStates": [
+        "RAWTEXT end tag open state"
+      ],
+      "lastStartTag": "style",
+      "output": [
+        [
+          "EndTag",
+          "style"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "unexpected-whitespace-after-end-tag-name",
+          "line": 1,
+          "col": 7
+        }
+      ]
+    },
+    {
+      "description": "script data end tag open state reports matching trailing solidus",
+      "input": "script/>tail",
+      "initialStates": [
+        "Script data end tag open state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-trailing-solidus",
+          "line": 1,
+          "col": 8
+        }
+      ]
+    },
+    {
+      "description": "script escaped end tag open state reports matching end tag attributes",
+      "input": "script class=x>tail",
+      "initialStates": [
+        "Script data escaped end tag open state"
+      ],
+      "lastStartTag": "script",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-attributes",
+          "line": 1,
+          "col": 15
+        }
+      ]
+    },
+    {
       "description": "script less-than state emits pending less-than at eof",
       "input": "",
       "initialStates": [

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -5214,6 +5214,145 @@ fn parser_facing_context_seeds_intermediate_text_states() {
 }
 
 #[test]
+fn parser_facing_end_tag_open_contexts_recover_literal_boundaries() {
+    for (context, input, expected_text) in [
+        (
+            HtmlLexContext::new(HtmlTokenizerState::RcdataEndTagOpen).with_last_start_tag("title"),
+            "",
+            "</",
+        ),
+        (
+            HtmlLexContext::new(HtmlTokenizerState::RawtextEndTagOpen).with_last_start_tag("style"),
+            "",
+            "</",
+        ),
+        (
+            HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataEndTagOpen).unwrap(),
+            "",
+            "</",
+        ),
+        (
+            HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataEscapedEndTagOpen)
+                .unwrap(),
+            "",
+            "</",
+        ),
+    ] {
+        assert_eq!(
+            lex_html_fragment(input, &context).unwrap(),
+            vec![Token::Text(expected_text.to_string()), Token::Eof],
+            "context {:?}",
+            context.initial_state
+        );
+    }
+
+    for (context, input, expected_text, expected_end_tag) in [
+        (
+            HtmlLexContext::new(HtmlTokenizerState::RcdataEndTagOpen).with_last_start_tag("title"),
+            "style>text</title>",
+            "</style>text",
+            "title",
+        ),
+        (
+            HtmlLexContext::new(HtmlTokenizerState::RawtextEndTagOpen).with_last_start_tag("style"),
+            "title>tail</style>",
+            "</title>tail",
+            "style",
+        ),
+        (
+            HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataEndTagOpen).unwrap(),
+            "style>tail</script>",
+            "</style>tail",
+            "script",
+        ),
+        (
+            HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataEscapedEndTagOpen)
+                .unwrap(),
+            "style>tail</script>",
+            "</style>tail",
+            "script",
+        ),
+    ] {
+        assert_eq!(
+            lex_html_fragment(input, &context).unwrap(),
+            vec![
+                Token::Text(expected_text.to_string()),
+                Token::EndTag {
+                    name: expected_end_tag.to_string()
+                },
+                Token::Eof,
+            ],
+            "context {:?}",
+            context.initial_state
+        );
+    }
+}
+
+#[test]
+fn parser_facing_end_tag_open_contexts_report_matching_recovery_diagnostics() {
+    for (context, input, expected_end_tag, expected_text, expected_diagnostic) in [
+        (
+            HtmlLexContext::new(HtmlTokenizerState::RcdataEndTagOpen).with_last_start_tag("title"),
+            "title class=x>after",
+            "title",
+            "after",
+            "end-tag-with-attributes",
+        ),
+        (
+            HtmlLexContext::new(HtmlTokenizerState::RawtextEndTagOpen).with_last_start_tag("style"),
+            "style >tail",
+            "style",
+            "tail",
+            "unexpected-whitespace-after-end-tag-name",
+        ),
+        (
+            HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataEndTagOpen).unwrap(),
+            "script/>tail",
+            "script",
+            "tail",
+            "end-tag-with-trailing-solidus",
+        ),
+        (
+            HtmlLexContext::script_substate(HtmlTokenizerState::ScriptDataEscapedEndTagOpen)
+                .unwrap(),
+            "script class=x>tail",
+            "script",
+            "tail",
+            "end-tag-with-attributes",
+        ),
+    ] {
+        let mut lexer = create_html_lexer().unwrap();
+        apply_html_lex_context(&mut lexer, &context).unwrap();
+
+        lexer.push(input).unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![
+                Token::EndTag {
+                    name: expected_end_tag.to_string()
+                },
+                Token::Text(expected_text.to_string()),
+                Token::Eof,
+            ],
+            "context {:?}",
+            context.initial_state
+        );
+        assert_eq!(
+            lexer
+                .diagnostics()
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<Vec<_>>(),
+            vec![expected_diagnostic],
+            "context {:?}",
+            context.initial_state
+        );
+    }
+}
+
+#[test]
 fn parser_facing_context_leaves_normal_elements_in_data_state() {
     assert_eq!(HtmlLexContext::for_element_text("p"), None);
     assert!(HtmlLexContext::data().is_data());


### PR DESCRIPTION
## Summary
- Expand parser-facing end-tag-open coverage across RCDATA, RAWTEXT, script data, and escaped script data.
- Add direct lexer tests for EOF literalization, mismatched end-tag recovery, and matching whitespace/attribute/trailing-solidus diagnostics.
- Add 12 raw html5lib-style smoke cases, regenerate the normalized corpus, and document the broader fixture surface.

## Verification
- cargo fmt --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check