### PR TITLE
feat(beam): add bitwise OR, XOR, NOT to BEAM backend (ir-to-beam v0.2.0)

### DIFF
--- a/code/packages/rust/ir-to-beam/CHANGELOG.md
+++ b/code/packages/rust/ir-to-beam/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — ir-to-beam
 
+## [0.2.0] — 2026-05-11
+
+### Added — Bitwise OR, XOR, NOT lowering
+
+- **`IrOp::Or`** — lowered to `gc_bif2 erlang:bor/2`.
+- **`IrOp::OrImm`** — synthesised as `move {i,imm} scratch; gc_bif2 bor src scratch dst`.
+- **`IrOp::Xor`** — lowered to `gc_bif2 erlang:bxor/2`.
+- **`IrOp::XorImm`** — synthesised as `move {i,imm} scratch; gc_bif2 bxor src scratch dst`.
+- **`IrOp::Not`** — lowered to `gc_bif1 erlang:bnot/1` (opcode 124).
+  `bnot` is Erlang's bitwise NOT and is a **unary** BIF, so it uses `gc_bif1`
+  rather than `gc_bif2`, unlike all other arithmetic ops.
+- Added `OP_GC_BIF1 = 124` constant and `emit_gc_bif1()` helper.
+- Interned atoms: `bor`, `bxor`, `bnot`; added corresponding import table entries.
+- Updated module-level doc table to include MUL, DIV, OR, OR_IMM, XOR, XOR_IMM, NOT.
+- 7 new unit tests: BIF instruction presence, import table contents, validate sweep,
+  lowering success sweep.
+
+---
+
 ## [0.1.0] — 2026-04-28
 
 ### Added

--- a/code/packages/rust/ir-to-beam/Cargo.toml
+++ b/code/packages/rust/ir-to-beam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ir-to-beam"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/code/packages/rust/ir-to-beam/src/backend.rs
+++ b/code/packages/rust/ir-to-beam/src/backend.rs
@@ -17,22 +17,29 @@
 //!
 //! # Supported IR opcodes (v1)
 //!
-//! | IR op      | BEAM instruction        | Notes |
-//! |------------|-------------------------|-------|
-//! | LABEL      | label {u,N}             | N from label map (starts at 3) |
-//! | LOAD_IMM   | move {i,val} {x,r}      | |
-//! | ADD        | gc_bif2 erlang:+/2      | |
-//! | ADD_IMM    | move + gc_bif2          | synthesised via scratch register |
-//! | SUB        | gc_bif2 erlang:-/2      | |
-//! | AND        | gc_bif2 erlang:band/2   | |
-//! | AND_IMM    | move + gc_bif2          | synthesised |
-//! | JUMP       | jump {f,label}          | opcode 36 |
+//! | IR op      | BEAM instruction          | Notes |
+//! |------------|---------------------------|-------|
+//! | LABEL      | label {u,N}               | N from label map (starts at 3) |
+//! | LOAD_IMM   | move {i,val} {x,r}        | |
+//! | ADD        | gc_bif2 erlang:+/2        | |
+//! | ADD_IMM    | move + gc_bif2 erlang:+/2 | synthesised via scratch register |
+//! | SUB        | gc_bif2 erlang:-/2        | |
+//! | MUL        | gc_bif2 erlang:*/2        | |
+//! | DIV        | gc_bif2 erlang:div/2      | truncates toward zero |
+//! | AND        | gc_bif2 erlang:band/2     | |
+//! | AND_IMM    | move + gc_bif2 band       | synthesised |
+//! | OR         | gc_bif2 erlang:bor/2      | |
+//! | OR_IMM     | move + gc_bif2 bor        | synthesised |
+//! | XOR        | gc_bif2 erlang:bxor/2     | |
+//! | XOR_IMM    | move + gc_bif2 bxor       | synthesised |
+//! | NOT        | gc_bif1 erlang:bnot/1     | unary; opcode 124 |
+//! | JUMP       | jump {f,label}            | opcode 36 |
 //! | BRANCH_Z   | is_ne_exact {f,L} r {i,0} | branch to L when reg == 0 |
 //! | BRANCH_NZ  | is_eq_exact {f,L} r {i,0} | branch to L when reg != 0 |
-//! | CALL       | call {u,0} {f,label}    | arity 0 in v1 |
-//! | RET / HALT | return                  | opcode 19 |
-//! | NOP        | (nothing)               | |
-//! | COMMENT    | (nothing)               | |
+//! | CALL       | call {u,0} {f,label}      | arity 0 in v1 |
+//! | RET / HALT | return                    | opcode 19 |
+//! | NOP        | (nothing)                 | |
+//! | COMMENT    | (nothing)                 | |
 //!
 //! # Module structure
 //!
@@ -85,6 +92,8 @@ const OP_IS_EQ_EXACT: u8 = 43;
 const OP_IS_NE_EXACT: u8 = 44;
 /// `{move, Src, Dst}` — copy operand to register.
 const OP_MOVE: u8 = 64;
+/// `{gc_bif1, Fail, Live, Bif, Arg, Dst}` — one-argument BIF call.
+const OP_GC_BIF1: u8 = 124;
 /// `{gc_bif2, Fail, Live, Bif, Arg1, Arg2, Dst}` — two-argument BIF call.
 const OP_GC_BIF2: u8 = 125;
 
@@ -329,6 +338,21 @@ fn imm_val(op: &IrOperand) -> Result<i64, BEAMBackendError> {
     }
 }
 
+/// Build a `gc_bif1` instruction.
+///
+/// Format: `{gc_bif1, {f,0}, {u,live}, {u,import_idx}, {x,arg}, {x,dst}}`
+///
+/// Used for one-argument BIFs such as `erlang:bnot/1` (bitwise NOT).
+fn emit_gc_bif1(import_idx: u32, live: u64, arg: u8, dst: u8) -> BEAMInstruction {
+    BEAMInstruction::new(OP_GC_BIF1, vec![
+        BEAMOperand::f(0),                   // no explicit fail label
+        BEAMOperand::u(live),                // live x-register count for GC
+        BEAMOperand::u(import_idx as u64),   // import table index (0-based)
+        BEAMOperand::x(arg),                 // sole argument
+        BEAMOperand::x(dst),                 // destination
+    ])
+}
+
 /// Build a `gc_bif2` instruction.
 ///
 /// Format: `{gc_bif2, {f,0}, {u,live}, {u,import_idx}, {x,a1}, {x,a2}, {x,dst}}`
@@ -422,6 +446,9 @@ pub fn lower_ir_to_beam(
     let band_idx   = atoms.intern("band");              // 6
     let times_idx  = atoms.intern("*");                 // 7 — for Mul
     let div_idx    = atoms.intern("div");               // 8 — for Div (Erlang integer div)
+    let bor_idx    = atoms.intern("bor");               // 9 — for Or (Erlang bitwise OR)
+    let bxor_idx   = atoms.intern("bxor");              // 10 — for Xor (Erlang bitwise XOR)
+    let bnot_idx   = atoms.intern("bnot");              // 11 — for Not (Erlang bitwise NOT, arity 1)
 
     // ── Import table setup ────────────────────────────────────────────────
     // Pre-register arithmetic BIFs so their indices are stable.
@@ -431,6 +458,9 @@ pub fn lower_ir_to_beam(
     let import_band  = imports.intern(erlang_idx, band_idx, 2);
     let import_times = imports.intern(erlang_idx, times_idx, 2);
     let import_div   = imports.intern(erlang_idx, div_idx, 2);
+    let import_bor   = imports.intern(erlang_idx, bor_idx,  2); // erlang:bor/2
+    let import_bxor  = imports.intern(erlang_idx, bxor_idx, 2); // erlang:bxor/2
+    let import_bnot  = imports.intern(erlang_idx, bnot_idx, 1); // erlang:bnot/1 — unary
 
     // ── Label first-pass ──────────────────────────────────────────────────
     // Assign BEAM label numbers starting at 3 (1 and 2 are reserved for
@@ -559,6 +589,63 @@ pub fn lower_ir_to_beam(
                     BEAMOperand::x(scratch),
                 ]));
                 instrs.push(emit_gc_bif2(import_band, live, src, scratch, dst));
+            }
+
+            // ── Bitwise OR ─────────────────────────────────────────────────
+            // OR v_dst, v_src1, v_src2  →  gc_bif2 erlang:bor/2 src1 src2 dst
+            IrOp::Or => {
+                let dst  = reg_idx(&instr.operands[0])? as u8;
+                let src1 = reg_idx(&instr.operands[1])? as u8;
+                let src2 = reg_idx(&instr.operands[2])? as u8;
+                instrs.push(emit_gc_bif2(import_bor, live, src1, src2, dst));
+            }
+
+            // ── Bitwise OR with immediate ──────────────────────────────────
+            // OR_IMM v_dst, v_src, imm  →  move {i,imm} scratch; gc_bif2 bor src scratch dst
+            IrOp::OrImm => {
+                let dst = reg_idx(&instr.operands[0])? as u8;
+                let src = reg_idx(&instr.operands[1])? as u8;
+                let val = imm_val(&instr.operands[2])?;
+                instrs.push(BEAMInstruction::new(OP_MOVE, vec![
+                    BEAMOperand::i(val as u64),
+                    BEAMOperand::x(scratch),
+                ]));
+                instrs.push(emit_gc_bif2(import_bor, live, src, scratch, dst));
+            }
+
+            // ── Bitwise XOR ────────────────────────────────────────────────
+            // XOR v_dst, v_src1, v_src2  →  gc_bif2 erlang:bxor/2 src1 src2 dst
+            IrOp::Xor => {
+                let dst  = reg_idx(&instr.operands[0])? as u8;
+                let src1 = reg_idx(&instr.operands[1])? as u8;
+                let src2 = reg_idx(&instr.operands[2])? as u8;
+                instrs.push(emit_gc_bif2(import_bxor, live, src1, src2, dst));
+            }
+
+            // ── Bitwise XOR with immediate ─────────────────────────────────
+            // XOR_IMM v_dst, v_src, imm  →  move {i,imm} scratch; gc_bif2 bxor src scratch dst
+            IrOp::XorImm => {
+                let dst = reg_idx(&instr.operands[0])? as u8;
+                let src = reg_idx(&instr.operands[1])? as u8;
+                let val = imm_val(&instr.operands[2])?;
+                instrs.push(BEAMInstruction::new(OP_MOVE, vec![
+                    BEAMOperand::i(val as u64),
+                    BEAMOperand::x(scratch),
+                ]));
+                instrs.push(emit_gc_bif2(import_bxor, live, src, scratch, dst));
+            }
+
+            // ── Bitwise NOT ────────────────────────────────────────────────
+            //
+            // `erlang:bnot/1` is the Erlang bitwise NOT (one's complement).
+            // Unlike OR and XOR (which are binary BIFs), bnot is unary, so we
+            // use `gc_bif1` (opcode 124) instead of `gc_bif2` (opcode 125).
+            //
+            // NOT v_dst, v_src  →  gc_bif1 erlang:bnot/1 src dst
+            IrOp::Not => {
+                let dst = reg_idx(&instr.operands[0])? as u8;
+                let src = reg_idx(&instr.operands[1])? as u8;
+                instrs.push(emit_gc_bif1(import_bnot, live, src, dst));
             }
 
             // ── Unconditional jump ─────────────────────────────────────────
@@ -1022,5 +1109,172 @@ mod tests {
         let bytes = encode_beam(&module);
         assert_eq!(&bytes[0..4], b"FOR1");
         assert_eq!(&bytes[8..12], b"BEAM");
+    }
+
+    // ── Bitwise OR, XOR, NOT ──────────────────────────────────────────────────
+
+    #[test]
+    fn or_lowers_to_gc_bif2_bor() {
+        // OR v2, v0, v1  →  gc_bif2 erlang:bor/2
+        let prog = bitwise_binary_prog(IrOp::Or);
+        let module = lower_ir_to_beam(&prog, &default_cfg()).unwrap();
+        // The instruction stream must contain a gc_bif2 (opcode 125) with
+        // erlang:bor/2 in the import table.
+        assert!(module.instructions.iter().any(|i| i.opcode == OP_GC_BIF2),
+            "expected gc_bif2 in: {:?}", module.instructions.iter().map(|i| i.opcode).collect::<Vec<_>>());
+        let has_bor = module.imports.iter().any(|imp| {
+            let m = &module.atoms[(imp.module_atom_index - 1) as usize];
+            let f = &module.atoms[(imp.function_atom_index - 1) as usize];
+            m == "erlang" && f == "bor" && imp.arity == 2
+        });
+        assert!(has_bor, "erlang:bor/2 not in import table");
+    }
+
+    #[test]
+    fn or_imm_lowers_synthesised() {
+        // OR_IMM v1, v0, 5  →  move {i,5} scratch; gc_bif2 bor src scratch dst
+        let prog = bitwise_imm_prog(IrOp::OrImm, 5);
+        let module = lower_ir_to_beam(&prog, &default_cfg()).unwrap();
+        // Must have both a move and a gc_bif2
+        assert!(module.instructions.iter().any(|i| i.opcode == OP_MOVE),
+            "expected move in OrImm output");
+        assert!(module.instructions.iter().any(|i| i.opcode == OP_GC_BIF2),
+            "expected gc_bif2 in OrImm output");
+    }
+
+    #[test]
+    fn xor_lowers_to_gc_bif2_bxor() {
+        // XOR v2, v0, v1  →  gc_bif2 erlang:bxor/2
+        let prog = bitwise_binary_prog(IrOp::Xor);
+        let module = lower_ir_to_beam(&prog, &default_cfg()).unwrap();
+        let has_bxor = module.imports.iter().any(|imp| {
+            let m = &module.atoms[(imp.module_atom_index - 1) as usize];
+            let f = &module.atoms[(imp.function_atom_index - 1) as usize];
+            m == "erlang" && f == "bxor" && imp.arity == 2
+        });
+        assert!(has_bxor, "erlang:bxor/2 not in import table");
+    }
+
+    #[test]
+    fn xor_imm_lowers_synthesised() {
+        // XOR_IMM v1, v0, 0xFF  →  move {i,255} scratch; gc_bif2 bxor ...
+        let prog = bitwise_imm_prog(IrOp::XorImm, 0xFF);
+        let module = lower_ir_to_beam(&prog, &default_cfg()).unwrap();
+        assert!(module.instructions.iter().any(|i| i.opcode == OP_GC_BIF2),
+            "expected gc_bif2 in XorImm output");
+    }
+
+    #[test]
+    fn not_lowers_to_gc_bif1_bnot() {
+        // NOT v1, v0  →  gc_bif1 erlang:bnot/1
+        //
+        // `bnot` is a unary BIF, so it uses gc_bif1 (opcode 124) not gc_bif2.
+        let prog = bitwise_not_prog();
+        let module = lower_ir_to_beam(&prog, &default_cfg()).unwrap();
+        assert!(module.instructions.iter().any(|i| i.opcode == OP_GC_BIF1),
+            "expected gc_bif1 (opcode 124) for NOT; got: {:?}",
+            module.instructions.iter().map(|i| i.opcode).collect::<Vec<_>>());
+        let has_bnot = module.imports.iter().any(|imp| {
+            let m = &module.atoms[(imp.module_atom_index - 1) as usize];
+            let f = &module.atoms[(imp.function_atom_index - 1) as usize];
+            m == "erlang" && f == "bnot" && imp.arity == 1
+        });
+        assert!(has_bnot, "erlang:bnot/1 not in import table");
+    }
+
+    #[test]
+    fn validate_accepts_all_bitwise_ops() {
+        // validate_for_beam must accept all five new bitwise ops.
+        for (name, prog) in [
+            ("Or",     bitwise_binary_prog(IrOp::Or)),
+            ("OrImm",  bitwise_imm_prog(IrOp::OrImm,  0b1010)),
+            ("Xor",    bitwise_binary_prog(IrOp::Xor)),
+            ("XorImm", bitwise_imm_prog(IrOp::XorImm, 0b1111)),
+            ("Not",    bitwise_not_prog()),
+        ] {
+            let errs = validate_for_beam(&prog);
+            assert!(errs.is_empty(), "validate_for_beam returned errors for {name}: {errs:?}");
+        }
+    }
+
+    #[test]
+    fn lower_all_bitwise_ops_succeed() {
+        // All five bitwise ops must lower without error.
+        for (name, prog) in [
+            ("Or",     bitwise_binary_prog(IrOp::Or)),
+            ("OrImm",  bitwise_imm_prog(IrOp::OrImm,  7)),
+            ("Xor",    bitwise_binary_prog(IrOp::Xor)),
+            ("XorImm", bitwise_imm_prog(IrOp::XorImm, 0xFF)),
+            ("Not",    bitwise_not_prog()),
+        ] {
+            let result = lower_ir_to_beam(&prog, &default_cfg());
+            assert!(result.is_ok(), "lowering failed for {name}: {}", result.unwrap_err());
+        }
+    }
+
+    // ── Program-builder helpers ───────────────────────────────────────────────
+
+    /// Build a minimal program: `op v2, v0, v1` (binary register-register op).
+    fn bitwise_binary_prog(op: IrOp) -> IrProgram {
+        let mut prog = IrProgram::new("_start");
+        prog.add_instruction(IrInstruction::new(
+            IrOp::LoadImm,
+            vec![IrOperand::Register(0), IrOperand::Immediate(42)],
+            0,
+        ));
+        prog.add_instruction(IrInstruction::new(
+            IrOp::LoadImm,
+            vec![IrOperand::Register(1), IrOperand::Immediate(15)],
+            1,
+        ));
+        prog.add_instruction(IrInstruction::new(
+            op,
+            vec![
+                IrOperand::Register(2),
+                IrOperand::Register(0),
+                IrOperand::Register(1),
+            ],
+            2,
+        ));
+        prog.add_instruction(IrInstruction::new(IrOp::Halt, vec![], 3));
+        prog
+    }
+
+    /// Build a minimal program: `op v1, v0, imm` (binary register-immediate op).
+    fn bitwise_imm_prog(op: IrOp, imm: i64) -> IrProgram {
+        let mut prog = IrProgram::new("_start");
+        prog.add_instruction(IrInstruction::new(
+            IrOp::LoadImm,
+            vec![IrOperand::Register(0), IrOperand::Immediate(42)],
+            0,
+        ));
+        prog.add_instruction(IrInstruction::new(
+            op,
+            vec![
+                IrOperand::Register(1),
+                IrOperand::Register(0),
+                IrOperand::Immediate(imm),
+            ],
+            1,
+        ));
+        prog.add_instruction(IrInstruction::new(IrOp::Halt, vec![], 2));
+        prog
+    }
+
+    /// Build a minimal program: `NOT v1, v0` (one's complement).
+    fn bitwise_not_prog() -> IrProgram {
+        let mut prog = IrProgram::new("_start");
+        prog.add_instruction(IrInstruction::new(
+            IrOp::LoadImm,
+            vec![IrOperand::Register(0), IrOperand::Immediate(42)],
+            0,
+        ));
+        prog.add_instruction(IrInstruction::new(
+            IrOp::Not,
+            vec![IrOperand::Register(1), IrOperand::Register(0)],
+            1,
+        ));
+        prog.add_instruction(IrInstruction::new(IrOp::Halt, vec![], 2));
+        prog
     }
 }

--- a/code/packages/rust/ir-to-beam/src/backend.rs
+++ b/code/packages/rust/ir-to-beam/src/backend.rs
@@ -211,7 +211,10 @@ impl _ImportTable {
         if let Some(&idx) = self.index.get(&key) {
             return idx;
         }
-        let idx = self.imports.len() as u32;
+        // Checked cast: apply the same pattern as _AtomTable::intern — make
+        // overflow explicit rather than silently wrapping to a wrong index.
+        let idx = u32::try_from(self.imports.len())
+            .expect("import table exceeded u32::MAX entries");
         self.imports.push(BEAMImport { module_atom_index: module_idx, function_atom_index: fn_idx, arity });
         self.index.insert(key, idx);
         idx
@@ -326,6 +329,19 @@ fn reg_idx(op: &IrOperand) -> Result<usize, BEAMBackendError> {
             format!("expected register operand, got {:?}", other),
         )),
     }
+}
+
+/// Extract a virtual-register index and narrow it to `u8`.
+///
+/// BEAM x-registers are numbered 0–255.  Any register index ≥ 256 would be
+/// silently truncated by a bare `as u8` cast and produce a wrong register
+/// reference.  This helper makes the overflow explicit and returns a typed
+/// error instead of silently miscompiling the program.
+fn reg_u8(op: &IrOperand) -> Result<u8, BEAMBackendError> {
+    let idx = reg_idx(op)?;
+    u8::try_from(idx).map_err(|_| BEAMBackendError::InvalidOperand(
+        format!("register index {} exceeds BEAM x-register limit of 255", idx),
+    ))
 }
 
 /// Extract an integer immediate from an operand, or return an error.
@@ -511,7 +527,7 @@ pub fn lower_ir_to_beam(
             // ── Load immediate ─────────────────────────────────────────────
             // LOAD_IMM v_dst, imm  →  move {i,imm} {x,dst}
             IrOp::LoadImm => {
-                let dst = reg_idx(&instr.operands[0])? as u8;
+                let dst = reg_u8(&instr.operands[0])?;
                 let val = imm_val(&instr.operands[1])?;
                 instrs.push(BEAMInstruction::new(OP_MOVE, vec![
                     BEAMOperand::i(val as u64), // works for non-negative; bit-pattern for negative
@@ -522,17 +538,17 @@ pub fn lower_ir_to_beam(
             // ── Register-register addition ─────────────────────────────────
             // ADD v_dst, v_src1, v_src2  →  gc_bif2 erlang:+/2 src1 src2 dst
             IrOp::Add => {
-                let dst  = reg_idx(&instr.operands[0])? as u8;
-                let src1 = reg_idx(&instr.operands[1])? as u8;
-                let src2 = reg_idx(&instr.operands[2])? as u8;
+                let dst  = reg_u8(&instr.operands[0])?;
+                let src1 = reg_u8(&instr.operands[1])?;
+                let src2 = reg_u8(&instr.operands[2])?;
                 instrs.push(emit_gc_bif2(import_plus, live, src1, src2, dst));
             }
 
             // ── Register-immediate addition ────────────────────────────────
             // ADD_IMM v_dst, v_src, imm  →  move {i,imm} scratch; gc_bif2 src scratch dst
             IrOp::AddImm => {
-                let dst = reg_idx(&instr.operands[0])? as u8;
-                let src = reg_idx(&instr.operands[1])? as u8;
+                let dst = reg_u8(&instr.operands[0])?;
+                let src = reg_u8(&instr.operands[1])?;
                 let val = imm_val(&instr.operands[2])?;
                 instrs.push(BEAMInstruction::new(OP_MOVE, vec![
                     BEAMOperand::i(val as u64),
@@ -544,18 +560,18 @@ pub fn lower_ir_to_beam(
             // ── Subtraction ────────────────────────────────────────────────
             // SUB v_dst, v_src1, v_src2  →  gc_bif2 erlang:-/2 src1 src2 dst
             IrOp::Sub => {
-                let dst  = reg_idx(&instr.operands[0])? as u8;
-                let src1 = reg_idx(&instr.operands[1])? as u8;
-                let src2 = reg_idx(&instr.operands[2])? as u8;
+                let dst  = reg_u8(&instr.operands[0])?;
+                let src1 = reg_u8(&instr.operands[1])?;
+                let src2 = reg_u8(&instr.operands[2])?;
                 instrs.push(emit_gc_bif2(import_minus, live, src1, src2, dst));
             }
 
             // ── Multiplication ─────────────────────────────────────────────
             // MUL v_dst, v_src1, v_src2  →  gc_bif2 erlang:*/2 src1 src2 dst
             IrOp::Mul => {
-                let dst  = reg_idx(&instr.operands[0])? as u8;
-                let src1 = reg_idx(&instr.operands[1])? as u8;
-                let src2 = reg_idx(&instr.operands[2])? as u8;
+                let dst  = reg_u8(&instr.operands[0])?;
+                let src1 = reg_u8(&instr.operands[1])?;
+                let src2 = reg_u8(&instr.operands[2])?;
                 instrs.push(emit_gc_bif2(import_times, live, src1, src2, dst));
             }
 
@@ -563,26 +579,26 @@ pub fn lower_ir_to_beam(
             // DIV v_dst, v_src1, v_src2  →  gc_bif2 erlang:div/2 src1 src2 dst
             // Erlang's `div` operator truncates toward zero, matching IR semantics.
             IrOp::Div => {
-                let dst  = reg_idx(&instr.operands[0])? as u8;
-                let src1 = reg_idx(&instr.operands[1])? as u8;
-                let src2 = reg_idx(&instr.operands[2])? as u8;
+                let dst  = reg_u8(&instr.operands[0])?;
+                let src1 = reg_u8(&instr.operands[1])?;
+                let src2 = reg_u8(&instr.operands[2])?;
                 instrs.push(emit_gc_bif2(import_div, live, src1, src2, dst));
             }
 
             // ── Bitwise AND ────────────────────────────────────────────────
             // AND v_dst, v_src1, v_src2  →  gc_bif2 erlang:band/2 src1 src2 dst
             IrOp::And => {
-                let dst  = reg_idx(&instr.operands[0])? as u8;
-                let src1 = reg_idx(&instr.operands[1])? as u8;
-                let src2 = reg_idx(&instr.operands[2])? as u8;
+                let dst  = reg_u8(&instr.operands[0])?;
+                let src1 = reg_u8(&instr.operands[1])?;
+                let src2 = reg_u8(&instr.operands[2])?;
                 instrs.push(emit_gc_bif2(import_band, live, src1, src2, dst));
             }
 
             // ── Bitwise AND with immediate ─────────────────────────────────
             // AND_IMM v_dst, v_src, imm  →  move {i,imm} scratch; gc_bif2 band src scratch dst
             IrOp::AndImm => {
-                let dst = reg_idx(&instr.operands[0])? as u8;
-                let src = reg_idx(&instr.operands[1])? as u8;
+                let dst = reg_u8(&instr.operands[0])?;
+                let src = reg_u8(&instr.operands[1])?;
                 let val = imm_val(&instr.operands[2])?;
                 instrs.push(BEAMInstruction::new(OP_MOVE, vec![
                     BEAMOperand::i(val as u64),
@@ -594,17 +610,17 @@ pub fn lower_ir_to_beam(
             // ── Bitwise OR ─────────────────────────────────────────────────
             // OR v_dst, v_src1, v_src2  →  gc_bif2 erlang:bor/2 src1 src2 dst
             IrOp::Or => {
-                let dst  = reg_idx(&instr.operands[0])? as u8;
-                let src1 = reg_idx(&instr.operands[1])? as u8;
-                let src2 = reg_idx(&instr.operands[2])? as u8;
+                let dst  = reg_u8(&instr.operands[0])?;
+                let src1 = reg_u8(&instr.operands[1])?;
+                let src2 = reg_u8(&instr.operands[2])?;
                 instrs.push(emit_gc_bif2(import_bor, live, src1, src2, dst));
             }
 
             // ── Bitwise OR with immediate ──────────────────────────────────
             // OR_IMM v_dst, v_src, imm  →  move {i,imm} scratch; gc_bif2 bor src scratch dst
             IrOp::OrImm => {
-                let dst = reg_idx(&instr.operands[0])? as u8;
-                let src = reg_idx(&instr.operands[1])? as u8;
+                let dst = reg_u8(&instr.operands[0])?;
+                let src = reg_u8(&instr.operands[1])?;
                 let val = imm_val(&instr.operands[2])?;
                 instrs.push(BEAMInstruction::new(OP_MOVE, vec![
                     BEAMOperand::i(val as u64),
@@ -616,17 +632,17 @@ pub fn lower_ir_to_beam(
             // ── Bitwise XOR ────────────────────────────────────────────────
             // XOR v_dst, v_src1, v_src2  →  gc_bif2 erlang:bxor/2 src1 src2 dst
             IrOp::Xor => {
-                let dst  = reg_idx(&instr.operands[0])? as u8;
-                let src1 = reg_idx(&instr.operands[1])? as u8;
-                let src2 = reg_idx(&instr.operands[2])? as u8;
+                let dst  = reg_u8(&instr.operands[0])?;
+                let src1 = reg_u8(&instr.operands[1])?;
+                let src2 = reg_u8(&instr.operands[2])?;
                 instrs.push(emit_gc_bif2(import_bxor, live, src1, src2, dst));
             }
 
             // ── Bitwise XOR with immediate ─────────────────────────────────
             // XOR_IMM v_dst, v_src, imm  →  move {i,imm} scratch; gc_bif2 bxor src scratch dst
             IrOp::XorImm => {
-                let dst = reg_idx(&instr.operands[0])? as u8;
-                let src = reg_idx(&instr.operands[1])? as u8;
+                let dst = reg_u8(&instr.operands[0])?;
+                let src = reg_u8(&instr.operands[1])?;
                 let val = imm_val(&instr.operands[2])?;
                 instrs.push(BEAMInstruction::new(OP_MOVE, vec![
                     BEAMOperand::i(val as u64),
@@ -643,8 +659,8 @@ pub fn lower_ir_to_beam(
             //
             // NOT v_dst, v_src  →  gc_bif1 erlang:bnot/1 src dst
             IrOp::Not => {
-                let dst = reg_idx(&instr.operands[0])? as u8;
-                let src = reg_idx(&instr.operands[1])? as u8;
+                let dst = reg_u8(&instr.operands[0])?;
+                let src = reg_u8(&instr.operands[1])?;
                 instrs.push(emit_gc_bif1(import_bnot, live, src, dst));
             }
 
@@ -664,7 +680,7 @@ pub fn lower_ir_to_beam(
             //   • if Reg != 0: test passes → fall through (skip the jump)
             //   • if Reg == 0: test fails  → jump to Fail (our target label)
             IrOp::BranchZ => {
-                let reg = reg_idx(&instr.operands[0])? as u8;
+                let reg = reg_u8(&instr.operands[0])?;
                 let name = label_name(&instr.operands[1])?;
                 let beam_lbl = *label_map.get(&name)
                     .ok_or_else(|| BEAMBackendError::UndefinedLabel(name.clone()))?;
@@ -682,7 +698,7 @@ pub fn lower_ir_to_beam(
             //   • if Reg == 0: test passes → fall through (skip the jump)
             //   • if Reg != 0: test fails  → jump to Fail (our target label)
             IrOp::BranchNz => {
-                let reg = reg_idx(&instr.operands[0])? as u8;
+                let reg = reg_u8(&instr.operands[0])?;
                 let name = label_name(&instr.operands[1])?;
                 let beam_lbl = *label_map.get(&name)
                     .ok_or_else(|| BEAMBackendError::UndefinedLabel(name.clone()))?;


### PR DESCRIPTION
## Summary

- Adds `IrOp::Or`, `OrImm`, `Xor`, `XorImm`, `Not` lowering to the Rust BEAM backend (`ir-to-beam`)
- `Or`/`Xor` and their `Imm` variants lower to `gc_bif2 erlang:bor/2` / `gc_bif2 erlang:bxor/2`; immediate forms are synthesised via `move {i,imm} scratch + gc_bif2`
- `Not` lowers to `gc_bif1 erlang:bnot/1` (opcode 124) — the only unary BIF in the backend; uses the new `emit_gc_bif1()` helper
- Security fixes applied: replaced all `reg_idx(...) as u8` truncating casts with a `reg_u8()` helper that returns `BEAMBackendError::InvalidOperand` for indices ≥ 256; fixed `_ImportTable::intern` to use `u32::try_from(...).expect(...)` matching the atom table
- 7 new unit tests; total: 59 unit + 5 doc tests

## Dependency

**Base branch is `feat/ir-bitwise-ops`** (PR #2700). This PR depends on `compiler-ir` v0.2.0 (Or/Xor/Not opcodes) which is on that branch, not yet on `main`.

## Test plan

- [ ] `cargo test -p ir-to-beam` → 59 unit + 5 doc tests pass
- [ ] CI passes on `feat/ir-bitwise-ops` base
- [ ] Merge only after PR #2700 merges to `main` and this branch is rebased onto `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)