### PR TITLE
Wire Board VM connection options into language connects

### DIFF
--- a/code/packages/python/board-vm-native/README.md
+++ b/code/packages/python/board-vm-native/README.md
@@ -34,6 +34,21 @@ Each frame is a Rust-produced Board VM wire frame ready for a transport to
 write to a board. A `Session` can also dispatch through any object that exposes
 `transact(frame, timeout_ms=...)` or `write(frame)`.
 
+The high-level `connect()` helpers resolve devices and connection choices
+through the Rust-owned target/discovery metadata too:
+
+```python
+from board_vm_native import connect
+
+board = connect("esp32", flash=True, firmware_image="board-vm-esp32.bin")
+wifi_board = connect("uno-r4-wifi", via="Wi-Fi", transport=wifi_endpoint)
+```
+
+`via=` accepts friendly names such as `"serial"`, `"Wi-Fi"`, and `"BLE"`.
+`pick_connection=True` prints the board's available transports for REPL flows.
+Until the host Wi-Fi/Bluetooth endpoint layers land, wireless choices require
+an injected transport object instead of falling back to a serial port.
+
 `run()` is configurable sugar over Rust-owned RUN wire-frame construction:
 Python can request reset/background/keep-handle behavior or pass a raw flag
 mask, but `board-vm-language-core` owns the actual payload encoding.

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1222,6 +1222,7 @@ class Connection:
         target: BoardTarget,
         port: str | None,
         transport: Any = None,
+        connection_option: dict[str, Any] | None = None,
         runner: Any = None,
         cargo_workspace: str | pathlib.Path | None = None,
         firmware_image: str | pathlib.Path | None = None,
@@ -1237,6 +1238,7 @@ class Connection:
         self.target = target
         self.port = None if port is None else str(port)
         self.transport = transport
+        self.connection_option = dict(connection_option or select_connection_option(target.board_id))
         self.runner = _default_runner if runner is None else runner
         self.cargo_workspace = pathlib.Path(cargo_workspace or DEFAULT_RUST_WORKSPACE)
         self.firmware_image = None if firmware_image is None else str(firmware_image)
@@ -1256,6 +1258,23 @@ class Connection:
     @property
     def family(self) -> str:
         return self.target.family
+
+    @property
+    def connection_transport(self) -> str | None:
+        transport = self.connection_option.get("transport")
+        return None if transport is None else str(transport)
+
+    @property
+    def serial_connection(self) -> bool:
+        return self.connection_transport in {None, "serial"}
+
+    @property
+    def wireless_connection(self) -> bool:
+        return not self.serial_connection
+
+    @property
+    def ota_connection(self) -> bool:
+        return bool(self.connection_option.get("ota_update"))
 
     def session(self, **options: Any) -> Session:
         options.setdefault("transport", self.transport)
@@ -1277,6 +1296,12 @@ class Connection:
     def flash(self) -> Any:
         if self.firmware_image is None:
             raise ValueError("Board VM flash requires firmware_image")
+        if not self.serial_connection and self.family != "raspberry_pi_pico":
+            display_name = self.connection_option.get("display_name", self.connection_transport)
+            raise ValueError(
+                f"{display_name} flashing is known in target metadata, but Python host flashing "
+                f"over {self.connection_transport} is not wired yet; choose via='serial'"
+            )
         if self.family == "esp32":
             command = esp_upload_command(
                 self.board_id,
@@ -1736,6 +1761,9 @@ def connect(
     device: DeviceReference | None = None,
     device_candidates: Iterable[BoardDevice | dict[str, Any]] | None = None,
     pick: bool = False,
+    via: str | None = None,
+    connection_option: dict[str, Any] | None = None,
+    pick_connection: bool = False,
     input_func: Any = input,
     output: Any = None,
     flash: bool = False,
@@ -1755,7 +1783,27 @@ def connect(
     pico_uf2_upload_options: dict[str, Any] | None = None,
 ) -> Connection:
     selected_device = None
-    if pick and port is None and device is None:
+    explicit_target = None if selector == "auto" else detect_target(selector)
+    if selector != "auto" and explicit_target is None:
+        raise ValueError(f"unsupported board: {selector!r}")
+
+    selected_connection_option = None
+    if explicit_target is not None:
+        selected_connection_option = _resolve_connection_option(
+            explicit_target.board_id,
+            via=via,
+            connection_option=connection_option,
+            pick_connection=pick_connection,
+            input_func=input_func,
+            output=output,
+        )
+
+    needs_device_for_target = explicit_target is None and port is None
+    needs_serial_port = _connection_uses_serial_port(selected_connection_option) and not _flash_without_port(
+        explicit_target.board_id if explicit_target is not None else selector,
+        flash,
+    )
+    if pick and port is None and device is None and (needs_device_for_target or needs_serial_port):
         selected_device = pick_device(
             selector,
             device_candidates=device_candidates,
@@ -1768,15 +1816,24 @@ def connect(
             device=device,
             device_candidates=device_candidates,
         )
-    elif port is None and not _flash_without_port(selector, flash):
+    elif port is None and (needs_device_for_target or needs_serial_port):
         selected_device = select_device(selector, device_candidates=device_candidates)
 
     selected_port = port or (selected_device.port if selected_device is not None else None)
     target = _connection_target(selector, selected_device, selected_port)
+    selected_connection_option = selected_connection_option or _resolve_connection_option(
+        target.board_id,
+        via=via,
+        connection_option=connection_option,
+        pick_connection=pick_connection,
+        input_func=input_func,
+        output=output,
+    )
     connection = Connection(
         target=target,
         port=selected_port,
         transport=transport,
+        connection_option=selected_connection_option,
         runner=runner,
         cargo_workspace=cargo_workspace,
         firmware_image=firmware_image or esp_image,
@@ -1794,6 +1851,26 @@ def connect(
     if smoke:
         connection.smoke()
     return connection
+
+
+def _resolve_connection_option(
+    selector: str,
+    *,
+    via: str | None,
+    connection_option: dict[str, Any] | None,
+    pick_connection: bool,
+    input_func: Any,
+    output: Any,
+) -> dict[str, Any]:
+    if connection_option is not None:
+        return dict(connection_option)
+    if pick_connection:
+        return pick_connection_option(selector, input_func=input_func, output=output)
+    return select_connection_option(selector, transport=via)
+
+
+def _connection_uses_serial_port(connection_option: dict[str, Any] | None) -> bool:
+    return connection_option is None or connection_option.get("transport") == "serial"
 
 
 def uno_r4_wifi(**options: Any) -> Connection:

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -209,6 +209,50 @@ def test_connection_option_picker_prompts_for_repl_use():
     assert "Select connection [1-3]: " in rendered
 
 
+def test_connect_records_the_rust_selected_serial_connection_option():
+    found = devices(["/dev/tty.usbserial-CP2102-esp32"])
+
+    connection = connect("esp32", device_candidates=found)
+
+    assert connection.connection_transport == "serial"
+    assert connection.connection_option["display_name"] == "USB/serial"
+    assert connection.serial_connection is True
+    assert connection.wireless_connection is False
+
+
+def test_connect_can_use_a_wireless_connection_option_with_an_injected_endpoint():
+    transport = FakeWriteTransport()
+
+    connection = connect(
+        "uno-r4-wifi",
+        via="Wi-Fi",
+        smoke=True,
+        transport=transport,
+    )
+
+    assert connection.port is None
+    assert connection.connection_transport == "wifi"
+    assert connection.wireless_connection is True
+    assert connection.ota_connection is True
+    assert len(transport.frames) == 2
+
+
+def test_connect_can_prompt_for_the_connection_option_after_the_board():
+    output = io.StringIO()
+
+    connection = connect(
+        "uno-r4-wifi",
+        pick_connection=True,
+        input_func=lambda _prompt: "2",
+        output=output,
+        transport=FakeWriteTransport(),
+    )
+
+    assert connection.connection_transport == "wifi"
+    assert connection.port is None
+    assert "Select connection [1-3]: " in output.getvalue()
+
+
 def test_targets_are_detected_from_rust_owned_aliases():
     esp32 = detect_target("esp32")
     pico = detect_target("Raspberry Pi Pico")

--- a/code/packages/ruby/board_vm/README.md
+++ b/code/packages/ruby/board_vm/README.md
@@ -64,6 +64,29 @@ session result for debugging.
 Tests and alternate runtimes can inject any transport object that responds to
 `transact(frame, timeout_ms:)` or `write(frame)`.
 
+Scripts can avoid hard-coded serial paths when the board is discoverable:
+
+```ruby
+CodingAdventures::BoardVM.esp32(flash: true, firmware_image: "board-vm-esp32.bin") do |board|
+  board.led.blink
+end
+```
+
+`connect` resolves the board/device through the Rust-owned discovery metadata.
+Connection options are also selected from the Rust target registry:
+
+```ruby
+CodingAdventures::BoardVM.uno_r4_wifi(via: :wifi, transport: wifi_endpoint) do |board|
+  board.session { |vm| vm.hello }
+end
+```
+
+`via:` accepts friendly names such as `:serial`, `"Wi-Fi"`, and `"BLE"`.
+`pick_connection: true` prints the board's available transports and lets a REPL
+user choose one. Until the host Wi-Fi/Bluetooth endpoint layers land, wireless
+choices require an injected transport object; they never silently fall back to a
+serial port.
+
 `time.now_ms` follows the same path and returns through Rust-decoded run-report
 values:
 

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -312,18 +312,23 @@ module CodingAdventures
       cargo_workspace: DEFAULT_RUST_WORKSPACE,
       runner: CommandRunner.new,
       transport: nil,
+      via: nil,
+      connection_option: nil,
+      pick_connection: false,
       **options
     )
-      if pick && port.nil? && device.nil?
-        device = pick_device(board: board, devices: devices, input: input, output: output)
-      end
-
       selection = connection_selection(
         board: board,
         port: port,
         device: device,
         devices: devices,
-        flash: flash
+        flash: flash,
+        via: via,
+        connection_option: connection_option,
+        pick_connection: pick_connection,
+        pick: pick,
+        input: input,
+        output: output
       )
       connection = Connection.new(
         board: selection.fetch(:board),
@@ -331,6 +336,7 @@ module CodingAdventures
         cargo_workspace: cargo_workspace,
         runner: runner,
         transport: transport,
+        connection_option: selection.fetch(:connection_option),
         baud_rate: options.delete(:baud_rate) || options.delete(:baud) || DEFAULT_BAUD_RATE,
         timeout_ms: options.delete(:timeout_ms) || DEFAULT_TIMEOUT_MS,
         **options
@@ -372,13 +378,45 @@ module CodingAdventures
       raspberry_pi_pico_w(**options, &block)
     end
 
-    def connection_selection(board:, port:, device:, devices:, flash: false)
+    def connection_selection(
+      board:,
+      port:,
+      device:,
+      devices:,
+      flash: false,
+      via: nil,
+      connection_option: nil,
+      pick_connection: false,
+      pick: false,
+      input: $stdin,
+      output: $stdout
+    )
       explicit_port = !port.nil?
+      normalized_board = board == :auto ? nil : normalize_board(board)
+      selected_connection_option = if normalized_board
+        resolve_connection_option(
+          normalized_board,
+          via: via,
+          connection_option: connection_option,
+          pick_connection: pick_connection,
+          input: input,
+          output: output
+        )
+      end
+      needs_device_for_board = normalized_board.nil? && port.nil?
+      needs_serial_port = connection_uses_serial_port?(selected_connection_option) &&
+        !flash_without_port?(normalized_board || board, flash)
       selected_device = resolve_device_reference(device, devices: devices) if device
-      selected_device ||= select_device(board: board, devices: devices) if port.nil? && !flash_without_port?(board, flash)
+
+      if selected_device.nil? && port.nil? && pick && (needs_device_for_board || needs_serial_port)
+        selected_device = pick_device(board: board, devices: devices, input: input, output: output)
+      end
+      if selected_device.nil? && port.nil? && (needs_device_for_board || needs_serial_port)
+        selected_device = select_device(board: board, devices: devices)
+      end
       port ||= selected_device && selected_device.fetch("port")
 
-      normalized_board = if board == :auto
+      normalized_board ||= if board == :auto
         inferred_board = selected_device && device_target_board(
           selected_device,
           minimum_confidence: 60
@@ -393,7 +431,33 @@ module CodingAdventures
         normalize_board(board)
       end
 
-      { board: normalized_board, port: port }
+      selected_connection_option ||= resolve_connection_option(
+        normalized_board,
+        via: via,
+        connection_option: connection_option,
+        pick_connection: pick_connection,
+        input: input,
+        output: output
+      )
+
+      { board: normalized_board, port: port, connection_option: selected_connection_option }
+    end
+
+    def resolve_connection_option(board, via:, connection_option:, pick_connection:, input:, output:)
+      return normalize_connection_option_hash(connection_option) if connection_option
+      return pick_connection_option(board, input: input, output: output) if pick_connection
+
+      select_connection_option(board, transport: via)
+    end
+
+    def normalize_connection_option_hash(connection_option)
+      connection_option.each_with_object({}) do |(key, value), normalized|
+        normalized[key.to_s] = value
+      end
+    end
+
+    def connection_uses_serial_port?(connection_option)
+      connection_option.nil? || connection_option.fetch("transport") == "serial"
     end
 
     def flash_without_port?(board, flash)

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -6,7 +6,7 @@ module CodingAdventures
     class DeviceSelectionError < ArgumentError; end
 
     class Connection
-      attr_reader :board, :cargo_workspace, :runner, :transport, :baud_rate, :timeout_ms
+      attr_reader :board, :cargo_workspace, :runner, :transport, :connection_option, :baud_rate, :timeout_ms
       attr_accessor :port
 
       def initialize(
@@ -15,6 +15,7 @@ module CodingAdventures
         cargo_workspace:,
         runner:,
         transport:,
+        connection_option:,
         baud_rate:,
         timeout_ms:,
         arduino_core: nil,
@@ -48,6 +49,7 @@ module CodingAdventures
         @cargo_workspace = cargo_workspace
         @runner = runner
         @transport = transport
+        @connection_option = connection_option
         @baud_rate = baud_rate
         @timeout_ms = timeout_ms
         @arduino_core = arduino_core
@@ -109,6 +111,11 @@ module CodingAdventures
       end
 
       def flash!
+        if !serial_connection? && !pico_board?
+          raise UnsupportedBoardError,
+            "#{connection_display_name} flashing is known in target metadata, but Ruby host flashing over #{connection_transport} is not wired yet; choose via: :serial"
+        end
+
         case board
         when :uno_r4_wifi
           flash_uno_r4_wifi!
@@ -119,6 +126,22 @@ module CodingAdventures
         else
           raise UnsupportedBoardError, "Ruby DSL flash currently supports :uno_r4_wifi, :esp32_devkit_v1, :raspberry_pi_pico, and :raspberry_pi_pico_w; got #{board.inspect}"
         end
+      end
+
+      def connection_transport
+        connection_option && connection_option["transport"]
+      end
+
+      def serial_connection?
+        connection_transport.nil? || connection_transport == "serial"
+      end
+
+      def wireless_connection?
+        !serial_connection?
+      end
+
+      def ota_connection?
+        !!(connection_option && connection_option["ota_update"])
       end
 
       def blink!(
@@ -486,7 +509,27 @@ module CodingAdventures
       end
 
       def active_transport
-        @transport ||= SerialTransport.new(port: port, baud_rate: baud_rate, timeout_ms: timeout_ms)
+        return @transport if @transport
+
+        unless serial_connection?
+          raise TransportError,
+            "#{connection_display_name} requires an injected Board VM transport endpoint; pass transport: or choose via: :serial"
+        end
+        if port.nil? || port.to_s.empty?
+          raise TransportError, "USB/serial Board VM connection requires a serial port"
+        end
+
+        @transport = SerialTransport.new(port: port, baud_rate: baud_rate, timeout_ms: timeout_ms)
+      end
+
+      def connection_display_name
+        return "Board VM connection" unless connection_option
+
+        connection_option["display_name"] || connection_option["transport"] || "Board VM connection"
+      end
+
+      def pico_board?
+        %i[raspberry_pi_pico raspberry_pi_pico_w].include?(board)
       end
 
       def decode_response(session, response)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -103,6 +103,70 @@ module CodingAdventures
         assert_includes output.string, "Select connection [1-3]: "
       end
 
+      def test_connect_records_the_rust_selected_serial_connection_option
+        devices = BoardVM.devices(paths: ["/dev/tty.usbserial-CP2102-esp32"])
+
+        connection = BoardVM.connect(
+          board: :esp32,
+          devices: devices,
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new
+        )
+
+        assert_equal "serial", connection.connection_transport
+        assert_equal "USB/serial", connection.connection_option.fetch("display_name")
+        assert connection.serial_connection?
+        refute connection.wireless_connection?
+      end
+
+      def test_connect_can_use_a_wireless_connection_option_with_an_injected_endpoint
+        transport = FakeWriteTransport.new
+
+        connection = BoardVM.uno_r4_wifi(
+          via: "Wi-Fi",
+          smoke: true,
+          transport: transport,
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new
+        )
+
+        assert_nil connection.port
+        assert_equal "wifi", connection.connection_transport
+        assert connection.wireless_connection?
+        assert connection.ota_connection?
+        assert_equal 2, transport.frames.length
+      end
+
+      def test_connect_can_prompt_for_the_connection_option_after_the_board
+        output = StringIO.new
+
+        connection = BoardVM.uno_r4_wifi(
+          pick_connection: true,
+          input: StringIO.new("2\n"),
+          output: output,
+          transport: FakeWriteTransport.new,
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new
+        )
+
+        assert_equal "wifi", connection.connection_transport
+        assert_nil connection.port
+        assert_includes output.string, "Select connection [1-3]: "
+      end
+
+      def test_wireless_connection_requires_an_endpoint_before_dispatch
+        connection = BoardVM.uno_r4_wifi(
+          via: :wifi,
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new
+        )
+
+        error = assert_raises(TransportError) do
+          connection.smoke!
+        end
+        assert_match(/requires an injected Board VM transport endpoint/, error.message)
+      end
+
       def test_targets_are_detected_from_rust_owned_aliases
         esp32 = BoardVM.detect_target("esp32")
         pico = BoardVM.detect_target("Raspberry Pi Pico")


### PR DESCRIPTION
## Summary
- route Ruby and Python `connect` helpers through Rust-owned connection option metadata via `via:` / `pick_connection`
- store the selected connection option on connection objects with serial/wireless/OTA predicates
- prevent Wi-Fi/Bluetooth choices from silently falling back to serial when no host endpoint transport is injected

## Validation
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q` in `code/packages/python/board-vm-native`
- `cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge` in `code/packages/rust`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`