### PR TITLE
Add IEEE 802.15.4 security primitives

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -426,6 +426,7 @@ members = [
     "bitset-c",
     "http-core",
     "ieee802154-core",
+    "ieee802154-security",
     "http1",
     "storage-core",
     "vault-sealed-store",

--- a/code/packages/rust/ieee802154-security/BUILD
+++ b/code/packages/rust/ieee802154-security/BUILD
@@ -1,0 +1,1 @@
+cargo test -p ieee802154-security -- --nocapture

--- a/code/packages/rust/ieee802154-security/BUILD_windows
+++ b/code/packages/rust/ieee802154-security/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p ieee802154-security -- --nocapture

--- a/code/packages/rust/ieee802154-security/CHANGELOG.md
+++ b/code/packages/rust/ieee802154-security/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Initial IEEE 802.15.4 nonce construction primitives.
+- Added replay window state for monotonic incoming frame counters.
+- Added key identifier normalization and in-memory key lookup scaffolding.

--- a/code/packages/rust/ieee802154-security/Cargo.toml
+++ b/code/packages/rust/ieee802154-security/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ieee802154-security"
+version = "0.1.0"
+edition = "2021"
+description = "From-scratch IEEE 802.15.4 security primitives: nonce construction, replay windows, and key lookup scaffolding."
+license = "MIT"
+
+[dependencies]
+ieee802154-core = { path = "../ieee802154-core" }

--- a/code/packages/rust/ieee802154-security/README.md
+++ b/code/packages/rust/ieee802154-security/README.md
@@ -1,0 +1,40 @@
+# ieee802154-security
+
+From-scratch IEEE 802.15.4 security primitives.
+
+This package sits immediately above `ieee802154-core`. The core package parses
+frame structure. This package starts turning that structure into the inputs a
+security engine needs: CCM* nonces, replay checks, and key lookup.
+
+## Current Scope
+
+- CCM* nonce construction for the IEEE 802.15.4-2006 style nonce:
+  `source extended address || frame counter || security level`
+- security source address extraction
+- replay-window acceptance for monotonic incoming frame counters
+- key identifier normalization
+- small in-memory key store for tests and simulators
+
+## Not Yet Implemented
+
+- AES-CCM* encryption/decryption
+- MIC verification
+- associated-data construction
+- outgoing frame counter allocation
+- persistent replay databases
+- integration with Vault-backed real key custody
+
+## Layer Position
+
+```text
+zigbee-security / thread-security
+    |
+    v
+ieee802154-security
+    |
+    v
+ieee802154-core
+```
+
+This package is still pure computation. It does not know about radios, files,
+Vault, or OS services.

--- a/code/packages/rust/ieee802154-security/required_capabilities.json
+++ b/code/packages/rust/ieee802154-security/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/ieee802154-security",
+  "capabilities": [],
+  "justification": "Pure security metadata computation. No filesystem, network, process, radio, serial, or environment access needed."
+}

--- a/code/packages/rust/ieee802154-security/src/lib.rs
+++ b/code/packages/rust/ieee802154-security/src/lib.rs
@@ -1,0 +1,304 @@
+// lib.rs -- IEEE 802.15.4 security primitives
+// ================================================================
+//
+// This package turns parsed 802.15.4 security metadata into the small pieces
+// higher security layers need: nonce construction, replay windows, and key
+// lookup. It deliberately does not implement AES-CCM* yet.
+
+#![deny(unsafe_code)]
+
+use ieee802154_core::{
+    Address, AuxiliarySecurityHeader, FrameCounter, KeyIdentifier, SecurityLevel,
+};
+use std::collections::BTreeMap;
+use std::fmt;
+
+pub const AES_128_KEY_LEN: usize = 16;
+pub const CCM_STAR_NONCE_LEN: usize = 13;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecurityContext {
+    pub source_address: u64,
+    pub frame_counter: u32,
+    pub security_level: SecurityLevel,
+    pub key_identifier: NormalizedKeyIdentifier,
+}
+
+impl SecurityContext {
+    pub fn nonce(&self) -> CcmStarNonce {
+        build_ccm_star_nonce(self.source_address, self.frame_counter, self.security_level)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CcmStarNonce([u8; CCM_STAR_NONCE_LEN]);
+
+impl CcmStarNonce {
+    pub fn as_bytes(&self) -> &[u8; CCM_STAR_NONCE_LEN] {
+        &self.0
+    }
+}
+
+pub fn build_ccm_star_nonce(
+    source_address: u64,
+    frame_counter: u32,
+    security_level: SecurityLevel,
+) -> CcmStarNonce {
+    let mut nonce = [0u8; CCM_STAR_NONCE_LEN];
+    nonce[..8].copy_from_slice(&source_address.to_le_bytes());
+    nonce[8..12].copy_from_slice(&frame_counter.to_le_bytes());
+    nonce[12] = security_level_bits(security_level);
+    CcmStarNonce(nonce)
+}
+
+pub fn security_context_from_parts(
+    source: Address,
+    header: &AuxiliarySecurityHeader,
+) -> Result<SecurityContext, SecurityError> {
+    let source_address = match source {
+        Address::Extended(value) => value,
+        Address::Short(_) => return Err(SecurityError::ExtendedSourceAddressRequired),
+    };
+
+    let frame_counter = match header.frame_counter {
+        Some(FrameCounter::Counter32(value)) => value,
+        Some(FrameCounter::Counter40(_)) => return Err(SecurityError::UnsupportedFrameCounterSize),
+        None => return Err(SecurityError::FrameCounterRequired),
+    };
+
+    Ok(SecurityContext {
+        source_address,
+        frame_counter,
+        security_level: header.security_control.security_level,
+        key_identifier: NormalizedKeyIdentifier::from_key_identifier(header.key_identifier),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NormalizedKeyIdentifier {
+    Implicit,
+    KeyIndex(u8),
+    KeySource4 { source: [u8; 4], index: u8 },
+    KeySource8 { source: [u8; 8], index: u8 },
+}
+
+impl NormalizedKeyIdentifier {
+    pub fn from_key_identifier(identifier: KeyIdentifier) -> Self {
+        match identifier {
+            KeyIdentifier::Implicit => Self::Implicit,
+            KeyIdentifier::KeyIndex(index) => Self::KeyIndex(index),
+            KeyIdentifier::KeySource4 { source, index } => Self::KeySource4 { source, index },
+            KeyIdentifier::KeySource8 { source, index } => Self::KeySource8 { source, index },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Aes128Key([u8; AES_128_KEY_LEN]);
+
+impl Aes128Key {
+    pub fn new(bytes: [u8; AES_128_KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn expose_for_crypto(&self) -> &[u8; AES_128_KEY_LEN] {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryKeyStore {
+    keys: BTreeMap<NormalizedKeyIdentifier, Aes128Key>,
+}
+
+impl InMemoryKeyStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, identifier: NormalizedKeyIdentifier, key: Aes128Key) {
+        self.keys.insert(identifier, key);
+    }
+
+    pub fn lookup(&self, identifier: &NormalizedKeyIdentifier) -> Result<Aes128Key, SecurityError> {
+        self.keys
+            .get(identifier)
+            .copied()
+            .ok_or(SecurityError::UnknownKeyIdentifier)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayDecision {
+    Accept,
+    RejectReplay,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayWindow {
+    highest_seen: Option<u64>,
+}
+
+impl ReplayWindow {
+    pub fn new() -> Self {
+        Self { highest_seen: None }
+    }
+
+    pub fn highest_seen(&self) -> Option<u64> {
+        self.highest_seen
+    }
+
+    pub fn check_and_update(&mut self, frame_counter: u64) -> ReplayDecision {
+        match self.highest_seen {
+            None => {
+                self.highest_seen = Some(frame_counter);
+                ReplayDecision::Accept
+            }
+            Some(highest) if frame_counter > highest => {
+                self.highest_seen = Some(frame_counter);
+                ReplayDecision::Accept
+            }
+            Some(_) => ReplayDecision::RejectReplay,
+        }
+    }
+}
+
+impl Default for ReplayWindow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SecurityError {
+    ExtendedSourceAddressRequired,
+    FrameCounterRequired,
+    UnsupportedFrameCounterSize,
+    UnknownKeyIdentifier,
+}
+
+impl fmt::Display for SecurityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExtendedSourceAddressRequired => {
+                write!(
+                    f,
+                    "IEEE 802.15.4 security requires an extended source address"
+                )
+            }
+            Self::FrameCounterRequired => {
+                write!(f, "frame counter is required for nonce construction")
+            }
+            Self::UnsupportedFrameCounterSize => {
+                write!(f, "40-bit frame counters are not supported yet")
+            }
+            Self::UnknownKeyIdentifier => write!(f, "unknown key identifier"),
+        }
+    }
+}
+
+impl std::error::Error for SecurityError {}
+
+fn security_level_bits(security_level: SecurityLevel) -> u8 {
+    match security_level {
+        SecurityLevel::None => 0,
+        SecurityLevel::Mic32 => 1,
+        SecurityLevel::Mic64 => 2,
+        SecurityLevel::Mic128 => 3,
+        SecurityLevel::Enc => 4,
+        SecurityLevel::EncMic32 => 5,
+        SecurityLevel::EncMic64 => 6,
+        SecurityLevel::EncMic128 => 7,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ieee802154_core::{KeyIdentifierMode, SecurityControl};
+
+    fn secured_header() -> AuxiliarySecurityHeader {
+        AuxiliarySecurityHeader {
+            security_control: SecurityControl {
+                security_level: SecurityLevel::EncMic32,
+                key_identifier_mode: KeyIdentifierMode::KeyIndex,
+                frame_counter_suppression: false,
+                frame_counter_size_5: false,
+            },
+            frame_counter: Some(FrameCounter::Counter32(0x0102_0304)),
+            key_identifier: KeyIdentifier::KeyIndex(2),
+        }
+    }
+
+    #[test]
+    fn builds_ccm_star_nonce() {
+        let nonce =
+            build_ccm_star_nonce(0x8877_6655_4433_2211, 0xaabb_ccdd, SecurityLevel::EncMic64);
+
+        assert_eq!(
+            nonce.as_bytes(),
+            &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xdd, 0xcc, 0xbb, 0xaa, 0x06,]
+        );
+    }
+
+    #[test]
+    fn builds_context_from_extended_source_and_aux_header() {
+        let context = security_context_from_parts(
+            Address::Extended(0x8877_6655_4433_2211),
+            &secured_header(),
+        )
+        .unwrap();
+
+        assert_eq!(context.source_address, 0x8877_6655_4433_2211);
+        assert_eq!(context.frame_counter, 0x0102_0304);
+        assert_eq!(context.security_level, SecurityLevel::EncMic32);
+        assert_eq!(context.key_identifier, NormalizedKeyIdentifier::KeyIndex(2));
+    }
+
+    #[test]
+    fn rejects_short_source_for_nonce_context() {
+        assert_eq!(
+            security_context_from_parts(Address::Short(0x1234), &secured_header()),
+            Err(SecurityError::ExtendedSourceAddressRequired)
+        );
+    }
+
+    #[test]
+    fn rejects_40_bit_frame_counter_until_supported() {
+        let mut header = secured_header();
+        header.frame_counter = Some(FrameCounter::Counter40(0x0001_0203_0405));
+
+        assert_eq!(
+            security_context_from_parts(Address::Extended(1), &header),
+            Err(SecurityError::UnsupportedFrameCounterSize)
+        );
+    }
+
+    #[test]
+    fn replay_window_accepts_only_monotonic_counters() {
+        let mut window = ReplayWindow::new();
+
+        assert_eq!(window.check_and_update(10), ReplayDecision::Accept);
+        assert_eq!(window.check_and_update(10), ReplayDecision::RejectReplay);
+        assert_eq!(window.check_and_update(9), ReplayDecision::RejectReplay);
+        assert_eq!(window.check_and_update(11), ReplayDecision::Accept);
+        assert_eq!(window.highest_seen(), Some(11));
+    }
+
+    #[test]
+    fn in_memory_key_store_round_trips_keys() {
+        let identifier = NormalizedKeyIdentifier::KeySource4 {
+            source: [1, 2, 3, 4],
+            index: 7,
+        };
+        let key = Aes128Key::new([0x42; AES_128_KEY_LEN]);
+        let mut store = InMemoryKeyStore::new();
+        store.insert(identifier.clone(), key);
+
+        assert_eq!(store.lookup(&identifier).unwrap(), key);
+        assert_eq!(
+            store.lookup(&NormalizedKeyIdentifier::Implicit),
+            Err(SecurityError::UnknownKeyIdentifier)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `ieee802154-security` Rust package above `ieee802154-core` for the first reusable security-layer primitives.

## What changed

- adds CCM* nonce construction for the classic IEEE 802.15.4 nonce shape: source extended address, 32-bit frame counter, security level
- adds `SecurityContext` extraction from parsed core address/security metadata
- adds normalized key identifiers and a small in-memory AES-128 key store for tests/simulators
- adds a monotonic replay window for incoming frame counters
- documents the boundary: no AES-CCM*, MIC verification, associated-data construction, persistent replay DB, or Vault-backed key custody yet

## Verification

- `cargo fmt -p ieee802154-security`
- `cargo test -p ieee802154-security -- --nocapture`
  - 6 passed
- `cargo test -p ieee802154-core -p ieee802154-security -- --nocapture`
  - 18 passed total
- `git diff --check`
