### PR TITLE
Spec native LANG pipeline, self-hosted Twig, and shared stdlib

### DIFF
--- a/code/specs/LANG25-native-aot-debugger-end-to-end.md
+++ b/code/specs/LANG25-native-aot-debugger-end-to-end.md
@@ -1,0 +1,463 @@
+# LANG25 - native AOT, JIT, and debugger end-to-end completion plan
+
+## Overview
+
+LANG22 defines the intended compilation model: every language lowers to
+InterpreterIR, can run in the LANG VM, can tier into JIT, can compile AOT with
+or without PGO, and can fall back to the runtime for dynamic operations.  The
+current implementation has many of the right crates, but the end-to-end path is
+not complete yet.
+
+This spec names the missing work required to make the LANG VM chain usable
+across:
+
+- macOS arm64
+- macOS x86_64
+- Linux x86_64
+- Linux arm64
+- Windows x86_64
+
+The immediate goal is not AOT-only closed-world compilation.  Dynamic languages
+must continue to link the runtime.  The goal is:
+
+```text
+Twig / Tetrad / Brainfuck / Dartmouth BASIC / Ruby / TypeScript / ...
+        |
+        v
+InterpreterIR + debug sidecar + language binding
+        |
+        +--> LANG VM interpreter
+        +--> JIT native code
+        +--> AOT native executable
+        +--> AOT with PGO
+        +--> WASM / JVM / CLR through existing codegen paths
+```
+
+## Current state
+
+### Working pieces
+
+- `interpreter-ir` is the common IR.
+- `vm-core`, `twig-vm`, `lang-runtime-core`, and `vm-runtime` provide the
+  interpreter/runtime foundation.
+- `jit-core` can specialise IIR to CIR and drive pluggable backends.
+- `aot-core` can infer, specialise, link function blobs, and write `.aot`
+  snapshots with an optional IIR table.
+- `aarch64-encoder` and `aarch64-backend` can lower a small integer/control-flow
+  subset to ARM64 bytes.
+- `code-packager` can emit several container formats, including Mach-O, ELF,
+  PE, raw, Intel HEX, and WASM.
+- `ldp-format` implements the profile artefact format.
+- `debug-sidecar`, `native-debug-info`, `dap-adapter-core`, `twig-dap`, and the
+  generated VS Code extension exist.
+
+### Known breakages
+
+- `twig-aot` does not compile on Windows because the CLI calls a macOS/unix-only
+  function and its test imports `std::os::unix` unconditionally.
+- `jit-loader-macos` doctests fail on non-macOS because the crate-level cfg hides
+  `CodePage` while the doc example still imports it.
+- `dap-adapter-core` launch does not establish `vm_conn`, so real DAP requests
+  such as `stackTrace` fail with `no VM`.
+- The VS Code extension has a `vitest run` test script but no tests.
+- `twig-aot` manually compiles each function with `AArch64Backend`; it does not
+  use the full `AOTCore` runtime-fallback snapshot path.
+- `aarch64-backend` does not lower `call`, `call_runtime`, closures, properties,
+  heap operations, or runtime dispatch.  `type_assert` traps instead of deopts.
+- `jit-core` and `aot-core` do not yet produce/consume `.ldp` profile artefacts.
+- `native-debug-info` is not wired into `twig-aot` or `aot-core` output.
+- Several critical crates lack build-tool metadata, so CI can miss regressions.
+
+## Non-goals
+
+- Pure closed-world AOT for dynamic languages.
+- AOT-only execution without `liblang-runtime` for untyped programs.
+- Cross-binary PGO.
+- Shipping every language frontend in this PR stream.  The first target is the
+  native pipeline; languages can then plug into it.
+
+## Target model
+
+The current API names macOS arm64 directly, for example
+`compile_file_macos_arm64`.  That should become target driven:
+
+```rust
+pub struct NativeTarget {
+    pub os: TargetOs,
+    pub arch: TargetArch,
+    pub object_format: ObjectFormat,
+    pub abi: Abi,
+    pub link_strategy: LinkStrategy,
+}
+
+pub enum TargetOs { Macos, Linux, Windows }
+pub enum TargetArch { Aarch64, X86_64 }
+pub enum ObjectFormat { MachO, Elf, Coff }
+pub enum Abi { DarwinAarch64, SysVAmd64, Win64, LinuxAarch64 }
+pub enum LinkStrategy { SystemLinker, Lld, SnapshotOnly }
+```
+
+The CLI shape should be:
+
+```bash
+twig-aot program.twig -o program
+twig-aot program.twig --target macos-arm64 -o program
+twig-aot program.twig --target linux-x86_64 -o program
+twig-aot program.twig --target windows-x86_64 -o program.exe
+```
+
+Default target is the host triple.  Unsupported targets must fail at argument
+validation with a clear message, not at Rust compile time.
+
+## Backend work
+
+### ARM64 backend completion
+
+The ARM64 backend is currently an integer/control-flow MVP.  It still needs:
+
+- `call` lowering for intra-module calls.
+- `call_runtime` lowering through the `liblang-runtime` C ABI.
+- argument and return marshalling for boxed LANG values.
+- relocation records for calls whose final address is not known during function
+  lowering.
+- stack maps or conservative root descriptors for runtime calls.
+- deopt stubs for PGO/JIT guards.
+- float operations.
+- string operations through runtime calls.
+- heap allocation, property get/set, closures, and dynamic dispatch through
+  `LangBinding`.
+
+### x86_64 backend MVP
+
+Add:
+
+- `x86_64-encoder`
+- `x86_64-backend`
+
+The first x86_64 backend should match the ARM64 MVP feature set:
+
+- function prologue/epilogue
+- integer constants
+- integer add/sub/mul/div
+- integer comparisons
+- labels and conditional/unconditional jumps
+- return values
+- up to six integer/pointer args for SysV and four for Win64
+- stack alignment for each ABI
+- backend trait implementation with `compile_function`
+
+The next step after parity is runtime-call support:
+
+- SysV call ABI for Linux/macOS x86_64
+- Win64 call ABI for Windows
+- shadow space on Win64
+- callee/caller-saved register preservation
+- relocation sites for external runtime symbols
+
+## Packaging and linking
+
+`code-packager` can emit executable-ish containers today, but the native path
+needs relocatable object output and system linker integration per platform.
+
+Required object packagers:
+
+- Mach-O relocatable object for macOS arm64 and macOS x86_64.
+- ELF relocatable object for Linux arm64 and Linux x86_64.
+- COFF relocatable object for Windows x86_64.
+
+Required link drivers:
+
+- macOS: Apple `ld` or `clang`, because macOS executable provenance and dyld
+  setup are best delegated to Apple tooling.
+- Linux: `cc`, `ld`, or `lld`, selectable by config.
+- Windows: `link.exe` or `lld-link`, selectable by config.
+
+Each link driver must support:
+
+- native text object
+- `liblang-runtime`
+- `liblang-std` for shared language-visible standard library calls
+- optional debug information
+- optional profile metadata section
+- predictable temporary-file cleanup
+- clear diagnostics containing the linker command and stderr
+
+## Runtime fallback
+
+AOT-no-profile must be conservative.  If a function or instruction cannot be
+fully lowered, the compiler should not reject the whole program.  It should
+emit a runtime call or place the function in the IIR table and let
+`liblang-runtime` interpret it.
+
+Missing pieces:
+
+- Build a real linkable `liblang-runtime` for each supported OS/arch.
+- Define a stable C ABI between native code and runtime:
+  - `lang_call_function`
+  - `lang_call_builtin`
+  - `lang_send_message`
+  - `lang_get_property`
+  - `lang_set_property`
+  - `lang_alloc`
+  - `lang_deopt`
+  - `lang_raise`
+- Replace the `aot-core` JSON-only IIR table bridge with the binary IIRT table
+  already modeled by `vm-runtime`, or deliberately converge both formats.
+- Teach `AOTCore` to emit relocation records for runtime calls.
+- Teach `twig-aot` to call `AOTCore` rather than bypassing it with a
+  per-function all-or-nothing compile loop.
+- Add runtime-level selection:
+  - none for fully native typed programs
+  - minimal for arithmetic/control fallback
+  - standard for builtins and I/O
+  - full for GC/profiler/JIT interop
+
+## PGO path
+
+`ldp-format` exists, but the producer and consumer are missing.
+
+Required producer work:
+
+- `jit-core` writes `.ldp` on shutdown or explicit flush.
+- The VM profiler records function call counts, instruction observations,
+  type states, promotion state, and deopt events.
+- The emitted profile includes language, module identity, source hash, and IIR
+  version so stale/cross-language profiles are rejected.
+
+Required consumer work:
+
+- `aot-core` reads `.ldp`.
+- AOT validates language/module/source compatibility.
+- Profile observations promote `type_hint` for hot stable sites.
+- AOT-with-PGO emits type guards and deopt anchors.
+- Guard failure materializes a VM frame and resumes in the interpreter.
+
+Acceptance tests:
+
+- Run a Twig program under JIT, flush `.ldp`, then AOT-compile with that
+  `.ldp`.
+- Verify the AOT-PGO binary returns the same result as interpreter execution.
+- Verify a deliberately stale profile is rejected.
+- Verify a guard mismatch deopts instead of trapping.
+
+## Deopt and stack maps
+
+JIT and AOT-with-PGO need the same deopt protocol.
+
+Missing pieces:
+
+- Native frame descriptors for each compiled function.
+- Register/stack slot maps at each deopt anchor.
+- Materialization of boxed values from unboxed native registers.
+- Inlined-frame representation.
+- Runtime entry point that rebuilds an interpreter frame from native state.
+- Tests for guard mismatch, nested calls, and live heap references.
+
+AOT-no-profile can ship before this, because it must not speculate.
+AOT-with-PGO and high-quality JIT require it.
+
+## Debugger completion
+
+The debugger needs to work in three execution modes:
+
+- interpreter mode
+- JIT mode
+- AOT binary with runtime/debug server enabled
+
+Immediate fixes:
+
+- `dap-adapter-core` launch must allocate/select a debug port, launch the VM,
+  connect with retry, and store `vm_conn`.
+- `twig-dap` must emit variable declarations/live ranges into the debug sidecar.
+- The current e2e test must fail if no breakpoint is hit.
+- Add a stdio DAP e2e test that drives the real adapter process:
+  - initialize
+  - launch
+  - setBreakpoints
+  - configurationDone
+  - stopped event
+  - stackTrace
+  - scopes
+  - variables
+  - continue
+  - terminated
+- Add VS Code extension tests or change the generated script so empty tests do
+  not make CI misleading.
+
+AOT debug mode:
+
+- Native binaries should accept a debug flag or environment variable that starts
+  the same VM debug protocol server when runtime support is linked.
+- Fully native frames should be represented through native debug info plus the
+  sidecar.
+- Runtime fallback frames should be represented through the existing VM debug
+  protocol.
+
+## Native debug info
+
+`native-debug-info` is currently a library, not part of the AOT output path.
+
+Missing pieces:
+
+- Convert debug sidecar line tables to DWARF line tables for ELF/Mach-O.
+- Convert debug sidecar line tables to CodeView for PE/COFF.
+- Emit function names, source files, line tables, and local variable ranges.
+- Embed or link debug sections during native packaging.
+- Keep DAP sidecar IDs and native debug IDs stable enough to correlate frames.
+
+## Language frontend requirements
+
+Every language frontend that wants the "free" VM/JIT/AOT path must implement:
+
+- parse source
+- lower to `IIRModule`
+- preserve source spans
+- emit debug sidecar
+- expose `LangBinding` for runtime builtins/dynamic semantics
+- provide conformance tests against interpreter, JIT, AOT, and AOT-PGO
+
+Language-specific notes:
+
+- Tetrad should be the Tier A typed golden path.
+- Twig should be the Tier C dynamic golden path.
+- Brainfuck should lower to IIR and use the same AOT/JIT path instead of
+  maintaining separate JVM/CLR/WASM-only compiler logic.
+- Dartmouth BASIC should lower to IIR first, then reuse the shared backend
+  matrix.
+- Ruby, TypeScript, Lua, and Perl ports should start by sharing the LANG VM
+  package skeleton and route dynamic semantics through `LangBinding`.
+
+## Build and CI requirements
+
+Build metadata must cover the critical native chain:
+
+- `aarch64-encoder`
+- `aarch64-backend`
+- `x86_64-encoder`
+- `x86_64-backend`
+- `aot-core`
+- `vm-runtime`
+- `lang-runtime-core`
+- `ldp-format`
+- `jit-core`
+- `jit-loader-macos`
+- `code-packager`
+- `native-debug-info`
+- `debug-sidecar`
+- `dap-adapter-core`
+- `twig-dap`
+- `twig-vm`
+- `twig-aot`
+
+Main builds should use the sharded build-plan work so the native matrix can
+scale without one runner building the whole world.  PR builds can stay affected
+package based.
+
+Required CI lanes:
+
+- Windows x86_64: compile/test non-macOS crates, PE/COFF packaging tests,
+  CodeView tests, DAP stdio e2e.
+- Linux x86_64: ELF packaging tests, x86_64 backend tests, AOT runtime fallback.
+- macOS arm64: Mach-O link/run, `jit-loader-macos`, DAP e2e, AOT e2e.
+- macOS x86_64 if available: Mach-O x86_64 packaging/backend tests.
+
+Mac provisioning is expensive, so macOS e2e should be limited to the native
+packages and languages that need it.  The build plan should avoid scheduling
+macOS just because unrelated packages changed.
+
+## PR plan
+
+### 25A - platform hygiene and build coverage
+
+- Fix `twig-aot` cfg so non-macOS hosts compile cleanly.
+- Fix `jit-loader-macos` doctest cfg.
+- Add missing BUILD/BUILD_windows metadata for debugger and AOT crates.
+- Add generated VS Code extension test coverage or correct the script.
+
+### 25B - DAP real launch e2e
+
+- Fix `dap-adapter-core` launch to connect to the VM.
+- Make the breakpoint e2e strict.
+- Add stdio DAP e2e coverage.
+- Emit Twig variables into the sidecar.
+
+### 25C - target model and AOT CLI
+
+- Introduce `NativeTarget`.
+- Replace macOS-arm64-only APIs with target-driven APIs.
+- Add host default target detection.
+- Keep macOS arm64 as the first runnable target.
+
+### 25D - x86_64 encoder/backend MVP
+
+- Add `x86_64-encoder`.
+- Add `x86_64-backend`.
+- Reach parity with the ARM64 integer/control-flow subset.
+- Add SysV and Win64 ABI tests.
+
+### 25E - relocatable object and linker drivers
+
+- Add or complete Mach-O, ELF, and COFF relocatable object packagers.
+- Add platform link drivers.
+- Make `twig-aot --target` produce runnable host executables where supported.
+
+### 25F - runtime fallback
+
+- Produce linkable `liblang-runtime` artefacts.
+- Link the `liblang-std` profile required by the program's standard library imports.
+- Lower `call_runtime` and dynamic operations.
+- Route `twig-aot` through `AOTCore`.
+- Demonstrate an untyped Twig program that runs as AOT plus runtime fallback.
+
+### 25G - PGO producer/consumer
+
+- Make JIT write `.ldp`.
+- Make AOT read `.ldp`.
+- Add stale-profile rejection and guard/deopt tests.
+
+### 25H - native debug info integration
+
+- Emit DWARF/CodeView from sidecar data.
+- Package debug sections into native outputs.
+- Correlate native frames with DAP sidecar frames.
+
+### 25I - language conformance matrix
+
+- Add shared tests that every LANG frontend can run:
+  - interpret
+  - JIT
+  - AOT no profile
+  - AOT with PGO
+  - debugger breakpoint/stack/variables
+- Start with Tetrad and Twig, then add Brainfuck and Dartmouth BASIC.
+
+## Definition of done
+
+The native chain is complete when these commands have equivalent behavior:
+
+```bash
+twig run examples/fib.twig
+twig jit examples/fib.twig
+twig-aot examples/fib.twig -o fib
+twig-aot examples/fib.twig --profile fib.ldp -o fib-pgo
+```
+
+And equivalent target-specific commands work where the host/toolchain supports
+them:
+
+```bash
+twig-aot examples/fib.twig --target macos-arm64
+twig-aot examples/fib.twig --target macos-x86_64
+twig-aot examples/fib.twig --target linux-x86_64
+twig-aot examples/fib.twig --target linux-arm64
+twig-aot examples/fib.twig --target windows-x86_64
+```
+
+The debugger is complete when the same source-level breakpoint test passes in:
+
+- interpreted Twig
+- JIT-enabled Twig
+- AOT Twig with runtime debug mode
+
+For each mode, DAP must return a stack trace, scopes, variables, continue, and
+termination without `no VM`, missing variables, or tolerated breakpoint misses.

--- a/code/specs/LANG26-shared-rust-stdlib.md
+++ b/code/specs/LANG26-shared-rust-stdlib.md
@@ -1,0 +1,620 @@
+# LANG26 - shared Rust standard library for LANG VM languages
+
+## Overview
+
+Every language implemented on top of the LANG VM needs a standard library:
+numbers, strings, bytes, lists, maps, sets, I/O, time, diagnostics, and common
+compiler utilities.  Without a shared layer, each language runtime will
+reimplement the same builtins and each JIT/AOT backend will need a different
+answer for `print`, `string-length`, `map-get`, or `read-file`.
+
+LANG15 defines `liblang-runtime`: execution mechanism for VM fallback,
+dispatch, IIR tables, and runtime entry points.
+
+LANG26 defines `liblang-std`: a Rust standard library that is visible to
+languages and callable from interpreter, JIT, and AOT code.
+
+```text
+language frontend
+    |
+    v
+IIR call_builtin / call_std
+    |
+    +--> interpreter calls Rust stdlib shim
+    +--> JIT emits direct or indirect stdlib call
+    +--> AOT links liblang_std_<target>.a
+```
+
+The goal is one implementation of common behavior, shared by Twig, Tetrad,
+Brainfuck, Dartmouth BASIC, Ruby, TypeScript, Lua, Perl, and future languages.
+
+## Goals
+
+- Provide a Rust implementation of common language-visible standard functions.
+- Expose the same functions to interpreter, JIT, and AOT paths.
+- Keep stable function IDs and signatures so compiled code can link by index,
+  not by string lookup.
+- Attach type, refinement, effect, and capability metadata to every standard
+  function.
+- Let each language choose its surface names while sharing the same underlying
+  implementation.
+- Make pure stdlib functions inlineable by JIT/AOT backends.
+- Make effectful stdlib functions capability-gated and deterministic in tests.
+
+## Non-goals
+
+- Replacing per-language semantics.  Ruby method lookup, JavaScript coercions,
+  and Twig list syntax still belong to each language binding.
+- Replacing `liblang-runtime`.  This spec is about library services, not VM
+  dispatch or deopt machinery.
+- Exposing raw host OS APIs directly to user code.
+- Implementing a package manager.
+- Making every stdlib function available on every target.  Embedded targets can
+  link smaller profiles.
+
+## Layering
+
+```text
+lang-stdlib-protocol
+    stable IDs, signatures, effects, capability metadata
+
+lang-stdlib-core
+    pure Rust implementations: math, strings, bytes, collections, diagnostics
+
+lang-stdlib-host
+    effectful adapters: stdio, filesystem, env, time, random, process
+
+lang-stdlib-ffi
+    C ABI symbols and static/dynamic library packaging
+
+<lang>-runtime
+    maps language surface names to stdlib function IDs
+```
+
+`lang-runtime-core` remains the owner of `LangBinding`, value representation,
+GC hooks, deopt, ICs, and frame materialization.  `lang-stdlib-*` is a consumer
+of that substrate.
+
+## Crates
+
+### `lang-stdlib-protocol`
+
+Pure data crate.  No OS access.
+
+Owns:
+
+- `StdFnId`
+- `StdModuleId`
+- `StdSignature`
+- `StdType`
+- `StdRefinement`
+- `StdEffect`
+- `StdCapability`
+- manifest reader/writer
+
+Example:
+
+```rust
+pub struct StdSignature {
+    pub id: StdFnId,
+    pub module: &'static str,
+    pub name: &'static str,
+    pub params: &'static [StdParam],
+    pub return_type: StdType,
+    pub effects: &'static [StdEffect],
+    pub capabilities: &'static [StdCapability],
+    pub purity: Purity,
+}
+```
+
+### `lang-stdlib-core`
+
+Pure and deterministic functions.
+
+Initial modules:
+
+- `core/bool`
+- `core/order`
+- `core/option`
+- `core/result`
+- `num/int`
+- `num/float`
+- `bytes`
+- `string`
+- `list`
+- `vector`
+- `map`
+- `set`
+- `hash`
+- `diagnostic`
+- `source_span`
+
+This crate should avoid host I/O.  It must be usable in tests, WASM, and
+eventually embedded targets.
+
+### `lang-stdlib-host`
+
+Effectful host functions.
+
+Initial modules:
+
+- `io/stdin`
+- `io/stdout`
+- `io/stderr`
+- `fs`
+- `env`
+- `time`
+- `random`
+- `process`
+
+Every function in this crate has explicit capability metadata.  Tests can
+provide a fake host adapter.
+
+### `lang-stdlib-ffi`
+
+C ABI and target packaging.
+
+Builds:
+
+- `liblang_std_macos_arm64.a`
+- `liblang_std_macos_x86_64.a`
+- `liblang_std_linux_arm64.a`
+- `liblang_std_linux_x86_64.a`
+- `lang_std_windows_x86_64.lib`
+
+Also supports dynamic libraries where useful for development:
+
+- `liblang_std.dylib`
+- `liblang_std.so`
+- `lang_std.dll`
+
+## Value ABI
+
+Stdlib calls need a common ABI that all language runtimes can use.  The ABI must
+not force every language to share the same high-level object representation.
+
+Use `lang-runtime-core` values at the boundary:
+
+```c
+typedef struct lang_std_value {
+    uint8_t tag;
+    uint8_t flags;
+    uint16_t reserved;
+    uint32_t type_id;
+    uint64_t payload;
+} lang_std_value_t;
+
+typedef struct lang_std_slice {
+    const lang_std_value_t *ptr;
+    uint32_t len;
+} lang_std_slice_t;
+
+typedef struct lang_std_result {
+    uint8_t ok;
+    uint8_t reserved[7];
+    lang_std_value_t value;
+    uint32_t error_code;
+} lang_std_result_t;
+```
+
+For language-specific objects, the value carries an opaque heap reference and a
+type id.  The active `LangBinding` remains responsible for materializing,
+tracing, comparing, and finalizing that object.
+
+## Call ABI
+
+Two call shapes are required.
+
+### Generic dispatch
+
+Used by interpreter fallback and early AOT/JIT:
+
+```c
+lang_std_result_t lang_std_call(
+    uint32_t fn_id,
+    const lang_std_value_t *args,
+    uint32_t argc,
+    void *runtime_context);
+```
+
+This is simple and stable.  It is not the final performance path for hot code.
+
+### Direct symbols
+
+Used by JIT/AOT for known monomorphic signatures:
+
+```c
+uint64_t lang_std_num_i64_add_checked(int64_t a, int64_t b, uint8_t *trap);
+uint64_t lang_std_string_len(lang_std_value_t s);
+lang_std_result_t lang_std_io_write_byte(uint8_t b, void *runtime_context);
+```
+
+The manifest maps each `StdFnId` to optional direct symbols.  Backends can
+choose between direct calls, generic dispatch, or inlining.
+
+## IIR integration
+
+The initial implementation can continue to use:
+
+```text
+call_builtin "std/string/len" value
+call_builtin "std/io/write-byte" byte
+```
+
+The long-term IIR should add an indexed form:
+
+```text
+call_std fn_id args...
+```
+
+Lowering rule:
+
+- frontend names resolve to `StdFnId` during type checking or module linking;
+- interpreter uses `lang_std_call`;
+- JIT either inlines, emits direct symbol calls, or emits `lang_std_call`;
+- AOT records relocations against direct symbols or the generic dispatcher.
+
+String lookup should not occur inside hot runtime loops.
+
+## Manifest
+
+The standard library manifest is generated from Rust declarations and checked
+into the build artifacts:
+
+```json
+{
+  "version": 1,
+  "functions": [
+    {
+      "id": 1001,
+      "module": "std/io",
+      "name": "write-byte",
+      "params": [{ "name": "b", "type": "(Int 0 256)" }],
+      "return": "Int",
+      "purity": "effectful",
+      "effects": ["stdout"],
+      "capabilities": ["io.stdout.write"],
+      "generic_symbol": "lang_std_call",
+      "direct_symbol": "lang_std_io_write_byte"
+    }
+  ]
+}
+```
+
+The manifest feeds:
+
+- frontend import resolution;
+- type checking;
+- refinement checking;
+- JIT/AOT lowering;
+- documentation generation;
+- capability auditing.
+
+## Type and refinement metadata
+
+Every stdlib function must have a signature.  Public functions should avoid
+`any` unless polymorphism is the point.
+
+Examples:
+
+```text
+std/io/write-byte : (b : (Int 0 256)) -> Int
+std/bytes/get     : (buf : Bytes, i : (Index (bytes-len buf))) -> Byte
+std/string/slice  : (s : String, start : (Index (string-len s)),
+                     end : (Int start (string-len s))) -> String
+std/list/head     : (xs : (NonEmptyList T)) -> T
+std/map/get       : (m : Map<K,V>, k : K) -> Option<V>
+```
+
+These signatures become proof obligations for `lang-refinement-checker`.
+
+If a caller passes an unconstrained integer to `write-byte`, strict mode rejects
+it unless a guard proves `0 <= b < 256`.  Lenient mode emits a runtime check.
+
+## Effects and capabilities
+
+Each function declares effects:
+
+- `pure`
+- `alloc`
+- `read_stdout`
+- `write_stdout`
+- `read_stdin`
+- `read_fs`
+- `write_fs`
+- `read_env`
+- `time`
+- `random`
+- `process`
+- `network`
+
+Capabilities are finer grained and host-policy facing:
+
+- `io.stdout.write`
+- `io.stdin.read`
+- `fs.read`
+- `fs.write`
+- `env.read`
+- `time.now`
+- `random.secure`
+- `process.exit`
+
+The runtime context passed to `lang_std_call` carries the active capability
+grant.  JIT/AOT code must not bypass the capability check for effectful
+functions.  Pure functions may be inlined freely.
+
+## Profiles
+
+Different targets should link different stdlib profiles:
+
+| Profile | Contents | Typical target |
+|---------|----------|----------------|
+| `core` | pure functions only | embedded, pure computation |
+| `cli` | core + stdio + env + process exit | command-line tools |
+| `files` | cli + filesystem | compilers, formatters |
+| `full` | all stable modules | desktop/server |
+| `test` | full API backed by deterministic fakes | CI and fixtures |
+
+AOT should pick the smallest profile that satisfies the program's imports.
+JIT/interpreter can load the full host profile during development.
+
+## Language surface mapping
+
+Each language owns its surface syntax and naming.  The shared stdlib only
+provides canonical functions and signatures.
+
+Examples:
+
+| Language | Surface | Shared stdlib target |
+|----------|---------|----------------------|
+| Twig | `(host/write-byte b)` | `std/io/write-byte` |
+| Twig | `(string-length s)` | `std/string/len` |
+| Brainfuck | `.` | `std/io/write-byte` |
+| Brainfuck | `,` | `std/io/read-byte` |
+| Dartmouth BASIC | `PRINT` | `std/io/write-string` / `std/io/write-byte` |
+| Ruby | `String#length` | `std/string/len` where semantics match |
+| TypeScript | `console.log` shim | `std/io/write-string` |
+| Tetrad | typed `print-u8` | `std/io/write-byte` |
+
+If a language has different semantics, it can wrap the shared primitive in its
+own runtime.  The wrapper still uses the shared implementation where possible.
+
+## JIT behavior
+
+The JIT lowering policy:
+
+1. Resolve `call_std fn_id`.
+2. If the function is pure and has a backend intrinsic, inline it.
+3. Else if a direct symbol exists for the observed monomorphic signature, emit a
+   direct call.
+4. Else emit `lang_std_call(fn_id, args, argc, cx)`.
+5. Record profile feedback for argument shapes, result type, trap count, and
+   effect usage.
+
+The JIT must never inline effectful operations across capability checks,
+safepoints, or observable ordering boundaries.
+
+## AOT behavior
+
+AOT lowering policy:
+
+1. Resolve all stdlib calls to `StdFnId` during link planning.
+2. Compute the required stdlib profile.
+3. Link `liblang_std_<target>` for that profile.
+4. Emit relocations for direct symbols or `lang_std_call`.
+5. Include the stdlib manifest version in the AOT metadata.
+6. Fail if the target does not support a required effectful function.
+
+For AOT-with-PGO, hot pure stdlib calls can be inlined if the target backend
+supports the intrinsic and the function's manifest entry is marked stable.
+
+## Interpreter behavior
+
+`vm-core` and `vm-runtime` should route standard builtins through the same
+registry:
+
+```rust
+StdRegistry::resolve("std/io/write-byte") -> StdFnId
+StdRegistry::call(fn_id, args, cx) -> Result<Value, RuntimeError>
+```
+
+Per-language `LangBinding::resolve_builtin` can delegate to this registry for
+standard names, then fall back to language-specific builtins.
+
+## Error model
+
+Stdlib errors use a stable error code table:
+
+```text
+0       ok
+1xxx    type/refinement violation
+2xxx    allocation failure
+3xxx    capability denied
+4xxx    I/O failure
+5xxx    unsupported target/profile
+6xxx    invalid argument count/signature
+```
+
+Language runtimes map these to their own error surfaces:
+
+- Twig diagnostic or runtime trap
+- Ruby exception
+- TypeScript exception-like object
+- BASIC runtime error code
+- Brainfuck EOF behavior where specified
+
+The shared stdlib should preserve enough structured detail for good diagnostics
+without forcing one language's exception model onto another.
+
+## Determinism and testing
+
+`lang-stdlib-host` must support a deterministic host adapter:
+
+- fixed stdin bytes;
+- captured stdout/stderr buffers;
+- in-memory filesystem;
+- deterministic clock;
+- seeded random source;
+- denied-by-default process/network operations.
+
+This lets every language run the same stdlib conformance tests without touching
+the real host system.
+
+## Security
+
+Effectful stdlib functions are capability-gated.  Compilers and backends must
+not lower them to raw syscalls unless the capability check is preserved.
+
+Rules:
+
+- Pure functions can be inlined.
+- Allocation functions must preserve GC safepoints and write barriers.
+- I/O and filesystem functions must call through the host adapter.
+- Process and network functions are optional and denied by default.
+- AOT binaries embed the capability manifest they were linked with.
+
+## Initial API set
+
+### Core
+
+- `std/core/id`
+- `std/core/equal`
+- `std/core/compare`
+- `std/core/hash`
+
+### Integers
+
+- `std/num/i64/add-checked`
+- `std/num/i64/sub-checked`
+- `std/num/i64/mul-checked`
+- `std/num/i64/div-checked`
+- `std/num/i64/mod`
+- `std/num/i64/abs`
+- `std/num/i64/min`
+- `std/num/i64/max`
+
+### Bytes and strings
+
+- `std/bytes/len`
+- `std/bytes/get`
+- `std/bytes/set`
+- `std/bytes/slice`
+- `std/string/len`
+- `std/string/concat`
+- `std/string/slice`
+- `std/string/from-bytes-utf8`
+- `std/string/to-bytes-utf8`
+
+### Collections
+
+- `std/list/empty`
+- `std/list/cons`
+- `std/list/head`
+- `std/list/tail`
+- `std/list/is-empty`
+- `std/vector/new`
+- `std/vector/len`
+- `std/vector/get`
+- `std/vector/set`
+- `std/map/new`
+- `std/map/get`
+- `std/map/set`
+- `std/set/new`
+- `std/set/contains`
+
+### Host
+
+- `std/io/write-byte`
+- `std/io/write-string`
+- `std/io/read-byte`
+- `std/env/get`
+- `std/time/now-ms`
+- `std/process/exit`
+
+### Compiler support
+
+- `std/source-span/new`
+- `std/source-span/merge`
+- `std/diagnostic/error`
+- `std/diagnostic/warning`
+- `std/diagnostic/render`
+
+The compiler support module exists because the self-hosted Twig compiler will
+need these utilities immediately.
+
+## Build and packaging
+
+Add build metadata for:
+
+- `lang-stdlib-protocol`
+- `lang-stdlib-core`
+- `lang-stdlib-host`
+- `lang-stdlib-ffi`
+
+CI must build and test:
+
+- Rust unit tests for pure functions;
+- host adapter deterministic tests;
+- manifest generation stability tests;
+- C ABI smoke tests;
+- interpreter call tests;
+- JIT lowering tests for pure intrinsics;
+- AOT link/run tests per supported platform.
+
+## PR plan
+
+### 26A - protocol and manifest
+
+- Add `lang-stdlib-protocol`.
+- Define IDs, signatures, effects, capabilities, and manifest format.
+- Generate a manifest for a tiny initial API.
+
+### 26B - pure core
+
+- Add `lang-stdlib-core`.
+- Implement integer, bool, bytes, string, list basics.
+- Add refined signatures for bounds-sensitive functions.
+
+### 26C - interpreter registry
+
+- Add `StdRegistry`.
+- Let `LangBinding::resolve_builtin` delegate standard names.
+- Route Twig and Brainfuck I/O builtins through the registry.
+
+### 26D - host adapter
+
+- Add `lang-stdlib-host`.
+- Implement stdio/env/time/process-exit through capability-checked adapters.
+- Add deterministic test adapter.
+
+### 26E - FFI and AOT link
+
+- Add `lang-stdlib-ffi`.
+- Export `lang_std_call` and a small set of direct symbols.
+- Link `liblang-std` into `twig-aot` for stdlib calls.
+
+### 26F - JIT intrinsics
+
+- Teach `jit-core` and native backends to inline selected pure stdlib calls.
+- Keep effectful calls behind capability-preserving runtime calls.
+
+### 26G - language conformance
+
+- Add shared stdlib conformance tests.
+- Run them through Twig, Brainfuck, Dartmouth BASIC, and Tetrad first.
+- Extend to Ruby, TypeScript, Lua, and Perl as those frontends land.
+
+## Definition of done
+
+LANG26 is complete when:
+
+- a standard function has one Rust implementation and is callable from the
+  interpreter, JIT, and AOT paths;
+- AOT binaries link only the stdlib profile they need;
+- JIT can inline pure stdlib intrinsics and call effectful stdlib functions
+  safely;
+- every stdlib function has type/refinement/effect metadata;
+- Twig, Brainfuck, Dartmouth BASIC, and Tetrad can all use the same stdlib I/O
+  and core collection functions;
+- the self-hosted Twig compiler can depend on shared source-span and diagnostic
+  utilities instead of private ad hoc helpers.

--- a/code/specs/TW05-self-hosted-refined-compiler.md
+++ b/code/specs/TW05-self-hosted-refined-compiler.md
@@ -1,0 +1,581 @@
+# TW05 - self-hosted, statically typed Twig compiler
+
+## Overview
+
+TW04 added modules partly because a real Twig compiler is too large to live in
+one file.  TW05 defines the next step: a Twig compiler written in Twig.
+
+The self-hosted compiler is not just a rewrite of the dynamic compiler.  It is
+the first large production user of typed Twig:
+
+- every compiler module is statically typed;
+- public compiler APIs use refinement types;
+- proof obligations are discharged by the repo's `constraint-vm` stack;
+- compiler bugs such as out-of-bounds token access, invalid spans, wrong arity,
+  unresolved labels, and invalid register ids become compile-time errors where
+  the solver can prove them.
+
+The compiler's output is InterpreterIR.  Native, JVM, CLR, WASM, JIT, and AOT
+remain shared downstream backends.
+
+```text
+typed Twig compiler source
+        |
+        v
+bootstrap Twig compiler (Rust/Python host implementation)
+        |
+        v
+self-hosted compiler as IIR/native executable
+        |
+        v
+Twig source -> InterpreterIR -> LANG VM / JIT / AOT / JVM / CLR / WASM
+```
+
+## Goals
+
+- Write the Twig lexer, parser, resolver, type checker, refinement checker
+  adapter, IIR emitter, optimizer, sidecar emitter, and driver in Twig.
+- Make typed Twig strong enough to express the compiler without falling back to
+  untyped `any` at module boundaries.
+- Use `lang-refined-types`, `lang-refinement-checker`, and `constraint-vm` for
+  real proof obligations.
+- Keep the compiler target-independent by emitting InterpreterIR.
+- Reach a fixed point: the compiler compiled by the host compiler and the
+  compiler compiled by itself produce equivalent output.
+
+## Non-goals
+
+- Rewriting `constraint-vm` in Twig as part of this milestone.
+- Making all user Twig code statically typed.  Dynamic Twig remains supported.
+- Replacing the native backend work from LANG25.
+- Adding macros before the compiler is self-hosted.
+- Full dependent types.  Refinements are constrained to decidable predicates the
+  solver can handle, with opaque predicates treated as unknown.
+
+## Relationship to existing specs
+
+| Spec | Relationship |
+|------|--------------|
+| TW00 | Defines the dynamic Twig surface and IIR lowering. |
+| TW04 | Adds modules, imports, exports, host package, and stdlib-in-Twig support. |
+| LANG23 | Defines refinement types and the three checker outcomes. |
+| LANG24 | Defines `constraint-vm`, the solver substrate used by refinement checking. |
+| LANG25 | Defines the native AOT/JIT/debugger completion plan that typed Twig will reuse. |
+| LANG26 | Defines the shared Rust stdlib, including source-span and diagnostic helpers the self-hosted compiler can reuse. |
+
+## Language additions
+
+TW05 introduces a typed Twig dialect.  The dialect is enabled per module:
+
+```scheme
+(module compiler/lexer
+  (typed strict)
+  (export lex)
+  (import compiler/token compiler/span))
+```
+
+Modes:
+
+- `(typed off)` - current dynamic Twig behavior.
+- `(typed lenient)` - type and refinement annotations are checked; unknown
+  refinement outcomes become runtime checks.
+- `(typed strict)` - no public `any`, unknown refinements are compile errors,
+  and every exported function has typed parameters and return type.
+
+Compiler modules must use `(typed strict)` once bootstrapping reaches stage 3.
+
+### Function annotations
+
+```scheme
+(define (ascii-info (i : (Int 0 128)) -> TokenInfo)
+  ...)
+
+(define (emit-load
+          (reg : (RegId frame-size))
+          (frame-size : Nat)
+          (out : IirBuilder)
+        -> IirBuilder)
+  ...)
+```
+
+Parameter syntax is `(name : Type)`.  Return syntax is `-> Type` before the
+body.  Unannotated parameters in strict mode are compile errors.
+
+### Local annotations
+
+```scheme
+(define start : (Index source-len) pos)
+(let (((next : (Index source-len)) (+ pos 1)))
+  ...)
+```
+
+Local annotations are optional in lenient mode and required only when inference
+cannot prove a useful type.  The compiler should prefer inference inside a
+function and explicit annotations at module boundaries.
+
+### Type aliases
+
+```scheme
+(type Nat       (Int 0 _))
+(type Byte      (Int 0 256))
+(type CharCode  (Int 0 1114112))
+(type RegId     (fn (frame-size) (Int 0 frame-size)))
+(type Index     (fn (len) (Int 0 len)))
+```
+
+Type aliases are compile-time only.  They expand before IIR emission.
+
+### Records
+
+The compiler needs structured data.  TW05 adds typed records:
+
+```scheme
+(record Span
+  (source-id : SourceId)
+  (start     : (Index source-len))
+  (end       : (Index source-len)))
+
+(record Token
+  (kind   : TokenKind)
+  (lexeme : String)
+  (span   : Span))
+```
+
+Records lower to the existing heap/runtime representation.  Field access lowers
+to typed property operations where available, or runtime calls in early stages.
+
+### Tagged unions
+
+The compiler needs AST and type nodes.  TW05 adds tagged unions:
+
+```scheme
+(union Expr
+  (IntLit    (value : Int) (span : Span))
+  (BoolLit   (value : Bool) (span : Span))
+  (NameRef   (name : Symbol) (span : Span))
+  (IfExpr    (cond : Expr) (then : Expr) (else : Expr) (span : Span))
+  (CallExpr  (callee : Expr) (args : (List Expr)) (span : Span)))
+```
+
+Pattern matching can be minimal in v1:
+
+```scheme
+(match expr
+  ((IntLit value span) ...)
+  ((NameRef name span) ...)
+  (_ ...))
+```
+
+The first self-hosted compiler may lower `match` to nested tag checks.
+
+## Refinement syntax
+
+Refinement types use the existing LANG23 vocabulary with Twig-friendly syntax.
+
+### Ranges
+
+```scheme
+(Int 0 128)      ; 0 <= x < 128
+(Int 1 _)        ; x >= 1
+(Int _ 0)        ; x < 0
+Nat              ; alias for (Int 0 _)
+Byte             ; alias for (Int 0 256)
+```
+
+### Membership
+
+```scheme
+(Member TokenKind LParen RParen Identifier Integer EOF)
+```
+
+### Named predicates
+
+```scheme
+(where Int
+  (and (<= 0 x)
+       (< x source-len)))
+```
+
+`x` is the value being checked.  Other names must be in scope as immutable
+parameters or locals with known refinements.
+
+### Built-in compiler refinements
+
+The compiler should ship aliases for common compiler invariants:
+
+```scheme
+(type SourceId      Nat)
+(type TokenIndex    (fn (token-count) (Int 0 token-count)))
+(type NonEmptyList  (fn (T) (List T where (not (null? x)))))
+(type InstrIndex    (fn (instr-count) (Int 0 instr-count)))
+(type LabelId       Nat)
+(type FrameSlot     (fn (frame-size) (Int 0 frame-size)))
+```
+
+## Constraint solver integration
+
+The typed Twig checker lowers annotations to:
+
+- `lang-refined-types::RefinedType`
+- `lang-refinement-checker` obligations
+- `constraint-vm` programs
+
+The checker uses the LANG23 outcome model:
+
+| Outcome | Compiler action in lenient mode | Compiler action in strict mode |
+|---------|---------------------------------|--------------------------------|
+| ProvenSafe | Strip runtime check and narrow downstream type. | Same. |
+| ProvenUnsafe | Compile error with counter-example. | Same. |
+| Unknown | Emit runtime check and warning. | Compile error. |
+
+Compiler modules use strict mode at public boundaries.  During early bootstrap,
+internal modules may temporarily use lenient mode while the type checker grows.
+
+## Flow-sensitive narrowing
+
+The type checker must learn from guards:
+
+```scheme
+(define (byte? (n : Int) -> Bool)
+  (and (<= 0 n) (< n 256)))
+
+(define (write-byte-safe (n : Int) -> Int)
+  (if (byte? n)
+      (host/write-byte n)   ; n narrowed to Byte
+      -1))
+```
+
+Required guard forms for v1:
+
+- `<`, `<=`, `>`, `>=`, `=`
+- `and`, `or`, `not`
+- predicates that have a declared refinement effect, such as `byte?`
+- union tag checks generated by `match`
+
+## Compiler invariants to prove
+
+The self-hosted compiler should deliberately use refinements where compiler bugs
+usually hide.
+
+### Lexer
+
+Invariant examples:
+
+- cursor position is always `(Index source-len)`;
+- `peek` only reads when `pos < source-len`;
+- produced token spans satisfy `0 <= start <= end <= source-len`;
+- integer literal scanners consume at least one digit;
+- string scanners either return a closed string token or a precise unterminated
+  string diagnostic.
+
+Example:
+
+```scheme
+(define (peek (src : Source) (pos : (Index (source-len src)))
+        -> (Option Char))
+  ...)
+```
+
+### Parser
+
+Invariant examples:
+
+- token cursor is always `(TokenIndex token-count)`;
+- successful parse returns `next > start`;
+- error spans are valid source spans;
+- every AST node carries a valid span;
+- parser recursion consumes input or explicitly reports an error.
+
+Example:
+
+```scheme
+(record ParseOk
+  (expr : Expr)
+  (next : (where Int (and (< start x) (<= x token-count)))))
+```
+
+### Resolver
+
+Invariant examples:
+
+- every `NameRef` resolves to exactly one binding or produces a diagnostic;
+- imported names must be exported by the imported module;
+- no duplicate exported names;
+- no dependency cycles unless a later spec permits them.
+
+### Type checker
+
+Invariant examples:
+
+- every public function in strict mode has refined parameter types;
+- every call arity matches the callee signature;
+- every branch narrows path facts consistently;
+- every `match` is exhaustive or has `_`;
+- no unresolved type alias reaches IIR emission.
+
+### IIR emitter
+
+Invariant examples:
+
+- every register read has a dominating write;
+- every register id is `< frame-size`;
+- every function call target exists;
+- every builtin name is known to the selected `LangBinding`;
+- every jump target is a valid instruction index;
+- every generated sidecar source span is valid.
+
+Example:
+
+```scheme
+(define (emit-jump
+          (target : (InstrIndex instr-count))
+          (builder : IirBuilder)
+        -> IirBuilder)
+  ...)
+```
+
+## Compiler module layout
+
+The self-hosted compiler source should live as Twig modules:
+
+```text
+code/twig/compiler/
+  compiler/
+    token.tw
+    span.tw
+    diagnostic.tw
+    lexer.tw
+    ast.tw
+    parser.tw
+    module_resolver.tw
+    types.tw
+    type_parser.tw
+    type_env.tw
+    flow.tw
+    refinement.tw
+    constraint_lowering.tw
+    iir.tw
+    emit_iir.tw
+    sidecar.tw
+    optimizer.tw
+    driver.tw
+```
+
+Bootstrap host crates should live in Rust until the fixed point is reached:
+
+- `twig-type-checker`
+- `twig-refinement-lowering`
+- `twig-self-host-bootstrap`
+- `twig-self-host-driver`
+
+Once the Twig implementation is complete, the Rust driver remains as a thin
+launcher: parse CLI flags, load files, call the compiled Twig compiler, write
+artifacts.
+
+## Bootstrap stages
+
+### TW05-A - typed syntax accepted
+
+- Extend Twig parser for `(typed ...)`, parameter annotations, return types,
+  local annotations, aliases, records, unions, and match.
+- Preserve annotations in the AST.
+- Lower typed programs exactly like dynamic programs by erasing annotations.
+- Add golden parser tests.
+
+Acceptance:
+
+- typed syntax round-trips through parse/format;
+- annotation-free Twig still parses unchanged;
+- annotated programs run after erasure.
+
+### TW05-B - base static type checker
+
+- Add `twig-type-checker`.
+- Check base kinds: Int, Bool, Nil, Symbol, String, List, Record, Union,
+  Function, Any.
+- Check call arity, module imports/exports, record fields, union constructors,
+  and match exhaustiveness.
+- Produce typed AST.
+
+Acceptance:
+
+- type errors include source spans;
+- compiler modules can type-check in lenient mode without refinements.
+
+### TW05-C - refinement checker bridge
+
+- Parse range, membership, and `where` refinements.
+- Lower Twig refinements to `lang-refined-types`.
+- Build proof obligations for annotations, calls, returns, guards, and indexes.
+- Call `lang-refinement-checker`.
+- Emit runtime checks for unknown outcomes in lenient mode.
+
+Acceptance:
+
+- `ascii-info` rejects unconstrained calls in strict mode;
+- guard-based narrowing proves safe calls;
+- an out-of-range literal produces a counter-example diagnostic.
+
+### TW05-D - compiler data model in typed Twig
+
+- Implement `Token`, `Span`, diagnostics, AST, type AST, and IIR builders in
+  typed Twig.
+- Prove basic invariants with refinements.
+
+Acceptance:
+
+- typed Twig modules define the compiler's data structures;
+- generated IIR builder APIs reject invalid register and instruction ids.
+
+### TW05-E - self-hosted lexer and parser
+
+- Port lexer and parser to typed Twig.
+- Keep the host compiler as oracle.
+- Compare token streams and ASTs against the existing implementation.
+
+Acceptance:
+
+- self-hosted lexer/parser match existing fixtures;
+- injected cursor/span bugs fail refinement checking.
+
+### TW05-F - self-hosted IIR emitter
+
+- Port resolver and IIR emitter to typed Twig.
+- Emit debug sidecar data.
+- Use the host compiler only to compile the compiler itself.
+
+Acceptance:
+
+- self-hosted compiler compiles sample Twig programs to IIR equivalent to the
+  host compiler;
+- sidecar line tables match source spans.
+
+### TW05-G - fixed-point self compilation
+
+Build stages:
+
+```text
+stage0: host Rust/Python compiler builds typed Twig compiler
+stage1: stage0 compiler compiles typed Twig compiler
+stage2: stage1 compiler compiles typed Twig compiler again
+```
+
+Acceptance:
+
+- stage1 and stage2 IIR are byte-for-byte identical after deterministic
+  serialization, or equivalent under an approved normalizer;
+- stage1 and stage2 compile the fixture suite identically;
+- no host compiler is used after stage0.
+
+### TW05-H - strict refined compiler
+
+- Turn compiler modules to `(typed strict)`.
+- Enforce no public `any`.
+- Treat unknown proof obligations as compile errors in compiler modules.
+- Allow narrow opt-outs only with an explicit annotation:
+
+```scheme
+(unsafe-assume "parser stack invariant proven by enclosing loop" expr)
+```
+
+Every `unsafe-assume` must carry a string reason and must appear in an audit
+report.
+
+Acceptance:
+
+- compiler source builds in strict mode;
+- audit report is empty or every opt-out is tracked by issue id;
+- mutation tests that break cursor bounds, arity, or register bounds fail at
+  compile time.
+
+## Artifact and CLI shape
+
+The long-term CLI should be:
+
+```bash
+twigc --emit=iir src/main.tw -o main.iir
+twigc --emit=aot src/main.tw -o main
+twigc --emit=wasm src/main.tw -o main.wasm
+twigc --check src/main.tw
+twigc --check --strict-refinements src/main.tw
+twigc --self-check code/twig/compiler/compiler/driver.tw
+```
+
+`twigc --self-check` runs stage0/stage1/stage2 and verifies the fixed point.
+
+## Runtime checks
+
+Runtime checks are allowed for user programs in lenient mode.  The compiler
+source itself must eventually avoid them in public APIs.
+
+Runtime check lowering:
+
+- `refine_assert` IIR instruction if available; otherwise
+- `call_builtin "refine_assert"` with predicate metadata; otherwise
+- explicit guard and diagnostic path emitted by the compiler.
+
+Runtime checks must include:
+
+- source span;
+- expected refined type;
+- actual value where available;
+- checker reason if the compile-time result was unknown.
+
+## Diagnostics
+
+Refinement diagnostics must be concrete:
+
+```text
+compiler/parser.tw:118:17
+parse-list calls token-at with next = token-count
+
+required:
+  next : (Int 0 token-count)
+
+counter-example:
+  token-count = 12
+  next = 12
+
+reason:
+  token-at requires an index strictly less than token-count.
+```
+
+Diagnostics should prefer source names over generated solver variable names.
+
+## Test strategy
+
+Required tests:
+
+- parser fixtures for typed syntax;
+- unit tests for type alias expansion;
+- checker tests for base type failures;
+- checker tests for refinement safe/unsafe/unknown outcomes;
+- flow narrowing tests for `if`, `and`, `or`, `not`, and `match`;
+- compiler invariant tests for spans, token indexes, register ids, jump targets,
+  and arity;
+- self-hosted lexer/parser parity tests;
+- self-hosted IIR parity tests;
+- stage1/stage2 fixed-point tests;
+- mutation tests that intentionally break common compiler invariants.
+
+## Definition of done
+
+TW05 is complete when:
+
+- the Twig compiler is written primarily in typed Twig modules;
+- the compiler source builds in strict refinement mode;
+- `twigc --self-check` reaches a stage1/stage2 fixed point;
+- sample programs compiled by the self-hosted compiler run on the LANG VM;
+- the same programs can use the existing downstream paths to AOT, JIT, JVM,
+  CLR, and WASM;
+- refinement tests catch at least:
+  - out-of-bounds token access;
+  - invalid source spans;
+  - wrong call arity;
+  - unresolved labels;
+  - invalid register ids;
+  - non-exhaustive union matching.
+
+The result is a compiler whose implementation language, static type system, and
+constraint-solver-backed refinement layer are all exercised by the compiler
+itself.


### PR DESCRIPTION
## Summary

- add LANG25 native AOT/JIT/debugger end-to-end completion plan
- add TW05 self-hosted statically typed/refinement-checked Twig compiler plan
- add LANG26 shared Rust stdlib plan for interpreter, JIT, and AOT paths

## Notes

This is a specs-only PR. It intentionally does not include the unrelated local aviation worktree changes.

## Verification

- `git diff --check -- code/specs/LANG25-native-aot-debugger-end-to-end.md code/specs/LANG26-shared-rust-stdlib.md code/specs/TW05-self-hosted-refined-compiler.md`