### PR TITLE
Add Board VM serial transport

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "board-vm-host",
     "board-vm-client",
     "board-vm-stream",
+    "board-vm-serial",
     "board-vm-device",
     "board-vm-loopback",
     "board-vm-ir",

--- a/code/packages/rust/board-vm-serial/BUILD
+++ b/code/packages/rust/board-vm-serial/BUILD
@@ -1,0 +1,1 @@
+cargo test -p board-vm-serial -- --nocapture

--- a/code/packages/rust/board-vm-serial/Cargo.toml
+++ b/code/packages/rust/board-vm-serial/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "board-vm-serial"
+version = "0.1.0"
+edition = "2021"
+description = "Serial port transport for Board VM host clients"
+
+[dependencies]
+board-vm-client = { path = "../board-vm-client" }
+board-vm-stream = { path = "../board-vm-stream" }
+serialport = { version = "4", default-features = false }
+
+[dev-dependencies]
+board-vm-protocol = { path = "../board-vm-protocol" }
+
+[lib]
+path = "src/lib.rs"

--- a/code/packages/rust/board-vm-serial/README.md
+++ b/code/packages/rust/board-vm-serial/README.md
@@ -1,0 +1,22 @@
+# board-vm-serial
+
+Serial-port transport for Board VM host clients.
+
+The crate opens an OS serial device with the `serialport` crate, wraps it in
+`board-vm-stream` COBS framing, and implements the `board-vm-client`
+`RawFrameTransport` trait.
+
+Example host shape:
+
+```rust
+use board_vm_client::BoardVmClient;
+use board_vm_serial::{BoardSerialTransport, SerialConfig};
+
+let config = SerialConfig::new("/dev/ttyACM0").baud_rate(115_200);
+let transport = BoardSerialTransport::<_, 1024>::open(&config)?;
+let mut client: BoardVmClient<_, 512, 768, 768> = BoardVmClient::new(transport);
+let hello = client.hello(0x1234_5678)?;
+```
+
+The crate does not assume Arduino, USB CDC, or UART semantics beyond "a byte
+stream with read/write timeouts". Board detection and flashing remain separate.

--- a/code/packages/rust/board-vm-serial/required_capabilities.json
+++ b/code/packages/rust/board-vm-serial/required_capabilities.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/board-vm-serial",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "serial device paths such as /dev/tty*, /dev/cu*, and COM*",
+      "justification": "Host transport must read Board VM response bytes from a user-selected serial device."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "serial device paths such as /dev/tty*, /dev/cu*, and COM*",
+      "justification": "Host transport must write Board VM request bytes to a user-selected serial device."
+    }
+  ],
+  "justification": "This host crate is the explicit real-hardware serial boundary. It only opens user-selected serial ports and delegates protocol framing to pure Board VM crates."
+}

--- a/code/packages/rust/board-vm-serial/src/lib.rs
+++ b/code/packages/rust/board-vm-serial/src/lib.rs
@@ -1,0 +1,303 @@
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use board_vm_client::{RawFrameTransport, TransportError};
+use board_vm_stream::{StreamTransport, StreamTransportError};
+pub use serialport::{DataBits, FlowControl, Parity, SerialPort, SerialPortInfo, StopBits};
+
+pub const DEFAULT_BAUD_RATE: u32 = 115_200;
+pub const DEFAULT_TIMEOUT_MS: u64 = 1_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SerialConfig {
+    pub path: String,
+    pub baud_rate: u32,
+    pub timeout: Duration,
+    pub data_bits: DataBits,
+    pub flow_control: FlowControl,
+    pub parity: Parity,
+    pub stop_bits: StopBits,
+}
+
+impl SerialConfig {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            baud_rate: DEFAULT_BAUD_RATE,
+            timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+            data_bits: DataBits::Eight,
+            flow_control: FlowControl::None,
+            parity: Parity::None,
+            stop_bits: StopBits::One,
+        }
+    }
+
+    pub fn baud_rate(mut self, baud_rate: u32) -> Self {
+        self.baud_rate = baud_rate;
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn data_bits(mut self, data_bits: DataBits) -> Self {
+        self.data_bits = data_bits;
+        self
+    }
+
+    pub fn flow_control(mut self, flow_control: FlowControl) -> Self {
+        self.flow_control = flow_control;
+        self
+    }
+
+    pub fn parity(mut self, parity: Parity) -> Self {
+        self.parity = parity;
+        self
+    }
+
+    pub fn stop_bits(mut self, stop_bits: StopBits) -> Self {
+        self.stop_bits = stop_bits;
+        self
+    }
+}
+
+#[derive(Debug)]
+pub enum SerialTransportError {
+    Open(serialport::Error),
+    Stream(StreamTransportError),
+}
+
+impl From<StreamTransportError> for SerialTransportError {
+    fn from(value: StreamTransportError) -> Self {
+        Self::Stream(value)
+    }
+}
+
+pub struct BoardSerialTransport<S, const WIRE_BYTES: usize = 1024> {
+    inner: StreamTransport<S, WIRE_BYTES>,
+}
+
+impl<S, const WIRE_BYTES: usize> BoardSerialTransport<S, WIRE_BYTES> {
+    pub fn from_stream(stream: S) -> Self {
+        Self {
+            inner: StreamTransport::new(stream),
+        }
+    }
+
+    pub fn into_inner(self) -> StreamTransport<S, WIRE_BYTES> {
+        self.inner
+    }
+
+    pub fn stream_transport(&self) -> &StreamTransport<S, WIRE_BYTES> {
+        &self.inner
+    }
+
+    pub fn stream_transport_mut(&mut self) -> &mut StreamTransport<S, WIRE_BYTES> {
+        &mut self.inner
+    }
+
+    pub fn send_raw_frame(&mut self, raw_frame: &[u8]) -> Result<usize, SerialTransportError>
+    where
+        S: Write,
+    {
+        Ok(self.inner.send_raw_frame(raw_frame)?)
+    }
+
+    pub fn receive_raw_frame(&mut self, raw_out: &mut [u8]) -> Result<usize, SerialTransportError>
+    where
+        S: Read,
+    {
+        Ok(self.inner.receive_raw_frame(raw_out)?)
+    }
+
+    pub fn exchange_raw_frame_checked(
+        &mut self,
+        raw_request: &[u8],
+        raw_response_out: &mut [u8],
+    ) -> Result<usize, SerialTransportError>
+    where
+        S: Read + Write,
+    {
+        Ok(self
+            .inner
+            .exchange_raw_frame_checked(raw_request, raw_response_out)?)
+    }
+}
+
+impl<const WIRE_BYTES: usize> BoardSerialTransport<Box<dyn SerialPort>, WIRE_BYTES> {
+    pub fn open(config: &SerialConfig) -> Result<Self, SerialTransportError> {
+        let port = serialport::new(&config.path, config.baud_rate)
+            .timeout(config.timeout)
+            .data_bits(config.data_bits)
+            .flow_control(config.flow_control)
+            .parity(config.parity)
+            .stop_bits(config.stop_bits)
+            .open()
+            .map_err(SerialTransportError::Open)?;
+        Ok(Self::from_stream(port))
+    }
+}
+
+impl<S, const WIRE_BYTES: usize> RawFrameTransport for BoardSerialTransport<S, WIRE_BYTES>
+where
+    S: Read + Write,
+{
+    fn exchange_raw_frame(
+        &mut self,
+        request: &[u8],
+        response_out: &mut [u8],
+    ) -> Result<usize, TransportError> {
+        self.inner.exchange_raw_frame(request, response_out)
+    }
+}
+
+pub fn available_ports() -> Result<Vec<SerialPortInfo>, serialport::Error> {
+    serialport::available_ports()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::io;
+
+    use board_vm_protocol::{
+        decode_wire_frame, encode_frame, encode_ping, encode_pong, encode_wire_frame, Frame,
+        MessageType, Ping, Pong, FLAG_IS_RESPONSE, FLAG_RESPONSE_REQUIRED,
+    };
+
+    #[derive(Default)]
+    struct ScriptedSerialStream {
+        read: VecDeque<u8>,
+        written: Vec<u8>,
+    }
+
+    impl ScriptedSerialStream {
+        fn with_read(bytes: &[u8]) -> Self {
+            Self {
+                read: bytes.iter().copied().collect(),
+                written: Vec::new(),
+            }
+        }
+    }
+
+    impl Read for ScriptedSerialStream {
+        fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+            if self.read.is_empty() {
+                return Ok(0);
+            }
+            let len = out.len().min(2).min(self.read.len());
+            for slot in out.iter_mut().take(len) {
+                *slot = self.read.pop_front().unwrap();
+            }
+            Ok(len)
+        }
+    }
+
+    impl Write for ScriptedSerialStream {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.written.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn raw_frame(flags: u8, message_type: MessageType, request_id: u16, payload: &[u8]) -> Vec<u8> {
+        let mut raw = [0; 64];
+        let len = encode_frame(
+            &Frame {
+                flags,
+                message_type,
+                request_id,
+                payload,
+            },
+            &mut raw,
+        )
+        .unwrap();
+        raw[..len].to_vec()
+    }
+
+    fn raw_ping(request_id: u16, nonce: u32) -> Vec<u8> {
+        let mut payload = [0; 8];
+        let payload_len = encode_ping(&Ping { nonce }, &mut payload).unwrap();
+        raw_frame(
+            FLAG_RESPONSE_REQUIRED,
+            MessageType::PING,
+            request_id,
+            &payload[..payload_len],
+        )
+    }
+
+    fn raw_pong(request_id: u16, nonce: u32) -> Vec<u8> {
+        let mut payload = [0; 8];
+        let payload_len = encode_pong(&Pong { nonce }, &mut payload).unwrap();
+        raw_frame(
+            FLAG_IS_RESPONSE,
+            MessageType::PONG,
+            request_id,
+            &payload[..payload_len],
+        )
+    }
+
+    fn wire_frame(raw: &[u8]) -> Vec<u8> {
+        let mut wire = [0; 96];
+        let len = encode_wire_frame(raw, &mut wire).unwrap();
+        wire[..len].to_vec()
+    }
+
+    #[test]
+    fn default_config_matches_usb_serial_smoke_test_defaults() {
+        let config = SerialConfig::new("/dev/ttyACM0");
+
+        assert_eq!(config.path, "/dev/ttyACM0");
+        assert_eq!(config.baud_rate, 115_200);
+        assert_eq!(config.timeout, Duration::from_millis(1_000));
+        assert_eq!(config.data_bits, DataBits::Eight);
+        assert_eq!(config.flow_control, FlowControl::None);
+        assert_eq!(config.parity, Parity::None);
+        assert_eq!(config.stop_bits, StopBits::One);
+    }
+
+    #[test]
+    fn config_builder_sets_serial_options() {
+        let config = SerialConfig::new("COM7")
+            .baud_rate(230_400)
+            .timeout(Duration::from_millis(250))
+            .data_bits(DataBits::Seven)
+            .flow_control(FlowControl::Software)
+            .parity(Parity::Even)
+            .stop_bits(StopBits::Two);
+
+        assert_eq!(config.path, "COM7");
+        assert_eq!(config.baud_rate, 230_400);
+        assert_eq!(config.timeout, Duration::from_millis(250));
+        assert_eq!(config.data_bits, DataBits::Seven);
+        assert_eq!(config.flow_control, FlowControl::Software);
+        assert_eq!(config.parity, Parity::Even);
+        assert_eq!(config.stop_bits, StopBits::Two);
+    }
+
+    #[test]
+    fn exchanges_raw_frames_over_serial_byte_stream() {
+        let request = raw_ping(9, 0xDEAD_BEEF);
+        let response = raw_pong(9, 0xDEAD_BEEF);
+        let stream = ScriptedSerialStream::with_read(&wire_frame(&response));
+        let mut transport: BoardSerialTransport<_, 96> = BoardSerialTransport::from_stream(stream);
+        let mut response_out = [0; 64];
+
+        let response_len = transport
+            .exchange_raw_frame_checked(&request, &mut response_out)
+            .unwrap();
+        assert_eq!(&response_out[..response_len], &response);
+
+        let stream = transport.into_inner().into_inner();
+        let mut decoded_request = [0; 64];
+        let request_len = decode_wire_frame(&stream.written, &mut decoded_request).unwrap();
+        assert_eq!(&decoded_request[..request_len], &request);
+    }
+}


### PR DESCRIPTION
## Summary

- add `board-vm-serial`, a host-side serialport-backed transport for Board VM clients
- wrap real serial ports in the existing COBS stream transport and implement `RawFrameTransport`
- add serial config builder, available-port wrapper, capability manifest, and no-hardware byte-stream tests

## Tests

- `cargo fmt -p board-vm-serial`
- `cargo test -p board-vm-serial`
- `cargo test -p board-vm-serial -p board-vm-stream -p board-vm-client -p board-vm-device -p board-vm-loopback -p board-vm-host -p board-vm-protocol -p board-vm-ir -p board-vm-runtime -p board-vm-uno-r4`
- `git diff --check`
- `git diff --cached --check`
