### PR TITLE
Add language TCP endpoint transports

### DIFF
--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -100,6 +100,94 @@ local function connection_uses_serial_port(connection_option)
     return connection_option == nil or connection_option.transport == "serial"
 end
 
+local function connection_uses_tcp_endpoint(connection_option)
+    return connection_option ~= nil and (
+        connection_option.endpoint_transport == "tcp_socket" or
+        connection_option.endpoint_scheme == "tcp"
+    )
+end
+
+local function parse_tcp_endpoint(endpoint)
+    local authority = tostring(endpoint or ""):gsub("^tcp://", "")
+    local host, port = authority:match("^%[([^%]]+)%]:(%d+)$")
+    if host == nil then
+        host, port = authority:match("^([^:]+):(%d+)$")
+    end
+    if host == nil or port == nil then
+        error("Board VM TCP endpoint must look like tcp://host:port")
+    end
+    return host, tonumber(port)
+end
+
+local TcpTransport = {}
+TcpTransport.__index = TcpTransport
+
+function TcpTransport.new(options)
+    options = options or {}
+    local endpoint = options.endpoint
+    local host, port = parse_tcp_endpoint(endpoint)
+    return setmetatable({
+        endpoint = tostring(endpoint),
+        host = host,
+        port = port,
+        timeout_ms = options.timeout_ms or 1000,
+        socket = nil,
+    }, TcpTransport)
+end
+
+function TcpTransport:_socket_module()
+    local ok, socket = pcall(require, "socket")
+    if not ok then
+        error("Board VM Lua TCP transport requires LuaSocket or an injected transport endpoint")
+    end
+    return socket
+end
+
+function TcpTransport:_io()
+    if self.socket then
+        return self.socket
+    end
+    local socket = self:_socket_module()
+    local client = assert(socket.tcp())
+    client:settimeout(self.timeout_ms / 1000)
+    assert(client:connect(self.host, self.port))
+    if client.setoption then
+        pcall(function()
+            client:setoption("tcp-nodelay", true)
+        end)
+    end
+    self.socket = client
+    return self.socket
+end
+
+function TcpTransport:write(frame)
+    assert(self:_io():send(frame))
+end
+
+function TcpTransport:transact(frame, options)
+    options = options or {}
+    self:write(frame)
+    local client = self:_io()
+    client:settimeout((options.timeout_ms or self.timeout_ms) / 1000)
+    local chunks = {}
+    while true do
+        local byte = assert(client:receive(1))
+        table.insert(chunks, byte)
+        if byte:byte(1) == 0 then
+            return table.concat(chunks)
+        end
+    end
+end
+
+function TcpTransport:close()
+    if self.socket then
+        self.socket:close()
+        self.socket = nil
+    end
+end
+
+M.TcpTransport = TcpTransport
+
 local function clone_table(value)
     if type(value) ~= "table" then
         return value
@@ -419,6 +507,7 @@ function Connection.new(options)
         device = options.device,
         connection_option = options.connection_option,
         transport = options.transport,
+        endpoint = options.endpoint,
         timeout_ms = options.timeout_ms or 1000,
     }, Connection)
 end
@@ -449,13 +538,31 @@ end
 
 function Connection:session(options)
     options = options or {}
-    options.transport = options.transport or self.transport
+    options.transport = options.transport or self:active_transport()
     options.timeout_ms = options.timeout_ms or self.timeout_ms
     return Session.new(options)
 end
 
 function Connection:smoke(options)
     return self:session():smoke(options)
+end
+
+function Connection:active_transport()
+    if self.transport then
+        return self.transport
+    end
+    if connection_uses_tcp_endpoint(self.connection_option) then
+        if self.endpoint == nil or tostring(self.endpoint) == "" then
+            error((self.connection_option.display_name or "Board VM TCP connection") ..
+                " requires a Board VM TCP endpoint; pass endpoint = \"tcp://host:port\" or choose via = \"serial\"")
+        end
+        self.transport = TcpTransport.new({
+            endpoint = self.endpoint,
+            timeout_ms = self.timeout_ms,
+        })
+        return self.transport
+    end
+    return nil
 end
 
 M.Connection = Connection
@@ -520,6 +627,7 @@ function M.connect(selector, options)
         device = device,
         connection_option = connection_option,
         transport = options.transport,
+        endpoint = options.endpoint,
         timeout_ms = options.timeout_ms,
     })
 end

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -126,6 +126,21 @@ describe("coding_adventures.board_vm_native", function()
         assert.are.equal(0, transport.frames[1]:byte(#transport.frames[1]))
     end)
 
+    it("builds TCP transports for Wi-Fi endpoints", function()
+        local connection = board_vm.connect("uno-r4-wifi", {
+            via = "Wi-Fi",
+            endpoint = "tcp://board-vm.local:4170",
+        })
+        local session = connection:session()
+
+        assert.is_nil(connection.port)
+        assert.are.equal("wifi", connection:connection_transport())
+        assert.are.equal("tcp://board-vm.local:4170", connection.endpoint)
+        assert.are.equal("tcp://board-vm.local:4170", session.transport.endpoint)
+        assert.are.equal("board-vm.local", session.transport.host)
+        assert.are.equal(4170, session.transport.port)
+    end)
+
     it("rejects dispatch when no Lua transport endpoint is available", function()
         local connection = board_vm.connect("uno-r4-wifi", { via = "Wi-Fi" })
 
@@ -134,7 +149,7 @@ describe("coding_adventures.board_vm_native", function()
         end)
 
         assert.is_false(ok)
-        assert.is_true(tostring(err):find("requires a transport endpoint") ~= nil)
+        assert.is_true(tostring(err):find("requires a Board VM TCP endpoint") ~= nil)
     end)
 
     it("builds blink upload/run frames through Rust-owned protocol builders", function()

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import pathlib
+import socket
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from typing import Any, Iterable
+from urllib.parse import urlparse
 
 from . import board_vm_native as _native
 
@@ -17,6 +19,7 @@ DEFAULT_HOST_NAME = "python-board-vm"
 DEFAULT_HOST_NONCE = 0xB0A2D001
 DEFAULT_PROGRAM_ID = 1
 DEFAULT_INSTRUCTION_BUDGET = 12
+DEFAULT_TIMEOUT_MS = 1_000
 DEFAULT_PICO_RUNTIME_PORT_WAIT_MS = 5_000
 DEFAULT_PICO_RUNTIME_PORT_POLL_MS = 250
 BOOT_POLICIES = {
@@ -411,6 +414,61 @@ class SessionResult:
             if descriptor is not None:
                 return descriptor
         return None
+
+
+class TcpTransport:
+    FRAME_DELIMITER = b"\x00"
+
+    def __init__(self, endpoint: str, *, timeout_ms: int = DEFAULT_TIMEOUT_MS):
+        self.endpoint = str(endpoint)
+        self.timeout_ms = int(timeout_ms)
+        self.host, self.port = _parse_tcp_endpoint(self.endpoint)
+        self._socket: socket.socket | None = None
+
+    def transact(self, frame: bytes, timeout_ms: int | None = None) -> bytes:
+        self.write(frame)
+        return self._read_frame(timeout_ms=self.timeout_ms if timeout_ms is None else int(timeout_ms))
+
+    def write(self, frame: bytes) -> None:
+        try:
+            self._io().sendall(bytes(frame))
+        except OSError as error:
+            raise OSError(f"failed to write Board VM frame to {self.endpoint}: {error}") from error
+
+    def close(self) -> None:
+        if self._socket is not None:
+            self._socket.close()
+            self._socket = None
+
+    def _io(self) -> socket.socket:
+        if self._socket is None:
+            try:
+                self._socket = socket.create_connection(
+                    (self.host, self.port),
+                    timeout=self.timeout_ms / 1000.0,
+                )
+                self._socket.settimeout(self.timeout_ms / 1000.0)
+                self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            except OSError as error:
+                raise OSError(f"failed to open Board VM TCP endpoint {self.endpoint}: {error}") from error
+        return self._socket
+
+    def _read_frame(self, *, timeout_ms: int) -> bytes:
+        stream = self._io()
+        stream.settimeout(timeout_ms / 1000.0)
+        response = bytearray()
+        try:
+            while True:
+                byte = stream.recv(1)
+                if not byte:
+                    raise OSError(f"Board VM TCP endpoint {self.endpoint} closed")
+                response.extend(byte)
+                if byte == self.FRAME_DELIMITER:
+                    return bytes(response)
+        except socket.timeout as error:
+            raise TimeoutError(f"timed out waiting for Board VM response on {self.endpoint}") from error
+        except OSError as error:
+            raise OSError(f"failed to read Board VM response from {self.endpoint}: {error}") from error
 
 
 class Session:
@@ -1222,6 +1280,7 @@ class Connection:
         target: BoardTarget,
         port: str | None,
         transport: Any = None,
+        endpoint: str | None = None,
         connection_option: dict[str, Any] | None = None,
         runner: Any = None,
         cargo_workspace: str | pathlib.Path | None = None,
@@ -1238,6 +1297,7 @@ class Connection:
         self.target = target
         self.port = None if port is None else str(port)
         self.transport = transport
+        self.endpoint = None if endpoint is None else str(endpoint)
         self.connection_option = dict(connection_option or select_connection_option(target.board_id))
         self.runner = _default_runner if runner is None else runner
         self.cargo_workspace = pathlib.Path(cargo_workspace or DEFAULT_RUST_WORKSPACE)
@@ -1277,7 +1337,7 @@ class Connection:
         return bool(self.connection_option.get("ota_update"))
 
     def session(self, **options: Any) -> Session:
-        options.setdefault("transport", self.transport)
+        options.setdefault("transport", self._active_transport())
         return Session(**options)
 
     def smoke(
@@ -1323,6 +1383,26 @@ class Connection:
                 self.rediscover_runtime_port()
             return result
         raise ValueError(f"Python flash sugar does not support {self.board_id!r}")
+
+    def _active_transport(self) -> Any:
+        if self.transport is not None:
+            return self.transport
+        if self._tcp_endpoint_connection():
+            if self.endpoint is None or not self.endpoint:
+                display_name = self.connection_option.get("display_name", self.connection_transport)
+                raise ValueError(
+                    f"{display_name} requires a Board VM TCP endpoint; "
+                    "pass endpoint='tcp://host:port' or choose via='serial'"
+                )
+            self.transport = TcpTransport(self.endpoint, timeout_ms=DEFAULT_TIMEOUT_MS)
+            return self.transport
+        return None
+
+    def _tcp_endpoint_connection(self) -> bool:
+        return (
+            self.connection_option.get("endpoint_transport") == "tcp_socket"
+            or self.connection_option.get("endpoint_scheme") == "tcp"
+        )
 
     def rediscover_runtime_port(self) -> BoardDevice:
         deadline = time.monotonic() + (self.pico_runtime_port_wait_ms / 1000)
@@ -1769,6 +1849,7 @@ def connect(
     flash: bool = False,
     smoke: bool = False,
     transport: Any = None,
+    endpoint: str | None = None,
     runner: Any = None,
     cargo_workspace: str | pathlib.Path | None = None,
     firmware_image: str | pathlib.Path | None = None,
@@ -1833,6 +1914,7 @@ def connect(
         target=target,
         port=selected_port,
         transport=transport,
+        endpoint=endpoint,
         connection_option=selected_connection_option,
         runner=runner,
         cargo_workspace=cargo_workspace,
@@ -1871,6 +1953,13 @@ def _resolve_connection_option(
 
 def _connection_uses_serial_port(connection_option: dict[str, Any] | None) -> bool:
     return connection_option is None or connection_option.get("transport") == "serial"
+
+
+def _parse_tcp_endpoint(endpoint: str) -> tuple[str, int]:
+    parsed = urlparse(endpoint if "://" in endpoint else f"tcp://{endpoint}")
+    if parsed.scheme != "tcp" or parsed.hostname is None or parsed.port is None:
+        raise ValueError("Board VM TCP endpoint must look like tcp://host:port")
+    return parsed.hostname, int(parsed.port)
 
 
 def uno_r4_wifi(**options: Any) -> Connection:
@@ -1974,6 +2063,7 @@ __all__ = [
     "RUN_FLAGS",
     "Session",
     "SessionResult",
+    "TcpTransport",
     "connection_option_list",
     "connect",
     "connection_options",

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -11,6 +11,7 @@ from board_vm_native import (
     PicoUf2UploadOptions,
     ProtocolResult,
     Session,
+    TcpTransport,
     connect,
     connection_option_list,
     connection_options,
@@ -241,6 +242,36 @@ def test_connect_can_use_a_wireless_connection_option_with_an_injected_endpoint(
     assert connection.wireless_connection is True
     assert connection.ota_connection is True
     assert len(transport.frames) == 2
+
+
+def test_connect_builds_a_tcp_transport_for_wifi_endpoints():
+    connection = connect(
+        "uno-r4-wifi",
+        via="Wi-Fi",
+        endpoint="tcp://board-vm.local:4170",
+    )
+
+    assert connection.port is None
+    assert connection.endpoint == "tcp://board-vm.local:4170"
+    assert connection.connection_transport == "wifi"
+    transport = connection._active_transport()
+    assert isinstance(transport, TcpTransport)
+    assert transport.endpoint == "tcp://board-vm.local:4170"
+    assert transport.host == "board-vm.local"
+    assert transport.port == 4170
+
+
+def test_wifi_endpoint_dispatch_requires_endpoint_when_not_injected():
+    connection = connect("uno-r4-wifi", via="Wi-Fi")
+
+    try:
+        connection.smoke()
+    except ValueError as error:
+        message = str(error)
+    else:
+        raise AssertionError("expected missing TCP endpoint to fail")
+
+    assert "requires a Board VM TCP endpoint" in message
 
 
 def test_connect_can_prompt_for_the_connection_option_after_the_board():

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -312,6 +312,7 @@ module CodingAdventures
       cargo_workspace: DEFAULT_RUST_WORKSPACE,
       runner: CommandRunner.new,
       transport: nil,
+      endpoint: nil,
       via: nil,
       connection_option: nil,
       pick_connection: false,
@@ -337,6 +338,7 @@ module CodingAdventures
         runner: runner,
         transport: transport,
         connection_option: selection.fetch(:connection_option),
+        endpoint: endpoint,
         baud_rate: options.delete(:baud_rate) || options.delete(:baud) || DEFAULT_BAUD_RATE,
         timeout_ms: options.delete(:timeout_ms) || DEFAULT_TIMEOUT_MS,
         **options

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -6,7 +6,7 @@ module CodingAdventures
     class DeviceSelectionError < ArgumentError; end
 
     class Connection
-      attr_reader :board, :cargo_workspace, :runner, :transport, :connection_option, :baud_rate, :timeout_ms
+      attr_reader :board, :cargo_workspace, :runner, :transport, :connection_option, :baud_rate, :timeout_ms, :endpoint
       attr_accessor :port
 
       def initialize(
@@ -16,6 +16,7 @@ module CodingAdventures
         runner:,
         transport:,
         connection_option:,
+        endpoint:,
         baud_rate:,
         timeout_ms:,
         arduino_core: nil,
@@ -50,6 +51,7 @@ module CodingAdventures
         @runner = runner
         @transport = transport
         @connection_option = connection_option
+        @endpoint = endpoint
         @baud_rate = baud_rate
         @timeout_ms = timeout_ms
         @arduino_core = arduino_core
@@ -511,6 +513,15 @@ module CodingAdventures
       def active_transport
         return @transport if @transport
 
+        if tcp_endpoint_connection?
+          unless endpoint && !endpoint.to_s.empty?
+            raise TransportError,
+              "#{connection_display_name} requires a Board VM TCP endpoint; pass endpoint: \"tcp://host:port\" or choose via: :serial"
+          end
+
+          return @transport = TcpTransport.new(endpoint: endpoint, timeout_ms: timeout_ms)
+        end
+
         unless serial_connection?
           raise TransportError,
             "#{connection_display_name} requires an injected Board VM transport endpoint; pass transport: or choose via: :serial"
@@ -520,6 +531,12 @@ module CodingAdventures
         end
 
         @transport = SerialTransport.new(port: port, baud_rate: baud_rate, timeout_ms: timeout_ms)
+      end
+
+      def tcp_endpoint_connection?
+        connection_option &&
+          (connection_option["endpoint_transport"] == "tcp_socket" ||
+            connection_option["endpoint_scheme"] == "tcp")
       end
 
       def connection_display_name

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
@@ -2,6 +2,8 @@
 
 require "io/wait"
 require "rbconfig"
+require "socket"
+require "uri"
 
 module CodingAdventures
   module BoardVM
@@ -130,6 +132,86 @@ module CodingAdventures
         end
       rescue SystemCallError, IOError => e
         raise TransportError, "failed to read Board VM response from #{@port}: #{e.message}"
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+
+    class TcpTransport
+      FRAME_DELIMITER = "\x00".b
+
+      attr_reader :endpoint
+
+      def initialize(endpoint:, timeout_ms:)
+        @endpoint = endpoint.to_s
+        @timeout_ms = timeout_ms
+        @host, @port = parse_endpoint(@endpoint)
+        @io = nil
+      end
+
+      def transact(frame, timeout_ms: @timeout_ms)
+        write(frame)
+        read_frame(timeout_ms: timeout_ms)
+      end
+
+      def write(frame)
+        io.write(frame.b)
+        io.flush
+      rescue SystemCallError, IOError => e
+        raise TransportError, "failed to write Board VM frame to #{@endpoint}: #{e.message}"
+      end
+
+      def close
+        @io&.close
+      ensure
+        @io = nil
+      end
+
+      private
+
+      def io
+        @io ||= begin
+          socket = TCPSocket.new(@host, @port)
+          socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+          socket
+        rescue SystemCallError => e
+          raise TransportError, "failed to open Board VM TCP endpoint #{@endpoint}: #{e.message}"
+        end
+      end
+
+      def parse_endpoint(endpoint)
+        uri = URI.parse(endpoint.include?("://") ? endpoint : "tcp://#{endpoint}")
+        unless uri.scheme == "tcp" && uri.host && uri.port
+          raise TransportError, "Board VM TCP endpoint must look like tcp://host:port"
+        end
+
+        [uri.host, uri.port]
+      rescue URI::InvalidURIError => e
+        raise TransportError, "invalid Board VM TCP endpoint #{endpoint.inspect}: #{e.message}"
+      end
+
+      def read_frame(timeout_ms:)
+        deadline = monotonic_now + (timeout_ms.to_f / 1000.0)
+        response = +"".b
+
+        loop do
+          remaining = deadline - monotonic_now
+          raise TransportError, "timed out waiting for Board VM response on #{@endpoint}" if remaining <= 0
+
+          readable = IO.select([io], nil, nil, remaining)
+          next if readable.nil?
+
+          byte = io.read_nonblock(1, exception: false)
+          next if byte == :wait_readable
+          raise TransportError, "Board VM TCP endpoint #{@endpoint} closed" if byte.nil? || byte.empty?
+
+          response << byte
+          return response if byte == FRAME_DELIMITER
+        end
+      rescue SystemCallError, IOError => e
+        raise TransportError, "failed to read Board VM response from #{@endpoint}: #{e.message}"
       end
 
       def monotonic_now

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -143,6 +143,23 @@ module CodingAdventures
         assert_equal 2, transport.frames.length
       end
 
+      def test_connect_builds_a_tcp_transport_for_wifi_endpoints
+        connection = BoardVM.uno_r4_wifi(
+          via: "Wi-Fi",
+          endpoint: "tcp://board-vm.local:4170",
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new
+        )
+
+        assert_nil connection.port
+        assert_equal "wifi", connection.connection_transport
+        assert_equal "tcp://board-vm.local:4170", connection.endpoint
+
+        transport = connection.send(:active_transport)
+        assert_instance_of TcpTransport, transport
+        assert_equal "tcp://board-vm.local:4170", transport.endpoint
+      end
+
       def test_connect_can_prompt_for_the_connection_option_after_the_board
         output = StringIO.new
 
@@ -170,7 +187,7 @@ module CodingAdventures
         error = assert_raises(TransportError) do
           connection.smoke!
         end
-        assert_match(/requires an injected Board VM transport endpoint/, error.message)
+        assert_match(/requires a Board VM TCP endpoint/, error.message)
       end
 
       def test_targets_are_detected_from_rust_owned_aliases


### PR DESCRIPTION
## Summary
- add TCP endpoint transports for Ruby and Python Board VM sessions using standard host sockets
- let Ruby, Python, and Lua connect flows carry `endpoint` alongside Rust-selected Wi-Fi/TCP connection metadata
- keep dispatch over the existing Rust-owned Board VM protocol frames while producing clear endpoint-required errors when Wi-Fi is selected without an endpoint

## Validation
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check HEAD~1..HEAD`