### PR TITLE
Add seeded character reference lexer contexts

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -35,6 +35,12 @@ documented in this file.
 - html5lib-style smoke fixture coverage for seeded DOCTYPE continuations,
   including missing-whitespace diagnostics, identifier accumulation, and
   force-quirks preservation.
+- Parser/importer-facing seeded text/RCDATA character-reference continuation
+  contexts, including named, numeric, decimal, and hexadecimal substates with
+  temporary-buffer plus return-state seeding.
+- html5lib-style smoke fixture coverage for seeded character-reference
+  continuations returning to both data and RCDATA, including missing-semicolon
+  and absence-of-digits diagnostics.
 
 ### Changed
 - Switched the stable `create_html_lexer` and `lex_html` API over from the
@@ -286,3 +292,6 @@ documented in this file.
   data, and escaped script data, including EOF literalization, mismatched end
   tag text recovery, and matching whitespace/attribute/trailing-solidus
   diagnostics in both direct lexer tests and html5lib-style fixtures.
+- Added typed character-reference continuation contexts and importer
+  `returnState` metadata so normalized html5lib-style fixtures can resume
+  text/RCDATA named and numeric reference substates.

--- a/code/packages/rust/html-lexer/README.md
+++ b/code/packages/rust/html-lexer/README.md
@@ -184,6 +184,10 @@ including comment start/dash, less-than/bang/dash substates, end-dash/end-bang,
 and bogus-comment recovery. This lets html5lib-style importer cases resume
 comment tokenization with an in-progress comment token instead of treating those
 states as runtime gaps.
+It also covers text/RCDATA character-reference continuation states. A seeded
+temporary buffer plus return state lets importer and parser-adapter fixtures
+resume named, numeric, decimal, and hexadecimal reference recovery without
+depending on raw generated machine internals.
 DOCTYPE continuation states are also exposed through the same typed layer. A
 seeded `DoctypeSeed` carries the partial name, public identifier, system
 identifier, and force-quirks flag so importer and parser-adapter tests can
@@ -236,8 +240,8 @@ fixture normalization logic to live forever inside the Rust tests.
 
 The normalized corpus now carries optional tokenizer-context metadata such as
 `initial_state` and `last_start_tag`, so upstream RCDATA, RAWTEXT, PLAINTEXT,
-CDATA section, comment and DOCTYPE continuation states, script data, script data
-escaped/dash/less-than/end-tag-open substates, and script data
+CDATA section, comment, character-reference, and DOCTYPE continuation states,
+script data, script data escaped/dash/less-than/end-tag-open substates, and script data
 double-escaped/dash/less-than substates can already live in the shared Venture
 fixture format. Current Rust conformance tests now seed that context into the
 generated lexer so non-data-state cases execute through the same static Rust
@@ -251,6 +255,8 @@ mismatched tags that must remain literal text, EOF recovery that preserves the
 pending `</`, and matching end-tag diagnostics for whitespace, attributes, and
 trailing solidus. Comment continuation fixtures cover seeded body, pending dash,
 pending bang, nested-comment, abrupt-close, and bogus-comment recovery paths.
+Character-reference continuation fixtures cover seeded named and numeric
+buffers returning to both data and RCDATA.
 DOCTYPE continuation fixtures cover keyword/name continuation, public/system
 identifier accumulation, missing-whitespace diagnostics, and bogus-doctype
 force-quirks preservation.

--- a/code/packages/rust/html-lexer/src/lib.rs
+++ b/code/packages/rust/html-lexer/src/lib.rs
@@ -86,6 +86,12 @@ pub enum HtmlTokenizerState {
     DoctypeSystemIdentifierSingleQuoted,
     AfterDoctypeSystemIdentifier,
     BogusDoctype,
+    TextCharacterReference,
+    TextNamedCharacterReference,
+    TextNumericCharacterReference,
+    TextNumericHexCharacterReferenceStart,
+    TextNumericHexCharacterReference,
+    TextNumericDecimalCharacterReference,
     ScriptData,
     ScriptDataLessThanSign,
     ScriptDataEndTagOpen,
@@ -113,7 +119,7 @@ pub enum HtmlTokenizerState {
 }
 
 /// Tokenizer states that are valid parser-facing entry points.
-pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 86] = [
+pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 92] = [
     HtmlTokenizerState::Data,
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
@@ -176,6 +182,12 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 86] = [
     HtmlTokenizerState::DoctypeSystemIdentifierSingleQuoted,
     HtmlTokenizerState::AfterDoctypeSystemIdentifier,
     HtmlTokenizerState::BogusDoctype,
+    HtmlTokenizerState::TextCharacterReference,
+    HtmlTokenizerState::TextNamedCharacterReference,
+    HtmlTokenizerState::TextNumericCharacterReference,
+    HtmlTokenizerState::TextNumericHexCharacterReferenceStart,
+    HtmlTokenizerState::TextNumericHexCharacterReference,
+    HtmlTokenizerState::TextNumericDecimalCharacterReference,
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
@@ -203,7 +215,7 @@ pub const HTML_TOKENIZER_STATES: [HtmlTokenizerState; 86] = [
 ];
 
 /// Tokenizer states used for parser-controlled text or foreign-content fragments.
-pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 85] = [
+pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 91] = [
     HtmlTokenizerState::Rcdata,
     HtmlTokenizerState::RcdataLessThanSign,
     HtmlTokenizerState::RcdataEndTagOpen,
@@ -265,6 +277,12 @@ pub const HTML_FRAGMENT_TOKENIZER_STATES: [HtmlTokenizerState; 85] = [
     HtmlTokenizerState::DoctypeSystemIdentifierSingleQuoted,
     HtmlTokenizerState::AfterDoctypeSystemIdentifier,
     HtmlTokenizerState::BogusDoctype,
+    HtmlTokenizerState::TextCharacterReference,
+    HtmlTokenizerState::TextNamedCharacterReference,
+    HtmlTokenizerState::TextNumericCharacterReference,
+    HtmlTokenizerState::TextNumericHexCharacterReferenceStart,
+    HtmlTokenizerState::TextNumericHexCharacterReference,
+    HtmlTokenizerState::TextNumericDecimalCharacterReference,
     HtmlTokenizerState::ScriptData,
     HtmlTokenizerState::ScriptDataLessThanSign,
     HtmlTokenizerState::ScriptDataEndTagOpen,
@@ -423,6 +441,16 @@ impl HtmlTokenizerState {
             Self::DoctypeSystemIdentifierSingleQuoted => "doctype_system_identifier_single_quoted",
             Self::AfterDoctypeSystemIdentifier => "after_doctype_system_identifier",
             Self::BogusDoctype => "bogus_doctype",
+            Self::TextCharacterReference => "text_character_reference",
+            Self::TextNamedCharacterReference => "text_named_character_reference",
+            Self::TextNumericCharacterReference => "text_numeric_character_reference",
+            Self::TextNumericHexCharacterReferenceStart => {
+                "text_numeric_hex_character_reference_start"
+            }
+            Self::TextNumericHexCharacterReference => "text_numeric_hex_character_reference",
+            Self::TextNumericDecimalCharacterReference => {
+                "text_numeric_decimal_character_reference"
+            }
             Self::ScriptData => "script_data",
             Self::ScriptDataLessThanSign => "script_data_less_than_sign",
             Self::ScriptDataEndTagOpen => "script_data_end_tag_open",
@@ -527,6 +555,14 @@ impl HtmlTokenizerState {
             }
             Self::AfterDoctypeSystemIdentifier => "After DOCTYPE system identifier state",
             Self::BogusDoctype => "Bogus DOCTYPE state",
+            Self::TextCharacterReference => "Character reference state",
+            Self::TextNamedCharacterReference => "Named character reference state",
+            Self::TextNumericCharacterReference => "Numeric character reference state",
+            Self::TextNumericHexCharacterReferenceStart => {
+                "Hexadecimal character reference start state"
+            }
+            Self::TextNumericHexCharacterReference => "Hexadecimal character reference state",
+            Self::TextNumericDecimalCharacterReference => "Decimal character reference state",
             Self::ScriptData => "Script data state",
             Self::ScriptDataLessThanSign => "Script data less-than sign state",
             Self::ScriptDataEndTagOpen => "Script data end tag open state",
@@ -591,6 +627,24 @@ impl HtmlTokenizerState {
     /// Return whether this state resumes an already-started DOCTYPE token.
     pub fn requires_doctype_seed(self) -> bool {
         HTML_DOCTYPE_TOKENIZER_STATES.contains(&self)
+    }
+
+    /// Return whether this state resumes an in-progress text character reference.
+    pub fn requires_character_reference_seed(self) -> bool {
+        matches!(
+            self,
+            Self::TextCharacterReference
+                | Self::TextNamedCharacterReference
+                | Self::TextNumericCharacterReference
+                | Self::TextNumericHexCharacterReferenceStart
+                | Self::TextNumericHexCharacterReference
+                | Self::TextNumericDecimalCharacterReference
+        )
+    }
+
+    /// Return whether this state can receive recovered character-reference text.
+    pub fn is_character_reference_return_state(self) -> bool {
+        matches!(self, Self::Data | Self::Rcdata)
     }
 
     /// Return whether this state is a parser-approved fragment entry point.
@@ -670,6 +724,7 @@ pub struct HtmlLexContext {
     pub current_comment: Option<String>,
     pub current_doctype: Option<DoctypeSeed>,
     pub temporary_buffer: Option<String>,
+    pub return_state: Option<HtmlTokenizerState>,
 }
 
 impl HtmlLexContext {
@@ -681,6 +736,7 @@ impl HtmlLexContext {
             current_comment: None,
             current_doctype: None,
             temporary_buffer: None,
+            return_state: None,
         }
     }
 
@@ -736,6 +792,11 @@ impl HtmlLexContext {
         self
     }
 
+    pub fn with_return_state(mut self, state: HtmlTokenizerState) -> Self {
+        self.return_state = Some(state);
+        self
+    }
+
     pub fn is_data(&self) -> bool {
         self.initial_state == HtmlTokenizerState::Data
             && self.last_start_tag.is_none()
@@ -743,6 +804,7 @@ impl HtmlLexContext {
             && self.current_comment.is_none()
             && self.current_doctype.is_none()
             && self.temporary_buffer.is_none()
+            && self.return_state.is_none()
     }
 
     /// Return a comment tokenizer continuation context for importer/parser tests.
@@ -773,6 +835,29 @@ impl HtmlLexContext {
     ) -> Option<Self> {
         if initial_state.requires_doctype_seed() {
             Some(Self::new(initial_state).with_current_doctype(seed))
+        } else {
+            None
+        }
+    }
+
+    /// Return a text/RCDATA character-reference continuation context.
+    ///
+    /// These states resume after the caller has already consumed `&` and
+    /// accumulated any partial reference text in the temporary buffer. The
+    /// return state records whether recovery should resume in data or RCDATA.
+    pub fn character_reference_continuation(
+        initial_state: HtmlTokenizerState,
+        return_state: HtmlTokenizerState,
+        temporary_buffer: impl Into<String>,
+    ) -> Option<Self> {
+        if initial_state.requires_character_reference_seed()
+            && return_state.is_character_reference_return_state()
+        {
+            Some(
+                Self::new(initial_state)
+                    .with_return_state(return_state)
+                    .with_temporary_buffer(temporary_buffer),
+            )
         } else {
             None
         }
@@ -867,6 +952,11 @@ pub fn apply_html_lex_context(lexer: &mut HtmlLexer, context: &HtmlLexContext) -
         lexer.set_temporary_buffer(temporary_buffer);
     } else {
         lexer.clear_temporary_buffer();
+    }
+    if let Some(return_state) = context.return_state {
+        lexer.set_return_state(return_state.as_machine_state())?;
+    } else {
+        lexer.clear_return_state();
     }
     Ok(())
 }

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -40,6 +40,8 @@ struct FixtureCase {
     current_doctype: Option<FixtureDoctypeSeed>,
     #[serde(default)]
     temporary_buffer: Option<String>,
+    #[serde(default)]
+    return_state: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -74,6 +76,8 @@ struct Html5libTokenizerTest {
     current_end_tag: Option<String>,
     #[serde(default, rename = "temporaryBuffer")]
     temporary_buffer: Option<String>,
+    #[serde(default, rename = "returnState")]
+    return_state: Option<String>,
     #[serde(default, rename = "currentComment")]
     current_comment: Option<String>,
     #[serde(default, rename = "currentDoctype")]
@@ -294,6 +298,15 @@ fn normalized_html5lib_fixture_parses_with_importer_metadata() {
                 == Some("DOCTYPE public identifier double quoted state")),
         "normalized fixtures should include seeded doctype continuation states"
     );
+    assert!(
+        normalized
+            .cases
+            .iter()
+            .any(|case| case.return_state.as_deref() == Some("RCDATA state")
+                && case.temporary_buffer.as_deref() == Some("&a")
+                && case.initial_state.as_deref() == Some("Named character reference state")),
+        "normalized fixtures should include seeded character-reference continuation states"
+    );
 }
 
 #[test]
@@ -412,6 +425,7 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
                 && case.current_comment.is_none()
                 && case.current_doctype.is_none()
                 && case.temporary_buffer.is_none()
+                && case.return_state.is_none()
         }
         Some(initial_state) => {
             let Some(state) = HtmlTokenizerState::from_html5lib_state(initial_state) else {
@@ -421,16 +435,33 @@ fn is_supported_by_current_runtime(case: &FixtureCase) -> bool {
                 case.current_end_tag.is_some() && case.temporary_buffer.is_some();
             let has_comment_seed = case.current_comment.is_some();
             let has_doctype_seed = case.current_doctype.is_some();
-            state.requires_last_start_tag() == case.last_start_tag.is_some()
+            let has_character_reference_seed =
+                case.return_state.is_some() && case.temporary_buffer.is_some();
+            let return_state = case
+                .return_state
+                .as_deref()
+                .and_then(HtmlTokenizerState::from_html5lib_state);
+            let needs_last_start_tag = state.requires_last_start_tag()
+                || (state.requires_character_reference_seed()
+                    && return_state == Some(HtmlTokenizerState::Rcdata));
+            needs_last_start_tag == case.last_start_tag.is_some()
                 && state.requires_end_tag_seed() == has_end_tag_seed
                 && state.requires_comment_seed() == has_comment_seed
                 && state.requires_doctype_seed() == has_doctype_seed
+                && state.requires_character_reference_seed() == has_character_reference_seed
                 && (has_end_tag_seed
+                    || has_character_reference_seed
                     || (case.current_end_tag.is_none() && case.temporary_buffer.is_none()))
                 && (!has_doctype_seed
                     || (case.current_end_tag.is_none()
                         && case.current_comment.is_none()
                         && case.temporary_buffer.is_none()))
+                && (!has_character_reference_seed
+                    || (case.current_end_tag.is_none()
+                        && case.current_comment.is_none()
+                        && case.current_doctype.is_none()
+                        && return_state
+                            .is_some_and(HtmlTokenizerState::is_character_reference_return_state)))
         }
     }
 }
@@ -503,6 +534,13 @@ fn configure_lexer_for_case(
     }
     if let Some(temporary_buffer) = case.temporary_buffer.as_deref() {
         context = context.with_temporary_buffer(temporary_buffer);
+    }
+    if let Some(return_state) = case
+        .return_state
+        .as_deref()
+        .and_then(HtmlTokenizerState::from_html5lib_state)
+    {
+        context = context.with_return_state(return_state);
     }
     apply_html_lex_context(lexer, &context)
 }

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -32,6 +32,7 @@ Each file is a JSON object with this shape:
       "current_end_tag": "optional in-progress end-tag token context",
       "current_doctype": "optional in-progress doctype token context",
       "temporary_buffer": "optional tokenizer temporary-buffer context",
+      "return_state": "optional tokenizer return-state context",
       "diagnostics": ["optional-diagnostic-code"]
     }
   ]
@@ -74,6 +75,9 @@ resume with an already-created comment token.
 DOCTYPE continuation fixtures accept a `currentDoctype` extension object,
 lowered to `current_doctype`, with optional `name`, `public_identifier`,
 `system_identifier`, and `force_quirks` fields for the partial doctype token.
+Character-reference continuation fixtures accept `temporaryBuffer` plus
+`returnState`, lowered to `temporary_buffer` and `return_state`, so seeded
+named/numeric reference substates can recover back into data or RCDATA.
 
 `normalize_html5lib_fixtures.py` is the checked-in importer for this shape. It
 currently supports:
@@ -85,6 +89,9 @@ currently supports:
 - `initialStates: ["PLAINTEXT state"]`
 - `initialStates: ["CDATA section state"]`
 - CDATA section `bracket` and `end` substates
+- character-reference, named-reference, numeric-reference, decimal-reference,
+  and hexadecimal-reference substates together with `temporaryBuffer` and
+  `returnState`
 - comment `start`, `start dash`, body, less-than-sign, less-than-sign bang,
   less-than-sign bang dash, less-than-sign bang dash dash, end-dash, end,
   end-bang, and bogus-comment substates together with `currentComment`
@@ -191,8 +198,10 @@ discarded. End-tag continuation coverage intentionally exercises matching,
 mismatched, EOF, and diagnostic recovery paths so parser/tokenizer handoff
 regressions show up in the shared fixture corpus instead of only in narrow unit
 tests. Comment continuation coverage does the same for pending dash/bang and
-bogus-comment recovery paths. DOCTYPE continuation coverage exercises partial
-keyword/name, identifier, diagnostic, and bogus-doctype recovery paths.
+bogus-comment recovery paths. Character-reference continuation coverage
+exercises seeded named/numeric reference recovery returning to data and RCDATA.
+DOCTYPE continuation coverage exercises partial keyword/name, identifier,
+diagnostic, and bogus-doctype recovery paths.
 
 To regenerate the normalized corpus:
 

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -19,6 +19,7 @@
     "CDATA section bracket state",
     "CDATA section end state",
     "CDATA section state",
+    "Character reference state",
     "Comment end bang state",
     "Comment end dash state",
     "Comment end state",
@@ -52,6 +53,11 @@
     "DOCTYPE system keyword T state",
     "DOCTYPE system keyword Y state",
     "Data state",
+    "Decimal character reference state",
+    "Hexadecimal character reference start state",
+    "Hexadecimal character reference state",
+    "Named character reference state",
+    "Numeric character reference state",
     "PLAINTEXT state",
     "RAWTEXT end tag attributes state",
     "RAWTEXT end tag name state",
@@ -2794,6 +2800,90 @@
         "name": "html",
         "force_quirks": true
       }
+    },
+    {
+      "id": "html5lib-smoke-214",
+      "description": "named character reference continuation returns to data state",
+      "input": "py;!",
+      "tokens": [
+        "Text(data=\u00a9!)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Named character reference state",
+      "temporary_buffer": "&co",
+      "return_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-215",
+      "description": "named character reference continuation can return to rcdata",
+      "input": "mp; &amp;</title>",
+      "tokens": [
+        "Text(data=& &)",
+        "EndTag(name=title)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Named character reference state",
+      "last_start_tag": "title",
+      "temporary_buffer": "&a",
+      "return_state": "RCDATA state"
+    },
+    {
+      "id": "html5lib-smoke-216",
+      "description": "numeric character reference continuation resumes decimal digits",
+      "input": "5;!",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Decimal character reference state",
+      "temporary_buffer": "&#6",
+      "return_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-217",
+      "description": "hex character reference continuation recovers missing semicolon",
+      "input": "1!",
+      "tokens": [
+        "Text(data=A!)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "missing-semicolon-after-character-reference"
+      ],
+      "initial_state": "Hexadecimal character reference state",
+      "temporary_buffer": "&#x4",
+      "return_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-218",
+      "description": "numeric character reference start continuation reports absent digits",
+      "input": ";!",
+      "tokens": [
+        "Text(data=&#;!)",
+        "EOF"
+      ],
+      "diagnostics": [
+        "absence-of-digits-in-numeric-character-reference"
+      ],
+      "initial_state": "Numeric character reference state",
+      "temporary_buffer": "&#",
+      "return_state": "Data state"
+    },
+    {
+      "id": "html5lib-smoke-219",
+      "description": "character reference state falls back through temporary buffer",
+      "input": " nope",
+      "tokens": [
+        "Text(data=& nope)",
+        "EOF"
+      ],
+      "diagnostics": [],
+      "initial_state": "Character reference state",
+      "temporary_buffer": "&",
+      "return_state": "Data state"
     }
   ],
   "skipped": []

--- a/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
@@ -14,6 +14,7 @@ SUPPORTED_INITIAL_STATES = {
     "CDATA section bracket state",
     "CDATA section end state",
     "CDATA section state",
+    "Character reference state",
     "Bogus comment state",
     "Comment end bang state",
     "Comment end dash state",
@@ -58,6 +59,11 @@ SUPPORTED_INITIAL_STATES = {
     "Before DOCTYPE system identifier state",
     "Between DOCTYPE public and system identifiers state",
     "Bogus DOCTYPE state",
+    "Decimal character reference state",
+    "Hexadecimal character reference start state",
+    "Hexadecimal character reference state",
+    "Named character reference state",
+    "Numeric character reference state",
     "PLAINTEXT state",
     "RCDATA end tag attributes state",
     "RCDATA end tag name state",
@@ -208,6 +214,20 @@ DOCTYPE_SEED_INITIAL_STATES = {
     "Bogus DOCTYPE state",
 }
 
+CHARACTER_REFERENCE_INITIAL_STATES = {
+    "Character reference state",
+    "Decimal character reference state",
+    "Hexadecimal character reference start state",
+    "Hexadecimal character reference state",
+    "Named character reference state",
+    "Numeric character reference state",
+}
+
+CHARACTER_REFERENCE_RETURN_STATES = {
+    "Data state",
+    "RCDATA state",
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -275,10 +295,18 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
         for initial_state in initial_states
         if initial_state in LAST_START_TAG_INITIAL_STATES
     ]
+    character_reference_returns_to_rcdata = (
+        any(initial_state in CHARACTER_REFERENCE_INITIAL_STATES for initial_state in initial_states)
+        and test.get("returnState") == "RCDATA state"
+    )
     if needs_last_start_tag and not isinstance(last_start_tag, str):
         return False, f"{needs_last_start_tag[0]} requires lastStartTag"
 
-    if last_start_tag is not None and len(needs_last_start_tag) != len(initial_states):
+    if (
+        last_start_tag is not None
+        and len(needs_last_start_tag) != len(initial_states)
+        and not character_reference_returns_to_rcdata
+    ):
         return False, f"unsupported lastStartTag={last_start_tag!r}"
 
     needs_end_tag_seed = [
@@ -289,9 +317,13 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     has_end_tag_seed = isinstance(test.get("currentEndTag"), str) and isinstance(
         test.get("temporaryBuffer"), str
     )
-    has_partial_end_tag_seed = test.get("currentEndTag") is not None or test.get(
-        "temporaryBuffer"
-    ) is not None
+    has_partial_end_tag_seed = test.get("currentEndTag") is not None or (
+        test.get("temporaryBuffer") is not None
+        and not any(
+            initial_state in CHARACTER_REFERENCE_INITIAL_STATES
+            for initial_state in initial_states
+        )
+    )
     if needs_end_tag_seed and not has_end_tag_seed:
         return False, f"{needs_end_tag_seed[0]} requires currentEndTag and temporaryBuffer"
 
@@ -300,6 +332,30 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
 
     if has_end_tag_seed and len(needs_end_tag_seed) != len(initial_states):
         return False, "currentEndTag/temporaryBuffer only supported for continuation states"
+
+    needs_character_reference_seed = [
+        initial_state
+        for initial_state in initial_states
+        if initial_state in CHARACTER_REFERENCE_INITIAL_STATES
+    ]
+    has_character_reference_seed = isinstance(test.get("returnState"), str) and isinstance(
+        test.get("temporaryBuffer"), str
+    )
+    has_partial_character_reference_seed = test.get("returnState") is not None
+    if needs_character_reference_seed and not has_character_reference_seed:
+        return False, f"{needs_character_reference_seed[0]} requires returnState and temporaryBuffer"
+
+    if has_partial_character_reference_seed and not has_character_reference_seed:
+        return False, "returnState and temporaryBuffer must be provided together"
+
+    if has_character_reference_seed and len(needs_character_reference_seed) != len(initial_states):
+        return False, "returnState/temporaryBuffer only supported for character-reference states"
+
+    if has_character_reference_seed and test.get("returnState") not in CHARACTER_REFERENCE_RETURN_STATES:
+        return False, "character-reference returnState must be Data state or RCDATA state"
+
+    if has_end_tag_seed and has_character_reference_seed:
+        return False, "end-tag and character-reference continuations cannot be combined"
 
     needs_comment_seed = [
         initial_state
@@ -313,7 +369,12 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if has_comment_seed and len(needs_comment_seed) != len(initial_states):
         return False, "currentComment only supported for comment continuation states"
 
-    if has_comment_seed and (has_end_tag_seed or has_partial_end_tag_seed):
+    if has_comment_seed and (
+        has_end_tag_seed
+        or has_partial_end_tag_seed
+        or has_character_reference_seed
+        or has_partial_character_reference_seed
+    ):
         return False, "currentComment cannot be combined with end-tag continuation context"
 
     needs_doctype_seed = [
@@ -328,7 +389,13 @@ def is_supported(test: dict[str, Any]) -> tuple[bool, str]:
     if has_doctype_seed and len(needs_doctype_seed) != len(initial_states):
         return False, "currentDoctype only supported for doctype continuation states"
 
-    if has_doctype_seed and (has_end_tag_seed or has_partial_end_tag_seed or has_comment_seed):
+    if has_doctype_seed and (
+        has_end_tag_seed
+        or has_partial_end_tag_seed
+        or has_comment_seed
+        or has_character_reference_seed
+        or has_partial_character_reference_seed
+    ):
         return False, "currentDoctype cannot be combined with other current-token context"
 
     for token in test.get("output", []):
@@ -405,6 +472,10 @@ def normalize_case(
     temporary_buffer = test.get("temporaryBuffer")
     if temporary_buffer is not None:
         normalized["temporary_buffer"] = temporary_buffer
+
+    return_state = test.get("returnState")
+    if return_state is not None:
+        normalized["return_state"] = return_state
 
     current_comment = test.get("currentComment")
     if current_comment is not None:

--- a/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
+++ b/code/packages/rust/html-lexer/tests/fixtures/upstream-html5lib-smoke.test
@@ -3085,6 +3085,115 @@
           "tail"
         ]
       ]
+    },
+    {
+      "description": "named character reference continuation returns to data state",
+      "input": "py;!",
+      "initialStates": [
+        "Named character reference state"
+      ],
+      "returnState": "Data state",
+      "temporaryBuffer": "&co",
+      "output": [
+        [
+          "Character",
+          "©!"
+        ]
+      ]
+    },
+    {
+      "description": "named character reference continuation can return to rcdata",
+      "input": "mp; &amp;</title>",
+      "initialStates": [
+        "Named character reference state"
+      ],
+      "returnState": "RCDATA state",
+      "temporaryBuffer": "&a",
+      "lastStartTag": "title",
+      "output": [
+        [
+          "Character",
+          "& &"
+        ],
+        [
+          "EndTag",
+          "title"
+        ]
+      ]
+    },
+    {
+      "description": "numeric character reference continuation resumes decimal digits",
+      "input": "5;!",
+      "initialStates": [
+        "Decimal character reference state"
+      ],
+      "returnState": "Data state",
+      "temporaryBuffer": "&#6",
+      "output": [
+        [
+          "Character",
+          "A!"
+        ]
+      ]
+    },
+    {
+      "description": "hex character reference continuation recovers missing semicolon",
+      "input": "1!",
+      "initialStates": [
+        "Hexadecimal character reference state"
+      ],
+      "returnState": "Data state",
+      "temporaryBuffer": "&#x4",
+      "output": [
+        [
+          "Character",
+          "A!"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "missing-semicolon-after-character-reference",
+          "line": 1,
+          "col": 2
+        }
+      ]
+    },
+    {
+      "description": "numeric character reference start continuation reports absent digits",
+      "input": ";!",
+      "initialStates": [
+        "Numeric character reference state"
+      ],
+      "returnState": "Data state",
+      "temporaryBuffer": "&#",
+      "output": [
+        [
+          "Character",
+          "&#;!"
+        ]
+      ],
+      "errors": [
+        {
+          "code": "absence-of-digits-in-numeric-character-reference",
+          "line": 1,
+          "col": 1
+        }
+      ]
+    },
+    {
+      "description": "character reference state falls back through temporary buffer",
+      "input": " nope",
+      "initialStates": [
+        "Character reference state"
+      ],
+      "returnState": "Data state",
+      "temporaryBuffer": "&",
+      "output": [
+        [
+          "Character",
+          "& nope"
+        ]
+      ]
     }
   ]
 }

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -5090,6 +5090,12 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
             "doctype_system_identifier_single_quoted",
             "after_doctype_system_identifier",
             "bogus_doctype",
+            "text_character_reference",
+            "text_named_character_reference",
+            "text_numeric_character_reference",
+            "text_numeric_hex_character_reference_start",
+            "text_numeric_hex_character_reference",
+            "text_numeric_decimal_character_reference",
             "script_data",
             "script_data_less_than_sign",
             "script_data_end_tag_open",
@@ -5184,10 +5190,18 @@ fn parser_facing_context_exposes_tokenizer_state_sets() {
     assert!(HtmlTokenizerState::DoctypeName.requires_doctype_seed());
     assert!(HtmlTokenizerState::AfterDoctypePublicIdentifier.requires_doctype_seed());
     assert!(HtmlTokenizerState::BogusDoctype.requires_doctype_seed());
+    assert!(HtmlTokenizerState::TextCharacterReference.requires_character_reference_seed());
+    assert!(HtmlTokenizerState::TextNamedCharacterReference.requires_character_reference_seed());
+    assert!(
+        HtmlTokenizerState::TextNumericHexCharacterReference.requires_character_reference_seed()
+    );
+    assert!(HtmlTokenizerState::Data.is_character_reference_return_state());
+    assert!(HtmlTokenizerState::Rcdata.is_character_reference_return_state());
     assert!(!HtmlTokenizerState::RcdataEndTagOpen.requires_end_tag_seed());
     assert!(!HtmlTokenizerState::CdataSectionEnd.requires_last_start_tag());
     assert!(!HtmlTokenizerState::Data.requires_comment_seed());
     assert!(!HtmlTokenizerState::Data.requires_doctype_seed());
+    assert!(!HtmlTokenizerState::Rawtext.is_character_reference_return_state());
 
     assert_eq!(
         HTML_DOCTYPE_TOKENIZER_STATES.map(HtmlTokenizerState::as_machine_state),
@@ -5610,6 +5624,90 @@ fn parser_facing_context_seeds_doctype_continuation_states() {
 
     assert_eq!(
         HtmlLexContext::doctype_continuation(HtmlTokenizerState::Rcdata, DoctypeSeed::new()),
+        None
+    );
+}
+
+#[test]
+fn parser_facing_context_seeds_character_reference_continuation_states() {
+    let named = HtmlLexContext::character_reference_continuation(
+        HtmlTokenizerState::TextNamedCharacterReference,
+        HtmlTokenizerState::Data,
+        "&co",
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("py;!", &named).unwrap(),
+        vec![Token::Text("©!".to_string()), Token::Eof]
+    );
+
+    let rcdata = HtmlLexContext::character_reference_continuation(
+        HtmlTokenizerState::TextNamedCharacterReference,
+        HtmlTokenizerState::Rcdata,
+        "&a",
+    )
+    .unwrap()
+    .with_last_start_tag("title");
+    assert_eq!(
+        lex_html_fragment("mp; &amp;</title>", &rcdata).unwrap(),
+        vec![
+            Token::Text("& &".to_string()),
+            Token::EndTag {
+                name: "title".to_string()
+            },
+            Token::Eof
+        ]
+    );
+
+    let decimal = HtmlLexContext::character_reference_continuation(
+        HtmlTokenizerState::TextNumericDecimalCharacterReference,
+        HtmlTokenizerState::Data,
+        "&#6",
+    )
+    .unwrap();
+    assert_eq!(
+        lex_html_fragment("5;!", &decimal).unwrap(),
+        vec![Token::Text("A!".to_string()), Token::Eof]
+    );
+
+    let mut lexer = create_html_lexer_with_context(
+        &HtmlLexContext::character_reference_continuation(
+            HtmlTokenizerState::TextNumericHexCharacterReference,
+            HtmlTokenizerState::Data,
+            "&#x4",
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    lexer.push("1!").unwrap();
+    lexer.finish().unwrap();
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![Token::Text("A!".to_string()), Token::Eof]
+    );
+    assert_eq!(
+        lexer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec!["missing-semicolon-after-character-reference"]
+    );
+
+    assert_eq!(
+        HtmlLexContext::character_reference_continuation(
+            HtmlTokenizerState::TextNamedCharacterReference,
+            HtmlTokenizerState::Rawtext,
+            "&amp",
+        ),
+        None
+    );
+    assert_eq!(
+        HtmlLexContext::character_reference_continuation(
+            HtmlTokenizerState::Rcdata,
+            HtmlTokenizerState::Data,
+            "&",
+        ),
         None
     );
 }

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -48,3 +48,5 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
 - Added `DoctypeSeed` and current-DOCTYPE seeding helpers so wrapper packages
   can resume DOCTYPE continuation states while preserving partial name,
   identifier, and force-quirks data.
+- Added public return-state seeding helpers so wrapper packages can resume
+  continuation states such as HTML character-reference recovery.

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -128,10 +128,10 @@ The runtime also exposes context-seeding helpers such as
 `Tokenizer::set_initial_state`, `Tokenizer::set_last_start_tag`,
 `Tokenizer::set_current_end_tag`, `Tokenizer::set_current_comment`, and
 `Tokenizer::set_current_doctype` with `DoctypeSeed`, plus
-`Tokenizer::set_temporary_buffer`, so wrapper packages can execute HTML
-submodes and continuation states like RCDATA end-tag-name, comment end-dash, or
-DOCTYPE public identifier continuation without loading definition files at
-runtime.
+`Tokenizer::set_temporary_buffer` and `Tokenizer::set_return_state`, so wrapper
+packages can execute HTML submodes and continuation states like RCDATA
+end-tag-name, comment end-dash, character-reference recovery, or DOCTYPE public
+identifier continuation without loading definition files at runtime.
 
 Wrapper packages can opt into HTML-style input-stream newline preprocessing
 with `Tokenizer::with_normalized_carriage_returns`. That maps CRLF pairs and

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -356,6 +356,12 @@ impl Tokenizer {
         self
     }
 
+    /// Seed the tokenizer return state used by character-reference continuations.
+    pub fn with_return_state(mut self, state: &str) -> Result<Self> {
+        self.set_return_state(state)?;
+        Ok(self)
+    }
+
     /// Store the tokenizer temporary buffer used by continuation states.
     pub fn set_temporary_buffer(&mut self, value: impl Into<String>) {
         self.temporary_buffer = value.into();
@@ -364,6 +370,20 @@ impl Tokenizer {
     /// Clear the tokenizer temporary buffer.
     pub fn clear_temporary_buffer(&mut self) {
         self.temporary_buffer.clear();
+    }
+
+    /// Store the tokenizer return state used by continuation states.
+    pub fn set_return_state(&mut self, state: &str) -> Result<()> {
+        if !self.machine.has_state(state) {
+            return Err(TokenizerError::Machine(format!("Unknown state '{state}'")));
+        }
+        self.return_state = Some(state.to_string());
+        Ok(())
+    }
+
+    /// Clear the tokenizer return state.
+    pub fn clear_return_state(&mut self) {
+        self.return_state = None;
     }
 
     /// Push one chunk of Unicode text into the tokenizer.


### PR DESCRIPTION
## Summary

- Add typed text/RCDATA character-reference continuation states with return-state and temporary-buffer seeding.
- Thread return-state seeding through the tokenizer runtime, HtmlLexContext, conformance harness, and html5lib-style normalizer.
- Add raw and generated html5lib smoke coverage for named/numeric character-reference continuations, including RCDATA return, missing-semicolon, and absence-of-digits recovery.

## Verification

- cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml
- cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml
- git diff --check
