### PR TITLE
[codex] port TypeScript cas-matrix row reduction

### DIFF
--- a/code/packages/typescript/cas-matrix/README.md
+++ b/code/packages/typescript/cas-matrix/README.md
@@ -28,3 +28,5 @@ fold numeric entries.
 | `trace(m)` | Main diagonal sum |
 | `determinant(m)` | Symbolic cofactor determinant |
 | `inverse(m)` | Symbolic adjugate inverse |
+| `rowReduce(m)` | Exact rational reduced row echelon form for integer/rational matrices |
+| `rank(m)` | Exact rational matrix rank for integer/rational matrices |

--- a/code/packages/typescript/cas-matrix/src/index.ts
+++ b/code/packages/typescript/cas-matrix/src/index.ts
@@ -8,7 +8,9 @@ import {
   app,
   headName,
   int,
+  rational,
   sym,
+  type IRInteger,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
 
@@ -170,6 +172,75 @@ export function inverse(node: IRNode): IRNode {
   return matrix(adjugate.map((row) => row.map((cell) => app(DIV, [cell, determinantNode]))));
 }
 
+export function rowReduce(node: IRNode): IRNode {
+  const frows = matrixToRationals(node);
+  const nrows = frows.length;
+  const ncols = frows[0]?.length ?? 0;
+
+  let pivotRow = 0;
+  for (let col = 0; col < ncols && pivotRow < nrows; col += 1) {
+    let pivotPos = -1;
+    for (let row = pivotRow; row < nrows; row += 1) {
+      if (!frows[row][col].isZero()) {
+        pivotPos = row;
+        break;
+      }
+    }
+    if (pivotPos === -1) continue;
+
+    if (pivotPos !== pivotRow) {
+      [frows[pivotRow], frows[pivotPos]] = [frows[pivotPos], frows[pivotRow]];
+    }
+
+    const pivot = frows[pivotRow][col];
+    frows[pivotRow] = frows[pivotRow].map((entry) => entry.div(pivot));
+
+    for (let row = 0; row < nrows; row += 1) {
+      if (row === pivotRow) continue;
+      const factor = frows[row][col];
+      if (factor.isZero()) continue;
+      frows[row] = frows[row].map((entry, entryCol) => entry.sub(factor.mul(frows[pivotRow][entryCol])));
+    }
+
+    pivotRow += 1;
+  }
+
+  return matrix(frows.map((row) => row.map(rationalToIr)));
+}
+
+export function rank(node: IRNode): IRInteger {
+  const frows = matrixToRationals(node);
+  const nrows = frows.length;
+  const ncols = frows[0]?.length ?? 0;
+
+  let pivotRow = 0;
+  for (let col = 0; col < ncols && pivotRow < nrows; col += 1) {
+    let pivotPos = -1;
+    for (let row = pivotRow; row < nrows; row += 1) {
+      if (!frows[row][col].isZero()) {
+        pivotPos = row;
+        break;
+      }
+    }
+    if (pivotPos === -1) continue;
+
+    [frows[pivotRow], frows[pivotPos]] = [frows[pivotPos], frows[pivotRow]];
+    const pivot = frows[pivotRow][col];
+    frows[pivotRow] = frows[pivotRow].map((entry) => entry.div(pivot));
+
+    for (let row = pivotRow + 1; row < nrows; row += 1) {
+      const factor = frows[row][col];
+      if (factor.isZero()) continue;
+      frows[row] = frows[row].map((entry, entryCol) => entry.sub(factor.mul(frows[pivotRow][entryCol])));
+    }
+
+    pivotRow += 1;
+  }
+
+  const nonZeroRows = frows.filter((row) => row.some((entry) => !entry.isZero())).length;
+  return int(nonZeroRows);
+}
+
 function rowArgs(row: IRNode): IRNode[] {
   if (row.kind === "apply" && headName(row.head) === LIST.name) {
     return [...row.args];
@@ -210,4 +281,68 @@ function minor(rows: MatrixRows, skipRow: number, skipCol: number): MatrixRows {
   return rows
     .filter((_, rowIndex) => rowIndex !== skipRow)
     .map((row) => row.filter((_, colIndex) => colIndex !== skipCol));
+}
+
+function matrixToRationals(node: IRNode): RationalValue[][] {
+  return rowsOf(node).map((row) => row.map(entryToRational));
+}
+
+function entryToRational(node: IRNode): RationalValue {
+  if (node.kind === "integer") return new RationalValue(node.value, 1n);
+  if (node.kind === "rational") return new RationalValue(node.numer, node.denom);
+  throw new MatrixError(`rowReduce/rank: symbolic entry not supported: ${node.kind}`);
+}
+
+function rationalToIr(value: RationalValue): IRNode {
+  return value.denom === 1n ? int(value.numer) : rational(value.numer, value.denom);
+}
+
+class RationalValue {
+  readonly numer: bigint;
+  readonly denom: bigint;
+
+  constructor(numer: bigint, denom: bigint) {
+    if (denom === 0n) throw new RangeError("Rational denominator cannot be zero");
+    let n = numer;
+    let d = denom;
+    if (d < 0n) {
+      n = -n;
+      d = -d;
+    }
+    const g = gcd(abs(n), d);
+    this.numer = n / g;
+    this.denom = d / g;
+  }
+
+  isZero(): boolean {
+    return this.numer === 0n;
+  }
+
+  sub(other: RationalValue): RationalValue {
+    return new RationalValue(this.numer * other.denom - other.numer * this.denom, this.denom * other.denom);
+  }
+
+  mul(other: RationalValue): RationalValue {
+    return new RationalValue(this.numer * other.numer, this.denom * other.denom);
+  }
+
+  div(other: RationalValue): RationalValue {
+    if (other.isZero()) throw new RangeError("Rational division by zero");
+    return new RationalValue(this.numer * other.denom, this.denom * other.numer);
+  }
+}
+
+function gcd(a: bigint, b: bigint): bigint {
+  let x = a;
+  let y = b;
+  while (y !== 0n) {
+    const t = y;
+    y = x % y;
+    x = t;
+  }
+  return x === 0n ? 1n : x;
+}
+
+function abs(value: bigint): bigint {
+  return value < 0n ? -value : value;
 }

--- a/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
+++ b/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
@@ -13,14 +13,16 @@ import {
   matrix,
   numCols,
   numRows,
+  rank,
   rowsOf,
+  rowReduce,
   scalarMultiply,
   subMatrices,
   trace,
   transpose,
   zeroMatrix,
 } from "../src/index";
-import { ADD, LIST, MUL, SUB, app, equals, int, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { ADD, LIST, MUL, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
 
 function irow(values: readonly number[]): IRNode[] {
   return values.map((value) => int(value));
@@ -150,5 +152,50 @@ describe("determinant and inverse", () => {
     expect(numRows(inv1)).toBe(1);
     expect(numCols(inv1)).toBe(1);
     expect(() => inverse(matrix([irow([1, 2, 3])]))).toThrow(MatrixError);
+  });
+});
+
+describe("rowReduce and rank", () => {
+  it("leaves identity matrices unchanged and reports full rank", () => {
+    const eye = identityMatrix(3);
+    expect(rowReduce(eye)).toEqual(eye);
+    expect(rank(eye)).toEqual(int(3));
+  });
+
+  it("keeps zero matrices at rank zero", () => {
+    const zero = zeroMatrix(2, 3);
+    expect(rowReduce(zero)).toEqual(zero);
+    expect(rank(zero)).toEqual(int(0));
+  });
+
+  it("reduces a full-rank 2x2 matrix to identity", () => {
+    const m = matrix([irow([2, 4]), irow([1, 3])]);
+    expect(rowReduce(m)).toEqual(identityMatrix(2));
+    expect(rank(m)).toEqual(int(2));
+  });
+
+  it("reduces a singular 3x3 matrix and reports rank two", () => {
+    const m = matrix([irow([1, 2, 3]), irow([4, 5, 6]), irow([7, 8, 9])]);
+    expect(rowReduce(m)).toEqual(matrix([irow([1, 0, -1]), irow([0, 1, 2]), irow([0, 0, 0])]));
+    expect(rank(m)).toEqual(int(2));
+  });
+
+  it("handles rational dependent rows exactly", () => {
+    const m = matrix([[rational(1, 2), int(1)], [int(1), int(2)]]);
+    expect(rowReduce(m)).toEqual(matrix([[int(1), int(2)], [int(0), int(0)]]));
+    expect(rank(m)).toEqual(int(1));
+  });
+
+  it("reports rank for wide and tall matrices", () => {
+    const wide = matrix([irow([1, 0, 2, 1]), irow([0, 1, 3, -1])]);
+    const tall = matrix([irow([1, 0]), irow([0, 1]), irow([1, 1]), irow([2, 3])]);
+    expect(rank(wide)).toEqual(int(2));
+    expect(rank(tall)).toEqual(int(2));
+  });
+
+  it("rejects symbolic entries for exact row reduction", () => {
+    const m = matrix([[sym("a"), int(1)], [int(0), int(1)]]);
+    expect(() => rowReduce(m)).toThrow(MatrixError);
+    expect(() => rank(m)).toThrow(MatrixError);
   });
 });


### PR DESCRIPTION
## Summary

- Adds exact rational Gauss-Jordan `rowReduce` for TypeScript `cas-matrix` integer/rational matrices.
- Adds exact rational `rank` using forward elimination.
- Rejects symbolic/non-rational entries with `MatrixError` and documents the new exports.

## Validation

- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage`

## Deferred parity gaps

- Symbolic row reduction remains unsupported for this slice, matching the Python numeric-only behavior.
- Existing symbolic determinant/inverse paths are unchanged and still rely on downstream simplification.
