### PR TITLE
feat(adjudication-polarity-modality): rewrite as ADJ03 v2 propagation check

### DIFF
--- a/code/packages/rust/adjudication-polarity-modality/CHANGELOG.md
+++ b/code/packages/rust/adjudication-polarity-modality/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-05-11 — ADJ03 v2 structural propagation rewrite
+
+### Replaced
+
+The entire v0.1.0 NegEx / ConText-style trigger-detection check is
+replaced with a **structural propagation consistency check** over
+the v2 IR (per
+[ADJ03 v2](../../../specs/ADJ03-polarity-modality-checker.md)).
+
+What's gone:
+
+- `TriggerClass` enum (Negation / Hedge / TemporalPast / etc.)
+- `TriggerDirection` (Forward / Backward / Bidirectional)
+- `ScopeRule` (UntilSentenceEnd / UntilPunctuation / etc.)
+- `Trigger` struct with surface / direction / scope fields
+- `TriggerTaxonomy` and the `clinical_default()` English trigger
+  list
+- Per-trigger scope detection
+- All NegEx / ConText machinery
+
+What replaces them:
+
+- `check_propagation(ir_doc) -> PropagationResult` — walks every
+  leaf, computes effective polarity / modality via ancestor lookup,
+  compares declared vs effective.
+- `PropagationResult { violations, warnings }` — violations gate
+  the adjudication; warnings are surfaced for review but do not
+  gate by default.
+- `PropagationViolation` (gating): `InheritChainUnresolved` (every
+  ancestor declared Inherit), `RuledOutMustBeAffirmed` (the
+  ADJ01 hard rule).
+- `PropagationWarning` (non-gating):
+  `LeafOverridesAncestorPolarity`, `LeafOverridesAncestorModality`
+  — surface legitimate-override cases for audit review (e.g.,
+  "denies X, Y; admits Z" structures in real prose).
+- Effective polarity / modality resolution with memoization for
+  `O(N)` total cost across the IR.
+
+### Algorithm
+
+Pure structural. No LLM call. No language-specific knowledge.
+Walks the part_of tree to resolve `Inherit` values; compares each
+non-TextRun leaf's declared values against the propagated effective
+values.
+
+### Default policy: warn-do-not-block
+
+The propagation check produces warnings for declared overrides
+because legitimate overrides exist in real documents. A deployment
+can configure warnings-as-errors for strict semantics; the check
+itself separates the two so callers choose.
+
+### Tests
+
+10 tests cover:
+
+- Concrete-polarity leaf with no ancestor — Pass
+- Child inheriting from parent's Denied polarity — Pass
+- Child overriding parent's polarity — Pass with warning
+- RuledOut + Affirmed — Pass (the canonical RuledOut shape)
+- RuledOut + Denied — Violation (the hard rule)
+- All-Inherit chain — InheritChainUnresolved violation
+- Multi-level inheritance through TextRuns — Pass
+- "Denies X, Y; admits Z" pattern — Pass with one polarity-override
+  warning on the affirmed item
+- Intermediate TextRun override — no warnings (only leaves emit them)
+- Discarded nodes — skipped per ADJ01
+
+`cargo build / test / clippy --no-deps` clean.
+
 ## [0.1.0] - 2026-05-11
 
 ### Added

--- a/code/packages/rust/adjudication-polarity-modality/Cargo.toml
+++ b/code/packages/rust/adjudication-polarity-modality/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "adjudication-polarity-modality"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Polarity and modality checker (ADJ03). NegEx/ConText-style scope detection over IR node source spans."
+description = "ADJ03 v2 — structural propagation consistency check over the hierarchical IR. No trigger taxonomy; language-agnostic."
 
 [dependencies]
 adjudication-ir = { path = "../adjudication-ir" }
+
+[dev-dependencies]
 logic-core = { path = "../logic-core" }

--- a/code/packages/rust/adjudication-polarity-modality/src/lib.rs
+++ b/code/packages/rust/adjudication-polarity-modality/src/lib.rs
@@ -1,533 +1,236 @@
-//! # adjudication-polarity-modality — ADJ03 checker.
+//! # adjudication-polarity-modality — ADJ03 v2 propagation check.
 //!
 //! Reference implementation of
-//! [`ADJ03`](../../../specs/ADJ03-polarity-modality-checker.md).
-//! Catches the canonical "denies chest pain" → `symptom(chest_pain)`
-//! failure class with a NegEx/ConText-style scope detector.
+//! [`ADJ03` v2](../../../specs/ADJ03-polarity-modality-checker.md).
+//! The check is a **structural propagation consistency check** over
+//! the hierarchical IR from ADJ01 v2. The LLM declares polarity /
+//! modality at each level of the decomposition tree; the framework
+//! verifies the declarations are self-consistent.
 //!
-//! The check is **per-node**: it inspects each node's `source_spans`
-//! for trigger phrases (negation, hedging, temporality, family
-//! history, rule-out), computes each trigger's scope, and verifies
-//! that the node's `polarity` and `modality` are consistent with the
-//! triggers whose scope covers the node's content. Cross-node scope
-//! analysis is `ADJ03a`, a planned follow-up.
+//! No trigger taxonomy. No NegEx. No scope detector. No English
+//! assumption. Language-agnostic by construction.
 //!
-//! Pure (no LLM at check time); embarrassingly parallel across nodes.
+//! ## The invariant
+//!
+//! A leaf's **effective** polarity / modality is the value declared
+//! on the nearest ancestor (or, if every ancestor is `Inherit`, the
+//! leaf's own declaration or the framework default). A leaf cannot
+//! silently contradict its ancestor — any declared override surfaces
+//! in the audit trail and may trigger clarification via ADJ06.
+//!
+//! ## Violations vs. warnings
+//!
+//! - **Violation** (gates adjudication): `InheritChainUnresolved`,
+//!   `RuledOutMustBeAffirmed`.
+//! - **Warning** (recorded, does not gate by default):
+//!   `LeafOverridesAncestorPolarity`, `LeafOverridesAncestorModality`.
+//!
+//! The default policy is *warn-do-not-block* because legitimate
+//! overrides are common in real documents ("Denies chest pain,
+//! fever, palpitations; admits shortness of breath."). A deployment
+//! can configure warnings-as-errors for strict semantics.
+
+use std::collections::HashMap;
 
 use adjudication_ir::{IRDocument, IRNode, Modality, NodeId, NodeKind, Polarity};
 
 // ---------------------------------------------------------------------------
-// Trigger taxonomy
+// Result types
 // ---------------------------------------------------------------------------
 
-/// What kind of cue a trigger represents.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum TriggerClass {
-    Negation,
-    Hedge,
-    TemporalPast,
-    TemporalPresent,
-    TemporalFuture,
-    Hypothetical,
-    FamilyHistory,
-    RuleOut,
-    Subject,
-}
-
-/// Which side of the trigger phrase its scope applies to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TriggerDirection {
-    /// Scope extends from after the trigger toward the right end of
-    /// the text (e.g. "denies chest pain" — "denies" scopes forward).
-    Forward,
-    /// Scope extends backwards from before the trigger (e.g.
-    /// "chest pain ruled out" — "ruled out" scopes back).
-    Backward,
-    /// The trigger affects content on either side.
-    Bidirectional,
-}
-
-/// How far a trigger's scope extends.
+/// The outcome of running the propagation check.
 #[derive(Debug, Clone, PartialEq)]
-pub enum ScopeRule {
-    /// Until the end of the current sentence (next `.`, `?`, `!` or
-    /// end of source span text).
-    UntilSentenceEnd,
-    /// Until any of the listed delimiter characters is reached.
-    UntilPunctuation(Vec<char>),
-    /// Until any of the listed termination keywords is encountered
-    /// (e.g., "but", "however", "except").
-    UntilTermination(Vec<String>),
-    /// A fixed token count from the trigger.
-    UntilTokenCount(usize),
+pub struct PropagationResult {
+    pub violations: Vec<PropagationViolation>,
+    pub warnings: Vec<PropagationWarning>,
 }
 
-/// One entry in the trigger taxonomy.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Trigger {
-    pub class: TriggerClass,
-    /// The lexical form. Multi-word phrases supported. Matched
-    /// case-insensitively as a whole word/phrase (word boundaries on
-    /// both sides).
-    pub surface: String,
-    pub direction: TriggerDirection,
-    pub scope: ScopeRule,
-}
-
-/// Versioned, configurable trigger taxonomy. Mirror the Python
-/// taxonomy's discipline of recording the version in audit-trail
-/// metadata.
-#[derive(Debug, Clone, Default)]
-pub struct TriggerTaxonomy {
-    pub triggers: Vec<Trigger>,
-    pub version: String,
-}
-
-impl TriggerTaxonomy {
-    pub fn new(version: &str) -> Self {
-        Self {
-            triggers: Vec::new(),
-            version: version.to_string(),
-        }
-    }
-
-    pub fn add(&mut self, t: Trigger) -> &mut Self {
-        self.triggers.push(t);
-        self
-    }
-
-    /// A reasonable English clinical taxonomy. NegEx + ConText
-    /// inspired. Covers the high-impact cases for the worked
-    /// examples; deployments are expected to extend.
-    pub fn clinical_default() -> Self {
-        let mut t = TriggerTaxonomy::new("clinical-en-v1");
-
-        // Negation triggers — forward scope to sentence end, with
-        // "but"/"however"/"except" terminating the scope.
-        let neg_terms = vec![
-            "but".to_string(),
-            "however".to_string(),
-            "except".to_string(),
-            "although".to_string(),
-        ];
-        for s in &["denies", "no", "without", "not", "negative for", "denied"] {
-            t.add(Trigger {
-                class: TriggerClass::Negation,
-                surface: (*s).to_string(),
-                direction: TriggerDirection::Forward,
-                scope: ScopeRule::UntilTermination(neg_terms.clone()),
-            });
-        }
-
-        // Hedges — forward scope until end of sentence.
-        for s in &["possibly", "questionable", "may have", "suggestive of", "consistent with", "concerning for"] {
-            t.add(Trigger {
-                class: TriggerClass::Hedge,
-                surface: (*s).to_string(),
-                direction: TriggerDirection::Forward,
-                scope: ScopeRule::UntilSentenceEnd,
-            });
-        }
-
-        // Temporality (past).
-        for s in &["history of", "previously", "prior", "in 2019", "in 2020", "in 2021", "in 2022", "in 2023", "in 2024", "in 2025"] {
-            t.add(Trigger {
-                class: TriggerClass::TemporalPast,
-                surface: (*s).to_string(),
-                direction: TriggerDirection::Forward,
-                scope: ScopeRule::UntilSentenceEnd,
-            });
-        }
-
-        // Temporality (present).
-        for s in &["currently", "today", "on admission"] {
-            t.add(Trigger {
-                class: TriggerClass::TemporalPresent,
-                surface: (*s).to_string(),
-                direction: TriggerDirection::Forward,
-                scope: ScopeRule::UntilSentenceEnd,
-            });
-        }
-
-        // Hypothetical.
-        for s in &["if", "when", "in case of"] {
-            t.add(Trigger {
-                class: TriggerClass::Hypothetical,
-                surface: (*s).to_string(),
-                direction: TriggerDirection::Forward,
-                scope: ScopeRule::UntilSentenceEnd,
-            });
-        }
-
-        // Family history.
-        for s in &["father", "mother", "brother", "sister", "family history of"] {
-            t.add(Trigger {
-                class: TriggerClass::FamilyHistory,
-                surface: (*s).to_string(),
-                direction: TriggerDirection::Forward,
-                scope: ScopeRule::UntilSentenceEnd,
-            });
-        }
-
-        // RuleOut — backwards over the diagnosis token, forward over
-        // the test used to rule it out.
-        for s in &["ruled out by", "ruled out", "excluded by", "negative on"] {
-            t.add(Trigger {
-                class: TriggerClass::RuleOut,
-                surface: (*s).to_string(),
-                direction: TriggerDirection::Bidirectional,
-                scope: ScopeRule::UntilSentenceEnd,
-            });
-        }
-
-        t
+impl PropagationResult {
+    pub fn pass(&self) -> bool {
+        self.violations.is_empty()
     }
 }
 
-// ---------------------------------------------------------------------------
-// Document type (intentionally minimal; matches adjudication-coverage's
-// shape so callers can pass the same document into both checkers).
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone)]
-pub struct Document {
-    pub id: adjudication_ir::DocumentId,
-    pub normalized_text: String,
-}
-
-// ---------------------------------------------------------------------------
-// Violation type
-// ---------------------------------------------------------------------------
-
-/// What kind of field a trigger constrains.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RequiredField {
-    Polarity(Polarity),
-    Modality(Modality),
-}
-
-/// One per-node violation.
+/// Gating failures. The propagation check fails if any of these
+/// is non-empty.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Violation {
-    pub node_id: NodeId,
-    pub trigger_class: TriggerClass,
-    pub trigger_surface: String,
-    pub required: RequiredField,
-    /// The actual value the IR carries.
-    pub actual: RequiredField,
-    /// Human-readable summary of the trigger phrase's location and
-    /// scope, suitable for surfacing via ADJ06.
-    pub suggestion: String,
+pub enum PropagationViolation {
+    /// Every ancestor up to the root declared `Inherit` AND the node
+    /// itself declared `Inherit`. With no concrete value anywhere in
+    /// the chain, the effective value cannot be resolved.
+    InheritChainUnresolved { node_id: NodeId },
+
+    /// A leaf with `modality = RuledOut` must have `polarity =
+    /// Affirmed` (per ADJ01 hard rule). RuledOut is the clinician's
+    /// adjudication, not a polarity flip.
+    RuledOutMustBeAffirmed {
+        node_id: NodeId,
+        actual_polarity: Polarity,
+    },
+}
+
+/// Non-gating warnings. Recorded in the audit trail; may be promoted
+/// to errors via configuration.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PropagationWarning {
+    /// A leaf's declared polarity overrides its ancestor's. Worth a
+    /// review (often legitimate, e.g. "denies X, Y; admits Z").
+    LeafOverridesAncestorPolarity {
+        node_id: NodeId,
+        declared: Polarity,
+        ancestor: Polarity,
+    },
+
+    /// A leaf's declared modality overrides its ancestor's.
+    LeafOverridesAncestorModality {
+        node_id: NodeId,
+        declared: Modality,
+        ancestor: Modality,
+    },
 }
 
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
-/// Run the polarity / modality check across every node in `ir_doc`.
-/// Returns the list of violations (empty list = pass).
-pub fn check_polarity_modality(
-    doc: &Document,
-    ir_doc: &IRDocument,
-    taxonomy: &TriggerTaxonomy,
-) -> Vec<Violation> {
-    let mut violations = Vec::new();
-    for node in &ir_doc.nodes {
-        // Only nodes that take a polarity/modality value participate.
-        if !matches!(
-            node.kind,
-            NodeKind::Fact | NodeKind::Query | NodeKind::Uncertainty | NodeKind::Rule
-        ) {
-            continue;
-        }
-        // Stitch the span texts together so a single trigger search
-        // sees the whole span.
-        let span_text = collect_node_text(doc, node);
-        if span_text.is_empty() {
-            continue;
-        }
-        let mut local: Vec<Violation> = scan_node(node, &span_text, taxonomy);
-        if !local.is_empty() {
-            violations.append(&mut local);
-        }
-    }
-    violations
-}
-
-fn collect_node_text(doc: &Document, node: &IRNode) -> String {
-    let mut s = String::new();
-    for span in &node.source_spans {
-        if span.document_id != doc.id {
-            continue;
-        }
-        if let Some(slice) = doc.normalized_text.get(span.start..span.end) {
-            if !s.is_empty() {
-                s.push(' ');
-            }
-            s.push_str(slice);
-        }
-    }
-    s
-}
-
-/// Run every trigger against the node's span text. Per ADJ03, returns
-/// **at most one** Violation per node — the first trigger whose scope
-/// covers the node's term content and whose required field disagrees
-/// with the actual.
-fn scan_node(node: &IRNode, span_text: &str, taxonomy: &TriggerTaxonomy) -> Vec<Violation> {
-    let lower = span_text.to_lowercase();
-    // Match longest surface first so e.g. "ruled out by" wins over
-    // "ruled out" when both could match.
-    let mut indexed: Vec<&Trigger> = taxonomy.triggers.iter().collect();
-    indexed.sort_by_key(|t| std::cmp::Reverse(t.surface.len()));
-
-    for trigger in indexed {
-        let Some(pos) = find_phrase(&lower, &trigger.surface.to_lowercase()) else {
-            continue;
-        };
-        let scoped_range = scoped_range(&lower, pos, &trigger.surface, &trigger.direction, &trigger.scope);
-        let in_scope_text = &lower[scoped_range.0..scoped_range.1];
-        if !term_content_in_text(node, in_scope_text) {
-            continue;
-        }
-        if let Some(v) = check_violation(node, trigger) {
-            return vec![v];
-        }
-    }
-    Vec::new()
-}
-
-/// Find a whitespace-delimited phrase in `text`. Returns the start
-/// byte index, or `None` if not found.
-fn find_phrase(text: &str, phrase: &str) -> Option<usize> {
-    let mut start = 0;
-    while let Some(idx) = text[start..].find(phrase) {
-        let abs = start + idx;
-        let before_ok = abs == 0
-            || text.as_bytes()[abs - 1].is_ascii_whitespace()
-            || is_punct_byte(text.as_bytes()[abs - 1]);
-        let end = abs + phrase.len();
-        let after_ok = end == text.len()
-            || text.as_bytes()[end].is_ascii_whitespace()
-            || is_punct_byte(text.as_bytes()[end]);
-        if before_ok && after_ok {
-            return Some(abs);
-        }
-        start = abs + phrase.len();
-    }
-    None
-}
-
-fn is_punct_byte(b: u8) -> bool {
-    matches!(
-        b,
-        b'.' | b',' | b';' | b':' | b'!' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}'
-    )
-}
-
-/// Compute the scoped byte range that a trigger covers in `text`.
-fn scoped_range(
-    text: &str,
-    trigger_pos: usize,
-    surface: &str,
-    direction: &TriggerDirection,
-    scope: &ScopeRule,
-) -> (usize, usize) {
-    let after_trigger = trigger_pos + surface.len();
-    match (direction, scope) {
-        (TriggerDirection::Forward, ScopeRule::UntilSentenceEnd) => {
-            (after_trigger, find_sentence_end(text, after_trigger))
-        }
-        (TriggerDirection::Forward, ScopeRule::UntilPunctuation(chars)) => {
-            (after_trigger, find_first_char(text, after_trigger, chars))
-        }
-        (TriggerDirection::Forward, ScopeRule::UntilTermination(words)) => {
-            (after_trigger, find_termination(text, after_trigger, words))
-        }
-        (TriggerDirection::Forward, ScopeRule::UntilTokenCount(n)) => {
-            (after_trigger, find_after_tokens(text, after_trigger, *n))
-        }
-        (TriggerDirection::Backward, ScopeRule::UntilSentenceEnd) => {
-            (find_sentence_start(text, trigger_pos), trigger_pos)
-        }
-        (TriggerDirection::Backward, _) => (find_sentence_start(text, trigger_pos), trigger_pos),
-        (TriggerDirection::Bidirectional, _) => {
-            (
-                find_sentence_start(text, trigger_pos),
-                find_sentence_end(text, after_trigger),
-            )
-        }
-    }
-}
-
-fn find_sentence_end(text: &str, from: usize) -> usize {
-    let bytes = text.as_bytes();
-    for (i, b) in bytes.iter().enumerate().skip(from) {
-        if matches!(*b, b'.' | b'?' | b'!') {
-            return i;
-        }
-    }
-    text.len()
-}
-
-fn find_sentence_start(text: &str, from: usize) -> usize {
-    let bytes = text.as_bytes();
-    for i in (0..from).rev() {
-        if matches!(bytes[i], b'.' | b'?' | b'!') {
-            return i + 1;
-        }
-    }
-    0
-}
-
-fn find_first_char(text: &str, from: usize, chars: &[char]) -> usize {
-    for (i, ch) in text.char_indices().skip_while(|(idx, _)| *idx < from) {
-        if chars.contains(&ch) {
-            return i;
-        }
-    }
-    text.len()
-}
-
-fn find_termination(text: &str, from: usize, words: &[String]) -> usize {
-    // Linear scan for any whole-word terminator.
-    for word in words {
-        if let Some(idx) = text[from..].find(word.as_str()) {
-            let abs = from + idx;
-            let before_ok = abs == 0
-                || text.as_bytes()[abs - 1].is_ascii_whitespace();
-            let end = abs + word.len();
-            let after_ok = end == text.len()
-                || text.as_bytes()[end].is_ascii_whitespace()
-                || is_punct_byte(text.as_bytes()[end]);
-            if before_ok && after_ok {
-                return abs;
-            }
-        }
-    }
-    find_sentence_end(text, from)
-}
-
-fn find_after_tokens(text: &str, from: usize, n: usize) -> usize {
-    let mut count = 0;
-    let mut in_token = false;
-    for (i, b) in text.as_bytes().iter().enumerate().skip(from) {
-        if b.is_ascii_whitespace() || is_punct_byte(*b) {
-            if in_token {
-                count += 1;
-                if count >= n {
-                    return i;
-                }
-            }
-            in_token = false;
-        } else {
-            in_token = true;
-        }
-    }
-    text.len()
-}
-
-/// `true` iff any of the node's term's content words (functor name
-/// or atom arguments) appears inside `text`.
+/// Run the propagation consistency check.
 ///
-/// Multi-word content words packed into a single atom with
-/// underscores (e.g. `chest_pain`) match if **all** of their pieces
-/// appear in `text`. This handles the common extraction convention
-/// of joining multi-word phrases with underscores without producing
-/// false positives when only one piece appears (e.g. a `back_pain`
-/// term should not match text that says "chest pain").
-fn term_content_in_text(node: &IRNode, text: &str) -> bool {
-    for word in extract_content_words(&node.term) {
-        let lower = word.to_lowercase();
-        // Single-piece content word: direct phrase match.
-        if !lower.contains('_') {
-            if find_phrase(text, &lower).is_some() {
-                return true;
-            }
+/// Walks every non-TextRun, non-Discarded leaf, resolves its
+/// effective polarity / modality from the ancestor chain, and:
+///
+/// - Emits `InheritChainUnresolved` if the chain has no concrete
+///   value (a gating violation).
+/// - Emits `RuledOutMustBeAffirmed` if `modality = RuledOut` but
+///   polarity isn't Affirmed (a gating violation).
+/// - Emits `LeafOverridesAncestor*` if the leaf's declared value is
+///   non-Inherit and differs from the ancestor's effective value
+///   (warnings).
+pub fn check_propagation(ir_doc: &IRDocument) -> PropagationResult {
+    let mut violations = Vec::new();
+    let mut warnings = Vec::new();
+
+    let by_id: HashMap<NodeId, &IRNode> = ir_doc
+        .nodes
+        .iter()
+        .map(|n| (n.id.clone(), n))
+        .collect();
+
+    // Pre-compute effective polarity/modality for every node, with
+    // memoization. The lookup uses ancestor traversal.
+    let mut eff_polarity: HashMap<NodeId, Polarity> = HashMap::new();
+    let mut eff_modality: HashMap<NodeId, Modality> = HashMap::new();
+    for node in &ir_doc.nodes {
+        let ep = resolve_effective_polarity(node, &by_id, &mut eff_polarity);
+        let em = resolve_effective_modality(node, &by_id, &mut eff_modality);
+
+        if ep == Polarity::Inherit {
+            violations.push(PropagationViolation::InheritChainUnresolved {
+                node_id: node.id.clone(),
+            });
+        }
+        if em == Modality::Inherit {
+            violations.push(PropagationViolation::InheritChainUnresolved {
+                node_id: node.id.clone(),
+            });
+        }
+    }
+
+    // Walk every leaf. TextRun nodes don't participate. Discarded
+    // nodes are skipped (their polarity and modality are formally
+    // fixed by ADJ01).
+    for node in &ir_doc.nodes {
+        if node.kind == NodeKind::TextRun || node.kind == NodeKind::Discarded {
             continue;
         }
-        // Multi-piece content word: every piece (length >= 3, to
-        // avoid noise like "of") must appear in `text` as a phrase.
-        let pieces: Vec<&str> = lower
-            .split('_')
-            .filter(|p| p.len() >= 3)
-            .collect();
-        if !pieces.is_empty() && pieces.iter().all(|p| find_phrase(text, p).is_some()) {
-            return true;
-        }
-        // Also accept the literal joined form (some texts do use
-        // underscores in identifiers).
-        if find_phrase(text, &lower).is_some() {
-            return true;
-        }
-    }
-    false
-}
 
-fn extract_content_words(term: &logic_core::Term) -> Vec<String> {
-    use logic_core::Term;
-    let mut out = Vec::new();
-    match term {
-        Term::Atom(name) => out.push(name.clone()),
-        Term::Compound { functor, args } => {
-            out.push(functor.clone());
-            for a in args {
-                out.extend(extract_content_words(a));
+        // RuledOut + non-Affirmed = hard rule violation.
+        if node.modality == Modality::RuledOut && node.polarity != Polarity::Affirmed {
+            violations.push(PropagationViolation::RuledOutMustBeAffirmed {
+                node_id: node.id.clone(),
+                actual_polarity: node.polarity,
+            });
+        }
+
+        // Check declared-vs-ancestor for non-Inherit leaf
+        // declarations.
+        if let Some(parent_id) = &node.part_of {
+            let parent_eff_p = eff_polarity.get(parent_id).copied().unwrap_or(Polarity::Affirmed);
+            let parent_eff_m = eff_modality.get(parent_id).copied().unwrap_or(Modality::Present);
+
+            if node.polarity != Polarity::Inherit && node.polarity != parent_eff_p {
+                warnings.push(PropagationWarning::LeafOverridesAncestorPolarity {
+                    node_id: node.id.clone(),
+                    declared: node.polarity,
+                    ancestor: parent_eff_p,
+                });
+            }
+            if node.modality != Modality::Inherit && node.modality != parent_eff_m {
+                warnings.push(PropagationWarning::LeafOverridesAncestorModality {
+                    node_id: node.id.clone(),
+                    declared: node.modality,
+                    ancestor: parent_eff_m,
+                });
             }
         }
-        Term::Str(s) => out.push(s.clone()),
-        _ => {}
     }
-    out
-}
 
-/// Required (polarity, modality) for a given trigger class.
-fn required_for(class: TriggerClass) -> Option<RequiredField> {
-    match class {
-        TriggerClass::Negation => Some(RequiredField::Polarity(Polarity::Denied)),
-        TriggerClass::Hedge => Some(RequiredField::Polarity(Polarity::Uncertain)),
-        TriggerClass::TemporalPast => Some(RequiredField::Modality(Modality::Past)),
-        TriggerClass::TemporalPresent => Some(RequiredField::Modality(Modality::Present)),
-        TriggerClass::TemporalFuture => Some(RequiredField::Modality(Modality::Future)),
-        TriggerClass::Hypothetical => Some(RequiredField::Modality(Modality::Hypothetical)),
-        TriggerClass::FamilyHistory => Some(RequiredField::Modality(Modality::FamilyHistory)),
-        TriggerClass::RuleOut => Some(RequiredField::Modality(Modality::RuledOut)),
-        // Subject triggers are bookkeeping; no required value.
-        TriggerClass::Subject => None,
+    PropagationResult {
+        violations,
+        warnings,
     }
 }
 
-fn actual_for(class: TriggerClass, node: &IRNode) -> Option<RequiredField> {
-    match class {
-        TriggerClass::Negation | TriggerClass::Hedge => Some(RequiredField::Polarity(node.polarity)),
-        TriggerClass::TemporalPast
-        | TriggerClass::TemporalPresent
-        | TriggerClass::TemporalFuture
-        | TriggerClass::Hypothetical
-        | TriggerClass::FamilyHistory
-        | TriggerClass::RuleOut => Some(RequiredField::Modality(node.modality)),
-        TriggerClass::Subject => None,
-    }
-}
+// ---------------------------------------------------------------------------
+// Effective polarity / modality resolution (with memoisation)
+// ---------------------------------------------------------------------------
 
-fn check_violation(node: &IRNode, trigger: &Trigger) -> Option<Violation> {
-    let required = required_for(trigger.class)?;
-    let actual = actual_for(trigger.class, node)?;
-    if required != actual {
-        Some(Violation {
-            node_id: node.id.clone(),
-            trigger_class: trigger.class,
-            trigger_surface: trigger.surface.clone(),
-            required,
-            actual,
-            suggestion: format!(
-                "The cue '{}' suggests {:?}; the IR is {:?}.",
-                trigger.surface, required, actual
-            ),
-        })
+fn resolve_effective_polarity(
+    node: &IRNode,
+    by_id: &HashMap<NodeId, &IRNode>,
+    cache: &mut HashMap<NodeId, Polarity>,
+) -> Polarity {
+    if let Some(v) = cache.get(&node.id) {
+        return *v;
+    }
+    let v = if node.polarity != Polarity::Inherit {
+        node.polarity
+    } else if let Some(parent_id) = &node.part_of {
+        if let Some(parent) = by_id.get(parent_id) {
+            resolve_effective_polarity(parent, by_id, cache)
+        } else {
+            // Dangling part_of — ADJ02 catches this; default here.
+            Polarity::Affirmed
+        }
     } else {
-        None
+        // Root with Inherit declared and no ancestor — chain is
+        // unresolved.
+        Polarity::Inherit
+    };
+    cache.insert(node.id.clone(), v);
+    v
+}
+
+fn resolve_effective_modality(
+    node: &IRNode,
+    by_id: &HashMap<NodeId, &IRNode>,
+    cache: &mut HashMap<NodeId, Modality>,
+) -> Modality {
+    if let Some(v) = cache.get(&node.id) {
+        return *v;
     }
+    let v = if node.modality != Modality::Inherit {
+        node.modality
+    } else if let Some(parent_id) = &node.part_of {
+        if let Some(parent) = by_id.get(parent_id) {
+            resolve_effective_modality(parent, by_id, cache)
+        } else {
+            Modality::Present
+        }
+    } else {
+        Modality::Inherit
+    };
+    cache.insert(node.id.clone(), v);
+    v
 }
 
 // ---------------------------------------------------------------------------
@@ -545,325 +248,283 @@ mod tests {
         DocumentId::new("doc1")
     }
 
-    fn mk_doc(text: &str) -> Document {
-        Document {
-            id: doc_id(),
-            normalized_text: text.to_string(),
-        }
+    fn span_of(start: usize, end: usize) -> Span {
+        Span::new(doc_id(), start, end)
     }
 
-    fn mk_node(
+    fn text_run(
         id: &str,
-        term: logic_core::Term,
-        polarity: Polarity,
-        modality: Modality,
         start: usize,
         end: usize,
+        part_of: Option<&str>,
+        polarity: Polarity,
+        modality: Modality,
     ) -> IRNode {
         IRNode {
             id: NodeId::new(id),
-            kind: NodeKind::Fact,
-            term,
+            kind: NodeKind::TextRun,
+            term: compound("text_run", vec![]),
             polarity,
             modality,
-            source_spans: vec![Span::new(doc_id(), start, end)],
+            source_spans: vec![span_of(start, end)],
             confidence: 1.0,
-            part_of: None,
+            part_of: part_of.map(NodeId::new),
             lowered_from: None,
             discard_reason: None,
             metadata: HashMap::new(),
         }
     }
 
-    fn ir_with(nodes: Vec<IRNode>) -> IRDocument {
-        IRDocument {
-            document_id: doc_id(),
-            nodes,
+    fn fact_leaf(
+        id: &str,
+        start: usize,
+        end: usize,
+        part_of: Option<&str>,
+        polarity: Polarity,
+        modality: Modality,
+    ) -> IRNode {
+        IRNode {
+            id: NodeId::new(id),
+            kind: NodeKind::Fact,
+            term: atom("placeholder"),
+            polarity,
+            modality,
+            source_spans: vec![span_of(start, end)],
+            confidence: 0.9,
+            part_of: part_of.map(NodeId::new),
+            lowered_from: None,
+            discard_reason: None,
+            metadata: HashMap::new(),
         }
     }
 
+    /// Single leaf with concrete polarity → Pass, no warnings.
     #[test]
-    fn denies_with_affirmed_polarity_is_violation() {
-        let doc = mk_doc("Patient denies chest pain.");
-        let n = mk_node(
-            "F1",
-            compound("chest_pain", vec![atom("patient")]),
-            Polarity::Affirmed,
-            Modality::Present,
-            0,
-            26,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert_eq!(vs.len(), 1);
-        assert_eq!(vs[0].trigger_class, TriggerClass::Negation);
-        assert_eq!(
-            vs[0].required,
-            RequiredField::Polarity(Polarity::Denied)
-        );
+    fn single_leaf_with_concrete_polarity_passes() {
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![fact_leaf(
+                "F1",
+                0,
+                10,
+                None,
+                Polarity::Affirmed,
+                Modality::Present,
+            )],
+        };
+        let r = check_propagation(&ir);
+        assert!(r.pass());
+        assert!(r.warnings.is_empty());
     }
 
+    /// Parent TextRun with Denied polarity, child Fact with Inherit
+    /// → child inherits Denied. No warning.
     #[test]
-    fn denies_with_denied_polarity_passes() {
-        let doc = mk_doc("Patient denies chest pain.");
-        let n = mk_node(
-            "F1",
-            compound("chest_pain", vec![atom("patient")]),
-            Polarity::Denied,
-            Modality::Present,
-            0,
-            26,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert!(vs.is_empty(), "expected no violations, got {:?}", vs);
+    fn child_inherits_parent_denied_polarity() {
+        let parent = text_run("T0", 0, 30, None, Polarity::Denied, Modality::Present);
+        let child = fact_leaf("F1", 0, 30, Some("T0"), Polarity::Inherit, Modality::Inherit);
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![parent, child],
+        };
+        let r = check_propagation(&ir);
+        assert!(r.pass(), "violations: {:?}", r.violations);
+        assert!(r.warnings.is_empty(), "warnings: {:?}", r.warnings);
     }
 
+    /// Parent Denied, child explicitly Affirmed → override warning,
+    /// but does not gate.
     #[test]
-    fn father_with_past_modality_flags_family_history() {
-        let doc = mk_doc("Father had MI at 50.");
-        let n = mk_node(
-            "F1",
-            atom("mi"),
-            Polarity::Affirmed,
-            Modality::Past,
-            0,
-            20,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert_eq!(vs.len(), 1);
-        assert_eq!(vs[0].trigger_class, TriggerClass::FamilyHistory);
-        assert_eq!(
-            vs[0].required,
-            RequiredField::Modality(Modality::FamilyHistory)
-        );
+    fn child_overriding_parent_polarity_emits_warning() {
+        let parent = text_run("T0", 0, 30, None, Polarity::Denied, Modality::Present);
+        let child = fact_leaf("F1", 0, 30, Some("T0"), Polarity::Affirmed, Modality::Present);
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![parent, child],
+        };
+        let r = check_propagation(&ir);
+        assert!(r.pass()); // warnings don't gate
+        let has_override = r.warnings.iter().any(|w| matches!(
+            w,
+            PropagationWarning::LeafOverridesAncestorPolarity { declared: Polarity::Affirmed, ancestor: Polarity::Denied, .. }
+        ));
+        assert!(has_override, "expected polarity override warning: {:?}", r.warnings);
     }
 
+    /// RuledOut + Affirmed = pass (the canonical RuledOut shape).
     #[test]
-    fn ruled_out_with_ruled_out_modality_and_affirmed_polarity_passes() {
-        // The spec is emphatic: RuledOut is modality only; polarity
-        // stays Affirmed. This is the test that catches a naive
-        // extractor flipping polarity instead of setting modality.
-        let doc = mk_doc("PE ruled out by CT angio.");
-        let n = mk_node(
+    fn ruled_out_with_affirmed_polarity_passes() {
+        let leaf = fact_leaf(
             "F1",
-            atom("pe"),
-            Polarity::Affirmed,
-            Modality::RuledOut,
-            0,
-            25,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert!(vs.is_empty(), "expected no violations, got {:?}", vs);
-    }
-
-    #[test]
-    fn ruled_out_with_denied_polarity_does_not_satisfy_the_modality_check() {
-        // The RuleOut trigger requires modality RuledOut. A node with
-        // polarity Denied and modality Present should still flag the
-        // modality mismatch (Denied does not satisfy RuledOut).
-        let doc = mk_doc("PE ruled out by CT angio.");
-        let n = mk_node(
-            "F1",
-            atom("pe"),
-            Polarity::Denied,
-            Modality::Present,
-            0,
-            25,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert_eq!(vs.len(), 1);
-        assert_eq!(vs[0].trigger_class, TriggerClass::RuleOut);
-        assert_eq!(
-            vs[0].required,
-            RequiredField::Modality(Modality::RuledOut)
-        );
-    }
-
-    #[test]
-    fn possibly_flags_uncertainty_when_polarity_is_affirmed() {
-        let doc = mk_doc("Possibly pneumonia.");
-        let n = mk_node(
-            "F1",
-            atom("pneumonia"),
-            Polarity::Affirmed,
-            Modality::Present,
-            0,
-            19,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert_eq!(vs.len(), 1);
-        assert_eq!(vs[0].trigger_class, TriggerClass::Hedge);
-        assert_eq!(
-            vs[0].required,
-            RequiredField::Polarity(Polarity::Uncertain)
-        );
-    }
-
-    #[test]
-    fn history_of_flags_past_modality_when_modality_is_present() {
-        let doc = mk_doc("History of asthma.");
-        let n = mk_node(
-            "F1",
-            atom("asthma"),
-            Polarity::Affirmed,
-            Modality::Present,
-            0,
-            18,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert_eq!(vs.len(), 1);
-        assert_eq!(vs[0].trigger_class, TriggerClass::TemporalPast);
-        assert_eq!(
-            vs[0].required,
-            RequiredField::Modality(Modality::Past)
-        );
-    }
-
-    #[test]
-    fn termination_keyword_limits_negation_scope() {
-        // "Denies chest pain but admits back pain." — "but"
-        // terminates the negation scope before "back". A
-        // back_pain(patient) Affirmed node should NOT be flagged.
-        let doc = mk_doc("Denies chest pain but admits back pain.");
-        let n = mk_node(
-            "F1",
-            atom("back_pain"),
-            Polarity::Affirmed,
-            Modality::Present,
-            0,
-            39,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        // Note: "back_pain" as an atom doesn't appear literally in the
-        // text (the text says "back pain"). The check looks for
-        // content words from the term; the functor "back_pain" won't
-        // match because the text has the space. This documents the
-        // current limit: word-boundary matching does not split
-        // underscores. Result: no violation regardless, because the
-        // content word is not found in scope.
-        // We assert no violation; if a future tokenizer-aware check
-        // changes this, the assertion is the trigger to update.
-        assert!(vs.is_empty(), "expected no violations, got {:?}", vs);
-    }
-
-    #[test]
-    fn unrelated_trigger_in_span_does_not_flag_if_term_not_in_scope() {
-        // Span includes "denies" but the term content word is outside
-        // the negation scope.
-        let doc = mk_doc("Denies chest pain. Admits fever.");
-        let n = mk_node(
-            "F1",
-            atom("fever"),
-            Polarity::Affirmed,
-            Modality::Present,
-            0,
-            32,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        // "fever" is after the sentence-ending "." that terminates
-        // the negation scope, so no violation should fire.
-        assert!(
-            vs.iter().all(|v| v.trigger_class != TriggerClass::Negation),
-            "negation should not fire on fever; got {:?}",
-            vs
-        );
-    }
-
-    #[test]
-    fn no_triggers_in_span_pass_silently() {
-        let doc = mk_doc("Patient reports clear breath sounds.");
-        let n = mk_node(
-            "F1",
-            atom("clear_breath_sounds"),
-            Polarity::Affirmed,
-            Modality::Present,
-            0,
-            36,
-        );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert!(vs.is_empty());
-    }
-
-    #[test]
-    fn previously_flags_past_modality() {
-        let doc = mk_doc("Patient previously had asthma.");
-        let n = mk_node(
-            "F1",
-            atom("asthma"),
-            Polarity::Affirmed,
-            Modality::Present,
             0,
             30,
+            None,
+            Polarity::Affirmed,
+            Modality::RuledOut,
         );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert!(vs
-            .iter()
-            .any(|v| v.trigger_class == TriggerClass::TemporalPast));
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![leaf],
+        };
+        let r = check_propagation(&ir);
+        assert!(r.pass());
     }
 
+    /// RuledOut + Denied = gating violation (the clinical/legal
+    /// distinction enforced as a hard rule).
     #[test]
-    fn no_token_flags_negation() {
-        let doc = mk_doc("No fever today.");
-        let n = mk_node(
+    fn ruled_out_with_denied_polarity_violates() {
+        let leaf = fact_leaf(
             "F1",
-            atom("fever"),
+            0,
+            30,
+            None,
+            Polarity::Denied,
+            Modality::RuledOut,
+        );
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![leaf],
+        };
+        let r = check_propagation(&ir);
+        assert!(!r.pass());
+        assert!(r.violations.iter().any(|v| matches!(
+            v,
+            PropagationViolation::RuledOutMustBeAffirmed { .. }
+        )));
+    }
+
+    /// Parent Inherit + child Inherit + no ancestor → unresolved
+    /// chain.
+    #[test]
+    fn unresolvable_inherit_chain_violates() {
+        let parent = text_run("T0", 0, 30, None, Polarity::Inherit, Modality::Inherit);
+        let child = fact_leaf("F1", 0, 30, Some("T0"), Polarity::Inherit, Modality::Inherit);
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![parent, child],
+        };
+        let r = check_propagation(&ir);
+        assert!(!r.pass(), "expected violations, got {:?}", r);
+        assert!(r.violations.iter().any(|v| matches!(
+            v,
+            PropagationViolation::InheritChainUnresolved { .. }
+        )));
+    }
+
+    /// Multi-level inheritance: grandchild inherits from grandparent.
+    #[test]
+    fn multilevel_inheritance_through_textruns() {
+        let outer = text_run("T0", 0, 50, None, Polarity::Denied, Modality::Past);
+        let inner = text_run("T1", 0, 50, Some("T0"), Polarity::Inherit, Modality::Inherit);
+        let leaf = fact_leaf(
+            "F1",
+            0,
+            50,
+            Some("T1"),
+            Polarity::Inherit,
+            Modality::Inherit,
+        );
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![outer, inner, leaf],
+        };
+        let r = check_propagation(&ir);
+        assert!(r.pass());
+        assert!(r.warnings.is_empty());
+    }
+
+    /// Legitimate override case: parent Denied with siblings inheriting
+    /// Denied + one sibling explicitly Affirmed.
+    #[test]
+    fn list_of_denials_with_one_affirmation_emits_one_warning() {
+        let parent = text_run("T0", 0, 100, None, Polarity::Denied, Modality::Present);
+        let c1 = fact_leaf("F1", 0, 25, Some("T0"), Polarity::Inherit, Modality::Inherit);
+        let c2 = fact_leaf("F2", 25, 50, Some("T0"), Polarity::Inherit, Modality::Inherit);
+        let c3 = fact_leaf("F3", 50, 75, Some("T0"), Polarity::Inherit, Modality::Inherit);
+        // The one explicit Affirmed amid the implicit Denieds.
+        let c4 = fact_leaf("F4", 75, 100, Some("T0"), Polarity::Affirmed, Modality::Present);
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![parent, c1, c2, c3, c4],
+        };
+        let r = check_propagation(&ir);
+        assert!(r.pass());
+        // Exactly one override warning (on F4); modality is Present
+        // which matches the parent's effective Present, so no modality
+        // warning. c1..c3 inherit cleanly.
+        let polarity_overrides = r.warnings.iter().filter(|w| matches!(
+            w,
+            PropagationWarning::LeafOverridesAncestorPolarity { .. }
+        )).count();
+        assert_eq!(polarity_overrides, 1, "warnings: {:?}", r.warnings);
+    }
+
+    /// TextRun nodes themselves don't generate override warnings —
+    /// only leaves do.
+    #[test]
+    fn textrun_does_not_emit_override_warnings() {
+        let outer = text_run("T0", 0, 50, None, Polarity::Denied, Modality::Present);
+        // Child TextRun that overrides; should not emit a warning
+        // (only leaves do).
+        let inner = text_run(
+            "T1",
+            0,
+            50,
+            Some("T0"),
             Polarity::Affirmed,
             Modality::Present,
-            0,
-            15,
         );
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert!(vs
-            .iter()
-            .any(|v| v.trigger_class == TriggerClass::Negation));
+        let leaf = fact_leaf(
+            "F1",
+            0,
+            50,
+            Some("T1"),
+            Polarity::Inherit,
+            Modality::Inherit,
+        );
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![outer, inner, leaf],
+        };
+        let r = check_propagation(&ir);
+        assert!(r.pass());
+        // Leaf F1's effective polarity is Affirmed (inherits from T1
+        // which overrode T0). Since F1 declared Inherit, no warning
+        // — the warning would only fire if F1 itself declared a
+        // non-Inherit value disagreeing with T1.
+        assert!(
+            r.warnings.is_empty(),
+            "intermediate TextRun overrides should not generate warnings: {:?}",
+            r.warnings
+        );
     }
 
+    /// Discarded nodes are skipped from the check.
     #[test]
-    fn nodes_without_polarity_modality_value_are_skipped() {
-        // Discarded nodes don't participate in the check.
-        let doc = mk_doc("Denies chest pain.");
-        let n = IRNode {
+    fn discarded_nodes_are_skipped() {
+        let parent = text_run("T0", 0, 30, None, Polarity::Denied, Modality::Present);
+        // A Discarded node with Affirmed (which would override
+        // ancestor's Denied if checked) is skipped per ADJ03.
+        let discard = IRNode {
             id: NodeId::new("D1"),
             kind: NodeKind::Discarded,
-            term: atom("chest_pain"),
-            polarity: Polarity::Affirmed, // would otherwise be flagged
+            term: atom("discarded"),
+            polarity: Polarity::Affirmed,
             modality: Modality::Present,
-            source_spans: vec![Span::new(doc_id(), 0, 18)],
+            source_spans: vec![span_of(0, 30)],
             confidence: 1.0,
-            part_of: None,
+            part_of: Some(NodeId::new("T0")),
             lowered_from: None,
             discard_reason: Some(adjudication_ir::DiscardReason::Pleasantry),
             metadata: HashMap::new(),
         };
-        let ir = ir_with(vec![n]);
-        let vs = check_polarity_modality(&doc, &ir, &TriggerTaxonomy::clinical_default());
-        assert!(vs.is_empty(), "Discarded nodes should be skipped");
-    }
-
-    #[test]
-    fn empty_taxonomy_never_flags() {
-        let doc = mk_doc("Denies chest pain.");
-        let n = mk_node(
-            "F1",
-            atom("chest_pain"),
-            Polarity::Affirmed,
-            Modality::Present,
-            0,
-            18,
-        );
-        let ir = ir_with(vec![n]);
-        let empty = TriggerTaxonomy::new("empty");
-        assert!(check_polarity_modality(&doc, &ir, &empty).is_empty());
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![parent, discard],
+        };
+        let r = check_propagation(&ir);
+        assert!(r.pass());
+        assert!(r.warnings.is_empty());
     }
 }


### PR DESCRIPTION
Replaces the v0.1.0 NegEx / ConText trigger-detection with a **structural propagation consistency check** over the hierarchical IR from ADJ01 v2. No trigger taxonomy, no scope detection, no English assumption. Language-agnostic by construction. **Stacked on [#2694](https://github.com/adhithyan15/coding-adventures/pull/2694)** (adjudication-ir v2).

## What's gone

- `TriggerClass`, `TriggerDirection`, `ScopeRule`, `Trigger`, `TriggerTaxonomy`
- `clinical_default()` English trigger list
- Per-trigger scope detection
- All NegEx / ConText machinery

## What replaces them

- `check_propagation(ir_doc) -> PropagationResult` — walks every leaf, resolves effective polarity/modality via ancestor lookup, compares declared vs effective.
- `PropagationResult { violations, warnings }` — violations gate; warnings recorded but do not gate by default.
- **Violations** (gating): `InheritChainUnresolved`, `RuledOutMustBeAffirmed`.
- **Warnings** (non-gating): `LeafOverridesAncestorPolarity`, `LeafOverridesAncestorModality`.

Effective-value resolution memoized for **O(N)** total cost.

## Default policy: warn-do-not-block

Legitimate overrides exist in real documents (*'denies X, Y; admits Z'*). Deployments can configure warnings-as-errors for strict semantics.

## Tests

**10 tests** cover the full propagation surface including the canonical RuledOut hard rule, multi-level inheritance, the 'denies list with one affirmation' case, intermediate-TextRun overrides, and Discarded skipping. `cargo build / test / clippy --no-deps` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)