### PR TITLE
Add Thread MLE supervision plan

### DIFF
--- a/code/packages/rust/thread-mle/CHANGELOG.md
+++ b/code/packages/rust/thread-mle/CHANGELOG.md
@@ -17,5 +17,7 @@ All notable changes to this package will be documented in this file.
   and sleepy-end-device diagnostic fields.
 - Thread diagnostic snapshots that combine neighbor, leader, connectivity,
   partition, and prefix state for D23-facing health reads.
+- Thread supervisor action projections that classify diagnostic drift into
+  stable repair intents for runtime supervisors.
 - Neighbor table primitives for parent/child/router relationships, stale
   timeout expiry, link margin tracking, and parent-candidate selection.

--- a/code/packages/rust/thread-mle/README.md
+++ b/code/packages/rust/thread-mle/README.md
@@ -15,6 +15,8 @@ This crate starts the D27 Thread control-plane layer above 6LoWPAN:
 - typed Connectivity TLV helpers for route-cost and active-router diagnostics
 - Thread diagnostic snapshots that combine neighbor health with leader,
   connectivity, partition, and prefix data from MLE messages
+- supervisor action projections that turn diagnostic drift into stable repair
+  intents for runtime supervisors
 - deterministic parent/child attach-state skeleton
 - neighbor table primitives for parent/child/router relationships, link margin,
   timeout freshness, and parent-candidate selection

--- a/code/packages/rust/thread-mle/src/lib.rs
+++ b/code/packages/rust/thread-mle/src/lib.rs
@@ -887,6 +887,41 @@ pub enum ThreadDiagnosticHealth {
     Healthy,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThreadSupervisionAction {
+    Observe,
+    EnableInterface,
+    StartAttach,
+    RefreshParent,
+    RefreshRouterConnectivity,
+}
+
+impl ThreadSupervisionAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Observe => "observe",
+            Self::EnableInterface => "enable_interface",
+            Self::StartAttach => "start_attach",
+            Self::RefreshParent => "refresh_parent",
+            Self::RefreshRouterConnectivity => "refresh_router_connectivity",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThreadSupervisionPlan {
+    pub health: ThreadDiagnosticHealth,
+    pub action: ThreadSupervisionAction,
+    pub parent: Option<ThreadNeighborId>,
+    pub best_parent_candidate: Option<ThreadNeighborId>,
+}
+
+impl ThreadSupervisionPlan {
+    pub fn needs_intervention(self) -> bool {
+        self.action != ThreadSupervisionAction::Observe
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThreadDiagnosticSnapshot {
     pub captured_at_ms: u64,
@@ -970,6 +1005,37 @@ impl ThreadDiagnosticSnapshot {
             return ThreadDiagnosticHealth::Degraded;
         }
         ThreadDiagnosticHealth::Healthy
+    }
+
+    pub fn supervision_plan(&self) -> ThreadSupervisionPlan {
+        let action = if self.local_role == DeviceRole::Disabled {
+            ThreadSupervisionAction::EnableInterface
+        } else if !self.local_role.is_attached() {
+            ThreadSupervisionAction::StartAttach
+        } else if self.local_role == DeviceRole::Child && self.parent.is_none() {
+            ThreadSupervisionAction::StartAttach
+        } else if self
+            .parent
+            .is_some_and(|parent| self.stale_neighbors.contains(&parent))
+        {
+            ThreadSupervisionAction::RefreshParent
+        } else if self
+            .connectivity
+            .is_some_and(|connectivity| connectivity.active_router_count == 0)
+            && self.local_role.can_route()
+            && self.local_role != DeviceRole::Leader
+        {
+            ThreadSupervisionAction::RefreshRouterConnectivity
+        } else {
+            ThreadSupervisionAction::Observe
+        };
+
+        ThreadSupervisionPlan {
+            health: self.health(),
+            action,
+            parent: self.parent,
+            best_parent_candidate: self.best_parent_candidate,
+        }
     }
 }
 
@@ -1649,6 +1715,17 @@ mod tests {
         assert_eq!(snapshot.active_router_count(), Some(12));
         assert_eq!(snapshot.prefixes, vec![prefix]);
         assert_eq!(snapshot.health(), ThreadDiagnosticHealth::Healthy);
+        assert_eq!(
+            snapshot.supervision_plan(),
+            ThreadSupervisionPlan {
+                health: ThreadDiagnosticHealth::Healthy,
+                action: ThreadSupervisionAction::Observe,
+                parent: Some(ThreadNeighborId(0x1000)),
+                best_parent_candidate: Some(ThreadNeighborId(0x3000)),
+            }
+        );
+        assert!(!snapshot.supervision_plan().needs_intervention());
+        assert_eq!(ThreadSupervisionAction::Observe.as_str(), "observe");
     }
 
     #[test]
@@ -1674,6 +1751,81 @@ mod tests {
             vec![ThreadNeighborId(0x1000)]
         );
         assert_eq!(stale_snapshot.health(), ThreadDiagnosticHealth::Degraded);
+    }
+
+    #[test]
+    fn supervision_plan_projects_repair_actions_from_diagnostics() {
+        let disabled = NeighborTable::new(DeviceRole::Disabled);
+        let disabled_plan = disabled
+            .diagnostic_snapshot(None, 10_000)
+            .unwrap()
+            .supervision_plan();
+        assert_eq!(disabled_plan.health, ThreadDiagnosticHealth::Offline);
+        assert_eq!(
+            disabled_plan.action,
+            ThreadSupervisionAction::EnableInterface
+        );
+        assert_eq!(
+            ThreadSupervisionAction::EnableInterface.as_str(),
+            "enable_interface"
+        );
+        assert!(disabled_plan.needs_intervention());
+
+        let detached = NeighborTable::new(DeviceRole::Detached);
+        let detached_plan = detached
+            .diagnostic_snapshot(None, 10_000)
+            .unwrap()
+            .supervision_plan();
+        assert_eq!(detached_plan.action, ThreadSupervisionAction::StartAttach);
+
+        let child_without_parent = NeighborTable::new(DeviceRole::Child);
+        let child_plan = child_without_parent
+            .diagnostic_snapshot(None, 10_000)
+            .unwrap()
+            .supervision_plan();
+        assert_eq!(child_plan.action, ThreadSupervisionAction::StartAttach);
+
+        let mut child_with_stale_parent = NeighborTable::new(DeviceRole::Child);
+        child_with_stale_parent.upsert(ThreadNeighbor::new(
+            ThreadNeighborId(0x1000),
+            DeviceRole::Router,
+            NeighborRelationship::Parent,
+            1_000,
+            500,
+        ));
+        let stale_parent_plan = child_with_stale_parent
+            .diagnostic_snapshot(None, 2_000)
+            .unwrap()
+            .supervision_plan();
+        assert_eq!(
+            stale_parent_plan.action,
+            ThreadSupervisionAction::RefreshParent
+        );
+
+        let router = NeighborTable::new(DeviceRole::Router);
+        let message = MleMessage {
+            command: MleCommand::Advertisement,
+            tlvs: vec![Connectivity {
+                parent_priority: 0,
+                link_quality_3: 0,
+                link_quality_2: 0,
+                link_quality_1: 0,
+                leader_cost: 0,
+                id_sequence: 1,
+                active_router_count: 0,
+                sleepy_end_device_buffer_size: None,
+                sleepy_end_device_datagram_count: None,
+            }
+            .to_tlv()],
+        };
+        let router_plan = router
+            .diagnostic_snapshot(Some(&message), 10_000)
+            .unwrap()
+            .supervision_plan();
+        assert_eq!(
+            router_plan.action,
+            ThreadSupervisionAction::RefreshRouterConnectivity
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add ThreadSupervisionAction and ThreadSupervisionPlan for supervisor-friendly MLE repair intents
- project diagnostic snapshots into observe, enable-interface, attach, parent-refresh, and router-connectivity actions
- document the new runtime supervision projection in thread-mle

## Tests
- cargo fmt --manifest-path code/packages/rust/Cargo.toml --package thread-mle --check
- cargo test --manifest-path code/packages/rust/Cargo.toml -p thread-mle
- git diff --check
- rm -f code/packages/rust/Cargo.lock && test ! -f code/packages/rust/Cargo.lock