### PR TITLE
Expose Pico UF2 upload through language bridges

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -271,6 +271,31 @@ class EspUploadOptions:
 
 
 @dataclass(frozen=True)
+class PicoUf2UploadOptions:
+    raw: dict[str, Any]
+
+    @property
+    def board_id(self) -> str:
+        return str(self.raw["board_id"])
+
+    @property
+    def command(self) -> str:
+        return str(self.raw["command"])
+
+    @property
+    def volume_label(self) -> str:
+        return str(self.raw["volume_label"])
+
+    @property
+    def image_extension(self) -> str:
+        return str(self.raw["image_extension"])
+
+    @property
+    def auto_detect_mount(self) -> bool:
+        return bool(self.raw["auto_detect_mount"])
+
+
+@dataclass(frozen=True)
 class BoardDevice:
     raw: dict[str, Any]
 
@@ -1176,6 +1201,18 @@ def esp_upload_options(
     return EspUploadOptions(merged)
 
 
+def pico_uf2_upload_options(
+    selector: str = "raspberry-pi-pico",
+    **overrides: Any,
+) -> PicoUf2UploadOptions | None:
+    raw = _native.pico_uf2_upload_options(str(selector))
+    if raw is None:
+        return None
+    merged = dict(raw)
+    merged.update(overrides)
+    return PicoUf2UploadOptions(merged)
+
+
 DeviceReference = BoardDevice | dict[str, Any] | str | int
 
 
@@ -1325,6 +1362,27 @@ def esp_upload_command(
     return command
 
 
+def pico_uf2_upload_command(
+    selector: str = "raspberry-pi-pico",
+    *,
+    image: str,
+    mount: str | None = None,
+    **overrides: Any,
+) -> list[str]:
+    options = pico_uf2_upload_options(selector, **overrides)
+    if options is None:
+        raise ValueError(f"Pico UF2 upload is not supported for {selector!r}")
+
+    command = [
+        options.command,
+        "--image",
+        str(image),
+    ]
+    if mount is not None:
+        command.extend(["--mount", str(mount)])
+    return command
+
+
 def devices(paths: Iterable[str] | None = None) -> list[BoardDevice]:
     raw_devices = (
         _native.discover_devices()
@@ -1360,6 +1418,7 @@ __all__ = [
     "EspUploadOptions",
     "GPIO_MODES",
     "GPIO_READ_MODES",
+    "PicoUf2UploadOptions",
     "ProtocolResult",
     "RUN_FLAG_BACKGROUND_RUN",
     "RUN_FLAG_KEEP_HANDLES_AFTER_RUN",
@@ -1374,6 +1433,8 @@ __all__ = [
     "esp_upload_options",
     "find_target",
     "known_targets",
+    "pico_uf2_upload_command",
+    "pico_uf2_upload_options",
     "pick_device",
     "select_device",
 ]

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -19,11 +19,12 @@ use board_vm_language_core::{
     capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
     decode_wire_response, detect_target as core_detect_target,
     discover_devices as core_discover_devices, discover_devices_from_paths,
-    esp_upload_options_for_target, known_targets, onboard_led_kind, program_format_name,
-    raw_module_len, run_status_name, wireless_transport_name, BoardVmLanguageSession,
-    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError,
-    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguageTargetInfo,
-    LanguageValue, LanguageWirelessInterface,
+    esp_upload_options_for_target, known_targets, onboard_led_kind,
+    pico_uf2_upload_options_for_target, program_format_name, raw_module_len, run_status_name,
+    wireless_transport_name, BoardVmLanguageSession, DecodedLanguageResponse,
+    DecodedLanguageResponseBody, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
+    LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageTargetInfo, LanguageValue,
+    LanguageWirelessInterface,
 };
 use python_bridge::*;
 
@@ -485,6 +486,27 @@ unsafe extern "C" fn py_esp_upload_options(_module: PyObjectPtr, args: PyObjectP
     }
 }
 
+unsafe extern "C" fn py_pico_uf2_upload_options(
+    _module: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    let selector = match parse_arg_str(args, 0) {
+        Some(value) => value,
+        None => {
+            set_error(
+                type_error_class(),
+                "pico_uf2_upload_options() requires selector as str",
+            );
+            return ptr::null_mut();
+        }
+    };
+
+    match pico_uf2_upload_options_for_target(&selector) {
+        Some(options) => pico_uf2_upload_options_to_py(&options),
+        None => py_none(),
+    }
+}
+
 unsafe extern "C" fn py_discover_devices(_module: PyObjectPtr, _args: PyObjectPtr) -> PyObjectPtr {
     host_devices_to_py(&core_discover_devices())
 }
@@ -805,6 +827,20 @@ unsafe fn esp_upload_options_to_py(options: &LanguageEspUploadOptions) -> PyObje
     dict
 }
 
+unsafe fn pico_uf2_upload_options_to_py(options: &LanguagePicoUf2UploadOptions) -> PyObjectPtr {
+    let dict = PyDict_New();
+    dict_set(dict, "board_id", str_to_py(&options.board_id));
+    dict_set(dict, "command", str_to_py(&options.command));
+    dict_set(dict, "volume_label", str_to_py(&options.volume_label));
+    dict_set(dict, "image_extension", str_to_py(&options.image_extension));
+    dict_set(
+        dict,
+        "auto_detect_mount",
+        bool_to_py(options.auto_detect_mount),
+    );
+    dict
+}
+
 unsafe fn host_devices_to_py(devices: &[LanguageHostDevice]) -> PyObjectPtr {
     let list = PyList_New(devices.len() as isize);
     for (index, device) in devices.iter().enumerate() {
@@ -1117,7 +1153,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 26] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 27] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1267,6 +1303,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_esp_upload_options),
             ml_flags: METH_VARARGS,
             ml_doc: b"Return Rust-owned ESP ROM upload defaults for a target.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"pico_uf2_upload_options\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_pico_uf2_upload_options),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Return Rust-owned Pico UF2 upload defaults for a target.\0".as_ptr()
                 as *const c_char,
         },
         PyMethodDef {

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -5,6 +5,7 @@ from board_vm_native import (
     BoardDescriptor,
     BoardTarget,
     EspUploadOptions,
+    PicoUf2UploadOptions,
     ProtocolResult,
     Session,
     device_list,
@@ -14,6 +15,8 @@ from board_vm_native import (
     esp_upload_options,
     find_target,
     known_targets,
+    pico_uf2_upload_command,
+    pico_uf2_upload_options,
     pick_device,
     select_device,
 )
@@ -153,6 +156,19 @@ def test_esp_upload_options_are_exposed_from_rust_language_core():
     assert overridden.verify_md5 is False
 
 
+def test_pico_uf2_upload_options_are_exposed_from_rust_language_core():
+    options = pico_uf2_upload_options("pico")
+
+    assert isinstance(options, PicoUf2UploadOptions)
+    assert options.board_id == "raspberry-pi-pico"
+    assert options.command == "pico-uf2"
+    assert options.volume_label == "RPI-RP2"
+    assert options.image_extension == ".uf2"
+    assert options.auto_detect_mount is True
+    assert pico_uf2_upload_options("pico-w") is not None
+    assert pico_uf2_upload_options("esp32") is None
+
+
 def test_esp_upload_command_uses_rust_owned_options():
     command = esp_upload_command(
         "esp32",
@@ -181,6 +197,22 @@ def test_esp_upload_command_uses_rust_owned_options():
         "4194304",
         "--no-verify",
         "--stay-in-bootloader",
+    ]
+
+
+def test_pico_uf2_upload_command_uses_rust_owned_options():
+    command = pico_uf2_upload_command(
+        "pico",
+        image="/tmp/board-vm-pico.uf2",
+        mount="/Volumes/RPI-RP2",
+    )
+
+    assert command == [
+        "pico-uf2",
+        "--image",
+        "/tmp/board-vm-pico.uf2",
+        "--mount",
+        "/Volumes/RPI-RP2",
     ]
 
 

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -20,11 +20,12 @@ use board_vm_language_core::{
     capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
     decode_wire_response, detect_target as core_detect_target,
     discover_devices as core_discover_devices, discover_devices_from_paths,
-    esp_upload_options_for_target, known_targets, onboard_led_kind, program_format_name,
-    raw_module_len, run_status_name, wireless_transport_name, BoardVmLanguageSession,
-    DecodedLanguageResponse, DecodedLanguageResponseBody, LanguageCoreError,
-    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguageTargetInfo,
-    LanguageValue, LanguageWirelessInterface,
+    esp_upload_options_for_target, known_targets, onboard_led_kind,
+    pico_uf2_upload_options_for_target, program_format_name, raw_module_len, run_status_name,
+    wireless_transport_name, BoardVmLanguageSession, DecodedLanguageResponse,
+    DecodedLanguageResponseBody, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
+    LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageTargetInfo, LanguageValue,
+    LanguageWirelessInterface,
 };
 use ruby_bridge::VALUE;
 
@@ -425,6 +426,15 @@ extern "C" fn native_esp_upload_options(_self_val: VALUE, selector_val: VALUE) -
     }
 }
 
+extern "C" fn native_pico_uf2_upload_options(_self_val: VALUE, selector_val: VALUE) -> VALUE {
+    let selector = ruby_bridge::str_from_rb(selector_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("selector must be a Ruby String"));
+    match pico_uf2_upload_options_for_target(&selector) {
+        Some(options) => pico_uf2_upload_options_to_rb(&options),
+        None => ruby_bridge::nil_value(),
+    }
+}
+
 extern "C" fn native_discover_devices(_self_val: VALUE) -> VALUE {
     host_devices_to_rb(&core_discover_devices())
 }
@@ -717,6 +727,28 @@ fn esp_upload_options_to_rb(options: &LanguageEspUploadOptions) -> VALUE {
         hash,
         "stay_in_bootloader",
         ruby_bridge::bool_to_rb(options.stay_in_bootloader),
+    );
+    hash
+}
+
+fn pico_uf2_upload_options_to_rb(options: &LanguagePicoUf2UploadOptions) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "board_id", ruby_bridge::str_to_rb(&options.board_id));
+    hash_set(hash, "command", ruby_bridge::str_to_rb(&options.command));
+    hash_set(
+        hash,
+        "volume_label",
+        ruby_bridge::str_to_rb(&options.volume_label),
+    );
+    hash_set(
+        hash,
+        "image_extension",
+        ruby_bridge::str_to_rb(&options.image_extension),
+    );
+    hash_set(
+        hash,
+        "auto_detect_mount",
+        ruby_bridge::bool_to_rb(options.auto_detect_mount),
     );
     hash
 }
@@ -1042,6 +1074,12 @@ pub extern "C" fn Init_board_vm_native() {
         native,
         "esp_upload_options",
         native_esp_upload_options as *const c_void,
+        1,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "pico_uf2_upload_options",
+        native_pico_uf2_upload_options as *const c_void,
         1,
     );
     ruby_bridge::define_module_function_raw(

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -122,6 +122,35 @@ module CodingAdventures
       options
     end
 
+    def pico_uf2_upload_options(board = :raspberry_pi_pico, **overrides)
+      options = Native.pico_uf2_upload_options(board.to_s)
+      return nil unless options
+
+      overrides.each do |key, value|
+        options[key.to_s] = value
+      end
+      options
+    end
+
+    def pico_uf2_upload_command(
+      board = :raspberry_pi_pico,
+      image:,
+      mount: nil,
+      **overrides
+    )
+      options = pico_uf2_upload_options(board, **overrides)
+      unless options
+        raise UnsupportedBoardError, "Pico UF2 upload is not supported for #{board.inspect}"
+      end
+
+      command = [
+        options.fetch("command"),
+        "--image", image.to_s
+      ]
+      command << "--mount" << mount.to_s unless mount.nil?
+      command
+    end
+
     def esp_upload_command(
       board = :esp32_devkit_v1,
       port: nil,

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -81,6 +81,32 @@ module CodingAdventures
         assert_equal false, overridden["verify_md5"]
       end
 
+      def test_pico_uf2_upload_options_are_exposed_from_rust_language_core
+        options = BoardVM.pico_uf2_upload_options(:pico)
+
+        assert_equal "raspberry-pi-pico", options["board_id"]
+        assert_equal "pico-uf2", options["command"]
+        assert_equal "RPI-RP2", options["volume_label"]
+        assert_equal ".uf2", options["image_extension"]
+        assert_equal true, options["auto_detect_mount"]
+        refute_nil BoardVM.pico_uf2_upload_options(:pico_w)
+        assert_nil BoardVM.pico_uf2_upload_options(:esp32)
+      end
+
+      def test_pico_uf2_upload_command_uses_rust_owned_options
+        command = BoardVM.pico_uf2_upload_command(
+          :pico,
+          image: "/tmp/board-vm-pico.uf2",
+          mount: "/Volumes/RPI-RP2"
+        )
+
+        assert_equal [
+          "pico-uf2",
+          "--image", "/tmp/board-vm-pico.uf2",
+          "--mount", "/Volumes/RPI-RP2"
+        ], command
+      end
+
       def test_devices_are_discovered_and_classified_by_rust_language_core
         devices = BoardVM.devices(paths: [
           "/dev/cu.usbmodem1101",

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -308,6 +308,15 @@ pub struct LanguageEspUploadOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguagePicoUf2UploadOptions {
+    pub board_id: String,
+    pub command: String,
+    pub volume_label: String,
+    pub image_extension: String,
+    pub auto_detect_mount: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageHostDevice {
     pub id: String,
     pub port: String,
@@ -517,6 +526,21 @@ pub fn esp_upload_options_for_target(selector: &str) -> Option<LanguageEspUpload
         flash_size: Some(LANGUAGE_ESP_DEFAULT_FLASH_SIZE),
         verify_md5: true,
         stay_in_bootloader: false,
+    })
+}
+
+pub fn pico_uf2_upload_options_for_target(selector: &str) -> Option<LanguagePicoUf2UploadOptions> {
+    let target = detect_target(selector)?;
+    if target.family != LanguageBoardFamily::RaspberryPiPico {
+        return None;
+    }
+
+    Some(LanguagePicoUf2UploadOptions {
+        board_id: target.board_id,
+        command: "pico-uf2".to_owned(),
+        volume_label: "RPI-RP2".to_owned(),
+        image_extension: ".uf2".to_owned(),
+        auto_detect_mount: true,
     })
 }
 
@@ -2069,6 +2093,19 @@ mod tests {
         assert!(options.verify_md5);
         assert!(!options.stay_in_bootloader);
         assert!(esp_upload_options_for_target("pico").is_none());
+    }
+
+    #[test]
+    fn pico_uf2_upload_options_are_owned_by_rust_language_core() {
+        let options = pico_uf2_upload_options_for_target("pico").unwrap();
+
+        assert_eq!(options.board_id, "raspberry-pi-pico");
+        assert_eq!(options.command, "pico-uf2");
+        assert_eq!(options.volume_label, "RPI-RP2");
+        assert_eq!(options.image_extension, ".uf2");
+        assert!(options.auto_detect_mount);
+        assert!(pico_uf2_upload_options_for_target("pico-w").is_some());
+        assert!(pico_uf2_upload_options_for_target("esp32").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Rust-owned Pico UF2 upload defaults to `board-vm-language-core`
- expose those defaults through the Ruby and Python native bridge packages
- add Ruby/Python helper commands that build `pico-uf2 --image ... [--mount ...]` from Rust-owned options

## Validation
- `cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge`
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`