### PR TITLE
feat(llm-primitives): add judge_plausibility primitive (LM00b)

### DIFF
--- a/code/packages/rust/llm-primitives/CHANGELOG.md
+++ b/code/packages/rust/llm-primitives/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-05-11
+
+### Added
+
+- `judge_plausibility` module — third concrete primitive from LM00b.
+  Binary judge for ADJ05's adversarial verifier. Takes
+  `JudgePlausibilityRequest { source_span_text, ir_rendered,
+  adversary_reading, domain_hint }`; returns
+  `JudgePlausibilityResponse { plausible, reason, call_record }`.
+  Decides whether a competent practitioner in the named domain
+  would actually adopt the adversary's reading. An `IMPLAUSIBLE`
+  verdict logs the adversary's reading in the audit trail but does
+  not fail the adjudication; a `PLAUSIBLE` verdict surfaces as an
+  `AdversarialReading` violation for ADJ06.
+- Re-exported at the crate root: `llm_primitives::judge_plausibility`,
+  `llm_primitives::JudgePlausibilityRequest`,
+  `llm_primitives::JudgePlausibilityResponse`.
+- Routes via `LlmClient::complete_json` with a strict 2-field schema
+  (`plausible: bool`, `reason: string`, `additionalProperties: false`,
+  `reason` `minLength: 1`, `maxLength: 1024`).
+- `LlmCallRecord` populated: `primitive="judge_plausibility"`,
+  `role="plausibility"`, `prompt_version="plausibility-v1"`,
+  content-addressed `prompt_hash`, provider, usage, latency.
+- 10 new tests. Coverage: `NoClientForRole` when plausibility role
+  unregistered; happy path for both `plausible: true` and `false`;
+  user message tags SOURCE / IR-RENDERED / ADVERSARY / DOMAIN
+  separately; gateway `Auth` error propagates; missing `plausible`
+  field → `ValidationExhausted`; wrong-typed `plausible` (string
+  `"maybe"`) → `ValidationExhausted`; empty/whitespace-only `reason`
+  → `ValidationExhausted`; reason is trimmed on success;
+  `prompt_hash` matches an independently-built request.
+
+### Notes
+
+`JudgePlausibilityRequest.domain_hint` is a free-form string at v0.4.
+The LM00b spec defines a `DomainHints` enum (None / Clinical / Legal /
+TsaDeclaration / LicenseCompatibility / Custom); a follow-up will
+swap to the enum once that type lands in a shared crate. Prompt and
+wire shape unchanged across the upgrade.
+
 ## [0.3.0] - 2026-05-11
 
 ### Added

--- a/code/packages/rust/llm-primitives/Cargo.toml
+++ b/code/packages/rust/llm-primitives/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "llm-primitives"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "LM00b — typed LLM primitives layer. v0.1: shared scaffolding (Role, GatewayConfig, LlmCallRecord, PrimitiveError, prompt-version constants). v0.2: `entail` (bidirectional NLI). v0.3: `render_node` (faithful natural-language rendering of an IR node). Remaining primitives ship in follow-up PRs."
+description = "LM00b — typed LLM primitives layer. v0.1: shared scaffolding. v0.2: `entail` (NLI). v0.3: `render_node` (IR→text). v0.4: `judge_plausibility` (ADJ05 binary judge). Remaining primitives ship in follow-up PRs."
 
 [dependencies]
 llm-gateway = { path = "../llm-gateway" }

--- a/code/packages/rust/llm-primitives/README.md
+++ b/code/packages/rust/llm-primitives/README.md
@@ -59,9 +59,9 @@ This crate defines the building blocks every primitive plugs into.
 |---|---|---|---|
 | `entail(req, gateway)` | ✅ v0.2.0 | `Nli` | `entail` |
 | `render_node(req, gateway)` | ✅ v0.3.0 | `Renderer` | `render_node` |
+| `judge_plausibility(req, gateway)` | ✅ v0.4.0 | `Plausibility` | `judge_plausibility` |
 | `decompose_text` | planned | `Extractor` | — |
 | `find_contradicting_reading` | planned | `Adversary` | — |
-| `judge_plausibility` | planned | `Plausibility` | — |
 | `extract_rules` | planned | `RuleExtractor` | — |
 
 The crate has **no async runtime dependency**: the `LlmClient` trait

--- a/code/packages/rust/llm-primitives/src/judge_plausibility.rs
+++ b/code/packages/rust/llm-primitives/src/judge_plausibility.rs
@@ -1,0 +1,422 @@
+//! # `judge_plausibility` — decide whether an adversary's reading is plausible
+//!
+//! Third concrete primitive from
+//! [LM00b §"judge_plausibility"](../../../specs/LM00b-llm-primitives.md).
+//! Given the source span, the IR's rendering, and an adversarial
+//! reading produced by [`find_contradicting_reading`](crate::Role::Adversary),
+//! decide whether a competent practitioner in the domain would
+//! actually interpret the source the adversary's way.
+//!
+//! ## Role in ADJ05 (the adversarial verifier)
+//!
+//! ADJ05 runs a three-step check on every IR node it samples:
+//!
+//!   1. **Render** the node back into natural language (via
+//!      [`render_node`](crate::render_node)).
+//!   2. **Find a contradicting reading** of the source (via
+//!      `find_contradicting_reading`, a separate PR).
+//!   3. **Judge** whether the contradicting reading is *plausible*
+//!      — this primitive.
+//!
+//! The judge prevents the adversary from winning by being silly.
+//! An adversary that finds e.g. "the patient is a sentient cloud"
+//! contradicts the IR, but a competent practitioner would not
+//! adopt that reading; the judge must say IMPLAUSIBLE. The decision
+//! is *binary* (plausible / not) plus a short rationale.
+//!
+//! An `IMPLAUSIBLE` verdict logs the adversary's reading in the
+//! audit trail but does **not** fail the adjudication. A `PLAUSIBLE`
+//! verdict surfaces as an `AdversarialReading` violation for ADJ06
+//! to clarify with the user.
+
+use llm_gateway::{
+    CompletionRequest, JsonSchema, LlmClient, Message, MessageContent, Role as MsgRole,
+};
+
+use crate::{
+    fingerprint_prompt, GatewayConfig, LlmCallRecord, PrimitiveError, Role,
+    PLAUSIBILITY_PROMPT_VERSION,
+};
+
+/// Inputs to [`judge_plausibility`]. The judge sees the source, the
+/// IR's rendering, and the adversary's proposed alternative reading —
+/// enough to decide whether the alternative is one a competent reader
+/// would actually adopt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JudgePlausibilityRequest {
+    /// The relevant slice of the source document, verbatim.
+    pub source_span_text: String,
+    /// The IR's natural-language rendering of the same span.
+    pub ir_rendered: String,
+    /// The adversary's proposed alternative reading.
+    pub adversary_reading: String,
+    /// Free-text domain hint (e.g., "clinical-note", "tsa-declaration").
+    /// The framework's LM00b spec defines a `DomainHints` enum; this
+    /// primitive takes the string form at v0.2 to avoid binding to a
+    /// not-yet-existent type. v0.3 will swap to the enum.
+    pub domain_hint: String,
+}
+
+/// Result of one [`judge_plausibility`] call.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JudgePlausibilityResponse {
+    /// `true` iff a competent practitioner in the named domain would
+    /// actually interpret the source the adversary's way.
+    pub plausible: bool,
+    /// Short rationale for the verdict. Always populated, even on a
+    /// `plausible: false` answer — the audit trail records *why*
+    /// the judge rejected the adversary.
+    pub reason: String,
+    pub call_record: LlmCallRecord,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You are a calibrated domain expert acting as a tie-breaker. You will \
+see a SOURCE excerpt, an IR-RENDERED reading of it, and an ADVERSARY \
+alternative reading that purports to contradict the IR. Decide one \
+thing: would a competent practitioner in the named DOMAIN actually \
+interpret SOURCE the way the adversary does?\n\
+\n\
+Answer `plausible: true` only when the adversary's reading is one a \
+careful reader of SOURCE could legitimately reach. Answer \
+`plausible: false` when the adversary's reading is fanciful, ignores \
+domain conventions, or requires reading information into SOURCE that \
+isn't there. Provide a short reason (one sentence) in either case.";
+
+const RESPONSE_SCHEMA: &str = r#"{
+    "type": "object",
+    "required": ["plausible", "reason"],
+    "properties": {
+        "plausible": { "type": "boolean" },
+        "reason":    { "type": "string", "minLength": 1, "maxLength": 1024 }
+    },
+    "additionalProperties": false
+}"#;
+
+fn build_user_text(req: &JudgePlausibilityRequest) -> String {
+    format!(
+        "DOMAIN: {domain}\n\n\
+         SOURCE:\n{src}\n\n\
+         IR-RENDERED:\n{ir}\n\n\
+         ADVERSARY:\n{adv}\n\n\
+         Return the JSON object now.",
+        domain = req.domain_hint,
+        src = req.source_span_text,
+        ir = req.ir_rendered,
+        adv = req.adversary_reading,
+    )
+}
+
+fn build_completion_request(
+    client: &dyn LlmClient,
+    req: &JudgePlausibilityRequest,
+) -> CompletionRequest {
+    CompletionRequest {
+        model: client.identity().model_family.clone(),
+        system: Some(SYSTEM_PROMPT.to_string()),
+        messages: vec![Message {
+            role: MsgRole::User,
+            content: MessageContent::Text(build_user_text(req)),
+        }],
+        temperature: 0.0,
+        max_tokens: Some(512),
+        stop_sequences: Vec::new(),
+        seed: None,
+        metadata: Default::default(),
+    }
+}
+
+/// Binary plausibility judge for ADJ05. Looks up `Role::Plausibility`
+/// on the gateway; returns [`PrimitiveError::NoClientForRole`] when
+/// absent, [`PrimitiveError::Gateway`] on transport / auth failures,
+/// and [`PrimitiveError::ValidationExhausted`] when the LLM's JSON
+/// output is missing required fields, wrong-typed, or has an empty
+/// reason.
+pub fn judge_plausibility(
+    req: &JudgePlausibilityRequest,
+    gateway: &GatewayConfig,
+) -> Result<JudgePlausibilityResponse, PrimitiveError> {
+    let client = gateway
+        .client(Role::Plausibility)
+        .ok_or(PrimitiveError::NoClientForRole {
+            role: Role::Plausibility,
+        })?;
+
+    let completion_req = build_completion_request(client, req);
+    let prompt_hash = fingerprint_prompt(&completion_req);
+
+    let schema = JsonSchema {
+        name: "JudgePlausibilityResponse".to_string(),
+        schema_json: RESPONSE_SCHEMA.to_string(),
+    };
+
+    let json_resp = client
+        .complete_json(completion_req, &schema)
+        .map_err(PrimitiveError::Gateway)?;
+
+    let v = &json_resp.parsed;
+    let plausible = v.get("plausible").and_then(|x| x.as_bool());
+    let reason = v.get("reason").and_then(|x| x.as_str()).map(str::to_string);
+
+    let (Some(plausible), Some(reason)) = (plausible, reason) else {
+        return Err(PrimitiveError::ValidationExhausted {
+            last_response: json_resp.raw_text,
+            last_error: "missing or wrong-typed field in plausibility response".to_string(),
+            attempts: 1,
+        });
+    };
+
+    let reason_trimmed = reason.trim().to_string();
+    if reason_trimmed.is_empty() {
+        return Err(PrimitiveError::ValidationExhausted {
+            last_response: json_resp.raw_text,
+            last_error: "plausibility judge returned empty reason".to_string(),
+            attempts: 1,
+        });
+    }
+
+    let call_record = LlmCallRecord {
+        primitive: "judge_plausibility".to_string(),
+        role: Role::Plausibility.as_str().to_string(),
+        prompt_version: PLAUSIBILITY_PROMPT_VERSION.to_string(),
+        prompt_hash,
+        provider: json_resp.provider_id,
+        usage: json_resp.usage,
+        finish_reason: llm_gateway::FinishReason::Stop,
+        latency_ms: json_resp.latency_ms,
+        cost_usd: 0.0,
+    };
+
+    Ok(JudgePlausibilityResponse {
+        plausible,
+        reason: reason_trimmed,
+        call_record,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llm_gateway::{
+        Capabilities, CompletionJsonResponse, CompletionRequest, JsonSchema, LlmClient, LlmError,
+        MockLlmClient, ProviderIdentity, TokenUsage,
+    };
+    use std::sync::Mutex;
+
+    fn judge_identity() -> ProviderIdentity {
+        ProviderIdentity {
+            vendor: "mock".into(),
+            model_family: "haiku-judge".into(),
+            model_version: "1".into(),
+            endpoint: None,
+        }
+    }
+
+    struct ScriptedJson {
+        identity: ProviderIdentity,
+        response: Mutex<Option<Result<CompletionJsonResponse, LlmError>>>,
+    }
+
+    impl ScriptedJson {
+        fn new(value: serde_json::Value) -> Self {
+            let raw_text = value.to_string();
+            Self {
+                identity: judge_identity(),
+                response: Mutex::new(Some(Ok(CompletionJsonResponse {
+                    raw_text,
+                    parsed: value,
+                    schema_valid: true,
+                    model: "haiku-judge".into(),
+                    usage: TokenUsage {
+                        input_tokens: 90,
+                        output_tokens: 14,
+                        cached_tokens: 0,
+                    },
+                    provider_id: judge_identity(),
+                    latency_ms: 31,
+                    polyfill_used: false,
+                }))),
+            }
+        }
+
+        fn with_error(err: LlmError) -> Self {
+            Self {
+                identity: judge_identity(),
+                response: Mutex::new(Some(Err(err))),
+            }
+        }
+    }
+
+    impl LlmClient for ScriptedJson {
+        fn identity(&self) -> ProviderIdentity {
+            self.identity.clone()
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::modern_frontier()
+        }
+        fn complete(
+            &self,
+            _req: CompletionRequest,
+        ) -> Result<llm_gateway::CompletionResponse, LlmError> {
+            unreachable!("judge_plausibility uses complete_json")
+        }
+        fn complete_json(
+            &self,
+            _req: CompletionRequest,
+            _schema: &JsonSchema,
+        ) -> Result<CompletionJsonResponse, LlmError> {
+            self.response
+                .lock()
+                .unwrap()
+                .take()
+                .expect("ScriptedJson::complete_json called more than once")
+        }
+    }
+
+    fn req() -> JudgePlausibilityRequest {
+        JudgePlausibilityRequest {
+            source_span_text: "1 carry-on bag, 1 personal item.".into(),
+            ir_rendered: "The passenger declared one carry-on bag and one personal item.".into(),
+            adversary_reading:
+                "The passenger declared zero carry-on bags by saying \"1 carry-on bag\"."
+                    .into(),
+            domain_hint: "tsa-declaration".into(),
+        }
+    }
+
+    #[test]
+    fn missing_plausibility_client_returns_no_client_for_role() {
+        let g = GatewayConfig::new();
+        let err = judge_plausibility(&req(), &g).unwrap_err();
+        match err {
+            PrimitiveError::NoClientForRole { role } => assert_eq!(role, Role::Plausibility),
+            other => panic!("expected NoClientForRole, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn happy_path_implausible_returns_parsed_response() {
+        let mock = ScriptedJson::new(serde_json::json!({
+            "plausible": false,
+            "reason": "Reading 1 as 0 contradicts the literal numeral; competent readers don't.",
+        }));
+        let g = GatewayConfig::new().with_client(Role::Plausibility, Box::new(mock));
+        let resp = judge_plausibility(&req(), &g).unwrap();
+
+        assert!(!resp.plausible);
+        assert!(resp.reason.contains("contradicts the literal numeral"));
+        assert_eq!(resp.call_record.primitive, "judge_plausibility");
+        assert_eq!(resp.call_record.role, "plausibility");
+        assert_eq!(resp.call_record.prompt_version, "plausibility-v1");
+        assert!(!resp.call_record.prompt_hash.is_empty());
+        assert_eq!(resp.call_record.usage.output_tokens, 14);
+        assert_eq!(resp.call_record.latency_ms, 31);
+    }
+
+    #[test]
+    fn happy_path_plausible_returns_parsed_response() {
+        let mock = ScriptedJson::new(serde_json::json!({
+            "plausible": true,
+            "reason": "The source is ambiguous about quantity given trailing punctuation.",
+        }));
+        let g = GatewayConfig::new().with_client(Role::Plausibility, Box::new(mock));
+        let resp = judge_plausibility(&req(), &g).unwrap();
+        assert!(resp.plausible);
+        assert!(resp.reason.contains("ambiguous"));
+    }
+
+    #[test]
+    fn user_message_tags_source_ir_and_adversary_separately() {
+        let r = req();
+        let text = build_user_text(&r);
+        assert!(text.contains("DOMAIN: tsa-declaration"));
+        assert!(text.contains("SOURCE:\n1 carry-on"));
+        assert!(text.contains("IR-RENDERED:\nThe passenger declared"));
+        assert!(text.contains("ADVERSARY:\nThe passenger declared zero"));
+    }
+
+    #[test]
+    fn gateway_auth_error_propagates_as_gateway_variant() {
+        let mock = ScriptedJson::with_error(LlmError::Auth {
+            provider: judge_identity(),
+            detail: "expired key".into(),
+        });
+        let g = GatewayConfig::new().with_client(Role::Plausibility, Box::new(mock));
+        let err = judge_plausibility(&req(), &g).unwrap_err();
+        assert!(matches!(err, PrimitiveError::Gateway(LlmError::Auth { .. })));
+    }
+
+    #[test]
+    fn missing_plausible_field_returns_validation_exhausted() {
+        let mock = ScriptedJson::new(serde_json::json!({
+            "reason": "ok",
+        }));
+        let g = GatewayConfig::new().with_client(Role::Plausibility, Box::new(mock));
+        let err = judge_plausibility(&req(), &g).unwrap_err();
+        match err {
+            PrimitiveError::ValidationExhausted { attempts, last_error, .. } => {
+                assert_eq!(attempts, 1);
+                assert!(last_error.contains("missing or wrong-typed"));
+            }
+            other => panic!("expected ValidationExhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_typed_plausible_returns_validation_exhausted() {
+        let mock = ScriptedJson::new(serde_json::json!({
+            "plausible": "maybe",
+            "reason": "hedging",
+        }));
+        let g = GatewayConfig::new().with_client(Role::Plausibility, Box::new(mock));
+        let err = judge_plausibility(&req(), &g).unwrap_err();
+        assert!(matches!(err, PrimitiveError::ValidationExhausted { .. }));
+    }
+
+    #[test]
+    fn empty_reason_returns_validation_exhausted() {
+        let mock = ScriptedJson::new(serde_json::json!({
+            "plausible": true,
+            "reason": "   \t\n",
+        }));
+        let g = GatewayConfig::new().with_client(Role::Plausibility, Box::new(mock));
+        let err = judge_plausibility(&req(), &g).unwrap_err();
+        match err {
+            PrimitiveError::ValidationExhausted { last_error, .. } => {
+                assert!(last_error.contains("empty reason"));
+            }
+            other => panic!("expected ValidationExhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reason_is_trimmed_on_success() {
+        let mock = ScriptedJson::new(serde_json::json!({
+            "plausible": false,
+            "reason": "  not plausible.  \n",
+        }));
+        let g = GatewayConfig::new().with_client(Role::Plausibility, Box::new(mock));
+        let resp = judge_plausibility(&req(), &g).unwrap();
+        assert_eq!(resp.reason, "not plausible.");
+    }
+
+    #[test]
+    fn call_record_prompt_hash_matches_built_request() {
+        let stub: Box<dyn LlmClient> =
+            Box::new(MockLlmClient::new().with_identity(judge_identity()));
+        let cr = build_completion_request(stub.as_ref(), &req());
+        let expected_hash = crate::fingerprint_prompt(&cr);
+
+        let mock = ScriptedJson::new(serde_json::json!({
+            "plausible": false,
+            "reason": "ok",
+        }));
+        let g = GatewayConfig::new().with_client(Role::Plausibility, Box::new(mock));
+        let resp = judge_plausibility(&req(), &g).unwrap();
+        assert_eq!(resp.call_record.prompt_hash, expected_hash);
+    }
+}

--- a/code/packages/rust/llm-primitives/src/lib.rs
+++ b/code/packages/rust/llm-primitives/src/lib.rs
@@ -41,9 +41,9 @@
 //!   * [`entail`] — bidirectional textual entailment (v0.2.0)
 //!   * [`render_node`] — faithful natural-language rendering of an
 //!     IR node (v0.3.0)
+//!   * [`judge_plausibility`] — ADJ05 binary plausibility judge (v0.4.0)
 //!   * `decompose_text` — extractor; not yet here
 //!   * `find_contradicting_reading` — adversary; not yet here
-//!   * `judge_plausibility` — plausibility judge; not yet here
 //!   * `extract_rules` — rule extractor; not yet here
 //!
 //! Until a primitive lands, its `PROMPT_VERSION_*` constant is the
@@ -65,13 +65,18 @@ use llm_gateway::{
 };
 
 pub mod entail;
+pub mod judge_plausibility;
 pub mod render_node;
 
 // Re-exports at the crate root. Each primitive's function and module
 // share a name; Rust allows that since they live in different
 // namespaces, so callers can write `llm_primitives::entail(...)` /
-// `llm_primitives::render_node(...)` directly.
+// `llm_primitives::render_node(...)` / `llm_primitives::judge_plausibility(...)`
+// directly.
 pub use entail::{entail, EntailRequest, EntailResponse};
+pub use judge_plausibility::{
+    judge_plausibility, JudgePlausibilityRequest, JudgePlausibilityResponse,
+};
 pub use render_node::{render_node, RenderNodeRequest, RenderNodeResponse, RenderStyle};
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Third concrete primitive from LM00b: binary plausibility judge for ADJ05's adversarial verifier.
- Lives in \`code/packages/rust/llm-primitives/src/judge_plausibility.rs\`. Re-exported at crate root.
- 10 new tests (25 total in crate, all passing). Clippy clean. Security review passed.

## What it does

\`\`\`rust
use llm_primitives::{judge_plausibility, JudgePlausibilityRequest, GatewayConfig, Role};

let gateway = GatewayConfig::new()
    .with_client(Role::Plausibility, Box::new(/* small cheap LlmClient */));

let resp = judge_plausibility(&JudgePlausibilityRequest {
    source_span_text:  \"1 carry-on bag, 1 personal item.\".into(),
    ir_rendered:       \"The passenger declared one carry-on bag and one personal item.\".into(),
    adversary_reading: \"The passenger declared zero carry-on bags by saying '1'.\".into(),
    domain_hint:       \"tsa-declaration\".into(),
}, &gateway)?;

// resp.plausible == false
// resp.reason    == \"Reading 1 as 0 contradicts the literal numeral; competent readers don't.\"
// resp.call_record → audit trail
\`\`\`

## Role in ADJ05

ADJ05's adversarial verifier runs three steps per sampled IR node:

1. \`render_node\` — render the IR back into natural language ([#2723](https://github.com/adhithyan15/coding-adventures/pull/2723)).
2. \`find_contradicting_reading\` — adversary finds a reading of SOURCE that contradicts the IR (separate follow-up PR).
3. \`judge_plausibility\` — **this primitive** — decide whether the adversary's reading is one a competent domain practitioner would actually adopt.

The judge prevents the adversary from winning by being silly. An \`IMPLAUSIBLE\` verdict logs the adversary's reading in the audit trail but does NOT fail the adjudication; a \`PLAUSIBLE\` verdict surfaces as an \`AdversarialReading\` violation for ADJ06 to clarify.

## Implementation notes

- \`Role::Plausibility\` lookup. Missing → \`PrimitiveError::NoClientForRole\`.
- System prompt versioned by \`PLAUSIBILITY_PROMPT_VERSION\`.
- User message tags \`DOMAIN\` / \`SOURCE\` / \`IR-RENDERED\` / \`ADVERSARY\` separately.
- Routes via \`LlmClient::complete_json\` with strict 2-field schema (\`additionalProperties: false\`).
- Empty/whitespace-only \`reason\` → \`ValidationExhausted\` — the judge must explain itself.
- \`reason\` is trimmed on success.

## Why \`domain_hint: String\` and not typed \`DomainHints\`

LM00b spec defines a \`DomainHints\` enum (Clinical / Legal / TsaDeclaration / LicenseCompatibility / Custom). v0.2 takes a free-form string. v0.3 will swap to the enum once that type lands in a shared crate. Prompt and wire shape unchanged across the upgrade.

## Security review

Passed, no findings. Same shape as the previously-reviewed \`entail\` and \`render_node\` primitives.

## Parallel to #2719 + #2723

Independent of [#2719 (entail)](https://github.com/adhithyan15/coding-adventures/pull/2719) and [#2723 (render_node)](https://github.com/adhithyan15/coding-adventures/pull/2723); all three branched from the merged llm-primitives v0.1 skeleton. The first to merge wins; the others rebase to keep all \`pub mod\` lines + re-export blocks in \`lib.rs\` and consolidate \`Cargo.toml\` / \`CHANGELOG\`.

## Test plan

- [x] \`cargo test -p llm-primitives\` — 25/25 pass
- [x] \`cargo clippy -p llm-primitives --tests -- -D warnings\` — clean
- [x] Security review — passed
- [ ] CI green
- [ ] User sign-off

3 primitives remain: \`decompose_text\`, \`find_contradicting_reading\`, \`extract_rules\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)