### PR TITLE
[codex] Enforce RWS in capability cage manifests

### DIFF
--- a/code/packages/rust/capability-cage/CHANGELOG.md
+++ b/code/packages/rust/capability-cage/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Added optional `flavor` and `trust` capability annotations for
+  Chief-of-Staff read/write separation.
+- Added `Manifest::try_new` and read/write separation validation for
+  `Manifest::load_from_str` / `Manifest::load_from_file`.
+- Manifest loading now rejects mixed untrusted ingestion and external
+  actuation, plus same-resource read/write overlap.
+
 ## 0.1.0 — 2026-05-08
 
 Initial release. V1 scope per `code/specs/capability-cage-rust.md`:
@@ -37,4 +46,3 @@ Out of scope for v1 (will land in subsequent PRs):
 - `build.rs`-driven package_manifest() codegen.
 - Cross-language conformance suite shared with the Go cage.
 - The lint that rejects raw stdlib usage outside of the backend.
-- RWS Phase 1 enforcement (per `read-write-separation.md`).

--- a/code/packages/rust/capability-cage/Cargo.toml
+++ b/code/packages/rust/capability-cage/Cargo.toml
@@ -7,3 +7,4 @@ description = "Rust port of the capability-cage runtime — manifests, secure wr
 [dependencies]
 coding-adventures-json-parser = { path = "../json-parser" }
 coding-adventures-json-value  = { path = "../json-value" }
+read-write-separation = { path = "../read-write-separation" }

--- a/code/packages/rust/capability-cage/README.md
+++ b/code/packages/rust/capability-cage/README.md
@@ -27,20 +27,25 @@ This crate ships rings 2 and 3's seams. The wrappers and the
 `Backend` trait are stable contracts; anything below them is a
 swappable detail.
 
+Manifest loading also runs the Chief-of-Staff read/write separation
+validator. Optional `flavor` (`ingestion`, `actuation`, `internal`)
+and `trust` (`trusted`, `untrusted`) fields let a manifest override
+the default classifier when a capability crosses an agent boundary.
+
 ## Quick example
 
 ```rust
 use capability_cage::{Capability, Category, Action, Manifest, secure_file};
 use std::path::Path;
 
-let m = Manifest::new(vec![
+let m = Manifest::try_new(vec![
     Capability::new(
         Category::Fs,
         Action::Read,
         "./grammars/*.tokens",
         "load lexer DFA",
     ).unwrap(),
-]);
+])?;
 
 // Reading a file the manifest covers — succeeds (calls OpenBackend).
 let bytes = secure_file::read_file(&m, Path::new("./grammars/json.tokens"))?;
@@ -60,7 +65,7 @@ assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
 | `capability`    | `Capability` struct (immutable, validated)              |
 | `errors`        | `CapabilityViolationError`, `ManifestError`, `InvalidCombination` |
 | `glob`          | `match_target(pattern, candidate)` for fs / net targets |
-| `manifest`      | `Manifest` with `has`/`check`/`load_from_str`/`load_from_file` |
+| `manifest`      | `Manifest` with `has`/`check`/`try_new`/`load_from_str`/`load_from_file` |
 | `backend`       | `Backend` trait + `OpenBackend` / `TestBackend` / `DenyAllBackend`, `with_backend(...)` guard |
 | `secure_file`   | `read_file` / `write_file` / `create_file` / `delete_file` / `list_dir` |
 
@@ -92,12 +97,12 @@ Spec-defined but landing in subsequent PRs:
 - `build.rs` codegen for `package_manifest()`
 - Cross-language conformance suite shared with the Go cage
 - The CI lint that rejects raw stdlib usage
-- RWS Phase 1 enforcement (per `read-write-separation.md`)
 
 ## Dependencies
 
 - `coding-adventures-json-parser` — manifest JSON parsing
 - `coding-adventures-json-value`  — typed JSON values
+- `read-write-separation` — manifest-level RWS classification and validation
 
 No std-OS access from this crate's own code: everything happens
 inside `Backend` implementations (which the consumer chooses).

--- a/code/packages/rust/capability-cage/src/capability.rs
+++ b/code/packages/rust/capability-cage/src/capability.rs
@@ -2,6 +2,7 @@
 
 use crate::category::{is_valid_combination, Action, Category};
 use crate::errors::InvalidCombination;
+use read_write_separation::{Capability as ReadWriteCapability, CapabilityFlavor, CapabilityTrust};
 
 /// A single OS-level permission declaration.
 ///
@@ -14,6 +15,8 @@ pub struct Capability {
     pub action: Action,
     pub target: String,
     pub justification: String,
+    pub flavor: Option<CapabilityFlavor>,
+    pub trust: Option<CapabilityTrust>,
 }
 
 impl Capability {
@@ -41,7 +44,39 @@ impl Capability {
             action,
             target,
             justification: justification.into(),
+            flavor: None,
+            trust: None,
         })
+    }
+
+    /// Annotate the capability for read/write separation checks.
+    pub fn with_flavor(mut self, flavor: CapabilityFlavor) -> Self {
+        self.flavor = Some(flavor);
+        self
+    }
+
+    /// Annotate the capability trust boundary for read/write separation checks.
+    pub fn with_trust(mut self, trust: CapabilityTrust) -> Self {
+        self.trust = Some(trust);
+        self
+    }
+
+    pub(crate) fn to_read_write_capability(&self) -> ReadWriteCapability {
+        let mut capability = ReadWriteCapability::new(
+            self.category.as_str(),
+            self.action.as_str(),
+            self.target.clone(),
+        )
+        .with_justification(self.justification.clone());
+
+        if let Some(flavor) = self.flavor {
+            capability = capability.with_flavor(flavor);
+        }
+        if let Some(trust) = self.trust {
+            capability = capability.with_trust(trust);
+        }
+
+        capability
     }
 }
 
@@ -62,6 +97,28 @@ mod tests {
         assert_eq!(cap.action, Action::Read);
         assert_eq!(cap.target, "./grammars/json.tokens");
         assert_eq!(cap.justification, "load lexer DFA");
+        assert_eq!(cap.flavor, None);
+        assert_eq!(cap.trust, None);
+    }
+
+    #[test]
+    fn read_write_annotations_are_preserved() {
+        let cap = Capability::new(
+            Category::Net,
+            Action::Connect,
+            "imap.example.test:993",
+            "mail",
+        )
+        .unwrap()
+        .with_flavor(CapabilityFlavor::Ingestion)
+        .with_trust(CapabilityTrust::Untrusted);
+        let rws = cap.to_read_write_capability();
+
+        assert_eq!(cap.flavor, Some(CapabilityFlavor::Ingestion));
+        assert_eq!(cap.trust, Some(CapabilityTrust::Untrusted));
+        assert_eq!(rws.flavor, Some(CapabilityFlavor::Ingestion));
+        assert_eq!(rws.trust, Some(CapabilityTrust::Untrusted));
+        assert_eq!(rws.justification.as_deref(), Some("mail"));
     }
 
     #[test]

--- a/code/packages/rust/capability-cage/src/errors.rs
+++ b/code/packages/rust/capability-cage/src/errors.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 
 use crate::category::{Action, Category};
+use read_write_separation::Capability as ReadWriteCapability;
 
 /// A capability check denied an OS operation.
 ///
@@ -64,6 +65,12 @@ pub enum ManifestError {
     InvalidCombination(InvalidCombination),
     /// An IO error reading the manifest file.
     Io(std::io::Error),
+    /// The manifest violates read/write separation.
+    RwsViolation {
+        untrusted_inputs: Vec<ReadWriteCapability>,
+        actuations: Vec<ReadWriteCapability>,
+        message: String,
+    },
 }
 
 impl fmt::Display for ManifestError {
@@ -75,6 +82,9 @@ impl fmt::Display for ManifestError {
                 write!(f, "manifest validation error: {inner}")
             }
             ManifestError::Io(err) => write!(f, "manifest I/O error: {err}"),
+            ManifestError::RwsViolation { message, .. } => {
+                write!(f, "manifest read/write separation error: {message}")
+            }
         }
     }
 }
@@ -98,6 +108,16 @@ impl From<InvalidCombination> for ManifestError {
 impl From<std::io::Error> for ManifestError {
     fn from(value: std::io::Error) -> Self {
         ManifestError::Io(value)
+    }
+}
+
+impl From<read_write_separation::RwsViolation> for ManifestError {
+    fn from(value: read_write_separation::RwsViolation) -> Self {
+        ManifestError::RwsViolation {
+            untrusted_inputs: value.untrusted_inputs,
+            actuations: value.actuations,
+            message: value.message,
+        }
     }
 }
 
@@ -145,5 +165,17 @@ mod tests {
         let io = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
         let err: ManifestError = io.into();
         assert!(matches!(err, ManifestError::Io(_)));
+    }
+
+    #[test]
+    fn rws_violation_displays_message() {
+        let err = ManifestError::RwsViolation {
+            untrusted_inputs: Vec::new(),
+            actuations: Vec::new(),
+            message: "split agent".into(),
+        };
+
+        assert!(format!("{err}").contains("read/write separation"));
+        assert!(format!("{err}").contains("split agent"));
     }
 }

--- a/code/packages/rust/capability-cage/src/lib.rs
+++ b/code/packages/rust/capability-cage/src/lib.rs
@@ -23,3 +23,4 @@ pub use category::{Action, Category};
 pub use errors::{CapabilityViolationError, InvalidCombination, ManifestError};
 pub use glob::match_target;
 pub use manifest::Manifest;
+pub use read_write_separation::{CapabilityFlavor, CapabilityTrust};

--- a/code/packages/rust/capability-cage/src/manifest.rs
+++ b/code/packages/rust/capability-cage/src/manifest.rs
@@ -12,6 +12,7 @@
 use std::path::Path;
 
 use coding_adventures_json_value::{parse, JsonNumber, JsonValue};
+use read_write_separation::{CapabilityFlavor, CapabilityTrust};
 
 use crate::capability::Capability;
 use crate::category::{Action, Category};
@@ -33,6 +34,16 @@ impl Manifest {
     /// [`Capability::new`]; this constructor does not re-check.
     pub fn new(capabilities: Vec<Capability>) -> Self {
         Self { capabilities }
+    }
+
+    /// Construct a manifest and validate read/write separation.
+    ///
+    /// This is the constructor to use for manifests assembled from
+    /// package metadata. [`Manifest::new`] remains available for
+    /// tests and already-gated in-memory manifests.
+    pub fn try_new(capabilities: Vec<Capability>) -> Result<Self, ManifestError> {
+        validate_read_write_separation(&capabilities)?;
+        Ok(Self::new(capabilities))
     }
 
     /// The pre-built zero-capability manifest. Equivalent to
@@ -121,6 +132,8 @@ impl Manifest {
                 .and_then(json_as_str)
                 .map(|s| s.to_string())
                 .unwrap_or_default();
+            let flavor = parse_optional_flavor(entry_obj, idx)?;
+            let trust = parse_optional_trust(entry_obj, idx)?;
 
             let category: Category = category_str.parse().map_err(|()| ManifestError::Schema {
                 reason: format!(
@@ -130,11 +143,17 @@ impl Manifest {
             let action: Action = action_str.parse().map_err(|()| ManifestError::Schema {
                 reason: format!("capabilities[{idx}].action '{action_str}' is not a known action"),
             })?;
-            let cap = Capability::new(category, action, target, justification)?;
+            let mut cap = Capability::new(category, action, target, justification)?;
+            if let Some(flavor) = flavor {
+                cap = cap.with_flavor(flavor);
+            }
+            if let Some(trust) = trust {
+                cap = cap.with_trust(trust);
+            }
             caps.push(cap);
         }
 
-        Ok(Manifest::new(caps))
+        Manifest::try_new(caps)
     }
 
     /// Returns true if the manifest declares a capability that covers
@@ -173,6 +192,11 @@ impl Manifest {
     pub fn capabilities(&self) -> &[Capability] {
         &self.capabilities
     }
+
+    /// Re-run read/write separation validation for this manifest.
+    pub fn validate_read_write_separation(&self) -> Result<(), ManifestError> {
+        validate_read_write_separation(&self.capabilities)
+    }
 }
 
 impl Default for Manifest {
@@ -197,6 +221,58 @@ fn json_as_i64(v: &JsonValue) -> Option<i64> {
         JsonValue::Number(JsonNumber::Integer(n)) => Some(*n),
         _ => None,
     }
+}
+
+fn parse_optional_flavor(
+    obj: &[(String, JsonValue)],
+    idx: usize,
+) -> Result<Option<CapabilityFlavor>, ManifestError> {
+    parse_optional_enum(obj, "flavor", idx, |value| match value {
+        "ingestion" => Some(CapabilityFlavor::Ingestion),
+        "actuation" => Some(CapabilityFlavor::Actuation),
+        "internal" => Some(CapabilityFlavor::Internal),
+        _ => None,
+    })
+}
+
+fn parse_optional_trust(
+    obj: &[(String, JsonValue)],
+    idx: usize,
+) -> Result<Option<CapabilityTrust>, ManifestError> {
+    parse_optional_enum(obj, "trust", idx, |value| match value {
+        "trusted" => Some(CapabilityTrust::Trusted),
+        "untrusted" => Some(CapabilityTrust::Untrusted),
+        _ => None,
+    })
+}
+
+fn parse_optional_enum<T>(
+    obj: &[(String, JsonValue)],
+    field: &str,
+    idx: usize,
+    parse_value: impl FnOnce(&str) -> Option<T>,
+) -> Result<Option<T>, ManifestError> {
+    match lookup(obj, field) {
+        None => Ok(None),
+        Some(value) => {
+            let raw = json_as_str(value).ok_or_else(|| ManifestError::Schema {
+                reason: format!("capabilities[{idx}].{field} must be a string"),
+            })?;
+            parse_value(raw)
+                .map(Some)
+                .ok_or_else(|| ManifestError::Schema {
+                    reason: format!("capabilities[{idx}].{field} '{raw}' is not supported"),
+                })
+        }
+    }
+}
+
+fn validate_read_write_separation(capabilities: &[Capability]) -> Result<(), ManifestError> {
+    let rws_capabilities: Vec<_> = capabilities
+        .iter()
+        .map(Capability::to_read_write_capability)
+        .collect();
+    read_write_separation::validate_manifest(&rws_capabilities).map_err(ManifestError::from)
 }
 
 #[cfg(test)]
@@ -275,6 +351,135 @@ mod tests {
         let m = Manifest::load_from_str(json).unwrap();
         assert_eq!(m.capabilities().len(), 1);
         assert!(m.has(Category::Fs, Action::Read, "./grammars/json.tokens"));
+    }
+
+    #[test]
+    fn load_manifest_preserves_read_write_annotations() {
+        let json = r#"{
+            "version": 1,
+            "package": "rust/mail-ingest",
+            "capabilities": [
+                {
+                    "category": "net",
+                    "action": "connect",
+                    "target": "imap.example.test:993",
+                    "flavor": "ingestion",
+                    "trust": "untrusted",
+                    "justification": "read mail"
+                }
+            ]
+        }"#;
+
+        let m = Manifest::load_from_str(json).unwrap();
+        let cap = &m.capabilities()[0];
+
+        assert_eq!(cap.flavor, Some(CapabilityFlavor::Ingestion));
+        assert_eq!(cap.trust, Some(CapabilityTrust::Untrusted));
+        assert!(m.validate_read_write_separation().is_ok());
+    }
+
+    #[test]
+    fn load_manifest_rejects_unknown_read_write_annotations() {
+        let json = r#"{
+            "version": 1,
+            "capabilities": [
+                {
+                    "category": "net",
+                    "action": "connect",
+                    "target": "imap.example.test:993",
+                    "flavor": "read"
+                }
+            ]
+        }"#;
+
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::Schema { reason } => assert!(reason.contains("flavor")),
+            other => panic!("expected Schema error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_mixed_untrusted_input_and_actuation() {
+        let json = r#"{
+            "version": 1,
+            "package": "rust/mail-agent",
+            "capabilities": [
+                {
+                    "category": "net",
+                    "action": "connect",
+                    "target": "imap.example.test:993",
+                    "flavor": "ingestion",
+                    "trust": "untrusted",
+                    "justification": "read mail"
+                },
+                {
+                    "category": "fs",
+                    "action": "write",
+                    "target": "package:/state/outbox.json",
+                    "justification": "write outbox"
+                }
+            ]
+        }"#;
+
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::RwsViolation {
+                untrusted_inputs,
+                actuations,
+                message,
+            } => {
+                assert_eq!(untrusted_inputs.len(), 1);
+                assert_eq!(actuations.len(), 1);
+                assert!(message.contains("untrusted inputs"));
+            }
+            other => panic!("expected RwsViolation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_rejects_same_path_read_write_overlap() {
+        let json = r#"{
+            "version": 1,
+            "package": "rust/cache-agent",
+            "capabilities": [
+                {
+                    "category": "fs",
+                    "action": "read",
+                    "target": "package:/state/cache.json",
+                    "trust": "trusted"
+                },
+                {
+                    "category": "fs",
+                    "action": "write",
+                    "target": "package:/state/cache.json"
+                }
+            ]
+        }"#;
+
+        let err = Manifest::load_from_str(json).unwrap_err();
+        match err {
+            ManifestError::RwsViolation { message, .. } => assert!(message.contains("overlap")),
+            other => panic!("expected RwsViolation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_manifest_accepts_pure_actuation_default_net_connect() {
+        let json = r#"{
+            "version": 1,
+            "package": "rust/mail-send",
+            "capabilities": [
+                {
+                    "category": "net",
+                    "action": "connect",
+                    "target": "smtp.example.test:465"
+                }
+            ]
+        }"#;
+
+        let m = Manifest::load_from_str(json).unwrap();
+        assert_eq!(m.capabilities().len(), 1);
     }
 
     #[test]
@@ -367,5 +572,28 @@ mod tests {
     fn load_manifest_rejects_unparseable_json() {
         let err = Manifest::load_from_str("not json").unwrap_err();
         assert!(matches!(err, ManifestError::Parse(_)));
+    }
+
+    #[test]
+    fn try_new_rejects_programmatic_rws_violations() {
+        let input = Capability::new(
+            Category::Net,
+            Action::Connect,
+            "imap.example.test:993",
+            "read mail",
+        )
+        .unwrap()
+        .with_flavor(CapabilityFlavor::Ingestion)
+        .with_trust(CapabilityTrust::Untrusted);
+        let actuation = Capability::new(
+            Category::Fs,
+            Action::Write,
+            "package:/state/outbox.json",
+            "write",
+        )
+        .unwrap();
+
+        let err = Manifest::try_new(vec![input, actuation]).unwrap_err();
+        assert!(matches!(err, ManifestError::RwsViolation { .. }));
     }
 }


### PR DESCRIPTION
## Summary
- add optional `flavor` and `trust` annotations to capability-cage capabilities
- validate loaded manifests with the shared `read-write-separation` package
- surface RWS manifest violations and document the new manifest-load behavior

## Tests
- `cargo fmt --manifest-path code/packages/rust/Cargo.toml --package capability-cage`
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p capability-cage -p read-write-separation`
- `git diff --check`