### PR TITLE
[codex] Add Board VM store-program sugar

### DIFF
--- a/code/packages/python/board-vm-native/README.md
+++ b/code/packages/python/board-vm-native/README.md
@@ -15,6 +15,7 @@ read_frames = session.gpio_read(pin=13, mode="pullup").frames
 write_frames = session.gpio_write(pin=13, value=True).frames
 now_frames = session.time_now(program_id=2, instruction_budget=12).frames
 sleep_frames = session.time_sleep_ms(250, program_id=3, instruction_budget=12).frames
+store_frame = session.store_program(program_id=1, slot=0, boot_policy="run-if-no-host").frame
 ```
 
 Each frame is a Rust-produced Board VM wire frame ready for a transport to
@@ -43,6 +44,7 @@ session.gpio_low(pin=13)
 The REPL-style sugar is intentionally thin as well:
 
 ```python
+session.run_command("store-program 1 0 run-if-no-host")
 session.run_command("gpio-read 13 pullup 24")
 session.run_command("gpio-write 13 high 24")
 session.run_command("time-sleep-ms 250 24")

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -12,6 +12,14 @@ DEFAULT_HOST_NAME = "python-board-vm"
 DEFAULT_HOST_NONCE = 0xB0A2D001
 DEFAULT_PROGRAM_ID = 1
 DEFAULT_INSTRUCTION_BUDGET = 12
+BOOT_POLICIES = {
+    "store_only": 0,
+    "store-only": 0,
+    "run_at_boot": 1,
+    "run-at-boot": 1,
+    "run_if_no_host": 2,
+    "run-if-no-host": 2,
+}
 GPIO_READ_MODES = {
     "input": 0,
     "input_pullup": 2,
@@ -207,6 +215,21 @@ class Session:
             self._dispatch("program_chunk", self._call_native(_native.program_chunk_wire, program_id, 0, module_bytes)),
             self._dispatch("program_end", self._call_native(_native.program_end_wire, program_id)),
         ])
+
+    def store_program(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        slot: int = 0,
+        boot_policy: str | int = "run_if_no_host",
+    ) -> ProtocolResult:
+        frame = self._call_native(
+            _native.store_program_wire,
+            program_id,
+            slot,
+            self._boot_policy(boot_policy),
+        )
+        return self._dispatch("store_program", frame)
 
     def upload_blink(
         self,
@@ -442,6 +465,8 @@ class Session:
             return self.upload_time_sleep_ms(
                 **self._with_time_sleep_ms_options(words, command, options, allow_budget=False)
             )
+        if command in {"store-program", "store.program"}:
+            return SessionResult([self.store_program(**self._with_store_program_options(words, command, options))])
         if command == "run":
             return SessionResult([self.run(**self._with_optional_budget(words, command, options))])
         if command == "stop":
@@ -500,6 +525,22 @@ class Session:
         self._ensure_no_extra(words, command)
         return merged
 
+    def _with_store_program_options(
+        self,
+        words: list[str],
+        command: str,
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        merged = dict(options)
+        if words:
+            merged["program_id"] = int(words.pop(0))
+        if words:
+            merged["slot"] = int(words.pop(0))
+        if words:
+            merged["boot_policy"] = words.pop(0)
+        self._ensure_no_extra(words, command)
+        return merged
+
     def _with_gpio_read_options(
         self,
         words: list[str],
@@ -553,6 +594,18 @@ class Session:
             return GPIO_READ_MODES[normalized]
         except KeyError as exc:
             raise ValueError(f"unsupported GPIO read mode: {mode!r}") from exc
+
+    @staticmethod
+    def _boot_policy(policy: str | int) -> int:
+        if isinstance(policy, int):
+            return policy
+        normalized = str(policy).replace("-", "_")
+        if normalized.isdecimal():
+            return int(normalized)
+        try:
+            return BOOT_POLICIES[normalized]
+        except KeyError as exc:
+            raise ValueError(f"unsupported boot policy: {policy!r}") from exc
 
     def _with_gpio_write_options(
         self,
@@ -611,6 +664,7 @@ class Session:
 
 __all__ = [
     "BoardDescriptor",
+    "BOOT_POLICIES",
     "Capability",
     "GPIO_READ_MODES",
     "ProtocolResult",

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -10,10 +10,10 @@ use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
     build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
     build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_background_wire_frame,
-    build_stop_wire_frame, build_time_now_module, build_time_sleep_ms_module,
-    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
-    capability_protocol_feature, decode_wire_response, program_format_name, run_status_name,
-    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    build_stop_wire_frame, build_store_program_wire_frame, build_time_now_module,
+    build_time_sleep_ms_module, capability_board_metadata, capability_bytecode_callable,
+    capability_flag_names, capability_protocol_feature, decode_wire_response, program_format_name,
+    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
     LanguageCoreError, LanguageValue,
 };
 use python_bridge::*;
@@ -221,6 +221,32 @@ unsafe extern "C" fn py_program_end_wire(_module: PyObjectPtr, args: PyObjectPtr
     with_session(next_request_id, |session| {
         let mut wire = [0u8; 64];
         let written = build_program_end_wire_frame(session, program_id, &mut wire)?;
+        Ok(wire_result(&wire, written.len, session))
+    })
+}
+
+unsafe extern "C" fn py_store_program_wire(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let next_request_id = match parse_arg_u16(args, 0, "next_request_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let program_id = match parse_arg_u16(args, 1, "program_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let slot = match parse_arg_u8(args, 2, "slot") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let boot_policy = match parse_arg_u8(args, 3, "boot_policy") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    with_session(next_request_id, |session| {
+        let mut wire = [0u8; 64];
+        let written =
+            build_store_program_wire_frame(session, program_id, slot, boot_policy, &mut wire)?;
         Ok(wire_result(&wire, written.len, session))
     })
 }
@@ -683,7 +709,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 14] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 15] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -746,6 +772,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_program_end_wire),
             ml_flags: METH_VARARGS,
             ml_doc: b"Build a Board VM PROGRAM_END wire frame in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"store_program_wire\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_store_program_wire),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM STORE_PROGRAM wire frame in Rust.\0".as_ptr()
+                as *const c_char,
         },
         PyMethodDef {
             ml_name: b"run_background_wire\0".as_ptr() as *const c_char,

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -93,6 +93,20 @@ def test_run_command_accepts_repl_style_stop():
     assert result.frames == transport.frames
 
 
+def test_store_program_dispatches_rust_owned_wire_frame():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.store_program(program_id=9, slot=2, boot_policy="run-at-boot")
+    command = session.run_command("store-program 10 3 store-only")
+
+    assert result.command == "store_program"
+    assert isinstance(result.frame, bytes)
+    assert result.frame == transport.frames[0]
+    assert [item.command for item in command.results] == ["store_program"]
+    assert command.frames == transport.frames[1:]
+
+
 def test_run_command_accepts_repl_style_gpio_read():
     transport = FakeWriteTransport()
     session = Session(transport=transport)

--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -112,6 +112,7 @@ CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
     vm.hello
     vm.capabilities
     vm.run_command("blink 24")
+    vm.run_command("store-program 1 0 run-if-no-host")
     vm.run_command("gpio-read 13 pullup 24")
     vm.run_command("gpio-write 13 high 24")
     vm.run_command("time-now 24")
@@ -120,12 +121,13 @@ CodingAdventures::BoardVM.uno_r4_wifi(port: "/dev/cu.usbmodem1101") do |board|
 end
 ```
 
-`hello`, `capabilities`, `upload_blink`, `upload_gpio_read`, `upload_time_now`,
-`upload_time_sleep_ms`, `upload_gpio_write`, `run`, `stop`, `blink`,
-`gpio_read`, `gpio_write`, `time_now`, `time_sleep_ms`, and `run_command` return
-dispatch results with the Rust-produced frame, optional raw response bytes, and
-optional Rust-decoded response hash. The text command parser is Ruby sugar only;
-every dispatched frame still comes from `CodingAdventures::BoardVM::Native::Session`.
+`hello`, `capabilities`, `upload_blink`, `store_program`, `upload_gpio_read`,
+`upload_time_now`, `upload_time_sleep_ms`, `upload_gpio_write`, `run`, `stop`,
+`blink`, `gpio_read`, `gpio_write`, `time_now`, `time_sleep_ms`, and
+`run_command` return dispatch results with the Rust-produced frame, optional raw
+response bytes, and optional Rust-decoded response hash. The text command parser
+is Ruby sugar only; every dispatched frame still comes from
+`CodingAdventures::BoardVM::Native::Session`.
 
 Capability reports can be lifted into Ruby objects after Rust decodes the board
 response:

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -11,10 +11,10 @@ use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
     build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
     build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_background_wire_frame,
-    build_stop_wire_frame, build_time_now_module, build_time_sleep_ms_module,
-    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
-    capability_protocol_feature, decode_wire_response, program_format_name, run_status_name,
-    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    build_stop_wire_frame, build_store_program_wire_frame, build_time_now_module,
+    build_time_sleep_ms_module, capability_board_metadata, capability_bytecode_callable,
+    capability_flag_names, capability_protocol_feature, decode_wire_response, program_format_name,
+    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
     LanguageCoreError, LanguageValue,
 };
 use ruby_bridge::VALUE;
@@ -181,6 +181,29 @@ extern "C" fn session_program_end_wire(self_val: VALUE, program_id_val: VALUE) -
     with_session_mut(self_val, |session| {
         let mut wire = [0u8; 64];
         let written = build_program_end_wire_frame(&mut session.inner, program_id, &mut wire)?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_store_program_wire(
+    self_val: VALUE,
+    program_id_val: VALUE,
+    slot_val: VALUE,
+    boot_policy_val: VALUE,
+) -> VALUE {
+    let program_id = rb_u16(program_id_val, "program_id");
+    let slot = rb_u8(slot_val, "slot");
+    let boot_policy = rb_u8(boot_policy_val, "boot_policy");
+
+    with_session_mut(self_val, |session| {
+        let mut wire = [0u8; 64];
+        let written = build_store_program_wire_frame(
+            &mut session.inner,
+            program_id,
+            slot,
+            boot_policy,
+            &mut wire,
+        )?;
         Ok(bytes_result(&wire, written.len))
     })
 }
@@ -716,6 +739,12 @@ pub extern "C" fn Init_board_vm_native() {
         "program_end_wire",
         session_program_end_wire as *const c_void,
         1,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "store_program_wire",
+        session_store_program_wire as *const c_void,
+        3,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -199,6 +199,20 @@ module CodingAdventures
         )
       end
 
+      def store_program!(
+        program_id: DEFAULT_PROGRAM_ID,
+        slot: DEFAULT_EJECT_SLOT,
+        boot_policy: DEFAULT_BOOT_POLICY
+      )
+        ensure_uno_r4_wifi!
+
+        session.store_program(
+          program_id: program_id,
+          slot: slot,
+          boot_policy: boot_policy
+        )
+      end
+
       def eject_blink!(
         output:,
         program_id: DEFAULT_PROGRAM_ID,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -21,6 +21,11 @@ module CodingAdventures
         off: false,
         :"false" => false
       }.freeze
+      BOOT_POLICIES = {
+        store_only: 0,
+        run_at_boot: 1,
+        run_if_no_host: 2
+      }.freeze
 
       attr_reader :connection, :native_session, :host_name, :host_nonce, :program_id,
         :instruction_budget
@@ -61,6 +66,13 @@ module CodingAdventures
           dispatch(:program_chunk, native_session.program_chunk_wire(program_id, 0, module_bytes)),
           dispatch(:program_end, native_session.program_end_wire(program_id))
         ])
+      end
+
+      def store_program(program_id: @program_id, slot: 0, boot_policy: DEFAULT_BOOT_POLICY)
+        dispatch(
+          :store_program,
+          native_session.store_program_wire(program_id, slot, boot_policy_value(boot_policy))
+        )
       end
 
       def upload_blink(
@@ -319,6 +331,8 @@ module CodingAdventures
           upload_time_now(**options)
         when "upload-time-sleep-ms", "upload-time.sleep_ms", "upload-sleep-ms"
           upload_time_sleep_ms(**time_sleep_ms_command_options(words, command, options, require_budget: false))
+        when "store-program", "store.program"
+          SessionResult.new(results: [store_program(**store_program_command_options(words, command, options))])
         when "run"
           SessionResult.new(results: [run(**options.merge(optional_budget(words, command)))])
         when "stop"
@@ -369,6 +383,15 @@ module CodingAdventures
         end
         ensure_no_extra_arguments!(words, command)
         {instruction_budget: budget}
+      end
+
+      def store_program_command_options(words, command, options)
+        merged = options.dup
+        merged[:program_id] = integer_argument(words.shift, "#{command} program_id") unless words.empty?
+        merged[:slot] = integer_argument(words.shift, "#{command} slot") unless words.empty?
+        merged[:boot_policy] = words.shift unless words.empty?
+        ensure_no_extra_arguments!(words, command)
+        merged
       end
 
       def gpio_read_command_options(words, command, options, require_budget: true)
@@ -458,6 +481,17 @@ module CodingAdventures
 
         GPIO_WRITE_VALUES.fetch(text.to_sym) do
           raise ArgumentError, "unsupported GPIO write value: #{value.inspect}"
+        end
+      end
+
+      def boot_policy_value(value)
+        return value if value.is_a?(Integer)
+
+        text = value.to_s.tr("-", "_")
+        return Integer(text, 10) if integer_literal?(text)
+
+        BOOT_POLICIES.fetch(text.to_sym) do
+          raise ArgumentError, "unsupported boot policy: #{value.inspect}"
         end
       end
 

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -130,6 +130,27 @@ module CodingAdventures
           result.results.map(&:command)
       end
 
+      def test_store_program_dispatches_native_protocol_frame_through_transport
+        runner = FakeRunner.new
+        transport = FakeWriteTransport.new
+        result = nil
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          transport: transport
+        ) do |board|
+          result = board.store_program!(program_id: 10, slot: 2, boot_policy: :run_at_boot)
+        end
+
+        assert_empty runner.calls
+        assert_equal 1, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+        assert_equal transport.frames.first, result.frame
+        assert_equal :store_program, result.command
+      end
+
       def test_gpio_read_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new
@@ -192,6 +213,7 @@ module CodingAdventures
             sleep_upload = session.upload_time_sleep_ms(program_id: 8, duration_ms: 250)
             gpio_upload = session.upload_gpio_read(program_id: 6, pin: 13, mode: :pullup)
             gpio_write_upload = session.upload_gpio_write(program_id: 7, pin: 13, value: true)
+            store = session.store_program(program_id: 4, slot: 2, boot_policy: :run_at_boot)
             run = session.run(program_id: 4, budget: 77)
             stop = session.stop
 
@@ -206,13 +228,14 @@ module CodingAdventures
               gpio_upload.results.map(&:command)
             assert_equal [:program_begin, :program_chunk, :program_end],
               gpio_write_upload.results.map(&:command)
+            assert_equal :store_program, store.command
             assert_equal :run, run.command
             assert_equal :stop, stop.command
           end
         end
 
         assert_empty runner.calls
-        assert_equal 19, transport.frames.length
+        assert_equal 20, transport.frames.length
         assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
       end
 
@@ -228,6 +251,22 @@ module CodingAdventures
           result = board.session.run_command("stop")
 
           assert_equal [:stop], result.results.map(&:command)
+          assert_equal result.frames, transport.frames
+        end
+      end
+
+      def test_session_run_command_accepts_repl_style_store_program
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("store-program 9 2 run-at-boot")
+
+          assert_equal [:store_program], result.results.map(&:command)
           assert_equal result.frames, transport.frames
         end
       end
@@ -407,10 +446,15 @@ module CodingAdventures
         assert_instance_of String, gpio_write_module_bytes
         assert_operator gpio_write_module_bytes.bytesize, :>, 0
 
+        store = session.store_program_wire(7, 2, 1)
+        assert_instance_of String, store
+        assert_operator store.bytesize, :>, 0
+        assert_equal 4, session.next_request_id
+
         stop = session.stop_wire
         assert_instance_of String, stop
         assert_operator stop.bytesize, :>, 0
-        assert_equal 4, session.next_request_id
+        assert_equal 5, session.next_request_id
 
         frames = BoardVM::Native::Session.new.blink_upload_run_frames(7, 12, 13, 250, 250, 4)
         assert_equal 4, frames.length

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -344,11 +344,28 @@ impl HostSession {
         payload_out: &mut [u8],
         frame_out: &mut [u8],
     ) -> Result<WrittenFrame, HostError> {
+        self.store_program_with_boot_policy_frame(
+            program_id,
+            slot,
+            BOOT_RUN_IF_NO_HOST,
+            payload_out,
+            frame_out,
+        )
+    }
+
+    pub fn store_program_with_boot_policy_frame(
+        &mut self,
+        program_id: u16,
+        slot: u8,
+        boot_policy: u8,
+        payload_out: &mut [u8],
+        frame_out: &mut [u8],
+    ) -> Result<WrittenFrame, HostError> {
         let payload_len = encode_store_program(
             &StoreProgram {
                 program_id,
                 slot,
-                boot_policy: BOOT_RUN_IF_NO_HOST,
+                boot_policy,
             },
             payload_out,
         )?;

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -495,6 +495,31 @@ pub fn build_program_end_wire_frame(
     })
 }
 
+pub fn build_store_program_wire_frame(
+    session: &mut BoardVmLanguageSession,
+    program_id: u16,
+    slot: u8,
+    boot_policy: u8,
+    wire_out: &mut [u8],
+) -> Result<BuiltWireFrame, LanguageCoreError> {
+    let mut payload = [0u8; 8];
+    let mut raw = [0u8; 16];
+    let mut host = session.host_session();
+    let written = host.store_program_with_boot_policy_frame(
+        program_id,
+        slot,
+        boot_policy,
+        &mut payload,
+        &mut raw,
+    )?;
+    let wire_len = encode_wire_frame(&raw[..written.len], wire_out)?;
+    session.update_from_host_session(&host);
+    Ok(BuiltWireFrame {
+        request_id: written.request_id,
+        len: wire_len,
+    })
+}
+
 pub fn build_run_background_wire_frame(
     session: &mut BoardVmLanguageSession,
     program_id: u16,
@@ -965,6 +990,27 @@ pub unsafe extern "C" fn board_vm_language_program_end_wire(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_store_program_wire(
+    session: *mut BoardVmLanguageSession,
+    program_id: u16,
+    slot: u8,
+    boot_policy: u8,
+    wire_out: *mut u8,
+    wire_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let session = unsafe { mut_ref(session, "board_vm_language_store_program_wire session") }?;
+        let wire_out = unsafe { out_slice(wire_out, wire_cap, "wire_out") }?;
+        let written =
+            build_store_program_wire_frame(session, program_id, slot, boot_policy, wire_out)?;
+        Ok(BoardVmLanguageStatus::written(
+            written.request_id,
+            written.len,
+        ))
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_run_background_wire(
     session: *mut BoardVmLanguageSession,
     program_id: u16,
@@ -1317,6 +1363,28 @@ mod tests {
         let frame = decode_frame(&raw[..decoded.len as usize]).unwrap();
         assert_eq!(decode_program_end(frame.payload).unwrap().program_id, 7);
 
+        let store = unsafe {
+            board_vm_language_store_program_wire(
+                &mut session,
+                7,
+                2,
+                board_vm_protocol::BOOT_RUN_AT_BOOT,
+                wire.as_mut_ptr(),
+                wire.len() as u64,
+            )
+        };
+        assert_eq!(store.request_id, 4);
+        let decoded = decode_wire_frame_into_raw(&wire[..store.len as usize], &mut raw).unwrap();
+        assert_eq!(decoded.message_type, MessageType::STORE_PROGRAM.0);
+        let frame = decode_frame(&raw[..decoded.len as usize]).unwrap();
+        let store_payload = board_vm_protocol::decode_store_program(frame.payload).unwrap();
+        assert_eq!(store_payload.program_id, 7);
+        assert_eq!(store_payload.slot, 2);
+        assert_eq!(
+            store_payload.boot_policy,
+            board_vm_protocol::BOOT_RUN_AT_BOOT
+        );
+
         let run = unsafe {
             board_vm_language_run_background_wire(
                 &mut session,
@@ -1326,7 +1394,7 @@ mod tests {
                 wire.len() as u64,
             )
         };
-        assert_eq!(run.request_id, 4);
+        assert_eq!(run.request_id, 5);
         let decoded = decode_wire_frame_into_raw(&wire[..run.len as usize], &mut raw).unwrap();
         assert_eq!(decoded.message_type, MessageType::RUN.0);
         let frame = decode_frame(&raw[..decoded.len as usize]).unwrap();
@@ -1340,7 +1408,7 @@ mod tests {
         let stop = unsafe {
             board_vm_language_stop_wire(&mut session, wire.as_mut_ptr(), wire.len() as u64)
         };
-        assert_eq!(stop.request_id, 5);
+        assert_eq!(stop.request_id, 6);
         let decoded = decode_wire_frame_into_raw(&wire[..stop.len as usize], &mut raw).unwrap();
         assert_eq!(decoded.message_type, MessageType::STOP.0);
         let frame = decode_frame(&raw[..decoded.len as usize]).unwrap();


### PR DESCRIPTION
## Summary

Adds `STORE_PROGRAM` as a Rust-owned protocol request surfaced through Python and Ruby sugar.

## Details

- Adds a `store_program_with_boot_policy_frame` host helper so boot policy stays in Rust protocol encoding.
- Exposes `build_store_program_wire_frame` and `board_vm_language_store_program_wire` in `board-vm-language-core`.
- Adds Python native/session support for `store_program`, `store-program`, boot policy parsing, and docs/tests.
- Adds Ruby native/session/connection support for `store_program`, `board.store_program!`, `store-program`, boot policy parsing, and docs/tests.
- Rebased on the merged `time.sleep_ms` work and preserved that API surface.

## Validation

- `cargo test --manifest-path code/packages/rust/Cargo.toml -p board-vm-host -p board-vm-language-core`
- `cargo build --release` in `code/packages/python/board-vm-native`
- `PYTHONPATH=src python3 -m pytest tests/ -v`
- `cargo build --release` in `code/packages/ruby/board_vm/ext/board_vm_native`
- `ruby -Ilib -Itest test/test_board_vm.rb`
- `git diff --check`
