### PR TITLE
spec: substrate for Rust statistics stack (Spec PR A)

### DIFF
--- a/code/specs/na-semantics.md
+++ b/code/specs/na-semantics.md
@@ -1,0 +1,357 @@
+# NA Semantics
+
+## Overview
+
+R has a built-in concept that no other mainstream programming language
+gets quite right: a value that is **not present** but is still typed.
+Not null. Not zero. Not NaN. A real arithmetic third state that says
+"there is supposed to be a number here, we just don't have it." This
+spec defines how that third state is represented in the Rust substrate,
+how it propagates through operations, and how it interacts with the
+Float-rung NaN that the Numeric Tower already provides.
+
+The contract lives across two surfaces:
+
+- The **per-type bit pattern** that marks a slot as NA. Owned by
+  `r-vector`; this spec defines what those patterns are and the
+  invariants they must satisfy.
+- The **propagation rules** for arithmetic, comparison, and logical
+  operations. Owned by every Layer 1 domain core; this spec defines
+  the rules they all follow.
+
+One contract, applied identically by every domain core, so that
+`mean(c(1, NA, 3))` and `=AVERAGE(A1:A3)` (where A2 is NA — distinct
+from "empty," see §NA vs Empty Cell) and the future R `lm` all give
+the same answer.
+
+---
+
+## Where It Fits
+
+```
+   Domain cores (statistics-core, financial-core, math-core, …)
+                          │
+                          │  call r-vector ops; observe NA propagation
+                          ▼
+   ┌──────────────────────────────────────────────┐
+   │   r-vector  (atomic types, indexing)         │
+   │   Each element slot is value-or-NA.          │
+   │   Per-type NA bit pattern owned here.        │
+   └──────────────────────────┬───────────────────┘
+                              │
+                              ▼
+                       numeric-tower
+                       (NaN ≠ NA — distinct concepts)
+```
+
+**Used by:** every numerical or statistical crate. The rules below are
+*the* rules; no domain core is allowed to invent its own.
+
+**Not used by:** `spreadsheet-core` for empty cells. An empty cell is
+a different sentinel with different propagation rules — see §NA vs
+Empty Cell.
+
+---
+
+## The Three-Valued Logic
+
+R's logical type takes three values: `TRUE`, `FALSE`, `NA`. Boolean
+operations are extended to handle `NA` using the **strong Kleene** truth
+tables, which agree with classical logic whenever an answer is
+determined and yield `NA` when the answer would depend on the unknown.
+
+### `&` (AND)
+
+|         | TRUE  | FALSE | NA    |
+|---------|-------|-------|-------|
+| **TRUE**  | TRUE  | FALSE | NA    |
+| **FALSE** | FALSE | FALSE | FALSE |
+| **NA**    | NA    | FALSE | NA    |
+
+Rule: `FALSE & x` is always `FALSE` (even if `x = NA`), because the
+answer is determined regardless of what `x` is. Symmetric.
+
+### `|` (OR)
+
+|         | TRUE  | FALSE | NA    |
+|---------|-------|-------|-------|
+| **TRUE**  | TRUE  | TRUE  | TRUE  |
+| **FALSE** | TRUE  | FALSE | NA    |
+| **NA**    | TRUE  | NA    | NA    |
+
+Rule: `TRUE | x` is always `TRUE`, mirror of above.
+
+### `!` (NOT)
+
+| x     | !x    |
+|-------|-------|
+| TRUE  | FALSE |
+| FALSE | TRUE  |
+| NA    | NA    |
+
+### Equality and ordering
+
+`NA == anything` (including `NA == NA`) is `NA`. The reasoning: equality
+asks whether two values are the same; if either is unknown, the answer
+is unknown. To test for NA, use `is_na(x)` — never `x == NA`.
+
+`NA < anything`, `NA > anything`, `NA <= anything`, `NA >= anything`
+are all `NA`. Same reasoning.
+
+`NA != NA` is `NA` (not `FALSE`). This is the classic R footgun and
+must be preserved.
+
+---
+
+## Per-Type Bit Patterns
+
+Each atomic-vector element type has a designated NA bit pattern.
+`r-vector` is responsible for never producing this pattern as a
+*computed* value and for preserving the pattern across operations
+that the propagation rules say should produce NA.
+
+### Logical
+
+`Logical` is a 3-state type stored as `i8`:
+
+| Value | i8  |
+|-------|-----|
+| FALSE | 0   |
+| TRUE  | 1   |
+| NA    | -128 (`i8::MIN`) |
+
+Any `i8` other than 0, 1, or -128 is invalid and indicates corruption.
+
+### Integer
+
+R's `integer` is fixed 32-bit signed. The NA pattern is `i32::MIN`
+(`-2_147_483_648`). This means the integer type cannot represent
+`-2_147_483_648` as a real value — that bit pattern is reserved.
+Producing it as the result of arithmetic is an overflow error
+distinct from NA, and `r-vector` rejects it. Note the distinction
+from `numeric-tower::Number::Integer` which is arbitrary-precision
+and has no NA — NA exists at the *vector* layer, not the scalar
+arithmetic layer.
+
+### Double
+
+`Double` is f64. The NA pattern is a specific NaN payload:
+
+```
+NA_REAL = 0x7FF0_0000_0000_07A2  (R's choice; we reproduce it for
+                                  cross-implementation parity)
+```
+
+Where 0x7A2 = 1954 is the year R was conceived (per the R FAQ;
+preserved here for compatibility with R `RData` interchange).
+
+This bit pattern *is* a NaN by IEEE 754, but it has a unique payload
+that the `is_na` predicate distinguishes. Every other NaN bit pattern
+is a "real" NaN that means *the computation produced something
+undefined* — see §NA vs NaN.
+
+### Complex
+
+`Complex` is two f64s. NA is signaled by the real part holding
+`NA_REAL` (the imaginary part is also set to `NA_REAL` for
+consistency, but `is_na` only inspects the real part).
+
+### Character
+
+`Character` is `Option<String>` semantically; the `None` variant is
+NA. There is no in-band string sentinel because `""` is a real
+distinct value (the empty string).
+
+### Raw
+
+`Raw` is `u8` and **has no NA representation**. R's `raw` type does
+not support NA. `r-vector` operations on `Raw` do not propagate NA;
+attempting to store NA in a `Raw` slot is a type error caught at
+construction.
+
+---
+
+## NA vs NaN
+
+These are distinct in R, distinct in this spec, and both must
+round-trip through the wire.
+
+| Concept | Meaning | Belongs to | Created by | `is_na` | `is_nan` |
+|---------|---------|------------|------------|---------|----------|
+| NaN     | The computation produced something undefined (`0/0`, `log(-1)`) | Float rung of the Numeric Tower | Arithmetic | TRUE  | TRUE  |
+| NA      | The value was never recorded; we don't know what it is | r-vector slot, every atomic type | Constructor / explicit assign | TRUE  | FALSE |
+
+Note that `is_na(NaN)` is `TRUE`. This is R's behavior and is
+deliberate: any "missing or undefined" check should accept both. To
+distinguish, use `is_nan` on a Double element.
+
+The distinction matters because:
+
+- `mean(c(1, NaN, 3))` returns `NaN` (a real arithmetic outcome)
+- `mean(c(1, NA, 3))` returns `NA` (the answer is unknown)
+- `mean(c(1, NaN, 3), na.rm = TRUE)` still returns `NaN` (NaN is not removable; it is real)
+- `mean(c(1, NA, 3), na.rm = TRUE)` returns `2` (NA is removable)
+
+`r-vector` and every domain core preserves this distinction.
+
+---
+
+## NA vs Empty Cell
+
+`spreadsheet-core` introduces a fourth state — the **empty cell**.
+This is *not* NA. It is its own sentinel with its own propagation
+rules:
+
+| Concept | Source | In arithmetic | In text concat | In count | In comparison |
+|---------|--------|---------------|----------------|----------|---------------|
+| NA      | `r-vector` slot (R origin) | propagates to NA | propagates to NA | counted by `count_non_na` as 0 | yields NA |
+| Empty cell | spreadsheet `=A1` where A1 is blank | coerces to 0 | coerces to "" | not counted by `COUNT` | coerces to 0 or "" |
+
+Excel chose this behavior for practical reasons: it lets `=SUM(A1:A100)`
+work over a partially-filled column without manually filtering. R chose
+NA because statistical analysis demands the distinction between "we
+didn't measure" and "we measured zero."
+
+The two sentinels are *both* representable in `spreadsheet-core`'s cell
+type, and a spreadsheet can hold an explicit `=NA()` (which behaves like
+R's NA) or a blank cell (which behaves like Excel's empty). When
+spreadsheet data is exported to an `r-vector`, blanks become NA — but
+that is a frontend concern, not a substrate concern, and is handled at
+the import boundary.
+
+---
+
+## Propagation Rules for Arithmetic
+
+The default rule applied by every Layer 1 domain core:
+
+> **If any input is NA, the output is NA, unless the function is
+> documented as taking `na.rm = TRUE` and the caller passed it.**
+
+Examples (where `vec` is shorthand for `Vector<Double>`):
+
+| Call | Result |
+|------|--------|
+| `add(NA, 5)` | NA |
+| `mean(vec[1, NA, 3])` | NA |
+| `mean(vec[1, NA, 3], na.rm = TRUE)` | 2 |
+| `mean(vec[NA, NA, NA])` | NA |
+| `mean(vec[NA, NA, NA], na.rm = TRUE)` | NaN (Float rung; mean of empty set) |
+| `sum(vec[NA, NA, NA], na.rm = TRUE)` | 0 (sum of empty set is 0 by convention) |
+| `prod(vec[NA, NA, NA], na.rm = TRUE)` | 1 (product of empty set is 1 by convention) |
+| `length(vec[1, NA, 3])` | 3 (length is structural — counts NAs) |
+| `count_non_na(vec[1, NA, 3])` | 2 |
+
+The "empty after na.rm" cases (`mean`, `var`, `sd` returning NaN; `sum`/`prod`
+returning identity) follow R exactly.
+
+---
+
+## The `na.rm` Convention
+
+Every reduction function in `statistics-core` (any function that
+collapses a vector to a scalar) accepts a final parameter
+`na_rm: bool` (Rust signature; Excel/R bind it differently at the
+frontend):
+
+```rust
+pub fn mean(x: &Vector<Double>, na_rm: bool) -> Number { … }
+```
+
+- Default value at the Rust API: `false`. Callers must opt in.
+- Excel binding: `=AVERAGE(...)` always sets `na_rm = true` and
+  treats `=NA()` cells as removable (matching Excel's "ignore NA"
+  policy as of Excel 2010+). `=AVERAGEA(...)` sets `na_rm = false`
+  and treats NA as part of the data, returning `#N/A`.
+- R binding: defaults to `na.rm = FALSE`; user passes `na.rm = TRUE`
+  to opt in.
+
+Functions that are not reductions (element-wise operations like
+`add`, `log`, `sqrt`) do not take `na_rm`. They always propagate.
+
+---
+
+## NA in Indexing
+
+Indexing a vector with an NA index produces an NA element in the
+output:
+
+```
+x <- c(10, 20, 30)
+x[NA_integer_]   # → NA
+x[c(1, NA, 3)]   # → c(10, NA, 30)
+```
+
+This is structural NA propagation: the *position* of the NA in the
+index becomes an NA in the output, regardless of `x`'s contents at
+that position.
+
+Logical indexing with NA also produces NA at that position:
+
+```
+x[c(TRUE, NA, TRUE)]  # → c(10, NA, 30)
+```
+
+---
+
+## Serialization
+
+| Format | NA representation |
+|--------|-------------------|
+| R `RData` (binary) | The native bit patterns above |
+| CSV out | Configurable string; default `"NA"` |
+| CSV in | Configurable list; default `["", "NA", "N/A"]` |
+| JSON out | `null` |
+| JSON in | `null` → NA |
+| Spreadsheet xlsx | `#N/A` error sentinel for explicit NA; blank cell for empty |
+
+Serialization libraries are out of this spec's scope; they live in
+`r-data-io` (future). The contract here is: an NA round-trips as an
+NA through any of these formats, and an empty-cell sentinel does
+not get conflated with NA except at the spreadsheet-import boundary.
+
+---
+
+## Test Vectors
+
+Every implementation of `r-vector` and every domain core function
+must pass a parity-test suite that exercises:
+
+1. All four element types (Logical, Integer, Double, Character) with
+   NA in every position of a 3-element vector
+2. Strong-Kleene tables for `&`, `|`, `!`, `==`, `!=`, `<`, `<=`,
+   `>`, `>=` over `{TRUE, FALSE, NA}` (9 cells per binary op)
+3. Reduction parity: `sum/mean/var/sd/min/max/prod` with all-NA,
+   one-NA, no-NA inputs, both with and without `na_rm`
+4. Empty-after-`na_rm` cases (NaN for mean/var/sd, 0 for sum, 1 for
+   prod)
+5. NA vs NaN distinction: `is_na` is true for both; `is_nan` is
+   true only for NaN
+6. NA-in-index propagation for all four index modes (positive,
+   negative, logical, by-name)
+
+The full test corpus lives in `r-vector/tests/na_parity.rs` and is
+referenced by every domain core's CI.
+
+---
+
+## Out of Scope
+
+- The bit-level representation invariants of `r-vector` (those live
+  in `r-vector.md`)
+- Per-function NA behavior of every statistics-core function (those
+  live in `statistics-core.md`'s function catalog)
+- The CSV / JSON / xlsx import-export contract (future `r-data-io`
+  spec)
+- POSIXct / Date NA (datetime-core; same rules but the bit pattern is
+  in time domain)
+
+---
+
+## References
+
+- R Language Definition, §3.3.1 NULL and NA
+- R Internals, §1.1 (NA bit patterns)
+- *The Statistical Sleuth*, ch. 1 (the philosophical case for NA as a
+  first-class arithmetic state)
+- Strong Kleene three-valued logic (Kleene 1938)

--- a/code/specs/numeric-tower.md
+++ b/code/specs/numeric-tower.md
@@ -1,0 +1,342 @@
+# Numeric Tower
+
+## Overview
+
+This spec defines the `Number` type that every numerical and statistical
+crate in the Rust half of the repo agrees on. It is the type a spreadsheet
+cell holds, the type an R atomic-double element carries, the type a
+financial calculation accepts, and the type an `lm` coefficient comes back
+as. Without a single answer to "what is a number," every domain crate
+invents its own and the layers above the substrate cannot talk to each
+other.
+
+The tower is small and lives in one Rust crate, `numeric-tower`, at
+`code/packages/rust/numeric-tower/`. It has no upstream Rust dependencies
+beyond the standard library and `num-bigint`/`num-rational` (for the
+exact-integer and exact-rational rungs). It is depended on by every Layer 1
+domain core (statistics-core, financial-core, …) and by every Layer 0
+companion crate (r-vector, data-frame).
+
+This spec does **not** define how a number is *displayed* (that is a
+spreadsheet cell-format concern) and does **not** define error behavior
+for individual functions (that is each domain core's contract). It defines
+representation, coercion, and arithmetic dispatch.
+
+---
+
+## Where It Fits
+
+```
+   statistics-core   financial-core   math-core   …          (Layer 1)
+            ▲              ▲              ▲
+            │              │              │
+            └──────────────┴──────────────┘
+                           │
+                  ┌────────┴────────┐
+                  │  numeric-tower  │   ← THIS SPEC
+                  └────────┬────────┘
+                           │
+                           ▼
+                std + num-bigint + num-rational
+```
+
+**Used by:**
+- `r-vector` (the atomic-numeric vectors hold these as elements)
+- `statistics-core` (every public function takes/returns these)
+- `financial-core` (NPV, IRR; benefits from `Decimal` for monetary precision)
+- `math-core`, `lookup-core`, `text-core` (coercion when crossing types)
+- `spreadsheet-core` (cell value type wraps `Number` plus error sentinels)
+- `cas-*` interop (the symbolic `IRInteger` / `IRRational` / `IRComplex`
+  bridge to and from the tower's `Integer` / `Rational` / `Complex` rungs)
+
+**Not used by:** `text-core`, `datetime-core` for their own values
+(strings and dates are not `Number`s). They use `Number` only when an
+arithmetic context coerces to or from one of them.
+
+---
+
+## The Five Rungs
+
+The tower has exactly five rungs, ordered by *expressiveness* (each rung
+can faithfully represent everything below it that is not lost in
+conversion). Rust:
+
+```rust
+pub enum Number {
+    Integer(Integer),     // arbitrary precision; wraps num_bigint::BigInt
+    Rational(Rational),   // arbitrary precision; wraps num_rational::BigRational
+    Float(f64),           // IEEE 754 binary64
+    Complex(Complex),     // pair of f64 (re, im)
+    Decimal(Decimal),     // base-10 fixed precision; see §Decimal below
+}
+```
+
+The order is **not** the coercion lattice (see next section). It is the
+order in which the rungs were chosen and the order in which the variants
+are listed for stable serialization.
+
+### Why these five and not others
+
+- **Integer** is arbitrary precision because spreadsheet cells, factor
+  codes, and R `integer` vectors all need it without overflow surprises.
+  A separate fixed-width `i64` rung was rejected: the cost of one extra
+  arithmetic dispatch case is tiny, and "integer overflow at row 5,
+  column AB" is the kind of bug this tower exists to prevent.
+- **Rational** because exact division is required for `lm` over rational
+  data, for `cas-*` interop (the symbolic IR uses `Fraction` everywhere),
+  and because monetary calculations during intermediate steps benefit
+  from no-loss division.
+- **Float** because most numerical algorithms (distributions, regression
+  internals, optimizers) want IEEE 754 and because every interchange
+  format the tower will eventually meet (CSV, JSON, R `RData`, Excel
+  XLSX) defaults to it.
+- **Complex** because R has it as an atomic type and the symbolic stack
+  already uses Gaussian integers in `cas-complex`. Any statistical
+  consumer can ignore it.
+- **Decimal** because spreadsheet financial functions and tax/accounting
+  calculations need radix-10 arithmetic where `0.1 + 0.2 == 0.3`. See
+  `§Decimal`.
+
+A `BigDecimal` (arbitrary precision base-10) was considered as a separate
+rung. It is folded into `Decimal` with a precision parameter; see below.
+
+---
+
+## Coercion Lattice
+
+When two rungs meet in a binary operation, the result lives on the
+*join* — the lowest rung that can represent both faithfully without
+loss. The lattice:
+
+```
+              Complex
+              ╱     ╲
+         Float       (no path)
+        ╱     ╲
+   Decimal   Rational
+              │
+           Integer
+```
+
+Read top-down for "more expressive." Joins:
+
+| Left      | Right     | Join     |
+|-----------|-----------|----------|
+| Integer   | Integer   | Integer  |
+| Integer   | Rational  | Rational |
+| Integer   | Decimal   | Decimal  |
+| Integer   | Float     | Float    |
+| Integer   | Complex   | Complex  |
+| Rational  | Decimal   | Decimal  |
+| Rational  | Float     | Float    |
+| Rational  | Complex   | Complex  |
+| Decimal   | Float     | **Float** (lossy; flagged in §Lossy Coercions) |
+| Decimal   | Complex   | Complex  |
+| Float     | Complex   | Complex  |
+
+**There is no path from Decimal to Rational.** A finite Decimal
+(`0.1`) is exactly representable as `Rational(1, 10)`, but a `Rational`
+with non-terminating decimal expansion (`1/3`) is not faithfully
+representable as a finite-precision `Decimal`. We resolve the
+asymmetric case by routing through Float and accepting the loss; users
+who want exact rational answers must stay on the Rational/Integer
+sub-lattice.
+
+The `coerce_to_join(a: &Number, b: &Number) -> (Number, Number)`
+function is the single entry point. Domain crates never inspect rung
+tags directly to decide arithmetic; they call `coerce_to_join` and
+match on the result.
+
+---
+
+## Lossy Coercions
+
+A coercion is **lossy** if the join cannot represent the source value
+exactly. Lossy coercions are permitted but recorded.
+
+| From      | To        | Lossy when                                      |
+|-----------|-----------|-------------------------------------------------|
+| Integer   | Float     | abs(value) ≥ 2^53                               |
+| Rational  | Float     | denominator is not a power of 2 small enough to be exact, OR magnitude exceeds f64 range |
+| Rational  | Decimal   | non-terminating decimal expansion (e.g. 1/3)    |
+| Decimal   | Float     | digits exceed f64 mantissa precision            |
+| Decimal   | Rational  | n/a — always exact                              |
+| Float     | anything  | NaN/Inf cannot leave the Float rung; coercion of NaN to Integer/Rational/Decimal is an error, not a silent zero |
+
+The tower exposes a `try_coerce(n: &Number, target_rung: Rung) -> Result<Number, CoercionError>` function for callers that want the loss reported. The
+internal `coerce_to_join` always succeeds (it picks the join precisely
+to avoid this); the failure case only arises when a frontend asks for
+"coerce this to integer."
+
+---
+
+## Arithmetic Dispatch
+
+Each binary operation is implemented as
+
+```
+fn add(a: &Number, b: &Number) -> Number {
+    let (a, b) = coerce_to_join(a, b);
+    match (a, b) {
+        (Integer(x), Integer(y)) => Integer(x + y),
+        (Rational(x), Rational(y)) => Rational(x + y),
+        (Float(x), Float(y)) => Float(x + y),
+        (Decimal(x), Decimal(y)) => Decimal(x + y),
+        (Complex(x), Complex(y)) => Complex(x + y),
+        _ => unreachable!(), // coerce_to_join returns same-rung pairs
+    }
+}
+```
+
+The `_ => unreachable!()` arm is load-bearing: the type system does
+not enforce that `coerce_to_join` returns same-rung pairs, so the
+crate's invariant is `coerce_to_join(a, b)` ⟹ both outputs share a rung.
+Tested by an exhaustive property-based suite over rung pairs.
+
+The five operations the tower defines: `add`, `sub`, `mul`, `div`, `neg`.
+Higher-order operations (`pow`, `sqrt`, `log`, `exp`, trig) live in
+`math-core` and accept/return `Number`s; the tower stays small.
+
+### Division on Integer
+
+`div` on `Integer / Integer` lifts to `Rational` if the divisor does
+not divide the dividend exactly. R does not do this (it returns Float);
+spreadsheets do not do this (also Float). The tower's choice is
+*Rational* for exactness, and frontends that want R-style floor or
+spreadsheet-style coerce-to-Float wrap the result. This keeps the
+tower itself opinion-free about which lossy step a frontend prefers.
+
+### NaN, Infinity, signed zero
+
+Live entirely on the `Float` rung. `Integer` / `Rational` / `Decimal`
+have no infinity and no NaN. A `Float(NaN)` propagates through any
+operation that touches it; this is **not** the same as NA (see
+`na-semantics.md` — NaN means *the computation produced something
+undefined*, NA means *we never had a value*). The two are distinct on
+the wire, distinct in equality, and distinct in serialization.
+
+`Float(0.0) == Float(-0.0)` is `true` for `Number::eq`, matching R
+and IEEE 754 semantics in equality (but the bit-patterns differ in
+serialization, and `Float::is_sign_negative` distinguishes them).
+
+---
+
+## Decimal
+
+`Decimal` is base-10 fixed-precision. The Rust representation:
+
+```rust
+pub struct Decimal {
+    coefficient: BigInt,   // signed
+    exponent: i32,         // value = coefficient * 10^exponent
+    precision: u32,        // significant digits; 0 means "as many as coefficient has"
+}
+```
+
+This follows IEEE 754-2008 decimal arithmetic and Java `BigDecimal`. A
+spreadsheet cell formatted as currency (`$1,234.56`) holds
+`Decimal { coefficient: 123456, exponent: -2, precision: 6 }`.
+
+Operations on `Decimal` use the *banker's rounding* mode (round
+half-to-even) by default. The mode is overridable per-operation for
+financial-core to use round-half-up where regulation requires it.
+
+**`Decimal` is not a high-performance rung.** Operations are
+`O(precision²)` in the worst case. Statistical algorithms should not
+work in `Decimal`; they should coerce to `Float` at the boundary.
+`Decimal` exists for spreadsheet cell values and financial outputs
+where the answer must be "the same answer the calculator on the
+accountant's desk gave."
+
+---
+
+## Equality and Ordering
+
+Two `Number`s are equal iff they coerce to the same join *and* the
+joined values are equal at that join. `Integer(2) == Float(2.0)` is
+`true`. `Integer(2) == Rational(4, 2)` is `true`. `Float(NaN) == Float(NaN)`
+is `false` (matches IEEE 754).
+
+Ordering exists on the totally-ordered sub-lattice (everything except
+Complex; partial-order on Complex would be a lie). Calling
+`Number::partial_cmp` on a Complex with anything else returns `None`.
+
+`hash(n: Number)` normalizes by coercing to the *highest exact* rung
+(Integer if the value is integral; Rational if rational; Float
+otherwise). This makes `Integer(2)` and `Rational(2, 1)` hash the same.
+Required for use as `HashMap` keys in the symbol table of `r-runtime`
+and the named-cell index of `spreadsheet-core`.
+
+---
+
+## Bridges
+
+### `cas-*` Bridge
+
+`cas-complex` / `cas-factor` / etc. use their own internal IR
+(`IRInteger`, `IRRational`, `IRComplex`) for symbolic computation.
+The bridge lives in `numeric-tower::cas` (feature-gated, so consumers
+that don't pull in `cas-*` aren't forced to compile it):
+
+```
+Number::Integer(n)   ⇄  cas_simplify::IRInteger(n)
+Number::Rational(r)  ⇄  cas_simplify::IRRational(r)
+Number::Complex(c)   ⇄  cas_complex::IRComplex(c)
+Number::Float(f)     →  cas_simplify::IRFloat(f)   [no inverse: cas-* prefers exact]
+Number::Decimal(d)   →  cas_simplify::IRRational(d as ratio)
+```
+
+The bridge is one-way for Float and Decimal because the symbolic stack
+has no Float/Decimal rung; converting back loses the symbolic identity
+of the value.
+
+### `r-vector` Bridge
+
+`r-vector` atomic types `Logical`, `Integer`, `Double`, `Complex`,
+`Character`, `Raw` hold elements at known rungs:
+
+```
+Vector<Logical>     elements are bool (or NA — see na-semantics)
+Vector<Integer>     elements are i32 (R's integer is fixed 32-bit; the tower's
+                    arbitrary-precision Integer is not the R atomic — see
+                    r-vector.md for the rationale)
+Vector<Double>      elements are Number::Float
+Vector<Complex>     elements are Number::Complex
+Vector<Character>   elements are String
+Vector<Raw>         elements are u8
+```
+
+A `Vector<Double>` element is a `Number::Float` *value*, not a
+`Number` *enum*. The vector knows its own rung; the variant tag is
+not stored per element.
+
+---
+
+## NaN vs NA
+
+This spec stays out of NA. See `na-semantics.md` for the contract.
+The relationship in one line: **NaN belongs to the Float rung and
+means an operation produced something undefined; NA is a per-vector
+sentinel layered on top by `r-vector` and means a value was never
+recorded.** The tower is unaware of NA.
+
+---
+
+## Out of Scope
+
+- Display / formatting (cell-format concern; lives in spreadsheet-core)
+- `pow`, `sqrt`, transcendentals (math-core)
+- Date and time arithmetic (datetime-core; dates are not Numbers)
+- Big-decimal arbitrary precision *with non-fixed scale* — folded into
+  `Decimal { precision: u32 }`
+- Posits / unum / fixed-point — out of scope; if added, a new rung
+- Interval arithmetic — out of scope
+
+---
+
+## References
+
+- IEEE 754-2008 (binary and decimal floating-point arithmetic)
+- R Internals, §1.1 Vector types (atomic types and storage modes)
+- The Java `BigDecimal` class (Decimal rung loosely follows)
+- `cas-complex`, `cas-simplify` in this repo (existing exact-arithmetic IR)

--- a/code/specs/r-vector.md
+++ b/code/specs/r-vector.md
@@ -1,0 +1,504 @@
+# R-Vector
+
+## Overview
+
+In R, *every* value is a vector. There is no scalar type. `1` and
+`c(1)` are indistinguishable; both are length-one numeric vectors.
+This decision shapes the rest of the language: arithmetic broadcasts,
+indexing has four flavors, and missing data is a per-element first-class
+concern. The Rust crate `r-vector` provides the foundational type that
+makes this design possible — a typed, NA-aware, named, recyclable
+sequence — used by every Layer 1 statistical or numerical core in the
+repo and by the future `r-runtime` and `s-runtime` frontends.
+
+This spec defines the crate's data structures, indexing modes, recycling
+rule, and the bridge to the `numeric-tower`. Per-element NA bit patterns
+and propagation rules live in `na-semantics.md`; this spec assumes that
+contract and focuses on the container.
+
+The crate lives at `code/packages/rust/r-vector/`. Its only Rust
+dependencies are the standard library, `numeric-tower`, and (transitively
+via numeric-tower) `num-bigint` and `num-rational`.
+
+---
+
+## Where It Fits
+
+```
+   r-runtime (future)        statistics-core         spreadsheet-core
+        │                          │                        │
+        │  AST → vectors           │  function inputs       │  range → vector
+        ▼                          ▼                        ▼
+   ┌────────────────────────────────────────────────────────────┐
+   │                       r-vector                             │
+   │   Vector<T>  +  atomic types  +  NA  +  names  +  indexing │
+   └──────────────────────────┬─────────────────────────────────┘
+                              │
+                              ▼
+                       numeric-tower
+```
+
+**Used by:** statistics-core (every function takes `&Vector<…>`);
+spreadsheet-core (cell ranges materialize as vectors before being passed
+to dispatch); future r-runtime and s-runtime; data-frame (a data frame
+is a list of equal-length `Vector`s).
+
+**Not used by:** text-core for non-vector string operations; datetime-core
+for scalar-only date arithmetic. Both wrap their results in vectors at
+the boundary.
+
+---
+
+## Atomic Types
+
+R has six atomic types. The crate exposes one Rust type per atomic:
+
+| R atomic   | Rust storage         | NA representation       | Notes |
+|------------|----------------------|-------------------------|-------|
+| `logical`  | `Vec<i8>`            | `i8::MIN` (-128)        | Tri-state: 0, 1, NA |
+| `integer`  | `Vec<i32>`           | `i32::MIN`              | Fixed 32-bit; reserved bit pattern is NA |
+| `double`   | `Vec<f64>`           | `NA_REAL` NaN payload   | The IEEE 754 base of R numerics |
+| `complex`  | `Vec<(f64, f64)>`    | `(NA_REAL, NA_REAL)`    | Real + imaginary |
+| `character`| `Vec<Option<String>>` | `None`                 | Empty string `""` is a real value, not NA |
+| `raw`      | `Vec<u8>`            | none (no NA support)    | Bytes; cannot hold NA |
+
+Each gets its own concrete Rust type so monomorphization specializes
+arithmetic and the NA check is inlined:
+
+```rust
+pub struct Logical { data: Vec<i8>,         names: Option<Names>, attrs: Attrs }
+pub struct Integer { data: Vec<i32>,        names: Option<Names>, attrs: Attrs }
+pub struct Double  { data: Vec<f64>,        names: Option<Names>, attrs: Attrs }
+pub struct Complex { data: Vec<(f64, f64)>, names: Option<Names>, attrs: Attrs }
+pub struct Character { data: Vec<Option<String>>, names: Option<Names>, attrs: Attrs }
+pub struct Raw     { data: Vec<u8>,         names: Option<Names>, attrs: Attrs }
+```
+
+A trait `Vector` unifies them for code that does not care about element
+type:
+
+```rust
+pub trait Vector {
+    type Element;
+    fn len(&self) -> usize;
+    fn is_na(&self, i: usize) -> bool;
+    fn names(&self) -> Option<&Names>;
+    fn attr(&self, key: &str) -> Option<&Attr>;
+    fn type_name(&self) -> &'static str;  // "logical" | "integer" | …
+}
+```
+
+The trait is small on purpose. Most operations live on the concrete
+types where the compiler can specialize.
+
+### Why `i32`-fixed for `Integer` when `numeric-tower::Integer` is arbitrary
+
+R's `integer` is a 32-bit signed type. We faithfully reproduce that
+because R `RData` files, R's C API, and R's coercion rules all assume
+it. The arbitrary-precision `numeric-tower::Integer` is a distinct
+concept used at the *scalar arithmetic* layer, not the vector layer.
+
+This is the same separation as in R itself: R's `integer` overflows to
+NA with a warning, but R's internal `bignum` (in package `gmp`) does
+not. The vector type matches the language; the tower's exact integer is
+for everything else.
+
+When a `Vector<Integer>` overflows during arithmetic, the result is NA
+with a flag set on the result vector's attributes (`overflow = TRUE`).
+This matches R.
+
+---
+
+## NA
+
+NA is per-type and per-element. The bit-pattern table is in
+`na-semantics.md`. Three crate-level invariants:
+
+1. Every constructor of every atomic type checks for and rejects an
+   accidentally-produced NA bit pattern in non-NA slots. (Specifically:
+   `i32::MIN` cannot enter an `Integer` vector except as an NA; the
+   `NA_REAL` payload cannot enter a `Double` vector except as an NA.)
+2. Every operation that the propagation rules say should produce NA
+   *does* produce NA at exactly the right slots, never spreading
+   beyond.
+3. `is_na(i)` is `O(1)` and inlines to a single comparison or pattern
+   match.
+
+The crate exposes one universal `is_na` predicate per atomic type plus
+a generic version through the `Vector` trait.
+
+---
+
+## Names Attribute
+
+A vector may have an optional `names` attribute:
+
+```rust
+pub struct Names { values: Vec<String> }   // length must match data
+```
+
+When present, `names.len() == data.len()`. Names are unique-or-not at
+the user's choice; R does not enforce uniqueness, and neither do we
+(but see §Indexing for what happens when `x["a"]` matches multiple).
+
+Names are preserved across operations that preserve shape:
+
+| Operation | Names preserved? |
+|-----------|------------------|
+| Element-wise arithmetic on a single named vector | Yes — names of the LHS |
+| Element-wise arithmetic on two named vectors | Yes — names of the longer (or LHS if same length) |
+| Reduction (sum, mean, …) | No — result is unnamed scalar |
+| Indexing | Yes — derived from indexed-into vector |
+| Concatenation `c(a, b)` | Yes — both sets concatenated, with `""` filling unnamed positions |
+
+---
+
+## Attributes (other)
+
+Every vector carries an attribute bag:
+
+```rust
+pub struct Attrs { entries: Vec<(String, AttrValue)> }
+pub enum AttrValue { Logical(Logical), Integer(Integer), Double(Double),
+                     Complex(Complex), Character(Character), Raw(Raw),
+                     List(List) }
+```
+
+`names` is conceptually an attribute (`x@names`) but is given a typed
+slot for performance because every operation queries it.
+
+Reserved attribute keys recognized across the repo:
+
+| Key       | Meaning                                                 | Owner |
+|-----------|---------------------------------------------------------|-------|
+| `dim`     | Vector is implicitly a matrix/array (e.g. `c(2, 3)` for 2×3) | r-vector |
+| `dimnames`| Per-axis names for a matrix/array                       | r-vector |
+| `class`   | S3 class chain                                          | r-runtime |
+| `levels`  | Factor levels (ordered or unordered)                    | r-runtime (factor type) |
+| `tsp`     | Time-series start, end, frequency                       | statistics-core::ts |
+| `comment` | Free-form annotation                                    | r-runtime |
+| `overflow`| Set to `TRUE` if any Integer arithmetic overflowed     | r-vector |
+
+User-defined attributes (any string key not on this list) are stored
+verbatim and round-trip through serialization.
+
+---
+
+## Indexing
+
+Four index modes, all supported by every atomic type. The Rust API:
+
+```rust
+impl<V: Vector> V {
+    fn index_positive(&self, idx: &Integer) -> V::Output;
+    fn index_negative(&self, idx: &Integer) -> V::Output;
+    fn index_logical(&self, idx: &Logical) -> V::Output;
+    fn index_named(&self, idx: &Character) -> V::Output;
+}
+```
+
+A higher-level `index(i: &Index)` dispatches by index kind. `Index` is
+an enum with the four variants plus a fifth for the empty index `x[]`
+(which returns `x` unchanged).
+
+### Positive indexing
+
+Indices are 1-based (R convention; the language we are emulating).
+`x[c(1, 3)]` returns positions 1 and 3. Position 0 is silently dropped.
+Out-of-range positions yield NA in the output, with the original NA
+distinction preserved.
+
+Internally the crate uses 0-based offsets; the 1-based-to-0-based shift
+happens at the API boundary in a single helper. This avoids the entire
+crate carrying a +1/-1 footgun.
+
+### Negative indexing
+
+`x[c(-1, -3)]` removes positions 1 and 3. Mixing positive and negative
+in the same index vector is an error (R behavior). Index 0 is silently
+dropped.
+
+### Logical indexing
+
+`x[c(TRUE, FALSE, TRUE)]` returns positions where the index is `TRUE`.
+The index is recycled to `length(x)` if shorter (see §Recycling). NA
+in the index produces NA in the output at that position
+(`na-semantics.md`, §NA in Indexing).
+
+### Named indexing
+
+`x["a"]` returns elements whose name is `"a"`. If multiple names match,
+returns the first (R behavior); to get all matches, the user converts
+to logical-index manually. Unmatched names produce NA in the output.
+
+---
+
+## Recycling
+
+When a binary operation receives two vectors of different lengths, the
+shorter is *recycled* — repeated end-to-end — to match the longer. This
+is R's most distinctive (and most dangerous) feature.
+
+```
+c(1, 2, 3, 4, 5, 6) + c(10, 20)
+```
+
+becomes
+
+```
+c(1, 2, 3, 4, 5, 6) + c(10, 20, 10, 20, 10, 20)  =  c(11, 22, 13, 24, 15, 26)
+```
+
+Rule:
+
+1. Let `n = max(len(a), len(b))`.
+2. Each operand is repeated to length `n` (the longer is repeated zero
+   times — i.e. unchanged).
+3. **If `n` is not a multiple of either input's length, emit a warning.**
+   The operation still proceeds with truncated recycling, but the
+   warning ("longer object length is not a multiple of shorter object
+   length") flags a likely bug.
+
+Recycling is implemented in `r-vector::recycle` and is invoked by
+domain cores explicitly:
+
+```rust
+pub fn recycle_to_max<A: Vector, B: Vector>(a: &A, b: &B) -> (A, B);
+```
+
+The function returns owned (or cheaply cloned) recycled copies. For
+zero-copy paths, `RecycledIter` provides an iterator interface that
+indexes modulo length without allocating.
+
+Recycling rule subtleties:
+
+- If either operand has length 0, the result has length 0.
+- If either operand has length 1, that single value is broadcast to
+  the other's length without warning.
+- Recycling does **not** apply to dispatch: `mean(c(1, 2, 3))` returns
+  a length-1 vector whose contents the receiving function decides;
+  there is no recycling at the function-call boundary.
+
+Spreadsheet array formulas use *broadcasting*, not recycling — see
+`vectorization-rules.md`.
+
+---
+
+## Coercion Lattice
+
+When two atomic types meet, the *less expressive* coerces upward.
+R's lattice (we reproduce it):
+
+```
+   character
+       │
+   complex
+       │
+    double
+       │
+   integer
+       │
+   logical
+```
+
+Joins for binary operations:
+
+| Left      | Right     | Join     |
+|-----------|-----------|----------|
+| Logical   | Integer   | Integer  |
+| Logical   | Double    | Double   |
+| Integer   | Double    | Double   |
+| Double    | Complex   | Complex  |
+| Anything  | Character | Character|
+
+`raw` does not participate in arithmetic coercion; mixing `raw` with
+non-`raw` is a type error.
+
+`Vector::coerce(target_type)` produces a copy at the requested type or
+an error if the conversion is invalid. Coercion of NA at any rung
+yields NA at the new rung. Coercion of out-of-range values (e.g.
+`integer(2147483648)`) yields NA with the overflow attribute set.
+
+Character coercion deserves a note: `as.character(c(0.1 + 0.2))`
+returns `"0.3"`, not `"0.30000000000000004"`. R uses the shortest
+decimal that round-trips. We match this via the `ryu` crate
+(or equivalent `f64`-shortest-decimal algorithm). Tested against R's
+`format` output.
+
+---
+
+## Element Access
+
+```rust
+impl Double {
+    pub fn get(&self, i: usize) -> Option<f64>;        // None if NA
+    pub fn get_raw(&self, i: usize) -> f64;            // Returns NA bit-pattern as-is
+    pub fn set(&mut self, i: usize, value: Option<f64>);
+    pub fn iter(&self) -> impl Iterator<Item = Option<f64>>;
+    pub fn iter_raw(&self) -> impl Iterator<Item = f64>;
+}
+```
+
+`get` returns `Option` so the caller cannot accidentally use an NA bit
+pattern as a real value. `get_raw` is the escape hatch for crates that
+want bit-level access (e.g. zero-copy serialization to `RData`).
+
+The same shape exists on every atomic type, with the appropriate
+element type substituted for `f64`.
+
+---
+
+## Construction
+
+```rust
+impl Double {
+    pub fn from_iter<I: IntoIterator<Item = Option<f64>>>(iter: I) -> Self;
+    pub fn of(values: &[f64]) -> Self;       // No NAs
+    pub fn na(n: usize) -> Self;             // All NA, length n
+    pub fn empty() -> Self;
+    pub fn singleton(v: f64) -> Self;
+}
+```
+
+The `from_iter` constructor is the only one that can produce NA slots.
+`of` rejects (panics in debug, returns error in release) any input
+containing an NA bit pattern, because that pattern would be ambiguous.
+
+---
+
+## Bridge to numeric-tower
+
+Each atomic type can lift to a `Number` for scalar contexts:
+
+```rust
+impl Double {
+    pub fn to_scalar(&self) -> Result<Option<Number>, NotScalar> {
+        if self.len() != 1 { return Err(NotScalar); }
+        match self.get(0) {
+            Some(v) => Ok(Some(Number::Float(v))),
+            None    => Ok(None),  // NA
+        }
+    }
+}
+```
+
+Length-1 vectors can be used as scalars; longer vectors cannot. This
+is the boundary at which `mean(c(1, 2, 3))` returns a length-1 vector
+that a frontend then unboxes to a scalar for display.
+
+The reverse direction:
+
+```rust
+impl Double {
+    pub fn from_scalar(n: Number) -> Result<Self, IncompatibleRung> {
+        match n {
+            Number::Float(f)   => Ok(Self::singleton(f)),
+            Number::Integer(i) => Ok(Self::singleton(i.to_f64())),
+            Number::Rational(r)=> Ok(Self::singleton(r.to_f64())),
+            Number::Complex(_) => Err(IncompatibleRung),
+            Number::Decimal(d) => Ok(Self::singleton(d.to_f64())),
+        }
+    }
+}
+```
+
+A `Number::Complex` cannot become a `Vector<Double>`; the caller must
+coerce to `Vector<Complex>` first.
+
+---
+
+## Implicit Matrix / Array
+
+A vector with the `dim` attribute is implicitly a matrix or array:
+
+```rust
+let m = Double::of(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    .with_dim(&[2, 3]);   // 2 rows × 3 cols, column-major
+```
+
+R uses column-major storage. We follow.
+
+This crate provides the storage; matrix arithmetic (multiplication,
+solve, decompositions) lives in `statistics-core::linalg`. The `dim`
+attribute is the only matrix concept r-vector exposes.
+
+---
+
+## Equality
+
+`Vector` equality is element-wise. Two vectors are `==` if:
+
+1. They have the same atomic type
+2. Same length
+3. Same `dim` attribute (or both absent)
+4. Same names (or both absent)
+5. Each non-NA element is equal at the join rung
+6. Each NA position aligns with an NA position in the other
+
+R has separate `==` (element-wise, returns a logical vector with NA
+where either side is NA) and `identical` (whole-vector strict
+equality). We expose both:
+
+```rust
+pub fn eq_elementwise(&self, other: &Self) -> Logical;  // R's ==
+pub fn identical(&self, other: &Self) -> bool;          // R's identical()
+```
+
+`identical` returns `false` (not NA) for NA-vs-non-NA mismatches.
+`eq_elementwise` returns NA at those positions. Both are needed.
+
+---
+
+## Memory and Performance
+
+- Vectors own their data (`Vec<T>` storage). No reference-counted
+  sharing in this crate.
+- R uses copy-on-modify semantics at the language level; `r-runtime`
+  layers that on top via `Rc<Vector>` with deep-clone-on-write. The
+  crate itself is value-typed.
+- Element access is `O(1)`. Indexing produces a new vector; we do not
+  return views (Rust lifetimes make views painful, and the cost of a
+  copy is acceptable for the educational scope).
+- Recycling does not allocate when used through `RecycledIter`.
+
+---
+
+## Test Vectors
+
+Every implementation must pass:
+
+1. NA round-trip: every atomic type, NA in every slot, survives
+   construct → serialize → deserialize → query
+2. Strong-Kleene tables for `&`, `|`, `!` over `Logical`
+3. Recycling: `c(1..6) + c(10, 20)` produces `c(11, 22, 13, 24, 15, 26)`
+4. Recycling warning: `c(1..5) + c(10, 20)` produces `c(11, 22, 13, 24, 15)` and emits one warning
+5. All four index modes on a 5-element vector with named slots
+6. Coercion: `Logical → Integer → Double → Complex → Character` round-trips for both real values and NA at each rung
+7. Names preservation across element-wise ops
+8. `dim` attribute round-trips through indexing
+
+The `tests/` directory contains all of these as separate test files.
+Cross-language parity tests (against the existing Python `stats`
+package's vector helpers and against actual R output) live in
+`code/programs/<lang>/r-vector-parity/`.
+
+---
+
+## Out of Scope
+
+- Factors (categorical type) — own crate, depends on r-vector
+- Data frames — own crate, depends on r-vector
+- Lists (heterogeneous typed) — folded into r-vector as `List` later
+- Lazy evaluation of vector expressions (e.g. delayed computation in
+  `lm(y ~ x)`) — that's r-runtime's job
+- SIMD optimizations — out of scope for v1; the substrate is correct
+  before it is fast
+
+---
+
+## References
+
+- R Language Definition, ch. 2 (vector structures) and §3.3 (NA, NULL)
+- R Internals, §1.1 (atomic types and storage modes)
+- *The R Inferno* (Burns 2011), ch. 1 (recycling pitfalls)
+- Wickham, *Advanced R*, ch. 3 (vectors), ch. 4 (subsetting)

--- a/code/specs/vectorization-rules.md
+++ b/code/specs/vectorization-rules.md
@@ -1,0 +1,298 @@
+# Vectorization Rules
+
+## Overview
+
+Every Layer 1 domain core in the Rust statistics stack receives
+**vectors** as input — never scalars. But "vector" means three
+different things to the three frontends that will consume the cores:
+
+- R recycles: `c(1, 2, 3, 4, 5, 6) + c(10, 20)` repeats the shorter
+  end-to-end to match the longer.
+- Excel array formulas broadcast: `{=A1:A6 + B1:B2}` aligns by shape
+  and fills mismatched positions with `#N/A`.
+- S follows R but with a few quirks (S's `cbind` recycles columns
+  differently from R's).
+
+If each domain core had to know which frontend was calling it, the
+core would carry frontend complexity. Instead, we resolve shape *at
+the frontend boundary* and hand the cores already-aligned vectors.
+This spec defines what each frontend does and the contract a core can
+rely on.
+
+The rule, in one sentence:
+
+> **Shape resolution is a frontend concern. By the time a domain
+> core sees a vector, all recycling, broadcasting, and shape-error
+> decisions have already been made.**
+
+---
+
+## Where It Fits
+
+```
+   r-runtime           spreadsheet-core         s-runtime
+       │                      │                     │
+       │ recycling            │ broadcasting        │ recycling-with-quirks
+       ▼                      ▼                     ▼
+       └──────────────────────┼─────────────────────┘
+                              │
+                              │  aligned vectors only
+                              ▼
+        ┌────────────────────────────────────────────┐
+        │   Layer 1 cores (statistics-core, etc.)    │
+        │   Receive vectors at known, equal shape.   │
+        └────────────────────────────────────────────┘
+```
+
+**Used by:** every frontend before it dispatches to a domain core.
+
+**Not used by:** domain cores themselves. Their function bodies do not
+implement recycling; they assume aligned inputs and produce results
+of derivable shape.
+
+---
+
+## R Recycling
+
+The canonical R rule, reproduced from `r-vector.md` for reference:
+
+1. For a binary element-wise operation, let `n = max(len(a), len(b))`.
+2. Each operand is repeated to length `n`.
+3. Warn if `n` is not a multiple of either input's length.
+
+The recycling helper lives in `r-vector::recycle`. The future
+`r-runtime` calls it before invoking a core function:
+
+```rust
+// In r-runtime, evaluating  a + b  where a, b are R vectors:
+let (a_aligned, b_aligned) = r_vector::recycle_to_max(a, b);
+math_core::add_elementwise(&a_aligned, &b_aligned)
+```
+
+Recycling applies to:
+
+- All element-wise arithmetic (`+`, `-`, `*`, `/`, `^`, `%%`, `%/%`)
+- All element-wise comparisons (`<`, `<=`, `==`, `!=`, `>=`, `>`)
+- All element-wise logical operators (`&`, `|`)
+
+Recycling does **not** apply to:
+
+- Reductions (`sum`, `mean`, …) — they take one vector
+- `match`, `%in%` — they take two vectors with their own length rules
+- Function calls in general — argument-vector shapes are not recycled
+  against each other; each function specifies its own contract
+
+### Length-zero rule
+
+If either operand has length 0, the result has length 0. R's most
+notorious silent-empty trap.
+
+### Length-one rule
+
+If either operand has length 1, that single value is broadcast without
+warning. This is the "scalar broadcasts" case and is the only
+recycling that R does silently.
+
+---
+
+## Excel Broadcasting (Array Formulas)
+
+Excel array formulas operate on rectangular ranges. The rules differ
+from R's recycling in three important ways:
+
+1. **Shape is rectangular** (rows × cols), not flat. Recycling means
+   nothing; *broadcasting* aligns by both axes.
+2. **Mismatch becomes `#N/A`**, not a warning + truncation. If the
+   shapes don't broadcast, missing positions are filled with `#N/A`
+   rather than recycling around.
+3. **Length-one expansion is per-axis**, not flat. A 1-row range
+   broadcasts row-wise across multiple rows; a 1-column broadcasts
+   column-wise.
+
+| Left shape | Right shape | Result shape | Behavior |
+|------------|-------------|--------------|----------|
+| 1×1        | n×m         | n×m          | Scalar broadcasts everywhere |
+| n×1        | n×m         | n×m          | Column broadcasts across columns |
+| 1×m        | n×m         | n×m          | Row broadcasts across rows |
+| n×m        | n×m         | n×m          | Element-wise, no broadcast needed |
+| n×m        | p×q (incompat) | max(n,p)×max(m,q) | Mismatched cells get `#N/A` |
+
+`spreadsheet-core` implements this in its array-formula evaluator:
+
+```rust
+pub fn align_array(
+    a: &CellArray,
+    b: &CellArray,
+) -> (CellArray, CellArray);
+```
+
+The aligned arrays then flatten into `Vector`s for dispatch into the
+domain core, with `#N/A`-positioned cells materialized as the spreadsheet
+NA sentinel (which translates to NA at the boundary — same as Excel
+`=NA()`).
+
+### Modern dynamic arrays (Excel 365)
+
+Excel 365 introduced *dynamic array* spilling, where any formula can
+return an array that auto-expands into adjacent cells. The broadcasting
+rules above apply unchanged; what differs is the *output* — the result
+flows into a cell range instead of being collapsed by an outer
+aggregation. `spreadsheet-core` supports this via a `spill_target`
+parameter on the formula evaluator; the array semantics are identical
+to legacy `{}`-bracketed formulas.
+
+### Implicit intersection
+
+The legacy "implicit intersection" behavior (where `=A1:A10` in a
+single cell collapses to the row-aligned scalar) is supported as a
+compatibility mode flag. The default is dynamic-array mode (Excel 365
+behavior).
+
+---
+
+## S Quirks
+
+S-PLUS shares R's recycling rule for arithmetic but differs in two
+places that bite when porting code:
+
+1. `cbind` / `rbind`: in S, recycles columns/rows to the longest;
+   in R, requires equal lengths or scalars. We follow R; the S
+   frontend (future `s-runtime`) will detect the difference and
+   either emulate or warn — TBD when that frontend is specced.
+2. `apply` / `sapply` over uneven rows: S simplifies to a list-of-vectors;
+   R simplifies to a matrix only if all rows have equal length. We
+   follow R.
+
+These differences live entirely in the S frontend. The cores see
+recycled-or-broadcast vectors and don't know which frontend called.
+
+---
+
+## The Contract Cores Rely On
+
+When a domain core function declares a signature like
+
+```rust
+pub fn add(a: &Double, b: &Double) -> Double { … }
+```
+
+it is allowed to assume:
+
+1. `a.len() == b.len()` (already aligned by the frontend).
+2. Both have the same `dim` attribute or both have none (already
+   aligned).
+3. NA propagation is element-wise: position-`i` NA in either input
+   produces position-`i` NA in the output (per `na-semantics.md`).
+
+If the frontend hands the core mismatched shapes, that is a frontend
+bug. The core may panic in debug and return an error in release; it
+does not attempt to recover.
+
+This contract simplifies cores significantly. A naive
+`add(a, b)` is:
+
+```rust
+pub fn add(a: &Double, b: &Double) -> Double {
+    debug_assert_eq!(a.len(), b.len());
+    let mut out = Double::na(a.len());
+    for i in 0..a.len() {
+        match (a.get(i), b.get(i)) {
+            (Some(x), Some(y)) => out.set(i, Some(x + y)),
+            _ => {} // already NA
+        }
+    }
+    out
+}
+```
+
+No recycling code, no shape juggling, no per-frontend branches.
+
+---
+
+## Shape Inference for Reductions
+
+Reductions (`sum`, `mean`, etc.) collapse a vector to a scalar (technically
+a length-1 vector). They take one input and have no shape-mismatch
+problem. The contract:
+
+- Input length 0 with `na_rm = true`: returns the function's empty-set
+  identity (0 for `sum`, 1 for `prod`, NaN for `mean`/`var`/`sd`,
+  `+Inf` for `min`, `-Inf` for `max`). See `na-semantics.md` for the
+  full table.
+- Input length 0 with `na_rm = false`: same as above; there are no
+  NAs to propagate.
+- Input has dim attribute (matrix): defaults to flattening (`sum(m)`
+  sums everything). Per-axis reductions live on dedicated functions
+  (`row_sums`, `col_sums`, etc.) that take the matrix in its native
+  shape.
+
+---
+
+## Aggregate-with-Group Operations
+
+`tapply`, `aggregate`, `by`, `dplyr::group_by` all share a shape:
+*partition rows by a grouping vector, apply a reduction per partition,
+return one row per group.*
+
+Vectorization here is per-group, not per-element. The grouping vector
+is recycled to the data's length under R's rules (so a length-2
+grouping vector applied to a length-6 data vector produces three
+groups of two each, with a warning if mismatched).
+
+Implementation lives in `statistics-core::aggregate` (yet to be
+specced). Both R and the future spreadsheet frontends route through
+the same function.
+
+---
+
+## SIMD and Parallelism
+
+Out of scope for this contract. The frontend hands the core aligned
+vectors; the core may evaluate sequentially, with SIMD intrinsics, or
+in parallel via `rayon`, all transparent to the caller. Numerical
+results must be identical regardless of execution strategy (this is
+non-trivial for floating-point reductions; see
+`statistics-core.md` §Numerical Accuracy Contract for ULP tolerance
+rules and the deterministic reduction order requirement).
+
+---
+
+## Test Vectors
+
+Every frontend that vectorizes must pass:
+
+1. R recycling: `c(1..6) + c(10, 20)` returns `c(11, 22, 13, 24, 15, 26)`
+2. R warning: `c(1..5) + c(10, 20)` returns `c(11, 22, 13, 24, 15)` with one warning
+3. Excel broadcast: `{1,2,3} + {10;20;30}` (row × column) returns 3×3 matrix
+4. Excel mismatch: `{1,2,3} + {10,20}` returns 1×3 with `#N/A` in column 3
+5. Length-zero: `c() + c(1, 2, 3)` returns length-zero
+6. Scalar broadcast: `5 + c(1, 2, 3)` returns `c(6, 7, 8)` without warning
+7. NA in either operand at position i produces NA at output position i
+8. Aligned vectors round-trip through a domain core unchanged in shape
+
+These tests live in `code/programs/<frontend>/vectorization-parity/`.
+
+---
+
+## Out of Scope
+
+- Per-frontend implementation details (which crate computes which
+  alignment) — covered in each frontend's own spec
+- Non-rectangular array formulas (Excel allows ragged ranges via
+  `LET`/`LAMBDA`; deferred to a follow-up)
+- Tensor algebra (Einstein summation, etc.) — out of scope for the
+  statistical stack; see future `tensor-core`
+- Dataflow optimization across multi-step expressions — `r-runtime`
+  may do this; the contract here is per-call
+
+---
+
+## References
+
+- R Language Definition, §3.3.1 ("recycling rule")
+- *The R Inferno*, ch. 1 ("Falling into the floating point trap" and
+  "Recycling")
+- Microsoft Excel function reference (Array Formulas; "Dynamic array
+  formulas and spilled array behavior")
+- Becker, Chambers, Wilks, *The New S Language* (1988), ch. 5
+  (vectorization and recycling in S)


### PR DESCRIPTION
## Summary

First of four spec PRs that together define the architecture for a from-scratch Rust spreadsheet whose formula library *is* a statistics core that R and S will later dispatch into. Two parallel reconstruction tracks emerge from this work:

- **Faithful**: real 1979 VisiCalc binary running on the existing Python `mos6502-simulator` (separate Python crate to come)
- **Modern**: from-scratch spreadsheet in Rust on the Mosaic UI substrate, sharing its formula library with future R/S runtimes

This PR is the **substrate** layer. Four specs, no implementation code yet.

## Specs added

- **`code/specs/numeric-tower.md`** — Five-rung `Number` type (`Integer` / `Rational` / `Float` / `Complex` / `Decimal`), coercion lattice, arithmetic dispatch, bridges to `cas-*` and `r-vector`. Stays out of NA deliberately — that's r-vector's slot-level concern.
- **`code/specs/na-semantics.md`** — Strong Kleene three-valued logic, per-type NA bit patterns, propagation rules, `na.rm` convention. Draws the line between NA, NaN, and spreadsheet empty cell.
- **`code/specs/r-vector.md`** — `Vector<T>` Rust crate spec: six atomic types matching R, names attribute, attribute bag, four indexing modes, recycling rule, coercion lattice.
- **`code/specs/vectorization-rules.md`** — Resolves shape at the frontend boundary so the cores receive aligned vectors. R recycles; Excel broadcasts; S has its own quirks. Cores are agnostic.

## Architectural notes

- Naming convention: the statistical core is named for what it *is* (statistics math), not how it's *consumed* (formulas in a spreadsheet). "Formula" is a spreadsheet-layer presentation concern.
- Per repo convention, new specs use topic-only filenames (no numeric prefixes).
- R's `i32` `integer` atomic kept deliberately distinct from `numeric-tower::Integer` (arbitrary precision) — matches R's `RData` contract.

## Follow-up spec PRs

- **Spec PR B** — `statistics-core.md` (the comprehensive function catalog: descriptive, distributions, inference, regression, ANOVA, multivariate, time-series, smoothing, RNG, with cross-cutting contracts for error/NA propagation, RNG state, distribution trait, numerical accuracy)
- **Spec PR C** — `spreadsheet-core.md` (formula language, parser, dependency DAG, recalc, Excel/Lotus/VisiCalc name dispatch)
- **Spec PR D** — `visicalc-faithful.md`, `visicalc-modern.md`, plus ST00 roadmap update

## Test plan

- [ ] Spec content review for technical correctness
- [ ] Cross-reference check (no broken filename references between specs)
- [ ] Naming convention conformance (topic-only, no numeric prefix)
- [ ] Style/format match against recent specs (`secure-host-channel.md`, `UI00-mosaic.md`)
- [ ] No mention of "formula" inside `numeric-tower.md`, `na-semantics.md`, `r-vector.md`, `vectorization-rules.md` (formula is a spreadsheet concept; these are foundation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
