### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 38

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -521,3 +521,16 @@ Line1<br>Line2<br>Line3<br>Line4
 |   <head>
 |   <body>
 |     "<#"
+
+#data
+</
+#errors
+(1,2): expected-closing-tag-but-got-eof
+(1,2): expected-doctype-but-got-chars
+#new-errors
+(1:3) eof-before-tag-name
+#document
+| <html>
+|   <head>
+|   <body>
+|     "</"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 38
- cover the existing EOF-before-end-tag-name recovery path with the upstream smoke corpus

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer