### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 68

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -940,3 +940,19 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <b>
 |         " def "
 |         <i>
+
+#data
+<DIV> abc <B> def <I> ghi
+#errors
+(1,5): expected-doctype-but-got-start-tag
+(1,25): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       " abc "
+|       <b>
+|         " def "
+|         <i>
+|           " ghi"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 68
- keep parser behavior unchanged for this fixture-only slice

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer