### PR TITLE
Port Rust cas-simplify Phase 21 helpers

### DIFF
--- a/code/packages/rust/cas-simplify/src/assumptions.rs
+++ b/code/packages/rust/cas-simplify/src/assumptions.rs
@@ -1,0 +1,222 @@
+//! Per-context assumptions for sign-aware simplification.
+
+use std::collections::{HashMap, HashSet};
+
+use symbolic_ir::{IRNode, EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, NOT_EQUAL};
+
+const POSITIVE: &str = "positive";
+const NEGATIVE: &str = "negative";
+const ZERO: &str = "zero";
+const NONZERO: &str = "nonzero";
+const NONNEG: &str = "nonneg";
+const NONPOS: &str = "nonpos";
+const INTEGER: &str = "integer";
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AssumptionContext {
+    facts: HashMap<String, HashSet<&'static str>>,
+}
+
+impl AssumptionContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn assume_relation(&mut self, expr: &IRNode) {
+        if let Some((sym_name, head)) = relation_against_zero(expr) {
+            match head {
+                GREATER => self.add(sym_name, POSITIVE),
+                LESS => self.add(sym_name, NEGATIVE),
+                GREATER_EQUAL => self.add(sym_name, NONNEG),
+                LESS_EQUAL => self.add(sym_name, NONPOS),
+                EQUAL => self.add(sym_name, ZERO),
+                NOT_EQUAL => self.add(sym_name, NONZERO),
+                _ => {}
+            }
+        }
+    }
+
+    pub fn assume_property(&mut self, sym: &IRNode, prop: &IRNode) {
+        let Some(symbol_name) = sym_name(sym) else {
+            return;
+        };
+        let Some(prop_name) = sym_name(prop) else {
+            return;
+        };
+        let fact = match prop_name.to_ascii_lowercase().as_str() {
+            "positive" | "pos" => POSITIVE,
+            "negative" | "neg" => NEGATIVE,
+            "zero" => ZERO,
+            "nonzero" => NONZERO,
+            "nonneg" | "nonnegative" => NONNEG,
+            "nonpos" | "nonpositive" => NONPOS,
+            "integer" | "integerp" => INTEGER,
+            _ => return,
+        };
+        self.add(symbol_name, fact);
+    }
+
+    pub fn forget_relation(&mut self, expr: &IRNode) {
+        if let Some((sym_name, head)) = relation_against_zero(expr) {
+            match head {
+                GREATER => self.remove(sym_name, POSITIVE),
+                LESS => self.remove(sym_name, NEGATIVE),
+                GREATER_EQUAL => self.remove(sym_name, NONNEG),
+                LESS_EQUAL => self.remove(sym_name, NONPOS),
+                EQUAL => self.remove(sym_name, ZERO),
+                NOT_EQUAL => self.remove(sym_name, NONZERO),
+                _ => {}
+            }
+        }
+    }
+
+    pub fn forget_all(&mut self) {
+        self.facts.clear();
+    }
+
+    pub fn is_positive(&self, sym_name: &str) -> Option<bool> {
+        let facts = self.facts_for(sym_name);
+        if facts.contains(POSITIVE) {
+            Some(true)
+        } else if facts.contains(NEGATIVE) || facts.contains(ZERO) {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_negative(&self, sym_name: &str) -> Option<bool> {
+        let facts = self.facts_for(sym_name);
+        if facts.contains(NEGATIVE) {
+            Some(true)
+        } else if facts.contains(POSITIVE) || facts.contains(ZERO) || facts.contains(NONNEG) {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_nonneg(&self, sym_name: &str) -> Option<bool> {
+        let facts = self.facts_for(sym_name);
+        if facts.contains(NONNEG) || facts.contains(POSITIVE) || facts.contains(ZERO) {
+            Some(true)
+        } else if facts.contains(NEGATIVE) {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_integer(&self, sym_name: &str) -> bool {
+        self.facts_for(sym_name).contains(INTEGER)
+    }
+
+    pub fn sign_of(&self, sym_name: &str) -> Option<i8> {
+        let facts = self.facts_for(sym_name);
+        if facts.contains(POSITIVE) {
+            Some(1)
+        } else if facts.contains(NEGATIVE) {
+            Some(-1)
+        } else if facts.contains(ZERO) {
+            Some(0)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_true_relation(&self, expr: &IRNode) -> Option<bool> {
+        let (sym_name, head) = relation_against_zero(expr)?;
+        let facts = self.facts_for(sym_name);
+        match head {
+            GREATER => self.is_positive(sym_name),
+            LESS => self.is_negative(sym_name),
+            GREATER_EQUAL => {
+                if facts.contains(POSITIVE) || facts.contains(ZERO) || facts.contains(NONNEG) {
+                    Some(true)
+                } else if facts.contains(NEGATIVE) {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            LESS_EQUAL => {
+                if facts.contains(NEGATIVE) || facts.contains(ZERO) || facts.contains(NONPOS) {
+                    Some(true)
+                } else if facts.contains(POSITIVE) {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            EQUAL => {
+                if facts.contains(ZERO) {
+                    Some(true)
+                } else if facts.contains(POSITIVE)
+                    || facts.contains(NEGATIVE)
+                    || facts.contains(NONZERO)
+                {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            NOT_EQUAL => {
+                if facts.contains(NONZERO) || facts.contains(POSITIVE) || facts.contains(NEGATIVE) {
+                    Some(true)
+                } else if facts.contains(ZERO) {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn has_any_facts(&self, sym_name: &str) -> bool {
+        self.facts
+            .get(sym_name)
+            .is_some_and(|facts| !facts.is_empty())
+    }
+
+    fn add(&mut self, sym_name: &str, fact: &'static str) {
+        self.facts
+            .entry(sym_name.to_string())
+            .or_default()
+            .insert(fact);
+    }
+
+    fn remove(&mut self, sym_name: &str, fact: &'static str) {
+        if let Some(facts) = self.facts.get_mut(sym_name) {
+            facts.remove(fact);
+            if facts.is_empty() {
+                self.facts.remove(sym_name);
+            }
+        }
+    }
+
+    fn facts_for(&self, sym_name: &str) -> HashSet<&'static str> {
+        self.facts.get(sym_name).cloned().unwrap_or_default()
+    }
+}
+
+fn relation_against_zero(expr: &IRNode) -> Option<(&str, &str)> {
+    let IRNode::Apply(apply) = expr else {
+        return None;
+    };
+    if apply.args.len() != 2 || apply.args[1] != IRNode::Integer(0) {
+        return None;
+    }
+    let sym_name = sym_name(&apply.args[0])?;
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    Some((sym_name, head.as_str()))
+}
+
+fn sym_name(node: &IRNode) -> Option<&str> {
+    match node {
+        IRNode::Symbol(name) => Some(name),
+        _ => None,
+    }
+}

--- a/code/packages/rust/cas-simplify/src/exponentialize.rs
+++ b/code/packages/rust/cas-simplify/src/exponentialize.rs
@@ -1,0 +1,218 @@
+//! Trig/hyperbolic exponentialization and De Moivre decomposition.
+
+use symbolic_ir::{
+    apply, int, sym, IRNode, ADD, COS, COSH, DIV, EXP, MUL, NEG, SIN, SINH, SUB, TAN, TANH,
+};
+
+const IMAGINARY_UNIT: &str = "ImaginaryUnit";
+
+pub fn exponentialize(expr: IRNode) -> IRNode {
+    let IRNode::Apply(apply_node) = expr else {
+        return expr;
+    };
+    let head = apply_node.head;
+    let args = apply_node.args.into_iter().map(exponentialize).collect();
+    let node = apply(head, args);
+    let IRNode::Apply(apply_node) = node else {
+        return node;
+    };
+    if apply_node.args.len() != 1 {
+        return IRNode::Apply(apply_node);
+    }
+    let x = apply_node.args[0].clone();
+    match head_name(&apply_node.head) {
+        Some(SIN) => sin_exp(x),
+        Some(COS) => cos_exp(x),
+        Some(TAN) => tan_exp(x),
+        Some(SINH) => sinh_exp(x),
+        Some(COSH) => cosh_exp(x),
+        Some(TANH) => tanh_exp(x),
+        _ => IRNode::Apply(apply_node),
+    }
+}
+
+pub fn demoivre(expr: IRNode) -> IRNode {
+    let IRNode::Apply(apply_node) = expr else {
+        return expr;
+    };
+    let head = apply_node.head;
+    let args = apply_node.args.into_iter().map(demoivre).collect();
+    let node = apply(head, args);
+    let IRNode::Apply(apply_node) = node else {
+        return node;
+    };
+    if head_name(&apply_node.head) != Some(EXP) || apply_node.args.len() != 1 {
+        return IRNode::Apply(apply_node);
+    }
+
+    let (real, imag) = split_real_imag(&apply_node.args[0]);
+    let Some(imag) = imag else {
+        return IRNode::Apply(apply_node);
+    };
+
+    let trig_sum = apply(
+        sym(ADD),
+        vec![
+            apply(sym(COS), vec![imag.clone()]),
+            apply(
+                sym(MUL),
+                vec![imaginary_unit(), apply(sym(SIN), vec![imag])],
+            ),
+        ],
+    );
+
+    if let Some(real) = real {
+        apply(sym(MUL), vec![apply(sym(EXP), vec![real]), trig_sum])
+    } else {
+        trig_sum
+    }
+}
+
+fn ix(x: IRNode) -> IRNode {
+    apply(sym(MUL), vec![imaginary_unit(), x])
+}
+
+fn neg_ix(x: IRNode) -> IRNode {
+    apply(sym(MUL), vec![imaginary_unit(), apply(sym(NEG), vec![x])])
+}
+
+fn sin_exp(x: IRNode) -> IRNode {
+    let e_pos = apply(sym(EXP), vec![ix(x.clone())]);
+    let e_neg = apply(sym(EXP), vec![neg_ix(x)]);
+    apply(
+        sym(DIV),
+        vec![
+            apply(sym(SUB), vec![e_pos, e_neg]),
+            apply(sym(MUL), vec![int(2), imaginary_unit()]),
+        ],
+    )
+}
+
+fn cos_exp(x: IRNode) -> IRNode {
+    let e_pos = apply(sym(EXP), vec![ix(x.clone())]);
+    let e_neg = apply(sym(EXP), vec![neg_ix(x)]);
+    apply(sym(DIV), vec![apply(sym(ADD), vec![e_pos, e_neg]), int(2)])
+}
+
+fn tan_exp(x: IRNode) -> IRNode {
+    let e_pos = apply(sym(EXP), vec![ix(x.clone())]);
+    let e_neg = apply(sym(EXP), vec![neg_ix(x)]);
+    apply(
+        sym(DIV),
+        vec![
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(NEG), vec![imaginary_unit()]),
+                    apply(sym(SUB), vec![e_pos.clone(), e_neg.clone()]),
+                ],
+            ),
+            apply(sym(ADD), vec![e_pos, e_neg]),
+        ],
+    )
+}
+
+fn sinh_exp(x: IRNode) -> IRNode {
+    let e_pos = apply(sym(EXP), vec![x.clone()]);
+    let e_neg = apply(sym(EXP), vec![apply(sym(NEG), vec![x])]);
+    apply(sym(DIV), vec![apply(sym(SUB), vec![e_pos, e_neg]), int(2)])
+}
+
+fn cosh_exp(x: IRNode) -> IRNode {
+    let e_pos = apply(sym(EXP), vec![x.clone()]);
+    let e_neg = apply(sym(EXP), vec![apply(sym(NEG), vec![x])]);
+    apply(sym(DIV), vec![apply(sym(ADD), vec![e_pos, e_neg]), int(2)])
+}
+
+fn tanh_exp(x: IRNode) -> IRNode {
+    let e_pos = apply(sym(EXP), vec![x.clone()]);
+    let e_neg = apply(sym(EXP), vec![apply(sym(NEG), vec![x])]);
+    apply(
+        sym(DIV),
+        vec![
+            apply(sym(SUB), vec![e_pos.clone(), e_neg.clone()]),
+            apply(sym(ADD), vec![e_pos, e_neg]),
+        ],
+    )
+}
+
+fn split_real_imag(arg: &IRNode) -> (Option<IRNode>, Option<IRNode>) {
+    if *arg == imaginary_unit() {
+        return (None, Some(int(1)));
+    }
+
+    if let IRNode::Apply(apply_node) = arg {
+        if head_name(&apply_node.head) == Some(MUL) {
+            if let Some(coeff) = extract_i_from_mul(&apply_node.args) {
+                return (None, Some(coeff));
+            }
+        }
+
+        if head_name(&apply_node.head) == Some(ADD) {
+            let mut real_terms = Vec::new();
+            let mut imag_coeff = None;
+            for term in &apply_node.args {
+                let i_part = if *term == imaginary_unit() {
+                    Some(int(1))
+                } else if let IRNode::Apply(term_apply) = term {
+                    if head_name(&term_apply.head) == Some(MUL) {
+                        extract_i_from_mul(&term_apply.args)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                if let Some(coeff) = i_part {
+                    if imag_coeff.is_some() {
+                        return (Some(arg.clone()), None);
+                    }
+                    imag_coeff = Some(coeff);
+                } else {
+                    real_terms.push(term.clone());
+                }
+            }
+
+            let Some(imag_coeff) = imag_coeff else {
+                return (Some(arg.clone()), None);
+            };
+            let real = match real_terms.as_slice() {
+                [] => None,
+                [only] => Some(only.clone()),
+                _ => Some(apply(sym(ADD), real_terms)),
+            };
+            return (real, Some(imag_coeff));
+        }
+    }
+
+    (Some(arg.clone()), None)
+}
+
+fn extract_i_from_mul(args: &[IRNode]) -> Option<IRNode> {
+    let i_count = args.iter().filter(|arg| **arg == imaginary_unit()).count();
+    if i_count != 1 {
+        return None;
+    }
+    let rest = args
+        .iter()
+        .filter(|arg| **arg != imaginary_unit())
+        .cloned()
+        .collect::<Vec<_>>();
+    match rest.as_slice() {
+        [] => Some(int(1)),
+        [only] => Some(only.clone()),
+        _ => Some(apply(sym(MUL), rest)),
+    }
+}
+
+fn imaginary_unit() -> IRNode {
+    sym(IMAGINARY_UNIT)
+}
+
+fn head_name(node: &IRNode) -> Option<&str> {
+    match node {
+        IRNode::Symbol(name) => Some(name),
+        _ => None,
+    }
+}

--- a/code/packages/rust/cas-simplify/src/heads.rs
+++ b/code/packages/rust/cas-simplify/src/heads.rs
@@ -1,0 +1,29 @@
+//! Sentinel heads introduced by `cas-simplify`.
+
+use symbolic_ir::{apply, sym, IRNode};
+
+pub const SIMPLIFY: &str = "Simplify";
+pub const CANONICAL: &str = "Canonical";
+
+pub const ASSUME: &str = "Assume";
+pub const FORGET: &str = "Forget";
+pub const IS: &str = "Is";
+pub const SIGN: &str = "Sign";
+
+pub const RADCAN: &str = "Radcan";
+pub const LOGCONTRACT: &str = "LogContract";
+pub const LOGEXPAND: &str = "LogExpand";
+pub const EXPONENTIALIZE: &str = "Exponentialize";
+pub const DEMOIVRE: &str = "DeMoivre";
+
+pub fn is_commutative_flat(head_name: &str) -> bool {
+    matches!(head_name, symbolic_ir::ADD | symbolic_ir::MUL)
+}
+
+pub fn unary(head: &str, arg: IRNode) -> IRNode {
+    apply(sym(head), vec![arg])
+}
+
+pub fn binary(head: &str, lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(head), vec![lhs, rhs])
+}

--- a/code/packages/rust/cas-simplify/src/lib.rs
+++ b/code/packages/rust/cas-simplify/src/lib.rs
@@ -34,12 +34,21 @@
 //! assert_eq!(simplify(expr3, 50), int(1));
 //! ```
 
+pub mod assumptions;
 pub mod canonical;
+pub mod exponentialize;
+pub mod heads;
+pub mod logcontract;
 pub mod numeric_fold;
+pub mod radcan;
 pub mod rules;
 pub mod simplifier;
 
+pub use assumptions::AssumptionContext;
 pub use canonical::canonical;
+pub use exponentialize::{demoivre, exponentialize};
+pub use logcontract::{logcontract, logexpand};
 pub use numeric_fold::numeric_fold;
+pub use radcan::radcan;
 pub use rules::build_identity_rules;
 pub use simplifier::simplify;

--- a/code/packages/rust/cas-simplify/src/logcontract.rs
+++ b/code/packages/rust/cas-simplify/src/logcontract.rs
@@ -1,0 +1,182 @@
+//! Log contraction and expansion helpers.
+
+use symbolic_ir::{apply, sym, IRNode, ADD, DIV, LOG, MUL, POW, SUB};
+
+use crate::assumptions::AssumptionContext;
+
+pub fn logcontract(expr: IRNode) -> IRNode {
+    let IRNode::Apply(apply_node) = expr else {
+        return expr;
+    };
+    let head = apply_node.head;
+    let args = apply_node.args.into_iter().map(logcontract).collect();
+    let node = apply(head, args);
+    let IRNode::Apply(apply_node) = node else {
+        return node;
+    };
+    match head_name(&apply_node.head) {
+        Some(ADD) => contract_add(&apply_node.args),
+        Some(SUB) => contract_sub(&apply_node.args),
+        Some(MUL) => contract_mul(&apply_node.args),
+        _ => IRNode::Apply(apply_node),
+    }
+}
+
+pub fn logexpand(expr: IRNode, ctx: Option<&AssumptionContext>) -> IRNode {
+    let _ = ctx;
+    let IRNode::Apply(apply_node) = expr else {
+        return expr;
+    };
+    let head = apply_node.head;
+    let args = apply_node
+        .args
+        .into_iter()
+        .map(|arg| logexpand(arg, ctx))
+        .collect();
+    let node = apply(head, args);
+    let IRNode::Apply(apply_node) = node else {
+        return node;
+    };
+    if head_name(&apply_node.head) == Some(LOG) {
+        expand_log(&apply_node.args)
+    } else {
+        IRNode::Apply(apply_node)
+    }
+}
+
+fn contract_add(args: &[IRNode]) -> IRNode {
+    let mut log_args = Vec::new();
+    let mut other = Vec::new();
+    for arg in args {
+        if let Some(inner) = log_inner(arg) {
+            log_args.push(inner.clone());
+        } else {
+            other.push(arg.clone());
+        }
+    }
+    if log_args.len() < 2 {
+        return apply(sym(ADD), args.to_vec());
+    }
+    let merged = apply(sym(LOG), vec![apply(sym(MUL), log_args)]);
+    if other.is_empty() {
+        merged
+    } else {
+        other.push(merged);
+        apply(sym(ADD), other)
+    }
+}
+
+fn contract_sub(args: &[IRNode]) -> IRNode {
+    if args.len() == 2 {
+        if let (Some(lhs), Some(rhs)) = (log_inner(&args[0]), log_inner(&args[1])) {
+            return apply(
+                sym(LOG),
+                vec![apply(sym(DIV), vec![lhs.clone(), rhs.clone()])],
+            );
+        }
+    }
+    apply(sym(SUB), args.to_vec())
+}
+
+fn contract_mul(args: &[IRNode]) -> IRNode {
+    let mut log_indices = Vec::new();
+    let mut numeric_indices = Vec::new();
+    let mut other_count = 0;
+
+    for (index, arg) in args.iter().enumerate() {
+        if log_inner(arg).is_some() {
+            log_indices.push(index);
+        } else if matches!(arg, IRNode::Integer(_) | IRNode::Rational(_, _)) {
+            numeric_indices.push(index);
+        } else {
+            other_count += 1;
+        }
+    }
+
+    if log_indices.len() != 1 || numeric_indices.is_empty() || other_count != 0 {
+        return apply(sym(MUL), args.to_vec());
+    }
+
+    let log_node = &args[log_indices[0]];
+    let coeff_args = numeric_indices
+        .into_iter()
+        .map(|index| args[index].clone())
+        .collect::<Vec<_>>();
+    let coeff = match coeff_args.as_slice() {
+        [only] => only.clone(),
+        _ => apply(sym(MUL), coeff_args),
+    };
+
+    apply(
+        sym(LOG),
+        vec![apply(
+            sym(POW),
+            vec![
+                log_inner(log_node)
+                    .expect("log index points to log")
+                    .clone(),
+                coeff,
+            ],
+        )],
+    )
+}
+
+fn expand_log(args: &[IRNode]) -> IRNode {
+    if args.len() != 1 {
+        return apply(sym(LOG), args.to_vec());
+    }
+    let arg = &args[0];
+    if let IRNode::Apply(apply_node) = arg {
+        match head_name(&apply_node.head) {
+            Some(POW) if apply_node.args.len() == 2 => {
+                let exp = &apply_node.args[1];
+                if matches!(exp, IRNode::Integer(_) | IRNode::Rational(_, _)) {
+                    return apply(
+                        sym(MUL),
+                        vec![
+                            exp.clone(),
+                            apply(sym(LOG), vec![apply_node.args[0].clone()]),
+                        ],
+                    );
+                }
+            }
+            Some(MUL) if apply_node.args.len() >= 2 => {
+                let mut terms = apply_node
+                    .args
+                    .iter()
+                    .map(|arg| apply(sym(LOG), vec![arg.clone()]));
+                let first = terms.next().expect("len checked");
+                return terms.fold(first, |acc, term| apply(sym(ADD), vec![acc, term]));
+            }
+            Some(DIV) if apply_node.args.len() == 2 => {
+                return apply(
+                    sym(SUB),
+                    vec![
+                        apply(sym(LOG), vec![apply_node.args[0].clone()]),
+                        apply(sym(LOG), vec![apply_node.args[1].clone()]),
+                    ],
+                );
+            }
+            _ => {}
+        }
+    }
+    apply(sym(LOG), args.to_vec())
+}
+
+fn log_inner(node: &IRNode) -> Option<&IRNode> {
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    if head_name(&apply_node.head) == Some(LOG) && apply_node.args.len() == 1 {
+        Some(&apply_node.args[0])
+    } else {
+        None
+    }
+}
+
+fn head_name(node: &IRNode) -> Option<&str> {
+    match node {
+        IRNode::Symbol(name) => Some(name),
+        _ => None,
+    }
+}

--- a/code/packages/rust/cas-simplify/src/numeric_fold.rs
+++ b/code/packages/rust/cas-simplify/src/numeric_fold.rs
@@ -67,14 +67,24 @@ fn numeric_fold_apply(node: IRApply) -> IRNode {
 
             // Empty container (shouldn't happen after canonical, but be safe).
             if folded.is_empty() {
-                return if is_mul { IRNode::Integer(1) } else { IRNode::Integer(0) };
+                return if is_mul {
+                    IRNode::Integer(1)
+                } else {
+                    IRNode::Integer(0)
+                };
             }
 
-            return IRNode::Apply(Box::new(IRApply { head: new_head, args: folded }));
+            return IRNode::Apply(Box::new(IRApply {
+                head: new_head,
+                args: folded,
+            }));
         }
     }
 
-    IRNode::Apply(Box::new(IRApply { head: new_head, args: new_args }))
+    IRNode::Apply(Box::new(IRApply {
+        head: new_head,
+        args: new_args,
+    }))
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-simplify/src/radcan.rs
+++ b/code/packages/rust/cas-simplify/src/radcan.rs
@@ -1,0 +1,269 @@
+//! Radical canonicalization helpers.
+
+use std::collections::BTreeMap;
+
+use symbolic_ir::{apply, int, rat, sym, IRNode, EXP, LOG, MUL, POW, SQRT};
+
+use crate::assumptions::AssumptionContext;
+
+pub fn radcan(expr: IRNode, ctx: Option<&AssumptionContext>) -> IRNode {
+    let IRNode::Apply(apply_node) = expr else {
+        return expr;
+    };
+    let head = apply_node.head;
+    let args = apply_node
+        .args
+        .into_iter()
+        .map(|arg| radcan(arg, ctx))
+        .collect::<Vec<_>>();
+    let node = apply(head, args);
+    let IRNode::Apply(apply_node) = node else {
+        return node;
+    };
+    match head_name(&apply_node.head) {
+        Some(MUL) => rule_mul(&apply_node.args, ctx),
+        Some(SQRT) => rule_sqrt(&apply_node.args, ctx),
+        Some(POW) => rule_pow(&apply_node.args),
+        Some(EXP) => rule_exp(&apply_node.args),
+        Some(LOG) => rule_log(&apply_node.args),
+        _ => IRNode::Apply(apply_node),
+    }
+}
+
+fn rule_mul(args: &[IRNode], ctx: Option<&AssumptionContext>) -> IRNode {
+    let mut sqrt_radicands = Vec::new();
+    let mut non_sqrt = Vec::new();
+
+    for arg in args {
+        if let Some(radicand) = unary_inner(arg, SQRT) {
+            sqrt_radicands.push(radicand.clone());
+        } else {
+            non_sqrt.push(arg.clone());
+        }
+    }
+
+    let mut args = if sqrt_radicands.len() >= 2 {
+        let merged = radcan(apply(sym(SQRT), vec![mul_or_one(sqrt_radicands)]), ctx);
+        non_sqrt.push(merged);
+        non_sqrt
+    } else {
+        args.to_vec()
+    };
+
+    let mut groups: BTreeMap<(i64, i64), Vec<IRNode>> = BTreeMap::new();
+    let mut remaining = Vec::new();
+    for arg in args.drain(..) {
+        if let Some((numer, denom)) = rational_exponent(&arg) {
+            if denom > 1 && (numer, denom) != (1, 2) {
+                if let Some(base) = base_of(&arg) {
+                    groups.entry((numer, denom)).or_default().push(base.clone());
+                    continue;
+                }
+            }
+        }
+        remaining.push(arg);
+    }
+
+    let mut merged = Vec::new();
+    for ((numer, denom), bases) in groups {
+        let exp = if denom == 1 {
+            int(numer)
+        } else {
+            rat(numer, denom)
+        };
+        if bases.len() == 1 {
+            remaining.push(apply(sym(POW), vec![bases[0].clone(), exp]));
+        } else {
+            merged.push(apply(sym(POW), vec![mul_or_one(bases), exp]));
+        }
+    }
+
+    remaining.extend(merged);
+    mul_or_one(remaining)
+}
+
+fn rule_sqrt(args: &[IRNode], ctx: Option<&AssumptionContext>) -> IRNode {
+    if args.len() != 1 {
+        return apply(sym(SQRT), args.to_vec());
+    }
+    let arg = &args[0];
+
+    if let IRNode::Integer(n) = arg {
+        if *n >= 0 {
+            if let Some(root) = integer_sqrt(*n) {
+                return int(root);
+            }
+        }
+    }
+
+    if is_square_power(arg) {
+        if let Some(base) = base_of(arg) {
+            let result = abs_or_pos(base, ctx);
+            if result != *arg {
+                return result;
+            }
+        }
+    }
+
+    if let IRNode::Apply(mul_node) = arg {
+        if head_name(&mul_node.head) == Some(MUL) {
+            let mut outer = Vec::new();
+            let mut inner = Vec::new();
+            for factor in &mul_node.args {
+                if let Some(extracted) = try_extract_from_sqrt(factor, ctx) {
+                    outer.push(extracted);
+                } else {
+                    inner.push(factor.clone());
+                }
+            }
+            if !outer.is_empty() {
+                let outer_prod = mul_or_one(outer);
+                let inner_prod = mul_or_one(inner);
+                if inner_prod == int(1) {
+                    return outer_prod;
+                }
+                return apply(
+                    sym(MUL),
+                    vec![outer_prod, apply(sym(SQRT), vec![inner_prod])],
+                );
+            }
+        }
+    }
+
+    apply(sym(SQRT), args.to_vec())
+}
+
+fn try_extract_from_sqrt(factor: &IRNode, ctx: Option<&AssumptionContext>) -> Option<IRNode> {
+    if is_square_power(factor) {
+        let base = base_of(factor)?;
+        if matches!(base, IRNode::Integer(n) if *n > 0) {
+            return Some(base.clone());
+        }
+        if let IRNode::Symbol(name) = base {
+            if ctx.is_some_and(|ctx| ctx.is_positive(name) == Some(true)) {
+                return Some(base.clone());
+            }
+        }
+    }
+
+    if let IRNode::Integer(n) = factor {
+        if *n > 0 {
+            return integer_sqrt(*n).map(int);
+        }
+    }
+    None
+}
+
+fn rule_pow(args: &[IRNode]) -> IRNode {
+    if args.len() == 2 && args[1] == int(2) {
+        if let Some(inner) = unary_inner(&args[0], SQRT) {
+            return inner.clone();
+        }
+    }
+    apply(sym(POW), args.to_vec())
+}
+
+fn rule_exp(args: &[IRNode]) -> IRNode {
+    if args.len() == 1 {
+        if let Some(inner) = unary_inner(&args[0], LOG) {
+            return inner.clone();
+        }
+    }
+    apply(sym(EXP), args.to_vec())
+}
+
+fn rule_log(args: &[IRNode]) -> IRNode {
+    if args.len() == 1 {
+        if let Some(inner) = unary_inner(&args[0], EXP) {
+            return inner.clone();
+        }
+    }
+    apply(sym(LOG), args.to_vec())
+}
+
+fn is_square_power(node: &IRNode) -> bool {
+    matches!(
+        node,
+        IRNode::Apply(apply_node)
+            if head_name(&apply_node.head) == Some(POW)
+                && apply_node.args.len() == 2
+                && apply_node.args[1] == int(2)
+    )
+}
+
+fn abs_or_pos(base: &IRNode, ctx: Option<&AssumptionContext>) -> IRNode {
+    if matches!(base, IRNode::Integer(n) if *n > 0) {
+        return base.clone();
+    }
+    if let IRNode::Symbol(name) = base {
+        if ctx.is_some_and(|ctx| ctx.is_positive(name) == Some(true)) {
+            return base.clone();
+        }
+    }
+    apply(sym(SQRT), vec![apply(sym(POW), vec![base.clone(), int(2)])])
+}
+
+fn rational_exponent(node: &IRNode) -> Option<(i64, i64)> {
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    if head_name(&apply_node.head) != Some(POW) || apply_node.args.len() != 2 {
+        return None;
+    }
+    match apply_node.args[1] {
+        IRNode::Integer(n) => Some((n, 1)),
+        IRNode::Rational(n, d) => Some((n, d)),
+        _ => None,
+    }
+}
+
+fn base_of(node: &IRNode) -> Option<&IRNode> {
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    if head_name(&apply_node.head) == Some(POW) && apply_node.args.len() == 2 {
+        Some(&apply_node.args[0])
+    } else {
+        None
+    }
+}
+
+fn integer_sqrt(n: i64) -> Option<i64> {
+    if n < 0 {
+        return None;
+    }
+    let mut root = (n as f64).sqrt() as i64;
+    while root.saturating_mul(root) > n {
+        root -= 1;
+    }
+    while (root + 1).saturating_mul(root + 1) <= n {
+        root += 1;
+    }
+    (root * root == n).then_some(root)
+}
+
+fn mul_or_one(nodes: Vec<IRNode>) -> IRNode {
+    match nodes.as_slice() {
+        [] => int(1),
+        [only] => only.clone(),
+        _ => apply(sym(MUL), nodes),
+    }
+}
+
+fn unary_inner<'a>(node: &'a IRNode, head: &str) -> Option<&'a IRNode> {
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    if head_name(&apply_node.head) == Some(head) && apply_node.args.len() == 1 {
+        Some(&apply_node.args[0])
+    } else {
+        None
+    }
+}
+
+fn head_name(node: &IRNode) -> Option<&str> {
+    match node {
+        IRNode::Symbol(name) => Some(name),
+        _ => None,
+    }
+}

--- a/code/packages/rust/cas-simplify/src/rules.rs
+++ b/code/packages/rust/cas-simplify/src/rules.rs
@@ -91,14 +91,8 @@ pub fn build_identity_rules() -> Vec<IRNode> {
         //   Log(Exp(x)) → x
         //   Exp(Log(x)) → x
         // ----------------------------------------------------------------
-        rule(
-            apply(sym(LOG), vec![apply(sym(EXP), vec![x()])]),
-            x(),
-        ),
-        rule(
-            apply(sym(EXP), vec![apply(sym(LOG), vec![x()])]),
-            x(),
-        ),
+        rule(apply(sym(LOG), vec![apply(sym(EXP), vec![x()])]), x()),
+        rule(apply(sym(EXP), vec![apply(sym(LOG), vec![x()])]), x()),
         // ----------------------------------------------------------------
         // Trig at zero
         //   Sin(0) → 0

--- a/code/packages/rust/cas-simplify/tests/tests.rs
+++ b/code/packages/rust/cas-simplify/tests/tests.rs
@@ -4,9 +4,13 @@
 // code/packages/python/cas-simplify/tests/ to ensure the Rust port is
 // behaviourally equivalent.
 
-use cas_simplify::{canonical, numeric_fold, simplify};
+use cas_simplify::{
+    canonical, demoivre, exponentialize, logcontract, logexpand, numeric_fold, radcan, simplify,
+    AssumptionContext,
+};
 use symbolic_ir::{
-    apply, flt, int, rat, sym, IRNode, ADD, COS, DIV, EXP, LOG, MUL, POW, SIN, SUB,
+    apply, flt, int, rat, sym, IRNode, ADD, COS, COSH, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL,
+    LESS, LOG, MUL, NOT_EQUAL, POW, SIN, SINH, SQRT, SUB, TAN, TANH,
 };
 
 // ---------------------------------------------------------------------------
@@ -36,6 +40,10 @@ fn zero() -> IRNode {
 }
 fn one() -> IRNode {
     int(1)
+}
+
+fn i() -> IRNode {
+    sym("ImaginaryUnit")
 }
 
 // ---------------------------------------------------------------------------
@@ -313,20 +321,14 @@ fn simplify_div_self() {
 fn simplify_log_exp() {
     // Log(Exp(x)) → x
     let inner = apply(sym(EXP), vec![x()]);
-    assert_eq!(
-        simplify(apply(sym(LOG), vec![inner]), 50),
-        x()
-    );
+    assert_eq!(simplify(apply(sym(LOG), vec![inner]), 50), x());
 }
 
 #[test]
 fn simplify_exp_log() {
     // Exp(Log(x)) → x
     let inner = apply(sym(LOG), vec![x()]);
-    assert_eq!(
-        simplify(apply(sym(EXP), vec![inner]), 50),
-        x()
-    );
+    assert_eq!(simplify(apply(sym(EXP), vec![inner]), 50), x());
 }
 
 #[test]
@@ -428,4 +430,254 @@ fn simplify_atom_unchanged() {
     assert_eq!(simplify(x(), 50), x());
     assert_eq!(simplify(int(42), 50), int(42));
     assert_eq!(simplify(flt(3.14), 50), flt(3.14));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 21 — assumptions, radcan, log helpers, exponentialize, DeMoivre
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assumptions_track_relation_and_property_facts() {
+    let mut ctx = AssumptionContext::new();
+    assert_eq!(ctx.is_positive("x"), None);
+    assert!(!ctx.is_integer("n"));
+
+    ctx.assume_relation(&apply(sym(GREATER), vec![x(), int(0)]));
+    assert_eq!(ctx.is_positive("x"), Some(true));
+    assert_eq!(ctx.is_negative("x"), Some(false));
+    assert_eq!(ctx.sign_of("x"), Some(1));
+    assert_eq!(
+        ctx.is_true_relation(&apply(sym(GREATER), vec![x(), int(0)])),
+        Some(true)
+    );
+
+    ctx.assume_relation(&apply(sym(LESS), vec![y(), int(0)]));
+    assert_eq!(ctx.is_negative("y"), Some(true));
+    assert_eq!(ctx.sign_of("y"), Some(-1));
+
+    ctx.assume_relation(&apply(sym(EQUAL), vec![z(), int(0)]));
+    assert_eq!(ctx.sign_of("z"), Some(0));
+    ctx.assume_relation(&apply(sym(NOT_EQUAL), vec![a(), int(0)]));
+    assert_eq!(
+        ctx.is_true_relation(&apply(sym(EQUAL), vec![a(), int(0)])),
+        Some(false)
+    );
+
+    ctx.assume_relation(&apply(sym(GREATER_EQUAL), vec![b(), int(0)]));
+    assert_eq!(ctx.is_nonneg("b"), Some(true));
+    ctx.assume_property(&sym("n"), &sym("integer"));
+    assert!(ctx.is_integer("n"));
+
+    ctx.forget_relation(&apply(sym(GREATER), vec![x(), int(0)]));
+    assert_eq!(ctx.is_positive("x"), None);
+    ctx.forget_all();
+    assert!(!ctx.has_any_facts("n"));
+}
+
+#[test]
+fn radcan_simplifies_square_roots_and_exp_log_pairs() {
+    assert_eq!(radcan(apply(sym(SQRT), vec![int(4)]), None), int(2));
+    assert_eq!(
+        radcan(apply(sym(SQRT), vec![int(2)]), None),
+        apply(sym(SQRT), vec![int(2)])
+    );
+
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&apply(sym(GREATER), vec![x(), int(0)]));
+    let x_sq = apply(sym(POW), vec![x(), int(2)]);
+    assert_eq!(
+        radcan(apply(sym(SQRT), vec![x_sq.clone()]), Some(&ctx)),
+        x()
+    );
+    assert_ne!(radcan(apply(sym(SQRT), vec![x_sq]), None), x());
+
+    let inner = apply(sym(MUL), vec![apply(sym(POW), vec![x(), int(2)]), y()]);
+    let result = radcan(apply(sym(SQRT), vec![inner]), Some(&ctx));
+    match result {
+        IRNode::Apply(ap) => {
+            assert_eq!(ap.head, sym(MUL));
+            assert!(ap.args.contains(&x()));
+            assert!(ap.args.contains(&apply(sym(SQRT), vec![y()])));
+        }
+        other => panic!("expected Mul, got {other:?}"),
+    }
+
+    assert_eq!(
+        radcan(
+            apply(sym(POW), vec![apply(sym(SQRT), vec![x()]), int(2)]),
+            None
+        ),
+        x()
+    );
+    assert_eq!(
+        radcan(apply(sym(EXP), vec![apply(sym(LOG), vec![x()])]), None),
+        x()
+    );
+    assert_eq!(
+        radcan(apply(sym(LOG), vec![apply(sym(EXP), vec![x()])]), None),
+        x()
+    );
+}
+
+#[test]
+fn radcan_merges_sqrt_products_and_common_rational_exponents() {
+    let merged = radcan(
+        apply(
+            sym(MUL),
+            vec![apply(sym(SQRT), vec![a()]), apply(sym(SQRT), vec![b()])],
+        ),
+        None,
+    );
+    match merged {
+        IRNode::Apply(ap) => {
+            assert_eq!(ap.head, sym(SQRT));
+            let IRNode::Apply(inner) = &ap.args[0] else {
+                panic!("expected inner Mul");
+            };
+            assert_eq!(inner.head, sym(MUL));
+            assert!(inner.args.contains(&a()));
+            assert!(inner.args.contains(&b()));
+        }
+        other => panic!("expected Sqrt, got {other:?}"),
+    }
+
+    let third = rat(1, 3);
+    let collected = radcan(
+        apply(
+            sym(MUL),
+            vec![
+                apply(sym(POW), vec![a(), third.clone()]),
+                apply(sym(POW), vec![b(), third.clone()]),
+            ],
+        ),
+        None,
+    );
+    match collected {
+        IRNode::Apply(ap) => {
+            assert_eq!(ap.head, sym(POW));
+            assert_eq!(ap.args[1], third);
+            let IRNode::Apply(base) = &ap.args[0] else {
+                panic!("expected merged base");
+            };
+            assert_eq!(base.head, sym(MUL));
+            assert!(base.args.contains(&a()));
+            assert!(base.args.contains(&b()));
+        }
+        other => panic!("expected Pow, got {other:?}"),
+    }
+}
+
+#[test]
+fn logcontract_combines_log_sums_differences_and_coefficients() {
+    let sum = logcontract(apply(
+        sym(ADD),
+        vec![apply(sym(LOG), vec![a()]), apply(sym(LOG), vec![b()])],
+    ));
+    match sum {
+        IRNode::Apply(ap) => {
+            assert_eq!(ap.head, sym(LOG));
+            assert!(matches!(&ap.args[0], IRNode::Apply(inner) if inner.head == sym(MUL)));
+        }
+        other => panic!("expected Log, got {other:?}"),
+    }
+
+    let diff = logcontract(apply(
+        sym(SUB),
+        vec![apply(sym(LOG), vec![a()]), apply(sym(LOG), vec![b()])],
+    ));
+    assert!(
+        matches!(diff, IRNode::Apply(ap) if ap.head == sym(LOG) && matches!(&ap.args[0], IRNode::Apply(inner) if inner.head == sym(DIV)))
+    );
+
+    let coeff = logcontract(apply(sym(MUL), vec![int(2), apply(sym(LOG), vec![x()])]));
+    assert!(
+        matches!(coeff, IRNode::Apply(ap) if ap.head == sym(LOG) && matches!(&ap.args[0], IRNode::Apply(inner) if inner.head == sym(POW) && inner.args[1] == int(2)))
+    );
+    let non_numeric = apply(sym(MUL), vec![x(), apply(sym(LOG), vec![y()])]);
+    assert_eq!(logcontract(non_numeric.clone()), non_numeric);
+}
+
+#[test]
+fn logexpand_distributes_over_powers_products_and_quotients() {
+    let power = logexpand(
+        apply(sym(LOG), vec![apply(sym(POW), vec![x(), int(3)])]),
+        None,
+    );
+    assert!(matches!(power, IRNode::Apply(ap) if ap.head == sym(MUL) && ap.args.contains(&int(3))));
+
+    let product = logexpand(
+        apply(sym(LOG), vec![apply(sym(MUL), vec![a(), b(), x()])]),
+        None,
+    );
+    fn count_logs(node: &IRNode) -> usize {
+        match node {
+            IRNode::Apply(ap) if ap.head == sym(LOG) => 1,
+            IRNode::Apply(ap) => ap.args.iter().map(count_logs).sum(),
+            _ => 0,
+        }
+    }
+    assert_eq!(count_logs(&product), 3);
+
+    let quotient = logexpand(apply(sym(LOG), vec![apply(sym(DIV), vec![a(), b()])]), None);
+    assert_eq!(
+        quotient,
+        apply(
+            sym(SUB),
+            vec![apply(sym(LOG), vec![a()]), apply(sym(LOG), vec![b()])]
+        )
+    );
+}
+
+#[test]
+fn exponentialize_rewrites_trig_and_hyperbolic_heads() {
+    let sin_out = exponentialize(apply(sym(SIN), vec![x()]));
+    assert!(
+        matches!(sin_out, IRNode::Apply(ap) if ap.head == sym(DIV) && matches!(&ap.args[0], IRNode::Apply(num) if num.head == sym(SUB)))
+    );
+
+    let cos_out = exponentialize(apply(sym(COS), vec![x()]));
+    assert!(matches!(cos_out, IRNode::Apply(ap) if ap.head == sym(DIV) && ap.args[1] == int(2)));
+
+    let tan_out = exponentialize(apply(sym(TAN), vec![x()]));
+    assert!(
+        matches!(tan_out, IRNode::Apply(ap) if ap.head == sym(DIV) && matches!(&ap.args[1], IRNode::Apply(den) if den.head == sym(ADD)))
+    );
+
+    for head in [SINH, COSH, TANH] {
+        let out = exponentialize(apply(sym(head), vec![x()]));
+        assert!(matches!(out, IRNode::Apply(ap) if ap.head == sym(DIV)));
+    }
+}
+
+#[test]
+fn demoivre_splits_pure_and_mixed_complex_exponentials() {
+    let pure = demoivre(apply(sym(EXP), vec![apply(sym(MUL), vec![i(), y()])]));
+    match pure {
+        IRNode::Apply(ap) => {
+            assert_eq!(ap.head, sym(ADD));
+            assert!(
+                matches!(&ap.args[0], IRNode::Apply(cos) if cos.head == sym(COS) && cos.args[0] == y())
+            );
+            assert!(
+                matches!(&ap.args[1], IRNode::Apply(mul) if mul.head == sym(MUL) && mul.args.contains(&i()))
+            );
+        }
+        other => panic!("expected Add, got {other:?}"),
+    }
+
+    let bare = demoivre(apply(sym(EXP), vec![i()]));
+    assert!(
+        matches!(bare, IRNode::Apply(ap) if ap.head == sym(ADD) && matches!(&ap.args[0], IRNode::Apply(cos) if cos.args[0] == int(1)))
+    );
+
+    let mixed = demoivre(apply(
+        sym(EXP),
+        vec![apply(sym(ADD), vec![x(), apply(sym(MUL), vec![i(), y()])])],
+    ));
+    assert!(
+        matches!(mixed, IRNode::Apply(ap) if ap.head == sym(MUL) && ap.args.iter().any(|arg| matches!(arg, IRNode::Apply(exp) if exp.head == sym(EXP) && exp.args[0] == x())))
+    );
+
+    let real_only = apply(sym(EXP), vec![x()]);
+    assert_eq!(demoivre(real_only.clone()), real_only);
 }


### PR DESCRIPTION
## Summary
- add Rust AssumptionContext basics plus Phase 21 head sentinels
- port radcan, logcontract/logexpand, exponentialize, and demoivre helpers from the Python reference
- add package-local parity tests for radical/log/exponential simplification cases

## Validation
- cargo fmt -p cas-simplify
- cargo test -p cas-simplify
- cargo check -p cas-simplify

## Deferred parity gaps
- no VM handler integration for Assume/Forget/Is/Sign heads in this slice
- transformations intentionally mirror the Python Phase 21 structural rules, without broader branch/cut-domain analysis for logs or radicals
