### PR TITLE
Add Board VM transport option pickers

### DIFF
--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1355,6 +1355,98 @@ def connection_options(selector: str) -> list[dict[str, Any]]:
     return target.connection_options
 
 
+def connection_option_list(selector: str) -> str:
+    options = connection_options(selector)
+    if not options:
+        return f"No Board VM connection options found for {selector}."
+
+    lines = []
+    for index, option in enumerate(options, start=1):
+        badges = []
+        if option.get("command_transport"):
+            badges.append("commands")
+        if option.get("ota_update"):
+            badges.append("OTA")
+        badge_label = f" [{', '.join(badges)}]" if badges else ""
+        lines.append(
+            f"{index}. {option['display_name']}{badge_label} - requires {option['requires']}"
+        )
+    return "\n".join(lines)
+
+
+def select_connection_option(
+    selector: str,
+    *,
+    transport: str | None = None,
+    ota: bool = False,
+) -> dict[str, Any]:
+    options = connection_options(selector)
+    matches = [option for option in options if option.get("command_transport")]
+    if ota:
+        matches = [option for option in matches if option.get("ota_update")]
+
+    if transport is not None:
+        normalized_transport = _normalize_connection_transport(transport)
+        selected = next(
+            (option for option in options if option["transport"] == normalized_transport),
+            None,
+        )
+        if selected is not None and (not ota or selected.get("ota_update")):
+            return dict(selected)
+        raise ValueError(
+            f"No {normalized_transport} connection option for {selector!r}.\n"
+            f"{connection_option_list(selector)}"
+        )
+
+    serial = next((option for option in matches if option["transport"] == "serial"), None)
+    if serial is not None and not ota:
+        return dict(serial)
+    if len(matches) == 1:
+        return dict(matches[0])
+
+    reason = "No matching connection option" if not matches else "Multiple connection options match"
+    raise ValueError(f"{reason} for {selector!r}.\n{connection_option_list(selector)}")
+
+
+def _normalize_connection_transport(transport: str) -> str:
+    normalized = str(transport).strip().lower().replace("-", "_").replace(" ", "_").replace("/", "_")
+    aliases = {
+        "usb": "serial",
+        "usb_serial": "serial",
+        "serial_port": "serial",
+        "wi_fi": "wifi",
+        "wireless": "wifi",
+        "ble": "bluetooth_le",
+        "bluetooth": "bluetooth_le",
+        "bluetooth_low_energy": "bluetooth_le",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def pick_connection_option(
+    selector: str,
+    *,
+    input_func: Any = input,
+    output: Any = None,
+) -> dict[str, Any]:
+    options = connection_options(selector)
+    if not options:
+        raise ValueError(f"No Board VM connection options found for {selector!r}.")
+
+    output = sys.stdout if output is None else output
+    output.write(connection_option_list(selector))
+    output.write("\n")
+    output.write(f"Select connection [1-{len(options)}]: ")
+    choice = input_func("")
+    try:
+        index = int(str(choice).strip())
+    except ValueError as error:
+        raise ValueError(f"Invalid Board VM connection selection: {choice!r}") from error
+    if not 1 <= index <= len(options):
+        raise ValueError(f"Invalid Board VM connection selection: {choice!r}")
+    return dict(options[index - 1])
+
+
 def esp_upload_options(
     selector: str = "esp32-devkit-v1",
     **overrides: Any,
@@ -1805,6 +1897,7 @@ __all__ = [
     "RUN_FLAGS",
     "Session",
     "SessionResult",
+    "connection_option_list",
     "connect",
     "connection_options",
     "device_list",
@@ -1818,6 +1911,7 @@ __all__ = [
     "known_targets",
     "pico",
     "pico_w",
+    "pick_connection_option",
     "pico_uf2_mount",
     "pico_uf2_upload_command",
     "pico_uf2_mounts",
@@ -1826,6 +1920,7 @@ __all__ = [
     "raspberry_pi_pico",
     "raspberry_pi_pico_w",
     "runtime_devices",
+    "select_connection_option",
     "select_device",
     "select_runtime_device",
     "uno_r4_wifi",

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -12,6 +12,7 @@ from board_vm_native import (
     ProtocolResult,
     Session,
     connect,
+    connection_option_list,
     connection_options,
     device_list,
     devices,
@@ -24,9 +25,11 @@ from board_vm_native import (
     pico_uf2_upload_command,
     pico_uf2_mounts,
     pico_uf2_upload_options,
+    pick_connection_option,
     pick_device,
     pico,
     runtime_devices,
+    select_connection_option,
     select_device,
     select_runtime_device,
 )
@@ -164,6 +167,46 @@ def test_connection_options_are_exposed_from_rust_registry():
         "ota_update": True,
         "requires": "network_endpoint",
     } in options
+    assert "Wi-Fi [commands, OTA]" in connection_option_list("uno-r4-wifi")
+
+
+def test_connection_options_can_be_selected_without_exposing_ports():
+    default = select_connection_option("uno-r4-wifi")
+    wifi = select_connection_option("uno-r4-wifi", transport="wifi")
+    friendly_wifi = select_connection_option("uno-r4-wifi", transport="Wi-Fi")
+    friendly_serial = select_connection_option("uno-r4-wifi", transport="USB serial")
+    ota = select_connection_option("uno-r4-wifi", ota=True)
+
+    assert default["transport"] == "serial"
+    assert wifi["transport"] == "wifi"
+    assert friendly_wifi["transport"] == "wifi"
+    assert friendly_serial["transport"] == "serial"
+    assert ota["transport"] == "wifi"
+
+    try:
+        select_connection_option("raspberry-pi-pico", transport="wifi")
+    except ValueError as error:
+        message = str(error)
+    else:
+        raise AssertionError("expected wifi selection to fail for non-wireless Pico")
+    assert "No wifi connection option" in message
+    assert "USB/serial" in message
+
+
+def test_connection_option_picker_prompts_for_repl_use():
+    output = io.StringIO()
+
+    option = pick_connection_option(
+        "uno-r4-wifi",
+        input_func=lambda _prompt: "2",
+        output=output,
+    )
+
+    assert option["transport"] == "wifi"
+    rendered = output.getvalue()
+    assert "1. USB/serial [commands] - requires serial_port" in rendered
+    assert "2. Wi-Fi [commands, OTA] - requires network_endpoint" in rendered
+    assert "Select connection [1-3]: " in rendered
 
 
 def test_targets_are_detected_from_rust_owned_aliases():

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -155,6 +155,57 @@ module CodingAdventures
       target.fetch("connection_options")
     end
 
+    def connection_option_list(board)
+      options = connection_options(board)
+      return "No Board VM connection options found for #{board}." if options.empty?
+
+      options.each_with_index.map do |option, index|
+        badges = []
+        badges << "commands" if option["command_transport"]
+        badges << "OTA" if option["ota_update"]
+        badge_label = badges.empty? ? "" : " [#{badges.join(", ")}]"
+
+        "#{index + 1}. #{option.fetch("display_name")}#{badge_label} - requires #{option.fetch("requires")}"
+      end.join("\n")
+    end
+
+    def select_connection_option(board, transport: nil, ota: false)
+      options = connection_options(board)
+      matches = options.select { |option| option["command_transport"] }
+      matches = matches.select { |option| option["ota_update"] } if ota
+
+      if transport
+        normalized_transport = normalize_connection_transport(transport)
+        selected = options.find { |option| option["transport"] == normalized_transport }
+        return selected if selected && (!ota || selected["ota_update"])
+
+        raise DeviceSelectionError,
+          "No #{normalized_transport} connection option for #{board.inspect}.\n#{connection_option_list(board)}"
+      end
+
+      serial = matches.find { |option| option["transport"] == "serial" }
+      return serial if serial && !ota
+      return matches.first if matches.length == 1
+
+      reason = matches.empty? ? "No matching connection option" : "Multiple connection options match"
+      raise DeviceSelectionError, "#{reason} for #{board.inspect}.\n#{connection_option_list(board)}"
+    end
+
+    def pick_connection_option(board, input: $stdin, output: $stdout)
+      options = connection_options(board)
+      raise DeviceSelectionError, "No Board VM connection options found for #{board.inspect}." if options.empty?
+
+      output.puts connection_option_list(board)
+      output.print "Select connection [1-#{options.length}]: "
+      choice = input.gets
+      index = Integer(choice.to_s.strip, exception: false)
+      unless index && index.between?(1, options.length)
+        raise DeviceSelectionError, "Invalid Board VM connection selection: #{choice.inspect}"
+      end
+
+      options.fetch(index - 1)
+    end
+
     def esp_upload_options(board = :esp32_devkit_v1, **overrides)
       options = Native.esp_upload_options(board.to_s)
       return nil unless options
@@ -410,6 +461,20 @@ module CodingAdventures
         :raspberry_pi_pico_w
       else
         board_id.to_s.tr("-", "_").to_sym
+      end
+    end
+
+    def normalize_connection_transport(transport)
+      normalized = transport.to_s.strip.downcase.tr("-", "_").tr(" /", "__")
+      case normalized
+      when "usb", "usb_serial", "serial_port"
+        "serial"
+      when "wi_fi", "wireless"
+        "wifi"
+      when "ble", "bluetooth", "bluetooth_low_energy"
+        "bluetooth_le"
+      else
+        normalized
       end
     end
   end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -71,6 +71,38 @@ module CodingAdventures
         }
       end
 
+      def test_connection_options_can_be_selected_without_exposing_ports
+        default = BoardVM.select_connection_option(:uno_r4_wifi)
+        wifi = BoardVM.select_connection_option(:uno_r4_wifi, transport: :wifi)
+        friendly_wifi = BoardVM.select_connection_option(:uno_r4_wifi, transport: "Wi-Fi")
+        friendly_serial = BoardVM.select_connection_option(:uno_r4_wifi, transport: "USB serial")
+        ota = BoardVM.select_connection_option(:uno_r4_wifi, ota: true)
+
+        assert_equal "serial", default.fetch("transport")
+        assert_equal "wifi", wifi.fetch("transport")
+        assert_equal "wifi", friendly_wifi.fetch("transport")
+        assert_equal "serial", friendly_serial.fetch("transport")
+        assert_equal "wifi", ota.fetch("transport")
+
+        error = assert_raises(DeviceSelectionError) do
+          BoardVM.select_connection_option(:raspberry_pi_pico, transport: :wifi)
+        end
+        assert_match(/No wifi connection option/, error.message)
+        assert_includes error.message, "USB/serial"
+      end
+
+      def test_connection_option_picker_prompts_for_repl_use
+        input = StringIO.new("2\n")
+        output = StringIO.new
+
+        option = BoardVM.pick_connection_option(:uno_r4_wifi, input: input, output: output)
+
+        assert_equal "wifi", option.fetch("transport")
+        assert_includes output.string, "1. USB/serial [commands] - requires serial_port"
+        assert_includes output.string, "2. Wi-Fi [commands, OTA] - requires network_endpoint"
+        assert_includes output.string, "Select connection [1-3]: "
+      end
+
       def test_targets_are_detected_from_rust_owned_aliases
         esp32 = BoardVM.detect_target("esp32")
         pico = BoardVM.detect_target("Raspberry Pi Pico")


### PR DESCRIPTION
## Summary
- add Ruby and Python helpers that render Rust-owned Board VM connection options as numbered choices
- default scripts to the command-capable USB/serial option while allowing friendly Wi-Fi/Bluetooth/OTA selection
- add explicit picker helpers for REPL flows so users can choose transports without handling raw port/protocol metadata

## Validation
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q` in `code/packages/python/board-vm-native`
- `cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge` in `code/packages/rust`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`