### PR TITLE
Make Board VM serial smoke robust for USB CDC

### DIFF
--- a/code/packages/rust/board-vm-cli/Cargo.toml
+++ b/code/packages/rust/board-vm-cli/Cargo.toml
@@ -6,6 +6,7 @@ description = "Command-line smoke tools for Board VM hardware sessions"
 
 [dependencies]
 board-vm-client = { path = "../board-vm-client" }
+board-vm-host = { path = "../board-vm-host" }
 board-vm-serial = { path = "../board-vm-serial" }
 
 [lib]

--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -18,4 +18,8 @@ cargo run -p board-vm-cli --bin board-vm -- smoke \
 `smoke` opens the selected serial device, sends `HELLO`, queries capabilities,
 uploads the standard onboard LED blink module, and starts it with a bounded
 instruction budget. It is transport-hosting glue only; the board firmware still
-owns the protocol dispatcher and HAL behavior.
+owns the protocol dispatcher and HAL behavior. The smoke path asserts DTR on
+open, waits briefly, and clears the serial buffers before the first request so
+USB CDC boards start each run from a clean host session. Its default run budget
+is intentionally small because the current firmware executes blink bytecode
+synchronously while it prepares the run report.

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -4,15 +4,17 @@ use std::time::Duration;
 use board_vm_client::{
     BoardDescriptorInfo, BoardVmClient, ClientError, HelloAckInfo, RunReportInfo,
 };
+use board_vm_host::{write_blink_module, BlinkProgram, BLINK_MODULE_LEN};
 use board_vm_serial::{
     available_ports, BoardSerialTransport, SerialConfig, SerialPortInfo, SerialTransportError,
     DEFAULT_BAUD_RATE, DEFAULT_TIMEOUT_MS,
 };
 
 pub const DEFAULT_PROGRAM_ID: u16 = 1;
-pub const DEFAULT_INSTRUCTION_BUDGET: u32 = 100;
+pub const DEFAULT_INSTRUCTION_BUDGET: u32 = 12;
 pub const DEFAULT_HOST_NONCE: u32 = 0xB0A2_D001;
 pub const DEFAULT_HOST_NAME: &str = "board-vm-cli";
+pub const DEFAULT_OPEN_SETTLE_MS: u64 = 250;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CliCommand {
@@ -36,6 +38,9 @@ impl SmokeOptions {
         SerialConfig::new(&self.port)
             .baud_rate(self.baud_rate)
             .timeout(Duration::from_millis(self.timeout_ms))
+            .dtr_on_open(true)
+            .clear_on_open(true)
+            .settle_on_open(Duration::from_millis(DEFAULT_OPEN_SETTLE_MS))
     }
 }
 
@@ -45,10 +50,17 @@ pub enum CliError {
     UnknownCommand(String),
     MissingValue(&'static str),
     MissingRequired(&'static str),
-    InvalidNumber { option: &'static str, value: String },
+    InvalidNumber {
+        option: &'static str,
+        value: String,
+    },
     UnknownOption(String),
     Serial(String),
     Client(ClientError),
+    Smoke {
+        stage: SmokeStage,
+        source: ClientError,
+    },
 }
 
 impl fmt::Display for CliError {
@@ -64,6 +76,7 @@ impl fmt::Display for CliError {
             Self::UnknownOption(option) => write!(f, "unknown option: {option}"),
             Self::Serial(error) => write!(f, "serial error: {error}"),
             Self::Client(error) => write!(f, "client error: {error:?}"),
+            Self::Smoke { stage, source } => write!(f, "smoke failed during {stage}: {source:?}"),
         }
     }
 }
@@ -167,12 +180,58 @@ pub struct SmokeReport {
     pub run: RunReportInfo,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmokeStage {
+    Hello,
+    Capabilities,
+    UploadBlink,
+    RunBlink,
+}
+
+impl fmt::Display for SmokeStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hello => write!(f, "hello"),
+            Self::Capabilities => write!(f, "capabilities"),
+            Self::UploadBlink => write!(f, "blink upload"),
+            Self::RunBlink => write!(f, "blink run"),
+        }
+    }
+}
+
 pub fn run_smoke(options: &SmokeOptions) -> Result<SmokeReport, CliError> {
     let transport = BoardSerialTransport::<_, 1024>::open(&options.serial_config())?;
     let mut client: BoardVmClient<_, 512, 768, 768> = BoardVmClient::new(transport);
-    let hello = client.hello_with_name(DEFAULT_HOST_NAME, options.host_nonce)?;
-    let descriptor = client.query_caps()?;
-    let run = client.blink_onboard_led(options.program_id, options.instruction_budget)?;
+    let hello = client
+        .hello_with_name(DEFAULT_HOST_NAME, options.host_nonce)
+        .map_err(|source| CliError::Smoke {
+            stage: SmokeStage::Hello,
+            source,
+        })?;
+    let descriptor = client.query_caps().map_err(|source| CliError::Smoke {
+        stage: SmokeStage::Capabilities,
+        source,
+    })?;
+    let mut module = [0u8; BLINK_MODULE_LEN];
+    let module_len =
+        write_blink_module(BlinkProgram::onboard_led(), &mut module).map_err(|source| {
+            CliError::Smoke {
+                stage: SmokeStage::UploadBlink,
+                source: source.into(),
+            }
+        })?;
+    client
+        .upload_program(options.program_id, &module[..module_len])
+        .map_err(|source| CliError::Smoke {
+            stage: SmokeStage::UploadBlink,
+            source,
+        })?;
+    let run = client
+        .run_background(options.program_id, options.instruction_budget)
+        .map_err(|source| CliError::Smoke {
+            stage: SmokeStage::RunBlink,
+            source,
+        })?;
     Ok(SmokeReport {
         hello,
         descriptor,
@@ -243,6 +302,30 @@ mod tests {
                 instruction_budget: 200,
                 host_nonce: 1234,
             })
+        );
+    }
+
+    #[test]
+    fn smoke_serial_config_asserts_dtr_and_clears_stale_bytes() {
+        let options = SmokeOptions {
+            port: "/dev/cu.usbmodem-test".to_owned(),
+            baud_rate: 57_600,
+            timeout_ms: 250,
+            program_id: 7,
+            instruction_budget: 200,
+            host_nonce: 1234,
+        };
+
+        let config = options.serial_config();
+
+        assert_eq!(config.path, "/dev/cu.usbmodem-test");
+        assert_eq!(config.baud_rate, 57_600);
+        assert_eq!(config.timeout, Duration::from_millis(250));
+        assert_eq!(config.dtr_on_open, Some(true));
+        assert!(config.clear_on_open);
+        assert_eq!(
+            config.settle_on_open,
+            Duration::from_millis(DEFAULT_OPEN_SETTLE_MS)
         );
     }
 

--- a/code/packages/rust/board-vm-serial/README.md
+++ b/code/packages/rust/board-vm-serial/README.md
@@ -20,3 +20,7 @@ let hello = client.hello(0x1234_5678)?;
 
 The crate does not assume Arduino, USB CDC, or UART semantics beyond "a byte
 stream with read/write timeouts". Board detection and flashing remain separate.
+Hosts that need CDC-style connection signaling can opt into
+`SerialConfig::dtr_on_open(true)`, and smoke tools can request
+`clear_on_open(true)` plus a short `settle_on_open(...)` delay to drop stale
+bytes before a fresh protocol session.

--- a/code/packages/rust/board-vm-serial/src/lib.rs
+++ b/code/packages/rust/board-vm-serial/src/lib.rs
@@ -3,7 +3,9 @@ use std::time::Duration;
 
 use board_vm_client::{RawFrameTransport, TransportError};
 use board_vm_stream::{StreamTransport, StreamTransportError};
-pub use serialport::{DataBits, FlowControl, Parity, SerialPort, SerialPortInfo, StopBits};
+pub use serialport::{
+    ClearBuffer, DataBits, FlowControl, Parity, SerialPort, SerialPortInfo, StopBits,
+};
 
 pub const DEFAULT_BAUD_RATE: u32 = 115_200;
 pub const DEFAULT_TIMEOUT_MS: u64 = 1_000;
@@ -17,6 +19,9 @@ pub struct SerialConfig {
     pub flow_control: FlowControl,
     pub parity: Parity,
     pub stop_bits: StopBits,
+    pub dtr_on_open: Option<bool>,
+    pub clear_on_open: bool,
+    pub settle_on_open: Duration,
 }
 
 impl SerialConfig {
@@ -29,6 +34,9 @@ impl SerialConfig {
             flow_control: FlowControl::None,
             parity: Parity::None,
             stop_bits: StopBits::One,
+            dtr_on_open: None,
+            clear_on_open: false,
+            settle_on_open: Duration::ZERO,
         }
     }
 
@@ -61,11 +69,32 @@ impl SerialConfig {
         self.stop_bits = stop_bits;
         self
     }
+
+    pub fn dtr_on_open(mut self, dtr_on_open: bool) -> Self {
+        self.dtr_on_open = Some(dtr_on_open);
+        self
+    }
+
+    pub fn preserve_dtr_on_open(mut self) -> Self {
+        self.dtr_on_open = None;
+        self
+    }
+
+    pub fn clear_on_open(mut self, clear_on_open: bool) -> Self {
+        self.clear_on_open = clear_on_open;
+        self
+    }
+
+    pub fn settle_on_open(mut self, settle_on_open: Duration) -> Self {
+        self.settle_on_open = settle_on_open;
+        self
+    }
 }
 
 #[derive(Debug)]
 pub enum SerialTransportError {
     Open(serialport::Error),
+    Configure(serialport::Error),
     Stream(StreamTransportError),
 }
 
@@ -128,14 +157,29 @@ impl<S, const WIRE_BYTES: usize> BoardSerialTransport<S, WIRE_BYTES> {
 
 impl<const WIRE_BYTES: usize> BoardSerialTransport<Box<dyn SerialPort>, WIRE_BYTES> {
     pub fn open(config: &SerialConfig) -> Result<Self, SerialTransportError> {
-        let port = serialport::new(&config.path, config.baud_rate)
+        let mut builder = serialport::new(&config.path, config.baud_rate)
             .timeout(config.timeout)
             .data_bits(config.data_bits)
             .flow_control(config.flow_control)
             .parity(config.parity)
-            .stop_bits(config.stop_bits)
-            .open()
-            .map_err(SerialTransportError::Open)?;
+            .stop_bits(config.stop_bits);
+
+        if let Some(dtr_on_open) = config.dtr_on_open {
+            builder = builder.dtr_on_open(dtr_on_open);
+        }
+
+        let port = builder.open().map_err(SerialTransportError::Open)?;
+        if config.clear_on_open {
+            port.clear(ClearBuffer::All)
+                .map_err(SerialTransportError::Configure)?;
+        }
+        if !config.settle_on_open.is_zero() {
+            std::thread::sleep(config.settle_on_open);
+            if config.clear_on_open {
+                port.clear(ClearBuffer::All)
+                    .map_err(SerialTransportError::Configure)?;
+            }
+        }
         Ok(Self::from_stream(port))
     }
 }
@@ -261,6 +305,9 @@ mod tests {
         assert_eq!(config.flow_control, FlowControl::None);
         assert_eq!(config.parity, Parity::None);
         assert_eq!(config.stop_bits, StopBits::One);
+        assert_eq!(config.dtr_on_open, None);
+        assert!(!config.clear_on_open);
+        assert_eq!(config.settle_on_open, Duration::ZERO);
     }
 
     #[test]
@@ -271,7 +318,10 @@ mod tests {
             .data_bits(DataBits::Seven)
             .flow_control(FlowControl::Software)
             .parity(Parity::Even)
-            .stop_bits(StopBits::Two);
+            .stop_bits(StopBits::Two)
+            .dtr_on_open(true)
+            .clear_on_open(true)
+            .settle_on_open(Duration::from_millis(50));
 
         assert_eq!(config.path, "COM7");
         assert_eq!(config.baud_rate, 230_400);
@@ -280,6 +330,18 @@ mod tests {
         assert_eq!(config.flow_control, FlowControl::Software);
         assert_eq!(config.parity, Parity::Even);
         assert_eq!(config.stop_bits, StopBits::Two);
+        assert_eq!(config.dtr_on_open, Some(true));
+        assert!(config.clear_on_open);
+        assert_eq!(config.settle_on_open, Duration::from_millis(50));
+    }
+
+    #[test]
+    fn config_builder_can_preserve_dtr_after_override() {
+        let config = SerialConfig::new("COM7")
+            .dtr_on_open(true)
+            .preserve_dtr_on_open();
+
+        assert_eq!(config.dtr_on_open, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add serial config knobs for DTR-on-open, stale-buffer clearing, and a short open-settle delay
- make the CLI smoke assert DTR, drain stale CDC bytes, and report the failed smoke stage
- lower the default blink run budget so the synchronous Uno R4 firmware returns a run report promptly

## Validation

- cargo fmt -p board-vm-serial -p board-vm-cli -- --check
- cargo test -p board-vm-serial -- --nocapture
- cargo test -p board-vm-cli -- --nocapture
- live Uno R4 WiFi smoke over /dev/tty.usbmodem1101: HELLO, CAPS, upload, blink run passed
- live Uno R4 WiFi smoke over /dev/cu.usbmodem1101: HELLO, CAPS, upload, blink run passed

## Hardware notes

The uploaded SerialUSB firmware now enumerates as Arduino UNO R4 WiFi PID 0x006D. A long default run budget could outlive the host timeout because the current firmware executes blink bytecode synchronously while sleeping; the smoke default now uses a small budget for a fast, repeatable hardware check.
