### PR TITLE
Add Lua Board VM connect flow sugar

### DIFF
--- a/code/packages/lua/board_vm_native/README.md
+++ b/code/packages/lua/board_vm_native/README.md
@@ -25,3 +25,24 @@ local devices = board_vm.devices({
 })
 print(devices[1].target.board_id) -- esp32-devkit-v1
 ```
+
+The higher-level connection helpers are still just Lua sugar over Rust-owned
+metadata. Lua asks the native bridge for known targets, discovered devices, and
+connection options, then keeps the chosen values on a small `Connection` object:
+
+```lua
+local board = board_vm.connect("esp32")
+print(board:board_id())              -- esp32-devkit-v1
+print(board:connection_transport())  -- serial
+
+local wifi_board = board_vm.connect("uno-r4-wifi", {
+    via = "Wi-Fi",
+    transport = wifi_endpoint,
+})
+wifi_board:smoke()
+```
+
+`via` accepts friendly names such as `serial`, `Wi-Fi`, and `BLE`. Wireless
+choices require an injected Lua transport object with `write(frame)` or
+`transact(frame, options)` until repo-native Wi-Fi/Bluetooth host endpoints are
+implemented; the module will not silently fall back to serial for those paths.

--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -81,6 +81,205 @@ function M.devices(paths)
     return native().devices()
 end
 
+local function normalize_connection_transport(transport)
+    local normalized = tostring(transport):lower():gsub("%-", "_"):gsub("[ /]", "_")
+    local aliases = {
+        usb = "serial",
+        usb_serial = "serial",
+        serial_port = "serial",
+        wi_fi = "wifi",
+        wireless = "wifi",
+        ble = "bluetooth_le",
+        bluetooth = "bluetooth_le",
+        bluetooth_low_energy = "bluetooth_le",
+    }
+    return aliases[normalized] or normalized
+end
+
+local function connection_uses_serial_port(connection_option)
+    return connection_option == nil or connection_option.transport == "serial"
+end
+
+local function clone_table(value)
+    if type(value) ~= "table" then
+        return value
+    end
+
+    local copy = {}
+    for key, item in pairs(value) do
+        copy[key] = item
+    end
+    return copy
+end
+
+function M.connection_option_list(selector)
+    local options = M.connection_options(selector)
+    if #options == 0 then
+        return "No Board VM connection options found for " .. tostring(selector) .. "."
+    end
+
+    local lines = {}
+    for index, option in ipairs(options) do
+        local badges = {}
+        if option.command_transport then
+            table.insert(badges, "commands")
+        end
+        if option.ota_update then
+            table.insert(badges, "OTA")
+        end
+        local badge_label = ""
+        if #badges > 0 then
+            badge_label = " [" .. table.concat(badges, ", ") .. "]"
+        end
+        lines[index] = string.format(
+            "%d. %s%s - requires %s",
+            index,
+            option.display_name,
+            badge_label,
+            option.requires
+        )
+    end
+    return table.concat(lines, "\n")
+end
+
+function M.select_connection_option(selector, options)
+    options = options or {}
+    local connection_options = M.connection_options(selector)
+    local matches = {}
+    for _, option in ipairs(connection_options) do
+        if option.command_transport and (not options.ota or option.ota_update) then
+            table.insert(matches, option)
+        end
+    end
+
+    local transport = options.transport or options.via
+    if transport then
+        local normalized = normalize_connection_transport(transport)
+        for _, option in ipairs(connection_options) do
+            if option.transport == normalized and (not options.ota or option.ota_update) then
+                return clone_table(option)
+            end
+        end
+        error(
+            "No " .. normalized .. " connection option for " .. tostring(selector) ..
+            ".\n" .. M.connection_option_list(selector)
+        )
+    end
+
+    if not options.ota then
+        for _, option in ipairs(matches) do
+            if option.transport == "serial" then
+                return clone_table(option)
+            end
+        end
+    end
+    if #matches == 1 then
+        return clone_table(matches[1])
+    end
+
+    local reason = #matches == 0 and "No matching connection option" or "Multiple connection options match"
+    error(reason .. " for " .. tostring(selector) .. ".\n" .. M.connection_option_list(selector))
+end
+
+function M.device_list(device_candidates)
+    local candidates = device_candidates or M.devices()
+    if #candidates == 0 then
+        return "No Board VM devices found."
+    end
+
+    local lines = {}
+    for index, device in ipairs(candidates) do
+        local target_name = "Unknown board"
+        if device.target then
+            target_name = device.target.display_name
+        end
+        local confidence = ""
+        if (device.target_confidence or 0) > 0 then
+            confidence = string.format(", %d%% match", device.target_confidence)
+        end
+        local tags = ""
+        if device.tags and #device.tags > 0 then
+            tags = " [" .. table.concat(device.tags, ", ") .. "]"
+        end
+        lines[index] = string.format("%d. %s - %s%s%s", index, target_name, device.port, confidence, tags)
+    end
+    return table.concat(lines, "\n")
+end
+
+function M.select_device(selector, options)
+    selector = selector or "auto"
+    options = options or {}
+    local candidates = options.devices or options.device_candidates
+    if candidates == nil then
+        candidates = M.devices(options.paths)
+    end
+
+    local device = options.device
+    if type(device) == "table" then
+        return device
+    elseif type(device) == "number" then
+        if candidates[device] then
+            return candidates[device]
+        end
+        error("No Board VM device at index " .. tostring(device) .. ".")
+    elseif device ~= nil then
+        local needle = tostring(device)
+        for _, candidate in ipairs(candidates) do
+            if candidate.id == needle or candidate.port == needle then
+                return candidate
+            end
+        end
+        error("No Board VM device named " .. string.format("%q", needle) .. ".\n" .. M.device_list(candidates))
+    end
+
+    local target = selector == "auto" and nil or M.detect_target(selector)
+    if selector ~= "auto" and target == nil then
+        error("unsupported board: " .. tostring(selector))
+    end
+
+    local matches = {}
+    if target == nil then
+        for _, candidate in ipairs(candidates) do
+            if candidate.target then
+                table.insert(matches, candidate)
+            end
+        end
+        if #matches == 0 and #candidates == 1 then
+            table.insert(matches, candidates[1])
+        end
+    else
+        for _, candidate in ipairs(candidates) do
+            if candidate.target and candidate.target.board_id == target.board_id then
+                table.insert(matches, candidate)
+            end
+        end
+        if #matches == 0 then
+            for _, candidate in ipairs(candidates) do
+                if candidate.target == nil then
+                    table.insert(matches, candidate)
+                end
+            end
+        end
+    end
+
+    if #matches == 1 then
+        return matches[1]
+    end
+    if #candidates == 0 then
+        error("No Board VM devices found. Plug in a board or pass an explicit device.")
+    end
+
+    local reason
+    if #matches == 0 and target == nil then
+        reason = "Multiple Board VM devices found; choose one"
+    elseif #matches == 0 then
+        reason = "No matching Board VM device found"
+    else
+        reason = "Multiple Board VM devices match"
+    end
+    error(reason .. ".\n" .. M.device_list(candidates))
+end
+
 local Session = {}
 Session.__index = Session
 
@@ -92,6 +291,8 @@ function Session.new(options)
         run_flags = options.run_flags or M.defaults().run_flags,
         instruction_budget = options.instruction_budget or M.defaults().instruction_budget,
         time_budget_ms = options.time_budget_ms or 0,
+        transport = options.transport,
+        timeout_ms = options.timeout_ms or 1000,
     }, Session)
 end
 
@@ -110,6 +311,37 @@ end
 
 function Session:caps_query_wire()
     return self:_frame(native().caps_query_wire(self.next_request_id))
+end
+
+function Session:dispatch_wire(frame)
+    if not self.transport then
+        error("Board VM Lua session requires a transport endpoint with write(frame) or transact(frame, options)")
+    end
+    local response = nil
+    if type(self.transport.transact) == "function" then
+        response = self.transport:transact(frame, { timeout_ms = self.timeout_ms })
+    elseif type(self.transport.write) == "function" then
+        self.transport:write(frame)
+    else
+        error("Board VM Lua transport must expose write(frame) or transact(frame, options)")
+    end
+    return { frame = frame, response = response }
+end
+
+function Session:hello(host_name, host_nonce)
+    return self:dispatch_wire(self:hello_wire(host_name, host_nonce))
+end
+
+function Session:capabilities()
+    return self:dispatch_wire(self:caps_query_wire())
+end
+
+function Session:smoke(options)
+    options = options or {}
+    return {
+        self:hello(options.host_name, options.host_nonce),
+        self:capabilities(),
+    }
 end
 
 function Session:blink_module(options)
@@ -175,6 +407,121 @@ M.Session = Session
 
 function M.session(options)
     return Session.new(options)
+end
+
+local Connection = {}
+Connection.__index = Connection
+
+function Connection.new(options)
+    return setmetatable({
+        target = options.target,
+        port = options.port,
+        device = options.device,
+        connection_option = options.connection_option,
+        transport = options.transport,
+        timeout_ms = options.timeout_ms or 1000,
+    }, Connection)
+end
+
+function Connection:board_id()
+    return self.target.board_id
+end
+
+function Connection:connection_transport()
+    if self.connection_option then
+        return self.connection_option.transport
+    end
+    return nil
+end
+
+function Connection:serial_connection()
+    local transport = self:connection_transport()
+    return transport == nil or transport == "serial"
+end
+
+function Connection:wireless_connection()
+    return not self:serial_connection()
+end
+
+function Connection:ota_connection()
+    return self.connection_option and self.connection_option.ota_update or false
+end
+
+function Connection:session(options)
+    options = options or {}
+    options.transport = options.transport or self.transport
+    options.timeout_ms = options.timeout_ms or self.timeout_ms
+    return Session.new(options)
+end
+
+function Connection:smoke(options)
+    return self:session():smoke(options)
+end
+
+M.Connection = Connection
+
+function M.connect(selector, options)
+    if type(selector) == "table" then
+        options = selector
+        selector = options.selector or options.board or "auto"
+    end
+    selector = selector or "auto"
+    options = options or {}
+
+    local target = selector == "auto" and nil or M.detect_target(selector)
+    if selector ~= "auto" and target == nil then
+        error("unsupported board: " .. tostring(selector))
+    end
+
+    local connection_option = nil
+    if target then
+        connection_option = options.connection_option or M.select_connection_option(target.board_id, {
+            via = options.via,
+            transport = options.transport_name,
+            ota = options.ota,
+        })
+    end
+
+    local needs_device_for_target = target == nil and options.port == nil
+    local needs_serial_port = connection_uses_serial_port(connection_option) and options.port == nil
+    local device = options.device
+    if type(device) ~= "table" and (device ~= nil or needs_device_for_target or needs_serial_port) then
+        device = M.select_device(selector, {
+            device = device,
+            devices = options.devices or options.device_candidates,
+            paths = options.paths,
+        })
+    end
+
+    local port = options.port
+    if port == nil and device then
+        port = device.port
+    end
+
+    if target == nil then
+        if device and device.target then
+            target = device.target
+        elseif port then
+            target = M.detect_target("uno-r4-wifi")
+        else
+            error("Could not infer the board for the selected device.\n" .. M.device_list(options.devices))
+        end
+    end
+
+    connection_option = connection_option or options.connection_option or M.select_connection_option(target.board_id, {
+        via = options.via,
+        transport = options.transport_name,
+        ota = options.ota,
+    })
+
+    return Connection.new({
+        target = target,
+        port = port,
+        device = device,
+        connection_option = connection_option,
+        transport = options.transport,
+        timeout_ms = options.timeout_ms,
+    })
 end
 
 return M

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -32,12 +32,19 @@ describe("coding_adventures.board_vm_native", function()
 
     it("exposes Rust-owned connection and upload options", function()
         local options = board_vm.connection_options("uno-r4-wifi")
+        local default = board_vm.select_connection_option("uno-r4-wifi")
+        local wifi = board_vm.select_connection_option("uno-r4-wifi", { via = "Wi-Fi" })
+        local ble = board_vm.select_connection_option("uno-r4-wifi", { via = "BLE" })
         local esp_upload = board_vm.esp_upload_options("esp32")
         local pico_upload = board_vm.pico_uf2_upload_options("pico-w")
 
         assert.are.equal("USB/serial", options[1].display_name)
         assert.are.equal("network_endpoint", options[2].requires)
         assert.is_true(options[2].ota_update)
+        assert.are.equal("serial", default.transport)
+        assert.are.equal("wifi", wifi.transport)
+        assert.are.equal("bluetooth_le", ble.transport)
+        assert.is_true(board_vm.connection_option_list("uno-r4-wifi"):find("Wi%-Fi") ~= nil)
         assert.are.equal(0x1000, esp_upload.offset)
         assert.are.equal(115200, esp_upload.baud_rate)
         assert.are.equal("pico-uf2", pico_upload.command)
@@ -73,6 +80,56 @@ describe("coding_adventures.board_vm_native", function()
         assert.is_not_nil(pico)
         assert.are.equal("raspberry-pi-pico", pico.target.board_id)
         assert.is_true(pico.bootloader)
+    end)
+
+    it("selects devices and connects without exposing serial details to callers", function()
+        local devices = board_vm.devices({
+            "/dev/cu.usbmodem1101",
+            "/dev/tty.usbserial-CP2102-esp32",
+        })
+        local selected = board_vm.select_device("esp32", { devices = devices })
+        local connection = board_vm.connect("esp32", { devices = devices })
+
+        assert.are.equal("/dev/tty.usbserial-CP2102-esp32", selected.port)
+        assert.are.equal("esp32-devkit-v1", connection:board_id())
+        assert.are.equal("/dev/tty.usbserial-CP2102-esp32", connection.port)
+        assert.are.equal("serial", connection:connection_transport())
+        assert.is_true(connection:serial_connection())
+        assert.is_false(connection:wireless_connection())
+    end)
+
+    it("connects to wireless transports through injected endpoints", function()
+        local transport = {
+            frames = {},
+            write = function(self, frame)
+                table.insert(self.frames, frame)
+            end,
+        }
+        local connection = board_vm.connect("uno-r4-wifi", {
+            via = "Wi-Fi",
+            transport = transport,
+        })
+        local results = connection:smoke({ host_name = "lua-test", host_nonce = 0x1234 })
+
+        assert.is_nil(connection.port)
+        assert.are.equal("wifi", connection:connection_transport())
+        assert.is_true(connection:wireless_connection())
+        assert.is_true(connection:ota_connection())
+        assert.are.equal(2, #results)
+        assert.are.equal(2, #transport.frames)
+        assert.is_string(transport.frames[1])
+        assert.are.equal(0, transport.frames[1]:byte(#transport.frames[1]))
+    end)
+
+    it("rejects dispatch when no Lua transport endpoint is available", function()
+        local connection = board_vm.connect("uno-r4-wifi", { via = "Wi-Fi" })
+
+        local ok, err = pcall(function()
+            connection:smoke()
+        end)
+
+        assert.is_false(ok)
+        assert.is_true(tostring(err):find("requires a transport endpoint") ~= nil)
     end)
 
     it("builds blink upload/run frames through Rust-owned protocol builders", function()


### PR DESCRIPTION
## Summary
- add Lua device and connection-option selection helpers over Rust-owned target/discovery metadata
- add a small Lua `Connection` object that tracks board, port, selected transport, and OTA/wireless predicates
- let Lua sessions dispatch Rust-built HELLO/CAPS frames through injected `write`/`transact` transports for smoke flows

## Validation
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `cargo test -p board-vm-language-core -p lua-bridge` in `code/packages/rust`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`