### PR TITLE
[codex] Route Ruby blink DSL through native transport

### DIFF
--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -52,19 +52,13 @@ Each element in `frames` is a COBS/CRC-framed Board VM request ready for a
 transport to write to the board. Ruby owns the friendly shape; Rust owns the
 wire bytes.
 
-Inside the block, `board.led.blink` currently runs the shared Rust host smoke
-command:
-
-```sh
-cargo run -p board-vm-cli --bin board-vm -- smoke ...
-```
-
-That smoke command sends `HELLO`, queries capabilities, uploads the standard
-blink module, and starts it through the binary protocol. The next Ruby step is
-to route `board.led.blink` through `BoardVM::Native::Session` plus a transport
-instead of through this subprocess bridge. The DSL surface should stay
-Ruby-shaped, but every board operation should still dispatch the Board VM
-binary protocol produced by Rust.
+Inside the block, `board.led.blink` creates a
+`CodingAdventures::BoardVM::Native::Session`, sends `HELLO`, queries
+capabilities, uploads the standard blink module, and starts it through the
+Rust-owned binary protocol. By default the Ruby DSL opens the configured serial
+device, writes the Rust-produced wire frames, and waits for framed responses.
+Tests and alternate runtimes can inject any transport object that responds to
+`transact(frame, timeout_ms:)` or `write(frame)`.
 
 The DSL also exposes the current board-agnostic blink ejection path:
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -2,8 +2,9 @@
 
 require_relative "board_vm/version"
 require_relative "board_vm/command_runner"
-require_relative "board_vm/connection"
 require_relative "board_vm/native"
+require_relative "board_vm/transport"
+require_relative "board_vm/connection"
 
 module CodingAdventures
   module BoardVM
@@ -24,6 +25,7 @@ module CodingAdventures
       flash: false,
       cargo_workspace: DEFAULT_RUST_WORKSPACE,
       runner: CommandRunner.new,
+      transport: nil,
       **options
     )
       connection = Connection.new(
@@ -31,6 +33,7 @@ module CodingAdventures
         port: port,
         cargo_workspace: cargo_workspace,
         runner: runner,
+        transport: transport,
         baud_rate: options.delete(:baud_rate) || options.delete(:baud) || DEFAULT_BAUD_RATE,
         timeout_ms: options.delete(:timeout_ms) || DEFAULT_TIMEOUT_MS,
         **options

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -5,7 +5,7 @@ module CodingAdventures
     class UnsupportedBoardError < ArgumentError; end
 
     class Connection
-      attr_reader :board, :cargo_workspace, :runner, :baud_rate, :timeout_ms
+      attr_reader :board, :cargo_workspace, :runner, :transport, :baud_rate, :timeout_ms
       attr_accessor :port
 
       def initialize(
@@ -13,6 +13,7 @@ module CodingAdventures
         port:,
         cargo_workspace:,
         runner:,
+        transport:,
         baud_rate:,
         timeout_ms:,
         arduino_core: nil,
@@ -35,6 +36,7 @@ module CodingAdventures
         @port = port
         @cargo_workspace = cargo_workspace
         @runner = runner
+        @transport = transport
         @baud_rate = baud_rate
         @timeout_ms = timeout_ms
         @arduino_core = arduino_core
@@ -74,22 +76,22 @@ module CodingAdventures
       def blink!(
         program_id: DEFAULT_PROGRAM_ID,
         budget: DEFAULT_INSTRUCTION_BUDGET,
-        host_nonce: DEFAULT_HOST_NONCE
+        host_nonce: DEFAULT_HOST_NONCE,
+        pin: 13,
+        high_ms: 250,
+        low_ms: 250,
+        max_stack: 4
       )
         ensure_uno_r4_wifi!
 
-        runner.call(
-          board_vm_cli_command(
-            "smoke",
-            "--port", port,
-            "--baud", baud_rate.to_s,
-            "--timeout-ms", timeout_ms.to_s,
-            "--program-id", program_id.to_s,
-            "--budget", budget.to_s,
-            "--host-nonce", host_nonce.to_s
-          ),
-          chdir: cargo_workspace
-        )
+        session = Native::Session.new
+        frames = [
+          session.hello_wire("ruby-board-vm", host_nonce),
+          session.caps_query_wire,
+          *session.blink_upload_run_frames(program_id, budget, pin, high_ms, low_ms, max_stack)
+        ]
+        responses = frames.map { |frame| dispatch_frame(frame) }
+        SessionResult.new(frames: frames, responses: responses)
       end
 
       def eject_blink!(
@@ -164,6 +166,21 @@ module CodingAdventures
         cargo_command("run", "-p", "board-vm-cli", "--bin", "board-vm", "--", *args)
       end
 
+      def dispatch_frame(frame)
+        if active_transport.respond_to?(:transact)
+          active_transport.transact(frame, timeout_ms: timeout_ms)
+        elsif active_transport.respond_to?(:write)
+          active_transport.write(frame)
+          nil
+        else
+          raise TransportError, "Board VM transport must respond to #transact or #write"
+        end
+      end
+
+      def active_transport
+        @transport ||= SerialTransport.new(port: port, baud_rate: baud_rate, timeout_ms: timeout_ms)
+      end
+
       def cargo_command(*args)
         ["cargo"] + args
       end
@@ -192,9 +209,21 @@ module CodingAdventures
       def blink(
         program_id: DEFAULT_PROGRAM_ID,
         budget: DEFAULT_INSTRUCTION_BUDGET,
-        host_nonce: DEFAULT_HOST_NONCE
+        host_nonce: DEFAULT_HOST_NONCE,
+        pin: 13,
+        high_ms: 250,
+        low_ms: 250,
+        max_stack: 4
       )
-        @connection.blink!(program_id: program_id, budget: budget, host_nonce: host_nonce)
+        @connection.blink!(
+          program_id: program_id,
+          budget: budget,
+          host_nonce: host_nonce,
+          pin: pin,
+          high_ms: high_ms,
+          low_ms: low_ms,
+          max_stack: max_stack
+        )
       end
     end
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "io/wait"
+require "rbconfig"
+
+module CodingAdventures
+  module BoardVM
+    SessionResult = Struct.new(:frames, :responses, keyword_init: true)
+
+    class TransportError < StandardError; end
+
+    class SerialTransport
+      FRAME_DELIMITER = "\x00".b
+
+      def initialize(port:, baud_rate:, timeout_ms:)
+        @port = port
+        @baud_rate = baud_rate
+        @timeout_ms = timeout_ms
+        @io = nil
+      end
+
+      def transact(frame, timeout_ms: @timeout_ms)
+        write(frame)
+        read_frame(timeout_ms: timeout_ms)
+      end
+
+      def write(frame)
+        io.write(frame.b)
+        io.flush
+      rescue SystemCallError, IOError => e
+        raise TransportError, "failed to write Board VM frame to #{@port}: #{e.message}"
+      end
+
+      def close
+        @io&.close
+      ensure
+        @io = nil
+      end
+
+      private
+
+      def io
+        @io ||= begin
+          configure_port
+          File.open(@port, "r+b")
+        rescue SystemCallError => e
+          raise TransportError, "failed to open Board VM serial port #{@port}: #{e.message}"
+        end
+      end
+
+      def configure_port
+        flag = RbConfig::CONFIG.fetch("host_os").match?(/darwin|bsd/) ? "-f" : "-F"
+        return if system("stty", flag, @port, @baud_rate.to_s, "raw", "-echo")
+
+        raise TransportError, "failed to configure Board VM serial port #{@port}"
+      end
+
+      def read_frame(timeout_ms:)
+        deadline = monotonic_now + (timeout_ms.to_f / 1000.0)
+        response = +"".b
+
+        loop do
+          remaining = deadline - monotonic_now
+          raise TransportError, "timed out waiting for Board VM response on #{@port}" if remaining <= 0
+
+          readable = IO.select([io], nil, nil, remaining)
+          next if readable.nil?
+
+          byte = io.read_nonblock(1, exception: false)
+          next if byte == :wait_readable
+          raise TransportError, "Board VM serial port #{@port} closed" if byte.nil? || byte.empty?
+
+          response << byte
+          return response if byte == FRAME_DELIMITER
+        end
+      rescue SystemCallError, IOError => e
+        raise TransportError, "failed to read Board VM response from #{@port}: #{e.message}"
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -60,32 +60,27 @@ module CodingAdventures
         ], runner.calls.first[:argv]
       end
 
-      def test_led_blink_runs_the_generic_board_vm_smoke_command
+      def test_led_blink_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
+        transport = FakeTransport.new
+        result = nil
 
         BoardVM.uno_r4_wifi(
           port: "/dev/cu.usbmodem2201",
           cargo_workspace: "/repo/code/packages/rust",
           runner: runner,
+          transport: transport,
           baud: 57_600,
           timeout_ms: 250
         ) do |board|
-          board.led.blink(program_id: 9, budget: 32, host_nonce: 123)
+          result = board.led.blink(program_id: 9, budget: 32, host_nonce: 123)
         end
 
-        assert_equal [
-          "cargo", "run",
-          "-p", "board-vm-cli",
-          "--bin", "board-vm",
-          "--",
-          "smoke",
-          "--port", "/dev/cu.usbmodem2201",
-          "--baud", "57600",
-          "--timeout-ms", "250",
-          "--program-id", "9",
-          "--budget", "32",
-          "--host-nonce", "123"
-        ], runner.calls.first[:argv]
+        assert_empty runner.calls
+        assert_equal 6, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal transport.frames, result.frames
+        assert_equal Array.new(6, "ack".b), result.responses
       end
 
       def test_native_session_builds_protocol_bytes_in_rust

--- a/code/packages/ruby/board_vm/test/test_helper.rb
+++ b/code/packages/ruby/board_vm/test/test_helper.rb
@@ -16,3 +16,16 @@ class FakeRunner
     @results.shift || CodingAdventures::BoardVM::CommandResult.new(argv, chdir, "", "", 0)
   end
 end
+
+class FakeTransport
+  attr_reader :frames
+
+  def initialize
+    @frames = []
+  end
+
+  def transact(frame, timeout_ms:)
+    @frames << frame
+    "ack".b
+  end
+end


### PR DESCRIPTION
## Summary

- route Ruby board.led.blink through CodingAdventures::BoardVM::Native::Session instead of the board-vm CLI smoke subprocess
- add an injectable Ruby byte transport boundary, with a default serial transport that writes Rust-owned wire frames and reads framed responses
- update the Ruby docs and tests to make the language-sugar-over-Rust-protocol layering explicit

## Validation

- rake test
