### PR TITLE
[codex] Wire Bluetooth endpoint picks into Board VM connect

### DIFF
--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -120,6 +120,61 @@ local function connection_uses_tcp_endpoint(connection_option)
     )
 end
 
+local function connection_uses_bluetooth_endpoint(connection_option)
+    return connection_option ~= nil and (
+        connection_option.transport == "bluetooth_le" or
+        connection_option.transport == "bluetooth_classic" or
+        connection_option.endpoint_transport == "bluetooth_le_gatt" or
+        connection_option.endpoint_transport == "bluetooth_classic_rfcomm" or
+        connection_option.endpoint_scheme == "ble" or
+        connection_option.endpoint_scheme == "btspp" or
+        connection_option.endpoint_scheme == "rfcomm"
+    )
+end
+
+local function bluetooth_candidate_matches_connection(candidate, connection_option)
+    local endpoint = candidate.endpoint or {}
+    return (
+        connection_option.transport ~= nil and endpoint.transport == connection_option.transport
+    ) or (
+        connection_option.endpoint_transport ~= nil and endpoint.endpoint_transport == connection_option.endpoint_transport
+    ) or (
+        connection_option.endpoint_scheme ~= nil and endpoint.endpoint_scheme == connection_option.endpoint_scheme
+    )
+end
+
+local function bluetooth_endpoint_choice_list(candidates)
+    local lines = {}
+    for index, candidate in ipairs(candidates) do
+        local endpoint = candidate.endpoint or {}
+        local display_name = candidate.display_name or candidate.device or endpoint.endpoint
+        table.insert(lines, tostring(index) .. ". " .. tostring(display_name) .. " - " .. tostring(endpoint.endpoint))
+    end
+    return table.concat(lines, "\n")
+end
+
+function M.bluetooth_connection_endpoint(connection_option, devices)
+    local matches = {}
+    for _, candidate in ipairs(M.bluetooth_endpoint_candidates(devices)) do
+        if bluetooth_candidate_matches_connection(candidate, connection_option) then
+            table.insert(matches, candidate)
+        end
+    end
+
+    if #matches == 1 then
+        return tostring(matches[1].endpoint.endpoint)
+    end
+
+    local display_name = connection_option.display_name or connection_option.transport or "Bluetooth"
+    if #matches == 0 then
+        error(display_name ..
+            " found no Board VM Bluetooth endpoints; pair or power on the board, pass endpoint = ..., or choose via = \"serial\"")
+    end
+
+    error("Multiple Board VM Bluetooth endpoints match " ..
+        display_name .. "; pass endpoint = ...\n" .. bluetooth_endpoint_choice_list(matches))
+end
+
 local function parse_tcp_endpoint(endpoint)
     local authority = tostring(endpoint or ""):gsub("^tcp://", "")
     local host, port = authority:match("^%[([^%]]+)%]:(%d+)$")
@@ -634,13 +689,18 @@ function M.connect(selector, options)
         ota = options.ota,
     })
 
+    local endpoint = options.endpoint
+    if endpoint == nil and connection_uses_bluetooth_endpoint(connection_option) then
+        endpoint = M.bluetooth_connection_endpoint(connection_option, options.bluetooth_devices)
+    end
+
     return Connection.new({
         target = target,
         port = port,
         device = device,
         connection_option = connection_option,
         transport = options.transport,
-        endpoint = options.endpoint,
+        endpoint = endpoint,
         timeout_ms = options.timeout_ms,
     })
 end

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -129,6 +129,32 @@ describe("coding_adventures.board_vm_native", function()
         assert.are.equal("table", type(board_vm.bluetooth_endpoint_candidates()))
     end)
 
+    it("filters Bluetooth endpoint candidates to the selected transport", function()
+        local option = board_vm.select_connection_option("uno-r4-wifi", { via = "BLE" })
+        local endpoint = board_vm.bluetooth_connection_endpoint(option, {
+            {
+                id = "esp32-board-vm",
+                name = "ESP32 Board VM",
+                paired = true,
+                board_vm_rfcomm_channels = { 3 },
+            },
+            {
+                id = "uno-r4",
+                name = "Uno R4 Board VM",
+                address = "AA:BB:CC:DD:EE:FF",
+                service_uuids = { "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" },
+            },
+        })
+
+        assert.are.equal(
+            "ble://AA:BB:CC:DD:EE:FF" ..
+            "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e" ..
+            "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e" ..
+            "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e",
+            endpoint
+        )
+    end)
+
     it("classifies host devices through Rust-owned discovery rules", function()
         local devices = board_vm.devices({
             "/dev/cu.usbmodem1101",
@@ -196,6 +222,30 @@ describe("coding_adventures.board_vm_native", function()
         assert.are.equal(2, #transport.frames)
         assert.is_string(transport.frames[1])
         assert.are.equal(0, transport.frames[1]:byte(#transport.frames[1]))
+    end)
+
+    it("auto-selects Bluetooth endpoint candidates while connecting", function()
+        local connection = board_vm.connect("uno-r4-wifi", {
+            via = "BLE",
+            bluetooth_devices = {
+                {
+                    id = "uno-r4",
+                    name = "Uno R4 Board VM",
+                    address = "AA:BB:CC:DD:EE:FF",
+                    service_uuids = { "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" },
+                },
+            },
+        })
+
+        assert.is_nil(connection.port)
+        assert.are.equal("bluetooth_le", connection:connection_transport())
+        assert.are.equal(
+            "ble://AA:BB:CC:DD:EE:FF" ..
+            "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e" ..
+            "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e" ..
+            "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e",
+            connection.endpoint
+        )
     end)
 
     it("builds TCP transports for Wi-Fi endpoints", function()

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1503,6 +1503,33 @@ def bluetooth_endpoint_candidates(
     return candidates
 
 
+def bluetooth_connection_endpoint(
+    connection_option: dict[str, Any],
+    *,
+    devices: Iterable[dict[str, Any]] | None = None,
+) -> str:
+    option = dict(connection_option)
+    matches = [
+        candidate
+        for candidate in bluetooth_endpoint_candidates(devices)
+        if _bluetooth_candidate_matches_connection(candidate, option)
+    ]
+    if len(matches) == 1:
+        return str(matches[0]["endpoint"]["endpoint"])
+
+    display_name = option.get("display_name") or option.get("transport") or "Bluetooth"
+    if not matches:
+        raise ValueError(
+            f"{display_name} found no Board VM Bluetooth endpoints; "
+            "pair or power on the board, pass endpoint=..., or choose via='serial'"
+        )
+
+    raise ValueError(
+        f"Multiple Board VM Bluetooth endpoints match {display_name}; pass endpoint=...\n"
+        f"{_bluetooth_endpoint_choice_list(matches)}"
+    )
+
+
 def _bluetooth_device_field(device: Any, key: str) -> Any:
     if isinstance(device, dict):
         return device.get(key)
@@ -1518,6 +1545,40 @@ def _bluetooth_device_sequence(device: Any, key: str) -> list[Any]:
     if value is None:
         return []
     return list(value)
+
+
+def _bluetooth_candidate_matches_connection(
+    candidate: dict[str, Any],
+    connection_option: dict[str, Any],
+) -> bool:
+    endpoint = candidate.get("endpoint") or {}
+    transport = connection_option.get("transport")
+    endpoint_transport = connection_option.get("endpoint_transport")
+    endpoint_scheme = connection_option.get("endpoint_scheme")
+    return (
+        (transport is not None and endpoint.get("transport") == transport)
+        or (
+            endpoint_transport is not None
+            and endpoint.get("endpoint_transport") == endpoint_transport
+        )
+        or (
+            endpoint_scheme is not None
+            and endpoint.get("endpoint_scheme") == endpoint_scheme
+        )
+    )
+
+
+def _bluetooth_endpoint_choice_list(candidates: Iterable[dict[str, Any]]) -> str:
+    lines = []
+    for index, candidate in enumerate(candidates, start=1):
+        endpoint = candidate["endpoint"]
+        display_name = (
+            candidate.get("display_name")
+            or candidate.get("device")
+            or endpoint["endpoint"]
+        )
+        lines.append(f"{index}. {display_name} - {endpoint['endpoint']}")
+    return "\n".join(lines)
 
 
 def connection_options(selector: str) -> list[dict[str, Any]]:
@@ -1917,6 +1978,7 @@ def connect(
     smoke: bool = False,
     transport: Any = None,
     endpoint: str | None = None,
+    bluetooth_devices: Iterable[dict[str, Any]] | None = None,
     runner: Any = None,
     cargo_workspace: str | pathlib.Path | None = None,
     firmware_image: str | pathlib.Path | None = None,
@@ -1977,11 +2039,19 @@ def connect(
         input_func=input_func,
         output=output,
     )
+    selected_endpoint = endpoint
+    if selected_endpoint is None and _connection_uses_bluetooth_endpoint(
+        selected_connection_option
+    ):
+        selected_endpoint = bluetooth_connection_endpoint(
+            selected_connection_option,
+            devices=bluetooth_devices,
+        )
     connection = Connection(
         target=target,
         port=selected_port,
         transport=transport,
-        endpoint=endpoint,
+        endpoint=selected_endpoint,
         connection_option=selected_connection_option,
         runner=runner,
         cargo_workspace=cargo_workspace,
@@ -2020,6 +2090,17 @@ def _resolve_connection_option(
 
 def _connection_uses_serial_port(connection_option: dict[str, Any] | None) -> bool:
     return connection_option is None or connection_option.get("transport") == "serial"
+
+
+def _connection_uses_bluetooth_endpoint(connection_option: dict[str, Any] | None) -> bool:
+    if connection_option is None:
+        return False
+    return (
+        connection_option.get("transport") in {"bluetooth_le", "bluetooth_classic"}
+        or connection_option.get("endpoint_transport")
+        in {"bluetooth_le_gatt", "bluetooth_classic_rfcomm"}
+        or connection_option.get("endpoint_scheme") in {"ble", "btspp", "rfcomm"}
+    )
 
 
 def _parse_tcp_endpoint(endpoint: str) -> tuple[str, int]:
@@ -2131,6 +2212,7 @@ __all__ = [
     "Session",
     "SessionResult",
     "TcpTransport",
+    "bluetooth_connection_endpoint",
     "bluetooth_devices",
     "bluetooth_endpoint",
     "bluetooth_endpoint_candidates",

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -15,6 +15,7 @@ from board_vm_native import (
     ProtocolResult,
     Session,
     TcpTransport,
+    bluetooth_connection_endpoint,
     bluetooth_devices,
     bluetooth_endpoint,
     bluetooth_endpoint_candidates,
@@ -271,6 +272,35 @@ def test_bluetooth_endpoint_candidates_default_to_host_discovery(monkeypatch):
     assert candidates[0]["endpoint"]["endpoint"] == "btspp://esp32-board-vm:3"
 
 
+def test_bluetooth_connection_endpoint_filters_to_the_selected_transport():
+    option = select_connection_option("uno-r4-wifi", transport="BLE")
+
+    endpoint = bluetooth_connection_endpoint(
+        option,
+        devices=[
+            {
+                "id": "esp32-board-vm",
+                "name": "ESP32 Board VM",
+                "paired": True,
+                "board_vm_rfcomm_channels": [3],
+            },
+            {
+                "id": "uno-r4",
+                "name": "Uno R4 Board VM",
+                "address": "AA:BB:CC:DD:EE:FF",
+                "service_uuids": ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"],
+            },
+        ],
+    )
+
+    assert endpoint == (
+        "ble://AA:BB:CC:DD:EE:FF"
+        "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+        "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+        "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+    )
+
+
 def test_connection_options_can_be_selected_without_exposing_ports():
     default = select_connection_option("uno-r4-wifi")
     wifi = select_connection_option("uno-r4-wifi", transport="wifi")
@@ -336,6 +366,30 @@ def test_connect_can_use_a_wireless_connection_option_with_an_injected_endpoint(
     assert connection.wireless_connection is True
     assert connection.ota_connection is True
     assert len(transport.frames) == 2
+
+
+def test_connect_auto_selects_bluetooth_endpoint_candidates():
+    connection = connect(
+        "uno-r4-wifi",
+        via="BLE",
+        bluetooth_devices=[
+            {
+                "id": "uno-r4",
+                "name": "Uno R4 Board VM",
+                "address": "AA:BB:CC:DD:EE:FF",
+                "service_uuids": ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"],
+            }
+        ],
+    )
+
+    assert connection.port is None
+    assert connection.connection_transport == "bluetooth_le"
+    assert connection.endpoint == (
+        "ble://AA:BB:CC:DD:EE:FF"
+        "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+        "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+        "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+    )
 
 
 def test_connect_builds_a_tcp_transport_for_wifi_endpoints():

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -174,6 +174,26 @@ module CodingAdventures
       Native.bluetooth_endpoint_candidates(normalized)
     end
 
+    def bluetooth_connection_endpoint(connection_option, devices: nil)
+      option = normalize_connection_option_hash(connection_option)
+      matches = bluetooth_endpoint_candidates(devices).select do |candidate|
+        bluetooth_candidate_matches_connection?(candidate, option)
+      end
+
+      return matches.first.fetch("endpoint").fetch("endpoint").to_s if matches.length == 1
+
+      display_name = option["display_name"] || option["transport"] || "Bluetooth"
+      if matches.empty?
+        raise DeviceSelectionError,
+          "#{display_name} found no Board VM Bluetooth endpoints; " \
+          "pair or power on the board, pass endpoint: ..., or choose via: :serial"
+      end
+
+      raise DeviceSelectionError,
+        "Multiple Board VM Bluetooth endpoints match #{display_name}; pass endpoint: ...\n" \
+        "#{bluetooth_endpoint_choice_list(matches)}"
+    end
+
     def connection_options(board)
       target = detect_target(board)
       unless target
@@ -341,6 +361,7 @@ module CodingAdventures
       runner: CommandRunner.new,
       transport: nil,
       endpoint: nil,
+      bluetooth_devices: nil,
       via: nil,
       connection_option: nil,
       pick_connection: false,
@@ -359,6 +380,13 @@ module CodingAdventures
         input: input,
         output: output
       )
+      resolved_endpoint = endpoint
+      if resolved_endpoint.nil? && connection_uses_bluetooth_endpoint?(selection.fetch(:connection_option))
+        resolved_endpoint = bluetooth_connection_endpoint(
+          selection.fetch(:connection_option),
+          devices: bluetooth_devices
+        )
+      end
       connection = Connection.new(
         board: selection.fetch(:board),
         port: selection.fetch(:port),
@@ -366,7 +394,7 @@ module CodingAdventures
         runner: runner,
         transport: transport,
         connection_option: selection.fetch(:connection_option),
-        endpoint: endpoint,
+        endpoint: resolved_endpoint,
         baud_rate: options.delete(:baud_rate) || options.delete(:baud) || DEFAULT_BAUD_RATE,
         timeout_ms: options.delete(:timeout_ms) || DEFAULT_TIMEOUT_MS,
         **options
@@ -488,6 +516,33 @@ module CodingAdventures
 
     def connection_uses_serial_port?(connection_option)
       connection_option.nil? || connection_option.fetch("transport") == "serial"
+    end
+
+    def connection_uses_bluetooth_endpoint?(connection_option)
+      return false if connection_option.nil?
+
+      %w[bluetooth_le bluetooth_classic].include?(connection_option["transport"]) ||
+        %w[bluetooth_le_gatt bluetooth_classic_rfcomm].include?(connection_option["endpoint_transport"]) ||
+        %w[ble btspp rfcomm].include?(connection_option["endpoint_scheme"])
+    end
+
+    def bluetooth_candidate_matches_connection?(candidate, connection_option)
+      endpoint = candidate.fetch("endpoint", {})
+      transport = connection_option["transport"]
+      endpoint_transport = connection_option["endpoint_transport"]
+      endpoint_scheme = connection_option["endpoint_scheme"]
+
+      (transport && endpoint["transport"] == transport) ||
+        (endpoint_transport && endpoint["endpoint_transport"] == endpoint_transport) ||
+        (endpoint_scheme && endpoint["endpoint_scheme"] == endpoint_scheme)
+    end
+
+    def bluetooth_endpoint_choice_list(candidates)
+      candidates.each_with_index.map do |candidate, index|
+        endpoint = candidate.fetch("endpoint")
+        display_name = candidate["display_name"] || candidate["device"] || endpoint.fetch("endpoint")
+        "#{index + 1}. #{display_name} - #{endpoint.fetch("endpoint")}"
+      end.join("\n")
     end
 
     def flash_without_port?(board, flash)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -152,6 +152,33 @@ module CodingAdventures
         end
       end
 
+      def test_bluetooth_connection_endpoint_filters_to_the_selected_transport
+        option = BoardVM.select_connection_option(:uno_r4_wifi, transport: "BLE")
+
+        endpoint = BoardVM.bluetooth_connection_endpoint(
+          option,
+          devices: [
+            {
+              "id" => "esp32-board-vm",
+              "name" => "ESP32 Board VM",
+              "paired" => true,
+              "board_vm_rfcomm_channels" => [3]
+            },
+            {
+              "id" => "uno-r4",
+              "name" => "Uno R4 Board VM",
+              "address" => "AA:BB:CC:DD:EE:FF",
+              "service_uuids" => ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"]
+            }
+          ]
+        )
+
+        assert_equal "ble://AA:BB:CC:DD:EE:FF" \
+          "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e" \
+          "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e" \
+          "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e", endpoint
+      end
+
       def test_connection_options_can_be_selected_without_exposing_ports
         default = BoardVM.select_connection_option(:uno_r4_wifi)
         wifi = BoardVM.select_connection_option(:uno_r4_wifi, transport: :wifi)
@@ -216,6 +243,29 @@ module CodingAdventures
         assert connection.wireless_connection?
         assert connection.ota_connection?
         assert_equal 2, transport.frames.length
+      end
+
+      def test_connect_auto_selects_bluetooth_endpoint_candidates
+        connection = BoardVM.uno_r4_wifi(
+          via: "BLE",
+          bluetooth_devices: [
+            {
+              "id" => "uno-r4",
+              "name" => "Uno R4 Board VM",
+              "address" => "AA:BB:CC:DD:EE:FF",
+              "service_uuids" => ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"]
+            }
+          ],
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new
+        )
+
+        assert_nil connection.port
+        assert_equal "bluetooth_le", connection.connection_transport
+        assert_equal "ble://AA:BB:CC:DD:EE:FF" \
+          "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e" \
+          "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e" \
+          "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e", connection.endpoint
       end
 
       def test_connect_builds_a_tcp_transport_for_wifi_endpoints


### PR DESCRIPTION
## Summary
- add Bluetooth endpoint auto-selection helpers for Ruby, Python, and Lua Board VM bindings
- have connect() fill the selected Bluetooth endpoint from Rust-owned discovery candidates when endpoint is omitted
- cover direct endpoint filtering and connect-time auto-selection in all three language test suites

## Validation
- BUNDLE_PATH=vendor/bundle bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- bash BUILD in code/packages/lua/board_vm_native
- cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge -p lua-bridge in code/packages/rust
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check
- git diff --cached --check