### PR TITLE
Add seeded DOCTYPE lexer contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -29,6 +29,12 @@ documented in this file.
 - html5lib-style smoke fixture coverage for seeded comment continuations,
   including pending dash/bang preservation, abrupt close diagnostics, and
   bogus-comment recovery.
+- Parser/importer-facing seeded DOCTYPE continuation contexts, including
+  keyword/name, public/system identifier, after-identifier, and bogus-doctype
+  substates with partial doctype-token seeding.
+- html5lib-style smoke fixture coverage for seeded DOCTYPE continuations,
+  including missing-whitespace diagnostics, identifier accumulation, and
+  force-quirks preservation.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -184,6 +184,11 @@ including comment start/dash, less-than/bang/dash substates, end-dash/end-bang,
 and bogus-comment recovery. This lets html5lib-style importer cases resume
 comment tokenization with an in-progress comment token instead of treating those
 states as runtime gaps.
+DOCTYPE continuation states are also exposed through the same typed layer. A
+seeded `DoctypeSeed` carries the partial name, public identifier, system
+identifier, and force-quirks flag so importer and parser-adapter tests can
+resume keyword, name, public/system identifier, trailing-junk, and bogus
+DOCTYPE recovery paths without relying on raw generated state strings.
 Foreign-content CDATA is exposed as an explicit
 `HtmlLexContext::cdata_section()` helper rather than as an element-name mapping,
 so future SVG/MathML tree-construction logic can opt into CDATA only after it
@@ -231,7 +236,7 @@ fixture normalization logic to live forever inside the Rust tests.
 
 The normalized corpus now carries optional tokenizer-context metadata such as
 `initial_state` and `last_start_tag`, so upstream RCDATA, RAWTEXT, PLAINTEXT,
-CDATA section, comment continuation states, script data, script data
+CDATA section, comment and DOCTYPE continuation states, script data, script data
 escaped/dash/less-than/end-tag-open substates, and script data
 double-escaped/dash/less-than substates can already live in the shared Venture
 fixture format. Current Rust conformance tests now seed that context into the
@@ -246,6 +251,9 @@ mismatched tags that must remain literal text, EOF recovery that preserves the
 pending `</`, and matching end-tag diagnostics for whitespace, attributes, and
 trailing solidus. Comment continuation fixtures cover seeded body, pending dash,
 pending bang, nested-comment, abrupt-close, and bogus-comment recovery paths.
+DOCTYPE continuation fixtures cover keyword/name continuation, public/system
+identifier accumulation, missing-whitespace diagnostics, and bogus-doctype
+force-quirks preservation.
 
 The intended WHATWG/WPT path is to normalize upstream tokenizer cases into this
 same schema rather than teaching the Rust harness to parse raw upstream files

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -7,8 +7,8 @@
 use state_machine::{EffectfulStateMachine, StateMachineDefinition};
 
 pub use state_machine_tokenizer::{
-    Attribute, Diagnostic, Result, SourcePosition, Token, Tokenizer as HtmlLexer, TokenizerError,
-    TokenizerTraceEntry,
+    Attribute, Diagnostic, DoctypeSeed, Result, SourcePosition, Token, Tokenizer as HtmlLexer,
+    TokenizerError, TokenizerTraceEntry,
 };
 
 mod generated_html1;
@@ -54,6 +54,38 @@ pub enum HtmlTokenizerState {
     CommentEnd,
     CommentEndBang,
     BogusComment,
+    DoctypeKeywordO,
+    DoctypeKeywordC,
+    DoctypeKeywordT,
+    DoctypeKeywordY,
+    DoctypeKeywordP,
+    DoctypeKeywordE,
+    DoctypeAfterKeyword,
+    BeforeDoctypeName,
+    DoctypeName,
+    AfterDoctypeName,
+    DoctypePublicKeywordU,
+    DoctypePublicKeywordB,
+    DoctypePublicKeywordL,
+    DoctypePublicKeywordI,
+    DoctypePublicKeywordC,
+    AfterDoctypePublicKeyword,
+    BeforeDoctypePublicIdentifier,
+    DoctypePublicIdentifierDoubleQuoted,
+    DoctypePublicIdentifierSingleQuoted,
+    AfterDoctypePublicIdentifier,
+    BetweenDoctypePublicAndSystemIdentifiers,
+    DoctypeSystemKeywordY,
+    DoctypeSystemKeywordS,
+    DoctypeSystemKeywordT,
+    DoctypeSystemKeywordE,
+    DoctypeSystemKeywordM,
+    AfterDoctypeSystemKeyword,
+    BeforeDoctypeSystemIdentifier,
+    DoctypeSystemIdentifierDoubleQuoted,
+    DoctypeSystemIdentifierSingleQuoted,
+    AfterDoctypeSystemIdentifier,
+    BogusDoctype,
     ScriptData,
     ScriptDataLessThanSign,
     ScriptDataEndTagOpen,
@@ -81,7 +113,7 @@ pub enum HtmlTokenizerState {
 }
 
 /// Tokenizer states that are valid parser-facing entry points.
-pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 54] = [
+pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 86] = [
     HtmlTokenizerState::Data,
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
@@ -112,6 +144,38 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 54] = [
     HtmlTokenizerState::CommentEnd,
     HtmlTokenizerState::CommentEndBang,
     HtmlTokenizerState::BogusComment,
+    HtmlTokenizerState::DoctypeKeywordO,
+    HtmlTokenizerState::DoctypeKeywordC,
+    HtmlTokenizerState::DoctypeKeywordT,
+    HtmlTokenizerState::DoctypeKeywordY,
+    HtmlTokenizerState::DoctypeKeywordP,
+    HtmlTokenizerState::DoctypeKeywordE,
+    HtmlTokenizerState::DoctypeAfterKeyword,
+    HtmlTokenizerState::BeforeDoctypeName,
+    HtmlTokenizerState::DoctypeName,
+    HtmlTokenizerState::AfterDoctypeName,
+    HtmlTokenizerState::DoctypePublicKeywordU,
+    HtmlTokenizerState::DoctypePublicKeywordB,
+    HtmlTokenizerState::DoctypePublicKeywordL,
+    HtmlTokenizerState::DoctypePublicKeywordI,
+    HtmlTokenizerState::DoctypePublicKeywordC,
+    HtmlTokenizerState::AfterDoctypePublicKeyword,
+    HtmlTokenizerState::BeforeDoctypePublicIdentifier,
+    HtmlTokenizerState::DoctypePublicIdentifierDoubleQuoted,
+    HtmlTokenizerState::DoctypePublicIdentifierSingleQuoted,
+    HtmlTokenizerState::AfterDoctypePublicIdentifier,
+    HtmlTokenizerState::BetweenDoctypePublicAndSystemIdentifiers,
+    HtmlTokenizerState::DoctypeSystemKeywordY,
+    HtmlTokenizerState::DoctypeSystemKeywordS,
+    HtmlTokenizerState::DoctypeSystemKeywordT,
+    HtmlTokenizerState::DoctypeSystemKeywordE,
+    HtmlTokenizerState::DoctypeSystemKeywordM,
+    HtmlTokenizerState::AfterDoctypeSystemKeyword,
+    HtmlTokenizerState::BeforeDoctypeSystemIdentifier,
+    HtmlTokenizerState::DoctypeSystemIdentifierDoubleQuoted,
+    HtmlTokenizerState::DoctypeSystemIdentifierSingleQuoted,
+    HtmlTokenizerState::AfterDoctypeSystemIdentifier,
+    HtmlTokenizerState::BogusDoctype,
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
@@ -139,7 +203,7 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 54] = [
 ];
 
 /// Tokenizer states used for parser-controlled text or foreign-content fragments.
-pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 53] = [
+pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 85] = [
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::RcdataEndTagOpen,
@@ -169,6 +233,38 @@ pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 53] = [
     HtmlTokenizerState::CommentEnd,
     HtmlTokenizerState::CommentEndBang,
     HtmlTokenizerState::BogusComment,
+    HtmlTokenizerState::DoctypeKeywordO,
+    HtmlTokenizerState::DoctypeKeywordC,
+    HtmlTokenizerState::DoctypeKeywordT,
+    HtmlTokenizerState::DoctypeKeywordY,
+    HtmlTokenizerState::DoctypeKeywordP,
+    HtmlTokenizerState::DoctypeKeywordE,
+    HtmlTokenizerState::DoctypeAfterKeyword,
+    HtmlTokenizerState::BeforeDoctypeName,
+    HtmlTokenizerState::DoctypeName,
+    HtmlTokenizerState::AfterDoctypeName,
+    HtmlTokenizerState::DoctypePublicKeywordU,
+    HtmlTokenizerState::DoctypePublicKeywordB,
+    HtmlTokenizerState::DoctypePublicKeywordL,
+    HtmlTokenizerState::DoctypePublicKeywordI,
+    HtmlTokenizerState::DoctypePublicKeywordC,
+    HtmlTokenizerState::AfterDoctypePublicKeyword,
+    HtmlTokenizerState::BeforeDoctypePublicIdentifier,
+    HtmlTokenizerState::DoctypePublicIdentifierDoubleQuoted,
+    HtmlTokenizerState::DoctypePublicIdentifierSingleQuoted,
+    HtmlTokenizerState::AfterDoctypePublicIdentifier,
+    HtmlTokenizerState::BetweenDoctypePublicAndSystemIdentifiers,
+    HtmlTokenizerState::DoctypeSystemKeywordY,
+    HtmlTokenizerState::DoctypeSystemKeywordS,
+    HtmlTokenizerState::DoctypeSystemKeywordT,
+    HtmlTokenizerState::DoctypeSystemKeywordE,
+    HtmlTokenizerState::DoctypeSystemKeywordM,
+    HtmlTokenizerState::AfterDoctypeSystemKeyword,
+    HtmlTokenizerState::BeforeDoctypeSystemIdentifier,
+    HtmlTokenizerState::DoctypeSystemIdentifierDoubleQuoted,
+    HtmlTokenizerState::DoctypeSystemIdentifierSingleQuoted,
+    HtmlTokenizerState::AfterDoctypeSystemIdentifier,
+    HtmlTokenizerState::BogusDoctype,
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
@@ -223,6 +319,42 @@ pub const HTML_SCRIPT_TOKENIZER_STATES: [HtmlTokenizerState; 24] = [
     HtmlTokenizerState::ScriptDataDoubleEscapeEnd,
 ];
 
+/// Tokenizer states that resume an already-created DOCTYPE token.
+pub const HTML_DOCTYPE_TOKENIZER_STATES: [HtmlTokenizerState; 32] = [
+    HtmlTokenizerState::DoctypeKeywordO,
+    HtmlTokenizerState::DoctypeKeywordC,
+    HtmlTokenizerState::DoctypeKeywordT,
+    HtmlTokenizerState::DoctypeKeywordY,
+    HtmlTokenizerState::DoctypeKeywordP,
+    HtmlTokenizerState::DoctypeKeywordE,
+    HtmlTokenizerState::DoctypeAfterKeyword,
+    HtmlTokenizerState::BeforeDoctypeName,
+    HtmlTokenizerState::DoctypeName,
+    HtmlTokenizerState::AfterDoctypeName,
+    HtmlTokenizerState::DoctypePublicKeywordU,
+    HtmlTokenizerState::DoctypePublicKeywordB,
+    HtmlTokenizerState::DoctypePublicKeywordL,
+    HtmlTokenizerState::DoctypePublicKeywordI,
+    HtmlTokenizerState::DoctypePublicKeywordC,
+    HtmlTokenizerState::AfterDoctypePublicKeyword,
+    HtmlTokenizerState::BeforeDoctypePublicIdentifier,
+    HtmlTokenizerState::DoctypePublicIdentifierDoubleQuoted,
+    HtmlTokenizerState::DoctypePublicIdentifierSingleQuoted,
+    HtmlTokenizerState::AfterDoctypePublicIdentifier,
+    HtmlTokenizerState::BetweenDoctypePublicAndSystemIdentifiers,
+    HtmlTokenizerState::DoctypeSystemKeywordY,
+    HtmlTokenizerState::DoctypeSystemKeywordS,
+    HtmlTokenizerState::DoctypeSystemKeywordT,
+    HtmlTokenizerState::DoctypeSystemKeywordE,
+    HtmlTokenizerState::DoctypeSystemKeywordM,
+    HtmlTokenizerState::AfterDoctypeSystemKeyword,
+    HtmlTokenizerState::BeforeDoctypeSystemIdentifier,
+    HtmlTokenizerState::DoctypeSystemIdentifierDoubleQuoted,
+    HtmlTokenizerState::DoctypeSystemIdentifierSingleQuoted,
+    HtmlTokenizerState::AfterDoctypeSystemIdentifier,
+    HtmlTokenizerState::BogusDoctype,
+];
+
 impl HtmlTokenizerState {
     /// Machine-state identifier used by the generated static lexer.
     pub fn as_machine_state(self) -> &'static str {
@@ -257,6 +389,40 @@ impl HtmlTokenizerState {
             Self::CommentEnd => "comment_end",
             Self::CommentEndBang => "comment_end_bang",
             Self::BogusComment => "bogus_comment",
+            Self::DoctypeKeywordO => "doctype_keyword_o",
+            Self::DoctypeKeywordC => "doctype_keyword_c",
+            Self::DoctypeKeywordT => "doctype_keyword_t",
+            Self::DoctypeKeywordY => "doctype_keyword_y",
+            Self::DoctypeKeywordP => "doctype_keyword_p",
+            Self::DoctypeKeywordE => "doctype_keyword_e",
+            Self::DoctypeAfterKeyword => "doctype_after_keyword",
+            Self::BeforeDoctypeName => "before_doctype_name",
+            Self::DoctypeName => "doctype_name",
+            Self::AfterDoctypeName => "after_doctype_name",
+            Self::DoctypePublicKeywordU => "doctype_public_keyword_u",
+            Self::DoctypePublicKeywordB => "doctype_public_keyword_b",
+            Self::DoctypePublicKeywordL => "doctype_public_keyword_l",
+            Self::DoctypePublicKeywordI => "doctype_public_keyword_i",
+            Self::DoctypePublicKeywordC => "doctype_public_keyword_c",
+            Self::AfterDoctypePublicKeyword => "after_doctype_public_keyword",
+            Self::BeforeDoctypePublicIdentifier => "before_doctype_public_identifier",
+            Self::DoctypePublicIdentifierDoubleQuoted => "doctype_public_identifier_double_quoted",
+            Self::DoctypePublicIdentifierSingleQuoted => "doctype_public_identifier_single_quoted",
+            Self::AfterDoctypePublicIdentifier => "after_doctype_public_identifier",
+            Self::BetweenDoctypePublicAndSystemIdentifiers => {
+                "between_doctype_public_and_system_identifiers"
+            }
+            Self::DoctypeSystemKeywordY => "doctype_system_keyword_y",
+            Self::DoctypeSystemKeywordS => "doctype_system_keyword_s",
+            Self::DoctypeSystemKeywordT => "doctype_system_keyword_t",
+            Self::DoctypeSystemKeywordE => "doctype_system_keyword_e",
+            Self::DoctypeSystemKeywordM => "doctype_system_keyword_m",
+            Self::AfterDoctypeSystemKeyword => "after_doctype_system_keyword",
+            Self::BeforeDoctypeSystemIdentifier => "before_doctype_system_identifier",
+            Self::DoctypeSystemIdentifierDoubleQuoted => "doctype_system_identifier_double_quoted",
+            Self::DoctypeSystemIdentifierSingleQuoted => "doctype_system_identifier_single_quoted",
+            Self::AfterDoctypeSystemIdentifier => "after_doctype_system_identifier",
+            Self::BogusDoctype => "bogus_doctype",
             Self::ScriptData => "script_data",
             Self::ScriptDataLessThanSign => "script_data_less_than_sign",
             Self::ScriptDataEndTagOpen => "script_data_end_tag_open",
@@ -319,6 +485,48 @@ impl HtmlTokenizerState {
             Self::CommentEnd => "Comment end state",
             Self::CommentEndBang => "Comment end bang state",
             Self::BogusComment => "Bogus comment state",
+            Self::DoctypeKeywordO => "DOCTYPE keyword O state",
+            Self::DoctypeKeywordC => "DOCTYPE keyword C state",
+            Self::DoctypeKeywordT => "DOCTYPE keyword T state",
+            Self::DoctypeKeywordY => "DOCTYPE keyword Y state",
+            Self::DoctypeKeywordP => "DOCTYPE keyword P state",
+            Self::DoctypeKeywordE => "DOCTYPE keyword E state",
+            Self::DoctypeAfterKeyword => "DOCTYPE after keyword state",
+            Self::BeforeDoctypeName => "Before DOCTYPE name state",
+            Self::DoctypeName => "DOCTYPE name state",
+            Self::AfterDoctypeName => "After DOCTYPE name state",
+            Self::DoctypePublicKeywordU => "DOCTYPE public keyword U state",
+            Self::DoctypePublicKeywordB => "DOCTYPE public keyword B state",
+            Self::DoctypePublicKeywordL => "DOCTYPE public keyword L state",
+            Self::DoctypePublicKeywordI => "DOCTYPE public keyword I state",
+            Self::DoctypePublicKeywordC => "DOCTYPE public keyword C state",
+            Self::AfterDoctypePublicKeyword => "After DOCTYPE public keyword state",
+            Self::BeforeDoctypePublicIdentifier => "Before DOCTYPE public identifier state",
+            Self::DoctypePublicIdentifierDoubleQuoted => {
+                "DOCTYPE public identifier double quoted state"
+            }
+            Self::DoctypePublicIdentifierSingleQuoted => {
+                "DOCTYPE public identifier single quoted state"
+            }
+            Self::AfterDoctypePublicIdentifier => "After DOCTYPE public identifier state",
+            Self::BetweenDoctypePublicAndSystemIdentifiers => {
+                "Between DOCTYPE public and system identifiers state"
+            }
+            Self::DoctypeSystemKeywordY => "DOCTYPE system keyword Y state",
+            Self::DoctypeSystemKeywordS => "DOCTYPE system keyword S state",
+            Self::DoctypeSystemKeywordT => "DOCTYPE system keyword T state",
+            Self::DoctypeSystemKeywordE => "DOCTYPE system keyword E state",
+            Self::DoctypeSystemKeywordM => "DOCTYPE system keyword M state",
+            Self::AfterDoctypeSystemKeyword => "After DOCTYPE system keyword state",
+            Self::BeforeDoctypeSystemIdentifier => "Before DOCTYPE system identifier state",
+            Self::DoctypeSystemIdentifierDoubleQuoted => {
+                "DOCTYPE system identifier double quoted state"
+            }
+            Self::DoctypeSystemIdentifierSingleQuoted => {
+                "DOCTYPE system identifier single quoted state"
+            }
+            Self::AfterDoctypeSystemIdentifier => "After DOCTYPE system identifier state",
+            Self::BogusDoctype => "Bogus DOCTYPE state",
             Self::ScriptData => "Script data state",
             Self::ScriptDataLessThanSign => "Script data less-than sign state",
             Self::ScriptDataEndTagOpen => "Script data end tag open state",
@@ -378,6 +586,11 @@ impl HtmlTokenizerState {
     /// Return whether this state is a parser-approved script tokenizer substate.
     pub fn is_script_substate(self) -> bool {
         HTML_SCRIPT_TOKENIZER_STATES.contains(&self)
+    }
+
+    /// Return whether this state resumes an already-started DOCTYPE token.
+    pub fn requires_doctype_seed(self) -> bool {
+        HTML_DOCTYPE_TOKENIZER_STATES.contains(&self)
     }
 
     /// Return whether this state is a parser-approved fragment entry point.
@@ -455,6 +668,7 @@ pub struct HtmlLexContext {
     pub last_start_tag: Option<String>,
     pub current_end_tag: Option<String>,
     pub current_comment: Option<String>,
+    pub current_doctype: Option<DoctypeSeed>,
     pub temporary_buffer: Option<String>,
 }
 
@@ -465,6 +679,7 @@ impl HtmlLexContext {
             last_start_tag: None,
             current_end_tag: None,
             current_comment: None,
+            current_doctype: None,
             temporary_buffer: None,
         }
     }
@@ -511,6 +726,11 @@ impl HtmlLexContext {
         self
     }
 
+    pub fn with_current_doctype(mut self, doctype: DoctypeSeed) -> Self {
+        self.current_doctype = Some(doctype);
+        self
+    }
+
     pub fn with_temporary_buffer(mut self, value: impl Into<String>) -> Self {
         self.temporary_buffer = Some(value.into());
         self
@@ -521,6 +741,7 @@ impl HtmlLexContext {
             && self.last_start_tag.is_none()
             && self.current_end_tag.is_none()
             && self.current_comment.is_none()
+            && self.current_doctype.is_none()
             && self.temporary_buffer.is_none()
     }
 
@@ -536,6 +757,22 @@ impl HtmlLexContext {
     ) -> Option<Self> {
         if initial_state.requires_comment_seed() {
             Some(Self::new(initial_state).with_current_comment(data))
+        } else {
+            None
+        }
+    }
+
+    /// Return a DOCTYPE tokenizer continuation context for importer/parser tests.
+    ///
+    /// These states resume after markup-declaration logic has already created
+    /// the current DOCTYPE token. The seed carries whatever name/identifier and
+    /// force-quirks data the chosen state has already accumulated.
+    pub fn doctype_continuation(
+        initial_state: HtmlTokenizerState,
+        seed: DoctypeSeed,
+    ) -> Option<Self> {
+        if initial_state.requires_doctype_seed() {
+            Some(Self::new(initial_state).with_current_doctype(seed))
         } else {
             None
         }
@@ -621,6 +858,8 @@ pub fn apply_html_lex_context(lexer: &mut HtmlLexer, context: &HtmlLexContext) -
         lexer.set_current_end_tag(current_end_tag);
     } else if let Some(current_comment) = context.current_comment.as_deref() {
         lexer.set_current_comment(current_comment);
+    } else if let Some(current_doctype) = context.current_doctype.as_ref() {
+        lexer.set_current_doctype(current_doctype.clone());
     } else {
         lexer.clear_current_token();
     }

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -1,6 +1,6 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, html1_machine, html_skeleton_machine, Attribute,
-    HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token, HTML_TOKENIZER_STATES,
+    DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlTokenizerState, Token, HTML_TOKENIZER_STATES,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -37,7 +37,22 @@ struct FixtureCase {
     #[serde(default)]
     current_comment: Option<String>,
     #[serde(default)]
+    current_doctype: Option<FixtureDoctypeSeed>,
+    #[serde(default)]
     temporary_buffer: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+struct FixtureDoctypeSeed {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    public_identifier: Option<String>,
+    #[serde(default)]
+    system_identifier: Option<String>,
+    #[serde(default)]
+    force_quirks: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -61,6 +76,8 @@ struct Html5libTokenizerTest {
     temporary_buffer: Option<String>,
     #[serde(default, rename = "currentComment")]
     current_comment: Option<String>,
+    #[serde(default, rename = "currentDoctype")]
+    current_doctype: Option<FixtureDoctypeSeed>,
     #[serde(default)]
     errors: Vec<Html5libTokenizerError>,
 }
@@ -267,6 +284,16 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
                 && case.initial_state.as_deref() == Some("Comment end dash state")),
         "normalized fixtures should include seeded comment continuation states"
     );
+    assert!(
+        normalized.cases.iter().any(|case| case
+            .current_doctype
+            .as_ref()
+            .and_then(|seed| seed.name.as_deref())
+            == Some("html")
+            && case.initial_state.as_deref()
+                == Some("DOCTYPE public identifier double quoted state")),
+        "normalized fixtures should include seeded doctype continuation states"
+    );
 }
 
 #[test]
@@ -383,6 +410,7 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
             case.last_start_tag.is_none()
                 && case.current_end_tag.is_none()
                 && case.current_comment.is_none()
+                && case.current_doctype.is_none()
                 && case.temporary_buffer.is_none()
         }
         Some(initial_state) => {
@@ -392,11 +420,17 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
             let has_end_tag_seed =
                 case.current_end_tag.is_some() && case.temporary_buffer.is_some();
             let has_comment_seed = case.current_comment.is_some();
+            let has_doctype_seed = case.current_doctype.is_some();
             state.requires_last_start_tag() == case.last_start_tag.is_some()
                 && state.requires_end_tag_seed() == has_end_tag_seed
                 && state.requires_comment_seed() == has_comment_seed
+                && state.requires_doctype_seed() == has_doctype_seed
                 && (has_end_tag_seed
                     || (case.current_end_tag.is_none() && case.temporary_buffer.is_none()))
+                && (!has_doctype_seed
+                    || (case.current_end_tag.is_none()
+                        && case.current_comment.is_none()
+                        && case.temporary_buffer.is_none()))
         }
     }
 }
@@ -458,6 +492,14 @@ fn configure_lexer_for_case(
     }
     if let Some(current_comment) = case.current_comment.as_deref() {
         context = context.with_current_comment(current_comment);
+    }
+    if let Some(current_doctype) = case.current_doctype.as_ref() {
+        context = context.with_current_doctype(DoctypeSeed {
+            name: current_doctype.name.clone(),
+            public_identifier: current_doctype.public_identifier.clone(),
+            system_identifier: current_doctype.system_identifier.clone(),
+            force_quirks: current_doctype.force_quirks,
+        });
     }
     if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
         context = context.with_temporary_buffer(temporary_buffer);

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -30,6 +30,7 @@ Each file is a JSON object with this shape:
       "initial_state": "optional tokenizer state context",
       "last_start_tag": "optional tokenizer tag context",
       "current_end_tag": "optional in-progress end-tag token context",
+      "current_doctype": "optional in-progress doctype token context",
       "temporary_buffer": "optional tokenizer temporary-buffer context",
       "diagnostics": ["optional-diagnostic-code"]
     }
@@ -70,6 +71,9 @@ fields; the normalizer lowers them to `current_end_tag` and `temporary_buffer`.
 Comment continuation fixtures likewise accept a `currentComment` extension
 field, lowered to `current_comment`, so html5lib-style comment substates can
 resume with an already-created comment token.
+DOCTYPE continuation fixtures accept a `currentDoctype` extension object,
+lowered to `current_doctype`, with optional `name`, `public_identifier`,
+`system_identifier`, and `force_quirks` fields for the partial doctype token.
 
 `normalize_html5lib_fixtures.py` is the checked-in importer for this shape. It
 currently supports:
@@ -84,6 +88,8 @@ currently supports:
 - comment `start`, `start dash`, body, less-than-sign, less-than-sign bang,
   less-than-sign bang dash, less-than-sign bang dash dash, end-dash, end,
   end-bang, and bogus-comment substates together with `currentComment`
+- DOCTYPE keyword/name, public/system keyword, public/system identifier,
+  after-identifier, and bogus-doctype substates together with `currentDoctype`
 - `initialStates: ["Script data state"]` together with `lastStartTag`
 - script `less-than sign`, `escape start`, and `escape start dash` substates
   together with `lastStartTag`
@@ -178,14 +184,15 @@ than silently disappearing. Rust conformance tests execute the generated
 `html5lib-smoke.json` corpus and separately parse the raw upstream-style file to
 keep the intake path visible. Tokenizer-context cases such as RCDATA, RAWTEXT,
 script submodes, CDATA bracket/end states, resumable end-tag-open states, and
-seeded end-tag and comment continuation states stay in the generated corpus with context
-metadata and are seeded into the Rust wrapper at test time, while still
+seeded end-tag, comment, and DOCTYPE continuation states stay in the generated
+corpus with context metadata and are seeded into the Rust wrapper at test time, while still
 unsupported upstream states remain recorded under `skipped` instead of being
 discarded. End-tag continuation coverage intentionally exercises matching,
 mismatched, EOF, and diagnostic recovery paths so parser/tokenizer handoff
 regressions show up in the shared fixture corpus instead of only in narrow unit
 tests. Comment continuation coverage does the same for pending dash/bang and
-bogus-comment recovery paths.
+bogus-comment recovery paths. DOCTYPE continuation coverage exercises partial
+keyword/name, identifier, diagnostic, and bogus-doctype recovery paths.
 
 To regenerate the normalized corpus:
 

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -5,6 +5,16 @@
   "source": "upstream-html5lib-smoke.test",
   "generator": "normalize_html5lib_fixtures.py",
   "supported_initial_states": [
+    "After DOCTYPE name state",
+    "After DOCTYPE public identifier state",
+    "After DOCTYPE public keyword state",
+    "After DOCTYPE system identifier state",
+    "After DOCTYPE system keyword state",
+    "Before DOCTYPE name state",
+    "Before DOCTYPE public identifier state",
+    "Before DOCTYPE system identifier state",
+    "Between DOCTYPE public and system identifiers state",
+    "Bogus DOCTYPE state",
     "Bogus comment state",
     "CDATA section bracket state",
     "CDATA section end state",
@@ -19,6 +29,28 @@
     "Comment start dash state",
     "Comment start state",
     "Comment state",
+    "DOCTYPE after keyword state",
+    "DOCTYPE keyword C state",
+    "DOCTYPE keyword E state",
+    "DOCTYPE keyword O state",
+    "DOCTYPE keyword P state",
+    "DOCTYPE keyword T state",
+    "DOCTYPE keyword Y state",
+    "DOCTYPE name state",
+    "DOCTYPE public identifier double quoted state",
+    "DOCTYPE public identifier single quoted state",
+    "DOCTYPE public keyword B state",
+    "DOCTYPE public keyword C state",
+    "DOCTYPE public keyword I state",
+    "DOCTYPE public keyword L state",
+    "DOCTYPE public keyword U state",
+    "DOCTYPE system identifier double quoted state",
+    "DOCTYPE system identifier single quoted state",
+    "DOCTYPE system keyword E state",
+    "DOCTYPE system keyword M state",
+    "DOCTYPE system keyword S state",
+    "DOCTYPE system keyword T state",
+    "DOCTYPE system keyword Y state",
     "Data state",
     "PLAINTEXT state",
     "RAWTEXT end tag attributes state",
@@ -2687,6 +2719,81 @@
       "diagnostics": [],
       "initial_state": "Bogus comment state",
       "current_comment": "bogus-"
+    },
+    {
+      "id": "html5lib-smoke-209",
+      "description": "doctype keyword continuation completes keyword and name",
+      "input": "OCTYPE html>tail",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "DOCTYPE keyword O state",
+      "current_doctype": {}
+    },
+    {
+      "id": "html5lib-smoke-210",
+      "description": "doctype name continuation appends to seeded name",
+      "input": "ml>",
+      "tokens": [
+        "Doctype(name=html, force_quirks=false)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "DOCTYPE name state",
+      "current_doctype": {
+        "name": "ht"
+      }
+    },
+    {
+      "id": "html5lib-smoke-211",
+      "description": "doctype public identifier continuation completes public and system ids",
+      "input": "b\" \"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "DOCTYPE public identifier double quoted state",
+      "current_doctype": {
+        "name": "html",
+        "public_identifier": "pu"
+      }
+    },
+    {
+      "id": "html5lib-smoke-212",
+      "description": "doctype after public identifier continuation reports missing whitespace before system id",
+      "input": "\"sys\">",
+      "tokens": [
+        "Doctype(name=html, public_identifier=pub, system_identifier=sys, force_quirks=false)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-whitespace-between-doctype-public-and-system-identifiers"
+      ],
+      "initial_state": "After DOCTYPE public identifier state",
+      "current_doctype": {
+        "name": "html",
+        "public_identifier": "pub"
+      }
+    },
+    {
+      "id": "html5lib-smoke-213",
+      "description": "bogus doctype continuation preserves seeded force quirks",
+      "input": "ignored>tail",
+      "tokens": [
+        "Doctype(name=html, force_quirks=true)",
+        "Text(data=tail)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Bogus DOCTYPE state",
+      "current_doctype": {
+        "name": "html",
+        "force_quirks": true
+      }
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -26,6 +26,38 @@ SUPPORTED_INITIAL_STATES = {
     "Comment start state",
     "Comment state",
     "Data state",
+    "DOCTYPE after keyword state",
+    "DOCTYPE keyword C state",
+    "DOCTYPE keyword E state",
+    "DOCTYPE keyword O state",
+    "DOCTYPE keyword P state",
+    "DOCTYPE keyword T state",
+    "DOCTYPE keyword Y state",
+    "DOCTYPE name state",
+    "DOCTYPE public identifier double quoted state",
+    "DOCTYPE public identifier single quoted state",
+    "DOCTYPE public keyword B state",
+    "DOCTYPE public keyword C state",
+    "DOCTYPE public keyword I state",
+    "DOCTYPE public keyword L state",
+    "DOCTYPE public keyword U state",
+    "DOCTYPE system identifier double quoted state",
+    "DOCTYPE system identifier single quoted state",
+    "DOCTYPE system keyword E state",
+    "DOCTYPE system keyword M state",
+    "DOCTYPE system keyword S state",
+    "DOCTYPE system keyword T state",
+    "DOCTYPE system keyword Y state",
+    "After DOCTYPE name state",
+    "After DOCTYPE public identifier state",
+    "After DOCTYPE public keyword state",
+    "After DOCTYPE system identifier state",
+    "After DOCTYPE system keyword state",
+    "Before DOCTYPE name state",
+    "Before DOCTYPE public identifier state",
+    "Before DOCTYPE system identifier state",
+    "Between DOCTYPE public and system identifiers state",
+    "Bogus DOCTYPE state",
     "PLAINTEXT state",
     "RCDATA end tag attributes state",
     "RCDATA end tag name state",
@@ -141,6 +173,41 @@ COMMENT_SEED_INITIAL_STATES = {
     "Comment state",
 }
 
+DOCTYPE_SEED_INITIAL_STATES = {
+    "DOCTYPE after keyword state",
+    "DOCTYPE keyword C state",
+    "DOCTYPE keyword E state",
+    "DOCTYPE keyword O state",
+    "DOCTYPE keyword P state",
+    "DOCTYPE keyword T state",
+    "DOCTYPE keyword Y state",
+    "DOCTYPE name state",
+    "DOCTYPE public identifier double quoted state",
+    "DOCTYPE public identifier single quoted state",
+    "DOCTYPE public keyword B state",
+    "DOCTYPE public keyword C state",
+    "DOCTYPE public keyword I state",
+    "DOCTYPE public keyword L state",
+    "DOCTYPE public keyword U state",
+    "DOCTYPE system identifier double quoted state",
+    "DOCTYPE system identifier single quoted state",
+    "DOCTYPE system keyword E state",
+    "DOCTYPE system keyword M state",
+    "DOCTYPE system keyword S state",
+    "DOCTYPE system keyword T state",
+    "DOCTYPE system keyword Y state",
+    "After DOCTYPE name state",
+    "After DOCTYPE public identifier state",
+    "After DOCTYPE public keyword state",
+    "After DOCTYPE system identifier state",
+    "After DOCTYPE system keyword state",
+    "Before DOCTYPE name state",
+    "Before DOCTYPE public identifier state",
+    "Before DOCTYPE system identifier state",
+    "Between DOCTYPE public and system identifiers state",
+    "Bogus DOCTYPE state",
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -249,6 +316,21 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if has_comment_seed and (has_end_tag_seed or has_partial_end_tag_seed):
         return False, "currentComment cannot be combined with end-tag continuation context"
 
+    needs_doctype_seed = [
+        initial_state
+        for initial_state in initial_states
+        if initial_state in DOCTYPE_SEED_INITIAL_STATES
+    ]
+    has_doctype_seed = isinstance(test.get("currentDoctype"), dict)
+    if needs_doctype_seed and not has_doctype_seed:
+        return False, f"{needs_doctype_seed[0]} requires currentDoctype"
+
+    if has_doctype_seed and len(needs_doctype_seed) != len(initial_states):
+        return False, "currentDoctype only supported for doctype continuation states"
+
+    if has_doctype_seed and (has_end_tag_seed or has_partial_end_tag_seed or has_comment_seed):
+        return False, "currentDoctype cannot be combined with other current-token context"
+
     for token in test.get("output", []):
         kind = token[0]
         if kind not in {"Character", "StartTag", "EndTag", "Comment", "DOCTYPE"}:
@@ -327,6 +409,10 @@ def normalize_case(
     current_comment = test.get("currentComment")
     if current_comment is not None:
         normalized["current_comment"] = current_comment
+
+    current_doctype = test.get("currentDoctype")
+    if current_doctype is not None:
+        normalized["current_doctype"] = current_doctype
 
     return normalized
 

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -2974,6 +2974,117 @@
           "after"
         ]
       ]
+    },
+    {
+      "description": "doctype keyword continuation completes keyword and name",
+      "input": "OCTYPE html>tail",
+      "initialStates": [
+        "DOCTYPE keyword O state"
+      ],
+      "currentDoctype": {},
+      "output": [
+        [
+          "DOCTYPE",
+          "html",
+          null,
+          null,
+          true
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ]
+    },
+    {
+      "description": "doctype name continuation appends to seeded name",
+      "input": "ml>",
+      "initialStates": [
+        "DOCTYPE name state"
+      ],
+      "currentDoctype": {
+        "name": "ht"
+      },
+      "output": [
+        [
+          "DOCTYPE",
+          "html",
+          null,
+          null,
+          true
+        ]
+      ]
+    },
+    {
+      "description": "doctype public identifier continuation completes public and system ids",
+      "input": "b\" \"sys\">",
+      "initialStates": [
+        "DOCTYPE public identifier double quoted state"
+      ],
+      "currentDoctype": {
+        "name": "html",
+        "public_identifier": "pu"
+      },
+      "output": [
+        [
+          "DOCTYPE",
+          "html",
+          "pub",
+          "sys",
+          true
+        ]
+      ]
+    },
+    {
+      "description": "doctype after public identifier continuation reports missing whitespace before system id",
+      "input": "\"sys\">",
+      "initialStates": [
+        "After DOCTYPE public identifier state"
+      ],
+      "currentDoctype": {
+        "name": "html",
+        "public_identifier": "pub"
+      },
+      "output": [
+        [
+          "DOCTYPE",
+          "html",
+          "pub",
+          "sys",
+          true
+        ]
+      ],
+      "errors": [
+        {
+          "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "bogus doctype continuation preserves seeded force quirks",
+      "input": "ignored>tail",
+      "initialStates": [
+        "Bogus DOCTYPE state"
+      ],
+      "currentDoctype": {
+        "name": "html",
+        "force_quirks": true
+      },
+      "output": [
+        [
+          "DOCTYPE",
+          "html",
+          null,
+          null,
+          false
+        ],
+        [
+          "Character",
+          "tail"
+        ]
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1,8 +1,9 @@
 use coding_adventures_html_lexer::{
     apply_html_lex_context, create_html_lexer, create_html_lexer_with_context, html1_definition,
     html1_machine, html_skeleton_definition, html_skeleton_machine, lex_html, lex_html_fragment,
-    Attribute, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token,
-    HTML_FRAGMENT_TOKENIZER_STATES, HTML_SCRIPT_TOKENIZER_STATES, HTML_TOKENIZER_STATES,
+    Attribute, DoctypeSeed, HtmlLexContext, HtmlScriptingMode, HtmlTokenizerState, Token,
+    HTML_DOCTYPE_TOKENIZER_STATES, HTML_FRAGMENT_TOKENIZER_STATES, HTML_SCRIPT_TOKENIZER_STATES,
+    HTML_TOKENIZER_STATES,
 };
 use state_machine::END_INPUT;
 
@@ -5057,6 +5058,38 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "comment_end",
             "comment_end_bang",
             "bogus_comment",
+            "doctype_keyword_o",
+            "doctype_keyword_c",
+            "doctype_keyword_t",
+            "doctype_keyword_y",
+            "doctype_keyword_p",
+            "doctype_keyword_e",
+            "doctype_after_keyword",
+            "before_doctype_name",
+            "doctype_name",
+            "after_doctype_name",
+            "doctype_public_keyword_u",
+            "doctype_public_keyword_b",
+            "doctype_public_keyword_l",
+            "doctype_public_keyword_i",
+            "doctype_public_keyword_c",
+            "after_doctype_public_keyword",
+            "before_doctype_public_identifier",
+            "doctype_public_identifier_double_quoted",
+            "doctype_public_identifier_single_quoted",
+            "after_doctype_public_identifier",
+            "between_doctype_public_and_system_identifiers",
+            "doctype_system_keyword_y",
+            "doctype_system_keyword_s",
+            "doctype_system_keyword_t",
+            "doctype_system_keyword_e",
+            "doctype_system_keyword_m",
+            "after_doctype_system_keyword",
+            "before_doctype_system_identifier",
+            "doctype_system_identifier_double_quoted",
+            "doctype_system_identifier_single_quoted",
+            "after_doctype_system_identifier",
+            "bogus_doctype",
             "script_data",
             "script_data_less_than_sign",
             "script_data_end_tag_open",
@@ -5148,9 +5181,51 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
     assert!(HtmlTokenizerState::Comment.requires_comment_seed());
     assert!(HtmlTokenizerState::CommentEndDash.requires_comment_seed());
     assert!(HtmlTokenizerState::BogusComment.requires_comment_seed());
+    assert!(HtmlTokenizerState::DoctypeName.requires_doctype_seed());
+    assert!(HtmlTokenizerState::AfterDoctypePublicIdentifier.requires_doctype_seed());
+    assert!(HtmlTokenizerState::BogusDoctype.requires_doctype_seed());
     assert!(!HtmlTokenizerState::RcdataEndTagOpen.requires_end_tag_seed());
     assert!(!HtmlTokenizerState::CdataSectionEnd.requires_last_start_tag());
     assert!(!HtmlTokenizerState::Data.requires_comment_seed());
+    assert!(!HtmlTokenizerState::Data.requires_doctype_seed());
+
+    assert_eq!(
+        HTML_DOCTYPE_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),
+        [
+            "doctype_keyword_o",
+            "doctype_keyword_c",
+            "doctype_keyword_t",
+            "doctype_keyword_y",
+            "doctype_keyword_p",
+            "doctype_keyword_e",
+            "doctype_after_keyword",
+            "before_doctype_name",
+            "doctype_name",
+            "after_doctype_name",
+            "doctype_public_keyword_u",
+            "doctype_public_keyword_b",
+            "doctype_public_keyword_l",
+            "doctype_public_keyword_i",
+            "doctype_public_keyword_c",
+            "after_doctype_public_keyword",
+            "before_doctype_public_identifier",
+            "doctype_public_identifier_double_quoted",
+            "doctype_public_identifier_single_quoted",
+            "after_doctype_public_identifier",
+            "between_doctype_public_and_system_identifiers",
+            "doctype_system_keyword_y",
+            "doctype_system_keyword_s",
+            "doctype_system_keyword_t",
+            "doctype_system_keyword_e",
+            "doctype_system_keyword_m",
+            "after_doctype_system_keyword",
+            "before_doctype_system_identifier",
+            "doctype_system_identifier_double_quoted",
+            "doctype_system_identifier_single_quoted",
+            "after_doctype_system_identifier",
+            "bogus_doctype",
+        ]
+    );
 }
 
 #[test]
@@ -5389,6 +5464,152 @@ fn parser_facing_context_seeds_comment_continuation_states() {
 
     assert_eq!(
         HtmlLexContext::comment_continuation(HtmlTokenizerState::Rcdata, "nope"),
+        None
+    );
+}
+
+#[test]
+fn parser_facing_context_seeds_doctype_continuation_states() {
+    let keyword = HtmlLexContext::doctype_continuation(
+        HtmlTokenizerState::DoctypeKeywordO,
+        DoctypeSeed::new(),
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("OCTYPE html>tail", &keyword).unwrap(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: None,
+                system_identifier: None,
+                force_quirks: false
+            },
+            Token::Text("tail".to_string()),
+            Token::Eof
+        ]
+    );
+
+    let name = HtmlLexContext::doctype_continuation(
+        HtmlTokenizerState::DoctypeName,
+        DoctypeSeed::with_name("ht"),
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("ml>", &name).unwrap(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: None,
+                system_identifier: None,
+                force_quirks: false
+            },
+            Token::Eof
+        ]
+    );
+
+    let after_name = HtmlLexContext::doctype_continuation(
+        HtmlTokenizerState::AfterDoctypeName,
+        DoctypeSeed::with_name("html"),
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("PUBLIC \"pub\" \"sys\">", &after_name).unwrap(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: Some("pub".to_string()),
+                system_identifier: Some("sys".to_string()),
+                force_quirks: false
+            },
+            Token::Eof
+        ]
+    );
+
+    let public_identifier = HtmlLexContext::doctype_continuation(
+        HtmlTokenizerState::DoctypePublicIdentifierDoubleQuoted,
+        DoctypeSeed {
+            name: Some("html".to_string()),
+            public_identifier: Some("pu".to_string()),
+            system_identifier: None,
+            force_quirks: false,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("b\" \"sys\">", &public_identifier).unwrap(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: Some("pub".to_string()),
+                system_identifier: Some("sys".to_string()),
+                force_quirks: false
+            },
+            Token::Eof
+        ]
+    );
+
+    let mut lexer = create_html_lexer_with_context(
+        &HtmlLexContext::doctype_continuation(
+            HtmlTokenizerState::AfterDoctypePublicIdentifier,
+            DoctypeSeed {
+                name: Some("html".to_string()),
+                public_identifier: Some("pub".to_string()),
+                system_identifier: None,
+                force_quirks: false,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    lexer.push("\"sys\">").unwrap();
+    lexer.finish().unwrap();
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: Some("pub".to_string()),
+                system_identifier: Some("sys".to_string()),
+                force_quirks: false
+            },
+            Token::Eof
+        ]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec!["missing-whitespace-between-doctype-public-and-system-identifiers"]
+    );
+
+    let bogus = HtmlLexContext::doctype_continuation(
+        HtmlTokenizerState::BogusDoctype,
+        DoctypeSeed {
+            name: Some("html".to_string()),
+            public_identifier: None,
+            system_identifier: None,
+            force_quirks: true,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("ignored>tail", &bogus).unwrap(),
+        vec![
+            Token::Doctype {
+                name: Some("html".to_string()),
+                public_identifier: None,
+                system_identifier: None,
+                force_quirks: true
+            },
+            Token::Text("tail".to_string()),
+            Token::Eof
+        ]
+    );
+
+    assert_eq!(
+        HtmlLexContext::doctype_continuation(HtmlTokenizerState::Rcdata, DoctypeSeed::new()),
         None
     );
 }

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -45,3 +45,6 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
   without `;`.
 - Added current-comment seeding helpers so wrapper packages can resume
   comment-token continuation states without loading tokenizer definition files.
+- Added `DoctypeSeed` and current-DOCTYPE seeding helpers so wrapper packages
+  can resume DOCTYPE continuation states while preserving partial name,
+  identifier, and force-quirks data.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -127,9 +127,11 @@ duplicates can continue using plain `commit_attribute`.
 The runtime also exposes context-seeding helpers such as
 `Tokenizer::set_initial_state`, `Tokenizer::set_last_start_tag`,
 `Tokenizer::set_current_end_tag`, `Tokenizer::set_current_comment`, and
-`Tokenizer::set_temporary_buffer` so wrapper packages can execute HTML submodes
-and continuation states like RCDATA end-tag-name or comment end-dash without
-loading definition files at runtime.
+`Tokenizer::set_current_doctype` with `DoctypeSeed`, plus
+`Tokenizer::set_temporary_buffer`, so wrapper packages can execute HTML
+submodes and continuation states like RCDATA end-tag-name, comment end-dash, or
+DOCTYPE public identifier continuation without loading definition files at
+runtime.
 
 Wrapper packages can opt into HTML-style input-stream newline preprocessing
 with `Tokenizer::with_normalized_carriage_returns`. That maps CRLF pairs and

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -47,6 +47,34 @@ pub enum Token {
     Eof,
 }
 
+/// Seed data for resuming tokenizer states with an in-progress DOCTYPE token.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DoctypeSeed {
+    /// Optional doctype name accumulated so far.
+    pub name: Option<String>,
+    /// Optional public identifier accumulated so far.
+    pub public_identifier: Option<String>,
+    /// Optional system identifier accumulated so far.
+    pub system_identifier: Option<String>,
+    /// Whether the partial doctype has already entered force-quirks mode.
+    pub force_quirks: bool,
+}
+
+impl DoctypeSeed {
+    /// Build an empty DOCTYPE seed.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a DOCTYPE seed with an already-accumulated name.
+    pub fn with_name(name: impl Into<String>) -> Self {
+        Self {
+            name: Some(name.into()),
+            ..Self::default()
+        }
+    }
+}
+
 /// Attribute attached to a start tag.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Attribute {
@@ -296,6 +324,23 @@ impl Tokenizer {
     /// Store the in-progress comment token used by tokenizer continuation states.
     pub fn set_current_comment(&mut self, data: impl Into<String>) {
         self.current_token = Some(CurrentToken::Comment { data: data.into() });
+        self.current_attribute = None;
+    }
+
+    /// Seed the in-progress DOCTYPE token used by tokenizer continuation states.
+    pub fn with_current_doctype(mut self, doctype: DoctypeSeed) -> Self {
+        self.set_current_doctype(doctype);
+        self
+    }
+
+    /// Store the in-progress DOCTYPE token used by tokenizer continuation states.
+    pub fn set_current_doctype(&mut self, doctype: DoctypeSeed) {
+        self.current_token = Some(CurrentToken::Doctype {
+            name: doctype.name,
+            public_identifier: doctype.public_identifier,
+            system_identifier: doctype.system_identifier,
+            force_quirks: doctype.force_quirks,
+        });
         self.current_attribute = None;
     }
 


### PR DESCRIPTION
## Summary

- Add `DoctypeSeed` and tokenizer runtime helpers for resuming in-progress DOCTYPE tokens.
- Expose typed parser/importer-facing DOCTYPE continuation states through `HtmlTokenizerState`, `HtmlLexContext`, and state-set validation.
- Expand html5lib-style normalization, generated smoke fixtures, docs, and direct lexer coverage for keyword/name, public/system identifier, missing-whitespace, and bogus-doctype recovery paths.

## Verification

- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check
