### PR TITLE
[codex] Add Uno R4 stream handshake probe

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
+++ b/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 description = "Uno R4 firmware smoke test for the Board VM runtime"
 
 [dependencies]
+board-vm-device = { path = "../board-vm-device" }
 board-vm-ir = { path = "../board-vm-ir" }
+board-vm-protocol = { path = "../board-vm-protocol" }
 board-vm-runtime = { path = "../board-vm-runtime" }
 board-vm-uno-r4 = { path = "../board-vm-uno-r4" }
 
@@ -25,3 +27,7 @@ path = "src/bin/uno_r4_vm_blink_smoke.rs"
 [[bin]]
 name = "uno-r4-wifi-raw-blink-probe"
 path = "src/bin/uno_r4_wifi_raw_blink_probe.rs"
+
+[[bin]]
+name = "uno-r4-wifi-stream-handshake-probe"
+path = "src/bin/uno_r4_wifi_stream_handshake_probe.rs"

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -67,6 +67,17 @@ from bytecode runtime issues:
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-wifi-raw-blink-probe --release
 ```
 
+`uno-r4-wifi-stream-handshake-probe` validates the board-side protocol path
+without requiring USB CDC yet. It creates an in-memory COBS-delimited `HELLO`
+request, serves it through `DeviceStreamEndpoint` and the Uno R4 `BoardVmDevice`,
+decodes the emitted `HELLO_ACK`, and then blinks the yellow `L` LED. A repeating
+three-fast-blink pattern means the stream/protocol/device path passed; a slow
+single blink means the probe failed before or during response validation.
+
+```sh
+RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-wifi-stream-handshake-probe --release
+```
+
 ```sh
 arduino-cli upload \
   -p /dev/cu.usbmodem... \

--- a/code/packages/rust/board-vm-uno-r4-firmware/build.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/build.rs
@@ -6,7 +6,11 @@ const UNO_R4_SKETCH_FLASH_ORIGIN: u32 = 0x0000_4000;
 const UNO_R4_CODE_FLASH_BYTES: u32 = 0x0004_0000;
 const UNO_R4_RAM_ORIGIN: u32 = 0x2000_0000;
 const UNO_R4_RAM_BYTES: u32 = 0x8000;
-const FIRMWARE_BINS: [&str; 2] = ["uno-r4-vm-blink-smoke", "uno-r4-wifi-raw-blink-probe"];
+const FIRMWARE_BINS: [&str; 3] = [
+    "uno-r4-vm-blink-smoke",
+    "uno-r4-wifi-raw-blink-probe",
+    "uno-r4-wifi-stream-handshake-probe",
+];
 
 fn main() {
     if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("arm") {

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_vm_blink_smoke.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_vm_blink_smoke.rs
@@ -3,72 +3,12 @@
 
 #[cfg(target_arch = "arm")]
 mod firmware {
-    use arduino_uno_r4_hal::Delay;
-    use board_vm_runtime::{GpioMode, HalError, Level, Runtime};
-    use board_vm_uno_r4::{UnoR4Backend, UnoR4Board};
+    use board_vm_runtime::Runtime;
+    use board_vm_uno_r4::UnoR4Board;
     use board_vm_uno_r4_firmware::{
-        run_blink_smoke_once,
-        uno_r4_wifi_led::{UnoR4WifiLed, UNO_R4_WIFI_LED_PIN},
-        SMOKE_INSTRUCTION_BUDGET,
+        run_blink_smoke_once, uno_r4_wifi_backend::UnoR4WifiLedBackend, SMOKE_INSTRUCTION_BUDGET,
     };
-    use embedded_hal::delay::DelayNs;
     use panic_halt as _;
-
-    pub struct UnoR4WifiLedBackend {
-        led: Option<UnoR4WifiLed>,
-        delay: Delay,
-        now_ms: u32,
-    }
-
-    impl UnoR4WifiLedBackend {
-        pub fn new() -> Self {
-            Self {
-                led: None,
-                delay: Delay::new(),
-                now_ms: 0,
-            }
-        }
-    }
-
-    impl UnoR4Backend for UnoR4WifiLedBackend {
-        fn configure_gpio(&mut self, pin: u8, mode: GpioMode) -> Result<(), HalError> {
-            if pin != UNO_R4_WIFI_LED_PIN || mode != GpioMode::Output {
-                return Err(HalError::UnsupportedMode);
-            }
-            self.led = Some(UnoR4WifiLed::configure_output());
-            Ok(())
-        }
-
-        fn write_gpio(&mut self, pin: u8, level: Level) -> Result<(), HalError> {
-            if pin != UNO_R4_WIFI_LED_PIN {
-                return Err(HalError::InvalidPin);
-            }
-            let led = self.led.as_mut().ok_or(HalError::ResourceBusy)?;
-            match level {
-                Level::Low => led.set_low(),
-                Level::High => led.set_high(),
-            }
-            Ok(())
-        }
-
-        fn read_gpio(&mut self, pin: u8) -> Result<Level, HalError> {
-            if pin == UNO_R4_WIFI_LED_PIN {
-                Ok(Level::Low)
-            } else {
-                Err(HalError::InvalidPin)
-            }
-        }
-
-        fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError> {
-            self.delay.delay_ms(duration_ms as u32);
-            self.now_ms = self.now_ms.wrapping_add(duration_ms as u32);
-            Ok(())
-        }
-
-        fn now_ms(&self) -> u32 {
-            self.now_ms
-        }
-    }
 
     #[cortex_m_rt::entry]
     fn main() -> ! {

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_stream_handshake_probe.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_stream_handshake_probe.rs
@@ -1,0 +1,166 @@
+#![cfg_attr(target_arch = "arm", no_std)]
+#![cfg_attr(target_arch = "arm", no_main)]
+
+#[cfg(target_arch = "arm")]
+mod firmware {
+    use board_vm_device::{DeviceByteStream, DeviceStreamEndpoint};
+    use board_vm_protocol::{
+        decode_frame, decode_hello_ack, decode_wire_frame, encode_frame, encode_hello,
+        encode_wire_frame, Frame, Hello, MessageType, FLAG_IS_RESPONSE, FLAG_RESPONSE_REQUIRED,
+    };
+    use board_vm_runtime::Level;
+    use board_vm_uno_r4::{UnoR4Board, UnoR4Device};
+    use board_vm_uno_r4_firmware::uno_r4_wifi_backend::UnoR4WifiLedBackend;
+    use panic_halt as _;
+
+    const HOST_NONCE: u32 = 0xB0A2_D002;
+    const BOARD_NONCE: u32 = 0xB04D_1002;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ProbeStreamError {
+        BufferTooSmall,
+        EndOfInput,
+    }
+
+    struct ProbeStream<const READ_BYTES: usize, const WRITE_BYTES: usize> {
+        read: [u8; READ_BYTES],
+        read_len: usize,
+        read_offset: usize,
+        written: [u8; WRITE_BYTES],
+        written_len: usize,
+    }
+
+    impl<const READ_BYTES: usize, const WRITE_BYTES: usize> ProbeStream<READ_BYTES, WRITE_BYTES> {
+        fn with_read(bytes: &[u8]) -> Result<Self, ProbeStreamError> {
+            if bytes.len() > READ_BYTES {
+                return Err(ProbeStreamError::BufferTooSmall);
+            }
+            let mut read = [0; READ_BYTES];
+            read[..bytes.len()].copy_from_slice(bytes);
+            Ok(Self {
+                read,
+                read_len: bytes.len(),
+                read_offset: 0,
+                written: [0; WRITE_BYTES],
+                written_len: 0,
+            })
+        }
+
+        fn written(&self) -> &[u8] {
+            &self.written[..self.written_len]
+        }
+    }
+
+    impl<const READ_BYTES: usize, const WRITE_BYTES: usize> DeviceByteStream
+        for ProbeStream<READ_BYTES, WRITE_BYTES>
+    {
+        type Error = ProbeStreamError;
+
+        fn read_byte(&mut self) -> Result<u8, Self::Error> {
+            if self.read_offset >= self.read_len {
+                return Err(ProbeStreamError::EndOfInput);
+            }
+            let byte = self.read[self.read_offset];
+            self.read_offset += 1;
+            Ok(byte)
+        }
+
+        fn write_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+            let end = self
+                .written_len
+                .checked_add(bytes.len())
+                .ok_or(ProbeStreamError::BufferTooSmall)?;
+            if end > WRITE_BYTES {
+                return Err(ProbeStreamError::BufferTooSmall);
+            }
+            self.written[self.written_len..end].copy_from_slice(bytes);
+            self.written_len = end;
+            Ok(())
+        }
+    }
+
+    fn build_hello_wire(out: &mut [u8]) -> Result<usize, ()> {
+        let mut payload = [0u8; 64];
+        let mut raw = [0u8; 128];
+        let payload_len = encode_hello(
+            &Hello {
+                min_version: 1,
+                max_version: 1,
+                host_name: "uno-r4-probe",
+                host_nonce: HOST_NONCE,
+            },
+            &mut payload,
+        )
+        .map_err(|_| ())?;
+        let raw_len = encode_frame(
+            &Frame {
+                flags: FLAG_RESPONSE_REQUIRED,
+                message_type: MessageType::HELLO,
+                request_id: 1,
+                payload: &payload[..payload_len],
+            },
+            &mut raw,
+        )
+        .map_err(|_| ())?;
+        encode_wire_frame(&raw[..raw_len], out).map_err(|_| ())
+    }
+
+    fn run_probe(device: &mut UnoR4Device<UnoR4WifiLedBackend>) -> bool {
+        let mut hello_wire = [0u8; 192];
+        let Ok(hello_wire_len) = build_hello_wire(&mut hello_wire) else {
+            return false;
+        };
+        let Ok(stream) = ProbeStream::<192, 192>::with_read(&hello_wire[..hello_wire_len]) else {
+            return false;
+        };
+        let mut endpoint = DeviceStreamEndpoint::<_, 192, 128, 128>::new(stream);
+        if endpoint.serve_one(device).is_err() {
+            return false;
+        }
+
+        let stream = endpoint.into_inner();
+        let mut raw_response = [0u8; 128];
+        let Ok(raw_len) = decode_wire_frame(stream.written(), &mut raw_response) else {
+            return false;
+        };
+        let Ok(frame) = decode_frame(&raw_response[..raw_len]) else {
+            return false;
+        };
+        if frame.flags != FLAG_IS_RESPONSE
+            || frame.message_type != MessageType::HELLO_ACK
+            || frame.request_id != 1
+        {
+            return false;
+        }
+        let Ok(ack) = decode_hello_ack(frame.payload) else {
+            return false;
+        };
+        ack.host_nonce == HOST_NONCE
+            && ack.board_nonce == BOARD_NONCE
+            && ack.board_name == "arduino-uno-r4-wifi"
+    }
+
+    #[cortex_m_rt::entry]
+    fn main() -> ! {
+        let backend = UnoR4WifiLedBackend::new();
+        let board = UnoR4Board::wifi(backend);
+        let mut device = board.into_device(BOARD_NONCE);
+        let ok = run_probe(&mut device);
+        let backend = device.hal_mut().backend_mut();
+
+        loop {
+            if ok {
+                backend.blink_pattern(3, 70, 90);
+                backend.pause_ms(700);
+            } else {
+                backend.set_led(Level::High);
+                backend.pause_ms(700);
+                backend.set_led(Level::Low);
+                backend.pause_ms(700);
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -4,6 +4,8 @@ use board_vm_ir::{parse_module, validate, ModuleError, ValidateError};
 use board_vm_runtime::{BoardHal, RunReport, Runtime, RuntimeError};
 
 #[cfg(target_arch = "arm")]
+pub mod uno_r4_wifi_backend;
+#[cfg(target_arch = "arm")]
 pub mod uno_r4_wifi_led;
 
 pub const EMBEDDED_BLINK_MODULE: [u8; 36] = [

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/uno_r4_wifi_backend.rs
@@ -1,0 +1,85 @@
+use arduino_uno_r4_hal::Delay;
+use board_vm_runtime::{GpioMode, HalError, Level};
+use board_vm_uno_r4::UnoR4Backend;
+use embedded_hal::delay::DelayNs;
+
+use crate::uno_r4_wifi_led::{UnoR4WifiLed, UNO_R4_WIFI_LED_PIN};
+
+pub struct UnoR4WifiLedBackend {
+    led: Option<UnoR4WifiLed>,
+    delay: Delay,
+    now_ms: u32,
+}
+
+impl UnoR4WifiLedBackend {
+    pub fn new() -> Self {
+        Self {
+            led: None,
+            delay: Delay::new(),
+            now_ms: 0,
+        }
+    }
+
+    pub fn set_led(&mut self, level: Level) {
+        let led = self.led.get_or_insert_with(UnoR4WifiLed::configure_output);
+        match level {
+            Level::Low => led.set_low(),
+            Level::High => led.set_high(),
+        }
+    }
+
+    pub fn pause_ms(&mut self, duration_ms: u32) {
+        self.delay.delay_ms(duration_ms);
+        self.now_ms = self.now_ms.wrapping_add(duration_ms);
+    }
+
+    pub fn blink_pattern(&mut self, pulses: u8, on_ms: u32, off_ms: u32) {
+        for _ in 0..pulses {
+            self.set_led(Level::High);
+            self.pause_ms(on_ms);
+            self.set_led(Level::Low);
+            self.pause_ms(off_ms);
+        }
+    }
+}
+
+impl Default for UnoR4WifiLedBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UnoR4Backend for UnoR4WifiLedBackend {
+    fn configure_gpio(&mut self, pin: u8, mode: GpioMode) -> Result<(), HalError> {
+        if pin != UNO_R4_WIFI_LED_PIN || mode != GpioMode::Output {
+            return Err(HalError::UnsupportedMode);
+        }
+        self.led = Some(UnoR4WifiLed::configure_output());
+        Ok(())
+    }
+
+    fn write_gpio(&mut self, pin: u8, level: Level) -> Result<(), HalError> {
+        if pin != UNO_R4_WIFI_LED_PIN {
+            return Err(HalError::InvalidPin);
+        }
+        self.set_led(level);
+        Ok(())
+    }
+
+    fn read_gpio(&mut self, pin: u8) -> Result<Level, HalError> {
+        if pin == UNO_R4_WIFI_LED_PIN {
+            Ok(Level::Low)
+        } else {
+            Err(HalError::InvalidPin)
+        }
+    }
+
+    fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError> {
+        self.pause_ms(duration_ms as u32);
+        Ok(())
+    }
+
+    fn now_ms(&self) -> u32 {
+        self.now_ms
+    }
+}


### PR DESCRIPTION
## Summary

- move the Uno R4 WiFi LED backend into the firmware library so multiple firmware probes can share it
- add `uno-r4-wifi-stream-handshake-probe`, which builds an in-memory COBS `HELLO`, serves it through `DeviceStreamEndpoint` and the Uno R4 device, verifies the `HELLO_ACK`, and signals success with three fast LED blinks
- document the new probe and include it in the firmware linker setup

## Hardware validation

- uploaded `uno-r4-wifi-stream-handshake-probe.bin` to an Arduino Uno R4 WiFi on `/dev/cu.usbmodem9070692469E42`
- observed the success pattern: repeating three fast blinks on the yellow `L` LED

## Validation

- cargo test -p board-vm-uno-r4-firmware
- RUSTC="$(rustup which rustc)" rustup run stable cargo build --manifest-path /tmp/coding-adventures-board-vm-uno-r4-stream-probe-pr/code/packages/rust/Cargo.toml --target thumbv7em-none-eabihf --bin uno-r4-wifi-stream-handshake-probe --release
