### PR TITLE
Expand Paint VM backend portability spec

### DIFF
--- a/code/specs/P2D09-paint-vm-backend-convergence.md
+++ b/code/specs/P2D09-paint-vm-backend-convergence.md
@@ -81,6 +81,99 @@ tessellation, and vendor-runtime experiments.
 
 ---
 
+## Portability Contract
+
+The portability contract is stricter than "all crates expose a render function."
+It defines where semantic work is allowed to happen and where backend-specific
+plumbing begins.
+
+Pipeline layers:
+
+| Layer | Responsibility | Must not do |
+|-------|----------------|-------------|
+| Producers | Barcode, Mermaid, chart, HTML, document, or UI semantics | Choose a graphics backend |
+| Layout | Resolve boxes, inline flow, glyph positions, transforms, and resource references | Emit backend API calls |
+| PaintScene | Backend-neutral paint record | Depend on Skia, Cairo, Vulkan, OpenGL, OpenCL, or OS handles |
+| Runtime selector | Analyze scene requirements and pick a compatible backend | Silently ignore unsupported features |
+| Backend crate | Lower `PaintScene` to a concrete renderer | Reinterpret layout or diagram semantics |
+
+Every backend must accept the same `PaintScene` contract:
+
+| Requirement | Contract |
+|-------------|----------|
+| Coordinate space | Top-left origin, x right, y down, f64 scene coordinates. Backends with bottom-left or NDC coordinates must adapt internally. |
+| Color | Parse the shared paint color syntax and produce premultiplied/straight output according to `PixelContainer` rules. |
+| Transforms | Apply Paint VM transforms in scene order, not in backend-specific order. |
+| Clips | Rect clips are required before path clips; nested clips intersect. |
+| Gradients | `PaintGradient` definitions are collected by id and referenced through `url(#id)`. Missing ids are render errors in strict mode. |
+| Text | `PaintGlyphRun` is the exact portable primitive; `PaintText` is a convenience primitive and may be degraded. |
+| Images | `ImageSrc::Pixels` is the baseline; decoded URI/file image support is optional and must be reported. |
+| Output | Offscreen `PixelContainer` export is mandatory for backend parity tests, even if a backend also supports live windows. |
+
+Backends can be idiomatic internally. A vector backend may set state on a
+context; a GPU backend may emit meshes and shaders; a compute backend may raster
+tiles. The externally visible result is still governed by `PaintScene`,
+capability reporting, and the shared compatibility suite.
+
+---
+
+## Backend Architecture Layers
+
+Paint VM backends fall into three implementation families:
+
+| Family | Backends | Preferred implementation shape |
+|--------|----------|--------------------------------|
+| Native vector/canvas | Direct2D, GDI, Cairo, Skia, CoreGraphics | Map Paint instructions directly to the native drawing context, using save/restore or layers for isolation. |
+| Graphics GPU | Metal, WGPU, Vulkan, OpenGL, Mesa profiles | Consume `paint-vm-gpu-core` render plans, upload meshes/textures, execute shader pipelines, then read back pixels. |
+| Compute/software raster | OpenCL, future CPU tile rasterizers | Consume `paint-vm-gpu-core` render plans, rasterize triangles/tiles in kernels, then read back or share the output buffer. |
+
+The split is intentional. Skia and Cairo should not be forced through GPU mesh
+lowering when their native vector APIs already solve antialiasing, stroking,
+patterns, images, and text integration. Vulkan, OpenGL, WGPU, Mesa, and OpenCL
+should not each invent their own path tessellator or gradient sampler.
+
+Shared crates:
+
+| Crate | Role |
+|-------|------|
+| `paint-instructions` | Stable scene data model and instruction definitions. |
+| `paint-vm-runtime` | Backend descriptor, capability model, scene analyzer, selector, and common render trait. |
+| `paint-vm-gpu-core` | Backend-neutral GPU/compute render plan: meshes, texture uploads, gradient textures, clip commands, text/glyph preservation. |
+| Backend crate | API-specific execution, context/device creation, readback, native text hooks, and capability truth. |
+
+No backend-specific crate should be required by producers. Applications may link
+one explicit backend for experiments, but normal product code should go through
+`paint-vm-runtime`.
+
+---
+
+## Porting Checklist
+
+A new Paint VM backend is considered properly ported only when it provides the
+following pieces:
+
+| Deliverable | Requirement |
+|-------------|-------------|
+| Crate scaffold | `Cargo.toml`, `README.md`, `CHANGELOG.md`, public `VERSION`, and backend id. |
+| Descriptor | `PaintBackendDescriptor` with honest family, acceleration, tier, platform support, priority, and capabilities. |
+| Renderer | `PaintRenderer` implementation returning `Result<PixelContainer, PaintRenderError>`. |
+| Feature analysis | Unsupported scene features return `PaintRenderError`, not missing pixels. |
+| Offscreen target | Headless pixel rendering path suitable for CI. |
+| Fixture coverage | Shared compatibility scenes plus backend-specific smoke tests. |
+| Docs | Support matrix, platform dependencies, and known degraded paths. |
+| CI | Build on at least one supported runner; pixel tests run where runtime/device dependencies exist. |
+
+Tier gates:
+
+| Tier | Minimum requirement |
+|------|---------------------|
+| Tier 0 scaffold | Descriptor exists, crate builds, runtime does not auto-select it for real rendering. |
+| Tier 1 smoke | Offscreen pixels for rect, line, ellipse/path subset, rectangular clip, group transform/opacity, image pixels, gradients if advertised. |
+| Tier 2 native scenes | Barcode/QR, Mermaid smoke diagrams, and simple HTML/layout smoke scenes render without missing major primitives. |
+| Tier 3 full parity | Shared fixture suite passes within documented tolerances, including text/glyphs, arcs, gradients, layers, images, and blend/filter behavior if advertised. |
+
+---
+
 ## Common Rust Interface
 
 Every Rust backend should expose a small common surface:
@@ -325,8 +418,11 @@ Handler mapping:
 
 First milestone:
 
-- Rect, line, ellipse, path, clip, group transform, image, glyph run.
-- Export to `PixelContainer`.
+- Keep the native Cairo image-surface path as the Linux/BSD baseline.
+- Add Pango/PangoCairo glyph and text support so text can move from degraded to
+  supported.
+- Lower SVG `PathCommand::ArcTo` to Cairo curves or shared arc-to-cubic helpers.
+- Keep linear/radial Cairo pattern support in the strict feature set.
 - Mermaid smoke render on Linux or WSL.
 
 ### `paint-vm-skia`
@@ -355,8 +451,11 @@ Handler mapping:
 
 First milestone:
 
-- CPU raster surface only.
-- Full primitive coverage before GPU acceleration.
+- Keep CPU raster surface as the Tier 1 default so CI and headless machines work
+  without GPU initialization.
+- Add robust `ArcTo` lowering and stricter glyph/font-ref semantics.
+- Add SkShaper/SkParagraph integration before marking text/glyphs exact.
+- Add optional GPU surfaces only after CPU parity is stable.
 - Golden comparison against Direct2D/GDI on Windows and Cairo on Linux.
 
 ### `paint-vm-vulkan`
@@ -391,10 +490,24 @@ Vulkan mapping:
 
 First milestone:
 
-- Offscreen render to `PixelContainer`.
-- Rect, image, clip, group transform, and simple glyph atlas.
-- Defer filters and advanced blend modes until the render-pass architecture is
+- Device/queue selection without requiring a visible window or swapchain.
+- Offscreen RGBA8 color attachment plus staging-buffer readback to
+  `PixelContainer`.
+- Vertex/index buffers generated from `paint-vm-gpu-core` meshes.
+- Descriptor sets for uniforms, images, gradient textures, and future glyph
+  atlases.
+- Scissor clips for rectangular clips; stencil clips can follow.
+- Defer filters and advanced blend modes until render-pass architecture is
   stable.
+
+Vulkan-specific acceptance checks:
+
+| Area | Requirement |
+|------|-------------|
+| Loader | Runtime load failure returns `BackendUnavailable`, not a panic. |
+| Synchronization | Command submission, barriers, and readback are explicit and validated. |
+| Format | Output maps to `PixelContainer` RGBA bytes with documented premultiply handling. |
+| Headless | CI can run with a software Vulkan path when lavapipe is present, otherwise tests skip cleanly. |
 
 ### `paint-vm-opengl`
 
@@ -412,6 +525,8 @@ First milestone:
 - Framebuffer object backed render target.
 - Triangle renderer for rects, paths, and images.
 - Readback via `glReadPixels` to `PixelContainer`.
+- Context creation through platform APIs, EGL, or OSMesa depending on target.
+- Shader program parity with the shared GPU plan's vertex layout and uniforms.
 
 Important constraints:
 
@@ -419,6 +534,8 @@ Important constraints:
   Apple platforms.
 - Driver behavior varies widely. Compatibility tests need tolerances for
   antialiasing and blending differences.
+- Global state must be isolated. The backend should bind and restore the state
+  it owns so embedding applications do not inherit stale GL state.
 
 ### `paint-vm-wgpu`
 
@@ -436,6 +553,69 @@ First milestone:
 - Offscreen texture render.
 - Rect, path tessellation, image texture, group transform, clip scissor.
 - Readback to `PixelContainer`.
+
+### `paint-vm-opencl`
+
+Purpose: compute-raster backend for platforms where OpenCL is the common device
+API, and a research path for filters, tile rasterization, and CPU/GPU shared
+software rendering.
+
+Recommended dependencies:
+
+- An OpenCL loader crate or local FFI bindings.
+- Shared kernel source compiled at runtime or precompiled where supported.
+
+OpenCL is not a vector drawing API. It should consume `paint-vm-gpu-core` plans
+and run kernels over tiles or spans.
+
+OpenCL mapping:
+
+| Paint instruction | OpenCL strategy |
+|-------------------|-----------------|
+| Rect, ellipse, path | Rasterize triangle meshes or analytic coverage in kernels |
+| Line | Use stroke meshes from `paint-vm-gpu-core` |
+| GlyphRun | Sample glyph atlas buffers once the text path exists |
+| Clip | Per-tile scissor/coverage mask buffers |
+| Group | Pre-fold transforms where possible; otherwise pass matrices to kernels |
+| Layer | Separate RGBA buffers plus composite kernels |
+| Image | Read-only image/buffer sampling |
+| Gradient | Generated gradient textures or analytic gradient kernels |
+
+First milestone:
+
+- Device/context/queue selection with CPU device fallback when available.
+- RGBA8 output buffer plus readback to `PixelContainer`.
+- Solid mesh raster kernel for rects, paths, and line strokes.
+- Buffer upload for images and gradient textures.
+- Runtime descriptor remains Tier 0 until kernels produce pixels.
+
+### `paint-vm-mesa`
+
+Purpose: explicit profile router for Mesa software and driver-backed execution,
+not a separate drawing API.
+
+Mesa should select an execution profile and then delegate:
+
+| Mesa profile | Preferred Paint VM path |
+|--------------|-------------------------|
+| `llvmpipe` / `softpipe` OpenGL | `paint-vm-opengl` through EGL/OSMesa |
+| `lavapipe` Vulkan | `paint-vm-vulkan` through the Vulkan loader |
+| Hardware Mesa driver | Vulkan first, then OpenGL, depending on capability and availability |
+
+First milestone:
+
+- Detect Mesa profiles on Linux/WSL without requiring a visible display.
+- Expose profile metadata to `paint-vm-runtime`.
+- Route to an OpenGL or Vulkan backend without duplicating render logic.
+- Keep deterministic software rendering selectable for CI and machines without
+  vendor GPU drivers.
+
+Mesa-specific constraints:
+
+- Mesa capabilities are profile-dependent. The `paint-vm-mesa` descriptor must
+  not claim support until it knows which profile will execute the scene.
+- Mesa is valuable for CI because llvmpipe/lavapipe can provide deterministic
+  software GPU coverage.
 
 ### `paint-vm-coregraphics`
 
@@ -503,7 +683,7 @@ Only Tier 2 and above should be candidates for automatic pipeline selection.
 
 ## Current Gaps to Close
 
-Known gaps after the GDI runtime adapter work:
+Known gaps after the first native/runtime convergence tranche:
 
 | Area | Status |
 |------|--------|
@@ -512,23 +692,30 @@ Known gaps after the GDI runtime adapter work:
 | GDI gradients | Not implemented. |
 | GDI layer filters and blend modes | Layer opacity/transform works; filters/blend modes are not implemented. |
 | Direct2D `PaintText` | Implemented with DirectWrite text layout, baseline positioning, alignment, and `directwrite:`/`canvas:` font-ref parsing. |
-| Direct2D gradients | Not implemented. |
+| Direct2D gradients | Convergence target for native Direct2D gradient brushes; descriptor must remain honest until merged. |
 | Direct2D layer filters and blend modes | Layer opacity works; full effects/blend modes are not implemented. |
 | Metal text | Still partial. Glyph/text convergence remains a larger font-system project. |
-| Cairo | Tier 1 native path implemented on Linux/BSD via `cairo-rs`; text/glyphs are degraded until Pango/HarfBuzz shaping is connected; gradients and SVG `ArcTo` lowering remain open. |
-| Skia/Vulkan/OpenGL/WGPU/OpenCL/Mesa/CoreGraphics | Scaffold crates exist for all except CoreGraphics; drawing implementations are not yet wired. |
+| Cairo | Tier 1 native path implemented on Linux/BSD via `cairo-rs`; gradients are supported; text/glyphs are degraded until Pango/HarfBuzz shaping is connected; SVG `ArcTo` lowering remains open. |
+| Skia | Tier 1 CPU raster path exists with primitive/image/gradient coverage; text/glyphs are degraded; `ArcTo`, filters, and blend modes remain open. |
+| WGPU | Concrete Tier 1 GPU consumer exists for shared GPU plans and gradients; availability depends on adapter/device setup. |
+| Vulkan/OpenGL/OpenCL/Mesa | Tier 0/Tier 1 plan adapters exist; real API execution paths still need context/device setup, draw or kernel dispatch, and readback. |
+| CoreGraphics | Still missing as a Rust crate. |
+| Shared fixture suite | Needs cross-backend golden/tolerant comparison harness and Mermaid/HTML smoke fixtures. |
 
 Recommended immediate order:
 
-1. Direct2D runtime adapter now that `PaintText` has landed.
-2. Direct2D and GDI gradients.
+1. Land Direct2D gradients and keep the descriptor aligned with actual support.
+2. Add GDI gradients or a correct software fallback for gradient-filled shapes.
 3. Cairo Pango/HarfBuzz text and SVG `ArcTo` lowering.
-4. Skia Tier 1, then Tier 2.
-5. Shared `paint-vm-gpu-core`.
-6. WGPU Tier 1.
-7. Vulkan Tier 1.
-8. OpenGL and Mesa-backed Tier 1.
-9. OpenCL compute raster experiments for filters/software paths.
+4. Skia `ArcTo`, exact glyph/font semantics, then Mermaid/HTML Tier 2 scenes.
+5. Harden `paint-vm-gpu-core` tessellation: robust fills, joins/caps, dashes,
+   and glyph-atlas planning.
+6. Vulkan execution path: instance/device, render pass, pipeline, texture upload,
+   readback.
+7. OpenGL execution path and Mesa llvmpipe/lavapipe routing.
+8. OpenCL compute raster kernels for solid meshes, images, gradients, and later
+   filters/software paths.
+9. CoreGraphics/CoreText backend for Apple CPU/native fallback.
 10. Filters and advanced blend modes across GPU-capable backends.
 
 ---
@@ -578,6 +765,8 @@ Backends should be isolated so CI can build what the machine supports:
 | Vulkan | Build everywhere with loader headers; hardware tests opt-in. |
 | OpenGL | Build everywhere; pixel tests require software GL or platform context setup. |
 | WGPU | Build everywhere; adapter-dependent tests gated by availability. |
+| OpenCL | Build where an OpenCL loader is available; kernel/device tests gated by runtime availability. |
+| Mesa | Linux/WSL profile-detection tests; pixel tests require llvmpipe/lavapipe or OSMesa/EGL setup. |
 | CoreGraphics | Build and test on macOS runners. |
 
 Every backend crate should include:


### PR DESCRIPTION
## Summary
- Confirms the backend convergence spec lives in `P2D09-paint-vm-backend-convergence.md` and expands it instead of creating a duplicate.
- Adds an explicit PaintScene portability contract, backend architecture layers, shared crate responsibilities, and a backend porting checklist.
- Adds more concrete Vulkan/OpenGL/OpenCL/Mesa requirements and updates current backend gap/status guidance for Cairo, Skia, WGPU, and raw API backends.

## Verification
- `git diff --check`

Spec-only PR; no code tests were run.