### PR TITLE
[codex] Expose smart-home supervision read tool

### DIFF
--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this package will be documented in this file.
 - Protocol identifier records for Hue, Zigbee, Z-Wave, Thread, Matter, MQTT,
   and vendor adapters.
 - D18D-style smart-home tool descriptors and command risk-tier helpers.
+- Read-only `smart_home.observe_supervision` tool descriptor for status loops.
 - Agent capability grant primitives for checking smart-home tool access before
   runtime dispatch.
 - Authorization-decision records for capturing allowed or denied tool/command

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -35,6 +35,8 @@ Current scope:
 - command risk tier helpers
 - state freshness helpers
 - D18D-style smart-home tool descriptors
+- read-only supervision observation tool descriptor for Chief of Staff status
+  loops
 - agent capability grants for checking tool access before dispatch
 - authorization decisions that can be logged by runtimes and agents
 

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -693,6 +693,7 @@ pub enum SmartHomeTool {
     Subscribe,
     DescribeCapabilities,
     GetHealth,
+    ObserveSupervision,
 }
 
 impl SmartHomeTool {
@@ -722,6 +723,7 @@ impl SmartHomeTool {
             Self::Subscribe => read_tool("smart_home.subscribe"),
             Self::DescribeCapabilities => read_tool("smart_home.describe_capabilities"),
             Self::GetHealth => read_tool("smart_home.get_health"),
+            Self::ObserveSupervision => read_tool("smart_home.observe_supervision"),
         }
     }
 }
@@ -1029,6 +1031,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::Subscribe,
         SmartHomeTool::DescribeCapabilities,
         SmartHomeTool::GetHealth,
+        SmartHomeTool::ObserveSupervision,
     ]
     .into_iter()
     .map(SmartHomeTool::descriptor)
@@ -1303,12 +1306,17 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 9);
+        assert_eq!(catalog.len(), 10);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
             vec![CapabilityId::trusted("smart_home.command.light")]
         );
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.observe_supervision"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -20,8 +20,8 @@ All notable changes to this package will be documented in this file.
   authorized commands.
 - Registry-backed tool authorization decisions for Chief of Staff tool calls.
 - D18D-style read tool execution for listing bridges/devices, reading entity
-  state, describing entity capabilities, and inspecting bridge health through
-  the registry without dispatching integration work.
+  state, describing entity capabilities, inspecting bridge health, and observing
+  supervision status through the registry without dispatching integration work.
 - D18D-style subscribe tool execution for authorized, filtered event-stream
   subscriptions with checkpointed replay metadata.
 - D18D-style pair-bridge execution with short-lived pairing sessions, VaultRef

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -19,8 +19,8 @@ Included surfaces:
   authorized commands
 - registry-backed tool authorization decisions for Chief of Staff tool calls
 - D18D-facing read tool facade for listing bridges/devices, reading entity
-  state, describing capabilities, and inspecting bridge health without invoking
-  integrations
+  state, describing capabilities, inspecting bridge health, and observing
+  supervision status without invoking integrations
 - D18D-facing subscribe tool facade that authorizes event-stream access and
   registers filtered replay subscriptions with checkpoints
 - D18D-facing pair-bridge facade with short-lived pairing sessions that complete

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -891,6 +891,7 @@ pub enum RuntimeReadToolRequest {
     GetHealth {
         bridge_id: Option<BridgeId>,
     },
+    ObserveSupervision,
 }
 
 impl RuntimeReadToolRequest {
@@ -901,6 +902,7 @@ impl RuntimeReadToolRequest {
             Self::GetState { .. } => SmartHomeTool::GetState,
             Self::DescribeCapabilities { .. } => SmartHomeTool::DescribeCapabilities,
             Self::GetHealth { .. } => SmartHomeTool::GetHealth,
+            Self::ObserveSupervision => SmartHomeTool::ObserveSupervision,
         }
     }
 }
@@ -1039,6 +1041,7 @@ pub enum RuntimeReadToolOutput {
         capabilities: Vec<Capability>,
     },
     Health(Vec<BridgeHealthSnapshot>),
+    SupervisionObservation(RuntimeSupervisionObservation),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1434,6 +1437,9 @@ impl SmartHomeRuntime {
                         .collect(),
                 )),
             },
+            RuntimeReadToolRequest::ObserveSupervision => Ok(
+                RuntimeReadToolOutput::SupervisionObservation(self.observe_supervision_at(now_ms)?),
+            ),
         }
     }
 
@@ -2870,6 +2876,14 @@ mod tests {
             .with_expiry(2_000),
         );
         runtime
+            .supervisor_mut()
+            .register_worker(SupervisedBridgeWorker::new(
+                BridgeId::trusted("bridge-1"),
+                IntegrationId::trusted("hue"),
+                1_000,
+                100,
+            ));
+        runtime
             .registry_mut()
             .apply_state_snapshot(StateSnapshot {
                 entity_id: EntityId::trusted("entity-1"),
@@ -2920,12 +2934,15 @@ mod tests {
             .unwrap();
         let health = runtime
             .execute_read_tool(
-                principal,
+                principal.clone(),
                 RuntimeReadToolRequest::GetHealth {
                     bridge_id: Some(BridgeId::trusted("bridge-1")),
                 },
                 1_504,
             )
+            .unwrap();
+        let observation = runtime
+            .execute_read_tool(principal, RuntimeReadToolRequest::ObserveSupervision, 1_505)
             .unwrap();
 
         assert!(matches!(
@@ -2963,7 +2980,15 @@ mod tests {
                 last_seen_at_ms: None,
             }]
         ));
-        assert_eq!(runtime.registry().counts().authorization_decisions, 5);
+        assert!(matches!(
+            observation,
+            RuntimeReadToolOutput::SupervisionObservation(observation)
+                if observation.generated_at_ms == 1_505
+                    && observation.worker_restart_count() == 1
+                    && observation.due_worker_deadline_count() == 1
+                    && observation.next_worker_heartbeat_due_at_ms() == Some(1_100)
+        ));
+        assert_eq!(runtime.registry().counts().authorization_decisions, 6);
         assert!(runtime
             .registry()
             .authorization_decisions()


### PR DESCRIPTION
## Summary
- add the read-only `smart_home.observe_supervision` tool descriptor to the smart-home catalog
- expose `RuntimeReadToolRequest::ObserveSupervision` through the authorized read-tool facade
- return `RuntimeSupervisionObservation` without running supervision ticks or mutating runtime state

## Tests
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p smart-home-core -p smart-home-runtime`
- `cargo clippy --manifest-path code/packages/rust/Cargo.toml -p smart-home-core -p smart-home-runtime --all-targets --no-deps -- -D warnings`
- `git diff --check HEAD~1..HEAD`