### PR TITLE
Add Kotlin sql-csv-source package

### DIFF
--- a/code/packages/kotlin/sql-csv-source/.gitignore
+++ b/code/packages/kotlin/sql-csv-source/.gitignore
@@ -1,0 +1,4 @@
+.gradle/
+gradle-build/
+build/
+out/

--- a/code/packages/kotlin/sql-csv-source/BUILD
+++ b/code/packages/kotlin/sql-csv-source/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/sql-csv-source/BUILD_windows
+++ b/code/packages/kotlin/sql-csv-source/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/sql-csv-source/CHANGELOG.md
+++ b/code/packages/kotlin/sql-csv-source/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Add the Kotlin CSV-backed data source adapter for the mini-sqlite execution engine.

--- a/code/packages/kotlin/sql-csv-source/README.md
+++ b/code/packages/kotlin/sql-csv-source/README.md
@@ -1,0 +1,7 @@
+# sql-csv-source (Kotlin)
+
+CSV-backed data source adapter for the Kotlin mini-sqlite execution engine.
+
+The package maps each `*.csv` file in a directory to a SQL table, parses rows
+with `coding_adventures_csv_parser`, coerces scalar values into SQL-friendly
+Kotlin values, and executes queries through `SqlExecutionEngine`.

--- a/code/packages/kotlin/sql-csv-source/build.gradle.kts
+++ b/code/packages/kotlin/sql-csv-source/build.gradle.kts
@@ -1,0 +1,37 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    api("com.codingadventures:csv-parser")
+    api("com.codingadventures:sql-execution-engine")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/sql-csv-source/required_capabilities.json
+++ b/code/packages/kotlin/sql-csv-source/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/sql-csv-source",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads CSV data files from a user-supplied directory path to serve as SQL table data sources."
+    }
+  ],
+  "justification": "Reads CSV files from user-provided paths. No write, network, or process access needed."
+}

--- a/code/packages/kotlin/sql-csv-source/settings.gradle.kts
+++ b/code/packages/kotlin/sql-csv-source/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "sql-csv-source"
+
+includeBuild("../csv-parser")
+includeBuild("../sql-execution-engine")

--- a/code/packages/kotlin/sql-csv-source/src/main/kotlin/com/codingadventures/sqlcsvsource/SqlCsvSource.kt
+++ b/code/packages/kotlin/sql-csv-source/src/main/kotlin/com/codingadventures/sqlcsvsource/SqlCsvSource.kt
@@ -1,0 +1,168 @@
+package com.codingadventures.sqlcsvsource
+
+import com.codingadventures.csvparser.CsvParseException
+import com.codingadventures.csvparser.parseCSV
+import com.codingadventures.sqlexecutionengine.DataSource
+import com.codingadventures.sqlexecutionengine.ExecutionResult
+import com.codingadventures.sqlexecutionengine.QueryResult
+import com.codingadventures.sqlexecutionengine.SqlExecutionEngine
+import com.codingadventures.sqlexecutionengine.SqlExecutionException
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.util.Locale
+
+class CsvDataSource(private val directory: Path) : DataSource {
+    constructor(directory: String) : this(Path.of(directory))
+
+    fun directory(): Path = directory
+
+    override fun schema(tableName: String): List<String> {
+        return try {
+            parseHeader(readTable(tableName)).toList()
+        } catch (ex: CsvParseException) {
+            throw SqlExecutionException("parsing CSV header for table $tableName", ex)
+        }
+    }
+
+    override fun scan(tableName: String): List<Map<String, Any?>> {
+        val stringRows = try {
+            parseCSV(readTable(tableName))
+        } catch (ex: CsvParseException) {
+            throw SqlExecutionException("parsing CSV for table $tableName", ex)
+        }
+
+        return stringRows.map { row ->
+            linkedMapOf<String, Any?>().also { coerced ->
+                for ((key, value) in row) {
+                    coerced[key] = coerce(value)
+                }
+            }
+        }
+    }
+
+    private fun readTable(tableName: String): String {
+        return try {
+            Files.readString(csvPath(tableName), StandardCharsets.UTF_8)
+        } catch (ex: NoSuchFileException) {
+            throw SqlExecutionException("table not found: $tableName", ex)
+        } catch (ex: IOException) {
+            throw SqlExecutionException("reading CSV table: $tableName", ex)
+        }
+    }
+
+    private fun csvPath(tableName: String): Path = directory.resolve("$tableName.csv")
+
+    companion object {
+        fun coerce(value: String): Any? {
+            if (value.isEmpty()) return null
+
+            return when (value.lowercase(Locale.ROOT)) {
+                "true" -> true
+                "false" -> false
+                else -> {
+                    value.toLongOrNull()
+                        ?: value.toDoubleOrNull()
+                        ?: value
+                }
+            }
+        }
+    }
+}
+
+object SqlCsvSource {
+    fun csvDataSource(directory: String): CsvDataSource = CsvDataSource(directory)
+
+    fun csvDataSource(directory: Path): CsvDataSource = CsvDataSource(directory)
+
+    fun executeCsv(sql: String, directory: String): QueryResult =
+        executeCsv(sql, Path.of(directory))
+
+    fun executeCsv(sql: String, directory: Path): QueryResult =
+        SqlExecutionEngine.execute(sql, csvDataSource(directory))
+
+    fun tryExecuteCsv(sql: String, directory: String): ExecutionResult =
+        tryExecuteCsv(sql, Path.of(directory))
+
+    fun tryExecuteCsv(sql: String, directory: Path): ExecutionResult =
+        SqlExecutionEngine.tryExecute(sql, csvDataSource(directory))
+}
+
+private fun parseHeader(source: String): List<String> {
+    val header = firstRecord(source)
+    if (header.isEmpty()) return emptyList()
+    return parseRecord(header).filter { it.isNotEmpty() }
+}
+
+private fun firstRecord(source: String): String {
+    val out = StringBuilder()
+    var quoted = false
+    var index = 0
+    while (index < source.length) {
+        val ch = source[index]
+        if (quoted) {
+            if (ch == '"') {
+                if (index + 1 < source.length && source[index + 1] == '"') {
+                    out.append(ch)
+                    index += 1
+                    out.append(source[index])
+                } else {
+                    quoted = false
+                    out.append(ch)
+                }
+            } else {
+                out.append(ch)
+            }
+        } else if (ch == '"') {
+            quoted = true
+            out.append(ch)
+        } else if (ch == '\n' || ch == '\r') {
+            return out.toString()
+        } else {
+            out.append(ch)
+        }
+        index += 1
+    }
+    if (quoted) throw CsvParseException("unclosed quoted field at end of header")
+    return out.toString()
+}
+
+private fun parseRecord(record: String): List<String> {
+    val fields = mutableListOf<String>()
+    val field = StringBuilder()
+    var quoted = false
+    var afterQuote = false
+    var index = 0
+
+    while (index < record.length) {
+        val ch = record[index]
+        if (quoted) {
+            if (ch == '"') {
+                if (index + 1 < record.length && record[index + 1] == '"') {
+                    field.append('"')
+                    index += 1
+                } else {
+                    quoted = false
+                    afterQuote = true
+                }
+            } else {
+                field.append(ch)
+            }
+        } else if (ch == ',') {
+            fields += field.toString().trim()
+            field.clear()
+            afterQuote = false
+        } else if (ch == '"' && field.isEmpty() && !afterQuote) {
+            quoted = true
+        } else {
+            field.append(ch)
+        }
+        index += 1
+    }
+
+    if (quoted) throw CsvParseException("unclosed quoted field in header")
+    fields += field.toString().trim()
+    return fields
+}

--- a/code/packages/kotlin/sql-csv-source/src/test/kotlin/com/codingadventures/sqlcsvsource/SqlCsvSourceTest.kt
+++ b/code/packages/kotlin/sql-csv-source/src/test/kotlin/com/codingadventures/sqlcsvsource/SqlCsvSourceTest.kt
@@ -81,9 +81,12 @@ class SqlCsvSourceTest {
             fixtures()
         )
 
+        // dept_id is coerced to Long by CsvDataSource; COUNT(*) returns Int from List.size.
+        // listOf(1L, 2) would widen 2 to Long via Kotlin literal coercion, so we use
+        // explicit List<Any?> to keep the Int intact and match what the engine returns.
         assertEquals(listOf("dept_id", "cnt"), result.columns)
-        assertEquals(listOf(1L, 2), result.rows[0])
-        assertEquals(listOf(2L, 1), result.rows[1])
+        assertEquals(listOf<Any?>(1L, 2), result.rows[0])
+        assertEquals(listOf<Any?>(2L, 1), result.rows[1])
     }
 
     @Test

--- a/code/packages/kotlin/sql-csv-source/src/test/kotlin/com/codingadventures/sqlcsvsource/SqlCsvSourceTest.kt
+++ b/code/packages/kotlin/sql-csv-source/src/test/kotlin/com/codingadventures/sqlcsvsource/SqlCsvSourceTest.kt
@@ -1,0 +1,112 @@
+package com.codingadventures.sqlcsvsource
+
+import com.codingadventures.sqlexecutionengine.SqlExecutionException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import java.nio.file.Path
+
+class SqlCsvSourceTest {
+    private fun fixtures(): Path {
+        val resource = checkNotNull(javaClass.getResource("/fixtures/employees.csv"))
+        return Path.of(resource.toURI()).parent
+    }
+
+    @Test
+    fun exposesSchemaInHeaderOrder() {
+        val source = CsvDataSource(fixtures())
+
+        assertEquals(listOf("id", "name", "dept_id", "salary", "active"), source.schema("employees"))
+        assertEquals(listOf("id", "name", "budget"), source.schema("departments"))
+    }
+
+    @Test
+    fun scansRowsWithCoercedValues() {
+        val rows = CsvDataSource(fixtures()).scan("employees")
+
+        assertEquals(4, rows.size)
+        val alice = rows[0]
+        assertEquals(1L, alice["id"])
+        assertEquals("Alice", alice["name"])
+        assertEquals(90000L, alice["salary"])
+        assertEquals(true, alice["active"])
+        assertNull(rows[3]["dept_id"])
+    }
+
+    @Test
+    fun executesSelectsAgainstCsvFiles() {
+        val result = SqlCsvSource.executeCsv(
+            "SELECT name, salary FROM employees WHERE active = true AND salary > 70000 ORDER BY salary DESC",
+            fixtures()
+        )
+
+        assertEquals(listOf("name", "salary"), result.columns)
+        assertEquals(listOf("Alice", 90000L), result.rows[0])
+        assertEquals(listOf("Bob", 75000L), result.rows[1])
+    }
+
+    @Test
+    fun supportsNullPredicates() {
+        val result = SqlCsvSource.executeCsv("SELECT name FROM employees WHERE dept_id IS NULL", fixtures())
+
+        assertEquals(listOf(listOf("Dave")), result.rows)
+    }
+
+    @Test
+    fun supportsJoinsAcrossCsvFiles() {
+        val result = SqlCsvSource.executeCsv(
+            """
+            SELECT e.name AS emp_name, d.name AS dept_name
+            FROM employees AS e
+            INNER JOIN departments AS d ON e.dept_id = d.id
+            ORDER BY e.id
+            """.trimIndent(),
+            fixtures()
+        )
+
+        assertEquals(listOf("emp_name", "dept_name"), result.columns)
+        assertEquals(listOf("Alice", "Engineering"), result.rows[0])
+        assertEquals(listOf("Bob", "Marketing"), result.rows[1])
+        assertEquals(listOf("Carol", "Engineering"), result.rows[2])
+    }
+
+    @Test
+    fun supportsGroupingAggregatesLimitAndOffset() {
+        val result = SqlCsvSource.executeCsv(
+            "SELECT dept_id, COUNT(*) AS cnt FROM employees WHERE dept_id IS NOT NULL GROUP BY dept_id ORDER BY dept_id LIMIT 2",
+            fixtures()
+        )
+
+        assertEquals(listOf("dept_id", "cnt"), result.columns)
+        assertEquals(listOf(1L, 2), result.rows[0])
+        assertEquals(listOf(2L, 1), result.rows[1])
+    }
+
+    @Test
+    fun reportsMissingTablesThroughEngineErrors() {
+        val ex = assertFailsWith<SqlExecutionException> {
+            SqlCsvSource.executeCsv("SELECT * FROM no_such_table", fixtures())
+        }
+
+        assertTrue(ex.message!!.contains("table not found: no_such_table"))
+        val result = SqlCsvSource.tryExecuteCsv("SELECT * FROM no_such_table", fixtures())
+        assertEquals(false, result.ok)
+        assertNotNull(result.error)
+    }
+
+    @Test
+    fun coercesScalarValues() {
+        assertNull(CsvDataSource.coerce(""))
+        assertEquals(true, CsvDataSource.coerce("TRUE"))
+        assertEquals(false, CsvDataSource.coerce("false"))
+        assertEquals(42L, CsvDataSource.coerce("42"))
+        assertEquals(-5L, CsvDataSource.coerce("-5"))
+        assertEquals(3.14, CsvDataSource.coerce("3.14"))
+        assertEquals("123abc", CsvDataSource.coerce("123abc"))
+        assertIs<String>(CsvDataSource.coerce("hello"))
+    }
+}

--- a/code/packages/kotlin/sql-csv-source/src/test/resources/fixtures/departments.csv
+++ b/code/packages/kotlin/sql-csv-source/src/test/resources/fixtures/departments.csv
@@ -1,0 +1,3 @@
+id,name,budget
+1,Engineering,500000
+2,Marketing,200000

--- a/code/packages/kotlin/sql-csv-source/src/test/resources/fixtures/employees.csv
+++ b/code/packages/kotlin/sql-csv-source/src/test/resources/fixtures/employees.csv
@@ -1,0 +1,5 @@
+id,name,dept_id,salary,active
+1,Alice,1,90000,true
+2,Bob,2,75000,true
+3,Carol,1,95000,false
+4,Dave,,60000,true


### PR DESCRIPTION
## Summary
- Add a Kotlin `sql-csv-source` package that exposes CSV files as a `DataSource` for the Kotlin SQL execution engine.
- Add Gradle metadata, build-tool BUILD files, capabilities, documentation, fixtures, and parity tests for schema, scan coercion, predicates, joins, grouping, and missing-table errors.

## Validation
- `kotlinc "-Xopt-in=kotlin.ExperimentalStdlibApi" code\packages\kotlin\csv-parser\src\main\kotlin\com\codingadventures\csvparser\CsvParser.kt code\packages\kotlin\sql-execution-engine\src\main\kotlin\com\codingadventures\sqlexecutionengine\SqlExecutionEngine.kt code\packages\kotlin\sql-csv-source\src\main\kotlin\com\codingadventures\sqlcsvsource\SqlCsvSource.kt -d code\packages\kotlin\sql-csv-source\gradle-build\kotlinc-classes`
- `git diff --cached --check`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -language kotlin -emit-plan ..\..\..\packages\kotlin\sql-csv-source\gradle-build\mini-sqlite-sql-csv-source-kotlin-plan.json`
- `gradle test` could not be run locally: Gradle is not installed on this machine.