### PR TITLE
Expose Board VM stop command

### DIFF
--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -6,10 +6,10 @@ use board_vm_host::{BlinkProgram, BLINK_MODULE_LEN};
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
     build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
-    build_run_background_wire_frame, capability_board_metadata, capability_bytecode_callable,
-    capability_flag_names, capability_protocol_feature, decode_wire_response, program_format_name,
-    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse,
-    DecodedLanguageResponseBody, LanguageCoreError,
+    build_run_background_wire_frame, build_stop_wire_frame, capability_board_metadata,
+    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
+    decode_wire_response, program_format_name, run_status_name, BoardVmLanguageSession,
+    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError,
 };
 use ruby_bridge::VALUE;
 
@@ -144,6 +144,14 @@ extern "C" fn session_run_background_wire(
             instruction_budget,
             &mut wire,
         )?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_stop_wire(self_val: VALUE) -> VALUE {
+    with_session_mut(self_val, |session| {
+        let mut wire = [0u8; 64];
+        let written = build_stop_wire_frame(&mut session.inner, &mut wire)?;
         Ok(bytes_result(&wire, written.len))
     })
 }
@@ -539,6 +547,12 @@ pub extern "C" fn Init_board_vm_native() {
         "run_background_wire",
         session_run_background_wire as *const c_void,
         2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "stop_wire",
+        session_stop_wire as *const c_void,
+        0,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -72,6 +72,10 @@ module CodingAdventures
         )
       end
 
+      def stop
+        dispatch(:stop, native_session.stop_wire)
+      end
+
       def blink(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -121,6 +125,9 @@ module CodingAdventures
           upload_blink(**options)
         when "run"
           SessionResult.new(results: [run(**options.merge(optional_budget(words, command)))])
+        when "stop"
+          ensure_no_extra_arguments!(words, command)
+          SessionResult.new(results: [stop])
         when "blink"
           blink(**options.merge(optional_budget(words, command)))
         else

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -101,17 +101,35 @@ module CodingAdventures
             caps = session.capabilities
             upload = session.upload_blink(program_id: 4)
             run = session.run(program_id: 4, budget: 77)
+            stop = session.stop
 
             assert_equal :hello, hello.command
             assert_equal :capabilities, caps.command
             assert_equal [:program_begin, :program_chunk, :program_end], upload.results.map(&:command)
             assert_equal :run, run.command
+            assert_equal :stop, stop.command
           end
         end
 
         assert_empty runner.calls
-        assert_equal 6, transport.frames.length
+        assert_equal 7, transport.frames.length
         assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+      end
+
+      def test_session_run_command_accepts_repl_style_stop
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("stop")
+
+          assert_equal [:stop], result.results.map(&:command)
+          assert_equal result.frames, transport.frames
+        end
       end
 
       def test_session_run_command_accepts_repl_style_blink
@@ -190,10 +208,16 @@ module CodingAdventures
 
         default_nonce_hello = session.hello_wire("bvm", BoardVM::DEFAULT_HOST_NONCE)
         assert_operator default_nonce_hello.bytesize, :>, 0
+        assert_equal 3, session.next_request_id
 
         module_bytes = session.blink_module(13, 250, 250, 4)
         assert_instance_of String, module_bytes
         assert_operator module_bytes.bytesize, :>, 0
+
+        stop = session.stop_wire
+        assert_instance_of String, stop
+        assert_operator stop.bytesize, :>, 0
+        assert_equal 4, session.next_request_id
 
         frames = BoardVM::Native::Session.new.blink_upload_run_frames(7, 12, 13, 250, 250, 4)
         assert_equal 4, frames.length

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -453,6 +453,21 @@ pub fn build_run_background_wire_frame(
     })
 }
 
+pub fn build_stop_wire_frame(
+    session: &mut BoardVmLanguageSession,
+    wire_out: &mut [u8],
+) -> Result<BuiltWireFrame, LanguageCoreError> {
+    let mut raw = [0u8; 16];
+    let mut host = session.host_session();
+    let written = host.stop_frame(&mut raw)?;
+    let wire_len = encode_wire_frame(&raw[..written.len], wire_out)?;
+    session.update_from_host_session(&host);
+    Ok(BuiltWireFrame {
+        request_id: written.request_id,
+        len: wire_len,
+    })
+}
+
 pub fn decode_wire_frame_into_raw(
     wire_frame: &[u8],
     raw_out: &mut [u8],
@@ -799,6 +814,23 @@ pub unsafe extern "C" fn board_vm_language_run_background_wire(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_stop_wire(
+    session: *mut BoardVmLanguageSession,
+    wire_out: *mut u8,
+    wire_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let session = unsafe { mut_ref(session, "board_vm_language_stop_wire session") }?;
+        let wire_out = unsafe { out_slice(wire_out, wire_cap, "wire_out") }?;
+        let written = build_stop_wire_frame(session, wire_out)?;
+        Ok(BoardVmLanguageStatus::written(
+            written.request_id,
+            written.len,
+        ))
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_decode_wire_frame(
     wire_frame: *const u8,
     wire_frame_len: u64,
@@ -1064,6 +1096,15 @@ mod tests {
             run_payload.flags,
             RUN_FLAG_RESET_VM_BEFORE_RUN | RUN_FLAG_BACKGROUND_RUN
         );
+
+        let stop = unsafe {
+            board_vm_language_stop_wire(&mut session, wire.as_mut_ptr(), wire.len() as u64)
+        };
+        assert_eq!(stop.request_id, 5);
+        let decoded = decode_wire_frame_into_raw(&wire[..stop.len as usize], &mut raw).unwrap();
+        assert_eq!(decoded.message_type, MessageType::STOP.0);
+        let frame = decode_frame(&raw[..decoded.len as usize]).unwrap();
+        assert!(frame.payload.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add Rust language-core wire-frame construction and C ABI export for Board VM STOP
- expose stop_wire through the Ruby native bridge and Session#stop
- add REPL-style Ruby session command support via run_command("stop")

## Tests

- cargo test -p board-vm-language-core
- rake test (code/packages/ruby/board_vm)
