### PR TITLE
feat(adjudication-audit-trail): ADJ07 v0.1 JSON-serializable audit-trail schema

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -179,6 +179,7 @@ members = [
     "adjudication-connector",
     "adjudication-polarity-modality",
     "adjudication-coverage",
+    "adjudication-audit-trail",
     "loss-functions",
     "markov-chain",
     "note-frequency",

--- a/code/packages/rust/adjudication-audit-trail/BUILD
+++ b/code/packages/rust/adjudication-audit-trail/BUILD
@@ -1,0 +1,9 @@
+load("code/packages/starlark/library-rules/rust_library.star", "rust_library")
+
+_targets = [
+    rust_library(
+        name = "adjudication-audit-trail",
+        srcs = ["src/**/*.rs"],
+        deps = [],
+    ),
+]

--- a/code/packages/rust/adjudication-audit-trail/BUILD_windows
+++ b/code/packages/rust/adjudication-audit-trail/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p adjudication-audit-trail -- --nocapture

--- a/code/packages/rust/adjudication-audit-trail/CHANGELOG.md
+++ b/code/packages/rust/adjudication-audit-trail/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-05-11
+
+### Added
+
+Reference implementation of [ADJ07](../../../specs/ADJ07-audit-trail-schema.md).
+Pure data types with `serde::{Serialize, Deserialize}` derives — no
+I/O, no behaviour beyond JSON round-trip.
+
+- `AuditTrail` — top-level record carrying adjudication id, timestamps,
+  outcome, documents, IR nodes, checker results, dialogue, engine
+  artifacts, configuration, and schema version. `new()` constructor
+  produces an in-progress trail with empty collections and
+  `AdjudicationOutcome::InProgress`.
+- Identifier newtypes: `AdjudicationId`, `DocumentId`, `NodeId`,
+  `TurnId`. All `#[serde(transparent)]` so the JSON shape is just the
+  inner value.
+- `Document`, `NormalizationRecord`, `AppendInfo` — input documents
+  with normalization provenance and per-turn append byte-ranges.
+- `IrNode` — per-node payload stored as `serde_json::Value` at v0.1
+  (will be typed `adjudication_ir::IRNode` at v0.2 once that crate
+  ships serde derives; **on-wire shape unchanged across the upgrade**).
+- `CheckerResult` + `Violation` + `PassName` + `PassOutcome` —
+  per-checker-pass results. `PassName` serializes as
+  `adj02_coverage` / `adj03_polarity_modality` / `adj04_round_trip` /
+  `adj05_adversarial`.
+- `ClarificationKind` — bridges to ADJ06 (UncoveredSpan,
+  AmbiguousPolarity, AmbiguousModality, RoundTripDrift,
+  AdversarialReading, InheritChainUnresolved, Other).
+- Dialogue types: `DialogueTurn`, `DialogueRung` (Rung1ReprompT /
+  Rung2SecondOpinion / Rung3Human), `DialogueResponse`,
+  `DialogueResponseSource` (Llm / Human / Cached), `DialogueOutcome`
+  (Resolved / Escalated / Abandoned).
+- `EngineArtifacts` — LP19 output with `engine_version`,
+  `search_mode` (FindFirst / EnumerateAll / AutoDetect), `kb_summary`,
+  `proof_dag` (opaque `serde_json::Value` until logic-engine ships
+  typed Serialize), optional `formula: BooleanFormula` and
+  `wmc_result: WmcResult` for probabilistic adjudications, and the
+  engine's structured answer.
+- `Configuration` + `VersionedComponent` — reproducibility-relevant
+  configuration. Every model (tagger, trigger taxonomy, extractor,
+  renderer, NLI, adversary, judge, rendering) has a `VersionedComponent`
+  slot with name, version, and free-form config map.
+- `AdjudicationOutcome` enum — `InProgress`, `Resolved { answer }`,
+  `ClarificationExhausted { unresolved }`, `Aborted { reason }`,
+  `TimedOut`. Serialized as an internally-tagged enum with
+  `tag = "kind"` and snake-case variant names.
+- `AppendedRecord` — optional content-addressed chaining for
+  tamper-evidence. The trail crate stores the shape; the deployment
+  chooses the hash algorithm and computes hashes at append time.
+- `AuditTrail::CURRENT_SCHEMA_VERSION = "ADJ07-v1"`.
+
+### Tests (16 passing)
+
+Coverage includes: round-trip serialization of `AuditTrail`, every
+outcome variant, every pass name, dialogue turns, engine artifacts
+in both minimal and probabilistic shapes, configuration with
+versioned components, schema-version constant lock-down, and
+forward-compatibility (missing optional fields deserialize via
+`Default`).
+
+### Notes
+
+This is the **schema-only** v0.1.0 — no producer logic, no replay
+engine. ADJ08 (replay tooling) is a planned follow-up that depends
+on this crate. The checker passes (ADJ02–05) will each gain an
+output type that fits into `CheckerResult.violations`.
+
+Reference: [ADJ07](../../../specs/ADJ07-audit-trail-schema.md).

--- a/code/packages/rust/adjudication-audit-trail/Cargo.toml
+++ b/code/packages/rust/adjudication-audit-trail/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "adjudication-audit-trail"
+version = "0.1.0"
+edition = "2021"
+description = "ADJ07 v0.1 — JSON-serializable audit-trail schema for the adjudication framework. Pure data types: AuditTrail / Document / CheckerResult / Violation / EngineArtifacts / Configuration / AdjudicationOutcome / VersionedComponent. Stores IR-node payloads opaquely (serde_json::Value) at v0.1; v0.2 will type them once adjudication-ir is Serialize."
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/code/packages/rust/adjudication-audit-trail/README.md
+++ b/code/packages/rust/adjudication-audit-trail/README.md
@@ -1,0 +1,105 @@
+# adjudication-audit-trail (Rust)
+
+JSON-serializable audit-trail schema for the adjudication framework.
+Reference implementation of
+[ADJ07 — Audit Trail Schema](../../../specs/ADJ07-audit-trail-schema.md).
+
+## What This Is
+
+> The IR is the audit trail. Every fact in the engine, every rule
+> that fires, every clarification turn, every checker-pass decision,
+> every proof step — all of these chain back without gaps to the
+> source bytes of the original document. The chain is **data**, not
+> commentary.
+
+This crate is the *shape* of that chain. Pure data types with
+`serde::{Serialize, Deserialize}` derives — no I/O, no behaviour
+beyond round-tripping through JSON. Producers (the checker passes,
+the engine, the dialogue layer) build up an [`AuditTrail`] as the
+adjudication runs; the trail is then handed to whatever persistence
+layer the deployment uses (inline response, append-only log,
+content-addressed storage).
+
+## Where It Fits
+
+```text
+   adjudication-coverage  -.
+   adjudication-polarity   |
+   adjudication-round-trip |---> audit-trail (this crate) ---> persistence
+   adjudication-adversary  |
+   logic-engine           -'
+   dialogue                /
+   primitives             /
+```
+
+## Public API
+
+| Item | Role |
+|---|---|
+| `AuditTrail` | Top-level. Carries id, timestamps, outcome, documents, IR nodes, checker results, dialogue, engine artifacts, configuration, schema version |
+| `AdjudicationId` / `DocumentId` / `NodeId` / `TurnId` | Stable string / integer identifiers |
+| `Document`, `NormalizationRecord`, `AppendInfo` | Input documents with byte-offset provenance |
+| `IrNode` | Per-node payload (opaque `serde_json::Value` at v0.1; typed at v0.2) |
+| `CheckerResult`, `Violation`, `PassName`, `PassOutcome`, `ClarificationKind` | Checker-pass results and per-violation detail |
+| `DialogueTurn`, `DialogueRung`, `DialogueResponse`, `DialogueOutcome`, `DialogueResponseSource` | ADJ06 dialogue records |
+| `EngineArtifacts`, `KbSummary`, `BooleanFormula`, `WmcResult`, `SearchMode` | LP19 engine output + probabilistic-inference artifacts |
+| `Configuration`, `VersionedComponent` | Reproducibility-relevant configuration |
+| `AdjudicationOutcome` | `InProgress` / `Resolved` / `ClarificationExhausted` / `Aborted` / `TimedOut` |
+| `AppendedRecord` | Optional content-addressed chaining for tamper-evidence |
+
+## Why IR nodes are opaque at v0.1
+
+`adjudication-ir`'s IR types don't yet derive `Serialize` /
+`Deserialize`. Rather than block the audit-trail schema on that
+refactor, v0.1 stores each `IrNode.payload` as a `serde_json::Value`.
+v0.2 will replace the payload type with `adjudication_ir::IRNode`
+once that crate gains serde derives. The **on-wire JSON shape stays
+the same** — only the static type signature changes — so consumers
+who serialize their typed IR via `serde_json::to_value` today won't
+break tomorrow.
+
+## Usage
+
+```rust
+use adjudication_audit_trail::*;
+
+let mut trail = AuditTrail::new(
+    AdjudicationId::new("adj-1"),
+    "2026-05-11T08:00:00Z",
+);
+
+trail.documents.push(Document {
+    id: DocumentId::new("doc1"),
+    name: "tsa_declaration".into(),
+    received_at: "2026-05-11T08:00:00Z".into(),
+    normalized_text: "1 carry-on bag, 1 personal item.".into(),
+    normalization: NormalizationRecord {
+        pipeline: "plain-text-v1".into(),
+        version: "1.0.0".into(),
+        options: Default::default(),
+    },
+    raw_base64: None,
+    appended_turns: Vec::new(),
+});
+
+trail.outcome = AdjudicationOutcome::Resolved {
+    answer: serde_json::json!({"allowed": true}),
+};
+trail.completed_at = Some("2026-05-11T08:00:05Z".into());
+
+let json = serde_json::to_string_pretty(&trail).unwrap();
+```
+
+## JSON Conventions
+
+- Enums serialize with `#[serde(rename_all = "snake_case")]` (e.g.
+  `PassName::Adj04RoundTrip` → `"adj04_round_trip"`).
+- `AdjudicationOutcome` is an internally-tagged enum with
+  `tag = "kind"`: `{"kind": "resolved", "answer": ...}`.
+- `SearchMode` uses `PascalCase` to match LP19's existing wire format.
+- Optional fields (`raw_base64`, `formula`, `wmc_result`, ...) are
+  omitted from JSON when `None` to keep typical trails compact.
+- Vectors and maps with default-empty values omit themselves when
+  empty (`#[serde(default, skip_serializing_if = "Vec::is_empty")]`).
+- All deserialization is forward-compatible: missing optional or
+  default-valued fields fall back to their `Default` impl.

--- a/code/packages/rust/adjudication-audit-trail/required_capabilities.json
+++ b/code/packages/rust/adjudication-audit-trail/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/adjudication-audit-trail",
+  "capabilities": [],
+  "justification": "Pure data types with serde derives. No I/O, no filesystem, no network. Producers and persistence layers consume this crate's types but the crate itself does not perform any side effects."
+}

--- a/code/packages/rust/adjudication-audit-trail/src/lib.rs
+++ b/code/packages/rust/adjudication-audit-trail/src/lib.rs
@@ -1,0 +1,730 @@
+//! # adjudication-audit-trail — the IR is the audit trail
+//!
+//! Reference implementation of [`ADJ07`](../../../specs/ADJ07-audit-trail-schema.md).
+//!
+//! The framework's audit story is "every byte of every verdict chains
+//! back to the source bytes of the original document, as data, not
+//! commentary." This crate is the **shape** of that chain: a tree of
+//! plain Rust types annotated with `serde` so the whole thing
+//! round-trips through JSON.
+//!
+//! This is intentionally **pure data types** — no I/O, no behaviour
+//! beyond `Serialize` / `Deserialize`. Producers (the checker passes
+//! in `adjudication-coverage`, `-polarity-modality`, `-round-trip`,
+//! `-adversarial`, plus the engine and the dialogue) build up an
+//! [`AuditTrail`] as the adjudication runs. The trail is then handed
+//! to whatever persistence layer the deployment uses (inline
+//! response, append-only log, content-addressed storage).
+//!
+//! ## Why opaque [`IrNodePayload`]
+//!
+//! ADJ01 v2 ([`adjudication_ir::IRNode`]) is the canonical IR shape,
+//! but `adjudication-ir` does not yet derive `Serialize` /
+//! `Deserialize`. To keep this PR small and let the schema land
+//! independently, [`IrNode`] in v0.1 stores the node payload as a
+//! `serde_json::Value` plus the node id. v0.2 will replace the
+//! `serde_json::Value` with a typed `adjudication_ir::IRNode` once
+//! that crate gets serde derives.
+//!
+//! Consumers can already serialize their own typed IR nodes into
+//! `serde_json::Value` via `serde_json::to_value` (after they
+//! gain `Serialize`) and drop them into the audit trail unchanged —
+//! when the upgrade happens, only the type signature changes; the
+//! on-wire shape stays the same.
+//!
+//! ## Schema versioning
+//!
+//! Every top-level structure carries a `schema_version` string. The
+//! v0.1 schema is `"ADJ07-v1"`. Bumping the schema (additive vs.
+//! breaking) is the audited way to evolve the trail format.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+// ---------------------------------------------------------------------------
+// Top-level identifiers
+// ---------------------------------------------------------------------------
+
+/// Stable per-run identifier. Conventionally a UUIDv7, but the schema
+/// only requires a non-empty string so deployments can choose the
+/// id scheme that fits their existing observability.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AdjudicationId(pub String);
+
+impl AdjudicationId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+/// Per-document identifier, scoped to one adjudication.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DocumentId(pub String);
+
+impl DocumentId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+/// Per-node identifier from the IR (mirrors `adjudication_ir::NodeId`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct NodeId(pub String);
+
+impl NodeId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+/// Per-turn identifier within an adjudication's dialogue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TurnId(pub u64);
+
+// ---------------------------------------------------------------------------
+// Top-level structure
+// ---------------------------------------------------------------------------
+
+/// The full audit trail of one adjudication run. Persistence-layer
+/// neutral: a deployment can serialize this whole struct to one
+/// JSON file, stream it incrementally as an append-only log, or
+/// shard substructures across a database.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AuditTrail {
+    pub adjudication_id: AdjudicationId,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub outcome: AdjudicationOutcome,
+    pub documents: Vec<Document>,
+    pub ir_nodes: Vec<IrNode>,
+    pub checker_results: Vec<CheckerResult>,
+    pub dialogue: Vec<DialogueTurn>,
+    pub engine_artifacts: Option<EngineArtifacts>,
+    pub configuration: Configuration,
+    pub schema_version: String,
+}
+
+impl AuditTrail {
+    /// Schema version constant. Bumped on any breaking change. Additive
+    /// fields (with `#[serde(default)]`) do not require a bump.
+    pub const CURRENT_SCHEMA_VERSION: &'static str = "ADJ07-v1";
+
+    /// Construct an empty in-progress trail. Producers add documents,
+    /// IR nodes, checker results, etc. as the adjudication runs.
+    pub fn new(adjudication_id: AdjudicationId, started_at: impl Into<String>) -> Self {
+        Self {
+            adjudication_id,
+            started_at: started_at.into(),
+            completed_at: None,
+            outcome: AdjudicationOutcome::InProgress,
+            documents: Vec::new(),
+            ir_nodes: Vec::new(),
+            checker_results: Vec::new(),
+            dialogue: Vec::new(),
+            engine_artifacts: None,
+            configuration: Configuration::default(),
+            schema_version: Self::CURRENT_SCHEMA_VERSION.to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Documents
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Document {
+    pub id: DocumentId,
+    pub name: String,
+    pub received_at: String,
+    pub normalized_text: String,
+    pub normalization: NormalizationRecord,
+    /// Raw original bytes if the deployment policy retains them.
+    /// Stored base64-encoded in JSON; absent means "normalized text
+    /// only retained."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_base64: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub appended_turns: Vec<AppendInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NormalizationRecord {
+    pub pipeline: String,
+    pub version: String,
+    #[serde(default)]
+    pub options: BTreeMap<String, serde_json::Value>,
+}
+
+/// Records the byte-offset range that a clarification turn appended
+/// to the normalized text. Lets the IR's span offsets remain valid
+/// after a clarification grows the document.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AppendInfo {
+    pub turn_id: TurnId,
+    pub start_offset: usize,
+    pub end_offset: usize,
+    pub appended_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// IR nodes (opaque at v0.1)
+// ---------------------------------------------------------------------------
+
+/// An IR node payload as it appears in the trail. v0.1 stores the
+/// node opaquely as `serde_json::Value` to keep this crate
+/// independent of the (currently non-Serialize) `adjudication-ir`
+/// types. The `id` is duplicated at this level so the trail is
+/// indexable without parsing the payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IrNode {
+    pub id: NodeId,
+    pub document_id: DocumentId,
+    /// The full ADJ01 v2 node serialized as a JSON value. v0.2 will
+    /// replace this with a typed `adjudication_ir::IRNode` once
+    /// that crate gets serde derives.
+    pub payload: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Checker results
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CheckerResult {
+    pub pass_name: PassName,
+    pub pass_version: String,
+    pub started_at: String,
+    pub completed_at: String,
+    pub outcome: PassOutcome,
+    #[serde(default)]
+    pub violations: Vec<Violation>,
+    #[serde(default)]
+    pub telemetry: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PassName {
+    Adj02Coverage,
+    Adj03PolarityModality,
+    Adj04RoundTrip,
+    Adj05Adversarial,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PassOutcome {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Violation {
+    pub node_id: NodeId,
+    pub pass_name: PassName,
+    pub kind: ClarificationKind,
+    /// Pass-specific extra fields. Each pass's spec defines its own
+    /// `detail` schema; this stays open-ended so the trail crate
+    /// doesn't have to be updated for every new pass detail.
+    #[serde(default)]
+    pub detail: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triggered_dialogue_turn: Option<TurnId>,
+    #[serde(default)]
+    pub resolved: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Dialogue (per ADJ06)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClarificationKind {
+    UncoveredSpan,
+    AmbiguousPolarity,
+    AmbiguousModality,
+    RoundTripDrift,
+    AdversarialReading,
+    InheritChainUnresolved,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DialogueRung {
+    /// Re-prompt the same LLM with a correction.
+    Rung1ReprompT,
+    /// Ask a different LLM acting as second opinion.
+    Rung2SecondOpinion,
+    /// Ask a human reviewer.
+    Rung3Human,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DialogueResponseSource {
+    Llm,
+    Human,
+    Cached,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DialogueResponse {
+    pub source: DialogueResponseSource,
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DialogueOutcome {
+    Resolved,
+    Escalated,
+    Abandoned,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DialogueTurn {
+    pub turn_id: TurnId,
+    pub at: String,
+    pub triggering_violation: Option<usize>, // index into checker_results[*].violations
+    pub rung: DialogueRung,
+    pub question_text: String,
+    pub response: DialogueResponse,
+    pub outcome: DialogueOutcome,
+}
+
+// ---------------------------------------------------------------------------
+// Engine artifacts
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum SearchMode {
+    FindFirst,
+    EnumerateAll,
+    AutoDetect,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KbSummary {
+    pub fact_count: usize,
+    pub rule_count: usize,
+    pub fact_ids: Vec<String>,
+    pub rule_ids: Vec<String>,
+    pub all_certain: bool,
+}
+
+/// d-DNNF / SDD / naive — kept opaque at v0.1 so the trail crate
+/// doesn't pin a probabilistic-inference encoding before LP19's
+/// formula representation stabilises.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BooleanFormula {
+    pub encoding: String,
+    pub payload: serde_json::Value,
+    pub fact_vars: BTreeMap<String, u32>,
+    pub rule_vars: BTreeMap<String, u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WmcResult {
+    pub probability: f64,
+    pub method: String,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EngineArtifacts {
+    pub engine_version: String,
+    pub search_mode: SearchMode,
+    pub kb_summary: KbSummary,
+    /// LP19's proof DAG. Kept as JSON until logic-engine ships its
+    /// own typed Serialize.
+    pub proof_dag: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub formula: Option<BooleanFormula>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wmc_result: Option<WmcResult>,
+    pub answer: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Records which component (model, tagger, prompt set, rendering
+/// function) ran with which version. *Reproducibility requires this*
+/// — running the same input through the same `Configuration` should
+/// produce the same `AuditTrail` modulo recorded non-determinism
+/// (temperature, sampling seed).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct VersionedComponent {
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub config: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct Configuration {
+    pub tagger: VersionedComponent,
+    pub trigger_taxonomy: VersionedComponent,
+    pub extractor_model: VersionedComponent,
+    pub renderer_model: VersionedComponent,
+    pub nli_model: VersionedComponent,
+    pub adversary_model: VersionedComponent,
+    pub judge_model: VersionedComponent,
+    pub rendering_function: VersionedComponent,
+    #[serde(default)]
+    pub coverage_strictness: String,
+    #[serde(default)]
+    pub polarity_modality_strictness: String,
+    #[serde(default)]
+    pub round_trip_strictness: String,
+    #[serde(default)]
+    pub adversary_sample_rate: f64,
+    #[serde(default)]
+    pub escalation_policy: String,
+    #[serde(default)]
+    pub schema_version: String,
+}
+
+// ---------------------------------------------------------------------------
+// Outcome
+// ---------------------------------------------------------------------------
+
+/// What happened at the end of the adjudication. `InProgress` is the
+/// transient state for an in-flight trail; terminal states carry the
+/// answer (`Resolved`), the unresolved violations
+/// (`ClarificationExhausted`), or the reason for early termination
+/// (`Aborted`, `TimedOut`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AdjudicationOutcome {
+    InProgress,
+    Resolved {
+        answer: serde_json::Value,
+    },
+    ClarificationExhausted {
+        unresolved: Vec<Violation>,
+    },
+    Aborted {
+        reason: String,
+    },
+    TimedOut,
+}
+
+// ---------------------------------------------------------------------------
+// Optional integrity chaining (per ADJ07 §"Cryptographic Integrity")
+// ---------------------------------------------------------------------------
+
+/// Wraps one appended record in a content-addressed chain. The trail
+/// crate does NOT compute the hashes — deployment chooses the hash
+/// algorithm and computes hashes at append time. The shape is
+/// preserved so reviewers can verify the chain by re-hashing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AppendedRecord {
+    pub record: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prev_hash: Option<String>,
+    pub record_hash: String,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_doc() -> Document {
+        Document {
+            id: DocumentId::new("doc1"),
+            name: "tsa_declaration".into(),
+            received_at: "2026-05-11T08:00:00Z".into(),
+            normalized_text: "1 carry-on bag, 1 personal item.".into(),
+            normalization: NormalizationRecord {
+                pipeline: "plain-text-v1".into(),
+                version: "1.0.0".into(),
+                options: BTreeMap::new(),
+            },
+            raw_base64: None,
+            appended_turns: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn new_trail_is_in_progress_and_minimal() {
+        let t = AuditTrail::new(
+            AdjudicationId::new("adj-1"),
+            "2026-05-11T08:00:00Z",
+        );
+        assert_eq!(t.adjudication_id.0, "adj-1");
+        assert!(matches!(t.outcome, AdjudicationOutcome::InProgress));
+        assert!(t.completed_at.is_none());
+        assert!(t.documents.is_empty());
+        assert_eq!(t.schema_version, "ADJ07-v1");
+    }
+
+    #[test]
+    fn audit_trail_roundtrips_through_json() {
+        let mut t = AuditTrail::new(
+            AdjudicationId::new("adj-1"),
+            "2026-05-11T08:00:00Z",
+        );
+        t.documents.push(sample_doc());
+        t.outcome = AdjudicationOutcome::Resolved {
+            answer: serde_json::json!({"allowed": true}),
+        };
+        t.completed_at = Some("2026-05-11T08:00:05Z".into());
+
+        let s = serde_json::to_string(&t).unwrap();
+        let back: AuditTrail = serde_json::from_str(&s).unwrap();
+        assert_eq!(t, back);
+    }
+
+    #[test]
+    fn outcome_serializes_with_kind_tag() {
+        let o = AdjudicationOutcome::Resolved {
+            answer: serde_json::json!({"x": 1}),
+        };
+        let s = serde_json::to_value(&o).unwrap();
+        assert_eq!(s["kind"], "resolved");
+        assert_eq!(s["answer"]["x"], 1);
+    }
+
+    #[test]
+    fn timed_out_serializes_as_kind_only() {
+        let o = AdjudicationOutcome::TimedOut;
+        let s = serde_json::to_value(&o).unwrap();
+        assert_eq!(s["kind"], "timed_out");
+    }
+
+    #[test]
+    fn clarification_exhausted_serializes_with_unresolved() {
+        let v = Violation {
+            node_id: NodeId::new("n1"),
+            pass_name: PassName::Adj02Coverage,
+            kind: ClarificationKind::UncoveredSpan,
+            detail: serde_json::json!({"range": [3, 10]}),
+            triggered_dialogue_turn: None,
+            resolved: false,
+        };
+        let o = AdjudicationOutcome::ClarificationExhausted {
+            unresolved: vec![v],
+        };
+        let s = serde_json::to_string(&o).unwrap();
+        assert!(s.contains("\"kind\":\"clarification_exhausted\""));
+        assert!(s.contains("\"uncovered_span\""));
+    }
+
+    #[test]
+    fn pass_name_round_trips_in_snake_case() {
+        let cr = CheckerResult {
+            pass_name: PassName::Adj04RoundTrip,
+            pass_version: "1.0".into(),
+            started_at: "2026-05-11T08:00:01Z".into(),
+            completed_at: "2026-05-11T08:00:02Z".into(),
+            outcome: PassOutcome::Passed,
+            violations: Vec::new(),
+            telemetry: BTreeMap::new(),
+        };
+        let s = serde_json::to_string(&cr).unwrap();
+        assert!(s.contains("\"pass_name\":\"adj04_round_trip\""));
+        let back: CheckerResult = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.pass_name, PassName::Adj04RoundTrip);
+    }
+
+    #[test]
+    fn violation_omits_empty_optional_fields_in_json() {
+        let v = Violation {
+            node_id: NodeId::new("n1"),
+            pass_name: PassName::Adj03PolarityModality,
+            kind: ClarificationKind::AmbiguousPolarity,
+            detail: serde_json::Value::Null,
+            triggered_dialogue_turn: None,
+            resolved: false,
+        };
+        let s = serde_json::to_value(&v).unwrap();
+        assert!(s.get("triggered_dialogue_turn").is_none());
+    }
+
+    #[test]
+    fn dialogue_turn_round_trips() {
+        let t = DialogueTurn {
+            turn_id: TurnId(1),
+            at: "2026-05-11T08:00:03Z".into(),
+            triggering_violation: Some(0),
+            rung: DialogueRung::Rung2SecondOpinion,
+            question_text: "Did the passenger declare a third bag?".into(),
+            response: DialogueResponse {
+                source: DialogueResponseSource::Llm,
+                text: "No.".into(),
+                actor_id: Some("anthropic/claude-haiku".into()),
+                model_version: Some("4-5-20251001".into()),
+            },
+            outcome: DialogueOutcome::Resolved,
+        };
+        let s = serde_json::to_string(&t).unwrap();
+        let back: DialogueTurn = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn engine_artifacts_serializes_minimal_form() {
+        let e = EngineArtifacts {
+            engine_version: "logic-engine 0.4.0".into(),
+            search_mode: SearchMode::FindFirst,
+            kb_summary: KbSummary {
+                fact_count: 3,
+                rule_count: 1,
+                fact_ids: vec!["f1".into(), "f2".into(), "f3".into()],
+                rule_ids: vec!["r1".into()],
+                all_certain: true,
+            },
+            proof_dag: serde_json::json!({"root": "f1"}),
+            formula: None,
+            wmc_result: None,
+            answer: serde_json::json!({"allowed": true}),
+        };
+        let s = serde_json::to_value(&e).unwrap();
+        assert!(s.get("formula").is_none()); // skipped because None
+        assert_eq!(s["kb_summary"]["fact_count"], 3);
+        assert_eq!(s["search_mode"], "FindFirst");
+    }
+
+    #[test]
+    fn engine_artifacts_serializes_probabilistic_form() {
+        let e = EngineArtifacts {
+            engine_version: "logic-engine 0.4.0".into(),
+            search_mode: SearchMode::EnumerateAll,
+            kb_summary: KbSummary {
+                fact_count: 1,
+                rule_count: 0,
+                fact_ids: vec!["f1".into()],
+                rule_ids: Vec::new(),
+                all_certain: false,
+            },
+            proof_dag: serde_json::json!({}),
+            formula: Some(BooleanFormula {
+                encoding: "d-DNNF".into(),
+                payload: serde_json::json!({"nodes": []}),
+                fact_vars: [("f1".to_string(), 0)].into_iter().collect(),
+                rule_vars: BTreeMap::new(),
+            }),
+            wmc_result: Some(WmcResult {
+                probability: 0.73,
+                method: "d-DNNF-eval".into(),
+                elapsed_ms: 12,
+            }),
+            answer: serde_json::Value::Null,
+        };
+        let s = serde_json::to_value(&e).unwrap();
+        assert_eq!(s["formula"]["encoding"], "d-DNNF");
+        assert!((s["wmc_result"]["probability"].as_f64().unwrap() - 0.73).abs() < 1e-9);
+    }
+
+    #[test]
+    fn configuration_round_trips_with_versioned_components() {
+        let cfg = Configuration {
+            extractor_model: VersionedComponent {
+                name: "anthropic/claude-opus".into(),
+                version: "4-7-20260301".into(),
+                config: [("temperature".into(), serde_json::json!(0.0))]
+                    .into_iter()
+                    .collect(),
+            },
+            adversary_sample_rate: 0.25,
+            escalation_policy: "strict-cheap-first".into(),
+            ..Configuration::default()
+        };
+
+        let s = serde_json::to_string(&cfg).unwrap();
+        let back: Configuration = serde_json::from_str(&s).unwrap();
+        assert_eq!(cfg, back);
+        assert_eq!(back.extractor_model.config["temperature"], 0.0);
+    }
+
+    #[test]
+    fn append_info_records_byte_range() {
+        let a = AppendInfo {
+            turn_id: TurnId(7),
+            start_offset: 100,
+            end_offset: 142,
+            appended_at: "2026-05-11T08:00:04Z".into(),
+        };
+        let s = serde_json::to_value(&a).unwrap();
+        assert_eq!(s["start_offset"], 100);
+        assert_eq!(s["end_offset"], 142);
+        assert_eq!(s["turn_id"], 7);
+    }
+
+    #[test]
+    fn ir_node_is_opaque_payload_at_v01() {
+        let n = IrNode {
+            id: NodeId::new("n1"),
+            document_id: DocumentId::new("doc1"),
+            payload: serde_json::json!({
+                "kind": "Fact",
+                "term": "carry_on(1)",
+                "polarity": "Affirmed",
+            }),
+        };
+        let s = serde_json::to_string(&n).unwrap();
+        let back: IrNode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.id.0, "n1");
+        assert_eq!(back.payload["kind"], "Fact");
+    }
+
+    #[test]
+    fn appended_record_chains_via_hash() {
+        let r1 = AppendedRecord {
+            record: serde_json::json!({"step": 1}),
+            prev_hash: None,
+            record_hash: "abc".into(),
+        };
+        let r2 = AppendedRecord {
+            record: serde_json::json!({"step": 2}),
+            prev_hash: Some("abc".into()),
+            record_hash: "def".into(),
+        };
+        // Just shape: the chain is "r2.prev_hash == r1.record_hash"
+        assert_eq!(r2.prev_hash.as_deref(), Some(r1.record_hash.as_str()));
+    }
+
+    #[test]
+    fn schema_version_constant_is_v1() {
+        assert_eq!(AuditTrail::CURRENT_SCHEMA_VERSION, "ADJ07-v1");
+    }
+
+    #[test]
+    fn deserialize_tolerates_missing_optional_fields() {
+        // Forward-compatibility: a future producer might omit
+        // appended_turns; the schema should accept that.
+        let s = r#"{
+            "id": "doc1",
+            "name": "x",
+            "received_at": "2026-05-11T00:00:00Z",
+            "normalized_text": "hi",
+            "normalization": {
+                "pipeline": "plain",
+                "version": "1"
+            }
+        }"#;
+        let d: Document = serde_json::from_str(s).unwrap();
+        assert!(d.appended_turns.is_empty());
+        assert!(d.raw_base64.is_none());
+        assert!(d.normalization.options.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- New crate \`code/packages/rust/adjudication-audit-trail/\` — pure data types with serde derives, no I/O.
- Reference implementation of [ADJ07](../../code/specs/ADJ07-audit-trail-schema.md): \`AuditTrail\`, \`Document\`, \`CheckerResult\`, \`Violation\`, \`DialogueTurn\`, \`EngineArtifacts\`, \`Configuration\`, \`AdjudicationOutcome\`, etc.
- 16 tests, all passing. Clippy clean.
- Security review: PASSED, no findings.
- **Fork-point**: once merged, every checker pass (ADJ02–05), the engine, dialogue, and primitives can write into the trail in parallel.

## Why fork-point

The audit trail touches every part of the pipeline:

\`\`\`text
   adjudication-coverage  -.
   adjudication-polarity   |
   adjudication-round-trip |---> audit-trail (this PR) ---> persistence
   adjudication-adversary  |
   logic-engine           -'
   dialogue                /
   primitives             /
\`\`\`

Today none of those producers can write a structured trail because the schema doesn't exist. Once this lands, the next ~5 PRs (one per producer) can land in parallel.

## Notable design decisions

- **\`IrNode.payload\` is \`serde_json::Value\` at v0.1**. \`adjudication-ir\`'s IRNode doesn't derive Serialize today. Rather than block ADJ07 on that refactor, payloads are opaque. v0.2 will swap to a typed \`adjudication_ir::IRNode\` once that crate ships serde derives — **on-wire JSON shape is unchanged across the upgrade**.
- **\`AdjudicationOutcome\` is internally tagged** (\`tag = \"kind\"\`, snake-case): \`{\"kind\":\"resolved\",\"answer\":...}\`. \`InProgress\` is the transient state for an in-flight trail; terminal states carry the answer or the unresolved violations.
- **Enums snake_case, SearchMode PascalCase** to match LP19's existing wire format.
- **Forward-compatible deserialization**: every optional / collection field has \`#[serde(default)]\` so a future producer can omit fields safely.
- **\`AppendedRecord\` shape only**: the deployment computes hashes; this crate documents the chain shape so reviewers can verify by re-hashing.

## Independent of #2703, #2704

This PR depends only on \`serde\` + \`serde_json\` (already used widely in the workspace). Independent of the LLM-side PRs ([#2703](https://github.com/adhithyan15/coding-adventures/pull/2703) primitives, [#2704](https://github.com/adhithyan15/coding-adventures/pull/2704) Ollama).

## Test plan

- [x] \`cargo test -p adjudication-audit-trail\` — 16/16 pass
- [x] \`cargo clippy -p adjudication-audit-trail --tests -- -D warnings\` — clean
- [x] Security review — passed
- [ ] CI green
- [ ] After merge: producer PRs for each checker pass / engine / dialogue write into AuditTrail

🤖 Generated with [Claude Code](https://claude.com/claude-code)