### PR TITLE
[codex] Add smart-home protocol foundation crates

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -525,4 +525,7 @@ members = [
     "zwave-core",
     "sixlowpan",
     "smart-home-registry",
+    "zigbee-aps",
+    "zwave-serial-api",
+    "thread-mle",
 ]

--- a/code/packages/rust/thread-mle/BUILD
+++ b/code/packages/rust/thread-mle/BUILD
@@ -1,0 +1,1 @@
+cargo test -p thread-mle -- --nocapture

--- a/code/packages/rust/thread-mle/CHANGELOG.md
+++ b/code/packages/rust/thread-mle/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-06
+
+### Added
+
+- Thread role, MLE command, TLV, scan-mask, and mode primitives.
+- MLE message parser/encoder and a deterministic parent/child attach-state
+  skeleton for simulator-first Thread work.

--- a/code/packages/rust/thread-mle/Cargo.toml
+++ b/code/packages/rust/thread-mle/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "thread-mle"
+version = "0.1.0"
+edition = "2021"
+description = "Thread Mesh Link Establishment roles, TLVs, and attach-state primitives"
+license = "MIT"
+
+[dependencies]
+sixlowpan = { path = "../sixlowpan" }

--- a/code/packages/rust/thread-mle/README.md
+++ b/code/packages/rust/thread-mle/README.md
@@ -1,0 +1,25 @@
+# thread-mle
+
+Thread Mesh Link Establishment roles, TLVs, and attach-state primitives.
+
+This crate starts the D27 Thread control-plane layer above 6LoWPAN:
+
+- device role model
+- MLE command ids
+- common MLE TLV ids
+- MLE message/TLV parsing and encoding
+- scan-mask and mode bit helpers
+- deterministic parent/child attach-state skeleton
+
+It does not yet implement UDP, CoAP, DTLS, commissioning, network data,
+neighbor tables, border routing, or real radio behavior.
+
+## Dependencies
+
+- `sixlowpan`
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/thread-mle/src/lib.rs
+++ b/code/packages/rust/thread-mle/src/lib.rs
@@ -1,0 +1,564 @@
+//! Thread Mesh Link Establishment primitives.
+//!
+//! MLE is the Thread control plane for roles, neighbors, parent/child attach,
+//! and network data exchange. This crate starts with pure message/TLV parsing
+//! and a deterministic attach-state skeleton. It intentionally performs no UDP,
+//! CoAP, DTLS, radio, commissioning, or border-router I/O.
+
+#![forbid(unsafe_code)]
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceRole {
+    Disabled,
+    Detached,
+    Child,
+    Router,
+    Leader,
+}
+
+impl DeviceRole {
+    pub fn can_route(self) -> bool {
+        matches!(self, Self::Router | Self::Leader)
+    }
+
+    pub fn is_attached(self) -> bool {
+        matches!(self, Self::Child | Self::Router | Self::Leader)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MleCommand {
+    LinkRequest,
+    LinkAccept,
+    LinkAcceptAndRequest,
+    LinkReject,
+    Advertisement,
+    Update,
+    UpdateRequest,
+    DataRequest,
+    DataResponse,
+    ParentRequest,
+    ParentResponse,
+    ChildIdRequest,
+    ChildIdResponse,
+    ChildUpdateRequest,
+    ChildUpdateResponse,
+    Announce,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    Unknown(u8),
+}
+
+impl MleCommand {
+    pub fn from_byte(value: u8) -> Self {
+        match value {
+            0 => Self::LinkRequest,
+            1 => Self::LinkAccept,
+            2 => Self::LinkAcceptAndRequest,
+            3 => Self::LinkReject,
+            4 => Self::Advertisement,
+            5 => Self::Update,
+            6 => Self::UpdateRequest,
+            7 => Self::DataRequest,
+            8 => Self::DataResponse,
+            9 => Self::ParentRequest,
+            10 => Self::ParentResponse,
+            11 => Self::ChildIdRequest,
+            12 => Self::ChildIdResponse,
+            13 => Self::ChildUpdateRequest,
+            14 => Self::ChildUpdateResponse,
+            15 => Self::Announce,
+            16 => Self::DiscoveryRequest,
+            17 => Self::DiscoveryResponse,
+            other => Self::Unknown(other),
+        }
+    }
+
+    pub fn as_byte(self) -> u8 {
+        match self {
+            Self::LinkRequest => 0,
+            Self::LinkAccept => 1,
+            Self::LinkAcceptAndRequest => 2,
+            Self::LinkReject => 3,
+            Self::Advertisement => 4,
+            Self::Update => 5,
+            Self::UpdateRequest => 6,
+            Self::DataRequest => 7,
+            Self::DataResponse => 8,
+            Self::ParentRequest => 9,
+            Self::ParentResponse => 10,
+            Self::ChildIdRequest => 11,
+            Self::ChildIdResponse => 12,
+            Self::ChildUpdateRequest => 13,
+            Self::ChildUpdateResponse => 14,
+            Self::Announce => 15,
+            Self::DiscoveryRequest => 16,
+            Self::DiscoveryResponse => 17,
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TlvType {
+    SourceAddress,
+    Mode,
+    Timeout,
+    Challenge,
+    Response,
+    LinkLayerFrameCounter,
+    MleFrameCounter,
+    Route64,
+    Address16,
+    LeaderData,
+    NetworkData,
+    TlvRequest,
+    ScanMask,
+    Connectivity,
+    LinkMargin,
+    Status,
+    Version,
+    AddressRegistration,
+    Channel,
+    PanId,
+    ActiveTimestamp,
+    PendingTimestamp,
+    Unknown(u8),
+}
+
+impl TlvType {
+    pub fn from_byte(value: u8) -> Self {
+        match value {
+            0 => Self::SourceAddress,
+            1 => Self::Mode,
+            2 => Self::Timeout,
+            3 => Self::Challenge,
+            4 => Self::Response,
+            5 => Self::LinkLayerFrameCounter,
+            8 => Self::MleFrameCounter,
+            9 => Self::Route64,
+            10 => Self::Address16,
+            11 => Self::LeaderData,
+            12 => Self::NetworkData,
+            13 => Self::TlvRequest,
+            14 => Self::ScanMask,
+            15 => Self::Connectivity,
+            16 => Self::LinkMargin,
+            17 => Self::Status,
+            18 => Self::Version,
+            19 => Self::AddressRegistration,
+            20 => Self::Channel,
+            21 => Self::PanId,
+            22 => Self::ActiveTimestamp,
+            23 => Self::PendingTimestamp,
+            other => Self::Unknown(other),
+        }
+    }
+
+    pub fn as_byte(self) -> u8 {
+        match self {
+            Self::SourceAddress => 0,
+            Self::Mode => 1,
+            Self::Timeout => 2,
+            Self::Challenge => 3,
+            Self::Response => 4,
+            Self::LinkLayerFrameCounter => 5,
+            Self::MleFrameCounter => 8,
+            Self::Route64 => 9,
+            Self::Address16 => 10,
+            Self::LeaderData => 11,
+            Self::NetworkData => 12,
+            Self::TlvRequest => 13,
+            Self::ScanMask => 14,
+            Self::Connectivity => 15,
+            Self::LinkMargin => 16,
+            Self::Status => 17,
+            Self::Version => 18,
+            Self::AddressRegistration => 19,
+            Self::Channel => 20,
+            Self::PanId => 21,
+            Self::ActiveTimestamp => 22,
+            Self::PendingTimestamp => 23,
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tlv {
+    pub tlv_type: TlvType,
+    pub value: Vec<u8>,
+}
+
+impl Tlv {
+    pub fn new(tlv_type: TlvType, value: Vec<u8>) -> Result<Self, MleError> {
+        if value.len() > u8::MAX as usize {
+            return Err(MleError::TlvTooLong(value.len()));
+        }
+        Ok(Self { tlv_type, value })
+    }
+
+    pub fn encode(&self, out: &mut Vec<u8>) -> Result<(), MleError> {
+        if self.value.len() > u8::MAX as usize {
+            return Err(MleError::TlvTooLong(self.value.len()));
+        }
+        out.push(self.tlv_type.as_byte());
+        out.push(self.value.len() as u8);
+        out.extend_from_slice(&self.value);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MleMessage {
+    pub command: MleCommand,
+    pub tlvs: Vec<Tlv>,
+}
+
+impl MleMessage {
+    pub fn parse(bytes: &[u8]) -> Result<Self, MleError> {
+        let Some((&command, rest)) = bytes.split_first() else {
+            return Err(MleError::Truncated {
+                needed: 1,
+                remaining: 0,
+            });
+        };
+        let mut cursor = Cursor::new(rest);
+        let mut tlvs = Vec::new();
+        while cursor.remaining() > 0 {
+            let tlv_type = TlvType::from_byte(cursor.read_u8()?);
+            let len = cursor.read_u8()? as usize;
+            let value = cursor.read_bytes(len)?.to_vec();
+            tlvs.push(Tlv { tlv_type, value });
+        }
+        Ok(Self {
+            command: MleCommand::from_byte(command),
+            tlvs,
+        })
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, MleError> {
+        let mut out = Vec::new();
+        out.push(self.command.as_byte());
+        for tlv in &self.tlvs {
+            tlv.encode(&mut out)?;
+        }
+        Ok(out)
+    }
+
+    pub fn find_tlv(&self, tlv_type: TlvType) -> Option<&Tlv> {
+        self.tlvs.iter().find(|tlv| tlv.tlv_type == tlv_type)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScanMask {
+    pub routers: bool,
+    pub end_devices: bool,
+}
+
+impl ScanMask {
+    pub fn parse(value: u8) -> Self {
+        Self {
+            routers: value & 0x80 != 0,
+            end_devices: value & 0x40 != 0,
+        }
+    }
+
+    pub fn encode(self) -> u8 {
+        ((self.routers as u8) << 7) | ((self.end_devices as u8) << 6)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Mode {
+    pub receiver_on_when_idle: bool,
+    pub secure_data_requests: bool,
+    pub full_thread_device: bool,
+    pub full_network_data: bool,
+}
+
+impl Mode {
+    pub fn parse(value: u8) -> Self {
+        Self {
+            receiver_on_when_idle: value & (1 << 3) != 0,
+            secure_data_requests: value & (1 << 2) != 0,
+            full_thread_device: value & (1 << 1) != 0,
+            full_network_data: value & 1 != 0,
+        }
+    }
+
+    pub fn encode(self) -> u8 {
+        ((self.receiver_on_when_idle as u8) << 3)
+            | ((self.secure_data_requests as u8) << 2)
+            | ((self.full_thread_device as u8) << 1)
+            | (self.full_network_data as u8)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachState {
+    Detached,
+    ParentSearch,
+    ParentCandidate,
+    ChildIdRequestSent,
+    Attached(DeviceRole),
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachAction {
+    SendParentRequest,
+    SendChildIdRequest,
+    BecomeChild,
+    BecomeRouter,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachMachine {
+    state: AttachState,
+}
+
+impl AttachMachine {
+    pub fn new() -> Self {
+        Self {
+            state: AttachState::Detached,
+        }
+    }
+
+    pub fn state(&self) -> AttachState {
+        self.state
+    }
+
+    pub fn start(&mut self) -> AttachAction {
+        self.state = AttachState::ParentSearch;
+        AttachAction::SendParentRequest
+    }
+
+    pub fn on_message(&mut self, message: &MleMessage) -> AttachAction {
+        match (self.state, message.command) {
+            (AttachState::ParentSearch, MleCommand::ParentResponse) => {
+                self.state = AttachState::ParentCandidate;
+                AttachAction::SendChildIdRequest
+            }
+            (AttachState::ParentCandidate, MleCommand::ChildIdResponse) => {
+                let role = role_from_child_id_response(message);
+                self.state = AttachState::Attached(role);
+                match role {
+                    DeviceRole::Router | DeviceRole::Leader => AttachAction::BecomeRouter,
+                    _ => AttachAction::BecomeChild,
+                }
+            }
+            (_, MleCommand::LinkReject) => {
+                self.state = AttachState::Rejected;
+                AttachAction::None
+            }
+            _ => AttachAction::None,
+        }
+    }
+}
+
+impl Default for AttachMachine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MleError {
+    Truncated { needed: usize, remaining: usize },
+    TlvTooLong(usize),
+}
+
+impl fmt::Display for MleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated { needed, remaining } => {
+                write!(
+                    f,
+                    "truncated Thread MLE bytes: needed {needed}, had {remaining}"
+                )
+            }
+            Self::TlvTooLong(len) => write!(f, "Thread MLE TLV too long: {len}"),
+        }
+    }
+}
+
+impl std::error::Error for MleError {}
+
+fn role_from_child_id_response(message: &MleMessage) -> DeviceRole {
+    let mode = message
+        .find_tlv(TlvType::Mode)
+        .and_then(|tlv| tlv.value.first().copied())
+        .map(Mode::parse);
+    match mode {
+        Some(mode) if mode.full_thread_device => DeviceRole::Router,
+        _ => DeviceRole::Child,
+    }
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len().saturating_sub(self.pos)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, MleError> {
+        if self.remaining() < 1 {
+            return Err(MleError::Truncated {
+                needed: 1,
+                remaining: self.remaining(),
+            });
+        }
+        let value = self.bytes[self.pos];
+        self.pos += 1;
+        Ok(value)
+    }
+
+    fn read_bytes(&mut self, len: usize) -> Result<&'a [u8], MleError> {
+        if self.remaining() < len {
+            return Err(MleError::Truncated {
+                needed: len,
+                remaining: self.remaining(),
+            });
+        }
+        let bytes = &self.bytes[self.pos..self.pos + len];
+        self.pos += len;
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mle_message_round_trips_tlvs() {
+        let message = MleMessage {
+            command: MleCommand::ParentRequest,
+            tlvs: vec![
+                Tlv::new(
+                    TlvType::ScanMask,
+                    vec![ScanMask {
+                        routers: true,
+                        end_devices: false,
+                    }
+                    .encode()],
+                )
+                .unwrap(),
+                Tlv::new(TlvType::Version, vec![0x00, 0x04]).unwrap(),
+            ],
+        };
+
+        assert_eq!(
+            MleMessage::parse(&message.encode().unwrap()).unwrap(),
+            message
+        );
+    }
+
+    #[test]
+    fn scan_mask_and_mode_bits_round_trip() {
+        let scan = ScanMask {
+            routers: true,
+            end_devices: true,
+        };
+        let mode = Mode {
+            receiver_on_when_idle: true,
+            secure_data_requests: true,
+            full_thread_device: false,
+            full_network_data: true,
+        };
+
+        assert_eq!(ScanMask::parse(scan.encode()), scan);
+        assert_eq!(Mode::parse(mode.encode()), mode);
+    }
+
+    #[test]
+    fn attach_machine_follows_parent_then_child_id_flow() {
+        let mut machine = AttachMachine::new();
+        let parent_response = MleMessage {
+            command: MleCommand::ParentResponse,
+            tlvs: Vec::new(),
+        };
+        let child_id_response = MleMessage {
+            command: MleCommand::ChildIdResponse,
+            tlvs: vec![Tlv::new(
+                TlvType::Mode,
+                vec![Mode {
+                    receiver_on_when_idle: false,
+                    secure_data_requests: true,
+                    full_thread_device: false,
+                    full_network_data: true,
+                }
+                .encode()],
+            )
+            .unwrap()],
+        };
+
+        assert_eq!(machine.start(), AttachAction::SendParentRequest);
+        assert_eq!(
+            machine.on_message(&parent_response),
+            AttachAction::SendChildIdRequest
+        );
+        assert_eq!(
+            machine.on_message(&child_id_response),
+            AttachAction::BecomeChild
+        );
+        assert_eq!(machine.state(), AttachState::Attached(DeviceRole::Child));
+    }
+
+    #[test]
+    fn attach_machine_can_attach_as_router_candidate() {
+        let mut machine = AttachMachine::new();
+        machine.start();
+        machine.on_message(&MleMessage {
+            command: MleCommand::ParentResponse,
+            tlvs: Vec::new(),
+        });
+
+        let action = machine.on_message(&MleMessage {
+            command: MleCommand::ChildIdResponse,
+            tlvs: vec![Tlv::new(
+                TlvType::Mode,
+                vec![Mode {
+                    receiver_on_when_idle: true,
+                    secure_data_requests: true,
+                    full_thread_device: true,
+                    full_network_data: true,
+                }
+                .encode()],
+            )
+            .unwrap()],
+        });
+
+        assert_eq!(action, AttachAction::BecomeRouter);
+        assert_eq!(machine.state(), AttachState::Attached(DeviceRole::Router));
+    }
+
+    #[test]
+    fn malformed_tlv_reports_truncation() {
+        assert_eq!(
+            MleMessage::parse(&[
+                MleCommand::ParentRequest.as_byte(),
+                TlvType::Version.as_byte(),
+                2,
+                1
+            ]),
+            Err(MleError::Truncated {
+                needed: 2,
+                remaining: 1
+            })
+        );
+    }
+}

--- a/code/packages/rust/zigbee-aps/BUILD
+++ b/code/packages/rust/zigbee-aps/BUILD
@@ -1,0 +1,1 @@
+cargo test -p zigbee-aps -- --nocapture

--- a/code/packages/rust/zigbee-aps/CHANGELOG.md
+++ b/code/packages/rust/zigbee-aps/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-06
+
+### Added
+
+- APS frame-control, endpoint, group, cluster, profile, counter, and delivery
+  mode primitives.
+- APS frame parser/encoder for unicast, broadcast, group, and indirect
+  addressing with payload preservation.

--- a/code/packages/rust/zigbee-aps/Cargo.toml
+++ b/code/packages/rust/zigbee-aps/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zigbee-aps"
+version = "0.1.0"
+edition = "2021"
+description = "Zigbee Application Support Sublayer frame primitives for endpoints, clusters, groups, and counters"
+license = "MIT"
+
+[dependencies]
+zigbee-nwk = { path = "../zigbee-nwk" }

--- a/code/packages/rust/zigbee-aps/README.md
+++ b/code/packages/rust/zigbee-aps/README.md
@@ -1,0 +1,27 @@
+# zigbee-aps
+
+Zigbee Application Support Sublayer frame primitives for endpoints, clusters,
+groups, and counters.
+
+This crate sits above `zigbee-nwk` and below ZDO/ZCL. It owns the APS byte
+boundary:
+
+- APS frame control parsing and encoding
+- delivery modes: unicast, indirect, broadcast, group
+- endpoint and group addressing
+- cluster/profile ids
+- APS counters
+- payload preservation
+
+It does not yet implement binding tables, APS commands, fragmentation, security,
+ZDO discovery, or ZCL command semantics.
+
+## Dependencies
+
+- `zigbee-nwk`
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/zigbee-aps/src/lib.rs
+++ b/code/packages/rust/zigbee-aps/src/lib.rs
@@ -1,0 +1,455 @@
+//! Zigbee Application Support Sublayer primitives.
+//!
+//! APS is where endpoint addressing, group addressing, cluster/profile ids,
+//! counters, and delivery-mode flags appear before ZDO/ZCL semantics take over.
+//! This crate only owns those bytes and validation rules.
+
+#![forbid(unsafe_code)]
+
+use std::fmt;
+
+const FRAME_CONTROL_LEN: usize = 1;
+const ENDPOINT_LEN: usize = 1;
+const GROUP_ADDRESS_LEN: usize = 2;
+const CLUSTER_ID_LEN: usize = 2;
+const PROFILE_ID_LEN: usize = 2;
+const COUNTER_LEN: usize = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Endpoint(pub u8);
+
+impl Endpoint {
+    pub const ZDO: Self = Self(0);
+    pub const MIN_APPLICATION: Self = Self(1);
+    pub const MAX_APPLICATION: Self = Self(240);
+
+    pub fn is_application(self) -> bool {
+        (Self::MIN_APPLICATION.0..=Self::MAX_APPLICATION.0).contains(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GroupAddress(pub u16);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClusterId(pub u16);
+
+impl ClusterId {
+    pub const BASIC: Self = Self(0x0000);
+    pub const ON_OFF: Self = Self(0x0006);
+    pub const LEVEL_CONTROL: Self = Self(0x0008);
+    pub const TEMPERATURE_MEASUREMENT: Self = Self(0x0402);
+    pub const OCCUPANCY_SENSING: Self = Self(0x0406);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ProfileId(pub u16);
+
+impl ProfileId {
+    pub const ZIGBEE_DEVICE_PROFILE: Self = Self(0x0000);
+    pub const HOME_AUTOMATION: Self = Self(0x0104);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApsFrameType {
+    Data,
+    Command,
+    Ack,
+    InterPan,
+}
+
+impl ApsFrameType {
+    fn from_bits(bits: u8) -> Self {
+        match bits & 0b11 {
+            0 => Self::Data,
+            1 => Self::Command,
+            2 => Self::Ack,
+            _ => Self::InterPan,
+        }
+    }
+
+    fn bits(self) -> u8 {
+        match self {
+            Self::Data => 0,
+            Self::Command => 1,
+            Self::Ack => 2,
+            Self::InterPan => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryMode {
+    Unicast,
+    Indirect,
+    Broadcast,
+    Group,
+}
+
+impl DeliveryMode {
+    fn from_bits(bits: u8) -> Self {
+        match bits & 0b11 {
+            0 => Self::Unicast,
+            1 => Self::Indirect,
+            2 => Self::Broadcast,
+            _ => Self::Group,
+        }
+    }
+
+    fn bits(self) -> u8 {
+        match self {
+            Self::Unicast => 0,
+            Self::Indirect => 1,
+            Self::Broadcast => 2,
+            Self::Group => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApsFrameControl {
+    pub frame_type: ApsFrameType,
+    pub delivery_mode: DeliveryMode,
+    pub ack_format: bool,
+    pub security: bool,
+    pub ack_request: bool,
+    pub extended_header: bool,
+}
+
+impl ApsFrameControl {
+    pub fn parse(raw: u8) -> Self {
+        Self {
+            frame_type: ApsFrameType::from_bits(raw),
+            delivery_mode: DeliveryMode::from_bits(raw >> 2),
+            ack_format: raw & (1 << 4) != 0,
+            security: raw & (1 << 5) != 0,
+            ack_request: raw & (1 << 6) != 0,
+            extended_header: raw & (1 << 7) != 0,
+        }
+    }
+
+    pub fn encode(self) -> u8 {
+        self.frame_type.bits()
+            | (self.delivery_mode.bits() << 2)
+            | ((self.ack_format as u8) << 4)
+            | ((self.security as u8) << 5)
+            | ((self.ack_request as u8) << 6)
+            | ((self.extended_header as u8) << 7)
+    }
+
+    pub fn data_unicast() -> Self {
+        Self {
+            frame_type: ApsFrameType::Data,
+            delivery_mode: DeliveryMode::Unicast,
+            ack_format: false,
+            security: false,
+            ack_request: false,
+            extended_header: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApsAddressing {
+    Unicast {
+        destination_endpoint: Endpoint,
+        source_endpoint: Endpoint,
+    },
+    Group {
+        group: GroupAddress,
+        source_endpoint: Endpoint,
+    },
+    Broadcast {
+        destination_endpoint: Endpoint,
+        source_endpoint: Endpoint,
+    },
+    Indirect {
+        source_endpoint: Endpoint,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApsFrame {
+    pub frame_control: ApsFrameControl,
+    pub addressing: ApsAddressing,
+    pub cluster_id: ClusterId,
+    pub profile_id: ProfileId,
+    pub counter: u8,
+    pub payload: Vec<u8>,
+}
+
+impl ApsFrame {
+    pub fn unicast_data(
+        destination_endpoint: Endpoint,
+        source_endpoint: Endpoint,
+        cluster_id: ClusterId,
+        profile_id: ProfileId,
+        counter: u8,
+        payload: Vec<u8>,
+    ) -> Self {
+        Self {
+            frame_control: ApsFrameControl::data_unicast(),
+            addressing: ApsAddressing::Unicast {
+                destination_endpoint,
+                source_endpoint,
+            },
+            cluster_id,
+            profile_id,
+            counter,
+            payload,
+        }
+    }
+
+    pub fn parse(bytes: &[u8]) -> Result<Self, ApsError> {
+        let mut cursor = Cursor::new(bytes);
+        let frame_control = ApsFrameControl::parse(cursor.read_u8()?);
+        let addressing = match frame_control.delivery_mode {
+            DeliveryMode::Unicast => ApsAddressing::Unicast {
+                destination_endpoint: Endpoint(cursor.read_u8()?),
+                source_endpoint: Endpoint::ZDO,
+            },
+            DeliveryMode::Group => ApsAddressing::Group {
+                group: GroupAddress(cursor.read_u16_le()?),
+                source_endpoint: Endpoint::ZDO,
+            },
+            DeliveryMode::Broadcast => ApsAddressing::Broadcast {
+                destination_endpoint: Endpoint(cursor.read_u8()?),
+                source_endpoint: Endpoint::ZDO,
+            },
+            DeliveryMode::Indirect => ApsAddressing::Indirect {
+                source_endpoint: Endpoint::ZDO,
+            },
+        };
+
+        let cluster_id = ClusterId(cursor.read_u16_le()?);
+        let profile_id = ProfileId(cursor.read_u16_le()?);
+        let mut addressing = addressing;
+        let counter = match &mut addressing {
+            ApsAddressing::Unicast {
+                source_endpoint, ..
+            }
+            | ApsAddressing::Group {
+                source_endpoint, ..
+            }
+            | ApsAddressing::Broadcast {
+                source_endpoint, ..
+            }
+            | ApsAddressing::Indirect { source_endpoint } => {
+                *source_endpoint = Endpoint(cursor.read_u8()?);
+                cursor.read_u8()?
+            }
+        };
+        let payload = cursor.remaining_bytes().to_vec();
+
+        Ok(Self {
+            frame_control,
+            addressing,
+            cluster_id,
+            profile_id,
+            counter,
+            payload,
+        })
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ApsError> {
+        validate_addressing(self.frame_control.delivery_mode, &self.addressing)?;
+
+        let mut out = Vec::with_capacity(
+            FRAME_CONTROL_LEN
+                + GROUP_ADDRESS_LEN
+                + (ENDPOINT_LEN * 2)
+                + CLUSTER_ID_LEN
+                + PROFILE_ID_LEN
+                + COUNTER_LEN
+                + self.payload.len(),
+        );
+        out.push(self.frame_control.encode());
+        match self.addressing {
+            ApsAddressing::Unicast {
+                destination_endpoint,
+                ..
+            }
+            | ApsAddressing::Broadcast {
+                destination_endpoint,
+                ..
+            } => out.push(destination_endpoint.0),
+            ApsAddressing::Group { group, .. } => out.extend_from_slice(&group.0.to_le_bytes()),
+            ApsAddressing::Indirect { .. } => {}
+        }
+        out.extend_from_slice(&self.cluster_id.0.to_le_bytes());
+        out.extend_from_slice(&self.profile_id.0.to_le_bytes());
+        out.push(source_endpoint(&self.addressing).0);
+        out.push(self.counter);
+        out.extend_from_slice(&self.payload);
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApsError {
+    Truncated { needed: usize, remaining: usize },
+    DeliveryModeMismatch,
+}
+
+impl fmt::Display for ApsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated { needed, remaining } => write!(
+                f,
+                "truncated Zigbee APS frame: needed {needed} bytes, had {remaining}"
+            ),
+            Self::DeliveryModeMismatch => write!(f, "APS delivery mode does not match addressing"),
+        }
+    }
+}
+
+impl std::error::Error for ApsError {}
+
+fn source_endpoint(addressing: &ApsAddressing) -> Endpoint {
+    match addressing {
+        ApsAddressing::Unicast {
+            source_endpoint, ..
+        }
+        | ApsAddressing::Group {
+            source_endpoint, ..
+        }
+        | ApsAddressing::Broadcast {
+            source_endpoint, ..
+        }
+        | ApsAddressing::Indirect { source_endpoint } => *source_endpoint,
+    }
+}
+
+fn validate_addressing(
+    delivery_mode: DeliveryMode,
+    addressing: &ApsAddressing,
+) -> Result<(), ApsError> {
+    let ok = matches!(
+        (delivery_mode, addressing),
+        (DeliveryMode::Unicast, ApsAddressing::Unicast { .. })
+            | (DeliveryMode::Group, ApsAddressing::Group { .. })
+            | (DeliveryMode::Broadcast, ApsAddressing::Broadcast { .. })
+            | (DeliveryMode::Indirect, ApsAddressing::Indirect { .. })
+    );
+    if ok {
+        Ok(())
+    } else {
+        Err(ApsError::DeliveryModeMismatch)
+    }
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn read_u8(&mut self) -> Result<u8, ApsError> {
+        let remaining = self.bytes.len().saturating_sub(self.pos);
+        if remaining < 1 {
+            return Err(ApsError::Truncated {
+                needed: 1,
+                remaining,
+            });
+        }
+        let value = self.bytes[self.pos];
+        self.pos += 1;
+        Ok(value)
+    }
+
+    fn read_u16_le(&mut self) -> Result<u16, ApsError> {
+        let remaining = self.bytes.len().saturating_sub(self.pos);
+        if remaining < 2 {
+            return Err(ApsError::Truncated {
+                needed: 2,
+                remaining,
+            });
+        }
+        let value = u16::from_le_bytes([self.bytes[self.pos], self.bytes[self.pos + 1]]);
+        self.pos += 2;
+        Ok(value)
+    }
+
+    fn remaining_bytes(&self) -> &'a [u8] {
+        &self.bytes[self.pos..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_control_round_trips() {
+        let control = ApsFrameControl {
+            frame_type: ApsFrameType::Data,
+            delivery_mode: DeliveryMode::Group,
+            ack_format: true,
+            security: true,
+            ack_request: true,
+            extended_header: false,
+        };
+
+        assert_eq!(ApsFrameControl::parse(control.encode()), control);
+    }
+
+    #[test]
+    fn unicast_data_frame_round_trips() {
+        let frame = ApsFrame::unicast_data(
+            Endpoint(1),
+            Endpoint(2),
+            ClusterId::ON_OFF,
+            ProfileId::HOME_AUTOMATION,
+            7,
+            vec![0x01, 0x02],
+        );
+
+        assert_eq!(ApsFrame::parse(&frame.encode().unwrap()).unwrap(), frame);
+    }
+
+    #[test]
+    fn group_frame_round_trips() {
+        let mut control = ApsFrameControl::data_unicast();
+        control.delivery_mode = DeliveryMode::Group;
+        let frame = ApsFrame {
+            frame_control: control,
+            addressing: ApsAddressing::Group {
+                group: GroupAddress(0x1234),
+                source_endpoint: Endpoint(1),
+            },
+            cluster_id: ClusterId::LEVEL_CONTROL,
+            profile_id: ProfileId::HOME_AUTOMATION,
+            counter: 9,
+            payload: vec![0x05],
+        };
+
+        assert_eq!(ApsFrame::parse(&frame.encode().unwrap()).unwrap(), frame);
+    }
+
+    #[test]
+    fn rejects_delivery_mode_addressing_mismatch() {
+        let mut frame = ApsFrame::unicast_data(
+            Endpoint(1),
+            Endpoint(2),
+            ClusterId::ON_OFF,
+            ProfileId::HOME_AUTOMATION,
+            1,
+            Vec::new(),
+        );
+        frame.frame_control.delivery_mode = DeliveryMode::Group;
+
+        assert_eq!(frame.encode(), Err(ApsError::DeliveryModeMismatch));
+    }
+
+    #[test]
+    fn endpoint_knows_application_range() {
+        assert!(!Endpoint::ZDO.is_application());
+        assert!(Endpoint(1).is_application());
+        assert!(Endpoint(240).is_application());
+        assert!(!Endpoint(241).is_application());
+    }
+}

--- a/code/packages/rust/zwave-serial-api/BUILD
+++ b/code/packages/rust/zwave-serial-api/BUILD
@@ -1,0 +1,1 @@
+cargo test -p zwave-serial-api -- --nocapture

--- a/code/packages/rust/zwave-serial-api/CHANGELOG.md
+++ b/code/packages/rust/zwave-serial-api/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-06
+
+### Added
+
+- Serial API function id, request/response/callback classification, controller
+  capability, Memory Get ID, and request tracking primitives.
+- Callback correlation and timeout expiry helpers for future controller loops.

--- a/code/packages/rust/zwave-serial-api/Cargo.toml
+++ b/code/packages/rust/zwave-serial-api/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zwave-serial-api"
+version = "0.1.0"
+edition = "2021"
+description = "Z-Wave Serial API request, response, callback, and controller capability primitives"
+license = "MIT"
+
+[dependencies]
+zwave-core = { path = "../zwave-core" }

--- a/code/packages/rust/zwave-serial-api/README.md
+++ b/code/packages/rust/zwave-serial-api/README.md
@@ -1,0 +1,27 @@
+# zwave-serial-api
+
+Z-Wave Serial API request, response, callback, and controller capability
+primitives.
+
+`zwave-core` owns raw Serial API frame bytes. This crate starts the host-side
+control-plane layer:
+
+- function id constants
+- request/response/callback classification
+- request callback ids
+- controller capability flag decoding
+- Memory Get ID payload decoding
+- request tracker with callback correlation and timeout expiry
+
+It does not yet open a serial port, interview nodes, handle inclusion, or map
+command classes.
+
+## Dependencies
+
+- `zwave-core`
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/zwave-serial-api/src/lib.rs
+++ b/code/packages/rust/zwave-serial-api/src/lib.rs
@@ -1,0 +1,313 @@
+//! Z-Wave Serial API host/controller primitives.
+//!
+//! `zwave-core` owns raw Serial API frames. This crate starts the host-side
+//! control-plane layer: function ids, request/response/callback classification,
+//! controller capability snapshots, and callback correlation.
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::fmt;
+use zwave_core::{HomeId, NodeId, SerialFrame, SerialFrameType, ZWaveError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FunctionId(pub u8);
+
+impl FunctionId {
+    pub const SERIAL_API_GET_INIT_DATA: Self = Self(0x02);
+    pub const APPLICATION_COMMAND_HANDLER: Self = Self(0x04);
+    pub const GET_CONTROLLER_CAPABILITIES: Self = Self(0x05);
+    pub const SERIAL_API_SET_TIMEOUTS: Self = Self(0x06);
+    pub const SEND_DATA: Self = Self(0x13);
+    pub const GET_VERSION: Self = Self(0x15);
+    pub const MEMORY_GET_ID: Self = Self(0x20);
+    pub const REQUEST_NODE_INFO: Self = Self(0x60);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SerialMessageKind {
+    Request,
+    Response,
+    Callback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SerialMessage {
+    pub kind: SerialMessageKind,
+    pub function_id: FunctionId,
+    pub callback_id: Option<u8>,
+    pub payload: Vec<u8>,
+}
+
+impl SerialMessage {
+    pub fn from_frame(frame: SerialFrame) -> Self {
+        let function_id = FunctionId(frame.function_id);
+        let callback_id = callback_id_for(function_id, &frame.payload);
+        let kind = match frame.frame_type {
+            SerialFrameType::Response => SerialMessageKind::Response,
+            SerialFrameType::Request if callback_id.is_some() => SerialMessageKind::Callback,
+            SerialFrameType::Request => SerialMessageKind::Request,
+        };
+        Self {
+            kind,
+            function_id,
+            callback_id,
+            payload: frame.payload,
+        }
+    }
+
+    pub fn request(function_id: FunctionId, payload: Vec<u8>) -> Self {
+        Self {
+            kind: SerialMessageKind::Request,
+            function_id,
+            callback_id: callback_id_for(function_id, &payload),
+            payload,
+        }
+    }
+
+    pub fn to_frame(&self) -> SerialFrame {
+        let frame_type = match self.kind {
+            SerialMessageKind::Response => SerialFrameType::Response,
+            SerialMessageKind::Request | SerialMessageKind::Callback => SerialFrameType::Request,
+        };
+        SerialFrame::new(frame_type, self.function_id.0, self.payload.clone())
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ZWaveError> {
+        self.to_frame().encode()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerCapabilities {
+    pub is_secondary: bool,
+    pub is_sis_present: bool,
+    pub was_real_primary: bool,
+    pub is_suc: bool,
+    pub supports_timers: bool,
+}
+
+impl ControllerCapabilities {
+    pub fn parse(flags: u8) -> Self {
+        Self {
+            is_secondary: flags & 0x01 != 0,
+            is_sis_present: flags & 0x02 != 0,
+            was_real_primary: flags & 0x04 != 0,
+            is_suc: flags & 0x08 != 0,
+            supports_timers: flags & 0x10 != 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryId {
+    pub home_id: HomeId,
+    pub controller_node_id: NodeId,
+}
+
+impl MemoryId {
+    pub fn parse(payload: &[u8]) -> Result<Self, SerialApiError> {
+        if payload.len() < 5 {
+            return Err(SerialApiError::Truncated {
+                needed: 5,
+                remaining: payload.len(),
+            });
+        }
+        Ok(Self {
+            home_id: HomeId(u32::from_be_bytes([
+                payload[0], payload[1], payload[2], payload[3],
+            ])),
+            controller_node_id: NodeId::classic(payload[4])
+                .map_err(|err| SerialApiError::Core(err.to_string()))?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RequestKey {
+    pub function_id: FunctionId,
+    pub callback_id: Option<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingRequest {
+    pub key: RequestKey,
+    pub sent_at_ms: u64,
+    pub timeout_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RequestTracker {
+    pending: BTreeMap<RequestKey, PendingRequest>,
+}
+
+impl RequestTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn track(
+        &mut self,
+        message: &SerialMessage,
+        sent_at_ms: u64,
+        timeout_ms: u64,
+    ) -> Result<RequestKey, SerialApiError> {
+        if message.kind != SerialMessageKind::Request {
+            return Err(SerialApiError::NotRequest);
+        }
+        let key = RequestKey {
+            function_id: message.function_id,
+            callback_id: message.callback_id,
+        };
+        self.pending.insert(
+            key,
+            PendingRequest {
+                key,
+                sent_at_ms,
+                timeout_at_ms: sent_at_ms.saturating_add(timeout_ms),
+            },
+        );
+        Ok(key)
+    }
+
+    pub fn complete(&mut self, message: &SerialMessage) -> Option<PendingRequest> {
+        match message.kind {
+            SerialMessageKind::Response => {
+                let key = RequestKey {
+                    function_id: message.function_id,
+                    callback_id: None,
+                };
+                self.pending
+                    .remove(&key)
+                    .or_else(|| remove_first_function_match(&mut self.pending, message.function_id))
+            }
+            SerialMessageKind::Callback => {
+                let key = RequestKey {
+                    function_id: message.function_id,
+                    callback_id: message.callback_id,
+                };
+                self.pending.remove(&key)
+            }
+            SerialMessageKind::Request => None,
+        }
+    }
+
+    pub fn expire(&mut self, now_ms: u64) -> Vec<PendingRequest> {
+        let expired_keys: Vec<_> = self
+            .pending
+            .iter()
+            .filter_map(|(key, pending)| (now_ms >= pending.timeout_at_ms).then_some(*key))
+            .collect();
+        expired_keys
+            .into_iter()
+            .filter_map(|key| self.pending.remove(&key))
+            .collect()
+    }
+
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SerialApiError {
+    Truncated { needed: usize, remaining: usize },
+    NotRequest,
+    Core(String),
+}
+
+impl fmt::Display for SerialApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated { needed, remaining } => write!(
+                f,
+                "truncated Z-Wave Serial API payload: needed {needed} bytes, had {remaining}"
+            ),
+            Self::NotRequest => write!(f, "only request messages can be tracked"),
+            Self::Core(message) => write!(f, "Z-Wave core error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for SerialApiError {}
+
+fn callback_id_for(function_id: FunctionId, payload: &[u8]) -> Option<u8> {
+    match function_id {
+        FunctionId::SEND_DATA | FunctionId::REQUEST_NODE_INFO => payload.last().copied(),
+        _ => None,
+    }
+}
+
+fn remove_first_function_match(
+    pending: &mut BTreeMap<RequestKey, PendingRequest>,
+    function_id: FunctionId,
+) -> Option<PendingRequest> {
+    let key = pending
+        .keys()
+        .copied()
+        .find(|key| key.function_id == function_id)?;
+    pending.remove(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serial_message_round_trips_through_core_frame() {
+        let message = SerialMessage::request(FunctionId::SEND_DATA, vec![0x02, 0x25, 0x01, 0x44]);
+        let encoded = message.encode().unwrap();
+        let parsed = SerialMessage::from_frame(SerialFrame::parse(&encoded).unwrap());
+
+        assert_eq!(parsed.function_id, FunctionId::SEND_DATA);
+        assert_eq!(parsed.kind, SerialMessageKind::Callback);
+        assert_eq!(parsed.callback_id, Some(0x44));
+    }
+
+    #[test]
+    fn controller_capabilities_parse_flags() {
+        let caps = ControllerCapabilities::parse(0b0001_1011);
+
+        assert!(caps.is_secondary);
+        assert!(caps.is_sis_present);
+        assert!(!caps.was_real_primary);
+        assert!(caps.is_suc);
+        assert!(caps.supports_timers);
+    }
+
+    #[test]
+    fn memory_id_extracts_home_and_controller_node() {
+        let id = MemoryId::parse(&[0x12, 0x34, 0x56, 0x78, 0x05]).unwrap();
+
+        assert_eq!(id.home_id, HomeId(0x1234_5678));
+        assert_eq!(id.controller_node_id, NodeId::Classic(5));
+    }
+
+    #[test]
+    fn request_tracker_correlates_callback_by_callback_id() {
+        let request = SerialMessage::request(FunctionId::SEND_DATA, vec![0x02, 0x25, 0x01, 0x44]);
+        let callback = SerialMessage {
+            kind: SerialMessageKind::Callback,
+            function_id: FunctionId::SEND_DATA,
+            callback_id: Some(0x44),
+            payload: vec![0x44, 0x00],
+        };
+        let mut tracker = RequestTracker::new();
+        let key = tracker.track(&request, 100, 500).unwrap();
+
+        assert_eq!(key.callback_id, Some(0x44));
+        assert!(tracker.complete(&callback).is_some());
+        assert_eq!(tracker.pending_len(), 0);
+    }
+
+    #[test]
+    fn request_tracker_expires_timed_out_requests() {
+        let request = SerialMessage::request(FunctionId::GET_VERSION, Vec::new());
+        let mut tracker = RequestTracker::new();
+        tracker.track(&request, 100, 50).unwrap();
+
+        assert!(tracker.expire(149).is_empty());
+        assert_eq!(tracker.expire(150).len(), 1);
+        assert_eq!(tracker.pending_len(), 0);
+    }
+}

--- a/code/specs/D25-zigbee-stack.md
+++ b/code/specs/D25-zigbee-stack.md
@@ -95,6 +95,11 @@ ZCL remain future packages/layers.
 - APS commands
 - fragmentation model
 
+**Initial Rust implementation:** `code/packages/rust/zigbee-aps` now provides
+APS frame-control, endpoint/group addressing, cluster/profile id, counter, and
+payload parser/encoder primitives. Binding tables, APS commands,
+fragmentation, and security remain future layers.
+
 ### `zigbee-zdo`
 
 - node descriptors

--- a/code/specs/D26-zwave-stack.md
+++ b/code/specs/D26-zwave-stack.md
@@ -79,6 +79,12 @@ future layers.
 - callbacks
 - controller capabilities
 
+**Initial Rust implementation:** `code/packages/rust/zwave-serial-api` now
+provides function ids, request/response/callback classification, controller
+capability decoding, Memory Get ID parsing, and request tracking with callback
+correlation and timeout expiry. Real serial-port I/O and controller loops remain
+future layers.
+
 ### `zwave-command-classes`
 
 - command-class registry

--- a/code/specs/D27-thread-stack.md
+++ b/code/specs/D27-thread-stack.md
@@ -94,6 +94,11 @@ layers.
 - attach/detach flows
 - network data model
 
+**Initial Rust implementation:** `code/packages/rust/thread-mle` now provides
+Thread role, MLE command, TLV, scan-mask, mode, message parser/encoder, and
+deterministic parent/child attach-state primitives. Neighbor tables, network
+data, UDP/CoAP/DTLS, and commissioning remain future layers.
+
 ### `thread-commissioning`
 
 - commissioning state model


### PR DESCRIPTION
## Summary

Adds the next protocol-foundation layer for the smart-home stack:

- `zigbee-aps`: APS frame control, endpoint/group addressing, cluster/profile ids, counters, delivery modes, and payload round-tripping
- `zwave-serial-api`: Serial API function ids, request/response/callback classification, controller capability decoding, Memory Get ID parsing, callback correlation, and timeout expiry
- `thread-mle`: Thread role, MLE command/TLV/message primitives, scan-mask/mode helpers, and a deterministic parent/child attach-state skeleton

The D25, D26, and D27 specs are updated with the implementation status.

## Impact

This moves Zigbee, Z-Wave, and Thread beyond the first byte-boundary crates without adding real radio, serial, bridge, Vault, or network I/O. These packages give future coordinators/controllers/simulators a tested layer to build on.

## Validation

- `cargo test -p zigbee-aps -p zwave-serial-api -p thread-mle -p zigbee-nwk -p zwave-core -p sixlowpan`
