### PR TITLE
Use discovered devices for ESP flash sugar

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1149,16 +1149,88 @@ def esp_upload_options(
     return EspUploadOptions(merged)
 
 
+DeviceReference = BoardDevice | dict[str, Any] | str | int
+
+
+def select_device(
+    selector: str = "auto",
+    *,
+    device: DeviceReference | None = None,
+    device_candidates: Iterable[BoardDevice | dict[str, Any]] | None = None,
+) -> BoardDevice:
+    candidates = [
+        item if isinstance(item, BoardDevice) else BoardDevice(item)
+        for item in (devices() if device_candidates is None else device_candidates)
+    ]
+
+    if isinstance(device, BoardDevice):
+        return device
+    if isinstance(device, dict):
+        return BoardDevice(device)
+    if isinstance(device, int):
+        try:
+            return candidates[device]
+        except IndexError as error:
+            raise ValueError(f"No Board VM device at index {device}.") from error
+    if device is not None:
+        needle = str(device)
+        for candidate in candidates:
+            if candidate.id == needle or candidate.port == needle:
+                return candidate
+        raise ValueError(f"No Board VM device named {needle!r}.\n{device_list(candidates)}")
+
+    target = None if selector == "auto" else detect_target(selector)
+    if selector != "auto" and target is None:
+        raise ValueError(f"unsupported board: {selector!r}")
+
+    if target is None:
+        matches = [candidate for candidate in candidates if candidate.target is not None]
+    else:
+        exact_matches = [
+            candidate
+            for candidate in candidates
+            if candidate.target is not None and candidate.target.board_id == target.board_id
+        ]
+        matches = exact_matches or [
+            candidate for candidate in candidates if candidate.target is None
+        ]
+
+    if target is None and not matches and len(candidates) == 1:
+        matches = candidates
+    if len(matches) == 1:
+        return matches[0]
+
+    if not candidates:
+        raise ValueError("No Board VM devices found. Plug in a board or pass an explicit device.")
+
+    if not matches and target is None:
+        reason = "Multiple Board VM devices found; choose one"
+    elif not matches:
+        reason = "No matching Board VM device found"
+    else:
+        reason = "Multiple Board VM devices match"
+    raise ValueError(f"{reason}.\n{device_list(candidates)}")
+
+
 def esp_upload_command(
     selector: str = "esp32-devkit-v1",
     *,
-    port: str,
+    port: str | None = None,
+    device: DeviceReference | None = None,
+    device_candidates: Iterable[BoardDevice | dict[str, Any]] | None = None,
     image: str,
     **overrides: Any,
 ) -> list[str]:
     options = esp_upload_options(selector, **overrides)
     if options is None:
         raise ValueError(f"ESP upload is not supported for {selector!r}")
+
+    if port is None:
+        port = select_device(
+            selector,
+            device=device,
+            device_candidates=device_candidates,
+        ).port
 
     command = [
         "esp-upload",
@@ -1235,4 +1307,5 @@ __all__ = [
     "esp_upload_options",
     "find_target",
     "known_targets",
+    "select_device",
 ]

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -12,6 +12,7 @@ from board_vm_native import (
     esp_upload_options,
     find_target,
     known_targets,
+    select_device,
 )
 
 
@@ -161,6 +162,42 @@ def test_esp_upload_command_uses_rust_owned_options():
         "4194304",
         "--no-verify",
         "--stay-in-bootloader",
+    ]
+
+
+def test_esp_upload_command_can_select_a_discovered_esp_device():
+    found = devices([
+        "/dev/cu.usbmodem1101",
+        "/dev/tty.usbserial-CP2102-esp32",
+    ])
+
+    selected = select_device("esp32", device_candidates=found)
+    command = esp_upload_command(
+        "esp32",
+        device_candidates=found,
+        image="/tmp/board-vm-esp32.bin",
+        offset=0x2000,
+        verify_md5=False,
+    )
+
+    assert selected.port == "/dev/tty.usbserial-CP2102-esp32"
+    assert command == [
+        "esp-upload",
+        "--port",
+        "/dev/tty.usbserial-CP2102-esp32",
+        "--image",
+        "/tmp/board-vm-esp32.bin",
+        "--baud",
+        "115200",
+        "--timeout-ms",
+        "1000",
+        "--offset",
+        "8192",
+        "--block-size",
+        "1024",
+        "--flash-size",
+        "4194304",
+        "--no-verify",
     ]
 
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -49,10 +49,8 @@ module CodingAdventures
       matches = if normalized_board == :auto
         candidates.select { |device| device_target_board(device) }
       else
-        candidates.select do |device|
-          target_board = device_target_board(device)
-          target_board.nil? || target_board == normalized_board
-        end
+        exact_matches = candidates.select { |device| device_target_board(device) == normalized_board }
+        exact_matches.empty? ? candidates.select { |device| device_target_board(device).nil? } : exact_matches
       end
 
       matches = candidates if normalized_board == :auto && matches.empty? && candidates.length == 1
@@ -95,11 +93,22 @@ module CodingAdventures
       options
     end
 
-    def esp_upload_command(board = :esp32_devkit_v1, port:, image:, **overrides)
+    def esp_upload_command(
+      board = :esp32_devkit_v1,
+      port: nil,
+      device: nil,
+      devices: nil,
+      image:,
+      **overrides
+    )
       options = esp_upload_options(board, **overrides)
       unless options
         raise UnsupportedBoardError, "ESP upload is not supported for #{board.inspect}"
       end
+
+      selected_device = resolve_device_reference(device, devices: devices) if device
+      selected_device ||= select_device(board: board, devices: devices) if port.nil?
+      port ||= selected_device && selected_device.fetch("port")
 
       command = [
         "esp-upload",
@@ -150,6 +159,14 @@ module CodingAdventures
 
     def uno_r4_wifi(**options, &block)
       connect(board: :uno_r4_wifi, **options, &block)
+    end
+
+    def esp32_devkit_v1(**options, &block)
+      connect(board: :esp32_devkit_v1, **options, &block)
+    end
+
+    def esp32(**options, &block)
+      esp32_devkit_v1(**options, &block)
     end
 
     def connection_selection(board:, port:, device:, devices:)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -219,6 +219,51 @@ module CodingAdventures
         ], runner.calls.first[:argv]
       end
 
+      def test_esp_upload_command_can_select_a_discovered_esp_device
+        devices = BoardVM.devices(paths: [
+          "/dev/cu.usbmodem1101",
+          "/dev/tty.usbserial-CP2102-esp32"
+        ])
+
+        command = BoardVM.esp_upload_command(
+          :esp32,
+          devices: devices,
+          image: "/tmp/board-vm-esp32.bin",
+          offset: 0x2000,
+          verify_md5: false
+        )
+
+        assert_equal [
+          "esp-upload",
+          "--port", "/dev/tty.usbserial-CP2102-esp32",
+          "--image", "/tmp/board-vm-esp32.bin",
+          "--baud", "115200",
+          "--timeout-ms", "1000",
+          "--offset", "8192",
+          "--block-size", "1024",
+          "--flash-size", "4194304",
+          "--no-verify"
+        ], command
+      end
+
+      def test_esp32_helper_flashes_the_selected_discovered_device
+        upload = CommandResult.new(["cargo"], "/repo/code/packages/rust", "uploaded\n", "", 0)
+        runner = FakeRunner.new([upload])
+        devices = BoardVM.devices(paths: ["/dev/tty.usbserial-CP2102-esp32"])
+
+        connection = BoardVM.esp32(
+          devices: devices,
+          flash: true,
+          firmware_image: "/tmp/board-vm-esp32.bin",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner
+        )
+
+        assert_equal :esp32_devkit_v1, connection.board
+        assert_equal "/dev/tty.usbserial-CP2102-esp32", connection.port
+        assert_equal "/dev/tty.usbserial-CP2102-esp32", runner.calls.first[:argv][9]
+      end
+
       def test_esp_upload_command_rejects_non_esp_targets
         error = assert_raises(UnsupportedBoardError) do
           BoardVM.esp_upload_command(:raspberry_pi_pico, port: "/dev/cu.usbmodem", image: "fw.bin")


### PR DESCRIPTION
## Summary
- lets Ruby `BoardVM.esp_upload_command` and Python `esp_upload_command` choose a Rust-discovered ESP device when no port is provided
- adds Ruby `BoardVM.esp32` / `BoardVM.esp32_devkit_v1` helpers so scripts can flash and connect without exposing serial-port details
- tightens device selection so exact Rust-classified board matches win before unknown fallback devices

## Validation
- `cargo test -p board-vm-language-core -p board-vm-cli -p board-vm-targets`
- `ruby -Ilib -Itest test/test_board_vm.rb` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/ruby/board_vm`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
