### PR TITLE
[codex] Add Ruby native Board VM language bridge

### DIFF
--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -39,6 +39,19 @@ The helper output is inspected for Arduino CLI's `New upload port:` handoff so
 subsequent Ruby DSL commands use the runtime CDC port when the board
 re-enumerates.
 
+The gem now ships a `board_vm_native` extension built with `ruby-bridge`. That
+extension exposes `CodingAdventures::BoardVM::Native::Session`, whose methods
+return binary Ruby strings produced by `board-vm-language-core`:
+
+```ruby
+session = CodingAdventures::BoardVM::Native::Session.new
+frames = session.blink_upload_run_frames(1, 12, 13, 250, 250, 4)
+```
+
+Each element in `frames` is a COBS/CRC-framed Board VM request ready for a
+transport to write to the board. Ruby owns the friendly shape; Rust owns the
+wire bytes.
+
 Inside the block, `board.led.blink` currently runs the shared Rust host smoke
 command:
 
@@ -47,11 +60,11 @@ cargo run -p board-vm-cli --bin board-vm -- smoke ...
 ```
 
 That smoke command sends `HELLO`, queries capabilities, uploads the standard
-blink module, and starts it through the binary protocol. Future Ruby releases
-should replace this subprocess bridge with a native extension built on
-`ruby-bridge` and `board-vm-language-core`, then send the Rust-built wire frames
-through a transport. The DSL surface should stay Ruby-shaped, but every board
-operation should still dispatch the Board VM binary protocol produced by Rust.
+blink module, and starts it through the binary protocol. The next Ruby step is
+to route `board.led.blink` through `BoardVM::Native::Session` plus a transport
+instead of through this subprocess bridge. The DSL surface should stay
+Ruby-shaped, but every board operation should still dispatch the Board VM
+binary protocol produced by Rust.
 
 The DSL also exposes the current board-agnostic blink ejection path:
 

--- a/code/packages/ruby/board_vm/Rakefile
+++ b/code/packages/ruby/board_vm/Rakefile
@@ -1,11 +1,47 @@
 # frozen_string_literal: true
 
 require "rake/testtask"
+require "rbconfig"
+
+DLEXT = RbConfig::CONFIG["DLEXT"]
+EXT_DIR = File.expand_path("ext/board_vm_native", __dir__)
+LIB_DIR = File.expand_path("lib", __dir__)
+CARGO_LIB = case RbConfig::CONFIG["host_os"]
+            when /darwin/
+              "libboard_vm_native.dylib"
+            when /mingw|mswin|cygwin/
+              "board_vm_native.dll"
+            else
+              "libboard_vm_native.so"
+            end
+TARGET = "board_vm_native.#{DLEXT}"
+
+desc "Compile the Rust Board VM native extension"
+task :compile do
+  cd EXT_DIR do
+    sh "cargo build --release"
+  end
+
+  src = File.join(EXT_DIR, "target", "release", CARGO_LIB)
+  dst = File.join(LIB_DIR, TARGET)
+  mkdir_p LIB_DIR
+  cp src, dst
+end
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task test: :compile
+
+desc "Remove native extension build artifacts"
+task :clean do
+  cd EXT_DIR do
+    sh "cargo clean" if File.exist?("Cargo.toml")
+  end
+  rm_f Dir[File.join(LIB_DIR, "board_vm_native.*")]
 end
 
 task default: :test

--- a/code/packages/ruby/board_vm/coding_adventures_board_vm.gemspec
+++ b/code/packages/ruby/board_vm/coding_adventures_board_vm.gemspec
@@ -7,12 +7,13 @@ Gem::Specification.new do |spec|
   spec.version = CodingAdventures::BoardVM::VERSION
   spec.authors = ["Adhithya Rajasekaran"]
   spec.summary = "Ruby DSL for Board VM hardware sessions"
-  spec.description = "Provides a small Ruby DSL for flashing a Board VM runtime and driving LED blink sessions through the shared Rust host tools."
+  spec.description = "Provides a small Ruby DSL for flashing a Board VM runtime and driving LED blink sessions through Rust-owned Board VM protocol frames."
   spec.homepage = "https://github.com/adhithyan15/coding-adventures"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
-  spec.files = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.files = Dir["lib/**/*.rb", "ext/**/*.{rb,rs,toml}", "README.md", "CHANGELOG.md"]
   spec.require_paths = ["lib"]
+  spec.extensions = ["ext/board_vm_native/extconf.rb"]
   spec.metadata = {
     "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
     "rubygems_mfa_required" => "true"

--- a/code/packages/ruby/board_vm/ext/board_vm_native/Cargo.toml
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+
+[package]
+name = "board-vm-native-ruby"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "board_vm_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+board-vm-host = { path = "../../../../rust/board-vm-host" }
+board-vm-language-core = { path = "../../../../rust/board-vm-language-core" }
+ruby-bridge = { path = "../../../../rust/ruby-bridge" }

--- a/code/packages/ruby/board_vm/ext/board_vm_native/build.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/build.rs
@@ -1,0 +1,143 @@
+use std::path::PathBuf;
+
+fn main() {
+    match std::env::var("CARGO_CFG_TARGET_OS")
+        .unwrap_or_default()
+        .as_str()
+    {
+        "macos" => {
+            println!("cargo:rustc-cdylib-link-arg=-undefined");
+            println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        }
+        "windows" => link_ruby_on_windows(),
+        _ => {}
+    }
+}
+
+fn link_ruby_on_windows() {
+    let Some(ruby) = find_ruby() else {
+        return;
+    };
+    let (Some(bin_dir), Some(lib_dir), Some(so_name)) = (
+        get_ruby_config(&ruby, "bindir"),
+        get_ruby_config(&ruby, "libdir"),
+        get_ruby_config(&ruby, "RUBY_SO_NAME"),
+    ) else {
+        return;
+    };
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    println!("cargo:rustc-link-search=native={lib_dir}");
+    println!("cargo:rustc-link-search=native={bin_dir}");
+
+    if target_env == "msvc" {
+        if generate_msvc_lib(&format!("{so_name}.dll"), &so_name, &out_dir) {
+            println!("cargo:rustc-link-search=native={out_dir}");
+            println!("cargo:rustc-link-lib={so_name}");
+        } else {
+            println!("cargo:rustc-link-lib=dylib={so_name}");
+        }
+        println!("cargo:rustc-cdylib-link-arg=/FORCE:UNRESOLVED");
+    } else if let Some(import_library) = get_ruby_config(&ruby, "LIBRUBY") {
+        let import_library = PathBuf::from(lib_dir).join(import_library);
+        println!("cargo:rustc-cdylib-link-arg={}", import_library.display());
+    } else {
+        println!("cargo:rustc-link-lib=dylib={so_name}");
+    }
+}
+
+fn generate_msvc_lib(dll_name: &str, so_name: &str, out_dir: &str) -> bool {
+    let symbols: &[(&str, bool)] = &[
+        ("rb_define_module", false),
+        ("rb_define_module_under", false),
+        ("rb_define_class_under", false),
+        ("rb_define_method", false),
+        ("rb_define_singleton_method", false),
+        ("rb_define_module_function", false),
+        ("rb_define_alloc_func", false),
+        ("rb_path2class", false),
+        ("rb_str_new", false),
+        ("rb_utf8_str_new", false),
+        ("rb_string_value_ptr", false),
+        ("rb_string_value_cstr", false),
+        ("rb_ary_new", false),
+        ("rb_ary_push", false),
+        ("rb_ary_entry", false),
+        ("rb_intern", false),
+        ("rb_funcallv", false),
+        ("rb_num2long", false),
+        ("rb_int2inum", false),
+        ("rb_float_new", false),
+        ("rb_num2dbl", false),
+        ("rb_hash_new", false),
+        ("rb_hash_aset", false),
+        ("rb_data_object_wrap", false),
+        ("rb_check_typeddata", false),
+        ("rb_raise", false),
+        ("rb_str_strlen", false),
+        ("rb_cObject", true),
+        ("rb_eStandardError", true),
+        ("rb_eArgError", true),
+        ("rb_eRuntimeError", true),
+    ];
+
+    let def_path = PathBuf::from(out_dir).join(format!("{so_name}.def"));
+    let mut def_content = format!("LIBRARY {dll_name}\nEXPORTS\n");
+    for (sym, is_data) in symbols {
+        if *is_data {
+            def_content.push_str(&format!("    {sym} DATA\n"));
+        } else {
+            def_content.push_str(&format!("    {sym}\n"));
+        }
+    }
+    if std::fs::write(&def_path, def_content).is_err() {
+        return false;
+    }
+
+    let lib_path = PathBuf::from(out_dir).join(format!("{so_name}.lib"));
+    for program in ["lib.exe", "lib"] {
+        let result = std::process::Command::new(program)
+            .args([
+                &format!("/def:{}", def_path.display()),
+                &format!("/out:{}", lib_path.display()),
+                "/machine:x64",
+                "/nologo",
+            ])
+            .output();
+        if matches!(result, Ok(output) if output.status.success() && lib_path.exists()) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn get_ruby_config(ruby: &str, key: &str) -> Option<String> {
+    let script = format!("require 'rbconfig'; print RbConfig::CONFIG['{key}']");
+    let output = std::process::Command::new(ruby)
+        .args(["-e", &script])
+        .output()
+        .ok()?;
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn find_ruby() -> Option<String> {
+    for finder in ["where", "which"] {
+        if let Ok(output) = std::process::Command::new(finder).arg("ruby").output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if !path.is_empty() {
+                    return Some(path);
+                }
+            }
+        }
+    }
+    None
+}

--- a/code/packages/ruby/board_vm/ext/board_vm_native/extconf.rb
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/extconf.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+dlext = RbConfig::CONFIG["DLEXT"]
+cargo_lib = case RbConfig::CONFIG["host_os"]
+            when /darwin/
+              "libboard_vm_native.dylib"
+            when /mingw|mswin|cygwin/
+              "board_vm_native.dll"
+            else
+              "libboard_vm_native.so"
+            end
+
+target = "board_vm_native.#{dlext}"
+lib_dir = File.expand_path("../../lib", __dir__)
+
+File.write("Makefile", <<~MAKEFILE)
+  CARGO_DIR = #{File.expand_path(__dir__)}
+  TARGET_DIR = $(CARGO_DIR)/target/release
+  CARGO_LIB = $(TARGET_DIR)/#{cargo_lib}
+  INSTALL_DIR = #{lib_dir}
+  TARGET = $(INSTALL_DIR)/#{target}
+
+  all: $(TARGET)
+
+  $(TARGET): $(CARGO_LIB)
+  \t@mkdir -p $(INSTALL_DIR)
+  \tcp $(CARGO_LIB) $(TARGET)
+
+  $(CARGO_LIB): src/lib.rs Cargo.toml build.rs
+  \tcd $(CARGO_DIR) && cargo build --release
+
+  clean:
+  \tcd $(CARGO_DIR) && cargo clean
+  \trm -f $(TARGET)
+
+  install: $(TARGET)
+
+  .PHONY: all clean install
+MAKEFILE
+
+puts "Makefile generated; will build board_vm_native via cargo"

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -1,0 +1,351 @@
+use std::ffi::{c_char, c_int, c_void};
+use std::ptr;
+use std::slice;
+
+use board_vm_host::{BlinkProgram, BLINK_MODULE_LEN};
+use board_vm_language_core::{
+    build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
+    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
+    build_run_background_wire_frame, BoardVmLanguageSession, LanguageCoreError,
+};
+use ruby_bridge::VALUE;
+
+struct RubyBoardVmSession {
+    inner: BoardVmLanguageSession,
+}
+
+unsafe extern "C" fn session_alloc(klass: VALUE) -> VALUE {
+    ruby_bridge::wrap_data(
+        klass,
+        RubyBoardVmSession {
+            inner: BoardVmLanguageSession::new(),
+        },
+    )
+}
+
+extern "C" fn session_initialize(self_val: VALUE) -> VALUE {
+    self_val
+}
+
+extern "C" fn session_next_request_id(self_val: VALUE) -> VALUE {
+    let session = unsafe { ruby_bridge::unwrap_data::<RubyBoardVmSession>(self_val) };
+    ruby_bridge::usize_to_rb(session.inner.next_request_id() as usize)
+}
+
+extern "C" fn session_hello_wire(
+    self_val: VALUE,
+    host_name_val: VALUE,
+    host_nonce_val: VALUE,
+) -> VALUE {
+    let host_name = ruby_bridge::str_from_rb(host_name_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("host_name must be a Ruby String"));
+    let host_nonce = rb_u32(host_nonce_val, "host_nonce");
+
+    with_session_mut(self_val, |session| {
+        let mut wire = vec![0; host_name.len().saturating_add(64).max(128)];
+        let written =
+            build_hello_wire_frame(&mut session.inner, &host_name, host_nonce, &mut wire)?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_caps_query_wire(self_val: VALUE) -> VALUE {
+    with_session_mut(self_val, |session| {
+        let mut wire = [0u8; 64];
+        let written = build_caps_query_wire_frame(&mut session.inner, &mut wire)?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_blink_module(
+    _self_val: VALUE,
+    pin_val: VALUE,
+    high_ms_val: VALUE,
+    low_ms_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let pin = rb_u8(pin_val, "pin");
+    let high_ms = rb_u16(high_ms_val, "high_ms");
+    let low_ms = rb_u16(low_ms_val, "low_ms");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_blink_module_value(pin, high_ms, low_ms, max_stack)
+        .unwrap_or_else(|error| raise_core_error("blink_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_program_begin_wire(
+    self_val: VALUE,
+    program_id_val: VALUE,
+    module_val: VALUE,
+) -> VALUE {
+    let program_id = rb_u16(program_id_val, "program_id");
+    let module = ruby_bridge::bytes_from_rb(module_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("module must be a Ruby binary String"));
+
+    with_session_mut(self_val, |session| {
+        let mut wire = [0u8; 96];
+        let written =
+            build_program_begin_wire_frame(&mut session.inner, program_id, &module, &mut wire)?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_program_chunk_wire(
+    self_val: VALUE,
+    program_id_val: VALUE,
+    offset_val: VALUE,
+    chunk_val: VALUE,
+) -> VALUE {
+    let program_id = rb_u16(program_id_val, "program_id");
+    let offset = rb_u32(offset_val, "offset");
+    let chunk = ruby_bridge::bytes_from_rb(chunk_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("chunk must be a Ruby binary String"));
+
+    with_session_mut(self_val, |session| {
+        let mut wire = vec![0; chunk.len().saturating_add(64).max(128)];
+        let written = build_program_chunk_wire_frame(
+            &mut session.inner,
+            program_id,
+            offset,
+            &chunk,
+            &mut wire,
+        )?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_program_end_wire(self_val: VALUE, program_id_val: VALUE) -> VALUE {
+    let program_id = rb_u16(program_id_val, "program_id");
+
+    with_session_mut(self_val, |session| {
+        let mut wire = [0u8; 64];
+        let written = build_program_end_wire_frame(&mut session.inner, program_id, &mut wire)?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_run_background_wire(
+    self_val: VALUE,
+    program_id_val: VALUE,
+    instruction_budget_val: VALUE,
+) -> VALUE {
+    let program_id = rb_u16(program_id_val, "program_id");
+    let instruction_budget = rb_u32(instruction_budget_val, "instruction_budget");
+
+    with_session_mut(self_val, |session| {
+        let mut wire = [0u8; 96];
+        let written = build_run_background_wire_frame(
+            &mut session.inner,
+            program_id,
+            instruction_budget,
+            &mut wire,
+        )?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_blink_upload_run_frames(
+    argc: c_int,
+    argv: *const VALUE,
+    self_val: VALUE,
+) -> VALUE {
+    if argc != 6 {
+        ruby_bridge::raise_arg_error(
+            "blink_upload_run_frames expects program_id, instruction_budget, pin, high_ms, low_ms, max_stack",
+        );
+    }
+    let args = unsafe { slice::from_raw_parts(argv, argc as usize) };
+    let program_id = rb_u16(args[0], "program_id");
+    let instruction_budget = rb_u32(args[1], "instruction_budget");
+    let pin = rb_u8(args[2], "pin");
+    let high_ms = rb_u16(args[3], "high_ms");
+    let low_ms = rb_u16(args[4], "low_ms");
+    let max_stack = rb_u8(args[5], "max_stack");
+
+    let module = build_blink_module_value(pin, high_ms, low_ms, max_stack)
+        .unwrap_or_else(|error| raise_core_error("blink_upload_run_frames", error));
+
+    with_session_mut(self_val, |session| {
+        let frames = ruby_bridge::array_new();
+
+        let mut begin_wire = [0u8; 96];
+        let begin = build_program_begin_wire_frame(
+            &mut session.inner,
+            program_id,
+            &module,
+            &mut begin_wire,
+        )?;
+        ruby_bridge::array_push(frames, bytes_result(&begin_wire, begin.len));
+
+        let mut chunk_wire = vec![0; module.len().saturating_add(64).max(128)];
+        let chunk = build_program_chunk_wire_frame(
+            &mut session.inner,
+            program_id,
+            0,
+            &module,
+            &mut chunk_wire,
+        )?;
+        ruby_bridge::array_push(frames, bytes_result(&chunk_wire, chunk.len));
+
+        let mut end_wire = [0u8; 64];
+        let end = build_program_end_wire_frame(&mut session.inner, program_id, &mut end_wire)?;
+        ruby_bridge::array_push(frames, bytes_result(&end_wire, end.len));
+
+        let mut run_wire = [0u8; 96];
+        let run = build_run_background_wire_frame(
+            &mut session.inner,
+            program_id,
+            instruction_budget,
+            &mut run_wire,
+        )?;
+        ruby_bridge::array_push(frames, bytes_result(&run_wire, run.len));
+
+        Ok(frames)
+    })
+}
+
+fn with_session_mut(
+    self_val: VALUE,
+    operation: impl FnOnce(&mut RubyBoardVmSession) -> Result<VALUE, LanguageCoreError>,
+) -> VALUE {
+    let session = unsafe { ruby_bridge::unwrap_data_mut::<RubyBoardVmSession>(self_val) };
+    match operation(session) {
+        Ok(value) => value,
+        Err(error) => raise_core_error("BoardVM::Native::Session", error),
+    }
+}
+
+fn bytes_result(buffer: &[u8], len: usize) -> VALUE {
+    ruby_bridge::bytes_to_rb(&buffer[..len])
+}
+
+fn build_blink_module_value(
+    pin: u8,
+    high_ms: u16,
+    low_ms: u16,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; BLINK_MODULE_LEN];
+    let len = build_blink_module(
+        BlinkProgram {
+            pin,
+            high_ms,
+            low_ms,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn rb_u8(value: VALUE, name: &str) -> u8 {
+    let value = rb_nonnegative_integer(value, name);
+    if value > u8::MAX as u64 {
+        ruby_bridge::raise_arg_error(&format!("{name} must fit in u8"));
+    }
+    value as u8
+}
+
+fn rb_u16(value: VALUE, name: &str) -> u16 {
+    let value = rb_nonnegative_integer(value, name);
+    if value > u16::MAX as u64 {
+        ruby_bridge::raise_arg_error(&format!("{name} must fit in u16"));
+    }
+    value as u16
+}
+
+fn rb_u32(value: VALUE, name: &str) -> u32 {
+    let value = rb_nonnegative_integer(value, name);
+    if value > u32::MAX as u64 {
+        ruby_bridge::raise_arg_error(&format!("{name} must fit in u32"));
+    }
+    value as u32
+}
+
+fn rb_nonnegative_integer(value: VALUE, name: &str) -> u64 {
+    let to_s = unsafe { ruby_bridge::rb_intern(b"to_s\0".as_ptr() as *const c_char) };
+    let string_value = unsafe { ruby_bridge::rb_funcallv(value, to_s, 0, ptr::null()) };
+    let text = ruby_bridge::str_from_rb(string_value)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error(&format!("{name} must be an integer")));
+    text.parse::<u64>()
+        .unwrap_or_else(|_| ruby_bridge::raise_arg_error(&format!("{name} must be non-negative")))
+}
+
+fn raise_core_error(context: &str, error: LanguageCoreError) -> ! {
+    ruby_bridge::raise_runtime_error(&format!(
+        "{context} failed in Rust language core: {error:?}"
+    ))
+}
+
+#[no_mangle]
+pub extern "C" fn Init_board_vm_native() {
+    let coding_adventures = ruby_bridge::define_module("CodingAdventures");
+    let board_vm = ruby_bridge::define_module_under(coding_adventures, "BoardVM");
+    let native = ruby_bridge::define_module_under(board_vm, "Native");
+    let session_class =
+        ruby_bridge::define_class_under(native, "Session", ruby_bridge::object_class());
+
+    ruby_bridge::define_alloc_func(session_class, session_alloc);
+    ruby_bridge::define_method_raw(
+        session_class,
+        "initialize",
+        session_initialize as *const c_void,
+        0,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "next_request_id",
+        session_next_request_id as *const c_void,
+        0,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "hello_wire",
+        session_hello_wire as *const c_void,
+        2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "caps_query_wire",
+        session_caps_query_wire as *const c_void,
+        0,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "blink_module",
+        session_blink_module as *const c_void,
+        4,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "program_begin_wire",
+        session_program_begin_wire as *const c_void,
+        2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "program_chunk_wire",
+        session_program_chunk_wire as *const c_void,
+        3,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "program_end_wire",
+        session_program_end_wire as *const c_void,
+        1,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "run_background_wire",
+        session_run_background_wire as *const c_void,
+        2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "blink_upload_run_frames",
+        session_blink_upload_run_frames as *const c_void,
+        -1,
+    );
+}

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -3,6 +3,7 @@
 require_relative "board_vm/version"
 require_relative "board_vm/command_runner"
 require_relative "board_vm/connection"
+require_relative "board_vm/native"
 
 module CodingAdventures
   module BoardVM

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/native.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/native.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "board_vm_native"

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -88,6 +88,26 @@ module CodingAdventures
         ], runner.calls.first[:argv]
       end
 
+      def test_native_session_builds_protocol_bytes_in_rust
+        session = BoardVM::Native::Session.new
+
+        hello = session.hello_wire("bvm", 0x1234_ABCD)
+        assert_instance_of String, hello
+        assert_operator hello.bytesize, :>, 0
+        assert_equal 2, session.next_request_id
+
+        default_nonce_hello = session.hello_wire("bvm", BoardVM::DEFAULT_HOST_NONCE)
+        assert_operator default_nonce_hello.bytesize, :>, 0
+
+        module_bytes = session.blink_module(13, 250, 250, 4)
+        assert_instance_of String, module_bytes
+        assert_operator module_bytes.bytesize, :>, 0
+
+        frames = BoardVM::Native::Session.new.blink_upload_run_frames(7, 12, 13, 250, 250, 4)
+        assert_equal 4, frames.length
+        assert frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+      end
+
       def test_eject_blink_writes_a_board_agnostic_artifact
         runner = FakeRunner.new
 


### PR DESCRIPTION
## Summary

- Add a `board_vm_native` Rust extension for the Ruby Board VM gem using the repo's `ruby-bridge` crate.
- Expose `CodingAdventures::BoardVM::Native::Session` methods that return Rust-built Board VM wire frames as Ruby binary strings.
- Teach the Ruby gem Rake/test path to compile the extension and cover blink frame generation through `board-vm-language-core`.

## Why

Ruby should be syntax sugar over the Rust-owned Board VM protocol, not a second implementation of request ids, module bytes, COBS framing, or CRC handling. This gives the Ruby path a native bridge boundary that wraps `board-vm-language-core` and keeps C FFI as a fallback rather than the main Ruby integration route.

## Validation

- `cargo build --release` in `code/packages/ruby/board_vm/ext/board_vm_native`
- `rake test` in `code/packages/ruby/board_vm`
