### PR TITLE
[codex] Handle script head whitespace for html5lib case 51

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -903,6 +903,19 @@ impl HtmlParser {
             return;
         }
 
+        let text = if self.current_element_is("head") {
+            match text.char_indices().find(|(_, character)| !character.is_whitespace()) {
+                Some((0, _)) => text,
+                Some((leading_end, _)) => {
+                    self.append_text_to_current(text[..leading_end].to_string());
+                    text[leading_end..].to_string()
+                }
+                None => text,
+            }
+        } else {
+            text
+        };
+
         if !text.chars().all(char::is_whitespace) {
             self.pop_current_if(|name| name == "head");
         }
@@ -913,6 +926,10 @@ impl HtmlParser {
             return;
         }
 
+        self.append_text_to_current(text);
+    }
+
+    fn append_text_to_current(&mut self, text: String) {
         if let Some(children) = self.current_children_mut() {
             if let Some(Node::Text(existing)) = children.last_mut() {
                 existing.data.push_str(&text);
@@ -1629,12 +1646,41 @@ impl DocumentShellBuilder {
             {
                 self.head_children.push(Node::Element(element));
             }
+            Node::Text(mut text)
+                if !self.seen_body_content && !self.head_children.is_empty() =>
+            {
+                match text
+                    .data
+                    .char_indices()
+                    .find(|(_, character)| !character.is_whitespace())
+                {
+                    Some((0, _)) => {
+                        self.seen_body_content = true;
+                        self.body_children.push(Node::Text(text));
+                    }
+                    Some((body_start, _)) => {
+                        let body_text = text.data.split_off(body_start);
+                        self.push_head_text(text.data);
+                        self.seen_body_content = true;
+                        self.body_children.push(Node::text(body_text));
+                    }
+                    None => self.push_head_text(text.data),
+                }
+            }
             node => {
                 if !is_ignorable_before_body(&node) {
                     self.seen_body_content = true;
                 }
                 self.body_children.push(node);
             }
+        }
+    }
+
+    fn push_head_text(&mut self, text: String) {
+        if let Some(Node::Text(existing)) = self.head_children.last_mut() {
+            existing.data.push_str(&text);
+        } else {
+            self.head_children.push(Node::text(text));
         }
     }
 

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -689,3 +689,17 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <style>
 |       " EOF"
 |   <body>
+
+#data
+<!DOCTYPE html><script> <!-- </script> --> </script> EOF
+#errors
+(1,52): unexpected-end-tag
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <script>
+|       " <!-- "
+|     " "
+|   <body>
+|     "-->  EOF"

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -664,3 +664,16 @@ Line1<br>Line2<br>Line3<br>Line4
 | <html>
 |   <head>
 |   <body>
+
+#data
+</ COM--MENT >
+#errors
+(1,2): expected-closing-tag-but-got-char
+(1,14): expected-doctype-but-got-eof
+#new-errors
+(1:3) invalid-first-character-of-tag-name
+#document
+| <!--  COM--MENT  -->
+| <html>
+|   <head>
+|   <body>

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -651,3 +651,16 @@ Line1<br>Line2<br>Line3<br>Line4
 | <html>
 |   <head>
 |   <body>
+
+#data
+<!COM--MENT>
+#errors
+(1,2): expected-dashes-or-doctype
+(1,12): expected-doctype-but-got-eof
+#new-errors
+(1:3) incorrectly-opened-comment
+#document
+| <!-- COM--MENT -->
+| <html>
+|   <head>
+|   <body>

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -677,3 +677,15 @@ Line1<br>Line2<br>Line3<br>Line4
 | <html>
 |   <head>
 |   <body>
+
+#data
+<!DOCTYPE html><style> EOF
+#errors
+(1,26): expected-named-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <style>
+|       " EOF"
+|   <body>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 51
- preserve leading whitespace in head context after script text-mode closure before body content starts
- split leading head whitespace during document shell normalization for parser-generated head elements

## Tests
- cargo test -p coding-adventures-html-parser --test tree_construction_test
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer