### PR TITLE
feat(prolog): add stream term io

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -14,6 +14,8 @@
 - adapt selected current-stream predicates including `set_input/1`,
   `set_output/1`, `current_input/1`, `current_output/1`, current-input read
   forms, and current-output write/flush forms
+- adapt parser-backed stream term I/O predicates including `read/1`,
+  `read/2`, `read_term/2`, `read_term/3`, `write_term/2`, and `write_term/3`
 - preserve source query variables across `goal_expansion/2` rewrites
 - adapt Prolog `call/2..8` into variadic callable-term execution
 - preserve extra arguments while rewriting module-qualified `call/N` meta-goals

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -68,6 +68,9 @@ It keeps parsing side-effect free, then exposes helpers to:
   `set_output/1`, `current_input/1`, `current_output/1`, `get_char/1`,
   `read_string/2`, `read_line_to_string/1`, `at_end_of_stream/0`,
   `write/1`, `nl/0`, and `flush_output/0`
+- adapt parser-backed stream term I/O predicates including `read/1`,
+  `read/2`, `read_term/2`, `read_term/3`, `write_term/2`, and
+  `write_term/3`
 - load SWI-Prolog source graphs from real `.pl` files through relative
   `consult/1`, `ensure_loaded/1`, and file-backed `use_module/1,2`
 - splice `include/1` targets into the including source before project linking

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Iterator
+from typing import Protocol
 
 from logic_builtins import (
     abolisho,
@@ -157,6 +158,12 @@ from logic_builtins import (
     write_currento,
     writeo,
 )
+from logic_builtins.builtins import (
+    _current_input_stream,
+    _read_stream,
+    _write_current_stream,
+    _write_stream,
+)
 from logic_engine import (
     Atom,
     Compound,
@@ -203,6 +210,7 @@ from logic_stdlib import (
     sorto,
 )
 from prolog_core import OperatorTable, expand_dcg_phrase
+from prolog_operator_parser import ParsedOperatorTerm
 from prolog_parser import PrologParseError
 from swi_prolog_parser import parse_swi_term
 
@@ -212,6 +220,11 @@ _FD_REIFIABLE_RELATIONS = frozenset({"#=", "#\\=", "#<", "#=<", "#>", "#>="})
 _PLAIN_ATOM_RE = re.compile(r"^[a-z][A-Za-z0-9_]*$")
 _VARIABLE_RE = re.compile(r"^(?:[A-Z_][A-Za-z0-9_]*)$")
 type IndicatorBuilder = Callable[[Term, Term], GoalExpr]
+
+
+class _StreamTermReader(Protocol):
+    contents: str
+    cursor: int
 
 
 def adapt_prolog_goal(
@@ -520,6 +533,18 @@ def _adapt_relation_call(
         return _read_term_from_atom_goal(*args)
     if name == "write_term_to_atom" and goal.relation.arity == 3:
         return _write_term_to_atom_goal(*args)
+    if name == "read" and goal.relation.arity == 1:
+        return _read_current_term_goal(args[0], logic_list([]))
+    if name == "read" and goal.relation.arity == 2:
+        return _read_stream_term_goal(args[0], args[1], logic_list([]))
+    if name == "read_term" and goal.relation.arity == 2:
+        return _read_current_term_goal(*args)
+    if name == "read_term" and goal.relation.arity == 3:
+        return _read_stream_term_goal(*args)
+    if name == "write_term" and goal.relation.arity == 2:
+        return _write_current_term_goal(*args)
+    if name == "write_term" and goal.relation.arity == 3:
+        return _write_stream_term_goal(*args)
     if name == "atom_concat" and goal.relation.arity == 3:
         return atom_concato(*args)
     if name == "atom_length" and goal.relation.arity == 2:
@@ -769,6 +794,62 @@ def _read_term_from_atom_goal(
     return native_goal(run, atom_value, term_value, options)
 
 
+def _read_current_term_goal(term_value: object, options: object) -> GoalExpr:
+    def run(
+        program_value: Program,
+        state: State,
+        args: tuple[Term, ...],
+    ) -> Iterator[State]:
+        term_arg, options_arg = args
+        stream = _current_input_stream()
+        if stream is None:
+            return
+        parsed = _read_next_stream_term(stream)
+        if parsed is None:
+            return
+        parsed_term, variables = parsed
+        options_goal = _read_term_options_goal(options_arg, variables)
+        if options_goal is None:
+            return
+        yield from solve_from(
+            program_value,
+            conj(eq(term_arg, parsed_term), options_goal),
+            state,
+        )
+
+    return native_goal(run, term_value, options)
+
+
+def _read_stream_term_goal(
+    stream_value: object,
+    term_value: object,
+    options: object,
+) -> GoalExpr:
+    def run(
+        program_value: Program,
+        state: State,
+        args: tuple[Term, ...],
+    ) -> Iterator[State]:
+        stream_arg, term_arg, options_arg = args
+        stream = _read_stream(reify(stream_arg, state.substitution))
+        if stream is None:
+            return
+        parsed = _read_next_stream_term(stream)
+        if parsed is None:
+            return
+        parsed_term, variables = parsed
+        options_goal = _read_term_options_goal(options_arg, variables)
+        if options_goal is None:
+            return
+        yield from solve_from(
+            program_value,
+            conj(eq(term_arg, parsed_term), options_goal),
+            state,
+        )
+
+    return native_goal(run, stream_value, term_value, options)
+
+
 def _write_term_to_atom_goal(
     term_value: object,
     atom_value: object,
@@ -795,11 +876,153 @@ def _write_term_to_atom_goal(
     return native_goal(run, term_value, atom_value, options)
 
 
-def _parse_atom_text(atom_value: Atom) -> object | None:
+def _write_current_term_goal(term_value: object, options: object) -> GoalExpr:
+    def run(_program: Program, state: State, args: tuple[Term, ...]) -> Iterator[State]:
+        term_arg, options_arg = args
+        reified_term = reify(term_arg, state.substitution)
+        if isinstance(reified_term, LogicVar):
+            return
+        write_options = _write_term_options(reify(options_arg, state.substitution))
+        if write_options is None:
+            return
+        rendered = _render_prolog_term(
+            reified_term,
+            numbervars=write_options["numbervars"],
+        )
+        if _write_current_stream(rendered):
+            yield state
+
+    return native_goal(run, term_value, options)
+
+
+def _write_stream_term_goal(
+    stream_value: object,
+    term_value: object,
+    options: object,
+) -> GoalExpr:
+    def run(_program: Program, state: State, args: tuple[Term, ...]) -> Iterator[State]:
+        stream_arg, term_arg, options_arg = args
+        reified_term = reify(term_arg, state.substitution)
+        if isinstance(reified_term, LogicVar):
+            return
+        write_options = _write_term_options(reify(options_arg, state.substitution))
+        if write_options is None:
+            return
+        rendered = _render_prolog_term(
+            reified_term,
+            numbervars=write_options["numbervars"],
+        )
+        if _write_stream(reify(stream_arg, state.substitution), rendered):
+            yield state
+
+    return native_goal(run, stream_value, term_value, options)
+
+
+def _parse_atom_text(atom_value: Atom) -> ParsedOperatorTerm | None:
+    return _parse_term_text(atom_value.symbol.name)
+
+
+def _parse_term_text(text: str) -> ParsedOperatorTerm | None:
     try:
-        return parse_swi_term(atom_value.symbol.name)
+        return parse_swi_term(text)
     except PrologParseError:
         return None
+
+
+def _read_next_stream_term(
+    stream: _StreamTermReader,
+) -> tuple[Term, dict[str, LogicVar]] | None:
+    text = stream.contents
+    start = _skip_stream_layout(text, stream.cursor)
+    if start >= len(text):
+        stream.cursor = len(text)
+        return atom("end_of_file"), {}
+
+    terminator = _stream_term_terminator(text, start)
+    if terminator is None:
+        return None
+
+    term_text = text[start:terminator].strip()
+    if not term_text:
+        return None
+    parsed = _parse_term_text(term_text)
+    if parsed is None:
+        return None
+
+    stream.cursor = _skip_stream_layout(text, terminator + 1)
+    return parsed.term, parsed.variables
+
+
+def _skip_stream_layout(text: str, index: int) -> int:
+    while index < len(text):
+        while index < len(text) and text[index].isspace():
+            index += 1
+        if text.startswith("%", index):
+            newline_index = text.find("\n", index)
+            if newline_index == -1:
+                return len(text)
+            index = newline_index + 1
+            continue
+        if text.startswith("/*", index):
+            comment_end = text.find("*/", index + 2)
+            if comment_end == -1:
+                return len(text)
+            index = comment_end + 2
+            continue
+        return index
+    return index
+
+
+def _stream_term_terminator(text: str, start: int) -> int | None:
+    index = start
+    depth = 0
+    quote: str | None = None
+    escaped = False
+
+    while index < len(text):
+        character = text[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            index += 1
+            continue
+
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if text.startswith("%", index):
+            newline_index = text.find("\n", index)
+            index = len(text) if newline_index == -1 else newline_index + 1
+            continue
+        if text.startswith("/*", index):
+            comment_end = text.find("*/", index + 2)
+            if comment_end == -1:
+                return None
+            index = comment_end + 2
+            continue
+        if character in "([{":
+            depth += 1
+        elif character in ")]}":
+            depth = max(0, depth - 1)
+        elif character == "." and depth == 0 and _dot_ends_stream_term(text, index):
+            return index
+        index += 1
+    return None
+
+
+def _dot_ends_stream_term(text: str, dot_index: int) -> bool:
+    next_index = dot_index + 1
+    return (
+        next_index >= len(text)
+        or text[next_index].isspace()
+        or text.startswith("%", next_index)
+        or text.startswith("/*", next_index)
+    )
 
 
 def _variable_bindings(variables: dict[str, LogicVar]) -> Term:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -1623,6 +1623,80 @@ class TestPrologGoalAdapter:
         assert (first, chunk, line) == (atom("a"), string("bc"), string("def"))
         assert output_path.read_text(encoding="utf-8") == "tea\ncake(slice)"
 
+    def test_adapt_prolog_goal_rewrites_stream_term_io(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        input_path = tmp_path / "terms.pltxt"
+        output_path = tmp_path / "written-terms.pltxt"
+        input_path.write_text(
+            "% leading layout is skipped\n"
+            "box(cake).\n"
+            "/* block comments are layout */\n"
+            "pair(tea, X).\n",
+            encoding="utf-8",
+        )
+        input_atom = str(input_path).replace("\\", "\\\\").replace("'", "\\'")
+        output_atom = str(output_path).replace("\\", "\\\\").replace("'", "\\'")
+        parsed = parse_swi_query(
+            f"?- open('{input_atom}', read, In, [alias(term_input)]), "
+            "read(In, First), "
+            "read_term(In, Second, [variable_names(Names), variables(Vars)]), "
+            "read(In, Eof), "
+            "close(In), "
+            f"open('{input_atom}', read, CurrentIn, [alias(current_term_input)]), "
+            f"open('{output_atom}', write, Out, [alias(term_output)]), "
+            "set_input(CurrentIn), "
+            "set_output(Out), "
+            "read(CurrentFirst), "
+            "read_term(CurrentSecond, []), "
+            "write_term(Out, First, []), "
+            "write(Out, '.'), "
+            "nl, "
+            "write_term(CurrentFirst, []), "
+            "write('.'), "
+            "nl, "
+            "write_term(CurrentSecond, []), "
+            "close(CurrentIn), "
+            "close(Out).",
+        )
+
+        answers = solve_all(
+            program(),
+            (
+                parsed.variables["First"],
+                parsed.variables["Second"],
+                parsed.variables["Names"],
+                parsed.variables["Vars"],
+                parsed.variables["Eof"],
+                parsed.variables["CurrentFirst"],
+                parsed.variables["CurrentSecond"],
+            ),
+            adapt_prolog_goal(parsed.goal),
+        )
+
+        assert len(answers) == 1
+        (
+            first,
+            second,
+            names,
+            vars_value,
+            eof,
+            current_first,
+            current_second,
+        ) = answers[0]
+        assert first == term("box", "cake")
+        assert isinstance(second, Compound)
+        assert second == term("pair", "tea", second.args[1])
+        assert names == logic_list([term("=", "X", second.args[1])])
+        assert vars_value == logic_list([second.args[1]])
+        assert eof == atom("end_of_file")
+        assert current_first == first
+        assert current_second == term("pair", "tea", current_second.args[1])
+        assert output_path.read_text(encoding="utf-8") == (
+            "box(cake).\nbox(cake).\npair(tea, X)"
+        )
+
     def test_adapt_prolog_goal_rewrites_term_read_write_options(self) -> None:
         parsed = parse_swi_query(
             "?- read_term_from_atom('pair(X, Y, X)', Term, "

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -17,8 +17,11 @@
 - Run selected current-stream predicates through structured and bytecode VM
   paths, including `set_input/1`, `set_output/1`, `current_input/1`,
   `current_output/1`, current-input reads, and current-output writes.
+- Run parser-backed stream term I/O predicates through structured and bytecode
+  VM paths, including `read/1`, `read/2`, `read_term/2`, `read_term/3`,
+  `write_term/2`, and `write_term/3`.
 - Add a public Prolog VM capability manifest and `prolog-vm --dump-capabilities`
-  so scripts and future planning can distinguish the completed PR00-PR82 track
+  so scripts and future planning can distinguish the completed PR00-PR83 track
   from deferred advanced dialect/runtime work.
 - Add end-to-end stress coverage for recursive search, modules, DCGs,
   arithmetic, collections, dynamic initialization, named answers, and expansion.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -249,7 +249,7 @@ assert [answer.as_dict() for answer in runtime.query("ancestor(homer, Who)")] ==
 
 ## Capability Manifest
 
-The Prolog-on-Logic-VM implementation track covers PR00 through PR82. The
+The Prolog-on-Logic-VM implementation track covers PR00 through PR83. The
 package exposes that as a machine-readable manifest so downstream tools and
 future implementation work can distinguish completed functionality from
 deliberately deferred advanced dialect/runtime emulation:
@@ -259,7 +259,7 @@ from prolog_vm_compiler import prolog_vm_capability_manifest
 
 manifest = prolog_vm_capability_manifest()
 
-assert manifest.status == "core-plus-current-streams"
+assert manifest.status == "core-plus-stream-term-io"
 assert manifest.dialects == ("iso", "swi")
 assert manifest.backends == ("structured", "bytecode")
 ```
@@ -277,8 +277,9 @@ bounded cursor repositioning via `set_stream_position/2` and `seek/4`, and
 selected current-stream forms via `set_input/1`, `set_output/1`,
 `current_input/1`, `current_output/1`, `get_char/1`, `read_string/2`,
 `read_line_to_string/1`, `at_end_of_stream/0`, `write/1`, `nl/0`, and
-`flush_output/0`. The
-manifest also names the remaining advanced-dialect work that is intentionally
+`flush_output/0`, plus parser-backed stream term I/O through `read/1`,
+`read/2`, `read_term/2`, `read_term/3`, `write_term/2`, and `write_term/3`.
+The manifest also names the remaining advanced-dialect work that is intentionally
 outside the completed batches: full external dialect emulation, tabling and
 well-founded negation, generalized attributed-variable/coroutining services,
 non-FD constraint domains, console/binary/rich stream services beyond the

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
@@ -252,6 +252,21 @@ def prolog_vm_capabilities() -> tuple[PrologVMCapability, ...]:
                 "structured and bytecode VM stress coverage",
             ),
         ),
+        PrologVMCapability(
+            id="host-stream-term-io",
+            title="Parser-backed bounded stream term I/O",
+            status="complete",
+            specs=("PR83",),
+            packages=("prolog-loader", "prolog-vm-compiler"),
+            features=(
+                "read/2 and read_term/3 parse one term from explicit streams",
+                "read/1 and read_term/2 parse from the selected current input",
+                "read_term variable_names/1 and variables/1 options on streams",
+                "end_of_file handling after stream terms are consumed",
+                "write_term/3 and write_term/2 render to explicit/current output",
+                "structured and bytecode VM stress coverage",
+            ),
+        ),
     )
 
 
@@ -302,8 +317,8 @@ def prolog_vm_capability_manifest() -> PrologVMCapabilityManifest:
     """Return the canonical capability manifest for this package."""
 
     return PrologVMCapabilityManifest(
-        track="Prolog-on-Logic-VM PR00-PR82",
-        status="core-plus-current-streams",
+        track="Prolog-on-Logic-VM PR00-PR83",
+        status="core-plus-stream-term-io",
         dialects=("iso", "swi"),
         backends=("structured", "bytecode"),
         capabilities=prolog_vm_capabilities(),

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_bytecode_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_bytecode_vm_stress.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from logic_engine import Number, atom, logic_list, num, string, term
+from logic_engine import Compound, Number, atom, logic_list, num, string, term
 
 from prolog_vm_compiler import (
     PrologAnswer,
@@ -495,3 +495,69 @@ class TestPrologBytecodeVMStress:
             "Line": string("def"),
         }
         assert output_path.read_text(encoding="utf-8") == "tea\ncake(slice)"
+
+    def test_stream_term_io_matches_structured_vm(self, tmp_path: Path) -> None:
+        input_path = tmp_path / "bytecode-terms.pltxt"
+        output_path = tmp_path / "bytecode-written-terms.pltxt"
+        input_path.write_text(
+            "% leading layout is skipped\n"
+            "box(cake).\n"
+            "/* block comments are layout */\n"
+            "pair(tea, X).\n",
+            encoding="utf-8",
+        )
+        input_atom = str(input_path).replace("\\", "\\\\").replace("'", "\\'")
+        output_atom = str(output_path).replace("\\", "\\\\").replace("'", "\\'")
+        compiled = compile_swi_prolog_source(
+            f"""
+            ?- open('{input_atom}', read, In, [alias(bytecode_term_input)]),
+               read(In, First),
+               read_term(In, Second, [variable_names(Names), variables(Vars)]),
+               read(In, Eof),
+               close(In),
+               open('{input_atom}', read, CurrentIn,
+                    [alias(bytecode_current_term_input)]),
+               open('{output_atom}', write, Out,
+                    [alias(bytecode_term_output)]),
+               set_input(CurrentIn),
+               set_output(Out),
+               read(CurrentFirst),
+               read_term(CurrentSecond, []),
+               write_term(Out, First, []),
+               write(Out, '.'),
+               nl,
+               write_term(CurrentFirst, []),
+               write('.'),
+               nl,
+               write_term(CurrentSecond, []),
+               close(CurrentIn),
+               close(Out).
+            """,
+        )
+
+        answers = run_compiled_prolog_bytecode_query_answers(compiled)
+
+        assert _project_answers(
+            answers,
+            "First",
+            "Eof",
+            "CurrentFirst",
+        ) == _project_answers(
+            run_compiled_prolog_query_answers(compiled),
+            "First",
+            "Eof",
+            "CurrentFirst",
+        )
+        assert len(answers) == 1
+        answer = answers[0].as_dict()
+        assert answer["First"] == term("box", "cake")
+        second = answer["Second"]
+        assert isinstance(second, Compound)
+        assert second == term("pair", "tea", second.args[1])
+        assert answer["Names"] == logic_list([term("=", "X", second.args[1])])
+        assert answer["Vars"] == logic_list([second.args[1]])
+        assert answer["Eof"] == atom("end_of_file")
+        assert answer["CurrentFirst"] == answer["First"]
+        assert output_path.read_text(encoding="utf-8") == (
+            "box(cake).\nbox(cake).\npair(tea, X)"
+        )

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
@@ -9,31 +9,31 @@ from prolog_vm_compiler import (
 )
 
 
-def test_manifest_marks_current_stream_extension_complete() -> None:
+def test_manifest_marks_stream_term_io_extension_complete() -> None:
     manifest = prolog_vm_capability_manifest()
 
-    assert manifest.track == "Prolog-on-Logic-VM PR00-PR82"
-    assert manifest.status == "core-plus-current-streams"
+    assert manifest.track == "Prolog-on-Logic-VM PR00-PR83"
+    assert manifest.status == "core-plus-stream-term-io"
     assert manifest.dialects == ("iso", "swi")
     assert manifest.backends == ("structured", "bytecode")
-    assert manifest.complete_count == 12
+    assert manifest.complete_count == 13
     assert manifest.deferred_count == 3
 
 
-def test_completed_capabilities_cover_pr00_through_pr82_once() -> None:
+def test_completed_capabilities_cover_pr00_through_pr83_once() -> None:
     covered_specs = [
         spec for capability in prolog_vm_capabilities() for spec in capability.specs
     ]
 
-    assert covered_specs == [f"PR{index:02d}" for index in range(83)]
+    assert covered_specs == [f"PR{index:02d}" for index in range(84)]
 
 
 def test_capability_manifest_is_json_serializable() -> None:
     payload = prolog_vm_capability_manifest().as_dict()
 
-    assert payload["status"] == "core-plus-current-streams"
+    assert payload["status"] == "core-plus-stream-term-io"
     assert payload["capabilities"][0]["id"] == "frontend-loader"
-    assert payload["capabilities"][-1]["id"] == "host-current-streams"
+    assert payload["capabilities"][-1]["id"] == "host-stream-term-io"
     assert payload["deferred_capabilities"][0]["status"] == "deferred"
 
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -21,11 +21,11 @@ def test_cli_dumps_capability_manifest_without_source(
     assert status == 0
     assert payload["success"] is True
     assert payload["mode"] == "capabilities"
-    assert payload["status"] == "core-plus-current-streams"
+    assert payload["status"] == "core-plus-stream-term-io"
     assert payload["dialects"] == ["iso", "swi"]
     assert payload["backends"] == ["structured", "bytecode"]
     assert payload["capabilities"][0]["specs"][0] == "PR00"
-    assert payload["capabilities"][-1]["specs"][-1] == "PR82"
+    assert payload["capabilities"][-1]["specs"][-1] == "PR83"
 
 
 def test_cli_dump_capabilities_rejects_source_modes(

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -1182,6 +1182,60 @@ class TestPrologVMStress:
         }
         assert output_path.read_text(encoding="utf-8") == "tea\ncake(slice)"
 
+    def test_stream_term_io_runs_through_vm(self, tmp_path: Path) -> None:
+        input_path = tmp_path / "terms.pltxt"
+        output_path = tmp_path / "written-terms.pltxt"
+        input_path.write_text(
+            "% leading layout is skipped\n"
+            "box(cake).\n"
+            "/* block comments are layout */\n"
+            "pair(tea, X).\n",
+            encoding="utf-8",
+        )
+        input_atom = str(input_path).replace("\\", "\\\\").replace("'", "\\'")
+        output_atom = str(output_path).replace("\\", "\\\\").replace("'", "\\'")
+        compiled = compile_swi_prolog_source(
+            f"""
+            ?- open('{input_atom}', read, In, [alias(vm_term_input)]),
+               read(In, First),
+               read_term(In, Second, [variable_names(Names), variables(Vars)]),
+               read(In, Eof),
+               close(In),
+               open('{input_atom}', read, CurrentIn,
+                    [alias(vm_current_term_input)]),
+               open('{output_atom}', write, Out, [alias(vm_term_output)]),
+               set_input(CurrentIn),
+               set_output(Out),
+               read(CurrentFirst),
+               read_term(CurrentSecond, []),
+               write_term(Out, First, []),
+               write(Out, '.'),
+               nl,
+               write_term(CurrentFirst, []),
+               write('.'),
+               nl,
+               write_term(CurrentSecond, []),
+               close(CurrentIn),
+               close(Out).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert len(answers) == 1
+        answer = answers[0].as_dict()
+        assert answer["First"] == term("box", "cake")
+        second = answer["Second"]
+        assert isinstance(second, Compound)
+        assert second == term("pair", "tea", second.args[1])
+        assert answer["Names"] == logic_list([term("=", "X", second.args[1])])
+        assert answer["Vars"] == logic_list([second.args[1]])
+        assert answer["Eof"] == atom("end_of_file")
+        assert answer["CurrentFirst"] == answer["First"]
+        assert output_path.read_text(encoding="utf-8") == (
+            "box(cake).\nbox(cake).\npair(tea, X)"
+        )
+
     def test_initialized_named_answers_keep_runtime_assertions_visible(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR79-prolog-file-stream-io.md
+++ b/code/specs/PR79-prolog-file-stream-io.md
@@ -58,6 +58,7 @@ Coverage should prove:
   implicit one-argument `write/1`/`nl/0`
 - no stream options, aliases, repositioning, binary I/O, or encodings beyond
   UTF-8
-- no `read/1`, `read_term/2`, or term parsing from stream handles
+- parser-backed `read/1`, `read_term/2`, and stream term parsing are deferred
+  to PR83
 - no directory enumeration
 - no foreign predicate or async host callback boundary

--- a/code/specs/PR80-prolog-stream-options-and-metadata.md
+++ b/code/specs/PR80-prolog-stream-options-and-metadata.md
@@ -54,5 +54,6 @@ Coverage should prove:
 
 - no standard stream aliases
 - no binary streams or encodings beyond UTF-8
-- no `read/1`, `read_term/2`, or term parsing from stream handles
+- parser-backed `read/1`, `read_term/2`, and stream term parsing are deferred
+  to PR83
 - no foreign predicate or async host callback boundary

--- a/code/specs/PR81-prolog-stream-positioning.md
+++ b/code/specs/PR81-prolog-stream-positioning.md
@@ -53,5 +53,6 @@ Coverage should prove:
 - no standard stream aliases
 - no output-stream truncation or random-access write positioning
 - no binary streams or encodings beyond UTF-8
-- no `read/1`, `read_term/2`, or term parsing from stream handles
+- parser-backed `read/1`, `read_term/2`, and stream term parsing are deferred
+  to PR83
 - no foreign predicate or async host callback boundary

--- a/code/specs/PR82-prolog-current-streams.md
+++ b/code/specs/PR82-prolog-current-streams.md
@@ -65,5 +65,6 @@ Coverage should prove:
 - no console-backed `user_input`, `user_output`, or `user_error` streams
 - no binary streams or encodings beyond UTF-8
 - no output-stream random-access writes
-- no `read/1`, `read_term/2`, or term parsing from stream handles
+- parser-backed `read/1`, `read_term/2`, and stream term parsing are deferred
+  to PR83
 - no foreign predicate or async host callback boundary

--- a/code/specs/PR83-prolog-stream-term-io.md
+++ b/code/specs/PR83-prolog-stream-term-io.md
@@ -1,0 +1,68 @@
+# PR83 - Prolog Stream Term I/O
+
+## Goal
+
+Close the parser-backed term I/O gap for the bounded UTF-8 stream facade without
+pretending to implement every ISO/SWI stream feature.
+
+This batch adds:
+
+- `read/1`
+- `read/2`
+- `read_term/2`
+- `read_term/3`
+- `write_term/2`
+- `write_term/3`
+
+## Semantics
+
+`read(Stream, Term)` and `read_term(Stream, Term, Options)` accept an open
+bounded read stream handle or alias. They skip leading layout/comments, consume
+one dot-terminated Prolog term, advance the stream cursor past trailing layout,
+and parse the consumed term through the SWI-compatible term parser used by
+`read_term_from_atom/3`.
+
+`read(Term)` and `read_term(Term, Options)` delegate to the selected current
+input stream from PR82. At end of file, the read predicates unify `Term` with
+`end_of_file` and leave the cursor at EOF.
+
+`read_term` supports the same finite option subset as `read_term_from_atom/3`:
+
+- `variable_names(Names)`
+- `variables(Vars)`
+
+`write_term(Stream, Term, Options)` writes the finite term renderer used by
+`write_term_to_atom/3` to an open bounded write/append stream handle or alias.
+`write_term(Term, Options)` writes to the selected current output stream.
+Supported write options remain the bounded subset:
+
+- `quoted(true|false)`
+- `ignore_ops(true|false)`
+- `numbervars(true|false)`
+
+As with earlier stream batches, invalid handles, output-stream reads,
+input-stream writes, malformed option lists, unterminated stream terms, and
+unparseable term text fail deterministically.
+
+## Validation
+
+Coverage should prove:
+
+- source-level Prolog calls adapt explicit and current stream term reads/writes
+  through the parser-backed loader layer.
+- stream reads advance one term at a time and return `end_of_file` after the
+  final term.
+- `read_term` preserves `variable_names/1` and `variables/1` bindings.
+- structured VM and bytecode VM run matching stream term I/O programs.
+- the capability manifest records PR83 as complete while leaving
+  console-backed standard streams, binary streams, rich ISO/SWI options,
+  foreign predicates, and async host services deferred.
+
+## Non-goals
+
+- no console-backed `user_input`, `user_output`, or `user_error` streams
+- no binary streams or encodings beyond UTF-8
+- no full ISO/SWI reader option matrix
+- no operator-sensitive stream parser beyond the existing SWI-compatible term
+  parser subset
+- no foreign predicate or async host callback boundary


### PR DESCRIPTION
## Summary

- add parser-backed stream term reads for `read/1`, `read/2`, `read_term/2`, and `read_term/3` over explicit/current bounded UTF-8 streams
- add stream/current `write_term/3` and `write_term/2` using the existing finite term renderer and option subset
- mark PR83 complete in the capability manifest and document the stream term I/O batch

## Validation

- `uv run --extra dev ruff check src tests` in `code/packages/python/prolog-loader`
- `uv run --extra dev python -m pytest tests/test_prolog_loader.py -q` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check src tests` in `code/packages/python/prolog-vm-compiler`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`

## Notes

- Direct `uv run --extra dev ...` in `prolog-vm-compiler` still hits the existing local-source resolver issue for `cli-builder`; `bash BUILD` is the package validation path used here.
