### PR TITLE
[codex] Extend HTML tree smoke fixture to case 86

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1311,3 +1311,15 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <script>
 |       "--><link>"
 |   <body>
+
+#data
+<head><meta></head><link>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,25): unexpected-start-tag-out-of-my-head
+#document
+| <html>
+|   <head>
+|     <meta>
+|     <link>
+|   <body>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 86
- cover explicit head close recovery where a following link is still inserted into head

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer