### PR TITLE
Add Pico BOOTSEL auto-mount sugar

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1219,6 +1219,25 @@ def pico_uf2_mounts(roots: Iterable[str] | None = None) -> list[str]:
     return [str(mount) for mount in _native.pico_uf2_mounts([str(root) for root in roots])]
 
 
+def _pico_uf2_mount_list(mounts: Iterable[str]) -> str:
+    return "\n".join(f"{index}. {mount}" for index, mount in enumerate(mounts, start=1))
+
+
+def pico_uf2_mount(roots: Iterable[str] | None = None) -> str:
+    mounts = pico_uf2_mounts(roots)
+    if len(mounts) == 1:
+        return mounts[0]
+    if not mounts:
+        raise ValueError(
+            "No Pico BOOTSEL UF2 mount found. "
+            "Hold BOOTSEL while plugging in the Pico/Pico W."
+        )
+    raise ValueError(
+        "Multiple Pico BOOTSEL UF2 mounts found; choose one.\n"
+        f"{_pico_uf2_mount_list(mounts)}"
+    )
+
+
 DeviceReference = BoardDevice | dict[str, Any] | str | int
 
 
@@ -1373,19 +1392,25 @@ def pico_uf2_upload_command(
     *,
     image: str,
     mount: str | None = None,
+    roots: Iterable[str] | None = None,
+    auto_mount: bool = True,
     **overrides: Any,
 ) -> list[str]:
     options = pico_uf2_upload_options(selector, **overrides)
     if options is None:
         raise ValueError(f"Pico UF2 upload is not supported for {selector!r}")
 
+    selected_mount = mount
+    if selected_mount is None and auto_mount:
+        selected_mount = pico_uf2_mount(roots)
+
     command = [
         options.command,
         "--image",
         str(image),
     ]
-    if mount is not None:
-        command.extend(["--mount", str(mount)])
+    if selected_mount is not None:
+        command.extend(["--mount", str(selected_mount)])
     return command
 
 
@@ -1439,6 +1464,7 @@ __all__ = [
     "esp_upload_options",
     "find_target",
     "known_targets",
+    "pico_uf2_mount",
     "pico_uf2_upload_command",
     "pico_uf2_mounts",
     "pico_uf2_upload_options",

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -17,6 +17,7 @@ from board_vm_native import (
     esp_upload_options,
     find_target,
     known_targets,
+    pico_uf2_mount,
     pico_uf2_upload_command,
     pico_uf2_mounts,
     pico_uf2_upload_options,
@@ -186,6 +187,46 @@ def test_pico_uf2_mounts_are_discovered_by_rust_language_core():
         assert pico_uf2_mounts([root]) == [str(mount)]
 
 
+def test_pico_uf2_mount_selects_single_discovered_mount():
+    with tempfile.TemporaryDirectory(prefix="board-vm-pico-uf2") as root:
+        mount = pathlib.Path(root) / "RPI-RP2"
+        mount.mkdir()
+        (mount / "INFO_UF2.TXT").write_text(
+            "UF2 Bootloader\nModel: Raspberry Pi RP2\n",
+            encoding="utf-8",
+        )
+        (mount / "INDEX.HTM").write_text("<html></html>", encoding="utf-8")
+
+        assert pico_uf2_mount([root]) == str(mount)
+
+
+def test_pico_uf2_mount_reports_multiple_discovered_mounts():
+    with (
+        tempfile.TemporaryDirectory(prefix="board-vm-pico-uf2-a") as root_a,
+        tempfile.TemporaryDirectory(prefix="board-vm-pico-uf2-b") as root_b,
+    ):
+        mount_a = pathlib.Path(root_a) / "RPI-RP2"
+        mount_b = pathlib.Path(root_b) / "RPI-RP2"
+        for mount in (mount_a, mount_b):
+            mount.mkdir()
+            (mount / "INFO_UF2.TXT").write_text(
+                "UF2 Bootloader\nModel: Raspberry Pi RP2\n",
+                encoding="utf-8",
+            )
+            (mount / "INDEX.HTM").write_text("<html></html>", encoding="utf-8")
+
+        try:
+            pico_uf2_mount([root_a, root_b])
+        except ValueError as error:
+            message = str(error)
+        else:
+            raise AssertionError("expected ambiguous Pico BOOTSEL mount selection to fail")
+
+        assert "Multiple Pico BOOTSEL UF2 mounts" in message
+        assert str(mount_a) in message
+        assert str(mount_b) in message
+
+
 def test_esp_upload_command_uses_rust_owned_options():
     command = esp_upload_command(
         "esp32",
@@ -230,6 +271,31 @@ def test_pico_uf2_upload_command_uses_rust_owned_options():
         "/tmp/board-vm-pico.uf2",
         "--mount",
         "/Volumes/RPI-RP2",
+    ]
+
+
+def test_pico_uf2_upload_command_auto_selects_single_mount():
+    with tempfile.TemporaryDirectory(prefix="board-vm-pico-uf2") as root:
+        mount = pathlib.Path(root) / "RPI-RP2"
+        mount.mkdir()
+        (mount / "INFO_UF2.TXT").write_text(
+            "UF2 Bootloader\nModel: Raspberry Pi RP2\n",
+            encoding="utf-8",
+        )
+        (mount / "INDEX.HTM").write_text("<html></html>", encoding="utf-8")
+
+        command = pico_uf2_upload_command(
+            "pico-w",
+            image="/tmp/board-vm-pico-w.uf2",
+            roots=[root],
+        )
+
+    assert command == [
+        "pico-uf2",
+        "--image",
+        "/tmp/board-vm-pico-w.uf2",
+        "--mount",
+        str(mount),
     ]
 
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -136,10 +136,25 @@ module CodingAdventures
       Native.pico_uf2_mounts(roots&.map(&:to_s))
     end
 
+    def pico_uf2_mount(roots: nil)
+      mounts = pico_uf2_mounts(roots: roots)
+      return mounts.first if mounts.length == 1
+
+      if mounts.empty?
+        raise DeviceSelectionError,
+          "No Pico BOOTSEL UF2 mount found. Hold BOOTSEL while plugging in the Pico/Pico W."
+      end
+
+      mount_list = mounts.each_with_index.map { |mount, index| "#{index + 1}. #{mount}" }.join("\n")
+      raise DeviceSelectionError, "Multiple Pico BOOTSEL UF2 mounts found; choose one.\n#{mount_list}"
+    end
+
     def pico_uf2_upload_command(
       board = :raspberry_pi_pico,
       image:,
       mount: nil,
+      roots: nil,
+      auto_mount: true,
       **overrides
     )
       options = pico_uf2_upload_options(board, **overrides)
@@ -147,6 +162,7 @@ module CodingAdventures
         raise UnsupportedBoardError, "Pico UF2 upload is not supported for #{board.inspect}"
       end
 
+      mount ||= pico_uf2_mount(roots: roots) if auto_mount
       command = [
         options.fetch("command"),
         "--image", image.to_s

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -36,6 +36,7 @@ module CodingAdventures
         esp_image: nil,
         esp_upload_options: nil,
         pico_uf2_mount: nil,
+        pico_uf2_mount_roots: nil,
         pico_uf2_upload_options: nil
       )
         @board = board
@@ -63,6 +64,7 @@ module CodingAdventures
         @firmware_image = firmware_image || esp_image
         @esp_upload_options = esp_upload_options || {}
         @pico_uf2_mount = pico_uf2_mount
+        @pico_uf2_mount_roots = pico_uf2_mount_roots
         @pico_uf2_upload_options = pico_uf2_upload_options || {}
       end
 
@@ -368,6 +370,7 @@ module CodingAdventures
               board,
               image: @firmware_image,
               mount: @pico_uf2_mount,
+              roots: @pico_uf2_mount_roots,
               **pico_uf2_upload_overrides
             )
           ),

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -105,6 +105,38 @@ module CodingAdventures
         end
       end
 
+      def test_pico_uf2_mount_selects_single_discovered_mount
+        Dir.mktmpdir("board-vm-pico-uf2") do |root|
+          mount = File.join(root, "RPI-RP2")
+          Dir.mkdir(mount)
+          File.write(File.join(mount, "INFO_UF2.TXT"), "UF2 Bootloader\nModel: Raspberry Pi RP2\n")
+          File.write(File.join(mount, "INDEX.HTM"), "<html></html>")
+
+          assert_equal mount, BoardVM.pico_uf2_mount(roots: [root])
+        end
+      end
+
+      def test_pico_uf2_mount_reports_multiple_discovered_mounts
+        Dir.mktmpdir("board-vm-pico-uf2-a") do |root_a|
+          Dir.mktmpdir("board-vm-pico-uf2-b") do |root_b|
+            mount_a = File.join(root_a, "RPI-RP2")
+            mount_b = File.join(root_b, "RPI-RP2")
+            [mount_a, mount_b].each do |mount|
+              Dir.mkdir(mount)
+              File.write(File.join(mount, "INFO_UF2.TXT"), "UF2 Bootloader\nModel: Raspberry Pi RP2\n")
+              File.write(File.join(mount, "INDEX.HTM"), "<html></html>")
+            end
+
+            error = assert_raises(DeviceSelectionError) do
+              BoardVM.pico_uf2_mount(roots: [root_a, root_b])
+            end
+            assert_match(/Multiple Pico BOOTSEL UF2 mounts/, error.message)
+            assert_includes error.message, mount_a
+            assert_includes error.message, mount_b
+          end
+        end
+      end
+
       def test_pico_uf2_upload_command_uses_rust_owned_options
         command = BoardVM.pico_uf2_upload_command(
           :pico,
@@ -381,23 +413,32 @@ module CodingAdventures
         upload = CommandResult.new(["cargo"], "/repo/code/packages/rust", "copied uf2\n", "", 0)
         runner = FakeRunner.new([upload])
 
-        connection = BoardVM.pico_w(
-          flash: true,
-          firmware_image: "/tmp/board-vm-pico-w.uf2",
-          cargo_workspace: "/repo/code/packages/rust",
-          runner: runner
-        )
+        Dir.mktmpdir("board-vm-pico-uf2") do |root|
+          mount = File.join(root, "RPI-RP2")
+          Dir.mkdir(mount)
+          File.write(File.join(mount, "INFO_UF2.TXT"), "UF2 Bootloader\nModel: Raspberry Pi RP2\n")
+          File.write(File.join(mount, "INDEX.HTM"), "<html></html>")
 
-        assert_equal :raspberry_pi_pico_w, connection.board
-        assert_nil connection.port
-        assert_equal [
-          "cargo", "run",
-          "-p", "board-vm-cli",
-          "--bin", "board-vm",
-          "--",
-          "pico-uf2",
-          "--image", "/tmp/board-vm-pico-w.uf2"
-        ], runner.calls.first[:argv]
+          connection = BoardVM.pico_w(
+            flash: true,
+            firmware_image: "/tmp/board-vm-pico-w.uf2",
+            cargo_workspace: "/repo/code/packages/rust",
+            pico_uf2_mount_roots: [root],
+            runner: runner
+          )
+
+          assert_equal :raspberry_pi_pico_w, connection.board
+          assert_nil connection.port
+          assert_equal [
+            "cargo", "run",
+            "-p", "board-vm-cli",
+            "--bin", "board-vm",
+            "--",
+            "pico-uf2",
+            "--image", "/tmp/board-vm-pico-w.uf2",
+            "--mount", mount
+          ], runner.calls.first[:argv]
+        end
       end
 
       def test_esp_upload_command_rejects_non_esp_targets


### PR DESCRIPTION
## Summary
- add Ruby and Python helpers that auto-select a single discovered Pico BOOTSEL UF2 mount
- make Pico `flash: true` in Ruby use Rust-owned BOOTSEL mount discovery by default
- keep explicit mount selection and lower-level command construction available for advanced cases

## Validation
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge` in `code/packages/rust`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
