### PR TITLE
spec(adjudication): ADJ01 v2 — hierarchical decomposition (revises ADJ01)

### DIFF
--- a/code/specs/ADJ01-adjudication-ir-grammar.md
+++ b/code/specs/ADJ01-adjudication-ir-grammar.md
@@ -1,23 +1,60 @@
-# ADJ01 — Adjudication IR: Node Grammar, Type Rules, Lowering
+# ADJ01 — Adjudication IR: Hierarchical Decomposition, Node Grammar, Lowering
+
+> **Revision v2 (2026-05-11): hierarchical decomposition.** The first
+> version of this spec defined a flat IR whose validation depended on
+> a language-specific token tagger (`ADJ02`) and a NegEx/ConText-style
+> trigger taxonomy (`ADJ03`). Both choices baked English-language
+> assumptions into the framework. This revision replaces those
+> assumptions with **LLM-driven hierarchical decomposition**: the
+> extractor produces a *tree* whose leaves are the existing IR kinds
+> (`Fact`, `Query`, `Uncertainty`, `Rule`, `Exception`, `Discarded`)
+> and whose internal nodes are a new `TextRun` kind that exists only
+> to carry the decomposition. Coverage becomes a **structural tree
+> check** (`ADJ02-v2`); polarity / modality consistency becomes a
+> **propagation check** (`ADJ03-v2`). No language-specific knowledge
+> lives in the framework. See `ADJ02` and `ADJ03` for the updated
+> checker semantics.
 
 ## Overview
 
-[`ADJ00`](ADJ00-adjudication-framework.md) introduced the framework and sketched the IR informally.
-This spec defines the IR grammar formally: node shapes, the polarity and
-modality lattices, the well-formedness conditions every node must satisfy,
-the term language nodes are built out of, and the lowering edges that turn
-high-level extractor output into the leaf nodes that the logic backends
-actually consume.
+[`ADJ00`](ADJ00-adjudication-framework.md) introduced the framework
+and sketched the IR informally. This spec defines the IR grammar
+formally: node shapes, the polarity and modality lattices, the
+hierarchical decomposition tree, the lowering DAG, and the
+well-formedness conditions every node must satisfy.
 
-The grammar is intentionally small. Six node kinds, two lattices, one DAG
-structure. Everything else in the framework — the four checker passes
-(`ADJ02..ADJ05`), the clarification protocol (`ADJ06`), the audit trail
-(`ADJ07`), the rule-compilation pipeline (`ADJ09`) — composes over this
-grammar without extending it.
+The grammar is intentionally small. Seven node kinds (one of them
+new in v2), two lattices, a decomposition tree, and a lowering DAG.
+Everything else in the framework — the four checker passes
+(`ADJ02..ADJ05`), the clarification protocol (`ADJ06`), the audit
+trail (`ADJ07`), the rule-compilation pipeline (`ADJ09`) — composes
+over this grammar without extending it.
 
-A subsequent crate (`code/packages/rust/adjudication-ir`, to be created
-parallel to `code/packages/python/adjudication-ir`) will implement the
-grammar directly. This spec is the contract.
+## Why a Hierarchical Tree
+
+The framework's central claim is that the LLM does the *linguistic*
+work and the checker passes do the *structural* verification. A flat
+IR cannot uphold that claim: deciding whether a token is "meaningful"
+or whether a span carries negation requires linguistic knowledge that
+the framework would have to encode itself, locking the design to a
+single language (and, in practice, the English clinical idiom).
+
+A hierarchical IR pushes all that knowledge into the LLM. The LLM
+breaks the input into a tree of text runs, refining toward atomic
+claims; each level is the LLM's report on what the input means at
+that granularity. The framework's job is only to verify the
+**tree's structural invariants**:
+
+- Every byte of the input is in some leaf's source spans
+  (structural coverage).
+- Each parent's polarity / modality is consistent with its
+  children's effective values (propagation consistency).
+- The leaves are well-formed nodes of the existing kinds.
+
+These checks are language-agnostic by construction. The trigger
+taxonomies and stopword lists of v1 disappear from the framework
+core; they may live on as optional accelerators for narrow domains
+where rule-based shortcuts are demonstrably reliable.
 
 ## Layer Position
 
@@ -32,42 +69,41 @@ grammar directly. This spec is the contract.
               │
        ┌──────┴──────────────┐
        ▼                     ▼
-   ADJ02..ADJ05         logic-core
-   checker passes       (LP00, used as the term layer)
+   ADJ02-v2..ADJ05      logic-core
+   structural / LLM     (LP00, used as the term layer)
+   checker passes
 ```
 
-The IR's term language is layered directly on top of `logic-core` (see
-[`LP00`](LP00-logic-core.md)). An IR node's `term` field holds an ordinary
-`logic_core::Term`. The IR adds metadata around terms — polarity, modality,
-source spans, provenance — that logic-core itself has no opinion about.
+The IR's term language is layered directly on top of `logic-core`
+(see [`LP00`](LP00-logic-core.md)). A leaf IR node's `term` field
+holds an ordinary `logic_core::Term`. The IR adds metadata around
+terms — polarity, modality, source spans, structural and refinement
+edges — that logic-core itself has no opinion about.
 
 ## Documents
 
-The IR operates on **documents**. A document is the unit of adjudication: a
-clinical note, a deal memo, a TSA carry-on declaration, a customer-support
-ticket. Every IR node belongs to exactly one document at extraction time.
+The IR operates on **documents**. A document is the unit of
+adjudication: a clinical note, a deal memo, a TSA carry-on
+declaration, a customer-support ticket.
 
 ```text
-DocumentId := opaque string (UUID v4 recommended; any unique identifier
-                             acceptable provided it is stable across
-                             clarification turns)
+DocumentId := opaque string (UUID v4 recommended; any unique
+                             identifier acceptable provided it is
+                             stable across clarification turns)
 
 Span        := (DocumentId, start_offset, end_offset)
-             where start_offset and end_offset are byte offsets into the
-             document's normalized text representation.
+             where start_offset and end_offset are byte offsets into
+             the document's normalized text representation.
 ```
 
-Span offsets are byte offsets, not character indices, to avoid Unicode
-normalization disagreements between extractor implementations. The
-**normalized text** is whatever the document parser produces — Markdown
-stripped to plain text, HTML rendered to text, OCR output cleaned — and
-this normalization is recorded as document metadata so spans can be
-re-resolved after re-normalization.
+Byte offsets, not character indices, to avoid Unicode normalization
+disagreements between implementations. The **normalized text** is
+whatever the document parser produces and is recorded as document
+metadata so spans can be re-resolved after re-normalization.
 
-A document's lifecycle spans multiple clarification turns. New text appended
-during clarification is part of the same document under a stable `DocumentId`,
-with span offsets continuing into the appended region. Replay of a closed
-adjudication recovers the document's exact byte sequence at each turn.
+A document's lifecycle spans multiple clarification turns. New text
+appended during clarification is part of the same document under a
+stable `DocumentId`.
 
 ## The Term Language
 
@@ -82,24 +118,18 @@ Term :=
   | Compound(functor, args[])
 ```
 
-No extensions. The IR's metadata is carried on the **node** that wraps a
-term, never inside the term itself. This separation is important: it means
-the existing logic backends consume IR-derived terms unchanged.
+No extensions. IR metadata is carried on the **node** that wraps a
+term, never inside the term itself. This keeps the existing logic
+backends consuming IR-derived terms unchanged.
 
-Lists, dates, quantities, and other "structured but not first-class" values
-are encoded as compound terms following Prolog convention:
+Lists, dates, quantities, and other structured values are encoded as
+compound terms following Prolog convention:
 
 ```text
 [a, b, c]            →   '.'(a, '.'(b, '.'(c, [])))
 2026-05-10           →   date(2026, 5, 10)
 "100 ml"             →   quantity(100, ml)
-"≤ 3.4 oz"           →   bound(le, 3.4, oz)
 ```
-
-A canonical encoding registry for common structured values (dates,
-quantities, units, ranges, durations) is part of `ADJ01a` (a forthcoming
-sub-spec). It is referenced here so that two independent extractor
-implementations agree on encoding.
 
 ## IR Nodes
 
@@ -109,36 +139,112 @@ Every IR node has the following fields:
 IRNode := {
     id:             NodeId,
     kind:           NodeKind,
-    term:           Term,
+    term:           Term,                  -- meaningful for non-TextRun kinds
     polarity:       Polarity,
     modality:       Modality,
     source_spans:   [Span],
     confidence:     Real in [0, 1],
-    lowered_from:   Option<NodeId>,
-    discard_reason: Option<DiscardReason>,
+    part_of:        Option<NodeId>,        -- NEW IN v2: structural parent
+    lowered_from:   Option<NodeId>,        -- refinement (clarification) parent
+    discard_reason: Option<DiscardReason>, -- required iff kind = Discarded
     metadata:       Map<string, Json>,
 }
 
 NodeId    := opaque string, unique within document
-NodeKind  := Fact | Query | Uncertainty | Rule | Exception | Discarded
+NodeKind  := TextRun                       -- NEW IN v2: non-leaf decomposition node
+           | Fact | Query | Uncertainty | Rule | Exception | Discarded
 ```
 
-Field semantics:
+### `part_of` (new in v2): the structural decomposition edge
 
-| Field | Meaning |
-|---|---|
-| `id` | Stable identifier within the document. Used by `lowered_from`, by the proof DAG, and by replay tooling. |
-| `kind` | The node's role in the IR. Determines which type rules apply. |
-| `term` | The logical content (a `logic-core::Term`). |
-| `polarity` | Whether the node asserts, denies, or is uncertain about `term`. |
-| `modality` | The temporal / hypothetical / ownership context of `term`. |
-| `source_spans` | The ranges of source text that produced this node. |
-| `confidence` | Extractor's self-reported confidence. Informational only; not used by the type check. |
-| `lowered_from` | If present, points to the parent node in the lowering DAG. |
-| `discard_reason` | Required iff `kind = Discarded`. |
-| `metadata` | Free-form extension. Reserved for downstream consumers; not consumed by the type check. |
+`part_of` points to the **parent** in the decomposition tree. A node
+with `part_of = None` is at the document root. A `TextRun` parent's
+**children** are every node whose `part_of` equals the parent's id.
 
-The next four sections specify the lattices and the per-kind type rules.
+The structural-coverage invariant (enforced by `ADJ02-v2`) requires
+that the union of a parent's children's `source_spans` equals the
+parent's `source_spans`. Every byte of the document ends up in some
+leaf, transitively.
+
+### `lowered_from` (unchanged): the refinement DAG edge
+
+`lowered_from` points to a node that this one **refines** —
+typically a more general claim that a clarification turn made
+specific. `lowered_from` is independent of `part_of`. A node can
+have both (it has a structural parent *and* refines an earlier
+version of itself). Refinement is a DAG (no cycles); the
+decomposition is a tree.
+
+### Term for `TextRun`
+
+`TextRun` nodes don't carry a domain claim — they exist only to
+group children. Their `term` field is required (the IRNode shape is
+uniform) and conventionally set to `text_run/0` (the zero-arity
+compound) or to a domain-specific description. Validators don't
+inspect it.
+
+## Hierarchical Decomposition
+
+```text
+Document (whole input, source_spans = [(doc, 0, len)])
+   │
+   ▼ part_of edges (children point to this root)
+   │
+   ├── TextRun  (a section / paragraph)
+   │     ├── TextRun (a sentence)
+   │     │     ├── Fact     ← leaf
+   │     │     └── Discarded ← leaf (a non-domain phrase)
+   │     └── Fact
+   ├── TextRun
+   │     └── Uncertainty
+   └── Discarded   (a top-level non-domain span)
+```
+
+The root has `part_of = None`. Every other node has `part_of` set to
+its structural parent. Leaves are nodes whose kind is not `TextRun`
+(though `Discarded` can also appear at non-leaf positions when a
+whole sub-tree of text is non-domain).
+
+**Two related design choices worth flagging:**
+
+1. **`Document` is not its own kind.** The document is represented
+   by whichever node(s) have `part_of = None`. Most documents have
+   one root (a single TextRun covering the whole input); split-root
+   documents (e.g., a clinical note with separate History and
+   Examination sections) are valid as long as every root collectively
+   tiles the document's bytes.
+2. **Leaves carry the term; TextRuns don't.** All claim content
+   lives at the leaves. TextRuns carry source spans and (optionally)
+   polarity/modality that propagates to descendants.
+
+## Polarity and Modality on TextRuns: Propagation
+
+A non-leaf `TextRun` can carry a polarity and modality that **applies
+to every leaf descendant unless overridden**. The canonical example:
+
+```text
+TextRun (polarity = Denied)        spans = [(doc, 0, 50)]
+  ↓ "Patient denies the following: chest pain, fever, shortness of breath."
+  Fact term=chest_pain(p)  polarity = Denied (inherited)
+  Fact term=fever(p)        polarity = Denied (inherited)
+  Fact term=sob(p)          polarity = Denied (inherited)
+```
+
+The LLM emits the parent's polarity once and propagates to children
+implicitly. Children may override by carrying their own non-`Inherit`
+value. Propagation rules:
+
+- If a leaf carries an explicit (non-default) polarity, that value
+  wins.
+- Otherwise, the nearest ancestor with a non-default polarity wins.
+- Modality propagates by the same rule.
+- The framework's default values are `Affirmed` for polarity and
+  `Present` for modality. A node that means "use the inherited
+  value" sets these defaults; one that means "override" sets a
+  different value.
+
+`ADJ03-v2` formalises the propagation algorithm and the check that
+the result is consistent.
 
 ## Polarity
 
@@ -146,19 +252,9 @@ The next four sections specify the lattices and the per-kind type rules.
 Polarity := Affirmed | Denied | Uncertain
 ```
 
-Semantics:
-
-- **Affirmed**: the node asserts `term`. "Patient has fever" → `Affirmed`.
-- **Denied**: the node asserts `¬term`. "Patient denies chest pain" → `Denied`.
-- **Uncertain**: the source neither asserts nor denies; the node records
-  that the question was *raised* in the source. "Possible pneumonia" → an
-  Uncertainty node with `Uncertain`. **Not** the same as low `confidence`.
-
-The polarity lattice is flat: no element subsumes another. A node either
-asserts, denies, or records uncertainty. There is no `Unknown` value; the
-absence of evidence is represented by the *absence* of a node, not by a
-node tagged Unknown — and the coverage check ensures any span that should
-have produced a node did.
+Unchanged from v1. Flat lattice; no `Unknown`. The absence of
+evidence is the absence of a node, enforced by the structural
+coverage check.
 
 ## Modality
 
@@ -172,76 +268,54 @@ Modality := Present
           | Conditional
 ```
 
-Semantics:
-
-- **Present**: holds at adjudication time. *"Patient currently has cough."*
-- **Past**: held previously, no claim about now. *"History of asthma."*
-- **Future**: anticipated. *"Will be discharged tomorrow."*
-- **Hypothetical**: counterfactual or instructional. *"If the patient develops X..."*
-- **FamilyHistory**: holds of a relative, not of the patient. *"Father had MI at 50."*
-- **RuledOut**: explicitly excluded after consideration. *"PE ruled out by CT angio."*
-  Distinct from `Denied` polarity: `Denied` is the source saying "no";
-  `RuledOut` is the source saying "I considered this and excluded it." For
-  diagnoses, this distinction matters for billing, audit, and downstream
-  reasoning.
-- **Conditional**: holds only when an attached condition is met. *"Avoid X
-  if patient has Y."* The condition itself must be a separate node referenced
-  by metadata.
-
-`RuledOut` and `Denied` are deliberately separate because they are not
-synonyms in clinical or legal practice. A clinician who *denies* writing a
-prescription is making a different claim than a clinician who *ruled out*
-prescribing one.
-
-The modality lattice is also flat: no element subsumes another. Combining
-modalities (e.g., past + family history) requires multiple nodes, not a
-join in the lattice.
+Unchanged from v1. Flat lattice. `RuledOut` and `Denied` (a polarity
+value) remain explicitly distinct because clinical and legal
+practice treats them as non-synonyms.
 
 ## Node Kinds and Their Type Rules
 
-Each node kind has well-formedness constraints. The type check enforces
-these structurally before any pass runs.
+### TextRun (new in v2)
 
-### Fact
-
-A Fact node represents a state-of-the-world claim extracted from the input
-(in the input pipeline) or a state-of-the-rulebook claim (in the rule
-pipeline used by `ADJ09`).
+A non-leaf node that exists to carry the decomposition.
 
 Well-formedness:
 
 ```text
+kind = TextRun implies:
+    source_spans          is non-empty (must cite document bytes)
+    discard_reason        is absent
+    at least one node has part_of = this.id     -- non-leaf by construction
+```
+
+### Fact
+
+A claim about the world.
+
+Well-formedness (unchanged from v1):
+
+```text
 kind = Fact implies:
-    polarity      != Uncertain         (Facts are not uncertain by construction)
+    polarity      != Uncertain
     source_spans  is non-empty
     discard_reason is absent
-    term          is a ground term, or a term containing only existentially
-                  quantified variables (the variables are local to the node)
 ```
 
 ### Query
 
-A Query node is a question the adjudication is asked to answer. Most
-documents have exactly one Query, but multiple are permitted (e.g., "what's
-the diagnosis AND what test to order next").
+A question the adjudication is asked.
 
 Well-formedness:
 
 ```text
 kind = Query implies:
-    polarity      = Affirmed            (Querying ¬p is itself a question)
+    polarity      = Affirmed
     source_spans  is non-empty
     discard_reason is absent
-    term          typically contains free variables — the answer binds them
 ```
 
 ### Uncertainty
 
-An Uncertainty node records that the source explicitly raised a question
-without answering it: "*possible* pneumonia," "*differential includes* PE."
-Distinct from a low-confidence Fact.
-
-Well-formedness:
+The source explicitly raised a question without answering it.
 
 ```text
 kind = Uncertainty implies:
@@ -250,43 +324,26 @@ kind = Uncertainty implies:
     discard_reason is absent
 ```
 
-Uncertainty nodes are consumed by the probabilistic backend (`ADJ11`) as
-hints about which facts to treat as variables of interest; in the
-non-probabilistic adjudication path they surface to clarification.
-
 ### Rule
 
-A Rule node represents a piece of the rulebook compiled into the IR. Rules
-are produced by the rule-compilation pipeline (`ADJ09`), not the
-input-extraction pipeline.
-
-Well-formedness:
+Produced by the rule-compilation pipeline (`ADJ09`).
 
 ```text
 kind = Rule implies:
     polarity      != Uncertain
-    source_spans  is non-empty       (must cite the rulebook span)
+    source_spans  is non-empty
     discard_reason is absent
+    metadata MUST contain `as_of` (ISO-8601)
     term          is a compound term whose functor is one of:
                       definitional( head, body[] )
                       constraint( body[] )
                       default( head, body[], exceptions[] )
                       probabilistic( probability, head, body[] )
-    metadata MUST contain an `as_of` ISO-8601 date stamp from the source.
 ```
-
-The Rule subtype is encoded in the term, not in the kind, to avoid an
-explosion of kinds while preserving the structural type check. See
-[`ADJ09`](ADJ09-rule-compilation-pipeline.md) — TBD — for the detailed
-typing of each Rule subtype.
 
 ### Exception
 
-An Exception node is a structured carve-out attached to a Rule. Distinct
-from a separate Rule because Exceptions are syntactically lexically scoped
-to their parent Rule.
-
-Well-formedness:
+A carve-out attached to a Rule.
 
 ```text
 kind = Exception implies:
@@ -296,224 +353,219 @@ kind = Exception implies:
     metadata MUST contain `applies_to: NodeId` pointing to a Rule node.
 ```
 
-Exceptions and the priority order between rules are first-class because
-real rulebooks (medical guidelines, tax code, license terms) routinely
-declare exceptions explicitly.
-
 ### Discarded
 
-A Discarded node represents a span of input that the extractor deliberately
-chose not to translate into a Fact / Query / Uncertainty / Rule.
-
-Well-formedness:
+An explicit span the extractor judged irrelevant.
 
 ```text
 kind = Discarded implies:
     discard_reason is non-empty
     source_spans   is non-empty
-    polarity       = Affirmed         (we affirm the discard, not deny content)
+    polarity       = Affirmed
     modality       = Present
     term           is the atom `discarded`
 ```
 
-`DiscardReason` is drawn from a controlled vocabulary so coverage analysis
-can audit *why* spans were dropped:
+Controlled `DiscardReason` vocabulary unchanged:
 
 ```text
 DiscardReason :=
-    Pleasantry            -- "Hi doc, hope you had a good weekend."
-    DocumentMetadata      -- header / footer / boilerplate
-    NonDomainContent      -- patient asked about parking
-    Restatement           -- duplicates an already-extracted fact
-    Unparseable           -- text whose meaning the extractor cannot determine
-    AdministrativeOnly    -- billing codes, MRN, etc. captured elsewhere
-    ExplicitlyOutOfScope  -- e.g., "I'll address this in next visit"
+    Pleasantry
+  | DocumentMetadata
+  | NonDomainContent
+  | Restatement
+  | Unparseable            -- always a coverage failure
+  | AdministrativeOnly
+  | ExplicitlyOutOfScope
 ```
 
-The `Unparseable` reason is *always* a coverage failure: an extractor that
-declares text Unparseable triggers a clarification rather than shipping the
-node. This is enforced by `ADJ02`.
+## The Decomposition Tree (replaces "The Lowering DAG" section from v1)
 
-## The Lowering DAG
+The IR has two distinct edge sets:
 
-The IR is a directed acyclic graph induced by `lowered_from` edges.
+1. **Decomposition tree** (`part_of`): structural. The whole hierarchy
+   from document roots to leaves. Every non-root node has exactly one
+   structural parent.
+2. **Refinement DAG** (`lowered_from`): historical / refinement.
+   Records that a node is a more-specific version of an earlier node,
+   typically created via clarification.
 
-```text
-A node X is a leaf if no other node Y has lowered_from = X.
-A node X is a root if X.lowered_from = None.
-```
+The two are orthogonal:
 
-Roots are produced directly by the extractor from the source. Leaves are
-what the logic backends consume. Intermediate nodes record refinement steps
-— a high-level extraction that was subsequently split, made more specific,
-or restated more formally during clarification.
+- A node may have a `part_of` (it's in the structural tree) and a
+  `lowered_from` (it's a refinement of an earlier leaf).
+- A leaf created during clarification typically has `part_of` set to
+  the same parent as its predecessor (the refinement happens
+  *inside* the structural slot).
 
-```text
-For every non-root node X:
-    X.lowered_from = Y  implies
-        Y.source_spans is a (not necessarily strict) superset of X.source_spans
-        Y.kind is "compatible with" X.kind (see lowering rules below)
-```
+### Structural-tree well-formedness
 
-The "spans superset" condition guarantees that lowering only narrows
-provenance, never invents it. A leaf node's source spans are always
-contained within its root's spans, transitively.
+For every node X with `X.part_of = Some(Y)`:
 
-### Lowering Rules
+- `Y` exists in the document.
+- `Y.kind = TextRun` (only TextRuns can have children; leaves cannot).
+- `X.source_spans` ⊆ `Y.source_spans` (children fit inside their
+  parent's spans).
 
-The kind-compatibility relation `≺` for lowering is:
+For every TextRun Y:
 
-```text
-Fact            ≺ Fact            (refinement: same claim, more specific)
-Uncertainty     ≺ Fact            (resolution: clarification turned uncertainty
-                                   into an affirmation or denial)
-Uncertainty     ≺ Uncertainty     (refinement: more specific uncertain claim)
-Query           ≺ Query           (decomposition: one query broken into
-                                   subqueries)
-Rule            ≺ Rule            (refinement during compilation)
-```
+- Let `C(Y)` = `{X : X.part_of = Some(Y)}`.
+- The union of `C(Y)`'s `source_spans` must equal `Y.source_spans`.
+  Every byte of the parent's spans is in some child's spans.
 
-Every other combination is forbidden. A Discarded node cannot be lowered;
-a node cannot be lowered *to* Discarded (use the type check instead).
+This is the **structural coverage invariant**, formalised in
+`ADJ02-v2`.
 
-A Fact may NOT lower to an Uncertainty. The framework treats clarification
-that *introduces* uncertainty as a coverage check failure: the extractor
-should have produced an Uncertainty at the root in the first place.
+### Refinement-DAG well-formedness (unchanged from v1)
+
+For every node X with `X.lowered_from = Some(Y)`:
+
+- `Y` exists.
+- `Y.kind` is "compatible with" `X.kind` per the kind-compatibility
+  relation: `Fact ≺ Fact`, `Uncertainty ≺ Fact`, `Uncertainty ≺
+  Uncertainty`, `Query ≺ Query`, `Rule ≺ Rule`.
+- `X.source_spans` ⊆ `Y.source_spans` (refinement narrows
+  provenance).
+
+The refinement DAG is acyclic.
 
 ## Well-Formedness Summary
 
 An IR document is well-formed iff:
 
 1. Every node satisfies its kind-specific constraints (above).
-2. `lowered_from` forms a DAG (no cycles).
-3. For every non-root node X with `X.lowered_from = Y`:
-   - `Y` exists in the document.
-   - `kind(Y) ≺ kind(X)` per the lowering rules.
-   - `X.source_spans ⊆ Y.source_spans`.
-4. Every Exception node's `applies_to` metadata points to an existing Rule
-   in the same document.
-5. Every Span's offsets are valid byte ranges in the document at the turn
-   the node was produced.
+2. Every node id is unique.
+3. The decomposition tree (`part_of` edges) is a forest of trees:
+   each non-root node has exactly one structural parent; no cycles.
+4. Every TextRun's children's spans tile its spans (structural
+   coverage invariant).
+5. The refinement DAG (`lowered_from` edges) is acyclic and obeys
+   the kind-compatibility relation.
+6. For every non-root node X with `X.part_of = Some(Y)`,
+   `X.source_spans ⊆ Y.source_spans`.
+7. Every Exception node's `applies_to` metadata points to an
+   existing Rule.
+8. Every Span's offsets are valid byte ranges in the document.
 
-The `ADJ01-ref` Rust crate (`code/packages/rust/adjudication-ir`) will
-implement a `validate()` function that enforces all five conditions and
-returns the specific violation when any fails. Validation is total — no
-partial well-formedness.
+`validate()` enforces all eight conditions and returns the specific
+violation when any fails. Validation is total — no partial
+well-formedness.
+
+## Lowering Rules (Kind Compatibility for Refinement)
+
+Unchanged from v1:
+
+```text
+Fact            ≺ Fact            (refinement: same claim, more specific)
+Uncertainty     ≺ Fact            (resolution via clarification)
+Uncertainty     ≺ Uncertainty     (more specific uncertain claim)
+Query           ≺ Query           (decomposition into subqueries)
+Rule            ≺ Rule            (rule refinement during compilation)
+```
+
+A Fact may **not** lower to an Uncertainty. The framework treats
+clarification that introduces uncertainty as a structural failure:
+the LLM should have produced an Uncertainty leaf at the original
+position.
+
+`TextRun` does not participate in the refinement DAG — it's a
+structural-only kind.
+
+## Worked Example (Hierarchical Form)
+
+Continuing the TSA example. The input *"I'd like to bring a 4 oz
+tube of toothpaste, ..., I am not bringing matches, only a single
+disposable lighter."* now decomposes hierarchically:
+
+```text
+N0 TextRun     "I'd like to bring ... disposable lighter."   (doc, 0, 209)
+   │
+   ├── N1 TextRun   "I'd like to bring ... lighter."         (doc, 0, 149)
+   │     │
+   │     ├── F1 Fact carry_on_item(toothpaste, ...) (doc, 5, 45)
+   │     ├── F2 Fact carry_on_item(perfume, ...)    (doc, 46, 62)
+   │     ├── F3 Fact carry_on_item(lithium_battery,...) (doc, 63, 93)
+   │     ├── F4 Fact carry_on_item(wine, ...)       (doc, 94, 124)
+   │     └── F5 Fact carry_on_item(pocket_knife,...) (doc, 125, 149)
+   │
+   ├── N2 TextRun polarity=Denied  "I am not bringing matches" (doc, 150, 176)
+   │     │
+   │     └── F6 Fact carry_on_item(matches)         (doc, 150, 176)
+   │           (inherits Denied from N2)
+   │
+   └── N3 TextRun     "only a single disposable lighter."   (doc, 177, 209)
+         │
+         └── F7 Fact carry_on_item(lighter, ...)   (doc, 177, 209)
+```
+
+The negation polarity for F6 is **carried by the TextRun parent N2**,
+not detected by scanning F6's span for the word "not". The framework
+verifies that F6's effective polarity (the propagated Denied) matches
+its declared polarity (also Denied or `Inherit` — either way
+consistent). No NegEx machinery is involved. The LLM saw the phrase
+*"I am not bringing matches"* and chose to emit a parent TextRun with
+Denied polarity; that decision is in the IR, auditable, and
+verifiable structurally.
 
 ## Serialization
 
-The on-disk and on-wire form is JSON. A JSON Schema for `IRNode` lives at
-`code/specs/schemas/adjudication-ir.schema.json` (to be added when the
-Rust crate lands).
+The on-disk and on-wire form is JSON. A JSON Schema for `IRNode` will
+live at `code/specs/schemas/adjudication-ir.schema.json` (to be
+added when the Rust crate's v2 lands).
 
-The schema mirrors the grammar above, with two presentation choices:
+Schema additions in v2:
 
-- `term` is encoded using the canonical s-expression-like form already used
-  by other logic-vm tooling in this repo, *not* as a nested JSON object.
-  This keeps round-tripping through external tools (Prolog dumps, ProbLog
-  programs) lossless.
-- `metadata` is a free-form JSON object; downstream consumers may add keys
-  but the framework reserves any key beginning with `adj.` for future use.
+- `kind` enum gains `"TextRun"`.
+- `part_of` field, optional NodeId.
+- `polarity` and `modality` gain an `"Inherit"` value indicating
+  "use the parent's effective value." Default for TextRun children.
 
-A reference round-trip (a parsed IR document re-emitted as JSON equals the
-input byte-for-byte after canonicalization) is part of the test suite for
-the Rust crate.
+## Open Questions (revised)
 
-## Worked Example: TSA, Lowered
+1. **Default vs. Inherit ambiguity.** `polarity: Affirmed` and
+   `polarity: Inherit` are different declarations but produce the
+   same effective value when the ancestor chain is all Affirmed.
+   Should the extractor be required to be explicit? The current
+   design accepts either; the audit trail records the literal field.
+2. **Sibling polarity disagreement.** If two siblings declare
+   `Affirmed` and `Denied` under a `Denied` parent, the propagation
+   succeeds (the Affirmed child overrides). Whether that pattern is
+   "natural" (a contrast) or "an error" depends on the source text.
+   `ADJ03-v2` will likely raise it for clarification but not fail
+   the structural check.
+3. **Multi-root documents.** Most documents have one root; sectioned
+   documents (clinical notes with separate sections) have several.
+   The framework supports both; deployments may prefer one
+   convention.
+4. **Discarded TextRuns vs. Discarded leaves.** A whole sub-tree
+   that is non-domain content can be represented either as a single
+   `Discarded` leaf at the right level OR as a TextRun with a
+   Discarded leaf inside. Both are well-formed; the LLM picks.
 
-Continuing the running example from `ADJ00`. The input *"I'd like to bring
-a 4 oz tube of toothpaste, ... I am not bringing matches, only a single
-disposable lighter."* produces the root nodes already shown in `ADJ00`.
-This section traces one lowering step.
+## Limitations (revised)
 
-Root node, produced by the extractor:
-
-```text
-F6 {
-    id:           "F6",
-    kind:         Fact,
-    term:         carry_on_item(matches),
-    polarity:     Denied,
-    modality:     Present,
-    source_spans: [(doc1, 142, 168)],   // "I am not bringing matches"
-    confidence:   0.93,
-    lowered_from: None,
-}
-```
-
-The polarity check (`ADJ03`) examines span `(doc1, 142, 168)`, finds the
-negation trigger "not bringing", confirms it is in scope of the noun
-"matches", and accepts polarity = Denied. Pass succeeds.
-
-Now suppose the clarification dialogue asks (because matches are not a
-single category in TSA rules — safety matches and strike-anywhere matches
-have different rules) and the user responds *"safety matches."* The
-extractor produces a lowered node:
-
-```text
-F6a {
-    id:           "F6a",
-    kind:         Fact,
-    term:         carry_on_item(safety_matches),
-    polarity:     Denied,
-    modality:     Present,
-    source_spans: [(doc1, 142, 168), (doc1, 245, 261)],
-                  // original span + clarification response span
-    confidence:   0.98,
-    lowered_from: Some("F6"),
-}
-```
-
-The well-formedness checks: `F6a.lowered_from = F6` exists; `kind(F6) =
-Fact ≺ Fact = kind(F6a)` is allowed; `F6a.source_spans ⊇ F6.source_spans`
-is satisfied. Validation passes.
-
-The logic engine consumes `F6a` (the leaf), not `F6`. The audit trail
-shows the lowering chain so a reviewer can see why the leaf has the spans
-it does.
-
-## Open Questions
-
-The following are deferred to subsequent revisions of this spec:
-
-1. **Quantifier semantics for variables inside Fact terms.** Existential is
-   the default; universal-in-fact-terms is rare but real ("all of patient's
-   medications include X"). Probably a metadata tag rather than a new kind.
-2. **Negation as failure vs. classical negation in rule bodies.** Cleanly
-   defined in ProbLog (well-founded semantics); needs explicit handling
-   when Rule terms contain negative literals. Punted to `ADJ09`.
-3. **Cross-document references.** A clinical note may reference a prior
-   note; a deal memo may reference a contract. Current scope is single-
-   document; cross-document is `ADJ08` (replay tooling) and beyond.
-4. **Anaphora resolution.** "The patient" → which patient? Currently
-   delegated to the extractor as a pre-processing step; the IR sees
-   resolved entities. May need to surface unresolved anaphora as
-   Uncertainty nodes if extractors disagree.
-5. **Streaming documents.** The spec assumes complete documents at
-   extraction time. Streaming (e.g., real-time scribing during a visit)
-   is out of scope for the first paper but worth thinking about for v2.
-
-## Limitations
-
-This spec defines the IR structurally. It does not define:
-
-1. **How a particular LLM should be prompted** to produce well-formed IR
-   nodes. Extractor prompts are an implementation choice and likely vary
-   per base model. The framework only cares whether the IR validates.
-2. **How clarification questions should be phrased.** That's `ADJ06`.
-3. **Probabilistic semantics for the IR.** Probabilities on Rules are a
-   number field; their meaning is given by ProbLog distribution semantics,
-   specified in `ADJ11`.
-4. **Performance characteristics.** Nothing in the IR forces a particular
-   representation; the Rust reference crate will pick one (likely
-   `serde`-friendly structs with `Arc<Term>` for sharing) but the spec
-   does not mandate it.
+1. **The LLM is doing more work** than in v1. Polarity decisions,
+   scope detection, sentence segmentation, family-history
+   recognition — all of these are now the LLM's responsibility.
+   The framework verifies the *output*, not the *process*.
+2. **Language-agnosticism in theory, model-agnosticism in
+   practice**. The LLM must be competent in the input language.
+   Frontier models handle major languages well; low-resource
+   languages remain a deployment concern.
+3. **The flat-IR optimisation path of v1** (rule-based tagger +
+   trigger taxonomy for narrow English-only domains) is retired
+   from the framework core. It may re-emerge as an optional
+   `domain-language-helpers` accelerator crate for deployments where
+   the rule-based approach is empirically fast and good enough.
+4. **Backwards compatibility**. v1 IR documents do not satisfy v2's
+   structural-coverage invariant unless wrapped in a single TextRun
+   covering the whole document. A migration helper for v1 → v2
+   trivially adds such a wrapper.
 
 ## Status
 
-Draft. The grammar is intended to be stable enough to implement against;
-small revisions are likely as the Rust reference crate exposes
-under-specified corners. Versioned via the surrounding repo's commit
-history; the `adjudication-ir` crate will declare a `schema_version` field
-on every emitted document so old IRs remain parsable as the grammar
-evolves.
+v2 draft. The hierarchical decomposition replaces the
+language-specific rule-based path of v1 across `ADJ02`, `ADJ03`, and
+the `adjudication-coverage` / `adjudication-polarity-modality` Rust
+crates. Those specs and crates are being revised in parallel; see
+`ADJ02` and `ADJ03` for the updated checker semantics.


### PR DESCRIPTION
**Revises** [ADJ01](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/ADJ01-adjudication-ir-grammar.md) to replace v1's flat IR + language-specific checkers with **LLM-driven hierarchical decomposition**.

## Why this revision

v1 baked English-language assumptions into the framework core (ADJ02 stopwords, ADJ03 NegEx triggers, ASCII punctuation segmentation). That broke the framework's central claim — *the LLM does linguistic work, the framework does structural verification*. This revision puts the framework back on the right side of that line.

## What changes

- **New `NodeKind::TextRun`**: non-leaf decomposition node, carries source_spans and optionally polarity/modality.
- **New field `part_of: Option<NodeId>`**: structural parent in the decomposition tree. Orthogonal to existing `lowered_from` (refinement DAG).
- **Polarity / Modality propagation**: a parent's value applies to all descendants unless overridden. Children carry `Inherit` by default or an explicit value to override.
- **Structural-coverage invariant**: each TextRun's children's spans must tile the parent's spans. Every byte is in some leaf. *Linear-time, deterministic, language-agnostic.*

## What stays

- The seven leaf NodeKinds (Fact, Query, Uncertainty, Rule, Exception, Discarded).
- Polarity / Modality lattices (`RuledOut` vs `Denied` distinction preserved).
- DiscardReason vocabulary including `Unparseable` as a hard coverage failure.
- Refinement DAG (`lowered_from`) semantics for clarification chains.
- Rule subtype encoding via term functors.

## Worked example revised

The TSA *"I am not bringing matches"* case now uses a parent TextRun with `polarity: Denied` to carry the negation; the Fact leaf inherits. **No NegEx machinery. No token scanning for "not". The LLM emits the structure; the framework verifies it.**

## Follow-ups

- **ADJ02-v2** (next PR): coverage becomes a structural tree check.
- **ADJ03-v2** (next PR): polarity/modality becomes a propagation consistency check.
- **adjudication-ir (Rust)** refactor: add TextRun + part_of; update validation.
- **adjudication-coverage / adjudication-polarity-modality (Rust)**: replace English-rule-based implementations with structural ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)