### PR TITLE
feat(ui): add mosmodel, moslayout, mosstyle specs (UI13-UI15)

### DIFF
--- a/code/specs/UI13-mosmodel.md
+++ b/code/specs/UI13-mosmodel.md
@@ -1,0 +1,515 @@
+# mosmodel — Component Interface Language
+
+## Overview
+
+`mosmodel` is a small, strictly compiled language for declaring the **external
+interface** of a UI component. A `.mosmodel` file answers exactly one question:
+*what does the outside world need to know to use this component?*
+
+It answers that question with two constructs:
+
+- **slots** — named, typed values the host pushes *into* the component
+- **emits** — named, typed events the component fires *out* to the host
+
+Nothing else belongs in a `.mosmodel` file. No layout. No style. No behavior.
+No conditional logic. The compiler rejects everything that is not a slot or emit
+declaration.
+
+This strict boundary is the point. A VisiCalc developer who wants to embed a
+`Grid` component reads one file, sees slots and emits, and knows everything they
+need. They never open the layout or style files. The contract is complete and
+self-contained.
+
+---
+
+## Position in the Stack
+
+```
+mosmodel (.mosmodel)         ← THIS SPEC
+     │  declares interface
+     ▼
+moslayout (.moslayout)       ← UI14-moslayout.md
+     │  references slot/emit names, arranges primitives
+     ▼
+mosstyle (.mosstyle)         ← UI15-mosstyle.md
+     │  references part names, declares visual appearance
+     ▼
+backend emitter
+     │  collapses all three into one output file
+     ▼
+Rust struct / Swift class / JSX component / Qt QObject / …
+```
+
+The three compilers run in dependency order. `moslayout` imports the slot and
+emit names that `mosmodel` exports. `mosstyle` imports the part names that
+`moslayout` exports. The backend emitter combines all three resolved artefacts
+into a single target-language file. **No three-file split exists at runtime.**
+The separation is authoring-time only.
+
+---
+
+## Design Principles
+
+### Principle 1 — The interface is the only public API
+
+Every other file in a component's source tree is an implementation detail.
+`moslayout` can change completely — mobile and desktop layouts may be entirely
+different — without the interface changing. `mosstyle` can be swapped for a
+different theme. Only `.mosmodel` is stable and public.
+
+### Principle 2 — One direction per construct
+
+Slots carry data *inward*. Emits carry signals *outward*. There is no two-way
+binding, no observable, no reactive stream at the interface level. The host
+pushes new slot values whenever state changes. The component fires emits when
+something happens. The host handles emits and decides what to do next. This is
+the MVVM View boundary enforced by grammar.
+
+### Principle 3 — The compiler is the enforcer
+
+Cultural conventions erode. Code review misses things. A grammar that cannot
+express style properties in a slot declaration is an enforcer that never sleeps
+and cannot be overridden by a deadline.
+
+### Principle 4 — Backend-agnostic by construction
+
+A `.mosmodel` file has no knowledge of any backend. The same file drives code
+generation for Rust structs, Swift classes, Qt QObjects, React props, and Web
+Component attributes. Adding a new backend never requires touching `.mosmodel`
+source files.
+
+---
+
+## §1 Slot Declarations
+
+A slot is a named, typed input channel. The host sets it. The component reads
+it. The component never writes to its own slots.
+
+### Syntax
+
+```
+slot <name> : <type> ;
+slot <name> : <type> = <default> ;
+```
+
+Names follow `kebab-case`. The optional `= <default>` provides a value used
+when the host does not set the slot. Slots without defaults are **required** —
+the compiler rejects a component instantiation that omits a required slot.
+
+### Slot types
+
+| Type | Description | Example value |
+|---|---|---|
+| `text` | UTF-8 string | `"Hello"` |
+| `number` | 64-bit floating point | `42`, `3.14` |
+| `bool` | boolean | `true`, `false` |
+| `image` | opaque image reference | backend-specific handle |
+| `color` | RGBA color value | `#4a90d9`, `rgba(74,144,217,0.5)` |
+| `list<T>` | homogeneous ordered list | `list<text>`, `list<number>` |
+| `node` | an arbitrary composed component | another component instance |
+| `<ComponentName>` | a specific component type | `CellData`, `ColumnDef` |
+
+`list<T>` is the only parameterized type. `T` may be any scalar type or a named
+component type. Nested lists (`list<list<text>>`) are valid for table data.
+
+### Named component slot types
+
+A slot may declare its type as another mosmodel component name:
+
+```
+slot row-data : CellData ;
+```
+
+The compiler resolves `CellData` by looking for `CellData.mosmodel` in the same
+component library. This enforces that the host passes structurally correct data,
+not an arbitrary object.
+
+### Slot examples
+
+```mosmodel
+// A label the host provides as text
+slot label : text ;
+
+// An optional subtitle with a default
+slot subtitle : text = "" ;
+
+// A count used for display
+slot total-rows : number ;
+
+// Whether the component is interactive
+slot disabled : bool = false ;
+
+// A list of column header strings
+slot column-headers : list<text> ;
+
+// A two-dimensional list — viewport rows for a grid
+slot viewport-rows : list<list<text>> ;
+
+// A specific typed data record
+slot active-cell : CellAddress ;
+```
+
+---
+
+## §2 Emit Declarations
+
+An emit is a named, typed output channel. The component fires it. The host
+handles it. The component never receives the result of an emit. There is no
+return value. There is no self-mutation triggered by an emit.
+
+### Syntax
+
+```
+emit <name> ;
+emit <name> ( <param> : <type> , … ) ;
+```
+
+Void emits carry no payload. Typed emits carry a structured payload that the
+host receives when handling the event.
+
+### Emit payload types
+
+Payload parameters use the same type vocabulary as slots: `text`, `number`,
+`bool`, `color`, and named component types. `image` and `node` are not valid
+in emit payloads — events carry data, not rendered subtrees.
+
+### Emit examples
+
+```mosmodel
+// A simple click with no payload
+emit onClick ;
+
+// Navigation carries the destination cell address
+emit onNavigate ( row : number , col : number ) ;
+
+// Edit commit carries the new cell value
+emit onEditCommit ( value : text ) ;
+
+// Edit cancel carries no payload
+emit onEditCancel ;
+
+// Scroll carries the new viewport offset
+emit onScroll ( offset : number ) ;
+
+// Selection change carries the selected range
+emit onSelect ( start-row : number , start-col : number ,
+                end-row   : number , end-col   : number ) ;
+```
+
+---
+
+## §3 Complete Component Examples
+
+### Button
+
+```mosmodel
+component Button {
+  slot label   : text ;
+  slot icon    : image ;
+  slot disabled : bool = false ;
+
+  emit onClick ;
+  emit onLongPress ;
+}
+```
+
+### Grid
+
+```mosmodel
+component Grid {
+  // What to show
+  slot column-headers  : list<text> ;
+  slot column-widths   : list<number> ;
+  slot total-rows      : number ;
+
+  // What the host has scrolled to
+  slot viewport-offset : number = 0 ;
+  slot viewport-rows   : list<list<text>> ;
+
+  // Selection and edit state — host owns, pushes in
+  slot selected-row    : number = 0 ;
+  slot selected-col    : number = 0 ;
+  slot edit-row        : number = -1 ;   // -1 means not editing
+  slot edit-col        : number = -1 ;
+  slot edit-content    : text   = "" ;
+
+  // Navigation
+  emit onNavigate ( row : number , col : number ) ;
+
+  // Edit lifecycle
+  emit onEditStart  ( row : number , col : number ) ;
+  emit onEditCommit ( value : text ) ;
+  emit onEditCancel ;
+
+  // Scroll — host must update viewport-offset and viewport-rows in response
+  emit onScroll ( offset : number ) ;
+
+  // Selection change
+  emit onSelect ( start-row : number , start-col : number ,
+                  end-row   : number , end-col   : number ) ;
+}
+```
+
+### FormulaBar
+
+```mosmodel
+component FormulaBar {
+  slot cell-address : text ;    // e.g. "A1", "B12"
+  slot formula      : text ;    // raw formula string shown in bar
+  slot read-only    : bool = false ;
+
+  emit onFormulaChange ( formula : text ) ;
+  emit onCommit ;
+  emit onCancel ;
+}
+```
+
+---
+
+## §4 Grammar
+
+The mosmodel grammar is intentionally tiny. Any construct that cannot be
+expressed with this grammar does not belong in a `.mosmodel` file.
+
+### Token file (`mosmodel.tokens`)
+
+```
+# Identifiers and keywords
+IDENT         = /[a-zA-Z][a-zA-Z0-9]*/
+KEBAB_IDENT   = /[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*/
+NUMBER        = /[0-9]+(\.[0-9]+)?/
+STRING        = /"([^"\\]|\\.)*"/
+BOOL_LIT      = "true" | "false"
+
+# Punctuation
+LBRACE        = "{"
+RBRACE        = "}"
+LPAREN        = "("
+RPAREN        = ")"
+COLON         = ":"
+SEMICOLON     = ";"
+COMMA         = ","
+EQUALS        = "="
+LANGLE        = "<"
+RANGLE        = ">"
+
+# Keywords (must come before IDENT in token ordering)
+KW_COMPONENT  = "component"
+KW_SLOT       = "slot"
+KW_EMIT       = "emit"
+KW_LIST       = "list"
+
+# Whitespace and comments
+WHITESPACE    = /\s+/               skip
+LINE_COMMENT  = /\/\/[^\n]*/       skip
+BLOCK_COMMENT = /\/\*.*?\*\//      skip
+```
+
+### Grammar file (`mosmodel.grammar`)
+
+```
+mosmodel_file = component_def ;
+
+component_def = KW_COMPONENT IDENT LBRACE { member } RBRACE ;
+
+member = slot_decl | emit_decl ;
+
+slot_decl = KW_SLOT KEBAB_IDENT COLON slot_type
+            [ EQUALS slot_default ] SEMICOLON ;
+
+slot_type = scalar_type
+          | list_type
+          | IDENT ;               # named component type
+
+scalar_type = "text" | "number" | "bool" | "image" | "color" | "node" ;
+
+list_type = KW_LIST LANGLE ( scalar_type | IDENT ) RANGLE ;
+
+slot_default = STRING | NUMBER | BOOL_LIT ;
+
+emit_decl = KW_EMIT KEBAB_IDENT
+            [ LPAREN emit_param { COMMA emit_param } RPAREN ]
+            SEMICOLON ;
+
+emit_param = KEBAB_IDENT COLON emit_payload_type ;
+
+emit_payload_type = "text" | "number" | "bool" | "color" | IDENT ;
+```
+
+The grammar is context-free and LL(1). Every construct begins with an
+unambiguous keyword (`component`, `slot`, `emit`). No lookahead beyond one
+token is required at any decision point.
+
+---
+
+## §5 Compiler Behaviour
+
+### Input
+
+A single `.mosmodel` file.
+
+### Validation
+
+1. **Unique names** — no two slots share a name; no two emits share a name; a
+   slot and emit may not share a name.
+2. **Valid types** — all slot types and emit payload types resolve to known
+   scalar types, `list<T>` with a valid inner type, or a named component found
+   in the component library.
+3. **Valid defaults** — slot defaults must be type-compatible. A `text` slot
+   may default to a string literal. A `number` slot may default to a number
+   literal. A `bool` slot may default to `true` or `false`. `image`, `color`,
+   `list<T>`, and component types may not have inline defaults (the host always
+   supplies them explicitly).
+4. **No unknown constructs** — anything that is not a `slot` or `emit`
+   declaration inside the component body is a compile error.
+
+### Output
+
+The compiler produces two artefacts:
+
+**1. Interface descriptor (internal, JSON)**
+
+```json
+{
+  "component": "Grid",
+  "slots": [
+    { "name": "column-headers", "type": "list<text>", "required": true },
+    { "name": "total-rows",     "type": "number",     "required": true },
+    { "name": "viewport-offset","type": "number",     "default": 0     },
+    { "name": "selected-row",   "type": "number",     "default": 0     }
+  ],
+  "emits": [
+    { "name": "onNavigate",    "params": [{"name":"row","type":"number"},{"name":"col","type":"number"}] },
+    { "name": "onEditCommit",  "params": [{"name":"value","type":"text"}] },
+    { "name": "onEditCancel",  "params": [] }
+  ]
+}
+```
+
+This descriptor is consumed by the `moslayout` and `mosstyle` compilers and by
+each backend emitter.
+
+**2. Target-language binding**
+
+The backend emitter generates one file per target. Examples:
+
+*Rust (paint-vm / Metal backend):*
+```rust
+pub struct Grid {
+    pub column_headers:   Vec<String>,
+    pub total_rows:       f64,
+    pub viewport_offset:  f64,              // default: 0
+    pub selected_row:     f64,              // default: 0
+    pub on_navigate:      Option<Box<dyn Fn(f64, f64)>>,
+    pub on_edit_commit:   Option<Box<dyn Fn(String)>>,
+    pub on_edit_cancel:   Option<Box<dyn Fn()>>,
+}
+
+impl Grid {
+    pub fn new() -> Self { … }
+    pub fn column_headers(mut self, v: Vec<String>) -> Self { … }
+    pub fn on_navigate(mut self, f: impl Fn(f64, f64) + 'static) -> Self { … }
+    // … builder methods for every slot and emit
+}
+```
+
+*Web Component (JavaScript):*
+```javascript
+class GridElement extends HTMLElement {
+  set columnHeaders(v) { this._columnHeaders = v; this._render(); }
+  set totalRows(v)     { this._totalRows = v;     this._render(); }
+  // …
+  _fireOnNavigate(row, col) {
+    this.dispatchEvent(new CustomEvent('on-navigate', { detail: { row, col } }));
+  }
+}
+customElements.define('mos-grid', GridElement);
+```
+
+*React (TypeScript):*
+```typescript
+export interface GridProps {
+  columnHeaders:  string[];
+  totalRows:      number;
+  viewportOffset?: number;
+  selectedRow?:   number;
+  onNavigate?:    (row: number, col: number) => void;
+  onEditCommit?:  (value: string) => void;
+  onEditCancel?:  () => void;
+}
+export function Grid(props: GridProps): JSX.Element { … }
+```
+
+*Swift / AppKit:*
+```swift
+public class GridView: NSView {
+  public var columnHeaders:  [String] = [] { didSet { setNeedsDisplay(bounds) } }
+  public var totalRows:      Double   = 0  { didSet { setNeedsDisplay(bounds) } }
+  public var onNavigate:     ((Double, Double) -> Void)?
+  public var onEditCommit:   ((String) -> Void)?
+  public var onEditCancel:   (() -> Void)?
+}
+```
+
+---
+
+## §6 Error Messages
+
+| Error | Condition | Example message |
+|---|---|---|
+| `DuplicateName` | Two slots or two emits share a name | `Duplicate slot name 'label' at line 4` |
+| `NameConflict` | A slot and emit share a name | `'onClick' is declared as both a slot and an emit at line 6` |
+| `UnknownType` | A type name does not resolve | `Unknown type 'CelAddress' — did you mean 'CellAddress'? at line 8` |
+| `InvalidDefault` | Default value is type-incompatible | `Slot 'disabled' has type bool but default value "yes" is text at line 3` |
+| `NoDefaultForType` | Default provided for non-defaultable type | `Slots of type image cannot have inline defaults at line 5` |
+| `UnknownConstruct` | Anything other than slot/emit in component body | `Unexpected token 'Box' — only slot and emit declarations are allowed here at line 9` |
+| `MissingComponent` | Named component type not found | `Component type 'CellAddress' not found in component library at line 12` |
+
+All errors include file path, line number, and column number.
+
+---
+
+## §7 Relationship to Other Specs
+
+- **UI14-moslayout.md** — the moslayout compiler imports the interface
+  descriptor produced by this compiler. Every slot and emit reference in a
+  `.moslayout` file is validated against the descriptor.
+- **UI15-mosstyle.md** — the mosstyle compiler does not import the interface
+  descriptor directly. It imports the part names that moslayout exports, which
+  are derived from the layout's wiring of slot values to named primitives.
+- **UI00-mosaic.md** — the original Mosaic spec conflated interface and layout
+  in a single `.mosaic` file. `mosmodel` is the strict interface-only successor.
+  New components use `.mosmodel` + `.moslayout` + `.mosstyle`. The original
+  `.mosaic` format is supported by a compatibility shim in the mosaic compiler
+  that splits the file into the three-file representation before compilation.
+
+---
+
+## §8 Out of Scope
+
+The following are explicitly not part of mosmodel:
+
+- Layout primitives (Box, Row, Column, Text, etc.) — see `moslayout`
+- Style properties (color, font, border, etc.) — see `mosstyle`
+- Animations and transitions — see `mosstyle`
+- Platform-specific variants — see `moslayout`
+- Behavior, event routing logic, conditional rendering — all belong in the host
+  application that wires slots and handles emits
+- Validation of slot values (e.g. "row must be ≥ 0") — belongs in the host
+- Default slot values for `image`, `color`, `list`, and component types — these
+  require the host to supply a concrete value
+
+---
+
+## §9 Future Extensions
+
+- **Slot groups** — a named bundle of related slots (`group viewport { offset, rows, count }`)
+  for components with many slots, giving the host a single object to pass.
+- **Computed slots** — a slot whose value is derived from other slots at the
+  interface level (e.g. `slot page-count = ceil(total-rows / page-size)`).
+  Kept out of v1 to preserve the "interface only, no logic" invariant.
+- **Slot validation attributes** — `slot row : number where row >= 0` — compile-time
+  annotation that the emitter can use to generate runtime assertions at the
+  host boundary.
+- **Versioning** — `component Grid version 2` — enables breaking changes to the
+  interface with explicit version negotiation.

--- a/code/specs/UI14-moslayout.md
+++ b/code/specs/UI14-moslayout.md
@@ -1,0 +1,584 @@
+# moslayout — Component Layout Language
+
+## Overview
+
+`moslayout` is a strictly compiled language for declaring the **structural
+arrangement** of a UI component. A `.moslayout` file answers exactly one
+question: *how are a component's primitives arranged in space, and how do they
+connect to the component's interface?*
+
+It does this by wiring `mosmodel` slot and emit names to a fixed vocabulary of
+layout primitives (Box, Row, Column, Text, Image, Spacer, Scroll, Grid). The
+compiler knows exactly which primitives exist and what structural properties
+each accepts. Anything outside that vocabulary is a compile error.
+
+Three things are explicitly forbidden in `.moslayout` files:
+
+1. **Style properties** — no color, font, border, shadow, opacity, or any other
+   visual property. These belong in `.mosstyle`.
+2. **Arbitrary logic** — no `if` statements, no loops, no expressions beyond
+   slot references. Conditional structure is handled by platform-specific layout
+   variants.
+3. **Slot mutation** — the layout renders slot values; it cannot change them.
+
+This boundary means a UI engineer can evolve the layout — rearrange primitives,
+change nesting, produce a completely different mobile variant — without touching
+the mosmodel interface or the mosstyle file.
+
+---
+
+## Position in the Stack
+
+```
+mosmodel (.mosmodel)          ← UI13-mosmodel.md
+     │  exports: slot names, emit names
+     ▼
+moslayout (.moslayout)        ← THIS SPEC
+     │  exports: part names
+     ▼
+mosstyle (.mosstyle)          ← UI15-mosstyle.md
+     │  references: part names, token names
+     ▼
+backend emitter
+```
+
+The `moslayout` compiler imports the interface descriptor from `mosmodel` and
+validates every slot and emit reference against it. It exports a **part map** —
+named layout nodes that `mosstyle` can style independently.
+
+---
+
+## §1 Platform Variants
+
+A component may have multiple layout files, one per target platform:
+
+```
+Button.mosmodel              ← universal interface
+Button.moslayout             ← default layout (used if no better match)
+Button.desktop.moslayout     ← desktop override
+Button.mobile.moslayout      ← mobile override
+Button.watch.moslayout       ← watch override
+```
+
+The compiler selects the most specific layout file for the target backend. If
+`Button.mobile.moslayout` exists and the target is iOS, it is used. If not, it
+falls back to `Button.moslayout`. All variants are validated against the same
+`Button.mosmodel` interface — they all reference the same slot and emit names.
+
+Platform tokens used in file names:
+
+| Token | Targets |
+|---|---|
+| `desktop` | macOS, Windows, Linux |
+| `mobile` | iOS, Android |
+| `tablet` | iPadOS, Android tablet |
+| `watch` | watchOS, Wear OS |
+| `tv` | tvOS, Android TV |
+
+---
+
+## §2 Primitives
+
+The primitive vocabulary is closed. The compiler knows every primitive. Any
+identifier used in layout position that is not in this table is a compile error.
+
+### Box
+
+A rectangular container. The foundational primitive. Everything else composes
+from Box.
+
+```
+Box { … }
+Box [ part-name ] { … }
+```
+
+Structural properties (all optional):
+
+| Property | Type | Description |
+|---|---|---|
+| `direction` | `row` \| `column` | Flex direction. Default: `column`. |
+| `align` | `start` \| `center` \| `end` \| `stretch` | Cross-axis alignment. Default: `stretch`. |
+| `justify` | `start` \| `center` \| `end` \| `space-between` \| `space-around` | Main-axis distribution. Default: `start`. |
+| `wrap` | `bool` | Allow children to wrap. Default: `false`. |
+| `grow` | `number` | Flex grow factor. Default: `0`. |
+| `shrink` | `number` | Flex shrink factor. Default: `1`. |
+| `clip` | `bool` | Clip overflowing children. Default: `false`. |
+| `focusable` | `bool` | Whether Box can receive keyboard focus. Default: `false`. |
+| `connects` | `emit-name` | Wires a mosmodel emit to this Box's native click event. |
+
+### Row
+
+Shorthand for `Box(direction: row)`. Accepts the same structural properties as
+Box except `direction`.
+
+```
+Row { … }
+Row [ part-name ] { … }
+```
+
+### Column
+
+Shorthand for `Box(direction: column)`. Accepts the same structural properties
+as Box except `direction`.
+
+```
+Column { … }
+Column [ part-name ] { … }
+```
+
+### Text
+
+Renders a text value from a slot.
+
+```
+Text ( slot: <slot-name> )
+Text [ part-name ] ( slot: <slot-name> )
+```
+
+The slot must be of type `text`. The visual properties of the text (font,
+color, size, weight) are declared in `.mosstyle`, not here.
+
+### Image
+
+Renders an image value from a slot.
+
+```
+Image ( slot: <slot-name> )
+Image [ part-name ] ( slot: <slot-name> )
+```
+
+The slot must be of type `image`.
+
+### Spacer
+
+A flexible empty space that expands to fill available room.
+
+```
+Spacer
+Spacer ( grow: <number> )
+```
+
+`grow` defaults to `1`. Multiple Spacers in a flex container divide available
+space proportionally by their grow values.
+
+### Scroll
+
+A scrollable container. Children that overflow the scroll axis are clipped; the
+scroll direction is navigable.
+
+```
+Scroll { … }
+Scroll [ part-name ] { … }
+Scroll ( direction: horizontal ) { … }
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `direction` | `vertical` \| `horizontal` \| `both` | Scroll axis. Default: `vertical`. |
+| `connects-scroll` | `emit-name` | Wires a mosmodel emit to the scroll position change event. |
+
+### Grid
+
+A high-performance virtual-scrolling grid primitive. The host provides only the
+visible viewport slice; Grid manages scrolling internally and fires the `onScroll`
+emit when the viewport must change.
+
+```
+Grid [ part-name ] (
+  headers:        slot: <slot-name> ,
+  widths:         slot: <slot-name> ,
+  rows:           slot: <slot-name> ,
+  selected-row:   slot: <slot-name> ,
+  selected-col:   slot: <slot-name> ,
+  edit-row:       slot: <slot-name> ,
+  edit-col:       slot: <slot-name> ,
+  edit-content:   slot: <slot-name> ,
+  on-navigate:    emit: <emit-name> ,
+  on-edit-start:  emit: <emit-name> ,
+  on-edit-commit: emit: <emit-name> ,
+  on-edit-cancel: emit: <emit-name> ,
+  on-scroll:      emit: <emit-name>
+)
+```
+
+All bindings are optional; unbound slots use zero values, unbound emits are
+silently ignored. The Grid primitive is implemented natively per backend — it is
+not composed from smaller primitives.
+
+---
+
+## §3 Part Names
+
+A **part** is a named layout node. Parts are the hook that `mosstyle` uses to
+apply visual properties to specific elements. Without a part name, a node is
+anonymous and cannot be individually styled.
+
+Part names are declared inline with square brackets:
+
+```
+Box [ container ] {
+  Image [ icon ] ( slot: icon )
+  Text  [ label ] ( slot: label )
+}
+```
+
+This exports three parts: `container`, `icon`, `label`. The mosstyle compiler
+validates that every part name it references exists in this export list.
+
+Part names follow `kebab-case`. They must be unique within a component layout.
+The compiler rejects duplicate part names.
+
+---
+
+## §4 Emit Wiring
+
+Emits declared in `mosmodel` are wired to primitive events using the `connects`
+property. The compiler validates that the emit name exists in the interface
+descriptor.
+
+```
+Box [ button-root ] ( focusable: true, connects: onClick ) {
+  Text [ label ] ( slot: label )
+}
+```
+
+Here, the native click event on `button-root` is wired to the `onClick` emit.
+Each backend translates this wiring to its native event mechanism:
+
+- **Metal / paint-vm** — pointer-up inside bounds calls the `on_click` closure
+- **AppKit** — `NSTrackingArea` triggers the event
+- **Web Component** — `addEventListener('click', …)` dispatches `CustomEvent('onClick')`
+- **React** — becomes the `onClick` prop
+
+---
+
+## §5 Complete Component Examples
+
+### Button
+
+```moslayout
+layout Button {
+  Box [ root ] ( direction: row, align: center,
+                 focusable: true, connects: onClick ) {
+    Image [ icon ]  ( slot: icon )
+    Text  [ label ] ( slot: label )
+  }
+}
+```
+
+Exports parts: `root`, `icon`, `label`.
+
+### Button — mobile variant (`Button.mobile.moslayout`)
+
+Same interface, different structure. The mobile variant stacks vertically and
+uses a larger touch target.
+
+```moslayout
+layout Button {
+  Box [ root ] ( direction: column, align: center,
+                 focusable: true, connects: onClick ) {
+    Image [ icon ]  ( slot: icon )
+    Text  [ label ] ( slot: label )
+  }
+}
+```
+
+### FormulaBar
+
+```moslayout
+layout FormulaBar {
+  Row [ root ] {
+    Text  [ address ] ( slot: cell-address )
+    Box   [ divider ] {}
+    Text  [ formula ] ( slot: formula )
+  }
+}
+```
+
+Exports parts: `root`, `address`, `divider`, `formula`.
+
+### SpreadsheetWorkbook
+
+```moslayout
+layout SpreadsheetWorkbook {
+  Column [ root ] {
+    Row [ toolbar ] {
+      // toolbar content provided by nested components
+    }
+
+    FormulaBar [ formula-bar ] (
+      slot cell-address: slot: active-cell-address ,
+      slot formula:      slot: active-cell-formula
+    )
+
+    Grid [ cell-grid ] (
+      headers:        slot: column-headers ,
+      widths:         slot: column-widths  ,
+      rows:           slot: viewport-rows  ,
+      selected-row:   slot: selected-row   ,
+      selected-col:   slot: selected-col   ,
+      edit-row:       slot: edit-row       ,
+      edit-col:       slot: edit-col       ,
+      edit-content:   slot: edit-content   ,
+      on-navigate:    emit: onNavigate     ,
+      on-edit-start:  emit: onEditStart    ,
+      on-edit-commit: emit: onEditCommit   ,
+      on-edit-cancel: emit: onEditCancel   ,
+      on-scroll:      emit: onScroll
+    )
+
+    Row [ status-bar ] {}
+  }
+}
+```
+
+---
+
+## §6 Grammar
+
+### Token file (`moslayout.tokens`)
+
+```
+# Keywords (must precede IDENT)
+KW_LAYOUT     = "layout"
+KW_SLOT       = "slot"
+KW_EMIT       = "emit"
+KW_BOX        = "Box"
+KW_ROW        = "Row"
+KW_COLUMN     = "Column"
+KW_TEXT       = "Text"
+KW_IMAGE      = "Image"
+KW_SPACER     = "Spacer"
+KW_SCROLL     = "Scroll"
+KW_GRID       = "Grid"
+
+KW_DIRECTION  = "direction"
+KW_ALIGN      = "align"
+KW_JUSTIFY    = "justify"
+KW_WRAP       = "wrap"
+KW_GROW       = "grow"
+KW_SHRINK     = "shrink"
+KW_CLIP       = "clip"
+KW_FOCUSABLE  = "focusable"
+KW_CONNECTS   = "connects"
+
+# Value keywords
+KW_ROW_DIR    = "row"
+KW_COLUMN_DIR = "column"
+KW_START      = "start"
+KW_CENTER     = "center"
+KW_END        = "end"
+KW_STRETCH    = "stretch"
+KW_SPACE_BTW  = "space-between"
+KW_SPACE_ARD  = "space-around"
+KW_VERTICAL   = "vertical"
+KW_HORIZONTAL = "horizontal"
+KW_BOTH       = "both"
+KW_TRUE       = "true"
+KW_FALSE      = "false"
+
+# Identifiers and numbers
+IDENT         = /[a-zA-Z][a-zA-Z0-9]*/
+KEBAB_IDENT   = /[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*/
+NUMBER        = /[0-9]+(\.[0-9]+)?/
+
+# Punctuation
+LBRACE        = "{"
+RBRACE        = "}"
+LPAREN        = "("
+RPAREN        = ")"
+LBRACKET      = "["
+RBRACKET      = "]"
+COLON         = ":"
+COMMA         = ","
+
+# Whitespace and comments — skipped
+WHITESPACE    = /\s+/           skip
+LINE_COMMENT  = /\/\/[^\n]*/   skip
+BLOCK_COMMENT = /\/\*.*?\*\//  skip
+```
+
+### Grammar file (`moslayout.grammar`)
+
+```
+moslayout_file = layout_def ;
+
+layout_def = KW_LAYOUT IDENT LBRACE { node } RBRACE ;
+
+node = box_node | row_node | column_node | text_node | image_node
+     | spacer_node | scroll_node | grid_node | component_node ;
+
+# Part name is optional on every node
+part_name = LBRACKET KEBAB_IDENT RBRACKET ;
+
+# Box
+box_node = KW_BOX [ part_name ] [ LPAREN box_props RPAREN ]
+           LBRACE { node } RBRACE ;
+
+box_props = box_prop { COMMA box_prop } ;
+
+box_prop = KW_DIRECTION COLON direction_val
+         | KW_ALIGN     COLON align_val
+         | KW_JUSTIFY   COLON justify_val
+         | KW_WRAP      COLON bool_val
+         | KW_GROW      COLON NUMBER
+         | KW_SHRINK    COLON NUMBER
+         | KW_CLIP      COLON bool_val
+         | KW_FOCUSABLE COLON bool_val
+         | KW_CONNECTS  COLON KEBAB_IDENT ;   # emit name
+
+direction_val = KW_ROW_DIR | KW_COLUMN_DIR ;
+align_val     = KW_START | KW_CENTER | KW_END | KW_STRETCH ;
+justify_val   = KW_START | KW_CENTER | KW_END | KW_SPACE_BTW | KW_SPACE_ARD ;
+bool_val      = KW_TRUE | KW_FALSE ;
+
+# Row — shorthand for Box(direction: row)
+row_node = KW_ROW [ part_name ] [ LPAREN box_props RPAREN ]
+           LBRACE { node } RBRACE ;
+
+# Column — shorthand for Box(direction: column)
+column_node = KW_COLUMN [ part_name ] [ LPAREN box_props RPAREN ]
+              LBRACE { node } RBRACE ;
+
+# Text
+text_node = KW_TEXT [ part_name ] LPAREN KW_SLOT COLON KEBAB_IDENT RPAREN ;
+
+# Image
+image_node = KW_IMAGE [ part_name ] LPAREN KW_SLOT COLON KEBAB_IDENT RPAREN ;
+
+# Spacer
+spacer_node = KW_SPACER [ LPAREN KW_GROW COLON NUMBER RPAREN ] ;
+
+# Scroll
+scroll_node = KW_SCROLL [ part_name ] [ LPAREN scroll_props RPAREN ]
+              LBRACE { node } RBRACE ;
+
+scroll_props = scroll_prop { COMMA scroll_prop } ;
+
+scroll_prop = KW_DIRECTION COLON scroll_dir_val
+            | "connects-scroll" COLON KEBAB_IDENT ;
+
+scroll_dir_val = KW_VERTICAL | KW_HORIZONTAL | KW_BOTH ;
+
+# Grid
+grid_node = KW_GRID [ part_name ] LPAREN grid_bindings RPAREN ;
+
+grid_bindings = grid_binding { COMMA grid_binding } ;
+
+grid_binding = KEBAB_IDENT COLON ( KW_SLOT | KW_EMIT ) COLON KEBAB_IDENT ;
+
+# Component reference — another mosmodel component used as a child
+component_node = IDENT [ part_name ] LPAREN component_bindings RPAREN ;
+
+component_bindings = component_binding { COMMA component_binding } ;
+
+component_binding = KW_SLOT KEBAB_IDENT COLON KW_SLOT COLON KEBAB_IDENT
+                  | KW_SLOT KEBAB_IDENT COLON KW_EMIT COLON KEBAB_IDENT ;
+```
+
+---
+
+## §7 Compiler Behaviour
+
+### Inputs
+
+1. A `.moslayout` file (or platform-specific variant).
+2. The interface descriptor JSON exported by the `mosmodel` compiler for the
+   same component.
+
+### Validation
+
+1. **Slot references** — every `slot: <name>` reference must name a slot
+   declared in the interface descriptor. Type compatibility is checked: a `Text`
+   node's slot must be of type `text`; an `Image` node's slot must be of type
+   `image`; a `Grid` binding for `rows` must be of type `list<list<text>>`.
+2. **Emit references** — every `connects: <name>` and `emit: <name>` reference
+   must name an emit declared in the interface descriptor.
+3. **No style properties** — the grammar admits no color, font, border, opacity,
+   or similar visual properties. This is enforced structurally — they are not in
+   the grammar, so they cannot be written.
+4. **Unique part names** — no two nodes in the same layout share a part name.
+5. **Valid nesting** — `Text`, `Image`, and `Spacer` are leaf nodes; they may
+   not contain children. `Box`, `Row`, `Column`, and `Scroll` are containers.
+   `Grid` is a self-contained leaf.
+6. **Known primitives** — only the primitives listed in §2 are valid at node
+   positions. An unknown identifier at a node position is a compile error.
+
+### Outputs
+
+**1. Part map (internal, JSON)**
+
+```json
+{
+  "component": "Button",
+  "platform": "default",
+  "parts": [
+    { "name": "root",  "primitive": "Box",   "connects": "onClick" },
+    { "name": "icon",  "primitive": "Image"  },
+    { "name": "label", "primitive": "Text"   }
+  ]
+}
+```
+
+This is consumed by the `mosstyle` compiler to validate part name references.
+
+**2. Layout IR**
+
+A resolved layout tree (LayoutNode format per `UI02-layout-ir.md`) with slot
+values represented as named references rather than concrete values. The backend
+emitter resolves named references to actual slot values at render time.
+
+---
+
+## §8 Backend Mapping
+
+Each backend translates the layout IR to its native layout primitives:
+
+| Primitive | Metal / paint-vm | AppKit | Web Component | React | Qt |
+|---|---|---|---|---|---|
+| Box / Row / Column | LayoutNode (flexbox) | NSStackView | `<div>` with flex CSS | `<div>` with inline style | QBoxLayout |
+| Text | PaintGlyphRun | NSTextField (non-editable) | `<span>` | `<span>` | QLabel |
+| Image | PaintImage | NSImageView | `<img>` | `<img>` | QLabel (pixmap) |
+| Spacer | flex-grow LayoutNode | NSLayoutGuide | `<div style="flex:1">` | `<div style="flex:1"}>` | QSpacerItem |
+| Scroll | LayoutNode + clip | NSScrollView | `<div style="overflow:auto">` | `<div style="overflow:auto">` | QScrollArea |
+| Grid | Grid primitive (native per backend) | NSTableView | `<canvas>` + ARIA grid | virtualized div grid | QTableView |
+
+---
+
+## §9 Error Messages
+
+| Error | Condition | Example message |
+|---|---|---|
+| `UnknownSlot` | `slot: foo` where `foo` not in interface | `Unknown slot 'foo' at line 8 — Grid declares no slot named 'foo'` |
+| `UnknownEmit` | `connects: bar` where `bar` not in interface | `Unknown emit 'bar' at line 12 — Button declares no emit named 'bar'` |
+| `SlotTypeMismatch` | Slot type incompatible with primitive | `Text node at line 6 requires a text slot, but 'total-rows' is number` |
+| `DuplicatePart` | Two nodes share a part name | `Duplicate part name 'label' at line 15` |
+| `LeafHasChildren` | Children inside Text, Image, or Spacer | `Text is a leaf node and cannot have children at line 9` |
+| `UnknownPrimitive` | Unknown identifier in node position | `Unknown primitive 'Divider' at line 20 — valid primitives are: Box, Row, Column, Text, Image, Spacer, Scroll, Grid` |
+| `UnknownComponent` | Component reference not in library | `Component 'FormulaBar' not found in component library at line 25` |
+
+---
+
+## §10 Relationship to Other Specs
+
+- **UI02-layout-ir.md** — the internal LayoutNode tree format that the moslayout
+  compiler produces as its layout IR output.
+- **UI03-layout-flexbox.md** — the flexbox algorithm that resolves the layout IR
+  to positioned nodes for backends that use flexbox (paint-vm, web).
+- **UI13-mosmodel.md** — the interface descriptor that this compiler imports for
+  slot and emit validation.
+- **UI15-mosstyle.md** — imports the part map that this compiler exports.
+
+---
+
+## §11 Out of Scope
+
+- Style properties of any kind — see `mosstyle`
+- Animations and transitions — see `mosstyle`
+- Conditional rendering based on slot values — the host changes slot values;
+  the layout always renders its full structure. Visibility as a style concern
+  (opacity: 0, display: none) belongs in `mosstyle` state declarations.
+- Computed layout values (e.g. `grow: total-rows / 10`) — all structural
+  property values are static literals
+- Arbitrary nested component composition beyond the one level shown in
+  `component_node` — deep trees are assembled by the host application

--- a/code/specs/UI15-mosstyle.md
+++ b/code/specs/UI15-mosstyle.md
@@ -1,0 +1,678 @@
+# mosstyle — Component Style Language
+
+## Overview
+
+`mosstyle` is a strictly compiled language for declaring the **visual
+appearance** of a UI component. A `.mosstyle` file answers exactly one question:
+*what do the parts of this component look like, in each of their possible
+states?*
+
+It does this by assigning visual properties to named **parts** (declared in
+`.moslayout`) across named **states** (normal, hover, pressed, disabled,
+focused). All values are expressed as design tokens resolved at compile time.
+No token reaches the runtime unresolved.
+
+Three things are explicitly forbidden in `.mosstyle` files:
+
+1. **Layout properties** — no direction, alignment, flex-grow, or anything
+   structural. Those belong in `.moslayout`.
+2. **Slot or emit references** — the style layer has no knowledge of the
+   component's interface. It knows part names only.
+3. **Arbitrary logic** — no conditionals, no loops, no expressions beyond
+   Lattice-compatible value computation (arithmetic, color functions, token
+   references).
+
+This boundary means a designer can retheme an entire component library by
+supplying a single override style file. They never touch `.mosmodel` or
+`.moslayout`. The compiler validates the override is complete and type-correct
+before anything runs.
+
+---
+
+## Position in the Stack
+
+```
+mosmodel (.mosmodel)          ← UI13-mosmodel.md
+     │
+moslayout (.moslayout)        ← UI14-moslayout.md
+     │  exports: part names
+     ▼
+mosstyle (.mosstyle)          ← THIS SPEC
+     │  imports: part names, token values
+     │  exports: resolved style map per part per state
+     ▼
+backend emitter
+     │
+     ├── DOM / Web Component  → scoped CSS
+     ├── AppKit               → NSColor, NSFont, CALayer values
+     ├── paint-vm / Metal     → Color structs, f32 values in PaintRect calls
+     └── Qt                   → QPalette, QFont, QSS values
+```
+
+---
+
+## §1 Design Tokens
+
+A **design token** is a named, typed value that represents a single visual
+decision: a color, a size, a font, a duration. Components reference token names,
+not concrete values. Concrete values are supplied by a token file that can be
+swapped to retheme the entire system.
+
+### Token types
+
+| Type | Example values |
+|---|---|
+| `color` | `#1e1e1e`, `rgba(0,0,0,0.5)` |
+| `length` | `4px`, `1.5rem`, `8pt` |
+| `number` | `0.4`, `1`, `2` |
+| `duration` | `120ms`, `0.3s` |
+| `easing` | `ease-out`, `linear`, `cubic-bezier(0.4,0,0.2,1)` |
+| `font-family` | `"Inter"`, `"system-ui"` |
+| `font-weight` | `400`, `600`, `bold` |
+
+### Token declaration
+
+Token files use Lattice syntax. Every token in a base theme file is declared
+with `!default` so it can be overridden by a consuming theme:
+
+```lattice
+// tokens/base.lattice
+
+$color-surface:       #1e1e1e  !default;
+$color-surface-hover: lighten(#1e1e1e, 10%) !default;  // computed from base
+$color-text-primary:  #ffffff  !default;
+$color-text-muted:    rgba(255,255,255,0.6) !default;
+$color-accent:        #4a90d9  !default;
+$color-border:        rgba(255,255,255,0.12) !default;
+$color-danger:        #e53e3e  !default;
+
+$radius-sm:           4px   !default;
+$radius-md:           8px   !default;
+$radius-lg:           12px  !default;
+
+$spacing-xs:          4px   !default;
+$spacing-sm:          8px   !default;
+$spacing-md:          16px  !default;
+$spacing-lg:          24px  !default;
+
+$font-family-body:    "Inter", system-ui !default;
+$font-size-sm:        12px !default;
+$font-size-body:      14px !default;
+$font-size-lg:        18px !default;
+$font-weight-normal:  400  !default;
+$font-weight-bold:    600  !default;
+
+$duration-fast:       80ms  !default;
+$duration-normal:     150ms !default;
+$duration-slow:       300ms !default;
+$easing-out:          ease-out !default;
+$easing-spring:       cubic-bezier(0.34, 1.56, 0.64, 1) !default;
+
+$opacity-disabled:    0.4 !default;
+```
+
+A brand theme overrides only what it needs to change:
+
+```lattice
+// tokens/acme-brand.lattice  — loaded before base.lattice
+$color-accent:  #ff6b00;
+$color-surface: #0a0a0a;
+// Everything else falls through to base.lattice defaults
+```
+
+---
+
+## §2 Style Properties
+
+The set of visual properties is closed. The compiler knows every property name
+and its expected token type. Specifying an unknown property name is a compile
+error.
+
+### Color properties
+
+| Property | Token type | Description |
+|---|---|---|
+| `background` | `color` | Fill color of the part's bounding box |
+| `color` | `color` | Foreground / text color |
+| `border-color` | `color` | Color of the border stroke |
+| `outline-color` | `color` | Color of the focus outline (drawn outside border) |
+| `shadow-color` | `color` | Color of the drop shadow |
+
+### Geometry properties
+
+| Property | Token type | Description |
+|---|---|---|
+| `border-radius` | `length` | Corner rounding radius |
+| `border-width` | `length` | Width of border stroke |
+| `outline-width` | `length` | Width of focus outline |
+| `padding` | `length` | Inner spacing (shorthand: all four sides) |
+| `padding-top` | `length` | Top inner spacing |
+| `padding-right` | `length` | Right inner spacing |
+| `padding-bottom` | `length` | Bottom inner spacing |
+| `padding-left` | `length` | Left inner spacing |
+| `gap` | `length` | Spacing between children (mirrors flex gap) |
+| `shadow-radius` | `length` | Blur radius of the drop shadow |
+| `shadow-offset-x` | `length` | Horizontal shadow offset |
+| `shadow-offset-y` | `length` | Vertical shadow offset |
+
+### Typography properties (valid on `Text` parts only)
+
+| Property | Token type | Description |
+|---|---|---|
+| `font-family` | `font-family` | Font face |
+| `font-size` | `length` | Type size |
+| `font-weight` | `font-weight` | Weight (400 = regular, 600 = semi-bold, 700 = bold) |
+| `line-height` | `number` | Line height multiplier (unitless) |
+| `letter-spacing` | `length` | Tracking |
+| `text-align` | `start` \| `center` \| `end` | Horizontal alignment |
+| `text-decoration` | `none` \| `underline` | Decoration |
+
+### Visibility / compositing properties
+
+| Property | Token type | Description |
+|---|---|---|
+| `opacity` | `number` | 0.0 (transparent) to 1.0 (opaque) |
+
+---
+
+## §3 State Declarations
+
+States represent interactive conditions. Visual properties inside a state block
+apply when the component is in that state; they override the base properties.
+
+### Built-in states
+
+| State | When active |
+|---|---|
+| (none) | Always — the baseline appearance |
+| `hover` | Pointer is over the part (desktop / trackpad only) |
+| `pressed` | Pointer is down within the part |
+| `focused` | Part has keyboard focus |
+| `disabled` | The component's `disabled` slot is `true` |
+| `selected` | The part is in a selected state (e.g. a grid row) |
+| `editing` | The part is in edit mode (e.g. an active grid cell) |
+| `error` | The component is in an error state |
+
+State blocks are additive: only properties listed inside the block change. All
+other properties retain their base values.
+
+---
+
+## §4 Animation and Transition Declarations
+
+Transitions describe how properties animate when their state changes. They live
+in `.mosstyle` because they are a presentational concern — whether a hover
+change is instant or animated is the designer's decision, not the engineer's.
+
+```
+transition <property> <duration-token> <easing-token> ;
+transition <property> <duration-token> ;          // easing defaults to ease-out
+```
+
+A `transition` declaration inside a state block applies when **entering** that
+state. A `transition` declaration at the base level applies to **all** state
+changes for that property.
+
+Keyframe animations (for non-state-driven motion) are declared with `@keyframes`
+(Lattice-compatible syntax):
+
+```
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+```
+
+Then applied to a part:
+
+```
+animation: spin $duration-slow linear infinite ;
+```
+
+Animation declarations are v1-deferred for native backends; they are fully
+supported for the DOM backend in v1.
+
+---
+
+## §5 The Override / Cascade System
+
+When multiple style files apply to a component, the compiler resolves them in
+priority order from lowest to highest:
+
+```
+1. Component base styles        (Button.mosstyle — lowest priority)
+2. Platform token overrides     (ios-tokens.lattice, desktop-tokens.lattice)
+3. Brand theme                  (acme-brand.lattice)
+4. Color scheme                 (dark.lattice, light.lattice)
+5. Component-specific override  (highest priority)
+```
+
+Each layer is a `.lattice` token file. Because component base styles declare
+all tokens with `!default`, a higher-priority file that declares the same token
+without `!default` wins automatically.
+
+The compiler:
+1. Loads token files in priority order (highest-priority first).
+2. Runs the Lattice transformer to resolve all variables, functions, and
+   expressions to concrete values.
+3. Validates the fully-resolved token map against the mosstyle property
+   declarations for the component.
+4. Emits the final concrete style map — no tokens remain in the output.
+
+**Warning on undefined tokens:** if a property references a token that is not
+defined anywhere in the chain, compilation fails with a clear error message.
+
+**Warning on unused tokens:** if a token is defined in a theme file but no
+component in the target set references it, the compiler warns. This prevents
+dead token accumulation in theme files.
+
+---
+
+## §6 Complete Component Examples
+
+### Button
+
+```mosstyle
+style Button {
+
+  // Root — the clickable container
+  part root {
+    background:    $color-surface ;
+    border-radius: $radius-sm ;
+    border-width:  1px ;
+    border-color:  $color-border ;
+    padding:       $spacing-xs $spacing-md ;
+    gap:           $spacing-xs ;
+
+    transition background $duration-fast $easing-out ;
+    transition border-color $duration-fast $easing-out ;
+
+    state hover {
+      background:   $color-surface-hover ;
+      border-color: $color-accent ;
+    }
+
+    state pressed {
+      background: darken($color-surface, 8%) ;
+    }
+
+    state focused {
+      outline-color: $color-accent ;
+      outline-width: 2px ;
+    }
+
+    state disabled {
+      opacity: $opacity-disabled ;
+    }
+  }
+
+  // Icon — the image part
+  part icon {
+    opacity: 0.8 ;
+
+    state disabled {
+      opacity: $opacity-disabled ;
+    }
+  }
+
+  // Label — the text part
+  part label {
+    color:       $color-text-primary ;
+    font-family: $font-family-body ;
+    font-size:   $font-size-body ;
+    font-weight: $font-weight-normal ;
+
+    state disabled {
+      color: $color-text-muted ;
+    }
+  }
+
+}
+```
+
+### Grid — cell styling
+
+```mosstyle
+style Grid {
+
+  part cell-grid {
+    background:   $color-surface ;
+    border-color: $color-border ;
+    border-width: 1px ;
+  }
+
+  part cell {
+    background:   transparent ;
+    color:        $color-text-primary ;
+    font-family:  $font-family-body ;
+    font-size:    $font-size-body ;
+    padding:      $spacing-xs ;
+
+    state selected {
+      background: $color-accent ;
+      color:      #ffffff ;
+    }
+
+    state editing {
+      background:    $color-surface-hover ;
+      outline-color: $color-accent ;
+      outline-width: 2px ;
+    }
+
+    state hover {
+      background: rgba(255,255,255,0.04) ;
+    }
+  }
+
+  part column-header {
+    background:  lighten($color-surface, 5%) ;
+    color:       $color-text-muted ;
+    font-size:   $font-size-sm ;
+    font-weight: $font-weight-bold ;
+    padding:     $spacing-xs ;
+    border-color: $color-border ;
+    border-width: 1px ;
+  }
+
+  part row-header {
+    background:  lighten($color-surface, 5%) ;
+    color:       $color-text-muted ;
+    font-size:   $font-size-sm ;
+    padding:     $spacing-xs ;
+    text-align:  end ;
+  }
+
+}
+```
+
+---
+
+## §7 Grammar
+
+### Token file (`mosstyle.tokens`)
+
+```
+# Keywords
+KW_STYLE      = "style"
+KW_PART       = "part"
+KW_STATE      = "state"
+KW_TRANSITION = "transition"
+KW_ANIMATION  = "animation"
+KW_KEYFRAMES  = "@keyframes"
+KW_FROM       = "from"
+KW_TO         = "to"
+
+# State names
+KW_HOVER      = "hover"
+KW_PRESSED    = "pressed"
+KW_FOCUSED    = "focused"
+KW_DISABLED   = "disabled"
+KW_SELECTED   = "selected"
+KW_EDITING    = "editing"
+KW_ERROR      = "error"
+
+# Identifiers and values
+IDENT         = /[a-zA-Z][a-zA-Z0-9]*/
+KEBAB_IDENT   = /[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*/
+TOKEN_REF     = /\$[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*/  # $token-name
+NUMBER        = /[0-9]+(\.[0-9]+)?/
+DIMENSION     = /[0-9]+(\.[0-9]+)?(px|rem|em|pt|ms|s|deg|%)/
+STRING        = /"([^"\\]|\\.)*"/
+HASH_COLOR    = /#[0-9a-fA-F]{3,8}/
+
+# Punctuation
+LBRACE        = "{"
+RBRACE        = "}"
+LPAREN        = "("
+RPAREN        = ")"
+SEMICOLON     = ";"
+COLON         = ":"
+COMMA         = ","
+
+# Whitespace and comments — skipped
+WHITESPACE    = /\s+/           skip
+LINE_COMMENT  = /\/\/[^\n]*/   skip
+BLOCK_COMMENT = /\/\*.*?\*\//  skip
+```
+
+### Grammar file (`mosstyle.grammar`)
+
+```
+mosstyle_file = style_def ;
+
+style_def = KW_STYLE IDENT LBRACE { part_def } RBRACE ;
+
+part_def = KW_PART KEBAB_IDENT LBRACE { part_item } RBRACE ;
+
+part_item = property_decl
+          | transition_decl
+          | animation_decl
+          | state_block ;
+
+state_block = KW_STATE state_name LBRACE { state_item } RBRACE ;
+
+state_name = KW_HOVER | KW_PRESSED | KW_FOCUSED | KW_DISABLED
+           | KW_SELECTED | KW_EDITING | KW_ERROR ;
+
+state_item = property_decl | transition_decl ;
+
+property_decl = KEBAB_IDENT COLON style_value SEMICOLON ;
+
+style_value = TOKEN_REF
+            | HASH_COLOR
+            | DIMENSION
+            | NUMBER
+            | STRING
+            | IDENT           # keyword values: none, underline, start, center, end, bold
+            | function_call ;
+
+function_call = IDENT LPAREN style_value { COMMA style_value } RPAREN ;
+
+transition_decl = KW_TRANSITION KEBAB_IDENT TOKEN_REF [ TOKEN_REF ] SEMICOLON ;
+                  # property-name  duration-token  optional-easing-token
+
+animation_decl = KW_ANIMATION COLON IDENT TOKEN_REF IDENT [ IDENT ] SEMICOLON ;
+                 # @keyframes-name  duration  easing  fill-mode
+```
+
+The grammar is context-free and LL(1). All state names are keywords, removing
+any ambiguity with part names. All property names are `kebab-case` identifiers
+validated by the semantic layer against the known property table, not by the
+grammar.
+
+---
+
+## §8 Compiler Behaviour
+
+### Inputs
+
+1. A `.mosstyle` file.
+2. The part map JSON exported by the `moslayout` compiler for the same component.
+3. The resolved token map produced by the Lattice transformer (after loading all
+   token files in priority order).
+
+### Validation
+
+1. **Known parts** — every `part <name>` block must correspond to a name in the
+   part map. Referencing a part that does not exist in the layout is an error.
+2. **Known properties** — every property name is checked against the closed
+   property table in §2. Unknown property names are compile errors.
+3. **Type compatibility** — the resolved value for each property must be
+   type-compatible. `background` expects a `color`-typed token; providing a
+   `length` token is a compile error.
+4. **Typography on non-Text parts** — font properties are only valid on parts
+   whose primitive is `Text`. Applying `font-size` to a `Box` part is an error.
+5. **Token resolution** — every `$token-ref` must resolve to a concrete value
+   after the Lattice pass. Unresolved tokens are compile errors.
+6. **Valid states** — only states from the built-in state list are valid inside
+   a state block.
+7. **Transition references** — the property named in a `transition` declaration
+   must be a property declared elsewhere in the same part block.
+
+### Outputs
+
+**1. Resolved style map (internal, JSON)**
+
+After compilation, all tokens are replaced with concrete values. No `$token-ref`
+remains.
+
+```json
+{
+  "component": "Button",
+  "parts": {
+    "root": {
+      "base": {
+        "background":    "#1e1e1e",
+        "border-radius": "4px",
+        "border-width":  "1px",
+        "border-color":  "rgba(255,255,255,0.12)",
+        "padding":       "4px 16px",
+        "gap":           "8px"
+      },
+      "transitions": [
+        { "property": "background",   "duration": "80ms", "easing": "ease-out" },
+        { "property": "border-color", "duration": "80ms", "easing": "ease-out" }
+      ],
+      "states": {
+        "hover":    { "background": "#2e2e2e", "border-color": "#4a90d9" },
+        "pressed":  { "background": "#161616" },
+        "focused":  { "outline-color": "#4a90d9", "outline-width": "2px" },
+        "disabled": { "opacity": "0.4" }
+      }
+    },
+    "label": {
+      "base": {
+        "color":        "#ffffff",
+        "font-family":  "\"Inter\", system-ui",
+        "font-size":    "14px",
+        "font-weight":  "400"
+      },
+      "states": {
+        "disabled": { "color": "rgba(255,255,255,0.6)" }
+      }
+    }
+  }
+}
+```
+
+**2. Backend-specific output**
+
+*DOM / Web Component — scoped CSS:*
+
+```css
+/* Generated — do not edit */
+.mos-Button-root {
+  background:    #1e1e1e;
+  border-radius: 4px;
+  border:        1px solid rgba(255,255,255,0.12);
+  padding:       4px 16px;
+  gap:           8px;
+  transition:    background 80ms ease-out, border-color 80ms ease-out;
+}
+.mos-Button-root:hover    { background: #2e2e2e; border-color: #4a90d9; }
+.mos-Button-root:active   { background: #161616; }
+.mos-Button-root:focus    { outline: 2px solid #4a90d9; }
+.mos-Button-root:disabled { opacity: 0.4; }
+
+.mos-Button-label {
+  color: #ffffff;
+  font-family: "Inter", system-ui;
+  font-size: 14px;
+  font-weight: 400;
+}
+.mos-Button-root:disabled .mos-Button-label { color: rgba(255,255,255,0.6); }
+```
+
+*Metal / paint-vm (Rust):*
+
+```rust
+// Generated — do not edit
+pub struct ButtonStyle {
+  pub root:  RootPartStyle,
+  pub label: LabelPartStyle,
+}
+
+pub struct RootPartStyle {
+  pub background:    Color,
+  pub border_radius: f32,
+  pub border_width:  f32,
+  pub border_color:  Color,
+  pub padding:       EdgeInsets,
+  pub gap:           f32,
+  // states
+  pub hover_background:    Color,
+  pub hover_border_color:  Color,
+  pub pressed_background:  Color,
+  pub focused_outline_color: Color,
+  pub focused_outline_width: f32,
+  pub disabled_opacity:    f32,
+}
+
+impl ButtonStyle {
+  pub fn default() -> Self {
+    Self {
+      root: RootPartStyle {
+        background:    Color::from_hex("#1e1e1e"),
+        border_radius: 4.0,
+        border_width:  1.0,
+        border_color:  Color::rgba(255,255,255,0.12),
+        padding:       EdgeInsets { top: 4.0, right: 16.0, bottom: 4.0, left: 16.0 },
+        gap:           8.0,
+        hover_background:   Color::from_hex("#2e2e2e"),
+        hover_border_color: Color::from_hex("#4a90d9"),
+        pressed_background: Color::from_hex("#161616"),
+        focused_outline_color: Color::from_hex("#4a90d9"),
+        focused_outline_width: 2.0,
+        disabled_opacity: 0.4,
+      },
+      // …
+    }
+  }
+}
+```
+
+---
+
+## §9 Error Messages
+
+| Error | Condition | Example message |
+|---|---|---|
+| `UnknownPart` | Part name not in layout's part map | `Unknown part 'body' at line 4 — Button layout exports: root, icon, label` |
+| `UnknownProperty` | Property name not in property table | `Unknown style property 'flex-direction' at line 8 — layout properties belong in .moslayout` |
+| `TypeMismatch` | Token type incompatible with property | `Property 'background' expects a color token, but '$font-size-body' resolves to a length at line 12` |
+| `TypographyOnNonText` | Font property on non-Text part | `'font-size' is only valid on Text parts, but 'root' is a Box at line 16` |
+| `UnresolvedToken` | Token reference has no definition | `Token '$color-brand-primary' is not defined in any token file at line 9` |
+| `UnusedToken` | Theme token not referenced by any component | `Token '$old-accent-color' defined in acme-brand.lattice is not used by any component` |
+| `UnknownState` | Unrecognised state name | `Unknown state 'hovered' at line 21 — did you mean 'hover'?` |
+| `TransitionPropertyNotDeclared` | Transition references undeclared property | `Transition on 'color' at line 25, but 'color' is not declared in the base style for part 'root'` |
+
+---
+
+## §10 Relationship to Other Specs
+
+- **UI14-moslayout.md** — supplies the part map that this compiler imports.
+- **17-lattice-transpiler.md** and **lattice-v2.md** — the Lattice transformer
+  runs as a pre-pass before this compiler, resolving all token references to
+  concrete values. `mosstyle` consumes the resolved output, not raw Lattice.
+- **UI04-layout-to-paint.md** — for the Metal/paint-vm backend, the resolved
+  style map is consumed here to produce PaintRect, PaintGlyphRun, and
+  PaintPath calls with correct colors, radii, and font metrics.
+
+---
+
+## §11 Out of Scope
+
+- Layout properties (`direction`, `align`, `grow`, etc.) — see `moslayout`
+- Platform-specific layout — see `moslayout`
+- Slot or emit declarations or references — see `mosmodel`
+- Runtime theming (changing tokens after compile time) — the DOM backend
+  naturally supports this via CSS custom properties as a tooling aid during
+  development; production builds use fully resolved concrete values
+- Complex keyframe animations (v1) — fully supported for DOM backend; native
+  backends (Metal, AppKit, Qt) animate via their own animation systems using
+  the duration and easing values from the resolved style map; keyframe support
+  for native backends is a v2 deliverable
+- Conditional styles based on slot values — the host changes slot values and
+  the layout re-renders; visibility and state changes are driven by the host
+  updating the relevant state slot (e.g. `disabled`), not by mosstyle
+  conditionals


### PR DESCRIPTION
## Summary

- UI13-mosmodel: component interface language (slots in, emits out, nothing else)
- UI14-moslayout: structural layout language (primitives wired to slots/emits, no style)
- UI15-mosstyle: visual appearance language (tokens, states, transitions, no layout)

All three compilers enforce separation via grammar. Backend emitter collapses all three into one output file with no runtime overhead.

## Test plan

- [ ] Verify Grid example consistent across all three specs
- [ ] Verify grammars are LL(1)
- [ ] Confirm token cascade uses Lattice !default correctly
