### PR TITLE
[codex] Add Ruby Board VM DSL

### DIFF
--- a/code/packages/ruby/board_vm/BUILD
+++ b/code/packages/ruby/board_vm/BUILD
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/board_vm/BUILD_windows
+++ b/code/packages/ruby/board_vm/BUILD_windows
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet
+bundle exec rake test

--- a/code/packages/ruby/board_vm/CHANGELOG.md
+++ b/code/packages/ruby/board_vm/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the first Ruby Board VM DSL for Uno R4 WiFi sessions.
+- Added `flash: true` support through the Rust SerialUSB artifact helper.
+- Added `board.led.blink` and `board.eject.blink` helpers backed by the shared
+  Rust CLI.

--- a/code/packages/ruby/board_vm/Gemfile
+++ b/code/packages/ruby/board_vm/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -1,0 +1,56 @@
+# coding_adventures_board_vm
+
+Ruby DSL for Board VM hardware sessions.
+
+The first target is the Arduino Uno R4 WiFi. The DSL keeps the frontend shape
+language-level and board-agnostic, while the implementation delegates the
+board-specific pieces to the Rust packages that already know how to build,
+flash, and speak the Board VM protocol.
+
+```ruby
+require "coding_adventures_board_vm"
+
+CodingAdventures::BoardVM.uno_r4_wifi(
+  port: "/dev/cu.usbmodem1101",
+  flash: true,
+  arduino_core: "#{Dir.home}/Library/Arduino15/packages/arduino/hardware/renesas_uno/1.5.3",
+  arm_toolchain_bin: "/opt/homebrew/bin",
+  bossac_path: "/tmp/arduino-bossa/bin"
+) do |board|
+  board.led.blink
+end
+```
+
+`flash: true` builds and uploads the Rust SerialUSB Board VM server firmware by
+running the Uno R4 artifact helper:
+
+```sh
+cargo run -p board-vm-uno-r4-firmware --bin uno-r4-wifi-serialusb-artifact -- --upload ...
+```
+
+The helper output is inspected for Arduino CLI's `New upload port:` handoff so
+subsequent Ruby DSL commands use the runtime CDC port when the board
+re-enumerates.
+
+Inside the block, `board.led.blink` currently runs the shared Rust host smoke
+command:
+
+```sh
+cargo run -p board-vm-cli --bin board-vm -- smoke ...
+```
+
+That smoke command sends `HELLO`, queries capabilities, uploads the standard
+blink module, and starts it through the binary protocol. Future Ruby releases
+can replace this subprocess bridge with a direct Ruby protocol transport while
+preserving the DSL surface.
+
+The DSL also exposes the current board-agnostic blink ejection path:
+
+```ruby
+CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
+  board.eject.blink(to: "src/ejected_blink.rs", boot_policy: :run_if_no_host)
+end
+```
+
+That writes Rust constants for the blink MVP. Board-specific firmware, such as
+the Uno R4 ejected runner, decides how to validate and execute those constants.

--- a/code/packages/ruby/board_vm/Rakefile
+++ b/code/packages/ruby/board_vm/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task default: :test

--- a/code/packages/ruby/board_vm/coding_adventures_board_vm.gemspec
+++ b/code/packages/ruby/board_vm/coding_adventures_board_vm.gemspec
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/board_vm/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "coding_adventures_board_vm"
+  spec.version = CodingAdventures::BoardVM::VERSION
+  spec.authors = ["Adhithya Rajasekaran"]
+  spec.summary = "Ruby DSL for Board VM hardware sessions"
+  spec.description = "Provides a small Ruby DSL for flashing a Board VM runtime and driving LED blink sessions through the shared Rust host tools."
+  spec.homepage = "https://github.com/adhithyan15/coding-adventures"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 2.6.0"
+  spec.files = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative "board_vm/version"
+require_relative "board_vm/command_runner"
+require_relative "board_vm/connection"
+
+module CodingAdventures
+  module BoardVM
+    DEFAULT_RUST_WORKSPACE = File.expand_path("../../../../rust", __dir__)
+    DEFAULT_BAUD_RATE = 115_200
+    DEFAULT_TIMEOUT_MS = 1_000
+    DEFAULT_PROGRAM_ID = 1
+    DEFAULT_INSTRUCTION_BUDGET = 12
+    DEFAULT_HOST_NONCE = 0xB0A2_D001
+    DEFAULT_EJECT_SLOT = 0
+    DEFAULT_BOOT_POLICY = :run_if_no_host
+
+    module_function
+
+    def connect(
+      board: :uno_r4_wifi,
+      port:,
+      flash: false,
+      cargo_workspace: DEFAULT_RUST_WORKSPACE,
+      runner: CommandRunner.new,
+      **options
+    )
+      connection = Connection.new(
+        board: normalize_board(board),
+        port: port,
+        cargo_workspace: cargo_workspace,
+        runner: runner,
+        baud_rate: options.delete(:baud_rate) || options.delete(:baud) || DEFAULT_BAUD_RATE,
+        timeout_ms: options.delete(:timeout_ms) || DEFAULT_TIMEOUT_MS,
+        **options
+      )
+      connection.flash! if flash
+
+      return connection unless block_given?
+
+      yield connection
+      connection
+    end
+
+    def uno_r4_wifi(**options, &block)
+      connect(board: :uno_r4_wifi, **options, &block)
+    end
+
+    def normalize_board(board)
+      case board.to_s.tr("-", "_")
+      when "uno_r4", "uno_r4_wifi", "arduino_uno_r4", "arduino_uno_r4_wifi"
+        :uno_r4_wifi
+      else
+        raise UnsupportedBoardError, "unsupported board: #{board.inspect}"
+      end
+    end
+  end
+end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/command_runner.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/command_runner.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module CodingAdventures
+  module BoardVM
+    CommandResult = Struct.new(:argv, :chdir, :stdout, :stderr, :exitstatus) do
+      def success?
+        exitstatus == 0
+      end
+
+      def output
+        [stdout, stderr].compact.join("\n")
+      end
+    end
+
+    class CommandError < StandardError
+      attr_reader :result
+
+      def initialize(result)
+        @result = result
+        super("command failed with exit #{result.exitstatus}: #{result.argv.join(" ")}")
+      end
+    end
+
+    class CommandRunner
+      def call(argv, chdir: nil)
+        stdout, stderr, status = Open3.capture3(*argv, chdir: chdir)
+        result = CommandResult.new(argv, chdir, stdout, stderr, status.exitstatus)
+        raise CommandError.new(result) unless result.success?
+
+        result
+      end
+    end
+  end
+end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module BoardVM
+    class UnsupportedBoardError < ArgumentError; end
+
+    class Connection
+      attr_reader :board, :cargo_workspace, :runner, :baud_rate, :timeout_ms
+      attr_accessor :port
+
+      def initialize(
+        board:,
+        port:,
+        cargo_workspace:,
+        runner:,
+        baud_rate:,
+        timeout_ms:,
+        arduino_core: nil,
+        arm_toolchain_bin: nil,
+        arm_gcc: nil,
+        arm_gxx: nil,
+        arm_ar: nil,
+        arm_compat_root: nil,
+        bossac_path: nil,
+        arduino_cli: nil,
+        objcopy: nil,
+        rustc: nil,
+        target_dir: nil,
+        bootloader_touch: true,
+        bootloader_touch_timeout_ms: nil,
+        bootloader_touch_settle_ms: nil,
+        bootloader_port_wait_ms: nil
+      )
+        @board = board
+        @port = port
+        @cargo_workspace = cargo_workspace
+        @runner = runner
+        @baud_rate = baud_rate
+        @timeout_ms = timeout_ms
+        @arduino_core = arduino_core
+        @arm_toolchain_bin = arm_toolchain_bin
+        @arm_gcc = arm_gcc
+        @arm_gxx = arm_gxx
+        @arm_ar = arm_ar
+        @arm_compat_root = arm_compat_root
+        @bossac_path = bossac_path
+        @arduino_cli = arduino_cli
+        @objcopy = objcopy
+        @rustc = rustc
+        @target_dir = target_dir
+        @bootloader_touch = bootloader_touch
+        @bootloader_touch_timeout_ms = bootloader_touch_timeout_ms
+        @bootloader_touch_settle_ms = bootloader_touch_settle_ms
+        @bootloader_port_wait_ms = bootloader_port_wait_ms
+      end
+
+      def led
+        Led.new(self)
+      end
+
+      def eject
+        Ejector.new(self)
+      end
+
+      def flash!
+        ensure_uno_r4_wifi!
+
+        result = runner.call(serial_usb_artifact_command(upload: true), chdir: cargo_workspace)
+        handoff_port = self.class.parse_new_upload_port(result.output)
+        self.port = handoff_port if handoff_port
+        result
+      end
+
+      def blink!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE
+      )
+        ensure_uno_r4_wifi!
+
+        runner.call(
+          board_vm_cli_command(
+            "smoke",
+            "--port", port,
+            "--baud", baud_rate.to_s,
+            "--timeout-ms", timeout_ms.to_s,
+            "--program-id", program_id.to_s,
+            "--budget", budget.to_s,
+            "--host-nonce", host_nonce.to_s
+          ),
+          chdir: cargo_workspace
+        )
+      end
+
+      def eject_blink!(
+        output:,
+        program_id: DEFAULT_PROGRAM_ID,
+        slot: DEFAULT_EJECT_SLOT,
+        boot_policy: DEFAULT_BOOT_POLICY
+      )
+        runner.call(
+          board_vm_cli_command(
+            "eject", "blink",
+            "--out", output,
+            "--program-id", program_id.to_s,
+            "--slot", slot.to_s,
+            "--boot-policy", boot_policy_name(boot_policy)
+          ),
+          chdir: cargo_workspace
+        )
+      end
+
+      def self.parse_new_upload_port(output)
+        port = nil
+        output.each_line do |line|
+          marker_index = line.index("New upload port:")
+          next if marker_index.nil?
+
+          candidate = line[(marker_index + "New upload port:".length)..-1].strip
+          candidate = candidate.split(/\s+/, 2).first
+          port = candidate unless candidate.nil? || candidate.empty?
+        end
+        port
+      end
+
+      private
+
+      def ensure_uno_r4_wifi!
+        return if board == :uno_r4_wifi
+
+        raise UnsupportedBoardError, "Ruby DSL currently supports :uno_r4_wifi; got #{board.inspect}"
+      end
+
+      def serial_usb_artifact_command(upload:)
+        command = cargo_command(
+          "run",
+          "-p", "board-vm-uno-r4-firmware",
+          "--bin", "uno-r4-wifi-serialusb-artifact",
+          "--"
+        )
+        append_option(command, "--core", @arduino_core)
+        append_option(command, "--rustc", @rustc)
+        append_option(command, "--arm-toolchain-bin", @arm_toolchain_bin)
+        append_option(command, "--arm-gcc", @arm_gcc)
+        append_option(command, "--arm-gxx", @arm_gxx)
+        append_option(command, "--arm-ar", @arm_ar)
+        append_option(command, "--arm-compat-root", @arm_compat_root)
+        append_option(command, "--target-dir", @target_dir)
+        append_option(command, "--objcopy", @objcopy)
+        append_option(command, "--arduino-cli", @arduino_cli)
+        append_option(command, "--bossac-path", @bossac_path)
+        append_option(command, "--port", port)
+        append_option(command, "--baud", baud_rate)
+        append_option(command, "--timeout-ms", timeout_ms)
+        append_option(command, "--bootloader-touch-timeout-ms", @bootloader_touch_timeout_ms)
+        append_option(command, "--bootloader-touch-settle-ms", @bootloader_touch_settle_ms)
+        append_option(command, "--bootloader-port-wait-ms", @bootloader_port_wait_ms)
+        command << "--no-bootloader-touch" unless @bootloader_touch
+        command << "--upload" if upload
+        command
+      end
+
+      def board_vm_cli_command(*args)
+        cargo_command("run", "-p", "board-vm-cli", "--bin", "board-vm", "--", *args)
+      end
+
+      def cargo_command(*args)
+        ["cargo"] + args
+      end
+
+      def append_option(command, option, value)
+        return if value.nil?
+
+        command << option << value.to_s
+      end
+
+      def boot_policy_name(policy)
+        case policy
+        when :store_only then "store-only"
+        when :run_at_boot then "run-at-boot"
+        when :run_if_no_host then "run-if-no-host"
+        else policy.to_s
+        end
+      end
+    end
+
+    class Led
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def blink(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE
+      )
+        @connection.blink!(program_id: program_id, budget: budget, host_nonce: host_nonce)
+      end
+    end
+
+    class Ejector
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def blink(
+        to:,
+        program_id: DEFAULT_PROGRAM_ID,
+        slot: DEFAULT_EJECT_SLOT,
+        boot_policy: DEFAULT_BOOT_POLICY
+      )
+        @connection.eject_blink!(
+          output: to,
+          program_id: program_id,
+          slot: slot,
+          boot_policy: boot_policy
+        )
+      end
+    end
+  end
+end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/version.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module BoardVM
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/board_vm/lib/coding_adventures_board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures_board_vm.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "coding_adventures/board_vm"

--- a/code/packages/ruby/board_vm/required_capabilities.json
+++ b/code/packages/ruby/board_vm/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ruby/board_vm",
+  "capabilities": [
+    {
+      "category": "proc",
+      "action": "exec",
+      "target": "cargo",
+      "justification": "Runs the Rust Board VM flash, smoke, and eject tools that own the hardware-specific implementation."
+    }
+  ],
+  "justification": "The Ruby DSL is a high-level frontend over existing Rust Board VM tools, so it must spawn cargo commands to flash firmware and drive protocol sessions."
+}

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module CodingAdventures
+  module BoardVM
+    class TestBoardVM < Minitest::Test
+      def test_connect_yields_connection_without_flashing_by_default
+        runner = FakeRunner.new
+        yielded = nil
+
+        connection = BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem1101",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner
+        ) do |board|
+          yielded = board
+        end
+
+        assert_same connection, yielded
+        assert_equal :uno_r4_wifi, connection.board
+        assert_equal "/dev/cu.usbmodem1101", connection.port
+        assert_empty runner.calls
+      end
+
+      def test_connect_flash_uploads_the_uno_r4_serialusb_vm_and_tracks_runtime_port
+        upload = CommandResult.new(
+          ["cargo"],
+          "/repo/code/packages/rust",
+          "Sketch uses 42000 bytes.\nNew upload port: /dev/cu.usbmodem2201 (serial)\n",
+          "",
+          0
+        )
+        runner = FakeRunner.new([upload])
+
+        connection = BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem1101",
+          flash: true,
+          cargo_workspace: "/repo/code/packages/rust",
+          arduino_core: "/arduino/core",
+          arm_toolchain_bin: "/opt/arm/bin",
+          bossac_path: "/tmp/bossa/bin",
+          runner: runner
+        )
+
+        assert_equal "/dev/cu.usbmodem2201", connection.port
+        assert_equal "/repo/code/packages/rust", runner.calls.first[:chdir]
+        assert_equal [
+          "cargo", "run",
+          "-p", "board-vm-uno-r4-firmware",
+          "--bin", "uno-r4-wifi-serialusb-artifact",
+          "--",
+          "--core", "/arduino/core",
+          "--arm-toolchain-bin", "/opt/arm/bin",
+          "--bossac-path", "/tmp/bossa/bin",
+          "--port", "/dev/cu.usbmodem1101",
+          "--baud", "115200",
+          "--timeout-ms", "1000",
+          "--upload"
+        ], runner.calls.first[:argv]
+      end
+
+      def test_led_blink_runs_the_generic_board_vm_smoke_command
+        runner = FakeRunner.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          baud: 57_600,
+          timeout_ms: 250
+        ) do |board|
+          board.led.blink(program_id: 9, budget: 32, host_nonce: 123)
+        end
+
+        assert_equal [
+          "cargo", "run",
+          "-p", "board-vm-cli",
+          "--bin", "board-vm",
+          "--",
+          "smoke",
+          "--port", "/dev/cu.usbmodem2201",
+          "--baud", "57600",
+          "--timeout-ms", "250",
+          "--program-id", "9",
+          "--budget", "32",
+          "--host-nonce", "123"
+        ], runner.calls.first[:argv]
+      end
+
+      def test_eject_blink_writes_a_board_agnostic_artifact
+        runner = FakeRunner.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner
+        ) do |board|
+          board.eject.blink(to: "/tmp/ejected_blink.rs", slot: 2, boot_policy: :run_at_boot)
+        end
+
+        assert_equal [
+          "cargo", "run",
+          "-p", "board-vm-cli",
+          "--bin", "board-vm",
+          "--",
+          "eject", "blink",
+          "--out", "/tmp/ejected_blink.rs",
+          "--program-id", "1",
+          "--slot", "2",
+          "--boot-policy", "run-at-boot"
+        ], runner.calls.first[:argv]
+      end
+
+      def test_parse_new_upload_port_prefers_the_last_reported_port
+        output = "New upload port: /dev/cu.usbmodemBOOT (serial)\n" \
+          "New upload port: /dev/cu.usbmodemRUNTIME (serial)\n"
+
+        assert_equal "/dev/cu.usbmodemRUNTIME", Connection.parse_new_upload_port(output)
+      end
+
+      def test_rejects_unknown_boards_before_running_commands
+        runner = FakeRunner.new
+
+        assert_raises(UnsupportedBoardError) do
+          BoardVM.connect(board: :esp32, port: "/dev/cu.usbserial", runner: runner)
+        end
+
+        assert_empty runner.calls
+      end
+    end
+  end
+end

--- a/code/packages/ruby/board_vm/test/test_helper.rb
+++ b/code/packages/ruby/board_vm/test/test_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_board_vm"
+
+class FakeRunner
+  attr_reader :calls
+
+  def initialize(results = [])
+    @results = results
+    @calls = []
+  end
+
+  def call(argv, chdir: nil)
+    @calls << {argv: argv, chdir: chdir}
+    @results.shift || CodingAdventures::BoardVM::CommandResult.new(argv, chdir, "", "", 0)
+  end
+end


### PR DESCRIPTION
## Summary

- Add `coding_adventures_board_vm`, the first Ruby frontend package for Board VM sessions.
- Provide `CodingAdventures::BoardVM.uno_r4_wifi(..., flash: true) { |board| board.led.blink }` as the first high-level DSL path.
- Bridge the DSL to the existing Rust Uno R4 SerialUSB artifact helper for flashing and the generic `board-vm smoke` command for protocol-driven blink.
- Add `board.eject.blink(to: ...)` for the current board-agnostic blink ejection path.

## Notes

This first Ruby layer intentionally shells out to the Rust tools we already trust. The API surface is shaped so a future Ruby-native protocol transport can replace the subprocess bridge without changing the user-facing DSL.

## Validation

- `ruby -Ilib -Itest test/test_board_vm.rb`
- `bundle install --path vendor/bundle && bundle exec rake test`
- `gem build coding_adventures_board_vm.gemspec`
