### PR TITLE
Add interactive Board VM device picker sugar

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import Any, Iterable
 
@@ -1238,6 +1239,46 @@ def select_device(
     raise ValueError(f"{reason}.\n{device_list(candidates)}")
 
 
+def pick_device(
+    selector: str = "auto",
+    *,
+    device_candidates: Iterable[BoardDevice | dict[str, Any]] | None = None,
+    input_func: Any = input,
+    output: Any = None,
+) -> BoardDevice:
+    candidates = [
+        item if isinstance(item, BoardDevice) else BoardDevice(item)
+        for item in (devices() if device_candidates is None else device_candidates)
+    ]
+    if not candidates:
+        raise ValueError("No Board VM devices found. Plug in a board.")
+
+    try:
+        return select_device(selector, device_candidates=candidates)
+    except ValueError:
+        pass
+
+    output = sys.stdout if output is None else output
+    output.write(device_list(candidates))
+    output.write("\n")
+    output.write(f"Select board [1-{len(candidates)}]: ")
+    choice = input_func("")
+    try:
+        index = int(str(choice).strip())
+    except ValueError as error:
+        raise ValueError(f"Invalid Board VM device selection: {choice!r}") from error
+    if not 1 <= index <= len(candidates):
+        raise ValueError(f"Invalid Board VM device selection: {choice!r}")
+
+    selected = candidates[index - 1]
+    target = None if selector == "auto" else detect_target(selector)
+    if target is not None and selected.target is not None and selected.target.board_id != target.board_id:
+        raise ValueError(
+            f"Selected {selected.port} is {selected.target.board_id}, not {target.board_id}."
+        )
+    return selected
+
+
 def esp_upload_command(
     selector: str = "esp32-devkit-v1",
     *,
@@ -1333,5 +1374,6 @@ __all__ = [
     "esp_upload_options",
     "find_target",
     "known_targets",
+    "pick_device",
     "select_device",
 ]

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -1,3 +1,5 @@
+import io
+
 from board_vm_native import (
     BoardDevice,
     BoardDescriptor,
@@ -12,6 +14,7 @@ from board_vm_native import (
     esp_upload_options,
     find_target,
     known_targets,
+    pick_device,
     select_device,
 )
 
@@ -251,6 +254,25 @@ def test_devices_are_classified_by_rust_language_core():
     rendered = device_list(found)
     assert "ESP32 DevKit V1" in rendered
     assert "/dev/cu.usbmodem1101" in rendered
+
+
+def test_pick_device_prompts_for_ambiguous_devices():
+    found = devices([
+        "/dev/cu.usbmodem1101",
+        "/dev/cu.usbmodem2201",
+    ])
+    output = io.StringIO()
+
+    selected = pick_device(
+        device_candidates=found,
+        input_func=lambda _prompt: "2",
+        output=output,
+    )
+
+    assert selected.port == "/dev/cu.usbmodem2201"
+    assert "1. Unknown board" in output.getvalue()
+    assert "2. Unknown board" in output.getvalue()
+    assert "Select board [1-2]: " in output.getvalue()
 
 
 def test_session_dispatches_frames_through_write_transport():

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -71,6 +71,35 @@ module CodingAdventures
       raise DeviceSelectionError, "#{reason}.\n#{device_list(candidates)}"
     end
 
+    def pick_device(board: :auto, devices: nil, input: $stdin, output: $stdout)
+      candidates = devices || self.devices
+      raise DeviceSelectionError, "No Board VM devices found. Plug in a board." if candidates.empty?
+
+      begin
+        return select_device(board: board, devices: candidates)
+      rescue DeviceSelectionError
+        # Fall through to an explicit numbered picker for REPL/script use.
+      end
+
+      output.puts device_list(candidates)
+      output.print "Select board [1-#{candidates.length}]: "
+      choice = input.gets
+      index = Integer(choice.to_s.strip, exception: false)
+      unless index && index.between?(1, candidates.length)
+        raise DeviceSelectionError, "Invalid Board VM device selection: #{choice.inspect}"
+      end
+
+      selected = candidates.fetch(index - 1)
+      requested_board = board == :auto ? :auto : normalize_board(board)
+      selected_board = device_target_board(selected)
+      if requested_board != :auto && selected_board && selected_board != requested_board
+        raise DeviceSelectionError,
+          "Selected #{selected.fetch("port")} is #{selected_board}, not #{requested_board}."
+      end
+
+      selected
+    end
+
     def known_targets
       Native.known_targets
     end
@@ -132,12 +161,19 @@ module CodingAdventures
       port: nil,
       device: nil,
       devices: nil,
+      pick: false,
+      input: $stdin,
+      output: $stdout,
       flash: false,
       cargo_workspace: DEFAULT_RUST_WORKSPACE,
       runner: CommandRunner.new,
       transport: nil,
       **options
     )
+      if pick && port.nil? && device.nil?
+        device = pick_device(board: board, devices: devices, input: input, output: output)
+      end
+
       selection = connection_selection(board: board, port: port, device: device, devices: devices)
       connection = Connection.new(
         board: selection.fetch(:board),

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -150,6 +150,43 @@ module CodingAdventures
         assert_includes error.message, "/dev/cu.usbmodem2201"
       end
 
+      def test_pick_device_prompts_for_ambiguous_devices
+        devices = BoardVM.devices(paths: [
+          "/dev/cu.usbmodem1101",
+          "/dev/cu.usbmodem2201"
+        ])
+        output = StringIO.new
+        input = StringIO.new("2\n")
+
+        selected = BoardVM.pick_device(devices: devices, input: input, output: output)
+
+        assert_equal "/dev/cu.usbmodem2201", selected["port"]
+        assert_includes output.string, "1. Unknown board"
+        assert_includes output.string, "2. Unknown board"
+        assert_includes output.string, "Select board [1-2]: "
+      end
+
+      def test_connect_can_use_interactive_picker_without_a_port
+        runner = FakeRunner.new
+        devices = BoardVM.devices(paths: [
+          "/dev/cu.usbmodem1101",
+          "/dev/tty.usbserial-CP2102-esp32"
+        ])
+
+        connection = BoardVM.connect(
+          pick: true,
+          devices: devices,
+          input: StringIO.new("2\n"),
+          output: StringIO.new,
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: runner
+        )
+
+        assert_equal :esp32_devkit_v1, connection.board
+        assert_equal "/dev/tty.usbserial-CP2102-esp32", connection.port
+        assert_empty runner.calls
+      end
+
       def test_connect_flash_uploads_the_uno_r4_serialusb_vm_and_tracks_runtime_port
         upload = CommandResult.new(
           ["cargo"],

--- a/code/packages/ruby/board_vm/test/test_helper.rb
+++ b/code/packages/ruby/board_vm/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "stringio"
 require "coding_adventures_board_vm"
 
 class FakeRunner


### PR DESCRIPTION
## Summary
- add Ruby `BoardVM.pick_device` and `connect(pick: true)` for numbered device selection when auto-detection is ambiguous
- add Python `pick_device` with the same numbered picker over Rust-owned discovered devices
- keep port discovery/classification in the native Rust bridge while Ruby/Python stay as thin REPL/script sugar

## Validation
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q` in `code/packages/python/board-vm-native`
- `cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`