### PR TITLE
Add Board VM TCP endpoint transport

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "board-vm-client",
     "board-vm-cli",
     "board-vm-stream",
+    "board-vm-tcp",
     "board-vm-serial",
     "board-vm-uart",
     "board-vm-usb-cdc",

--- a/code/packages/rust/board-vm-cli/Cargo.toml
+++ b/code/packages/rust/board-vm-cli/Cargo.toml
@@ -12,6 +12,7 @@ board-vm-host = { path = "../board-vm-host" }
 board-vm-language-core = { path = "../board-vm-language-core" }
 board-vm-protocol = { path = "../board-vm-protocol" }
 board-vm-serial = { path = "../board-vm-serial" }
+board-vm-tcp = { path = "../board-vm-tcp" }
 board-vm-targets = { path = "../board-vm-targets" }
 
 [lib]

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use std::fs;
 use std::io::{BufRead, Write};
+use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -23,10 +24,11 @@ use board_vm_host::{
 use board_vm_language_core::{detect_target, discover_devices, LanguageHostDevice};
 use board_vm_protocol::{BOOT_RUN_AT_BOOT, BOOT_RUN_IF_NO_HOST, BOOT_STORE_ONLY};
 use board_vm_serial::{
-    available_ports, BoardSerialTransport, SerialConfig, SerialPortInfo, SerialTransportError,
-    DEFAULT_BAUD_RATE, DEFAULT_TIMEOUT_MS,
+    available_ports, BoardSerialTransport, SerialConfig, SerialPort, SerialPortInfo,
+    SerialTransportError, DEFAULT_BAUD_RATE, DEFAULT_TIMEOUT_MS,
 };
 use board_vm_targets::{all_targets, BoardTargetInfo, OnboardLed};
+use board_vm_tcp::{BoardTcpTransport, TcpConfig, TcpTransportError};
 
 pub const DEFAULT_PROGRAM_ID: u16 = 1;
 pub const DEFAULT_INSTRUCTION_BUDGET: u32 = 12;
@@ -51,6 +53,7 @@ pub enum CliCommand {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SmokeOptions {
     pub port: Option<String>,
+    pub endpoint: Option<String>,
     pub board: String,
     pub baud_rate: u32,
     pub timeout_ms: u64,
@@ -67,6 +70,12 @@ impl SmokeOptions {
             .dtr_on_open(true)
             .clear_on_open(true)
             .settle_on_open(Duration::from_millis(DEFAULT_OPEN_SETTLE_MS))
+    }
+
+    pub fn tcp_config(&self, endpoint: &str) -> TcpConfig {
+        TcpConfig::new(endpoint)
+            .connect_timeout(Duration::from_millis(self.timeout_ms))
+            .io_timeout(Duration::from_millis(self.timeout_ms))
     }
 }
 
@@ -136,6 +145,7 @@ impl EspUploadOptions {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReplOptions {
     pub port: Option<String>,
+    pub endpoint: Option<String>,
     pub board: String,
     pub baud_rate: u32,
     pub timeout_ms: u64,
@@ -152,6 +162,30 @@ impl ReplOptions {
             .dtr_on_open(true)
             .clear_on_open(true)
             .settle_on_open(Duration::from_millis(DEFAULT_OPEN_SETTLE_MS))
+    }
+
+    pub fn tcp_config(&self, endpoint: &str) -> TcpConfig {
+        TcpConfig::new(endpoint)
+            .connect_timeout(Duration::from_millis(self.timeout_ms))
+            .io_timeout(Duration::from_millis(self.timeout_ms))
+    }
+}
+
+enum SessionTransport {
+    Serial(BoardSerialTransport<Box<dyn SerialPort>, 1024>),
+    Tcp(BoardTcpTransport<TcpStream, 1024>),
+}
+
+impl RawFrameTransport for SessionTransport {
+    fn exchange_raw_frame(
+        &mut self,
+        request: &[u8],
+        response_out: &mut [u8],
+    ) -> Result<usize, board_vm_client::TransportError> {
+        match self {
+            Self::Serial(transport) => transport.exchange_raw_frame(request, response_out),
+            Self::Tcp(transport) => transport.exchange_raw_frame(request, response_out),
+        }
     }
 }
 
@@ -270,6 +304,12 @@ impl From<ClientError> for CliError {
 impl From<SerialTransportError> for CliError {
     fn from(value: SerialTransportError) -> Self {
         Self::Serial(format!("{value:?}"))
+    }
+}
+
+impl From<TcpTransportError> for CliError {
+    fn from(value: TcpTransportError) -> Self {
+        Self::Io(format!("tcp transport error: {value:?}"))
     }
 }
 
@@ -428,6 +468,7 @@ where
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionOptions {
     port: Option<String>,
+    endpoint: Option<String>,
     board: String,
     baud_rate: u32,
     timeout_ms: u64,
@@ -443,6 +484,7 @@ where
     let options = parse_session_options(&mut args)?;
     Ok(CliCommand::Smoke(SmokeOptions {
         port: options.port,
+        endpoint: options.endpoint,
         board: options.board,
         baud_rate: options.baud_rate,
         timeout_ms: options.timeout_ms,
@@ -459,6 +501,7 @@ where
     let options = parse_session_options(&mut args)?;
     Ok(CliCommand::Repl(ReplOptions {
         port: options.port,
+        endpoint: options.endpoint,
         board: options.board,
         baud_rate: options.baud_rate,
         timeout_ms: options.timeout_ms,
@@ -518,6 +561,7 @@ where
     I: Iterator<Item = String>,
 {
     let mut port = None;
+    let mut endpoint = None;
     let mut board = "auto".to_owned();
     let mut baud_rate = DEFAULT_BAUD_RATE;
     let mut timeout_ms = DEFAULT_TIMEOUT_MS;
@@ -528,6 +572,7 @@ where
     while let Some(option) = args.next() {
         match option.as_str() {
             "--port" | "-p" => port = Some(next_value(args, "--port")?),
+            "--endpoint" | "--tcp-endpoint" => endpoint = Some(next_value(args, "--endpoint")?),
             "--board" | "--target" => board = next_value(args, "--board")?,
             "--baud" | "-b" => baud_rate = parse_number(next_value(args, "--baud")?, "--baud")?,
             "--timeout-ms" => {
@@ -548,6 +593,7 @@ where
 
     Ok(SessionOptions {
         port,
+        endpoint,
         board,
         baud_rate,
         timeout_ms,
@@ -860,8 +906,7 @@ pub fn format_device_list(devices: &[LanguageHostDevice]) -> String {
 }
 
 pub fn run_smoke(options: &SmokeOptions) -> Result<SmokeReport, CliError> {
-    let port = resolve_session_port(options.port.as_deref(), &options.board)?;
-    let transport = BoardSerialTransport::<_, 1024>::open(&options.serial_config(&port))?;
+    let transport = open_smoke_transport(options)?;
     let mut client: BoardVmClient<_, 512, 768, 768> = BoardVmClient::new(transport);
     let hello = client
         .hello_with_name(DEFAULT_HOST_NAME, options.host_nonce)
@@ -1094,8 +1139,7 @@ where
     R: BufRead,
     W: Write,
 {
-    let port = resolve_session_port(options.port.as_deref(), &options.board)?;
-    let transport = BoardSerialTransport::<_, 1024>::open(&options.serial_config(&port))?;
+    let (connection_label, transport) = open_repl_transport(options)?;
     let mut client: BoardVmClient<_, 512, 768, 768> = BoardVmClient::new(transport);
     let mut state = ReplState {
         program_id: options.program_id,
@@ -1105,14 +1149,55 @@ where
 
     writeln!(
         output,
-        "connected port={} baud={} timeout_ms={}",
-        port, options.baud_rate, options.timeout_ms
+        "connected {} timeout_ms={}",
+        connection_label, options.timeout_ms
     )?;
     let hello = client.hello_with_name(DEFAULT_HOST_NAME, state.host_nonce)?;
     write_hello(&mut output, &hello)?;
     write_repl_help(&mut output)?;
 
     run_repl_loop(&mut client, &mut state, input, output)
+}
+
+fn open_smoke_transport(options: &SmokeOptions) -> Result<SessionTransport, CliError> {
+    if let Some(endpoint) = options.endpoint.as_deref() {
+        ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
+        return Ok(SessionTransport::Tcp(
+            BoardTcpTransport::<_, 1024>::connect(&options.tcp_config(endpoint))?,
+        ));
+    }
+
+    let port = resolve_session_port(options.port.as_deref(), &options.board)?;
+    Ok(SessionTransport::Serial(
+        BoardSerialTransport::<_, 1024>::open(&options.serial_config(&port))?,
+    ))
+}
+
+fn open_repl_transport(options: &ReplOptions) -> Result<(String, SessionTransport), CliError> {
+    if let Some(endpoint) = options.endpoint.as_deref() {
+        ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
+        let transport = BoardTcpTransport::<_, 1024>::connect(&options.tcp_config(endpoint))?;
+        return Ok((
+            format!("endpoint={endpoint}"),
+            SessionTransport::Tcp(transport),
+        ));
+    }
+
+    let port = resolve_session_port(options.port.as_deref(), &options.board)?;
+    let transport = BoardSerialTransport::<_, 1024>::open(&options.serial_config(&port))?;
+    Ok((
+        format!("port={} baud={}", port, options.baud_rate),
+        SessionTransport::Serial(transport),
+    ))
+}
+
+fn ensure_endpoint_not_mixed_with_port(port: Option<&str>) -> Result<(), CliError> {
+    if port.is_some() {
+        return Err(CliError::UnexpectedArgument(
+            "--endpoint cannot be combined with --port".to_owned(),
+        ));
+    }
+    Ok(())
 }
 
 fn run_repl_loop<T, R, W>(
@@ -1413,7 +1498,7 @@ pub fn format_onboard_led(led: Option<OnboardLed>) -> String {
 }
 
 pub fn usage() -> &'static str {
-    "usage:\n  board-vm list-ports\n  board-vm list-targets\n  board-vm esp-detect --port <path> [--baud <rate>] [--timeout-ms <ms>] [--no-reset]\n  board-vm esp-upload --port <path> --image <path> [--offset <addr>] [--block-size <bytes>] [--flash-size <bytes>] [--baud <rate>] [--timeout-ms <ms>] [--no-reset] [--no-verify] [--stay-in-bootloader]\n  board-vm pico-uf2 --image <path.uf2> [--mount <RPI-RP2 mount>]\n  board-vm pico-uf2 --list\n  board-vm smoke [--port <path>] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm repl [--port <path>] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm eject blink --out <path> [--program-id <id>] [--slot <slot>] [--boot-policy store-only|run-at-boot|run-if-no-host|<u8>]"
+    "usage:\n  board-vm list-ports\n  board-vm list-targets\n  board-vm esp-detect --port <path> [--baud <rate>] [--timeout-ms <ms>] [--no-reset]\n  board-vm esp-upload --port <path> --image <path> [--offset <addr>] [--block-size <bytes>] [--flash-size <bytes>] [--baud <rate>] [--timeout-ms <ms>] [--no-reset] [--no-verify] [--stay-in-bootloader]\n  board-vm pico-uf2 --image <path.uf2> [--mount <RPI-RP2 mount>]\n  board-vm pico-uf2 --list\n  board-vm smoke [--port <path>|--endpoint tcp://host:port] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm repl [--port <path>|--endpoint tcp://host:port] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm eject blink --out <path> [--program-id <id>] [--slot <slot>] [--boot-policy store-only|run-at-boot|run-if-no-host|<u8>]"
 }
 
 #[cfg(test)]
@@ -1703,6 +1788,7 @@ mod tests {
             command,
             CliCommand::Smoke(SmokeOptions {
                 port: Some("/dev/cu.usbmodem-test".to_owned()),
+                endpoint: None,
                 board: "auto".to_owned(),
                 baud_rate: DEFAULT_BAUD_RATE,
                 timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -1738,6 +1824,7 @@ mod tests {
             command,
             CliCommand::Smoke(SmokeOptions {
                 port: Some("COM9".to_owned()),
+                endpoint: None,
                 board: "pico".to_owned(),
                 baud_rate: 57_600,
                 timeout_ms: 250,
@@ -1756,6 +1843,7 @@ mod tests {
             command,
             CliCommand::Repl(ReplOptions {
                 port: Some("/dev/cu.usbmodem-test".to_owned()),
+                endpoint: None,
                 board: "auto".to_owned(),
                 baud_rate: DEFAULT_BAUD_RATE,
                 timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -1789,12 +1877,58 @@ mod tests {
             command,
             CliCommand::Repl(ReplOptions {
                 port: Some("COM9".to_owned()),
+                endpoint: None,
                 board: "auto".to_owned(),
                 baud_rate: 57_600,
                 timeout_ms: 250,
                 program_id: 7,
                 instruction_budget: 200,
                 host_nonce: 1234,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_smoke_tcp_endpoint() {
+        let command = parse_args([
+            "smoke",
+            "--endpoint",
+            "tcp://board-vm.local:4170",
+            "--timeout-ms",
+            "250",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            command,
+            CliCommand::Smoke(SmokeOptions {
+                port: None,
+                endpoint: Some("tcp://board-vm.local:4170".to_owned()),
+                board: "auto".to_owned(),
+                baud_rate: DEFAULT_BAUD_RATE,
+                timeout_ms: 250,
+                program_id: DEFAULT_PROGRAM_ID,
+                instruction_budget: DEFAULT_INSTRUCTION_BUDGET,
+                host_nonce: DEFAULT_HOST_NONCE,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_repl_tcp_endpoint_alias() {
+        let command = parse_args(["repl", "--tcp-endpoint", "127.0.0.1:4170"]).unwrap();
+
+        assert_eq!(
+            command,
+            CliCommand::Repl(ReplOptions {
+                port: None,
+                endpoint: Some("127.0.0.1:4170".to_owned()),
+                board: "auto".to_owned(),
+                baud_rate: DEFAULT_BAUD_RATE,
+                timeout_ms: DEFAULT_TIMEOUT_MS,
+                program_id: DEFAULT_PROGRAM_ID,
+                instruction_budget: DEFAULT_INSTRUCTION_BUDGET,
+                host_nonce: DEFAULT_HOST_NONCE,
             })
         );
     }
@@ -1909,6 +2043,7 @@ mod tests {
     fn repl_serial_config_asserts_dtr_and_clears_stale_bytes() {
         let options = ReplOptions {
             port: Some("/dev/cu.usbmodem-test".to_owned()),
+            endpoint: None,
             board: "auto".to_owned(),
             baud_rate: 57_600,
             timeout_ms: 250,
@@ -2001,6 +2136,7 @@ mod tests {
     fn smoke_serial_config_asserts_dtr_and_clears_stale_bytes() {
         let options = SmokeOptions {
             port: Some("/dev/cu.usbmodem-test".to_owned()),
+            endpoint: None,
             board: "auto".to_owned(),
             baud_rate: 57_600,
             timeout_ms: 250,
@@ -2028,6 +2164,7 @@ mod tests {
             parse_args(["smoke"]).unwrap(),
             CliCommand::Smoke(SmokeOptions {
                 port: None,
+                endpoint: None,
                 board: "auto".to_owned(),
                 baud_rate: DEFAULT_BAUD_RATE,
                 timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -2040,6 +2177,7 @@ mod tests {
             parse_args(["repl", "--board", "esp32"]).unwrap(),
             CliCommand::Repl(ReplOptions {
                 port: None,
+                endpoint: None,
                 board: "esp32".to_owned(),
                 baud_rate: DEFAULT_BAUD_RATE,
                 timeout_ms: DEFAULT_TIMEOUT_MS,

--- a/code/packages/rust/board-vm-tcp/BUILD
+++ b/code/packages/rust/board-vm-tcp/BUILD
@@ -1,0 +1,1 @@
+cargo test -p board-vm-tcp -- --nocapture

--- a/code/packages/rust/board-vm-tcp/Cargo.toml
+++ b/code/packages/rust/board-vm-tcp/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "board-vm-tcp"
+version = "0.1.0"
+edition = "2021"
+description = "TCP socket transport for Board VM host clients"
+
+[dependencies]
+board-vm-client = { path = "../board-vm-client" }
+board-vm-stream = { path = "../board-vm-stream" }
+
+[dev-dependencies]
+board-vm-loopback = { path = "../board-vm-loopback" }
+
+[lib]
+path = "src/lib.rs"

--- a/code/packages/rust/board-vm-tcp/README.md
+++ b/code/packages/rust/board-vm-tcp/README.md
@@ -1,0 +1,5 @@
+# Board VM TCP Transport
+
+`board-vm-tcp` connects host clients to Board VM firmware over a TCP byte
+stream. It reuses the shared COBS/CRC stream adapter, so Wi-Fi transports carry
+the same Rust-owned binary protocol frames as USB/serial.

--- a/code/packages/rust/board-vm-tcp/src/lib.rs
+++ b/code/packages/rust/board-vm-tcp/src/lib.rs
@@ -1,0 +1,211 @@
+use std::io::{self, Read, Write};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+use board_vm_client::{RawFrameTransport, TransportError};
+use board_vm_stream::{StreamTransport, StreamTransportError};
+
+pub const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 1_000;
+pub const DEFAULT_IO_TIMEOUT_MS: u64 = 1_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TcpConfig {
+    pub endpoint: String,
+    pub connect_timeout: Duration,
+    pub io_timeout: Duration,
+    pub nodelay: bool,
+}
+
+impl TcpConfig {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            connect_timeout: Duration::from_millis(DEFAULT_CONNECT_TIMEOUT_MS),
+            io_timeout: Duration::from_millis(DEFAULT_IO_TIMEOUT_MS),
+            nodelay: true,
+        }
+    }
+
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    pub fn io_timeout(mut self, timeout: Duration) -> Self {
+        self.io_timeout = timeout;
+        self
+    }
+
+    pub fn nodelay(mut self, nodelay: bool) -> Self {
+        self.nodelay = nodelay;
+        self
+    }
+
+    pub fn authority(&self) -> &str {
+        tcp_endpoint_authority(&self.endpoint)
+    }
+}
+
+#[derive(Debug)]
+pub enum TcpTransportError {
+    Resolve(io::Error),
+    NoResolvedAddress,
+    Connect(io::Error),
+    Configure(io::Error),
+    Stream(StreamTransportError),
+}
+
+impl From<StreamTransportError> for TcpTransportError {
+    fn from(value: StreamTransportError) -> Self {
+        Self::Stream(value)
+    }
+}
+
+pub struct BoardTcpTransport<S, const WIRE_BYTES: usize = 1024> {
+    inner: StreamTransport<S, WIRE_BYTES>,
+}
+
+impl<S, const WIRE_BYTES: usize> BoardTcpTransport<S, WIRE_BYTES> {
+    pub fn from_stream(stream: S) -> Self {
+        Self {
+            inner: StreamTransport::new(stream),
+        }
+    }
+
+    pub fn into_inner(self) -> StreamTransport<S, WIRE_BYTES> {
+        self.inner
+    }
+
+    pub fn stream_transport(&self) -> &StreamTransport<S, WIRE_BYTES> {
+        &self.inner
+    }
+
+    pub fn stream_transport_mut(&mut self) -> &mut StreamTransport<S, WIRE_BYTES> {
+        &mut self.inner
+    }
+
+    pub fn send_raw_frame(&mut self, raw_frame: &[u8]) -> Result<usize, TcpTransportError>
+    where
+        S: Write,
+    {
+        Ok(self.inner.send_raw_frame(raw_frame)?)
+    }
+
+    pub fn receive_raw_frame(&mut self, raw_out: &mut [u8]) -> Result<usize, TcpTransportError>
+    where
+        S: Read,
+    {
+        Ok(self.inner.receive_raw_frame(raw_out)?)
+    }
+
+    pub fn exchange_raw_frame_checked(
+        &mut self,
+        raw_request: &[u8],
+        raw_response_out: &mut [u8],
+    ) -> Result<usize, TcpTransportError>
+    where
+        S: Read + Write,
+    {
+        Ok(self
+            .inner
+            .exchange_raw_frame_checked(raw_request, raw_response_out)?)
+    }
+}
+
+impl<const WIRE_BYTES: usize> BoardTcpTransport<TcpStream, WIRE_BYTES> {
+    pub fn connect(config: &TcpConfig) -> Result<Self, TcpTransportError> {
+        let address = resolve_first_socket_addr(config.authority())?;
+        let stream = TcpStream::connect_timeout(&address, config.connect_timeout)
+            .map_err(TcpTransportError::Connect)?;
+        stream
+            .set_read_timeout(Some(config.io_timeout))
+            .map_err(TcpTransportError::Configure)?;
+        stream
+            .set_write_timeout(Some(config.io_timeout))
+            .map_err(TcpTransportError::Configure)?;
+        stream
+            .set_nodelay(config.nodelay)
+            .map_err(TcpTransportError::Configure)?;
+        Ok(Self::from_stream(stream))
+    }
+}
+
+impl<S, const WIRE_BYTES: usize> RawFrameTransport for BoardTcpTransport<S, WIRE_BYTES>
+where
+    S: Read + Write,
+{
+    fn exchange_raw_frame(
+        &mut self,
+        request: &[u8],
+        response_out: &mut [u8],
+    ) -> Result<usize, TransportError> {
+        self.inner.exchange_raw_frame(request, response_out)
+    }
+}
+
+pub fn tcp_endpoint_authority(endpoint: &str) -> &str {
+    endpoint.strip_prefix("tcp://").unwrap_or(endpoint)
+}
+
+fn resolve_first_socket_addr(endpoint: &str) -> Result<SocketAddr, TcpTransportError> {
+    let mut addresses = endpoint
+        .to_socket_addrs()
+        .map_err(TcpTransportError::Resolve)?;
+    addresses.next().ok_or(TcpTransportError::NoResolvedAddress)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::thread;
+
+    use board_vm_client::BoardVmClient;
+    use board_vm_loopback::LoopbackBoard;
+
+    #[test]
+    fn strips_tcp_scheme_from_endpoint_authority() {
+        assert_eq!(
+            tcp_endpoint_authority("tcp://board-vm.local:4170"),
+            "board-vm.local:4170"
+        );
+        assert_eq!(tcp_endpoint_authority("127.0.0.1:4170"), "127.0.0.1:4170");
+    }
+
+    #[test]
+    fn tcp_transport_exchanges_board_vm_frames() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut transport = StreamTransport::<_, 1024>::new(stream);
+            let mut board = LoopbackBoard::<256, 8, 8>::new();
+            let mut request_raw = [0u8; 768];
+            let mut response_payload = [0u8; 512];
+            let mut response_raw = [0u8; 768];
+
+            let request_len = transport.receive_raw_frame(&mut request_raw).unwrap();
+            let response_len = board
+                .handle_raw_frame(
+                    &request_raw[..request_len],
+                    &mut response_payload,
+                    &mut response_raw,
+                )
+                .unwrap();
+            transport
+                .send_raw_frame(&response_raw[..response_len])
+                .unwrap();
+        });
+
+        let config = TcpConfig::new(format!("tcp://{address}"))
+            .connect_timeout(Duration::from_millis(500))
+            .io_timeout(Duration::from_millis(500));
+        let transport = BoardTcpTransport::<_, 1024>::connect(&config).unwrap();
+        let mut client: BoardVmClient<_, 512, 768, 768> = BoardVmClient::new(transport);
+
+        let hello = client.hello_with_name("tcp-test", 0xCAFE_BABE).unwrap();
+
+        assert_eq!(hello.host_nonce, 0xCAFE_BABE);
+        server.join().unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- add a `board-vm-tcp` Rust crate that carries existing Board VM COBS/CRC wire frames over TCP streams
- teach `board-vm smoke` and `board-vm repl` to open `--endpoint tcp://host:port` while preserving serial auto-discovery by default
- cover endpoint parsing and a loopback TCP Board VM frame exchange in tests

## Validation
- `cargo test -p board-vm-tcp -p board-vm-cli`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check`
- `git diff --cached --check`