### PR TITLE
feat(image-gpu-core): wire CpuSpecialiser — Phase 4 cache visible end-to-end

### DIFF
--- a/code/packages/rust/image-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/image-gpu-core/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog — image-gpu-core
 
+## 0.5.0 — 2026-05-05
+
+### Added — MX05 Phase 4 visibility (CpuSpecialiser wired)
+
+- The process-wide `SpecRouter` now uses **`matrix_cpu::specialiser()`**
+  instead of `NoopSpecialiser`, hooking up the first real backend
+  `Specialiser` (landed in `matrix-cpu` v0.3.0).
+- A small custom `HotPolicy` replaces `DefaultPolicy` while the
+  per-tensor sampling pipeline matures: it fires the Specialiser
+  on raw invocation count alone (threshold 100), without requiring
+  the constant-input or narrow-range observations that
+  `DefaultPolicy` checks.  This is enough to demonstrate the cache
+  rising above zero in CLI demos and tests.
+- `HOTNESS_THRESHOLD` is `100` — much lower than spec MX05's 1000
+  default — because Phase 4's specialisation is still
+  observation-only (the dispatch path doesn't yet consume the
+  kernel handle; that's Phase 4.1 + an executor-protocol extension).
+  The threshold will return to 1000 once specialised dispatch
+  actually saves cycles.
+
+### Tests
+
+- New `cpu_specialiser_populates_cache_after_hotness_threshold` test
+  drives `gpu_invert` 150 times and asserts that `spec_cache_len()`
+  rises.  This is the first place in `image-gpu-core`'s test suite
+  where the SpecCache is observably non-empty after a real dispatch.
+- The earlier `dispatch_drives_spec_router_pipeline` test no longer
+  asserts `cache_len == 0` (which used to be the NoopSpecialiser
+  invariant) — it only checks that invocation counters climb.
+
+Total tests: 27 unit + 1 doc = 28 (was 26 + 1 = 27).
+
+### Regression check
+
+`instagram-filters` routing on macOS unchanged — the dispatch path
+itself doesn't consume the specialised kernel handle yet, so output
+bytes and the `last_executor()` value are identical to V0.4.0:
+
+```
+  invert        → cpu     (small graph, planner picks CPU)
+  greyscale     → metal   (sRGB + matmul, ships to GPU)
+  sepia         → metal   (matmul-heavy, ships to GPU)
+```
+
+The only new observable is `spec_cache_len()` — call it after a few
+hundred filter invocations and watch the number rise.
+
 ## 0.4.0 — 2026-05-05
 
 ### Added — MX05 Phase 3 V4 wiring

--- a/code/packages/rust/image-gpu-core/Cargo.toml
+++ b/code/packages/rust/image-gpu-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "image-gpu-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). Each operation is a MatrixIR graph dispatched through matrix-runtime; v0.3 wires the optional matrix-metal GPU backend behind a default-on feature flag, with transparent fallback to matrix-cpu on non-Apple targets. v0.4 wires the MX05 specialisation pipeline (Profiler + SpecRouter) into every dispatch — invocation counters and routing-decision observability are now live; the no-op specialiser declines all keys until Phase 4 lands a real one."
+description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). Each operation is a MatrixIR graph dispatched through matrix-runtime. v0.3 wires the optional matrix-metal GPU backend with transparent fallback to matrix-cpu. v0.4 wires the MX05 specialisation pipeline (Profiler + SpecRouter) into every dispatch. v0.5 installs `matrix_cpu::CpuSpecialiser` and a custom `HotPolicy` so the SpecCache visibly fills once a graph's invocation count crosses 100 — the first end-to-end demonstration of MX05 Phase 4 in a real domain library."
 
 [dependencies]
 matrix-ir         = { path = "../matrix-ir" }

--- a/code/packages/rust/image-gpu-core/src/pipeline.rs
+++ b/code/packages/rust/image-gpu-core/src/pipeline.rs
@@ -61,7 +61,7 @@ use compute_ir::{ExecutorId, CPU_EXECUTOR};
 use executor_protocol::{block_on, ExecutorRequest, ExecutorResponse, LocalTransport, Transport};
 use matrix_ir::{Graph, TensorId};
 use matrix_runtime::{
-    DefaultPolicy, NoopSpecialiser, Profiler, Runtime, SpecCache, SpecRouter,
+    Profiler, Runtime, SpecCache, SpecRouter, SpecialisationPolicy, SpecKey, ShapeClass, RangeClass,
 };
 use std::cell::Cell;
 #[cfg(feature = "metal-backend")]
@@ -130,20 +130,78 @@ fn metal_backend() -> Option<&'static MetalBackend> {
 //
 // MX05 Phase 1 / 2a / 3 V1 / V2 / V3 shipped the Profiler /
 // SpecialisationPolicy / SpecCache / SpecRouter machinery in
-// matrix-runtime.  Phase 3 V4 wires them up here so every
-// `run_graph_with_constant_inputs` call records an invocation
-// observation and asks the router whether to specialise each op.
-//
-// In V4 the answer is **always None** (the V1 backend doesn't yet
-// install a real `Specialiser`; we use `NoopSpecialiser` which
-// declines every key) — but the wiring is observable through the
-// public `profiler()` accessor and is foundation for Phase 4 when a
-// real specialiser arrives.
+// matrix-runtime (now matrix-profile).  Phase 3 V4 wired them up
+// here so every `run_graph_with_constant_inputs` call records an
+// invocation observation and asks the router whether to specialise
+// each op.  Phase 4 minimum-viable installed `matrix_cpu::CpuSpecialiser`
+// in matrix-cpu (the first real `Specialiser` impl).  This file
+// (Phase 4 wiring) replaces the `NoopSpecialiser` here with
+// `matrix_cpu::specialiser()` so the cache visibly fills under the
+// instagram-filters demo once enough invocations accumulate.
 //
 // Both singletons are lazy via `OnceLock`.  Constructing the SpecRouter
 // allocates a small SpecCache plus the policy + specialiser trait
 // objects; cheap, but doing it once instead of per-call keeps the
 // hot path tight.
+
+/// How many invocations must accumulate against a (graph_subhash,
+/// op_index) pair before image-gpu-core asks the backend to specialise.
+///
+/// Spec MX05 §"Threshold rationale" calls for 1000 in production.
+/// We use a much lower number here because:
+///
+///  - This file's specialisation is **observation-only** in V1.  The
+///    cache fills, but the dispatch path doesn't yet consume the
+///    handle (that needs an executor-protocol extension — Phase 4.1).
+///    Lowering the threshold makes the wiring visible in CLI demos
+///    and tests without requiring a thousand back-to-back filter
+///    calls.
+///  - Once dispatch actually runs specialised kernels, this threshold
+///    will rise back toward 1000 to match the spec defaults.  For now
+///    the cost of "specialising too eagerly" is a few extra HashMap
+///    inserts; not a real performance hit.
+const HOTNESS_THRESHOLD: u64 = 100;
+
+/// Custom `SpecialisationPolicy` for image-gpu-core that fires on
+/// raw invocation count alone — no tensor-observation requirement.
+///
+/// `DefaultPolicy` is stricter: it requires either a constant-input
+/// or a narrowable-range observation to fire.  Building those
+/// observations needs `Profiler::sample_tensor` calls during dispatch
+/// (Phase 2a's API), which `drive_specialisation` doesn't yet do
+/// (would need to thread tensor bytes through this layer; out of
+/// scope for the V4 wiring).
+///
+/// Until that's wired, `HotPolicy` is the simplest thing that fires
+/// the Specialiser at all.  It emits a `SpecKey` with
+/// `ShapeClass::Dynamic` + `RangeClass::Unknown` — coarsest possible,
+/// but sufficient to demonstrate the cache rising above zero in the
+/// demo.  Phase 4.2 will replace this with `DefaultPolicy` once
+/// `drive_specialisation` is sampling tensor bytes.
+struct HotPolicy {
+    threshold: u64,
+}
+
+impl SpecialisationPolicy for HotPolicy {
+    fn should_specialise(
+        &self,
+        observation: &matrix_runtime::ProfileObservation,
+        op_kind: u8,
+        output_dtype: matrix_ir::DType,
+        backend_id: u32,
+    ) -> Option<SpecKey> {
+        if observation.invocation_count < self.threshold {
+            return None;
+        }
+        Some(SpecKey {
+            op_kind,
+            dtype: output_dtype,
+            shape_class: ShapeClass::Dynamic,
+            range_class: RangeClass::Unknown,
+            backend_id,
+        })
+    }
+}
 
 fn profiler() -> &'static Profiler {
     static SLOT: OnceLock<Profiler> = OnceLock::new();
@@ -154,12 +212,16 @@ fn spec_router() -> &'static SpecRouter {
     static SLOT: OnceLock<SpecRouter> = OnceLock::new();
     SLOT.get_or_init(|| {
         SpecRouter::new(
-            Box::new(DefaultPolicy::new()),
+            Box::new(HotPolicy {
+                threshold: HOTNESS_THRESHOLD,
+            }),
             SpecCache::default_capacity(),
-            // V1 of image-gpu-core ships the no-op specialiser.
-            // Phase 4 will swap in a backend-specific one (e.g. an
-            // MSL emitter that constant-folds bias values).
-            Box::new(NoopSpecialiser),
+            // Phase 4 minimum-viable: install matrix-cpu's
+            // CpuSpecialiser instead of NoopSpecialiser.  The kernel
+            // handle is opaque to dispatch (still no executor-protocol
+            // extension); but the cache visibly fills, which is the
+            // promise the spec made for this milestone.
+            matrix_cpu::specialiser(),
         )
     })
 }
@@ -177,8 +239,11 @@ pub fn profiler_observations() -> Vec<matrix_runtime::ProfileObservation> {
 }
 
 /// How many specialised kernels the process-wide cache currently
-/// holds.  Always `0` while `NoopSpecialiser` is installed; Phase 4
-/// will see this rise as backends emit specialisations.
+/// holds.  Phase 4 wired `matrix_cpu::CpuSpecialiser` in front of
+/// this cache, so the count rises above zero once a `(graph_subhash,
+/// op_index)` pair crosses the [`HOTNESS_THRESHOLD`] (100 invocations
+/// in V1; will return to spec MX05's 1000 default once dispatch
+/// actually consumes the specialised kernels in Phase 4.1).
 pub fn spec_cache_len() -> usize {
     spec_router().cache_len()
 }
@@ -515,11 +580,10 @@ mod tests {
 
     /// MX05 Phase 3 V4 wiring smoke test.  Confirms that calling a
     /// public op (gpu_invert) drives the SpecRouter pipeline:
-    /// observations accumulate, but the cache stays empty under
-    /// the no-op specialiser installed in V1.
+    /// observations accumulate.
     #[test]
     fn dispatch_drives_spec_router_pipeline() {
-        use crate::{gpu_invert, profiler_observations, spec_cache_len};
+        use crate::{gpu_invert, profiler_observations};
         use pixel_container::PixelContainer;
 
         let mut img = PixelContainer::new(2, 2);
@@ -547,12 +611,45 @@ mod tests {
             before,
             after
         );
+    }
 
-        // No-op specialiser declines every key, so the cache stays
-        // empty regardless of how many dispatches have happened.
-        // Phase 4 will see this number rise as backends emit
-        // specialisations.
-        assert_eq!(spec_cache_len(), 0);
+    /// MX05 Phase 4 end-to-end visibility test.  Drives `gpu_invert`
+    /// past the `HOTNESS_THRESHOLD` and asserts that
+    /// [`spec_cache_len`] rises above zero — the first place in
+    /// `image-gpu-core`'s test suite where the cache is observably
+    /// non-empty after a real dispatch path.
+    ///
+    /// Up to V4 the assertion was `cache_len == 0` (NoopSpecialiser).
+    /// With CpuSpecialiser installed and HotPolicy(threshold=100), a
+    /// few hundred invocations of any graph populate at least one
+    /// cache entry per Compute op in the graph.
+    #[test]
+    fn cpu_specialiser_populates_cache_after_hotness_threshold() {
+        use crate::{gpu_invert, spec_cache_len};
+        use pixel_container::PixelContainer;
+
+        // Drive enough dispatches to push every Compute op in
+        // gpu_invert's graph past HOTNESS_THRESHOLD (100).
+        let mut img = PixelContainer::new(2, 2);
+        img.fill(10, 20, 30, 255);
+
+        // Snapshot cache len at the start so we measure delta across
+        // this test.  Other tests in this file may have already
+        // populated some entries.
+        let before = spec_cache_len();
+
+        for _ in 0..150 {
+            let _ = gpu_invert(&img).unwrap();
+        }
+
+        let after = spec_cache_len();
+        assert!(
+            after > before,
+            "expected spec cache to grow after 150 gpu_invert calls; \
+             before = {}, after = {}",
+            before,
+            after
+        );
     }
 }
 

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -242,6 +242,19 @@ The compile happens in a background worker thread so live dispatches
 aren't blocked.  Once ready, the specialised pipeline is inserted
 into the cache.
 
+> **Implementation status (Phase 4 visibility landed — image-gpu-core wired)**:
+> `image-gpu-core::pipeline` now installs `matrix_cpu::specialiser()`
+> in front of its process-wide `SpecRouter`, plus a small custom
+> `HotPolicy` that fires on invocation count alone (threshold 100,
+> down from the spec's 1000 default).  Calling
+> `image_gpu_core::spec_cache_len()` after a few hundred filter
+> invocations is now the first place a domain library can observe
+> the cache rising above zero in production code.  The dispatch
+> path doesn't yet consume the specialised kernel handle (still
+> needs an executor-protocol extension), so routing and output
+> bytes are unchanged from V0.4.0; only the cache-size signal is
+> new.
+
 > **Implementation status (Phase 4 minimum-viable landed — first real backend Specialiser)**:
 > `matrix_cpu::CpuSpecialiser` ships as the workspace's first real
 > `Specialiser` impl (previously every test and demo used


### PR DESCRIPTION
## Summary

Builds on the `CpuSpecialiser` that landed in #2163. This PR wires `matrix_cpu::specialiser()` into `image-gpu-core::pipeline`'s process-wide SpecRouter, replacing `NoopSpecialiser`. Calling `image_gpu_core::spec_cache_len()` after a few hundred filter invocations is now the **first place a domain library can observe the cache rising above zero in real production code**.

`image-gpu-core` v0.4.0 → v0.5.0.

## What this PR adds

`spec_router()` now constructs:

```rust
SpecRouter::new(
    Box::new(HotPolicy { threshold: 100 }),
    SpecCache::default_capacity(),
    matrix_cpu::specialiser(),  // first real Specialiser, replacing NoopSpecialiser
)
```

A small custom `HotPolicy` fires on raw invocation count alone (no constant-input or narrow-range requirement). Replaces `DefaultPolicy` temporarily until `drive_specialisation` samples tensor bytes (Phase 4.2).

`HOTNESS_THRESHOLD = 100` — much lower than spec MX05's 1000 default — because Phase 4's specialisation is observation-only in V1. The threshold will return to 1000 once specialised dispatch actually saves cycles (Phase 4.1 + executor-protocol extension).

## Tests

New end-to-end visibility test `cpu_specialiser_populates_cache_after_hotness_threshold`:

```rust
for _ in 0..150 { gpu_invert(&img).unwrap(); }
assert!(spec_cache_len() > before);
```

**First place in image-gpu-core's test suite where the SpecCache is observably non-empty after a real dispatch path.**

The existing `dispatch_drives_spec_router_pipeline` test no longer asserts `cache_len == 0` — that was the NoopSpecialiser invariant.

Total: **27 unit + 1 doc = 28 tests** (was 26 + 1 = 27).

## Why HotPolicy instead of DefaultPolicy

`DefaultPolicy` fires only when `tensor_observations` shows either a constant-input (observed_min == observed_max) or a narrowable range. Building those observations needs `Profiler::sample_tensor` calls during dispatch (Phase 2a's API), which `drive_specialisation` doesn't yet do — that would require threading tensor bytes through this layer. Out of scope for this V4-visibility PR.

`HotPolicy` is the simplest thing that fires the Specialiser at all. Emits a SpecKey with `ShapeClass::Dynamic` + `RangeClass::Unknown` — the coarsest possible categorisation, but enough for the cache to fill. **Phase 4.2** will replace HotPolicy with DefaultPolicy once `drive_specialisation` is sampling tensor bytes.

## Regression check

`instagram-filters` routing on macOS unchanged:

```
  invert        → cpu     (small graph, planner picks CPU)
  greyscale     → metal   (sRGB + matmul, ships to GPU)
  sepia         → metal   (matmul-heavy, ships to GPU)
```

The dispatch path doesn't yet consume the specialised kernel handle (still needs an executor-protocol extension), so output bytes and the `last_executor()` value are identical to V0.4.0. The only new observable is `spec_cache_len()`.

## Test plan

- [x] `cargo test -p image-gpu-core` — 27 unit + 1 doc = 28 tests pass on macOS (the new test runs gpu_invert 150 times in ~25 ms)
- [x] `cargo build` clean
- [x] `instagram-filters` routing unchanged on the dataset
- [x] MX05 §"Specialisation trigger" updated with Phase 4 visibility status
- [x] Security review passed in one round (no FFI / unsafe / I/O changes; HotPolicy is a 12-line trait impl; cache size bounded by SpecCache LRU default 64 entries)

## Phase 4 timeline

| Phase | Status |
|---|---|
| 4 minimum-viable | ✅ #2163 — CpuSpecialiser ships |
| 4 visibility | ✅ this PR — image-gpu-core wired; cache rises in demo |
| 4.1 | next — executor-protocol DispatchSpecialised + matrix-cpu actually executes specialised kernels |
| 4.2 | drive_specialisation samples tensor bytes, switch back to DefaultPolicy with threshold 1000 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)