### PR TITLE
Add Pico UF2 BOOTSEL mount listing

### DIFF
--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -40,6 +40,7 @@ pub enum CliCommand {
     EspDetect(EspDetectOptions),
     EspUpload(EspUploadOptions),
     PicoUf2Upload(PicoUf2Options),
+    PicoUf2List,
     Smoke(SmokeOptions),
     Repl(ReplOptions),
     EjectBlink(EjectBlinkOptions),
@@ -295,6 +296,7 @@ where
         "esp-detect" | "detect-esp" => parse_esp_detect_args(args),
         "esp-upload" | "upload-esp" => parse_esp_upload_args(args),
         "pico-uf2" | "pico-upload" | "upload-pico" => parse_pico_uf2_args(args),
+        "pico-uf2-list" | "list-pico-uf2" | "list-pico" => Ok(CliCommand::PicoUf2List),
         "smoke" => parse_smoke_args(args),
         "repl" => parse_repl_args(args),
         "eject" => parse_eject_args(args),
@@ -405,6 +407,7 @@ where
 
     while let Some(option) = args.next() {
         match option.as_str() {
+            "--list" | "list" => return Ok(CliCommand::PicoUf2List),
             "--image" | "--input" | "-i" => image = Some(next_value(&mut args, "--image")?),
             "--mount" | "--volume" | "-m" => mount = Some(next_value(&mut args, "--mount")?),
             other => return Err(CliError::UnknownOption(other.to_owned())),
@@ -817,6 +820,10 @@ pub fn run_pico_uf2_upload(options: &PicoUf2Options) -> Result<PicoUf2Report, Cl
 
 pub fn detect_pico_bootsel_mounts() -> Vec<String> {
     detect_pico_bootsel_mounts_in_roots(default_pico_mount_roots())
+}
+
+pub fn list_pico_bootsel_mounts() -> Vec<String> {
+    detect_pico_bootsel_mounts()
 }
 
 pub fn detect_pico_bootsel_mounts_in_roots<I, P>(roots: I) -> Vec<String>
@@ -1274,7 +1281,7 @@ pub fn format_onboard_led(led: Option<OnboardLed>) -> String {
 }
 
 pub fn usage() -> &'static str {
-    "usage:\n  board-vm list-ports\n  board-vm list-targets\n  board-vm esp-detect --port <path> [--baud <rate>] [--timeout-ms <ms>] [--no-reset]\n  board-vm esp-upload --port <path> --image <path> [--offset <addr>] [--block-size <bytes>] [--flash-size <bytes>] [--baud <rate>] [--timeout-ms <ms>] [--no-reset] [--no-verify] [--stay-in-bootloader]\n  board-vm pico-uf2 --image <path.uf2> [--mount <RPI-RP2 mount>]\n  board-vm smoke --port <path> [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm repl --port <path> [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm eject blink --out <path> [--program-id <id>] [--slot <slot>] [--boot-policy store-only|run-at-boot|run-if-no-host|<u8>]"
+    "usage:\n  board-vm list-ports\n  board-vm list-targets\n  board-vm esp-detect --port <path> [--baud <rate>] [--timeout-ms <ms>] [--no-reset]\n  board-vm esp-upload --port <path> --image <path> [--offset <addr>] [--block-size <bytes>] [--flash-size <bytes>] [--baud <rate>] [--timeout-ms <ms>] [--no-reset] [--no-verify] [--stay-in-bootloader]\n  board-vm pico-uf2 --image <path.uf2> [--mount <RPI-RP2 mount>]\n  board-vm pico-uf2 --list\n  board-vm smoke --port <path> [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm repl --port <path> [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm eject blink --out <path> [--program-id <id>] [--slot <slot>] [--boot-policy store-only|run-at-boot|run-if-no-host|<u8>]"
 }
 
 #[cfg(test)]
@@ -1497,6 +1504,19 @@ mod tests {
                 mount: Some("/Volumes/RPI-RP2".to_owned()),
             })
         );
+    }
+
+    #[test]
+    fn parses_pico_uf2_list_aliases() {
+        assert_eq!(
+            parse_args(["pico-uf2", "--list"]).unwrap(),
+            CliCommand::PicoUf2List
+        );
+        assert_eq!(
+            parse_args(["pico-uf2-list"]).unwrap(),
+            CliCommand::PicoUf2List
+        );
+        assert_eq!(parse_args(["list-pico"]).unwrap(), CliCommand::PicoUf2List);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-cli/src/main.rs
+++ b/code/packages/rust/board-vm-cli/src/main.rs
@@ -1,8 +1,9 @@
 use std::env;
 
 use board_vm_cli::{
-    format_onboard_led, list_ports, list_targets, parse_args, run_eject_blink, run_esp_detect,
-    run_esp_upload, run_pico_uf2_upload, run_repl, run_smoke, usage, CliCommand,
+    format_onboard_led, list_pico_bootsel_mounts, list_ports, list_targets, parse_args,
+    run_eject_blink, run_esp_detect, run_esp_upload, run_pico_uf2_upload, run_repl, run_smoke,
+    usage, CliCommand,
 };
 
 fn main() {
@@ -71,6 +72,12 @@ fn run_command(command: CliCommand) -> Result<(), board_vm_cli::CliError> {
                 "pico-uf2 image={} mount={} output={} bytes={}",
                 report.image, report.mount, report.output, report.bytes
             );
+            Ok(())
+        }
+        CliCommand::PicoUf2List => {
+            for mount in list_pico_bootsel_mounts() {
+                println!("pico-uf2 mount={mount}");
+            }
             Ok(())
         }
         CliCommand::Smoke(options) => {


### PR DESCRIPTION
## Summary
- add `board-vm pico-uf2 --list` plus list-oriented aliases for discovering Pico BOOTSEL UF2 volumes
- expose a small CLI helper backed by the existing Rust BOOTSEL mount detector
- cover the new parser aliases in the Board VM CLI tests

## Validation
- `cargo test -p board-vm-cli`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`