### PR TITLE
Expose Bluetooth endpoint metadata to language bridges

### DIFF
--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -66,6 +66,10 @@ function M.connection_options(selector)
     return native().connection_options(selector)
 end
 
+function M.bluetooth_endpoint(endpoint)
+    return native().bluetooth_endpoint(endpoint)
+end
+
 function M.esp_upload_options(selector)
     return native().esp_upload_options(selector or "esp32")
 end

--- a/code/packages/lua/board_vm_native/src/lib.rs
+++ b/code/packages/lua/board_vm_native/src/lib.rs
@@ -13,9 +13,10 @@ use board_vm_language_core::{
     build_run_wire_frame, connection_options_for_target, connection_transport_name, detect_target,
     discover_devices, discover_devices_from_paths, esp_upload_options_for_target,
     host_endpoint_transport_name, known_targets, onboard_led_kind,
-    pico_uf2_upload_options_for_target, wireless_transport_name, BoardVmLanguageSession,
-    BuiltWireFrame, LanguageConnectionOption, LanguageCoreError, LanguageEspUploadOptions,
-    LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageTargetInfo,
+    parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
+    wireless_transport_name, BoardVmLanguageSession, BuiltWireFrame, LanguageBluetoothEndpoint,
+    LanguageConnectionOption, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
+    LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageTargetInfo,
     LanguageWirelessInterface,
 };
 use lua_bridge::{
@@ -192,6 +193,53 @@ unsafe fn push_connection_options(L: *mut lua_State, options: &[LanguageConnecti
     }
 }
 
+unsafe fn push_optional_str(L: *mut lua_State, key: &str, value: Option<&str>) {
+    let key = CString::new(key).unwrap();
+    match value {
+        Some(value) => push_str(L, value),
+        None => lua_pushnil(L),
+    }
+    lua_setfield(L, -2, key.as_ptr());
+}
+
+unsafe fn push_optional_int(L: *mut lua_State, key: &str, value: Option<u8>) {
+    let key = CString::new(key).unwrap();
+    match value {
+        Some(value) => lua_pushinteger(L, value as lua_Integer),
+        None => lua_pushnil(L),
+    }
+    lua_setfield(L, -2, key.as_ptr());
+}
+
+unsafe fn push_bluetooth_endpoint(L: *mut lua_State, endpoint: &LanguageBluetoothEndpoint) {
+    lua_bridge::lua_newtable(L);
+    set_str(L, "endpoint", &endpoint.endpoint);
+    set_str(
+        L,
+        "transport",
+        connection_transport_name(endpoint.transport),
+    );
+    set_str(
+        L,
+        "endpoint_transport",
+        host_endpoint_transport_name(endpoint.endpoint_transport),
+    );
+    set_str(L, "endpoint_scheme", &endpoint.endpoint_scheme);
+    set_str(L, "device", &endpoint.device);
+    push_optional_str(L, "service_uuid", endpoint.service_uuid.as_deref());
+    push_optional_str(
+        L,
+        "write_characteristic_uuid",
+        endpoint.write_characteristic_uuid.as_deref(),
+    );
+    push_optional_str(
+        L,
+        "notify_characteristic_uuid",
+        endpoint.notify_characteristic_uuid.as_deref(),
+    );
+    push_optional_int(L, "channel", endpoint.channel);
+}
+
 unsafe fn push_target(L: *mut lua_State, target: &LanguageTargetInfo) {
     lua_bridge::lua_newtable(L);
     set_str(L, "board_id", &target.board_id);
@@ -309,6 +357,15 @@ unsafe extern "C" fn lua_connection_options(L: *mut lua_State) -> c_int {
     match connection_options_for_target(&selector) {
         Some(options) => push_connection_options(L, &options),
         None => raise_error(L, &format!("unsupported board: {selector}")),
+    }
+    1
+}
+
+unsafe extern "C" fn lua_bluetooth_endpoint(L: *mut lua_State) -> c_int {
+    let endpoint = get_str(L, 1).unwrap_or_else(|| raise_error(L, "endpoint must be a string"));
+    match core_parse_bluetooth_endpoint(&endpoint) {
+        Some(endpoint) => push_bluetooth_endpoint(L, &endpoint),
+        None => lua_pushnil(L),
     }
     1
 }
@@ -458,7 +515,7 @@ unsafe extern "C" fn lua_defaults(L: *mut lua_State) -> c_int {
     1
 }
 
-struct FuncTable([luaL_Reg; 16]);
+struct FuncTable([luaL_Reg; 17]);
 unsafe impl Sync for FuncTable {}
 
 static FUNCS: FuncTable = FuncTable([
@@ -473,6 +530,10 @@ static FUNCS: FuncTable = FuncTable([
     luaL_Reg {
         name: b"connection_options\0".as_ptr() as *const _,
         func: Some(lua_connection_options),
+    },
+    luaL_Reg {
+        name: b"bluetooth_endpoint\0".as_ptr() as *const _,
+        func: Some(lua_bluetooth_endpoint),
     },
     luaL_Reg {
         name: b"esp_upload_options\0".as_ptr() as *const _,

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -57,6 +57,27 @@ describe("coding_adventures.board_vm_native", function()
         assert.is_nil(board_vm.esp_upload_options("pico"))
     end)
 
+    it("parses Bluetooth endpoints through Rust-owned metadata", function()
+        local ble = board_vm.bluetooth_endpoint("ble://uno-r4-wifi/180f/2a19/2a1a")
+        local rfcomm = board_vm.bluetooth_endpoint("btspp://ESP32-BoardVM:3")
+
+        assert.are.equal("bluetooth_le", ble.transport)
+        assert.are.equal("bluetooth_le_gatt", ble.endpoint_transport)
+        assert.are.equal("ble", ble.endpoint_scheme)
+        assert.are.equal("uno-r4-wifi", ble.device)
+        assert.are.equal("180f", ble.service_uuid)
+        assert.are.equal("2a19", ble.write_characteristic_uuid)
+        assert.are.equal("2a1a", ble.notify_characteristic_uuid)
+        assert.is_nil(ble.channel)
+
+        assert.are.equal("bluetooth_classic", rfcomm.transport)
+        assert.are.equal("bluetooth_classic_rfcomm", rfcomm.endpoint_transport)
+        assert.are.equal("btspp", rfcomm.endpoint_scheme)
+        assert.are.equal("ESP32-BoardVM", rfcomm.device)
+        assert.are.equal(3, rfcomm.channel)
+        assert.is_nil(board_vm.bluetooth_endpoint("tcp://board-vm.local:4170"))
+    end)
+
     it("classifies host devices through Rust-owned discovery rules", function()
         local devices = board_vm.devices({
             "/dev/cu.usbmodem1101",

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1453,6 +1453,11 @@ def find_target(board_id: str) -> BoardTarget | None:
     return detect_target(board_id)
 
 
+def bluetooth_endpoint(endpoint: str) -> dict[str, Any] | None:
+    parsed = _native.bluetooth_endpoint(str(endpoint))
+    return None if parsed is None else dict(parsed)
+
+
 def connection_options(selector: str) -> list[dict[str, Any]]:
     target = detect_target(selector)
     if target is None:

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -22,9 +22,10 @@ use board_vm_language_core::{
     discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
     discover_pico_bootsel_mounts_in_roots, esp_upload_options_for_target,
     host_endpoint_transport_name, known_targets, onboard_led_kind,
-    pico_uf2_upload_options_for_target, program_format_name, raw_module_len, run_status_name,
-    wireless_transport_name, BoardVmLanguageSession, DecodedLanguageResponse,
-    DecodedLanguageResponseBody, LanguageConnectionOption, LanguageCoreError,
+    parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
+    program_format_name, raw_module_len, run_status_name, wireless_transport_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageBluetoothEndpoint, LanguageConnectionOption, LanguageCoreError,
     LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
     LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
 };
@@ -470,6 +471,24 @@ unsafe extern "C" fn py_detect_target(_module: PyObjectPtr, args: PyObjectPtr) -
     }
 }
 
+unsafe extern "C" fn py_bluetooth_endpoint(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let endpoint = match parse_arg_str(args, 0) {
+        Some(value) => value,
+        None => {
+            set_error(
+                type_error_class(),
+                "bluetooth_endpoint() requires endpoint as str",
+            );
+            return ptr::null_mut();
+        }
+    };
+
+    match core_parse_bluetooth_endpoint(&endpoint) {
+        Some(endpoint) => language_bluetooth_endpoint_to_py(&endpoint),
+        None => py_none(),
+    }
+}
+
 unsafe extern "C" fn py_esp_upload_options(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
     let selector = match parse_arg_str(args, 0) {
         Some(value) => value,
@@ -853,6 +872,63 @@ unsafe fn language_connection_options_to_py(options: &[LanguageConnectionOption]
     list
 }
 
+unsafe fn language_bluetooth_endpoint_to_py(endpoint: &LanguageBluetoothEndpoint) -> PyObjectPtr {
+    let dict = PyDict_New();
+    dict_set(dict, "endpoint", str_to_py(&endpoint.endpoint));
+    dict_set(
+        dict,
+        "transport",
+        str_to_py(connection_transport_name(endpoint.transport)),
+    );
+    dict_set(
+        dict,
+        "endpoint_transport",
+        str_to_py(host_endpoint_transport_name(endpoint.endpoint_transport)),
+    );
+    dict_set(
+        dict,
+        "endpoint_scheme",
+        str_to_py(&endpoint.endpoint_scheme),
+    );
+    dict_set(dict, "device", str_to_py(&endpoint.device));
+    dict_set(
+        dict,
+        "service_uuid",
+        endpoint
+            .service_uuid
+            .as_ref()
+            .map(|value| str_to_py(value))
+            .unwrap_or_else(|| py_none()),
+    );
+    dict_set(
+        dict,
+        "write_characteristic_uuid",
+        endpoint
+            .write_characteristic_uuid
+            .as_ref()
+            .map(|value| str_to_py(value))
+            .unwrap_or_else(|| py_none()),
+    );
+    dict_set(
+        dict,
+        "notify_characteristic_uuid",
+        endpoint
+            .notify_characteristic_uuid
+            .as_ref()
+            .map(|value| str_to_py(value))
+            .unwrap_or_else(|| py_none()),
+    );
+    dict_set(
+        dict,
+        "channel",
+        endpoint
+            .channel
+            .map(|value| usize_to_py(value as usize))
+            .unwrap_or_else(|| py_none()),
+    );
+    dict
+}
+
 unsafe fn esp_upload_options_to_py(options: &LanguageEspUploadOptions) -> PyObjectPtr {
     let dict = PyDict_New();
     dict_set(dict, "board_id", str_to_py(&options.board_id));
@@ -1216,7 +1292,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 28] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 29] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1360,6 +1436,12 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_flags: METH_VARARGS,
             ml_doc: b"Resolve a Board VM target selector using Rust-owned aliases.\0".as_ptr()
                 as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"bluetooth_endpoint\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_bluetooth_endpoint),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Parse a Board VM Bluetooth endpoint in Rust.\0".as_ptr() as *const c_char,
         },
         PyMethodDef {
             ml_name: b"esp_upload_options\0".as_ptr() as *const c_char,

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -12,6 +12,7 @@ from board_vm_native import (
     ProtocolResult,
     Session,
     TcpTransport,
+    bluetooth_endpoint,
     connect,
     connection_option_list,
     connection_options,
@@ -175,6 +176,29 @@ def test_connection_options_are_exposed_from_rust_registry():
         "wire_protocol": "board_vm_cobs_crc",
     } in options
     assert "Wi-Fi [commands, OTA]" in connection_option_list("uno-r4-wifi")
+
+
+def test_bluetooth_endpoints_are_parsed_by_rust_language_core():
+    ble = bluetooth_endpoint("ble://uno-r4-wifi/180f/2a19/2a1a")
+    rfcomm = bluetooth_endpoint("btspp://ESP32-BoardVM:3")
+
+    assert ble is not None
+    assert ble["transport"] == "bluetooth_le"
+    assert ble["endpoint_transport"] == "bluetooth_le_gatt"
+    assert ble["endpoint_scheme"] == "ble"
+    assert ble["device"] == "uno-r4-wifi"
+    assert ble["service_uuid"] == "180f"
+    assert ble["write_characteristic_uuid"] == "2a19"
+    assert ble["notify_characteristic_uuid"] == "2a1a"
+    assert ble["channel"] is None
+
+    assert rfcomm is not None
+    assert rfcomm["transport"] == "bluetooth_classic"
+    assert rfcomm["endpoint_transport"] == "bluetooth_classic_rfcomm"
+    assert rfcomm["endpoint_scheme"] == "btspp"
+    assert rfcomm["device"] == "ESP32-BoardVM"
+    assert rfcomm["channel"] == 3
+    assert bluetooth_endpoint("tcp://board-vm.local:4170") is None
 
 
 def test_connection_options_can_be_selected_without_exposing_ports():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -23,9 +23,10 @@ use board_vm_language_core::{
     discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
     discover_pico_bootsel_mounts_in_roots, esp_upload_options_for_target,
     host_endpoint_transport_name, known_targets, onboard_led_kind,
-    pico_uf2_upload_options_for_target, program_format_name, raw_module_len, run_status_name,
-    wireless_transport_name, BoardVmLanguageSession, DecodedLanguageResponse,
-    DecodedLanguageResponseBody, LanguageConnectionOption, LanguageCoreError,
+    parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
+    program_format_name, raw_module_len, run_status_name, wireless_transport_name,
+    BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
+    LanguageBluetoothEndpoint, LanguageConnectionOption, LanguageCoreError,
     LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
     LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
 };
@@ -419,6 +420,15 @@ extern "C" fn native_detect_target(_self_val: VALUE, selector_val: VALUE) -> VAL
     }
 }
 
+extern "C" fn native_bluetooth_endpoint(_self_val: VALUE, endpoint_val: VALUE) -> VALUE {
+    let endpoint = ruby_bridge::str_from_rb(endpoint_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("endpoint must be a Ruby String"));
+    match core_parse_bluetooth_endpoint(&endpoint) {
+        Some(endpoint) => bluetooth_endpoint_to_rb(&endpoint),
+        None => ruby_bridge::nil_value(),
+    }
+}
+
 extern "C" fn native_esp_upload_options(_self_val: VALUE, selector_val: VALUE) -> VALUE {
     let selector = ruby_bridge::str_from_rb(selector_val)
         .unwrap_or_else(|| ruby_bridge::raise_arg_error("selector must be a Ruby String"));
@@ -757,6 +767,63 @@ fn language_connection_options_to_rb(options: &[LanguageConnectionOption]) -> VA
         ruby_bridge::array_push(array, hash);
     }
     array
+}
+
+fn bluetooth_endpoint_to_rb(endpoint: &LanguageBluetoothEndpoint) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "endpoint", ruby_bridge::str_to_rb(&endpoint.endpoint));
+    hash_set(
+        hash,
+        "transport",
+        ruby_bridge::str_to_rb(connection_transport_name(endpoint.transport)),
+    );
+    hash_set(
+        hash,
+        "endpoint_transport",
+        ruby_bridge::str_to_rb(host_endpoint_transport_name(endpoint.endpoint_transport)),
+    );
+    hash_set(
+        hash,
+        "endpoint_scheme",
+        ruby_bridge::str_to_rb(&endpoint.endpoint_scheme),
+    );
+    hash_set(hash, "device", ruby_bridge::str_to_rb(&endpoint.device));
+    hash_set(
+        hash,
+        "service_uuid",
+        endpoint
+            .service_uuid
+            .as_ref()
+            .map(|value| ruby_bridge::str_to_rb(value))
+            .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash_set(
+        hash,
+        "write_characteristic_uuid",
+        endpoint
+            .write_characteristic_uuid
+            .as_ref()
+            .map(|value| ruby_bridge::str_to_rb(value))
+            .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash_set(
+        hash,
+        "notify_characteristic_uuid",
+        endpoint
+            .notify_characteristic_uuid
+            .as_ref()
+            .map(|value| ruby_bridge::str_to_rb(value))
+            .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash_set(
+        hash,
+        "channel",
+        endpoint
+            .channel
+            .map(rb_usize)
+            .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash
 }
 
 fn esp_upload_options_to_rb(options: &LanguageEspUploadOptions) -> VALUE {
@@ -1137,6 +1204,12 @@ pub extern "C" fn Init_board_vm_native() {
         native,
         "detect_target",
         native_detect_target as *const c_void,
+        1,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "bluetooth_endpoint",
+        native_bluetooth_endpoint as *const c_void,
         1,
     );
     ruby_bridge::define_module_function_raw(

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -146,6 +146,10 @@ module CodingAdventures
       detect_target(board_id)
     end
 
+    def bluetooth_endpoint(endpoint)
+      Native.bluetooth_endpoint(endpoint.to_s)
+    end
+
     def connection_options(board)
       target = detect_target(board)
       unless target

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -77,6 +77,27 @@ module CodingAdventures
         }
       end
 
+      def test_bluetooth_endpoints_are_parsed_by_rust_language_core
+        ble = BoardVM.bluetooth_endpoint("ble://uno-r4-wifi/180f/2a19/2a1a")
+        rfcomm = BoardVM.bluetooth_endpoint("btspp://ESP32-BoardVM:3")
+
+        assert_equal "bluetooth_le", ble.fetch("transport")
+        assert_equal "bluetooth_le_gatt", ble.fetch("endpoint_transport")
+        assert_equal "ble", ble.fetch("endpoint_scheme")
+        assert_equal "uno-r4-wifi", ble.fetch("device")
+        assert_equal "180f", ble.fetch("service_uuid")
+        assert_equal "2a19", ble.fetch("write_characteristic_uuid")
+        assert_equal "2a1a", ble.fetch("notify_characteristic_uuid")
+        assert_nil ble.fetch("channel")
+
+        assert_equal "bluetooth_classic", rfcomm.fetch("transport")
+        assert_equal "bluetooth_classic_rfcomm", rfcomm.fetch("endpoint_transport")
+        assert_equal "btspp", rfcomm.fetch("endpoint_scheme")
+        assert_equal "ESP32-BoardVM", rfcomm.fetch("device")
+        assert_equal 3, rfcomm.fetch("channel")
+        assert_nil BoardVM.bluetooth_endpoint("tcp://board-vm.local:4170")
+      end
+
       def test_connection_options_can_be_selected_without_exposing_ports
         default = BoardVM.select_connection_option(:uno_r4_wifi)
         wifi = BoardVM.select_connection_option(:uno_r4_wifi, transport: :wifi)

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "board-vm-cli",
     "board-vm-stream",
     "board-vm-tcp",
+    "board-vm-bluetooth",
     "board-vm-serial",
     "board-vm-uart",
     "board-vm-usb-cdc",

--- a/code/packages/rust/board-vm-bluetooth/BUILD
+++ b/code/packages/rust/board-vm-bluetooth/BUILD
@@ -1,0 +1,1 @@
+cargo test -p board-vm-bluetooth -- --nocapture

--- a/code/packages/rust/board-vm-bluetooth/Cargo.toml
+++ b/code/packages/rust/board-vm-bluetooth/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "board-vm-bluetooth"
+version = "0.1.0"
+edition = "2021"
+description = "Bluetooth endpoint parsing for Board VM host clients"
+
+[lib]
+path = "src/lib.rs"

--- a/code/packages/rust/board-vm-bluetooth/README.md
+++ b/code/packages/rust/board-vm-bluetooth/README.md
@@ -1,0 +1,8 @@
+# board-vm-bluetooth
+
+Zero-dependency Bluetooth endpoint parsing for Board VM host clients.
+
+The crate keeps Bluetooth connection endpoint shapes in Rust so language
+frontends can stay thin. It does not open OS Bluetooth stacks yet; it validates
+and normalizes endpoint strings for the BLE GATT and Bluetooth Classic RFCOMM
+transports that later host backends will use.

--- a/code/packages/rust/board-vm-bluetooth/src/lib.rs
+++ b/code/packages/rust/board-vm-bluetooth/src/lib.rs
@@ -1,0 +1,283 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BluetoothEndpoint {
+    BleGatt(BleGattEndpoint),
+    Rfcomm(RfcommEndpoint),
+}
+
+impl BluetoothEndpoint {
+    pub const fn transport(&self) -> BluetoothEndpointTransport {
+        match self {
+            Self::BleGatt(_) => BluetoothEndpointTransport::BleGatt,
+            Self::Rfcomm(_) => BluetoothEndpointTransport::Rfcomm,
+        }
+    }
+
+    pub fn device(&self) -> &str {
+        match self {
+            Self::BleGatt(endpoint) => &endpoint.device,
+            Self::Rfcomm(endpoint) => &endpoint.device,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BluetoothEndpointTransport {
+    BleGatt,
+    Rfcomm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BleGattEndpoint {
+    pub endpoint: String,
+    pub device: String,
+    pub service_uuid: String,
+    pub write_characteristic_uuid: String,
+    pub notify_characteristic_uuid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RfcommEndpoint {
+    pub endpoint: String,
+    pub device: String,
+    pub channel: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BluetoothEndpointError {
+    UnsupportedScheme(String),
+    MissingDevice,
+    MissingServiceUuid,
+    MissingWriteCharacteristicUuid,
+    MissingNotifyCharacteristicUuid,
+    MissingChannel,
+    InvalidChannel(String),
+    InvalidUuid { field: &'static str, value: String },
+}
+
+pub fn parse_bluetooth_endpoint(
+    endpoint: &str,
+) -> Result<BluetoothEndpoint, BluetoothEndpointError> {
+    let endpoint = endpoint.trim();
+    if endpoint.starts_with("ble://") {
+        return parse_ble_gatt_endpoint(endpoint).map(BluetoothEndpoint::BleGatt);
+    }
+    if endpoint.starts_with("btspp://") || endpoint.starts_with("rfcomm://") {
+        return parse_rfcomm_endpoint(endpoint).map(BluetoothEndpoint::Rfcomm);
+    }
+
+    let scheme = endpoint
+        .split_once("://")
+        .map(|(scheme, _)| scheme)
+        .unwrap_or("");
+    Err(BluetoothEndpointError::UnsupportedScheme(scheme.to_owned()))
+}
+
+pub fn parse_ble_gatt_endpoint(endpoint: &str) -> Result<BleGattEndpoint, BluetoothEndpointError> {
+    let body = endpoint.trim().strip_prefix("ble://").ok_or_else(|| {
+        BluetoothEndpointError::UnsupportedScheme(endpoint_scheme(endpoint).to_owned())
+    })?;
+    let (path, query) = body.split_once('?').unwrap_or((body, ""));
+    let mut path_parts = path.split('/').filter(|part| !part.is_empty());
+    let device = path_parts
+        .next()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or(BluetoothEndpointError::MissingDevice)?;
+    let service_uuid = query_value(query, "service")
+        .or_else(|| path_parts.next())
+        .ok_or(BluetoothEndpointError::MissingServiceUuid)?;
+    let write_characteristic_uuid = query_value(query, "write")
+        .or_else(|| query_value(query, "tx"))
+        .or_else(|| path_parts.next())
+        .ok_or(BluetoothEndpointError::MissingWriteCharacteristicUuid)?;
+    let notify_characteristic_uuid = query_value(query, "notify")
+        .or_else(|| query_value(query, "rx"))
+        .or_else(|| path_parts.next())
+        .ok_or(BluetoothEndpointError::MissingNotifyCharacteristicUuid)?;
+
+    validate_uuid("service", service_uuid)?;
+    validate_uuid("write", write_characteristic_uuid)?;
+    validate_uuid("notify", notify_characteristic_uuid)?;
+
+    Ok(BleGattEndpoint {
+        endpoint: endpoint.trim().to_owned(),
+        device: device.to_owned(),
+        service_uuid: service_uuid.to_owned(),
+        write_characteristic_uuid: write_characteristic_uuid.to_owned(),
+        notify_characteristic_uuid: notify_characteristic_uuid.to_owned(),
+    })
+}
+
+pub fn parse_rfcomm_endpoint(endpoint: &str) -> Result<RfcommEndpoint, BluetoothEndpointError> {
+    let body = endpoint
+        .trim()
+        .strip_prefix("btspp://")
+        .or_else(|| endpoint.trim().strip_prefix("rfcomm://"))
+        .ok_or_else(|| {
+            BluetoothEndpointError::UnsupportedScheme(endpoint_scheme(endpoint).to_owned())
+        })?;
+    let (device, channel) = body
+        .rsplit_once(':')
+        .ok_or(BluetoothEndpointError::MissingChannel)?;
+    if device.trim().is_empty() {
+        return Err(BluetoothEndpointError::MissingDevice);
+    }
+    let channel_text = channel;
+    let channel = channel_text
+        .parse::<u8>()
+        .map_err(|_| BluetoothEndpointError::InvalidChannel(channel_text.to_owned()))?;
+    if !(1..=30).contains(&channel) {
+        return Err(BluetoothEndpointError::InvalidChannel(
+            channel_text.to_owned(),
+        ));
+    }
+
+    Ok(RfcommEndpoint {
+        endpoint: endpoint.trim().to_owned(),
+        device: device.to_owned(),
+        channel,
+    })
+}
+
+fn endpoint_scheme(endpoint: &str) -> &str {
+    endpoint
+        .split_once("://")
+        .map(|(scheme, _)| scheme)
+        .unwrap_or("")
+}
+
+fn query_value<'a>(query: &'a str, key: &str) -> Option<&'a str> {
+    query.split('&').find_map(|pair| {
+        let (name, value) = pair.split_once('=')?;
+        (name == key && !value.is_empty()).then_some(value)
+    })
+}
+
+fn validate_uuid(field: &'static str, value: &str) -> Result<(), BluetoothEndpointError> {
+    if is_short_uuid(value) || is_canonical_uuid(value) {
+        return Ok(());
+    }
+
+    Err(BluetoothEndpointError::InvalidUuid {
+        field,
+        value: value.to_owned(),
+    })
+}
+
+fn is_short_uuid(value: &str) -> bool {
+    matches!(value.len(), 4 | 8) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_canonical_uuid(value: &str) -> bool {
+    if value.len() != 36 {
+        return false;
+    }
+    value.bytes().enumerate().all(|(index, byte)| {
+        matches!(index, 8 | 13 | 18 | 23) && byte == b'-'
+            || !matches!(index, 8 | 13 | 18 | 23) && byte.is_ascii_hexdigit()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SERVICE_UUID: &str = "6e400001-b5a3-f393-e0a9-e50e24dcca9e";
+    const WRITE_UUID: &str = "6e400002-b5a3-f393-e0a9-e50e24dcca9e";
+    const NOTIFY_UUID: &str = "6e400003-b5a3-f393-e0a9-e50e24dcca9e";
+
+    #[test]
+    fn parses_ble_gatt_query_endpoint() {
+        let endpoint = parse_ble_gatt_endpoint(&format!(
+            "ble://AA:BB:CC:DD:EE:FF?service={SERVICE_UUID}&write={WRITE_UUID}&notify={NOTIFY_UUID}"
+        ))
+        .unwrap();
+
+        assert_eq!(endpoint.device, "AA:BB:CC:DD:EE:FF");
+        assert_eq!(endpoint.service_uuid, SERVICE_UUID);
+        assert_eq!(endpoint.write_characteristic_uuid, WRITE_UUID);
+        assert_eq!(endpoint.notify_characteristic_uuid, NOTIFY_UUID);
+    }
+
+    #[test]
+    fn parses_ble_gatt_path_endpoint_and_short_uuids() {
+        let endpoint = parse_ble_gatt_endpoint("ble://uno-r4-wifi/180f/2a19/2a1a").unwrap();
+
+        assert_eq!(endpoint.device, "uno-r4-wifi");
+        assert_eq!(endpoint.service_uuid, "180f");
+        assert_eq!(endpoint.write_characteristic_uuid, "2a19");
+        assert_eq!(endpoint.notify_characteristic_uuid, "2a1a");
+    }
+
+    #[test]
+    fn rejects_incomplete_ble_gatt_endpoint() {
+        assert_eq!(
+            parse_ble_gatt_endpoint("ble://esp32?service=180f").unwrap_err(),
+            BluetoothEndpointError::MissingWriteCharacteristicUuid
+        );
+        assert_eq!(
+            parse_ble_gatt_endpoint(&format!(
+                "ble://esp32?service={SERVICE_UUID}&write=not-a-uuid&notify={NOTIFY_UUID}"
+            ))
+            .unwrap_err(),
+            BluetoothEndpointError::InvalidUuid {
+                field: "write",
+                value: "not-a-uuid".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn parses_bluetooth_classic_rfcomm_endpoints() {
+        let btspp = parse_rfcomm_endpoint("btspp://ESP32-BoardVM:1").unwrap();
+        let rfcomm = parse_bluetooth_endpoint("rfcomm://AA:BB:CC:DD:EE:FF:12").unwrap();
+
+        assert_eq!(btspp.device, "ESP32-BoardVM");
+        assert_eq!(btspp.channel, 1);
+        assert_eq!(
+            rfcomm,
+            BluetoothEndpoint::Rfcomm(RfcommEndpoint {
+                endpoint: "rfcomm://AA:BB:CC:DD:EE:FF:12".to_owned(),
+                device: "AA:BB:CC:DD:EE:FF".to_owned(),
+                channel: 12
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_bad_rfcomm_channels() {
+        assert_eq!(
+            parse_rfcomm_endpoint("btspp://ESP32-BoardVM:0").unwrap_err(),
+            BluetoothEndpointError::InvalidChannel("0".to_owned())
+        );
+        assert_eq!(
+            parse_rfcomm_endpoint("btspp://ESP32-BoardVM:31").unwrap_err(),
+            BluetoothEndpointError::InvalidChannel("31".to_owned())
+        );
+        assert_eq!(
+            parse_rfcomm_endpoint("btspp://ESP32-BoardVM").unwrap_err(),
+            BluetoothEndpointError::MissingChannel
+        );
+    }
+
+    #[test]
+    fn dispatches_supported_bluetooth_endpoint_schemes() {
+        assert_eq!(
+            parse_bluetooth_endpoint(&format!(
+                "ble://esp32?service={SERVICE_UUID}&write={WRITE_UUID}&notify={NOTIFY_UUID}"
+            ))
+            .unwrap()
+            .transport(),
+            BluetoothEndpointTransport::BleGatt
+        );
+        assert_eq!(
+            parse_bluetooth_endpoint("btspp://ESP32-BoardVM:3")
+                .unwrap()
+                .transport(),
+            BluetoothEndpointTransport::Rfcomm
+        );
+        assert_eq!(
+            parse_bluetooth_endpoint("tcp://board-vm.local:4170").unwrap_err(),
+            BluetoothEndpointError::UnsupportedScheme("tcp".to_owned())
+        );
+    }
+}

--- a/code/packages/rust/board-vm-language-core/Cargo.toml
+++ b/code/packages/rust/board-vm-language-core/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
+board-vm-bluetooth = { path = "../board-vm-bluetooth" }
 board-vm-esp-rom = { path = "../board-vm-esp-rom" }
 board-vm-host = { path = "../board-vm-host" }
 board-vm-protocol = { path = "../board-vm-protocol" }

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -16,6 +16,9 @@ use std::ptr;
 use std::slice;
 use std::str;
 
+use board_vm_bluetooth::{
+    parse_bluetooth_endpoint as parse_board_vm_bluetooth_endpoint, BluetoothEndpoint,
+};
 use board_vm_esp_rom::{
     DEFAULT_BAUD_RATE as ESP_DEFAULT_BAUD_RATE,
     DEFAULT_FLASH_BLOCK_SIZE as ESP_DEFAULT_FLASH_BLOCK_SIZE,
@@ -304,6 +307,19 @@ pub struct LanguageConnectionOption {
     pub endpoint_transport: LanguageHostEndpointTransport,
     pub endpoint_scheme: String,
     pub wire_protocol: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageBluetoothEndpoint {
+    pub endpoint: String,
+    pub transport: LanguageConnectionTransport,
+    pub endpoint_transport: LanguageHostEndpointTransport,
+    pub endpoint_scheme: String,
+    pub device: String,
+    pub service_uuid: Option<String>,
+    pub write_characteristic_uuid: Option<String>,
+    pub notify_characteristic_uuid: Option<String>,
+    pub channel: Option<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -599,6 +615,33 @@ pub fn connection_options_for_target(selector: &str) -> Option<Vec<LanguageConne
     Some(target.connection_options)
 }
 
+pub fn parse_bluetooth_endpoint(endpoint: &str) -> Option<LanguageBluetoothEndpoint> {
+    match parse_board_vm_bluetooth_endpoint(endpoint).ok()? {
+        BluetoothEndpoint::BleGatt(endpoint) => Some(LanguageBluetoothEndpoint {
+            endpoint: endpoint.endpoint,
+            transport: LanguageConnectionTransport::BluetoothLe,
+            endpoint_transport: LanguageHostEndpointTransport::BluetoothLeGatt,
+            endpoint_scheme: "ble".to_owned(),
+            device: endpoint.device,
+            service_uuid: Some(endpoint.service_uuid),
+            write_characteristic_uuid: Some(endpoint.write_characteristic_uuid),
+            notify_characteristic_uuid: Some(endpoint.notify_characteristic_uuid),
+            channel: None,
+        }),
+        BluetoothEndpoint::Rfcomm(endpoint) => Some(LanguageBluetoothEndpoint {
+            endpoint: endpoint.endpoint.clone(),
+            transport: LanguageConnectionTransport::BluetoothClassic,
+            endpoint_transport: LanguageHostEndpointTransport::BluetoothClassicRfcomm,
+            endpoint_scheme: bluetooth_endpoint_scheme(&endpoint.endpoint).to_owned(),
+            device: endpoint.device,
+            service_uuid: None,
+            write_characteristic_uuid: None,
+            notify_characteristic_uuid: None,
+            channel: Some(endpoint.channel),
+        }),
+    }
+}
+
 pub fn discover_devices() -> Vec<LanguageHostDevice> {
     let mut paths = env_device_paths();
 
@@ -798,6 +841,13 @@ const fn connection_endpoint_scheme(transport: LanguageConnectionTransport) -> &
         LanguageConnectionTransport::BluetoothLe => "ble",
         LanguageConnectionTransport::BluetoothClassic => "btspp",
     }
+}
+
+fn bluetooth_endpoint_scheme(endpoint: &str) -> &str {
+    endpoint
+        .split_once("://")
+        .map(|(scheme, _)| scheme)
+        .unwrap_or("")
 }
 
 fn language_family(family: BoardFamily) -> LanguageBoardFamily {
@@ -2324,6 +2374,37 @@ mod tests {
             "bluetooth_classic_rfcomm"
         );
         assert!(connection_options_for_target("not-a-board").is_none());
+    }
+
+    #[test]
+    fn bluetooth_endpoint_metadata_is_owned_by_rust_language_core() {
+        let ble = parse_bluetooth_endpoint("ble://uno-r4-wifi/180f/2a19/2a1a").unwrap();
+        let rfcomm = parse_bluetooth_endpoint("btspp://ESP32-BoardVM:3").unwrap();
+
+        assert_eq!(ble.transport, LanguageConnectionTransport::BluetoothLe);
+        assert_eq!(
+            ble.endpoint_transport,
+            LanguageHostEndpointTransport::BluetoothLeGatt
+        );
+        assert_eq!(ble.endpoint_scheme, "ble");
+        assert_eq!(ble.device, "uno-r4-wifi");
+        assert_eq!(ble.service_uuid.as_deref(), Some("180f"));
+        assert_eq!(ble.write_characteristic_uuid.as_deref(), Some("2a19"));
+        assert_eq!(ble.notify_characteristic_uuid.as_deref(), Some("2a1a"));
+        assert_eq!(ble.channel, None);
+
+        assert_eq!(
+            rfcomm.transport,
+            LanguageConnectionTransport::BluetoothClassic
+        );
+        assert_eq!(
+            rfcomm.endpoint_transport,
+            LanguageHostEndpointTransport::BluetoothClassicRfcomm
+        );
+        assert_eq!(rfcomm.endpoint_scheme, "btspp");
+        assert_eq!(rfcomm.device, "ESP32-BoardVM");
+        assert_eq!(rfcomm.channel, Some(3));
+        assert!(parse_bluetooth_endpoint("tcp://board-vm.local:4170").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- wire the Rust-owned Bluetooth endpoint parser into board-vm-language-core
- expose parsed BLE GATT and Bluetooth Classic RFCOMM endpoint metadata through Ruby, Python, and Lua native bridges
- add language-level sugar helpers/tests so scripts can inspect Bluetooth endpoint shape without any OS Bluetooth dependency yet

## Stacking
- stacked on PR #2578 / `codex/board-vm-bluetooth-endpoints` because it depends on the new `board-vm-bluetooth` parser crate
- after #2578 merges, this can be retargeted/rebased onto `main`

## Validation
- cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge -p lua-bridge
- BUNDLE_PATH=vendor/bundle bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- bash BUILD in code/packages/lua/board_vm_native
- build-tool -root . -diff-base codex/board-vm-bluetooth-endpoints -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check codex/board-vm-bluetooth-endpoints...HEAD
- git diff --check
- git diff --cached --check
- git diff --check HEAD~1..HEAD