### PR TITLE
[codex] Add Board VM serial smoke CLI

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "board-vm-protocol",
     "board-vm-host",
     "board-vm-client",
+    "board-vm-cli",
     "board-vm-stream",
     "board-vm-serial",
     "board-vm-device",

--- a/code/packages/rust/board-vm-cli/BUILD
+++ b/code/packages/rust/board-vm-cli/BUILD
@@ -1,0 +1,1 @@
+cargo test -p board-vm-cli -- --nocapture

--- a/code/packages/rust/board-vm-cli/Cargo.toml
+++ b/code/packages/rust/board-vm-cli/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "board-vm-cli"
+version = "0.1.0"
+edition = "2021"
+description = "Command-line smoke tools for Board VM hardware sessions"
+
+[dependencies]
+board-vm-client = { path = "../board-vm-client" }
+board-vm-serial = { path = "../board-vm-serial" }
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "board-vm"
+path = "src/main.rs"

--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -1,0 +1,21 @@
+# board-vm-cli
+
+Command-line smoke tools for Board VM hardware sessions.
+
+The first command surface is intentionally small:
+
+```sh
+cargo run -p board-vm-cli --bin board-vm -- list-ports
+```
+
+```sh
+cargo run -p board-vm-cli --bin board-vm -- smoke \
+  --port /dev/cu.usbmodem... \
+  --baud 115200 \
+  --timeout-ms 1000
+```
+
+`smoke` opens the selected serial device, sends `HELLO`, queries capabilities,
+uploads the standard onboard LED blink module, and starts it with a bounded
+instruction budget. It is transport-hosting glue only; the board firmware still
+owns the protocol dispatcher and HAL behavior.

--- a/code/packages/rust/board-vm-cli/required_capabilities.json
+++ b/code/packages/rust/board-vm-cli/required_capabilities.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/board-vm-cli",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "serial device paths such as /dev/tty*, /dev/cu*, and COM*",
+      "justification": "The smoke command reads Board VM response bytes from a user-selected serial device."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "serial device paths such as /dev/tty*, /dev/cu*, and COM*",
+      "justification": "The smoke command writes Board VM request bytes to a user-selected serial device."
+    }
+  ],
+  "justification": "This host CLI is an explicit hardware smoke-test boundary. It opens user-selected serial ports and delegates protocol framing/session logic to Board VM crates."
+}

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -1,0 +1,264 @@
+use core::fmt;
+use std::time::Duration;
+
+use board_vm_client::{
+    BoardDescriptorInfo, BoardVmClient, ClientError, HelloAckInfo, RunReportInfo,
+};
+use board_vm_serial::{
+    available_ports, BoardSerialTransport, SerialConfig, SerialPortInfo, SerialTransportError,
+    DEFAULT_BAUD_RATE, DEFAULT_TIMEOUT_MS,
+};
+
+pub const DEFAULT_PROGRAM_ID: u16 = 1;
+pub const DEFAULT_INSTRUCTION_BUDGET: u32 = 100;
+pub const DEFAULT_HOST_NONCE: u32 = 0xB0A2_D001;
+pub const DEFAULT_HOST_NAME: &str = "board-vm-cli";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CliCommand {
+    ListPorts,
+    Smoke(SmokeOptions),
+    Help,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SmokeOptions {
+    pub port: String,
+    pub baud_rate: u32,
+    pub timeout_ms: u64,
+    pub program_id: u16,
+    pub instruction_budget: u32,
+    pub host_nonce: u32,
+}
+
+impl SmokeOptions {
+    pub fn serial_config(&self) -> SerialConfig {
+        SerialConfig::new(&self.port)
+            .baud_rate(self.baud_rate)
+            .timeout(Duration::from_millis(self.timeout_ms))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CliError {
+    MissingCommand,
+    UnknownCommand(String),
+    MissingValue(&'static str),
+    MissingRequired(&'static str),
+    InvalidNumber { option: &'static str, value: String },
+    UnknownOption(String),
+    Serial(String),
+    Client(ClientError),
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingCommand => write!(f, "missing command"),
+            Self::UnknownCommand(command) => write!(f, "unknown command: {command}"),
+            Self::MissingValue(option) => write!(f, "missing value for {option}"),
+            Self::MissingRequired(option) => write!(f, "missing required option: {option}"),
+            Self::InvalidNumber { option, value } => {
+                write!(f, "invalid numeric value for {option}: {value}")
+            }
+            Self::UnknownOption(option) => write!(f, "unknown option: {option}"),
+            Self::Serial(error) => write!(f, "serial error: {error}"),
+            Self::Client(error) => write!(f, "client error: {error:?}"),
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
+
+impl From<ClientError> for CliError {
+    fn from(value: ClientError) -> Self {
+        Self::Client(value)
+    }
+}
+
+impl From<SerialTransportError> for CliError {
+    fn from(value: SerialTransportError) -> Self {
+        Self::Serial(format!("{value:?}"))
+    }
+}
+
+pub fn parse_args<I, S>(args: I) -> Result<CliCommand, CliError>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut args = args.into_iter().map(Into::into);
+    let Some(command) = args.next() else {
+        return Err(CliError::MissingCommand);
+    };
+
+    match command.as_str() {
+        "list-ports" => Ok(CliCommand::ListPorts),
+        "smoke" => parse_smoke_args(args),
+        "help" | "--help" | "-h" => Ok(CliCommand::Help),
+        other => Err(CliError::UnknownCommand(other.to_owned())),
+    }
+}
+
+fn parse_smoke_args<I>(mut args: I) -> Result<CliCommand, CliError>
+where
+    I: Iterator<Item = String>,
+{
+    let mut port = None;
+    let mut baud_rate = DEFAULT_BAUD_RATE;
+    let mut timeout_ms = DEFAULT_TIMEOUT_MS;
+    let mut program_id = DEFAULT_PROGRAM_ID;
+    let mut instruction_budget = DEFAULT_INSTRUCTION_BUDGET;
+    let mut host_nonce = DEFAULT_HOST_NONCE;
+
+    while let Some(option) = args.next() {
+        match option.as_str() {
+            "--port" | "-p" => port = Some(next_value(&mut args, "--port")?),
+            "--baud" | "-b" => {
+                baud_rate = parse_number(next_value(&mut args, "--baud")?, "--baud")?
+            }
+            "--timeout-ms" => {
+                timeout_ms = parse_number(next_value(&mut args, "--timeout-ms")?, "--timeout-ms")?
+            }
+            "--program-id" => {
+                program_id = parse_number(next_value(&mut args, "--program-id")?, "--program-id")?
+            }
+            "--budget" => {
+                instruction_budget = parse_number(next_value(&mut args, "--budget")?, "--budget")?
+            }
+            "--host-nonce" => {
+                host_nonce = parse_number(next_value(&mut args, "--host-nonce")?, "--host-nonce")?
+            }
+            other => return Err(CliError::UnknownOption(other.to_owned())),
+        }
+    }
+
+    let port = port.ok_or(CliError::MissingRequired("--port"))?;
+    Ok(CliCommand::Smoke(SmokeOptions {
+        port,
+        baud_rate,
+        timeout_ms,
+        program_id,
+        instruction_budget,
+        host_nonce,
+    }))
+}
+
+fn next_value<I>(args: &mut I, option: &'static str) -> Result<String, CliError>
+where
+    I: Iterator<Item = String>,
+{
+    args.next().ok_or(CliError::MissingValue(option))
+}
+
+fn parse_number<T>(value: String, option: &'static str) -> Result<T, CliError>
+where
+    T: core::str::FromStr,
+{
+    value
+        .parse::<T>()
+        .map_err(|_| CliError::InvalidNumber { option, value })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SmokeReport {
+    pub hello: HelloAckInfo,
+    pub descriptor: BoardDescriptorInfo,
+    pub run: RunReportInfo,
+}
+
+pub fn run_smoke(options: &SmokeOptions) -> Result<SmokeReport, CliError> {
+    let transport = BoardSerialTransport::<_, 1024>::open(&options.serial_config())?;
+    let mut client: BoardVmClient<_, 512, 768, 768> = BoardVmClient::new(transport);
+    let hello = client.hello_with_name(DEFAULT_HOST_NAME, options.host_nonce)?;
+    let descriptor = client.query_caps()?;
+    let run = client.blink_onboard_led(options.program_id, options.instruction_budget)?;
+    Ok(SmokeReport {
+        hello,
+        descriptor,
+        run,
+    })
+}
+
+pub fn list_ports() -> Result<Vec<SerialPortInfo>, CliError> {
+    available_ports().map_err(|error| CliError::Serial(error.to_string()))
+}
+
+pub fn usage() -> &'static str {
+    "usage:\n  board-vm list-ports\n  board-vm smoke --port <path> [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_list_ports_command() {
+        assert_eq!(parse_args(["list-ports"]).unwrap(), CliCommand::ListPorts);
+    }
+
+    #[test]
+    fn parses_smoke_defaults() {
+        let command = parse_args(["smoke", "--port", "/dev/cu.usbmodem-test"]).unwrap();
+
+        assert_eq!(
+            command,
+            CliCommand::Smoke(SmokeOptions {
+                port: "/dev/cu.usbmodem-test".to_owned(),
+                baud_rate: DEFAULT_BAUD_RATE,
+                timeout_ms: DEFAULT_TIMEOUT_MS,
+                program_id: DEFAULT_PROGRAM_ID,
+                instruction_budget: DEFAULT_INSTRUCTION_BUDGET,
+                host_nonce: DEFAULT_HOST_NONCE,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_smoke_overrides() {
+        let command = parse_args([
+            "smoke",
+            "--port",
+            "COM9",
+            "--baud",
+            "57600",
+            "--timeout-ms",
+            "250",
+            "--program-id",
+            "7",
+            "--budget",
+            "200",
+            "--host-nonce",
+            "1234",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            command,
+            CliCommand::Smoke(SmokeOptions {
+                port: "COM9".to_owned(),
+                baud_rate: 57_600,
+                timeout_ms: 250,
+                program_id: 7,
+                instruction_budget: 200,
+                host_nonce: 1234,
+            })
+        );
+    }
+
+    #[test]
+    fn requires_smoke_port() {
+        assert_eq!(
+            parse_args(["smoke"]).unwrap_err(),
+            CliError::MissingRequired("--port")
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_option() {
+        assert_eq!(
+            parse_args(["smoke", "--port", "COM9", "--wat"]).unwrap_err(),
+            CliError::UnknownOption("--wat".to_owned())
+        );
+    }
+}

--- a/code/packages/rust/board-vm-cli/src/main.rs
+++ b/code/packages/rust/board-vm-cli/src/main.rs
@@ -1,0 +1,57 @@
+use std::env;
+
+use board_vm_cli::{list_ports, parse_args, run_smoke, usage, CliCommand};
+
+fn main() {
+    match parse_args(env::args().skip(1)).and_then(run_command) {
+        Ok(()) => {}
+        Err(error) => {
+            eprintln!("error: {error}\n\n{}", usage());
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run_command(command: CliCommand) -> Result<(), board_vm_cli::CliError> {
+    match command {
+        CliCommand::ListPorts => {
+            for port in list_ports()? {
+                println!("{}\t{:?}", port.port_name, port.port_type);
+            }
+            Ok(())
+        }
+        CliCommand::Smoke(options) => {
+            let report = run_smoke(&options)?;
+            println!(
+                "hello board={} runtime={} protocol={} host_nonce=0x{:08X} board_nonce=0x{:08X}",
+                report.hello.board_name,
+                report.hello.runtime_name,
+                report.hello.selected_version,
+                report.hello.host_nonce,
+                report.hello.board_nonce
+            );
+            println!(
+                "caps board={} runtime={} max_program_bytes={} stack={} handles={} capabilities={}",
+                report.descriptor.board_id,
+                report.descriptor.runtime_id,
+                report.descriptor.max_program_bytes,
+                report.descriptor.max_stack_values,
+                report.descriptor.max_handles,
+                report.descriptor.capabilities.len()
+            );
+            println!(
+                "blink program_id={} status={:?} instructions={} elapsed_ms={} open_handles={}",
+                report.run.program_id,
+                report.run.status,
+                report.run.instructions_executed,
+                report.run.elapsed_ms,
+                report.run.open_handles
+            );
+            Ok(())
+        }
+        CliCommand::Help => {
+            println!("{}", usage());
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a new board-vm-cli workspace package with a `board-vm` command
- support `list-ports` and a `smoke` command that opens a serial transport, sends HELLO, queries capabilities, uploads the standard blink module, and starts it
- document the command and declare the serial device capabilities for the host hardware boundary

## Validation

- cargo test -p board-vm-cli
- cargo run -p board-vm-cli --bin board-vm -- list-ports
