### PR TITLE
Expose Board VM connection options

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -211,6 +211,29 @@ class BoardTarget:
     def wireless_transports(self) -> list[str]:
         return [str(item["transport"]) for item in self.wireless]
 
+    @property
+    def connection_options(self) -> list[dict[str, Any]]:
+        return [dict(item) for item in self.raw.get("connection_options", [])]
+
+    @property
+    def command_transports(self) -> list[str]:
+        return [
+            str(item["transport"])
+            for item in self.connection_options
+            if item.get("command_transport")
+        ]
+
+    @property
+    def ota_transports(self) -> list[str]:
+        return [
+            str(item["transport"])
+            for item in self.connection_options
+            if item.get("ota_update")
+        ]
+
+    def supports_command_transport(self, transport: str) -> bool:
+        return str(transport) in self.command_transports
+
     def supports_wireless_transport(self, transport: str) -> bool:
         return str(transport) in self.wireless_transports
 
@@ -227,7 +250,7 @@ class BoardTarget:
 
     @property
     def supports_ota_update(self) -> bool:
-        return any(bool(item.get("ota_update")) for item in self.wireless)
+        return bool(self.ota_transports)
 
     @property
     def capabilities(self) -> list[str]:
@@ -1312,6 +1335,13 @@ def find_target(board_id: str) -> BoardTarget | None:
     return detect_target(board_id)
 
 
+def connection_options(selector: str) -> list[dict[str, Any]]:
+    target = detect_target(selector)
+    if target is None:
+        raise ValueError(f"unsupported board: {selector!r}")
+    return target.connection_options
+
+
 def esp_upload_options(
     selector: str = "esp32-devkit-v1",
     **overrides: Any,
@@ -1760,6 +1790,7 @@ __all__ = [
     "Session",
     "SessionResult",
     "connect",
+    "connection_options",
     "device_list",
     "devices",
     "detect_target",

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -17,16 +17,16 @@ use board_vm_language_core::{
     build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
     build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
     capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, detect_target as core_detect_target,
+    connection_transport_name, decode_wire_response, detect_target as core_detect_target,
     discover_devices as core_discover_devices, discover_devices_from_paths,
     discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
     discover_pico_bootsel_mounts_in_roots,
     esp_upload_options_for_target, known_targets, onboard_led_kind,
     pico_uf2_upload_options_for_target, program_format_name, raw_module_len, run_status_name,
     wireless_transport_name, BoardVmLanguageSession, DecodedLanguageResponse,
-    DecodedLanguageResponseBody, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
-    LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageTargetInfo, LanguageValue,
-    LanguageWirelessInterface,
+    DecodedLanguageResponseBody, LanguageConnectionOption, LanguageCoreError,
+    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
+    LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
 };
 use python_bridge::*;
 
@@ -790,6 +790,11 @@ unsafe fn language_target_to_py(target: &LanguageTargetInfo) -> PyObjectPtr {
         usize_to_py(target.digital_pin_count),
     );
     dict_set(dict, "wireless", language_wireless_to_py(&target.wireless));
+    dict_set(
+        dict,
+        "connection_options",
+        language_connection_options_to_py(&target.connection_options),
+    );
     let capabilities = PyList_New(target.capabilities.len() as isize);
     for (index, capability) in target.capabilities.iter().enumerate() {
         PyList_SetItem(capabilities, index as isize, str_to_py(capability));
@@ -814,6 +819,30 @@ unsafe fn language_wireless_to_py(interfaces: &[LanguageWirelessInterface]) -> P
             bool_to_py(interface.command_transport),
         );
         dict_set(dict, "ota_update", bool_to_py(interface.ota_update));
+        PyList_SetItem(list, index as isize, dict);
+    }
+    list
+}
+
+unsafe fn language_connection_options_to_py(
+    options: &[LanguageConnectionOption],
+) -> PyObjectPtr {
+    let list = PyList_New(options.len() as isize);
+    for (index, option) in options.iter().enumerate() {
+        let dict = PyDict_New();
+        dict_set(
+            dict,
+            "transport",
+            str_to_py(connection_transport_name(option.transport)),
+        );
+        dict_set(dict, "display_name", str_to_py(&option.display_name));
+        dict_set(
+            dict,
+            "command_transport",
+            bool_to_py(option.command_transport),
+        );
+        dict_set(dict, "ota_update", bool_to_py(option.ota_update));
+        dict_set(dict, "requires", str_to_py(&option.requires));
         PyList_SetItem(list, index as isize, dict);
     }
     list

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -12,6 +12,7 @@ from board_vm_native import (
     ProtocolResult,
     Session,
     connect,
+    connection_options,
     device_list,
     devices,
     detect_target,
@@ -122,6 +123,9 @@ def test_known_targets_are_exposed_from_rust_registry():
     assert uno_r4_wifi.supports_wifi is True
     assert uno_r4_wifi.supports_bluetooth is True
     assert uno_r4_wifi.supports_ota_update is True
+    assert uno_r4_wifi.command_transports == ["serial", "wifi", "bluetooth_le"]
+    assert uno_r4_wifi.ota_transports == ["wifi"]
+    assert uno_r4_wifi.supports_command_transport("serial") is True
     assert esp32 is not None
     assert esp32.family == "esp32"
     assert esp32.runtime_id == "board-vm-esp32"
@@ -129,13 +133,37 @@ def test_known_targets_are_exposed_from_rust_registry():
     assert "gpio.open" in esp32.capabilities
     assert "transport.bluetooth_classic" in esp32.capabilities
     assert all(item["command_transport"] for item in esp32.wireless)
+    assert any(
+        item["transport"] == "bluetooth_classic" and item["requires"] == "paired_device"
+        for item in esp32.connection_options
+    )
     assert pico is not None
     assert pico.wireless == []
+    assert [item["transport"] for item in pico.connection_options] == ["serial"]
     assert "transport.wifi" not in pico.capabilities
     assert pico_w is not None
     assert pico_w.onboard_led == {"kind": "wireless_chip_gpio", "pin": 0}
     assert "transport.wifi" in pico_w.capabilities
     assert "ota.wifi" in pico_w.capabilities
+
+
+def test_connection_options_are_exposed_from_rust_registry():
+    options = connection_options("uno-r4-wifi")
+
+    assert options[0] == {
+        "transport": "serial",
+        "display_name": "USB/serial",
+        "command_transport": True,
+        "ota_update": False,
+        "requires": "serial_port",
+    }
+    assert {
+        "transport": "wifi",
+        "display_name": "Wi-Fi",
+        "command_transport": True,
+        "ota_update": True,
+        "requires": "network_endpoint",
+    } in options
 
 
 def test_targets_are_detected_from_rust_owned_aliases():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -18,16 +18,16 @@ use board_vm_language_core::{
     build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
     build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
     capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    decode_wire_response, detect_target as core_detect_target,
+    connection_transport_name, decode_wire_response, detect_target as core_detect_target,
     discover_devices as core_discover_devices, discover_devices_from_paths,
     discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
     discover_pico_bootsel_mounts_in_roots,
     esp_upload_options_for_target, known_targets, onboard_led_kind,
     pico_uf2_upload_options_for_target, program_format_name, raw_module_len, run_status_name,
     wireless_transport_name, BoardVmLanguageSession, DecodedLanguageResponse,
-    DecodedLanguageResponseBody, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
-    LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageTargetInfo, LanguageValue,
-    LanguageWirelessInterface,
+    DecodedLanguageResponseBody, LanguageConnectionOption, LanguageCoreError,
+    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
+    LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
 };
 use ruby_bridge::VALUE;
 
@@ -676,6 +676,11 @@ fn language_target_to_rb(target: &LanguageTargetInfo) -> VALUE {
         rb_usize(target.digital_pin_count),
     );
     hash_set(hash, "wireless", language_wireless_to_rb(&target.wireless));
+    hash_set(
+        hash,
+        "connection_options",
+        language_connection_options_to_rb(&target.connection_options),
+    );
     let capabilities = ruby_bridge::array_new();
     for capability in &target.capabilities {
         ruby_bridge::array_push(capabilities, ruby_bridge::str_to_rb(capability));
@@ -704,6 +709,36 @@ fn language_wireless_to_rb(interfaces: &[LanguageWirelessInterface]) -> VALUE {
             "ota_update",
             ruby_bridge::bool_to_rb(interface.ota_update),
         );
+        ruby_bridge::array_push(array, hash);
+    }
+    array
+}
+
+fn language_connection_options_to_rb(options: &[LanguageConnectionOption]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for option in options {
+        let hash = ruby_bridge::hash_new();
+        hash_set(
+            hash,
+            "transport",
+            ruby_bridge::str_to_rb(connection_transport_name(option.transport)),
+        );
+        hash_set(
+            hash,
+            "display_name",
+            ruby_bridge::str_to_rb(&option.display_name),
+        );
+        hash_set(
+            hash,
+            "command_transport",
+            ruby_bridge::bool_to_rb(option.command_transport),
+        );
+        hash_set(
+            hash,
+            "ota_update",
+            ruby_bridge::bool_to_rb(option.ota_update),
+        );
+        hash_set(hash, "requires", ruby_bridge::str_to_rb(&option.requires));
         ruby_bridge::array_push(array, hash);
     }
     array

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -146,6 +146,15 @@ module CodingAdventures
       detect_target(board_id)
     end
 
+    def connection_options(board)
+      target = detect_target(board)
+      unless target
+        raise UnsupportedBoardError, "unsupported board: #{board.inspect}"
+      end
+
+      target.fetch("connection_options")
+    end
+
     def esp_upload_options(board = :esp32_devkit_v1, **overrides)
       options = Native.esp_upload_options(board.to_s)
       return nil unless options

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -35,17 +35,40 @@ module CodingAdventures
         assert_includes uno_r4_wifi["capabilities"], "transport.bluetooth_le"
         assert_equal ["wifi", "bluetooth_le"], uno_r4_wifi["wireless"].map { |item| item["transport"] }
         assert uno_r4_wifi["wireless"].find { |item| item["transport"] == "wifi" }["ota_update"]
+        assert_equal ["serial", "wifi", "bluetooth_le"], uno_r4_wifi["connection_options"].map { |item| item["transport"] }
+        assert_equal ["wifi"], uno_r4_wifi["connection_options"].select { |item| item["ota_update"] }.map { |item| item["transport"] }
         assert_equal "esp32", esp32["family"]
         assert_equal "board-vm-esp32", esp32["runtime_id"]
         assert_equal({ "kind" => "gpio", "pin" => 2 }, esp32["onboard_led"])
         assert_includes esp32["capabilities"], "gpio.open"
         assert_includes esp32["capabilities"], "transport.bluetooth_classic"
         assert esp32["wireless"].all? { |item| item["command_transport"] }
+        assert esp32["connection_options"].any? { |item| item["transport"] == "bluetooth_classic" && item["requires"] == "paired_device" }
         assert_equal [], pico["wireless"]
+        assert_equal ["serial"], pico["connection_options"].map { |item| item["transport"] }
         refute_includes pico["capabilities"], "transport.wifi"
         assert_equal({ "kind" => "wireless_chip_gpio", "pin" => 0 }, pico_w["onboard_led"])
         assert_includes pico_w["capabilities"], "transport.wifi"
         assert_includes pico_w["capabilities"], "ota.wifi"
+      end
+
+      def test_connection_options_are_exposed_from_rust_registry
+        options = BoardVM.connection_options(:uno_r4_wifi)
+
+        assert_equal({
+          "transport" => "serial",
+          "display_name" => "USB/serial",
+          "command_transport" => true,
+          "ota_update" => false,
+          "requires" => "serial_port"
+        }, options.first)
+        assert_includes options, {
+          "transport" => "wifi",
+          "display_name" => "Wi-Fi",
+          "command_transport" => true,
+          "ota_update" => true,
+          "requires" => "network_endpoint"
+        }
       end
 
       def test_targets_are_detected_from_rust_owned_aliases

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -269,12 +269,29 @@ pub enum LanguageWirelessTransport {
     BluetoothClassic,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageConnectionTransport {
+    Serial,
+    Wifi,
+    BluetoothLe,
+    BluetoothClassic,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageWirelessInterface {
     pub transport: LanguageWirelessTransport,
     pub chip: String,
     pub command_transport: bool,
     pub ota_update: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageConnectionOption {
+    pub transport: LanguageConnectionTransport,
+    pub display_name: String,
+    pub command_transport: bool,
+    pub ota_update: bool,
+    pub requires: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -291,6 +308,7 @@ pub struct LanguageTargetInfo {
     pub onboard_led: Option<LanguageOnboardLed>,
     pub digital_pin_count: usize,
     pub wireless: Vec<LanguageWirelessInterface>,
+    pub connection_options: Vec<LanguageConnectionOption>,
     pub capabilities: Vec<String>,
 }
 
@@ -449,6 +467,15 @@ pub const fn wireless_transport_name(transport: LanguageWirelessTransport) -> &'
     }
 }
 
+pub const fn connection_transport_name(transport: LanguageConnectionTransport) -> &'static str {
+    match transport {
+        LanguageConnectionTransport::Serial => "serial",
+        LanguageConnectionTransport::Wifi => "wifi",
+        LanguageConnectionTransport::BluetoothLe => "bluetooth_le",
+        LanguageConnectionTransport::BluetoothClassic => "bluetooth_classic",
+    }
+}
+
 pub fn capability_flag_names(flags: u16, out: &mut [&'static str]) -> usize {
     let mut count = 0;
     if capability_bytecode_callable(flags) {
@@ -544,6 +571,11 @@ pub fn pico_uf2_upload_options_for_target(selector: &str) -> Option<LanguagePico
     })
 }
 
+pub fn connection_options_for_target(selector: &str) -> Option<Vec<LanguageConnectionOption>> {
+    let target = detect_target(selector)?;
+    Some(target.connection_options)
+}
+
 pub fn discover_devices() -> Vec<LanguageHostDevice> {
     let mut paths = env_device_paths();
 
@@ -637,6 +669,7 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
             .iter()
             .map(language_wireless_interface)
             .collect(),
+        connection_options: language_connection_options(target),
         capabilities: target
             .capabilities
             .iter()
@@ -659,6 +692,60 @@ fn language_wireless_transport(transport: TargetWirelessTransport) -> LanguageWi
         TargetWirelessTransport::Wifi => LanguageWirelessTransport::Wifi,
         TargetWirelessTransport::BluetoothLe => LanguageWirelessTransport::BluetoothLe,
         TargetWirelessTransport::BluetoothClassic => LanguageWirelessTransport::BluetoothClassic,
+    }
+}
+
+fn language_connection_options(target: &BoardTargetInfo) -> Vec<LanguageConnectionOption> {
+    let mut options = Vec::new();
+    if target.capabilities.contains(&"transport.serial") {
+        options.push(LanguageConnectionOption {
+            transport: LanguageConnectionTransport::Serial,
+            display_name: "USB/serial".to_owned(),
+            command_transport: true,
+            ota_update: false,
+            requires: "serial_port".to_owned(),
+        });
+    }
+
+    for interface in target.wireless {
+        let transport = language_connection_transport(interface.transport);
+        options.push(LanguageConnectionOption {
+            transport,
+            display_name: connection_transport_display_name(transport).to_owned(),
+            command_transport: interface.command_transport,
+            ota_update: interface.ota_update,
+            requires: connection_transport_requires(transport).to_owned(),
+        });
+    }
+
+    options
+}
+
+fn language_connection_transport(
+    transport: TargetWirelessTransport,
+) -> LanguageConnectionTransport {
+    match transport {
+        TargetWirelessTransport::Wifi => LanguageConnectionTransport::Wifi,
+        TargetWirelessTransport::BluetoothLe => LanguageConnectionTransport::BluetoothLe,
+        TargetWirelessTransport::BluetoothClassic => LanguageConnectionTransport::BluetoothClassic,
+    }
+}
+
+const fn connection_transport_display_name(transport: LanguageConnectionTransport) -> &'static str {
+    match transport {
+        LanguageConnectionTransport::Serial => "USB/serial",
+        LanguageConnectionTransport::Wifi => "Wi-Fi",
+        LanguageConnectionTransport::BluetoothLe => "Bluetooth LE",
+        LanguageConnectionTransport::BluetoothClassic => "Bluetooth Classic",
+    }
+}
+
+const fn connection_transport_requires(transport: LanguageConnectionTransport) -> &'static str {
+    match transport {
+        LanguageConnectionTransport::Serial => "serial_port",
+        LanguageConnectionTransport::Wifi => "network_endpoint",
+        LanguageConnectionTransport::BluetoothLe
+        | LanguageConnectionTransport::BluetoothClassic => "paired_device",
     }
 }
 
@@ -2121,6 +2208,15 @@ mod tests {
             == LanguageWirelessTransport::Wifi
             && interface.command_transport
             && interface.ota_update));
+        assert!(esp32
+            .connection_options
+            .iter()
+            .any(
+                |option| option.transport == LanguageConnectionTransport::BluetoothClassic
+                    && option.command_transport
+                    && !option.ota_update
+                    && option.requires == "paired_device"
+            ));
         assert_eq!(
             pico_w.onboard_led,
             Some(LanguageOnboardLed::WirelessChipGpio(0))
@@ -2130,6 +2226,42 @@ mod tests {
             .unwrap()
             .wireless
             .is_empty());
+    }
+
+    #[test]
+    fn connection_options_are_owned_by_rust_language_core() {
+        let uno = connection_options_for_target("uno-r4-wifi").unwrap();
+        let pico = connection_options_for_target("pico").unwrap();
+
+        assert!(uno.iter().any(
+            |option| option.transport == LanguageConnectionTransport::Serial
+                && option.display_name == "USB/serial"
+                && option.command_transport
+                && !option.ota_update
+                && option.requires == "serial_port"
+        ));
+        assert!(uno.iter().any(
+            |option| option.transport == LanguageConnectionTransport::Wifi
+                && option.command_transport
+                && option.ota_update
+                && option.requires == "network_endpoint"
+        ));
+        assert!(uno.iter().any(|option| option.transport
+            == LanguageConnectionTransport::BluetoothLe
+            && option.command_transport
+            && !option.ota_update
+            && option.requires == "paired_device"));
+        assert_eq!(
+            pico.iter()
+                .map(|option| option.transport)
+                .collect::<Vec<_>>(),
+            vec![LanguageConnectionTransport::Serial]
+        );
+        assert_eq!(
+            connection_transport_name(LanguageConnectionTransport::BluetoothLe),
+            "bluetooth_le"
+        );
+        assert!(connection_options_for_target("not-a-board").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Rust-owned connection option metadata for serial, Wi-Fi, Bluetooth LE, and Bluetooth Classic per Board VM target
- expose connection options through the Ruby and Python native bridge target maps
- add Ruby/Python sugar so scripts can ask for supported command and OTA transports without parsing raw capability strings

## Validation
- `cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge` in `code/packages/rust`
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q` in `code/packages/python/board-vm-native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check`