### PR TITLE
[codex] Add Rust cas-multivariate crate

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -509,6 +509,7 @@ members = [
     "cas-algebraic",
     "cas-factor",
     "cas-fourier",
+    "cas-multivariate",
     "cas-solve",
     "cas-list-operations",
     "cas-matrix",

--- a/code/packages/rust/cas-multivariate/BUILD
+++ b/code/packages/rust/cas-multivariate/BUILD
@@ -1,0 +1,9 @@
+load("code/packages/starlark/library-rules/rust_library.star", "rust_library")
+
+_targets = [
+    rust_library(
+        name = "cas-multivariate",
+        srcs = ["src/**/*.rs", "tests/**/*.rs"],
+        deps = [],
+    ),
+]

--- a/code/packages/rust/cas-multivariate/Cargo.toml
+++ b/code/packages/rust/cas-multivariate/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cas-multivariate"
+version = "0.1.0"
+edition = "2021"
+description = "Multivariate rational polynomials, Groebner bases, reduction, and ideal solving"
+license = "MIT"
+
+[dependencies]

--- a/code/packages/rust/cas-multivariate/README.md
+++ b/code/packages/rust/cas-multivariate/README.md
@@ -1,0 +1,29 @@
+# cas-multivariate (Rust)
+
+Multivariate polynomial operations and Groebner bases over exact rationals.
+Rust port of the Python `cas-multivariate` package.
+
+## What it covers
+
+- Sparse multivariate polynomials over Q
+- Monomial orders: lex, grlex, grevlex
+- Multivariate reduction and S-polynomials
+- Buchberger Groebner basis computation with safety caps
+- Ideal solving through lex Groebner bases and back-substitution
+
+```rust
+use cas_multivariate::{buchberger, ideal_solve, MPoly, Rational};
+
+let f1 = MPoly::new(
+    [((1, 0).into(), Rational::one()), ((0, 1).into(), Rational::one()), ((0, 0).into(), Rational::from_int(-1))],
+    2,
+);
+let f2 = MPoly::new(
+    [((1, 0).into(), Rational::one()), ((0, 1).into(), Rational::from_int(-1))],
+    2,
+);
+
+let basis = buchberger(&[f1.clone(), f2.clone()], "lex").unwrap();
+assert_eq!(basis.len(), 2);
+assert_eq!(ideal_solve(&[f1, f2]).unwrap(), vec![vec![Rational::new(1, 2), Rational::new(1, 2)]]);
+```

--- a/code/packages/rust/cas-multivariate/src/groebner.rs
+++ b/code/packages/rust/cas-multivariate/src/groebner.rs
@@ -1,0 +1,144 @@
+use std::collections::BTreeSet;
+
+use crate::monomial::{divides, MonomialOrder};
+use crate::{reduce_poly, s_poly, MPoly, PolynomialError, Rational};
+
+const MAX_BASIS_SIZE: usize = 50;
+const MAX_DEGREE: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrobnerError {
+    Polynomial(PolynomialError),
+    BasisTooLarge { max: usize },
+    DegreeTooLarge { degree: usize, max: usize },
+}
+
+impl std::fmt::Display for GrobnerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Polynomial(err) => write!(f, "{err}"),
+            Self::BasisTooLarge { max } => {
+                write!(f, "Groebner basis grew beyond {max} elements")
+            }
+            Self::DegreeTooLarge { degree, max } => {
+                write!(
+                    f,
+                    "polynomial total degree {degree} exceeds safety cap {max}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for GrobnerError {}
+
+impl From<PolynomialError> for GrobnerError {
+    fn from(value: PolynomialError) -> Self {
+        Self::Polynomial(value)
+    }
+}
+
+pub fn buchberger(polys: &[MPoly], order: &str) -> Result<Vec<MPoly>, GrobnerError> {
+    let order = MonomialOrder::parse(order).map_err(PolynomialError::from)?;
+    let mut basis: Vec<MPoly> = polys.iter().filter(|p| !p.is_zero()).cloned().collect();
+    if basis.is_empty() {
+        return Ok(vec![]);
+    }
+
+    for p in &basis {
+        if p.total_degree() > MAX_DEGREE {
+            return Err(GrobnerError::DegreeTooLarge {
+                degree: p.total_degree(),
+                max: MAX_DEGREE,
+            });
+        }
+    }
+
+    let mut pairs: BTreeSet<(usize, usize)> = (0..basis.len())
+        .flat_map(|i| (i + 1..basis.len()).map(move |j| (i, j)))
+        .collect();
+
+    while let Some(pair) = pairs.pop_first() {
+        let sp = s_poly(&basis[pair.0], &basis[pair.1], order_name(order))?;
+        let r = reduce_poly(&sp, &basis, order_name(order))?;
+        if r.is_zero() {
+            continue;
+        }
+
+        if basis.len() >= MAX_BASIS_SIZE {
+            return Err(GrobnerError::BasisTooLarge {
+                max: MAX_BASIS_SIZE,
+            });
+        }
+        if r.total_degree() > MAX_DEGREE {
+            return Err(GrobnerError::DegreeTooLarge {
+                degree: r.total_degree(),
+                max: MAX_DEGREE,
+            });
+        }
+
+        let new_idx = basis.len();
+        pairs.extend((0..new_idx).map(|i| (i, new_idx)));
+        basis.push(r);
+    }
+
+    inter_reduce(&basis, order)
+}
+
+fn make_monic(p: &MPoly, order: MonomialOrder) -> Result<MPoly, PolynomialError> {
+    if p.is_zero() {
+        return Ok(p.clone());
+    }
+    Ok(p.scale(Rational::ONE / p.leading_coefficient(order)?))
+}
+
+fn inter_reduce(basis: &[MPoly], order: MonomialOrder) -> Result<Vec<MPoly>, GrobnerError> {
+    if basis.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut minimal = Vec::new();
+    for (i, g) in basis.iter().enumerate() {
+        if g.is_zero() {
+            continue;
+        }
+        let lm_g = g.leading_monomial(order)?;
+        let mut dominated = false;
+        for (j, h) in basis.iter().enumerate() {
+            if i == j || h.is_zero() {
+                continue;
+            }
+            let lm_h = h.leading_monomial(order)?;
+            if divides(&lm_h, &lm_g) && (lm_h != lm_g || j < i) {
+                dominated = true;
+                break;
+            }
+        }
+        if !dominated {
+            minimal.push(make_monic(g, order)?);
+        }
+    }
+
+    let mut reduced = Vec::new();
+    for (i, g) in minimal.iter().enumerate() {
+        let others: Vec<MPoly> = minimal
+            .iter()
+            .enumerate()
+            .filter_map(|(j, h)| if i == j { None } else { Some(h.clone()) })
+            .collect();
+        let r = reduce_poly(g, &others, order_name(order))?;
+        if !r.is_zero() {
+            reduced.push(make_monic(&r, order)?);
+        }
+    }
+
+    Ok(reduced)
+}
+
+fn order_name(order: MonomialOrder) -> &'static str {
+    match order {
+        MonomialOrder::Lex => "lex",
+        MonomialOrder::GrLex => "grlex",
+        MonomialOrder::GRevLex => "grevlex",
+    }
+}

--- a/code/packages/rust/cas-multivariate/src/lib.rs
+++ b/code/packages/rust/cas-multivariate/src/lib.rs
@@ -1,0 +1,30 @@
+//! # cas-multivariate
+//!
+//! Sparse multivariate polynomials over Q, polynomial reduction, Groebner
+//! bases, and small ideal solving via lex order back-substitution.
+
+pub mod groebner;
+pub mod monomial;
+pub mod polynomial;
+pub mod rational;
+pub mod reduce;
+pub mod solve;
+
+pub use groebner::{buchberger, GrobnerError};
+pub use monomial::{
+    cmp_monomials, div_monomial, divides, lcm_monomial, total_degree, Monomial, MonomialOrder,
+    MonomialOrderError,
+};
+pub use polynomial::{div_reduction_step, make_var, MPoly, PolynomialError};
+pub use rational::Rational;
+pub use reduce::{reduce_poly, s_poly};
+pub use solve::{ideal_solve, ideal_solve_with_order, rational_roots, solve_univariate};
+
+/// Head symbol for Groebner basis operations.
+pub const GROEBNER: &str = "Groebner";
+
+/// Head symbol for polynomial normal-form reduction.
+pub const POLY_REDUCE: &str = "PolyReduce";
+
+/// Head symbol for ideal solving.
+pub const IDEAL_SOLVE: &str = "IdealSolve";

--- a/code/packages/rust/cas-multivariate/src/monomial.rs
+++ b/code/packages/rust/cas-multivariate/src/monomial.rs
@@ -1,0 +1,86 @@
+use std::cmp::Ordering;
+
+/// Exponent vector for a monomial.
+pub type Monomial = Vec<usize>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonomialOrder {
+    Lex,
+    GrLex,
+    GRevLex,
+}
+
+impl MonomialOrder {
+    pub fn parse(order: &str) -> Result<Self, MonomialOrderError> {
+        match order {
+            "lex" => Ok(Self::Lex),
+            "grlex" => Ok(Self::GrLex),
+            "grevlex" => Ok(Self::GRevLex),
+            _ => Err(MonomialOrderError {
+                order: order.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MonomialOrderError {
+    pub order: String,
+}
+
+impl std::fmt::Display for MonomialOrderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unknown monomial order {:?}; use lex, grlex, or grevlex",
+            self.order
+        )
+    }
+}
+
+impl std::error::Error for MonomialOrderError {}
+
+pub fn cmp_monomials(a: &[usize], b: &[usize], order: MonomialOrder) -> Ordering {
+    match order {
+        MonomialOrder::Lex => a.cmp(b),
+        MonomialOrder::GrLex => total_degree(a).cmp(&total_degree(b)).then_with(|| a.cmp(b)),
+        MonomialOrder::GRevLex => total_degree(a)
+            .cmp(&total_degree(b))
+            .then_with(|| cmp_grevlex_tie(a, b)),
+    }
+}
+
+fn cmp_grevlex_tie(a: &[usize], b: &[usize]) -> Ordering {
+    for (&ai, &bi) in a.iter().rev().zip(b.iter().rev()) {
+        match bi.cmp(&ai) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
+    }
+    Ordering::Equal
+}
+
+pub fn lcm_monomial(a: &[usize], b: &[usize]) -> Monomial {
+    assert_eq!(a.len(), b.len(), "monomial variable count mismatch");
+    a.iter().zip(b).map(|(&ai, &bi)| ai.max(bi)).collect()
+}
+
+pub fn divides(a: &[usize], b: &[usize]) -> bool {
+    assert_eq!(a.len(), b.len(), "monomial variable count mismatch");
+    a.iter().zip(b).all(|(&ai, &bi)| ai <= bi)
+}
+
+pub fn div_monomial(b: &[usize], a: &[usize]) -> Monomial {
+    assert_eq!(a.len(), b.len(), "monomial variable count mismatch");
+    b.iter()
+        .zip(a)
+        .map(|(&bi, &ai)| {
+            assert!(bi >= ai, "monomial divisor does not divide dividend");
+            bi - ai
+        })
+        .collect()
+}
+
+pub fn total_degree(m: &[usize]) -> usize {
+    m.iter().sum()
+}

--- a/code/packages/rust/cas-multivariate/src/polynomial.rs
+++ b/code/packages/rust/cas-multivariate/src/polynomial.rs
@@ -1,0 +1,321 @@
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::{Add, Mul, Neg, Sub};
+
+use crate::monomial::{
+    cmp_monomials, div_monomial, divides, total_degree, Monomial, MonomialOrder, MonomialOrderError,
+};
+use crate::Rational;
+
+/// Sparse multivariate polynomial over Q.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MPoly {
+    pub coeffs: BTreeMap<Monomial, Rational>,
+    pub nvars: usize,
+}
+
+impl MPoly {
+    pub fn new<I>(coeffs: I, nvars: usize) -> Self
+    where
+        I: IntoIterator<Item = (Monomial, Rational)>,
+    {
+        let mut out = BTreeMap::new();
+        for (m, c) in coeffs {
+            assert_eq!(m.len(), nvars, "monomial variable count mismatch");
+            if !c.is_zero() {
+                out.insert(m, c);
+            }
+        }
+        Self { coeffs: out, nvars }
+    }
+
+    pub fn zero(nvars: usize) -> Self {
+        Self {
+            coeffs: BTreeMap::new(),
+            nvars,
+        }
+    }
+
+    pub fn constant<C: Into<Rational>>(c: C, nvars: usize) -> Self {
+        let c = c.into();
+        if c.is_zero() {
+            return Self::zero(nvars);
+        }
+        Self::new([(vec![0; nvars], c)], nvars)
+    }
+
+    pub fn monomial_poly<C: Into<Rational>>(exp: Monomial, c: C, nvars: usize) -> Self {
+        let c = c.into();
+        if c.is_zero() {
+            return Self::zero(nvars);
+        }
+        Self::new([(exp, c)], nvars)
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.coeffs.is_empty()
+    }
+
+    pub fn lm(&self, order: &str) -> Result<Monomial, PolynomialError> {
+        let order = MonomialOrder::parse(order)?;
+        self.leading_monomial(order)
+    }
+
+    pub fn lc(&self, order: &str) -> Result<Rational, PolynomialError> {
+        let lm = self.lm(order)?;
+        Ok(self.coeffs[&lm])
+    }
+
+    pub fn lt(&self, order: &str) -> Result<Self, PolynomialError> {
+        let lm = self.lm(order)?;
+        Ok(Self::monomial_poly(
+            lm.clone(),
+            self.coeffs[&lm],
+            self.nvars,
+        ))
+    }
+
+    pub(crate) fn leading_monomial(
+        &self,
+        order: MonomialOrder,
+    ) -> Result<Monomial, PolynomialError> {
+        self.coeffs
+            .keys()
+            .max_by(|a, b| cmp_monomials(a, b, order))
+            .cloned()
+            .ok_or(PolynomialError::ZeroLeadingTerm)
+    }
+
+    pub(crate) fn leading_coefficient(
+        &self,
+        order: MonomialOrder,
+    ) -> Result<Rational, PolynomialError> {
+        let lm = self.leading_monomial(order)?;
+        Ok(self.coeffs[&lm])
+    }
+
+    pub(crate) fn leading_term(&self, order: MonomialOrder) -> Result<Self, PolynomialError> {
+        let lm = self.leading_monomial(order)?;
+        Ok(Self::monomial_poly(
+            lm.clone(),
+            self.coeffs[&lm],
+            self.nvars,
+        ))
+    }
+
+    pub fn total_degree(&self) -> usize {
+        self.coeffs
+            .keys()
+            .map(|m| total_degree(m))
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub fn scale<C: Into<Rational>>(&self, c: C) -> Self {
+        let c = c.into();
+        if c.is_zero() {
+            return Self::zero(self.nvars);
+        }
+        Self::new(
+            self.coeffs.iter().map(|(m, coeff)| (m.clone(), *coeff * c)),
+            self.nvars,
+        )
+    }
+
+    pub fn mul_monomial<C: Into<Rational>>(&self, exp: &[usize], c: C) -> Self {
+        assert_eq!(exp.len(), self.nvars, "monomial variable count mismatch");
+        let c = c.into();
+        if c.is_zero() {
+            return Self::zero(self.nvars);
+        }
+        Self::new(
+            self.coeffs.iter().map(|(m, coeff)| {
+                (
+                    exp.iter().zip(m).map(|(&ei, &mi)| ei + mi).collect(),
+                    *coeff * c,
+                )
+            }),
+            self.nvars,
+        )
+    }
+
+    pub fn monomials_descending(&self, order: &str) -> Result<Vec<Monomial>, PolynomialError> {
+        let order = MonomialOrder::parse(order)?;
+        let mut monomials: Vec<_> = self.coeffs.keys().cloned().collect();
+        monomials.sort_by(|a, b| cmp_monomials(b, a, order));
+        Ok(monomials)
+    }
+
+    pub fn is_univariate(&self) -> Option<usize> {
+        let mut active = BTreeSet::new();
+        for m in self.coeffs.keys() {
+            for (i, &e) in m.iter().enumerate() {
+                if e != 0 {
+                    active.insert(i);
+                }
+            }
+        }
+        match active.len().cmp(&1) {
+            Ordering::Less => Some(0),
+            Ordering::Equal => active.into_iter().next(),
+            Ordering::Greater => None,
+        }
+    }
+
+    pub fn to_univariate_coeffs(&self, var_idx: usize) -> Vec<Rational> {
+        let max_deg = self
+            .coeffs
+            .keys()
+            .map(|m| m[var_idx])
+            .max()
+            .unwrap_or_default();
+        let mut out = vec![Rational::ZERO; max_deg + 1];
+        for (m, c) in &self.coeffs {
+            out[m[var_idx]] = *c;
+        }
+        out
+    }
+
+    pub fn leading_monomial_divides(
+        &self,
+        m: &[usize],
+        order: &str,
+    ) -> Result<bool, PolynomialError> {
+        let lm = self.lm(order)?;
+        Ok(divides(&lm, m))
+    }
+
+    pub fn diff(&self, var_idx: usize) -> Self {
+        let mut out: BTreeMap<Monomial, Rational> = BTreeMap::new();
+        for (m, c) in &self.coeffs {
+            let exp = m[var_idx];
+            if exp == 0 {
+                continue;
+            }
+            let mut new_m = m.clone();
+            new_m[var_idx] -= 1;
+            let coeff = *c * Rational::from_int(exp as i64);
+            let current = out.get(&new_m).copied().unwrap_or(Rational::ZERO);
+            out.insert(new_m, current + coeff);
+        }
+        Self::new(out, self.nvars)
+    }
+
+    pub fn eval_at(&self, var_idx: usize, value: Rational) -> Self {
+        let mut out: BTreeMap<Monomial, Rational> = BTreeMap::new();
+        for (m, c) in &self.coeffs {
+            let mut new_m = m.clone();
+            new_m[var_idx] = 0;
+            let coeff = *c * value.pow_usize(m[var_idx]);
+            let current = out.get(&new_m).copied().unwrap_or(Rational::ZERO);
+            out.insert(new_m, current + coeff);
+        }
+        Self::new(out, self.nvars)
+    }
+}
+
+impl Add for MPoly {
+    type Output = MPoly;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        assert_eq!(self.nvars, rhs.nvars, "MPoly variable count mismatch");
+        let mut out = self.coeffs;
+        for (m, c) in rhs.coeffs {
+            let next = out.get(&m).copied().unwrap_or(Rational::ZERO) + c;
+            if next.is_zero() {
+                out.remove(&m);
+            } else {
+                out.insert(m, next);
+            }
+        }
+        Self::new(out, self.nvars)
+    }
+}
+
+impl Sub for MPoly {
+    type Output = MPoly;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self + (-rhs)
+    }
+}
+
+impl Neg for MPoly {
+    type Output = MPoly;
+
+    fn neg(self) -> Self::Output {
+        Self::new(self.coeffs.into_iter().map(|(m, c)| (m, -c)), self.nvars)
+    }
+}
+
+impl Mul for MPoly {
+    type Output = MPoly;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        assert_eq!(self.nvars, rhs.nvars, "MPoly variable count mismatch");
+        let mut out: BTreeMap<Monomial, Rational> = BTreeMap::new();
+        for (ma, ca) in &self.coeffs {
+            for (mb, cb) in &rhs.coeffs {
+                let m = ma.iter().zip(mb).map(|(&a, &b)| a + b).collect::<Vec<_>>();
+                let next = out.get(&m).copied().unwrap_or(Rational::ZERO) + (*ca * *cb);
+                if next.is_zero() {
+                    out.remove(&m);
+                } else {
+                    out.insert(m, next);
+                }
+            }
+        }
+        Self::new(out, self.nvars)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolynomialError {
+    BadOrder(MonomialOrderError),
+    ZeroLeadingTerm,
+}
+
+impl std::fmt::Display for PolynomialError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadOrder(err) => write!(f, "{err}"),
+            Self::ZeroLeadingTerm => {
+                write!(f, "leading monomial of the zero polynomial is undefined")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PolynomialError {}
+
+impl From<MonomialOrderError> for PolynomialError {
+    fn from(value: MonomialOrderError) -> Self {
+        Self::BadOrder(value)
+    }
+}
+
+pub fn make_var(var_idx: usize, nvars: usize) -> MPoly {
+    let mut exp = vec![0; nvars];
+    exp[var_idx] = 1;
+    MPoly::monomial_poly(exp, Rational::ONE, nvars)
+}
+
+pub fn div_reduction_step(
+    f: &MPoly,
+    g: &MPoly,
+    order: &str,
+) -> Result<Option<(MPoly, MPoly)>, PolynomialError> {
+    if f.is_zero() {
+        return Ok(None);
+    }
+    let order = MonomialOrder::parse(order)?;
+    let lm_f = f.leading_monomial(order)?;
+    let lm_g = g.leading_monomial(order)?;
+    if !divides(&lm_g, &lm_f) {
+        return Ok(None);
+    }
+    let exp_diff = div_monomial(&lm_f, &lm_g);
+    let coeff = f.leading_coefficient(order)? / g.leading_coefficient(order)?;
+    let term = MPoly::monomial_poly(exp_diff.clone(), coeff, f.nvars);
+    Ok(Some((term, f.clone() - g.mul_monomial(&exp_diff, coeff))))
+}

--- a/code/packages/rust/cas-multivariate/src/rational.rs
+++ b/code/packages/rust/cas-multivariate/src/rational.rs
@@ -1,0 +1,167 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+/// Exact rational number in reduced form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Rational {
+    pub numer: i64,
+    pub denom: i64,
+}
+
+impl Rational {
+    pub const ZERO: Rational = Rational { numer: 0, denom: 1 };
+    pub const ONE: Rational = Rational { numer: 1, denom: 1 };
+
+    /// Construct a rational number and reduce it to canonical form.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `denom == 0`.
+    pub fn new(numer: i64, denom: i64) -> Self {
+        assert!(denom != 0, "Rational denominator cannot be zero");
+        if numer == 0 {
+            return Self::ZERO;
+        }
+        let (n, d) = if denom < 0 {
+            (-(numer as i128), -(denom as i128))
+        } else {
+            (numer as i128, denom as i128)
+        };
+        let g = gcd_u128(n.unsigned_abs(), d.unsigned_abs()) as i128;
+        Self {
+            numer: (n / g) as i64,
+            denom: (d / g) as i64,
+        }
+    }
+
+    pub fn from_int(value: i64) -> Self {
+        Self::new(value, 1)
+    }
+
+    pub fn zero() -> Self {
+        Self::ZERO
+    }
+
+    pub fn one() -> Self {
+        Self::ONE
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.numer == 0
+    }
+
+    pub fn is_negative(self) -> bool {
+        self.numer < 0
+    }
+
+    pub fn pow_usize(self, exp: usize) -> Self {
+        let mut out = Self::ONE;
+        for _ in 0..exp {
+            out = out * self;
+        }
+        out
+    }
+
+    fn new_i128(numer: i128, denom: i128) -> Self {
+        assert!(denom != 0, "Rational denominator cannot be zero");
+        if numer == 0 {
+            return Self::ZERO;
+        }
+        let (n, d) = if denom < 0 {
+            (-numer, -denom)
+        } else {
+            (numer, denom)
+        };
+        let g = gcd_u128(n.unsigned_abs(), d.unsigned_abs()) as i128;
+        Self {
+            numer: (n / g) as i64,
+            denom: (d / g) as i64,
+        }
+    }
+}
+
+impl From<i64> for Rational {
+    fn from(value: i64) -> Self {
+        Self::from_int(value)
+    }
+}
+
+impl Neg for Rational {
+    type Output = Rational;
+
+    fn neg(self) -> Self::Output {
+        Rational {
+            numer: -self.numer,
+            denom: self.denom,
+        }
+    }
+}
+
+impl Add for Rational {
+    type Output = Rational;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Rational::new_i128(
+            self.numer as i128 * rhs.denom as i128 + rhs.numer as i128 * self.denom as i128,
+            self.denom as i128 * rhs.denom as i128,
+        )
+    }
+}
+
+impl Sub for Rational {
+    type Output = Rational;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self + (-rhs)
+    }
+}
+
+impl Mul for Rational {
+    type Output = Rational;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Rational::new_i128(
+            self.numer as i128 * rhs.numer as i128,
+            self.denom as i128 * rhs.denom as i128,
+        )
+    }
+}
+
+impl Div for Rational {
+    type Output = Rational;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        assert!(!rhs.is_zero(), "Rational division by zero");
+        Rational::new_i128(
+            self.numer as i128 * rhs.denom as i128,
+            self.denom as i128 * rhs.numer as i128,
+        )
+    }
+}
+
+pub(crate) fn gcd_i64(mut a: i64, mut b: i64) -> i64 {
+    a = a.abs();
+    b = b.abs();
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+pub(crate) fn lcm_i64(a: i64, b: i64) -> i64 {
+    if a == 0 || b == 0 {
+        0
+    } else {
+        (a / gcd_i64(a, b)) * b
+    }
+}
+
+fn gcd_u128(mut a: u128, mut b: u128) -> u128 {
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}

--- a/code/packages/rust/cas-multivariate/src/reduce.rs
+++ b/code/packages/rust/cas-multivariate/src/reduce.rs
@@ -1,0 +1,51 @@
+use crate::monomial::{div_monomial, divides, lcm_monomial, MonomialOrder};
+use crate::{MPoly, PolynomialError, Rational};
+
+pub fn reduce_poly(f: &MPoly, basis: &[MPoly], order: &str) -> Result<MPoly, PolynomialError> {
+    let order = MonomialOrder::parse(order)?;
+    let mut p = f.clone();
+    let mut r = MPoly::zero(f.nvars);
+
+    while !p.is_zero() {
+        let lm_p = p.leading_monomial(order)?;
+        let mut reduced = false;
+
+        for g in basis {
+            if g.is_zero() {
+                continue;
+            }
+            let lm_g = g.leading_monomial(order)?;
+            if divides(&lm_g, &lm_p) {
+                let exp_diff = div_monomial(&lm_p, &lm_g);
+                let coeff = p.leading_coefficient(order)? / g.leading_coefficient(order)?;
+                p = p - g.mul_monomial(&exp_diff, coeff);
+                reduced = true;
+                break;
+            }
+        }
+
+        if !reduced {
+            let lt = p.leading_term(order)?;
+            r = r + lt.clone();
+            p = p - lt;
+        }
+    }
+
+    Ok(r)
+}
+
+pub fn s_poly(f: &MPoly, g: &MPoly, order: &str) -> Result<MPoly, PolynomialError> {
+    assert!(
+        !f.is_zero() && !g.is_zero(),
+        "S-polynomial undefined for zero polynomials"
+    );
+    let order = MonomialOrder::parse(order)?;
+    let lm_f = f.leading_monomial(order)?;
+    let lm_g = g.leading_monomial(order)?;
+    let lcm = lcm_monomial(&lm_f, &lm_g);
+    let exp_f = div_monomial(&lcm, &lm_f);
+    let exp_g = div_monomial(&lcm, &lm_g);
+    let coeff_f = Rational::ONE / f.leading_coefficient(order)?;
+    let coeff_g = Rational::ONE / g.leading_coefficient(order)?;
+    Ok(f.mul_monomial(&exp_f, coeff_f) - g.mul_monomial(&exp_g, coeff_g))
+}

--- a/code/packages/rust/cas-multivariate/src/solve.rs
+++ b/code/packages/rust/cas-multivariate/src/solve.rs
@@ -1,0 +1,311 @@
+use crate::rational::{gcd_i64, lcm_i64};
+use crate::{buchberger, MPoly, Rational};
+
+pub fn rational_roots(coeffs: &[Rational]) -> Vec<Rational> {
+    let mut lcm_denom = 1;
+    for c in coeffs {
+        lcm_denom = lcm_i64(lcm_denom, c.denom).abs();
+    }
+    let mut int_coeffs: Vec<i64> = coeffs
+        .iter()
+        .map(|c| c.numer * (lcm_denom / c.denom))
+        .collect();
+    trim_trailing_zeros(&mut int_coeffs);
+
+    if int_coeffs.len() <= 1 {
+        return vec![];
+    }
+
+    if int_coeffs[0] == 0 {
+        let mut roots = vec![Rational::ZERO];
+        let trimmed: Vec<Rational> = int_coeffs[1..]
+            .iter()
+            .map(|&c| Rational::from_int(c))
+            .collect();
+        roots.extend(rational_roots(&trimmed));
+        dedup(roots)
+    } else {
+        let p_divs = divisors(int_coeffs[0]);
+        let q_divs = divisors(*int_coeffs.last().unwrap());
+        let mut roots = Vec::new();
+        for p in p_divs {
+            for q in &q_divs {
+                for sign in [1, -1] {
+                    let cand = Rational::new(sign * p, *q);
+                    if roots.contains(&cand) {
+                        continue;
+                    }
+                    let val = int_coeffs
+                        .iter()
+                        .enumerate()
+                        .fold(Rational::ZERO, |acc, (k, &c)| {
+                            acc + Rational::from_int(c) * cand.pow_usize(k)
+                        });
+                    if val.is_zero() {
+                        roots.push(cand);
+                    }
+                }
+            }
+        }
+        roots
+    }
+}
+
+pub fn solve_univariate(coeffs: &[Rational]) -> Option<Vec<Rational>> {
+    let mut coeffs = coeffs.to_vec();
+    while coeffs.len() > 1 && coeffs.last() == Some(&Rational::ZERO) {
+        coeffs.pop();
+    }
+
+    let degree = coeffs.len().saturating_sub(1);
+    match degree {
+        0 => Some(vec![]),
+        1 => {
+            let b = coeffs[0];
+            let a = coeffs[1];
+            if a.is_zero() {
+                Some(vec![])
+            } else {
+                Some(vec![-b / a])
+            }
+        }
+        2 => solve_quadratic_rational(&coeffs),
+        3 | 4 => {
+            let rational = rational_roots(&coeffs);
+            if rational.is_empty() {
+                return Some(vec![]);
+            }
+            let mut all_roots = rational.clone();
+            let mut remaining = coeffs;
+            for root in rational {
+                remaining = divide_by_linear(&remaining, root);
+                if remaining.is_empty() {
+                    break;
+                }
+            }
+            if let Some(more) = solve_univariate(&remaining) {
+                all_roots.extend(more);
+            }
+            Some(dedup(all_roots))
+        }
+        _ => None,
+    }
+}
+
+pub fn ideal_solve(polys: &[MPoly]) -> Option<Vec<Vec<Rational>>> {
+    ideal_solve_with_order(polys, "lex")
+}
+
+pub fn ideal_solve_with_order(polys: &[MPoly], order: &str) -> Option<Vec<Vec<Rational>>> {
+    if polys.is_empty() {
+        return None;
+    }
+    let nvars = polys[0].nvars;
+    let basis = buchberger(polys, order).ok()?;
+    if basis.is_empty() {
+        return None;
+    }
+
+    let last_var = nvars - 1;
+    let univariate_poly = basis.iter().find(|g| g.is_univariate() == Some(last_var))?;
+    let roots = solve_univariate(&univariate_poly.to_univariate_coeffs(last_var))?;
+    if roots.is_empty() {
+        return None;
+    }
+
+    let mut solutions = Vec::new();
+    for root in roots {
+        let reduced_basis: Vec<MPoly> = basis
+            .iter()
+            .map(|g| g.eval_at(last_var, root))
+            .filter(|g| !g.is_zero())
+            .collect();
+
+        if nvars == 1 {
+            solutions.push(vec![root]);
+        } else if nvars == 2 {
+            if let Some(poly) = find_linear_in_var(&reduced_basis, 0) {
+                if let Some(sol0) = eval_linear_root(poly, 0) {
+                    solutions.push(vec![sol0, root]);
+                }
+            } else if let Some(sub_solutions) = solve_from_basis(&reduced_basis, nvars - 1) {
+                for mut sub_sol in sub_solutions {
+                    sub_sol.push(root);
+                    solutions.push(sub_sol);
+                }
+            }
+        } else if let Some(projected) = project_out_last(&reduced_basis, nvars) {
+            if let Some(sub_solutions) = ideal_solve_with_order(&projected, order) {
+                for mut sub_sol in sub_solutions {
+                    sub_sol.push(root);
+                    solutions.push(sub_sol);
+                }
+            }
+        }
+    }
+
+    if solutions.is_empty() {
+        None
+    } else {
+        Some(solutions)
+    }
+}
+
+fn solve_quadratic_rational(coeffs: &[Rational]) -> Option<Vec<Rational>> {
+    let c = coeffs[0];
+    let b = coeffs[1];
+    let a = coeffs[2];
+    let disc = b * b - Rational::from_int(4) * a * c;
+    if disc.is_negative() {
+        return Some(vec![]);
+    }
+    if disc.is_zero() {
+        return Some(vec![-b / (Rational::from_int(2) * a)]);
+    }
+    let Some(sqrt_disc) = rational_square_root(disc) else {
+        return Some(vec![]);
+    };
+    let r1 = (-b + sqrt_disc) / (Rational::from_int(2) * a);
+    let r2 = (-b - sqrt_disc) / (Rational::from_int(2) * a);
+    if r1 == r2 {
+        Some(vec![r1])
+    } else {
+        Some(vec![r1, r2])
+    }
+}
+
+fn rational_square_root(value: Rational) -> Option<Rational> {
+    let n = integer_square_root(value.numer)?;
+    let d = integer_square_root(value.denom)?;
+    Some(Rational::new(n, d))
+}
+
+fn integer_square_root(value: i64) -> Option<i64> {
+    if value < 0 {
+        return None;
+    }
+    let root = (value as f64).sqrt() as i64;
+    for candidate in root.saturating_sub(1)..=root + 1 {
+        if candidate >= 0 && candidate.saturating_mul(candidate) == value {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn divisors(n: i64) -> Vec<i64> {
+    let n = n.abs();
+    if n == 0 {
+        return vec![];
+    }
+    let mut out = Vec::new();
+    let mut d = 1;
+    while d * d <= n {
+        if n % d == 0 {
+            out.push(d);
+            if d != n / d {
+                out.push(n / d);
+            }
+        }
+        d += 1;
+    }
+    out.sort_unstable();
+    out
+}
+
+fn divide_by_linear(coeffs: &[Rational], root: Rational) -> Vec<Rational> {
+    let mut p = coeffs.to_vec();
+    while p.len() > 1 && p.last() == Some(&Rational::ZERO) {
+        p.pop();
+    }
+    if p.len() <= 1 {
+        return vec![];
+    }
+
+    let degree = p.len() - 1;
+    let mut q = vec![Rational::ZERO; degree];
+    q[degree - 1] = p[degree];
+    for i in (1..degree).rev() {
+        q[i - 1] = p[i] + root * q[i];
+    }
+    trim_trailing_rational_zeros(&mut q);
+    q
+}
+
+fn find_linear_in_var(basis: &[MPoly], var_idx: usize) -> Option<&MPoly> {
+    basis.iter().find(|p| {
+        p.is_univariate() == Some(var_idx)
+            && p.to_univariate_coeffs(var_idx).len() == 2
+            && p.to_univariate_coeffs(var_idx)[1] != Rational::ZERO
+    })
+}
+
+fn eval_linear_root(p: &MPoly, var_idx: usize) -> Option<Rational> {
+    let coeffs = p.to_univariate_coeffs(var_idx);
+    if coeffs.len() != 2 || coeffs[1].is_zero() {
+        return None;
+    }
+    Some(-coeffs[0] / coeffs[1])
+}
+
+fn solve_from_basis(basis: &[MPoly], nvars: usize) -> Option<Vec<Vec<Rational>>> {
+    if nvars == 1 {
+        for p in basis {
+            if !p.is_zero() && p.is_univariate() == Some(0) {
+                let roots = solve_univariate(&p.to_univariate_coeffs(0))?;
+                if !roots.is_empty() {
+                    return Some(roots.into_iter().map(|r| vec![r]).collect());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn project_out_last(basis: &[MPoly], nvars: usize) -> Option<Vec<MPoly>> {
+    let mut result = Vec::new();
+    for p in basis {
+        if p.is_zero() {
+            continue;
+        }
+        if p.coeffs.keys().any(|m| m[nvars - 1] != 0) {
+            return None;
+        }
+        result.push(MPoly::new(
+            p.coeffs.iter().map(|(m, c)| (m[..nvars - 1].to_vec(), *c)),
+            nvars - 1,
+        ));
+    }
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+fn trim_trailing_zeros(values: &mut Vec<i64>) {
+    while values.last() == Some(&0) {
+        values.pop();
+    }
+}
+
+fn trim_trailing_rational_zeros(values: &mut Vec<Rational>) {
+    while values.last() == Some(&Rational::ZERO) {
+        values.pop();
+    }
+}
+
+fn dedup(values: Vec<Rational>) -> Vec<Rational> {
+    let mut out = Vec::new();
+    for value in values {
+        if !out.contains(&value) {
+            out.push(value);
+        }
+    }
+    out
+}
+
+#[allow(dead_code)]
+fn primitive_content(values: &[i64]) -> i64 {
+    values.iter().fold(0, |acc, &v| gcd_i64(acc, v.abs()))
+}

--- a/code/packages/rust/cas-multivariate/tests/tests.rs
+++ b/code/packages/rust/cas-multivariate/tests/tests.rs
@@ -1,0 +1,219 @@
+use std::cmp::Ordering;
+
+use cas_multivariate::{
+    buchberger, cmp_monomials, div_monomial, div_reduction_step, divides, ideal_solve,
+    lcm_monomial, make_var, rational_roots, reduce_poly, s_poly, solve_univariate, total_degree,
+    GrobnerError, MPoly, MonomialOrder, Rational,
+};
+
+fn f(n: i64) -> Rational {
+    Rational::from_int(n)
+}
+
+fn frac(n: i64, d: i64) -> Rational {
+    Rational::new(n, d)
+}
+
+fn p2(terms: &[([usize; 2], Rational)]) -> MPoly {
+    MPoly::new(terms.iter().map(|(m, c)| (m.to_vec(), *c)), 2)
+}
+
+#[test]
+fn monomial_orders_match_python_examples() {
+    assert_eq!(
+        cmp_monomials(&[2, 1], &[1, 2], MonomialOrder::GrLex),
+        Ordering::Greater
+    );
+    assert_eq!(
+        cmp_monomials(&[0, 3], &[1, 1], MonomialOrder::GrLex),
+        Ordering::Greater
+    );
+    assert_eq!(
+        cmp_monomials(&[2, 0], &[1, 5], MonomialOrder::Lex),
+        Ordering::Greater
+    );
+    assert_eq!(
+        cmp_monomials(&[3, 0, 0], &[1, 1, 1], MonomialOrder::GRevLex),
+        Ordering::Greater
+    );
+}
+
+#[test]
+fn monomial_arithmetic_helpers() {
+    assert_eq!(lcm_monomial(&[2, 1, 0], &[1, 2, 3]), vec![2, 2, 3]);
+    assert!(divides(&[1, 1], &[2, 3]));
+    assert!(!divides(&[2, 1], &[1, 2]));
+    assert_eq!(div_monomial(&[3, 2], &[1, 1]), vec![2, 1]);
+    assert_eq!(total_degree(&[3, 2, 1]), 6);
+}
+
+#[test]
+fn mpoly_constructs_and_cleans_zero_terms() {
+    let poly = p2(&[([2, 0], f(1)), ([0, 1], Rational::ZERO), ([0, 0], f(-1))]);
+    assert_eq!(poly.coeffs.len(), 2);
+    assert!(!poly.coeffs.contains_key(&vec![0, 1]));
+    assert!(MPoly::zero(2).is_zero());
+    assert_eq!(
+        MPoly::constant(frac(3, 2), 2).coeffs[&vec![0, 0]],
+        frac(3, 2)
+    );
+}
+
+#[test]
+fn mpoly_leading_terms_and_arithmetic() {
+    let poly = p2(&[([2, 1], f(3)), ([0, 3], f(2))]);
+    assert_eq!(poly.lm("grlex").unwrap(), vec![2, 1]);
+    assert_eq!(poly.lc("grlex").unwrap(), f(3));
+    assert_eq!(poly.lt("grlex").unwrap().coeffs[&vec![2, 1]], f(3));
+
+    let lhs = p2(&[([1, 0], f(1)), ([0, 0], f(1))]);
+    let rhs = p2(&[([1, 0], f(1)), ([0, 0], f(-1))]);
+    let product = lhs.clone() * rhs;
+    assert_eq!(product, p2(&[([2, 0], f(1)), ([0, 0], f(-1))]));
+
+    assert_eq!(
+        lhs.mul_monomial(&[1, 0], Rational::ONE),
+        p2(&[([2, 0], f(1)), ([1, 0], f(1))])
+    );
+}
+
+#[test]
+fn mpoly_utilities_match_python_behavior() {
+    let poly = p2(&[([2, 1], f(1)), ([1, 0], f(1))]);
+    assert_eq!(poly.total_degree(), 3);
+    assert_eq!(poly.diff(0), p2(&[([1, 1], f(2)), ([0, 0], f(1))]));
+
+    let eval = p2(&[([2, 0], f(1)), ([0, 1], f(1))]).eval_at(0, f(2));
+    assert_eq!(eval, p2(&[([0, 1], f(1)), ([0, 0], f(4))]));
+
+    assert_eq!(make_var(0, 2), p2(&[([1, 0], f(1))]));
+    assert_eq!(
+        p2(&[([2, 0], f(1)), ([0, 0], f(-1))]).to_univariate_coeffs(0),
+        vec![f(-1), Rational::ZERO, Rational::ONE]
+    );
+}
+
+#[test]
+fn div_reduction_step_applies_once() {
+    let result = div_reduction_step(&p2(&[([2, 0], f(1))]), &p2(&[([1, 0], f(1))]), "lex")
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.0, p2(&[([1, 0], f(1))]));
+    assert!(result.1.is_zero());
+
+    let no_step =
+        div_reduction_step(&p2(&[([0, 1], f(1))]), &p2(&[([1, 0], f(1))]), "lex").unwrap();
+    assert!(no_step.is_none());
+}
+
+#[test]
+fn s_polynomial_examples() {
+    let sp = s_poly(&p2(&[([2, 0], f(1))]), &p2(&[([1, 1], f(1))]), "grlex").unwrap();
+    assert!(sp.is_zero());
+
+    let f_poly = p2(&[([2, 0], f(1)), ([0, 1], f(1))]);
+    let g_poly = p2(&[([1, 1], f(1)), ([0, 0], f(1))]);
+    assert_eq!(
+        s_poly(&f_poly, &g_poly, "grlex").unwrap(),
+        p2(&[([0, 2], f(1)), ([1, 0], f(-1))])
+    );
+}
+
+#[test]
+fn reduce_poly_examples() {
+    let remainder = reduce_poly(
+        &p2(&[([2, 0], f(1)), ([0, 0], f(-1))]),
+        &[p2(&[([1, 0], f(1)), ([0, 0], f(-1))])],
+        "lex",
+    )
+    .unwrap();
+    assert!(remainder.is_zero());
+
+    let remainder = reduce_poly(
+        &p2(&[([2, 0], f(1)), ([0, 1], f(1))]),
+        &[p2(&[([2, 0], f(1)), ([0, 0], f(-1))])],
+        "grlex",
+    )
+    .unwrap();
+    assert_eq!(remainder, p2(&[([0, 1], f(1)), ([0, 0], f(1))]));
+}
+
+#[test]
+fn groebner_linear_system_reduces_generators() {
+    let f1 = p2(&[([1, 0], f(1)), ([0, 1], f(1)), ([0, 0], f(-1))]);
+    let f2 = p2(&[([1, 0], f(1)), ([0, 1], f(-1))]);
+    let basis = buchberger(&[f1.clone(), f2.clone()], "lex").unwrap();
+    assert_eq!(basis.len(), 2);
+    assert!(reduce_poly(&f1, &basis, "lex").unwrap().is_zero());
+    assert!(reduce_poly(&f2, &basis, "lex").unwrap().is_zero());
+}
+
+#[test]
+fn groebner_quadratic_and_basis_membership() {
+    let f1 = p2(&[([2, 0], f(1)), ([0, 0], f(-1))]);
+    let f2 = p2(&[([0, 1], f(1)), ([1, 0], f(-1))]);
+    let basis = buchberger(&[f1.clone(), f2.clone()], "lex").unwrap();
+    assert!(reduce_poly(&f1, &basis, "lex").unwrap().is_zero());
+    assert!(reduce_poly(&f2, &basis, "lex").unwrap().is_zero());
+
+    let g1 = p2(&[([2, 1], f(1)), ([0, 0], f(-1))]);
+    let g2 = p2(&[([1, 2], f(1)), ([0, 0], f(-1))]);
+    let basis = buchberger(&[g1.clone(), g2.clone()], "grlex").unwrap();
+    assert!(reduce_poly(&g1, &basis, "grlex").unwrap().is_zero());
+    assert!(reduce_poly(&g2, &basis, "grlex").unwrap().is_zero());
+}
+
+#[test]
+fn groebner_degree_limit() {
+    let err = buchberger(&[p2(&[([9, 0], f(1))])], "grlex").unwrap_err();
+    assert!(matches!(err, GrobnerError::DegreeTooLarge { .. }));
+}
+
+#[test]
+fn rational_root_and_univariate_solving() {
+    let mut roots = rational_roots(&[f(-1), Rational::ZERO, Rational::ONE]);
+    roots.sort();
+    assert_eq!(roots, vec![f(-1), f(1)]);
+    assert_eq!(
+        rational_roots(&[f(-2), Rational::ZERO, Rational::ONE]),
+        vec![]
+    );
+    assert_eq!(rational_roots(&[f(-1), f(2)]), vec![frac(1, 2)]);
+
+    assert_eq!(solve_univariate(&[f(-4), f(2)]).unwrap(), vec![f(2)]);
+    let mut roots = solve_univariate(&[f(-4), Rational::ZERO, Rational::ONE]).unwrap();
+    roots.sort();
+    assert_eq!(roots, vec![f(-2), f(2)]);
+    assert_eq!(
+        solve_univariate(&[f(1), Rational::ZERO, Rational::ONE]).unwrap(),
+        Vec::<Rational>::new()
+    );
+    assert_eq!(
+        solve_univariate(&[f(-2), Rational::ZERO, Rational::ONE]).unwrap(),
+        Vec::<Rational>::new()
+    );
+}
+
+#[test]
+fn ideal_solve_linear_and_quadratic_systems() {
+    let f1 = p2(&[([1, 0], f(1)), ([0, 1], f(1)), ([0, 0], f(-1))]);
+    let f2 = p2(&[([1, 0], f(1)), ([0, 1], f(-1))]);
+    assert_eq!(
+        ideal_solve(&[f1, f2]).unwrap(),
+        vec![vec![frac(1, 2), frac(1, 2)]]
+    );
+
+    let f1 = p2(&[([2, 0], f(1)), ([0, 0], f(-1))]);
+    let f2 = p2(&[([0, 1], f(1)), ([1, 0], f(-1))]);
+    let mut solutions = ideal_solve(&[f1, f2]).unwrap();
+    solutions.sort();
+    assert_eq!(solutions, vec![vec![f(-1), f(-1)], vec![f(1), f(1)]]);
+}
+
+#[test]
+fn ideal_solve_none_cases() {
+    let f1 = p2(&[([2, 0], f(1)), ([0, 0], f(1))]);
+    let f2 = p2(&[([0, 1], f(1)), ([1, 0], f(-1))]);
+    assert!(ideal_solve(&[f1, f2]).is_none());
+    assert!(ideal_solve(&[]).is_none());
+}


### PR DESCRIPTION
## Summary
- add a Rust `cas-multivariate` crate mirroring the Python package core
- implement exact rational multivariate polynomials, monomial orders, reduction, S-polynomials, Buchberger Groebner bases, and ideal solving
- add focused Rust tests covering the Python monomial, polynomial, Groebner, reduction, and solve examples

## Validation
- `cargo fmt -p cas-multivariate`
- `cargo test -p cas-multivariate`
- `cargo check -p cas-multivariate`

`code/packages/rust/Cargo.lock` was generated during validation and removed before commit.