### PR TITLE
fix(dap-adapter-core,twig-vscode): gutter breakpoints + initialized event + stopOnEntry

### DIFF
--- a/code/packages/rust/dap-adapter-core/CHANGELOG.md
+++ b/code/packages/rust/dap-adapter-core/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog — `dap-adapter-core`
 
+## 0.4.0 — 2026-05-11
+
+**LANG25 follow-up — Fix breakpoints and `stopOnEntry` via `initialized` event.**
+
+Breakpoints set before a debug session started were silently ignored because
+the adapter never sent the DAP `initialized` event, so VS Code never sent
+`setBreakpoints` while the sidecar was loaded.
+
+### Changes
+
+- **Emit `initialized` event after `launch` response.**  After a successful
+  `launch` (sidecar loaded, VM connected) the adapter now writes an
+  `initialized` event.  VS Code responds by sending `setBreakpoints` while
+  the VM is still blocked in its startup pause — every breakpoint is
+  installed before execution begins.
+
+- **`stopOnEntry` support in `configurationDone`.**  Added `stop_on_entry:
+  bool` field to `DapServer`.  When `launch` includes `"stopOnEntry": true`,
+  `configurationDone` calls `step_instruction` instead of `cont`, so the VM
+  pauses at the first source line rather than running freely.
+
+- **`stop_on_entry` field initialised to `false` in `DapServer::new`.**
+
 ## 0.3.0 — 2026-05-10
 
 **LANG25-25B — Fix `handle_launch` to establish the VM connection.**

--- a/code/packages/rust/dap-adapter-core/src/server.rs
+++ b/code/packages/rust/dap-adapter-core/src/server.rs
@@ -71,6 +71,11 @@ pub struct DapServer<A: LanguageDebugAdapter> {
     seq: SeqCounter,
     /// Stop signal; set by `disconnect` handler.
     pub(crate) shutdown: bool,
+    /// Whether `launch` requested `stopOnEntry`.
+    ///
+    /// When true, `configurationDone` uses `step_instruction` so the VM
+    /// halts at its first source line rather than running freely.
+    stop_on_entry: bool,
 }
 
 impl<A: LanguageDebugAdapter> DapServer<A> {
@@ -85,6 +90,7 @@ impl<A: LanguageDebugAdapter> DapServer<A> {
             vm_proc: None,
             seq: SeqCounter::new(),
             shutdown: false,
+            stop_on_entry: false,
         }
     }
 
@@ -145,12 +151,25 @@ impl<A: LanguageDebugAdapter> DapServer<A> {
             other => Err(format!("unsupported command: {other}")),
         };
 
+        // Remember whether launch succeeded BEFORE `result` is consumed.
+        let launch_succeeded = req.command == "launch" && result.is_ok();
+
         let resp = match result {
             Ok(body)    => build_response(req.seq, self.seq.next(), &req.command, true,  None, body),
             Err(msg)    => build_response(req.seq, self.seq.next(), &req.command, false, Some(&msg),
                                           json!({})),
         };
         write_message(w, &resp)?;
+
+        // After a successful `launch` the sidecar is loaded and the VM is
+        // running.  Emit `initialized` NOW so VS Code sends `setBreakpoints`
+        // while the sidecar is already available — the VM is blocked in its
+        // initial pause waiting for `configurationDone`, so every
+        // `set_breakpoint` TCP message is processed before execution starts.
+        if launch_succeeded {
+            let ev = build_event(self.seq.next(), "initialized", json!({}));
+            write_message(w, &ev)?;
+        }
 
         // Flush any pending events that the handler may have produced.
         self.drain_vm_events(w)?;
@@ -181,6 +200,11 @@ impl<A: LanguageDebugAdapter> DapServer<A> {
             .ok_or("launch: missing 'program'")?;
         let workspace = req.arguments.get("workspaceFolder").and_then(|v| v.as_str())
             .unwrap_or(".");
+
+        // Remember whether the editor wants to pause at the first source line.
+        self.stop_on_entry = req.arguments.get("stopOnEntry")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         let (bytecode_path, sidecar_bytes) = self.adapter
             .compile(&PathBuf::from(program), &PathBuf::from(workspace))
@@ -270,8 +294,16 @@ impl<A: LanguageDebugAdapter> DapServer<A> {
 
     fn handle_configuration_done(&mut self, _req: &DapRequest) -> Result<Value, String> {
         // After breakpoints are configured, kick the VM off.
+        //
+        // If the editor requested `stopOnEntry`, use `step_instruction` so the
+        // VM pauses at its first source line rather than running freely.
+        // Otherwise just `cont` — the VM will run until a breakpoint or exit.
         if let Some(conn) = self.vm_conn.as_deref_mut() {
-            conn.cont()?;
+            if self.stop_on_entry {
+                conn.step_instruction()?;
+            } else {
+                conn.cont()?;
+            }
         }
         Ok(json!({}))
     }

--- a/code/packages/rust/twig-dap/CHANGELOG.md
+++ b/code/packages/rust/twig-dap/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog — `twig-dap`
 
+## 0.3.2 — 2026-05-11
+
+**LANG25 follow-up — Hide compiler-internal registers from Variables panel.**
+
+Compiler-generated temporaries (names starting with `_`, e.g. `_r1`, `_n2`)
+were leaking into the VS Code Variables panel alongside user-visible names.
+
+### Root cause
+
+`build_sidecar` called `declare_variable` for every instruction destination,
+including internal temporaries the user never wrote.
+
+### Fix
+
+In the SSA-temporaries loop (Step 4b of `build_sidecar`), skip any dest name
+that starts with `_`.  Slot indices for user-visible variables are unaffected
+because both the sidecar and the VM's debug server derive slot indices from the
+*full* alphabetically-sorted name list (including `_`-prefixed names).
+
+### New tests
+
+- `internal_temporaries_are_not_declared_as_variables` — confirms `_r1` is
+  absent from `live_variables` while user-visible `result` and param `n`
+  remain present.
+- `internal_temp_slot_indices_do_not_displace_params` — confirms that even
+  when `_r1` (alpha-sorted before `n`) occupies slot 0, param `n` is still
+  declared with `reg_index = 1`, matching the VM's `get_slot` index.
+
 ## 0.3.1 — 2026-05-11
 
 **LANG25 follow-up — alphabetical slot ordering + variable introspection e2e test.**

--- a/code/packages/rust/twig-dap/src/lib.rs
+++ b/code/packages/rust/twig-dap/src/lib.rs
@@ -130,6 +130,13 @@ impl LanguageDebugAdapter for TwigDebugAdapter {
 /// value and keeps it visible until function exit, matching the behaviour of
 /// GDB/LLDB for ordinary local variables.
 ///
+/// **Internal temporaries are excluded.** The twig compiler prefixes
+/// compiler-generated registers with `_` (e.g. `_r1`, `_n2`).  These are
+/// never declared as sidecar variables so they do not appear in the VS Code
+/// Variables panel.  User-visible slot indices remain correct because both
+/// the sidecar and the VM's debug server use the *full* alphabetically-sorted
+/// name list (including `_`-prefixed names) when mapping `get_slot` indices.
+///
 /// ### Slot-index assignment: alphabetical order
 ///
 /// The twig-vm debug server's `get_slot(N)` returns the Nth variable when
@@ -203,6 +210,14 @@ pub fn build_sidecar(module: &IIRModule, source_path: &Path) -> Vec<u8> {
         }
 
         // Step 4b — emit SSA temporaries (live from defining instruction).
+        //
+        // Internal compiler temporaries are named with a leading `_` (e.g.
+        // `_r1`, `_n2`).  These are implementation details of the code
+        // generator and should not appear in the VS Code Variables panel.
+        // We skip them here so `live_variables` never returns them, while the
+        // slot indices for user-visible names (params and user-named lets)
+        // remain correct because both the sidecar and the VM use the same
+        // full alphabetically-sorted list for slot assignment.
         let param_names: std::collections::HashSet<&str> = func.params.iter()
             .map(|(n, _)| n.as_str())
             .collect();
@@ -211,6 +226,8 @@ pub fn build_sidecar(module: &IIRModule, source_path: &Path) -> Vec<u8> {
                 Some(d) if !param_names.contains(d.as_str()) => d,
                 _ => continue,  // void or param-shadowing instruction
             };
+            // Skip compiler-internal temporaries (leading `_`).
+            if dest_name.starts_with('_') { continue; }
             let slot = match slot_of.get(dest_name) {
                 Some(&s) => s,
                 None => continue,   // defensive: should never happen
@@ -637,5 +654,59 @@ mod tests {
             vars.iter().any(|v| v.name == "x"),
             "parameter 'x' of 'sq' must be declared as a variable; got: {vars:?}",
         );
+    }
+
+    #[test]
+    fn internal_temporaries_are_not_declared_as_variables() {
+        // Compiler-generated registers (names starting with `_`) must never
+        // appear in `live_variables`.  Only user-visible names (here: param
+        // `n` and user-named temp `result`) should be returned.
+        let m = make_module_with_fn(
+            "sq",
+            vec![("n", "i32")],
+            vec![
+                // _r1 and _r2 are compiler-generated; result is user-visible.
+                IIRInstr::new("mul_i32", Some("_r1".into()),
+                    vec![Operand::Var("n".into()), Operand::Var("n".into())], "i32"),
+                IIRInstr::new("mov", Some("result".into()),
+                    vec![Operand::Var("_r1".into())], "i32"),
+                IIRInstr::new("ret", None, vec![Operand::Var("result".into())], "i32"),
+            ],
+        );
+        let bytes = build_sidecar(&m, Path::new("sq.twig"));
+        // At instr 2 both `n` (param) and `result` (user temp) are live.
+        let vars = live_vars_at(&bytes, "sq", 2);
+        let names: Vec<&str> = vars.iter().map(|v| v.name.as_str()).collect();
+        assert!(names.contains(&"n"),      "param 'n' must appear: {names:?}");
+        assert!(names.contains(&"result"), "user temp 'result' must appear: {names:?}");
+        assert!(
+            !names.iter().any(|n| n.starts_with('_')),
+            "internal registers must be hidden from Variables panel: {names:?}",
+        );
+    }
+
+    #[test]
+    fn internal_temp_slot_indices_do_not_displace_params() {
+        // When a function has both a param and an internal `_r*` temp, the
+        // param's slot index must still be correct even though `_r1` occupies
+        // an earlier alphabetical slot (and is excluded from the sidecar).
+        //
+        // Alphabetical order of all names: ["_r1", "n"]
+        // So: slot 0 → _r1 (excluded), slot 1 → n (declared with reg_index 1).
+        let m = make_module_with_fn(
+            "sq",
+            vec![("n", "i32")],
+            vec![
+                IIRInstr::new("mul_i32", Some("_r1".into()),
+                    vec![Operand::Var("n".into()), Operand::Var("n".into())], "i32"),
+                IIRInstr::new("ret", None, vec![Operand::Var("_r1".into())], "i32"),
+            ],
+        );
+        let bytes = build_sidecar(&m, Path::new("sq.twig"));
+        let vars = live_vars_at(&bytes, "sq", 0);
+        let n_reg = vars.iter().find(|v| v.name == "n").map(|v| v.reg_index);
+        // `n` is alphabetically after `_r1`, so its slot index must be 1 —
+        // matching what the VM's `get_slot(frame, 1)` returns.
+        assert_eq!(n_reg, Some(1), "'n' must have reg_index 1 (after _r1 in alpha order): {vars:?}");
     }
 }

--- a/code/packages/typescript/twig-vscode/CHANGELOG.md
+++ b/code/packages/typescript/twig-vscode/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the Twig VS Code extension are
 documented in this file.
 
+## 0.1.2 - 2026-05-11
+
+**LANG25 follow-up — Bundle deps + fix LSP blocking + enable gutter breakpoints.**
+
+### Changes
+
+- **Bundle all dependencies with esbuild.**  Changed `main` from
+  `./out/extension.js` to `./out/bundle.js` and added an esbuild step to
+  `npm run build`.  Without bundling, `require('vscode-languageclient/node')`
+  failed at runtime because `node_modules` is not included in the VSIX.
+
+- **LSP start is now fire-and-forget.**  `activate()` no longer `await`s
+  `startLanguageClient()`, so a missing `twig-lsp-server` binary no longer
+  blocks DAP registration.  Errors are logged as warnings instead.
+
+- **Add `breakpoints` contribution to `package.json`.**  Without this entry
+  VS Code's editor does not register gutter clicks or `Run → Toggle
+  Breakpoint` as valid breakpoints for `.twig` files.  Adding `"breakpoints":
+  [{"language": "twig"}]` to `contributes` enables the full gutter-click
+  workflow.
+
 ## 0.1.1 - 2026-05-10
 
 **LANG25-25A — Add unit tests; fix empty test suite CI failure.**

--- a/code/packages/typescript/twig-vscode/package.json
+++ b/code/packages/typescript/twig-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "coding-adventures-twig",
   "description": "Twig language support and debugging for Visual Studio Code",
   "version": "0.1.0",
-  "main": "./out/extension.js",
+  "main": "./out/bundle.js",
   "engines": {
     "vscode": "^1.82.0"
   },
@@ -73,6 +73,11 @@
         ]
       }
     ],
+    "breakpoints": [
+      {
+        "language": "twig"
+      }
+    ],
     "configuration": {
       "title": "Twig",
       "properties": {
@@ -100,7 +105,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "tsc -p . && npx esbuild src/extension.ts --bundle --outfile=out/bundle.js --external:vscode --format=cjs --platform=node",
     "test": "vitest run"
   },
   "dependencies": {
@@ -109,6 +114,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/vscode": "^1.82.0",
+    "esbuild": "^0.28.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0"
   }

--- a/code/packages/typescript/twig-vscode/src/extension.ts
+++ b/code/packages/typescript/twig-vscode/src/extension.ts
@@ -6,7 +6,11 @@ import { startLanguageClient, stopLanguageClient } from "./lsp";
 import { registerDebugAdapter } from "./dap";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  await startLanguageClient(context);
+  // LSP is optional: if twig-lsp-server isn't on PATH (e.g. not yet built),
+  // log the error and continue.  DAP debugging works without the language server.
+  startLanguageClient(context).catch((err: unknown) => {
+    console.warn(`Twig: language server failed to start: ${err}`);
+  });
   registerDebugAdapter(context);
 }
 


### PR DESCRIPTION
## Summary

- **`dap-adapter-core` — emit `initialized` event after `launch`**: Without this, VS Code never sent `setBreakpoints` for pre-session breakpoints (the ones set via gutter click before pressing F5). The adapter now emits `initialized` immediately after a successful `launch` response, while the VM is still blocked in its startup pause, so every breakpoint is installed before execution begins.

- **`dap-adapter-core` — `stopOnEntry` support**: When `launch` includes `"stopOnEntry": true`, `configurationDone` now calls `step_instruction` instead of `cont`, so the VM pauses at the first source line rather than running freely to the first breakpoint.

- **`twig-vscode` — `breakpoints` contribution in `package.json`**: Without `"breakpoints": [{"language": "twig"}]` in `contributes`, VS Code refuses gutter clicks and Run → Toggle Breakpoint for `.twig` files entirely.

- **`twig-vscode` — non-blocking LSP startup**: `activate()` now fire-and-forgets `startLanguageClient()` with `.catch()`, so a missing `twig-lsp-server` no longer blocks DAP adapter registration.

- **`twig-vscode` — esbuild bundle**: Added esbuild to inline all npm dependencies into `out/bundle.js`, fixing the `require('vscode-languageclient/node')` failure at runtime.

## Test plan

- [ ] Click in the gutter on line 8 of `demo.twig` — red breakpoint dot appears and BREAKPOINTS panel shows `demo.twig:8`
- [ ] Press F5 to start debugging — session starts, pauses at line 13 (`stopOnEntry` stop)
- [ ] Press F5 again (Continue) — execution runs to the breakpoint on line 8 inside `sq`
- [ ] Variables panel shows `n = 3` (first call to `sq(3)`)
- [ ] Call stack shows `sq → sum-of-squares → main`
- [ ] All 81 `dap-adapter-core` tests pass: `cargo test -p dap-adapter-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)