### PR TITLE
[codex] Add Uno R4 TinyUSB link manifest

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -108,17 +108,29 @@ runtime as the UART server. The reusable server helper is host-tested with a
 fake CDC transport so the Board VM wire-frame path is validated before the
 Arduino/TinyUSB link layer is wired in.
 
-The Rust entrypoint expects the Arduino Renesas/TinyUSB startup and
-`tud_cdc_n_*` symbols to be provided by the firmware link bundle. Build the
-firmware library and host-tested server path now:
+The Rust entrypoint now starts Arduino Renesas USB through the `__USBStart()`
+C++ ABI symbol exposed by the Arduino core. The `board-vm-uno-r4-usb-cdc`
+backend supplies the serial-install descriptor hook and the Uno R4 WiFi USB-C
+mux hook from Rust, so the final link set does not need Arduino's full
+`SerialUSB.cpp` object or WiFi `variant.cpp` just to expose CDC.
+
+`src/arduino_usb_link.rs` records the Arduino Renesas/TinyUSB link contract for
+the built-in USB path: Arduino core version `1.5.3`, FQBN
+`arduino:renesas_uno:unor4wifi`, required TinyUSB C objects, `USB.cpp`,
+`IRQManager.cpp`, the Uno R4 WiFi `libfsp.a`, include directories, compile
+defines, and the Rust-provided C++ ABI hook symbols. It is data-only for now so
+CI can validate the contract without requiring a local Arduino install.
+
+Build the firmware library and host-tested server path now:
 
 ```sh
 cargo test -p board-vm-uno-r4-firmware -- --nocapture
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib
 ```
 
-The final flashable `uno-r4-wifi-serialusb-server` binary needs the follow-up
-Arduino/TinyUSB link package before it can be uploaded to a real board.
+The final flashable `uno-r4-wifi-serialusb-server` binary still needs the
+follow-up build-script step that compiles the manifest's Arduino/TinyUSB C/C++
+objects and links them into the Rust firmware image.
 
 After flashing the generated `.bin`, run the host smoke test against the adapter
 serial port:

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -1,0 +1,199 @@
+//! Data-only link manifest for the Uno R4 WiFi Arduino/TinyUSB USB device stack.
+//!
+//! The Rust firmware owns the VM, protocol, device state, and CDC byte stream.
+//! Arduino's Renesas core still owns the RA4M1 TinyUSB descriptors, IRQ
+//! plumbing, and FSP USB driver objects needed by `__USBStart`.
+
+pub const ARDUINO_RENESAS_UNO_CORE_VERSION: &str = "1.5.3";
+pub const UNO_R4_WIFI_FQBN: &str = "arduino:renesas_uno:unor4wifi";
+pub const UNO_R4_WIFI_VARIANT: &str = "UNOWIFIR4";
+pub const UNO_R4_WIFI_RUNTIME_USB_VID: u16 = 0x2341;
+pub const UNO_R4_WIFI_RUNTIME_USB_PID: u16 = 0x006D;
+pub const UNO_R4_WIFI_BOOTLOADER_USB_PID: u16 = 0x1002;
+pub const UNO_R4_WIFI_USB_RHPORT: u8 = 0;
+
+pub const ARDUINO_CORE_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARDUINO_CORE";
+pub const ARDUINO_ARM_GCC_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_GCC";
+pub const ARDUINO_ARM_GXX_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_GXX";
+pub const ARDUINO_ARM_AR_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_AR";
+
+pub const ARDUINO_USB_START_SYMBOL: &str = "_Z10__USBStartv";
+pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
+pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
+
+pub const UNO_R4_WIFI_FSP_ARCHIVE: &str = "variants/UNOWIFIR4/libs/libfsp.a";
+pub const UNO_R4_WIFI_FSP_LINKER_SCRIPT: &str = "variants/UNOWIFIR4/fsp.ld";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArduinoSourceLanguage {
+    C,
+    Cxx,
+    StaticArchive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArduinoLinkSource {
+    pub language: ArduinoSourceLanguage,
+    pub path: &'static str,
+}
+
+impl ArduinoLinkSource {
+    pub const fn c(path: &'static str) -> Self {
+        Self {
+            language: ArduinoSourceLanguage::C,
+            path,
+        }
+    }
+
+    pub const fn cxx(path: &'static str) -> Self {
+        Self {
+            language: ArduinoSourceLanguage::Cxx,
+            path,
+        }
+    }
+
+    pub const fn static_archive(path: &'static str) -> Self {
+        Self {
+            language: ArduinoSourceLanguage::StaticArchive,
+            path,
+        }
+    }
+}
+
+pub const ARDUINO_USB_LINK_SOURCES: &[ArduinoLinkSource] = &[
+    ArduinoLinkSource::c("cores/arduino/tinyusb/tusb.c"),
+    ArduinoLinkSource::c("cores/arduino/tinyusb/common/tusb_fifo.c"),
+    ArduinoLinkSource::c("cores/arduino/tinyusb/device/usbd.c"),
+    ArduinoLinkSource::c("cores/arduino/tinyusb/device/usbd_control.c"),
+    ArduinoLinkSource::c("cores/arduino/tinyusb/class/cdc/cdc_device.c"),
+    ArduinoLinkSource::c("cores/arduino/tinyusb/class/hid/hid_device.c"),
+    ArduinoLinkSource::c("cores/arduino/tinyusb/rusb2/dcd_rusb2.c"),
+    ArduinoLinkSource::c("cores/arduino/tinyusb/rusb2/rusb2_common.c"),
+    ArduinoLinkSource::cxx("cores/arduino/IRQManager.cpp"),
+    ArduinoLinkSource::cxx("cores/arduino/usb/USB.cpp"),
+    ArduinoLinkSource::static_archive(UNO_R4_WIFI_FSP_ARCHIVE),
+];
+
+pub const ARDUINO_USB_LINK_INCLUDE_DIRS: &[&str] = &[
+    "cores/arduino",
+    "cores/arduino/api",
+    "cores/arduino/tinyusb",
+    "cores/arduino/tinyusb/common",
+    "cores/arduino/tinyusb/device",
+    "cores/arduino/usb",
+    "variants/UNOWIFIR4",
+    "variants/UNOWIFIR4/includes/ra/fsp/inc",
+    "variants/UNOWIFIR4/includes/ra/fsp/inc/api",
+    "variants/UNOWIFIR4/includes/ra/fsp/inc/instances",
+    "variants/UNOWIFIR4/includes/ra/arm/CMSIS_5/CMSIS/Core/Include",
+    "variants/UNOWIFIR4/includes/ra_gen",
+    "variants/UNOWIFIR4/includes/ra_cfg/fsp_cfg/bsp",
+    "variants/UNOWIFIR4/includes/ra_cfg/fsp_cfg",
+    "variants/UNOWIFIR4/includes/ra/fsp/src/r_usb_basic/src/driver/inc",
+];
+
+pub const ARDUINO_USB_LINK_DEFINES: &[&str] = &[
+    "F_CPU=48000000",
+    "NO_USB",
+    "BACKTRACE_SUPPORT",
+    "ARDUINO_UNOR4_WIFI",
+    "ARDUINO_FSP",
+    "_XOPEN_SOURCE=700",
+    "_RA_CORE=CM4",
+    "_RENESAS_RA_",
+    "CFG_TUSB_MCU=OPT_MCU_RAXXX",
+];
+
+pub const ARDUINO_USB_LINK_CFLAGS: &[&str] = &[
+    "-mcpu=cortex-m4",
+    "-mthumb",
+    "-mfloat-abi=hard",
+    "-mfpu=fpv4-sp-d16",
+    "-ffunction-sections",
+    "-fdata-sections",
+    "-fsigned-char",
+];
+
+pub const ARDUINO_USB_LINK_CXXFLAGS: &[&str] = &[
+    "-mcpu=cortex-m4",
+    "-mthumb",
+    "-mfloat-abi=hard",
+    "-mfpu=fpv4-sp-d16",
+    "-ffunction-sections",
+    "-fdata-sections",
+    "-fsigned-char",
+    "-fno-rtti",
+    "-fno-exceptions",
+];
+
+pub const RUST_PROVIDED_USB_SYMBOLS: &[&str] = &[
+    RUST_USB_INSTALL_SERIAL_SYMBOL,
+    RUST_USB_CONFIGURE_MUX_SYMBOL,
+];
+
+pub const ARDUINO_PROVIDED_USB_SYMBOLS: &[&str] = &[
+    ARDUINO_USB_START_SYMBOL,
+    "tud_task_ext",
+    "tud_cdc_n_connected",
+    "tud_cdc_n_get_line_state",
+    "tud_cdc_n_get_line_coding",
+    "tud_cdc_n_available",
+    "tud_cdc_n_read",
+    "tud_cdc_n_write",
+    "tud_cdc_n_write_flush",
+    "tud_cdc_n_write_available",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contains_source(path: &str) -> bool {
+        ARDUINO_USB_LINK_SOURCES
+            .iter()
+            .any(|source| source.path == path)
+    }
+
+    #[test]
+    fn records_uno_r4_wifi_arduino_usb_identity() {
+        assert_eq!(ARDUINO_RENESAS_UNO_CORE_VERSION, "1.5.3");
+        assert_eq!(UNO_R4_WIFI_FQBN, "arduino:renesas_uno:unor4wifi");
+        assert_eq!(UNO_R4_WIFI_VARIANT, "UNOWIFIR4");
+        assert_eq!(UNO_R4_WIFI_RUNTIME_USB_VID, 0x2341);
+        assert_eq!(UNO_R4_WIFI_RUNTIME_USB_PID, 0x006D);
+        assert_eq!(UNO_R4_WIFI_BOOTLOADER_USB_PID, 0x1002);
+        assert_eq!(UNO_R4_WIFI_USB_RHPORT, 0);
+    }
+
+    #[test]
+    fn link_manifest_includes_usb_start_tinyusb_and_fsp_objects() {
+        assert!(contains_source("cores/arduino/usb/USB.cpp"));
+        assert!(contains_source("cores/arduino/IRQManager.cpp"));
+        assert!(contains_source("cores/arduino/tinyusb/tusb.c"));
+        assert!(contains_source(
+            "cores/arduino/tinyusb/class/cdc/cdc_device.c"
+        ));
+        assert!(contains_source("cores/arduino/tinyusb/rusb2/dcd_rusb2.c"));
+        assert!(contains_source(UNO_R4_WIFI_FSP_ARCHIVE));
+        assert!(!contains_source("cores/arduino/usb/SerialUSB.cpp"));
+    }
+
+    #[test]
+    fn link_manifest_carries_arduino_flags_needed_by_tinyusb() {
+        assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"cores/arduino/tinyusb"));
+        assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"variants/UNOWIFIR4"));
+        assert!(ARDUINO_USB_LINK_DEFINES.contains(&"CFG_TUSB_MCU=OPT_MCU_RAXXX"));
+        assert!(ARDUINO_USB_LINK_DEFINES.contains(&"ARDUINO_UNOR4_WIFI"));
+        assert!(ARDUINO_USB_LINK_CFLAGS.contains(&"-mcpu=cortex-m4"));
+        assert!(ARDUINO_USB_LINK_CXXFLAGS.contains(&"-fno-exceptions"));
+    }
+
+    #[test]
+    fn rust_backend_supplies_the_serial_descriptor_and_mux_hooks() {
+        assert_eq!(ARDUINO_USB_START_SYMBOL, "_Z10__USBStartv");
+        assert!(RUST_PROVIDED_USB_SYMBOLS.contains(&"_Z18__USBInstallSerialv"));
+        assert!(RUST_PROVIDED_USB_SYMBOLS.contains(&"_Z17configure_usb_muxv"));
+        assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"tud_cdc_n_read"));
+        assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"tud_cdc_n_write_flush"));
+    }
+}

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/lib.rs
@@ -3,6 +3,7 @@
 use board_vm_ir::{parse_module, validate, ModuleError, ValidateError};
 use board_vm_runtime::{BoardHal, RunReport, Runtime, RuntimeError};
 
+pub mod arduino_usb_link;
 #[cfg(target_arch = "arm")]
 pub mod scripted_probe_stream;
 pub mod serial_usb_server;

--- a/code/packages/rust/board-vm-uno-r4-usb-cdc/README.md
+++ b/code/packages/rust/board-vm-uno-r4-usb-cdc/README.md
@@ -10,5 +10,15 @@ This crate keeps that board-specific USB path outside the generic
 `board-vm-usb-cdc` transport crate. It adapts a TinyUSB-style CDC interface to
 `BlockingUsbCdc`, while tests use a fake CDC API so the transport semantics stay
 host-testable. The ARM FFI backend targets TinyUSB's `tud_cdc_n_*` symbols and
-`tud_task_ext`; a flashable firmware binary still needs to link the Arduino/FSP
-USB startup and descriptor stack.
+`tud_task_ext`.
+
+`begin()` calls Arduino Renesas `__USBStart()` through the core's C++ ABI symbol,
+then marks the CDC stream as ready. The crate also provides the C++-mangled
+`__USBInstallSerial()` hook so Arduino's descriptor builder includes the CDC
+interface without linking the full `SerialUSB.cpp` object, and it overrides the
+Uno R4 WiFi `configure_usb_mux()` weak hook with direct RA4M1 register writes so
+the USB-C connector is routed to the RA4M1 USB peripheral.
+
+A flashable firmware binary still needs to compile and link the Arduino/FSP
+TinyUSB startup objects listed by `board-vm-uno-r4-firmware`'s Arduino USB link
+manifest.

--- a/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
@@ -13,6 +13,9 @@ pub const UNO_R4_WIFI_USB_PRODUCT: &str = "UNO R4 WiFi";
 pub const UNO_R4_WIFI_SERIAL_USB_NAME: &str = "SerialUSB";
 pub const UNO_R4_WIFI_USB_CDC_INTERFACE: u8 = 0;
 pub const UNO_R4_WIFI_USB_MAX_PACKET_BYTES: usize = USB_CDC_FULL_SPEED_MAX_PACKET_BYTES;
+pub const ARDUINO_RENESAS_USB_START_SYMBOL: &str = "_Z10__USBStartv";
+pub const ARDUINO_RENESAS_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
+pub const UNO_R4_WIFI_CONFIGURE_USB_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnoR4UsbCdcError {
@@ -23,6 +26,7 @@ pub enum UnoR4UsbCdcError {
 }
 
 pub trait TinyUsbCdcApi {
+    fn start(&mut self) {}
     fn poll(&mut self);
     fn connected(&self) -> bool;
     fn available(&self) -> usize;
@@ -58,7 +62,11 @@ impl<A> UnoR4WifiSerialUsbCdc<A> {
         Self { api, started: true }
     }
 
-    pub fn begin(&mut self) {
+    pub fn begin(&mut self)
+    where
+        A: TinyUsbCdcApi,
+    {
+        self.api.start();
         self.started = true;
     }
 
@@ -197,6 +205,12 @@ impl Default for TinyUsbCdc0 {
 
 #[cfg(target_arch = "arm")]
 impl TinyUsbCdcApi for TinyUsbCdc0 {
+    fn start(&mut self) {
+        unsafe {
+            ffi::arduino_renesas_usb_start();
+        }
+    }
+
     fn poll(&mut self) {
         unsafe {
             ffi::tud_task_ext(0, false);
@@ -294,6 +308,80 @@ fn control_line_state_from_tinyusb(line_state: u8) -> UsbCdcControlLineState {
 }
 
 #[cfg(target_arch = "arm")]
+#[unsafe(export_name = "_Z18__USBInstallSerialv")]
+pub extern "C" fn arduino_renesas_usb_install_serial() {}
+
+#[cfg(target_arch = "arm")]
+#[unsafe(export_name = "_Z17configure_usb_muxv")]
+pub extern "C" fn arduino_uno_r4_wifi_configure_usb_mux() {
+    unsafe {
+        uno_r4_wifi_usb_mux::route_usb_c_to_ra4m1();
+    }
+}
+
+#[cfg(target_arch = "arm")]
+mod uno_r4_wifi_usb_mux {
+    use core::ptr::{read_volatile, write_volatile};
+
+    const SYSTEM_PRCR: *mut u16 = 0x4001_E3FE as *mut u16;
+    const SYSTEM_VBTBKR1: *mut u8 = 0x4001_E501 as *mut u8;
+    const PORT4_PCNTR1: *mut u32 = 0x4004_0080 as *mut u32;
+    const PORT4_PORR: *mut u16 = 0x4004_0088 as *mut u16;
+    const PMISC_PWPR: *mut u8 = 0x4004_0D03 as *mut u8;
+    const PFS_P408: *mut u32 = 0x4004_0920 as *mut u32;
+
+    const PRCR_KEY: u16 = 0xA500;
+    const PRCR_PRC1_UNLOCK: u16 = PRCR_KEY | 0x0002;
+    const PRCR_LOCK: u16 = PRCR_KEY;
+    const USB_MUX_BACKUP_MARKER: u8 = 40;
+    const USB_SWITCH_MASK: u16 = 1 << 8;
+    const PWPR_B0WI: u8 = 1 << 7;
+    const PWPR_PFSWE: u8 = 1 << 6;
+    const PFS_PDR_OUTPUT: u32 = 1 << 2;
+
+    pub unsafe fn route_usb_c_to_ra4m1() {
+        unlock_system_registers();
+        write_volatile(SYSTEM_VBTBKR1, USB_MUX_BACKUP_MARKER);
+        write_volatile(SYSTEM_VBTBKR1.add(1), 0);
+        write_volatile(SYSTEM_VBTBKR1.add(2), 0);
+        write_volatile(SYSTEM_VBTBKR1.add(3), 0);
+        lock_system_registers();
+
+        enable_pfs_writes();
+        write_volatile(PFS_P408, PFS_PDR_OUTPUT);
+        disable_pfs_writes();
+
+        let mut pcntr1 = read_volatile(PORT4_PCNTR1);
+        pcntr1 |= USB_SWITCH_MASK as u32;
+        pcntr1 &= !((USB_SWITCH_MASK as u32) << 16);
+        write_volatile(PORT4_PCNTR1, pcntr1);
+        write_volatile(PORT4_PORR, USB_SWITCH_MASK);
+    }
+
+    unsafe fn unlock_system_registers() {
+        write_volatile(SYSTEM_PRCR, PRCR_PRC1_UNLOCK);
+    }
+
+    unsafe fn lock_system_registers() {
+        write_volatile(SYSTEM_PRCR, PRCR_LOCK);
+    }
+
+    unsafe fn enable_pfs_writes() {
+        let mut pwpr = read_volatile(PMISC_PWPR);
+        pwpr &= !PWPR_B0WI;
+        write_volatile(PMISC_PWPR, pwpr);
+        write_volatile(PMISC_PWPR, pwpr | PWPR_PFSWE);
+    }
+
+    unsafe fn disable_pfs_writes() {
+        let mut pwpr = read_volatile(PMISC_PWPR);
+        pwpr &= !PWPR_B0WI;
+        write_volatile(PMISC_PWPR, pwpr);
+        write_volatile(PMISC_PWPR, pwpr & !PWPR_PFSWE);
+    }
+}
+
+#[cfg(target_arch = "arm")]
 mod ffi {
     #[repr(C, packed)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -334,6 +422,8 @@ mod ffi {
     }
 
     unsafe extern "C" {
+        #[link_name = "_Z10__USBStartv"]
+        pub fn arduino_renesas_usb_start();
         pub fn tud_task_ext(timeout_ms: u32, in_isr: bool);
         pub fn tud_cdc_n_connected(itf: u8) -> bool;
         pub fn tud_cdc_n_get_line_state(itf: u8) -> u8;
@@ -369,6 +459,7 @@ mod tests {
         polls: usize,
         flushes: usize,
         writes: usize,
+        starts: usize,
     }
 
     impl FakeTinyUsb {
@@ -388,6 +479,7 @@ mod tests {
                 polls: 0,
                 flushes: 0,
                 writes: 0,
+                starts: 0,
             }
         }
 
@@ -400,6 +492,10 @@ mod tests {
     }
 
     impl TinyUsbCdcApi for FakeTinyUsb {
+        fn start(&mut self) {
+            self.starts += 1;
+        }
+
         fn poll(&mut self) {
             self.polls += 1;
         }
@@ -454,6 +550,15 @@ mod tests {
         assert_eq!(UNO_R4_WIFI_USB_PRODUCT, "UNO R4 WiFi");
         assert_eq!(UNO_R4_WIFI_SERIAL_USB_NAME, "SerialUSB");
         assert_eq!(UNO_R4_WIFI_USB_MAX_PACKET_BYTES, 64);
+        assert_eq!(ARDUINO_RENESAS_USB_START_SYMBOL, "_Z10__USBStartv");
+        assert_eq!(
+            ARDUINO_RENESAS_USB_INSTALL_SERIAL_SYMBOL,
+            "_Z18__USBInstallSerialv"
+        );
+        assert_eq!(
+            UNO_R4_WIFI_CONFIGURE_USB_MUX_SYMBOL,
+            "_Z17configure_usb_muxv"
+        );
     }
 
     #[test]
@@ -464,6 +569,7 @@ mod tests {
         cdc.begin();
         assert_eq!(cdc.read_byte().unwrap(), 0x42);
         assert_eq!(cdc.api().polls, 1);
+        assert_eq!(cdc.api().starts, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- start the Uno R4 SerialUSB backend through Arduino Renesas `__USBStart()` using the C++ ABI symbol
- provide Rust-side Arduino USB CDC descriptor and Uno R4 WiFi USB-C mux hooks so the link set can avoid `SerialUSB.cpp` and `variant.cpp`
- add a host-tested Arduino/TinyUSB link manifest for the Uno R4 WiFi USB stack sources, defines, include paths, FSP archive, and ABI symbols

## Testing

- `cargo test -p board-vm-uno-r4-usb-cdc -- --nocapture`
- `cargo test -p board-vm-uno-r4-firmware -- --nocapture`
- `RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-usb-cdc`
- `RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib`
- `RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-uart-server`

## Notes

- The flashable `uno-r4-wifi-serialusb-server` binary still needs the next build-script bundle to compile and link the manifest's Arduino/TinyUSB C/C++ objects into the Rust firmware image.
