### PR TITLE
[codex] Add event-stream checkpoint resume

### DIFF
--- a/code/packages/rust/smart-home-event-streams/CHANGELOG.md
+++ b/code/packages/rust/smart-home-event-streams/CHANGELOG.md
@@ -14,5 +14,7 @@ All notable changes to this package will be documented in this file.
 - Bounded reconnect policy with deterministic exponential backoff.
 - Event stream runtime state helpers for connection, heartbeat, event, gap,
   disconnect, stale-state, and restart-plan decisions.
+- Checkpoint resume helpers that rebuild stream state from durable cursors while
+  rejecting mismatched stream ids.
 - Heartbeat deadline and restart schedules for batching supervisor wakeups
   across multiple stream workers.

--- a/code/packages/rust/smart-home-event-streams/README.md
+++ b/code/packages/rust/smart-home-event-streams/README.md
@@ -10,6 +10,7 @@ radio workers a shared deterministic shape for:
 - stream identity and transport classification
 - MQTT topic filter validation, matching, and subscription descriptors
 - stream cursors and replay checkpoints
+- checkpoint-based state resume after supervised worker restarts
 - heartbeat freshness and stale-event deadlines
 - heartbeat deadline schedules for supervisor wakeups across many streams
 - disconnect tracking without losing the last cursor

--- a/code/packages/rust/smart-home-event-streams/src/lib.rs
+++ b/code/packages/rust/smart-home-event-streams/src/lib.rs
@@ -37,6 +37,27 @@ impl fmt::Display for EventStreamId {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventStreamError {
+    CheckpointStreamMismatch {
+        expected: EventStreamId,
+        actual: EventStreamId,
+    },
+}
+
+impl fmt::Display for EventStreamError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CheckpointStreamMismatch { expected, actual } => write!(
+                f,
+                "checkpoint stream {actual} does not match expected stream {expected}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EventStreamError {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EventStreamTransport {
     ServerSentEvents,
@@ -503,6 +524,29 @@ impl EventStreamState {
         }
     }
 
+    pub fn resume_from_checkpoint(
+        spec: EventStreamSpec,
+        checkpoint: EventStreamCheckpoint,
+    ) -> Result<Self, EventStreamError> {
+        if checkpoint.stream_id != spec.stream_id {
+            return Err(EventStreamError::CheckpointStreamMismatch {
+                expected: spec.stream_id,
+                actual: checkpoint.stream_id,
+            });
+        }
+
+        Ok(Self {
+            spec,
+            status: EventStreamStatus::Idle,
+            cursor: checkpoint.cursor,
+            connected_at_ms: None,
+            last_heartbeat_at_ms: None,
+            last_disconnect_at_ms: None,
+            reconnect_attempt: 0,
+            pending_gap_count: 0,
+        })
+    }
+
     pub fn checkpoint(&self) -> EventStreamCheckpoint {
         EventStreamCheckpoint::new(self.spec.stream_id.clone(), self.cursor.clone())
     }
@@ -912,6 +956,53 @@ mod tests {
             Some(EventId::trusted("event-1"))
         );
         assert_eq!(state.last_heartbeat_at_ms, Some(1_300));
+    }
+
+    #[test]
+    fn state_resumes_from_matching_checkpoints_without_replaying_zero() {
+        let spec = EventStreamSpec::hue_sse(bridge_id(), "https://bridge/eventstream");
+        let checkpoint = EventStreamCheckpoint::new(
+            spec.stream_id.clone(),
+            EventStreamCursor::start(1_000).advance(
+                EventId::trusted("event-42"),
+                Some("sse:last-event-id:42".to_string()),
+                1_500,
+            ),
+        );
+
+        let resumed = EventStreamState::resume_from_checkpoint(spec, checkpoint).unwrap();
+
+        assert_eq!(resumed.status, EventStreamStatus::Idle);
+        assert_eq!(resumed.cursor.sequence, 1);
+        assert_eq!(
+            resumed.cursor.native_cursor,
+            Some("sse:last-event-id:42".to_string())
+        );
+        assert_eq!(
+            resumed.cursor.last_event_id,
+            Some(EventId::trusted("event-42"))
+        );
+        assert_eq!(resumed.cursor.observed_at_ms, 1_500);
+        assert_eq!(resumed.reconnect_attempt, 0);
+    }
+
+    #[test]
+    fn state_rejects_mismatched_checkpoints() {
+        let spec = EventStreamSpec::hue_sse(bridge_id(), "https://bridge/eventstream");
+        let checkpoint = EventStreamCheckpoint::new(
+            EventStreamId::trusted("mqtt:broker-1"),
+            EventStreamCursor::start(1_000),
+        );
+
+        let error = EventStreamState::resume_from_checkpoint(spec.clone(), checkpoint).unwrap_err();
+
+        assert_eq!(
+            error,
+            EventStreamError::CheckpointStreamMismatch {
+                expected: spec.stream_id,
+                actual: EventStreamId::trusted("mqtt:broker-1")
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an EventStreamError type for checkpoint/stream mismatches
- add `EventStreamState::resume_from_checkpoint` so supervised workers can rebuild state from durable cursors without replaying from zero
- document and test matching and mismatched checkpoint resume behavior

## Validation
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p smart-home-event-streams`
- `cargo clippy --manifest-path code/packages/rust/Cargo.toml -p smart-home-event-streams --all-targets --no-deps -- -D warnings`
- `git diff --check`