### PR TITLE
[codex] Add Uno R4 bootloader touch before SerialUSB upload

### DIFF
--- a/code/packages/rust/board-vm-serial/src/lib.rs
+++ b/code/packages/rust/board-vm-serial/src/lib.rs
@@ -9,6 +9,10 @@ pub use serialport::{
 
 pub const DEFAULT_BAUD_RATE: u32 = 115_200;
 pub const DEFAULT_TIMEOUT_MS: u64 = 1_000;
+pub const ARDUINO_BOOTLOADER_TOUCH_BAUD_RATE: u32 = 1_200;
+pub const ARDUINO_BOOTLOADER_TOUCH_TIMEOUT_MS: u64 = 250;
+pub const ARDUINO_BOOTLOADER_TOUCH_DTR_HIGH_MS: u64 = 50;
+pub const ARDUINO_BOOTLOADER_TOUCH_SETTLE_MS: u64 = 1_500;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SerialConfig {
@@ -201,6 +205,35 @@ pub fn available_ports() -> Result<Vec<SerialPortInfo>, serialport::Error> {
     serialport::available_ports()
 }
 
+pub fn touch_arduino_bootloader(path: &str) -> Result<(), serialport::Error> {
+    touch_arduino_bootloader_with_timing(
+        path,
+        Duration::from_millis(ARDUINO_BOOTLOADER_TOUCH_TIMEOUT_MS),
+        Duration::from_millis(ARDUINO_BOOTLOADER_TOUCH_SETTLE_MS),
+    )
+}
+
+pub fn touch_arduino_bootloader_with_timing(
+    path: &str,
+    timeout: Duration,
+    settle: Duration,
+) -> Result<(), serialport::Error> {
+    let mut port = serialport::new(path, ARDUINO_BOOTLOADER_TOUCH_BAUD_RATE)
+        .timeout(timeout)
+        .dtr_on_open(true)
+        .open()?;
+    port.write_data_terminal_ready(true)?;
+    std::thread::sleep(Duration::from_millis(ARDUINO_BOOTLOADER_TOUCH_DTR_HIGH_MS));
+    port.write_data_terminal_ready(false)?;
+    drop(port);
+
+    if !settle.is_zero() {
+        std::thread::sleep(settle);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +375,14 @@ mod tests {
             .preserve_dtr_on_open();
 
         assert_eq!(config.dtr_on_open, None);
+    }
+
+    #[test]
+    fn arduino_bootloader_touch_uses_the_reset_baud_rate() {
+        assert_eq!(ARDUINO_BOOTLOADER_TOUCH_BAUD_RATE, 1_200);
+        assert_eq!(ARDUINO_BOOTLOADER_TOUCH_TIMEOUT_MS, 250);
+        assert_eq!(ARDUINO_BOOTLOADER_TOUCH_DTR_HIGH_MS, 50);
+        assert_eq!(ARDUINO_BOOTLOADER_TOUCH_SETTLE_MS, 1_500);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
+++ b/code/packages/rust/board-vm-uno-r4-firmware/Cargo.toml
@@ -21,6 +21,9 @@ cortex-m-rt = "0.7"
 embedded-hal = "1.0"
 panic-halt = "0.2"
 
+[target.'cfg(not(target_arch = "arm"))'.dependencies]
+board-vm-serial = { path = "../board-vm-serial" }
+
 [dev-dependencies]
 board-vm-host = { path = "../board-vm-host" }
 

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -194,7 +194,12 @@ The helper discovers Rust's bundled `llvm-objcopy`, the stable rustup `rustc`,
 and `arm-none-eabi-*` tools on `PATH` when available. Override `--rustc`,
 `--arm-gcc`, `--arm-gxx`, `--arm-ar`, `--arm-compat-root`, `--objcopy`,
 `--arduino-cli`, `--bossac-path`, `--target-dir`, `--baud`, or `--timeout-ms`
-for local tooling differences.
+for local tooling differences. Before upload, the helper now performs the
+Arduino-compatible 1200-baud bootloader touch on the requested port and polls
+for the bootloader port before invoking Arduino CLI. Pass `--no-bootloader-touch`
+when the board is already in bootloader mode, or tune
+`--bootloader-touch-timeout-ms`, `--bootloader-touch-settle-ms`, and
+`--bootloader-port-wait-ms` for local USB timing.
 
 After flashing any Board VM server image manually, run the host smoke test
 against the adapter serial port:

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_artifact.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_artifact.rs
@@ -61,14 +61,31 @@ fn main() -> std::process::ExitCode {
 
     let mut upload_output_text = String::new();
     if run.options.upload {
-        let command = match run.options.upload_command() {
-            Ok(command) => command,
+        let requested_port = match run.options.upload_port() {
+            Ok(port) => port,
             Err(error) => {
                 eprintln!("error: {error}");
                 eprintln!("{}", usage());
                 return ExitCode::from(2);
             }
         };
+        let upload_port = if run.options.touch_bootloader {
+            println!("+ touch-arduino-bootloader --port {requested_port} --baud 1200");
+            match run.options.touch_bootloader_port(requested_port) {
+                Ok(port) => {
+                    println!("+ bootloader upload port {port}");
+                    port
+                }
+                Err(error) => {
+                    eprintln!("error: {error}");
+                    return ExitCode::FAILURE;
+                }
+            }
+        } else {
+            requested_port.to_string()
+        };
+
+        let command = run.options.upload_command_for_port(&upload_port);
 
         if run.options.smoke {
             let output = match run_command_capture(&command) {

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_artifact.rs
@@ -6,7 +6,11 @@ use std::format;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::string::{String, ToString};
+use std::thread;
+use std::time::{Duration, Instant};
 use std::vec::Vec;
+
+use board_vm_serial::{available_ports, touch_arduino_bootloader_with_timing};
 
 use crate::arduino_usb_link::{
     ARDUINO_ARM_AR_ENV_VAR, ARDUINO_ARM_COMPAT_ROOT_ENV_VAR, ARDUINO_ARM_GCC_ENV_VAR,
@@ -18,6 +22,10 @@ pub const TARGET_TRIPLE: &str = "thumbv7em-none-eabihf";
 pub const FIRMWARE_PACKAGE: &str = "board-vm-uno-r4-firmware";
 pub const DEFAULT_BAUD_RATE: u32 = 115_200;
 pub const DEFAULT_TIMEOUT_MS: u64 = 1_000;
+pub const DEFAULT_BOOTLOADER_TOUCH_TIMEOUT_MS: u64 = 250;
+pub const DEFAULT_BOOTLOADER_TOUCH_SETTLE_MS: u64 = 1_500;
+pub const DEFAULT_BOOTLOADER_PORT_WAIT_MS: u64 = 5_000;
+pub const DEFAULT_BOOTLOADER_PORT_POLL_MS: u64 = 100;
 pub const ARDUINO_BOSSAC_PATH_ENV_VAR: &str = "BOARD_VM_UNO_R4_BOSSAC_PATH";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,6 +106,10 @@ pub struct SerialUsbArtifactOptions {
     pub release: bool,
     pub port: Option<String>,
     pub upload: bool,
+    pub touch_bootloader: bool,
+    pub bootloader_touch_timeout_ms: u64,
+    pub bootloader_touch_settle_ms: u64,
+    pub bootloader_port_wait_ms: u64,
     pub smoke: bool,
     pub smoke_baud_rate: u32,
     pub smoke_timeout_ms: u64,
@@ -119,6 +131,10 @@ impl Default for SerialUsbArtifactOptions {
             release: true,
             port: None,
             upload: false,
+            touch_bootloader: true,
+            bootloader_touch_timeout_ms: DEFAULT_BOOTLOADER_TOUCH_TIMEOUT_MS,
+            bootloader_touch_settle_ms: DEFAULT_BOOTLOADER_TOUCH_SETTLE_MS,
+            bootloader_port_wait_ms: DEFAULT_BOOTLOADER_PORT_WAIT_MS,
             smoke: false,
             smoke_baud_rate: DEFAULT_BAUD_RATE,
             smoke_timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -234,14 +250,15 @@ impl SerialUsbArtifactOptions {
     }
 
     pub fn upload_command(&self) -> Result<CommandSpec, ArtifactCliError> {
-        let port = self.port.as_ref().ok_or(ArtifactCliError::MissingPort(
-            "--port is required with --upload",
-        ))?;
+        let port = self.upload_port()?;
+        Ok(self.upload_command_for_port(port))
+    }
 
+    pub fn upload_command_for_port(&self, port: &str) -> CommandSpec {
         let mut command = CommandSpec::new(self.arduino_cli.as_os_str().to_os_string())
             .arg("upload")
             .arg("-p")
-            .arg(port.as_str())
+            .arg(port)
             .arg("-b")
             .arg(UNO_R4_WIFI_FQBN)
             .arg("-i")
@@ -254,7 +271,29 @@ impl SerialUsbArtifactOptions {
             ));
         }
 
-        Ok(command)
+        command
+    }
+
+    pub fn upload_port(&self) -> Result<&str, ArtifactCliError> {
+        self.port.as_deref().ok_or(ArtifactCliError::MissingPort(
+            "--port is required with --upload",
+        ))
+    }
+
+    pub fn touch_bootloader_port(&self, port: &str) -> Result<String, ArtifactCliError> {
+        let before = serial_port_names()?;
+        touch_arduino_bootloader_with_timing(
+            port,
+            Duration::from_millis(self.bootloader_touch_timeout_ms),
+            Duration::from_millis(self.bootloader_touch_settle_ms),
+        )
+        .map_err(|error| ArtifactCliError::BootloaderTouch(error.to_string()))?;
+        wait_for_bootloader_port(
+            port,
+            &before,
+            Duration::from_millis(self.bootloader_port_wait_ms),
+            Duration::from_millis(DEFAULT_BOOTLOADER_PORT_POLL_MS),
+        )
     }
 
     pub fn smoke_command(&self) -> Result<CommandSpec, ArtifactCliError> {
@@ -308,6 +347,44 @@ pub fn parse_new_upload_port(output: &str) -> Option<String> {
     })
 }
 
+pub fn choose_bootloader_port(
+    requested: &str,
+    before: &[String],
+    after: &[String],
+) -> Option<String> {
+    after
+        .iter()
+        .find(|port| !before.contains(port) && port.contains("usbmodem"))
+        .or_else(|| after.iter().find(|port| !before.contains(port)))
+        .or_else(|| after.iter().find(|port| port.as_str() == requested))
+        .cloned()
+}
+
+fn wait_for_bootloader_port(
+    requested: &str,
+    before: &[String],
+    wait: Duration,
+    poll: Duration,
+) -> Result<String, ArtifactCliError> {
+    let deadline = Instant::now() + wait;
+    loop {
+        let after = serial_port_names()?;
+        if let Some(port) = choose_bootloader_port(requested, before, &after) {
+            return Ok(port);
+        }
+        if Instant::now() >= deadline {
+            return Ok(requested.to_string());
+        }
+        thread::sleep(poll);
+    }
+}
+
+fn serial_port_names() -> Result<Vec<String>, ArtifactCliError> {
+    available_ports()
+        .map(|ports| ports.into_iter().map(|port| port.port_name).collect())
+        .map_err(|error| ArtifactCliError::BootloaderPortList(error.to_string()))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SerialUsbArtifactRun {
     pub options: SerialUsbArtifactOptions,
@@ -325,6 +402,8 @@ pub enum ArtifactCliError {
     MissingValue(&'static str),
     MissingPort(&'static str),
     InvalidNumber { option: &'static str, value: String },
+    BootloaderTouch(String),
+    BootloaderPortList(String),
     UnknownOption(String),
 }
 
@@ -336,6 +415,8 @@ impl fmt::Display for ArtifactCliError {
             Self::InvalidNumber { option, value } => {
                 write!(f, "invalid numeric value for {option}: {value}")
             }
+            Self::BootloaderTouch(error) => write!(f, "bootloader touch failed: {error}"),
+            Self::BootloaderPortList(error) => write!(f, "bootloader port listing failed: {error}"),
             Self::UnknownOption(option) => write!(f, "unknown option: {option}"),
         }
     }
@@ -405,8 +486,27 @@ where
                 options.smoke_timeout_ms =
                     parse_number(next_value(&mut args, "--timeout-ms")?, "--timeout-ms")?;
             }
+            "--bootloader-touch-timeout-ms" => {
+                options.bootloader_touch_timeout_ms = parse_number(
+                    next_value(&mut args, "--bootloader-touch-timeout-ms")?,
+                    "--bootloader-touch-timeout-ms",
+                )?;
+            }
+            "--bootloader-touch-settle-ms" => {
+                options.bootloader_touch_settle_ms = parse_number(
+                    next_value(&mut args, "--bootloader-touch-settle-ms")?,
+                    "--bootloader-touch-settle-ms",
+                )?;
+            }
+            "--bootloader-port-wait-ms" => {
+                options.bootloader_port_wait_ms = parse_number(
+                    next_value(&mut args, "--bootloader-port-wait-ms")?,
+                    "--bootloader-port-wait-ms",
+                )?;
+            }
             "--debug" => options.release = false,
             "--upload" => options.upload = true,
+            "--no-bootloader-touch" => options.touch_bootloader = false,
             "--smoke" => options.smoke = true,
             "--print-only" => print_only = true,
             other => return Err(ArtifactCliError::UnknownOption(other.to_string())),
@@ -420,7 +520,7 @@ where
 }
 
 pub fn usage() -> &'static str {
-    "usage:\n  uno-r4-wifi-serialusb-artifact [--core <arduino-core>] [--rustc <path>] [--arm-toolchain-bin <dir>] [--arm-gcc <path>] [--arm-gxx <path>] [--arm-ar <path>] [--arm-compat-root <dir>] [--target-dir <dir>] [--objcopy <path>] [--arduino-cli <path>] [--bossac-path <dir>] [--print-only] [--upload --port <bootloader-or-runtime-port>] [--smoke --port <serial-port>] [--baud <rate>] [--timeout-ms <ms>]"
+    "usage:\n  uno-r4-wifi-serialusb-artifact [--core <arduino-core>] [--rustc <path>] [--arm-toolchain-bin <dir>] [--arm-gcc <path>] [--arm-gxx <path>] [--arm-ar <path>] [--arm-compat-root <dir>] [--target-dir <dir>] [--objcopy <path>] [--arduino-cli <path>] [--bossac-path <dir>] [--print-only] [--upload --port <bootloader-or-runtime-port>] [--no-bootloader-touch] [--bootloader-touch-timeout-ms <ms>] [--bootloader-touch-settle-ms <ms>] [--bootloader-port-wait-ms <ms>] [--smoke --port <serial-port>] [--baud <rate>] [--timeout-ms <ms>]"
 }
 
 pub fn resolve_rust_llvm_objcopy() -> Option<PathBuf> {
@@ -538,6 +638,7 @@ fn shell_escape(value: &OsStr) -> String {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+    use std::vec;
 
     fn options() -> SerialUsbArtifactOptions {
         SerialUsbArtifactOptions {
@@ -554,6 +655,10 @@ mod tests {
             release: true,
             port: None,
             upload: false,
+            touch_bootloader: true,
+            bootloader_touch_timeout_ms: DEFAULT_BOOTLOADER_TOUCH_TIMEOUT_MS,
+            bootloader_touch_settle_ms: DEFAULT_BOOTLOADER_TOUCH_SETTLE_MS,
+            bootloader_port_wait_ms: DEFAULT_BOOTLOADER_PORT_WAIT_MS,
             smoke: false,
             smoke_baud_rate: DEFAULT_BAUD_RATE,
             smoke_timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -743,6 +848,35 @@ mod tests {
     }
 
     #[test]
+    fn bootloader_port_selection_prefers_new_usbmodem_ports() {
+        let before = vec![
+            "/dev/cu.debug-console".to_string(),
+            "/dev/cu.usbmodem1101".to_string(),
+        ];
+        let after = vec![
+            "/dev/cu.debug-console".to_string(),
+            "/dev/cu.usbserial-abc".to_string(),
+            "/dev/cu.usbmodem2201".to_string(),
+        ];
+
+        assert_eq!(
+            choose_bootloader_port("/dev/cu.usbmodem1101", &before, &after),
+            Some("/dev/cu.usbmodem2201".to_string())
+        );
+    }
+
+    #[test]
+    fn bootloader_port_selection_falls_back_to_requested_port() {
+        let before = vec!["/dev/cu.usbmodem1101".to_string()];
+        let after = vec!["/dev/cu.usbmodem1101".to_string()];
+
+        assert_eq!(
+            choose_bootloader_port("/dev/cu.usbmodem1101", &before, &after),
+            Some("/dev/cu.usbmodem1101".to_string())
+        );
+    }
+
+    #[test]
     fn upload_requires_a_port() {
         let mut options = options();
         options.upload = true;
@@ -810,9 +944,41 @@ mod tests {
         assert_eq!(run.options.bossac_path, Some(PathBuf::from("/bossac/bin")));
         assert_eq!(run.options.port, Some("/dev/cu.usbmodem-test".to_string()));
         assert!(run.options.upload);
+        assert!(run.options.touch_bootloader);
         assert!(run.options.smoke);
         assert_eq!(run.options.smoke_baud_rate, 57_600);
         assert_eq!(run.options.smoke_timeout_ms, 250);
+    }
+
+    #[test]
+    fn parses_bootloader_touch_overrides() {
+        let invocation = parse_artifact_args(
+            [
+                "--upload",
+                "--port",
+                "/dev/cu.usbmodem-test",
+                "--no-bootloader-touch",
+                "--bootloader-touch-timeout-ms",
+                "25",
+                "--bootloader-touch-settle-ms",
+                "50",
+                "--bootloader-port-wait-ms",
+                "75",
+            ],
+            SerialUsbArtifactOptions::default(),
+        )
+        .unwrap();
+
+        let ArtifactInvocation::Run(run) = invocation else {
+            panic!("expected run invocation");
+        };
+
+        assert!(run.options.upload);
+        assert_eq!(run.options.port, Some("/dev/cu.usbmodem-test".to_string()));
+        assert!(!run.options.touch_bootloader);
+        assert_eq!(run.options.bootloader_touch_timeout_ms, 25);
+        assert_eq!(run.options.bootloader_touch_settle_ms, 50);
+        assert_eq!(run.options.bootloader_port_wait_ms, 75);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add reusable Arduino 1200-baud bootloader touch helpers to `board-vm-serial`
- have the Uno R4 SerialUSB artifact helper touch the requested port, poll for a bootloader upload port, and then upload to the discovered port
- document the new flags for disabling or tuning the bootloader touch/wait behavior

## Validation

- `cargo fmt -p board-vm-serial -p board-vm-uno-r4-firmware -- --check`
- `cargo test -p board-vm-serial -p board-vm-uno-r4-firmware -- --nocapture`
- Hardware attempt on plugged Uno R4 built and objcopied the SerialUSB firmware, performed the 1200-baud touch, but the currently running board image did not enter bootloader mode; Arduino CLI still reported `No device found on cu.usbmodem1101`. This PR captures the host-side recovery behavior and exposes the remaining board-state/manual-reset blocker.
