### PR TITLE
[codex] Reconstruct code formatting before code starts

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -2170,7 +2170,7 @@ fn starts_inner_formatting_reconstruction_boundary(name: &str) -> bool {
 }
 
 fn starts_before_formatting_reconstruction_boundary(name: &str) -> bool {
-    matches!(name, "a" | "b" | "marquee" | "option")
+    matches!(name, "a" | "b" | "code" | "marquee" | "option")
 }
 
 fn is_special_element(name: &str) -> bool {
@@ -3335,6 +3335,25 @@ mod tests {
         assert_eq!(inner_anchor.children, vec![Node::text("bb")]);
 
         assert_eq!(outer_anchor.children[2], Node::text("aa"));
+    }
+
+    #[test]
+    fn reconstructs_code_formatting_before_code_start_tag() {
+        let document = parse_html("<wbr><strike><code></strike><code><strike></code>").unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 3);
+        assert_eq!(element(&body.children[0]).name, "wbr");
+
+        let first_strike = element(&body.children[1]);
+        assert_eq!(first_strike.name, "strike");
+        assert_eq!(element(&first_strike.children[0]).name, "code");
+
+        let reconstructed_code = element(&body.children[2]);
+        assert_eq!(reconstructed_code.name, "code");
+        let nested_code = element(&reconstructed_code.children[0]);
+        assert_eq!(nested_code.name, "code");
+        assert_eq!(element(&nested_code.children[0]).name, "strike");
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1253,3 +1253,21 @@ Line1<br>Line2<br>Line3<br>Line4
 |           href="b"
 |           "bb"
 |       "aa"
+
+#data
+<wbr><strike><code></strike><code><strike></code>
+#errors
+(1,5): expected-doctype-but-got-start-tag
+(1,28): adoption-agency-1.3
+(1,49): adoption-agency-1.3
+(1,49): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <wbr>
+|     <strike>
+|       <code>
+|     <code>
+|       <code>
+|         <strike>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 82
- reconstruct pending code formatting before a following code start tag
- cover the strike/code adoption-agency fixture shape

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer