### PR TITLE
[codex] Add generic job executor health classification

### DIFF
--- a/code/packages/rust/generic-job-runtime/CHANGELOG.md
+++ b/code/packages/rust/generic-job-runtime/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this package will be documented in this file.
   policies stop crash loops.
 - Added non-consuming executor snapshots for supervisor/read-side tools to
   inspect worker liveness, queue saturation, and in-flight job counts.
+- Added executor snapshot health classification for supervisor/read-side tools
+  to identify idle, busy, saturated, draining, and offline executors.
 
 ## [0.1.0] - 2026-04-21
 

--- a/code/packages/rust/generic-job-runtime/README.md
+++ b/code/packages/rust/generic-job-runtime/README.md
@@ -26,6 +26,8 @@ targets.
 - Capability and limit metadata that adapters can inspect.
 - Non-consuming executor snapshots for supervisor/read-side tools, including
   live workers, in-flight jobs, queued jobs, running jobs, and saturation.
+- Snapshot health classification for D18C supervisors to distinguish idle,
+  busy, saturated, draining, and offline executors.
 
 The crate does not know about TCP, RESP, Redis, IRC, or sockets. Those adapters
 submit typed job payloads and decide how to apply responses.

--- a/code/packages/rust/generic-job-runtime/src/lib.rs
+++ b/code/packages/rust/generic-job-runtime/src/lib.rs
@@ -73,6 +73,15 @@ pub struct ExecutorSnapshot {
     pub max_payload_bytes: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutorHealth {
+    Idle,
+    Busy,
+    Saturated,
+    Draining,
+    Offline,
+}
+
 impl ExecutorSnapshot {
     pub fn remaining_queue_capacity(&self) -> usize {
         self.max_queue_depth.saturating_sub(self.in_flight_jobs)
@@ -80,6 +89,37 @@ impl ExecutorSnapshot {
 
     pub fn is_saturated(&self) -> bool {
         self.in_flight_jobs >= self.max_queue_depth
+    }
+
+    pub fn pending_jobs(&self) -> usize {
+        self.queued_jobs.saturating_add(self.running_jobs)
+    }
+
+    pub fn has_live_capacity(&self) -> bool {
+        !self.shutting_down && self.live_workers > 0 && self.remaining_queue_capacity() > 0
+    }
+
+    pub fn health(&self) -> ExecutorHealth {
+        if self.shutting_down {
+            return ExecutorHealth::Draining;
+        }
+        if self.live_workers == 0 {
+            return ExecutorHealth::Offline;
+        }
+        if self.is_saturated() {
+            return ExecutorHealth::Saturated;
+        }
+        if self.pending_jobs() > 0 {
+            return ExecutorHealth::Busy;
+        }
+        ExecutorHealth::Idle
+    }
+
+    pub fn needs_supervisor_attention(&self) -> bool {
+        matches!(
+            self.health(),
+            ExecutorHealth::Offline | ExecutorHealth::Saturated
+        )
     }
 }
 
@@ -1535,6 +1575,10 @@ for line in sys.stdin:
         assert_eq!(snapshot.max_payload_bytes, 256);
         assert_eq!(snapshot.remaining_queue_capacity(), 0);
         assert!(snapshot.is_saturated());
+        assert_eq!(snapshot.pending_jobs(), 2);
+        assert_eq!(snapshot.health(), ExecutorHealth::Saturated);
+        assert!(!snapshot.has_live_capacity());
+        assert!(snapshot.needs_supervisor_attention());
         assert!(!snapshot.shutting_down);
 
         open_gate(&gate);
@@ -1567,6 +1611,50 @@ for line in sys.stdin:
         let shutdown_snapshot = idle_pool.snapshot();
         assert!(shutdown_snapshot.shutting_down);
         assert_eq!(shutdown_snapshot.live_workers, 0);
+        assert_eq!(shutdown_snapshot.health(), ExecutorHealth::Draining);
+        assert!(!shutdown_snapshot.needs_supervisor_attention());
+    }
+
+    #[test]
+    fn executor_snapshot_health_classifies_supervisor_states() {
+        let idle = ExecutorSnapshot {
+            worker_count: 2,
+            live_workers: 2,
+            in_flight_jobs: 0,
+            queued_jobs: 0,
+            running_jobs: 0,
+            shutting_down: false,
+            max_queue_depth: 4,
+            max_payload_bytes: 1024,
+        };
+        assert_eq!(idle.health(), ExecutorHealth::Idle);
+        assert!(idle.has_live_capacity());
+        assert!(!idle.needs_supervisor_attention());
+
+        let busy = ExecutorSnapshot {
+            in_flight_jobs: 1,
+            running_jobs: 1,
+            ..idle.clone()
+        };
+        assert_eq!(busy.health(), ExecutorHealth::Busy);
+        assert_eq!(busy.pending_jobs(), 1);
+        assert!(busy.has_live_capacity());
+
+        let offline = ExecutorSnapshot {
+            live_workers: 0,
+            ..idle.clone()
+        };
+        assert_eq!(offline.health(), ExecutorHealth::Offline);
+        assert!(offline.needs_supervisor_attention());
+
+        let draining = ExecutorSnapshot {
+            live_workers: 0,
+            shutting_down: true,
+            ..idle
+        };
+        assert_eq!(draining.health(), ExecutorHealth::Draining);
+        assert!(!draining.has_live_capacity());
+        assert!(!draining.needs_supervisor_attention());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `ExecutorHealth` classifications for idle, busy, saturated, draining, and offline executor snapshots
- expose snapshot helpers for pending jobs, live capacity, and supervisor attention
- document the D18C supervisor/read-side health surface

## Tests
- `cargo fmt --manifest-path code/packages/rust/Cargo.toml --package generic-job-runtime`
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p generic-job-runtime`
- `git diff --check`