### PR TITLE
Add Prolog filesystem operation predicates

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- `directory_fileso/2`, `make_directoryo/1`, `delete_fileo/1`,
+  `delete_directoryo/1`, `rename_fileo/2`, and `working_directoryo/2` for
+  bounded explicit filesystem operations over bound atom/string paths.
 - `exists_directoryo/1`, `absolute_file_nameo/2`, `access_fileo/2`,
   `file_directory_nameo/2`, `file_base_nameo/2`, `directory_file_patho/3`,
   `file_name_extensiono/3`, `same_fileo/2`, `size_fileo/2`, and

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -59,8 +59,11 @@ ordinary logic goal expressions.
 - `exists_fileo/1`, `exists_directoryo/1`, `absolute_file_nameo/2`,
   `access_fileo/2`, `file_directory_nameo/2`, `file_base_nameo/2`,
   `directory_file_patho/3`, `file_name_extensiono/3`, `same_fileo/2`,
-  `size_fileo/2`, `time_fileo/2`, `read_file_to_stringo/2`, and
-  `read_file_to_codeso/2` for bounded file metadata and UTF-8 file text reads
+  `size_fileo/2`, `time_fileo/2`, `directory_fileso/2`,
+  `make_directoryo/1`, `delete_fileo/1`, `delete_directoryo/1`,
+  `rename_fileo/2`, `working_directoryo/2`, `read_file_to_stringo/2`, and
+  `read_file_to_codeso/2` for bounded file metadata, explicit filesystem
+  operations, and UTF-8 file text reads
 - `openo/3`, `closeo/1`, `read_stringo/3`, `read_line_to_stringo/2`,
   `get_charo/2`, `at_end_of_streamo/1`, `writeo/2`, and `nlo/1` for bounded
   UTF-8 file stream handles

--- a/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/__init__.py
@@ -58,7 +58,10 @@ from logic_builtins.builtins import (
     current_streamo,
     cuto,
     cyclic_termo,
+    delete_directoryo,
+    delete_fileo,
     difo,
+    directory_fileso,
     directory_file_patho,
     div,
     dynamico,
@@ -117,6 +120,7 @@ from logic_builtins.builtins import (
     labelingo,
     leqo,
     lto,
+    make_directoryo,
     maplisto,
     mod,
     mul,
@@ -164,6 +168,7 @@ from logic_builtins.builtins import (
     read_file_to_stringo,
     read_line_to_stringo,
     read_stringo,
+    rename_fileo,
     repeato,
     retractallo,
     retracto,
@@ -205,6 +210,7 @@ from logic_builtins.builtins import (
     varo,
     write_currento,
     writeo,
+    working_directoryo,
 )
 
 __all__ = [
@@ -253,7 +259,10 @@ __all__ = [
     "current_streamo",
     "cuto",
     "cyclic_termo",
+    "delete_directoryo",
+    "delete_fileo",
     "difo",
+    "directory_fileso",
     "directory_file_patho",
     "div",
     "fd_addo",
@@ -314,6 +323,7 @@ __all__ = [
     "labelingo",
     "leqo",
     "lto",
+    "make_directoryo",
     "maplisto",
     "mod",
     "mul",
@@ -368,6 +378,7 @@ __all__ = [
     "read_file_to_stringo",
     "read_line_to_stringo",
     "read_stringo",
+    "rename_fileo",
     "retractallo",
     "retracto",
     "same_fileo",
@@ -409,6 +420,7 @@ __all__ = [
     "variant_termo",
     "write_currento",
     "writeo",
+    "working_directoryo",
 ]
 
 __version__ = "0.15.0"

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -118,7 +118,10 @@ __all__ = [
     "current_streamo",
     "cuto",
     "cyclic_termo",
+    "delete_directoryo",
+    "delete_fileo",
     "difo",
+    "directory_fileso",
     "directory_file_patho",
     "dynamico",
     "div",
@@ -178,6 +181,7 @@ __all__ = [
     "leqo",
     "labelingo",
     "lto",
+    "make_directoryo",
     "maplisto",
     "mod",
     "mul",
@@ -218,6 +222,7 @@ __all__ = [
     "read_stringo",
     "read_current_line_to_stringo",
     "read_current_stringo",
+    "rename_fileo",
     "repeato",
     "PrologEvaluationError",
     "PrologFlagStore",
@@ -275,6 +280,7 @@ __all__ = [
     "varo",
     "write_currento",
     "writeo",
+    "working_directoryo",
     "not_variant_termo",
     "subsumes_termo",
     "variant_termo",
@@ -5078,6 +5084,114 @@ def time_fileo(path_value: object, time_value: object) -> GoalExpr:
         yield from solve_from(program_value, eq(time_term, num(modified_at)), state)
 
     return native_goal(run, path_value, time_value)
+
+
+def directory_fileso(path_value: object, entries_value: object) -> GoalExpr:
+    """Relate a bound directory path to a sorted list of entry-name atoms."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        path_term, entries_term = args
+        path_text = _path_text(_reified(path_term, state))
+        if path_text is None:
+            return
+        try:
+            entries = sorted(path.name for path in Path(path_text).iterdir())
+        except OSError:
+            return
+        yield from solve_from(
+            program_value,
+            eq(entries_term, logic_list([atom(entry) for entry in entries])),
+            state,
+        )
+
+    return native_goal(run, path_value, entries_value)
+
+
+def make_directoryo(path_value: object) -> GoalExpr:
+    """Create one bound directory path if the immediate parent exists."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        [path_term] = args
+        path_text = _path_text(_reified(path_term, state))
+        if path_text is None:
+            return
+        try:
+            Path(path_text).mkdir()
+        except OSError:
+            return
+        yield state
+
+    return native_goal(run, path_value)
+
+
+def delete_fileo(path_value: object) -> GoalExpr:
+    """Delete one bound regular file path."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        [path_term] = args
+        path_text = _path_text(_reified(path_term, state))
+        if path_text is None:
+            return
+        try:
+            Path(path_text).unlink()
+        except OSError:
+            return
+        yield state
+
+    return native_goal(run, path_value)
+
+
+def delete_directoryo(path_value: object) -> GoalExpr:
+    """Delete one bound empty directory path."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        [path_term] = args
+        path_text = _path_text(_reified(path_term, state))
+        if path_text is None:
+            return
+        try:
+            Path(path_text).rmdir()
+        except OSError:
+            return
+        yield state
+
+    return native_goal(run, path_value)
+
+
+def rename_fileo(old_path_value: object, new_path_value: object) -> GoalExpr:
+    """Rename one bound filesystem path to another bound path."""
+
+    def run(_program: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        old_path_term, new_path_term = args
+        old_path_text = _path_text(_reified(old_path_term, state))
+        new_path_text = _path_text(_reified(new_path_term, state))
+        if old_path_text is None or new_path_text is None:
+            return
+        try:
+            Path(old_path_text).rename(new_path_text)
+        except OSError:
+            return
+        yield state
+
+    return native_goal(run, old_path_value, new_path_value)
+
+
+def working_directoryo(old_value: object, new_value: object) -> GoalExpr:
+    """Relate the current working directory and change to a bound directory."""
+
+    def run(program_value: Program, state: State, args: NativeArgs) -> Iterator[State]:
+        old_term, new_term = args
+        new_text = _path_text(_reified(new_term, state))
+        if new_text is None:
+            return
+        old_text = os.getcwd()
+        try:
+            os.chdir(new_text)
+        except OSError:
+            return
+        yield from solve_from(program_value, eq(old_term, atom(old_text)), state)
+
+    return native_goal(run, old_value, new_value)
 
 
 def read_file_to_stringo(path_value: object, contents: object) -> GoalExpr:

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -79,7 +80,10 @@ from logic_builtins import (
     current_streamo,
     cuto,
     cyclic_termo,
+    delete_directoryo,
+    delete_fileo,
     difo,
+    directory_fileso,
     directory_file_patho,
     div,
     dynamico,
@@ -137,6 +141,7 @@ from logic_builtins import (
     labelingo,
     leqo,
     lto,
+    make_directoryo,
     maplisto,
     mod,
     mul,
@@ -180,6 +185,7 @@ from logic_builtins import (
     read_file_to_stringo,
     read_line_to_stringo,
     read_stringo,
+    rename_fileo,
     repeato,
     retractallo,
     retracto,
@@ -221,6 +227,7 @@ from logic_builtins import (
     varo,
     write_currento,
     writeo,
+    working_directoryo,
 )
 
 
@@ -346,6 +353,56 @@ class TestFileTextBuiltins:
         assert size_term == num(len("fact(a).\n"))
         assert isinstance(time_term, Number)
         assert isinstance(time_term.value, int | float)
+
+    def test_file_operation_facade_mutates_bounded_paths(self, tmp_path: Path) -> None:
+        source_path = tmp_path / "draft.txt"
+        renamed_path = tmp_path / "final.txt"
+        created_directory = tmp_path / "created"
+        source_path.write_text("draft\n", encoding="utf-8")
+        old_cwd = Path.cwd()
+
+        entries = var("Entries")
+        old_directory = var("OldDirectory")
+        cwd_entries = var("CwdEntries")
+        result = var("Result")
+
+        try:
+            answers = solve_all(
+                program(),
+                result,
+                conj(
+                    make_directoryo(atom(str(created_directory))),
+                    rename_fileo(atom(str(source_path)), atom(str(renamed_path))),
+                    directory_fileso(atom(str(tmp_path)), entries),
+                    delete_fileo(atom(str(renamed_path))),
+                    delete_directoryo(atom(str(created_directory))),
+                    working_directoryo(old_directory, atom(str(tmp_path))),
+                    directory_fileso(atom("."), cwd_entries),
+                    eq(
+                        result,
+                        term(
+                            "file_operations",
+                            entries,
+                            old_directory,
+                            cwd_entries,
+                        ),
+                    ),
+                ),
+            )
+        finally:
+            os.chdir(old_cwd)
+
+        assert answers == [
+            term(
+                "file_operations",
+                logic_list(["created", "final.txt"]),
+                atom(str(old_cwd)),
+                logic_list([]),
+            ),
+        ]
+        assert not source_path.exists()
+        assert not renamed_path.exists()
+        assert not created_directory.exists()
 
     def test_file_stream_read_facade_tracks_cursor(self, tmp_path: Path) -> None:
         source_path = tmp_path / "stream.txt"

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- adapt source-level bounded filesystem operation predicates including
+  `directory_files/2`, `make_directory/1`, `delete_file/1`,
+  `delete_directory/1`, `rename_file/2`, and `working_directory/2` into the
+  executable logic builtin layer
 - adapt source-level read-only filesystem metadata predicates including
   `exists_directory/1`, `absolute_file_name/2`, `access_file/2`,
   `file_directory_name/2`, `file_base_name/2`, `directory_file_path/3`,

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -62,11 +62,13 @@ It keeps parsing side-effect free, then exposes helpers to:
   `exists_file/1`, `exists_directory/1`, `absolute_file_name/2`,
   `access_file/2`, `file_directory_name/2`, `file_base_name/2`,
   `directory_file_path/3`, `file_name_extension/3`, `same_file/2`,
-  `size_file/2`, `time_file/2`, `read_file_to_string/2`,
-  `read_file_to_codes/2`, `open/3`, `close/1`, `read_string/3`,
-  `read_line_to_string/2`, `get_char/2`, `at_end_of_stream/1`, `write/2`,
-  `nl/1`, `open/4`, `current_stream/3`, `stream_property/2`,
-  `flush_output/1`, `set_stream_position/2`, and `seek/4`
+  `size_file/2`, `time_file/2`, `directory_files/2`, `make_directory/1`,
+  `delete_file/1`, `delete_directory/1`, `rename_file/2`,
+  `working_directory/2`, `read_file_to_string/2`, `read_file_to_codes/2`,
+  `open/3`, `close/1`, `read_string/3`, `read_line_to_string/2`,
+  `get_char/2`, `at_end_of_stream/1`, `write/2`, `nl/1`, `open/4`,
+  `current_stream/3`, `stream_property/2`, `flush_output/1`,
+  `set_stream_position/2`, and `seek/4`
 - adapt selected current-stream predicates including `set_input/1`,
   `set_output/1`, `current_input/1`, `current_output/1`, `get_char/1`,
   `read_string/2`, `read_line_to_string/1`, `at_end_of_stream/0`,

--- a/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
+++ b/code/packages/python/prolog-loader/src/prolog_loader/adapters.py
@@ -50,7 +50,10 @@ from logic_builtins import (
     current_streamo,
     cuto,
     cyclic_termo,
+    delete_directoryo,
+    delete_fileo,
     difo,
+    directory_fileso,
     directory_file_patho,
     dynamico,
     excludeo,
@@ -102,6 +105,7 @@ from logic_builtins import (
     labeling_optionso,
     labelingo,
     maplisto,
+    make_directoryo,
     nl_currento,
     nlo,
     nonvaro,
@@ -143,6 +147,7 @@ from logic_builtins import (
     read_file_to_stringo,
     read_line_to_stringo,
     read_stringo,
+    rename_fileo,
     repeato,
     retractallo,
     retracto,
@@ -183,6 +188,7 @@ from logic_builtins import (
     varo,
     write_currento,
     writeo,
+    working_directoryo,
 )
 from logic_builtins.builtins import (
     _current_input_stream,
@@ -629,6 +635,18 @@ def _adapt_relation_call(
         return size_fileo(*args)
     if name == "time_file" and goal.relation.arity == 2:
         return time_fileo(*args)
+    if name == "directory_files" and goal.relation.arity == 2:
+        return directory_fileso(*args)
+    if name == "make_directory" and goal.relation.arity == 1:
+        return make_directoryo(*args)
+    if name == "delete_file" and goal.relation.arity == 1:
+        return delete_fileo(*args)
+    if name == "delete_directory" and goal.relation.arity == 1:
+        return delete_directoryo(*args)
+    if name == "rename_file" and goal.relation.arity == 2:
+        return rename_fileo(*args)
+    if name == "working_directory" and goal.relation.arity == 2:
+        return working_directoryo(*args)
     if name == "open" and goal.relation.arity == 3:
         return openo(*args)
     if name == "open" and goal.relation.arity == 4:

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -1532,6 +1533,53 @@ class TestPrologGoalAdapter:
         assert extension == atom("data")
         assert size == num(len("tea\n"))
         assert isinstance(timestamp, Number)
+
+    def test_adapt_prolog_goal_rewrites_file_operation_predicates(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        source_path = tmp_path / "draft.txt"
+        renamed_path = tmp_path / "final.txt"
+        created_directory = tmp_path / "created"
+        source_path.write_text("draft\n", encoding="utf-8")
+        path_atom = str(source_path).replace("\\", "\\\\").replace("'", "\\'")
+        renamed_atom = str(renamed_path).replace("\\", "\\\\").replace("'", "\\'")
+        created_atom = str(created_directory).replace("\\", "\\\\").replace("'", "\\'")
+        root_atom = str(tmp_path).replace("\\", "\\\\").replace("'", "\\'")
+        old_cwd = Path.cwd()
+        parsed = parse_swi_query(
+            f"?- make_directory('{created_atom}'), "
+            f"rename_file('{path_atom}', '{renamed_atom}'), "
+            f"directory_files('{root_atom}', Entries), "
+            f"delete_file('{renamed_atom}'), "
+            f"delete_directory('{created_atom}'), "
+            f"working_directory(OldDirectory, '{root_atom}'), "
+            "directory_files('.', CwdEntries).",
+        )
+
+        try:
+            answers = solve_all(
+                program(),
+                (
+                    parsed.variables["Entries"],
+                    parsed.variables["OldDirectory"],
+                    parsed.variables["CwdEntries"],
+                ),
+                adapt_prolog_goal(parsed.goal),
+            )
+        finally:
+            os.chdir(old_cwd)
+
+        assert answers == [
+            (
+                logic_list(["created", "final.txt"]),
+                atom(str(old_cwd)),
+                logic_list([]),
+            ),
+        ]
+        assert not source_path.exists()
+        assert not renamed_path.exists()
+        assert not created_directory.exists()
 
     def test_adapt_prolog_goal_rewrites_file_stream_predicates(
         self,

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Run bounded source-level filesystem operation predicates through structured
+  and bytecode VM paths, including `directory_files/2`, `make_directory/1`,
+  `delete_file/1`, `delete_directory/1`, `rename_file/2`, and
+  `working_directory/2`.
 - Run bounded source-level read-only filesystem metadata predicates through
   structured and bytecode VM paths, including `exists_directory/1`,
   `absolute_file_name/2`, `access_file/2`, `file_directory_name/2`,
@@ -35,7 +39,7 @@
   paths, including `open/4` `type(binary)`, `get_byte/1,2`, `peek_byte/1,2`,
   and `put_byte/1,2`.
 - Add a public Prolog VM capability manifest and `prolog-vm --dump-capabilities`
-  so scripts and future planning can distinguish the completed PR00-PR87 track
+  so scripts and future planning can distinguish the completed PR00-PR88 track
   from deferred advanced dialect/runtime work.
 - Add end-to-end stress coverage for recursive search, modules, DCGs,
   arithmetic, collections, dynamic initialization, named answers, and expansion.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -249,7 +249,7 @@ assert [answer.as_dict() for answer in runtime.query("ancestor(homer, Who)")] ==
 
 ## Capability Manifest
 
-The Prolog-on-Logic-VM implementation track covers PR00 through PR87. The
+The Prolog-on-Logic-VM implementation track covers PR00 through PR88. The
 package exposes that as a machine-readable manifest so downstream tools and
 future implementation work can distinguish completed functionality from
 deliberately deferred advanced dialect/runtime emulation:
@@ -259,7 +259,7 @@ from prolog_vm_compiler import prolog_vm_capability_manifest
 
 manifest = prolog_vm_capability_manifest()
 
-assert manifest.status == "core-plus-filesystem-metadata"
+assert manifest.status == "core-plus-filesystem-operations"
 assert manifest.dialects == ("iso", "swi")
 assert manifest.backends == ("structured", "bytecode")
 ```
@@ -287,13 +287,16 @@ byte stream I/O through `open/4` `type(binary)`, `get_byte/1,2`,
 `peek_byte/1,2`, and `put_byte/1,2`, plus read-only filesystem metadata
 through `exists_directory/1`, `absolute_file_name/2`, `access_file/2`,
 `file_directory_name/2`, `file_base_name/2`, `directory_file_path/3`,
-`file_name_extension/3`, `same_file/2`, `size_file/2`, and `time_file/2`.
+`file_name_extension/3`, `same_file/2`, `size_file/2`, and `time_file/2`, plus
+bounded filesystem operations through `directory_files/2`,
+`make_directory/1`, `delete_file/1`, `delete_directory/1`, `rename_file/2`,
+and `working_directory/2`.
 The manifest also names the remaining advanced-dialect work that is intentionally
 outside the completed batches: full external dialect emulation, tabling and
 well-founded negation, generalized attributed-variable/coroutining services,
-non-FD constraint domains, console streams, mutable filesystem services, richer
-stream services beyond the bounded file-backed subset, foreign predicates,
-engines, and concurrency.
+non-FD constraint domains, console streams, recursive or wildcard filesystem
+services, richer stream services beyond the bounded file-backed subset, foreign
+predicates, engines, and concurrency.
 
 ## CLI
 
@@ -467,6 +470,9 @@ The package includes end-to-end stress tests for:
   `absolute_file_name/2`, `access_file/2`, `file_directory_name/2`,
   `file_base_name/2`, `directory_file_path/3`, `file_name_extension/3`,
   `same_file/2`, `size_file/2`, and `time_file/2`
+- bounded filesystem operations with `directory_files/2`, `make_directory/1`,
+  `delete_file/1`, `delete_directory/1`, `rename_file/2`, and
+  `working_directory/2`
 - bounded UTF-8 file stream I/O with `open/3`, `close/1`,
   `read_string/3`, `read_line_to_string/2`, `get_char/2`,
   `at_end_of_stream/1`, `write/2`, and `nl/1`

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
@@ -326,6 +326,21 @@ def prolog_vm_capabilities() -> tuple[PrologVMCapability, ...]:
                 "structured and bytecode VM stress coverage",
             ),
         ),
+        PrologVMCapability(
+            id="host-filesystem-operations",
+            title="Bounded host filesystem operations",
+            status="complete",
+            specs=("PR88",),
+            packages=("logic-builtins", "prolog-loader", "prolog-vm-compiler"),
+            features=(
+                "directory_files/2 enumerates sorted directory entry names",
+                "make_directory/1 and delete_directory/1 manage empty directories",
+                "delete_file/1 removes one bound regular file path",
+                "rename_file/2 renames one bound filesystem path",
+                "working_directory/2 changes to an explicit bound directory",
+                "structured and bytecode VM stress coverage",
+            ),
+        ),
     )
 
 
@@ -365,7 +380,7 @@ def deferred_prolog_vm_capabilities() -> tuple[PrologVMCapability, ...]:
             features=(
                 "console-backed standard streams and richer binary stream services",
                 "rich ISO/SWI stream options beyond bounded text/binary files",
-                "mutable filesystem services beyond read-only metadata",
+                "recursive and wildcard filesystem services beyond bounded paths",
                 "foreign predicates and host callbacks",
                 "engines, concurrency, and async integration",
             ),
@@ -377,8 +392,8 @@ def prolog_vm_capability_manifest() -> PrologVMCapabilityManifest:
     """Return the canonical capability manifest for this package."""
 
     return PrologVMCapabilityManifest(
-        track="Prolog-on-Logic-VM PR00-PR87",
-        status="core-plus-filesystem-metadata",
+        track="Prolog-on-Logic-VM PR00-PR88",
+        status="core-plus-filesystem-operations",
         dialects=("iso", "swi"),
         backends=("structured", "bytecode"),
         capabilities=prolog_vm_capabilities(),

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_bytecode_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_bytecode_vm_stress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from logic_engine import Compound, Number, atom, logic_list, num, string, term
@@ -358,6 +359,47 @@ class TestPrologBytecodeVMStress:
             },
         ]
         assert isinstance(answers[0].as_dict()["Time"], Number)
+
+    def test_file_operation_predicates_run_through_bytecode_vm(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        source_path = tmp_path / "draft.txt"
+        renamed_path = tmp_path / "final.txt"
+        created_directory = tmp_path / "created"
+        source_path.write_text("draft\n", encoding="utf-8")
+        path_atom = str(source_path).replace("\\", "\\\\").replace("'", "\\'")
+        renamed_atom = str(renamed_path).replace("\\", "\\\\").replace("'", "\\'")
+        created_atom = str(created_directory).replace("\\", "\\\\").replace("'", "\\'")
+        root_atom = str(tmp_path).replace("\\", "\\\\").replace("'", "\\'")
+        old_cwd = Path.cwd()
+        compiled = compile_swi_prolog_source(
+            f"""
+            ?- make_directory('{created_atom}'),
+               rename_file('{path_atom}', '{renamed_atom}'),
+               directory_files('{root_atom}', Entries),
+               delete_file('{renamed_atom}'),
+               delete_directory('{created_atom}'),
+               working_directory(OldDirectory, '{root_atom}'),
+               directory_files('.', CwdEntries).
+            """,
+        )
+
+        try:
+            answers = run_compiled_prolog_bytecode_query_answers(compiled)
+        finally:
+            os.chdir(old_cwd)
+
+        assert _answer_dicts(answers) == [
+            {
+                "Entries": logic_list(["created", "final.txt"]),
+                "OldDirectory": atom(str(old_cwd)),
+                "CwdEntries": logic_list([]),
+            },
+        ]
+        assert not source_path.exists()
+        assert not renamed_path.exists()
+        assert not created_directory.exists()
 
     def test_file_stream_io_matches_structured_vm(self, tmp_path: Path) -> None:
         source_path = tmp_path / "stream.pltxt"

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
@@ -9,31 +9,31 @@ from prolog_vm_compiler import (
 )
 
 
-def test_manifest_marks_filesystem_metadata_extension_complete() -> None:
+def test_manifest_marks_filesystem_operations_extension_complete() -> None:
     manifest = prolog_vm_capability_manifest()
 
-    assert manifest.track == "Prolog-on-Logic-VM PR00-PR87"
-    assert manifest.status == "core-plus-filesystem-metadata"
+    assert manifest.track == "Prolog-on-Logic-VM PR00-PR88"
+    assert manifest.status == "core-plus-filesystem-operations"
     assert manifest.dialects == ("iso", "swi")
     assert manifest.backends == ("structured", "bytecode")
-    assert manifest.complete_count == 17
+    assert manifest.complete_count == 18
     assert manifest.deferred_count == 3
 
 
-def test_completed_capabilities_cover_pr00_through_pr87_once() -> None:
+def test_completed_capabilities_cover_pr00_through_pr88_once() -> None:
     covered_specs = [
         spec for capability in prolog_vm_capabilities() for spec in capability.specs
     ]
 
-    assert covered_specs == [f"PR{index:02d}" for index in range(88)]
+    assert covered_specs == [f"PR{index:02d}" for index in range(89)]
 
 
 def test_capability_manifest_is_json_serializable() -> None:
     payload = prolog_vm_capability_manifest().as_dict()
 
-    assert payload["status"] == "core-plus-filesystem-metadata"
+    assert payload["status"] == "core-plus-filesystem-operations"
     assert payload["capabilities"][0]["id"] == "frontend-loader"
-    assert payload["capabilities"][-1]["id"] == "host-filesystem-metadata"
+    assert payload["capabilities"][-1]["id"] == "host-filesystem-operations"
     assert payload["deferred_capabilities"][0]["status"] == "deferred"
 
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -21,11 +21,11 @@ def test_cli_dumps_capability_manifest_without_source(
     assert status == 0
     assert payload["success"] is True
     assert payload["mode"] == "capabilities"
-    assert payload["status"] == "core-plus-filesystem-metadata"
+    assert payload["status"] == "core-plus-filesystem-operations"
     assert payload["dialects"] == ["iso", "swi"]
     assert payload["backends"] == ["structured", "bytecode"]
     assert payload["capabilities"][0]["specs"][0] == "PR00"
-    assert payload["capabilities"][-1]["specs"][-1] == "PR87"
+    assert payload["capabilities"][-1]["specs"][-1] == "PR88"
 
 
 def test_cli_dump_capabilities_rejects_source_modes(

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from logic_engine import (
@@ -1074,6 +1075,44 @@ class TestPrologVMStress:
             },
         ]
         assert isinstance(answers[0].as_dict()["Time"], Number)
+
+    def test_file_operation_predicates_run_through_vm(self, tmp_path: Path) -> None:
+        source_path = tmp_path / "draft.txt"
+        renamed_path = tmp_path / "final.txt"
+        created_directory = tmp_path / "created"
+        source_path.write_text("draft\n", encoding="utf-8")
+        path_atom = str(source_path).replace("\\", "\\\\").replace("'", "\\'")
+        renamed_atom = str(renamed_path).replace("\\", "\\\\").replace("'", "\\'")
+        created_atom = str(created_directory).replace("\\", "\\\\").replace("'", "\\'")
+        root_atom = str(tmp_path).replace("\\", "\\\\").replace("'", "\\'")
+        old_cwd = Path.cwd()
+        compiled = compile_swi_prolog_source(
+            f"""
+            ?- make_directory('{created_atom}'),
+               rename_file('{path_atom}', '{renamed_atom}'),
+               directory_files('{root_atom}', Entries),
+               delete_file('{renamed_atom}'),
+               delete_directory('{created_atom}'),
+               working_directory(OldDirectory, '{root_atom}'),
+               directory_files('.', CwdEntries).
+            """,
+        )
+
+        try:
+            answers = run_compiled_prolog_query_answers(compiled)
+        finally:
+            os.chdir(old_cwd)
+
+        assert [answer.as_dict() for answer in answers] == [
+            {
+                "Entries": logic_list(["created", "final.txt"]),
+                "OldDirectory": atom(str(old_cwd)),
+                "CwdEntries": logic_list([]),
+            },
+        ]
+        assert not source_path.exists()
+        assert not renamed_path.exists()
+        assert not created_directory.exists()
 
     def test_file_stream_predicates_run_through_vm(self, tmp_path: Path) -> None:
         source_path = tmp_path / "stream.pltxt"

--- a/code/specs/PR02-prolog-dialects-and-vm-gap-analysis.md
+++ b/code/specs/PR02-prolog-dialects-and-vm-gap-analysis.md
@@ -19,12 +19,13 @@ can land in a few coherent batches rather than many tiny compatibility PRs.
 
 ## Core Track Status
 
-As of the PR00-PR87 Prolog-on-Logic-VM track, the shared core is implemented
+As of the PR00-PR88 Prolog-on-Logic-VM track, the shared core is implemented
 through the parser, loader, expansion, VM compiler, structured VM runtime,
 bytecode VM runtime, source/file/project runner APIs, top-level query APIs, the
 `prolog-vm` CLI, bounded UTF-8 file text I/O, and bounded UTF-8 file stream
 handles with alias/metadata/positioning/current-stream support, bounded binary
-byte stream I/O, and read-only filesystem metadata predicates.
+byte stream I/O, read-only filesystem metadata predicates, and bounded
+filesystem operations.
 
 The core track is now treated as complete for practical ISO/SWI-subset work:
 
@@ -57,6 +58,10 @@ The core track is now treated as complete for practical ISO/SWI-subset work:
   `access_file/2`, `file_directory_name/2`, `file_base_name/2`,
   `directory_file_path/3`, `file_name_extension/3`, `same_file/2`,
   `size_file/2`, and `time_file/2`.
+- Bound atom/string paths can be enumerated or explicitly mutated with
+  filesystem operation predicates including `directory_files/2`,
+  `make_directory/1`, `delete_file/1`, `delete_directory/1`, `rename_file/2`,
+  and `working_directory/2`.
 - The CLI provides source/query execution, check mode, structured instruction
   dumps, bytecode dumps, source-query metadata, all-query execution,
   interactive mode, text/JSON/JSONL output, summaries, machine-readable
@@ -64,13 +69,14 @@ The core track is now treated as complete for practical ISO/SWI-subset work:
 
 The package-level source of truth is `prolog_vm_capability_manifest()` and the
 matching `prolog-vm --dump-capabilities` CLI output. New work should update
-that manifest instead of reopening open-ended PR00-PR87 gap analysis.
+that manifest instead of reopening open-ended PR00-PR88 gap analysis.
 
 Remaining work in this document is advanced dialect and runtime emulation:
 full external Prolog dialect compatibility, tabling, attributed variables,
 generalized coroutining, CHR/non-FD constraint domains, console/rich stream
-services beyond the bounded file-backed text/binary subset, mutable filesystem
-services, foreign predicates, engines, concurrency, and async host integration.
+services beyond the bounded file-backed text/binary subset, recursive or
+wildcard filesystem services, foreign predicates, engines, concurrency, and
+async host integration.
 
 ## Current Project Surface
 
@@ -109,8 +115,8 @@ Current support:
   exceptions, flags, CLP(FD), DCG expansion, consult/include, source/file
   runners, bounded UTF-8 file text reads and file stream handles with aliases,
   current-stream selection, cursor positioning, bounded binary byte stream I/O,
-  read-only filesystem metadata predicates, bytecode parity, and
-  machine-readable tooling.
+  read-only filesystem metadata predicates, bounded filesystem operations,
+  bytecode parity, and machine-readable tooling.
 - Missing or incomplete for full ISO-system emulation: console-backed standard
   streams, richer binary stream services, rich stream options beyond the
   bounded file-backed subset, full ISO standard-library breadth, every ISO
@@ -254,7 +260,8 @@ The current Logic VM cannot yet support full external dialect behavior for:
 
 - complete ISO standard predicate semantics and every ISO error-term nuance
 - console-backed standard streams, richer binary stream services, rich stream
-  options beyond the bounded file-backed subset, and mutable filesystem services
+  options beyond the bounded file-backed subset, and recursive or wildcard
+  filesystem services
 - attributed variables
 - generalized coroutining
 - tabled execution and well-founded semantics
@@ -368,12 +375,12 @@ This is a major runtime feature and should be its own batch.
 
 ## Historical Implementation Batches
 
-The original gap analysis proposed these implementation batches. PR00-PR87
+The original gap analysis proposed these implementation batches. PR00-PR88
 completed the core versions of Batches 1-5, added a broad Prolog stdlib and
 CLP(FD) compatibility layer, delivered runner/CLI tooling, and added bounded
 file text and stream I/O with aliases/metadata/positioning/current-stream
-selection, bounded binary byte stream I/O, and read-only filesystem metadata.
-Batch 6 remains future advanced dialect work.
+selection, bounded binary byte stream I/O, read-only filesystem metadata, and
+bounded filesystem operations. Batch 6 remains future advanced dialect work.
 
 ### Batch 1 - Grammar and Dialect Profile Foundation
 

--- a/code/specs/PR88-prolog-filesystem-operations.md
+++ b/code/specs/PR88-prolog-filesystem-operations.md
@@ -1,0 +1,58 @@
+# PR88 - Prolog Filesystem Operations
+
+## Goal
+
+Close the bounded filesystem operation gap that remains after PR87 metadata.
+This batch gives Prolog programs deterministic directory enumeration and
+explicit path mutation predicates without adding recursive deletion, globbing,
+shell execution, or ambient host callbacks.
+
+This batch adds:
+
+- `directory_files/2`
+- `make_directory/1`
+- `delete_file/1`
+- `delete_directory/1`
+- `rename_file/2`
+- `working_directory/2`
+
+## Semantics
+
+All path arguments must be bound atoms or strings. Invalid path shapes, missing
+inputs, existing outputs, non-empty directories, and operating system failures
+fail deterministically.
+
+`directory_files(Directory, Entries)` relates a bound directory path to a
+sorted list of entry-name atoms. The bounded subset reports actual entries in
+that directory and does not synthesize `.` or `..`.
+
+`make_directory/1` creates one directory level when the immediate parent exists.
+`delete_directory/1` removes one empty directory. `delete_file/1` removes one
+bound file path. `rename_file/2` renames one bound filesystem path to another
+bound path.
+
+`working_directory(Old, New)` unifies `Old` with the process working directory
+before changing to the bound directory `New`. This operation is intentionally
+explicit because the underlying host process working directory is global.
+
+## Validation
+
+Coverage should prove:
+
+- direct logic-builtin goals mutate only explicitly bound temp paths and restore
+  process working directory state in tests.
+- source-level Prolog calls adapt through `prolog-loader`.
+- structured VM and bytecode VM run matching filesystem operation programs.
+- the capability manifest records PR88 as complete while leaving recursive or
+  wildcard filesystem services, console streams, rich stream options, foreign
+  predicates, engines, and async host services deferred.
+
+## Non-goals
+
+- no recursive directory deletion
+- no globbing, wildcard expansion, or directory walking
+- no shell/process predicates
+- no ISO/SWI exception taxonomy; invalid bounded operations fail
+  deterministically
+- no sandbox or capability policy beyond explicit bound path arguments and the
+  host process permissions


### PR DESCRIPTION
## Summary

- Add bounded filesystem operation builtins for directory enumeration, one-level directory creation/removal, file deletion, renaming, and working-directory changes.
- Adapt the new source-level Prolog predicates through prolog-loader and cover them through structured and bytecode VM stress tests.
- Record PR88 in the capability manifest/spec/docs while keeping recursive/wildcard filesystem services and richer host runtime work deferred.

## Verification

- `bash BUILD` in `code/packages/python/logic-builtins`
- `bash BUILD` in `code/packages/python/prolog-loader`
- `bash BUILD` in `code/packages/python/prolog-vm-compiler`
- `git diff --check`
