### PR TITLE
[codex] Extend html5lib tree smoke coverage through case 41

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -560,3 +560,16 @@ Line1<br>Line2<br>Line3<br>Line4
 | <html>
 |   <head>
 |   <body>
+
+#data
+<?#
+#errors
+(1,1): expected-tag-name-but-got-question-mark
+(1,3): expected-doctype-but-got-eof
+#new-errors
+(1:2) unexpected-question-mark-instead-of-tag-name
+#document
+| <!-- ?# -->
+| <html>
+|   <head>
+|   <body>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 41
- capture the existing bogus-comment recovery for <?#

## Tests
- cargo test -p coding-adventures-html-parser --test tree_construction_test
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer