### PR TITLE
[codex] Add smart-home integration primitive backlog

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this package will be documented in this file.
   Home, Google Home, Alexa, Z-Wave Alliance, and Thread Group.
 - Query helpers for integration id, category, connectivity, capability,
   primitive family, implementation status, and rollout priority.
+- Primitive backlog planning helpers for ranking the shared primitive families
+  needed by priority-bounded rollout waves.
 - Computed policy-surface helpers so Chief of Staff tools can identify camera,
   entry-access, climate, energy, cloud, credential, radio-network, and local
   actuation review boundaries before activating integrations.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -22,6 +22,8 @@ runtime and Chief of Staff tools a typed catalog for:
   Pro, SmartThings, openHAB, Homebridge, ioBroker, Domoticz, Jeedom, HomeSeer,
   Apple Home, Google Home, Alexa, Z-Wave Alliance, and Thread Group references
   to reusable primitive-family hints
+- primitive backlog planning for prioritizing the shared families needed by a
+  rollout wave
 - first-party rollout seed entries
 - virtual product aliases that point to real implementations or standards
 

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -10,6 +10,7 @@ use smart_home_core::{
     CapabilityId, EntityKind, IntegrationId, PrivilegeTier, ProtocolFamily, RuntimeKind,
     ToolDescriptor, ToolSideEffects,
 };
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationCategory {
@@ -344,6 +345,22 @@ pub struct IntegrationCatalogEntry {
     pub required_primitives: Vec<PrimitiveFamily>,
     pub source_refs: Vec<SourceReference>,
     pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrimitiveBacklogItem {
+    pub primitive: PrimitiveFamily,
+    pub highest_priority: u8,
+    pub entry_count: usize,
+    pub integration_ids: Vec<IntegrationId>,
+}
+
+impl PrimitiveBacklogItem {
+    pub fn includes_integration(&self, integration_id: &IntegrationId) -> bool {
+        self.integration_ids
+            .iter()
+            .any(|candidate| candidate == integration_id)
+    }
 }
 
 impl IntegrationCatalogEntry {
@@ -1236,6 +1253,48 @@ pub fn entries_at_or_before_priority(
         .collect()
 }
 
+pub fn primitive_backlog(catalog: &[IntegrationCatalogEntry]) -> Vec<PrimitiveBacklogItem> {
+    primitive_backlog_at_or_before_priority(catalog, u8::MAX)
+}
+
+pub fn primitive_backlog_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+) -> Vec<PrimitiveBacklogItem> {
+    let mut by_primitive: BTreeMap<PrimitiveFamily, (u8, Vec<IntegrationId>)> = BTreeMap::new();
+
+    for entry in catalog.iter().filter(|entry| entry.priority <= priority) {
+        for primitive in &entry.required_primitives {
+            let (highest_priority, integration_ids) = by_primitive
+                .entry(*primitive)
+                .or_insert((entry.priority, Vec::new()));
+            *highest_priority = (*highest_priority).min(entry.priority);
+            if !integration_ids.contains(&entry.integration_id) {
+                integration_ids.push(entry.integration_id.clone());
+            }
+        }
+    }
+
+    let mut backlog = by_primitive
+        .into_iter()
+        .map(
+            |(primitive, (highest_priority, integration_ids))| PrimitiveBacklogItem {
+                primitive,
+                highest_priority,
+                entry_count: integration_ids.len(),
+                integration_ids,
+            },
+        )
+        .collect::<Vec<_>>();
+    backlog.sort_by(|left, right| {
+        left.highest_priority
+            .cmp(&right.highest_priority)
+            .then_with(|| right.entry_count.cmp(&left.entry_count))
+            .then_with(|| left.primitive.cmp(&right.primitive))
+    });
+    backlog
+}
+
 pub fn policy_surfaces_for_entry(entry: &IntegrationCatalogEntry) -> Vec<IntegrationPolicySurface> {
     let mut surfaces = Vec::new();
 
@@ -1838,12 +1897,14 @@ fn protocol_primitives(protocol: &ProtocolFamily) -> &'static [PrimitiveFamily] 
             PrimitiveFamily::SerialController,
             PrimitiveFamily::Radio802154,
             PrimitiveFamily::RadioNetworkKey,
+            PrimitiveFamily::Supervision,
         ],
         ProtocolFamily::ZWave => &[
             PrimitiveFamily::Usb,
             PrimitiveFamily::SerialController,
             PrimitiveFamily::ZWaveSerialApi,
             PrimitiveFamily::RadioNetworkKey,
+            PrimitiveFamily::Supervision,
         ],
         ProtocolFamily::Thread => &[
             PrimitiveFamily::Usb,
@@ -1851,17 +1912,20 @@ fn protocol_primitives(protocol: &ProtocolFamily) -> &'static [PrimitiveFamily] 
             PrimitiveFamily::Radio802154,
             PrimitiveFamily::Mdns,
             PrimitiveFamily::RadioNetworkKey,
+            PrimitiveFamily::Supervision,
         ],
         ProtocolFamily::Matter => &[
             PrimitiveFamily::Mdns,
             PrimitiveFamily::MatterCommissioning,
             PrimitiveFamily::CertificatePairing,
             PrimitiveFamily::LocalPairing,
+            PrimitiveFamily::Supervision,
         ],
         ProtocolFamily::Mqtt => &[
             PrimitiveFamily::Mqtt,
             PrimitiveFamily::MqttCredentials,
             PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::Supervision,
         ],
         ProtocolFamily::Vendor(_) => &[PrimitiveFamily::LocalHttp, PrimitiveFamily::CommandMapping],
     }
@@ -2141,6 +2205,36 @@ mod tests {
         assert!(!early
             .iter()
             .any(|entry| entry.integration_id == IntegrationId::trusted("tuya")));
+    }
+
+    #[test]
+    fn primitive_backlog_ranks_rollout_wave_foundations() {
+        let catalog = first_party_catalog();
+        let backlog = primitive_backlog_at_or_before_priority(&catalog, 1);
+        let supervision = backlog
+            .iter()
+            .find(|item| item.primitive == PrimitiveFamily::Supervision)
+            .unwrap();
+        let radio = backlog
+            .iter()
+            .find(|item| item.primitive == PrimitiveFamily::Radio802154)
+            .unwrap();
+        let mqtt = backlog
+            .iter()
+            .find(|item| item.primitive == PrimitiveFamily::Mqtt)
+            .unwrap();
+
+        assert_eq!(backlog[0].highest_priority, 0);
+        assert_eq!(supervision.highest_priority, 0);
+        assert!(supervision.entry_count >= 8);
+        assert!(supervision.includes_integration(&IntegrationId::trusted("hue")));
+        assert!(supervision.includes_integration(&IntegrationId::trusted("zigbee")));
+        assert!(supervision.includes_integration(&IntegrationId::trusted("zwave")));
+        assert!(supervision.includes_integration(&IntegrationId::trusted("thread")));
+        assert!(radio.includes_integration(&IntegrationId::trusted("zigbee")));
+        assert!(radio.includes_integration(&IntegrationId::trusted("thread")));
+        assert!(mqtt.includes_integration(&IntegrationId::trusted("mqtt")));
+        assert!(mqtt.includes_integration(&IntegrationId::trusted("tasmota")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add primitive backlog helpers for ranking shared smart-home primitive families by rollout priority
- add explicit supervision primitive hints to protocol-standard seeds for Zigbee, Z-Wave, Thread, Matter, and MQTT
- document the backlog planning surface in the integration catalog README and changelog

## Validation
- cargo test --manifest-path code/packages/rust/Cargo.toml -p smart-home-integration-catalog
- cargo clippy --manifest-path code/packages/rust/Cargo.toml -p smart-home-integration-catalog --all-targets -- -D warnings
- git diff --check