### PR TITLE
Add OS job status summaries

### DIFF
--- a/code/packages/rust/os-job-core/CHANGELOG.md
+++ b/code/packages/rust/os-job-core/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
 - Installed-job and job-status query options for filtering read-side runtime
   views by backend, enabled state, action/trigger kind, status, run outcome,
   next-run deadline, sort order, and bounded result count
+- Job-status summary counts for D18C/D18D read tools that need a compact
+  runtime health rollup
 - Repository-owned `InstallPlan`, `InstallFile`, and `InstallCommand` contracts
 - Shared validation and error reporting for job identifiers, triggers, outputs,
   retry settings, and environment variables

--- a/code/packages/rust/os-job-core/README.md
+++ b/code/packages/rust/os-job-core/README.md
@@ -20,6 +20,8 @@ call site, this crate gives the repository one shared vocabulary:
 - Portable job data types
 - Installed-job, status, and run-receipt records for runtime APIs
 - Bounded read-side queries for installed jobs and runtime status records
+- Aggregate status summaries for D18C/D18D tools that need stable runtime
+  health counts
 - Validation for identifiers, triggers, retry policy, and environment entries
 - A deterministic install-plan shape that higher layers can inspect before
   mutating the OS

--- a/code/packages/rust/os-job-core/src/lib.rs
+++ b/code/packages/rust/os-job-core/src/lib.rs
@@ -575,6 +575,50 @@ impl JobStatus {
     }
 }
 
+/// Aggregate counts for a bounded D18C job-status read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct JobStatusSummary {
+    pub total: usize,
+    pub missing: usize,
+    pub installed: usize,
+    pub running: usize,
+    pub disabled: usize,
+    pub failed: usize,
+    pub enabled: usize,
+    pub with_last_run: usize,
+    pub failed_last_runs: usize,
+    pub next_run_known: usize,
+}
+
+impl JobStatusSummary {
+    pub fn record(&mut self, status: &JobStatus) {
+        self.total += 1;
+        match status.status {
+            JobStatusKind::Missing => self.missing += 1,
+            JobStatusKind::Installed => self.installed += 1,
+            JobStatusKind::Running => self.running += 1,
+            JobStatusKind::Disabled => self.disabled += 1,
+            JobStatusKind::Failed => self.failed += 1,
+        }
+        if status.enabled {
+            self.enabled += 1;
+        }
+        if let Some(last_run) = &status.last_run {
+            self.with_last_run += 1;
+            if !last_run.exit_status.is_success() {
+                self.failed_last_runs += 1;
+            }
+        }
+        if status.next_run_hint.is_some() {
+            self.next_run_known += 1;
+        }
+    }
+
+    pub fn has_runtime_failures(self) -> bool {
+        self.failed > 0 || self.failed_last_runs > 0
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstalledJobSort {
     JobId,
@@ -855,6 +899,17 @@ where
     }
 
     results
+}
+
+pub fn summarize_job_statuses<'a, I>(statuses: I) -> JobStatusSummary
+where
+    I: IntoIterator<Item = &'a JobStatus>,
+{
+    let mut summary = JobStatusSummary::default();
+    for status in statuses {
+        summary.record(status);
+    }
+    summary
 }
 
 /// Coarse outcome of one job run.
@@ -1997,6 +2052,24 @@ mod tests {
                 next_run_hint: None,
             },
         ];
+        let summary = summarize_job_statuses(&statuses);
+        assert_eq!(
+            summary,
+            JobStatusSummary {
+                total: 3,
+                missing: 0,
+                installed: 1,
+                running: 0,
+                disabled: 1,
+                failed: 1,
+                enabled: 2,
+                with_last_run: 2,
+                failed_last_runs: 1,
+                next_run_known: 2,
+            }
+        );
+        assert!(summary.has_runtime_failures());
+
         let failed_query = JobStatusQuery::new()
             .enabled(true)
             .has_last_run(true)


### PR DESCRIPTION
## Summary
- add JobStatusSummary for D18C/D18D read-side runtime health rollups
- count job status kinds, enabled jobs, last-run coverage, failed last runs, and known next-run hints
- document the summary helper in os-job-core

## Tests
- cargo fmt --manifest-path code/packages/rust/Cargo.toml --package os-job-core --check
- cargo test --manifest-path code/packages/rust/Cargo.toml -p os-job-core
- git diff --check
- rm -f code/packages/rust/Cargo.lock && test ! -f code/packages/rust/Cargo.lock