### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 30

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -812,9 +812,13 @@ impl HtmlParser {
     ) {
         self.apply_document_shell_implied_contexts(&name);
         self.apply_table_implied_contexts(&name);
+        self.clear_pending_formatting_unless_next_reconstructs(&name);
         let formatting_inside = self.take_formatting_reconstruction_inside_for(&name);
         self.apply_simple_implied_end_tags(&name);
         if self.apply_interactive_implied_contexts(&name) {
+            return;
+        }
+        if self.apply_select_implied_contexts(&name) {
             return;
         }
 
@@ -996,6 +1000,12 @@ impl HtmlParser {
         }
     }
 
+    fn clear_pending_formatting_unless_next_reconstructs(&mut self, incoming_name: &str) {
+        if !starts_before_formatting_reconstruction_boundary(incoming_name) {
+            self.pending_formatting_reconstruction.clear();
+        }
+    }
+
     fn apply_document_shell_implied_contexts(&mut self, incoming_name: &str) {
         if starts_body_after_head(incoming_name) {
             self.pop_current_if(|name| name == "head");
@@ -1167,6 +1177,16 @@ impl HtmlParser {
         }
     }
 
+    fn apply_select_implied_contexts(&mut self, incoming_name: &str) -> bool {
+        if incoming_name != "select" || !self.has_open_element("select") {
+            return false;
+        }
+
+        self.close_open_element_if(|name| name == "option");
+        self.close_open_element_if(|name| name == "select");
+        true
+    }
+
     fn close_open_element_silently(&mut self, name: &str) -> bool {
         self.close_open_element_if(|candidate| candidate == name)
     }
@@ -1177,7 +1197,14 @@ impl HtmlParser {
         }) else {
             return false;
         };
-        self.capture_formatting_above(index);
+        let should_capture_formatting = self
+            .open_elements
+            .get(index)
+            .and_then(|path| element_at_path(&self.document, path))
+            .is_some_and(|name| matches!(name, "p" | "select"));
+        if should_capture_formatting {
+            self.capture_formatting_above(index);
+        }
         self.open_elements.truncate(index);
         true
     }
@@ -1516,7 +1543,7 @@ fn starts_inner_formatting_reconstruction_boundary(name: &str) -> bool {
 }
 
 fn starts_before_formatting_reconstruction_boundary(name: &str) -> bool {
-    matches!(name, "marquee")
+    matches!(name, "marquee" | "option")
 }
 
 fn is_special_element(name: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -303,3 +303,69 @@ Line1<br>Line2<br>Line3<br>Line4
 |         <marquee>
 |           <p>
 |           "X"
+
+#data
+<script><div></script></div><title><p></title><p><p>
+#errors
+(1,8): expected-doctype-but-got-start-tag
+(1,28): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|     <script>
+|       "<div>"
+|     <title>
+|       "<p>"
+|   <body>
+|     <p>
+|     <p>
+
+#data
+<!--><div>--<!-->
+#errors
+(1,5): incorrect-comment
+(1,10): expected-doctype-but-got-start-tag
+(1,17): incorrect-comment
+(1,17): expected-closing-tag-but-got-eof
+#new-errors
+(1:5) abrupt-closing-of-empty-comment
+(1:17) abrupt-closing-of-empty-comment
+#document
+| <!--  -->
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       "--"
+|       <!--  -->
+
+#data
+<p><hr></p>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,11): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <hr>
+|     <p>
+
+#data
+<select><b><option><select><option></b></select>X
+#errors
+1:1: ERROR: Expected a doctype token
+1:20: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, b, option.
+1:36: ERROR: End tag 'b' isn't allowed here. Currently open tags: html, body, b, select, option.
+1:50: ERROR: Premature end of file. Currently open tags: html, body, b.
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <b>
+|         <option>
+|     <b>
+|       <option>
+|     "X"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture from the first 26 upstream `tests1.dat` document cases through case 30
- handle nested `<select>` start tags by closing the existing select scope instead of nesting a second select
- keep pending formatting reconstruction short-lived and reconstruct formatting before the follow-up `<option>` needed by the nested-select recovery path

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`

## Notes
- This is stacked on #2397 and deliberately stops before upstream case 31, which enters adoption-agency plus table/foster-parenting behavior and deserves a separate design slice.