### PR TITLE
Expose Bluetooth discovery through language bridges

### DIFF
--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -70,7 +70,12 @@ function M.bluetooth_endpoint(endpoint)
     return native().bluetooth_endpoint(endpoint)
 end
 
+function M.bluetooth_devices()
+    return native().bluetooth_devices()
+end
+
 function M.bluetooth_endpoint_candidates(devices)
+    devices = devices or M.bluetooth_devices()
     return native().bluetooth_endpoint_candidates(devices)
 end
 

--- a/code/packages/lua/board_vm_native/src/lib.rs
+++ b/code/packages/lua/board_vm_native/src/lib.rs
@@ -11,7 +11,8 @@ use board_vm_language_core::{
     bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
     build_caps_query_wire_frame, build_hello_wire_frame, build_program_begin_wire_frame,
     build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_wire_frame,
-    connection_options_for_target, connection_transport_name, detect_target, discover_devices,
+    connection_options_for_target, connection_transport_name, detect_target,
+    discover_bluetooth_devices as core_discover_bluetooth_devices, discover_devices,
     discover_devices_from_paths, esp_upload_options_for_target, host_endpoint_transport_name,
     known_targets, onboard_led_kind, parse_bluetooth_endpoint as core_parse_bluetooth_endpoint,
     pico_uf2_upload_options_for_target, wireless_transport_name, BoardVmLanguageSession,
@@ -247,6 +248,14 @@ unsafe fn push_string_array(L: *mut lua_State, values: &[String]) {
     }
 }
 
+unsafe fn push_u8_array(L: *mut lua_State, values: &[u8]) {
+    lua_createtable(L, values.len() as c_int, 0);
+    for (index, value) in values.iter().enumerate() {
+        lua_pushinteger(L, *value as lua_Integer);
+        lua_rawseti(L, -2, (index + 1) as lua_Integer);
+    }
+}
+
 unsafe fn push_onboard_led(L: *mut lua_State, led: Option<LanguageOnboardLed>) {
     match led {
         Some(led) => {
@@ -369,6 +378,40 @@ unsafe fn push_bluetooth_endpoint_candidates(
     lua_createtable(L, candidates.len() as c_int, 0);
     for (index, candidate) in candidates.iter().enumerate() {
         push_bluetooth_endpoint_candidate(L, candidate);
+        lua_rawseti(L, -2, (index + 1) as lua_Integer);
+    }
+}
+
+unsafe fn push_bluetooth_discovered_device(
+    L: *mut lua_State,
+    device: &LanguageBluetoothDiscoveredDevice,
+) {
+    lua_bridge::lua_newtable(L);
+    set_str(L, "id", &device.id);
+    push_optional_str(L, "name", device.name.as_deref());
+    push_optional_str(L, "address", device.address.as_deref());
+    set_bool(L, "paired", device.paired);
+
+    let key = CString::new("service_uuids").unwrap();
+    push_string_array(L, &device.service_uuids);
+    lua_setfield(L, -2, key.as_ptr());
+
+    let key = CString::new("characteristic_uuids").unwrap();
+    push_string_array(L, &device.characteristic_uuids);
+    lua_setfield(L, -2, key.as_ptr());
+
+    let key = CString::new("board_vm_rfcomm_channels").unwrap();
+    push_u8_array(L, &device.board_vm_rfcomm_channels);
+    lua_setfield(L, -2, key.as_ptr());
+}
+
+unsafe fn push_bluetooth_discovered_devices(
+    L: *mut lua_State,
+    devices: &[LanguageBluetoothDiscoveredDevice],
+) {
+    lua_createtable(L, devices.len() as c_int, 0);
+    for (index, device) in devices.iter().enumerate() {
+        push_bluetooth_discovered_device(L, device);
         lua_rawseti(L, -2, (index + 1) as lua_Integer);
     }
 }
@@ -507,6 +550,13 @@ unsafe extern "C" fn lua_bluetooth_endpoint_candidates(L: *mut lua_State) -> c_i
     let devices = read_bluetooth_discovered_devices(L, 1);
     let candidates = bluetooth_endpoint_candidates_from_devices(&devices);
     push_bluetooth_endpoint_candidates(L, &candidates);
+    1
+}
+
+unsafe extern "C" fn lua_bluetooth_devices(L: *mut lua_State) -> c_int {
+    let _ = lua_gettop(L);
+    let devices = core_discover_bluetooth_devices();
+    push_bluetooth_discovered_devices(L, &devices);
     1
 }
 
@@ -655,7 +705,7 @@ unsafe extern "C" fn lua_defaults(L: *mut lua_State) -> c_int {
     1
 }
 
-struct FuncTable([luaL_Reg; 18]);
+struct FuncTable([luaL_Reg; 19]);
 unsafe impl Sync for FuncTable {}
 
 static FUNCS: FuncTable = FuncTable([
@@ -678,6 +728,10 @@ static FUNCS: FuncTable = FuncTable([
     luaL_Reg {
         name: b"bluetooth_endpoint_candidates\0".as_ptr() as *const _,
         func: Some(lua_bluetooth_endpoint_candidates),
+    },
+    luaL_Reg {
+        name: b"bluetooth_devices\0".as_ptr() as *const _,
+        func: Some(lua_bluetooth_devices),
     },
     luaL_Reg {
         name: b"esp_upload_options\0".as_ptr() as *const _,

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -124,6 +124,11 @@ describe("coding_adventures.board_vm_native", function()
         assert.is_true(ble.requires_pairing)
     end)
 
+    it("can discover Bluetooth metadata through the Rust adapter", function()
+        assert.are.equal("table", type(board_vm.bluetooth_devices()))
+        assert.are.equal("table", type(board_vm.bluetooth_endpoint_candidates()))
+    end)
+
     it("classifies host devices through Rust-owned discovery rules", function()
         local devices = board_vm.devices({
             "/dev/cu.usbmodem1101",

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1458,9 +1458,16 @@ def bluetooth_endpoint(endpoint: str) -> dict[str, Any] | None:
     return None if parsed is None else dict(parsed)
 
 
-def bluetooth_endpoint_candidates(devices: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+def bluetooth_devices() -> list[dict[str, Any]]:
+    return [dict(device) for device in _native.bluetooth_devices()]
+
+
+def bluetooth_endpoint_candidates(
+    devices: Iterable[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
     normalized = []
-    for device in devices:
+    source_devices = bluetooth_devices() if devices is None else devices
+    for device in source_devices:
         device_id = _bluetooth_device_field(device, "id")
         if device_id is None:
             raise ValueError("Bluetooth discovered device id is required")
@@ -2124,6 +2131,7 @@ __all__ = [
     "Session",
     "SessionResult",
     "TcpTransport",
+    "bluetooth_devices",
     "bluetooth_endpoint",
     "bluetooth_endpoint_candidates",
     "connection_option_list",

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -18,8 +18,10 @@ use board_vm_language_core::{
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, connection_transport_name, decode_wire_response,
-    detect_target as core_detect_target, discover_devices as core_discover_devices,
-    discover_devices_from_paths, discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
+    detect_target as core_detect_target,
+    discover_bluetooth_devices as core_discover_bluetooth_devices,
+    discover_devices as core_discover_devices, discover_devices_from_paths,
+    discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
     discover_pico_bootsel_mounts_in_roots, esp_upload_options_for_target,
     host_endpoint_transport_name, known_targets, onboard_led_kind,
     parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
@@ -499,11 +501,10 @@ unsafe extern "C" fn py_bluetooth_endpoint_candidates(
     let devices_arg = PyTuple_GetItem(args, 0);
     if devices_arg.is_null() {
         PyErr_Clear();
-        set_error(
-            type_error_class(),
-            "bluetooth_endpoint_candidates() requires devices as list",
+        let devices = core_discover_bluetooth_devices();
+        return language_bluetooth_endpoint_candidates_to_py(
+            &bluetooth_endpoint_candidates_from_devices(&devices),
         );
-        return ptr::null_mut();
     }
 
     let devices = match language_bluetooth_devices_from_py(devices_arg) {
@@ -514,6 +515,10 @@ unsafe extern "C" fn py_bluetooth_endpoint_candidates(
     language_bluetooth_endpoint_candidates_to_py(&bluetooth_endpoint_candidates_from_devices(
         &devices,
     ))
+}
+
+unsafe extern "C" fn py_bluetooth_devices(_module: PyObjectPtr, _args: PyObjectPtr) -> PyObjectPtr {
+    language_bluetooth_devices_to_py(&core_discover_bluetooth_devices())
 }
 
 unsafe extern "C" fn py_esp_upload_options(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
@@ -975,6 +980,52 @@ unsafe fn language_bluetooth_endpoint_candidates_to_py(
             "requires_pairing",
             bool_to_py(candidate.requires_pairing),
         );
+        PyList_SetItem(list, index as isize, dict);
+    }
+    list
+}
+
+unsafe fn language_bluetooth_devices_to_py(
+    devices: &[LanguageBluetoothDiscoveredDevice],
+) -> PyObjectPtr {
+    let list = PyList_New(devices.len() as isize);
+    for (index, device) in devices.iter().enumerate() {
+        let dict = PyDict_New();
+        dict_set(dict, "id", str_to_py(&device.id));
+        dict_set(
+            dict,
+            "name",
+            device
+                .name
+                .as_ref()
+                .map(|value| str_to_py(value))
+                .unwrap_or_else(|| py_none()),
+        );
+        dict_set(
+            dict,
+            "address",
+            device
+                .address
+                .as_ref()
+                .map(|value| str_to_py(value))
+                .unwrap_or_else(|| py_none()),
+        );
+        dict_set(dict, "paired", bool_to_py(device.paired));
+        dict_set(dict, "service_uuids", strings_to_py(&device.service_uuids));
+        dict_set(
+            dict,
+            "characteristic_uuids",
+            strings_to_py(&device.characteristic_uuids),
+        );
+        let channels = PyList_New(device.board_vm_rfcomm_channels.len() as isize);
+        for (channel_index, channel) in device.board_vm_rfcomm_channels.iter().enumerate() {
+            PyList_SetItem(
+                channels,
+                channel_index as isize,
+                usize_to_py(*channel as usize),
+            );
+        }
+        dict_set(dict, "board_vm_rfcomm_channels", channels);
         PyList_SetItem(list, index as isize, dict);
     }
     list
@@ -1464,7 +1515,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 30] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 31] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1620,6 +1671,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_bluetooth_endpoint_candidates),
             ml_flags: METH_VARARGS,
             ml_doc: b"Plan Board VM Bluetooth endpoint candidates in Rust.\0".as_ptr()
+                as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"bluetooth_devices\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_bluetooth_devices),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Discover host Bluetooth Board VM device metadata in Rust.\0".as_ptr()
                 as *const c_char,
         },
         PyMethodDef {

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -4,6 +4,7 @@ import socket
 import tempfile
 import threading
 
+import board_vm_native as board_vm_native_module
 from board_vm_native import (
     BoardDevice,
     BoardDescriptor,
@@ -14,6 +15,7 @@ from board_vm_native import (
     ProtocolResult,
     Session,
     TcpTransport,
+    bluetooth_devices,
     bluetooth_endpoint,
     bluetooth_endpoint_candidates,
     connect,
@@ -246,6 +248,27 @@ def test_bluetooth_endpoint_candidates_are_planned_by_rust_language_core():
     assert ble["endpoint"]["service_uuid"] == "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
     assert ble["paired"] is False
     assert ble["requires_pairing"] is True
+
+
+def test_bluetooth_endpoint_candidates_default_to_host_discovery(monkeypatch):
+    monkeypatch.setattr(
+        board_vm_native_module._native,
+        "bluetooth_devices",
+        lambda: [
+            {
+                "id": "esp32-board-vm",
+                "name": "ESP32 Board VM",
+                "paired": True,
+                "board_vm_rfcomm_channels": [3],
+            }
+        ],
+    )
+
+    candidates = bluetooth_endpoint_candidates()
+
+    assert bluetooth_devices()[0]["id"] == "esp32-board-vm"
+    assert len(candidates) == 1
+    assert candidates[0]["endpoint"]["endpoint"] == "btspp://esp32-board-vm:3"
 
 
 def test_connection_options_can_be_selected_without_exposing_ports():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -19,8 +19,10 @@ use board_vm_language_core::{
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, connection_transport_name, decode_wire_response,
-    detect_target as core_detect_target, discover_devices as core_discover_devices,
-    discover_devices_from_paths, discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
+    detect_target as core_detect_target,
+    discover_bluetooth_devices as core_discover_bluetooth_devices,
+    discover_devices as core_discover_devices, discover_devices_from_paths,
+    discover_pico_bootsel_mounts as core_discover_pico_bootsel_mounts,
     discover_pico_bootsel_mounts_in_roots, esp_upload_options_for_target,
     host_endpoint_transport_name, known_targets, onboard_led_kind,
     parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
@@ -433,6 +435,10 @@ extern "C" fn native_bluetooth_endpoint(_self_val: VALUE, endpoint_val: VALUE) -
 extern "C" fn native_bluetooth_endpoint_candidates(_self_val: VALUE, devices_val: VALUE) -> VALUE {
     let devices = bluetooth_discovered_devices_from_rb(devices_val);
     bluetooth_endpoint_candidates_to_rb(&bluetooth_endpoint_candidates_from_devices(&devices))
+}
+
+extern "C" fn native_bluetooth_devices(_self_val: VALUE) -> VALUE {
+    bluetooth_discovered_devices_to_rb(&core_discover_bluetooth_devices())
 }
 
 extern "C" fn native_esp_upload_options(_self_val: VALUE, selector_val: VALUE) -> VALUE {
@@ -853,6 +859,46 @@ fn bluetooth_endpoint_candidates_to_rb(candidates: &[LanguageBluetoothEndpointCa
             "requires_pairing",
             ruby_bridge::bool_to_rb(candidate.requires_pairing),
         );
+        ruby_bridge::array_push(array, hash);
+    }
+    array
+}
+
+fn bluetooth_discovered_devices_to_rb(devices: &[LanguageBluetoothDiscoveredDevice]) -> VALUE {
+    let array = ruby_bridge::array_new();
+    for device in devices {
+        let hash = ruby_bridge::hash_new();
+        hash_set(hash, "id", ruby_bridge::str_to_rb(&device.id));
+        hash_set(
+            hash,
+            "name",
+            device
+                .name
+                .as_ref()
+                .map(|value| ruby_bridge::str_to_rb(value))
+                .unwrap_or_else(ruby_bridge::nil_value),
+        );
+        hash_set(
+            hash,
+            "address",
+            device
+                .address
+                .as_ref()
+                .map(|value| ruby_bridge::str_to_rb(value))
+                .unwrap_or_else(ruby_bridge::nil_value),
+        );
+        hash_set(hash, "paired", ruby_bridge::bool_to_rb(device.paired));
+        hash_set(hash, "service_uuids", strings_to_rb(&device.service_uuids));
+        hash_set(
+            hash,
+            "characteristic_uuids",
+            strings_to_rb(&device.characteristic_uuids),
+        );
+        let channels = ruby_bridge::array_new();
+        for channel in &device.board_vm_rfcomm_channels {
+            ruby_bridge::array_push(channels, rb_usize(*channel));
+        }
+        hash_set(hash, "board_vm_rfcomm_channels", channels);
         ruby_bridge::array_push(array, hash);
     }
     array
@@ -1314,6 +1360,12 @@ pub extern "C" fn Init_board_vm_native() {
         "bluetooth_endpoint_candidates",
         native_bluetooth_endpoint_candidates as *const c_void,
         1,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "bluetooth_devices",
+        native_bluetooth_devices as *const c_void,
+        0,
     );
     ruby_bridge::define_module_function_raw(
         native,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -150,7 +150,12 @@ module CodingAdventures
       Native.bluetooth_endpoint(endpoint.to_s)
     end
 
-    def bluetooth_endpoint_candidates(devices)
+    def bluetooth_devices
+      Native.bluetooth_devices
+    end
+
+    def bluetooth_endpoint_candidates(devices = nil)
+      devices ||= bluetooth_devices
       normalized = Array(devices).map do |device|
         id = bluetooth_device_field(device, "id")
         raise ArgumentError, "Bluetooth discovered device id is required" if id.nil?

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -137,6 +137,21 @@ module CodingAdventures
         assert ble.fetch("requires_pairing")
       end
 
+      def test_bluetooth_endpoint_candidates_default_to_host_discovery
+        discovered = [{
+          "id" => "esp32-board-vm",
+          "name" => "ESP32 Board VM",
+          "paired" => true,
+          "board_vm_rfcomm_channels" => [3]
+        }]
+
+        BoardVM::Native.stub(:bluetooth_devices, discovered) do
+          candidates = BoardVM.bluetooth_endpoint_candidates
+          assert_equal 1, candidates.length
+          assert_equal "btspp://esp32-board-vm:3", candidates.first.fetch("endpoint").fetch("endpoint")
+        end
+      end
+
       def test_connection_options_can_be_selected_without_exposing_ports
         default = BoardVM.select_connection_option(:uno_r4_wifi)
         wifi = BoardVM.select_connection_option(:uno_r4_wifi, transport: :wifi)

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -18,6 +18,7 @@ use std::str;
 
 use board_vm_bluetooth::{
     board_vm_endpoint_candidates as board_vm_bluetooth_endpoint_candidates,
+    discover_bluetooth_devices as discover_board_vm_bluetooth_devices,
     parse_bluetooth_endpoint as parse_board_vm_bluetooth_endpoint, BluetoothDiscoveredDevice,
     BluetoothEndpoint, BluetoothEndpointCandidate,
 };
@@ -661,6 +662,33 @@ pub fn bluetooth_endpoint_candidates_from_devices(
         .into_iter()
         .filter_map(language_bluetooth_endpoint_candidate)
         .collect()
+}
+
+pub fn discover_bluetooth_devices() -> Vec<LanguageBluetoothDiscoveredDevice> {
+    discover_board_vm_bluetooth_devices()
+        .unwrap_or_default()
+        .into_iter()
+        .map(language_bluetooth_discovered_device)
+        .collect()
+}
+
+pub fn discover_bluetooth_endpoint_candidates() -> Vec<LanguageBluetoothEndpointCandidate> {
+    let devices = discover_bluetooth_devices();
+    bluetooth_endpoint_candidates_from_devices(&devices)
+}
+
+fn language_bluetooth_discovered_device(
+    device: BluetoothDiscoveredDevice,
+) -> LanguageBluetoothDiscoveredDevice {
+    LanguageBluetoothDiscoveredDevice {
+        id: device.id,
+        name: device.name,
+        address: device.address,
+        paired: device.paired,
+        service_uuids: device.service_uuids,
+        characteristic_uuids: device.characteristic_uuids,
+        board_vm_rfcomm_channels: device.board_vm_rfcomm_channels,
+    }
 }
 
 fn language_bluetooth_endpoint(endpoint: BluetoothEndpoint) -> Option<LanguageBluetoothEndpoint> {
@@ -2522,6 +2550,19 @@ mod tests {
         );
         assert!(!ble.paired);
         assert!(ble.requires_pairing);
+    }
+
+    #[test]
+    fn bluetooth_discovery_adapter_is_safe_for_language_frontends() {
+        let devices = discover_bluetooth_devices();
+        let candidates = discover_bluetooth_endpoint_candidates();
+
+        for device in &devices {
+            assert!(!device.id.trim().is_empty());
+        }
+        for candidate in &candidates {
+            assert!(!candidate.endpoint.endpoint.trim().is_empty());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expose Rust-owned Bluetooth device discovery through board-vm-language-core
- add bluetooth_devices() in Ruby, Python, and Lua native bridges
- let existing bluetooth_endpoint_candidates helpers auto-discover host Bluetooth metadata when no device list is provided

## Validation
- cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge -p lua-bridge
- BUNDLE_PATH=vendor/bundle bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- bash BUILD in code/packages/lua/board_vm_native
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check