### PR TITLE
Expose seeded HTML comment lexer contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -23,6 +23,12 @@ documented in this file.
 - html5lib-style smoke fixture coverage for the seeded continuation states,
   including matching end tags, mismatched literal recovery, EOF recovery, and
   whitespace/attribute/trailing-solidus diagnostics.
+- Parser/importer-facing seeded comment continuation contexts, including
+  comment body, start-dash, less-than, end-dash, end-bang, and bogus-comment
+  substates with current-comment seeding.
+- html5lib-style smoke fixture coverage for seeded comment continuations,
+  including pending dash/bang preservation, abrupt close diagnostics, and
+  bogus-comment recovery.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -179,6 +179,11 @@ machine-state strings. Parsers that keep one lexer alive can call
 `apply_html_lex_context` to move that lexer between data state, text-mode
 states, and seeded end-tag continuation states while clearing stale
 last-start-tag, current-token, and temporary-buffer context.
+The same typed context layer now covers seeded comment continuation states,
+including comment start/dash, less-than/bang/dash substates, end-dash/end-bang,
+and bogus-comment recovery. This lets html5lib-style importer cases resume
+comment tokenization with an in-progress comment token instead of treating those
+states as runtime gaps.
 Foreign-content CDATA is exposed as an explicit
 `HtmlLexContext::cdata_section()` helper rather than as an element-name mapping,
 so future SVG/MathML tree-construction logic can opt into CDATA only after it
@@ -226,11 +231,12 @@ fixture normalization logic to live forever inside the Rust tests.
 
 The normalized corpus now carries optional tokenizer-context metadata such as
 `initial_state` and `last_start_tag`, so upstream RCDATA, RAWTEXT, PLAINTEXT,
-CDATA section, script data, script data escaped/dash/less-than/end-tag-open
-substates, and script data double-escaped/dash/less-than substates can already
-live in the shared Venture fixture format. Current Rust conformance tests now
-seed that context into the generated lexer so non-data-state cases execute
-through the same static Rust wrapper as the data-state corpus.
+CDATA section, comment continuation states, script data, script data
+escaped/dash/less-than/end-tag-open substates, and script data
+double-escaped/dash/less-than substates can already live in the shared Venture
+fixture format. Current Rust conformance tests now seed that context into the
+generated lexer so non-data-state cases execute through the same static Rust
+wrapper as the data-state corpus.
 The importer also expands supported multi-state html5lib entries into stable
 per-state Venture cases and now covers intermediate text-like states such as
 RCDATA/RAWTEXT less-than and end-tag-open, CDATA bracket/end, script less-than
@@ -238,7 +244,8 @@ and end-tag-open, script escape-start, script escaped end-tag-open, and script
 double-escape start/end. End-tag-open fixtures now cover matching tags,
 mismatched tags that must remain literal text, EOF recovery that preserves the
 pending `</`, and matching end-tag diagnostics for whitespace, attributes, and
-trailing solidus.
+trailing solidus. Comment continuation fixtures cover seeded body, pending dash,
+pending bang, nested-comment, abrupt-close, and bogus-comment recovery paths.
 
 The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
 same schema rather than teaching the Rust harness to parse raw upstream files

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -43,6 +43,17 @@ pub enum HtmlTokenizerState {
     CdataSection,
     CdataSectionBracket,
     CdataSectionEnd,
+    CommentStart,
+    CommentStartDash,
+    Comment,
+    CommentLessThanSign,
+    CommentLessThanSignBang,
+    CommentLessThanSignBangDash,
+    CommentLessThanSignBangDashDash,
+    CommentEndDash,
+    CommentEnd,
+    CommentEndBang,
+    BogusComment,
     ScriptData,
     ScriptDataLessThanSign,
     ScriptDataEndTagOpen,
@@ -70,7 +81,7 @@ pub enum HtmlTokenizerState {
 }
 
 /// Tokenizer states that are valid parser-facing entry points.
-pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 43] = [
+pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 54] = [
     HtmlTokenizerState::Data,
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
@@ -90,6 +101,17 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 43] = [
     HtmlTokenizerState::CdataSection,
     HtmlTokenizerState::CdataSectionBracket,
     HtmlTokenizerState::CdataSectionEnd,
+    HtmlTokenizerState::CommentStart,
+    HtmlTokenizerState::CommentStartDash,
+    HtmlTokenizerState::Comment,
+    HtmlTokenizerState::CommentLessThanSign,
+    HtmlTokenizerState::CommentLessThanSignBang,
+    HtmlTokenizerState::CommentLessThanSignBangDash,
+    HtmlTokenizerState::CommentLessThanSignBangDashDash,
+    HtmlTokenizerState::CommentEndDash,
+    HtmlTokenizerState::CommentEnd,
+    HtmlTokenizerState::CommentEndBang,
+    HtmlTokenizerState::BogusComment,
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
@@ -117,7 +139,7 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 43] = [
 ];
 
 /// Tokenizer states used for parser-controlled text or foreign-content fragments.
-pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 42] = [
+pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 53] = [
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::RcdataEndTagOpen,
@@ -136,6 +158,17 @@ pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 42] = [
     HtmlTokenizerState::CdataSection,
     HtmlTokenizerState::CdataSectionBracket,
     HtmlTokenizerState::CdataSectionEnd,
+    HtmlTokenizerState::CommentStart,
+    HtmlTokenizerState::CommentStartDash,
+    HtmlTokenizerState::Comment,
+    HtmlTokenizerState::CommentLessThanSign,
+    HtmlTokenizerState::CommentLessThanSignBang,
+    HtmlTokenizerState::CommentLessThanSignBangDash,
+    HtmlTokenizerState::CommentLessThanSignBangDashDash,
+    HtmlTokenizerState::CommentEndDash,
+    HtmlTokenizerState::CommentEnd,
+    HtmlTokenizerState::CommentEndBang,
+    HtmlTokenizerState::BogusComment,
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
@@ -213,6 +246,17 @@ impl HtmlTokenizerState {
             Self::CdataSection => "cdata_section",
             Self::CdataSectionBracket => "cdata_section_bracket",
             Self::CdataSectionEnd => "cdata_section_end",
+            Self::CommentStart => "comment_start",
+            Self::CommentStartDash => "comment_start_dash",
+            Self::Comment => "comment",
+            Self::CommentLessThanSign => "comment_less_than_sign",
+            Self::CommentLessThanSignBang => "comment_less_than_sign_bang",
+            Self::CommentLessThanSignBangDash => "comment_less_than_sign_bang_dash",
+            Self::CommentLessThanSignBangDashDash => "comment_less_than_sign_bang_dash_dash",
+            Self::CommentEndDash => "comment_end_dash",
+            Self::CommentEnd => "comment_end",
+            Self::CommentEndBang => "comment_end_bang",
+            Self::BogusComment => "bogus_comment",
             Self::ScriptData => "script_data",
             Self::ScriptDataLessThanSign => "script_data_less_than_sign",
             Self::ScriptDataEndTagOpen => "script_data_end_tag_open",
@@ -264,6 +308,17 @@ impl HtmlTokenizerState {
             Self::CdataSection => "CDATA section state",
             Self::CdataSectionBracket => "CDATA section bracket state",
             Self::CdataSectionEnd => "CDATA section end state",
+            Self::CommentStart => "Comment start state",
+            Self::CommentStartDash => "Comment start dash state",
+            Self::Comment => "Comment state",
+            Self::CommentLessThanSign => "Comment less-than sign state",
+            Self::CommentLessThanSignBang => "Comment less-than sign bang state",
+            Self::CommentLessThanSignBangDash => "Comment less-than sign bang dash state",
+            Self::CommentLessThanSignBangDashDash => "Comment less-than sign bang dash dash state",
+            Self::CommentEndDash => "Comment end dash state",
+            Self::CommentEnd => "Comment end state",
+            Self::CommentEndBang => "Comment end bang state",
+            Self::BogusComment => "Bogus comment state",
             Self::ScriptData => "Script data state",
             Self::ScriptDataLessThanSign => "Script data less-than sign state",
             Self::ScriptDataEndTagOpen => "Script data end tag open state",
@@ -353,6 +408,24 @@ impl HtmlTokenizerState {
         )
     }
 
+    /// Return whether this state resumes an already-started comment token.
+    pub fn requires_comment_seed(self) -> bool {
+        matches!(
+            self,
+            Self::CommentStart
+                | Self::CommentStartDash
+                | Self::Comment
+                | Self::CommentLessThanSign
+                | Self::CommentLessThanSignBang
+                | Self::CommentLessThanSignBangDash
+                | Self::CommentLessThanSignBangDashDash
+                | Self::CommentEndDash
+                | Self::CommentEnd
+                | Self::CommentEndBang
+                | Self::BogusComment
+        )
+    }
+
     /// Return whether a seeded state needs the parser's last-start-tag context.
     pub fn requires_last_start_tag(self) -> bool {
         matches!(
@@ -381,6 +454,7 @@ pub struct HtmlLexContext {
     pub initial_state: HtmlTokenizerState,
     pub last_start_tag: Option<String>,
     pub current_end_tag: Option<String>,
+    pub current_comment: Option<String>,
     pub temporary_buffer: Option<String>,
 }
 
@@ -390,6 +464,7 @@ impl HtmlLexContext {
             initial_state,
             last_start_tag: None,
             current_end_tag: None,
+            current_comment: None,
             temporary_buffer: None,
         }
     }
@@ -431,6 +506,11 @@ impl HtmlLexContext {
         self
     }
 
+    pub fn with_current_comment(mut self, data: impl Into<String>) -> Self {
+        self.current_comment = Some(data.into());
+        self
+    }
+
     pub fn with_temporary_buffer(mut self, value: impl Into<String>) -> Self {
         self.temporary_buffer = Some(value.into());
         self
@@ -440,7 +520,25 @@ impl HtmlLexContext {
         self.initial_state == HtmlTokenizerState::Data
             && self.last_start_tag.is_none()
             && self.current_end_tag.is_none()
+            && self.current_comment.is_none()
             && self.temporary_buffer.is_none()
+    }
+
+    /// Return a comment tokenizer continuation context for importer/parser tests.
+    ///
+    /// These states resume with an already-created comment token. States such as
+    /// `comment_end_dash` and `comment_end` encode pending dash delimiters in
+    /// the tokenizer state itself, so the seed only contains already-committed
+    /// comment data.
+    pub fn comment_continuation(
+        initial_state: HtmlTokenizerState,
+        data: impl Into<String>,
+    ) -> Option<Self> {
+        if initial_state.requires_comment_seed() {
+            Some(Self::new(initial_state).with_current_comment(data))
+        } else {
+            None
+        }
     }
 
     /// Return the tokenizer context used for text following a start tag.
@@ -521,6 +619,8 @@ pub fn apply_html_lex_context(lexer: &mut HtmlLexer, context: &HtmlLexContext) -
     }
     if let Some(current_end_tag) = context.current_end_tag.as_deref() {
         lexer.set_current_end_tag(current_end_tag);
+    } else if let Some(current_comment) = context.current_comment.as_deref() {
+        lexer.set_current_comment(current_comment);
     } else {
         lexer.clear_current_token();
     }

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -35,6 +35,8 @@ struct FixtureCase {
     #[serde(default)]
     current_end_tag: Option<String>,
     #[serde(default)]
+    current_comment: Option<String>,
+    #[serde(default)]
     temporary_buffer: Option<String>,
 }
 
@@ -57,6 +59,8 @@ struct Html5libTokenizerTest {
     current_end_tag: Option<String>,
     #[serde(default, rename = "temporaryBuffer")]
     temporary_buffer: Option<String>,
+    #[serde(default, rename = "currentComment")]
+    current_comment: Option<String>,
     #[serde(default)]
     errors: Vec<Html5libTokenizerError>,
 }
@@ -255,6 +259,14 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
                 && case.initial_state.as_deref() == Some("RCDATA end tag name state")),
         "normalized fixtures should include seeded end-tag continuation states"
     );
+    assert!(
+        normalized
+            .cases
+            .iter()
+            .any(|case| case.current_comment.as_deref() == Some("seed")
+                && case.initial_state.as_deref() == Some("Comment end dash state")),
+        "normalized fixtures should include seeded comment continuation states"
+    );
 }
 
 #[test]
@@ -370,6 +382,7 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
         None => {
             case.last_start_tag.is_none()
                 && case.current_end_tag.is_none()
+                && case.current_comment.is_none()
                 && case.temporary_buffer.is_none()
         }
         Some(initial_state) => {
@@ -378,8 +391,10 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
             };
             let has_end_tag_seed =
                 case.current_end_tag.is_some() && case.temporary_buffer.is_some();
+            let has_comment_seed = case.current_comment.is_some();
             state.requires_last_start_tag() == case.last_start_tag.is_some()
                 && state.requires_end_tag_seed() == has_end_tag_seed
+                && state.requires_comment_seed() == has_comment_seed
                 && (has_end_tag_seed
                     || (case.current_end_tag.is_none() && case.temporary_buffer.is_none()))
         }
@@ -440,6 +455,9 @@ fn configure_lexer_for_case(
     }
     if let Some(current_end_tag) = case.current_end_tag.as_deref() {
         context = context.with_current_end_tag(current_end_tag);
+    }
+    if let Some(current_comment) = case.current_comment.as_deref() {
+        context = context.with_current_comment(current_comment);
     }
     if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
         context = context.with_temporary_buffer(temporary_buffer);

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -67,6 +67,9 @@ optional `initialStates`, optional `lastStartTag`, and optional `errors`.
 For seeded continuation states that upstream fixtures cannot fully describe,
 this smoke file also accepts `currentEndTag` and `temporaryBuffer` extension
 fields; the normalizer lowers them to `current_end_tag` and `temporary_buffer`.
+Comment continuation fixtures likewise accept a `currentComment` extension
+field, lowered to `current_comment`, so html5lib-style comment substates can
+resume with an already-created comment token.
 
 `normalize_html5lib_fixtures.py` is the checked-in importer for this shape. It
 currently supports:
@@ -78,6 +81,9 @@ currently supports:
 - `initialStates: ["PLAINTEXT state"]`
 - `initialStates: ["CDATA section state"]`
 - CDATA section `bracket` and `end` substates
+- comment `start`, `start dash`, body, less-than-sign, less-than-sign bang,
+  less-than-sign bang dash, less-than-sign bang dash dash, end-dash, end,
+  end-bang, and bogus-comment substates together with `currentComment`
 - `initialStates: ["Script data state"]` together with `lastStartTag`
 - script `less-than sign`, `escape start`, and `escape start dash` substates
   together with `lastStartTag`
@@ -172,13 +178,14 @@ than silently disappearing. Rust conformance tests execute the generated
 `html5lib-smoke.json` corpus and separately parse the raw upstream-style file to
 keep the intake path visible. Tokenizer-context cases such as RCDATA, RAWTEXT,
 script submodes, CDATA bracket/end states, resumable end-tag-open states, and
-seeded end-tag continuation states stay in the generated corpus with context
+seeded end-tag and comment continuation states stay in the generated corpus with context
 metadata and are seeded into the Rust wrapper at test time, while still
 unsupported upstream states remain recorded under `skipped` instead of being
 discarded. End-tag continuation coverage intentionally exercises matching,
 mismatched, EOF, and diagnostic recovery paths so parser/tokenizer handoff
 regressions show up in the shared fixture corpus instead of only in narrow unit
-tests.
+tests. Comment continuation coverage does the same for pending dash/bang and
+bogus-comment recovery paths.
 
 To regenerate the normalized corpus:
 

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -5,9 +5,20 @@
   "source": "upstream-html5lib-smoke.test",
   "generator": "normalize_html5lib_fixtures.py",
   "supported_initial_states": [
+    "Bogus comment state",
     "CDATA section bracket state",
     "CDATA section end state",
     "CDATA section state",
+    "Comment end bang state",
+    "Comment end dash state",
+    "Comment end state",
+    "Comment less-than sign bang dash dash state",
+    "Comment less-than sign bang dash state",
+    "Comment less-than sign bang state",
+    "Comment less-than sign state",
+    "Comment start dash state",
+    "Comment start state",
+    "Comment state",
     "Data state",
     "PLAINTEXT state",
     "RAWTEXT end tag attributes state",
@@ -2581,6 +2592,101 @@
       "last_start_tag": "script",
       "current_end_tag": "script",
       "temporary_buffer": "script"
+    },
+    {
+      "id": "html5lib-smoke-202",
+      "description": "comment state resumes seeded comment data",
+      "input": " body -->tail",
+      "tokens": [
+        "Comment(data=seed body )",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Comment state",
+      "current_comment": "seed"
+    },
+    {
+      "id": "html5lib-smoke-203",
+      "description": "comment end dash state preserves pending dash on fallback",
+      "input": "x-->tail",
+      "tokens": [
+        "Comment(data=seed-x)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Comment end dash state",
+      "current_comment": "seed"
+    },
+    {
+      "id": "html5lib-smoke-204",
+      "description": "comment end state emits incorrectly closed comment",
+      "input": "!>tail",
+      "tokens": [
+        "Comment(data=seed)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "incorrectly-closed-comment"
+      ],
+      "initial_state": "Comment end state",
+      "current_comment": "seed"
+    },
+    {
+      "id": "html5lib-smoke-205",
+      "description": "comment end bang state preserves pending bang on fallback",
+      "input": "y-->tail",
+      "tokens": [
+        "Comment(data=seed--!y)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Comment end bang state",
+      "current_comment": "seed"
+    },
+    {
+      "id": "html5lib-smoke-206",
+      "description": "comment less-than sign state resumes committed less-than",
+      "input": "x-->tail",
+      "tokens": [
+        "Comment(data=seed<x)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Comment less-than sign state",
+      "current_comment": "seed<"
+    },
+    {
+      "id": "html5lib-smoke-207",
+      "description": "comment start dash state reports abrupt close",
+      "input": ">tail",
+      "tokens": [
+        "Comment(data=)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ],
+      "initial_state": "Comment start dash state",
+      "current_comment": ""
+    },
+    {
+      "id": "html5lib-smoke-208",
+      "description": "bogus comment state resumes seeded comment data",
+      "input": "tail>after",
+      "tokens": [
+        "Comment(data=bogus-tail)",
+        "Text(data=after)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Bogus comment state",
+      "current_comment": "bogus-"
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -14,6 +14,17 @@ SUPPORTED_INITIAL_STATES = {
     "CDATA section bracket state",
     "CDATA section end state",
     "CDATA section state",
+    "Bogus comment state",
+    "Comment end bang state",
+    "Comment end dash state",
+    "Comment end state",
+    "Comment less-than sign bang dash dash state",
+    "Comment less-than sign bang dash state",
+    "Comment less-than sign bang state",
+    "Comment less-than sign state",
+    "Comment start dash state",
+    "Comment start state",
+    "Comment state",
     "Data state",
     "PLAINTEXT state",
     "RCDATA end tag attributes state",
@@ -116,6 +127,20 @@ END_TAG_SEED_INITIAL_STATES = {
     "Script data escaped self-closing end tag state",
 }
 
+COMMENT_SEED_INITIAL_STATES = {
+    "Bogus comment state",
+    "Comment end bang state",
+    "Comment end dash state",
+    "Comment end state",
+    "Comment less-than sign bang dash dash state",
+    "Comment less-than sign bang dash state",
+    "Comment less-than sign bang state",
+    "Comment less-than sign state",
+    "Comment start dash state",
+    "Comment start state",
+    "Comment state",
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -209,6 +234,21 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if has_end_tag_seed and len(needs_end_tag_seed) != len(initial_states):
         return False, "currentEndTag/temporaryBuffer only supported for continuation states"
 
+    needs_comment_seed = [
+        initial_state
+        for initial_state in initial_states
+        if initial_state in COMMENT_SEED_INITIAL_STATES
+    ]
+    has_comment_seed = isinstance(test.get("currentComment"), str)
+    if needs_comment_seed and not has_comment_seed:
+        return False, f"{needs_comment_seed[0]} requires currentComment"
+
+    if has_comment_seed and len(needs_comment_seed) != len(initial_states):
+        return False, "currentComment only supported for comment continuation states"
+
+    if has_comment_seed and (has_end_tag_seed or has_partial_end_tag_seed):
+        return False, "currentComment cannot be combined with end-tag continuation context"
+
     for token in test.get("output", []):
         kind = token[0]
         if kind not in {"Character", "StartTag", "EndTag", "Comment", "DOCTYPE"}:
@@ -283,6 +323,10 @@ def normalize_case(
     temporary_buffer = test.get("temporaryBuffer")
     if temporary_buffer is not None:
         normalized["temporary_buffer"] = temporary_buffer
+
+    current_comment = test.get("currentComment")
+    if current_comment is not None:
+        normalized["current_comment"] = current_comment
 
     return normalized
 

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -2834,6 +2834,146 @@
           "col": 1
         }
       ]
+    },
+    {
+      "description": "comment state resumes seeded comment data",
+      "input": " body -->tail",
+      "initialStates": [
+        "Comment state"
+      ],
+      "currentComment": "seed",
+      "output": [
+        [
+          "Comment",
+          "seed body "
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ]
+    },
+    {
+      "description": "comment end dash state preserves pending dash on fallback",
+      "input": "x-->tail",
+      "initialStates": [
+        "Comment end dash state"
+      ],
+      "currentComment": "seed",
+      "output": [
+        [
+          "Comment",
+          "seed-x"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ]
+    },
+    {
+      "description": "comment end state emits incorrectly closed comment",
+      "input": "!>tail",
+      "initialStates": [
+        "Comment end state"
+      ],
+      "currentComment": "seed",
+      "output": [
+        [
+          "Comment",
+          "seed"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "incorrectly-closed-comment",
+          "line": 1,
+          "col": 2
+        }
+      ]
+    },
+    {
+      "description": "comment end bang state preserves pending bang on fallback",
+      "input": "y-->tail",
+      "initialStates": [
+        "Comment end bang state"
+      ],
+      "currentComment": "seed",
+      "output": [
+        [
+          "Comment",
+          "seed--!y"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ]
+    },
+    {
+      "description": "comment less-than sign state resumes committed less-than",
+      "input": "x-->tail",
+      "initialStates": [
+        "Comment less-than sign state"
+      ],
+      "currentComment": "seed<",
+      "output": [
+        [
+          "Comment",
+          "seed<x"
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ]
+    },
+    {
+      "description": "comment start dash state reports abrupt close",
+      "input": ">tail",
+      "initialStates": [
+        "Comment start dash state"
+      ],
+      "currentComment": "",
+      "output": [
+        [
+          "Comment",
+          ""
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "abrupt-closing-of-empty-comment",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "bogus comment state resumes seeded comment data",
+      "input": "tail>after",
+      "initialStates": [
+        "Bogus comment state"
+      ],
+      "currentComment": "bogus-",
+      "output": [
+        [
+          "Comment",
+          "bogus-tail"
+        ],
+        [
+          "Character",
+          "after"
+        ]
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,8 +1,8 @@
 use coding_adventures_html_lexer::{
-    apply_html_lex_context, create_html_lexer, html1_definition, html1_machine,
-    html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment, Attribute,
-    HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token, HTML_FRAGMENT_TOKENIZER_STATES,
-    HTML_SCRIPT_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
+    apply_html_lex_context, create_html_lexer, create_html_lexer_with_context, html1_definition,
+    html1_machine, html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment,
+    Attribute, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token,
+    HTML_FRAGMENT_TOKENIZER_STATES, HTML_SCRIPT_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
 };
 use state_machine::END_INPUT;
 
@@ -5046,6 +5046,17 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "cdata_section",
             "cdata_section_bracket",
             "cdata_section_end",
+            "comment_start",
+            "comment_start_dash",
+            "comment",
+            "comment_less_than_sign",
+            "comment_less_than_sign_bang",
+            "comment_less_than_sign_bang_dash",
+            "comment_less_than_sign_bang_dash_dash",
+            "comment_end_dash",
+            "comment_end",
+            "comment_end_bang",
+            "bogus_comment",
             "script_data",
             "script_data_less_than_sign",
             "script_data_end_tag_open",
@@ -5134,8 +5145,12 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
     assert!(HtmlTokenizerState::ScriptDataEscapedEndTagOpen.requires_last_start_tag());
     assert!(HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace.requires_last_start_tag());
     assert!(HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace.requires_end_tag_seed());
+    assert!(HtmlTokenizerState::Comment.requires_comment_seed());
+    assert!(HtmlTokenizerState::CommentEndDash.requires_comment_seed());
+    assert!(HtmlTokenizerState::BogusComment.requires_comment_seed());
     assert!(!HtmlTokenizerState::RcdataEndTagOpen.requires_end_tag_seed());
     assert!(!HtmlTokenizerState::CdataSectionEnd.requires_last_start_tag());
+    assert!(!HtmlTokenizerState::Data.requires_comment_seed());
 }
 
 #[test]
@@ -5267,6 +5282,114 @@ fn parser_facing_context_seeds_intermediate_text_states() {
             },
             Token::Eof
         ]
+    );
+}
+
+#[test]
+fn parser_facing_context_seeds_comment_continuation_states() {
+    let comment =
+        HtmlLexContext::comment_continuation(HtmlTokenizerState::Comment, "seed").unwrap();
+    assert_eq!(
+        lex_html_fragment(" body -->tail", &comment).unwrap(),
+        vec![
+            Token::Comment("seed body ".to_string()),
+            Token::Text("tail".to_string()),
+            Token::Eof,
+        ]
+    );
+
+    let comment_end_dash =
+        HtmlLexContext::comment_continuation(HtmlTokenizerState::CommentEndDash, "seed").unwrap();
+    assert_eq!(
+        lex_html_fragment("x-->tail", &comment_end_dash).unwrap(),
+        vec![
+            Token::Comment("seed-x".to_string()),
+            Token::Text("tail".to_string()),
+            Token::Eof,
+        ]
+    );
+
+    let comment_end =
+        HtmlLexContext::comment_continuation(HtmlTokenizerState::CommentEnd, "seed").unwrap();
+    let mut lexer = create_html_lexer_with_context(&comment_end).unwrap();
+    lexer.push("!>tail").unwrap();
+    lexer.finish().unwrap();
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Comment("seed".to_string()),
+            Token::Text("tail".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec!["incorrectly-closed-comment"]
+    );
+
+    let comment_end_bang =
+        HtmlLexContext::comment_continuation(HtmlTokenizerState::CommentEndBang, "seed").unwrap();
+    assert_eq!(
+        lex_html_fragment("y-->tail", &comment_end_bang).unwrap(),
+        vec![
+            Token::Comment("seed--!y".to_string()),
+            Token::Text("tail".to_string()),
+            Token::Eof,
+        ]
+    );
+
+    let less_than =
+        HtmlLexContext::comment_continuation(HtmlTokenizerState::CommentLessThanSign, "seed<")
+            .unwrap();
+    assert_eq!(
+        lex_html_fragment("x-->tail", &less_than).unwrap(),
+        vec![
+            Token::Comment("seed<x".to_string()),
+            Token::Text("tail".to_string()),
+            Token::Eof,
+        ]
+    );
+
+    let start_dash =
+        HtmlLexContext::comment_continuation(HtmlTokenizerState::CommentStartDash, "").unwrap();
+    let mut lexer = create_html_lexer_with_context(&start_dash).unwrap();
+    lexer.push(">tail").unwrap();
+    lexer.finish().unwrap();
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Comment(String::new()),
+            Token::Text("tail".to_string()),
+            Token::Eof,
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec!["abrupt-closing-of-empty-comment"]
+    );
+
+    let bogus =
+        HtmlLexContext::comment_continuation(HtmlTokenizerState::BogusComment, "bogus-").unwrap();
+    assert_eq!(
+        lex_html_fragment("tail>after", &bogus).unwrap(),
+        vec![
+            Token::Comment("bogus-tail".to_string()),
+            Token::Text("after".to_string()),
+            Token::Eof,
+        ]
+    );
+
+    assert_eq!(
+        HtmlLexContext::comment_continuation(HtmlTokenizerState::Rcdata, "nope"),
+        None
     );
 }
 

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -43,3 +43,5 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
 - Restricted missing-semicolon named-character-reference recovery to the
   WHATWG legacy no-semicolon aliases instead of accepting every known name
   without `;`.
+- Added current-comment seeding helpers so wrapper packages can resume
+  comment-token continuation states without loading tokenizer definition files.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -126,9 +126,10 @@ duplicates can continue using plain `commit_attribute`.
 
 The runtime also exposes context-seeding helpers such as
 `Tokenizer::set_initial_state`, `Tokenizer::set_last_start_tag`,
-`Tokenizer::set_current_end_tag`, and `Tokenizer::set_temporary_buffer` so
-wrapper packages can execute HTML submodes and continuation states like RCDATA
-end-tag-name without loading definition files at runtime.
+`Tokenizer::set_current_end_tag`, `Tokenizer::set_current_comment`, and
+`Tokenizer::set_temporary_buffer` so wrapper packages can execute HTML submodes
+and continuation states like RCDATA end-tag-name or comment end-dash without
+loading definition files at runtime.
 
 Wrapper packages can opt into HTML-style input-stream newline preprocessing
 with `Tokenizer::with_normalized_carriage_returns`. That maps CRLF pairs and

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -287,6 +287,18 @@ impl Tokenizer {
         self.current_attribute = None;
     }
 
+    /// Seed the in-progress comment token used by tokenizer continuation states.
+    pub fn with_current_comment(mut self, data: impl Into<String>) -> Self {
+        self.set_current_comment(data);
+        self
+    }
+
+    /// Store the in-progress comment token used by tokenizer continuation states.
+    pub fn set_current_comment(&mut self, data: impl Into<String>) {
+        self.current_token = Some(CurrentToken::Comment { data: data.into() });
+        self.current_attribute = None;
+    }
+
     /// Clear any in-progress token construction state.
     pub fn clear_current_token(&mut self) {
         self.current_token = None;


### PR DESCRIPTION
## Summary

- Add tokenizer/runtime seeding for in-progress comment tokens and expose typed HTML comment continuation states.
- Teach the html5lib smoke normalizer and conformance harness to carry `currentComment` / `current_comment` fixture metadata.
- Add generated smoke fixtures and unit coverage for seeded comment body, pending dash/bang, abrupt close, and bogus-comment recovery paths.

## Verification

- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check
