### PR TITLE
[codex] Port Phase 21 CAS simplification helpers to TypeScript

### DIFF
--- a/code/packages/typescript/cas-simplify/src/assumptions.ts
+++ b/code/packages/typescript/cas-simplify/src/assumptions.ts
@@ -1,0 +1,174 @@
+import {
+  EQUAL,
+  GREATER,
+  GREATER_EQUAL,
+  IRNode,
+  LESS,
+  LESS_EQUAL,
+  NOT_EQUAL,
+  equals,
+  headName,
+  int,
+} from "@coding-adventures/symbolic-ir";
+
+const POSITIVE = "positive";
+const NEGATIVE = "negative";
+const ZERO = "zero";
+const NONZERO = "nonzero";
+const NONNEG = "nonneg";
+const NONPOS = "nonpos";
+const INTEGER = "integer";
+
+const PROPERTY_MAP = new Map<string, string>([
+  ["positive", POSITIVE],
+  ["pos", POSITIVE],
+  ["negative", NEGATIVE],
+  ["neg", NEGATIVE],
+  ["zero", ZERO],
+  ["nonzero", NONZERO],
+  ["nonneg", NONNEG],
+  ["nonnegative", NONNEG],
+  ["nonpos", NONPOS],
+  ["nonpositive", NONPOS],
+  ["integer", INTEGER],
+  ["integerp", INTEGER],
+]);
+
+const ZERO_IR = int(0);
+
+export class AssumptionContext {
+  private readonly facts = new Map<string, Set<string>>();
+
+  assumeRelation(expr: IRNode): void {
+    const parsed = relationAgainstZero(expr);
+    if (parsed === undefined) return;
+    const [symbolName, relation] = parsed;
+    if (relation === GREATER.name) this.add(symbolName, POSITIVE);
+    else if (relation === LESS.name) this.add(symbolName, NEGATIVE);
+    else if (relation === GREATER_EQUAL.name) this.add(symbolName, NONNEG);
+    else if (relation === LESS_EQUAL.name) this.add(symbolName, NONPOS);
+    else if (relation === EQUAL.name) this.add(symbolName, ZERO);
+    else if (relation === NOT_EQUAL.name) this.add(symbolName, NONZERO);
+  }
+
+  assumeProperty(symbol: IRNode, property: IRNode): void {
+    const symbolName = symbolNameOf(symbol);
+    const propertyName = symbolNameOf(property);
+    if (symbolName === undefined || propertyName === undefined) return;
+    const fact = PROPERTY_MAP.get(propertyName.toLowerCase());
+    if (fact !== undefined) this.add(symbolName, fact);
+  }
+
+  forgetRelation(expr: IRNode): void {
+    const parsed = relationAgainstZero(expr);
+    if (parsed === undefined) return;
+    const [symbolName, relation] = parsed;
+    if (relation === GREATER.name) this.remove(symbolName, POSITIVE);
+    else if (relation === LESS.name) this.remove(symbolName, NEGATIVE);
+    else if (relation === GREATER_EQUAL.name) this.remove(symbolName, NONNEG);
+    else if (relation === LESS_EQUAL.name) this.remove(symbolName, NONPOS);
+    else if (relation === EQUAL.name) this.remove(symbolName, ZERO);
+    else if (relation === NOT_EQUAL.name) this.remove(symbolName, NONZERO);
+  }
+
+  forgetAll(): void {
+    this.facts.clear();
+  }
+
+  isPositive(symbolName: string): boolean | undefined {
+    const facts = this.facts.get(symbolName);
+    if (facts?.has(POSITIVE)) return true;
+    if (facts?.has(NEGATIVE) || facts?.has(ZERO)) return false;
+    return undefined;
+  }
+
+  isNegative(symbolName: string): boolean | undefined {
+    const facts = this.facts.get(symbolName);
+    if (facts?.has(NEGATIVE)) return true;
+    if (facts?.has(POSITIVE) || facts?.has(ZERO) || facts?.has(NONNEG)) return false;
+    return undefined;
+  }
+
+  isNonneg(symbolName: string): boolean | undefined {
+    const facts = this.facts.get(symbolName);
+    if (facts?.has(NONNEG) || facts?.has(POSITIVE) || facts?.has(ZERO)) return true;
+    if (facts?.has(NEGATIVE)) return false;
+    return undefined;
+  }
+
+  isInteger(symbolName: string): boolean {
+    return this.facts.get(symbolName)?.has(INTEGER) ?? false;
+  }
+
+  signOf(symbolName: string): 1 | -1 | 0 | undefined {
+    const facts = this.facts.get(symbolName);
+    if (facts?.has(POSITIVE)) return 1;
+    if (facts?.has(NEGATIVE)) return -1;
+    if (facts?.has(ZERO)) return 0;
+    return undefined;
+  }
+
+  isTrueRelation(expr: IRNode): boolean | undefined {
+    const parsed = relationAgainstZero(expr);
+    if (parsed === undefined) return undefined;
+    const [symbolName, relation] = parsed;
+    const facts = this.facts.get(symbolName);
+
+    if (relation === GREATER.name) return this.isPositive(symbolName);
+    if (relation === LESS.name) return this.isNegative(symbolName);
+    if (relation === GREATER_EQUAL.name) {
+      if (facts?.has(POSITIVE) || facts?.has(ZERO) || facts?.has(NONNEG)) return true;
+      if (facts?.has(NEGATIVE)) return false;
+      return undefined;
+    }
+    if (relation === LESS_EQUAL.name) {
+      if (facts?.has(NEGATIVE) || facts?.has(ZERO) || facts?.has(NONPOS)) return true;
+      if (facts?.has(POSITIVE)) return false;
+      return undefined;
+    }
+    if (relation === EQUAL.name) {
+      if (facts?.has(ZERO)) return true;
+      if (facts?.has(POSITIVE) || facts?.has(NEGATIVE) || facts?.has(NONZERO)) return false;
+      return undefined;
+    }
+    if (relation === NOT_EQUAL.name) {
+      if (facts?.has(NONZERO) || facts?.has(POSITIVE) || facts?.has(NEGATIVE)) return true;
+      if (facts?.has(ZERO)) return false;
+      return undefined;
+    }
+    return undefined;
+  }
+
+  hasAnyFacts(symbolName: string): boolean {
+    return (this.facts.get(symbolName)?.size ?? 0) > 0;
+  }
+
+  private add(symbolName: string, fact: string): void {
+    const existing = this.facts.get(symbolName);
+    if (existing === undefined) {
+      this.facts.set(symbolName, new Set([fact]));
+    } else {
+      existing.add(fact);
+    }
+  }
+
+  private remove(symbolName: string, fact: string): void {
+    const existing = this.facts.get(symbolName);
+    if (existing === undefined) return;
+    existing.delete(fact);
+    if (existing.size === 0) this.facts.delete(symbolName);
+  }
+}
+
+function relationAgainstZero(expr: IRNode): readonly [string, string] | undefined {
+  if (expr.kind !== "apply" || expr.args.length !== 2 || !equals(expr.args[1], ZERO_IR)) {
+    return undefined;
+  }
+  const symbolName = symbolNameOf(expr.args[0]);
+  if (symbolName === undefined) return undefined;
+  return [symbolName, headName(expr.head)];
+}
+
+function symbolNameOf(node: IRNode): string | undefined {
+  return node.kind === "symbol" ? node.name : undefined;
+}

--- a/code/packages/typescript/cas-simplify/src/exponentialize.ts
+++ b/code/packages/typescript/cas-simplify/src/exponentialize.ts
@@ -1,0 +1,157 @@
+import {
+  ADD,
+  COS,
+  COSH,
+  DIV,
+  EXP,
+  IRNode,
+  MUL,
+  NEG,
+  SIN,
+  SINH,
+  SUB,
+  TAN,
+  TANH,
+  app,
+  equals,
+  headName,
+  int,
+  sym,
+} from "@coding-adventures/symbolic-ir";
+
+export const IMAGINARY_UNIT = sym("ImaginaryUnit");
+
+const TWO = int(2);
+
+export function exponentialize(expr: IRNode): IRNode {
+  if (expr.kind !== "apply") return expr;
+  const node = app(expr.head, expr.args.map(exponentialize));
+  return exponentializeNode(node);
+}
+
+export function demoivre(expr: IRNode): IRNode {
+  if (expr.kind !== "apply") return expr;
+  const node = app(expr.head, expr.args.map(demoivre));
+  return demoivreNode(node);
+}
+
+function exponentializeNode(expr: Extract<IRNode, { kind: "apply" }>): IRNode {
+  if (expr.args.length !== 1) return expr;
+  const name = headName(expr.head);
+  const x = expr.args[0];
+  if (name === SIN.name) return sinExp(x);
+  if (name === COS.name) return cosExp(x);
+  if (name === TAN.name) return tanExp(x);
+  if (name === SINH.name) return sinhExp(x);
+  if (name === COSH.name) return coshExp(x);
+  if (name === TANH.name) return tanhExp(x);
+  return expr;
+}
+
+function ix(x: IRNode): IRNode {
+  return app(MUL, [IMAGINARY_UNIT, x]);
+}
+
+function negIx(x: IRNode): IRNode {
+  return app(MUL, [IMAGINARY_UNIT, app(NEG, [x])]);
+}
+
+function sinExp(x: IRNode): IRNode {
+  const ePos = app(EXP, [ix(x)]);
+  const eNeg = app(EXP, [negIx(x)]);
+  return app(DIV, [app(SUB, [ePos, eNeg]), app(MUL, [TWO, IMAGINARY_UNIT])]);
+}
+
+function cosExp(x: IRNode): IRNode {
+  const ePos = app(EXP, [ix(x)]);
+  const eNeg = app(EXP, [negIx(x)]);
+  return app(DIV, [app(ADD, [ePos, eNeg]), TWO]);
+}
+
+function tanExp(x: IRNode): IRNode {
+  const ePos = app(EXP, [ix(x)]);
+  const eNeg = app(EXP, [negIx(x)]);
+  const numerator = app(MUL, [app(NEG, [IMAGINARY_UNIT]), app(SUB, [ePos, eNeg])]);
+  return app(DIV, [numerator, app(ADD, [ePos, eNeg])]);
+}
+
+function sinhExp(x: IRNode): IRNode {
+  const ePos = app(EXP, [x]);
+  const eNeg = app(EXP, [app(NEG, [x])]);
+  return app(DIV, [app(SUB, [ePos, eNeg]), TWO]);
+}
+
+function coshExp(x: IRNode): IRNode {
+  const ePos = app(EXP, [x]);
+  const eNeg = app(EXP, [app(NEG, [x])]);
+  return app(DIV, [app(ADD, [ePos, eNeg]), TWO]);
+}
+
+function tanhExp(x: IRNode): IRNode {
+  const ePos = app(EXP, [x]);
+  const eNeg = app(EXP, [app(NEG, [x])]);
+  return app(DIV, [app(SUB, [ePos, eNeg]), app(ADD, [ePos, eNeg])]);
+}
+
+function demoivreNode(expr: Extract<IRNode, { kind: "apply" }>): IRNode {
+  if (headName(expr.head) !== EXP.name || expr.args.length !== 1) return expr;
+  const [real, imag] = splitRealImag(expr.args[0]);
+  if (imag === undefined) return expr;
+
+  const trigSum = app(ADD, [app(COS, [imag]), app(MUL, [IMAGINARY_UNIT, app(SIN, [imag])])]);
+  if (real === undefined) return trigSum;
+  return app(MUL, [app(EXP, [real]), trigSum]);
+}
+
+function splitRealImag(arg: IRNode): readonly [IRNode | undefined, IRNode | undefined] {
+  if (equals(arg, IMAGINARY_UNIT)) return [undefined, int(1)];
+
+  if (isApplyHead(arg, MUL.name)) {
+    const coeff = extractIFromMul(arg);
+    if (coeff !== undefined) return [undefined, coeff];
+  }
+
+  if (isApplyHead(arg, ADD.name)) {
+    const realTerms: IRNode[] = [];
+    let imagCoeff: IRNode | undefined;
+    for (const term of arg.args) {
+      if (equals(term, IMAGINARY_UNIT)) {
+        if (imagCoeff !== undefined) return [arg, undefined];
+        imagCoeff = int(1);
+        continue;
+      }
+      const iPart = extractIFromTerm(term);
+      if (iPart !== undefined) {
+        if (imagCoeff !== undefined) return [arg, undefined];
+        imagCoeff = iPart;
+      } else {
+        realTerms.push(term);
+      }
+    }
+
+    if (imagCoeff === undefined) return [arg, undefined];
+    if (realTerms.length === 0) return [undefined, imagCoeff];
+    return [realTerms.length === 1 ? realTerms[0] : app(ADD, realTerms), imagCoeff];
+  }
+
+  return [arg, undefined];
+}
+
+function extractIFromMul(mulNode: Extract<IRNode, { kind: "apply" }>): IRNode | undefined {
+  const iPositions = mulNode.args.flatMap((arg, index) => (equals(arg, IMAGINARY_UNIT) ? [index] : []));
+  if (iPositions.length !== 1) return undefined;
+  const rest = mulNode.args.filter((_, index) => index !== iPositions[0]);
+  if (rest.length === 0) return int(1);
+  if (rest.length === 1) return rest[0];
+  return app(MUL, rest);
+}
+
+function extractIFromTerm(term: IRNode): IRNode | undefined {
+  if (equals(term, IMAGINARY_UNIT)) return int(1);
+  if (isApplyHead(term, MUL.name)) return extractIFromMul(term);
+  return undefined;
+}
+
+function isApplyHead(node: IRNode, name: string): node is Extract<IRNode, { kind: "apply" }> {
+  return node.kind === "apply" && headName(node.head) === name;
+}

--- a/code/packages/typescript/cas-simplify/src/heads.ts
+++ b/code/packages/typescript/cas-simplify/src/heads.ts
@@ -1,0 +1,20 @@
+import { sym } from "@coding-adventures/symbolic-ir";
+
+export const CANONICAL = sym("Canonical");
+
+export const ASSUME = sym("Assume");
+export const FORGET = sym("Forget");
+export const IS = sym("Is");
+export const SIGN = sym("Sign");
+
+export const RADCAN = sym("Radcan");
+export const LOGCONTRACT = sym("LogContract");
+export const LOGEXPAND = sym("LogExpand");
+export const EXPONENTIALIZE = sym("Exponentialize");
+export const DEMOIVRE = sym("DeMoivre");
+
+const COMMUTATIVE_FLAT = new Set(["Add", "Mul"]);
+
+export function isCommutativeFlat(headName: string): boolean {
+  return COMMUTATIVE_FLAT.has(headName);
+}

--- a/code/packages/typescript/cas-simplify/src/index.ts
+++ b/code/packages/typescript/cas-simplify/src/index.ts
@@ -18,6 +18,12 @@ import {
   structuralKey,
 } from "@coding-adventures/symbolic-ir";
 
+export { AssumptionContext } from "./assumptions";
+export { IMAGINARY_UNIT, demoivre, exponentialize } from "./exponentialize";
+export * from "./heads";
+export { logcontract, logexpand } from "./logcontract";
+export { radcan } from "./radcan";
+
 export function canonical(node: IRNode): IRNode {
   if (node.kind !== "apply") return node;
   const head = canonical(node.head);

--- a/code/packages/typescript/cas-simplify/src/logcontract.ts
+++ b/code/packages/typescript/cas-simplify/src/logcontract.ts
@@ -1,0 +1,82 @@
+import { ADD, DIV, IRNode, LOG, MUL, POW, SUB, app, headName } from "@coding-adventures/symbolic-ir";
+import { AssumptionContext } from "./assumptions";
+
+export function logcontract(expr: IRNode): IRNode {
+  if (expr.kind !== "apply") return expr;
+  const args = expr.args.map(logcontract);
+  const node = app(expr.head, args);
+  const name = headName(node.head);
+  if (name === ADD.name) return contractAdd(node);
+  if (name === SUB.name) return contractSub(node);
+  if (name === MUL.name) return contractMul(node);
+  return node;
+}
+
+export function logexpand(expr: IRNode, _ctx?: AssumptionContext): IRNode {
+  if (expr.kind !== "apply") return expr;
+  const args = expr.args.map((arg) => logexpand(arg, _ctx));
+  const node = app(expr.head, args);
+  return headName(node.head) === LOG.name ? expandLog(node) : node;
+}
+
+function contractAdd(expr: Extract<IRNode, { kind: "apply" }>): IRNode {
+  const logArgs: IRNode[] = [];
+  const other: IRNode[] = [];
+  for (const arg of expr.args) {
+    if (isLog(arg)) logArgs.push(arg.args[0]);
+    else other.push(arg);
+  }
+  if (logArgs.length < 2) return expr;
+  const merged = app(LOG, [app(MUL, logArgs)]);
+  return other.length === 0 ? merged : app(ADD, [...other, merged]);
+}
+
+function contractSub(expr: Extract<IRNode, { kind: "apply" }>): IRNode {
+  if (expr.args.length !== 2) return expr;
+  const [lhs, rhs] = expr.args;
+  if (isLog(lhs) && isLog(rhs)) return app(LOG, [app(DIV, [lhs.args[0], rhs.args[0]])]);
+  return expr;
+}
+
+function contractMul(expr: Extract<IRNode, { kind: "apply" }>): IRNode {
+  const logs: Extract<IRNode, { kind: "apply" }>[] = [];
+  const numerics: IRNode[] = [];
+  const other: IRNode[] = [];
+  for (const arg of expr.args) {
+    if (isLog(arg)) logs.push(arg);
+    else if (arg.kind === "integer" || arg.kind === "rational") numerics.push(arg);
+    else other.push(arg);
+  }
+  if (logs.length !== 1 || numerics.length === 0 || other.length > 0) return expr;
+  const coefficient = numerics.length === 1 ? numerics[0] : app(MUL, numerics);
+  return app(LOG, [app(POW, [logs[0].args[0], coefficient])]);
+}
+
+function expandLog(expr: Extract<IRNode, { kind: "apply" }>): IRNode {
+  if (expr.args.length !== 1) return expr;
+  const arg = expr.args[0];
+
+  if (isApplyHead(arg, POW.name) && arg.args.length === 2) {
+    const [base, exp] = arg.args;
+    if (exp.kind === "integer" || exp.kind === "rational") return app(MUL, [exp, app(LOG, [base])]);
+  }
+
+  if (isApplyHead(arg, MUL.name) && arg.args.length >= 2) {
+    const terms = arg.args.map((factor) => app(LOG, [factor]));
+    return terms.slice(1).reduce<IRNode>((acc, term) => app(ADD, [acc, term]), terms[0]);
+  }
+
+  if (isApplyHead(arg, DIV.name) && arg.args.length === 2) {
+    return app(SUB, [app(LOG, [arg.args[0]]), app(LOG, [arg.args[1]])]);
+  }
+
+  return expr;
+}
+
+function isLog(node: IRNode): node is Extract<IRNode, { kind: "apply" }> {
+  return isApplyHead(node, LOG.name) && node.args.length === 1;
+}
+
+function isApplyHead(node: IRNode, name: string): node is Extract<IRNode, { kind: "apply" }> {
+  return node.kind === "apply" && headName(node.head) === name;
+}

--- a/code/packages/typescript/cas-simplify/src/radcan.ts
+++ b/code/packages/typescript/cas-simplify/src/radcan.ts
@@ -1,0 +1,221 @@
+import {
+  EXP,
+  IRNode,
+  LOG,
+  MUL,
+  POW,
+  SQRT,
+  app,
+  equals,
+  headName,
+  int,
+  rational,
+} from "@coding-adventures/symbolic-ir";
+import { AssumptionContext } from "./assumptions";
+
+interface Fraction {
+  readonly numer: bigint;
+  readonly denom: bigint;
+}
+
+export function radcan(expr: IRNode, ctx?: AssumptionContext): IRNode {
+  if (expr.kind !== "apply") return expr;
+  const args = expr.args.map((arg) => radcan(arg, ctx));
+  return applyRadcanRules(app(expr.head, args), ctx);
+}
+
+function applyRadcanRules(expr: IRNode, ctx: AssumptionContext | undefined): IRNode {
+  if (expr.kind !== "apply") return expr;
+  const name = headName(expr.head);
+  if (name === MUL.name) return ruleMul(expr.args, ctx);
+  if (name === SQRT.name) return ruleSqrt(expr, ctx);
+  if (name === POW.name) return rulePow(expr);
+  if (name === EXP.name) return ruleExp(expr);
+  if (name === LOG.name) return ruleLog(expr);
+  return expr;
+}
+
+function ruleMul(argsIn: readonly IRNode[], ctx: AssumptionContext | undefined): IRNode {
+  let args = [...argsIn];
+  const sqrtRadicands: IRNode[] = [];
+  const nonSqrt: IRNode[] = [];
+
+  for (const arg of args) {
+    if (isApplyHead(arg, SQRT.name) && arg.args.length === 1) sqrtRadicands.push(arg.args[0]);
+    else nonSqrt.push(arg);
+  }
+
+  if (sqrtRadicands.length >= 2) {
+    const mergedRadicand = mulOrOne(sqrtRadicands);
+    args = [...nonSqrt, radcan(app(SQRT, [mergedRadicand]), ctx)];
+  }
+
+  const groups = new Map<string, { fraction: Fraction; bases: IRNode[] }>();
+  const remaining: IRNode[] = [];
+  for (const arg of args) {
+    const exp = rationalExponent(arg);
+    const base = baseOf(arg);
+    if (exp !== undefined && base !== undefined && exp.denom > 1n && !sameFraction(exp, { numer: 1n, denom: 2n })) {
+      const key = `${exp.numer}/${exp.denom}`;
+      const group = groups.get(key);
+      if (group === undefined) groups.set(key, { fraction: exp, bases: [base] });
+      else group.bases.push(base);
+    } else {
+      remaining.push(arg);
+    }
+  }
+
+  const merged: IRNode[] = [];
+  for (const group of groups.values()) {
+    if (group.bases.length === 1) remaining.push(app(POW, [group.bases[0], fractionToIr(group.fraction)]));
+    else merged.push(app(POW, [mulOrOne(group.bases), fractionToIr(group.fraction)]));
+  }
+
+  return mulOrOne([...remaining, ...merged]);
+}
+
+function ruleSqrt(expr: IRNode, ctx: AssumptionContext | undefined): IRNode {
+  if (!isApplyHead(expr, SQRT.name) || expr.args.length !== 1) return expr;
+  const arg = expr.args[0];
+
+  if (arg.kind === "integer" && arg.value >= 0n) {
+    const root = integerSqrt(arg.value);
+    if (root !== undefined) return int(root);
+  }
+
+  if (isSquarePower(arg)) {
+    const base = baseOf(arg);
+    if (base !== undefined) return absOrPositive(base, ctx);
+  }
+
+  if (isApplyHead(arg, MUL.name)) {
+    const outer: IRNode[] = [];
+    const inner: IRNode[] = [];
+    for (const factor of arg.args) {
+      const extracted = tryExtractFromSqrt(factor, ctx);
+      if (extracted === undefined) inner.push(factor);
+      else outer.push(extracted);
+    }
+    if (outer.length > 0) {
+      const outerProduct = mulOrOne(outer);
+      const innerProduct = mulOrOne(inner);
+      if (equals(innerProduct, int(1))) return outerProduct;
+      return app(MUL, [outerProduct, app(SQRT, [innerProduct])]);
+    }
+  }
+
+  return expr;
+}
+
+function tryExtractFromSqrt(factor: IRNode, ctx: AssumptionContext | undefined): IRNode | undefined {
+  if (isSquarePower(factor)) {
+    const base = baseOf(factor);
+    if (base?.kind === "integer" && base.value > 0n) return base;
+    if (base?.kind === "symbol" && ctx?.isPositive(base.name) === true) return base;
+    return undefined;
+  }
+
+  if (factor.kind === "integer" && factor.value > 0n) {
+    const root = integerSqrt(factor.value);
+    if (root !== undefined) return int(root);
+  }
+
+  return undefined;
+}
+
+function rulePow(expr: IRNode): IRNode {
+  if (!isApplyHead(expr, POW.name) || expr.args.length !== 2) return expr;
+  const [base, exp] = expr.args;
+  if (isApplyHead(base, SQRT.name) && base.args.length === 1 && equals(exp, int(2))) {
+    return base.args[0];
+  }
+  return expr;
+}
+
+function ruleExp(expr: IRNode): IRNode {
+  if (!isApplyHead(expr, EXP.name) || expr.args.length !== 1) return expr;
+  const arg = expr.args[0];
+  if (isApplyHead(arg, LOG.name) && arg.args.length === 1) return arg.args[0];
+  return expr;
+}
+
+function ruleLog(expr: IRNode): IRNode {
+  if (!isApplyHead(expr, LOG.name) || expr.args.length !== 1) return expr;
+  const arg = expr.args[0];
+  if (isApplyHead(arg, EXP.name) && arg.args.length === 1) return arg.args[0];
+  return expr;
+}
+
+function isSquarePower(node: IRNode): boolean {
+  return isApplyHead(node, POW.name) && node.args.length === 2 && equals(node.args[1], int(2));
+}
+
+function absOrPositive(base: IRNode, ctx: AssumptionContext | undefined): IRNode {
+  if (base.kind === "integer" && base.value > 0n) return base;
+  if (base.kind === "symbol" && ctx?.isPositive(base.name) === true) return base;
+  return app(SQRT, [app(POW, [base, int(2)])]);
+}
+
+function rationalExponent(node: IRNode): Fraction | undefined {
+  if (!isApplyHead(node, POW.name) || node.args.length !== 2) return undefined;
+  const exp = node.args[1];
+  if (exp.kind === "integer") return normalizeFraction({ numer: exp.value, denom: 1n });
+  if (exp.kind === "rational") return normalizeFraction({ numer: exp.numer, denom: exp.denom });
+  return undefined;
+}
+
+function baseOf(node: IRNode): IRNode | undefined {
+  return isApplyHead(node, POW.name) && node.args.length === 2 ? node.args[0] : undefined;
+}
+
+function integerSqrt(value: bigint): bigint | undefined {
+  if (value < 0n) return undefined;
+  if (value < 2n) return value;
+  let low = 1n;
+  let high = value;
+  while (low <= high) {
+    const mid = (low + high) >> 1n;
+    const square = mid * mid;
+    if (square === value) return mid;
+    if (square < value) low = mid + 1n;
+    else high = mid - 1n;
+  }
+  return undefined;
+}
+
+function fractionToIr(frac: Fraction): IRNode {
+  return frac.denom === 1n ? int(frac.numer) : rational(frac.numer, frac.denom);
+}
+
+function normalizeFraction(frac: Fraction): Fraction {
+  if (frac.denom < 0n) return normalizeFraction({ numer: -frac.numer, denom: -frac.denom });
+  const divisor = gcd(abs(frac.numer), frac.denom);
+  return { numer: frac.numer / divisor, denom: frac.denom / divisor };
+}
+
+function sameFraction(a: Fraction, b: Fraction): boolean {
+  return a.numer === b.numer && a.denom === b.denom;
+}
+
+function gcd(a: bigint, b: bigint): bigint {
+  while (b !== 0n) {
+    const next = a % b;
+    a = b;
+    b = next;
+  }
+  return a === 0n ? 1n : a;
+}
+
+function abs(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}
+
+function mulOrOne(nodes: readonly IRNode[]): IRNode {
+  if (nodes.length === 0) return int(1);
+  if (nodes.length === 1) return nodes[0];
+  return app(MUL, nodes);
+}
+
+function isApplyHead(node: IRNode, name: string): node is Extract<IRNode, { kind: "apply" }> {
+  return node.kind === "apply" && headName(node.head) === name;
+}

--- a/code/packages/typescript/cas-simplify/tests/phase21.test.ts
+++ b/code/packages/typescript/cas-simplify/tests/phase21.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  COS,
+  COSH,
+  DIV,
+  EQUAL,
+  EXP,
+  GREATER,
+  GREATER_EQUAL,
+  IRNode,
+  LESS,
+  LOG,
+  MUL,
+  NOT_EQUAL,
+  POW,
+  SIN,
+  SINH,
+  SQRT,
+  SUB,
+  TAN,
+  TANH,
+  app,
+  int,
+  rational,
+  sym,
+} from "@coding-adventures/symbolic-ir";
+import {
+  AssumptionContext,
+  IMAGINARY_UNIT,
+  demoivre,
+  exponentialize,
+  logcontract,
+  logexpand,
+  radcan,
+} from "../src/index";
+
+const x = sym("x");
+const y = sym("y");
+const a = sym("a");
+const b = sym("b");
+const n = sym("n");
+
+function greaterZero(node: IRNode): IRNode {
+  return app(GREATER, [node, int(0)]);
+}
+
+function positiveContext(...nodes: readonly IRNode[]): AssumptionContext {
+  const ctx = new AssumptionContext();
+  for (const node of nodes) ctx.assumeRelation(greaterZero(node));
+  return ctx;
+}
+
+describe("AssumptionContext", () => {
+  it("tracks and forgets sign and property facts", () => {
+    const ctx = new AssumptionContext();
+    expect(ctx.isPositive("x")).toBeUndefined();
+    expect(ctx.isInteger("n")).toBe(false);
+
+    ctx.assumeRelation(greaterZero(x));
+    ctx.assumeRelation(app(NOT_EQUAL, [y, int(0)]));
+    ctx.assumeProperty(n, sym("integer"));
+
+    expect(ctx.isPositive("x")).toBe(true);
+    expect(ctx.isNegative("x")).toBe(false);
+    expect(ctx.signOf("x")).toBe(1);
+    expect(ctx.isTrueRelation(greaterZero(x))).toBe(true);
+    expect(ctx.isTrueRelation(app(EQUAL, [y, int(0)]))).toBe(false);
+    expect(ctx.isInteger("n")).toBe(true);
+    expect(ctx.hasAnyFacts("x")).toBe(true);
+
+    ctx.forgetRelation(greaterZero(x));
+    expect(ctx.isPositive("x")).toBeUndefined();
+    ctx.forgetAll();
+    expect(ctx.isInteger("n")).toBe(false);
+  });
+
+  it("records negative and nonnegative assumptions", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(app(LESS, [x, int(0)]));
+    ctx.assumeRelation(app(GREATER_EQUAL, [y, int(0)]));
+    expect(ctx.isNegative("x")).toBe(true);
+    expect(ctx.isPositive("x")).toBe(false);
+    expect(ctx.signOf("x")).toBe(-1);
+    expect(ctx.isNonneg("y")).toBe(true);
+    expect(ctx.isNegative("y")).toBe(false);
+  });
+});
+
+describe("radcan", () => {
+  it("simplifies integer perfect-square radicals", () => {
+    expect(radcan(app(SQRT, [int(4)]))).toEqual(int(2));
+    expect(radcan(app(SQRT, [int(9)]))).toEqual(int(3));
+    expect(radcan(app(SQRT, [int(2)]))).toEqual(app(SQRT, [int(2)]));
+  });
+
+  it("uses positivity when simplifying Sqrt(x^2)", () => {
+    expect(radcan(app(SQRT, [app(POW, [x, int(2)])]))).toEqual(app(SQRT, [app(POW, [x, int(2)])]));
+    expect(radcan(app(SQRT, [app(POW, [x, int(2)])]), positiveContext(x))).toEqual(x);
+  });
+
+  it("extracts and merges square-root products", () => {
+    const extracted = radcan(app(SQRT, [app(MUL, [app(POW, [x, int(2)]), y])]), positiveContext(x));
+    expect(extracted).toEqual(app(MUL, [x, app(SQRT, [y])]));
+
+    const merged = radcan(app(MUL, [app(SQRT, [a]), app(SQRT, [b])]));
+    expect(merged).toEqual(app(SQRT, [app(MUL, [a, b])]));
+  });
+
+  it("cancels square and exp/log inverse shapes", () => {
+    expect(radcan(app(POW, [app(SQRT, [x]), int(2)]))).toEqual(x);
+    expect(radcan(app(EXP, [app(LOG, [x])]))).toEqual(x);
+    expect(radcan(app(LOG, [app(EXP, [x])]))).toEqual(x);
+  });
+
+  it("collects common non-half rational exponents", () => {
+    const third = rational(1, 3);
+    expect(radcan(app(MUL, [app(POW, [a, third]), app(POW, [b, third])]))).toEqual(
+      app(POW, [app(MUL, [a, b]), third]),
+    );
+  });
+});
+
+describe("logcontract and logexpand", () => {
+  it("contracts log sums, differences, and numeric multiples", () => {
+    expect(logcontract(app(ADD, [app(LOG, [a]), app(LOG, [b])]))).toEqual(app(LOG, [app(MUL, [a, b])]));
+    expect(logcontract(app(ADD, [app(LOG, [a]), x, app(LOG, [b])]))).toEqual(
+      app(ADD, [x, app(LOG, [app(MUL, [a, b])])]),
+    );
+    expect(logcontract(app(SUB, [app(LOG, [a]), app(LOG, [b])]))).toEqual(app(LOG, [app(DIV, [a, b])]));
+    expect(logcontract(app(MUL, [int(2), app(LOG, [x])]))).toEqual(app(LOG, [app(POW, [x, int(2)])]));
+    expect(logcontract(app(MUL, [x, app(LOG, [y])]))).toEqual(app(MUL, [x, app(LOG, [y])]));
+  });
+
+  it("expands logs over powers products and quotients", () => {
+    expect(logexpand(app(LOG, [app(POW, [x, int(3)])]))).toEqual(app(MUL, [int(3), app(LOG, [x])]));
+    expect(logexpand(app(LOG, [app(POW, [x, rational(1, 2)])]))).toEqual(
+      app(MUL, [rational(1, 2), app(LOG, [x])]),
+    );
+    expect(logexpand(app(LOG, [app(MUL, [a, b, x])]))).toEqual(
+      app(ADD, [app(ADD, [app(LOG, [a]), app(LOG, [b])]), app(LOG, [x])]),
+    );
+    expect(logexpand(app(LOG, [app(DIV, [a, b])]))).toEqual(app(SUB, [app(LOG, [a]), app(LOG, [b])]));
+    expect(logexpand(app(LOG, [x]), positiveContext(x))).toEqual(app(LOG, [x]));
+  });
+});
+
+describe("exponentialize", () => {
+  it("rewrites circular trig functions to exponential form", () => {
+    const sinX = exponentialize(app(SIN, [x]));
+    expect(sinX.kind).toBe("apply");
+    expect(sinX.kind === "apply" ? sinX.head : undefined).toEqual(DIV);
+    expect(sinX.kind === "apply" ? sinX.args[0] : undefined).toMatchObject({ head: SUB });
+    expect(sinX.kind === "apply" ? sinX.args[1] : undefined).toEqual(app(MUL, [int(2), IMAGINARY_UNIT]));
+
+    const cosX = exponentialize(app(COS, [x]));
+    expect(cosX.kind === "apply" ? cosX.args[0] : undefined).toMatchObject({ head: ADD });
+    expect(cosX.kind === "apply" ? cosX.args[1] : undefined).toEqual(int(2));
+
+    const tanX = exponentialize(app(TAN, [x]));
+    expect(tanX.kind === "apply" ? tanX.args[1] : undefined).toMatchObject({ head: ADD });
+  });
+
+  it("rewrites hyperbolic functions to exponential form", () => {
+    const sinhX = exponentialize(app(SINH, [x]));
+    const coshX = exponentialize(app(COSH, [x]));
+    const tanhX = exponentialize(app(TANH, [x]));
+    expect(sinhX.kind === "apply" ? sinhX.args[0] : undefined).toMatchObject({ head: SUB });
+    expect(coshX.kind === "apply" ? coshX.args[0] : undefined).toMatchObject({ head: ADD });
+    expect(tanhX.kind === "apply" ? tanhX.args[1] : undefined).toMatchObject({ head: ADD });
+  });
+});
+
+describe("demoivre", () => {
+  it("decomposes pure imaginary exponentials", () => {
+    expect(demoivre(app(EXP, [IMAGINARY_UNIT]))).toEqual(
+      app(ADD, [app(COS, [int(1)]), app(MUL, [IMAGINARY_UNIT, app(SIN, [int(1)])])]),
+    );
+    expect(demoivre(app(EXP, [app(MUL, [IMAGINARY_UNIT, y])]))).toEqual(
+      app(ADD, [app(COS, [y]), app(MUL, [IMAGINARY_UNIT, app(SIN, [y])])]),
+    );
+    expect(demoivre(app(EXP, [app(MUL, [y, IMAGINARY_UNIT])]))).toEqual(
+      app(ADD, [app(COS, [y]), app(MUL, [IMAGINARY_UNIT, app(SIN, [y])])]),
+    );
+  });
+
+  it("splits mixed real plus imaginary exponentials", () => {
+    expect(demoivre(app(EXP, [app(ADD, [x, app(MUL, [IMAGINARY_UNIT, y])])]))).toEqual(
+      app(MUL, [app(EXP, [x]), app(ADD, [app(COS, [y]), app(MUL, [IMAGINARY_UNIT, app(SIN, [y])])])]),
+    );
+    expect(demoivre(app(EXP, [x]))).toEqual(app(EXP, [x]));
+    expect(demoivre(app(ADD, [app(EXP, [app(MUL, [IMAGINARY_UNIT, x])]), y]))).toEqual(
+      app(ADD, [app(ADD, [app(COS, [x]), app(MUL, [IMAGINARY_UNIT, app(SIN, [x])])]), y]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Port Phase 21 CAS simplification helpers into the TypeScript cas-simplify package
- Add an AssumptionContext, radical canonicalization, log contract/expand, exponentialization, DeMoivre, and Phase 21 head exports
- Cover the new parity surface with package-local Vitest tests

## Validation
- npm install
- npm run build
- npm test
- npm run test:coverage

## Notes
- Scope is limited to code/packages/typescript/cas-simplify.
- This does not wire the helpers into symbolic-vm handlers or parser/grammar tooling.
