### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 58

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -801,3 +801,16 @@ Line1<br>Line2<br>Line3<br>Line4
 |           "cruel"
 |       <b>
 |         "world"
+
+#data
+<b>Test</i>Test
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,11): unexpected-end-tag
+(1,15): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|       "TestTest"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 58
- keep the parser behavior unchanged for this fixture-only slice

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer