### PR TITLE
feat(pdf417): add render_png() → PNG bytes via barcode-2d rendering hub

### DIFF
--- a/code/packages/rust/barcode-2d/CHANGELOG.md
+++ b/code/packages/rust/barcode-2d/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog — barcode-2d (Rust)
 
+## 0.2.0 — 2026-05-11
+
+### Added
+
+- **Native rendering pipeline** — `barcode-2d` is now the shared rendering hub
+  for all 2D barcode formats. Any `PaintScene` produced by `encode_and_layout()`
+  in `qr-code`, `pdf417`, `aztec-code`, `data-matrix`, or `micro-qr` can be
+  passed directly to the render functions below.
+
+- `current_backend() -> &'static str` — reports the platform-default backend
+  name (`"direct2d"`, `"metal"`, `"cairo"`, or `"skia"`).
+
+- `render_scene(scene: &PaintScene) -> Result<PixelContainer, String>` —
+  renders using the platform-default backend. Priority order:
+  Windows → Direct2D, macOS → Metal, Linux/BSD → Cairo, all others → Skia.
+
+- `render_scene_png(scene: &PaintScene) -> Result<Vec<u8>, String>` —
+  convenience wrapper: render → PNG bytes. The standard entry point for
+  per-format wrappers in `qr-code`, `pdf417`, etc.
+
+- `render_scene_with_backend(scene: &PaintScene, backend: &str) -> Result<PixelContainer, String>` —
+  explicit backend selection. Accepts `"skia"`, `"cairo"`, `"metal"`,
+  `"direct2d"`. Returns `Err` for unknown names or unavailable backends.
+
+- `render_scene_png_with_backend(scene: &PaintScene, backend: &str) -> Result<Vec<u8>, String>` —
+  explicit backend + PNG output. Useful for CI tests that pin a backend.
+
+### Changed
+
+- `VERSION` bumped to `"0.2.0"`.
+- Description updated to reflect the crate's dual role as layout hub AND
+  rendering hub.
+
+### Dependencies added
+
+- `paint-codec-png` — PNG encoding.
+- `paint-vm-runtime` — `PaintRenderError` type.
+- `paint-vm-skia` — Skia CPU raster backend (all platforms).
+- `paint-vm-cairo` — Cairo backend (macOS, Linux, BSD; system `cairo` required).
+- `paint-metal` — Metal GPU backend (macOS only).
+- `paint-vm-direct2d` — Direct2D GPU backend (Windows only).
+
+### Tests added (3 unconditional + 1 platform-gated)
+
+- `current_backend_returns_known_name` — backend name is one of the 4 known strings.
+- `skia_renders_tiny_square_to_png` — Skia output is a valid PNG on all platforms.
+- `unknown_backend_returns_error` — descriptive error on bad backend name.
+- `cairo_renders_tiny_square_to_png` — Cairo PNG is valid (macOS/Linux/BSD only).
+- `platform_default_render_produces_png` — default dispatcher produces valid PNG.
+
+**Total tests: 44 (43 unit + 1 doctest).**
+
 ## 0.1.0 — 2026-04-23
 
 Initial release.

--- a/code/packages/rust/barcode-2d/Cargo.toml
+++ b/code/packages/rust/barcode-2d/Cargo.toml
@@ -1,8 +1,20 @@
 [package]
 name = "barcode-2d"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Shared 2D barcode abstraction: ModuleGrid type and layout() pipeline"
+description = "Shared 2D barcode abstraction: ModuleGrid type, layout() pipeline, and native rendering hub"
 
 [dependencies]
 paint-instructions = { path = "../paint-instructions" }
+paint-codec-png = { path = "../paint-codec-png" }
+paint-vm-runtime = { path = "../paint-vm-runtime" }
+paint-vm-skia = { path = "../paint-vm-skia" }
+
+[target.'cfg(target_vendor = "apple")'.dependencies]
+paint-metal = { path = "../paint-metal" }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+paint-vm-direct2d = { path = "../paint-vm-direct2d" }
+
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
+paint-vm-cairo = { path = "../paint-vm-cairo" }

--- a/code/packages/rust/barcode-2d/src/lib.rs
+++ b/code/packages/rust/barcode-2d/src/lib.rs
@@ -34,10 +34,10 @@
 //! - **Hex** (flat-top hexagons): MaxiCode (ISO/IEC 16023).
 //!   Each dark module becomes a [`PaintPath`] tracing six vertices.
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 use paint_instructions::{
-    PaintBase, PaintInstruction, PaintPath, PaintRect, PaintScene, PathCommand,
+    PaintBase, PaintInstruction, PaintPath, PaintRect, PaintScene, PathCommand, PixelContainer,
 };
 use std::f64::consts::PI;
 
@@ -622,6 +622,259 @@ fn build_flat_top_hex_path(cx: f64, cy: f64, r: f64, fill: &str) -> PaintPath {
 }
 
 // ============================================================================
+// Native rendering pipeline
+// ============================================================================
+//
+// `barcode-2d` is the shared rendering hub for ALL 2D barcode formats.
+//
+// Every 2D barcode encoder (qr-code, pdf417, aztec-code, data-matrix, micro-qr)
+// produces a `PaintScene` via `encode_and_layout()`.  The functions below
+// accept that `PaintScene` and convert it to pixels or a PNG byte vector using
+// the best native backend available on the current platform.
+//
+// ## Backend priority (same as barcode-1d)
+//
+// | Platform   | Primary          | Fallback          |
+// |------------|------------------|-------------------|
+// | Windows    | Direct2D (GPU)   | Skia (CPU raster) |
+// | macOS      | Metal (GPU)      | Skia (CPU raster) |
+// | Linux/BSD  | Cairo (CPU)      | Skia (CPU raster) |
+// | Exotic     | —                | Skia (CPU raster) |
+//
+// Skia is statically linked via the `skia-safe` crate, so it works everywhere
+// with no additional system libraries.  Cairo requires a system-level `cairo`
+// package (available on Linux and macOS via `brew install cairo`).
+//
+// ## Function naming
+//
+// Because the 2D barcode pipeline already has `layout()` that accepts a
+// `ModuleGrid` and produces a `PaintScene`, the rendering layer uses the
+// prefix `render_scene_*` to make the input type clear.
+//
+// ```text
+// ModuleGrid
+//   → layout()         → PaintScene    (this crate, existing)
+//   → render_scene()   → PixelContainer (this section)
+//   → encode_png()     → Vec<u8>       (paint-codec-png)
+// ```
+
+use paint_vm_runtime::PaintRenderError;
+
+/// Report the name of the platform-default paint backend.
+///
+/// This matches the backend that `render_scene()` will use when called without
+/// an explicit backend name.  Useful for logging and for conditional test
+/// skipping.
+///
+/// Returns one of `"direct2d"`, `"metal"`, `"cairo"`, or `"skia"`.
+pub fn current_backend() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "direct2d"
+    }
+    #[cfg(all(not(target_os = "windows"), target_vendor = "apple"))]
+    {
+        "metal"
+    }
+    #[cfg(all(
+        not(target_os = "windows"),
+        not(target_vendor = "apple"),
+        any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        )
+    ))]
+    {
+        "cairo"
+    }
+    #[cfg(all(
+        not(target_os = "windows"),
+        not(target_vendor = "apple"),
+        not(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd"
+        ))
+    ))]
+    {
+        "skia"
+    }
+}
+
+/// Render a [`PaintScene`] to a [`PixelContainer`] using the platform-default
+/// backend.
+///
+/// Call this after `encode_and_layout()` (from `qr-code`, `pdf417`, etc.) to
+/// obtain a pixel buffer suitable for PNG encoding.
+///
+/// # Errors
+///
+/// Returns `Err(String)` when the native backend reports a render failure.
+/// This is rare in practice — it typically means Cairo/Metal initialisation
+/// failed (e.g., running headless without a GPU on macOS).  The Skia fallback
+/// path never fails on valid scenes.
+pub fn render_scene(scene: &PaintScene) -> Result<PixelContainer, String> {
+    #[cfg(target_os = "windows")]
+    {
+        return Ok(paint_vm_direct2d::render(scene));
+    }
+
+    #[cfg(all(not(target_os = "windows"), target_vendor = "apple"))]
+    {
+        return Ok(paint_metal::render(scene));
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))]
+    {
+        return paint_vm_cairo::render(scene).map_err(paint_render_error_to_string);
+    }
+
+    // Universal cross-platform fallback via skia-safe (CPU raster).
+    // Reached on macOS (below Metal layer) or any other exotic target.
+    #[allow(unreachable_code)]
+    paint_vm_skia::render(scene).map_err(paint_render_error_to_string)
+}
+
+/// Render a [`PaintScene`] to a PNG byte vector using the platform-default
+/// backend.
+///
+/// Convenience wrapper around `render_scene()` + `paint_codec_png::encode_png()`.
+///
+/// # Example
+///
+/// ```no_run
+/// use barcode_2d::{
+///     make_module_grid, set_module, layout, render_scene_png,
+///     Barcode2DLayoutConfig, ModuleShape,
+/// };
+///
+/// // Normally produced by qr-code, pdf417, aztec-code, data-matrix, or micro-qr.
+/// let grid = set_module(&make_module_grid(1, 1, ModuleShape::Square), 0, 0, true);
+/// let scene = layout(&grid, &Barcode2DLayoutConfig::default()).unwrap();
+/// let png_bytes = render_scene_png(&scene).unwrap();
+/// std::fs::write("barcode.png", &png_bytes).unwrap();
+/// ```
+pub fn render_scene_png(scene: &PaintScene) -> Result<Vec<u8>, String> {
+    let pixels = render_scene(scene)?;
+    Ok(paint_codec_png::encode_png(&pixels))
+}
+
+/// Render a [`PaintScene`] to a [`PixelContainer`] using a named backend.
+///
+/// This is useful for testing with a specific backend or for users who want to
+/// bypass the platform default.
+///
+/// # Backend names
+///
+/// - `"skia"` — Skia CPU raster (all platforms, always available)
+/// - `"cairo"` — Cairo vector raster (Linux, macOS, BSD; requires system `cairo`)
+/// - `"metal"` — Metal GPU (macOS only)
+/// - `"direct2d"` — Direct2D GPU (Windows only)
+///
+/// # Errors
+///
+/// Returns `Err(String)` when the named backend is unavailable on the current
+/// platform, or when `backend` is not one of the four names above.
+pub fn render_scene_with_backend(
+    scene: &PaintScene,
+    backend: &str,
+) -> Result<PixelContainer, String> {
+    match backend {
+        "skia" => paint_vm_skia::render(scene).map_err(paint_render_error_to_string),
+
+        "cairo" => {
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "macos",
+                target_os = "freebsd",
+                target_os = "openbsd",
+                target_os = "netbsd"
+            ))]
+            {
+                paint_vm_cairo::render(scene).map_err(paint_render_error_to_string)
+            }
+            #[cfg(not(any(
+                target_os = "linux",
+                target_os = "macos",
+                target_os = "freebsd",
+                target_os = "openbsd",
+                target_os = "netbsd"
+            )))]
+            {
+                let _ = scene;
+                Err("Cairo backend is not available on this platform".to_string())
+            }
+        }
+
+        "metal" => {
+            #[cfg(target_vendor = "apple")]
+            {
+                Ok(paint_metal::render(scene))
+            }
+            #[cfg(not(target_vendor = "apple"))]
+            {
+                let _ = scene;
+                Err("Metal backend is only available on Apple platforms".to_string())
+            }
+        }
+
+        "direct2d" => {
+            #[cfg(target_os = "windows")]
+            {
+                Ok(paint_vm_direct2d::render(scene))
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let _ = scene;
+                Err("Direct2D backend is only available on Windows".to_string())
+            }
+        }
+
+        _ => Err(format!(
+            "unknown backend: '{backend}'. Use 'skia', 'cairo', 'metal', or 'direct2d'"
+        )),
+    }
+}
+
+/// Render a [`PaintScene`] to a PNG byte vector using a named backend.
+///
+/// See [`render_scene_with_backend`] for the list of backend names.
+pub fn render_scene_png_with_backend(
+    scene: &PaintScene,
+    backend: &str,
+) -> Result<Vec<u8>, String> {
+    let pixels = render_scene_with_backend(scene, backend)?;
+    Ok(paint_codec_png::encode_png(&pixels))
+}
+
+/// Format a [`PaintRenderError`] as a human-readable `String`.
+///
+/// `PaintRenderError` does not implement `std::fmt::Display`; this helper
+/// performs the pattern match manually so call-sites stay concise.
+fn paint_render_error_to_string(error: PaintRenderError) -> String {
+    match error {
+        PaintRenderError::NoBackendsRegistered => "no paint backends registered".to_string(),
+        PaintRenderError::NoCompatibleBackend { missing, .. } => {
+            format!("no compatible backend: missing features {missing:?}")
+        }
+        PaintRenderError::BackendUnavailable { backend, reason } => {
+            format!("backend '{backend}' unavailable: {reason}")
+        }
+        PaintRenderError::RenderFailed { backend, message } => {
+            format!("render failed in backend '{backend}': {message}")
+        }
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -633,7 +886,7 @@ mod tests {
 
     #[test]
     fn version_is_correct() {
-        assert_eq!(VERSION, "0.1.0");
+        assert_eq!(VERSION, "0.2.0");
     }
 
     // ── make_module_grid ─────────────────────────────────────────────────────
@@ -1090,5 +1343,91 @@ mod tests {
     fn default_config_module_shape_square() {
         let cfg = Barcode2DLayoutConfig::default();
         assert_eq!(cfg.module_shape, ModuleShape::Square);
+    }
+
+    // ── Rendering pipeline ───────────────────────────────────────────────────
+    //
+    // These tests exercise the full stack: ModuleGrid → layout() → render_scene*().
+    // We use a tiny 1×1 grid so the scene is trivially small, keeping CI fast.
+
+    /// Helper: build the smallest valid square `PaintScene` for render tests.
+    fn tiny_square_scene() -> PaintScene {
+        let g = set_module(&make_module_grid(1, 1, ModuleShape::Square), 0, 0, true);
+        let config = Barcode2DLayoutConfig {
+            module_size_px: 4.0,
+            quiet_zone_modules: 0,
+            ..Default::default()
+        };
+        layout(&g, &config).unwrap()
+    }
+
+    /// `current_backend()` must return a non-empty string on every platform.
+    #[test]
+    fn current_backend_returns_known_name() {
+        let b = current_backend();
+        assert!(
+            ["skia", "cairo", "metal", "direct2d"].contains(&b),
+            "unexpected backend name: {b}"
+        );
+    }
+
+    /// Skia is the universal fallback — it builds from source via `skia-safe`
+    /// and is always available.  The PNG header magic bytes must be present.
+    #[test]
+    fn skia_renders_tiny_square_to_png() {
+        let scene = tiny_square_scene();
+        let png = render_scene_png_with_backend(&scene, "skia").unwrap();
+        assert!(png.len() > 8, "PNG too small");
+        assert_eq!(
+            &png[0..8],
+            &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+            "not a PNG magic header"
+        );
+    }
+
+    /// Requesting an unknown backend name returns a descriptive error string
+    /// without panicking.
+    #[test]
+    fn unknown_backend_returns_error() {
+        let scene = tiny_square_scene();
+        let err = render_scene_with_backend(&scene, "nonexistent").unwrap_err();
+        assert!(
+            err.contains("nonexistent"),
+            "error should mention the bad backend name: {err}"
+        );
+    }
+
+    /// Cairo renders a valid PNG on macOS and Linux where the system `cairo`
+    /// library is installed.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))]
+    #[test]
+    fn cairo_renders_tiny_square_to_png() {
+        let scene = tiny_square_scene();
+        let png = render_scene_png_with_backend(&scene, "cairo").unwrap();
+        assert!(png.len() > 8, "Cairo PNG too small");
+        assert_eq!(
+            &png[0..8],
+            &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+            "Cairo output is not a PNG"
+        );
+    }
+
+    /// The platform default produces a valid PNG on all platforms.
+    #[test]
+    fn platform_default_render_produces_png() {
+        let scene = tiny_square_scene();
+        let png = render_scene_png(&scene).unwrap();
+        assert!(png.len() > 8, "default backend PNG too small");
+        assert_eq!(
+            &png[0..8],
+            &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
+            "default backend output is not a PNG"
+        );
     }
 }

--- a/code/packages/rust/pdf417/CHANGELOG.md
+++ b/code/packages/rust/pdf417/CHANGELOG.md
@@ -5,6 +5,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.2.0] — 2026-05-11
+
+### Added
+
+- **`render_png(data, options)`** — single-call convenience function that
+  encodes `data` as a PDF417 symbol and renders it directly to PNG bytes.
+  - Internally calls `encode_and_layout()` with the default 2-module quiet
+    zone, then delegates pixel rendering to `barcode_2d::render_scene_png()`.
+  - The rendering backend is selected at runtime by `barcode-2d` (Metal on
+    macOS, Cairo on Linux, Direct2D on Windows, Skia elsewhere).
+  - Returns `Result<Vec<u8>, String>` — errors from both the encoder and the
+    renderer are mapped to `String` for ergonomic `.unwrap()` / `?` usage.
+- **`pdf417_render_png_produces_valid_png`** test — encodes `b"HELLO"` with
+  default options and asserts the PNG magic bytes
+  `[0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A]` are present.
+
+---
+
 ## [0.1.0] — 2026-04-24
 
 ### Added

--- a/code/packages/rust/pdf417/Cargo.toml
+++ b/code/packages/rust/pdf417/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf417"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "PDF417 stacked linear barcode encoder — ISO/IEC 15438:2015 compliant, produces scannable PDF417 symbols"
 

--- a/code/packages/rust/pdf417/src/lib.rs
+++ b/code/packages/rust/pdf417/src/lib.rs
@@ -37,7 +37,7 @@
 //! This release implements **byte compaction only**. All inputs are treated as
 //! raw bytes. Text and numeric compaction are planned for v0.2.0.
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 mod tables;
 use tables::{CLUSTER_TABLES, START_PATTERN, STOP_PATTERN};
@@ -597,6 +597,41 @@ pub fn encode_and_layout(
     Ok(scene)
 }
 
+/// Encode `data` as a PDF417 symbol and render it to PNG bytes.
+///
+/// This is the single-call convenience path from raw bytes to a PNG image.
+/// Internally it:
+///
+/// 1. Calls [`encode_and_layout()`] with default layout config (2-module quiet
+///    zone) to produce a [`PaintScene`].
+/// 2. Delegates pixel rendering to [`barcode_2d::render_scene_png()`], which
+///    dispatches to the platform-default backend (Metal on macOS, Cairo on
+///    Linux, Direct2D on Windows, Skia elsewhere).
+///
+/// # Arguments
+///
+/// - `data` — raw bytes to encode; all inputs are treated as byte compaction.
+/// - `options` — encoding options (ECC level, columns, row height).
+///
+/// # Returns
+///
+/// A `Vec<u8>` containing a valid PNG file, or a `String` error message if
+/// encoding or rendering fails.
+///
+/// # Example
+///
+/// ```rust
+/// # use pdf417::{render_png, PDF417Options};
+/// let png = render_png(b"HELLO", &PDF417Options::default()).unwrap();
+/// // PNG magic bytes: 0x89 'P' 'N' 'G' 0x0D 0x0A 0x1A 0x0A
+/// assert_eq!(&png[..8], &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]);
+/// ```
+pub fn render_png(data: &[u8], options: &PDF417Options) -> Result<Vec<u8>, String> {
+    let scene = encode_and_layout(data, options, None)
+        .map_err(|e| e.to_string())?;
+    barcode_2d::render_scene_png(&scene)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -999,5 +1034,35 @@ mod tests {
         let scene = result.unwrap();
         assert!(scene.width > 0.0);
         assert!(scene.height > 0.0);
+    }
+
+    #[test]
+    fn pdf417_render_png_produces_valid_png() {
+        // render_png() must return bytes whose first 8 octets are the PNG
+        // magic signature defined in §5.2 of the PNG specification:
+        //   0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
+        //         'P'  'N'  'G'  CR   LF  SUB  LF
+        //
+        // The 0x89 high-bit byte detects 7-bit transmission corruption; the
+        // CRLF/LF pair catches line-ending translations; 0x1A (DOS EOF) stops
+        // accidental `type` display; the trailing LF checks UNIX newline
+        // stripping.  Verifying these bytes confirms the rendering backend
+        // produced a structurally valid PNG file.
+        let png = render_png(b"HELLO", &PDF417Options::default())
+            .expect("render_png should succeed for valid input");
+
+        const PNG_MAGIC: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        assert!(
+            png.len() >= 8,
+            "PNG output is too short ({} bytes) to contain the magic header",
+            png.len()
+        );
+        assert_eq!(
+            &png[..8],
+            &PNG_MAGIC,
+            "First 8 bytes {:?} do not match PNG magic {:?}",
+            &png[..8],
+            &PNG_MAGIC,
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `render_png(data, options) -> Result<Vec<u8>, String>` as a single-call path from PDF417 data to PNG bytes
- Delegates rendering to `barcode_2d::render_scene_png()` — platform-default backend
- Stacked on #2707 (barcode-2d render unlock PR)

## Test plan
- [x] 34 existing tests + 1 doc-test still pass
- [x] `pdf417_render_png_produces_valid_png` — validates PNG magic bytes
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)