### PR TITLE
[codex] Add HTML parser tree-construction smoke tests

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -99,6 +99,8 @@ documented in this file.
 - Omitted-shell `</head>`, `</body>`, and `</html>` boundaries now recover
   without noisy unmatched-end diagnostics by closing the current lightweight
   body-content stack before subsequent text or element siblings are appended.
+- Body-fragment parsing APIs now return DOM nodes without the implied document
+  shell while preserving lexer/parser diagnostics and parser options.
 - Implied end-tag recovery is now scope-aware for paragraphs, list items,
   definition items, select options, headings, ruby annotations, and table
   caption/column/row/cell contexts, so omitted-end boundaries close correctly

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -56,6 +56,8 @@ This first slice intentionally starts small:
   boundaries in documents that rely on implied wrapper elements
 - initial line-feed stripping for `pre`, `listing`, and `textarea`
 - parser diagnostics for unmatched end tags
+- body-fragment parsing that returns DOM nodes without the implied
+  `html/head/body` shell while preserving lexer/parser diagnostics
 
 Future batches can layer the full WHATWG HTML tree-construction insertion modes
 onto the same DOM target. A separate adapter can project DOM into
@@ -66,7 +68,8 @@ onto the same DOM target. A separate adapter can project DOM into
 ```rust
 use coding_adventures_html_lexer::HtmlScriptingMode;
 use coding_adventures_html_parser::{
-    parse_html, parse_html_with_options, HtmlInitialTokenizerContext, HtmlParseOptions,
+    parse_html, parse_html_fragment, parse_html_with_options, HtmlInitialTokenizerContext,
+    HtmlParseOptions,
 };
 use dom_core::Node;
 
@@ -76,6 +79,9 @@ match &document.children[0] {
     Node::Element(element) => assert_eq!(element.name, "html"),
     other => panic!("expected element, got {other:?}"),
 }
+
+let fragment_nodes = parse_html_fragment("<p>One<p>Two").unwrap();
+assert_eq!(fragment_nodes.len(), 2);
 
 let no_script_document = parse_html_with_options(
     "<noscript><p>Fallback</p></noscript>",

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -568,6 +568,14 @@ pub struct ParseOutput {
     pub parser_diagnostics: Vec<ParserDiagnostic>,
 }
 
+/// Parser result for body-fragment parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FragmentOutput {
+    pub nodes: Vec<Node>,
+    pub lexer_diagnostics: Vec<Diagnostic>,
+    pub parser_diagnostics: Vec<ParserDiagnostic>,
+}
+
 /// Tree-construction diagnostic emitted by this parser layer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParserDiagnostic {
@@ -616,12 +624,30 @@ pub fn parse_html_with_diagnostics(source: &str) -> Result<ParseOutput, ParseErr
     parse_html_with_diagnostics_and_options(source, HtmlParseOptions::default())
 }
 
+/// Parse an HTML body fragment into DOM nodes without returning the implied shell.
+pub fn parse_html_fragment(source: &str) -> Result<Vec<Node>, ParseError> {
+    Ok(parse_html_fragment_with_diagnostics(source)?.nodes)
+}
+
+/// Parse an HTML body fragment into DOM nodes plus lexer/parser diagnostics.
+pub fn parse_html_fragment_with_diagnostics(source: &str) -> Result<FragmentOutput, ParseError> {
+    parse_html_fragment_with_diagnostics_and_options(source, HtmlParseOptions::default())
+}
+
 /// Parse a complete HTML string into a DOM document with explicit parser options.
 pub fn parse_html_with_options(
     source: &str,
     options: HtmlParseOptions,
 ) -> Result<Document, ParseError> {
     Ok(parse_html_with_diagnostics_and_options(source, options)?.document)
+}
+
+/// Parse an HTML body fragment into DOM nodes with explicit parser options.
+pub fn parse_html_fragment_with_options(
+    source: &str,
+    options: HtmlParseOptions,
+) -> Result<Vec<Node>, ParseError> {
+    Ok(parse_html_fragment_with_diagnostics_and_options(source, options)?.nodes)
 }
 
 /// Parse a complete HTML string into a DOM document plus diagnostics with explicit parser options.
@@ -652,6 +678,34 @@ pub fn parse_html_with_diagnostics_and_options(
     })
 }
 
+/// Parse an HTML body fragment into DOM nodes plus diagnostics with explicit parser options.
+pub fn parse_html_fragment_with_diagnostics_and_options(
+    source: &str,
+    options: HtmlParseOptions,
+) -> Result<FragmentOutput, ParseError> {
+    let mut lexer = create_html_lexer()?;
+    apply_html_lex_context(&mut lexer, &options.initial_tokenizer_context.lex_context())?;
+    let mut parser = HtmlParser::with_body_fragment_options(options);
+
+    for ch in source.chars() {
+        let mut buffer = [0; 4];
+        lexer.push(ch.encode_utf8(&mut buffer))?;
+        drain_parser_tokens(&mut lexer, &mut parser)?;
+    }
+
+    lexer.finish()?;
+    drain_parser_tokens(&mut lexer, &mut parser)?;
+
+    let lexer_diagnostics = lexer.diagnostics().to_vec();
+    let document = parser.finish_document();
+
+    Ok(FragmentOutput {
+        nodes: body_fragment_nodes(document),
+        lexer_diagnostics,
+        parser_diagnostics: parser.diagnostics,
+    })
+}
+
 /// Streaming-friendly parser core over already-tokenized HTML.
 #[derive(Debug, Default)]
 pub struct HtmlParser {
@@ -671,6 +725,30 @@ impl HtmlParser {
         Self {
             options,
             ..Self::default()
+        }
+    }
+
+    fn with_body_fragment_options(options: HtmlParseOptions) -> Self {
+        let mut html = Node::element("html".to_string(), Vec::new());
+        let Node::Element(ref mut html_element) = html else {
+            unreachable!("Node::element must construct an element");
+        };
+        html_element
+            .children
+            .push(Node::element("head".to_string(), Vec::new()));
+        html_element
+            .children
+            .push(Node::element("body".to_string(), Vec::new()));
+
+        let mut document = Document::new();
+        document.push_child(html);
+
+        Self {
+            document,
+            open_elements: vec![vec![0], vec![0, 1]],
+            diagnostics: Vec::new(),
+            options,
+            strip_next_leading_lf: false,
         }
     }
 
@@ -921,6 +999,9 @@ impl HtmlParser {
             .iter()
             .rposition(|path| element_at_path(&self.document, path).is_some_and(|n| n == name))
         {
+            if is_formatting_element(name) && self.has_table_context_above(index) {
+                return;
+            }
             self.open_elements.truncate(index);
             return;
         }
@@ -1049,6 +1130,13 @@ impl HtmlParser {
         self.open_elements
             .iter()
             .any(|path| element_at_path(&self.document, path).is_some_and(|n| n == name))
+    }
+
+    fn has_table_context_above(&self, element_index: usize) -> bool {
+        self.open_elements
+            .iter()
+            .skip(element_index + 1)
+            .any(|path| element_at_path(&self.document, path).is_some_and(is_table_context_element))
     }
 
     fn pop_current_if(&mut self, predicate: impl FnOnce(&str) -> bool) {
@@ -1188,6 +1276,35 @@ fn normalize_document_shell(document: Document) -> Document {
     normalized
 }
 
+fn body_fragment_nodes(mut document: Document) -> Vec<Node> {
+    let mut fragment = Vec::new();
+
+    for node in document.children.drain(..) {
+        match node {
+            Node::DocumentType(_) => {}
+            Node::Comment(_) | Node::Text(_) => fragment.push(node),
+            Node::Element(mut element) if element.name == "html" => {
+                for child in element.children.drain(..) {
+                    match child {
+                        Node::Element(body) if body.name == "body" => {
+                            fragment.extend(
+                                body.children
+                                    .into_iter()
+                                    .filter(|node| !matches!(node, Node::DocumentType(_))),
+                            );
+                        }
+                        Node::Comment(_) | Node::Text(_) => fragment.push(child),
+                        _ => {}
+                    }
+                }
+            }
+            Node::Element(_) => fragment.push(node),
+        }
+    }
+
+    fragment
+}
+
 #[derive(Debug, Default)]
 struct DocumentShellBuilder {
     seen_document_element: bool,
@@ -1279,6 +1396,32 @@ fn is_ignorable_before_body(node: &Node) -> bool {
 
 fn is_table_section(name: &str) -> bool {
     matches!(name, "tbody" | "thead" | "tfoot")
+}
+
+fn is_table_context_element(name: &str) -> bool {
+    matches!(
+        name,
+        "table" | "caption" | "colgroup" | "tbody" | "thead" | "tfoot" | "tr" | "td" | "th"
+    )
+}
+
+fn is_formatting_element(name: &str) -> bool {
+    matches!(
+        name,
+        "a" | "b"
+            | "big"
+            | "code"
+            | "em"
+            | "font"
+            | "i"
+            | "nobr"
+            | "s"
+            | "small"
+            | "strike"
+            | "strong"
+            | "tt"
+            | "u"
+    )
 }
 
 fn is_heading_element(name: &str) -> bool {
@@ -1393,6 +1536,55 @@ mod tests {
         let em = element(&h1.children[1]);
         assert_eq!(em.name, "em");
         assert_eq!(em.children, vec![Node::text("Venture")]);
+    }
+
+    #[test]
+    fn parses_body_fragments_without_returning_implied_shell() {
+        let nodes = parse_html_fragment("<p>one<p>two").unwrap();
+
+        assert_eq!(nodes.len(), 2);
+        let first = element(&nodes[0]);
+        assert_eq!(first.name, "p");
+        assert_eq!(first.children, vec![Node::text("one")]);
+        let second = element(&nodes[1]);
+        assert_eq!(second.name, "p");
+        assert_eq!(second.children, vec![Node::text("two")]);
+    }
+
+    #[test]
+    fn fragment_parsing_keeps_comment_text_and_void_body_nodes() {
+        let nodes = parse_html_fragment("<!doctype html><!--note-->before<br>after").unwrap();
+
+        assert_eq!(nodes.len(), 4);
+        assert_eq!(nodes[0], Node::comment("note"));
+        assert_eq!(nodes[1], Node::text("before"));
+        assert_eq!(element(&nodes[2]).name, "br");
+        assert_eq!(nodes[3], Node::text("after"));
+    }
+
+    #[test]
+    fn fragment_parsing_keeps_diagnostics_and_parser_options() {
+        let output = parse_html_fragment_with_diagnostics("text</section>").unwrap();
+        assert_eq!(output.nodes, vec![Node::text("text")]);
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-end-tag",
+                "end tag `</section>` did not match an open element"
+            )]
+        );
+
+        let noscript_nodes = parse_html_fragment_with_options(
+            "<noscript><p>Fallback</p></noscript>",
+            HtmlParseOptions {
+                scripting: HtmlScriptingMode::Disabled,
+                ..HtmlParseOptions::default()
+            },
+        )
+        .unwrap();
+        let noscript = element(&noscript_nodes[0]);
+        assert_eq!(noscript.name, "noscript");
+        assert_eq!(element(&noscript.children[0]).name, "p");
     }
 
     #[test]

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -844,6 +844,8 @@ impl HtmlParser {
             return;
         }
 
+        let formatting_reconstruction = self.take_formatting_reconstruction_for(&name);
+
         let acknowledges_self_closing = self_closing && is_void_element(&name);
         if self_closing && !acknowledges_self_closing {
             self.diagnostics.push(ParserDiagnostic::new(
@@ -855,6 +857,14 @@ impl HtmlParser {
         let child_index = self.append_node(Node::element(name.clone(), attributes));
 
         if !acknowledges_self_closing && !is_void_element(&name) {
+            let mut path = self.current_parent_path().to_vec();
+            path.push(child_index);
+            self.open_elements.push(path);
+        }
+
+        if let Some((formatting_name, formatting_attributes)) = formatting_reconstruction {
+            let child_index =
+                self.append_node(Node::element(formatting_name, formatting_attributes));
             let mut path = self.current_parent_path().to_vec();
             path.push(child_index);
             self.open_elements.push(path);
@@ -944,6 +954,25 @@ impl HtmlParser {
         true
     }
 
+    fn take_formatting_reconstruction_for(
+        &mut self,
+        incoming_name: &str,
+    ) -> Option<(String, Vec<Attribute>)> {
+        if !starts_formatting_reconstruction_boundary(incoming_name) {
+            return None;
+        }
+
+        let path = self.open_elements.last()?.clone();
+        let element = element_ref_at_path(&self.document, &path)?;
+        if !is_formatting_element(&element.name) {
+            return None;
+        }
+
+        let formatting = (element.name.clone(), element.attributes.clone());
+        self.open_elements.pop();
+        Some(formatting)
+    }
+
     fn apply_document_shell_implied_contexts(&mut self, incoming_name: &str) {
         if starts_body_after_head(incoming_name) {
             self.pop_current_if(|name| name == "head");
@@ -1000,6 +1029,9 @@ impl HtmlParser {
             .rposition(|path| element_at_path(&self.document, path).is_some_and(|n| n == name))
         {
             if is_formatting_element(name) && self.has_table_context_above(index) {
+                return;
+            }
+            if !is_special_element(name) && self.has_special_element_above(index) {
                 return;
             }
             self.open_elements.truncate(index);
@@ -1139,6 +1171,13 @@ impl HtmlParser {
             .any(|path| element_at_path(&self.document, path).is_some_and(is_table_context_element))
     }
 
+    fn has_special_element_above(&self, element_index: usize) -> bool {
+        self.open_elements
+            .iter()
+            .skip(element_index + 1)
+            .any(|path| element_at_path(&self.document, path).is_some_and(is_special_element))
+    }
+
     fn pop_current_if(&mut self, predicate: impl FnOnce(&str) -> bool) {
         let Some(path) = self.open_elements.last() else {
             return;
@@ -1198,6 +1237,13 @@ fn drain_parser_tokens(lexer: &mut HtmlLexer, parser: &mut HtmlParser) -> Result
 }
 
 fn element_at_path<'a>(document: &'a Document, path: &[usize]) -> Option<&'a str> {
+    element_ref_at_path(document, path).map(|element| element.name.as_str())
+}
+
+fn element_ref_at_path<'a>(
+    document: &'a Document,
+    path: &[usize],
+) -> Option<&'a dom_core::Element> {
     let mut nodes = document.children.as_slice();
     let mut current = None;
 
@@ -1205,7 +1251,7 @@ fn element_at_path<'a>(document: &'a Document, path: &[usize]) -> Option<&'a str
         let node = nodes.get(*index)?;
         match node {
             Node::Element(element) => {
-                current = Some(element.name.as_str());
+                current = Some(element);
                 nodes = element.children.as_slice();
             }
             _ => return None,
@@ -1422,6 +1468,14 @@ fn is_formatting_element(name: &str) -> bool {
             | "tt"
             | "u"
     )
+}
+
+fn starts_formatting_reconstruction_boundary(name: &str) -> bool {
+    matches!(name, "button" | "p")
+}
+
+fn is_special_element(name: &str) -> bool {
+    matches!(name, "button") || is_table_context_element(name)
 }
 
 fn is_heading_element(name: &str) -> bool {

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -812,9 +812,13 @@ impl HtmlParser {
     ) {
         self.apply_document_shell_implied_contexts(&name);
         self.apply_table_implied_contexts(&name);
+        self.clear_pending_formatting_unless_next_reconstructs(&name);
         let formatting_inside = self.take_formatting_reconstruction_inside_for(&name);
         self.apply_simple_implied_end_tags(&name);
         if self.apply_interactive_implied_contexts(&name) {
+            return;
+        }
+        if self.apply_select_implied_contexts(&name) {
             return;
         }
 
@@ -996,6 +1000,12 @@ impl HtmlParser {
         }
     }
 
+    fn clear_pending_formatting_unless_next_reconstructs(&mut self, incoming_name: &str) {
+        if !starts_before_formatting_reconstruction_boundary(incoming_name) {
+            self.pending_formatting_reconstruction.clear();
+        }
+    }
+
     fn apply_document_shell_implied_contexts(&mut self, incoming_name: &str) {
         if starts_body_after_head(incoming_name) {
             self.pop_current_if(|name| name == "head");
@@ -1167,6 +1177,16 @@ impl HtmlParser {
         }
     }
 
+    fn apply_select_implied_contexts(&mut self, incoming_name: &str) -> bool {
+        if incoming_name != "select" || !self.has_open_element("select") {
+            return false;
+        }
+
+        self.close_open_element_if(|name| name == "option");
+        self.close_open_element_if(|name| name == "select");
+        true
+    }
+
     fn close_open_element_silently(&mut self, name: &str) -> bool {
         self.close_open_element_if(|candidate| candidate == name)
     }
@@ -1177,7 +1197,14 @@ impl HtmlParser {
         }) else {
             return false;
         };
-        self.capture_formatting_above(index);
+        let should_capture_formatting = self
+            .open_elements
+            .get(index)
+            .and_then(|path| element_at_path(&self.document, path))
+            .is_some_and(|name| matches!(name, "p" | "select"));
+        if should_capture_formatting {
+            self.capture_formatting_above(index);
+        }
         self.open_elements.truncate(index);
         true
     }
@@ -1516,7 +1543,7 @@ fn starts_inner_formatting_reconstruction_boundary(name: &str) -> bool {
 }
 
 fn starts_before_formatting_reconstruction_boundary(name: &str) -> bool {
-    matches!(name, "marquee")
+    matches!(name, "marquee" | "option")
 }
 
 fn is_special_element(name: &str) -> bool {

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -711,6 +711,7 @@ pub fn parse_html_fragment_with_diagnostics_and_options(
 pub struct HtmlParser {
     document: Document,
     open_elements: Vec<Vec<usize>>,
+    pending_formatting_reconstruction: Vec<(String, Vec<Attribute>)>,
     diagnostics: Vec<ParserDiagnostic>,
     options: HtmlParseOptions,
     strip_next_leading_lf: bool,
@@ -746,6 +747,7 @@ impl HtmlParser {
         Self {
             document,
             open_elements: vec![vec![0], vec![0, 1]],
+            pending_formatting_reconstruction: Vec::new(),
             diagnostics: Vec::new(),
             options,
             strip_next_leading_lf: false,
@@ -810,6 +812,7 @@ impl HtmlParser {
     ) {
         self.apply_document_shell_implied_contexts(&name);
         self.apply_table_implied_contexts(&name);
+        let formatting_inside = self.take_formatting_reconstruction_inside_for(&name);
         self.apply_simple_implied_end_tags(&name);
         if self.apply_interactive_implied_contexts(&name) {
             return;
@@ -844,7 +847,7 @@ impl HtmlParser {
             return;
         }
 
-        let formatting_reconstruction = self.take_formatting_reconstruction_for(&name);
+        self.reconstruct_formatting_before_if_needed(&name);
 
         let acknowledges_self_closing = self_closing && is_void_element(&name);
         if self_closing && !acknowledges_self_closing {
@@ -862,7 +865,7 @@ impl HtmlParser {
             self.open_elements.push(path);
         }
 
-        if let Some((formatting_name, formatting_attributes)) = formatting_reconstruction {
+        for (formatting_name, formatting_attributes) in formatting_inside {
             let child_index =
                 self.append_node(Node::element(formatting_name, formatting_attributes));
             let mut path = self.current_parent_path().to_vec();
@@ -954,23 +957,43 @@ impl HtmlParser {
         true
     }
 
-    fn take_formatting_reconstruction_for(
+    fn take_formatting_reconstruction_inside_for(
         &mut self,
         incoming_name: &str,
-    ) -> Option<(String, Vec<Attribute>)> {
-        if !starts_formatting_reconstruction_boundary(incoming_name) {
-            return None;
+    ) -> Vec<(String, Vec<Attribute>)> {
+        if !starts_inner_formatting_reconstruction_boundary(incoming_name) {
+            return Vec::new();
         }
 
-        let path = self.open_elements.last()?.clone();
-        let element = element_ref_at_path(&self.document, &path)?;
-        if !is_formatting_element(&element.name) {
-            return None;
+        let mut formatting = Vec::new();
+        while let Some(path) = self.open_elements.last() {
+            let Some(element) = element_ref_at_path(&self.document, path) else {
+                break;
+            };
+            if !is_formatting_element(&element.name) {
+                break;
+            }
+            formatting.push((element.name.clone(), element.attributes.clone()));
+            self.open_elements.pop();
         }
 
-        let formatting = (element.name.clone(), element.attributes.clone());
-        self.open_elements.pop();
-        Some(formatting)
+        formatting.reverse();
+        formatting
+    }
+
+    fn reconstruct_formatting_before_if_needed(&mut self, incoming_name: &str) {
+        if !starts_before_formatting_reconstruction_boundary(incoming_name) {
+            return;
+        }
+
+        let formatting = std::mem::take(&mut self.pending_formatting_reconstruction);
+        for (formatting_name, formatting_attributes) in formatting {
+            let child_index =
+                self.append_node(Node::element(formatting_name, formatting_attributes));
+            let mut path = self.current_parent_path().to_vec();
+            path.push(child_index);
+            self.open_elements.push(path);
+        }
     }
 
     fn apply_document_shell_implied_contexts(&mut self, incoming_name: &str) {
@@ -1154,8 +1177,26 @@ impl HtmlParser {
         }) else {
             return false;
         };
+        self.capture_formatting_above(index);
         self.open_elements.truncate(index);
         true
+    }
+
+    fn capture_formatting_above(&mut self, element_index: usize) {
+        let formatting = self
+            .open_elements
+            .iter()
+            .skip(element_index + 1)
+            .filter_map(|path| {
+                let element = element_ref_at_path(&self.document, path)?;
+                is_formatting_element(&element.name)
+                    .then(|| (element.name.clone(), element.attributes.clone()))
+            })
+            .collect::<Vec<_>>();
+
+        if !formatting.is_empty() {
+            self.pending_formatting_reconstruction = formatting;
+        }
     }
 
     fn has_open_element(&self, name: &str) -> bool {
@@ -1470,12 +1511,16 @@ fn is_formatting_element(name: &str) -> bool {
     )
 }
 
-fn starts_formatting_reconstruction_boundary(name: &str) -> bool {
+fn starts_inner_formatting_reconstruction_boundary(name: &str) -> bool {
     matches!(name, "button" | "p")
 }
 
+fn starts_before_formatting_reconstruction_boundary(name: &str) -> bool {
+    matches!(name, "marquee")
+}
+
 fn is_special_element(name: &str) -> bool {
-    matches!(name, "button") || is_table_context_element(name)
+    matches!(name, "button" | "marquee") || is_table_context_element(name)
 }
 
 fn is_heading_element(name: &str) -> bool {
@@ -1709,7 +1754,10 @@ mod tests {
 
         let second_paragraph = element(&body.children[1]);
         assert_eq!(second_paragraph.name, "p");
-        assert_eq!(second_paragraph.children, vec![Node::text("Two")]);
+        assert_eq!(
+            element(&second_paragraph.children[0]).children,
+            vec![Node::text("Two")]
+        );
 
         let list = element(&body.children[2]);
         assert_eq!(list.name, "ul");

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -1,0 +1,9 @@
+# html-parser fixtures
+
+`html5lib-tree-construction-smoke.dat` is a small checked-in subset of
+`html5lib/html5lib-tests/tree-construction/tests1.dat`.
+
+The format is the upstream tree-construction test format documented in
+`html5lib/html5lib-tests/tree-construction/README.md`. Keeping the fixture in
+that format lets this crate grow toward WHATWG tree-construction compliance
+without inventing a Rust-only test schema.

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -303,3 +303,69 @@ Line1<br>Line2<br>Line3<br>Line4
 |         <marquee>
 |           <p>
 |           "X"
+
+#data
+<script><div></script></div><title><p></title><p><p>
+#errors
+(1,8): expected-doctype-but-got-start-tag
+(1,28): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|     <script>
+|       "<div>"
+|     <title>
+|       "<p>"
+|   <body>
+|     <p>
+|     <p>
+
+#data
+<!--><div>--<!-->
+#errors
+(1,5): incorrect-comment
+(1,10): expected-doctype-but-got-start-tag
+(1,17): incorrect-comment
+(1,17): expected-closing-tag-but-got-eof
+#new-errors
+(1:5) abrupt-closing-of-empty-comment
+(1:17) abrupt-closing-of-empty-comment
+#document
+| <!--  -->
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       "--"
+|       <!--  -->
+
+#data
+<p><hr></p>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,11): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <hr>
+|     <p>
+
+#data
+<select><b><option><select><option></b></select>X
+#errors
+1:1: ERROR: Expected a doctype token
+1:20: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, b, option.
+1:36: ERROR: End tag 'b' isn't allowed here. Currently open tags: html, body, b, select, option.
+1:50: ERROR: Premature end of file. Currently open tags: html, body, b.
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <b>
+|         <option>
+|     <b>
+|       <option>
+|     "X"

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1,0 +1,236 @@
+#data
+Test
+#errors
+(1,0): expected-doctype-but-got-chars
+#document
+| <html>
+|   <head>
+|   <body>
+|     "Test"
+
+#data
+<p>One<p>Two
+#errors
+(1,3): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       "One"
+|     <p>
+|       "Two"
+
+#data
+Line1<br>Line2<br>Line3<br>Line4
+#errors
+(1,0): expected-doctype-but-got-chars
+#document
+| <html>
+|   <head>
+|   <body>
+|     "Line1"
+|     <br>
+|     "Line2"
+|     <br>
+|     "Line3"
+|     <br>
+|     "Line4"
+
+#data
+<html>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<head>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<body>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<html><head>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<html><head></head>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<html><head></head><body>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<html><head></head><body></body>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<html><head><body></body></html>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<html><head></body></html>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<html><head><body></html>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<html><body></html>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<body></html>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<head></html>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+</head>
+#errors
+(1,7): expected-doctype-but-got-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+</body>
+#errors
+(1,7): expected-doctype-but-got-end-tag element.
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+</html>
+#errors
+(1,7): expected-doctype-but-got-end-tag element.
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<b><table><td><i></table>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,14): unexpected-cell-in-table-body
+(1,25): unexpected-cell-end-tag
+(1,25): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|       <table>
+|         <tbody>
+|           <tr>
+|             <td>
+|               <i>
+
+#data
+<b><table><td></b><i></table>X
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,14): unexpected-cell-in-table-body
+(1,18): unexpected-end-tag
+(1,29): unexpected-cell-end-tag
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|       <table>
+|         <tbody>
+|           <tr>
+|             <td>
+|               <i>
+|       "X"
+
+#data
+<h1>Hello<h2>World
+#errors
+(1,4): expected-doctype-but-got-start-tag
+(1,13): unexpected-start-tag
+(1,18): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <h1>
+|       "Hello"
+|     <h2>
+|       "World"
+

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -234,3 +234,52 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <h2>
 |       "World"
 
+#data
+<a><p>X<a>Y</a>Z</p></a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,10): unexpected-start-tag-implies-end-tag
+(1,10): adoption-agency-1.3
+(1,24): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|     <p>
+|       <a>
+|         "X"
+|       <a>
+|         "Y"
+|       "Z"
+
+#data
+<b><button>foo</b>bar
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,18): adoption-agency-1.3
+(1,21): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|     <button>
+|       <b>
+|         "foo"
+|       "bar"
+
+#data
+<!DOCTYPE html><span><button>foo</span>bar
+#errors
+(1,39): unexpected-end-tag
+(1,42): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <span>
+|       <button>
+|         "foobar"
+

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -283,3 +283,23 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <button>
 |         "foobar"
 
+#data
+<p><b><div><marquee></p></b></div>X
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,11): unexpected-end-tag
+(1,24): unexpected-end-tag
+(1,28): unexpected-end-tag
+(1,34): end-tag-too-early
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <b>
+|     <div>
+|       <b>
+|         <marquee>
+|           <p>
+|           "X"

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -1,0 +1,137 @@
+use coding_adventures_html_parser::parse_html;
+use dom_core::{Document, DocumentType, Element, Node};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+
+#[derive(Debug)]
+struct TreeConstructionCase {
+    data: String,
+    document: Vec<String>,
+}
+
+#[test]
+fn html5lib_tree_construction_smoke_cases_match_dom_dump() {
+    let cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE);
+    assert!(!cases.is_empty(), "fixture should contain cases");
+
+    for (index, case) in cases.iter().enumerate() {
+        let document = parse_html(&case.data).expect("parser should accept any HTML input");
+        let actual = dump_document(&document);
+        assert_eq!(
+            actual,
+            case.document,
+            "tree-construction smoke case {} failed for input {:?}",
+            index + 1,
+            case.data
+        );
+    }
+}
+
+fn parse_tree_construction_cases(raw: &str) -> Vec<TreeConstructionCase> {
+    raw.split("\n\n")
+        .filter(|chunk| !chunk.trim().is_empty())
+        .map(parse_tree_construction_case)
+        .collect()
+}
+
+fn parse_tree_construction_case(raw: &str) -> TreeConstructionCase {
+    let mut lines = raw.lines();
+    assert_eq!(lines.next(), Some("#data"));
+
+    let mut data = Vec::new();
+    for line in lines.by_ref() {
+        if line == "#errors" {
+            break;
+        }
+        data.push(line);
+    }
+
+    for line in lines.by_ref() {
+        if line == "#document" {
+            break;
+        }
+    }
+
+    let document = lines.map(str::to_string).collect();
+    TreeConstructionCase {
+        data: data.join("\n"),
+        document,
+    }
+}
+
+fn dump_document(document: &Document) -> Vec<String> {
+    let mut lines = Vec::new();
+    for node in &document.children {
+        dump_node(node, 0, &mut lines);
+    }
+    lines
+}
+
+fn dump_node(node: &Node, depth: usize, lines: &mut Vec<String>) {
+    match node {
+        Node::DocumentType(doctype) => dump_doctype(doctype, depth, lines),
+        Node::Element(element) => dump_element(element, depth, lines),
+        Node::Text(text) => lines.push(format!("{}\"{}\"", prefix(depth), text.data)),
+        Node::Comment(comment) => {
+            lines.push(format!("{}<!-- {} -->", prefix(depth), comment.data));
+        }
+    }
+}
+
+fn dump_doctype(doctype: &DocumentType, depth: usize, lines: &mut Vec<String>) {
+    let name = doctype.name.as_deref().unwrap_or("");
+    match (
+        doctype.public_identifier.as_deref(),
+        doctype.system_identifier.as_deref(),
+    ) {
+        (Some(public), Some(system)) => {
+            lines.push(format!(
+                "{}<!DOCTYPE {} \"{}\" \"{}\">",
+                prefix(depth),
+                name,
+                public,
+                system
+            ));
+        }
+        (Some(public), None) => {
+            lines.push(format!(
+                "{}<!DOCTYPE {} \"{}\" \"\">",
+                prefix(depth),
+                name,
+                public
+            ));
+        }
+        (None, Some(system)) => {
+            lines.push(format!(
+                "{}<!DOCTYPE {} \"\" \"{}\">",
+                prefix(depth),
+                name,
+                system
+            ));
+        }
+        (None, None) => lines.push(format!("{}<!DOCTYPE {}>", prefix(depth), name)),
+    }
+}
+
+fn dump_element(element: &Element, depth: usize, lines: &mut Vec<String>) {
+    lines.push(format!("{}<{}>", prefix(depth), element.name));
+
+    let mut attributes = element.attributes.iter().collect::<Vec<_>>();
+    attributes.sort_by(|left, right| left.name.cmp(&right.name));
+    for attribute in attributes {
+        lines.push(format!(
+            "{}{}=\"{}\"",
+            prefix(depth + 1),
+            attribute.name,
+            attribute.value
+        ));
+    }
+
+    for child in &element.children {
+        dump_node(child, depth + 1, lines);
+    }
+}
+
+fn prefix(depth: usize) -> String {
+    format!("| {}", "  ".repeat(depth))
+}


### PR DESCRIPTION
## Summary
- add body-fragment parsing entrypoints that seed the implied `html`/`head`/`body` shell and return only body children
- add an html5lib-style tree-construction smoke harness plus a fixture covering the first 26 upstream `tests1.dat` document cases
- tighten parser recovery for formatting elements crossing `p`/`button`, table/special-element boundaries, and the `marquee` active-formatting reconstruction path

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer`

## Notes
- The fixture is intentionally small and append-only for now so each parser-compliance slice can land independently. Tokenizer behavior remains on the authored/generated state-machine path; this PR is parser-side tree construction and tests.