### PR TITLE
[codex] Extend html5lib tree smoke coverage through case 46

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -625,3 +625,16 @@ Line1<br>Line2<br>Line3<br>Line4
 | <html>
 |   <head>
 |   <body>
+
+#data
+</ COMMENT >
+#errors
+(1,2): expected-closing-tag-but-got-char
+(1,12): expected-doctype-but-got-eof
+#new-errors
+(1:3) invalid-first-character-of-tag-name
+#document
+| <!--  COMMENT  -->
+| <html>
+|   <head>
+|   <body>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 46
- capture the existing invalid end-tag opener recovery for </ COMMENT >

## Tests
- cargo test -p coding-adventures-html-parser --test tree_construction_test
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer