### PR TITLE
feat(llm-primitives): add render_node primitive (LM00b)

### DIFF
--- a/code/packages/rust/llm-primitives/CHANGELOG.md
+++ b/code/packages/rust/llm-primitives/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-05-11
+
+### Added
+
+- `render_node` module — second concrete primitive from LM00b.
+  Faithful natural-language rendering of one IR node. Takes a
+  caller-formatted `node_description`, a `document_excerpt` for
+  grounding, and a target `RenderStyle` (`Plain` / `Clinical` /
+  `Legal`); returns a `rendering` string plus the `LlmCallRecord`.
+- `RenderStyle` enum + `as_str()` for audit-trail tags and
+  per-style prompt directives (plain English / clinical shorthand /
+  formal legal register).
+- Routes via `LlmClient::complete` (free-form text, not JSON).
+  The only structural failure surfaced is whitespace-only output,
+  which returns `PrimitiveError::ValidationExhausted` so ADJ06 can
+  clarify. Substantive faithfulness is ADJ04's job via `entail`.
+- `LlmCallRecord` populated with `primitive = "render_node"`,
+  `role = "renderer"`, `prompt_version = "render-node-v1"`, content-
+  addressed `prompt_hash`, plus provider identity, token usage,
+  finish reason, and latency from the gateway response.
+- 8 new tests. Coverage: `RenderStyle::as_str` stability,
+  `NoClientForRole` when renderer is unregistered, happy-path
+  trimmed-rendering with full `call_record` population, style
+  directives in the user message (Clinical and Legal),
+  whitespace-only response → `ValidationExhausted`, `RateLimit`
+  propagates as `Gateway`, `prompt_hash` matches an
+  independently-built request, `finish_reason` passes through to
+  the call record.
+
+### Notes
+
+`render_node`'s `RenderNodeRequest.node_description` is a string at
+v0.3 — the caller formats their IR node however they like. A
+follow-up will swap to typed `adjudication_ir::IRNode` once that
+crate ships its `serde` feature; the prompt and wire shape stay
+unchanged.
+
 ## [0.2.0] - 2026-05-11
 
 ### Added

--- a/code/packages/rust/llm-primitives/Cargo.toml
+++ b/code/packages/rust/llm-primitives/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "llm-primitives"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "LM00b — typed LLM primitives layer. v0.1: shared scaffolding (Role, GatewayConfig, LlmCallRecord, PrimitiveError, prompt-version constants). v0.2: adds the `entail` primitive (bidirectional textual entailment). Remaining primitives (decompose_text, render_node, find_contradicting_reading, judge_plausibility, extract_rules) ship in follow-up PRs."
+description = "LM00b — typed LLM primitives layer. v0.1: shared scaffolding (Role, GatewayConfig, LlmCallRecord, PrimitiveError, prompt-version constants). v0.2: `entail` (bidirectional NLI). v0.3: `render_node` (faithful natural-language rendering of an IR node). Remaining primitives ship in follow-up PRs."
 
 [dependencies]
 llm-gateway = { path = "../llm-gateway" }

--- a/code/packages/rust/llm-primitives/README.md
+++ b/code/packages/rust/llm-primitives/README.md
@@ -58,8 +58,8 @@ This crate defines the building blocks every primitive plugs into.
 | Primitive | Status | Role | Module |
 |---|---|---|---|
 | `entail(req, gateway)` | ✅ v0.2.0 | `Nli` | `entail` |
+| `render_node(req, gateway)` | ✅ v0.3.0 | `Renderer` | `render_node` |
 | `decompose_text` | planned | `Extractor` | — |
-| `render_node` | planned | `Renderer` | — |
 | `find_contradicting_reading` | planned | `Adversary` | — |
 | `judge_plausibility` | planned | `Plausibility` | — |
 | `extract_rules` | planned | `RuleExtractor` | — |

--- a/code/packages/rust/llm-primitives/src/lib.rs
+++ b/code/packages/rust/llm-primitives/src/lib.rs
@@ -35,16 +35,16 @@
 //!
 //! ## Primitives shipped here
 //!
-//! Each of the six LM00b primitives ships as its own module so the
-//! implementations can land in parallel without conflicting on one
-//! giant file:
+//! Each of the six LM00b primitives ships in its own module so they
+//! can land in parallel without conflicting on one giant file:
 //!
 //!   * [`entail`] — bidirectional textual entailment (v0.2.0)
-//!   * `decompose_text` — extractor; not yet implemented
-//!   * `render_node` — renderer; not yet implemented
-//!   * `find_contradicting_reading` — adversary; not yet implemented
-//!   * `judge_plausibility` — plausibility judge; not yet implemented
-//!   * `extract_rules` — rule extractor; not yet implemented
+//!   * [`render_node`] — faithful natural-language rendering of an
+//!     IR node (v0.3.0)
+//!   * `decompose_text` — extractor; not yet here
+//!   * `find_contradicting_reading` — adversary; not yet here
+//!   * `judge_plausibility` — plausibility judge; not yet here
+//!   * `extract_rules` — rule extractor; not yet here
 //!
 //! Until a primitive lands, its `PROMPT_VERSION_*` constant is the
 //! only thing this crate exposes for it.
@@ -65,11 +65,14 @@ use llm_gateway::{
 };
 
 pub mod entail;
-// Re-export the entry points so callers can write
-// `llm_primitives::entail(...)` and `llm_primitives::EntailRequest`.
-// (`entail` the function and `entail` the module share a name, which
-// Rust allows because they live in different namespaces.)
+pub mod render_node;
+
+// Re-exports at the crate root. Each primitive's function and module
+// share a name; Rust allows that since they live in different
+// namespaces, so callers can write `llm_primitives::entail(...)` /
+// `llm_primitives::render_node(...)` directly.
 pub use entail::{entail, EntailRequest, EntailResponse};
+pub use render_node::{render_node, RenderNodeRequest, RenderNodeResponse, RenderStyle};
 
 // ---------------------------------------------------------------------------
 // Roles

--- a/code/packages/rust/llm-primitives/src/render_node.rs
+++ b/code/packages/rust/llm-primitives/src/render_node.rs
@@ -1,0 +1,377 @@
+//! # `render_node` — render an IR node back into natural language
+//!
+//! Second concrete primitive from
+//! [LM00b §"render_node"](../../../specs/LM00b-llm-primitives.md). Given
+//! a textual description of one IR node (plus optional document
+//! context and a target style), returns a faithful natural-language
+//! rendering. The rendering is intentionally **weak** — a trivial
+//! paraphrase rather than a clever rewrite. Cleverness masks IR loss;
+//! trivial paraphrasing exposes it (per ADJ04 §"Render IR → Natural
+//! Language").
+//!
+//! ## Why a string `node_description` instead of typed `IRNode`
+//!
+//! The LM00b spec carries an `adjudication_ir::IRNode` directly in
+//! the request. v0.1 of this primitive takes the **caller-formatted
+//! textual description** of the node instead, because
+//! `adjudication-ir` does not yet derive `Serialize` and the
+//! primitive does not (yet) want to bind to a specific in-process
+//! shape. The caller builds whatever text representation makes
+//! sense for its consumer; the LLM sees a stable shape regardless.
+//!
+//! v0.2 will swap the request type to `IRNode` once
+//! `adjudication-ir` ships its `serde` feature; the prompt and
+//! audit-trail behaviour will be unchanged.
+
+use llm_gateway::{
+    CompletionRequest, LlmClient, Message, MessageContent, Role as MsgRole,
+};
+
+use crate::{
+    fingerprint_prompt, GatewayConfig, LlmCallRecord, PrimitiveError, Role,
+    RENDER_NODE_PROMPT_VERSION,
+};
+
+/// Render style. The LLM is instructed to produce a *faithful* trivial
+/// paraphrase in the requested register — not a clever rewrite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderStyle {
+    /// Everyday-English ("The patient has chest pain.").
+    Plain,
+    /// Clinical shorthand ("Chest pain (acute, severe), affirmed.").
+    Clinical,
+    /// Formal-register restatement appropriate for legal text.
+    Legal,
+}
+
+impl RenderStyle {
+    /// Stable string tag — flows into the audit trail.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RenderStyle::Plain => "plain",
+            RenderStyle::Clinical => "clinical",
+            RenderStyle::Legal => "legal",
+        }
+    }
+
+    /// Prompt-side instruction the LLM follows.
+    fn directive(&self) -> &'static str {
+        match self {
+            RenderStyle::Plain => "everyday English, indicative mood, no shorthand",
+            RenderStyle::Clinical => "concise clinical shorthand; abbreviations are fine",
+            RenderStyle::Legal => "formal legal register; precise modal verbs",
+        }
+    }
+}
+
+/// Inputs to [`render_node`]. The `node_description` is whatever
+/// textual representation of the IR node the caller wants the LLM
+/// to render; the `document_excerpt` is the relevant slice of the
+/// source document so the rendering can stay close to the source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderNodeRequest {
+    pub node_description: String,
+    pub document_excerpt: String,
+    pub style: RenderStyle,
+}
+
+/// Result of one [`render_node`] call.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenderNodeResponse {
+    /// The LLM's natural-language rendering. ADJ04 then uses
+    /// [`crate::entail`] in both directions to flag round-trip drift
+    /// between this rendering and the original source.
+    pub rendering: String,
+    pub call_record: LlmCallRecord,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You are a faithful paraphraser. Given a structured description of one \
+fact from a document, restate it as a single short natural-language \
+sentence. Be faithful: do not embellish, do not add information that is \
+not in the description, do not strip information that is. A trivial \
+restatement is the goal — cleverness hides extraction errors. Respond \
+with the rendered sentence only, no prefix and no commentary.";
+
+fn build_user_text(req: &RenderNodeRequest) -> String {
+    format!(
+        "STYLE: {style} ({directive})\n\n\
+         NODE:\n{node}\n\n\
+         SOURCE EXCERPT:\n{src}\n\n\
+         Render the NODE as one sentence in the requested style now.",
+        style = req.style.as_str(),
+        directive = req.style.directive(),
+        node = req.node_description,
+        src = req.document_excerpt,
+    )
+}
+
+fn build_completion_request(client: &dyn LlmClient, req: &RenderNodeRequest) -> CompletionRequest {
+    CompletionRequest {
+        model: client.identity().model_family.clone(),
+        system: Some(SYSTEM_PROMPT.to_string()),
+        messages: vec![Message {
+            role: MsgRole::User,
+            content: MessageContent::Text(build_user_text(req)),
+        }],
+        // Deterministic by default — renderings should be reproducible
+        // in tests and replays.
+        temperature: 0.0,
+        max_tokens: Some(256),
+        stop_sequences: Vec::new(),
+        seed: None,
+        metadata: Default::default(),
+    }
+}
+
+/// Render one IR-node-equivalent description into natural language.
+/// Looks up `Role::Renderer` on the gateway; returns
+/// [`PrimitiveError::NoClientForRole`] if absent,
+/// [`PrimitiveError::Gateway`] on transport / auth failures, or
+/// [`PrimitiveError::ValidationExhausted`] if the LLM returns
+/// whitespace-only output (the only structural failure that's worth
+/// catching at this layer — substantive faithfulness is ADJ04's job
+/// via `entail`).
+pub fn render_node(
+    req: &RenderNodeRequest,
+    gateway: &GatewayConfig,
+) -> Result<RenderNodeResponse, PrimitiveError> {
+    let client = gateway
+        .client(Role::Renderer)
+        .ok_or(PrimitiveError::NoClientForRole {
+            role: Role::Renderer,
+        })?;
+
+    let completion_req = build_completion_request(client, req);
+    let prompt_hash = fingerprint_prompt(&completion_req);
+
+    let resp = client
+        .complete(completion_req)
+        .map_err(PrimitiveError::Gateway)?;
+
+    let rendering = resp.text.trim().to_string();
+    if rendering.is_empty() {
+        return Err(PrimitiveError::ValidationExhausted {
+            last_response: resp.text,
+            last_error: "rendering was empty after trimming whitespace".to_string(),
+            attempts: 1,
+        });
+    }
+
+    let call_record = LlmCallRecord {
+        primitive: "render_node".to_string(),
+        role: Role::Renderer.as_str().to_string(),
+        prompt_version: RENDER_NODE_PROMPT_VERSION.to_string(),
+        prompt_hash,
+        provider: resp.provider_id,
+        usage: resp.usage,
+        finish_reason: resp.finish_reason,
+        latency_ms: resp.latency_ms,
+        cost_usd: 0.0, // cost-table integration is a follow-up
+    };
+
+    Ok(RenderNodeResponse {
+        rendering,
+        call_record,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llm_gateway::{
+        Capabilities, CompletionRequest, CompletionResponse, FinishReason, JsonSchema, LlmClient,
+        LlmError, MockLlmClient, ProviderIdentity, TokenUsage,
+    };
+    use std::sync::Mutex;
+
+    fn renderer_identity() -> ProviderIdentity {
+        ProviderIdentity {
+            vendor: "mock".into(),
+            model_family: "haiku-renderer".into(),
+            model_version: "1".into(),
+            endpoint: None,
+        }
+    }
+
+    struct ScriptedText {
+        identity: ProviderIdentity,
+        response: Mutex<Option<Result<CompletionResponse, LlmError>>>,
+    }
+
+    impl ScriptedText {
+        fn new(text: &str) -> Self {
+            Self {
+                identity: renderer_identity(),
+                response: Mutex::new(Some(Ok(CompletionResponse {
+                    text: text.to_string(),
+                    model: "haiku-renderer".into(),
+                    usage: TokenUsage {
+                        input_tokens: 30,
+                        output_tokens: 9,
+                        cached_tokens: 0,
+                    },
+                    finish_reason: FinishReason::Stop,
+                    provider_id: renderer_identity(),
+                    latency_ms: 23,
+                }))),
+            }
+        }
+
+        fn with_error(err: LlmError) -> Self {
+            Self {
+                identity: renderer_identity(),
+                response: Mutex::new(Some(Err(err))),
+            }
+        }
+    }
+
+    impl LlmClient for ScriptedText {
+        fn identity(&self) -> ProviderIdentity {
+            self.identity.clone()
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::modern_frontier()
+        }
+
+        fn complete(&self, _req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+            self.response
+                .lock()
+                .unwrap()
+                .take()
+                .expect("ScriptedText::complete called more than once")
+        }
+
+        fn complete_json(
+            &self,
+            _req: CompletionRequest,
+            _schema: &JsonSchema,
+        ) -> Result<llm_gateway::CompletionJsonResponse, LlmError> {
+            unreachable!("render_node uses complete, not complete_json")
+        }
+    }
+
+    fn req(style: RenderStyle) -> RenderNodeRequest {
+        RenderNodeRequest {
+            node_description:
+                "Fact: carry_on(passenger_a, 1). polarity=Affirmed modality=Stated".into(),
+            document_excerpt: "1 carry-on bag, 1 personal item.".into(),
+            style,
+        }
+    }
+
+    #[test]
+    fn render_style_as_str_is_stable() {
+        assert_eq!(RenderStyle::Plain.as_str(), "plain");
+        assert_eq!(RenderStyle::Clinical.as_str(), "clinical");
+        assert_eq!(RenderStyle::Legal.as_str(), "legal");
+    }
+
+    #[test]
+    fn missing_renderer_client_returns_no_client_for_role() {
+        let g = GatewayConfig::new();
+        let err = render_node(&req(RenderStyle::Plain), &g).unwrap_err();
+        match err {
+            PrimitiveError::NoClientForRole { role } => assert_eq!(role, Role::Renderer),
+            other => panic!("expected NoClientForRole, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn happy_path_returns_trimmed_rendering() {
+        let mock = ScriptedText::new("  The passenger declared one carry-on bag.\n");
+        let g = GatewayConfig::new().with_client(Role::Renderer, Box::new(mock));
+        let resp = render_node(&req(RenderStyle::Plain), &g).unwrap();
+        assert_eq!(resp.rendering, "The passenger declared one carry-on bag.");
+
+        assert_eq!(resp.call_record.primitive, "render_node");
+        assert_eq!(resp.call_record.role, "renderer");
+        assert_eq!(resp.call_record.prompt_version, "render-node-v1");
+        assert_eq!(resp.call_record.usage.output_tokens, 9);
+        assert_eq!(resp.call_record.latency_ms, 23);
+    }
+
+    #[test]
+    fn user_message_includes_style_directive_and_node_text() {
+        // Build the user text directly and assert. Going through the
+        // gateway's Box<dyn LlmClient> doesn't give us a hook to peek
+        // at the captured request.
+        let r = req(RenderStyle::Clinical);
+        let text = build_user_text(&r);
+        assert!(text.contains("STYLE: clinical"));
+        assert!(text.contains("clinical shorthand"));
+        assert!(text.contains("NODE:\nFact: carry_on(passenger_a, 1)"));
+        assert!(text.contains("SOURCE EXCERPT:\n1 carry-on bag"));
+    }
+
+    #[test]
+    fn legal_style_directive_appears_in_user_message() {
+        let text = build_user_text(&req(RenderStyle::Legal));
+        assert!(text.contains("STYLE: legal"));
+        assert!(text.contains("formal legal register"));
+    }
+
+    #[test]
+    fn empty_rendering_returns_validation_exhausted() {
+        let mock = ScriptedText::new("   \n\t  ");
+        let g = GatewayConfig::new().with_client(Role::Renderer, Box::new(mock));
+        let err = render_node(&req(RenderStyle::Plain), &g).unwrap_err();
+        match err {
+            PrimitiveError::ValidationExhausted { last_error, attempts, .. } => {
+                assert_eq!(attempts, 1);
+                assert!(last_error.contains("empty"));
+            }
+            other => panic!("expected ValidationExhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_limit_propagates_as_gateway_variant() {
+        let mock = ScriptedText::with_error(LlmError::RateLimit {
+            provider: renderer_identity(),
+            retry_after_ms: Some(5000),
+        });
+        let g = GatewayConfig::new().with_client(Role::Renderer, Box::new(mock));
+        let err = render_node(&req(RenderStyle::Plain), &g).unwrap_err();
+        assert!(matches!(
+            err,
+            PrimitiveError::Gateway(LlmError::RateLimit { .. })
+        ));
+    }
+
+    #[test]
+    fn call_record_prompt_hash_matches_built_request() {
+        let identity = renderer_identity();
+        let stub: Box<dyn LlmClient> = Box::new(MockLlmClient::new().with_identity(identity));
+        let cr = build_completion_request(stub.as_ref(), &req(RenderStyle::Plain));
+        let expected_hash = crate::fingerprint_prompt(&cr);
+
+        let mock = ScriptedText::new("ok");
+        let g = GatewayConfig::new().with_client(Role::Renderer, Box::new(mock));
+        let resp = render_node(&req(RenderStyle::Plain), &g).unwrap();
+        assert_eq!(resp.call_record.prompt_hash, expected_hash);
+    }
+
+    #[test]
+    fn finish_reason_is_passed_through_to_call_record() {
+        let mock = ScriptedText {
+            identity: renderer_identity(),
+            response: Mutex::new(Some(Ok(CompletionResponse {
+                text: "truncated".into(),
+                model: "haiku-renderer".into(),
+                usage: TokenUsage::default(),
+                finish_reason: FinishReason::MaxTokens,
+                provider_id: renderer_identity(),
+                latency_ms: 11,
+            }))),
+        };
+        let g = GatewayConfig::new().with_client(Role::Renderer, Box::new(mock));
+        let resp = render_node(&req(RenderStyle::Plain), &g).unwrap();
+        assert_eq!(resp.call_record.finish_reason, FinishReason::MaxTokens);
+    }
+}


### PR DESCRIPTION
## Summary

- Second concrete primitive from LM00b: faithful natural-language rendering of one IR node.
- Lives in \`code/packages/rust/llm-primitives/src/render_node.rs\`. Re-exported at crate root.
- 8 new tests (24 total in the crate, all passing). Clippy clean. Security review passed.

## What it does

\`\`\`rust
use llm_primitives::{render_node, RenderNodeRequest, RenderStyle, GatewayConfig, Role};

let gateway = GatewayConfig::new()
    .with_client(Role::Renderer, Box::new(/* small cheap LlmClient */));

let resp = render_node(&RenderNodeRequest {
    node_description: \"Fact: carry_on(passenger_a, 1). polarity=Affirmed\".into(),
    document_excerpt:  \"1 carry-on bag, 1 personal item.\".into(),
    style:             RenderStyle::Plain,
}, &gateway)?;

// resp.rendering   == \"The passenger declared one carry-on bag.\"
// resp.call_record → goes into the audit trail
\`\`\`

## Why \"faithful, trivial\" rendering

Per [LM00b §render_node](../../code/specs/LM00b-llm-primitives.md): the rendering is **deliberately weak**. A trivial paraphrase exposes IR loss; a clever rewrite hides it. ADJ04 (round-trip checker) then runs \`entail\` bidirectionally between this rendering and the original source — drift in either direction surfaces an extraction error.

## Why \`node_description: String\` and not typed \`IRNode\`

\`adjudication-ir\`'s \`IRNode\` doesn't yet derive \`Serialize\`. Rather than block this primitive on a foundational refactor, v0.2 takes a string description (caller formats their node however they like). v0.3 will swap to typed \`IRNode\` once \`adjudication-ir\` ships its \`serde\` feature — **prompt and wire shape unchanged across the upgrade**.

## Implementation notes

- Looks up \`Role::Renderer\` on the \`GatewayConfig\`. Missing → \`PrimitiveError::NoClientForRole\`.
- Stable system prompt versioned by \`RENDER_NODE_PROMPT_VERSION\`.
- User message tags STYLE / NODE / SOURCE EXCERPT so the LLM can't confuse the pieces.
- Routes via \`LlmClient::complete\` (free-form text, not JSON mode).
- Whitespace-only response → \`PrimitiveError::ValidationExhausted\`. Substantive faithfulness is ADJ04's job, not this primitive's.
- \`LlmCallRecord\` populated: \`primitive=\"render_node\"\`, \`role=\"renderer\"\`, \`prompt_version=\"render-node-v1\"\`, content-addressed \`prompt_hash\`, provider identity, token usage, finish reason, latency.

## Security review

Passed, no findings. Smaller attack surface than \`entail\` (no JSON parsing, single structural check). Same accepted-risk prompt-injection model: the LLM is the trust boundary.

## Parallel to #2719

Independent of [#2719 (entail primitive)](https://github.com/adhithyan15/coding-adventures/pull/2719). Both branched from the merged llm-primitives v0.1 skeleton. When one merges, the other will need a rebase: \`lib.rs\` will add **both** \`pub mod\` lines, \`Cargo.toml\` will end up at version \`0.3.0\` with both modules present.

## Test plan

- [x] \`cargo test -p llm-primitives\` — 24/24 pass
- [x] \`cargo clippy -p llm-primitives --tests -- -D warnings\` — clean
- [x] Security review — passed
- [ ] CI green on PR
- [ ] User sign-off

4 primitives remain (\`decompose_text\`, \`find_contradicting_reading\`, \`judge_plausibility\`, \`extract_rules\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)