### PR TITLE
Add Rust CAS mnewton package

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -509,6 +509,7 @@ members = [
     "cas-list-operations",
     "cas-matrix",
     "cas-limit-series",
+    "cas-mnewton",
     "cas-pretty-printer",
     "cas-number-theory",
     "cas-complex",

--- a/code/packages/rust/cas-mnewton/BUILD
+++ b/code/packages/rust/cas-mnewton/BUILD
@@ -1,0 +1,9 @@
+load("code/packages/starlark/library-rules/rust_library.star", "rust_library")
+
+_targets = [
+    rust_library(
+        name = "cas-mnewton",
+        srcs = ["src/**/*.rs", "tests/**/*.rs"],
+        deps = ["symbolic-ir", "cas-substitution"],
+    ),
+]

--- a/code/packages/rust/cas-mnewton/CHANGELOG.md
+++ b/code/packages/rust/cas-mnewton/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add Rust Newton-Raphson root finder parity with Python `cas-mnewton`.

--- a/code/packages/rust/cas-mnewton/Cargo.toml
+++ b/code/packages/rust/cas-mnewton/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cas-mnewton"
+version = "0.1.0"
+edition = "2021"
+description = "Newton-Raphson numeric root finder over symbolic IR"
+license = "MIT"
+
+[dependencies]
+symbolic-ir = { path = "../symbolic-ir" }
+cas-substitution = { path = "../cas-substitution" }

--- a/code/packages/rust/cas-mnewton/README.md
+++ b/code/packages/rust/cas-mnewton/README.md
@@ -1,0 +1,13 @@
+# cas-mnewton
+
+Rust port of the MACSYMA `MNewton` numeric root finder over `symbolic-ir`.
+
+The core algorithm stays VM-agnostic: callers provide an evaluator callback and
+a symbolic derivative callback. That mirrors the Python implementation and
+keeps this crate reusable from `symbolic-vm`, WASM bindings, and standalone
+tests.
+
+`mnewton_solve(f, x, x0, eval, diff, options)` returns `IRNode::Float(root)` on
+convergence, returns the original function expression when the input cannot be
+evaluated numerically, and reports `MNewtonError::ZeroDerivative` when Newton's
+step is undefined.

--- a/code/packages/rust/cas-mnewton/src/lib.rs
+++ b/code/packages/rust/cas-mnewton/src/lib.rs
@@ -1,0 +1,14 @@
+//! Newton-Raphson numeric root finding over symbolic IR.
+//!
+//! The crate mirrors Python `cas-mnewton` while staying independent from a
+//! concrete VM. Callers provide two callbacks:
+//!
+//! - `eval_fn`: collapses a substituted IR expression to a numeric literal.
+//! - `diff_fn`: computes the symbolic derivative once before iteration.
+//!
+//! This shape avoids an import cycle with `symbolic-vm` and keeps the core
+//! suitable for standalone Rust and WASM use.
+
+mod newton;
+
+pub use newton::{ir_to_float, mnewton_solve, MNewtonError, MNewtonOptions, MNEWTON};

--- a/code/packages/rust/cas-mnewton/src/newton.rs
+++ b/code/packages/rust/cas-mnewton/src/newton.rs
@@ -1,0 +1,91 @@
+use std::error::Error;
+use std::fmt;
+
+use cas_substitution::subst;
+use symbolic_ir::IRNode;
+
+pub const MNEWTON: &str = "MNewton";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MNewtonOptions {
+    pub tol: f64,
+    pub max_iter: usize,
+}
+
+impl Default for MNewtonOptions {
+    fn default() -> Self {
+        Self {
+            tol: 1e-10,
+            max_iter: 50,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MNewtonError {
+    ZeroDerivative { x: f64 },
+}
+
+impl fmt::Display for MNewtonError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ZeroDerivative { x } => {
+                write!(f, "Newton's method: derivative is zero at x = {x:?}")
+            }
+        }
+    }
+}
+
+impl Error for MNewtonError {}
+
+pub fn ir_to_float(node: &IRNode) -> Option<f64> {
+    match node {
+        IRNode::Integer(value) => Some(*value as f64),
+        IRNode::Rational(numer, denom) => Some(*numer as f64 / *denom as f64),
+        IRNode::Float(value) => Some(*value),
+        _ => None,
+    }
+}
+
+pub fn mnewton_solve<E, D>(
+    f_ir: &IRNode,
+    x_sym: &IRNode,
+    x0_ir: &IRNode,
+    mut eval_fn: E,
+    mut diff_fn: D,
+    options: MNewtonOptions,
+) -> Result<IRNode, MNewtonError>
+where
+    E: FnMut(IRNode) -> IRNode,
+    D: FnMut(&IRNode, &IRNode) -> IRNode,
+{
+    let f_prime_ir = eval_fn(diff_fn(f_ir, x_sym));
+    let Some(mut x_n) = ir_to_float(x0_ir) else {
+        return Ok(f_ir.clone());
+    };
+
+    for _ in 0..options.max_iter {
+        let x_n_ir = IRNode::Float(x_n);
+        let f_xn_ir = eval_fn(subst(x_n_ir.clone(), x_sym, f_ir.clone()));
+        let Some(f_xn) = ir_to_float(&f_xn_ir) else {
+            return Ok(f_ir.clone());
+        };
+
+        if f_xn.abs() < options.tol {
+            return Ok(IRNode::Float(x_n));
+        }
+
+        let f_prime_xn_ir = eval_fn(subst(x_n_ir, x_sym, f_prime_ir.clone()));
+        let Some(f_prime_xn) = ir_to_float(&f_prime_xn_ir) else {
+            return Ok(f_ir.clone());
+        };
+
+        if f_prime_xn.abs() < 1e-300 {
+            return Err(MNewtonError::ZeroDerivative { x: x_n });
+        }
+
+        x_n -= f_xn / f_prime_xn;
+    }
+
+    Ok(IRNode::Float(x_n))
+}

--- a/code/packages/rust/cas-mnewton/tests/tests.rs
+++ b/code/packages/rust/cas-mnewton/tests/tests.rs
@@ -1,0 +1,215 @@
+use cas_mnewton::{ir_to_float, mnewton_solve, MNewtonError, MNewtonOptions};
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, COS, MUL, POW, SIN, SUB};
+
+fn eval(node: IRNode) -> IRNode {
+    match node {
+        IRNode::Apply(apply_node) => {
+            let head = apply_node.head.clone();
+            let args: Vec<IRNode> = apply_node.args.into_iter().map(eval).collect();
+            let name = match &head {
+                IRNode::Symbol(name) => name.as_str(),
+                _ => return IRNode::Apply(Box::new(symbolic_ir::IRApply { head, args })),
+            };
+            match (name, args.as_slice()) {
+                (ADD, [a, b]) => numeric_binary(a, b, |x, y| x + y),
+                (SUB, [a, b]) => numeric_binary(a, b, |x, y| x - y),
+                (MUL, [a, b]) => numeric_binary(a, b, |x, y| x * y),
+                (POW, [a, b]) => numeric_binary(a, b, |x, y| x.powf(y)),
+                (SIN, [a]) => ir_to_float(a).map(|v| IRNode::Float(v.sin())),
+                (COS, [a]) => ir_to_float(a).map(|v| IRNode::Float(v.cos())),
+                _ => None,
+            }
+            .unwrap_or_else(|| IRNode::Apply(Box::new(symbolic_ir::IRApply { head, args })))
+        }
+        other => other,
+    }
+}
+
+fn numeric_binary(a: &IRNode, b: &IRNode, op: impl FnOnce(f64, f64) -> f64) -> Option<IRNode> {
+    Some(IRNode::Float(op(ir_to_float(a)?, ir_to_float(b)?)))
+}
+
+fn diff(node: &IRNode, var: &IRNode) -> IRNode {
+    if node == var {
+        return int(1);
+    }
+    match node {
+        IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_) => int(0),
+        IRNode::Symbol(_) => int(0),
+        IRNode::Apply(apply_node) => {
+            let head_name = match &apply_node.head {
+                IRNode::Symbol(name) => name.as_str(),
+                _ => return int(0),
+            };
+            match (head_name, apply_node.args.as_slice()) {
+                (ADD, [a, b]) => apply(sym(ADD), vec![diff(a, var), diff(b, var)]),
+                (SUB, [a, b]) => apply(sym(SUB), vec![diff(a, var), diff(b, var)]),
+                (MUL, [a, b]) => apply(
+                    sym(ADD),
+                    vec![
+                        apply(sym(MUL), vec![diff(a, var), b.clone()]),
+                        apply(sym(MUL), vec![a.clone(), diff(b, var)]),
+                    ],
+                ),
+                (POW, [base, IRNode::Integer(exp)]) if *exp >= 1 => {
+                    let coefficient = int(*exp);
+                    let lowered = if *exp == 1 {
+                        int(1)
+                    } else {
+                        apply(sym(POW), vec![base.clone(), int(exp - 1)])
+                    };
+                    apply(
+                        sym(MUL),
+                        vec![coefficient, apply(sym(MUL), vec![lowered, diff(base, var)])],
+                    )
+                }
+                (SIN, [arg]) => apply(
+                    sym(MUL),
+                    vec![apply(sym(COS), vec![arg.clone()]), diff(arg, var)],
+                ),
+                _ => int(0),
+            }
+        }
+        IRNode::Str(_) => int(0),
+    }
+}
+
+fn solve(f: IRNode, x0: IRNode) -> IRNode {
+    let x = sym("x");
+    mnewton_solve(&f, &x, &x0, eval, diff, MNewtonOptions::default()).unwrap()
+}
+
+fn assert_close(node: IRNode, expected: f64, tol: f64) {
+    let actual = ir_to_float(&node).expect("expected numeric result");
+    assert!(
+        (actual - expected).abs() < tol,
+        "expected {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn ir_to_float_accepts_numeric_literals() {
+    assert_eq!(ir_to_float(&int(3)), Some(3.0));
+    assert_eq!(ir_to_float(&IRNode::Float(1.5)), Some(1.5));
+    assert_eq!(ir_to_float(&rat(1, 2)), Some(0.5));
+    assert_eq!(ir_to_float(&sym("x")), None);
+    assert_eq!(ir_to_float(&apply(sym(ADD), vec![int(1), int(2)])), None);
+}
+
+#[test]
+fn solves_linear_functions() {
+    let x = sym("x");
+    assert_close(
+        solve(apply(sym(SUB), vec![x.clone(), int(2)]), IRNode::Float(0.0)),
+        2.0,
+        1e-9,
+    );
+    assert_close(solve(apply(sym(SUB), vec![x, int(7)]), int(0)), 7.0, 1e-9);
+}
+
+#[test]
+fn solves_quadratic_roots_from_starting_side() {
+    let x = sym("x");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(4)],
+    );
+    assert_close(solve(f.clone(), IRNode::Float(3.0)), 2.0, 1e-9);
+    assert_close(solve(f, IRNode::Float(-3.0)), -2.0, 1e-9);
+}
+
+#[test]
+fn solves_sqrt_two_and_cubic() {
+    let x = sym("x");
+    let sqrt_two = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(2)],
+    );
+    assert_close(solve(sqrt_two, IRNode::Float(1.5)), 2.0_f64.sqrt(), 1e-8);
+
+    let cubic = apply(sym(SUB), vec![apply(sym(POW), vec![x, int(3)]), int(8)]);
+    assert_close(solve(cubic, IRNode::Float(1.0)), 2.0, 1e-8);
+}
+
+#[test]
+fn accepts_rational_initial_guess() {
+    let x = sym("x");
+    let f = apply(sym(SUB), vec![x, int(2)]);
+    assert_close(solve(f, rat(3, 2)), 2.0, 1e-9);
+}
+
+#[test]
+fn returns_initial_guess_when_already_at_root() {
+    let x = sym("x");
+    let f = apply(sym(SUB), vec![x, int(5)]);
+    assert_eq!(solve(f, IRNode::Float(5.0)), IRNode::Float(5.0));
+}
+
+#[test]
+fn returns_original_expression_for_symbolic_initial_guess_or_non_numeric_eval() {
+    let x = sym("x");
+    let y = sym("y");
+    let f = apply(sym(SUB), vec![x.clone(), int(2)]);
+    let out = mnewton_solve(&f, &x, &sym("a"), eval, diff, MNewtonOptions::default()).unwrap();
+    assert_eq!(out, f);
+
+    let f_with_extra_symbol = apply(sym(ADD), vec![x.clone(), y]);
+    let out = mnewton_solve(
+        &f_with_extra_symbol,
+        &x,
+        &IRNode::Float(1.0),
+        eval,
+        diff,
+        MNewtonOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(out, f_with_extra_symbol);
+}
+
+#[test]
+fn reports_zero_derivative_before_newton_step() {
+    let x = sym("x");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+    );
+    let err = mnewton_solve(
+        &f,
+        &x,
+        &IRNode::Float(0.0),
+        eval,
+        diff,
+        MNewtonOptions::default(),
+    )
+    .unwrap_err();
+    assert_eq!(err, MNewtonError::ZeroDerivative { x: 0.0 });
+}
+
+#[test]
+fn honors_custom_tolerance_and_max_iter() {
+    let x = sym("x");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(2)],
+    );
+    let out = mnewton_solve(
+        &f,
+        &x,
+        &IRNode::Float(1.5),
+        eval,
+        diff,
+        MNewtonOptions {
+            tol: 1e-4,
+            max_iter: 50,
+        },
+    )
+    .unwrap();
+    assert_close(out, 2.0_f64.sqrt(), 1e-3);
+}
+
+#[test]
+fn solves_sin_root_near_pi() {
+    let x = sym("x");
+    let f = apply(sym(SIN), vec![x]);
+    assert_close(solve(f, IRNode::Float(3.0)), std::f64::consts::PI, 1e-8);
+}

--- a/code/specs/rust-cas-mnewton-parity.md
+++ b/code/specs/rust-cas-mnewton-parity.md
@@ -1,0 +1,22 @@
+# Rust CAS MNewton Parity
+
+## Status
+
+Initial Rust parity slice for Python `cas-mnewton`.
+
+## Scope
+
+- `mnewton_solve` implements Newton-Raphson iteration over `symbolic-ir`.
+- Evaluation and differentiation are callback parameters, matching the Python
+  package's import-cycle-free design.
+- Numeric literals accepted for the initial guess and evaluated values:
+  integer, rational, and float.
+- Zero derivatives are reported as `MNewtonError::ZeroDerivative`.
+- Non-numeric starting points or non-numeric evaluated function values return
+  the original expression unevaluated.
+
+## Follow-up
+
+- Add `symbolic-vm` handler wiring once the Rust VM exposes derivative helpers
+  equivalent to Python `symbolic_vm.derivative._diff`.
+- Port the same package to TypeScript with the same callback-shaped API.


### PR DESCRIPTION
## Summary
- add Rust cas-mnewton package for Newton-Raphson root finding over symbolic IR
- mirror Python's callback-shaped design with evaluator and derivative callbacks
- cover numeric literals, convergence, custom tolerance, non-numeric fallthrough, and zero-derivative errors

## Validation
- cargo fmt -p cas-mnewton
- cargo test -p cas-mnewton
- git diff --check HEAD~1 HEAD
- go run . -root /Users/adhithya/Downloads/Codex/coding-adventures-rust-cas-mnewton -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/rust-cas-mnewton-build-plan.json
- go run . -root /Users/adhithya/Downloads/Codex/coding-adventures-rust-cas-mnewton -plan-file /tmp/rust-cas-mnewton-build-plan.json -language rust -jobs 2