### PR TITLE
[codex] Extend HTML tree smoke fixture to case 88

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1344,3 +1344,20 @@ Line1<br>Line2<br>Line3<br>Line4
 |           <th>
 |             <span>
 |               "X"
+
+#data
+<body><body><base><link><meta><title><p></title><body><p></body>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,12): unexpected-start-tag
+(1,54): unexpected-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <base>
+|     <link>
+|     <meta>
+|     <title>
+|       "<p>"
+|     <p>


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 88
- cover body-start recovery around late head elements and title raw-text content

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer