### PR TITLE
Add Hue grouped light state updates

### DIFF
--- a/code/packages/rust/hue-client/CHANGELOG.md
+++ b/code/packages/rust/hue-client/CHANGELOG.md
@@ -22,3 +22,5 @@ All notable changes to this package will be documented in this file.
 - Incremental Hue event-stream decoder for split Server-Sent Events chunks.
 - Hue light, motion, and button state update extraction from resource snapshots
   and event-stream batches for normalized runtime state deltas.
+- Hue grouped-light state update extraction from resource snapshots and
+  event-stream batches for room/zone aggregate state.

--- a/code/packages/rust/hue-client/README.md
+++ b/code/packages/rust/hue-client/README.md
@@ -23,8 +23,8 @@ Included surfaces:
 - Hue room, zone, and scene resource decoding
 - Hue motion and button resource decoding for sensor/input entities
 - Hue light resource decoding
-- Hue light, motion, and button state update extraction from snapshots and
-  event-stream batches
+- Hue light, grouped-light, motion, and button state update extraction from
+  snapshots and event-stream batches
 
 ## Dependencies
 

--- a/code/packages/rust/hue-client/src/lib.rs
+++ b/code/packages/rust/hue-client/src/lib.rs
@@ -11,10 +11,11 @@ use coding_adventures_json_value::{parse as parse_json, JsonNumber, JsonValue};
 use http_core::{find_header, Header};
 use hue_core::{
     validate_brightness, HueBridgeResource, HueButtonResource, HueButtonStateUpdate, HueCommand,
-    HueDeviceResource, HueGroupedLightResource, HueLightResource, HueLightStateUpdate, HueMethod,
-    HueMotionResource, HueMotionStateUpdate, HueRequest, HueRequestBody, HueResourceId,
-    HueResourceRef, HueResourceType, HueRoomResource, HueSceneAction, HueSceneResource,
-    HueZoneResource, CLIP_V2_EVENT_STREAM_PATH, CLIP_V2_RESOURCE_ROOT, HUE_APPLICATION_KEY_HEADER,
+    HueDeviceResource, HueGroupedLightResource, HueGroupedLightStateUpdate, HueLightResource,
+    HueLightStateUpdate, HueMethod, HueMotionResource, HueMotionStateUpdate, HueRequest,
+    HueRequestBody, HueResourceId, HueResourceRef, HueResourceType, HueRoomResource,
+    HueSceneAction, HueSceneResource, HueZoneResource, CLIP_V2_EVENT_STREAM_PATH,
+    CLIP_V2_RESOURCE_ROOT, HUE_APPLICATION_KEY_HEADER,
 };
 use std::fmt;
 
@@ -761,6 +762,20 @@ pub fn parse_light_state_updates_from_envelope(
     Ok(updates)
 }
 
+pub fn parse_grouped_light_state_updates_from_envelope(
+    envelope: &HueEnvelope,
+) -> Result<Vec<HueGroupedLightStateUpdate>, HueClientError> {
+    let mut updates = Vec::new();
+    for resource in &envelope.data {
+        if object_string_field(resource, "type")
+            == Some(HueResourceType::GroupedLight.as_hue_type())
+        {
+            updates.push(parse_grouped_light_state_update(resource)?);
+        }
+    }
+    Ok(updates)
+}
+
 pub fn parse_motion_state_updates_from_envelope(
     envelope: &HueEnvelope,
 ) -> Result<Vec<HueMotionStateUpdate>, HueClientError> {
@@ -796,6 +811,24 @@ pub fn parse_light_state_updates_from_event_batches(
                     == Some(HueResourceType::Light.as_hue_type())
                 {
                     updates.push(parse_light_state_update(resource)?);
+                }
+            }
+        }
+    }
+    Ok(updates)
+}
+
+pub fn parse_grouped_light_state_updates_from_event_batches(
+    batches: &[HueEventStreamBatch],
+) -> Result<Vec<HueGroupedLightStateUpdate>, HueClientError> {
+    let mut updates = Vec::new();
+    for batch in batches {
+        for event in &batch.events {
+            for resource in &event.data {
+                if object_string_field(resource, "type")
+                    == Some(HueResourceType::GroupedLight.as_hue_type())
+                {
+                    updates.push(parse_grouped_light_state_update(resource)?);
                 }
             }
         }
@@ -993,6 +1026,33 @@ fn parse_light_state_update(resource: &JsonValue) -> Result<HueLightStateUpdate,
     })
 }
 
+fn parse_grouped_light_state_update(
+    resource: &JsonValue,
+) -> Result<HueGroupedLightStateUpdate, HueClientError> {
+    let id = object_string_field(resource, "id").ok_or_else(|| {
+        HueClientError::unexpected_json("Hue grouped_light resource is missing id")
+    })?;
+    let owner = object_field(resource, "owner")
+        .map(parse_resource_ref)
+        .transpose()?;
+    let name = object_field(resource, "metadata")
+        .and_then(|metadata| object_string_field(metadata, "name"))
+        .map(str::to_string);
+    let on = object_field(resource, "on").and_then(|on| object_bool_field(on, "on"));
+    let brightness = object_field(resource, "dimming")
+        .and_then(|dimming| object_field(dimming, "brightness"))
+        .map(json_number_to_percent)
+        .transpose()?;
+
+    Ok(HueGroupedLightStateUpdate {
+        id: HueResourceId::trusted(id),
+        owner,
+        name,
+        on,
+        brightness,
+    })
+}
+
 fn parse_bridge_resource(resource: &JsonValue) -> Result<HueBridgeResource, HueClientError> {
     let id = object_string_field(resource, "id")
         .ok_or_else(|| HueClientError::unexpected_json("Hue bridge resource is missing id"))?;
@@ -1014,27 +1074,21 @@ fn parse_bridge_resource(resource: &JsonValue) -> Result<HueBridgeResource, HueC
 fn parse_grouped_light_resource(
     resource: &JsonValue,
 ) -> Result<HueGroupedLightResource, HueClientError> {
-    let id = object_string_field(resource, "id").ok_or_else(|| {
-        HueClientError::unexpected_json("Hue grouped_light resource is missing id")
-    })?;
-    let owner = object_field(resource, "owner")
+    let update = parse_grouped_light_state_update(resource)?;
+    let owner = update
+        .owner
         .ok_or_else(|| HueClientError::unexpected_json("Hue grouped_light is missing owner"))?;
-    let name = object_field(resource, "metadata")
-        .and_then(|metadata| object_string_field(metadata, "name"))
-        .unwrap_or(id)
-        .to_string();
-    let on = object_field(resource, "on").and_then(|on| object_bool_field(on, "on"));
-    let brightness = object_field(resource, "dimming")
-        .and_then(|dimming| object_field(dimming, "brightness"))
-        .map(json_number_to_percent)
-        .transpose()?;
+    let name = update
+        .name
+        .clone()
+        .unwrap_or_else(|| update.id.as_str().to_string());
 
     Ok(HueGroupedLightResource {
-        id: HueResourceId::trusted(id),
-        owner: parse_resource_ref(owner)?,
+        id: update.id,
+        owner,
         name,
-        on,
-        brightness,
+        on: update.on,
+        brightness: update.brightness,
     })
 }
 
@@ -1562,6 +1616,28 @@ mod tests {
     }
 
     #[test]
+    fn parses_grouped_light_state_updates_from_event_stream_batches() {
+        let batches = parse_event_stream(
+            b"data: [{\"id\":\"event-1\",\"type\":\"update\",\"data\":[{\"id\":\"grouped-light-1\",\"type\":\"grouped_light\",\"on\":{\"on\":true},\"dimming\":{\"brightness\":67}}]}]\n\n",
+        )
+        .unwrap();
+
+        let updates = parse_grouped_light_state_updates_from_event_batches(&batches).unwrap();
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].id.as_str(), "grouped-light-1");
+        assert_eq!(updates[0].owner, None);
+        assert_eq!(updates[0].name, None);
+        assert_eq!(updates[0].on, Some(true));
+        assert_eq!(updates[0].brightness, Some(67));
+
+        let deltas = updates[0].state_deltas();
+        assert_eq!(deltas.len(), 2);
+        assert_eq!(deltas[0].capability_id.as_str(), "light.on_off");
+        assert_eq!(deltas[1].capability_id.as_str(), "light.brightness");
+    }
+
+    #[test]
     fn parses_motion_and_button_state_updates_from_event_stream_batches() {
         let batches = parse_event_stream(
             b"data: [{\"id\":\"event-1\",\"type\":\"update\",\"data\":[{\"id\":\"motion-1\",\"type\":\"motion\",\"motion\":{\"motion\":true,\"motion_valid\":true}},{\"id\":\"button-1\",\"type\":\"button\",\"button\":{\"last_event\":\"short_release\"}}]}]\n\n",
@@ -1827,6 +1903,17 @@ mod tests {
         assert_eq!(grouped_lights[0].owner.id.as_str(), "room-1");
         assert_eq!(grouped_lights[0].on, Some(true));
         assert_eq!(grouped_lights[0].brightness, Some(84));
+
+        let updates = parse_grouped_light_state_updates_from_envelope(&envelope).unwrap();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].id.as_str(), "grouped-light-1");
+        assert_eq!(
+            updates[0].owner.as_ref().unwrap().resource_type,
+            HueResourceType::Room
+        );
+        assert_eq!(updates[0].name.as_deref(), Some("Kitchen"));
+        assert_eq!(updates[0].on, Some(true));
+        assert_eq!(updates[0].brightness, Some(84));
     }
 
     #[test]

--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this package will be documented in this file.
   `smart-home-core`.
 - Hue light, motion, and button state update helpers that project partial Hue
   changes into normalized `StateDelta` records.
+- Hue grouped-light state update helpers for room/zone aggregate light state.
 - Hue light snapshots and scene desired states now use canonical D23 capability
   ids as object keys, matching smart-home runtime reconciliation.
 - Direct Hue light brightness and color-temperature command helpers.

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -18,7 +18,8 @@ packages a typed surface for:
 - Hue light/device-to-normalized-model projection
 - Hue scene-to-normalized-`Scene` projection
 - Hue motion/button-to-normalized-`Entity` projection
-- Hue light, motion, and button state update-to-`StateDelta` projection
+- Hue light, grouped-light, motion, and button state update-to-`StateDelta`
+  projection
 - Hue snapshot and scene desired-state values keyed by canonical D23 capability
   ids such as `light.on_off` and `light.brightness`
 - integration descriptor metadata for Chief of Staff discovery

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -421,6 +421,35 @@ impl HueGroupedLightResource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HueGroupedLightStateUpdate {
+    pub id: HueResourceId,
+    pub owner: Option<HueResourceRef>,
+    pub name: Option<String>,
+    pub on: Option<bool>,
+    pub brightness: Option<u8>,
+}
+
+impl HueGroupedLightStateUpdate {
+    pub fn from_grouped_light_resource(grouped_light: &HueGroupedLightResource) -> Self {
+        Self {
+            id: grouped_light.id.clone(),
+            owner: Some(grouped_light.owner.clone()),
+            name: Some(grouped_light.name.clone()),
+            on: grouped_light.on,
+            brightness: grouped_light.brightness,
+        }
+    }
+
+    pub fn has_state(&self) -> bool {
+        self.on.is_some() || self.brightness.is_some()
+    }
+
+    pub fn state_deltas(&self) -> Vec<StateDelta> {
+        hue_grouped_light_state_deltas(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HueRoomResource {
     pub id: HueResourceId,
     pub name: String,
@@ -697,6 +726,23 @@ pub fn hue_light_state_deltas(update: &HueLightStateUpdate) -> Vec<StateDelta> {
         deltas.push(StateDelta {
             capability_id: CapabilityId::trusted("light.color_temperature"),
             value: Value::Integer(i64::from(mirek)),
+        });
+    }
+    deltas
+}
+
+pub fn hue_grouped_light_state_deltas(update: &HueGroupedLightStateUpdate) -> Vec<StateDelta> {
+    let mut deltas = Vec::new();
+    if let Some(on) = update.on {
+        deltas.push(StateDelta {
+            capability_id: CapabilityId::trusted("light.on_off"),
+            value: Value::Bool(on),
+        });
+    }
+    if let Some(brightness) = update.brightness {
+        deltas.push(StateDelta {
+            capability_id: CapabilityId::trusted("light.brightness"),
+            value: Value::Percentage(brightness),
         });
     }
     deltas
@@ -1049,6 +1095,17 @@ mod tests {
             Some(HueRequestBody::SetBrightness { brightness: 55 })
         );
         assert_eq!(grouped.owner.resource_type, HueResourceType::Room);
+
+        let update = HueGroupedLightStateUpdate::from_grouped_light_resource(&grouped);
+        assert!(update.has_state());
+        assert_eq!(
+            update.owner.as_ref().unwrap().resource_type,
+            HueResourceType::Room
+        );
+        let deltas = update.state_deltas();
+        assert_eq!(deltas.len(), 2);
+        assert_eq!(deltas[0].capability_id.as_str(), "light.on_off");
+        assert_eq!(deltas[1].capability_id.as_str(), "light.brightness");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Hue grouped-light partial state update primitives in hue-core
- extract grouped-light updates from Hue snapshots and event-stream batches in hue-client
- document grouped-light state delta support for room and zone aggregate lights

## Tests
- cargo test --manifest-path code/packages/rust/Cargo.toml -p hue-core -p hue-client
- cargo fmt --manifest-path code/packages/rust/Cargo.toml --package hue-core --package hue-client --check
- git diff --check