### PR TITLE
[codex] Add smart-home integration primitive catalog

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -531,6 +531,7 @@ members = [
     "conduit",
     "smart-home-core",
     "smart-home-discovery",
+    "smart-home-integration-catalog",
     "hue-core",
     "zigbee-nwk",
     "zwave-core",

--- a/code/packages/rust/smart-home-integration-catalog/BUILD
+++ b/code/packages/rust/smart-home-integration-catalog/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-integration-catalog -- --nocapture

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-05-08
+
+### Added
+
+- Integration catalog enums for category, connectivity class, discovery,
+  authentication, and implementation status.
+- Primitive-family metadata for discovery, transport, auth/pairing, command
+  mapping, capability policy, Vault leases, supervision, camera/media,
+  telemetry, and test simulators.
+- First-party seed catalog entries for Hue, Zigbee, Z-Wave, Thread, MQTT,
+  Matter, HomeKit Controller, ESPHome, Tasmota, Shelly, TP-Link/Tapo, WLED,
+  LIFX, cameras/media, energy/climate, and cloud hubs.
+- Virtual alias entries for product lines supported by another integration or
+  standard.
+- Query helpers for integration id, category, connectivity, capability,
+  primitive family, implementation status, and rollout priority.

--- a/code/packages/rust/smart-home-integration-catalog/Cargo.toml
+++ b/code/packages/rust/smart-home-integration-catalog/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "smart-home-integration-catalog"
+version = "0.1.0"
+edition = "2021"
+description = "First-party smart-home integration catalog model and seed entries"
+license = "MIT"
+
+[dependencies]
+smart-home-core = { path = "../smart-home-core" }

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -1,0 +1,32 @@
+# smart-home-integration-catalog
+
+First-party smart-home integration and primitive catalog model with seed
+entries.
+
+This crate is the executable companion to D23A. It has no network, filesystem,
+Vault, radio, serial, or worker-management behavior. It gives the smart-home
+runtime and Chief of Staff tools a typed catalog for:
+
+- Home Assistant-style connectivity classes
+- integration categories
+- implementation status
+- discovery and auth metadata
+- required primitive-family hints
+- required capability hints
+- target entity kind hints
+- first-party rollout seed entries
+- virtual product aliases that point to real implementations or standards
+
+Hue is treated as the trial run for the primitive shape: local discovery,
+physical pairing, local token storage, local HTTP reads, event-stream updates,
+normalized entity projection, command mapping, health, audit, and tests.
+
+## Dependencies
+
+- `smart-home-core`
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1,0 +1,1391 @@
+//! First-party smart-home integration catalog model and seed entries.
+//!
+//! The catalog is intentionally pure data. It lets D23 runtime packages and
+//! D18D tools answer "what can this system support?" without starting workers,
+//! opening sockets, reading secrets, or probing the local network.
+
+#![forbid(unsafe_code)]
+
+use smart_home_core::{CapabilityId, EntityKind, IntegrationId, ProtocolFamily, RuntimeKind};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationCategory {
+    ProtocolStandard,
+    LocalHub,
+    LocalDevice,
+    BluetoothProfile,
+    CloudHub,
+    CameraMedia,
+    EnergyClimate,
+    NotificationChannel,
+    DataService,
+    HelperCalculated,
+    VirtualAlias,
+    SystemHardware,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ConnectivityClass {
+    LocalPush,
+    LocalPolling,
+    CloudPush,
+    CloudPolling,
+    Calculated,
+    AssumedState,
+}
+
+impl ConnectivityClass {
+    pub fn as_home_assistant_iot_class(self) -> &'static str {
+        match self {
+            Self::LocalPush => "local_push",
+            Self::LocalPolling => "local_polling",
+            Self::CloudPush => "cloud_push",
+            Self::CloudPolling => "cloud_polling",
+            Self::Calculated => "calculated",
+            Self::AssumedState => "assumed_state",
+        }
+    }
+
+    pub fn is_local(self) -> bool {
+        matches!(self, Self::LocalPush | Self::LocalPolling)
+    }
+
+    pub fn requires_cloud(self) -> bool {
+        matches!(self, Self::CloudPush | Self::CloudPolling)
+    }
+
+    pub fn is_push(self) -> bool {
+        matches!(self, Self::LocalPush | Self::CloudPush)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DiscoveryMechanism {
+    Mdns,
+    Ssdp,
+    Bluetooth,
+    Usb,
+    Dhcp,
+    Mqtt,
+    Manual,
+    CloudAccount,
+    Webhook,
+    FileConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AuthMode {
+    None,
+    LocalPairing,
+    LocalToken,
+    UsernamePassword,
+    OAuth2,
+    ApiKey,
+    Certificate,
+    RadioNetworkKey,
+    MqttCredentials,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ImplementationStatus {
+    Cataloged,
+    Specified,
+    Scaffolded,
+    Simulated,
+    FirstPartyRuntime,
+    ProductionReady,
+    DelegatedToStandard,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PrimitiveFamily {
+    NormalizedModel,
+    DiscoveryIndex,
+    Mdns,
+    Ssdp,
+    Dhcp,
+    LocalHttp,
+    WebSocket,
+    ServerSentEvents,
+    Mqtt,
+    BluetoothLowEnergy,
+    Usb,
+    SerialController,
+    Radio802154,
+    ZWaveSerialApi,
+    MatterCommissioning,
+    HomeKitPairing,
+    CloudApi,
+    Webhook,
+    OAuth2,
+    LocalPairing,
+    LocalToken,
+    CertificatePairing,
+    RadioNetworkKey,
+    MqttCredentials,
+    CameraMedia,
+    EnergyTelemetry,
+    CalculatedState,
+    CommandMapping,
+    CapabilityPolicy,
+    VaultLease,
+    Supervision,
+    TestSimulator,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceReference {
+    pub label: String,
+    pub url: String,
+    pub external_id: Option<String>,
+}
+
+impl SourceReference {
+    pub fn home_assistant(domain: &'static str) -> Self {
+        Self {
+            label: "Home Assistant".to_string(),
+            url: format!("https://www.home-assistant.io/integrations/{domain}/"),
+            external_id: Some(domain.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationCatalogEntry {
+    pub integration_id: IntegrationId,
+    pub display_name: String,
+    pub summary: String,
+    pub category: IntegrationCategory,
+    pub connectivity: ConnectivityClass,
+    pub runtime_kind: RuntimeKind,
+    pub implementation_status: ImplementationStatus,
+    pub priority: u8,
+    pub discovery_mechanisms: Vec<DiscoveryMechanism>,
+    pub auth_modes: Vec<AuthMode>,
+    pub required_capabilities: Vec<CapabilityId>,
+    pub target_entity_kinds: Vec<EntityKind>,
+    pub supported_protocols: Vec<ProtocolFamily>,
+    pub depends_on_integrations: Vec<IntegrationId>,
+    pub virtual_target: Option<IntegrationId>,
+    pub virtual_iot_standards: Vec<ProtocolFamily>,
+    pub required_primitives: Vec<PrimitiveFamily>,
+    pub source_refs: Vec<SourceReference>,
+    pub notes: Vec<String>,
+}
+
+impl IntegrationCatalogEntry {
+    pub fn is_virtual(&self) -> bool {
+        self.category == IntegrationCategory::VirtualAlias
+    }
+
+    pub fn is_local(&self) -> bool {
+        self.connectivity.is_local()
+    }
+
+    pub fn requires_cloud(&self) -> bool {
+        self.connectivity.requires_cloud()
+    }
+
+    pub fn supports_capability(&self, capability_id: &CapabilityId) -> bool {
+        self.required_capabilities
+            .iter()
+            .any(|candidate| candidate == capability_id)
+    }
+
+    pub fn uses_discovery(&self, mechanism: DiscoveryMechanism) -> bool {
+        self.discovery_mechanisms.contains(&mechanism)
+    }
+
+    pub fn requires_primitive(&self, primitive: PrimitiveFamily) -> bool {
+        self.required_primitives.contains(&primitive)
+    }
+}
+
+pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
+    vec![
+        hue_entry(),
+        protocol_entry(
+            "zigbee",
+            "Zigbee",
+            "Repository-owned Zigbee stack and coordinator integration.",
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::Scaffolded,
+            0,
+            ProtocolFamily::Zigbee,
+            &["smart_home.read", "smart_home.command.light", "smart_home.manage_network"],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor],
+            &[DiscoveryMechanism::Usb, DiscoveryMechanism::Manual],
+            &[AuthMode::RadioNetworkKey],
+            "zha",
+        ),
+        protocol_entry(
+            "zwave",
+            "Z-Wave",
+            "Repository-owned Z-Wave controller, serial API, and command-class integration.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Scaffolded,
+            0,
+            ProtocolFamily::ZWave,
+            &[
+                "smart_home.read",
+                "smart_home.command.light",
+                "smart_home.command.lock",
+                "smart_home.manage_network",
+            ],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor, EntityKind::Lock],
+            &[DiscoveryMechanism::Usb, DiscoveryMechanism::Manual],
+            &[AuthMode::RadioNetworkKey],
+            "zwave_js",
+        ),
+        protocol_entry(
+            "thread",
+            "Thread",
+            "Repository-owned Thread networking and diagnostics integration.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Scaffolded,
+            0,
+            ProtocolFamily::Thread,
+            &["smart_home.read", "smart_home.manage_network"],
+            &[EntityKind::NetworkDiagnostic],
+            &[DiscoveryMechanism::Usb, DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual],
+            &[AuthMode::RadioNetworkKey],
+            "thread",
+        ),
+        protocol_entry(
+            "mqtt",
+            "MQTT",
+            "MQTT broker integration for power-user devices, Tasmota, sensors, and bridge-style ecosystems.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Specified,
+            1,
+            ProtocolFamily::Mqtt,
+            &["smart_home.read", "smart_home.command.light", "smart_home.command.switch"],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor],
+            &[DiscoveryMechanism::Mqtt, DiscoveryMechanism::Manual],
+            &[AuthMode::MqttCredentials],
+            "mqtt",
+        ),
+        protocol_entry(
+            "matter",
+            "Matter",
+            "Matter controller integration over Thread, Wi-Fi, and Ethernet.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Specified,
+            1,
+            ProtocolFamily::Matter,
+            &["smart_home.read", "smart_home.command.light", "smart_home.command.lock"],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor, EntityKind::Lock],
+            &[DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual],
+            &[AuthMode::LocalPairing, AuthMode::Certificate],
+            "matter",
+        ),
+        local_device_entry(
+            "matter_bridge",
+            "Matter Bridge",
+            "Catalog route for bridged Matter devices exposed by other ecosystems.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Cataloged,
+            1,
+            &["smart_home.read", "smart_home.command.light", "smart_home.command.switch"],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor],
+            &[DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual],
+            &[AuthMode::LocalPairing, AuthMode::Certificate],
+            "matter",
+        )
+        .with_primitives(&[
+            PrimitiveFamily::MatterCommissioning,
+            PrimitiveFamily::Mdns,
+            PrimitiveFamily::LocalPairing,
+            PrimitiveFamily::CertificatePairing,
+        ]),
+        local_device_entry(
+            "homekit_controller",
+            "HomeKit Controller",
+            "Local controller for devices that expose the HomeKit Accessory Protocol.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Specified,
+            1,
+            &["smart_home.read", "smart_home.command.light", "smart_home.command.lock"],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor, EntityKind::Lock],
+            &[DiscoveryMechanism::Mdns, DiscoveryMechanism::Bluetooth, DiscoveryMechanism::Manual],
+            &[AuthMode::LocalPairing],
+            "homekit_controller",
+        ),
+        local_device_entry(
+            "esphome",
+            "ESPHome",
+            "Local ESPHome device integration for DIY sensors, lights, switches, and voice devices.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Specified,
+            1,
+            &["smart_home.read", "smart_home.command.light", "smart_home.command.switch"],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor, EntityKind::Input],
+            &[DiscoveryMechanism::Mdns, DiscoveryMechanism::Usb, DiscoveryMechanism::Manual],
+            &[AuthMode::LocalToken],
+            "esphome",
+        ),
+        tasmota_entry(),
+        local_device_entry(
+            "shelly",
+            "Shelly",
+            "Local Shelly relay, switch, cover, sensor, and energy integration.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Cataloged,
+            2,
+            &["smart_home.read", "smart_home.command.switch"],
+            &[EntityKind::Switch, EntityKind::Sensor],
+            &[DiscoveryMechanism::Mdns, DiscoveryMechanism::Dhcp, DiscoveryMechanism::Manual],
+            &[AuthMode::None, AuthMode::UsernamePassword],
+            "shelly",
+        ),
+        local_device_entry(
+            "tplink",
+            "TP-Link Smart Home",
+            "Local TP-Link and Kasa device integration for plugs, lights, switches, and cameras.",
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::Cataloged,
+            2,
+            &["smart_home.read", "smart_home.command.light", "smart_home.command.switch"],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor],
+            &[DiscoveryMechanism::Manual, DiscoveryMechanism::Dhcp],
+            &[AuthMode::None, AuthMode::UsernamePassword],
+            "tplink",
+        ),
+        virtual_alias(
+            "tplink_tapo",
+            "Tapo",
+            "Tapo products route through the TP-Link integration catalog entry.",
+            "tplink",
+            2,
+            "tplink_tapo",
+        ),
+        local_device_entry(
+            "wled",
+            "WLED",
+            "Local WLED light and effect integration.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Cataloged,
+            2,
+            &["smart_home.read", "smart_home.command.light"],
+            &[EntityKind::Light],
+            &[DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual],
+            &[AuthMode::None],
+            "wled",
+        ),
+        local_device_entry(
+            "lifx",
+            "LIFX",
+            "Local LIFX light integration.",
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::Cataloged,
+            2,
+            &["smart_home.read", "smart_home.command.light"],
+            &[EntityKind::Light],
+            &[DiscoveryMechanism::Dhcp, DiscoveryMechanism::Manual],
+            &[AuthMode::None],
+            "lifx",
+        ),
+        local_device_entry(
+            "govee_light_local",
+            "Govee Lights Local",
+            "Local LAN control path for Govee lights.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Cataloged,
+            2,
+            &["smart_home.read", "smart_home.command.light"],
+            &[EntityKind::Light],
+            &[DiscoveryMechanism::Dhcp, DiscoveryMechanism::Manual],
+            &[AuthMode::None],
+            "govee_light_local",
+        ),
+        bluetooth_entry(
+            "switchbot",
+            "SwitchBot Bluetooth",
+            "Bluetooth integration for SwitchBot buttons, meters, curtains, and locks.",
+            ImplementationStatus::Cataloged,
+            2,
+            &["smart_home.read", "smart_home.command.switch", "smart_home.command.lock"],
+            &[EntityKind::Switch, EntityKind::Sensor, EntityKind::Lock, EntityKind::Input],
+            "switchbot",
+        ),
+        local_hub_entry(
+            "unifi",
+            "UniFi Network",
+            "Local UniFi controller integration for presence, network, and device telemetry.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Cataloged,
+            2,
+            &["smart_home.read", "smart_home.diagnostics"],
+            &[EntityKind::Sensor, EntityKind::NetworkDiagnostic],
+            &[DiscoveryMechanism::Manual],
+            &[AuthMode::ApiKey, AuthMode::UsernamePassword],
+            "unifi",
+        ),
+        media_entry(
+            "sonos",
+            "Sonos",
+            "Local Sonos speaker and media-player integration.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Cataloged,
+            2,
+            "sonos",
+        ),
+        media_entry(
+            "cast",
+            "Google Cast",
+            "Local Cast media-player integration.",
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::Cataloged,
+            2,
+            "cast",
+        ),
+        camera_entry(
+            "onvif",
+            "ONVIF",
+            "Local ONVIF camera integration.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Cataloged,
+            3,
+            "onvif",
+        ),
+        camera_entry(
+            "reolink",
+            "Reolink",
+            "Reolink camera, doorbell, siren, and sensor hub integration.",
+            ConnectivityClass::LocalPush,
+            ImplementationStatus::Cataloged,
+            3,
+            "reolink",
+        ),
+        camera_entry(
+            "ring",
+            "Ring",
+            "Cloud Ring camera and doorbell integration.",
+            ConnectivityClass::CloudPolling,
+            ImplementationStatus::Cataloged,
+            3,
+            "ring",
+        ),
+        cloud_hub_entry(
+            "tuya",
+            "Tuya",
+            "Cloud Tuya hub for broad long-tail product coverage.",
+            ConnectivityClass::CloudPush,
+            ImplementationStatus::Cataloged,
+            5,
+            &["smart_home.read", "smart_home.command.light", "smart_home.command.switch"],
+            &[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor],
+            "tuya",
+        ),
+        energy_entry(
+            "enphase_envoy",
+            "Enphase Envoy",
+            "Local solar and energy telemetry integration.",
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::Cataloged,
+            4,
+            "enphase_envoy",
+        ),
+        energy_entry(
+            "fronius",
+            "Fronius",
+            "Local inverter and solar telemetry integration.",
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::Cataloged,
+            4,
+            "fronius",
+        ),
+        energy_entry(
+            "tesla_powerwall",
+            "Tesla Powerwall",
+            "Local battery and energy telemetry integration.",
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::Cataloged,
+            4,
+            "tesla_powerwall",
+        ),
+        cloud_hub_entry(
+            "ecobee",
+            "ecobee",
+            "Cloud thermostat and occupancy integration.",
+            ConnectivityClass::CloudPolling,
+            ImplementationStatus::Cataloged,
+            4,
+            &["smart_home.read", "smart_home.command.climate"],
+            &[EntityKind::Thermostat, EntityKind::Sensor],
+            "ecobee",
+        ),
+        cloud_hub_entry(
+            "nest",
+            "Google Nest",
+            "Cloud thermostat, camera, and sensor integration.",
+            ConnectivityClass::CloudPush,
+            ImplementationStatus::Cataloged,
+            4,
+            &[
+                "smart_home.read",
+                "smart_home.command.climate",
+                "smart_home.command.camera",
+            ],
+            &[EntityKind::Thermostat, EntityKind::Sensor, EntityKind::Unknown],
+            "nest",
+        ),
+        cloud_hub_entry(
+            "home_connect",
+            "Home Connect",
+            "Cloud appliance integration used by several appliance-brand aliases.",
+            ConnectivityClass::CloudPush,
+            ImplementationStatus::Cataloged,
+            4,
+            &["smart_home.read", "smart_home.command.switch"],
+            &[EntityKind::Switch, EntityKind::Sensor],
+            "home_connect",
+        ),
+        virtual_alias(
+            "symfonisk",
+            "IKEA SYMFONISK",
+            "SYMFONISK speakers are supported through the Sonos integration.",
+            "sonos",
+            2,
+            "symfonisk",
+        ),
+        virtual_standard(
+            "ultraloq",
+            "Ultraloq",
+            "Ultraloq products route through the Z-Wave standard.",
+            ProtocolFamily::ZWave,
+            2,
+            "ultraloq",
+        ),
+    ]
+}
+
+pub fn find_entry<'a>(
+    catalog: &'a [IntegrationCatalogEntry],
+    integration_id: &IntegrationId,
+) -> Option<&'a IntegrationCatalogEntry> {
+    catalog
+        .iter()
+        .find(|entry| &entry.integration_id == integration_id)
+}
+
+pub fn entries_by_category(
+    catalog: &[IntegrationCatalogEntry],
+    category: IntegrationCategory,
+) -> Vec<&IntegrationCatalogEntry> {
+    catalog
+        .iter()
+        .filter(|entry| entry.category == category)
+        .collect()
+}
+
+pub fn entries_by_connectivity(
+    catalog: &[IntegrationCatalogEntry],
+    connectivity: ConnectivityClass,
+) -> Vec<&IntegrationCatalogEntry> {
+    catalog
+        .iter()
+        .filter(|entry| entry.connectivity == connectivity)
+        .collect()
+}
+
+pub fn entries_by_status(
+    catalog: &[IntegrationCatalogEntry],
+    status: ImplementationStatus,
+) -> Vec<&IntegrationCatalogEntry> {
+    catalog
+        .iter()
+        .filter(|entry| entry.implementation_status == status)
+        .collect()
+}
+
+pub fn entries_requiring_capability<'a>(
+    catalog: &'a [IntegrationCatalogEntry],
+    capability_id: &CapabilityId,
+) -> Vec<&'a IntegrationCatalogEntry> {
+    catalog
+        .iter()
+        .filter(|entry| entry.supports_capability(capability_id))
+        .collect()
+}
+
+pub fn entries_requiring_primitive(
+    catalog: &[IntegrationCatalogEntry],
+    primitive: PrimitiveFamily,
+) -> Vec<&IntegrationCatalogEntry> {
+    catalog
+        .iter()
+        .filter(|entry| entry.requires_primitive(primitive))
+        .collect()
+}
+
+pub fn entries_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+) -> Vec<&IntegrationCatalogEntry> {
+    catalog
+        .iter()
+        .filter(|entry| entry.priority <= priority)
+        .collect()
+}
+
+fn hue_entry() -> IntegrationCatalogEntry {
+    base_entry(
+        "hue",
+        "Philips Hue",
+        "Hue bridge integration with CLIP v2 resources, pairing, event stream, and command mapping.",
+        IntegrationCategory::LocalHub,
+        ConnectivityClass::LocalPush,
+        ImplementationStatus::Scaffolded,
+        0,
+        "hue",
+    )
+    .with_capabilities(&[
+        "smart_home.read",
+        "smart_home.command.light",
+        "smart_home.pair",
+    ])
+    .with_entities(&[
+        EntityKind::Light,
+        EntityKind::LightGroup,
+        EntityKind::Scene,
+        EntityKind::Sensor,
+        EntityKind::Input,
+    ])
+    .with_protocols(vec![ProtocolFamily::Hue, ProtocolFamily::Zigbee])
+    .with_discovery(&[DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual])
+    .with_auth(&[AuthMode::LocalPairing, AuthMode::LocalToken])
+    .with_primitives(&[
+        PrimitiveFamily::Mdns,
+        PrimitiveFamily::LocalHttp,
+        PrimitiveFamily::ServerSentEvents,
+        PrimitiveFamily::LocalPairing,
+        PrimitiveFamily::LocalToken,
+        PrimitiveFamily::CommandMapping,
+        PrimitiveFamily::VaultLease,
+        PrimitiveFamily::Supervision,
+        PrimitiveFamily::TestSimulator,
+    ])
+}
+
+#[allow(clippy::too_many_arguments)]
+fn protocol_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    connectivity: ConnectivityClass,
+    status: ImplementationStatus,
+    priority: u8,
+    protocol: ProtocolFamily,
+    capabilities: &[&'static str],
+    entities: &[EntityKind],
+    discovery: &[DiscoveryMechanism],
+    auth: &[AuthMode],
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::ProtocolStandard,
+        connectivity,
+        status,
+        priority,
+        ha_domain,
+    )
+    .with_protocols(vec![protocol.clone()])
+    .with_capabilities(capabilities)
+    .with_entities(entities)
+    .with_discovery(discovery)
+    .with_auth(auth)
+    .with_primitives(protocol_primitives(&protocol))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn local_hub_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    connectivity: ConnectivityClass,
+    status: ImplementationStatus,
+    priority: u8,
+    capabilities: &[&'static str],
+    entities: &[EntityKind],
+    discovery: &[DiscoveryMechanism],
+    auth: &[AuthMode],
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::LocalHub,
+        connectivity,
+        status,
+        priority,
+        ha_domain,
+    )
+    .with_capabilities(capabilities)
+    .with_entities(entities)
+    .with_discovery(discovery)
+    .with_auth(auth)
+    .with_primitives(&local_transport_primitives(connectivity, discovery, auth))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn local_device_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    connectivity: ConnectivityClass,
+    status: ImplementationStatus,
+    priority: u8,
+    capabilities: &[&'static str],
+    entities: &[EntityKind],
+    discovery: &[DiscoveryMechanism],
+    auth: &[AuthMode],
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::LocalDevice,
+        connectivity,
+        status,
+        priority,
+        ha_domain,
+    )
+    .with_capabilities(capabilities)
+    .with_entities(entities)
+    .with_discovery(discovery)
+    .with_auth(auth)
+    .with_primitives(&local_transport_primitives(connectivity, discovery, auth))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn bluetooth_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    status: ImplementationStatus,
+    priority: u8,
+    capabilities: &[&'static str],
+    entities: &[EntityKind],
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::BluetoothProfile,
+        ConnectivityClass::LocalPush,
+        status,
+        priority,
+        ha_domain,
+    )
+    .with_capabilities(capabilities)
+    .with_entities(entities)
+    .with_discovery(&[DiscoveryMechanism::Bluetooth])
+    .with_auth(&[AuthMode::None, AuthMode::LocalPairing])
+    .with_primitives(&[
+        PrimitiveFamily::BluetoothLowEnergy,
+        PrimitiveFamily::LocalPairing,
+        PrimitiveFamily::Supervision,
+    ])
+}
+
+fn media_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    connectivity: ConnectivityClass,
+    status: ImplementationStatus,
+    priority: u8,
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::CameraMedia,
+        connectivity,
+        status,
+        priority,
+        ha_domain,
+    )
+    .with_capabilities(&["smart_home.read", "smart_home.command.media"])
+    .with_entities(&[EntityKind::Unknown])
+    .with_discovery(&[
+        DiscoveryMechanism::Mdns,
+        DiscoveryMechanism::Ssdp,
+        DiscoveryMechanism::Manual,
+    ])
+    .with_auth(&[AuthMode::None, AuthMode::LocalToken])
+    .with_primitives(&[
+        PrimitiveFamily::Mdns,
+        PrimitiveFamily::Ssdp,
+        PrimitiveFamily::LocalHttp,
+        PrimitiveFamily::LocalToken,
+        PrimitiveFamily::CommandMapping,
+        PrimitiveFamily::Supervision,
+    ])
+}
+
+fn camera_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    connectivity: ConnectivityClass,
+    status: ImplementationStatus,
+    priority: u8,
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::CameraMedia,
+        connectivity,
+        status,
+        priority,
+        ha_domain,
+    )
+    .with_capabilities(&["smart_home.read", "smart_home.command.camera"])
+    .with_entities(&[EntityKind::Unknown, EntityKind::Sensor])
+    .with_discovery(&[DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual])
+    .with_auth(&[AuthMode::UsernamePassword, AuthMode::ApiKey])
+    .with_primitives(&[
+        PrimitiveFamily::Mdns,
+        PrimitiveFamily::LocalHttp,
+        PrimitiveFamily::CameraMedia,
+        PrimitiveFamily::CapabilityPolicy,
+        PrimitiveFamily::VaultLease,
+        PrimitiveFamily::Supervision,
+    ])
+    .with_notes(&["Camera/media integrations require privacy-sensitive D21 policy."])
+}
+
+fn energy_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    connectivity: ConnectivityClass,
+    status: ImplementationStatus,
+    priority: u8,
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::EnergyClimate,
+        connectivity,
+        status,
+        priority,
+        ha_domain,
+    )
+    .with_capabilities(&["smart_home.read", "smart_home.command.energy"])
+    .with_entities(&[EntityKind::Sensor])
+    .with_discovery(&[
+        DiscoveryMechanism::Mdns,
+        DiscoveryMechanism::Dhcp,
+        DiscoveryMechanism::Manual,
+    ])
+    .with_auth(&[
+        AuthMode::None,
+        AuthMode::LocalToken,
+        AuthMode::UsernamePassword,
+    ])
+    .with_primitives(&[
+        PrimitiveFamily::Mdns,
+        PrimitiveFamily::Dhcp,
+        PrimitiveFamily::LocalHttp,
+        PrimitiveFamily::EnergyTelemetry,
+        PrimitiveFamily::VaultLease,
+        PrimitiveFamily::Supervision,
+    ])
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cloud_hub_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    connectivity: ConnectivityClass,
+    status: ImplementationStatus,
+    priority: u8,
+    capabilities: &[&'static str],
+    entities: &[EntityKind],
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::CloudHub,
+        connectivity,
+        status,
+        priority,
+        ha_domain,
+    )
+    .with_capabilities(capabilities)
+    .with_entities(entities)
+    .with_discovery(&[
+        DiscoveryMechanism::CloudAccount,
+        DiscoveryMechanism::Webhook,
+    ])
+    .with_auth(&[AuthMode::OAuth2, AuthMode::ApiKey])
+    .with_primitives(&[
+        PrimitiveFamily::CloudApi,
+        PrimitiveFamily::Webhook,
+        PrimitiveFamily::OAuth2,
+        PrimitiveFamily::CommandMapping,
+        PrimitiveFamily::CapabilityPolicy,
+        PrimitiveFamily::VaultLease,
+        PrimitiveFamily::Supervision,
+    ])
+}
+
+fn tasmota_entry() -> IntegrationCatalogEntry {
+    base_entry(
+        "tasmota",
+        "Tasmota",
+        "MQTT-native Tasmota device integration.",
+        IntegrationCategory::LocalDevice,
+        ConnectivityClass::LocalPush,
+        ImplementationStatus::DelegatedToStandard,
+        1,
+        "tasmota",
+    )
+    .with_capabilities(&[
+        "smart_home.read",
+        "smart_home.command.light",
+        "smart_home.command.switch",
+    ])
+    .with_entities(&[EntityKind::Light, EntityKind::Switch, EntityKind::Sensor])
+    .with_discovery(&[DiscoveryMechanism::Mqtt])
+    .with_auth(&[AuthMode::MqttCredentials])
+    .with_dependencies(&["mqtt"])
+    .with_protocols(vec![ProtocolFamily::Mqtt])
+    .with_primitives(&[
+        PrimitiveFamily::Mqtt,
+        PrimitiveFamily::MqttCredentials,
+        PrimitiveFamily::CommandMapping,
+        PrimitiveFamily::CapabilityPolicy,
+        PrimitiveFamily::Supervision,
+    ])
+}
+
+fn virtual_alias(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    target: &'static str,
+    priority: u8,
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::VirtualAlias,
+        ConnectivityClass::Calculated,
+        ImplementationStatus::DelegatedToStandard,
+        priority,
+        ha_domain,
+    )
+    .with_virtual_target(target)
+    .with_primitives(&[
+        PrimitiveFamily::NormalizedModel,
+        PrimitiveFamily::DiscoveryIndex,
+        PrimitiveFamily::CalculatedState,
+    ])
+    .with_notes(&["Virtual aliases route users and agents to an implementation entry."])
+}
+
+fn virtual_standard(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    standard: ProtocolFamily,
+    priority: u8,
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    base_entry(
+        id,
+        name,
+        summary,
+        IntegrationCategory::VirtualAlias,
+        ConnectivityClass::Calculated,
+        ImplementationStatus::DelegatedToStandard,
+        priority,
+        ha_domain,
+    )
+    .with_virtual_iot_standards(vec![standard])
+    .with_primitives(&[
+        PrimitiveFamily::NormalizedModel,
+        PrimitiveFamily::DiscoveryIndex,
+        PrimitiveFamily::CalculatedState,
+    ])
+    .with_notes(&["Virtual standard aliases route pairing through the protocol stack."])
+}
+
+#[allow(clippy::too_many_arguments)]
+fn base_entry(
+    id: &'static str,
+    name: &'static str,
+    summary: &'static str,
+    category: IntegrationCategory,
+    connectivity: ConnectivityClass,
+    implementation_status: ImplementationStatus,
+    priority: u8,
+    ha_domain: &'static str,
+) -> IntegrationCatalogEntry {
+    IntegrationCatalogEntry {
+        integration_id: IntegrationId::trusted(id),
+        display_name: name.to_string(),
+        summary: summary.to_string(),
+        category,
+        connectivity,
+        runtime_kind: if category == IntegrationCategory::VirtualAlias {
+            RuntimeKind::InProcessRust
+        } else {
+            RuntimeKind::RustWorkerProcess
+        },
+        implementation_status,
+        priority,
+        discovery_mechanisms: Vec::new(),
+        auth_modes: Vec::new(),
+        required_capabilities: vec![capability("smart_home.read")],
+        target_entity_kinds: Vec::new(),
+        supported_protocols: Vec::new(),
+        depends_on_integrations: Vec::new(),
+        virtual_target: None,
+        virtual_iot_standards: Vec::new(),
+        required_primitives: vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::VaultLease,
+            PrimitiveFamily::Supervision,
+        ],
+        source_refs: vec![SourceReference::home_assistant(ha_domain)],
+        notes: Vec::new(),
+    }
+}
+
+trait EntryBuilder {
+    fn with_capabilities(self, capabilities: &[&'static str]) -> Self;
+    fn with_entities(self, entities: &[EntityKind]) -> Self;
+    fn with_discovery(self, discovery: &[DiscoveryMechanism]) -> Self;
+    fn with_auth(self, auth_modes: &[AuthMode]) -> Self;
+    fn with_protocols(self, protocols: Vec<ProtocolFamily>) -> Self;
+    fn with_dependencies(self, integration_ids: &[&'static str]) -> Self;
+    fn with_virtual_target(self, integration_id: &'static str) -> Self;
+    fn with_virtual_iot_standards(self, standards: Vec<ProtocolFamily>) -> Self;
+    fn with_primitives(self, primitives: &[PrimitiveFamily]) -> Self;
+    fn with_notes(self, notes: &[&'static str]) -> Self;
+}
+
+impl EntryBuilder for IntegrationCatalogEntry {
+    fn with_capabilities(mut self, capabilities: &[&'static str]) -> Self {
+        self.required_capabilities = dedupe_capabilities(capabilities);
+        self
+    }
+
+    fn with_entities(mut self, entities: &[EntityKind]) -> Self {
+        self.target_entity_kinds = entities.to_vec();
+        self
+    }
+
+    fn with_discovery(mut self, discovery: &[DiscoveryMechanism]) -> Self {
+        self.discovery_mechanisms = discovery.to_vec();
+        self
+    }
+
+    fn with_auth(mut self, auth_modes: &[AuthMode]) -> Self {
+        self.auth_modes = auth_modes.to_vec();
+        self
+    }
+
+    fn with_protocols(mut self, protocols: Vec<ProtocolFamily>) -> Self {
+        self.supported_protocols = protocols;
+        self
+    }
+
+    fn with_dependencies(mut self, integration_ids: &[&'static str]) -> Self {
+        self.depends_on_integrations = integration_ids
+            .iter()
+            .map(|integration_id| IntegrationId::trusted(*integration_id))
+            .collect();
+        self
+    }
+
+    fn with_virtual_target(mut self, integration_id: &'static str) -> Self {
+        self.virtual_target = Some(IntegrationId::trusted(integration_id));
+        self
+    }
+
+    fn with_virtual_iot_standards(mut self, standards: Vec<ProtocolFamily>) -> Self {
+        self.virtual_iot_standards = standards;
+        self
+    }
+
+    fn with_primitives(mut self, primitives: &[PrimitiveFamily]) -> Self {
+        for primitive in primitives {
+            if !self.required_primitives.contains(primitive) {
+                self.required_primitives.push(*primitive);
+            }
+        }
+        self
+    }
+
+    fn with_notes(mut self, notes: &[&'static str]) -> Self {
+        self.notes = notes.iter().map(|note| (*note).to_string()).collect();
+        self
+    }
+}
+
+fn protocol_primitives(protocol: &ProtocolFamily) -> &'static [PrimitiveFamily] {
+    match protocol {
+        ProtocolFamily::Hue => &[
+            PrimitiveFamily::Mdns,
+            PrimitiveFamily::LocalHttp,
+            PrimitiveFamily::ServerSentEvents,
+            PrimitiveFamily::LocalPairing,
+        ],
+        ProtocolFamily::Zigbee => &[
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::RadioNetworkKey,
+        ],
+        ProtocolFamily::ZWave => &[
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::ZWaveSerialApi,
+            PrimitiveFamily::RadioNetworkKey,
+        ],
+        ProtocolFamily::Thread => &[
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Mdns,
+            PrimitiveFamily::RadioNetworkKey,
+        ],
+        ProtocolFamily::Matter => &[
+            PrimitiveFamily::Mdns,
+            PrimitiveFamily::MatterCommissioning,
+            PrimitiveFamily::CertificatePairing,
+            PrimitiveFamily::LocalPairing,
+        ],
+        ProtocolFamily::Mqtt => &[
+            PrimitiveFamily::Mqtt,
+            PrimitiveFamily::MqttCredentials,
+            PrimitiveFamily::CommandMapping,
+        ],
+        ProtocolFamily::Vendor(_) => &[PrimitiveFamily::LocalHttp, PrimitiveFamily::CommandMapping],
+    }
+}
+
+fn local_transport_primitives(
+    connectivity: ConnectivityClass,
+    discovery: &[DiscoveryMechanism],
+    auth: &[AuthMode],
+) -> Vec<PrimitiveFamily> {
+    let mut primitives = vec![
+        PrimitiveFamily::LocalHttp,
+        PrimitiveFamily::CommandMapping,
+        PrimitiveFamily::Supervision,
+    ];
+
+    if connectivity.is_push() {
+        primitives.push(PrimitiveFamily::WebSocket);
+    }
+
+    for mechanism in discovery {
+        let primitive = match mechanism {
+            DiscoveryMechanism::Mdns => Some(PrimitiveFamily::Mdns),
+            DiscoveryMechanism::Ssdp => Some(PrimitiveFamily::Ssdp),
+            DiscoveryMechanism::Bluetooth => Some(PrimitiveFamily::BluetoothLowEnergy),
+            DiscoveryMechanism::Usb => Some(PrimitiveFamily::Usb),
+            DiscoveryMechanism::Dhcp => Some(PrimitiveFamily::Dhcp),
+            DiscoveryMechanism::Mqtt => Some(PrimitiveFamily::Mqtt),
+            DiscoveryMechanism::Manual
+            | DiscoveryMechanism::CloudAccount
+            | DiscoveryMechanism::Webhook
+            | DiscoveryMechanism::FileConfig => None,
+        };
+        if let Some(primitive) = primitive {
+            primitives.push(primitive);
+        }
+    }
+
+    for mode in auth {
+        let primitive = match mode {
+            AuthMode::None => None,
+            AuthMode::LocalPairing => Some(PrimitiveFamily::LocalPairing),
+            AuthMode::LocalToken => Some(PrimitiveFamily::LocalToken),
+            AuthMode::UsernamePassword | AuthMode::ApiKey => Some(PrimitiveFamily::VaultLease),
+            AuthMode::OAuth2 => Some(PrimitiveFamily::OAuth2),
+            AuthMode::Certificate => Some(PrimitiveFamily::CertificatePairing),
+            AuthMode::RadioNetworkKey => Some(PrimitiveFamily::RadioNetworkKey),
+            AuthMode::MqttCredentials => Some(PrimitiveFamily::MqttCredentials),
+        };
+        if let Some(primitive) = primitive {
+            primitives.push(primitive);
+        }
+    }
+
+    dedupe_primitives(primitives)
+}
+
+fn dedupe_primitives(primitives: Vec<PrimitiveFamily>) -> Vec<PrimitiveFamily> {
+    let mut result = Vec::new();
+    for primitive in primitives {
+        if !result.contains(&primitive) {
+            result.push(primitive);
+        }
+    }
+    result
+}
+
+fn dedupe_capabilities(capabilities: &[&'static str]) -> Vec<CapabilityId> {
+    let mut result = Vec::new();
+    for capability_id in capabilities {
+        let capability_id = capability(capability_id);
+        if !result.contains(&capability_id) {
+            result.push(capability_id);
+        }
+    }
+    result
+}
+
+fn capability(value: &'static str) -> CapabilityId {
+    CapabilityId::trusted(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_party_catalog_includes_current_and_multiplier_integrations() {
+        let catalog = first_party_catalog();
+
+        assert!(find_entry(&catalog, &IntegrationId::trusted("hue")).is_some());
+        assert!(find_entry(&catalog, &IntegrationId::trusted("mqtt")).is_some());
+        assert!(find_entry(&catalog, &IntegrationId::trusted("matter")).is_some());
+        assert!(find_entry(&catalog, &IntegrationId::trusted("esphome")).is_some());
+        assert!(catalog.len() >= 30);
+    }
+
+    #[test]
+    fn connectivity_class_preserves_home_assistant_iot_class_names() {
+        assert_eq!(
+            ConnectivityClass::LocalPush.as_home_assistant_iot_class(),
+            "local_push"
+        );
+        assert!(ConnectivityClass::CloudPolling.requires_cloud());
+        assert!(ConnectivityClass::LocalPolling.is_local());
+        assert!(ConnectivityClass::CloudPush.is_push());
+    }
+
+    #[test]
+    fn virtual_aliases_route_to_real_targets_or_standards() {
+        let catalog = first_party_catalog();
+        let tapo = find_entry(&catalog, &IntegrationId::trusted("tplink_tapo")).unwrap();
+        let ultraloq = find_entry(&catalog, &IntegrationId::trusted("ultraloq")).unwrap();
+
+        assert!(tapo.is_virtual());
+        assert_eq!(tapo.virtual_target, Some(IntegrationId::trusted("tplink")));
+        assert_eq!(ultraloq.virtual_iot_standards, vec![ProtocolFamily::ZWave]);
+        assert_eq!(tapo.runtime_kind, RuntimeKind::InProcessRust);
+    }
+
+    #[test]
+    fn capability_queries_find_high_risk_surfaces() {
+        let catalog = first_party_catalog();
+        let lock_entries = entries_requiring_capability(
+            &catalog,
+            &CapabilityId::trusted("smart_home.command.lock"),
+        );
+
+        assert!(lock_entries
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("zwave")));
+        assert!(lock_entries
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("matter")));
+    }
+
+    #[test]
+    fn priority_queries_include_wave_zero_and_one() {
+        let catalog = first_party_catalog();
+        let early = entries_at_or_before_priority(&catalog, 1);
+
+        assert!(early
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("hue")));
+        assert!(early
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("mqtt")));
+        assert!(!early
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("tuya")));
+    }
+
+    #[test]
+    fn local_push_entries_can_be_filtered_for_supervision_shape() {
+        let catalog = first_party_catalog();
+        let local_push = entries_by_connectivity(&catalog, ConnectivityClass::LocalPush);
+
+        assert!(local_push
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("hue")));
+        assert!(local_push
+            .iter()
+            .all(|entry| entry.connectivity == ConnectivityClass::LocalPush));
+    }
+
+    #[test]
+    fn hue_records_the_trial_run_primitive_shape() {
+        let catalog = first_party_catalog();
+        let hue = find_entry(&catalog, &IntegrationId::trusted("hue")).unwrap();
+
+        assert!(hue.requires_primitive(PrimitiveFamily::Mdns));
+        assert!(hue.requires_primitive(PrimitiveFamily::LocalHttp));
+        assert!(hue.requires_primitive(PrimitiveFamily::ServerSentEvents));
+        assert!(hue.requires_primitive(PrimitiveFamily::LocalPairing));
+        assert!(hue.requires_primitive(PrimitiveFamily::Supervision));
+    }
+
+    #[test]
+    fn primitive_queries_group_delegated_mqtt_device_families() {
+        let catalog = first_party_catalog();
+        let mqtt_entries = entries_requiring_primitive(&catalog, PrimitiveFamily::Mqtt);
+
+        assert!(mqtt_entries
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("mqtt")));
+        assert!(mqtt_entries
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("tasmota")));
+    }
+
+    #[test]
+    fn camera_entries_are_marked_as_privacy_sensitive_primitives() {
+        let catalog = first_party_catalog();
+        let camera_entries = entries_requiring_primitive(&catalog, PrimitiveFamily::CameraMedia);
+
+        assert!(camera_entries
+            .iter()
+            .any(|entry| entry.integration_id == IntegrationId::trusted("onvif")));
+        assert!(camera_entries.iter().all(|entry| entry
+            .required_primitives
+            .contains(&PrimitiveFamily::CapabilityPolicy)));
+    }
+}

--- a/code/specs/D23A-smart-home-integration-catalog.md
+++ b/code/specs/D23A-smart-home-integration-catalog.md
@@ -1,0 +1,753 @@
+# D23A - Smart Home Integration Primitive Catalog
+
+## Overview
+
+D23 defines the normalized smart-home runtime: bridges, devices, entities,
+events, commands, state cache, supervision, policy, and audit. D23A defines the
+catalog and primitive roadmap that let the runtime grow from "Hue as a trial
+run" into a broad smart-home ecosystem without copying any one platform's
+architecture.
+
+The architectural shape is:
+
+```text
+ecosystem survey
+  -> primitive family catalog
+  -> integration catalog entry
+  -> supervised worker or capability-caged sidecar
+  -> normalized D23 bridge/device/entity/event/command model
+  -> Chief of Staff tools
+```
+
+Home Assistant is only one implementation. It is a useful public map because it
+has a large integration index and machine-readable manifests, but the same
+primitive families show up in Hubitat, Homey Pro, SmartThings, openHAB,
+Homebridge, ioBroker, Domoticz, Jeedom, HomeSeer, and automation systems like
+Node-RED, n8n, IFTTT, and Zapier.
+
+D23A's job is not "implement every adapter now." Its job is to identify the
+smallest shared primitives that make later adapters boring:
+
+- normalized entity, capability, state, event, command, health, and audit models
+- discovery primitives for LAN, radio, USB, MQTT, cloud account, webhook, and
+  manual setup
+- transport primitives for local HTTP, WebSocket, SSE, MQTT, BLE, serial, radio,
+  camera media, cloud APIs, and webhooks
+- auth and pairing primitives for bridge buttons, local tokens, OAuth2, API keys,
+  certificates, Matter commissioning, HomeKit pairing, radio keys, and MQTT
+  credentials
+- supervision primitives for pollers, event streams, serial/radio controllers,
+  bridge actors, webhook receivers, cloud leases, and calculated workers
+- capability cage and Vault primitives so every integration has explicit access
+  to secrets, network, filesystem, serial, BLE, radio, camera, and high-risk
+  commands
+
+Hue proved the pattern: local discovery, physical pairing, local token storage,
+HTTP resource reads, event-stream updates, normalized entity projection, command
+mapping, health transitions, and tests can be built once as reusable primitive
+families instead of as Hue-only machinery.
+
+---
+
+## Source Snapshot
+
+This spec was refreshed on 2026-05-08 using official or project-owned source
+surfaces.
+
+| Platform | Source surface | What it contributes to D23A |
+|----------|----------------|-----------------------------|
+| Home Assistant | public integration index, developer manifest docs, Core manifests | broad catalog taxonomy, `iot_class`, `integration_type`, virtual aliases |
+| Hubitat | supported device list, app/driver docs | local hub, Zigbee/Z-Wave/LAN/cloud driver split, Groovy app sandbox lessons |
+| Homey Pro | app store and protocol-rich hub model | app ecosystem, consumer pairing flows, local radios plus cloud apps |
+| SmartThings | hub-connected device and Edge driver docs | capability model, Matter/Zigbee/Z-Wave/LAN local execution through hub drivers |
+| openHAB | add-ons and bindings reference | bindings as hardware/service adapters, mature protocol-first framing |
+| Homebridge | plugin docs and verified plugin program | HomeKit/Matter bridge semantics, plugin quality gates, Node sidecar lessons |
+| ioBroker | `sources-dist.json` adapter catalog | adapter-scale ecosystem and admin-installable integration metadata |
+| Domoticz | hardware and protocol wiki | hardware gateway view across 433/868/915 MHz, Z-Wave, Zigbee, cameras, Modbus, MQTT |
+| Jeedom | smart-home solution and market pages | local-first, plugin-driven, multi-protocol market framing |
+| HomeSeer | plugin documentation and hub/software pages | local hub plus commercial plugin ecosystem, Zigbee/Z-Wave/Matter/Hue/ONVIF examples |
+
+Machine-readable checks performed:
+
+```text
+home-assistant/core branch: dev
+home-assistant/core commit: 27969c3
+home-assistant/core commit_time: 2026-05-09T00:24:51+03:00
+home-assistant/core manifest_count: 1461
+
+ioBroker sources-dist.json adapter_count: 607
+```
+
+Home Assistant manifest `iot_class` distribution in that snapshot:
+
+| IoT class | Count | Runtime primitive implication |
+|-----------|------:|-------------------------------|
+| `local_polling` | 417 | local transport plus scheduled refresh and stale-state deadlines |
+| `cloud_polling` | 389 | cloud API, token lease, quota-aware scheduler, internet dependency |
+| `local_push` | 250 | local subscription/event stream with fast health transitions |
+| missing | 241 | helper, platform, internal, legacy, or metadata-gap entries |
+| `cloud_push` | 116 | cloud webhook/subscription, token lease, outage-aware health |
+| `calculated` | 32 | internal calculated state worker, no external transport |
+| `assumed_state` | 16 | command path without trustworthy state feedback |
+
+Home Assistant manifest `integration_type` distribution in that snapshot:
+
+| Integration type | Count | Catalog implication |
+|------------------|------:|---------------------|
+| missing | 391 | legacy or uncategorized metadata |
+| `device` | 267 | one device or device family |
+| `hub` | 264 | bridge, controller, gateway, account, or ecosystem |
+| `service` | 255 | external data/API service |
+| `virtual` | 121 | product alias that routes to a real implementation or standard |
+| `system` | 83 | host/system/runtime integration |
+| `entity` | 46 | entity-level platform or synthetic entity |
+| `helper` | 28 | helper or calculated entity |
+| `hardware` | 6 | hardware adapter, dongle, or appliance support |
+
+---
+
+## Core Interpretation
+
+### 1. Integration Is Not A Primitive
+
+"Integration" is a packaging word. The reusable substrate underneath it is more
+stable and should be modeled first.
+
+| Integration shape | Examples across platforms | Primitive families |
+|-------------------|---------------------------|--------------------|
+| Protocol standard | Matter, MQTT, Zigbee, Z-Wave, Thread, HomeKit Controller, ESPHome, Tasmota, KNX, Modbus, BTHome | protocol model, discovery, pairing, transport, command mapping |
+| Local hub | Hue, deCONZ, IKEA, UniFi, Sonos, Bond, Broadlink | bridge actor, local auth, event stream/polling, child device projection |
+| Local device | Shelly, TP-Link/Kasa/Tapo, WLED, LIFX, Govee local, Roku, Wemo | LAN discovery, local HTTP/UDP/TCP, state cache, command idempotency |
+| Bluetooth profile | SwitchBot, BTHome, Govee BLE, trackers, buttons, meters | BLE scanning, GATT, rate limits, host adapter health |
+| Cloud account/hub | Tuya, SmartThings, Nest, Ring, Roborock, Alexa/Google ecosystems | OAuth/API key, webhook/polling, cloud outage state, quota policy |
+| Camera/media | ONVIF, RTSP, Reolink, Frigate, UniFi Protect, Sonos, Cast | media/camera transport, privacy policy, stream lease, snapshot audit |
+| Energy/climate/water | Ecobee, Nest, Enphase, Fronius, Tesla Powerwall, Opower, DSMR/P1, Rachio | telemetry model, forecast/rate state, high-risk setpoint/valve policy |
+| Notification/human channel | mobile push, Telegram, Discord, email, Slack, Alexa announcements | D18D service connector, outbound message policy, audit |
+| Data service sensor | weather, transit, calendar, finance, health, mail | D18A/D18D service connector, freshness and provenance |
+| Helper/calculated entity | template, group, min/max, utility meter, derived presence | calculated worker, dependency graph, replay/cursor |
+| Virtual alias | Tapo through TP-Link, Symfonisk through Sonos, appliance brands through Home Connect | catalog alias, guided setup route, no worker |
+
+### 2. Connectivity Class Becomes Supervision
+
+The catalog's connectivity field is not display metadata. It tells the runtime
+how to supervise the worker.
+
+| Connectivity | Worker shape |
+|--------------|--------------|
+| `local_push` | long-lived local stream/socket/subscription plus restart and stale-state deadlines |
+| `local_polling` | scheduled local refresh with adaptive backoff and stale-state deadlines |
+| `cloud_push` | webhook/subscription worker with token refresh and cloud outage state |
+| `cloud_polling` | scheduled cloud refresh with quota policy and explicit internet dependency |
+| `calculated` | internal worker fed by event/state dependencies |
+| `assumed_state` | command audit plus low-confidence state projection |
+
+### 3. Virtual Entries Are User Experience, Not Runtime Work
+
+Many platforms expose aliases because people search by product or brand, not by
+underlying standard. D23A should preserve this without launching duplicate
+workers.
+
+Examples:
+
+- Tapo routes to TP-Link/Kasa/Tapo primitives.
+- SYMFONISK routes to Sonos/media primitives.
+- Ultraloq often routes through Z-Wave.
+- ESPHome product lines route through ESPHome or MQTT.
+- Appliance brands may route through Home Connect.
+- Utility providers may route through Opower-like energy-service primitives.
+
+### 4. Automation Products Are Adjacent, Not Device Truth
+
+Node-RED, n8n, IFTTT, Zapier, and similar systems are flow/workflow engines.
+They are important integration surfaces, but they should not be the primary
+source of smart-home truth in D23. They belong in D18D as tool/service
+connectors or outbound automation bridges. D23 owns device/entity state,
+supervision, and command audit.
+
+---
+
+## Primitive Families
+
+### Normalized Model
+
+Required for every integration:
+
+- bridge, device, endpoint/entity, capability, scene, group, event, command,
+  health, audit, and provenance identifiers
+- stable mapping from vendor resources into D23 entity kinds
+- source confidence and state freshness metadata
+- alias routing for product names that map to another implementation
+
+### Discovery
+
+Discovery must be reusable and observable:
+
+| Primitive | Examples |
+|-----------|----------|
+| mDNS/DNS-SD | Hue, Matter, HomeKit, ESPHome, Shelly, WLED, Sonos |
+| SSDP/UPnP | media devices, some LAN hubs, discovery fallbacks |
+| DHCP/router observation | TP-Link/Kasa/Tapo, LIFX-style LAN devices, static-IP candidates |
+| Bluetooth advertisement scan | BTHome, SwitchBot, Govee BLE, trackers |
+| USB enumeration | Zigbee coordinators, Z-Wave sticks, Thread border-router adapters |
+| MQTT discovery | Home Assistant MQTT discovery, Tasmota, Zigbee2MQTT, custom sensors |
+| cloud account inventory | Tuya, SmartThings, Nest, Ring, Roborock |
+| webhook registration | cloud push integrations, local callback integrations |
+| manual/file config | KNX, Modbus, camera URLs, edge cases |
+
+Every discovery observation should record source, timestamp, confidence,
+network/interface, pairing status, and the catalog entry it appears to satisfy.
+
+### Transport
+
+| Primitive | Examples |
+|-----------|----------|
+| local HTTP/HTTPS | Hue, Shelly, WLED, ESPHome, cameras, energy gateways |
+| WebSocket | ESPHome, some local APIs, bidirectional streams |
+| Server-Sent Events | Hue CLIP v2 event stream |
+| MQTT | Tasmota, Zigbee2MQTT, sensors, user-defined automations |
+| CoAP/UDP/TCP | Matter-adjacent and LAN device protocols, vendor APIs |
+| serial | Zigbee, Z-Wave, Thread adapters, Modbus RTU |
+| BLE GATT | SwitchBot, sensors, locks, meters |
+| radio controller | 802.15.4, Z-Wave, 433/868/915 MHz via gateways |
+| camera/media | RTSP, ONVIF events, snapshots, stream leases |
+| cloud API | OAuth/API-key REST/GraphQL/vendor SDK calls |
+| webhook receiver | cloud push, local callbacks, D18D flow bridges |
+
+### Auth And Pairing
+
+| Primitive | Examples |
+|-----------|----------|
+| physical link button | Hue, some bridges |
+| local token/API key | Hue, Shelly, UniFi, cameras, energy gateways |
+| OAuth2 | Ecobee, Nest, Ring, SmartThings-like accounts |
+| username/password | local controllers, cameras, legacy hubs |
+| certificate pairing | Matter, mTLS-capable local services |
+| HomeKit pairing | HomeKit Controller/HAP devices |
+| Matter commissioning | Matter over Thread/Wi-Fi/Ethernet |
+| radio network key | Zigbee, Z-Wave, Thread |
+| MQTT credentials | broker username/password/cert |
+
+Secrets are Vault records. Workers receive leases, not ambient access.
+
+### State, Command, And Audit
+
+The shared runtime needs:
+
+- canonical state snapshots and event deltas
+- replay cursors and subscription cursors
+- stale-state deadlines and state-confidence levels
+- idempotent command envelopes
+- command outcome events, including "accepted but state unknown"
+- high-risk command classification for locks, alarms, covers, valves, cameras,
+  irrigation, thermostat setpoints, and garage doors
+- per-command audit records with actor, capability grant, target, desired state,
+  result, and correlation id
+
+### Supervision
+
+| Worker kind | Used by |
+|-------------|---------|
+| `poller` | local/cloud polling integrations |
+| `event_stream` | Hue SSE, WebSocket streams, cloud push subscriptions |
+| `bridge_actor` | hubs that multiplex many child devices |
+| `serial_controller` | Zigbee, Z-Wave, Thread, Modbus RTU |
+| `radio_controller` | BLE, 802.15.4, 433/868/915 MHz via adapters |
+| `webhook_receiver` | cloud and local callbacks |
+| `calculated_worker` | templates, groups, utility meters, derived state |
+| `sidecar` | non-Rust SDKs inside a capability cage |
+
+Supervision must own restart policy, health state, exponential backoff,
+heartbeat deadlines, credential renewal, and degraded/offline transitions.
+
+### Capability Cage
+
+Each primitive exposes the minimum capabilities needed:
+
+```text
+net.lan.http
+net.lan.mdns
+net.lan.ssdp
+net.cloud.https
+net.webhook.receive
+secret.vault.lease
+serial.open
+ble.scan
+ble.gatt
+radio.802154
+radio.zwave
+camera.snapshot
+camera.stream
+filesystem.config.read
+smart_home.read
+smart_home.pair
+smart_home.manage_network
+smart_home.manage_credentials
+smart_home.command.*
+```
+
+---
+
+## Cross-Platform Integration Matrix
+
+This matrix is intentionally primitive-oriented. It names integration families
+that recur across Home Assistant, Hubitat, Homey Pro, SmartThings, openHAB,
+Homebridge, ioBroker, Domoticz, Jeedom, and HomeSeer.
+
+| Family | Why it matters | First primitive focus |
+|--------|----------------|-----------------------|
+| Matter | cross-vendor standard across Wi-Fi, Ethernet, and Thread | commissioning, certificates, mDNS, fabric metadata |
+| Thread | low-power IP mesh used by Matter | border-router discovery, diagnostics, network credentials |
+| Zigbee | large installed base and common hub radio | coordinator serial API, network keys, ZCL projection |
+| Z-Wave | locks, switches, sensors, energy, mature mesh | serial API, command-class projection, inclusion/exclusion |
+| MQTT | universal local bus and automation bridge | broker client, discovery topics, retained state, command topics |
+| HomeKit/HAP | local pairing and bridge interoperability | pairing, mDNS, accessory model, bridge projection |
+| ESPHome | DIY/local devices and voice/sensor surfaces | mDNS, local API, entity projection |
+| Tasmota | MQTT-native flashed devices | MQTT device/entity profile |
+| BLE/BTHome | cheap sensors, buttons, trackers | scan/GATT primitives and host health |
+| Modbus/KNX | HVAC, energy, industrial/building automation | register/group-address mapping, TCP/RTU transports |
+| RF/IR bridges | Broadlink, Bond, 433/868 MHz ecosystems | learned command storage, one-way/assumed-state model |
+| Hue/deCONZ/IKEA | bridge-based lighting and sensors | local bridge actor, child entities, pairing |
+| Shelly/TP-Link/WLED/LIFX | high-leverage local LAN device families | LAN discovery, local HTTP/UDP, command mapping |
+| Cameras/NVR | ONVIF, RTSP, Reolink, Frigate, UniFi Protect | camera privacy policy, event stream, snapshot/stream lease |
+| Media | Sonos, Cast, Roku, Apple TV, Android TV | media entity model, discovery, command surface |
+| Energy/climate | Ecobee, Nest, Enphase, Fronius, Powerwall, Opower | telemetry freshness, cloud/local split, setpoint policy |
+| Cloud long tail | Tuya, SmartThings, Ring, Roborock, Alexa/Google | OAuth/API keys, cloud outage, rate limits, webhooks |
+| Flow engines | Node-RED, n8n, IFTTT, Zapier | D18D bridge, webhook/action connector, no device truth ownership |
+
+---
+
+## Catalog Entry Model
+
+Each integration catalog entry should describe:
+
+```text
+IntegrationCatalogEntry
+|-- integration_id
+|-- display_name
+|-- summary
+|-- category
+|-- connectivity_class
+|-- runtime_kind
+|-- implementation_status
+|-- priority
+|-- discovery_mechanisms[]
+|-- auth_modes[]
+|-- required_capabilities[]
+|-- target_entity_kinds[]
+|-- supported_protocols[]
+|-- depends_on_integrations[]
+|-- virtual_target?
+|-- virtual_iot_standards[]
+|-- required_primitives[]
+|-- source_refs[]
+|-- notes[]
+```
+
+Recommended enums:
+
+```text
+IntegrationCategory
+  protocol_standard
+  local_hub
+  local_device
+  bluetooth_profile
+  cloud_hub
+  camera_media
+  energy_climate
+  notification_channel
+  data_service
+  helper_calculated
+  virtual_alias
+  system_hardware
+
+ConnectivityClass
+  local_push
+  local_polling
+  cloud_push
+  cloud_polling
+  calculated
+  assumed_state
+
+ImplementationStatus
+  cataloged
+  specified
+  scaffolded
+  simulated
+  first_party_runtime
+  production_ready
+  delegated_to_standard
+  unsupported
+
+PrimitiveFamily
+  normalized_model
+  discovery_index
+  mdns
+  ssdp
+  dhcp
+  local_http
+  websocket
+  server_sent_events
+  mqtt
+  bluetooth_low_energy
+  usb
+  serial_controller
+  radio_802154
+  zwave_serial_api
+  matter_commissioning
+  homekit_pairing
+  cloud_api
+  webhook
+  oauth2
+  local_pairing
+  local_token
+  certificate_pairing
+  radio_network_key
+  mqtt_credentials
+  camera_media
+  energy_telemetry
+  calculated_state
+  command_mapping
+  capability_policy
+  vault_lease
+  supervision
+  test_simulator
+```
+
+---
+
+## Chief Of Staff Mapping
+
+D23A integrations should surface through D18D tools, D18A stores, and D21
+capability policy.
+
+Read tools:
+
+```text
+smart_home.list_integrations
+smart_home.describe_integration
+smart_home.list_primitives
+smart_home.describe_primitive
+smart_home.discover
+smart_home.list_bridges
+smart_home.list_devices
+smart_home.get_state
+smart_home.get_health
+smart_home.subscribe
+```
+
+Management tools:
+
+```text
+smart_home.pair_bridge
+smart_home.configure_integration
+smart_home.manage_network
+smart_home.rotate_credentials
+smart_home.run_diagnostics
+```
+
+Command capabilities:
+
+```text
+smart_home.command.light
+smart_home.command.switch
+smart_home.command.climate
+smart_home.command.cover
+smart_home.command.lock
+smart_home.command.alarm
+smart_home.command.camera
+smart_home.command.media
+smart_home.command.vacuum
+smart_home.command.irrigation
+smart_home.command.valve
+smart_home.command.energy
+smart_home.command.scene
+```
+
+High-risk command examples:
+
+- unlock a lock
+- open a garage door
+- disable an alarm
+- move or expose a camera
+- change thermostat setpoints aggressively
+- start irrigation
+- open a water/gas valve
+
+The catalog should declare default risk for each command surface so the Tool API
+can require human approval, biometric auth, or a hardware-key challenge.
+
+---
+
+## Storage Model
+
+D18A should persist:
+
+```text
+integration_catalog_entries
+primitive_catalog_entries
+integration_aliases
+integration_installations
+integration_workers
+integration_credentials
+integration_discovery_observations
+integration_pairing_sessions
+integration_health_events
+integration_capability_grants
+integration_source_refs
+```
+
+The catalog is mostly static. Installations are local to the user's home. One
+catalog entry can have many installations: two Hue bridges, several MQTT
+brokers, multiple UniFi sites, and multiple cloud accounts are normal.
+
+---
+
+## Runtime Model
+
+Each installed integration becomes one or more supervised workers:
+
+```text
+IntegrationSupervisor
+|-- catalog_entry
+|-- required_primitives[]
+|-- installation
+|-- worker_kind
+|-- transport lease
+|-- Vault lease
+|-- state cursor
+|-- event stream cursor
+|-- command queue
+|-- health reporter
+|-- audit sink
+```
+
+The supervisor never trusts an adapter to be self-healing. It owns restart
+policy, health state, backoff, worker lease renewal, and stale-state deadlines.
+
+---
+
+## Rollout Waves
+
+### Wave 0 - Trial Run And Existing Substrate
+
+| Area | Packages |
+|------|----------|
+| Core model | `smart-home-core` |
+| Registry | `smart-home-registry` |
+| Runtime | `smart-home-runtime` |
+| Discovery | `smart-home-discovery` |
+| Hue trial run | `hue-core`, `hue-client`, future `hue-integration` |
+| Zigbee substrate | `zigbee-nwk`, `zigbee-aps`, `zigbee-zdo`, `zigbee-zcl` |
+| Z-Wave substrate | `zwave-core`, `zwave-serial-api`, `zwave-command-classes` |
+| Thread substrate | `thread-mle`, future 6LoWPAN/Thread packages |
+
+Hue's purpose is to validate the primitive shape: discovery, physical pairing,
+local token, HTTP reads, SSE events, command mapping, health, audit, and tests.
+
+### Wave 1 - Primitive Multipliers
+
+These should be implemented before most vendor-specific adapters:
+
+| Primitive package direction | Unlocks |
+|-----------------------------|---------|
+| `smart-home-integration-catalog` | integration/primitive metadata, aliases, roadmap, D18D descriptors |
+| `smart-home-mqtt` | Tasmota, Zigbee2MQTT, sensors, local automation bridges |
+| `smart-home-ble` and `bthome-core` | SwitchBot, BTHome, BLE sensors/buttons |
+| `smart-home-local-http` | Hue, Shelly, WLED, ESPHome, cameras, energy gateways |
+| `smart-home-event-streams` | Hue SSE, WebSocket workers, subscription health |
+| `smart-home-usb-serial` | Zigbee, Z-Wave, Thread, Modbus RTU |
+| `smart-home-camera-media` | ONVIF, RTSP, snapshots, privacy-sensitive state |
+| `smart-home-cloud-account` | OAuth/API-key cloud integrations and webhook registration |
+| `smart-home-testkit` | fake bridges, fake brokers, fake event streams, replay fixtures |
+
+### Wave 2 - Standards
+
+| Standard | Why |
+|----------|-----|
+| MQTT | smallest local bus multiplier |
+| Matter | modern cross-vendor standard |
+| HomeKit Controller | local pairing for many consumer devices |
+| ESPHome | DIY/local ecosystem |
+| Tasmota | MQTT-native device ecosystem |
+| Modbus | HVAC, energy, industrial |
+| KNX | building automation |
+
+### Wave 3 - High-Leverage Local Hubs And Devices
+
+| Family | Surfaces |
+|--------|----------|
+| Hue/deCONZ/IKEA | lights, groups, scenes, sensors, buttons |
+| Shelly | relays, switches, covers, sensors, energy |
+| TP-Link/Kasa/Tapo | plugs, lights, switches, cameras |
+| WLED/LIFX/Govee local | lighting |
+| SwitchBot BLE | buttons, curtains, locks, meters |
+| UniFi | presence, network, Protect-adjacent surfaces |
+| Sonos/Cast/Roku/Apple TV/Android TV | media control and announcements |
+
+### Wave 4 - Cameras, Energy, Climate, Water
+
+| Family | Notes |
+|--------|-------|
+| ONVIF/RTSP/Reolink/Frigate/UniFi Protect | require camera privacy policy and stream leases |
+| Enphase/Fronius/Powerwall/DSMR/P1 | energy telemetry freshness and provenance |
+| Ecobee/Nest/tado/Home Connect | climate/appliance cloud-local split |
+| Rachio/irrigation/valves | high-risk command approval |
+
+### Wave 5 - Cloud Long Tail And Flow Bridges
+
+| Family | Notes |
+|--------|-------|
+| Tuya/SmartThings/Ring/Roborock | broad product coverage, cloud dependency and rate limits |
+| Alexa/Google assistant bridges | voice/control projection, not core truth source |
+| Node-RED/n8n/IFTTT/Zapier | D18D flow connector or webhook/action bridge |
+| weather/transit/finance/mail/calendar | D18D data/service connectors, projected into D23 only when device-like |
+
+---
+
+## Package Plan
+
+### `smart-home-integration-catalog`
+
+Pure Rust catalog model and seed data.
+
+Responsibilities:
+
+- integration catalog entry structs/enums
+- primitive-family metadata
+- connectivity and supervision hints
+- first-party rollout seed entries
+- alias entries for virtual/product integrations
+- query helpers by id, category, capability, primitive, connectivity, status,
+  and priority
+
+No network, filesystem, Vault, radio, serial, or runtime I/O.
+
+### `smart-home-primitive-kit`
+
+Future shared primitives package set.
+
+Responsibilities:
+
+- reusable discovery observation records
+- transport lease descriptors
+- pairing session descriptors
+- worker-kind descriptors
+- testkit traits for fake brokers, bridges, streams, cloud APIs, and radios
+
+### `smart-home-integration-importer`
+
+Later offline tool for importing external catalog metadata.
+
+Responsibilities:
+
+- read Home Assistant manifests, ioBroker adapter metadata, openHAB binding
+  metadata, and similar source catalogs
+- produce stable catalog JSON/CBOR artifacts
+- normalize connectivity, category, discovery, auth, virtual aliases, and source
+  refs
+- mark generated entries as reference/catalog-only until first-party support
+  exists
+
+### `smart-home-integration-host`
+
+Later supervised worker host.
+
+Responsibilities:
+
+- launch integration workers or capability-caged sidecars
+- mediate Vault/network/serial/BLE/radio/camera capabilities
+- emit health and audit events
+- connect workers to D23 runtime commands/events
+
+---
+
+## Acceptance Criteria
+
+D23A is useful when:
+
+1. A Chief of Staff agent can ask which integrations and primitive families are
+   supported, planned, or catalog-only.
+2. A user searching for a product alias can be routed to the real integration or
+   standard.
+3. The runtime can choose poller, event stream, bridge actor, serial/radio
+   controller, webhook receiver, or calculated worker from catalog metadata.
+4. Security policy can distinguish read-only services, ordinary commands, and
+   high-risk commands before an adapter exists.
+5. The backlog is driven by standards and high-leverage primitives before cloud
+   long-tail work.
+6. New integrations can be added as small Rust packages or capability-caged
+   sidecars with shared discovery, pairing, auth, state, command, supervision,
+   and testkit primitives.
+
+---
+
+## Immediate Implementation Sequence
+
+1. Add `smart-home-integration-catalog` with primitive requirements and seed
+   entries.
+2. Add D18D descriptors for `smart_home.list_integrations`,
+   `smart_home.describe_integration`, `smart_home.list_primitives`, and
+   `smart_home.describe_primitive`.
+3. Add catalog-backed discovery hints to `smart-home-discovery`.
+4. Add the MQTT primitive package before vendor-specific MQTT integrations.
+5. Add shared local HTTP/event-stream primitives, reusing Hue as the proof.
+6. Add BLE/BTHome, USB/serial, and camera-media primitive packages.
+7. Add Matter/HomeKit/ESPHome/Tasmota catalog entries and primitive descriptors
+   before full adapters.
+8. Add importer tooling that can refresh external catalog snapshots into a
+   checked artifact.
+
+---
+
+## Open Questions
+
+1. Should external catalog snapshots be vendored as generated artifacts, or
+   remain developer-only research inputs?
+2. Should cloud integrations live in D23 if they represent devices, or should
+   all cloud services be D18D service connectors projected into D23 only when
+   they expose physical devices?
+3. Should camera/media capabilities be part of `smart_home.*`, or split into
+   `camera.*` and `media.*` tool namespaces with D23 entity projection?
+4. Should Matter become a direct first-party stack immediately, or should we
+   first support a local Matter server/bridge while Thread and commissioning
+   primitives mature?
+5. Which runtime should host non-Rust adapters: WASI, process sandbox, Firecracker
+   microVM, macOS sandbox, container, or a narrower custom capability cage?
+
+---
+
+## References
+
+- Home Assistant integrations index:
+  <https://www.home-assistant.io/integrations/>
+- Home Assistant integration manifest documentation:
+  <https://developers.home-assistant.io/docs/creating_integration_manifest/>
+- Home Assistant Core integration manifests:
+  <https://github.com/home-assistant/core/tree/dev/homeassistant/components>
+- Hubitat app overview:
+  <https://docs.hubitat.com/index.php?title=App_Overview>
+- Hubitat supported devices:
+  <https://docs.hubitat.com/index.php?title=List_of_Supported_Devices_v1>
+- Homey app store:
+  <https://homey.app/en-us/apps/>
+- SmartThings hub-connected device docs:
+  <https://developer.smartthings.com/docs/devices/hub-connected/get-started/>
+- openHAB add-ons:
+  <https://www.openhab.org/addons/>
+- Homebridge developer docs:
+  <https://developers.homebridge.io/homebridge/>
+- Homebridge plugin verification:
+  <https://github.com/homebridge/plugins>
+- ioBroker adapter source catalog:
+  <https://download.iobroker.net/sources-dist.json>
+- Domoticz hardware and protocols:
+  <https://wiki.domoticz.com/Hardware>
+  <https://wiki.domoticz.com/Integrations_and_Protocols>
+- Jeedom smart-home overview:
+  <https://jeedom.com/solutions/smart-home>
+- HomeSeer plugins:
+  <https://docs.homeseer.com/products/plugins>
+- D23 Smart Home Runtime: `code/specs/D23-smart-home-runtime.md`
+- D18 Chief of Staff: `code/specs/D18-chief-of-staff.md`
+- D18D Chief of Staff Tool API: `code/specs/D18D-chief-of-staff-tool-api.md`
+- D21 Capability Cage: `code/specs/D21-capability-cage.md`


### PR DESCRIPTION
## Summary
- Add D23A as a primitives-first smart-home integration catalog spec across Home Assistant, Hubitat, Homey Pro, SmartThings, openHAB, Homebridge, ioBroker, Domoticz, Jeedom, HomeSeer, and flow engines.
- Add the `smart-home-integration-catalog` Rust crate with category/connectivity/discovery/auth/status/primitive-family metadata, seed entries, virtual aliases, and query helpers.
- Treat Hue as the trial run for reusable primitives while deferring actual vendor adapters until the shared substrate is in place.

## Verification
- `cargo fmt --manifest-path code/packages/rust/Cargo.toml --package smart-home-integration-catalog`
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p smart-home-integration-catalog`
- `cargo clippy --manifest-path code/packages/rust/Cargo.toml -p smart-home-integration-catalog --no-deps -- -D warnings`
- `git diff --check`