### PR TITLE
[codex] Extend HTML tree smoke fixture to case 89

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1361,3 +1361,14 @@ Line1<br>Line2<br>Line3<br>Line4
 |     <title>
 |       "<p>"
 |     <p>
+
+#data
+<textarea><p></textarea>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+|       "<p>"


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture through tests1.dat case 89
- cover top-level textarea RCDATA handoff so embedded start-tag text remains literal

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer