### PR TITLE
[codex] Add Board VM time.sleep_ms sugar

### DIFF
--- a/code/packages/python/board-vm-native/README.md
+++ b/code/packages/python/board-vm-native/README.md
@@ -14,6 +14,7 @@ frames = session.blink(program_id=1, instruction_budget=12).frames
 read_frames = session.gpio_read(pin=13, mode="pullup").frames
 write_frames = session.gpio_write(pin=13, value=True).frames
 now_frames = session.time_now(program_id=2, instruction_budget=12).frames
+sleep_frames = session.time_sleep_ms(250, program_id=3, instruction_budget=12).frames
 ```
 
 Each frame is a Rust-produced Board VM wire frame ready for a transport to
@@ -23,6 +24,9 @@ write to a board. A `Session` can also dispatch through any object that exposes
 `time_now()` uploads a Rust-built `time.now_ms` module and returns the board's
 millisecond clock through Rust-decoded run-report values when the transport
 returns a response.
+
+`time_sleep_ms()` uploads a Rust-built `time.sleep_ms` module and runs it; the
+duration argument is Python sugar over a Rust-owned bytecode module builder.
 
 GPIO reads follow the same path: Python resolves friendly mode names, while
 the GPIO-read module bytes, request IDs, frames, and response decoding stay in
@@ -41,6 +45,7 @@ The REPL-style sugar is intentionally thin as well:
 ```python
 session.run_command("gpio-read 13 pullup 24")
 session.run_command("gpio-write 13 high 24")
+session.run_command("time-sleep-ms 250 24")
 session.run_command("stop")
 ```
 

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -198,6 +198,9 @@ class Session:
     def time_now_module(self, max_stack: int = 1) -> bytes:
         return _native.time_now_module(max_stack)
 
+    def time_sleep_ms_module(self, duration_ms: int, max_stack: int = 1) -> bytes:
+        return _native.time_sleep_ms_module(duration_ms, max_stack)
+
     def upload(self, *, program_id: int = DEFAULT_PROGRAM_ID, module_bytes: bytes) -> SessionResult:
         return SessionResult([
             self._dispatch("program_begin", self._call_native(_native.program_begin_wire, program_id, module_bytes)),
@@ -254,6 +257,18 @@ class Session:
         return self.upload(
             program_id=program_id,
             module_bytes=self.time_now_module(max_stack=max_stack),
+        )
+
+    def upload_time_sleep_ms(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        duration_ms: int,
+        max_stack: int = 1,
+    ) -> SessionResult:
+        return self.upload(
+            program_id=program_id,
+            module_bytes=self.time_sleep_ms_module(duration_ms, max_stack=max_stack),
         )
 
     def run(self, *, program_id: int = DEFAULT_PROGRAM_ID, instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET) -> ProtocolResult:
@@ -371,6 +386,33 @@ class Session:
         results.append(self.run(program_id=program_id, instruction_budget=instruction_budget))
         return SessionResult(results)
 
+    def time_sleep_ms(
+        self,
+        duration_ms: int,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET,
+        handshake: bool = False,
+        query_caps: bool = False,
+        max_stack: int = 1,
+    ) -> SessionResult:
+        results: list[ProtocolResult] = []
+        if handshake:
+            results.append(self.hello())
+        if query_caps:
+            results.append(self.capabilities())
+        results.extend(
+            self.upload_time_sleep_ms(
+                program_id=program_id,
+                duration_ms=duration_ms,
+                max_stack=max_stack,
+            ).results
+        )
+        results.append(self.run(program_id=program_id, instruction_budget=instruction_budget))
+        return SessionResult(results)
+
+    sleep_ms = time_sleep_ms
+
     def run_command(self, line: str, **options: Any) -> SessionResult:
         words = line.split()
         if not words:
@@ -396,6 +438,10 @@ class Session:
         if command in {"upload-time-now", "upload-time.now"}:
             self._ensure_no_extra(words, command)
             return self.upload_time_now(**options)
+        if command in {"upload-time-sleep-ms", "upload-time.sleep_ms", "upload-sleep-ms"}:
+            return self.upload_time_sleep_ms(
+                **self._with_time_sleep_ms_options(words, command, options, allow_budget=False)
+            )
         if command == "run":
             return SessionResult([self.run(**self._with_optional_budget(words, command, options))])
         if command == "stop":
@@ -413,6 +459,10 @@ class Session:
             return self.gpio_write(**self._with_gpio_level_options(words, command, options, value=False))
         if command in {"time-now", "time.now", "now"}:
             return self.time_now(**self._with_optional_budget(words, command, options))
+        if command in {"time-sleep-ms", "time.sleep_ms", "sleep-ms"}:
+            return self.time_sleep_ms(
+                **self._with_time_sleep_ms_options(words, command, options)
+            )
         raise ValueError(f"unknown Board VM session command: {command}")
 
     def decode_response(self, response: bytes) -> dict[str, Any]:
@@ -472,6 +522,24 @@ class Session:
         self._ensure_no_extra(words, command)
         if "pin" not in merged:
             raise ValueError(f"{command} requires pin")
+        return merged
+
+    def _with_time_sleep_ms_options(
+        self,
+        words: list[str],
+        command: str,
+        options: dict[str, Any],
+        *,
+        allow_budget: bool = True,
+    ) -> dict[str, Any]:
+        merged = dict(options)
+        if words:
+            merged["duration_ms"] = int(words.pop(0))
+        if allow_budget and words:
+            merged["instruction_budget"] = int(words.pop(0))
+        self._ensure_no_extra(words, command)
+        if "duration_ms" not in merged:
+            raise ValueError(f"{command} requires duration_ms")
         return merged
 
     @staticmethod

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -2,17 +2,19 @@ use std::ffi::{c_char, c_long};
 use std::ptr;
 
 use board_vm_host::{
-    BlinkProgram, GpioReadProgram, GpioWriteProgram, TimeNowProgram, BLINK_MODULE_LEN,
-    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    BlinkProgram, GpioReadProgram, GpioWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    BLINK_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
     build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
     build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_background_wire_frame,
-    build_stop_wire_frame, build_time_now_module, capability_board_metadata,
-    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, program_format_name, run_status_name, BoardVmLanguageSession,
-    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError, LanguageValue,
+    build_stop_wire_frame, build_time_now_module, build_time_sleep_ms_module,
+    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
+    capability_protocol_feature, decode_wire_response, program_format_name, run_status_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageCoreError, LanguageValue,
 };
 use python_bridge::*;
 
@@ -135,6 +137,26 @@ unsafe extern "C" fn py_time_now_module(_module: PyObjectPtr, args: PyObjectPtr)
     let module = match build_time_now_module_value(max_stack) {
         Ok(module) => module,
         Err(error) => return raise_core_error("time_now_module", error),
+    };
+    bytes_to_py(&module)
+}
+
+unsafe extern "C" fn py_time_sleep_ms_module(
+    _module: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    let duration_ms = match parse_arg_u16(args, 0, "duration_ms") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let max_stack = match parse_arg_u8(args, 1, "max_stack") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    let module = match build_time_sleep_ms_module_value(duration_ms, max_stack) {
+        Ok(module) => module,
+        Err(error) => return raise_core_error("time_sleep_ms_module", error),
     };
     bytes_to_py(&module)
 }
@@ -508,6 +530,22 @@ fn build_time_now_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreErr
     Ok(module)
 }
 
+fn build_time_sleep_ms_module_value(
+    duration_ms: u16,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; TIME_SLEEP_MS_MODULE_LEN];
+    let len = build_time_sleep_ms_module(
+        TimeSleepMsProgram {
+            duration_ms,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_gpio_read_module_value(
     pin: u8,
     mode: u8,
@@ -645,7 +683,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 13] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 14] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -681,6 +719,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_time_now_module),
             ml_flags: METH_VARARGS,
             ml_doc: b"Build a Board VM time.now_ms BVM module in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"time_sleep_ms_module\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_time_sleep_ms_module),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM time.sleep_ms BVM module in Rust.\0".as_ptr()
+                as *const c_char,
         },
         PyMethodDef {
             ml_name: b"program_begin_wire\0".as_ptr() as *const c_char,

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -38,6 +38,10 @@ def test_native_session_builds_protocol_bytes_in_rust():
     assert isinstance(time_module, bytes)
     assert len(time_module) > 0
 
+    sleep_module = session.time_sleep_ms_module(250, max_stack=1)
+    assert isinstance(sleep_module, bytes)
+    assert len(sleep_module) > 0
+
     stop = session.stop()
     assert isinstance(stop.frame, bytes)
     assert len(stop.frame) > 0
@@ -146,6 +150,27 @@ def test_run_command_accepts_repl_style_time_now():
         "run",
     ]
     assert result.frames == transport.frames
+
+
+def test_run_command_accepts_repl_style_time_sleep_ms():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.run_command("time-sleep-ms 250 42", program_id=9)
+    upload = session.run_command("upload-time-sleep-ms 125", program_id=10)
+
+    assert [item.command for item in result.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+        "run",
+    ]
+    assert [item.command for item in upload.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+    ]
+    assert result.frames + upload.frames == transport.frames
 
 
 def test_board_descriptor_wraps_rust_decoded_capability_payload():

--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -74,6 +74,14 @@ CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
 end
 ```
 
+`time.sleep_ms` is exposed as a one-shot Rust-built module too:
+
+```ruby
+CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
+  board.time.sleep_ms(250)
+end
+```
+
 GPIO reads follow the same path:
 
 ```ruby
@@ -107,16 +115,17 @@ CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
     vm.run_command("gpio-read 13 pullup 24")
     vm.run_command("gpio-write 13 high 24")
     vm.run_command("time-now 24")
+    vm.run_command("time-sleep-ms 250 24")
   end
 end
 ```
 
 `hello`, `capabilities`, `upload_blink`, `upload_gpio_read`, `upload_time_now`,
-`upload_gpio_write`, `run`, `stop`, `blink`, `gpio_read`, `gpio_write`,
-`time_now`, and `run_command` return dispatch results with the Rust-produced
-frame, optional raw response bytes, and optional Rust-decoded response hash. The
-text command parser is Ruby sugar only; every dispatched frame still comes from
-`CodingAdventures::BoardVM::Native::Session`.
+`upload_time_sleep_ms`, `upload_gpio_write`, `run`, `stop`, `blink`,
+`gpio_read`, `gpio_write`, `time_now`, `time_sleep_ms`, and `run_command` return
+dispatch results with the Rust-produced frame, optional raw response bytes, and
+optional Rust-decoded response hash. The text command parser is Ruby sugar only;
+every dispatched frame still comes from `CodingAdventures::BoardVM::Native::Session`.
 
 Capability reports can be lifted into Ruby objects after Rust decodes the board
 response:

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -3,17 +3,19 @@ use std::ptr;
 use std::slice;
 
 use board_vm_host::{
-    BlinkProgram, GpioReadProgram, GpioWriteProgram, TimeNowProgram, BLINK_MODULE_LEN,
-    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    BlinkProgram, GpioReadProgram, GpioWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    BLINK_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
     build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
     build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_background_wire_frame,
-    build_stop_wire_frame, build_time_now_module, capability_board_metadata,
-    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, program_format_name, run_status_name, BoardVmLanguageSession,
-    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError, LanguageValue,
+    build_stop_wire_frame, build_time_now_module, build_time_sleep_ms_module,
+    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
+    capability_protocol_feature, decode_wire_response, program_format_name, run_status_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageCoreError, LanguageValue,
 };
 use ruby_bridge::VALUE;
 
@@ -116,6 +118,19 @@ extern "C" fn session_time_now_module(_self_val: VALUE, max_stack_val: VALUE) ->
 
     let module = build_time_now_module_value(max_stack)
         .unwrap_or_else(|error| raise_core_error("time_now_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_time_sleep_ms_module(
+    _self_val: VALUE,
+    duration_ms_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let duration_ms = rb_u16(duration_ms_val, "duration_ms");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_time_sleep_ms_module_value(duration_ms, max_stack)
+        .unwrap_or_else(|error| raise_core_error("time_sleep_ms_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -530,6 +545,22 @@ fn build_time_now_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreErr
     Ok(module)
 }
 
+fn build_time_sleep_ms_module_value(
+    duration_ms: u16,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; TIME_SLEEP_MS_MODULE_LEN];
+    let len = build_time_sleep_ms_module(
+        TimeSleepMsProgram {
+            duration_ms,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_gpio_read_module_value(
     pin: u8,
     mode: u8,
@@ -661,6 +692,12 @@ pub extern "C" fn Init_board_vm_native() {
         "time_now_module",
         session_time_now_module as *const c_void,
         1,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "time_sleep_ms_module",
+        session_time_sleep_ms_module as *const c_void,
+        2,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -179,6 +179,26 @@ module CodingAdventures
         )
       end
 
+      def time_sleep_ms!(
+        duration_ms:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        max_stack: 1
+      )
+        ensure_uno_r4_wifi!
+
+        session.time_sleep_ms(
+          duration_ms: duration_ms,
+          program_id: program_id,
+          budget: budget,
+          max_stack: max_stack,
+          handshake: true,
+          query_caps: true,
+          host_nonce: host_nonce
+        )
+      end
+
       def eject_blink!(
         output:,
         program_id: DEFAULT_PROGRAM_ID,
@@ -335,6 +355,22 @@ module CodingAdventures
         max_stack: 1
       )
         @connection.time_now!(
+          program_id: program_id,
+          budget: budget,
+          host_nonce: host_nonce,
+          max_stack: max_stack
+        )
+      end
+
+      def sleep_ms(
+        duration_ms,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        max_stack: 1
+      )
+        @connection.time_sleep_ms!(
+          duration_ms: duration_ms,
           program_id: program_id,
           budget: budget,
           host_nonce: host_nonce,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -112,10 +112,21 @@ module CodingAdventures
         native_session.time_now_module(max_stack)
       end
 
+      def time_sleep_ms_module(duration_ms:, max_stack: 1)
+        native_session.time_sleep_ms_module(duration_ms, max_stack)
+      end
+
       def upload_time_now(program_id: @program_id, max_stack: 1)
         upload(
           program_id: program_id,
           module_bytes: time_now_module(max_stack: max_stack)
+        )
+      end
+
+      def upload_time_sleep_ms(program_id: @program_id, duration_ms:, max_stack: 1)
+        upload(
+          program_id: program_id,
+          module_bytes: time_sleep_ms_module(duration_ms: duration_ms, max_stack: max_stack)
         )
       end
 
@@ -255,6 +266,35 @@ module CodingAdventures
         SessionResult.new(results: results)
       end
 
+      def time_sleep_ms(
+        duration_ms:,
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        max_stack: 1,
+        handshake: false,
+        query_caps: false,
+        host_name: @host_name,
+        host_nonce: @host_nonce
+      )
+        results = []
+        results << hello(host_name: host_name, host_nonce: host_nonce) if handshake
+        results << capabilities if query_caps
+        results.concat(
+          upload_time_sleep_ms(
+            program_id: program_id,
+            duration_ms: duration_ms,
+            max_stack: max_stack
+          ).results
+        )
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget
+        )
+        SessionResult.new(results: results)
+      end
+      alias sleep_ms time_sleep_ms
+
       def run_command(line, **options)
         words = line.to_s.split
         command = words.shift
@@ -277,6 +317,8 @@ module CodingAdventures
         when "upload-time-now", "upload-time.now"
           ensure_no_extra_arguments!(words, command)
           upload_time_now(**options)
+        when "upload-time-sleep-ms", "upload-time.sleep_ms", "upload-sleep-ms"
+          upload_time_sleep_ms(**time_sleep_ms_command_options(words, command, options, require_budget: false))
         when "run"
           SessionResult.new(results: [run(**options.merge(optional_budget(words, command)))])
         when "stop"
@@ -294,6 +336,8 @@ module CodingAdventures
           gpio_write(**gpio_level_command_options(words, command, options, value: false))
         when "time-now", "time.now", "now"
           time_now(**options.merge(optional_budget(words, command)))
+        when "time-sleep-ms", "time.sleep_ms", "sleep-ms"
+          time_sleep_ms(**time_sleep_ms_command_options(words, command, options))
         else
           raise UnknownSessionCommandError, "unknown Board VM session command: #{command}"
         end
@@ -346,6 +390,20 @@ module CodingAdventures
 
         ensure_no_extra_arguments!(words, command)
         raise ArgumentError, "#{command} requires pin" unless merged.key?(:pin)
+
+        merged
+      end
+
+      def time_sleep_ms_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:duration_ms] = integer_argument(words.shift, "#{command} duration_ms") unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires duration_ms" unless merged.key?(:duration_ms)
 
         merged
       end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -108,6 +108,28 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_time_sleep_ms_dispatches_native_protocol_frames_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          result = board.time.sleep_ms(250, program_id: 10, budget: 24)
+        end
+
+        assert_empty runner.calls
+        assert_equal 6, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal transport.frames, result.frames
+        assert_equal [:hello, :capabilities, :program_begin, :program_chunk, :program_end, :run],
+          result.results.map(&:command)
+      end
+
       def test_gpio_read_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -167,6 +189,7 @@ module CodingAdventures
             caps = session.capabilities
             upload = session.upload_blink(program_id: 4)
             time_upload = session.upload_time_now(program_id: 5)
+            sleep_upload = session.upload_time_sleep_ms(program_id: 8, duration_ms: 250)
             gpio_upload = session.upload_gpio_read(program_id: 6, pin: 13, mode: :pullup)
             gpio_write_upload = session.upload_gpio_write(program_id: 7, pin: 13, value: true)
             run = session.run(program_id: 4, budget: 77)
@@ -178,6 +201,8 @@ module CodingAdventures
             assert_equal [:program_begin, :program_chunk, :program_end],
               time_upload.results.map(&:command)
             assert_equal [:program_begin, :program_chunk, :program_end],
+              sleep_upload.results.map(&:command)
+            assert_equal [:program_begin, :program_chunk, :program_end],
               gpio_upload.results.map(&:command)
             assert_equal [:program_begin, :program_chunk, :program_end],
               gpio_write_upload.results.map(&:command)
@@ -187,7 +212,7 @@ module CodingAdventures
         end
 
         assert_empty runner.calls
-        assert_equal 16, transport.frames.length
+        assert_equal 19, transport.frames.length
         assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
       end
 
@@ -281,6 +306,26 @@ module CodingAdventures
         end
       end
 
+      def test_session_run_command_accepts_repl_style_time_sleep_ms
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("time-sleep-ms 250 24", program_id: 9)
+          upload = board.session.run_command("upload-time-sleep-ms 125", program_id: 10)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            result.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end],
+            upload.results.map(&:command)
+          assert_equal result.frames + upload.frames, transport.frames
+        end
+      end
+
       def test_board_descriptor_wraps_rust_decoded_capability_report
         decoded = {
           "kind" => "caps_report",
@@ -349,6 +394,10 @@ module CodingAdventures
         time_module_bytes = session.time_now_module(1)
         assert_instance_of String, time_module_bytes
         assert_operator time_module_bytes.bytesize, :>, 0
+
+        sleep_module_bytes = session.time_sleep_ms_module(250, 1)
+        assert_instance_of String, sleep_module_bytes
+        assert_operator sleep_module_bytes.bytesize, :>, 0
 
         gpio_module_bytes = session.gpio_read_module(13, 2, 2)
         assert_instance_of String, gpio_module_bytes

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -22,6 +22,8 @@ pub const GPIO_READ_CODE_LEN: usize = 13;
 pub const GPIO_READ_MODULE_LEN: usize = 23;
 pub const TIME_NOW_CODE_LEN: usize = 3;
 pub const TIME_NOW_MODULE_LEN: usize = 13;
+pub const TIME_SLEEP_MS_CODE_LEN: usize = 5;
+pub const TIME_SLEEP_MS_MODULE_LEN: usize = 15;
 
 pub const GPIO_MODE_INPUT: u8 = 0;
 pub const GPIO_MODE_OUTPUT: u8 = 1;
@@ -158,6 +160,21 @@ impl TimeNowProgram {
 impl Default for TimeNowProgram {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeSleepMsProgram {
+    pub duration_ms: u16,
+    pub max_stack: u8,
+}
+
+impl TimeSleepMsProgram {
+    pub const fn new(duration_ms: u16) -> Self {
+        Self {
+            duration_ms,
+            max_stack: 1,
+        }
     }
 }
 
@@ -577,6 +594,39 @@ pub fn write_time_now_module(program: TimeNowProgram, out: &mut [u8]) -> Result<
     Ok(offset)
 }
 
+pub fn write_time_sleep_ms_code(
+    program: TimeSleepMsProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < TIME_SLEEP_MS_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_push_u16(out, &mut offset, program.duration_ms)?;
+    write_call_u8(out, &mut offset, CAP_TIME_SLEEP_MS)?;
+    Ok(offset)
+}
+
+pub fn write_time_sleep_ms_module(
+    program: TimeSleepMsProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < TIME_SLEEP_MS_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; TIME_SLEEP_MS_CODE_LEN];
+    let code_len = write_time_sleep_ms_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(0, program.max_stack, &code[..code_len]),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(&module, CapabilitySet::blink_mvp(), program.max_stack)?;
+    Ok(offset)
+}
+
 pub fn write_module(spec: ModuleSpec<'_>, out: &mut [u8]) -> Result<usize, HostError> {
     if spec.code.len() > u32::MAX as usize || spec.const_pool.len() > u32::MAX as usize {
         return Err(HostError::ProgramTooLarge);
@@ -703,6 +753,9 @@ mod tests {
     const TIME_NOW_MODULE_HEX: [u8; TIME_NOW_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x03, 0x40, 0x11, 0x50, 0x00,
     ];
+    const TIME_SLEEP_MS_MODULE_HEX: [u8; TIME_SLEEP_MS_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x05, 0x13, 0xFA, 0x00, 0x40, 0x10, 0x00,
+    ];
 
     #[test]
     fn builds_blink_module_from_bvm05_fixture() {
@@ -776,6 +829,20 @@ mod tests {
         let mut capabilities = [0u16; 1];
         let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
         assert_eq!(&capabilities[..count], &[CAP_TIME_NOW_MS]);
+    }
+
+    #[test]
+    fn builds_time_sleep_ms_module_without_return() {
+        let mut module = [0u8; TIME_SLEEP_MS_MODULE_LEN];
+        let len = write_time_sleep_ms_module(TimeSleepMsProgram::new(250), &mut module).unwrap();
+        assert_eq!(len, TIME_SLEEP_MS_MODULE_LEN);
+        assert_eq!(module, TIME_SLEEP_MS_MODULE_HEX);
+
+        let parsed = parse_module(&module).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp(), 1).unwrap();
+        let mut capabilities = [0u16; 1];
+        let count = collect_required_capabilities(&parsed, &mut capabilities).unwrap();
+        assert_eq!(&capabilities[..count], &[CAP_TIME_SLEEP_MS]);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -14,9 +14,10 @@ use std::str;
 
 use board_vm_host::{
     write_blink_module, write_gpio_read_module, write_gpio_write_module, write_time_now_module,
-    BlinkProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession, TimeNowProgram,
-    BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, GPIO_READ_MODULE_LEN,
-    GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    write_time_sleep_ms_module, BlinkProgram, GpioReadProgram, GpioWriteProgram, HostError,
+    HostSession, TimeNowProgram, TimeSleepMsProgram, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
+    DEFAULT_PROGRAM_ID, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
+    TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -431,6 +432,13 @@ pub fn build_time_now_module(
     out: &mut [u8],
 ) -> Result<usize, LanguageCoreError> {
     Ok(write_time_now_module(program, out)?)
+}
+
+pub fn build_time_sleep_ms_module(
+    program: TimeSleepMsProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_time_sleep_ms_module(program, out)?)
 }
 
 pub fn build_program_begin_wire_frame(
@@ -873,6 +881,29 @@ pub unsafe extern "C" fn board_vm_language_time_now_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_time_sleep_ms_module(
+    duration_ms: u16,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_time_sleep_ms_module(
+            TimeSleepMsProgram {
+                duration_ms,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_program_begin_wire(
     session: *mut BoardVmLanguageSession,
     program_id: u16,
@@ -1012,6 +1043,11 @@ pub extern "C" fn board_vm_language_gpio_write_module_len() -> u64 {
 #[no_mangle]
 pub extern "C" fn board_vm_language_time_now_module_len() -> u64 {
     TIME_NOW_MODULE_LEN as u64
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_time_sleep_ms_module_len() -> u64 {
+    TIME_SLEEP_MS_MODULE_LEN as u64
 }
 
 fn catch_status(
@@ -1192,6 +1228,18 @@ mod tests {
         };
         assert_eq!(time_now_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(time_now_status.len, TIME_NOW_MODULE_LEN as u64);
+
+        let mut time_sleep_module = [0u8; TIME_SLEEP_MS_MODULE_LEN];
+        let time_sleep_status = unsafe {
+            board_vm_language_time_sleep_ms_module(
+                250,
+                1,
+                time_sleep_module.as_mut_ptr(),
+                time_sleep_module.len() as u64,
+            )
+        };
+        assert_eq!(time_sleep_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(time_sleep_status.len, TIME_SLEEP_MS_MODULE_LEN as u64);
 
         let mut gpio_read_module = [0u8; GPIO_READ_MODULE_LEN];
         let gpio_read_status = unsafe {


### PR DESCRIPTION
## Summary

Adds standalone `time.sleep_ms` support as another thin language-sugar layer over Rust-owned Board VM protocol/module builders.

## Details

- Adds `TimeSleepMsProgram` plus `write_time_sleep_ms_code` / `write_time_sleep_ms_module` in `board-vm-host` with golden byte coverage.
- Exposes the module builder through `board-vm-language-core` and its C ABI.
- Adds Python native/high-level methods: `time_sleep_ms_module`, `upload_time_sleep_ms`, `time_sleep_ms`/`sleep_ms`, and REPL-style commands.
- Adds Ruby native/session/connection/time API equivalents, including `board.time.sleep_ms(250)` and `time-sleep-ms` command sugar.
- Updates README examples for Python and Ruby.

## Validation

- `cargo test --manifest-path code/packages/rust/Cargo.toml -p board-vm-host -p board-vm-language-core`
- `cargo build --release` in `code/packages/python/board-vm-native`
- `PYTHONPATH=src python3 -m pytest tests/ -v`
- `cargo build --release` in `code/packages/ruby/board_vm/ext/board_vm_native`
- `ruby -Ilib -Itest test/test_board_vm.rb`
- `git diff --check HEAD~1..HEAD`
