### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 64

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -886,3 +886,15 @@ Line1<br>Line2<br>Line3<br>Line4
 |   <head>
 |   <body>
 |     <div>
+
+#data
+<DIV> abc
+#errors
+(1,5): expected-doctype-but-got-start-tag
+(1,9): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       " abc"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 64
- keep parser behavior unchanged for this fixture-only slice

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer