### PR TITLE
Port symbolic Integrate Phase 1 to Rust

### DIFF
--- a/code/packages/rust/symbolic-vm/README.md
+++ b/code/packages/rust/symbolic-vm/README.md
@@ -34,7 +34,7 @@ are included:
 ## Quick start
 
 ```rust
-use symbolic_ir::{apply, int, sym, ADD, D, MUL, POW};
+use symbolic_ir::{apply, int, sym, ADD, D, INTEGRATE, MUL, POW};
 use symbolic_vm::{SymbolicBackend, VM};
 
 let mut vm = VM::new(Box::new(SymbolicBackend::new()));
@@ -52,6 +52,16 @@ assert_eq!(vm.eval(sym("t")), sym("t"));
 // Symbolic differentiation is installed only on SymbolicBackend.
 let dx_x_sq = apply(sym(D), vec![apply(sym(POW), vec![sym("x"), int(2)]), sym("x")]);
 assert_eq!(vm.eval(dx_x_sq), apply(sym(MUL), vec![int(2), sym("x")]));
+
+// Symbolic integration has a small Phase 1 table on SymbolicBackend.
+let int_x_sq = apply(sym(INTEGRATE), vec![apply(sym(POW), vec![sym("x"), int(2)]), sym("x")]);
+assert_eq!(
+    vm.eval(int_x_sq),
+    apply(
+        sym(MUL),
+        vec![symbolic_ir::rat(1, 3), apply(sym(POW), vec![sym("x"), int(3)])],
+    )
+);
 ```
 
 ## Custom backend

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -25,8 +25,8 @@ use std::collections::HashMap;
 
 use symbolic_ir::{
     IRApply, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ASSIGN, ATAN, ATANH, COS, COSH, D, DEFINE,
-    DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INV, LESS, LESS_EQUAL, LOG, MUL, NEG, NOT,
-    NOT_EQUAL, OR, POW, SIN, SINH, SQRT, SUB, TAN, TANH,
+    DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INTEGRATE, INV, LESS, LESS_EQUAL, LOG, MUL, NEG,
+    NOT, NOT_EQUAL, OR, POW, SIN, SINH, SQRT, SUB, TAN, TANH,
 };
 
 use crate::backend::Handler;
@@ -939,6 +939,135 @@ fn derivative_handler() -> Handler {
     })
 }
 
+fn integrate_handler() -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() != 2 {
+            panic!("Integrate expects 2 arguments, got {}", expr.args.len());
+        }
+
+        let f = expr.args[0].clone();
+        let x = match &expr.args[1] {
+            IRNode::Symbol(s) => s.clone(),
+            _ => return IRNode::Apply(Box::new(expr)),
+        };
+
+        let result = integrate(&f, &x);
+        let original = apply_node(INTEGRATE, vec![f, IRNode::Symbol(x)]);
+        if result == original {
+            result
+        } else {
+            vm.eval(result)
+        }
+    })
+}
+
+fn integrate(f: &IRNode, x: &str) -> IRNode {
+    if !depends_on(f, x) {
+        return apply_node(MUL, vec![f.clone(), IRNode::Symbol(x.to_string())]);
+    }
+
+    if f == &IRNode::Symbol(x.to_string()) {
+        return apply_node(
+            MUL,
+            vec![
+                IRNode::Rational(1, 2),
+                apply_node(POW, vec![IRNode::Symbol(x.to_string()), IRNode::Integer(2)]),
+            ],
+        );
+    }
+
+    let IRNode::Apply(apply) = f else {
+        return apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]);
+    };
+
+    let IRNode::Symbol(head) = &apply.head else {
+        return apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]);
+    };
+
+    match (head.as_str(), apply.args.as_slice()) {
+        (ADD, [a, b]) => apply_node(ADD, vec![integrate(a, x), integrate(b, x)]),
+        (SUB, [a, b]) => apply_node(SUB, vec![integrate(a, x), integrate(b, x)]),
+        (NEG, [a]) => apply_node(NEG, vec![integrate(a, x)]),
+        (MUL, [a, b]) if !depends_on(a, x) => apply_node(MUL, vec![a.clone(), integrate(b, x)]),
+        (MUL, [a, b]) if !depends_on(b, x) => apply_node(MUL, vec![b.clone(), integrate(a, x)]),
+        (DIV, [c, denom]) if denom == &IRNode::Symbol(x.to_string()) && !depends_on(c, x) => {
+            apply_node(MUL, vec![c.clone(), apply_node(LOG, vec![denom.clone()])])
+        }
+        (POW, [base, exponent]) if base == &IRNode::Symbol(x.to_string()) => {
+            integrate_power_of_x(exponent, x)
+        }
+        (POW, [base, exponent]) if exponent == &IRNode::Symbol(x.to_string()) => {
+            if !depends_on(base, x) {
+                apply_node(
+                    DIV,
+                    vec![
+                        apply_node(POW, vec![base.clone(), exponent.clone()]),
+                        apply_node(LOG, vec![base.clone()]),
+                    ],
+                )
+            } else {
+                apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])
+            }
+        }
+        (SIN, [inner]) if inner == &IRNode::Symbol(x.to_string()) => {
+            apply_node(NEG, vec![apply_node(COS, vec![inner.clone()])])
+        }
+        (COS, [inner]) if inner == &IRNode::Symbol(x.to_string()) => {
+            apply_node(SIN, vec![inner.clone()])
+        }
+        (EXP, [inner]) if inner == &IRNode::Symbol(x.to_string()) => {
+            apply_node(EXP, vec![inner.clone()])
+        }
+        (LOG, [inner]) if inner == &IRNode::Symbol(x.to_string()) => apply_node(
+            SUB,
+            vec![
+                apply_node(
+                    MUL,
+                    vec![inner.clone(), apply_node(LOG, vec![inner.clone()])],
+                ),
+                inner.clone(),
+            ],
+        ),
+        (SQRT, [inner]) if inner == &IRNode::Symbol(x.to_string()) => apply_node(
+            MUL,
+            vec![
+                IRNode::Rational(2, 3),
+                apply_node(POW, vec![inner.clone(), IRNode::Rational(3, 2)]),
+            ],
+        ),
+        _ => apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]),
+    }
+}
+
+fn integrate_power_of_x(exponent: &IRNode, x: &str) -> IRNode {
+    let Some(n) = to_numeric(exponent) else {
+        return apply_node(
+            INTEGRATE,
+            vec![
+                apply_node(POW, vec![IRNode::Symbol(x.to_string()), exponent.clone()]),
+                IRNode::Symbol(x.to_string()),
+            ],
+        );
+    };
+
+    if n == Numeric::Int(-1) {
+        return apply_node(LOG, vec![IRNode::Symbol(x.to_string())]);
+    }
+
+    let next = n + Numeric::Int(1);
+    if next.is_zero() {
+        return apply_node(LOG, vec![IRNode::Symbol(x.to_string())]);
+    }
+
+    apply_node(
+        MUL,
+        vec![
+            from_numeric(Numeric::Int(1) / next),
+            apply_node(POW, vec![IRNode::Symbol(x.to_string()), from_numeric(next)]),
+        ],
+    )
+}
+
 fn diff(f: &IRNode, x: &str) -> IRNode {
     if !depends_on(f, x) {
         return IRNode::Integer(0);
@@ -1229,6 +1358,7 @@ pub fn build_handler_table(simplify: bool) -> HashMap<String, Handler> {
     m.insert("List".to_string(), list_handler(simplify));
     if simplify {
         m.insert(D.to_string(), derivative_handler());
+        m.insert(INTEGRATE.to_string(), integrate_handler());
     }
     m
 }

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -5,7 +5,7 @@
 
 use symbolic_ir::{
     apply, flt, int, rat, sym, ACOSH, ADD, AND, ASINH, ASSIGN, ATANH, COS, COSH, D, DEFINE, DIV,
-    EXP, IF, LIST, LOG, MUL, NEG, NOT, OR, POW, SIN, SINH, SQRT, SUB, TAN, TANH,
+    EXP, IF, INTEGRATE, LIST, LOG, MUL, NEG, NOT, OR, POW, SIN, SINH, SQRT, SUB, TAN, TANH,
 };
 use symbolic_vm::{StrictBackend, SymbolicBackend, VM};
 
@@ -23,6 +23,10 @@ fn symbolic() -> VM {
 
 fn d(f: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
     symbolic().eval(apply(sym(D), vec![f, sym("x")]))
+}
+
+fn integrate(f: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
+    symbolic().eval(apply(sym(INTEGRATE), vec![f, sym("x")]))
 }
 
 // ---------------------------------------------------------------------------
@@ -514,6 +518,156 @@ fn derivative_reciprocal_hyperbolic_chain_rules() {
 fn derivative_unknown_head_stays_unevaluated() {
     let f = apply(sym("F"), vec![sym("x")]);
     let expr = apply(sym(D), vec![f, sym("x")]);
+    assert_eq!(symbolic().eval(expr.clone()), expr);
+}
+
+// ---------------------------------------------------------------------------
+// Symbolic integration handler
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integrate_is_symbolic_backend_only() {
+    assert!(symbolic().backend.handler_for(INTEGRATE).is_some());
+    assert!(strict().backend.handler_for(INTEGRATE).is_none());
+}
+
+#[test]
+fn integrate_constants_and_variables() {
+    assert_eq!(integrate(int(5)), apply(sym(MUL), vec![int(5), sym("x")]));
+    assert_eq!(
+        integrate(sym("y")),
+        apply(sym(MUL), vec![sym("y"), sym("x")])
+    );
+    assert_eq!(
+        integrate(sym("x")),
+        apply(
+            sym(MUL),
+            vec![rat(1, 2), apply(sym(POW), vec![sym("x"), int(2)])],
+        )
+    );
+    assert_eq!(integrate(int(0)), int(0));
+}
+
+#[test]
+fn integrate_power_rules() {
+    assert_eq!(
+        integrate(apply(sym(POW), vec![sym("x"), int(2)])),
+        apply(
+            sym(MUL),
+            vec![rat(1, 3), apply(sym(POW), vec![sym("x"), int(3)])],
+        )
+    );
+    assert_eq!(
+        integrate(apply(sym(POW), vec![sym("x"), rat(1, 2)])),
+        apply(
+            sym(MUL),
+            vec![rat(2, 3), apply(sym(POW), vec![sym("x"), rat(3, 2)])],
+        )
+    );
+    assert_eq!(
+        integrate(apply(sym(POW), vec![sym("x"), int(-1)])),
+        apply(sym(LOG), vec![sym("x")])
+    );
+    assert_eq!(
+        integrate(apply(sym(DIV), vec![int(3), sym("x")])),
+        apply(sym(MUL), vec![int(3), apply(sym(LOG), vec![sym("x")])])
+    );
+}
+
+#[test]
+fn integrate_linearity_and_constant_factor() {
+    let half_x_squared = apply(
+        sym(MUL),
+        vec![rat(1, 2), apply(sym(POW), vec![sym("x"), int(2)])],
+    );
+
+    assert_eq!(
+        integrate(apply(sym(ADD), vec![sym("x"), int(3)])),
+        apply(
+            sym(ADD),
+            vec![
+                half_x_squared.clone(),
+                apply(sym(MUL), vec![int(3), sym("x")])
+            ],
+        )
+    );
+    assert_eq!(
+        integrate(apply(sym(SUB), vec![sym("x"), int(1)])),
+        apply(sym(SUB), vec![half_x_squared.clone(), sym("x")])
+    );
+    assert_eq!(
+        integrate(apply(sym(NEG), vec![sym("x")])),
+        apply(sym(NEG), vec![half_x_squared.clone()])
+    );
+    assert_eq!(
+        integrate(apply(
+            sym(MUL),
+            vec![sym("y"), apply(sym(POW), vec![sym("x"), int(2)])]
+        )),
+        apply(
+            sym(MUL),
+            vec![
+                sym("y"),
+                apply(
+                    sym(MUL),
+                    vec![rat(1, 3), apply(sym(POW), vec![sym("x"), int(3)])],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
+fn integrate_elementary_direct_forms() {
+    assert_eq!(
+        integrate(apply(sym(SIN), vec![sym("x")])),
+        apply(sym(NEG), vec![apply(sym(COS), vec![sym("x")])])
+    );
+    assert_eq!(
+        integrate(apply(sym(COS), vec![sym("x")])),
+        apply(sym(SIN), vec![sym("x")])
+    );
+    assert_eq!(
+        integrate(apply(sym(EXP), vec![sym("x")])),
+        apply(sym(EXP), vec![sym("x")])
+    );
+    assert_eq!(
+        integrate(apply(sym(LOG), vec![sym("x")])),
+        apply(
+            sym(SUB),
+            vec![
+                apply(sym(MUL), vec![sym("x"), apply(sym(LOG), vec![sym("x")])]),
+                sym("x"),
+            ],
+        )
+    );
+    assert_eq!(
+        integrate(apply(sym(SQRT), vec![sym("x")])),
+        apply(
+            sym(MUL),
+            vec![rat(2, 3), apply(sym(POW), vec![sym("x"), rat(3, 2)])],
+        )
+    );
+}
+
+#[test]
+fn integrate_constant_base_power() {
+    assert_eq!(
+        integrate(apply(sym(POW), vec![sym("a"), sym("x")])),
+        apply(
+            sym(DIV),
+            vec![
+                apply(sym(POW), vec![sym("a"), sym("x")]),
+                apply(sym(LOG), vec![sym("a")]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn integrate_unknown_dependent_form_stays_unevaluated() {
+    let f = apply(sym("F"), vec![sym("x")]);
+    let expr = apply(sym(INTEGRATE), vec![f, sym("x")]);
     assert_eq!(symbolic().eval(expr.clone()), expr);
 }
 


### PR DESCRIPTION
## Summary
- add a SymbolicBackend-only Integrate handler for the Rust symbolic-vm
- support Phase 1 indefinite integration rules for constants/free symbols, x, integer/rational powers, c/x, linearity, binary constant factors, direct elementary functions, sqrt/log, and constant-base powers
- document the new Integrate slice and add package-local integration tests

## Validation
- cargo fmt -p symbolic-vm
- cargo test -p symbolic-vm
- cargo check -p symbolic-vm

## Deferred parity gaps
- rational-function integration / Hermite / Rothstein-Trager routes
- definite Integrate(f, x, a, b)
- substitution/composed elementary integrations beyond direct f(x)
- special-function and advanced trig/hyperbolic polynomial integrations
- parser/grammar integration