### PR TITLE
[codex] Fix Uno R4 USB mux startup hooks

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -111,8 +111,9 @@ Arduino/TinyUSB link layer is wired in.
 The Rust entrypoint now starts Arduino Renesas USB through the `__USBStart()`
 C++ ABI symbol exposed by the Arduino core. The `board-vm-uno-r4-usb-cdc`
 backend supplies the serial-install descriptor hook and the Uno R4 WiFi USB-C
-mux hook from Rust, so the final link set does not need Arduino's full
-`SerialUSB.cpp` object or WiFi `variant.cpp` just to expose CDC.
+mux and USB post-initialization hooks from Rust, so the final link set does not
+need Arduino's full `SerialUSB.cpp` object or WiFi `variant.cpp` just to expose
+CDC.
 
 `src/arduino_usb_link.rs` records the Arduino Renesas/TinyUSB link contract for
 the built-in USB path: Arduino core version `1.5.3`, FQBN

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/arduino_usb_link.rs
@@ -22,6 +22,7 @@ pub const ARDUINO_ARM_COMPAT_ROOT_ENV_VAR: &str = "BOARD_VM_UNO_R4_ARM_COMPAT_RO
 pub const ARDUINO_USB_START_SYMBOL: &str = "_Z10__USBStartv";
 pub const RUST_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const RUST_USB_CONFIGURE_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
+pub const RUST_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
 
 pub const UNO_R4_WIFI_FSP_ARCHIVE: &str = "variants/UNOWIFIR4/libs/libfsp.a";
 pub const UNO_R4_WIFI_FSP_LINKER_SCRIPT: &str = "variants/UNOWIFIR4/fsp.ld";
@@ -155,10 +156,13 @@ pub const ARDUINO_USB_LINK_CXXFLAGS: &[&str] = &[
 pub const RUST_PROVIDED_USB_SYMBOLS: &[&str] = &[
     RUST_USB_INSTALL_SERIAL_SYMBOL,
     RUST_USB_CONFIGURE_MUX_SYMBOL,
+    RUST_USB_POST_INITIALIZATION_SYMBOL,
 ];
 
 pub const ARDUINO_PROVIDED_USB_SYMBOLS: &[&str] = &[
     ARDUINO_USB_START_SYMBOL,
+    "R_IOPORT_PinCfg",
+    "R_IOPORT_PinWrite",
     "tud_task_ext",
     "tud_cdc_n_connected",
     "tud_cdc_n_get_line_state",
@@ -229,6 +233,9 @@ mod tests {
         assert_eq!(ARDUINO_USB_START_SYMBOL, "_Z10__USBStartv");
         assert!(RUST_PROVIDED_USB_SYMBOLS.contains(&"_Z18__USBInstallSerialv"));
         assert!(RUST_PROVIDED_USB_SYMBOLS.contains(&"_Z17configure_usb_muxv"));
+        assert!(RUST_PROVIDED_USB_SYMBOLS.contains(&"_Z23usb_post_initializationv"));
+        assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"R_IOPORT_PinCfg"));
+        assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"R_IOPORT_PinWrite"));
         assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"tud_cdc_n_read"));
         assert!(ARDUINO_PROVIDED_USB_SYMBOLS.contains(&"tud_cdc_n_write_flush"));
     }

--- a/code/packages/rust/board-vm-uno-r4-usb-cdc/README.md
+++ b/code/packages/rust/board-vm-uno-r4-usb-cdc/README.md
@@ -16,8 +16,19 @@ host-testable. The ARM FFI backend targets TinyUSB's `tud_cdc_n_*` symbols and
 then marks the CDC stream as ready. The crate also provides the C++-mangled
 `__USBInstallSerial()` hook so Arduino's descriptor builder includes the CDC
 interface without linking the full `SerialUSB.cpp` object, and it overrides the
-Uno R4 WiFi `configure_usb_mux()` weak hook with direct RA4M1 register writes so
-the USB-C connector is routed to the RA4M1 USB peripheral.
+Uno R4 WiFi `configure_usb_mux()` weak hook so the USB-C connector is routed to
+the RA4M1 USB peripheral. It also overrides the variant
+`usb_post_initialization()` hook to enable the RA4M1 USB regulator bit after
+TinyUSB initialization, matching the Arduino Uno R4 WiFi variant startup. The
+mux hook calls the same FSP `R_IOPORT_PinCfg`/`R_IOPORT_PinWrite` path that
+Arduino's `pinMode(21, OUTPUT); digitalWrite(21, HIGH);` sequence uses, without
+linking the full WiFi `variant.cpp` object.
+
+For hardware smoke tests, a board that still enumerates as VID/PID
+`2341:1002` after upload has not handed USB-C off from the bridge. If the bridge
+port disappears but the host sees an unmatched USB device stuck before CDC port
+creation, the mux hook ran and the remaining failure is in RA4M1 USB device
+enumeration.
 
 The Arduino descriptor builder allocates its configuration descriptor at USB
 startup. Because the Rust firmware links without a C runtime allocator, this

--- a/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
@@ -16,6 +16,7 @@ pub const UNO_R4_WIFI_USB_MAX_PACKET_BYTES: usize = USB_CDC_FULL_SPEED_MAX_PACKE
 pub const ARDUINO_RENESAS_USB_START_SYMBOL: &str = "_Z10__USBStartv";
 pub const ARDUINO_RENESAS_USB_INSTALL_SERIAL_SYMBOL: &str = "_Z18__USBInstallSerialv";
 pub const UNO_R4_WIFI_CONFIGURE_USB_MUX_SYMBOL: &str = "_Z17configure_usb_muxv";
+pub const UNO_R4_WIFI_USB_POST_INITIALIZATION_SYMBOL: &str = "_Z23usb_post_initializationv";
 pub const UNO_R4_WIFI_USB_DESCRIPTOR_HEAP_BYTES: usize = 512;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -321,24 +322,29 @@ pub extern "C" fn arduino_uno_r4_wifi_configure_usb_mux() {
 }
 
 #[cfg(target_arch = "arm")]
+#[unsafe(export_name = "_Z23usb_post_initializationv")]
+pub extern "C" fn arduino_uno_r4_wifi_usb_post_initialization() {
+    unsafe {
+        uno_r4_wifi_usb_mux::enable_ra4m1_usb_regulator();
+    }
+}
+
+#[cfg(target_arch = "arm")]
 mod uno_r4_wifi_usb_mux {
-    use core::ptr::{read_volatile, write_volatile};
+    use core::ptr::{null_mut, read_volatile, write_volatile};
 
     const SYSTEM_PRCR: *mut u16 = 0x4001_E3FE as *mut u16;
     const SYSTEM_VBTBKR1: *mut u8 = 0x4001_E501 as *mut u8;
-    const PORT4_PCNTR1: *mut u32 = 0x4004_0080 as *mut u32;
-    const PORT4_PORR: *mut u16 = 0x4004_0088 as *mut u16;
-    const PMISC_PWPR: *mut u8 = 0x4004_0D03 as *mut u8;
-    const PFS_P408: *mut u32 = 0x4004_0920 as *mut u32;
+    const USBFS_USBMC: *mut u16 = 0x4009_00CC as *mut u16;
 
     const PRCR_KEY: u16 = 0xA500;
     const PRCR_PRC1_UNLOCK: u16 = PRCR_KEY | 0x0002;
     const PRCR_LOCK: u16 = PRCR_KEY;
     const USB_MUX_BACKUP_MARKER: u8 = 40;
-    const USB_SWITCH_MASK: u16 = 1 << 8;
-    const PWPR_B0WI: u8 = 1 << 7;
-    const PWPR_PFSWE: u8 = 1 << 6;
-    const PFS_PDR_OUTPUT: u32 = 1 << 2;
+    const USB_SWITCH_PIN_P408: u16 = 0x0408;
+    const IOPORT_CFG_PORT_DIRECTION_OUTPUT: u32 = 0x0000_0004;
+    const BSP_IO_LEVEL_HIGH: u32 = 1;
+    const USBMC_VDCEN: u16 = 1 << 7;
 
     pub unsafe fn route_usb_c_to_ra4m1() {
         unlock_system_registers();
@@ -348,15 +354,19 @@ mod uno_r4_wifi_usb_mux {
         write_volatile(SYSTEM_VBTBKR1.add(3), 0);
         lock_system_registers();
 
-        enable_pfs_writes();
-        write_volatile(PFS_P408, PFS_PDR_OUTPUT);
-        disable_pfs_writes();
+        unsafe {
+            ffi::R_IOPORT_PinCfg(
+                null_mut(),
+                USB_SWITCH_PIN_P408,
+                IOPORT_CFG_PORT_DIRECTION_OUTPUT,
+            );
+            ffi::R_IOPORT_PinWrite(null_mut(), USB_SWITCH_PIN_P408, BSP_IO_LEVEL_HIGH);
+        }
+    }
 
-        let mut pcntr1 = read_volatile(PORT4_PCNTR1);
-        pcntr1 |= USB_SWITCH_MASK as u32;
-        pcntr1 &= !((USB_SWITCH_MASK as u32) << 16);
-        write_volatile(PORT4_PCNTR1, pcntr1);
-        write_volatile(PORT4_PORR, USB_SWITCH_MASK);
+    pub unsafe fn enable_ra4m1_usb_regulator() {
+        let usbmc = read_volatile(USBFS_USBMC);
+        write_volatile(USBFS_USBMC, usbmc | USBMC_VDCEN);
     }
 
     unsafe fn unlock_system_registers() {
@@ -367,18 +377,11 @@ mod uno_r4_wifi_usb_mux {
         write_volatile(SYSTEM_PRCR, PRCR_LOCK);
     }
 
-    unsafe fn enable_pfs_writes() {
-        let mut pwpr = read_volatile(PMISC_PWPR);
-        pwpr &= !PWPR_B0WI;
-        write_volatile(PMISC_PWPR, pwpr);
-        write_volatile(PMISC_PWPR, pwpr | PWPR_PFSWE);
-    }
-
-    unsafe fn disable_pfs_writes() {
-        let mut pwpr = read_volatile(PMISC_PWPR);
-        pwpr &= !PWPR_B0WI;
-        write_volatile(PMISC_PWPR, pwpr);
-        write_volatile(PMISC_PWPR, pwpr & !PWPR_PFSWE);
+    mod ffi {
+        unsafe extern "C" {
+            pub fn R_IOPORT_PinCfg(p_ctrl: *mut core::ffi::c_void, pin: u16, cfg: u32) -> i32;
+            pub fn R_IOPORT_PinWrite(p_ctrl: *mut core::ffi::c_void, pin: u16, level: u32) -> i32;
+        }
     }
 }
 
@@ -606,6 +609,10 @@ mod tests {
         assert_eq!(
             UNO_R4_WIFI_CONFIGURE_USB_MUX_SYMBOL,
             "_Z17configure_usb_muxv"
+        );
+        assert_eq!(
+            UNO_R4_WIFI_USB_POST_INITIALIZATION_SYMBOL,
+            "_Z23usb_post_initializationv"
         );
         assert_eq!(UNO_R4_WIFI_USB_DESCRIPTOR_HEAP_BYTES, 512);
     }


### PR DESCRIPTION
## Summary

- Add the Uno R4 WiFi `usb_post_initialization()` Rust hook so the SerialUSB firmware enables the RA4M1 USB regulator bit after TinyUSB initialization.
- Replace the hand-written P408 mux register sequence with Arduino's FSP `R_IOPORT_PinCfg`/`R_IOPORT_PinWrite` path, matching the WiFi variant's `pinMode(21, OUTPUT); digitalWrite(21, HIGH);` behavior.
- Extend the Arduino/TinyUSB link manifest and docs so the required Rust-provided and Arduino-provided symbols are explicit.

## Hardware status

- Built and uploaded the SerialUSB server on the plugged-in Uno R4 WiFi while iterating on this branch.
- The board no longer stays on the bridge/CMSIS-DAP `2341:1002` path after the FSP mux handoff; the previous `/dev/cu.usbmodem*` bridge port disappears.
- macOS then sees an unmatched USB device stuck before CDC port creation (`UsbEnumerationState=1`), so the remaining real-hardware blocker is RA4M1 USB device enumeration rather than USB-C mux routing.

## Validation

- `cargo fmt -p board-vm-uno-r4-usb-cdc -p board-vm-uno-r4-firmware -- --check`
- `cargo test -p board-vm-uno-r4-usb-cdc -- --nocapture`
- `cargo test -p board-vm-uno-r4-firmware -- --nocapture`
- `cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --core /Users/adhithya/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3 --arm-toolchain-bin /opt/homebrew/bin --bossac-path /tmp/arduino-bossa/bin`
- `arm-none-eabi-nm -C target/thumbv7em-none-eabihf/release/uno-r4-wifi-serialusb-server | rg "configure_usb_mux|usb_post_initialization|R_IOPORT_PinCfg|R_IOPORT_PinWrite|__USBInstallSerial|__USBStart"`
