### PR TITLE
[codex] Audit smart-home tool authorization decisions

### DIFF
--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this package will be documented in this file.
   capabilities before command acceptance.
 - Registry-backed authorization decision auditing for accepted and rejected
   authorized commands.
+- Registry-backed tool authorization decisions for Chief of Staff tool calls.
 - Supervisor primitives for bridge-worker heartbeat tracking and restart
   signaling.
 - Desired-state reconciliation for missing, stale, or drifted entity state,

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -15,6 +15,7 @@ Included surfaces:
   tools
 - registry-backed authorization decision auditing for accepted and rejected
   authorized commands
+- registry-backed tool authorization decisions for Chief of Staff tool calls
 - accepted command results that remain separate from confirmed device state
 - optimistic command state with expiry into stale snapshots
 - desired-state reconciliation that detects missing, stale, or drifted state

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -666,6 +666,19 @@ impl SmartHomeRuntime {
         Ok(())
     }
 
+    pub fn authorize_tool_for_principal(
+        &mut self,
+        principal_id: AgentId,
+        tool: SmartHomeTool,
+        now_ms: u64,
+    ) -> AuthorizationDecision {
+        let grants = self.registry.capability_grants_for_principal(&principal_id);
+        let decision = AuthorizationDecision::for_tool(principal_id, tool, grants, now_ms);
+        self.registry
+            .record_authorization_decision(decision.clone());
+        decision
+    }
+
     pub fn submit_command(
         &mut self,
         command: DeviceCommand,
@@ -1304,6 +1317,48 @@ mod tests {
         assert_eq!(decisions.len(), 2);
         assert_eq!(decisions[0].outcome, AuthorizationOutcome::Allowed);
         assert_eq!(decisions[1].outcome, AuthorizationOutcome::Denied);
+    }
+
+    #[test]
+    fn tool_authorization_records_decisions_without_dispatching_commands() {
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:lighting-planner");
+        runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-read"),
+                principal.clone(),
+                CapabilityId::trusted("smart_home.read"),
+                PrivilegeTier::ReadOnly,
+                "chief-of-staff",
+                1_000,
+            )
+            .with_expiry(2_000),
+        );
+
+        let allowed =
+            runtime.authorize_tool_for_principal(principal.clone(), SmartHomeTool::GetState, 1_500);
+        let denied =
+            runtime.authorize_tool_for_principal(principal.clone(), SmartHomeTool::Command, 1_500);
+        let expired =
+            runtime.authorize_tool_for_principal(principal.clone(), SmartHomeTool::GetState, 2_000);
+        let decisions = runtime
+            .registry()
+            .authorization_decisions_for_principal(&principal);
+
+        assert_eq!(allowed.outcome, AuthorizationOutcome::Allowed);
+        assert_eq!(denied.outcome, AuthorizationOutcome::Denied);
+        assert_eq!(expired.outcome, AuthorizationOutcome::Denied);
+        assert_eq!(runtime.registry().counts().authorization_decisions, 3);
+        assert_eq!(decisions.len(), 3);
+        assert!(runtime.event_bus().published().is_empty());
+        assert_eq!(
+            denied.missing_capabilities,
+            vec![CapabilityId::trusted("smart_home.command.light")]
+        );
+        assert_eq!(
+            expired.missing_capabilities,
+            vec![CapabilityId::trusted("smart_home.read")]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `SmartHomeRuntime::authorize_tool_for_principal` for Chief of Staff tool-call authorization checks without command dispatch
- persist registry-backed authorization decisions with observed grant snapshots and allow/deny reasoning
- document the runtime authorization audit path in the smart-home runtime README and changelog

## Tests

- `cargo test --manifest-path code/packages/rust/Cargo.toml -p smart-home-runtime -p smart-home-registry`
