### PR TITLE
[codex] Add Hue device resource decoding

### DIFF
--- a/code/packages/rust/hue-client/CHANGELOG.md
+++ b/code/packages/rust/hue-client/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this package will be documented in this file.
   runtime adapters.
 - Hue v2 envelope/error parsing, registration response parsing, and light
   resource decoding.
+- Hue device resource decoding with product metadata and CLIP v2 service refs.
 - Hue event-stream Server-Sent Events parsing into batches and raw resource
   records.
 - Hue light state update extraction from resource snapshots and event-stream

--- a/code/packages/rust/hue-client/README.md
+++ b/code/packages/rust/hue-client/README.md
@@ -16,6 +16,7 @@ Included surfaces:
 - event-stream request shape
 - event-stream batch parsing from Server-Sent Events data frames
 - Hue v2 envelope/error parsing
+- Hue device resource decoding with product metadata and service references
 - Hue light resource decoding
 - Hue light state update extraction from snapshots and event-stream batches
 

--- a/code/packages/rust/hue-client/src/lib.rs
+++ b/code/packages/rust/hue-client/src/lib.rs
@@ -10,9 +10,9 @@ use coding_adventures_json_serializer::serialize;
 use coding_adventures_json_value::{parse as parse_json, JsonNumber, JsonValue};
 use http_core::{find_header, Header};
 use hue_core::{
-    validate_brightness, HueCommand, HueLightResource, HueLightStateUpdate, HueMethod, HueRequest,
-    HueRequestBody, HueResourceId, HueResourceRef, HueResourceType, CLIP_V2_EVENT_STREAM_PATH,
-    CLIP_V2_RESOURCE_ROOT, HUE_APPLICATION_KEY_HEADER,
+    validate_brightness, HueCommand, HueDeviceResource, HueLightResource, HueLightStateUpdate,
+    HueMethod, HueRequest, HueRequestBody, HueResourceId, HueResourceRef, HueResourceType,
+    CLIP_V2_EVENT_STREAM_PATH, CLIP_V2_RESOURCE_ROOT, HUE_APPLICATION_KEY_HEADER,
 };
 use std::fmt;
 
@@ -237,6 +237,11 @@ impl<T: HueTransport> HueClient<T> {
     pub fn get_light_resources(&mut self) -> Result<Vec<HueLightResource>, HueClientError> {
         let envelope = self.get_collection(HueResourceType::Light)?;
         parse_lights_from_envelope(&envelope)
+    }
+
+    pub fn get_device_resources(&mut self) -> Result<Vec<HueDeviceResource>, HueClientError> {
+        let envelope = self.get_collection(HueResourceType::Device)?;
+        parse_devices_from_envelope(&envelope)
     }
 
     pub fn get_light_state_updates(&mut self) -> Result<Vec<HueLightStateUpdate>, HueClientError> {
@@ -534,6 +539,18 @@ pub fn parse_lights_from_envelope(
     Ok(lights)
 }
 
+pub fn parse_devices_from_envelope(
+    envelope: &HueEnvelope,
+) -> Result<Vec<HueDeviceResource>, HueClientError> {
+    let mut devices = Vec::new();
+    for resource in &envelope.data {
+        if object_string_field(resource, "type") == Some(HueResourceType::Device.as_hue_type()) {
+            devices.push(parse_device_resource(resource)?);
+        }
+    }
+    Ok(devices)
+}
+
 pub fn parse_light_state_updates_from_envelope(
     envelope: &HueEnvelope,
 ) -> Result<Vec<HueLightStateUpdate>, HueClientError> {
@@ -732,6 +749,58 @@ fn parse_light_state_update(resource: &JsonValue) -> Result<HueLightStateUpdate,
         brightness,
         color_temperature_mirek,
     })
+}
+
+fn parse_device_resource(resource: &JsonValue) -> Result<HueDeviceResource, HueClientError> {
+    let id = object_string_field(resource, "id")
+        .ok_or_else(|| HueClientError::unexpected_json("Hue device resource is missing id"))?;
+    let name = object_field(resource, "metadata")
+        .and_then(|metadata| object_string_field(metadata, "name"))
+        .unwrap_or(id)
+        .to_string();
+    let product_data = object_field(resource, "product_data");
+    let services = match object_field(resource, "services") {
+        Some(JsonValue::Array(values)) => parse_resource_refs(values)?,
+        Some(_) => {
+            return Err(HueClientError::unexpected_json(
+                "Hue device services field must be an array",
+            ))
+        }
+        None => Vec::new(),
+    };
+
+    Ok(HueDeviceResource {
+        id: HueResourceId::trusted(id),
+        name,
+        manufacturer: product_data
+            .and_then(|data| object_string_field(data, "manufacturer_name"))
+            .map(str::to_string),
+        model: product_data
+            .and_then(|data| object_string_field(data, "model_id"))
+            .map(str::to_string),
+        product_name: product_data
+            .and_then(|data| object_string_field(data, "product_name"))
+            .map(str::to_string),
+        software_version: product_data
+            .and_then(|data| object_string_field(data, "software_version"))
+            .map(str::to_string),
+        services,
+    })
+}
+
+fn parse_resource_refs(values: &[JsonValue]) -> Result<Vec<HueResourceRef>, HueClientError> {
+    values.iter().map(parse_resource_ref).collect()
+}
+
+fn parse_resource_ref(value: &JsonValue) -> Result<HueResourceRef, HueClientError> {
+    let rid = object_string_field(value, "rid")
+        .ok_or_else(|| HueClientError::unexpected_json("Hue resource ref is missing rid"))?;
+    let rtype = object_string_field(value, "rtype")
+        .ok_or_else(|| HueClientError::unexpected_json("Hue resource ref is missing rtype"))?;
+    Ok(HueResourceRef::new(
+        HueResourceType::from_hue_type(rtype),
+        HueResourceId::trusted(rid),
+    ))
 }
 
 fn parse_api_errors(values: &[JsonValue]) -> Result<Vec<HueApiError>, HueClientError> {
@@ -996,6 +1065,23 @@ mod tests {
     }
 
     #[test]
+    fn client_reads_device_collection_through_injected_transport() {
+        let transport = RecordingTransport::with_response(
+            r#"{"data":[{"id":"device-1","type":"device","metadata":{"name":"Kitchen lamp"}}],"errors":[]}"#,
+        );
+        let mut client = HueClient::new(HueClientConfig::paired("app-key"), transport);
+
+        let devices = client.get_device_resources().unwrap();
+        let transport = client.into_transport();
+
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].id.as_str(), "device-1");
+        assert_eq!(devices[0].name, "Kitchen lamp");
+        assert_eq!(transport.requests.len(), 1);
+        assert_eq!(transport.requests[0].path, "/clip/v2/resource/device");
+    }
+
+    #[test]
     fn parses_registration_success() {
         let registration = parse_registration_response(
             br#"[{"success":{"username":"app-key","clientkey":"client-key"}}]"#,
@@ -1034,6 +1120,47 @@ mod tests {
         assert_eq!(lights[0].on, Some(true));
         assert_eq!(lights[0].brightness, Some(42));
         assert_eq!(lights[0].color_temperature_mirek, Some(366));
+    }
+
+    #[test]
+    fn parses_device_resources_from_snapshot_envelope() {
+        let envelope = parse_hue_envelope(
+            br#"{"data":[{"id":"device-1","type":"device","metadata":{"name":"Kitchen lamp"},"product_data":{"manufacturer_name":"Signify Netherlands B.V.","model_id":"LCA001","product_name":"Hue color lamp","software_version":"1.116.3"},"services":[{"rid":"light-1","rtype":"light"},{"rid":"button-1","rtype":"button"}]},{"id":"light-1","type":"light"}],"errors":[]}"#,
+        )
+        .unwrap();
+
+        let devices = parse_devices_from_envelope(&envelope).unwrap();
+
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].id.as_str(), "device-1");
+        assert_eq!(devices[0].name, "Kitchen lamp");
+        assert_eq!(
+            devices[0].manufacturer.as_deref(),
+            Some("Signify Netherlands B.V.")
+        );
+        assert_eq!(devices[0].model.as_deref(), Some("LCA001"));
+        assert_eq!(devices[0].product_name.as_deref(), Some("Hue color lamp"));
+        assert_eq!(devices[0].software_version.as_deref(), Some("1.116.3"));
+        assert_eq!(devices[0].services.len(), 2);
+        assert_eq!(devices[0].services[0].resource_type, HueResourceType::Light);
+        assert_eq!(devices[0].services[0].id.as_str(), "light-1");
+        assert_eq!(
+            devices[0].services[1].resource_type,
+            HueResourceType::Button
+        );
+    }
+
+    #[test]
+    fn device_resource_parser_rejects_malformed_services() {
+        let envelope = parse_hue_envelope(
+            br#"{"data":[{"id":"device-1","type":"device","services":{"rid":"light-1","rtype":"light"}}],"errors":[]}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            parse_devices_from_envelope(&envelope),
+            Err(HueClientError::UnexpectedJson { .. })
+        ));
     }
 
     #[test]

--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this package will be documented in this file.
 - Hue CLIP v2 resource type/id/path primitives.
 - Structured Hue command intents for light, grouped-light, color-temperature,
   and scene requests.
+- Typed Hue device resources with product metadata and service references.
 - Mapping helpers from discovered Hue bridge/device/light records into
   `smart-home-core`.
 - Hue light state update helpers that project partial Hue light changes into

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -9,6 +9,7 @@ packages a typed surface for:
 - CLIP v2 resource paths
 - event stream path constants
 - structured Hue command intents
+- typed Hue device resources and service references
 - discovery-to-`Bridge` projection
 - Hue light/device-to-normalized-model projection
 - Hue light state update-to-`StateDelta` projection

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -338,6 +338,51 @@ impl HueLightResource {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HueDeviceResource {
+    pub id: HueResourceId,
+    pub name: String,
+    pub manufacturer: Option<String>,
+    pub model: Option<String>,
+    pub product_name: Option<String>,
+    pub software_version: Option<String>,
+    pub services: Vec<HueResourceRef>,
+}
+
+impl HueDeviceResource {
+    pub fn to_core(&self, bridge_id: &BridgeId) -> Device {
+        let manufacturer = self
+            .manufacturer
+            .clone()
+            .unwrap_or_else(|| "Philips Hue".to_string());
+        let model = self
+            .model
+            .clone()
+            .or_else(|| self.product_name.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        let mut device = hue_device_to_core(
+            bridge_id,
+            self.id.clone(),
+            manufacturer,
+            model,
+            self.name.clone(),
+        );
+        device.firmware_version = self.software_version.clone();
+        if let Some(product_name) = &self.product_name {
+            device
+                .metadata
+                .push(Metadata::new("hue.product_name", product_name));
+        }
+        for service in &self.services {
+            device.metadata.push(Metadata::new(
+                "hue.service",
+                format!("{}:{}", service.resource_type.as_hue_type(), service.id),
+            ));
+        }
+        device
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct HueLightStateUpdate {
     pub id: HueResourceId,
@@ -541,6 +586,37 @@ mod tests {
             .any(|capability| capability.capability_id.as_str() == "light.color_temperature"));
         assert_eq!(entity.metadata[1].value, "light-1");
         assert_eq!(entity.state.unwrap().confidence, StateConfidence::Confirmed);
+    }
+
+    #[test]
+    fn hue_device_resource_maps_to_normalized_device() {
+        let bridge_id = BridgeId::trusted("hue.bridge.001788");
+        let device = HueDeviceResource {
+            id: HueResourceId::trusted("device-1"),
+            name: "Kitchen lamp".to_string(),
+            manufacturer: Some("Signify Netherlands B.V.".to_string()),
+            model: Some("LCA001".to_string()),
+            product_name: Some("Hue color lamp".to_string()),
+            software_version: Some("1.116.3".to_string()),
+            services: vec![HueResourceRef::new(
+                HueResourceType::Light,
+                HueResourceId::trusted("light-1"),
+            )],
+        }
+        .to_core(&bridge_id);
+
+        assert_eq!(device.bridge_id, bridge_id);
+        assert_eq!(
+            device.device_id.as_str(),
+            "hue.device.hue.bridge.001788.device-1"
+        );
+        assert_eq!(device.model, "LCA001");
+        assert_eq!(device.firmware_version.as_deref(), Some("1.116.3"));
+        assert_eq!(device.identifiers[0].kind, "device");
+        assert!(device
+            .metadata
+            .iter()
+            .any(|metadata| metadata.value == "light:light-1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add typed Hue device resources with product metadata and service refs in hue-core
- add hue-client device collection decoding plus a client helper
- document the new Hue device surface in package READMEs/changelogs

## Tests

- cargo test --manifest-path code/packages/rust/Cargo.toml -p hue-core -p hue-client
