### PR TITLE
[codex] Add Zigbee environmental sensor deltas

### DIFF
--- a/code/packages/rust/zigbee-zcl/CHANGELOG.md
+++ b/code/packages/rust/zigbee-zcl/CHANGELOG.md
@@ -11,3 +11,5 @@ All notable changes to this package will be documented in this file.
 - Level and color-temperature command frame builders for light actuation.
 - Typed attribute report parsing for common scalar/string data types.
 - D23 capability and state-delta mapping for common smart-home clusters.
+- Temperature and illuminance measurement cluster projections into normalized
+  D23 sensor state deltas.

--- a/code/packages/rust/zigbee-zcl/README.md
+++ b/code/packages/rust/zigbee-zcl/README.md
@@ -11,7 +11,7 @@ coordinator policy. It provides:
 - typed attribute report parsing
 - D23 capability projection for common clusters
 - D23 `StateDelta` projection for on/off, level, color-temperature, occupancy,
-  and lock-state reports
+  lock-state, temperature, and illuminance reports
 - endpoint references grounded in `zigbee-nwk` network addresses
 
 ## Dependencies

--- a/code/packages/rust/zigbee-zcl/src/lib.rs
+++ b/code/packages/rust/zigbee-zcl/src/lib.rs
@@ -60,6 +60,7 @@ impl ZclAttributeId {
     pub const CURRENT_LEVEL: Self = Self(0x0000);
     pub const LOCK_STATE: Self = Self(0x0000);
     pub const LOCAL_TEMPERATURE: Self = Self(0x0000);
+    pub const MEASURED_VALUE: Self = Self(0x0000);
     pub const OCCUPANCY: Self = Self(0x0000);
     pub const COLOR_TEMPERATURE_MIREK: Self = Self(0x0007);
     pub const MANUFACTURER_NAME: Self = Self(0x0004);
@@ -410,6 +411,8 @@ pub fn capabilities_for_cluster(cluster_id: ZclClusterId) -> Vec<Capability> {
         ZclClusterId::LEVEL_CONTROL => vec![Capability::light_brightness()],
         ZclClusterId::COLOR_CONTROL => vec![Capability::light_color_temperature()],
         ZclClusterId::OCCUPANCY_SENSING => vec![Capability::sensor_occupancy()],
+        ZclClusterId::TEMPERATURE_MEASUREMENT => vec![Capability::sensor_temperature()],
+        ZclClusterId::ILLUMINANCE_MEASUREMENT => vec![Capability::sensor_illuminance()],
         ZclClusterId::DOOR_LOCK => vec![Capability::new(
             CapabilityId::trusted("lock.state"),
             CapabilityMode::ObserveAndCommand,
@@ -456,6 +459,22 @@ pub fn state_delta_for_report(report: &ZclAttributeReport) -> Option<StateDelta>
                 value: Value::Text(lock_state_name(*state).to_string()),
             })
         }
+        (
+            ZclClusterId::TEMPERATURE_MEASUREMENT,
+            ZclAttributeId::MEASURED_VALUE,
+            ZclValue::I16(centi_celsius),
+        ) => Some(StateDelta {
+            capability_id: CapabilityId::trusted("sensor.temperature"),
+            value: Value::Number(centi_celsius_to_celsius(*centi_celsius)),
+        }),
+        (
+            ZclClusterId::ILLUMINANCE_MEASUREMENT,
+            ZclAttributeId::MEASURED_VALUE,
+            ZclValue::U16(measured_value),
+        ) => illuminance_measured_value_to_lux(*measured_value).map(|lux| StateDelta {
+            capability_id: CapabilityId::trusted("sensor.illuminance"),
+            value: Value::Number(lux),
+        }),
         _ => None,
     }
 }
@@ -475,6 +494,18 @@ pub fn lock_state_name(value: u8) -> &'static str {
         0x01 => "locked",
         0x02 => "unlocked",
         _ => "unknown",
+    }
+}
+
+pub fn centi_celsius_to_celsius(value: i16) -> f64 {
+    f64::from(value) / 100.0
+}
+
+pub fn illuminance_measured_value_to_lux(value: u16) -> Option<f64> {
+    match value {
+        0xffff => None,
+        0 => Some(0.0),
+        measured_value => Some(10_f64.powf((f64::from(measured_value) - 1.0) / 10_000.0)),
     }
 }
 
@@ -697,6 +728,45 @@ mod tests {
     }
 
     #[test]
+    fn maps_environment_measurement_reports_to_d23_deltas() {
+        let temperature = ZclAttributeReport {
+            cluster_id: ZclClusterId::TEMPERATURE_MEASUREMENT,
+            attribute_id: ZclAttributeId::MEASURED_VALUE,
+            data_type: ZclDataType::I16,
+            value: ZclValue::I16(2312),
+        };
+        let illuminance = ZclAttributeReport {
+            cluster_id: ZclClusterId::ILLUMINANCE_MEASUREMENT,
+            attribute_id: ZclAttributeId::MEASURED_VALUE,
+            data_type: ZclDataType::U16,
+            value: ZclValue::U16(10001),
+        };
+        let invalid_illuminance = ZclAttributeReport {
+            value: ZclValue::U16(0xffff),
+            ..illuminance.clone()
+        };
+
+        assert_eq!(
+            state_delta_for_report(&temperature).unwrap(),
+            StateDelta {
+                capability_id: CapabilityId::trusted("sensor.temperature"),
+                value: Value::Number(23.12),
+            }
+        );
+        assert_eq!(
+            state_delta_for_report(&illuminance).unwrap(),
+            StateDelta {
+                capability_id: CapabilityId::trusted("sensor.illuminance"),
+                value: Value::Number(10.0),
+            }
+        );
+        assert!(state_delta_for_report(&invalid_illuminance).is_none());
+        assert_eq!(centi_celsius_to_celsius(-550), -5.5);
+        assert_eq!(illuminance_measured_value_to_lux(0), Some(0.0));
+        assert_eq!(illuminance_measured_value_to_lux(0xffff), None);
+    }
+
+    #[test]
     fn common_clusters_project_capabilities() {
         assert_eq!(
             capabilities_for_cluster(ZclClusterId::ON_OFF)[0].capability_id,
@@ -705,6 +775,14 @@ mod tests {
         assert_eq!(
             capabilities_for_cluster(ZclClusterId::DOOR_LOCK)[0].capability_id,
             CapabilityId::trusted("lock.state")
+        );
+        assert_eq!(
+            capabilities_for_cluster(ZclClusterId::TEMPERATURE_MEASUREMENT)[0].capability_id,
+            CapabilityId::trusted("sensor.temperature")
+        );
+        assert_eq!(
+            capabilities_for_cluster(ZclClusterId::ILLUMINANCE_MEASUREMENT)[0].capability_id,
+            CapabilityId::trusted("sensor.illuminance")
         );
         assert!(capabilities_for_cluster(ZclClusterId::BASIC).is_empty());
     }


### PR DESCRIPTION
## Summary
- project Zigbee Temperature Measurement and Illuminance Measurement clusters into shared sensor capabilities
- map measured temperature reports into `sensor.temperature` state deltas
- map illuminance measured values into normalized lux `sensor.illuminance` state deltas

## Validation
- `cargo fmt --manifest-path code/packages/rust/Cargo.toml --package zigbee-zcl`
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p zigbee-zcl`
- `git diff --check`
