### PR TITLE
[codex] Add Lua Board VM native protocol bridge

### DIFF
--- a/code/packages/lua/board_vm_native/BUILD
+++ b/code/packages/lua/board_vm_native/BUILD
@@ -1,0 +1,1 @@
+cargo build --release && cd tests && busted . --verbose --pattern=test_

--- a/code/packages/lua/board_vm_native/BUILD_windows
+++ b/code/packages/lua/board_vm_native/BUILD_windows
@@ -1,0 +1,1 @@
+echo Skipping lua/board_vm_native on Windows -- Lua native extension requires a Lua import library

--- a/code/packages/lua/board_vm_native/CHANGELOG.md
+++ b/code/packages/lua/board_vm_native/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add Rust-backed Lua native Board VM frame/module builders.
+- Add Lua `Session` sugar for HELLO, CAPS_QUERY, and blink upload/run frames.

--- a/code/packages/lua/board_vm_native/Cargo.toml
+++ b/code/packages/lua/board_vm_native/Cargo.toml
@@ -1,0 +1,17 @@
+[workspace]
+
+[package]
+name = "board-vm-native-lua"
+version = "0.1.0"
+edition = "2021"
+description = "Lua C extension exposing Board VM protocol builders from Rust"
+build = "build.rs"
+
+[lib]
+name = "board_vm_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+board-vm-host = { path = "../../rust/board-vm-host" }
+board-vm-language-core = { path = "../../rust/board-vm-language-core" }
+lua-bridge = { path = "../../rust/lua-bridge" }

--- a/code/packages/lua/board_vm_native/README.md
+++ b/code/packages/lua/board_vm_native/README.md
@@ -1,0 +1,19 @@
+# board_vm_native (Lua)
+
+Lua sugar over the Rust-owned Board VM protocol builders.
+
+The Lua module does not hand-roll framing or bytecode. It loads a Rust C
+extension backed by `board-vm-language-core`, then exposes a small `Session`
+object that tracks request ids while Rust builds the COBS-framed wire messages
+and BVM modules.
+
+```lua
+local board_vm = require("coding_adventures.board_vm_native")
+
+local session = board_vm.session()
+local frames = session:blink_upload_run_frames({
+    pin = 13,
+    high_ms = 250,
+    low_ms = 250,
+})
+```

--- a/code/packages/lua/board_vm_native/build.rs
+++ b/code/packages/lua/board_vm_native/build.rs
@@ -1,0 +1,44 @@
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    match target_os.as_str() {
+        "macos" => {
+            println!("cargo:rustc-cdylib-link-arg=-undefined");
+            println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        }
+        "windows" => {
+            if let Some(lua_lib_dir) = find_lua_lib_dir() {
+                println!("cargo:rustc-link-search=native={}", lua_lib_dir);
+            }
+            for name in &["lua5.4", "lua54", "lua-5.4"] {
+                println!("cargo:rustc-link-lib={}", name);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn find_lua_lib_dir() -> Option<String> {
+    let lua_exe = find_exe("lua")?;
+    let parent = std::path::Path::new(&lua_exe).parent()?;
+    Some(parent.to_string_lossy().to_string())
+}
+
+fn find_exe(name: &str) -> Option<String> {
+    let output = std::process::Command::new("where")
+        .arg(name)
+        .output()
+        .ok()?;
+    if output.status.success() {
+        let path = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if !path.is_empty() {
+            return Some(path);
+        }
+    }
+    None
+}

--- a/code/packages/lua/board_vm_native/required_capabilities.json
+++ b/code/packages/lua/board_vm_native/required_capabilities.json
@@ -1,0 +1,6 @@
+{
+  "capabilities": [
+    "lua",
+    "rust"
+  ]
+}

--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -1,0 +1,153 @@
+local M = {}
+
+local function dirname(path)
+    return path:match("^(.*)[/\\][^/\\]+$")
+end
+
+local native_module = false
+
+local function load_native()
+    if native_module ~= false then
+        return native_module
+    end
+
+    local ok, module = pcall(require, "board_vm_native")
+    if ok then
+        native_module = module
+        return native_module
+    end
+
+    local source = debug.getinfo(1, "S").source
+    local file = source:sub(1, 1) == "@" and source:sub(2) or source
+    local base = dirname(file) .. "/../../../target/release/"
+    local candidates = {
+        base .. "libboard_vm_native.dylib",
+        base .. "libboard_vm_native.so",
+        base .. "board_vm_native.dll",
+    }
+
+    for _, path in ipairs(candidates) do
+        local loader = package.loadlib(path, "luaopen_board_vm_native")
+        if loader then
+            native_module = loader()
+            return native_module
+        end
+    end
+
+    native_module = nil
+    return native_module
+end
+
+local function native()
+    local module = load_native()
+    if module == nil then
+        error("board_vm_native extension is not available")
+    end
+    return module
+end
+
+function M.available()
+    return load_native() ~= nil
+end
+
+function M.defaults()
+    return native().defaults()
+end
+
+local Session = {}
+Session.__index = Session
+
+function Session.new(options)
+    options = options or {}
+    return setmetatable({
+        next_request_id = options.next_request_id or 1,
+        program_id = options.program_id or M.defaults().program_id,
+        run_flags = options.run_flags or M.defaults().run_flags,
+        instruction_budget = options.instruction_budget or M.defaults().instruction_budget,
+        time_budget_ms = options.time_budget_ms or 0,
+    }, Session)
+end
+
+function Session:_frame(result)
+    self.next_request_id = result.next_request_id
+    return result.frame
+end
+
+function Session:hello_wire(host_name, host_nonce)
+    return self:_frame(native().hello_wire(
+        self.next_request_id,
+        host_name or "bvm-lua",
+        host_nonce or 0x1234abcd
+    ))
+end
+
+function Session:caps_query_wire()
+    return self:_frame(native().caps_query_wire(self.next_request_id))
+end
+
+function Session:blink_module(options)
+    options = options or {}
+    return native().blink_module(
+        options.pin or 13,
+        options.high_ms or 250,
+        options.low_ms or 250,
+        options.max_stack or 4
+    )
+end
+
+function Session:program_begin_wire(program_id, module_bytes)
+    return self:_frame(native().program_begin_wire(
+        self.next_request_id,
+        program_id,
+        module_bytes
+    ))
+end
+
+function Session:program_chunk_wire(program_id, offset, chunk)
+    return self:_frame(native().program_chunk_wire(
+        self.next_request_id,
+        program_id,
+        offset,
+        chunk
+    ))
+end
+
+function Session:program_end_wire(program_id)
+    return self:_frame(native().program_end_wire(self.next_request_id, program_id))
+end
+
+function Session:run_wire(options)
+    options = options or {}
+    return self:_frame(native().run_wire(
+        self.next_request_id,
+        options.program_id or self.program_id,
+        options.flags or self.run_flags,
+        options.instruction_budget or self.instruction_budget,
+        options.time_budget_ms or self.time_budget_ms
+    ))
+end
+
+function Session:blink_upload_run_frames(options)
+    options = options or {}
+    local program_id = options.program_id or self.program_id
+    local module_bytes = self:blink_module(options)
+    return {
+        self:program_begin_wire(program_id, module_bytes),
+        self:program_chunk_wire(program_id, 0, module_bytes),
+        self:program_end_wire(program_id),
+        self:run_wire({
+            program_id = program_id,
+            flags = options.flags or self.run_flags,
+            instruction_budget = options.instruction_budget or self.instruction_budget,
+            time_budget_ms = options.time_budget_ms or self.time_budget_ms,
+        }),
+    }
+end
+
+M.Session = Session
+
+function M.session(options)
+    return Session.new(options)
+end
+
+return M

--- a/code/packages/lua/board_vm_native/src/lib.rs
+++ b/code/packages/lua/board_vm_native/src/lib.rs
@@ -1,0 +1,250 @@
+#![allow(non_snake_case)]
+
+use std::ffi::{c_char, c_int, CString};
+use std::ptr;
+
+use board_vm_host::{
+    BlinkProgram, BLINK_MODULE_LEN, DEFAULT_INSTRUCTION_BUDGET, DEFAULT_PROGRAM_ID,
+    DEFAULT_RUN_FLAGS,
+};
+use board_vm_language_core::{
+    build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
+    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
+    build_run_wire_frame, BoardVmLanguageSession, BuiltWireFrame, LanguageCoreError,
+};
+use lua_bridge::{
+    get_str, luaL_Reg, luaL_checkinteger, lua_Integer, lua_State, lua_gettop, lua_pushinteger,
+    lua_pushlstring, lua_setfield, lua_tolstring, raise_error, register_lib,
+};
+
+unsafe fn check_u8(L: *mut lua_State, index: c_int, name: &str) -> u8 {
+    let value = luaL_checkinteger(L, index);
+    if !(0..=u8::MAX as lua_Integer).contains(&value) {
+        raise_error(L, &format!("{name} must fit in u8"));
+    }
+    value as u8
+}
+
+unsafe fn check_u16(L: *mut lua_State, index: c_int, name: &str) -> u16 {
+    let value = luaL_checkinteger(L, index);
+    if !(0..=u16::MAX as lua_Integer).contains(&value) {
+        raise_error(L, &format!("{name} must fit in u16"));
+    }
+    value as u16
+}
+
+unsafe fn check_u32(L: *mut lua_State, index: c_int, name: &str) -> u32 {
+    let value = luaL_checkinteger(L, index);
+    if !(0..=u32::MAX as lua_Integer).contains(&value) {
+        raise_error(L, &format!("{name} must fit in u32"));
+    }
+    value as u32
+}
+
+unsafe fn check_bytes(L: *mut lua_State, index: c_int, name: &str) -> Vec<u8> {
+    let mut len = 0usize;
+    let ptr = lua_tolstring(L, index, &mut len);
+    if ptr.is_null() {
+        raise_error(L, &format!("{name} must be a string"));
+    }
+    std::slice::from_raw_parts(ptr as *const u8, len).to_vec()
+}
+
+unsafe fn push_bytes(L: *mut lua_State, bytes: &[u8]) {
+    lua_pushlstring(L, bytes.as_ptr() as *const c_char, bytes.len());
+}
+
+unsafe fn set_int(L: *mut lua_State, key: &str, value: u64) {
+    let key = CString::new(key).unwrap();
+    lua_pushinteger(L, value as lua_Integer);
+    lua_setfield(L, -2, key.as_ptr());
+}
+
+unsafe fn set_bytes(L: *mut lua_State, key: &str, value: &[u8]) {
+    let key = CString::new(key).unwrap();
+    push_bytes(L, value);
+    lua_setfield(L, -2, key.as_ptr());
+}
+
+fn core_result<T>(L: *mut lua_State, result: Result<T, LanguageCoreError>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => unsafe {
+            raise_error(L, &format!("Board VM language core error: {error:?}"))
+        },
+    }
+}
+
+unsafe fn push_wire_result(
+    L: *mut lua_State,
+    session: &BoardVmLanguageSession,
+    built: BuiltWireFrame,
+    wire: &[u8],
+) -> c_int {
+    lua_bridge::lua_newtable(L);
+    set_bytes(L, "frame", &wire[..built.len]);
+    set_int(L, "request_id", built.request_id as u64);
+    set_int(L, "next_request_id", session.next_request_id() as u64);
+    1
+}
+
+unsafe extern "C" fn lua_hello_wire(L: *mut lua_State) -> c_int {
+    let next_request_id = check_u16(L, 1, "next_request_id");
+    let host_name = get_str(L, 2).unwrap_or_else(|| raise_error(L, "host_name must be a string"));
+    let host_nonce = check_u32(L, 3, "host_nonce");
+    let mut session = BoardVmLanguageSession::with_next_request_id(next_request_id);
+    let mut wire = vec![0; host_name.len().saturating_add(96)];
+    let built = core_result(
+        L,
+        build_hello_wire_frame(&mut session, &host_name, host_nonce, &mut wire),
+    );
+    push_wire_result(L, &session, built, &wire)
+}
+
+unsafe extern "C" fn lua_caps_query_wire(L: *mut lua_State) -> c_int {
+    let next_request_id = check_u16(L, 1, "next_request_id");
+    let mut session = BoardVmLanguageSession::with_next_request_id(next_request_id);
+    let mut wire = [0u8; 64];
+    let built = core_result(L, build_caps_query_wire_frame(&mut session, &mut wire));
+    push_wire_result(L, &session, built, &wire)
+}
+
+unsafe extern "C" fn lua_blink_module(L: *mut lua_State) -> c_int {
+    let pin = check_u8(L, 1, "pin");
+    let high_ms = check_u16(L, 2, "high_ms");
+    let low_ms = check_u16(L, 3, "low_ms");
+    let max_stack = check_u8(L, 4, "max_stack");
+    let mut module = vec![0; BLINK_MODULE_LEN];
+    let len = core_result(
+        L,
+        build_blink_module(
+            BlinkProgram {
+                pin,
+                high_ms,
+                low_ms,
+                max_stack,
+            },
+            &mut module,
+        ),
+    );
+    push_bytes(L, &module[..len]);
+    1
+}
+
+unsafe extern "C" fn lua_program_begin_wire(L: *mut lua_State) -> c_int {
+    let next_request_id = check_u16(L, 1, "next_request_id");
+    let program_id = check_u16(L, 2, "program_id");
+    let module = check_bytes(L, 3, "module");
+    let mut session = BoardVmLanguageSession::with_next_request_id(next_request_id);
+    let mut wire = [0u8; 96];
+    let built = core_result(
+        L,
+        build_program_begin_wire_frame(&mut session, program_id, &module, &mut wire),
+    );
+    push_wire_result(L, &session, built, &wire)
+}
+
+unsafe extern "C" fn lua_program_chunk_wire(L: *mut lua_State) -> c_int {
+    let next_request_id = check_u16(L, 1, "next_request_id");
+    let program_id = check_u16(L, 2, "program_id");
+    let offset = check_u32(L, 3, "offset");
+    let chunk = check_bytes(L, 4, "chunk");
+    let mut session = BoardVmLanguageSession::with_next_request_id(next_request_id);
+    let mut wire = vec![0; chunk.len().saturating_add(96)];
+    let built = core_result(
+        L,
+        build_program_chunk_wire_frame(&mut session, program_id, offset, &chunk, &mut wire),
+    );
+    push_wire_result(L, &session, built, &wire)
+}
+
+unsafe extern "C" fn lua_program_end_wire(L: *mut lua_State) -> c_int {
+    let next_request_id = check_u16(L, 1, "next_request_id");
+    let program_id = check_u16(L, 2, "program_id");
+    let mut session = BoardVmLanguageSession::with_next_request_id(next_request_id);
+    let mut wire = [0u8; 64];
+    let built = core_result(
+        L,
+        build_program_end_wire_frame(&mut session, program_id, &mut wire),
+    );
+    push_wire_result(L, &session, built, &wire)
+}
+
+unsafe extern "C" fn lua_run_wire(L: *mut lua_State) -> c_int {
+    let next_request_id = check_u16(L, 1, "next_request_id");
+    let program_id = check_u16(L, 2, "program_id");
+    let flags = check_u8(L, 3, "flags");
+    let instruction_budget = check_u32(L, 4, "instruction_budget");
+    let time_budget_ms = check_u32(L, 5, "time_budget_ms");
+    let mut session = BoardVmLanguageSession::with_next_request_id(next_request_id);
+    let mut wire = [0u8; 96];
+    let built = core_result(
+        L,
+        build_run_wire_frame(
+            &mut session,
+            program_id,
+            flags,
+            instruction_budget,
+            time_budget_ms,
+            &mut wire,
+        ),
+    );
+    push_wire_result(L, &session, built, &wire)
+}
+
+unsafe extern "C" fn lua_defaults(L: *mut lua_State) -> c_int {
+    let _ = lua_gettop(L);
+    lua_bridge::lua_newtable(L);
+    set_int(L, "program_id", DEFAULT_PROGRAM_ID as u64);
+    set_int(L, "run_flags", DEFAULT_RUN_FLAGS as u64);
+    set_int(L, "instruction_budget", DEFAULT_INSTRUCTION_BUDGET as u64);
+    1
+}
+
+struct FuncTable([luaL_Reg; 9]);
+unsafe impl Sync for FuncTable {}
+
+static FUNCS: FuncTable = FuncTable([
+    luaL_Reg {
+        name: b"hello_wire\0".as_ptr() as *const _,
+        func: Some(lua_hello_wire),
+    },
+    luaL_Reg {
+        name: b"caps_query_wire\0".as_ptr() as *const _,
+        func: Some(lua_caps_query_wire),
+    },
+    luaL_Reg {
+        name: b"blink_module\0".as_ptr() as *const _,
+        func: Some(lua_blink_module),
+    },
+    luaL_Reg {
+        name: b"program_begin_wire\0".as_ptr() as *const _,
+        func: Some(lua_program_begin_wire),
+    },
+    luaL_Reg {
+        name: b"program_chunk_wire\0".as_ptr() as *const _,
+        func: Some(lua_program_chunk_wire),
+    },
+    luaL_Reg {
+        name: b"program_end_wire\0".as_ptr() as *const _,
+        func: Some(lua_program_end_wire),
+    },
+    luaL_Reg {
+        name: b"run_wire\0".as_ptr() as *const _,
+        func: Some(lua_run_wire),
+    },
+    luaL_Reg {
+        name: b"defaults\0".as_ptr() as *const _,
+        func: Some(lua_defaults),
+    },
+    luaL_Reg {
+        name: ptr::null(),
+        func: None,
+    },
+]);
+
+#[no_mangle]
+pub unsafe extern "C" fn luaopen_board_vm_native(L: *mut lua_State) -> c_int {
+    register_lib(L, &FUNCS.0);
+    1
+}

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -1,0 +1,41 @@
+package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+
+local board_vm = require("coding_adventures.board_vm_native")
+
+describe("coding_adventures.board_vm_native", function()
+    it("loads the Rust native extension", function()
+        assert.is_true(board_vm.available())
+    end)
+
+    it("builds blink upload/run frames through Rust-owned protocol builders", function()
+        local session = board_vm.session({ next_request_id = 7, program_id = 9 })
+        local frames = session:blink_upload_run_frames({
+            pin = 13,
+            high_ms = 125,
+            low_ms = 250,
+            max_stack = 4,
+            instruction_budget = 777,
+            time_budget_ms = 50,
+        })
+
+        assert.are.equal(4, #frames)
+        assert.are.equal(11, session.next_request_id)
+        for _, frame in ipairs(frames) do
+            assert.is_string(frame)
+            assert.is_true(#frame > 0)
+            assert.are.equal(0, frame:byte(#frame))
+        end
+    end)
+
+    it("builds HELLO and CAPS_QUERY frames with session request ids", function()
+        local session = board_vm.session({ next_request_id = 3 })
+        local hello = session:hello_wire("lua-host", 0x1234)
+        local caps = session:caps_query_wire()
+
+        assert.is_string(hello)
+        assert.is_string(caps)
+        assert.are.equal(5, session.next_request_id)
+        assert.are.equal(0, hello:byte(#hello))
+        assert.are.equal(0, caps:byte(#caps))
+    end)
+end)


### PR DESCRIPTION
## Summary

- add a Lua native extension backed by board-vm-language-core for Board VM wire-frame and blink module builders
- add Lua Session sugar that only tracks request ids while Rust owns framing and BVM module construction
- cover HELLO, CAPS_QUERY, blink upload frames, and RUN frame generation with Lua tests

## Validation

- cargo build --release
- cd tests && busted . --verbose --pattern=test_
- git diff --check

This starts the Lua lane independently of the Ruby/Python target-registry stack and keeps Lua as syntax sugar over Rust-owned Board VM protocol bytes.
