### PR TITLE
Add TypeScript symbolic Integrate slice

### DIFF
--- a/code/packages/typescript/symbolic-vm/README.md
+++ b/code/packages/typescript/symbolic-vm/README.md
@@ -6,7 +6,7 @@ The VM is policy-free. A backend supplies name lookup, held heads, rewrite
 rules, and per-head handlers.
 
 ```ts
-import { ADD, D, POW, app, int, sym } from "@coding-adventures/symbolic-ir";
+import { ADD, D, INTEGRATE, POW, SIN, app, int, sym } from "@coding-adventures/symbolic-ir";
 import { SymbolicBackend, VM } from "@coding-adventures/symbolic-vm";
 
 const vm = new VM(new SymbolicBackend());
@@ -14,6 +14,7 @@ const vm = new VM(new SymbolicBackend());
 vm.eval(app(ADD, [int(2), int(3)]));    // 5
 vm.eval(app(ADD, [sym("x"), int(0)])); // x
 vm.eval(app(D, [app(POW, [sym("x"), int(2)]), sym("x")])); // 2*x
+vm.eval(app(INTEGRATE, [app(SIN, [sym("x")]), sym("x")])); // -cos(x)
 ```
 
 The package has no host dependencies and is safe to use in browsers.

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -19,6 +19,7 @@ import {
   GREATER,
   GREATER_EQUAL,
   IF,
+  INTEGRATE,
   INV,
   IRApply,
   IRNode,
@@ -348,9 +349,103 @@ function buildHandlerTable(simplify: boolean): ReadonlyMap<string, Handler> {
   table.set(LIST.name, (_vm, expr) => expr);
   if (simplify) {
     table.set(D.name, differentiate());
+    table.set(INTEGRATE.name, integrate());
   }
 
   return table;
+}
+
+function integrate(): Handler {
+  return (vm, expr) => {
+    if (expr.args.length !== 2) {
+      throw new ArityError(`Integrate expects 2 arguments, got ${expr.args.length}`);
+    }
+    const [f, x] = expr.args;
+    if (x.kind !== "symbol") {
+      return expr;
+    }
+    const result = integrateIndefinite(f, x);
+    if (result === undefined) {
+      return expr;
+    }
+    return isDeferredIntegral(result, f, x) ? result : vm.eval(result);
+  };
+}
+
+function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
+  if (!dependsOn(f, x)) {
+    return app(MUL, [f, x]);
+  }
+  if (equals(f, x)) {
+    return app(MUL, [rational(1, 2), app(POW, [x, int(2)])]);
+  }
+  if (f.kind !== "apply") {
+    return undefined;
+  }
+
+  if (equals(f.head, ADD)) {
+    const pieces = f.args.map((arg) => integrateIndefinite(arg, x));
+    if (pieces.some((piece) => piece === undefined)) return undefined;
+    return binaryChain(ADD, pieces as IRNode[]);
+  }
+  if (equals(f.head, SUB)) {
+    const [a, b] = binaryArgs(f);
+    const ia = integrateIndefinite(a, x);
+    const ib = integrateIndefinite(b, x);
+    return ia === undefined || ib === undefined ? undefined : app(SUB, [ia, ib]);
+  }
+  if (equals(f.head, NEG)) {
+    const [inner] = unaryArgs(f);
+    const integrated = integrateIndefinite(inner, x);
+    return integrated === undefined ? undefined : app(NEG, [integrated]);
+  }
+  if (equals(f.head, MUL)) {
+    const [a, b] = binaryArgs(f);
+    if (!dependsOn(a, x)) {
+      const ib = integrateIndefinite(b, x);
+      return ib === undefined ? undefined : app(MUL, [a, ib]);
+    }
+    if (!dependsOn(b, x)) {
+      const ia = integrateIndefinite(a, x);
+      return ia === undefined ? undefined : app(MUL, [b, ia]);
+    }
+    return undefined;
+  }
+  if (equals(f.head, DIV)) {
+    const [numerator, denominator] = binaryArgs(f);
+    if (!dependsOn(numerator, x) && equals(denominator, x)) {
+      return app(MUL, [numerator, app(LOG, [x])]);
+    }
+    return undefined;
+  }
+  if (equals(f.head, POW)) {
+    const [base, exponent] = binaryArgs(f);
+    if (equals(base, x) && exactRational(exponent) !== undefined) {
+      const n = exactRational(exponent)!;
+      if (n.numer === -n.denom) {
+        return app(LOG, [x]);
+      }
+      const next = makeRat(n.numer + n.denom, n.denom);
+      return app(MUL, [fromNumeric(divNumeric({ kind: "int", value: 1n }, next)), app(POW, [x, fromNumeric(next)])]);
+    }
+    if (!dependsOn(base, x) && equals(exponent, x)) {
+      return app(DIV, [f, app(LOG, [base])]);
+    }
+    return undefined;
+  }
+
+  const [inner] = f.args.length === 1 ? [f.args[0]] : [undefined];
+  if (inner !== undefined && equals(inner, x)) {
+    if (equals(f.head, SIN)) return app(NEG, [app(COS, [x])]);
+    if (equals(f.head, COS)) return app(SIN, [x]);
+    if (equals(f.head, EXP)) return app(EXP, [x]);
+    if (equals(f.head, LOG)) return app(SUB, [app(MUL, [x, app(LOG, [x])]), x]);
+    if (equals(f.head, SQRT)) {
+      return app(MUL, [rational(2, 3), app(POW, [x, rational(3, 2)])]);
+    }
+  }
+
+  return undefined;
 }
 
 function differentiate(): Handler {
@@ -482,12 +577,33 @@ function dependsOn(node: IRNode, variable: IRNode): boolean {
   return false;
 }
 
+function isDeferredIntegral(node: IRNode, f: IRNode, x: IRNode): boolean {
+  return node.kind === "apply"
+    && equals(node.head, INTEGRATE)
+    && node.args.length === 2
+    && equals(node.args[0], f)
+    && equals(node.args[1], x);
+}
+
 function isDeferredDerivative(node: IRNode, f: IRNode, x: IRNode): boolean {
   return node.kind === "apply"
     && equals(node.head, D)
     && node.args.length === 2
     && equals(node.args[0], f)
     && equals(node.args[1], x);
+}
+
+function binaryChain(head: IRNode, pieces: readonly IRNode[]): IRNode {
+  if (pieces.length === 0) {
+    throw new ArityError(`${headName(head) || "<non-symbol-head>"} requires at least one argument`);
+  }
+  return pieces.slice(1).reduce((left, right) => app(head, [left, right]), pieces[0]);
+}
+
+function exactRational(node: IRNode): { readonly numer: bigint; readonly denom: bigint } | undefined {
+  if (node.kind === "integer") return { numer: node.value, denom: 1n };
+  if (node.kind === "rational") return { numer: node.numer, denom: node.denom };
+  return undefined;
 }
 
 type Numeric =

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -14,6 +14,7 @@ import {
   EXP,
   FALSE,
   IF,
+  INTEGRATE,
   LIST,
   LOG,
   MUL,
@@ -33,7 +34,7 @@ import {
   rational,
   sym,
 } from "@coding-adventures/symbolic-ir";
-import { StrictBackend, StrictEvaluationError, SymbolicBackend, VM } from "../src/index.js";
+import { ArityError, StrictBackend, StrictEvaluationError, SymbolicBackend, VM } from "../src/index.js";
 
 describe("symbolic-vm", () => {
   it("strict backend folds numeric arithmetic exactly", () => {
@@ -196,5 +197,89 @@ describe("symbolic-vm", () => {
     const vm = new VM(new SymbolicBackend());
     const expr = app(D, [app(sym("F"), [sym("x")]), sym("x")]);
     expect(vm.eval(expr)).toEqual(expr);
+  });
+
+  it("keeps Integrate symbolic-backend-only", () => {
+    const vm = new VM(new StrictBackend());
+    expect(() => vm.eval(app(INTEGRATE, [int(1), sym("x")]))).toThrow(StrictEvaluationError);
+  });
+
+  it("integrates constants, free symbols, and variable identity", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(INTEGRATE, [int(5), sym("x")]))).toEqual(app(MUL, [int(5), sym("x")]));
+    expect(vm.eval(app(INTEGRATE, [sym("y"), sym("x")]))).toEqual(app(MUL, [sym("y"), sym("x")]));
+    expect(vm.eval(app(INTEGRATE, [sym("x"), sym("x")]))).toEqual(
+      app(MUL, [rational(1, 2), app(POW, [sym("x"), int(2)])]),
+    );
+    expect(vm.eval(app(INTEGRATE, [int(0), sym("x")]))).toEqual(int(0));
+  });
+
+  it("integrates powers and reciprocals", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(INTEGRATE, [app(POW, [sym("x"), int(2)]), sym("x")]))).toEqual(
+      app(MUL, [rational(1, 3), app(POW, [sym("x"), int(3)])]),
+    );
+    expect(vm.eval(app(INTEGRATE, [app(POW, [sym("x"), rational(1, 2)]), sym("x")]))).toEqual(
+      app(MUL, [rational(2, 3), app(POW, [sym("x"), rational(3, 2)])]),
+    );
+    expect(vm.eval(app(INTEGRATE, [app(POW, [sym("x"), int(-1)]), sym("x")]))).toEqual(
+      app(LOG, [sym("x")]),
+    );
+    expect(vm.eval(app(INTEGRATE, [app(DIV, [int(3), sym("x")]), sym("x")]))).toEqual(
+      app(MUL, [int(3), app(LOG, [sym("x")])]),
+    );
+  });
+
+  it("integrates Add, Sub, Neg, and constant factors", () => {
+    const vm = new VM(new SymbolicBackend());
+    const halfXSquared = app(MUL, [rational(1, 2), app(POW, [sym("x"), int(2)])]);
+    expect(vm.eval(app(INTEGRATE, [app(ADD, [sym("x"), int(3)]), sym("x")]))).toEqual(
+      app(ADD, [halfXSquared, app(MUL, [int(3), sym("x")])]),
+    );
+    expect(vm.eval(app(INTEGRATE, [app(SUB, [sym("x"), int(1)]), sym("x")]))).toEqual(
+      app(SUB, [halfXSquared, sym("x")]),
+    );
+    expect(vm.eval(app(INTEGRATE, [app(NEG, [sym("x")]), sym("x")]))).toEqual(app(NEG, [halfXSquared]));
+    expect(vm.eval(app(INTEGRATE, [app(MUL, [sym("y"), app(POW, [sym("x"), int(2)])]), sym("x")]))).toEqual(
+      app(MUL, [sym("y"), app(MUL, [rational(1, 3), app(POW, [sym("x"), int(3)])])]),
+    );
+    expect(vm.eval(app(INTEGRATE, [app(MUL, [sym("x"), int(7)]), sym("x")]))).toEqual(
+      app(MUL, [int(7), halfXSquared]),
+    );
+  });
+
+  it("integrates direct elementary functions at x", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(INTEGRATE, [app(SIN, [sym("x")]), sym("x")]))).toEqual(
+      app(NEG, [app(COS, [sym("x")])]),
+    );
+    expect(vm.eval(app(INTEGRATE, [app(COS, [sym("x")]), sym("x")]))).toEqual(app(SIN, [sym("x")]));
+    expect(vm.eval(app(INTEGRATE, [app(EXP, [sym("x")]), sym("x")]))).toEqual(app(EXP, [sym("x")]));
+    expect(vm.eval(app(INTEGRATE, [app(LOG, [sym("x")]), sym("x")]))).toEqual(
+      app(SUB, [app(MUL, [sym("x"), app(LOG, [sym("x")])]), sym("x")]),
+    );
+    expect(vm.eval(app(INTEGRATE, [app(SQRT, [sym("x")]), sym("x")]))).toEqual(
+      app(MUL, [rational(2, 3), app(POW, [sym("x"), rational(3, 2)])]),
+    );
+  });
+
+  it("integrates constant-base exponentials", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(INTEGRATE, [app(POW, [int(2), sym("x")]), sym("x")]))).toEqual(
+      app(DIV, [app(POW, [int(2), sym("x")]), numberNode(Math.log(2))]),
+    );
+  });
+
+  it("leaves unknown dependent integrals unevaluated", () => {
+    const vm = new VM(new SymbolicBackend());
+    const expr = app(INTEGRATE, [app(sym("F"), [sym("x")]), sym("x")]);
+    expect(vm.eval(expr)).toEqual(expr);
+  });
+
+  it("leaves non-symbol integration variables unevaluated and rejects wrong arity", () => {
+    const vm = new VM(new SymbolicBackend());
+    const expr = app(INTEGRATE, [sym("x"), int(1)]);
+    expect(vm.eval(expr)).toEqual(expr);
+    expect(() => vm.eval(app(INTEGRATE, [sym("x")]))).toThrow(ArityError);
   });
 });


### PR DESCRIPTION
## Summary
- add a SymbolicBackend-only `Integrate` handler for the small Phase 1 indefinite integration slice
- cover constants/free symbols, identity, powers, `c/x`, linearity, constant factors, direct elementary functions, constant-base exponentials, strict-backend behavior, and unevaluated fallbacks
- document the new `Integrate` example in the package README

## Validation
- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage`

## Deferred parity gaps
- no StrictBackend `Integrate` support, matching `D` behavior
- no definite integration / 4-arg `Integrate`
- no rational-function Hermite/RT/arctan routes
- no u-substitution, composed elementary functions, polynomial-times-transcendental, or broader special-function phases
- no parser or grammar-tool changes