### PR TITLE
[codex] Add Uno R4 scripted stream session probe

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
+++ b/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
@@ -31,3 +31,7 @@ path = "src/bin/uno_r4_wifi_raw_blink_probe.rs"
 [[bin]]
 name = "uno-r4-wifi-stream-handshake-probe"
 path = "src/bin/uno_r4_wifi_stream_handshake_probe.rs"
+
+[[bin]]
+name = "uno-r4-wifi-stream-session-probe"
+path = "src/bin/uno_r4_wifi_stream_session_probe.rs"

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -78,6 +78,16 @@ single blink means the probe failed before or during response validation.
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-wifi-stream-handshake-probe --release
 ```
 
+`uno-r4-wifi-stream-session-probe` extends the same idea to a complete scripted
+session. It feeds `HELLO`, `CAPS_QUERY`, `PROGRAM_BEGIN`, `PROGRAM_CHUNK`,
+`PROGRAM_END`, and `RUN` wire frames into the device stream endpoint, verifies
+each response, and runs the uploaded blink module through the Uno R4 runtime. A
+repeating four-fast-blink pattern means the full scripted upload/run path passed.
+
+```sh
+RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-wifi-stream-session-probe --release
+```
+
 ```sh
 arduino-cli upload \
   -p /dev/cu.usbmodem... \

--- a/code/packages/rust/board-vm-uno-r4-firmware/build.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/build.rs
@@ -6,10 +6,11 @@ const UNO_R4_SKETCH_FLASH_ORIGIN: u32 = 0x0000_4000;
 const UNO_R4_CODE_FLASH_BYTES: u32 = 0x0004_0000;
 const UNO_R4_RAM_ORIGIN: u32 = 0x2000_0000;
 const UNO_R4_RAM_BYTES: u32 = 0x8000;
-const FIRMWARE_BINS: [&str; 3] = [
+const FIRMWARE_BINS: [&str; 4] = [
     "uno-r4-vm-blink-smoke",
     "uno-r4-wifi-raw-blink-probe",
     "uno-r4-wifi-stream-handshake-probe",
+    "uno-r4-wifi-stream-session-probe",
 ];
 
 fn main() {

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_stream_handshake_probe.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_stream_handshake_probe.rs
@@ -3,81 +3,20 @@
 
 #[cfg(target_arch = "arm")]
 mod firmware {
-    use board_vm_device::{DeviceByteStream, DeviceStreamEndpoint};
+    use board_vm_device::DeviceStreamEndpoint;
     use board_vm_protocol::{
         decode_frame, decode_hello_ack, decode_wire_frame, encode_frame, encode_hello,
         encode_wire_frame, Frame, Hello, MessageType, FLAG_IS_RESPONSE, FLAG_RESPONSE_REQUIRED,
     };
     use board_vm_runtime::Level;
     use board_vm_uno_r4::{UnoR4Board, UnoR4Device};
-    use board_vm_uno_r4_firmware::uno_r4_wifi_backend::UnoR4WifiLedBackend;
+    use board_vm_uno_r4_firmware::{
+        scripted_probe_stream::ProbeStream, uno_r4_wifi_backend::UnoR4WifiLedBackend,
+    };
     use panic_halt as _;
 
     const HOST_NONCE: u32 = 0xB0A2_D002;
     const BOARD_NONCE: u32 = 0xB04D_1002;
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    enum ProbeStreamError {
-        BufferTooSmall,
-        EndOfInput,
-    }
-
-    struct ProbeStream<const READ_BYTES: usize, const WRITE_BYTES: usize> {
-        read: [u8; READ_BYTES],
-        read_len: usize,
-        read_offset: usize,
-        written: [u8; WRITE_BYTES],
-        written_len: usize,
-    }
-
-    impl<const READ_BYTES: usize, const WRITE_BYTES: usize> ProbeStream<READ_BYTES, WRITE_BYTES> {
-        fn with_read(bytes: &[u8]) -> Result<Self, ProbeStreamError> {
-            if bytes.len() > READ_BYTES {
-                return Err(ProbeStreamError::BufferTooSmall);
-            }
-            let mut read = [0; READ_BYTES];
-            read[..bytes.len()].copy_from_slice(bytes);
-            Ok(Self {
-                read,
-                read_len: bytes.len(),
-                read_offset: 0,
-                written: [0; WRITE_BYTES],
-                written_len: 0,
-            })
-        }
-
-        fn written(&self) -> &[u8] {
-            &self.written[..self.written_len]
-        }
-    }
-
-    impl<const READ_BYTES: usize, const WRITE_BYTES: usize> DeviceByteStream
-        for ProbeStream<READ_BYTES, WRITE_BYTES>
-    {
-        type Error = ProbeStreamError;
-
-        fn read_byte(&mut self) -> Result<u8, Self::Error> {
-            if self.read_offset >= self.read_len {
-                return Err(ProbeStreamError::EndOfInput);
-            }
-            let byte = self.read[self.read_offset];
-            self.read_offset += 1;
-            Ok(byte)
-        }
-
-        fn write_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
-            let end = self
-                .written_len
-                .checked_add(bytes.len())
-                .ok_or(ProbeStreamError::BufferTooSmall)?;
-            if end > WRITE_BYTES {
-                return Err(ProbeStreamError::BufferTooSmall);
-            }
-            self.written[self.written_len..end].copy_from_slice(bytes);
-            self.written_len = end;
-            Ok(())
-        }
-    }
 
     fn build_hello_wire(out: &mut [u8]) -> Result<usize, ()> {
         let mut payload = [0u8; 64];

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_stream_session_probe.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_stream_session_probe.rs
@@ -1,0 +1,302 @@
+#![cfg_attr(target_arch = "arm", no_std)]
+#![cfg_attr(target_arch = "arm", no_main)]
+
+#[cfg(target_arch = "arm")]
+mod firmware {
+    use board_vm_device::DeviceStreamEndpoint;
+    use board_vm_protocol::{
+        decode_caps_report_header, decode_frame, decode_hello_ack, decode_program_begin,
+        decode_program_chunk, decode_program_end, decode_run_report_header, decode_wire_frame,
+        encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
+        encode_run_request, encode_wire_frame, Frame, Hello, MessageType, ProgramBegin,
+        ProgramChunk, ProgramEnd, ProgramFormat, RunRequest, RunStatus, FLAG_IS_RESPONSE,
+        FLAG_RESPONSE_REQUIRED, RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
+    };
+    use board_vm_runtime::Level;
+    use board_vm_uno_r4::{UnoR4Board, UnoR4Device, UNO_R4_VM_RUNTIME_ID};
+    use board_vm_uno_r4_firmware::{
+        scripted_probe_stream::ProbeStream, uno_r4_wifi_backend::UnoR4WifiLedBackend,
+        EMBEDDED_BLINK_MODULE, SMOKE_INSTRUCTION_BUDGET,
+    };
+    use panic_halt as _;
+
+    const HOST_NONCE: u32 = 0xB0A2_D003;
+    const BOARD_NONCE: u32 = 0xB04D_1003;
+    const PROGRAM_ID: u16 = 1;
+
+    fn encode_request(
+        message_type: MessageType,
+        request_id: u16,
+        payload: &[u8],
+        out: &mut [u8],
+    ) -> Result<usize, ()> {
+        let mut raw = [0u8; 192];
+        let raw_len = encode_frame(
+            &Frame {
+                flags: FLAG_RESPONSE_REQUIRED,
+                message_type,
+                request_id,
+                payload,
+            },
+            &mut raw,
+        )
+        .map_err(|_| ())?;
+        encode_wire_frame(&raw[..raw_len], out).map_err(|_| ())
+    }
+
+    fn serve_request(
+        device: &mut UnoR4Device<UnoR4WifiLedBackend>,
+        request_wire: &[u8],
+        raw_response: &mut [u8],
+    ) -> Result<usize, ()> {
+        let stream = ProbeStream::<256, 256>::with_read(request_wire).map_err(|_| ())?;
+        let mut endpoint = DeviceStreamEndpoint::<_, 256, 192, 256>::new(stream);
+        endpoint.serve_one(device).map_err(|_| ())?;
+        let stream = endpoint.into_inner();
+        decode_wire_frame(stream.written(), raw_response).map_err(|_| ())
+    }
+
+    fn expect_response<'a>(
+        raw_response: &'a [u8],
+        expected_type: MessageType,
+        request_id: u16,
+    ) -> Result<Frame<'a>, ()> {
+        let frame = decode_frame(raw_response).map_err(|_| ())?;
+        if frame.flags != FLAG_IS_RESPONSE
+            || frame.message_type != expected_type
+            || frame.request_id != request_id
+        {
+            return Err(());
+        }
+        Ok(frame)
+    }
+
+    fn serve_and_expect<'a>(
+        device: &mut UnoR4Device<UnoR4WifiLedBackend>,
+        message_type: MessageType,
+        expected_type: MessageType,
+        request_id: u16,
+        payload: &[u8],
+        raw_response: &'a mut [u8],
+    ) -> Result<Frame<'a>, ()> {
+        let mut request_wire = [0u8; 256];
+        let wire_len = encode_request(message_type, request_id, payload, &mut request_wire)?;
+        let response_len =
+            serve_request(device, &request_wire[..wire_len], raw_response).map_err(|_| ())?;
+        expect_response(&raw_response[..response_len], expected_type, request_id)
+    }
+
+    fn crc32_ieee(bytes: &[u8]) -> u32 {
+        let mut crc = 0xFFFF_FFFFu32;
+        for byte in bytes {
+            crc ^= *byte as u32;
+            for _ in 0..8 {
+                if crc & 1 != 0 {
+                    crc = (crc >> 1) ^ 0xEDB8_8320;
+                } else {
+                    crc >>= 1;
+                }
+            }
+        }
+        !crc
+    }
+
+    fn run_probe(device: &mut UnoR4Device<UnoR4WifiLedBackend>) -> bool {
+        let mut payload = [0u8; 128];
+        let mut raw_response = [0u8; 256];
+
+        let Ok(payload_len) = encode_hello(
+            &Hello {
+                min_version: 1,
+                max_version: 1,
+                host_name: "uno-r4-session-probe",
+                host_nonce: HOST_NONCE,
+            },
+            &mut payload,
+        ) else {
+            return false;
+        };
+        let Ok(frame) = serve_and_expect(
+            device,
+            MessageType::HELLO,
+            MessageType::HELLO_ACK,
+            1,
+            &payload[..payload_len],
+            &mut raw_response,
+        ) else {
+            return false;
+        };
+        let Ok(ack) = decode_hello_ack(frame.payload) else {
+            return false;
+        };
+        if ack.host_nonce != HOST_NONCE
+            || ack.board_nonce != BOARD_NONCE
+            || ack.board_name != "arduino-uno-r4-wifi"
+            || ack.runtime_name != UNO_R4_VM_RUNTIME_ID
+        {
+            return false;
+        }
+
+        let Ok(frame) = serve_and_expect(
+            device,
+            MessageType::CAPS_QUERY,
+            MessageType::CAPS_REPORT,
+            2,
+            &[],
+            &mut raw_response,
+        ) else {
+            return false;
+        };
+        let Ok((caps, mut caps_decoder)) = decode_caps_report_header(frame.payload) else {
+            return false;
+        };
+        for _ in 0..caps.capability_count {
+            if caps_decoder.read_capability_descriptor().is_err() {
+                return false;
+            }
+        }
+        if caps_decoder.finish().is_err()
+            || caps.board_id != "arduino-uno-r4-wifi"
+            || caps.runtime_id != UNO_R4_VM_RUNTIME_ID
+        {
+            return false;
+        }
+
+        let Ok(payload_len) = encode_program_begin(
+            &ProgramBegin {
+                program_id: PROGRAM_ID,
+                format: ProgramFormat::BvmModule,
+                total_len: EMBEDDED_BLINK_MODULE.len() as u32,
+                program_crc32: crc32_ieee(&EMBEDDED_BLINK_MODULE),
+            },
+            &mut payload,
+        ) else {
+            return false;
+        };
+        let Ok(frame) = serve_and_expect(
+            device,
+            MessageType::PROGRAM_BEGIN,
+            MessageType::PROGRAM_BEGIN,
+            3,
+            &payload[..payload_len],
+            &mut raw_response,
+        ) else {
+            return false;
+        };
+        let Ok(begin) = decode_program_begin(frame.payload) else {
+            return false;
+        };
+        if begin.program_id != PROGRAM_ID {
+            return false;
+        }
+
+        let Ok(payload_len) = encode_program_chunk(
+            &ProgramChunk {
+                program_id: PROGRAM_ID,
+                offset: 0,
+                bytes: &EMBEDDED_BLINK_MODULE,
+            },
+            &mut payload,
+        ) else {
+            return false;
+        };
+        let Ok(frame) = serve_and_expect(
+            device,
+            MessageType::PROGRAM_CHUNK,
+            MessageType::PROGRAM_CHUNK,
+            4,
+            &payload[..payload_len],
+            &mut raw_response,
+        ) else {
+            return false;
+        };
+        let Ok(chunk) = decode_program_chunk(frame.payload) else {
+            return false;
+        };
+        if chunk.program_id != PROGRAM_ID
+            || chunk.offset != 0
+            || chunk.bytes.len() != EMBEDDED_BLINK_MODULE.len()
+        {
+            return false;
+        }
+
+        let Ok(payload_len) = encode_program_end(
+            &ProgramEnd {
+                program_id: PROGRAM_ID,
+            },
+            &mut payload,
+        ) else {
+            return false;
+        };
+        let Ok(frame) = serve_and_expect(
+            device,
+            MessageType::PROGRAM_END,
+            MessageType::PROGRAM_END,
+            5,
+            &payload[..payload_len],
+            &mut raw_response,
+        ) else {
+            return false;
+        };
+        let Ok(end) = decode_program_end(frame.payload) else {
+            return false;
+        };
+        if end.program_id != PROGRAM_ID {
+            return false;
+        }
+
+        let Ok(payload_len) = encode_run_request(
+            &RunRequest {
+                program_id: PROGRAM_ID,
+                flags: RUN_FLAG_RESET_VM_BEFORE_RUN | RUN_FLAG_BACKGROUND_RUN,
+                instruction_budget: SMOKE_INSTRUCTION_BUDGET,
+                time_budget_ms: 0,
+            },
+            &mut payload,
+        ) else {
+            return false;
+        };
+        let Ok(frame) = serve_and_expect(
+            device,
+            MessageType::RUN,
+            MessageType::RUN_REPORT,
+            6,
+            &payload[..payload_len],
+            &mut raw_response,
+        ) else {
+            return false;
+        };
+        let Ok((report, decoder)) = decode_run_report_header(frame.payload) else {
+            return false;
+        };
+        decoder.finish().is_ok()
+            && report.program_id == PROGRAM_ID
+            && report.status == RunStatus::Running
+            && report.instructions_executed > 0
+            && report.open_handles == 1
+    }
+
+    #[cortex_m_rt::entry]
+    fn main() -> ! {
+        let backend = UnoR4WifiLedBackend::new();
+        let board = UnoR4Board::wifi(backend);
+        let mut device = board.into_device(BOARD_NONCE);
+        let ok = run_probe(&mut device);
+        let backend = device.hal_mut().backend_mut();
+
+        loop {
+            if ok {
+                backend.blink_pattern(4, 55, 75);
+                backend.pause_ms(800);
+            } else {
+                backend.set_led(Level::High);
+                backend.pause_ms(900);
+                backend.set_led(Level::Low);
+                backend.pause_ms(900);
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -4,6 +4,8 @@ use board_vm_ir::{parse_module, validate, ModuleError, ValidateError};
 use board_vm_runtime::{BoardHal, RunReport, Runtime, RuntimeError};
 
 #[cfg(target_arch = "arm")]
+pub mod scripted_probe_stream;
+#[cfg(target_arch = "arm")]
 pub mod uno_r4_wifi_backend;
 #[cfg(target_arch = "arm")]
 pub mod uno_r4_wifi_led;

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/scripted_probe_stream.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/scripted_probe_stream.rs
@@ -1,0 +1,64 @@
+use board_vm_device::DeviceByteStream;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeStreamError {
+    BufferTooSmall,
+    EndOfInput,
+}
+
+pub struct ProbeStream<const READ_BYTES: usize, const WRITE_BYTES: usize> {
+    read: [u8; READ_BYTES],
+    read_len: usize,
+    read_offset: usize,
+    written: [u8; WRITE_BYTES],
+    written_len: usize,
+}
+
+impl<const READ_BYTES: usize, const WRITE_BYTES: usize> ProbeStream<READ_BYTES, WRITE_BYTES> {
+    pub fn with_read(bytes: &[u8]) -> Result<Self, ProbeStreamError> {
+        if bytes.len() > READ_BYTES {
+            return Err(ProbeStreamError::BufferTooSmall);
+        }
+        let mut read = [0; READ_BYTES];
+        read[..bytes.len()].copy_from_slice(bytes);
+        Ok(Self {
+            read,
+            read_len: bytes.len(),
+            read_offset: 0,
+            written: [0; WRITE_BYTES],
+            written_len: 0,
+        })
+    }
+
+    pub fn written(&self) -> &[u8] {
+        &self.written[..self.written_len]
+    }
+}
+
+impl<const READ_BYTES: usize, const WRITE_BYTES: usize> DeviceByteStream
+    for ProbeStream<READ_BYTES, WRITE_BYTES>
+{
+    type Error = ProbeStreamError;
+
+    fn read_byte(&mut self) -> Result<u8, Self::Error> {
+        if self.read_offset >= self.read_len {
+            return Err(ProbeStreamError::EndOfInput);
+        }
+        let byte = self.read[self.read_offset];
+        self.read_offset += 1;
+        Ok(byte)
+    }
+
+    fn write_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        let end = self
+            .written_len
+            .checked_add(bytes.len())
+            .ok_or(ProbeStreamError::BufferTooSmall)?;
+        if end > WRITE_BYTES {
+            return Err(ProbeStreamError::BufferTooSmall);
+        }
+        self.written[self.written_len..end].copy_from_slice(bytes);
+        self.written_len = end;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- extract the in-memory firmware probe stream so multiple Uno R4 probes can reuse the same `DeviceByteStream` adapter
- add `uno-r4-wifi-stream-session-probe`, which serves HELLO, CAPS_QUERY, PROGRAM_BEGIN, PROGRAM_CHUNK, PROGRAM_END, and RUN through `DeviceStreamEndpoint`
- verify each protocol response and run the uploaded blink module, with a repeating four-fast-blink success pattern

## Hardware validation

- built and uploaded `uno-r4-wifi-stream-session-probe.bin` to the Arduino Uno R4 WiFi on `/dev/cu.usbmodem9070692469E42`
- upload completed successfully; visual success signal is expected to be a repeating four-fast-blink pattern

## Validation

- cargo test -p board-vm-uno-r4-firmware
- RUSTC="$(rustup which rustc)" rustup run stable cargo build --manifest-path /tmp/coding-adventures-board-vm-uno-r4-stream-probe-pr/code/packages/rust/Cargo.toml --target thumbv7em-none-eabihf --bin uno-r4-wifi-stream-session-probe --release

Stacked on #2190 because it reuses the stream handshake probe refactor.
