### PR TITLE
Add Board VM device discovery sugar

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -244,6 +244,44 @@ class EspUploadOptions:
 
 
 @dataclass(frozen=True)
+class BoardDevice:
+    raw: dict[str, Any]
+
+    @property
+    def id(self) -> str:
+        return str(self.raw["id"])
+
+    @property
+    def port(self) -> str:
+        return str(self.raw["port"])
+
+    @property
+    def transport(self) -> str:
+        return str(self.raw["transport"])
+
+    @property
+    def display_name(self) -> str:
+        return str(self.raw["display_name"])
+
+    @property
+    def target(self) -> BoardTarget | None:
+        target = self.raw.get("target")
+        return None if target is None else BoardTarget(target)
+
+    @property
+    def target_confidence(self) -> int:
+        return int(self.raw.get("target_confidence", 0))
+
+    @property
+    def bootloader(self) -> bool:
+        return bool(self.raw.get("bootloader", False))
+
+    @property
+    def tags(self) -> list[str]:
+        return [str(tag) for tag in self.raw.get("tags", [])]
+
+
+@dataclass(frozen=True)
 class ProtocolResult:
     command: str
     frame: bytes
@@ -1148,7 +1186,33 @@ def esp_upload_command(
     return command
 
 
+def devices(paths: Iterable[str] | None = None) -> list[BoardDevice]:
+    raw_devices = (
+        _native.discover_devices()
+        if paths is None
+        else _native.classify_devices([str(path) for path in paths])
+    )
+    return [BoardDevice(raw) for raw in raw_devices]
+
+
+def device_list(device_candidates: Iterable[BoardDevice | dict[str, Any]] | None = None) -> str:
+    items = list(devices() if device_candidates is None else device_candidates)
+    if not items:
+        return "No Board VM devices found."
+
+    lines = []
+    for index, item in enumerate(items, start=1):
+        device = item if isinstance(item, BoardDevice) else BoardDevice(item)
+        target = device.target
+        target_name = target.display_name if target is not None else "Unknown board"
+        confidence = f", {device.target_confidence}% match" if device.target_confidence > 0 else ""
+        tags = f" [{', '.join(device.tags)}]" if device.tags else ""
+        lines.append(f"{index}. {target_name} - {device.port}{confidence}{tags}")
+    return "\n".join(lines)
+
+
 __all__ = [
+    "BoardDevice",
     "BoardDescriptor",
     "BoardTarget",
     "BOOT_POLICIES",
@@ -1164,6 +1228,8 @@ __all__ = [
     "RUN_FLAGS",
     "Session",
     "SessionResult",
+    "device_list",
+    "devices",
     "detect_target",
     "esp_upload_command",
     "esp_upload_options",

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -17,11 +17,12 @@ use board_vm_language_core::{
     build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
     build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
     capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, detect_target as core_detect_target, esp_upload_options_for_target,
-    known_targets, onboard_led_kind, program_format_name, raw_module_len, run_status_name,
-    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageCoreError, LanguageEspUploadOptions, LanguageOnboardLed, LanguageTargetInfo,
-    LanguageValue,
+    decode_wire_response, detect_target as core_detect_target,
+    discover_devices as core_discover_devices, discover_devices_from_paths,
+    esp_upload_options_for_target, known_targets, onboard_led_kind, program_format_name,
+    raw_module_len, run_status_name, BoardVmLanguageSession, DecodedLanguageResponse,
+    DecodedLanguageResponseBody, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
+    LanguageOnboardLed, LanguageTargetInfo, LanguageValue,
 };
 use python_bridge::*;
 
@@ -483,6 +484,33 @@ unsafe extern "C" fn py_esp_upload_options(_module: PyObjectPtr, args: PyObjectP
     }
 }
 
+unsafe extern "C" fn py_discover_devices(_module: PyObjectPtr, _args: PyObjectPtr) -> PyObjectPtr {
+    host_devices_to_py(&core_discover_devices())
+}
+
+unsafe extern "C" fn py_classify_devices(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let paths_arg = PyTuple_GetItem(args, 0);
+    if paths_arg.is_null() {
+        PyErr_Clear();
+        set_error(
+            type_error_class(),
+            "classify_devices() requires a list of device paths",
+        );
+        return ptr::null_mut();
+    }
+    let paths = match vec_str_from_py(paths_arg) {
+        Some(value) => value,
+        None => {
+            set_error(
+                type_error_class(),
+                "classify_devices() requires a list of device paths",
+            );
+            return ptr::null_mut();
+        }
+    };
+    host_devices_to_py(&discover_devices_from_paths(paths))
+}
+
 fn with_session(
     next_request_id: u16,
     operation: impl FnOnce(&mut BoardVmLanguageSession) -> Result<PyObjectPtr, LanguageCoreError>,
@@ -751,6 +779,43 @@ unsafe fn esp_upload_options_to_py(options: &LanguageEspUploadOptions) -> PyObje
         "stay_in_bootloader",
         bool_to_py(options.stay_in_bootloader),
     );
+    dict
+}
+
+unsafe fn host_devices_to_py(devices: &[LanguageHostDevice]) -> PyObjectPtr {
+    let list = PyList_New(devices.len() as isize);
+    for (index, device) in devices.iter().enumerate() {
+        PyList_SetItem(list, index as isize, host_device_to_py(device));
+    }
+    list
+}
+
+unsafe fn host_device_to_py(device: &LanguageHostDevice) -> PyObjectPtr {
+    let dict = PyDict_New();
+    dict_set(dict, "id", str_to_py(&device.id));
+    dict_set(dict, "port", str_to_py(&device.port));
+    dict_set(dict, "transport", str_to_py(&device.transport));
+    dict_set(dict, "display_name", str_to_py(&device.display_name));
+    dict_set(
+        dict,
+        "target",
+        device
+            .target
+            .as_ref()
+            .map(|target| language_target_to_py(target))
+            .unwrap_or_else(|| py_none()),
+    );
+    dict_set(
+        dict,
+        "target_confidence",
+        usize_to_py(device.target_confidence as usize),
+    );
+    dict_set(dict, "bootloader", bool_to_py(device.bootloader));
+    let tags = PyList_New(device.tags.len() as isize);
+    for (index, tag) in device.tags.iter().enumerate() {
+        PyList_SetItem(tags, index as isize, str_to_py(tag));
+    }
+    dict_set(dict, "tags", tags);
     dict
 }
 
@@ -1029,7 +1094,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 24] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 26] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1180,6 +1245,19 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_flags: METH_VARARGS,
             ml_doc: b"Return Rust-owned ESP ROM upload defaults for a target.\0".as_ptr()
                 as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"discover_devices\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_discover_devices),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Discover host Board VM device candidates in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"classify_devices\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_classify_devices),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Classify host Board VM device paths in Rust.\0".as_ptr() as *const c_char,
         },
         method_def_sentinel(),
     ]));

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -1,9 +1,12 @@
 from board_vm_native import (
+    BoardDevice,
     BoardDescriptor,
     BoardTarget,
     EspUploadOptions,
     ProtocolResult,
     Session,
+    device_list,
+    devices,
     detect_target,
     esp_upload_command,
     esp_upload_options,
@@ -168,6 +171,33 @@ def test_esp_upload_command_rejects_non_esp_targets():
         assert "ESP upload is not supported" in str(error)
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_devices_are_classified_by_rust_language_core():
+    found = devices([
+        "/dev/cu.usbmodem1101",
+        "/dev/tty.usbserial-CP2102-esp32",
+        "/dev/serial/by-id/usb-Raspberry_Pi_Pico_E660-DAPLINK-if00",
+    ])
+
+    assert all(isinstance(device, BoardDevice) for device in found)
+    assert found[0].port == "/dev/cu.usbmodem1101"
+    assert found[0].target is None
+    assert "usb_cdc" in found[0].tags
+
+    esp = next(device for device in found if "usbserial" in device.port)
+    assert esp.target is not None
+    assert esp.target.board_id == "esp32-devkit-v1"
+    assert "uart" in esp.tags
+
+    pico = next(device for device in found if "Raspberry_Pi_Pico" in device.port)
+    assert pico.target is not None
+    assert pico.target.board_id == "raspberry-pi-pico"
+    assert pico.bootloader is True
+
+    rendered = device_list(found)
+    assert "ESP32 DevKit V1" in rendered
+    assert "/dev/cu.usbmodem1101" in rendered
 
 
 def test_session_dispatches_frames_through_write_transport():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -18,11 +18,12 @@ use board_vm_language_core::{
     build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
     build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
     capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, detect_target as core_detect_target, esp_upload_options_for_target,
-    known_targets, onboard_led_kind, program_format_name, raw_module_len, run_status_name,
-    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageCoreError, LanguageEspUploadOptions, LanguageOnboardLed, LanguageTargetInfo,
-    LanguageValue,
+    decode_wire_response, detect_target as core_detect_target,
+    discover_devices as core_discover_devices, discover_devices_from_paths,
+    esp_upload_options_for_target, known_targets, onboard_led_kind, program_format_name,
+    raw_module_len, run_status_name, BoardVmLanguageSession, DecodedLanguageResponse,
+    DecodedLanguageResponseBody, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
+    LanguageOnboardLed, LanguageTargetInfo, LanguageValue,
 };
 use ruby_bridge::VALUE;
 
@@ -423,6 +424,15 @@ extern "C" fn native_esp_upload_options(_self_val: VALUE, selector_val: VALUE) -
     }
 }
 
+extern "C" fn native_discover_devices(_self_val: VALUE) -> VALUE {
+    host_devices_to_rb(&core_discover_devices())
+}
+
+extern "C" fn native_classify_devices(_self_val: VALUE, paths_val: VALUE) -> VALUE {
+    let paths = ruby_bridge::vec_str_from_rb(paths_val);
+    host_devices_to_rb(&discover_devices_from_paths(paths))
+}
+
 fn with_session_mut(
     self_val: VALUE,
     operation: impl FnOnce(&mut RubyBoardVmSession) -> Result<VALUE, LanguageCoreError>,
@@ -681,6 +691,51 @@ fn esp_upload_options_to_rb(options: &LanguageEspUploadOptions) -> VALUE {
         "stay_in_bootloader",
         ruby_bridge::bool_to_rb(options.stay_in_bootloader),
     );
+    hash
+}
+
+fn host_devices_to_rb(devices: &[LanguageHostDevice]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for device in devices {
+        ruby_bridge::array_push(array, host_device_to_rb(device));
+    }
+    array
+}
+
+fn host_device_to_rb(device: &LanguageHostDevice) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "id", ruby_bridge::str_to_rb(&device.id));
+    hash_set(hash, "port", ruby_bridge::str_to_rb(&device.port));
+    hash_set(hash, "transport", ruby_bridge::str_to_rb(&device.transport));
+    hash_set(
+        hash,
+        "display_name",
+        ruby_bridge::str_to_rb(&device.display_name),
+    );
+    hash_set(
+        hash,
+        "target",
+        device
+            .target
+            .as_ref()
+            .map(language_target_to_rb)
+            .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash_set(
+        hash,
+        "target_confidence",
+        rb_usize(device.target_confidence),
+    );
+    hash_set(
+        hash,
+        "bootloader",
+        ruby_bridge::bool_to_rb(device.bootloader),
+    );
+    let tags = ruby_bridge::array_new();
+    for tag in &device.tags {
+        ruby_bridge::array_push(tags, ruby_bridge::str_to_rb(tag));
+    }
+    hash_set(hash, "tags", tags);
     hash
 }
 
@@ -960,6 +1015,18 @@ pub extern "C" fn Init_board_vm_native() {
         native,
         "esp_upload_options",
         native_esp_upload_options as *const c_void,
+        1,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "discover_devices",
+        native_discover_devices as *const c_void,
+        0,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "classify_devices",
+        native_classify_devices as *const c_void,
         1,
     );
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -21,6 +21,58 @@ module CodingAdventures
 
     module_function
 
+    def devices(paths: nil)
+      return Native.discover_devices if paths.nil?
+
+      Native.classify_devices(paths.map(&:to_s))
+    end
+
+    def device_list(device_candidates = nil)
+      device_candidates ||= devices
+      return "No Board VM devices found." if device_candidates.empty?
+
+      device_candidates.each_with_index.map do |device, index|
+        target = device["target"]
+        target_name = target ? target.fetch("display_name") : "Unknown board"
+        confidence = device.fetch("target_confidence", 0)
+        confidence_label = confidence.positive? ? ", #{confidence}% match" : ""
+        tags = Array(device["tags"])
+        status = tags.empty? ? "" : " [#{tags.join(", ")}]"
+
+        "#{index + 1}. #{target_name} - #{device.fetch("port")}#{confidence_label}#{status}"
+      end.join("\n")
+    end
+
+    def select_device(board: :auto, devices: nil)
+      candidates = devices || self.devices
+      normalized_board = board == :auto ? :auto : normalize_board(board)
+      matches = if normalized_board == :auto
+        candidates.select { |device| device_target_board(device) }
+      else
+        candidates.select do |device|
+          target_board = device_target_board(device)
+          target_board.nil? || target_board == normalized_board
+        end
+      end
+
+      matches = candidates if normalized_board == :auto && matches.empty? && candidates.length == 1
+      return matches.first if matches.length == 1
+
+      if candidates.empty?
+        raise DeviceSelectionError,
+          "No Board VM devices found. Plug in a board or pass an explicit device."
+      end
+
+      reason = if matches.empty? && normalized_board == :auto
+        "Multiple Board VM devices found; choose one"
+      elsif matches.empty?
+        "No matching Board VM device found"
+      else
+        "Multiple Board VM devices match"
+      end
+      raise DeviceSelectionError, "#{reason}.\n#{device_list(candidates)}"
+    end
+
     def known_targets
       Native.known_targets
     end
@@ -67,17 +119,20 @@ module CodingAdventures
     end
 
     def connect(
-      board: :uno_r4_wifi,
-      port:,
+      board: :auto,
+      port: nil,
+      device: nil,
+      devices: nil,
       flash: false,
       cargo_workspace: DEFAULT_RUST_WORKSPACE,
       runner: CommandRunner.new,
       transport: nil,
       **options
     )
+      selection = connection_selection(board: board, port: port, device: device, devices: devices)
       connection = Connection.new(
-        board: normalize_board(board),
-        port: port,
+        board: selection.fetch(:board),
+        port: selection.fetch(:port),
         cargo_workspace: cargo_workspace,
         runner: runner,
         transport: transport,
@@ -95,6 +150,62 @@ module CodingAdventures
 
     def uno_r4_wifi(**options, &block)
       connect(board: :uno_r4_wifi, **options, &block)
+    end
+
+    def connection_selection(board:, port:, device:, devices:)
+      explicit_port = !port.nil?
+      selected_device = resolve_device_reference(device, devices: devices) if device
+      selected_device ||= select_device(board: board, devices: devices) if port.nil?
+      port ||= selected_device && selected_device.fetch("port")
+
+      normalized_board = if board == :auto
+        inferred_board = selected_device && device_target_board(
+          selected_device,
+          minimum_confidence: 60
+        )
+        inferred_board ||= :uno_r4_wifi if explicit_port
+        unless inferred_board
+          raise DeviceSelectionError,
+            "Could not infer the board for #{port || "the selected device"}.\n#{device_list(devices || self.devices)}"
+        end
+        inferred_board
+      else
+        normalize_board(board)
+      end
+
+      { board: normalized_board, port: port }
+    end
+
+    def resolve_device_reference(device, devices: nil)
+      return device if device.is_a?(Hash)
+
+      candidates = devices || self.devices
+      if device.is_a?(Integer)
+        selected = candidates[device]
+        raise DeviceSelectionError, "No Board VM device at index #{device}." unless selected
+
+        return selected
+      end
+
+      needle = device.to_s
+      selected = candidates.find do |candidate|
+        candidate["id"] == needle || candidate["port"] == needle
+      end
+      unless selected
+        raise DeviceSelectionError,
+          "No Board VM device named #{needle.inspect}.\n#{device_list(candidates)}"
+      end
+
+      selected
+    end
+
+    def device_target_board(device, minimum_confidence: 0)
+      return nil if device.fetch("target_confidence", 0).to_i < minimum_confidence
+
+      target = device["target"]
+      return nil unless target
+
+      board_symbol(target.fetch("board_id"))
     end
 
     def normalize_board(board)

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -3,6 +3,7 @@
 module CodingAdventures
   module BoardVM
     class UnsupportedBoardError < ArgumentError; end
+    class DeviceSelectionError < ArgumentError; end
 
     class Connection
       attr_reader :board, :cargo_workspace, :runner, :transport, :baud_rate, :timeout_ms

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -69,6 +69,75 @@ module CodingAdventures
         assert_equal false, overridden["verify_md5"]
       end
 
+      def test_devices_are_discovered_and_classified_by_rust_language_core
+        devices = BoardVM.devices(paths: [
+          "/dev/cu.usbmodem1101",
+          "/dev/tty.usbserial-CP2102-esp32",
+          "/dev/serial/by-id/usb-Raspberry_Pi_Pico_E660-DAPLINK-if00"
+        ])
+
+        assert_equal "/dev/cu.usbmodem1101", devices.first["port"]
+        assert_nil devices.first["target"]
+        assert_includes devices.first["tags"], "usb_cdc"
+
+        esp = devices.find { |device| device["port"].include?("usbserial") }
+        assert_equal "esp32-devkit-v1", esp["target"]["board_id"]
+        assert_includes esp["tags"], "uart"
+
+        pico = devices.find { |device| device["port"].include?("Raspberry_Pi_Pico") }
+        assert_equal "raspberry-pi-pico", pico["target"]["board_id"]
+        assert_equal true, pico["bootloader"]
+
+        rendered = BoardVM.device_list(devices)
+        assert_includes rendered, "ESP32 DevKit V1"
+        assert_includes rendered, "/dev/cu.usbmodem1101"
+      end
+
+      def test_board_specific_connect_can_select_the_only_device_without_a_port
+        runner = FakeRunner.new
+        devices = BoardVM.devices(paths: ["/dev/cu.usbmodem1101"])
+
+        connection = BoardVM.uno_r4_wifi(
+          devices: devices,
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner
+        )
+
+        assert_equal :uno_r4_wifi, connection.board
+        assert_equal "/dev/cu.usbmodem1101", connection.port
+        assert_empty runner.calls
+      end
+
+      def test_auto_connect_uses_a_confident_rust_classified_device
+        runner = FakeRunner.new
+        devices = BoardVM.devices(paths: ["/dev/tty.usbserial-CP2102-esp32"])
+
+        connection = BoardVM.connect(
+          devices: devices,
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner
+        )
+
+        assert_equal :esp32_devkit_v1, connection.board
+        assert_equal "/dev/tty.usbserial-CP2102-esp32", connection.port
+        assert_empty runner.calls
+      end
+
+      def test_auto_connect_displays_devices_when_board_is_ambiguous
+        devices = BoardVM.devices(paths: [
+          "/dev/cu.usbmodem1101",
+          "/dev/cu.usbmodem2201"
+        ])
+
+        error = assert_raises(DeviceSelectionError) do
+          BoardVM.connect(devices: devices, runner: FakeRunner.new)
+        end
+
+        assert_includes error.message, "Multiple Board VM devices found"
+        assert_includes error.message, "/dev/cu.usbmodem1101"
+        assert_includes error.message, "/dev/cu.usbmodem2201"
+      end
+
       def test_connect_flash_uploads_the_uno_r4_serialusb_vm_and_tracks_runtime_port
         upload = CommandResult.new(
           ["cargo"],

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -6,8 +6,12 @@
 //! already share the same implementation.
 
 use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
+use std::env;
 use std::ffi::CString;
+use std::fs;
 use std::panic::{self, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
 use std::ptr;
 use std::slice;
 use std::str;
@@ -285,6 +289,18 @@ pub struct LanguageEspUploadOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageHostDevice {
+    pub id: String,
+    pub port: String,
+    pub transport: String,
+    pub display_name: String,
+    pub target: Option<LanguageTargetInfo>,
+    pub target_confidence: u8,
+    pub bootloader: bool,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageProgramBegin {
     pub program_id: u16,
     pub format: ProgramFormat,
@@ -477,6 +493,35 @@ pub fn esp_upload_options_for_target(selector: &str) -> Option<LanguageEspUpload
     })
 }
 
+pub fn discover_devices() -> Vec<LanguageHostDevice> {
+    let mut paths = env_device_paths();
+
+    #[cfg(unix)]
+    paths.extend(unix_device_paths());
+
+    #[cfg(windows)]
+    paths.extend(windows_device_paths());
+
+    discover_devices_from_paths(paths)
+}
+
+pub fn discover_devices_from_paths<I, S>(paths: I) -> Vec<LanguageHostDevice>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut devices = BTreeMap::new();
+    for path in paths {
+        let path = path.as_ref().trim();
+        if path.is_empty() || !is_serial_candidate(path) {
+            continue;
+        }
+        let device = classify_host_device(path);
+        devices.entry(device_dedupe_key(path)).or_insert(device);
+    }
+    devices.into_values().collect()
+}
+
 pub fn normalize_target_selector(selector: &str) -> String {
     let mut normalized = String::new();
     let mut last_was_separator = false;
@@ -530,6 +575,167 @@ fn language_onboard_led(led: TargetOnboardLed) -> LanguageOnboardLed {
     match led {
         TargetOnboardLed::Gpio(pin) => LanguageOnboardLed::Gpio(pin),
         TargetOnboardLed::WirelessChipGpio(pin) => LanguageOnboardLed::WirelessChipGpio(pin),
+    }
+}
+
+fn env_device_paths() -> Vec<String> {
+    env::var_os("BOARD_VM_DEVICE_PATHS")
+        .map(|paths| {
+            env::split_paths(&paths)
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(unix)]
+fn unix_device_paths() -> Vec<String> {
+    let mut paths = Vec::new();
+    collect_matching_dir_paths("/dev", &mut paths, |name| {
+        let lower = name.to_ascii_lowercase();
+        lower.starts_with("cu.usbmodem")
+            || lower.starts_with("tty.usbmodem")
+            || lower.starts_with("cu.usbserial")
+            || lower.starts_with("tty.usbserial")
+            || lower.starts_with("cu.wchusbserial")
+            || lower.starts_with("tty.wchusbserial")
+            || lower.starts_with("cu.slab_usbtouart")
+            || lower.starts_with("tty.slab_usbtouart")
+            || lower.starts_with("ttyacm")
+            || lower.starts_with("ttyusb")
+    });
+    collect_matching_dir_paths("/dev/serial/by-id", &mut paths, |_| true);
+    paths
+}
+
+#[cfg(windows)]
+fn windows_device_paths() -> Vec<String> {
+    Vec::new()
+}
+
+fn collect_matching_dir_paths(dir: &str, paths: &mut Vec<String>, matches: impl Fn(&str) -> bool) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if matches(&name) {
+            paths.push(entry.path().to_string_lossy().into_owned());
+        }
+    }
+}
+
+fn is_serial_candidate(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    lower.contains("usbmodem")
+        || lower.contains("usbserial")
+        || lower.contains("wchusbserial")
+        || lower.contains("slab_usbtouart")
+        || lower.contains("ttyacm")
+        || lower.contains("ttyusb")
+        || lower.contains("cp210")
+        || lower.contains("ch340")
+        || lower.contains("ftdi")
+        || lower.contains("arduino")
+        || lower.contains("espressif")
+        || lower.contains("esp32")
+        || lower.contains("pico")
+        || lower.contains("rp2040")
+        || lower.starts_with("com")
+        || lower.starts_with(r"\\.\com")
+}
+
+fn classify_host_device(path: &str) -> LanguageHostDevice {
+    let lower = path.to_ascii_lowercase();
+    let normalized = normalize_target_selector(path);
+    let mut tags = Vec::new();
+    push_unique_tag(&mut tags, "serial");
+
+    let (board_id, confidence) = if normalized.contains("pico_w")
+        || normalized.contains("picow")
+        || normalized.contains("raspberry_pi_pico_w")
+    {
+        push_unique_tag(&mut tags, "pico");
+        push_unique_tag(&mut tags, "rp2040");
+        (Some("raspberry-pi-pico-w"), 95)
+    } else if normalized.contains("pico") || normalized.contains("rp2040") {
+        push_unique_tag(&mut tags, "pico");
+        push_unique_tag(&mut tags, "rp2040");
+        (Some("raspberry-pi-pico"), 95)
+    } else if normalized.contains("esp32")
+        || normalized.contains("espressif")
+        || normalized.contains("silicon_labs")
+        || normalized.contains("cp210")
+        || normalized.contains("ch340")
+        || normalized.contains("wchusbserial")
+        || normalized.contains("slab_usbtouart")
+        || normalized.contains("usbserial")
+    {
+        push_unique_tag(&mut tags, "esp");
+        push_unique_tag(&mut tags, "uart");
+        (Some("esp32-devkit-v1"), 70)
+    } else if normalized.contains("arduino")
+        || normalized.contains("uno_r4")
+        || normalized.contains("renesas")
+    {
+        push_unique_tag(&mut tags, "arduino");
+        push_unique_tag(&mut tags, "usb_cdc");
+        (Some("arduino-uno-r4-wifi"), 85)
+    } else {
+        if lower.contains("usbmodem") || lower.contains("ttyacm") {
+            push_unique_tag(&mut tags, "usb_cdc");
+        }
+        (None, 0)
+    };
+
+    let bootloader = normalized.contains("boot")
+        || normalized.contains("bootloader")
+        || normalized.contains("cmsis_dap")
+        || normalized.contains("daplink")
+        || normalized.contains("uf2");
+    if bootloader {
+        push_unique_tag(&mut tags, "bootloader");
+    } else {
+        push_unique_tag(&mut tags, "runtime_or_upload");
+    }
+
+    let target = board_id.and_then(known_target);
+    let target_name = target
+        .as_ref()
+        .map(|target| target.display_name.as_str())
+        .unwrap_or("Board VM serial device");
+
+    LanguageHostDevice {
+        id: device_id(path),
+        port: path.to_owned(),
+        transport: "serial".to_owned(),
+        display_name: format!("{target_name} on {path}"),
+        target,
+        target_confidence: confidence,
+        bootloader,
+        tags,
+    }
+}
+
+fn device_dedupe_key(path: &str) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|_| PathBuf::from(path))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn device_id(path: &str) -> String {
+    let name = Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| path.into());
+    normalize_target_selector(&name).replace('_', "-")
+}
+
+fn push_unique_tag(tags: &mut Vec<String>, tag: &str) {
+    if !tags.iter().any(|existing| existing == tag) {
+        tags.push(tag.to_owned());
     }
 }
 
@@ -1802,6 +2008,36 @@ mod tests {
         assert!(options.verify_md5);
         assert!(!options.stay_in_bootloader);
         assert!(esp_upload_options_for_target("pico").is_none());
+    }
+
+    #[test]
+    fn host_device_discovery_classifies_serial_candidates() {
+        let devices = discover_devices_from_paths([
+            "/dev/cu.usbmodem1101",
+            "/dev/tty.usbserial-CP2102-esp32",
+            "/dev/serial/by-id/usb-Raspberry_Pi_Pico_E660-DAPLINK-if00",
+            "/tmp/not-a-board",
+        ]);
+
+        assert_eq!(devices.len(), 3);
+        assert_eq!(devices[0].port, "/dev/cu.usbmodem1101");
+        assert_eq!(devices[0].target, None);
+        assert!(devices[0].tags.contains(&"usb_cdc".to_owned()));
+
+        let pico = devices
+            .iter()
+            .find(|device| device.port.contains("Raspberry_Pi_Pico"))
+            .unwrap();
+        assert_eq!(pico.target.as_ref().unwrap().board_id, "raspberry-pi-pico");
+        assert!(pico.bootloader);
+        assert!(pico.target_confidence >= 90);
+
+        let esp = devices
+            .iter()
+            .find(|device| device.port.contains("usbserial"))
+            .unwrap();
+        assert_eq!(esp.target.as_ref().unwrap().board_id, "esp32-devkit-v1");
+        assert!(esp.tags.contains(&"uart".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add Rust-owned host device discovery/classification for Board VM serial candidates
- expose device lists through the Ruby and Python native bridges
- let Ruby scripts/REPLs list devices and connect without manually typing a port when selection is unambiguous

## Validation

- cargo test -p board-vm-language-core -p board-vm-cli -p board-vm-targets
- bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
