### PR TITLE
Add MACSYMA runtime WASM bindings

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -165,6 +165,7 @@ members = [
     "macsyma-parser",
     "macsyma-compiler",
     "macsyma-runtime",
+    "macsyma-wasm",
     "logic-gates",
     "loss-functions",
     "markov-chain",

--- a/code/packages/rust/macsyma-wasm/BUILD
+++ b/code/packages/rust/macsyma-wasm/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-macsyma-wasm -- --nocapture

--- a/code/packages/rust/macsyma-wasm/CHANGELOG.md
+++ b/code/packages/rust/macsyma-wasm/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add JSON-oriented WASM facade for the Rust MACSYMA runtime.

--- a/code/packages/rust/macsyma-wasm/Cargo.toml
+++ b/code/packages/rust/macsyma-wasm/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-macsyma-wasm"
+version = "0.1.0"
+edition = "2021"
+description = "JSON support facade for the Rust MACSYMA WASM bindings"
+license = "MIT"
+
+[dependencies]
+cas-pretty-printer = { path = "../cas-pretty-printer" }
+coding-adventures-macsyma-runtime = { path = "../macsyma-runtime" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+symbolic-ir = { path = "../symbolic-ir" }

--- a/code/packages/rust/macsyma-wasm/README.md
+++ b/code/packages/rust/macsyma-wasm/README.md
@@ -1,0 +1,10 @@
+# coding-adventures-macsyma-wasm
+
+JSON-oriented support facade over `coding-adventures-macsyma-runtime` for the
+browser/WASM binding package.
+
+This crate keeps the boundary intentionally simple: callers provide MACSYMA
+source text and receive JSON strings containing display metadata, pretty
+MACSYMA text, Lisp-style IR text, recursive IR JSON, and session history
+indices. The actual `wasm-bindgen` exports live in
+`code/packages/wasm/macsyma-runtime`.

--- a/code/packages/rust/macsyma-wasm/required_capabilities.json
+++ b/code/packages/rust/macsyma-wasm/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/macsyma-wasm",
+  "capabilities": [],
+  "justification": "Pure in-memory JSON facade over the MACSYMA runtime. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/macsyma-wasm/src/lib.rs
+++ b/code/packages/rust/macsyma-wasm/src/lib.rs
@@ -1,0 +1,328 @@
+//! Browser/WASM-facing JSON facade for the Rust MACSYMA runtime.
+//!
+//! The core runtime stays typed and Rust-native. This crate provides a stable
+//! string boundary for browser embeddings: source text in, JSON result out.
+
+use cas_pretty_printer::{format_lisp, pretty, MacsymaDialect};
+use coding_adventures_macsyma_runtime::{EvalResult, History, MacsymaSession};
+use serde::Serialize;
+use std::any::Any;
+use std::panic::{catch_unwind, set_hook, take_hook, AssertUnwindSafe};
+use std::sync::{Mutex, OnceLock};
+use symbolic_ir::IRNode;
+
+/// Stateful MACSYMA session with JSON result helpers.
+pub struct MacsymaWasmSession {
+    session: MacsymaSession,
+}
+
+impl MacsymaWasmSession {
+    pub fn new() -> Self {
+        Self {
+            session: MacsymaSession::new(),
+        }
+    }
+
+    /// Evaluate MACSYMA source and return a JSON string.
+    ///
+    /// The returned JSON always has an `ok` boolean. Compile errors are encoded
+    /// as `{ "ok": false, "error": { ... } }` so JS callers do not need Rust
+    /// error plumbing to render diagnostics.
+    pub fn eval_json(&mut self, source: &str) -> String {
+        match catch_parser_panics(|| self.session.eval_source(source)) {
+            Ok(Ok(results)) => encode_response(EvalResponse::ok(results, self.session.history())),
+            Ok(Err(error)) => {
+                encode_response(EvalResponse::err(error.to_string(), self.session.history()))
+            }
+            Err(payload) => encode_response(EvalResponse::err(
+                panic_payload_to_string(&payload),
+                self.session.history(),
+            )),
+        }
+    }
+
+    pub fn history_json(&self) -> String {
+        encode_response(HistoryResponse {
+            ok: true,
+            history: JsonHistory::from_history(self.session.history()),
+        })
+    }
+
+    pub fn reset_history(&mut self) {
+        self.session.history_mut().reset();
+    }
+
+    pub fn inner(&self) -> &MacsymaSession {
+        &self.session
+    }
+}
+
+impl Default for MacsymaWasmSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Stateless convenience function for single-shot browser calls.
+pub fn eval_source_json(source: &str) -> String {
+    let mut session = MacsymaWasmSession::new();
+    session.eval_json(source)
+}
+
+#[derive(Serialize)]
+struct EvalResponse {
+    ok: bool,
+    results: Vec<JsonEvalResult>,
+    visible_outputs: Vec<String>,
+    history: JsonHistory,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonError>,
+}
+
+impl EvalResponse {
+    fn ok(results: Vec<EvalResult>, history: &History) -> Self {
+        let results = results
+            .into_iter()
+            .map(JsonEvalResult::from_result)
+            .collect::<Vec<_>>();
+        let visible_outputs = results
+            .iter()
+            .filter(|result| result.display)
+            .map(|result| result.output_macsyma.clone())
+            .collect();
+        Self {
+            ok: true,
+            results,
+            visible_outputs,
+            history: JsonHistory::from_history(history),
+            error: None,
+        }
+    }
+
+    fn err(message: String, history: &History) -> Self {
+        Self {
+            ok: false,
+            results: Vec::new(),
+            visible_outputs: Vec::new(),
+            history: JsonHistory::from_history(history),
+            error: Some(JsonError {
+                kind: "compile".to_string(),
+                message,
+            }),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct HistoryResponse {
+    ok: bool,
+    history: JsonHistory,
+}
+
+#[derive(Serialize)]
+struct JsonEvalResult {
+    input_index: usize,
+    output_index: usize,
+    display: bool,
+    input_macsyma: String,
+    output_macsyma: String,
+    input_lisp: String,
+    output_lisp: String,
+    input_ir: JsonIrNode,
+    output_ir: JsonIrNode,
+}
+
+impl JsonEvalResult {
+    fn from_result(result: EvalResult) -> Self {
+        Self {
+            input_index: result.input_index,
+            output_index: result.output_index,
+            display: result.display,
+            input_macsyma: pretty(&result.input, &MacsymaDialect),
+            output_macsyma: pretty(&result.output, &MacsymaDialect),
+            input_lisp: format_lisp(&result.input),
+            output_lisp: format_lisp(&result.output),
+            input_ir: JsonIrNode::from_ir(&result.input),
+            output_ir: JsonIrNode::from_ir(&result.output),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct JsonHistory {
+    input_count: usize,
+    output_count: usize,
+    next_input_index: usize,
+    last_output_macsyma: Option<String>,
+    last_output_lisp: Option<String>,
+}
+
+impl JsonHistory {
+    fn from_history(history: &History) -> Self {
+        Self {
+            input_count: history.inputs().len(),
+            output_count: history.outputs().len(),
+            next_input_index: history.next_input_index(),
+            last_output_macsyma: history
+                .last_output()
+                .map(|output| pretty(output, &MacsymaDialect)),
+            last_output_lisp: history.last_output().map(format_lisp),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct JsonError {
+    kind: String,
+    message: String,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum JsonIrNode {
+    Symbol {
+        name: String,
+    },
+    Integer {
+        value: i64,
+    },
+    Rational {
+        numerator: i64,
+        denominator: i64,
+    },
+    Float {
+        value: f64,
+    },
+    String {
+        value: String,
+    },
+    Apply {
+        head: Box<JsonIrNode>,
+        args: Vec<JsonIrNode>,
+    },
+}
+
+impl JsonIrNode {
+    fn from_ir(node: &IRNode) -> Self {
+        match node {
+            IRNode::Symbol(name) => JsonIrNode::Symbol { name: name.clone() },
+            IRNode::Integer(value) => JsonIrNode::Integer { value: *value },
+            IRNode::Rational(numerator, denominator) => JsonIrNode::Rational {
+                numerator: *numerator,
+                denominator: *denominator,
+            },
+            IRNode::Float(value) => JsonIrNode::Float { value: *value },
+            IRNode::Str(value) => JsonIrNode::String {
+                value: value.clone(),
+            },
+            IRNode::Apply(apply) => JsonIrNode::Apply {
+                head: Box::new(JsonIrNode::from_ir(&apply.head)),
+                args: apply.args.iter().map(JsonIrNode::from_ir).collect(),
+            },
+        }
+    }
+}
+
+fn encode_response<T: Serialize>(response: T) -> String {
+    serde_json::to_string(&response).unwrap_or_else(|error| {
+        format!(
+            r#"{{"ok":false,"error":{{"kind":"serialization","message":"{}"}}}}"#,
+            escape_json_string(&error.to_string())
+        )
+    })
+}
+
+fn escape_json_string(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|ch| ch.escape_default())
+        .collect::<String>()
+}
+
+fn panic_payload_to_string(payload: &Box<dyn Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "MACSYMA evaluation panicked".to_string()
+    }
+}
+
+fn catch_parser_panics<F, T>(f: F) -> Result<T, Box<dyn Any + Send>>
+where
+    F: FnOnce() -> T,
+{
+    static PANIC_HOOK_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let lock = PANIC_HOOK_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap();
+    let previous_hook = take_hook();
+    set_hook(Box::new(|_| {}));
+    let result = catch_unwind(AssertUnwindSafe(f));
+    set_hook(previous_hook);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn json(raw: &str) -> Value {
+        serde_json::from_str(raw).expect("facade should emit valid JSON")
+    }
+
+    #[test]
+    fn evaluates_single_shot_source_to_json() {
+        let payload = json(&eval_source_json("1 + 2 * 3;"));
+        assert_eq!(payload["ok"], true);
+        assert_eq!(payload["results"][0]["output_macsyma"], "7");
+        assert_eq!(payload["results"][0]["output_ir"]["kind"], "integer");
+        assert_eq!(payload["results"][0]["output_ir"]["value"], 7);
+        assert_eq!(payload["visible_outputs"][0], "7");
+    }
+
+    #[test]
+    fn preserves_session_bindings_across_calls() {
+        let mut session = MacsymaWasmSession::new();
+        let first = json(&session.eval_json("x : 5$"));
+        assert_eq!(first["visible_outputs"].as_array().unwrap().len(), 0);
+
+        let second = json(&session.eval_json("x + 2;"));
+        assert_eq!(second["results"][0]["input_index"], 2);
+        assert_eq!(second["results"][0]["output_macsyma"], "7");
+        assert_eq!(second["history"]["input_count"], 2);
+    }
+
+    #[test]
+    fn encodes_symbolic_ir_shape() {
+        let payload = json(&eval_source_json("(x + 0) * y^2;"));
+        let output = &payload["results"][0]["output_ir"];
+        assert_eq!(output["kind"], "apply");
+        assert_eq!(output["head"]["name"], "Mul");
+        assert_eq!(output["args"][0]["name"], "x");
+        assert_eq!(payload["results"][0]["output_lisp"], "(Mul x (Pow y 2))");
+    }
+
+    #[test]
+    fn reports_compile_errors_as_json() {
+        let payload = json(&eval_source_json("1 + ;"));
+        assert_eq!(payload["ok"], false);
+        assert_eq!(payload["error"]["kind"], "compile");
+        assert!(payload["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("parse"));
+    }
+
+    #[test]
+    fn can_reset_history_without_recreating_session() {
+        let mut session = MacsymaWasmSession::new();
+        session.eval_json("1; 2;");
+        session.reset_history();
+        let payload = json(&session.history_json());
+        assert_eq!(payload["history"]["input_count"], 0);
+        assert_eq!(payload["history"]["next_input_index"], 1);
+        assert!(payload["history"]["last_output_macsyma"].is_null());
+    }
+}

--- a/code/packages/wasm/macsyma-runtime/BUILD
+++ b/code/packages/wasm/macsyma-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -- --nocapture

--- a/code/packages/wasm/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/wasm/macsyma-runtime/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add `wasm-bindgen` bindings for the Rust MACSYMA runtime JSON facade.

--- a/code/packages/wasm/macsyma-runtime/Cargo.toml
+++ b/code/packages/wasm/macsyma-runtime/Cargo.toml
@@ -1,0 +1,15 @@
+[workspace]
+
+[package]
+name = "macsyma-runtime-wasm"
+version = "0.1.0"
+edition = "2021"
+description = "WebAssembly bindings for the Rust MACSYMA runtime"
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+coding-adventures-macsyma-wasm = { path = "../../rust/macsyma-wasm" }
+wasm-bindgen = "0.2"

--- a/code/packages/wasm/macsyma-runtime/README.md
+++ b/code/packages/wasm/macsyma-runtime/README.md
@@ -1,0 +1,14 @@
+# macsyma-runtime-wasm
+
+WebAssembly bindings for the Rust MACSYMA runtime.
+
+The exported API is intentionally JSON-string based so browser and TypeScript
+callers can consume a stable schema without depending on Rust enum layouts:
+
+- `evalSource(source)` evaluates one source string with a fresh session.
+- `new WasmMacsymaSession().eval(source)` keeps bindings and history across
+  calls.
+- `historyJson()` exposes the current history counters and last output.
+- `resetHistory()` clears `%i`/`%o` history without rebuilding the session.
+
+Build with `wasm-pack build --target web` or `wasm-pack build --target nodejs`.

--- a/code/packages/wasm/macsyma-runtime/required_capabilities.json
+++ b/code/packages/wasm/macsyma-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "wasm/macsyma-runtime",
+  "capabilities": [],
+  "justification": "Pure computation WebAssembly wrapper over the Rust MACSYMA runtime. No filesystem, network, process, DOM, or environment access."
+}

--- a/code/packages/wasm/macsyma-runtime/src/lib.rs
+++ b/code/packages/wasm/macsyma-runtime/src/lib.rs
@@ -1,0 +1,71 @@
+//! WebAssembly bindings for the Rust MACSYMA runtime JSON facade.
+
+use coding_adventures_macsyma_wasm::{eval_source_json, MacsymaWasmSession};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct WasmMacsymaSession {
+    inner: MacsymaWasmSession,
+}
+
+#[wasm_bindgen]
+impl WasmMacsymaSession {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: MacsymaWasmSession::new(),
+        }
+    }
+
+    /// Evaluate MACSYMA source with this session's persistent bindings/history.
+    #[wasm_bindgen]
+    pub fn eval(&mut self, source: &str) -> String {
+        self.inner.eval_json(source)
+    }
+
+    /// Return this session's current history counters as JSON.
+    #[wasm_bindgen(js_name = "historyJson")]
+    pub fn history_json(&self) -> String {
+        self.inner.history_json()
+    }
+
+    /// Clear `%i`/`%o` history while preserving the session object.
+    #[wasm_bindgen(js_name = "resetHistory")]
+    pub fn reset_history(&mut self) {
+        self.inner.reset_history();
+    }
+}
+
+impl Default for WasmMacsymaSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Evaluate MACSYMA source in a fresh session and return JSON.
+#[wasm_bindgen(js_name = "evalSource")]
+pub fn eval_source(source: &str) -> String {
+    eval_source_json(source)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_shot_eval_exports_json() {
+        let json = eval_source("1 + 2;");
+        assert!(json.contains("\"ok\":true"));
+        assert!(json.contains("\"output_macsyma\":\"3\""));
+    }
+
+    #[test]
+    fn session_preserves_bindings() {
+        let mut session = WasmMacsymaSession::new();
+        session.eval("x : 5$");
+        let json = session.eval("x + 1;");
+        assert!(json.contains("\"input_index\":2"));
+        assert!(json.contains("\"output_macsyma\":\"6\""));
+    }
+}


### PR DESCRIPTION
## Summary
- add a Rust JSON support facade for MACSYMA runtime evaluation results
- expose browser-facing `wasm-bindgen` bindings under `code/packages/wasm/macsyma-runtime`
- include persistent session APIs, stateless eval, history JSON, display filtering, pretty MACSYMA text, Lisp IR text, recursive IR JSON, and JSON error reporting

## Validation
- `cargo test -p coding-adventures-macsyma-wasm -- --nocapture`
- `cargo test --manifest-path code/packages/wasm/macsyma-runtime/Cargo.toml -- --nocapture`
- `PATH=/Users/adhithya/.cargo/bin:$PATH cargo check --manifest-path code/packages/wasm/macsyma-runtime/Cargo.toml --target wasm32-unknown-unknown`
- `./build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/rust-macsyma-wasm-build-plan.json`
- `git diff --check`