### PR TITLE
[codex] Add storage-fs conformance coverage

### DIFF
--- a/code/packages/rust/storage-fs/CHANGELOG.md
+++ b/code/packages/rust/storage-fs/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InMemoryStorageBackend`'s) — durable cross-process leases
   would require platform-specific `flock`/`lockf` and are
   deferred.
+- Shared `storage-core` conformance coverage for initialize,
+  put/get, stale compare-and-swap rejection, idempotent delete,
+  prefix listing order, and lease expiry.
 - 19 unit tests covering: put/get round-trip, missing-record
   read returns None, overwrite advances revision, CAS with
   correct/wrong/missing-record `if_revision`, delete +

--- a/code/packages/rust/storage-fs/README.md
+++ b/code/packages/rust/storage-fs/README.md
@@ -58,6 +58,11 @@ durability on filesystems that need it.
 in-memory revision counter from the highest revision on disk so
 monotonic numbering survives process restart.
 
+The backend also runs the shared `storage-core` conformance suite,
+so its point reads, conditional writes, stable prefix listing,
+idempotent deletes, and advisory leases are checked against the same
+contract as the in-memory backend.
+
 ## Where it fits
 
 ```text

--- a/code/packages/rust/storage-fs/src/lib.rs
+++ b/code/packages/rust/storage-fs/src/lib.rs
@@ -636,6 +636,7 @@ fn revision_to_u64(r: &Revision) -> Option<u64> {
 mod tests {
     use super::*;
     use std::env;
+    use storage_core::conformance;
 
     fn temp_root() -> PathBuf {
         let mut p = env::temp_dir();
@@ -656,6 +657,46 @@ mod tests {
             body: body.to_vec(),
             if_revision: None,
         }
+    }
+
+    fn with_backend<T>(test: impl FnOnce(&FsStorageBackend) -> T) -> T {
+        let root = temp_root();
+        let be = FsStorageBackend::new(&root);
+        let output = test(&be);
+        let _ = fs::remove_dir_all(&root);
+        output
+    }
+
+    // --- Shared storage-core conformance ---
+
+    #[test]
+    fn conformance_initialize_twice_is_safe() {
+        with_backend(|be| conformance::initialize_twice_is_safe(be).unwrap());
+    }
+
+    #[test]
+    fn conformance_put_then_get_round_trips() {
+        with_backend(|be| conformance::put_then_get_round_trips(be).unwrap());
+    }
+
+    #[test]
+    fn conformance_stale_revision_is_rejected() {
+        with_backend(|be| conformance::stale_revision_is_rejected(be).unwrap());
+    }
+
+    #[test]
+    fn conformance_delete_is_idempotent() {
+        with_backend(|be| conformance::delete_is_idempotent(be).unwrap());
+    }
+
+    #[test]
+    fn conformance_prefix_listing_is_stable() {
+        with_backend(|be| conformance::prefix_listing_is_stable(be).unwrap());
+    }
+
+    #[test]
+    fn conformance_advisory_lease_expires() {
+        with_backend(|be| conformance::advisory_lease_expires(be).unwrap());
     }
 
     // --- Round-trip ---


### PR DESCRIPTION
## Summary

- run the shared `storage-core` backend conformance suite against `FsStorageBackend`
- cover initialize idempotence, put/get round trips, stale CAS rejection, idempotent delete, stable prefix listing, and lease expiry
- document the conformance coverage in storage-fs README/changelog

## Tests

- `cargo test --manifest-path code/packages/rust/Cargo.toml -p coding_adventures_storage_fs`
