### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 56

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -768,3 +768,16 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <p>
 |         "Test"
 |         <u>
+
+#data
+<!DOCTYPE html><font><table></font></table></font>
+#errors
+(1,35): unexpected-end-tag-implies-table-voodoo
+(1,35): unexpected-end-tag
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <font>
+|       <table>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 56
- keep the parser behavior unchanged for this fixture-only slice

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer