### PR TITLE
Add ESP flash sugar for language bridges

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1111,6 +1111,43 @@ def esp_upload_options(
     return EspUploadOptions(merged)
 
 
+def esp_upload_command(
+    selector: str = "esp32-devkit-v1",
+    *,
+    port: str,
+    image: str,
+    **overrides: Any,
+) -> list[str]:
+    options = esp_upload_options(selector, **overrides)
+    if options is None:
+        raise ValueError(f"ESP upload is not supported for {selector!r}")
+
+    command = [
+        "esp-upload",
+        "--port",
+        str(port),
+        "--image",
+        str(image),
+        "--baud",
+        str(options.baud_rate),
+        "--timeout-ms",
+        str(options.timeout_ms),
+        "--offset",
+        str(options.offset),
+        "--block-size",
+        str(options.block_size),
+    ]
+    if options.flash_size is not None:
+        command.extend(["--flash-size", str(options.flash_size)])
+    if not options.reset_into_bootloader:
+        command.append("--no-reset")
+    if not options.verify_md5:
+        command.append("--no-verify")
+    if options.stay_in_bootloader:
+        command.append("--stay-in-bootloader")
+    return command
+
+
 __all__ = [
     "BoardDescriptor",
     "BoardTarget",
@@ -1128,6 +1165,7 @@ __all__ = [
     "Session",
     "SessionResult",
     "detect_target",
+    "esp_upload_command",
     "esp_upload_options",
     "find_target",
     "known_targets",

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -5,6 +5,7 @@ from board_vm_native import (
     ProtocolResult,
     Session,
     detect_target,
+    esp_upload_command,
     esp_upload_options,
     find_target,
     known_targets,
@@ -127,6 +128,46 @@ def test_esp_upload_options_are_exposed_from_rust_language_core():
     assert overridden is not None
     assert overridden.offset == 0x2000
     assert overridden.verify_md5 is False
+
+
+def test_esp_upload_command_uses_rust_owned_options():
+    command = esp_upload_command(
+        "esp32",
+        port="/dev/cu.usbserial-110",
+        image="/tmp/board-vm-esp32.bin",
+        offset=0x2000,
+        verify_md5=False,
+        stay_in_bootloader=True,
+    )
+
+    assert command == [
+        "esp-upload",
+        "--port",
+        "/dev/cu.usbserial-110",
+        "--image",
+        "/tmp/board-vm-esp32.bin",
+        "--baud",
+        "115200",
+        "--timeout-ms",
+        "1000",
+        "--offset",
+        "8192",
+        "--block-size",
+        "1024",
+        "--flash-size",
+        "4194304",
+        "--no-verify",
+        "--stay-in-bootloader",
+    ]
+
+
+def test_esp_upload_command_rejects_non_esp_targets():
+    try:
+        esp_upload_command("pico", port="/dev/cu.usbmodem", image="fw.bin")
+    except ValueError as error:
+        assert "ESP upload is not supported" in str(error)
+    else:
+        raise AssertionError("expected ValueError")
 
 
 def test_session_dispatches_frames_through_write_transport():

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -43,6 +43,29 @@ module CodingAdventures
       options
     end
 
+    def esp_upload_command(board = :esp32_devkit_v1, port:, image:, **overrides)
+      options = esp_upload_options(board, **overrides)
+      unless options
+        raise UnsupportedBoardError, "ESP upload is not supported for #{board.inspect}"
+      end
+
+      command = [
+        "esp-upload",
+        "--port", port.to_s,
+        "--image", image.to_s,
+        "--baud", options.fetch("baud_rate").to_s,
+        "--timeout-ms", options.fetch("timeout_ms").to_s,
+        "--offset", options.fetch("offset").to_s,
+        "--block-size", options.fetch("block_size").to_s
+      ]
+      flash_size = options["flash_size"]
+      command << "--flash-size" << flash_size.to_s unless flash_size.nil?
+      command << "--no-reset" unless options.fetch("reset_into_bootloader")
+      command << "--no-verify" unless options.fetch("verify_md5")
+      command << "--stay-in-bootloader" if options.fetch("stay_in_bootloader")
+      command
+    end
+
     def connect(
       board: :uno_r4_wifi,
       port:,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -30,7 +30,10 @@ module CodingAdventures
         bootloader_touch: true,
         bootloader_touch_timeout_ms: nil,
         bootloader_touch_settle_ms: nil,
-        bootloader_port_wait_ms: nil
+        bootloader_port_wait_ms: nil,
+        firmware_image: nil,
+        esp_image: nil,
+        esp_upload_options: nil
       )
         @board = board
         @port = port
@@ -54,6 +57,8 @@ module CodingAdventures
         @bootloader_touch_timeout_ms = bootloader_touch_timeout_ms
         @bootloader_touch_settle_ms = bootloader_touch_settle_ms
         @bootloader_port_wait_ms = bootloader_port_wait_ms
+        @firmware_image = firmware_image || esp_image
+        @esp_upload_options = esp_upload_options || {}
       end
 
       def led
@@ -85,12 +90,14 @@ module CodingAdventures
       end
 
       def flash!
-        ensure_uno_r4_wifi!
-
-        result = runner.call(serial_usb_artifact_command(upload: true), chdir: cargo_workspace)
-        handoff_port = self.class.parse_new_upload_port(result.output)
-        self.port = handoff_port if handoff_port
-        result
+        case board
+        when :uno_r4_wifi
+          flash_uno_r4_wifi!
+        when :esp32_devkit_v1
+          flash_esp32!
+        else
+          raise UnsupportedBoardError, "Ruby DSL flash currently supports :uno_r4_wifi and :esp32_devkit_v1; got #{board.inspect}"
+        end
       end
 
       def blink!(
@@ -317,6 +324,32 @@ module CodingAdventures
 
       private
 
+      def flash_uno_r4_wifi!
+        result = runner.call(serial_usb_artifact_command(upload: true), chdir: cargo_workspace)
+        handoff_port = self.class.parse_new_upload_port(result.output)
+        self.port = handoff_port if handoff_port
+        result
+      end
+
+      def flash_esp32!
+        unless @firmware_image
+          raise ArgumentError, "ESP flash requires firmware_image: or esp_image:"
+        end
+
+        result = runner.call(
+          board_vm_cli_command(
+            *BoardVM.esp_upload_command(
+              board,
+              port: port,
+              image: @firmware_image,
+              **esp_upload_overrides
+            )
+          ),
+          chdir: cargo_workspace
+        )
+        result
+      end
+
       def ensure_uno_r4_wifi!
         return if board == :uno_r4_wifi
 
@@ -354,6 +387,16 @@ module CodingAdventures
 
       def board_vm_cli_command(*args)
         cargo_command("run", "-p", "board-vm-cli", "--bin", "board-vm", "--", *args)
+      end
+
+      def esp_upload_overrides
+        overrides = {}
+        @esp_upload_options.each do |key, value|
+          overrides[key.to_sym] = value
+        end
+        overrides[:baud_rate] = baud_rate unless overrides.key?(:baud_rate)
+        overrides[:timeout_ms] = timeout_ms unless overrides.key?(:timeout_ms)
+        overrides
       end
 
       def dispatch_frame(frame)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -106,6 +106,58 @@ module CodingAdventures
         ], runner.calls.first[:argv]
       end
 
+      def test_connect_flash_uploads_esp32_image_with_rust_owned_upload_options
+        upload = CommandResult.new(
+          ["cargo"],
+          "/repo/code/packages/rust",
+          "uploaded 4096 bytes\n",
+          "",
+          0
+        )
+        runner = FakeRunner.new([upload])
+
+        connection = BoardVM.connect(
+          board: :esp32,
+          port: "/dev/cu.usbserial-110",
+          flash: true,
+          firmware_image: "/tmp/board-vm-esp32.bin",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner,
+          esp_upload_options: {
+            offset: 0x2000,
+            verify_md5: false,
+            stay_in_bootloader: true
+          }
+        )
+
+        assert_equal :esp32_devkit_v1, connection.board
+        assert_equal "/repo/code/packages/rust", runner.calls.first[:chdir]
+        assert_equal [
+          "cargo", "run",
+          "-p", "board-vm-cli",
+          "--bin", "board-vm",
+          "--",
+          "esp-upload",
+          "--port", "/dev/cu.usbserial-110",
+          "--image", "/tmp/board-vm-esp32.bin",
+          "--baud", "115200",
+          "--timeout-ms", "1000",
+          "--offset", "8192",
+          "--block-size", "1024",
+          "--flash-size", "4194304",
+          "--no-verify",
+          "--stay-in-bootloader"
+        ], runner.calls.first[:argv]
+      end
+
+      def test_esp_upload_command_rejects_non_esp_targets
+        error = assert_raises(UnsupportedBoardError) do
+          BoardVM.esp_upload_command(:raspberry_pi_pico, port: "/dev/cu.usbmodem", image: "fw.bin")
+        end
+
+        assert_match(/ESP upload is not supported/, error.message)
+      end
+
       def test_led_blink_dispatches_native_protocol_frames_through_transport
         runner = FakeRunner.new
         transport = FakeWriteTransport.new


### PR DESCRIPTION
## Summary
- Add Ruby BoardVM.esp_upload_command sugar that consumes Rust-owned ESP upload options.
- Route Ruby connect(board: :esp32, flash: true, firmware_image: ...) through the Rust board-vm CLI esp-upload path.
- Add Python board_vm_native.esp_upload_command sugar using the same Rust-owned ESP upload option surface.

## Validation
- bash BUILD in code/packages/ruby/board_vm
- ruby -Ilib -Itest test/test_board_vm.rb in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- PYTHONPATH=src .venv/bin/python -m pytest tests/ -q in code/packages/python/board-vm-native
- build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD

## Notes
- The board-specific defaults still come from board-vm-language-core; Ruby and Python only assemble user-facing command sugar.
- Non-ESP targets still reject ESP upload command generation, keeping the Pico UF2/BOOTSEL path separate for the next slice.