### PR TITLE
[codex] Expand Board VM CLI REPL capabilities

### DIFF
--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -38,11 +38,13 @@ is intentionally small because the current firmware executes blink bytecode
 synchronously while it prepares the run report.
 
 `repl` opens the same serial transport, sends `HELLO`, and then accepts a small
-interactive command set: `caps`, `upload-blink`, `run [budget]`,
-`blink [budget]`, `stop`, `hello`, `help`, and `quit`. This is the first
-language-agnostic host shell: it drives the binary protocol through the shared
-client library, while future frontend packages can put richer syntax on top of
-the same transport calls.
+interactive command set: `caps`, `upload-blink`, `upload-gpio-read <pin>
+[mode]`, `upload-time-now`, `run [budget]`, `blink [budget]`, `gpio-read <pin>
+[mode] [budget]`, `time-now [budget]`, `stop`, `hello`, `help`, and `quit`.
+This is the first language-agnostic host shell: it drives the binary protocol
+through the shared client library, while future frontend packages can put
+richer syntax on top of the same transport calls. `gpio-read` and `time-now`
+print Rust-decoded run-report return values from the board.
 
 `eject blink` writes the current blink MVP as embeddable Rust constants with a
 program id, slot, boot policy, bytecode CRC, and BVM module bytes. That output

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -5,13 +5,16 @@ use std::time::Duration;
 
 use board_vm_client::{
     BoardDescriptorInfo, BoardVmClient, ClientError, HelloAckInfo, RawFrameTransport,
-    RunReportInfo, UploadReport,
+    RunReportInfo, RunValue, UploadReport,
 };
 use board_vm_eject::{
     build_blink_eject_artifact, write_embedded_rust_constants,
     EjectOptions as ArtifactEjectOptions, RustConstNames, DEFAULT_BOOT_POLICY, DEFAULT_EJECT_SLOT,
 };
-use board_vm_host::{write_blink_module, BlinkProgram, BLINK_MODULE_LEN};
+use board_vm_host::{
+    write_blink_module, write_gpio_read_module, write_time_now_module, BlinkProgram,
+    GpioReadProgram, TimeNowProgram, BLINK_MODULE_LEN, GPIO_READ_MODULE_LEN, TIME_NOW_MODULE_LEN,
+};
 use board_vm_protocol::{BOOT_RUN_AT_BOOT, BOOT_RUN_IF_NO_HOST, BOOT_STORE_ONLY};
 use board_vm_serial::{
     available_ports, BoardSerialTransport, SerialConfig, SerialPortInfo, SerialTransportError,
@@ -90,10 +93,44 @@ pub enum ReplCommand {
     Hello,
     Caps,
     UploadBlink,
-    Run { instruction_budget: Option<u32> },
-    Blink { instruction_budget: Option<u32> },
+    UploadGpioRead {
+        pin: u8,
+        mode: ReplGpioReadMode,
+    },
+    UploadTimeNow,
+    Run {
+        instruction_budget: Option<u32>,
+    },
+    Blink {
+        instruction_budget: Option<u32>,
+    },
+    GpioRead {
+        pin: u8,
+        mode: ReplGpioReadMode,
+        instruction_budget: Option<u32>,
+    },
+    TimeNow {
+        instruction_budget: Option<u32>,
+    },
     Stop,
     Quit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplGpioReadMode {
+    Input,
+    InputPullup,
+    InputPulldown,
+}
+
+impl ReplGpioReadMode {
+    fn program(self, pin: u8) -> GpioReadProgram {
+        match self {
+            Self::Input => GpioReadProgram::input(pin),
+            Self::InputPullup => GpioReadProgram::input_pullup(pin),
+            Self::InputPulldown => GpioReadProgram::input_pulldown(pin),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -317,11 +354,28 @@ pub fn parse_repl_line(line: &str) -> Result<ReplCommand, CliError> {
         "hello" => Ok(ReplCommand::Hello),
         "caps" | "capabilities" => Ok(ReplCommand::Caps),
         "upload-blink" => Ok(ReplCommand::UploadBlink),
+        "upload-gpio-read" | "upload-gpio.read" => {
+            let (pin, mode, _) = parse_repl_gpio_read_args(&mut words, "upload-gpio-read", false)?;
+            Ok(ReplCommand::UploadGpioRead { pin, mode })
+        }
+        "upload-time-now" | "upload-time.now" => Ok(ReplCommand::UploadTimeNow),
         "run" => Ok(ReplCommand::Run {
             instruction_budget: optional_repl_budget(words.next(), "run")?,
         }),
         "blink" => Ok(ReplCommand::Blink {
             instruction_budget: optional_repl_budget(words.next(), "blink")?,
+        }),
+        "gpio-read" | "gpio.read" => {
+            let (pin, mode, instruction_budget) =
+                parse_repl_gpio_read_args(&mut words, "gpio-read", true)?;
+            Ok(ReplCommand::GpioRead {
+                pin,
+                mode,
+                instruction_budget,
+            })
+        }
+        "time-now" | "time.now" | "now" => Ok(ReplCommand::TimeNow {
+            instruction_budget: optional_repl_budget(words.next(), "time-now")?,
         }),
         "stop" => Ok(ReplCommand::Stop),
         "quit" | "exit" => Ok(ReplCommand::Quit),
@@ -351,6 +405,52 @@ fn optional_repl_budget(
     value
         .map(|value| parse_number(value.to_owned(), command))
         .transpose()
+}
+
+fn parse_repl_gpio_read_args<'a, I>(
+    words: &mut I,
+    command: &'static str,
+    allow_budget: bool,
+) -> Result<(u8, ReplGpioReadMode, Option<u32>), CliError>
+where
+    I: Iterator<Item = &'a str>,
+{
+    let pin = words
+        .next()
+        .ok_or(CliError::MissingRequired("gpio-read pin"))
+        .and_then(|value| parse_number(value.to_owned(), command))?;
+    let mut mode = ReplGpioReadMode::Input;
+    let mut instruction_budget = None;
+
+    if let Some(value) = words.next() {
+        if allow_budget && integer_literal(value) {
+            instruction_budget = Some(parse_number(value.to_owned(), command)?);
+        } else {
+            mode = parse_repl_gpio_read_mode(value)?;
+        }
+    }
+
+    if allow_budget && instruction_budget.is_none() {
+        instruction_budget = optional_repl_budget(words.next(), command)?;
+    }
+
+    Ok((pin, mode, instruction_budget))
+}
+
+fn parse_repl_gpio_read_mode(value: &str) -> Result<ReplGpioReadMode, CliError> {
+    match value {
+        "input" | "in" => Ok(ReplGpioReadMode::Input),
+        "pullup" | "input-pullup" | "input_pullup" => Ok(ReplGpioReadMode::InputPullup),
+        "pulldown" | "input-pulldown" | "input_pulldown" => Ok(ReplGpioReadMode::InputPulldown),
+        other => Err(CliError::InvalidNumber {
+            option: "gpio-read mode",
+            value: other.to_owned(),
+        }),
+    }
+}
+
+fn integer_literal(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn next_value<I>(args: &mut I, option: &'static str) -> Result<String, CliError>
@@ -563,6 +663,14 @@ where
             let upload = upload_blink(client, state.program_id)?;
             write_upload(output, &upload)?;
         }
+        ReplCommand::UploadGpioRead { pin, mode } => {
+            let upload = upload_gpio_read(client, state.program_id, pin, mode)?;
+            write_upload(output, &upload)?;
+        }
+        ReplCommand::UploadTimeNow => {
+            let upload = upload_time_now(client, state.program_id)?;
+            write_upload(output, &upload)?;
+        }
         ReplCommand::Run { instruction_budget } => {
             let run = client.run_background(
                 state.program_id,
@@ -572,6 +680,28 @@ where
         }
         ReplCommand::Blink { instruction_budget } => {
             let upload = upload_blink(client, state.program_id)?;
+            write_upload(output, &upload)?;
+            let run = client.run_background(
+                state.program_id,
+                instruction_budget.unwrap_or(state.instruction_budget),
+            )?;
+            write_run(output, &run)?;
+        }
+        ReplCommand::GpioRead {
+            pin,
+            mode,
+            instruction_budget,
+        } => {
+            let upload = upload_gpio_read(client, state.program_id, pin, mode)?;
+            write_upload(output, &upload)?;
+            let run = client.run_background(
+                state.program_id,
+                instruction_budget.unwrap_or(state.instruction_budget),
+            )?;
+            write_run(output, &run)?;
+        }
+        ReplCommand::TimeNow { instruction_budget } => {
+            let upload = upload_time_now(client, state.program_id)?;
             write_upload(output, &upload)?;
             let run = client.run_background(
                 state.program_id,
@@ -597,6 +727,38 @@ where
 {
     let mut module = [0u8; BLINK_MODULE_LEN];
     let module_len = write_blink_module(BlinkProgram::onboard_led(), &mut module)
+        .map_err(|source| CliError::Client(source.into()))?;
+    client
+        .upload_program(program_id, &module[..module_len])
+        .map_err(CliError::from)
+}
+
+fn upload_gpio_read<T>(
+    client: &mut BoardVmClient<T, 512, 768, 768>,
+    program_id: u16,
+    pin: u8,
+    mode: ReplGpioReadMode,
+) -> Result<UploadReport, CliError>
+where
+    T: RawFrameTransport,
+{
+    let mut module = [0u8; GPIO_READ_MODULE_LEN];
+    let module_len = write_gpio_read_module(mode.program(pin), &mut module)
+        .map_err(|source| CliError::Client(source.into()))?;
+    client
+        .upload_program(program_id, &module[..module_len])
+        .map_err(CliError::from)
+}
+
+fn upload_time_now<T>(
+    client: &mut BoardVmClient<T, 512, 768, 768>,
+    program_id: u16,
+) -> Result<UploadReport, CliError>
+where
+    T: RawFrameTransport,
+{
+    let mut module = [0u8; TIME_NOW_MODULE_LEN];
+    let module_len = write_time_now_module(TimeNowProgram::new(), &mut module)
         .map_err(|source| CliError::Client(source.into()))?;
     client
         .upload_program(program_id, &module[..module_len])
@@ -660,17 +822,56 @@ fn write_run<W>(output: &mut W, run: &RunReportInfo) -> Result<(), CliError>
 where
     W: Write,
 {
-    writeln!(
-        output,
-        "run program_id={} status={:?} instructions={} elapsed_ms={} stack_depth={} open_handles={}",
-        run.program_id,
-        run.status,
-        run.instructions_executed,
-        run.elapsed_ms,
-        run.stack_depth,
-        run.open_handles
-    )?;
+    if run.returns.is_empty() {
+        writeln!(
+            output,
+            "run program_id={} status={:?} instructions={} elapsed_ms={} stack_depth={} open_handles={}",
+            run.program_id,
+            run.status,
+            run.instructions_executed,
+            run.elapsed_ms,
+            run.stack_depth,
+            run.open_handles
+        )?;
+    } else {
+        writeln!(
+            output,
+            "run program_id={} status={:?} instructions={} elapsed_ms={} stack_depth={} open_handles={} returns=[{}]",
+            run.program_id,
+            run.status,
+            run.instructions_executed,
+            run.elapsed_ms,
+            run.stack_depth,
+            run.open_handles,
+            format_run_values(&run.returns)
+        )?;
+    }
     Ok(())
+}
+
+fn format_run_values(values: &[RunValue]) -> String {
+    let mut out = String::new();
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(&format_run_value(value));
+    }
+    out
+}
+
+fn format_run_value(value: &RunValue) -> String {
+    match value {
+        RunValue::Unit => "unit".to_owned(),
+        RunValue::Bool(value) => value.to_string(),
+        RunValue::U8(value) => value.to_string(),
+        RunValue::U16(value) => value.to_string(),
+        RunValue::U32(value) => value.to_string(),
+        RunValue::I16(value) => value.to_string(),
+        RunValue::Handle(value) => format!("handle:{value}"),
+        RunValue::Bytes(value) => format!("bytes:{}b", value.len()),
+        RunValue::String(value) => format!("string:{value}"),
+    }
 }
 
 fn write_repl_help<W>(output: &mut W) -> Result<(), CliError>
@@ -679,7 +880,7 @@ where
 {
     writeln!(
         output,
-        "commands: hello, caps, upload-blink, run [budget], blink [budget], stop, help, quit"
+        "commands: hello, caps, upload-blink, upload-gpio-read <pin> [mode], upload-time-now, run [budget], blink [budget], gpio-read <pin> [mode] [budget], time-now [budget], stop, help, quit"
     )?;
     Ok(())
 }
@@ -941,6 +1142,17 @@ mod tests {
             ReplCommand::UploadBlink
         );
         assert_eq!(
+            parse_repl_line("upload-gpio-read 13 pullup").unwrap(),
+            ReplCommand::UploadGpioRead {
+                pin: 13,
+                mode: ReplGpioReadMode::InputPullup,
+            }
+        );
+        assert_eq!(
+            parse_repl_line("upload-time-now").unwrap(),
+            ReplCommand::UploadTimeNow
+        );
+        assert_eq!(
             parse_repl_line("run").unwrap(),
             ReplCommand::Run {
                 instruction_budget: None
@@ -955,6 +1167,28 @@ mod tests {
         assert_eq!(
             parse_repl_line("blink 24").unwrap(),
             ReplCommand::Blink {
+                instruction_budget: Some(24)
+            }
+        );
+        assert_eq!(
+            parse_repl_line("gpio-read 13 pullup 24").unwrap(),
+            ReplCommand::GpioRead {
+                pin: 13,
+                mode: ReplGpioReadMode::InputPullup,
+                instruction_budget: Some(24),
+            }
+        );
+        assert_eq!(
+            parse_repl_line("gpio-read 13 24").unwrap(),
+            ReplCommand::GpioRead {
+                pin: 13,
+                mode: ReplGpioReadMode::Input,
+                instruction_budget: Some(24),
+            }
+        );
+        assert_eq!(
+            parse_repl_line("time-now 24").unwrap(),
+            ReplCommand::TimeNow {
                 instruction_budget: Some(24)
             }
         );

--- a/code/packages/rust/board-vm-client/src/lib.rs
+++ b/code/packages/rust/board-vm-client/src/lib.rs
@@ -3,7 +3,7 @@ use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
     decode_program_begin, decode_program_chunk, decode_program_end, decode_run_report_header,
     ErrorPayload, HelloAck, MessageType, ProgramBegin, ProgramChunk, ProgramEnd, ProtocolError,
-    RunReportHeader, RunStatus, FLAG_IS_ERROR_RESPONSE,
+    RunReportHeader, RunStatus, Value, FLAG_IS_ERROR_RESPONSE,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -165,7 +165,36 @@ impl From<ProgramEnd> for ProgramEndReport {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunValue {
+    Unit,
+    Bool(bool),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    I16(i16),
+    Handle(u16),
+    Bytes(Vec<u8>),
+    String(String),
+}
+
+impl From<Value<'_>> for RunValue {
+    fn from(value: Value<'_>) -> Self {
+        match value {
+            Value::Unit => Self::Unit,
+            Value::Bool(value) => Self::Bool(value),
+            Value::U8(value) => Self::U8(value),
+            Value::U16(value) => Self::U16(value),
+            Value::U32(value) => Self::U32(value),
+            Value::I16(value) => Self::I16(value),
+            Value::Handle(value) => Self::Handle(value),
+            Value::Bytes(value) => Self::Bytes(value.to_vec()),
+            Value::String(value) => Self::String(value.to_owned()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunReportInfo {
     pub program_id: u16,
     pub status: RunStatus,
@@ -173,6 +202,7 @@ pub struct RunReportInfo {
     pub elapsed_ms: u32,
     pub stack_depth: u8,
     pub open_handles: u8,
+    pub returns: Vec<RunValue>,
 }
 
 impl From<RunReportHeader> for RunReportInfo {
@@ -184,6 +214,7 @@ impl From<RunReportHeader> for RunReportInfo {
             elapsed_ms: value.elapsed_ms,
             stack_depth: value.stack_depth,
             open_handles: value.open_handles,
+            returns: Vec::new(),
         }
     }
 }
@@ -360,9 +391,21 @@ where
         request_len: usize,
     ) -> Result<RunReportInfo, ClientError> {
         let payload = self.exchange_checked(request_id, request_len, MessageType::RUN_REPORT)?;
-        let (report, decoder) = decode_run_report_header(payload)?;
+        let (report, mut decoder) = decode_run_report_header(payload)?;
+        let mut returns = Vec::with_capacity(report.return_count as usize);
+        for _ in 0..report.return_count {
+            returns.push(decoder.read_value()?.into());
+        }
         decoder.finish()?;
-        Ok(report.into())
+        Ok(RunReportInfo {
+            program_id: report.program_id,
+            status: report.status,
+            instructions_executed: report.instructions_executed,
+            elapsed_ms: report.elapsed_ms,
+            stack_depth: report.stack_depth,
+            open_handles: report.open_handles,
+            returns,
+        })
     }
 
     fn exchange_checked(
@@ -475,6 +518,7 @@ mod tests {
         assert_eq!(run.status, RunStatus::Running);
         assert!(run.instructions_executed > 0);
         assert_eq!(run.open_handles, 1);
+        assert!(run.returns.is_empty());
 
         let board = &client.transport().board;
         assert_eq!(
@@ -501,6 +545,61 @@ mod tests {
         let stop = client.stop().unwrap();
         assert_eq!(stop.status, RunStatus::Stopped);
         assert_eq!(stop.open_handles, 0);
+    }
+
+    #[test]
+    fn decodes_run_report_return_values() {
+        use board_vm_protocol::{
+            decode_frame, encode_frame, encode_run_report_header, encode_value, Frame,
+            RunReportHeader, Value, FLAG_IS_RESPONSE,
+        };
+
+        struct ReturnValueTransport {
+            payload: [u8; 64],
+        }
+
+        impl RawFrameTransport for ReturnValueTransport {
+            fn exchange_raw_frame(
+                &mut self,
+                request: &[u8],
+                response_out: &mut [u8],
+            ) -> Result<usize, TransportError> {
+                let request = decode_frame(request).map_err(|_| TransportError::Io)?;
+                let mut payload_len = encode_run_report_header(
+                    &RunReportHeader {
+                        program_id: 2,
+                        status: RunStatus::Halted,
+                        instructions_executed: 3,
+                        elapsed_ms: 4,
+                        stack_depth: 1,
+                        open_handles: 0,
+                        return_count: 2,
+                    },
+                    &mut self.payload,
+                )
+                .map_err(|_| TransportError::Io)?;
+                payload_len += encode_value(&Value::Bool(false), &mut self.payload[payload_len..])
+                    .map_err(|_| TransportError::Io)?;
+                payload_len += encode_value(&Value::U32(42), &mut self.payload[payload_len..])
+                    .map_err(|_| TransportError::Io)?;
+                encode_frame(
+                    &Frame {
+                        flags: FLAG_IS_RESPONSE,
+                        message_type: MessageType::RUN_REPORT,
+                        request_id: request.request_id,
+                        payload: &self.payload[..payload_len],
+                    },
+                    response_out,
+                )
+                .map_err(|_| TransportError::Io)
+            }
+        }
+
+        let transport = ReturnValueTransport { payload: [0; 64] };
+        let mut client: BoardVmClient<_, 256, 512, 512> = BoardVmClient::new(transport);
+
+        let run = client.run_background(2, 32).unwrap();
+        assert_eq!(run.returns, vec![RunValue::Bool(false), RunValue::U32(42)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Expands the Rust Board VM CLI REPL beyond blink so it can exercise more already-supported board capabilities through Rust-owned module builders and the shared binary protocol client.

## Details

- Adds owned run-report return-value decoding to `board-vm-client`.
- Adds CLI REPL commands for `upload-gpio-read <pin> [mode]`, `gpio-read <pin> [mode] [budget]`, `upload-time-now`, and `time-now [budget]`.
- Keeps module construction in `board-vm-host` via `write_gpio_read_module` and `write_time_now_module`.
- Prints decoded return values from run reports in the REPL output.
- Updates CLI docs and parser/client tests.

## Validation

- `cargo fmt --manifest-path code/packages/rust/board-vm-client/Cargo.toml`
- `cargo fmt --manifest-path code/packages/rust/board-vm-cli/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p board-vm-client -p board-vm-cli`
- `git diff --check origin/main...HEAD`
