### PR TITLE
[codex] Add Hue grouped-light resource decoding

### DIFF
--- a/code/packages/rust/hue-client/CHANGELOG.md
+++ b/code/packages/rust/hue-client/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this package will be documented in this file.
   resource decoding.
 - Hue bridge resource decoding for paired bridge identity and time zone data.
 - Hue device resource decoding with product metadata and CLIP v2 service refs.
+- Hue grouped-light resource decoding for room/zone aggregate lights.
 - Hue event-stream Server-Sent Events parsing into batches and raw resource
   records.
 - Hue light state update extraction from resource snapshots and event-stream

--- a/code/packages/rust/hue-client/README.md
+++ b/code/packages/rust/hue-client/README.md
@@ -18,6 +18,7 @@ Included surfaces:
 - Hue v2 envelope/error parsing
 - Hue bridge resource decoding for paired bridge identity and time zone data
 - Hue device resource decoding with product metadata and service references
+- Hue grouped-light resource decoding for room/zone aggregate lights
 - Hue light resource decoding
 - Hue light state update extraction from snapshots and event-stream batches
 

--- a/code/packages/rust/hue-client/src/lib.rs
+++ b/code/packages/rust/hue-client/src/lib.rs
@@ -10,9 +10,10 @@ use coding_adventures_json_serializer::serialize;
 use coding_adventures_json_value::{parse as parse_json, JsonNumber, JsonValue};
 use http_core::{find_header, Header};
 use hue_core::{
-    validate_brightness, HueBridgeResource, HueCommand, HueDeviceResource, HueLightResource,
-    HueLightStateUpdate, HueMethod, HueRequest, HueRequestBody, HueResourceId, HueResourceRef,
-    HueResourceType, CLIP_V2_EVENT_STREAM_PATH, CLIP_V2_RESOURCE_ROOT, HUE_APPLICATION_KEY_HEADER,
+    validate_brightness, HueBridgeResource, HueCommand, HueDeviceResource, HueGroupedLightResource,
+    HueLightResource, HueLightStateUpdate, HueMethod, HueRequest, HueRequestBody, HueResourceId,
+    HueResourceRef, HueResourceType, CLIP_V2_EVENT_STREAM_PATH, CLIP_V2_RESOURCE_ROOT,
+    HUE_APPLICATION_KEY_HEADER,
 };
 use std::fmt;
 
@@ -237,6 +238,13 @@ impl<T: HueTransport> HueClient<T> {
     pub fn get_light_resources(&mut self) -> Result<Vec<HueLightResource>, HueClientError> {
         let envelope = self.get_collection(HueResourceType::Light)?;
         parse_lights_from_envelope(&envelope)
+    }
+
+    pub fn get_grouped_light_resources(
+        &mut self,
+    ) -> Result<Vec<HueGroupedLightResource>, HueClientError> {
+        let envelope = self.get_collection(HueResourceType::GroupedLight)?;
+        parse_grouped_lights_from_envelope(&envelope)
     }
 
     pub fn get_bridge_resources(&mut self) -> Result<Vec<HueBridgeResource>, HueClientError> {
@@ -544,6 +552,20 @@ pub fn parse_lights_from_envelope(
     Ok(lights)
 }
 
+pub fn parse_grouped_lights_from_envelope(
+    envelope: &HueEnvelope,
+) -> Result<Vec<HueGroupedLightResource>, HueClientError> {
+    let mut grouped_lights = Vec::new();
+    for resource in &envelope.data {
+        if object_string_field(resource, "type")
+            == Some(HueResourceType::GroupedLight.as_hue_type())
+        {
+            grouped_lights.push(parse_grouped_light_resource(resource)?);
+        }
+    }
+    Ok(grouped_lights)
+}
+
 pub fn parse_bridges_from_envelope(
     envelope: &HueEnvelope,
 ) -> Result<Vec<HueBridgeResource>, HueClientError> {
@@ -783,6 +805,33 @@ fn parse_bridge_resource(resource: &JsonValue) -> Result<HueBridgeResource, HueC
         owner_device_id,
         bridge_id: object_string_field(resource, "bridge_id").map(str::to_string),
         time_zone,
+    })
+}
+
+fn parse_grouped_light_resource(
+    resource: &JsonValue,
+) -> Result<HueGroupedLightResource, HueClientError> {
+    let id = object_string_field(resource, "id").ok_or_else(|| {
+        HueClientError::unexpected_json("Hue grouped_light resource is missing id")
+    })?;
+    let owner = object_field(resource, "owner")
+        .ok_or_else(|| HueClientError::unexpected_json("Hue grouped_light is missing owner"))?;
+    let name = object_field(resource, "metadata")
+        .and_then(|metadata| object_string_field(metadata, "name"))
+        .unwrap_or(id)
+        .to_string();
+    let on = object_field(resource, "on").and_then(|on| object_bool_field(on, "on"));
+    let brightness = object_field(resource, "dimming")
+        .and_then(|dimming| object_field(dimming, "brightness"))
+        .map(json_number_to_percent)
+        .transpose()?;
+
+    Ok(HueGroupedLightResource {
+        id: HueResourceId::trusted(id),
+        owner: parse_resource_ref(owner)?,
+        name,
+        on,
+        brightness,
     })
 }
 
@@ -1134,6 +1183,26 @@ mod tests {
     }
 
     #[test]
+    fn client_reads_grouped_light_collection_through_injected_transport() {
+        let transport = RecordingTransport::with_response(
+            r#"{"data":[{"id":"grouped-light-1","type":"grouped_light","owner":{"rid":"room-1","rtype":"room"}}],"errors":[]}"#,
+        );
+        let mut client = HueClient::new(HueClientConfig::paired("app-key"), transport);
+
+        let grouped_lights = client.get_grouped_light_resources().unwrap();
+        let transport = client.into_transport();
+
+        assert_eq!(grouped_lights.len(), 1);
+        assert_eq!(grouped_lights[0].id.as_str(), "grouped-light-1");
+        assert_eq!(grouped_lights[0].owner.resource_type, HueResourceType::Room);
+        assert_eq!(transport.requests.len(), 1);
+        assert_eq!(
+            transport.requests[0].path,
+            "/clip/v2/resource/grouped_light"
+        );
+    }
+
+    #[test]
     fn parses_registration_success() {
         let registration = parse_registration_response(
             br#"[{"success":{"username":"app-key","clientkey":"client-key"}}]"#,
@@ -1172,6 +1241,37 @@ mod tests {
         assert_eq!(lights[0].on, Some(true));
         assert_eq!(lights[0].brightness, Some(42));
         assert_eq!(lights[0].color_temperature_mirek, Some(366));
+    }
+
+    #[test]
+    fn parses_grouped_light_resources_from_snapshot_envelope() {
+        let envelope = parse_hue_envelope(
+            br#"{"data":[{"id":"grouped-light-1","type":"grouped_light","metadata":{"name":"Kitchen"},"owner":{"rid":"room-1","rtype":"room"},"on":{"on":true},"dimming":{"brightness":84}},{"id":"light-1","type":"light"}],"errors":[]}"#,
+        )
+        .unwrap();
+
+        let grouped_lights = parse_grouped_lights_from_envelope(&envelope).unwrap();
+
+        assert_eq!(grouped_lights.len(), 1);
+        assert_eq!(grouped_lights[0].id.as_str(), "grouped-light-1");
+        assert_eq!(grouped_lights[0].name, "Kitchen");
+        assert_eq!(grouped_lights[0].owner.resource_type, HueResourceType::Room);
+        assert_eq!(grouped_lights[0].owner.id.as_str(), "room-1");
+        assert_eq!(grouped_lights[0].on, Some(true));
+        assert_eq!(grouped_lights[0].brightness, Some(84));
+    }
+
+    #[test]
+    fn grouped_light_parser_rejects_missing_owner() {
+        let envelope = parse_hue_envelope(
+            br#"{"data":[{"id":"grouped-light-1","type":"grouped_light"}],"errors":[]}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            parse_grouped_lights_from_envelope(&envelope),
+            Err(HueClientError::UnexpectedJson { .. })
+        ));
     }
 
     #[test]

--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this package will be documented in this file.
   and scene requests.
 - Typed Hue bridge resources for paired bridge identity/health refresh.
 - Typed Hue device resources with product metadata and service references.
+- Typed Hue grouped-light resources for room/zone aggregate lights.
 - Mapping helpers from discovered Hue bridge/device/light records into
   `smart-home-core`.
 - Hue light state update helpers that project partial Hue light changes into

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -11,6 +11,7 @@ packages a typed surface for:
 - structured Hue command intents
 - typed Hue bridge resources for paired bridge identity/health refresh
 - typed Hue device resources and service references
+- typed Hue grouped-light resources for room/zone aggregate lights
 - discovery-to-`Bridge` projection
 - Hue light/device-to-normalized-model projection
 - Hue light state update-to-`StateDelta` projection

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -381,6 +381,31 @@ impl HueLightResource {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct HueGroupedLightResource {
+    pub id: HueResourceId,
+    pub owner: HueResourceRef,
+    pub name: String,
+    pub on: Option<bool>,
+    pub brightness: Option<u8>,
+}
+
+impl HueGroupedLightResource {
+    pub fn command_set_on(&self, on: bool) -> HueCommand {
+        HueCommand::SetGroupedLightOn {
+            grouped_light_id: self.id.clone(),
+            on,
+        }
+    }
+
+    pub fn command_set_brightness(&self, brightness: u8) -> HueCommand {
+        HueCommand::SetGroupedLightBrightness {
+            grouped_light_id: self.id.clone(),
+            brightness,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HueDeviceResource {
     pub id: HueResourceId,
@@ -654,6 +679,31 @@ mod tests {
             .any(|capability| capability.capability_id.as_str() == "light.color_temperature"));
         assert_eq!(entity.metadata[1].value, "light-1");
         assert_eq!(entity.state.unwrap().confidence, StateConfidence::Confirmed);
+    }
+
+    #[test]
+    fn hue_grouped_light_resource_builds_group_commands() {
+        let grouped = HueGroupedLightResource {
+            id: HueResourceId::trusted("grouped-light-1"),
+            owner: HueResourceRef::new(HueResourceType::Room, HueResourceId::trusted("room-1")),
+            name: "Kitchen".to_string(),
+            on: Some(false),
+            brightness: Some(20),
+        };
+
+        assert_eq!(
+            grouped.command_set_on(true).to_request(),
+            HueRequest {
+                method: HueMethod::Put,
+                path: "/clip/v2/resource/grouped_light/grouped-light-1".to_string(),
+                body: Some(HueRequestBody::SetOn { on: true }),
+            }
+        );
+        assert_eq!(
+            grouped.command_set_brightness(55).to_request().body,
+            Some(HueRequestBody::SetBrightness { brightness: 55 })
+        );
+        assert_eq!(grouped.owner.resource_type, HueResourceType::Room);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add typed Hue grouped-light resources for room and zone aggregate lights
- add hue-client grouped-light collection decoding with owner/state parsing
- document the grouped-light Hue surface

## Tests

- cargo test --manifest-path code/packages/rust/Cargo.toml -p hue-core -p hue-client
