### PR TITLE
Wire Uno R4 target to Board VM device

### DIFF
--- a/code/packages/rust/board-vm-uno-r4/Cargo.toml
+++ b/code/packages/rust/board-vm-uno-r4/Cargo.toml
@@ -5,8 +5,13 @@ edition = "2021"
 description = "Abstract Arduino Uno R4 target descriptor and HAL adapter for Board VM"
 
 [dependencies]
+board-vm-device = { path = "../board-vm-device" }
 board-vm-ir = { path = "../board-vm-ir" }
 board-vm-runtime = { path = "../board-vm-runtime" }
+
+[dev-dependencies]
+board-vm-host = { path = "../board-vm-host" }
+board-vm-protocol = { path = "../board-vm-protocol" }
 
 [lib]
 path = "src/lib.rs"

--- a/code/packages/rust/board-vm-uno-r4/README.md
+++ b/code/packages/rust/board-vm-uno-r4/README.md
@@ -5,3 +5,7 @@ Abstract Arduino Uno R4 target descriptor and HAL adapter for Board VM.
 This crate does not simulate the Renesas RA4M1 or Arm Cortex-M4 ISA. It only
 describes the board target and adapts a board-specific backend to the portable
 `board-vm-runtime` HAL traits.
+
+It also provides the first Uno R4 `board-vm-device` wrapper, so firmware can
+instantiate the generic Board VM protocol core with an Uno R4 HAL backend while
+UART/USB setup remains outside this crate.

--- a/code/packages/rust/board-vm-uno-r4/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+use board_vm_device::{
+    BoardVmDevice, DeviceDescriptor, BLINK_MVP_CAPABILITIES, DEFAULT_MAX_FRAME_PAYLOAD,
+};
 use board_vm_ir::CapabilitySet;
 use board_vm_runtime::{BoardHal, GpioMode, HalError, Level};
 
@@ -8,6 +11,18 @@ pub const UNO_R4_FLASH_BYTES: u32 = 256 * 1024;
 pub const UNO_R4_SRAM_BYTES: u32 = 32 * 1024;
 pub const UNO_R4_DATA_FLASH_BYTES: u32 = 8 * 1024;
 pub const UNO_R4_ONBOARD_LED_PIN: u8 = 13;
+pub const UNO_R4_VM_RUNTIME_ID: &str = "board-vm-uno-r4";
+pub const UNO_R4_VM_MAX_PROGRAM_BYTES: usize = 4096;
+pub const UNO_R4_VM_MAX_STACK_VALUES: usize = 16;
+pub const UNO_R4_VM_MAX_HANDLES: usize = 8;
+
+pub type UnoR4Device<B> = BoardVmDevice<
+    'static,
+    UnoR4Board<B>,
+    UNO_R4_VM_MAX_PROGRAM_BYTES,
+    UNO_R4_VM_MAX_STACK_VALUES,
+    UNO_R4_VM_MAX_HANDLES,
+>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnoR4Variant {
@@ -229,6 +244,11 @@ where
     pub fn backend_mut(&mut self) -> &mut B {
         &mut self.backend
     }
+
+    pub fn into_device(self, board_nonce: u32) -> UnoR4Device<B> {
+        let descriptor = uno_r4_device_descriptor(self.target, board_nonce);
+        BoardVmDevice::new(descriptor, self)
+    }
 }
 
 impl<B> BoardHal for UnoR4Board<B>
@@ -278,6 +298,34 @@ pub fn is_valid_digital_pin(pin: u16) -> bool {
     pin <= 13
 }
 
+pub fn uno_r4_device_descriptor(
+    target: &'static TargetDescriptor,
+    board_nonce: u32,
+) -> DeviceDescriptor<'static> {
+    DeviceDescriptor {
+        board_id: target.board_id,
+        runtime_id: UNO_R4_VM_RUNTIME_ID,
+        board_nonce,
+        max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
+        supports_store_program: false,
+        capabilities: &BLINK_MVP_CAPABILITIES,
+    }
+}
+
+pub fn minima_device<B>(backend: B, board_nonce: u32) -> UnoR4Device<B>
+where
+    B: UnoR4Backend,
+{
+    UnoR4Board::minima(backend).into_device(board_nonce)
+}
+
+pub fn wifi_device<B>(backend: B, board_nonce: u32) -> UnoR4Device<B>
+where
+    B: UnoR4Backend,
+{
+    UnoR4Board::wifi(backend).into_device(board_nonce)
+}
+
 fn normalize_digital_pin(pin: u16) -> Result<u8, HalError> {
     if is_valid_digital_pin(pin) {
         Ok(pin as u8)
@@ -292,6 +340,11 @@ extern crate std;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use board_vm_host::{write_blink_module, BlinkProgram, HostSession, DEFAULT_PROGRAM_ID};
+    use board_vm_protocol::{
+        decode_caps_report_header, decode_frame, decode_hello_ack, decode_run_report_header,
+        MessageType, RunStatus as ProtocolRunStatus,
+    };
     use board_vm_runtime::{RunStatus, Runtime};
     use std::vec;
     use std::vec::Vec;
@@ -390,6 +443,106 @@ mod tests {
         assert_eq!(
             board.gpio_open(99, GpioMode::Output),
             Err(HalError::InvalidPin)
+        );
+    }
+
+    #[test]
+    fn maps_target_metadata_to_device_descriptor() {
+        let descriptor = uno_r4_device_descriptor(&UNO_R4_WIFI, 0xA11C_E001);
+
+        assert_eq!(descriptor.board_id, UNO_R4_WIFI.board_id);
+        assert_eq!(descriptor.runtime_id, UNO_R4_VM_RUNTIME_ID);
+        assert_eq!(descriptor.board_nonce, 0xA11C_E001);
+        assert_eq!(descriptor.max_frame_payload, DEFAULT_MAX_FRAME_PAYLOAD);
+        assert_eq!(descriptor.capabilities.len(), BLINK_MVP_CAPABILITIES.len());
+    }
+
+    #[test]
+    fn host_can_upload_and_run_blink_through_uno_r4_device() {
+        let mut device = minima_device(FakeBackend::new(), 0xB04D_1001);
+        let mut session = HostSession::new();
+        let mut host_payload = [0u8; 128];
+        let mut request = [0u8; 256];
+        let mut device_payload = [0u8; 512];
+        let mut response = [0u8; 768];
+
+        let hello = session
+            .hello_frame("uno-r4-test", 0xCAFE_BABE, &mut host_payload, &mut request)
+            .unwrap();
+        let response_len = device
+            .handle_raw_frame(&request[..hello.len], &mut device_payload, &mut response)
+            .unwrap();
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        assert_eq!(frame.message_type, MessageType::HELLO_ACK);
+        let ack = decode_hello_ack(frame.payload).unwrap();
+        assert_eq!(ack.board_name, UNO_R4_MINIMA.board_id);
+        assert_eq!(ack.runtime_name, UNO_R4_VM_RUNTIME_ID);
+        assert_eq!(ack.host_nonce, 0xCAFE_BABE);
+
+        let caps = session.caps_query_frame(&mut request).unwrap();
+        let response_len = device
+            .handle_raw_frame(&request[..caps.len], &mut device_payload, &mut response)
+            .unwrap();
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        let (header, mut decoder) = decode_caps_report_header(frame.payload).unwrap();
+        assert_eq!(header.board_id, UNO_R4_MINIMA.board_id);
+        assert_eq!(header.runtime_id, UNO_R4_VM_RUNTIME_ID);
+        assert_eq!(header.max_program_bytes, UNO_R4_VM_MAX_PROGRAM_BYTES as u32);
+        assert_eq!(header.max_stack_values, UNO_R4_VM_MAX_STACK_VALUES as u8);
+        assert_eq!(header.max_handles, UNO_R4_VM_MAX_HANDLES as u8);
+        for _ in 0..header.capability_count {
+            decoder.read_capability_descriptor().unwrap();
+        }
+        decoder.finish().unwrap();
+
+        let mut module = [0u8; board_vm_host::BLINK_MODULE_LEN];
+        let module_len = write_blink_module(BlinkProgram::onboard_led(), &mut module).unwrap();
+        let module = &module[..module_len];
+        let begin = session
+            .program_begin_frame(DEFAULT_PROGRAM_ID, module, &mut host_payload, &mut request)
+            .unwrap();
+        device
+            .handle_raw_frame(&request[..begin.len], &mut device_payload, &mut response)
+            .unwrap();
+        let chunk = session
+            .program_chunk_frame(
+                DEFAULT_PROGRAM_ID,
+                0,
+                module,
+                &mut host_payload,
+                &mut request,
+            )
+            .unwrap();
+        device
+            .handle_raw_frame(&request[..chunk.len], &mut device_payload, &mut response)
+            .unwrap();
+        let end = session
+            .program_end_frame(DEFAULT_PROGRAM_ID, &mut host_payload, &mut request)
+            .unwrap();
+        device
+            .handle_raw_frame(&request[..end.len], &mut device_payload, &mut response)
+            .unwrap();
+
+        let run = session
+            .run_background_frame(DEFAULT_PROGRAM_ID, 100, &mut host_payload, &mut request)
+            .unwrap();
+        let response_len = device
+            .handle_raw_frame(&request[..run.len], &mut device_payload, &mut response)
+            .unwrap();
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        let (report, decoder) = decode_run_report_header(frame.payload).unwrap();
+        decoder.finish().unwrap();
+        assert_eq!(report.status, ProtocolRunStatus::Running);
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            device.hal().backend().events[..5],
+            [
+                Event::Configure(13, GpioMode::Output),
+                Event::Write(13, Level::High),
+                Event::Sleep(250),
+                Event::Write(13, Level::Low),
+                Event::Sleep(250),
+            ]
         );
     }
 }


### PR DESCRIPTION
## Summary

- add Uno R4 VM sizing constants and a `UnoR4Device` alias over `board-vm-device`
- map Uno R4 target metadata into a Board VM `DeviceDescriptor`
- add `minima_device`/`wifi_device` constructors and an end-to-end host upload/run blink test through the Uno R4 device wrapper

## Tests

- `cargo fmt -p board-vm-uno-r4`
- `cargo test -p board-vm-uno-r4`
- `cargo test -p board-vm-uno-r4 -p board-vm-device -p board-vm-stream -p board-vm-client -p board-vm-loopback -p board-vm-host -p board-vm-protocol -p board-vm-ir -p board-vm-runtime`
- `git diff --check`
- `git diff --cached --check`
