### PR TITLE
Add generic job retry policy primitives

### DIFF
--- a/code/packages/rust/generic-job-protocol/CHANGELOG.md
+++ b/code/packages/rust/generic-job-protocol/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - Added portable job metadata builders, envelope validation, deadline helpers,
   and attempt increment helpers for cross-language workers.
+- Added portable retry policy primitives for retryable errors, capped
+  exponential backoff, and exhausted-attempt decisions.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/rust/generic-job-protocol/README.md
+++ b/code/packages/rust/generic-job-protocol/README.md
@@ -10,6 +10,8 @@ bridges:
 - `JobMetadata` carries routing, ordering, priority, trace, and affinity facts.
 - Metadata helpers validate portable envelopes and compute deadline/attempt facts
   without depending on a runtime scheduler.
+- `JobRetryPolicy` classifies retryable errors, exhausted attempts, and capped
+  exponential backoff using the same metadata across runtimes.
 - JSON-line codec helpers provide a phase-one process/stdio wire format.
 
 It intentionally does not implement a thread pool, process pool, TCP runtime, or

--- a/code/packages/rust/generic-job-protocol/src/lib.rs
+++ b/code/packages/rust/generic-job-protocol/src/lib.rs
@@ -199,6 +199,108 @@ impl JobMetadata {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobRetryPolicy {
+    #[serde(default)]
+    pub max_retries: u32,
+    #[serde(default)]
+    pub initial_backoff_ms: u64,
+    #[serde(default)]
+    pub max_backoff_ms: u64,
+}
+
+impl Default for JobRetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            initial_backoff_ms: 1_000,
+            max_backoff_ms: 30_000,
+        }
+    }
+}
+
+impl JobRetryPolicy {
+    pub fn disabled() -> Self {
+        Self {
+            max_retries: 0,
+            initial_backoff_ms: 0,
+            max_backoff_ms: 0,
+        }
+    }
+
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    pub fn with_initial_backoff_ms(mut self, initial_backoff_ms: u64) -> Self {
+        self.initial_backoff_ms = initial_backoff_ms;
+        self
+    }
+
+    pub fn with_max_backoff_ms(mut self, max_backoff_ms: u64) -> Self {
+        self.max_backoff_ms = max_backoff_ms;
+        self
+    }
+
+    pub fn retry_delay_ms_for_attempt(&self, attempt: u32) -> u64 {
+        let shift = attempt.min(63);
+        let multiplier = if shift == 63 {
+            u64::MAX
+        } else {
+            1_u64 << shift
+        };
+        self.initial_backoff_ms
+            .saturating_mul(multiplier)
+            .min(self.max_backoff_ms)
+    }
+
+    pub fn decision_for_error(&self, metadata: &JobMetadata, error: &JobError) -> JobRetryDecision {
+        if !error.retryable {
+            return JobRetryDecision::Stop {
+                reason: JobRetryStopReason::NotRetryable,
+            };
+        }
+        if metadata.attempt >= self.max_retries {
+            return JobRetryDecision::Stop {
+                reason: JobRetryStopReason::AttemptsExhausted,
+            };
+        }
+
+        let next_metadata = metadata.next_attempt();
+        JobRetryDecision::Retry {
+            metadata: next_metadata,
+            delay_ms: self.retry_delay_ms_for_attempt(metadata.attempt),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum JobRetryStopReason {
+    NotRetryable,
+    AttemptsExhausted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "snake_case", deny_unknown_fields)]
+pub enum JobRetryDecision {
+    Retry {
+        metadata: JobMetadata,
+        delay_ms: u64,
+    },
+    Stop {
+        reason: JobRetryStopReason,
+    },
+}
+
+impl JobRetryDecision {
+    pub fn should_retry(&self) -> bool {
+        matches!(self, Self::Retry { .. })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JobValidationError {
     EmptyField {
@@ -265,6 +367,16 @@ impl JobError {
             origin,
             detail: None,
         }
+    }
+
+    pub fn with_retryable(mut self, retryable: bool) -> Self {
+        self.retryable = retryable;
+        self
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
     }
 }
 
@@ -532,6 +644,62 @@ mod tests {
         assert_eq!(metadata.remaining_deadline_ms_at(260), Some(0));
         assert_eq!(metadata.next_attempt().attempt, 3);
         metadata.validate().unwrap();
+    }
+
+    #[test]
+    fn retry_policy_classifies_retryable_errors_with_capped_backoff() {
+        let metadata = JobMetadata::default()
+            .with_created_at_ms(100)
+            .with_deadline_at_ms(1_000)
+            .with_attempt(2)
+            .with_trace_id("trace-7");
+        let policy = JobRetryPolicy::default()
+            .with_initial_backoff_ms(250)
+            .with_max_backoff_ms(750);
+        let error = JobError::new("busy", "worker saturated", JobErrorOrigin::Executor)
+            .with_retryable(true)
+            .with_detail("queue depth exceeded");
+
+        let decision = policy.decision_for_error(&metadata, &error);
+
+        assert!(decision.should_retry());
+        assert_eq!(policy.retry_delay_ms_for_attempt(0), 250);
+        assert_eq!(policy.retry_delay_ms_for_attempt(1), 500);
+        assert_eq!(policy.retry_delay_ms_for_attempt(2), 750);
+        assert_eq!(policy.retry_delay_ms_for_attempt(63), 750);
+        assert_eq!(error.detail.as_deref(), Some("queue depth exceeded"));
+        match decision {
+            JobRetryDecision::Retry { metadata, delay_ms } => {
+                assert_eq!(metadata.attempt, 3);
+                assert_eq!(metadata.trace_id.as_deref(), Some("trace-7"));
+                assert_eq!(delay_ms, 750);
+            }
+            JobRetryDecision::Stop { .. } => panic!("retryable error should retry"),
+        }
+    }
+
+    #[test]
+    fn retry_policy_stops_for_non_retryable_or_exhausted_errors() {
+        let policy = JobRetryPolicy::default().with_max_retries(1);
+        let retryable = JobError::new("busy", "worker saturated", JobErrorOrigin::Executor)
+            .with_retryable(true);
+        let permanent = JobError::new("bad_input", "invalid request", JobErrorOrigin::Producer);
+
+        assert_eq!(
+            policy.decision_for_error(&JobMetadata::default(), &permanent),
+            JobRetryDecision::Stop {
+                reason: JobRetryStopReason::NotRetryable
+            }
+        );
+        assert_eq!(
+            policy.decision_for_error(&JobMetadata::default().with_attempt(1), &retryable),
+            JobRetryDecision::Stop {
+                reason: JobRetryStopReason::AttemptsExhausted
+            }
+        );
+        assert!(!JobRetryPolicy::disabled()
+            .decision_for_error(&JobMetadata::default(), &retryable)
+            .should_retry());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add portable JobRetryPolicy, JobRetryDecision, and stop-reason primitives
- add retryable/detail builders for JobError
- cover retryable errors, exhausted attempts, disabled retry policy, and capped exponential backoff

## Tests
- cargo fmt --manifest-path code/packages/rust/Cargo.toml --package generic-job-protocol
- cargo test --manifest-path code/packages/rust/Cargo.toml -p generic-job-protocol
- git diff --check
- rm -f code/packages/rust/Cargo.lock && test ! -f code/packages/rust/Cargo.lock