### PR TITLE
[codex] Surface Board VM time.now return values

### DIFF
--- a/code/packages/python/board-vm-native/README.md
+++ b/code/packages/python/board-vm-native/README.md
@@ -11,8 +11,13 @@ from board_vm_native import Session
 
 session = Session()
 frames = session.blink(program_id=1, instruction_budget=12).frames
+now_frames = session.time_now(program_id=2, instruction_budget=12).frames
 ```
 
 Each frame is a Rust-produced Board VM wire frame ready for a transport to
 write to a board. A `Session` can also dispatch through any object that exposes
 `transact(frame, timeout_ms=...)` or `write(frame)`.
+
+`time_now()` uploads a Rust-built `time.now_ms` module and returns the board's
+millisecond clock through Rust-decoded run-report values when the transport
+returns a response.

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -182,6 +182,9 @@ class Session:
     def blink_module(self, pin: int = 13, high_ms: int = 250, low_ms: int = 250, max_stack: int = 4) -> bytes:
         return _native.blink_module(pin, high_ms, low_ms, max_stack)
 
+    def time_now_module(self, max_stack: int = 1) -> bytes:
+        return _native.time_now_module(max_stack)
+
     def upload(self, *, program_id: int = DEFAULT_PROGRAM_ID, module_bytes: bytes) -> SessionResult:
         return SessionResult([
             self._dispatch("program_begin", self._call_native(_native.program_begin_wire, program_id, module_bytes)),
@@ -201,6 +204,17 @@ class Session:
         return self.upload(
             program_id=program_id,
             module_bytes=self.blink_module(pin=pin, high_ms=high_ms, low_ms=low_ms, max_stack=max_stack),
+        )
+
+    def upload_time_now(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        max_stack: int = 1,
+    ) -> SessionResult:
+        return self.upload(
+            program_id=program_id,
+            module_bytes=self.time_now_module(max_stack=max_stack),
         )
 
     def run(self, *, program_id: int = DEFAULT_PROGRAM_ID, instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET) -> ProtocolResult:
@@ -236,6 +250,24 @@ class Session:
         results.append(self.run(program_id=program_id, instruction_budget=instruction_budget))
         return SessionResult(results)
 
+    def time_now(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET,
+        handshake: bool = False,
+        query_caps: bool = False,
+        max_stack: int = 1,
+    ) -> SessionResult:
+        results: list[ProtocolResult] = []
+        if handshake:
+            results.append(self.hello())
+        if query_caps:
+            results.append(self.capabilities())
+        results.extend(self.upload_time_now(program_id=program_id, max_stack=max_stack).results)
+        results.append(self.run(program_id=program_id, instruction_budget=instruction_budget))
+        return SessionResult(results)
+
     def run_command(self, line: str, **options: Any) -> SessionResult:
         words = line.split()
         if not words:
@@ -250,10 +282,15 @@ class Session:
         if command == "upload-blink":
             self._ensure_no_extra(words, command)
             return self.upload_blink(**options)
+        if command in {"upload-time-now", "upload-time.now"}:
+            self._ensure_no_extra(words, command)
+            return self.upload_time_now(**options)
         if command == "run":
             return SessionResult([self.run(**self._with_optional_budget(words, command, options))])
         if command == "blink":
             return self.blink(**self._with_optional_budget(words, command, options))
+        if command in {"time-now", "time.now", "now"}:
+            return self.time_now(**self._with_optional_budget(words, command, options))
         raise ValueError(f"unknown Board VM session command: {command}")
 
     def decode_response(self, response: bytes) -> dict[str, Any]:

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -1,14 +1,14 @@
 use std::ffi::{c_char, c_long};
 use std::ptr;
 
-use board_vm_host::{BlinkProgram, BLINK_MODULE_LEN};
+use board_vm_host::{BlinkProgram, TimeNowProgram, BLINK_MODULE_LEN, TIME_NOW_MODULE_LEN};
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
     build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
-    build_run_background_wire_frame, capability_board_metadata, capability_bytecode_callable,
-    capability_flag_names, capability_protocol_feature, decode_wire_response, program_format_name,
-    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageCoreError,
+    build_run_background_wire_frame, build_time_now_module, capability_board_metadata,
+    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
+    decode_wire_response, program_format_name, run_status_name, BoardVmLanguageSession,
+    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError, LanguageValue,
 };
 use python_bridge::*;
 
@@ -76,6 +76,19 @@ unsafe extern "C" fn py_blink_module(_module: PyObjectPtr, args: PyObjectPtr) ->
     let module = match build_blink_module_value(pin, high_ms, low_ms, max_stack) {
         Ok(module) => module,
         Err(error) => return raise_core_error("blink_module", error),
+    };
+    bytes_to_py(&module)
+}
+
+unsafe extern "C" fn py_time_now_module(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let max_stack = match parse_arg_u8(args, 0, "max_stack") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    let module = match build_time_now_module_value(max_stack) {
+        Ok(module) => module,
+        Err(error) => return raise_core_error("time_now_module", error),
     };
     bytes_to_py(&module)
 }
@@ -353,6 +366,7 @@ unsafe fn response_body_to_py(
                 "return_count",
                 usize_to_py(report.return_count as usize),
             );
+            dict_set(dict, "returns", language_values_to_py(&report.returns));
         }
         DecodedLanguageResponseBody::Error(error) => {
             dict_set(dict, "code", usize_to_py(error.code as usize));
@@ -382,6 +396,32 @@ unsafe fn capability_flag_names_to_py(flags: u16) -> PyObjectPtr {
     list
 }
 
+unsafe fn language_values_to_py(values: &[LanguageValue]) -> PyObjectPtr {
+    let list = PyList_New(values.len() as isize);
+    for (index, value) in values.iter().enumerate() {
+        PyList_SetItem(list, index as isize, language_value_to_py(value));
+    }
+    list
+}
+
+unsafe fn language_value_to_py(value: &LanguageValue) -> PyObjectPtr {
+    let dict = PyDict_New();
+    dict_set(dict, "kind", str_to_py(value.kind()));
+    let value_py = match value {
+        LanguageValue::Unit => py_none(),
+        LanguageValue::Bool(value) => bool_to_py(*value),
+        LanguageValue::U8(value) => usize_to_py(*value as usize),
+        LanguageValue::U16(value) => usize_to_py(*value as usize),
+        LanguageValue::U32(value) => usize_to_py(*value as usize),
+        LanguageValue::I16(value) => PyLong_FromLong(*value as c_long),
+        LanguageValue::Handle(value) => usize_to_py(*value as usize),
+        LanguageValue::Bytes(value) => bytes_to_py(value),
+        LanguageValue::String(value) => str_to_py(value),
+    };
+    dict_set(dict, "value", value_py);
+    dict
+}
+
 fn build_blink_module_value(
     pin: u8,
     high_ms: u16,
@@ -398,6 +438,13 @@ fn build_blink_module_value(
         },
         &mut module,
     )?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_time_now_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; TIME_NOW_MODULE_LEN];
+    let len = build_time_now_module(TimeNowProgram { max_stack }, &mut module)?;
     module.truncate(len);
     Ok(module)
 }
@@ -503,7 +550,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 9] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 10] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -521,6 +568,12 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_blink_module),
             ml_flags: METH_VARARGS,
             ml_doc: b"Build a Board VM blink BVM module in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"time_now_module\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_time_now_module),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM time.now_ms BVM module in Rust.\0".as_ptr() as *const c_char,
         },
         PyMethodDef {
             ml_name: b"program_begin_wire\0".as_ptr() as *const c_char,

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -26,6 +26,10 @@ def test_native_session_builds_protocol_bytes_in_rust():
     assert isinstance(module, bytes)
     assert len(module) > 0
 
+    time_module = session.time_now_module(max_stack=1)
+    assert isinstance(time_module, bytes)
+    assert len(time_module) > 0
+
 
 def test_session_dispatches_frames_through_write_transport():
     transport = FakeWriteTransport()
@@ -52,6 +56,21 @@ def test_run_command_accepts_repl_style_blink():
     session = Session(transport=transport)
 
     result = session.run_command("blink 42", program_id=9)
+
+    assert [item.command for item in result.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+        "run",
+    ]
+    assert result.frames == transport.frames
+
+
+def test_run_command_accepts_repl_style_time_now():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.run_command("time-now 42", program_id=9)
 
     assert [item.command for item in result.results] == [
         "program_begin",

--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -64,6 +64,16 @@ session result for debugging.
 Tests and alternate runtimes can inject any transport object that responds to
 `transact(frame, timeout_ms:)` or `write(frame)`.
 
+`time.now_ms` follows the same path and returns through Rust-decoded run-report
+values:
+
+```ruby
+CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
+  result = board.time.now_ms
+  millis = result.results.last.decoded_response["payload"]["returns"].first["value"]
+end
+```
+
 For REPL-style sessions, the Ruby surface exposes named commands while keeping
 the same Rust-owned protocol boundary:
 
@@ -73,14 +83,15 @@ CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
     vm.hello
     vm.capabilities
     vm.run_command("blink 24")
+    vm.run_command("time-now 24")
   end
 end
 ```
 
-`hello`, `capabilities`, `upload_blink`, `run`, `blink`, and `run_command`
-return dispatch results with the Rust-produced frame, optional raw response
-bytes, and optional Rust-decoded response hash. The text command parser is Ruby
-sugar only; every dispatched frame still comes from
+`hello`, `capabilities`, `upload_blink`, `upload_time_now`, `run`, `blink`,
+`time_now`, and `run_command` return dispatch results with the Rust-produced
+frame, optional raw response bytes, and optional Rust-decoded response hash. The
+text command parser is Ruby sugar only; every dispatched frame still comes from
 `CodingAdventures::BoardVM::Native::Session`.
 
 Capability reports can be lifted into Ruby objects after Rust decodes the board

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -1,15 +1,16 @@
-use std::ffi::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_long, c_void};
 use std::ptr;
 use std::slice;
 
-use board_vm_host::{BlinkProgram, BLINK_MODULE_LEN};
+use board_vm_host::{BlinkProgram, TimeNowProgram, BLINK_MODULE_LEN, TIME_NOW_MODULE_LEN};
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
     build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
-    build_run_background_wire_frame, build_stop_wire_frame, capability_board_metadata,
-    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, program_format_name, run_status_name, BoardVmLanguageSession,
-    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError,
+    build_run_background_wire_frame, build_stop_wire_frame, build_time_now_module,
+    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
+    capability_protocol_feature, decode_wire_response, program_format_name, run_status_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageCoreError, LanguageValue,
 };
 use ruby_bridge::VALUE;
 
@@ -74,6 +75,14 @@ extern "C" fn session_blink_module(
 
     let module = build_blink_module_value(pin, high_ms, low_ms, max_stack)
         .unwrap_or_else(|error| raise_core_error("blink_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_time_now_module(_self_val: VALUE, max_stack_val: VALUE) -> VALUE {
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_time_now_module_value(max_stack)
+        .unwrap_or_else(|error| raise_core_error("time_now_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -326,7 +335,11 @@ fn response_body_to_rb(body: &DecodedLanguageResponseBody, payload_len: usize) -
                     "board_metadata",
                     ruby_bridge::bool_to_rb(capability_board_metadata(capability.flags)),
                 );
-                hash_set(item, "flag_names", capability_flag_names_to_rb(capability.flags));
+                hash_set(
+                    item,
+                    "flag_names",
+                    capability_flag_names_to_rb(capability.flags),
+                );
                 ruby_bridge::array_push(capabilities, item);
             }
             hash_set(hash, "capabilities", capabilities);
@@ -366,6 +379,7 @@ fn response_body_to_rb(body: &DecodedLanguageResponseBody, payload_len: usize) -
             hash_set(hash, "stack_depth", rb_usize(report.stack_depth));
             hash_set(hash, "open_handles", rb_usize(report.open_handles));
             hash_set(hash, "return_count", rb_usize(report.return_count));
+            hash_set(hash, "returns", language_values_to_rb(&report.returns));
         }
         DecodedLanguageResponseBody::Error(error) => {
             hash_set(hash, "code", rb_usize(error.code));
@@ -389,6 +403,32 @@ fn capability_flag_names_to_rb(flags: u16) -> VALUE {
         ruby_bridge::array_push(array, ruby_bridge::str_to_rb(name));
     }
     array
+}
+
+fn language_values_to_rb(values: &[LanguageValue]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for value in values {
+        ruby_bridge::array_push(array, language_value_to_rb(value));
+    }
+    array
+}
+
+fn language_value_to_rb(value: &LanguageValue) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "kind", ruby_bridge::str_to_rb(value.kind()));
+    let value_rb = match value {
+        LanguageValue::Unit => ruby_bridge::QNIL,
+        LanguageValue::Bool(value) => ruby_bridge::bool_to_rb(*value),
+        LanguageValue::U8(value) => rb_usize(*value),
+        LanguageValue::U16(value) => rb_usize(*value),
+        LanguageValue::U32(value) => rb_usize(*value),
+        LanguageValue::I16(value) => rb_i64(*value as i64),
+        LanguageValue::Handle(value) => rb_usize(*value),
+        LanguageValue::Bytes(value) => ruby_bridge::bytes_to_rb(value),
+        LanguageValue::String(value) => ruby_bridge::str_to_rb(value),
+    };
+    hash_set(hash, "value", value_rb);
+    hash
 }
 
 fn message_type_name(code: u8) -> &'static str {
@@ -426,6 +466,10 @@ fn rb_usize(value: impl TryInto<usize>) -> VALUE {
     ruby_bridge::usize_to_rb(value.try_into().unwrap_or(usize::MAX))
 }
 
+fn rb_i64(value: i64) -> VALUE {
+    unsafe { ruby_bridge::rb_int2inum(value as c_long) }
+}
+
 fn build_blink_module_value(
     pin: u8,
     high_ms: u16,
@@ -442,6 +486,13 @@ fn build_blink_module_value(
         },
         &mut module,
     )?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_time_now_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; TIME_NOW_MODULE_LEN];
+    let len = build_time_now_module(TimeNowProgram { max_stack }, &mut module)?;
     module.truncate(len);
     Ok(module)
 }
@@ -523,6 +574,12 @@ pub extern "C" fn Init_board_vm_native() {
         "blink_module",
         session_blink_module as *const c_void,
         4,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "time_now_module",
+        session_time_now_module as *const c_void,
+        1,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -60,6 +60,10 @@ module CodingAdventures
         Led.new(self)
       end
 
+      def time
+        TimeApi.new(self)
+      end
+
       def eject
         Ejector.new(self)
       end
@@ -102,6 +106,24 @@ module CodingAdventures
           pin: pin,
           high_ms: high_ms,
           low_ms: low_ms,
+          max_stack: max_stack,
+          handshake: true,
+          query_caps: true,
+          host_nonce: host_nonce
+        )
+      end
+
+      def time_now!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        max_stack: 1
+      )
+        ensure_uno_r4_wifi!
+
+        session.time_now(
+          program_id: program_id,
+          budget: budget,
           max_stack: max_stack,
           handshake: true,
           query_caps: true,
@@ -248,6 +270,26 @@ module CodingAdventures
           pin: pin,
           high_ms: high_ms,
           low_ms: low_ms,
+          max_stack: max_stack
+        )
+      end
+    end
+
+    class TimeApi
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def now_ms(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        max_stack: 1
+      )
+        @connection.time_now!(
+          program_id: program_id,
+          budget: budget,
+          host_nonce: host_nonce,
           max_stack: max_stack
         )
       end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -61,6 +61,17 @@ module CodingAdventures
         )
       end
 
+      def time_now_module(max_stack: 1)
+        native_session.time_now_module(max_stack)
+      end
+
+      def upload_time_now(program_id: @program_id, max_stack: 1)
+        upload(
+          program_id: program_id,
+          module_bytes: time_now_module(max_stack: max_stack)
+        )
+      end
+
       def run(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -108,6 +119,27 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def time_now(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        max_stack: 1,
+        handshake: false,
+        query_caps: false,
+        host_name: @host_name,
+        host_nonce: @host_nonce
+      )
+        results = []
+        results << hello(host_name: host_name, host_nonce: host_nonce) if handshake
+        results << capabilities if query_caps
+        results.concat(upload_time_now(program_id: program_id, max_stack: max_stack).results)
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget
+        )
+        SessionResult.new(results: results)
+      end
+
       def run_command(line, **options)
         words = line.to_s.split
         command = words.shift
@@ -123,6 +155,9 @@ module CodingAdventures
         when "upload-blink"
           ensure_no_extra_arguments!(words, command)
           upload_blink(**options)
+        when "upload-time-now", "upload-time.now"
+          ensure_no_extra_arguments!(words, command)
+          upload_time_now(**options)
         when "run"
           SessionResult.new(results: [run(**options.merge(optional_budget(words, command)))])
         when "stop"
@@ -130,6 +165,8 @@ module CodingAdventures
           SessionResult.new(results: [stop])
         when "blink"
           blink(**options.merge(optional_budget(words, command)))
+        when "time-now", "time.now", "now"
+          time_now(**options.merge(optional_budget(words, command)))
         else
           raise UnknownSessionCommandError, "unknown Board VM session command: #{command}"
         end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -86,6 +86,28 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_time_now_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          result = board.time.now_ms(program_id: 10, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 6, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal transport.frames, result.frames
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          result.results.map(&:command)
+      end
+
       def test_session_surface_dispatches_protocol_commands_with_native_frames
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -100,19 +122,22 @@ module CodingAdventures
             hello = session.hello(host_nonce: 99)
             caps = session.capabilities
             upload = session.upload_blink(program_id: 4)
+            time_upload = session.upload_time_now(program_id: 5)
             run = session.run(program_id: 4, budget: 77)
             stop = session.stop
 
             assert_equal :hello, hello.command
             assert_equal :capabilities, caps.command
             assert_equal [:program_begin, :program_chunk, :program_end], upload.results.map(&:command)
+            assert_equal [:program_begin, :program_chunk, :program_end],
+              time_upload.results.map(&:command)
             assert_equal :run, run.command
             assert_equal :stop, stop.command
           end
         end
 
         assert_empty runner.calls
-        assert_equal 7, transport.frames.length
+        assert_equal 10, transport.frames.length
         assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
       end
 
@@ -142,6 +167,23 @@ module CodingAdventures
           transport: transport
         ) do |board|
           result = board.session.run_command("blink 24", program_id: 8)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal result.frames, transport.frames
+        end
+      end
+
+      def test_session_run_command_accepts_repl_style_time_now
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("time-now 24", program_id: 9)
 
           assert_equal [:program_begin, :program_chunk, :program_end, :run],
             result.results.map(&:command)
@@ -213,6 +255,10 @@ module CodingAdventures
         module_bytes = session.blink_module(13, 250, 250, 4)
         assert_instance_of String, module_bytes
         assert_operator module_bytes.bytesize, :>, 0
+
+        time_module_bytes = session.time_now_module(1)
+        assert_instance_of String, time_module_bytes
+        assert_operator time_module_bytes.bytesize, :>, 0
 
         stop = session.stop_wire
         assert_instance_of String, stop

--- a/code/packages/rust/board-vm-device/src/lib.rs
+++ b/code/packages/rust/board-vm-device/src/lib.rs
@@ -8,15 +8,16 @@ use board_vm_protocol::{
     decode_frame, decode_hello, decode_program_begin, decode_program_chunk, decode_program_end,
     decode_run_request, decode_wire_frame, encode_caps_report, encode_error_payload, encode_frame,
     encode_hello_ack, encode_program_begin, encode_program_chunk, encode_program_end,
-    encode_run_report_header, encode_wire_frame, CapabilityDescriptor, CapsReportHeader,
-    ErrorPayload, Frame, HelloAck, MessageType, ProgramBegin, ProgramChunk, ProgramEnd,
-    ProtocolError, RunReportHeader, RunStatus as ProtocolRunStatus, CAP_FLAG_BYTECODE_CALLABLE,
-    CAP_FLAG_PROTOCOL_FEATURE, CAP_PROGRAM_RAM_EXEC, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
-    NO_BYTECODE_OFFSET, NO_PROGRAM_ID, RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
+    encode_run_report_header, encode_value, encode_wire_frame, CapabilityDescriptor,
+    CapsReportHeader, ErrorPayload, Frame, HelloAck, MessageType, ProgramBegin, ProgramChunk,
+    ProgramEnd, ProtocolError, RunReportHeader, RunStatus as ProtocolRunStatus,
+    Value as ProtocolValue, CAP_FLAG_BYTECODE_CALLABLE, CAP_FLAG_PROTOCOL_FEATURE,
+    CAP_PROGRAM_RAM_EXEC, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE, NO_BYTECODE_OFFSET,
+    NO_PROGRAM_ID, RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
 };
 use board_vm_runtime::{
     BoardHal, RunCursor, RunReport as RuntimeRunReport, RunStatus as RuntimeRunStatus, Runtime,
-    RuntimeError,
+    RuntimeError, Value as RuntimeValue,
 };
 
 pub const DEFAULT_DEVICE_RUNTIME_ID: &str = "board-vm-device";
@@ -149,6 +150,7 @@ pub struct BackgroundRunReport {
     pub elapsed_ms: u32,
     pub stack_depth: u8,
     pub open_handles: u8,
+    pub return_value: RuntimeValue,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -167,6 +169,7 @@ impl BackgroundRunReport {
             elapsed_ms,
             stack_depth: report.stack_depth,
             open_handles: report.open_handles,
+            return_value: report.return_value,
         }
     }
 
@@ -182,6 +185,7 @@ impl BackgroundRunReport {
             elapsed_ms,
             stack_depth: report.stack_depth,
             open_handles: report.open_handles,
+            return_value: report.return_value,
         }
     }
 }
@@ -940,7 +944,8 @@ fn write_run_report_response(
     payload_out: &mut [u8],
     frame_out: &mut [u8],
 ) -> Result<usize, BoardFault> {
-    let payload_len = encode_run_report_header(
+    let return_count = runtime_return_count(report.status, report.return_value);
+    let mut payload_len = encode_run_report_header(
         &RunReportHeader {
             program_id: report.program_id,
             status: report.status,
@@ -948,16 +953,42 @@ fn write_run_report_response(
             elapsed_ms: report.elapsed_ms,
             stack_depth: report.stack_depth,
             open_handles: report.open_handles,
-            return_count: 0,
+            return_count,
         },
         payload_out,
     )?;
+    if return_count == 1 {
+        let value = protocol_value_from_runtime(report.return_value);
+        payload_len += encode_value(&value, &mut payload_out[payload_len..])?;
+    }
     write_response(
         MessageType::RUN_REPORT,
         request_id,
         &payload_out[..payload_len],
         frame_out,
     )
+}
+
+fn runtime_return_count(status: ProtocolRunStatus, value: RuntimeValue) -> u32 {
+    if status == ProtocolRunStatus::Halted && value != RuntimeValue::Unit {
+        1
+    } else {
+        0
+    }
+}
+
+fn protocol_value_from_runtime(value: RuntimeValue) -> ProtocolValue<'static> {
+    match value {
+        RuntimeValue::Unit => ProtocolValue::Unit,
+        RuntimeValue::Bool(value) => ProtocolValue::Bool(value),
+        RuntimeValue::U8(value) => ProtocolValue::U8(value),
+        RuntimeValue::U16(value) => ProtocolValue::U16(value),
+        RuntimeValue::U32(value) => ProtocolValue::U32(value),
+        RuntimeValue::I16(value) => ProtocolValue::I16(value),
+        RuntimeValue::Handle(value) => {
+            ProtocolValue::Handle(u16::from(value.index) | (u16::from(value.generation) << 8))
+        }
+    }
 }
 
 fn crc32_ieee(bytes: &[u8]) -> u32 {
@@ -978,11 +1009,14 @@ fn crc32_ieee(bytes: &[u8]) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use board_vm_host::{write_blink_module, BlinkProgram, HostSession, DEFAULT_PROGRAM_ID};
+    use board_vm_host::{
+        write_blink_module, write_time_now_module, BlinkProgram, HostSession, TimeNowProgram,
+        DEFAULT_PROGRAM_ID,
+    };
     use board_vm_ir::CapabilitySet;
     use board_vm_protocol::{
         decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
-        decode_run_report_header, decode_wire_frame, encode_wire_frame, RunStatus,
+        decode_run_report_header, decode_wire_frame, encode_wire_frame, RunStatus, Value,
     };
     use board_vm_runtime::{GpioMode, HalError, Level};
 
@@ -1436,6 +1470,69 @@ mod tests {
         assert_eq!(report.open_handles, 0);
         assert!(!device.is_background_running());
         assert_eq!(device.poll_background(100).unwrap(), None);
+    }
+
+    #[test]
+    fn run_report_encodes_return_value_for_halting_module() {
+        let mut device = new_device();
+        let mut session = HostSession::new();
+        let mut module = [0u8; board_vm_host::TIME_NOW_MODULE_LEN];
+        let module_len = write_time_now_module(TimeNowProgram::new(), &mut module).unwrap();
+        let module = &module[..module_len];
+        let mut host_payload = [0u8; 128];
+        let mut request = [0u8; 192];
+        let mut device_payload = [0u8; 256];
+        let mut response = [0u8; 320];
+
+        let begin = session
+            .program_begin_frame(DEFAULT_PROGRAM_ID, module, &mut host_payload, &mut request)
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..begin.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let chunk = session
+            .program_chunk_frame(
+                DEFAULT_PROGRAM_ID,
+                0,
+                module,
+                &mut host_payload,
+                &mut request,
+            )
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..chunk.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let end = session
+            .program_end_frame(DEFAULT_PROGRAM_ID, &mut host_payload, &mut request)
+            .unwrap();
+        handle(
+            &mut device,
+            &request[..end.len],
+            &mut device_payload,
+            &mut response,
+        );
+
+        let run = session
+            .run_background_frame(DEFAULT_PROGRAM_ID, 10, &mut host_payload, &mut request)
+            .unwrap();
+        let response_len = handle(
+            &mut device,
+            &request[..run.len],
+            &mut device_payload,
+            &mut response,
+        );
+        let frame = decode_frame(&response[..response_len]).unwrap();
+        let (report, mut decoder) = decode_run_report_header(frame.payload).unwrap();
+        assert_eq!(report.status, RunStatus::Halted);
+        assert_eq!(report.return_count, 1);
+        assert_eq!(decoder.read_value().unwrap(), Value::U32(0));
+        decoder.finish().unwrap();
     }
 
     #[test]

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,7 +1,7 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_GPIO_CLOSE,
-    CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_TIME_SLEEP_MS, FLAG_PROGRAM_MAY_RUN_FOREVER,
-    MODULE_MAGIC, MODULE_VERSION,
+    CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
+    FLAG_PROGRAM_MAY_RUN_FOREVER, MODULE_MAGIC, MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -18,6 +18,8 @@ pub const BLINK_CODE_LEN: usize = 26;
 pub const BLINK_MODULE_LEN: usize = 36;
 pub const GPIO_READ_CODE_LEN: usize = 13;
 pub const GPIO_READ_MODULE_LEN: usize = 23;
+pub const TIME_NOW_CODE_LEN: usize = 3;
+pub const TIME_NOW_MODULE_LEN: usize = 13;
 
 pub const GPIO_MODE_INPUT: u8 = 0;
 pub const GPIO_MODE_OUTPUT: u8 = 1;
@@ -112,6 +114,23 @@ impl GpioReadProgram {
             mode: GPIO_MODE_INPUT_PULLDOWN,
             max_stack: 2,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeNowProgram {
+    pub max_stack: u8,
+}
+
+impl TimeNowProgram {
+    pub const fn new() -> Self {
+        Self { max_stack: 1 }
+    }
+}
+
+impl Default for TimeNowProgram {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -456,6 +475,33 @@ pub fn write_gpio_read_module(
     Ok(offset)
 }
 
+pub fn write_time_now_code(_program: TimeNowProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if out.len() < TIME_NOW_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_call_u8(out, &mut offset, CAP_TIME_NOW_MS)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_time_now_module(program: TimeNowProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if out.len() < TIME_NOW_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; TIME_NOW_CODE_LEN];
+    let code_len = write_time_now_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(0, program.max_stack, &code[..code_len]),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(&module, CapabilitySet::blink_mvp(), program.max_stack)?;
+    Ok(offset)
+}
+
 pub fn write_module(spec: ModuleSpec<'_>, out: &mut [u8]) -> Result<usize, HostError> {
     if spec.code.len() > u32::MAX as usize || spec.const_pool.len() > u32::MAX as usize {
         return Err(HostError::ProgramTooLarge);
@@ -575,6 +621,9 @@ mod tests {
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x02, 0x00, 0x0D, 0x12, 0x0D, 0x12, 0x02, 0x40, 0x01,
         0x20, 0x40, 0x03, 0x22, 0x40, 0x04, 0x50, 0x00,
     ];
+    const TIME_NOW_MODULE_HEX: [u8; TIME_NOW_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x03, 0x40, 0x11, 0x50, 0x00,
+    ];
 
     #[test]
     fn builds_blink_module_from_bvm05_fixture() {
@@ -617,6 +666,20 @@ mod tests {
             write_gpio_read_module(program, &mut module),
             Err(HostError::InvalidGpioReadMode(GPIO_MODE_OUTPUT))
         );
+    }
+
+    #[test]
+    fn builds_time_now_module_with_return() {
+        let mut module = [0u8; TIME_NOW_MODULE_LEN];
+        let len = write_time_now_module(TimeNowProgram::new(), &mut module).unwrap();
+        assert_eq!(len, TIME_NOW_MODULE_LEN);
+        assert_eq!(module, TIME_NOW_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp(), 1).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_TIME_NOW_MS]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -13,15 +13,16 @@ use std::slice;
 use std::str;
 
 use board_vm_host::{
-    write_blink_module, BlinkProgram, HostError, HostSession, BLINK_MODULE_LEN,
-    DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
+    write_blink_module, write_time_now_module, BlinkProgram, HostError, HostSession,
+    TimeNowProgram, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
+    TIME_NOW_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
     decode_program_begin, decode_program_chunk, decode_program_end, decode_run_report_header,
     decode_wire_frame, encode_wire_frame, Frame, MessageType, ProgramFormat, ProtocolError,
-    RunStatus, CAP_FLAG_BOARD_METADATA, CAP_FLAG_BYTECODE_CALLABLE, CAP_FLAG_PROTOCOL_FEATURE,
-    FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
+    RunStatus, Value as ProtocolValue, CAP_FLAG_BOARD_METADATA, CAP_FLAG_BYTECODE_CALLABLE,
+    CAP_FLAG_PROTOCOL_FEATURE, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
 };
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
@@ -250,6 +251,36 @@ pub struct LanguageRunReport {
     pub stack_depth: u8,
     pub open_handles: u8,
     pub return_count: u32,
+    pub returns: Vec<LanguageValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LanguageValue {
+    Unit,
+    Bool(bool),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    I16(i16),
+    Handle(u16),
+    Bytes(Vec<u8>),
+    String(String),
+}
+
+impl LanguageValue {
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Unit => "unit",
+            Self::Bool(_) => "bool",
+            Self::U8(_) => "u8",
+            Self::U16(_) => "u16",
+            Self::U32(_) => "u32",
+            Self::I16(_) => "i16",
+            Self::Handle(_) => "handle",
+            Self::Bytes(_) => "bytes",
+            Self::String(_) => "string",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -378,6 +409,13 @@ pub fn build_blink_module(
     out: &mut [u8],
 ) -> Result<usize, LanguageCoreError> {
     Ok(write_blink_module(program, out)?)
+}
+
+pub fn build_time_now_module(
+    program: TimeNowProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_time_now_module(program, out)?)
 }
 
 pub fn build_program_begin_wire_frame(
@@ -583,7 +621,11 @@ fn decode_response_body(
             ))
         }
         MessageType::RUN_REPORT => {
-            let (report, decoder) = decode_run_report_header(frame.payload)?;
+            let (report, mut decoder) = decode_run_report_header(frame.payload)?;
+            let mut returns = Vec::with_capacity(report.return_count as usize);
+            for _ in 0..report.return_count {
+                returns.push(language_value_from_protocol(decoder.read_value()?)?);
+            }
             decoder.finish()?;
             Ok(DecodedLanguageResponseBody::RunReport(LanguageRunReport {
                 program_id: report.program_id,
@@ -593,10 +635,27 @@ fn decode_response_body(
                 stack_depth: report.stack_depth,
                 open_handles: report.open_handles,
                 return_count: report.return_count,
+                returns,
             }))
         }
         _ => Ok(DecodedLanguageResponseBody::Raw),
     }
+}
+
+fn language_value_from_protocol(
+    value: ProtocolValue<'_>,
+) -> Result<LanguageValue, LanguageCoreError> {
+    Ok(match value {
+        ProtocolValue::Unit => LanguageValue::Unit,
+        ProtocolValue::Bool(value) => LanguageValue::Bool(value),
+        ProtocolValue::U8(value) => LanguageValue::U8(value),
+        ProtocolValue::U16(value) => LanguageValue::U16(value),
+        ProtocolValue::U32(value) => LanguageValue::U32(value),
+        ProtocolValue::I16(value) => LanguageValue::I16(value),
+        ProtocolValue::Handle(value) => LanguageValue::Handle(value),
+        ProtocolValue::Bytes(value) => LanguageValue::Bytes(value.to_vec()),
+        ProtocolValue::String(value) => LanguageValue::String(value.to_owned()),
+    })
 }
 
 thread_local! {
@@ -733,6 +792,22 @@ pub unsafe extern "C" fn board_vm_language_blink_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_time_now_module(
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_time_now_module(TimeNowProgram { max_stack }, module_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_program_begin_wire(
     session: *mut BoardVmLanguageSession,
     program_id: u16,
@@ -857,6 +932,11 @@ pub extern "C" fn board_vm_language_default_instruction_budget() -> u32 {
 #[no_mangle]
 pub extern "C" fn board_vm_language_blink_module_len() -> u64 {
     BLINK_MODULE_LEN as u64
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_time_now_module_len() -> u64 {
+    TIME_NOW_MODULE_LEN as u64
 }
 
 fn catch_status(
@@ -988,10 +1068,10 @@ mod tests {
     use super::*;
     use board_vm_protocol::{
         decode_program_begin, decode_program_chunk, decode_program_end, decode_run_request,
-        encode_caps_report, encode_frame, encode_hello_ack, encode_wire_frame,
+        encode_caps_report, encode_frame, encode_hello_ack, encode_value, encode_wire_frame,
         CapabilityDescriptor, CapsReportHeader, Frame, HelloAck, MessageType, RunReportHeader,
-        RunStatus, FLAG_IS_RESPONSE, GOLDEN_HELLO_WIRE_FRAME_BVM_V1, RUN_FLAG_BACKGROUND_RUN,
-        RUN_FLAG_RESET_VM_BEFORE_RUN,
+        RunStatus, Value, FLAG_IS_RESPONSE, GOLDEN_HELLO_WIRE_FRAME_BVM_V1,
+        RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
     };
 
     #[test]
@@ -1026,6 +1106,17 @@ mod tests {
         };
         assert_eq!(module_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(module_status.len, BLINK_MODULE_LEN as u64);
+
+        let mut time_now_module = [0u8; TIME_NOW_MODULE_LEN];
+        let time_now_status = unsafe {
+            board_vm_language_time_now_module(
+                1,
+                time_now_module.as_mut_ptr(),
+                time_now_module.len() as u64,
+            )
+        };
+        assert_eq!(time_now_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(time_now_status.len, TIME_NOW_MODULE_LEN as u64);
 
         let begin = unsafe {
             board_vm_language_program_begin_wire(
@@ -1209,20 +1300,24 @@ mod tests {
 
         let run = RunReportHeader {
             program_id: 7,
-            status: RunStatus::Running,
+            status: RunStatus::Halted,
             instructions_executed: 42,
             elapsed_ms: 8,
             stack_depth: 2,
             open_handles: 1,
-            return_count: 0,
+            return_count: 1,
         };
-        let payload_len = board_vm_protocol::encode_run_report_header(&run, &mut payload).unwrap();
+        let mut payload_len =
+            board_vm_protocol::encode_run_report_header(&run, &mut payload).unwrap();
+        payload_len += encode_value(&Value::U32(1234), &mut payload[payload_len..]).unwrap();
         let decoded = decode_response_fixture(MessageType::RUN_REPORT, 13, &payload[..payload_len]);
         match decoded.body {
             DecodedLanguageResponseBody::RunReport(report) => {
                 assert_eq!(report.program_id, 7);
-                assert_eq!(report.status, RunStatus::Running);
+                assert_eq!(report.status, RunStatus::Halted);
                 assert_eq!(report.instructions_executed, 42);
+                assert_eq!(report.return_count, 1);
+                assert_eq!(report.returns, vec![LanguageValue::U32(1234)]);
             }
             other => panic!("unexpected run response body: {other:?}"),
         }
@@ -1257,11 +1352,7 @@ mod tests {
 
         assert_eq!(
             &names[..count],
-            &[
-                "bytecode_callable",
-                "protocol_feature",
-                "board_metadata"
-            ]
+            &["bytecode_callable", "protocol_feature", "board_metadata"]
         );
 
         let mut short = [""; 1];


### PR DESCRIPTION
## Summary

- Add a Rust host `time.now_ms` BVM module builder and language-core/C ABI wrapper.
- Encode one typed run-return value from the device for halting modules and decode it in language-core.
- Expose `time_now`/`board.time.now_ms` sugar in Ruby and `time_now` sugar in Python while keeping module bytes and protocol decoding Rust-owned.

## Validation

- `cargo test -p board-vm-host -p board-vm-device -p board-vm-language-core`
- `rake test`
- `sh BUILD` from `code/packages/python/board-vm-native`
- `git diff --check HEAD`
