### PR TITLE
[codex] Add smart-home primitive crates

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -519,4 +519,9 @@ members = [
     "twig-lsp-bridge",
     "twig-dap",
     "conduit",
+    "smart-home-core",
+    "hue-core",
+    "zigbee-nwk",
+    "zwave-core",
+    "sixlowpan",
 ]

--- a/code/packages/rust/hue-core/BUILD
+++ b/code/packages/rust/hue-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p hue-core -- --nocapture

--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-06
+
+### Added
+
+- Hue CLIP v2 resource type/id/path primitives.
+- Structured Hue command intents for light, grouped-light, color-temperature,
+  and scene requests.
+- Mapping helpers from discovered Hue bridge/device/light records into
+  `smart-home-core`.

--- a/code/packages/rust/hue-core/Cargo.toml
+++ b/code/packages/rust/hue-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hue-core"
+version = "0.1.0"
+edition = "2021"
+description = "Philips Hue CLIP v2 resource and mapping primitives for the smart-home runtime"
+license = "MIT"
+
+[dependencies]
+smart-home-core = { path = "../smart-home-core" }

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -1,0 +1,24 @@
+# hue-core
+
+Philips Hue CLIP v2 resource and mapping primitives for the smart-home runtime.
+
+This crate contains no network I/O. It gives later Hue client and integration
+packages a typed surface for:
+
+- Hue resource kinds and ids
+- CLIP v2 resource paths
+- event stream path constants
+- structured Hue command intents
+- discovery-to-`Bridge` projection
+- Hue light/device-to-normalized-model projection
+- integration descriptor metadata for Chief of Staff discovery
+
+## Dependencies
+
+- `smart-home-core`
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -1,0 +1,502 @@
+//! Philips Hue CLIP v2 resource and mapping primitives.
+//!
+//! This crate deliberately has no network I/O. It owns Hue resource names,
+//! endpoint paths, structured command intents, and projection into
+//! `smart-home-core`. A later `hue-client` crate can attach HTTPS, TLS policy,
+//! Vault-leased application keys, and event-stream transport.
+
+#![forbid(unsafe_code)]
+
+use smart_home_core::{
+    Bridge, BridgeId, BridgeTransport, Capability, Device, DeviceId, Entity, EntityId, EntityKind,
+    Health, IntegrationDescriptor, IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier,
+    RuntimeKind, StateConfidence, StateSnapshot, StateSource, Value,
+};
+use std::fmt;
+
+pub const HUE_INTEGRATION_ID: &str = "hue";
+pub const CLIP_V2_RESOURCE_ROOT: &str = "/clip/v2/resource";
+pub const CLIP_V2_EVENT_STREAM_PATH: &str = "/eventstream/clip/v2";
+pub const HUE_APPLICATION_KEY_HEADER: &str = "hue-application-key";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HueError {
+    EmptyResourceId,
+    UnsupportedCommandTarget { resource_type: HueResourceType },
+    InvalidBrightness { value: u16 },
+}
+
+impl fmt::Display for HueError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyResourceId => write!(f, "Hue resource id must not be empty"),
+            Self::UnsupportedCommandTarget { resource_type } => {
+                write!(f, "Hue command target {resource_type:?} is not supported")
+            }
+            Self::InvalidBrightness { value } => {
+                write!(f, "Hue brightness {value} is outside 0..=100")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HueError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HueResourceId(String);
+
+impl HueResourceId {
+    pub fn new(value: impl Into<String>) -> Result<Self, HueError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(HueError::EmptyResourceId);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn trusted(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for HueResourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HueResourceType {
+    Bridge,
+    Device,
+    Light,
+    GroupedLight,
+    Room,
+    Zone,
+    Scene,
+    Motion,
+    Button,
+    SmartScene,
+    Unknown(String),
+}
+
+impl HueResourceType {
+    pub fn from_hue_type(value: &str) -> Self {
+        match value {
+            "bridge" => Self::Bridge,
+            "device" => Self::Device,
+            "light" => Self::Light,
+            "grouped_light" => Self::GroupedLight,
+            "room" => Self::Room,
+            "zone" => Self::Zone,
+            "scene" => Self::Scene,
+            "motion" | "motion_sensor" => Self::Motion,
+            "button" => Self::Button,
+            "smart_scene" => Self::SmartScene,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+
+    pub fn as_hue_type(&self) -> &str {
+        match self {
+            Self::Bridge => "bridge",
+            Self::Device => "device",
+            Self::Light => "light",
+            Self::GroupedLight => "grouped_light",
+            Self::Room => "room",
+            Self::Zone => "zone",
+            Self::Scene => "scene",
+            Self::Motion => "motion",
+            Self::Button => "button",
+            Self::SmartScene => "smart_scene",
+            Self::Unknown(value) => value.as_str(),
+        }
+    }
+
+    pub fn maps_to_entity_kind(&self) -> Option<EntityKind> {
+        match self {
+            Self::Light => Some(EntityKind::Light),
+            Self::GroupedLight => Some(EntityKind::LightGroup),
+            Self::Scene | Self::SmartScene => Some(EntityKind::Scene),
+            Self::Motion => Some(EntityKind::Sensor),
+            Self::Button => Some(EntityKind::Input),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HueResourceRef {
+    pub resource_type: HueResourceType,
+    pub id: HueResourceId,
+}
+
+impl HueResourceRef {
+    pub fn new(resource_type: HueResourceType, id: HueResourceId) -> Self {
+        Self { resource_type, id }
+    }
+
+    pub fn collection_path(resource_type: &HueResourceType) -> String {
+        format!("{CLIP_V2_RESOURCE_ROOT}/{}", resource_type.as_hue_type())
+    }
+
+    pub fn path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            CLIP_V2_RESOURCE_ROOT,
+            self.resource_type.as_hue_type(),
+            self.id
+        )
+    }
+
+    pub fn protocol_identifier(&self) -> ProtocolIdentifier {
+        ProtocolIdentifier::new(
+            ProtocolFamily::Hue,
+            self.resource_type.as_hue_type(),
+            self.id.as_str(),
+        )
+        .expect("Hue resource refs are constructed with non-empty resource ids")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HueMethod {
+    Get,
+    Post,
+    Put,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HueRequestBody {
+    RegisterApplication {
+        app_name: String,
+        instance_name: String,
+    },
+    SetOn {
+        on: bool,
+    },
+    SetBrightness {
+        brightness: u8,
+    },
+    SetColorTemperature {
+        mirek: u16,
+    },
+    RecallScene,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HueRequest {
+    pub method: HueMethod,
+    pub path: String,
+    pub body: Option<HueRequestBody>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HueCommand {
+    SetLightOn {
+        light_id: HueResourceId,
+        on: bool,
+    },
+    SetGroupedLightOn {
+        grouped_light_id: HueResourceId,
+        on: bool,
+    },
+    SetLightBrightness {
+        light_id: HueResourceId,
+        brightness: u8,
+    },
+    SetGroupedLightBrightness {
+        grouped_light_id: HueResourceId,
+        brightness: u8,
+    },
+    SetLightColorTemperature {
+        light_id: HueResourceId,
+        mirek: u16,
+    },
+    RecallScene {
+        scene_id: HueResourceId,
+    },
+}
+
+impl HueCommand {
+    pub fn to_request(&self) -> HueRequest {
+        match self {
+            Self::SetLightOn { light_id, on } => {
+                set_on_request(HueResourceType::Light, light_id, *on)
+            }
+            Self::SetGroupedLightOn {
+                grouped_light_id,
+                on,
+            } => set_on_request(HueResourceType::GroupedLight, grouped_light_id, *on),
+            Self::SetLightBrightness {
+                light_id,
+                brightness,
+            } => set_brightness_request(HueResourceType::Light, light_id, *brightness),
+            Self::SetGroupedLightBrightness {
+                grouped_light_id,
+                brightness,
+            } => {
+                set_brightness_request(HueResourceType::GroupedLight, grouped_light_id, *brightness)
+            }
+            Self::SetLightColorTemperature { light_id, mirek } => HueRequest {
+                method: HueMethod::Put,
+                path: HueResourceRef::new(HueResourceType::Light, light_id.clone()).path(),
+                body: Some(HueRequestBody::SetColorTemperature { mirek: *mirek }),
+            },
+            Self::RecallScene { scene_id } => HueRequest {
+                method: HueMethod::Put,
+                path: HueResourceRef::new(HueResourceType::Scene, scene_id.clone()).path(),
+                body: Some(HueRequestBody::RecallScene),
+            },
+        }
+    }
+}
+
+fn set_on_request(resource_type: HueResourceType, id: &HueResourceId, on: bool) -> HueRequest {
+    HueRequest {
+        method: HueMethod::Put,
+        path: HueResourceRef::new(resource_type, id.clone()).path(),
+        body: Some(HueRequestBody::SetOn { on }),
+    }
+}
+
+fn set_brightness_request(
+    resource_type: HueResourceType,
+    id: &HueResourceId,
+    brightness: u8,
+) -> HueRequest {
+    HueRequest {
+        method: HueMethod::Put,
+        path: HueResourceRef::new(resource_type, id.clone()).path(),
+        body: Some(HueRequestBody::SetBrightness { brightness }),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredHueBridge {
+    pub bridge_id: String,
+    pub address: String,
+    pub hardware_model: Option<String>,
+    pub firmware_version: Option<String>,
+}
+
+pub fn hue_integration_descriptor() -> IntegrationDescriptor {
+    IntegrationDescriptor {
+        integration_id: IntegrationId::trusted(HUE_INTEGRATION_ID),
+        display_name: "Philips Hue".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        runtime_kind: RuntimeKind::RustWorkerProcess,
+        capabilities: vec![
+            smart_home_core::CapabilityId::trusted("smart_home.read"),
+            smart_home_core::CapabilityId::trusted("smart_home.command.light"),
+            smart_home_core::CapabilityId::trusted("smart_home.pair"),
+        ],
+        discovery_roles: vec!["hue-bridge".to_string()],
+        pairing_roles: vec!["hue-bridge".to_string()],
+    }
+}
+
+pub fn discovered_bridge_to_core(discovered: DiscoveredHueBridge) -> Bridge {
+    let mut bridge = Bridge::new(
+        BridgeId::trusted(format!("hue.bridge.{}", discovered.bridge_id)),
+        IntegrationId::trusted(HUE_INTEGRATION_ID),
+        BridgeTransport::LanHttp,
+    );
+    bridge.address = Some(discovered.address);
+    bridge.hardware_model = discovered.hardware_model;
+    bridge.firmware_version = discovered.firmware_version;
+    bridge.health = Health::Unpaired;
+    bridge.identifiers.push(
+        ProtocolIdentifier::new(ProtocolFamily::Hue, "bridge", discovered.bridge_id)
+            .expect("discovered Hue bridge id is non-empty"),
+    );
+    bridge
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HueLightResource {
+    pub id: HueResourceId,
+    pub owner_device_id: HueResourceId,
+    pub name: String,
+    pub on: Option<bool>,
+    pub brightness: Option<u8>,
+    pub color_temperature_mirek: Option<u16>,
+}
+
+impl HueLightResource {
+    pub fn command_set_on(&self, on: bool) -> HueCommand {
+        HueCommand::SetLightOn {
+            light_id: self.id.clone(),
+            on,
+        }
+    }
+}
+
+pub fn hue_device_to_core(
+    bridge_id: &BridgeId,
+    hue_device_id: HueResourceId,
+    manufacturer: impl Into<String>,
+    model: impl Into<String>,
+    name: impl Into<String>,
+) -> Device {
+    Device {
+        device_id: DeviceId::trusted(format!("hue.device.{}.{}", bridge_id, hue_device_id)),
+        bridge_id: bridge_id.clone(),
+        manufacturer: manufacturer.into(),
+        model: model.into(),
+        name: name.into(),
+        serial: None,
+        firmware_version: None,
+        room_id: None,
+        entity_ids: Vec::new(),
+        identifiers: vec![
+            HueResourceRef::new(HueResourceType::Device, hue_device_id).protocol_identifier()
+        ],
+        health: Health::Online,
+        metadata: Vec::new(),
+    }
+}
+
+pub fn hue_light_to_entity(
+    bridge_id: &BridgeId,
+    device_id: DeviceId,
+    light: HueLightResource,
+    received_at_ms: u64,
+) -> Entity {
+    let entity_id = EntityId::trusted(format!("hue.light.{}.{}", bridge_id, light.id));
+    let mut capabilities = vec![Capability::light_on_off(), Capability::light_brightness()];
+    if light.color_temperature_mirek.is_some() {
+        capabilities.push(Capability::light_color_temperature());
+    }
+
+    let state = light.on.map(|on| StateSnapshot {
+        entity_id: entity_id.clone(),
+        value: Value::Object(vec![
+            ("on".to_string(), Value::Bool(on)),
+            (
+                "brightness".to_string(),
+                light
+                    .brightness
+                    .map(Value::Percentage)
+                    .unwrap_or(Value::Null),
+            ),
+        ]),
+        source: StateSource::Poll,
+        observed_at_ms: received_at_ms,
+        received_at_ms,
+        expires_at_ms: None,
+        confidence: StateConfidence::Confirmed,
+    });
+
+    Entity {
+        entity_id,
+        device_id,
+        kind: EntityKind::Light,
+        name: light.name,
+        capabilities,
+        state,
+        metadata: vec![
+            Metadata::new("hue.resource_type", "light"),
+            Metadata::new("hue.resource_id", light.id.as_str()),
+        ],
+    }
+}
+
+pub fn validate_brightness(value: u16) -> Result<u8, HueError> {
+    if value > 100 {
+        return Err(HueError::InvalidBrightness { value });
+    }
+    Ok(value as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_paths_match_clip_v2_shape() {
+        let light = HueResourceRef::new(HueResourceType::Light, HueResourceId::trusted("abc"));
+
+        assert_eq!(
+            HueResourceRef::collection_path(&HueResourceType::Light),
+            "/clip/v2/resource/light"
+        );
+        assert_eq!(light.path(), "/clip/v2/resource/light/abc");
+        assert_eq!(CLIP_V2_EVENT_STREAM_PATH, "/eventstream/clip/v2");
+    }
+
+    #[test]
+    fn commands_build_structured_requests() {
+        let command = HueCommand::SetLightBrightness {
+            light_id: HueResourceId::trusted("light-1"),
+            brightness: validate_brightness(70).unwrap(),
+        };
+
+        assert_eq!(
+            command.to_request(),
+            HueRequest {
+                method: HueMethod::Put,
+                path: "/clip/v2/resource/light/light-1".to_string(),
+                body: Some(HueRequestBody::SetBrightness { brightness: 70 }),
+            }
+        );
+    }
+
+    #[test]
+    fn discovered_bridge_projects_to_unpaired_core_bridge() {
+        let bridge = discovered_bridge_to_core(DiscoveredHueBridge {
+            bridge_id: "001788fffeabcdef".to_string(),
+            address: "https://192.0.2.10".to_string(),
+            hardware_model: Some("BSB002".to_string()),
+            firmware_version: None,
+        });
+
+        assert_eq!(bridge.integration_id, IntegrationId::trusted("hue"));
+        assert_eq!(bridge.health, Health::Unpaired);
+        assert_eq!(bridge.transport, BridgeTransport::LanHttp);
+        assert_eq!(bridge.identifiers[0].kind, "bridge");
+    }
+
+    #[test]
+    fn hue_light_maps_to_normalized_light_entity() {
+        let bridge_id = BridgeId::trusted("hue.bridge.001788");
+        let entity = hue_light_to_entity(
+            &bridge_id,
+            DeviceId::trusted("hue.device.1"),
+            HueLightResource {
+                id: HueResourceId::trusted("light-1"),
+                owner_device_id: HueResourceId::trusted("device-1"),
+                name: "Kitchen".to_string(),
+                on: Some(true),
+                brightness: Some(42),
+                color_temperature_mirek: Some(366),
+            },
+            1_000,
+        );
+
+        assert_eq!(entity.kind, EntityKind::Light);
+        assert!(entity
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id.as_str() == "light.color_temperature"));
+        assert_eq!(entity.metadata[1].value, "light-1");
+        assert_eq!(entity.state.unwrap().confidence, StateConfidence::Confirmed);
+    }
+
+    #[test]
+    fn hue_integration_declares_agent_facing_capabilities() {
+        let descriptor = hue_integration_descriptor();
+
+        assert_eq!(descriptor.integration_id, IntegrationId::trusted("hue"));
+        assert!(descriptor
+            .capabilities
+            .iter()
+            .any(|capability| capability.as_str() == "smart_home.command.light"));
+        assert_eq!(descriptor.discovery_roles, vec!["hue-bridge"]);
+    }
+}

--- a/code/packages/rust/sixlowpan/BUILD
+++ b/code/packages/rust/sixlowpan/BUILD
@@ -1,0 +1,1 @@
+cargo test -p sixlowpan -- --nocapture

--- a/code/packages/rust/sixlowpan/CHANGELOG.md
+++ b/code/packages/rust/sixlowpan/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-06
+
+### Added
+
+- 6LoWPAN dispatch classification for IPv6, HC1, IPHC, mesh, broadcast, and
+  fragmentation headers.
+- LOWPAN_IPHC first/second byte parsing plus fragment first/next header
+  parse/encode helpers.

--- a/code/packages/rust/sixlowpan/Cargo.toml
+++ b/code/packages/rust/sixlowpan/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sixlowpan"
+version = "0.1.0"
+edition = "2021"
+description = "6LoWPAN IPv6 adaptation primitives for Thread over IEEE 802.15.4"
+license = "MIT"
+
+[dependencies]
+ieee802154-core = { path = "../ieee802154-core" }

--- a/code/packages/rust/sixlowpan/README.md
+++ b/code/packages/rust/sixlowpan/README.md
@@ -1,0 +1,23 @@
+# sixlowpan
+
+6LoWPAN IPv6 adaptation primitives for Thread over IEEE 802.15.4.
+
+This crate starts D27 below Thread MLE:
+
+- dispatch byte classification
+- LOWPAN_IPHC first/second byte parsing
+- fragment first/next header parse and encode
+- low-level frame payload extraction
+
+It does not yet perform full IPv6 header decompression, UDP compression,
+fragment reassembly, MLE, commissioning, or border-router behavior.
+
+## Dependencies
+
+- `ieee802154-core`
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/sixlowpan/src/lib.rs
+++ b/code/packages/rust/sixlowpan/src/lib.rs
@@ -1,0 +1,320 @@
+//! 6LoWPAN adaptation primitives for Thread over IEEE 802.15.4.
+//!
+//! The first useful Thread foundation is not an MLE state machine. It is the
+//! small set of dispatch bytes, fragmentation headers, and IPHC header bits
+//! that let higher layers classify and replay captured packets deterministically.
+
+#![forbid(unsafe_code)]
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dispatch {
+    Ipv6,
+    LowpanHc1,
+    Iphc,
+    FragmentFirst,
+    FragmentNext,
+    Mesh,
+    Broadcast,
+    Unknown(u8),
+}
+
+impl Dispatch {
+    pub fn parse(byte: u8) -> Self {
+        match byte {
+            0x41 => Self::Ipv6,
+            0x42 => Self::LowpanHc1,
+            value if value & 0b1110_0000 == 0b0110_0000 => Self::Iphc,
+            value if value & 0b1111_1000 == 0b1100_0000 => Self::FragmentFirst,
+            value if value & 0b1111_1000 == 0b1110_0000 => Self::FragmentNext,
+            value if value & 0b1100_0000 == 0b1000_0000 => Self::Mesh,
+            value if value & 0b1111_0000 == 0b0101_0000 => Self::Broadcast,
+            other => Self::Unknown(other),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IphcTrafficClassFlowLabel {
+    Inline,
+    FlowLabelInline,
+    TrafficClassInline,
+    Elided,
+}
+
+impl IphcTrafficClassFlowLabel {
+    fn from_bits(bits: u8) -> Self {
+        match bits & 0b11 {
+            0 => Self::Inline,
+            1 => Self::FlowLabelInline,
+            2 => Self::TrafficClassInline,
+            _ => Self::Elided,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IphcHopLimit {
+    Inline,
+    One,
+    SixtyFour,
+    TwoHundredFiftyFive,
+}
+
+impl IphcHopLimit {
+    fn from_bits(bits: u8) -> Self {
+        match bits & 0b11 {
+            0 => Self::Inline,
+            1 => Self::One,
+            2 => Self::SixtyFour,
+            _ => Self::TwoHundredFiftyFive,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IphcAddressMode {
+    Inline128,
+    Compressed64,
+    Compressed16,
+    Elided,
+}
+
+impl IphcAddressMode {
+    fn from_bits(bits: u8) -> Self {
+        match bits & 0b11 {
+            0 => Self::Inline128,
+            1 => Self::Compressed64,
+            2 => Self::Compressed16,
+            _ => Self::Elided,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IphcEncoding {
+    pub traffic_class_flow_label: IphcTrafficClassFlowLabel,
+    pub next_header_compressed: bool,
+    pub hop_limit: IphcHopLimit,
+    pub context_identifier_extension: bool,
+    pub source_address_compression: bool,
+    pub source_address_mode: IphcAddressMode,
+    pub multicast_destination: bool,
+    pub destination_address_compression: bool,
+    pub destination_address_mode: IphcAddressMode,
+}
+
+impl IphcEncoding {
+    pub fn parse(first: u8, second: u8) -> Result<Self, SixlowpanError> {
+        if Dispatch::parse(first) != Dispatch::Iphc {
+            return Err(SixlowpanError::NotIphc(first));
+        }
+
+        Ok(Self {
+            traffic_class_flow_label: IphcTrafficClassFlowLabel::from_bits(first >> 3),
+            next_header_compressed: first & (1 << 2) != 0,
+            hop_limit: IphcHopLimit::from_bits(first),
+            context_identifier_extension: second & (1 << 7) != 0,
+            source_address_compression: second & (1 << 6) != 0,
+            source_address_mode: IphcAddressMode::from_bits(second >> 4),
+            multicast_destination: second & (1 << 3) != 0,
+            destination_address_compression: second & (1 << 2) != 0,
+            destination_address_mode: IphcAddressMode::from_bits(second),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FragmentKind {
+    First,
+    Next,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FragmentHeader {
+    pub kind: FragmentKind,
+    pub datagram_size: u16,
+    pub datagram_tag: u16,
+    pub datagram_offset: Option<u8>,
+}
+
+impl FragmentHeader {
+    pub fn first(datagram_size: u16, datagram_tag: u16) -> Result<Self, SixlowpanError> {
+        validate_datagram_size(datagram_size)?;
+        Ok(Self {
+            kind: FragmentKind::First,
+            datagram_size,
+            datagram_tag,
+            datagram_offset: None,
+        })
+    }
+
+    pub fn next(
+        datagram_size: u16,
+        datagram_tag: u16,
+        datagram_offset: u8,
+    ) -> Result<Self, SixlowpanError> {
+        validate_datagram_size(datagram_size)?;
+        Ok(Self {
+            kind: FragmentKind::Next,
+            datagram_size,
+            datagram_tag,
+            datagram_offset: Some(datagram_offset),
+        })
+    }
+
+    pub fn parse(bytes: &[u8]) -> Result<Self, SixlowpanError> {
+        if bytes.len() < 4 {
+            return Err(SixlowpanError::Truncated {
+                needed: 4,
+                remaining: bytes.len(),
+            });
+        }
+        let dispatch = Dispatch::parse(bytes[0]);
+        let datagram_size = (((bytes[0] & 0b0000_0111) as u16) << 8) | bytes[1] as u16;
+        let datagram_tag = u16::from_be_bytes([bytes[2], bytes[3]]);
+        match dispatch {
+            Dispatch::FragmentFirst => Self::first(datagram_size, datagram_tag),
+            Dispatch::FragmentNext => {
+                if bytes.len() < 5 {
+                    return Err(SixlowpanError::Truncated {
+                        needed: 5,
+                        remaining: bytes.len(),
+                    });
+                }
+                Self::next(datagram_size, datagram_tag, bytes[4])
+            }
+            _ => Err(SixlowpanError::NotFragment(bytes[0])),
+        }
+    }
+
+    pub fn encode(self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(match self.kind {
+            FragmentKind::First => 4,
+            FragmentKind::Next => 5,
+        });
+        let prefix = match self.kind {
+            FragmentKind::First => 0b1100_0000,
+            FragmentKind::Next => 0b1110_0000,
+        };
+        out.push(prefix | ((self.datagram_size >> 8) as u8 & 0b0000_0111));
+        out.push(self.datagram_size as u8);
+        out.extend_from_slice(&self.datagram_tag.to_be_bytes());
+        if let Some(offset) = self.datagram_offset {
+            out.push(offset);
+        }
+        out
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LowpanFrame {
+    pub dispatch: Dispatch,
+    pub payload: Vec<u8>,
+}
+
+impl LowpanFrame {
+    pub fn parse(bytes: &[u8]) -> Result<Self, SixlowpanError> {
+        let Some((&first, payload)) = bytes.split_first() else {
+            return Err(SixlowpanError::Truncated {
+                needed: 1,
+                remaining: 0,
+            });
+        };
+        Ok(Self {
+            dispatch: Dispatch::parse(first),
+            payload: payload.to_vec(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SixlowpanError {
+    Truncated { needed: usize, remaining: usize },
+    NotIphc(u8),
+    NotFragment(u8),
+    DatagramSizeTooLarge(u16),
+}
+
+impl fmt::Display for SixlowpanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated { needed, remaining } => write!(
+                f,
+                "truncated 6LoWPAN frame: needed {needed} bytes, had {remaining}"
+            ),
+            Self::NotIphc(value) => write!(f, "dispatch 0x{value:02x} is not LOWPAN_IPHC"),
+            Self::NotFragment(value) => {
+                write!(f, "dispatch 0x{value:02x} is not a 6LoWPAN fragment header")
+            }
+            Self::DatagramSizeTooLarge(value) => {
+                write!(f, "6LoWPAN datagram size {value} exceeds 11-bit field")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SixlowpanError {}
+
+fn validate_datagram_size(datagram_size: u16) -> Result<(), SixlowpanError> {
+    if datagram_size > 0x07ff {
+        return Err(SixlowpanError::DatagramSizeTooLarge(datagram_size));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_classifies_common_headers() {
+        assert_eq!(Dispatch::parse(0x41), Dispatch::Ipv6);
+        assert_eq!(Dispatch::parse(0x60), Dispatch::Iphc);
+        assert_eq!(Dispatch::parse(0xc2), Dispatch::FragmentFirst);
+        assert_eq!(Dispatch::parse(0xe2), Dispatch::FragmentNext);
+        assert_eq!(Dispatch::parse(0x80), Dispatch::Mesh);
+    }
+
+    #[test]
+    fn iphc_encoding_parses_first_two_header_bytes() {
+        let encoding = IphcEncoding::parse(0b0111_1110, 0b1111_1111).unwrap();
+
+        assert_eq!(
+            encoding.traffic_class_flow_label,
+            IphcTrafficClassFlowLabel::Elided
+        );
+        assert!(encoding.next_header_compressed);
+        assert_eq!(encoding.hop_limit, IphcHopLimit::SixtyFour);
+        assert!(encoding.context_identifier_extension);
+        assert_eq!(encoding.source_address_mode, IphcAddressMode::Elided);
+        assert!(encoding.multicast_destination);
+        assert_eq!(encoding.destination_address_mode, IphcAddressMode::Elided);
+    }
+
+    #[test]
+    fn fragment_headers_round_trip() {
+        let first = FragmentHeader::first(1_280, 0x3344).unwrap();
+        let next = FragmentHeader::next(1_280, 0x3344, 16).unwrap();
+
+        assert_eq!(FragmentHeader::parse(&first.encode()).unwrap(), first);
+        assert_eq!(FragmentHeader::parse(&next.encode()).unwrap(), next);
+    }
+
+    #[test]
+    fn fragment_size_is_limited_to_eleven_bits() {
+        assert_eq!(
+            FragmentHeader::first(0x0800, 1),
+            Err(SixlowpanError::DatagramSizeTooLarge(0x0800))
+        );
+    }
+
+    #[test]
+    fn lowpan_frame_keeps_payload_bytes() {
+        let frame = LowpanFrame::parse(&[0x41, 0xaa, 0xbb]).unwrap();
+
+        assert_eq!(frame.dispatch, Dispatch::Ipv6);
+        assert_eq!(frame.payload, vec![0xaa, 0xbb]);
+    }
+}

--- a/code/packages/rust/smart-home-core/BUILD
+++ b/code/packages/rust/smart-home-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-core -- --nocapture

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-06
+
+### Added
+
+- Normalized bridge, device, entity, capability, event, command, scene, and
+  state snapshot types for D23.
+- Protocol identifier records for Hue, Zigbee, Z-Wave, Thread, Matter, MQTT,
+  and vendor adapters.
+- D18D-style smart-home tool descriptors and command risk-tier helpers.

--- a/code/packages/rust/smart-home-core/Cargo.toml
+++ b/code/packages/rust/smart-home-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "smart-home-core"
+version = "0.1.0"
+edition = "2021"
+description = "Repository-owned normalized smart-home model shared by integrations, tools, and agents"
+license = "MIT"
+
+[dependencies]

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -1,0 +1,47 @@
+# smart-home-core
+
+Repository-owned normalized smart-home model shared by integrations, tools, and
+Chief of Staff agents.
+
+This crate is the D23 common vocabulary. Hue, Zigbee, Z-Wave, Thread, Matter,
+MQTT, and future adapters project into these same records:
+
+- `Bridge`
+- `Device`
+- `Entity`
+- `Capability`
+- `DeviceEvent`
+- `DeviceCommand`
+- `CommandResult`
+- `Scene`
+- `StateSnapshot`
+- `IntegrationDescriptor`
+- `SmartHomeTool` / `ToolDescriptor`
+
+Protocol-private identifiers stay in `ProtocolIdentifier` records rather than
+becoming repository-owned entity ids.
+
+## Scope
+
+Current scope:
+
+- normalized bridge/device/entity records
+- capability and value typing
+- immutable device events and command requests
+- command risk tier helpers
+- state freshness helpers
+- D18D-style smart-home tool descriptors
+
+Out of scope:
+
+- persistent registry storage
+- actor supervision
+- HTTP/serial/radio I/O
+- Vault leases
+- policy execution
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1,0 +1,747 @@
+//! Repository-owned smart-home vocabulary shared by integrations, tools, and
+//! Chief of Staff agents.
+//!
+//! The types in this crate are intentionally protocol-neutral. A Hue light,
+//! Zigbee endpoint, Z-Wave node value, Thread/Matter endpoint, or MQTT device
+//! can all be projected into the same bridge/device/entity/event/command model.
+
+#![forbid(unsafe_code)]
+
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmartHomeError {
+    EmptyIdentifier { kind: &'static str },
+    InvalidPercentage { value: u16 },
+    MissingCapability { command_type: CommandType },
+}
+
+impl fmt::Display for SmartHomeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyIdentifier { kind } => write!(f, "{kind} must not be empty"),
+            Self::InvalidPercentage { value } => {
+                write!(f, "percentage value {value} is outside 0..=100")
+            }
+            Self::MissingCapability { command_type } => {
+                write!(
+                    f,
+                    "no canonical capability for command type {command_type:?}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SmartHomeError {}
+
+macro_rules! id_type {
+    ($name:ident, $kind:literal) => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, SmartHomeError> {
+                let value = value.into();
+                if value.trim().is_empty() {
+                    return Err(SmartHomeError::EmptyIdentifier { kind: $kind });
+                }
+                Ok(Self(value))
+            }
+
+            pub fn trusted(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+id_type!(IntegrationId, "integration id");
+id_type!(BridgeId, "bridge id");
+id_type!(DeviceId, "device id");
+id_type!(EntityId, "entity id");
+id_type!(SceneId, "scene id");
+id_type!(CapabilityId, "capability id");
+id_type!(CommandId, "command id");
+id_type!(EventId, "event id");
+id_type!(CorrelationId, "correlation id");
+id_type!(VaultRef, "vault reference");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeKind {
+    InProcessRust,
+    RustWorkerProcess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeTransport {
+    LanHttp,
+    Mdns,
+    Serial,
+    Ble,
+    Cloud,
+    LocalProcess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Health {
+    Unknown,
+    Discoverable,
+    Unpaired,
+    Online,
+    Degraded,
+    Offline,
+    AuthFailed,
+    Unsupported,
+    Removed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntityKind {
+    Light,
+    LightGroup,
+    Switch,
+    Sensor,
+    Lock,
+    Thermostat,
+    Scene,
+    Input,
+    BridgeHealth,
+    NetworkDiagnostic,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityMode {
+    Observe,
+    Command,
+    ObserveAndCommand,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueKind {
+    Boolean,
+    Integer,
+    Number,
+    Percentage,
+    Text,
+    Object,
+    Array,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Null,
+    Bool(bool),
+    Integer(i64),
+    Number(f64),
+    Percentage(u8),
+    Text(String),
+    Object(Vec<(String, Value)>),
+    Array(Vec<Value>),
+}
+
+impl Value {
+    pub fn percentage(value: u16) -> Result<Self, SmartHomeError> {
+        if value > 100 {
+            return Err(SmartHomeError::InvalidPercentage { value });
+        }
+        Ok(Self::Percentage(value as u8))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Capability {
+    pub capability_id: CapabilityId,
+    pub mode: CapabilityMode,
+    pub value_kind: ValueKind,
+    pub unit: Option<String>,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+    pub step: Option<f64>,
+}
+
+impl Capability {
+    pub fn new(capability_id: CapabilityId, mode: CapabilityMode, value_kind: ValueKind) -> Self {
+        Self {
+            capability_id,
+            mode,
+            value_kind,
+            unit: None,
+            min: None,
+            max: None,
+            step: None,
+        }
+    }
+
+    pub fn with_range(mut self, min: f64, max: f64, step: Option<f64>) -> Self {
+        self.min = Some(min);
+        self.max = Some(max);
+        self.step = step;
+        self
+    }
+
+    pub fn light_on_off() -> Self {
+        Self::new(
+            CapabilityId::trusted("light.on_off"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Boolean,
+        )
+    }
+
+    pub fn light_brightness() -> Self {
+        Self::new(
+            CapabilityId::trusted("light.brightness"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Percentage,
+        )
+        .with_range(0.0, 100.0, Some(1.0))
+    }
+
+    pub fn light_color_temperature() -> Self {
+        let mut capability = Self::new(
+            CapabilityId::trusted("light.color_temperature"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Integer,
+        );
+        capability.unit = Some("mirek".to_string());
+        capability
+    }
+
+    pub fn sensor_occupancy() -> Self {
+        Self::new(
+            CapabilityId::trusted("sensor.occupancy"),
+            CapabilityMode::Observe,
+            ValueKind::Boolean,
+        )
+    }
+
+    pub fn input_button() -> Self {
+        Self::new(
+            CapabilityId::trusted("input.button"),
+            CapabilityMode::Observe,
+            ValueKind::Text,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProtocolFamily {
+    Hue,
+    Zigbee,
+    ZWave,
+    Thread,
+    Matter,
+    Mqtt,
+    Vendor(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolIdentifier {
+    pub family: ProtocolFamily,
+    pub kind: String,
+    pub value: String,
+}
+
+impl ProtocolIdentifier {
+    pub fn new(
+        family: ProtocolFamily,
+        kind: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Self, SmartHomeError> {
+        let kind = kind.into();
+        if kind.trim().is_empty() {
+            return Err(SmartHomeError::EmptyIdentifier {
+                kind: "protocol identifier kind",
+            });
+        }
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(SmartHomeError::EmptyIdentifier {
+                kind: "protocol identifier value",
+            });
+        }
+        Ok(Self {
+            family,
+            kind,
+            value,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Metadata {
+    pub key: String,
+    pub value: String,
+}
+
+impl Metadata {
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationDescriptor {
+    pub integration_id: IntegrationId,
+    pub display_name: String,
+    pub version: String,
+    pub runtime_kind: RuntimeKind,
+    pub capabilities: Vec<CapabilityId>,
+    pub discovery_roles: Vec<String>,
+    pub pairing_roles: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Bridge {
+    pub bridge_id: BridgeId,
+    pub integration_id: IntegrationId,
+    pub transport: BridgeTransport,
+    pub address: Option<String>,
+    pub hardware_model: Option<String>,
+    pub firmware_version: Option<String>,
+    pub auth_ref: Option<VaultRef>,
+    pub health: Health,
+    pub last_seen_at_ms: Option<u64>,
+    pub identifiers: Vec<ProtocolIdentifier>,
+    pub metadata: Vec<Metadata>,
+}
+
+impl Bridge {
+    pub fn new(
+        bridge_id: BridgeId,
+        integration_id: IntegrationId,
+        transport: BridgeTransport,
+    ) -> Self {
+        Self {
+            bridge_id,
+            integration_id,
+            transport,
+            address: None,
+            hardware_model: None,
+            firmware_version: None,
+            auth_ref: None,
+            health: Health::Unknown,
+            last_seen_at_ms: None,
+            identifiers: Vec::new(),
+            metadata: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Device {
+    pub device_id: DeviceId,
+    pub bridge_id: BridgeId,
+    pub manufacturer: String,
+    pub model: String,
+    pub name: String,
+    pub serial: Option<String>,
+    pub firmware_version: Option<String>,
+    pub room_id: Option<String>,
+    pub entity_ids: Vec<EntityId>,
+    pub identifiers: Vec<ProtocolIdentifier>,
+    pub health: Health,
+    pub metadata: Vec<Metadata>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Entity {
+    pub entity_id: EntityId,
+    pub device_id: DeviceId,
+    pub kind: EntityKind,
+    pub name: String,
+    pub capabilities: Vec<Capability>,
+    pub state: Option<StateSnapshot>,
+    pub metadata: Vec<Metadata>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateSource {
+    EventStream,
+    Poll,
+    OptimisticCommand,
+    Manual,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateConfidence {
+    Confirmed,
+    Optimistic,
+    Stale,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateSnapshot {
+    pub entity_id: EntityId,
+    pub value: Value,
+    pub source: StateSource,
+    pub observed_at_ms: u64,
+    pub received_at_ms: u64,
+    pub expires_at_ms: Option<u64>,
+    pub confidence: StateConfidence,
+}
+
+impl StateSnapshot {
+    pub fn is_stale_at(&self, now_ms: u64) -> bool {
+        self.confidence == StateConfidence::Stale
+            || self.expires_at_ms.is_some_and(|expires| now_ms >= expires)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceEventType {
+    Discovered,
+    Updated,
+    Removed,
+    Unavailable,
+    Error,
+    Health,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateDelta {
+    pub capability_id: CapabilityId,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeviceEvent {
+    pub event_id: EventId,
+    pub bridge_id: BridgeId,
+    pub device_id: Option<DeviceId>,
+    pub entity_id: Option<EntityId>,
+    pub observed_at_ms: u64,
+    pub received_at_ms: u64,
+    pub event_type: DeviceEventType,
+    pub state_delta: Option<StateDelta>,
+    pub raw_ref: Option<String>,
+    pub correlation_id: Option<CorrelationId>,
+    pub metadata: Vec<Metadata>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandType {
+    TurnOn,
+    TurnOff,
+    SetBrightness,
+    SetColor,
+    SetColorTemperature,
+    RecallScene,
+    SetLock,
+    SetThermostatSetpoint,
+}
+
+impl CommandType {
+    pub fn canonical_capability_id(self) -> Option<CapabilityId> {
+        match self {
+            Self::TurnOn | Self::TurnOff => Some(CapabilityId::trusted("light.on_off")),
+            Self::SetBrightness => Some(CapabilityId::trusted("light.brightness")),
+            Self::SetColor => Some(CapabilityId::trusted("light.color")),
+            Self::SetColorTemperature => Some(CapabilityId::trusted("light.color_temperature")),
+            Self::RecallScene => Some(CapabilityId::trusted("scene.recall")),
+            Self::SetLock => Some(CapabilityId::trusted("lock.state")),
+            Self::SetThermostatSetpoint => Some(CapabilityId::trusted("climate.setpoint")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivilegeTier {
+    ReadOnly,
+    LowRisk,
+    HumanApproval,
+    HighRisk,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeviceCommand {
+    pub command_id: CommandId,
+    pub entity_id: EntityId,
+    pub command_type: CommandType,
+    pub arguments: Value,
+    pub requested_by: String,
+    pub idempotency_key: Option<String>,
+    pub required_tier: PrivilegeTier,
+    pub required_capabilities: Vec<CapabilityId>,
+    pub timeout_ms: u64,
+    pub correlation_id: CorrelationId,
+}
+
+impl DeviceCommand {
+    pub fn new(
+        command_id: CommandId,
+        entity_id: EntityId,
+        command_type: CommandType,
+        arguments: Value,
+        requested_by: impl Into<String>,
+        correlation_id: CorrelationId,
+    ) -> Result<Self, SmartHomeError> {
+        let capability = command_type
+            .canonical_capability_id()
+            .ok_or(SmartHomeError::MissingCapability { command_type })?;
+        Ok(Self {
+            command_id,
+            entity_id,
+            command_type,
+            arguments,
+            requested_by: requested_by.into(),
+            idempotency_key: None,
+            required_tier: tier_for_command(command_type),
+            required_capabilities: vec![capability],
+            timeout_ms: 5_000,
+            correlation_id,
+        })
+    }
+}
+
+pub fn tier_for_command(command_type: CommandType) -> PrivilegeTier {
+    match command_type {
+        CommandType::SetLock => PrivilegeTier::HighRisk,
+        CommandType::SetThermostatSetpoint => PrivilegeTier::HumanApproval,
+        CommandType::TurnOn
+        | CommandType::TurnOff
+        | CommandType::SetBrightness
+        | CommandType::SetColor
+        | CommandType::SetColorTemperature
+        | CommandType::RecallScene => PrivilegeTier::LowRisk,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandStatus {
+    Accepted,
+    Rejected,
+    TimedOut,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandResult {
+    pub command_id: CommandId,
+    pub status: CommandStatus,
+    pub bridge_id: BridgeId,
+    pub correlation_id: CorrelationId,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SceneScope {
+    Room,
+    Zone,
+    Home,
+    Bridge,
+    Custom,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SceneAction {
+    pub entity_id: EntityId,
+    pub desired_state: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Scene {
+    pub scene_id: SceneId,
+    pub scope: SceneScope,
+    pub native_ref: Option<ProtocolIdentifier>,
+    pub actions: Vec<SceneAction>,
+    pub metadata: Vec<Metadata>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolSideEffects {
+    None,
+    Read,
+    Write,
+    External,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolDescriptor {
+    pub tool_id: &'static str,
+    pub side_effects: ToolSideEffects,
+    pub required_capabilities: Vec<CapabilityId>,
+    pub required_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmartHomeTool {
+    Discover,
+    PairBridge,
+    ListBridges,
+    ListDevices,
+    GetState,
+    Command,
+    Subscribe,
+    DescribeCapabilities,
+    GetHealth,
+}
+
+impl SmartHomeTool {
+    pub fn descriptor(self) -> ToolDescriptor {
+        match self {
+            Self::Discover => ToolDescriptor {
+                tool_id: "smart_home.discover",
+                side_effects: ToolSideEffects::Read,
+                required_capabilities: vec![CapabilityId::trusted("smart_home.read")],
+                required_tier: PrivilegeTier::ReadOnly,
+            },
+            Self::PairBridge => ToolDescriptor {
+                tool_id: "smart_home.pair_bridge",
+                side_effects: ToolSideEffects::External,
+                required_capabilities: vec![CapabilityId::trusted("smart_home.pair")],
+                required_tier: PrivilegeTier::HumanApproval,
+            },
+            Self::ListBridges => read_tool("smart_home.list_bridges"),
+            Self::ListDevices => read_tool("smart_home.list_devices"),
+            Self::GetState => read_tool("smart_home.get_state"),
+            Self::Command => ToolDescriptor {
+                tool_id: "smart_home.command",
+                side_effects: ToolSideEffects::External,
+                required_capabilities: vec![CapabilityId::trusted("smart_home.command.light")],
+                required_tier: PrivilegeTier::LowRisk,
+            },
+            Self::Subscribe => read_tool("smart_home.subscribe"),
+            Self::DescribeCapabilities => read_tool("smart_home.describe_capabilities"),
+            Self::GetHealth => read_tool("smart_home.get_health"),
+        }
+    }
+}
+
+pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
+    [
+        SmartHomeTool::Discover,
+        SmartHomeTool::PairBridge,
+        SmartHomeTool::ListBridges,
+        SmartHomeTool::ListDevices,
+        SmartHomeTool::GetState,
+        SmartHomeTool::Command,
+        SmartHomeTool::Subscribe,
+        SmartHomeTool::DescribeCapabilities,
+        SmartHomeTool::GetHealth,
+    ]
+    .into_iter()
+    .map(SmartHomeTool::descriptor)
+    .collect()
+}
+
+fn read_tool(tool_id: &'static str) -> ToolDescriptor {
+    ToolDescriptor {
+        tool_id,
+        side_effects: ToolSideEffects::Read,
+        required_capabilities: vec![CapabilityId::trusted("smart_home.read")],
+        required_tier: PrivilegeTier::ReadOnly,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_reject_empty_values() {
+        assert_eq!(
+            BridgeId::new("   "),
+            Err(SmartHomeError::EmptyIdentifier { kind: "bridge id" })
+        );
+        assert_eq!(
+            EntityId::new("light.kitchen").unwrap().as_str(),
+            "light.kitchen"
+        );
+    }
+
+    #[test]
+    fn protocol_identifiers_keep_native_ids_out_of_entity_ids() {
+        let hue = ProtocolIdentifier::new(
+            ProtocolFamily::Hue,
+            "light",
+            "25a6d2a2-5f19-452e-a944-9d0b75fb3b2d",
+        )
+        .unwrap();
+        let zigbee =
+            ProtocolIdentifier::new(ProtocolFamily::Zigbee, "ieee_address", "0x00124b0024c8abcd")
+                .unwrap();
+
+        assert_ne!(hue.family, zigbee.family);
+        assert_eq!(hue.kind, "light");
+        assert_eq!(zigbee.kind, "ieee_address");
+    }
+
+    #[test]
+    fn command_constructor_sets_policy_shape() {
+        let command = DeviceCommand::new(
+            CommandId::trusted("cmd-1"),
+            EntityId::trusted("entity.light.kitchen"),
+            CommandType::SetBrightness,
+            Value::percentage(42).unwrap(),
+            "agent:lighting-planner",
+            CorrelationId::trusted("corr-1"),
+        )
+        .unwrap();
+
+        assert_eq!(command.required_tier, PrivilegeTier::LowRisk);
+        assert_eq!(
+            command.required_capabilities,
+            vec![CapabilityId::trusted("light.brightness")]
+        );
+    }
+
+    #[test]
+    fn high_risk_commands_are_tiered_differently() {
+        assert_eq!(
+            tier_for_command(CommandType::SetLock),
+            PrivilegeTier::HighRisk
+        );
+        assert_eq!(
+            tier_for_command(CommandType::SetThermostatSetpoint),
+            PrivilegeTier::HumanApproval
+        );
+    }
+
+    #[test]
+    fn state_snapshot_knows_staleness() {
+        let snapshot = StateSnapshot {
+            entity_id: EntityId::trusted("entity.light.kitchen"),
+            value: Value::Bool(true),
+            source: StateSource::OptimisticCommand,
+            observed_at_ms: 1_000,
+            received_at_ms: 1_001,
+            expires_at_ms: Some(2_000),
+            confidence: StateConfidence::Optimistic,
+        };
+
+        assert!(!snapshot.is_stale_at(1_999));
+        assert!(snapshot.is_stale_at(2_000));
+    }
+
+    #[test]
+    fn tool_catalog_exposes_model_facing_smart_home_surface() {
+        let catalog = smart_home_tool_catalog();
+        let command = catalog
+            .iter()
+            .find(|tool| tool.tool_id == "smart_home.command")
+            .unwrap();
+
+        assert_eq!(catalog.len(), 9);
+        assert_eq!(command.side_effects, ToolSideEffects::External);
+        assert_eq!(
+            command.required_capabilities,
+            vec![CapabilityId::trusted("smart_home.command.light")]
+        );
+    }
+}

--- a/code/packages/rust/zigbee-nwk/BUILD
+++ b/code/packages/rust/zigbee-nwk/BUILD
@@ -1,0 +1,1 @@
+cargo test -p zigbee-nwk -- --nocapture

--- a/code/packages/rust/zigbee-nwk/CHANGELOG.md
+++ b/code/packages/rust/zigbee-nwk/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-06
+
+### Added
+
+- Zigbee NWK address and frame-control primitives.
+- NWK frame parser/encoder for base headers, optional IEEE addresses,
+  multicast control, radius, sequence, and payload bytes.

--- a/code/packages/rust/zigbee-nwk/Cargo.toml
+++ b/code/packages/rust/zigbee-nwk/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zigbee-nwk"
+version = "0.1.0"
+edition = "2021"
+description = "Zigbee network-layer frame and address primitives built above IEEE 802.15.4"
+license = "MIT"
+
+[dependencies]
+ieee802154-core = { path = "../ieee802154-core" }

--- a/code/packages/rust/zigbee-nwk/README.md
+++ b/code/packages/rust/zigbee-nwk/README.md
@@ -1,0 +1,26 @@
+# zigbee-nwk
+
+Zigbee network-layer frame and address primitives built above IEEE 802.15.4.
+
+This crate starts D25 at the NWK byte boundary:
+
+- 16-bit network addresses
+- extended IEEE addresses
+- NWK frame-control fields
+- radius and sequence fields
+- optional extended source/destination addresses
+- optional multicast control byte
+- payload extraction and round-trip encoding
+
+It intentionally does not implement APS, ZDO, ZCL, route discovery state,
+joining, security policy, or coordinator behavior yet.
+
+## Dependencies
+
+- `ieee802154-core`
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/zigbee-nwk/src/lib.rs
+++ b/code/packages/rust/zigbee-nwk/src/lib.rs
@@ -1,0 +1,419 @@
+//! Zigbee network-layer primitives built above IEEE 802.15.4.
+//!
+//! This crate starts with the NWK byte boundary: network addresses, frame
+//! control bits, optional extended addresses, radius/sequence fields, and
+//! payload extraction. Joining, routing tables, APS, ZDO, and ZCL live in later
+//! crates.
+
+#![forbid(unsafe_code)]
+
+use std::fmt;
+
+const NWK_FRAME_CONTROL_LEN: usize = 2;
+const NWK_ADDR_LEN: usize = 2;
+const IEEE_ADDR_LEN: usize = 8;
+const NWK_BASE_HEADER_LEN: usize = NWK_FRAME_CONTROL_LEN + (NWK_ADDR_LEN * 2) + 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NetworkAddress(pub u16);
+
+impl NetworkAddress {
+    pub const COORDINATOR: Self = Self(0x0000);
+    pub const BROADCAST_ALL_DEVICES: Self = Self(0xffff);
+    pub const BROADCAST_RX_ON_WHEN_IDLE: Self = Self(0xfffd);
+
+    pub fn is_broadcast(self) -> bool {
+        self.0 >= 0xfff8
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct IeeeAddress(pub u64);
+
+impl IeeeAddress {
+    pub fn to_le_bytes(self) -> [u8; IEEE_ADDR_LEN] {
+        self.0.to_le_bytes()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NwkFrameType {
+    Data,
+    Command,
+    InterPan,
+    Reserved,
+}
+
+impl NwkFrameType {
+    fn from_bits(bits: u16) -> Self {
+        match bits & 0b11 {
+            0 => Self::Data,
+            1 => Self::Command,
+            3 => Self::InterPan,
+            _ => Self::Reserved,
+        }
+    }
+
+    fn bits(self) -> u16 {
+        match self {
+            Self::Data => 0,
+            Self::Command => 1,
+            Self::Reserved => 2,
+            Self::InterPan => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscoverRoute {
+    Suppress,
+    Enable,
+    Force,
+    Reserved,
+}
+
+impl DiscoverRoute {
+    fn from_bits(bits: u16) -> Self {
+        match bits & 0b11 {
+            0 => Self::Suppress,
+            1 => Self::Enable,
+            2 => Self::Force,
+            _ => Self::Reserved,
+        }
+    }
+
+    fn bits(self) -> u16 {
+        match self {
+            Self::Suppress => 0,
+            Self::Enable => 1,
+            Self::Force => 2,
+            Self::Reserved => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NwkFrameControl {
+    pub frame_type: NwkFrameType,
+    pub protocol_version: u8,
+    pub discover_route: DiscoverRoute,
+    pub multicast: bool,
+    pub security: bool,
+    pub source_route: bool,
+    pub extended_destination: bool,
+    pub extended_source: bool,
+    pub end_device_initiator: bool,
+}
+
+impl NwkFrameControl {
+    pub fn parse(raw: u16) -> Self {
+        Self {
+            frame_type: NwkFrameType::from_bits(raw),
+            protocol_version: ((raw >> 2) & 0b1111) as u8,
+            discover_route: DiscoverRoute::from_bits(raw >> 6),
+            multicast: raw & (1 << 8) != 0,
+            security: raw & (1 << 9) != 0,
+            source_route: raw & (1 << 10) != 0,
+            extended_destination: raw & (1 << 11) != 0,
+            extended_source: raw & (1 << 12) != 0,
+            end_device_initiator: raw & (1 << 13) != 0,
+        }
+    }
+
+    pub fn encode(self) -> u16 {
+        let mut raw = self.frame_type.bits();
+        raw |= ((self.protocol_version as u16) & 0b1111) << 2;
+        raw |= self.discover_route.bits() << 6;
+        raw |= (self.multicast as u16) << 8;
+        raw |= (self.security as u16) << 9;
+        raw |= (self.source_route as u16) << 10;
+        raw |= (self.extended_destination as u16) << 11;
+        raw |= (self.extended_source as u16) << 12;
+        raw |= (self.end_device_initiator as u16) << 13;
+        raw
+    }
+
+    pub fn zigbee_pro_2007(frame_type: NwkFrameType) -> Self {
+        Self {
+            frame_type,
+            protocol_version: 2,
+            discover_route: DiscoverRoute::Suppress,
+            multicast: false,
+            security: false,
+            source_route: false,
+            extended_destination: false,
+            extended_source: false,
+            end_device_initiator: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NwkFrame {
+    pub frame_control: NwkFrameControl,
+    pub destination: NetworkAddress,
+    pub source: NetworkAddress,
+    pub radius: u8,
+    pub sequence_number: u8,
+    pub destination_ieee: Option<IeeeAddress>,
+    pub source_ieee: Option<IeeeAddress>,
+    pub multicast_control: Option<u8>,
+    pub payload: Vec<u8>,
+}
+
+impl NwkFrame {
+    pub fn parse(bytes: &[u8]) -> Result<Self, NwkError> {
+        if bytes.len() < NWK_BASE_HEADER_LEN {
+            return Err(NwkError::Truncated {
+                needed: NWK_BASE_HEADER_LEN,
+                remaining: bytes.len(),
+            });
+        }
+
+        let mut cursor = Cursor::new(bytes);
+        let frame_control = NwkFrameControl::parse(cursor.read_u16_le()?);
+        let destination = NetworkAddress(cursor.read_u16_le()?);
+        let source = NetworkAddress(cursor.read_u16_le()?);
+        let radius = cursor.read_u8()?;
+        let sequence_number = cursor.read_u8()?;
+
+        let destination_ieee = if frame_control.extended_destination {
+            Some(IeeeAddress(cursor.read_u64_le()?))
+        } else {
+            None
+        };
+        let source_ieee = if frame_control.extended_source {
+            Some(IeeeAddress(cursor.read_u64_le()?))
+        } else {
+            None
+        };
+        let multicast_control = if frame_control.multicast {
+            Some(cursor.read_u8()?)
+        } else {
+            None
+        };
+        let payload = cursor.remaining_bytes().to_vec();
+
+        Ok(Self {
+            frame_control,
+            destination,
+            source,
+            radius,
+            sequence_number,
+            destination_ieee,
+            source_ieee,
+            multicast_control,
+            payload,
+        })
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, NwkError> {
+        if self.frame_control.extended_destination != self.destination_ieee.is_some() {
+            return Err(NwkError::ExtendedAddressMismatch {
+                field: "destination",
+            });
+        }
+        if self.frame_control.extended_source != self.source_ieee.is_some() {
+            return Err(NwkError::ExtendedAddressMismatch { field: "source" });
+        }
+        if self.frame_control.multicast != self.multicast_control.is_some() {
+            return Err(NwkError::MulticastControlMismatch);
+        }
+
+        let mut out = Vec::with_capacity(NWK_BASE_HEADER_LEN + self.payload.len());
+        out.extend_from_slice(&self.frame_control.encode().to_le_bytes());
+        out.extend_from_slice(&self.destination.0.to_le_bytes());
+        out.extend_from_slice(&self.source.0.to_le_bytes());
+        out.push(self.radius);
+        out.push(self.sequence_number);
+        if let Some(address) = self.destination_ieee {
+            out.extend_from_slice(&address.to_le_bytes());
+        }
+        if let Some(address) = self.source_ieee {
+            out.extend_from_slice(&address.to_le_bytes());
+        }
+        if let Some(multicast_control) = self.multicast_control {
+            out.push(multicast_control);
+        }
+        out.extend_from_slice(&self.payload);
+        Ok(out)
+    }
+
+    pub fn plain_data(
+        destination: NetworkAddress,
+        source: NetworkAddress,
+        radius: u8,
+        sequence_number: u8,
+        payload: Vec<u8>,
+    ) -> Self {
+        Self {
+            frame_control: NwkFrameControl::zigbee_pro_2007(NwkFrameType::Data),
+            destination,
+            source,
+            radius,
+            sequence_number,
+            destination_ieee: None,
+            source_ieee: None,
+            multicast_control: None,
+            payload,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NwkError {
+    Truncated { needed: usize, remaining: usize },
+    ExtendedAddressMismatch { field: &'static str },
+    MulticastControlMismatch,
+}
+
+impl fmt::Display for NwkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated { needed, remaining } => write!(
+                f,
+                "truncated Zigbee NWK frame: needed {needed} bytes, had {remaining}"
+            ),
+            Self::ExtendedAddressMismatch { field } => {
+                write!(
+                    f,
+                    "extended {field} address flag does not match address field"
+                )
+            }
+            Self::MulticastControlMismatch => {
+                write!(f, "multicast flag does not match multicast control field")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NwkError {}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn read_u8(&mut self) -> Result<u8, NwkError> {
+        if self.pos >= self.bytes.len() {
+            return Err(NwkError::Truncated {
+                needed: 1,
+                remaining: 0,
+            });
+        }
+        let value = self.bytes[self.pos];
+        self.pos += 1;
+        Ok(value)
+    }
+
+    fn read_u16_le(&mut self) -> Result<u16, NwkError> {
+        let bytes = self.read_array::<2>()?;
+        Ok(u16::from_le_bytes(bytes))
+    }
+
+    fn read_u64_le(&mut self) -> Result<u64, NwkError> {
+        let bytes = self.read_array::<8>()?;
+        Ok(u64::from_le_bytes(bytes))
+    }
+
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], NwkError> {
+        let remaining = self.bytes.len().saturating_sub(self.pos);
+        if remaining < N {
+            return Err(NwkError::Truncated {
+                needed: N,
+                remaining,
+            });
+        }
+        let mut out = [0u8; N];
+        out.copy_from_slice(&self.bytes[self.pos..self.pos + N]);
+        self.pos += N;
+        Ok(out)
+    }
+
+    fn remaining_bytes(&self) -> &'a [u8] {
+        &self.bytes[self.pos..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_control_round_trips() {
+        let control = NwkFrameControl {
+            frame_type: NwkFrameType::Command,
+            protocol_version: 2,
+            discover_route: DiscoverRoute::Enable,
+            multicast: true,
+            security: true,
+            source_route: false,
+            extended_destination: true,
+            extended_source: true,
+            end_device_initiator: false,
+        };
+
+        assert_eq!(NwkFrameControl::parse(control.encode()), control);
+    }
+
+    #[test]
+    fn plain_data_frame_round_trips() {
+        let frame = NwkFrame::plain_data(
+            NetworkAddress(0x1234),
+            NetworkAddress(0x0000),
+            30,
+            7,
+            vec![0x01, 0x02, 0x03],
+        );
+        let encoded = frame.encode().unwrap();
+
+        assert_eq!(NwkFrame::parse(&encoded).unwrap(), frame);
+    }
+
+    #[test]
+    fn extended_addresses_are_parsed_when_flags_are_set() {
+        let mut control = NwkFrameControl::zigbee_pro_2007(NwkFrameType::Data);
+        control.extended_destination = true;
+        control.extended_source = true;
+        let frame = NwkFrame {
+            frame_control: control,
+            destination: NetworkAddress(0xfffc),
+            source: NetworkAddress(0x3344),
+            radius: 10,
+            sequence_number: 9,
+            destination_ieee: Some(IeeeAddress(0x8877_6655_4433_2211)),
+            source_ieee: Some(IeeeAddress(0x1100_ffee_ddcc_bbaa)),
+            multicast_control: None,
+            payload: vec![0xaa],
+        };
+
+        let parsed = NwkFrame::parse(&frame.encode().unwrap()).unwrap();
+
+        assert_eq!(parsed.destination_ieee, frame.destination_ieee);
+        assert_eq!(parsed.source_ieee, frame.source_ieee);
+        assert_eq!(parsed.payload, vec![0xaa]);
+    }
+
+    #[test]
+    fn rejects_extended_flag_without_address() {
+        let mut frame =
+            NwkFrame::plain_data(NetworkAddress(1), NetworkAddress(2), 1, 1, Vec::new());
+        frame.frame_control.extended_source = true;
+
+        assert_eq!(
+            frame.encode(),
+            Err(NwkError::ExtendedAddressMismatch { field: "source" })
+        );
+    }
+
+    #[test]
+    fn broadcast_addresses_are_identified() {
+        assert!(NetworkAddress::BROADCAST_ALL_DEVICES.is_broadcast());
+        assert!(!NetworkAddress(0x1234).is_broadcast());
+    }
+}

--- a/code/packages/rust/zwave-core/BUILD
+++ b/code/packages/rust/zwave-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p zwave-core -- --nocapture

--- a/code/packages/rust/zwave-core/CHANGELOG.md
+++ b/code/packages/rust/zwave-core/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-06
+
+### Added
+
+- Z-Wave Home ID, classic node id, Long Range node id, region profile, and
+  command-class id primitives.
+- Serial API frame parser/encoder with SOF and checksum validation.

--- a/code/packages/rust/zwave-core/Cargo.toml
+++ b/code/packages/rust/zwave-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "zwave-core"
+version = "0.1.0"
+edition = "2021"
+description = "Z-Wave identifier, region, and serial-frame primitives for the smart-home runtime"
+license = "MIT"
+
+[dependencies]

--- a/code/packages/rust/zwave-core/README.md
+++ b/code/packages/rust/zwave-core/README.md
@@ -1,0 +1,28 @@
+# zwave-core
+
+Z-Wave identifier, region, and Serial API frame primitives for the smart-home
+runtime.
+
+Current scope:
+
+- Home ID and classic/Long Range node id models
+- region profile metadata
+- common command-class ids
+- Serial API SOF/ACK/NAK/CAN constants
+- Serial API request/response frame parse and encode
+- checksum validation
+
+Out of scope:
+
+- controller request/callback correlation
+- inclusion/exclusion
+- S0/S2 security
+- node interview
+- command-class semantics
+- Long Range topology behavior
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/zwave-core/src/lib.rs
+++ b/code/packages/rust/zwave-core/src/lib.rs
@@ -1,0 +1,303 @@
+//! Z-Wave identifier, region, and Serial API frame primitives.
+//!
+//! This crate does not try to be a controller yet. It gives later Z-Wave
+//! packages a tested byte boundary for controller serial frames, node identity,
+//! command class ids, and regional profile metadata.
+
+#![forbid(unsafe_code)]
+
+use std::fmt;
+
+pub const SOF: u8 = 0x01;
+pub const ACK: u8 = 0x06;
+pub const NAK: u8 = 0x15;
+pub const CAN: u8 = 0x18;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HomeId(pub u32);
+
+impl HomeId {
+    pub fn to_be_bytes(self) -> [u8; 4] {
+        self.0.to_be_bytes()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NodeId {
+    Classic(u8),
+    LongRange(u16),
+}
+
+impl NodeId {
+    pub fn classic(value: u8) -> Result<Self, ZWaveError> {
+        if value == 0 || value > 232 {
+            return Err(ZWaveError::InvalidClassicNodeId(value));
+        }
+        Ok(Self::Classic(value))
+    }
+
+    pub fn long_range(value: u16) -> Result<Self, ZWaveError> {
+        if !(1..=4_000).contains(&value) {
+            return Err(ZWaveError::InvalidLongRangeNodeId(value));
+        }
+        Ok(Self::LongRange(value))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionProfile {
+    Europe,
+    UnitedStates,
+    AustraliaNewZealand,
+    HongKong,
+    India,
+    Israel,
+    Russia,
+    China,
+    Japan,
+    Korea,
+    UnitedStatesLongRange,
+    EuropeLongRange,
+}
+
+impl RegionProfile {
+    pub fn band_description(self) -> &'static str {
+        match self {
+            Self::Europe => "EU sub-GHz",
+            Self::UnitedStates => "US sub-GHz",
+            Self::AustraliaNewZealand => "ANZ sub-GHz",
+            Self::HongKong => "Hong Kong sub-GHz",
+            Self::India => "India sub-GHz",
+            Self::Israel => "Israel sub-GHz",
+            Self::Russia => "Russia sub-GHz",
+            Self::China => "China sub-GHz",
+            Self::Japan => "Japan sub-GHz",
+            Self::Korea => "Korea sub-GHz",
+            Self::UnitedStatesLongRange => "US Z-Wave Long Range",
+            Self::EuropeLongRange => "EU Z-Wave Long Range",
+        }
+    }
+
+    pub fn supports_long_range(self) -> bool {
+        matches!(self, Self::UnitedStatesLongRange | Self::EuropeLongRange)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CommandClassId(pub u16);
+
+impl CommandClassId {
+    pub const BASIC: Self = Self(0x20);
+    pub const SWITCH_BINARY: Self = Self(0x25);
+    pub const SWITCH_MULTILEVEL: Self = Self(0x26);
+    pub const SENSOR_BINARY: Self = Self(0x30);
+    pub const SENSOR_MULTILEVEL: Self = Self(0x31);
+    pub const DOOR_LOCK: Self = Self(0x62);
+    pub const SECURITY_2: Self = Self(0x9f);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SerialFrameType {
+    Request,
+    Response,
+}
+
+impl SerialFrameType {
+    fn from_byte(byte: u8) -> Result<Self, ZWaveError> {
+        match byte {
+            0x00 => Ok(Self::Request),
+            0x01 => Ok(Self::Response),
+            other => Err(ZWaveError::InvalidFrameType(other)),
+        }
+    }
+
+    fn as_byte(self) -> u8 {
+        match self {
+            Self::Request => 0x00,
+            Self::Response => 0x01,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SerialFrame {
+    pub frame_type: SerialFrameType,
+    pub function_id: u8,
+    pub payload: Vec<u8>,
+}
+
+impl SerialFrame {
+    pub fn new(frame_type: SerialFrameType, function_id: u8, payload: Vec<u8>) -> Self {
+        Self {
+            frame_type,
+            function_id,
+            payload,
+        }
+    }
+
+    pub fn parse(bytes: &[u8]) -> Result<Self, ZWaveError> {
+        if bytes.len() < 5 {
+            return Err(ZWaveError::Truncated {
+                needed: 5,
+                remaining: bytes.len(),
+            });
+        }
+        if bytes[0] != SOF {
+            return Err(ZWaveError::MissingStartOfFrame(bytes[0]));
+        }
+
+        let len = bytes[1] as usize;
+        if len < 3 {
+            return Err(ZWaveError::InvalidLength(len));
+        }
+        let frame_len = len + 2;
+        if bytes.len() < frame_len {
+            return Err(ZWaveError::Truncated {
+                needed: frame_len,
+                remaining: bytes.len(),
+            });
+        }
+
+        let checksum = bytes[frame_len - 1];
+        let checksum_input = &bytes[1..frame_len - 1];
+        let expected = serial_checksum(checksum_input);
+        if checksum != expected {
+            return Err(ZWaveError::ChecksumMismatch {
+                expected,
+                actual: checksum,
+            });
+        }
+
+        let frame_type = SerialFrameType::from_byte(bytes[2])?;
+        let function_id = bytes[3];
+        let payload = bytes[4..frame_len - 1].to_vec();
+
+        Ok(Self {
+            frame_type,
+            function_id,
+            payload,
+        })
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ZWaveError> {
+        let len = self
+            .payload
+            .len()
+            .checked_add(3)
+            .ok_or(ZWaveError::PayloadTooLong(self.payload.len()))?;
+        if len > u8::MAX as usize {
+            return Err(ZWaveError::PayloadTooLong(self.payload.len()));
+        }
+
+        let mut out = Vec::with_capacity(len + 2);
+        out.push(SOF);
+        out.push(len as u8);
+        out.push(self.frame_type.as_byte());
+        out.push(self.function_id);
+        out.extend_from_slice(&self.payload);
+        let checksum = serial_checksum(&out[1..]);
+        out.push(checksum);
+        Ok(out)
+    }
+}
+
+pub fn serial_checksum(bytes_after_sof_before_checksum: &[u8]) -> u8 {
+    bytes_after_sof_before_checksum
+        .iter()
+        .fold(0xff, |acc, byte| acc ^ byte)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZWaveError {
+    InvalidClassicNodeId(u8),
+    InvalidLongRangeNodeId(u16),
+    MissingStartOfFrame(u8),
+    InvalidLength(usize),
+    InvalidFrameType(u8),
+    Truncated { needed: usize, remaining: usize },
+    PayloadTooLong(usize),
+    ChecksumMismatch { expected: u8, actual: u8 },
+}
+
+impl fmt::Display for ZWaveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidClassicNodeId(value) => {
+                write!(f, "invalid classic Z-Wave node id {value}")
+            }
+            Self::InvalidLongRangeNodeId(value) => {
+                write!(f, "invalid Z-Wave Long Range node id {value}")
+            }
+            Self::MissingStartOfFrame(value) => {
+                write!(f, "expected Z-Wave SOF 0x01, got 0x{value:02x}")
+            }
+            Self::InvalidLength(value) => write!(f, "invalid Z-Wave frame length {value}"),
+            Self::InvalidFrameType(value) => write!(f, "invalid Z-Wave frame type 0x{value:02x}"),
+            Self::Truncated { needed, remaining } => write!(
+                f,
+                "truncated Z-Wave frame: needed {needed} bytes, had {remaining}"
+            ),
+            Self::PayloadTooLong(len) => write!(f, "Z-Wave serial payload too long: {len}"),
+            Self::ChecksumMismatch { expected, actual } => write!(
+                f,
+                "Z-Wave checksum mismatch: expected 0x{expected:02x}, got 0x{actual:02x}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ZWaveError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_node_id_ranges() {
+        assert_eq!(NodeId::classic(1).unwrap(), NodeId::Classic(1));
+        assert_eq!(NodeId::classic(0), Err(ZWaveError::InvalidClassicNodeId(0)));
+        assert_eq!(NodeId::long_range(4_000).unwrap(), NodeId::LongRange(4_000));
+        assert_eq!(
+            NodeId::long_range(4_001),
+            Err(ZWaveError::InvalidLongRangeNodeId(4_001))
+        );
+    }
+
+    #[test]
+    fn serial_frame_round_trips_with_checksum() {
+        let frame = SerialFrame::new(SerialFrameType::Request, 0x13, vec![0x02, 0x25, 0x01]);
+        let encoded = frame.encode().unwrap();
+
+        assert_eq!(encoded[0], SOF);
+        assert_eq!(SerialFrame::parse(&encoded).unwrap(), frame);
+    }
+
+    #[test]
+    fn checksum_mismatch_is_rejected() {
+        let frame = SerialFrame::new(SerialFrameType::Response, 0x02, vec![0x01, 0x02]);
+        let mut encoded = frame.encode().unwrap();
+        let checksum_index = encoded.len() - 1;
+        encoded[checksum_index] ^= 0x01;
+
+        assert!(matches!(
+            SerialFrame::parse(&encoded),
+            Err(ZWaveError::ChecksumMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn region_profiles_mark_long_range_explicitly() {
+        assert!(!RegionProfile::UnitedStates.supports_long_range());
+        assert!(RegionProfile::UnitedStatesLongRange.supports_long_range());
+        assert_eq!(
+            RegionProfile::EuropeLongRange.band_description(),
+            "EU Z-Wave Long Range"
+        );
+    }
+
+    #[test]
+    fn common_command_class_ids_are_stable() {
+        assert_eq!(CommandClassId::SWITCH_BINARY.0, 0x25);
+        assert_eq!(CommandClassId::SECURITY_2.0, 0x9f);
+    }
+}

--- a/code/specs/D23-smart-home-runtime.md
+++ b/code/specs/D23-smart-home-runtime.md
@@ -727,6 +727,10 @@ Repository-owned types:
 
 No protocol dependencies.
 
+**Initial Rust implementation:** `code/packages/rust/smart-home-core` now owns
+the normalized D23 data model plus D18D-style smart-home tool descriptors. It is
+pure data and performs no I/O.
+
 ### `smart-home-registry`
 
 Durable storage for bridge/device/entity identity and protocol mapping tables.
@@ -752,6 +756,11 @@ Reusable discovery helpers:
 ### `hue-core`
 
 Hue-specific types and mapping code. No network I/O.
+
+**Initial Rust implementation:** `code/packages/rust/hue-core` now owns CLIP v2
+resource/id/path primitives, structured Hue command intents, and bridge/device/
+light projection into `smart-home-core`. HTTPS, TLS policy, Vault leases, and
+event-stream transport remain for `hue-client` and `hue-integration`.
 
 ### `hue-client`
 

--- a/code/specs/D25-zigbee-stack.md
+++ b/code/specs/D25-zigbee-stack.md
@@ -81,6 +81,12 @@ ieee802154-*     MAC/PHY foundation from D24
 - neighbor and route tables
 - join/leave state machines
 
+**Initial Rust implementation:** `code/packages/rust/zigbee-nwk` now provides
+the first NWK byte-boundary primitives: network addresses, frame-control bits,
+radius/sequence fields, optional IEEE source/destination addresses, multicast
+control, and payload round-tripping. Routing, joins, security, APS, ZDO, and
+ZCL remain future packages/layers.
+
 ### `zigbee-aps`
 
 - endpoint addressing

--- a/code/specs/D26-zwave-stack.md
+++ b/code/specs/D26-zwave-stack.md
@@ -66,6 +66,12 @@ integrations, learning tools.
 - regional profile metadata
 - parse errors
 
+**Initial Rust implementation:** `code/packages/rust/zwave-core` now provides
+Home ID, classic node id, Long Range node id, region profile, command-class id,
+and Serial API frame parse/encode primitives with checksum validation. The
+controller state machine, inclusion, callbacks, command classes, and S2 remain
+future layers.
+
 ### `zwave-serial-api`
 
 - serial framing

--- a/code/specs/D27-thread-stack.md
+++ b/code/specs/D27-thread-stack.md
@@ -80,6 +80,12 @@ ieee802154-*      MAC/PHY foundation from D24
 - mesh addressing helpers
 - UDP compression
 
+**Initial Rust implementation:** `code/packages/rust/sixlowpan` now provides
+dispatch-byte classification, LOWPAN_IPHC first/second byte parsing, and
+fragment first/next header parse/encode helpers. Full IPv6/UDP decompression,
+reassembly, MLE, commissioning, and border-router behavior remain future
+layers.
+
 ### `thread-mle`
 
 - roles and neighbor state


### PR DESCRIPTION
## Summary

Adds the first Rust implementation layer for the smart-home and Chief of Staff agent-facing stack described in D23-D27.

New crates:

- `smart-home-core`: normalized bridge/device/entity/capability/event/command/state model plus D18D-style smart-home tool descriptors
- `hue-core`: Philips Hue CLIP v2 resource/path primitives, structured command intents, and Hue-to-normalized-model mapping
- `zigbee-nwk`: starter Zigbee network-layer frame/address parse and encode primitives
- `zwave-core`: Z-Wave IDs, region profiles, command class IDs, and Serial API frame parse/encode with checksum validation
- `sixlowpan`: 6LoWPAN dispatch, IPHC header bits, and fragmentation header primitives for Thread groundwork

The D23, D25, D26, and D27 specs are updated with the initial implementation status.

## Impact

This gives the smart-home runtime a shared Rust vocabulary before any bridge, radio, serial, HTTPS, Vault, or actor runtime I/O is added. Hue, Zigbee, Z-Wave, Thread, and future Matter/MQTT integrations can now project into common Chief of Staff-friendly entities, commands, events, and tool descriptors.

## Validation

- `cargo test -p smart-home-core -p hue-core -p zigbee-nwk -p zwave-core -p sixlowpan -p ieee802154-core -p ieee802154-security`
