### PR TITLE
Add language TCP endpoint smoke coverage

### DIFF
--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -141,6 +141,63 @@ describe("coding_adventures.board_vm_native", function()
         assert.are.equal(4170, session.transport.port)
     end)
 
+    it("transacts over LuaSocket-compatible TCP endpoints", function()
+        local sent = {}
+        local response_index = 0
+        local fake_client = {
+            settimeout = function(self, timeout)
+                self.timeout = timeout
+            end,
+            connect = function(self, host, port)
+                self.host = host
+                self.port = port
+                return true
+            end,
+            setoption = function(self, option, value)
+                self[option] = value
+                return true
+            end,
+            send = function(_, frame)
+                table.insert(sent, frame)
+                return #frame
+            end,
+            receive = function(_, size)
+                assert.are.equal(1, size)
+                response_index = response_index + 1
+                return ({ "\3", "\4", "\0" })[response_index]
+            end,
+            close = function(self)
+                self.closed = true
+            end,
+        }
+        local previous_socket = package.loaded.socket
+        package.loaded.socket = {
+            tcp = function()
+                return fake_client
+            end,
+        }
+
+        local ok, err = pcall(function()
+            local transport = board_vm.TcpTransport.new({
+                endpoint = "tcp://board-vm.local:4170",
+                timeout_ms = 500,
+            })
+            local response = transport:transact("\1\2\0", { timeout_ms = 250 })
+
+            assert.are.equal("\3\4\0", response)
+            assert.are.equal("\1\2\0", sent[1])
+            assert.are.equal("board-vm.local", fake_client.host)
+            assert.are.equal(4170, fake_client.port)
+            assert.is_true(fake_client["tcp-nodelay"])
+            transport:close()
+            assert.is_true(fake_client.closed)
+        end)
+        package.loaded.socket = previous_socket
+        if not ok then
+            error(err)
+        end
+    end)
+
     it("rejects dispatch when no Lua transport endpoint is available", function()
         local connection = board_vm.connect("uno-r4-wifi", { via = "Wi-Fi" })
 

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -1,6 +1,8 @@
 import io
 import pathlib
+import socket
 import tempfile
+import threading
 
 from board_vm_native import (
     BoardDevice,
@@ -259,6 +261,47 @@ def test_connect_builds_a_tcp_transport_for_wifi_endpoints():
     assert transport.endpoint == "tcp://board-vm.local:4170"
     assert transport.host == "board-vm.local"
     assert transport.port == 4170
+
+
+def test_tcp_transport_transacts_with_a_local_endpoint():
+    request = b"\x01\x02\x00"
+    response = b"\x03\x04\x00"
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    received = []
+    errors = []
+
+    def serve():
+        try:
+            conn, _addr = listener.accept()
+            with conn:
+                frame = bytearray()
+                while not frame.endswith(b"\x00"):
+                    chunk = conn.recv(1)
+                    if not chunk:
+                        break
+                    frame.extend(chunk)
+                received.append(bytes(frame))
+                conn.sendall(response)
+        except OSError as error:
+            errors.append(error)
+
+    thread = threading.Thread(target=serve)
+    thread.start()
+    endpoint = f"tcp://127.0.0.1:{listener.getsockname()[1]}"
+    transport = TcpTransport(endpoint, timeout_ms=500)
+
+    try:
+        assert transport.transact(request, timeout_ms=500) == response
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+        assert errors == []
+        assert received == [request]
+    finally:
+        transport.close()
+        listener.close()
 
 
 def test_wifi_endpoint_dispatch_requires_endpoint_when_not_injected():

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "socket"
 require "test_helper"
 
 module CodingAdventures
@@ -158,6 +159,38 @@ module CodingAdventures
         transport = connection.send(:active_transport)
         assert_instance_of TcpTransport, transport
         assert_equal "tcp://board-vm.local:4170", transport.endpoint
+      end
+
+      def test_tcp_transport_transacts_with_a_local_endpoint
+        server = TCPServer.new("127.0.0.1", 0)
+        endpoint = "tcp://127.0.0.1:#{server.addr[1]}"
+        request = "\x01\x02\x00".b
+        response = "\x03\x04\x00".b
+
+        thread = Thread.new do
+          socket = server.accept
+          frame = +"".b
+          begin
+            loop do
+              byte = socket.readpartial(1)
+              frame << byte
+              break if byte == "\x00".b
+            end
+            socket.write(response)
+            frame
+          ensure
+            socket.close
+          end
+        end
+
+        transport = TcpTransport.new(endpoint: endpoint, timeout_ms: 500)
+
+        assert_equal response, transport.transact(request, timeout_ms: 500)
+        assert_equal request, thread.value
+      ensure
+        transport&.close
+        server&.close
+        thread&.kill if thread&.alive?
       end
 
       def test_connect_can_prompt_for_the_connection_option_after_the_board


### PR DESCRIPTION
## Summary
- add Ruby and Python local-loopback TCP transport smoke tests that verify Board VM frames are written and response frames are read through the endpoint path
- add Lua TCP transport smoke coverage with a LuaSocket-compatible fake so CI does not need a host LuaSocket dependency
- keep the coverage at the language-sugar layer while continuing to use Rust-owned Board VM wire frames

## Validation
- BUNDLE_PATH=vendor/bundle bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- bash BUILD in code/packages/lua/board_vm_native
- build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check HEAD~1..HEAD