### PR TITLE
Add Prolog standard stream support

### DIFF
--- a/code/packages/python/logic-builtins/CHANGELOG.md
+++ b/code/packages/python/logic-builtins/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- standard `user_input`, `user_output`, and `user_error` stream aliases plus
+  richer accepted `open_optionso/4` metadata for `reposition`, `eof_action`,
+  `buffer`, and `close_on_abort`.
 - `expand_file_nameo/2`, `make_directory_patho/1`,
   `delete_directory_and_contentso/1`, and `copy_fileo/2` for bounded
   recursive/wildcard filesystem operations over bound atom/string paths.

--- a/code/packages/python/logic-builtins/README.md
+++ b/code/packages/python/logic-builtins/README.md
@@ -70,8 +70,9 @@ ordinary logic goal expressions.
   `get_charo/2`, `at_end_of_streamo/1`, `writeo/2`, and `nlo/1` for bounded
   UTF-8 file stream handles
 - `open_optionso/4`, `current_streamo/3`, `stream_propertyo/2`, and
-  `flush_outputo/1` for bounded stream aliases, option validation, and
-  metadata
+  `flush_outputo/1` for bounded stream aliases, option validation, metadata,
+  standard `user_input`/`user_output`/`user_error` streams, and accepted
+  `reposition`, `eof_action`, `buffer`, and `close_on_abort` options
 - `set_stream_positiono/2` and `seeko/4` for bounded read-stream cursor
   repositioning
 - `set_inputo/1`, `set_outputo/1`, `current_inputo/1`, `current_outputo/1`,

--- a/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
+++ b/code/packages/python/logic-builtins/src/logic_builtins/builtins.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import glob
 import os
 import shutil
+import sys
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from hashlib import blake2b
@@ -316,13 +317,45 @@ class _TextStream:
     binary_contents: bytes = b""
     cursor: int = 0
     alias: str | None = None
+    display_name: str | None = None
+    standard_stream: str | None = None
+    option_properties: tuple[Term, ...] = ()
 
 
 _STREAM_IDS = count(1)
-_STREAMS: dict[str, _TextStream] = {}
-_STREAM_ALIASES: dict[str, str] = {}
-_CURRENT_INPUT_HANDLE: str | None = None
-_CURRENT_OUTPUT_HANDLE: str | None = None
+_STANDARD_INPUT_HANDLE = "$stream_user_input"
+_STANDARD_OUTPUT_HANDLE = "$stream_user_output"
+_STANDARD_ERROR_HANDLE = "$stream_user_error"
+_STREAMS: dict[str, _TextStream] = {
+    _STANDARD_INPUT_HANDLE: _TextStream(
+        mode="read",
+        path=Path("<user_input>"),
+        alias="user_input",
+        display_name="user_input",
+        standard_stream="user_input",
+    ),
+    _STANDARD_OUTPUT_HANDLE: _TextStream(
+        mode="append",
+        path=Path("<user_output>"),
+        alias="user_output",
+        display_name="user_output",
+        standard_stream="user_output",
+    ),
+    _STANDARD_ERROR_HANDLE: _TextStream(
+        mode="append",
+        path=Path("<user_error>"),
+        alias="user_error",
+        display_name="user_error",
+        standard_stream="user_error",
+    ),
+}
+_STREAM_ALIASES: dict[str, str] = {
+    "user_input": _STANDARD_INPUT_HANDLE,
+    "user_output": _STANDARD_OUTPUT_HANDLE,
+    "user_error": _STANDARD_ERROR_HANDLE,
+}
+_CURRENT_INPUT_HANDLE: str | None = _STANDARD_INPUT_HANDLE
+_CURRENT_OUTPUT_HANDLE: str | None = _STANDARD_OUTPUT_HANDLE
 
 
 @dataclass(frozen=True, slots=True)
@@ -5359,6 +5392,7 @@ def _open_text_stream(
     *,
     alias_text: str | None = None,
     stream_type: str = "text",
+    option_properties: tuple[Term, ...] = (),
 ) -> _TextStream | None:
     path = Path(path_text)
     try:
@@ -5372,6 +5406,7 @@ def _open_text_stream(
                     stream_type=stream_type,
                     contents=path.read_text(encoding="utf-8"),
                     alias=alias_text,
+                    option_properties=option_properties,
                 )
             if mode_text == "write":
                 path.write_text("", encoding="utf-8")
@@ -5380,6 +5415,7 @@ def _open_text_stream(
                     path=path,
                     stream_type=stream_type,
                     alias=alias_text,
+                    option_properties=option_properties,
                 )
             if mode_text == "append":
                 path.parent.mkdir(parents=True, exist_ok=True)
@@ -5389,6 +5425,7 @@ def _open_text_stream(
                     path=path,
                     stream_type=stream_type,
                     alias=alias_text,
+                    option_properties=option_properties,
                 )
         if stream_type == "binary":
             if mode_text == "read":
@@ -5400,6 +5437,7 @@ def _open_text_stream(
                     stream_type=stream_type,
                     binary_contents=path.read_bytes(),
                     alias=alias_text,
+                    option_properties=option_properties,
                 )
             if mode_text == "write":
                 path.write_bytes(b"")
@@ -5408,6 +5446,7 @@ def _open_text_stream(
                     path=path,
                     stream_type=stream_type,
                     alias=alias_text,
+                    option_properties=option_properties,
                 )
             if mode_text == "append":
                 path.parent.mkdir(parents=True, exist_ok=True)
@@ -5417,6 +5456,7 @@ def _open_text_stream(
                     path=path,
                     stream_type=stream_type,
                     alias=alias_text,
+                    option_properties=option_properties,
                 )
     except OSError:
         return None
@@ -5425,7 +5465,14 @@ def _open_text_stream(
     return None
 
 
-def _open_options(term_value: Term) -> tuple[str | None, str] | None:
+def _boolean_option_value(term_value: Term) -> str | None:
+    value_text = _plain_atom_text(term_value)
+    if value_text in {"true", "false"}:
+        return value_text
+    return None
+
+
+def _open_options(term_value: Term) -> tuple[str | None, str, tuple[Term, ...]] | None:
     items = _proper_list_items(term_value)
     if items is None:
         return None
@@ -5433,6 +5480,7 @@ def _open_options(term_value: Term) -> tuple[str | None, str] | None:
     alias_text: str | None = None
     stream_type = "text"
     has_encoding = False
+    option_properties: list[Term] = []
     for item in items:
         if not isinstance(item, Compound) or len(item.args) != 1:
             return None
@@ -5451,6 +5499,7 @@ def _open_options(term_value: Term) -> tuple[str | None, str] | None:
             if encoding_text not in {"utf8", "utf-8"}:
                 return None
             has_encoding = True
+            option_properties.append(term("encoding", atom("utf8")))
             continue
 
         if option_name == "type":
@@ -5460,11 +5509,39 @@ def _open_options(term_value: Term) -> tuple[str | None, str] | None:
             stream_type = parsed_type
             continue
 
+        if option_name == "reposition":
+            reposition_text = _boolean_option_value(option_arg)
+            if reposition_text is None:
+                return None
+            option_properties.append(term("reposition", atom(reposition_text)))
+            continue
+
+        if option_name == "eof_action":
+            eof_action_text = _plain_atom_text(option_arg)
+            if eof_action_text not in {"eof_code", "error", "reset"}:
+                return None
+            option_properties.append(term("eof_action", atom(eof_action_text)))
+            continue
+
+        if option_name == "buffer":
+            buffer_text = _plain_atom_text(option_arg)
+            if buffer_text not in {"full", "line", "false"}:
+                return None
+            option_properties.append(term("buffer", atom(buffer_text)))
+            continue
+
+        if option_name == "close_on_abort":
+            close_on_abort_text = _boolean_option_value(option_arg)
+            if close_on_abort_text is None:
+                return None
+            option_properties.append(term("close_on_abort", atom(close_on_abort_text)))
+            continue
+
         return None
 
     if stream_type == "binary" and has_encoding:
         return None
-    return (alias_text, stream_type)
+    return (alias_text, stream_type, tuple(option_properties))
 
 
 def _register_stream(handle: Atom, stream: _TextStream) -> bool:
@@ -5515,12 +5592,13 @@ def open_optionso(
         if path_text is None or mode_text is None or parsed_options is None:
             return
 
-        alias_text, stream_type = parsed_options
+        alias_text, stream_type, option_properties = parsed_options
         stream = _open_text_stream(
             path_text,
             mode_text,
             alias_text=alias_text,
             stream_type=stream_type,
+            option_properties=option_properties,
         )
         if stream is None:
             return
@@ -5542,6 +5620,12 @@ def closeo(stream_value: object) -> GoalExpr:
         [stream_term] = args
         handle_text = _stream_key(_reified(stream_term, state))
         if handle_text is None or handle_text not in _STREAMS:
+            return
+        if handle_text in {
+            _STANDARD_INPUT_HANDLE,
+            _STANDARD_OUTPUT_HANDLE,
+            _STANDARD_ERROR_HANDLE,
+        }:
             return
         stream = _STREAMS.pop(handle_text)
         if stream.alias is not None:
@@ -6284,6 +6368,16 @@ def _write_stream(term_value: Term, text: str) -> bool:
         or stream.stream_type != "text"
     ):
         return False
+    if stream.standard_stream == "user_output":
+        sys.stdout.write(text)
+        stream.contents += text
+        stream.cursor += len(text)
+        return True
+    if stream.standard_stream == "user_error":
+        sys.stderr.write(text)
+        stream.contents += text
+        stream.cursor += len(text)
+        return True
     try:
         with stream.path.open("a", encoding="utf-8") as file:
             file.write(text)
@@ -6380,6 +6474,10 @@ def flush_outputo(stream_value: object) -> GoalExpr:
         handle_text = _stream_key(_reified(stream_term, state))
         stream = _STREAMS.get(handle_text) if handle_text is not None else None
         if stream is not None and stream.mode in {"write", "append"}:
+            if stream.standard_stream == "user_output":
+                sys.stdout.flush()
+            if stream.standard_stream == "user_error":
+                sys.stderr.flush()
             yield state
 
     return native_goal(run, stream_value)
@@ -6389,7 +6487,13 @@ def flush_current_outputo() -> GoalExpr:
     """Validate the selected output stream; writes are already flushed."""
 
     def run(_program: Program, state: State, _args: NativeArgs) -> Iterator[State]:
-        if _current_output_stream_term() is not None:
+        output_stream = _current_output_stream_term()
+        if output_stream is not None:
+            stream = _STREAMS.get(output_stream.symbol.name)
+            if stream is not None and stream.standard_stream == "user_output":
+                sys.stdout.flush()
+            if stream is not None and stream.standard_stream == "user_error":
+                sys.stderr.flush()
             yield state
 
     return native_goal(run)
@@ -6408,7 +6512,7 @@ def current_streamo(
             yield from solve_from(
                 program_value,
                 conj(
-                    eq(path_term, atom(str(stream.path))),
+                    eq(path_term, atom(_stream_display_name(stream))),
                     eq(mode_term, atom(stream.mode)),
                     eq(stream_term, atom(handle_text)),
                 ),
@@ -6418,9 +6522,13 @@ def current_streamo(
     return native_goal(run, path_value, mode_value, stream_value)
 
 
+def _stream_display_name(stream: _TextStream) -> str:
+    return stream.display_name if stream.display_name is not None else str(stream.path)
+
+
 def _stream_properties(handle_text: str, stream: _TextStream) -> tuple[Term, ...]:
     properties: list[Term] = [
-        term("file_name", atom(str(stream.path))),
+        term("file_name", atom(_stream_display_name(stream))),
         term("mode", atom(stream.mode)),
         term("type", atom(stream.stream_type)),
         term("position", num(stream.cursor)),
@@ -6437,6 +6545,7 @@ def _stream_properties(handle_text: str, stream: _TextStream) -> tuple[Term, ...
             properties.append(atom("current_output"))
     if stream.alias is not None:
         properties.append(term("alias", atom(stream.alias)))
+    properties.extend(stream.option_properties)
     properties.append(term("handle", atom(handle_text)))
     return tuple(properties)
 

--- a/code/packages/python/logic-builtins/tests/test_logic_builtins.py
+++ b/code/packages/python/logic-builtins/tests/test_logic_builtins.py
@@ -869,6 +869,55 @@ class TestFileTextBuiltins:
         assert line_answer == string("def")
         assert output_path.read_text(encoding="utf-8") == "tea\ncake(slice)"
 
+    def test_standard_streams_are_available_by_default(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        current_input = var("CurrentInput")
+        current_output = var("CurrentOutput")
+        path = var("Path")
+        mode = var("Mode")
+        handle = var("Handle")
+        result = var("Result")
+
+        answers = solve_all(
+            program(),
+            result,
+            conj(
+                set_inputo(atom("user_input")),
+                set_outputo(atom("user_output")),
+                current_inputo(current_input),
+                current_outputo(current_output),
+                at_end_of_current_streamo(),
+                write_currento(string("stdout")),
+                nl_currento(),
+                writeo(atom("user_error"), string("stderr")),
+                flush_current_outputo(),
+                flush_outputo(atom("user_error")),
+                stream_propertyo(atom("user_input"), term("alias", atom("user_input"))),
+                stream_propertyo(
+                    atom("user_output"),
+                    term("alias", atom("user_output")),
+                ),
+                current_streamo(path, mode, handle),
+                eq(path, atom("user_error")),
+                eq(mode, atom("append")),
+                eq(handle, atom("$stream_user_error")),
+                eq(result, term("standard_streams", current_input, current_output)),
+            ),
+        )
+
+        captured = capsys.readouterr()
+        assert answers == [
+            term(
+                "standard_streams",
+                atom("$stream_user_input"),
+                atom("$stream_user_output"),
+            ),
+        ]
+        assert captured.out == "stdout\n"
+        assert captured.err == "stderr"
+
 
 class TestAdvancedControlBuiltins:
     """Advanced control should stay honest about committed search behavior."""

--- a/code/packages/python/prolog-loader/CHANGELOG.md
+++ b/code/packages/python/prolog-loader/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- adapt source-level standard stream aliases and richer stream options,
+  including `user_input`, `user_output`, `user_error`, `reposition/1`,
+  `eof_action/1`, `buffer/1`, and `close_on_abort/1`
 - adapt source-level recursive/wildcard filesystem operation predicates
   including `expand_file_name/2`, `make_directory_path/1`,
   `delete_directory_and_contents/1`, and `copy_file/2` into the executable

--- a/code/packages/python/prolog-loader/README.md
+++ b/code/packages/python/prolog-loader/README.md
@@ -70,7 +70,9 @@ It keeps parsing side-effect free, then exposes helpers to:
   `read_string/3`, `read_line_to_string/2`, `get_char/2`,
   `at_end_of_stream/1`, `write/2`, `nl/1`, `open/4`, `current_stream/3`,
   `stream_property/2`, `flush_output/1`, `set_stream_position/2`, and
-  `seek/4`
+  `seek/4`, including standard `user_input`, `user_output`, and `user_error`
+  streams plus accepted `reposition`, `eof_action`, `buffer`, and
+  `close_on_abort` options
 - adapt selected current-stream predicates including `set_input/1`,
   `set_output/1`, `current_input/1`, `current_output/1`, `get_char/1`,
   `read_string/2`, `read_line_to_string/1`, `at_end_of_stream/0`,

--- a/code/packages/python/prolog-loader/tests/test_prolog_loader.py
+++ b/code/packages/python/prolog-loader/tests/test_prolog_loader.py
@@ -1661,10 +1661,17 @@ class TestPrologGoalAdapter:
         path_atom = str(source_path).replace("\\", "\\\\").replace("'", "\\'")
         parsed = parse_swi_query(
             f"?- open('{path_atom}', write, Out, "
-            "[alias(report_stream), encoding(utf8), type(text)]), "
+            "[alias(report_stream), encoding(utf8), type(text), "
+            "reposition(true), eof_action(eof_code), buffer(line), "
+            "close_on_abort(false)]), "
             'write(report_stream, "tea"), '
             "flush_output(report_stream), "
             "stream_property(report_stream, alias(Alias)), "
+            "stream_property(report_stream, encoding(Encoding)), "
+            "stream_property(report_stream, reposition(Reposition)), "
+            "stream_property(report_stream, eof_action(EofAction)), "
+            "stream_property(report_stream, buffer(Buffer)), "
+            "stream_property(report_stream, close_on_abort(CloseOnAbort)), "
             "current_stream(Path, Mode, Out), "
             "close(report_stream).",
         )
@@ -1673,12 +1680,59 @@ class TestPrologGoalAdapter:
             program(),
             (
                 parsed.variables["Alias"],
+                parsed.variables["Encoding"],
+                parsed.variables["Reposition"],
+                parsed.variables["EofAction"],
+                parsed.variables["Buffer"],
+                parsed.variables["CloseOnAbort"],
                 parsed.variables["Path"],
                 parsed.variables["Mode"],
             ),
             adapt_prolog_goal(parsed.goal),
-        ) == [(atom("report_stream"), atom(str(source_path)), atom("write"))]
+        ) == [
+            (
+                atom("report_stream"),
+                atom("utf8"),
+                atom("true"),
+                atom("eof_code"),
+                atom("line"),
+                atom("false"),
+                atom(str(source_path)),
+                atom("write"),
+            ),
+        ]
         assert source_path.read_text(encoding="utf-8") == "tea"
+
+    def test_adapt_prolog_goal_rewrites_standard_streams(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parsed = parse_swi_query(
+            "?- set_input(user_input), "
+            "set_output(user_output), "
+            "current_input(CurrentIn), "
+            "current_output(CurrentOut), "
+            "at_end_of_stream, "
+            'write("stdout"), '
+            "nl, "
+            'write(user_error, "stderr"), '
+            "flush_output, "
+            "flush_output(user_error), "
+            "stream_property(user_input, alias(user_input)), "
+            "stream_property(user_output, alias(user_output)), "
+            "current_stream(user_error, append, '$stream_user_error').",
+        )
+
+        answers = solve_all(
+            program(),
+            (parsed.variables["CurrentIn"], parsed.variables["CurrentOut"]),
+            adapt_prolog_goal(parsed.goal),
+        )
+
+        captured = capsys.readouterr()
+        assert answers == [(atom("$stream_user_input"), atom("$stream_user_output"))]
+        assert captured.out == "stdout\n"
+        assert captured.err == "stderr"
 
     def test_adapt_prolog_goal_rewrites_stream_positioning(
         self,

--- a/code/packages/python/prolog-vm-compiler/CHANGELOG.md
+++ b/code/packages/python/prolog-vm-compiler/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Run standard stream aliases and richer accepted stream options through
+  structured and bytecode VM paths, including `user_input`, `user_output`,
+  `user_error`, `reposition/1`, `eof_action/1`, `buffer/1`, and
+  `close_on_abort/1`.
 - Run bounded source-level recursive/wildcard filesystem operation predicates
   through structured and bytecode VM paths, including `expand_file_name/2`,
   `make_directory_path/1`, `delete_directory_and_contents/1`, and
@@ -43,7 +47,7 @@
   paths, including `open/4` `type(binary)`, `get_byte/1,2`, `peek_byte/1,2`,
   and `put_byte/1,2`.
 - Add a public Prolog VM capability manifest and `prolog-vm --dump-capabilities`
-  so scripts and future planning can distinguish the completed PR00-PR89 track
+  so scripts and future planning can distinguish the completed PR00-PR90 track
   from deferred advanced dialect/runtime work.
 - Add end-to-end stress coverage for recursive search, modules, DCGs,
   arithmetic, collections, dynamic initialization, named answers, and expansion.

--- a/code/packages/python/prolog-vm-compiler/README.md
+++ b/code/packages/python/prolog-vm-compiler/README.md
@@ -249,7 +249,7 @@ assert [answer.as_dict() for answer in runtime.query("ancestor(homer, Who)")] ==
 
 ## Capability Manifest
 
-The Prolog-on-Logic-VM implementation track covers PR00 through PR89. The
+The Prolog-on-Logic-VM implementation track covers PR00 through PR90. The
 package exposes that as a machine-readable manifest so downstream tools and
 future implementation work can distinguish completed functionality from
 deliberately deferred advanced dialect/runtime emulation:
@@ -259,7 +259,7 @@ from prolog_vm_compiler import prolog_vm_capability_manifest
 
 manifest = prolog_vm_capability_manifest()
 
-assert manifest.status == "core-plus-recursive-filesystem"
+assert manifest.status == "core-plus-standard-streams"
 assert manifest.dialects == ("iso", "swi")
 assert manifest.backends == ("structured", "bytecode")
 ```
@@ -272,7 +272,10 @@ UTF-8 file text I/O through `exists_file/1`, `read_file_to_string/2`, and
 `read_file_to_codes/2`, plus bounded UTF-8 file stream I/O through `open/3`,
 `close/1`, `read_string/3`, `read_line_to_string/2`, `get_char/2`,
 `at_end_of_stream/1`, `write/2`, and `nl/1`, with alias/metadata support via
-`open/4`, `current_stream/3`, `stream_property/2`, and `flush_output/1`, plus
+`open/4`, `current_stream/3`, `stream_property/2`, and `flush_output/1`,
+standard `user_input`, `user_output`, and `user_error` streams, and accepted
+stream options for `reposition`, `eof_action`, `buffer`, and
+`close_on_abort`, plus
 bounded cursor repositioning via `set_stream_position/2` and `seek/4`, and
 selected current-stream forms via `set_input/1`, `set_output/1`,
 `current_input/1`, `current_output/1`, `get_char/1`, `read_string/2`,
@@ -296,8 +299,8 @@ and `working_directory/2`, plus recursive/wildcard filesystem helpers through
 The manifest also names the remaining advanced-dialect work that is intentionally
 outside the completed batches: full external dialect emulation, tabling and
 well-founded negation, generalized attributed-variable/coroutining services,
-non-FD constraint domains, console streams, richer stream services beyond the
-bounded file-backed subset, foreign predicates, engines, and concurrency.
+non-FD constraint domains, remaining richer stream services beyond the bounded
+subset, foreign predicates, engines, and concurrency.
 
 ## CLI
 
@@ -482,6 +485,9 @@ The package includes end-to-end stress tests for:
   `at_end_of_stream/1`, `write/2`, and `nl/1`
 - bounded stream aliases and metadata with `open/4`, `current_stream/3`,
   `stream_property/2`, and `flush_output/1`
+- standard stream aliases and richer accepted stream options with `user_input`,
+  `user_output`, `user_error`, `reposition/1`, `eof_action/1`, `buffer/1`,
+  and `close_on_abort/1`
 - bounded binary byte stream I/O with `open/4` `type(binary)`,
   `get_byte/1,2`, `peek_byte/1,2`, and `put_byte/1,2`
 - bounded stream cursor repositioning with `set_stream_position/2` and

--- a/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/src/prolog_vm_compiler/capabilities.py
@@ -355,6 +355,21 @@ def prolog_vm_capabilities() -> tuple[PrologVMCapability, ...]:
                 "structured and bytecode VM stress coverage",
             ),
         ),
+        PrologVMCapability(
+            id="host-standard-streams",
+            title="Standard streams and richer stream options",
+            status="complete",
+            specs=("PR90",),
+            packages=("logic-builtins", "prolog-loader", "prolog-vm-compiler"),
+            features=(
+                "user_input, user_output, and user_error standard stream aliases",
+                "current_input/1 and current_output/1 default to standard streams",
+                "current output writes can target stdout and stderr",
+                "open/4 accepts reposition, eof_action, buffer, and close_on_abort",
+                "stream_property/2 exposes accepted stream option metadata",
+                "structured and bytecode VM stress coverage",
+            ),
+        ),
     )
 
 
@@ -392,8 +407,8 @@ def deferred_prolog_vm_capabilities() -> tuple[PrologVMCapability, ...]:
             specs=("PR02",),
             packages=("future",),
             features=(
-                "console-backed standard streams and richer binary stream services",
-                "rich ISO/SWI stream options beyond bounded text/binary files",
+                "richer binary stream services",
+                "remaining ISO/SWI stream options beyond the bounded subset",
                 "foreign predicates and host callbacks",
                 "engines, concurrency, and async integration",
             ),
@@ -405,8 +420,8 @@ def prolog_vm_capability_manifest() -> PrologVMCapabilityManifest:
     """Return the canonical capability manifest for this package."""
 
     return PrologVMCapabilityManifest(
-        track="Prolog-on-Logic-VM PR00-PR89",
-        status="core-plus-recursive-filesystem",
+        track="Prolog-on-Logic-VM PR00-PR90",
+        status="core-plus-standard-streams",
         dialects=("iso", "swi"),
         backends=("structured", "bytecode"),
         capabilities=prolog_vm_capabilities(),

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_bytecode_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_bytecode_vm_stress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
 from logic_engine import Compound, Number, atom, logic_list, num, string, term
 
 from prolog_vm_compiler import (
@@ -485,10 +486,17 @@ class TestPrologBytecodeVMStress:
         compiled = compile_swi_prolog_source(
             f"""
             ?- open('{path_atom}', write, Out,
-                    [alias(bytecode_report), encoding(utf8), type(text)]),
+                    [alias(bytecode_report), encoding(utf8), type(text),
+                     reposition(true), eof_action(eof_code), buffer(line),
+                     close_on_abort(false)]),
                write(bytecode_report, "tea"),
                flush_output(bytecode_report),
                stream_property(bytecode_report, alias(Alias)),
+               stream_property(bytecode_report, encoding(Encoding)),
+               stream_property(bytecode_report, reposition(Reposition)),
+               stream_property(bytecode_report, eof_action(EofAction)),
+               stream_property(bytecode_report, buffer(Buffer)),
+               stream_property(bytecode_report, close_on_abort(CloseOnAbort)),
                current_stream(Path, Mode, Out),
                close(bytecode_report).
             """,
@@ -496,15 +504,28 @@ class TestPrologBytecodeVMStress:
 
         answers = run_compiled_prolog_bytecode_query_answers(compiled)
 
-        assert _project_answers(answers, "Alias", "Path", "Mode") == _project_answers(
-            run_compiled_prolog_query_answers(compiled),
+        names = (
             "Alias",
+            "Encoding",
+            "Reposition",
+            "EofAction",
+            "Buffer",
+            "CloseOnAbort",
             "Path",
             "Mode",
         )
-        assert _project_answers(answers, "Alias", "Path", "Mode") == [
+        assert _project_answers(answers, *names) == _project_answers(
+            run_compiled_prolog_query_answers(compiled),
+            *names,
+        )
+        assert _project_answers(answers, *names) == [
             {
                 "Alias": atom("bytecode_report"),
+                "Encoding": atom("utf8"),
+                "Reposition": atom("true"),
+                "EofAction": atom("eof_code"),
+                "Buffer": atom("line"),
+                "CloseOnAbort": atom("false"),
                 "Path": atom(str(source_path)),
                 "Mode": atom("write"),
             },
@@ -793,6 +814,45 @@ class TestPrologBytecodeVMStress:
             "Line": string("def"),
         }
         assert output_path.read_text(encoding="utf-8") == "tea\ncake(slice)"
+
+    def test_standard_streams_match_structured_vm(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            ?- set_input(user_input),
+               set_output(user_output),
+               current_input(CurrentIn),
+               current_output(CurrentOut),
+               at_end_of_stream,
+               write("stdout"),
+               nl,
+               write(user_error, "stderr"),
+               flush_output,
+               flush_output(user_error),
+               stream_property(user_input, alias(user_input)),
+               stream_property(user_output, alias(user_output)),
+               current_stream(user_error, append, '$stream_user_error').
+            """,
+        )
+
+        answers = run_compiled_prolog_bytecode_query_answers(compiled)
+        bytecode_capture = capsys.readouterr()
+        structured_answers = run_compiled_prolog_query_answers(compiled)
+        structured_capture = capsys.readouterr()
+
+        assert _project_answers(answers, "CurrentIn", "CurrentOut") == (
+            _project_answers(structured_answers, "CurrentIn", "CurrentOut")
+        )
+        assert _project_answers(answers, "CurrentIn", "CurrentOut") == [
+            {
+                "CurrentIn": atom("$stream_user_input"),
+                "CurrentOut": atom("$stream_user_output"),
+            },
+        ]
+        assert bytecode_capture.out == structured_capture.out == "stdout\n"
+        assert bytecode_capture.err == structured_capture.err == "stderr"
 
     def test_stream_term_io_matches_structured_vm(self, tmp_path: Path) -> None:
         input_path = tmp_path / "bytecode-terms.pltxt"

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_capabilities.py
@@ -9,31 +9,31 @@ from prolog_vm_compiler import (
 )
 
 
-def test_manifest_marks_recursive_filesystem_extension_complete() -> None:
+def test_manifest_marks_standard_stream_extension_complete() -> None:
     manifest = prolog_vm_capability_manifest()
 
-    assert manifest.track == "Prolog-on-Logic-VM PR00-PR89"
-    assert manifest.status == "core-plus-recursive-filesystem"
+    assert manifest.track == "Prolog-on-Logic-VM PR00-PR90"
+    assert manifest.status == "core-plus-standard-streams"
     assert manifest.dialects == ("iso", "swi")
     assert manifest.backends == ("structured", "bytecode")
-    assert manifest.complete_count == 19
+    assert manifest.complete_count == 20
     assert manifest.deferred_count == 3
 
 
-def test_completed_capabilities_cover_pr00_through_pr89_once() -> None:
+def test_completed_capabilities_cover_pr00_through_pr90_once() -> None:
     covered_specs = [
         spec for capability in prolog_vm_capabilities() for spec in capability.specs
     ]
 
-    assert covered_specs == [f"PR{index:02d}" for index in range(90)]
+    assert covered_specs == [f"PR{index:02d}" for index in range(91)]
 
 
 def test_capability_manifest_is_json_serializable() -> None:
     payload = prolog_vm_capability_manifest().as_dict()
 
-    assert payload["status"] == "core-plus-recursive-filesystem"
+    assert payload["status"] == "core-plus-standard-streams"
     assert payload["capabilities"][0]["id"] == "frontend-loader"
-    assert payload["capabilities"][-1]["id"] == "host-recursive-filesystem-operations"
+    assert payload["capabilities"][-1]["id"] == "host-standard-streams"
     assert payload["deferred_capabilities"][0]["status"] == "deferred"
 
 

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_cli.py
@@ -21,11 +21,11 @@ def test_cli_dumps_capability_manifest_without_source(
     assert status == 0
     assert payload["success"] is True
     assert payload["mode"] == "capabilities"
-    assert payload["status"] == "core-plus-recursive-filesystem"
+    assert payload["status"] == "core-plus-standard-streams"
     assert payload["dialects"] == ["iso", "swi"]
     assert payload["backends"] == ["structured", "bytecode"]
     assert payload["capabilities"][0]["specs"][0] == "PR00"
-    assert payload["capabilities"][-1]["specs"][-1] == "PR89"
+    assert payload["capabilities"][-1]["specs"][-1] == "PR90"
 
 
 def test_cli_dump_capabilities_rejects_source_modes(

--- a/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
+++ b/code/packages/python/prolog-vm-compiler/tests/test_prolog_vm_stress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
 from logic_engine import (
     Compound,
     Disequality,
@@ -1197,10 +1198,17 @@ class TestPrologVMStress:
         compiled = compile_swi_prolog_source(
             f"""
             ?- open('{path_atom}', write, Out,
-                    [alias(report_stream), encoding(utf8), type(text)]),
+                    [alias(report_stream), encoding(utf8), type(text),
+                     reposition(true), eof_action(eof_code), buffer(line),
+                     close_on_abort(false)]),
                write(report_stream, "tea"),
                flush_output(report_stream),
                stream_property(report_stream, alias(Alias)),
+               stream_property(report_stream, encoding(Encoding)),
+               stream_property(report_stream, reposition(Reposition)),
+               stream_property(report_stream, eof_action(EofAction)),
+               stream_property(report_stream, buffer(Buffer)),
+               stream_property(report_stream, close_on_abort(CloseOnAbort)),
                current_stream(Path, Mode, Out),
                close(report_stream).
             """,
@@ -1211,6 +1219,11 @@ class TestPrologVMStress:
         assert [
             {
                 "Alias": answer.as_dict()["Alias"],
+                "Encoding": answer.as_dict()["Encoding"],
+                "Reposition": answer.as_dict()["Reposition"],
+                "EofAction": answer.as_dict()["EofAction"],
+                "Buffer": answer.as_dict()["Buffer"],
+                "CloseOnAbort": answer.as_dict()["CloseOnAbort"],
                 "Path": answer.as_dict()["Path"],
                 "Mode": answer.as_dict()["Mode"],
             }
@@ -1218,6 +1231,11 @@ class TestPrologVMStress:
         ] == [
             {
                 "Alias": atom("report_stream"),
+                "Encoding": atom("utf8"),
+                "Reposition": atom("true"),
+                "EofAction": atom("eof_code"),
+                "Buffer": atom("line"),
+                "CloseOnAbort": atom("false"),
                 "Path": atom(str(source_path)),
                 "Mode": atom("write"),
             },
@@ -1431,6 +1449,40 @@ class TestPrologVMStress:
             "Line": string("def"),
         }
         assert output_path.read_text(encoding="utf-8") == "tea\ncake(slice)"
+
+    def test_standard_streams_run_through_vm(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        compiled = compile_swi_prolog_source(
+            """
+            ?- set_input(user_input),
+               set_output(user_output),
+               current_input(CurrentIn),
+               current_output(CurrentOut),
+               at_end_of_stream,
+               write("stdout"),
+               nl,
+               write(user_error, "stderr"),
+               flush_output,
+               flush_output(user_error),
+               stream_property(user_input, alias(user_input)),
+               stream_property(user_output, alias(user_output)),
+               current_stream(user_error, append, '$stream_user_error').
+            """,
+        )
+
+        answers = run_compiled_prolog_query_answers(compiled)
+
+        captured = capsys.readouterr()
+        assert [answer.as_dict() for answer in answers] == [
+            {
+                "CurrentIn": atom("$stream_user_input"),
+                "CurrentOut": atom("$stream_user_output"),
+            },
+        ]
+        assert captured.out == "stdout\n"
+        assert captured.err == "stderr"
 
     def test_stream_term_io_runs_through_vm(self, tmp_path: Path) -> None:
         input_path = tmp_path / "terms.pltxt"

--- a/code/specs/PR02-prolog-dialects-and-vm-gap-analysis.md
+++ b/code/specs/PR02-prolog-dialects-and-vm-gap-analysis.md
@@ -19,13 +19,14 @@ can land in a few coherent batches rather than many tiny compatibility PRs.
 
 ## Core Track Status
 
-As of the PR00-PR89 Prolog-on-Logic-VM track, the shared core is implemented
+As of the PR00-PR90 Prolog-on-Logic-VM track, the shared core is implemented
 through the parser, loader, expansion, VM compiler, structured VM runtime,
 bytecode VM runtime, source/file/project runner APIs, top-level query APIs, the
 `prolog-vm` CLI, bounded UTF-8 file text I/O, and bounded UTF-8 file stream
 handles with alias/metadata/positioning/current-stream support, bounded binary
-byte stream I/O, read-only filesystem metadata predicates, and bounded
-filesystem operations including recursive/wildcard helpers.
+byte stream I/O, read-only filesystem metadata predicates, bounded filesystem
+operations including recursive/wildcard helpers, standard streams, and richer
+accepted stream options.
 
 The core track is now treated as complete for practical ISO/SWI-subset work:
 
@@ -51,6 +52,9 @@ The core track is now treated as complete for practical ISO/SWI-subset work:
   `set_stream_position/2` and `seek/4`.
 - Opened bounded streams can be selected as current input/output streams, and
   current-stream read/write forms run through the same VM path.
+- Standard `user_input`, `user_output`, and `user_error` stream aliases are
+  available, and accepted `open/4` stream options include `reposition/1`,
+  `eof_action/1`, `buffer/1`, and `close_on_abort/1` metadata.
 - Bounded binary streams support byte reads, peeks, and writes through
   `get_byte/1,2`, `peek_byte/1,2`, and `put_byte/1,2`.
 - Bound atom/string paths can be inspected with read-only filesystem metadata
@@ -73,13 +77,13 @@ The core track is now treated as complete for practical ISO/SWI-subset work:
 
 The package-level source of truth is `prolog_vm_capability_manifest()` and the
 matching `prolog-vm --dump-capabilities` CLI output. New work should update
-that manifest instead of reopening open-ended PR00-PR89 gap analysis.
+that manifest instead of reopening open-ended PR00-PR90 gap analysis.
 
 Remaining work in this document is advanced dialect and runtime emulation:
 full external Prolog dialect compatibility, tabling, attributed variables,
-generalized coroutining, CHR/non-FD constraint domains, console/rich stream
-services beyond the bounded file-backed text/binary subset, foreign
-predicates, engines, concurrency, and async host integration.
+generalized coroutining, CHR/non-FD constraint domains, remaining rich stream
+services beyond the bounded text/binary subset, foreign predicates, engines,
+concurrency, and async host integration.
 
 ## Current Project Surface
 
@@ -117,15 +121,14 @@ Current support:
   introspection builtins, operator declarations, directives, modules,
   exceptions, flags, CLP(FD), DCG expansion, consult/include, source/file
   runners, bounded UTF-8 file text reads and file stream handles with aliases,
-  current-stream selection, cursor positioning, bounded binary byte stream I/O,
-  read-only filesystem metadata predicates, bounded filesystem operations,
-  recursive/wildcard filesystem helpers, bytecode parity, and
-  machine-readable tooling.
-- Missing or incomplete for full ISO-system emulation: console-backed standard
-  streams, richer binary stream services, rich stream options beyond the
-  bounded file-backed subset, full ISO standard-library breadth, every ISO
-  error-term nuance, and implementation-specific dialect services outside the
-  shared core.
+  current-stream selection, standard streams, cursor positioning, bounded
+  binary byte stream I/O, read-only filesystem metadata predicates, bounded
+  filesystem operations, recursive/wildcard filesystem helpers, bytecode
+  parity, and machine-readable tooling.
+- Missing or incomplete for full ISO-system emulation: richer binary stream
+  services, remaining rich stream options beyond the bounded subset, full ISO
+  standard-library breadth, every ISO error-term nuance, and
+  implementation-specific dialect services outside the shared core.
 
 ### Edinburgh, DEC-10, Quintus, SICStus Family
 
@@ -379,13 +382,14 @@ This is a major runtime feature and should be its own batch.
 
 ## Historical Implementation Batches
 
-The original gap analysis proposed these implementation batches. PR00-PR89
+The original gap analysis proposed these implementation batches. PR00-PR90
 completed the core versions of Batches 1-5, added a broad Prolog stdlib and
 CLP(FD) compatibility layer, delivered runner/CLI tooling, and added bounded
 file text and stream I/O with aliases/metadata/positioning/current-stream
-selection, bounded binary byte stream I/O, read-only filesystem metadata, and
-bounded filesystem operations including recursive/wildcard helpers. Batch 6
-remains future advanced dialect work.
+selection, bounded binary byte stream I/O, read-only filesystem metadata,
+bounded filesystem operations including recursive/wildcard helpers, standard
+streams, and richer accepted stream options. Batch 6 remains future advanced
+dialect work.
 
 ### Batch 1 - Grammar and Dialect Profile Foundation
 

--- a/code/specs/PR90-prolog-standard-streams.md
+++ b/code/specs/PR90-prolog-standard-streams.md
@@ -1,0 +1,53 @@
+# PR90 - Prolog Standard Streams And Stream Options
+
+## Overview
+
+PR90 closes the practical standard-stream portion of the host runtime gap. The
+VM already supported bounded file-backed streams; this batch adds default
+standard stream aliases and a richer accepted `open/4` option subset that can
+round-trip through `stream_property/2`.
+
+This batch covers:
+
+- `user_input`
+- `user_output`
+- `user_error`
+- `reposition/1`
+- `eof_action/1`
+- `buffer/1`
+- `close_on_abort/1`
+
+The behavior is exposed through `logic-builtins`, adapted from source-level
+Prolog calls by `prolog-loader`, and covered through both structured and
+bytecode Prolog VM execution.
+
+## Semantics
+
+`user_input`, `user_output`, and `user_error` are always-open stream aliases.
+The initial current input is `user_input`; the initial current output is
+`user_output`. Current stream predicates can still select ordinary opened file
+streams using `set_input/1` and `set_output/1`.
+
+The standard output aliases are console-backed:
+
+- writes to `user_output` write to `sys.stdout`
+- writes to `user_error` write to `sys.stderr`
+
+The default `user_input` stream is an empty bounded text stream. It is available
+for metadata and EOF behavior without blocking on an interactive terminal.
+
+`open/4` accepts these additional finite options:
+
+- `reposition(true|false)`
+- `eof_action(eof_code|error|reset)`
+- `buffer(full|line|false)`
+- `close_on_abort(true|false)`
+
+Accepted options are exposed as `stream_property/2` metadata. They do not yet
+implement every external Prolog runtime behavior behind those options.
+
+## Boundaries
+
+Standard stream aliases are process-global host resources, so they are not
+closed by `close/1`. Richer binary stream services and the rest of the ISO/SWI
+stream option surface remain future host-runtime work.


### PR DESCRIPTION
## Summary

- Add always-open user_input, user_output, and user_error stream aliases with default current input/output behavior.
- Route standard output/error writes through stdout/stderr while exposing standard stream metadata through current_stream/3 and stream_property/2.
- Accept and expose richer open/4 stream option metadata for reposition/1, eof_action/1, buffer/1, and close_on_abort/1, and record PR90 in the capability manifest/spec/docs.

## Verification

- bash BUILD in code/packages/python/logic-builtins
- bash BUILD in code/packages/python/prolog-loader
- bash BUILD in code/packages/python/prolog-vm-compiler
- git diff --check
