### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 35

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -477,3 +477,21 @@ Line1<br>Line2<br>Line3<br>Line4
 |           "do"
 |       "you"
 |   <!-- do -->
+
+#data
+<!DOCTYPE html>A<option>B<optgroup>C<select>D</option>E
+#errors
+(1,54): unexpected-end-tag-in-select
+(1,55): eof-in-select
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "A"
+|     <option>
+|       "B"
+|     <optgroup>
+|       "C"
+|       <select>
+|         "DE"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 35
- cover the existing select/option recovery path with the upstream smoke corpus

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer