### PR TITLE
[codex] Add Uno R4 UART server firmware

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/BUILD
+++ b/code/packages/rust/board-vm-uno-r4-firmware/BUILD
@@ -1,1 +1,3 @@
 cargo test -p board-vm-uno-r4-firmware -- --nocapture
+rustup target add thumbv7em-none-eabihf
+RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-uart-server

--- a/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
+++ b/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
@@ -13,6 +13,8 @@ board-vm-uno-r4 = { path = "../board-vm-uno-r4" }
 
 [target.'cfg(target_arch = "arm")'.dependencies]
 arduino-uno-r4-hal = "0.1.0"
+board-vm-uart = { path = "../board-vm-uart" }
+board-vm-uno-r4-uart = { path = "../board-vm-uno-r4-uart" }
 cortex-m-rt = "0.7"
 embedded-hal = "1.0"
 panic-halt = "0.2"
@@ -35,3 +37,7 @@ path = "src/bin/uno_r4_wifi_stream_handshake_probe.rs"
 [[bin]]
 name = "uno-r4-wifi-stream-session-probe"
 path = "src/bin/uno_r4_wifi_stream_session_probe.rs"
+
+[[bin]]
+name = "uno-r4-wifi-uart-server"
+path = "src/bin/uno_r4_wifi_uart_server.rs"

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -2,11 +2,11 @@
 
 Uno R4 firmware smoke test for the Board VM runtime.
 
-This crate embeds the BVM1 blink module and provides a tiny firmware binary that
-executes the bytecode against the Uno R4 WiFi D13 LED HAL. It is not the
-interactive serial protocol firmware yet; it is the first real-board check that
-the Rust target, linker script, Uno R4 GPIO mapping, and Board VM runtime can
-produce a flashable image.
+This crate embeds the BVM1 blink module and provides firmware binaries for Uno
+R4 WiFi bring-up. The early probes check the Rust target, linker script, GPIO
+mapping, runtime, and in-memory stream path. `uno-r4-wifi-uart-server` is the
+first interactive firmware: it serves Board VM wire frames over the Uno R4 WiFi
+SCI9 UART route exposed by `board-vm-uno-r4-uart`.
 
 Host-side validation:
 
@@ -86,6 +86,29 @@ repeating four-fast-blink pattern means the full scripted upload/run path passed
 
 ```sh
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-wifi-stream-session-probe --release
+```
+
+`uno-r4-wifi-uart-server` keeps a `DeviceStreamEndpoint` attached to
+`UartByteStream<UnoR4WifiSerialUart>` and serves host requests indefinitely. It
+uses the Uno R4 WiFi Arduino `Serial1` route on D22/D23 over SCI9. The built-in
+USB-C serial device is Arduino `SerialUSB`, so it will not answer this UART
+server until a separate USB CDC transport backend exists. Use a level-compatible
+USB-to-UART adapter on D22/D23 for this firmware.
+
+Build the UART server firmware:
+
+```sh
+RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-wifi-uart-server --release
+```
+
+After flashing the generated `.bin`, run the host smoke test against the adapter
+serial port:
+
+```sh
+cargo run -p board-vm-cli --bin board-vm -- smoke \
+  --port /dev/cu.usbmodem... \
+  --baud 115200 \
+  --timeout-ms 1000
 ```
 
 ```sh

--- a/code/packages/rust/board-vm-uno-r4-firmware/build.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/build.rs
@@ -6,11 +6,12 @@ const UNO_R4_SKETCH_FLASH_ORIGIN: u32 = 0x0000_4000;
 const UNO_R4_CODE_FLASH_BYTES: u32 = 0x0004_0000;
 const UNO_R4_RAM_ORIGIN: u32 = 0x2000_0000;
 const UNO_R4_RAM_BYTES: u32 = 0x8000;
-const FIRMWARE_BINS: [&str; 4] = [
+const FIRMWARE_BINS: [&str; 5] = [
     "uno-r4-vm-blink-smoke",
     "uno-r4-wifi-raw-blink-probe",
     "uno-r4-wifi-stream-handshake-probe",
     "uno-r4-wifi-stream-session-probe",
+    "uno-r4-wifi-uart-server",
 ];
 
 fn main() {

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_uart_server.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_uart_server.rs
@@ -1,0 +1,52 @@
+#![cfg_attr(target_arch = "arm", no_std)]
+#![cfg_attr(target_arch = "arm", no_main)]
+
+#[cfg(target_arch = "arm")]
+mod firmware {
+    use board_vm_device::DeviceStreamEndpoint;
+    use board_vm_runtime::Level;
+    use board_vm_uart::UartByteStream;
+    use board_vm_uno_r4::UnoR4Board;
+    use board_vm_uno_r4_firmware::uno_r4_wifi_backend::UnoR4WifiLedBackend;
+    use board_vm_uno_r4_uart::UnoR4WifiSerialUart;
+    use panic_halt as _;
+
+    const BOARD_NONCE: u32 = 0xB04D_1004;
+
+    #[cortex_m_rt::entry]
+    fn main() -> ! {
+        let mut backend = UnoR4WifiLedBackend::new();
+        let uart = match UnoR4WifiSerialUart::new() {
+            Ok(uart) => uart,
+            Err(_) => fault_loop(backend),
+        };
+
+        backend.blink_pattern(2, 45, 65);
+        let board = UnoR4Board::wifi(backend);
+        let mut device = board.into_device(BOARD_NONCE);
+        // This serves the Uno R4 WiFi Arduino Serial1 route on D22/D23. The
+        // board's built-in USB port is Arduino SerialUSB and needs a separate
+        // USB CDC transport backend.
+        let stream = UartByteStream::new(uart);
+        let mut endpoint = DeviceStreamEndpoint::<_, 1024, 512, 256>::new(stream);
+
+        loop {
+            if endpoint.serve_one(&mut device).is_err() {
+                let backend = device.hal_mut().backend_mut();
+                backend.blink_pattern(1, 160, 120);
+            }
+        }
+    }
+
+    fn fault_loop(mut backend: UnoR4WifiLedBackend) -> ! {
+        loop {
+            backend.set_led(Level::High);
+            backend.pause_ms(900);
+            backend.set_led(Level::Low);
+            backend.pause_ms(900);
+        }
+    }
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}


### PR DESCRIPTION
## Summary

- add an Uno R4 WiFi UART server firmware binary that serves Board VM wire frames through DeviceStreamEndpoint over UartByteStream<UnoR4WifiSerialUart>
- wire the firmware crate to the reusable UART crates for ARM builds and linker injection
- document the D22/D23 Serial1 boundary and the remaining USB CDC transport gap

## Validation

- cargo test -p board-vm-uno-r4-firmware -- --nocapture
- cargo test -p board-vm-uart -p board-vm-uno-r4-uart -p board-vm-device -p board-vm-uno-r4-firmware -- --nocapture
- RUSTC="/Users/adhithya/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-uart-server
- RUSTC="/Users/adhithya/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-uart-server --release
- flashed uno-r4-wifi-uart-server.bin to /dev/cu.usbmodem9070692469E42 with arduino-cli

## Hardware note

The built-in Uno R4 WiFi USB serial port is Arduino SerialUSB. This bundle serves the SCI9 UART exposed as Serial1 on D22/D23, so the host CLI smoke over /dev/cu.usbmodem currently times out until we add a USB CDC transport backend or test through a USB-to-UART adapter.
