### PR TITLE
[codex] Add TypeScript CAS ODE solver

### DIFF
--- a/code/packages/typescript/cas-ode/BUILD
+++ b/code/packages/typescript/cas-ode/BUILD
@@ -1,0 +1,4 @@
+cd ../symbolic-ir && npm ci --quiet
+npm ci --quiet
+npm run build
+npx vitest run --coverage

--- a/code/packages/typescript/cas-ode/CHANGELOG.md
+++ b/code/packages/typescript/cas-ode/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Added the pure TypeScript symbolic ODE solver over `@coding-adventures/symbolic-ir`.
+- Ported the main Python `cas-ode` families: first-order linear, separable,
+  Bernoulli, exact, second-order constant-coefficient homogeneous and
+  nonhomogeneous, Euler-Cauchy, and variation-of-parameters fallback.

--- a/code/packages/typescript/cas-ode/README.md
+++ b/code/packages/typescript/cas-ode/README.md
@@ -1,0 +1,40 @@
+# cas-ode
+
+Pure TypeScript symbolic ODE solver for the `@coding-adventures/symbolic-ir`
+expression tree.
+
+The package is browser-safe: it does not call Python, a VM, a parser, Node-only
+APIs, or dynamic evaluation. Public APIs accept existing symbolic IR nodes and
+return symbolic IR nodes.
+
+## Supported families
+
+| Family | Form |
+| --- | --- |
+| First-order linear | `D(y,x) + P(x)*y = Q(x)` |
+| Separable | `D(y,x) = f(x)*g(y)` |
+| Bernoulli | `D(y,x) + P(x)*y = Q(x)*y^n` |
+| Exact | `M(x,y) + N(x,y)*D(y,x) = 0` |
+| Second-order constant-coefficient homogeneous | `a*y'' + b*y' + c*y = 0` |
+| Second-order constant-coefficient nonhomogeneous | polynomial, exponential, sine, and cosine forcing, with variation-of-parameters fallback |
+| Euler-Cauchy | `a*x^2*y'' + b*x*y' + c*y = 0` |
+
+When an exact primitive is outside the built-in integration table, the solver
+returns symbolic `Integrate(expr, x)` nodes rather than failing the whole ODE.
+
+## Usage
+
+```ts
+import { ADD, D, MUL, SUB, app, int, sym } from "@coding-adventures/symbolic-ir";
+import { ode2 } from "@coding-adventures/cas-ode";
+
+const x = sym("x");
+const y = sym("y");
+const yPrime = app(D, [y, x]);
+
+const equation = app(SUB, [yPrime, app(MUL, [int(2), y])]);
+const result = ode2(equation, y, x);
+```
+
+`ode2(equation, y, x)` returns `Equal(y, ...)` when a supported solver matches,
+or the unevaluated `ODE2(equation, y, x)` node otherwise.

--- a/code/packages/typescript/cas-ode/package-lock.json
+++ b/code/packages/typescript/cas-ode/package-lock.json
@@ -1,0 +1,2506 @@
+{
+  "name": "@coding-adventures/cas-ode",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/cas-ode",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../symbolic-ir": {
+      "name": "@coding-adventures/symbolic-ir",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/symbolic-ir": {
+      "resolved": "../symbolic-ir",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/cas-ode/package.json
+++ b/code/packages/typescript/cas-ode/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@coding-adventures/cas-ode",
+  "version": "0.1.0",
+  "description": "Pure TypeScript symbolic ODE solver over symbolic IR",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": ["cas", "ode", "symbolic", "browser"],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/cas-ode/src/index.ts
+++ b/code/packages/typescript/cas-ode/src/index.ts
@@ -1,0 +1,1067 @@
+import {
+  ADD,
+  COS,
+  D,
+  DIV,
+  EQUAL,
+  EXP,
+  INTEGRATE,
+  LOG,
+  MUL,
+  NEG,
+  POW,
+  SIN,
+  SUB,
+  app,
+  equals,
+  headName,
+  int,
+  rational,
+  sym,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+
+export const ODE2 = sym("ODE2");
+export const C = sym("%c");
+export const C1 = sym("%c1");
+export const C2 = sym("%c2");
+
+export type EvalFn = (node: IRNode) => IRNode;
+
+export interface SolveOdeOptions {
+  readonly simplify?: EvalFn;
+  readonly integrate?: (node: IRNode, variable: IRNode) => IRNode | null | undefined;
+  readonly differentiate?: (node: IRNode, variable: IRNode) => IRNode | null | undefined;
+}
+
+type ClassifiedForcing =
+  | readonly ["poly", readonly Frac[]]
+  | readonly ["exp", Frac]
+  | readonly ["sin", Frac]
+  | readonly ["cos", Frac];
+
+const ZERO = int(0);
+const ONE = int(1);
+const TWO = int(2);
+const HALF = rational(1, 2);
+
+class Frac {
+  readonly numer: bigint;
+  readonly denom: bigint;
+
+  constructor(numerInput: bigint | number | string, denomInput: bigint | number | string = 1n) {
+    let numer = toBigInt(numerInput);
+    let denom = toBigInt(denomInput);
+    if (denom === 0n) throw new RangeError("Frac denominator must not be zero");
+    if (numer === 0n) {
+      this.numer = 0n;
+      this.denom = 1n;
+      return;
+    }
+    if (denom < 0n) {
+      numer = -numer;
+      denom = -denom;
+    }
+    const g = gcd(abs(numer), denom);
+    this.numer = numer / g;
+    this.denom = denom / g;
+  }
+
+  static zero(): Frac {
+    return new Frac(0n);
+  }
+
+  static one(): Frac {
+    return new Frac(1n);
+  }
+
+  static fromNode(node: IRNode): Frac | null {
+    if (node.kind === "integer") return new Frac(node.value);
+    if (node.kind === "rational") return new Frac(node.numer, node.denom);
+    if (node.kind === "apply" && headName(node.head) === NEG.name && node.args.length === 1) {
+      const inner = Frac.fromNode(node.args[0]);
+      return inner?.neg() ?? null;
+    }
+    return null;
+  }
+
+  isZero(): boolean {
+    return this.numer === 0n;
+  }
+
+  isOne(): boolean {
+    return this.numer === this.denom;
+  }
+
+  isNeg(): boolean {
+    return this.numer < 0n;
+  }
+
+  neg(): Frac {
+    return new Frac(-this.numer, this.denom);
+  }
+
+  add(rhs: Frac): Frac {
+    return new Frac(this.numer * rhs.denom + rhs.numer * this.denom, this.denom * rhs.denom);
+  }
+
+  sub(rhs: Frac): Frac {
+    return this.add(rhs.neg());
+  }
+
+  mul(rhs: Frac): Frac {
+    return new Frac(this.numer * rhs.numer, this.denom * rhs.denom);
+  }
+
+  div(rhs: Frac): Frac {
+    if (rhs.isZero()) throw new RangeError("Frac division by zero");
+    return new Frac(this.numer * rhs.denom, this.denom * rhs.numer);
+  }
+
+  eq(rhs: Frac): boolean {
+    return this.numer === rhs.numer && this.denom === rhs.denom;
+  }
+
+  gtZero(): boolean {
+    return this.numer > 0n;
+  }
+
+  ltZero(): boolean {
+    return this.numer < 0n;
+  }
+
+  toIr(): IRNode {
+    return this.denom === 1n ? int(this.numer) : rational(this.numer, this.denom);
+  }
+}
+
+export function solveOde(equation: IRNode, y: IRNode, x: IRNode, options: SolveOdeOptions = {}): IRNode | null {
+  if (y.kind !== "symbol" || x.kind !== "symbol") return null;
+  const ops = makeOps(options);
+  const expr = normalizeEquation(equation);
+
+  const nonhom = trySecondOrderNonhom(expr, y, x, ops);
+  if (nonhom !== null) return nonhom;
+
+  const second = collectSecondOrderCoeffs(expr, y, x);
+  if (second !== null) return solveSecondOrderConstCoeff(second.a, second.b, second.c, y, x);
+
+  const euler = tryEulerCauchy(expr, y, x);
+  if (euler !== null) return euler;
+
+  const bernoulli = tryBernoulli(expr, y, x, ops);
+  if (bernoulli !== null) return bernoulli;
+
+  const linear = collectLinearFirstOrder(expr, y, x);
+  if (linear !== null) return solveLinearFirstOrder(linear.p, linear.q, y, x, ops);
+
+  const exact = tryExact(expr, y, x, ops);
+  if (exact !== null) return exact;
+
+  const separable = trySeparable(expr, y, x, ops);
+  if (separable !== null) return separable;
+
+  return null;
+}
+
+export function ode2(equation: IRNode, y: IRNode, x: IRNode, options: SolveOdeOptions = {}): IRNode {
+  return solveOde(equation, y, x, options) ?? app(ODE2, [equation, y, x]);
+}
+
+export function ode2Handler(expr: IRNode, evalFn: EvalFn = (node) => node): IRNode {
+  const args = applyArgs(expr, ODE2);
+  if (args === undefined || args.length !== 3 || args[1].kind !== "symbol" || args[2].kind !== "symbol") return expr;
+  const solved = solveOde(args[0], args[1], args[2], { simplify: evalFn });
+  return solved === null ? expr : evalFn(solved);
+}
+
+export function buildOdeHandlerTable(): ReadonlyMap<string, (expr: IRNode, evalFn: EvalFn) => IRNode> {
+  return new Map([["ODE2", ode2Handler]]);
+}
+
+function normalizeEquation(equation: IRNode): IRNode {
+  const equal = applyArgs(equation, EQUAL);
+  return equal !== undefined && equal.length === 2 ? sub(equal[0], equal[1]) : equation;
+}
+
+interface Ops {
+  readonly simp: EvalFn;
+  readonly integrate: (node: IRNode, variable: IRNode) => IRNode;
+  readonly differentiate: (node: IRNode, variable: IRNode) => IRNode;
+}
+
+function makeOps(options: SolveOdeOptions): Ops {
+  const simp = options.simplify ?? ((node: IRNode) => localSimplify(node));
+  return {
+    simp: (node) => simp(localSimplify(node)),
+    integrate: (node, variable) => {
+      const custom = options.integrate?.(node, variable);
+      if (custom !== null && custom !== undefined) return simp(custom);
+      return simp(integrateLocal(node, variable));
+    },
+    differentiate: (node, variable) => {
+      const custom = options.differentiate?.(node, variable);
+      if (custom !== null && custom !== undefined) return simp(custom);
+      return simp(differentiateLocal(node, variable));
+    },
+  };
+}
+
+function solveLinearFirstOrder(p: IRNode, q: IRNode, y: IRNode, x: IRNode, ops: Ops): IRNode {
+  const intP = ops.integrate(p, x);
+  const mu = ops.simp(exp(intP));
+  const intMuQ = ops.integrate(mul(mu, q), x);
+  return app(EQUAL, [y, ops.simp(div(add(intMuQ, C), mu))]);
+}
+
+function trySeparable(expr: IRNode, y: IRNode, x: IRNode, ops: Ops): IRNode | null {
+  const extracted = extractFirstOrderRhs(expr, y, x);
+  if (extracted === null) return null;
+  const rhs = ops.simp(extracted);
+  if (isConstWrt(rhs, y)) return app(EQUAL, [y, ops.simp(add(ops.integrate(rhs, x), C))]);
+  if (isConstWrt(rhs, x)) {
+    const lhs = ops.integrate(div(ONE, rhs), y);
+    return app(EQUAL, [lhs, add(x, C)]);
+  }
+
+  const product = splitSeparableProduct(rhs, y, x);
+  if (product === null) return null;
+  const lhs = ops.integrate(div(ONE, product.gy), y);
+  const rhsInt = ops.integrate(product.fx, x);
+  return app(EQUAL, [lhs, ops.simp(add(rhsInt, C))]);
+}
+
+function tryBernoulli(expr: IRNode, y: IRNode, x: IRNode, ops: Ops): IRNode | null {
+  const yPrime = deriv(y, x);
+  let yPrimeCoeff = Frac.zero();
+  const pTerms: IRNode[] = [];
+  const qTerms: IRNode[] = [];
+  let power: bigint | null = null;
+
+  for (const term of flattenAdd(expr)) {
+    const coeffBase = extractRationalCoeff(term);
+    if (equals(coeffBase.base, yPrime)) {
+      yPrimeCoeff = yPrimeCoeff.add(coeffBase.coeff);
+      continue;
+    }
+
+    const yPow = extractPowerOfYTerm(term, y);
+    if (yPow !== null) {
+      if (power === null) power = yPow.power;
+      if (power !== yPow.power) return null;
+      qTerms.push(neg(yPow.coeff));
+      continue;
+    }
+
+    const yTerm = extractYFactor(term, y);
+    if (yTerm !== null) {
+      pTerms.push(yTerm);
+      continue;
+    }
+    return null;
+  }
+
+  if (!yPrimeCoeff.eq(Frac.one()) || power === null) return null;
+  const oneMinusN = new Frac(1n - power);
+  const reducedP = ops.simp(mul(oneMinusN.toIr(), sum(pTerms)));
+  const reducedQ = ops.simp(mul(oneMinusN.toIr(), sum(qTerms)));
+  const linear = solveLinearFirstOrder(reducedP, reducedQ, y, x, ops);
+  const rhs = linear.kind === "apply" && equals(linear.head, EQUAL) ? linear.args[1] : null;
+  if (rhs === null) return null;
+  return app(EQUAL, [y, ops.simp(pow(rhs, Frac.one().div(oneMinusN).toIr()))]);
+}
+
+function tryExact(expr: IRNode, y: IRNode, x: IRNode, ops: Ops): IRNode | null {
+  const yPrime = deriv(y, x);
+  const mParts: IRNode[] = [];
+  const nParts: IRNode[] = [];
+
+  for (const term of flattenAdd(expr)) {
+    const withoutDerivative = removeFactor(term, yPrime);
+    if (withoutDerivative !== null) {
+      nParts.push(withoutDerivative);
+    } else {
+      mParts.push(term);
+    }
+  }
+
+  if (nParts.length === 0) return null;
+  const M = ops.simp(sum(mParts));
+  const N = ops.simp(sum(nParts));
+  const dMdy = ops.simp(ops.differentiate(M, y));
+  const dNdx = ops.simp(ops.differentiate(N, x));
+  if (!equals(dMdy, dNdx)) return null;
+
+  const F = ops.integrate(M, x);
+  if (isApplyOf(F, INTEGRATE)) return null;
+  const dFdy = ops.differentiate(F, y);
+  const gPrime = ops.simp(sub(N, dFdy));
+  const g = ops.integrate(gPrime, y);
+  if (isApplyOf(g, INTEGRATE)) return null;
+  return app(EQUAL, [ops.simp(add(F, g)), C]);
+}
+
+function collectSecondOrderCoeffs(expr: IRNode, y: IRNode, x: IRNode): { a: Frac; b: Frac; c: Frac } | null {
+  const yPrime = deriv(y, x);
+  const yDouble = deriv(yPrime, x);
+  let a = Frac.zero();
+  let b = Frac.zero();
+  let c = Frac.zero();
+  let matched = 0;
+
+  for (const term of flattenAdd(expr)) {
+    const { coeff, base } = extractRationalCoeff(term);
+    if (equals(base, yDouble)) {
+      a = a.add(coeff);
+      matched += 1;
+    } else if (equals(base, yPrime)) {
+      b = b.add(coeff);
+      matched += 1;
+    } else if (equals(base, y)) {
+      c = c.add(coeff);
+      matched += 1;
+    } else {
+      return null;
+    }
+  }
+
+  return a.isZero() || matched < 2 ? null : { a, b, c };
+}
+
+function solveSecondOrderConstCoeff(a: Frac, b: Frac, c: Frac, y: IRNode, x: IRNode): IRNode {
+  const roots = characteristicRoots(a, b, c);
+  let solution: IRNode;
+  if (roots.kind === "distinct") {
+    solution = add(mul(C1, expR(roots.r1, x)), mul(C2, expR(roots.r2, x)));
+  } else if (roots.kind === "repeated") {
+    solution = mul(add(C1, mul(C2, x)), expR(roots.r, x));
+  } else {
+    const phase = mul(roots.beta, x);
+    solution = mul(exp(mul(roots.alpha, x)), add(mul(C1, app(COS, [phase])), mul(C2, app(SIN, [phase]))));
+  }
+  return app(EQUAL, [y, localSimplify(solution)]);
+}
+
+function tryEulerCauchy(expr: IRNode, y: IRNode, x: IRNode): IRNode | null {
+  const yPrime = deriv(y, x);
+  const yDouble = deriv(yPrime, x);
+  const xSq = pow(x, TWO);
+  let a = Frac.zero();
+  let b = Frac.zero();
+  let c = Frac.zero();
+  let matched = 0;
+
+  for (const term of flattenAdd(expr)) {
+    const product = flattenProduct(term);
+    const factors = product.factors;
+    if (factors.length === 1 && equals(factors[0], y)) {
+      c = c.add(product.coeff);
+      matched += 1;
+      continue;
+    }
+    if (factors.length === 2 && hasFactors(factors, x, yPrime)) {
+      b = b.add(product.coeff);
+      matched += 1;
+      continue;
+    }
+    if (factors.length === 2 && hasFactors(factors, xSq, yDouble)) {
+      a = a.add(product.coeff);
+      matched += 1;
+      continue;
+    }
+    return null;
+  }
+
+  if (a.isZero() || matched < 2) return null;
+  return solveEulerCauchy(a, b, c, y, x);
+}
+
+function solveEulerCauchy(a: Frac, b: Frac, c: Frac, y: IRNode, x: IRNode): IRNode {
+  const roots = characteristicRoots(a, b.sub(a), c);
+  const logX = app(LOG, [x]);
+  let solution: IRNode;
+  if (roots.kind === "distinct") {
+    solution = add(mul(C1, pow(x, roots.r1)), mul(C2, pow(x, roots.r2)));
+  } else if (roots.kind === "repeated") {
+    solution = mul(add(C1, mul(C2, logX)), pow(x, roots.r));
+  } else {
+    const phase = mul(roots.beta, logX);
+    solution = mul(pow(x, roots.alpha), add(mul(C1, app(COS, [phase])), mul(C2, app(SIN, [phase]))));
+  }
+  return app(EQUAL, [y, localSimplify(solution)]);
+}
+
+function trySecondOrderNonhom(expr: IRNode, y: IRNode, x: IRNode, ops: Ops): IRNode | null {
+  const collected = collectSecondOrderNonhom(expr, y, x);
+  if (collected === null) return null;
+  const hom = solveSecondOrderConstCoeff(collected.a, collected.b, collected.c, y, x);
+  const yh = hom.kind === "apply" && equals(hom.head, EQUAL) ? hom.args[1] : ZERO;
+  const forcing = classifyForcing(collected.f, x);
+  const particular = forcing === null
+    ? null
+    : computeParticular(collected.a, collected.b, collected.c, forcing, x);
+  const yp = particular ?? variationOfParameters(collected.a, collected.b, collected.c, collected.f, x, ops);
+  return app(EQUAL, [y, ops.simp(add(yh, yp))]);
+}
+
+function collectSecondOrderNonhom(expr: IRNode, y: IRNode, x: IRNode): { a: Frac; b: Frac; c: Frac; f: IRNode } | null {
+  const yPrime = deriv(y, x);
+  const yDouble = deriv(yPrime, x);
+  let a = Frac.zero();
+  let b = Frac.zero();
+  let c = Frac.zero();
+  const forcing: IRNode[] = [];
+
+  for (const term of flattenAdd(expr)) {
+    const { coeff, base } = extractRationalCoeff(term);
+    if (equals(base, yDouble)) {
+      a = a.add(coeff);
+    } else if (equals(base, yPrime)) {
+      b = b.add(coeff);
+    } else if (equals(base, y)) {
+      c = c.add(coeff);
+    } else if (isConstWrt(term, y)) {
+      forcing.push(neg(term));
+    } else {
+      return null;
+    }
+  }
+
+  if (a.isZero() || forcing.length === 0) return null;
+  return { a, b, c, f: sum(forcing) };
+}
+
+function classifyForcing(f: IRNode, x: IRNode): ClassifiedForcing | null {
+  const poly = polynomialCoeffs(f, x, 2);
+  if (poly !== null) return ["poly", poly];
+  const expArg = unaryArg(f, EXP);
+  if (expArg !== undefined) {
+    const alpha = extractLinearCoeff(expArg, x);
+    if (alpha !== null) return ["exp", alpha];
+  }
+  const sinArg = unaryArg(f, SIN);
+  if (sinArg !== undefined) {
+    const beta = extractLinearCoeff(sinArg, x);
+    if (beta !== null && beta.gtZero()) return ["sin", beta];
+  }
+  const cosArg = unaryArg(f, COS);
+  if (cosArg !== undefined) {
+    const beta = extractLinearCoeff(cosArg, x);
+    if (beta !== null && beta.gtZero()) return ["cos", beta];
+  }
+  return null;
+}
+
+function computeParticular(a: Frac, b: Frac, c: Frac, forcing: ClassifiedForcing, x: IRNode): IRNode | null {
+  if (forcing[0] === "poly") return polynomialParticular(a, b, c, forcing[1], x);
+  if (forcing[0] === "exp") {
+    const alpha = forcing[1];
+    const denom = charAt(a, b, c, alpha);
+    return denom.isZero() ? null : div(exp(mul(alpha.toIr(), x)), denom.toIr());
+  }
+  if (forcing[0] === "sin" || forcing[0] === "cos") {
+    const beta = forcing[1];
+    const m = c.sub(a.mul(beta).mul(beta));
+    const n = b.mul(beta);
+    const det = m.mul(m).add(n.mul(n));
+    if (det.isZero()) return null;
+    const cosTarget = forcing[0] === "cos" ? Frac.one() : Frac.zero();
+    const sinTarget = forcing[0] === "sin" ? Frac.one() : Frac.zero();
+    const A = cosTarget.mul(m).sub(sinTarget.mul(n)).div(det);
+    const B = sinTarget.mul(m).add(cosTarget.mul(n)).div(det);
+    return add(mul(A.toIr(), app(COS, [mul(beta.toIr(), x)])), mul(B.toIr(), app(SIN, [mul(beta.toIr(), x)])));
+  }
+  return null;
+}
+
+function polynomialParticular(a: Frac, b: Frac, c: Frac, coeffs: readonly Frac[], x: IRNode): IRNode | null {
+  const degree = coeffs.length - 1;
+  const unknownCount = degree + 3;
+  const equations = unknownCount;
+  const matrix: Frac[][] = [];
+  for (let row = 0; row < equations; row += 1) {
+    const line = Array.from({ length: unknownCount + 1 }, () => Frac.zero());
+    for (let k = 0; k < unknownCount; k += 1) {
+      if (k === row) line[k] = line[k].add(c);
+      if (k >= 1 && k - 1 === row) line[k] = line[k].add(b.mul(new Frac(k)));
+      if (k >= 2 && k - 2 === row) line[k] = line[k].add(a.mul(new Frac(k)).mul(new Frac(k - 1)));
+    }
+    line[unknownCount] = coeffs[row] ?? Frac.zero();
+    matrix.push(line);
+  }
+  const solution = solveLinearSystem(matrix, unknownCount);
+  if (solution === null) return null;
+  const terms: IRNode[] = [];
+  solution.forEach((coeff, powerIndex) => {
+    if (coeff.isZero()) return;
+    const base = powerIndex === 0 ? ONE : powerIndex === 1 ? x : pow(x, int(powerIndex));
+    terms.push(coeff.isOne() ? base : mul(coeff.toIr(), base));
+  });
+  return terms.length === 0 ? ZERO : sum(terms);
+}
+
+function variationOfParameters(a: Frac, b: Frac, c: Frac, f: IRNode, x: IRNode, ops: Ops): IRNode {
+  const roots = characteristicRoots(a, b, c);
+  const g = div(f, a.toIr());
+  let y1: IRNode;
+  let y2: IRNode;
+  let wronskian: IRNode;
+
+  if (roots.kind === "distinct") {
+    y1 = expR(roots.r1, x);
+    y2 = expR(roots.r2, x);
+    wronskian = mul(sub(roots.r2, roots.r1), exp(mul(add(roots.r1, roots.r2), x)));
+  } else if (roots.kind === "repeated") {
+    y1 = expR(roots.r, x);
+    y2 = mul(x, y1);
+    wronskian = exp(mul(mul(TWO, roots.r), x));
+  } else {
+    const phase = mul(roots.beta, x);
+    const envelope = exp(mul(roots.alpha, x));
+    y1 = mul(envelope, app(COS, [phase]));
+    y2 = mul(envelope, app(SIN, [phase]));
+    wronskian = mul(roots.beta, exp(mul(mul(TWO, roots.alpha), x)));
+  }
+
+  const u1Prime = neg(div(mul(y2, g), wronskian));
+  const u2Prime = div(mul(y1, g), wronskian);
+  return ops.simp(add(mul(neg(y1), ops.integrate(div(mul(y2, g), wronskian), x)), mul(y2, ops.integrate(u2Prime, x))));
+}
+
+function characteristicRoots(a: Frac, b: Frac, c: Frac):
+  | { readonly kind: "distinct"; readonly r1: IRNode; readonly r2: IRNode }
+  | { readonly kind: "repeated"; readonly r: IRNode }
+  | { readonly kind: "complex"; readonly alpha: IRNode; readonly beta: IRNode } {
+  const disc = b.mul(b).sub(new Frac(4).mul(a).mul(c));
+  if (disc.gtZero()) {
+    const sqrtDisc = exactSqrt(disc);
+    const twoA = new Frac(2).mul(a);
+    if (sqrtDisc !== null) {
+      return {
+        kind: "distinct",
+        r1: b.neg().add(sqrtDisc).div(twoA).toIr(),
+        r2: b.neg().sub(sqrtDisc).div(twoA).toIr(),
+      };
+    }
+    const sqrtIr = pow(disc.toIr(), HALF);
+    return {
+      kind: "distinct",
+      r1: div(add(b.neg().toIr(), sqrtIr), twoA.toIr()),
+      r2: div(sub(b.neg().toIr(), sqrtIr), twoA.toIr()),
+    };
+  }
+  if (disc.isZero()) return { kind: "repeated", r: b.neg().div(new Frac(2).mul(a)).toIr() };
+  const alpha = b.neg().div(new Frac(2).mul(a)).toIr();
+  const betaSq = disc.neg().div(new Frac(4).mul(a).mul(a));
+  const beta = exactSqrt(betaSq)?.toIr() ?? pow(betaSq.toIr(), HALF);
+  return { kind: "complex", alpha, beta };
+}
+
+function collectLinearFirstOrder(expr: IRNode, y: IRNode, x: IRNode): { p: IRNode; q: IRNode } | null {
+  const yPrime = deriv(y, x);
+  let yPrimeCoeff = Frac.zero();
+  const pTerms: IRNode[] = [];
+  const qTerms: IRNode[] = [];
+
+  for (const term of flattenAdd(expr)) {
+    const coeffBase = extractRationalCoeff(term);
+    if (equals(coeffBase.base, yPrime)) {
+      yPrimeCoeff = yPrimeCoeff.add(coeffBase.coeff);
+      continue;
+    }
+    const yFactor = extractYFactor(term, y);
+    if (yFactor !== null) {
+      pTerms.push(yFactor);
+      continue;
+    }
+    if (isConstWrt(term, y)) {
+      qTerms.push(neg(term));
+      continue;
+    }
+    return null;
+  }
+
+  if (yPrimeCoeff.isZero()) return null;
+  return {
+    p: div(sum(pTerms), yPrimeCoeff.toIr()),
+    q: div(sum(qTerms), yPrimeCoeff.toIr()),
+  };
+}
+
+function extractFirstOrderRhs(expr: IRNode, y: IRNode, x: IRNode): IRNode | null {
+  const yPrime = deriv(y, x);
+  const rhsTerms: IRNode[] = [];
+  let seen = false;
+  for (const term of flattenAdd(expr)) {
+    if (equals(term, yPrime)) {
+      seen = true;
+    } else {
+      const coeffBase = extractRationalCoeff(term);
+      if (equals(coeffBase.base, yPrime) && coeffBase.coeff.eq(Frac.one())) {
+        seen = true;
+      } else if (equals(coeffBase.base, yPrime)) {
+        return null;
+      } else {
+        rhsTerms.push(neg(term));
+      }
+    }
+  }
+  return seen ? sum(rhsTerms) : null;
+}
+
+function splitSeparableProduct(rhs: IRNode, y: IRNode, x: IRNode): { fx: IRNode; gy: IRNode } | null {
+  const product = flattenProduct(rhs);
+  const fx: IRNode[] = [];
+  const gy: IRNode[] = [];
+  if (!product.coeff.isOne()) fx.push(product.coeff.toIr());
+  for (const factor of product.factors) {
+    if (isConstWrt(factor, y)) {
+      fx.push(factor);
+    } else if (isConstWrt(factor, x)) {
+      gy.push(factor);
+    } else {
+      return null;
+    }
+  }
+  if (fx.length === 0 || gy.length === 0) return null;
+  return { fx: productOf(fx), gy: productOf(gy) };
+}
+
+function extractPowerOfYTerm(term: IRNode, y: IRNode): { coeff: IRNode; power: bigint } | null {
+  const product = flattenProduct(term);
+  const factors = [...product.factors];
+  const index = factors.findIndex((factor) => {
+    const args = applyArgs(factor, POW);
+    return args !== undefined
+      && args.length === 2
+      && equals(args[0], y)
+      && args[1].kind === "integer"
+      && args[1].value !== 0n
+      && args[1].value !== 1n;
+  });
+  if (index < 0) return null;
+  const powNode = factors[index];
+  const power = applyArgs(powNode, POW)?.[1];
+  if (power?.kind !== "integer") return null;
+  factors.splice(index, 1);
+  const coeffParts = product.coeff.isOne() ? factors : [product.coeff.toIr(), ...factors];
+  const coeff = productOf(coeffParts);
+  return isConstWrt(coeff, y) ? { coeff, power: power.value } : null;
+}
+
+function extractYFactor(term: IRNode, y: IRNode): IRNode | null {
+  const product = flattenProduct(term);
+  const factors = [...product.factors];
+  const index = factors.findIndex((factor) => equals(factor, y));
+  if (index < 0) return null;
+  factors.splice(index, 1);
+  const coeffParts = product.coeff.isOne() ? factors : [product.coeff.toIr(), ...factors];
+  const coeff = productOf(coeffParts);
+  return isConstWrt(coeff, y) ? coeff : null;
+}
+
+function removeFactor(term: IRNode, factor: IRNode): IRNode | null {
+  const product = flattenProduct(term);
+  const factors = [...product.factors];
+  const index = factors.findIndex((candidate) => equals(candidate, factor));
+  if (index < 0) return null;
+  factors.splice(index, 1);
+  return productOf(product.coeff.isOne() ? factors : [product.coeff.toIr(), ...factors]);
+}
+
+function flattenAdd(node: IRNode): IRNode[] {
+  if (node.kind === "apply" && headName(node.head) === ADD.name) return node.args.flatMap(flattenAdd);
+  if (node.kind === "apply" && headName(node.head) === SUB.name && node.args.length === 2) {
+    return [...flattenAdd(node.args[0]), ...flattenAdd(neg(node.args[1]))];
+  }
+  if (node.kind === "apply" && headName(node.head) === NEG.name && node.args.length === 1) {
+    return flattenAdd(node.args[0]).map(neg);
+  }
+  return [node];
+}
+
+function flattenProduct(node: IRNode): { coeff: Frac; factors: IRNode[] } {
+  if (node.kind === "apply" && headName(node.head) === MUL.name) {
+    return node.args.reduce(
+      (acc, arg) => {
+        const rhs = flattenProduct(arg);
+        return { coeff: acc.coeff.mul(rhs.coeff), factors: [...acc.factors, ...rhs.factors] };
+      },
+      { coeff: Frac.one(), factors: [] as IRNode[] },
+    );
+  }
+  if (node.kind === "apply" && headName(node.head) === NEG.name && node.args.length === 1) {
+    const inner = flattenProduct(node.args[0]);
+    return { coeff: inner.coeff.neg(), factors: inner.factors };
+  }
+  const literal = Frac.fromNode(node);
+  if (literal !== null) return { coeff: literal, factors: [] };
+  return { coeff: Frac.one(), factors: [node] };
+}
+
+function extractRationalCoeff(term: IRNode): { coeff: Frac; base: IRNode } {
+  const product = flattenProduct(term);
+  return { coeff: product.coeff, base: productOf(product.factors) };
+}
+
+function polynomialCoeffs(node: IRNode, variable: IRNode, maxDegree: number): Frac[] | null {
+  if (equals(node, variable)) return [Frac.zero(), Frac.one()];
+  const lit = Frac.fromNode(node);
+  if (lit !== null) return [lit];
+  if (node.kind === "symbol") return null;
+  if (node.kind !== "apply") return null;
+  const name = headName(node.head);
+  if (name === ADD.name) {
+    let out = [Frac.zero()];
+    for (const arg of node.args) {
+      const rhs = polynomialCoeffs(arg, variable, maxDegree);
+      if (rhs === null) return null;
+      out = coeffsAdd(out, rhs);
+    }
+    return trimDegree(out, maxDegree);
+  }
+  if (name === SUB.name && node.args.length === 2) {
+    const lhs = polynomialCoeffs(node.args[0], variable, maxDegree);
+    const rhs = polynomialCoeffs(node.args[1], variable, maxDegree);
+    return lhs === null || rhs === null ? null : trimDegree(coeffsSub(lhs, rhs), maxDegree);
+  }
+  if (name === NEG.name && node.args.length === 1) {
+    const inner = polynomialCoeffs(node.args[0], variable, maxDegree);
+    return inner?.map((c) => c.neg()) ?? null;
+  }
+  if (name === MUL.name) {
+    let out = [Frac.one()];
+    for (const arg of node.args) {
+      const rhs = polynomialCoeffs(arg, variable, maxDegree);
+      if (rhs === null) return null;
+      out = coeffsMul(out, rhs);
+      if (out.length > maxDegree + 1 && out.slice(maxDegree + 1).some((c) => !c.isZero())) return null;
+    }
+    return trimDegree(out, maxDegree);
+  }
+  if (name === POW.name && node.args.length === 2 && node.args[1].kind === "integer" && node.args[1].value >= 0n) {
+    let out = [Frac.one()];
+    const base = polynomialCoeffs(node.args[0], variable, maxDegree);
+    if (base === null || node.args[1].value > BigInt(maxDegree)) return null;
+    for (let i = 0n; i < node.args[1].value; i += 1n) out = coeffsMul(out, base);
+    return trimDegree(out, maxDegree);
+  }
+  return null;
+}
+
+function differentiateLocal(node: IRNode, variable: IRNode): IRNode {
+  if (equals(node, variable)) return ONE;
+  if (node.kind !== "apply") return ZERO;
+  const name = headName(node.head);
+  if (name === ADD.name) return sum(node.args.map((arg) => differentiateLocal(arg, variable)));
+  if (name === SUB.name && node.args.length === 2) return sub(differentiateLocal(node.args[0], variable), differentiateLocal(node.args[1], variable));
+  if (name === NEG.name && node.args.length === 1) return neg(differentiateLocal(node.args[0], variable));
+  if (name === MUL.name) {
+    return sum(node.args.map((arg, index) => productOf(node.args.map((factor, factorIndex) => (
+      index === factorIndex ? differentiateLocal(arg, variable) : factor
+    )))));
+  }
+  if (name === DIV.name && node.args.length === 2) {
+    const [u, v] = node.args;
+    return div(sub(mul(differentiateLocal(u, variable), v), mul(u, differentiateLocal(v, variable))), pow(v, TWO));
+  }
+  if (name === POW.name && node.args.length === 2 && node.args[1].kind === "integer") {
+    const n = node.args[1].value;
+    if (n === 0n) return ZERO;
+    return mul(int(n), mul(pow(node.args[0], int(n - 1n)), differentiateLocal(node.args[0], variable)));
+  }
+  if (name === EXP.name && node.args.length === 1) return mul(app(EXP, [node.args[0]]), differentiateLocal(node.args[0], variable));
+  if (name === SIN.name && node.args.length === 1) return mul(app(COS, [node.args[0]]), differentiateLocal(node.args[0], variable));
+  if (name === COS.name && node.args.length === 1) return neg(mul(app(SIN, [node.args[0]]), differentiateLocal(node.args[0], variable)));
+  if (name === LOG.name && node.args.length === 1) return div(differentiateLocal(node.args[0], variable), node.args[0]);
+  return app(D, [node, variable]);
+}
+
+function integrateLocal(node: IRNode, variable: IRNode): IRNode {
+  const simplified = localSimplify(node);
+  if (isConstWrt(simplified, variable)) return mul(simplified, variable);
+  if (equals(simplified, variable)) return div(pow(variable, TWO), TWO);
+  if (simplified.kind === "apply") {
+    const name = headName(simplified.head);
+    if (name === ADD.name) return sum(simplified.args.map((arg) => integrateLocal(arg, variable)));
+    if (name === SUB.name && simplified.args.length === 2) return sub(integrateLocal(simplified.args[0], variable), integrateLocal(simplified.args[1], variable));
+    if (name === NEG.name && simplified.args.length === 1) return neg(integrateLocal(simplified.args[0], variable));
+    if (name === MUL.name) {
+      const product = flattenProduct(simplified);
+      const constants = product.factors.filter((factor) => isConstWrt(factor, variable));
+      const rest = product.factors.filter((factor) => !isConstWrt(factor, variable));
+      if (rest.length === 1 && (constants.length > 0 || !product.coeff.isOne())) {
+        const constant = productOf(product.coeff.isOne() ? constants : [product.coeff.toIr(), ...constants]);
+        return mul(constant, integrateLocal(rest[0], variable));
+      }
+    }
+    if (name === POW.name && simplified.args.length === 2 && equals(simplified.args[0], variable) && simplified.args[1].kind === "integer") {
+      const n = simplified.args[1].value;
+      if (n === -1n) return app(LOG, [variable]);
+      return div(pow(variable, int(n + 1n)), int(n + 1n));
+    }
+    if (name === DIV.name && simplified.args.length === 2 && equals(simplified.args[1], variable) && equals(simplified.args[0], ONE)) {
+      return app(LOG, [variable]);
+    }
+    if (name === EXP.name && simplified.args.length === 1) {
+      const coeff = extractLinearCoeff(simplified.args[0], variable);
+      if (coeff !== null && !coeff.isZero()) return div(simplified, coeff.toIr());
+    }
+    if ((name === SIN.name || name === COS.name) && simplified.args.length === 1) {
+      const coeff = extractLinearCoeff(simplified.args[0], variable);
+      if (coeff !== null && !coeff.isZero()) {
+        return name === SIN.name
+          ? neg(div(app(COS, [simplified.args[0]]), coeff.toIr()))
+          : div(app(SIN, [simplified.args[0]]), coeff.toIr());
+      }
+    }
+  }
+  return app(INTEGRATE, [simplified, variable]);
+}
+
+function localSimplify(node: IRNode): IRNode {
+  if (node.kind !== "apply") return node;
+  const head = localSimplify(node.head);
+  const args = node.args.map(localSimplify);
+  const name = headName(head);
+  if (name === NEG.name && args.length === 1) return neg(args[0]);
+  if (name === ADD.name) return sum(args);
+  if (name === SUB.name && args.length === 2) return sub(args[0], args[1]);
+  if (name === MUL.name) return productOf(args);
+  if (name === DIV.name && args.length === 2) return div(args[0], args[1]);
+  if (name === POW.name && args.length === 2) return pow(args[0], args[1]);
+  if (name === EXP.name && args.length === 1 && isInteger(args[0], 0n)) return ONE;
+  return app(head, args);
+}
+
+function extractLinearCoeff(node: IRNode, variable: IRNode): Frac | null {
+  if (equals(node, variable)) return Frac.one();
+  if (node.kind === "apply" && headName(node.head) === NEG.name && node.args.length === 1) {
+    return extractLinearCoeff(node.args[0], variable)?.neg() ?? null;
+  }
+  const product = flattenProduct(node);
+  if (product.factors.length === 1 && equals(product.factors[0], variable)) return product.coeff;
+  return null;
+}
+
+function isConstWrt(node: IRNode, variable: IRNode): boolean {
+  if (equals(node, variable)) return false;
+  return node.kind !== "apply" || node.args.every((arg) => isConstWrt(arg, variable));
+}
+
+function applyArgs(node: IRNode, head: IRNode): readonly IRNode[] | undefined {
+  return node.kind === "apply" && equals(node.head, head) ? node.args : undefined;
+}
+
+function unaryArg(node: IRNode, head: IRNode): IRNode | undefined {
+  const args = applyArgs(node, head);
+  return args !== undefined && args.length === 1 ? args[0] : undefined;
+}
+
+function isApplyOf(node: IRNode, head: IRNode): boolean {
+  return node.kind === "apply" && equals(node.head, head);
+}
+
+function hasFactors(factors: readonly IRNode[], a: IRNode, b: IRNode): boolean {
+  return (equals(factors[0], a) && equals(factors[1], b)) || (equals(factors[0], b) && equals(factors[1], a));
+}
+
+function expR(r: IRNode, x: IRNode): IRNode {
+  return exp(mul(r, x));
+}
+
+function deriv(expr: IRNode, variable: IRNode): IRNode {
+  return app(D, [expr, variable]);
+}
+
+function add(...args: IRNode[]): IRNode {
+  return sum(args);
+}
+
+function sum(args: readonly IRNode[]): IRNode {
+  const flat = args.flatMap((arg) => (arg.kind === "apply" && headName(arg.head) === ADD.name ? [...arg.args] : [arg]));
+  const kept: IRNode[] = [];
+  let literal = Frac.zero();
+  for (const arg of flat) {
+    const f = Frac.fromNode(arg);
+    if (f !== null) literal = literal.add(f);
+    else if (!isInteger(arg, 0n)) {
+      const negArg = unwrapNeg(arg);
+      const cancelIndex = negArg === null
+        ? kept.findIndex((candidate) => {
+          const inner = unwrapNeg(candidate);
+          return inner !== null && equals(inner, arg);
+        })
+        : kept.findIndex((candidate) => equals(candidate, negArg));
+      if (cancelIndex >= 0) kept.splice(cancelIndex, 1);
+      else kept.push(arg);
+    }
+  }
+  if (!literal.isZero()) kept.unshift(literal.toIr());
+  if (kept.length === 0) return ZERO;
+  if (kept.length === 1) return kept[0];
+  return app(ADD, kept);
+}
+
+function sub(lhs: IRNode, rhs: IRNode): IRNode {
+  return equals(rhs, ZERO) ? lhs : sum([lhs, neg(rhs)]);
+}
+
+function mul(...args: IRNode[]): IRNode {
+  return productOf(args);
+}
+
+function productOf(args: readonly IRNode[]): IRNode {
+  const flat = args.flatMap((arg) => (arg.kind === "apply" && headName(arg.head) === MUL.name ? [...arg.args] : [arg]));
+  const kept: IRNode[] = [];
+  let literal = Frac.one();
+  for (const arg of flat) {
+    const f = Frac.fromNode(arg);
+    if (f !== null) literal = literal.mul(f);
+    else if (!isInteger(arg, 1n)) kept.push(arg);
+  }
+  for (let i = 0; i < kept.length; i += 1) {
+    const divArgs = applyArgs(kept[i], DIV);
+    const denom = divArgs?.length === 2 ? Frac.fromNode(divArgs[1]) : null;
+    if (divArgs !== undefined && denom !== null && !literal.isOne()) {
+      literal = literal.div(denom);
+      kept[i] = divArgs[0];
+    }
+  }
+  if (literal.isZero()) return ZERO;
+  if (!literal.isOne()) kept.unshift(literal.toIr());
+  if (kept.length === 0) return ONE;
+  if (kept.length === 1) return kept[0];
+  return app(MUL, kept);
+}
+
+function div(lhs: IRNode, rhs: IRNode): IRNode {
+  if (equals(lhs, ZERO)) return ZERO;
+  if (equals(rhs, ONE)) return lhs;
+  const lf = Frac.fromNode(lhs);
+  const rf = Frac.fromNode(rhs);
+  if (lf !== null && rf !== null) return lf.div(rf).toIr();
+  return app(DIV, [lhs, rhs]);
+}
+
+function pow(base: IRNode, exponent: IRNode): IRNode {
+  if (isInteger(exponent, 0n)) return ONE;
+  if (isInteger(exponent, 1n)) return base;
+  if (base.kind === "integer" && exponent.kind === "integer" && exponent.value >= 0n) return int(base.value ** exponent.value);
+  return app(POW, [base, exponent]);
+}
+
+function exp(arg: IRNode): IRNode {
+  return isInteger(arg, 0n) ? ONE : app(EXP, [arg]);
+}
+
+function neg(node: IRNode): IRNode {
+  const f = Frac.fromNode(node);
+  if (f !== null) return f.neg().toIr();
+  if (node.kind === "apply" && headName(node.head) === NEG.name && node.args.length === 1) return node.args[0];
+  return app(NEG, [node]);
+}
+
+function unwrapNeg(node: IRNode): IRNode | null {
+  return node.kind === "apply" && headName(node.head) === NEG.name && node.args.length === 1 ? node.args[0] : null;
+}
+
+function isInteger(node: IRNode, value: bigint): boolean {
+  return node.kind === "integer" && node.value === value;
+}
+
+function coeffsAdd(lhs: readonly Frac[], rhs: readonly Frac[]): Frac[] {
+  const n = Math.max(lhs.length, rhs.length);
+  return Array.from({ length: n }, (_, index) => (lhs[index] ?? Frac.zero()).add(rhs[index] ?? Frac.zero()));
+}
+
+function coeffsSub(lhs: readonly Frac[], rhs: readonly Frac[]): Frac[] {
+  const n = Math.max(lhs.length, rhs.length);
+  return Array.from({ length: n }, (_, index) => (lhs[index] ?? Frac.zero()).sub(rhs[index] ?? Frac.zero()));
+}
+
+function coeffsMul(lhs: readonly Frac[], rhs: readonly Frac[]): Frac[] {
+  const out = Array.from({ length: lhs.length + rhs.length - 1 }, () => Frac.zero());
+  for (let i = 0; i < lhs.length; i += 1) {
+    for (let j = 0; j < rhs.length; j += 1) out[i + j] = out[i + j].add(lhs[i].mul(rhs[j]));
+  }
+  return out;
+}
+
+function trimDegree(coeffs: readonly Frac[], maxDegree: number): Frac[] | null {
+  if (coeffs.slice(maxDegree + 1).some((coeff) => !coeff.isZero())) return null;
+  let end = Math.min(coeffs.length, maxDegree + 1);
+  while (end > 1 && coeffs[end - 1].isZero()) end -= 1;
+  return coeffs.slice(0, end);
+}
+
+function charAt(a: Frac, b: Frac, c: Frac, r: Frac): Frac {
+  return a.mul(r).mul(r).add(b.mul(r)).add(c);
+}
+
+function exactSqrt(value: Frac): Frac | null {
+  if (value.ltZero()) return null;
+  const n = integerSqrt(value.numer);
+  const d = integerSqrt(value.denom);
+  return n === null || d === null ? null : new Frac(n, d);
+}
+
+function integerSqrt(value: bigint): bigint | null {
+  if (value < 0n) return null;
+  if (value < 2n) return value;
+  let lo = 1n;
+  let hi = value;
+  while (lo <= hi) {
+    const mid = (lo + hi) / 2n;
+    const sq = mid * mid;
+    if (sq === value) return mid;
+    if (sq < value) lo = mid + 1n;
+    else hi = mid - 1n;
+  }
+  return null;
+}
+
+function solveLinearSystem(matrix: Frac[][], unknownCount: number): Frac[] | null {
+  let row = 0;
+  const pivots: number[] = [];
+  for (let col = 0; col < unknownCount && row < matrix.length; col += 1) {
+    const pivot = matrix.findIndex((line, index) => index >= row && !line[col].isZero());
+    if (pivot < 0) continue;
+    [matrix[row], matrix[pivot]] = [matrix[pivot], matrix[row]];
+    const scale = matrix[row][col];
+    matrix[row] = matrix[row].map((entry) => entry.div(scale));
+    for (let r = 0; r < matrix.length; r += 1) {
+      if (r === row || matrix[r][col].isZero()) continue;
+      const factor = matrix[r][col];
+      matrix[r] = matrix[r].map((entry, index) => entry.sub(factor.mul(matrix[row][index])));
+    }
+    pivots[row] = col;
+    row += 1;
+  }
+  if (matrix.some((line) => line.slice(0, unknownCount).every((entry) => entry.isZero()) && !line[unknownCount].isZero())) {
+    return null;
+  }
+  const out = Array.from({ length: unknownCount }, () => Frac.zero());
+  for (let r = 0; r < pivots.length; r += 1) out[pivots[r]] = matrix[r][unknownCount];
+  return out;
+}
+
+function toBigInt(value: bigint | number | string): bigint {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "string") return BigInt(value);
+  if (!Number.isSafeInteger(value)) throw new RangeError("number inputs must be safe integers");
+  return BigInt(value);
+}
+
+function gcd(a: bigint, b: bigint): bigint {
+  while (b !== 0n) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a === 0n ? 1n : a;
+}
+
+function abs(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}

--- a/code/packages/typescript/cas-ode/tests/cas-ode.test.ts
+++ b/code/packages/typescript/cas-ode/tests/cas-ode.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  COS,
+  D,
+  DIV,
+  EQUAL,
+  EXP,
+  INTEGRATE,
+  LOG,
+  MUL,
+  POW,
+  SIN,
+  SUB,
+  app,
+  equals,
+  headName,
+  int,
+  sym,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+import { C, C1, C2, ODE2, buildOdeHandlerTable, ode2, solveOde } from "../src/index";
+
+const x = sym("x");
+const y = sym("y");
+const yp = app(D, [y, x]);
+const ypp = app(D, [yp, x]);
+
+function expectEqual(actual: IRNode, expected: IRNode): void {
+  expect(equals(actual, expected), `${display(actual)} !== ${display(expected)}`).toBe(true);
+}
+
+function display(node: IRNode): string {
+  return JSON.stringify(node, (_key, value) => (typeof value === "bigint" ? value.toString() : value));
+}
+
+function hasHead(node: IRNode, name: string): boolean {
+  return node.kind === "apply" && (headName(node.head) === name || node.args.some((arg) => hasHead(arg, name)));
+}
+
+function rhsOfEqual(node: IRNode): IRNode {
+  expect(node.kind).toBe("apply");
+  expect(node.kind === "apply" && equals(node.head, EQUAL)).toBe(true);
+  return (node as Extract<IRNode, { kind: "apply" }>).args[1];
+}
+
+describe("cas-ode package shape", () => {
+  it("exports an ODE2 handler table", () => {
+    const table = buildOdeHandlerTable();
+    expect(table.get("ODE2")).toBeTypeOf("function");
+  });
+
+  it("falls through as an unevaluated ODE2 node", () => {
+    const unsupported = app(ADD, [yp, app(SIN, [app(MUL, [x, y])])]);
+    expectEqual(ode2(unsupported, y, x), app(ODE2, [unsupported, y, x]));
+  });
+});
+
+describe("first-order ODEs", () => {
+  it("solves first-order linear equations with symbolic integrating factors", () => {
+    const equation = app(SUB, [yp, app(MUL, [int(2), y])]);
+    const result = solveOde(equation, y, x);
+    expect(result).not.toBeNull();
+    const rhs = rhsOfEqual(result!);
+    expect(hasHead(rhs, EXP.name)).toBe(true);
+    expect(hasHead(rhs, DIV.name)).toBe(true);
+    expect(display(rhs)).toContain("%c");
+  });
+
+  it("returns implicit integrals for separable nonlinear equations", () => {
+    const equation = app(SUB, [yp, app(MUL, [x, app(POW, [y, int(2)])])]);
+    const result = solveOde(equation, y, x);
+    expect(result).not.toBeNull();
+    expect(result?.kind === "apply" && equals(result.head, EQUAL)).toBe(true);
+    expect(display(result!)).toContain("%c");
+  });
+
+  it("solves Bernoulli equations through the linearized substitution", () => {
+    const equation = app(ADD, [app(SUB, [yp, y]), app(POW, [y, int(2)])]);
+    const result = solveOde(equation, y, x);
+    expect(result).not.toBeNull();
+    const rhs = rhsOfEqual(result!);
+    expect(hasHead(rhs, POW.name)).toBe(true);
+    expect(display(rhs)).toContain("%c");
+  });
+
+  it("solves exact equations as implicit potentials", () => {
+    const M = app(ADD, [app(MUL, [int(2), x, y]), int(1)]);
+    const N = app(POW, [x, int(2)]);
+    const equation = app(ADD, [M, app(MUL, [N, yp])]);
+    const result = solveOde(equation, y, x);
+    const expectedPotential = app(ADD, [x, app(MUL, [y, app(POW, [x, int(2)])])]);
+    expectEqual(result!, app(EQUAL, [expectedPotential, C]));
+  });
+});
+
+describe("second-order ODEs", () => {
+  it("solves constant-coefficient homogeneous equations", () => {
+    const result = solveOde(app(ADD, [ypp, y]), y, x);
+    const expected = app(EQUAL, [
+      y,
+      app(ADD, [
+        app(MUL, [C1, app(COS, [x])]),
+        app(MUL, [C2, app(SIN, [x])]),
+      ]),
+    ]);
+    expectEqual(result!, expected);
+  });
+
+  it("solves polynomial-forced constant-coefficient equations", () => {
+    const equation = app(SUB, [app(ADD, [ypp, y]), x]);
+    const result = solveOde(equation, y, x);
+    const rhs = rhsOfEqual(result!);
+    expect(display(rhs)).toContain("%c1");
+    expect(display(rhs)).toContain("%c2");
+    expect(display(rhs)).toContain("\"name\":\"x\"");
+  });
+
+  it("uses variation of parameters with symbolic Integrate fallback", () => {
+    const equation = app(SUB, [app(ADD, [ypp, y]), app(LOG, [x])]);
+    const result = solveOde(equation, y, x);
+    expect(result).not.toBeNull();
+    expect(hasHead(result!, INTEGRATE.name)).toBe(true);
+  });
+
+  it("solves Euler-Cauchy equations", () => {
+    const equation = app(SUB, [app(MUL, [app(POW, [x, int(2)]), ypp]), app(MUL, [int(2), y])]);
+    const result = solveOde(equation, y, x);
+    const rhs = rhsOfEqual(result!);
+    expect(display(rhs)).toContain("%c1");
+    expect(display(rhs)).toContain("%c2");
+    expect(hasHead(rhs, POW.name)).toBe(true);
+  });
+});

--- a/code/packages/typescript/cas-ode/tsconfig.json
+++ b/code/packages/typescript/cas-ode/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ESNext"],
+    "types": ["vitest", "node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add `@coding-adventures/cas-ode`, a pure TypeScript/browser-safe symbolic ODE solver over `@coding-adventures/symbolic-ir`.
- Port the main Python-supported ODE families where feasible: first-order linear, separable, Bernoulli, exact, second-order constant-coefficient homogeneous/nonhomogeneous, Euler-Cauchy, and variation-of-parameters fallback with symbolic `Integrate(...)` nodes.
- Add package metadata, BUILD, tsconfig, README, CHANGELOG, lockfile, and focused Vitest coverage.

## Validation

- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage` (83.06% lines / 83.06% statements)

## Deferred Python edge cases

- No lexer/parser or VM wiring; this package intentionally exposes pure IR APIs only.
- Homogeneous-type first-order `y'/x` ratio substitution from Python Phase 18c is not included in this initial TS port.
- Undetermined coefficients handles polynomial, exponential, sine, and cosine forcing directly; mixed `exp(alpha*x)*sin/cos(beta*x)` and resonant forcing route through symbolic variation-of-parameters integrals.
- Exact ODE support uses local symbolic differentiation/integration, so exactness cases requiring broader VM algebraic simplification remain deferred.
