### PR TITLE
[codex] Extend HTML tree smoke fixture to case 87

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1323,3 +1323,24 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <meta>
 |     <link>
 |   <body>
+
+#data
+<table><tr><tr><td><td><span><th><span>X</table>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,33): unexpected-cell-end-tag
+(1,48): unexpected-cell-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|         <tr>
+|           <td>
+|           <td>
+|             <span>
+|           <th>
+|             <span>
+|               "X"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 87
- cover repeated table row/cell recovery around tr, td, th, and span content

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer