### PR TITLE
[codex] Extend HTML tree construction smoke tests through case 70

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -973,3 +973,21 @@ Line1<br>Line2<br>Line3<br>Line4
 |         <i>
 |           " ghi "
 |           <p>
+
+#data
+<DIV> abc <B> def <I> ghi <P> jkl
+#errors
+(1,5): expected-doctype-but-got-start-tag
+(1,33): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       " abc "
+|       <b>
+|         " def "
+|         <i>
+|           " ghi "
+|           <p>
+|             " jkl"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 70
- cover text appended inside the freshly inserted nested-formatting paragraph from the previous slice

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer