### PR TITLE
[codex] Add Hue bridge resource decoding

### DIFF
--- a/code/packages/rust/hue-client/CHANGELOG.md
+++ b/code/packages/rust/hue-client/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this package will be documented in this file.
   runtime adapters.
 - Hue v2 envelope/error parsing, registration response parsing, and light
   resource decoding.
+- Hue bridge resource decoding for paired bridge identity and time zone data.
 - Hue device resource decoding with product metadata and CLIP v2 service refs.
 - Hue event-stream Server-Sent Events parsing into batches and raw resource
   records.

--- a/code/packages/rust/hue-client/README.md
+++ b/code/packages/rust/hue-client/README.md
@@ -16,6 +16,7 @@ Included surfaces:
 - event-stream request shape
 - event-stream batch parsing from Server-Sent Events data frames
 - Hue v2 envelope/error parsing
+- Hue bridge resource decoding for paired bridge identity and time zone data
 - Hue device resource decoding with product metadata and service references
 - Hue light resource decoding
 - Hue light state update extraction from snapshots and event-stream batches

--- a/code/packages/rust/hue-client/src/lib.rs
+++ b/code/packages/rust/hue-client/src/lib.rs
@@ -10,9 +10,9 @@ use coding_adventures_json_serializer::serialize;
 use coding_adventures_json_value::{parse as parse_json, JsonNumber, JsonValue};
 use http_core::{find_header, Header};
 use hue_core::{
-    validate_brightness, HueCommand, HueDeviceResource, HueLightResource, HueLightStateUpdate,
-    HueMethod, HueRequest, HueRequestBody, HueResourceId, HueResourceRef, HueResourceType,
-    CLIP_V2_EVENT_STREAM_PATH, CLIP_V2_RESOURCE_ROOT, HUE_APPLICATION_KEY_HEADER,
+    validate_brightness, HueBridgeResource, HueCommand, HueDeviceResource, HueLightResource,
+    HueLightStateUpdate, HueMethod, HueRequest, HueRequestBody, HueResourceId, HueResourceRef,
+    HueResourceType, CLIP_V2_EVENT_STREAM_PATH, CLIP_V2_RESOURCE_ROOT, HUE_APPLICATION_KEY_HEADER,
 };
 use std::fmt;
 
@@ -237,6 +237,11 @@ impl<T: HueTransport> HueClient<T> {
     pub fn get_light_resources(&mut self) -> Result<Vec<HueLightResource>, HueClientError> {
         let envelope = self.get_collection(HueResourceType::Light)?;
         parse_lights_from_envelope(&envelope)
+    }
+
+    pub fn get_bridge_resources(&mut self) -> Result<Vec<HueBridgeResource>, HueClientError> {
+        let envelope = self.get_collection(HueResourceType::Bridge)?;
+        parse_bridges_from_envelope(&envelope)
     }
 
     pub fn get_device_resources(&mut self) -> Result<Vec<HueDeviceResource>, HueClientError> {
@@ -539,6 +544,18 @@ pub fn parse_lights_from_envelope(
     Ok(lights)
 }
 
+pub fn parse_bridges_from_envelope(
+    envelope: &HueEnvelope,
+) -> Result<Vec<HueBridgeResource>, HueClientError> {
+    let mut bridges = Vec::new();
+    for resource in &envelope.data {
+        if object_string_field(resource, "type") == Some(HueResourceType::Bridge.as_hue_type()) {
+            bridges.push(parse_bridge_resource(resource)?);
+        }
+    }
+    Ok(bridges)
+}
+
 pub fn parse_devices_from_envelope(
     envelope: &HueEnvelope,
 ) -> Result<Vec<HueDeviceResource>, HueClientError> {
@@ -748,6 +765,24 @@ fn parse_light_state_update(resource: &JsonValue) -> Result<HueLightStateUpdate,
         on,
         brightness,
         color_temperature_mirek,
+    })
+}
+
+fn parse_bridge_resource(resource: &JsonValue) -> Result<HueBridgeResource, HueClientError> {
+    let id = object_string_field(resource, "id")
+        .ok_or_else(|| HueClientError::unexpected_json("Hue bridge resource is missing id"))?;
+    let owner_device_id = object_field(resource, "owner")
+        .and_then(|owner| object_string_field(owner, "rid"))
+        .map(HueResourceId::trusted);
+    let time_zone = object_field(resource, "time_zone")
+        .and_then(|time_zone| object_string_field(time_zone, "time_zone"))
+        .map(str::to_string);
+
+    Ok(HueBridgeResource {
+        id: HueResourceId::trusted(id),
+        owner_device_id,
+        bridge_id: object_string_field(resource, "bridge_id").map(str::to_string),
+        time_zone,
     })
 }
 
@@ -1082,6 +1117,23 @@ mod tests {
     }
 
     #[test]
+    fn client_reads_bridge_collection_through_injected_transport() {
+        let transport = RecordingTransport::with_response(
+            r#"{"data":[{"id":"bridge-resource-1","type":"bridge","bridge_id":"001788fffeabcdef"}],"errors":[]}"#,
+        );
+        let mut client = HueClient::new(HueClientConfig::paired("app-key"), transport);
+
+        let bridges = client.get_bridge_resources().unwrap();
+        let transport = client.into_transport();
+
+        assert_eq!(bridges.len(), 1);
+        assert_eq!(bridges[0].id.as_str(), "bridge-resource-1");
+        assert_eq!(bridges[0].bridge_id.as_deref(), Some("001788fffeabcdef"));
+        assert_eq!(transport.requests.len(), 1);
+        assert_eq!(transport.requests[0].path, "/clip/v2/resource/bridge");
+    }
+
+    #[test]
     fn parses_registration_success() {
         let registration = parse_registration_response(
             br#"[{"success":{"username":"app-key","clientkey":"client-key"}}]"#,
@@ -1120,6 +1172,28 @@ mod tests {
         assert_eq!(lights[0].on, Some(true));
         assert_eq!(lights[0].brightness, Some(42));
         assert_eq!(lights[0].color_temperature_mirek, Some(366));
+    }
+
+    #[test]
+    fn parses_bridge_resources_from_snapshot_envelope() {
+        let envelope = parse_hue_envelope(
+            br#"{"data":[{"id":"bridge-resource-1","type":"bridge","bridge_id":"001788fffeabcdef","owner":{"rid":"device-bridge","rtype":"device"},"time_zone":{"time_zone":"America/Los_Angeles"}},{"id":"device-1","type":"device"}],"errors":[]}"#,
+        )
+        .unwrap();
+
+        let bridges = parse_bridges_from_envelope(&envelope).unwrap();
+
+        assert_eq!(bridges.len(), 1);
+        assert_eq!(bridges[0].id.as_str(), "bridge-resource-1");
+        assert_eq!(
+            bridges[0]
+                .owner_device_id
+                .as_ref()
+                .map(HueResourceId::as_str),
+            Some("device-bridge")
+        );
+        assert_eq!(bridges[0].bridge_id.as_deref(), Some("001788fffeabcdef"));
+        assert_eq!(bridges[0].time_zone.as_deref(), Some("America/Los_Angeles"));
     }
 
     #[test]

--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this package will be documented in this file.
 - Hue CLIP v2 resource type/id/path primitives.
 - Structured Hue command intents for light, grouped-light, color-temperature,
   and scene requests.
+- Typed Hue bridge resources for paired bridge identity/health refresh.
 - Typed Hue device resources with product metadata and service references.
 - Mapping helpers from discovered Hue bridge/device/light records into
   `smart-home-core`.

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -9,6 +9,7 @@ packages a typed surface for:
 - CLIP v2 resource paths
 - event stream path constants
 - structured Hue command intents
+- typed Hue bridge resources for paired bridge identity/health refresh
 - typed Hue device resources and service references
 - discovery-to-`Bridge` projection
 - Hue light/device-to-normalized-model projection

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -319,6 +319,49 @@ pub fn discovered_bridge_to_core(discovered: DiscoveredHueBridge) -> Bridge {
     bridge
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HueBridgeResource {
+    pub id: HueResourceId,
+    pub owner_device_id: Option<HueResourceId>,
+    pub bridge_id: Option<String>,
+    pub time_zone: Option<String>,
+}
+
+impl HueBridgeResource {
+    pub fn to_core(&self, address: Option<String>) -> Bridge {
+        let bridge_identifier = self
+            .bridge_id
+            .as_deref()
+            .unwrap_or_else(|| self.id.as_str());
+        let mut bridge = Bridge::new(
+            BridgeId::trusted(format!("hue.bridge.{bridge_identifier}")),
+            IntegrationId::trusted(HUE_INTEGRATION_ID),
+            BridgeTransport::LanHttp,
+        );
+        bridge.address = address;
+        bridge.health = Health::Online;
+        bridge.identifiers.push(
+            ProtocolIdentifier::new(ProtocolFamily::Hue, "bridge", bridge_identifier)
+                .expect("Hue bridge resources have a non-empty identifier"),
+        );
+        bridge
+            .metadata
+            .push(Metadata::new("hue.resource_id", self.id.as_str()));
+        if let Some(owner_device_id) = &self.owner_device_id {
+            bridge.metadata.push(Metadata::new(
+                "hue.owner_device_id",
+                owner_device_id.as_str(),
+            ));
+        }
+        if let Some(time_zone) = &self.time_zone {
+            bridge
+                .metadata
+                .push(Metadata::new("hue.time_zone", time_zone));
+        }
+        bridge
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct HueLightResource {
     pub id: HueResourceId,
@@ -560,6 +603,31 @@ mod tests {
         assert_eq!(bridge.health, Health::Unpaired);
         assert_eq!(bridge.transport, BridgeTransport::LanHttp);
         assert_eq!(bridge.identifiers[0].kind, "bridge");
+    }
+
+    #[test]
+    fn hue_bridge_resource_projects_to_online_core_bridge() {
+        let bridge = HueBridgeResource {
+            id: HueResourceId::trusted("bridge-resource-1"),
+            owner_device_id: Some(HueResourceId::trusted("device-bridge")),
+            bridge_id: Some("001788fffeabcdef".to_string()),
+            time_zone: Some("America/Los_Angeles".to_string()),
+        }
+        .to_core(Some("https://192.0.2.10".to_string()));
+
+        assert_eq!(bridge.bridge_id.as_str(), "hue.bridge.001788fffeabcdef");
+        assert_eq!(bridge.integration_id, IntegrationId::trusted("hue"));
+        assert_eq!(bridge.health, Health::Online);
+        assert_eq!(bridge.address.as_deref(), Some("https://192.0.2.10"));
+        assert_eq!(bridge.identifiers[0].value, "001788fffeabcdef");
+        assert!(bridge
+            .metadata
+            .iter()
+            .any(|metadata| metadata.value == "bridge-resource-1"));
+        assert!(bridge
+            .metadata
+            .iter()
+            .any(|metadata| metadata.value == "America/Los_Angeles"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add typed Hue bridge resources and core bridge projection for paired identity refresh
- add hue-client bridge collection decoding for bridge_id, owner, and time zone fields
- document the Hue bridge resource surface

## Tests

- cargo test --manifest-path code/packages/rust/Cargo.toml -p hue-core -p hue-client

Reference
- https://www.openhue.io/api/openhue-api/bridge
