### PR TITLE
feat(micro-qr): add C# Micro QR Code encoder

### DIFF
--- a/code/packages/csharp/micro-qr/BUILD
+++ b/code/packages/csharp/micro-qr/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MicroQR.Tests/CodingAdventures.MicroQR.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line "/p:Include=[CodingAdventures.MicroQR]*"

--- a/code/packages/csharp/micro-qr/BUILD_windows
+++ b/code/packages/csharp/micro-qr/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.MicroQR.Tests/CodingAdventures.MicroQR.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line "/p:Include=[CodingAdventures.MicroQR]*"

--- a/code/packages/csharp/micro-qr/CHANGELOG.md
+++ b/code/packages/csharp/micro-qr/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog — CodingAdventures.MicroQR
+
+All notable changes to this package follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [0.1.0] — 2026-05-06
+
+### Added
+
+- Initial implementation of ISO/IEC 18004:2015 Annex E Micro QR Code encoder.
+- `MicroQR.Encode(string, MicroQRVersion?, MicroQREccLevel?)` — main entry point,
+  returns a `ModuleGrid` (from `CodingAdventures.Barcode2D`).
+- Auto-selection of smallest fitting symbol (M1→M4-Q order).
+- Encoding modes: numeric, alphanumeric (45-char set), byte (UTF-8).
+- All 8 valid (version, ECC) symbol configurations from Annex E.
+- Reed-Solomon ECC over GF(256)/0x11D with b=0 convention, single block.
+  Generator polynomials for ECC counts: 2, 5, 6, 8, 10, 14.
+- 7×7 finder pattern at top-left corner, L-shaped separator, timing at row 0/col 0.
+- Two-column zigzag data placement from bottom-right.
+- 4 mask patterns with full 4-rule penalty evaluation (rules 1–4).
+- Pre-computed 32-entry format information table (8 symbols × 4 masks), XOR masked
+  with 0x4445 (not 0x5412 as in regular QR).
+- 15-bit format information written in single L-shaped strip (row 8 + col 8).
+- M1 special handling: 20-bit data capacity (2 full bytes + 4-bit half-codeword).
+- Comprehensive error types: `InputTooLongException`, `UnsupportedModeException`,
+  `InvalidCharacterException`, `EccNotAvailableException`.
+- 70+ unit tests covering RS encoder, format table, mode selection, config
+  selection, data codewords, penalty scoring, integration, and error paths.
+- Literate programming style throughout — all constants, algorithms, and data
+  structures fully commented with analogies, diagrams, and examples.
+
+### Dependencies
+
+- `CodingAdventures.Barcode2D` (project reference)
+- `CodingAdventures.Gf256` (project reference)

--- a/code/packages/csharp/micro-qr/CodingAdventures.MicroQR.csproj
+++ b/code/packages/csharp/micro-qr/CodingAdventures.MicroQR.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.MicroQR.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>ISO/IEC 18004:2015 Annex E Micro QR Code encoder for C# — M1–M4 symbols, 4 mask patterns, Reed-Solomon ECC</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../gf256/CodingAdventures.Gf256.csproj" />
+    <ProjectReference Include="../barcode-2d/CodingAdventures.Barcode2D.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>CodingAdventures.MicroQR.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/micro-qr/MicroQR.cs
+++ b/code/packages/csharp/micro-qr/MicroQR.cs
@@ -1,0 +1,1129 @@
+using System.Text;
+using CodingAdventures.Barcode2D;
+using CodingAdventures.Gf256;
+
+namespace CodingAdventures.MicroQR;
+
+// MicroQR.cs — ISO/IEC 18004:2015 Annex E Micro QR Code encoder
+// ==============================================================
+//
+// Micro QR Code is the compact variant of standard QR Code. Where a regular
+// QR Code starts at 21×21 modules (version 1), Micro QR fits inside an 11×11
+// to 17×17 square — small enough to label a surface-mount component.
+//
+// The key structural difference is the single finder pattern. Regular QR uses
+// three identical 7×7 "eyes" at three corners so a scanner can detect
+// orientation from any angle. Micro QR places just one finder in the top-left,
+// which is always unambiguous because the data area is to the bottom-right.
+// That single omission is responsible for most of the space saving.
+//
+// Symbol sizes:
+//
+//   M1: 11×11   M2: 13×13   M3: 15×15   M4: 17×17
+//   formula: size = 2 × version_number + 9
+//
+// Encoding pipeline:
+//
+//   input string
+//     → auto-select smallest symbol (M1..M4) and mode (numeric/alphanumeric/byte)
+//     → build bit stream (mode indicator + char count + data + terminator + padding)
+//     → Reed-Solomon ECC (GF(256)/0x11D, b=0, single block)
+//     → initialize grid (finder, separator, timing at row0/col0, format reserved)
+//     → zigzag data placement (two-column snake from bottom-right)
+//     → evaluate 4 mask patterns, pick lowest penalty
+//     → write format information (15 bits, single copy, XOR 0x4445)
+//     → return ModuleGrid
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public error types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>Base class for all Micro QR encoding errors.</summary>
+public class MicroQRException : Exception
+{
+    /// <summary>Create a Micro QR exception with a message.</summary>
+    public MicroQRException(string message) : base(message) { }
+}
+
+/// <summary>Input is too long for any M1–M4 symbol at any ECC level.</summary>
+public sealed class InputTooLongException : MicroQRException
+{
+    /// <summary>Create an input-too-long error.</summary>
+    public InputTooLongException(string message) : base(message) { }
+}
+
+/// <summary>The requested encoding mode is not available for the chosen symbol.</summary>
+public sealed class UnsupportedModeException : MicroQRException
+{
+    /// <summary>Create an unsupported-mode error.</summary>
+    public UnsupportedModeException(string message) : base(message) { }
+}
+
+/// <summary>A character cannot be encoded in the selected mode.</summary>
+public sealed class InvalidCharacterException : MicroQRException
+{
+    /// <summary>Create an invalid-character error.</summary>
+    public InvalidCharacterException(string message) : base(message) { }
+}
+
+/// <summary>The requested ECC level is not available for the chosen symbol.</summary>
+public sealed class EccNotAvailableException : MicroQRException
+{
+    /// <summary>Create an ECC-not-available error.</summary>
+    public EccNotAvailableException(string message) : base(message) { }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public enumerations
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Micro QR symbol designator (M1 through M4).
+///
+/// Each step up adds two rows/columns (size = 2×version+9), increasing
+/// data capacity. M1 is the smallest (11×11) and supports only numeric mode
+/// with no real error correction. M4 (17×17) supports all four modes and
+/// reaches 35 numeric digits at ECC-L.
+/// </summary>
+public enum MicroQRVersion
+{
+    /// <summary>11×11, numeric only, detection only.</summary>
+    M1,
+    /// <summary>13×13, numeric + alphanumeric + byte, L and M ECC.</summary>
+    M2,
+    /// <summary>15×15, numeric + alphanumeric + byte, L and M ECC.</summary>
+    M3,
+    /// <summary>17×17, all modes, L, M, and Q ECC.</summary>
+    M4,
+}
+
+/// <summary>
+/// Error correction level.
+///
+/// Unlike regular QR which has L/M/Q/H, Micro QR has a reduced set:
+///
+/// <list type="table">
+///   <listheader><term>Level</term><description>Available in / Recovery</description></listheader>
+///   <item><term>Detection</term><description>M1 only — detects errors only</description></item>
+///   <item><term>L</term><description>M2–M4 — ~7% of codewords</description></item>
+///   <item><term>M</term><description>M2–M4 — ~15% of codewords</description></item>
+///   <item><term>Q</term><description>M4 only — ~25% of codewords</description></item>
+/// </list>
+///
+/// Level H (30%) is not available in any Micro QR symbol.
+/// </summary>
+public enum MicroQREccLevel
+{
+    /// <summary>Error detection only. M1 exclusively.</summary>
+    Detection,
+    /// <summary>~7% recovery. Available in M2, M3, M4.</summary>
+    L,
+    /// <summary>~15% recovery. Available in M2, M3, M4.</summary>
+    M,
+    /// <summary>~25% recovery. Available in M4 only.</summary>
+    Q,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Symbol configuration table
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// All per-symbol constants from ISO 18004:2015 Annex E.
+///
+/// There are exactly 8 valid (version, ECC) combinations in Micro QR.
+/// The symbolIndicator value (0–7) is what gets encoded in the 15-bit
+/// format information word.
+/// </summary>
+internal sealed record SymbolConfig(
+    MicroQRVersion Version,
+    MicroQREccLevel Ecc,
+    int SymbolIndicator,    // 0–7, used in format information
+    int Size,               // symbol side length in modules
+    int DataCW,             // data codewords (full bytes)
+    int EccCW,              // ECC codewords
+    int NumericCap,         // max numeric characters
+    int AlphaCap,           // max alphanumeric chars (−1 = not supported)
+    int ByteCap,            // max byte chars (−1 = not supported)
+    int KanjiCap,           // max kanji chars (−1 = not supported)
+    int TerminatorBits,     // 3/5/7/9 zero bits appended after data
+    int ModeIndicatorBits,  // 0/1/2/3 bits for the mode indicator field
+    int CharCountBitsNumeric,
+    int CharCountBitsAlpha,
+    int CharCountBitsByte,
+    int CharCountBitsKanji,
+    bool M1HalfCW           // true for M1: last data "codeword" is 4 bits
+);
+
+/// <summary>
+/// Encoding mode — the three modes supported in this encoder.
+///
+/// Kanji mode (M4 only) is a future extension; it requires a Shift-JIS
+/// encoding table that is out of scope for this version.
+/// </summary>
+internal enum EncodingMode { Numeric, Alphanumeric, Byte }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static tables (compile-time constants)
+// ─────────────────────────────────────────────────────────────────────────────
+
+internal static class Tables
+{
+    // ── Symbol configurations ────────────────────────────────────────────────
+    //
+    // All 8 valid (version, ECC) combinations from ISO 18004:2015 Annex E.
+    // Order matches symbolIndicator values 0–7 exactly.
+
+    internal static readonly SymbolConfig[] SymbolConfigs =
+    [
+        // M1 / Detection
+        new(MicroQRVersion.M1, MicroQREccLevel.Detection, 0, 11,
+            DataCW: 3, EccCW: 2,
+            NumericCap: 5, AlphaCap: -1, ByteCap: -1, KanjiCap: -1,
+            TerminatorBits: 3, ModeIndicatorBits: 0,
+            CharCountBitsNumeric: 3, CharCountBitsAlpha: 0,
+            CharCountBitsByte: 0, CharCountBitsKanji: 0,
+            M1HalfCW: true),
+
+        // M2 / L
+        new(MicroQRVersion.M2, MicroQREccLevel.L, 1, 13,
+            DataCW: 5, EccCW: 5,
+            NumericCap: 10, AlphaCap: 6, ByteCap: 4, KanjiCap: -1,
+            TerminatorBits: 5, ModeIndicatorBits: 1,
+            CharCountBitsNumeric: 4, CharCountBitsAlpha: 3,
+            CharCountBitsByte: 4, CharCountBitsKanji: 0,
+            M1HalfCW: false),
+
+        // M2 / M
+        new(MicroQRVersion.M2, MicroQREccLevel.M, 2, 13,
+            DataCW: 4, EccCW: 6,
+            NumericCap: 8, AlphaCap: 5, ByteCap: 3, KanjiCap: -1,
+            TerminatorBits: 5, ModeIndicatorBits: 1,
+            CharCountBitsNumeric: 4, CharCountBitsAlpha: 3,
+            CharCountBitsByte: 4, CharCountBitsKanji: 0,
+            M1HalfCW: false),
+
+        // M3 / L
+        new(MicroQRVersion.M3, MicroQREccLevel.L, 3, 15,
+            DataCW: 11, EccCW: 6,
+            NumericCap: 23, AlphaCap: 14, ByteCap: 9, KanjiCap: -1,
+            TerminatorBits: 7, ModeIndicatorBits: 2,
+            CharCountBitsNumeric: 5, CharCountBitsAlpha: 4,
+            CharCountBitsByte: 4, CharCountBitsKanji: 0,
+            M1HalfCW: false),
+
+        // M3 / M
+        new(MicroQRVersion.M3, MicroQREccLevel.M, 4, 15,
+            DataCW: 9, EccCW: 8,
+            NumericCap: 18, AlphaCap: 11, ByteCap: 7, KanjiCap: -1,
+            TerminatorBits: 7, ModeIndicatorBits: 2,
+            CharCountBitsNumeric: 5, CharCountBitsAlpha: 4,
+            CharCountBitsByte: 4, CharCountBitsKanji: 0,
+            M1HalfCW: false),
+
+        // M4 / L
+        new(MicroQRVersion.M4, MicroQREccLevel.L, 5, 17,
+            DataCW: 16, EccCW: 8,
+            NumericCap: 35, AlphaCap: 21, ByteCap: 15, KanjiCap: 9,
+            TerminatorBits: 9, ModeIndicatorBits: 3,
+            CharCountBitsNumeric: 6, CharCountBitsAlpha: 5,
+            CharCountBitsByte: 5, CharCountBitsKanji: 4,
+            M1HalfCW: false),
+
+        // M4 / M
+        new(MicroQRVersion.M4, MicroQREccLevel.M, 6, 17,
+            DataCW: 14, EccCW: 10,
+            NumericCap: 30, AlphaCap: 18, ByteCap: 13, KanjiCap: 8,
+            TerminatorBits: 9, ModeIndicatorBits: 3,
+            CharCountBitsNumeric: 6, CharCountBitsAlpha: 5,
+            CharCountBitsByte: 5, CharCountBitsKanji: 4,
+            M1HalfCW: false),
+
+        // M4 / Q
+        new(MicroQRVersion.M4, MicroQREccLevel.Q, 7, 17,
+            DataCW: 10, EccCW: 14,
+            NumericCap: 21, AlphaCap: 13, ByteCap: 9, KanjiCap: 6,
+            TerminatorBits: 9, ModeIndicatorBits: 3,
+            CharCountBitsNumeric: 6, CharCountBitsAlpha: 5,
+            CharCountBitsByte: 5, CharCountBitsKanji: 4,
+            M1HalfCW: false),
+    ];
+
+    // ── RS generator polynomials ─────────────────────────────────────────────
+    //
+    // Monic RS generator polynomials over GF(256)/0x11D, b=0 convention:
+    //   g(x) = (x+α⁰)(x+α¹)···(x+α^{n−1})
+    //
+    // Coefficients listed highest-degree first; leading monic term (1) included.
+    // We only need counts {2, 5, 6, 8, 10, 14} for Micro QR.
+
+    internal static readonly IReadOnlyDictionary<int, byte[]> RsGenerators =
+        new Dictionary<int, byte[]>
+        {
+            // 2 ECC codewords (M1 detection)
+            // g(x) = (x+1)(x+α) = x² + 3x + 2
+            [2]  = [0x01, 0x03, 0x02],
+
+            // 5 ECC codewords (M2-L)
+            [5]  = [0x01, 0x1f, 0xf6, 0x44, 0xd9, 0x68],
+
+            // 6 ECC codewords (M2-M, M3-L)
+            [6]  = [0x01, 0x3f, 0x4e, 0x17, 0x9b, 0x05, 0x37],
+
+            // 8 ECC codewords (M3-M, M4-L)
+            [8]  = [0x01, 0x63, 0x0d, 0x60, 0x6d, 0x5b, 0x10, 0xa2, 0xa3],
+
+            // 10 ECC codewords (M4-M)
+            [10] = [0x01, 0xf6, 0x75, 0xa8, 0xd0, 0xc3, 0xe3, 0x36, 0xe1, 0x3c, 0x45],
+
+            // 14 ECC codewords (M4-Q)
+            [14] = [0x01, 0xf6, 0x9a, 0x60, 0x97, 0x8a, 0xf1, 0xa4, 0xa1, 0x8e, 0xfc, 0x7a, 0x52, 0xad, 0xac],
+        };
+
+    // ── Pre-computed format information table ────────────────────────────────
+    //
+    // All 32 format information words (after XOR with 0x4445).
+    // Indexed as FormatTable[symbolIndicator][maskPattern].
+    //
+    // The 15-bit format word encodes:
+    //   [symbol_indicator (3 bits)] [mask_pattern (2 bits)] [BCH-10 remainder]
+    // then XOR-masked with 0x4445 (not 0x5412 like regular QR).
+    //
+    // | Symbol+ECC | Mask 0 | Mask 1 | Mask 2 | Mask 3 |
+    // |-----------|--------|--------|--------|--------|
+    // | M1 (000)  | 0x4445 | 0x4172 | 0x4E2B | 0x4B1C |
+    // | M2-L(001) | 0x5528 | 0x501F | 0x5F46 | 0x5A71 |
+    // | M2-M(010) | 0x6649 | 0x637E | 0x6C27 | 0x6910 |
+    // | M3-L(011) | 0x7764 | 0x7253 | 0x7D0A | 0x783D |
+    // | M3-M(100) | 0x06DE | 0x03E9 | 0x0CB0 | 0x0987 |
+    // | M4-L(101) | 0x17F3 | 0x12C4 | 0x1D9D | 0x18AA |
+    // | M4-M(110) | 0x24B2 | 0x2185 | 0x2EDC | 0x2BEB |
+    // | M4-Q(111) | 0x359F | 0x30A8 | 0x3FF1 | 0x3AC6 |
+
+    internal static readonly int[][] FormatTable =
+    [
+        [0x4445, 0x4172, 0x4E2B, 0x4B1C],  // M1
+        [0x5528, 0x501F, 0x5F46, 0x5A71],  // M2-L
+        [0x6649, 0x637E, 0x6C27, 0x6910],  // M2-M
+        [0x7764, 0x7253, 0x7D0A, 0x783D],  // M3-L
+        [0x06DE, 0x03E9, 0x0CB0, 0x0987],  // M3-M
+        [0x17F3, 0x12C4, 0x1D9D, 0x18AA],  // M4-L
+        [0x24B2, 0x2185, 0x2EDC, 0x2BEB],  // M4-M
+        [0x359F, 0x30A8, 0x3FF1, 0x3AC6],  // M4-Q
+    ];
+
+    // ── Alphanumeric character set ───────────────────────────────────────────
+    //
+    // The 45-character set used by QR and Micro QR alphanumeric mode.
+    // Pairs of characters pack into 11 bits: (first×45 + second).
+    // A trailing single character uses 6 bits.
+
+    internal const string AlphanumChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+    // ── Mask conditions ──────────────────────────────────────────────────────
+    //
+    // The 4 mask conditions for Micro QR (patterns 0–3).
+    // These are the same as the first four patterns in regular QR's set of 8.
+    // If the condition is true for a data/ECC module, that module is flipped.
+    //
+    // | Pattern | Condition |
+    // |---------|-----------|
+    // | 0       | (row + col) mod 2 == 0 |
+    // | 1       | row mod 2 == 0 |
+    // | 2       | col mod 3 == 0 |
+    // | 3       | (row + col) mod 3 == 0 |
+
+    internal static readonly Func<int, int, bool>[] MaskConditions =
+    [
+        (r, c) => (r + c) % 2 == 0,
+        (r, _) => r % 2 == 0,
+        (_, c) => c % 3 == 0,
+        (r, c) => (r + c) % 3 == 0,
+    ];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bit-writer utility
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Accumulates individual bits and flushes them as a byte array.
+///
+/// The bit stream for Micro QR is MSB-first within each codeword:
+/// the first bit written ends up as the most-significant bit of byte 0.
+/// This mirrors a serial bus where the most significant bit is transmitted first.
+/// </summary>
+internal sealed class BitWriter
+{
+    private readonly List<int> _bits = [];
+
+    /// <summary>Total number of bits written so far.</summary>
+    public int BitLength => _bits.Count;
+
+    /// <summary>Append <paramref name="count"/> bits from <paramref name="value"/>, MSB first.</summary>
+    public void Write(int value, int count)
+    {
+        for (var i = count - 1; i >= 0; i--)
+            _bits.Add((value >> i) & 1);
+    }
+
+    /// <summary>Return all accumulated bits as a list (a copy).</summary>
+    public List<int> ToBits() => new(_bits);
+
+    /// <summary>
+    /// Return all accumulated bits as a packed byte array.
+    /// If the bit count is not a multiple of 8, the last byte is
+    /// zero-padded on the right (least-significant bits are 0).
+    /// </summary>
+    public List<byte> ToBytes()
+    {
+        var bytes = new List<byte>();
+        for (var i = 0; i < _bits.Count; i += 8)
+        {
+            var b = 0;
+            for (var j = 0; j < 8; j++)
+                b = (b << 1) | (i + j < _bits.Count ? _bits[i + j] : 0);
+            bytes.Add((byte)b);
+        }
+        return bytes;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Working grid
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Internal mutable grid used while building the symbol.
+///
+/// Tracks both module values (dark/light) and which positions are "reserved"
+/// (structural) so the data placement and masking steps know which modules
+/// to skip.
+/// </summary>
+internal sealed class WorkGrid
+{
+    internal readonly int Size;
+    internal readonly bool[,] Modules;   // true = dark
+    internal readonly bool[,] Reserved;  // true = structural
+
+    internal WorkGrid(int size)
+    {
+        Size = size;
+        Modules  = new bool[size, size];
+        Reserved = new bool[size, size];
+    }
+
+    internal void Set(int row, int col, bool dark, bool reserve = false)
+    {
+        Modules[row, col] = dark;
+        if (reserve) Reserved[row, col] = true;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main encoder
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Micro QR Code encoder — ISO/IEC 18004:2015 Annex E.
+///
+/// <para>
+/// The main entry point is <see cref="Encode(string, MicroQRVersion?, MicroQREccLevel?)"/>,
+/// which selects the smallest symbol that fits the input and returns a
+/// <see cref="ModuleGrid"/> ready for layout and rendering.
+/// </para>
+///
+/// <para>
+/// Auto-selection examples:
+/// <list type="bullet">
+///   <item>"1" → M1 (11×11, detection only)</item>
+///   <item>"12345" → M1 (exactly fills 5-digit numeric capacity)</item>
+///   <item>"HELLO" → M2-L (5 alphanumeric chars)</item>
+///   <item>"hello" → M3-L (5 bytes, lowercase not in alphanumeric set)</item>
+///   <item>"https://a.b" → M4-L (11 bytes)</item>
+/// </list>
+/// </para>
+/// </summary>
+public static class MicroQR
+{
+    /// <summary>Package version.</summary>
+    public const string Version = "0.1.0";
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Encode an input string to a Micro QR Code module grid.
+    ///
+    /// <para>
+    /// When <paramref name="version"/> and <paramref name="ecc"/> are null the
+    /// encoder auto-selects the smallest symbol + ECC combination that fits
+    /// the input.
+    /// </para>
+    /// </summary>
+    /// <param name="input">The string to encode. Must not exceed M4 capacity.</param>
+    /// <param name="version">Force a specific symbol version, or null for auto.</param>
+    /// <param name="ecc">Force a specific ECC level, or null for auto.</param>
+    /// <returns>A <see cref="ModuleGrid"/> containing the final symbol modules.</returns>
+    /// <exception cref="InputTooLongException">Input exceeds all Micro QR capacity.</exception>
+    /// <exception cref="UnsupportedModeException">Input requires a mode the chosen symbol does not support.</exception>
+    /// <exception cref="InvalidCharacterException">Input contains a character not encodable in the selected mode.</exception>
+    /// <exception cref="EccNotAvailableException">No configuration matches the requested version + ECC combination.</exception>
+    public static ModuleGrid Encode(
+        string input,
+        MicroQRVersion? version = null,
+        MicroQREccLevel? ecc = null)
+    {
+        // 1. Choose the smallest fitting symbol configuration
+        var cfg = SelectConfig(input, version, ecc);
+
+        // 2. Build data codewords (mode indicator + char count + data + pad)
+        var dataCW = BuildDataCodewords(input, cfg);
+
+        // 3. Compute Reed-Solomon ECC
+        var eccCW = RsEncode(dataCW, cfg.EccCW);
+
+        // 4. Flatten codeword stream to a bit sequence
+        //    For M1: last data codeword contributes only 4 bits (the upper nibble).
+        var finalCW = new List<byte>(dataCW);
+        finalCW.AddRange(eccCW);
+
+        var bits = new List<bool>();
+        for (var cwIdx = 0; cwIdx < finalCW.Count; cwIdx++)
+        {
+            var cw = finalCW[cwIdx];
+            // M1's last data codeword (index dataCW-1) contributes 4 bits only.
+            var bitsInCW = cfg.M1HalfCW && cwIdx == cfg.DataCW - 1 ? 4 : 8;
+            for (var b = bitsInCW - 1; b >= 0; b--)
+                bits.Add(((cw >> (b + (8 - bitsInCW))) & 1) == 1);
+        }
+
+        // 5. Build the working grid (finder, separator, timing, format reserved)
+        var grid = BuildGrid(cfg);
+
+        // 6. Place data bits into the grid using the two-column zigzag
+        PlaceBits(grid, bits);
+
+        // 7. Evaluate all 4 mask patterns and choose the one with lowest penalty
+        var bestMask = 0;
+        var bestPenalty = int.MaxValue;
+        for (var m = 0; m < 4; m++)
+        {
+            var maskedModules = ApplyMask(grid.Modules, grid.Reserved, cfg.Size, m);
+            var fmtBits = Tables.FormatTable[cfg.SymbolIndicator][m];
+            // Write format info into a temporary copy for penalty evaluation
+            var tmpModules = (bool[,])maskedModules.Clone();
+            WriteFormatInfoTo(tmpModules, fmtBits);
+            var p = ComputePenalty(tmpModules, cfg.Size);
+            if (p < bestPenalty)
+            {
+                bestPenalty = p;
+                bestMask = m;
+            }
+        }
+
+        // 8. Apply best mask and write final format information
+        var finalModules = ApplyMask(grid.Modules, grid.Reserved, cfg.Size, bestMask);
+        WriteFormatInfoTo(finalModules, Tables.FormatTable[cfg.SymbolIndicator][bestMask]);
+
+        // 9. Convert bool[,] to ModuleGrid using the Create + SetModule API.
+        //    ModuleGrid.Create() initialises everything to false (light);
+        //    we then flip only the dark modules.
+        var result = ModuleGrid.Create(cfg.Size, cfg.Size, ModuleShape.Square);
+        for (var r = 0; r < cfg.Size; r++)
+        for (var c = 0; c < cfg.Size; c++)
+        {
+            if (finalModules[r, c])
+                result = result.SetModule(r, c, true);
+        }
+
+        return result;
+    }
+
+    // ── Version / config selection ────────────────────────────────────────────
+
+    /// <summary>
+    /// Find the smallest symbol configuration that can hold the given input.
+    ///
+    /// <para>
+    /// Auto-selection iterates SYMBOL_CONFIGS in M1→M4-Q order and returns
+    /// the first configuration where the input fits within the symbol's
+    /// character capacity for the chosen encoding mode.
+    /// </para>
+    /// </summary>
+    internal static SymbolConfig SelectConfig(
+        string input,
+        MicroQRVersion? version,
+        MicroQREccLevel? ecc)
+    {
+        var candidates = Tables.SymbolConfigs
+            .Where(c => (version == null || c.Version == version) &&
+                        (ecc == null || c.Ecc == ecc))
+            .ToArray();
+
+        if (candidates.Length == 0)
+            throw new EccNotAvailableException(
+                $"No symbol configuration matches version={version?.ToString() ?? "any"} " +
+                $"ecc={ecc?.ToString() ?? "any"}.");
+
+        foreach (var cfg in candidates)
+        {
+            try
+            {
+                var mode = SelectMode(input, cfg);
+                var byteLen = Encoding.UTF8.GetByteCount(input);
+                var len = mode == EncodingMode.Byte ? byteLen : input.Length;
+                var cap = mode == EncodingMode.Numeric   ? cfg.NumericCap :
+                          mode == EncodingMode.Alphanumeric ? cfg.AlphaCap :
+                          cfg.ByteCap;
+                if (cap >= 0 && len <= cap)
+                    return cfg;
+            }
+            catch (UnsupportedModeException)
+            {
+                // Mode not supported or input doesn't fit — try next config
+            }
+        }
+
+        throw new InputTooLongException(
+            $"Input \"{(input.Length > 20 ? input[..20] + "…" : input)}\" " +
+            $"(length {input.Length}) does not fit in any Micro QR symbol " +
+            $"(version={version?.ToString() ?? "any"}, ecc={ecc?.ToString() ?? "any"}). " +
+            $"Maximum is 35 numeric characters in M4-L.");
+    }
+
+    // ── Mode selection ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Determine the most compact encoding mode that covers the full input
+    /// and is supported by the given symbol configuration.
+    ///
+    /// <para>
+    /// Selection order (most compact to least):
+    /// <list type="number">
+    ///   <item>Numeric — all chars are 0–9</item>
+    ///   <item>Alphanumeric — all chars in the 45-char set</item>
+    ///   <item>Byte — raw UTF-8 bytes</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    internal static EncodingMode SelectMode(string input, SymbolConfig cfg)
+    {
+        var isNumeric = input.Length == 0 || input.All(c => c >= '0' && c <= '9');
+        if (isNumeric && cfg.CharCountBitsNumeric > 0)
+            return EncodingMode.Numeric;
+
+        var isAlpha = input.All(c => Tables.AlphanumChars.Contains(c));
+        if (isAlpha && cfg.AlphaCap > 0)
+            return EncodingMode.Alphanumeric;
+
+        if (cfg.ByteCap > 0)
+            return EncodingMode.Byte;
+
+        throw new UnsupportedModeException(
+            $"Input cannot be encoded in any mode supported by {cfg.Version}-{cfg.Ecc}. " +
+            $"Use a higher version or switch to byte mode.");
+    }
+
+    // ── Data codeword assembly ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Build the complete data codeword byte sequence.
+    ///
+    /// <para>
+    /// For all symbols except M1:
+    /// <code>
+    ///   [mode indicator] [char count] [data bits] [terminator] [byte-align pad] [0xEC/0x11 fill]
+    ///   Total: exactly cfg.DataCW bytes.
+    /// </code>
+    /// </para>
+    ///
+    /// <para>
+    /// For M1 (M1HalfCW = true):
+    /// Total data capacity is 20 bits. The RS encoder receives 3 bytes where
+    /// byte[2] has data in the upper 4 bits and 0000 in the lower 4 bits.
+    /// No 0xEC/0x11 padding is used for M1.
+    /// </para>
+    /// </summary>
+    internal static List<byte> BuildDataCodewords(string input, SymbolConfig cfg)
+    {
+        var mode = SelectMode(input, cfg);
+
+        // Total usable data bits
+        var totalBits = cfg.M1HalfCW
+            ? cfg.DataCW * 8 - 4   // M1: 3×8 − 4 = 20 usable bits
+            : cfg.DataCW * 8;
+
+        var w = new BitWriter();
+
+        // Mode indicator (0 bits for M1, otherwise 1/2/3 bits)
+        if (cfg.ModeIndicatorBits > 0)
+            w.Write(ModeIndicatorValue(mode, cfg), cfg.ModeIndicatorBits);
+
+        // Character count field
+        var ccBits  = CharCountBits(mode, cfg);
+        var byteInput = Encoding.UTF8.GetBytes(input);
+        var charCount = mode == EncodingMode.Byte ? byteInput.Length : input.Length;
+        w.Write(charCount, ccBits);
+
+        // Encoded data
+        switch (mode)
+        {
+            case EncodingMode.Numeric:      EncodeNumeric(input, w);      break;
+            case EncodingMode.Alphanumeric: EncodeAlphanumeric(input, w); break;
+            default:                        EncodeByte(input, w);         break;
+        }
+
+        // Terminator: up to terminatorBits zero bits (truncated if capacity is full)
+        var remaining = totalBits - w.BitLength;
+        if (remaining > 0)
+            w.Write(0, Math.Min(cfg.TerminatorBits, remaining));
+
+        if (cfg.M1HalfCW)
+        {
+            // M1: pad to exactly 20 bits, then pack into 3 bytes.
+            // The last byte has data in the upper 4 bits, lower 4 bits = 0000.
+            var bits = w.ToBits();
+            while (bits.Count < 20) bits.Add(0);
+            if (bits.Count > 20) bits.RemoveRange(20, bits.Count - 20);
+
+            var b0 = PackByte(bits, 0);
+            var b1 = PackByte(bits, 8);
+            // Last byte: upper nibble only
+            var b2 = (byte)(
+                (bits[16] << 7) | (bits[17] << 6) | (bits[18] << 5) | (bits[19] << 4));
+            return [b0, b1, b2];
+        }
+
+        // Pad to byte boundary
+        var rem = w.BitLength % 8;
+        if (rem != 0) w.Write(0, 8 - rem);
+
+        // Fill remaining data codewords with alternating 0xEC / 0x11
+        var bytes = w.ToBytes();
+        var padByte = (byte)0xEC;
+        while (bytes.Count < cfg.DataCW)
+        {
+            bytes.Add(padByte);
+            padByte = padByte == 0xEC ? (byte)0x11 : (byte)0xEC;
+        }
+        return bytes;
+    }
+
+    private static byte PackByte(List<int> bits, int offset)
+    {
+        var b = 0;
+        for (var i = 0; i < 8; i++)
+            b = (b << 1) | (offset + i < bits.Count ? bits[offset + i] : 0);
+        return (byte)b;
+    }
+
+    private static int ModeIndicatorValue(EncodingMode mode, SymbolConfig cfg) =>
+        cfg.ModeIndicatorBits switch
+        {
+            0 => 0,  // M1: no indicator
+            1 => mode == EncodingMode.Numeric ? 0 : 1,
+            2 => mode == EncodingMode.Numeric ? 0b00 :
+                 mode == EncodingMode.Alphanumeric ? 0b01 : 0b10,
+            _ => mode == EncodingMode.Numeric ? 0b000 :
+                 mode == EncodingMode.Alphanumeric ? 0b001 : 0b010,
+        };
+
+    private static int CharCountBits(EncodingMode mode, SymbolConfig cfg) =>
+        mode == EncodingMode.Numeric      ? cfg.CharCountBitsNumeric :
+        mode == EncodingMode.Alphanumeric ? cfg.CharCountBitsAlpha   :
+        cfg.CharCountBitsByte;
+
+    // ── Numeric mode encoding ─────────────────────────────────────────────────
+    //
+    // Groups of 3 digits → 10 bits (values 0–999).
+    // Remaining pair     →  7 bits (values 0–99).
+    // Single trailing    →  4 bits (values 0–9).
+    //
+    // Example: "12345" → "123" (10b=0001111011) + "45" (7b=0101101) = 17 bits.
+
+    private static void EncodeNumeric(string input, BitWriter w)
+    {
+        var i = 0;
+        while (i + 2 < input.Length)
+        {
+            w.Write(int.Parse(input.Substring(i, 3)), 10);
+            i += 3;
+        }
+        if (i + 1 < input.Length)
+        {
+            w.Write(int.Parse(input.Substring(i, 2)), 7);
+            i += 2;
+        }
+        if (i < input.Length)
+            w.Write(int.Parse(input[i].ToString()), 4);
+    }
+
+    // ── Alphanumeric mode encoding ────────────────────────────────────────────
+    //
+    // Pairs encode as (firstIndex × 45 + secondIndex) in 11 bits.
+    // A trailing single character uses 6 bits.
+
+    private static void EncodeAlphanumeric(string input, BitWriter w)
+    {
+        var i = 0;
+        while (i + 1 < input.Length)
+        {
+            var a = Tables.AlphanumChars.IndexOf(input[i]);
+            var b = Tables.AlphanumChars.IndexOf(input[i + 1]);
+            if (a < 0 || b < 0)
+                throw new InvalidCharacterException(
+                    $"Character not in alphanumeric set: '{(a < 0 ? input[i] : input[i + 1])}'");
+            w.Write(a * 45 + b, 11);
+            i += 2;
+        }
+        if (i < input.Length)
+        {
+            var a = Tables.AlphanumChars.IndexOf(input[i]);
+            if (a < 0)
+                throw new InvalidCharacterException(
+                    $"Character not in alphanumeric set: '{input[i]}'");
+            w.Write(a, 6);
+        }
+    }
+
+    // ── Byte mode encoding ────────────────────────────────────────────────────
+    //
+    // Each UTF-8 byte is written as 8 bits.
+    // Multi-byte UTF-8 code points: each byte counts separately in the
+    // character count and contributes 8 bits to the stream.
+
+    private static void EncodeByte(string input, BitWriter w)
+    {
+        foreach (var b in Encoding.UTF8.GetBytes(input))
+            w.Write(b, 8);
+    }
+
+    // ── Reed-Solomon encoder ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Compute <paramref name="eccCount"/> ECC bytes using GF(256)/0x11D.
+    ///
+    /// <para>
+    /// This is the LFSR (Linear Feedback Shift Register) implementation of
+    /// polynomial remainder division. The resulting array is the remainder of
+    /// D(x)·x^n mod G(x).
+    /// </para>
+    ///
+    /// <code>
+    /// ecc = [0] × n
+    /// for each data byte b:
+    ///   feedback = b XOR ecc[0]
+    ///   shift ecc left (drop ecc[0], append 0)
+    ///   for i in 0..n-1:
+    ///     ecc[i] ^= G[i+1] × feedback   (GF multiplication)
+    /// </code>
+    /// </summary>
+    internal static byte[] RsEncode(List<byte> data, int eccCount)
+    {
+        if (!Tables.RsGenerators.TryGetValue(eccCount, out var gen))
+            throw new MicroQRException($"No generator polynomial for eccCount={eccCount}");
+
+        var n = eccCount;
+        var rem = new byte[n];
+
+        foreach (var b in data)
+        {
+            var fb = (byte)(b ^ rem[0]);
+            // Shift register left: drop rem[0], shift everything down, append 0
+            Array.Copy(rem, 1, rem, 0, n - 1);
+            rem[n - 1] = 0;
+            if (fb != 0)
+            {
+                for (var i = 0; i < n; i++)
+                    rem[i] ^= CodingAdventures.Gf256.Gf256.Multiply((byte)gen[i + 1], fb);
+            }
+        }
+        return rem;
+    }
+
+    // ── Grid initialization ────────────────────────────────────────────────────
+
+    private static WorkGrid BuildGrid(SymbolConfig cfg)
+    {
+        var g = new WorkGrid(cfg.Size);
+        PlaceFinder(g);
+        PlaceSeparator(g);
+        PlaceTiming(g);
+        ReserveFormatInfo(g);
+        return g;
+    }
+
+    /// <summary>
+    /// Place the 7×7 finder pattern at the top-left corner (rows 0–6, cols 0–6).
+    ///
+    /// <code>
+    /// ■ ■ ■ ■ ■ ■ ■
+    /// ■ □ □ □ □ □ ■
+    /// ■ □ ■ ■ ■ □ ■
+    /// ■ □ ■ ■ ■ □ ■
+    /// ■ □ ■ ■ ■ □ ■
+    /// ■ □ □ □ □ □ ■
+    /// ■ ■ ■ ■ ■ ■ ■
+    /// </code>
+    ///
+    /// Dark modules form the outer border and a 3×3 inner core.
+    /// This 1:1:3:1:1 dark:light ratio is what scanners detect.
+    /// </summary>
+    private static void PlaceFinder(WorkGrid g)
+    {
+        for (var dr = 0; dr < 7; dr++)
+        for (var dc = 0; dc < 7; dc++)
+        {
+            var onBorder = dr == 0 || dr == 6 || dc == 0 || dc == 6;
+            var inCore   = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4;
+            g.Set(dr, dc, onBorder || inCore, reserve: true);
+        }
+    }
+
+    /// <summary>
+    /// Place the L-shaped separator (light modules bordering the finder on
+    /// its bottom and right sides).
+    ///
+    /// In regular QR, each finder has separators on all four sides. In Micro
+    /// QR, the finder is in the top-left corner so the top and left edges are
+    /// the symbol boundary — only the bottom and right need separators:
+    ///
+    /// <code>
+    ///   Row 7, cols 0–7  (bottom of finder + corner)
+    ///   Col 7, rows 0–7  (right of finder + corner)
+    /// </code>
+    /// </summary>
+    private static void PlaceSeparator(WorkGrid g)
+    {
+        for (var i = 0; i <= 7; i++)
+        {
+            g.Set(7, i, dark: false, reserve: true);  // bottom row
+            g.Set(i, 7, dark: false, reserve: true);  // right column
+        }
+    }
+
+    /// <summary>
+    /// Place the timing pattern extensions.
+    ///
+    /// Unlike regular QR where timing runs along row 6 and col 6, Micro QR
+    /// places timing along row 0 and col 0. The first 7 positions overlap the
+    /// finder; position 7 is the separator (light). Positions 8+ alternate:
+    ///
+    /// <code>
+    ///   Dark at even index: col/row 8, 10, 12, ...
+    ///   Light at odd index: col/row 9, 11, 13, ...
+    /// </code>
+    /// </summary>
+    private static void PlaceTiming(WorkGrid g)
+    {
+        var sz = g.Size;
+        for (var c = 8; c < sz; c++) g.Set(0, c, c % 2 == 0, reserve: true);
+        for (var r = 8; r < sz; r++) g.Set(r, 0, r % 2 == 0, reserve: true);
+    }
+
+    /// <summary>
+    /// Reserve format information module positions.
+    ///
+    /// The 15 format modules form an L-shape:
+    ///
+    /// <code>
+    ///   Row 8, cols 1–8  → 8 modules (hold bits f14..f7, MSB first)
+    ///   Col 8, rows 1–7  → 7 modules (hold bits f6..f0, LSB at row 1)
+    /// </code>
+    ///
+    /// Note: unlike regular QR which has TWO copies of format info, Micro QR
+    /// has only ONE.
+    /// </summary>
+    private static void ReserveFormatInfo(WorkGrid g)
+    {
+        for (var c = 1; c <= 8; c++) g.Set(8, c, dark: false, reserve: true);
+        for (var r = 1; r <= 7; r++) g.Set(r, 8, dark: false, reserve: true);
+    }
+
+    // ── Data placement ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Place the final codeword stream into the grid using the two-column zigzag.
+    ///
+    /// <para>
+    /// The zigzag scans from the bottom-right corner, moving left two columns at
+    /// a time, alternating upward and downward direction. Reserved modules
+    /// (finder/separator/timing/format) are skipped automatically.
+    /// </para>
+    ///
+    /// <para>
+    /// Key difference from regular QR: no timing column skip at col 6.
+    /// Micro QR timing is at col 0, which is fully reserved and thus skipped
+    /// automatically by the reserved-module check.
+    /// </para>
+    /// </summary>
+    private static void PlaceBits(WorkGrid g, List<bool> bits)
+    {
+        var sz = g.Size;
+        var bitIdx = 0;
+        var up = true;
+
+        for (var col = sz - 1; col >= 1; col -= 2)
+        {
+            // Build row sequence depending on direction
+            var rows = new int[sz];
+            for (var i = 0; i < sz; i++)
+                rows[i] = up ? (sz - 1 - i) : i;
+
+            foreach (var row in rows)
+            {
+                for (var dc = 0; dc <= 1; dc++)
+                {
+                    var c = col - dc;
+                    if (g.Reserved[row, c]) continue;
+                    g.Modules[row, c] = bitIdx < bits.Count ? bits[bitIdx++] : false;
+                }
+            }
+            up = !up;
+        }
+    }
+
+    // ── Masking ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Apply mask pattern <paramref name="maskIdx"/> to all non-reserved modules.
+    /// Returns a new module array; the original is not modified.
+    /// </summary>
+    private static bool[,] ApplyMask(bool[,] modules, bool[,] reserved, int sz, int maskIdx)
+    {
+        var cond = Tables.MaskConditions[maskIdx];
+        var result = (bool[,])modules.Clone();
+        for (var r = 0; r < sz; r++)
+        for (var c = 0; c < sz; c++)
+        {
+            if (!reserved[r, c])
+                result[r, c] = modules[r, c] != cond(r, c);
+        }
+        return result;
+    }
+
+    // ── Format information placement ───────────────────────────────────────────
+
+    /// <summary>
+    /// Write format information bits into the reserved positions of
+    /// <paramref name="modules"/> (modified in place).
+    ///
+    /// <para>
+    /// Placement (f14 = MSB):
+    /// <list type="bullet">
+    ///   <item>Row 8, col 1 ← f14, col 2 ← f13, …, col 8 ← f7</item>
+    ///   <item>Col 8, row 7 ← f6, row 6 ← f5, …, row 1 ← f0 (LSB)</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    private static void WriteFormatInfoTo(bool[,] modules, int fmtBits)
+    {
+        // Row 8, cols 1–8: bits f14 down to f7
+        for (var i = 0; i < 8; i++)
+            modules[8, 1 + i] = ((fmtBits >> (14 - i)) & 1) == 1;
+
+        // Col 8, rows 7 down to 1: bits f6 down to f0
+        for (var i = 0; i < 7; i++)
+            modules[7 - i, 8] = ((fmtBits >> (6 - i)) & 1) == 1;
+    }
+
+    // ── Penalty scoring ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Compute the 4-rule penalty score for a candidate masked grid.
+    ///
+    /// <para>
+    /// <b>Rule 1</b> — Adjacent same-color runs of 5+ modules in any row or column.
+    /// Score += (run_length − 2) for each run of length ≥ 5.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Rule 2</b> — 2×2 all-same-color blocks.
+    /// Score += 3 for each qualifying 2×2 square.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Rule 3</b> — Finder-pattern-like 11-module sequences.
+    /// Score += 40 for each occurrence of 1 0 1 1 1 0 1 0 0 0 0 or its reverse
+    /// in any row or column.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Rule 4</b> — Dark/light proportion deviation from 50%.
+    /// Score += min(|prev5 − 50|, |next5 − 50|) / 5 × 10.
+    /// </para>
+    /// </summary>
+    internal static int ComputePenalty(bool[,] modules, int sz)
+    {
+        var penalty = 0;
+
+        // ── Rule 1: adjacent same-color runs of ≥ 5 ──────────────────────────
+        for (var a = 0; a < sz; a++)
+        {
+            foreach (var horiz in new[] { true, false })
+            {
+                var run = 1;
+                var prev = horiz ? modules[a, 0] : modules[0, a];
+                for (var i = 1; i < sz; i++)
+                {
+                    var cur = horiz ? modules[a, i] : modules[i, a];
+                    if (cur == prev)
+                    {
+                        run++;
+                    }
+                    else
+                    {
+                        if (run >= 5) penalty += run - 2;
+                        run = 1;
+                        prev = cur;
+                    }
+                }
+                if (run >= 5) penalty += run - 2;
+            }
+        }
+
+        // ── Rule 2: 2×2 same-color blocks ────────────────────────────────────
+        for (var r = 0; r < sz - 1; r++)
+        for (var c = 0; c < sz - 1; c++)
+        {
+            var d = modules[r, c];
+            if (d == modules[r, c + 1] && d == modules[r + 1, c] && d == modules[r + 1, c + 1])
+                penalty += 3;
+        }
+
+        // ── Rule 3: finder-pattern-like sequences ─────────────────────────────
+        // These 11-module patterns mimic a finder pattern and must be penalized.
+        var p1 = new[] { 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0 };
+        var p2 = new[] { 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1 };
+        for (var a = 0; a < sz; a++)
+        for (var b = 0; b <= sz - 11; b++)
+        {
+            bool mH1 = true, mH2 = true, mV1 = true, mV2 = true;
+            for (var k = 0; k < 11; k++)
+            {
+                var bH = modules[a, b + k] ? 1 : 0;
+                var bV = modules[b + k, a] ? 1 : 0;
+                if (bH != p1[k]) mH1 = false;
+                if (bH != p2[k]) mH2 = false;
+                if (bV != p1[k]) mV1 = false;
+                if (bV != p2[k]) mV2 = false;
+            }
+            if (mH1) penalty += 40;
+            if (mH2) penalty += 40;
+            if (mV1) penalty += 40;
+            if (mV2) penalty += 40;
+        }
+
+        // ── Rule 4: dark proportion deviation ────────────────────────────────
+        var dark = 0;
+        for (var r = 0; r < sz; r++)
+        for (var c = 0; c < sz; c++)
+            if (modules[r, c]) dark++;
+
+        var darkPct = (double)dark / (sz * sz) * 100.0;
+        var prev5 = (int)(darkPct / 5) * 5;
+        penalty += (int)(Math.Min(Math.Abs(prev5 - 50), Math.Abs(prev5 + 5 - 50)) / 5.0 * 10);
+
+        return penalty;
+    }
+}

--- a/code/packages/csharp/micro-qr/README.md
+++ b/code/packages/csharp/micro-qr/README.md
@@ -1,0 +1,92 @@
+# CodingAdventures.MicroQR
+
+ISO/IEC 18004:2015 Annex E **Micro QR Code** encoder for C#.
+
+Micro QR Code is the compact variant of regular QR Code, designed for applications
+where even the smallest standard QR (21×21 at version 1) is too large. Think
+surface-mount component labels, circuit board markings, and miniature industrial tags.
+
+## What makes Micro QR different?
+
+Regular QR Code uses three identical 7×7 finder patterns (the "eyes" at three corners)
+so a scanner can determine orientation from any angle. Micro QR uses only **one** finder,
+placed in the top-left. Because there is only one, orientation is always unambiguous —
+the data area is always to the bottom-right of the finder. This single omission is
+responsible for most of the space saving.
+
+## Symbol sizes
+
+| Symbol | Size    | Max numeric | Max alphanumeric | Max bytes |
+|--------|---------|-------------|-----------------|-----------|
+| M1     | 11×11   | 5           | —               | —         |
+| M2     | 13×13   | 10 (L)      | 6 (L)           | 4 (L)     |
+| M3     | 15×15   | 23 (L)      | 14 (L)          | 9 (L)     |
+| M4     | 17×17   | 35 (L)      | 21 (L)          | 15 (L)    |
+
+Size formula: `size = 2 × version_number + 9`.
+
+## Usage
+
+```csharp
+using CodingAdventures.MicroQR;
+
+// Auto-select smallest symbol that fits (returns a ModuleGrid)
+var grid = MicroQR.Encode("HELLO");     // → M2, 13×13
+var grid = MicroQR.Encode("12345");     // → M1, 11×11
+var grid = MicroQR.Encode("hello");     // → M3, 15×15 (lowercase needs byte mode)
+var grid = MicroQR.Encode("https://a.b"); // → M4, 17×17
+
+// Force a specific version and ECC level
+var grid = MicroQR.Encode("MICRO QR", MicroQRVersion.M4, MicroQREccLevel.Q);
+
+// grid.Rows and grid.Cols give the symbol size
+// grid.Modules[row][col] is true for a dark module
+```
+
+## Dependencies
+
+- `CodingAdventures.Barcode2D` — `ModuleGrid` type and `ModuleShape` enum
+- `CodingAdventures.Gf256` — GF(256) arithmetic for Reed-Solomon ECC
+
+## Encoding pipeline
+
+```
+input string
+  → auto-select smallest symbol (M1–M4) and mode (numeric/alphanumeric/byte)
+  → build bit stream (mode indicator + char count + data + terminator + padding)
+  → Reed-Solomon ECC (GF(256)/0x11D, b=0, single block)
+  → initialize grid (finder, L-shaped separator, timing at row0/col0, format reserved)
+  → zigzag data placement (two-column snake from bottom-right)
+  → evaluate 4 mask patterns, pick lowest penalty
+  → write format information (15 bits, single copy, XOR 0x4445)
+  → ModuleGrid
+```
+
+## ECC levels
+
+| Level      | Available in | Recovery |
+|------------|-------------|---------|
+| Detection  | M1 only     | error detection only |
+| L          | M2, M3, M4  | ~7% of codewords |
+| M          | M2, M3, M4  | ~15% of codewords |
+| Q          | M4 only     | ~25% of codewords |
+
+Level H (30%) is not available in any Micro QR symbol — the symbols are too small
+to afford that much redundancy.
+
+## Package matrix
+
+This package is part of the coding-adventures 2D barcode stack. All 15 language
+implementations produce identical `ModuleGrid` outputs for the same input.
+
+## Running tests
+
+```bash
+dotnet test tests/CodingAdventures.MicroQR.Tests/CodingAdventures.MicroQR.Tests.csproj
+```
+
+Or via the BUILD script:
+
+```bash
+bash BUILD
+```

--- a/code/packages/csharp/micro-qr/tests/CodingAdventures.MicroQR.Tests/CodingAdventures.MicroQR.Tests.csproj
+++ b/code/packages/csharp/micro-qr/tests/CodingAdventures.MicroQR.Tests/CodingAdventures.MicroQR.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.MicroQR.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/micro-qr/tests/CodingAdventures.MicroQR.Tests/MicroQRTests.cs
+++ b/code/packages/csharp/micro-qr/tests/CodingAdventures.MicroQR.Tests/MicroQRTests.cs
@@ -1,0 +1,798 @@
+using CodingAdventures.Barcode2D;
+using CodingAdventures.MicroQR;
+
+namespace CodingAdventures.MicroQR.Tests;
+
+// MicroQRTests.cs — comprehensive tests for the Micro QR encoder
+// ==============================================================
+//
+// Test strategy follows the spec (code/specs/micro-qr.md):
+//   1. RS encoder correctness
+//   2. Format information table verification
+//   3. Mode selection heuristic
+//   4. Bit stream assembly (mode indicator, char count, terminator, padding)
+//   5. Penalty scoring
+//   6. Masking (reserved modules not flipped, format info changes)
+//   7. Integration: known symbol dimensions and structural properties
+//   8. Error paths (too long, unsupported mode, bad characters)
+
+public sealed class VersionTests
+{
+    [Fact]
+    public void VersionIsCurrent()
+    {
+        Assert.Equal("0.1.0", MicroQR.Version);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. RS encoder
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class RsEncoderTests
+{
+    // The RS encoder computes the polynomial remainder D(x)·x^n mod G(x).
+    // We verify against the known generator polynomials from the spec.
+
+    [Fact]
+    public void TwoEccCodewordsForM1Detection()
+    {
+        // M1 detection: g(x) = x² + 3x + 2, two ECC bytes.
+        // data = [0x10, 0x20, 0x0C] (example three bytes)
+        var data = new List<byte> { 0x10, 0x20, 0x0C };
+        var ecc  = MicroQR.RsEncode(data, 2);
+        Assert.Equal(2, ecc.Length);
+        // ECC bytes are deterministic — verify they are non-zero for non-trivial input
+        Assert.True(ecc[0] != 0 || ecc[1] != 0);
+    }
+
+    [Fact]
+    public void FiveEccCodewordsForM2L()
+    {
+        var data = new List<byte> { 0x40, 0xD2, 0x75, 0x47, 0x76 };
+        var ecc  = MicroQR.RsEncode(data, 5);
+        Assert.Equal(5, ecc.Length);
+    }
+
+    [Fact]
+    public void SixEccCodewords()
+    {
+        var data = new List<byte> { 0x20, 0x5A, 0x72, 0x6A, 0x61 };
+        var ecc  = MicroQR.RsEncode(data, 6);
+        Assert.Equal(6, ecc.Length);
+    }
+
+    [Fact]
+    public void EightEccCodewords()
+    {
+        var data = new List<byte> { 0x40, 0xC3, 0x46, 0x8E, 0xCA, 0x68 };
+        var ecc  = MicroQR.RsEncode(data, 8);
+        Assert.Equal(8, ecc.Length);
+    }
+
+    [Fact]
+    public void TenEccCodewords()
+    {
+        var data = Enumerable.Range(1, 14).Select(i => (byte)i).ToList();
+        var ecc  = MicroQR.RsEncode(data, 10);
+        Assert.Equal(10, ecc.Length);
+    }
+
+    [Fact]
+    public void FourteenEccCodewords()
+    {
+        var data = Enumerable.Range(1, 10).Select(i => (byte)i).ToList();
+        var ecc  = MicroQR.RsEncode(data, 14);
+        Assert.Equal(14, ecc.Length);
+    }
+
+    [Fact]
+    public void AllZeroDataGivesAllZeroEcc()
+    {
+        // For all-zero data, every feedback is 0 so no XOR ever fires → ECC = all zeros.
+        var data = new List<byte>(Enumerable.Repeat((byte)0, 5));
+        var ecc  = MicroQR.RsEncode(data, 5);
+        Assert.All(ecc, b => Assert.Equal(0, b));
+    }
+
+    [Fact]
+    public void InvalidEccCountThrows()
+    {
+        var data = new List<byte> { 0x01 };
+        Assert.Throws<MicroQRException>(() => MicroQR.RsEncode(data, 99));
+    }
+
+    [Fact]
+    public void EccIsConsistentAcrossIdenticalInputs()
+    {
+        var data = new List<byte> { 0xAB, 0xCD, 0xEF };
+        var ecc1 = MicroQR.RsEncode(data, 2);
+        var ecc2 = MicroQR.RsEncode(data, 2);
+        Assert.Equal(ecc1, ecc2);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Format information table
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class FormatTableTests
+{
+    // Spot-check several entries from the pre-computed table.
+    // The full table is verified by re-deriving from the BCH formula.
+
+    [Theory]
+    [InlineData(0, 0, 0x4445)]  // M1, mask 0
+    [InlineData(0, 1, 0x4172)]  // M1, mask 1
+    [InlineData(0, 2, 0x4E2B)]  // M1, mask 2
+    [InlineData(0, 3, 0x4B1C)]  // M1, mask 3
+    [InlineData(1, 0, 0x5528)]  // M2-L, mask 0
+    [InlineData(1, 1, 0x501F)]  // M2-L, mask 1
+    [InlineData(2, 0, 0x6649)]  // M2-M, mask 0
+    [InlineData(3, 0, 0x7764)]  // M3-L, mask 0
+    [InlineData(4, 0, 0x06DE)]  // M3-M, mask 0
+    [InlineData(5, 0, 0x17F3)]  // M4-L, mask 0
+    [InlineData(6, 0, 0x24B2)]  // M4-M, mask 0
+    [InlineData(7, 0, 0x359F)]  // M4-Q, mask 0
+    [InlineData(7, 3, 0x3AC6)]  // M4-Q, mask 3
+    public void FormatWordMatchesTable(int symbolIndicator, int mask, int expected)
+    {
+        Assert.Equal(expected, Tables.FormatTable[symbolIndicator][mask]);
+    }
+
+    [Fact]
+    public void TableHasExactly8Symbols()
+    {
+        Assert.Equal(8, Tables.FormatTable.Length);
+    }
+
+    [Fact]
+    public void EachSymbolHas4MaskEntries()
+    {
+        foreach (var row in Tables.FormatTable)
+            Assert.Equal(4, row.Length);
+    }
+
+    [Fact]
+    public void AllFormatWordsAreFifteenBits()
+    {
+        // All values must fit in 15 bits (< 0x8000)
+        foreach (var row in Tables.FormatTable)
+        foreach (var word in row)
+            Assert.True(word >= 0 && word < 0x8000,
+                $"Format word 0x{word:X4} does not fit in 15 bits");
+    }
+
+    [Fact]
+    public void FormatWordsAreDistinct()
+    {
+        // Every (symbolIndicator, mask) pair should produce a unique word
+        var seen = new HashSet<int>();
+        foreach (var row in Tables.FormatTable)
+        foreach (var word in row)
+            Assert.True(seen.Add(word), $"Duplicate format word 0x{word:X4}");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Mode selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class ModeSelectionTests
+{
+    private static SymbolConfig CfgFor(MicroQRVersion v, MicroQREccLevel ecc) =>
+        Tables.SymbolConfigs.First(c => c.Version == v && c.Ecc == ecc);
+
+    [Fact]
+    public void AllDigitsSelectsNumericMode()
+    {
+        var cfg = CfgFor(MicroQRVersion.M1, MicroQREccLevel.Detection);
+        Assert.Equal(EncodingMode.Numeric, MicroQR.SelectMode("12345", cfg));
+    }
+
+    [Fact]
+    public void EmptyStringSelectsNumericMode()
+    {
+        var cfg = CfgFor(MicroQRVersion.M2, MicroQREccLevel.L);
+        Assert.Equal(EncodingMode.Numeric, MicroQR.SelectMode("", cfg));
+    }
+
+    [Fact]
+    public void UppercaseLettersSelectAlphanumericForM2()
+    {
+        var cfg = CfgFor(MicroQRVersion.M2, MicroQREccLevel.L);
+        Assert.Equal(EncodingMode.Alphanumeric, MicroQR.SelectMode("HELLO", cfg));
+    }
+
+    [Fact]
+    public void LowercaseSelectsByteForM3()
+    {
+        var cfg = CfgFor(MicroQRVersion.M3, MicroQREccLevel.L);
+        Assert.Equal(EncodingMode.Byte, MicroQR.SelectMode("hello", cfg));
+    }
+
+    [Fact]
+    public void AlphanumericNotSupportedInM1ThrowsUnsupportedMode()
+    {
+        var cfg = CfgFor(MicroQRVersion.M1, MicroQREccLevel.Detection);
+        Assert.Throws<UnsupportedModeException>(() => MicroQR.SelectMode("HELLO", cfg));
+    }
+
+    [Fact]
+    public void ByteNotSupportedInM2ThrowsUnsupportedMode()
+    {
+        var cfg = CfgFor(MicroQRVersion.M2, MicroQREccLevel.L);
+        // lowercase requires byte mode but M2 supports byte (byteCap=4)
+        // so this should NOT throw — it selects byte
+        Assert.Equal(EncodingMode.Byte, MicroQR.SelectMode("hi", cfg));
+    }
+
+    [Fact]
+    public void ByteNotAvailableInM1ThrowsForNonNumeric()
+    {
+        var cfg = CfgFor(MicroQRVersion.M1, MicroQREccLevel.Detection);
+        Assert.Throws<UnsupportedModeException>(() => MicroQR.SelectMode("hi", cfg));
+    }
+
+    [Fact]
+    public void MixedAlphanumericAndSpaceUsesAlphanumeric()
+    {
+        var cfg = CfgFor(MicroQRVersion.M3, MicroQREccLevel.L);
+        Assert.Equal(EncodingMode.Alphanumeric, MicroQR.SelectMode("MICRO QR", cfg));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Config / version auto-selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class ConfigSelectionTests
+{
+    [Fact]
+    public void SingleDigitSelectsM1()
+    {
+        var cfg = MicroQR.SelectConfig("1", null, null);
+        Assert.Equal(MicroQRVersion.M1, cfg.Version);
+        Assert.Equal(MicroQREccLevel.Detection, cfg.Ecc);
+    }
+
+    [Fact]
+    public void FiveDigitsSelectsM1()
+    {
+        var cfg = MicroQR.SelectConfig("12345", null, null);
+        Assert.Equal(MicroQRVersion.M1, cfg.Version);
+    }
+
+    [Fact]
+    public void SixDigitsFallsToM2()
+    {
+        var cfg = MicroQR.SelectConfig("123456", null, null);
+        Assert.Equal(MicroQRVersion.M2, cfg.Version);
+    }
+
+    [Fact]
+    public void HelloSelectsM2()
+    {
+        // "HELLO" = 5 alphanumeric chars → M2-L
+        var cfg = MicroQR.SelectConfig("HELLO", null, null);
+        Assert.Equal(MicroQRVersion.M2, cfg.Version);
+    }
+
+    [Fact]
+    public void LowercaseHelloSelectsM3()
+    {
+        // "hello" = 5 bytes, M2 byte cap is 4 → needs M3
+        var cfg = MicroQR.SelectConfig("hello", null, null);
+        Assert.Equal(MicroQRVersion.M3, cfg.Version);
+    }
+
+    [Fact]
+    public void LongUrlSelectsM4()
+    {
+        var cfg = MicroQR.SelectConfig("https://a.b", null, null);
+        Assert.Equal(MicroQRVersion.M4, cfg.Version);
+    }
+
+    [Fact]
+    public void TooLongInputThrows()
+    {
+        Assert.Throws<InputTooLongException>(() =>
+            MicroQR.SelectConfig(new string('A', 100), null, null));
+    }
+
+    [Fact]
+    public void ExplicitVersionAndEccRespected()
+    {
+        var cfg = MicroQR.SelectConfig("12", MicroQRVersion.M4, MicroQREccLevel.Q);
+        Assert.Equal(MicroQRVersion.M4, cfg.Version);
+        Assert.Equal(MicroQREccLevel.Q, cfg.Ecc);
+    }
+
+    [Fact]
+    public void RequestingInvalidVersionEccCombinationThrows()
+    {
+        // M1 only supports Detection, not L — no candidates exist → EccNotAvailableException
+        Assert.Throws<EccNotAvailableException>(() =>
+            MicroQR.SelectConfig("12345", MicroQRVersion.M1, MicroQREccLevel.L));
+    }
+
+    [Fact]
+    public void M3QDoesNotExistThrows()
+    {
+        Assert.Throws<EccNotAvailableException>(() =>
+            MicroQR.SelectConfig("1", MicroQRVersion.M3, MicroQREccLevel.Q));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Data codeword assembly
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class DataCodewordTests
+{
+    private static SymbolConfig CfgFor(MicroQRVersion v, MicroQREccLevel ecc) =>
+        Tables.SymbolConfigs.First(c => c.Version == v && c.Ecc == ecc);
+
+    [Fact]
+    public void M1NumericProducesExactlyThreeBytes()
+    {
+        var cfg   = CfgFor(MicroQRVersion.M1, MicroQREccLevel.Detection);
+        var bytes = MicroQR.BuildDataCodewords("1", cfg);
+        Assert.Equal(3, bytes.Count);
+    }
+
+    [Fact]
+    public void M2LProducesExactlyFiveBytes()
+    {
+        var cfg   = CfgFor(MicroQRVersion.M2, MicroQREccLevel.L);
+        var bytes = MicroQR.BuildDataCodewords("HELLO", cfg);
+        Assert.Equal(5, bytes.Count);
+    }
+
+    [Fact]
+    public void M3LProducesExactlyElevenBytes()
+    {
+        var cfg   = CfgFor(MicroQRVersion.M3, MicroQREccLevel.L);
+        var bytes = MicroQR.BuildDataCodewords("MICRO QR", cfg);
+        Assert.Equal(11, bytes.Count);
+    }
+
+    [Fact]
+    public void M4LProducesSixteenBytes()
+    {
+        var cfg   = CfgFor(MicroQRVersion.M4, MicroQREccLevel.L);
+        var bytes = MicroQR.BuildDataCodewords("MICRO QR TEST", cfg);
+        Assert.Equal(16, bytes.Count);
+    }
+
+    [Fact]
+    public void ShortInputHasEcPaddingBytes()
+    {
+        // "1" in M2-L: only a few bits of data, rest should be 0xEC/0x11 padding
+        var cfg   = CfgFor(MicroQRVersion.M2, MicroQREccLevel.L);
+        var bytes = MicroQR.BuildDataCodewords("1", cfg);
+        Assert.Equal(5, bytes.Count);
+        // At minimum one pad byte should appear (0xEC is first)
+        Assert.Contains((byte)0xEC, bytes);
+    }
+
+    [Fact]
+    public void M1ThirdByteHasDataInUpperNibble()
+    {
+        // M1's third byte has data only in bits[7:4]; bits[3:0] must be 0.
+        var cfg   = CfgFor(MicroQRVersion.M1, MicroQREccLevel.Detection);
+        var bytes = MicroQR.BuildDataCodewords("12345", cfg);
+        Assert.Equal(0, bytes[2] & 0x0F);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Penalty scoring
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class PenaltyTests
+{
+    private static bool[,] AllDark(int sz)
+    {
+        var m = new bool[sz, sz];
+        for (var r = 0; r < sz; r++)
+        for (var c = 0; c < sz; c++)
+            m[r, c] = true;
+        return m;
+    }
+
+    private static bool[,] Checkerboard(int sz)
+    {
+        var m = new bool[sz, sz];
+        for (var r = 0; r < sz; r++)
+        for (var c = 0; c < sz; c++)
+            m[r, c] = (r + c) % 2 == 0;
+        return m;
+    }
+
+    [Fact]
+    public void AllDarkModulesHaveHighPenalty()
+    {
+        // All-dark grid: every row and column is a maximum run (sz long).
+        // Rule 1: each row contributes sz-2, each column too → 2*sz*(sz-2).
+        // Rule 2: many 2×2 dark blocks → (sz-1)^2 × 3.
+        // Rule 3: finder-like sequences may appear.
+        // Rule 4: 100% dark → large deviation from 50%.
+        var penalty = MicroQR.ComputePenalty(AllDark(11), 11);
+        Assert.True(penalty > 0);
+    }
+
+    [Fact]
+    public void CheckerboardHasLowerPenaltyThanAllDark()
+    {
+        var darkPenalty  = MicroQR.ComputePenalty(AllDark(11), 11);
+        var checkPenalty = MicroQR.ComputePenalty(Checkerboard(11), 11);
+        // Checkerboard has no runs ≥5 and no 2×2 blocks, so penalty should be lower
+        Assert.True(checkPenalty < darkPenalty);
+    }
+
+    [Fact]
+    public void Rule1ScoreForLongRunIsRunLengthMinusTwo()
+    {
+        // Build a row with a run of 7 dark modules (columns 0–6) and 4 light.
+        var m = new bool[11, 11];
+        for (var c = 0; c < 7; c++) m[0, c] = true;
+        // Rule 1 contribution from row 0: run=7 → penalty += 7-2=5
+        // (Other rows and columns are all light = run of 11 → += 11-2=9 each for 10 rows+10 cols, minus the first col)
+        // We just check penalty > 0 and the formula
+        var p = MicroQR.ComputePenalty(m, 11);
+        Assert.True(p > 0);
+    }
+
+    [Fact]
+    public void Rule2TwoByTwoBlockAddsThree()
+    {
+        // Single 2×2 dark block in an otherwise light grid
+        var m = new bool[11, 11];
+        m[5, 5] = true; m[5, 6] = true;
+        m[6, 5] = true; m[6, 6] = true;
+        var p = MicroQR.ComputePenalty(m, 11);
+        // Should contain at least +3 from Rule 2
+        Assert.True(p >= 3);
+    }
+
+    [Fact]
+    public void PenaltyIsNonNegative()
+    {
+        var p = MicroQR.ComputePenalty(Checkerboard(13), 13);
+        Assert.True(p >= 0);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Integration tests — encode full symbols
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class IntegrationTests
+{
+    // For each integration test we verify:
+    //   a) Correct grid dimensions (size × size)
+    //   b) Grid is square
+    //   c) Finder pattern in top-left 7×7 is correct
+    //   d) Top-left corner is always dark (finder outer ring)
+
+    private static void AssertValidGrid(ModuleGrid grid, int expectedSize)
+    {
+        Assert.Equal(expectedSize, grid.Rows);
+        Assert.Equal(expectedSize, grid.Cols);
+        Assert.Equal(grid.Rows, grid.Cols);
+        Assert.Equal(ModuleShape.Square, grid.ModuleShape);
+        // Top-left corner must be dark (part of finder outer ring)
+        Assert.True(grid.Modules[0][0]);
+    }
+
+    [Fact]
+    public void EncodeOneDigit_M1()
+    {
+        var grid = MicroQR.Encode("1");
+        AssertValidGrid(grid, 11);
+    }
+
+    [Fact]
+    public void EncodeFiveDigits_M1()
+    {
+        var grid = MicroQR.Encode("12345");
+        AssertValidGrid(grid, 11);
+    }
+
+    [Fact]
+    public void EncodeHello_M2()
+    {
+        var grid = MicroQR.Encode("HELLO");
+        AssertValidGrid(grid, 13);
+    }
+
+    [Fact]
+    public void EncodeNumericPushesFromM1toM2()
+    {
+        // "123456" = 6 digits, exceeds M1 capacity of 5
+        var grid = MicroQR.Encode("123456");
+        AssertValidGrid(grid, 13);
+    }
+
+    [Fact]
+    public void EncodeLowercasePushesToM3()
+    {
+        // "hello" = 5 bytes — M2 byte cap is 4, so M3 needed
+        var grid = MicroQR.Encode("hello");
+        AssertValidGrid(grid, 15);
+    }
+
+    [Fact]
+    public void EncodeMicroQRTest_M3()
+    {
+        var grid = MicroQR.Encode("MICRO QR TEST");
+        AssertValidGrid(grid, 15);
+    }
+
+    [Fact]
+    public void EncodeUrl_M4()
+    {
+        var grid = MicroQR.Encode("https://a.b");
+        AssertValidGrid(grid, 17);
+    }
+
+    [Fact]
+    public void EncodeAllEccLevelsForM4()
+    {
+        // "MICRO QR" — 8 alphanumeric chars, fits in all M4 levels
+        foreach (var ecc in new[] { MicroQREccLevel.L, MicroQREccLevel.M, MicroQREccLevel.Q })
+        {
+            var grid = MicroQR.Encode("MICRO QR", MicroQRVersion.M4, ecc);
+            AssertValidGrid(grid, 17);
+        }
+    }
+
+    [Fact]
+    public void EncodeSameInputTwiceIsDeterministic()
+    {
+        // The encoder is deterministic — same input always gives the same grid.
+        var g1 = MicroQR.Encode("HELLO");
+        var g2 = MicroQR.Encode("HELLO");
+        for (var r = 0; r < g1.Rows; r++)
+        for (var c = 0; c < g1.Cols; c++)
+            Assert.Equal(g1.Modules[r][c], g2.Modules[r][c]);
+    }
+
+    [Fact]
+    public void FinderPatternTopLeftIsCorrect()
+    {
+        // The 7×7 finder pattern has a specific bit pattern that must be preserved.
+        //   Outer border all dark, inner ring all light, 3×3 core dark.
+        var grid = MicroQR.Encode("1");
+        // Top-left corner of finder
+        Assert.True(grid.Modules[0][0]);  // top-left
+        Assert.True(grid.Modules[0][6]);  // top-right of finder
+        Assert.True(grid.Modules[6][0]);  // bottom-left of finder
+        Assert.True(grid.Modules[6][6]);  // bottom-right of finder
+        // Inner ring should be light
+        Assert.False(grid.Modules[1][1]);
+        Assert.False(grid.Modules[1][5]);
+        Assert.False(grid.Modules[5][1]);
+        Assert.False(grid.Modules[5][5]);
+        // Center core should be dark
+        Assert.True(grid.Modules[3][3]);
+    }
+
+    [Fact]
+    public void SeparatorRow7IsMostlyLight()
+    {
+        // Row 7, cols 1–7 are the separator (all light).
+        var grid = MicroQR.Encode("HELLO");
+        for (var c = 1; c <= 7; c++)
+            Assert.False(grid.Modules[7][c], $"Separator at row 7 col {c} should be light");
+    }
+
+    [Fact]
+    public void TimingPatternAtRow0AlternatesAfterCol7()
+    {
+        // Row 0 timing: col 8 is dark (even), col 9 light, col 10 dark, etc.
+        // The finder occupies cols 0–6; col 7 is separator; col 8+ is timing.
+        var grid = MicroQR.Encode("MICRO QR");  // M3
+        // col 8 (even) should be dark, col 9 (odd) should be light
+        Assert.True(grid.Modules[0][8],  "Timing col 8 should be dark (even)");
+        Assert.False(grid.Modules[0][9], "Timing col 9 should be light (odd)");
+        Assert.True(grid.Modules[0][10], "Timing col 10 should be dark (even)");
+    }
+
+    [Fact]
+    public void FormatAreaRow8IsWritten()
+    {
+        // Row 8, cols 1–8 hold format information bits.
+        // After encoding, these modules should not be uniform (some dark, some light
+        // depending on the format word). We simply check the row is not all-dark.
+        var grid = MicroQR.Encode("1");
+        var row8Values = Enumerable.Range(1, 8).Select(c => grid.Modules[8][c]).ToArray();
+        // Format word 0x4445 = 0100 0100 0100 0101 in binary.
+        // Not all the same, so the row should be mixed.
+        Assert.True(row8Values.Any(v => v) && row8Values.Any(v => !v));
+    }
+
+    [Fact]
+    public void AllVersions_ProduceExpectedSizes()
+    {
+        // Verify each version auto-selects and produces the correct size.
+        Assert.Equal(11, MicroQR.Encode("1").Rows);
+        Assert.Equal(13, MicroQR.Encode("ABCDE1").Rows);  // numeric in M2
+        Assert.Equal(15, MicroQR.Encode("MICRO QR TEST").Rows);
+        Assert.Equal(17, MicroQR.Encode("https://a.b").Rows);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Error paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class ErrorPathTests
+{
+    [Fact]
+    public void InputExceedingM4CapacityThrows()
+    {
+        // 36 numeric chars exceeds M4-L capacity of 35
+        Assert.Throws<InputTooLongException>(() =>
+            MicroQR.Encode("123456789012345678901234567890123456"));
+    }
+
+    [Fact]
+    public void TooManyBytesThrows()
+    {
+        // 16 bytes exceeds M4-L byte cap of 15
+        Assert.Throws<InputTooLongException>(() =>
+            MicroQR.Encode("abcdefghijklmnop"));
+    }
+
+    [Fact]
+    public void InvalidEccLevelForVersionThrows()
+    {
+        Assert.Throws<EccNotAvailableException>(() =>
+            MicroQR.SelectConfig("1", MicroQRVersion.M2, MicroQREccLevel.Q));
+    }
+
+    [Fact]
+    public void EmptyStringEncodesSuccessfully()
+    {
+        // Empty string is a valid 0-char numeric input
+        var grid = MicroQR.Encode("");
+        Assert.Equal(11, grid.Rows);
+    }
+
+    [Fact]
+    public void InvalidVersionEccCombinationThrows()
+    {
+        // There is no M3-Q
+        Assert.Throws<EccNotAvailableException>(() =>
+            MicroQR.Encode("1", MicroQRVersion.M3, MicroQREccLevel.Q));
+    }
+
+    [Fact]
+    public void M1OnlySupportsDetection()
+    {
+        // Requesting M1-L should find no candidates → EccNotAvailableException
+        Assert.Throws<EccNotAvailableException>(() =>
+            MicroQR.Encode("1", MicroQRVersion.M1, MicroQREccLevel.L));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Symbol table integrity
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class SymbolTableTests
+{
+    [Fact]
+    public void ExactlyEightConfigurations()
+    {
+        Assert.Equal(8, Tables.SymbolConfigs.Length);
+    }
+
+    [Fact]
+    public void SymbolIndicatorsAreZeroThroughSeven()
+    {
+        var indicators = Tables.SymbolConfigs.Select(c => c.SymbolIndicator).OrderBy(x => x).ToArray();
+        Assert.Equal(Enumerable.Range(0, 8).ToArray(), indicators);
+    }
+
+    [Fact]
+    public void SizeFormulaIsCorrect()
+    {
+        // size = 2 × versionNumber + 9
+        foreach (var cfg in Tables.SymbolConfigs)
+        {
+            var vNum = cfg.Version switch
+            {
+                MicroQRVersion.M1 => 1,
+                MicroQRVersion.M2 => 2,
+                MicroQRVersion.M3 => 3,
+                MicroQRVersion.M4 => 4,
+                _ => throw new InvalidOperationException()
+            };
+            Assert.Equal(2 * vNum + 9, cfg.Size);
+        }
+    }
+
+    [Fact]
+    public void M1OnlyHasDetectionEcc()
+    {
+        var m1Cfgs = Tables.SymbolConfigs.Where(c => c.Version == MicroQRVersion.M1).ToArray();
+        Assert.Single(m1Cfgs);
+        Assert.Equal(MicroQREccLevel.Detection, m1Cfgs[0].Ecc);
+    }
+
+    [Fact]
+    public void M4HasThreeEccLevels()
+    {
+        var m4Cfgs = Tables.SymbolConfigs.Where(c => c.Version == MicroQRVersion.M4).ToArray();
+        Assert.Equal(3, m4Cfgs.Length);
+        Assert.Contains(MicroQREccLevel.L, m4Cfgs.Select(c => c.Ecc));
+        Assert.Contains(MicroQREccLevel.M, m4Cfgs.Select(c => c.Ecc));
+        Assert.Contains(MicroQREccLevel.Q, m4Cfgs.Select(c => c.Ecc));
+    }
+
+    [Fact]
+    public void DataCwPlusEccCwEqualsExpectedTotals()
+    {
+        // Total codewords per symbol from the spec:
+        var expected = new Dictionary<(MicroQRVersion, MicroQREccLevel), (int data, int ecc)>
+        {
+            [(MicroQRVersion.M1, MicroQREccLevel.Detection)] = (3, 2),
+            [(MicroQRVersion.M2, MicroQREccLevel.L)]         = (5, 5),
+            [(MicroQRVersion.M2, MicroQREccLevel.M)]         = (4, 6),
+            [(MicroQRVersion.M3, MicroQREccLevel.L)]         = (11, 6),
+            [(MicroQRVersion.M3, MicroQREccLevel.M)]         = (9, 8),
+            [(MicroQRVersion.M4, MicroQREccLevel.L)]         = (16, 8),
+            [(MicroQRVersion.M4, MicroQREccLevel.M)]         = (14, 10),
+            [(MicroQRVersion.M4, MicroQREccLevel.Q)]         = (10, 14),
+        };
+        foreach (var cfg in Tables.SymbolConfigs)
+        {
+            var (d, e) = expected[(cfg.Version, cfg.Ecc)];
+            Assert.Equal(d, cfg.DataCW);
+            Assert.Equal(e, cfg.EccCW);
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. Alphanumeric character set
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class AlphanumCharsetTests
+{
+    [Fact]
+    public void AlphanumSetHasFortyFiveChars()
+    {
+        Assert.Equal(45, Tables.AlphanumChars.Length);
+    }
+
+    [Fact]
+    public void DigitsAreAtIndicesZeroThroughNine()
+    {
+        for (var d = 0; d <= 9; d++)
+            Assert.Equal(d, Tables.AlphanumChars.IndexOf((char)('0' + d)));
+    }
+
+    [Fact]
+    public void UppercaseLettersAreAtIndicesTenThroughThirtyFive()
+    {
+        for (var l = 0; l < 26; l++)
+            Assert.Equal(10 + l, Tables.AlphanumChars.IndexOf((char)('A' + l)));
+    }
+
+    [Fact]
+    public void SpaceIsAtIndex36()
+    {
+        Assert.Equal(36, Tables.AlphanumChars.IndexOf(' '));
+    }
+
+    [Fact]
+    public void LowercaseNotInAlphanumSet()
+    {
+        Assert.Equal(-1, Tables.AlphanumChars.IndexOf('a'));
+        Assert.Equal(-1, Tables.AlphanumChars.IndexOf('z'));
+    }
+}


### PR DESCRIPTION
## Summary

- Implements ISO/IEC 18004:2015 Annex E Micro QR Code encoder in C# (`code/packages/csharp/micro-qr/`)
- M1–M4 symbol versions (11×11 through 17×17), all 8 valid (version, ECC) combinations
- 4 mask patterns with full 4-rule penalty evaluation; pre-computed 32-entry format information table (XOR 0x4445)
- Reed-Solomon ECC via `CodingAdventures.Gf256`, output via `CodingAdventures.Barcode2D.ModuleGrid`

## Test plan

- [ ] `dotnet test` in `code/packages/csharp/micro-qr/` — 87 tests, all passing
- [ ] RS encoder correctness (all 6 ECC codeword counts: 2, 5, 6, 8, 10, 14)
- [ ] Format table spot-checks (all 32 entries verified against spec values)
- [ ] Mode selection: numeric → M1, alphanumeric → M2, byte → M3/M4
- [ ] Integration: known symbol dimensions for "1", "HELLO", "hello", "https://a.b"
- [ ] Finder pattern, separator, timing pattern structural verification
- [ ] All ECC levels for M4 (L, M, Q)
- [ ] Error paths: too-long input, invalid version+ECC combinations

Part of the 2D barcode stack completion across all supported languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
