### PR TITLE
Add Python connect smoke option

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1238,6 +1238,19 @@ class Connection:
         options.setdefault("transport", self.transport)
         return Session(**options)
 
+    def smoke(
+        self,
+        *,
+        host_name: str = DEFAULT_HOST_NAME,
+        host_nonce: int = DEFAULT_HOST_NONCE,
+        query_caps: bool = True,
+    ) -> SessionResult:
+        return self.session().smoke(
+            host_name=host_name,
+            host_nonce=host_nonce,
+            query_caps=query_caps,
+        )
+
     def flash(self) -> Any:
         if self.firmware_image is None:
             raise ValueError("Board VM flash requires firmware_image")
@@ -1604,6 +1617,7 @@ def connect(
     input_func: Any = input,
     output: Any = None,
     flash: bool = False,
+    smoke: bool = False,
     transport: Any = None,
     runner: Any = None,
     cargo_workspace: str | pathlib.Path | None = None,
@@ -1655,6 +1669,8 @@ def connect(
     )
     if flash:
         connection.flash()
+    if smoke:
+        connection.smoke()
     return connection
 
 

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -443,6 +443,22 @@ def test_python_connect_auto_selects_device_and_dispatches_native_session():
     assert result.frames == transport.frames
 
 
+def test_python_connect_can_smoke_auto_selected_device():
+    found = devices(["/dev/tty.usbserial-CP2102-esp32"])
+    transport = FakeWriteTransport()
+
+    connection = connect(
+        "esp32",
+        smoke=True,
+        device_candidates=found,
+        transport=transport,
+    )
+
+    assert connection.port == "/dev/tty.usbserial-CP2102-esp32"
+    assert len(transport.frames) == 2
+    assert all(isinstance(frame, bytes) and frame for frame in transport.frames)
+
+
 def test_python_esp_connect_flash_uses_rust_owned_upload_command():
     found = devices(["/dev/tty.usbserial-CP2102-esp32"])
     runner = FakeRunner()
@@ -525,6 +541,38 @@ def test_python_pico_flash_rediscover_runtime_port():
             "/repo/code/packages/rust",
         )
     ]
+
+
+def test_python_pico_flash_can_smoke_rediscovered_runtime_port():
+    runner = FakeRunner()
+    transport = FakeWriteTransport()
+    runtime_devices = devices(["/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00"])
+
+    connection = pico(
+        flash=True,
+        smoke=True,
+        firmware_image="/tmp/board-vm-pico.uf2",
+        pico_uf2_mount="/Volumes/RPI-RP2",
+        pico_runtime_port_wait_ms=0,
+        device_discovery=lambda: runtime_devices,
+        cargo_workspace="/repo/code/packages/rust",
+        runner=runner,
+        transport=transport,
+    )
+
+    assert connection.port == "/dev/serial/by-id/usb-Raspberry_Pi_Pico_Board_VM-if00"
+    assert len(runner.calls) == 1
+    assert len(transport.frames) == 2
+
+
+def test_session_smoke_dispatches_hello_and_capabilities():
+    transport = FakeWriteTransport()
+    session = Session(transport=transport)
+
+    result = session.smoke(host_nonce=123)
+
+    assert [item.command for item in result.results] == ["hello", "capabilities"]
+    assert result.frames == transport.frames
 
 
 def test_session_dispatches_frames_through_write_transport():


### PR DESCRIPTION
## Summary
- add Python `Connection.smoke` over the native `Session.smoke` HELLO/capability frames
- let `connect(..., smoke=True)` smoke an auto-selected device after optional flash
- cover Pico `flash=True, smoke=True` using rediscovered runtime serial selection

## Validation
- `bash BUILD` in `code/packages/python/board-vm-native`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q` in `code/packages/python/board-vm-native`
- `cargo test -p board-vm-language-core -p python-bridge` in `code/packages/rust`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check`

Retargeted to `main` after #2493 merged.