### PR TITLE
[codex] Make Uno R4 artifact smoke follow runtime port

### DIFF
--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -159,8 +159,10 @@ reuse those headers.
 For the built-in USB route, the host artifact helper wraps the repeatable
 hardware path: build the linked SerialUSB firmware, convert the ELF to the
 bootloader `.bin`, optionally upload it with Arduino CLI, and optionally run the
-Board VM smoke session against the same serial port. Use `--print-only` first to
-inspect the exact commands:
+Board VM smoke session. When `--upload` and `--smoke` are used together, the
+helper follows Arduino CLI's reported `New upload port` so the smoke session
+targets the runtime CDC port after the board re-enumerates. Use `--print-only`
+first to inspect the static command plan:
 
 ```sh
 cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- \
@@ -176,7 +178,7 @@ cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- \
 When the Arduino Renesas core and a compatible ARM GCC toolchain are available,
 drop `--print-only` to produce
 `target/thumbv7em-none-eabihf/release/uno-r4-wifi-serialusb-server.bin`, flash
-it, and run the host smoke path:
+it, follow the post-upload runtime port, and run the host smoke path:
 
 ```sh
 cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- \

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_artifact.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_artifact.rs
@@ -2,12 +2,18 @@
 #![cfg_attr(target_arch = "arm", no_main)]
 
 #[cfg(not(target_arch = "arm"))]
+use board_vm_uno_r4_firmware::serial_usb_artifact::CommandSpec;
+#[cfg(not(target_arch = "arm"))]
+use std::io::{self, Write};
+#[cfg(not(target_arch = "arm"))]
+use std::process::{ExitCode, ExitStatus, Output};
+
+#[cfg(not(target_arch = "arm"))]
 fn main() -> std::process::ExitCode {
     use board_vm_uno_r4_firmware::serial_usb_artifact::{
         parse_artifact_args, resolve_rust_llvm_objcopy, usage, ArtifactInvocation,
         SerialUsbArtifactOptions,
     };
-    use std::process::ExitCode;
 
     let mut defaults = SerialUsbArtifactOptions::default();
     if let Some(objcopy) = resolve_rust_llvm_objcopy() {
@@ -29,36 +35,138 @@ fn main() -> std::process::ExitCode {
     };
     run.options.fill_host_defaults();
 
-    let commands = match run.options.command_plan() {
-        Ok(commands) => commands,
-        Err(error) => {
-            eprintln!("error: {error}");
-            eprintln!("{}", usage());
-            return ExitCode::from(2);
-        }
-    };
-
-    for command in commands {
-        println!("+ {}", command.shell_line());
-        if run.print_only {
-            continue;
-        }
-
-        let status = match command.to_command().status() {
-            Ok(status) => status,
+    if run.print_only {
+        let commands = match run.options.command_plan() {
+            Ok(commands) => commands,
             Err(error) => {
-                eprintln!("error: failed to start command: {error}");
-                return ExitCode::FAILURE;
+                eprintln!("error: {error}");
+                eprintln!("{}", usage());
+                return ExitCode::from(2);
             }
         };
 
-        if !status.success() {
-            eprintln!("error: command exited with {status}");
-            return ExitCode::from(status.code().unwrap_or(1) as u8);
+        for command in commands {
+            println!("+ {}", command.shell_line());
+        }
+
+        return ExitCode::SUCCESS;
+    }
+
+    if let Err(code) = run_command(&run.options.build_command()) {
+        return code;
+    }
+    if let Err(code) = run_command(&run.options.objcopy_command()) {
+        return code;
+    }
+
+    let mut upload_output_text = String::new();
+    if run.options.upload {
+        let command = match run.options.upload_command() {
+            Ok(command) => command,
+            Err(error) => {
+                eprintln!("error: {error}");
+                eprintln!("{}", usage());
+                return ExitCode::from(2);
+            }
+        };
+
+        if run.options.smoke {
+            let output = match run_command_capture(&command) {
+                Ok(output) => output,
+                Err(code) => return code,
+            };
+            upload_output_text = output_text(&output);
+        } else if let Err(code) = run_command(&command) {
+            return code;
+        }
+    }
+
+    if run.options.smoke {
+        let port = match run
+            .options
+            .smoke_port_after_upload_output(&upload_output_text)
+        {
+            Ok(port) => port,
+            Err(error) => {
+                eprintln!("error: {error}");
+                eprintln!("{}", usage());
+                return ExitCode::from(2);
+            }
+        };
+        if let Err(code) = run_command(&run.options.smoke_command_for_port(&port)) {
+            return code;
         }
     }
 
     ExitCode::SUCCESS
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn run_command(command: &CommandSpec) -> Result<(), ExitCode> {
+    println!("+ {}", command.shell_line());
+    let status = command_status(command)?;
+    if !status.success() {
+        eprintln!("error: command exited with {status}");
+        return Err(exit_code_from_status(&status));
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn run_command_capture(command: &CommandSpec) -> Result<Output, ExitCode> {
+    println!("+ {}", command.shell_line());
+    let output = match command.to_command().output() {
+        Ok(output) => output,
+        Err(error) => {
+            eprintln!("error: failed to start command: {error}");
+            return Err(ExitCode::FAILURE);
+        }
+    };
+
+    if let Err(error) = io::stdout().write_all(&output.stdout) {
+        eprintln!("error: failed to write command stdout: {error}");
+        return Err(ExitCode::FAILURE);
+    }
+    if let Err(error) = io::stderr().write_all(&output.stderr) {
+        eprintln!("error: failed to write command stderr: {error}");
+        return Err(ExitCode::FAILURE);
+    }
+
+    if !output.status.success() {
+        eprintln!("error: command exited with {}", output.status);
+        return Err(exit_code_from_status(&output.status));
+    }
+
+    Ok(output)
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn command_status(command: &CommandSpec) -> Result<ExitStatus, ExitCode> {
+    command.to_command().status().map_err(|error| {
+        eprintln!("error: failed to start command: {error}");
+        ExitCode::FAILURE
+    })
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn output_text(output: &Output) -> String {
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !text.ends_with('\n') && !output.stderr.is_empty() {
+        text.push('\n');
+    }
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    text
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn exit_code_from_status(status: &ExitStatus) -> ExitCode {
+    let code = status.code().unwrap_or(1);
+    if (0..=255).contains(&code) {
+        ExitCode::from(code as u8)
+    } else {
+        ExitCode::FAILURE
+    }
 }
 
 #[cfg(target_arch = "arm")]

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
@@ -185,7 +185,7 @@ impl SerialUsbArtifactOptions {
         Ok(commands)
     }
 
-    fn build_command(&self) -> CommandSpec {
+    pub fn build_command(&self) -> CommandSpec {
         let mut command = CommandSpec::new("rustup")
             .arg("run")
             .arg("stable")
@@ -225,7 +225,7 @@ impl SerialUsbArtifactOptions {
         command
     }
 
-    fn objcopy_command(&self) -> CommandSpec {
+    pub fn objcopy_command(&self) -> CommandSpec {
         CommandSpec::new(self.objcopy.as_os_str().to_os_string())
             .arg("-O")
             .arg("binary")
@@ -233,7 +233,7 @@ impl SerialUsbArtifactOptions {
             .arg_path(&self.bin_path())
     }
 
-    fn upload_command(&self) -> Result<CommandSpec, ArtifactCliError> {
+    pub fn upload_command(&self) -> Result<CommandSpec, ArtifactCliError> {
         let port = self.port.as_ref().ok_or(ArtifactCliError::MissingPort(
             "--port is required with --upload",
         ))?;
@@ -257,12 +257,16 @@ impl SerialUsbArtifactOptions {
         Ok(command)
     }
 
-    fn smoke_command(&self) -> Result<CommandSpec, ArtifactCliError> {
+    pub fn smoke_command(&self) -> Result<CommandSpec, ArtifactCliError> {
         let port = self.port.as_ref().ok_or(ArtifactCliError::MissingPort(
             "--port is required with --smoke",
         ))?;
 
-        Ok(CommandSpec::new("cargo")
+        Ok(self.smoke_command_for_port(port))
+    }
+
+    pub fn smoke_command_for_port(&self, port: &str) -> CommandSpec {
+        CommandSpec::new("cargo")
             .arg("run")
             .arg("-p")
             .arg("board-vm-cli")
@@ -271,12 +275,37 @@ impl SerialUsbArtifactOptions {
             .arg("--")
             .arg("smoke")
             .arg("--port")
-            .arg(port.as_str())
+            .arg(port)
             .arg("--baud")
             .arg(self.smoke_baud_rate.to_string())
             .arg("--timeout-ms")
-            .arg(self.smoke_timeout_ms.to_string()))
+            .arg(self.smoke_timeout_ms.to_string())
     }
+
+    pub fn smoke_port_after_upload_output(
+        &self,
+        upload_output: &str,
+    ) -> Result<String, ArtifactCliError> {
+        if let Some(port) = parse_new_upload_port(upload_output) {
+            return Ok(port);
+        }
+
+        self.port.clone().ok_or(ArtifactCliError::MissingPort(
+            "--port is required with --smoke",
+        ))
+    }
+}
+
+pub fn parse_new_upload_port(output: &str) -> Option<String> {
+    output.lines().rev().find_map(|line| {
+        let (_, port) = line.split_once("New upload port:")?;
+        let port = port
+            .trim()
+            .split_once(" (")
+            .map_or_else(|| port.trim(), |(port, _)| port.trim());
+
+        (!port.is_empty()).then(|| port.to_string())
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -391,7 +420,7 @@ where
 }
 
 pub fn usage() -> &'static str {
-    "usage:\n  uno-r4-wifi-serialusb-artifact [--core <arduino-core>] [--rustc <path>] [--arm-toolchain-bin <dir>] [--arm-gcc <path>] [--arm-gxx <path>] [--arm-ar <path>] [--arm-compat-root <dir>] [--target-dir <dir>] [--objcopy <path>] [--arduino-cli <path>] [--bossac-path <dir>] [--print-only] [--upload --port <path>] [--smoke --port <path>] [--baud <rate>] [--timeout-ms <ms>]"
+    "usage:\n  uno-r4-wifi-serialusb-artifact [--core <arduino-core>] [--rustc <path>] [--arm-toolchain-bin <dir>] [--arm-gcc <path>] [--arm-gxx <path>] [--arm-ar <path>] [--arm-compat-root <dir>] [--target-dir <dir>] [--objcopy <path>] [--arduino-cli <path>] [--bossac-path <dir>] [--print-only] [--upload --port <bootloader-or-runtime-port>] [--smoke --port <serial-port>] [--baud <rate>] [--timeout-ms <ms>]"
 }
 
 pub fn resolve_rust_llvm_objcopy() -> Option<PathBuf> {
@@ -648,6 +677,68 @@ mod tests {
                 "--timeout-ms",
                 "1000",
             ]
+        );
+    }
+
+    #[test]
+    fn parses_new_upload_port_from_arduino_cli_output() {
+        assert_eq!(
+            parse_new_upload_port(
+                "Sketch uses 30720 bytes.\nNew upload port: /dev/cu.usbmodem1101 (serial)\n"
+            ),
+            Some("/dev/cu.usbmodem1101".to_string())
+        );
+        assert_eq!(
+            parse_new_upload_port(
+                "New upload port: /dev/cu.usbmodem9070692469E42 (serial)\n\
+                 New upload port: /dev/cu.usbmodem1101 (serial)\n"
+            ),
+            Some("/dev/cu.usbmodem1101".to_string())
+        );
+        assert_eq!(parse_new_upload_port("No new serial port found."), None);
+    }
+
+    #[test]
+    fn smoke_after_upload_prefers_the_runtime_port_reported_by_arduino_cli() {
+        let mut options = options();
+        options.port = Some("/dev/cu.usbmodem9070692469E42".to_string());
+
+        let port = options
+            .smoke_port_after_upload_output(
+                "Resetting board...\nNew upload port: /dev/cu.usbmodem1101 (serial)\n",
+            )
+            .unwrap();
+        let smoke = options.smoke_command_for_port(&port);
+
+        assert_eq!(port, "/dev/cu.usbmodem1101");
+        assert_eq!(
+            args(&smoke),
+            [
+                "run",
+                "-p",
+                "board-vm-cli",
+                "--bin",
+                "board-vm",
+                "--",
+                "smoke",
+                "--port",
+                "/dev/cu.usbmodem1101",
+                "--baud",
+                "115200",
+                "--timeout-ms",
+                "1000",
+            ]
+        );
+    }
+
+    #[test]
+    fn smoke_after_upload_falls_back_to_the_requested_port_without_a_handoff() {
+        let mut options = options();
+        options.port = Some("/dev/cu.usbmodem1101".to_string());
+
+        assert_eq!(
+            options.smoke_port_after_upload_output("No new upload port found."),
+            Ok("/dev/cu.usbmodem1101".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

- expose the Uno R4 SerialUSB artifact command constructors so the host runner can execute upload/smoke dynamically
- parse Arduino CLI `New upload port` output and smoke the runtime CDC port after a successful upload
- document the runtime-port handoff and cover parser/fallback behavior with unit tests

## Validation

- cargo fmt -p board-vm-uno-r4-firmware -- --check
- cargo test -p board-vm-uno-r4-firmware -- --nocapture
- cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --print-only --port /dev/cu.usbmodem-test --upload --smoke
- Hardware attempt: upload from the currently-running custom CDC port `/dev/cu.usbmodem1101` stops before flashing with Arduino CLI `No device found on cu.usbmodem1101`; this confirms the remaining bootloader-reset/catch step is separate from the post-upload runtime-port smoke handoff fixed here.
