### PR TITLE
Add Pico flash session smoke helper

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -403,6 +403,18 @@ class Session:
     def board_descriptor(self) -> BoardDescriptor | None:
         return self.capabilities().board_descriptor
 
+    def smoke(
+        self,
+        *,
+        host_name: str = DEFAULT_HOST_NAME,
+        host_nonce: int = DEFAULT_HOST_NONCE,
+        query_caps: bool = True,
+    ) -> SessionResult:
+        results = [self.hello(host_name=host_name, host_nonce=host_nonce)]
+        if query_caps:
+            results.append(self.capabilities())
+        return SessionResult(results)
+
     def blink_module(self, pin: int = 13, high_ms: int = 250, low_ms: int = 250, max_stack: int = 4) -> bytes:
         return _native.blink_module(pin, high_ms, low_ms, max_stack)
 

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -428,6 +428,16 @@ def test_session_dispatches_frames_through_write_transport():
     assert result.decoded_responses == [None] * 6
 
 
+def test_session_smoke_dispatches_hello_and_capabilities():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.smoke(host_nonce=123)
+
+    assert [item.command for item in result.results] == ["hello", "capabilities"]
+    assert result.frames == transport.frames
+
+
 def test_run_command_accepts_repl_style_blink():
     transport = FakeWriteTransport()
     session = Session(transport=transport)

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -248,6 +248,7 @@ module CodingAdventures
       input: $stdin,
       output: $stdout,
       flash: false,
+      smoke: false,
       cargo_workspace: DEFAULT_RUST_WORKSPACE,
       runner: CommandRunner.new,
       transport: nil,
@@ -275,6 +276,7 @@ module CodingAdventures
         **options
       )
       connection.flash! if flash
+      connection.smoke! if smoke
 
       return connection unless block_given?
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -96,6 +96,10 @@ module CodingAdventures
         session.board_descriptor
       end
 
+      def smoke!(host_name: Session::DEFAULT_HOST_NAME, host_nonce: DEFAULT_HOST_NONCE, query_caps: true)
+        session.smoke(host_name: host_name, host_nonce: host_nonce, query_caps: query_caps)
+      end
+
       def session(**options)
         protocol_session = Session.new(self, **options)
         return protocol_session unless block_given?

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/session.rb
@@ -73,6 +73,12 @@ module CodingAdventures
       end
       alias describe board_descriptor
 
+      def smoke(host_name: @host_name, host_nonce: @host_nonce, query_caps: true)
+        results = [hello(host_name: host_name, host_nonce: host_nonce)]
+        results << capabilities if query_caps
+        SessionResult.new(results: results)
+      end
+
       def upload(program_id: @program_id, module_bytes:)
         SessionResult.new(results: [
           dispatch(:program_begin, native_session.program_begin_wire(program_id, module_bytes)),
@@ -497,6 +503,9 @@ module CodingAdventures
         when "hello"
           ensure_no_extra_arguments!(words, command)
           SessionResult.new(results: [hello(**options)])
+        when "smoke"
+          ensure_no_extra_arguments!(words, command)
+          smoke(**options)
         when "caps", "capabilities"
           ensure_no_extra_arguments!(words, command)
           SessionResult.new(results: [capabilities])

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -481,6 +481,32 @@ module CodingAdventures
         assert_equal 1, runner.calls.length
       end
 
+      def test_pico_flash_can_immediately_smoke_rediscovered_runtime_port
+        upload = CommandResult.new(["cargo"], "/repo/code/packages/rust", "copied uf2\n", "", 0)
+        runner = FakeRunner.new([upload])
+        transport = FakeWriteTransport.new
+        runtime_devices = BoardVM.devices(paths: [
+          "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00"
+        ])
+
+        connection = BoardVM.pico(
+          flash: true,
+          smoke: true,
+          firmware_image: "/tmp/board-vm-pico.uf2",
+          cargo_workspace: "/repo/code/packages/rust",
+          pico_uf2_mount: "/Volumes/RPI-RP2",
+          device_discovery: -> { runtime_devices },
+          transport: transport,
+          runner: runner
+        )
+
+        assert_equal :raspberry_pi_pico, connection.board
+        assert_equal "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00", connection.port
+        assert_equal 1, runner.calls.length
+        assert_equal 2, transport.frames.length
+        assert transport.frames.all? { |frame| frame.is_a?(String) && frame.bytesize.positive? }
+      end
+
       def test_esp_upload_command_rejects_non_esp_targets
         error = assert_raises(UnsupportedBoardError) do
           BoardVM.esp_upload_command(:raspberry_pi_pico, port: "/dev/cu.usbmodem", image: "fw.bin")
@@ -711,6 +737,22 @@ module CodingAdventures
           result = board.session.run_command("stop")
 
           assert_equal [:stop], result.results.map(&:command)
+          assert_equal result.frames, transport.frames
+        end
+      end
+
+      def test_session_run_command_accepts_repl_style_smoke
+        transport = FakeWriteTransport.new
+
+        BoardVM.uno_r4_wifi(
+          port: "/dev/cu.usbmodem2201",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new,
+          transport: transport
+        ) do |board|
+          result = board.session.run_command("smoke")
+
+          assert_equal [:hello, :capabilities], result.results.map(&:command)
           assert_equal result.frames, transport.frames
         end
       end


### PR DESCRIPTION
## Summary
- add Ruby/Python session smoke helpers that dispatch HELLO and capabilities frames through the native session path
- let Ruby `connect(..., smoke: true)` run a smoke session after flashing
- cover Pico `flash: true, smoke: true` using the rediscovered runtime serial port

## Validation
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge` in `code/packages/rust`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check`