### PR TITLE
[codex] Keep outer anchors across marquee boundaries

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1465,6 +1465,9 @@ impl HtmlParser {
         if self.has_table_context_above(index) {
             return false;
         }
+        if self.has_special_element_above(index) {
+            return false;
+        }
         self.capture_formatting_above(index);
         self.open_elements.truncate(index);
         true
@@ -3308,6 +3311,30 @@ mod tests {
         assert_eq!(trailing_anchor.name, "a");
         assert_eq!(trailing_anchor.attribute("href"), Some("blah"));
         assert_eq!(trailing_anchor.children, vec![Node::text("aoe")]);
+    }
+
+    #[test]
+    fn preserves_outer_anchor_across_marquee_when_nested_anchor_starts() {
+        let document = parse_html("<a href=a>aa<marquee>aa<a href=b>bb</marquee>aa").unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 1);
+
+        let outer_anchor = element(&body.children[0]);
+        assert_eq!(outer_anchor.name, "a");
+        assert_eq!(outer_anchor.attribute("href"), Some("a"));
+        assert_eq!(outer_anchor.children[0], Node::text("aa"));
+
+        let marquee = element(&outer_anchor.children[1]);
+        assert_eq!(marquee.name, "marquee");
+        assert_eq!(marquee.children[0], Node::text("aa"));
+
+        let inner_anchor = element(&marquee.children[1]);
+        assert_eq!(inner_anchor.name, "a");
+        assert_eq!(inner_anchor.attribute("href"), Some("b"));
+        assert_eq!(inner_anchor.children, vec![Node::text("bb")]);
+
+        assert_eq!(outer_anchor.children[2], Node::text("aa"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1233,3 +1233,23 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <a>
 |       href="blah"
 |       "aoe"
+
+#data
+<a href=a>aa<marquee>aa<a href=b>bb</marquee>aa
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(1,45): end-tag-too-early
+(1,47): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       href="a"
+|       "aa"
+|       <marquee>
+|         "aa"
+|         <a>
+|           href="b"
+|           "bb"
+|       "aa"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 81
- keep repeated-anchor recovery from crossing special marquee boundaries
- preserve nested anchors inside marquee while trailing text returns to the outer anchor

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer