### PR TITLE
[codex] Expose Board VM capabilities in Ruby

### DIFF
--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -83,6 +83,23 @@ bytes, and optional Rust-decoded response hash. The text command parser is Ruby
 sugar only; every dispatched frame still comes from
 `CodingAdventures::BoardVM::Native::Session`.
 
+Capability reports can be lifted into Ruby objects after Rust decodes the board
+response:
+
+```ruby
+CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
+  descriptor = board.capabilities
+  descriptor.supports?("gpio.write")
+  descriptor.bytecode_capabilities.map(&:name)
+  descriptor.protocol_features.map(&:name)
+end
+```
+
+The descriptor exposes board/runtime ids, VM limits, store-program support, and
+capability groups such as `gpio`, `time`, and `program`. Capability flag names
+and booleans are supplied by the Rust language core, keeping Ruby out of the
+protocol-bit interpretation business.
+
 The DSL also exposes the current board-agnostic blink ejection path:
 
 ```ruby

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -6,9 +6,10 @@ use board_vm_host::{BlinkProgram, BLINK_MODULE_LEN};
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
     build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
-    build_run_background_wire_frame, decode_wire_response, program_format_name, run_status_name,
-    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageCoreError,
+    build_run_background_wire_frame, capability_board_metadata, capability_bytecode_callable,
+    capability_flag_names, capability_protocol_feature, decode_wire_response, program_format_name,
+    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse,
+    DecodedLanguageResponseBody, LanguageCoreError,
 };
 use ruby_bridge::VALUE;
 
@@ -302,6 +303,22 @@ fn response_body_to_rb(body: &DecodedLanguageResponseBody, payload_len: usize) -
                 hash_set(item, "version", rb_usize(capability.version));
                 hash_set(item, "flags", rb_usize(capability.flags));
                 hash_set(item, "name", ruby_bridge::str_to_rb(&capability.name));
+                hash_set(
+                    item,
+                    "bytecode_callable",
+                    ruby_bridge::bool_to_rb(capability_bytecode_callable(capability.flags)),
+                );
+                hash_set(
+                    item,
+                    "protocol_feature",
+                    ruby_bridge::bool_to_rb(capability_protocol_feature(capability.flags)),
+                );
+                hash_set(
+                    item,
+                    "board_metadata",
+                    ruby_bridge::bool_to_rb(capability_board_metadata(capability.flags)),
+                );
+                hash_set(item, "flag_names", capability_flag_names_to_rb(capability.flags));
                 ruby_bridge::array_push(capabilities, item);
             }
             hash_set(hash, "capabilities", capabilities);
@@ -354,6 +371,16 @@ fn response_body_to_rb(body: &DecodedLanguageResponseBody, payload_len: usize) -
         }
     }
     hash
+}
+
+fn capability_flag_names_to_rb(flags: u16) -> VALUE {
+    let mut names = [""; 3];
+    let count = capability_flag_names(flags, &mut names);
+    let array = ruby_bridge::array_new();
+    for name in &names[..count] {
+        ruby_bridge::array_push(array, ruby_bridge::str_to_rb(name));
+    }
+    array
 }
 
 fn message_type_name(code: u8) -> &'static str {

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "board_vm/version"
+require_relative "board_vm/capabilities"
 require_relative "board_vm/command_runner"
 require_relative "board_vm/native"
 require_relative "board_vm/transport"

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/capabilities.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/capabilities.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module BoardVM
+    class Capability
+      attr_reader :id, :version, :flags, :name, :flag_names, :raw
+
+      def initialize(raw)
+        @raw = raw
+        @id = raw.fetch("id")
+        @version = raw.fetch("version")
+        @flags = raw.fetch("flags")
+        @name = raw.fetch("name")
+        @flag_names = Array(raw["flag_names"]).freeze
+      end
+
+      def bytecode_callable?
+        bool_or_flag?("bytecode_callable")
+      end
+
+      def protocol_feature?
+        bool_or_flag?("protocol_feature")
+      end
+
+      def board_metadata?
+        bool_or_flag?("board_metadata")
+      end
+
+      private
+
+      def bool_or_flag?(name)
+        raw[name] == true || flag_names.include?(name)
+      end
+    end
+
+    class BoardDescriptor
+      attr_reader :board_id, :runtime_id, :max_program_bytes, :max_stack_values,
+        :max_handles, :supports_store_program, :capabilities, :raw
+
+      def self.from_decoded_response(decoded_response)
+        return nil unless decoded_response && decoded_response["kind"] == "caps_report"
+
+        new(decoded_response.fetch("payload"))
+      end
+
+      def initialize(raw)
+        @raw = raw
+        @board_id = raw.fetch("board_id")
+        @runtime_id = raw.fetch("runtime_id")
+        @max_program_bytes = raw.fetch("max_program_bytes")
+        @max_stack_values = raw.fetch("max_stack_values")
+        @max_handles = raw.fetch("max_handles")
+        @supports_store_program = raw.fetch("supports_store_program")
+        @capabilities = Array(raw.fetch("capabilities")).map { |capability| Capability.new(capability) }.freeze
+      end
+
+      def supports?(name_or_id)
+        !!capability(name_or_id)
+      end
+
+      def capability(name_or_id)
+        if name_or_id.is_a?(Integer)
+          capabilities.find { |capability| capability.id == name_or_id }
+        else
+          wanted = name_or_id.to_s
+          capabilities.find { |capability| capability.name == wanted }
+        end
+      end
+      alias [] capability
+
+      def capability_names
+        capabilities.map(&:name)
+      end
+
+      def bytecode_capabilities
+        capabilities.select(&:bytecode_callable?)
+      end
+
+      def protocol_features
+        capabilities.select(&:protocol_feature?)
+      end
+
+      def board_metadata
+        capabilities.select(&:board_metadata?)
+      end
+
+      def gpio
+        capabilities.select { |capability| capability.name.start_with?("gpio.") }
+      end
+
+      def time
+        capabilities.select { |capability| capability.name.start_with?("time.") }
+      end
+
+      def program
+        capabilities.select { |capability| capability.name.start_with?("program.") }
+      end
+
+      def store_program?
+        supports_store_program || supports?("program.store")
+      end
+    end
+  end
+end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -64,6 +64,10 @@ module CodingAdventures
         Ejector.new(self)
       end
 
+      def capabilities
+        session.board_descriptor
+      end
+
       def session(**options)
         protocol_session = Session.new(self, **options)
         return protocol_session unless block_given?

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -35,6 +35,11 @@ module CodingAdventures
       end
       alias caps capabilities
 
+      def board_descriptor
+        capabilities.board_descriptor
+      end
+      alias describe board_descriptor
+
       def upload(program_id: @program_id, module_bytes:)
         SessionResult.new(results: [
           dispatch(:program_begin, native_session.program_begin_wire(program_id, module_bytes)),

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
@@ -16,6 +16,14 @@ module CodingAdventures
         decoded_response && decoded_response["kind"]
       end
 
+      def payload
+        decoded_response && decoded_response["payload"]
+      end
+
+      def board_descriptor
+        BoardDescriptor.from_decoded_response(decoded_response)
+      end
+
       def error?
         !!(decoded_response && decoded_response["error"])
       end
@@ -43,6 +51,14 @@ module CodingAdventures
 
       def error?
         results.any?(&:error?)
+      end
+
+      def board_descriptor
+        results.each do |result|
+          descriptor = result.board_descriptor
+          return descriptor if descriptor
+        end
+        nil
       end
     end
 

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -131,6 +131,55 @@ module CodingAdventures
         end
       end
 
+      def test_board_descriptor_wraps_rust_decoded_capability_report
+        decoded = {
+          "kind" => "caps_report",
+          "payload" => {
+            "board_id" => "arduino-uno-r4-wifi",
+            "runtime_id" => "board-vm-uno-r4",
+            "max_program_bytes" => 1024,
+            "max_stack_values" => 16,
+            "max_handles" => 4,
+            "supports_store_program" => false,
+            "capabilities" => [
+              {
+                "id" => 1,
+                "version" => 1,
+                "flags" => 1,
+                "name" => "gpio.open",
+                "bytecode_callable" => true,
+                "protocol_feature" => false,
+                "board_metadata" => false,
+                "flag_names" => ["bytecode_callable"]
+              },
+              {
+                "id" => 0x7001,
+                "version" => 1,
+                "flags" => 2,
+                "name" => "program.ram_exec",
+                "bytecode_callable" => false,
+                "protocol_feature" => true,
+                "board_metadata" => false,
+                "flag_names" => ["protocol_feature"]
+              }
+            ]
+          }
+        }
+
+        descriptor = ProtocolResult.new(decoded_response: decoded).board_descriptor
+
+        assert_equal "arduino-uno-r4-wifi", descriptor.board_id
+        assert_equal "board-vm-uno-r4", descriptor.runtime_id
+        assert_equal ["gpio.open", "program.ram_exec"], descriptor.capability_names
+        assert descriptor.supports?("gpio.open")
+        assert descriptor.supports?(0x7001)
+        assert descriptor["gpio.open"].bytecode_callable?
+        assert descriptor["program.ram_exec"].protocol_feature?
+        refute descriptor.store_program?
+        assert_equal ["gpio.open"], descriptor.gpio.map(&:name)
+        assert_equal ["program.ram_exec"], descriptor.program.map(&:name)
+      end
+
       def test_native_session_builds_protocol_bytes_in_rust
         session = BoardVM::Native::Session.new
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -20,7 +20,8 @@ use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
     decode_program_begin, decode_program_chunk, decode_program_end, decode_run_report_header,
     decode_wire_frame, encode_wire_frame, Frame, MessageType, ProgramFormat, ProtocolError,
-    RunStatus, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
+    RunStatus, CAP_FLAG_BOARD_METADATA, CAP_FLAG_BYTECODE_CALLABLE, CAP_FLAG_PROTOCOL_FEATURE,
+    FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
 };
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
@@ -273,6 +274,41 @@ pub const fn run_status_name(status: RunStatus) -> &'static str {
         RunStatus::Stopped => "stopped",
         RunStatus::BudgetExceeded => "budget_exceeded",
         RunStatus::Faulted => "faulted",
+    }
+}
+
+pub const fn capability_bytecode_callable(flags: u16) -> bool {
+    flags & CAP_FLAG_BYTECODE_CALLABLE != 0
+}
+
+pub const fn capability_protocol_feature(flags: u16) -> bool {
+    flags & CAP_FLAG_PROTOCOL_FEATURE != 0
+}
+
+pub const fn capability_board_metadata(flags: u16) -> bool {
+    flags & CAP_FLAG_BOARD_METADATA != 0
+}
+
+pub fn capability_flag_names(flags: u16, out: &mut [&'static str]) -> usize {
+    let mut count = 0;
+    if capability_bytecode_callable(flags) {
+        count = push_flag_name(out, count, "bytecode_callable");
+    }
+    if capability_protocol_feature(flags) {
+        count = push_flag_name(out, count, "protocol_feature");
+    }
+    if capability_board_metadata(flags) {
+        count = push_flag_name(out, count, "board_metadata");
+    }
+    count
+}
+
+fn push_flag_name(out: &mut [&'static str], count: usize, name: &'static str) -> usize {
+    if let Some(slot) = out.get_mut(count) {
+        *slot = name;
+        count + 1
+    } else {
+        count
     }
 }
 
@@ -1166,6 +1202,35 @@ mod tests {
                 .into_owned()
         };
         assert!(message.contains("module_out"));
+    }
+
+    #[test]
+    fn rust_core_names_capability_flags_for_language_bindings() {
+        let mut names = [""; 3];
+        let count = capability_flag_names(
+            board_vm_protocol::CAP_FLAG_BYTECODE_CALLABLE
+                | board_vm_protocol::CAP_FLAG_PROTOCOL_FEATURE
+                | board_vm_protocol::CAP_FLAG_BOARD_METADATA,
+            &mut names,
+        );
+
+        assert_eq!(
+            &names[..count],
+            &[
+                "bytecode_callable",
+                "protocol_feature",
+                "board_metadata"
+            ]
+        );
+
+        let mut short = [""; 1];
+        let count = capability_flag_names(
+            board_vm_protocol::CAP_FLAG_BYTECODE_CALLABLE
+                | board_vm_protocol::CAP_FLAG_PROTOCOL_FEATURE,
+            &mut short,
+        );
+        assert_eq!(count, 1);
+        assert_eq!(short[0], "bytecode_callable");
     }
 
     fn decode_response_fixture(


### PR DESCRIPTION
## Summary

- add Rust-owned capability flag helpers for language bindings
- include decoded capability flag booleans/names in the Ruby native bridge
- add Ruby BoardDescriptor/Capability sugar with board.capabilities, grouping helpers, and support checks

## Tests

- cargo test -p board-vm-language-core
- rake test
