### PR TITLE
[codex] Extend HTML tree smoke fixture to case 84

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1283,3 +1283,17 @@ Line1<br>Line2<br>Line3<br>Line4
 |   <body>
 |     <spacer>
 |       "foo"
+
+#data
+<title><meta></title><link><title><meta></title>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|     <title>
+|       "<meta>"
+|     <link>
+|     <title>
+|       "<meta>"
+|   <body>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 84
- cover repeated title/head tokenization handoff around meta and link content

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer