### PR TITLE
[codex] Expose Board VM target registry to language bridges

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -141,6 +141,67 @@ class BoardDescriptor:
 
 
 @dataclass(frozen=True)
+class BoardTarget:
+    raw: dict[str, Any]
+
+    @property
+    def board_id(self) -> str:
+        return str(self.raw["board_id"])
+
+    @property
+    def display_name(self) -> str:
+        return str(self.raw["display_name"])
+
+    @property
+    def family(self) -> str:
+        return str(self.raw["family"])
+
+    @property
+    def runtime_id(self) -> str:
+        return str(self.raw["runtime_id"])
+
+    @property
+    def mcu(self) -> str:
+        return str(self.raw["mcu"])
+
+    @property
+    def core(self) -> str:
+        return str(self.raw["core"])
+
+    @property
+    def rust_target(self) -> str:
+        return str(self.raw["rust_target"])
+
+    @property
+    def clock_hz(self) -> int:
+        return int(self.raw["clock_hz"])
+
+    @property
+    def operating_voltage_mv(self) -> int:
+        return int(self.raw["operating_voltage_mv"])
+
+    @property
+    def onboard_led(self) -> dict[str, Any] | None:
+        led = self.raw.get("onboard_led")
+        return None if led is None else dict(led)
+
+    @property
+    def onboard_led_pin(self) -> int | None:
+        led = self.onboard_led
+        if led is None:
+            return None
+        return int(led["pin"])
+
+    @property
+    def digital_pin_count(self) -> int:
+        return int(self.raw["digital_pin_count"])
+
+    @property
+    def capabilities(self) -> list[str]:
+        return [str(capability) for capability in self.raw.get("capabilities", [])]
+
+
+@dataclass(frozen=True)
 class ProtocolResult:
     command: str
     frame: bytes
@@ -981,8 +1042,20 @@ class Session:
         raise ValueError(f"unsupported GPIO write value: {value!r}")
 
 
+def known_targets() -> list[BoardTarget]:
+    return [BoardTarget(raw) for raw in _native.known_targets()]
+
+
+def find_target(board_id: str) -> BoardTarget | None:
+    for target in known_targets():
+        if target.board_id == board_id:
+            return target
+    return None
+
+
 __all__ = [
     "BoardDescriptor",
+    "BoardTarget",
     "BOOT_POLICIES",
     "Capability",
     "DEFAULT_RUN_FLAGS",
@@ -995,4 +1068,6 @@ __all__ = [
     "RUN_FLAGS",
     "Session",
     "SessionResult",
+    "find_target",
+    "known_targets",
 ]

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -9,16 +9,17 @@ use board_vm_host::{
     GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
-    build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
-    build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
-    build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
-    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
-    build_raw_module, build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
-    build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
-    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
-    capability_protocol_feature, decode_wire_response, program_format_name, raw_module_len,
+    board_family_name, build_blink_module, build_caps_query_wire_frame,
+    build_gpio_handle_close_module, build_gpio_handle_read_module, build_gpio_handle_write_module,
+    build_gpio_open_module, build_gpio_read_module, build_gpio_write_module,
+    build_hello_wire_frame, build_program_begin_wire_frame, build_program_chunk_wire_frame,
+    build_program_end_wire_frame, build_raw_module, build_run_background_wire_frame,
+    build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
+    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
+    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
+    decode_wire_response, known_targets, onboard_led_kind, program_format_name, raw_module_len,
     run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageCoreError, LanguageValue,
+    LanguageCoreError, LanguageOnboardLed, LanguageTargetInfo, LanguageValue,
 };
 use python_bridge::*;
 
@@ -440,6 +441,10 @@ unsafe extern "C" fn py_decode_response(_module: PyObjectPtr, args: PyObjectPtr)
     decoded_response_to_py(&decoded)
 }
 
+unsafe extern "C" fn py_known_targets(_module: PyObjectPtr, _args: PyObjectPtr) -> PyObjectPtr {
+    language_targets_to_py(&known_targets())
+}
+
 fn with_session(
     next_request_id: u16,
     operation: impl FnOnce(&mut BoardVmLanguageSession) -> Result<PyObjectPtr, LanguageCoreError>,
@@ -639,6 +644,60 @@ unsafe fn capability_flag_names_to_py(flags: u16) -> PyObjectPtr {
         PyList_SetItem(list, index as isize, str_to_py(name));
     }
     list
+}
+
+unsafe fn language_targets_to_py(targets: &[LanguageTargetInfo]) -> PyObjectPtr {
+    let list = PyList_New(targets.len() as isize);
+    for (index, target) in targets.iter().enumerate() {
+        PyList_SetItem(list, index as isize, language_target_to_py(target));
+    }
+    list
+}
+
+unsafe fn language_target_to_py(target: &LanguageTargetInfo) -> PyObjectPtr {
+    let dict = PyDict_New();
+    dict_set(dict, "board_id", str_to_py(&target.board_id));
+    dict_set(dict, "display_name", str_to_py(&target.display_name));
+    dict_set(dict, "family", str_to_py(board_family_name(target.family)));
+    dict_set(dict, "runtime_id", str_to_py(&target.runtime_id));
+    dict_set(dict, "mcu", str_to_py(&target.mcu));
+    dict_set(dict, "core", str_to_py(&target.core));
+    dict_set(dict, "rust_target", str_to_py(&target.rust_target));
+    dict_set(dict, "clock_hz", usize_to_py(target.clock_hz as usize));
+    dict_set(
+        dict,
+        "operating_voltage_mv",
+        usize_to_py(target.operating_voltage_mv as usize),
+    );
+    dict_set(
+        dict,
+        "onboard_led",
+        language_onboard_led_to_py(target.onboard_led),
+    );
+    dict_set(
+        dict,
+        "digital_pin_count",
+        usize_to_py(target.digital_pin_count),
+    );
+    let capabilities = PyList_New(target.capabilities.len() as isize);
+    for (index, capability) in target.capabilities.iter().enumerate() {
+        PyList_SetItem(capabilities, index as isize, str_to_py(capability));
+    }
+    dict_set(dict, "capabilities", capabilities);
+    dict
+}
+
+unsafe fn language_onboard_led_to_py(led: Option<LanguageOnboardLed>) -> PyObjectPtr {
+    let Some(led) = led else {
+        return py_none();
+    };
+    let dict = PyDict_New();
+    dict_set(dict, "kind", str_to_py(onboard_led_kind(led)));
+    let pin = match led {
+        LanguageOnboardLed::Gpio(pin) | LanguageOnboardLed::WirelessChipGpio(pin) => pin,
+    };
+    dict_set(dict, "pin", usize_to_py(pin as usize));
+    dict
 }
 
 unsafe fn language_values_to_py(values: &[LanguageValue]) -> PyObjectPtr {
@@ -903,7 +962,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 21] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 22] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1034,6 +1093,12 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_decode_response),
             ml_flags: METH_VARARGS,
             ml_doc: b"Decode a Board VM wire response in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"known_targets\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_known_targets),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Return known Board VM targets from Rust.\0".as_ptr() as *const c_char,
         },
         method_def_sentinel(),
     ]));

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -1,4 +1,4 @@
-from board_vm_native import BoardDescriptor, ProtocolResult, Session
+from board_vm_native import BoardDescriptor, BoardTarget, ProtocolResult, Session, find_target, known_targets
 
 
 class FakeWriteTransport:
@@ -66,6 +66,21 @@ def test_native_session_builds_protocol_bytes_in_rust():
     assert isinstance(stop.frame, bytes)
     assert len(stop.frame) > 0
     assert session.next_request_id == 4
+
+
+def test_known_targets_are_exposed_from_rust_registry():
+    targets = known_targets()
+    esp32 = find_target("esp32-devkit-v1")
+    pico_w = find_target("raspberry-pi-pico-w")
+
+    assert all(isinstance(target, BoardTarget) for target in targets)
+    assert esp32 is not None
+    assert esp32.family == "esp32"
+    assert esp32.runtime_id == "board-vm-esp32"
+    assert esp32.onboard_led_pin == 2
+    assert "gpio.open" in esp32.capabilities
+    assert pico_w is not None
+    assert pico_w.onboard_led == {"kind": "wireless_chip_gpio", "pin": 0}
 
 
 def test_session_dispatches_frames_through_write_transport():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -10,16 +10,17 @@ use board_vm_host::{
     GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
-    build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
-    build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
-    build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
-    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
-    build_raw_module, build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
-    build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
-    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
-    capability_protocol_feature, decode_wire_response, program_format_name, raw_module_len,
+    board_family_name, build_blink_module, build_caps_query_wire_frame,
+    build_gpio_handle_close_module, build_gpio_handle_read_module, build_gpio_handle_write_module,
+    build_gpio_open_module, build_gpio_read_module, build_gpio_write_module,
+    build_hello_wire_frame, build_program_begin_wire_frame, build_program_chunk_wire_frame,
+    build_program_end_wire_frame, build_raw_module, build_run_background_wire_frame,
+    build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
+    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
+    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
+    decode_wire_response, known_targets, onboard_led_kind, program_format_name, raw_module_len,
     run_status_name, BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageCoreError, LanguageValue,
+    LanguageCoreError, LanguageOnboardLed, LanguageTargetInfo, LanguageValue,
 };
 use ruby_bridge::VALUE;
 
@@ -398,6 +399,10 @@ extern "C" fn session_decode_response(_self_val: VALUE, wire_val: VALUE) -> VALU
     decoded_response_to_rb(&decoded)
 }
 
+extern "C" fn native_known_targets(_self_val: VALUE) -> VALUE {
+    language_targets_to_rb(&known_targets())
+}
+
 fn with_session_mut(
     self_val: VALUE,
     operation: impl FnOnce(&mut RubyBoardVmSession) -> Result<VALUE, LanguageCoreError>,
@@ -567,6 +572,76 @@ fn capability_flag_names_to_rb(flags: u16) -> VALUE {
         ruby_bridge::array_push(array, ruby_bridge::str_to_rb(name));
     }
     array
+}
+
+fn language_targets_to_rb(targets: &[LanguageTargetInfo]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for target in targets {
+        ruby_bridge::array_push(array, language_target_to_rb(target));
+    }
+    array
+}
+
+fn language_target_to_rb(target: &LanguageTargetInfo) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "board_id", ruby_bridge::str_to_rb(&target.board_id));
+    hash_set(
+        hash,
+        "display_name",
+        ruby_bridge::str_to_rb(&target.display_name),
+    );
+    hash_set(
+        hash,
+        "family",
+        ruby_bridge::str_to_rb(board_family_name(target.family)),
+    );
+    hash_set(
+        hash,
+        "runtime_id",
+        ruby_bridge::str_to_rb(&target.runtime_id),
+    );
+    hash_set(hash, "mcu", ruby_bridge::str_to_rb(&target.mcu));
+    hash_set(hash, "core", ruby_bridge::str_to_rb(&target.core));
+    hash_set(
+        hash,
+        "rust_target",
+        ruby_bridge::str_to_rb(&target.rust_target),
+    );
+    hash_set(hash, "clock_hz", rb_usize(target.clock_hz));
+    hash_set(
+        hash,
+        "operating_voltage_mv",
+        rb_usize(target.operating_voltage_mv),
+    );
+    hash_set(
+        hash,
+        "onboard_led",
+        language_onboard_led_to_rb(target.onboard_led),
+    );
+    hash_set(
+        hash,
+        "digital_pin_count",
+        rb_usize(target.digital_pin_count),
+    );
+    let capabilities = ruby_bridge::array_new();
+    for capability in &target.capabilities {
+        ruby_bridge::array_push(capabilities, ruby_bridge::str_to_rb(capability));
+    }
+    hash_set(hash, "capabilities", capabilities);
+    hash
+}
+
+fn language_onboard_led_to_rb(led: Option<LanguageOnboardLed>) -> VALUE {
+    let Some(led) = led else {
+        return ruby_bridge::QNIL;
+    };
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "kind", ruby_bridge::str_to_rb(onboard_led_kind(led)));
+    let pin = match led {
+        LanguageOnboardLed::Gpio(pin) | LanguageOnboardLed::WirelessChipGpio(pin) => pin,
+    };
+    hash_set(hash, "pin", rb_usize(pin));
+    hash
 }
 
 fn language_values_to_rb(values: &[LanguageValue]) -> VALUE {
@@ -815,6 +890,13 @@ pub extern "C" fn Init_board_vm_native() {
     let native = ruby_bridge::define_module_under(board_vm, "Native");
     let session_class =
         ruby_bridge::define_class_under(native, "Session", ruby_bridge::object_class());
+
+    ruby_bridge::define_module_function_raw(
+        native,
+        "known_targets",
+        native_known_targets as *const c_void,
+        0,
+    );
 
     ruby_bridge::define_alloc_func(session_class, session_alloc);
     ruby_bridge::define_method_raw(

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -21,6 +21,14 @@ module CodingAdventures
 
     module_function
 
+    def known_targets
+      Native.known_targets
+    end
+
+    def find_target(board_id)
+      known_targets.find { |target| target["board_id"] == board_id.to_s }
+    end
+
     def connect(
       board: :uno_r4_wifi,
       port:,

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -23,6 +23,19 @@ module CodingAdventures
         assert_empty runner.calls
       end
 
+      def test_known_targets_are_exposed_from_rust_registry
+        targets = BoardVM.known_targets
+        esp32 = BoardVM.find_target("esp32-devkit-v1")
+        pico_w = BoardVM.find_target("raspberry-pi-pico-w")
+
+        assert targets.any? { |target| target["board_id"] == "arduino-uno-r4-wifi" }
+        assert_equal "esp32", esp32["family"]
+        assert_equal "board-vm-esp32", esp32["runtime_id"]
+        assert_equal({ "kind" => "gpio", "pin" => 2 }, esp32["onboard_led"])
+        assert_includes esp32["capabilities"], "gpio.open"
+        assert_equal({ "kind" => "wireless_chip_gpio", "pin" => 0 }, pico_w["onboard_led"])
+      end
+
       def test_connect_flash_uploads_the_uno_r4_serialusb_vm_and_tracks_runtime_port
         upload = CommandResult.new(
           ["cargo"],

--- a/code/packages/rust/board-vm-language-core/Cargo.toml
+++ b/code/packages/rust/board-vm-language-core/Cargo.toml
@@ -12,3 +12,4 @@ path = "src/lib.rs"
 [dependencies]
 board-vm-host = { path = "../board-vm-host" }
 board-vm-protocol = { path = "../board-vm-protocol" }
+board-vm-targets = { path = "../board-vm-targets" }

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -30,6 +30,7 @@ use board_vm_protocol::{
     RunStatus, Value as ProtocolValue, CAP_FLAG_BOARD_METADATA, CAP_FLAG_BYTECODE_CALLABLE,
     CAP_FLAG_PROTOCOL_FEATURE, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
 };
+use board_vm_targets::{all_targets, BoardFamily, OnboardLed as TargetOnboardLed};
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
 pub const LANGUAGE_CORE_VERSION_MINOR: u16 = 1;
@@ -234,6 +235,35 @@ pub struct LanguageBoardDescriptor {
     pub capabilities: Vec<LanguageCapability>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageBoardFamily {
+    ArduinoUnoR4,
+    Esp32,
+    RaspberryPiPico,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageOnboardLed {
+    Gpio(u8),
+    WirelessChipGpio(u8),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageTargetInfo {
+    pub board_id: String,
+    pub display_name: String,
+    pub family: LanguageBoardFamily,
+    pub runtime_id: String,
+    pub mcu: String,
+    pub core: String,
+    pub rust_target: String,
+    pub clock_hz: u32,
+    pub operating_voltage_mv: u16,
+    pub onboard_led: Option<LanguageOnboardLed>,
+    pub digital_pin_count: usize,
+    pub capabilities: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageProgramBegin {
     pub program_id: u16,
@@ -332,6 +362,21 @@ pub const fn capability_board_metadata(flags: u16) -> bool {
     flags & CAP_FLAG_BOARD_METADATA != 0
 }
 
+pub const fn board_family_name(family: LanguageBoardFamily) -> &'static str {
+    match family {
+        LanguageBoardFamily::ArduinoUnoR4 => "arduino_uno_r4",
+        LanguageBoardFamily::Esp32 => "esp32",
+        LanguageBoardFamily::RaspberryPiPico => "raspberry_pi_pico",
+    }
+}
+
+pub const fn onboard_led_kind(led: LanguageOnboardLed) -> &'static str {
+    match led {
+        LanguageOnboardLed::Gpio(_) => "gpio",
+        LanguageOnboardLed::WirelessChipGpio(_) => "wireless_chip_gpio",
+    }
+}
+
 pub fn capability_flag_names(flags: u16, out: &mut [&'static str]) -> usize {
     let mut count = 0;
     if capability_bytecode_callable(flags) {
@@ -344,6 +389,51 @@ pub fn capability_flag_names(flags: u16, out: &mut [&'static str]) -> usize {
         count = push_flag_name(out, count, "board_metadata");
     }
     count
+}
+
+pub fn known_targets() -> Vec<LanguageTargetInfo> {
+    all_targets()
+        .iter()
+        .map(|target| LanguageTargetInfo {
+            board_id: target.board_id.to_owned(),
+            display_name: target.display_name.to_owned(),
+            family: language_family(target.family),
+            runtime_id: target.runtime_id.to_owned(),
+            mcu: target.mcu.to_owned(),
+            core: target.core.to_owned(),
+            rust_target: target.rust_target.to_owned(),
+            clock_hz: target.clock_hz,
+            operating_voltage_mv: target.operating_voltage_mv,
+            onboard_led: target.onboard_led.map(language_onboard_led),
+            digital_pin_count: target.digital_pin_count,
+            capabilities: target
+                .capabilities
+                .iter()
+                .map(|capability| (*capability).to_owned())
+                .collect(),
+        })
+        .collect()
+}
+
+pub fn known_target(board_id: &str) -> Option<LanguageTargetInfo> {
+    known_targets()
+        .into_iter()
+        .find(|target| target.board_id == board_id)
+}
+
+fn language_family(family: BoardFamily) -> LanguageBoardFamily {
+    match family {
+        BoardFamily::ArduinoUnoR4 => LanguageBoardFamily::ArduinoUnoR4,
+        BoardFamily::Esp32 => LanguageBoardFamily::Esp32,
+        BoardFamily::RaspberryPiPico => LanguageBoardFamily::RaspberryPiPico,
+    }
+}
+
+fn language_onboard_led(led: TargetOnboardLed) -> LanguageOnboardLed {
+    match led {
+        TargetOnboardLed::Gpio(pin) => LanguageOnboardLed::Gpio(pin),
+        TargetOnboardLed::WirelessChipGpio(pin) => LanguageOnboardLed::WirelessChipGpio(pin),
+    }
 }
 
 fn push_flag_name(out: &mut [&'static str], count: usize, name: &'static str) -> usize {
@@ -1532,6 +1622,26 @@ mod tests {
         assert_eq!(written.len, GOLDEN_HELLO_WIRE_FRAME_BVM_V1.len());
         assert_eq!(&wire[..written.len], GOLDEN_HELLO_WIRE_FRAME_BVM_V1);
         assert_eq!(session.next_request_id(), 0x1235);
+    }
+
+    #[test]
+    fn known_targets_are_owned_by_rust_language_core() {
+        let targets = known_targets();
+        let esp32 = known_target("esp32-devkit-v1").unwrap();
+        let pico_w = known_target("raspberry-pi-pico-w").unwrap();
+
+        assert!(targets
+            .iter()
+            .any(|target| target.board_id == esp32.board_id));
+        assert_eq!(esp32.family, LanguageBoardFamily::Esp32);
+        assert_eq!(board_family_name(esp32.family), "esp32");
+        assert_eq!(esp32.runtime_id, "board-vm-esp32");
+        assert_eq!(esp32.onboard_led, Some(LanguageOnboardLed::Gpio(2)));
+        assert!(esp32.capabilities.contains(&"gpio.open".to_owned()));
+        assert_eq!(
+            pico_w.onboard_led,
+            Some(LanguageOnboardLed::WirelessChipGpio(0))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- expose the Rust-owned Board VM target registry through board-vm-language-core
- add Python BoardTarget sugar plus known_targets/find_target helpers over the native bridge
- add Ruby BoardVM.known_targets/find_target over the native bridge

## Validation

- cargo test --manifest-path code/packages/rust/board-vm-language-core/Cargo.toml
- cargo build --release --manifest-path code/packages/python/board-vm-native/Cargo.toml
- PYTHONPATH=code/packages/python/board-vm-native/src python3 -m pytest code/packages/python/board-vm-native/tests/ -v
- cargo build --release --manifest-path code/packages/ruby/board_vm/ext/board_vm_native/Cargo.toml
- ruby -Icode/packages/ruby/board_vm/lib -Icode/packages/ruby/board_vm/test code/packages/ruby/board_vm/test/test_board_vm.rb
- git diff --check

Stacked on #2371 so the language bridges consume the Rust target registry instead of duplicating target facts in Ruby or Python.
