### PR TITLE
[codex] Add Board VM generic module builder sugar

### DIFF
--- a/code/packages/python/board-vm-native/README.md
+++ b/code/packages/python/board-vm-native/README.md
@@ -16,6 +16,7 @@ write_frames = session.gpio_write(pin=13, value=True).frames
 now_frames = session.time_now(program_id=2, instruction_budget=12).frames
 sleep_frames = session.time_sleep_ms(250, program_id=3, instruction_budget=12).frames
 store_frame = session.store_program(program_id=1, slot=0, boot_policy="run-if-no-host").frame
+raw_module = session.raw_module(code=b"\x00", max_stack=1)
 ```
 
 Each frame is a Rust-produced Board VM wire frame ready for a transport to
@@ -54,3 +55,8 @@ session.run_command("stop")
 Python parses the friendly command text, then delegates module construction,
 request IDs, framing, and response decoding to `board-vm-language-core` through
 the repo-local `python-bridge` extension.
+
+For lower-level language experiments, `raw_module(code:, max_stack:, flags:,
+const_pool:)` still routes through Rust. Python supplies bytecode bytes, while
+`board-vm-language-core` owns the BVM header, length encoding, validation, and
+upload framing.

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -209,6 +209,18 @@ class Session:
     def time_sleep_ms_module(self, duration_ms: int, max_stack: int = 1) -> bytes:
         return _native.time_sleep_ms_module(duration_ms, max_stack)
 
+    def raw_module(
+        self,
+        *,
+        code: bytes | bytearray,
+        max_stack: int,
+        flags: int = 0,
+        const_pool: bytes | bytearray = b"",
+    ) -> bytes:
+        return _native.raw_module(flags, max_stack, bytes(code), bytes(const_pool))
+
+    module = raw_module
+
     def upload(self, *, program_id: int = DEFAULT_PROGRAM_ID, module_bytes: bytes) -> SessionResult:
         return SessionResult([
             self._dispatch("program_begin", self._call_native(_native.program_begin_wire, program_id, module_bytes)),
@@ -292,6 +304,25 @@ class Session:
         return self.upload(
             program_id=program_id,
             module_bytes=self.time_sleep_ms_module(duration_ms, max_stack=max_stack),
+        )
+
+    def upload_raw_module(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        code: bytes | bytearray,
+        max_stack: int,
+        flags: int = 0,
+        const_pool: bytes | bytearray = b"",
+    ) -> SessionResult:
+        return self.upload(
+            program_id=program_id,
+            module_bytes=self.raw_module(
+                code=code,
+                max_stack=max_stack,
+                flags=flags,
+                const_pool=const_pool,
+            ),
         )
 
     def run(self, *, program_id: int = DEFAULT_PROGRAM_ID, instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET) -> ProtocolResult:

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -9,11 +9,12 @@ use board_vm_host::{
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
     build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
-    build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_background_wire_frame,
-    build_stop_wire_frame, build_store_program_wire_frame, build_time_now_module,
-    build_time_sleep_ms_module, capability_board_metadata, capability_bytecode_callable,
-    capability_flag_names, capability_protocol_feature, decode_wire_response, program_format_name,
-    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
+    build_run_background_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
+    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
+    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
+    decode_wire_response, program_format_name, raw_module_len, run_status_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
     LanguageCoreError, LanguageValue,
 };
 use python_bridge::*;
@@ -157,6 +158,31 @@ unsafe extern "C" fn py_time_sleep_ms_module(
     let module = match build_time_sleep_ms_module_value(duration_ms, max_stack) {
         Ok(module) => module,
         Err(error) => return raise_core_error("time_sleep_ms_module", error),
+    };
+    bytes_to_py(&module)
+}
+
+unsafe extern "C" fn py_raw_module(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let flags = match parse_arg_u8(args, 0, "flags") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let max_stack = match parse_arg_u8(args, 1, "max_stack") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let code = match parse_arg_bytes(args, 2, "code") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let const_pool = match parse_arg_bytes(args, 3, "const_pool") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    let module = match build_raw_module_value(flags, max_stack, &code, &const_pool) {
+        Ok(module) => module,
+        Err(error) => return raise_core_error("raw_module", error),
     };
     bytes_to_py(&module)
 }
@@ -572,6 +598,19 @@ fn build_time_sleep_ms_module_value(
     Ok(module)
 }
 
+fn build_raw_module_value(
+    flags: u8,
+    max_stack: u8,
+    code: &[u8],
+    const_pool: &[u8],
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let module_len = raw_module_len(code.len() as u64, const_pool.len() as u64)?;
+    let mut module = vec![0; module_len];
+    let len = build_raw_module(flags, max_stack, code, const_pool, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_gpio_read_module_value(
     pin: u8,
     mode: u8,
@@ -709,7 +748,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 15] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 16] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -751,6 +790,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_time_sleep_ms_module),
             ml_flags: METH_VARARGS,
             ml_doc: b"Build a Board VM time.sleep_ms BVM module in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"raw_module\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_raw_module),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a generic BVM module from raw bytecode in Rust.\0".as_ptr()
                 as *const c_char,
         },
         PyMethodDef {

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -42,6 +42,10 @@ def test_native_session_builds_protocol_bytes_in_rust():
     assert isinstance(sleep_module, bytes)
     assert len(sleep_module) > 0
 
+    raw_module = session.raw_module(code=b"\x00", max_stack=1, const_pool=b"\xAA\x55")
+    assert raw_module.startswith(b"BVM1")
+    assert raw_module.endswith(b"\xAA\x55")
+
     stop = session.stop()
     assert isinstance(stop.frame, bytes)
     assert len(stop.frame) > 0
@@ -185,6 +189,25 @@ def test_run_command_accepts_repl_style_time_sleep_ms():
         "program_end",
     ]
     assert result.frames + upload.frames == transport.frames
+
+
+def test_upload_raw_module_uses_rust_owned_module_builder():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.upload_raw_module(
+        program_id=12,
+        code=b"\x00",
+        max_stack=1,
+        const_pool=b"\xAA\x55",
+    )
+
+    assert [item.command for item in result.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+    ]
+    assert result.frames == transport.frames
 
 
 def test_board_descriptor_wraps_rust_decoded_capability_payload():

--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -146,6 +146,20 @@ capability groups such as `gpio`, `time`, and `program`. Capability flag names
 and booleans are supplied by the Rust language core, keeping Ruby out of the
 protocol-bit interpretation business.
 
+For lower-level language experiments, Ruby can pass raw bytecode while still
+leaving module framing to Rust:
+
+```ruby
+board.session do |vm|
+  module_bytes = vm.raw_module(code: "\x00".b, max_stack: 1)
+  vm.upload(program_id: 42, module_bytes: module_bytes)
+end
+```
+
+`raw_module` is still sugar over `CodingAdventures::BoardVM::Native::Session`;
+the BVM header, length encoding, validation, and upload frames are produced by
+`board-vm-language-core`.
+
 The DSL also exposes the current board-agnostic blink ejection path:
 
 ```ruby

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -10,11 +10,12 @@ use board_vm_host::{
 use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
     build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
-    build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_background_wire_frame,
-    build_stop_wire_frame, build_store_program_wire_frame, build_time_now_module,
-    build_time_sleep_ms_module, capability_board_metadata, capability_bytecode_callable,
-    capability_flag_names, capability_protocol_feature, decode_wire_response, program_format_name,
-    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
+    build_run_background_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
+    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
+    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
+    decode_wire_response, program_format_name, raw_module_len, run_status_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
     LanguageCoreError, LanguageValue,
 };
 use ruby_bridge::VALUE;
@@ -131,6 +132,25 @@ extern "C" fn session_time_sleep_ms_module(
 
     let module = build_time_sleep_ms_module_value(duration_ms, max_stack)
         .unwrap_or_else(|error| raise_core_error("time_sleep_ms_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_raw_module(
+    _self_val: VALUE,
+    flags_val: VALUE,
+    max_stack_val: VALUE,
+    code_val: VALUE,
+    const_pool_val: VALUE,
+) -> VALUE {
+    let flags = rb_u8(flags_val, "flags");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+    let code = ruby_bridge::bytes_from_rb(code_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("code must be a Ruby binary String"));
+    let const_pool = ruby_bridge::bytes_from_rb(const_pool_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("const_pool must be a Ruby binary String"));
+
+    let module = build_raw_module_value(flags, max_stack, &code, &const_pool)
+        .unwrap_or_else(|error| raise_core_error("raw_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -584,6 +604,19 @@ fn build_time_sleep_ms_module_value(
     Ok(module)
 }
 
+fn build_raw_module_value(
+    flags: u8,
+    max_stack: u8,
+    code: &[u8],
+    const_pool: &[u8],
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let module_len = raw_module_len(code.len() as u64, const_pool.len() as u64)?;
+    let mut module = vec![0; module_len];
+    let len = build_raw_module(flags, max_stack, code, const_pool, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn build_gpio_read_module_value(
     pin: u8,
     mode: u8,
@@ -721,6 +754,12 @@ pub extern "C" fn Init_board_vm_native() {
         "time_sleep_ms_module",
         session_time_sleep_ms_module as *const c_void,
         2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "raw_module",
+        session_raw_module as *const c_void,
+        4,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -128,6 +128,11 @@ module CodingAdventures
         native_session.time_sleep_ms_module(duration_ms, max_stack)
       end
 
+      def raw_module(code:, max_stack:, flags: 0, const_pool: +"")
+        native_session.raw_module(flags, max_stack, code.b, const_pool.b)
+      end
+      alias module raw_module
+
       def upload_time_now(program_id: @program_id, max_stack: 1)
         upload(
           program_id: program_id,
@@ -139,6 +144,18 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: time_sleep_ms_module(duration_ms: duration_ms, max_stack: max_stack)
+        )
+      end
+
+      def upload_raw_module(program_id: @program_id, code:, max_stack:, flags: 0, const_pool: +"")
+        upload(
+          program_id: program_id,
+          module_bytes: raw_module(
+            code: code,
+            max_stack: max_stack,
+            flags: flags,
+            const_pool: const_pool
+          )
         )
       end
 

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -214,6 +214,13 @@ module CodingAdventures
             gpio_upload = session.upload_gpio_read(program_id: 6, pin: 13, mode: :pullup)
             gpio_write_upload = session.upload_gpio_write(program_id: 7, pin: 13, value: true)
             store = session.store_program(program_id: 4, slot: 2, boot_policy: :run_at_boot)
+            raw_module = session.raw_module(code: "\x00".b, max_stack: 1, const_pool: "\xAA\x55".b)
+            raw_upload = session.upload_raw_module(
+              program_id: 9,
+              code: "\x00".b,
+              max_stack: 1,
+              const_pool: "\xAA\x55".b
+            )
             run = session.run(program_id: 4, budget: 77)
             stop = session.stop
 
@@ -229,13 +236,17 @@ module CodingAdventures
             assert_equal [:program_begin, :program_chunk, :program_end],
               gpio_write_upload.results.map(&:command)
             assert_equal :store_program, store.command
+            assert raw_module.start_with?("BVM1")
+            assert raw_module.end_with?("\xAA\x55".b)
+            assert_equal [:program_begin, :program_chunk, :program_end],
+              raw_upload.results.map(&:command)
             assert_equal :run, run.command
             assert_equal :stop, stop.command
           end
         end
 
         assert_empty runner.calls
-        assert_equal 20, transport.frames.length
+        assert_equal 23, transport.frames.length
         assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
       end
 

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -13,11 +13,11 @@ use std::slice;
 use std::str;
 
 use board_vm_host::{
-    write_blink_module, write_gpio_read_module, write_gpio_write_module, write_time_now_module,
-    write_time_sleep_ms_module, BlinkProgram, GpioReadProgram, GpioWriteProgram, HostError,
-    HostSession, TimeNowProgram, TimeSleepMsProgram, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
-    DEFAULT_PROGRAM_ID, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
-    TIME_SLEEP_MS_MODULE_LEN,
+    write_blink_module, write_gpio_read_module, write_gpio_write_module, write_module,
+    write_time_now_module, write_time_sleep_ms_module, BlinkProgram, GpioReadProgram,
+    GpioWriteProgram, HostError, HostSession, ModuleSpec, TimeNowProgram, TimeSleepMsProgram,
+    BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, GPIO_READ_MODULE_LEN,
+    GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -439,6 +439,29 @@ pub fn build_time_sleep_ms_module(
     out: &mut [u8],
 ) -> Result<usize, LanguageCoreError> {
     Ok(write_time_sleep_ms_module(program, out)?)
+}
+
+pub fn build_raw_module(
+    flags: u8,
+    max_stack: u8,
+    code: &[u8],
+    const_pool: &[u8],
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_module(
+        ModuleSpec::new(flags, max_stack, code).const_pool(const_pool),
+        out,
+    )?)
+}
+
+pub fn raw_module_len(code_len: u64, const_pool_len: u64) -> Result<usize, LanguageCoreError> {
+    if code_len > u32::MAX as u64 || const_pool_len > u32::MAX as u64 {
+        return Err(LanguageCoreError::ValueTooLarge);
+    }
+    let code_len = usize::try_from(code_len).map_err(|_| LanguageCoreError::ValueTooLarge)?;
+    let const_pool_len =
+        usize::try_from(const_pool_len).map_err(|_| LanguageCoreError::ValueTooLarge)?;
+    checked_module_len(code_len, const_pool_len)
 }
 
 pub fn build_program_begin_wire_frame(
@@ -929,6 +952,29 @@ pub unsafe extern "C" fn board_vm_language_time_sleep_ms_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_raw_module(
+    flags: u8,
+    max_stack: u8,
+    code: *const u8,
+    code_len: u64,
+    const_pool: *const u8,
+    const_pool_len: u64,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let code = unsafe { in_slice(code, code_len, "code") }?;
+        let const_pool = unsafe { in_slice(const_pool, const_pool_len, "const_pool") }?;
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_raw_module(flags, max_stack, code, const_pool, module_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_program_begin_wire(
     session: *mut BoardVmLanguageSession,
     program_id: u16,
@@ -1096,6 +1142,19 @@ pub extern "C" fn board_vm_language_time_sleep_ms_module_len() -> u64 {
     TIME_SLEEP_MS_MODULE_LEN as u64
 }
 
+#[no_mangle]
+pub extern "C" fn board_vm_language_raw_module_len(code_len: u64, const_pool_len: u64) -> u64 {
+    clear_error();
+    match raw_module_len(code_len, const_pool_len) {
+        Ok(len) => len as u64,
+        Err(error) => {
+            let code = status_code_for_error(&error);
+            set_error(code, error_message(&error));
+            0
+        }
+    }
+}
+
 fn catch_status(
     operation: impl FnOnce() -> Result<BoardVmLanguageStatus, LanguageCoreError>,
 ) -> BoardVmLanguageStatus {
@@ -1143,6 +1202,27 @@ fn clear_error() {
 fn set_error(code: BoardVmLanguageStatusCode, message: impl AsRef<str>) {
     LAST_ERROR_CODE.with(|slot| slot.set(code as u32));
     LAST_ERROR_MESSAGE.with(|slot| *slot.borrow_mut() = Some(sanitize_message(message.as_ref())));
+}
+
+fn checked_module_len(code_len: usize, const_pool_len: usize) -> Result<usize, LanguageCoreError> {
+    let code_len_len = uleb128_len(code_len)?;
+    let const_pool_len_len = uleb128_len(const_pool_len)?;
+    8usize
+        .checked_add(code_len_len)
+        .and_then(|len| len.checked_add(code_len))
+        .and_then(|len| len.checked_add(const_pool_len_len))
+        .and_then(|len| len.checked_add(const_pool_len))
+        .ok_or(LanguageCoreError::ValueTooLarge)
+}
+
+fn uleb128_len(value: usize) -> Result<usize, LanguageCoreError> {
+    let mut value = u32::try_from(value).map_err(|_| LanguageCoreError::ValueTooLarge)?;
+    let mut len = 1usize;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    Ok(len)
 }
 
 fn sanitize_message(message: &str) -> CString {
@@ -1413,6 +1493,22 @@ mod tests {
         assert_eq!(decoded.message_type, MessageType::STOP.0);
         let frame = decode_frame(&raw[..decoded.len as usize]).unwrap();
         assert!(frame.payload.is_empty());
+    }
+
+    #[test]
+    fn rust_core_builds_raw_module_from_code_and_const_pool() {
+        let code = [0x00];
+        let const_pool = [0xAA, 0x55];
+        let expected_len = raw_module_len(code.len() as u64, const_pool.len() as u64).unwrap();
+        let mut module = vec![0u8; expected_len];
+
+        let len = build_raw_module(0, 1, &code, &const_pool, &mut module).unwrap();
+
+        assert_eq!(len, expected_len);
+        assert_eq!(
+            module,
+            [0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x02, 0xAA, 0x55,]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- expose Rust-owned raw BVM module construction from board-vm-language-core
- add Python and Ruby raw_module/upload_raw_module sugar through the native bridge packages
- document the low-level bytecode path while preserving store-program sugar from #2333

## Tests

- cargo test --manifest-path code/packages/rust/board-vm-language-core/Cargo.toml
- cargo test --manifest-path code/packages/rust/board-vm-host/Cargo.toml
- cargo build --release (code/packages/python/board-vm-native)
- PYTHONPATH=src python3 -m pytest tests/ -v
- cargo build --release (code/packages/ruby/board_vm/ext/board_vm_native)
- ruby -Ilib -Itest test/test_board_vm.rb
