### PR TITLE
[codex] Extend html5lib tree smoke coverage through case 45

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -612,3 +612,16 @@ Line1<br>Line2<br>Line3<br>Line4
 | <html>
 |   <head>
 |   <body>
+
+#data
+<!COMMENT>
+#errors
+(1,2): expected-dashes-or-doctype
+(1,10): expected-doctype-but-got-eof
+#new-errors
+(1:3) incorrectly-opened-comment
+#document
+| <!-- COMMENT -->
+| <html>
+|   <head>
+|   <body>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 45
- capture the existing incorrectly-opened-comment recovery for <!COMMENT>

## Tests
- cargo test -p coding-adventures-html-parser --test tree_construction_test
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer