### PR TITLE
[codex] Add TypeScript cas-ode homogeneous type parity

### DIFF
--- a/code/packages/typescript/cas-ode/CHANGELOG.md
+++ b/code/packages/typescript/cas-ode/CHANGELOG.md
@@ -6,3 +6,5 @@
 - Ported the main Python `cas-ode` families: first-order linear, separable,
   Bernoulli, exact, second-order constant-coefficient homogeneous and
   nonhomogeneous, Euler-Cauchy, and variation-of-parameters fallback.
+- Added homogeneous-type `D(y,x) = f(y/x)` parity, including the degenerate
+  `y = %c*x` case and symbolic implicit `Integrate(...)` fallback.

--- a/code/packages/typescript/cas-ode/README.md
+++ b/code/packages/typescript/cas-ode/README.md
@@ -15,12 +15,15 @@ return symbolic IR nodes.
 | Separable | `D(y,x) = f(x)*g(y)` |
 | Bernoulli | `D(y,x) + P(x)*y = Q(x)*y^n` |
 | Exact | `M(x,y) + N(x,y)*D(y,x) = 0` |
+| Homogeneous type | `D(y,x) = f(y/x)` |
 | Second-order constant-coefficient homogeneous | `a*y'' + b*y' + c*y = 0` |
 | Second-order constant-coefficient nonhomogeneous | polynomial, exponential, sine, and cosine forcing, with variation-of-parameters fallback |
 | Euler-Cauchy | `a*x^2*y'' + b*x*y' + c*y = 0` |
 
 When an exact primitive is outside the built-in integration table, the solver
 returns symbolic `Integrate(expr, x)` nodes rather than failing the whole ODE.
+For homogeneous-type equations this includes implicit solutions such as
+`Equal(Integrate(1/(f(y/x)-y/x), y/x), Log(x)+%c)`.
 
 ## Usage
 

--- a/code/packages/typescript/cas-ode/src/index.ts
+++ b/code/packages/typescript/cas-ode/src/index.ts
@@ -161,6 +161,9 @@ export function solveOde(equation: IRNode, y: IRNode, x: IRNode, options: SolveO
   const separable = trySeparable(expr, y, x, ops);
   if (separable !== null) return separable;
 
+  const homogeneous = tryHomogeneousType(expr, y, x, ops);
+  if (homogeneous !== null) return homogeneous;
+
   return null;
 }
 
@@ -299,6 +302,56 @@ function tryExact(expr: IRNode, y: IRNode, x: IRNode, ops: Ops): IRNode | null {
   const g = ops.integrate(gPrime, y);
   if (isApplyOf(g, INTEGRATE)) return null;
   return app(EQUAL, [ops.simp(add(F, g)), C]);
+}
+
+export function substRatioIr(node: IRNode, y: IRNode, x: IRNode, v: IRNode): IRNode | null {
+  if (equals(node, y)) return null;
+  if (node.kind !== "apply") return node;
+
+  if (headName(node.head) === DIV.name && node.args.length === 2 && equals(node.args[0], y) && equals(node.args[1], x)) {
+    return v;
+  }
+
+  const args: IRNode[] = [];
+  for (const arg of node.args) {
+    const substituted = substRatioIr(arg, y, x, v);
+    if (substituted === null) return null;
+    args.push(substituted);
+  }
+  return app(node.head, args);
+}
+
+function tryHomogeneousType(expr: IRNode, y: IRNode, x: IRNode, ops: Ops): IRNode | null {
+  const extracted = extractFirstOrderRhs(expr, y, x);
+  if (extracted === null) return null;
+
+  const rhs = ops.simp(extracted);
+  if (isConstWrt(rhs, y)) return null;
+
+  const v = sym("_hom_v");
+  const fRaw = substRatioIr(rhs, y, x, v);
+  if (fRaw === null) return null;
+
+  const f = ops.simp(fRaw);
+  if (!isConstWrt(f, x)) return null;
+  if (equals(f, v)) return app(EQUAL, [y, ops.simp(mul(C, x))]);
+
+  const denom = simplifyLinearInVariable(ops.simp(sub(f, v)), v);
+  const integrand = ops.simp(div(ONE, denom));
+  const hV = ops.integrate(integrand, v);
+  const yOverX = div(y, x);
+  const hYX = ops.simp(substIr(hV, v, yOverX));
+  return app(EQUAL, [hYX, ops.simp(add(app(LOG, [x]), C))]);
+}
+
+function simplifyLinearInVariable(node: IRNode, variable: IRNode): IRNode {
+  let coeff = Frac.zero();
+  for (const term of flattenAdd(node)) {
+    const termCoeff = extractLinearCoeff(term, variable);
+    if (termCoeff === null) return node;
+    coeff = coeff.add(termCoeff);
+  }
+  return mul(coeff.toIr(), variable);
 }
 
 function collectSecondOrderCoeffs(expr: IRNode, y: IRNode, x: IRNode): { a: Frac; b: Frac; c: Frac } | null {
@@ -847,6 +900,12 @@ function extractLinearCoeff(node: IRNode, variable: IRNode): Frac | null {
 function isConstWrt(node: IRNode, variable: IRNode): boolean {
   if (equals(node, variable)) return false;
   return node.kind !== "apply" || node.args.every((arg) => isConstWrt(arg, variable));
+}
+
+function substIr(node: IRNode, from: IRNode, to: IRNode): IRNode {
+  if (equals(node, from)) return to;
+  if (node.kind !== "apply") return node;
+  return app(node.head, node.args.map((arg) => substIr(arg, from, to)));
 }
 
 function applyArgs(node: IRNode, head: IRNode): readonly IRNode[] | undefined {

--- a/code/packages/typescript/cas-ode/tests/cas-ode.test.ts
+++ b/code/packages/typescript/cas-ode/tests/cas-ode.test.ts
@@ -19,7 +19,7 @@ import {
   sym,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
-import { C, C1, C2, ODE2, buildOdeHandlerTable, ode2, solveOde } from "../src/index";
+import { C, C1, C2, ODE2, buildOdeHandlerTable, ode2, solveOde, substRatioIr } from "../src/index";
 
 const x = sym("x");
 const y = sym("y");
@@ -44,6 +44,12 @@ function rhsOfEqual(node: IRNode): IRNode {
   return (node as Extract<IRNode, { kind: "apply" }>).args[1];
 }
 
+function lhsOfEqual(node: IRNode): IRNode {
+  expect(node.kind).toBe("apply");
+  expect(node.kind === "apply" && equals(node.head, EQUAL)).toBe(true);
+  return (node as Extract<IRNode, { kind: "apply" }>).args[0];
+}
+
 describe("cas-ode package shape", () => {
   it("exports an ODE2 handler table", () => {
     const table = buildOdeHandlerTable();
@@ -57,6 +63,22 @@ describe("cas-ode package shape", () => {
 });
 
 describe("first-order ODEs", () => {
+  it("substitutes exact y/x ratios for the homogeneous recognizer", () => {
+    const v = sym("v");
+    const yOverX = app(DIV, [y, x]);
+    expectEqual(substRatioIr(yOverX, y, x, v)!, v);
+    expectEqual(substRatioIr(app(POW, [yOverX, int(2)]), y, x, v)!, app(POW, [v, int(2)]));
+    expectEqual(substRatioIr(app(ADD, [yOverX, yOverX]), y, x, v)!, app(ADD, [v, v]));
+  });
+
+  it("rejects y when it is not structurally y/x", () => {
+    const v = sym("v");
+    expect(substRatioIr(y, y, x, v)).toBeNull();
+    expect(substRatioIr(app(DIV, [app(ADD, [y, x]), x]), y, x, v)).toBeNull();
+    expect(substRatioIr(app(MUL, [y, x]), y, x, v)).toBeNull();
+    expectEqual(substRatioIr(x, y, x, v)!, x);
+  });
+
   it("solves first-order linear equations with symbolic integrating factors", () => {
     const equation = app(SUB, [yp, app(MUL, [int(2), y])]);
     const result = solveOde(equation, y, x);
@@ -91,6 +113,38 @@ describe("first-order ODEs", () => {
     const result = solveOde(equation, y, x);
     const expectedPotential = app(ADD, [x, app(MUL, [y, app(POW, [x, int(2)])])]);
     expectEqual(result!, app(EQUAL, [expectedPotential, C]));
+  });
+
+  it("solves the homogeneous degenerate y prime equals y over x case", () => {
+    const equation = app(SUB, [yp, app(DIV, [y, x])]);
+    const result = solveOde(equation, y, x);
+    expectEqual(result!, app(EQUAL, [y, app(MUL, [C, x])]));
+  });
+
+  it("returns an implicit homogeneous solution when the v integral is symbolic", () => {
+    const yOverX = app(DIV, [y, x]);
+    const equation = app(SUB, [yp, app(EXP, [yOverX])]);
+    const result = solveOde(equation, y, x);
+    expect(result).not.toBeNull();
+    expect(hasHead(lhsOfEqual(result!), INTEGRATE.name)).toBe(true);
+    expect(hasHead(rhsOfEqual(result!), LOG.name)).toBe(true);
+    expect(display(result!)).toContain("%c");
+    expect(display(result!)).not.toContain("_hom_v");
+  });
+
+  it("uses primitive homogeneous integration when the v integral is available", () => {
+    const yOverX = app(DIV, [y, x]);
+    const equation = app(SUB, [yp, app(MUL, [int(2), yOverX])]);
+    const result = solveOde(equation, y, x);
+    expect(result).not.toBeNull();
+    expect(hasHead(lhsOfEqual(result!), LOG.name)).toBe(true);
+    expect(hasHead(rhsOfEqual(result!), LOG.name)).toBe(true);
+  });
+
+  it("falls through when y also appears outside y over x", () => {
+    const yOverX = app(DIV, [y, x]);
+    const unsupported = app(SUB, [yp, app(ADD, [app(MUL, [y, x]), yOverX])]);
+    expectEqual(ode2(unsupported, y, x), app(ODE2, [unsupported, y, x]));
   });
 });
 


### PR DESCRIPTION
## Summary

- add the TypeScript homogeneous-type `D(y,x) = f(y/x)` ODE recognizer and structural `Div(y,x) -> v` substitution helper
- handle the degenerate `f(v)=v` case as `Equal(y, %c*x)`
- return symbolic implicit `Integrate(...) = Log(x)+%c` solutions when the local primitive integrator cannot close the v integral
- cover representative parity cases, fallthroughs, and docs/changelog updates

## Validation

- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage`

## Deferred

- broader algebraic normalization such as `(y+x)/x -> y/x + 1` remains outside this pure structural slice
- additional primitive integration for rational v expressions can be expanded separately
