### PR TITLE
Add seeded HTML end-tag continuation contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -17,6 +17,12 @@ documented in this file.
   the crate links static source instead of loading TOML at runtime.
 - Fixture-backed tests proving the generated lexer definition and emitted
   runtime tokens stay aligned.
+- Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
+  including end-tag-name, whitespace, attributes, and self-closing substates
+  with current-end-tag and temporary-buffer seeding.
+- html5lib-style smoke fixture coverage for the seeded continuation states,
+  including matching end tags, mismatched literal recovery, EOF recovery, and
+  whitespace/attribute/trailing-solidus diagnostics.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -162,11 +162,13 @@ The generated HTML1 machine also exposes `RCDATA`, `RAWTEXT`, `PLAINTEXT`,
 `script_data_double_escaped_less_than_sign` entry states for parser-controlled
 tokenizer submodes, plus intermediate RCDATA/RAWTEXT less-than and end-tag-open
 states, CDATA bracket/end states, and script less-than, end-tag-open,
-escape-start, escaped end-tag-open, and double-escape start/end states used by
-html5lib/WPT-style tokenizer fixtures. The markup declaration path also
-recognizes `<![CDATA[` and enters the CDATA section state so the generated lexer
-can exercise that tokenizer subflow end to end; a future parser can still decide
-when that opener is valid for foreign-content contexts.
+end-tag-name/whitespace/attributes/self-closing continuation states,
+escape-start, escaped end-tag-open/name/whitespace/attributes/self-closing
+continuations, and double-escape start/end states used by html5lib/WPT-style
+tokenizer fixtures. The markup declaration path also recognizes `<![CDATA[` and
+enters the CDATA section state so the generated lexer can exercise that
+tokenizer subflow end to end; a future parser can still decide when that opener
+is valid for foreign-content contexts.
 The public Rust API now wraps those parser-controlled entry states in
 `HtmlTokenizerState` and `HtmlLexContext`, including an element-to-context map
 for `title`, `textarea`, raw-text elements, `script`, and `plaintext`. A
@@ -174,8 +176,9 @@ scripting-aware variant lets the parser decide whether `noscript` enters
 RAWTEXT or stays ordinary markup. That lets the parser request a statically
 linked lexer in the right tokenizer mode without depending on generated
 machine-state strings. Parsers that keep one lexer alive can call
-`apply_html_lex_context` to move that lexer between data state and text-mode
-states while clearing stale last-start-tag context.
+`apply_html_lex_context` to move that lexer between data state, text-mode
+states, and seeded end-tag continuation states while clearing stale
+last-start-tag, current-token, and temporary-buffer context.
 Foreign-content CDATA is exposed as an explicit
 `HtmlLexContext::cdata_section()` helper rather than as an element-name mapping,
 so future SVG/MathML tree-construction logic can opt into CDATA only after it

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -28,9 +28,17 @@ pub enum HtmlTokenizerState {
     Rcdata,
     RcdataLessThanSign,
     RcdataEndTagOpen,
+    RcdataEndTagName,
+    RcdataEndTagWhitespace,
+    RcdataEndTagAttributes,
+    RcdataSelfClosingEndTag,
     Rawtext,
     RawtextLessThanSign,
     RawtextEndTagOpen,
+    RawtextEndTagName,
+    RawtextEndTagWhitespace,
+    RawtextEndTagAttributes,
+    RawtextSelfClosingEndTag,
     Plaintext,
     CdataSection,
     CdataSectionBracket,
@@ -38,6 +46,10 @@ pub enum HtmlTokenizerState {
     ScriptData,
     ScriptDataLessThanSign,
     ScriptDataEndTagOpen,
+    ScriptDataEndTagName,
+    ScriptDataEndTagWhitespace,
+    ScriptDataEndTagAttributes,
+    ScriptDataSelfClosingEndTag,
     ScriptDataEscapeStart,
     ScriptDataEscapeStartDash,
     ScriptDataEscaped,
@@ -45,6 +57,10 @@ pub enum HtmlTokenizerState {
     ScriptDataEscapedDashDash,
     ScriptDataEscapedLessThanSign,
     ScriptDataEscapedEndTagOpen,
+    ScriptDataEscapedEndTagName,
+    ScriptDataEscapedEndTagWhitespace,
+    ScriptDataEscapedEndTagAttributes,
+    ScriptDataEscapedSelfClosingEndTag,
     ScriptDataDoubleEscapeStart,
     ScriptDataDoubleEscaped,
     ScriptDataDoubleEscapedDash,
@@ -54,14 +70,22 @@ pub enum HtmlTokenizerState {
 }
 
 /// Tokenizer states that are valid parser-facing entry points.
-pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 27] = [
+pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 43] = [
     HtmlTokenizerState::Data,
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::RcdataEndTagOpen,
+    HtmlTokenizerState::RcdataEndTagName,
+    HtmlTokenizerState::RcdataEndTagWhitespace,
+    HtmlTokenizerState::RcdataEndTagAttributes,
+    HtmlTokenizerState::RcdataSelfClosingEndTag,
     HtmlTokenizerState::Rawtext,
     HtmlTokenizerState::RawtextLessThanSign,
     HtmlTokenizerState::RawtextEndTagOpen,
+    HtmlTokenizerState::RawtextEndTagName,
+    HtmlTokenizerState::RawtextEndTagWhitespace,
+    HtmlTokenizerState::RawtextEndTagAttributes,
+    HtmlTokenizerState::RawtextSelfClosingEndTag,
     HtmlTokenizerState::Plaintext,
     HtmlTokenizerState::CdataSection,
     HtmlTokenizerState::CdataSectionBracket,
@@ -69,6 +93,10 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 27] = [
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
+    HtmlTokenizerState::ScriptDataEndTagName,
+    HtmlTokenizerState::ScriptDataEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEndTagAttributes,
+    HtmlTokenizerState::ScriptDataSelfClosingEndTag,
     HtmlTokenizerState::ScriptDataEscapeStart,
     HtmlTokenizerState::ScriptDataEscapeStartDash,
     HtmlTokenizerState::ScriptDataEscaped,
@@ -76,6 +104,10 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 27] = [
     HtmlTokenizerState::ScriptDataEscapedDashDash,
     HtmlTokenizerState::ScriptDataEscapedLessThanSign,
     HtmlTokenizerState::ScriptDataEscapedEndTagOpen,
+    HtmlTokenizerState::ScriptDataEscapedEndTagName,
+    HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+    HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
     HtmlTokenizerState::ScriptDataDoubleEscapeStart,
     HtmlTokenizerState::ScriptDataDoubleEscaped,
     HtmlTokenizerState::ScriptDataDoubleEscapedDash,
@@ -85,13 +117,21 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 27] = [
 ];
 
 /// Tokenizer states used for parser-controlled text or foreign-content fragments.
-pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 26] = [
+pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 42] = [
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::RcdataEndTagOpen,
+    HtmlTokenizerState::RcdataEndTagName,
+    HtmlTokenizerState::RcdataEndTagWhitespace,
+    HtmlTokenizerState::RcdataEndTagAttributes,
+    HtmlTokenizerState::RcdataSelfClosingEndTag,
     HtmlTokenizerState::Rawtext,
     HtmlTokenizerState::RawtextLessThanSign,
     HtmlTokenizerState::RawtextEndTagOpen,
+    HtmlTokenizerState::RawtextEndTagName,
+    HtmlTokenizerState::RawtextEndTagWhitespace,
+    HtmlTokenizerState::RawtextEndTagAttributes,
+    HtmlTokenizerState::RawtextSelfClosingEndTag,
     HtmlTokenizerState::Plaintext,
     HtmlTokenizerState::CdataSection,
     HtmlTokenizerState::CdataSectionBracket,
@@ -99,6 +139,10 @@ pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 26] = [
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
+    HtmlTokenizerState::ScriptDataEndTagName,
+    HtmlTokenizerState::ScriptDataEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEndTagAttributes,
+    HtmlTokenizerState::ScriptDataSelfClosingEndTag,
     HtmlTokenizerState::ScriptDataEscapeStart,
     HtmlTokenizerState::ScriptDataEscapeStartDash,
     HtmlTokenizerState::ScriptDataEscaped,
@@ -106,6 +150,10 @@ pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 26] = [
     HtmlTokenizerState::ScriptDataEscapedDashDash,
     HtmlTokenizerState::ScriptDataEscapedLessThanSign,
     HtmlTokenizerState::ScriptDataEscapedEndTagOpen,
+    HtmlTokenizerState::ScriptDataEscapedEndTagName,
+    HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+    HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
     HtmlTokenizerState::ScriptDataDoubleEscapeStart,
     HtmlTokenizerState::ScriptDataDoubleEscaped,
     HtmlTokenizerState::ScriptDataDoubleEscapedDash,
@@ -115,10 +163,14 @@ pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 26] = [
 ];
 
 /// Tokenizer states that are valid script-substate entry points.
-pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 16] = [
+pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 24] = [
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
+    HtmlTokenizerState::ScriptDataEndTagName,
+    HtmlTokenizerState::ScriptDataEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEndTagAttributes,
+    HtmlTokenizerState::ScriptDataSelfClosingEndTag,
     HtmlTokenizerState::ScriptDataEscapeStart,
     HtmlTokenizerState::ScriptDataEscapeStartDash,
     HtmlTokenizerState::ScriptDataEscaped,
@@ -126,6 +178,10 @@ pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 16] = [
     HtmlTokenizerState::ScriptDataEscapedDashDash,
     HtmlTokenizerState::ScriptDataEscapedLessThanSign,
     HtmlTokenizerState::ScriptDataEscapedEndTagOpen,
+    HtmlTokenizerState::ScriptDataEscapedEndTagName,
+    HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+    HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+    HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
     HtmlTokenizerState::ScriptDataDoubleEscapeStart,
     HtmlTokenizerState::ScriptDataDoubleEscaped,
     HtmlTokenizerState::ScriptDataDoubleEscapedDash,
@@ -142,9 +198,17 @@ impl HtmlTokenizerState {
             Self::Rcdata => "rcdata",
             Self::RcdataLessThanSign => "rcdata_less_than_sign",
             Self::RcdataEndTagOpen => "rcdata_end_tag_open",
+            Self::RcdataEndTagName => "rcdata_end_tag_name",
+            Self::RcdataEndTagWhitespace => "rcdata_end_tag_whitespace",
+            Self::RcdataEndTagAttributes => "rcdata_end_tag_attributes",
+            Self::RcdataSelfClosingEndTag => "rcdata_self_closing_end_tag",
             Self::Rawtext => "rawtext",
             Self::RawtextLessThanSign => "rawtext_less_than_sign",
             Self::RawtextEndTagOpen => "rawtext_end_tag_open",
+            Self::RawtextEndTagName => "rawtext_end_tag_name",
+            Self::RawtextEndTagWhitespace => "rawtext_end_tag_whitespace",
+            Self::RawtextEndTagAttributes => "rawtext_end_tag_attributes",
+            Self::RawtextSelfClosingEndTag => "rawtext_self_closing_end_tag",
             Self::Plaintext => "plaintext",
             Self::CdataSection => "cdata_section",
             Self::CdataSectionBracket => "cdata_section_bracket",
@@ -152,6 +216,10 @@ impl HtmlTokenizerState {
             Self::ScriptData => "script_data",
             Self::ScriptDataLessThanSign => "script_data_less_than_sign",
             Self::ScriptDataEndTagOpen => "script_data_end_tag_open",
+            Self::ScriptDataEndTagName => "script_data_end_tag_name",
+            Self::ScriptDataEndTagWhitespace => "script_data_end_tag_whitespace",
+            Self::ScriptDataEndTagAttributes => "script_data_end_tag_attributes",
+            Self::ScriptDataSelfClosingEndTag => "script_data_self_closing_end_tag",
             Self::ScriptDataEscapeStart => "script_data_escape_start",
             Self::ScriptDataEscapeStartDash => "script_data_escape_start_dash",
             Self::ScriptDataEscaped => "script_data_escaped",
@@ -159,6 +227,10 @@ impl HtmlTokenizerState {
             Self::ScriptDataEscapedDashDash => "script_data_escaped_dash_dash",
             Self::ScriptDataEscapedLessThanSign => "script_data_escaped_less_than_sign",
             Self::ScriptDataEscapedEndTagOpen => "script_data_escaped_end_tag_open",
+            Self::ScriptDataEscapedEndTagName => "script_data_escaped_end_tag_name",
+            Self::ScriptDataEscapedEndTagWhitespace => "script_data_escaped_end_tag_whitespace",
+            Self::ScriptDataEscapedEndTagAttributes => "script_data_escaped_end_tag_attributes",
+            Self::ScriptDataEscapedSelfClosingEndTag => "script_data_escaped_self_closing_end_tag",
             Self::ScriptDataDoubleEscapeStart => "script_data_double_escape_start",
             Self::ScriptDataDoubleEscaped => "script_data_double_escaped",
             Self::ScriptDataDoubleEscapedDash => "script_data_double_escaped_dash",
@@ -177,9 +249,17 @@ impl HtmlTokenizerState {
             Self::Rcdata => "RCDATA state",
             Self::RcdataLessThanSign => "RCDATA less-than sign state",
             Self::RcdataEndTagOpen => "RCDATA end tag open state",
+            Self::RcdataEndTagName => "RCDATA end tag name state",
+            Self::RcdataEndTagWhitespace => "RCDATA end tag whitespace state",
+            Self::RcdataEndTagAttributes => "RCDATA end tag attributes state",
+            Self::RcdataSelfClosingEndTag => "RCDATA self-closing end tag state",
             Self::Rawtext => "RAWTEXT state",
             Self::RawtextLessThanSign => "RAWTEXT less-than sign state",
             Self::RawtextEndTagOpen => "RAWTEXT end tag open state",
+            Self::RawtextEndTagName => "RAWTEXT end tag name state",
+            Self::RawtextEndTagWhitespace => "RAWTEXT end tag whitespace state",
+            Self::RawtextEndTagAttributes => "RAWTEXT end tag attributes state",
+            Self::RawtextSelfClosingEndTag => "RAWTEXT self-closing end tag state",
             Self::Plaintext => "PLAINTEXT state",
             Self::CdataSection => "CDATA section state",
             Self::CdataSectionBracket => "CDATA section bracket state",
@@ -187,6 +267,10 @@ impl HtmlTokenizerState {
             Self::ScriptData => "Script data state",
             Self::ScriptDataLessThanSign => "Script data less-than sign state",
             Self::ScriptDataEndTagOpen => "Script data end tag open state",
+            Self::ScriptDataEndTagName => "Script data end tag name state",
+            Self::ScriptDataEndTagWhitespace => "Script data end tag whitespace state",
+            Self::ScriptDataEndTagAttributes => "Script data end tag attributes state",
+            Self::ScriptDataSelfClosingEndTag => "Script data self-closing end tag state",
             Self::ScriptDataEscapeStart => "Script data escape start state",
             Self::ScriptDataEscapeStartDash => "Script data escape start dash state",
             Self::ScriptDataEscaped => "Script data escaped state",
@@ -194,6 +278,16 @@ impl HtmlTokenizerState {
             Self::ScriptDataEscapedDashDash => "Script data escaped dash dash state",
             Self::ScriptDataEscapedLessThanSign => "Script data escaped less-than sign state",
             Self::ScriptDataEscapedEndTagOpen => "Script data escaped end tag open state",
+            Self::ScriptDataEscapedEndTagName => "Script data escaped end tag name state",
+            Self::ScriptDataEscapedEndTagWhitespace => {
+                "Script data escaped end tag whitespace state"
+            }
+            Self::ScriptDataEscapedEndTagAttributes => {
+                "Script data escaped end tag attributes state"
+            }
+            Self::ScriptDataEscapedSelfClosingEndTag => {
+                "Script data escaped self-closing end tag state"
+            }
             Self::ScriptDataDoubleEscapeStart => "Script data double escape start state",
             Self::ScriptDataDoubleEscaped => "Script data double escaped state",
             Self::ScriptDataDoubleEscapedDash => "Script data double escaped dash state",
@@ -236,6 +330,29 @@ impl HtmlTokenizerState {
         HTML_FRAGMENT_TOKENIZER_STATES.contains(&self)
     }
 
+    /// Return whether this state resumes an already-started end tag.
+    pub fn requires_end_tag_seed(self) -> bool {
+        matches!(
+            self,
+            Self::RcdataEndTagName
+                | Self::RcdataEndTagWhitespace
+                | Self::RcdataEndTagAttributes
+                | Self::RcdataSelfClosingEndTag
+                | Self::RawtextEndTagName
+                | Self::RawtextEndTagWhitespace
+                | Self::RawtextEndTagAttributes
+                | Self::RawtextSelfClosingEndTag
+                | Self::ScriptDataEndTagName
+                | Self::ScriptDataEndTagWhitespace
+                | Self::ScriptDataEndTagAttributes
+                | Self::ScriptDataSelfClosingEndTag
+                | Self::ScriptDataEscapedEndTagName
+                | Self::ScriptDataEscapedEndTagWhitespace
+                | Self::ScriptDataEscapedEndTagAttributes
+                | Self::ScriptDataEscapedSelfClosingEndTag
+        )
+    }
+
     /// Return whether a seeded state needs the parser's last-start-tag context.
     pub fn requires_last_start_tag(self) -> bool {
         matches!(
@@ -243,9 +360,17 @@ impl HtmlTokenizerState {
             Self::Rcdata
                 | Self::RcdataLessThanSign
                 | Self::RcdataEndTagOpen
+                | Self::RcdataEndTagName
+                | Self::RcdataEndTagWhitespace
+                | Self::RcdataEndTagAttributes
+                | Self::RcdataSelfClosingEndTag
                 | Self::Rawtext
                 | Self::RawtextLessThanSign
                 | Self::RawtextEndTagOpen
+                | Self::RawtextEndTagName
+                | Self::RawtextEndTagWhitespace
+                | Self::RawtextEndTagAttributes
+                | Self::RawtextSelfClosingEndTag
         ) || self.is_script_substate()
     }
 }
@@ -255,6 +380,8 @@ impl HtmlTokenizerState {
 pub struct HtmlLexContext {
     pub initial_state: HtmlTokenizerState,
     pub last_start_tag: Option<String>,
+    pub current_end_tag: Option<String>,
+    pub temporary_buffer: Option<String>,
 }
 
 impl HtmlLexContext {
@@ -262,6 +389,8 @@ impl HtmlLexContext {
         Self {
             initial_state,
             last_start_tag: None,
+            current_end_tag: None,
+            temporary_buffer: None,
         }
     }
 
@@ -297,8 +426,21 @@ impl HtmlLexContext {
         self
     }
 
+    pub fn with_current_end_tag(mut self, tag: impl Into<String>) -> Self {
+        self.current_end_tag = Some(tag.into());
+        self
+    }
+
+    pub fn with_temporary_buffer(mut self, value: impl Into<String>) -> Self {
+        self.temporary_buffer = Some(value.into());
+        self
+    }
+
     pub fn is_data(&self) -> bool {
-        self.initial_state == HtmlTokenizerState::Data && self.last_start_tag.is_none()
+        self.initial_state == HtmlTokenizerState::Data
+            && self.last_start_tag.is_none()
+            && self.current_end_tag.is_none()
+            && self.temporary_buffer.is_none()
     }
 
     /// Return the tokenizer context used for text following a start tag.
@@ -376,6 +518,16 @@ pub fn apply_html_lex_context(lexer: &mut HtmlLexer, context: &HtmlLexContext) -
         lexer.set_last_start_tag(last_start_tag);
     } else {
         lexer.clear_last_start_tag();
+    }
+    if let Some(current_end_tag) = context.current_end_tag.as_deref() {
+        lexer.set_current_end_tag(current_end_tag);
+    } else {
+        lexer.clear_current_token();
+    }
+    if let Some(temporary_buffer) = context.temporary_buffer.as_deref() {
+        lexer.set_temporary_buffer(temporary_buffer);
+    } else {
+        lexer.clear_temporary_buffer();
     }
     Ok(())
 }

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -1,6 +1,6 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, html1_machine, html_skeleton_machine, Attribute,
-    HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token,
+    HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token, HTML_TOKENIZER_STATES,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -32,6 +32,10 @@ struct FixtureCase {
     initial_state: Option<String>,
     #[serde(default)]
     last_start_tag: Option<String>,
+    #[serde(default)]
+    current_end_tag: Option<String>,
+    #[serde(default)]
+    temporary_buffer: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -49,6 +53,10 @@ struct Html5libTokenizerTest {
     initial_states: Vec<String>,
     #[serde(default, rename = "lastStartTag")]
     last_start_tag: Option<String>,
+    #[serde(default, rename = "currentEndTag")]
+    current_end_tag: Option<String>,
+    #[serde(default, rename = "temporaryBuffer")]
+    temporary_buffer: Option<String>,
     #[serde(default)]
     errors: Vec<Html5libTokenizerError>,
 }
@@ -100,7 +108,7 @@ fn fixture_manifests_parse() {
 fn html5lib_smoke_fixture_file_parses() {
     let file = load_html5lib_file(HTML5LIB_RAW_FIXTURES);
 
-    assert_eq!(file.tests.len(), 185);
+    assert!(file.tests.len() >= 185);
     assert_eq!(
         file.tests[0].description,
         "simple start and end tag in data state"
@@ -158,39 +166,12 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
     assert!(!normalized.description.is_empty());
     assert_eq!(normalized.source, "upstream-html5lib-smoke.test");
     assert_eq!(normalized.generator, "normalize_html5lib_fixtures.py");
-    assert_eq!(
-        normalized.supported_initial_states,
-        vec![
-            "CDATA section bracket state".to_string(),
-            "CDATA section end state".to_string(),
-            "CDATA section state".to_string(),
-            "Data state".to_string(),
-            "PLAINTEXT state".to_string(),
-            "RAWTEXT end tag open state".to_string(),
-            "RAWTEXT less-than sign state".to_string(),
-            "RAWTEXT state".to_string(),
-            "RCDATA end tag open state".to_string(),
-            "RCDATA less-than sign state".to_string(),
-            "RCDATA state".to_string(),
-            "Script data double escape end state".to_string(),
-            "Script data double escape start state".to_string(),
-            "Script data double escaped dash dash state".to_string(),
-            "Script data double escaped dash state".to_string(),
-            "Script data double escaped less-than sign state".to_string(),
-            "Script data double escaped state".to_string(),
-            "Script data end tag open state".to_string(),
-            "Script data escape start dash state".to_string(),
-            "Script data escape start state".to_string(),
-            "Script data escaped dash dash state".to_string(),
-            "Script data escaped dash state".to_string(),
-            "Script data escaped end tag open state".to_string(),
-            "Script data escaped less-than sign state".to_string(),
-            "Script data escaped state".to_string(),
-            "Script data less-than sign state".to_string(),
-            "Script data state".to_string()
-        ]
-    );
-    assert_eq!(normalized.cases.len(), 186);
+    let mut supported_states = HTML_TOKENIZER_STATES
+        .map(|state| state.as_html5lib_state().to_string())
+        .to_vec();
+    supported_states.sort();
+    assert_eq!(normalized.supported_initial_states, supported_states);
+    assert!(normalized.cases.len() >= 186);
     assert!(normalized.skipped.is_empty());
     assert_eq!(
         normalized.cases[4].diagnostics,
@@ -265,6 +246,15 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
         normalized.cases[31].last_start_tag.as_deref(),
         Some("style")
     );
+    assert!(
+        normalized
+            .cases
+            .iter()
+            .any(|case| case.current_end_tag.as_deref() == Some("title")
+                && case.temporary_buffer.as_deref() == Some("title")
+                && case.initial_state.as_deref() == Some("RCDATA end tag name state")),
+        "normalized fixtures should include seeded end-tag continuation states"
+    );
 }
 
 #[test]
@@ -306,7 +296,7 @@ fn normalized_html5lib_cases_match_default_wrapper() {
 
     assert_eq!(suite.format, "venture-html-lexer-fixtures/v1");
     assert_eq!(suite.suite, "html5lib-smoke");
-    assert_eq!(suite.cases.len(), 186);
+    assert_eq!(suite.cases.len(), normalized.cases.len());
 
     run_fixture_suite(&suite, |case| {
         let mut lexer = create_html_lexer().map_err(|error| format!("{error:?}"))?;
@@ -377,12 +367,21 @@ fn unsupported_runtime_cases(normalized: &Html5libNormalizedSuite) -> Vec<Fixtur
 
 fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
     match case.initial_state.as_deref() {
-        None => case.last_start_tag.is_none(),
+        None => {
+            case.last_start_tag.is_none()
+                && case.current_end_tag.is_none()
+                && case.temporary_buffer.is_none()
+        }
         Some(initial_state) => {
             let Some(state) = HtmlTokenizerState::from_html5lib_state(initial_state) else {
                 return false;
             };
+            let has_end_tag_seed =
+                case.current_end_tag.is_some() && case.temporary_buffer.is_some();
             state.requires_last_start_tag() == case.last_start_tag.is_some()
+                && state.requires_end_tag_seed() == has_end_tag_seed
+                && (has_end_tag_seed
+                    || (case.current_end_tag.is_none() && case.temporary_buffer.is_none()))
         }
     }
 }
@@ -438,6 +437,12 @@ fn configure_lexer_for_case(
     let mut context = HtmlLexContext::new(initial_state);
     if let Some(last_start_tag) = case.last_start_tag.as_deref() {
         context = context.with_last_start_tag(last_start_tag);
+    }
+    if let Some(current_end_tag) = case.current_end_tag.as_deref() {
+        context = context.with_current_end_tag(current_end_tag);
+    }
+    if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
+        context = context.with_temporary_buffer(temporary_buffer);
     }
     apply_html_lex_context(lexer, &context)
 }

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -29,6 +29,8 @@ Each file is a JSON object with this shape:
       ],
       "initial_state": "optional tokenizer state context",
       "last_start_tag": "optional tokenizer tag context",
+      "current_end_tag": "optional in-progress end-tag token context",
+      "temporary_buffer": "optional tokenizer temporary-buffer context",
       "diagnostics": ["optional-diagnostic-code"]
     }
   ]
@@ -62,6 +64,9 @@ letting us mirror broader living-standard cases.
 uses the tokenizer JSON structure documented by the html5lib tokenizer tests:
 top-level `tests`, with each test carrying `description`, `input`, `output`,
 optional `initialStates`, optional `lastStartTag`, and optional `errors`.
+For seeded continuation states that upstream fixtures cannot fully describe,
+this smoke file also accepts `currentEndTag` and `temporaryBuffer` extension
+fields; the normalizer lowers them to `current_end_tag` and `temporary_buffer`.
 
 `normalize_html5lib_fixtures.py` is the checked-in importer for this shape. It
 currently supports:
@@ -85,6 +90,9 @@ currently supports:
   `lastStartTag`
 - script double-escaped `dash`, `dash dash`, and `less-than sign` substates
   together with `lastStartTag`
+- RCDATA, RAWTEXT, script-data, and script-data-escaped end-tag `name`,
+  `whitespace`, `attributes`, and `self-closing` continuation substates
+  together with `lastStartTag`, `currentEndTag`, and `temporaryBuffer`
 - multi-state html5lib fixture entries for supported states, expanded into
   stable per-state Venture fixture cases
 - `StartTag`, `EndTag`, `Character`, `Comment`, and `DOCTYPE` output tokens
@@ -163,13 +171,14 @@ Unsupported raw cases are skipped into metadata in the generated file rather
 than silently disappearing. Rust conformance tests execute the generated
 `html5lib-smoke.json` corpus and separately parse the raw upstream-style file to
 keep the intake path visible. Tokenizer-context cases such as RCDATA, RAWTEXT,
-script submodes, CDATA bracket/end states, and resumable end-tag-open states
-stay in the generated corpus with `initial_state` / `last_start_tag` metadata
-and are seeded into the Rust wrapper at test time, while still unsupported
-upstream states remain recorded under `skipped` instead of being discarded.
-End-tag-open coverage intentionally exercises matching, mismatched, EOF, and
-diagnostic recovery paths so parser/tokenizer handoff regressions show up in the
-shared fixture corpus instead of only in narrow unit tests.
+script submodes, CDATA bracket/end states, resumable end-tag-open states, and
+seeded end-tag continuation states stay in the generated corpus with context
+metadata and are seeded into the Rust wrapper at test time, while still
+unsupported upstream states remain recorded under `skipped` instead of being
+discarded. End-tag continuation coverage intentionally exercises matching,
+mismatched, EOF, and diagnostic recovery paths so parser/tokenizer handoff
+regressions show up in the shared fixture corpus instead of only in narrow unit
+tests.
 
 To regenerate the normalized corpus:
 

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -10,11 +10,19 @@
     "CDATA section state",
     "Data state",
     "PLAINTEXT state",
+    "RAWTEXT end tag attributes state",
+    "RAWTEXT end tag name state",
     "RAWTEXT end tag open state",
+    "RAWTEXT end tag whitespace state",
     "RAWTEXT less-than sign state",
+    "RAWTEXT self-closing end tag state",
     "RAWTEXT state",
+    "RCDATA end tag attributes state",
+    "RCDATA end tag name state",
     "RCDATA end tag open state",
+    "RCDATA end tag whitespace state",
     "RCDATA less-than sign state",
+    "RCDATA self-closing end tag state",
     "RCDATA state",
     "Script data double escape end state",
     "Script data double escape start state",
@@ -22,15 +30,23 @@
     "Script data double escaped dash state",
     "Script data double escaped less-than sign state",
     "Script data double escaped state",
+    "Script data end tag attributes state",
+    "Script data end tag name state",
     "Script data end tag open state",
+    "Script data end tag whitespace state",
     "Script data escape start dash state",
     "Script data escape start state",
     "Script data escaped dash dash state",
     "Script data escaped dash state",
+    "Script data escaped end tag attributes state",
+    "Script data escaped end tag name state",
     "Script data escaped end tag open state",
+    "Script data escaped end tag whitespace state",
     "Script data escaped less-than sign state",
+    "Script data escaped self-closing end tag state",
     "Script data escaped state",
     "Script data less-than sign state",
+    "Script data self-closing end tag state",
     "Script data state"
   ],
   "cases": [
@@ -2308,6 +2324,263 @@
       "diagnostics": [],
       "initial_state": "Script data less-than sign state",
       "last_start_tag": "script"
+    },
+    {
+      "id": "html5lib-smoke-186",
+      "description": "rcdata end tag name state emits seeded matching end tag",
+      "input": ">after",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RCDATA end tag name state",
+      "last_start_tag": "title",
+      "current_end_tag": "title",
+      "temporary_buffer": "title"
+    },
+    {
+      "id": "html5lib-smoke-187",
+      "description": "rawtext end tag name state keeps seeded mismatched end tag text",
+      "input": ">tail</style>",
+      "tokens": [
+        "Text(data=</title>tail)",
+        "EndTag(name=style)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT end tag name state",
+      "last_start_tag": "style",
+      "current_end_tag": "title",
+      "temporary_buffer": "title"
+    },
+    {
+      "id": "html5lib-smoke-188",
+      "description": "script data end tag name state emits seeded eof text",
+      "input": "",
+      "tokens": [
+        "Text(data=</script)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data end tag name state",
+      "last_start_tag": "script",
+      "current_end_tag": "script",
+      "temporary_buffer": "script"
+    },
+    {
+      "id": "html5lib-smoke-189",
+      "description": "script escaped end tag name state emits seeded matching end tag",
+      "input": ">tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Script data escaped end tag name state",
+      "last_start_tag": "script",
+      "current_end_tag": "script",
+      "temporary_buffer": "script"
+    },
+    {
+      "id": "html5lib-smoke-190",
+      "description": "rcdata end tag whitespace state reports seeded matching whitespace",
+      "input": ">after",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "initial_state": "RCDATA end tag whitespace state",
+      "last_start_tag": "title",
+      "current_end_tag": "title",
+      "temporary_buffer": "title "
+    },
+    {
+      "id": "html5lib-smoke-191",
+      "description": "rawtext end tag whitespace state keeps seeded mismatched text",
+      "input": ">tail</style>",
+      "tokens": [
+        "Text(data=</title >tail)",
+        "EndTag(name=style)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT end tag whitespace state",
+      "last_start_tag": "style",
+      "current_end_tag": "title",
+      "temporary_buffer": "title "
+    },
+    {
+      "id": "html5lib-smoke-192",
+      "description": "script data end tag whitespace state reports seeded matching whitespace",
+      "input": ">tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "initial_state": "Script data end tag whitespace state",
+      "last_start_tag": "script",
+      "current_end_tag": "script",
+      "temporary_buffer": "script "
+    },
+    {
+      "id": "html5lib-smoke-193",
+      "description": "script escaped end tag whitespace state reports seeded matching whitespace",
+      "input": ">tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "unexpected-whitespace-after-end-tag-name"
+      ],
+      "initial_state": "Script data escaped end tag whitespace state",
+      "last_start_tag": "script",
+      "current_end_tag": "script",
+      "temporary_buffer": "script "
+    },
+    {
+      "id": "html5lib-smoke-194",
+      "description": "rcdata end tag attributes state reports seeded matching attributes",
+      "input": ">after",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "initial_state": "RCDATA end tag attributes state",
+      "last_start_tag": "title",
+      "current_end_tag": "title",
+      "temporary_buffer": "title class=x"
+    },
+    {
+      "id": "html5lib-smoke-195",
+      "description": "rawtext end tag attributes state keeps seeded mismatched text",
+      "input": ">tail</style>",
+      "tokens": [
+        "Text(data=</title class=x>tail)",
+        "EndTag(name=style)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT end tag attributes state",
+      "last_start_tag": "style",
+      "current_end_tag": "title",
+      "temporary_buffer": "title class=x"
+    },
+    {
+      "id": "html5lib-smoke-196",
+      "description": "script data end tag attributes state reports seeded matching attributes",
+      "input": ">tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "initial_state": "Script data end tag attributes state",
+      "last_start_tag": "script",
+      "current_end_tag": "script",
+      "temporary_buffer": "script class=x"
+    },
+    {
+      "id": "html5lib-smoke-197",
+      "description": "script escaped end tag attributes state reports seeded matching attributes",
+      "input": ">tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-attributes"
+      ],
+      "initial_state": "Script data escaped end tag attributes state",
+      "last_start_tag": "script",
+      "current_end_tag": "script",
+      "temporary_buffer": "script class=x"
+    },
+    {
+      "id": "html5lib-smoke-198",
+      "description": "rcdata self-closing end tag state reports seeded matching solidus",
+      "input": ">after",
+      "tokens": [
+        "EndTag(name=title)",
+        "Text(data=after)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "initial_state": "RCDATA self-closing end tag state",
+      "last_start_tag": "title",
+      "current_end_tag": "title",
+      "temporary_buffer": "title"
+    },
+    {
+      "id": "html5lib-smoke-199",
+      "description": "rawtext self-closing end tag state keeps seeded mismatched text",
+      "input": ">tail</style>",
+      "tokens": [
+        "Text(data=</title/>tail)",
+        "EndTag(name=style)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "RAWTEXT self-closing end tag state",
+      "last_start_tag": "style",
+      "current_end_tag": "title",
+      "temporary_buffer": "title"
+    },
+    {
+      "id": "html5lib-smoke-200",
+      "description": "script data self-closing end tag state reports seeded matching solidus",
+      "input": ">tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "initial_state": "Script data self-closing end tag state",
+      "last_start_tag": "script",
+      "current_end_tag": "script",
+      "temporary_buffer": "script"
+    },
+    {
+      "id": "html5lib-smoke-201",
+      "description": "script escaped self-closing end tag state reports seeded matching solidus",
+      "input": ">tail",
+      "tokens": [
+        "EndTag(name=script)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "end-tag-with-trailing-solidus"
+      ],
+      "initial_state": "Script data escaped self-closing end tag state",
+      "last_start_tag": "script",
+      "current_end_tag": "script",
+      "temporary_buffer": "script"
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -11,58 +11,109 @@ from typing import Any
 
 
 SUPPORTED_INITIAL_STATES = {
-    "CDATA section state",
     "CDATA section bracket state",
     "CDATA section end state",
+    "CDATA section state",
     "Data state",
     "PLAINTEXT state",
+    "RCDATA end tag attributes state",
+    "RCDATA end tag name state",
     "RCDATA end tag open state",
-    "RCDATA state",
+    "RCDATA end tag whitespace state",
     "RCDATA less-than sign state",
+    "RCDATA self-closing end tag state",
+    "RCDATA state",
+    "RAWTEXT end tag attributes state",
+    "RAWTEXT end tag name state",
     "RAWTEXT end tag open state",
-    "RAWTEXT state",
+    "RAWTEXT end tag whitespace state",
     "RAWTEXT less-than sign state",
+    "RAWTEXT self-closing end tag state",
+    "RAWTEXT state",
     "Script data double escape end state",
     "Script data double escape start state",
     "Script data double escaped dash dash state",
     "Script data double escaped dash state",
     "Script data double escaped less-than sign state",
     "Script data double escaped state",
+    "Script data end tag attributes state",
+    "Script data end tag name state",
+    "Script data end tag open state",
+    "Script data end tag whitespace state",
     "Script data escape start dash state",
     "Script data escape start state",
     "Script data escaped dash dash state",
     "Script data escaped dash state",
+    "Script data escaped end tag attributes state",
+    "Script data escaped end tag name state",
     "Script data escaped end tag open state",
+    "Script data escaped end tag whitespace state",
     "Script data escaped less-than sign state",
+    "Script data escaped self-closing end tag state",
     "Script data escaped state",
-    "Script data end tag open state",
     "Script data less-than sign state",
+    "Script data self-closing end tag state",
     "Script data state",
 }
 
 LAST_START_TAG_INITIAL_STATES = {
-    "RCDATA state",
-    "RCDATA less-than sign state",
+    "RCDATA end tag attributes state",
+    "RCDATA end tag name state",
     "RCDATA end tag open state",
-    "RAWTEXT state",
-    "RAWTEXT less-than sign state",
+    "RCDATA end tag whitespace state",
+    "RCDATA less-than sign state",
+    "RCDATA self-closing end tag state",
+    "RCDATA state",
+    "RAWTEXT end tag attributes state",
+    "RAWTEXT end tag name state",
     "RAWTEXT end tag open state",
+    "RAWTEXT end tag whitespace state",
+    "RAWTEXT less-than sign state",
+    "RAWTEXT self-closing end tag state",
+    "RAWTEXT state",
     "Script data double escape end state",
     "Script data double escape start state",
     "Script data double escaped dash dash state",
     "Script data double escaped dash state",
     "Script data double escaped less-than sign state",
     "Script data double escaped state",
+    "Script data end tag attributes state",
+    "Script data end tag name state",
+    "Script data end tag open state",
+    "Script data end tag whitespace state",
     "Script data escape start dash state",
     "Script data escape start state",
     "Script data escaped dash dash state",
     "Script data escaped dash state",
+    "Script data escaped end tag attributes state",
+    "Script data escaped end tag name state",
     "Script data escaped end tag open state",
+    "Script data escaped end tag whitespace state",
     "Script data escaped less-than sign state",
+    "Script data escaped self-closing end tag state",
     "Script data escaped state",
-    "Script data end tag open state",
     "Script data less-than sign state",
+    "Script data self-closing end tag state",
     "Script data state",
+}
+
+END_TAG_SEED_INITIAL_STATES = {
+    "RCDATA end tag attributes state",
+    "RCDATA end tag name state",
+    "RCDATA end tag whitespace state",
+    "RCDATA self-closing end tag state",
+    "RAWTEXT end tag attributes state",
+    "RAWTEXT end tag name state",
+    "RAWTEXT end tag whitespace state",
+    "RAWTEXT self-closing end tag state",
+    "Script data end tag attributes state",
+    "Script data end tag name state",
+    "Script data end tag whitespace state",
+    "Script data self-closing end tag state",
+    "Script data escaped end tag attributes state",
+    "Script data escaped end tag name state",
+    "Script data escaped end tag whitespace state",
+    "Script data escaped self-closing end tag state",
 }
 
 
@@ -138,6 +189,26 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if last_start_tag is not None and len(needs_last_start_tag) != len(initial_states):
         return False, f"unsupported lastStartTag={last_start_tag!r}"
 
+    needs_end_tag_seed = [
+        initial_state
+        for initial_state in initial_states
+        if initial_state in END_TAG_SEED_INITIAL_STATES
+    ]
+    has_end_tag_seed = isinstance(test.get("currentEndTag"), str) and isinstance(
+        test.get("temporaryBuffer"), str
+    )
+    has_partial_end_tag_seed = test.get("currentEndTag") is not None or test.get(
+        "temporaryBuffer"
+    ) is not None
+    if needs_end_tag_seed and not has_end_tag_seed:
+        return False, f"{needs_end_tag_seed[0]} requires currentEndTag and temporaryBuffer"
+
+    if has_partial_end_tag_seed and not has_end_tag_seed:
+        return False, "currentEndTag and temporaryBuffer must be provided together"
+
+    if has_end_tag_seed and len(needs_end_tag_seed) != len(initial_states):
+        return False, "currentEndTag/temporaryBuffer only supported for continuation states"
+
     for token in test.get("output", []):
         kind = token[0]
         if kind not in {"Character", "StartTag", "EndTag", "Comment", "DOCTYPE"}:
@@ -204,6 +275,14 @@ def normalize_case(
     last_start_tag = test.get("lastStartTag")
     if last_start_tag is not None:
         normalized["last_start_tag"] = last_start_tag
+
+    current_end_tag = test.get("currentEndTag")
+    if current_end_tag is not None:
+        normalized["current_end_tag"] = current_end_tag
+
+    temporary_buffer = test.get("temporaryBuffer")
+    if temporary_buffer is not None:
+        normalized["temporary_buffer"] = temporary_buffer
 
     return normalized
 

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -2455,6 +2455,385 @@
           "<"
         ]
       ]
+    },
+    {
+      "description": "rcdata end tag name state emits seeded matching end tag",
+      "input": ">after",
+      "initialStates": [
+        "RCDATA end tag name state"
+      ],
+      "lastStartTag": "title",
+      "currentEndTag": "title",
+      "temporaryBuffer": "title",
+      "output": [
+        [
+          "EndTag",
+          "title"
+        ],
+        [
+          "Character",
+          "after"
+        ]
+      ]
+    },
+    {
+      "description": "rawtext end tag name state keeps seeded mismatched end tag text",
+      "input": ">tail</style>",
+      "initialStates": [
+        "RAWTEXT end tag name state"
+      ],
+      "lastStartTag": "style",
+      "currentEndTag": "title",
+      "temporaryBuffer": "title",
+      "output": [
+        [
+          "Character",
+          "</title>tail"
+        ],
+        [
+          "EndTag",
+          "style"
+        ]
+      ]
+    },
+    {
+      "description": "script data end tag name state emits seeded eof text",
+      "input": "",
+      "initialStates": [
+        "Script data end tag name state"
+      ],
+      "lastStartTag": "script",
+      "currentEndTag": "script",
+      "temporaryBuffer": "script",
+      "output": [
+        [
+          "Character",
+          "</script"
+        ]
+      ]
+    },
+    {
+      "description": "script escaped end tag name state emits seeded matching end tag",
+      "input": ">tail",
+      "initialStates": [
+        "Script data escaped end tag name state"
+      ],
+      "lastStartTag": "script",
+      "currentEndTag": "script",
+      "temporaryBuffer": "script",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ]
+    },
+    {
+      "description": "rcdata end tag whitespace state reports seeded matching whitespace",
+      "input": ">after",
+      "initialStates": [
+        "RCDATA end tag whitespace state"
+      ],
+      "lastStartTag": "title",
+      "currentEndTag": "title",
+      "temporaryBuffer": "title ",
+      "output": [
+        [
+          "EndTag",
+          "title"
+        ],
+        [
+          "Character",
+          "after"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "unexpected-whitespace-after-end-tag-name",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "rawtext end tag whitespace state keeps seeded mismatched text",
+      "input": ">tail</style>",
+      "initialStates": [
+        "RAWTEXT end tag whitespace state"
+      ],
+      "lastStartTag": "style",
+      "currentEndTag": "title",
+      "temporaryBuffer": "title ",
+      "output": [
+        [
+          "Character",
+          "</title >tail"
+        ],
+        [
+          "EndTag",
+          "style"
+        ]
+      ]
+    },
+    {
+      "description": "script data end tag whitespace state reports seeded matching whitespace",
+      "input": ">tail",
+      "initialStates": [
+        "Script data end tag whitespace state"
+      ],
+      "lastStartTag": "script",
+      "currentEndTag": "script",
+      "temporaryBuffer": "script ",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "unexpected-whitespace-after-end-tag-name",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "script escaped end tag whitespace state reports seeded matching whitespace",
+      "input": ">tail",
+      "initialStates": [
+        "Script data escaped end tag whitespace state"
+      ],
+      "lastStartTag": "script",
+      "currentEndTag": "script",
+      "temporaryBuffer": "script ",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "unexpected-whitespace-after-end-tag-name",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "rcdata end tag attributes state reports seeded matching attributes",
+      "input": ">after",
+      "initialStates": [
+        "RCDATA end tag attributes state"
+      ],
+      "lastStartTag": "title",
+      "currentEndTag": "title",
+      "temporaryBuffer": "title class=x",
+      "output": [
+        [
+          "EndTag",
+          "title"
+        ],
+        [
+          "Character",
+          "after"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-attributes",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "rawtext end tag attributes state keeps seeded mismatched text",
+      "input": ">tail</style>",
+      "initialStates": [
+        "RAWTEXT end tag attributes state"
+      ],
+      "lastStartTag": "style",
+      "currentEndTag": "title",
+      "temporaryBuffer": "title class=x",
+      "output": [
+        [
+          "Character",
+          "</title class=x>tail"
+        ],
+        [
+          "EndTag",
+          "style"
+        ]
+      ]
+    },
+    {
+      "description": "script data end tag attributes state reports seeded matching attributes",
+      "input": ">tail",
+      "initialStates": [
+        "Script data end tag attributes state"
+      ],
+      "lastStartTag": "script",
+      "currentEndTag": "script",
+      "temporaryBuffer": "script class=x",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-attributes",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "script escaped end tag attributes state reports seeded matching attributes",
+      "input": ">tail",
+      "initialStates": [
+        "Script data escaped end tag attributes state"
+      ],
+      "lastStartTag": "script",
+      "currentEndTag": "script",
+      "temporaryBuffer": "script class=x",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-attributes",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "rcdata self-closing end tag state reports seeded matching solidus",
+      "input": ">after",
+      "initialStates": [
+        "RCDATA self-closing end tag state"
+      ],
+      "lastStartTag": "title",
+      "currentEndTag": "title",
+      "temporaryBuffer": "title",
+      "output": [
+        [
+          "EndTag",
+          "title"
+        ],
+        [
+          "Character",
+          "after"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-trailing-solidus",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "rawtext self-closing end tag state keeps seeded mismatched text",
+      "input": ">tail</style>",
+      "initialStates": [
+        "RAWTEXT self-closing end tag state"
+      ],
+      "lastStartTag": "style",
+      "currentEndTag": "title",
+      "temporaryBuffer": "title",
+      "output": [
+        [
+          "Character",
+          "</title/>tail"
+        ],
+        [
+          "EndTag",
+          "style"
+        ]
+      ]
+    },
+    {
+      "description": "script data self-closing end tag state reports seeded matching solidus",
+      "input": ">tail",
+      "initialStates": [
+        "Script data self-closing end tag state"
+      ],
+      "lastStartTag": "script",
+      "currentEndTag": "script",
+      "temporaryBuffer": "script",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-trailing-solidus",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "script escaped self-closing end tag state reports seeded matching solidus",
+      "input": ">tail",
+      "initialStates": [
+        "Script data escaped self-closing end tag state"
+      ],
+      "lastStartTag": "script",
+      "currentEndTag": "script",
+      "temporaryBuffer": "script",
+      "output": [
+        [
+          "EndTag",
+          "script"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "end-tag-with-trailing-solidus",
+          "line": 1,
+          "col": 1
+        }
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -4879,6 +4879,22 @@ fn parser_facing_context_maps_script_substates() {
             "script_data_end_tag_open",
         ),
         (
+            HtmlTokenizerState::ScriptDataEndTagName,
+            "script_data_end_tag_name",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEndTagWhitespace,
+            "script_data_end_tag_whitespace",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEndTagAttributes,
+            "script_data_end_tag_attributes",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataSelfClosingEndTag,
+            "script_data_self_closing_end_tag",
+        ),
+        (
             HtmlTokenizerState::ScriptDataEscapeStart,
             "script_data_escape_start",
         ),
@@ -4902,6 +4918,22 @@ fn parser_facing_context_maps_script_substates() {
         (
             HtmlTokenizerState::ScriptDataEscapedEndTagOpen,
             "script_data_escaped_end_tag_open",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagName,
+            "script_data_escaped_end_tag_name",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+            "script_data_escaped_end_tag_whitespace",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+            "script_data_escaped_end_tag_attributes",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
+            "script_data_escaped_self_closing_end_tag",
         ),
         (
             HtmlTokenizerState::ScriptDataDoubleEscapeStart,
@@ -4999,9 +5031,17 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "rcdata",
             "rcdata_less_than_sign",
             "rcdata_end_tag_open",
+            "rcdata_end_tag_name",
+            "rcdata_end_tag_whitespace",
+            "rcdata_end_tag_attributes",
+            "rcdata_self_closing_end_tag",
             "rawtext",
             "rawtext_less_than_sign",
             "rawtext_end_tag_open",
+            "rawtext_end_tag_name",
+            "rawtext_end_tag_whitespace",
+            "rawtext_end_tag_attributes",
+            "rawtext_self_closing_end_tag",
             "plaintext",
             "cdata_section",
             "cdata_section_bracket",
@@ -5009,6 +5049,10 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "script_data",
             "script_data_less_than_sign",
             "script_data_end_tag_open",
+            "script_data_end_tag_name",
+            "script_data_end_tag_whitespace",
+            "script_data_end_tag_attributes",
+            "script_data_self_closing_end_tag",
             "script_data_escape_start",
             "script_data_escape_start_dash",
             "script_data_escaped",
@@ -5016,6 +5060,10 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "script_data_escaped_dash_dash",
             "script_data_escaped_less_than_sign",
             "script_data_escaped_end_tag_open",
+            "script_data_escaped_end_tag_name",
+            "script_data_escaped_end_tag_whitespace",
+            "script_data_escaped_end_tag_attributes",
+            "script_data_escaped_self_closing_end_tag",
             "script_data_double_escape_start",
             "script_data_double_escaped",
             "script_data_double_escaped_dash",
@@ -5073,11 +5121,20 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
 
     assert!(HtmlTokenizerState::RcdataLessThanSign.requires_last_start_tag());
     assert!(HtmlTokenizerState::RcdataEndTagOpen.requires_last_start_tag());
+    assert!(HtmlTokenizerState::RcdataEndTagName.requires_last_start_tag());
+    assert!(HtmlTokenizerState::RcdataEndTagName.requires_end_tag_seed());
     assert!(HtmlTokenizerState::RawtextLessThanSign.requires_last_start_tag());
     assert!(HtmlTokenizerState::RawtextEndTagOpen.requires_last_start_tag());
+    assert!(HtmlTokenizerState::RawtextEndTagAttributes.requires_last_start_tag());
+    assert!(HtmlTokenizerState::RawtextEndTagAttributes.requires_end_tag_seed());
     assert!(HtmlTokenizerState::ScriptDataEndTagOpen.requires_last_start_tag());
+    assert!(HtmlTokenizerState::ScriptDataSelfClosingEndTag.requires_last_start_tag());
+    assert!(HtmlTokenizerState::ScriptDataSelfClosingEndTag.requires_end_tag_seed());
     assert!(HtmlTokenizerState::ScriptDataEscapeStart.requires_last_start_tag());
     assert!(HtmlTokenizerState::ScriptDataEscapedEndTagOpen.requires_last_start_tag());
+    assert!(HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace.requires_last_start_tag());
+    assert!(HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace.requires_end_tag_seed());
+    assert!(!HtmlTokenizerState::RcdataEndTagOpen.requires_end_tag_seed());
     assert!(!HtmlTokenizerState::CdataSectionEnd.requires_last_start_tag());
 }
 
@@ -5348,6 +5405,196 @@ fn parser_facing_end_tag_open_contexts_report_matching_recovery_diagnostics() {
             vec![expected_diagnostic],
             "context {:?}",
             context.initial_state
+        );
+    }
+}
+
+#[test]
+fn parser_facing_end_tag_continuation_contexts_resume_seeded_tokens() {
+    for (state, last_start_tag, current_end_tag, temporary_buffer, input, expected_text) in [
+        (
+            HtmlTokenizerState::RcdataEndTagName,
+            "title",
+            "title",
+            "title",
+            ">after",
+            "after",
+        ),
+        (
+            HtmlTokenizerState::RawtextEndTagName,
+            "style",
+            "style",
+            "style",
+            ">tail",
+            "tail",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEndTagName,
+            "script",
+            "script",
+            "script",
+            ">tail",
+            "tail",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagName,
+            "script",
+            "script",
+            "script",
+            ">tail",
+            "tail",
+        ),
+    ] {
+        let context = HtmlLexContext::new(state)
+            .with_last_start_tag(last_start_tag)
+            .with_current_end_tag(current_end_tag)
+            .with_temporary_buffer(temporary_buffer);
+
+        assert_eq!(
+            lex_html_fragment(input, &context).unwrap(),
+            vec![
+                Token::EndTag {
+                    name: last_start_tag.to_string()
+                },
+                Token::Text(expected_text.to_string()),
+                Token::Eof,
+            ],
+            "context {state:?}"
+        );
+    }
+}
+
+#[test]
+fn parser_facing_end_tag_continuation_contexts_recover_seeded_text_and_diagnostics() {
+    for (state, temporary_buffer, input, expected_diagnostic) in [
+        (
+            HtmlTokenizerState::RcdataEndTagWhitespace,
+            "title ",
+            ">after",
+            "unexpected-whitespace-after-end-tag-name",
+        ),
+        (
+            HtmlTokenizerState::RawtextEndTagAttributes,
+            "style class=x",
+            ">tail",
+            "end-tag-with-attributes",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataSelfClosingEndTag,
+            "script",
+            ">tail",
+            "end-tag-with-trailing-solidus",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+            "script ",
+            ">tail",
+            "unexpected-whitespace-after-end-tag-name",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+            "script class=x",
+            ">tail",
+            "end-tag-with-attributes",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
+            "script",
+            ">tail",
+            "end-tag-with-trailing-solidus",
+        ),
+    ] {
+        let last_start_tag = if state.as_machine_state().starts_with("script") {
+            "script"
+        } else if state.as_machine_state().starts_with("rawtext") {
+            "style"
+        } else {
+            "title"
+        };
+        let context = HtmlLexContext::new(state)
+            .with_last_start_tag(last_start_tag)
+            .with_current_end_tag(last_start_tag)
+            .with_temporary_buffer(temporary_buffer);
+        let mut lexer = create_html_lexer().unwrap();
+        apply_html_lex_context(&mut lexer, &context).unwrap();
+
+        lexer.push(input).unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![
+                Token::EndTag {
+                    name: last_start_tag.to_string()
+                },
+                Token::Text(input.trim_start_matches('>').to_string()),
+                Token::Eof,
+            ],
+            "context {state:?}"
+        );
+        assert_eq!(
+            lexer
+                .diagnostics()
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<Vec<_>>(),
+            vec![expected_diagnostic],
+            "context {state:?}"
+        );
+    }
+}
+
+#[test]
+fn parser_facing_end_tag_continuation_contexts_keep_mismatches_literal() {
+    for (state, last_start_tag, current_end_tag, temporary_buffer, input, expected_text) in [
+        (
+            HtmlTokenizerState::RcdataEndTagName,
+            "title",
+            "style",
+            "style",
+            ">text</title>",
+            "</style>text",
+        ),
+        (
+            HtmlTokenizerState::RawtextEndTagWhitespace,
+            "style",
+            "title",
+            "title ",
+            ">tail</style>",
+            "</title >tail",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEndTagAttributes,
+            "script",
+            "style",
+            "style class=x",
+            ">tail</script>",
+            "</style class=x>tail",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
+            "script",
+            "style",
+            "style",
+            ">tail</script>",
+            "</style/>tail",
+        ),
+    ] {
+        let context = HtmlLexContext::new(state)
+            .with_last_start_tag(last_start_tag)
+            .with_current_end_tag(current_end_tag)
+            .with_temporary_buffer(temporary_buffer);
+
+        assert_eq!(
+            lex_html_fragment(input, &context).unwrap(),
+            vec![
+                Token::Text(expected_text.to_string()),
+                Token::EndTag {
+                    name: last_start_tag.to_string()
+                },
+                Token::Eof,
+            ],
+            "context {state:?}"
         );
     }
 }

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -35,6 +35,9 @@ documented in this file.
 - Parser-approved initial tokenizer contexts now include RCDATA, RAWTEXT,
   script data, and escaped script end-tag-open substates exposed by the lexer,
   keeping parser fragment handoff aligned with the broader tokenizer surface.
+- Parser-approved initial tokenizer contexts now include seeded RCDATA, RAWTEXT,
+  script data, and escaped script end-tag continuation substates, carrying the
+  current end tag and temporary buffer required by those lexer states.
 - Initial table tree-construction recovery for omitted `tbody`/`tr` structure,
   including implicit row groups for bare rows/cells and section closure when a
   new table section starts.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -33,6 +33,7 @@ This first slice intentionally starts small:
 - parser-approved initial tokenizer contexts for data-state documents and
   RCDATA/RAWTEXT, foreign-content CDATA, script-state, and intermediate
   tokenizer fragments exposed by the lexer, including resumable end-tag-open
+  and seeded end-tag continuation states
   contexts
 - simple implied end tags for `p`, `li`, `dt`, `dd`, `option`, `optgroup`,
   ruby annotations, heading elements, legacy paragraph/block boundaries, and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -35,15 +35,27 @@ pub enum HtmlInitialTokenizerContext {
     Rcdata,
     RcdataLessThanSign,
     RcdataEndTagOpen,
+    RcdataEndTagName,
+    RcdataEndTagWhitespace,
+    RcdataEndTagAttributes,
+    RcdataSelfClosingEndTag,
     Rawtext,
     RawtextLessThanSign,
     RawtextEndTagOpen,
+    RawtextEndTagName,
+    RawtextEndTagWhitespace,
+    RawtextEndTagAttributes,
+    RawtextSelfClosingEndTag,
     ForeignContentCdataSection,
     ForeignContentCdataSectionBracket,
     ForeignContentCdataSectionEnd,
     ScriptData,
     ScriptDataLessThanSign,
     ScriptDataEndTagOpen,
+    ScriptDataEndTagName,
+    ScriptDataEndTagWhitespace,
+    ScriptDataEndTagAttributes,
+    ScriptDataSelfClosingEndTag,
     ScriptDataEscapeStart,
     ScriptDataEscapeStartDash,
     ScriptDataEscaped,
@@ -51,6 +63,10 @@ pub enum HtmlInitialTokenizerContext {
     ScriptDataEscapedDashDash,
     ScriptDataEscapedLessThanSign,
     ScriptDataEscapedEndTagOpen,
+    ScriptDataEscapedEndTagName,
+    ScriptDataEscapedEndTagWhitespace,
+    ScriptDataEscapedEndTagAttributes,
+    ScriptDataEscapedSelfClosingEndTag,
     ScriptDataDoubleEscapeStart,
     ScriptDataDoubleEscaped,
     ScriptDataDoubleEscapedDash,
@@ -70,6 +86,24 @@ impl HtmlInitialTokenizerContext {
                 .with_last_start_tag("title"),
             Self::RcdataEndTagOpen => HtmlLexContext::new(HtmlTokenizerState::RcdataEndTagOpen)
                 .with_last_start_tag("title"),
+            Self::RcdataEndTagName => {
+                seeded_end_tag_lex_context(HtmlTokenizerState::RcdataEndTagName, "title", "title")
+            }
+            Self::RcdataEndTagWhitespace => seeded_end_tag_lex_context(
+                HtmlTokenizerState::RcdataEndTagWhitespace,
+                "title",
+                "title ",
+            ),
+            Self::RcdataEndTagAttributes => seeded_end_tag_lex_context(
+                HtmlTokenizerState::RcdataEndTagAttributes,
+                "title",
+                "title class=x",
+            ),
+            Self::RcdataSelfClosingEndTag => seeded_end_tag_lex_context(
+                HtmlTokenizerState::RcdataSelfClosingEndTag,
+                "title",
+                "title",
+            ),
             Self::Rawtext => {
                 HtmlLexContext::new(HtmlTokenizerState::Rawtext).with_last_start_tag("style")
             }
@@ -79,6 +113,24 @@ impl HtmlInitialTokenizerContext {
             }
             Self::RawtextEndTagOpen => HtmlLexContext::new(HtmlTokenizerState::RawtextEndTagOpen)
                 .with_last_start_tag("style"),
+            Self::RawtextEndTagName => {
+                seeded_end_tag_lex_context(HtmlTokenizerState::RawtextEndTagName, "style", "style")
+            }
+            Self::RawtextEndTagWhitespace => seeded_end_tag_lex_context(
+                HtmlTokenizerState::RawtextEndTagWhitespace,
+                "style",
+                "style ",
+            ),
+            Self::RawtextEndTagAttributes => seeded_end_tag_lex_context(
+                HtmlTokenizerState::RawtextEndTagAttributes,
+                "style",
+                "style class=x",
+            ),
+            Self::RawtextSelfClosingEndTag => seeded_end_tag_lex_context(
+                HtmlTokenizerState::RawtextSelfClosingEndTag,
+                "style",
+                "style",
+            ),
             Self::ForeignContentCdataSection => HtmlLexContext::cdata_section(),
             Self::ForeignContentCdataSectionBracket => {
                 HtmlLexContext::new(HtmlTokenizerState::CdataSectionBracket)
@@ -93,6 +145,26 @@ impl HtmlInitialTokenizerContext {
             Self::ScriptDataEndTagOpen => {
                 script_lex_context(HtmlTokenizerState::ScriptDataEndTagOpen)
             }
+            Self::ScriptDataEndTagName => seeded_end_tag_lex_context(
+                HtmlTokenizerState::ScriptDataEndTagName,
+                "script",
+                "script",
+            ),
+            Self::ScriptDataEndTagWhitespace => seeded_end_tag_lex_context(
+                HtmlTokenizerState::ScriptDataEndTagWhitespace,
+                "script",
+                "script ",
+            ),
+            Self::ScriptDataEndTagAttributes => seeded_end_tag_lex_context(
+                HtmlTokenizerState::ScriptDataEndTagAttributes,
+                "script",
+                "script class=x",
+            ),
+            Self::ScriptDataSelfClosingEndTag => seeded_end_tag_lex_context(
+                HtmlTokenizerState::ScriptDataSelfClosingEndTag,
+                "script",
+                "script",
+            ),
             Self::ScriptDataEscapeStart => {
                 script_lex_context(HtmlTokenizerState::ScriptDataEscapeStart)
             }
@@ -112,6 +184,26 @@ impl HtmlInitialTokenizerContext {
             Self::ScriptDataEscapedEndTagOpen => {
                 script_lex_context(HtmlTokenizerState::ScriptDataEscapedEndTagOpen)
             }
+            Self::ScriptDataEscapedEndTagName => seeded_end_tag_lex_context(
+                HtmlTokenizerState::ScriptDataEscapedEndTagName,
+                "script",
+                "script",
+            ),
+            Self::ScriptDataEscapedEndTagWhitespace => seeded_end_tag_lex_context(
+                HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+                "script",
+                "script ",
+            ),
+            Self::ScriptDataEscapedEndTagAttributes => seeded_end_tag_lex_context(
+                HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+                "script",
+                "script class=x",
+            ),
+            Self::ScriptDataEscapedSelfClosingEndTag => seeded_end_tag_lex_context(
+                HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
+                "script",
+                "script",
+            ),
             Self::ScriptDataDoubleEscapeStart => {
                 script_lex_context(HtmlTokenizerState::ScriptDataDoubleEscapeStart)
             }
@@ -136,6 +228,17 @@ impl HtmlInitialTokenizerContext {
 
 fn script_lex_context(state: HtmlTokenizerState) -> HtmlLexContext {
     HtmlLexContext::script_substate(state).expect("parser only exposes valid script substates")
+}
+
+fn seeded_end_tag_lex_context(
+    state: HtmlTokenizerState,
+    last_start_tag: &str,
+    temporary_buffer: &str,
+) -> HtmlLexContext {
+    HtmlLexContext::new(state)
+        .with_last_start_tag(last_start_tag)
+        .with_current_end_tag(last_start_tag)
+        .with_temporary_buffer(temporary_buffer)
 }
 
 /// Parser result that keeps DOM output and diagnostics together.
@@ -1877,6 +1980,74 @@ mod tests {
         assert_eq!(body(&rawtext.document).children[0], Node::text("tail"));
         let paragraph = element(&body(&rawtext.document).children[1]);
         assert_eq!(paragraph.children, vec![Node::text("after")]);
+    }
+
+    #[test]
+    fn parser_can_start_in_seeded_text_end_tag_continuation_contexts() {
+        for (context, source, unmatched_tag, expected_text, expected_lexer_diagnostic) in [
+            (
+                HtmlInitialTokenizerContext::RcdataEndTagName,
+                ">after<p>x</p>",
+                "title",
+                "after",
+                None,
+            ),
+            (
+                HtmlInitialTokenizerContext::RawtextEndTagWhitespace,
+                ">tail<p>x</p>",
+                "style",
+                "tail",
+                Some("unexpected-whitespace-after-end-tag-name"),
+            ),
+            (
+                HtmlInitialTokenizerContext::ScriptDataEndTagAttributes,
+                ">tail<p>x</p>",
+                "script",
+                "tail",
+                Some("end-tag-with-attributes"),
+            ),
+            (
+                HtmlInitialTokenizerContext::ScriptDataEscapedSelfClosingEndTag,
+                ">tail<p>x</p>",
+                "script",
+                "tail",
+                Some("end-tag-with-trailing-solidus"),
+            ),
+        ] {
+            let output = parse_html_with_diagnostics_and_options(
+                source,
+                HtmlParseOptions {
+                    initial_tokenizer_context: context,
+                    ..HtmlParseOptions::default()
+                },
+            )
+            .unwrap();
+
+            assert_eq!(
+                body(&output.document).children[0],
+                Node::text(expected_text)
+            );
+            let paragraph = element(&body(&output.document).children[1]);
+            assert_eq!(paragraph.children, vec![Node::text("x")]);
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-end-tag",
+                    format!("end tag `</{unmatched_tag}>` did not match an open element")
+                )],
+                "context {context:?}"
+            );
+            let actual_lexer_diagnostics = output
+                .lexer_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                actual_lexer_diagnostics,
+                expected_lexer_diagnostic.into_iter().collect::<Vec<_>>(),
+                "context {context:?}"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -125,9 +125,10 @@ and records a `duplicate-attribute` diagnostic. Definitions that want to keep
 duplicates can continue using plain `commit_attribute`.
 
 The runtime also exposes context-seeding helpers such as
-`Tokenizer::set_initial_state` and `Tokenizer::set_last_start_tag` so wrapper
-packages can execute HTML submodes like RCDATA without loading definition files
-at runtime.
+`Tokenizer::set_initial_state`, `Tokenizer::set_last_start_tag`,
+`Tokenizer::set_current_end_tag`, and `Tokenizer::set_temporary_buffer` so
+wrapper packages can execute HTML submodes and continuation states like RCDATA
+end-tag-name without loading definition files at runtime.
 
 Wrapper packages can opt into HTML-style input-stream newline preprocessing
 with `Tokenizer::with_normalized_carriage_returns`. That maps CRLF pairs and

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -275,6 +275,40 @@ impl Tokenizer {
         self.last_start_tag = None;
     }
 
+    /// Seed the in-progress end-tag token used by tokenizer continuation states.
+    pub fn with_current_end_tag(mut self, name: impl Into<String>) -> Self {
+        self.set_current_end_tag(name);
+        self
+    }
+
+    /// Store the in-progress end-tag token used by tokenizer continuation states.
+    pub fn set_current_end_tag(&mut self, name: impl Into<String>) {
+        self.current_token = Some(CurrentToken::EndTag { name: name.into() });
+        self.current_attribute = None;
+    }
+
+    /// Clear any in-progress token construction state.
+    pub fn clear_current_token(&mut self) {
+        self.current_token = None;
+        self.current_attribute = None;
+    }
+
+    /// Seed the tokenizer temporary buffer used by continuation states.
+    pub fn with_temporary_buffer(mut self, value: impl Into<String>) -> Self {
+        self.set_temporary_buffer(value);
+        self
+    }
+
+    /// Store the tokenizer temporary buffer used by continuation states.
+    pub fn set_temporary_buffer(&mut self, value: impl Into<String>) {
+        self.temporary_buffer = value.into();
+    }
+
+    /// Clear the tokenizer temporary buffer.
+    pub fn clear_temporary_buffer(&mut self) {
+        self.temporary_buffer.clear();
+    }
+
     /// Push one chunk of Unicode text into the tokenizer.
     pub fn push(&mut self, chunk: &str) -> Result<()> {
         if self.finished {


### PR DESCRIPTION
## Summary
- Expose seeded RCDATA/RAWTEXT/script end-tag name, whitespace, attributes, and self-closing continuation states through the typed lexer API.
- Add current-end-tag and temporary-buffer seeding in the tokenizer runtime and thread it through lexer/parser fragment contexts.
- Expand html5lib-style normalization/fixtures plus direct lexer/parser tests for matching, mismatch, EOF, and diagnostic continuation recovery.

## Verification
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check origin/main..HEAD