### PR TITLE
feat(llm-primitives): skeleton crate for LM00b — fork-point for 6 parallel primitive PRs

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -173,6 +173,7 @@ members = [
     "logic-engine",
     "adjudication-ir",
     "llm-gateway",
+    "llm-primitives",
     "prolog-lexer",
     "prolog-parser",
     "prolog-loader",

--- a/code/packages/rust/llm-primitives/BUILD
+++ b/code/packages/rust/llm-primitives/BUILD
@@ -1,0 +1,12 @@
+load("code/packages/starlark/library-rules/rust_library.star", "rust_library")
+
+_targets = [
+    rust_library(
+        name = "llm-primitives",
+        srcs = ["src/**/*.rs"],
+        deps = [
+            "//code/packages/rust/llm-gateway",
+            "//code/packages/rust/adjudication-ir",
+        ],
+    ),
+]

--- a/code/packages/rust/llm-primitives/BUILD_windows
+++ b/code/packages/rust/llm-primitives/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p llm-primitives -- --nocapture

--- a/code/packages/rust/llm-primitives/CHANGELOG.md
+++ b/code/packages/rust/llm-primitives/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-05-11
+
+### Added
+
+- `Role` enum: `Extractor`, `Renderer`, `Nli`, `Adversary`,
+  `Plausibility`, `RuleExtractor`. Stable `as_str()` for audit-trail
+  records.
+- `GatewayConfig` — role-keyed registry of `Box<dyn LlmClient>` with
+  builder-style `with_client`. Lookup via `client(Role)` returns
+  `Option<&dyn LlmClient>`.
+- `GatewayConfig::check_independence()` — ADJ05 startup check that
+  `Role::Extractor` and `Role::Adversary` come from different
+  `(vendor, model_family)` pairs. Returns `IndependenceViolation`
+  with full provider identities on failure.
+- `LlmCallRecord` — one row of the LLM audit trail. Carries
+  `primitive`, `role`, `prompt_version`, `prompt_hash`, `provider`,
+  `usage`, `finish_reason`, `latency_ms`, `cost_usd`. `PartialEq`
+  only (not `Eq`) because `cost_usd: f64`.
+- `PrimitiveCallRecord` — wraps one or more `LlmCallRecord`s (one
+  per retry attempt) with primitive-level context (`inputs_hash`,
+  `outputs_hash`, `cache_hit`, `attempts`, `total_cost_usd`).
+- `PrimitiveError`: `Gateway(LlmError)`, `ValidationExhausted`,
+  `StructuralFailure`, `NoClientForRole`. `From<LlmError>` impl
+  for `?`-friendly propagation.
+- Six prompt-version constants (`DECOMPOSE_TEXT_PROMPT_VERSION` …
+  `EXTRACT_RULES_PROMPT_VERSION`) covering the LM00b primitive set.
+- `fingerprint_prompt(&CompletionRequest) -> String` — deterministic
+  FNV-1a-based hash of the prompt portion of a request, ignoring
+  `temperature` and `seed` so retries match.
+- 15 tests covering: `Role::as_str` stability, `GatewayConfig`
+  registration / lookup, ADJ05 independence-check pass and fail
+  cases (different families, same family same vendor, same vendor
+  different families), `fingerprint_prompt` determinism and
+  insensitivity to temperature/seed, `PrimitiveError` display, and
+  prompt-version constant stability.
+
+### Notes
+
+This is the **skeleton-only** v0.1.0. The six primitive functions
+(`decompose_text`, `render_node`, `entail`,
+`find_contradicting_reading`, `judge_plausibility`,
+`extract_rules`) ship in follow-up PRs that can land in parallel
+because they don't conflict on a shared file.
+
+Reference: [`LM00b`](../../../specs/LM00b-llm-primitives.md).

--- a/code/packages/rust/llm-primitives/Cargo.toml
+++ b/code/packages/rust/llm-primitives/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "llm-primitives"
+version = "0.1.0"
+edition = "2021"
+description = "LM00b — skeleton for the typed LLM primitives layer. Defines Role, GatewayConfig, LlmCallRecord, PrimitiveError, and prompt-version constants. The six concrete primitives (decompose_text, render_node, entail, find_contradicting_reading, judge_plausibility, extract_rules) ship in follow-up crates / modules."
+
+[dependencies]
+llm-gateway = { path = "../llm-gateway" }
+adjudication-ir = { path = "../adjudication-ir" }

--- a/code/packages/rust/llm-primitives/README.md
+++ b/code/packages/rust/llm-primitives/README.md
@@ -1,0 +1,81 @@
+# llm-primitives (Rust)
+
+Skeleton for the typed LLM primitives layer of the adjudication
+framework. This crate holds the shared scaffolding every primitive
+needs; the six concrete primitives (`decompose_text`, `render_node`,
+`entail`, `find_contradicting_reading`, `judge_plausibility`,
+`extract_rules`) ship as follow-up PRs that depend on this one.
+
+## What This Is
+
+Reference implementation of [LM00b — LLM Primitives](../../../specs/LM00b-llm-primitives.md).
+
+The framework never lets its checkers / extractor call an
+`LlmClient` directly. Instead, every LLM-driven operation goes
+through a **typed primitive**: a pure function from typed input to
+typed output, with a versioned prompt, a JSON-schema-validated
+output, an audit-trail record, and a deterministic retry harness.
+This crate defines the building blocks every primitive plugs into.
+
+## Where It Fits
+
+```text
+   framework consumers (extractor, ADJ02–05, ADJ06, ADJ09)
+        │
+        ▼
+   llm-primitives                            ← this crate (scaffolding)
+        │     ├── decompose_text             ← follow-up crate
+        │     ├── render_node                ← follow-up crate
+        │     ├── entail                     ← follow-up crate
+        │     ├── find_contradicting_reading ← follow-up crate
+        │     ├── judge_plausibility         ← follow-up crate
+        │     └── extract_rules              ← follow-up crate
+        │
+        ▼
+   llm-gateway (LlmClient trait + types)
+        │
+        ▼
+   llm-provider-anthropic / -openai / -ollama / -mock
+```
+
+## Public API (v0.1.0)
+
+| Item | Role |
+|---|---|
+| `Role` enum | Which slot a primitive fills (Extractor / Renderer / Nli / Adversary / Plausibility / RuleExtractor) |
+| `GatewayConfig` | Role → `Box<dyn LlmClient>` registry used by every primitive |
+| `IndependenceViolation` | ADJ05 check: extractor and adversary must be different model families |
+| `LlmCallRecord` | Audit-trail row for one LLM call (provider identity, prompt hash, usage, latency, cost) |
+| `PrimitiveCallRecord` | Per-primitive audit record wrapping retry attempts |
+| `PrimitiveError` | `Gateway` / `ValidationExhausted` / `StructuralFailure` / `NoClientForRole` |
+| `DECOMPOSE_TEXT_PROMPT_VERSION` … `EXTRACT_RULES_PROMPT_VERSION` | Six version constants |
+| `fingerprint_prompt(&CompletionRequest)` | Deterministic content hash of the prompt portion |
+
+The crate has **no async runtime dependency**: the `LlmClient` trait
+in `llm-gateway` is synchronous in v0.1.0, and so is everything
+that wraps it here. A future async surface can be added without
+breaking these types.
+
+## Usage
+
+```rust
+use llm_primitives::{GatewayConfig, Role, fingerprint_prompt};
+use llm_gateway::MockLlmClient;
+
+let gateway = GatewayConfig::new()
+    .with_client(Role::Extractor, Box::new(MockLlmClient::new()))
+    .with_client(Role::Renderer,  Box::new(MockLlmClient::new()));
+
+// ADJ05 sanity check at startup:
+gateway.check_independence().expect("extractor and adversary must differ");
+
+// Each primitive crate calls `gateway.client(Role::Extractor)` etc.
+```
+
+## Why a Skeleton-Only PR
+
+The six primitives can be implemented in parallel once the shared
+types are in place. Shipping the skeleton first as a small,
+mechanically reviewable PR unlocks six concurrent implementation
+PRs that won't conflict on a single giant file. This is the
+fork-point pattern: ship the cheap multiplier first.

--- a/code/packages/rust/llm-primitives/required_capabilities.json
+++ b/code/packages/rust/llm-primitives/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/llm-primitives",
+  "capabilities": [],
+  "justification": "Scaffolding types and pure helpers (Role, GatewayConfig, LlmCallRecord, fingerprint_prompt). No I/O. The concrete primitive crates that depend on this one consume network capabilities through their llm-gateway client; this crate itself does not."
+}

--- a/code/packages/rust/llm-primitives/src/lib.rs
+++ b/code/packages/rust/llm-primitives/src/lib.rs
@@ -1,0 +1,573 @@
+// LlmError carried inside PrimitiveError::Gateway is itself a large
+// variant; the same audit-trail discipline (every error carries full
+// context) is worth the size cost as long as errors are not on a hot
+// path. Box later if profiling shows it.
+#![allow(clippy::result_large_err)]
+
+//! # llm-primitives — typed LLM operations for the adjudication framework
+//!
+//! Reference skeleton for
+//! [LM00b](../../../specs/LM00b-llm-primitives.md).
+//!
+//! This crate defines the **scaffolding** every primitive needs and
+//! that every framework consumer (extractor, ADJ02–05, ADJ06, ADJ09)
+//! programs against:
+//!
+//!   * [`Role`] — the role a primitive plays in the framework
+//!     (extractor / renderer / nli / adversary / plausibility /
+//!     rule_extractor). The deployment maps roles to concrete
+//!     [`LlmClient`](llm_gateway::LlmClient) instances so that the
+//!     same primitive can run against different models in different
+//!     deployments.
+//!   * [`GatewayConfig`] — the role-keyed registry of clients.
+//!   * [`LlmCallRecord`] — the audit-trail record produced by every
+//!     LLM call. Carries the provider identity, the prompt version
+//!     and hash, token usage, and finish reason — enough to replay
+//!     and to attribute cost.
+//!   * [`PrimitiveCallRecord`] — wraps one or more `LlmCallRecord`s
+//!     (one per retry attempt) plus the primitive-level context
+//!     (primitive name, attempts, cache hit, total cost).
+//!   * [`PrimitiveError`] — the failure shape every primitive returns.
+//!   * Six [`PROMPT_VERSION_*`](DECOMPOSE_TEXT_PROMPT_VERSION) constants —
+//!     one per primitive — so the framework can carry the version
+//!     into the audit trail without each primitive crate hard-coding
+//!     a magic string.
+//!
+//! ## What this crate deliberately does NOT contain
+//!
+//! The six primitive functions (`decompose_text`, `render_node`,
+//! `entail`, `find_contradicting_reading`, `judge_plausibility`,
+//! `extract_rules`) are intentionally **not** here. Each ships as its
+//! own module (or its own crate) once this skeleton is merged, so the
+//! six implementations can land in parallel without conflicting on
+//! one giant file. This is the fork-point pattern: a small,
+//! mechanically-reviewable PR that unlocks N concurrent implementation
+//! PRs.
+//!
+//! ## Why a separate `LlmCallRecord` here
+//!
+//! The audit-trail record lives in `llm-primitives` rather than
+//! `llm-gateway` because it's the *primitive layer* that always
+//! produces one — the gateway trait is intentionally I/O-only and
+//! does not concern itself with audit semantics. A future refactor
+//! may pull `LlmCallRecord` down into `llm-gateway` if other
+//! gateway-direct consumers appear; for now its home is here.
+
+use std::collections::HashMap;
+
+use llm_gateway::{
+    CompletionRequest, FinishReason, LlmClient, LlmError, ProviderIdentity, TokenUsage,
+};
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+/// Why role-based dispatch instead of just passing an `LlmClient`?
+///
+/// Different primitives play different roles in the adversarial /
+/// audit-trail pipeline, and the **deployment** — not the primitive —
+/// decides which model serves which role. Two reasons:
+///
+/// 1. **Independence requirement (ADJ05).** The extractor and the
+///    adversary must come from different model families; if both
+///    were the same client, the adversary would just rubber-stamp
+///    the extraction. The framework enforces independence by checking
+///    that `Role::Extractor` and `Role::Adversary` map to different
+///    `ProviderIdentity::model_family` values.
+/// 2. **Cost / latency policy.** Renderers and plausibility judges
+///    can be cheap small models; extractors and adversaries usually
+///    want the frontier. Pinning the model in primitive code would
+///    force every deployment to negotiate a hard-coded choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Role {
+    /// Used by `decompose_text` and `extract_rules`. Heavy lifting —
+    /// the deployment usually maps this to the frontier model.
+    Extractor,
+    /// Used by `render_node`. Faithful trivial paraphrase; small
+    /// cheap model is fine.
+    Renderer,
+    /// Used by `entail`. The framework recommends a purpose-trained
+    /// NLI model here (different from the renderer to avoid self-
+    /// confirmation per ADJ04).
+    Nli,
+    /// Used by `find_contradicting_reading`. ADJ05 requires this to
+    /// be a different model family from `Extractor`.
+    Adversary,
+    /// Used by `judge_plausibility`. Decision is binary; small model
+    /// is fine.
+    Plausibility,
+    /// Used by `extract_rules`. Defaults to the same client as
+    /// `Extractor`; deployments can override.
+    RuleExtractor,
+}
+
+impl Role {
+    /// Stable string name for audit-trail records.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Role::Extractor => "extractor",
+            Role::Renderer => "renderer",
+            Role::Nli => "nli",
+            Role::Adversary => "adversary",
+            Role::Plausibility => "plausibility",
+            Role::RuleExtractor => "rule_extractor",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GatewayConfig — role → client registry
+// ---------------------------------------------------------------------------
+
+/// Maps roles to concrete `LlmClient` instances.
+///
+/// Deployments construct this once at startup and pass it to every
+/// primitive call. The framework treats it as immutable for the
+/// duration of a request — swapping a client mid-request would
+/// muddle the audit trail.
+///
+/// The same `LlmClient` may be registered against multiple roles
+/// (e.g., a single small model serves both `Renderer` and
+/// `Plausibility`); the framework's only hard rule is the
+/// extractor/adversary independence check, performed by
+/// [`GatewayConfig::check_independence`].
+pub struct GatewayConfig {
+    clients: HashMap<Role, Box<dyn LlmClient>>,
+}
+
+impl GatewayConfig {
+    pub fn new() -> Self {
+        Self { clients: HashMap::new() }
+    }
+
+    /// Register a client against a role. Replaces any prior client.
+    pub fn with_client(mut self, role: Role, client: Box<dyn LlmClient>) -> Self {
+        self.clients.insert(role, client);
+        self
+    }
+
+    /// Look up the client for a role. Returns `None` if the role has
+    /// no registered client; primitives translate this to
+    /// [`PrimitiveError::NoClientForRole`].
+    pub fn client(&self, role: Role) -> Option<&dyn LlmClient> {
+        self.clients.get(&role).map(|c| c.as_ref())
+    }
+
+    /// ADJ05 independence check: `Extractor` and `Adversary` must
+    /// come from different model families. Returns a description of
+    /// the violation if both roles are registered and share a family;
+    /// returns `Ok(())` otherwise (including when one or both roles
+    /// are unregistered — that's a separate error surfaced at call time).
+    pub fn check_independence(&self) -> Result<(), IndependenceViolation> {
+        let extractor = self.clients.get(&Role::Extractor).map(|c| c.identity());
+        let adversary = self.clients.get(&Role::Adversary).map(|c| c.identity());
+        if let (Some(e), Some(a)) = (extractor, adversary) {
+            if e.vendor == a.vendor && e.model_family == a.model_family {
+                return Err(IndependenceViolation {
+                    extractor: e,
+                    adversary: a,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for GatewayConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Surfaced by [`GatewayConfig::check_independence`] when the
+/// extractor and adversary share a model family — a configuration
+/// bug that ADJ05 explicitly forbids.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndependenceViolation {
+    pub extractor: ProviderIdentity,
+    pub adversary: ProviderIdentity,
+}
+
+impl std::fmt::Display for IndependenceViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ADJ05 independence violated: extractor and adversary both \
+             use {vendor}/{family}",
+            vendor = self.extractor.vendor,
+            family = self.extractor.model_family,
+        )
+    }
+}
+
+impl std::error::Error for IndependenceViolation {}
+
+// ---------------------------------------------------------------------------
+// LlmCallRecord — per-call audit-trail row
+// ---------------------------------------------------------------------------
+
+/// One row of the LLM audit trail. Produced by every LLM call a
+/// primitive makes (including retries) and emitted into the
+/// document's audit trail (ADJ07).
+///
+/// The record is intentionally **content-addressed**: `prompt_hash`
+/// is a deterministic hash of the prompt text, so a replay can match
+/// recorded calls exactly without storing the prompt verbatim
+/// alongside every record. The full prompt lives once in the prompts
+/// directory under the same version.
+///
+/// `Eq` is intentionally not derived because `cost_usd: f64`
+/// (`f64` is not `Eq` since NaN ≠ NaN). Replay comparison should go
+/// through `prompt_hash` rather than struct-level equality.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LlmCallRecord {
+    /// Which primitive made this call (e.g., `"decompose_text"`).
+    pub primitive: String,
+    /// Which role's client was used (e.g., `"extractor"`).
+    pub role: String,
+    /// The prompt-version string baked into the call.
+    pub prompt_version: String,
+    /// Content-addressed hash of the rendered prompt (system + messages).
+    pub prompt_hash: String,
+    /// The provider identity at call time. Recorded verbatim so
+    /// replay can detect "model drift" — same prompt, different
+    /// model version producing different output.
+    pub provider: ProviderIdentity,
+    /// Token usage as reported by the provider.
+    pub usage: TokenUsage,
+    /// Why the provider stopped generating.
+    pub finish_reason: FinishReason,
+    /// Wall-clock latency of this call in milliseconds.
+    pub latency_ms: u64,
+    /// Estimated cost in USD. Zero for local providers by default.
+    pub cost_usd: f64,
+}
+
+// ---------------------------------------------------------------------------
+// PrimitiveCallRecord — wraps the per-primitive context
+// ---------------------------------------------------------------------------
+
+/// What the audit trail records for one primitive invocation. Wraps
+/// the per-attempt `LlmCallRecord` list with primitive-level context
+/// (was it a cache hit, how many attempts, total cost).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrimitiveCallRecord {
+    pub primitive: String,
+    pub prompt_version: String,
+    pub role: String,
+    /// Hash of the typed input (e.g., the source text and domain hint).
+    pub inputs_hash: String,
+    /// Hash of the typed output (e.g., the IR document).
+    pub outputs_hash: String,
+    /// Whether the primitive cache served this call without an LLM round-trip.
+    pub cache_hit: bool,
+    /// Number of LLM attempts including retries. `1` on success-first-try.
+    pub attempts: usize,
+    /// One record per attempt. Empty on a cache hit; the cache may
+    /// preserve the original record separately.
+    pub llm_calls: Vec<LlmCallRecord>,
+    pub total_cost_usd: f64,
+}
+
+// ---------------------------------------------------------------------------
+// PrimitiveError
+// ---------------------------------------------------------------------------
+
+/// Every primitive returns `Result<_, PrimitiveError>`. The four
+/// variants cover the failure axes ADJ06 (clarification) needs to
+/// distinguish to render a useful question.
+#[derive(Debug)]
+pub enum PrimitiveError {
+    /// Gateway-level error (transport, auth, rate limit, refused, …).
+    /// ADJ06 cannot meaningfully clarify these; they're operator-
+    /// surface errors.
+    Gateway(LlmError),
+
+    /// The LLM's output failed JSON-schema validation after N retries.
+    /// ADJ06 surfaces the last response so a reviewer can see what
+    /// the model actually produced.
+    ValidationExhausted {
+        last_response: String,
+        last_error: String,
+        attempts: usize,
+    },
+
+    /// The output parsed and validated against the JSON schema but
+    /// failed a framework-specific check (e.g., ADJ02 coverage, ADJ01
+    /// well-formedness). ADJ06 turns this into a structural
+    /// clarification ("the IR doesn't cover X — please review").
+    StructuralFailure {
+        check_name: String,
+        detail: String,
+    },
+
+    /// The deployment's `GatewayConfig` has no client registered for
+    /// a role the primitive needs. This is a configuration bug, not
+    /// a runtime failure; the framework wants to surface it loudly.
+    NoClientForRole { role: Role },
+}
+
+impl std::fmt::Display for PrimitiveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrimitiveError::Gateway(e) => write!(f, "gateway error: {e}"),
+            PrimitiveError::ValidationExhausted { last_error, attempts, .. } => write!(
+                f,
+                "validation exhausted after {attempts} attempts: {last_error}",
+            ),
+            PrimitiveError::StructuralFailure { check_name, detail } => {
+                write!(f, "structural failure in {check_name}: {detail}")
+            }
+            PrimitiveError::NoClientForRole { role } => {
+                write!(f, "no client registered for role {}", role.as_str())
+            }
+        }
+    }
+}
+
+impl std::error::Error for PrimitiveError {}
+
+impl From<LlmError> for PrimitiveError {
+    fn from(e: LlmError) -> Self {
+        PrimitiveError::Gateway(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt versions
+// ---------------------------------------------------------------------------
+
+// Each constant pairs with the prompt template that lives (or will
+// live) under `code/packages/rust/llm-primitives/src/prompts/<name>.md`.
+// Bumping the version (e.g., `"-v2"`) is the audited way to change a
+// prompt: every `LlmCallRecord` carries the version, so replay
+// matches `(prompt_version, prompt_hash)`.
+
+pub const DECOMPOSE_TEXT_PROMPT_VERSION: &str = "decompose-text-v1";
+pub const RENDER_NODE_PROMPT_VERSION: &str = "render-node-v1";
+pub const ENTAIL_PROMPT_VERSION: &str = "entail-v1";
+pub const ADVERSARY_PROMPT_VERSION: &str = "adversary-v1";
+pub const PLAUSIBILITY_PROMPT_VERSION: &str = "plausibility-v1";
+pub const EXTRACT_RULES_PROMPT_VERSION: &str = "extract-rules-v1";
+
+// ---------------------------------------------------------------------------
+// Prompt fingerprinting (deterministic, no external crate)
+// ---------------------------------------------------------------------------
+
+/// Content-addressed hash of a [`CompletionRequest`]'s prompt portion
+/// (system + messages, ignoring temperature and seed so a retry of
+/// the same prompt matches the same fingerprint).
+///
+/// This is the helper every primitive uses to populate
+/// `LlmCallRecord::prompt_hash`. The implementation is a simple
+/// FNV-1a 64-bit hash rendered as hex; cryptographic strength is
+/// not required for replay-matching, only determinism.
+pub fn fingerprint_prompt(req: &CompletionRequest) -> String {
+    let mut h: u64 = 0xcbf29ce484222325; // FNV-1a 64-bit offset basis
+    fn step(h: &mut u64, bytes: &[u8]) {
+        for b in bytes {
+            *h ^= u64::from(*b);
+            *h = h.wrapping_mul(0x100000001b3); // FNV-1a 64-bit prime
+        }
+    }
+    step(&mut h, req.model.as_bytes());
+    step(&mut h, b"|");
+    if let Some(sys) = &req.system {
+        step(&mut h, sys.as_bytes());
+    }
+    step(&mut h, b"|");
+    for msg in &req.messages {
+        match msg.role {
+            llm_gateway::Role::System => step(&mut h, b"S:"),
+            llm_gateway::Role::User => step(&mut h, b"U:"),
+            llm_gateway::Role::Assistant => step(&mut h, b"A:"),
+        }
+        match &msg.content {
+            llm_gateway::MessageContent::Text(t) => step(&mut h, t.as_bytes()),
+            llm_gateway::MessageContent::Multimodal(blocks) => {
+                for b in blocks {
+                    if let llm_gateway::ContentBlock::Text(text) = b {
+                        step(&mut h, text.as_bytes());
+                    }
+                }
+            }
+        }
+        step(&mut h, b"|");
+    }
+    format!("{:016x}", h)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llm_gateway::{
+        CompletionRequest, Message, MessageContent, MockLlmClient, ProviderIdentity,
+        Role as MsgRole,
+    };
+
+    fn req_with_text(text: &str) -> CompletionRequest {
+        CompletionRequest {
+            model: "test-model".into(),
+            system: None,
+            messages: vec![Message {
+                role: MsgRole::User,
+                content: MessageContent::Text(text.into()),
+            }],
+            temperature: 0.0,
+            max_tokens: None,
+            stop_sequences: Vec::new(),
+            seed: None,
+            metadata: Default::default(),
+        }
+    }
+
+    #[test]
+    fn role_as_str_is_stable() {
+        assert_eq!(Role::Extractor.as_str(), "extractor");
+        assert_eq!(Role::Adversary.as_str(), "adversary");
+        assert_eq!(Role::Nli.as_str(), "nli");
+        assert_eq!(Role::Plausibility.as_str(), "plausibility");
+        assert_eq!(Role::Renderer.as_str(), "renderer");
+        assert_eq!(Role::RuleExtractor.as_str(), "rule_extractor");
+    }
+
+    #[test]
+    fn empty_gateway_returns_no_client() {
+        let g = GatewayConfig::new();
+        assert!(g.client(Role::Extractor).is_none());
+    }
+
+    #[test]
+    fn gateway_serves_registered_client() {
+        let g = GatewayConfig::new()
+            .with_client(Role::Extractor, Box::new(MockLlmClient::new()));
+        assert!(g.client(Role::Extractor).is_some());
+        assert!(g.client(Role::Adversary).is_none());
+    }
+
+    fn mock_with_identity(vendor: &str, family: &str) -> MockLlmClient {
+        MockLlmClient::new().with_identity(ProviderIdentity {
+            vendor: vendor.into(),
+            model_family: family.into(),
+            model_version: "v1".into(),
+            endpoint: None,
+        })
+    }
+
+    #[test]
+    fn independence_passes_when_only_one_role_set() {
+        let g = GatewayConfig::new()
+            .with_client(Role::Extractor, Box::new(mock_with_identity("a", "x")));
+        assert!(g.check_independence().is_ok());
+    }
+
+    #[test]
+    fn independence_passes_when_families_differ() {
+        let g = GatewayConfig::new()
+            .with_client(Role::Extractor, Box::new(mock_with_identity("anthropic", "claude-opus")))
+            .with_client(Role::Adversary, Box::new(mock_with_identity("openai", "gpt-5")));
+        assert!(g.check_independence().is_ok());
+    }
+
+    #[test]
+    fn independence_fails_when_same_vendor_and_family() {
+        let g = GatewayConfig::new()
+            .with_client(Role::Extractor, Box::new(mock_with_identity("anthropic", "claude-opus")))
+            .with_client(Role::Adversary, Box::new(mock_with_identity("anthropic", "claude-opus")));
+        let err = g.check_independence().unwrap_err();
+        assert_eq!(err.extractor.vendor, "anthropic");
+        assert_eq!(err.adversary.vendor, "anthropic");
+    }
+
+    #[test]
+    fn independence_passes_when_vendor_same_but_family_differs() {
+        // Anthropic Opus vs Anthropic Haiku — same vendor but the
+        // family field captures the model lineage, so this is two
+        // independent models from the ADJ05 perspective.
+        let g = GatewayConfig::new()
+            .with_client(Role::Extractor, Box::new(mock_with_identity("anthropic", "claude-opus-4-7")))
+            .with_client(Role::Adversary, Box::new(mock_with_identity("anthropic", "claude-haiku-4-5")));
+        assert!(g.check_independence().is_ok());
+    }
+
+    #[test]
+    fn fingerprint_is_deterministic() {
+        let r = req_with_text("hello");
+        assert_eq!(fingerprint_prompt(&r), fingerprint_prompt(&r));
+    }
+
+    #[test]
+    fn fingerprint_changes_with_text() {
+        let r1 = req_with_text("hello");
+        let r2 = req_with_text("world");
+        assert_ne!(fingerprint_prompt(&r1), fingerprint_prompt(&r2));
+    }
+
+    #[test]
+    fn fingerprint_ignores_temperature_and_seed() {
+        let mut r1 = req_with_text("hello");
+        let mut r2 = req_with_text("hello");
+        r1.temperature = 0.0;
+        r1.seed = Some(42);
+        r2.temperature = 1.0;
+        r2.seed = Some(7);
+        assert_eq!(fingerprint_prompt(&r1), fingerprint_prompt(&r2));
+    }
+
+    #[test]
+    fn fingerprint_changes_with_model() {
+        let mut r1 = req_with_text("hello");
+        let mut r2 = req_with_text("hello");
+        r1.model = "a".into();
+        r2.model = "b".into();
+        assert_ne!(fingerprint_prompt(&r1), fingerprint_prompt(&r2));
+    }
+
+    #[test]
+    fn no_client_for_role_error_displays_role_name() {
+        let err = PrimitiveError::NoClientForRole { role: Role::Adversary };
+        assert!(format!("{err}").contains("adversary"));
+    }
+
+    #[test]
+    fn validation_exhausted_displays_attempts() {
+        let err = PrimitiveError::ValidationExhausted {
+            last_response: "{}".into(),
+            last_error: "missing field 'nodes'".into(),
+            attempts: 3,
+        };
+        let s = format!("{err}");
+        assert!(s.contains("3 attempts"));
+        assert!(s.contains("missing field"));
+    }
+
+    #[test]
+    fn primitive_error_implements_from_llm_error() {
+        let provider = ProviderIdentity {
+            vendor: "mock".into(),
+            model_family: "test".into(),
+            model_version: "1".into(),
+            endpoint: None,
+        };
+        let llm_err = LlmError::Transport { provider, detail: "boom".into() };
+        let prim_err: PrimitiveError = llm_err.into();
+        assert!(matches!(prim_err, PrimitiveError::Gateway(_)));
+    }
+
+    #[test]
+    fn prompt_version_constants_are_stable() {
+        // Locking the constants down — bumping any of these is an
+        // audit-trail-affecting change and should be a separate PR.
+        assert_eq!(DECOMPOSE_TEXT_PROMPT_VERSION, "decompose-text-v1");
+        assert_eq!(RENDER_NODE_PROMPT_VERSION, "render-node-v1");
+        assert_eq!(ENTAIL_PROMPT_VERSION, "entail-v1");
+        assert_eq!(ADVERSARY_PROMPT_VERSION, "adversary-v1");
+        assert_eq!(PLAUSIBILITY_PROMPT_VERSION, "plausibility-v1");
+        assert_eq!(EXTRACT_RULES_PROMPT_VERSION, "extract-rules-v1");
+    }
+}


### PR DESCRIPTION
## Summary

- New crate \`code/packages/rust/llm-primitives/\` — the **skeleton-only** layer that every concrete primitive plugs into.
- Defines \`Role\`, \`GatewayConfig\`, \`LlmCallRecord\`, \`PrimitiveCallRecord\`, \`PrimitiveError\`, six prompt-version constants, and \`fingerprint_prompt\` — no I/O, no primitives.
- 15 tests; clippy clean with \`-D warnings\`.
- **Fork-point PR**: once merged, the six LM00b primitives (\`decompose_text\`, \`render_node\`, \`entail\`, \`find_contradicting_reading\`, \`judge_plausibility\`, \`extract_rules\`) can land in parallel because they no longer collide on a single file.

## Why ship the skeleton separately

Each of the six primitives is its own narrow function with its own prompt template, retry harness, and validation logic. Bundling them in one PR makes the diff huge and serializes implementation. Splitting the shared types into a tiny skeleton PR up front trades one extra hop for **6× parallel fan-out** afterwards.

## Where this fits

\`\`\`text
   framework consumers (extractor, ADJ02–05, ADJ06, ADJ09)
        │
        ▼
   llm-primitives (this PR: scaffolding)
        │     └── 6 primitive PRs (parallel, after this lands)
        ▼
   llm-gateway (merged #2698)
        │
        ▼
   llm-provider-* (separate parallel stream)
\`\`\`

## Notable design notes

- **ADJ05 independence check** lives on \`GatewayConfig::check_independence()\`: if \`Role::Extractor\` and \`Role::Adversary\` resolve to the same \`(vendor, model_family)\`, that's an \`IndependenceViolation\` at startup. The framework requires this for adversarial verification to work; better to fail loudly at config time than silently get rubber-stamp adversaries.
- **LlmCallRecord is here, not in llm-gateway**: the audit-trail record is a primitive-layer concept. The gateway trait is intentionally I/O-only. A future refactor may push it down if other direct gateway consumers appear.
- **Sync trait**: matches \`LlmClient\`'s v0.1.0 sync surface. Async wrappers can be added without breaking these types.
- **\`Eq\` on \`LlmCallRecord\` is intentionally omitted** (\`cost_usd: f64\`). Replay comparison should go through \`prompt_hash\`.

## Test plan

- [x] \`cargo test -p llm-primitives\` — 15/15 pass
- [x] \`cargo clippy -p llm-primitives -- -D warnings\` — clean
- [x] Security review — passed first round
- [ ] CI green on rebased branch
- [ ] After merge, open 6 follow-up PRs for the primitives in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)