### PR TITLE
[codex] Add Uno R4 SerialUSB server entrypoint

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/BUILD
+++ b/code/packages/rust/board-vm-uno-r4-firmware/BUILD
@@ -1,3 +1,4 @@
 cargo test -p board-vm-uno-r4-firmware -- --nocapture
 rustup target add thumbv7em-none-eabihf
+RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-uart-server

--- a/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
+++ b/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
@@ -10,14 +10,19 @@ board-vm-ir = { path = "../board-vm-ir" }
 board-vm-protocol = { path = "../board-vm-protocol" }
 board-vm-runtime = { path = "../board-vm-runtime" }
 board-vm-uno-r4 = { path = "../board-vm-uno-r4" }
+board-vm-usb-cdc = { path = "../board-vm-usb-cdc" }
 
 [target.'cfg(target_arch = "arm")'.dependencies]
 arduino-uno-r4-hal = "0.1.0"
 board-vm-uart = { path = "../board-vm-uart" }
+board-vm-uno-r4-usb-cdc = { path = "../board-vm-uno-r4-usb-cdc" }
 board-vm-uno-r4-uart = { path = "../board-vm-uno-r4-uart" }
 cortex-m-rt = "0.7"
 embedded-hal = "1.0"
 panic-halt = "0.2"
+
+[dev-dependencies]
+board-vm-host = { path = "../board-vm-host" }
 
 [lib]
 path = "src/lib.rs"
@@ -41,3 +46,7 @@ path = "src/bin/uno_r4_wifi_stream_session_probe.rs"
 [[bin]]
 name = "uno-r4-wifi-uart-server"
 path = "src/bin/uno_r4_wifi_uart_server.rs"
+
+[[bin]]
+name = "uno-r4-wifi-serialusb-server"
+path = "src/bin/uno_r4_wifi_serialusb_server.rs"

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -101,6 +101,25 @@ Build the UART server firmware:
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf --bin uno-r4-wifi-uart-server --release
 ```
 
+`uno-r4-wifi-serialusb-server` is the matching entrypoint for the built-in
+USB-C `SerialUSB` route. It attaches `DeviceStreamEndpoint` to
+`UsbCdcByteStream<UnoR4WifiSerialUsb>` and uses the same Uno R4 WiFi board
+runtime as the UART server. The reusable server helper is host-tested with a
+fake CDC transport so the Board VM wire-frame path is validated before the
+Arduino/TinyUSB link layer is wired in.
+
+The Rust entrypoint expects the Arduino Renesas/TinyUSB startup and
+`tud_cdc_n_*` symbols to be provided by the firmware link bundle. Build the
+firmware library and host-tested server path now:
+
+```sh
+cargo test -p board-vm-uno-r4-firmware -- --nocapture
+RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib
+```
+
+The final flashable `uno-r4-wifi-serialusb-server` binary needs the follow-up
+Arduino/TinyUSB link package before it can be uploaded to a real board.
+
 After flashing the generated `.bin`, run the host smoke test against the adapter
 serial port:
 

--- a/code/packages/rust/board-vm-uno-r4-firmware/build.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/build.rs
@@ -6,12 +6,13 @@ const UNO_R4_SKETCH_FLASH_ORIGIN: u32 = 0x0000_4000;
 const UNO_R4_CODE_FLASH_BYTES: u32 = 0x0004_0000;
 const UNO_R4_RAM_ORIGIN: u32 = 0x2000_0000;
 const UNO_R4_RAM_BYTES: u32 = 0x8000;
-const FIRMWARE_BINS: [&str; 5] = [
+const FIRMWARE_BINS: [&str; 6] = [
     "uno-r4-vm-blink-smoke",
     "uno-r4-wifi-raw-blink-probe",
     "uno-r4-wifi-stream-handshake-probe",
     "uno-r4-wifi-stream-session-probe",
     "uno-r4-wifi-uart-server",
+    "uno-r4-wifi-serialusb-server",
 ];
 
 fn main() {

--- a/code/packages/rust/board-vm-uno-r4-firmware/required_capabilities.json
+++ b/code/packages/rust/board-vm-uno-r4-firmware/required_capabilities.json
@@ -2,6 +2,19 @@
   "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
   "version": 1,
   "package": "rust/board-vm-uno-r4-firmware",
-  "capabilities": [],
-  "justification": "Firmware code is no_std and accesses board hardware only through target HAL traits at runtime; it does not use host OS resources."
+  "capabilities": [
+    {
+      "category": "hardware",
+      "action": "read",
+      "target": "Arduino Uno R4 WiFi UART and USB CDC device interfaces",
+      "justification": "Interactive Board VM firmware receives host protocol frames over board-local serial transports."
+    },
+    {
+      "category": "hardware",
+      "action": "write",
+      "target": "Arduino Uno R4 WiFi LED, UART, and USB CDC device interfaces",
+      "justification": "Interactive Board VM firmware drives the onboard LED through the runtime and writes protocol responses over board-local serial transports."
+    }
+  ],
+  "justification": "Firmware code is no_std and accesses board hardware only through target HAL traits or board-specific transport crates at runtime; it does not use host OS resources."
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_server.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_server.rs
@@ -1,0 +1,46 @@
+#![cfg_attr(target_arch = "arm", no_std)]
+#![cfg_attr(target_arch = "arm", no_main)]
+
+#[cfg(target_arch = "arm")]
+mod firmware {
+    use board_vm_runtime::Level;
+    use board_vm_uno_r4::UnoR4Board;
+    use board_vm_uno_r4_firmware::serial_usb_server::serial_usb_endpoint;
+    use board_vm_uno_r4_firmware::uno_r4_wifi_backend::UnoR4WifiLedBackend;
+    use board_vm_uno_r4_usb_cdc::UnoR4WifiSerialUsb;
+    use panic_halt as _;
+
+    const BOARD_NONCE: u32 = 0xB04D_1005;
+
+    #[cortex_m_rt::entry]
+    fn main() -> ! {
+        let mut backend = UnoR4WifiLedBackend::new();
+        let mut usb = UnoR4WifiSerialUsb::serial_usb();
+        usb.begin();
+
+        backend.blink_pattern(3, 45, 65);
+        let board = UnoR4Board::wifi(backend);
+        let mut device = board.into_device(BOARD_NONCE);
+        let mut endpoint = serial_usb_endpoint(usb);
+
+        loop {
+            if endpoint.serve_one(&mut device).is_err() {
+                let backend = device.hal_mut().backend_mut();
+                backend.blink_pattern(1, 160, 120);
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn fault_loop(mut backend: UnoR4WifiLedBackend) -> ! {
+        loop {
+            backend.set_led(Level::High);
+            backend.pause_ms(900);
+            backend.set_led(Level::Low);
+            backend.pause_ms(900);
+        }
+    }
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -5,6 +5,7 @@ use board_vm_runtime::{BoardHal, RunReport, Runtime, RuntimeError};
 
 #[cfg(target_arch = "arm")]
 pub mod scripted_probe_stream;
+pub mod serial_usb_server;
 #[cfg(target_arch = "arm")]
 pub mod uno_r4_wifi_backend;
 #[cfg(target_arch = "arm")]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_server.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_server.rs
@@ -1,0 +1,147 @@
+use board_vm_device::{BoardVmDevice, DeviceStreamEndpoint, DeviceStreamError};
+use board_vm_runtime::BoardHal;
+use board_vm_usb_cdc::{BlockingUsbCdc, UsbCdcByteStream};
+
+pub const SERIAL_USB_WIRE_BYTES: usize = 1024;
+pub const SERIAL_USB_RAW_BYTES: usize = 512;
+pub const SERIAL_USB_PAYLOAD_BYTES: usize = 256;
+
+pub type SerialUsbEndpoint<C> = DeviceStreamEndpoint<
+    UsbCdcByteStream<C>,
+    SERIAL_USB_WIRE_BYTES,
+    SERIAL_USB_RAW_BYTES,
+    SERIAL_USB_PAYLOAD_BYTES,
+>;
+
+pub fn serial_usb_endpoint<C>(cdc: C) -> SerialUsbEndpoint<C>
+where
+    C: BlockingUsbCdc,
+{
+    DeviceStreamEndpoint::new(UsbCdcByteStream::new(cdc))
+}
+
+pub fn serve_serial_usb_once<
+    'a,
+    C,
+    H,
+    const MAX_PROGRAM_BYTES: usize,
+    const MAX_STACK: usize,
+    const MAX_HANDLES: usize,
+>(
+    endpoint: &mut SerialUsbEndpoint<C>,
+    device: &mut BoardVmDevice<'a, H, MAX_PROGRAM_BYTES, MAX_STACK, MAX_HANDLES>,
+) -> Result<usize, DeviceStreamError<C::Error>>
+where
+    C: BlockingUsbCdc,
+    H: BoardHal,
+{
+    endpoint.serve_one(device)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use board_vm_host::HostSession;
+    use board_vm_protocol::{decode_frame, decode_hello_ack, encode_wire_frame, MessageType};
+    use board_vm_runtime::{GpioMode, HalError, Level};
+    use board_vm_uno_r4::{minima_device, UnoR4Backend};
+    use std::vec::Vec;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum FakeCdcError {
+        EndOfInput,
+    }
+
+    struct FakeCdc {
+        read: Vec<u8>,
+        read_offset: usize,
+        written: Vec<u8>,
+    }
+
+    impl FakeCdc {
+        fn new(read: Vec<u8>) -> Self {
+            Self {
+                read,
+                read_offset: 0,
+                written: Vec::new(),
+            }
+        }
+    }
+
+    impl BlockingUsbCdc for FakeCdc {
+        type Error = FakeCdcError;
+
+        fn read_byte(&mut self) -> Result<u8, Self::Error> {
+            if self.read_offset >= self.read.len() {
+                return Err(FakeCdcError::EndOfInput);
+            }
+            let byte = self.read[self.read_offset];
+            self.read_offset += 1;
+            Ok(byte)
+        }
+
+        fn write_packet(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+            self.written.extend_from_slice(bytes);
+            Ok(())
+        }
+    }
+
+    struct FakeBackend;
+
+    impl UnoR4Backend for FakeBackend {
+        fn configure_gpio(&mut self, _pin: u8, _mode: GpioMode) -> Result<(), HalError> {
+            Ok(())
+        }
+
+        fn write_gpio(&mut self, _pin: u8, _level: Level) -> Result<(), HalError> {
+            Ok(())
+        }
+
+        fn read_gpio(&mut self, _pin: u8) -> Result<Level, HalError> {
+            Ok(Level::Low)
+        }
+
+        fn sleep_ms(&mut self, _duration_ms: u16) -> Result<(), HalError> {
+            Ok(())
+        }
+
+        fn now_ms(&self) -> u32 {
+            0
+        }
+    }
+
+    #[test]
+    fn serial_usb_endpoint_serves_a_board_vm_hello_frame() {
+        let mut session = HostSession::new();
+        let mut host_payload = [0u8; 128];
+        let mut raw_request = [0u8; 256];
+        let mut wire_request = [0u8; 512];
+        let hello = session
+            .hello_frame(
+                "serialusb-host",
+                0xCAFE_BABE,
+                &mut host_payload,
+                &mut raw_request,
+            )
+            .unwrap();
+        let wire_len = encode_wire_frame(&raw_request[..hello.len], &mut wire_request).unwrap();
+
+        let cdc = FakeCdc::new(wire_request[..wire_len].to_vec());
+        let mut endpoint = serial_usb_endpoint(cdc);
+        let mut device = minima_device(FakeBackend, 0xB04D_1005);
+
+        let response_len = serve_serial_usb_once(&mut endpoint, &mut device).unwrap();
+        let cdc = endpoint.into_inner().into_inner();
+        assert_eq!(response_len, cdc.written.len());
+
+        let mut raw_response = [0u8; 512];
+        let raw_len =
+            board_vm_protocol::decode_wire_frame(&cdc.written, &mut raw_response).unwrap();
+        let frame = decode_frame(&raw_response[..raw_len]).unwrap();
+        assert_eq!(frame.message_type, MessageType::HELLO_ACK);
+        let ack = decode_hello_ack(frame.payload).unwrap();
+        assert_eq!(ack.host_nonce, 0xCAFE_BABE);
+        assert_eq!(ack.board_name, "arduino-uno-r4-minima");
+        assert_eq!(ack.runtime_name, "board-vm-uno-r4");
+    }
+}


### PR DESCRIPTION
## Summary

- add a reusable `serial_usb_server` helper that wires `UsbCdcByteStream` into `DeviceStreamEndpoint`
- add `uno-r4-wifi-serialusb-server`, the Uno R4 WiFi built-in USB-C `SerialUSB` firmware entrypoint
- extend firmware docs, capabilities, and build checks for the SerialUSB path

## Notes

This deliberately stops at the Rust firmware entrypoint and tested stream composition. The final flashable SerialUSB binary still needs the follow-up Arduino Renesas/TinyUSB link bundle to provide startup, descriptors, and `tud_cdc_n_*` symbols.

## Validation

- `cargo test -p board-vm-uno-r4-firmware -- --nocapture`
- `RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib`
- `RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-uart-server`
