### PR TITLE
[codex] Add Board VM GPIO handle sugar

### DIFF
--- a/code/packages/python/board-vm-native/README.md
+++ b/code/packages/python/board-vm-native/README.md
@@ -13,6 +13,10 @@ session = Session()
 frames = session.blink(program_id=1, instruction_budget=12).frames
 read_frames = session.gpio_read(pin=13, mode="pullup").frames
 write_frames = session.gpio_write(pin=13, value=True).frames
+open_frames = session.gpio_open(pin=13, mode="output").frames
+handle_write_frames = session.gpio_handle_write(value=True).frames
+handle_read_frames = session.gpio_handle_read().frames
+handle_close_frames = session.gpio_handle_close().frames
 now_frames = session.time_now(program_id=2, instruction_budget=12).frames
 sleep_frames = session.time_sleep_ms(250, program_id=3, instruction_budget=12).frames
 store_frame = session.store_program(program_id=1, slot=0, boot_policy="run-if-no-host").frame
@@ -53,12 +57,22 @@ session.gpio_high(pin=13)
 session.gpio_low(pin=13)
 ```
 
+For REPL-style sessions that keep a handle open across calls, the handle helpers
+use Rust-built modules that operate on the VM's top stack handle. `gpio_open()`
+duplicates the opened handle so the host can see it in the decoded run report
+while the VM keeps the original handle for later `gpio_handle_read()`,
+`gpio_handle_write()`, and `gpio_handle_close()` calls.
+
 The REPL-style sugar is intentionally thin as well:
 
 ```python
 session.run_command("store-program 1 0 run-if-no-host")
 session.run_command("gpio-read 13 pullup 24")
 session.run_command("gpio-write 13 high 24")
+session.run_command("gpio-open 13 output 24")
+session.run_command("gpio-handle-write high 24")
+session.run_command("gpio-handle-read 24")
+session.run_command("gpio-handle-close 24")
 session.run_command("time-sleep-ms 250 24")
 session.run_command("stop")
 ```

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -39,6 +39,10 @@ GPIO_READ_MODES = {
     "input_pulldown": 3,
     "pulldown": 3,
 }
+GPIO_MODES = {
+    **GPIO_READ_MODES,
+    "output": 1,
+}
 
 
 @dataclass(frozen=True)
@@ -215,6 +219,18 @@ class Session:
     def gpio_write_module(self, *, pin: int, value: bool, max_stack: int = 3) -> bytes:
         return _native.gpio_write_module(pin, 1 if value else 0, max_stack)
 
+    def gpio_open_module(self, *, pin: int, mode: str | int = "output", max_stack: int = 2) -> bytes:
+        return _native.gpio_open_module(pin, self._gpio_mode(mode), max_stack)
+
+    def gpio_handle_read_module(self, max_stack: int = 2) -> bytes:
+        return _native.gpio_handle_read_module(max_stack)
+
+    def gpio_handle_write_module(self, *, value: bool, max_stack: int = 3) -> bytes:
+        return _native.gpio_handle_write_module(1 if value else 0, max_stack)
+
+    def gpio_handle_close_module(self, max_stack: int = 1) -> bytes:
+        return _native.gpio_handle_close_module(max_stack)
+
     def time_now_module(self, max_stack: int = 1) -> bytes:
         return _native.time_now_module(max_stack)
 
@@ -293,6 +309,53 @@ class Session:
         return self.upload(
             program_id=program_id,
             module_bytes=self.gpio_write_module(pin=pin, value=value, max_stack=max_stack),
+        )
+
+    def upload_gpio_open(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        pin: int,
+        mode: str | int = "output",
+        max_stack: int = 2,
+    ) -> SessionResult:
+        return self.upload(
+            program_id=program_id,
+            module_bytes=self.gpio_open_module(pin=pin, mode=mode, max_stack=max_stack),
+        )
+
+    def upload_gpio_handle_read(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        max_stack: int = 2,
+    ) -> SessionResult:
+        return self.upload(
+            program_id=program_id,
+            module_bytes=self.gpio_handle_read_module(max_stack=max_stack),
+        )
+
+    def upload_gpio_handle_write(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        value: bool,
+        max_stack: int = 3,
+    ) -> SessionResult:
+        return self.upload(
+            program_id=program_id,
+            module_bytes=self.gpio_handle_write_module(value=value, max_stack=max_stack),
+        )
+
+    def upload_gpio_handle_close(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        max_stack: int = 1,
+    ) -> SessionResult:
+        return self.upload(
+            program_id=program_id,
+            module_bytes=self.gpio_handle_close_module(max_stack=max_stack),
         )
 
     def upload_time_now(
@@ -455,6 +518,101 @@ class Session:
     def gpio_low(self, *, pin: int, **options: Any) -> SessionResult:
         return self.gpio_write(pin=pin, value=False, **options)
 
+    def gpio_open(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET,
+        handshake: bool = False,
+        query_caps: bool = False,
+        pin: int,
+        mode: str | int = "output",
+        max_stack: int = 2,
+    ) -> SessionResult:
+        results: list[ProtocolResult] = []
+        if handshake:
+            results.append(self.hello())
+        if query_caps:
+            results.append(self.capabilities())
+        results.extend(
+            self.upload_gpio_open(
+                program_id=program_id,
+                pin=pin,
+                mode=mode,
+                max_stack=max_stack,
+            ).results
+        )
+        results.append(
+            self.run(
+                program_id=program_id,
+                instruction_budget=instruction_budget,
+                keep_handles=True,
+                background=False,
+            )
+        )
+        return SessionResult(results)
+
+    def gpio_handle_read(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: int = 2,
+    ) -> SessionResult:
+        results = self.upload_gpio_handle_read(program_id=program_id, max_stack=max_stack).results
+        results.append(
+            self.run(
+                program_id=program_id,
+                instruction_budget=instruction_budget,
+                reset_vm=False,
+                keep_handles=True,
+                background=False,
+            )
+        )
+        return SessionResult(results)
+
+    def gpio_handle_write(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET,
+        value: bool,
+        max_stack: int = 3,
+    ) -> SessionResult:
+        results = self.upload_gpio_handle_write(
+            program_id=program_id,
+            value=value,
+            max_stack=max_stack,
+        ).results
+        results.append(
+            self.run(
+                program_id=program_id,
+                instruction_budget=instruction_budget,
+                reset_vm=False,
+                keep_handles=True,
+                background=False,
+            )
+        )
+        return SessionResult(results)
+
+    def gpio_handle_close(
+        self,
+        *,
+        program_id: int = DEFAULT_PROGRAM_ID,
+        instruction_budget: int = DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: int = 1,
+    ) -> SessionResult:
+        results = self.upload_gpio_handle_close(program_id=program_id, max_stack=max_stack).results
+        results.append(
+            self.run(
+                program_id=program_id,
+                instruction_budget=instruction_budget,
+                reset_vm=False,
+                background=False,
+            )
+        )
+        return SessionResult(results)
+
     def time_now(
         self,
         *,
@@ -522,6 +680,20 @@ class Session:
             return self.upload_gpio_write(
                 **self._with_gpio_write_options(words, command, options, allow_budget=False)
             )
+        if command in {"upload-gpio-open", "upload-gpio.open"}:
+            return self.upload_gpio_open(
+                **self._with_gpio_open_options(words, command, options, allow_budget=False)
+            )
+        if command in {"upload-gpio-handle-read", "upload-gpio.handle-read"}:
+            self._ensure_no_extra(words, command)
+            return self.upload_gpio_handle_read(**options)
+        if command in {"upload-gpio-handle-write", "upload-gpio.handle-write"}:
+            return self.upload_gpio_handle_write(
+                **self._with_gpio_handle_write_options(words, command, options, allow_budget=False)
+            )
+        if command in {"upload-gpio-handle-close", "upload-gpio.handle-close"}:
+            self._ensure_no_extra(words, command)
+            return self.upload_gpio_handle_close(**options)
         if command in {"upload-time-now", "upload-time.now"}:
             self._ensure_no_extra(words, command)
             return self.upload_time_now(**options)
@@ -546,6 +718,16 @@ class Session:
             return self.gpio_write(**self._with_gpio_level_options(words, command, options, value=True))
         if command in {"gpio-low", "gpio.low"}:
             return self.gpio_write(**self._with_gpio_level_options(words, command, options, value=False))
+        if command in {"gpio-open", "gpio.open"}:
+            return self.gpio_open(**self._with_gpio_open_options(words, command, options))
+        if command in {"gpio-handle-read", "gpio.handle-read"}:
+            return self.gpio_handle_read(**self._with_optional_budget(words, command, options))
+        if command in {"gpio-handle-write", "gpio.handle-write"}:
+            return self.gpio_handle_write(
+                **self._with_gpio_handle_write_options(words, command, options)
+            )
+        if command in {"gpio-handle-close", "gpio.handle-close"}:
+            return self.gpio_handle_close(**self._with_optional_budget(words, command, options))
         if command in {"time-now", "time.now", "now"}:
             return self.time_now(**self._with_optional_budget(words, command, options))
         if command in {"time-sleep-ms", "time.sleep_ms", "sleep-ms"}:
@@ -679,6 +861,18 @@ class Session:
             raise ValueError(f"unsupported GPIO read mode: {mode!r}") from exc
 
     @staticmethod
+    def _gpio_mode(mode: str | int) -> int:
+        if isinstance(mode, int):
+            return mode
+        normalized = str(mode).replace("-", "_")
+        if normalized.isdecimal():
+            return int(normalized)
+        try:
+            return GPIO_MODES[normalized]
+        except KeyError as exc:
+            raise ValueError(f"unsupported GPIO mode: {mode!r}") from exc
+
+    @staticmethod
     def _boot_policy(policy: str | int) -> int:
         if isinstance(policy, int):
             return policy
@@ -708,6 +902,48 @@ class Session:
         self._ensure_no_extra(words, command)
         if "pin" not in merged:
             raise ValueError(f"{command} requires pin")
+        if "value" not in merged:
+            raise ValueError(f"{command} requires value")
+        return merged
+
+    def _with_gpio_open_options(
+        self,
+        words: list[str],
+        command: str,
+        options: dict[str, Any],
+        *,
+        allow_budget: bool = True,
+    ) -> dict[str, Any]:
+        merged = dict(options)
+        if words:
+            merged["pin"] = int(words.pop(0))
+        if words:
+            mode_or_budget = words.pop(0)
+            if allow_budget and mode_or_budget.isdecimal():
+                merged["instruction_budget"] = int(mode_or_budget)
+            else:
+                merged["mode"] = mode_or_budget
+        if allow_budget and words:
+            merged["instruction_budget"] = int(words.pop(0))
+        self._ensure_no_extra(words, command)
+        if "pin" not in merged:
+            raise ValueError(f"{command} requires pin")
+        return merged
+
+    def _with_gpio_handle_write_options(
+        self,
+        words: list[str],
+        command: str,
+        options: dict[str, Any],
+        *,
+        allow_budget: bool = True,
+    ) -> dict[str, Any]:
+        merged = dict(options)
+        if words:
+            merged["value"] = self._gpio_write_value(words.pop(0))
+        if allow_budget and words:
+            merged["instruction_budget"] = int(words.pop(0))
+        self._ensure_no_extra(words, command)
         if "value" not in merged:
             raise ValueError(f"{command} requires value")
         return merged
@@ -750,6 +986,7 @@ __all__ = [
     "BOOT_POLICIES",
     "Capability",
     "DEFAULT_RUN_FLAGS",
+    "GPIO_MODES",
     "GPIO_READ_MODES",
     "ProtocolResult",
     "RUN_FLAG_BACKGROUND_RUN",

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -2,15 +2,18 @@ use std::ffi::{c_char, c_long};
 use std::ptr;
 
 use board_vm_host::{
-    BlinkProgram, GpioReadProgram, GpioWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    BLINK_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
-    TIME_SLEEP_MS_MODULE_LEN,
+    BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
+    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    BLINK_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
+    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
+    GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
-    build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
-    build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
-    build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
-    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
+    build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
+    build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
+    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
+    build_raw_module, build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, decode_wire_response, program_format_name, raw_module_len,
@@ -125,6 +128,79 @@ unsafe extern "C" fn py_gpio_write_module(_module: PyObjectPtr, args: PyObjectPt
     let module = match build_gpio_write_module_value(pin, value != 0, max_stack) {
         Ok(module) => module,
         Err(error) => return raise_core_error("gpio_write_module", error),
+    };
+    bytes_to_py(&module)
+}
+
+unsafe extern "C" fn py_gpio_open_module(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let pin = match parse_arg_u8(args, 0, "pin") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let mode = match parse_arg_u8(args, 1, "mode") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let max_stack = match parse_arg_u8(args, 2, "max_stack") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    let module = match build_gpio_open_module_value(pin, mode, max_stack) {
+        Ok(module) => module,
+        Err(error) => return raise_core_error("gpio_open_module", error),
+    };
+    bytes_to_py(&module)
+}
+
+unsafe extern "C" fn py_gpio_handle_read_module(
+    _module: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    let max_stack = match parse_arg_u8(args, 0, "max_stack") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    let module = match build_gpio_handle_read_module_value(max_stack) {
+        Ok(module) => module,
+        Err(error) => return raise_core_error("gpio_handle_read_module", error),
+    };
+    bytes_to_py(&module)
+}
+
+unsafe extern "C" fn py_gpio_handle_write_module(
+    _module: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    let value = match parse_arg_u8(args, 0, "value") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let max_stack = match parse_arg_u8(args, 1, "max_stack") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    let module = match build_gpio_handle_write_module_value(value != 0, max_stack) {
+        Ok(module) => module,
+        Err(error) => return raise_core_error("gpio_handle_write_module", error),
+    };
+    bytes_to_py(&module)
+}
+
+unsafe extern "C" fn py_gpio_handle_close_module(
+    _module: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    let max_stack = match parse_arg_u8(args, 0, "max_stack") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+
+    let module = match build_gpio_handle_close_module_value(max_stack) {
+        Ok(module) => module,
+        Err(error) => return raise_core_error("gpio_handle_close_module", error),
     };
     bytes_to_py(&module)
 }
@@ -683,6 +759,49 @@ fn build_gpio_write_module_value(
     Ok(module)
 }
 
+fn build_gpio_open_module_value(
+    pin: u8,
+    mode: u8,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; GPIO_OPEN_MODULE_LEN];
+    let len = build_gpio_open_module(
+        GpioOpenProgram {
+            pin,
+            mode,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_gpio_handle_read_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; GPIO_HANDLE_READ_MODULE_LEN];
+    let len = build_gpio_handle_read_module(GpioHandleReadProgram { max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_gpio_handle_write_module_value(
+    value: bool,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; GPIO_HANDLE_WRITE_MODULE_LEN];
+    let len =
+        build_gpio_handle_write_module(GpioHandleWriteProgram { value, max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_gpio_handle_close_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; GPIO_HANDLE_CLOSE_MODULE_LEN];
+    let len = build_gpio_handle_close_module(GpioHandleCloseProgram { max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
 unsafe fn parse_arg_bytes(args: PyObjectPtr, index: isize, name: &str) -> Option<Vec<u8>> {
     let arg = PyTuple_GetItem(args, index);
     if arg.is_null() {
@@ -784,7 +903,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 17] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 21] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -814,6 +933,34 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_gpio_write_module),
             ml_flags: METH_VARARGS,
             ml_doc: b"Build a Board VM GPIO write BVM module in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"gpio_open_module\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_gpio_open_module),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM GPIO open-handle BVM module in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"gpio_handle_read_module\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_gpio_handle_read_module),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM GPIO read-top-handle BVM module in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"gpio_handle_write_module\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_gpio_handle_write_module),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM GPIO write-top-handle BVM module in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"gpio_handle_close_module\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_gpio_handle_close_module),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Build a Board VM GPIO close-top-handle BVM module in Rust.\0".as_ptr()
+                as *const c_char,
         },
         PyMethodDef {
             ml_name: b"time_now_module\0".as_ptr() as *const c_char,

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -34,6 +34,22 @@ def test_native_session_builds_protocol_bytes_in_rust():
     assert isinstance(gpio_write_module, bytes)
     assert len(gpio_write_module) > 0
 
+    gpio_open_module = session.gpio_open_module(pin=13, mode="output", max_stack=2)
+    assert isinstance(gpio_open_module, bytes)
+    assert len(gpio_open_module) > 0
+
+    gpio_handle_read_module = session.gpio_handle_read_module(max_stack=2)
+    assert isinstance(gpio_handle_read_module, bytes)
+    assert len(gpio_handle_read_module) > 0
+
+    gpio_handle_write_module = session.gpio_handle_write_module(value=True, max_stack=3)
+    assert isinstance(gpio_handle_write_module, bytes)
+    assert len(gpio_handle_write_module) > 0
+
+    gpio_handle_close_module = session.gpio_handle_close_module(max_stack=1)
+    assert isinstance(gpio_handle_close_module, bytes)
+    assert len(gpio_handle_close_module) > 0
+
     time_module = session.time_now_module(max_stack=1)
     assert isinstance(time_module, bytes)
     assert len(time_module) > 0
@@ -171,6 +187,42 @@ def test_run_command_accepts_repl_style_gpio_write_and_levels():
         "run",
     ]
     assert result.frames + high.frames + low.frames == transport.frames
+
+
+def test_run_command_accepts_repl_style_gpio_handle_commands():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    open_result = session.run_command("gpio-open 13 output 24", program_id=9)
+    read = session.run_command("gpio-handle-read 24", program_id=10)
+    write = session.run_command("gpio-handle-write high 24", program_id=11)
+    close = session.run_command("gpio-handle-close 24", program_id=12)
+
+    assert [item.command for item in open_result.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+        "run",
+    ]
+    assert [item.command for item in read.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+        "run",
+    ]
+    assert [item.command for item in write.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+        "run",
+    ]
+    assert [item.command for item in close.results] == [
+        "program_begin",
+        "program_chunk",
+        "program_end",
+        "run",
+    ]
+    assert open_result.frames + read.frames + write.frames + close.frames == transport.frames
 
 
 def test_run_command_accepts_repl_style_time_now():

--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -122,11 +122,14 @@ end
 ```
 
 `hello`, `capabilities`, `upload_blink`, `store_program`, `upload_gpio_read`,
-`upload_time_now`, `upload_time_sleep_ms`, `upload_gpio_write`, `run`, `stop`,
-`blink`, `gpio_read`, `gpio_write`, `time_now`, `time_sleep_ms`, and
-`run_command` return dispatch results with the Rust-produced frame, optional raw
-response bytes, and optional Rust-decoded response hash. The text command parser
-is Ruby sugar only; every dispatched frame still comes from
+`upload_time_now`, `upload_time_sleep_ms`, `upload_gpio_write`,
+`upload_gpio_open`, `upload_gpio_handle_read`, `upload_gpio_handle_write`,
+`upload_gpio_handle_close`, `run`, `stop`, `blink`, `gpio_read`, `gpio_write`,
+`gpio_open`, `gpio_handle_read`, `gpio_handle_write`, `gpio_handle_close`,
+`time_now`, `time_sleep_ms`, and `run_command` return dispatch results with the
+Rust-produced frame, optional raw response bytes, and optional Rust-decoded
+response hash. The text command parser is Ruby sugar only; every dispatched
+frame still comes from
 `CodingAdventures::BoardVM::Native::Session`.
 
 `run` also accepts protocol-level options without moving protocol work into
@@ -140,6 +143,22 @@ end
 
 Ruby turns friendly keywords into a flag mask; the RUN request payload and wire
 frame are still built by `board-vm-language-core`.
+
+For REPL-style GPIO sessions, Ruby can keep a VM stack handle open across
+commands:
+
+```ruby
+board.session do |vm|
+  vm.gpio_open(pin: 13, mode: :output)
+  vm.gpio_handle_write(value: :high)
+  vm.gpio_handle_read
+  vm.gpio_handle_close
+end
+```
+
+Those calls still upload and run Rust-built modules. The open module duplicates
+the handle so the host can receive it in the decoded run report while the VM
+keeps the original as the top stack value for later read/write/close helpers.
 
 Capability reports can be lifted into Ruby objects after Rust decodes the board
 response:

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -3,15 +3,18 @@ use std::ptr;
 use std::slice;
 
 use board_vm_host::{
-    BlinkProgram, GpioReadProgram, GpioWriteProgram, TimeNowProgram, TimeSleepMsProgram,
-    BLINK_MODULE_LEN, GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN,
-    TIME_SLEEP_MS_MODULE_LEN,
+    BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
+    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, TimeNowProgram, TimeSleepMsProgram,
+    BLINK_MODULE_LEN, GPIO_HANDLE_CLOSE_MODULE_LEN, GPIO_HANDLE_READ_MODULE_LEN,
+    GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN, GPIO_READ_MODULE_LEN,
+    GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
-    build_blink_module, build_caps_query_wire_frame, build_gpio_read_module,
-    build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
-    build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
-    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
+    build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
+    build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
+    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
+    build_raw_module, build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, decode_wire_response, program_format_name, raw_module_len,
@@ -111,6 +114,50 @@ extern "C" fn session_gpio_write_module(
 
     let module = build_gpio_write_module_value(pin, value, max_stack)
         .unwrap_or_else(|error| raise_core_error("gpio_write_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_gpio_open_module(
+    _self_val: VALUE,
+    pin_val: VALUE,
+    mode_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let pin = rb_u8(pin_val, "pin");
+    let mode = rb_u8(mode_val, "mode");
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_gpio_open_module_value(pin, mode, max_stack)
+        .unwrap_or_else(|error| raise_core_error("gpio_open_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_gpio_handle_read_module(_self_val: VALUE, max_stack_val: VALUE) -> VALUE {
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_gpio_handle_read_module_value(max_stack)
+        .unwrap_or_else(|error| raise_core_error("gpio_handle_read_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_gpio_handle_write_module(
+    _self_val: VALUE,
+    value_val: VALUE,
+    max_stack_val: VALUE,
+) -> VALUE {
+    let value = rb_u8(value_val, "value") != 0;
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_gpio_handle_write_module_value(value, max_stack)
+        .unwrap_or_else(|error| raise_core_error("gpio_handle_write_module", error));
+    ruby_bridge::bytes_to_rb(&module)
+}
+
+extern "C" fn session_gpio_handle_close_module(_self_val: VALUE, max_stack_val: VALUE) -> VALUE {
+    let max_stack = rb_u8(max_stack_val, "max_stack");
+
+    let module = build_gpio_handle_close_module_value(max_stack)
+        .unwrap_or_else(|error| raise_core_error("gpio_handle_close_module", error));
     ruby_bridge::bytes_to_rb(&module)
 }
 
@@ -679,6 +726,49 @@ fn build_gpio_write_module_value(
     Ok(module)
 }
 
+fn build_gpio_open_module_value(
+    pin: u8,
+    mode: u8,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; GPIO_OPEN_MODULE_LEN];
+    let len = build_gpio_open_module(
+        GpioOpenProgram {
+            pin,
+            mode,
+            max_stack,
+        },
+        &mut module,
+    )?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_gpio_handle_read_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; GPIO_HANDLE_READ_MODULE_LEN];
+    let len = build_gpio_handle_read_module(GpioHandleReadProgram { max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_gpio_handle_write_module_value(
+    value: bool,
+    max_stack: u8,
+) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; GPIO_HANDLE_WRITE_MODULE_LEN];
+    let len =
+        build_gpio_handle_write_module(GpioHandleWriteProgram { value, max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
+fn build_gpio_handle_close_module_value(max_stack: u8) -> Result<Vec<u8>, LanguageCoreError> {
+    let mut module = vec![0; GPIO_HANDLE_CLOSE_MODULE_LEN];
+    let len = build_gpio_handle_close_module(GpioHandleCloseProgram { max_stack }, &mut module)?;
+    module.truncate(len);
+    Ok(module)
+}
+
 fn rb_u8(value: VALUE, name: &str) -> u8 {
     let value = rb_nonnegative_integer(value, name);
     if value > u8::MAX as u64 {
@@ -768,6 +858,30 @@ pub extern "C" fn Init_board_vm_native() {
         "gpio_write_module",
         session_gpio_write_module as *const c_void,
         3,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "gpio_open_module",
+        session_gpio_open_module as *const c_void,
+        3,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "gpio_handle_read_module",
+        session_gpio_handle_read_module as *const c_void,
+        1,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "gpio_handle_write_module",
+        session_gpio_handle_write_module as *const c_void,
+        2,
+    );
+    ruby_bridge::define_method_raw(
+        session_class,
+        "gpio_handle_close_module",
+        session_gpio_handle_close_module as *const c_void,
+        1,
     );
     ruby_bridge::define_method_raw(
         session_class,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -161,6 +161,72 @@ module CodingAdventures
         )
       end
 
+      def gpio_open!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        pin:,
+        mode: :output,
+        max_stack: 2
+      )
+        ensure_uno_r4_wifi!
+
+        session.gpio_open(
+          program_id: program_id,
+          budget: budget,
+          pin: pin,
+          mode: mode,
+          max_stack: max_stack,
+          handshake: true,
+          query_caps: true,
+          host_nonce: host_nonce
+        )
+      end
+
+      def gpio_handle_read!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 2
+      )
+        ensure_uno_r4_wifi!
+
+        session.gpio_handle_read(
+          program_id: program_id,
+          budget: budget,
+          max_stack: max_stack
+        )
+      end
+
+      def gpio_handle_write!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        value:,
+        max_stack: 3
+      )
+        ensure_uno_r4_wifi!
+
+        session.gpio_handle_write(
+          program_id: program_id,
+          budget: budget,
+          value: value,
+          max_stack: max_stack
+        )
+      end
+
+      def gpio_handle_close!(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 1
+      )
+        ensure_uno_r4_wifi!
+
+        session.gpio_handle_close(
+          program_id: program_id,
+          budget: budget,
+          max_stack: max_stack
+        )
+      end
+
       def time_now!(
         program_id: DEFAULT_PROGRAM_ID,
         budget: DEFAULT_INSTRUCTION_BUDGET,
@@ -440,6 +506,62 @@ module CodingAdventures
 
       def low(pin:, **options)
         write(pin: pin, value: false, **options)
+      end
+
+      def open(
+        pin:,
+        mode: :output,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        host_nonce: DEFAULT_HOST_NONCE,
+        max_stack: 2
+      )
+        @connection.gpio_open!(
+          program_id: program_id,
+          budget: budget,
+          host_nonce: host_nonce,
+          pin: pin,
+          mode: mode,
+          max_stack: max_stack
+        )
+      end
+
+      def handle_read(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 2
+      )
+        @connection.gpio_handle_read!(
+          program_id: program_id,
+          budget: budget,
+          max_stack: max_stack
+        )
+      end
+
+      def handle_write(
+        value:,
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 3
+      )
+        @connection.gpio_handle_write!(
+          program_id: program_id,
+          budget: budget,
+          value: value,
+          max_stack: max_stack
+        )
+      end
+
+      def handle_close(
+        program_id: DEFAULT_PROGRAM_ID,
+        budget: DEFAULT_INSTRUCTION_BUDGET,
+        max_stack: 1
+      )
+        @connection.gpio_handle_close!(
+          program_id: program_id,
+          budget: budget,
+          max_stack: max_stack
+        )
       end
     end
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -13,6 +13,7 @@ module CodingAdventures
         input_pulldown: 3,
         pulldown: 3
       }.freeze
+      GPIO_MODES = GPIO_READ_MODES.merge(output: 1).freeze
       GPIO_WRITE_VALUES = {
         high: true,
         on: true,
@@ -108,6 +109,22 @@ module CodingAdventures
         native_session.gpio_write_module(pin, gpio_write_value(value) ? 1 : 0, max_stack)
       end
 
+      def gpio_open_module(pin:, mode: :output, max_stack: 2)
+        native_session.gpio_open_module(pin, gpio_mode(mode), max_stack)
+      end
+
+      def gpio_handle_read_module(max_stack: 2)
+        native_session.gpio_handle_read_module(max_stack)
+      end
+
+      def gpio_handle_write_module(value:, max_stack: 3)
+        native_session.gpio_handle_write_module(gpio_write_value(value) ? 1 : 0, max_stack)
+      end
+
+      def gpio_handle_close_module(max_stack: 1)
+        native_session.gpio_handle_close_module(max_stack)
+      end
+
       def upload_gpio_read(
         program_id: @program_id,
         pin:,
@@ -129,6 +146,39 @@ module CodingAdventures
         upload(
           program_id: program_id,
           module_bytes: gpio_write_module(pin: pin, value: value, max_stack: max_stack)
+        )
+      end
+
+      def upload_gpio_open(
+        program_id: @program_id,
+        pin:,
+        mode: :output,
+        max_stack: 2
+      )
+        upload(
+          program_id: program_id,
+          module_bytes: gpio_open_module(pin: pin, mode: mode, max_stack: max_stack)
+        )
+      end
+
+      def upload_gpio_handle_read(program_id: @program_id, max_stack: 2)
+        upload(
+          program_id: program_id,
+          module_bytes: gpio_handle_read_module(max_stack: max_stack)
+        )
+      end
+
+      def upload_gpio_handle_write(program_id: @program_id, value:, max_stack: 3)
+        upload(
+          program_id: program_id,
+          module_bytes: gpio_handle_write_module(value: value, max_stack: max_stack)
+        )
+      end
+
+      def upload_gpio_handle_close(program_id: @program_id, max_stack: 1)
+        upload(
+          program_id: program_id,
+          module_bytes: gpio_handle_close_module(max_stack: max_stack)
         )
       end
 
@@ -301,6 +351,93 @@ module CodingAdventures
         gpio_write(pin: pin, value: false, **options)
       end
 
+      def gpio_open(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        pin:,
+        mode: :output,
+        max_stack: 2,
+        handshake: false,
+        query_caps: false,
+        host_name: @host_name,
+        host_nonce: @host_nonce
+      )
+        results = []
+        results << hello(host_name: host_name, host_nonce: host_nonce) if handshake
+        results << capabilities if query_caps
+        results.concat(
+          upload_gpio_open(
+            program_id: program_id,
+            pin: pin,
+            mode: mode,
+            max_stack: max_stack
+          ).results
+        )
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
+      def gpio_handle_read(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        max_stack: 2
+      )
+        results = upload_gpio_handle_read(program_id: program_id, max_stack: max_stack).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
+      def gpio_handle_write(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        value:,
+        max_stack: 3
+      )
+        results = upload_gpio_handle_write(
+          program_id: program_id,
+          value: value,
+          max_stack: max_stack
+        ).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          keep_handles: true,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
+      def gpio_handle_close(
+        program_id: @program_id,
+        budget: @instruction_budget,
+        instruction_budget: nil,
+        max_stack: 1
+      )
+        results = upload_gpio_handle_close(program_id: program_id, max_stack: max_stack).results
+        results << run(
+          program_id: program_id,
+          instruction_budget: instruction_budget || budget,
+          reset_vm: false,
+          background: false
+        )
+        SessionResult.new(results: results)
+      end
+
       def time_now(
         program_id: @program_id,
         budget: @instruction_budget,
@@ -370,6 +507,16 @@ module CodingAdventures
           upload_gpio_read(**gpio_read_command_options(words, command, options, require_budget: false))
         when "upload-gpio-write", "upload-gpio.write"
           upload_gpio_write(**gpio_write_command_options(words, command, options, require_budget: false))
+        when "upload-gpio-open", "upload-gpio.open"
+          upload_gpio_open(**gpio_open_command_options(words, command, options, require_budget: false))
+        when "upload-gpio-handle-read", "upload-gpio.handle-read"
+          ensure_no_extra_arguments!(words, command)
+          upload_gpio_handle_read(**options)
+        when "upload-gpio-handle-write", "upload-gpio.handle-write"
+          upload_gpio_handle_write(**gpio_handle_write_command_options(words, command, options, require_budget: false))
+        when "upload-gpio-handle-close", "upload-gpio.handle-close"
+          ensure_no_extra_arguments!(words, command)
+          upload_gpio_handle_close(**options)
         when "upload-time-now", "upload-time.now"
           ensure_no_extra_arguments!(words, command)
           upload_time_now(**options)
@@ -392,6 +539,14 @@ module CodingAdventures
           gpio_write(**gpio_level_command_options(words, command, options, value: true))
         when "gpio-low", "gpio.low"
           gpio_write(**gpio_level_command_options(words, command, options, value: false))
+        when "gpio-open", "gpio.open"
+          gpio_open(**gpio_open_command_options(words, command, options))
+        when "gpio-handle-read", "gpio.handle-read"
+          gpio_handle_read(**options.merge(optional_budget(words, command)))
+        when "gpio-handle-write", "gpio.handle-write"
+          gpio_handle_write(**gpio_handle_write_command_options(words, command, options))
+        when "gpio-handle-close", "gpio.handle-close"
+          gpio_handle_close(**options.merge(optional_budget(words, command)))
         when "time-now", "time.now", "now"
           time_now(**options.merge(optional_budget(words, command)))
         when "time-sleep-ms", "time.sleep_ms", "sleep-ms"
@@ -486,6 +641,17 @@ module CodingAdventures
         end
       end
 
+      def gpio_mode(mode)
+        return mode if mode.is_a?(Integer)
+
+        text = mode.to_s.tr("-", "_")
+        return Integer(text, 10) if integer_literal?(text)
+
+        GPIO_MODES.fetch(text.to_sym) do
+          raise ArgumentError, "unsupported GPIO mode: #{mode.inspect}"
+        end
+      end
+
       def gpio_write_command_options(words, command, options, require_budget: true)
         merged = options.dup
         merged[:pin] = integer_argument(words.shift, "#{command} pin") unless words.empty?
@@ -497,6 +663,43 @@ module CodingAdventures
 
         ensure_no_extra_arguments!(words, command)
         raise ArgumentError, "#{command} requires pin" unless merged.key?(:pin)
+        raise ArgumentError, "#{command} requires value" unless merged.key?(:value)
+
+        merged
+      end
+
+      def gpio_open_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:pin] = integer_argument(words.shift, "#{command} pin") unless words.empty?
+
+        unless words.empty?
+          mode_or_budget = words.shift
+          if integer_literal?(mode_or_budget) && require_budget
+            merged[:instruction_budget] = Integer(mode_or_budget, 10)
+          else
+            merged[:mode] = mode_or_budget
+          end
+        end
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
+        raise ArgumentError, "#{command} requires pin" unless merged.key?(:pin)
+
+        merged
+      end
+
+      def gpio_handle_write_command_options(words, command, options, require_budget: true)
+        merged = options.dup
+        merged[:value] = gpio_write_value(words.shift) unless words.empty?
+
+        if require_budget && !words.empty?
+          merged[:instruction_budget] = integer_argument(words.shift, "#{command} budget")
+        end
+
+        ensure_no_extra_arguments!(words, command)
         raise ArgumentError, "#{command} requires value" unless merged.key?(:value)
 
         merged

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -213,6 +213,10 @@ module CodingAdventures
             sleep_upload = session.upload_time_sleep_ms(program_id: 8, duration_ms: 250)
             gpio_upload = session.upload_gpio_read(program_id: 6, pin: 13, mode: :pullup)
             gpio_write_upload = session.upload_gpio_write(program_id: 7, pin: 13, value: true)
+            gpio_open_upload = session.upload_gpio_open(program_id: 10, pin: 13, mode: :output)
+            gpio_handle_read_upload = session.upload_gpio_handle_read(program_id: 11)
+            gpio_handle_write_upload = session.upload_gpio_handle_write(program_id: 12, value: true)
+            gpio_handle_close_upload = session.upload_gpio_handle_close(program_id: 13)
             store = session.store_program(program_id: 4, slot: 2, boot_policy: :run_at_boot)
             raw_module = session.raw_module(code: "\x00".b, max_stack: 1, const_pool: "\xAA\x55".b)
             raw_upload = session.upload_raw_module(
@@ -242,6 +246,14 @@ module CodingAdventures
               gpio_upload.results.map(&:command)
             assert_equal [:program_begin, :program_chunk, :program_end],
               gpio_write_upload.results.map(&:command)
+            assert_equal [:program_begin, :program_chunk, :program_end],
+              gpio_open_upload.results.map(&:command)
+            assert_equal [:program_begin, :program_chunk, :program_end],
+              gpio_handle_read_upload.results.map(&:command)
+            assert_equal [:program_begin, :program_chunk, :program_end],
+              gpio_handle_write_upload.results.map(&:command)
+            assert_equal [:program_begin, :program_chunk, :program_end],
+              gpio_handle_close_upload.results.map(&:command)
             assert_equal :store_program, store.command
             assert raw_module.start_with?("BVM1")
             assert raw_module.end_with?("\xAA\x55".b)
@@ -254,7 +266,7 @@ module CodingAdventures
         end
 
         assert_empty runner.calls
-        assert_equal 24, transport.frames.length
+        assert_equal 36, transport.frames.length
         assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
       end
 
@@ -344,6 +356,32 @@ module CodingAdventures
           assert_equal [:program_begin, :program_chunk, :program_end, :run],
             low.results.map(&:command)
           assert_equal write.frames + high.frames + low.frames, transport.frames
+        end
+      end
+
+      def test_session_run_command_accepts_repl_style_gpio_handle_commands
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          open = board.session.run_command("gpio-open 13 output 24", program_id: 9)
+          read = board.session.run_command("gpio-handle-read 24", program_id: 10)
+          write = board.session.run_command("gpio-handle-write high 24", program_id: 11)
+          close = board.session.run_command("gpio-handle-close 24", program_id: 12)
+
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            open.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            read.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            write.results.map(&:command)
+          assert_equal [:program_begin, :program_chunk, :program_end, :run],
+            close.results.map(&:command)
+          assert_equal open.frames + read.frames + write.frames + close.frames, transport.frames
         end
       end
 
@@ -464,6 +502,22 @@ module CodingAdventures
         gpio_write_module_bytes = session.gpio_write_module(13, 1, 3)
         assert_instance_of String, gpio_write_module_bytes
         assert_operator gpio_write_module_bytes.bytesize, :>, 0
+
+        gpio_open_module_bytes = session.gpio_open_module(13, 1, 2)
+        assert_instance_of String, gpio_open_module_bytes
+        assert_operator gpio_open_module_bytes.bytesize, :>, 0
+
+        gpio_handle_read_module_bytes = session.gpio_handle_read_module(2)
+        assert_instance_of String, gpio_handle_read_module_bytes
+        assert_operator gpio_handle_read_module_bytes.bytesize, :>, 0
+
+        gpio_handle_write_module_bytes = session.gpio_handle_write_module(1, 3)
+        assert_instance_of String, gpio_handle_write_module_bytes
+        assert_operator gpio_handle_write_module_bytes.bytesize, :>, 0
+
+        gpio_handle_close_module_bytes = session.gpio_handle_close_module(1)
+        assert_instance_of String, gpio_handle_close_module_bytes
+        assert_operator gpio_handle_close_module_bytes.bytesize, :>, 0
 
         store = session.store_program_wire(7, 2, 1)
         assert_instance_of String, store

--- a/code/packages/rust/board-vm-host/src/lib.rs
+++ b/code/packages/rust/board-vm-host/src/lib.rs
@@ -1,7 +1,8 @@
 use board_vm_ir::{
     parse_module, validate, CapabilitySet, ModuleError, ValidateError, CAP_GPIO_CLOSE,
     CAP_GPIO_OPEN, CAP_GPIO_READ, CAP_GPIO_WRITE, CAP_TIME_NOW_MS, CAP_TIME_SLEEP_MS,
-    FLAG_PROGRAM_MAY_RUN_FOREVER, MODULE_MAGIC, MODULE_VERSION,
+    FLAG_PROGRAM_MAY_RUN_FOREVER, FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES, MODULE_MAGIC,
+    MODULE_VERSION,
 };
 use board_vm_protocol::{
     encode_frame, encode_hello, encode_program_begin, encode_program_chunk, encode_program_end,
@@ -21,6 +22,14 @@ pub const GPIO_WRITE_CODE_LEN: usize = 12;
 pub const GPIO_WRITE_MODULE_LEN: usize = 22;
 pub const GPIO_READ_CODE_LEN: usize = 13;
 pub const GPIO_READ_MODULE_LEN: usize = 23;
+pub const GPIO_OPEN_CODE_LEN: usize = 8;
+pub const GPIO_OPEN_MODULE_LEN: usize = 18;
+pub const GPIO_HANDLE_READ_CODE_LEN: usize = 4;
+pub const GPIO_HANDLE_READ_MODULE_LEN: usize = 14;
+pub const GPIO_HANDLE_WRITE_CODE_LEN: usize = 4;
+pub const GPIO_HANDLE_WRITE_MODULE_LEN: usize = 14;
+pub const GPIO_HANDLE_CLOSE_CODE_LEN: usize = 2;
+pub const GPIO_HANDLE_CLOSE_MODULE_LEN: usize = 12;
 pub const TIME_NOW_CODE_LEN: usize = 3;
 pub const TIME_NOW_MODULE_LEN: usize = 13;
 pub const TIME_SLEEP_MS_CODE_LEN: usize = 5;
@@ -127,6 +136,103 @@ pub struct GpioWriteProgram {
     pub pin: u8,
     pub value: bool,
     pub max_stack: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpioOpenProgram {
+    pub pin: u8,
+    pub mode: u8,
+    pub max_stack: u8,
+}
+
+impl GpioOpenProgram {
+    pub const fn output(pin: u8) -> Self {
+        Self {
+            pin,
+            mode: GPIO_MODE_OUTPUT,
+            max_stack: 2,
+        }
+    }
+
+    pub const fn input(pin: u8) -> Self {
+        Self {
+            pin,
+            mode: GPIO_MODE_INPUT,
+            max_stack: 2,
+        }
+    }
+
+    pub const fn input_pullup(pin: u8) -> Self {
+        Self {
+            pin,
+            mode: GPIO_MODE_INPUT_PULLUP,
+            max_stack: 2,
+        }
+    }
+
+    pub const fn input_pulldown(pin: u8) -> Self {
+        Self {
+            pin,
+            mode: GPIO_MODE_INPUT_PULLDOWN,
+            max_stack: 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpioHandleReadProgram {
+    pub max_stack: u8,
+}
+
+impl GpioHandleReadProgram {
+    pub const fn new() -> Self {
+        Self { max_stack: 2 }
+    }
+}
+
+impl Default for GpioHandleReadProgram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpioHandleWriteProgram {
+    pub value: bool,
+    pub max_stack: u8,
+}
+
+impl GpioHandleWriteProgram {
+    pub const fn high() -> Self {
+        Self {
+            value: true,
+            max_stack: 3,
+        }
+    }
+
+    pub const fn low() -> Self {
+        Self {
+            value: false,
+            max_stack: 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GpioHandleCloseProgram {
+    pub max_stack: u8,
+}
+
+impl GpioHandleCloseProgram {
+    pub const fn new() -> Self {
+        Self { max_stack: 1 }
+    }
+}
+
+impl Default for GpioHandleCloseProgram {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl GpioWriteProgram {
@@ -578,9 +684,174 @@ pub fn write_gpio_write_module(
     Ok(offset)
 }
 
+pub fn write_gpio_open_code(program: GpioOpenProgram, out: &mut [u8]) -> Result<usize, HostError> {
+    if out.len() < GPIO_OPEN_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+    validate_gpio_mode(program.mode)?;
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.pin)?;
+    write_u8(out, &mut offset, OP_PUSH_U8)?;
+    write_u8(out, &mut offset, program.mode)?;
+    write_call_u8(out, &mut offset, CAP_GPIO_OPEN)?;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_gpio_open_module(
+    program: GpioOpenProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < GPIO_OPEN_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; GPIO_OPEN_CODE_LEN];
+    let code_len = write_gpio_open_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(0, program.max_stack, &code[..code_len]),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(&module, CapabilitySet::blink_mvp(), program.max_stack)?;
+    Ok(offset)
+}
+
+pub fn write_gpio_handle_read_code(
+    _program: GpioHandleReadProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < GPIO_HANDLE_READ_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_call_u8(out, &mut offset, CAP_GPIO_READ)?;
+    write_u8(out, &mut offset, OP_RETURN_TOP)?;
+    Ok(offset)
+}
+
+pub fn write_gpio_handle_read_module(
+    program: GpioHandleReadProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < GPIO_HANDLE_READ_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; GPIO_HANDLE_READ_CODE_LEN];
+    let code_len = write_gpio_handle_read_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(&module, CapabilitySet::blink_mvp(), program.max_stack)?;
+    Ok(offset)
+}
+
+pub fn write_gpio_handle_write_code(
+    program: GpioHandleWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < GPIO_HANDLE_WRITE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_u8(out, &mut offset, OP_DUP)?;
+    write_u8(
+        out,
+        &mut offset,
+        if program.value {
+            OP_PUSH_TRUE
+        } else {
+            OP_PUSH_FALSE
+        },
+    )?;
+    write_call_u8(out, &mut offset, CAP_GPIO_WRITE)?;
+    Ok(offset)
+}
+
+pub fn write_gpio_handle_write_module(
+    program: GpioHandleWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < GPIO_HANDLE_WRITE_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; GPIO_HANDLE_WRITE_CODE_LEN];
+    let code_len = write_gpio_handle_write_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(&module, CapabilitySet::blink_mvp(), program.max_stack)?;
+    Ok(offset)
+}
+
+pub fn write_gpio_handle_close_code(
+    _program: GpioHandleCloseProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < GPIO_HANDLE_CLOSE_CODE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut offset = 0;
+    write_call_u8(out, &mut offset, CAP_GPIO_CLOSE)?;
+    Ok(offset)
+}
+
+pub fn write_gpio_handle_close_module(
+    program: GpioHandleCloseProgram,
+    out: &mut [u8],
+) -> Result<usize, HostError> {
+    if out.len() < GPIO_HANDLE_CLOSE_MODULE_LEN {
+        return Err(HostError::OutputTooSmall);
+    }
+
+    let mut code = [0u8; GPIO_HANDLE_CLOSE_CODE_LEN];
+    let code_len = write_gpio_handle_close_code(program, &mut code)?;
+    let offset = write_module(
+        ModuleSpec::new(
+            FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            program.max_stack,
+            &code[..code_len],
+        ),
+        out,
+    )?;
+    let module = parse_module(&out[..offset])?;
+    validate(&module, CapabilitySet::blink_mvp(), program.max_stack)?;
+    Ok(offset)
+}
+
 fn validate_gpio_read_mode(mode: u8) -> Result<(), HostError> {
     match mode {
         GPIO_MODE_INPUT | GPIO_MODE_INPUT_PULLUP | GPIO_MODE_INPUT_PULLDOWN => Ok(()),
+        other => Err(HostError::InvalidGpioReadMode(other)),
+    }
+}
+
+fn validate_gpio_mode(mode: u8) -> Result<(), HostError> {
+    match mode {
+        GPIO_MODE_INPUT | GPIO_MODE_OUTPUT | GPIO_MODE_INPUT_PULLUP | GPIO_MODE_INPUT_PULLDOWN => {
+            Ok(())
+        }
         other => Err(HostError::InvalidGpioReadMode(other)),
     }
 }
@@ -788,6 +1059,19 @@ mod tests {
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x03, 0x00, 0x0C, 0x12, 0x0D, 0x12, 0x01, 0x40, 0x01,
         0x20, 0x11, 0x40, 0x02, 0x40, 0x04, 0x00,
     ];
+    const GPIO_OPEN_OUTPUT_MODULE_HEX: [u8; GPIO_OPEN_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x02, 0x00, 0x08, 0x12, 0x0D, 0x12, 0x01, 0x40, 0x01,
+        0x20, 0x50, 0x00,
+    ];
+    const GPIO_HANDLE_READ_MODULE_HEX: [u8; GPIO_HANDLE_READ_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x02, 0x00, 0x04, 0x20, 0x40, 0x03, 0x50, 0x00,
+    ];
+    const GPIO_HANDLE_WRITE_HIGH_MODULE_HEX: [u8; GPIO_HANDLE_WRITE_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x03, 0x00, 0x04, 0x20, 0x11, 0x40, 0x02, 0x00,
+    ];
+    const GPIO_HANDLE_CLOSE_MODULE_HEX: [u8; GPIO_HANDLE_CLOSE_MODULE_LEN] = [
+        0x42, 0x56, 0x4D, 0x31, 0x01, 0x04, 0x01, 0x00, 0x02, 0x40, 0x04, 0x00,
+    ];
     const TIME_NOW_MODULE_HEX: [u8; TIME_NOW_MODULE_LEN] = [
         0x42, 0x56, 0x4D, 0x31, 0x01, 0x00, 0x01, 0x00, 0x03, 0x40, 0x11, 0x50, 0x00,
     ];
@@ -853,6 +1137,41 @@ mod tests {
             &capabilities[..count],
             &[CAP_GPIO_OPEN, CAP_GPIO_WRITE, CAP_GPIO_CLOSE]
         );
+    }
+
+    #[test]
+    fn builds_gpio_handle_modules_for_repl_sessions() {
+        let mut open = [0u8; GPIO_OPEN_MODULE_LEN];
+        let open_len = write_gpio_open_module(GpioOpenProgram::output(13), &mut open).unwrap();
+        assert_eq!(open_len, GPIO_OPEN_MODULE_LEN);
+        assert_eq!(open, GPIO_OPEN_OUTPUT_MODULE_HEX);
+        let parsed = parse_module(&open).unwrap();
+        assert_eq!(parsed.flags, 0);
+        validate(&parsed, CapabilitySet::blink_mvp(), 2).unwrap();
+
+        let mut read = [0u8; GPIO_HANDLE_READ_MODULE_LEN];
+        let read_len =
+            write_gpio_handle_read_module(GpioHandleReadProgram::new(), &mut read).unwrap();
+        assert_eq!(read_len, GPIO_HANDLE_READ_MODULE_LEN);
+        assert_eq!(read, GPIO_HANDLE_READ_MODULE_HEX);
+        let parsed = parse_module(&read).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp(), 2).unwrap();
+
+        let mut write = [0u8; GPIO_HANDLE_WRITE_MODULE_LEN];
+        let write_len =
+            write_gpio_handle_write_module(GpioHandleWriteProgram::high(), &mut write).unwrap();
+        assert_eq!(write_len, GPIO_HANDLE_WRITE_MODULE_LEN);
+        assert_eq!(write, GPIO_HANDLE_WRITE_HIGH_MODULE_HEX);
+        let parsed = parse_module(&write).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp(), 3).unwrap();
+
+        let mut close = [0u8; GPIO_HANDLE_CLOSE_MODULE_LEN];
+        let close_len =
+            write_gpio_handle_close_module(GpioHandleCloseProgram::new(), &mut close).unwrap();
+        assert_eq!(close_len, GPIO_HANDLE_CLOSE_MODULE_LEN);
+        assert_eq!(close, GPIO_HANDLE_CLOSE_MODULE_HEX);
+        let parsed = parse_module(&close).unwrap();
+        validate(&parsed, CapabilitySet::blink_mvp(), 1).unwrap();
     }
 
     #[test]

--- a/code/packages/rust/board-vm-ir/src/lib.rs
+++ b/code/packages/rust/board-vm-ir/src/lib.rs
@@ -209,7 +209,11 @@ pub fn validate(
     }
 
     let mut ip = 0;
-    let mut depth: i16 = 0;
+    let mut depth: i16 = if module.flags & FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES != 0 {
+        1
+    } else {
+        0
+    };
     while ip < module.code.len() {
         let instruction_start = ip;
         let (op, next_ip) = decode_next(module.code, ip).map_err(ValidateError::Decode)?;
@@ -460,6 +464,33 @@ mod tests {
 
         assert_eq!(count, 1);
         assert_eq!(capabilities[0], 0x1234);
+    }
+
+    #[test]
+    fn persistent_handle_modules_validate_with_existing_stack_handle() {
+        let module = Module {
+            flags: FLAG_PROGRAM_REQUESTS_PERSISTENT_HANDLES,
+            max_stack: 1,
+            code: &[0x40, CAP_GPIO_CLOSE as u8],
+            const_pool: &[],
+        };
+
+        validate(&module, CapabilitySet::blink_mvp(), 8).unwrap();
+    }
+
+    #[test]
+    fn handle_stack_modules_without_persistent_flag_still_underflow() {
+        let module = Module {
+            flags: 0,
+            max_stack: 1,
+            code: &[0x40, CAP_GPIO_CLOSE as u8],
+            const_pool: &[],
+        };
+
+        assert_eq!(
+            validate(&module, CapabilitySet::blink_mvp(), 8),
+            Err(ValidateError::StackUnderflow(0))
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -13,10 +13,14 @@ use std::slice;
 use std::str;
 
 use board_vm_host::{
-    write_blink_module, write_gpio_read_module, write_gpio_write_module, write_module,
-    write_time_now_module, write_time_sleep_ms_module, BlinkProgram, GpioReadProgram,
-    GpioWriteProgram, HostError, HostSession, ModuleSpec, TimeNowProgram, TimeSleepMsProgram,
-    BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS,
+    write_blink_module, write_gpio_handle_close_module, write_gpio_handle_read_module,
+    write_gpio_handle_write_module, write_gpio_open_module, write_gpio_read_module,
+    write_gpio_write_module, write_module, write_time_now_module, write_time_sleep_ms_module,
+    BlinkProgram, GpioHandleCloseProgram, GpioHandleReadProgram, GpioHandleWriteProgram,
+    GpioOpenProgram, GpioReadProgram, GpioWriteProgram, HostError, HostSession, ModuleSpec,
+    TimeNowProgram, TimeSleepMsProgram, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET,
+    DEFAULT_PROGRAM_ID, DEFAULT_RUN_FLAGS, GPIO_HANDLE_CLOSE_MODULE_LEN,
+    GPIO_HANDLE_READ_MODULE_LEN, GPIO_HANDLE_WRITE_MODULE_LEN, GPIO_OPEN_MODULE_LEN,
     GPIO_READ_MODULE_LEN, GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_protocol::{
@@ -431,6 +435,34 @@ pub fn build_gpio_write_module(
     out: &mut [u8],
 ) -> Result<usize, LanguageCoreError> {
     Ok(write_gpio_write_module(program, out)?)
+}
+
+pub fn build_gpio_open_module(
+    program: GpioOpenProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_gpio_open_module(program, out)?)
+}
+
+pub fn build_gpio_handle_read_module(
+    program: GpioHandleReadProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_gpio_handle_read_module(program, out)?)
+}
+
+pub fn build_gpio_handle_write_module(
+    program: GpioHandleWriteProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_gpio_handle_write_module(program, out)?)
+}
+
+pub fn build_gpio_handle_close_module(
+    program: GpioHandleCloseProgram,
+    out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    Ok(write_gpio_handle_close_module(program, out)?)
 }
 
 pub fn build_time_now_module(
@@ -943,6 +975,86 @@ pub unsafe extern "C" fn board_vm_language_gpio_write_module(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_gpio_open_module(
+    pin: u8,
+    mode: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_gpio_open_module(
+            GpioOpenProgram {
+                pin,
+                mode,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn board_vm_language_gpio_handle_read_module(
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_gpio_handle_read_module(GpioHandleReadProgram { max_stack }, module_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn board_vm_language_gpio_handle_write_module(
+    value: u8,
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_gpio_handle_write_module(
+            GpioHandleWriteProgram {
+                value: value != 0,
+                max_stack,
+            },
+            module_out,
+        )?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn board_vm_language_gpio_handle_close_module(
+    max_stack: u8,
+    module_out: *mut u8,
+    module_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let module_out = unsafe { out_slice(module_out, module_cap, "module_out") }?;
+        let len = build_gpio_handle_close_module(GpioHandleCloseProgram { max_stack }, module_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn board_vm_language_time_now_module(
     max_stack: u8,
     module_out: *mut u8,
@@ -1211,6 +1323,26 @@ pub extern "C" fn board_vm_language_gpio_write_module_len() -> u64 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_gpio_open_module_len() -> u64 {
+    GPIO_OPEN_MODULE_LEN as u64
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_gpio_handle_read_module_len() -> u64 {
+    GPIO_HANDLE_READ_MODULE_LEN as u64
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_gpio_handle_write_module_len() -> u64 {
+    GPIO_HANDLE_WRITE_MODULE_LEN as u64
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_gpio_handle_close_module_len() -> u64 {
+    GPIO_HANDLE_CLOSE_MODULE_LEN as u64
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_time_now_module_len() -> u64 {
     TIME_NOW_MODULE_LEN as u64
 }
@@ -1470,6 +1602,71 @@ mod tests {
         };
         assert_eq!(gpio_write_status.code, BoardVmLanguageStatusCode::Ok as u32);
         assert_eq!(gpio_write_status.len, GPIO_WRITE_MODULE_LEN as u64);
+
+        let mut gpio_open_module = [0u8; GPIO_OPEN_MODULE_LEN];
+        let gpio_open_status = unsafe {
+            board_vm_language_gpio_open_module(
+                13,
+                board_vm_host::GPIO_MODE_OUTPUT,
+                2,
+                gpio_open_module.as_mut_ptr(),
+                gpio_open_module.len() as u64,
+            )
+        };
+        assert_eq!(gpio_open_status.code, BoardVmLanguageStatusCode::Ok as u32);
+        assert_eq!(gpio_open_status.len, GPIO_OPEN_MODULE_LEN as u64);
+
+        let mut gpio_handle_read_module = [0u8; GPIO_HANDLE_READ_MODULE_LEN];
+        let gpio_handle_read_status = unsafe {
+            board_vm_language_gpio_handle_read_module(
+                2,
+                gpio_handle_read_module.as_mut_ptr(),
+                gpio_handle_read_module.len() as u64,
+            )
+        };
+        assert_eq!(
+            gpio_handle_read_status.code,
+            BoardVmLanguageStatusCode::Ok as u32
+        );
+        assert_eq!(
+            gpio_handle_read_status.len,
+            GPIO_HANDLE_READ_MODULE_LEN as u64
+        );
+
+        let mut gpio_handle_write_module = [0u8; GPIO_HANDLE_WRITE_MODULE_LEN];
+        let gpio_handle_write_status = unsafe {
+            board_vm_language_gpio_handle_write_module(
+                1,
+                3,
+                gpio_handle_write_module.as_mut_ptr(),
+                gpio_handle_write_module.len() as u64,
+            )
+        };
+        assert_eq!(
+            gpio_handle_write_status.code,
+            BoardVmLanguageStatusCode::Ok as u32
+        );
+        assert_eq!(
+            gpio_handle_write_status.len,
+            GPIO_HANDLE_WRITE_MODULE_LEN as u64
+        );
+
+        let mut gpio_handle_close_module = [0u8; GPIO_HANDLE_CLOSE_MODULE_LEN];
+        let gpio_handle_close_status = unsafe {
+            board_vm_language_gpio_handle_close_module(
+                1,
+                gpio_handle_close_module.as_mut_ptr(),
+                gpio_handle_close_module.len() as u64,
+            )
+        };
+        assert_eq!(
+            gpio_handle_close_status.code,
+            BoardVmLanguageStatusCode::Ok as u32
+        );
+        assert_eq!(
+            gpio_handle_close_status.len,
+            GPIO_HANDLE_CLOSE_MODULE_LEN as u64
+        );
 
         let begin = unsafe {
             board_vm_language_program_begin_wire(


### PR DESCRIPTION
## Summary

- add Rust-owned GPIO open/read/write/close handle module builders, C ABI exports, and persistent-handle IR validation
- expose Python and Ruby module/upload/run/REPL sugar over those builders
- document the stack-top handle model so language APIs remain thin sugar over Board VM binary frames

## Validation

- cargo test --manifest-path code/packages/rust/board-vm-ir/Cargo.toml
- cargo test --manifest-path code/packages/rust/board-vm-host/Cargo.toml
- cargo test --manifest-path code/packages/rust/board-vm-language-core/Cargo.toml
- cargo build --release --manifest-path code/packages/python/board-vm-native/Cargo.toml
- PYTHONPATH=code/packages/python/board-vm-native/src python3 -m pytest code/packages/python/board-vm-native/tests/ -v
- cargo build --release --manifest-path code/packages/ruby/board_vm/ext/board_vm_native/Cargo.toml
- ruby -Icode/packages/ruby/board_vm/lib -Icode/packages/ruby/board_vm/test code/packages/ruby/board_vm/test/test_board_vm.rb
- git diff --check
