### PR TITLE
build(capability-cage): Rust implementation v1 — manifest, glob, secure_file

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -536,4 +536,5 @@ members = [
     "hue-client",
     "zigbee-zdo",
     "zwave-command-classes",
+    "capability-cage",
 ]

--- a/code/packages/rust/capability-cage/BUILD
+++ b/code/packages/rust/capability-cage/BUILD
@@ -1,0 +1,1 @@
+cargo test -p capability-cage

--- a/code/packages/rust/capability-cage/BUILD_windows
+++ b/code/packages/rust/capability-cage/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p capability-cage

--- a/code/packages/rust/capability-cage/CHANGELOG.md
+++ b/code/packages/rust/capability-cage/CHANGELOG.md
@@ -23,7 +23,8 @@ Initial release. V1 scope per `code/specs/capability-cage-rust.md`:
   - `OpenBackend` — calls stdlib `std::fs`
   - `DenyAllBackend` — refuses every call (good test default)
   - `TestBackend` — records every call, returns scripted responses
-- `with_backend(...)` for scoped process-wide backend swap.
+- `with_backend(...)` for scoped process-wide backend swap, including
+  serialized overrides for parallel test safety.
 - `secure_file` module with `read_file`, `write_file`, `create_file`,
   `delete_file`, `list_dir` — all manifest-checked and delegating to
   the current backend.

--- a/code/packages/rust/capability-cage/CHANGELOG.md
+++ b/code/packages/rust/capability-cage/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## 0.1.0 — 2026-05-08
+
+Initial release. V1 scope per `code/specs/capability-cage-rust.md`:
+
+- `Category` and `Action` enums (8 categories, 14 actions) with the
+  19 valid pairings from the spec.
+- Immutable `Capability` and `Manifest` types.
+- `Manifest::load_from_str` / `Manifest::load_from_file` that parse
+  the `required_capabilities.json` schema and reject invalid
+  combinations (unknown category, unknown action, unsupported pair,
+  empty target).
+- `Manifest::has` / `Manifest::check` with glob matching against
+  manifest targets.
+- Glob matcher (`match_target`) supporting:
+  - exact literal match
+  - `*` (one path component / one wildcard within a segment)
+  - `**` (any number of components)
+  - net targets `host:port` with `*` wildcards on either side
+  - Windows backslashes normalized to `/`
+- `Backend` trait with three implementations:
+  - `OpenBackend` — calls stdlib `std::fs`
+  - `DenyAllBackend` — refuses every call (good test default)
+  - `TestBackend` — records every call, returns scripted responses
+- `with_backend(...)` for scoped process-wide backend swap.
+- `secure_file` module with `read_file`, `write_file`, `create_file`,
+  `delete_file`, `list_dir` — all manifest-checked and delegating to
+  the current backend.
+
+Out of scope for v1 (will land in subsequent PRs):
+
+- Operation/audit envelope (`Operation<T>`, `AuditSink`).
+- Other secure-wrapper categories (`secure_net`, `secure_proc`,
+  `secure_env`, `secure_time`, `secure_stdio`).
+- `build.rs`-driven package_manifest() codegen.
+- Cross-language conformance suite shared with the Go cage.
+- The lint that rejects raw stdlib usage outside of the backend.
+- RWS Phase 1 enforcement (per `read-write-separation.md`).

--- a/code/packages/rust/capability-cage/Cargo.toml
+++ b/code/packages/rust/capability-cage/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "capability-cage"
+version = "0.1.0"
+edition = "2021"
+description = "Rust port of the capability-cage runtime — manifests, secure wrappers, audit envelope"
+
+[dependencies]
+coding-adventures-json-parser = { path = "../json-parser" }
+coding-adventures-json-value  = { path = "../json-value" }

--- a/code/packages/rust/capability-cage/README.md
+++ b/code/packages/rust/capability-cage/README.md
@@ -1,0 +1,108 @@
+# capability-cage
+
+Rust port of `code/packages/go/capability-cage/`. Implements the
+runtime ring of the capability cage: manifest loading, secure
+wrappers, and the swappable `Backend` trait.
+
+See `code/specs/capability-cage-rust.md` for the full design and
+`code/specs/13-capability-security.md` for the cross-language
+taxonomy.
+
+## What this crate is
+
+The cage's job is to ensure that no Rust package in this repo
+performs an OS operation that its `required_capabilities.json`
+hasn't declared. Three rings of enforcement:
+
+1. **Lint-time** — a separate `cargo` lint (future package) flags
+   raw stdlib usage outside of the secure wrappers.
+2. **Runtime** — the secure-wrapper functions in this crate (e.g.
+   `secure_file::read_file`) check the manifest before every OS
+   call.
+3. **Hard-cage** — Tier 2 / 3 agents inject a `HostRpcBackend`
+   (provided by `host-runtime-rust`, future) that routes calls
+   over `secure-host-channel` instead of hitting stdlib at all.
+
+This crate ships rings 2 and 3's seams. The wrappers and the
+`Backend` trait are stable contracts; anything below them is a
+swappable detail.
+
+## Quick example
+
+```rust
+use capability_cage::{Capability, Category, Action, Manifest, secure_file};
+use std::path::Path;
+
+let m = Manifest::new(vec![
+    Capability::new(
+        Category::Fs,
+        Action::Read,
+        "./grammars/*.tokens",
+        "load lexer DFA",
+    ).unwrap(),
+]);
+
+// Reading a file the manifest covers — succeeds (calls OpenBackend).
+let bytes = secure_file::read_file(&m, Path::new("./grammars/json.tokens"))?;
+
+// Reading a path the manifest does NOT cover — fails before any
+// stdlib call. The error wraps a CapabilityViolationError.
+let err = secure_file::read_file(&m, Path::new("/etc/passwd")).unwrap_err();
+assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+```
+
+## Module surface
+
+| Module          | What it does                                           |
+|-----------------|--------------------------------------------------------|
+| (root)          | re-exports of the public API                            |
+| `category`      | `Category`, `Action` enums + valid-pair table           |
+| `capability`    | `Capability` struct (immutable, validated)              |
+| `errors`        | `CapabilityViolationError`, `ManifestError`, `InvalidCombination` |
+| `glob`          | `match_target(pattern, candidate)` for fs / net targets |
+| `manifest`      | `Manifest` with `has`/`check`/`load_from_str`/`load_from_file` |
+| `backend`       | `Backend` trait + `OpenBackend` / `TestBackend` / `DenyAllBackend`, `with_backend(...)` guard |
+| `secure_file`   | `read_file` / `write_file` / `create_file` / `delete_file` / `list_dir` |
+
+## Backend swap
+
+Tests inject a `TestBackend` to assert on the call sequence:
+
+```rust
+use capability_cage::{TestBackend, with_backend, secure_file, ...};
+use std::sync::Arc;
+
+let backend = Arc::new(TestBackend::new().with_response("./out", b"hi"));
+let _guard = with_backend(backend.clone());
+// ... secure-wrapper calls now route through TestBackend ...
+let calls = backend.calls();
+```
+
+Run such tests with `--test-threads=1` for the affected suite —
+the backend slot is process-wide.
+
+## Out of scope (V1)
+
+Spec-defined but landing in subsequent PRs:
+
+- Audit envelope (`Operation<T>`, `AuditSink`)
+- `secure_net` / `secure_proc` / `secure_env` / `secure_time` /
+  `secure_stdio` modules
+- `build.rs` codegen for `package_manifest()`
+- Cross-language conformance suite shared with the Go cage
+- The CI lint that rejects raw stdlib usage
+- RWS Phase 1 enforcement (per `read-write-separation.md`)
+
+## Dependencies
+
+- `coding-adventures-json-parser` — manifest JSON parsing
+- `coding-adventures-json-value`  — typed JSON values
+
+No std-OS access from this crate's own code: everything happens
+inside `Backend` implementations (which the consumer chooses).
+
+## Development
+
+```bash
+bash BUILD          # cargo test -p capability-cage
+```

--- a/code/packages/rust/capability-cage/README.md
+++ b/code/packages/rust/capability-cage/README.md
@@ -78,8 +78,9 @@ let _guard = with_backend(backend.clone());
 let calls = backend.calls();
 ```
 
-Run such tests with `--test-threads=1` for the affected suite —
-the backend slot is process-wide.
+The backend slot is process-wide, but `with_backend` serializes
+overlapping overrides so the crate's own tests can run with Rust's
+default parallel test scheduler.
 
 ## Out of scope (V1)
 

--- a/code/packages/rust/capability-cage/required_capabilities.json
+++ b/code/packages/rust/capability-cage/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/capability-cage",
+  "capabilities": [],
+  "justification": "Pure trait + manifest validator + secure-wrapper layer. The cage performs zero OS I/O of its own; OS access happens only inside Backend implementations, and the OpenBackend in this crate is itself the kernel of every other package's enforcement story. Tests use TestBackend (no real OS access)."
+}

--- a/code/packages/rust/capability-cage/src/backend.rs
+++ b/code/packages/rust/capability-cage/src/backend.rs
@@ -11,7 +11,7 @@
 
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
 /// The contract the cage delegates OS work to.
 ///
@@ -185,10 +185,10 @@ impl Backend for TestBackend {
     }
 
     fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()> {
-        self.log
-            .lock()
-            .unwrap()
-            .push(TestBackendCall::WriteFile(path.to_path_buf(), data.to_vec()));
+        self.log.lock().unwrap().push(TestBackendCall::WriteFile(
+            path.to_path_buf(),
+            data.to_vec(),
+        ));
         Ok(())
     }
 
@@ -231,6 +231,8 @@ impl Backend for TestBackend {
 
 static DEFAULT_BACKEND: once_cell_shim::Lazy<RwLock<Arc<dyn Backend>>> =
     once_cell_shim::Lazy::new(|| RwLock::new(Arc::new(OpenBackend)));
+static BACKEND_OVERRIDE_LOCK: once_cell_shim::Lazy<Mutex<()>> =
+    once_cell_shim::Lazy::new(|| Mutex::new(()));
 
 mod once_cell_shim {
     //! Tiny replacement for `once_cell::sync::Lazy` so we don't take an
@@ -267,6 +269,7 @@ mod once_cell_shim {
 /// Returned by [`with_backend`]. Restores the previous backend on drop.
 pub struct BackendGuard {
     previous: Arc<dyn Backend>,
+    _override_guard: MutexGuard<'static, ()>,
 }
 
 impl Drop for BackendGuard {
@@ -278,17 +281,31 @@ impl Drop for BackendGuard {
 }
 
 /// Replace the process-wide default backend until the returned guard
-/// is dropped. Concurrent test runs must not call this in parallel;
-/// run such tests with `--test-threads=1` if needed.
+/// is dropped.
+///
+/// Only one override can be active at a time. That keeps parallel Rust
+/// tests from restoring each other's process-wide backend mid-call.
 pub fn with_backend(backend: Arc<dyn Backend>) -> BackendGuard {
-    let mut slot = DEFAULT_BACKEND.write().expect("default backend lock poisoned");
+    let override_guard = BACKEND_OVERRIDE_LOCK
+        .lock()
+        .expect("backend override lock poisoned");
+    let mut slot = DEFAULT_BACKEND
+        .write()
+        .expect("default backend lock poisoned");
     let previous = std::mem::replace(&mut *slot, backend);
-    BackendGuard { previous }
+    BackendGuard {
+        previous,
+        _override_guard: override_guard,
+    }
 }
 
 /// Internal accessor for secure-wrapper modules.
 pub(crate) fn current_backend() -> Arc<dyn Backend> {
-    Arc::clone(&DEFAULT_BACKEND.read().expect("default backend lock poisoned"))
+    Arc::clone(
+        &DEFAULT_BACKEND
+            .read()
+            .expect("default backend lock poisoned"),
+    )
 }
 
 #[cfg(test)]
@@ -345,15 +362,16 @@ mod tests {
         b.delete_file(Path::new("./z")).unwrap();
         let calls = b.calls();
         assert_eq!(calls.len(), 3);
-        assert!(matches!(&calls[0], TestBackendCall::WriteFile(p, d) if p == Path::new("./x") && d == b"data"));
+        assert!(
+            matches!(&calls[0], TestBackendCall::WriteFile(p, d) if p == Path::new("./x") && d == b"data")
+        );
         assert!(matches!(&calls[1], TestBackendCall::CreateFile(p) if p == Path::new("./y")));
         assert!(matches!(&calls[2], TestBackendCall::DeleteFile(p) if p == Path::new("./z")));
     }
 
     #[test]
     fn test_backend_dir_listing() {
-        let b = TestBackend::new()
-            .with_dir_response("./dir", vec!["a.txt".into(), "b.txt".into()]);
+        let b = TestBackend::new().with_dir_response("./dir", vec!["a.txt".into(), "b.txt".into()]);
         let entries = b.list_dir(Path::new("./dir")).unwrap();
         assert_eq!(entries, vec!["a.txt".to_string(), "b.txt".to_string()]);
     }

--- a/code/packages/rust/capability-cage/src/backend.rs
+++ b/code/packages/rust/capability-cage/src/backend.rs
@@ -1,0 +1,360 @@
+//! Backend trait and the three default implementations.
+//!
+//! The cage performs the manifest check, then delegates the actual OS
+//! call to a [`Backend`] implementation. The default is [`OpenBackend`]
+//! (calls stdlib). [`TestBackend`] records calls for tests; the
+//! `host-runtime-rust` crate (future) installs its own backend that
+//! routes secure calls over the host channel.
+//!
+//! V1 scope: file-system methods only. Network, process, env, time,
+//! and stdio methods land in subsequent PRs.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, RwLock};
+
+/// The contract the cage delegates OS work to.
+///
+/// Implementations are responsible only for performing the operation;
+/// the manifest check happens before the call in the secure-wrapper
+/// functions.
+pub trait Backend: Send + Sync {
+    fn read_file(&self, path: &Path) -> io::Result<Vec<u8>>;
+    fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()>;
+    fn create_file(&self, path: &Path) -> io::Result<()>;
+    fn delete_file(&self, path: &Path) -> io::Result<()>;
+    fn list_dir(&self, path: &Path) -> io::Result<Vec<String>>;
+}
+
+/// The default backend. Delegates straight to [`std::fs`].
+pub struct OpenBackend;
+
+impl Backend for OpenBackend {
+    fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        std::fs::read(path)
+    }
+
+    fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()> {
+        std::fs::write(path, data)
+    }
+
+    fn create_file(&self, path: &Path) -> io::Result<()> {
+        std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(path)
+            .map(|_| ())
+    }
+
+    fn delete_file(&self, path: &Path) -> io::Result<()> {
+        std::fs::remove_file(path)
+    }
+
+    fn list_dir(&self, path: &Path) -> io::Result<Vec<String>> {
+        let mut names = Vec::new();
+        for entry in std::fs::read_dir(path)? {
+            let entry = entry?;
+            if let Some(name) = entry.file_name().to_str() {
+                names.push(name.to_string());
+            }
+        }
+        Ok(names)
+    }
+}
+
+/// A backend that refuses every call with `PermissionDenied`.
+///
+/// Useful as a default for tests of pure-computation packages: any
+/// accidental OS access fails loud.
+pub struct DenyAllBackend;
+
+impl Backend for DenyAllBackend {
+    fn read_file(&self, _path: &Path) -> io::Result<Vec<u8>> {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "DenyAllBackend refused fs.read",
+        ))
+    }
+
+    fn write_file(&self, _path: &Path, _data: &[u8]) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "DenyAllBackend refused fs.write",
+        ))
+    }
+
+    fn create_file(&self, _path: &Path) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "DenyAllBackend refused fs.create",
+        ))
+    }
+
+    fn delete_file(&self, _path: &Path) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "DenyAllBackend refused fs.delete",
+        ))
+    }
+
+    fn list_dir(&self, _path: &Path) -> io::Result<Vec<String>> {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "DenyAllBackend refused fs.list",
+        ))
+    }
+}
+
+/// A backend that records every call into an internal log. Useful in
+/// tests that assert on the sequence of secure operations.
+///
+/// Reads and lists return scripted responses provided via
+/// [`TestBackend::with_response`]; if no response is scripted,
+/// reads return empty bytes and lists return an empty vector. Writes
+/// / creates / deletes always succeed and are recorded.
+pub struct TestBackend {
+    log: Mutex<Vec<TestBackendCall>>,
+    file_responses: Mutex<Vec<(PathBuf, Vec<u8>)>>,
+    dir_responses: Mutex<Vec<(PathBuf, Vec<String>)>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TestBackendCall {
+    ReadFile(PathBuf),
+    WriteFile(PathBuf, Vec<u8>),
+    CreateFile(PathBuf),
+    DeleteFile(PathBuf),
+    ListDir(PathBuf),
+}
+
+impl TestBackend {
+    pub fn new() -> Self {
+        Self {
+            log: Mutex::new(Vec::new()),
+            file_responses: Mutex::new(Vec::new()),
+            dir_responses: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Script a response for a given path. The next [`Backend::read_file`]
+    /// call against this path returns these bytes.
+    pub fn with_response(self, path: impl Into<PathBuf>, data: impl Into<Vec<u8>>) -> Self {
+        self.file_responses
+            .lock()
+            .unwrap()
+            .push((path.into(), data.into()));
+        self
+    }
+
+    /// Script a response for a directory listing.
+    pub fn with_dir_response(self, path: impl Into<PathBuf>, entries: Vec<String>) -> Self {
+        self.dir_responses
+            .lock()
+            .unwrap()
+            .push((path.into(), entries));
+        self
+    }
+
+    /// Snapshot the call log.
+    pub fn calls(&self) -> Vec<TestBackendCall> {
+        self.log.lock().unwrap().clone()
+    }
+}
+
+impl Default for TestBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Backend for TestBackend {
+    fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        self.log
+            .lock()
+            .unwrap()
+            .push(TestBackendCall::ReadFile(path.to_path_buf()));
+        let data = self
+            .file_responses
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(p, _)| p == path)
+            .map(|(_, d)| d.clone())
+            .unwrap_or_default();
+        Ok(data)
+    }
+
+    fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()> {
+        self.log
+            .lock()
+            .unwrap()
+            .push(TestBackendCall::WriteFile(path.to_path_buf(), data.to_vec()));
+        Ok(())
+    }
+
+    fn create_file(&self, path: &Path) -> io::Result<()> {
+        self.log
+            .lock()
+            .unwrap()
+            .push(TestBackendCall::CreateFile(path.to_path_buf()));
+        Ok(())
+    }
+
+    fn delete_file(&self, path: &Path) -> io::Result<()> {
+        self.log
+            .lock()
+            .unwrap()
+            .push(TestBackendCall::DeleteFile(path.to_path_buf()));
+        Ok(())
+    }
+
+    fn list_dir(&self, path: &Path) -> io::Result<Vec<String>> {
+        self.log
+            .lock()
+            .unwrap()
+            .push(TestBackendCall::ListDir(path.to_path_buf()));
+        let entries = self
+            .dir_responses
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(p, _)| p == path)
+            .map(|(_, e)| e.clone())
+            .unwrap_or_default();
+        Ok(entries)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide default backend slot.
+// ---------------------------------------------------------------------------
+
+static DEFAULT_BACKEND: once_cell_shim::Lazy<RwLock<Arc<dyn Backend>>> =
+    once_cell_shim::Lazy::new(|| RwLock::new(Arc::new(OpenBackend)));
+
+mod once_cell_shim {
+    //! Tiny replacement for `once_cell::sync::Lazy` so we don't take an
+    //! external dep just for this. Single-write semantics; first
+    //! `force` wins.
+    use std::sync::OnceLock;
+
+    pub struct Lazy<T> {
+        cell: OnceLock<T>,
+        init: fn() -> T,
+    }
+
+    impl<T> Lazy<T> {
+        pub const fn new(init: fn() -> T) -> Self {
+            Self {
+                cell: OnceLock::new(),
+                init,
+            }
+        }
+
+        fn force(&self) -> &T {
+            self.cell.get_or_init(self.init)
+        }
+    }
+
+    impl<T> std::ops::Deref for Lazy<T> {
+        type Target = T;
+        fn deref(&self) -> &T {
+            self.force()
+        }
+    }
+}
+
+/// Returned by [`with_backend`]. Restores the previous backend on drop.
+pub struct BackendGuard {
+    previous: Arc<dyn Backend>,
+}
+
+impl Drop for BackendGuard {
+    fn drop(&mut self) {
+        if let Ok(mut slot) = DEFAULT_BACKEND.write() {
+            *slot = Arc::clone(&self.previous);
+        }
+    }
+}
+
+/// Replace the process-wide default backend until the returned guard
+/// is dropped. Concurrent test runs must not call this in parallel;
+/// run such tests with `--test-threads=1` if needed.
+pub fn with_backend(backend: Arc<dyn Backend>) -> BackendGuard {
+    let mut slot = DEFAULT_BACKEND.write().expect("default backend lock poisoned");
+    let previous = std::mem::replace(&mut *slot, backend);
+    BackendGuard { previous }
+}
+
+/// Internal accessor for secure-wrapper modules.
+pub(crate) fn current_backend() -> Arc<dyn Backend> {
+    Arc::clone(&DEFAULT_BACKEND.read().expect("default backend lock poisoned"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deny_all_refuses_everything() {
+        let b = DenyAllBackend;
+        assert_eq!(
+            b.read_file(Path::new("./x")).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            b.write_file(Path::new("./x"), b"y").unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            b.create_file(Path::new("./x")).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            b.delete_file(Path::new("./x")).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            b.list_dir(Path::new("./x")).unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn test_backend_records_and_returns_scripted_response() {
+        let b = TestBackend::new().with_response("./foo", b"hello");
+        let bytes = b.read_file(Path::new("./foo")).unwrap();
+        assert_eq!(bytes, b"hello");
+        let calls = b.calls();
+        assert_eq!(calls.len(), 1);
+        assert!(matches!(&calls[0], TestBackendCall::ReadFile(p) if p == Path::new("./foo")));
+    }
+
+    #[test]
+    fn test_backend_unscripted_read_returns_empty() {
+        let b = TestBackend::new();
+        let bytes = b.read_file(Path::new("./missing")).unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn test_backend_records_writes() {
+        let b = TestBackend::new();
+        b.write_file(Path::new("./x"), b"data").unwrap();
+        b.create_file(Path::new("./y")).unwrap();
+        b.delete_file(Path::new("./z")).unwrap();
+        let calls = b.calls();
+        assert_eq!(calls.len(), 3);
+        assert!(matches!(&calls[0], TestBackendCall::WriteFile(p, d) if p == Path::new("./x") && d == b"data"));
+        assert!(matches!(&calls[1], TestBackendCall::CreateFile(p) if p == Path::new("./y")));
+        assert!(matches!(&calls[2], TestBackendCall::DeleteFile(p) if p == Path::new("./z")));
+    }
+
+    #[test]
+    fn test_backend_dir_listing() {
+        let b = TestBackend::new()
+            .with_dir_response("./dir", vec!["a.txt".into(), "b.txt".into()]);
+        let entries = b.list_dir(Path::new("./dir")).unwrap();
+        assert_eq!(entries, vec!["a.txt".to_string(), "b.txt".to_string()]);
+    }
+}

--- a/code/packages/rust/capability-cage/src/capability.rs
+++ b/code/packages/rust/capability-cage/src/capability.rs
@@ -1,0 +1,93 @@
+//! The atomic Capability declaration.
+
+use crate::category::{is_valid_combination, Action, Category};
+use crate::errors::InvalidCombination;
+
+/// A single OS-level permission declaration.
+///
+/// Capabilities are immutable. Construct via [`Capability::new`], which
+/// validates the (category, action) pair against the cage taxonomy
+/// and rejects empty targets.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Capability {
+    pub category: Category,
+    pub action: Action,
+    pub target: String,
+    pub justification: String,
+}
+
+impl Capability {
+    /// Construct a capability after validating the (category, action)
+    /// pair and the target string.
+    ///
+    /// Returns [`InvalidCombination::UnsupportedPair`] if the pair is
+    /// not in the cage taxonomy, or [`InvalidCombination::EmptyTarget`]
+    /// if the target is empty.
+    pub fn new(
+        category: Category,
+        action: Action,
+        target: impl Into<String>,
+        justification: impl Into<String>,
+    ) -> Result<Self, InvalidCombination> {
+        if !is_valid_combination(category, action) {
+            return Err(InvalidCombination::UnsupportedPair { category, action });
+        }
+        let target = target.into();
+        if target.is_empty() {
+            return Err(InvalidCombination::EmptyTarget);
+        }
+        Ok(Self {
+            category,
+            action,
+            target,
+            justification: justification.into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_capability_round_trips_fields() {
+        let cap = Capability::new(
+            Category::Fs,
+            Action::Read,
+            "./grammars/json.tokens",
+            "load lexer DFA",
+        )
+        .unwrap();
+        assert_eq!(cap.category, Category::Fs);
+        assert_eq!(cap.action, Action::Read);
+        assert_eq!(cap.target, "./grammars/json.tokens");
+        assert_eq!(cap.justification, "load lexer DFA");
+    }
+
+    #[test]
+    fn invalid_pair_rejected() {
+        let err = Capability::new(Category::Fs, Action::Connect, "x", "y").unwrap_err();
+        assert_eq!(
+            err,
+            InvalidCombination::UnsupportedPair {
+                category: Category::Fs,
+                action: Action::Connect,
+            }
+        );
+    }
+
+    #[test]
+    fn empty_target_rejected() {
+        let err = Capability::new(Category::Fs, Action::Read, "", "y").unwrap_err();
+        assert_eq!(err, InvalidCombination::EmptyTarget);
+    }
+
+    #[test]
+    fn capabilities_compare_by_value() {
+        let a = Capability::new(Category::Fs, Action::Read, "x", "j").unwrap();
+        let b = Capability::new(Category::Fs, Action::Read, "x", "j").unwrap();
+        let c = Capability::new(Category::Fs, Action::Read, "y", "j").unwrap();
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/code/packages/rust/capability-cage/src/category.rs
+++ b/code/packages/rust/capability-cage/src/category.rs
@@ -1,0 +1,268 @@
+//! Capability categories and actions.
+//!
+//! The taxonomy is fixed by `capability-cage-rust.md`: 8 categories and
+//! 14 actions. Not every (category, action) pair is meaningful; the
+//! valid pairings are encoded in [`Capability::new`] (see `capability.rs`).
+
+use std::fmt;
+use std::str::FromStr;
+
+/// One of the eight category types in the cage taxonomy.
+///
+/// Adding a category requires a spec amendment and corresponding
+/// updates to the JSON schema and every backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Category {
+    Fs,
+    Net,
+    Proc,
+    Env,
+    Ffi,
+    Time,
+    Stdin,
+    Stdout,
+}
+
+impl Category {
+    /// Lower-case wire form. Stable across versions.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Category::Fs => "fs",
+            Category::Net => "net",
+            Category::Proc => "proc",
+            Category::Env => "env",
+            Category::Ffi => "ffi",
+            Category::Time => "time",
+            Category::Stdin => "stdin",
+            Category::Stdout => "stdout",
+        }
+    }
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Category {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fs" => Ok(Category::Fs),
+            "net" => Ok(Category::Net),
+            "proc" => Ok(Category::Proc),
+            "env" => Ok(Category::Env),
+            "ffi" => Ok(Category::Ffi),
+            "time" => Ok(Category::Time),
+            "stdin" => Ok(Category::Stdin),
+            "stdout" => Ok(Category::Stdout),
+            _ => Err(()),
+        }
+    }
+}
+
+/// One of the fourteen action types in the cage taxonomy.
+///
+/// Adding an action requires a spec amendment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Action {
+    Read,
+    Write,
+    Create,
+    Delete,
+    List,
+    Connect,
+    Listen,
+    Dns,
+    Exec,
+    Fork,
+    Signal,
+    Call,
+    Load,
+    Sleep,
+}
+
+impl Action {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Action::Read => "read",
+            Action::Write => "write",
+            Action::Create => "create",
+            Action::Delete => "delete",
+            Action::List => "list",
+            Action::Connect => "connect",
+            Action::Listen => "listen",
+            Action::Dns => "dns",
+            Action::Exec => "exec",
+            Action::Fork => "fork",
+            Action::Signal => "signal",
+            Action::Call => "call",
+            Action::Load => "load",
+            Action::Sleep => "sleep",
+        }
+    }
+}
+
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Action {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "read" => Ok(Action::Read),
+            "write" => Ok(Action::Write),
+            "create" => Ok(Action::Create),
+            "delete" => Ok(Action::Delete),
+            "list" => Ok(Action::List),
+            "connect" => Ok(Action::Connect),
+            "listen" => Ok(Action::Listen),
+            "dns" => Ok(Action::Dns),
+            "exec" => Ok(Action::Exec),
+            "fork" => Ok(Action::Fork),
+            "signal" => Ok(Action::Signal),
+            "call" => Ok(Action::Call),
+            "load" => Ok(Action::Load),
+            "sleep" => Ok(Action::Sleep),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Returns true if (category, action) is a meaningful pair per the
+/// cage taxonomy.
+///
+/// The valid pairings (from the spec):
+/// ```text
+/// fs       read, write, create, delete, list
+/// net      connect, listen, dns
+/// proc     exec, fork, signal
+/// env      read, write
+/// ffi      call, load
+/// time     read, sleep
+/// stdin    read
+/// stdout   write
+/// ```
+pub fn is_valid_combination(category: Category, action: Action) -> bool {
+    use Action::*;
+    use Category::*;
+    matches!(
+        (category, action),
+        (Fs, Read)
+            | (Fs, Write)
+            | (Fs, Create)
+            | (Fs, Delete)
+            | (Fs, List)
+            | (Net, Connect)
+            | (Net, Listen)
+            | (Net, Dns)
+            | (Proc, Exec)
+            | (Proc, Fork)
+            | (Proc, Signal)
+            | (Env, Read)
+            | (Env, Write)
+            | (Ffi, Call)
+            | (Ffi, Load)
+            | (Time, Read)
+            | (Time, Sleep)
+            | (Stdin, Read)
+            | (Stdout, Write)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_round_trips() {
+        for s in [
+            "fs", "net", "proc", "env", "ffi", "time", "stdin", "stdout",
+        ] {
+            let cat: Category = s.parse().unwrap();
+            assert_eq!(cat.as_str(), s);
+            assert_eq!(format!("{cat}"), s);
+        }
+    }
+
+    #[test]
+    fn action_round_trips() {
+        for s in [
+            "read", "write", "create", "delete", "list", "connect", "listen",
+            "dns", "exec", "fork", "signal", "call", "load", "sleep",
+        ] {
+            let act: Action = s.parse().unwrap();
+            assert_eq!(act.as_str(), s);
+        }
+    }
+
+    #[test]
+    fn unknown_category_rejected() {
+        assert!("network".parse::<Category>().is_err());
+        assert!("".parse::<Category>().is_err());
+    }
+
+    #[test]
+    fn unknown_action_rejected() {
+        assert!("destroy".parse::<Action>().is_err());
+        assert!("".parse::<Action>().is_err());
+    }
+
+    #[test]
+    fn valid_combinations_exhaustive() {
+        // The 19 valid pairs from the spec table.
+        let valid = [
+            (Category::Fs, Action::Read),
+            (Category::Fs, Action::Write),
+            (Category::Fs, Action::Create),
+            (Category::Fs, Action::Delete),
+            (Category::Fs, Action::List),
+            (Category::Net, Action::Connect),
+            (Category::Net, Action::Listen),
+            (Category::Net, Action::Dns),
+            (Category::Proc, Action::Exec),
+            (Category::Proc, Action::Fork),
+            (Category::Proc, Action::Signal),
+            (Category::Env, Action::Read),
+            (Category::Env, Action::Write),
+            (Category::Ffi, Action::Call),
+            (Category::Ffi, Action::Load),
+            (Category::Time, Action::Read),
+            (Category::Time, Action::Sleep),
+            (Category::Stdin, Action::Read),
+            (Category::Stdout, Action::Write),
+        ];
+        for (c, a) in valid {
+            assert!(
+                is_valid_combination(c, a),
+                "expected {c}:{a} to be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_combinations_rejected() {
+        // A few that should NOT be valid.
+        let invalid = [
+            (Category::Fs, Action::Connect),
+            (Category::Net, Action::Read),
+            (Category::Proc, Action::Read),
+            (Category::Env, Action::Connect),
+            (Category::Time, Action::Connect),
+            (Category::Stdin, Action::Write),
+            (Category::Stdout, Action::Read),
+        ];
+        for (c, a) in invalid {
+            assert!(
+                !is_valid_combination(c, a),
+                "expected {c}:{a} to be invalid"
+            );
+        }
+    }
+}

--- a/code/packages/rust/capability-cage/src/category.rs
+++ b/code/packages/rust/capability-cage/src/category.rs
@@ -182,9 +182,7 @@ mod tests {
 
     #[test]
     fn category_round_trips() {
-        for s in [
-            "fs", "net", "proc", "env", "ffi", "time", "stdin", "stdout",
-        ] {
+        for s in ["fs", "net", "proc", "env", "ffi", "time", "stdin", "stdout"] {
             let cat: Category = s.parse().unwrap();
             assert_eq!(cat.as_str(), s);
             assert_eq!(format!("{cat}"), s);
@@ -194,8 +192,8 @@ mod tests {
     #[test]
     fn action_round_trips() {
         for s in [
-            "read", "write", "create", "delete", "list", "connect", "listen",
-            "dns", "exec", "fork", "signal", "call", "load", "sleep",
+            "read", "write", "create", "delete", "list", "connect", "listen", "dns", "exec",
+            "fork", "signal", "call", "load", "sleep",
         ] {
             let act: Action = s.parse().unwrap();
             assert_eq!(act.as_str(), s);
@@ -239,10 +237,7 @@ mod tests {
             (Category::Stdout, Action::Write),
         ];
         for (c, a) in valid {
-            assert!(
-                is_valid_combination(c, a),
-                "expected {c}:{a} to be valid"
-            );
+            assert!(is_valid_combination(c, a), "expected {c}:{a} to be valid");
         }
     }
 

--- a/code/packages/rust/capability-cage/src/errors.rs
+++ b/code/packages/rust/capability-cage/src/errors.rs
@@ -29,14 +29,9 @@ impl std::error::Error for CapabilityViolationError {}
 /// per the cage taxonomy, or a target / format that does not parse.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InvalidCombination {
-    UnsupportedPair {
-        category: Category,
-        action: Action,
-    },
+    UnsupportedPair { category: Category, action: Action },
     EmptyTarget,
-    InvalidTargetFormat {
-        reason: String,
-    },
+    InvalidTargetFormat { reason: String },
 }
 
 impl fmt::Display for InvalidCombination {
@@ -76,7 +71,9 @@ impl fmt::Display for ManifestError {
         match self {
             ManifestError::Parse(msg) => write!(f, "manifest parse error: {msg}"),
             ManifestError::Schema { reason } => write!(f, "manifest schema error: {reason}"),
-            ManifestError::InvalidCombination(inner) => write!(f, "manifest validation error: {inner}"),
+            ManifestError::InvalidCombination(inner) => {
+                write!(f, "manifest validation error: {inner}")
+            }
             ManifestError::Io(err) => write!(f, "manifest I/O error: {err}"),
         }
     }

--- a/code/packages/rust/capability-cage/src/errors.rs
+++ b/code/packages/rust/capability-cage/src/errors.rs
@@ -1,0 +1,152 @@
+//! Errors produced by the capability cage.
+
+use std::fmt;
+
+use crate::category::{Action, Category};
+
+/// A capability check denied an OS operation.
+///
+/// Returned by [`Manifest::check`](crate::Manifest::check) and by
+/// the secure-wrapper functions when the manifest does not cover
+/// the requested triple.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityViolationError {
+    pub category: Category,
+    pub action: Action,
+    pub target: String,
+    pub message: String,
+}
+
+impl fmt::Display for CapabilityViolationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for CapabilityViolationError {}
+
+/// A `(category, action)` pair that is not a meaningful combination
+/// per the cage taxonomy, or a target / format that does not parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidCombination {
+    UnsupportedPair {
+        category: Category,
+        action: Action,
+    },
+    EmptyTarget,
+    InvalidTargetFormat {
+        reason: String,
+    },
+}
+
+impl fmt::Display for InvalidCombination {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InvalidCombination::UnsupportedPair { category, action } => write!(
+                f,
+                "category {} does not support action {} per the cage taxonomy",
+                category, action
+            ),
+            InvalidCombination::EmptyTarget => f.write_str("capability target is empty"),
+            InvalidCombination::InvalidTargetFormat { reason } => {
+                write!(f, "invalid capability target: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for InvalidCombination {}
+
+/// Anything that can go wrong loading a `required_capabilities.json`.
+#[derive(Debug)]
+pub enum ManifestError {
+    /// The JSON did not parse.
+    Parse(String),
+    /// The JSON parsed but did not match the expected schema.
+    Schema { reason: String },
+    /// The JSON contained an unsupported (category, action) pair, an
+    /// empty target, or a bad target format.
+    InvalidCombination(InvalidCombination),
+    /// An IO error reading the manifest file.
+    Io(std::io::Error),
+}
+
+impl fmt::Display for ManifestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ManifestError::Parse(msg) => write!(f, "manifest parse error: {msg}"),
+            ManifestError::Schema { reason } => write!(f, "manifest schema error: {reason}"),
+            ManifestError::InvalidCombination(inner) => write!(f, "manifest validation error: {inner}"),
+            ManifestError::Io(err) => write!(f, "manifest I/O error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for ManifestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ManifestError::InvalidCombination(inner) => Some(inner),
+            ManifestError::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<InvalidCombination> for ManifestError {
+    fn from(value: InvalidCombination) -> Self {
+        ManifestError::InvalidCombination(value)
+    }
+}
+
+impl From<std::io::Error> for ManifestError {
+    fn from(value: std::io::Error) -> Self {
+        ManifestError::Io(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_violation_error_displays_message() {
+        let err = CapabilityViolationError {
+            category: Category::Fs,
+            action: Action::Read,
+            target: "/etc/passwd".into(),
+            message: "fs:read:/etc/passwd not declared".into(),
+        };
+        assert_eq!(format!("{err}"), "fs:read:/etc/passwd not declared");
+    }
+
+    #[test]
+    fn invalid_combination_messages() {
+        let pair = InvalidCombination::UnsupportedPair {
+            category: Category::Fs,
+            action: Action::Connect,
+        };
+        let s = format!("{pair}");
+        assert!(s.contains("fs"));
+        assert!(s.contains("connect"));
+
+        let empty = InvalidCombination::EmptyTarget;
+        assert!(format!("{empty}").contains("empty"));
+
+        let bad = InvalidCombination::InvalidTargetFormat {
+            reason: "expected host:port".into(),
+        };
+        assert!(format!("{bad}").contains("expected host:port"));
+    }
+
+    #[test]
+    fn manifest_error_into_chain() {
+        use std::error::Error;
+        let err: ManifestError = InvalidCombination::EmptyTarget.into();
+        assert!(matches!(err, ManifestError::InvalidCombination(_)));
+        assert!(err.source().is_some());
+
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        let err: ManifestError = io.into();
+        assert!(matches!(err, ManifestError::Io(_)));
+    }
+}

--- a/code/packages/rust/capability-cage/src/glob.rs
+++ b/code/packages/rust/capability-cage/src/glob.rs
@@ -1,0 +1,229 @@
+//! Glob matcher for capability targets.
+//!
+//! The matching rules (from `capability-cage-rust.md` and the Go
+//! conformance suite):
+//!
+//! ```text
+//! Pattern              Matches
+//! foo                  exactly `foo`
+//! *                    any single path component (no separators)
+//! **                   any number of components
+//! *.tokens             any single component ending in `.tokens`
+//! ./grammars/*.tokens  one-level files under `./grammars/`
+//! ./grammars/**/*.tokens  any-depth `.tokens` under `./grammars/`
+//! host:port            literal host and port
+//! *:443                any host on port 443
+//! api.weather.gov:*    any port on `api.weather.gov`
+//! ```
+//!
+//! Path separators are `/` (we normalize Windows backslashes before
+//! matching). Net targets use `:` as the separator between host and
+//! port.
+
+const PATH_SEP: char = '/';
+
+/// Returns true if `candidate` (a literal call argument) matches
+/// `pattern` (a target string from the manifest).
+pub fn match_target(pattern: &str, candidate: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+
+    // Net targets use `:` to separate host and port; if both pattern
+    // and candidate look like net targets, match each side
+    // independently.
+    if let (Some(p_idx), Some(c_idx)) = (pattern.rfind(':'), candidate.rfind(':')) {
+        let (p_host, p_port) = (&pattern[..p_idx], &pattern[p_idx + 1..]);
+        let (c_host, c_port) = (&candidate[..c_idx], &candidate[c_idx + 1..]);
+        // Heuristic: if neither side contains `/`, treat as net
+        // target. Path globs never contain `:` between segments
+        // (Windows drive letters would, but our paths use `./` or
+        // start with `/`).
+        let looks_like_net =
+            !pattern.contains('/') && !pattern.contains('\\') && !p_port.contains(' ');
+        if looks_like_net {
+            return match_host(p_host, c_host) && match_port(p_port, c_port);
+        }
+    }
+
+    // Otherwise treat as path match.
+    let pattern = normalize_separators(pattern);
+    let candidate = normalize_separators(candidate);
+    match_path(&pattern, &candidate)
+}
+
+fn normalize_separators(s: &str) -> String {
+    s.replace('\\', "/")
+}
+
+fn match_host(pattern: &str, candidate: &str) -> bool {
+    pattern == "*" || pattern == candidate
+}
+
+fn match_port(pattern: &str, candidate: &str) -> bool {
+    pattern == "*" || pattern == candidate
+}
+
+fn match_path(pattern: &str, candidate: &str) -> bool {
+    let p_segs: Vec<&str> = pattern.split(PATH_SEP).collect();
+    let c_segs: Vec<&str> = candidate.split(PATH_SEP).collect();
+    match_segments(&p_segs, &c_segs)
+}
+
+fn match_segments(p: &[&str], c: &[&str]) -> bool {
+    match (p.first(), c.first()) {
+        (None, None) => true,
+        (None, Some(_)) => false,
+        (Some(&"**"), _) => {
+            // ** matches zero or more components.
+            // Try matching the rest of the pattern against
+            // increasing suffixes of the candidate.
+            let rest_pattern = &p[1..];
+            let mut idx = 0;
+            loop {
+                if match_segments(rest_pattern, &c[idx..]) {
+                    return true;
+                }
+                if idx >= c.len() {
+                    return false;
+                }
+                idx += 1;
+            }
+        }
+        (Some(p_seg), Some(c_seg)) => {
+            if !match_one_segment(p_seg, c_seg) {
+                return false;
+            }
+            match_segments(&p[1..], &c[1..])
+        }
+        (Some(_), None) => false,
+    }
+}
+
+/// Match a single path component (no `/` allowed in either side).
+/// Supports `*` wildcard within the component.
+fn match_one_segment(pattern: &str, candidate: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == candidate;
+    }
+    // Pattern with `*` chars: split into literal pieces and match
+    // sequentially. e.g. "*.tokens" → ["", ".tokens"]; "foo*.bar" →
+    // ["foo", ".bar"].
+    let pieces: Vec<&str> = pattern.split('*').collect();
+    let mut cursor = 0;
+    for (i, piece) in pieces.iter().enumerate() {
+        if piece.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // First piece must be a prefix.
+            if !candidate[cursor..].starts_with(piece) {
+                return false;
+            }
+            cursor += piece.len();
+        } else if i == pieces.len() - 1 {
+            // Last piece must be a suffix at end-of-string.
+            if !candidate[cursor..].ends_with(piece) {
+                return false;
+            }
+            // Ensure suffix starts no earlier than current cursor.
+            if candidate.len() < cursor + piece.len() {
+                return false;
+            }
+        } else {
+            // Middle piece: find anywhere from current cursor.
+            match candidate[cursor..].find(piece) {
+                Some(idx) => cursor += idx + piece.len(),
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn star_matches_everything() {
+        assert!(match_target("*", "anything"));
+        assert!(match_target("*", "/etc/passwd"));
+        assert!(match_target("*", "api.weather.gov:443"));
+    }
+
+    #[test]
+    fn literal_match() {
+        assert!(match_target("foo", "foo"));
+        assert!(!match_target("foo", "bar"));
+        assert!(!match_target("foo", "foobar"));
+    }
+
+    #[test]
+    fn single_star_one_component() {
+        assert!(match_target("./grammars/*", "./grammars/json.tokens"));
+        assert!(!match_target(
+            "./grammars/*",
+            "./grammars/sub/json.tokens"
+        ));
+    }
+
+    #[test]
+    fn double_star_any_depth() {
+        assert!(match_target("./**/*.tokens", "./grammars/json.tokens"));
+        assert!(match_target(
+            "./**/*.tokens",
+            "./grammars/sub/deep/json.tokens"
+        ));
+        assert!(!match_target("./**/*.tokens", "./grammars/json.json"));
+    }
+
+    #[test]
+    fn extension_glob_within_segment() {
+        assert!(match_target("*.tokens", "json.tokens"));
+        assert!(!match_target("*.tokens", "json.toml"));
+        assert!(match_target("./grammars/*.tokens", "./grammars/json.tokens"));
+    }
+
+    #[test]
+    fn middle_wildcard() {
+        assert!(match_target("foo*.bar", "fooXY.bar"));
+        assert!(match_target("foo*.bar", "foo.bar"));
+        assert!(!match_target("foo*.bar", "foo.baz"));
+    }
+
+    #[test]
+    fn net_target_match() {
+        assert!(match_target("api.weather.gov:443", "api.weather.gov:443"));
+        assert!(!match_target("api.weather.gov:443", "api.weather.gov:80"));
+        assert!(!match_target(
+            "api.weather.gov:443",
+            "evil.example.com:443"
+        ));
+    }
+
+    #[test]
+    fn net_wildcard_port() {
+        assert!(match_target("api.weather.gov:*", "api.weather.gov:443"));
+        assert!(match_target("api.weather.gov:*", "api.weather.gov:80"));
+        assert!(!match_target("api.weather.gov:*", "evil.example.com:443"));
+    }
+
+    #[test]
+    fn net_wildcard_host() {
+        assert!(match_target("*:443", "api.weather.gov:443"));
+        assert!(match_target("*:443", "evil.example.com:443"));
+        assert!(!match_target("*:443", "api.weather.gov:80"));
+    }
+
+    #[test]
+    fn windows_paths_normalize() {
+        assert!(match_target(
+            "./grammars/*.tokens",
+            ".\\grammars\\json.tokens"
+        ));
+    }
+}

--- a/code/packages/rust/capability-cage/src/glob.rs
+++ b/code/packages/rust/capability-cage/src/glob.rs
@@ -165,10 +165,7 @@ mod tests {
     #[test]
     fn single_star_one_component() {
         assert!(match_target("./grammars/*", "./grammars/json.tokens"));
-        assert!(!match_target(
-            "./grammars/*",
-            "./grammars/sub/json.tokens"
-        ));
+        assert!(!match_target("./grammars/*", "./grammars/sub/json.tokens"));
     }
 
     #[test]
@@ -185,7 +182,10 @@ mod tests {
     fn extension_glob_within_segment() {
         assert!(match_target("*.tokens", "json.tokens"));
         assert!(!match_target("*.tokens", "json.toml"));
-        assert!(match_target("./grammars/*.tokens", "./grammars/json.tokens"));
+        assert!(match_target(
+            "./grammars/*.tokens",
+            "./grammars/json.tokens"
+        ));
     }
 
     #[test]
@@ -199,10 +199,7 @@ mod tests {
     fn net_target_match() {
         assert!(match_target("api.weather.gov:443", "api.weather.gov:443"));
         assert!(!match_target("api.weather.gov:443", "api.weather.gov:80"));
-        assert!(!match_target(
-            "api.weather.gov:443",
-            "evil.example.com:443"
-        ));
+        assert!(!match_target("api.weather.gov:443", "evil.example.com:443"));
     }
 
     #[test]

--- a/code/packages/rust/capability-cage/src/lib.rs
+++ b/code/packages/rust/capability-cage/src/lib.rs
@@ -17,7 +17,7 @@ mod glob;
 mod manifest;
 pub mod secure_file;
 
-pub use backend::{Backend, BackendGuard, DenyAllBackend, OpenBackend, TestBackend, with_backend};
+pub use backend::{with_backend, Backend, BackendGuard, DenyAllBackend, OpenBackend, TestBackend};
 pub use capability::Capability;
 pub use category::{Action, Category};
 pub use errors::{CapabilityViolationError, InvalidCombination, ManifestError};

--- a/code/packages/rust/capability-cage/src/lib.rs
+++ b/code/packages/rust/capability-cage/src/lib.rs
@@ -1,0 +1,25 @@
+//! capability-cage — Rust port of the Go capability-cage runtime.
+//!
+//! See `code/specs/capability-cage-rust.md` for the full design.
+//!
+//! V1 scope: foundational types, manifest loading and validation, glob
+//! matcher, the [`Backend`] trait with [`OpenBackend`] / [`TestBackend`]
+//! / [`DenyAllBackend`] implementations, and the [`secure_file`] family
+//! of secure-wrapper functions. Other secure-wrapper categories
+//! (`net`, `proc`, `env`, `time`, `stdio`) and the audit envelope land
+//! in subsequent PRs.
+
+mod backend;
+mod capability;
+mod category;
+mod errors;
+mod glob;
+mod manifest;
+pub mod secure_file;
+
+pub use backend::{Backend, BackendGuard, DenyAllBackend, OpenBackend, TestBackend, with_backend};
+pub use capability::Capability;
+pub use category::{Action, Category};
+pub use errors::{CapabilityViolationError, InvalidCombination, ManifestError};
+pub use glob::match_target;
+pub use manifest::Manifest;

--- a/code/packages/rust/capability-cage/src/manifest.rs
+++ b/code/packages/rust/capability-cage/src/manifest.rs
@@ -15,9 +15,9 @@ use coding_adventures_json_value::{parse, JsonNumber, JsonValue};
 
 use crate::capability::Capability;
 use crate::category::{Action, Category};
-use crate::errors::{CapabilityViolationError, ManifestError};
 #[cfg(test)]
 use crate::errors::InvalidCombination;
+use crate::errors::{CapabilityViolationError, ManifestError};
 use crate::glob::match_target;
 
 /// An immutable capability manifest.
@@ -101,16 +101,16 @@ impl Manifest {
                     })
                 }
             };
-            let category_str = lookup(entry_obj, "category").and_then(json_as_str).ok_or_else(
-                || ManifestError::Schema {
+            let category_str = lookup(entry_obj, "category")
+                .and_then(json_as_str)
+                .ok_or_else(|| ManifestError::Schema {
                     reason: format!("capabilities[{idx}] missing string 'category'"),
-                },
-            )?;
-            let action_str = lookup(entry_obj, "action").and_then(json_as_str).ok_or_else(
-                || ManifestError::Schema {
+                })?;
+            let action_str = lookup(entry_obj, "action")
+                .and_then(json_as_str)
+                .ok_or_else(|| ManifestError::Schema {
                     reason: format!("capabilities[{idx}] missing string 'action'"),
-                },
-            )?;
+                })?;
             let target = lookup(entry_obj, "target")
                 .and_then(json_as_str)
                 .ok_or_else(|| ManifestError::Schema {
@@ -122,16 +122,13 @@ impl Manifest {
                 .map(|s| s.to_string())
                 .unwrap_or_default();
 
-            let category: Category =
-                category_str.parse().map_err(|()| ManifestError::Schema {
-                    reason: format!(
-                        "capabilities[{idx}].category '{category_str}' is not a known category"
-                    ),
-                })?;
-            let action: Action = action_str.parse().map_err(|()| ManifestError::Schema {
+            let category: Category = category_str.parse().map_err(|()| ManifestError::Schema {
                 reason: format!(
-                    "capabilities[{idx}].action '{action_str}' is not a known action"
+                    "capabilities[{idx}].category '{category_str}' is not a known category"
                 ),
+            })?;
+            let action: Action = action_str.parse().map_err(|()| ManifestError::Schema {
+                reason: format!("capabilities[{idx}].action '{action_str}' is not a known action"),
             })?;
             let cap = Capability::new(category, action, target, justification)?;
             caps.push(cap);
@@ -145,9 +142,7 @@ impl Manifest {
     /// manifest are matched against the literal `target` argument.
     pub fn has(&self, category: Category, action: Action, target: &str) -> bool {
         self.capabilities.iter().any(|cap| {
-            cap.category == category
-                && cap.action == action
-                && match_target(&cap.target, target)
+            cap.category == category && cap.action == action && match_target(&cap.target, target)
         })
     }
 

--- a/code/packages/rust/capability-cage/src/manifest.rs
+++ b/code/packages/rust/capability-cage/src/manifest.rs
@@ -1,0 +1,376 @@
+//! Immutable capability manifest.
+//!
+//! A `Manifest` is constructed from a `required_capabilities.json`
+//! (or programmatically from a list of [`Capability`]) and answers
+//! the single question every secure wrapper asks before performing
+//! an OS operation: *does this manifest cover this (category,
+//! action, target) triple?*
+//!
+//! The default — an empty manifest — grants no OS access. This is
+//! the expected state for the majority of pure-computation packages.
+
+use std::path::Path;
+
+use coding_adventures_json_value::{parse, JsonNumber, JsonValue};
+
+use crate::capability::Capability;
+use crate::category::{Action, Category};
+use crate::errors::{CapabilityViolationError, ManifestError};
+#[cfg(test)]
+use crate::errors::InvalidCombination;
+use crate::glob::match_target;
+
+/// An immutable capability manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Manifest {
+    capabilities: Vec<Capability>,
+}
+
+impl Manifest {
+    /// Construct a manifest from a list of capabilities.
+    ///
+    /// Each capability must have already been validated via
+    /// [`Capability::new`]; this constructor does not re-check.
+    pub fn new(capabilities: Vec<Capability>) -> Self {
+        Self { capabilities }
+    }
+
+    /// The pre-built zero-capability manifest. Equivalent to
+    /// `Manifest::new(vec![])`.
+    pub fn empty() -> Manifest {
+        Manifest::new(vec![])
+    }
+
+    /// Load a manifest from a JSON string in the
+    /// `required_capabilities.json` shape.
+    pub fn load_from_str(s: &str) -> Result<Self, ManifestError> {
+        let root = parse(s).map_err(|e| ManifestError::Parse(e.to_string()))?;
+        Self::from_json(&root)
+    }
+
+    /// Load a manifest from a path to a JSON file.
+    pub fn load_from_file(path: &Path) -> Result<Self, ManifestError> {
+        let bytes = std::fs::read(path)?;
+        let s = std::str::from_utf8(&bytes)
+            .map_err(|e| ManifestError::Parse(format!("manifest is not UTF-8: {e}")))?;
+        Self::load_from_str(s)
+    }
+
+    fn from_json(root: &JsonValue) -> Result<Self, ManifestError> {
+        let obj = match root {
+            JsonValue::Object(pairs) => pairs,
+            _ => {
+                return Err(ManifestError::Schema {
+                    reason: "top-level value must be a JSON object".into(),
+                })
+            }
+        };
+
+        let version = lookup(obj, "version")
+            .and_then(json_as_i64)
+            .ok_or_else(|| ManifestError::Schema {
+                reason: "missing or non-integer field: version".into(),
+            })?;
+        if version != 1 {
+            return Err(ManifestError::Schema {
+                reason: format!(
+                    "unsupported manifest version: {version} (only 1 is supported in v1)"
+                ),
+            });
+        }
+
+        let caps_value = lookup(obj, "capabilities").ok_or_else(|| ManifestError::Schema {
+            reason: "missing field: capabilities".into(),
+        })?;
+        let caps_array = match caps_value {
+            JsonValue::Array(items) => items,
+            _ => {
+                return Err(ManifestError::Schema {
+                    reason: "capabilities must be an array".into(),
+                })
+            }
+        };
+
+        let mut caps = Vec::with_capacity(caps_array.len());
+        for (idx, entry) in caps_array.iter().enumerate() {
+            let entry_obj = match entry {
+                JsonValue::Object(pairs) => pairs,
+                _ => {
+                    return Err(ManifestError::Schema {
+                        reason: format!("capabilities[{idx}] must be a JSON object"),
+                    })
+                }
+            };
+            let category_str = lookup(entry_obj, "category").and_then(json_as_str).ok_or_else(
+                || ManifestError::Schema {
+                    reason: format!("capabilities[{idx}] missing string 'category'"),
+                },
+            )?;
+            let action_str = lookup(entry_obj, "action").and_then(json_as_str).ok_or_else(
+                || ManifestError::Schema {
+                    reason: format!("capabilities[{idx}] missing string 'action'"),
+                },
+            )?;
+            let target = lookup(entry_obj, "target")
+                .and_then(json_as_str)
+                .ok_or_else(|| ManifestError::Schema {
+                    reason: format!("capabilities[{idx}] missing string 'target'"),
+                })?
+                .to_string();
+            let justification = lookup(entry_obj, "justification")
+                .and_then(json_as_str)
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+
+            let category: Category =
+                category_str.parse().map_err(|()| ManifestError::Schema {
+                    reason: format!(
+                        "capabilities[{idx}].category '{category_str}' is not a known category"
+                    ),
+                })?;
+            let action: Action = action_str.parse().map_err(|()| ManifestError::Schema {
+                reason: format!(
+                    "capabilities[{idx}].action '{action_str}' is not a known action"
+                ),
+            })?;
+            let cap = Capability::new(category, action, target, justification)?;
+            caps.push(cap);
+        }
+
+        Ok(Manifest::new(caps))
+    }
+
+    /// Returns true if the manifest declares a capability that covers
+    /// the (category, action, target) triple. Glob targets in the
+    /// manifest are matched against the literal `target` argument.
+    pub fn has(&self, category: Category, action: Action, target: &str) -> bool {
+        self.capabilities.iter().any(|cap| {
+            cap.category == category
+                && cap.action == action
+                && match_target(&cap.target, target)
+        })
+    }
+
+    /// Returns Ok(()) if the manifest covers the triple, otherwise
+    /// returns [`CapabilityViolationError`] with a diagnostic message.
+    pub fn check(
+        &self,
+        category: Category,
+        action: Action,
+        target: &str,
+    ) -> Result<(), CapabilityViolationError> {
+        if self.has(category, action, target) {
+            Ok(())
+        } else {
+            Err(CapabilityViolationError {
+                category,
+                action,
+                target: target.to_string(),
+                message: format!(
+                    "capability {}:{}:{} not declared; add it to required_capabilities.json",
+                    category, action, target,
+                ),
+            })
+        }
+    }
+
+    /// Borrow the capability list.
+    pub fn capabilities(&self) -> &[Capability] {
+        &self.capabilities
+    }
+}
+
+impl Default for Manifest {
+    fn default() -> Self {
+        Manifest::empty()
+    }
+}
+
+fn lookup<'a>(obj: &'a [(String, JsonValue)], key: &str) -> Option<&'a JsonValue> {
+    obj.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+}
+
+fn json_as_str(v: &JsonValue) -> Option<&str> {
+    match v {
+        JsonValue::String(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+fn json_as_i64(v: &JsonValue) -> Option<i64> {
+    match v {
+        JsonValue::Number(JsonNumber::Integer(n)) => Some(*n),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fs_read_cap(target: &str) -> Capability {
+        Capability::new(Category::Fs, Action::Read, target, "test").unwrap()
+    }
+
+    #[test]
+    fn empty_manifest_has_nothing() {
+        let m = Manifest::empty();
+        assert!(!m.has(Category::Fs, Action::Read, "/anything"));
+        let err = m.check(Category::Fs, Action::Read, "/x").unwrap_err();
+        assert_eq!(err.category, Category::Fs);
+        assert_eq!(err.action, Action::Read);
+        assert_eq!(err.target, "/x");
+        assert!(err.message.contains("fs:read:/x"));
+    }
+
+    #[test]
+    fn exact_match() {
+        let m = Manifest::new(vec![fs_read_cap("./grammars/json.tokens")]);
+        assert!(m.has(Category::Fs, Action::Read, "./grammars/json.tokens"));
+        assert!(!m.has(Category::Fs, Action::Read, "./grammars/other.tokens"));
+    }
+
+    #[test]
+    fn glob_match() {
+        let m = Manifest::new(vec![fs_read_cap("./grammars/*.tokens")]);
+        assert!(m.has(Category::Fs, Action::Read, "./grammars/json.tokens"));
+        assert!(m.has(Category::Fs, Action::Read, "./grammars/yaml.tokens"));
+        assert!(!m.has(Category::Fs, Action::Read, "./grammars/sub/json.tokens"));
+    }
+
+    #[test]
+    fn category_action_must_match() {
+        let m = Manifest::new(vec![fs_read_cap("./x")]);
+        assert!(!m.has(Category::Fs, Action::Write, "./x"));
+        assert!(!m.has(Category::Net, Action::Connect, "./x"));
+    }
+
+    #[test]
+    fn check_returns_ok_on_match() {
+        let m = Manifest::new(vec![fs_read_cap("./x")]);
+        assert!(m.check(Category::Fs, Action::Read, "./x").is_ok());
+    }
+
+    #[test]
+    fn load_minimal_pure_manifest() {
+        let json = r#"{
+            "version": 1,
+            "package": "rust/capability-cage-test",
+            "capabilities": [],
+            "justification": "pure computation"
+        }"#;
+        let m = Manifest::load_from_str(json).unwrap();
+        assert_eq!(m.capabilities().len(), 0);
+    }
+
+    #[test]
+    fn load_manifest_with_one_cap() {
+        let json = r#"{
+            "version": 1,
+            "package": "rust/json-lexer",
+            "capabilities": [
+                {
+                    "category": "fs",
+                    "action": "read",
+                    "target": "./grammars/*.tokens",
+                    "justification": "load lexer DFA"
+                }
+            ]
+        }"#;
+        let m = Manifest::load_from_str(json).unwrap();
+        assert_eq!(m.capabilities().len(), 1);
+        assert!(m.has(Category::Fs, Action::Read, "./grammars/json.tokens"));
+    }
+
+    #[test]
+    fn load_manifest_rejects_missing_version() {
+        let json = r#"{ "capabilities": [] }"#;
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::Schema { reason } => assert!(reason.contains("version")),
+            other => panic!("expected Schema error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_unknown_version() {
+        let json = r#"{ "version": 2, "capabilities": [] }"#;
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::Schema { reason } => assert!(reason.contains("version")),
+            other => panic!("expected Schema error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_missing_capabilities() {
+        let json = r#"{ "version": 1 }"#;
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::Schema { reason } => assert!(reason.contains("capabilities")),
+            other => panic!("expected Schema error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_capabilities_not_array() {
+        let json = r#"{ "version": 1, "capabilities": {} }"#;
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::Schema { reason } => assert!(reason.contains("array")),
+            other => panic!("expected Schema error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_unknown_category() {
+        let json = r#"{
+            "version": 1,
+            "capabilities": [
+                { "category": "network", "action": "connect", "target": "x:80" }
+            ]
+        }"#;
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::Schema { reason } => assert!(reason.contains("category")),
+            other => panic!("expected Schema error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_invalid_pair() {
+        // fs + connect is not a valid combination.
+        let json = r#"{
+            "version": 1,
+            "capabilities": [
+                { "category": "fs", "action": "connect", "target": "x" }
+            ]
+        }"#;
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::InvalidCombination(InvalidCombination::UnsupportedPair { .. }) => {}
+            other => panic!("expected InvalidCombination error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_empty_target() {
+        let json = r#"{
+            "version": 1,
+            "capabilities": [
+                { "category": "fs", "action": "read", "target": "" }
+            ]
+        }"#;
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::InvalidCombination(InvalidCombination::EmptyTarget) => {}
+            other => panic!("expected EmptyTarget error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_unparseable_json() {
+        let err = Manifest::load_from_str("not json").unwrap_err();
+        assert!(matches!(err, ManifestError::Parse(_)));
+    }
+}

--- a/code/packages/rust/capability-cage/src/secure_file.rs
+++ b/code/packages/rust/capability-cage/src/secure_file.rs
@@ -64,7 +64,7 @@ mod tests {
 
     fn manifest_with(category: Category, action: Action, target: &str) -> Manifest {
         Manifest::new(vec![
-            Capability::new(category, action, target, "test").unwrap(),
+            Capability::new(category, action, target, "test").unwrap()
         ])
     }
 
@@ -117,16 +117,17 @@ mod tests {
         delete_file(&m, Path::new("./out.txt")).unwrap();
         let calls = backend.calls();
         assert_eq!(calls.len(), 3);
-        assert!(matches!(&calls[0], TestBackendCall::WriteFile(p, d) if p == Path::new("./out.txt") && d == b"data"));
+        assert!(
+            matches!(&calls[0], TestBackendCall::WriteFile(p, d) if p == Path::new("./out.txt") && d == b"data")
+        );
         assert!(matches!(&calls[1], TestBackendCall::CreateFile(p) if p == Path::new("./out.txt")));
         assert!(matches!(&calls[2], TestBackendCall::DeleteFile(p) if p == Path::new("./out.txt")));
     }
 
     #[test]
     fn list_dir_with_manifest() {
-        let backend = Arc::new(
-            TestBackend::new().with_dir_response("./tmp", vec!["a".into(), "b".into()]),
-        );
+        let backend =
+            Arc::new(TestBackend::new().with_dir_response("./tmp", vec!["a".into(), "b".into()]));
         let _guard = with_backend(backend);
         let m = manifest_with(Category::Fs, Action::List, "./tmp");
         let entries = list_dir(&m, Path::new("./tmp")).unwrap();

--- a/code/packages/rust/capability-cage/src/secure_file.rs
+++ b/code/packages/rust/capability-cage/src/secure_file.rs
@@ -1,0 +1,143 @@
+//! Secure-wrapper functions for the `fs` capability category.
+//!
+//! Every call validates the manifest first, then delegates to the
+//! current [`Backend`]. The manifest check produces an
+//! [`io::Error::other`]-wrapped [`CapabilityViolationError`] on
+//! denial, so callers' existing `io::Result` propagation works.
+
+use std::io;
+use std::path::Path;
+
+use crate::backend::current_backend;
+use crate::category::{Action, Category};
+use crate::errors::CapabilityViolationError;
+use crate::manifest::Manifest;
+
+/// Read the entire contents of `path`.
+pub fn read_file(manifest: &Manifest, path: &Path) -> io::Result<Vec<u8>> {
+    check(manifest, Action::Read, path)?;
+    current_backend().read_file(path)
+}
+
+/// Write `data` to `path`, replacing any existing contents.
+pub fn write_file(manifest: &Manifest, path: &Path, data: &[u8]) -> io::Result<()> {
+    check(manifest, Action::Write, path)?;
+    current_backend().write_file(path, data)
+}
+
+/// Create a new empty file at `path`. Fails if it already exists.
+pub fn create_file(manifest: &Manifest, path: &Path) -> io::Result<()> {
+    check(manifest, Action::Create, path)?;
+    current_backend().create_file(path)
+}
+
+/// Remove the file at `path`.
+pub fn delete_file(manifest: &Manifest, path: &Path) -> io::Result<()> {
+    check(manifest, Action::Delete, path)?;
+    current_backend().delete_file(path)
+}
+
+/// List the entries in the directory at `path`.
+pub fn list_dir(manifest: &Manifest, path: &Path) -> io::Result<Vec<String>> {
+    check(manifest, Action::List, path)?;
+    current_backend().list_dir(path)
+}
+
+fn check(manifest: &Manifest, action: Action, path: &Path) -> io::Result<()> {
+    let target = path.to_string_lossy();
+    manifest
+        .check(Category::Fs, action, target.as_ref())
+        .map_err(violation_to_io)
+}
+
+fn violation_to_io(err: CapabilityViolationError) -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, err)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::backend::{with_backend, TestBackend, TestBackendCall};
+    use crate::capability::Capability;
+
+    fn manifest_with(category: Category, action: Action, target: &str) -> Manifest {
+        Manifest::new(vec![
+            Capability::new(category, action, target, "test").unwrap(),
+        ])
+    }
+
+    #[test]
+    fn read_file_calls_backend_when_allowed() {
+        let backend = Arc::new(TestBackend::new().with_response("./allowed.txt", b"hello"));
+        let _guard = with_backend(backend.clone());
+        let m = manifest_with(Category::Fs, Action::Read, "./allowed.txt");
+        let bytes = read_file(&m, Path::new("./allowed.txt")).unwrap();
+        assert_eq!(bytes, b"hello");
+    }
+
+    #[test]
+    fn read_file_denied_without_manifest_entry() {
+        let backend = Arc::new(TestBackend::new());
+        let _guard = with_backend(backend.clone());
+        let m = Manifest::empty();
+        let err = read_file(&m, Path::new("./forbidden.txt")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        let underlying = err.into_inner().expect("expected source error");
+        let viol = underlying
+            .downcast_ref::<CapabilityViolationError>()
+            .expect("expected CapabilityViolationError");
+        assert_eq!(viol.category, Category::Fs);
+        assert_eq!(viol.action, Action::Read);
+        assert_eq!(viol.target, "./forbidden.txt");
+    }
+
+    #[test]
+    fn read_file_does_not_call_backend_when_denied() {
+        let backend = Arc::new(TestBackend::new());
+        let _guard = with_backend(backend.clone());
+        let m = Manifest::empty();
+        let _ = read_file(&m, Path::new("./forbidden.txt"));
+        // Backend should never have been called.
+        assert!(backend.calls().is_empty(), "backend was called on denial");
+    }
+
+    #[test]
+    fn write_create_delete_round_trip() {
+        let backend = Arc::new(TestBackend::new());
+        let _guard = with_backend(backend.clone());
+        let m = Manifest::new(vec![
+            Capability::new(Category::Fs, Action::Write, "./out.txt", "t").unwrap(),
+            Capability::new(Category::Fs, Action::Create, "./out.txt", "t").unwrap(),
+            Capability::new(Category::Fs, Action::Delete, "./out.txt", "t").unwrap(),
+        ]);
+        write_file(&m, Path::new("./out.txt"), b"data").unwrap();
+        create_file(&m, Path::new("./out.txt")).unwrap();
+        delete_file(&m, Path::new("./out.txt")).unwrap();
+        let calls = backend.calls();
+        assert_eq!(calls.len(), 3);
+        assert!(matches!(&calls[0], TestBackendCall::WriteFile(p, d) if p == Path::new("./out.txt") && d == b"data"));
+        assert!(matches!(&calls[1], TestBackendCall::CreateFile(p) if p == Path::new("./out.txt")));
+        assert!(matches!(&calls[2], TestBackendCall::DeleteFile(p) if p == Path::new("./out.txt")));
+    }
+
+    #[test]
+    fn list_dir_with_manifest() {
+        let backend = Arc::new(
+            TestBackend::new().with_dir_response("./tmp", vec!["a".into(), "b".into()]),
+        );
+        let _guard = with_backend(backend);
+        let m = manifest_with(Category::Fs, Action::List, "./tmp");
+        let entries = list_dir(&m, Path::new("./tmp")).unwrap();
+        assert_eq!(entries, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn glob_target_matches_specific_path() {
+        let backend = Arc::new(TestBackend::new().with_response("./logs/2026.txt", b"x"));
+        let _guard = with_backend(backend);
+        let m = manifest_with(Category::Fs, Action::Read, "./logs/*.txt");
+        assert!(read_file(&m, Path::new("./logs/2026.txt")).is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

First crate of the build phase. Implements `code/specs/capability-cage-rust.md` v1 — the runtime ring of the capability cage in Rust, mirroring the Go reference.

**1812 lines added across 15 files. 49 unit tests passing. Clean clippy.**

## V1 scope

- **Types** — `Category` and `Action` enums (8 categories, 14 actions) with the 19 valid pairings from the spec; `FromStr` / `Display` round-trip.
- **Capability** struct, immutable, validated at construction.
- **Errors** — `CapabilityViolationError`, `ManifestError`, `InvalidCombination` with `std::error::Error` impls.
- **Glob matcher** (`match_target`):
  - exact literal match
  - `*` (one path component / wildcard within a segment)
  - `**` (any number of components)
  - net targets `host:port` with `*` on either side
  - Windows backslash normalization
- **Manifest** with `new`, `empty`, `load_from_str`, `load_from_file` parsing `required_capabilities.json` strict schema; `has` / `check` for the triple lookup.
- **Backend trait** with three implementations:
  - `OpenBackend` — calls `std::fs`
  - `DenyAllBackend` — refuses every call (test default)
  - `TestBackend` — records calls, returns scripted responses
- **`with_backend(...)`** guard for scoped process-wide backend swap.
- **`secure_file`** module — `read_file`, `write_file`, `create_file`, `delete_file`, `list_dir`. Manifest check first, then backend delegation. `CapabilityViolationError` wrapped via `io::Error::PermissionDenied`.

## Out of scope for V1 (future PRs)

- Operation/audit envelope (`Operation<T>`, `AuditSink`)
- `secure_net` / `secure_proc` / `secure_env` / `secure_time` / `secure_stdio`
- `build.rs` codegen for `package_manifest()`
- Cross-language conformance suite shared with the Go cage
- The CI lint that rejects raw stdlib usage outside wrappers
- RWS Phase 1 enforcement (per `read-write-separation.md`)

## Test plan

- [x] Unit tests: 49 passing locally
- [x] Clippy clean on this crate (warnings elsewhere are pre-existing)
- [x] Workspace build succeeds with crate added
- [ ] Reviewer confirms the secure_file API shape matches what host-runtime-rust will need
- [ ] Reviewer confirms the `with_backend` guard semantics are right (process-wide; tests serial via `--test-threads=1`)

## Why this first

Foundation. Every substrate crate (supervisor, host-runtime-rust, orchestrator, etc.) enforces manifests via this. Without it, none of those can land. The Go sibling has been validating the design pattern; this is the Rust port that lets first-party Rust agents and the orchestrator participate.

## Next

`supervisor` crate. OTP-style strategies, child specs, restart policies. Builds on the existing `actor` crate; uses this `capability-cage` for child manifest validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
