### PR TITLE
Add Rust smart home protocol stack specs

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -425,6 +425,7 @@ members = [
     "nib-jvm-compiler",
     "bitset-c",
     "http-core",
+    "ieee802154-core",
     "http1",
     "storage-core",
     "vault-sealed-store",

--- a/code/packages/rust/ieee802154-core/BUILD
+++ b/code/packages/rust/ieee802154-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p ieee802154-core -- --nocapture

--- a/code/packages/rust/ieee802154-core/BUILD_windows
+++ b/code/packages/rust/ieee802154-core/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p ieee802154-core -- --nocapture

--- a/code/packages/rust/ieee802154-core/CHANGELOG.md
+++ b/code/packages/rust/ieee802154-core/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial MAC frame-control, addressing, payload, and optional FCS parsing.

--- a/code/packages/rust/ieee802154-core/Cargo.toml
+++ b/code/packages/rust/ieee802154-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ieee802154-core"
+version = "0.1.0"
+edition = "2021"
+description = "From-scratch IEEE 802.15.4 MAC frame primitives for low-power smart-home protocol stacks."
+license = "MIT"
+
+[dependencies]
+# No dependencies. This is a pure parser/encoder foundation package.

--- a/code/packages/rust/ieee802154-core/README.md
+++ b/code/packages/rust/ieee802154-core/README.md
@@ -1,0 +1,67 @@
+# ieee802154-core
+
+From-scratch IEEE 802.15.4 MAC frame primitives.
+
+This package is the first executable brick under the Zigbee and Thread learning
+tracks. It intentionally starts with bytes: parse a MAC frame, inspect its frame
+control field, decode addressing, and encode it again.
+
+## Scope
+
+Current scope:
+
+- frame control field parsing
+- frame type decoding
+- address mode decoding
+- optional sequence-number suppression
+- PAN id compression for common intra-PAN frames
+- short and extended address parsing
+- payload extraction
+- optional FCS handling
+
+Not yet implemented:
+
+- auxiliary security header parsing
+- AES-CCM security processing
+- MAC command payload semantics
+- beacon payload semantics
+- CSMA/CA state machines
+- PHY/baseband behavior
+
+Those belong in later D24 packages.
+
+## Example
+
+```rust
+use ieee802154_core::{MacFrame, Address};
+
+let bytes = [
+    0x41, 0x98, // data frame, PAN compression, short dst/src, 2006 version
+    0x07,       // sequence number
+    0x34, 0x12, // destination PAN
+    0x78, 0x56, // destination short address
+    0xbc, 0x9a, // source short address
+    0x01, 0x02, // payload
+];
+
+let frame = MacFrame::parse_without_fcs(&bytes).unwrap();
+assert_eq!(frame.sequence_number, Some(7));
+assert_eq!(frame.destination, Some(Address::Short(0x5678)));
+assert_eq!(frame.source, Some(Address::Short(0x9abc)));
+assert_eq!(frame.payload, vec![0x01, 0x02]);
+```
+
+## Layer Position
+
+```text
+zigbee-nwk / sixlowpan / thread-mle
+    |
+    v
+ieee802154-core
+    |
+    v
+ieee802154-mac / ieee802154-security / ieee802154-radio
+```
+
+The package has no hardware dependency. Radio drivers and simulators should
+consume these types rather than reimplementing frame parsing.

--- a/code/packages/rust/ieee802154-core/required_capabilities.json
+++ b/code/packages/rust/ieee802154-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/ieee802154-core",
+  "capabilities": [],
+  "justification": "Pure frame parsing and encoding. No filesystem, network, process, radio, serial, or environment access needed."
+}

--- a/code/packages/rust/ieee802154-core/src/lib.rs
+++ b/code/packages/rust/ieee802154-core/src/lib.rs
@@ -1,0 +1,614 @@
+// lib.rs -- IEEE 802.15.4 MAC frame primitives
+// ================================================================
+//
+// This package starts the smart-home radio work at the byte boundary. Zigbee
+// and Thread both build on IEEE 802.15.4, so the first reusable primitive is a
+// small, dependency-free MAC frame parser/encoder.
+
+use std::fmt;
+
+const SEQ_LEN: usize = 1;
+const PAN_ID_LEN: usize = 2;
+const SHORT_ADDR_LEN: usize = 2;
+const EXTENDED_ADDR_LEN: usize = 8;
+const FCS_LEN: usize = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameType {
+    Beacon,
+    Data,
+    Acknowledgment,
+    MacCommand,
+    Multipurpose,
+    Fragment,
+    Extended,
+    Reserved(u8),
+}
+
+impl FrameType {
+    fn from_bits(bits: u8) -> Self {
+        match bits {
+            0 => Self::Beacon,
+            1 => Self::Data,
+            2 => Self::Acknowledgment,
+            3 => Self::MacCommand,
+            5 => Self::Multipurpose,
+            6 => Self::Fragment,
+            7 => Self::Extended,
+            other => Self::Reserved(other),
+        }
+    }
+
+    fn bits(self) -> u16 {
+        match self {
+            Self::Beacon => 0,
+            Self::Data => 1,
+            Self::Acknowledgment => 2,
+            Self::MacCommand => 3,
+            Self::Reserved(bits) => bits as u16,
+            Self::Multipurpose => 5,
+            Self::Fragment => 6,
+            Self::Extended => 7,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddressMode {
+    None,
+    Reserved,
+    Short,
+    Extended,
+}
+
+impl AddressMode {
+    fn from_bits(bits: u8) -> Self {
+        match bits {
+            0 => Self::None,
+            2 => Self::Short,
+            3 => Self::Extended,
+            _ => Self::Reserved,
+        }
+    }
+
+    fn bits(self) -> u16 {
+        match self {
+            Self::None => 0,
+            Self::Reserved => 1,
+            Self::Short => 2,
+            Self::Extended => 3,
+        }
+    }
+
+    pub fn encoded_len(self) -> usize {
+        match self {
+            Self::None => 0,
+            Self::Reserved => 0,
+            Self::Short => SHORT_ADDR_LEN,
+            Self::Extended => EXTENDED_ADDR_LEN,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameVersion {
+    Ieee8021542003,
+    Ieee8021542006,
+    Ieee8021542015,
+    Reserved,
+}
+
+impl FrameVersion {
+    fn from_bits(bits: u8) -> Self {
+        match bits {
+            0 => Self::Ieee8021542003,
+            1 => Self::Ieee8021542006,
+            2 => Self::Ieee8021542015,
+            _ => Self::Reserved,
+        }
+    }
+
+    fn bits(self) -> u16 {
+        match self {
+            Self::Ieee8021542003 => 0,
+            Self::Ieee8021542006 => 1,
+            Self::Ieee8021542015 => 2,
+            Self::Reserved => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Address {
+    Short(u16),
+    Extended(u64),
+}
+
+impl Address {
+    fn mode(self) -> AddressMode {
+        match self {
+            Self::Short(_) => AddressMode::Short,
+            Self::Extended(_) => AddressMode::Extended,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameControl {
+    pub frame_type: FrameType,
+    pub security_enabled: bool,
+    pub frame_pending: bool,
+    pub ack_request: bool,
+    pub pan_id_compression: bool,
+    pub sequence_number_suppression: bool,
+    pub information_elements_present: bool,
+    pub destination_address_mode: AddressMode,
+    pub frame_version: FrameVersion,
+    pub source_address_mode: AddressMode,
+}
+
+impl FrameControl {
+    pub fn parse(raw: u16) -> Self {
+        Self {
+            frame_type: FrameType::from_bits((raw & 0b111) as u8),
+            security_enabled: raw & (1 << 3) != 0,
+            frame_pending: raw & (1 << 4) != 0,
+            ack_request: raw & (1 << 5) != 0,
+            pan_id_compression: raw & (1 << 6) != 0,
+            sequence_number_suppression: raw & (1 << 8) != 0,
+            information_elements_present: raw & (1 << 9) != 0,
+            destination_address_mode: AddressMode::from_bits(((raw >> 10) & 0b11) as u8),
+            frame_version: FrameVersion::from_bits(((raw >> 12) & 0b11) as u8),
+            source_address_mode: AddressMode::from_bits(((raw >> 14) & 0b11) as u8),
+        }
+    }
+
+    pub fn encode(self) -> u16 {
+        let mut raw = self.frame_type.bits();
+        raw |= (self.security_enabled as u16) << 3;
+        raw |= (self.frame_pending as u16) << 4;
+        raw |= (self.ack_request as u16) << 5;
+        raw |= (self.pan_id_compression as u16) << 6;
+        raw |= (self.sequence_number_suppression as u16) << 8;
+        raw |= (self.information_elements_present as u16) << 9;
+        raw |= self.destination_address_mode.bits() << 10;
+        raw |= self.frame_version.bits() << 12;
+        raw |= self.source_address_mode.bits() << 14;
+        raw
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MacFrame {
+    pub frame_control: FrameControl,
+    pub sequence_number: Option<u8>,
+    pub destination_pan_id: Option<u16>,
+    pub destination: Option<Address>,
+    pub source_pan_id: Option<u16>,
+    pub source: Option<Address>,
+    pub payload: Vec<u8>,
+    pub fcs: Option<u16>,
+}
+
+impl MacFrame {
+    pub fn parse_without_fcs(bytes: &[u8]) -> Result<Self, MacFrameError> {
+        Self::parse(bytes, false)
+    }
+
+    pub fn parse_with_fcs(bytes: &[u8]) -> Result<Self, MacFrameError> {
+        Self::parse(bytes, true)
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, MacFrameError> {
+        validate_modes(self)?;
+
+        let mut out = Vec::new();
+        out.extend_from_slice(&self.frame_control.encode().to_le_bytes());
+
+        if !self.frame_control.sequence_number_suppression {
+            out.push(
+                self.sequence_number
+                    .ok_or(MacFrameError::MissingSequenceNumber)?,
+            );
+        }
+
+        if let Some(destination) = self.destination {
+            out.extend_from_slice(
+                &self
+                    .destination_pan_id
+                    .ok_or(MacFrameError::MissingDestinationPanId)?
+                    .to_le_bytes(),
+            );
+            encode_address(destination, &mut out);
+        }
+
+        if let Some(source) = self.source {
+            if !self.frame_control.pan_id_compression || self.destination_pan_id.is_none() {
+                out.extend_from_slice(
+                    &self
+                        .source_pan_id
+                        .ok_or(MacFrameError::MissingSourcePanId)?
+                        .to_le_bytes(),
+                );
+            }
+            encode_address(source, &mut out);
+        }
+
+        out.extend_from_slice(&self.payload);
+
+        if let Some(fcs) = self.fcs {
+            out.extend_from_slice(&fcs.to_le_bytes());
+        }
+
+        Ok(out)
+    }
+
+    fn parse(bytes: &[u8], has_fcs: bool) -> Result<Self, MacFrameError> {
+        let mut cursor = Cursor::new(bytes);
+        let raw_fcf = cursor.read_u16_le()?;
+        let frame_control = FrameControl::parse(raw_fcf);
+
+        reject_reserved_address_modes(frame_control)?;
+
+        if frame_control.security_enabled {
+            return Err(MacFrameError::SecurityHeaderNotYetSupported);
+        }
+
+        let sequence_number = if frame_control.sequence_number_suppression {
+            None
+        } else {
+            Some(cursor.read_u8()?)
+        };
+
+        let (destination_pan_id, destination) =
+            read_pan_and_address(&mut cursor, frame_control.destination_address_mode)?;
+
+        let source_pan_id = if frame_control.source_address_mode == AddressMode::None {
+            None
+        } else if frame_control.pan_id_compression && destination_pan_id.is_some() {
+            destination_pan_id
+        } else {
+            Some(cursor.read_u16_le()?)
+        };
+
+        let source = read_address(&mut cursor, frame_control.source_address_mode)?;
+
+        let remaining = cursor.remaining();
+        let payload_len = if has_fcs {
+            remaining
+                .checked_sub(FCS_LEN)
+                .ok_or(MacFrameError::TruncatedFrame {
+                    needed: FCS_LEN,
+                    remaining,
+                })?
+        } else {
+            remaining
+        };
+
+        let payload = cursor.read_bytes(payload_len)?.to_vec();
+        let fcs = if has_fcs {
+            Some(cursor.read_u16_le()?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            frame_control,
+            sequence_number,
+            destination_pan_id,
+            destination,
+            source_pan_id,
+            source,
+            payload,
+            fcs,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacFrameError {
+    TruncatedFrame { needed: usize, remaining: usize },
+    ReservedAddressMode { field: &'static str },
+    AddressModeMismatch { field: &'static str },
+    MissingSequenceNumber,
+    MissingDestinationPanId,
+    MissingSourcePanId,
+    SecurityHeaderNotYetSupported,
+}
+
+impl fmt::Display for MacFrameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TruncatedFrame { needed, remaining } => write!(
+                f,
+                "truncated IEEE 802.15.4 frame: needed {needed} bytes, had {remaining}"
+            ),
+            Self::ReservedAddressMode { field } => {
+                write!(f, "reserved address mode in {field} field")
+            }
+            Self::AddressModeMismatch { field } => {
+                write!(f, "frame-control address mode does not match {field}")
+            }
+            Self::MissingSequenceNumber => write!(f, "missing sequence number"),
+            Self::MissingDestinationPanId => write!(f, "missing destination PAN id"),
+            Self::MissingSourcePanId => write!(f, "missing source PAN id"),
+            Self::SecurityHeaderNotYetSupported => {
+                write!(
+                    f,
+                    "auxiliary security header parsing is not implemented yet"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for MacFrameError {}
+
+fn reject_reserved_address_modes(frame_control: FrameControl) -> Result<(), MacFrameError> {
+    if frame_control.destination_address_mode == AddressMode::Reserved {
+        return Err(MacFrameError::ReservedAddressMode {
+            field: "destination",
+        });
+    }
+    if frame_control.source_address_mode == AddressMode::Reserved {
+        return Err(MacFrameError::ReservedAddressMode { field: "source" });
+    }
+    Ok(())
+}
+
+fn validate_modes(frame: &MacFrame) -> Result<(), MacFrameError> {
+    if frame.frame_control.destination_address_mode == AddressMode::Reserved {
+        return Err(MacFrameError::ReservedAddressMode {
+            field: "destination",
+        });
+    }
+    if frame.frame_control.source_address_mode == AddressMode::Reserved {
+        return Err(MacFrameError::ReservedAddressMode { field: "source" });
+    }
+
+    let destination_mode = frame
+        .destination
+        .map(Address::mode)
+        .unwrap_or(AddressMode::None);
+    if destination_mode != frame.frame_control.destination_address_mode {
+        return Err(MacFrameError::AddressModeMismatch {
+            field: "destination",
+        });
+    }
+
+    let source_mode = frame.source.map(Address::mode).unwrap_or(AddressMode::None);
+    if source_mode != frame.frame_control.source_address_mode {
+        return Err(MacFrameError::AddressModeMismatch { field: "source" });
+    }
+
+    Ok(())
+}
+
+fn read_pan_and_address(
+    cursor: &mut Cursor<'_>,
+    mode: AddressMode,
+) -> Result<(Option<u16>, Option<Address>), MacFrameError> {
+    if mode == AddressMode::None {
+        return Ok((None, None));
+    }
+
+    let pan_id = cursor.read_u16_le()?;
+    let address = read_address(cursor, mode)?;
+    Ok((Some(pan_id), address))
+}
+
+fn read_address(
+    cursor: &mut Cursor<'_>,
+    mode: AddressMode,
+) -> Result<Option<Address>, MacFrameError> {
+    match mode {
+        AddressMode::None => Ok(None),
+        AddressMode::Reserved => Err(MacFrameError::ReservedAddressMode { field: "address" }),
+        AddressMode::Short => Ok(Some(Address::Short(cursor.read_u16_le()?))),
+        AddressMode::Extended => Ok(Some(Address::Extended(cursor.read_u64_le()?))),
+    }
+}
+
+fn encode_address(address: Address, out: &mut Vec<u8>) {
+    match address {
+        Address::Short(value) => out.extend_from_slice(&value.to_le_bytes()),
+        Address::Extended(value) => out.extend_from_slice(&value.to_le_bytes()),
+    }
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len().saturating_sub(self.offset)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, MacFrameError> {
+        Ok(self.read_bytes(SEQ_LEN)?[0])
+    }
+
+    fn read_u16_le(&mut self) -> Result<u16, MacFrameError> {
+        let bytes = self.read_bytes(PAN_ID_LEN)?;
+        Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn read_u64_le(&mut self) -> Result<u64, MacFrameError> {
+        let bytes = self.read_bytes(EXTENDED_ADDR_LEN)?;
+        Ok(u64::from_le_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        ]))
+    }
+
+    fn read_bytes(&mut self, len: usize) -> Result<&'a [u8], MacFrameError> {
+        let remaining = self.remaining();
+        if remaining < len {
+            return Err(MacFrameError::TruncatedFrame {
+                needed: len,
+                remaining,
+            });
+        }
+
+        let start = self.offset;
+        self.offset += len;
+        Ok(&self.bytes[start..start + len])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn data_frame_control() -> FrameControl {
+        FrameControl {
+            frame_type: FrameType::Data,
+            security_enabled: false,
+            frame_pending: false,
+            ack_request: false,
+            pan_id_compression: true,
+            sequence_number_suppression: false,
+            information_elements_present: false,
+            destination_address_mode: AddressMode::Short,
+            frame_version: FrameVersion::Ieee8021542006,
+            source_address_mode: AddressMode::Short,
+        }
+    }
+
+    #[test]
+    fn parses_short_address_data_frame_without_fcs() {
+        let bytes = [
+            0x41, 0x98, // frame control
+            0x07, // sequence number
+            0x34, 0x12, // destination PAN id
+            0x78, 0x56, // destination short address
+            0xbc, 0x9a, // source short address, PAN compressed
+            0x01, 0x02, // payload
+        ];
+
+        let frame = MacFrame::parse_without_fcs(&bytes).unwrap();
+
+        assert_eq!(frame.frame_control, data_frame_control());
+        assert_eq!(frame.sequence_number, Some(7));
+        assert_eq!(frame.destination_pan_id, Some(0x1234));
+        assert_eq!(frame.destination, Some(Address::Short(0x5678)));
+        assert_eq!(frame.source_pan_id, Some(0x1234));
+        assert_eq!(frame.source, Some(Address::Short(0x9abc)));
+        assert_eq!(frame.payload, vec![0x01, 0x02]);
+        assert_eq!(frame.fcs, None);
+    }
+
+    #[test]
+    fn encodes_short_address_data_frame_without_fcs() {
+        let frame = MacFrame {
+            frame_control: data_frame_control(),
+            sequence_number: Some(7),
+            destination_pan_id: Some(0x1234),
+            destination: Some(Address::Short(0x5678)),
+            source_pan_id: Some(0x1234),
+            source: Some(Address::Short(0x9abc)),
+            payload: vec![0x01, 0x02],
+            fcs: None,
+        };
+
+        assert_eq!(
+            frame.encode().unwrap(),
+            vec![0x41, 0x98, 0x07, 0x34, 0x12, 0x78, 0x56, 0xbc, 0x9a, 0x01, 0x02]
+        );
+    }
+
+    #[test]
+    fn parses_ack_frame() {
+        let bytes = [0x02, 0x00, 0x2a];
+
+        let frame = MacFrame::parse_without_fcs(&bytes).unwrap();
+
+        assert_eq!(frame.frame_control.frame_type, FrameType::Acknowledgment);
+        assert_eq!(frame.sequence_number, Some(0x2a));
+        assert_eq!(frame.destination, None);
+        assert_eq!(frame.source, None);
+        assert!(frame.payload.is_empty());
+    }
+
+    #[test]
+    fn parses_frame_with_fcs() {
+        let bytes = [0x02, 0x00, 0x2a, 0xef, 0xbe];
+
+        let frame = MacFrame::parse_with_fcs(&bytes).unwrap();
+
+        assert_eq!(frame.sequence_number, Some(0x2a));
+        assert_eq!(frame.fcs, Some(0xbeef));
+        assert!(frame.payload.is_empty());
+    }
+
+    #[test]
+    fn supports_sequence_number_suppression() {
+        let control = FrameControl {
+            sequence_number_suppression: true,
+            ..data_frame_control()
+        };
+        let bytes = [
+            0x41, 0x99, // same data frame with sequence suppression bit set
+            0x34, 0x12, 0x78, 0x56, 0xbc, 0x9a,
+        ];
+
+        let frame = MacFrame::parse_without_fcs(&bytes).unwrap();
+
+        assert_eq!(frame.frame_control, control);
+        assert_eq!(frame.sequence_number, None);
+        assert!(frame.payload.is_empty());
+    }
+
+    #[test]
+    fn rejects_reserved_address_mode() {
+        let bytes = [
+            0x01, 0x04, // data frame with reserved destination address mode
+            0x07,
+        ];
+
+        assert_eq!(
+            MacFrame::parse_without_fcs(&bytes),
+            Err(MacFrameError::ReservedAddressMode {
+                field: "destination"
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_security_until_aux_header_is_implemented() {
+        let bytes = [
+            0x49, 0x98, // data frame plus security enabled
+            0x07, 0x34, 0x12, 0x78, 0x56, 0xbc, 0x9a,
+        ];
+
+        assert_eq!(
+            MacFrame::parse_without_fcs(&bytes),
+            Err(MacFrameError::SecurityHeaderNotYetSupported)
+        );
+    }
+
+    #[test]
+    fn reports_truncated_frame() {
+        let bytes = [0x41];
+
+        assert_eq!(
+            MacFrame::parse_without_fcs(&bytes),
+            Err(MacFrameError::TruncatedFrame {
+                needed: 2,
+                remaining: 1
+            })
+        );
+    }
+
+    #[test]
+    fn address_mode_knows_encoded_length() {
+        assert_eq!(AddressMode::None.encoded_len(), 0);
+        assert_eq!(AddressMode::Short.encoded_len(), 2);
+        assert_eq!(AddressMode::Extended.encoded_len(), 8);
+    }
+}

--- a/code/specs/D23-smart-home-runtime.md
+++ b/code/specs/D23-smart-home-runtime.md
@@ -29,6 +29,22 @@ If the Hue adapter is cut correctly, the same substrate can host Zigbee radios,
 Z-Wave controllers, Thread border routers, Matter controllers, cloud APIs, and
 arbitrary user-written integrations.
 
+D23 is the application substrate. It does not mean Zigbee, Z-Wave, and Thread
+should remain opaque forever. Those protocols are low-level enough that this
+repository should implement them from scratch as separate learning-oriented
+stacks:
+
+- D24 IEEE 802.15.4 for the shared MAC/PHY foundation used by Zigbee and Thread
+- D25 Zigbee Stack for network, APS, ZDO, ZCL, coordinator, and simulator work
+- D26 Z-Wave Stack for controller, inclusion, command-class, security, and Long
+  Range work
+- D27 Thread Stack for 6LoWPAN, MLE, commissioning, border routing, and Matter
+  diagnostics
+
+The smart-home runtime consumes those stacks through normalized bridge, device,
+entity, event, and command interfaces. The protocol packages own frame formats,
+state machines, security handshakes, routing, and simulators.
+
 ---
 
 ## Where It Fits
@@ -84,6 +100,10 @@ Infrastructure:
   D18D Tool API    -> model/workflow-facing command surface
   D21 Cage/Policy  -> capability and tier enforcement
   Vault packages   -> bridge app keys, radio network keys, fabric credentials
+  D24 IEEE 802.15.4 -> shared low-level radio foundation for Zigbee/Thread
+  D25 Zigbee Stack  -> from-scratch Zigbee implementation track
+  D26 Z-Wave Stack  -> from-scratch Z-Wave implementation track
+  D27 Thread Stack  -> from-scratch Thread implementation track
 ```
 
 **Depends on:** D19 Actor, D18A Stores, D18C Job Framework, D18D Tool API,
@@ -111,8 +131,9 @@ style products.
    integrations are supervised actors with restart policy and health state.
 7. **State is cached, but truth is external.** The cache represents the latest
    known state plus freshness metadata. It is never treated as omniscient.
-8. **User-written integrations are welcome.** WASM, BEAM-native, and external
-   process adapters can participate if they speak the same host protocol.
+8. **Rust implementation is the rule.** Repository-owned integrations and
+   protocol stacks are written in Rust and isolated by actors/processes rather
+   than mixed implementation languages.
 
 ---
 
@@ -142,7 +163,7 @@ Integration
 |-- integration_id
 |-- display_name
 |-- version
-|-- runtime_kind        native | wasm | deno | node | python | ruby | executable
+|-- runtime_kind        in_process_rust | rust_worker_process
 |-- capabilities[]
 |-- discovery_handlers[]
 |-- pairing_handlers[]
@@ -626,6 +647,11 @@ binding/reporting    -> adapter-private configuration
 network key          -> Vault secret
 ```
 
+The implementation should be repository-owned and layered through D24/D25:
+frame parsing first, deterministic simulation second, hardware adapters third.
+USB coordinator support is an adapter around our Zigbee stack, not the
+definition of the stack.
+
 ### Z-Wave
 
 Z-Wave is controller-mediated. It should also be a separate integration because
@@ -645,6 +671,11 @@ S2 keys              -> Vault secrets
 
 The runtime must understand that some Z-Wave commands are slow, sleepy,
 queued, or require secure inclusion before they are available.
+
+The implementation should be repository-owned and layered through D26. Existing
+controller APIs are useful references and hardware access paths, but the stack
+should model frames, inclusion, command classes, security, node interviews, and
+Long Range topology explicitly.
 
 ### Thread and Matter
 
@@ -669,6 +700,11 @@ fabric credentials   -> Vault secrets
 Thread diagnostics are still valuable: border-router health, network partition
 state, route reachability, and multicast/service-discovery health affect Matter
 reliability.
+
+The implementation should be repository-owned and layered through D24/D27.
+Thread is networking, not device automation. Matter-over-Thread should consume
+Thread reachability and diagnostics while keeping Matter clusters in the
+application layer.
 
 ---
 
@@ -839,26 +875,18 @@ audit log content.
 
 ---
 
-## Guest Integrations
+## Rust Integration Runtime
 
-Some users will want to write integrations in JavaScript, Python, Ruby, Elixir,
-Rust, or something stranger. D23 should allow that without making the runtime
-unsafe.
+All repository-owned smart-home integration code is written in Rust. That
+includes Hue, Zigbee, Z-Wave, Thread, Matter, MQTT, protocol simulators,
+hardware adapters, and diagnostic tools.
 
-Supported runtime classes:
+The runtime can still preserve a process boundary between the smart-home host
+and an integration package. That boundary is for supervision, capability
+control, restart isolation, and memory accounting, not for allowing arbitrary
+implementation languages inside the core stack.
 
-```text
-wasm        preferred portable sandbox for small adapters
-beam        native Elixir/Erlang actor integration
-native      repository-owned Rust/Elixir package
-deno        external process, user owns V8 footprint
-node        external process, user owns V8 footprint
-python      external process, user owns interpreter footprint
-ruby        external process, user owns interpreter footprint
-executable  explicit process contract
-```
-
-Every guest integration speaks the same host protocol:
+Every integration process speaks the same host protocol:
 
 ```text
 host.discover
@@ -869,10 +897,10 @@ host.subscribe
 host.health
 ```
 
-The host grants capabilities, Vault leases, network access, serial access, and
-filesystem access explicitly. External runtimes are useful, but they are not
-cheap. A million logical integrations can exist as records; a million Python,
-Node, or Deno processes cannot.
+The host grants capabilities, Vault leases, network access, serial access, radio
+access, and filesystem access explicitly. A million logical integrations can
+exist as records; real integration workers are supervised Rust processes or
+actors with explicit resource budgets.
 
 ---
 
@@ -931,7 +959,7 @@ scriptable event streams. Integration authors should be able to test:
 - adapters cannot read credentials except through explicit Vault leases
 - command tools emit audit records on allow and deny
 - high-risk commands require stronger policy than ordinary lighting commands
-- guest integrations receive only declared host capabilities
+- integration workers receive only declared host capabilities
 - raw diagnostic payload retention follows configured policy
 
 ---
@@ -953,12 +981,12 @@ scriptable event streams. Integration authors should be able to test:
 
 1. Should Matter be a first-class D23 integration immediately, or should it wait
    until Hue and one direct-radio adapter prove the normalized model?
-2. Should the first implementation target Rust actors, Elixir/OTP supervisors, or
-   a split model where BEAM supervises Rust bridge workers?
+2. Should the first implementation use in-process Rust actors, separate Rust
+   worker processes, or both depending on adapter risk?
 3. How much raw protocol payload should be retained by default for debugging?
 4. Should automations consume only normalized events, or should expert workflows
    be allowed to subscribe to protocol-native events?
-5. What is the minimum WASI/host ABI required for guest integrations to be
+5. What is the minimum Rust host protocol required for integration workers to be
    useful without exposing ambient authority?
 
 ---

--- a/code/specs/D24-ieee802154.md
+++ b/code/specs/D24-ieee802154.md
@@ -1,0 +1,155 @@
+# D24 - IEEE 802.15.4
+
+## Overview
+
+IEEE 802.15.4 is the low-rate wireless personal area network foundation used by
+Zigbee, Thread, 6LoWPAN, WirelessHART, and other low-power IoT stacks. It defines
+the PHY and MAC layers: how short wireless frames are shaped, addressed,
+acknowledged, secured at the link layer, and moved across a low-power radio.
+
+D24 exists so the repository can implement that foundation from scratch instead
+of treating Zigbee and Thread radios as opaque dongles. The goal is not merely
+device control. The goal is to understand the stack down to frames, timing,
+addresses, channels, scanning, association, security headers, and eventually
+software-defined-radio simulation.
+
+All D24 implementation packages are written in Rust.
+
+---
+
+## Where It Fits
+
+```text
+Smart Home Runtime (D23)
+    |
+    +--> Zigbee Stack (D25)
+    |       |
+    |       v
+    |   IEEE 802.15.4 MAC/PHY (D24)
+    |
+    +--> Thread Stack (D27)
+            |
+            v
+        IEEE 802.15.4 MAC/PHY (D24)
+
+Hardware / simulation targets:
+  - pure frame parser/encoder
+  - simulated radio medium
+  - USB/SPI/UART radio adapters
+  - packet capture files
+  - future SDR baseband experiments
+```
+
+**Depends on:** byte/bit primitives, crypto primitives, CRC/FCS utilities,
+state-machine packages.
+
+**Used by:** D25 Zigbee Stack, D27 Thread Stack, packet analyzers, radio
+simulators, smart-home protocol diagnostics.
+
+---
+
+## Design Principles
+
+1. **Frames first.** Parse and encode MAC frames before implementing network
+   behavior.
+2. **Simulation first, hardware second.** A deterministic simulated radio medium
+   is the fastest way to learn and test.
+3. **No ambient radio magic.** Radio drivers are adapters around repository-owned
+   frame and state-machine logic.
+4. **Keep PHY and MAC separable.** Most early work should operate on MAC frames;
+   PHY/baseband can arrive later.
+5. **Expose captures as artifacts.** Raw frames should be storable and replayable.
+6. **Do not couple to Zigbee or Thread.** D24 knows LR-WPAN frames and radio
+   behavior, not application clusters or IPv6.
+
+---
+
+## Package Roadmap
+
+### `ieee802154-core`
+
+Pure Rust frame types, parser, encoder, and validation helpers:
+
+- frame control field
+- sequence numbers
+- addressing modes
+- PAN identifiers
+- MAC payload extraction
+- optional FCS handling
+- parse errors
+
+### `ieee802154-security`
+
+Link-layer security primitives:
+
+- auxiliary security header model
+- nonce construction
+- frame counters
+- key identifier modes
+- AES-CCM integration
+- replay checks
+
+### `ieee802154-mac`
+
+MAC state machines:
+
+- active/passive scan
+- association/disassociation
+- beacon handling
+- CSMA/CA model
+- acknowledgement handling
+- retry and backoff policy
+
+### `ieee802154-sim`
+
+Deterministic simulated radio medium:
+
+- virtual channels
+- packet loss
+- interference
+- latency
+- multiple nodes
+- capture/replay
+
+### `ieee802154-capture`
+
+Capture file model and tooling for packet traces.
+
+### `ieee802154-radio`
+
+Hardware adapter traits for real radios. This layer should be thin and should
+not own protocol semantics.
+
+---
+
+## Test Strategy
+
+- known byte fixtures round-trip through parse/encode
+- invalid frame-control combinations fail deterministically
+- address-mode combinations parse correctly
+- FCS validation rejects corrupted frames when an FCS is present
+- simulated radios deliver, drop, delay, and replay frames deterministically
+- MAC state machines are testable without hardware
+
+---
+
+## Future Extensions
+
+- O-QPSK PHY simulation for the 2.4 GHz profile
+- sub-GHz PHY modeling for regional/long-range variants
+- SDR receive/transmit experiments
+- Wireshark-compatible capture export
+- property tests and fuzzing for frame parsers
+
+---
+
+## References
+
+- IEEE 802.15.4-2020:
+  <https://standards.ieee.org/standard/802_15_4-2020.html>
+- IEEE 802.15 Working Group:
+  <https://www.ieee802.org/15/about.html>
+- Connectivity Standards Alliance Zigbee materials:
+  <https://csa-iot.org/all-solutions/zigbee/>
+- Thread Group overview:
+  <https://threadgroup.org/What-is-Thread>

--- a/code/specs/D25-zigbee-stack.md
+++ b/code/specs/D25-zigbee-stack.md
@@ -1,0 +1,157 @@
+# D25 - Zigbee Stack
+
+## Overview
+
+Zigbee is a complete low-power IoT stack built above IEEE 802.15.4. It adds a
+network layer, device roles, joining, routing, security, endpoints, clusters,
+profiles, and application-level device behavior.
+
+D25 defines a from-scratch Zigbee implementation track. The smart-home runtime
+can use vendor bridges when that is practical, but this repository should also
+be able to form, inspect, simulate, and eventually operate its own Zigbee
+networks.
+
+All D25 implementation packages are written in Rust.
+
+---
+
+## Where It Fits
+
+```text
+Smart Home Runtime (D23)
+    |
+    v
+Zigbee Integration
+    |
+    v
+Zigbee Stack (D25)
+  - network layer
+  - application support sublayer
+  - device objects
+  - cluster library mapping
+  - security services
+    |
+    v
+IEEE 802.15.4 (D24)
+```
+
+**Depends on:** D24 IEEE 802.15.4, crypto primitives, state-machine packages,
+D23 smart-home entity/capability model.
+
+**Used by:** Zigbee coordinator packages, packet analyzers, protocol simulators,
+smart-home integrations, learning tools.
+
+---
+
+## Design Principles
+
+1. **Do not start with a USB stick API.** Start with frames, network messages,
+   and state machines.
+2. **Separate network behavior from device modeling.** Routing and joining are
+   not clusters.
+3. **Clusters map upward.** Zigbee clusters become D23 capabilities and entities.
+4. **Security is explicit.** Network keys, link keys, counters, and trust-center
+   behavior are first-class objects.
+5. **Interop later, understanding first.** Early packages should decode, encode,
+   simulate, and explain before trying to control real homes.
+
+---
+
+## Layers
+
+```text
+zigbee-zcl       Zigbee Cluster Library mapping
+zigbee-zdo       Zigbee Device Object behavior
+zigbee-aps       Application Support Sublayer frames and binding
+zigbee-nwk       network frames, addressing, routing, joining
+zigbee-security  keys, counters, encryption, trust center model
+ieee802154-*     MAC/PHY foundation from D24
+```
+
+---
+
+## Package Roadmap
+
+### `zigbee-nwk`
+
+- network frame parser/encoder
+- network addresses
+- radius/depth fields
+- route discovery records
+- neighbor and route tables
+- join/leave state machines
+
+### `zigbee-aps`
+
+- endpoint addressing
+- group addressing
+- binding table model
+- APS commands
+- fragmentation model
+
+### `zigbee-zdo`
+
+- node descriptors
+- simple descriptors
+- active endpoint discovery
+- bind/unbind requests
+- management requests
+
+### `zigbee-zcl`
+
+- cluster ids
+- attribute reports
+- command frames
+- foundation commands
+- common smart-home clusters mapped to D23 capabilities
+
+### `zigbee-coordinator`
+
+- network formation
+- permit join
+- device interview
+- trust-center policy
+- projection into D23 Bridge/Device/Entity records
+
+### `zigbee-sim`
+
+- virtual coordinator/router/end-device nodes
+- deterministic routing and join tests
+- sleepy end-device behavior
+
+---
+
+## D23 Mapping
+
+```text
+Zigbee coordinator -> Bridge
+Zigbee node        -> Device
+endpoint           -> entity grouping hint
+cluster            -> capability family
+attribute report   -> DeviceEvent
+cluster command    -> DeviceCommand
+network key        -> Vault record
+link key           -> Vault record
+```
+
+---
+
+## Test Strategy
+
+- network frame fixtures parse and encode exactly
+- join/leave flows run in a simulator without hardware
+- address allocation and route-table updates are deterministic
+- security counters reject replay
+- cluster reports map into stable D23 capabilities
+- sleepy-device queues preserve ordering and expiry semantics
+
+---
+
+## References
+
+- Connectivity Standards Alliance Zigbee:
+  <https://csa-iot.org/all-solutions/zigbee/>
+- Zigbee FAQ:
+  <https://csa-iot.org/all-solutions/zigbee/zigbee-faq/>
+- Zigbee 4.0 announcement:
+  <https://csa-iot.org/newsroom/the-connectivity-standards-alliance-announces-zigbee-4-0/>

--- a/code/specs/D26-zwave-stack.md
+++ b/code/specs/D26-zwave-stack.md
@@ -1,0 +1,151 @@
+# D26 - Z-Wave Stack
+
+## Overview
+
+Z-Wave is a sub-GHz smart-home protocol with its own radio, MAC/network behavior,
+controller model, node inclusion, security classes, and application command
+classes. Unlike Zigbee and Thread, it is not built on IEEE 802.15.4.
+
+D26 defines a from-scratch Z-Wave implementation track. The goal is to understand
+classic Z-Wave, Z-Wave Plus, S2 security, SmartStart-style provisioning, and
+Z-Wave Long Range as protocol machinery rather than only through existing
+controller libraries.
+
+All D26 implementation packages are written in Rust.
+
+---
+
+## Where It Fits
+
+```text
+Smart Home Runtime (D23)
+    |
+    v
+Z-Wave Integration
+    |
+    v
+Z-Wave Stack (D26)
+  - serial/controller API boundary
+  - frame parser/encoder
+  - node table
+  - inclusion/exclusion
+  - command classes
+  - S0/S2 security model
+  - Long Range mode
+```
+
+**Depends on:** crypto primitives, state-machine packages, serial/USB adapter
+packages, D23 smart-home entity/capability model.
+
+**Used by:** Z-Wave controller packages, simulators, packet analyzers, smart-home
+integrations, learning tools.
+
+---
+
+## Design Principles
+
+1. **Model the protocol, not just the controller library.**
+2. **Command classes map upward.** Z-Wave command classes become D23
+   capabilities and entities.
+3. **Regional radio constraints are data, not conditionals scattered through the
+   stack.**
+4. **Security inclusion is a lifecycle.** Keys and granted command classes are
+   part of node identity.
+5. **Long Range is not just bigger mesh.** It has different topology and scaling
+   assumptions, so model it explicitly.
+
+---
+
+## Package Roadmap
+
+### `zwave-core`
+
+- frame types
+- home id and node id model
+- controller/node identifiers
+- regional profile metadata
+- parse errors
+
+### `zwave-serial-api`
+
+- serial framing
+- host/controller request-response correlation
+- callbacks
+- controller capabilities
+
+### `zwave-command-classes`
+
+- command-class registry
+- value reports
+- set/get commands
+- interview descriptors
+- mapping into D23 capabilities
+
+### `zwave-security`
+
+- S0 model for historical understanding
+- S2 key classes
+- nonce lifecycle
+- inclusion state machine
+- replay and counter checks
+
+### `zwave-controller`
+
+- inclusion/exclusion
+- node interview
+- route and health state
+- sleepy node queues
+- projection into D23 Bridge/Device/Entity records
+
+### `zwave-lr`
+
+- Long Range topology model
+- 12-bit addressing
+- direct gateway-to-node assumptions
+- LR-specific inclusion and health tracking
+
+### `zwave-sim`
+
+- virtual controller
+- virtual nodes
+- sleepy devices
+- secure inclusion fixtures
+- command class behavior tests
+
+---
+
+## D23 Mapping
+
+```text
+Z-Wave controller -> Bridge
+node id           -> Device identifier scoped to controller
+command class     -> capability family
+value report      -> DeviceEvent
+set command       -> DeviceCommand
+S2 key            -> Vault record
+```
+
+---
+
+## Test Strategy
+
+- serial frames round-trip through parser and encoder
+- controller request/callback correlation is deterministic
+- inclusion/exclusion state machines survive interruption
+- S2 replay protection rejects stale messages
+- sleepy-node command queues expire correctly
+- command classes map into stable D23 capabilities
+- Long Range nodes do not accidentally use classic mesh assumptions
+
+---
+
+## References
+
+- Z-Wave developer specification resources:
+  <https://z-wavealliance.org/development-resources-overview/specification-for-developers/>
+- Z-Wave specification overview:
+  <https://z-wavealliance.org/certification-overview/specification/>
+- Z-Wave Long Range:
+  <https://z-wavealliance.org/z-wave-long-range-technology/>
+- Z-Wave 2025B announcement:
+  <https://z-wavealliance.org/introducing-the-z-wave-2025b-specification-support-for-self-powered-devices-smarter-automation-and-streamlined-certification/>

--- a/code/specs/D27-thread-stack.md
+++ b/code/specs/D27-thread-stack.md
@@ -1,0 +1,167 @@
+# D27 - Thread Stack
+
+## Overview
+
+Thread is a secure, low-power IPv6 mesh networking stack built above IEEE
+802.15.4. It is not itself a smart-home application model. In modern smart homes,
+Matter usually supplies that application layer over Thread.
+
+D27 defines a from-scratch Thread implementation track. The repository should be
+able to understand and simulate Thread networking, border routing, commissioning,
+mesh link establishment, service discovery interactions, and diagnostics rather
+than treating Thread as a black box hidden behind platform APIs.
+
+All D27 implementation packages are written in Rust.
+
+---
+
+## Where It Fits
+
+```text
+Smart Home Runtime (D23)
+    |
+    v
+Matter Integration
+    |
+    v
+Thread Diagnostics / Network Path (D27)
+    |
+    +--> IPv6 / UDP / CoAP / mDNS pieces
+    +--> 6LoWPAN adaptation
+    +--> Thread MLE
+    +--> border router model
+    |
+    v
+IEEE 802.15.4 (D24)
+```
+
+**Depends on:** D24 IEEE 802.15.4, IPv6/UDP/network packages, crypto
+primitives, state-machine packages, D23 smart-home model.
+
+**Used by:** Thread simulators, Matter-over-Thread diagnostics, border router
+experiments, packet analyzers, smart-home reliability tooling.
+
+---
+
+## Design Principles
+
+1. **Thread is networking.** Do not confuse it with Matter clusters or device
+   automation.
+2. **Use IP-native abstractions where appropriate.** Thread nodes should project
+   into IPv6 routes and services, not vendor bridge commands.
+3. **Diagnostics are product value.** Border-router health, partitions, multicast
+   reachability, and service discovery explain many Matter failures.
+4. **Commissioning is security-sensitive.** Mesh credentials and fabric-facing
+   credentials belong in Vault-backed records.
+5. **Simulate partitions early.** Thread reliability is easiest to understand in
+   a deterministic mesh simulator.
+
+---
+
+## Layers
+
+```text
+matter-*          application layer above Thread, future spec/package family
+thread-diagnostics D23-facing health, topology, and reachability projection
+thread-border-router border routing and prefix behavior
+thread-mle        mesh link establishment state machines
+sixlowpan         IPv6 adaptation over 802.15.4
+ieee802154-*      MAC/PHY foundation from D24
+```
+
+---
+
+## Package Roadmap
+
+### `sixlowpan`
+
+- IPv6 header compression model
+- fragmentation/reassembly
+- mesh addressing helpers
+- UDP compression
+
+### `thread-mle`
+
+- roles and neighbor state
+- parent/child relationships
+- leader/router/end-device behavior
+- attach/detach flows
+- network data model
+
+### `thread-commissioning`
+
+- commissioning state model
+- joiner lifecycle
+- credential custody
+- audit events
+
+### `thread-border-router`
+
+- prefix advertisement model
+- external route model
+- border-router health
+- multicast and service-discovery diagnostics
+
+### `thread-diagnostics`
+
+- topology snapshots
+- partition detection
+- route reachability
+- D23 health projection
+
+### `thread-sim`
+
+- virtual mesh nodes
+- border-router scenarios
+- network partition/merge tests
+- sleepy end-device behavior
+
+---
+
+## D23 Mapping
+
+Thread usually maps into D23 through Matter:
+
+```text
+Thread border router -> Bridge / network path
+Thread partition     -> diagnostic health domain
+Matter fabric        -> controller credential set
+Matter node          -> Device
+Matter endpoint      -> entity grouping hint
+Matter cluster       -> capability family
+```
+
+Thread-specific state should still be visible in diagnostics:
+
+```text
+border router health -> smart_home.health event
+route failure        -> smart_home.health event
+partition change     -> smart_home.health event
+commissioning event  -> audit event
+```
+
+---
+
+## Test Strategy
+
+- 6LoWPAN compression fixtures round-trip
+- MLE attach/detach flows run without hardware
+- partitions and merges are deterministic in simulation
+- border-router route advertisements produce expected reachability state
+- commissioning stores credentials only through Vault references
+- D23 receives health events without needing Thread internals
+
+---
+
+## References
+
+- Thread Group overview:
+  <https://threadgroup.org/What-is-Thread>
+- Thread in homes:
+  <https://www.threadgroup.org/BUILT-FOR-IOT/Home>
+- Thread 1.4.0 specification page:
+  <https://threadgroup.org/ThreadSpec>
+- Thread Network Fundamentals:
+  <https://www.threadgroup.org/Portals/0/documents/support/Thread%20Network%20Fundamentals_v3.pdf>
+- Matter connectivity transports:
+  <https://handbook.buildwithmatter.com/how-it-works/connectivity-transports/>


### PR DESCRIPTION
## Summary

Adds Rust-only, from-scratch protocol-stack specs beneath the smart home runtime and seeds the first implementation package.

## What changed

- updates D23 so Zigbee, Z-Wave, and Thread are not treated as opaque integrations
- makes smart-home integration/protocol implementation Rust-only
- adds D24 IEEE 802.15.4 as the shared MAC/PHY foundation for Zigbee and Thread
- adds D25 Zigbee Stack spec
- adds D26 Z-Wave Stack spec
- adds D27 Thread Stack spec
- adds `ieee802154-core`, a dependency-free Rust package for IEEE 802.15.4 MAC frame control, addressing, payload, and optional FCS parsing/encoding

## Verification

- `cargo fmt -p ieee802154-core`
- `cargo test -p ieee802154-core -- --nocapture`
  - 9 passed
