### PR TITLE
[codex] Add Ruby Board VM session commands

### DIFF
--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -64,6 +64,25 @@ session result for debugging.
 Tests and alternate runtimes can inject any transport object that responds to
 `transact(frame, timeout_ms:)` or `write(frame)`.
 
+For REPL-style sessions, the Ruby surface exposes named commands while keeping
+the same Rust-owned protocol boundary:
+
+```ruby
+CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
+  board.session do |vm|
+    vm.hello
+    vm.capabilities
+    vm.run_command("blink 24")
+  end
+end
+```
+
+`hello`, `capabilities`, `upload_blink`, `run`, `blink`, and `run_command`
+return dispatch results with the Rust-produced frame, optional raw response
+bytes, and optional Rust-decoded response hash. The text command parser is Ruby
+sugar only; every dispatched frame still comes from
+`CodingAdventures::BoardVM::Native::Session`.
+
 The DSL also exposes the current board-agnostic blink ejection path:
 
 ```ruby

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -4,6 +4,7 @@ require_relative "board_vm/version"
 require_relative "board_vm/command_runner"
 require_relative "board_vm/native"
 require_relative "board_vm/transport"
+require_relative "board_vm/session"
 require_relative "board_vm/connection"
 
 module CodingAdventures

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -64,6 +64,14 @@ module CodingAdventures
         Ejector.new(self)
       end
 
+      def session(**options)
+        protocol_session = Session.new(self, **options)
+        return protocol_session unless block_given?
+
+        yield protocol_session
+        protocol_session
+      end
+
       def flash!
         ensure_uno_r4_wifi!
 
@@ -84,18 +92,16 @@ module CodingAdventures
       )
         ensure_uno_r4_wifi!
 
-        session = Native::Session.new
-        frames = [
-          session.hello_wire("ruby-board-vm", host_nonce),
-          session.caps_query_wire,
-          *session.blink_upload_run_frames(program_id, budget, pin, high_ms, low_ms, max_stack)
-        ]
-        responses = frames.map { |frame| dispatch_frame(frame) }
-        decoded_responses = responses.map { |response| decode_response(session, response) }
-        SessionResult.new(
-          frames: frames,
-          responses: responses,
-          decoded_responses: decoded_responses
+        session.blink(
+          program_id: program_id,
+          budget: budget,
+          pin: pin,
+          high_ms: high_ms,
+          low_ms: low_ms,
+          max_stack: max_stack,
+          handshake: true,
+          query_caps: true,
+          host_nonce: host_nonce
         )
       end
 
@@ -128,6 +134,11 @@ module CodingAdventures
           port = candidate unless candidate.nil? || candidate.empty?
         end
         port
+      end
+
+      def dispatch_protocol_frame(frame, native_session:)
+        response = dispatch_frame(frame)
+        [response, decode_response(native_session, response)]
       end
 
       private

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module BoardVM
+    class UnknownSessionCommandError < ArgumentError; end
+
+    class Session
+      DEFAULT_HOST_NAME = "ruby-board-vm"
+
+      attr_reader :connection, :native_session, :host_name, :host_nonce, :program_id,
+        :instruction_budget
+
+      def initialize(
+        connection,
+        native_session: Native::Session.new,
+        host_name: DEFAULT_HOST_NAME,
+        host_nonce: DEFAULT_HOST_NONCE,
+        program_id: DEFAULT_PROGRAM_ID,
+        instruction_budget: DEFAULT_INSTRUCTION_BUDGET
+      )
+        @connection = connection
+        @native_session = native_session
+        @host_name = host_name
+        @host_nonce = host_nonce
+        @program_id = program_id
+        @instruction_budget = instruction_budget
+      end
+
+      def hello(host_name: @host_name, host_nonce: @host_nonce)
+        dispatch(:hello, native_session.hello_wire(host_name, host_nonce))
+      end
+
+      def capabilities
+        dispatch(:capabilities, native_session.caps_query_wire)
+      end
+      alias caps capabilities
+
+      def upload(program_id: @program_id, module_bytes:)
+        SessionResult.new(results: [
+          dispatch(:program_begin, native_session.program_begin_wire(program_id, module_bytes)),
+          dispatch(:program_chunk, native_session.program_chunk_wire(program_id, 0, module_bytes)),
+          dispatch(:program_end, native_session.program_end_wire(program_id))
+        ])
+      end
+
+      def upload_blink(
+        program_id: @program_id,
+        pin: 13,
+        high_ms: 250,
+        low_ms: 250,
+        max_stack: 4
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: native_session.blink_module(pin, high_ms, low_ms, max_stack)
+        )
+      end
+
+      def run(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil
+      )
+        dispatch(
+          :run,
+          native_session.run_background_wire(program_id, instruction_budget || budget)
+        )
+      end
+
+      def blink(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        pin: 13,
+        high_ms: 250,
+        low_ms: 250,
+        max_stack: 4,
+        handshake: false,
+        query_caps: false,
+        host_name: @host_name,
+        host_nonce: @host_nonce
+      )
+        results = []
+        results << hello(host_name: host_name, host_nonce: host_nonce) if handshake
+        results << capabilities if query_caps
+        results.concat(
+          upload_blink(
+            program_id: program_id,
+            pin: pin,
+            high_ms: high_ms,
+            low_ms: low_ms,
+            max_stack: max_stack
+          ).results
+        )
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget
+        )
+        SessionResult.new(results: results)
+      end
+
+      def run_command(line, **options)
+        words = line.to_s.split
+        command = words.shift
+        return SessionResult.new if command.nil?
+
+        case command
+        when "hello"
+          ensure_no_extra_arguments!(words, command)
+          SessionResult.new(results: [hello(**options)])
+        when "caps", "capabilities"
+          ensure_no_extra_arguments!(words, command)
+          SessionResult.new(results: [capabilities])
+        when "upload-blink"
+          ensure_no_extra_arguments!(words, command)
+          upload_blink(**options)
+        when "run"
+          SessionResult.new(results: [run(**options.merge(optional_budget(words, command)))])
+        when "blink"
+          blink(**options.merge(optional_budget(words, command)))
+        else
+          raise UnknownSessionCommandError, "unknown Board VM session command: #{command}"
+        end
+      end
+
+      private
+
+      def dispatch(command, frame)
+        response, decoded_response = connection.dispatch_protocol_frame(
+          frame,
+          native_session: native_session
+        )
+        ProtocolResult.new(
+          command: command,
+          frame: frame,
+          response: response,
+          decoded_response: decoded_response
+        )
+      end
+
+      def optional_budget(words, command)
+        return {} if words.empty?
+
+        value = words.shift
+        budget = begin
+          Integer(value, 10)
+        rescue ArgumentError
+          raise ArgumentError, "#{command} budget must be an integer: #{value}"
+        end
+        ensure_no_extra_arguments!(words, command)
+        {instruction_budget: budget}
+      end
+
+      def ensure_no_extra_arguments!(words, command)
+        return if words.empty?
+
+        raise ArgumentError, "#{command} got unexpected argument: #{words.first}"
+      end
+    end
+  end
+end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
@@ -5,7 +5,46 @@ require "rbconfig"
 
 module CodingAdventures
   module BoardVM
-    SessionResult = Struct.new(:frames, :responses, :decoded_responses, keyword_init: true)
+    ProtocolResult = Struct.new(
+      :command,
+      :frame,
+      :response,
+      :decoded_response,
+      keyword_init: true
+    ) do
+      def kind
+        decoded_response && decoded_response["kind"]
+      end
+
+      def error?
+        !!(decoded_response && decoded_response["error"])
+      end
+    end
+
+    SessionResult = Struct.new(
+      :results,
+      :frames,
+      :responses,
+      :decoded_responses,
+      keyword_init: true
+    ) do
+      def initialize(results: nil, frames: nil, responses: nil, decoded_responses: nil)
+        results ||= []
+        frames ||= results.map(&:frame)
+        responses ||= results.map(&:response)
+        decoded_responses ||= results.map(&:decoded_response)
+        super(
+          results: results,
+          frames: frames,
+          responses: responses,
+          decoded_responses: decoded_responses
+        )
+      end
+
+      def error?
+        results.any?(&:error?)
+      end
+    end
 
     class TransportError < StandardError; end
 

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -82,6 +82,53 @@ module CodingAdventures
         assert_equal transport.frames, result.frames
         assert_equal Array.new(6), result.responses
         assert_equal Array.new(6), result.decoded_responses
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          result.results.map(&:command)
+      end
+
+      def test_session_surface_dispatches_protocol_commands_with_native_frames
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          board.session do |session|
+            hello = session.hello(host_nonce: 99)
+            caps = session.capabilities
+            upload = session.upload_blink(program_id: 4)
+            run = session.run(program_id: 4, budget: 77)
+
+            assert_equal :hello, hello.command
+            assert_equal :capabilities, caps.command
+            assert_equal [:program_begin, :program_chunk, :program_end], upload.results.map(&:command)
+            assert_equal :run, run.command
+          end
+        end
+
+        assert_empty runner.calls
+        assert_equal 6, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+      end
+
+      def test_session_run_command_accepts_repl_style_blink
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("blink 24", program_id: 8)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal result.frames, transport.frames
+        end
       end
 
       def test_native_session_builds_protocol_bytes_in_rust

--- a/code/packages/ruby/board_vm/test/test_helper.rb
+++ b/code/packages/ruby/board_vm/test/test_helper.rb
@@ -28,3 +28,19 @@ class FakeWriteTransport
     @frames << frame
   end
 end
+
+class FakeTransactTransport
+  attr_reader :frames, :timeout_values
+
+  def initialize(responses = [])
+    @responses = responses
+    @frames = []
+    @timeout_values = []
+  end
+
+  def transact(frame, timeout_ms:)
+    @frames << frame
+    @timeout_values << timeout_ms
+    @responses.shift
+  end
+end


### PR DESCRIPTION
## Summary

- add a Ruby BoardVM::Session wrapper that exposes hello/capabilities/upload/run/blink command sugar over Native::Session
- keep frame construction and response decoding in the Rust native bridge while returning ProtocolResult/SessionResult objects
- document REPL-style Ruby command usage and add tests for command dispatch paths

## Tests

- rake test
- cargo test -p board-vm-language-core
