### PR TITLE
spec(adjudication): ADJ03 v2 — propagation consistency check

### DIFF
--- a/code/specs/ADJ03-polarity-modality-checker.md
+++ b/code/specs/ADJ03-polarity-modality-checker.md
@@ -1,339 +1,326 @@
-# ADJ03 — Polarity and Modality Checker: Catching the "Denies Chest Pain" Class
+# ADJ03 — Polarity and Modality Checker: Propagation Consistency
+
+> **Revision v2 (2026-05-11): propagation consistency.** v1 of this
+> spec described a NegEx/ConText-style trigger-detection check that
+> baked English clinical idiom into the framework core. This revision
+> replaces the trigger taxonomy with a **structural propagation
+> consistency check** over the hierarchical IR from
+> [`ADJ01` v2](ADJ01-adjudication-ir-grammar.md). The LLM that
+> produces the IR is now responsible for deciding *what* the polarity
+> and modality of each node are (in any language). The framework's
+> only job is to verify that the polarity and modality values the
+> LLM declared on each node **propagate consistently** through the
+> decomposition tree.
 
 ## Overview
 
-This is the second of the four checker passes from [`ADJ00`](ADJ00-adjudication-framework.md).
-After [`ADJ02`](ADJ02-coverage-checker.md) has confirmed that every
-meaningful span of input is accounted for by some IR node, this pass
-verifies that the *polarity* (Affirmed / Denied / Uncertain) and the
-*modality* (Present / Past / Future / Hypothetical / FamilyHistory /
-RuledOut / Conditional) of each node are consistent with the lexical
-and syntactic evidence in the span it cites.
+The propagation invariant in v2 is:
 
-The failure mode this catches is the canonical one:
+> A leaf's *effective* polarity (and modality) is the polarity (and
+> modality) declared on the nearest ancestor — or, if no ancestor
+> declares a value, the leaf's own declaration. The leaf's *declared*
+> polarity must match this effective value, or must be `Inherit`.
 
-> Source span: *"patient denies chest pain"*
-> IR node:    `Fact { term: chest_pain(patient), polarity: Affirmed }`
-> Coverage:   passes — the entire span is covered.
-> Polarity:   **fails** — "denies" is an in-scope negation trigger,
->             polarity should be Denied, not Affirmed.
+In short: a child cannot silently contradict its ancestor's polarity
+or modality. If the ancestor says "the patient denies the following:"
+and a leaf wants to assert (rather than deny) one of those items, the
+leaf must say so *explicitly* — its declared polarity overrides the
+inherited one, the override is visible in the audit trail, and the
+inconsistency surfaces as a clarification opportunity rather than a
+silent flip.
 
-Coverage was designed to be cheap and catch silent omission. Polarity is
-designed to be cheap and catch silent flipping. Both run before any LLM
-call at check time, both are deterministic, both produce a specific
-clarification question on failure.
+There is no trigger taxonomy. There is no scope detector. There is
+no NegEx machinery. The LLM's hierarchical decomposition already
+encodes the linguistic information; ADJ03 verifies the encoding is
+self-consistent.
+
+## What the Check Catches
+
+| v1 (rule-based) caught | v2 (propagation) catches |
+|---|---|
+| English negation triggers misaligned with leaf polarity | A leaf whose declared polarity contradicts the ancestor's propagated polarity without explicit override semantics |
+| Hedge/temporality/family-history English cues | Same failure classes, but driven by the LLM's hierarchical declarations rather than per-node lexical detection |
+| RuledOut vs. Denied distinction enforced by trigger class | Same distinction preserved by ADJ01 v2's separate fields |
+
+The class of failure caught is the same: silent flipping of polarity
+or modality. What changes is the mechanism: instead of finding
+English negation triggers in source spans, the framework checks that
+the LLM's own ancestor-vs-leaf declarations are coherent.
 
 ## Layer Position
 
 ```
-   ADJ02 coverage              ← already ran, every meaningful span covered
+   ADJ01 v2 hierarchical IR
         │
         ▼
-   ADJ03 polarity/modality     ← this document
+   ADJ02 v2 structural coverage
+        │
+        ▼
+   ADJ03 v2 propagation consistency   ← this document
         │
         ▼
    ADJ04 round-trip entailment
+        │
+        ▼
+   ADJ05 adversarial verifier
 ```
 
-ADJ03 is the rule-based scope detector in the lineage of **NegEx**
-(Chapman et al. 2001) and **ConText** (Harkema et al. 2009). The
-algorithm generalizes that lineage to a configurable trigger taxonomy
-covering polarity *and* modality together, since the two interact
-constantly in practice (e.g., "father had MI" is family-history modality
-*and* affirmed polarity; "denies family history of cancer" is a denied
-claim *about* family history).
+Propagation runs after coverage so it can assume the tree is
+well-formed (every byte covered, parents above children). The
+propagation check itself is independent of source text — it operates
+on the tree structure and the polarity/modality fields only.
 
-## What This Pass Is Responsible For
+## Effective Polarity / Modality
 
-For every IR node of kind `Fact`, `Query`, `Uncertainty`, or `Rule`, the
-pass examines the union of the node's source spans and checks:
-
-1. **Negation scope.** Are there negation triggers ("not", "denies",
-   "without", "negative for", "ruled out", "no"...) whose syntactic
-   scope covers the term's content words? If yes, the node's polarity
-   must be `Denied`.
-2. **Hedge / uncertainty triggers.** Are there hedge cues ("possibly",
-   "questionable", "consistent with", "suggestive of", "differential
-   includes")? If yes, the node should be `Uncertainty`, not `Fact`.
-3. **Temporality triggers.** Are there past-tense cues, history markers,
-   or explicit dates ("history of", "in 2019", "previously",
-   "currently", "on admission")? Modality should align with whatever
-   the cue indicates.
-4. **Subject triggers.** Are there family-relation tokens ("father",
-   "mother", "brother", "family history of") in scope? If yes, the
-   subject of the predicate is **not** the patient, and modality should
-   be `FamilyHistory`.
-5. **Conditional triggers.** "If", "when", "in case of" — these mark a
-   `Conditional` modality. The node's term may also need a structural
-   `condition` argument (see open questions below).
-6. **Rule-out triggers.** "Ruled out", "excluded by", "negative on CT"
-   — these are *not* the same as negation. Modality must be `RuledOut`,
-   and polarity remains `Affirmed` (we affirm that the diagnosis was
-   considered and excluded).
-
-Each check has the shape: *"if the span contains a trigger with scope
-covering the term, then a specific (polarity, modality) field must take
-a specific value."* The pass reports the first violation it finds per
-node, with the trigger, its scope, and the required value.
-
-## The Trigger Taxonomy
-
-Triggers are organized by class and direction. Direction matters
-because a trigger like "denies" applies to what *follows* it, while
-"no" can apply in either direction depending on syntax. The taxonomy
-draws directly from NegEx/ConText and is configurable for new domains.
+`Polarity` and `Modality` carry an `Inherit` value in v2 (per
+ADJ01 v2). The **effective** value at a node is computed:
 
 ```text
-Trigger := {
-    class:      TriggerClass,
-    surface:    string,            -- the lexical form
-    direction:  Forward | Backward | Bidirectional,
-    scope:      ScopeRule,
-}
+effective_polarity(node, tree) =
+    if node.polarity != Inherit:
+        node.polarity
+    elif node.part_of is Some(parent_id):
+        effective_polarity(tree.find(parent_id), tree)
+    else:
+        Affirmed                     # the framework's outermost default
 
-TriggerClass :=
-    Negation              -- "not", "no", "denies", "without"
-  | Hedge                  -- "possibly", "questionable"
-  | TemporalPast           -- "history of", "in 2019", "previously"
-  | TemporalPresent        -- "currently", "today", "on admission"
-  | TemporalFuture         -- "will", "anticipated", "planned"
-  | Hypothetical           -- "if X then Y", "in case of"
-  | FamilyHistory          -- "father", "mother", "family history of"
-  | RuleOut                -- "ruled out", "excluded", "negative for"
-  | Subject                -- "patient", "she", "he" (for entity attribution)
-
-ScopeRule :=
-    UntilSentenceEnd
-  | UntilPunctuation([;., ])
-  | UntilTermination(["but", "however", "except", "although"])
-  | UntilTokenCount(n)
-  | UntilCueOpposite             -- e.g., another negation cancels
+effective_modality(node, tree) = ... (same shape; default Present)
 ```
 
-A trigger has effective scope from its position until the first
-matching `ScopeRule` boundary in the trigger's `direction`. Concretely,
-"denies" with `Forward` direction and `UntilSentenceEnd` scope applies
-to every token between itself and the next sentence-ending punctuation.
+`Inherit` says "use the ancestor's value." A non-`Inherit` value at a
+node *overrides* the ancestor's, and the override is what the leaf
+contributes to downstream reasoning.
+
+## The Five Propagation Conditions
+
+For an IR document to satisfy propagation consistency:
+
+1. **Inherit-resolvable**: every node's `effective_polarity` (and
+   `effective_modality`) resolves to a non-`Inherit` value within
+   the document. (No `Inherit` chain reaches the root with the root
+   itself declared `Inherit`.)
+2. **Leaf-vs-ancestor consistency**: when a leaf's *declared*
+   polarity is non-`Inherit` and *differs* from its ancestor's
+   propagated value, the difference must be the leaf's intent (it
+   IS the override). The framework flags such overrides for review
+   but does not fail by default — they are warnings, not errors.
+3. **Conflict-with-itself**: a leaf cannot declare two contradictory
+   things. (Trivially enforced by the IR's well-formedness; one node
+   has one polarity field.)
+4. **RuledOut + Denied separation**: if a leaf's modality is
+   `RuledOut`, its polarity must be `Affirmed`. The clinical/legal
+   distinction is preserved as a hard rule.
+5. **Discarded nodes**: skipped from the check. Their polarity and
+   modality are formally `Affirmed` and `Present` per ADJ01.
+
+The check produces *violations* for conditions 1, 3, 4 and *warnings*
+for condition 2. Warnings are surfaced in the audit trail and may
+trigger clarification per ADJ06 but do not gate the adjudication by
+default. A deployment can configure warnings-as-errors if it wants
+strict semantics.
 
 ## The Algorithm
 
 ```text
-check_polarity_modality(ir_doc, doc, taxonomy):
+propagation_check(ir_doc) -> Result:
+    violations = []
+    warnings   = []
+    by_id = index_nodes(ir_doc)
+
+    # Pre-compute effective values for every node.
+    eff_polarity = {}   # node_id -> Polarity (non-Inherit)
+    eff_modality = {}
+
     for node in ir_doc.nodes:
-        if node.kind not in [Fact, Query, Uncertainty, Rule]:
-            continue
-        span_text = doc.text(union(node.source_spans))
-        triggers  = find_triggers(span_text, taxonomy)
-        for trigger in triggers:
-            scope = compute_scope(trigger, span_text, taxonomy)
-            if not term_content_in_scope(node.term, span_text, scope):
-                continue
-            required = required_field(trigger, node)
-            actual   = node_field(trigger.class, node)
-            if actual != required:
-                emit_violation(node, trigger, required, actual)
-                break  // first violation per node is enough to fail
+        eff_polarity[node.id] = resolve(node, by_id, .polarity, Affirmed)
+        eff_modality[node.id] = resolve(node, by_id, .modality, Present)
+        if eff_polarity[node.id] == Inherit or eff_modality[node.id] == Inherit:
+            violations.push(InheritChainUnresolved { node.id })
+
+    # Walk every leaf; compare declared vs. effective; flag overrides.
+    for node in ir_doc.nodes:
+        if node.kind == TextRun: continue
+        if node.kind == Discarded: continue
+
+        if node.modality == RuledOut and node.polarity != Affirmed:
+            violations.push(RuledOutMustBeAffirmed { node.id })
+
+        if node.part_of is Some(parent_id):
+            parent_p = eff_polarity[parent_id]
+            parent_m = eff_modality[parent_id]
+            if node.polarity != Inherit and node.polarity != parent_p:
+                warnings.push(LeafOverridesAncestorPolarity {
+                    node.id, declared: node.polarity, ancestor: parent_p
+                })
+            if node.modality != Inherit and node.modality != parent_m:
+                warnings.push(LeafOverridesAncestorModality {
+                    node.id, declared: node.modality, ancestor: parent_m
+                })
+
+    return Pass(warnings) if violations is empty else Fail(violations, warnings)
 ```
 
-`term_content_in_scope` checks whether the *content words* of the
-node's term — the functor name and ground-atom arguments — appear inside
-the trigger's effective scope. This is a small surface-language check;
-it operates on the source text, not on the abstract term.
+The walk is `O(N)` over IR nodes. Effective-value resolution is
+`O(depth)` per node, `O(N × depth)` total, with memoisation reducing
+to `O(N)`.
 
-`required_field` and `node_field` are small lookup tables encoding the
-rule-out-cases-by-class summary above. For example, for a Negation
-trigger:
+## Violation and Warning Types
 
 ```text
-required_field(Negation, _) = (polarity: Denied)
-node_field    (Negation, node) = (polarity: node.polarity)
+PropagationViolation :=
+    InheritChainUnresolved { node_id }
+  | RuledOutMustBeAffirmed { node_id }
+
+PropagationWarning :=
+    LeafOverridesAncestorPolarity { node_id, declared, ancestor }
+  | LeafOverridesAncestorModality { node_id, declared, ancestor }
 ```
 
-If they disagree, the violation is reported. The exact API for
-violations is in `ADJ06` (clarification), but the data shape is
-straightforward:
+Violations gate the adjudication. Warnings are recorded in the audit
+trail and may be promoted to violations via configuration. The
+default policy is **warn-do-not-block** because legitimate overrides
+exist in real documents (e.g., a paragraph that lists denied
+symptoms but mentions one the patient does affirm: *"Denies chest
+pain, fever, palpitations; admits shortness of breath."*).
 
-```text
-Violation := {
-    node_id:    NodeId,
-    trigger:    Trigger,
-    span:       Span,                  -- where the trigger occurred
-    required:   PolarityOrModality,
-    actual:     PolarityOrModality,
-    suggestion: string,                -- human-readable clarification cue
-}
-```
+## Clarification Generation
 
-## Interaction with Coverage
+| Violation / warning | Clarification question shape |
+|---|---|
+| `InheritChainUnresolved` | Internal: re-prompt the LLM (the IR is malformed) |
+| `RuledOutMustBeAffirmed` | Internal: re-prompt the LLM (ADJ01 hard rule) |
+| `LeafOverridesAncestorPolarity` | *"In the context '<parent text>' (denied), this claim '<leaf text>' is marked affirmed. Is the patient affirming this one item despite denying the surrounding context, or should this be denied too?"* |
+| `LeafOverridesAncestorModality` | Similar shape for modality overrides |
 
-ADJ02 has already guaranteed that every meaningful span is inside the
-union of node source-spans. ADJ03 needs only the *intra-node* check
-above. It does **not** need to inspect the global document; it can run
-node by node, independently, in parallel.
+Override warnings are the genuinely interesting case. They surface
+the cases where the LLM made a structural choice that may need human
+review.
 
-One small global check remains: a trigger token (e.g., the word
-"denies") that is inside a node's spans is itself a meaningful token by
-the coverage taxonomy. Coverage will have accepted it as covered iff
-the node it belongs to also accepted it. The polarity check now
-re-examines whether the node *responded to* the trigger correctly.
+## RuledOut vs. Denied — Preserved
 
-## Triggers Whose Scope Crosses Node Boundaries
+The clinical and legal distinction between *RuledOut* (clinician's
+adjudication) and *Denied* (patient's claim) was emphasised in v1
+and is preserved in v2 as a hard rule (`RuledOutMustBeAffirmed`).
 
-A negation trigger inside node A may have scope extending into the
-text covered by node B. The framework's policy:
+The propagation mechanism doesn't blur this. A parent with `modality:
+RuledOut` propagates RuledOut to descendants, who can override; a
+parent with `polarity: Denied` propagates Denied. They never collapse
+into each other.
 
-- Each node is checked against triggers in its **own** source spans
-  only. Cross-node triggers are not the per-node check's concern.
-- A separate **global cross-node negation check** runs after the
-  per-node checks. It uses the document's full text plus the IR's span
-  index to find triggers whose effective scope ends in a different
-  node's spans. Violations are emitted against the affected nodes.
+## Comparison to v1
 
-The cross-node check is deferred to `ADJ03a` because real-world clinical
-prose tends to keep negation scope inside a sentence, and the simpler
-per-node check covers the high-impact cases.
-
-## Handling Compound Cues
-
-Some cues are multi-word ("ruled out", "negative for", "no history of",
-"family history of"). The trigger surface is a phrase rather than a
-single token. The taxonomy supports phrase triggers via:
-
-```text
-Trigger {
-    class:    RuleOut,
-    surface:  "ruled out",     -- whitespace-separated tokens; matched as a phrase
-    ...
-}
-```
-
-Matching is case-insensitive by default but configurable per
-domain. Stemming and lemmatization are deliberately not applied because
-they introduce false positives in clinical text ("ruling" is not the
-same as "ruled"; "negation" is not the same as "negative").
-
-## Configuration Surface
-
-Each adjudication ships with a *trigger taxonomy* — a versioned
-configuration that lists the triggers, their classes, directions, and
-scope rules. The framework's default taxonomy targets clinical text and
-draws from NegEx and ConText releases that were validated against
-clinical data (Chapman et al. 2001; Harkema et al. 2009). Other domains
-will add their own (legal triggers like "shall not", "except where",
-"provided that"; technical triggers like "deprecated", "removed in
-version X").
-
-The taxonomy and its version are recorded in the audit-trail metadata
-for every adjudication. Re-running the check with a different taxonomy
-version is a re-adjudication, not a re-check.
-
-## RuledOut vs. Denied — The Distinction Is Real
-
-A note specifically on the **distinction between RuledOut modality and
-Denied polarity**, because collapsing them is a real and common semantic
-error.
-
-| Source phrasing | Polarity | Modality |
+| Aspect | v1 (rule-based) | v2 (propagation) |
 |---|---|---|
-| "Patient denies chest pain." | Denied | Present |
-| "No history of chest pain." | Denied | Past |
-| "PE ruled out by CT angio." | Affirmed | RuledOut |
-| "Concerning for PE." | Uncertain | Present |
+| Trigger taxonomy (NegEx, ConText) | Required, English-specific | Removed |
+| Scope detection | Required | Removed |
+| Languages supported | English (effectively) | Any language the LLM handles |
+| Algorithm | Per-node scope analysis | Tree-shape propagation |
+| Asymptotic complexity | `O(triggers × nodes × span_text_len)` | `O(N)` over IR nodes |
+| Determinism | Yes (rule-based) | Yes (structural) |
+| LLM calls at check time | Zero | Zero |
+| Failure modes caught | Silent polarity flip via missed trigger | Silent polarity flip via inconsistent declaration |
+| False-positive rate | Domain-dependent (high in non-clinical text) | Zero — by construction |
+| RuledOut vs. Denied distinction | Enforced via trigger class | Enforced by ADJ01 v2 hard rule |
 
-"Denies" is the *patient's claim*. "Ruled out" is the *clinician's
-adjudication*. Billing systems, malpractice review, and downstream
-reasoning all treat these distinctly. The framework refuses to merge
-them.
+## Worked Example (Revised)
 
-## Worked Examples
+Continuing the TSA case from ADJ02 v2's worked example. The IR has a
+parent `N2 TextRun` with `polarity = Denied` that wraps the *"I am not
+bringing matches"* span; its child `F6` has `polarity = Inherit`.
 
-### Example 1: Negation caught
+Propagation:
+- `eff_polarity[N2] = Denied` (declared).
+- `eff_polarity[F6] = eff_polarity[N2] = Denied` (inherited).
 
-Source: *"Patient denies chest pain."*
-Extractor output:
+`F6` is a Fact leaf with `polarity = Inherit`. The effective polarity
+is Denied, which matches what the LLM intended (the patient is *not*
+bringing matches). No override; no warning; the check passes.
+
+Counterexample: suppose the LLM gets confused and emits `F6` with
+`polarity = Affirmed` directly (declaring "yes, bringing matches")
+while still being a child of `N2` (declared "not bringing"). The
+propagation check flags this:
+
 ```text
-Fact { term: chest_pain(patient), polarity: Affirmed,
-       source_spans: [(doc1, 0, 28)] }
+LeafOverridesAncestorPolarity {
+    node_id: F6,
+    declared: Affirmed,
+    ancestor: Denied (from N2),
+}
 ```
 
-Polarity check:
-- Find triggers in span. "denies" matches Negation class.
-- Scope: forward to sentence end → covers "chest pain".
-- Term's content word "chest_pain" is in scope.
-- `required = polarity: Denied`, `actual = Affirmed`. **Fail.**
-- Clarification: *"The span 'denies' indicates negation, but the IR is
-  Affirmed. Is the patient denying chest pain, or affirming it?"*
+Clarification: *"In the context 'I am not bringing matches' (denied),
+this claim about matches is marked affirmed. Should it be denied?"*
+The LLM (or user) confirms or corrects; the IR updates; the check
+re-runs.
 
-### Example 2: Family history caught
+A *legitimate* override case: under a `Denied` parent listing
+multiple items, one item is actually affirmed. Example:
 
-Source: *"Father had MI at age 50."*
-Extractor output:
 ```text
-Fact { term: mi(patient), polarity: Affirmed, modality: Past,
-       source_spans: [(doc1, 0, 24)] }
+TextRun polarity=Denied   "Denies chest pain, fever, palpitations; admits shortness of breath."
+  Fact chest_pain        polarity=Inherit     → effective Denied  ✓
+  Fact fever             polarity=Inherit     → effective Denied  ✓
+  Fact palpitations      polarity=Inherit     → effective Denied  ✓
+  Fact sob               polarity=Affirmed    → override! warning
 ```
 
-Polarity/modality check:
-- Find triggers. "father" matches FamilyHistory.
-- Scope: forward to sentence end.
-- Term's content word "mi" is in scope.
-- `required = modality: FamilyHistory`, `actual = Past`. **Fail.**
-- Clarification: *"The span 'father' indicates a family-history
-  attribution. The MI applies to a relative, not the patient. Re-extract
-  with subject = father and modality = FamilyHistory."*
-
-### Example 3: RuledOut correctly affirmed
-
-Source: *"PE ruled out by CT angiography."*
-Extractor output:
-```text
-Fact { term: pe(patient), polarity: Affirmed, modality: RuledOut,
-       source_spans: [(doc1, 0, 30)] }
-```
-
-Polarity check:
-- Find triggers. "ruled out" matches RuleOut class.
-- Scope: backward over "PE".
-- Term's content word "pe" is in scope.
-- `required = modality: RuledOut`, `actual = RuledOut`. **Pass.**
-- `required` does NOT touch polarity (RuleOut is modality only).
-- Polarity remains Affirmed, which is correct.
-
-This example shows why RuledOut is modality, not a polarity flip. A
-naïve extractor might emit Denied here; the check catches it because
-the RuleOut trigger class declares modality requirements only.
+The warning lets a reviewer (or a downstream LLM call in ADJ04) read
+the source span and verify that "admits shortness of breath" is a
+genuine contrast within a denial list. Real medical prose does this
+all the time; the framework surfaces it for review rather than
+silently blocking.
 
 ## Open Questions
 
-1. **Conditional terms with structural conditions.** "Avoid X if patient
-   has Y." Should the Conditional modality flag the node, and a separate
-   node represent the condition? Probably yes; the structural shape is
-   `Rule { head: avoid(X), body: [Pos(has(Y))] }` lowered. ADJ09 covers.
-2. **Quoted speech inside notes.** "Patient said 'I don't drink alcohol'."
-   The negation is inside a quoted attribution. Should the framework
-   strip quotes or honor them? Current policy: honor them — the quoted
-   span produces its own subject-attributed node.
-3. **Stemming and lemmatization.** Deliberately omitted from the default
-   taxonomy. Domains that need them may opt in via configuration.
-4. **Trigger taxonomies for non-English.** All examples here are
-   English. Generalization to other languages requires per-language
-   trigger lists. Out of scope for the first paper.
+1. **Default behaviour for unresolved Inherit.** Currently if every
+   ancestor up to the root declares `Inherit`, the effective value
+   falls back to `Affirmed` (polarity) or `Present` (modality). This
+   is the framework default, recorded explicitly in the audit trail
+   so reviewers can challenge it. Alternative: require every IR
+   document to have a non-`Inherit` value at every root. Either is
+   defensible; the current default favours leniency.
+2. **Promoting warnings to errors.** The default `warn-do-not-block`
+   policy is permissive. A deployment that wants strict propagation
+   can configure warnings-as-errors. The line between "real
+   override" and "extraction mistake" is empirical — the deployment
+   chooses based on its observed false-positive rate.
+3. **Multi-language consistency.** The framework's check is
+   language-agnostic, but the LLM's polarity/modality decisions are
+   language-specific. A deployment in a low-resource language may
+   see higher rates of `LeafOverridesAncestorPolarity` warnings as
+   extraction quality drops. The audit trail's per-language metrics
+   will show this; the framework itself has nothing to tune.
+4. **What about cross-document polarity?** A clinical note may
+   reference a prior note: *"As discussed before, denies the
+   following:"*. The reference is in this document; the polarity
+   propagates from the parent text run. Cross-document propagation
+   (the prior note's polarity bleeding into this one) is out of
+   scope. Each document's tree is independent.
 
 ## Limitations
 
-1. The pass is a **scope detector**, not a syntactic parser. Genuinely
-   syntactically subtle negation ("Although the chest pain has resolved,
-   the patient remains uncomfortable.") may be miscategorized. The
-   fall-through is ADJ04 (round-trip) and ADJ05 (adversarial).
-2. **Domain coverage is finite.** A domain whose trigger taxonomy has
-   gaps may produce false negatives. The fix is taxonomy iteration over
-   adversarial corpora.
-3. **Trigger conflicts.** Two overlapping triggers can produce
-   contradictory required values. The framework reports both as
-   violations and routes to clarification rather than guessing.
+1. **The check trusts the LLM's polarity declarations.** If the LLM
+   wrongly emits `polarity: Affirmed` on a parent that should be
+   `Denied`, propagation alone cannot detect it. ADJ04 (round-trip)
+   and ADJ05 (adversarial) are the safety nets for *content*
+   mistakes; ADJ03 only verifies *consistency*.
+2. **Override warnings are inherently noisy.** A deployment that
+   produces many overrides legitimately (medical prose with
+   "denies X, Y; admits Z" structures) will see many warnings.
+   This is by design — the warnings highlight cases worth a second
+   look, not cases worth blocking.
+3. **No language-specific shortcuts.** The v1 rule-based approach
+   was very cheap on cases like "denies chest pain"; in v2 the cost
+   is paid up front in extraction (the LLM must produce the
+   hierarchical structure correctly). For high-volume English
+   clinical use the v1 path *may* still be a useful optimisation,
+   available as an opt-in domain accelerator — but it is no longer
+   the default and no longer part of the framework core.
 
 ## Status
 
-Draft. Sufficient to implement the per-node check directly. `ADJ03a`
-(cross-node scope) and `ADJ03b` (taxonomy extensions for legal and
-technical domains) are planned follow-ups.
+v2 draft. Replaces the v1 trigger-detection path. Implementation
+depends on the `ADJ01` v2 grammar; the Rust crate
+`adjudication-polarity-modality` is being rewritten in parallel
+(the v1 trigger taxonomy is retired).


### PR DESCRIPTION
**Revises** [ADJ03](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/ADJ03-polarity-modality-checker.md) to replace NegEx/ConText trigger detection with **structural propagation consistency** over [ADJ01 v2](https://github.com/adhithyan15/coding-adventures/pull/2687)'s hierarchical IR.

## The invariant

A leaf's *effective* polarity / modality is the value declared on the nearest ancestor (or the leaf's own declaration if no ancestor declares). A leaf cannot silently contradict its ancestor — any declared override is **visible in the audit trail** and may trigger clarification.

## Mechanism

`Polarity` and `Modality` carry an `Inherit` value (per ADJ01 v2). Algorithm walks every leaf, resolves effective values up the tree, compares declared vs. effective, emits:

- **Violations** (gate adjudication): `InheritChainUnresolved`, `RuledOutMustBeAffirmed`
- **Warnings** (recorded; do not gate by default): `LeafOverridesAncestorPolarity`, `LeafOverridesAncestorModality`

Default policy is **warn-do-not-block** because legitimate overrides exist in real documents (*"Denies chest pain, fever, palpitations; admits shortness of breath."*).

## What's gone

- Trigger taxonomy (NegEx, ConText)
- Per-node scope detection
- English clinical idiom
- ADJ03a (cross-node scope) sub-spec — no longer needed

## What stays

- RuledOut vs Denied distinction (ADJ01 hard rule)
- Clarification question shapes via ADJ06
- The class of failures caught (silent polarity flip) — same failures, different mechanism

## Worked example revised

Two cases: TSA matches denial with proper inheritance (passes); counterexample with leaf overriding to Affirmed fires `LeafOverridesAncestorPolarity`. Also: legitimate override case (denied list with one affirmed item) — warnings surface, reviewer confirms.

## Depends on

[#2687](https://github.com/adhithyan15/coding-adventures/pull/2687) (ADJ01 v2) and [#2688](https://github.com/adhithyan15/coding-adventures/pull/2688) (ADJ02 v2). Merge those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)