### PR TITLE
Add Rust CAS ODE numeric RK4 package

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -510,6 +510,7 @@ members = [
     "cas-matrix",
     "cas-limit-series",
     "cas-mnewton",
+    "cas-ode-numeric",
     "cas-pretty-printer",
     "cas-number-theory",
     "cas-complex",

--- a/code/packages/rust/cas-ode-numeric/BUILD
+++ b/code/packages/rust/cas-ode-numeric/BUILD
@@ -1,0 +1,9 @@
+load("code/packages/starlark/library-rules/rust_library.star", "rust_library")
+
+_targets = [
+    rust_library(
+        name = "cas-ode-numeric",
+        srcs = ["src/**/*.rs", "tests/**/*.rs"],
+        deps = ["symbolic-ir"],
+    ),
+]

--- a/code/packages/rust/cas-ode-numeric/CHANGELOG.md
+++ b/code/packages/rust/cas-ode-numeric/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add fixed-step RK4 solver over symbolic IR expressions.
+- Add numeric literal extraction and focused ODE regression tests.

--- a/code/packages/rust/cas-ode-numeric/Cargo.toml
+++ b/code/packages/rust/cas-ode-numeric/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cas-ode-numeric"
+version = "0.1.0"
+edition = "2021"
+description = "Fixed-step RK4 numeric ODE integrator over symbolic IR"
+license = "MIT"
+
+[dependencies]
+symbolic-ir = { path = "../symbolic-ir" }

--- a/code/packages/rust/cas-ode-numeric/README.md
+++ b/code/packages/rust/cas-ode-numeric/README.md
@@ -1,0 +1,8 @@
+# cas-ode-numeric
+
+Fixed-step fourth-order Runge-Kutta integration for symbolic-IR right hand sides.
+
+The crate mirrors the Python `cas-ode-numeric` package while staying VM-neutral:
+`rk4_solve` owns RK4 stepping and passes temporary `(time, state)` bindings to an
+evaluation callback. A symbolic VM, MACSYMA runtime, or WASM host can provide the
+callback without coupling this package to one backend.

--- a/code/packages/rust/cas-ode-numeric/src/lib.rs
+++ b/code/packages/rust/cas-ode-numeric/src/lib.rs
@@ -1,0 +1,5 @@
+mod rk4;
+
+pub use rk4::{
+    default_state_names, ir_to_float, rk4_solve, Binding, Rk4Error, Rk4Options, Rk4Point, RK4_SOLVE,
+};

--- a/code/packages/rust/cas-ode-numeric/src/rk4.rs
+++ b/code/packages/rust/cas-ode-numeric/src/rk4.rs
@@ -1,0 +1,224 @@
+use std::error::Error;
+use std::fmt;
+
+use symbolic_ir::IRNode;
+
+pub const RK4_SOLVE: &str = "RK4Solve";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Rk4Options {
+    pub state_names: Option<Vec<String>>,
+    pub t_name: String,
+}
+
+impl Default for Rk4Options {
+    fn default() -> Self {
+        Self {
+            state_names: None,
+            t_name: "t".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Binding<'a> {
+    pub name: &'a str,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Rk4Point {
+    pub t: f64,
+    pub state: Vec<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Rk4Error {
+    Y0LengthMismatch {
+        f_components: usize,
+        y0_entries: usize,
+    },
+    StateNamesLengthMismatch {
+        state_names: usize,
+        f_components: usize,
+    },
+    NonPositiveDt {
+        dt: f64,
+    },
+    Eval {
+        index: usize,
+        message: String,
+    },
+}
+
+impl fmt::Display for Rk4Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Y0LengthMismatch {
+                f_components,
+                y0_entries,
+            } => write!(
+                f,
+                "f_ir has {f_components} components but y0 has {y0_entries} entries."
+            ),
+            Self::StateNamesLengthMismatch {
+                state_names,
+                f_components,
+            } => write!(
+                f,
+                "state_names has {state_names} entries but f_ir has {f_components}."
+            ),
+            Self::NonPositiveDt { dt } => write!(f, "dt must be positive, got {dt:?}."),
+            Self::Eval { index, message } => {
+                write!(
+                    f,
+                    "RK4: failed to evaluate RHS component {index}: {message}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for Rk4Error {}
+
+pub fn ir_to_float(node: &IRNode) -> Option<f64> {
+    match node {
+        IRNode::Integer(value) => Some(*value as f64),
+        IRNode::Rational(numer, denom) => Some(*numer as f64 / *denom as f64),
+        IRNode::Float(value) => Some(*value),
+        _ => None,
+    }
+}
+
+pub fn default_state_names(n: usize) -> Vec<String> {
+    (0..n).map(|i| format!("y{i}")).collect()
+}
+
+pub fn rk4_solve<E>(
+    f_ir: &[IRNode],
+    y0: &[f64],
+    t_span: (f64, f64),
+    dt: f64,
+    mut eval_fn: E,
+    options: Rk4Options,
+) -> Result<Vec<Rk4Point>, Rk4Error>
+where
+    E: FnMut(&IRNode, &[Binding<'_>]) -> Result<f64, String>,
+{
+    let n = f_ir.len();
+    if y0.len() != n {
+        return Err(Rk4Error::Y0LengthMismatch {
+            f_components: n,
+            y0_entries: y0.len(),
+        });
+    }
+    if dt <= 0.0 {
+        return Err(Rk4Error::NonPositiveDt { dt });
+    }
+
+    let state_names = options
+        .state_names
+        .unwrap_or_else(|| default_state_names(n));
+    if state_names.len() != n {
+        return Err(Rk4Error::StateNamesLengthMismatch {
+            state_names: state_names.len(),
+            f_components: n,
+        });
+    }
+
+    let (t_start, t_end) = t_span;
+    let mut trajectory = Vec::new();
+    let mut t_cur = t_start;
+    let mut y_cur = y0.to_vec();
+    trajectory.push(Rk4Point {
+        t: t_cur,
+        state: y_cur.clone(),
+    });
+
+    while t_cur < t_end - dt * 1e-10 {
+        let h = dt.min(t_end - t_cur);
+        let k1 = eval_rhs(
+            f_ir,
+            t_cur,
+            &y_cur,
+            &state_names,
+            &options.t_name,
+            &mut eval_fn,
+        )?;
+
+        let y_mid1: Vec<f64> = (0..n).map(|i| y_cur[i] + 0.5 * h * k1[i]).collect();
+        let k2 = eval_rhs(
+            f_ir,
+            t_cur + 0.5 * h,
+            &y_mid1,
+            &state_names,
+            &options.t_name,
+            &mut eval_fn,
+        )?;
+
+        let y_mid2: Vec<f64> = (0..n).map(|i| y_cur[i] + 0.5 * h * k2[i]).collect();
+        let k3 = eval_rhs(
+            f_ir,
+            t_cur + 0.5 * h,
+            &y_mid2,
+            &state_names,
+            &options.t_name,
+            &mut eval_fn,
+        )?;
+
+        let y_end_stage: Vec<f64> = (0..n).map(|i| y_cur[i] + h * k3[i]).collect();
+        let k4 = eval_rhs(
+            f_ir,
+            t_cur + h,
+            &y_end_stage,
+            &state_names,
+            &options.t_name,
+            &mut eval_fn,
+        )?;
+
+        let y_next: Vec<f64> = (0..n)
+            .map(|i| y_cur[i] + (h / 6.0) * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]))
+            .collect();
+
+        t_cur += h;
+        y_cur = y_next;
+        trajectory.push(Rk4Point {
+            t: t_cur,
+            state: y_cur.clone(),
+        });
+    }
+
+    Ok(trajectory)
+}
+
+fn eval_rhs<E>(
+    f_ir: &[IRNode],
+    t_value: f64,
+    y_values: &[f64],
+    state_names: &[String],
+    t_name: &str,
+    eval_fn: &mut E,
+) -> Result<Vec<f64>, Rk4Error>
+where
+    E: FnMut(&IRNode, &[Binding<'_>]) -> Result<f64, String>,
+{
+    let mut bindings = Vec::with_capacity(1 + state_names.len());
+    bindings.push(Binding {
+        name: t_name,
+        value: t_value,
+    });
+    for (name, value) in state_names.iter().zip(y_values.iter()) {
+        bindings.push(Binding {
+            name,
+            value: *value,
+        });
+    }
+
+    let mut result = Vec::with_capacity(f_ir.len());
+    for (index, node) in f_ir.iter().enumerate() {
+        let value =
+            eval_fn(node, &bindings).map_err(|message| Rk4Error::Eval { index, message })?;
+        result.push(value);
+    }
+    Ok(result)
+}

--- a/code/packages/rust/cas-ode-numeric/tests/tests.rs
+++ b/code/packages/rust/cas-ode-numeric/tests/tests.rs
@@ -1,0 +1,230 @@
+use cas_ode_numeric::{ir_to_float, rk4_solve, Binding, Rk4Error, Rk4Options};
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, MUL, NEG, POW, SUB};
+
+fn eval_numeric(node: &IRNode, bindings: &[Binding<'_>]) -> Result<f64, String> {
+    let out = eval_node(node, bindings);
+    ir_to_float(&out).ok_or_else(|| format!("expected numeric IR node, got {out:?}"))
+}
+
+fn eval_node(node: &IRNode, bindings: &[Binding<'_>]) -> IRNode {
+    match node {
+        IRNode::Symbol(name) => bindings
+            .iter()
+            .find(|binding| binding.name == name)
+            .map(|binding| IRNode::Float(binding.value))
+            .unwrap_or_else(|| node.clone()),
+        IRNode::Apply(apply_node) => {
+            let head = apply_node.head.clone();
+            let args: Vec<IRNode> = apply_node
+                .args
+                .iter()
+                .map(|arg| eval_node(arg, bindings))
+                .collect();
+            let name = match &head {
+                IRNode::Symbol(name) => name.as_str(),
+                _ => return IRNode::Apply(Box::new(symbolic_ir::IRApply { head, args })),
+            };
+            match (name, args.as_slice()) {
+                (ADD, [a, b]) => numeric_binary(a, b, |x, y| x + y),
+                (SUB, [a, b]) => numeric_binary(a, b, |x, y| x - y),
+                (MUL, [a, b]) => numeric_binary(a, b, |x, y| x * y),
+                (POW, [a, b]) => numeric_binary(a, b, |x, y| x.powf(y)),
+                (NEG, [a]) => ir_to_float(a).map(|v| IRNode::Float(-v)),
+                _ => None,
+            }
+            .unwrap_or_else(|| IRNode::Apply(Box::new(symbolic_ir::IRApply { head, args })))
+        }
+        other => other.clone(),
+    }
+}
+
+fn numeric_binary(a: &IRNode, b: &IRNode, op: impl FnOnce(f64, f64) -> f64) -> Option<IRNode> {
+    Some(IRNode::Float(op(ir_to_float(a)?, ir_to_float(b)?)))
+}
+
+fn solve(
+    f_ir: &[IRNode],
+    y0: &[f64],
+    t_span: (f64, f64),
+    dt: f64,
+    state_names: &[&str],
+) -> Vec<cas_ode_numeric::Rk4Point> {
+    rk4_solve(
+        f_ir,
+        y0,
+        t_span,
+        dt,
+        eval_numeric,
+        Rk4Options {
+            state_names: Some(state_names.iter().map(|name| name.to_string()).collect()),
+            ..Rk4Options::default()
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn ir_to_float_accepts_numeric_literals() {
+    assert_eq!(ir_to_float(&int(3)), Some(3.0));
+    assert_eq!(ir_to_float(&IRNode::Float(1.5)), Some(1.5));
+    assert_eq!(ir_to_float(&rat(1, 2)), Some(0.5));
+    assert_eq!(ir_to_float(&sym("x")), None);
+}
+
+#[test]
+fn integrates_scalar_decay() {
+    let y = sym("y");
+    let f = apply(sym(MUL), vec![int(-2), y]);
+    let traj = solve(&[f], &[1.0], (0.0, 1.0), 0.001, &["y"]);
+    let end = traj.last().unwrap();
+    assert!((end.t - 1.0).abs() < 1e-10);
+    assert!((end.state[0] - (-2.0_f64).exp()).abs() < 1e-4);
+}
+
+#[test]
+fn records_initial_condition_and_expected_length() {
+    let y = sym("y");
+    let f = apply(sym(MUL), vec![int(-1), y]);
+    let traj = solve(&[f], &[2.5], (0.0, 1.0), 0.1, &["y"]);
+    assert_eq!(traj.len(), 11);
+    assert!((traj[0].t - 0.0).abs() < 1e-12);
+    assert!((traj[0].state[0] - 2.5).abs() < 1e-12);
+}
+
+#[test]
+fn keeps_zero_rhs_constant() {
+    let traj = solve(&[int(0)], &[3.7], (0.0, 2.0), 0.5, &["y"]);
+    assert!(traj
+        .iter()
+        .all(|point| (point.state[0] - 3.7).abs() < 1e-12));
+}
+
+#[test]
+fn integrates_coupled_oscillator() {
+    let y = sym("y");
+    let v = sym("v");
+    let f_y = v;
+    let f_v = apply(sym(NEG), vec![y]);
+    let traj = solve(
+        &[f_y, f_v],
+        &[1.0, 0.0],
+        (0.0, 2.0 * std::f64::consts::PI),
+        0.001,
+        &["y", "v"],
+    );
+    let state = &traj.last().unwrap().state;
+    assert!((state[0] - 1.0).abs() < 0.01);
+    assert!(state[1].abs() < 0.01);
+}
+
+#[test]
+fn uses_time_binding_and_clamps_final_step() {
+    let traj = rk4_solve(
+        &[sym("time")],
+        &[0.0],
+        (0.0, 1.0),
+        0.3,
+        eval_numeric,
+        Rk4Options {
+            state_names: Some(vec!["y".to_string()]),
+            t_name: "time".to_string(),
+        },
+    )
+    .unwrap();
+
+    let end = traj.last().unwrap();
+    assert!((end.t - 1.0).abs() < 1e-12);
+    assert_eq!(traj.len(), 5);
+    assert!((end.state[0] - 0.5).abs() < 1e-8);
+}
+
+#[test]
+fn smaller_dt_gives_lower_error() {
+    let y = sym("y");
+    let f = apply(sym(MUL), vec![int(-1), y]);
+    let exact = (-1.0_f64).exp();
+    let coarse = solve(std::slice::from_ref(&f), &[1.0], (0.0, 1.0), 0.1, &["y"]);
+    let fine = solve(&[f], &[1.0], (0.0, 1.0), 0.05, &["y"]);
+    let coarse_err = (coarse.last().unwrap().state[0] - exact).abs();
+    let fine_err = (fine.last().unwrap().state[0] - exact).abs();
+    assert!(coarse_err > fine_err);
+}
+
+#[test]
+fn reports_argument_errors() {
+    assert_eq!(
+        rk4_solve(
+            &[int(0)],
+            &[1.0],
+            (0.0, 1.0),
+            0.0,
+            eval_numeric,
+            Rk4Options::default()
+        )
+        .unwrap_err(),
+        Rk4Error::NonPositiveDt { dt: 0.0 }
+    );
+    assert_eq!(
+        rk4_solve(
+            &[int(0)],
+            &[1.0, 2.0],
+            (0.0, 1.0),
+            0.1,
+            eval_numeric,
+            Rk4Options::default()
+        )
+        .unwrap_err(),
+        Rk4Error::Y0LengthMismatch {
+            f_components: 1,
+            y0_entries: 2
+        }
+    );
+    assert_eq!(
+        rk4_solve(
+            &[int(0)],
+            &[1.0],
+            (0.0, 1.0),
+            0.1,
+            eval_numeric,
+            Rk4Options {
+                state_names: Some(vec!["a".to_string(), "b".to_string()]),
+                ..Rk4Options::default()
+            },
+        )
+        .unwrap_err(),
+        Rk4Error::StateNamesLengthMismatch {
+            state_names: 2,
+            f_components: 1
+        }
+    );
+}
+
+#[test]
+fn reports_non_numeric_rhs() {
+    let err = rk4_solve(
+        &[sym("unbound")],
+        &[1.0],
+        (0.0, 0.1),
+        0.05,
+        eval_numeric,
+        Rk4Options {
+            state_names: Some(vec!["y".to_string()]),
+            ..Rk4Options::default()
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, Rk4Error::Eval { index: 0, .. }));
+}
+
+#[test]
+fn simulates_underdamped_rlc_transient() {
+    let q = sym("q");
+    let i = sym("i");
+    let half_i = apply(sym(MUL), vec![IRNode::Float(0.5), i.clone()]);
+    let di_dt = apply(sym(SUB), vec![apply(sym(SUB), vec![int(1), half_i]), q]);
+    let traj = solve(&[i, di_dt], &[0.0, 0.0], (0.0, 20.0), 0.01, &["q", "i"]);
+    let q_values: Vec<f64> = traj.iter().map(|point| point.state[0]).collect();
+    assert!(q_values.iter().copied().fold(f64::NEG_INFINITY, f64::max) < 3.0);
+    assert!(q_values.iter().copied().fold(f64::INFINITY, f64::min) > -1.0);
+    assert!((traj.last().unwrap().state[0] - 1.0).abs() < 0.05);
+}


### PR DESCRIPTION
## Summary
- add Rust `cas-ode-numeric` package with fixed-step RK4 integration over symbolic IR
- expose VM-neutral binding/evaluator callback API plus numeric literal extraction
- cover scalar decay, oscillator, final-step clamping, argument errors, non-numeric RHS, and RLC transient regressions

## Validation
- `cargo fmt -p cas-ode-numeric`
- `cargo test -p cas-ode-numeric`
- `go run . -root /Users/adhithya/Downloads/Codex/coding-adventures-rust-cas-ode-numeric -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/rust-cas-ode-numeric-plan.json`