### PR TITLE
Expose Board VM wireless target capabilities

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -197,6 +197,32 @@ class BoardTarget:
         return int(self.raw["digital_pin_count"])
 
     @property
+    def wireless(self) -> list[dict[str, Any]]:
+        return [dict(item) for item in self.raw.get("wireless", [])]
+
+    @property
+    def wireless_transports(self) -> list[str]:
+        return [str(item["transport"]) for item in self.wireless]
+
+    def supports_wireless_transport(self, transport: str) -> bool:
+        return str(transport) in self.wireless_transports
+
+    @property
+    def supports_wifi(self) -> bool:
+        return self.supports_wireless_transport("wifi")
+
+    @property
+    def supports_bluetooth(self) -> bool:
+        return any(
+            transport.startswith("bluetooth")
+            for transport in self.wireless_transports
+        )
+
+    @property
+    def supports_ota_update(self) -> bool:
+        return any(bool(item.get("ota_update")) for item in self.wireless)
+
+    @property
     def capabilities(self) -> list[str]:
         return [str(capability) for capability in self.raw.get("capabilities", [])]
 

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -20,9 +20,10 @@ use board_vm_language_core::{
     decode_wire_response, detect_target as core_detect_target,
     discover_devices as core_discover_devices, discover_devices_from_paths,
     esp_upload_options_for_target, known_targets, onboard_led_kind, program_format_name,
-    raw_module_len, run_status_name, BoardVmLanguageSession, DecodedLanguageResponse,
-    DecodedLanguageResponseBody, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
-    LanguageOnboardLed, LanguageTargetInfo, LanguageValue,
+    raw_module_len, run_status_name, wireless_transport_name, BoardVmLanguageSession,
+    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError,
+    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguageTargetInfo,
+    LanguageValue, LanguageWirelessInterface,
 };
 use python_bridge::*;
 
@@ -745,12 +746,34 @@ unsafe fn language_target_to_py(target: &LanguageTargetInfo) -> PyObjectPtr {
         "digital_pin_count",
         usize_to_py(target.digital_pin_count),
     );
+    dict_set(dict, "wireless", language_wireless_to_py(&target.wireless));
     let capabilities = PyList_New(target.capabilities.len() as isize);
     for (index, capability) in target.capabilities.iter().enumerate() {
         PyList_SetItem(capabilities, index as isize, str_to_py(capability));
     }
     dict_set(dict, "capabilities", capabilities);
     dict
+}
+
+unsafe fn language_wireless_to_py(interfaces: &[LanguageWirelessInterface]) -> PyObjectPtr {
+    let list = PyList_New(interfaces.len() as isize);
+    for (index, interface) in interfaces.iter().enumerate() {
+        let dict = PyDict_New();
+        dict_set(
+            dict,
+            "transport",
+            str_to_py(wireless_transport_name(interface.transport)),
+        );
+        dict_set(dict, "chip", str_to_py(&interface.chip));
+        dict_set(
+            dict,
+            "command_transport",
+            bool_to_py(interface.command_transport),
+        );
+        dict_set(dict, "ota_update", bool_to_py(interface.ota_update));
+        PyList_SetItem(list, index as isize, dict);
+    }
+    list
 }
 
 unsafe fn esp_upload_options_to_py(options: &LanguageEspUploadOptions) -> PyObjectPtr {

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -84,17 +84,33 @@ def test_native_session_builds_protocol_bytes_in_rust():
 
 def test_known_targets_are_exposed_from_rust_registry():
     targets = known_targets()
+    uno_r4_wifi = find_target("arduino-uno-r4-wifi")
     esp32 = find_target("esp32-devkit-v1")
+    pico = find_target("raspberry-pi-pico")
     pico_w = find_target("raspberry-pi-pico-w")
 
     assert all(isinstance(target, BoardTarget) for target in targets)
+    assert uno_r4_wifi is not None
+    assert "transport.wifi" in uno_r4_wifi.capabilities
+    assert "transport.bluetooth_le" in uno_r4_wifi.capabilities
+    assert uno_r4_wifi.wireless_transports == ["wifi", "bluetooth_le"]
+    assert uno_r4_wifi.supports_wifi is True
+    assert uno_r4_wifi.supports_bluetooth is True
+    assert uno_r4_wifi.supports_ota_update is True
     assert esp32 is not None
     assert esp32.family == "esp32"
     assert esp32.runtime_id == "board-vm-esp32"
     assert esp32.onboard_led_pin == 2
     assert "gpio.open" in esp32.capabilities
+    assert "transport.bluetooth_classic" in esp32.capabilities
+    assert all(item["command_transport"] for item in esp32.wireless)
+    assert pico is not None
+    assert pico.wireless == []
+    assert "transport.wifi" not in pico.capabilities
     assert pico_w is not None
     assert pico_w.onboard_led == {"kind": "wireless_chip_gpio", "pin": 0}
+    assert "transport.wifi" in pico_w.capabilities
+    assert "ota.wifi" in pico_w.capabilities
 
 
 def test_targets_are_detected_from_rust_owned_aliases():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -21,9 +21,10 @@ use board_vm_language_core::{
     decode_wire_response, detect_target as core_detect_target,
     discover_devices as core_discover_devices, discover_devices_from_paths,
     esp_upload_options_for_target, known_targets, onboard_led_kind, program_format_name,
-    raw_module_len, run_status_name, BoardVmLanguageSession, DecodedLanguageResponse,
-    DecodedLanguageResponseBody, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
-    LanguageOnboardLed, LanguageTargetInfo, LanguageValue,
+    raw_module_len, run_status_name, wireless_transport_name, BoardVmLanguageSession,
+    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError,
+    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguageTargetInfo,
+    LanguageValue, LanguageWirelessInterface,
 };
 use ruby_bridge::VALUE;
 
@@ -653,12 +654,38 @@ fn language_target_to_rb(target: &LanguageTargetInfo) -> VALUE {
         "digital_pin_count",
         rb_usize(target.digital_pin_count),
     );
+    hash_set(hash, "wireless", language_wireless_to_rb(&target.wireless));
     let capabilities = ruby_bridge::array_new();
     for capability in &target.capabilities {
         ruby_bridge::array_push(capabilities, ruby_bridge::str_to_rb(capability));
     }
     hash_set(hash, "capabilities", capabilities);
     hash
+}
+
+fn language_wireless_to_rb(interfaces: &[LanguageWirelessInterface]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for interface in interfaces {
+        let hash = ruby_bridge::hash_new();
+        hash_set(
+            hash,
+            "transport",
+            ruby_bridge::str_to_rb(wireless_transport_name(interface.transport)),
+        );
+        hash_set(hash, "chip", ruby_bridge::str_to_rb(&interface.chip));
+        hash_set(
+            hash,
+            "command_transport",
+            ruby_bridge::bool_to_rb(interface.command_transport),
+        );
+        hash_set(
+            hash,
+            "ota_update",
+            ruby_bridge::bool_to_rb(interface.ota_update),
+        );
+        ruby_bridge::array_push(array, hash);
+    }
+    array
 }
 
 fn esp_upload_options_to_rb(options: &LanguageEspUploadOptions) -> VALUE {

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -25,15 +25,27 @@ module CodingAdventures
 
       def test_known_targets_are_exposed_from_rust_registry
         targets = BoardVM.known_targets
+        uno_r4_wifi = BoardVM.find_target("arduino-uno-r4-wifi")
         esp32 = BoardVM.find_target("esp32-devkit-v1")
+        pico = BoardVM.find_target("raspberry-pi-pico")
         pico_w = BoardVM.find_target("raspberry-pi-pico-w")
 
         assert targets.any? { |target| target["board_id"] == "arduino-uno-r4-wifi" }
+        assert_includes uno_r4_wifi["capabilities"], "transport.wifi"
+        assert_includes uno_r4_wifi["capabilities"], "transport.bluetooth_le"
+        assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
+        assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
         assert_equal "esp32", esp32["family"]
         assert_equal "board-vm-esp32", esp32["runtime_id"]
         assert_equal({ "kind" => "gpio", "pin" => 2 }, esp32["onboard_led"])
         assert_includes esp32["capabilities"], "gpio.open"
+        assert_includes esp32["capabilities"], "transport.bluetooth_classic"
+        assert esp32["wireless"].all? { |item| item["command_transport"] }
+        assert_equal [], pico["wireless"]
+        refute_includes pico["capabilities"], "transport.wifi"
         assert_equal({ "kind" => "wireless_chip_gpio", "pin" => 0 }, pico_w["onboard_led"])
+        assert_includes pico_w["capabilities"], "transport.wifi"
+        assert_includes pico_w["capabilities"], "ota.wifi"
       end
 
       def test_targets_are_detected_from_rust_owned_aliases

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -39,7 +39,10 @@ use board_vm_protocol::{
     RunStatus, Value as ProtocolValue, CAP_FLAG_BOARD_METADATA, CAP_FLAG_BYTECODE_CALLABLE,
     CAP_FLAG_PROTOCOL_FEATURE, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
 };
-use board_vm_targets::{all_targets, BoardFamily, BoardTargetInfo, OnboardLed as TargetOnboardLed};
+use board_vm_targets::{
+    all_targets, BoardFamily, BoardTargetInfo, OnboardLed as TargetOnboardLed,
+    WirelessInterfaceInfo as TargetWirelessInterface, WirelessTransport as TargetWirelessTransport,
+};
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
 pub const LANGUAGE_CORE_VERSION_MINOR: u16 = 1;
@@ -259,6 +262,21 @@ pub enum LanguageOnboardLed {
     WirelessChipGpio(u8),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageWirelessTransport {
+    Wifi,
+    BluetoothLe,
+    BluetoothClassic,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageWirelessInterface {
+    pub transport: LanguageWirelessTransport,
+    pub chip: String,
+    pub command_transport: bool,
+    pub ota_update: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageTargetInfo {
     pub board_id: String,
@@ -272,6 +290,7 @@ pub struct LanguageTargetInfo {
     pub operating_voltage_mv: u16,
     pub onboard_led: Option<LanguageOnboardLed>,
     pub digital_pin_count: usize,
+    pub wireless: Vec<LanguageWirelessInterface>,
     pub capabilities: Vec<String>,
 }
 
@@ -410,6 +429,14 @@ pub const fn onboard_led_kind(led: LanguageOnboardLed) -> &'static str {
     match led {
         LanguageOnboardLed::Gpio(_) => "gpio",
         LanguageOnboardLed::WirelessChipGpio(_) => "wireless_chip_gpio",
+    }
+}
+
+pub const fn wireless_transport_name(transport: LanguageWirelessTransport) -> &'static str {
+    match transport {
+        LanguageWirelessTransport::Wifi => "wifi",
+        LanguageWirelessTransport::BluetoothLe => "bluetooth_le",
+        LanguageWirelessTransport::BluetoothClassic => "bluetooth_classic",
     }
 }
 
@@ -555,11 +582,33 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
         operating_voltage_mv: target.operating_voltage_mv,
         onboard_led: target.onboard_led.map(language_onboard_led),
         digital_pin_count: target.digital_pin_count,
+        wireless: target
+            .wireless
+            .iter()
+            .map(language_wireless_interface)
+            .collect(),
         capabilities: target
             .capabilities
             .iter()
             .map(|capability| (*capability).to_owned())
             .collect(),
+    }
+}
+
+fn language_wireless_interface(interface: &TargetWirelessInterface) -> LanguageWirelessInterface {
+    LanguageWirelessInterface {
+        transport: language_wireless_transport(interface.transport),
+        chip: interface.chip.to_owned(),
+        command_transport: interface.command_transport,
+        ota_update: interface.ota_update,
+    }
+}
+
+fn language_wireless_transport(transport: TargetWirelessTransport) -> LanguageWirelessTransport {
+    match transport {
+        TargetWirelessTransport::Wifi => LanguageWirelessTransport::Wifi,
+        TargetWirelessTransport::BluetoothLe => LanguageWirelessTransport::BluetoothLe,
+        TargetWirelessTransport::BluetoothClassic => LanguageWirelessTransport::BluetoothClassic,
     }
 }
 
@@ -1966,10 +2015,22 @@ mod tests {
         assert_eq!(esp32.runtime_id, "board-vm-esp32");
         assert_eq!(esp32.onboard_led, Some(LanguageOnboardLed::Gpio(2)));
         assert!(esp32.capabilities.contains(&"gpio.open".to_owned()));
+        assert!(esp32
+            .capabilities
+            .contains(&"transport.bluetooth_classic".to_owned()));
+        assert!(esp32.wireless.iter().any(|interface| interface.transport
+            == LanguageWirelessTransport::Wifi
+            && interface.command_transport
+            && interface.ota_update));
         assert_eq!(
             pico_w.onboard_led,
             Some(LanguageOnboardLed::WirelessChipGpio(0))
         );
+        assert!(pico_w.capabilities.contains(&"transport.wifi".to_owned()));
+        assert!(known_target("raspberry-pi-pico")
+            .unwrap()
+            .wireless
+            .is_empty());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -4,8 +4,23 @@ Host-side Board VM target registry for supported boards.
 
 The registry gives generic front ends and language bindings one stable place to
 ask which boards are known, what runtime id they use, what Rust target they
-compile for, and where their onboard LED lives. Board-specific runtime crates
-remain responsible for HAL behavior and pin validation.
+compile for, where their onboard LED lives, and which host transports are
+available. Board-specific runtime crates remain responsible for HAL behavior,
+pin validation, wireless stack integration, and upload mechanics.
+
+Wireless metadata separates physical support from the generic front-end sugar:
+
+- every current target exposes `transport.serial`
+- Arduino Uno R4 WiFi exposes Wi-Fi and Bluetooth LE through its ESP32-S3
+  coprocessor
+- ESP32 DevKit V1 exposes Wi-Fi, Bluetooth LE, and Bluetooth Classic natively
+- Raspberry Pi Pico exposes no wireless transports
+- Raspberry Pi Pico W exposes Wi-Fi, Bluetooth LE, and Bluetooth Classic through
+  its CYW43439 radio
+
+Wi-Fi OTA is marked as a feasible Board VM update path for the wireless targets;
+Bluetooth command channels are tracked separately because OTA over Bluetooth is
+possible but not the first practical update path.
 
 Host-side validation:
 

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -14,6 +14,21 @@ pub enum OnboardLed {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WirelessTransport {
+    Wifi,
+    BluetoothLe,
+    BluetoothClassic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WirelessInterfaceInfo {
+    pub transport: WirelessTransport,
+    pub chip: &'static str,
+    pub command_transport: bool,
+    pub ota_update: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoardTargetInfo {
     pub board_id: &'static str,
     pub display_name: &'static str,
@@ -26,10 +41,12 @@ pub struct BoardTargetInfo {
     pub operating_voltage_mv: u16,
     pub onboard_led: Option<OnboardLed>,
     pub digital_pin_count: usize,
+    pub wireless: &'static [WirelessInterfaceInfo],
     pub capabilities: &'static [&'static str],
 }
 
-pub const BLINK_MVP_CAPABILITIES: [&str; 7] = [
+pub const BLINK_MVP_CAPABILITIES: [&str; 8] = [
+    "transport.serial",
     "gpio.open",
     "gpio.write",
     "gpio.read",
@@ -37,6 +54,107 @@ pub const BLINK_MVP_CAPABILITIES: [&str; 7] = [
     "time.sleep_ms",
     "time.now_ms",
     "program.ram_exec",
+];
+
+pub const UNO_R4_WIFI_CAPABILITIES: [&str; 11] = [
+    "transport.serial",
+    "transport.wifi",
+    "transport.bluetooth_le",
+    "ota.wifi",
+    "gpio.open",
+    "gpio.write",
+    "gpio.read",
+    "gpio.close",
+    "time.sleep_ms",
+    "time.now_ms",
+    "program.ram_exec",
+];
+
+pub const ESP32_CAPABILITIES: [&str; 12] = [
+    "transport.serial",
+    "transport.wifi",
+    "transport.bluetooth_le",
+    "transport.bluetooth_classic",
+    "ota.wifi",
+    "gpio.open",
+    "gpio.write",
+    "gpio.read",
+    "gpio.close",
+    "time.sleep_ms",
+    "time.now_ms",
+    "program.ram_exec",
+];
+
+pub const PICO_W_CAPABILITIES: [&str; 12] = [
+    "transport.serial",
+    "transport.wifi",
+    "transport.bluetooth_le",
+    "transport.bluetooth_classic",
+    "ota.wifi",
+    "gpio.open",
+    "gpio.write",
+    "gpio.read",
+    "gpio.close",
+    "time.sleep_ms",
+    "time.now_ms",
+    "program.ram_exec",
+];
+
+pub const UNO_R4_WIFI_WIRELESS: [WirelessInterfaceInfo; 2] = [
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::Wifi,
+        chip: "ESP32-S3 coprocessor",
+        command_transport: true,
+        ota_update: true,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothLe,
+        chip: "ESP32-S3 coprocessor",
+        command_transport: true,
+        ota_update: false,
+    },
+];
+
+pub const ESP32_WIRELESS: [WirelessInterfaceInfo; 3] = [
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::Wifi,
+        chip: "ESP32-WROOM-32",
+        command_transport: true,
+        ota_update: true,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothLe,
+        chip: "ESP32-WROOM-32",
+        command_transport: true,
+        ota_update: false,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothClassic,
+        chip: "ESP32-WROOM-32",
+        command_transport: true,
+        ota_update: false,
+    },
+];
+
+pub const PICO_W_WIRELESS: [WirelessInterfaceInfo; 3] = [
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::Wifi,
+        chip: "Infineon CYW43439",
+        command_transport: true,
+        ota_update: true,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothLe,
+        chip: "Infineon CYW43439",
+        command_transport: true,
+        ota_update: false,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothClassic,
+        chip: "Infineon CYW43439",
+        command_transport: true,
+        ota_update: false,
+    },
 ];
 
 pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
@@ -54,6 +172,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             board_vm_uno_r4::UNO_R4_MINIMA.onboard_led_pin,
         )),
         digital_pin_count: board_vm_uno_r4::UNO_R4_MINIMA.digital_pins.len(),
+        wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
     BoardTargetInfo {
@@ -70,7 +189,8 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             board_vm_uno_r4::UNO_R4_WIFI.onboard_led_pin,
         )),
         digital_pin_count: board_vm_uno_r4::UNO_R4_WIFI.digital_pins.len(),
-        capabilities: &BLINK_MVP_CAPABILITIES,
+        wireless: &UNO_R4_WIFI_WIRELESS,
+        capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
     BoardTargetInfo {
         board_id: board_vm_esp32::ESP32_DEVKIT_V1.board_id,
@@ -87,7 +207,8 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             None => None,
         },
         digital_pin_count: board_vm_esp32::ESP32_DEVKIT_V1.digital_pins.len(),
-        capabilities: &BLINK_MVP_CAPABILITIES,
+        wireless: &ESP32_WIRELESS,
+        capabilities: &ESP32_CAPABILITIES,
     },
     BoardTargetInfo {
         board_id: board_vm_pico::PICO.board_id,
@@ -107,6 +228,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             None => None,
         },
         digital_pin_count: board_vm_pico::PICO.digital_pins.len(),
+        wireless: &[],
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
     BoardTargetInfo {
@@ -127,7 +249,8 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
             None => None,
         },
         digital_pin_count: board_vm_pico::PICO_W.digital_pins.len(),
-        capabilities: &BLINK_MVP_CAPABILITIES,
+        wireless: &PICO_W_WIRELESS,
+        capabilities: &PICO_W_CAPABILITIES,
     },
 ];
 
@@ -173,7 +296,34 @@ mod tests {
     fn registry_exposes_common_runtime_capabilities() {
         let pico = find_target("raspberry-pi-pico").unwrap();
         assert_eq!(pico.runtime_id, "board-vm-pico");
+        assert!(pico.capabilities.contains(&"transport.serial"));
         assert!(pico.capabilities.contains(&"gpio.open"));
         assert!(pico.capabilities.contains(&"program.ram_exec"));
+    }
+
+    #[test]
+    fn registry_exposes_wireless_only_for_wireless_boards() {
+        let uno_r4_minima = find_target("arduino-uno-r4-minima").unwrap();
+        let uno_r4_wifi = find_target("arduino-uno-r4-wifi").unwrap();
+        let esp32 = find_target("esp32-devkit-v1").unwrap();
+        let pico = find_target("raspberry-pi-pico").unwrap();
+        let pico_w = find_target("raspberry-pi-pico-w").unwrap();
+
+        assert!(uno_r4_minima.wireless.is_empty());
+        assert!(pico.wireless.is_empty());
+        assert!(uno_r4_wifi.capabilities.contains(&"transport.wifi"));
+        assert!(uno_r4_wifi.capabilities.contains(&"transport.bluetooth_le"));
+        assert!(!uno_r4_wifi
+            .capabilities
+            .contains(&"transport.bluetooth_classic"));
+        assert!(esp32.capabilities.contains(&"transport.bluetooth_classic"));
+        assert!(pico_w.capabilities.contains(&"transport.wifi"));
+        assert!(pico_w.capabilities.contains(&"ota.wifi"));
+        assert!(pico_w
+            .wireless
+            .iter()
+            .any(|interface| interface.transport == WirelessTransport::Wifi
+                && interface.command_transport
+                && interface.ota_update));
     }
 }


### PR DESCRIPTION
## Summary
- adds Rust-owned wireless target metadata for Wi-Fi, Bluetooth LE, Bluetooth Classic, command-channel feasibility, and OTA feasibility
- exposes that metadata through the Ruby and Python native bridges while keeping language frontends as thin sugar over the Rust registry
- marks Uno R4 WiFi and ESP32 as wireless-capable, keeps Raspberry Pi Pico wireless-free, and exposes Pico W wireless separately

## Validation
- `cargo test -p board-vm-targets -p board-vm-language-core`
- `bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`

## Notes
- Wi-Fi OTA is exposed as the practical OTA path for wireless targets.
- Bluetooth transports are exposed as command channels, with Bluetooth OTA left unadvertised for now because it should be a later, explicit protocol path rather than an accidental promise.
