### PR TITLE
Add parser tokenizer fragment contexts

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -35,9 +35,16 @@ documented in this file.
 - Parser-approved initial tokenizer contexts now include RCDATA, RAWTEXT,
   script data, and escaped script end-tag-open substates exposed by the lexer,
   keeping parser fragment handoff aligned with the broader tokenizer surface.
+- Parser-approved initial tokenizer contexts now include PLAINTEXT fragments,
+  allowing parser-approved resumptions that consume all remaining input as text
+  through EOF.
 - Parser-approved initial tokenizer contexts now include seeded RCDATA, RAWTEXT,
   script data, and escaped script end-tag continuation substates, carrying the
   current end tag and temporary buffer required by those lexer states.
+- Parser-approved initial tokenizer contexts now include seeded HTML comment
+  continuation substates, carrying current comment data through comment body,
+  pending dash/bang, nested-comment, abrupt-close, and bogus-comment recovery
+  paths exposed by the lexer.
 - Initial table tree-construction recovery for omitted `tbody`/`tr` structure,
   including implicit row groups for bare rows/cells and section closure when a
   new table section starts.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -36,9 +36,9 @@ This first slice intentionally starts small:
 - parser options for scripting-sensitive tokenizer handoff, including
   `noscript`
 - parser-approved initial tokenizer contexts for data-state documents and
-  RCDATA/RAWTEXT, foreign-content CDATA, script-state, and intermediate
-  tokenizer fragments exposed by the lexer, including resumable end-tag-open
-  and seeded end-tag continuation states
+  RCDATA/RAWTEXT, PLAINTEXT, foreign-content CDATA, comment, script-state, and
+  intermediate tokenizer fragments exposed by the lexer, including resumable
+  end-tag-open, seeded end-tag continuation, and seeded comment continuation
   contexts
 - simple implied end tags for `p`, `li`, `dt`, `dd`, `option`, `optgroup`,
   ruby annotations, heading elements, legacy paragraph/block boundaries, and
@@ -98,6 +98,15 @@ let script_fragment = parse_html_with_options(
     "if (a < b) { run(); }</script><p>done</p>",
     HtmlParseOptions {
         initial_tokenizer_context: HtmlInitialTokenizerContext::ScriptData,
+        ..HtmlParseOptions::default()
+    },
+)
+.unwrap();
+
+let comment_fragment = parse_html_with_options(
+    " body --><p>done</p>",
+    HtmlParseOptions {
+        initial_tokenizer_context: HtmlInitialTokenizerContext::Comment,
         ..HtmlParseOptions::default()
     },
 )

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -46,9 +46,21 @@ pub enum HtmlInitialTokenizerContext {
     RawtextEndTagWhitespace,
     RawtextEndTagAttributes,
     RawtextSelfClosingEndTag,
+    Plaintext,
     ForeignContentCdataSection,
     ForeignContentCdataSectionBracket,
     ForeignContentCdataSectionEnd,
+    CommentStart,
+    CommentStartDash,
+    Comment,
+    CommentLessThanSign,
+    CommentLessThanSignBang,
+    CommentLessThanSignBangDash,
+    CommentLessThanSignBangDashDash,
+    CommentEndDash,
+    CommentEnd,
+    CommentEndBang,
+    BogusComment,
     ScriptData,
     ScriptDataLessThanSign,
     ScriptDataEndTagOpen,
@@ -131,12 +143,42 @@ impl HtmlInitialTokenizerContext {
                 "style",
                 "style",
             ),
+            Self::Plaintext => HtmlLexContext::new(HtmlTokenizerState::Plaintext),
             Self::ForeignContentCdataSection => HtmlLexContext::cdata_section(),
             Self::ForeignContentCdataSectionBracket => {
                 HtmlLexContext::new(HtmlTokenizerState::CdataSectionBracket)
             }
             Self::ForeignContentCdataSectionEnd => {
                 HtmlLexContext::new(HtmlTokenizerState::CdataSectionEnd)
+            }
+            Self::CommentStart => seeded_comment_lex_context(HtmlTokenizerState::CommentStart, ""),
+            Self::CommentStartDash => {
+                seeded_comment_lex_context(HtmlTokenizerState::CommentStartDash, "")
+            }
+            Self::Comment => seeded_comment_lex_context(HtmlTokenizerState::Comment, "seed"),
+            Self::CommentLessThanSign => {
+                seeded_comment_lex_context(HtmlTokenizerState::CommentLessThanSign, "seed<")
+            }
+            Self::CommentLessThanSignBang => {
+                seeded_comment_lex_context(HtmlTokenizerState::CommentLessThanSignBang, "seed<!")
+            }
+            Self::CommentLessThanSignBangDash => seeded_comment_lex_context(
+                HtmlTokenizerState::CommentLessThanSignBangDash,
+                "seed<!",
+            ),
+            Self::CommentLessThanSignBangDashDash => seeded_comment_lex_context(
+                HtmlTokenizerState::CommentLessThanSignBangDashDash,
+                "seed<!",
+            ),
+            Self::CommentEndDash => {
+                seeded_comment_lex_context(HtmlTokenizerState::CommentEndDash, "seed")
+            }
+            Self::CommentEnd => seeded_comment_lex_context(HtmlTokenizerState::CommentEnd, "seed"),
+            Self::CommentEndBang => {
+                seeded_comment_lex_context(HtmlTokenizerState::CommentEndBang, "seed")
+            }
+            Self::BogusComment => {
+                seeded_comment_lex_context(HtmlTokenizerState::BogusComment, "bogus-")
             }
             Self::ScriptData => script_lex_context(HtmlTokenizerState::ScriptData),
             Self::ScriptDataLessThanSign => {
@@ -228,6 +270,11 @@ impl HtmlInitialTokenizerContext {
 
 fn script_lex_context(state: HtmlTokenizerState) -> HtmlLexContext {
     HtmlLexContext::script_substate(state).expect("parser only exposes valid script substates")
+}
+
+fn seeded_comment_lex_context(state: HtmlTokenizerState, data: &str) -> HtmlLexContext {
+    HtmlLexContext::comment_continuation(state, data)
+        .expect("parser only exposes valid comment continuation states")
 }
 
 fn seeded_end_tag_lex_context(
@@ -2168,6 +2215,19 @@ mod tests {
         assert_eq!(body(&cdata_end).children[0], Node::text("after"));
         let paragraph = element(&body(&cdata_end).children[1]);
         assert_eq!(paragraph.children, vec![Node::text("x")]);
+
+        let plaintext = parse_html_with_options(
+            "<b>&amp;</b></plaintext><p>x</p>",
+            HtmlParseOptions {
+                initial_tokenizer_context: HtmlInitialTokenizerContext::Plaintext,
+                ..HtmlParseOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            body(&plaintext).children,
+            vec![Node::text("<b>&amp;</b></plaintext><p>x</p>")]
+        );
     }
 
     #[test]
@@ -2274,6 +2334,102 @@ mod tests {
             assert_eq!(
                 actual_lexer_diagnostics,
                 expected_lexer_diagnostic.into_iter().collect::<Vec<_>>(),
+                "context {context:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parser_can_start_in_seeded_comment_continuation_contexts() {
+        for (context, source, expected_comment, expected_lexer_diagnostics) in [
+            (
+                HtmlInitialTokenizerContext::CommentStart,
+                "body --><p>x</p>",
+                "-body --",
+                vec!["incorrectly-opened-comment"],
+            ),
+            (
+                HtmlInitialTokenizerContext::CommentStartDash,
+                "><p>x</p>",
+                "",
+                vec!["abrupt-closing-of-empty-comment"],
+            ),
+            (
+                HtmlInitialTokenizerContext::Comment,
+                " body --><p>x</p>",
+                "seed body ",
+                Vec::<&str>::new(),
+            ),
+            (
+                HtmlInitialTokenizerContext::CommentLessThanSign,
+                "x--><p>x</p>",
+                "seed<x",
+                Vec::<&str>::new(),
+            ),
+            (
+                HtmlInitialTokenizerContext::CommentLessThanSignBang,
+                "x--><p>x</p>",
+                "seed<!x",
+                Vec::<&str>::new(),
+            ),
+            (
+                HtmlInitialTokenizerContext::CommentLessThanSignBangDash,
+                "x--><p>x</p>",
+                "seed<!-x",
+                Vec::<&str>::new(),
+            ),
+            (
+                HtmlInitialTokenizerContext::CommentLessThanSignBangDashDash,
+                "x--><p>x</p>",
+                "seed<!--x",
+                vec!["nested-comment"],
+            ),
+            (
+                HtmlInitialTokenizerContext::CommentEndDash,
+                "x--><p>x</p>",
+                "seed-x",
+                Vec::<&str>::new(),
+            ),
+            (
+                HtmlInitialTokenizerContext::CommentEnd,
+                "!><p>x</p>",
+                "seed",
+                vec!["incorrectly-closed-comment"],
+            ),
+            (
+                HtmlInitialTokenizerContext::CommentEndBang,
+                "y--><p>x</p>",
+                "seed--!y",
+                Vec::<&str>::new(),
+            ),
+            (
+                HtmlInitialTokenizerContext::BogusComment,
+                "tail><p>x</p>",
+                "bogus-tail",
+                Vec::<&str>::new(),
+            ),
+        ] {
+            let output = parse_html_with_diagnostics_and_options(
+                source,
+                HtmlParseOptions {
+                    initial_tokenizer_context: context,
+                    ..HtmlParseOptions::default()
+                },
+            )
+            .unwrap();
+
+            assert_eq!(output.document.children[0], Node::comment(expected_comment));
+            let paragraph = element(&body(&output.document).children[0]);
+            assert_eq!(paragraph.children, vec![Node::text("x")]);
+            assert!(output.parser_diagnostics.is_empty(), "context {context:?}");
+
+            let actual_lexer_diagnostics = output
+                .lexer_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                actual_lexer_diagnostics, expected_lexer_diagnostics,
                 "context {context:?}"
             );
         }


### PR DESCRIPTION
## Summary

- Add parser-approved initial tokenizer contexts for PLAINTEXT and seeded HTML comment continuation states.
- Seed comment fragments through the lexer context API while preserving bogus-comment, abrupt-close, nested-comment, and incorrectly-closed-comment diagnostics.
- Document the expanded parser/lexer handoff surface and cover comment body, less-than/bang/dash, end-dash/end-bang, bogus-comment, and plaintext EOF paths.

## Verification

- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- git diff --check
