### PR TITLE
Add Prolog term I/O conveniences

### DIFF
--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -16,6 +16,9 @@
   forms, and current-output write/flush forms
 - adapt parser-backed stream term I/O predicates including `read/1`,
   `read/2`, `read_term/2`, `read_term/3`, `write_term/2`, and `write_term/3`
+- adapt term I/O conveniences including `read_term` `singletons/1`,
+  `writeq/1,2`, `write_canonical/1,2`, `writeln/1,2`, and
+  `portray_clause/1,2`
 - preserve source query variables across `goal_expansion/2` rewrites
 - adapt Prolog `call/2..8` into variadic callable-term execution
 - preserve extra arguments while rewriting module-qualified `call/N` meta-goals

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -71,6 +71,9 @@ It keeps parsing side-effect free, then exposes helpers to:
 - adapt parser-backed stream term I/O predicates including `read/1`,
   `read/2`, `read_term/2`, `read_term/3`, `write_term/2`, and
   `write_term/3`
+- adapt term I/O conveniences including `read_term` `singletons/1`,
+  `writeq/1,2`, `write_canonical/1,2`, `writeln/1,2`, and
+  `portray_clause/1,2`
 - load SWI-Prolog source graphs from real `.pl` files through relative
   `consult/1`, `ensure_loaded/1`, and file-backed `use_module/1,2`
 - splice `include/1` targets into the including source before project linking

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -545,6 +545,22 @@ def _adapt_relation_call(
         return _write_current_term_goal(*args)
     if name == "write_term" and goal.relation.arity == 3:
         return _write_stream_term_goal(*args)
+    if name == "writeq" and goal.relation.arity == 1:
+        return _write_current_term_goal(args[0], _quoted_write_options())
+    if name == "writeq" and goal.relation.arity == 2:
+        return _write_stream_term_goal(args[0], args[1], _quoted_write_options())
+    if name == "write_canonical" and goal.relation.arity == 1:
+        return _write_current_term_goal(args[0], _canonical_write_options())
+    if name == "write_canonical" and goal.relation.arity == 2:
+        return _write_stream_term_goal(args[0], args[1], _canonical_write_options())
+    if name == "writeln" and goal.relation.arity == 1:
+        return _writeln_current_term_goal(args[0])
+    if name == "writeln" and goal.relation.arity == 2:
+        return _writeln_stream_term_goal(*args)
+    if name == "portray_clause" and goal.relation.arity == 1:
+        return _portray_current_clause_goal(args[0])
+    if name == "portray_clause" and goal.relation.arity == 2:
+        return _portray_stream_clause_goal(*args)
     if name == "atom_concat" and goal.relation.arity == 3:
         return atom_concato(*args)
     if name == "atom_length" and goal.relation.arity == 2:
@@ -782,7 +798,11 @@ def _read_term_from_atom_goal(
         parsed = _parse_atom_text(reified_atom)
         if parsed is None:
             return
-        options_goal = _read_term_options_goal(options_arg, parsed.variables)
+        options_goal = _read_term_options_goal(
+            options_arg,
+            parsed.term,
+            parsed.variables,
+        )
         if options_goal is None:
             return
         yield from solve_from(
@@ -808,7 +828,7 @@ def _read_current_term_goal(term_value: object, options: object) -> GoalExpr:
         if parsed is None:
             return
         parsed_term, variables = parsed
-        options_goal = _read_term_options_goal(options_arg, variables)
+        options_goal = _read_term_options_goal(options_arg, parsed_term, variables)
         if options_goal is None:
             return
         yield from solve_from(
@@ -838,7 +858,7 @@ def _read_stream_term_goal(
         if parsed is None:
             return
         parsed_term, variables = parsed
-        options_goal = _read_term_options_goal(options_arg, variables)
+        options_goal = _read_term_options_goal(options_arg, parsed_term, variables)
         if options_goal is None:
             return
         yield from solve_from(
@@ -916,6 +936,78 @@ def _write_stream_term_goal(
             yield state
 
     return native_goal(run, stream_value, term_value, options)
+
+
+def _writeln_current_term_goal(term_value: object) -> GoalExpr:
+    def run(_program: Program, state: State, args: tuple[Term, ...]) -> Iterator[State]:
+        [term_arg] = args
+        rendered = _render_bound_term(reify(term_arg, state.substitution))
+        if rendered is not None and _write_current_stream(f"{rendered}\n"):
+            yield state
+
+    return native_goal(run, term_value)
+
+
+def _writeln_stream_term_goal(stream_value: object, term_value: object) -> GoalExpr:
+    def run(_program: Program, state: State, args: tuple[Term, ...]) -> Iterator[State]:
+        stream_arg, term_arg = args
+        rendered = _render_bound_term(reify(term_arg, state.substitution))
+        if rendered is not None and _write_stream(
+            reify(stream_arg, state.substitution),
+            f"{rendered}\n",
+        ):
+            yield state
+
+    return native_goal(run, stream_value, term_value)
+
+
+def _portray_current_clause_goal(term_value: object) -> GoalExpr:
+    def run(_program: Program, state: State, args: tuple[Term, ...]) -> Iterator[State]:
+        [term_arg] = args
+        rendered = _render_bound_term(
+            reify(term_arg, state.substitution),
+            numbervars=True,
+        )
+        if rendered is not None and _write_current_stream(f"{rendered}.\n"):
+            yield state
+
+    return native_goal(run, term_value)
+
+
+def _portray_stream_clause_goal(stream_value: object, term_value: object) -> GoalExpr:
+    def run(_program: Program, state: State, args: tuple[Term, ...]) -> Iterator[State]:
+        stream_arg, term_arg = args
+        rendered = _render_bound_term(
+            reify(term_arg, state.substitution),
+            numbervars=True,
+        )
+        if rendered is not None and _write_stream(
+            reify(stream_arg, state.substitution),
+            f"{rendered}.\n",
+        ):
+            yield state
+
+    return native_goal(run, stream_value, term_value)
+
+
+def _render_bound_term(term_value: Term, *, numbervars: bool = False) -> str | None:
+    if isinstance(term_value, LogicVar):
+        return None
+    return _render_prolog_term(term_value, numbervars=numbervars)
+
+
+def _quoted_write_options() -> Term:
+    return logic_list([term("quoted", atom("true"))])
+
+
+def _canonical_write_options() -> Term:
+    return logic_list(
+        [
+            term("quoted", atom("true")),
+            term("ignore_ops", atom("true")),
+            term("numbervars", atom("true")),
+        ],
+    )
 
 
 def _parse_atom_text(atom_value: Atom) -> ParsedOperatorTerm | None:
@@ -1035,8 +1127,33 @@ def _variable_values(variables: dict[str, LogicVar]) -> Term:
     return logic_list(list(variables.values()))
 
 
+def _variable_singletons(
+    parsed_term: Term,
+    variables: dict[str, LogicVar],
+) -> Term:
+    counts: dict[LogicVar, int] = {}
+    _count_term_variables(parsed_term, counts)
+    return logic_list(
+        [
+            term("=", atom(name), variable)
+            for name, variable in variables.items()
+            if counts.get(variable, 0) == 1
+        ],
+    )
+
+
+def _count_term_variables(term_value: Term, counts: dict[LogicVar, int]) -> None:
+    if isinstance(term_value, LogicVar):
+        counts[term_value] = counts.get(term_value, 0) + 1
+        return
+    if isinstance(term_value, Compound):
+        for argument in term_value.args:
+            _count_term_variables(argument, counts)
+
+
 def _read_term_options_goal(
     options: Term,
+    parsed_term: Term,
     variables: dict[str, LogicVar],
 ) -> GoalExpr | None:
     items = _logic_list_items(options)
@@ -1051,6 +1168,8 @@ def _read_term_options_goal(
             goals.append(eq(item.args[0], _variable_bindings(variables)))
         elif item.functor.name == "variables":
             goals.append(eq(item.args[0], _variable_values(variables)))
+        elif item.functor.name == "singletons":
+            goals.append(eq(item.args[0], _variable_singletons(parsed_term, variables)))
         else:
             return None
     return conj(*goals)

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -1641,7 +1641,8 @@ class TestPrologGoalAdapter:
         parsed = parse_swi_query(
             f"?- open('{input_atom}', read, In, [alias(term_input)]), "
             "read(In, First), "
-            "read_term(In, Second, [variable_names(Names), variables(Vars)]), "
+            "read_term(In, Second, "
+            "[variable_names(Names), variables(Vars), singletons(Singletons)]), "
             "read(In, Eof), "
             "close(In), "
             f"open('{input_atom}', read, CurrentIn, [alias(current_term_input)]), "
@@ -1668,6 +1669,7 @@ class TestPrologGoalAdapter:
                 parsed.variables["Second"],
                 parsed.variables["Names"],
                 parsed.variables["Vars"],
+                parsed.variables["Singletons"],
                 parsed.variables["Eof"],
                 parsed.variables["CurrentFirst"],
                 parsed.variables["CurrentSecond"],
@@ -1681,6 +1683,7 @@ class TestPrologGoalAdapter:
             second,
             names,
             vars_value,
+            singletons,
             eof,
             current_first,
             current_second,
@@ -1690,11 +1693,51 @@ class TestPrologGoalAdapter:
         assert second == term("pair", "tea", second.args[1])
         assert names == logic_list([term("=", "X", second.args[1])])
         assert vars_value == logic_list([second.args[1]])
+        assert singletons == logic_list([term("=", "X", second.args[1])])
         assert eof == atom("end_of_file")
         assert current_first == first
         assert current_second == term("pair", "tea", current_second.args[1])
         assert output_path.read_text(encoding="utf-8") == (
             "box(cake).\nbox(cake).\npair(tea, X)"
+        )
+
+    def test_adapt_prolog_goal_rewrites_term_writer_conveniences(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        output_path = tmp_path / "writer-conveniences.pltxt"
+        output_atom = str(output_path).replace("\\", "\\\\").replace("'", "\\'")
+        parsed = parse_swi_query(
+            f"?- read_term_from_atom('pair(X, Y, X, Z)', Term, "
+            "[singletons(Singletons)]), "
+            f"open('{output_atom}', write, Out, [alias(writer_output)]), "
+            "writeq(Out, 'two words'), "
+            "nl(Out), "
+            "write_canonical(Out, '$VAR'(0)), "
+            "nl(Out), "
+            "writeln(Out, line(one)), "
+            "set_output(writer_output), "
+            "portray_clause(fact('$VAR'(1))), "
+            "close(Out).",
+        )
+
+        answers = solve_all(
+            program(),
+            (parsed.variables["Term"], parsed.variables["Singletons"]),
+            adapt_prolog_goal(parsed.goal),
+        )
+
+        assert len(answers) == 1
+        parsed_term, singletons = answers[0]
+        assert isinstance(parsed_term, Compound)
+        assert singletons == logic_list(
+            [
+                term("=", "Y", parsed_term.args[1]),
+                term("=", "Z", parsed_term.args[3]),
+            ],
+        )
+        assert output_path.read_text(encoding="utf-8") == (
+            "'two words'\nA\nline(one)\nfact(B).\n"
         )
 
     def test_adapt_prolog_goal_rewrites_term_read_write_options(self) -> None:

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -20,8 +20,11 @@
 - Run parser-backed stream term I/O predicates through structured and bytecode
   VM paths, including `read/1`, `read/2`, `read_term/2`, `read_term/3`,
   `write_term/2`, and `write_term/3`.
+- Run term I/O convenience predicates through structured and bytecode VM paths,
+  including `read_term` `singletons/1`, `writeq/1,2`,
+  `write_canonical/1,2`, `writeln/1,2`, and `portray_clause/1,2`.
 - Add a public Prolog VM capability manifest and `prolog-vm --dump-capabilities`
-  so scripts and future planning can distinguish the completed PR00-PR83 track
+  so scripts and future planning can distinguish the completed PR00-PR84 track
   from deferred advanced dialect/runtime work.
 - Add end-to-end stress coverage for recursive search, modules, DCGs,
   arithmetic, collections, dynamic initialization, named answers, and expansion.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -249,7 +249,7 @@ assert [answer.as_dict() for answer in runtime.query("ancestor(homer, Who)")] ==
 
 ## Capability Manifest
 
-The Prolog-on-Logic-VM implementation track covers PR00 through PR83. The
+The Prolog-on-Logic-VM implementation track covers PR00 through PR84. The
 package exposes that as a machine-readable manifest so downstream tools and
 future implementation work can distinguish completed functionality from
 deliberately deferred advanced dialect/runtime emulation:
@@ -259,7 +259,7 @@ from prolog_vm_compiler import prolog_vm_capability_manifest
 
 manifest = prolog_vm_capability_manifest()
 
-assert manifest.status == "core-plus-stream-term-io"
+assert manifest.status == "core-plus-term-io-conveniences"
 assert manifest.dialects == ("iso", "swi")
 assert manifest.backends == ("structured", "bytecode")
 ```
@@ -278,7 +278,9 @@ selected current-stream forms via `set_input/1`, `set_output/1`,
 `current_input/1`, `current_output/1`, `get_char/1`, `read_string/2`,
 `read_line_to_string/1`, `at_end_of_stream/0`, `write/1`, `nl/0`, and
 `flush_output/0`, plus parser-backed stream term I/O through `read/1`,
-`read/2`, `read_term/2`, `read_term/3`, `write_term/2`, and `write_term/3`.
+`read/2`, `read_term/2`, `read_term/3`, `write_term/2`, and `write_term/3`,
+plus term I/O conveniences through `read_term` `singletons/1`, `writeq/1,2`,
+`write_canonical/1,2`, `writeln/1,2`, and `portray_clause/1,2`.
 The manifest also names the remaining advanced-dialect work that is intentionally
 outside the completed batches: full external dialect emulation, tabling and
 well-founded negation, generalized attributed-variable/coroutining services,

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
@@ -267,6 +267,21 @@ def prolog_vm_capabilities() -> tuple[PrologVMCapability, ...]:
                 "structured and bytecode VM stress coverage",
             ),
         ),
+        PrologVMCapability(
+            id="host-term-io-conveniences",
+            title="Bounded term I/O convenience predicates",
+            status="complete",
+            specs=("PR84",),
+            packages=("prolog-loader", "prolog-vm-compiler"),
+            features=(
+                "read_term singletons/1 option support on atom/current/stream reads",
+                "writeq/1,2 quoted term rendering",
+                "write_canonical/1,2 numbervars-aware canonical rendering",
+                "writeln/1,2 newline-terminating term writes",
+                "portray_clause/1,2 clause-terminating canonical writes",
+                "structured and bytecode VM stress coverage",
+            ),
+        ),
     )
 
 
@@ -317,8 +332,8 @@ def prolog_vm_capability_manifest() -> PrologVMCapabilityManifest:
     """Return the canonical capability manifest for this package."""
 
     return PrologVMCapabilityManifest(
-        track="Prolog-on-Logic-VM PR00-PR83",
-        status="core-plus-stream-term-io",
+        track="Prolog-on-Logic-VM PR00-PR84",
+        status="core-plus-term-io-conveniences",
         dialects=("iso", "swi"),
         backends=("structured", "bytecode"),
         capabilities=prolog_vm_capabilities(),

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_bytecode_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_bytecode_vm_stress.py
@@ -561,3 +561,43 @@ class TestPrologBytecodeVMStress:
         assert output_path.read_text(encoding="utf-8") == (
             "box(cake).\nbox(cake).\npair(tea, X)"
         )
+
+    def test_term_writer_conveniences_match_structured_vm(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        output_path = tmp_path / "bytecode-writer-conveniences.pltxt"
+        output_atom = str(output_path).replace("\\", "\\\\").replace("'", "\\'")
+        compiled = compile_swi_prolog_source(
+            f"""
+            ?- read_term_from_atom('pair(X, Y, X, Z)', Term,
+                   [singletons(Singletons)]),
+               open('{output_atom}', write, Out,
+                    [alias(bytecode_writer_output)]),
+               writeq(Out, 'two words'),
+               nl(Out),
+               write_canonical(Out, '$VAR'(0)),
+               nl(Out),
+               writeln(Out, line(one)),
+               set_output(bytecode_writer_output),
+               portray_clause(fact('$VAR'(1))),
+               close(Out).
+            """,
+        )
+
+        answers = run_compiled_prolog_bytecode_query_answers(compiled)
+
+        assert len(run_compiled_prolog_query_answers(compiled)) == len(answers)
+        assert len(answers) == 1
+        answer = answers[0].as_dict()
+        parsed_term = answer["Term"]
+        assert isinstance(parsed_term, Compound)
+        assert answer["Singletons"] == logic_list(
+            [
+                term("=", "Y", parsed_term.args[1]),
+                term("=", "Z", parsed_term.args[3]),
+            ],
+        )
+        assert output_path.read_text(encoding="utf-8") == (
+            "'two words'\nA\nline(one)\nfact(B).\n"
+        )

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
@@ -9,31 +9,31 @@ from prolog_vm_compiler import (
 )
 
 
-def test_manifest_marks_stream_term_io_extension_complete() -> None:
+def test_manifest_marks_term_io_conveniences_extension_complete() -> None:
     manifest = prolog_vm_capability_manifest()
 
-    assert manifest.track == "Prolog-on-Logic-VM PR00-PR83"
-    assert manifest.status == "core-plus-stream-term-io"
+    assert manifest.track == "Prolog-on-Logic-VM PR00-PR84"
+    assert manifest.status == "core-plus-term-io-conveniences"
     assert manifest.dialects == ("iso", "swi")
     assert manifest.backends == ("structured", "bytecode")
-    assert manifest.complete_count == 13
+    assert manifest.complete_count == 14
     assert manifest.deferred_count == 3
 
 
-def test_completed_capabilities_cover_pr00_through_pr83_once() -> None:
+def test_completed_capabilities_cover_pr00_through_pr84_once() -> None:
     covered_specs = [
         spec for capability in prolog_vm_capabilities() for spec in capability.specs
     ]
 
-    assert covered_specs == [f"PR{index:02d}" for index in range(84)]
+    assert covered_specs == [f"PR{index:02d}" for index in range(85)]
 
 
 def test_capability_manifest_is_json_serializable() -> None:
     payload = prolog_vm_capability_manifest().as_dict()
 
-    assert payload["status"] == "core-plus-stream-term-io"
+    assert payload["status"] == "core-plus-term-io-conveniences"
     assert payload["capabilities"][0]["id"] == "frontend-loader"
-    assert payload["capabilities"][-1]["id"] == "host-stream-term-io"
+    assert payload["capabilities"][-1]["id"] == "host-term-io-conveniences"
     assert payload["deferred_capabilities"][0]["status"] == "deferred"
 
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -21,11 +21,11 @@ def test_cli_dumps_capability_manifest_without_source(
     assert status == 0
     assert payload["success"] is True
     assert payload["mode"] == "capabilities"
-    assert payload["status"] == "core-plus-stream-term-io"
+    assert payload["status"] == "core-plus-term-io-conveniences"
     assert payload["dialects"] == ["iso", "swi"]
     assert payload["backends"] == ["structured", "bytecode"]
     assert payload["capabilities"][0]["specs"][0] == "PR00"
-    assert payload["capabilities"][-1]["specs"][-1] == "PR83"
+    assert payload["capabilities"][-1]["specs"][-1] == "PR84"
 
 
 def test_cli_dump_capabilities_rejects_source_modes(

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -1236,6 +1236,41 @@ class TestPrologVMStress:
             "box(cake).\nbox(cake).\npair(tea, X)"
         )
 
+    def test_term_writer_conveniences_run_through_vm(self, tmp_path: Path) -> None:
+        output_path = tmp_path / "writer-conveniences.pltxt"
+        output_atom = str(output_path).replace("\\", "\\\\").replace("'", "\\'")
+        compiled = compile_swi_prolog_source(
+            f"""
+            ?- read_term_from_atom('pair(X, Y, X, Z)', Term,
+                   [singletons(Singletons)]),
+               open('{output_atom}', write, Out, [alias(vm_writer_output)]),
+               writeq(Out, 'two words'),
+               nl(Out),
+               write_canonical(Out, '$VAR'(0)),
+               nl(Out),
+               writeln(Out, line(one)),
+               set_output(vm_writer_output),
+               portray_clause(fact('$VAR'(1))),
+               close(Out).
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        assert len(answers) == 1
+        answer = answers[0].as_dict()
+        parsed_term = answer["Term"]
+        assert isinstance(parsed_term, Compound)
+        assert answer["Singletons"] == logic_list(
+            [
+                term("=", "Y", parsed_term.args[1]),
+                term("=", "Z", parsed_term.args[3]),
+            ],
+        )
+        assert output_path.read_text(encoding="utf-8") == (
+            "'two words'\nA\nline(one)\nfact(B).\n"
+        )
+
     def test_initialized_named_answers_keep_runtime_assertions_visible(self) -> None:
         compiled = compile_swi_prolog_source(
             """

--- a/code/specs/PR84-prolog-term-io-conveniences.md
+++ b/code/specs/PR84-prolog-term-io-conveniences.md
@@ -1,0 +1,65 @@
+# PR84 - Prolog Term I/O Conveniences
+
+## Goal
+
+Close the next practical term I/O gap by adding the common reader and writer
+conveniences that Prolog programs expect on top of the bounded parser-backed
+term I/O layer from PR83.
+
+This batch adds:
+
+- `read_term` `singletons/1`
+- `writeq/1`
+- `writeq/2`
+- `write_canonical/1`
+- `write_canonical/2`
+- `writeln/1`
+- `writeln/2`
+- `portray_clause/1`
+- `portray_clause/2`
+
+## Semantics
+
+`read_term_from_atom/3`, `read_term/2`, and `read_term/3` support
+`singletons(Singletons)` in the same finite parser-backed option subset as
+`variable_names/1` and `variables/1`. The value is a list of `Name = Var`
+pairs for named variables that occur exactly once in the parsed term.
+
+`writeq/1` and `writeq/2` render through `write_term` with `quoted(true)`.
+`write_canonical/1` and `write_canonical/2` render through `write_term` with
+`ignore_ops(true)` and `numbervars(true)`. `writeln/1` and `writeln/2` render a
+term and then emit a newline.
+
+`portray_clause/1` and `portray_clause/2` render a term in canonical
+numbervars-aware form, append a full stop, and terminate the clause with a
+newline. The arity-one forms target the selected current output stream from
+PR82; the arity-two forms target an explicit bounded output stream handle or
+alias.
+
+The predicates intentionally inherit the finite bounded stream model from
+PR79-PR83. Invalid stream handles, input-stream writes, malformed option lists,
+unparseable term text, and unsupported rich SWI/ISO reader/writer options fail
+deterministically.
+
+## Validation
+
+Coverage should prove:
+
+- source-level Prolog calls adapt singleton-aware term reads through the
+  parser-backed loader layer.
+- source-level writer convenience predicates lower to executable bounded stream
+  writes for explicit and current output streams.
+- quoted, canonical numbervars, newline, and clause-terminating rendering all
+  produce deterministic text.
+- structured VM and bytecode VM run matching term I/O convenience programs.
+- the capability manifest records PR84 as complete while leaving
+  console-backed standard streams, binary streams, rich ISO/SWI options,
+  foreign predicates, and async host services deferred.
+
+## Non-goals
+
+- no console-backed `user_input`, `user_output`, or `user_error` streams
+- no binary streams or encodings beyond UTF-8
+- no full ISO/SWI reader or writer option matrix
+- no custom portray hooks or module-sensitive operator printing
+- no foreign predicate or async host callback boundary


### PR DESCRIPTION
## Summary

- Add singleton-aware `read_term` option support for atom, current stream, and explicit stream reads.
- Adapt `writeq/1,2`, `write_canonical/1,2`, `writeln/1,2`, and `portray_clause/1,2` onto the bounded term/stream I/O layer.
- Record PR84 in the Prolog VM capability manifest, docs, changelogs, and spec with loader, structured VM, and bytecode VM coverage.

## Verification

- `uv run --extra dev python -m pytest tests/test_prolog_loader.py -q --no-cov`
- `uv run --extra dev ruff check src tests` in `code/packages/python/prolog-loader`
- `.venv/bin/ruff check src tests` in `code/packages/python/prolog-vm-compiler`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `git diff --check`
