### PR TITLE
Add Uno R4 firmware smoke test

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "board-vm-ir",
     "board-vm-runtime",
     "board-vm-uno-r4",
+    "board-vm-uno-r4-firmware",
     "brainfuck",
     "brainfuck-clr-compiler",
     "brainfuck-jvm-compiler",

--- a/code/packages/rust/board-vm-uno-r4-firmware/.cargo/config.toml
+++ b/code/packages/rust/board-vm-uno-r4-firmware/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.thumbv7em-none-eabihf]
+rustflags = ["-C", "link-arg=-Tlink.x"]

--- a/code/packages/rust/board-vm-uno-r4-firmware/BUILD
+++ b/code/packages/rust/board-vm-uno-r4-firmware/BUILD
@@ -1,0 +1,1 @@
+cargo test -p board-vm-uno-r4-firmware -- --nocapture

--- a/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
+++ b/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "board-vm-uno-r4-firmware"
+version = "0.1.0"
+edition = "2021"
+description = "Uno R4 firmware smoke test for the Board VM runtime"
+
+[dependencies]
+board-vm-ir = { path = "../board-vm-ir" }
+board-vm-runtime = { path = "../board-vm-runtime" }
+board-vm-uno-r4 = { path = "../board-vm-uno-r4" }
+
+[target.'cfg(target_arch = "arm")'.dependencies]
+arduino-uno-r4-hal = "0.1.0"
+cortex-m-rt = "0.7"
+embedded-hal = "1.0"
+panic-halt = "0.2"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "uno-r4-vm-blink-smoke"
+path = "src/bin/uno_r4_vm_blink_smoke.rs"

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -1,0 +1,38 @@
+# board-vm-uno-r4-firmware
+
+Uno R4 firmware smoke test for the Board VM runtime.
+
+This crate embeds the BVM1 blink module and provides a tiny firmware binary that
+executes the bytecode against the Uno R4 D13 LED HAL. It is not the interactive
+serial protocol firmware yet; it is the first real-board check that the Rust
+target, linker script, Uno R4 GPIO mapping, and Board VM runtime can produce a
+flashable image.
+
+Host-side validation:
+
+```sh
+cargo test -p board-vm-uno-r4-firmware
+```
+
+Target compile from this crate directory:
+
+```sh
+rustup target add thumbv7em-none-eabihf
+cargo build --target thumbv7em-none-eabihf --bin uno-r4-vm-blink-smoke --release
+```
+
+If `cargo` comes from Homebrew or another non-rustup toolchain but the target was
+installed with rustup, force cargo to use rustup's `rustc`:
+
+```sh
+RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-vm-blink-smoke --release
+```
+
+The resulting ELF is under:
+
+```text
+../../target/thumbv7em-none-eabihf/release/uno-r4-vm-blink-smoke
+```
+
+Uploading that artifact is intentionally left to the next bundle, where we can
+choose the least surprising Arduino CLI/probe-rs path for the board on hand.

--- a/code/packages/rust/board-vm-uno-r4-firmware/required_capabilities.json
+++ b/code/packages/rust/board-vm-uno-r4-firmware/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/board-vm-uno-r4-firmware",
+  "capabilities": [],
+  "justification": "Firmware code is no_std and accesses board hardware only through target HAL traits at runtime; it does not use host OS resources."
+}

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_vm_blink_smoke.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_vm_blink_smoke.rs
@@ -1,0 +1,85 @@
+#![cfg_attr(target_arch = "arm", no_std)]
+#![cfg_attr(target_arch = "arm", no_main)]
+
+#[cfg(target_arch = "arm")]
+mod firmware {
+    use arduino_uno_r4_hal::{
+        gpio::{Output, Pin},
+        Delay,
+    };
+    use board_vm_runtime::{GpioMode, HalError, Level, Runtime};
+    use board_vm_uno_r4::{UnoR4Backend, UnoR4Board};
+    use board_vm_uno_r4_firmware::{run_blink_smoke_once, SMOKE_INSTRUCTION_BUDGET};
+    use embedded_hal::delay::DelayNs;
+    use panic_halt as _;
+
+    pub struct UnoR4LedBackend {
+        led: Option<Pin<'1', 11, Output>>,
+        delay: Delay,
+        now_ms: u32,
+    }
+
+    impl UnoR4LedBackend {
+        pub fn new() -> Self {
+            Self {
+                led: None,
+                delay: Delay::new(),
+                now_ms: 0,
+            }
+        }
+    }
+
+    impl UnoR4Backend for UnoR4LedBackend {
+        fn configure_gpio(&mut self, pin: u8, mode: GpioMode) -> Result<(), HalError> {
+            if pin != 13 || mode != GpioMode::Output {
+                return Err(HalError::UnsupportedMode);
+            }
+            self.led = Some(Pin::<'1', 11, Output>::new());
+            Ok(())
+        }
+
+        fn write_gpio(&mut self, pin: u8, level: Level) -> Result<(), HalError> {
+            if pin != 13 {
+                return Err(HalError::InvalidPin);
+            }
+            let led = self.led.as_mut().ok_or(HalError::ResourceBusy)?;
+            match level {
+                Level::Low => led.set_low(),
+                Level::High => led.set_high(),
+            }
+            Ok(())
+        }
+
+        fn read_gpio(&mut self, pin: u8) -> Result<Level, HalError> {
+            if pin == 13 {
+                Ok(Level::Low)
+            } else {
+                Err(HalError::InvalidPin)
+            }
+        }
+
+        fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError> {
+            self.delay.delay_ms(duration_ms as u32);
+            self.now_ms = self.now_ms.wrapping_add(duration_ms as u32);
+            Ok(())
+        }
+
+        fn now_ms(&self) -> u32 {
+            self.now_ms
+        }
+    }
+
+    #[cortex_m_rt::entry]
+    fn main() -> ! {
+        let backend = UnoR4LedBackend::new();
+        let board = UnoR4Board::minima(backend);
+        let mut runtime: Runtime<_, 16, 8> = Runtime::new(board);
+
+        loop {
+            let _ = run_blink_smoke_once(&mut runtime, SMOKE_INSTRUCTION_BUDGET);
+        }
+    }
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -1,0 +1,169 @@
+#![no_std]
+
+use board_vm_ir::{parse_module, validate, ModuleError, ValidateError};
+use board_vm_runtime::{BoardHal, RunReport, Runtime, RuntimeError};
+
+pub const EMBEDDED_BLINK_MODULE: [u8; 36] = [
+    0x42, 0x56, 0x4D, 0x31, 0x01, 0x01, 0x04, 0x00, 0x1A, 0x12, 0x0D, 0x12, 0x01, 0x40, 0x01, 0x20,
+    0x11, 0x40, 0x02, 0x13, 0xFA, 0x00, 0x40, 0x10, 0x20, 0x10, 0x40, 0x02, 0x13, 0xFA, 0x00, 0x40,
+    0x10, 0x30, 0xEC, 0x00,
+];
+
+pub const SMOKE_INSTRUCTION_BUDGET: u32 = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FirmwareSmokeError {
+    Module(ModuleError),
+    Validate(ValidateError),
+    Runtime(RuntimeError),
+}
+
+impl From<ModuleError> for FirmwareSmokeError {
+    fn from(value: ModuleError) -> Self {
+        Self::Module(value)
+    }
+}
+
+impl From<ValidateError> for FirmwareSmokeError {
+    fn from(value: ValidateError) -> Self {
+        Self::Validate(value)
+    }
+}
+
+impl From<RuntimeError> for FirmwareSmokeError {
+    fn from(value: RuntimeError) -> Self {
+        Self::Runtime(value)
+    }
+}
+
+pub fn validate_embedded_blink_module(board_max_stack: u8) -> Result<(), FirmwareSmokeError> {
+    let module = parse_module(&EMBEDDED_BLINK_MODULE)?;
+    validate(
+        &module,
+        board_vm_ir::CapabilitySet::blink_mvp(),
+        board_max_stack,
+    )?;
+    Ok(())
+}
+
+pub fn run_blink_smoke_once<H, const MAX_STACK: usize, const MAX_HANDLES: usize>(
+    runtime: &mut Runtime<H, MAX_STACK, MAX_HANDLES>,
+    instruction_budget: u32,
+) -> Result<RunReport, FirmwareSmokeError>
+where
+    H: BoardHal,
+{
+    let module = parse_module(&EMBEDDED_BLINK_MODULE)?;
+    runtime.reset_vm();
+    Ok(runtime.run_module(&module, instruction_budget)?)
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use board_vm_ir::{parse_module, CapabilitySet, FLAG_PROGRAM_MAY_RUN_FOREVER};
+    use board_vm_runtime::{GpioMode, HalError, Level, RunStatus};
+    use std::vec::Vec;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Event {
+        Open { pin: u16, mode: GpioMode },
+        Write { token: u32, level: Level },
+        Sleep(u16),
+    }
+
+    struct FakeHal {
+        now_ms: u32,
+        next_token: u32,
+        events: Vec<Event>,
+    }
+
+    impl FakeHal {
+        fn new() -> Self {
+            Self {
+                now_ms: 0,
+                next_token: 1,
+                events: Vec::new(),
+            }
+        }
+    }
+
+    impl BoardHal for FakeHal {
+        fn capabilities(&self) -> CapabilitySet {
+            CapabilitySet::blink_mvp()
+        }
+
+        fn gpio_open(&mut self, pin: u16, mode: GpioMode) -> Result<u32, HalError> {
+            let token = self.next_token;
+            self.next_token = self.next_token.wrapping_add(1).max(1);
+            self.events.push(Event::Open { pin, mode });
+            Ok(token)
+        }
+
+        fn gpio_write(&mut self, token: u32, level: Level) -> Result<(), HalError> {
+            self.events.push(Event::Write { token, level });
+            Ok(())
+        }
+
+        fn gpio_read(&mut self, _token: u32) -> Result<Level, HalError> {
+            Ok(Level::Low)
+        }
+
+        fn gpio_close(&mut self, _token: u32) -> Result<(), HalError> {
+            Ok(())
+        }
+
+        fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError> {
+            self.now_ms += duration_ms as u32;
+            self.events.push(Event::Sleep(duration_ms));
+            Ok(())
+        }
+
+        fn now_ms(&self) -> u32 {
+            self.now_ms
+        }
+    }
+
+    #[test]
+    fn embedded_blink_module_is_valid_bvm1_bytecode() {
+        let module = parse_module(&EMBEDDED_BLINK_MODULE).unwrap();
+
+        assert_eq!(module.flags, FLAG_PROGRAM_MAY_RUN_FOREVER);
+        assert_eq!(module.max_stack, 4);
+        assert!(module.const_pool.is_empty());
+        validate_embedded_blink_module(16).unwrap();
+    }
+
+    #[test]
+    fn smoke_cycle_runs_blink_bytecode_against_hal() {
+        let hal = FakeHal::new();
+        let mut runtime: Runtime<_, 16, 8> = Runtime::new(hal);
+
+        let report = run_blink_smoke_once(&mut runtime, SMOKE_INSTRUCTION_BUDGET).unwrap();
+
+        assert_eq!(report.status, RunStatus::BudgetExceeded);
+        assert_eq!(report.open_handles, 1);
+        assert_eq!(
+            &runtime.hal().events[..5],
+            &[
+                Event::Open {
+                    pin: 13,
+                    mode: GpioMode::Output
+                },
+                Event::Write {
+                    token: 1,
+                    level: Level::High
+                },
+                Event::Sleep(250),
+                Event::Write {
+                    token: 1,
+                    level: Level::Low
+                },
+                Event::Sleep(250),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add `board-vm-uno-r4-firmware`, a no_std firmware smoke crate for Uno R4
- embed the BVM1 blink bytecode module and expose a host-tested smoke cycle helper
- add an ARM-only `uno-r4-vm-blink-smoke` binary that maps Arduino D13 to the Uno R4 HAL P111 LED pin and runs the Board VM runtime
- document the thumb target build command and rustup/Homebrew toolchain workaround

## Tests

- `cargo fmt -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-uno-r4-firmware`
- `cargo test -p board-vm-uno-r4-firmware -p board-vm-device -p board-vm-stream -p board-vm-client -p board-vm-loopback -p board-vm-host -p board-vm-protocol -p board-vm-ir -p board-vm-runtime -p board-vm-uno-r4`
- `RUSTC=$(rustup which rustc) rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-vm-blink-smoke --release`
- `git diff --check`
- `git diff --cached --check`
