### PR TITLE
[codex] Add TypeScript symbolic derivative handler

### DIFF
--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added a symbolic-backend-only `D` handler for pure IR differentiation,
+  including arithmetic, power, elementary, hyperbolic, and inverse hyperbolic
+  chain rules.
+
 ## [0.1.0] - 2026-05-08
 
 ### Added

--- a/code/packages/typescript/symbolic-vm/README.md
+++ b/code/packages/typescript/symbolic-vm/README.md
@@ -6,13 +6,14 @@ The VM is policy-free. A backend supplies name lookup, held heads, rewrite
 rules, and per-head handlers.
 
 ```ts
-import { ADD, app, int, sym } from "@coding-adventures/symbolic-ir";
+import { ADD, D, POW, app, int, sym } from "@coding-adventures/symbolic-ir";
 import { SymbolicBackend, VM } from "@coding-adventures/symbolic-vm";
 
 const vm = new VM(new SymbolicBackend());
 
 vm.eval(app(ADD, [int(2), int(3)]));    // 5
 vm.eval(app(ADD, [sym("x"), int(0)])); // x
+vm.eval(app(D, [app(POW, [sym("x"), int(2)]), sym("x")])); // 2*x
 ```
 
 The package has no host dependencies and is safe to use in browsers.

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -10,6 +10,7 @@ import {
   ATANH,
   COS,
   COSH,
+  D,
   DEFINE,
   DIV,
   EQUAL,
@@ -345,8 +346,148 @@ function buildHandlerTable(simplify: boolean): ReadonlyMap<string, Handler> {
     return name;
   });
   table.set(LIST.name, (_vm, expr) => expr);
+  if (simplify) {
+    table.set(D.name, differentiate());
+  }
 
   return table;
+}
+
+function differentiate(): Handler {
+  return (vm, expr) => {
+    if (expr.args.length !== 2) {
+      throw new ArityError(`D expects 2 arguments, got ${expr.args.length}`);
+    }
+    const [f, x] = expr.args;
+    if (x.kind !== "symbol") {
+      return expr;
+    }
+    const result = diff(f, x);
+    return isDeferredDerivative(result, f, x) ? result : vm.eval(result);
+  };
+}
+
+function diff(f: IRNode, x: IRNode): IRNode {
+  if (!dependsOn(f, x)) {
+    return int(0);
+  }
+  if (equals(f, x)) {
+    return int(1);
+  }
+  if (f.kind !== "apply") {
+    return app(D, [f, x]);
+  }
+
+  if (equals(f.head, ADD)) {
+    return f.args.map((arg) => diff(arg, x)).reduce((left, right) => app(ADD, [left, right]));
+  }
+  if (equals(f.head, SUB)) {
+    const [a, b] = binaryArgs(f);
+    return app(SUB, [diff(a, x), diff(b, x)]);
+  }
+  if (equals(f.head, NEG)) {
+    const [inner] = unaryArgs(f);
+    return app(NEG, [diff(inner, x)]);
+  }
+  if (equals(f.head, MUL)) {
+    const [a, b] = binaryArgs(f);
+    return app(ADD, [
+      app(MUL, [diff(a, x), b]),
+      app(MUL, [a, diff(b, x)]),
+    ]);
+  }
+  if (equals(f.head, DIV)) {
+    const [a, b] = binaryArgs(f);
+    return app(DIV, [
+      app(SUB, [
+        app(MUL, [diff(a, x), b]),
+        app(MUL, [a, diff(b, x)]),
+      ]),
+      app(POW, [b, int(2)]),
+    ]);
+  }
+  if (equals(f.head, POW)) {
+    const [base, exponent] = binaryArgs(f);
+    const baseDepends = dependsOn(base, x);
+    const exponentDepends = dependsOn(exponent, x);
+    if (!exponentDepends) {
+      return app(MUL, [
+        app(MUL, [
+          exponent,
+          app(POW, [base, app(SUB, [exponent, int(1)])]),
+        ]),
+        diff(base, x),
+      ]);
+    }
+    if (!baseDepends) {
+      return app(MUL, [
+        app(MUL, [f, app(LOG, [base])]),
+        diff(exponent, x),
+      ]);
+    }
+    return diff(app(EXP, [app(MUL, [exponent, app(LOG, [base])])]), x);
+  }
+
+  const [inner] = f.args.length === 1 ? [f.args[0]] : [undefined];
+  if (inner !== undefined) {
+    const innerDiff = diff(inner, x);
+    if (equals(f.head, SIN)) {
+      return app(MUL, [app(COS, [inner]), innerDiff]);
+    }
+    if (equals(f.head, COS)) {
+      return app(MUL, [app(NEG, [app(SIN, [inner])]), innerDiff]);
+    }
+    if (equals(f.head, TAN)) {
+      return app(DIV, [innerDiff, app(POW, [app(COS, [inner]), int(2)])]);
+    }
+    if (equals(f.head, EXP)) {
+      return app(MUL, [app(EXP, [inner]), innerDiff]);
+    }
+    if (equals(f.head, LOG)) {
+      return app(DIV, [innerDiff, inner]);
+    }
+    if (equals(f.head, SQRT)) {
+      return app(DIV, [innerDiff, app(MUL, [int(2), app(SQRT, [inner])])]);
+    }
+    if (equals(f.head, SINH)) {
+      return app(MUL, [app(COSH, [inner]), innerDiff]);
+    }
+    if (equals(f.head, COSH)) {
+      return app(MUL, [app(SINH, [inner]), innerDiff]);
+    }
+    if (equals(f.head, TANH)) {
+      return app(DIV, [innerDiff, app(POW, [app(COSH, [inner]), int(2)])]);
+    }
+    if (equals(f.head, ASINH)) {
+      return app(DIV, [innerDiff, app(SQRT, [app(ADD, [app(POW, [inner, int(2)]), int(1)])])]);
+    }
+    if (equals(f.head, ACOSH)) {
+      return app(DIV, [innerDiff, app(SQRT, [app(SUB, [app(POW, [inner, int(2)]), int(1)])])]);
+    }
+    if (equals(f.head, ATANH)) {
+      return app(DIV, [innerDiff, app(SUB, [int(1), app(POW, [inner, int(2)])])]);
+    }
+  }
+
+  return app(D, [f, x]);
+}
+
+function dependsOn(node: IRNode, variable: IRNode): boolean {
+  if (node.kind === "symbol") {
+    return equals(node, variable);
+  }
+  if (node.kind === "apply") {
+    return dependsOn(node.head, variable) || node.args.some((arg) => dependsOn(arg, variable));
+  }
+  return false;
+}
+
+function isDeferredDerivative(node: IRNode, f: IRNode, x: IRNode): boolean {
+  return node.kind === "apply"
+    && equals(node.head, D)
+    && node.args.length === 2
+    && equals(node.args[0], f)
+    && equals(node.args[1], x);
 }
 
 type Numeric =

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -1,20 +1,35 @@
 import { describe, expect, it } from "vitest";
 import {
+  ACOSH,
   ADD,
+  ASINH,
   ASSIGN,
+  ATANH,
+  COS,
+  COSH,
+  D,
   DEFINE,
   DIV,
   EQUAL,
+  EXP,
   FALSE,
   IF,
   LIST,
+  LOG,
   MUL,
+  NEG,
   POW,
   SIN,
+  SINH,
+  SQRT,
+  SUB,
+  TAN,
+  TANH,
   TRUE,
   app,
   equals,
   int,
+  numberNode,
   rational,
   sym,
 } from "@coding-adventures/symbolic-ir";
@@ -96,5 +111,90 @@ describe("symbolic-vm", () => {
     const vm = new VM(new SymbolicBackend());
     const result = vm.eval(app(ADD, [int(1), int(2)]));
     expect(equals(result, int(3))).toBe(true);
+  });
+
+  it("keeps D symbolic-backend-only", () => {
+    const vm = new VM(new StrictBackend());
+    expect(() => vm.eval(app(D, [int(1), int(1)]))).toThrow(StrictEvaluationError);
+  });
+
+  it("differentiates constants and variable identity", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(D, [int(5), sym("x")]))).toEqual(int(0));
+    expect(vm.eval(app(D, [sym("y"), sym("x")]))).toEqual(int(0));
+    expect(vm.eval(app(D, [sym("x"), sym("x")]))).toEqual(int(1));
+  });
+
+  it("differentiates Add, Sub, and Neg", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(D, [app(ADD, [app(POW, [sym("x"), int(2)]), sym("x")]), sym("x")]))).toEqual(
+      app(ADD, [app(MUL, [int(2), sym("x")]), int(1)]),
+    );
+    expect(vm.eval(app(D, [app(SUB, [sym("x"), sym("y")]), sym("x")]))).toEqual(int(1));
+    expect(vm.eval(app(D, [app(NEG, [sym("x")]), sym("x")]))).toEqual(int(-1));
+  });
+
+  it("differentiates product and quotient rules", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(D, [app(MUL, [sym("x"), sym("y")]), sym("x")]))).toEqual(sym("y"));
+    expect(vm.eval(app(D, [app(DIV, [sym("x"), sym("y")]), sym("x")]))).toEqual(
+      app(DIV, [sym("y"), app(POW, [sym("y"), int(2)])]),
+    );
+  });
+
+  it("differentiates constant, exponential, and general powers", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(D, [app(POW, [sym("x"), int(3)]), sym("x")]))).toEqual(
+      app(MUL, [int(3), app(POW, [sym("x"), int(2)])]),
+    );
+    expect(vm.eval(app(D, [app(POW, [int(2), sym("x")]), sym("x")]))).toEqual(
+      app(MUL, [app(POW, [int(2), sym("x")]), numberNode(Math.log(2))]),
+    );
+    expect(vm.eval(app(D, [app(POW, [sym("x"), sym("x")]), sym("x")]))).toEqual(
+      app(MUL, [
+        app(EXP, [app(MUL, [sym("x"), app(LOG, [sym("x")])])]),
+        app(ADD, [app(LOG, [sym("x")]), app(MUL, [sym("x"), app(DIV, [int(1), sym("x")])])]),
+      ]),
+    );
+  });
+
+  it("applies elementary chain rules", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(D, [app(SIN, [app(POW, [sym("x"), int(2)])]), sym("x")]))).toEqual(
+      app(MUL, [app(COS, [app(POW, [sym("x"), int(2)])]), app(MUL, [int(2), sym("x")])]),
+    );
+    expect(vm.eval(app(D, [app(COS, [sym("x")]), sym("x")]))).toEqual(app(NEG, [app(SIN, [sym("x")])]));
+    expect(vm.eval(app(D, [app(TAN, [sym("x")]), sym("x")]))).toEqual(
+      app(DIV, [int(1), app(POW, [app(COS, [sym("x")]), int(2)])]),
+    );
+    expect(vm.eval(app(D, [app(EXP, [sym("x")]), sym("x")]))).toEqual(app(EXP, [sym("x")]));
+    expect(vm.eval(app(D, [app(LOG, [sym("x")]), sym("x")]))).toEqual(app(DIV, [int(1), sym("x")]));
+    expect(vm.eval(app(D, [app(SQRT, [sym("x")]), sym("x")]))).toEqual(
+      app(DIV, [int(1), app(MUL, [int(2), app(SQRT, [sym("x")])])]),
+    );
+  });
+
+  it("applies hyperbolic and inverse hyperbolic chain rules", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(D, [app(SINH, [sym("x")]), sym("x")]))).toEqual(app(COSH, [sym("x")]));
+    expect(vm.eval(app(D, [app(COSH, [sym("x")]), sym("x")]))).toEqual(app(SINH, [sym("x")]));
+    expect(vm.eval(app(D, [app(TANH, [sym("x")]), sym("x")]))).toEqual(
+      app(DIV, [int(1), app(POW, [app(COSH, [sym("x")]), int(2)])]),
+    );
+    expect(vm.eval(app(D, [app(ASINH, [sym("x")]), sym("x")]))).toEqual(
+      app(DIV, [int(1), app(SQRT, [app(ADD, [app(POW, [sym("x"), int(2)]), int(1)])])]),
+    );
+    expect(vm.eval(app(D, [app(ACOSH, [sym("x")]), sym("x")]))).toEqual(
+      app(DIV, [int(1), app(SQRT, [app(SUB, [app(POW, [sym("x"), int(2)]), int(1)])])]),
+    );
+    expect(vm.eval(app(D, [app(ATANH, [sym("x")]), sym("x")]))).toEqual(
+      app(DIV, [int(1), app(SUB, [int(1), app(POW, [sym("x"), int(2)])])]),
+    );
+  });
+
+  it("leaves unknown dependent derivatives unevaluated", () => {
+    const vm = new VM(new SymbolicBackend());
+    const expr = app(D, [app(sym("F"), [sym("x")]), sym("x")]);
+    expect(vm.eval(expr)).toEqual(expr);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a symbolic-backend-only `D` handler for the pure TypeScript symbolic VM.
- Covers constants, variable identity, Add/Sub/Neg, product, quotient, constant/exponential/general powers, elementary chain rules, and hyperbolic/inverse hyperbolic chain rules present in `symbolic-ir`.
- Documents the IR API entry point and records the change in the package changelog.

## Validation
- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage`