### PR TITLE
[codex] Add binary byte helpers to language bridges

### DIFF
--- a/code/packages/rust/python-bridge/README.md
+++ b/code/packages/rust/python-bridge/README.md
@@ -11,6 +11,7 @@ A ~400-line crate that wraps only the raw Python C API functions needed to build
 | Category | Functions |
 |----------|-----------|
 | Strings | `str_to_py`, `str_from_py` |
+| Bytes | `bytes_to_py`, `bytes_from_py` |
 | Lists | `vec_str_to_py`, `vec_str_from_py`, `vec_vec_str_to_py`, `vec_tuple2_str_to_py` |
 | Sets | `set_str_to_py`, `set_str_from_py` |
 | Booleans | `bool_to_py` |

--- a/code/packages/rust/python-bridge/src/lib.rs
+++ b/code/packages/rust/python-bridge/src/lib.rs
@@ -74,6 +74,12 @@ extern "C" {
         unicode: PyObjectPtr,
         size: *mut isize,
     ) -> *const c_char;
+    pub fn PyBytes_FromStringAndSize(v: *const c_char, len: isize) -> PyObjectPtr;
+    pub fn PyBytes_AsStringAndSize(
+        obj: PyObjectPtr,
+        buffer: *mut *mut c_char,
+        length: *mut isize,
+    ) -> c_int;
 
     // -- List operations ---------------------------------------------------
     pub fn PyList_New(len: isize) -> PyObjectPtr;
@@ -223,6 +229,30 @@ pub unsafe fn str_from_py(obj: PyObjectPtr) -> Option<String> {
     }
     let slice = std::slice::from_raw_parts(ptr as *const u8, size as usize);
     String::from_utf8(slice.to_vec()).ok()
+}
+
+/// Convert a Rust byte slice to a Python `bytes` object (new reference).
+pub unsafe fn bytes_to_py(bytes: &[u8]) -> PyObjectPtr {
+    unsafe { PyBytes_FromStringAndSize(bytes.as_ptr() as *const c_char, bytes.len() as isize) }
+}
+
+/// Convert a Python `bytes` object to an owned Rust byte buffer.
+pub unsafe fn bytes_from_py(obj: PyObjectPtr) -> Option<Vec<u8>> {
+    if obj.is_null() {
+        return None;
+    }
+
+    let mut ptr: *mut c_char = ptr::null_mut();
+    let mut len: isize = 0;
+    if unsafe { PyBytes_AsStringAndSize(obj, &mut ptr, &mut len) } != 0 {
+        unsafe { PyErr_Clear() };
+        return None;
+    }
+    if ptr.is_null() || len < 0 {
+        return None;
+    }
+
+    Some(unsafe { std::slice::from_raw_parts(ptr as *const u8, len as usize) }.to_vec())
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/ruby-bridge/README.md
+++ b/code/packages/rust/ruby-bridge/README.md
@@ -14,6 +14,7 @@ A ~350-line crate that wraps only the raw Ruby C API functions needed to build n
 | Classes | `define_class_under` |
 | Methods | `define_method`, `define_singleton_method` |
 | Strings | `str_to_rb`, `str_from_rb` |
+| Binary strings | `bytes_to_rb`, `bytes_from_rb` |
 | Arrays | `array_new`, `array_push`, `vec_str_to_rb`, `vec_str_from_rb`, `vec_vec_str_to_rb` |
 | Booleans | `bool_to_rb`, `qtrue`, `qfalse`, `qnil` |
 | Integers | `usize_to_rb` |

--- a/code/packages/rust/ruby-bridge/src/lib.rs
+++ b/code/packages/rust/ruby-bridge/src/lib.rs
@@ -22,6 +22,7 @@
 //! On 64-bit systems, VALUE is `u64`. On 32-bit, it's `u32`.
 
 use std::ffi::{c_char, c_int, c_long, c_void, CString};
+use std::slice;
 
 // ---------------------------------------------------------------------------
 // The VALUE type
@@ -121,7 +122,9 @@ extern "C" {
     pub static rb_eRuntimeError: VALUE;
 
     // -- String operations -------------------------------------------------
+    pub fn rb_str_new(ptr: *const c_char, len: c_long) -> VALUE;
     pub fn rb_utf8_str_new(ptr: *const c_char, len: c_long) -> VALUE;
+    fn rb_string_value_ptr(ptr: *mut VALUE) -> *const c_char;
     fn rb_string_value_cstr(ptr: *mut VALUE) -> *const c_char;
 
     // -- Array operations --------------------------------------------------
@@ -288,6 +291,40 @@ pub fn str_from_rb(val: VALUE) -> Option<String> {
         }
         let c_str = std::ffi::CStr::from_ptr(ptr);
         c_str.to_str().ok().map(|s| s.to_string())
+    }
+}
+
+/// Convert a Rust byte slice to a Ruby String without interpreting it as
+/// UTF-8. This is the right helper for compact binary protocols, COBS frames,
+/// checksummed payloads, and buffers that may contain NUL bytes.
+pub fn bytes_to_rb(bytes: &[u8]) -> VALUE {
+    unsafe { rb_str_new(bytes.as_ptr() as *const c_char, bytes.len() as c_long) }
+}
+
+/// Convert a Ruby String VALUE to an owned Rust byte buffer.
+///
+/// Unlike `str_from_rb`, this preserves embedded NUL bytes and invalid UTF-8.
+pub fn bytes_from_rb(val: VALUE) -> Option<Vec<u8>> {
+    unsafe {
+        let mut v = val;
+        let ptr = rb_string_value_ptr(&mut v);
+        if ptr.is_null() {
+            return None;
+        }
+
+        let mid = rb_intern(b"bytesize\0".as_ptr() as *const c_char);
+        let len_val = rb_funcallv(v, mid, 0, std::ptr::null());
+        let len = rb_num2long(len_val);
+        if len < 0 {
+            return None;
+        }
+
+        let ptr = rb_string_value_ptr(&mut v);
+        if ptr.is_null() {
+            return None;
+        }
+
+        Some(slice::from_raw_parts(ptr as *const u8, len as usize).to_vec())
     }
 }
 


### PR DESCRIPTION
## Summary

- Add byte-preserving Ruby bridge helpers for binary protocol strings.
- Add Python bridge helpers for Python `bytes` objects.
- Document the new byte helpers in both bridge README files.

## Why

Board VM language bindings need to pass compact framed protocol bytes through Ruby, Python, and future language layers without treating those buffers as UTF-8 text. These helpers keep protocol/framing bytes in Rust bridge packages while language DSLs remain sugar on top.

## Validation

- `cargo test -p ruby-bridge -p python-bridge`
