### PR TITLE
Add Rust MACSYMA runtime session

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -164,6 +164,7 @@ members = [
     "macsyma-lexer",
     "macsyma-parser",
     "macsyma-compiler",
+    "macsyma-runtime",
     "logic-gates",
     "loss-functions",
     "markov-chain",

--- a/code/packages/rust/macsyma-runtime/BUILD
+++ b/code/packages/rust/macsyma-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-macsyma-runtime -- --nocapture

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - 2026-05-08
+
+### Added
+
+- Initial Rust MACSYMA runtime session facade.
+- Source-to-IR compilation, symbolic VM evaluation, display/suppress result metadata, and in-memory input/output history.

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "coding-adventures-macsyma-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "MACSYMA runtime session facade over the Rust symbolic VM"
+license = "MIT"
+
+[dependencies]
+coding-adventures-macsyma-compiler = { path = "../macsyma-compiler" }
+symbolic-ir = { path = "../symbolic-ir" }
+symbolic-vm = { path = "../symbolic-vm" }

--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -1,0 +1,9 @@
+# coding-adventures-macsyma-runtime
+
+Rust MACSYMA runtime session facade over the statically linked MACSYMA compiler
+and `symbolic-vm`.
+
+This first slice is intentionally small: it compiles MACSYMA source, evaluates
+statements through the Rust symbolic VM, preserves `;` versus `$` display
+metadata, and records in-memory `%i`/`%o`-style history for a future REPL/WASM
+facade.

--- a/code/packages/rust/macsyma-runtime/required_capabilities.json
+++ b/code/packages/rust/macsyma-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/macsyma-runtime",
+  "capabilities": [],
+  "justification": "Pure in-memory MACSYMA evaluation over symbolic IR. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -1,0 +1,159 @@
+//! MACSYMA runtime session facade.
+//!
+//! This crate is the first Rust runtime layer above the grammar-driven
+//! MACSYMA compiler. It keeps the public API pure and WASM-friendly: callers
+//! pass source strings in and receive evaluated IR nodes plus display metadata.
+
+use coding_adventures_macsyma_compiler::{
+    compile_macsyma_with_options, CompileError, CompileOptions, DISPLAY, SUPPRESS,
+};
+use symbolic_ir::{sym, IRNode};
+use symbolic_vm::{SymbolicBackend, VM};
+
+/// One evaluated MACSYMA statement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvalResult {
+    /// The 1-based input index, matching MACSYMA's `%iN` convention.
+    pub input_index: usize,
+    /// The 1-based output index, matching MACSYMA's `%oN` convention.
+    pub output_index: usize,
+    /// The compiled input expression with display/suppress wrapper removed.
+    pub input: IRNode,
+    /// The evaluated output expression.
+    pub output: IRNode,
+    /// Whether this statement should be shown by a REPL. `;` displays, `$`
+    /// suppresses.
+    pub display: bool,
+}
+
+/// In-memory `%i`/`%o` history for a single runtime session.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct History {
+    inputs: Vec<IRNode>,
+    outputs: Vec<IRNode>,
+}
+
+impl History {
+    pub fn record_input(&mut self, node: IRNode) -> usize {
+        self.inputs.push(node);
+        self.inputs.len()
+    }
+
+    pub fn record_output(&mut self, node: IRNode) -> usize {
+        self.outputs.push(node);
+        self.outputs.len()
+    }
+
+    pub fn get_input(&self, index: usize) -> Option<&IRNode> {
+        index.checked_sub(1).and_then(|idx| self.inputs.get(idx))
+    }
+
+    pub fn get_output(&self, index: usize) -> Option<&IRNode> {
+        index.checked_sub(1).and_then(|idx| self.outputs.get(idx))
+    }
+
+    pub fn last_output(&self) -> Option<&IRNode> {
+        self.outputs.last()
+    }
+
+    pub fn next_input_index(&self) -> usize {
+        self.inputs.len() + 1
+    }
+
+    pub fn inputs(&self) -> &[IRNode] {
+        &self.inputs
+    }
+
+    pub fn outputs(&self) -> &[IRNode] {
+        &self.outputs
+    }
+
+    pub fn reset(&mut self) {
+        self.inputs.clear();
+        self.outputs.clear();
+    }
+}
+
+/// Stateful MACSYMA evaluator over the Rust symbolic VM.
+pub struct MacsymaSession {
+    vm: VM,
+    history: History,
+}
+
+impl MacsymaSession {
+    pub fn new() -> Self {
+        let mut backend = SymbolicBackend::new();
+        backend.pre_bind("%pi", IRNode::Float(std::f64::consts::PI));
+        backend.pre_bind("%e", IRNode::Float(std::f64::consts::E));
+        backend.pre_bind("%i", sym("ImaginaryUnit"));
+        Self {
+            vm: VM::new(Box::new(backend)),
+            history: History::default(),
+        }
+    }
+
+    pub fn history(&self) -> &History {
+        &self.history
+    }
+
+    pub fn history_mut(&mut self) -> &mut History {
+        &mut self.history
+    }
+
+    /// Compile and evaluate every statement in `source`.
+    pub fn eval_source(&mut self, source: &str) -> Result<Vec<EvalResult>, CompileError> {
+        let statements = compile_macsyma_with_options(
+            source,
+            CompileOptions {
+                wrap_terminators: true,
+            },
+        )?;
+        Ok(self.eval_statements(statements))
+    }
+
+    /// Evaluate already-compiled statements. Display wrappers are honored when
+    /// present; unwrapped statements default to display=true.
+    pub fn eval_statements(&mut self, statements: Vec<IRNode>) -> Vec<EvalResult> {
+        statements
+            .into_iter()
+            .map(|statement| self.eval_statement(statement))
+            .collect()
+    }
+
+    fn eval_statement(&mut self, statement: IRNode) -> EvalResult {
+        let (input, display) = unwrap_display(statement);
+        let input_index = self.history.record_input(input.clone());
+        let output = self.vm.eval(input.clone());
+        let output_index = self.history.record_output(output.clone());
+        EvalResult {
+            input_index,
+            output_index,
+            input,
+            output,
+            display,
+        }
+    }
+}
+
+impl Default for MacsymaSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn unwrap_display(statement: IRNode) -> (IRNode, bool) {
+    if let IRNode::Apply(apply) = statement {
+        if apply.args.len() == 1 {
+            if let IRNode::Symbol(head) = &apply.head {
+                if head == DISPLAY {
+                    return (apply.args[0].clone(), true);
+                }
+                if head == SUPPRESS {
+                    return (apply.args[0].clone(), false);
+                }
+            }
+        }
+        return (IRNode::Apply(apply), true);
+    }
+    (statement, true)
+}

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -1,0 +1,70 @@
+use coding_adventures_macsyma_runtime::MacsymaSession;
+use symbolic_ir::{apply, int, sym, MUL, POW};
+
+#[test]
+fn evaluates_arithmetic_program() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("1 + 2 * 3;").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].output, int(7));
+    assert!(results[0].display);
+}
+
+#[test]
+fn preserves_suppressed_statement_metadata() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("x : 5$ x + 1;").unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(!results[0].display);
+    assert!(results[1].display);
+    assert_eq!(results[1].output, int(6));
+}
+
+#[test]
+fn records_input_and_output_history() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("x : 5$ x + 2;").unwrap();
+    assert_eq!(results[0].input_index, 1);
+    assert_eq!(results[1].input_index, 2);
+    assert_eq!(session.history().get_output(1), Some(&int(5)));
+    assert_eq!(session.history().last_output(), Some(&int(7)));
+}
+
+#[test]
+fn evaluates_function_definitions_across_statements() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("f(x) := x^2; f(4);").unwrap();
+    assert_eq!(results[0].output, sym("f"));
+    assert_eq!(results[1].output, int(16));
+}
+
+#[test]
+fn leaves_symbolic_results_unevaluated_when_needed() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("(x + 0) * (y^2);").unwrap();
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![sym("x"), apply(sym(POW), vec![sym("y"), int(2)])]
+        )
+    );
+}
+
+#[test]
+fn prebinds_macsyma_numeric_constants() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("%pi; %e;").unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results[0].output.to_string().starts_with("3.14159"));
+    assert!(results[1].output.to_string().starts_with("2.71828"));
+}
+
+#[test]
+fn history_can_be_reset() {
+    let mut session = MacsymaSession::new();
+    session.eval_source("1; 2;").unwrap();
+    session.history_mut().reset();
+    assert_eq!(session.history().next_input_index(), 1);
+    assert!(session.history().last_output().is_none());
+}


### PR DESCRIPTION
## Summary
- add a pure Rust `macsyma-runtime` crate over the grammar-driven MACSYMA compiler and symbolic VM
- evaluate MACSYMA source with persistent VM bindings, display/suppress metadata, and in-memory `%i`/`%o`-style history
- cover arithmetic, assignment, function definitions, symbolic output, constants, suppression, and history reset

## Validation
- `cargo test -p coding-adventures-macsyma-runtime -- --nocapture`
- `cargo test -p coding-adventures-macsyma-lexer -p coding-adventures-macsyma-parser -p coding-adventures-macsyma-compiler -p coding-adventures-macsyma-runtime -- --nocapture`
- `PATH=/Users/adhithya/.cargo/bin:$PATH cargo check --target wasm32-unknown-unknown -p coding-adventures-macsyma-runtime`
- `./build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/rust-macsyma-runtime-build-plan.json`