### PR TITLE
[codex] Extend HTML tree smoke fixture to case 79

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1178,3 +1178,26 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <a>
 |       href="foo"
 |       "aoe"
+
+#data
+<a href="blah">aba<table><tr><td><a href="foo">br</td></tr>x</table>aoe
+#errors
+(1,15): expected-doctype-but-got-start-tag
+(1,54): unexpected-cell-end-tag
+(1,68): unexpected text in table
+(1,71): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       href="blah"
+|       "abax"
+|       <table>
+|         <tbody>
+|           <tr>
+|             <td>
+|               <a>
+|                 href="foo"
+|                 "br"
+|       "aoe"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 79
- cover the nested table anchor case that now passes with existing foster-parenting behavior

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer