### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 37

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -508,3 +508,16 @@ Line1<br>Line2<br>Line3<br>Line4
 |   <head>
 |   <body>
 |     "<"
+
+#data
+<#
+#errors
+(1,1): expected-tag-name
+(1,1): expected-doctype-but-got-chars
+#new-errors
+(1:2) invalid-first-character-of-tag-name
+#document
+| <html>
+|   <head>
+|   <body>
+|     "<#"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 37
- cover the existing invalid tag-open recovery path with the upstream smoke corpus

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer