### PR TITLE
[codex] Add smart-home testkit registry fixtures

### DIFF
--- a/code/packages/rust/smart-home-testkit/CHANGELOG.md
+++ b/code/packages/rust/smart-home-testkit/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - Deterministic fixture clock for freshness and supervisor tests.
 - Normalized Hue-like bridge, device, light entity, and sensor entity fixtures.
+- Registry seeding helpers for installing normalized fixture records into the
+  in-memory smart-home registry.
 - Helpers for confirmed, stale, and optimistic state snapshots.
 - Helpers for update, unavailable, and error device events.
 - Scripted fake event stream with event, disconnect, and gap markers.

--- a/code/packages/rust/smart-home-testkit/Cargo.toml
+++ b/code/packages/rust/smart-home-testkit/Cargo.toml
@@ -7,3 +7,4 @@ license = "MIT"
 
 [dependencies]
 smart-home-core = { path = "../smart-home-core" }
+smart-home-registry = { path = "../smart-home-registry" }

--- a/code/packages/rust/smart-home-testkit/README.md
+++ b/code/packages/rust/smart-home-testkit/README.md
@@ -8,6 +8,8 @@ It gives future Hue, MQTT, Zigbee, Z-Wave, Thread, Matter, and runtime packages
 a shared way to build:
 
 - normalized bridge/device/entity fixtures
+- registry seeding helpers for installing fixture records into
+  `smart-home-registry`
 - confirmed, stale, and optimistic state snapshots
 - deterministic device events
 - scripted fake event streams with disconnect and gap markers
@@ -16,6 +18,7 @@ a shared way to build:
 ## Dependencies
 
 - `smart-home-core`
+- `smart-home-registry`
 
 ## Development
 

--- a/code/packages/rust/smart-home-testkit/src/lib.rs
+++ b/code/packages/rust/smart-home-testkit/src/lib.rs
@@ -12,6 +12,7 @@ use smart_home_core::{
     IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier, StateConfidence, StateDelta,
     StateSnapshot, StateSource, Value,
 };
+use smart_home_registry::{InMemorySmartHomeRegistry, RegistryError};
 use std::collections::VecDeque;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,6 +66,17 @@ impl SmartHomeFixture {
 
     pub fn entities(&self) -> [&Entity; 2] {
         [&self.light, &self.sensor]
+    }
+
+    pub fn install_in_registry(
+        &self,
+        registry: &mut InMemorySmartHomeRegistry,
+    ) -> Result<(), RegistryError> {
+        install_fixture_in_registry(registry, self)
+    }
+
+    pub fn to_registry(&self) -> Result<InMemorySmartHomeRegistry, RegistryError> {
+        registry_with_fixture(self)
     }
 }
 
@@ -302,6 +314,32 @@ pub fn error_event(
     }
 }
 
+pub fn install_fixture_in_registry(
+    registry: &mut InMemorySmartHomeRegistry,
+    fixture: &SmartHomeFixture,
+) -> Result<(), RegistryError> {
+    registry.upsert_bridge(fixture.bridge.clone())?;
+    registry.upsert_device(fixture.device.clone())?;
+    for entity in fixture.entities() {
+        registry.upsert_entity(entity.clone())?;
+    }
+    Ok(())
+}
+
+pub fn registry_with_fixture(
+    fixture: &SmartHomeFixture,
+) -> Result<InMemorySmartHomeRegistry, RegistryError> {
+    let mut registry = InMemorySmartHomeRegistry::new();
+    install_fixture_in_registry(&mut registry, fixture)?;
+    Ok(registry)
+}
+
+pub fn hue_lighting_registry() -> InMemorySmartHomeRegistry {
+    SmartHomeFixture::hue_lighting()
+        .to_registry()
+        .expect("hue lighting fixture records are internally consistent")
+}
+
 fn protocol_id(
     family: ProtocolFamily,
     kind: &'static str,
@@ -399,5 +437,64 @@ mod tests {
         assert_eq!(unavailable.event_type, DeviceEventType::Unavailable);
         assert_eq!(error.event_type, DeviceEventType::Error);
         assert_eq!(error.raw_ref.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn fixture_installs_normalized_records_into_registry() {
+        let fixture = SmartHomeFixture::hue_lighting();
+        let registry = fixture.to_registry().unwrap();
+
+        assert_eq!(registry.counts().bridges, 1);
+        assert_eq!(registry.counts().devices, 1);
+        assert_eq!(registry.counts().entities, 2);
+        assert_eq!(registry.counts().protocol_identifiers, 2);
+        assert_eq!(
+            registry
+                .bridge(&fixture.bridge.bridge_id)
+                .unwrap()
+                .bridge_id,
+            fixture.bridge.bridge_id
+        );
+        assert_eq!(
+            registry
+                .device(&fixture.device.device_id)
+                .unwrap()
+                .entity_ids,
+            vec![
+                fixture.light.entity_id.clone(),
+                fixture.sensor.entity_id.clone()
+            ]
+        );
+        assert_eq!(
+            registry.entity(&fixture.light.entity_id).unwrap().kind,
+            EntityKind::Light
+        );
+        assert_eq!(
+            registry.entity(&fixture.sensor.entity_id).unwrap().kind,
+            EntityKind::Sensor
+        );
+    }
+
+    #[test]
+    fn hue_lighting_registry_is_ready_for_event_replay() {
+        let fixture = SmartHomeFixture::hue_lighting();
+        let mut registry = hue_lighting_registry();
+        let event = light_on_event(
+            "event-1",
+            &fixture.bridge.bridge_id,
+            &fixture.device.device_id,
+            &fixture.light.entity_id,
+            2_000,
+        );
+
+        registry.record_event(event).unwrap();
+
+        let state = registry.state(&fixture.light.entity_id).unwrap();
+        assert_eq!(registry.counts().events, 1);
+        assert_eq!(state.confidence, StateConfidence::Confirmed);
+        assert_eq!(
+            state.value,
+            Value::Object(vec![("light.on_off".to_string(), Value::Bool(true))])
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add smart-home-testkit helpers to install normalized Hue fixture records into the in-memory smart-home registry
- expose a ready-to-use Hue lighting registry fixture for runtime and integration tests
- cover registry seeding and event replay through the fixture records

## Validation
- cargo fmt --manifest-path code/packages/rust/Cargo.toml --package smart-home-testkit
- cargo test --manifest-path code/packages/rust/Cargo.toml -p smart-home-testkit
- cargo clippy --manifest-path code/packages/rust/Cargo.toml -p smart-home-testkit --no-deps -- -D warnings
- git diff --check origin/main..HEAD