### PR TITLE
[codex] Add nonblocking device stream polling

### DIFF
--- a/code/packages/rust/board-vm-device/README.md
+++ b/code/packages/rust/board-vm-device/README.md
@@ -12,7 +12,9 @@ either feed decoded raw frames into `BoardVmDevice` directly or wrap a UART, USB
 CDC, BLE, TCP tunnel, or simulator byte stream with `DeviceStreamEndpoint`. The
 stream endpoint reads one zero-terminated COBS wire frame, dispatches it through
 the device, writes the encoded response frame, and keeps the transport itself
-board-specific.
+board-specific. Blocking transports can use `serve_one()`, while USB CDC-style
+transports can use `serve_available()` to return quickly when no host byte is
+ready.
 
 Background `RUN` requests are scheduled into a resumable VM cursor and execute a
 bounded instruction slice before returning `RUN_REPORT`. Firmware can call

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -582,6 +582,10 @@ pub trait DeviceByteStream {
 
     fn read_byte(&mut self) -> Result<u8, Self::Error>;
 
+    fn try_read_byte(&mut self) -> Result<Option<u8>, Self::Error> {
+        self.read_byte().map(Some)
+    }
+
     fn write_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error>;
 
     fn flush(&mut self) -> Result<(), Self::Error> {
@@ -597,6 +601,12 @@ pub enum DeviceStreamError<E> {
     ResponseWireFrameTooLarge,
     Protocol(ProtocolError),
     Device(DeviceError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceStreamPoll {
+    Idle,
+    Served(usize),
 }
 
 pub struct DeviceStreamEndpoint<
@@ -657,6 +667,79 @@ where
         H: BoardHal,
     {
         let wire_len = self.read_wire_frame()?;
+        self.handle_wire_frame(device, wire_len)
+    }
+
+    pub fn serve_available<
+        'a,
+        H,
+        const MAX_PROGRAM_BYTES: usize,
+        const MAX_STACK: usize,
+        const MAX_HANDLES: usize,
+    >(
+        &mut self,
+        device: &mut BoardVmDevice<'a, H, MAX_PROGRAM_BYTES, MAX_STACK, MAX_HANDLES>,
+    ) -> Result<DeviceStreamPoll, DeviceStreamError<S::Error>>
+    where
+        H: BoardHal,
+    {
+        let Some(first_byte) = self
+            .stream
+            .try_read_byte()
+            .map_err(DeviceStreamError::Stream)?
+        else {
+            return Ok(DeviceStreamPoll::Idle);
+        };
+        let wire_len = self.read_wire_frame_after_first(first_byte)?;
+        let write_len = self.handle_wire_frame(device, wire_len)?;
+        Ok(DeviceStreamPoll::Served(write_len))
+    }
+
+    fn read_wire_frame(&mut self) -> Result<usize, DeviceStreamError<S::Error>> {
+        let first_byte = self.stream.read_byte().map_err(DeviceStreamError::Stream)?;
+        self.read_wire_frame_after_first(first_byte)
+    }
+
+    fn read_wire_frame_after_first(
+        &mut self,
+        first_byte: u8,
+    ) -> Result<usize, DeviceStreamError<S::Error>> {
+        let mut len = 0;
+        self.wire[len] = first_byte;
+        len += 1;
+        if first_byte == 0 {
+            return Ok(len);
+        }
+
+        loop {
+            if len >= self.wire.len() {
+                return Err(DeviceStreamError::IncomingWireFrameTooLarge);
+            }
+
+            let byte = self.stream.read_byte().map_err(DeviceStreamError::Stream)?;
+            self.wire[len] = byte;
+            len += 1;
+
+            if byte == 0 {
+                return Ok(len);
+            }
+        }
+    }
+
+    fn handle_wire_frame<
+        'a,
+        H,
+        const MAX_PROGRAM_BYTES: usize,
+        const MAX_STACK: usize,
+        const MAX_HANDLES: usize,
+    >(
+        &mut self,
+        device: &mut BoardVmDevice<'a, H, MAX_PROGRAM_BYTES, MAX_STACK, MAX_HANDLES>,
+        wire_len: usize,
+    ) -> Result<usize, DeviceStreamError<S::Error>>
+    where
+        H: BoardHal,
+    {
         let request_len = decode_wire_frame(&self.wire[..wire_len], &mut self.raw_request)
             .map_err(map_decode_wire_error)?;
         let response_len = device
@@ -673,23 +756,6 @@ where
             .map_err(DeviceStreamError::Stream)?;
         self.stream.flush().map_err(DeviceStreamError::Stream)?;
         Ok(write_len)
-    }
-
-    fn read_wire_frame(&mut self) -> Result<usize, DeviceStreamError<S::Error>> {
-        let mut len = 0;
-        loop {
-            if len >= self.wire.len() {
-                return Err(DeviceStreamError::IncomingWireFrameTooLarge);
-            }
-
-            let byte = self.stream.read_byte().map_err(DeviceStreamError::Stream)?;
-            self.wire[len] = byte;
-            len += 1;
-
-            if byte == 0 {
-                return Ok(len);
-            }
-        }
     }
 }
 
@@ -1048,6 +1114,13 @@ mod tests {
             Ok(byte)
         }
 
+        fn try_read_byte(&mut self) -> Result<Option<u8>, Self::Error> {
+            if self.read_offset >= self.read_len {
+                return Ok(None);
+            }
+            self.read_byte().map(Some)
+        }
+
         fn write_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
             let end = self
                 .written_len
@@ -1109,6 +1182,44 @@ mod tests {
         assert_eq!(hello_ack.runtime_name, DEFAULT_DEVICE_RUNTIME_ID);
         assert_eq!(hello_ack.host_nonce, 0xCAFE_BABE);
         assert_eq!(hello_ack.board_nonce, 0xB04D_1001);
+    }
+
+    #[test]
+    fn stream_endpoint_serves_available_wire_frame() {
+        let mut device = new_device();
+        let mut session = HostSession::new();
+        let mut host_payload = [0u8; 96];
+        let mut request = [0u8; 128];
+        let mut request_wire = [0u8; 192];
+        let mut raw_response = [0u8; 128];
+
+        let hello = session
+            .hello_frame("stream-host", 0xCAFE_BABE, &mut host_payload, &mut request)
+            .unwrap();
+        let request_wire_len = encode_wire_frame(&request[..hello.len], &mut request_wire).unwrap();
+        let stream = ScriptedByteStream::<192, 192>::with_read(&request_wire[..request_wire_len]);
+        let mut endpoint = DeviceStreamEndpoint::<_, 192, 128, 128>::new(stream);
+
+        let poll = endpoint.serve_available(&mut device).unwrap();
+        let stream = endpoint.into_inner();
+        assert_eq!(poll, DeviceStreamPoll::Served(stream.written().len()));
+
+        let raw_len = decode_wire_frame(stream.written(), &mut raw_response).unwrap();
+        let frame = decode_frame(&raw_response[..raw_len]).unwrap();
+        assert_eq!(frame.message_type, MessageType::HELLO_ACK);
+        assert_eq!(frame.request_id, hello.request_id);
+    }
+
+    #[test]
+    fn stream_endpoint_reports_idle_when_no_byte_is_available() {
+        let mut device = new_device();
+        let stream = ScriptedByteStream::<8, 8>::with_read(&[]);
+        let mut endpoint = DeviceStreamEndpoint::<_, 8, 8, 8>::new(stream);
+
+        assert_eq!(
+            endpoint.serve_available(&mut device),
+            Ok(DeviceStreamPoll::Idle)
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-uno-r4-firmware/README.md
+++ b/code/packages/rust/board-vm-uno-r4-firmware/README.md
@@ -106,7 +106,9 @@ USB-C `SerialUSB` route. It attaches `DeviceStreamEndpoint` to
 `UsbCdcByteStream<UnoR4WifiSerialUsb>` and uses the same Uno R4 WiFi board
 runtime as the UART server. The reusable server helper is host-tested with a
 fake CDC transport so the Board VM wire-frame path is validated before the
-Arduino/TinyUSB link layer is wired in.
+Arduino/TinyUSB link layer is wired in. The firmware loop uses the nonblocking
+`serve_available()` path so an active background `RUN` can keep advancing in
+small instruction slices while the USB host is idle.
 
 The Rust entrypoint now starts Arduino Renesas USB through the `__USBStart()`
 C++ ABI symbol exposed by the Arduino core. The `board-vm-uno-r4-usb-cdc`

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_server.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/bin/uno_r4_wifi_serialusb_server.rs
@@ -3,9 +3,12 @@
 
 #[cfg(target_arch = "arm")]
 mod firmware {
+    use board_vm_device::{DeviceStreamPoll, DEFAULT_BACKGROUND_INSTRUCTION_SLICE};
     use board_vm_runtime::Level;
     use board_vm_uno_r4::UnoR4Board;
-    use board_vm_uno_r4_firmware::serial_usb_server::serial_usb_endpoint;
+    use board_vm_uno_r4_firmware::serial_usb_server::{
+        serial_usb_endpoint, serve_serial_usb_available,
+    };
     use board_vm_uno_r4_firmware::uno_r4_wifi_backend::UnoR4WifiLedBackend;
     use board_vm_uno_r4_usb_cdc::UnoR4WifiSerialUsb;
     use panic_halt as _;
@@ -24,9 +27,21 @@ mod firmware {
         let mut endpoint = serial_usb_endpoint(usb);
 
         loop {
-            if endpoint.serve_one(&mut device).is_err() {
-                let backend = device.hal_mut().backend_mut();
-                backend.blink_pattern(1, 160, 120);
+            match serve_serial_usb_available(&mut endpoint, &mut device) {
+                Ok(DeviceStreamPoll::Served(_)) => {}
+                Ok(DeviceStreamPoll::Idle) => {
+                    if device
+                        .poll_background(DEFAULT_BACKGROUND_INSTRUCTION_SLICE)
+                        .is_err()
+                    {
+                        let backend = device.hal_mut().backend_mut();
+                        backend.blink_pattern(1, 160, 120);
+                    }
+                }
+                Err(_) => {
+                    let backend = device.hal_mut().backend_mut();
+                    backend.blink_pattern(1, 160, 120);
+                }
             }
         }
     }

--- a/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_server.rs
+++ b/code/packages/rust/board-vm-uno-r4-firmware/src/serial_usb_server.rs
@@ -1,4 +1,4 @@
-use board_vm_device::{BoardVmDevice, DeviceStreamEndpoint, DeviceStreamError};
+use board_vm_device::{BoardVmDevice, DeviceStreamEndpoint, DeviceStreamError, DeviceStreamPoll};
 use board_vm_runtime::BoardHal;
 use board_vm_usb_cdc::{BlockingUsbCdc, UsbCdcByteStream};
 
@@ -36,6 +36,24 @@ where
     H: BoardHal,
 {
     endpoint.serve_one(device)
+}
+
+pub fn serve_serial_usb_available<
+    'a,
+    C,
+    H,
+    const MAX_PROGRAM_BYTES: usize,
+    const MAX_STACK: usize,
+    const MAX_HANDLES: usize,
+>(
+    endpoint: &mut SerialUsbEndpoint<C>,
+    device: &mut BoardVmDevice<'a, H, MAX_PROGRAM_BYTES, MAX_STACK, MAX_HANDLES>,
+) -> Result<DeviceStreamPoll, DeviceStreamError<C::Error>>
+where
+    C: BlockingUsbCdc,
+    H: BoardHal,
+{
+    endpoint.serve_available(device)
 }
 
 #[cfg(test)]
@@ -78,6 +96,13 @@ mod tests {
             let byte = self.read[self.read_offset];
             self.read_offset += 1;
             Ok(byte)
+        }
+
+        fn try_read_byte(&mut self) -> Result<Option<u8>, Self::Error> {
+            if self.read_offset >= self.read.len() {
+                return Ok(None);
+            }
+            self.read_byte().map(Some)
         }
 
         fn write_packet(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
@@ -143,5 +168,17 @@ mod tests {
         assert_eq!(ack.host_nonce, 0xCAFE_BABE);
         assert_eq!(ack.board_name, "arduino-uno-r4-minima");
         assert_eq!(ack.runtime_name, "board-vm-uno-r4");
+    }
+
+    #[test]
+    fn serial_usb_endpoint_reports_idle_without_input() {
+        let cdc = FakeCdc::new(Vec::new());
+        let mut endpoint = serial_usb_endpoint(cdc);
+        let mut device = minima_device(FakeBackend, 0xB04D_1005);
+
+        assert_eq!(
+            serve_serial_usb_available(&mut endpoint, &mut device),
+            Ok(DeviceStreamPoll::Idle)
+        );
     }
 }

--- a/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
+++ b/code/packages/rust/board-vm-uno-r4-usb-cdc/src/lib.rs
@@ -134,6 +134,19 @@ where
         }
     }
 
+    fn try_read_byte(&mut self) -> Result<Option<u8>, Self::Error> {
+        self.ensure_started()?;
+        let mut byte = [0];
+        self.api.poll();
+        if !self.api.connected() {
+            return Err(UnoR4UsbCdcError::NotConnected);
+        }
+        if self.api.available() == 0 {
+            return Ok(None);
+        }
+        Ok((self.api.read(&mut byte) == 1).then_some(byte[0]))
+    }
+
     fn write_packet(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
         self.ensure_started()?;
         if bytes.len() > UNO_R4_WIFI_USB_MAX_PACKET_BYTES {
@@ -846,6 +859,23 @@ mod tests {
         assert_eq!(api.flushes, 2);
         assert_eq!(api.line_coding, UsbCdcLineCoding::new(115_200));
         assert!(api.line_state.connected());
+    }
+
+    #[test]
+    fn try_read_byte_polls_once_and_reports_idle() {
+        let mut cdc = UnoR4WifiSerialUsbCdc::started(FakeTinyUsb::new(&[]));
+
+        assert_eq!(cdc.try_read_byte().unwrap(), None);
+        assert_eq!(cdc.api().polls, 1);
+    }
+
+    #[test]
+    fn try_read_byte_returns_available_byte_without_spinning() {
+        let mut cdc = UnoR4WifiSerialUsbCdc::started(FakeTinyUsb::new(&[0x33]));
+
+        assert_eq!(cdc.try_read_byte().unwrap(), Some(0x33));
+        assert_eq!(cdc.api().polls, 1);
+        assert_eq!(cdc.api().read_offset, 1);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-usb-cdc/src/lib.rs
+++ b/code/packages/rust/board-vm-usb-cdc/src/lib.rs
@@ -101,6 +101,10 @@ pub trait BlockingUsbCdc {
 
     fn read_byte(&mut self) -> Result<u8, Self::Error>;
 
+    fn try_read_byte(&mut self) -> Result<Option<u8>, Self::Error> {
+        self.read_byte().map(Some)
+    }
+
     fn write_packet(&mut self, bytes: &[u8]) -> Result<(), Self::Error>;
 
     fn flush(&mut self) -> Result<(), Self::Error> {
@@ -158,6 +162,10 @@ where
 
     fn read_byte(&mut self) -> Result<u8, Self::Error> {
         self.cdc.read_byte()
+    }
+
+    fn try_read_byte(&mut self) -> Result<Option<u8>, Self::Error> {
+        self.cdc.try_read_byte()
     }
 
     fn write_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
@@ -221,6 +229,13 @@ mod tests {
             Ok(byte)
         }
 
+        fn try_read_byte(&mut self) -> Result<Option<u8>, Self::Error> {
+            if self.read_offset >= self.read_len {
+                return Ok(None);
+            }
+            self.read_byte().map(Some)
+        }
+
         fn write_packet(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
             self.packets += 1;
             let end = self
@@ -278,6 +293,13 @@ mod tests {
         assert_eq!(cdc.flushes, 1);
         assert!(cdc.connected());
         assert_eq!(cdc.line_coding(), UsbCdcLineCoding::default());
+    }
+
+    #[test]
+    fn usb_cdc_byte_stream_can_report_idle_without_error() {
+        let mut stream = UsbCdcByteStream::new(FakeCdc::with_read(&[]));
+
+        assert_eq!(stream.try_read_byte().unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add transport-level nonblocking byte polling for device stream endpoints
- let SerialUSB firmware keep servicing USB while background Board VM bytecode advances during idle polls
- document the async server loop and add idle-path coverage for device, USB CDC, Uno R4 USB CDC, and SerialUSB server helpers

## Validation

- cargo fmt -p board-vm-device -p board-vm-usb-cdc -p board-vm-uno-r4-usb-cdc -p board-vm-uno-r4-firmware -- --check
- cargo test -p board-vm-device -p board-vm-usb-cdc -p board-vm-uno-r4-usb-cdc -p board-vm-uno-r4-firmware -- --nocapture
- git diff --check
- BOARD_VM_UNO_R4_LINK_ARDUINO_USB=1 ... cargo build --target thumbv7em-none-eabihf -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-server --release
