### PR TITLE
[codex] Add reusable Board VM USB CDC stream

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "board-vm-stream",
     "board-vm-serial",
     "board-vm-uart",
+    "board-vm-usb-cdc",
     "board-vm-fixed-stream",
     "board-vm-device",
     "board-vm-loopback",

--- a/code/packages/rust/board-vm-usb-cdc/BUILD
+++ b/code/packages/rust/board-vm-usb-cdc/BUILD
@@ -1,0 +1,1 @@
+cargo test -p board-vm-usb-cdc -- --nocapture

--- a/code/packages/rust/board-vm-usb-cdc/Cargo.toml
+++ b/code/packages/rust/board-vm-usb-cdc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "board-vm-usb-cdc"
+version = "0.1.0"
+edition = "2021"
+description = "Reusable USB CDC byte stream adapter for Board VM device transports"
+
+[dependencies]
+board-vm-device = { path = "../board-vm-device" }

--- a/code/packages/rust/board-vm-usb-cdc/README.md
+++ b/code/packages/rust/board-vm-usb-cdc/README.md
@@ -1,0 +1,21 @@
+# board-vm-usb-cdc
+
+Reusable no-heap USB CDC byte stream adapter for Board VM device firmware.
+
+This crate does not own a USB device controller or descriptors. Board-specific
+packages provide that lower layer and implement `BlockingUsbCdc`; this crate
+adapts that CDC byte pipe into `board-vm-device`'s `DeviceByteStream` so the
+same `DeviceStreamEndpoint` can serve Board VM protocol frames over USB CDC,
+UART, loopback streams, or simulator transports.
+
+The first expected hardware consumer is the Arduino Uno R4 WiFi built-in USB
+serial route. Its Arduino core exposes the USB-C port as `SerialUSB`, while
+the earlier UART server uses `Serial1` on D22/D23. Keeping CDC as a separate
+package lets the Uno R4 USB backend share framing/session logic with other
+boards that expose a CDC ACM serial device.
+
+Validation:
+
+```sh
+cargo test -p board-vm-usb-cdc -- --nocapture
+```

--- a/code/packages/rust/board-vm-usb-cdc/required_capabilities.json
+++ b/code/packages/rust/board-vm-usb-cdc/required_capabilities.json
@@ -1,0 +1,5 @@
+{
+  "package": "board-vm-usb-cdc",
+  "capabilities": [],
+  "justification": "Pure no_std USB CDC byte-stream adapter. It defines transport traits and fixed-size helpers only; board-specific packages own device controller, USB stack, host serial devices, clocks, and hardware access."
+}

--- a/code/packages/rust/board-vm-usb-cdc/src/lib.rs
+++ b/code/packages/rust/board-vm-usb-cdc/src/lib.rs
@@ -1,0 +1,295 @@
+#![no_std]
+
+use board_vm_device::DeviceByteStream;
+
+pub const USB_CDC_FULL_SPEED_MAX_PACKET_BYTES: usize = 64;
+pub const DEFAULT_USB_CDC_BAUD_RATE: u32 = 115_200;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsbCdcStopBits {
+    One,
+    OnePointFive,
+    Two,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsbCdcParity {
+    None,
+    Odd,
+    Even,
+    Mark,
+    Space,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UsbCdcLineCoding {
+    pub baud_rate: u32,
+    pub stop_bits: UsbCdcStopBits,
+    pub parity: UsbCdcParity,
+    pub data_bits: u8,
+}
+
+impl UsbCdcLineCoding {
+    pub const fn new(baud_rate: u32) -> Self {
+        Self {
+            baud_rate,
+            stop_bits: UsbCdcStopBits::One,
+            parity: UsbCdcParity::None,
+            data_bits: 8,
+        }
+    }
+
+    pub const fn stop_bits(mut self, stop_bits: UsbCdcStopBits) -> Self {
+        self.stop_bits = stop_bits;
+        self
+    }
+
+    pub const fn parity(mut self, parity: UsbCdcParity) -> Self {
+        self.parity = parity;
+        self
+    }
+
+    pub const fn data_bits(mut self, data_bits: u8) -> Self {
+        self.data_bits = data_bits;
+        self
+    }
+
+    pub const fn is_8n1(self) -> bool {
+        matches!(self.stop_bits, UsbCdcStopBits::One)
+            && matches!(self.parity, UsbCdcParity::None)
+            && self.data_bits == 8
+    }
+}
+
+impl Default for UsbCdcLineCoding {
+    fn default() -> Self {
+        Self::new(DEFAULT_USB_CDC_BAUD_RATE)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UsbCdcControlLineState {
+    pub dtr: bool,
+    pub rts: bool,
+}
+
+impl UsbCdcControlLineState {
+    pub const fn new(dtr: bool, rts: bool) -> Self {
+        Self { dtr, rts }
+    }
+
+    pub const fn disconnected() -> Self {
+        Self {
+            dtr: false,
+            rts: false,
+        }
+    }
+
+    pub const fn connected(self) -> bool {
+        self.dtr
+    }
+}
+
+impl Default for UsbCdcControlLineState {
+    fn default() -> Self {
+        Self::disconnected()
+    }
+}
+
+pub trait BlockingUsbCdc {
+    type Error;
+
+    fn read_byte(&mut self) -> Result<u8, Self::Error>;
+
+    fn write_packet(&mut self, bytes: &[u8]) -> Result<(), Self::Error>;
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn line_coding(&self) -> UsbCdcLineCoding {
+        UsbCdcLineCoding::default()
+    }
+
+    fn control_line_state(&self) -> UsbCdcControlLineState {
+        UsbCdcControlLineState::default()
+    }
+
+    fn connected(&self) -> bool {
+        self.control_line_state().connected()
+    }
+
+    fn write_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        for chunk in bytes.chunks(USB_CDC_FULL_SPEED_MAX_PACKET_BYTES) {
+            self.write_packet(chunk)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UsbCdcByteStream<C> {
+    cdc: C,
+}
+
+impl<C> UsbCdcByteStream<C> {
+    pub const fn new(cdc: C) -> Self {
+        Self { cdc }
+    }
+
+    pub fn into_inner(self) -> C {
+        self.cdc
+    }
+
+    pub fn cdc(&self) -> &C {
+        &self.cdc
+    }
+
+    pub fn cdc_mut(&mut self) -> &mut C {
+        &mut self.cdc
+    }
+}
+
+impl<C> DeviceByteStream for UsbCdcByteStream<C>
+where
+    C: BlockingUsbCdc,
+{
+    type Error = C::Error;
+
+    fn read_byte(&mut self) -> Result<u8, Self::Error> {
+        self.cdc.read_byte()
+    }
+
+    fn write_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.cdc.write_all(bytes)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.cdc.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum FakeError {
+        EndOfInput,
+        OutputFull,
+    }
+
+    struct FakeCdc {
+        read: [u8; 4],
+        read_len: usize,
+        read_offset: usize,
+        written: [u8; 96],
+        written_len: usize,
+        packets: usize,
+        flushes: usize,
+        state: UsbCdcControlLineState,
+        line_coding: UsbCdcLineCoding,
+    }
+
+    impl FakeCdc {
+        fn with_read(bytes: &[u8]) -> Self {
+            let mut read = [0; 4];
+            read[..bytes.len()].copy_from_slice(bytes);
+            Self {
+                read,
+                read_len: bytes.len(),
+                read_offset: 0,
+                written: [0; 96],
+                written_len: 0,
+                packets: 0,
+                flushes: 0,
+                state: UsbCdcControlLineState::new(true, false),
+                line_coding: UsbCdcLineCoding::default(),
+            }
+        }
+    }
+
+    impl BlockingUsbCdc for FakeCdc {
+        type Error = FakeError;
+
+        fn read_byte(&mut self) -> Result<u8, Self::Error> {
+            if self.read_offset >= self.read_len {
+                return Err(FakeError::EndOfInput);
+            }
+            let byte = self.read[self.read_offset];
+            self.read_offset += 1;
+            Ok(byte)
+        }
+
+        fn write_packet(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+            self.packets += 1;
+            let end = self
+                .written_len
+                .checked_add(bytes.len())
+                .ok_or(FakeError::OutputFull)?;
+            if end > self.written.len() {
+                return Err(FakeError::OutputFull);
+            }
+            self.written[self.written_len..end].copy_from_slice(bytes);
+            self.written_len = end;
+            Ok(())
+        }
+
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            self.flushes += 1;
+            Ok(())
+        }
+
+        fn line_coding(&self) -> UsbCdcLineCoding {
+            self.line_coding
+        }
+
+        fn control_line_state(&self) -> UsbCdcControlLineState {
+            self.state
+        }
+    }
+
+    #[test]
+    fn default_line_coding_matches_serial_smoke_defaults() {
+        let line_coding = UsbCdcLineCoding::default();
+
+        assert_eq!(line_coding, UsbCdcLineCoding::new(115_200));
+        assert!(line_coding.is_8n1());
+        assert!(!UsbCdcLineCoding::new(115_200).data_bits(7).is_8n1());
+        assert!(!UsbCdcLineCoding::new(115_200)
+            .parity(UsbCdcParity::Even)
+            .is_8n1());
+        assert!(!UsbCdcLineCoding::new(115_200)
+            .stop_bits(UsbCdcStopBits::Two)
+            .is_8n1());
+    }
+
+    #[test]
+    fn usb_cdc_byte_stream_delegates_to_cdc_backend() {
+        let mut stream = UsbCdcByteStream::new(FakeCdc::with_read(&[0x11, 0x22]));
+
+        assert_eq!(stream.read_byte().unwrap(), 0x11);
+        stream.write_all(&[0xA0, 0xB1]).unwrap();
+        stream.flush().unwrap();
+
+        let cdc = stream.into_inner();
+        assert_eq!(&cdc.written[..cdc.written_len], &[0xA0, 0xB1]);
+        assert_eq!(cdc.packets, 1);
+        assert_eq!(cdc.flushes, 1);
+        assert!(cdc.connected());
+        assert_eq!(cdc.line_coding(), UsbCdcLineCoding::default());
+    }
+
+    #[test]
+    fn write_all_chunks_full_speed_packets() {
+        let mut cdc = FakeCdc::with_read(&[]);
+        let bytes = [0x5A; 70];
+
+        cdc.write_all(&bytes).unwrap();
+
+        assert_eq!(cdc.written_len, 70);
+        assert_eq!(cdc.packets, 2);
+        assert_eq!(cdc.written[0], 0x5A);
+        assert_eq!(cdc.written[69], 0x5A);
+    }
+}


### PR DESCRIPTION
## Summary

- add a no_std board-vm-usb-cdc crate for reusable USB CDC device byte streams
- define CDC line coding and control-line state helpers for board-specific USB backends
- adapt BlockingUsbCdc implementations into board-vm-device DeviceByteStream so DeviceStreamEndpoint can serve protocol frames over CDC

## Validation

- cargo test -p board-vm-usb-cdc -- --nocapture

## Hardware path

This is the reusable CDC layer needed for the Uno R4 WiFi built-in USB transport. The next bundle can plug the Uno R4 SerialUSB/TinyUSB backend into BlockingUsbCdc and use the existing host smoke command against /dev/cu.usbmodem...
