### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 33

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -491,6 +491,9 @@ id = "self_closing_start_tag"
 id = "markup_declaration_open"
 
 [[states]]
+id = "markup_declaration_open_dash"
+
+[[states]]
 id = "cdata_open_bracket"
 
 [[states]]
@@ -5230,8 +5233,37 @@ actions = [
 [[transitions]]
 from = "markup_declaration_open"
 matcher = { literal = "-" }
+to = "markup_declaration_open_dash"
+
+[[transitions]]
+from = "markup_declaration_open_dash"
+matcher = { literal = "-" }
 to = "comment_start"
 actions = ["create_comment"]
+
+[[transitions]]
+from = "markup_declaration_open_dash"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = [
+  "parse_error(incorrectly-opened-comment)",
+  "create_comment",
+  "append_comment(-)",
+  "emit_current_token",
+  "emit(EOF)",
+]
+
+[[transitions]]
+from = "markup_declaration_open_dash"
+matcher = { anything = true }
+to = "bogus_comment"
+consume = false
+actions = [
+  "parse_error(incorrectly-opened-comment)",
+  "create_comment",
+  "append_comment(-)",
+]
 
 [[transitions]]
 from = "markup_declaration_open"
@@ -5506,8 +5538,7 @@ from = "comment_start"
 matcher = { literal = ">" }
 to = "data"
 actions = [
-  "parse_error(incorrectly-opened-comment)",
-  "append_comment(-)",
+  "parse_error(abrupt-closing-of-empty-comment)",
   "emit_current_token",
 ]
 
@@ -5517,8 +5548,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
-  "parse_error(incorrectly-opened-comment)",
-  "append_comment(-)",
+  "parse_error(eof-in-comment)",
   "emit_current_token",
   "emit(EOF)",
 ]
@@ -5526,23 +5556,17 @@ actions = [
 [[transitions]]
 from = "comment_start"
 matcher = { literal = "\u0000" }
-to = "bogus_comment"
+to = "comment"
 actions = [
-  "parse_error(incorrectly-opened-comment)",
   "parse_error(unexpected-null-character)",
-  "append_comment(-)",
   "append_comment_replacement",
 ]
 
 [[transitions]]
 from = "comment_start"
 matcher = { anything = true }
-to = "bogus_comment"
-actions = [
-  "parse_error(incorrectly-opened-comment)",
-  "append_comment(-)",
-  "append_comment(current)",
-]
+to = "comment"
+consume = false
 
 [[transitions]]
 from = "comment_start_dash"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -4,11 +4,7 @@
 //! Do not edit by hand.
 
 #[allow(unused_imports)]
-use state_machine::{
-    EffectfulStateMachine, FixtureDefinition, GuardDefinition, InputDefinition, MachineKind,
-    MatcherDefinition, RegisterDefinition, StateDefinition, StateMachineDefinition,
-    TokenDefinition, TransitionDefinition,
-};
+use state_machine::{EffectfulStateMachine, FixtureDefinition, GuardDefinition, InputDefinition, MachineKind, MatcherDefinition, RegisterDefinition, StateDefinition, StateMachineDefinition, TokenDefinition, TransitionDefinition};
 
 pub fn html1_lexer_definition() -> StateMachineDefinition {
     let mut definition = StateMachineDefinition::new("html1-lexer", MachineKind::Transducer);
@@ -81,7 +77,9 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
     definition.tokens = vec![
         TokenDefinition {
             name: "Text".to_string(),
-            fields: vec!["data".to_string()],
+            fields: vec![
+                "data".to_string(),
+            ],
         },
         TokenDefinition {
             name: "StartTag".to_string(),
@@ -93,11 +91,15 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         TokenDefinition {
             name: "EndTag".to_string(),
-            fields: vec!["name".to_string()],
+            fields: vec![
+                "name".to_string(),
+            ],
         },
         TokenDefinition {
             name: "Comment".to_string(),
-            fields: vec!["data".to_string()],
+            fields: vec![
+                "data".to_string(),
+            ],
         },
         TokenDefinition {
             name: "Doctype".to_string(),
@@ -914,6 +916,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         },
         StateDefinition {
             id: "markup_declaration_open".to_string(),
+            initial: false,
+            accepting: false,
+            final_state: false,
+            external_entry: false,
+        },
+        StateDefinition {
+            id: "markup_declaration_open_dash".to_string(),
             initial: false,
             accepting: false,
             final_state: false,
@@ -11110,6 +11119,19 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Literal("-".to_string())),
             to: vec![
+                "markup_declaration_open_dash".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: Vec::new(),
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "markup_declaration_open_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Literal("-".to_string())),
+            to: vec![
                 "comment_start".to_string(),
             ],
             guard: None,
@@ -11119,6 +11141,42 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
                 "create_comment".to_string(),
             ],
             consume: true,
+        },
+        TransitionDefinition {
+            from: "markup_declaration_open_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Eof),
+            to: vec![
+                "done".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(incorrectly-opened-comment)".to_string(),
+                "create_comment".to_string(),
+                "append_comment(-)".to_string(),
+                "emit_current_token".to_string(),
+                "emit(EOF)".to_string(),
+            ],
+            consume: false,
+        },
+        TransitionDefinition {
+            from: "markup_declaration_open_dash".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "bogus_comment".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "parse_error(incorrectly-opened-comment)".to_string(),
+                "create_comment".to_string(),
+                "append_comment(-)".to_string(),
+            ],
+            consume: false,
         },
         TransitionDefinition {
             from: "markup_declaration_open".to_string(),
@@ -11621,8 +11679,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "parse_error(incorrectly-opened-comment)".to_string(),
-                "append_comment(-)".to_string(),
+                "parse_error(abrupt-closing-of-empty-comment)".to_string(),
                 "emit_current_token".to_string(),
             ],
             consume: true,
@@ -11638,8 +11695,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "parse_error(incorrectly-opened-comment)".to_string(),
-                "append_comment(-)".to_string(),
+                "parse_error(eof-in-comment)".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -11650,15 +11706,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Literal("\0".to_string())),
             to: vec![
-                "bogus_comment".to_string(),
+                "comment".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "parse_error(incorrectly-opened-comment)".to_string(),
                 "parse_error(unexpected-null-character)".to_string(),
-                "append_comment(-)".to_string(),
                 "append_comment_replacement".to_string(),
             ],
             consume: true,
@@ -11668,17 +11722,13 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             on: None,
             matcher: Some(MatcherDefinition::Anything),
             to: vec![
-                "bogus_comment".to_string(),
+                "comment".to_string(),
             ],
             guard: None,
             stack_pop: None,
             stack_push: Vec::new(),
-            actions: vec![
-                "parse_error(incorrectly-opened-comment)".to_string(),
-                "append_comment(-)".to_string(),
-                "append_comment(current)".to_string(),
-            ],
-            consume: true,
+            actions: Vec::new(),
+            consume: false,
         },
         TransitionDefinition {
             from: "comment_start_dash".to_string(),

--- a/code/packages/rust/html-lexer/tests/fixtures/html1.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html1.json
@@ -450,6 +450,9 @@
         "Comment(data=)",
         "Text(data=After)",
         "EOF"
+      ],
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
       ]
     },
     {

--- a/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
+++ b/code/packages/rust/html-lexer/tests/fixtures/html5lib-smoke.json
@@ -445,7 +445,9 @@
         "Text(data=After)",
         "EOF"
       ],
-      "diagnostics": []
+      "diagnostics": [
+        "abrupt-closing-of-empty-comment"
+      ]
     },
     {
       "id": "html5lib-smoke-30",

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1768,6 +1768,21 @@ fn default_html_lexer_closes_dash_prefixed_empty_html_comment() {
 }
 
 #[test]
+fn default_html_lexer_preserves_extra_dash_before_comment_close() {
+    let tokens = lex_html("Before<!----->After").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Text("Before".to_string()),
+            Token::Comment("-".to_string()),
+            Token::Text("After".to_string()),
+            Token::Eof,
+        ]
+    );
+}
+
+#[test]
 fn default_html_lexer_reports_nested_comment_opener() {
     let mut lexer = create_html_lexer().unwrap();
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -811,6 +811,7 @@ impl HtmlParser {
         self_closing: bool,
     ) {
         self.apply_document_shell_implied_contexts(&name);
+        self.close_fostered_formatting_before_table_context(&name);
         self.apply_table_implied_contexts(&name);
         self.clear_pending_formatting_unless_next_reconstructs(&name);
         let formatting_inside = self.take_formatting_reconstruction_inside_for(&name);
@@ -904,6 +905,12 @@ impl HtmlParser {
 
         if !text.chars().all(char::is_whitespace) {
             self.pop_current_if(|name| name == "head");
+        }
+
+        if self.current_element_is_table_structure()
+            && self.foster_text_before_open_table(text.clone())
+        {
+            return;
         }
 
         if let Some(children) = self.current_children_mut() {
@@ -1016,33 +1023,96 @@ impl HtmlParser {
         incoming_name: &str,
         attributes: &[Attribute],
     ) -> bool {
-        if incoming_name != "a" || !self.current_element_is_table_structure() {
+        if !self.current_element_is_table_structure() {
             return false;
         }
 
-        let Some(table_path) = self
-            .open_elements
-            .iter()
-            .rfind(|path| element_at_path(&self.document, path).is_some_and(|name| name == "table"))
-            .cloned()
-        else {
+        if incoming_name == "a" {
+            let Some(_) = self.insert_node_before_open_table(Node::element(
+                incoming_name.to_string(),
+                attributes.to_vec(),
+            )) else {
+                return false;
+            };
+            self.pending_formatting_reconstruction =
+                vec![(incoming_name.to_string(), attributes.to_vec())];
+            return true;
+        }
+
+        if !is_formatting_element(incoming_name) {
             return false;
-        };
-        let Some((&table_index, parent_path)) = table_path.split_last() else {
-            return false;
-        };
-        let Some(children) = children_at_path_mut(&mut self.document.children, parent_path) else {
+        }
+
+        let Some(path) = self.insert_node_before_open_table(Node::element(
+            incoming_name.to_string(),
+            attributes.to_vec(),
+        )) else {
             return false;
         };
 
-        children.insert(
-            table_index,
-            Node::element(incoming_name.to_string(), attributes.to_vec()),
-        );
-        increment_open_element_paths_after_insert(&mut self.open_elements, parent_path, table_index);
-        self.pending_formatting_reconstruction =
-            vec![(incoming_name.to_string(), attributes.to_vec())];
+        self.open_elements.push(path);
         true
+    }
+
+    fn foster_text_before_open_table(&mut self, text: String) -> bool {
+        self.insert_node_before_open_table(Node::text(text)).is_some()
+    }
+
+    fn insert_node_before_open_table(&mut self, node: Node) -> Option<Vec<usize>> {
+        let table_path = self
+            .open_elements
+            .iter()
+            .rfind(|path| element_at_path(&self.document, path).is_some_and(|name| name == "table"))
+            .cloned()?;
+        let (&table_index, parent_path) = table_path.split_last()?;
+        let children = children_at_path_mut(&mut self.document.children, parent_path)?;
+
+        if let Node::Text(text) = node {
+            if let Some(Node::Text(existing)) = table_index
+                .checked_sub(1)
+                .and_then(|index| children.get_mut(index))
+            {
+                existing.data.push_str(&text.data);
+                return Some(parent_path.to_vec());
+            }
+            children.insert(table_index, Node::Text(text));
+        } else {
+            children.insert(table_index, node);
+        }
+
+        increment_open_element_paths_after_insert(&mut self.open_elements, parent_path, table_index);
+        let mut inserted_path = parent_path.to_vec();
+        inserted_path.push(table_index);
+        Some(inserted_path)
+    }
+
+    fn close_fostered_formatting_before_table_context(&mut self, incoming_name: &str) {
+        if !starts_table_context(incoming_name) {
+            return;
+        }
+        let Some(table_stack_index) = self
+            .open_elements
+            .iter()
+            .rposition(|path| element_at_path(&self.document, path).is_some_and(|name| name == "table"))
+        else {
+            return;
+        };
+        let Some(table_path) = self.open_elements.get(table_stack_index).cloned() else {
+            return;
+        };
+
+        while self.open_elements.len() > table_stack_index + 1 {
+            let Some(path) = self.open_elements.last() else {
+                break;
+            };
+            let is_fostered_formatting = element_at_path(&self.document, path)
+                .is_some_and(is_formatting_element)
+                && !path.starts_with(&table_path);
+            if !is_fostered_formatting {
+                break;
+            }
+            self.open_elements.pop();
+        }
     }
 
     fn apply_document_shell_implied_contexts(&mut self, incoming_name: &str) {
@@ -1332,7 +1402,7 @@ impl HtmlParser {
         self.current_element_name().is_some_and(|current| {
             matches!(
                 current,
-                "table" | "tbody" | "thead" | "tfoot" | "tr" | "caption" | "colgroup"
+                "table" | "tbody" | "thead" | "tfoot" | "tr"
             )
         })
     }
@@ -1605,6 +1675,13 @@ fn is_table_context_element(name: &str) -> bool {
     matches!(
         name,
         "table" | "caption" | "colgroup" | "tbody" | "thead" | "tfoot" | "tr" | "td" | "th"
+    )
+}
+
+fn starts_table_context(name: &str) -> bool {
+    matches!(
+        name,
+        "caption" | "colgroup" | "col" | "tbody" | "thead" | "tfoot" | "tr" | "td" | "th"
     )
 }
 
@@ -3027,8 +3104,8 @@ mod tests {
             (
                 HtmlInitialTokenizerContext::CommentStart,
                 "body --><p>x</p>",
-                "-body --",
-                vec!["incorrectly-opened-comment"],
+                "body ",
+                Vec::<&str>::new(),
             ),
             (
                 HtmlInitialTokenizerContext::CommentStartDash,

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -422,3 +422,39 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <a>
 |         y=""
 |         "2"
+
+#data
+<!-----><font><div>hello<table>excite!<b>me!<th><i>please!</tr><!--X-->
+#errors
+(1,14): expected-doctype-but-got-start-tag
+(1,41): unexpected-start-tag-implies-table-voodoo
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): foster-parenting-character-in-table
+(1,48): unexpected-cell-in-table-body
+(1,63): unexpected-cell-end-tag
+(1,71): eof-in-table
+#document
+| <!-- - -->
+| <html>
+|   <head>
+|   <body>
+|     <font>
+|       <div>
+|         "helloexcite!"
+|         <b>
+|           "me!"
+|         <table>
+|           <tbody>
+|             <tr>
+|               <th>
+|                 <i>
+|                   "please!"
+|             <!-- X -->


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 33
- fix the TOML-authored HTML tokenizer comment opener flow for extra dash comments and regenerate the Rust machine
- foster table text and formatting starts before the nearest open table for the case 33 table recovery path

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer