### PR TITLE
[codex] Add Uno R4 TinyUSB build link path

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -118,8 +118,10 @@ mux hook from Rust, so the final link set does not need Arduino's full
 the built-in USB path: Arduino core version `1.5.3`, FQBN
 `arduino:renesas_uno:unor4wifi`, required TinyUSB C objects, `USB.cpp`,
 `IRQManager.cpp`, the Uno R4 WiFi `libfsp.a`, include directories, compile
-defines, and the Rust-provided C++ ABI hook symbols. It is data-only for now so
-CI can validate the contract without requiring a local Arduino install.
+defines, and the Rust-provided C++ ABI hook symbols. The firmware build script
+uses the same manifest when `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`, keeping CI
+independent from a local Arduino install while giving hardware builds an
+explicit link path.
 
 Build the firmware library and host-tested server path now:
 
@@ -128,9 +130,25 @@ cargo test -p board-vm-uno-r4-firmware -- --nocapture
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib
 ```
 
-The final flashable `uno-r4-wifi-serialusb-server` binary still needs the
-follow-up build-script step that compiles the manifest's Arduino/TinyUSB C/C++
-objects and links them into the Rust firmware image.
+Build the SerialUSB server with the Arduino/TinyUSB link path enabled:
+
+```sh
+BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1 \
+BOARD_VM_UNO_R4_ARDUINO_CORE="$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" \
+RUSTC="$(rustup which rustc)" \
+rustup run stable cargo build \
+  --target thumbv7em-none-eabihf \
+  -p board-vm-uno-r4-firmware \
+  --bin uno-r4-wifi-serialusb-server \
+  --release
+```
+
+The build script compiles the manifest's Arduino/TinyUSB C/C++ sources into a
+small archive under Cargo's `OUT_DIR`, links it with the Uno R4 WiFi `libfsp.a`
+for `uno-r4-wifi-serialusb-server`, and leaves the other firmware binaries on
+the pure-Rust link path. Override `BOARD_VM_UNO_R4_ARM_GCC`,
+`BOARD_VM_UNO_R4_ARM_GXX`, or `BOARD_VM_UNO_R4_ARM_AR` if the Arduino-packaged
+toolchain cannot run on the host.
 
 After flashing the generated `.bin`, run the host smoke test against the adapter
 serial port:

--- a/code/packages/rust/board-vm-uno-r4-firmware/build.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/build.rs
@@ -1,11 +1,26 @@
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[allow(dead_code)]
+mod arduino_usb_link {
+    include!("src/arduino_usb_link.rs");
+}
+
+use arduino_usb_link::{
+    ArduinoSourceLanguage, ARDUINO_ARM_AR_ENV_VAR, ARDUINO_ARM_GCC_ENV_VAR,
+    ARDUINO_ARM_GXX_ENV_VAR, ARDUINO_CORE_ENV_VAR, ARDUINO_USB_LINK_CFLAGS,
+    ARDUINO_USB_LINK_CXXFLAGS, ARDUINO_USB_LINK_DEFINES, ARDUINO_USB_LINK_ENV_VAR,
+    ARDUINO_USB_LINK_INCLUDE_DIRS, ARDUINO_USB_LINK_SOURCES, UNO_R4_WIFI_FSP_ARCHIVE,
+};
 
 const UNO_R4_SKETCH_FLASH_ORIGIN: u32 = 0x0000_4000;
 const UNO_R4_CODE_FLASH_BYTES: u32 = 0x0004_0000;
 const UNO_R4_RAM_ORIGIN: u32 = 0x2000_0000;
 const UNO_R4_RAM_BYTES: u32 = 0x8000;
+const ARDUINO_ARM_GCC_VERSION: &str = "7-2017q4";
+const ARDUINO_USB_ARCHIVE: &str = "board_vm_uno_r4_arduino_usb";
 const FIRMWARE_BINS: [&str; 6] = [
     "uno-r4-vm-blink-smoke",
     "uno-r4-wifi-raw-blink-probe",
@@ -16,20 +31,219 @@ const FIRMWARE_BINS: [&str; 6] = [
 ];
 
 fn main() {
+    emit_rerun_hints();
+
     if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("arm") {
         let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by Cargo"));
-        let flash_len = UNO_R4_CODE_FLASH_BYTES - UNO_R4_SKETCH_FLASH_ORIGIN;
-        fs::write(
-            out_dir.join("memory.x"),
-            format!(
-                "MEMORY\n{{\n  FLASH : ORIGIN = 0x{UNO_R4_SKETCH_FLASH_ORIGIN:08X}, LENGTH = 0x{flash_len:X}\n  RAM : ORIGIN = 0x{UNO_R4_RAM_ORIGIN:08X}, LENGTH = 0x{UNO_R4_RAM_BYTES:X}\n}}\n\n_stack_start = ORIGIN(RAM) + LENGTH(RAM);\n"
-            ),
-        )
-        .expect("write Uno R4 memory.x");
+        write_memory_x(&out_dir);
 
         println!("cargo:rustc-link-search={}", out_dir.display());
         for firmware_bin in FIRMWARE_BINS {
             println!("cargo:rustc-link-arg-bin={firmware_bin}=-Tlink.x");
         }
+
+        if env_enabled(ARDUINO_USB_LINK_ENV_VAR) {
+            compile_and_link_arduino_usb(&out_dir);
+        }
     }
+}
+
+fn emit_rerun_hints() {
+    println!("cargo:rerun-if-env-changed={ARDUINO_USB_LINK_ENV_VAR}");
+    println!("cargo:rerun-if-env-changed={ARDUINO_CORE_ENV_VAR}");
+    println!("cargo:rerun-if-env-changed={ARDUINO_ARM_GCC_ENV_VAR}");
+    println!("cargo:rerun-if-env-changed={ARDUINO_ARM_GXX_ENV_VAR}");
+    println!("cargo:rerun-if-env-changed={ARDUINO_ARM_AR_ENV_VAR}");
+}
+
+fn write_memory_x(out_dir: &Path) {
+    let flash_len = UNO_R4_CODE_FLASH_BYTES - UNO_R4_SKETCH_FLASH_ORIGIN;
+    fs::write(
+        out_dir.join("memory.x"),
+        format!(
+            "MEMORY\n{{\n  FLASH : ORIGIN = 0x{UNO_R4_SKETCH_FLASH_ORIGIN:08X}, LENGTH = 0x{flash_len:X}\n  RAM : ORIGIN = 0x{UNO_R4_RAM_ORIGIN:08X}, LENGTH = 0x{UNO_R4_RAM_BYTES:X}\n}}\n\n_stack_start = ORIGIN(RAM) + LENGTH(RAM);\n"
+        ),
+    )
+    .expect("write Uno R4 memory.x");
+}
+
+fn compile_and_link_arduino_usb(out_dir: &Path) {
+    let core_dir = resolve_arduino_core_dir();
+    let packages_dir = arduino_packages_dir(&core_dir);
+    let gcc = resolve_tool(ARDUINO_ARM_GCC_ENV_VAR, &packages_dir, "gcc");
+    let gxx = resolve_tool(ARDUINO_ARM_GXX_ENV_VAR, &packages_dir, "g++");
+    let ar = resolve_tool(ARDUINO_ARM_AR_ENV_VAR, &packages_dir, "ar");
+
+    let object_dir = out_dir.join("arduino-usb-objects");
+    fs::create_dir_all(&object_dir).expect("create Arduino USB object dir");
+
+    let mut objects = Vec::new();
+    for source in ARDUINO_USB_LINK_SOURCES {
+        let source_path = core_dir.join(source.path);
+        println!("cargo:rerun-if-changed={}", source_path.display());
+
+        match source.language {
+            ArduinoSourceLanguage::C => {
+                let object = object_dir.join(object_name(source.path));
+                compile_source(
+                    &gcc,
+                    &core_dir,
+                    &source_path,
+                    &object,
+                    ARDUINO_USB_LINK_CFLAGS,
+                );
+                objects.push(object);
+            }
+            ArduinoSourceLanguage::Cxx => {
+                let object = object_dir.join(object_name(source.path));
+                compile_source(
+                    &gxx,
+                    &core_dir,
+                    &source_path,
+                    &object,
+                    ARDUINO_USB_LINK_CXXFLAGS,
+                );
+                objects.push(object);
+            }
+            ArduinoSourceLanguage::StaticArchive => {
+                let archive = core_dir.join(source.path);
+                assert_path_exists(&archive, "Arduino static archive");
+                println!("cargo:rerun-if-changed={}", archive.display());
+            }
+        }
+    }
+
+    let archive_path = out_dir.join(format!("lib{ARDUINO_USB_ARCHIVE}.a"));
+    if archive_path.exists() {
+        fs::remove_file(&archive_path).expect("remove stale Arduino USB archive");
+    }
+    run_command(
+        Command::new(&ar)
+            .arg("rcs")
+            .arg(&archive_path)
+            .args(&objects),
+        "archive Arduino USB objects",
+    );
+
+    let fsp_archive = core_dir.join(UNO_R4_WIFI_FSP_ARCHIVE);
+    assert_path_exists(&fsp_archive, "Uno R4 WiFi FSP archive");
+    let fsp_archive_dir = fsp_archive
+        .parent()
+        .expect("FSP archive lives under a directory");
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        fsp_archive_dir.display()
+    );
+    emit_serial_usb_link_arg("--whole-archive");
+    emit_serial_usb_link_arg("--start-group");
+    emit_serial_usb_link_arg(&format!("-l{ARDUINO_USB_ARCHIVE}"));
+    emit_serial_usb_link_arg("-lfsp");
+    emit_serial_usb_link_arg("--no-whole-archive");
+    emit_serial_usb_link_arg("--end-group");
+}
+
+fn compile_source(
+    compiler: &Path,
+    core_dir: &Path,
+    source_path: &Path,
+    object_path: &Path,
+    flags: &[&str],
+) {
+    assert_path_exists(source_path, "Arduino source");
+
+    let mut command = Command::new(compiler);
+    command.args(flags);
+    for define in ARDUINO_USB_LINK_DEFINES {
+        command.arg(format!("-D{define}"));
+    }
+    for include in ARDUINO_USB_LINK_INCLUDE_DIRS {
+        command.arg(format!("-I{}", core_dir.join(include).display()));
+    }
+    command.arg("-o").arg(object_path).arg(source_path);
+
+    run_command(&mut command, "compile Arduino USB source");
+}
+
+fn env_enabled(name: &str) -> bool {
+    env::var(name)
+        .map(|value| {
+            matches!(
+                value.as_str(),
+                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn resolve_arduino_core_dir() -> PathBuf {
+    if let Some(path) = env::var_os(ARDUINO_CORE_ENV_VAR) {
+        let path = PathBuf::from(path);
+        assert_path_exists(&path, "Arduino Renesas UNO core");
+        return path;
+    }
+
+    let home = PathBuf::from(env::var_os("HOME").unwrap_or_default());
+    let candidates = [
+        home.join("Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3"),
+        home.join(".arduino15/packages/arduino/hardware/renesas_uno/1.5.3"),
+    ];
+    for candidate in candidates {
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    panic!(
+        "{ARDUINO_CORE_ENV_VAR} must point to the Arduino Renesas UNO core when {ARDUINO_USB_LINK_ENV_VAR}=1"
+    );
+}
+
+fn arduino_packages_dir(core_dir: &Path) -> PathBuf {
+    core_dir
+        .ancestors()
+        .nth(4)
+        .expect("Arduino core path is under packages/arduino/hardware")
+        .to_path_buf()
+}
+
+fn resolve_tool(env_var: &str, packages_dir: &Path, suffix: &str) -> PathBuf {
+    if let Some(path) = env::var_os(env_var) {
+        let path = PathBuf::from(path);
+        assert_path_exists(&path, "Arduino ARM tool");
+        return path;
+    }
+
+    let exe_suffix = if cfg!(windows) { ".exe" } else { "" };
+    let tool = packages_dir
+        .join("arduino/tools/arm-none-eabi-gcc")
+        .join(ARDUINO_ARM_GCC_VERSION)
+        .join("bin")
+        .join(format!("arm-none-eabi-{suffix}{exe_suffix}"));
+    assert_path_exists(&tool, "Arduino ARM tool");
+    tool
+}
+
+fn assert_path_exists(path: &Path, label: &str) {
+    assert!(path.exists(), "{label} does not exist: {}", path.display());
+}
+
+fn object_name(source_path: &str) -> String {
+    let mut name = source_path.replace(['/', '\\', '.'], "_");
+    name.push_str(".o");
+    name
+}
+
+fn emit_serial_usb_link_arg(arg: &str) {
+    println!("cargo:rustc-link-arg-bin=uno-r4-wifi-serialusb-server={arg}");
+}
+
+fn run_command(command: &mut Command, action: &str) {
+    let status = command.status().unwrap_or_else(|error| {
+        panic!(
+            "{action} failed to start: {error}. If the Arduino-packaged ARM toolchain cannot run on this host, set {ARDUINO_ARM_GCC_ENV_VAR}, {ARDUINO_ARM_GXX_ENV_VAR}, and {ARDUINO_ARM_AR_ENV_VAR} to compatible arm-none-eabi tools."
+        );
+    });
+    assert!(status.success(), "{action} failed with status {status}");
 }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -1,8 +1,8 @@
-//! Data-only link manifest for the Uno R4 WiFi Arduino/TinyUSB USB device stack.
-//!
-//! The Rust firmware owns the VM, protocol, device state, and CDC byte stream.
-//! Arduino's Renesas core still owns the RA4M1 TinyUSB descriptors, IRQ
-//! plumbing, and FSP USB driver objects needed by `__USBStart`.
+// Data-only link manifest for the Uno R4 WiFi Arduino/TinyUSB USB device stack.
+//
+// The Rust firmware owns the VM, protocol, device state, and CDC byte stream.
+// Arduino's Renesas core still owns the RA4M1 TinyUSB descriptors, IRQ
+// plumbing, and FSP USB driver objects needed by `__USBStart`.
 
 pub const ARDUINO_RENESAS_UNO_CORE_VERSION: &str = "1.5.3";
 pub const UNO_R4_WIFI_FQBN: &str = "arduino:renesas_uno:unor4wifi";
@@ -13,6 +13,7 @@ pub const UNO_R4_WIFI_BOOTLOADER_USB_PID: u16 = 0x1002;
 pub const UNO_R4_WIFI_USB_RHPORT: u8 = 0;
 
 pub const ARDUINO_CORE_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARDUINO_CORE";
+pub const ARDUINO_USB_LINK_ENV_VAR: &str = "BOARD_VM_UNO_R4_LINK_ARDUINO_USB";
 pub const ARDUINO_ARM_GCC_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_GCC";
 pub const ARDUINO_ARM_GXX_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_GXX";
 pub const ARDUINO_ARM_AR_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_AR";
@@ -81,6 +82,8 @@ pub const ARDUINO_USB_LINK_INCLUDE_DIRS: &[&str] = &[
     "cores/arduino/tinyusb/common",
     "cores/arduino/tinyusb/device",
     "cores/arduino/usb",
+    "cores/arduino/api/deprecated",
+    "cores/arduino/api/deprecated-avr-comp",
     "variants/UNOWIFIR4",
     "variants/UNOWIFIR4/includes/ra/fsp/inc",
     "variants/UNOWIFIR4/includes/ra/fsp/inc/api",
@@ -93,6 +96,10 @@ pub const ARDUINO_USB_LINK_INCLUDE_DIRS: &[&str] = &[
 ];
 
 pub const ARDUINO_USB_LINK_DEFINES: &[&str] = &[
+    "ARDUINO=10607",
+    "ARDUINO_UNOWIFIR4",
+    "ARDUINO_ARCH_RENESAS_UNO",
+    "ARDUINO_ARCH_RENESAS",
     "F_CPU=48000000",
     "NO_USB",
     "BACKTRACE_SUPPORT",
@@ -105,6 +112,13 @@ pub const ARDUINO_USB_LINK_DEFINES: &[&str] = &[
 ];
 
 pub const ARDUINO_USB_LINK_CFLAGS: &[&str] = &[
+    "-c",
+    "-w",
+    "-Os",
+    "-g3",
+    "-nostdlib",
+    "-MMD",
+    "-std=gnu11",
     "-mcpu=cortex-m4",
     "-mthumb",
     "-mfloat-abi=hard",
@@ -112,9 +126,21 @@ pub const ARDUINO_USB_LINK_CFLAGS: &[&str] = &[
     "-ffunction-sections",
     "-fdata-sections",
     "-fsigned-char",
+    "-fno-builtin",
 ];
 
 pub const ARDUINO_USB_LINK_CXXFLAGS: &[&str] = &[
+    "-c",
+    "-w",
+    "-Os",
+    "-g3",
+    "-fno-use-cxa-atexit",
+    "-fno-threadsafe-statics",
+    "-fno-rtti",
+    "-fno-exceptions",
+    "-MMD",
+    "-nostdlib",
+    "-std=gnu++17",
     "-mcpu=cortex-m4",
     "-mthumb",
     "-mfloat-abi=hard",
@@ -122,8 +148,7 @@ pub const ARDUINO_USB_LINK_CXXFLAGS: &[&str] = &[
     "-ffunction-sections",
     "-fdata-sections",
     "-fsigned-char",
-    "-fno-rtti",
-    "-fno-exceptions",
+    "-fno-builtin",
 ];
 
 pub const RUST_PROVIDED_USB_SYMBOLS: &[&str] = &[
@@ -163,6 +188,7 @@ mod tests {
         assert_eq!(UNO_R4_WIFI_RUNTIME_USB_PID, 0x006D);
         assert_eq!(UNO_R4_WIFI_BOOTLOADER_USB_PID, 0x1002);
         assert_eq!(UNO_R4_WIFI_USB_RHPORT, 0);
+        assert_eq!(ARDUINO_USB_LINK_ENV_VAR, "BOARD_VM_UNO_R4_LINK_ARDUINO_USB");
     }
 
     #[test]
@@ -181,11 +207,16 @@ mod tests {
     #[test]
     fn link_manifest_carries_arduino_flags_needed_by_tinyusb() {
         assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"cores/arduino/tinyusb"));
+        assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"cores/arduino/api/deprecated"));
         assert!(ARDUINO_USB_LINK_INCLUDE_DIRS.contains(&"variants/UNOWIFIR4"));
+        assert!(ARDUINO_USB_LINK_DEFINES.contains(&"ARDUINO_UNOWIFIR4"));
+        assert!(ARDUINO_USB_LINK_DEFINES.contains(&"ARDUINO_ARCH_RENESAS_UNO"));
         assert!(ARDUINO_USB_LINK_DEFINES.contains(&"CFG_TUSB_MCU=OPT_MCU_RAXXX"));
         assert!(ARDUINO_USB_LINK_DEFINES.contains(&"ARDUINO_UNOR4_WIFI"));
+        assert!(ARDUINO_USB_LINK_CFLAGS.contains(&"-std=gnu11"));
         assert!(ARDUINO_USB_LINK_CFLAGS.contains(&"-mcpu=cortex-m4"));
         assert!(ARDUINO_USB_LINK_CXXFLAGS.contains(&"-fno-exceptions"));
+        assert!(ARDUINO_USB_LINK_CXXFLAGS.contains(&"-fno-threadsafe-statics"));
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-usb-cdc/README.md
+++ b/code/packages/rust/board-vm-uno-r4-usb-cdc/README.md
@@ -19,6 +19,11 @@ interface without linking the full `SerialUSB.cpp` object, and it overrides the
 Uno R4 WiFi `configure_usb_mux()` weak hook with direct RA4M1 register writes so
 the USB-C connector is routed to the RA4M1 USB peripheral.
 
+The Arduino descriptor builder allocates its configuration descriptor at USB
+startup. Because the Rust firmware links without a C runtime allocator, this
+crate provides a tiny no-free `malloc`/`free` shim sized for that descriptor path
+when built for ARM.
+
 A flashable firmware binary still needs to compile and link the Arduino/FSP
 TinyUSB startup objects listed by `board-vm-uno-r4-firmware`'s Arduino USB link
 manifest.

--- a/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
@@ -16,6 +16,7 @@ pub const UNO_R4_WIFI_USB_MAX_PACKET_BYTES: usize = USB_CDC_FULL_SPEED_MAX_PACKE
 pub const ARDUINO_RENESAS_USB_START_SYMBOL: &str = "_Z10__USBStartv";
 pub const ARDUINO_RENESAS_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const UNO_R4_WIFI_CONFIGURE_USB_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
+pub const UNO_R4_WIFI_USB_DESCRIPTOR_HEAP_BYTES: usize = 512;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnoR4UsbCdcError {
@@ -382,6 +383,53 @@ mod uno_r4_wifi_usb_mux {
 }
 
 #[cfg(target_arch = "arm")]
+mod arduino_usb_malloc {
+    use core::ptr::null_mut;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::UNO_R4_WIFI_USB_DESCRIPTOR_HEAP_BYTES;
+
+    #[repr(align(8))]
+    struct AlignedHeap([u8; UNO_R4_WIFI_USB_DESCRIPTOR_HEAP_BYTES]);
+
+    static mut HEAP: AlignedHeap = AlignedHeap([0; UNO_R4_WIFI_USB_DESCRIPTOR_HEAP_BYTES]);
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn malloc(size: usize) -> *mut core::ffi::c_void {
+        if size == 0 {
+            return null_mut();
+        }
+
+        let mut current = NEXT.load(Ordering::Relaxed);
+        loop {
+            let aligned = align_up(current, 8);
+            let Some(next) = aligned.checked_add(size) else {
+                return null_mut();
+            };
+            if next > UNO_R4_WIFI_USB_DESCRIPTOR_HEAP_BYTES {
+                return null_mut();
+            }
+
+            match NEXT.compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => unsafe {
+                    let base = core::ptr::addr_of_mut!(HEAP.0) as *mut u8;
+                    return base.add(aligned) as *mut core::ffi::c_void;
+                },
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn free(_ptr: *mut core::ffi::c_void) {}
+
+    const fn align_up(value: usize, align: usize) -> usize {
+        (value + align - 1) & !(align - 1)
+    }
+}
+
+#[cfg(target_arch = "arm")]
 mod ffi {
     #[repr(C, packed)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -559,6 +607,7 @@ mod tests {
             UNO_R4_WIFI_CONFIGURE_USB_MUX_SYMBOL,
             "_Z17configure_usb_muxv"
         );
+        assert_eq!(UNO_R4_WIFI_USB_DESCRIPTOR_HEAP_BYTES, 512);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an opt-in Uno R4 Arduino/TinyUSB build-script path gated by `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1`
- compile the manifest's Arduino TinyUSB/USB C/C++ sources into a Cargo `OUT_DIR` archive and link it with the Uno R4 WiFi `libfsp.a` for `uno-r4-wifi-serialusb-server`
- add a small ARM-only `malloc`/`free` shim for Arduino's USB descriptor allocation path
- document the hardware build environment variables and toolchain overrides

## Testing

- `cargo test -p board-vm-uno-r4-firmware -- --nocapture`
- `cargo test -p board-vm-uno-r4-usb-cdc -- --nocapture`
- `RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib`
- `RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-uart-server`
- `RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-usb-cdc`

## Local hardware build probe

- Tried `BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1 ... cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-server`
- It reached the new opt-in build path and failed before compiling Arduino sources because the locally installed Arduino `arm-none-eabi-gcc` package is x86-only on this Apple Silicon host: `Bad CPU type in executable`.
- The build script now reports the `BOARD_VM_UNO_R4_ARM_GCC`, `BOARD_VM_UNO_R4_ARM_GXX`, and `BOARD_VM_UNO_R4_ARM_AR` override variables for hosts that need a compatible ARM GCC toolchain.
