### PR TITLE
[codex] Extend HTML tree smoke fixture to case 85

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1297,3 +1297,17 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <title>
 |       "<meta>"
 |   <body>
+
+#data
+<style><!--</style><meta><script>--><link></script>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|     <style>
+|       "<!--"
+|     <meta>
+|     <script>
+|       "--><link>"
+|   <body>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 85
- cover head style/script tokenization handoff around meta and link markup

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer