### PR TITLE
feat(executor-protocol): MX03 v0.2 — DispatchSpecialised request (MX05 Phase 4.1 surface)

### DIFF
--- a/code/packages/rust/executor-protocol/CHANGELOG.md
+++ b/code/packages/rust/executor-protocol/CHANGELOG.md
@@ -3,6 +3,65 @@
 All notable changes to `executor-protocol` are documented here.  The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.0] — 2026-05-05
+
+### Added — MX05 Phase 4.1 protocol surface
+
+- New `ExecutorRequest::DispatchSpecialised { job_id, handle, inputs,
+  outputs }` variant (wire tag `0x0A`) that routes a previously-emitted
+  specialised kernel by **handle**.
+
+  Wire format:
+    - `u8 0x0A`
+    - `u64 job_id`
+    - `u64 handle`
+    - `u32 n_inputs` followed by `n_inputs × u64` buffer ids
+    - `u32 n_outputs` followed by `n_outputs × u64` buffer ids
+
+  Reply uses the existing `ExecutorResponse::DispatchDone { job_id,
+  timings }` on success or `ExecutorResponse::Error { code:
+  NOT_IMPLEMENTED, .. }` if the backend hasn't yet wired execution.
+
+- New `ErrorCode::NOT_IMPLEMENTED` (`0x0062`) — soft refusal for
+  recognised request shapes the backend doesn't yet execute.
+  Distinct from `UNKNOWN_VARIANT`.  Stays in the runtime-defined
+  range (< 0x80).
+
+### Changed
+
+- `PROTOCOL_VERSION` bumped from `1` to `2`.  Forward-compatible
+  with v1 senders: every existing variant still encodes/decodes
+  byte-identically.
+
+### Security hardening
+
+- The `DispatchSpecialised` decoder bounds `Vec::with_capacity` for the
+  `inputs` and `outputs` lists against the bytes actually remaining in
+  the wire reader (each `BufferId` costs 8 bytes), using the same
+  `bounded_capacity` helper that already protects `OpTiming` decoding.
+  Without this bound, an attacker-supplied `n_inputs = u32::MAX` would
+  request a ~34 GiB allocation per malicious frame.
+
+### Tests (5 new)
+
+- `dispatch_specialised_wire_tag_is_0x0a`
+- `not_implemented_error_code_in_runtime_range`
+- `dispatch_specialised_request_round_trips`
+- `dispatch_specialised_with_empty_buffer_lists_round_trips`
+- `dispatch_specialised_oversized_input_count_does_not_oom` — security
+  regression test that asserts the decoder rejects a frame claiming
+  `n_inputs = u32::MAX` cleanly, without OOM-aborting on the
+  pre-allocation.
+- `request_tags_unique` extended to include the new variant.
+
+### Notes
+
+- Both `matrix-cpu` and `matrix-metal` reply with `Error { code:
+  NOT_IMPLEMENTED }` for `DispatchSpecialised`.  The protocol
+  surface lands here; per-backend execution is tracked under
+  "MX05 Phase 4.1: matrix-cpu executes specialised kernels" and
+  "Phase 4.2: matrix-metal MSL emitter".
+
 ## [0.1.0] — 2026-05-04
 
 Initial release.  Implements spec MX03 V1.

--- a/code/packages/rust/executor-protocol/Cargo.toml
+++ b/code/packages/rust/executor-protocol/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "executor-protocol"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "MX03 — wire-level protocol between the matrix-execution runtime and its executors. Hand-rolled binary message format, transport-pluggable Transport trait, in-process LocalTransport, hand-rolled minimal block_on. Zero external dependencies."
+description = "MX03 — wire-level protocol between the matrix-execution runtime and its executors. Hand-rolled binary message format, transport-pluggable Transport trait, in-process LocalTransport, hand-rolled minimal block_on. v0.2 adds ExecutorRequest::DispatchSpecialised (MX05 Phase 4.1) for routing pre-emitted specialised kernels by handle, plus ErrorCode::NOT_IMPLEMENTED for soft refusals. Zero external dependencies."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/executor-protocol/src/lib.rs
+++ b/code/packages/rust/executor-protocol/src/lib.rs
@@ -61,4 +61,15 @@ pub use wire::WireError;
 
 /// Protocol version.  Distinct from the wire-frame version; bump when
 /// a message variant's payload layout changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 1;
+///
+/// History:
+///
+/// - **v1**: initial release.  10 request variants (`Register` through
+///   `Shutdown`), 11 response variants, 3 event variants.
+/// - **v2** (this revision): adds `ExecutorRequest::DispatchSpecialised`
+///   (tag 0x0A) for MX05 Phase 4.1 specialised-kernel dispatch.
+///   Adds `ErrorCode::NOT_IMPLEMENTED` (0x0062) for backends that
+///   recognise the request shape but haven't yet wired up execution.
+///   Forward-compatible with v1 senders: every existing variant
+///   still encodes/decodes byte-identically.
+pub const PROTOCOL_VERSION: u32 = 2;

--- a/code/packages/rust/executor-protocol/src/messages.rs
+++ b/code/packages/rust/executor-protocol/src/messages.rs
@@ -130,6 +130,15 @@ impl ErrorCode {
     /// Dispatch exceeded the timeout.
     pub const TIMEOUT: ErrorCode = ErrorCode(0x0061);
 
+    /// The executor recognises the request shape but doesn't yet
+    /// implement it (e.g. `DispatchSpecialised` arrived but the
+    /// backend hasn't installed the corresponding specialised-kernel
+    /// table yet).  Distinct from `UNKNOWN_VARIANT` (which is "I
+    /// don't recognise this tag").  Callers should treat
+    /// `NOT_IMPLEMENTED` as a soft refusal — fall back to the
+    /// generic dispatch path and try again later.
+    pub const NOT_IMPLEMENTED: ErrorCode = ErrorCode(0x0062);
+
     /// Whether this code is in the executor-specific range.
     pub fn is_backend_specific(self) -> bool {
         self.0 >= 0x0080
@@ -177,6 +186,40 @@ pub enum ExecutorRequest {
     /// executor unless the graph itself contains download transfers.
     Dispatch { job_id: u64, graph: ComputeGraph },
 
+    /// Run a previously-emitted **specialised kernel** by handle
+    /// (MX05 Phase 4.1).  The executor looks up the handle in its
+    /// per-process specialised-kernel table (populated by its
+    /// `Specialiser::specialise` calls) and runs that kernel against
+    /// the supplied input/output buffers.
+    ///
+    /// The runtime only sends this request after a `Specialiser::specialise`
+    /// call returned `Some(SpecialisedKernel { handle, .. })` — so the
+    /// handle is already known to the executor.  If the handle is
+    /// unknown (e.g. process restart, driver reset), the executor
+    /// replies with `Error { code: NOT_IMPLEMENTED }` and the runtime
+    /// falls back to the generic `Dispatch` path.
+    ///
+    /// V1 of this variant ships **the protocol surface only**.  Both
+    /// `matrix-cpu` and `matrix-metal` reply with `NOT_IMPLEMENTED`
+    /// until they install their per-handle kernel tables — that's
+    /// the work tracked under "MX05 Phase 4.1: matrix-cpu executes
+    /// specialised kernels".
+    DispatchSpecialised {
+        /// Per-job correlation id, mirrored back in the response.
+        job_id: u64,
+        /// Opaque kernel handle previously emitted by this backend's
+        /// `Specialiser::specialise`.  Identifying which kernel to
+        /// run.
+        handle: u64,
+        /// Buffers holding input data, in slot order.  Already
+        /// resident on this executor (the runtime ensured residency
+        /// before issuing the request).
+        inputs: Vec<BufferId>,
+        /// Buffers to write output data into, in slot order.  Must
+        /// already be allocated.
+        outputs: Vec<BufferId>,
+    },
+
     /// Read bytes from a buffer back into runtime memory.
     DownloadBuffer {
         buffer: BufferId,
@@ -213,6 +256,7 @@ impl ExecutorRequest {
             ExecutorRequest::CancelJob { .. } => 0x07,
             ExecutorRequest::Heartbeat => 0x08,
             ExecutorRequest::Shutdown => 0x09,
+            ExecutorRequest::DispatchSpecialised { .. } => 0x0A,
         }
     }
 }
@@ -338,12 +382,51 @@ mod tests {
             ExecutorRequest::CancelJob { job_id: 0 },
             ExecutorRequest::Heartbeat,
             ExecutorRequest::Shutdown,
+            ExecutorRequest::DispatchSpecialised {
+                job_id: 0,
+                handle: 0,
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+            },
         ];
         let mut tags: Vec<u8> = reqs.iter().map(|r| r.wire_tag()).collect();
         tags.sort();
         let len = tags.len();
         tags.dedup();
         assert_eq!(tags.len(), len);
+    }
+
+    #[test]
+    fn dispatch_specialised_wire_tag_is_0x0a() {
+        let req = ExecutorRequest::DispatchSpecialised {
+            job_id: 0,
+            handle: 0,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+        };
+        assert_eq!(req.wire_tag(), 0x0A);
+    }
+
+    #[test]
+    fn not_implemented_error_code_in_runtime_range() {
+        // Runtime-defined error codes are < 0x80; backend-specific
+        // start at 0x80.  NOT_IMPLEMENTED must stay in the runtime
+        // range so backends can return it without conflicting with
+        // their own custom codes.
+        assert!(!ErrorCode::NOT_IMPLEMENTED.is_backend_specific());
+        // Distinct from all other named runtime codes.
+        for other in [
+            ErrorCode::MALFORMED_FRAME,
+            ErrorCode::UNKNOWN_VARIANT,
+            ErrorCode::VERSION_MISMATCH,
+            ErrorCode::OUT_OF_MEMORY,
+            ErrorCode::DEVICE_LOST,
+            ErrorCode::COMPILATION_FAILED,
+            ErrorCode::RUNTIME_ERROR,
+            ErrorCode::TIMEOUT,
+        ] {
+            assert_ne!(ErrorCode::NOT_IMPLEMENTED, other);
+        }
     }
 
     #[test]

--- a/code/packages/rust/executor-protocol/src/wire.rs
+++ b/code/packages/rust/executor-protocol/src/wire.rs
@@ -330,6 +330,23 @@ fn encode_request(req: &ExecutorRequest, w: &mut Writer<'_>) {
         }
         ExecutorRequest::Heartbeat => {}
         ExecutorRequest::Shutdown => {}
+        ExecutorRequest::DispatchSpecialised {
+            job_id,
+            handle,
+            inputs,
+            outputs,
+        } => {
+            w.u64(*job_id);
+            w.u64(*handle);
+            w.u32(inputs.len() as u32);
+            for b in inputs {
+                w.u64(b.0);
+            }
+            w.u32(outputs.len() as u32);
+            for b in outputs {
+                w.u64(b.0);
+            }
+        }
     }
 }
 
@@ -368,6 +385,34 @@ fn decode_request(r: &mut Reader<'_>) -> Result<ExecutorRequest, WireError> {
         0x07 => Ok(ExecutorRequest::CancelJob { job_id: r.u64()? }),
         0x08 => Ok(ExecutorRequest::Heartbeat),
         0x09 => Ok(ExecutorRequest::Shutdown),
+        0x0A => {
+            let job_id = r.u64()?;
+            let handle = r.u64()?;
+            // Each BufferId is 8 wire bytes; bound the pre-allocation
+            // against the bytes actually remaining so an attacker cannot
+            // request a multi-GB Vec via a maliciously large `n_in`.
+            // Same pattern as `OpTiming` decoding above.  If the
+            // attacker lies about the count, the loop below will hit
+            // the truncated-read path and fail cleanly.
+            let n_in = r.u32()? as u64;
+            let cap_in = bounded_capacity(n_in, 8, r.remaining());
+            let mut inputs = Vec::with_capacity(cap_in);
+            for _ in 0..n_in {
+                inputs.push(BufferId(r.u64()?));
+            }
+            let n_out = r.u32()? as u64;
+            let cap_out = bounded_capacity(n_out, 8, r.remaining());
+            let mut outputs = Vec::with_capacity(cap_out);
+            for _ in 0..n_out {
+                outputs.push(BufferId(r.u64()?));
+            }
+            Ok(ExecutorRequest::DispatchSpecialised {
+                job_id,
+                handle,
+                inputs,
+                outputs,
+            })
+        }
         unknown => Err(WireError::UnknownTag {
             what: "ExecutorRequest",
             tag: unknown as u64,
@@ -678,5 +723,69 @@ mod tests {
             MessageFrame::from_bytes(&buf),
             Err(WireError::UnsupportedFrameVersion(99))
         ));
+    }
+
+    #[test]
+    fn dispatch_specialised_request_round_trips() {
+        let original = ExecutorRequest::DispatchSpecialised {
+            job_id: 0xABCD_EF12_3456_7890,
+            handle: 0x1234_5678_9ABC_DEF0,
+            inputs: vec![BufferId(7), BufferId(8), BufferId(9)],
+            outputs: vec![BufferId(10), BufferId(11)],
+        };
+
+        let frame = MessageFrame::request(99, &original);
+        let bytes = frame.to_bytes();
+        let decoded_frame = MessageFrame::from_bytes(&bytes).expect("frame decodes");
+        let decoded_req = decoded_frame.as_request().expect("payload decodes");
+
+        assert_eq!(decoded_req, original);
+    }
+
+    #[test]
+    fn dispatch_specialised_with_empty_buffer_lists_round_trips() {
+        let original = ExecutorRequest::DispatchSpecialised {
+            job_id: 0,
+            handle: 0,
+            inputs: vec![],
+            outputs: vec![],
+        };
+        let frame = MessageFrame::request(0, &original);
+        let bytes = frame.to_bytes();
+        let decoded_frame = MessageFrame::from_bytes(&bytes).expect("frame decodes");
+        assert_eq!(decoded_frame.as_request().unwrap(), original);
+    }
+
+    /// **Security regression test.**  An attacker-supplied `n_inputs` of
+    /// `u32::MAX` would request ~34 GiB if `Vec::with_capacity` were
+    /// passed the raw count.  The decoder must bound capacity against
+    /// remaining wire bytes (each `BufferId` costs 8 bytes), so
+    /// pre-allocation stays small and the truncated-read path catches
+    /// the malformed message cleanly without panicking.
+    #[test]
+    fn dispatch_specialised_oversized_input_count_does_not_oom() {
+        let mut payload = Vec::new();
+        let mut w = Writer::new(&mut payload);
+        // tag 0x0A, job_id, handle
+        w.u8(0x0A);
+        w.u64(0);
+        w.u64(0);
+        // attacker-controlled "n_inputs = u32::MAX" with no actual
+        // buffer ids following.  A naive decoder would allocate
+        // capacity for 4.29B BufferId entries.
+        w.u32(u32::MAX);
+
+        let mut frame_bytes = Vec::new();
+        let mut fw = Writer::new(&mut frame_bytes);
+        fw.u8(1); // format_version
+        fw.u8(0); // kind = Request
+        fw.u64(0); // correlation_id
+        fw.bytes(&payload);
+
+        // Decode must return Err(Truncated) — and crucially, must
+        // return *cleanly* without panic or OOM-abort.
+        let frame = MessageFrame::from_bytes(&frame_bytes).expect("outer frame ok");
+        let res = frame.as_request();
+        assert!(res.is_err(), "decoder must reject the malformed message");
     }
 }

--- a/code/packages/rust/matrix-cpu/src/lib.rs
+++ b/code/packages/rust/matrix-cpu/src/lib.rs
@@ -210,6 +210,19 @@ impl CpuExecutor {
             ExecutorRequest::Heartbeat => ExecutorResponse::Alive { profile: profile() },
 
             ExecutorRequest::Shutdown => ExecutorResponse::ShuttingDown,
+
+            // V1 of `DispatchSpecialised` is the protocol surface only.
+            // matrix-cpu doesn't yet maintain a per-handle kernel
+            // table — that's MX05 Phase 4.1 work.  Reply with
+            // NOT_IMPLEMENTED so the runtime falls back to the
+            // generic `Dispatch` path.
+            ExecutorRequest::DispatchSpecialised { job_id, .. } => ExecutorResponse::Error {
+                code: ErrorCode::NOT_IMPLEMENTED,
+                message: "matrix-cpu doesn't yet execute specialised kernels; \
+                          MX05 Phase 4.1 will install the per-handle table"
+                    .to_string(),
+                job_id: Some(job_id),
+            },
         }
     }
 }

--- a/code/packages/rust/matrix-metal/src/lib.rs
+++ b/code/packages/rust/matrix-metal/src/lib.rs
@@ -314,6 +314,19 @@ impl MetalExecutor {
             ExecutorRequest::Heartbeat => ExecutorResponse::Alive { profile: profile() },
 
             ExecutorRequest::Shutdown => ExecutorResponse::ShuttingDown,
+
+            // V1 protocol surface only.  matrix-metal doesn't yet
+            // maintain a per-handle MTLComputePipelineState table
+            // for specialised kernels — Phase 4.2 work that needs
+            // an MSL emitter.  Reply with NOT_IMPLEMENTED so the
+            // runtime falls back to the generic `Dispatch` path.
+            ExecutorRequest::DispatchSpecialised { job_id, .. } => ExecutorResponse::Error {
+                code: ErrorCode::NOT_IMPLEMENTED,
+                message: "matrix-metal doesn't yet execute specialised kernels; \
+                          MX05 Phase 4.2 will add an MSL emitter and per-handle table"
+                    .to_string(),
+                job_id: Some(job_id),
+            },
         }
     }
 

--- a/code/specs/MX03-executor-protocol.md
+++ b/code/specs/MX03-executor-protocol.md
@@ -204,6 +204,21 @@ pub enum ExecutorRequest {
     /// Graceful shutdown — executor flushes outstanding work and
     /// stops accepting new requests.
     Shutdown,
+
+    /// (v0.2 / protocol v2)  Dispatch a previously-emitted **specialised
+    /// kernel** by handle.  The handle was returned by a `Specialiser`
+    /// at compile time (see MX05 §"SpecRouter") and is opaque to the
+    /// runtime — the executor owns the per-handle table.
+    ///
+    /// Wire tag: `0x0A`.  Backends that recognise the variant but have
+    /// not yet wired execution reply with
+    /// `Error { code: NOT_IMPLEMENTED, .. }`.
+    DispatchSpecialised {
+        job_id:  u64,
+        handle:  u64,
+        inputs:  Vec<BufferId>,
+        outputs: Vec<BufferId>,
+    },
 }
 
 pub enum ExecutorResponse {
@@ -382,7 +397,11 @@ Errors propagate from executor to runtime as `ExecutorResponse::Error
 - **Compilation errors** (`0x40–0x5F`): kernel source rejected.  Does
   not invalidate other state.
 - **Runtime errors** (`0x60–0x7F`): kernel produced NaN, dispatch
-  exceeded timeout.  Per-job, does not invalidate the executor.
+  exceeded timeout.  Per-job, does not invalidate the executor.  This
+  band also holds **`NOT_IMPLEMENTED` (`0x0062`)**, added in protocol
+  v2: the request shape is recognised but this backend has not yet
+  wired execution.  Distinct from the protocol-band `UNKNOWN_VARIANT`
+  (which means the backend doesn't even know the tag).
 - **Executor-specific** (`0x80–0xFF`): backend-defined.
 
 Every error carries a UTF-8 `message` for diagnostics.  Messages are
@@ -428,3 +447,64 @@ Coverage target: **100%** of the public API.
 3. Should `OpTiming` be optional in `DispatchDone`?  Some backends can't
    measure per-op time without overhead.  V1 leaves it always present
    but allows `ns: 0` to mean "unmeasured".
+
+## Protocol version history
+
+### v1 — initial release (executor-protocol 0.1.0)
+
+Everything described above through the V1 lens: 10 request variants,
+11 response variants, 3 event variants.  `PROTOCOL_VERSION = 1`.
+
+### v2 — MX05 Phase 4.1 protocol surface (executor-protocol 0.2.0)
+
+Adds the wire-format support for routing pre-emitted **specialised
+kernels** (see MX05 §"SpecRouter") through the same `Transport` that
+already carries every other request.  `PROTOCOL_VERSION = 2`.
+
+**Forward-compatible with v1 senders.**  Every existing variant still
+encodes/decodes byte-identically.  A v1-only executor receiving the new
+request would fail with `UNKNOWN_VARIANT` (existing behaviour for any
+unknown tag); a v2 executor receiving a v1 request stream decodes it
+unchanged.
+
+Added:
+
+- `ExecutorRequest::DispatchSpecialised { job_id, handle, inputs,
+  outputs }` — wire tag `0x0A`.
+
+  Wire layout of the payload (after the variant tag):
+
+  ```
+  u64           job_id
+  u64           handle
+  u32           n_inputs
+  n_inputs ×    u64 buffer_id
+  u32           n_outputs
+  n_outputs ×   u64 buffer_id
+  ```
+
+  Reply on success: `ExecutorResponse::DispatchDone { job_id, timings }`
+  (existing variant, unchanged).  Reply when execution isn't wired yet:
+  `ExecutorResponse::Error { code: NOT_IMPLEMENTED, .. }`.
+
+- `ErrorCode::NOT_IMPLEMENTED = 0x0062` — soft refusal in the
+  runtime-errors band.  Means "I recognise the request shape, the
+  request is well-formed, but I have not yet wired execution for it."
+  Distinct from `UNKNOWN_VARIANT` (which is a protocol-band hard error).
+
+  V2 backends ship behaviour:
+  - `matrix-cpu` 0.x — replies `NOT_IMPLEMENTED` for `DispatchSpecialised`.
+    Phase 4.1 (next) installs a per-handle closure table so this returns
+    `DispatchDone`.
+  - `matrix-metal` 0.x — same, until Phase 4.2 lands the MSL emitter.
+
+Why a new tag rather than overloading `Dispatch`:
+
+`Dispatch` carries a full `compute_ir::ComputeGraph`; `DispatchSpecialised`
+carries a single opaque `u64` handle plus its buffer arguments.  The
+two payload shapes are disjoint enough that overloading would force
+every reader to peek at sub-fields to disambiguate.  Separate tags keep
+the wire format flat and the decode path branchless.
+
+Reserved tags `0x0B`+ for future MX05 phases (e.g. specialised kernel
+unload, specialised kernel re-emit).


### PR DESCRIPTION
## Summary

- New \`ExecutorRequest::DispatchSpecialised { job_id, handle, inputs, outputs }\` (wire tag \`0x0A\`) — routes a previously-emitted specialised kernel by handle. Reply uses existing \`DispatchDone\` on success or new \`Error { code: NOT_IMPLEMENTED }\` until backends wire execution.
- New \`ErrorCode::NOT_IMPLEMENTED\` (\`0x0062\`) — soft refusal in the runtime-errors band, distinct from the protocol-band \`UNKNOWN_VARIANT\` hard error.
- \`PROTOCOL_VERSION\` bumps from 1 to 2. **Forward-compatible**: every existing variant encodes/decodes byte-identically.
- \`matrix-cpu\` and \`matrix-metal\` install handler arms returning \`NOT_IMPLEMENTED\` for the new variant. Per-backend execution tracked under MX05 Phase 4.1 (matrix-cpu) and Phase 4.2 (matrix-metal MSL emitter).
- Spec MX03 updated with the new variant, error code, and a "Protocol version history" section explaining v1 → v2.

This is the protocol surface that closes the gap between Phase 3 (cache fill produces handles) and Phase 4 (runtime actually dispatches them). The handle-table install lands in the next PR.

## Wire layout (after the variant tag)

\`\`\`
u64           job_id
u64           handle
u32           n_inputs
n_inputs ×    u64 buffer_id
u32           n_outputs
n_outputs ×   u64 buffer_id
\`\`\`

## Security hardening

Caught during the pre-push security review: the new decoder originally called \`Vec::with_capacity(n_inputs as usize)\` directly, which an attacker could exploit by sending \`n_inputs = u32::MAX\` to request a ~34 GiB allocation per malicious frame. Fixed by routing both \`n_inputs\` and \`n_outputs\` through the existing \`bounded_capacity(n, 8, r.remaining())\` helper that already protects \`OpTiming\` decoding. Regression test \`dispatch_specialised_oversized_input_count_does_not_oom\` locks this in.

## Test plan

- [x] \`cargo test -p executor-protocol\` — 16 unit + 20 integration tests pass (5 new)
- [x] \`cargo test -p matrix-cpu\` — 26 + 17 tests pass
- [x] \`cargo test -p matrix-metal\` — 17 tests pass
- [x] \`cargo test -p matrix-runtime\` — 17 + 8 tests pass
- [x] Security review (2 rounds, HIGH finding fixed before push)
- [x] Spec MX03 updated to match implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)