### PR TITLE
Expose Bluetooth discovery candidates to languages

### DIFF
--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -70,6 +70,10 @@ function M.bluetooth_endpoint(endpoint)
     return native().bluetooth_endpoint(endpoint)
 end
 
+function M.bluetooth_endpoint_candidates(devices)
+    return native().bluetooth_endpoint_candidates(devices)
+end
+
 function M.esp_upload_options(selector)
     return native().esp_upload_options(selector or "esp32")
 end

--- a/code/packages/lua/board_vm_native/src/lib.rs
+++ b/code/packages/lua/board_vm_native/src/lib.rs
@@ -8,22 +8,23 @@ use board_vm_host::{
     DEFAULT_RUN_FLAGS,
 };
 use board_vm_language_core::{
-    board_family_name, build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
-    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
-    build_run_wire_frame, connection_options_for_target, connection_transport_name, detect_target,
-    discover_devices, discover_devices_from_paths, esp_upload_options_for_target,
-    host_endpoint_transport_name, known_targets, onboard_led_kind,
-    parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
-    wireless_transport_name, BoardVmLanguageSession, BuiltWireFrame, LanguageBluetoothEndpoint,
-    LanguageConnectionOption, LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice,
-    LanguageOnboardLed, LanguagePicoUf2UploadOptions, LanguageTargetInfo,
-    LanguageWirelessInterface,
+    bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
+    build_caps_query_wire_frame, build_hello_wire_frame, build_program_begin_wire_frame,
+    build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_wire_frame,
+    connection_options_for_target, connection_transport_name, detect_target, discover_devices,
+    discover_devices_from_paths, esp_upload_options_for_target, host_endpoint_transport_name,
+    known_targets, onboard_led_kind, parse_bluetooth_endpoint as core_parse_bluetooth_endpoint,
+    pico_uf2_upload_options_for_target, wireless_transport_name, BoardVmLanguageSession,
+    BuiltWireFrame, LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
+    LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
+    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
+    LanguageTargetInfo, LanguageWirelessInterface,
 };
 use lua_bridge::{
-    get_str, luaL_Reg, luaL_checkinteger, lua_Integer, lua_State, lua_createtable, lua_gettop,
-    lua_pop, lua_pushboolean, lua_pushinteger, lua_pushlstring, lua_pushnil, lua_rawgeti,
-    lua_rawlen, lua_rawseti, lua_setfield, lua_tolstring, lua_type, push_str, raise_error,
-    register_lib, LUA_TTABLE,
+    get_str, luaL_Reg, luaL_checkinteger, lua_Integer, lua_State, lua_createtable, lua_getfield,
+    lua_gettop, lua_pop, lua_pushboolean, lua_pushinteger, lua_pushlstring, lua_pushnil,
+    lua_rawgeti, lua_rawlen, lua_rawseti, lua_setfield, lua_toboolean, lua_tointegerx,
+    lua_tolstring, lua_type, push_str, raise_error, register_lib, LUA_TNIL, LUA_TTABLE,
 };
 
 unsafe fn check_u8(L: *mut lua_State, index: c_int, name: &str) -> u8 {
@@ -107,6 +108,113 @@ unsafe fn read_string_table(L: *mut lua_State, index: c_int, name: &str) -> Vec<
         lua_pop(L, 1);
     }
     values
+}
+
+unsafe fn absolute_index(L: *mut lua_State, index: c_int) -> c_int {
+    if index < 0 {
+        lua_gettop(L) + index + 1
+    } else {
+        index
+    }
+}
+
+unsafe fn read_optional_string_field(
+    L: *mut lua_State,
+    table_index: c_int,
+    key: &str,
+) -> Option<String> {
+    let table_index = absolute_index(L, table_index);
+    let c_key = CString::new(key).unwrap();
+    lua_getfield(L, table_index, c_key.as_ptr());
+    let value = if lua_type(L, -1) == LUA_TNIL {
+        None
+    } else {
+        Some(get_str(L, -1).unwrap_or_else(|| raise_error(L, &format!("{key} must be a string"))))
+    };
+    lua_pop(L, 1);
+    value
+}
+
+unsafe fn read_bool_field(L: *mut lua_State, table_index: c_int, key: &str) -> bool {
+    let table_index = absolute_index(L, table_index);
+    let c_key = CString::new(key).unwrap();
+    lua_getfield(L, table_index, c_key.as_ptr());
+    let value = lua_type(L, -1) != LUA_TNIL && lua_toboolean(L, -1) != 0;
+    lua_pop(L, 1);
+    value
+}
+
+unsafe fn read_string_array_field(L: *mut lua_State, table_index: c_int, key: &str) -> Vec<String> {
+    let table_index = absolute_index(L, table_index);
+    let c_key = CString::new(key).unwrap();
+    lua_getfield(L, table_index, c_key.as_ptr());
+    let value = if lua_type(L, -1) == LUA_TNIL {
+        Vec::new()
+    } else {
+        read_string_table(L, -1, key)
+    };
+    lua_pop(L, 1);
+    value
+}
+
+unsafe fn read_u8_array_field(L: *mut lua_State, table_index: c_int, key: &str) -> Vec<u8> {
+    let table_index = absolute_index(L, table_index);
+    let c_key = CString::new(key).unwrap();
+    lua_getfield(L, table_index, c_key.as_ptr());
+    if lua_type(L, -1) == LUA_TNIL {
+        lua_pop(L, 1);
+        return Vec::new();
+    }
+    if lua_type(L, -1) != LUA_TTABLE {
+        raise_error(L, &format!("{key} must be a table of integers"));
+    }
+
+    let len = lua_rawlen(L, -1);
+    let mut values = Vec::with_capacity(len as usize);
+    for i in 1..=len {
+        lua_rawgeti(L, -1, i);
+        let mut isnum = 0;
+        let value = lua_tointegerx(L, -1, &mut isnum);
+        if isnum == 0 || !(0..=u8::MAX as lua_Integer).contains(&value) {
+            raise_error(L, &format!("{key}[{i}] must fit in u8"));
+        }
+        values.push(value as u8);
+        lua_pop(L, 1);
+    }
+    lua_pop(L, 1);
+    values
+}
+
+unsafe fn read_bluetooth_discovered_devices(
+    L: *mut lua_State,
+    index: c_int,
+) -> Vec<LanguageBluetoothDiscoveredDevice> {
+    if lua_type(L, index) != LUA_TTABLE {
+        raise_error(L, "devices must be a table");
+    }
+
+    let table_index = absolute_index(L, index);
+    let len = lua_rawlen(L, table_index);
+    let mut devices = Vec::with_capacity(len as usize);
+    for i in 1..=len {
+        lua_rawgeti(L, table_index, i);
+        if lua_type(L, -1) != LUA_TTABLE {
+            raise_error(L, &format!("devices[{i}] must be a table"));
+        }
+        let id = read_optional_string_field(L, -1, "id")
+            .unwrap_or_else(|| raise_error(L, &format!("devices[{i}].id must be a string")));
+        devices.push(LanguageBluetoothDiscoveredDevice {
+            id,
+            name: read_optional_string_field(L, -1, "name"),
+            address: read_optional_string_field(L, -1, "address"),
+            paired: read_bool_field(L, -1, "paired"),
+            service_uuids: read_string_array_field(L, -1, "service_uuids"),
+            characteristic_uuids: read_string_array_field(L, -1, "characteristic_uuids"),
+            board_vm_rfcomm_channels: read_u8_array_field(L, -1, "board_vm_rfcomm_channels"),
+        });
+        lua_pop(L, 1);
+    }
+    devices
 }
 
 fn core_result<T>(L: *mut lua_State, result: Result<T, LanguageCoreError>) -> T {
@@ -240,6 +348,31 @@ unsafe fn push_bluetooth_endpoint(L: *mut lua_State, endpoint: &LanguageBluetoot
     push_optional_int(L, "channel", endpoint.channel);
 }
 
+unsafe fn push_bluetooth_endpoint_candidate(
+    L: *mut lua_State,
+    candidate: &LanguageBluetoothEndpointCandidate,
+) {
+    lua_bridge::lua_newtable(L);
+    let key = CString::new("endpoint").unwrap();
+    push_bluetooth_endpoint(L, &candidate.endpoint);
+    lua_setfield(L, -2, key.as_ptr());
+    set_str(L, "device", &candidate.device);
+    set_str(L, "display_name", &candidate.display_name);
+    set_bool(L, "paired", candidate.paired);
+    set_bool(L, "requires_pairing", candidate.requires_pairing);
+}
+
+unsafe fn push_bluetooth_endpoint_candidates(
+    L: *mut lua_State,
+    candidates: &[LanguageBluetoothEndpointCandidate],
+) {
+    lua_createtable(L, candidates.len() as c_int, 0);
+    for (index, candidate) in candidates.iter().enumerate() {
+        push_bluetooth_endpoint_candidate(L, candidate);
+        lua_rawseti(L, -2, (index + 1) as lua_Integer);
+    }
+}
+
 unsafe fn push_target(L: *mut lua_State, target: &LanguageTargetInfo) {
     lua_bridge::lua_newtable(L);
     set_str(L, "board_id", &target.board_id);
@@ -367,6 +500,13 @@ unsafe extern "C" fn lua_bluetooth_endpoint(L: *mut lua_State) -> c_int {
         Some(endpoint) => push_bluetooth_endpoint(L, &endpoint),
         None => lua_pushnil(L),
     }
+    1
+}
+
+unsafe extern "C" fn lua_bluetooth_endpoint_candidates(L: *mut lua_State) -> c_int {
+    let devices = read_bluetooth_discovered_devices(L, 1);
+    let candidates = bluetooth_endpoint_candidates_from_devices(&devices);
+    push_bluetooth_endpoint_candidates(L, &candidates);
     1
 }
 
@@ -515,7 +655,7 @@ unsafe extern "C" fn lua_defaults(L: *mut lua_State) -> c_int {
     1
 }
 
-struct FuncTable([luaL_Reg; 17]);
+struct FuncTable([luaL_Reg; 18]);
 unsafe impl Sync for FuncTable {}
 
 static FUNCS: FuncTable = FuncTable([
@@ -534,6 +674,10 @@ static FUNCS: FuncTable = FuncTable([
     luaL_Reg {
         name: b"bluetooth_endpoint\0".as_ptr() as *const _,
         func: Some(lua_bluetooth_endpoint),
+    },
+    luaL_Reg {
+        name: b"bluetooth_endpoint_candidates\0".as_ptr() as *const _,
+        func: Some(lua_bluetooth_endpoint_candidates),
     },
     luaL_Reg {
         name: b"esp_upload_options\0".as_ptr() as *const _,

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -78,6 +78,52 @@ describe("coding_adventures.board_vm_native", function()
         assert.is_nil(board_vm.bluetooth_endpoint("tcp://board-vm.local:4170"))
     end)
 
+    it("plans Bluetooth endpoint candidates through Rust-owned metadata", function()
+        local candidates = board_vm.bluetooth_endpoint_candidates({
+            {
+                id = "ignore-me",
+                service_uuids = { "180f" },
+            },
+            {
+                id = "esp32-board-vm",
+                name = "ESP32 Board VM",
+                paired = true,
+                board_vm_rfcomm_channels = { 3, 3, 31 },
+            },
+            {
+                id = "uno-r4",
+                name = "Uno R4 Board VM",
+                address = "AA:BB:CC:DD:EE:FF",
+                service_uuids = { "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" },
+            },
+        })
+
+        local rfcomm = nil
+        local ble = nil
+        for _, candidate in ipairs(candidates) do
+            if candidate.endpoint.channel == 3 then
+                rfcomm = candidate
+            end
+            if candidate.endpoint.service_uuid ~= nil then
+                ble = candidate
+            end
+        end
+
+        assert.are.equal(2, #candidates)
+        assert.are.equal("ESP32 Board VM", rfcomm.display_name)
+        assert.are.equal("bluetooth_classic_rfcomm", rfcomm.endpoint.endpoint_transport)
+        assert.are.equal("btspp://esp32-board-vm:3", rfcomm.endpoint.endpoint)
+        assert.is_true(rfcomm.paired)
+        assert.is_false(rfcomm.requires_pairing)
+
+        assert.are.equal("Uno R4 Board VM", ble.display_name)
+        assert.are.equal("bluetooth_le_gatt", ble.endpoint.endpoint_transport)
+        assert.are.equal("AA:BB:CC:DD:EE:FF", ble.device)
+        assert.are.equal("6e400001-b5a3-f393-e0a9-e50e24dcca9e", ble.endpoint.service_uuid)
+        assert.is_false(ble.paired)
+        assert.is_true(ble.requires_pairing)
+    end)
+
     it("classifies host devices through Rust-owned discovery rules", function()
         local devices = board_vm.devices({
             "/dev/cu.usbmodem1101",

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1458,6 +1458,61 @@ def bluetooth_endpoint(endpoint: str) -> dict[str, Any] | None:
     return None if parsed is None else dict(parsed)
 
 
+def bluetooth_endpoint_candidates(devices: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized = []
+    for device in devices:
+        device_id = _bluetooth_device_field(device, "id")
+        if device_id is None:
+            raise ValueError("Bluetooth discovered device id is required")
+
+        normalized.append(
+            {
+                "id": str(device_id),
+                "name": _optional_str(_bluetooth_device_field(device, "name")),
+                "address": _optional_str(_bluetooth_device_field(device, "address")),
+                "paired": bool(_bluetooth_device_field(device, "paired")),
+                "service_uuids": [
+                    str(value)
+                    for value in _bluetooth_device_sequence(device, "service_uuids")
+                ],
+                "characteristic_uuids": [
+                    str(value)
+                    for value in _bluetooth_device_sequence(device, "characteristic_uuids")
+                ],
+                "board_vm_rfcomm_channels": [
+                    int(value)
+                    for value in _bluetooth_device_sequence(
+                        device, "board_vm_rfcomm_channels"
+                    )
+                ],
+            }
+        )
+
+    candidates = []
+    for candidate in _native.bluetooth_endpoint_candidates(normalized):
+        value = dict(candidate)
+        value["endpoint"] = dict(value["endpoint"])
+        candidates.append(value)
+    return candidates
+
+
+def _bluetooth_device_field(device: Any, key: str) -> Any:
+    if isinstance(device, dict):
+        return device.get(key)
+    return getattr(device, key, None)
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _bluetooth_device_sequence(device: Any, key: str) -> list[Any]:
+    value = _bluetooth_device_field(device, key)
+    if value is None:
+        return []
+    return list(value)
+
+
 def connection_options(selector: str) -> list[dict[str, Any]]:
     target = detect_target(selector)
     if target is None:
@@ -2069,6 +2124,8 @@ __all__ = [
     "Session",
     "SessionResult",
     "TcpTransport",
+    "bluetooth_endpoint",
+    "bluetooth_endpoint_candidates",
     "connection_option_list",
     "connect",
     "connection_options",

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_long};
+use std::ffi::{c_char, c_int, c_long, CString};
 use std::ptr;
 
 use board_vm_host::{
@@ -9,23 +9,24 @@ use board_vm_host::{
     GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
-    board_family_name, build_blink_module, build_caps_query_wire_frame,
-    build_gpio_handle_close_module, build_gpio_handle_read_module, build_gpio_handle_write_module,
-    build_gpio_open_module, build_gpio_read_module, build_gpio_write_module,
-    build_hello_wire_frame, build_program_begin_wire_frame, build_program_chunk_wire_frame,
-    build_program_end_wire_frame, build_raw_module, build_run_background_wire_frame,
-    build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
-    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
-    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    connection_transport_name, decode_wire_response, detect_target as core_detect_target,
-    discover_devices as core_discover_devices, discover_devices_from_paths,
-    discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
+    bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
+    build_caps_query_wire_frame, build_gpio_handle_close_module, build_gpio_handle_read_module,
+    build_gpio_handle_write_module, build_gpio_open_module, build_gpio_read_module,
+    build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
+    build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
+    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
+    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
+    capability_protocol_feature, connection_transport_name, decode_wire_response,
+    detect_target as core_detect_target, discover_devices as core_discover_devices,
+    discover_devices_from_paths, discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
     discover_pico_bootsel_mounts_in_roots, esp_upload_options_for_target,
     host_endpoint_transport_name, known_targets, onboard_led_kind,
     parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
     program_format_name, raw_module_len, run_status_name, wireless_transport_name,
     BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageBluetoothEndpoint, LanguageConnectionOption, LanguageCoreError,
+    LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
+    LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
     LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
     LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
 };
@@ -35,6 +36,8 @@ use python_bridge::*;
 extern "C" {
     fn PyLong_AsLong(obj: PyObjectPtr) -> c_long;
     fn PyErr_Occurred() -> PyObjectPtr;
+    fn PyDict_GetItemString(p: PyObjectPtr, key: *const c_char) -> PyObjectPtr;
+    fn PyObject_IsTrue(o: PyObjectPtr) -> c_int;
 }
 
 unsafe extern "C" fn py_hello_wire(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
@@ -489,6 +492,30 @@ unsafe extern "C" fn py_bluetooth_endpoint(_module: PyObjectPtr, args: PyObjectP
     }
 }
 
+unsafe extern "C" fn py_bluetooth_endpoint_candidates(
+    _module: PyObjectPtr,
+    args: PyObjectPtr,
+) -> PyObjectPtr {
+    let devices_arg = PyTuple_GetItem(args, 0);
+    if devices_arg.is_null() {
+        PyErr_Clear();
+        set_error(
+            type_error_class(),
+            "bluetooth_endpoint_candidates() requires devices as list",
+        );
+        return ptr::null_mut();
+    }
+
+    let devices = match language_bluetooth_devices_from_py(devices_arg) {
+        Some(devices) => devices,
+        None => return ptr::null_mut(),
+    };
+
+    language_bluetooth_endpoint_candidates_to_py(&bluetooth_endpoint_candidates_from_devices(
+        &devices,
+    ))
+}
+
 unsafe extern "C" fn py_esp_upload_options(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
     let selector = match parse_arg_str(args, 0) {
         Some(value) => value,
@@ -929,6 +956,151 @@ unsafe fn language_bluetooth_endpoint_to_py(endpoint: &LanguageBluetoothEndpoint
     dict
 }
 
+unsafe fn language_bluetooth_endpoint_candidates_to_py(
+    candidates: &[LanguageBluetoothEndpointCandidate],
+) -> PyObjectPtr {
+    let list = PyList_New(candidates.len() as isize);
+    for (index, candidate) in candidates.iter().enumerate() {
+        let dict = PyDict_New();
+        dict_set(
+            dict,
+            "endpoint",
+            language_bluetooth_endpoint_to_py(&candidate.endpoint),
+        );
+        dict_set(dict, "device", str_to_py(&candidate.device));
+        dict_set(dict, "display_name", str_to_py(&candidate.display_name));
+        dict_set(dict, "paired", bool_to_py(candidate.paired));
+        dict_set(
+            dict,
+            "requires_pairing",
+            bool_to_py(candidate.requires_pairing),
+        );
+        PyList_SetItem(list, index as isize, dict);
+    }
+    list
+}
+
+unsafe fn language_bluetooth_devices_from_py(
+    devices: PyObjectPtr,
+) -> Option<Vec<LanguageBluetoothDiscoveredDevice>> {
+    let len = PyList_Size(devices);
+    if len < 0 {
+        PyErr_Clear();
+        set_error(
+            type_error_class(),
+            "bluetooth_endpoint_candidates() requires devices as list",
+        );
+        return None;
+    }
+
+    let mut parsed = Vec::with_capacity(len as usize);
+    for index in 0..len {
+        let device = PyList_GetItem(devices, index);
+        let Some(id) = py_dict_optional_str(device, "id") else {
+            set_error(
+                type_error_class(),
+                "Bluetooth discovered device id must be a str",
+            );
+            return None;
+        };
+
+        parsed.push(LanguageBluetoothDiscoveredDevice {
+            id,
+            name: py_dict_optional_str(device, "name"),
+            address: py_dict_optional_str(device, "address"),
+            paired: py_dict_bool(device, "paired"),
+            service_uuids: py_dict_vec_str(device, "service_uuids")?,
+            characteristic_uuids: py_dict_vec_str(device, "characteristic_uuids")?,
+            board_vm_rfcomm_channels: py_dict_vec_u8(device, "board_vm_rfcomm_channels")?,
+        });
+    }
+    Some(parsed)
+}
+
+unsafe fn py_dict_get(dict: PyObjectPtr, key: &str) -> PyObjectPtr {
+    let key = CString::new(key).unwrap();
+    PyDict_GetItemString(dict, key.as_ptr())
+}
+
+unsafe fn py_dict_optional_str(dict: PyObjectPtr, key: &str) -> Option<String> {
+    let value = py_dict_get(dict, key);
+    if value.is_null() {
+        None
+    } else {
+        str_from_py(value)
+    }
+}
+
+unsafe fn py_dict_bool(dict: PyObjectPtr, key: &str) -> bool {
+    let value = py_dict_get(dict, key);
+    if value.is_null() {
+        return false;
+    }
+    let truthy = PyObject_IsTrue(value);
+    if truthy < 0 {
+        PyErr_Clear();
+        false
+    } else {
+        truthy != 0
+    }
+}
+
+unsafe fn py_dict_vec_str(dict: PyObjectPtr, key: &str) -> Option<Vec<String>> {
+    let value = py_dict_get(dict, key);
+    if value.is_null() {
+        Some(Vec::new())
+    } else {
+        vec_str_from_py(value).or_else(|| {
+            set_error(
+                type_error_class(),
+                &format!("Bluetooth discovered device {key} must be a list of str"),
+            );
+            None
+        })
+    }
+}
+
+unsafe fn py_dict_vec_u8(dict: PyObjectPtr, key: &str) -> Option<Vec<u8>> {
+    let value = py_dict_get(dict, key);
+    if value.is_null() {
+        return Some(Vec::new());
+    }
+
+    let len = PyList_Size(value);
+    if len < 0 {
+        PyErr_Clear();
+        set_error(
+            type_error_class(),
+            &format!("Bluetooth discovered device {key} must be a list of int"),
+        );
+        return None;
+    }
+
+    let mut values = Vec::with_capacity(len as usize);
+    for index in 0..len {
+        let item = PyList_GetItem(value, index);
+        PyErr_Clear();
+        let channel = PyLong_AsLong(item);
+        if channel == -1 && !PyErr_Occurred().is_null() {
+            PyErr_Clear();
+            set_error(
+                type_error_class(),
+                &format!("Bluetooth discovered device {key}[{index}] must be an int"),
+            );
+            return None;
+        }
+        if !(0..=u8::MAX as c_long).contains(&channel) {
+            set_error(
+                value_error_class(),
+                &format!("Bluetooth discovered device {key}[{index}] must fit in u8"),
+            );
+            return None;
+        }
+        values.push(channel as u8);
+    }
+    Some(values)
+}
+
 unsafe fn esp_upload_options_to_py(options: &LanguageEspUploadOptions) -> PyObjectPtr {
     let dict = PyDict_New();
     dict_set(dict, "board_id", str_to_py(&options.board_id));
@@ -1292,7 +1464,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 29] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 30] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1442,6 +1614,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_bluetooth_endpoint),
             ml_flags: METH_VARARGS,
             ml_doc: b"Parse a Board VM Bluetooth endpoint in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"bluetooth_endpoint_candidates\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_bluetooth_endpoint_candidates),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Plan Board VM Bluetooth endpoint candidates in Rust.\0".as_ptr()
+                as *const c_char,
         },
         PyMethodDef {
             ml_name: b"esp_upload_options\0".as_ptr() as *const c_char,

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -15,6 +15,7 @@ from board_vm_native import (
     Session,
     TcpTransport,
     bluetooth_endpoint,
+    bluetooth_endpoint_candidates,
     connect,
     connection_option_list,
     connection_options,
@@ -201,6 +202,50 @@ def test_bluetooth_endpoints_are_parsed_by_rust_language_core():
     assert rfcomm["device"] == "ESP32-BoardVM"
     assert rfcomm["channel"] == 3
     assert bluetooth_endpoint("tcp://board-vm.local:4170") is None
+
+
+def test_bluetooth_endpoint_candidates_are_planned_by_rust_language_core():
+    candidates = bluetooth_endpoint_candidates(
+        [
+            {
+                "id": "ignore-me",
+                "service_uuids": ["180f"],
+            },
+            {
+                "id": "esp32-board-vm",
+                "name": "ESP32 Board VM",
+                "paired": True,
+                "board_vm_rfcomm_channels": [3, 3, 31],
+            },
+            {
+                "id": "uno-r4",
+                "name": "Uno R4 Board VM",
+                "address": "AA:BB:CC:DD:EE:FF",
+                "service_uuids": ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"],
+            },
+        ]
+    )
+
+    assert len(candidates) == 2
+    rfcomm = next(
+        candidate for candidate in candidates if candidate["endpoint"]["channel"] == 3
+    )
+    ble = next(
+        candidate for candidate in candidates if candidate["endpoint"]["service_uuid"]
+    )
+
+    assert rfcomm["display_name"] == "ESP32 Board VM"
+    assert rfcomm["endpoint"]["endpoint_transport"] == "bluetooth_classic_rfcomm"
+    assert rfcomm["endpoint"]["endpoint"] == "btspp://esp32-board-vm:3"
+    assert rfcomm["paired"] is True
+    assert rfcomm["requires_pairing"] is False
+
+    assert ble["display_name"] == "Uno R4 Board VM"
+    assert ble["endpoint"]["endpoint_transport"] == "bluetooth_le_gatt"
+    assert ble["device"] == "AA:BB:CC:DD:EE:FF"
+    assert ble["endpoint"]["service_uuid"] == "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+    assert ble["paired"] is False
+    assert ble["requires_pairing"] is True
 
 
 def test_connection_options_can_be_selected_without_exposing_ports():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -10,23 +10,24 @@ use board_vm_host::{
     GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
-    board_family_name, build_blink_module, build_caps_query_wire_frame,
-    build_gpio_handle_close_module, build_gpio_handle_read_module, build_gpio_handle_write_module,
-    build_gpio_open_module, build_gpio_read_module, build_gpio_write_module,
-    build_hello_wire_frame, build_program_begin_wire_frame, build_program_chunk_wire_frame,
-    build_program_end_wire_frame, build_raw_module, build_run_background_wire_frame,
-    build_run_wire_frame, build_stop_wire_frame, build_store_program_wire_frame,
-    build_time_now_module, build_time_sleep_ms_module, capability_board_metadata,
-    capability_bytecode_callable, capability_flag_names, capability_protocol_feature,
-    connection_transport_name, decode_wire_response, detect_target as core_detect_target,
-    discover_devices as core_discover_devices, discover_devices_from_paths,
-    discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
+    bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
+    build_caps_query_wire_frame, build_gpio_handle_close_module, build_gpio_handle_read_module,
+    build_gpio_handle_write_module, build_gpio_open_module, build_gpio_read_module,
+    build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
+    build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
+    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
+    capability_board_metadata, capability_bytecode_callable, capability_flag_names,
+    capability_protocol_feature, connection_transport_name, decode_wire_response,
+    detect_target as core_detect_target, discover_devices as core_discover_devices,
+    discover_devices_from_paths, discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
     discover_pico_bootsel_mounts_in_roots, esp_upload_options_for_target,
     host_endpoint_transport_name, known_targets, onboard_led_kind,
     parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
     program_format_name, raw_module_len, run_status_name, wireless_transport_name,
     BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageBluetoothEndpoint, LanguageConnectionOption, LanguageCoreError,
+    LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
+    LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
     LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
     LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
 };
@@ -429,6 +430,11 @@ extern "C" fn native_bluetooth_endpoint(_self_val: VALUE, endpoint_val: VALUE) -
     }
 }
 
+extern "C" fn native_bluetooth_endpoint_candidates(_self_val: VALUE, devices_val: VALUE) -> VALUE {
+    let devices = bluetooth_discovered_devices_from_rb(devices_val);
+    bluetooth_endpoint_candidates_to_rb(&bluetooth_endpoint_candidates_from_devices(&devices))
+}
+
 extern "C" fn native_esp_upload_options(_self_val: VALUE, selector_val: VALUE) -> VALUE {
     let selector = ruby_bridge::str_from_rb(selector_val)
         .unwrap_or_else(|| ruby_bridge::raise_arg_error("selector must be a Ruby String"));
@@ -826,6 +832,97 @@ fn bluetooth_endpoint_to_rb(endpoint: &LanguageBluetoothEndpoint) -> VALUE {
     hash
 }
 
+fn bluetooth_endpoint_candidates_to_rb(candidates: &[LanguageBluetoothEndpointCandidate]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for candidate in candidates {
+        let hash = ruby_bridge::hash_new();
+        hash_set(
+            hash,
+            "endpoint",
+            bluetooth_endpoint_to_rb(&candidate.endpoint),
+        );
+        hash_set(hash, "device", ruby_bridge::str_to_rb(&candidate.device));
+        hash_set(
+            hash,
+            "display_name",
+            ruby_bridge::str_to_rb(&candidate.display_name),
+        );
+        hash_set(hash, "paired", ruby_bridge::bool_to_rb(candidate.paired));
+        hash_set(
+            hash,
+            "requires_pairing",
+            ruby_bridge::bool_to_rb(candidate.requires_pairing),
+        );
+        ruby_bridge::array_push(array, hash);
+    }
+    array
+}
+
+fn bluetooth_discovered_devices_from_rb(
+    devices_val: VALUE,
+) -> Vec<LanguageBluetoothDiscoveredDevice> {
+    let len = ruby_bridge::array_len(devices_val);
+    let mut devices = Vec::with_capacity(len);
+    for index in 0..len {
+        let device = ruby_bridge::array_entry(devices_val, index);
+        let id = rb_hash_optional_str(device, "id").unwrap_or_else(|| {
+            ruby_bridge::raise_arg_error("Bluetooth discovered device id must be a String")
+        });
+        devices.push(LanguageBluetoothDiscoveredDevice {
+            id,
+            name: rb_hash_optional_str(device, "name"),
+            address: rb_hash_optional_str(device, "address"),
+            paired: rb_hash_bool(device, "paired"),
+            service_uuids: rb_hash_vec_str(device, "service_uuids"),
+            characteristic_uuids: rb_hash_vec_str(device, "characteristic_uuids"),
+            board_vm_rfcomm_channels: rb_hash_vec_u8(device, "board_vm_rfcomm_channels"),
+        });
+    }
+    devices
+}
+
+fn rb_hash_value(hash: VALUE, key: &str) -> VALUE {
+    let key = ruby_bridge::str_to_rb(key);
+    unsafe {
+        let mid = ruby_bridge::rb_intern(b"[]\0".as_ptr() as *const c_char);
+        ruby_bridge::rb_funcallv(hash, mid, 1, &key)
+    }
+}
+
+fn rb_hash_optional_str(hash: VALUE, key: &str) -> Option<String> {
+    let value = rb_hash_value(hash, key);
+    (value != ruby_bridge::nil_value())
+        .then(|| ruby_bridge::str_from_rb(value))
+        .flatten()
+}
+
+fn rb_hash_bool(hash: VALUE, key: &str) -> bool {
+    let value = rb_hash_value(hash, key);
+    value != ruby_bridge::nil_value() && value != ruby_bridge::QFALSE
+}
+
+fn rb_hash_vec_str(hash: VALUE, key: &str) -> Vec<String> {
+    let value = rb_hash_value(hash, key);
+    if value == ruby_bridge::nil_value() {
+        Vec::new()
+    } else {
+        ruby_bridge::vec_str_from_rb(value)
+    }
+}
+
+fn rb_hash_vec_u8(hash: VALUE, key: &str) -> Vec<u8> {
+    let value = rb_hash_value(hash, key);
+    if value == ruby_bridge::nil_value() {
+        return Vec::new();
+    }
+    let len = ruby_bridge::array_len(value);
+    let mut values = Vec::with_capacity(len);
+    for index in 0..len {
+        values.push(rb_u8(ruby_bridge::array_entry(value, index), key));
+    }
+    values
+}
+
 fn esp_upload_options_to_rb(options: &LanguageEspUploadOptions) -> VALUE {
     let hash = ruby_bridge::hash_new();
     hash_set(hash, "board_id", ruby_bridge::str_to_rb(&options.board_id));
@@ -1210,6 +1307,12 @@ pub extern "C" fn Init_board_vm_native() {
         native,
         "bluetooth_endpoint",
         native_bluetooth_endpoint as *const c_void,
+        1,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "bluetooth_endpoint_candidates",
+        native_bluetooth_endpoint_candidates as *const c_void,
         1,
     );
     ruby_bridge::define_module_function_raw(

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -150,6 +150,25 @@ module CodingAdventures
       Native.bluetooth_endpoint(endpoint.to_s)
     end
 
+    def bluetooth_endpoint_candidates(devices)
+      normalized = Array(devices).map do |device|
+        id = bluetooth_device_field(device, "id")
+        raise ArgumentError, "Bluetooth discovered device id is required" if id.nil?
+
+        {
+          "id" => id.to_s,
+          "name" => bluetooth_optional_device_field(device, "name"),
+          "address" => bluetooth_optional_device_field(device, "address"),
+          "paired" => !!bluetooth_device_field(device, "paired"),
+          "service_uuids" => bluetooth_device_array_field(device, "service_uuids").map(&:to_s),
+          "characteristic_uuids" => bluetooth_device_array_field(device, "characteristic_uuids").map(&:to_s),
+          "board_vm_rfcomm_channels" => bluetooth_device_array_field(device, "board_vm_rfcomm_channels").map { |channel| Integer(channel) }
+        }
+      end
+
+      Native.bluetooth_endpoint_candidates(normalized)
+    end
+
     def connection_options(board)
       target = detect_target(board)
       unless target
@@ -497,6 +516,24 @@ module CodingAdventures
       end
 
       selected
+    end
+
+    def bluetooth_device_field(device, key)
+      return device[key] if device.respond_to?(:key?) && device.key?(key)
+
+      symbol_key = key.to_sym
+      return device[symbol_key] if device.respond_to?(:key?) && device.key?(symbol_key)
+
+      nil
+    end
+
+    def bluetooth_optional_device_field(device, key)
+      value = bluetooth_device_field(device, key)
+      value.nil? ? nil : value.to_s
+    end
+
+    def bluetooth_device_array_field(device, key)
+      Array(bluetooth_device_field(device, key))
     end
 
     def device_target_board(device, minimum_confidence: 0)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -99,6 +99,44 @@ module CodingAdventures
         assert_nil BoardVM.bluetooth_endpoint("tcp://board-vm.local:4170")
       end
 
+      def test_bluetooth_endpoint_candidates_are_planned_by_rust_language_core
+        candidates = BoardVM.bluetooth_endpoint_candidates([
+          {
+            id: "ignore-me",
+            service_uuids: ["180f"]
+          },
+          {
+            id: "esp32-board-vm",
+            name: "ESP32 Board VM",
+            paired: true,
+            board_vm_rfcomm_channels: [3, 3, 31]
+          },
+          {
+            "id" => "uno-r4",
+            "name" => "Uno R4 Board VM",
+            "address" => "AA:BB:CC:DD:EE:FF",
+            "service_uuids" => ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"]
+          }
+        ])
+
+        assert_equal 2, candidates.length
+        rfcomm = candidates.find { |candidate| candidate.fetch("endpoint").fetch("channel") == 3 }
+        ble = candidates.find { |candidate| candidate.fetch("endpoint").fetch("service_uuid") }
+
+        assert_equal "ESP32 Board VM", rfcomm.fetch("display_name")
+        assert_equal "bluetooth_classic_rfcomm", rfcomm.fetch("endpoint").fetch("endpoint_transport")
+        assert_equal "btspp://esp32-board-vm:3", rfcomm.fetch("endpoint").fetch("endpoint")
+        assert rfcomm.fetch("paired")
+        refute rfcomm.fetch("requires_pairing")
+
+        assert_equal "Uno R4 Board VM", ble.fetch("display_name")
+        assert_equal "bluetooth_le_gatt", ble.fetch("endpoint").fetch("endpoint_transport")
+        assert_equal "AA:BB:CC:DD:EE:FF", ble.fetch("device")
+        assert_equal "6e400001-b5a3-f393-e0a9-e50e24dcca9e", ble.fetch("endpoint").fetch("service_uuid")
+        refute ble.fetch("paired")
+        assert ble.fetch("requires_pairing")
+      end
+
       def test_connection_options_can_be_selected_without_exposing_ports
         default = BoardVM.select_connection_option(:uno_r4_wifi)
         wifi = BoardVM.select_connection_option(:uno_r4_wifi, transport: :wifi)


### PR DESCRIPTION
## Summary
- expose Rust-owned Bluetooth endpoint candidate planning through Ruby, Python, and Lua native extensions
- add thin language sugar that accepts discovered Bluetooth device metadata and returns normalized BLE/RFCOMM candidate metadata
- cover candidate planning in Ruby, Python, and Lua tests so scripts can present connect choices without exposing UUID/channel assembly

## Validation
- BUNDLE_PATH=vendor/bundle bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- bash BUILD in code/packages/lua/board_vm_native
- cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge -p lua-bridge in code/packages/rust
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD; git diff --check; git diff --cached --check