### PR TITLE
[codex] Reconstruct formatting across nested anchors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1251,6 +1251,7 @@ impl HtmlParser {
         if self.has_table_context_above(index) {
             return false;
         }
+        self.capture_formatting_above(index);
         self.open_elements.truncate(index);
         true
     }
@@ -1631,7 +1632,7 @@ fn starts_inner_formatting_reconstruction_boundary(name: &str) -> bool {
 }
 
 fn starts_before_formatting_reconstruction_boundary(name: &str) -> bool {
-    matches!(name, "b" | "marquee" | "option")
+    matches!(name, "a" | "b" | "marquee" | "option")
 }
 
 fn is_special_element(name: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -401,3 +401,24 @@ Line1<br>Line2<br>Line3<br>Line4
 |       "C"
 |     <a>
 |       "Y"
+
+#data
+<a X>0<b>1<a Y>2
+#errors
+(1,5): expected-doctype-but-got-start-tag
+(1,15): unexpected-start-tag-implies-end-tag
+(1,15): adoption-agency-1.3
+(1,16): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       x=""
+|       "0"
+|       <b>
+|         "1"
+|     <b>
+|       <a>
+|         y=""
+|         "2"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through upstream `tests1.dat` case 32
- preserve formatting elements above an earlier `<a>` when a later `<a>` triggers interactive formatting recovery
- reconstruct the preserved formatting before the new anchor so `<b>` adoption output matches html5lib

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`

## Notes
- Stacked on #2426. Tokenizer state-machine/TOML behavior is unchanged.