### PR TITLE
[codex] Extend HTML tree smoke coverage through case 199

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -1295,7 +1295,7 @@ to = "rcdata_end_tag_name"
 actions = [
   "create_end_tag",
   "append_tag_name(current_lowercase)",
-  "append_temporary_buffer(current_lowercase)",
+  "append_temporary_buffer(current)",
 ]
 
 [[transitions]]
@@ -1312,7 +1312,7 @@ to = "rawtext_end_tag_name"
 actions = [
   "create_end_tag",
   "append_tag_name(current_lowercase)",
-  "append_temporary_buffer(current_lowercase)",
+  "append_temporary_buffer(current)",
 ]
 
 [[transitions]]
@@ -1329,7 +1329,7 @@ to = "script_data_end_tag_name"
 actions = [
   "create_end_tag",
   "append_tag_name(current_lowercase)",
-  "append_temporary_buffer(current_lowercase)",
+  "append_temporary_buffer(current)",
 ]
 
 [[transitions]]
@@ -1346,7 +1346,7 @@ to = "script_data_escaped_end_tag_name"
 actions = [
   "create_end_tag",
   "append_tag_name(current_lowercase)",
-  "append_temporary_buffer(current_lowercase)",
+  "append_temporary_buffer(current)",
 ]
 
 [[transitions]]
@@ -1405,11 +1405,31 @@ actions = [
 
 [[transitions]]
 from = "rcdata_end_tag_name"
-matcher = { anything = true }
+matcher = { range = ["A", "Z"] }
 to = "rcdata_end_tag_name"
 actions = [
   "append_tag_name(current_lowercase)",
-  "append_temporary_buffer(current_lowercase)",
+  "append_temporary_buffer(current)",
+]
+
+[[transitions]]
+from = "rcdata_end_tag_name"
+matcher = { range = ["a", "z"] }
+to = "rcdata_end_tag_name"
+actions = [
+  "append_tag_name(current_lowercase)",
+  "append_temporary_buffer(current)",
+]
+
+[[transitions]]
+from = "rcdata_end_tag_name"
+matcher = { anything = true }
+to = "rcdata"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
 ]
 
 [[transitions]]
@@ -1468,11 +1488,31 @@ actions = [
 
 [[transitions]]
 from = "rawtext_end_tag_name"
-matcher = { anything = true }
+matcher = { range = ["A", "Z"] }
 to = "rawtext_end_tag_name"
 actions = [
   "append_tag_name(current_lowercase)",
-  "append_temporary_buffer(current_lowercase)",
+  "append_temporary_buffer(current)",
+]
+
+[[transitions]]
+from = "rawtext_end_tag_name"
+matcher = { range = ["a", "z"] }
+to = "rawtext_end_tag_name"
+actions = [
+  "append_tag_name(current_lowercase)",
+  "append_temporary_buffer(current)",
+]
+
+[[transitions]]
+from = "rawtext_end_tag_name"
+matcher = { anything = true }
+to = "rawtext"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
 ]
 
 [[transitions]]
@@ -1531,11 +1571,31 @@ actions = [
 
 [[transitions]]
 from = "script_data_end_tag_name"
-matcher = { anything = true }
+matcher = { range = ["A", "Z"] }
 to = "script_data_end_tag_name"
 actions = [
   "append_tag_name(current_lowercase)",
-  "append_temporary_buffer(current_lowercase)",
+  "append_temporary_buffer(current)",
+]
+
+[[transitions]]
+from = "script_data_end_tag_name"
+matcher = { range = ["a", "z"] }
+to = "script_data_end_tag_name"
+actions = [
+  "append_tag_name(current_lowercase)",
+  "append_temporary_buffer(current)",
+]
+
+[[transitions]]
+from = "script_data_end_tag_name"
+matcher = { anything = true }
+to = "script_data"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
 ]
 
 [[transitions]]
@@ -1594,11 +1654,31 @@ actions = [
 
 [[transitions]]
 from = "script_data_escaped_end_tag_name"
-matcher = { anything = true }
+matcher = { range = ["A", "Z"] }
 to = "script_data_escaped_end_tag_name"
 actions = [
   "append_tag_name(current_lowercase)",
-  "append_temporary_buffer(current_lowercase)",
+  "append_temporary_buffer(current)",
+]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_name"
+matcher = { range = ["a", "z"] }
+to = "script_data_escaped_end_tag_name"
+actions = [
+  "append_tag_name(current_lowercase)",
+  "append_temporary_buffer(current)",
+]
+
+[[transitions]]
+from = "script_data_escaped_end_tag_name"
+matcher = { anything = true }
+to = "script_data_escaped"
+consume = false
+actions = [
+  "discard_current_token",
+  "append_text(</)",
+  "append_temporary_buffer_to_text",
 ]
 
 [[transitions]]
@@ -5773,7 +5853,6 @@ to = "done"
 consume = false
 actions = [
   "parse_error(eof-in-comment)",
-  "append_comment(--)",
   "emit_current_token",
   "emit(EOF)",
 ]

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -2997,7 +2997,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "create_end_tag".to_string(),
                 "append_tag_name(current_lowercase)".to_string(),
-                "append_temporary_buffer(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
         },
@@ -3031,7 +3031,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "create_end_tag".to_string(),
                 "append_tag_name(current_lowercase)".to_string(),
-                "append_temporary_buffer(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
         },
@@ -3065,7 +3065,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "create_end_tag".to_string(),
                 "append_tag_name(current_lowercase)".to_string(),
-                "append_temporary_buffer(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
         },
@@ -3099,7 +3099,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             actions: vec![
                 "create_end_tag".to_string(),
                 "append_tag_name(current_lowercase)".to_string(),
-                "append_temporary_buffer(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
         },
@@ -3228,7 +3228,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "rcdata_end_tag_name".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::Anything),
+            matcher: Some(MatcherDefinition::Range { start: "A".to_string(), end: "Z".to_string() }),
             to: vec![
                 "rcdata_end_tag_name".to_string(),
             ],
@@ -3237,9 +3237,42 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_tag_name(current_lowercase)".to_string(),
-                "append_temporary_buffer(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Range { start: "a".to_string(), end: "z".to_string() }),
+            to: vec![
+                "rcdata_end_tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_tag_name(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rcdata_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "rcdata".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+            ],
+            consume: false,
         },
         TransitionDefinition {
             from: "rawtext_end_tag_name".to_string(),
@@ -3366,7 +3399,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "rawtext_end_tag_name".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::Anything),
+            matcher: Some(MatcherDefinition::Range { start: "A".to_string(), end: "Z".to_string() }),
             to: vec![
                 "rawtext_end_tag_name".to_string(),
             ],
@@ -3375,9 +3408,42 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_tag_name(current_lowercase)".to_string(),
-                "append_temporary_buffer(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Range { start: "a".to_string(), end: "z".to_string() }),
+            to: vec![
+                "rawtext_end_tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_tag_name(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "rawtext_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "rawtext".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+            ],
+            consume: false,
         },
         TransitionDefinition {
             from: "script_data_end_tag_name".to_string(),
@@ -3504,7 +3570,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_end_tag_name".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::Anything),
+            matcher: Some(MatcherDefinition::Range { start: "A".to_string(), end: "Z".to_string() }),
             to: vec![
                 "script_data_end_tag_name".to_string(),
             ],
@@ -3513,9 +3579,42 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_tag_name(current_lowercase)".to_string(),
-                "append_temporary_buffer(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Range { start: "a".to_string(), end: "z".to_string() }),
+            to: vec![
+                "script_data_end_tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_tag_name(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "script_data".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+            ],
+            consume: false,
         },
         TransitionDefinition {
             from: "script_data_escaped_end_tag_name".to_string(),
@@ -3642,7 +3741,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
         TransitionDefinition {
             from: "script_data_escaped_end_tag_name".to_string(),
             on: None,
-            matcher: Some(MatcherDefinition::Anything),
+            matcher: Some(MatcherDefinition::Range { start: "A".to_string(), end: "Z".to_string() }),
             to: vec![
                 "script_data_escaped_end_tag_name".to_string(),
             ],
@@ -3651,9 +3750,42 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "append_tag_name(current_lowercase)".to_string(),
-                "append_temporary_buffer(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
             ],
             consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Range { start: "a".to_string(), end: "z".to_string() }),
+            to: vec![
+                "script_data_escaped_end_tag_name".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "append_tag_name(current_lowercase)".to_string(),
+                "append_temporary_buffer(current)".to_string(),
+            ],
+            consume: true,
+        },
+        TransitionDefinition {
+            from: "script_data_escaped_end_tag_name".to_string(),
+            on: None,
+            matcher: Some(MatcherDefinition::Anything),
+            to: vec![
+                "script_data_escaped".to_string(),
+            ],
+            guard: None,
+            stack_pop: None,
+            stack_push: Vec::new(),
+            actions: vec![
+                "discard_current_token".to_string(),
+                "append_text(</)".to_string(),
+                "append_temporary_buffer_to_text".to_string(),
+            ],
+            consume: false,
         },
         TransitionDefinition {
             from: "rcdata_end_tag_whitespace".to_string(),
@@ -12190,7 +12322,6 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-comment)".to_string(),
-                "append_comment(--)".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1922,6 +1922,16 @@ fn default_html_lexer_reports_recoverable_comment_eof_diagnostic() {
 }
 
 #[test]
+fn default_html_lexer_does_not_include_comment_end_dashes_at_eof() {
+    let tokens = lex_html("<!--x--").unwrap();
+
+    assert_eq!(
+        tokens,
+        vec![Token::Comment("x".to_string()), Token::Eof]
+    );
+}
+
+#[test]
 fn default_html_lexer_supports_seeded_rcdata_end_tags() {
     let mut lexer = create_html_lexer().unwrap();
     lexer.set_initial_state("rcdata").unwrap();
@@ -4871,6 +4881,10 @@ fn parser_facing_context_maps_script_and_plaintext_elements() {
             },
             Token::Eof
         ]
+    );
+    assert_eq!(
+        lex_html_fragment("X</SCRipt", &script).unwrap(),
+        vec![Token::Text("X</SCRipt".to_string()), Token::Eof]
     );
 
     let plaintext = HtmlLexContext::for_element_text("plaintext").unwrap();

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -10,7 +10,7 @@ use coding_adventures_html_lexer::{
     DoctypeSeed, HtmlLexContext, HtmlLexer, HtmlScriptingMode, HtmlTokenizerState, Token,
     TokenizerError,
 };
-use dom_core::{Attribute, Document, DocumentType, Node};
+use dom_core::{Attribute, Document, DocumentType, Element, Node};
 use std::fmt;
 
 /// Parser options that influence tokenizer handoff and tree construction.
@@ -707,7 +707,7 @@ pub fn parse_html_fragment_with_diagnostics_and_options(
 }
 
 /// Streaming-friendly parser core over already-tokenized HTML.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct HtmlParser {
     document: Document,
     open_elements: Vec<Vec<usize>>,
@@ -715,7 +715,23 @@ pub struct HtmlParser {
     prunable_empty_reconstructed_formatting_paths: Vec<Vec<usize>>,
     diagnostics: Vec<ParserDiagnostic>,
     options: HtmlParseOptions,
+    quirks_mode: bool,
     strip_next_leading_lf: bool,
+}
+
+impl Default for HtmlParser {
+    fn default() -> Self {
+        Self {
+            document: Document::new(),
+            open_elements: Vec::new(),
+            pending_formatting_reconstruction: Vec::new(),
+            prunable_empty_reconstructed_formatting_paths: Vec::new(),
+            diagnostics: Vec::new(),
+            options: HtmlParseOptions::default(),
+            quirks_mode: true,
+            strip_next_leading_lf: false,
+        }
+    }
 }
 
 impl HtmlParser {
@@ -752,6 +768,7 @@ impl HtmlParser {
             prunable_empty_reconstructed_formatting_paths: Vec::new(),
             diagnostics: Vec::new(),
             options,
+            quirks_mode: true,
             strip_next_leading_lf: false,
         }
     }
@@ -792,6 +809,14 @@ impl HtmlParser {
                         system_identifier,
                         force_quirks,
                     } => {
+                        if self.current_element_is("frameset") || self.has_document_type() {
+                            self.diagnostics.push(ParserDiagnostic::new(
+                                "unexpected-doctype",
+                                "doctype token outside the initial document position was ignored",
+                            ));
+                            return;
+                        }
+                        self.quirks_mode = force_quirks;
                         self.append_node(Node::DocumentType(DocumentType {
                             name,
                             public_identifier,
@@ -828,6 +853,30 @@ impl HtmlParser {
         let formatting_inside = self.take_formatting_reconstruction_inside_for(&name);
         self.apply_simple_implied_end_tags(&name);
 
+        if is_table_only_start_tag(&name) && !self.has_open_element("table") {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-table-start-tag",
+                format!("start tag `<{name}>` outside a table was ignored"),
+            ));
+            return;
+        }
+
+        if name == "col" && !self.current_element_is("colgroup") {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-col-start-tag",
+                "start tag `<col>` outside a column group was ignored",
+            ));
+            return;
+        }
+
+        if name == "frame" && !self.current_element_is("frameset") {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-frame-start-tag",
+                "start tag `<frame>` outside a frameset was ignored",
+            ));
+            return;
+        }
+
         let attributes: Vec<Attribute> = attributes
             .into_iter()
             .map(|attribute| Attribute {
@@ -835,6 +884,18 @@ impl HtmlParser {
                 value: attribute.value,
             })
             .collect();
+
+        if matches!(name.as_str(), "br" | "plaintext") && self.current_element_is_table_structure()
+        {
+            let acknowledges_self_closing = self_closing && is_void_element(&name);
+            let is_void = is_void_element(&name);
+            if let Some(path) = self.insert_node_before_open_table(Node::element(name.clone(), attributes)) {
+                if !acknowledges_self_closing && !is_void {
+                    self.open_elements.push(path);
+                }
+            }
+            return;
+        }
 
         if self.foster_formatting_start_in_table_context(&name, &attributes) {
             return;
@@ -914,6 +975,30 @@ impl HtmlParser {
         } else {
             text
         };
+        if text.is_empty() {
+            return;
+        }
+
+        if self.open_elements.is_empty()
+            && text.chars().all(char::is_whitespace)
+            && !self.document.children.iter().any(is_body_content_node)
+        {
+            return;
+        }
+
+        let text = if self.in_frameset_text_context() {
+            let whitespace = text
+                .chars()
+                .filter(|character| character.is_whitespace())
+                .collect::<String>();
+            if whitespace.is_empty() {
+                return;
+            }
+            whitespace
+        } else {
+            text
+        };
+
         if text.is_empty() {
             return;
         }
@@ -1236,6 +1321,12 @@ impl HtmlParser {
             "head" if !self.has_open_element("head") && !self.has_open_element("body") => {
                 self.strip_next_leading_lf = false;
             }
+            "body" if !self.has_open_element("body") && self.has_open_table_context() => {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-body-end-tag-in-table",
+                    "end tag `</body>` inside a table context was ignored",
+                ));
+            }
             "body" if !self.has_open_element("body") && !self.open_elements.is_empty() => {
                 self.open_elements.clear();
             }
@@ -1252,6 +1343,12 @@ impl HtmlParser {
                     format!("end tag `</{name}>` for a void element was ignored"),
                 ));
             }
+            "p" if self.has_open_element("head") && !self.has_open_element("body") => {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-p-end-tag-before-body",
+                    "end tag `</p>` before body content was ignored",
+                ));
+            }
             "p" if !self.has_open_element("p") => {
                 self.diagnostics.push(ParserDiagnostic::new(
                     "unexpected-p-end-tag",
@@ -1259,6 +1356,18 @@ impl HtmlParser {
                 ));
                 self.append_start_tag("p".to_string(), Vec::new(), false);
                 self.close_element("p");
+            }
+            "html" if self.has_open_element("head") && !self.has_open_element("body") => {
+                self.pop_current_if(|current| current == "head");
+                self.append_implied_element("body");
+            }
+            "li" => {
+                if !self.close_open_list_item_if_in_scope() {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "unexpected-li-end-tag",
+                        "end tag `</li>` did not match a list item in scope",
+                    ));
+                }
             }
             "html" => {
                 if self.has_open_element("html") {
@@ -1342,6 +1451,7 @@ impl HtmlParser {
                 self.close_open_element_if(|name| name == "caption" || name == "colgroup");
             }
             "col" => {
+                self.pop_table_cell_row_and_section_contexts();
                 self.close_open_element_if(|name| name == "caption");
                 if self.current_element_is("table") {
                     self.append_implied_element("colgroup");
@@ -1382,8 +1492,10 @@ impl HtmlParser {
         if incoming_name == "p" {
             self.close_open_element_if(|name| name == "p");
         } else if incoming_name == "li" {
+            self.close_open_element_if(|name| name == "p");
             self.close_open_list_item_if_in_scope();
         } else if incoming_name == "dt" || incoming_name == "dd" {
+            self.close_open_element_if(|name| name == "p");
             self.close_open_element_if(|name| name == "dt" || name == "dd");
         } else if incoming_name == "option" {
             self.close_open_element_if(|name| name == "option");
@@ -1400,8 +1512,11 @@ impl HtmlParser {
             self.close_open_element_if(|name| name == "rtc");
         } else if is_heading_element(incoming_name) {
             self.close_open_element_if(|name| name == "p");
-            self.close_open_element_if(is_heading_element);
+            self.close_open_heading_if_in_scope();
         } else if is_paragraph_boundary_element(incoming_name) {
+            if incoming_name == "table" && self.quirks_mode {
+                return;
+            }
             self.close_open_element_if(|name| name == "p");
         }
     }
@@ -1409,7 +1524,26 @@ impl HtmlParser {
     fn apply_interactive_implied_contexts(&mut self, incoming_name: &str) -> bool {
         match incoming_name {
             "a" => {
-                self.close_open_formatting_element_silently("a");
+                if self.current_empty_element_is("a")
+                    && !self.current_parent_element_is(|name| name == "p")
+                {
+                    return true;
+                }
+                let consumes_pending_anchor =
+                    !self.has_open_table_context() && !matches!(self.current_element_name(), Some("p"));
+                if consumes_pending_anchor {
+                    self.remove_pending_formatting_reconstruction("a");
+                }
+                let reconstruct_anchor_above_paragraph = self
+                    .current_element_is("p")
+                    .then(|| self.open_formatting_element_before_current("a"))
+                    .flatten();
+                if self.close_open_formatting_element_silently("a") && consumes_pending_anchor {
+                    self.remove_pending_formatting_reconstruction("a");
+                }
+                if let Some(formatting) = reconstruct_anchor_above_paragraph {
+                    self.pending_formatting_reconstruction.push(formatting);
+                }
                 false
             }
             "button" => {
@@ -1456,6 +1590,19 @@ impl HtmlParser {
         if self.open_elements.iter().skip(index + 1).any(|path| {
             element_at_path(&self.document, path).is_some_and(is_list_item_scope_boundary)
         }) {
+            return false;
+        }
+        self.open_elements.truncate(index);
+        true
+    }
+
+    fn close_open_heading_if_in_scope(&mut self) -> bool {
+        let Some(index) = self.open_elements.iter().rposition(|path| {
+            element_at_path(&self.document, path).is_some_and(is_heading_element)
+        }) else {
+            return false;
+        };
+        if self.has_table_context_above(index) {
             return false;
         }
         self.open_elements.truncate(index);
@@ -1514,6 +1661,26 @@ impl HtmlParser {
         if !formatting.is_empty() {
             self.pending_formatting_reconstruction = formatting;
         }
+    }
+
+    fn remove_pending_formatting_reconstruction(&mut self, name: &str) {
+        self.pending_formatting_reconstruction
+            .retain(|(candidate, _)| candidate != name);
+    }
+
+    fn open_formatting_element_before_current(
+        &self,
+        name: &str,
+    ) -> Option<(String, Vec<Attribute>)> {
+        let index = self
+            .open_elements
+            .iter()
+            .rposition(|path| element_at_path(&self.document, path).is_some_and(|n| n == name))?;
+        if index + 1 >= self.open_elements.len() {
+            return None;
+        }
+        let element = element_ref_at_path(&self.document, &self.open_elements[index])?;
+        Some((element.name.clone(), element.attributes.clone()))
     }
 
     fn is_empty_reconstructed_formatting_element(&self, path: &[usize]) -> bool {
@@ -1768,6 +1935,13 @@ impl HtmlParser {
             .any(|path| element_at_path(&self.document, path).is_some_and(|n| n == name))
     }
 
+    fn has_document_type(&self) -> bool {
+        self.document
+            .children
+            .iter()
+            .any(|node| matches!(node, Node::DocumentType(_)))
+    }
+
     fn has_table_context_above(&self, element_index: usize) -> bool {
         self.open_elements
             .iter()
@@ -1807,6 +1981,28 @@ impl HtmlParser {
             .is_some_and(|current| current == name)
     }
 
+    fn current_empty_element_is(&self, name: &str) -> bool {
+        self.open_elements
+            .last()
+            .and_then(|path| element_ref_at_path(&self.document, path))
+            .is_some_and(|element| {
+                element.name == name && element.attributes.is_empty() && element.children.is_empty()
+            })
+    }
+
+    fn current_parent_element_is(&self, predicate: impl FnOnce(&str) -> bool) -> bool {
+        let Some(path) = self.open_elements.last() else {
+            return false;
+        };
+        let Some((_, parent_path)) = path.split_last() else {
+            return false;
+        };
+        if parent_path.is_empty() {
+            return false;
+        }
+        element_at_path(&self.document, parent_path).is_some_and(predicate)
+    }
+
     fn current_element_is_table_structure(&self) -> bool {
         self.current_element_name().is_some_and(|current| {
             matches!(
@@ -1814,6 +2010,18 @@ impl HtmlParser {
                 "table" | "tbody" | "thead" | "tfoot" | "tr"
             )
         })
+    }
+
+    fn in_frameset_text_context(&self) -> bool {
+        if self.current_element_is("frameset") {
+            return true;
+        }
+        self.open_elements.is_empty()
+            && self
+                .document
+                .children
+                .last()
+                .is_some_and(|node| matches!(node, Node::Element(element) if element.name == "frameset"))
     }
 
     fn current_element_name(&self) -> Option<&str> {
@@ -2020,6 +2228,7 @@ struct DocumentShellBuilder {
     head_attributes: Vec<Attribute>,
     body_attributes: Vec<Attribute>,
     head_children: Vec<Node>,
+    pre_body_html_children: Vec<Node>,
     body_children: Vec<Node>,
     trailing_html_children: Vec<Node>,
 }
@@ -2029,7 +2238,9 @@ impl DocumentShellBuilder {
         match node {
             Node::Element(mut element) if element.name == "head" => {
                 self.head_attributes.extend(element.attributes);
-                self.head_children.append(&mut element.children);
+                for child in element.children.drain(..) {
+                    self.push_head_child(child);
+                }
             }
             Node::Element(mut element) if element.name == "body" => {
                 self.seen_body_content = true;
@@ -2039,6 +2250,9 @@ impl DocumentShellBuilder {
             }
             Node::Comment(_) if self.seen_body_content => {
                 self.trailing_html_children.push(node);
+            }
+            Node::Comment(_) if !self.seen_body_content => {
+                self.pre_body_html_children.push(node);
             }
             Node::Element(element)
                 if !self.seen_body_content && is_head_element(element.name.as_str()) =>
@@ -2067,6 +2281,9 @@ impl DocumentShellBuilder {
                 }
             }
             node => {
+                if !self.seen_body_element && !self.trailing_html_children.is_empty() {
+                    self.body_children.append(&mut self.trailing_html_children);
+                }
                 if !is_ignorable_before_body(&node) {
                     self.seen_body_content = true;
                 }
@@ -2080,6 +2297,18 @@ impl DocumentShellBuilder {
             existing.data.push_str(&text);
         } else {
             self.head_children.push(Node::text(text));
+        }
+    }
+
+    fn push_head_child(&mut self, node: Node) {
+        match node {
+            Node::Element(mut element) if element.name == "html" => {
+                self.html_attributes.extend(element.attributes);
+                for child in element.children.drain(..) {
+                    self.push_html_child(child);
+                }
+            }
+            node => self.head_children.push(node),
         }
     }
 
@@ -2102,10 +2331,20 @@ impl DocumentShellBuilder {
             unreachable!("Node::element always returns an element")
         };
         html_element.children.push(Node::Element(head));
-        html_element.children.push(Node::Element(body));
+        html_element.children.extend(self.pre_body_html_children);
+        html_element.children.extend(body_or_frameset_nodes(body));
         html_element.children.extend(self.trailing_html_children);
         html
     }
+}
+
+fn body_or_frameset_nodes(body: Element) -> Vec<Node> {
+    if body.attributes.is_empty()
+        && matches!(body.children.first(), Some(Node::Element(element)) if element.name == "frameset")
+    {
+        return body.children;
+    }
+    vec![Node::Element(body)]
 }
 
 fn is_head_element(name: &str) -> bool {
@@ -2136,6 +2375,14 @@ fn is_ignorable_before_body(node: &Node) -> bool {
     }
 }
 
+fn is_body_content_node(node: &Node) -> bool {
+    match node {
+        Node::DocumentType(_) | Node::Comment(_) => false,
+        Node::Text(text) => !text.data.chars().all(char::is_whitespace),
+        Node::Element(_) => true,
+    }
+}
+
 fn is_table_section(name: &str) -> bool {
     matches!(name, "tbody" | "thead" | "tfoot")
 }
@@ -2151,6 +2398,13 @@ fn starts_table_context(name: &str) -> bool {
     matches!(
         name,
         "caption" | "colgroup" | "col" | "tbody" | "thead" | "tfoot" | "tr" | "td" | "th"
+    )
+}
+
+fn is_table_only_start_tag(name: &str) -> bool {
+    matches!(
+        name,
+        "caption" | "colgroup" | "tbody" | "thead" | "tfoot" | "tr" | "td" | "th"
     )
 }
 
@@ -2255,6 +2509,7 @@ fn is_void_element(name: &str) -> bool {
             | "br"
             | "col"
             | "embed"
+            | "frame"
             | "hr"
             | "img"
             | "input"
@@ -2902,6 +3157,43 @@ mod tests {
     }
 
     #[test]
+    fn list_item_end_tags_do_not_cross_nested_list_boundaries() {
+        let document = parse_html("<ul><li><ul></li><li>a</li></ul></li></ul>").unwrap();
+
+        let outer_list = element(&body(&document).children[0]);
+        assert_eq!(outer_list.name, "ul");
+        assert_eq!(outer_list.children.len(), 1);
+
+        let outer_item = element(&outer_list.children[0]);
+        assert_eq!(outer_item.name, "li");
+        let inner_list = element(&outer_item.children[0]);
+        assert_eq!(inner_list.name, "ul");
+        assert_eq!(inner_list.children.len(), 1);
+
+        let inner_item = element(&inner_list.children[0]);
+        assert_eq!(inner_item.name, "li");
+        assert_eq!(inner_item.children, vec![Node::text("a")]);
+    }
+
+    #[test]
+    fn list_item_start_tags_close_open_paragraphs() {
+        let document = parse_html("<p><li>").unwrap();
+
+        let body = body(&document);
+        assert_eq!(element(&body.children[0]).name, "p");
+        assert_eq!(element(&body.children[1]).name, "li");
+    }
+
+    #[test]
+    fn definition_item_start_tags_close_open_paragraphs() {
+        let document = parse_html("<p><dt>").unwrap();
+
+        let body = body(&document);
+        assert_eq!(element(&body.children[0]).name, "p");
+        assert_eq!(element(&body.children[1]).name, "dt");
+    }
+
+    #[test]
     fn applies_ruby_annotation_implied_end_tags() {
         let document = parse_html(
             "<ruby><rb>漢<rt>kan<rb>字<rt>ji<rp>(fallback<rtc><rt>group<rtc><rt>group2</ruby>",
@@ -3015,9 +3307,24 @@ mod tests {
     }
 
     #[test]
+    fn heading_start_tags_do_not_close_ancestors_across_table_cells() {
+        let document = parse_html("<h1><table><td><h3></table><h3></h1>").unwrap();
+
+        let body = body(&document);
+        let heading = element(&body.children[0]);
+        assert_eq!(heading.name, "h1");
+
+        let table = element(&heading.children[0]);
+        let cell = element(&element(&element(&table.children[0]).children[0]).children[0]);
+        assert_eq!(element(&cell.children[0]).name, "h3");
+
+        assert_eq!(element(&body.children[1]).name, "h3");
+    }
+
+    #[test]
     fn closes_paragraphs_before_block_boundaries() {
         let document = parse_html(
-            "<p>Intro<div>Block</div><p>Items<ul><li>One</ul><p>Table<table><tr><td>A</table>",
+            "<!doctype html><p>Intro<div>Block</div><p>Items<ul><li>One</ul><p>Table<table><tr><td>A</table>",
         )
         .unwrap();
 
@@ -3052,6 +3359,15 @@ mod tests {
         let tbody = element(&table.children[0]);
         let row = element(&tbody.children[0]);
         assert_eq!(element(&row.children[0]).children, vec![Node::text("A")]);
+    }
+
+    #[test]
+    fn quirks_mode_keeps_tables_inside_open_paragraphs() {
+        let document = parse_html("<p><table></table>").unwrap();
+
+        let paragraph = element(&body(&document).children[0]);
+        assert_eq!(paragraph.name, "p");
+        assert_eq!(element(&paragraph.children[0]).name, "table");
     }
 
     #[test]
@@ -3175,6 +3491,30 @@ mod tests {
         let tbody = element(&table.children[1]);
         let row = element(&tbody.children[0]);
         assert_eq!(element(&row.children[0]).children, vec![Node::text("A")]);
+    }
+
+    #[test]
+    fn misplaced_table_columns_reopen_colgroups_from_table_contexts() {
+        let document =
+            parse_html("<table><col><tbody><col><tr><col><td><col></table><col>").unwrap();
+
+        let table = element(&body(&document).children[0]);
+        assert_eq!(table.children.len(), 7);
+
+        assert_eq!(element(&table.children[0]).name, "colgroup");
+        assert_eq!(element(&element(&table.children[0]).children[0]).name, "col");
+        assert_eq!(element(&table.children[1]).name, "tbody");
+        assert_eq!(element(&table.children[2]).name, "colgroup");
+        assert_eq!(element(&element(&table.children[2]).children[0]).name, "col");
+        assert_eq!(element(&table.children[3]).name, "tbody");
+        assert_eq!(element(&element(&table.children[3]).children[0]).name, "tr");
+        assert_eq!(element(&table.children[4]).name, "colgroup");
+        assert_eq!(element(&element(&table.children[4]).children[0]).name, "col");
+        assert_eq!(element(&table.children[5]).name, "tbody");
+        let cell = element(&element(&element(&table.children[5]).children[0]).children[0]);
+        assert_eq!(cell.name, "td");
+        assert_eq!(element(&table.children[6]).name, "colgroup");
+        assert_eq!(element(&element(&table.children[6]).children[0]).name, "col");
     }
 
     #[test]
@@ -3319,6 +3659,28 @@ mod tests {
         assert_eq!(trailing_anchor.name, "a");
         assert_eq!(trailing_anchor.attribute("href"), Some("blah"));
         assert_eq!(trailing_anchor.children, vec![Node::text("aoe")]);
+    }
+
+    #[test]
+    fn drops_pending_anchor_reconstruction_when_anchor_repeats_after_table() {
+        let document = parse_html("<a><table><a></table><p><a><div><a>").unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 3);
+
+        let outer_anchor = element(&body.children[0]);
+        assert_eq!(outer_anchor.name, "a");
+        assert_eq!(element(&outer_anchor.children[0]).name, "a");
+        assert_eq!(element(&outer_anchor.children[1]).name, "table");
+
+        let paragraph = element(&body.children[1]);
+        assert_eq!(paragraph.name, "p");
+        assert_eq!(element(&paragraph.children[0]).name, "a");
+
+        let div = element(&body.children[2]);
+        assert_eq!(div.name, "div");
+        assert_eq!(div.children.len(), 1);
+        assert_eq!(element(&div.children[0]).name, "a");
     }
 
     #[test]
@@ -3583,6 +3945,114 @@ mod tests {
     }
 
     #[test]
+    fn top_level_frameset_replaces_implied_body_and_frame_is_void() {
+        let document =
+            parse_html("<frameset><frame><frameset><frame></frameset><noframes></noframes></frameset>")
+                .unwrap();
+
+        let html = html(&document);
+        assert_eq!(html.children.len(), 2);
+        assert_eq!(element(&html.children[0]).name, "head");
+
+        let frameset = element(&html.children[1]);
+        assert_eq!(frameset.name, "frameset");
+        assert_eq!(frameset.children.len(), 3);
+        assert_eq!(element(&frameset.children[0]).name, "frame");
+        let nested_frameset = element(&frameset.children[1]);
+        assert_eq!(nested_frameset.name, "frameset");
+        assert_eq!(element(&nested_frameset.children[0]).name, "frame");
+        assert_eq!(element(&frameset.children[2]).name, "noframes");
+    }
+
+    #[test]
+    fn ignores_frame_start_tags_outside_framesets() {
+        let document = parse_html("<frame>test").unwrap();
+
+        assert_eq!(body(&document).children, vec![Node::text("test")]);
+    }
+
+    #[test]
+    fn ignores_non_whitespace_text_directly_inside_framesets() {
+        let document = parse_html("<!DOCTYPE html><frameset>test").unwrap();
+
+        let html = html(&document);
+        let frameset = element(&html.children[1]);
+        assert_eq!(frameset.name, "frameset");
+        assert!(frameset.children.is_empty());
+    }
+
+    #[test]
+    fn preserves_only_whitespace_from_mixed_frameset_text() {
+        let document = parse_html("<!DOCTYPE html><frameset> te st").unwrap();
+
+        let html = html(&document);
+        let frameset = element(&html.children[1]);
+        assert_eq!(frameset.children, vec![Node::text("  ")]);
+    }
+
+    #[test]
+    fn top_level_frameset_keeps_filtered_trailing_html_text() {
+        let document = parse_html("<!DOCTYPE html><frameset></frameset> te st").unwrap();
+
+        let html = html(&document);
+        assert_eq!(element(&html.children[1]).name, "frameset");
+        assert_eq!(html.children[2], Node::text("  "));
+    }
+
+    #[test]
+    fn ignores_doctype_tokens_inside_framesets() {
+        let document = parse_html("<!DOCTYPE html><frameset><!DOCTYPE html>").unwrap();
+
+        let html = html(&document);
+        let frameset = element(&html.children[1]);
+        assert!(frameset.children.is_empty());
+    }
+
+    #[test]
+    fn ignores_before_html_whitespace_and_duplicate_doctype() {
+        let document = parse_html("<!DOCTYPE html> <!DOCTYPE html>").unwrap();
+
+        assert_eq!(document.children.len(), 2);
+        assert!(matches!(document.children[0], Node::DocumentType(_)));
+        assert!(body(&document).children.is_empty());
+    }
+
+    #[test]
+    fn merges_html_start_tags_seen_inside_head() {
+        let document = parse_html("<!DOCTYPE html><head><html id=x>").unwrap();
+
+        assert_eq!(html(&document).attribute("id"), Some("x"));
+        assert!(head(&document).children.is_empty());
+    }
+
+    #[test]
+    fn keeps_trailing_whitespace_after_html_end_when_body_has_text() {
+        let document = parse_html("<!DOCTYPE html>X</html> ").unwrap();
+
+        assert_eq!(body(&document).children, vec![Node::text("X ")]);
+    }
+
+    #[test]
+    fn keeps_comments_in_source_order_for_implicit_body_content() {
+        let document = parse_html("><!--<!--x-->-->").unwrap();
+
+        assert_eq!(body(&document).children[0], Node::text(">"));
+        assert!(matches!(body(&document).children[1], Node::Comment(_)));
+        assert_eq!(body(&document).children[2], Node::text("-->"));
+    }
+
+    #[test]
+    fn keeps_comments_after_head_before_body_at_html_level() {
+        let document = parse_html("<head></head><!-- --><style></style><!-- --><script></script>").unwrap();
+
+        let html = html(&document);
+        assert_eq!(element(&html.children[0]).name, "head");
+        assert!(matches!(html.children[1], Node::Comment(_)));
+        assert!(matches!(html.children[2], Node::Comment(_)));
+        assert_eq!(element(&html.children[3]).name, "body");
+    }
+
+    #[test]
     fn treats_legacy_image_start_tag_as_img() {
         let output = parse_html_with_diagnostics("<p><image src=hero.png></p>").unwrap();
 
@@ -3633,6 +4103,26 @@ mod tests {
                 "non-void-html-element-self-closing",
             ]
         );
+    }
+
+    #[test]
+    fn fosters_recovered_br_end_tag_before_table_rows() {
+        let document = parse_html("<table><tr></body></br></table>").unwrap();
+
+        let body = body(&document);
+        assert_eq!(element(&body.children[0]).name, "br");
+        assert_eq!(element(&body.children[1]).name, "table");
+    }
+
+    #[test]
+    fn fosters_plaintext_before_table_context_and_keeps_it_open() {
+        let document = parse_html("<table><plaintext><td>").unwrap();
+
+        let body = body(&document);
+        let plaintext = element(&body.children[0]);
+        assert_eq!(plaintext.name, "plaintext");
+        assert_eq!(plaintext.children, vec![Node::text("<td>")]);
+        assert_eq!(element(&body.children[1]).name, "table");
     }
 
     #[test]
@@ -4527,6 +5017,37 @@ mod tests {
             element(&body(&document).children[0]).children,
             vec![Node::text("Hello Mosaic")]
         );
+    }
+
+    #[test]
+    fn ignores_stray_paragraph_end_tag_before_body_starts() {
+        let output = parse_html_with_diagnostics("<head></p><meta><p>").unwrap();
+
+        let head = head(&output.document);
+        assert_eq!(head.children.len(), 1);
+        assert_eq!(element(&head.children[0]).name, "meta");
+
+        let body = body(&output.document);
+        assert_eq!(body.children.len(), 1);
+        assert_eq!(element(&body.children[0]).name, "p");
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-p-end-tag-before-body",
+                "end tag `</p>` before body content was ignored"
+            )]
+        );
+    }
+
+    #[test]
+    fn html_end_tag_in_head_moves_following_head_elements_to_body() {
+        let document = parse_html("<head></html><meta><p>").unwrap();
+
+        assert!(head(&document).children.is_empty());
+        let body = body(&document);
+        assert_eq!(body.children.len(), 2);
+        assert_eq!(element(&body.children[0]).name, "meta");
+        assert_eq!(element(&body.children[1]).name, "p");
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -1384,3 +1384,1713 @@ Line1<br>Line2<br>Line3<br>Line4
 |   <body>
 |     <p>
 |       <img>
+
+#data
+<a><table><a></table><p><a><div><a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,13): unexpected-start-tag-implies-table-voodoo
+(1,13): unexpected-start-tag-implies-end-tag
+(1,13): adoption-agency-1.3
+(1,27): unexpected-start-tag-implies-end-tag
+(1,27): adoption-agency-1.2
+(1,32): unexpected-end-tag
+(1,35): unexpected-start-tag-implies-end-tag
+(1,35): adoption-agency-1.2
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       <a>
+|       <table>
+|     <p>
+|       <a>
+|     <div>
+|       <a>
+
+#data
+<head></p><meta><p>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,10): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|     <meta>
+|   <body>
+|     <p>
+
+#data
+<head></html><meta><p>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,19): expected-eof-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <meta>
+|     <p>
+
+#data
+<b><table><td></b><i></table>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,14): unexpected-cell-in-table-body
+(1,18): unexpected-end-tag
+(1,29): unexpected-cell-end-tag
+(1,29): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|       <table>
+|         <tbody>
+|           <tr>
+|             <td>
+|               <i>
+
+#data
+<h1><h2>
+#errors
+(1,4): expected-doctype-but-got-start-tag
+(1,8): unexpected-start-tag
+(1,8): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <h1>
+|     <h2>
+
+#data
+<a><p><a></a></p></a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,9): unexpected-start-tag-implies-end-tag
+(1,9): adoption-agency-1.3
+(1,21): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|     <p>
+|       <a>
+|       <a>
+
+#data
+<b><button></b></button></b>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,15): adoption-agency-1.3
+(1,28): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|     <button>
+|       <b>
+
+#data
+<p><b><div><marquee></p></b></div>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,11): unexpected-end-tag
+(1,24): unexpected-end-tag
+(1,28): unexpected-end-tag
+(1,34): end-tag-too-early
+(1,34): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <b>
+|     <div>
+|       <b>
+|         <marquee>
+|           <p>
+
+#data
+<script></script></div><title></title><p><p>
+#errors
+(1,8): expected-doctype-but-got-start-tag
+(1,23): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|     <script>
+|     <title>
+|   <body>
+|     <p>
+|     <p>
+
+#data
+<select><b><option><select><option></b></select>
+#errors
+1:1: ERROR: Expected a doctype token
+1:20: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, b, option.
+1:36: ERROR: End tag 'b' isn't allowed here. Currently open tags: html, body, b, select, option.
+1:49: ERROR: Premature end of file. Currently open tags: html, body, b.
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <b>
+|         <option>
+|     <b>
+|       <option>
+
+#data
+<html><head><title></title><body></body></html>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|     <title>
+|   <body>
+
+#data
+<a><table><td><a><table></table><a></tr><a></table><a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,14): unexpected-cell-in-table-body
+(1,35): unexpected-start-tag-implies-end-tag
+(1,40): unexpected-cell-end-tag
+(1,43): unexpected-start-tag-implies-table-voodoo
+(1,43): unexpected-start-tag-implies-end-tag
+(1,43): unexpected-end-tag
+(1,54): unexpected-start-tag-implies-end-tag
+(1,54): adoption-agency-1.2
+(1,54): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       <a>
+|       <table>
+|         <tbody>
+|           <tr>
+|             <td>
+|               <a>
+|                 <table>
+|               <a>
+|     <a>
+
+#data
+<ul><li></li><div><li></div><li><li><div><li><address><li><b><em></b><li></ul>
+#errors
+(1,4): expected-doctype-but-got-start-tag
+(1,45): end-tag-too-early
+(1,58): end-tag-too-early
+(1,69): adoption-agency-1.3
+#document
+| <html>
+|   <head>
+|   <body>
+|     <ul>
+|       <li>
+|       <div>
+|         <li>
+|       <li>
+|       <li>
+|         <div>
+|       <li>
+|         <address>
+|       <li>
+|         <b>
+|           <em>
+|       <li>
+
+#data
+<ul><li><ul></li><li>a</li></ul></li></ul>
+#errors
+(1,4): expected-doctype-but-got-start-tag
+(1,17): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <ul>
+|       <li>
+|         <ul>
+|           <li>
+|             "a"
+
+#data
+<frameset><frame><frameset><frame></frameset><noframes></noframes></frameset>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <frameset>
+|     <frame>
+|     <frameset>
+|       <frame>
+|     <noframes>
+
+#data
+<h1><table><td><h3></table><h3></h1>
+#errors
+(1,4): expected-doctype-but-got-start-tag
+(1,15): unexpected-cell-in-table-body
+(1,27): unexpected-cell-end-tag
+(1,31): unexpected-start-tag
+(1,36): end-tag-too-early
+#document
+| <html>
+|   <head>
+|   <body>
+|     <h1>
+|       <table>
+|         <tbody>
+|           <tr>
+|             <td>
+|               <h3>
+|     <h3>
+
+#data
+<table><colgroup><col><colgroup><col><col><col><colgroup><col><col><thead><tr><td></table>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <colgroup>
+|         <col>
+|       <colgroup>
+|         <col>
+|         <col>
+|         <col>
+|       <colgroup>
+|         <col>
+|         <col>
+|       <thead>
+|         <tr>
+|           <td>
+
+#data
+<table><col><tbody><col><tr><col><td><col></table><col>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,37): unexpected-cell-in-table-body
+(1,55): unexpected-start-tag-ignored
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <colgroup>
+|         <col>
+|       <tbody>
+|       <colgroup>
+|         <col>
+|       <tbody>
+|         <tr>
+|       <colgroup>
+|         <col>
+|       <tbody>
+|         <tr>
+|           <td>
+|       <colgroup>
+|         <col>
+
+#data
+<table><colgroup><tbody><colgroup><tr><colgroup><td><colgroup></table><colgroup>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,52): unexpected-cell-in-table-body
+(1,80): unexpected-start-tag-ignored
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <colgroup>
+|       <tbody>
+|       <colgroup>
+|       <tbody>
+|         <tr>
+|       <colgroup>
+|       <tbody>
+|         <tr>
+|           <td>
+|       <colgroup>
+
+#data
+</strong></b></em></i></u></strike></s></blink></tt></pre></big></small></font></select></h1></h2></h3></h4></h5></h6></body></br></a></img></title></span></style></script></table></th></td></tr></frame></area></link></param></hr></input></col></base></meta></basefont></bgsound></embed></spacer></p></dd></dt></caption></colgroup></tbody></tfoot></thead></address></blockquote></center></dir></div></dl></fieldset></listing></menu></ol></ul></li></nobr></wbr></form></button></marquee></object></html></frameset></head></iframe></image></isindex></noembed></noframes></noscript></optgroup></option></plaintext></textarea>
+#errors
+(1,9): expected-doctype-but-got-end-tag
+(1,9): unexpected-end-tag-before-html
+(1,13): unexpected-end-tag-before-html
+(1,18): unexpected-end-tag-before-html
+(1,22): unexpected-end-tag-before-html
+(1,26): unexpected-end-tag-before-html
+(1,35): unexpected-end-tag-before-html
+(1,39): unexpected-end-tag-before-html
+(1,47): unexpected-end-tag-before-html
+(1,52): unexpected-end-tag-before-html
+(1,58): unexpected-end-tag-before-html
+(1,64): unexpected-end-tag-before-html
+(1,72): unexpected-end-tag-before-html
+(1,79): unexpected-end-tag-before-html
+(1,88): unexpected-end-tag-before-html
+(1,93): unexpected-end-tag-before-html
+(1,98): unexpected-end-tag-before-html
+(1,103): unexpected-end-tag-before-html
+(1,108): unexpected-end-tag-before-html
+(1,113): unexpected-end-tag-before-html
+(1,118): unexpected-end-tag-before-html
+(1,130): unexpected-end-tag-after-body
+(1,130): unexpected-end-tag-treated-as
+(1,134): unexpected-end-tag
+(1,140): unexpected-end-tag
+(1,148): unexpected-end-tag
+(1,155): unexpected-end-tag
+(1,163): unexpected-end-tag
+(1,172): unexpected-end-tag
+(1,180): unexpected-end-tag
+(1,185): unexpected-end-tag
+(1,190): unexpected-end-tag
+(1,195): unexpected-end-tag
+(1,203): unexpected-end-tag
+(1,210): unexpected-end-tag
+(1,217): unexpected-end-tag
+(1,225): unexpected-end-tag
+(1,230): unexpected-end-tag
+(1,238): unexpected-end-tag
+(1,244): unexpected-end-tag
+(1,251): unexpected-end-tag
+(1,258): unexpected-end-tag
+(1,269): unexpected-end-tag
+(1,279): unexpected-end-tag
+(1,287): unexpected-end-tag
+(1,296): unexpected-end-tag
+(1,300): unexpected-end-tag
+(1,305): unexpected-end-tag
+(1,310): unexpected-end-tag
+(1,320): unexpected-end-tag
+(1,331): unexpected-end-tag
+(1,339): unexpected-end-tag
+(1,347): unexpected-end-tag
+(1,355): unexpected-end-tag
+(1,365): end-tag-too-early
+(1,378): end-tag-too-early
+(1,387): end-tag-too-early
+(1,393): end-tag-too-early
+(1,399): end-tag-too-early
+(1,404): end-tag-too-early
+(1,415): end-tag-too-early
+(1,425): end-tag-too-early
+(1,432): end-tag-too-early
+(1,437): end-tag-too-early
+(1,442): end-tag-too-early
+(1,447): unexpected-end-tag
+(1,454): unexpected-end-tag
+(1,460): unexpected-end-tag
+(1,467): unexpected-end-tag
+(1,476): end-tag-too-early
+(1,486): end-tag-too-early
+(1,495): end-tag-too-early
+(1,513): expected-eof-but-got-end-tag
+(1,513): unexpected-end-tag
+(1,520): unexpected-end-tag
+(1,529): unexpected-end-tag
+(1,537): unexpected-end-tag
+(1,547): unexpected-end-tag
+(1,557): unexpected-end-tag
+(1,568): unexpected-end-tag
+(1,579): unexpected-end-tag
+(1,590): unexpected-end-tag
+(1,599): unexpected-end-tag
+(1,611): unexpected-end-tag
+(1,622): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <br>
+|     <p>
+
+#data
+<table><tr></strong></b></em></i></u></strike></s></blink></tt></pre></big></small></font></select></h1></h2></h3></h4></h5></h6></body></br></a></img></title></span></style></script></table></th></td></tr></frame></area></link></param></hr></input></col></base></meta></basefont></bgsound></embed></spacer></p></dd></dt></caption></colgroup></tbody></tfoot></thead></address></blockquote></center></dir></div></dl></fieldset></listing></menu></ol></ul></li></nobr></wbr></form></button></marquee></object></html></frameset></head></iframe></image></isindex></noembed></noframes></noscript></optgroup></option></plaintext></textarea>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,20): unexpected-end-tag-implies-table-voodoo
+(1,20): unexpected-end-tag
+(1,24): unexpected-end-tag-implies-table-voodoo
+(1,24): unexpected-end-tag
+(1,29): unexpected-end-tag-implies-table-voodoo
+(1,29): unexpected-end-tag
+(1,33): unexpected-end-tag-implies-table-voodoo
+(1,33): unexpected-end-tag
+(1,37): unexpected-end-tag-implies-table-voodoo
+(1,37): unexpected-end-tag
+(1,46): unexpected-end-tag-implies-table-voodoo
+(1,46): unexpected-end-tag
+(1,50): unexpected-end-tag-implies-table-voodoo
+(1,50): unexpected-end-tag
+(1,58): unexpected-end-tag-implies-table-voodoo
+(1,58): unexpected-end-tag
+(1,63): unexpected-end-tag-implies-table-voodoo
+(1,63): unexpected-end-tag
+(1,69): unexpected-end-tag-implies-table-voodoo
+(1,69): end-tag-too-early
+(1,75): unexpected-end-tag-implies-table-voodoo
+(1,75): unexpected-end-tag
+(1,83): unexpected-end-tag-implies-table-voodoo
+(1,83): unexpected-end-tag
+(1,90): unexpected-end-tag-implies-table-voodoo
+(1,90): unexpected-end-tag
+(1,99): unexpected-end-tag-implies-table-voodoo
+(1,99): unexpected-end-tag
+(1,104): unexpected-end-tag-implies-table-voodoo
+(1,104): end-tag-too-early
+(1,109): unexpected-end-tag-implies-table-voodoo
+(1,109): end-tag-too-early
+(1,114): unexpected-end-tag-implies-table-voodoo
+(1,114): end-tag-too-early
+(1,119): unexpected-end-tag-implies-table-voodoo
+(1,119): end-tag-too-early
+(1,124): unexpected-end-tag-implies-table-voodoo
+(1,124): end-tag-too-early
+(1,129): unexpected-end-tag-implies-table-voodoo
+(1,129): end-tag-too-early
+(1,136): unexpected-end-tag-in-table-row
+(1,141): unexpected-end-tag-implies-table-voodoo
+(1,141): unexpected-end-tag-treated-as
+(1,145): unexpected-end-tag-implies-table-voodoo
+(1,145): unexpected-end-tag
+(1,151): unexpected-end-tag-implies-table-voodoo
+(1,151): unexpected-end-tag
+(1,159): unexpected-end-tag-implies-table-voodoo
+(1,159): unexpected-end-tag
+(1,166): unexpected-end-tag-implies-table-voodoo
+(1,166): unexpected-end-tag
+(1,174): unexpected-end-tag-implies-table-voodoo
+(1,174): unexpected-end-tag
+(1,183): unexpected-end-tag-implies-table-voodoo
+(1,183): unexpected-end-tag
+(1,196): unexpected-end-tag
+(1,201): unexpected-end-tag
+(1,206): unexpected-end-tag
+(1,214): unexpected-end-tag
+(1,221): unexpected-end-tag
+(1,228): unexpected-end-tag
+(1,236): unexpected-end-tag
+(1,241): unexpected-end-tag
+(1,249): unexpected-end-tag
+(1,255): unexpected-end-tag
+(1,262): unexpected-end-tag
+(1,269): unexpected-end-tag
+(1,280): unexpected-end-tag
+(1,290): unexpected-end-tag
+(1,298): unexpected-end-tag
+(1,307): unexpected-end-tag
+(1,311): unexpected-end-tag
+(1,316): unexpected-end-tag
+(1,321): unexpected-end-tag
+(1,331): unexpected-end-tag
+(1,342): unexpected-end-tag
+(1,350): unexpected-end-tag
+(1,358): unexpected-end-tag
+(1,366): unexpected-end-tag
+(1,376): end-tag-too-early
+(1,389): end-tag-too-early
+(1,398): end-tag-too-early
+(1,404): end-tag-too-early
+(1,410): end-tag-too-early
+(1,415): end-tag-too-early
+(1,426): end-tag-too-early
+(1,436): end-tag-too-early
+(1,443): end-tag-too-early
+(1,448): end-tag-too-early
+(1,453): end-tag-too-early
+(1,458): unexpected-end-tag
+(1,465): unexpected-end-tag
+(1,471): unexpected-end-tag
+(1,478): unexpected-end-tag
+(1,487): end-tag-too-early
+(1,497): end-tag-too-early
+(1,506): end-tag-too-early
+(1,524): expected-eof-but-got-end-tag
+(1,524): unexpected-end-tag
+(1,531): unexpected-end-tag
+(1,540): unexpected-end-tag
+(1,548): unexpected-end-tag
+(1,558): unexpected-end-tag
+(1,568): unexpected-end-tag
+(1,579): unexpected-end-tag
+(1,590): unexpected-end-tag
+(1,601): unexpected-end-tag
+(1,610): unexpected-end-tag
+(1,622): unexpected-end-tag
+(1,633): unexpected-end-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <br>
+|     <table>
+|       <tbody>
+|         <tr>
+|     <p>
+
+#data
+<frameset>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(1,10): eof-in-frameset
+#document
+| <html>
+|   <head>
+|   <frameset>
+
+#data
+<!DOCTYPE html>Test
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "Test"
+
+#data
+<textarea>test</div>test
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(1,24): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+|       "test</div>test"
+
+#data
+<table><td>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,11): unexpected-cell-in-table-body
+(1,11): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+
+#data
+<table><td>test</tbody></table>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,11): unexpected-cell-in-table-body
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+|             "test"
+
+#data
+<frame>test
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,7): unexpected-start-tag-ignored
+#document
+| <html>
+|   <head>
+|   <body>
+|     "test"
+
+#data
+<!DOCTYPE html><frameset>test
+#errors
+(1,29): unexpected-char-in-frameset
+(1,29): unexpected-char-in-frameset
+(1,29): unexpected-char-in-frameset
+(1,29): unexpected-char-in-frameset
+(1,29): eof-in-frameset
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <frameset>
+
+#data
+<!DOCTYPE html><frameset> te st
+#errors
+(1,29): unexpected-char-in-frameset
+(1,29): unexpected-char-in-frameset
+(1,29): unexpected-char-in-frameset
+(1,29): unexpected-char-in-frameset
+(1,29): eof-in-frameset
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <frameset>
+|     "  "
+
+#data
+<!DOCTYPE html><frameset></frameset> te st
+#errors
+(1,29): unexpected-char-after-frameset
+(1,29): unexpected-char-after-frameset
+(1,29): unexpected-char-after-frameset
+(1,29): unexpected-char-after-frameset
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <frameset>
+|   "  "
+
+#data
+<!DOCTYPE html><frameset><!DOCTYPE html>
+#errors
+(1,40): unexpected-doctype
+(1,40): eof-in-frameset
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <frameset>
+
+#data
+<!DOCTYPE html><font><p><b>test</font>
+#errors
+(1,38): adoption-agency-1.3
+(1,38): adoption-agency-1.3
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <font>
+|     <p>
+|       <font>
+|         <b>
+|           "test"
+
+#data
+<!DOCTYPE html><dt><div><dd>
+#errors
+(1,28): end-tag-too-early
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <dt>
+|       <div>
+|     <dd>
+
+#data
+<script></x
+#errors
+(1,8): expected-doctype-but-got-start-tag
+(1,11): expected-named-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|     <script>
+|       "</x"
+|   <body>
+
+#data
+<table><plaintext><td>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,18): unexpected-start-tag-implies-table-voodoo
+(1,22): foster-parenting-character-in-table
+(1,22): foster-parenting-character-in-table
+(1,22): foster-parenting-character-in-table
+(1,22): foster-parenting-character-in-table
+(1,22): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <plaintext>
+|       "<td>"
+|     <table>
+
+#data
+<plaintext></plaintext>
+#errors
+(1,11): expected-doctype-but-got-start-tag
+(1,23): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <plaintext>
+|       "</plaintext>"
+
+#data
+<!DOCTYPE html><table><tr>TEST
+#errors
+(1,30): foster-parenting-character-in-table
+(1,30): foster-parenting-character-in-table
+(1,30): foster-parenting-character-in-table
+(1,30): foster-parenting-character-in-table
+(1,30): eof-in-table
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "TEST"
+|     <table>
+|       <tbody>
+|         <tr>
+
+#data
+<!DOCTYPE html><body t1=1><body t2=2><body t3=3 t4=4>
+#errors
+(1,37): unexpected-start-tag
+(1,53): unexpected-start-tag
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     t1="1"
+|     t2="2"
+|     t3="3"
+|     t4="4"
+
+#data
+</b test
+#errors
+(1,8): eof-in-attribute-name
+(1,8): expected-doctype-but-got-eof
+#new-errors
+(1:9) eof-in-tag
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html></b test<b &=&amp>X
+#errors
+(1,24): invalid-character-in-attribute-name
+(1,32): named-entity-without-semicolon
+(1,33): attributes-in-end-tag
+(1,33): unexpected-end-tag-before-html
+#new-errors
+(1:24) unexpected-character-in-attribute-name
+(1:33) missing-semicolon-after-character-reference
+(1:33) end-tag-with-attributes
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "X"
+
+#data
+<!doctypehtml><scrIPt type=text/x-foobar;baz>X</SCRipt
+#errors
+(1,9): need-space-after-doctype
+(1,54): expected-named-closing-tag-but-got-eof
+#new-errors
+(1:10) missing-whitespace-before-doctype-name
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <script>
+|       type="text/x-foobar;baz"
+|       "X</SCRipt"
+|   <body>
+
+#data
+&
+#errors
+(1,1): expected-doctype-but-got-chars
+#document
+| <html>
+|   <head>
+|   <body>
+|     "&"
+
+#data
+&#
+#errors
+(1,2): expected-numeric-entity
+(1,2): expected-doctype-but-got-chars
+#new-errors
+(1:3) absence-of-digits-in-numeric-character-reference
+#document
+| <html>
+|   <head>
+|   <body>
+|     "&#"
+
+#data
+&#X
+#errors
+(1,3): expected-numeric-entity
+(1,3): expected-doctype-but-got-chars
+#new-errors
+(1:4) absence-of-digits-in-numeric-character-reference
+#document
+| <html>
+|   <head>
+|   <body>
+|     "&#X"
+
+#data
+&#x
+#errors
+(1,3): expected-numeric-entity
+(1,3): expected-doctype-but-got-chars
+#new-errors
+(1:4) absence-of-digits-in-numeric-character-reference
+#document
+| <html>
+|   <head>
+|   <body>
+|     "&#x"
+
+#data
+&#45
+#errors
+(1,4): numeric-entity-without-semicolon
+(1,4): expected-doctype-but-got-chars
+#new-errors
+(1:5) missing-semicolon-after-character-reference
+#document
+| <html>
+|   <head>
+|   <body>
+|     "-"
+
+#data
+&x-test
+#errors
+(1,2): expected-doctype-but-got-chars
+#document
+| <html>
+|   <head>
+|   <body>
+|     "&x-test"
+
+#data
+<!doctypehtml><p><li>
+#errors
+(1,9): need-space-after-doctype
+#new-errors
+(1:10) missing-whitespace-before-doctype-name
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <li>
+
+#data
+<!doctypehtml><p><dt>
+#errors
+(1,9): need-space-after-doctype
+#new-errors
+(1:10) missing-whitespace-before-doctype-name
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <dt>
+
+#data
+<!doctypehtml><p><dd>
+#errors
+(1,9): need-space-after-doctype
+#new-errors
+(1:10) missing-whitespace-before-doctype-name
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <dd>
+
+#data
+<!doctypehtml><p><form>
+#errors
+(1,9): need-space-after-doctype
+(1,23): expected-closing-tag-but-got-eof
+#new-errors
+(1:10) missing-whitespace-before-doctype-name
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <form>
+
+#data
+<!DOCTYPE html><p></P>X
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     "X"
+
+#data
+&AMP
+#errors
+(1,4): named-entity-without-semicolon
+(1,4): expected-doctype-but-got-chars
+#new-errors
+(1:5) missing-semicolon-after-character-reference
+#document
+| <html>
+|   <head>
+|   <body>
+|     "&"
+
+#data
+&AMp;
+#errors
+(1,3): expected-named-entity
+(1,3): expected-doctype-but-got-chars
+#new-errors
+(1:5) unknown-named-character-reference
+#document
+| <html>
+|   <head>
+|   <body>
+|     "&AMp;"
+
+#data
+<!DOCTYPE html><html><head></head><body><thisISasillyTESTelementNameToMakeSureCrazyTagNamesArePARSEDcorrectLY>
+#errors
+(1,110): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <thisisasillytestelementnametomakesurecrazytagnamesareparsedcorrectly>
+
+#data
+<!DOCTYPE html>X</body>X
+#errors
+(1,24): unexpected-char-after-body
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "XX"
+
+#data
+<!DOCTYPE html><!-- X
+#errors
+(1,21): eof-in-comment
+#new-errors
+(1:22) eof-in-comment
+#document
+| <!DOCTYPE html>
+| <!--  X -->
+| <html>
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html><table><caption>test TEST</caption><td>test
+#errors
+(1,54): unexpected-cell-in-table-body
+(1,58): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <caption>
+|         "test TEST"
+|       <tbody>
+|         <tr>
+|           <td>
+|             "test"
+
+#data
+<!DOCTYPE html><select><option><optgroup>
+#errors
+(1,41): eof-in-select
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <option>
+|       <optgroup>
+
+#data
+<!DOCTYPE html><select><optgroup><option></optgroup><option><select><option>
+#errors
+1:61: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <optgroup>
+|         <option>
+|       <option>
+|     <option>
+
+#data
+<!DOCTYPE html><select><optgroup><option><optgroup>
+#errors
+(1,51): eof-in-select
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <optgroup>
+|         <option>
+|       <optgroup>
+
+#data
+<!DOCTYPE html><datalist><option>foo</datalist>bar
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <datalist>
+|       <option>
+|         "foo"
+|     "bar"
+
+#data
+<!DOCTYPE html><font><input><input></font>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <font>
+|       <input>
+|       <input>
+
+#data
+<!DOCTYPE html><!-- XXX - XXX -->
+#errors
+#document
+| <!DOCTYPE html>
+| <!--  XXX - XXX  -->
+| <html>
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html><!-- XXX - XXX
+#errors
+(1,29): eof-in-comment
+#new-errors
+(1:30) eof-in-comment
+#document
+| <!DOCTYPE html>
+| <!--  XXX - XXX -->
+| <html>
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html><!-- XXX - XXX - XXX -->
+#errors
+#document
+| <!DOCTYPE html>
+| <!--  XXX - XXX - XXX  -->
+| <html>
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html> <!DOCTYPE html>
+#errors
+Line: 1 Col: 31 Unexpected DOCTYPE. Ignored.
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+
+#data
+test
+test
+#errors
+(2,4): expected-doctype-but-got-chars
+#document
+| <html>
+|   <head>
+|   <body>
+|     "test
+test"
+
+#data
+<!DOCTYPE html><body><title>test</body></title>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <title>
+|       "test</body>"
+
+#data
+<!DOCTYPE html><body><title>X</title><meta name=z><link rel=foo><style>
+x { content:"</style" } </style>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <title>
+|       "X"
+|     <meta>
+|       name="z"
+|     <link>
+|       rel="foo"
+|     <style>
+|       "
+x { content:"</style" } "
+
+#data
+<!DOCTYPE html><select><optgroup></optgroup></select>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <optgroup>
+
+#data
+ 
+ 
+#errors
+(2,1): expected-doctype-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html>  <html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html><script>
+</script>  <title>x</title>  </head>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <script>
+|       "
+"
+|     "  "
+|     <title>
+|       "x"
+|     "  "
+|   <body>
+
+#data
+<!DOCTYPE html><html><body><html id=x>
+#errors
+(1,38): non-html-root
+#document
+| <!DOCTYPE html>
+| <html>
+|   id="x"
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html>X</body><html id="x">
+#errors
+(1,36): non-html-root
+#document
+| <!DOCTYPE html>
+| <html>
+|   id="x"
+|   <head>
+|   <body>
+|     "X"
+
+#data
+<!DOCTYPE html><head><html id=x>
+#errors
+(1,32): non-html-root
+#document
+| <!DOCTYPE html>
+| <html>
+|   id="x"
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html>X</html>X
+#errors
+(1,24): expected-eof-but-got-char
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "XX"
+
+#data
+<!DOCTYPE html>X</html> 
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "X "
+
+#data
+<!DOCTYPE html>X</html><p>X
+#errors
+(1,26): expected-eof-but-got-start-tag
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "X"
+|     <p>
+|       "X"
+
+#data
+<!DOCTYPE html>X<p/x/y/z>
+#errors
+(1,19): unexpected-character-after-solidus-in-tag
+(1,21): unexpected-character-after-solidus-in-tag
+(1,23): unexpected-character-after-solidus-in-tag
+#new-errors
+(1:20) unexpected-solidus-in-tag
+(1:22) unexpected-solidus-in-tag
+(1:24) unexpected-solidus-in-tag
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "X"
+|     <p>
+|       x=""
+|       y=""
+|       z=""
+
+#data
+<!DOCTYPE html><!--x--
+#errors
+(1,22): eof-in-comment-double-dash
+#new-errors
+(1:23) eof-in-comment
+#document
+| <!DOCTYPE html>
+| <!-- x -->
+| <html>
+|   <head>
+|   <body>
+
+#data
+<!DOCTYPE html><table><tr><td></p></table>
+#errors
+(1,34): unexpected-end-tag
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+|             <p>
+
+#data
+<!DOCTYPE <!DOCTYPE HTML>><!--<!--x-->-->
+#errors
+(1,20): expected-space-or-right-bracket-in-doctype
+(1,25): unknown-doctype
+(1,35): unexpected-char-in-comment
+#new-errors
+(1:21) invalid-character-sequence-after-doctype-name
+(1:35) nested-comment
+#document
+| <!DOCTYPE <!doctype>
+| <html>
+|   <head>
+|   <body>
+|     ">"
+|     <!-- <!--x -->
+|     "-->"
+
+#data
+<!doctype html><div><form></form><div></div></div>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       <form>
+|       <div>
+
+#data
+<head></head><style></style>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,20): unexpected-start-tag-out-of-my-head
+#document
+| <html>
+|   <head>
+|     <style>
+|   <body>
+
+#data
+<head></head><script></script>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,21): unexpected-start-tag-out-of-my-head
+#document
+| <html>
+|   <head>
+|     <script>
+|   <body>
+
+#data
+<head></head><!-- --><style></style><!-- --><script></script>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,28): unexpected-start-tag-out-of-my-head
+(1,52): unexpected-start-tag-out-of-my-head
+#document
+| <html>
+|   <head>
+|     <style>
+|     <script>
+|   <!--   -->
+|   <!--   -->
+|   <body>
+
+#data
+<head></head><!-- -->x<style></style><!-- --><script></script>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <!--   -->
+|   <body>
+|     "x"
+|     <style>
+|     <!--   -->
+|     <script>
+
+#data
+<!DOCTYPE html><html><head></head><body><pre>
+</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+
+#data
+<!DOCTYPE html><html><head></head><body><pre>
+foo</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "foo"
+
+#data
+<!DOCTYPE html><html><head></head><body><pre>
+
+foo</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "
+foo"
+
+#data
+<!DOCTYPE html><html><head></head><body><pre>
+foo
+</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "foo
+"
+
+#data
+<!DOCTYPE html><html><head></head><body><pre>x</pre><span>
+</span></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "x"
+|     <span>
+|       "
+"
+
+#data
+<!DOCTYPE html><html><head></head><body><pre>x
+y</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "x
+y"
+
+#data
+<!DOCTYPE html><html><head></head><body><pre>x<div>
+y</pre></body></html>
+#errors
+(2,7): end-tag-too-early
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "x"
+|       <div>
+|         "
+y"
+
+#data
+<!DOCTYPE html><pre>&#x0a;&#x0a;A</pre>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "
+A"
+
+#data
+<!DOCTYPE html><HTML><META><HEAD></HEAD></HTML>
+#errors
+(1,33): two-heads-are-not-better-than-one
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <meta>
+|   <body>
+
+#data
+<!DOCTYPE html><HTML><HEAD><head></HEAD></HTML>
+#errors
+(1,33): two-heads-are-not-better-than-one
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+
+#data
+<textarea>foo<span>bar</span><i>baz
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+|       "foo<span>bar</span><i>baz"
+
+#data
+<title>foo<span>bar</em><i>baz
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,30): expected-named-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|     <title>
+|       "foo<span>bar</em><i>baz"
+|   <body>
+
+#data
+<!DOCTYPE html><textarea>
+</textarea>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+
+#data
+<!DOCTYPE html><textarea>
+foo</textarea>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+|       "foo"
+
+#data
+<!DOCTYPE html><textarea>
+
+foo</textarea>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+|       "
+foo"
+
+#data
+<!DOCTYPE html><html><head></head><body><ul><li><div><p><li></ul></body></html>
+#errors
+(1,60): end-tag-too-early
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <ul>
+|       <li>
+|         <div>
+|           <p>
+|       <li>
+
+#data
+<!doctype html><nobr><nobr><nobr>
+#errors
+(1,27): unexpected-start-tag-implies-end-tag
+(1,33): unexpected-start-tag-implies-end-tag
+(1,33): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <nobr>
+|     <nobr>
+|     <nobr>
+
+#data
+<!doctype html><nobr><nobr></nobr><nobr>
+#errors
+(1,27): unexpected-start-tag-implies-end-tag
+(1,40): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <nobr>
+|     <nobr>
+|     <nobr>
+
+#data
+<!doctype html><html><body><p><table></table></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <table>
+
+#data
+<p><table></table>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <table>

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -83,9 +83,26 @@ fn dump_node(node: &Node, depth: usize, lines: &mut Vec<String>) {
     match node {
         Node::DocumentType(doctype) => dump_doctype(doctype, depth, lines),
         Node::Element(element) => dump_element(element, depth, lines),
-        Node::Text(text) => lines.push(format!("{}\"{}\"", prefix(depth), text.data)),
+        Node::Text(text) => dump_text(&text.data, depth, lines),
         Node::Comment(comment) => {
             lines.push(format!("{}<!-- {} -->", prefix(depth), comment.data));
+        }
+    }
+}
+
+fn dump_text(text: &str, depth: usize, lines: &mut Vec<String>) {
+    let parts = text.split('\n').collect::<Vec<_>>();
+    if parts.len() == 1 {
+        lines.push(format!("{}\"{}\"", prefix(depth), text));
+        return;
+    }
+
+    let last_index = parts.len() - 1;
+    for (index, part) in parts.iter().enumerate() {
+        match index {
+            0 => lines.push(format!("{}\"{}", prefix(depth), part)),
+            index if index == last_index => lines.push(format!("{part}\"")),
+            _ => lines.push((*part).to_string()),
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the html5lib tree-construction smoke fixture from 90 to 199 cases (+109 cases)
- add parser recovery for frameset, misplaced table columns, foster-parented table content, shell normalization, list/definition item paragraph closure, and quirks-mode table-in-paragraph behavior
- keep tokenizer state-machine changes TOML-first and regenerate the checked-in Rust table for RAWTEXT/RCDATA/script end-tag fallback and comment EOF recovery

## Validation
- cargo test -p coding-adventures-html-parser --test tree_construction_test html5lib_tree_construction_smoke_cases_match_dom_dump -- --exact
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer