### PR TITLE
Expose ESP upload options through language bridges

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -202,6 +202,48 @@ class BoardTarget:
 
 
 @dataclass(frozen=True)
+class EspUploadOptions:
+    raw: dict[str, Any]
+
+    @property
+    def board_id(self) -> str:
+        return str(self.raw["board_id"])
+
+    @property
+    def baud_rate(self) -> int:
+        return int(self.raw["baud_rate"])
+
+    @property
+    def timeout_ms(self) -> int:
+        return int(self.raw["timeout_ms"])
+
+    @property
+    def reset_into_bootloader(self) -> bool:
+        return bool(self.raw["reset_into_bootloader"])
+
+    @property
+    def offset(self) -> int:
+        return int(self.raw["offset"])
+
+    @property
+    def block_size(self) -> int:
+        return int(self.raw["block_size"])
+
+    @property
+    def flash_size(self) -> int | None:
+        value = self.raw.get("flash_size")
+        return None if value is None else int(value)
+
+    @property
+    def verify_md5(self) -> bool:
+        return bool(self.raw["verify_md5"])
+
+    @property
+    def stay_in_bootloader(self) -> bool:
+        return bool(self.raw["stay_in_bootloader"])
+
+
+@dataclass(frozen=True)
 class ProtocolResult:
     command: str
     frame: bytes
@@ -1057,12 +1099,25 @@ def find_target(board_id: str) -> BoardTarget | None:
     return detect_target(board_id)
 
 
+def esp_upload_options(
+    selector: str = "esp32-devkit-v1",
+    **overrides: Any,
+) -> EspUploadOptions | None:
+    raw = _native.esp_upload_options(str(selector))
+    if raw is None:
+        return None
+    merged = dict(raw)
+    merged.update(overrides)
+    return EspUploadOptions(merged)
+
+
 __all__ = [
     "BoardDescriptor",
     "BoardTarget",
     "BOOT_POLICIES",
     "Capability",
     "DEFAULT_RUN_FLAGS",
+    "EspUploadOptions",
     "GPIO_MODES",
     "GPIO_READ_MODES",
     "ProtocolResult",
@@ -1073,6 +1128,7 @@ __all__ = [
     "Session",
     "SessionResult",
     "detect_target",
+    "esp_upload_options",
     "find_target",
     "known_targets",
 ]

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -17,10 +17,11 @@ use board_vm_language_core::{
     build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
     build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
     capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, detect_target as core_detect_target, known_targets, onboard_led_kind,
-    program_format_name, raw_module_len, run_status_name, BoardVmLanguageSession,
-    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError, LanguageOnboardLed,
-    LanguageTargetInfo, LanguageValue,
+    decode_wire_response, detect_target as core_detect_target, esp_upload_options_for_target,
+    known_targets, onboard_led_kind, program_format_name, raw_module_len, run_status_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageCoreError, LanguageEspUploadOptions, LanguageOnboardLed, LanguageTargetInfo,
+    LanguageValue,
 };
 use python_bridge::*;
 
@@ -464,6 +465,24 @@ unsafe extern "C" fn py_detect_target(_module: PyObjectPtr, args: PyObjectPtr) -
     }
 }
 
+unsafe extern "C" fn py_esp_upload_options(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let selector = match parse_arg_str(args, 0) {
+        Some(value) => value,
+        None => {
+            set_error(
+                type_error_class(),
+                "esp_upload_options() requires selector as str",
+            );
+            return ptr::null_mut();
+        }
+    };
+
+    match esp_upload_options_for_target(&selector) {
+        Some(options) => esp_upload_options_to_py(&options),
+        None => py_none(),
+    }
+}
+
 fn with_session(
     next_request_id: u16,
     operation: impl FnOnce(&mut BoardVmLanguageSession) -> Result<PyObjectPtr, LanguageCoreError>,
@@ -703,6 +722,35 @@ unsafe fn language_target_to_py(target: &LanguageTargetInfo) -> PyObjectPtr {
         PyList_SetItem(capabilities, index as isize, str_to_py(capability));
     }
     dict_set(dict, "capabilities", capabilities);
+    dict
+}
+
+unsafe fn esp_upload_options_to_py(options: &LanguageEspUploadOptions) -> PyObjectPtr {
+    let dict = PyDict_New();
+    dict_set(dict, "board_id", str_to_py(&options.board_id));
+    dict_set(dict, "baud_rate", usize_to_py(options.baud_rate as usize));
+    dict_set(dict, "timeout_ms", usize_to_py(options.timeout_ms as usize));
+    dict_set(
+        dict,
+        "reset_into_bootloader",
+        bool_to_py(options.reset_into_bootloader),
+    );
+    dict_set(dict, "offset", usize_to_py(options.offset as usize));
+    dict_set(dict, "block_size", usize_to_py(options.block_size as usize));
+    dict_set(
+        dict,
+        "flash_size",
+        options
+            .flash_size
+            .map(|value| usize_to_py(value as usize))
+            .unwrap_or_else(|| py_none()),
+    );
+    dict_set(dict, "verify_md5", bool_to_py(options.verify_md5));
+    dict_set(
+        dict,
+        "stay_in_bootloader",
+        bool_to_py(options.stay_in_bootloader),
+    );
     dict
 }
 
@@ -981,7 +1029,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 23] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 24] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1124,6 +1172,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_detect_target),
             ml_flags: METH_VARARGS,
             ml_doc: b"Resolve a Board VM target selector using Rust-owned aliases.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"esp_upload_options\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_esp_upload_options),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Return Rust-owned ESP ROM upload defaults for a target.\0".as_ptr()
                 as *const c_char,
         },
         method_def_sentinel(),

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -1,9 +1,11 @@
 from board_vm_native import (
     BoardDescriptor,
     BoardTarget,
+    EspUploadOptions,
     ProtocolResult,
     Session,
     detect_target,
+    esp_upload_options,
     find_target,
     known_targets,
 )
@@ -104,6 +106,27 @@ def test_targets_are_detected_from_rust_owned_aliases():
     assert pico_w is not None
     assert pico_w.board_id == "raspberry-pi-pico-w"
     assert detect_target("not-a-board") is None
+
+
+def test_esp_upload_options_are_exposed_from_rust_language_core():
+    options = esp_upload_options("esp32")
+
+    assert isinstance(options, EspUploadOptions)
+    assert options.board_id == "esp32-devkit-v1"
+    assert options.baud_rate == 115_200
+    assert options.timeout_ms == 1_000
+    assert options.reset_into_bootloader is True
+    assert options.offset == 0x1000
+    assert options.block_size == 0x400
+    assert options.flash_size == 4 * 1024 * 1024
+    assert options.verify_md5 is True
+    assert options.stay_in_bootloader is False
+    assert esp_upload_options("pico") is None
+
+    overridden = esp_upload_options("esp32", offset=0x2000, verify_md5=False)
+    assert overridden is not None
+    assert overridden.offset == 0x2000
+    assert overridden.verify_md5 is False
 
 
 def test_session_dispatches_frames_through_write_transport():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -18,10 +18,11 @@ use board_vm_language_core::{
     build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
     build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
     capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, detect_target as core_detect_target, known_targets, onboard_led_kind,
-    program_format_name, raw_module_len, run_status_name, BoardVmLanguageSession,
-    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError, LanguageOnboardLed,
-    LanguageTargetInfo, LanguageValue,
+    decode_wire_response, detect_target as core_detect_target, esp_upload_options_for_target,
+    known_targets, onboard_led_kind, program_format_name, raw_module_len, run_status_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageCoreError, LanguageEspUploadOptions, LanguageOnboardLed, LanguageTargetInfo,
+    LanguageValue,
 };
 use ruby_bridge::VALUE;
 
@@ -413,6 +414,15 @@ extern "C" fn native_detect_target(_self_val: VALUE, selector_val: VALUE) -> VAL
     }
 }
 
+extern "C" fn native_esp_upload_options(_self_val: VALUE, selector_val: VALUE) -> VALUE {
+    let selector = ruby_bridge::str_from_rb(selector_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("selector must be a Ruby String"));
+    match esp_upload_options_for_target(&selector) {
+        Some(options) => esp_upload_options_to_rb(&options),
+        None => ruby_bridge::nil_value(),
+    }
+}
+
 fn with_session_mut(
     self_val: VALUE,
     operation: impl FnOnce(&mut RubyBoardVmSession) -> Result<VALUE, LanguageCoreError>,
@@ -638,6 +648,39 @@ fn language_target_to_rb(target: &LanguageTargetInfo) -> VALUE {
         ruby_bridge::array_push(capabilities, ruby_bridge::str_to_rb(capability));
     }
     hash_set(hash, "capabilities", capabilities);
+    hash
+}
+
+fn esp_upload_options_to_rb(options: &LanguageEspUploadOptions) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "board_id", ruby_bridge::str_to_rb(&options.board_id));
+    hash_set(hash, "baud_rate", rb_usize(options.baud_rate));
+    hash_set(hash, "timeout_ms", rb_usize(options.timeout_ms));
+    hash_set(
+        hash,
+        "reset_into_bootloader",
+        ruby_bridge::bool_to_rb(options.reset_into_bootloader),
+    );
+    hash_set(hash, "offset", rb_usize(options.offset));
+    hash_set(hash, "block_size", rb_usize(options.block_size));
+    hash_set(
+        hash,
+        "flash_size",
+        options
+            .flash_size
+            .map(rb_usize)
+            .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash_set(
+        hash,
+        "verify_md5",
+        ruby_bridge::bool_to_rb(options.verify_md5),
+    );
+    hash_set(
+        hash,
+        "stay_in_bootloader",
+        ruby_bridge::bool_to_rb(options.stay_in_bootloader),
+    );
     hash
 }
 
@@ -911,6 +954,12 @@ pub extern "C" fn Init_board_vm_native() {
         native,
         "detect_target",
         native_detect_target as *const c_void,
+        1,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "esp_upload_options",
+        native_esp_upload_options as *const c_void,
         1,
     );
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -33,6 +33,16 @@ module CodingAdventures
       detect_target(board_id)
     end
 
+    def esp_upload_options(board = :esp32_devkit_v1, **overrides)
+      options = Native.esp_upload_options(board.to_s)
+      return nil unless options
+
+      overrides.each do |key, value|
+        options[key.to_s] = value
+      end
+      options
+    end
+
     def connect(
       board: :uno_r4_wifi,
       port:,

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -50,6 +50,25 @@ module CodingAdventures
         assert_equal :raspberry_pi_pico_w, BoardVM.normalize_board("pico-w")
       end
 
+      def test_esp_upload_options_are_exposed_from_rust_language_core
+        options = BoardVM.esp_upload_options(:esp32)
+
+        assert_equal "esp32-devkit-v1", options["board_id"]
+        assert_equal 115_200, options["baud_rate"]
+        assert_equal 1_000, options["timeout_ms"]
+        assert_equal true, options["reset_into_bootloader"]
+        assert_equal 0x1000, options["offset"]
+        assert_equal 0x400, options["block_size"]
+        assert_equal 4 * 1024 * 1024, options["flash_size"]
+        assert_equal true, options["verify_md5"]
+        assert_equal false, options["stay_in_bootloader"]
+        assert_nil BoardVM.esp_upload_options(:raspberry_pi_pico)
+
+        overridden = BoardVM.esp_upload_options(:esp32, offset: 0x2000, verify_md5: false)
+        assert_equal 0x2000, overridden["offset"]
+        assert_equal false, overridden["verify_md5"]
+      end
+
       def test_connect_flash_uploads_the_uno_r4_serialusb_vm_and_tracks_runtime_port
         upload = CommandResult.new(
           ["cargo"],

--- a/code/packages/rust/board-vm-language-core/Cargo.toml
+++ b/code/packages/rust/board-vm-language-core/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
+board-vm-esp-rom = { path = "../board-vm-esp-rom" }
 board-vm-host = { path = "../board-vm-host" }
 board-vm-protocol = { path = "../board-vm-protocol" }
 board-vm-targets = { path = "../board-vm-targets" }

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -12,6 +12,11 @@ use std::ptr;
 use std::slice;
 use std::str;
 
+use board_vm_esp_rom::{
+    DEFAULT_BAUD_RATE as ESP_DEFAULT_BAUD_RATE,
+    DEFAULT_FLASH_BLOCK_SIZE as ESP_DEFAULT_FLASH_BLOCK_SIZE,
+    DEFAULT_TIMEOUT_MS as ESP_DEFAULT_TIMEOUT_MS,
+};
 use board_vm_host::{
     write_blink_module, write_gpio_handle_close_module, write_gpio_handle_read_module,
     write_gpio_handle_write_module, write_gpio_open_module, write_gpio_read_module,
@@ -41,6 +46,8 @@ pub const LANGUAGE_RUN_FLAG_RESET_VM_BEFORE_RUN: u8 =
 pub const LANGUAGE_RUN_FLAG_KEEP_HANDLES_AFTER_RUN: u8 =
     board_vm_protocol::RUN_FLAG_KEEP_HANDLES_AFTER_RUN;
 pub const LANGUAGE_RUN_FLAG_BACKGROUND_RUN: u8 = board_vm_protocol::RUN_FLAG_BACKGROUND_RUN;
+pub const LANGUAGE_ESP_DEFAULT_FLASH_OFFSET: u32 = 0x1000;
+pub const LANGUAGE_ESP_DEFAULT_FLASH_SIZE: u32 = 4 * 1024 * 1024;
 
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -265,6 +272,19 @@ pub struct LanguageTargetInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageEspUploadOptions {
+    pub board_id: String,
+    pub baud_rate: u32,
+    pub timeout_ms: u64,
+    pub reset_into_bootloader: bool,
+    pub offset: u32,
+    pub block_size: u32,
+    pub flash_size: Option<u32>,
+    pub verify_md5: bool,
+    pub stay_in_bootloader: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageProgramBegin {
     pub program_id: u16,
     pub format: ProgramFormat,
@@ -436,6 +456,25 @@ pub fn detect_target(selector: &str) -> Option<LanguageTargetInfo> {
         _ => return None,
     };
     known_target(board_id)
+}
+
+pub fn esp_upload_options_for_target(selector: &str) -> Option<LanguageEspUploadOptions> {
+    let target = detect_target(selector)?;
+    if target.family != LanguageBoardFamily::Esp32 {
+        return None;
+    }
+
+    Some(LanguageEspUploadOptions {
+        board_id: target.board_id,
+        baud_rate: ESP_DEFAULT_BAUD_RATE,
+        timeout_ms: ESP_DEFAULT_TIMEOUT_MS,
+        reset_into_bootloader: true,
+        offset: LANGUAGE_ESP_DEFAULT_FLASH_OFFSET,
+        block_size: ESP_DEFAULT_FLASH_BLOCK_SIZE,
+        flash_size: Some(LANGUAGE_ESP_DEFAULT_FLASH_SIZE),
+        verify_md5: true,
+        stay_in_bootloader: false,
+    })
 }
 
 pub fn normalize_target_selector(selector: &str) -> String {
@@ -1441,6 +1480,31 @@ pub extern "C" fn board_vm_language_default_run_flags() -> u8 {
 }
 
 #[no_mangle]
+pub extern "C" fn board_vm_language_esp_default_baud_rate() -> u32 {
+    ESP_DEFAULT_BAUD_RATE
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_esp_default_timeout_ms() -> u64 {
+    ESP_DEFAULT_TIMEOUT_MS
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_esp_default_flash_offset() -> u32 {
+    LANGUAGE_ESP_DEFAULT_FLASH_OFFSET
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_esp_default_flash_block_size() -> u32 {
+    ESP_DEFAULT_FLASH_BLOCK_SIZE
+}
+
+#[no_mangle]
+pub extern "C" fn board_vm_language_esp_default_flash_size() -> u32 {
+    LANGUAGE_ESP_DEFAULT_FLASH_SIZE
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_run_flag_reset_vm_before_run() -> u8 {
     LANGUAGE_RUN_FLAG_RESET_VM_BEFORE_RUN
 }
@@ -1722,6 +1786,22 @@ mod tests {
             "esp32_devkit_v1"
         );
         assert!(detect_target("definitely-not-a-board").is_none());
+    }
+
+    #[test]
+    fn esp_upload_options_are_owned_by_rust_language_core() {
+        let options = esp_upload_options_for_target("esp32").unwrap();
+
+        assert_eq!(options.board_id, "esp32-devkit-v1");
+        assert_eq!(options.baud_rate, ESP_DEFAULT_BAUD_RATE);
+        assert_eq!(options.timeout_ms, ESP_DEFAULT_TIMEOUT_MS);
+        assert!(options.reset_into_bootloader);
+        assert_eq!(options.offset, LANGUAGE_ESP_DEFAULT_FLASH_OFFSET);
+        assert_eq!(options.block_size, ESP_DEFAULT_FLASH_BLOCK_SIZE);
+        assert_eq!(options.flash_size, Some(LANGUAGE_ESP_DEFAULT_FLASH_SIZE));
+        assert!(options.verify_md5);
+        assert!(!options.stay_in_bootloader);
+        assert!(esp_upload_options_for_target("pico").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Rust-owned ESP ROM upload defaults/options to board-vm-language-core for ESP targets.
- Expose those options through the Ruby native bridge and BoardVM.esp_upload_options sugar.
- Expose the same Rust-owned options through the Python native bridge and board_vm_native.esp_upload_options sugar.

## Validation
- cargo test -p board-vm-esp-rom -p board-vm-cli -p board-vm-targets -p board-vm-language-core
- bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD

## Notes
- Ruby and Python remain thin sugar; ESP defaults stay in Rust alongside target detection and ROM upload helpers.
- Pico returns nil for ESP upload options, preserving the board-family split for the next flashing path.