### PR TITLE
[codex] Extend HTML tree smoke fixture to case 83

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1271,3 +1271,15 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <code>
 |       <code>
 |         <strike>
+
+#data
+<!DOCTYPE html><spacer>foo
+#errors
+(1,26): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <spacer>
+|       "foo"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 83
- cover the doctype plus legacy spacer element fixture that already matches the expected DOM

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer