### PR TITLE
Add Python native Board VM bridge

### DIFF
--- a/code/packages/python/board-vm-native/BUILD
+++ b/code/packages/python/board-vm-native/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install pytest --quiet
+cargo build --release
+if [ -f target/release/libboard_vm_native.so ]; then cp target/release/libboard_vm_native.so src/board_vm_native/board_vm_native.so; elif [ -f target/release/libboard_vm_native.dylib ]; then cp target/release/libboard_vm_native.dylib src/board_vm_native/board_vm_native.so; elif [ -f target/release/board_vm_native.dll ]; then cp target/release/board_vm_native.dll src/board_vm_native/board_vm_native.pyd; fi
+if [ -f .venv/Scripts/python.exe ]; then PYTHONPATH=src .venv/Scripts/python -m pytest tests/ -v; else PYTHONPATH=src .venv/bin/python -m pytest tests/ -v; fi

--- a/code/packages/python/board-vm-native/BUILD_windows
+++ b/code/packages/python/board-vm-native/BUILD_windows
@@ -1,0 +1,6 @@
+uv venv --quiet --clear
+uv pip install pytest --quiet
+cargo build --release
+if exist target\release\board_vm_native.dll copy target\release\board_vm_native.dll src\board_vm_native\board_vm_native.pyd
+set PYTHONPATH=src
+.venv\Scripts\python -m pytest tests/ -v

--- a/code/packages/python/board-vm-native/CHANGELOG.md
+++ b/code/packages/python/board-vm-native/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Python native Board VM bridge package.

--- a/code/packages/python/board-vm-native/Cargo.toml
+++ b/code/packages/python/board-vm-native/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "board-vm-native-python"
+version = "0.1.0"
+edition = "2021"
+description = "Python native extension wrapping Board VM language core via python-bridge"
+
+[lib]
+name = "board_vm_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+board-vm-host = { path = "../../rust/board-vm-host" }
+board-vm-language-core = { path = "../../rust/board-vm-language-core" }
+python-bridge = { path = "../../rust/python-bridge" }
+
+[workspace]

--- a/code/packages/python/board-vm-native/README.md
+++ b/code/packages/python/board-vm-native/README.md
@@ -1,0 +1,18 @@
+# coding-adventures-board-vm-native
+
+Python sugar over the Rust Board VM language core.
+
+The Python package does not implement request IDs, framing, CRCs, or Board VM
+message layouts. Those remain in `board-vm-language-core`, with this package
+wrapping that Rust boundary through the repo-local `python-bridge`.
+
+```python
+from board_vm_native import Session
+
+session = Session()
+frames = session.blink(program_id=1, instruction_budget=12).frames
+```
+
+Each frame is a Rust-produced Board VM wire frame ready for a transport to
+write to a board. A `Session` can also dispatch through any object that exposes
+`transact(frame, timeout_ms=...)` or `write(frame)`.

--- a/code/packages/python/board-vm-native/build.rs
+++ b/code/packages/python/board-vm-native/build.rs
@@ -1,0 +1,57 @@
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    match target_os.as_str() {
+        "macos" => {
+            println!("cargo:rustc-cdylib-link-arg=-undefined");
+            println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        }
+        "windows" => {
+            let python = std::env::var("PYO3_PYTHON")
+                .or_else(|_| std::env::var("PYTHON_SYS_EXECUTABLE"))
+                .or_else(|_| which_python())
+                .unwrap_or_else(|_| "python".to_string());
+
+            let script = "import sys, os; prefix = sys.base_prefix; v = sys.version_info; \
+                          lib_dir = os.path.join(prefix, 'libs'); \
+                          lib_name = f'python{v.major}{v.minor}'; \
+                          print(f'{lib_dir}|{lib_name}')";
+            if let Ok(output) = std::process::Command::new(&python)
+                .args(["-c", script])
+                .output()
+            {
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if let Some((lib_dir, lib_name)) = stdout.split_once('|') {
+                    println!("cargo:rustc-link-search=native={}", lib_dir);
+                    println!("cargo:rustc-link-lib={}", lib_name);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn which_python() -> Result<String, std::env::VarError> {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let finder = if target_os == "windows" {
+        "where"
+    } else {
+        "which"
+    };
+    for name in &["python3", "python"] {
+        if let Ok(output) = std::process::Command::new(finder).arg(name).output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if !path.is_empty() {
+                    return Ok(path);
+                }
+            }
+        }
+    }
+    Err(std::env::VarError::NotPresent)
+}

--- a/code/packages/python/board-vm-native/pyproject.toml
+++ b/code/packages/python/board-vm-native/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "coding-adventures-board-vm-native"
+version = "0.1.0"
+description = "Rust-backed Board VM protocol bridge for Python"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/code/packages/python/board-vm-native/required_capabilities.json
+++ b/code/packages/python/board-vm-native/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/board-vm-native",
+  "capabilities": [],
+  "justification": "In-process native extension for Board VM protocol frame construction and response decoding."
+}

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1,0 +1,301 @@
+"""Python sugar over Rust-owned Board VM protocol frames."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from . import board_vm_native as _native
+
+
+DEFAULT_HOST_NAME = "python-board-vm"
+DEFAULT_HOST_NONCE = 0xB0A2D001
+DEFAULT_PROGRAM_ID = 1
+DEFAULT_INSTRUCTION_BUDGET = 12
+
+
+@dataclass(frozen=True)
+class Capability:
+    raw: dict[str, Any]
+
+    @property
+    def id(self) -> int:
+        return int(self.raw["id"])
+
+    @property
+    def version(self) -> int:
+        return int(self.raw["version"])
+
+    @property
+    def flags(self) -> int:
+        return int(self.raw["flags"])
+
+    @property
+    def name(self) -> str:
+        return str(self.raw["name"])
+
+    @property
+    def bytecode_callable(self) -> bool:
+        return bool(self.raw.get("bytecode_callable", self.flags & 0x0001 != 0))
+
+    @property
+    def protocol_feature(self) -> bool:
+        return bool(self.raw.get("protocol_feature", self.flags & 0x0002 != 0))
+
+    @property
+    def board_metadata(self) -> bool:
+        return bool(self.raw.get("board_metadata", self.flags & 0x0004 != 0))
+
+    @property
+    def flag_names(self) -> list[str]:
+        names = self.raw.get("flag_names")
+        if names is not None:
+            return [str(name) for name in names]
+        result = []
+        if self.bytecode_callable:
+            result.append("bytecode_callable")
+        if self.protocol_feature:
+            result.append("protocol_feature")
+        if self.board_metadata:
+            result.append("board_metadata")
+        return result
+
+
+@dataclass(frozen=True)
+class BoardDescriptor:
+    raw: dict[str, Any]
+
+    @property
+    def board_id(self) -> str:
+        return str(self.raw["board_id"])
+
+    @property
+    def runtime_id(self) -> str:
+        return str(self.raw["runtime_id"])
+
+    @property
+    def max_program_bytes(self) -> int:
+        return int(self.raw["max_program_bytes"])
+
+    @property
+    def max_stack_values(self) -> int:
+        return int(self.raw["max_stack_values"])
+
+    @property
+    def max_handles(self) -> int:
+        return int(self.raw["max_handles"])
+
+    @property
+    def supports_store_program(self) -> bool:
+        return bool(self.raw["supports_store_program"])
+
+    @property
+    def capabilities(self) -> list[Capability]:
+        return [Capability(item) for item in self.raw.get("capabilities", [])]
+
+    def supports(self, name_or_id: str | int) -> bool:
+        return self.capability(name_or_id) is not None
+
+    def capability(self, name_or_id: str | int) -> Capability | None:
+        for capability in self.capabilities:
+            if isinstance(name_or_id, int) and capability.id == name_or_id:
+                return capability
+            if not isinstance(name_or_id, int) and capability.name == str(name_or_id):
+                return capability
+        return None
+
+    @property
+    def capability_names(self) -> list[str]:
+        return [capability.name for capability in self.capabilities]
+
+
+@dataclass(frozen=True)
+class ProtocolResult:
+    command: str
+    frame: bytes
+    response: bytes | None = None
+    decoded_response: dict[str, Any] | None = None
+
+    @property
+    def kind(self) -> str | None:
+        if self.decoded_response is None:
+            return None
+        return self.decoded_response.get("kind")
+
+    @property
+    def payload(self) -> dict[str, Any] | None:
+        if self.decoded_response is None:
+            return None
+        return self.decoded_response.get("payload")
+
+    @property
+    def board_descriptor(self) -> BoardDescriptor | None:
+        if self.kind != "caps_report" or self.payload is None:
+            return None
+        return BoardDescriptor(self.payload)
+
+
+@dataclass(frozen=True)
+class SessionResult:
+    results: list[ProtocolResult]
+
+    @property
+    def frames(self) -> list[bytes]:
+        return [result.frame for result in self.results]
+
+    @property
+    def responses(self) -> list[bytes | None]:
+        return [result.response for result in self.results]
+
+    @property
+    def decoded_responses(self) -> list[dict[str, Any] | None]:
+        return [result.decoded_response for result in self.results]
+
+    @property
+    def board_descriptor(self) -> BoardDescriptor | None:
+        for result in self.results:
+            descriptor = result.board_descriptor
+            if descriptor is not None:
+                return descriptor
+        return None
+
+
+class Session:
+    def __init__(self, *, next_request_id: int = 1, transport: Any = None, timeout_ms: int = 1000):
+        self.next_request_id = next_request_id
+        self.transport = transport
+        self.timeout_ms = timeout_ms
+
+    def hello(self, host_name: str = DEFAULT_HOST_NAME, host_nonce: int = DEFAULT_HOST_NONCE) -> ProtocolResult:
+        frame = self._call_native(_native.hello_wire, host_name, host_nonce)
+        return self._dispatch("hello", frame)
+
+    def capabilities(self) -> ProtocolResult:
+        frame = self._call_native(_native.caps_query_wire)
+        return self._dispatch("capabilities", frame)
+
+    caps = capabilities
+
+    def board_descriptor(self) -> BoardDescriptor | None:
+        return self.capabilities().board_descriptor
+
+    def blink_module(self, pin: int = 13, high_ms: int = 250, low_ms: int = 250, max_stack: int = 4) -> bytes:
+        return _native.blink_module(pin, high_ms, low_ms, max_stack)
+
+    def upload(self, *, program_id: int = DEFAULT_PROGRAM_ID, module_bytes: bytes) -> SessionResult:
+        return SessionResult([
+            self._dispatch("program_begin", self._call_native(_native.program_begin_wire, program_id, module_bytes)),
+            self._dispatch("program_chunk", self._call_native(_native.program_chunk_wire, program_id, 0, module_bytes)),
+            self._dispatch("program_end", self._call_native(_native.program_end_wire, program_id)),
+        ])
+
+    def upload_blink(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        pin: int = 13,
+        high_ms: int = 250,
+        low_ms: int = 250,
+        max_stack: int = 4,
+    ) -> SessionResult:
+        return self.upload(
+            program_id=program_id,
+            module_bytes=self.blink_module(pin=pin, high_ms=high_ms, low_ms=low_ms, max_stack=max_stack),
+        )
+
+    def run(self, *, program_id: int = DEFAULT_PROGRAM_ID, instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET) -> ProtocolResult:
+        frame = self._call_native(_native.run_background_wire, program_id, instruction_budget)
+        return self._dispatch("run", frame)
+
+    def blink(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET,
+        handshake: bool = False,
+        query_caps: bool = False,
+        pin: int = 13,
+        high_ms: int = 250,
+        low_ms: int = 250,
+        max_stack: int = 4,
+    ) -> SessionResult:
+        results: list[ProtocolResult] = []
+        if handshake:
+            results.append(self.hello())
+        if query_caps:
+            results.append(self.capabilities())
+        results.extend(
+            self.upload_blink(
+                program_id=program_id,
+                pin=pin,
+                high_ms=high_ms,
+                low_ms=low_ms,
+                max_stack=max_stack,
+            ).results
+        )
+        results.append(self.run(program_id=program_id, instruction_budget=instruction_budget))
+        return SessionResult(results)
+
+    def run_command(self, line: str, **options: Any) -> SessionResult:
+        words = line.split()
+        if not words:
+            return SessionResult([])
+        command = words.pop(0)
+        if command == "hello":
+            self._ensure_no_extra(words, command)
+            return SessionResult([self.hello(**options)])
+        if command in {"caps", "capabilities"}:
+            self._ensure_no_extra(words, command)
+            return SessionResult([self.capabilities()])
+        if command == "upload-blink":
+            self._ensure_no_extra(words, command)
+            return self.upload_blink(**options)
+        if command == "run":
+            return SessionResult([self.run(**self._with_optional_budget(words, command, options))])
+        if command == "blink":
+            return self.blink(**self._with_optional_budget(words, command, options))
+        raise ValueError(f"unknown Board VM session command: {command}")
+
+    def decode_response(self, response: bytes) -> dict[str, Any]:
+        return _native.decode_response(response)
+
+    def _call_native(self, func: Any, *args: Any) -> bytes:
+        result = func(self.next_request_id, *args)
+        self.next_request_id = int(result["next_request_id"])
+        return bytes(result["frame"])
+
+    def _dispatch(self, command: str, frame: bytes) -> ProtocolResult:
+        response = None
+        decoded = None
+        if self.transport is not None:
+            if hasattr(self.transport, "transact"):
+                response = self.transport.transact(frame, timeout_ms=self.timeout_ms)
+            elif hasattr(self.transport, "write"):
+                self.transport.write(frame)
+            else:
+                raise TypeError("Board VM transport must expose transact(frame, timeout_ms=...) or write(frame)")
+        if response is not None:
+            decoded = self.decode_response(response)
+        return ProtocolResult(command=command, frame=frame, response=response, decoded_response=decoded)
+
+    @staticmethod
+    def _ensure_no_extra(words: Iterable[str], command: str) -> None:
+        words = list(words)
+        if words:
+            raise ValueError(f"{command} got unexpected argument: {words[0]}")
+
+    def _with_optional_budget(self, words: list[str], command: str, options: dict[str, Any]) -> dict[str, Any]:
+        merged = dict(options)
+        if words:
+            merged["instruction_budget"] = int(words.pop(0))
+        self._ensure_no_extra(words, command)
+        return merged
+
+
+__all__ = [
+    "BoardDescriptor",
+    "Capability",
+    "ProtocolResult",
+    "Session",
+    "SessionResult",
+]

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -1,0 +1,580 @@
+use std::ffi::{c_char, c_long};
+use std::ptr;
+
+use board_vm_host::{BlinkProgram, BLINK_MODULE_LEN};
+use board_vm_language_core::{
+    build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
+    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
+    build_run_background_wire_frame, capability_board_metadata, capability_bytecode_callable,
+    capability_flag_names, capability_protocol_feature, decode_wire_response, program_format_name,
+    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageCoreError,
+};
+use python_bridge::*;
+
+#[allow(non_snake_case)]
+extern "C" {
+    fn PyLong_AsLong(obj: PyObjectPtr) -> c_long;
+    fn PyErr_Occurred() -> PyObjectPtr;
+}
+
+unsafe extern "C" fn py_hello_wire(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let next_request_id = match parse_arg_u16(args, 0, "next_request_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let host_name = match parse_arg_str(args, 1) {
+        Some(value) => value,
+        None => {
+            set_error(type_error_class(), "hello_wire() requires host_name as str");
+            return ptr::null_mut();
+        }
+    };
+    let host_nonce = match parse_arg_u32(args, 2, "host_nonce") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    with_session(next_request_id, |session| {
+        let mut wire = vec![0; host_name.len().saturating_add(64).max(128)];
+        let written = build_hello_wire_frame(session, &host_name, host_nonce, &mut wire)?;
+        Ok(wire_result(&wire, written.len, session))
+    })
+}
+
+unsafe extern "C" fn py_caps_query_wire(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let next_request_id = match parse_arg_u16(args, 0, "next_request_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    with_session(next_request_id, |session| {
+        let mut wire = [0u8; 64];
+        let written = build_caps_query_wire_frame(session, &mut wire)?;
+        Ok(wire_result(&wire, written.len, session))
+    })
+}
+
+unsafe extern "C" fn py_blink_module(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let pin = match parse_arg_u8(args, 0, "pin") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let high_ms = match parse_arg_u16(args, 1, "high_ms") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let low_ms = match parse_arg_u16(args, 2, "low_ms") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let max_stack = match parse_arg_u8(args, 3, "max_stack") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    let module = match build_blink_module_value(pin, high_ms, low_ms, max_stack) {
+        Ok(module) => module,
+        Err(error) => return raise_core_error("blink_module", error),
+    };
+    bytes_to_py(&module)
+}
+
+unsafe extern "C" fn py_program_begin_wire(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let next_request_id = match parse_arg_u16(args, 0, "next_request_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let program_id = match parse_arg_u16(args, 1, "program_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let module = match parse_arg_bytes(args, 2, "module_bytes") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    with_session(next_request_id, |session| {
+        let mut wire = [0u8; 96];
+        let written = build_program_begin_wire_frame(session, program_id, &module, &mut wire)?;
+        Ok(wire_result(&wire, written.len, session))
+    })
+}
+
+unsafe extern "C" fn py_program_chunk_wire(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let next_request_id = match parse_arg_u16(args, 0, "next_request_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let program_id = match parse_arg_u16(args, 1, "program_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let offset = match parse_arg_u32(args, 2, "offset") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let chunk = match parse_arg_bytes(args, 3, "chunk") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    with_session(next_request_id, |session| {
+        let mut wire = vec![0; chunk.len().saturating_add(64).max(128)];
+        let written =
+            build_program_chunk_wire_frame(session, program_id, offset, &chunk, &mut wire)?;
+        Ok(wire_result(&wire, written.len, session))
+    })
+}
+
+unsafe extern "C" fn py_program_end_wire(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let next_request_id = match parse_arg_u16(args, 0, "next_request_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let program_id = match parse_arg_u16(args, 1, "program_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    with_session(next_request_id, |session| {
+        let mut wire = [0u8; 64];
+        let written = build_program_end_wire_frame(session, program_id, &mut wire)?;
+        Ok(wire_result(&wire, written.len, session))
+    })
+}
+
+unsafe extern "C" fn py_run_background_wire(
+    _module: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    let next_request_id = match parse_arg_u16(args, 0, "next_request_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let program_id = match parse_arg_u16(args, 1, "program_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let instruction_budget = match parse_arg_u32(args, 2, "instruction_budget") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    with_session(next_request_id, |session| {
+        let mut wire = [0u8; 96];
+        let written =
+            build_run_background_wire_frame(session, program_id, instruction_budget, &mut wire)?;
+        Ok(wire_result(&wire, written.len, session))
+    })
+}
+
+unsafe extern "C" fn py_decode_response(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let wire = match parse_arg_bytes(args, 0, "wire response") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let mut raw = vec![0; wire.len().max(64)];
+    let decoded = match decode_wire_response(&wire, &mut raw) {
+        Ok(decoded) => decoded,
+        Err(error) => return raise_core_error("decode_response", error),
+    };
+    decoded_response_to_py(&decoded)
+}
+
+fn with_session(
+    next_request_id: u16,
+    operation: impl FnOnce(&mut BoardVmLanguageSession) -> Result<PyObjectPtr, LanguageCoreError>,
+) -> PyObjectPtr {
+    let mut session = BoardVmLanguageSession::with_next_request_id(next_request_id);
+    match operation(&mut session) {
+        Ok(value) => value,
+        Err(error) => unsafe { raise_core_error("Board VM language core", error) },
+    }
+}
+
+unsafe fn wire_result(buffer: &[u8], len: usize, session: &BoardVmLanguageSession) -> PyObjectPtr {
+    let result = PyDict_New();
+    dict_set(result, "frame", bytes_to_py(&buffer[..len]));
+    dict_set(
+        result,
+        "next_request_id",
+        usize_to_py(session.next_request_id() as usize),
+    );
+    result
+}
+
+unsafe fn decoded_response_to_py(decoded: &DecodedLanguageResponse) -> PyObjectPtr {
+    let dict = PyDict_New();
+    dict_set(dict, "request_id", usize_to_py(decoded.request_id as usize));
+    dict_set(
+        dict,
+        "message_type",
+        str_to_py(message_type_name(decoded.message_type.0)),
+    );
+    dict_set(
+        dict,
+        "message_type_code",
+        usize_to_py(decoded.message_type.0 as usize),
+    );
+    dict_set(dict, "flags", usize_to_py(decoded.flags as usize));
+    dict_set(dict, "response", bool_to_py(decoded.is_response()));
+    dict_set(dict, "error", bool_to_py(decoded.is_error_response()));
+    dict_set(dict, "kind", str_to_py(decoded.body.kind()));
+    dict_set(dict, "payload_len", usize_to_py(decoded.payload_len));
+    dict_set(
+        dict,
+        "payload",
+        response_body_to_py(&decoded.body, decoded.payload_len),
+    );
+    dict
+}
+
+unsafe fn response_body_to_py(
+    body: &DecodedLanguageResponseBody,
+    payload_len: usize,
+) -> PyObjectPtr {
+    let dict = PyDict_New();
+    match body {
+        DecodedLanguageResponseBody::HelloAck(ack) => {
+            dict_set(
+                dict,
+                "selected_version",
+                usize_to_py(ack.selected_version as usize),
+            );
+            dict_set(dict, "board_name", str_to_py(&ack.board_name));
+            dict_set(dict, "runtime_name", str_to_py(&ack.runtime_name));
+            dict_set(dict, "host_nonce", usize_to_py(ack.host_nonce as usize));
+            dict_set(dict, "board_nonce", usize_to_py(ack.board_nonce as usize));
+            dict_set(
+                dict,
+                "max_frame_payload",
+                usize_to_py(ack.max_frame_payload as usize),
+            );
+        }
+        DecodedLanguageResponseBody::CapsReport(report) => {
+            dict_set(dict, "board_id", str_to_py(&report.board_id));
+            dict_set(dict, "runtime_id", str_to_py(&report.runtime_id));
+            dict_set(
+                dict,
+                "max_program_bytes",
+                usize_to_py(report.max_program_bytes as usize),
+            );
+            dict_set(
+                dict,
+                "max_stack_values",
+                usize_to_py(report.max_stack_values as usize),
+            );
+            dict_set(
+                dict,
+                "max_handles",
+                usize_to_py(report.max_handles as usize),
+            );
+            dict_set(
+                dict,
+                "supports_store_program",
+                bool_to_py(report.supports_store_program),
+            );
+            let capabilities = PyList_New(report.capabilities.len() as isize);
+            for (index, capability) in report.capabilities.iter().enumerate() {
+                let item = PyDict_New();
+                dict_set(item, "id", usize_to_py(capability.id as usize));
+                dict_set(item, "version", usize_to_py(capability.version as usize));
+                dict_set(item, "flags", usize_to_py(capability.flags as usize));
+                dict_set(item, "name", str_to_py(&capability.name));
+                dict_set(
+                    item,
+                    "bytecode_callable",
+                    bool_to_py(capability_bytecode_callable(capability.flags)),
+                );
+                dict_set(
+                    item,
+                    "protocol_feature",
+                    bool_to_py(capability_protocol_feature(capability.flags)),
+                );
+                dict_set(
+                    item,
+                    "board_metadata",
+                    bool_to_py(capability_board_metadata(capability.flags)),
+                );
+                dict_set(
+                    item,
+                    "flag_names",
+                    capability_flag_names_to_py(capability.flags),
+                );
+                PyList_SetItem(capabilities, index as isize, item);
+            }
+            dict_set(dict, "capabilities", capabilities);
+        }
+        DecodedLanguageResponseBody::ProgramBegin(begin) => {
+            dict_set(dict, "program_id", usize_to_py(begin.program_id as usize));
+            dict_set(dict, "format", str_to_py(program_format_name(begin.format)));
+            dict_set(dict, "total_len", usize_to_py(begin.total_len as usize));
+            dict_set(
+                dict,
+                "program_crc32",
+                usize_to_py(begin.program_crc32 as usize),
+            );
+        }
+        DecodedLanguageResponseBody::ProgramChunk(chunk) => {
+            dict_set(dict, "program_id", usize_to_py(chunk.program_id as usize));
+            dict_set(dict, "offset", usize_to_py(chunk.offset as usize));
+            dict_set(dict, "len", usize_to_py(chunk.len));
+        }
+        DecodedLanguageResponseBody::ProgramEnd(end) => {
+            dict_set(dict, "program_id", usize_to_py(end.program_id as usize));
+        }
+        DecodedLanguageResponseBody::RunReport(report) => {
+            dict_set(dict, "program_id", usize_to_py(report.program_id as usize));
+            dict_set(dict, "status", str_to_py(run_status_name(report.status)));
+            dict_set(
+                dict,
+                "status_code",
+                usize_to_py(report.status.as_u8() as usize),
+            );
+            dict_set(
+                dict,
+                "instructions_executed",
+                usize_to_py(report.instructions_executed as usize),
+            );
+            dict_set(dict, "elapsed_ms", usize_to_py(report.elapsed_ms as usize));
+            dict_set(
+                dict,
+                "stack_depth",
+                usize_to_py(report.stack_depth as usize),
+            );
+            dict_set(
+                dict,
+                "open_handles",
+                usize_to_py(report.open_handles as usize),
+            );
+            dict_set(
+                dict,
+                "return_count",
+                usize_to_py(report.return_count as usize),
+            );
+        }
+        DecodedLanguageResponseBody::Error(error) => {
+            dict_set(dict, "code", usize_to_py(error.code as usize));
+            dict_set(dict, "request_id", usize_to_py(error.request_id as usize));
+            dict_set(dict, "program_id", usize_to_py(error.program_id as usize));
+            dict_set(
+                dict,
+                "bytecode_offset",
+                usize_to_py(error.bytecode_offset as usize),
+            );
+            dict_set(dict, "message", str_to_py(&error.message));
+        }
+        DecodedLanguageResponseBody::Raw => {
+            dict_set(dict, "payload_len", usize_to_py(payload_len));
+        }
+    }
+    dict
+}
+
+unsafe fn capability_flag_names_to_py(flags: u16) -> PyObjectPtr {
+    let mut names = [""; 3];
+    let count = capability_flag_names(flags, &mut names);
+    let list = PyList_New(count as isize);
+    for (index, name) in names[..count].iter().enumerate() {
+        PyList_SetItem(list, index as isize, str_to_py(name));
+    }
+    list
+}
+
+fn build_blink_module_value(
+    pin: u8,
+    high_ms: u16,
+    low_ms: u16,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; BLINK_MODULE_LEN];
+    let len = build_blink_module(
+        BlinkProgram {
+            pin,
+            high_ms,
+            low_ms,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
+unsafe fn parse_arg_bytes(args: PyObjectPtr, index: isize, name: &str) -> Option<Vec<u8>> {
+    let arg = PyTuple_GetItem(args, index);
+    if arg.is_null() {
+        PyErr_Clear();
+        set_error(type_error_class(), &format!("missing {name} argument"));
+        return None;
+    }
+    match bytes_from_py(arg) {
+        Some(value) => Some(value),
+        None => {
+            set_error(type_error_class(), &format!("{name} must be bytes"));
+            None
+        }
+    }
+}
+
+unsafe fn parse_arg_u8(args: PyObjectPtr, index: isize, name: &str) -> Option<u8> {
+    parse_arg_unsigned(args, index, name, u8::MAX as u64).map(|value| value as u8)
+}
+
+unsafe fn parse_arg_u16(args: PyObjectPtr, index: isize, name: &str) -> Option<u16> {
+    parse_arg_unsigned(args, index, name, u16::MAX as u64).map(|value| value as u16)
+}
+
+unsafe fn parse_arg_u32(args: PyObjectPtr, index: isize, name: &str) -> Option<u32> {
+    parse_arg_unsigned(args, index, name, u32::MAX as u64).map(|value| value as u32)
+}
+
+unsafe fn parse_arg_unsigned(args: PyObjectPtr, index: isize, name: &str, max: u64) -> Option<u64> {
+    let arg = PyTuple_GetItem(args, index);
+    if arg.is_null() {
+        PyErr_Clear();
+        set_error(type_error_class(), &format!("missing {name} argument"));
+        return None;
+    }
+    PyErr_Clear();
+    let value = PyLong_AsLong(arg);
+    if value == -1 && !PyErr_Occurred().is_null() {
+        PyErr_Clear();
+        set_error(type_error_class(), &format!("{name} must be an integer"));
+        return None;
+    }
+    if value < 0 {
+        set_error(value_error_class(), &format!("{name} must be non-negative"));
+        return None;
+    }
+    let value = value as u64;
+    if value > max {
+        set_error(
+            value_error_class(),
+            &format!("{name} must be less than or equal to {max}"),
+        );
+        return None;
+    }
+    Some(value)
+}
+
+unsafe fn dict_set(dict: PyObjectPtr, key: &str, value: PyObjectPtr) {
+    let key = str_to_py(key);
+    PyDict_SetItem(dict, key, value);
+    Py_DecRef(key);
+    Py_DecRef(value);
+}
+
+fn message_type_name(code: u8) -> &'static str {
+    match code {
+        0x01 => "hello",
+        0x02 => "hello_ack",
+        0x03 => "caps_query",
+        0x04 => "caps_report",
+        0x05 => "program_begin",
+        0x06 => "program_chunk",
+        0x07 => "program_end",
+        0x08 => "run",
+        0x09 => "run_report",
+        0x0A => "stop",
+        0x0B => "reset_vm",
+        0x0C => "store_program",
+        0x0D => "run_stored",
+        0x0E => "read_state",
+        0x0F => "state_report",
+        0x10 => "subscribe",
+        0x11 => "event",
+        0x12 => "log",
+        0x13 => "error",
+        0x14 => "ping",
+        0x15 => "pong",
+        _ => "unknown",
+    }
+}
+
+unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectPtr {
+    set_error(
+        runtime_error_class(),
+        &format!("{context} failed in Rust language core: {error:?}"),
+    );
+    ptr::null_mut()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
+    let methods: &'static mut [PyMethodDef; 9] = Box::leak(Box::new([
+        PyMethodDef {
+            ml_name: b"hello_wire\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_hello_wire),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM HELLO wire frame in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"caps_query_wire\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_caps_query_wire),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM CAPS_QUERY wire frame in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"blink_module\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_blink_module),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM blink BVM module in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"program_begin_wire\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_program_begin_wire),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM PROGRAM_BEGIN wire frame in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"program_chunk_wire\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_program_chunk_wire),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM PROGRAM_CHUNK wire frame in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"program_end_wire\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_program_end_wire),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM PROGRAM_END wire frame in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"run_background_wire\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_run_background_wire),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM background RUN wire frame in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"decode_response\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_decode_response),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Decode a Board VM wire response in Rust.\0".as_ptr() as *const c_char,
+        },
+        method_def_sentinel(),
+    ]));
+
+    let def: &'static mut PyModuleDef = Box::leak(Box::new(PyModuleDef {
+        m_base: PyModuleDef_Base {
+            ob_base: [0u8; std::mem::size_of::<usize>() * 2],
+            m_init: None,
+            m_index: 0,
+            m_copy: ptr::null_mut(),
+        },
+        m_name: b"board_vm_native\0".as_ptr() as *const c_char,
+        m_doc: b"Rust-owned Board VM protocol framing and decoding for Python sugar.\0".as_ptr()
+            as *const c_char,
+        m_size: -1,
+        m_methods: methods.as_mut_ptr(),
+        m_slots: ptr::null_mut(),
+        m_traverse: ptr::null_mut(),
+        m_clear: ptr::null_mut(),
+        m_free: ptr::null_mut(),
+    }));
+
+    PyModule_Create2(def as *mut PyModuleDef, PYTHON_API_VERSION)
+}

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -1,0 +1,103 @@
+from board_vm_native import BoardDescriptor, ProtocolResult, Session
+
+
+class FakeWriteTransport:
+    def __init__(self):
+        self.frames = []
+
+    def write(self, frame):
+        self.frames.append(frame)
+
+
+def test_native_session_builds_protocol_bytes_in_rust():
+    session = Session()
+
+    hello = session.hello(host_nonce=0x1234_ABCD)
+    assert isinstance(hello.frame, bytes)
+    assert len(hello.frame) > 0
+    assert session.next_request_id == 2
+
+    caps = session.capabilities()
+    assert isinstance(caps.frame, bytes)
+    assert len(caps.frame) > 0
+    assert session.next_request_id == 3
+
+    module = session.blink_module(pin=13, high_ms=250, low_ms=250, max_stack=4)
+    assert isinstance(module, bytes)
+    assert len(module) > 0
+
+
+def test_session_dispatches_frames_through_write_transport():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.blink(program_id=7, instruction_budget=24, handshake=True, query_caps=True)
+
+    assert [item.command for item in result.results] == [
+        "hello",
+        "capabilities",
+        "program_begin",
+        "program_chunk",
+        "program_end",
+        "run",
+    ]
+    assert result.frames == transport.frames
+    assert all(isinstance(frame, bytes) and frame for frame in result.frames)
+    assert result.responses == [None] * 6
+    assert result.decoded_responses == [None] * 6
+
+
+def test_run_command_accepts_repl_style_blink():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.run_command("blink 42", program_id=9)
+
+    assert [item.command for item in result.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+        "run",
+    ]
+    assert result.frames == transport.frames
+
+
+def test_board_descriptor_wraps_rust_decoded_capability_payload():
+    descriptor = BoardDescriptor(
+        {
+            "board_id": "arduino-uno-r4-wifi",
+            "runtime_id": "board-vm-uno-r4",
+            "max_program_bytes": 1024,
+            "max_stack_values": 16,
+            "max_handles": 4,
+            "supports_store_program": False,
+            "capabilities": [
+                {"id": 1, "version": 1, "flags": 1, "name": "gpio.open"},
+                {
+                    "id": 0x7001,
+                    "version": 1,
+                    "flags": 2,
+                    "name": "program.ram_exec",
+                    "protocol_feature": True,
+                    "flag_names": ["protocol_feature"],
+                },
+            ],
+        }
+    )
+
+    assert descriptor.board_id == "arduino-uno-r4-wifi"
+    assert descriptor.runtime_id == "board-vm-uno-r4"
+    assert descriptor.capability_names == ["gpio.open", "program.ram_exec"]
+    assert descriptor.supports("gpio.open")
+    assert descriptor.supports(0x7001)
+    assert descriptor.capability("gpio.open").name == "gpio.open"
+    assert descriptor.capability("gpio.open").bytecode_callable
+    assert descriptor.capability("program.ram_exec").protocol_feature
+    assert descriptor.capability("program.ram_exec").flag_names == ["protocol_feature"]
+
+    result = ProtocolResult(
+        command="capabilities",
+        frame=b"frame",
+        decoded_response={"kind": "caps_report", "payload": descriptor.raw},
+    )
+    assert result.board_descriptor.capability_names == descriptor.capability_names


### PR DESCRIPTION
## Summary

- add a Python board-vm-native package backed by the repo-local python-bridge
- route Python session sugar through board-vm-language-core for Rust-owned request IDs, wire frames, blink modules, and response decoding
- expose board descriptors and capability flag helpers in Python while keeping protocol details in Rust

## Tests

- sh BUILD (code/packages/python/board-vm-native)
- cargo test -p board-vm-language-core
- cargo test -p board-vm-protocol
