### PR TITLE
spec: VisiCalc faithful + modern tracks (Spec PR D)

### DIFF
--- a/code/specs/ST00-r-stats-roadmap.md
+++ b/code/specs/ST00-r-stats-roadmap.md
@@ -10,6 +10,64 @@ plugs into the existing generic language pipeline (LANG00…LANG17).
 This document does not duplicate `ST01-stats.md`; it places ST01 in the
 larger map and identifies the further specs that need to be written.
 
+## Update — Rust Foundation Shift
+
+The roadmap below was originally drafted with per-host-language
+implementations (Python ST01 shipped, Ruby ST01 shipped, etc.). After
+the VisiCalc reconstruction work began, the *real implementation* of
+the statistics stack consolidated into Rust. The new layered home:
+
+- **Substrate (Layer 0)**: `numeric-tower`, `na-semantics`, `r-vector`,
+  `vectorization-rules` — see `numeric-tower.md`, `na-semantics.md`,
+  `r-vector.md`, `vectorization-rules.md`.
+- **Domain core (Layer 1)**: `statistics-core` — see
+  `statistics-core.md`. Comprehensive: every statistical function across
+  VisiCalc, Lotus 1-2-3, Symphony, Multiplan, Excel, R, and S, with
+  cross-cutting contracts for error/NA propagation, RNG state,
+  distribution trait, numerical accuracy.
+- **Spreadsheet engine (Layer 3)**: `spreadsheet-core` — see
+  `spreadsheet-core.md`. Owns the formula language, dependency DAG,
+  recalc, and the dispatch table that maps Excel/Lotus/VisiCalc names
+  to Layer 1 function pointers.
+- **Frontends (Layer 4)**: `visicalc-modern` (Rust on Mosaic) and
+  `visicalc-faithful` (Python on the existing 6502 simulator) — see
+  `visicalc-modern.md` and `visicalc-faithful.md`. The future R and S
+  runtimes plug into the same Layer 1 cores via their own dispatch.
+
+What this means for the roadmap below:
+
+- **ST01 (descriptive stats)** in Python, Ruby, TS, etc. **stays as
+  shipped**. It serves the per-language ecosystems (the Ruby tooling
+  in this repo, the Python notebooks, the TS web demos). It is no
+  longer the canonical implementation; that is the Rust
+  `statistics-core` crate. Cross-language parity tests verify the two
+  agree.
+- **ST02-ST09 (distributions, inference, regression, multivariate,
+  time-series, smoothing, resampling, clustering)** are subsumed into
+  `statistics-core.md` as families within the catalog. The individual
+  ST0N specs may still be written for didactic depth, but the
+  implementation home is the Rust crate, not per-host-language ports.
+- **ST10-ST12 (vector semantics, data frames, formulas)** are
+  redirected to `r-vector` (and a future `data-frame` crate). ST10's
+  Rust home is `r-vector`; ST11 becomes a follow-up `data-frame.md`;
+  ST12 becomes a follow-up `r-formulas.md` once the R runtime needs it.
+- **R00-R05 (the R language frontend)** now sits on top of the Rust
+  Layer 1 cores. The R runtime's dispatcher maps R names (`mean`,
+  `lm`, `dnorm`) to the same Rust function pointers that
+  `spreadsheet-core` dispatches `AVERAGE`, `LINEST`, `NORMDIST` to.
+
+The architectural rule, locked in: **the statistical core is named for
+what it *is* (statistics math), not how it's *consumed* (formulas in a
+spreadsheet).** "Formula" is a presentation concern at the spreadsheet
+layer; the core is agnostic. Every consumer (spreadsheet,
+R runtime, S runtime) gets its own dispatch layer; the cores have no
+frontend awareness.
+
+The original roadmap below remains accurate as a *taxonomy* of the
+statistical surface area. Read it for the breadth of what an R/S
+environment requires; treat the implementation guidance as
+superseded by the Rust specs.
+
 ## Purpose
 
 The eventual goal is a self-hosted, educational R implementation that:

--- a/code/specs/visicalc-faithful.md
+++ b/code/specs/visicalc-faithful.md
@@ -1,0 +1,383 @@
+# VisiCalc Faithful Reconstruction
+
+## Overview
+
+VisiCalc was the first spreadsheet program, released in October 1979
+on the Apple II. Dan Bricklin and Bob Frankston wrote it in 6502
+assembly to fit in 32 KB of RAM. The 27 KB binary that shipped on the
+original distribution diskette is the cultural artifact that turned
+the Apple II from a hobbyist machine into a serious business tool and
+that defined the design vocabulary every spreadsheet since has
+inherited.
+
+This spec lays out the **faithful reconstruction track**: running the
+real 1979 VisiCalc binary on a from-scratch Apple II machine
+emulator, sitting on top of the existing Python `mos6502-simulator`
+in this repo. The goal is not to be the fastest Apple II emulator
+(it will be slow) and not to support every Apple II program (it
+won't) — the goal is to make the artifact run again, in the
+literate-programming style this repo prefers, with the surrounding
+hardware specified and implemented well enough that VisiCalc itself,
+as the canary application, runs end-to-end.
+
+A separate spec, `visicalc-modern.md`, covers the *modern*
+reconstruction in Rust on the Mosaic UI substrate. The two tracks
+share specs and a vision but live in different language ecosystems
+and on different platforms. They are siblings, not layers.
+
+---
+
+## Why the Faithful Track Belongs in Python
+
+The existing 6502 simulator at `code/packages/python/mos6502-simulator/`
+is mature: 151 official NMOS opcodes, 13 addressing modes, BCD
+decimal-mode arithmetic, the indirect-JMP page-wrap bug,
+cycle-accurate behavioral simulation. Building the Apple II machine
+layer in Python keeps it next to the simulator it depends on, lets
+us reuse the same `SIM00 Simulator[MOS6502State]` protocol for
+testing, and avoids cross-language plumbing for what is essentially
+hardware emulation.
+
+The "real implementation" of the spreadsheet (formula engine, statistics
+library, modern UI) moves to Rust per the architecture in
+`statistics-core.md` and `spreadsheet-core.md`. The faithful track
+does **not** share code with the modern track. It does not need a
+formula engine — VisiCalc *is* its own formula engine, baked into the
+6502 binary. It does not need a statistics core — VisiCalc's 25
+functions are inside the binary too. The faithful track exists to run
+the binary, not to interoperate with the rest of the Rust stack.
+
+---
+
+## Where It Fits
+
+```
+   Apple II VisiCalc disk image (.dsk file, 140 KB)
+                       │
+                       │  VisiCalc binary loaded into memory at $1000
+                       ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │             Apple II Machine Layer (Python)              │
+   │                                                          │
+   │   ┌────────────────────────────────────────────────────┐ │
+   │   │  apple-ii-machine                                  │ │
+   │   │   memory map  ($0000–$FFFF)                        │ │
+   │   │   soft switches ($C000–$C0FF)                      │ │
+   │   │   text page ($0400–$07FF) → 40×24 character grid   │ │
+   │   │   lores page ($0400–$07FF, alternate use)          │ │
+   │   │   hires pages ($2000–$3FFF, $4000–$5FFF)           │ │
+   │   │   keyboard strobe ($C000), $C010 clear             │ │
+   │   │   speaker click ($C030)                            │ │
+   │   │   paddle buttons ($C061–$C063)                     │ │
+   │   │   language card switching ($C080–$C08F)            │ │
+   │   └─────────────────────┬──────────────────────────────┘ │
+   │                         │                                │
+   │   ┌─────────────────────▼──────────────────────────────┐ │
+   │   │  apple-ii-disk                                     │ │
+   │   │   Disk II controller hardware ($C0E0–$C0EF)        │ │
+   │   │   .dsk and .nib image formats                      │ │
+   │   │   GCR encoding / decoding                          │ │
+   │   │   sector skewing                                   │ │
+   │   │   DOS 3.3 RWTS routines (or Apple ProDOS for v2)  │ │
+   │   └─────────────────────┬──────────────────────────────┘ │
+   │                         │                                │
+   │   ┌─────────────────────▼──────────────────────────────┐ │
+   │   │  apple-ii-display                                  │ │
+   │   │   text-page → ASCII art (terminal frontend)        │ │
+   │   │   text-page → glyph buffer (GUI frontend)          │ │
+   │   │   refresh on $0400-$07FF write                     │ │
+   │   └─────────────────────┬──────────────────────────────┘ │
+   │                         │                                │
+   │                         ▼                                │
+   │   ┌────────────────────────────────────────────────────┐ │
+   │   │  mos6502-simulator (existing — Python)             │ │
+   │   │  Memory-mapped I/O hooks invoke the layers above   │ │
+   │   └────────────────────────────────────────────────────┘ │
+   └──────────────────────────────────────────────────────────┘
+```
+
+Two follow-up specs flesh out the layers:
+
+- **`apple-ii-machine.md`** (follow-up; not in this PR) — the memory
+  map, soft switches, video pages, keyboard, speaker, paddles,
+  language card. The hardware that VisiCalc directly touches and a
+  few extras for completeness. Targets: enough fidelity that the
+  VisiCalc binary boots, accepts keystrokes, and writes the screen
+  buffer.
+- **`apple-ii-disk.md`** (follow-up) — Disk II controller, GCR
+  encoding, .dsk/.nib formats, RWTS routines from DOS 3.3. Targets:
+  enough fidelity that the VisiCalc disk boots, that VisiCalc can
+  load and save sheets to a writable disk image.
+
+This spec is a top-level overview that sequences the work, defines
+the success criteria, and pins down the boundaries. The detailed
+hardware specs follow.
+
+---
+
+## §1 Success Criteria
+
+The faithful track is *done* when:
+
+1. The original 1979 VisiCalc binary (the 27 KB image hosted on
+   bricklin.com, MD5 verified) boots on the emulator from a `.dsk`
+   image we can construct from the binary plus a DOS 3.3 boot loader.
+2. The UI grid renders correctly in both terminal mode (40×24 text
+   characters, no color) and an optional GUI window with a CRT-like
+   font.
+3. Keyboard input is accepted: cursor movement (`I/J/K/M`), command
+   leader (`/`), function entry (`@SUM`, `@AVERAGE`, etc.), all
+   produce the same screen state as the original.
+4. Spreadsheets can be saved to and loaded from disk images. Round-tripping
+   a saved sheet through emulator → disk image → emulator returns the
+   same display.
+5. The full VisiCalc reference card's example session runs to
+   completion without divergence.
+6. We can play the 1979 demo sheet bundled on the original disk.
+
+Success is *not* measured by:
+
+- General Apple II compatibility (other programs may or may not work)
+- Performance matching real hardware (we don't need real-time)
+- Disk II copy protection workarounds (we use the ungated VisiCalc
+  binary; protected versions are out of scope)
+- Color, hires graphics, mouse, mockingboard sound (VisiCalc uses
+  none of these)
+
+---
+
+## §2 What VisiCalc Touches
+
+A 6502 trace of VisiCalc's first second of execution shows what the
+machine layer actually has to provide. The list is short:
+
+| Hardware                  | Why VisiCalc needs it                              |
+|---------------------------|----------------------------------------------------|
+| 64 KB RAM (with language card for the upper 16 KB) | Code + sheet data |
+| Text page at `$0400-$07FF` | The 40×24 character display |
+| Keyboard at `$C000-$C001`  | Reading keystrokes |
+| Speaker at `$C030`         | Cell-overflow beep |
+| Disk II controller         | Loading the binary at boot, save/load sheets |
+| ROM monitor (`$F800-$FFFF`) | Boot path; VisiCalc itself does not use monitor calls beyond startup |
+| DOS 3.3 RWTS               | File operations (GET FILE, SAVE FILE) |
+
+Things VisiCalc does **not** touch:
+
+- Hires pages
+- Lores pages (uses text only)
+- Paddles, joysticks, mouse
+- Cassette interface
+- Auxiliary slots beyond Disk II
+
+This is the entire reason the faithful track is feasible: the
+hardware surface is small. We do not need a complete Apple II
+emulator. We need the slice VisiCalc uses.
+
+---
+
+## §3 Boot Sequence
+
+The Apple II boot ROM at `$FF00` runs at power-on, looks for a Disk
+II controller in slot 6, jumps to its boot ROM. Disk II's boot ROM
+loads track 0 sector 0 from the disk into `$0800`, jumps to it. Track
+0 sector 0 is the DOS 3.3 boot loader, which loads DOS into upper
+memory and chain-loads the binary specified in `HELLO` (the boot
+program).
+
+For VisiCalc:
+
+1. Boot disk track 0: DOS 3.3 boot loader
+2. DOS 3.3 loads, finds `HELLO` (the boot program), executes it
+3. `HELLO` is a small BASIC program that does `BRUN VISICALC`
+4. `BRUN` loads VisiCalc into `$1000-$76FF` and jumps to `$1000`
+5. VisiCalc takes over
+
+The emulator's job is to provide enough of (a) the boot ROM, (b) the
+Disk II controller, (c) DOS 3.3, and (d) the file system to let
+this sequence run. We do not need to handle the case where the user
+types `]CATALOG` from the BASIC prompt or runs other programs; the
+boot disk is purpose-built to launch VisiCalc.
+
+A simplification we adopt: instead of constructing a faithful DOS 3.3
+disk image and running its full boot loader, we provide a *mock boot*
+that loads the VisiCalc binary directly into memory at `$1000` and
+jumps there. This shortcuts the multi-stage boot for development but
+sacrifices fidelity. A `--full-boot` flag enables the real boot path
+once `apple-ii-disk.md` is implemented, for users who want the
+authentic load-from-disk experience.
+
+---
+
+## §4 Display Backends
+
+The text page maps directly to a 40×24 character grid. Each cell is
+a byte at `$0400 + offset`, where the offset is computed by the Apple
+II's notorious non-linear screen layout (rows are interleaved in
+groups of 8 to support hires-mode hardware addressing). The
+character byte's high bit indicates inverse video; low 7 bits are
+the (modified) ASCII code.
+
+Two backends:
+
+### Terminal backend
+
+Renders to stdout using ANSI escape codes for cursor positioning and
+inverse video. Each frame is a `40×24` block written to a fixed
+position. Refresh on every change to `$0400-$07FF`. The terminal
+must support at least 40×24; we recommend 80×24 with 40 columns of
+padding.
+
+### GUI backend
+
+Renders into a window using a CRT-style font (the Apple II's
+character ROM dumped to a TrueType-equivalent). Optional CRT
+shader for the period feel. The GUI backend is in a separate Python
+package depending on `pygame` or similar, kept optional so the
+terminal backend works on any Python install.
+
+Both backends watch the same memory range and re-render on dirty.
+Refresh rate caps at 60 Hz to avoid thrashing.
+
+### No graphics
+
+Hires-page rendering is out of scope. VisiCalc never draws to hires.
+
+---
+
+## §5 Keyboard
+
+The Apple II keyboard appears at `$C000` (read for the current key
++ strobe bit) and `$C010` (write to clear the strobe). The mapping
+is a near-ASCII subset with modifications:
+
+- Letters arrive as uppercase only (no shift state)
+- Control characters from `Ctrl`-modified keys
+- Arrow keys do not exist on the original Apple II — VisiCalc uses
+  `I` (up), `J` (left), `K` (right), `M` (down) for navigation
+- The `Esc` key sends `$1B` (standard ASCII)
+- The `Return` key sends `$0D`
+
+The emulator polls the Python frontend's input source (terminal stdin
+in non-canonical mode, or the GUI window's events) and queues
+keystrokes. The 6502 sees one byte at `$C000` with the high bit set
+when a key is pending; reading `$C010` clears it.
+
+Key-repeat behavior: the original Apple II had a hardware repeat
+after a held delay. VisiCalc relies on this for cursor movement.
+The emulator's input driver implements key-repeat with the same
+~250 ms delay, ~10 Hz repeat rate.
+
+---
+
+## §6 Speaker
+
+The speaker at `$C030` toggles every read. VisiCalc beeps on cell
+overflow and on errors. The emulator's audio backend is optional; on
+machines without audio output, beeps are dropped silently.
+
+---
+
+## §7 Disk and File System
+
+VisiCalc saves sheets as a custom binary format on the boot disk.
+The format is documented in the VisiCalc reference materials and is
+small (header + cell array). The emulator's disk layer presents a
+writable `.dsk` image to VisiCalc's RWTS calls.
+
+For development, the recommended workflow:
+
+1. Start with a read-only boot disk containing the VisiCalc binary
+2. Mount a separate writable data disk in slot 6 drive 2 (or use a
+   single-drive disk swap)
+3. SAVE FILES to the data disk
+4. Inspect the saved sheets via a host-side tool that reads the
+   VisiCalc file format
+
+The host-side tool lives at `code/programs/python/visicalc-file-reader/`
+and is a thin wrapper around the documented format. It is useful for
+verification and round-trip testing but is not part of the emulator
+itself.
+
+---
+
+## §8 Testing
+
+Three test layers:
+
+1. **Per-component tests** (in each Python package's own tests/):
+   memory map decoding, soft-switch behavior, keyboard queue, screen
+   layout decoding, GCR encoding round-trip.
+2. **Integration tests** (in `code/programs/python/visicalc-faithful-tests/`):
+   boot the binary, drive a scripted keystroke sequence, assert the
+   final screen state. The keystroke sequences come from a corpus of
+   VisiCalc tutorial examples.
+3. **Differential testing** against AppleWin (or another mature Apple
+   II emulator): same keystroke sequence, compare final screen
+   state. Useful for catching subtle hardware-emulation bugs we
+   missed.
+
+Testing notes:
+
+- The corpus includes the demo sheet from the original 1979
+  distribution, recreated by hand from the documentation.
+- Cycle-accurate timing is asserted only at the unit-test level for
+  the simulator itself; the integration tests do not depend on
+  cycle counts.
+
+---
+
+## §9 Implementation Phases
+
+Each phase is its own follow-up implementation PR:
+
+1. **Phase 1 — `apple-ii-machine.md` spec + skeleton** (Python crate
+   `apple-ii-machine`). Spec the memory map, soft switches, write
+   the Python module that wires `mos6502-simulator`'s memory-access
+   hooks to soft-switch handlers. Boot a tiny test program (not
+   VisiCalc yet).
+2. **Phase 2 — Display backend.** Terminal first, GUI later. Watch
+   `$0400-$07FF`, render the screen.
+3. **Phase 3 — Keyboard.** Terminal stdin in non-canonical mode +
+   GUI events.
+4. **Phase 4 — `apple-ii-disk.md` spec + Disk II + DOS 3.3 RWTS.**
+   Full disk image support. Boot a real DOS 3.3 disk.
+5. **Phase 5 — VisiCalc boot.** Construct the boot disk, run the
+   binary, watch it draw the splash screen.
+6. **Phase 6 — End-to-end demo.** Full keystroke-driven demo sheet.
+
+Phases 1-3 are useful even without Phases 4-6: they give us a working
+Apple II text-mode emulator that can run BASIC and small assembly
+programs from memory dumps. Phases 4-6 add the disk subsystem to
+support the original VisiCalc binary specifically.
+
+---
+
+## §10 Out of Scope
+
+- Color (VisiCalc is monochrome)
+- Hires / lores graphics
+- Mouse, paddles, joysticks
+- Auxiliary cards beyond Disk II
+- Other 1979-era spreadsheets (SuperCalc, Multiplan early version,
+  context MBA) — those would each need their own boot ROM and
+  language environment
+- The Lotus 1-2-3 / Symphony / Excel reconstruction lineage — those
+  ran on PCs, not Apple IIs, and have their own emulation
+  requirements (8086, MS-DOS, EGA/VGA)
+- Period-correct printer output (Imagewriter, Silentype)
+- Networking (none in 1979)
+
+---
+
+## References
+
+- Sather, *Understanding the Apple II* (1983) — definitive hardware
+  reference
+- Bricklin & Frankston interview on VisiCalc internals (Computer
+  History Museum oral history)
+- DOS 3.3 source listing (Apple Computer, 1980)
+- Bricklin's site, https://www.bricklin.com/history/intro.htm — hosts
+  the original VisiCalc binary and historical materials
+- VisiCalc Reference Card (1979)
+- The existing `mos6502-simulator` and its spec
+  `code/specs/07j-mos6502-simulator.md`

--- a/code/specs/visicalc-modern.md
+++ b/code/specs/visicalc-modern.md
@@ -1,0 +1,335 @@
+# VisiCalc Modern Reconstruction
+
+## Overview
+
+VisiCalc Modern is a from-scratch Rust spreadsheet that reproduces
+the *idea* of VisiCalc — a grid of cells, formulas with cross-cell
+references, instant recalculation — using only modern infrastructure:
+the Mosaic UI language, the layered statistics core, and the
+spreadsheet engine. The spreadsheet itself is the canary application
+that exercises the whole stack end-to-end.
+
+Where the *faithful* reconstruction (`visicalc-faithful.md`) runs the
+1979 binary, this track builds the spreadsheet again from current
+materials. The two are not layers and do not share code; they share
+specs and a vision. The faithful track is preservation; the modern
+track is *exercise* — it forces the new substrate (numeric-tower,
+r-vector, statistics-core, spreadsheet-core) to be complete enough
+to host a real, end-user-facing application, and it forces the
+Mosaic UI compiler to be complete enough to render a non-trivial
+interactive grid.
+
+The application lives at `code/programs/rust/visicalc-modern/` and
+depends on every Layer-0, -1, and -3 crate in the statistics stack
+plus the Mosaic compiler and the chosen Mosaic backend (paint-vm
+for native, web-component for browser).
+
+---
+
+## Why Modern as Well as Faithful
+
+The faithful track answers "can we make the 1979 program run?" — a
+preservation question.
+
+The modern track answers four different questions:
+
+1. **Does the Layer 1 statistics-core have the right shape?** Building
+   `=AVERAGE(A1:A10)` end-to-end means writing the spreadsheet-core
+   dispatcher, which resolves a name to a function pointer in
+   statistics-core. If the function pointer's signature is awkward,
+   the dispatcher is awkward, and the design needs revision *before*
+   we hand it to the future R runtime where the awkwardness would
+   be permanent.
+2. **Is the Mosaic UI complete enough for a real application?** A
+   spreadsheet with 1000 cells, scrolling, in-place cell editing,
+   formula bar, and clipboard is the most demanding UI Mosaic has
+   tried to render. If something is missing, the modern VisiCalc
+   work surfaces it.
+3. **Does the recalc engine perform?** A spreadsheet user expects
+   sub-100ms response on a 10 000-cell sheet. If `spreadsheet-core`'s
+   recalc algorithm is too slow, this is where we find out.
+4. **Can statistics-core's first phase serve as a real formula
+   library?** Phase 1 (descriptive + counting + rank) is enough to
+   support a VisiCalc-replica function set (`@SUM`, `@AVERAGE`,
+   `@MIN`, `@MAX`, `@COUNT`, `@STDEV`, `@VAR`, `@MEDIAN`, `@RANK`).
+   The modern track stresses these in a real workload.
+
+---
+
+## Where It Fits
+
+```
+   visicalc-modern (binary)              ← THIS SPEC's program
+        │
+        │ Mosaic .mosaic source
+        │ compiles to paint-vm or web-component backend
+        ▼
+   ┌───────────────────────────────────────────────────────┐
+   │   Mosaic-compiled UI                                  │
+   │   - cell grid component (virtual scrolling)           │
+   │   - formula bar                                       │
+   │   - menu / status line                                │
+   └─────────────────────────┬─────────────────────────────┘
+                             │ user events: edit cell, navigate
+                             ▼
+   ┌───────────────────────────────────────────────────────┐
+   │   spreadsheet-core (Rust)                             │
+   │   formula AST + DAG + recalc + dispatch               │
+   └─────────────────────────┬─────────────────────────────┘
+                             │ delegates math
+                             ▼
+   ┌───────────────────────────────────────────────────────┐
+   │   statistics-core · math-core · financial-core · …    │
+   └─────────────────────────┬─────────────────────────────┘
+                             ▼
+                  numeric-tower · r-vector
+```
+
+A follow-up spec, `mosaic-spreadsheet-component.md`, defines the
+specific Mosaic component for the cell grid: virtual scrolling, cell
+edit mode, selection, formula bar, clipboard. Not in this PR.
+
+---
+
+## §1 What "Modern VisiCalc" Means
+
+The modern track replicates VisiCalc's *user experience* and *function
+set* but uses modern materials. Concretely:
+
+| Aspect                | VisiCalc Faithful   | VisiCalc Modern                          |
+|-----------------------|---------------------|------------------------------------------|
+| Display               | 40×24 text grid     | resizable window, virtual-scrolling grid |
+| Input                 | Apple II keyboard   | full keyboard + mouse + clipboard         |
+| Function set          | 25 functions (1979) | VisiCalc 25 + Lotus 80 + Excel ~100       |
+| Formula language      | A1 refs, `@FN(…)`   | A1 refs, `=FN(…)`, both `@` and `=` accepted |
+| File format           | VisiCalc binary    | XLSX (read/write), CSV, JSON-flat         |
+| Recalc model          | manual `!`         | automatic / manual / iterative            |
+| Performance           | 32 KB / 1 MHz      | 10 000 cells in < 100 ms                  |
+| Underlying CPU        | 6502                | native Rust                               |
+| Color                 | none                | optional cell formatting                  |
+| Charting              | none                | none in v1 (chart-core is a future crate) |
+| History (undo)        | none                | full undo/redo                            |
+| Multi-sheet           | no                  | yes                                       |
+
+The function set extension is the major modernization. Where 1979
+VisiCalc was a small sealed environment, the modern reconstruction
+is open-ended — every Excel statistical function, every Lotus
+financial function, every R distribution sampler is callable from a
+cell. The same function name conventions Excel users expect
+(`AVERAGE`, `STDEV`, `NPV`) work, plus the legacy VisiCalc names
+(`@SUM`, `@AVG`) for users referencing 1979-era documentation.
+
+---
+
+## §2 Phases
+
+Each phase is its own follow-up implementation PR. The phases assume
+the spec PRs A, B, C have landed and the corresponding implementation
+PRs are progressing in parallel.
+
+### Phase M1 — Headless Shell
+
+Just enough to prove the dispatch path:
+
+- Construct a `Workbook` programmatically
+- Type a few formulas via API (no UI)
+- Recalc and assert results
+- Tests against a corpus of VisiCalc-original example sheets
+  (transcribed from the reference card)
+
+Depends on: spreadsheet-core impl phase 1 (parser + DAG + recalc)
+and statistics-core phase 1 (descriptive + counting + rank).
+
+### Phase M2 — Mosaic Cell Grid
+
+Drives out the missing virtual-scrolling table from `code/specs/table.md`
+plus the cell-edit interaction:
+
+- Cell rendering with text alignment (numbers right, text left,
+  matching VisiCalc)
+- Selection model (single cell, range, named range)
+- In-place editing: click a cell, type, press Enter
+- Formula bar: shows the current cell's formula; edits route to the
+  cell
+
+Depends on: Mosaic compiler's web-component or paint-vm backend.
+
+### Phase M3 — VisiCalc Function Parity
+
+Implement and dispatch the original VisiCalc 25-function set,
+verifying that each works in a real workbook context:
+
+| Function | Source                                |
+|----------|----------------------------------------|
+| `@SUM`, `@AVERAGE`, `@MIN`, `@MAX`, `@COUNT` | statistics-core::descriptive |
+| `@STDEV` (Lotus addition; not in 1979)        | statistics-core::descriptive::sd_pop |
+| `@VAR` (Lotus addition)                       | statistics-core::descriptive::var_pop |
+| `@ABS`, `@INT`, `@SQRT`, `@EXP`, `@LN`, `@LOG`, `@SIN`, `@COS`, `@TAN`, `@ASIN`, `@ACOS`, `@ATAN` | math-core (when implemented; until then, std `f64` methods) |
+| `@PI`                                          | math-core constant |
+| `@NPV`                                         | financial-core (when implemented) |
+| `@IF`                                          | spreadsheet-core inlined |
+| `@LOOKUP`                                      | lookup-core (when implemented) |
+| `@ERROR`, `@NA`, `@TRUE`, `@FALSE`             | spreadsheet-core sentinels |
+| `@AND`, `@OR`, `@NOT`                          | spreadsheet-core inlined |
+
+If a Layer 1 crate that hosts a function is not yet implemented when
+M3 ships, the function is implemented inline in `visicalc-modern`'s
+own dispatch table as a temporary measure, with a TODO and a
+follow-up PR queued to extract.
+
+### Phase M4 — File Formats
+
+XLSX read/write via a future `xlsx-io` crate, plus CSV and a
+JSON-flat format for diffing. CSV and JSON ship in M4; XLSX may slip
+to M5 depending on `xlsx-io` readiness.
+
+### Phase M5 — Polish
+
+- Undo/redo (event-sourced log of edits)
+- Multi-sheet workbooks
+- Named ranges
+- Cell formatting (number format, text alignment, font weight)
+- Print preview
+- Keyboard shortcut parity with Excel (`Ctrl-C`, `Ctrl-V`,
+  `F2` to edit, `Ctrl-Z` to undo, etc.)
+
+### Phase M6 — Excel Function Parity
+
+Beyond VisiCalc's 25, ship the full Excel statistical-function
+catalog as those phases of statistics-core ship. Phase M6 is the
+ongoing track that follows statistics-core's phase progression.
+
+---
+
+## §3 Mosaic Component Surface
+
+`mosaic-spreadsheet-component.md` (follow-up) details the components.
+Outline of what M2 needs:
+
+```
+SpreadsheetWorkbook(workbook: WorkbookHandle) {
+    Toolbar()
+    FormulaBar(active_cell: CellAddress, formula: String)
+    SheetTabs(sheets: list<Sheet>)
+    SheetView(sheet: Sheet, viewport: Viewport)
+}
+
+SheetView(sheet, viewport) {
+    ColumnHeaders(start_col, end_col)
+    RowHeaders(start_row, end_row)
+    CellGrid(visible_cells: Range, selection: Selection)
+}
+
+CellGrid {
+    // virtual-scrolling, only renders visible cells
+    // delegates to Cell for each visible position
+}
+
+Cell(value: CellValue, format: CellFormat, selected: bool, edit_mode: bool) {
+    when edit_mode { CellEditor(formula: String) }
+    else { CellDisplay(formatted_text: String, alignment: Alignment) }
+}
+```
+
+These are Mosaic component declarations; the compiler emits paint-vm
+or web-component code per the chosen backend.
+
+The cell editor needs *autocomplete* for function names, range
+references, and named ranges, but autocomplete is a Phase M5
+deliverable; M2 ships a plain text input.
+
+---
+
+## §4 The Renderer Bridge
+
+Modern VisiCalc renders through Mosaic. Two backends matter:
+
+- **paint-vm** (native): the Rust paint-vm executes layout-IR
+  paint instructions on a window via Direct2D / Quartz / Skia
+  (per platform). The visicalc-modern binary is a native
+  executable.
+- **web-component** (browser): the same Mosaic source compiles to
+  Web Components, rendering in a browser tab. Useful for
+  notebook embedding and remote demos.
+
+Both share the same `.mosaic` source and the same
+`spreadsheet-core` library underneath. The binary chooses backend
+by build flag.
+
+A *third* backend, terminal (à la `tput` / `crossterm`), is an
+attractive idea for parity with the faithful track's terminal mode.
+Out of scope for v1; gets added once paint-vm has a terminal output
+target (currently it does not).
+
+---
+
+## §5 Test Plan
+
+End-to-end tests live in `code/programs/rust/visicalc-modern/tests/`:
+
+1. **Headless integration** (no UI): construct workbooks, recalc,
+   assert results.
+2. **Mosaic UI driver tests** using a headless paint-vm output: drive
+   keystrokes, capture rendered frames, assert frame contents.
+3. **Excel parity** (read XLSX, recalc, write XLSX, diff against
+   Excel-recalculated reference): once `xlsx-io` lands.
+4. **VisiCalc reference-card examples**: every formula from the 1979
+   reference card runs in modern VisiCalc and produces the same
+   numeric result.
+
+Performance tests: 10 000-cell workbook builds, recalcs, scrolls.
+Targets per `spreadsheet-core.md` §18.
+
+---
+
+## §6 Out of Scope
+
+- Charting (separate `chart-core`)
+- Pivot tables (separate `pivot-core`)
+- Conditional formatting (display only; future)
+- Data validation (input gating; future)
+- Real-time data refresh
+- Macros / VBA / LAMBDA / LET (formula-language extension; future)
+- Multi-user collaborative editing (CRDT-based; way out of scope)
+- Mobile / touch UI
+
+---
+
+## §7 Comparison to Faithful
+
+The two tracks are independent but cross-link:
+
+| Dimension              | Faithful (Python)                  | Modern (Rust)                        |
+|------------------------|-------------------------------------|--------------------------------------|
+| Boot state             | 1979 binary loaded from .dsk        | Native Rust startup                  |
+| CPU                    | mos6502-simulator                   | host CPU                             |
+| Display                | text page or CRT shader             | Mosaic-rendered native window or web |
+| Function set           | sealed at 25                        | open-ended; grows with statistics-core |
+| File format            | VisiCalc binary on disk image       | XLSX, CSV, JSON                      |
+| Tests                  | screen-state diffs vs scripted keystrokes | function dispatch + UI driver |
+| Performance bar        | "fast enough to use"                | sub-100ms recalc on 10k cells        |
+| Educational value      | hardware emulation, 6502 assembly  | UI compilation, formula language, dispatch design |
+
+Cross-linking happens at the spec level (both tracks reference the
+same `statistics-core.md` for function semantics, even though the
+faithful track does not call into the Rust crate — its functions live
+in the 6502 binary). When a function's behavior in the faithful
+track differs from the modern track (e.g. `@AVERAGE` over a range
+containing a "blank" cell), the spec is the single source of truth
+and both implementations are checked against it.
+
+---
+
+## References
+
+- Bricklin & Frankston, *VisiCalc User's Guide* (1979) — function
+  reference
+- Microsoft Excel function reference — for the modernization's
+  expanded function set
+- `statistics-core.md` — function semantics
+- `spreadsheet-core.md` — engine semantics
+- `code/specs/UI00-mosaic.md` — UI compiler
+- `code/specs/UI01-mosaic-vm.md`, `UI02-layout-ir.md` — rendering
+  pipeline
+- `code/specs/table.md` — table component (the virtual-scrolling
+  cell grid will land here once specced)


### PR DESCRIPTION
## Summary

Fourth and final spec PR in the substrate-and-cores series. Defines the two parallel VisiCalc reconstruction tracks and updates the existing R-stats roadmap to reflect the Rust-foundation shift.

The two tracks are independent but cross-link at the spec level. Faithful is preservation; modern is exercise.

## Specs added

### `code/specs/visicalc-faithful.md` — Python track

Runs the 1979 VisiCalc binary on a from-scratch Apple II machine emulator built atop the existing Python `mos6502-simulator`.

- Defines the slim hardware surface VisiCalc actually touches (memory + text page + keyboard + speaker + Disk II — and *not* hires, lores, paddles, etc.)
- Boot sequence: ROM → Disk II → DOS 3.3 → BRUN VISICALC, plus a `--full-boot` vs mock-boot tradeoff
- Two display backends: terminal (40×24 ANSI) and optional GUI (CRT-style font)
- Six implementation phases from machine layer through end-to-end demo
- Outlines two follow-up specs not in this PR: **`apple-ii-machine.md`** and **`apple-ii-disk.md`**

### `code/specs/visicalc-modern.md` — Rust track

From-scratch spreadsheet on Mosaic UI + the layered statistics core + spreadsheet-core. The canary application that exercises the entire Rust stack end-to-end.

- Justifies the modern track separately from faithful: dispatch design, Mosaic completeness, recalc performance, statistics-core Phase 1 viability — each forced into validation by a real workload
- Six implementation phases (M1 headless shell → M6 Excel function parity)
- Outlines follow-up: **`mosaic-spreadsheet-component.md`** — drives out the missing virtual-scrolling table from `code/specs/table.md`
- Comparison table makes the boundaries between faithful and modern explicit

## Spec updated

### `code/specs/ST00-r-stats-roadmap.md`

Prepended an **"Update — Rust Foundation Shift"** section noting that the implementation home consolidated into Rust. The original roadmap below remains accurate as a taxonomy; implementation guidance is superseded by the new Rust specs.

- Per-host-language ST01 ports (Python, Ruby, TS, Go, etc.) remain shipped for their ecosystems; canonical implementation is now `statistics-core` (Rust)
- ST10/ST11/ST12 redirected to `r-vector` + future `data-frame` + future `r-formulas`
- R00-R05 (R language frontend) plugs into the Rust Layer 1 cores via R-runtime dispatch
- Architectural rule recorded explicitly: **the statistical core is named for what it *is* (statistics math), not how it's *consumed* (formulas in a spreadsheet)**

## Series recap

This completes the four-PR substrate-and-cores spec drop:

| PR | Title | Specs |
|----|-------|-------|
| [#2249](https://github.com/adhithyan15/coding-adventures/pull/2249) | Spec PR A — Substrate | `numeric-tower`, `na-semantics`, `r-vector`, `vectorization-rules` |
| [#2252](https://github.com/adhithyan15/coding-adventures/pull/2252) | Spec PR B — statistics-core | the comprehensive function catalog (200 fns × 330 names) |
| [#2255](https://github.com/adhithyan15/coding-adventures/pull/2255) | Spec PR C — spreadsheet-core | engine, DAG, recalc, dispatch, inlined logical/info |
| this | Spec PR D — VisiCalc tracks | faithful + modern + ST00 update |

After all four merge, implementation PRs follow in dependency order: `numeric-tower` → `r-vector` → `statistics-core` Phase 1 → `spreadsheet-core` Phase 1 → fork into the two VisiCalc tracks plus statistics-core Phase 2+.

## Test plan

- [ ] `visicalc-faithful.md` references existing `mos6502-simulator` correctly; success criteria are concrete and testable
- [ ] `visicalc-modern.md` makes clear the modern track does NOT share code with the faithful track
- [ ] ST00 update preserves the original roadmap content; only prepends the shift note
- [ ] No spec mentions "formula" inside the statistical core itself (consistent rule across the series)
- [ ] Cross-links to follow-up specs (`apple-ii-machine.md`, `apple-ii-disk.md`, `mosaic-spreadsheet-component.md`) are explicit and labeled as not-in-this-PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
