### PR TITLE
[codex] Add Uno R4 native toolchain smoke path

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/BUILD
+++ b/code/packages/rust/board-vm-uno-r4-firmware/BUILD
@@ -1,5 +1,5 @@
 cargo test -p board-vm-uno-r4-firmware -- --nocapture
-RUSTC="$(rustup which rustc)" rustup run stable cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --print-only --port /dev/cu.usbmodem... --upload --smoke
+RUSTC="$(rustup which --toolchain stable rustc)" cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --print-only --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" --arm-toolchain-bin /opt/homebrew/bin --bossac-path /tmp/arduino-bossa/bin --port /dev/cu.usbmodem... --upload --smoke
 rustup target add thumbv7em-none-eabihf
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib
 RUSTC="$(rustup which rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-uart-server

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -148,7 +148,10 @@ small archive under Cargo's `OUT_DIR`, links it with the Uno R4 WiFi `libfsp.a`
 for `uno-r4-wifi-serialusb-server`, and leaves the other firmware binaries on
 the pure-Rust link path. Override `BOARD_VM_UNO_R4_ARM_GCC`,
 `BOARD_VM_UNO_R4_ARM_GXX`, or `BOARD_VM_UNO_R4_ARM_AR` if the Arduino-packaged
-toolchain cannot run on the host.
+toolchain cannot run on the host. When using a native ARM compiler that does
+not carry Newlib/libstdc++ headers, point `BOARD_VM_UNO_R4_ARM_COMPAT_ROOT` at
+Arduino's packaged `arm-none-eabi-gcc/7-2017q4` root so the build script can
+reuse those headers.
 
 For the built-in USB route, the host artifact helper wraps the repeatable
 hardware path: build the linked SerialUSB firmware, convert the ELF to the
@@ -159,6 +162,9 @@ inspect the exact commands:
 ```sh
 cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- \
   --print-only \
+  --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" \
+  --arm-toolchain-bin /opt/homebrew/bin \
+  --bossac-path /tmp/arduino-bossa/bin \
   --port /dev/cu.usbmodem... \
   --upload \
   --smoke
@@ -172,14 +178,18 @@ it, and run the host smoke path:
 ```sh
 cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- \
   --core "$HOME/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3" \
+  --arm-toolchain-bin /opt/homebrew/bin \
+  --bossac-path /tmp/arduino-bossa/bin \
   --port /dev/cu.usbmodem... \
   --upload \
   --smoke
 ```
 
-The helper discovers Rust's bundled `llvm-objcopy` when available. Override
-`--objcopy`, `--arduino-cli`, `--target-dir`, `--baud`, or `--timeout-ms` for
-local tooling differences.
+The helper discovers Rust's bundled `llvm-objcopy`, the stable rustup `rustc`,
+and `arm-none-eabi-*` tools on `PATH` when available. Override `--rustc`,
+`--arm-gcc`, `--arm-gxx`, `--arm-ar`, `--arm-compat-root`, `--objcopy`,
+`--arduino-cli`, `--bossac-path`, `--target-dir`, `--baud`, or `--timeout-ms`
+for local tooling differences.
 
 After flashing any Board VM server image manually, run the host smoke test
 against the adapter serial port:

--- a/code/packages/rust/board-vm-uno-r4-firmware/build.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/build.rs
@@ -9,10 +9,11 @@ mod arduino_usb_link {
 }
 
 use arduino_usb_link::{
-    ArduinoSourceLanguage, ARDUINO_ARM_AR_ENV_VAR, ARDUINO_ARM_GCC_ENV_VAR,
-    ARDUINO_ARM_GXX_ENV_VAR, ARDUINO_CORE_ENV_VAR, ARDUINO_USB_LINK_CFLAGS,
-    ARDUINO_USB_LINK_CXXFLAGS, ARDUINO_USB_LINK_DEFINES, ARDUINO_USB_LINK_ENV_VAR,
-    ARDUINO_USB_LINK_INCLUDE_DIRS, ARDUINO_USB_LINK_SOURCES, UNO_R4_WIFI_FSP_ARCHIVE,
+    ArduinoSourceLanguage, ARDUINO_ARM_AR_ENV_VAR, ARDUINO_ARM_COMPAT_ROOT_ENV_VAR,
+    ARDUINO_ARM_GCC_ENV_VAR, ARDUINO_ARM_GXX_ENV_VAR, ARDUINO_CORE_ENV_VAR,
+    ARDUINO_USB_LINK_CFLAGS, ARDUINO_USB_LINK_CXXFLAGS, ARDUINO_USB_LINK_DEFINES,
+    ARDUINO_USB_LINK_ENV_VAR, ARDUINO_USB_LINK_INCLUDE_DIRS, ARDUINO_USB_LINK_SOURCES,
+    UNO_R4_WIFI_FSP_ARCHIVE,
 };
 
 const UNO_R4_SKETCH_FLASH_ORIGIN: u32 = 0x0000_4000;
@@ -54,6 +55,7 @@ fn emit_rerun_hints() {
     println!("cargo:rerun-if-env-changed={ARDUINO_ARM_GCC_ENV_VAR}");
     println!("cargo:rerun-if-env-changed={ARDUINO_ARM_GXX_ENV_VAR}");
     println!("cargo:rerun-if-env-changed={ARDUINO_ARM_AR_ENV_VAR}");
+    println!("cargo:rerun-if-env-changed={ARDUINO_ARM_COMPAT_ROOT_ENV_VAR}");
 }
 
 fn write_memory_x(out_dir: &Path) {
@@ -73,6 +75,8 @@ fn compile_and_link_arduino_usb(out_dir: &Path) {
     let gcc = resolve_tool(ARDUINO_ARM_GCC_ENV_VAR, &packages_dir, "gcc");
     let gxx = resolve_tool(ARDUINO_ARM_GXX_ENV_VAR, &packages_dir, "g++");
     let ar = resolve_tool(ARDUINO_ARM_AR_ENV_VAR, &packages_dir, "ar");
+    let compat_root = resolve_compat_root(&packages_dir);
+    let compat_header = write_compat_header(out_dir);
 
     let object_dir = out_dir.join("arduino-usb-objects");
     fs::create_dir_all(&object_dir).expect("create Arduino USB object dir");
@@ -91,6 +95,7 @@ fn compile_and_link_arduino_usb(out_dir: &Path) {
                     &source_path,
                     &object,
                     ARDUINO_USB_LINK_CFLAGS,
+                    &c_compat_args(&compat_root),
                 );
                 objects.push(object);
             }
@@ -102,6 +107,7 @@ fn compile_and_link_arduino_usb(out_dir: &Path) {
                     &source_path,
                     &object,
                     ARDUINO_USB_LINK_CXXFLAGS,
+                    &cxx_compat_args(&compat_root, &compat_header),
                 );
                 objects.push(object);
             }
@@ -150,11 +156,13 @@ fn compile_source(
     source_path: &Path,
     object_path: &Path,
     flags: &[&str],
+    compat_args: &[String],
 ) {
     assert_path_exists(source_path, "Arduino source");
 
     let mut command = Command::new(compiler);
     command.args(flags);
+    command.args(compat_args);
     for define in ARDUINO_USB_LINK_DEFINES {
         command.arg(format!("-D{define}"));
     }
@@ -223,6 +231,68 @@ fn resolve_tool(env_var: &str, packages_dir: &Path, suffix: &str) -> PathBuf {
         .join(format!("arm-none-eabi-{suffix}{exe_suffix}"));
     assert_path_exists(&tool, "Arduino ARM tool");
     tool
+}
+
+fn resolve_compat_root(packages_dir: &Path) -> PathBuf {
+    if let Some(path) = env::var_os(ARDUINO_ARM_COMPAT_ROOT_ENV_VAR) {
+        let path = PathBuf::from(path);
+        assert_path_exists(&path, "Arduino ARM compatibility root");
+        return path;
+    }
+
+    let compat_root = packages_dir
+        .join("arduino/tools/arm-none-eabi-gcc")
+        .join(ARDUINO_ARM_GCC_VERSION);
+    assert_path_exists(&compat_root, "Arduino ARM compatibility root");
+    compat_root
+}
+
+fn c_compat_args(compat_root: &Path) -> Vec<String> {
+    let c_include = compat_root.join("arm-none-eabi/include");
+    assert_path_exists(&c_include, "Arduino ARM Newlib include directory");
+
+    vec![
+        "-Wno-error=implicit-function-declaration".to_string(),
+        "-Wno-error=return-mismatch".to_string(),
+        "-include".to_string(),
+        "string.h".to_string(),
+        "-isystem".to_string(),
+        c_include.display().to_string(),
+    ]
+}
+
+fn cxx_compat_args(compat_root: &Path, compat_header: &Path) -> Vec<String> {
+    let cxx_include = compat_root.join("arm-none-eabi/include/c++/7.2.1");
+    let cxx_target_include = cxx_include.join("arm-none-eabi");
+    let c_include = compat_root.join("arm-none-eabi/include");
+
+    assert_path_exists(&cxx_include, "Arduino ARM libstdc++ include directory");
+    assert_path_exists(
+        &cxx_target_include,
+        "Arduino ARM target libstdc++ include directory",
+    );
+    assert_path_exists(&c_include, "Arduino ARM Newlib include directory");
+
+    vec![
+        "-include".to_string(),
+        compat_header.display().to_string(),
+        "-isystem".to_string(),
+        cxx_include.display().to_string(),
+        "-isystem".to_string(),
+        cxx_target_include.display().to_string(),
+        "-isystem".to_string(),
+        c_include.display().to_string(),
+    ]
+}
+
+fn write_compat_header(out_dir: &Path) -> PathBuf {
+    let header = out_dir.join("board_vm_uno_r4_arduino_compat.h");
+    fs::write(
+        &header,
+        "#pragma once\n#include <stddef.h>\n#ifdef __cplusplus\nextern \"C\" {\nvoid *memset(void *, int, size_t);\nvoid *memcpy(void *, const void *, size_t);\nsize_t strlen(const char *);\n}\n#endif\n",
+    )
+    .expect("write Arduino compatibility header");
+    header
 }
 
 fn assert_path_exists(path: &Path, label: &str) {

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -17,6 +17,7 @@ pub const ARDUINO_USB_LINK_ENV_VAR: &str = "BOARD_VM_UNO_R4_LINK_ARDUINO_USB";
 pub const ARDUINO_ARM_GCC_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_GCC";
 pub const ARDUINO_ARM_GXX_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_GXX";
 pub const ARDUINO_ARM_AR_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_AR";
+pub const ARDUINO_ARM_COMPAT_ROOT_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_COMPAT_ROOT";
 
 pub const ARDUINO_USB_START_SYMBOL: &str = "_Z10__USBStartv";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
@@ -189,6 +190,10 @@ mod tests {
         assert_eq!(UNO_R4_WIFI_BOOTLOADER_USB_PID, 0x1002);
         assert_eq!(UNO_R4_WIFI_USB_RHPORT, 0);
         assert_eq!(ARDUINO_USB_LINK_ENV_VAR, "BOARD_VM_UNO_R4_LINK_ARDUINO_USB");
+        assert_eq!(
+            ARDUINO_ARM_COMPAT_ROOT_ENV_VAR,
+            "BOARD_VM_UNO_R4_ARM_COMPAT_ROOT"
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_artifact.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_artifact.rs
@@ -23,10 +23,11 @@ fn main() -> std::process::ExitCode {
         }
     };
 
-    let ArtifactInvocation::Run(run) = invocation else {
+    let ArtifactInvocation::Run(mut run) = invocation else {
         println!("{}", usage());
         return ExitCode::SUCCESS;
     };
+    run.options.fill_host_defaults();
 
     let commands = match run.options.command_plan() {
         Ok(commands) => commands,

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
@@ -8,13 +8,17 @@ use std::process::Command;
 use std::string::{String, ToString};
 use std::vec::Vec;
 
-use crate::arduino_usb_link::{ARDUINO_CORE_ENV_VAR, ARDUINO_USB_LINK_ENV_VAR, UNO_R4_WIFI_FQBN};
+use crate::arduino_usb_link::{
+    ARDUINO_ARM_AR_ENV_VAR, ARDUINO_ARM_COMPAT_ROOT_ENV_VAR, ARDUINO_ARM_GCC_ENV_VAR,
+    ARDUINO_ARM_GXX_ENV_VAR, ARDUINO_CORE_ENV_VAR, ARDUINO_USB_LINK_ENV_VAR, UNO_R4_WIFI_FQBN,
+};
 
 pub const SERIAL_USB_SERVER_BIN: &str = "uno-r4-wifi-serialusb-server";
 pub const TARGET_TRIPLE: &str = "thumbv7em-none-eabihf";
 pub const FIRMWARE_PACKAGE: &str = "board-vm-uno-r4-firmware";
 pub const DEFAULT_BAUD_RATE: u32 = 115_200;
 pub const DEFAULT_TIMEOUT_MS: u64 = 1_000;
+pub const ARDUINO_BOSSAC_PATH_ENV_VAR: &str = "BOARD_VM_UNO_R4_BOSSAC_PATH";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandSpec {
@@ -82,6 +86,12 @@ impl CommandSpec {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SerialUsbArtifactOptions {
     pub arduino_core: Option<PathBuf>,
+    pub rustc: Option<PathBuf>,
+    pub arm_gcc: Option<PathBuf>,
+    pub arm_gxx: Option<PathBuf>,
+    pub arm_ar: Option<PathBuf>,
+    pub arm_compat_root: Option<PathBuf>,
+    pub bossac_path: Option<PathBuf>,
     pub target_dir: PathBuf,
     pub objcopy: PathBuf,
     pub arduino_cli: PathBuf,
@@ -97,6 +107,12 @@ impl Default for SerialUsbArtifactOptions {
     fn default() -> Self {
         Self {
             arduino_core: env::var_os(ARDUINO_CORE_ENV_VAR).map(PathBuf::from),
+            rustc: env::var_os("RUSTC").map(PathBuf::from),
+            arm_gcc: env::var_os(ARDUINO_ARM_GCC_ENV_VAR).map(PathBuf::from),
+            arm_gxx: env::var_os(ARDUINO_ARM_GXX_ENV_VAR).map(PathBuf::from),
+            arm_ar: env::var_os(ARDUINO_ARM_AR_ENV_VAR).map(PathBuf::from),
+            arm_compat_root: env::var_os(ARDUINO_ARM_COMPAT_ROOT_ENV_VAR).map(PathBuf::from),
+            bossac_path: env::var_os(ARDUINO_BOSSAC_PATH_ENV_VAR).map(PathBuf::from),
             target_dir: PathBuf::from("target"),
             objcopy: PathBuf::from("llvm-objcopy"),
             arduino_cli: PathBuf::from("arduino-cli"),
@@ -111,6 +127,29 @@ impl Default for SerialUsbArtifactOptions {
 }
 
 impl SerialUsbArtifactOptions {
+    pub fn fill_host_defaults(&mut self) {
+        if self.rustc.is_none() {
+            self.rustc = resolve_rustup_stable_rustc();
+        }
+
+        if self.arm_gcc.is_none() {
+            self.arm_gcc = find_on_path("arm-none-eabi-gcc");
+        }
+        if self.arm_gxx.is_none() {
+            self.arm_gxx = find_on_path("arm-none-eabi-g++");
+        }
+        if self.arm_ar.is_none() {
+            self.arm_ar = find_on_path("arm-none-eabi-ar");
+        }
+
+        if self.arm_compat_root.is_none() {
+            self.arm_compat_root = self
+                .arduino_core
+                .as_deref()
+                .and_then(arduino_arm_compat_root_from_core);
+        }
+    }
+
     pub fn profile_dir(&self) -> &'static str {
         if self.release {
             "release"
@@ -167,6 +206,21 @@ impl SerialUsbArtifactOptions {
         if let Some(core) = &self.arduino_core {
             command = command.env_path(ARDUINO_CORE_ENV_VAR, core);
         }
+        if let Some(rustc) = &self.rustc {
+            command = command.env_path("RUSTC", rustc);
+        }
+        if let Some(gcc) = &self.arm_gcc {
+            command = command.env_path(ARDUINO_ARM_GCC_ENV_VAR, gcc);
+        }
+        if let Some(gxx) = &self.arm_gxx {
+            command = command.env_path(ARDUINO_ARM_GXX_ENV_VAR, gxx);
+        }
+        if let Some(ar) = &self.arm_ar {
+            command = command.env_path(ARDUINO_ARM_AR_ENV_VAR, ar);
+        }
+        if let Some(root) = &self.arm_compat_root {
+            command = command.env_path(ARDUINO_ARM_COMPAT_ROOT_ENV_VAR, root);
+        }
 
         command
     }
@@ -184,16 +238,23 @@ impl SerialUsbArtifactOptions {
             "--port is required with --upload",
         ))?;
 
-        Ok(
-            CommandSpec::new(self.arduino_cli.as_os_str().to_os_string())
-                .arg("upload")
-                .arg("-p")
-                .arg(port.as_str())
-                .arg("-b")
-                .arg(UNO_R4_WIFI_FQBN)
-                .arg("-i")
-                .arg_path(&self.bin_path()),
-        )
+        let mut command = CommandSpec::new(self.arduino_cli.as_os_str().to_os_string())
+            .arg("upload")
+            .arg("-p")
+            .arg(port.as_str())
+            .arg("-b")
+            .arg(UNO_R4_WIFI_FQBN)
+            .arg("-i")
+            .arg_path(&self.bin_path());
+
+        if let Some(path) = &self.bossac_path {
+            command = command.arg("--upload-property").arg(format!(
+                "runtime.tools.bossac-1.9.1-arduino5.path={}",
+                path.display()
+            ));
+        }
+
+        Ok(command)
     }
 
     fn smoke_command(&self) -> Result<CommandSpec, ArtifactCliError> {
@@ -271,6 +332,28 @@ where
             "--core" => {
                 options.arduino_core = Some(PathBuf::from(next_value(&mut args, "--core")?));
             }
+            "--rustc" => {
+                options.rustc = Some(PathBuf::from(next_value(&mut args, "--rustc")?));
+            }
+            "--arm-toolchain-bin" => {
+                let bin_dir = PathBuf::from(next_value(&mut args, "--arm-toolchain-bin")?);
+                options.arm_gcc = Some(bin_dir.join(executable_name("arm-none-eabi-gcc")));
+                options.arm_gxx = Some(bin_dir.join(executable_name("arm-none-eabi-g++")));
+                options.arm_ar = Some(bin_dir.join(executable_name("arm-none-eabi-ar")));
+            }
+            "--arm-gcc" => {
+                options.arm_gcc = Some(PathBuf::from(next_value(&mut args, "--arm-gcc")?));
+            }
+            "--arm-gxx" => {
+                options.arm_gxx = Some(PathBuf::from(next_value(&mut args, "--arm-gxx")?));
+            }
+            "--arm-ar" => {
+                options.arm_ar = Some(PathBuf::from(next_value(&mut args, "--arm-ar")?));
+            }
+            "--arm-compat-root" => {
+                options.arm_compat_root =
+                    Some(PathBuf::from(next_value(&mut args, "--arm-compat-root")?));
+            }
             "--target-dir" => {
                 options.target_dir = PathBuf::from(next_value(&mut args, "--target-dir")?);
             }
@@ -279,6 +362,9 @@ where
             }
             "--arduino-cli" => {
                 options.arduino_cli = PathBuf::from(next_value(&mut args, "--arduino-cli")?);
+            }
+            "--bossac-path" => {
+                options.bossac_path = Some(PathBuf::from(next_value(&mut args, "--bossac-path")?));
             }
             "--port" | "-p" => {
                 options.port = Some(next_value(&mut args, "--port")?);
@@ -305,12 +391,14 @@ where
 }
 
 pub fn usage() -> &'static str {
-    "usage:\n  uno-r4-wifi-serialusb-artifact [--core <arduino-core>] [--target-dir <dir>] [--objcopy <path>] [--print-only] [--upload --port <path>] [--smoke --port <path>] [--baud <rate>] [--timeout-ms <ms>]"
+    "usage:\n  uno-r4-wifi-serialusb-artifact [--core <arduino-core>] [--rustc <path>] [--arm-toolchain-bin <dir>] [--arm-gcc <path>] [--arm-gxx <path>] [--arm-ar <path>] [--arm-compat-root <dir>] [--target-dir <dir>] [--objcopy <path>] [--arduino-cli <path>] [--bossac-path <dir>] [--print-only] [--upload --port <path>] [--smoke --port <path>] [--baud <rate>] [--timeout-ms <ms>]"
 }
 
 pub fn resolve_rust_llvm_objcopy() -> Option<PathBuf> {
     let rustc_output = Command::new("rustup")
         .arg("which")
+        .arg("--toolchain")
+        .arg("stable")
         .arg("rustc")
         .output()
         .ok()?;
@@ -330,6 +418,37 @@ pub fn resolve_rust_llvm_objcopy() -> Option<PathBuf> {
     let host = detect_host_triple(&version)?;
     let objcopy = rust_llvm_objcopy_path_from_rustc(Path::new(&rustc_path), &host)?;
     objcopy.exists().then_some(objcopy)
+}
+
+pub fn resolve_rustup_stable_rustc() -> Option<PathBuf> {
+    let output = Command::new("rustup")
+        .arg("which")
+        .arg("--toolchain")
+        .arg("stable")
+        .arg("rustc")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!path.is_empty()).then(|| PathBuf::from(path))
+}
+
+pub fn find_on_path(program: &str) -> Option<PathBuf> {
+    let paths = env::var_os("PATH")?;
+    env::split_paths(&paths)
+        .map(|dir| dir.join(executable_name(program)))
+        .find(|candidate| candidate.exists())
+}
+
+pub fn arduino_arm_compat_root_from_core(core_dir: &Path) -> Option<PathBuf> {
+    let packages_dir = core_dir.ancestors().nth(4)?;
+    let root = packages_dir
+        .join("arduino/tools/arm-none-eabi-gcc")
+        .join("7-2017q4");
+    root.exists().then_some(root)
 }
 
 pub fn detect_host_triple(rustc_verbose_version: &str) -> Option<String> {
@@ -394,6 +513,12 @@ mod tests {
     fn options() -> SerialUsbArtifactOptions {
         SerialUsbArtifactOptions {
             arduino_core: Some(PathBuf::from("/arduino/renesas_uno/1.5.3")),
+            rustc: Some(PathBuf::from("/rustup/stable/bin/rustc")),
+            arm_gcc: Some(PathBuf::from("/opt/toolchain/bin/arm-none-eabi-gcc")),
+            arm_gxx: Some(PathBuf::from("/opt/toolchain/bin/arm-none-eabi-g++")),
+            arm_ar: Some(PathBuf::from("/opt/toolchain/bin/arm-none-eabi-ar")),
+            arm_compat_root: Some(PathBuf::from("/arduino/tools/arm-none-eabi-gcc/7-2017q4")),
+            bossac_path: Some(PathBuf::from("/tmp/arduino-bossa/bin")),
             target_dir: PathBuf::from("target"),
             objcopy: PathBuf::from("/rust/llvm-objcopy"),
             arduino_cli: PathBuf::from("arduino-cli"),
@@ -444,6 +569,26 @@ mod tests {
             OsString::from(ARDUINO_CORE_ENV_VAR),
             OsString::from("/arduino/renesas_uno/1.5.3")
         )));
+        assert!(build.env.contains(&(
+            OsString::from("RUSTC"),
+            OsString::from("/rustup/stable/bin/rustc")
+        )));
+        assert!(build.env.contains(&(
+            OsString::from(ARDUINO_ARM_GCC_ENV_VAR),
+            OsString::from("/opt/toolchain/bin/arm-none-eabi-gcc")
+        )));
+        assert!(build.env.contains(&(
+            OsString::from(ARDUINO_ARM_GXX_ENV_VAR),
+            OsString::from("/opt/toolchain/bin/arm-none-eabi-g++")
+        )));
+        assert!(build.env.contains(&(
+            OsString::from(ARDUINO_ARM_AR_ENV_VAR),
+            OsString::from("/opt/toolchain/bin/arm-none-eabi-ar")
+        )));
+        assert!(build.env.contains(&(
+            OsString::from(ARDUINO_ARM_COMPAT_ROOT_ENV_VAR),
+            OsString::from("/arduino/tools/arm-none-eabi-gcc/7-2017q4")
+        )));
     }
 
     #[test]
@@ -482,6 +627,8 @@ mod tests {
                 UNO_R4_WIFI_FQBN,
                 "-i",
                 "target/thumbv7em-none-eabihf/release/uno-r4-wifi-serialusb-server.bin",
+                "--upload-property",
+                "runtime.tools.bossac-1.9.1-arduino5.path=/tmp/arduino-bossa/bin",
             ]
         );
         assert_eq!(
@@ -522,10 +669,18 @@ mod tests {
                 "--print-only",
                 "--core",
                 "/core",
+                "--rustc",
+                "/rustc",
+                "--arm-toolchain-bin",
+                "/native/bin",
+                "--arm-compat-root",
+                "/compat",
                 "--target-dir",
                 "out",
                 "--objcopy",
                 "/bin/llvm-objcopy",
+                "--bossac-path",
+                "/bossac/bin",
                 "--port",
                 "/dev/cu.usbmodem-test",
                 "--upload",
@@ -545,8 +700,23 @@ mod tests {
 
         assert!(run.print_only);
         assert_eq!(run.options.arduino_core, Some(PathBuf::from("/core")));
+        assert_eq!(run.options.rustc, Some(PathBuf::from("/rustc")));
+        assert_eq!(
+            run.options.arm_gcc,
+            Some(PathBuf::from("/native/bin/arm-none-eabi-gcc"))
+        );
+        assert_eq!(
+            run.options.arm_gxx,
+            Some(PathBuf::from("/native/bin/arm-none-eabi-g++"))
+        );
+        assert_eq!(
+            run.options.arm_ar,
+            Some(PathBuf::from("/native/bin/arm-none-eabi-ar"))
+        );
+        assert_eq!(run.options.arm_compat_root, Some(PathBuf::from("/compat")));
         assert_eq!(run.options.target_dir, PathBuf::from("out"));
         assert_eq!(run.options.objcopy, PathBuf::from("/bin/llvm-objcopy"));
+        assert_eq!(run.options.bossac_path, Some(PathBuf::from("/bossac/bin")));
         assert_eq!(run.options.port, Some("/dev/cu.usbmodem-test".to_string()));
         assert!(run.options.upload);
         assert!(run.options.smoke);
@@ -569,6 +739,16 @@ mod tests {
             PathBuf::from(
                 "/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-objcopy"
             )
+        );
+    }
+
+    #[test]
+    fn derives_arduino_arm_compat_root_from_core_dir() {
+        assert_eq!(
+            arduino_arm_compat_root_from_core(Path::new(
+                "/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3"
+            )),
+            None
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add native ARM GCC override support for the Uno R4 SerialUSB artifact helper, including explicit `--arm-toolchain-bin`, `--arm-gcc`, `--arm-gxx`, `--arm-ar`, `--arm-compat-root`, `--rustc`, and `--bossac-path` options.
- Teach the firmware build script to compile Arduino/TinyUSB C/C++ objects with a modern host ARM GCC while reusing the Arduino Renesas core's packaged compatibility headers.
- Document the Apple Silicon-friendly toolchain/upload path for producing and uploading the Uno R4 SerialUSB server artifact.

## Validation

- `cargo fmt -p board-vm-uno-r4-firmware -- --check`
- `cargo test -p board-vm-uno-r4-firmware -- --nocapture`
- `RUSTC="$(rustup which --toolchain stable rustc)" rustup run stable cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --lib`
- Built the Uno R4 SerialUSB server artifact locally with Homebrew `arm-none-eabi-gcc` and the Arduino Renesas Uno core.
- Uploaded the generated `.bin` to the plugged-in Arduino Uno R4 WiFi via `arduino-cli` using the locally built Arduino-patched `bossac`.

## Hardware note

The direct upload path succeeded, but the post-upload Board VM smoke currently fails with `Transport(Io)`. After upload, the board is still enumerating as `UNO WiFi R4 CMSIS-DAP` with PID `0x1002`, so the next bundle should debug runtime re-enumeration or early SerialUSB firmware startup.
