### PR TITLE
Rediscover Pico runtime serial port after UF2 flash

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1301,6 +1301,63 @@ def select_device(
     raise ValueError(f"{reason}.\n{device_list(candidates)}")
 
 
+def runtime_devices(
+    selector: str = "auto",
+    *,
+    device_candidates: Iterable[BoardDevice | dict[str, Any]] | None = None,
+) -> list[BoardDevice]:
+    candidates = [
+        item if isinstance(item, BoardDevice) else BoardDevice(item)
+        for item in (devices() if device_candidates is None else device_candidates)
+        if not (item.bootloader if isinstance(item, BoardDevice) else item.get("bootloader", False))
+    ]
+    target = None if selector == "auto" else detect_target(selector)
+    if selector != "auto" and target is None:
+        raise ValueError(f"unsupported board: {selector!r}")
+
+    if target is None:
+        matches = [candidate for candidate in candidates if candidate.target is not None]
+        if not matches and len(candidates) == 1:
+            return candidates
+        return matches
+
+    exact_matches = [
+        candidate
+        for candidate in candidates
+        if candidate.target is not None and candidate.target.board_id == target.board_id
+    ]
+    if exact_matches:
+        return exact_matches
+    return [candidate for candidate in candidates if candidate.target is None]
+
+
+def select_runtime_device(
+    selector: str = "auto",
+    *,
+    device_candidates: Iterable[BoardDevice | dict[str, Any]] | None = None,
+) -> BoardDevice:
+    candidates = [
+        item if isinstance(item, BoardDevice) else BoardDevice(item)
+        for item in (devices() if device_candidates is None else device_candidates)
+    ]
+    matches = runtime_devices(selector, device_candidates=candidates)
+    if len(matches) == 1:
+        return matches[0]
+
+    if not candidates:
+        raise ValueError(
+            "No Board VM runtime serial devices found. "
+            "Plug in a board or pass an explicit port."
+        )
+
+    reason = (
+        "No matching runtime serial device found"
+        if not matches
+        else "Multiple runtime serial devices match"
+    )
+    raise ValueError(f"{reason}.\n{device_list(candidates)}")
+
+
 def pick_device(
     selector: str = "auto",
     *,
@@ -1469,5 +1526,7 @@ __all__ = [
     "pico_uf2_mounts",
     "pico_uf2_upload_options",
     "pick_device",
+    "runtime_devices",
     "select_device",
+    "select_runtime_device",
 ]

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -22,7 +22,9 @@ from board_vm_native import (
     pico_uf2_mounts,
     pico_uf2_upload_options,
     pick_device,
+    runtime_devices,
     select_device,
+    select_runtime_device,
 )
 
 
@@ -369,6 +371,22 @@ def test_devices_are_classified_by_rust_language_core():
     rendered = device_list(found)
     assert "ESP32 DevKit V1" in rendered
     assert "/dev/cu.usbmodem1101" in rendered
+
+
+def test_runtime_device_selection_ignores_pico_bootloader_devices():
+    found = devices(
+        [
+            "/dev/serial/by-id/usb-Raspberry_Pi_Pico_E660-DAPLINK-if00",
+            "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00",
+        ]
+    )
+
+    selected = select_runtime_device("pico", device_candidates=found)
+    runtime = runtime_devices("pico", device_candidates=found)
+
+    assert selected.port == "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00"
+    assert selected.bootloader is False
+    assert [device.port for device in runtime] == [selected.port]
 
 
 def test_pick_device_prompts_for_ambiguous_devices():

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -18,6 +18,8 @@ module CodingAdventures
     DEFAULT_HOST_NONCE = 0xB0A2_D001
     DEFAULT_EJECT_SLOT = 0
     DEFAULT_BOOT_POLICY = :run_if_no_host
+    DEFAULT_PICO_RUNTIME_PORT_WAIT_MS = 5_000
+    DEFAULT_PICO_RUNTIME_PORT_POLL_MS = 250
 
     module_function
 
@@ -67,6 +69,38 @@ module CodingAdventures
         "No matching Board VM device found"
       else
         "Multiple Board VM devices match"
+      end
+      raise DeviceSelectionError, "#{reason}.\n#{device_list(candidates)}"
+    end
+
+    def runtime_devices(board: :auto, devices: nil)
+      candidates = (devices || self.devices).reject { |device| device.fetch("bootloader", false) }
+      normalized_board = board == :auto ? :auto : normalize_board(board)
+      if normalized_board == :auto
+        matches = candidates.select { |device| device_target_board(device) }
+        return candidates if matches.empty? && candidates.length == 1
+
+        return matches
+      end
+
+      exact_matches = candidates.select { |device| device_target_board(device) == normalized_board }
+      exact_matches.empty? ? candidates.select { |device| device_target_board(device).nil? } : exact_matches
+    end
+
+    def select_runtime_device(board: :auto, devices: nil)
+      candidates = devices || self.devices
+      matches = runtime_devices(board: board, devices: candidates)
+      return matches.first if matches.length == 1
+
+      if candidates.empty?
+        raise DeviceSelectionError,
+          "No Board VM runtime serial devices found. Plug in a board or pass an explicit port."
+      end
+
+      reason = if matches.empty?
+        "No matching runtime serial device found"
+      else
+        "Multiple runtime serial devices match"
       end
       raise DeviceSelectionError, "#{reason}.\n#{device_list(candidates)}"
     end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -35,9 +35,13 @@ module CodingAdventures
         firmware_image: nil,
         esp_image: nil,
         esp_upload_options: nil,
+        device_discovery: nil,
         pico_uf2_mount: nil,
         pico_uf2_mount_roots: nil,
-        pico_uf2_upload_options: nil
+        pico_uf2_upload_options: nil,
+        pico_runtime_port: true,
+        pico_runtime_port_wait_ms: DEFAULT_PICO_RUNTIME_PORT_WAIT_MS,
+        pico_runtime_port_poll_ms: DEFAULT_PICO_RUNTIME_PORT_POLL_MS
       )
         @board = board
         @port = port
@@ -63,9 +67,13 @@ module CodingAdventures
         @bootloader_port_wait_ms = bootloader_port_wait_ms
         @firmware_image = firmware_image || esp_image
         @esp_upload_options = esp_upload_options || {}
+        @device_discovery = device_discovery || -> { BoardVM.devices }
         @pico_uf2_mount = pico_uf2_mount
         @pico_uf2_mount_roots = pico_uf2_mount_roots
         @pico_uf2_upload_options = pico_uf2_upload_options || {}
+        @pico_runtime_port = pico_runtime_port
+        @pico_runtime_port_wait_ms = pico_runtime_port_wait_ms
+        @pico_runtime_port_poll_ms = pico_runtime_port_poll_ms
       end
 
       def led
@@ -364,7 +372,7 @@ module CodingAdventures
           raise ArgumentError, "Pico UF2 flash requires firmware_image:"
         end
 
-        runner.call(
+        result = runner.call(
           board_vm_cli_command(
             *BoardVM.pico_uf2_upload_command(
               board,
@@ -376,6 +384,33 @@ module CodingAdventures
           ),
           chdir: cargo_workspace
         )
+        rediscover_pico_runtime_port! if @pico_runtime_port
+        result
+      end
+
+      def rediscover_pico_runtime_port!
+        timeout_seconds = @pico_runtime_port_wait_ms.to_f / 1000.0
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
+        last_error = nil
+
+        loop do
+          begin
+            selected = BoardVM.select_runtime_device(board: board, devices: @device_discovery.call)
+            self.port = selected.fetch("port")
+            return selected
+          rescue DeviceSelectionError => error
+            last_error = error
+          end
+
+          break if timeout_seconds <= 0 || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          poll_seconds = [@pico_runtime_port_poll_ms.to_f / 1000.0, 0.01].max
+          sleep [poll_seconds, remaining].min
+        end
+
+        raise DeviceSelectionError,
+          "Pico UF2 upload finished, but no runtime serial device was found for #{board.inspect}.\n#{last_error.message}"
       end
 
       def ensure_uno_r4_wifi!

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -175,6 +175,18 @@ module CodingAdventures
         assert_includes rendered, "/dev/cu.usbmodem1101"
       end
 
+      def test_runtime_device_selection_ignores_pico_bootloader_devices
+        devices = BoardVM.devices(paths: [
+          "/dev/serial/by-id/usb-Raspberry_Pi_Pico_E660-DAPLINK-if00",
+          "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00"
+        ])
+
+        selected = BoardVM.select_runtime_device(board: :pico, devices: devices)
+
+        assert_equal "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00", selected.fetch("port")
+        refute selected.fetch("bootloader")
+      end
+
       def test_board_specific_connect_can_select_the_only_device_without_a_port
         runner = FakeRunner.new
         devices = BoardVM.devices(paths: ["/dev/cu.usbmodem1101"])
@@ -386,17 +398,21 @@ module CodingAdventures
       def test_pico_helper_flashes_uf2_image_without_requiring_a_serial_port
         upload = CommandResult.new(["cargo"], "/repo/code/packages/rust", "copied uf2\n", "", 0)
         runner = FakeRunner.new([upload])
+        runtime_devices = BoardVM.devices(paths: [
+          "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00"
+        ])
 
         connection = BoardVM.pico(
           flash: true,
           firmware_image: "/tmp/board-vm-pico.uf2",
           cargo_workspace: "/repo/code/packages/rust",
           pico_uf2_mount: "/Volumes/RPI-RP2",
+          device_discovery: -> { runtime_devices },
           runner: runner
         )
 
         assert_equal :raspberry_pi_pico, connection.board
-        assert_nil connection.port
+        assert_equal "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00", connection.port
         assert_equal "/repo/code/packages/rust", runner.calls.first[:chdir]
         assert_equal [
           "cargo", "run",
@@ -412,6 +428,9 @@ module CodingAdventures
       def test_pico_flash_uses_auto_detected_bootsel_mount_by_default
         upload = CommandResult.new(["cargo"], "/repo/code/packages/rust", "copied uf2\n", "", 0)
         runner = FakeRunner.new([upload])
+        runtime_devices = BoardVM.devices(paths: [
+          "/dev/serial/by-id/usb-Raspberry_Pi_Pico_W_Board_VM-if00"
+        ])
 
         Dir.mktmpdir("board-vm-pico-uf2") do |root|
           mount = File.join(root, "RPI-RP2")
@@ -424,11 +443,12 @@ module CodingAdventures
             firmware_image: "/tmp/board-vm-pico-w.uf2",
             cargo_workspace: "/repo/code/packages/rust",
             pico_uf2_mount_roots: [root],
+            device_discovery: -> { runtime_devices },
             runner: runner
           )
 
           assert_equal :raspberry_pi_pico_w, connection.board
-          assert_nil connection.port
+          assert_equal "/dev/serial/by-id/usb-Raspberry_Pi_Pico_W_Board_VM-if00", connection.port
           assert_equal [
             "cargo", "run",
             "-p", "board-vm-cli",
@@ -439,6 +459,26 @@ module CodingAdventures
             "--mount", mount
           ], runner.calls.first[:argv]
         end
+      end
+
+      def test_pico_flash_reports_missing_runtime_device_after_upload
+        upload = CommandResult.new(["cargo"], "/repo/code/packages/rust", "copied uf2\n", "", 0)
+        runner = FakeRunner.new([upload])
+
+        error = assert_raises(DeviceSelectionError) do
+          BoardVM.pico(
+            flash: true,
+            firmware_image: "/tmp/board-vm-pico.uf2",
+            cargo_workspace: "/repo/code/packages/rust",
+            pico_uf2_mount: "/Volumes/RPI-RP2",
+            pico_runtime_port_wait_ms: 0,
+            device_discovery: -> { [] },
+            runner: runner
+          )
+        end
+
+        assert_match(/Pico UF2 upload finished/, error.message)
+        assert_equal 1, runner.calls.length
       end
 
       def test_esp_upload_command_rejects_non_esp_targets


### PR DESCRIPTION
## Summary
- add Ruby and Python runtime-device selectors that ignore Pico BOOTSEL/DAPLink bootloader ports
- make Ruby Pico `flash: true` rediscover the runtime serial port after UF2 upload and set `connection.port`
- keep failures actionable when the upload finishes but no runtime serial device appears

## Validation
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge` in `code/packages/rust`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
