### PR TITLE
Add Rust CAS algebraic extension factoring

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -503,6 +503,7 @@ members = [
     "cas-pattern-matching",
     "cas-simplify",
     "cas-substitution",
+    "cas-algebraic",
     "cas-factor",
     "cas-solve",
     "cas-list-operations",

--- a/code/packages/rust/cas-algebraic/BUILD
+++ b/code/packages/rust/cas-algebraic/BUILD
@@ -1,0 +1,9 @@
+load("code/packages/starlark/library-rules/rust_library.star", "rust_library")
+
+_targets = [
+    rust_library(
+        name = "cas-algebraic",
+        srcs = ["src/**/*.rs", "tests/**/*.rs"],
+        deps = ["cas-factor", "symbolic-ir"],
+    ),
+]

--- a/code/packages/rust/cas-algebraic/CHANGELOG.md
+++ b/code/packages/rust/cas-algebraic/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Rust port of the Python `cas-algebraic` quadratic-extension factoring
+  slice.

--- a/code/packages/rust/cas-algebraic/Cargo.toml
+++ b/code/packages/rust/cas-algebraic/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cas-algebraic"
+version = "0.1.0"
+edition = "2021"
+description = "Quadratic algebraic extension factoring for symbolic CAS polynomials"
+license = "MIT"
+
+[dependencies]
+cas-factor = { path = "../cas-factor" }
+symbolic-ir = { path = "../symbolic-ir" }

--- a/code/packages/rust/cas-algebraic/README.md
+++ b/code/packages/rust/cas-algebraic/README.md
@@ -1,0 +1,13 @@
+# cas-algebraic
+
+`cas-algebraic` factors integer univariate polynomials over quadratic
+extensions `Q[sqrt(d)]`.
+
+This Rust port covers the same first slice as the Python package:
+
+- monic quadratics whose discriminant is a rational square times `d`;
+- depressed monic quartics `x^4 + p*x^2 + q`;
+- integer-polynomial pre-factoring through `cas-factor`;
+- lightweight symbolic-IR helpers for `AlgFactor(poly, Sqrt(d))`.
+
+Polynomials use ascending coefficient order: `[-2, 0, 1]` is `x^2 - 2`.

--- a/code/packages/rust/cas-algebraic/src/algebraic.rs
+++ b/code/packages/rust/cas-algebraic/src/algebraic.rs
@@ -1,0 +1,135 @@
+use cas_factor::factor_integer_polynomial;
+
+use crate::rational::{rational_square_root, Rational};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AlgCoeff {
+    pub rational: Rational,
+    pub radical: Rational,
+}
+
+pub type AlgPoly = Vec<AlgCoeff>;
+
+impl AlgCoeff {
+    pub fn new(rational: Rational, radical: Rational) -> Self {
+        Self { rational, radical }
+    }
+
+    pub fn rational(value: i64) -> Self {
+        Self::new(Rational::from_int(value), Rational::ZERO)
+    }
+}
+
+pub fn factor_over_extension(coeffs: &[i64], d: i64) -> Option<Vec<AlgPoly>> {
+    if coeffs.len() <= 2 || d <= 0 {
+        return None;
+    }
+
+    let (_content, factors_z) = factor_integer_polynomial(coeffs);
+    let mut result = Vec::new();
+    let mut any_split = false;
+
+    for (factor, multiplicity) in factors_z {
+        if let Some(split) = try_split_single(&factor, d) {
+            for _ in 0..multiplicity {
+                result.extend(split.clone());
+            }
+            any_split = true;
+        } else {
+            let alg_factor = integer_poly_to_alg_poly(&factor);
+            for _ in 0..multiplicity {
+                result.push(alg_factor.clone());
+            }
+        }
+    }
+
+    any_split.then_some(result)
+}
+
+pub fn try_split_quadratic(coeffs: &[i64], d: i64) -> Option<Vec<AlgPoly>> {
+    if coeffs.len() != 3 || coeffs[2] != 1 || d <= 0 {
+        return None;
+    }
+
+    let c = Rational::from_int(coeffs[0]);
+    let b = Rational::from_int(coeffs[1]);
+    let disc = b * b - Rational::from_int(4) * c;
+    if disc.is_zero() {
+        return None;
+    }
+
+    let two_beta = rational_square_root(disc / Rational::from_int(d))?;
+    if two_beta.is_zero() {
+        return None;
+    }
+    let beta = two_beta / Rational::from_int(2);
+    let root_rational = -b / Rational::from_int(2);
+
+    let linear = |radical: Rational| {
+        vec![
+            AlgCoeff::new(-root_rational, radical),
+            AlgCoeff::rational(1),
+        ]
+    };
+
+    Some(vec![linear(-beta), linear(beta)])
+}
+
+pub fn try_split_depressed_quartic(coeffs: &[i64], d: i64) -> Option<Vec<AlgPoly>> {
+    if coeffs.len() != 5 || coeffs[4] != 1 || coeffs[3] != 0 || coeffs[1] != 0 || d <= 0 {
+        return None;
+    }
+
+    let q = Rational::from_int(coeffs[0]);
+    let p = Rational::from_int(coeffs[2]);
+    let q_root = rational_square_root(q)?;
+
+    for s in [q_root, -q_root] {
+        let numerator = Rational::from_int(2) * s - p;
+        if numerator.is_negative() {
+            continue;
+        }
+        let Some(r) = rational_square_root(numerator / Rational::from_int(d)) else {
+            continue;
+        };
+        if r.is_zero() {
+            continue;
+        }
+
+        let h1 = vec![
+            AlgCoeff::new(s, Rational::ZERO),
+            AlgCoeff::new(Rational::ZERO, r),
+            AlgCoeff::rational(1),
+        ];
+        let h2 = vec![
+            AlgCoeff::new(s, Rational::ZERO),
+            AlgCoeff::new(Rational::ZERO, -r),
+            AlgCoeff::rational(1),
+        ];
+        return Some(vec![h1, h2]);
+    }
+
+    None
+}
+
+pub fn try_split_single(coeffs: &[i64], d: i64) -> Option<Vec<AlgPoly>> {
+    if coeffs.len() < 3 {
+        return None;
+    }
+
+    let normalized = if coeffs.last() == Some(&-1) {
+        coeffs.iter().map(|value| -*value).collect::<Vec<_>>()
+    } else {
+        coeffs.to_vec()
+    };
+
+    match normalized.len() - 1 {
+        2 => try_split_quadratic(&normalized, d),
+        4 => try_split_depressed_quartic(&normalized, d),
+        _ => None,
+    }
+}
+
+fn integer_poly_to_alg_poly(coeffs: &[i64]) -> AlgPoly {
+    coeffs.iter().copied().map(AlgCoeff::rational).collect()
+}

--- a/code/packages/rust/cas-algebraic/src/ir.rs
+++ b/code/packages/rust/cas-algebraic/src/ir.rs
@@ -1,0 +1,216 @@
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, MUL, NEG, POW, SQRT, SUB};
+
+use crate::algebraic::{factor_over_extension, AlgCoeff, AlgPoly};
+use crate::rational::Rational;
+
+pub const ALG_FACTOR: &str = "AlgFactor";
+
+pub fn extract_radical_d(node: &IRNode) -> Option<i64> {
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    if apply_node.head != sym(SQRT) || apply_node.args.len() != 1 {
+        return None;
+    }
+    let IRNode::Integer(value) = apply_node.args[0] else {
+        return None;
+    };
+    if value <= 0 || is_square(value) {
+        return None;
+    }
+    Some(value)
+}
+
+pub fn alg_factor_ir(poly: &IRNode, sqrt_d: &IRNode, variable: &IRNode) -> Option<IRNode> {
+    let d = extract_radical_d(sqrt_d)?;
+    let coeffs = ir_to_integer_poly(poly, variable)?;
+    let factors = factor_over_extension(&coeffs, d)?;
+    Some(factors_to_ir(&factors, variable, sqrt_d))
+}
+
+pub fn factors_to_ir(factors: &[AlgPoly], variable: &IRNode, sqrt_d: &IRNode) -> IRNode {
+    let mut iter = factors
+        .iter()
+        .map(|factor| alg_poly_to_ir(factor, variable, sqrt_d));
+    let Some(first) = iter.next() else {
+        return int(1);
+    };
+    iter.fold(first, |acc, factor| apply(sym(MUL), vec![acc, factor]))
+}
+
+pub fn alg_poly_to_ir(poly: &AlgPoly, variable: &IRNode, sqrt_d: &IRNode) -> IRNode {
+    let mut terms = Vec::new();
+    for (degree, coeff) in poly.iter().enumerate() {
+        if coeff.rational.is_zero() && coeff.radical.is_zero() {
+            continue;
+        }
+
+        let coeff_ir = alg_coeff_to_ir(*coeff, sqrt_d);
+        let term = match degree {
+            0 => coeff_ir,
+            1 => multiply_coeff(coeff_ir, variable.clone()),
+            _ => {
+                let power = apply(sym(POW), vec![variable.clone(), int(degree as i64)]);
+                multiply_coeff(coeff_ir, power)
+            }
+        };
+        terms.push(term);
+    }
+
+    if terms.is_empty() {
+        int(0)
+    } else {
+        terms
+            .into_iter()
+            .reduce(|acc, term| apply(sym(ADD), vec![acc, term]))
+            .unwrap()
+    }
+}
+
+pub fn alg_coeff_to_ir(coeff: AlgCoeff, sqrt_d: &IRNode) -> IRNode {
+    let rational = rational_to_ir(coeff.rational);
+    if coeff.radical.is_zero() {
+        return rational;
+    }
+
+    let radical_part = if coeff.radical.is_one() {
+        sqrt_d.clone()
+    } else if coeff.radical == Rational::from_int(-1) {
+        apply(sym(NEG), vec![sqrt_d.clone()])
+    } else {
+        apply(
+            sym(MUL),
+            vec![rational_to_ir(coeff.radical), sqrt_d.clone()],
+        )
+    };
+
+    if coeff.rational.is_zero() {
+        radical_part
+    } else {
+        apply(sym(ADD), vec![rational, radical_part])
+    }
+}
+
+pub fn ir_to_integer_poly(node: &IRNode, variable: &IRNode) -> Option<Vec<i64>> {
+    let coeffs = ir_to_rational_poly(node, variable)?;
+    let mut out = Vec::with_capacity(coeffs.len());
+    for coeff in coeffs {
+        if coeff.denom != 1 {
+            return None;
+        }
+        out.push(coeff.numer);
+    }
+    trim_trailing_zeros(out)
+}
+
+fn ir_to_rational_poly(node: &IRNode, variable: &IRNode) -> Option<Vec<Rational>> {
+    if node == variable {
+        return Some(vec![Rational::ZERO, Rational::ONE]);
+    }
+
+    match node {
+        IRNode::Integer(value) => Some(vec![Rational::from_int(*value)]),
+        IRNode::Rational(numer, denom) => Some(vec![Rational::new(*numer, *denom)]),
+        IRNode::Apply(apply_node) if apply_node.head == sym(ADD) => {
+            let mut acc = vec![Rational::ZERO];
+            for arg in &apply_node.args {
+                acc = poly_add(&acc, &ir_to_rational_poly(arg, variable)?);
+            }
+            Some(acc)
+        }
+        IRNode::Apply(apply_node) if apply_node.head == sym(SUB) && apply_node.args.len() == 2 => {
+            let lhs = ir_to_rational_poly(&apply_node.args[0], variable)?;
+            let rhs = ir_to_rational_poly(&apply_node.args[1], variable)?;
+            Some(poly_sub(&lhs, &rhs))
+        }
+        IRNode::Apply(apply_node) if apply_node.head == sym(MUL) => {
+            let mut acc = vec![Rational::ONE];
+            for arg in &apply_node.args {
+                acc = poly_mul(&acc, &ir_to_rational_poly(arg, variable)?);
+            }
+            Some(acc)
+        }
+        IRNode::Apply(apply_node) if apply_node.head == sym(NEG) && apply_node.args.len() == 1 => {
+            let poly = ir_to_rational_poly(&apply_node.args[0], variable)?;
+            Some(poly.into_iter().map(|coeff| -coeff).collect())
+        }
+        IRNode::Apply(apply_node) if apply_node.head == sym(POW) && apply_node.args.len() == 2 => {
+            let IRNode::Integer(exp) = apply_node.args[1] else {
+                return None;
+            };
+            if exp < 0 {
+                return None;
+            }
+            let base = ir_to_rational_poly(&apply_node.args[0], variable)?;
+            let mut acc = vec![Rational::ONE];
+            for _ in 0..exp {
+                acc = poly_mul(&acc, &base);
+            }
+            Some(acc)
+        }
+        _ => None,
+    }
+}
+
+fn multiply_coeff(coeff: IRNode, term: IRNode) -> IRNode {
+    if coeff == int(1) {
+        term
+    } else if coeff == int(-1) {
+        apply(sym(NEG), vec![term])
+    } else {
+        apply(sym(MUL), vec![coeff, term])
+    }
+}
+
+fn rational_to_ir(value: Rational) -> IRNode {
+    if value.denom == 1 {
+        int(value.numer)
+    } else {
+        rat(value.numer, value.denom)
+    }
+}
+
+fn trim_trailing_zeros(mut poly: Vec<i64>) -> Option<Vec<i64>> {
+    while poly.last() == Some(&0) {
+        poly.pop();
+    }
+    Some(poly)
+}
+
+fn poly_add(lhs: &[Rational], rhs: &[Rational]) -> Vec<Rational> {
+    let len = lhs.len().max(rhs.len());
+    let mut out = vec![Rational::ZERO; len];
+    for index in 0..len {
+        out[index] = lhs.get(index).copied().unwrap_or(Rational::ZERO)
+            + rhs.get(index).copied().unwrap_or(Rational::ZERO);
+    }
+    out
+}
+
+fn poly_sub(lhs: &[Rational], rhs: &[Rational]) -> Vec<Rational> {
+    let len = lhs.len().max(rhs.len());
+    let mut out = vec![Rational::ZERO; len];
+    for index in 0..len {
+        out[index] = lhs.get(index).copied().unwrap_or(Rational::ZERO)
+            - rhs.get(index).copied().unwrap_or(Rational::ZERO);
+    }
+    out
+}
+
+fn poly_mul(lhs: &[Rational], rhs: &[Rational]) -> Vec<Rational> {
+    if lhs.is_empty() || rhs.is_empty() {
+        return vec![Rational::ZERO];
+    }
+    let mut out = vec![Rational::ZERO; lhs.len() + rhs.len() - 1];
+    for (i, lhs_coeff) in lhs.iter().enumerate() {
+        for (j, rhs_coeff) in rhs.iter().enumerate() {
+            out[i + j] = out[i + j] + *lhs_coeff * *rhs_coeff;
+        }
+    }
+    out
+}
+
+fn is_square(value: i64) -> bool {
+    let root = (value as f64).sqrt() as i64;
+    root * root == value || (root + 1) * (root + 1) == value
+}

--- a/code/packages/rust/cas-algebraic/src/lib.rs
+++ b/code/packages/rust/cas-algebraic/src/lib.rs
@@ -1,0 +1,20 @@
+//! Quadratic algebraic extension factoring for symbolic CAS polynomials.
+//!
+//! This crate ports the Python `cas-algebraic` package's first factoring
+//! slice to Rust. It factors integer univariate polynomials over `Q[sqrt(d)]`
+//! for monic quadratics and depressed monic quartics, after first using
+//! `cas-factor` to split any integer factors already visible over `Z`.
+
+pub mod algebraic;
+pub mod ir;
+pub mod rational;
+
+pub use algebraic::{
+    factor_over_extension, try_split_depressed_quartic, try_split_quadratic, try_split_single,
+    AlgCoeff, AlgPoly,
+};
+pub use ir::{
+    alg_coeff_to_ir, alg_factor_ir, alg_poly_to_ir, extract_radical_d, factors_to_ir,
+    ir_to_integer_poly, ALG_FACTOR,
+};
+pub use rational::{rational_square_root, Rational};

--- a/code/packages/rust/cas-algebraic/src/rational.rs
+++ b/code/packages/rust/cas-algebraic/src/rational.rs
@@ -1,0 +1,128 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Rational {
+    pub numer: i64,
+    pub denom: i64,
+}
+
+impl Rational {
+    pub const ZERO: Rational = Rational { numer: 0, denom: 1 };
+    pub const ONE: Rational = Rational { numer: 1, denom: 1 };
+
+    pub fn new(numer: i64, denom: i64) -> Self {
+        assert!(denom != 0, "Rational denominator cannot be zero");
+        if numer == 0 {
+            return Self::ZERO;
+        }
+
+        let (numer, denom) = if denom < 0 {
+            (-numer, -denom)
+        } else {
+            (numer, denom)
+        };
+        let g = gcd(numer.unsigned_abs(), denom as u64) as i64;
+        Self {
+            numer: numer / g,
+            denom: denom / g,
+        }
+    }
+
+    pub fn from_int(value: i64) -> Self {
+        Self::new(value, 1)
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.numer == 0
+    }
+
+    pub fn is_one(self) -> bool {
+        self.numer == 1 && self.denom == 1
+    }
+
+    pub fn is_negative(self) -> bool {
+        self.numer < 0
+    }
+}
+
+impl Add for Rational {
+    type Output = Rational;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Rational::new(
+            self.numer * rhs.denom + rhs.numer * self.denom,
+            self.denom * rhs.denom,
+        )
+    }
+}
+
+impl Sub for Rational {
+    type Output = Rational;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self + (-rhs)
+    }
+}
+
+impl Mul for Rational {
+    type Output = Rational;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Rational::new(self.numer * rhs.numer, self.denom * rhs.denom)
+    }
+}
+
+impl Div for Rational {
+    type Output = Rational;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        assert!(!rhs.is_zero(), "Rational division by zero");
+        Rational::new(self.numer * rhs.denom, self.denom * rhs.numer)
+    }
+}
+
+impl Neg for Rational {
+    type Output = Rational;
+
+    fn neg(self) -> Self::Output {
+        Rational {
+            numer: -self.numer,
+            denom: self.denom,
+        }
+    }
+}
+
+pub fn rational_square_root(value: Rational) -> Option<Rational> {
+    if value.is_negative() {
+        return None;
+    }
+    if value.is_zero() {
+        return Some(Rational::ZERO);
+    }
+
+    let numer_root = integer_square_root(value.numer)?;
+    let denom_root = integer_square_root(value.denom)?;
+    Some(Rational::new(numer_root, denom_root))
+}
+
+fn integer_square_root(value: i64) -> Option<i64> {
+    if value < 0 {
+        return None;
+    }
+    let root = (value as f64).sqrt() as i64;
+    for candidate in root.saturating_sub(1)..=root + 1 {
+        if candidate >= 0 && candidate.saturating_mul(candidate) == value {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn gcd(mut a: u64, mut b: u64) -> u64 {
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}

--- a/code/packages/rust/cas-algebraic/tests/tests.rs
+++ b/code/packages/rust/cas-algebraic/tests/tests.rs
@@ -1,0 +1,108 @@
+use cas_algebraic::{
+    alg_factor_ir, extract_radical_d, factor_over_extension, rational_square_root,
+    try_split_depressed_quartic, try_split_quadratic, Rational,
+};
+use symbolic_ir::{apply, int, sym, ADD, MUL, POW, SQRT, SUB};
+
+fn sqrt_d(d: i64) -> symbolic_ir::IRNode {
+    apply(sym(SQRT), vec![int(d)])
+}
+
+#[test]
+fn rational_square_root_detects_exact_squares() {
+    assert_eq!(
+        rational_square_root(Rational::from_int(4)),
+        Some(Rational::from_int(2))
+    );
+    assert_eq!(
+        rational_square_root(Rational::new(1, 4)),
+        Some(Rational::new(1, 2))
+    );
+    assert_eq!(rational_square_root(Rational::from_int(2)), None);
+    assert_eq!(rational_square_root(Rational::from_int(-1)), None);
+}
+
+#[test]
+fn x2_minus_d_splits_over_matching_extension() {
+    let result = try_split_quadratic(&[-2, 0, 1], 2).expect("x^2 - 2 should split");
+    assert_eq!(result.len(), 2);
+
+    let radicals = [result[0][0].radical, result[1][0].radical];
+    assert!(radicals.contains(&Rational::from_int(-1)));
+    assert!(radicals.contains(&Rational::from_int(1)));
+}
+
+#[test]
+fn quadratic_with_wrong_discriminant_does_not_split() {
+    assert!(try_split_quadratic(&[2, 0, 1], 2).is_none());
+    assert!(try_split_quadratic(&[1, 1, 1], 2).is_none());
+}
+
+#[test]
+fn x4_plus_one_splits_over_sqrt_two() {
+    let result =
+        factor_over_extension(&[1, 0, 0, 0, 1], 2).expect("x^4 + 1 should split over sqrt(2)");
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].len(), 3);
+    assert_eq!(result[1].len(), 3);
+
+    let radicals = [result[0][1].radical, result[1][1].radical];
+    assert!(radicals.contains(&Rational::from_int(-1)));
+    assert!(radicals.contains(&Rational::from_int(1)));
+}
+
+#[test]
+fn x4_plus_one_does_not_split_over_sqrt_three() {
+    assert!(factor_over_extension(&[1, 0, 0, 0, 1], 3).is_none());
+}
+
+#[test]
+fn depressed_quartic_checks_shape() {
+    assert!(try_split_depressed_quartic(&[1, 0, 0, 1, 1], 2).is_none());
+    assert!(try_split_depressed_quartic(&[2, 0, 0, 0, 1], 2).is_none());
+}
+
+#[test]
+fn keeps_rational_factors_when_residual_splits() {
+    // (x - 1) * (x^2 - 2) should keep the rational linear factor and split
+    // the quadratic over Q[sqrt(2)].
+    let result = factor_over_extension(&[2, -2, -1, 1], 2).expect("residual should split");
+    assert_eq!(result.len(), 3);
+    assert!(result
+        .iter()
+        .any(|factor| factor.len() == 2 && factor[0].rational == Rational::from_int(-1)));
+}
+
+#[test]
+fn extract_radical_rejects_trivial_or_malformed_extensions() {
+    assert_eq!(extract_radical_d(&sqrt_d(2)), Some(2));
+    assert_eq!(extract_radical_d(&sqrt_d(4)), None);
+    assert_eq!(extract_radical_d(&int(2)), None);
+}
+
+#[test]
+fn ir_adapter_factors_pow_polynomial() {
+    let x = sym("x");
+    let x2_minus_2 = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(2)],
+    );
+    let result = alg_factor_ir(&x2_minus_2, &sqrt_d(2), &x).expect("IR should factor");
+    assert!(matches!(result, symbolic_ir::IRNode::Apply(_)));
+}
+
+#[test]
+fn ir_adapter_factors_nested_mul_polynomial() {
+    let x = sym("x");
+    let x4 = apply(sym(MUL), vec![x.clone(), x.clone(), x.clone(), x.clone()]);
+    let poly = apply(sym(ADD), vec![x4, int(1)]);
+    let result = alg_factor_ir(&poly, &sqrt_d(2), &x).expect("IR should factor");
+    assert!(matches!(result, symbolic_ir::IRNode::Apply(_)));
+}
+
+#[test]
+fn ir_adapter_returns_none_for_non_polynomial() {
+    let x = sym("x");
+    let sin_x = apply(sym("Sin"), vec![x.clone()]);
+    assert!(alg_factor_ir(&sin_x, &sqrt_d(2), &x).is_none());
+}

--- a/code/specs/rust-cas-algebraic-parity.md
+++ b/code/specs/rust-cas-algebraic-parity.md
@@ -1,0 +1,41 @@
+# Rust CAS algebraic parity
+
+## Goal
+
+Port the Python `cas-algebraic` package to Rust so the Rust symbolic/CAS stack
+can factor integer univariate polynomials over a quadratic extension
+`Q[sqrt(d)]`.
+
+## Scope
+
+The first Rust slice matches the implemented Python surface:
+
+- Represent algebraic coefficients as `a + b*sqrt(d)` with exact rational
+  `a` and `b`.
+- Represent algebraic polynomials as coefficient lists in ascending degree.
+- Split monic quadratics when the discriminant becomes a rational square after
+  adjoining `sqrt(d)`.
+- Split depressed monic quartics of the form `x^4 + p*x^2 + q` into conjugate
+  quadratics when the Python pattern applies.
+- Factor an integer polynomial over `Z` first through the existing Rust
+  `cas-factor` package, then split each residual factor over `Q[sqrt(d)]`.
+- Provide an IR adapter for `AlgFactor(poly, Sqrt(d))`-style callers without
+  coupling this package to the symbolic VM.
+
+## Non-goals
+
+- General algebraic number fields beyond quadratic extensions.
+- General polynomial factorization over algebraic extensions.
+- VM registration. This crate exposes pure functions and IR conversion helpers;
+  VM handler wiring remains a later integration slice.
+
+## Validation
+
+Rust unit tests cover:
+
+- Rational square detection.
+- `x^2 - d` splitting over `Q[sqrt(d)]`.
+- `x^4 + 1` splitting over `Q[sqrt(2)]`.
+- Non-splitting cases from the Python package.
+- Keeping already rational factors when only a residual factor splits.
+- `AlgFactor` IR conversion and malformed-input fallthrough.


### PR DESCRIPTION
## Summary
- port the Python cas-algebraic quadratic-extension factoring slice to Rust
- add exact rational algebraic coefficients and polynomial splitting over Q[sqrt(d)]
- add IR helpers for AlgFactor-style callers plus parity spec and tests

## Validation
- cargo test -p cas-algebraic
- go run . -root /Users/adhithya/Downloads/Codex/coding-adventures-rust-cas-algebraic -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/rust-cas-algebraic-build-plan.json
- git diff --check origin/main..HEAD