### PR TITLE
[codex] Return structured Ruby Board VM responses

### DIFF
--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -57,6 +57,10 @@ Inside the block, `board.led.blink` creates a
 capabilities, uploads the standard blink module, and starts it through the
 Rust-owned binary protocol. By default the Ruby DSL opens the configured serial
 device, writes the Rust-produced wire frames, and waits for framed responses.
+Responses are decoded by the same Rust language core into Ruby hashes for
+`HELLO_ACK`, capability reports, upload acknowledgements, and run reports, while
+the raw wire frames and raw response bytes remain available from the returned
+session result for debugging.
 Tests and alternate runtimes can inject any transport object that responds to
 `transact(frame, timeout_ms:)` or `write(frame)`.
 

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -6,7 +6,9 @@ use board_vm_host::{BlinkProgram, BLINK_MODULE_LEN};
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
     build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
-    build_run_background_wire_frame, BoardVmLanguageSession, LanguageCoreError,
+    build_run_background_wire_frame, decode_wire_response, program_format_name, run_status_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageCoreError,
 };
 use ruby_bridge::VALUE;
 
@@ -205,6 +207,15 @@ extern "C" fn session_blink_upload_run_frames(
     })
 }
 
+extern "C" fn session_decode_response(_self_val: VALUE, wire_val: VALUE) -> VALUE {
+    let wire = ruby_bridge::bytes_from_rb(wire_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("wire response must be a binary String"));
+    let mut raw = vec![0; wire.len().max(64)];
+    let decoded = decode_wire_response(&wire, &mut raw)
+        .unwrap_or_else(|error| raise_core_error("decode_response", error));
+    decoded_response_to_rb(&decoded)
+}
+
 fn with_session_mut(
     self_val: VALUE,
     operation: impl FnOnce(&mut RubyBoardVmSession) -> Result<VALUE, LanguageCoreError>,
@@ -218,6 +229,166 @@ fn with_session_mut(
 
 fn bytes_result(buffer: &[u8], len: usize) -> VALUE {
     ruby_bridge::bytes_to_rb(&buffer[..len])
+}
+
+fn decoded_response_to_rb(decoded: &DecodedLanguageResponse) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "request_id", rb_usize(decoded.request_id));
+    hash_set(
+        hash,
+        "message_type",
+        ruby_bridge::str_to_rb(message_type_name(decoded.message_type.0)),
+    );
+    hash_set(hash, "message_type_code", rb_usize(decoded.message_type.0));
+    hash_set(hash, "flags", rb_usize(decoded.flags));
+    hash_set(
+        hash,
+        "response",
+        ruby_bridge::bool_to_rb(decoded.is_response()),
+    );
+    hash_set(
+        hash,
+        "error",
+        ruby_bridge::bool_to_rb(decoded.is_error_response()),
+    );
+    hash_set(hash, "kind", ruby_bridge::str_to_rb(decoded.body.kind()));
+    hash_set(hash, "payload_len", rb_usize(decoded.payload_len));
+    hash_set(
+        hash,
+        "payload",
+        response_body_to_rb(&decoded.body, decoded.payload_len),
+    );
+    hash
+}
+
+fn response_body_to_rb(body: &DecodedLanguageResponseBody, payload_len: usize) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    match body {
+        DecodedLanguageResponseBody::HelloAck(ack) => {
+            hash_set(hash, "selected_version", rb_usize(ack.selected_version));
+            hash_set(hash, "board_name", ruby_bridge::str_to_rb(&ack.board_name));
+            hash_set(
+                hash,
+                "runtime_name",
+                ruby_bridge::str_to_rb(&ack.runtime_name),
+            );
+            hash_set(hash, "host_nonce", rb_usize(ack.host_nonce));
+            hash_set(hash, "board_nonce", rb_usize(ack.board_nonce));
+            hash_set(hash, "max_frame_payload", rb_usize(ack.max_frame_payload));
+        }
+        DecodedLanguageResponseBody::CapsReport(report) => {
+            hash_set(hash, "board_id", ruby_bridge::str_to_rb(&report.board_id));
+            hash_set(
+                hash,
+                "runtime_id",
+                ruby_bridge::str_to_rb(&report.runtime_id),
+            );
+            hash_set(
+                hash,
+                "max_program_bytes",
+                rb_usize(report.max_program_bytes),
+            );
+            hash_set(hash, "max_stack_values", rb_usize(report.max_stack_values));
+            hash_set(hash, "max_handles", rb_usize(report.max_handles));
+            hash_set(
+                hash,
+                "supports_store_program",
+                ruby_bridge::bool_to_rb(report.supports_store_program),
+            );
+            let capabilities = ruby_bridge::array_new();
+            for capability in &report.capabilities {
+                let item = ruby_bridge::hash_new();
+                hash_set(item, "id", rb_usize(capability.id));
+                hash_set(item, "version", rb_usize(capability.version));
+                hash_set(item, "flags", rb_usize(capability.flags));
+                hash_set(item, "name", ruby_bridge::str_to_rb(&capability.name));
+                ruby_bridge::array_push(capabilities, item);
+            }
+            hash_set(hash, "capabilities", capabilities);
+        }
+        DecodedLanguageResponseBody::ProgramBegin(begin) => {
+            hash_set(hash, "program_id", rb_usize(begin.program_id));
+            hash_set(
+                hash,
+                "format",
+                ruby_bridge::str_to_rb(program_format_name(begin.format)),
+            );
+            hash_set(hash, "total_len", rb_usize(begin.total_len));
+            hash_set(hash, "program_crc32", rb_usize(begin.program_crc32));
+        }
+        DecodedLanguageResponseBody::ProgramChunk(chunk) => {
+            hash_set(hash, "program_id", rb_usize(chunk.program_id));
+            hash_set(hash, "offset", rb_usize(chunk.offset));
+            hash_set(hash, "len", rb_usize(chunk.len));
+        }
+        DecodedLanguageResponseBody::ProgramEnd(end) => {
+            hash_set(hash, "program_id", rb_usize(end.program_id));
+        }
+        DecodedLanguageResponseBody::RunReport(report) => {
+            hash_set(hash, "program_id", rb_usize(report.program_id));
+            hash_set(
+                hash,
+                "status",
+                ruby_bridge::str_to_rb(run_status_name(report.status)),
+            );
+            hash_set(hash, "status_code", rb_usize(report.status.as_u8()));
+            hash_set(
+                hash,
+                "instructions_executed",
+                rb_usize(report.instructions_executed),
+            );
+            hash_set(hash, "elapsed_ms", rb_usize(report.elapsed_ms));
+            hash_set(hash, "stack_depth", rb_usize(report.stack_depth));
+            hash_set(hash, "open_handles", rb_usize(report.open_handles));
+            hash_set(hash, "return_count", rb_usize(report.return_count));
+        }
+        DecodedLanguageResponseBody::Error(error) => {
+            hash_set(hash, "code", rb_usize(error.code));
+            hash_set(hash, "request_id", rb_usize(error.request_id));
+            hash_set(hash, "program_id", rb_usize(error.program_id));
+            hash_set(hash, "bytecode_offset", rb_usize(error.bytecode_offset));
+            hash_set(hash, "message", ruby_bridge::str_to_rb(&error.message));
+        }
+        DecodedLanguageResponseBody::Raw => {
+            hash_set(hash, "payload_len", rb_usize(payload_len));
+        }
+    }
+    hash
+}
+
+fn message_type_name(code: u8) -> &'static str {
+    match code {
+        0x01 => "hello",
+        0x02 => "hello_ack",
+        0x03 => "caps_query",
+        0x04 => "caps_report",
+        0x05 => "program_begin",
+        0x06 => "program_chunk",
+        0x07 => "program_end",
+        0x08 => "run",
+        0x09 => "run_report",
+        0x0A => "stop",
+        0x0B => "reset_vm",
+        0x0C => "store_program",
+        0x0D => "run_stored",
+        0x0E => "read_state",
+        0x0F => "state_report",
+        0x10 => "subscribe",
+        0x11 => "event",
+        0x12 => "log",
+        0x13 => "error",
+        0x14 => "ping",
+        0x15 => "pong",
+        _ => "unknown",
+    }
+}
+
+fn hash_set(hash: VALUE, key: &str, value: VALUE) {
+    ruby_bridge::hash_aset(hash, ruby_bridge::str_to_rb(key), value);
+}
+
+fn rb_usize(value: impl TryInto<usize>) -> VALUE {
+    ruby_bridge::usize_to_rb(value.try_into().unwrap_or(usize::MAX))
 }
 
 fn build_blink_module_value(
@@ -347,5 +518,11 @@ pub extern "C" fn Init_board_vm_native() {
         "blink_upload_run_frames",
         session_blink_upload_run_frames as *const c_void,
         -1,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "decode_response",
+        session_decode_response as *const c_void,
+        1,
     );
 }

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -91,7 +91,12 @@ module CodingAdventures
           *session.blink_upload_run_frames(program_id, budget, pin, high_ms, low_ms, max_stack)
         ]
         responses = frames.map { |frame| dispatch_frame(frame) }
-        SessionResult.new(frames: frames, responses: responses)
+        decoded_responses = responses.map { |response| decode_response(session, response) }
+        SessionResult.new(
+          frames: frames,
+          responses: responses,
+          decoded_responses: decoded_responses
+        )
       end
 
       def eject_blink!(
@@ -179,6 +184,12 @@ module CodingAdventures
 
       def active_transport
         @transport ||= SerialTransport.new(port: port, baud_rate: baud_rate, timeout_ms: timeout_ms)
+      end
+
+      def decode_response(session, response)
+        return nil if response.nil?
+
+        session.decode_response(response)
       end
 
       def cargo_command(*args)

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
@@ -5,7 +5,7 @@ require "rbconfig"
 
 module CodingAdventures
   module BoardVM
-    SessionResult = Struct.new(:frames, :responses, keyword_init: true)
+    SessionResult = Struct.new(:frames, :responses, :decoded_responses, keyword_init: true)
 
     class TransportError < StandardError; end
 

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -62,7 +62,7 @@ module CodingAdventures
 
       def test_led_blink_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
-        transport = FakeTransport.new
+        transport = FakeWriteTransport.new
         result = nil
 
         BoardVM.uno_r4_wifi(
@@ -80,7 +80,8 @@ module CodingAdventures
         assert_equal 6, transport.frames.length
         assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
         assert_equal transport.frames, result.frames
-        assert_equal Array.new(6, "ack".b), result.responses
+        assert_equal Array.new(6), result.responses
+        assert_equal Array.new(6), result.decoded_responses
       end
 
       def test_native_session_builds_protocol_bytes_in_rust

--- a/code/packages/ruby/board_vm/test/test_helper.rb
+++ b/code/packages/ruby/board_vm/test/test_helper.rb
@@ -17,15 +17,14 @@ class FakeRunner
   end
 end
 
-class FakeTransport
+class FakeWriteTransport
   attr_reader :frames
 
   def initialize
     @frames = []
   end
 
-  def transact(frame, timeout_ms:)
+  def write(frame)
     @frames << frame
-    "ack".b
   end
 end

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -16,7 +16,12 @@ use board_vm_host::{
     write_blink_module, BlinkProgram, HostError, HostSession, BLINK_MODULE_LEN,
     DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
 };
-use board_vm_protocol::{decode_frame, decode_wire_frame, encode_wire_frame, Frame, ProtocolError};
+use board_vm_protocol::{
+    decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
+    decode_program_begin, decode_program_chunk, decode_program_end, decode_run_report_header,
+    decode_wire_frame, encode_wire_frame, Frame, MessageType, ProgramFormat, ProtocolError,
+    RunStatus, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
+};
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
 pub const LANGUAGE_CORE_VERSION_MINOR: u16 = 1;
@@ -138,6 +143,137 @@ impl Default for BoardVmLanguageSession {
 pub struct BuiltWireFrame {
     pub request_id: u16,
     pub len: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedLanguageResponse {
+    pub request_id: u16,
+    pub message_type: MessageType,
+    pub flags: u8,
+    pub payload_len: usize,
+    pub body: DecodedLanguageResponseBody,
+}
+
+impl DecodedLanguageResponse {
+    pub const fn is_response(&self) -> bool {
+        self.flags & FLAG_IS_RESPONSE != 0
+    }
+
+    pub const fn is_error_response(&self) -> bool {
+        self.flags & FLAG_IS_ERROR_RESPONSE != 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodedLanguageResponseBody {
+    HelloAck(LanguageHelloAck),
+    CapsReport(LanguageBoardDescriptor),
+    ProgramBegin(LanguageProgramBegin),
+    ProgramChunk(LanguageProgramChunk),
+    ProgramEnd(LanguageProgramEnd),
+    RunReport(LanguageRunReport),
+    Error(LanguageBoardError),
+    Raw,
+}
+
+impl DecodedLanguageResponseBody {
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::HelloAck(_) => "hello_ack",
+            Self::CapsReport(_) => "caps_report",
+            Self::ProgramBegin(_) => "program_begin",
+            Self::ProgramChunk(_) => "program_chunk",
+            Self::ProgramEnd(_) => "program_end",
+            Self::RunReport(_) => "run_report",
+            Self::Error(_) => "error",
+            Self::Raw => "raw",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageHelloAck {
+    pub selected_version: u8,
+    pub board_name: String,
+    pub runtime_name: String,
+    pub host_nonce: u32,
+    pub board_nonce: u32,
+    pub max_frame_payload: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageCapability {
+    pub id: u16,
+    pub version: u8,
+    pub flags: u16,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageBoardDescriptor {
+    pub board_id: String,
+    pub runtime_id: String,
+    pub max_program_bytes: u32,
+    pub max_stack_values: u8,
+    pub max_handles: u8,
+    pub supports_store_program: bool,
+    pub capabilities: Vec<LanguageCapability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageProgramBegin {
+    pub program_id: u16,
+    pub format: ProgramFormat,
+    pub total_len: u32,
+    pub program_crc32: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageProgramChunk {
+    pub program_id: u16,
+    pub offset: u32,
+    pub len: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageProgramEnd {
+    pub program_id: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageRunReport {
+    pub program_id: u16,
+    pub status: RunStatus,
+    pub instructions_executed: u32,
+    pub elapsed_ms: u32,
+    pub stack_depth: u8,
+    pub open_handles: u8,
+    pub return_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageBoardError {
+    pub code: u16,
+    pub request_id: u16,
+    pub program_id: u16,
+    pub bytecode_offset: u32,
+    pub message: String,
+}
+
+pub const fn program_format_name(format: ProgramFormat) -> &'static str {
+    match format {
+        ProgramFormat::BvmModule => "bvm_module",
+    }
+}
+
+pub const fn run_status_name(status: RunStatus) -> &'static str {
+    match status {
+        RunStatus::Halted => "halted",
+        RunStatus::Running => "running",
+        RunStatus::Stopped => "stopped",
+        RunStatus::BudgetExceeded => "budget_exceeded",
+        RunStatus::Faulted => "faulted",
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -292,6 +428,124 @@ pub fn decode_wire_frame_into_raw(
         raw_out.as_ptr(),
         raw_len,
     ))
+}
+
+pub fn decode_wire_response(
+    wire_frame: &[u8],
+    raw_out: &mut [u8],
+) -> Result<DecodedLanguageResponse, LanguageCoreError> {
+    let raw_len = decode_wire_frame(wire_frame, raw_out)?;
+    decode_raw_response(&raw_out[..raw_len])
+}
+
+pub fn decode_raw_response(raw_frame: &[u8]) -> Result<DecodedLanguageResponse, LanguageCoreError> {
+    let frame = decode_frame(raw_frame)?;
+    let body = if frame.flags & FLAG_IS_ERROR_RESPONSE != 0 {
+        let error = decode_error_payload(frame.payload)?;
+        DecodedLanguageResponseBody::Error(LanguageBoardError {
+            code: error.code,
+            request_id: error.request_id,
+            program_id: error.program_id,
+            bytecode_offset: error.bytecode_offset,
+            message: error.message.to_owned(),
+        })
+    } else {
+        decode_response_body(&frame)?
+    };
+
+    Ok(DecodedLanguageResponse {
+        request_id: frame.request_id,
+        message_type: frame.message_type,
+        flags: frame.flags,
+        payload_len: frame.payload.len(),
+        body,
+    })
+}
+
+fn decode_response_body(
+    frame: &Frame<'_>,
+) -> Result<DecodedLanguageResponseBody, LanguageCoreError> {
+    match frame.message_type {
+        MessageType::HELLO_ACK => {
+            let ack = decode_hello_ack(frame.payload)?;
+            Ok(DecodedLanguageResponseBody::HelloAck(LanguageHelloAck {
+                selected_version: ack.selected_version,
+                board_name: ack.board_name.to_owned(),
+                runtime_name: ack.runtime_name.to_owned(),
+                host_nonce: ack.host_nonce,
+                board_nonce: ack.board_nonce,
+                max_frame_payload: ack.max_frame_payload,
+            }))
+        }
+        MessageType::CAPS_REPORT => {
+            let (header, mut decoder) = decode_caps_report_header(frame.payload)?;
+            let mut capabilities = Vec::new();
+            for _ in 0..header.capability_count {
+                let capability = decoder.read_capability_descriptor()?;
+                capabilities.push(LanguageCapability {
+                    id: capability.id,
+                    version: capability.version,
+                    flags: capability.flags,
+                    name: capability.name.to_owned(),
+                });
+            }
+            decoder.finish()?;
+            Ok(DecodedLanguageResponseBody::CapsReport(
+                LanguageBoardDescriptor {
+                    board_id: header.board_id.to_owned(),
+                    runtime_id: header.runtime_id.to_owned(),
+                    max_program_bytes: header.max_program_bytes,
+                    max_stack_values: header.max_stack_values,
+                    max_handles: header.max_handles,
+                    supports_store_program: header.supports_store_program,
+                    capabilities,
+                },
+            ))
+        }
+        MessageType::PROGRAM_BEGIN => {
+            let begin = decode_program_begin(frame.payload)?;
+            Ok(DecodedLanguageResponseBody::ProgramBegin(
+                LanguageProgramBegin {
+                    program_id: begin.program_id,
+                    format: begin.format,
+                    total_len: begin.total_len,
+                    program_crc32: begin.program_crc32,
+                },
+            ))
+        }
+        MessageType::PROGRAM_CHUNK => {
+            let chunk = decode_program_chunk(frame.payload)?;
+            Ok(DecodedLanguageResponseBody::ProgramChunk(
+                LanguageProgramChunk {
+                    program_id: chunk.program_id,
+                    offset: chunk.offset,
+                    len: chunk.bytes.len(),
+                },
+            ))
+        }
+        MessageType::PROGRAM_END => {
+            let end = decode_program_end(frame.payload)?;
+            Ok(DecodedLanguageResponseBody::ProgramEnd(
+                LanguageProgramEnd {
+                    program_id: end.program_id,
+                },
+            ))
+        }
+        MessageType::RUN_REPORT => {
+            let (report, decoder) = decode_run_report_header(frame.payload)?;
+            decoder.finish()?;
+            Ok(DecodedLanguageResponseBody::RunReport(LanguageRunReport {
+                program_id: report.program_id,
+                status: report.status,
+                instructions_executed: report.instructions_executed,
+                elapsed_ms: report.elapsed_ms,
+                stack_depth: report.stack_depth,
+                open_handles: report.open_handles,
+                return_count: report.return_count,
+            }))
+        }
+        _ => Ok(DecodedLanguageResponseBody::Raw),
+    }
 }
 
 thread_local! {
@@ -666,8 +920,9 @@ mod tests {
     use super::*;
     use board_vm_protocol::{
         decode_program_begin, decode_program_chunk, decode_program_end, decode_run_request,
-        encode_frame, encode_wire_frame, Frame, MessageType, RunReportHeader, RunStatus,
-        FLAG_IS_RESPONSE, GOLDEN_HELLO_WIRE_FRAME_BVM_V1, RUN_FLAG_BACKGROUND_RUN,
+        encode_caps_report, encode_frame, encode_hello_ack, encode_wire_frame,
+        CapabilityDescriptor, CapsReportHeader, Frame, HelloAck, MessageType, RunReportHeader,
+        RunStatus, FLAG_IS_RESPONSE, GOLDEN_HELLO_WIRE_FRAME_BVM_V1, RUN_FLAG_BACKGROUND_RUN,
         RUN_FLAG_RESET_VM_BEFORE_RUN,
     };
 
@@ -822,6 +1077,81 @@ mod tests {
     }
 
     #[test]
+    fn rust_core_decodes_structured_response_bodies() {
+        let hello = HelloAck {
+            selected_version: 1,
+            board_name: "uno-r4-wifi",
+            runtime_name: "board-vm",
+            host_nonce: 0xAABB_CCDD,
+            board_nonce: 0x1122_3344,
+            max_frame_payload: 512,
+        };
+        let mut payload = [0u8; 128];
+        let payload_len = encode_hello_ack(&hello, &mut payload).unwrap();
+        let decoded = decode_response_fixture(MessageType::HELLO_ACK, 11, &payload[..payload_len]);
+        assert_eq!(decoded.request_id, 11);
+        assert!(decoded.is_response());
+        assert_eq!(decoded.body.kind(), "hello_ack");
+        match decoded.body {
+            DecodedLanguageResponseBody::HelloAck(ack) => {
+                assert_eq!(ack.board_name, "uno-r4-wifi");
+                assert_eq!(ack.runtime_name, "board-vm");
+                assert_eq!(ack.host_nonce, 0xAABB_CCDD);
+                assert_eq!(ack.max_frame_payload, 512);
+            }
+            other => panic!("unexpected hello response body: {other:?}"),
+        }
+
+        let caps = CapsReportHeader {
+            board_id: "arduino:uno-r4-wifi",
+            runtime_id: "board-vm-rust",
+            max_program_bytes: 1024,
+            max_stack_values: 16,
+            max_handles: 4,
+            supports_store_program: true,
+            capability_count: 1,
+        };
+        let capabilities = [CapabilityDescriptor {
+            id: board_vm_protocol::CAP_PROGRAM_RAM_EXEC,
+            version: 1,
+            flags: board_vm_protocol::CAP_FLAG_BYTECODE_CALLABLE,
+            name: "program.ram.exec",
+        }];
+        let payload_len = encode_caps_report(&caps, &capabilities, &mut payload).unwrap();
+        let decoded =
+            decode_response_fixture(MessageType::CAPS_REPORT, 12, &payload[..payload_len]);
+        match decoded.body {
+            DecodedLanguageResponseBody::CapsReport(report) => {
+                assert_eq!(report.board_id, "arduino:uno-r4-wifi");
+                assert!(report.supports_store_program);
+                assert_eq!(report.capabilities.len(), 1);
+                assert_eq!(report.capabilities[0].name, "program.ram.exec");
+            }
+            other => panic!("unexpected caps response body: {other:?}"),
+        }
+
+        let run = RunReportHeader {
+            program_id: 7,
+            status: RunStatus::Running,
+            instructions_executed: 42,
+            elapsed_ms: 8,
+            stack_depth: 2,
+            open_handles: 1,
+            return_count: 0,
+        };
+        let payload_len = board_vm_protocol::encode_run_report_header(&run, &mut payload).unwrap();
+        let decoded = decode_response_fixture(MessageType::RUN_REPORT, 13, &payload[..payload_len]);
+        match decoded.body {
+            DecodedLanguageResponseBody::RunReport(report) => {
+                assert_eq!(report.program_id, 7);
+                assert_eq!(report.status, RunStatus::Running);
+                assert_eq!(report.instructions_executed, 42);
+            }
+            other => panic!("unexpected run response body: {other:?}"),
+        }
+    }
+
+    #[test]
     fn c_abi_reports_null_output_buffers_without_unwinding() {
         let status = unsafe { board_vm_language_blink_module(13, 250, 250, 4, ptr::null_mut(), 0) };
 
@@ -836,5 +1166,27 @@ mod tests {
                 .into_owned()
         };
         assert!(message.contains("module_out"));
+    }
+
+    fn decode_response_fixture(
+        message_type: MessageType,
+        request_id: u16,
+        payload: &[u8],
+    ) -> DecodedLanguageResponse {
+        let mut raw = [0u8; 256];
+        let raw_len = encode_frame(
+            &Frame {
+                flags: FLAG_IS_RESPONSE,
+                message_type,
+                request_id,
+                payload,
+            },
+            &mut raw,
+        )
+        .unwrap();
+        let mut wire = [0u8; 320];
+        let wire_len = encode_wire_frame(&raw[..raw_len], &mut wire).unwrap();
+        let mut decoded_raw = [0u8; 256];
+        decode_wire_response(&wire[..wire_len], &mut decoded_raw).unwrap()
     }
 }


### PR DESCRIPTION
## Summary

- add Rust-owned Board VM response decoding for HELLO_ACK, capabilities, program upload ACKs, run reports, board errors, and raw fallback responses
- expose response decoding through the Ruby native bridge as Ruby hashes while keeping binary framing in board-vm-language-core
- return decoded_responses from the Ruby blink DSL alongside raw request frames and raw response bytes

## Validation

- cargo test -p board-vm-language-core
- rake test
