### PR TITLE
[codex] Add configurable Board VM run sugar

### DIFF
--- a/code/packages/python/board-vm-native/README.md
+++ b/code/packages/python/board-vm-native/README.md
@@ -17,11 +17,22 @@ now_frames = session.time_now(program_id=2, instruction_budget=12).frames
 sleep_frames = session.time_sleep_ms(250, program_id=3, instruction_budget=12).frames
 store_frame = session.store_program(program_id=1, slot=0, boot_policy="run-if-no-host").frame
 raw_module = session.raw_module(code=b"\x00", max_stack=1)
+run_frame = session.run(
+    program_id=1,
+    instruction_budget=1_000,
+    keep_handles=True,
+    background=False,
+    time_budget_ms=250,
+).frame
 ```
 
 Each frame is a Rust-produced Board VM wire frame ready for a transport to
 write to a board. A `Session` can also dispatch through any object that exposes
 `transact(frame, timeout_ms=...)` or `write(frame)`.
+
+`run()` is configurable sugar over Rust-owned RUN wire-frame construction:
+Python can request reset/background/keep-handle behavior or pass a raw flag
+mask, but `board-vm-language-core` owns the actual payload encoding.
 
 `time_now()` uploads a Rust-built `time.now_ms` module and returns the board's
 millisecond clock through Rust-decoded run-report values when the transport

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -20,6 +20,18 @@ BOOT_POLICIES = {
     "run_if_no_host": 2,
     "run-if-no-host": 2,
 }
+RUN_FLAG_RESET_VM_BEFORE_RUN = 0x01
+RUN_FLAG_KEEP_HANDLES_AFTER_RUN = 0x02
+RUN_FLAG_BACKGROUND_RUN = 0x04
+DEFAULT_RUN_FLAGS = RUN_FLAG_RESET_VM_BEFORE_RUN | RUN_FLAG_BACKGROUND_RUN
+RUN_FLAGS = {
+    "reset_vm_before_run": RUN_FLAG_RESET_VM_BEFORE_RUN,
+    "reset-vm-before-run": RUN_FLAG_RESET_VM_BEFORE_RUN,
+    "keep_handles_after_run": RUN_FLAG_KEEP_HANDLES_AFTER_RUN,
+    "keep-handles-after-run": RUN_FLAG_KEEP_HANDLES_AFTER_RUN,
+    "background_run": RUN_FLAG_BACKGROUND_RUN,
+    "background-run": RUN_FLAG_BACKGROUND_RUN,
+}
 GPIO_READ_MODES = {
     "input": 0,
     "input_pullup": 2,
@@ -325,8 +337,29 @@ class Session:
             ),
         )
 
-    def run(self, *, program_id: int = DEFAULT_PROGRAM_ID, instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET) -> ProtocolResult:
-        frame = self._call_native(_native.run_background_wire, program_id, instruction_budget)
+    def run(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET,
+        flags: int | None = None,
+        reset_vm: bool = True,
+        keep_handles: bool = False,
+        background: bool = True,
+        time_budget_ms: int = 0,
+    ) -> ProtocolResult:
+        frame = self._call_native(
+            _native.run_wire,
+            program_id,
+            self._run_flags(
+                flags=flags,
+                reset_vm=reset_vm,
+                keep_handles=keep_handles,
+                background=background,
+            ),
+            instruction_budget,
+            time_budget_ms,
+        )
         return self._dispatch("run", frame)
 
     def stop(self) -> ProtocolResult:
@@ -556,6 +589,25 @@ class Session:
         self._ensure_no_extra(words, command)
         return merged
 
+    @staticmethod
+    def _run_flags(
+        *,
+        flags: int | None,
+        reset_vm: bool,
+        keep_handles: bool,
+        background: bool,
+    ) -> int:
+        if flags is not None:
+            return int(flags)
+        value = 0
+        if reset_vm:
+            value |= RUN_FLAG_RESET_VM_BEFORE_RUN
+        if keep_handles:
+            value |= RUN_FLAG_KEEP_HANDLES_AFTER_RUN
+        if background:
+            value |= RUN_FLAG_BACKGROUND_RUN
+        return value
+
     def _with_store_program_options(
         self,
         words: list[str],
@@ -697,8 +749,13 @@ __all__ = [
     "BoardDescriptor",
     "BOOT_POLICIES",
     "Capability",
+    "DEFAULT_RUN_FLAGS",
     "GPIO_READ_MODES",
     "ProtocolResult",
+    "RUN_FLAG_BACKGROUND_RUN",
+    "RUN_FLAG_KEEP_HANDLES_AFTER_RUN",
+    "RUN_FLAG_RESET_VM_BEFORE_RUN",
+    "RUN_FLAGS",
     "Session",
     "SessionResult",
 ]

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -10,11 +10,11 @@ use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
     build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
     build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
-    build_run_background_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
-    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
-    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, program_format_name, raw_module_len, run_status_name,
-    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
+    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
+    capability_protocol_feature, decode_wire_response, program_format_name, raw_module_len,
+    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
     LanguageCoreError, LanguageValue,
 };
 use python_bridge::*;
@@ -298,6 +298,42 @@ unsafe extern "C" fn py_run_background_wire(
         let mut wire = [0u8; 96];
         let written =
             build_run_background_wire_frame(session, program_id, instruction_budget, &mut wire)?;
+        Ok(wire_result(&wire, written.len, session))
+    })
+}
+
+unsafe extern "C" fn py_run_wire(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let next_request_id = match parse_arg_u16(args, 0, "next_request_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let program_id = match parse_arg_u16(args, 1, "program_id") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let flags = match parse_arg_u8(args, 2, "flags") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let instruction_budget = match parse_arg_u32(args, 3, "instruction_budget") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let time_budget_ms = match parse_arg_u32(args, 4, "time_budget_ms") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    with_session(next_request_id, |session| {
+        let mut wire = [0u8; 96];
+        let written = build_run_wire_frame(
+            session,
+            program_id,
+            flags,
+            instruction_budget,
+            time_budget_ms,
+            &mut wire,
+        )?;
         Ok(wire_result(&wire, written.len, session))
     })
 }
@@ -748,7 +784,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 16] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 17] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -831,6 +867,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_run_background_wire),
             ml_flags: METH_VARARGS,
             ml_doc: b"Build a Board VM background RUN wire frame in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"run_wire\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_run_wire),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a configurable Board VM RUN wire frame in Rust.\0".as_ptr()
                 as *const c_char,
         },
         PyMethodDef {

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -111,6 +111,24 @@ def test_store_program_dispatches_rust_owned_wire_frame():
     assert command.frames == transport.frames[1:]
 
 
+def test_run_accepts_configurable_rust_owned_flags():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.run(
+        program_id=9,
+        instruction_budget=42,
+        keep_handles=True,
+        background=False,
+        time_budget_ms=250,
+    )
+
+    assert result.command == "run"
+    assert isinstance(result.frame, bytes)
+    assert result.frame == transport.frames[0]
+    assert session.next_request_id == 2
+
+
 def test_run_command_accepts_repl_style_gpio_read():
     transport = FakeWriteTransport()
     session = Session(transport=transport)

--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -129,6 +129,18 @@ response bytes, and optional Rust-decoded response hash. The text command parser
 is Ruby sugar only; every dispatched frame still comes from
 `CodingAdventures::BoardVM::Native::Session`.
 
+`run` also accepts protocol-level options without moving protocol work into
+Ruby:
+
+```ruby
+board.session do |vm|
+  vm.run(program_id: 1, keep_handles: true, background: false, time_budget_ms: 250)
+end
+```
+
+Ruby turns friendly keywords into a flag mask; the RUN request payload and wire
+frame are still built by `board-vm-language-core`.
+
 Capability reports can be lifted into Ruby objects after Rust decodes the board
 response:
 

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -11,11 +11,11 @@ use board_vm_language_core::{
     build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
     build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
     build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
-    build_run_background_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
-    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
-    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, program_format_name, raw_module_len, run_status_name,
-    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
+    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
+    capability_protocol_feature, decode_wire_response, program_format_name, raw_module_len,
+    run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
     LanguageCoreError, LanguageValue,
 };
 use ruby_bridge::VALUE;
@@ -242,6 +242,32 @@ extern "C" fn session_run_background_wire(
             &mut session.inner,
             program_id,
             instruction_budget,
+            &mut wire,
+        )?;
+        Ok(bytes_result(&wire, written.len))
+    })
+}
+
+extern "C" fn session_run_wire(
+    self_val: VALUE,
+    program_id_val: VALUE,
+    flags_val: VALUE,
+    instruction_budget_val: VALUE,
+    time_budget_ms_val: VALUE,
+) -> VALUE {
+    let program_id = rb_u16(program_id_val, "program_id");
+    let flags = rb_u8(flags_val, "flags");
+    let instruction_budget = rb_u32(instruction_budget_val, "instruction_budget");
+    let time_budget_ms = rb_u32(time_budget_ms_val, "time_budget_ms");
+
+    with_session_mut(self_val, |session| {
+        let mut wire = [0u8; 96];
+        let written = build_run_wire_frame(
+            &mut session.inner,
+            program_id,
+            flags,
+            instruction_budget,
+            time_budget_ms,
             &mut wire,
         )?;
         Ok(bytes_result(&wire, written.len))
@@ -790,6 +816,12 @@ pub extern "C" fn Init_board_vm_native() {
         "run_background_wire",
         session_run_background_wire as *const c_void,
         2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "run_wire",
+        session_run_wire as *const c_void,
+        4,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -26,6 +26,18 @@ module CodingAdventures
         run_at_boot: 1,
         run_if_no_host: 2
       }.freeze
+      RUN_FLAG_RESET_VM_BEFORE_RUN = 0x01
+      RUN_FLAG_KEEP_HANDLES_AFTER_RUN = 0x02
+      RUN_FLAG_BACKGROUND_RUN = 0x04
+      DEFAULT_RUN_FLAGS = RUN_FLAG_RESET_VM_BEFORE_RUN | RUN_FLAG_BACKGROUND_RUN
+      RUN_FLAGS = {
+        reset_vm_before_run: RUN_FLAG_RESET_VM_BEFORE_RUN,
+        reset_vm: RUN_FLAG_RESET_VM_BEFORE_RUN,
+        keep_handles_after_run: RUN_FLAG_KEEP_HANDLES_AFTER_RUN,
+        keep_handles: RUN_FLAG_KEEP_HANDLES_AFTER_RUN,
+        background_run: RUN_FLAG_BACKGROUND_RUN,
+        background: RUN_FLAG_BACKGROUND_RUN
+      }.freeze
 
       attr_reader :connection, :native_session, :host_name, :host_nonce, :program_id,
         :instruction_budget
@@ -162,11 +174,26 @@ module CodingAdventures
       def run(
         program_id: @program_id,
         budget: @instruction_budget,
-        instruction_budget: nil
+        instruction_budget: nil,
+        flags: nil,
+        reset_vm: true,
+        keep_handles: false,
+        background: true,
+        time_budget_ms: 0
       )
         dispatch(
           :run,
-          native_session.run_background_wire(program_id, instruction_budget || budget)
+          native_session.run_wire(
+            program_id,
+            run_flags(
+              flags: flags,
+              reset_vm: reset_vm,
+              keep_handles: keep_handles,
+              background: background
+            ),
+            instruction_budget || budget,
+            time_budget_ms
+          )
         )
       end
 
@@ -510,6 +537,24 @@ module CodingAdventures
         BOOT_POLICIES.fetch(text.to_sym) do
           raise ArgumentError, "unsupported boot policy: #{value.inspect}"
         end
+      end
+
+      def run_flags(flags:, reset_vm:, keep_handles:, background:)
+        return flags if flags.is_a?(Integer)
+
+        if flags
+          return Array(flags).reduce(0) do |mask, flag|
+            mask | RUN_FLAGS.fetch(flag.to_s.tr("-", "_").to_sym) do
+              raise ArgumentError, "unsupported run flag: #{flag.inspect}"
+            end
+          end
+        end
+
+        value = 0
+        value |= RUN_FLAG_RESET_VM_BEFORE_RUN if reset_vm
+        value |= RUN_FLAG_KEEP_HANDLES_AFTER_RUN if keep_handles
+        value |= RUN_FLAG_BACKGROUND_RUN if background
+        value
       end
 
       def integer_argument(value, name)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -222,6 +222,13 @@ module CodingAdventures
               const_pool: "\xAA\x55".b
             )
             run = session.run(program_id: 4, budget: 77)
+            run_with_handles = session.run(
+              program_id: 4,
+              budget: 77,
+              keep_handles: true,
+              background: false,
+              time_budget_ms: 250
+            )
             stop = session.stop
 
             assert_equal :hello, hello.command
@@ -241,12 +248,13 @@ module CodingAdventures
             assert_equal [:program_begin, :program_chunk, :program_end],
               raw_upload.results.map(&:command)
             assert_equal :run, run.command
+            assert_equal :run, run_with_handles.command
             assert_equal :stop, stop.command
           end
         end
 
         assert_empty runner.calls
-        assert_equal 23, transport.frames.length
+        assert_equal 24, transport.frames.length
         assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
       end
 
@@ -462,10 +470,15 @@ module CodingAdventures
         assert_operator store.bytesize, :>, 0
         assert_equal 4, session.next_request_id
 
+        run = session.run_wire(7, BoardVM::Session::RUN_FLAG_KEEP_HANDLES_AFTER_RUN, 77, 250)
+        assert_instance_of String, run
+        assert_operator run.bytesize, :>, 0
+        assert_equal 5, session.next_request_id
+
         stop = session.stop_wire
         assert_instance_of String, stop
         assert_operator stop.bytesize, :>, 0
-        assert_equal 5, session.next_request_id
+        assert_equal 6, session.next_request_id
 
         frames = BoardVM::Native::Session.new.blink_upload_run_frames(7, 12, 13, 250, 250, 4)
         assert_equal 4, frames.length

--- a/code/packages/rust/board-vm-client/src/lib.rs
+++ b/code/packages/rust/board-vm-client/src/lib.rs
@@ -369,6 +369,24 @@ where
         self.expect_run_report(written.request_id, written.len)
     }
 
+    pub fn run(
+        &mut self,
+        program_id: u16,
+        flags: u8,
+        instruction_budget: u32,
+        time_budget_ms: u32,
+    ) -> Result<RunReportInfo, ClientError> {
+        let written = self.session.run_frame(
+            program_id,
+            flags,
+            instruction_budget,
+            time_budget_ms,
+            &mut self.payload,
+            &mut self.request,
+        )?;
+        self.expect_run_report(written.request_id, written.len)
+    }
+
     pub fn stop(&mut self) -> Result<RunReportInfo, ClientError> {
         let written = self.session.stop_frame(&mut self.request)?;
         self.expect_run_report(written.request_id, written.len)

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -14,6 +14,7 @@ use board_vm_protocol::{
 pub const DEFAULT_HOST_NAME: &str = "board-vm-host";
 pub const DEFAULT_PROGRAM_ID: u16 = 1;
 pub const DEFAULT_INSTRUCTION_BUDGET: u32 = 1000;
+pub const DEFAULT_RUN_FLAGS: u8 = RUN_FLAG_RESET_VM_BEFORE_RUN | RUN_FLAG_BACKGROUND_RUN;
 pub const BLINK_CODE_LEN: usize = 26;
 pub const BLINK_MODULE_LEN: usize = 36;
 pub const GPIO_WRITE_CODE_LEN: usize = 12;
@@ -325,12 +326,31 @@ impl HostSession {
         payload_out: &mut [u8],
         frame_out: &mut [u8],
     ) -> Result<WrittenFrame, HostError> {
+        self.run_frame(
+            program_id,
+            DEFAULT_RUN_FLAGS,
+            instruction_budget,
+            0,
+            payload_out,
+            frame_out,
+        )
+    }
+
+    pub fn run_frame(
+        &mut self,
+        program_id: u16,
+        flags: u8,
+        instruction_budget: u32,
+        time_budget_ms: u32,
+        payload_out: &mut [u8],
+        frame_out: &mut [u8],
+    ) -> Result<WrittenFrame, HostError> {
         let payload_len = encode_run_request(
             &RunRequest {
                 program_id,
-                flags: RUN_FLAG_RESET_VM_BEFORE_RUN | RUN_FLAG_BACKGROUND_RUN,
+                flags,
                 instruction_budget,
-                time_budget_ms: 0,
+                time_budget_ms,
             },
             payload_out,
         )?;
@@ -751,7 +771,8 @@ mod tests {
     };
     use board_vm_protocol::{
         decode_frame, decode_program_begin, decode_program_chunk, decode_program_end,
-        decode_run_request, MessageType, RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
+        decode_run_request, MessageType, RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_KEEP_HANDLES_AFTER_RUN,
+        RUN_FLAG_RESET_VM_BEFORE_RUN,
     };
 
     const BLINK_MODULE_HEX: [u8; BLINK_MODULE_LEN] = [
@@ -988,6 +1009,31 @@ mod tests {
             RUN_FLAG_RESET_VM_BEFORE_RUN | RUN_FLAG_BACKGROUND_RUN
         );
         assert_eq!(run_payload.instruction_budget, DEFAULT_INSTRUCTION_BUDGET);
+    }
+
+    #[test]
+    fn writes_configurable_run_frame() {
+        let mut session = HostSession::new();
+        let mut payload = [0u8; 16];
+        let mut frame = [0u8; 48];
+
+        let written = session
+            .run_frame(
+                42,
+                RUN_FLAG_KEEP_HANDLES_AFTER_RUN,
+                777,
+                250,
+                &mut payload,
+                &mut frame,
+            )
+            .unwrap();
+        let decoded = decode_frame(&frame[..written.len]).unwrap();
+        assert_eq!(decoded.message_type, MessageType::RUN);
+        let run_payload = decode_run_request(decoded.payload).unwrap();
+        assert_eq!(run_payload.program_id, 42);
+        assert_eq!(run_payload.flags, RUN_FLAG_KEEP_HANDLES_AFTER_RUN);
+        assert_eq!(run_payload.instruction_budget, 777);
+        assert_eq!(run_payload.time_budget_ms, 250);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -16,8 +16,8 @@ use board_vm_host::{
     write_blink_module, write_gpio_read_module, write_gpio_write_module, write_module,
     write_time_now_module, write_time_sleep_ms_module, BlinkProgram, GpioReadProgram,
     GpioWriteProgram, HostError, HostSession, ModuleSpec, TimeNowProgram, TimeSleepMsProgram,
-    BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, GPIO_READ_MODULE_LEN,
-    GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
+    BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
+    GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
     decode_caps_report_header, decode_error_payload, decode_frame, decode_hello_ack,
@@ -30,6 +30,12 @@ use board_vm_protocol::{
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
 pub const LANGUAGE_CORE_VERSION_MINOR: u16 = 1;
 pub const LANGUAGE_CORE_VERSION_PATCH: u16 = 0;
+pub const LANGUAGE_DEFAULT_RUN_FLAGS: u8 = DEFAULT_RUN_FLAGS;
+pub const LANGUAGE_RUN_FLAG_RESET_VM_BEFORE_RUN: u8 =
+    board_vm_protocol::RUN_FLAG_RESET_VM_BEFORE_RUN;
+pub const LANGUAGE_RUN_FLAG_KEEP_HANDLES_AFTER_RUN: u8 =
+    board_vm_protocol::RUN_FLAG_KEEP_HANDLES_AFTER_RUN;
+pub const LANGUAGE_RUN_FLAG_BACKGROUND_RUN: u8 = board_vm_protocol::RUN_FLAG_BACKGROUND_RUN;
 
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -549,11 +555,35 @@ pub fn build_run_background_wire_frame(
     instruction_budget: u32,
     wire_out: &mut [u8],
 ) -> Result<BuiltWireFrame, LanguageCoreError> {
+    build_run_wire_frame(
+        session,
+        program_id,
+        DEFAULT_RUN_FLAGS,
+        instruction_budget,
+        0,
+        wire_out,
+    )
+}
+
+pub fn build_run_wire_frame(
+    session: &mut BoardVmLanguageSession,
+    program_id: u16,
+    flags: u8,
+    instruction_budget: u32,
+    time_budget_ms: u32,
+    wire_out: &mut [u8],
+) -> Result<BuiltWireFrame, LanguageCoreError> {
     let mut payload = [0u8; 16];
     let mut raw = [0u8; 32];
     let mut host = session.host_session();
-    let written =
-        host.run_background_frame(program_id, instruction_budget, &mut payload, &mut raw)?;
+    let written = host.run_frame(
+        program_id,
+        flags,
+        instruction_budget,
+        time_budget_ms,
+        &mut payload,
+        &mut raw,
+    )?;
     let wire_len = encode_wire_frame(&raw[..written.len], wire_out)?;
     session.update_from_host_session(&host);
     Ok(BuiltWireFrame {
@@ -1077,6 +1107,34 @@ pub unsafe extern "C" fn board_vm_language_run_background_wire(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_run_wire(
+    session: *mut BoardVmLanguageSession,
+    program_id: u16,
+    flags: u8,
+    instruction_budget: u32,
+    time_budget_ms: u32,
+    wire_out: *mut u8,
+    wire_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let session = unsafe { mut_ref(session, "board_vm_language_run_wire session") }?;
+        let wire_out = unsafe { out_slice(wire_out, wire_cap, "wire_out") }?;
+        let written = build_run_wire_frame(
+            session,
+            program_id,
+            flags,
+            instruction_budget,
+            time_budget_ms,
+            wire_out,
+        )?;
+        Ok(BoardVmLanguageStatus::written(
+            written.request_id,
+            written.len,
+        ))
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_stop_wire(
     session: *mut BoardVmLanguageSession,
     wire_out: *mut u8,
@@ -1115,6 +1173,26 @@ pub extern "C" fn board_vm_language_default_program_id() -> u16 {
 #[no_mangle]
 pub extern "C" fn board_vm_language_default_instruction_budget() -> u32 {
     DEFAULT_INSTRUCTION_BUDGET
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_default_run_flags() -> u8 {
+    LANGUAGE_DEFAULT_RUN_FLAGS
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_run_flag_reset_vm_before_run() -> u8 {
+    LANGUAGE_RUN_FLAG_RESET_VM_BEFORE_RUN
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_run_flag_keep_handles_after_run() -> u8 {
+    LANGUAGE_RUN_FLAG_KEEP_HANDLES_AFTER_RUN
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_run_flag_background_run() -> u8 {
+    LANGUAGE_RUN_FLAG_BACKGROUND_RUN
 }
 
 #[no_mangle]
@@ -1308,7 +1386,7 @@ mod tests {
         encode_caps_report, encode_frame, encode_hello_ack, encode_value, encode_wire_frame,
         CapabilityDescriptor, CapsReportHeader, Frame, HelloAck, MessageType, RunReportHeader,
         RunStatus, Value, FLAG_IS_RESPONSE, GOLDEN_HELLO_WIRE_FRAME_BVM_V1,
-        RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
+        RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_KEEP_HANDLES_AFTER_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
     };
 
     #[test]
@@ -1485,10 +1563,31 @@ mod tests {
             RUN_FLAG_RESET_VM_BEFORE_RUN | RUN_FLAG_BACKGROUND_RUN
         );
 
+        let run = unsafe {
+            board_vm_language_run_wire(
+                &mut session,
+                7,
+                RUN_FLAG_KEEP_HANDLES_AFTER_RUN,
+                456,
+                250,
+                wire.as_mut_ptr(),
+                wire.len() as u64,
+            )
+        };
+        assert_eq!(run.request_id, 6);
+        let decoded = decode_wire_frame_into_raw(&wire[..run.len as usize], &mut raw).unwrap();
+        assert_eq!(decoded.message_type, MessageType::RUN.0);
+        let frame = decode_frame(&raw[..decoded.len as usize]).unwrap();
+        let run_payload = decode_run_request(frame.payload).unwrap();
+        assert_eq!(run_payload.program_id, 7);
+        assert_eq!(run_payload.flags, RUN_FLAG_KEEP_HANDLES_AFTER_RUN);
+        assert_eq!(run_payload.instruction_budget, 456);
+        assert_eq!(run_payload.time_budget_ms, 250);
+
         let stop = unsafe {
             board_vm_language_stop_wire(&mut session, wire.as_mut_ptr(), wire.len() as u64)
         };
-        assert_eq!(stop.request_id, 6);
+        assert_eq!(stop.request_id, 7);
         let decoded = decode_wire_frame_into_raw(&wire[..stop.len as usize], &mut raw).unwrap();
         assert_eq!(decoded.message_type, MessageType::STOP.0);
         let frame = decode_frame(&raw[..decoded.len as usize]).unwrap();


### PR DESCRIPTION
## Summary

- add Rust host/language-core builders for configurable RUN frames with flags and time budgets
- expose RUN flag sugar through Python and Ruby while keeping payload encoding in Rust
- add tests and docs for keep-handle/background/time-budget run options

## Validation

- cargo test --manifest-path code/packages/rust/board-vm-host/Cargo.toml
- cargo test --manifest-path code/packages/rust/board-vm-language-core/Cargo.toml
- cargo test --manifest-path code/packages/rust/board-vm-client/Cargo.toml
- PYTHONPATH=code/packages/python/board-vm-native/src python3 -m pytest code/packages/python/board-vm-native/tests/ -v
- ruby -Icode/packages/ruby/board_vm/lib -Icode/packages/ruby/board_vm/test code/packages/ruby/board_vm/test/test_board_vm.rb
