### PR TITLE
Add Rust cas-matrix row reduction

### DIFF
--- a/code/packages/rust/cas-matrix/CHANGELOG.md
+++ b/code/packages/rust/cas-matrix/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — cas-matrix (Rust)
 
+## Unreleased
+
+### Added
+
+- `rowreduce` module with exact rational Gauss-Jordan `row_reduce(m)` and
+  forward-elimination `rank(m)` for integer/rational matrices.
+- Row-reduction tests covering identity, zero, full-rank, singular, rational
+  dependent rows, wide/tall rank, and symbolic-entry errors.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-matrix/README.md
+++ b/code/packages/rust/cas-matrix/README.md
@@ -24,6 +24,8 @@ All arithmetic produces unevaluated IR; pass through `cas_simplify::simplify` to
 | `dot(a, b)` | Matrix product |
 | `determinant(m)` | Cofactor expansion (O(n!)) |
 | `inverse(m)` | Adjugate/determinant (symbolic) |
+| `row_reduce(m)` | Exact rational Gauss-Jordan RREF for integer/rational entries |
+| `rank(m)` | Exact rational row rank for integer/rational entries |
 
 ## Usage
 
@@ -46,6 +48,9 @@ let d = determinant(&m).unwrap();
 ## Error handling
 
 All fallible operations return `MatrixResult<IRNode>` (= `Result<IRNode, MatrixError>`).
+
+`row_reduce` and `rank` are numeric-only: integer and rational entries are
+accepted, while symbolic entries return `MatrixError`.
 
 ## Stack position
 

--- a/code/packages/rust/cas-matrix/src/arithmetic.rs
+++ b/code/packages/rust/cas-matrix/src/arithmetic.rs
@@ -31,18 +31,12 @@ use crate::matrix::{matrix, rows_of, MatrixError, MatrixResult};
 /// ```
 pub fn identity_matrix(n: usize) -> MatrixResult<IRNode> {
     let rows: Vec<Vec<IRNode>> = (0..n)
-        .map(|i| {
-            (0..n)
-                .map(|j| int(if i == j { 1 } else { 0 }))
-                .collect()
-        })
+        .map(|i| (0..n).map(|j| int(if i == j { 1 } else { 0 })).collect())
         .collect();
     // edge case: 0×0 identity is a valid empty matrix — but our constructor
     // rejects empty vecs, so we special-case it.
     if n == 0 {
-        return Err(MatrixError(
-            "identity_matrix: n must be positive".into(),
-        ));
+        return Err(MatrixError("identity_matrix: n must be positive".into()));
     }
     matrix(rows)
 }
@@ -58,9 +52,7 @@ pub fn identity_matrix(n: usize) -> MatrixResult<IRNode> {
 /// ```
 pub fn zero_matrix(nrows: usize, ncols: usize) -> MatrixResult<IRNode> {
     if nrows == 0 || ncols == 0 {
-        return Err(MatrixError(
-            "zero_matrix: dims must be positive".into(),
-        ));
+        return Err(MatrixError("zero_matrix: dims must be positive".into()));
     }
     let rows: Vec<Vec<IRNode>> = (0..nrows)
         .map(|_| (0..ncols).map(|_| int(0)).collect())
@@ -226,12 +218,7 @@ pub fn dot(a: &IRNode, b: &IRNode) -> MatrixResult<IRNode> {
             (0..b_cols)
                 .map(|j| {
                     let terms: Vec<IRNode> = (0..a_cols)
-                        .map(|k| {
-                            apply(
-                                sym(MUL),
-                                vec![a_rows[i][k].clone(), b_rows[k][j].clone()],
-                            )
-                        })
+                        .map(|k| apply(sym(MUL), vec![a_rows[i][k].clone(), b_rows[k][j].clone()]))
                         .collect();
                     if terms.len() == 1 {
                         terms.into_iter().next().unwrap()
@@ -250,11 +237,7 @@ pub fn dot(a: &IRNode, b: &IRNode) -> MatrixResult<IRNode> {
 // ---------------------------------------------------------------------------
 
 /// Verify that two row-of-rows have the same shape.
-fn check_same_shape(
-    a: &[Vec<IRNode>],
-    b: &[Vec<IRNode>],
-    op: &str,
-) -> MatrixResult<()> {
+fn check_same_shape(a: &[Vec<IRNode>], b: &[Vec<IRNode>], op: &str) -> MatrixResult<()> {
     let (ar, ac) = (a.len(), a.first().map_or(0, |r| r.len()));
     let (br, bc) = (b.len(), b.first().map_or(0, |r| r.len()));
     if ar != br || ac != bc {
@@ -274,11 +257,6 @@ fn elementwise(
     a_rows
         .into_iter()
         .zip(b_rows)
-        .map(|(ra, rb)| {
-            ra.into_iter()
-                .zip(rb)
-                .map(|(x, y)| f(x, y))
-                .collect()
-        })
+        .map(|(ra, rb)| ra.into_iter().zip(rb).map(|(x, y)| f(x, y)).collect())
         .collect()
 }

--- a/code/packages/rust/cas-matrix/src/determinant.rs
+++ b/code/packages/rust/cas-matrix/src/determinant.rs
@@ -97,7 +97,7 @@ pub fn inverse(m: &IRNode) -> MatrixResult<IRNode> {
         )));
     }
     if n == 0 {
-        return matrix(vec![vec![]]);  // 0×0 case — return empty matrix
+        return matrix(vec![vec![]]); // 0×0 case — return empty matrix
     }
     let d = det(&rows);
 
@@ -155,10 +155,7 @@ pub(crate) fn det(rows: &[Vec<IRNode>]) -> IRNode {
             let (c, d) = (rows[1][0].clone(), rows[1][1].clone());
             apply(
                 sym(SUB),
-                vec![
-                    apply(sym(MUL), vec![a, d]),
-                    apply(sym(MUL), vec![b, c]),
-                ],
+                vec![apply(sym(MUL), vec![a, d]), apply(sym(MUL), vec![b, c])],
             )
         }
         _ => {

--- a/code/packages/rust/cas-matrix/src/lib.rs
+++ b/code/packages/rust/cas-matrix/src/lib.rs
@@ -47,6 +47,7 @@
 pub mod arithmetic;
 pub mod determinant;
 pub mod matrix;
+pub mod rowreduce;
 
 pub use arithmetic::{
     add_matrices, dot, identity_matrix, scalar_multiply, sub_matrices, trace, transpose,
@@ -57,3 +58,4 @@ pub use matrix::{
     dimensions, get_entry, is_matrix, matrix, num_cols, num_rows, rows_of, MatrixError,
     MatrixResult, MATRIX,
 };
+pub use rowreduce::{rank, row_reduce};

--- a/code/packages/rust/cas-matrix/src/matrix.rs
+++ b/code/packages/rust/cas-matrix/src/matrix.rs
@@ -85,10 +85,7 @@ pub fn matrix(rows: Vec<Vec<IRNode>>) -> MatrixResult<IRNode> {
             )));
         }
     }
-    let ir_rows: Vec<IRNode> = rows
-        .into_iter()
-        .map(|row| apply(sym(LIST), row))
-        .collect();
+    let ir_rows: Vec<IRNode> = rows.into_iter().map(|row| apply(sym(LIST), row)).collect();
     Ok(apply(sym(MATRIX), ir_rows))
 }
 

--- a/code/packages/rust/cas-matrix/src/rowreduce.rs
+++ b/code/packages/rust/cas-matrix/src/rowreduce.rs
@@ -1,0 +1,238 @@
+//! Exact rational row reduction and rank.
+//!
+//! `row_reduce` and `rank` intentionally accept only integer/rational matrix
+//! entries.  Symbolic entries return [`MatrixError`] so callers can simplify
+//! first or fall through to a symbolic backend later.
+
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+use symbolic_ir::{int, rat, IRNode};
+
+use crate::matrix::{matrix, rows_of, MatrixError, MatrixResult};
+
+/// Return the reduced row echelon form (RREF) of a numeric matrix.
+///
+/// The algorithm is Gauss-Jordan elimination over exact rational arithmetic.
+pub fn row_reduce(m: &IRNode) -> MatrixResult<IRNode> {
+    let mut rows = matrix_to_fracs(m)?;
+    let nr = rows.len();
+    let nc = rows.first().map_or(0, |row| row.len());
+
+    let mut pivot_row = 0;
+    for col in 0..nc {
+        let pivot_pos = (pivot_row..nr).find(|&row| !rows[row][col].is_zero());
+        let Some(pivot_pos) = pivot_pos else {
+            continue;
+        };
+
+        if pivot_pos != pivot_row {
+            rows.swap(pivot_row, pivot_pos);
+        }
+
+        let pivot = rows[pivot_row][col];
+        rows[pivot_row] = rows[pivot_row].iter().map(|entry| *entry / pivot).collect();
+
+        for row in 0..nr {
+            if row == pivot_row {
+                continue;
+            }
+            let factor = rows[row][col];
+            if factor.is_zero() {
+                continue;
+            }
+            rows[row] = (0..nc)
+                .map(|c| rows[row][c] - factor * rows[pivot_row][c])
+                .collect();
+        }
+
+        pivot_row += 1;
+    }
+
+    fracs_to_matrix(rows)
+}
+
+/// Return the rank of a numeric matrix as `IRNode::Integer`.
+///
+/// This uses forward elimination only; the rank is the number of pivot rows.
+pub fn rank(m: &IRNode) -> MatrixResult<IRNode> {
+    let mut rows = matrix_to_fracs(m)?;
+    let nr = rows.len();
+    let nc = rows.first().map_or(0, |row| row.len());
+
+    let mut pivot_row = 0;
+    for col in 0..nc {
+        let pivot_pos = (pivot_row..nr).find(|&row| !rows[row][col].is_zero());
+        let Some(pivot_pos) = pivot_pos else {
+            continue;
+        };
+
+        if pivot_pos != pivot_row {
+            rows.swap(pivot_row, pivot_pos);
+        }
+
+        let pivot = rows[pivot_row][col];
+        rows[pivot_row] = rows[pivot_row].iter().map(|entry| *entry / pivot).collect();
+
+        for row in (pivot_row + 1)..nr {
+            let factor = rows[row][col];
+            if factor.is_zero() {
+                continue;
+            }
+            rows[row] = (0..nc)
+                .map(|c| rows[row][c] - factor * rows[pivot_row][c])
+                .collect();
+        }
+
+        pivot_row += 1;
+    }
+
+    let rank = rows
+        .iter()
+        .filter(|row| row.iter().any(|entry| !entry.is_zero()))
+        .count();
+    Ok(int(rank as i64))
+}
+
+fn matrix_to_fracs(m: &IRNode) -> MatrixResult<Vec<Vec<Frac>>> {
+    rows_of(m)?
+        .into_iter()
+        .map(|row| row.into_iter().map(entry_to_frac).collect())
+        .collect()
+}
+
+fn entry_to_frac(entry: IRNode) -> MatrixResult<Frac> {
+    match entry {
+        IRNode::Integer(value) => Ok(Frac::from_i64(value)),
+        IRNode::Rational(numer, denom) => Ok(Frac::new(numer as i128, denom as i128)),
+        other => Err(MatrixError(format!(
+            "row_reduce/rank: symbolic entry not supported: {other:?}"
+        ))),
+    }
+}
+
+fn fracs_to_matrix(rows: Vec<Vec<Frac>>) -> MatrixResult<IRNode> {
+    rows.into_iter()
+        .map(|row| row.into_iter().map(Frac::to_irnode).collect())
+        .collect::<MatrixResult<Vec<Vec<IRNode>>>>()
+        .and_then(matrix)
+}
+
+/// Exact rational number in reduced form.
+///
+/// `denom > 0`; the sign is always carried by `numer`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Frac {
+    numer: i128,
+    denom: i128,
+}
+
+impl Frac {
+    fn zero() -> Self {
+        Self { numer: 0, denom: 1 }
+    }
+
+    fn new(numer: i128, denom: i128) -> Self {
+        assert!(denom != 0, "Frac denominator must not be zero");
+        if numer == 0 {
+            return Self::zero();
+        }
+        let (numer, denom) = if denom < 0 {
+            (-numer, -denom)
+        } else {
+            (numer, denom)
+        };
+        let divisor = gcd(numer.unsigned_abs(), denom.unsigned_abs()) as i128;
+        Self {
+            numer: numer / divisor,
+            denom: denom / divisor,
+        }
+    }
+
+    fn from_i64(value: i64) -> Self {
+        Self {
+            numer: value as i128,
+            denom: 1,
+        }
+    }
+
+    fn is_zero(self) -> bool {
+        self.numer == 0
+    }
+
+    fn to_irnode(self) -> MatrixResult<IRNode> {
+        let numer = i64::try_from(self.numer).map_err(|_| {
+            MatrixError(format!(
+                "row_reduce/rank: numerator overflow: {}",
+                self.numer
+            ))
+        })?;
+        let denom = i64::try_from(self.denom).map_err(|_| {
+            MatrixError(format!(
+                "row_reduce/rank: denominator overflow: {}",
+                self.denom
+            ))
+        })?;
+
+        if denom == 1 {
+            Ok(int(numer))
+        } else {
+            Ok(rat(numer, denom))
+        }
+    }
+}
+
+impl Add for Frac {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(
+            self.numer * rhs.denom + rhs.numer * self.denom,
+            self.denom * rhs.denom,
+        )
+    }
+}
+
+impl Sub for Frac {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self + (-rhs)
+    }
+}
+
+impl Mul for Frac {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self::new(self.numer * rhs.numer, self.denom * rhs.denom)
+    }
+}
+
+impl Div for Frac {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        assert!(!rhs.is_zero(), "Frac division by zero");
+        Self::new(self.numer * rhs.denom, self.denom * rhs.numer)
+    }
+}
+
+impl Neg for Frac {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self {
+            numer: -self.numer,
+            denom: self.denom,
+        }
+    }
+}
+
+fn gcd(mut a: u128, mut b: u128) -> u128 {
+    while b != 0 {
+        let r = a % b;
+        a = b;
+        b = r;
+    }
+    a
+}

--- a/code/packages/rust/cas-matrix/tests/tests.rs
+++ b/code/packages/rust/cas-matrix/tests/tests.rs
@@ -5,10 +5,10 @@
 
 use cas_matrix::{
     add_matrices, determinant, dimensions, dot, get_entry, identity_matrix, inverse, is_matrix,
-    matrix, num_cols, num_rows, scalar_multiply, sub_matrices, trace, transpose, zero_matrix,
-    MatrixError, MATRIX,
+    matrix, num_cols, num_rows, rank, row_reduce, scalar_multiply, sub_matrices, trace, transpose,
+    zero_matrix, MatrixError, MATRIX,
 };
-use symbolic_ir::{apply, int, sym, ADD, LIST, SUB};
+use symbolic_ir::{apply, int, rat, sym, ADD, LIST, SUB};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,6 +17,22 @@ use symbolic_ir::{apply, int, sym, ADD, LIST, SUB};
 /// Build a row of IRNode::Integer values.
 fn irow(vals: &[i64]) -> Vec<symbolic_ir::IRNode> {
     vals.iter().map(|&v| int(v)).collect()
+}
+
+fn matrix_entries(m: &symbolic_ir::IRNode) -> Vec<Vec<(i64, i64)>> {
+    cas_matrix::rows_of(m)
+        .unwrap()
+        .into_iter()
+        .map(|row| {
+            row.into_iter()
+                .map(|entry| match entry {
+                    symbolic_ir::IRNode::Integer(value) => (value, 1),
+                    symbolic_ir::IRNode::Rational(numer, denom) => (numer, denom),
+                    other => panic!("expected numeric entry, got {other:?}"),
+                })
+                .collect()
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -64,11 +80,7 @@ fn num_rows_cols_2x3() {
 
 #[test]
 fn get_entry_one_based() {
-    let m = matrix(vec![
-        vec![sym("a"), sym("b")],
-        vec![sym("c"), sym("d")],
-    ])
-    .unwrap();
+    let m = matrix(vec![vec![sym("a"), sym("b")], vec![sym("c"), sym("d")]]).unwrap();
     assert_eq!(get_entry(&m, 1, 1).unwrap(), sym("a"));
     assert_eq!(get_entry(&m, 2, 2).unwrap(), sym("d"));
     assert_eq!(get_entry(&m, 1, 2).unwrap(), sym("b"));
@@ -96,12 +108,7 @@ fn is_matrix_rejects_non_matrix() {
 #[test]
 fn identity_3x3() {
     let eye = identity_matrix(3).unwrap();
-    let expected = matrix(vec![
-        irow(&[1, 0, 0]),
-        irow(&[0, 1, 0]),
-        irow(&[0, 0, 1]),
-    ])
-    .unwrap();
+    let expected = matrix(vec![irow(&[1, 0, 0]), irow(&[0, 1, 0]), irow(&[0, 0, 1])]).unwrap();
     assert_eq!(eye, expected);
 }
 
@@ -148,11 +155,7 @@ fn transpose_rectangular() {
 
 #[test]
 fn transpose_double_is_identity() {
-    let m = matrix(vec![
-        vec![sym("a"), sym("b")],
-        vec![sym("c"), sym("d")],
-    ])
-    .unwrap();
+    let m = matrix(vec![vec![sym("a"), sym("b")], vec![sym("c"), sym("d")]]).unwrap();
     let tt = transpose(&transpose(&m).unwrap()).unwrap();
     assert_eq!(tt, m);
 }
@@ -278,11 +281,7 @@ fn det_1x1() {
 
 #[test]
 fn det_2x2_returns_sub_expr() {
-    let m = matrix(vec![
-        vec![sym("a"), sym("b")],
-        vec![sym("c"), sym("d")],
-    ])
-    .unwrap();
+    let m = matrix(vec![vec![sym("a"), sym("b")], vec![sym("c"), sym("d")]]).unwrap();
     let d = determinant(&m).unwrap();
     // Sub(Mul(a, d), Mul(b, c))
     if let symbolic_ir::IRNode::Apply(a) = &d {
@@ -316,11 +315,7 @@ fn det_non_square_raises() {
 
 #[test]
 fn inverse_2x2_shape() {
-    let m = matrix(vec![
-        vec![sym("a"), sym("b")],
-        vec![sym("c"), sym("d")],
-    ])
-    .unwrap();
+    let m = matrix(vec![vec![sym("a"), sym("b")], vec![sym("c"), sym("d")]]).unwrap();
     let inv = inverse(&m).unwrap();
     assert_eq!(num_rows(&inv).unwrap(), 2);
     assert_eq!(num_cols(&inv).unwrap(), 2);
@@ -338,4 +333,103 @@ fn inverse_1x1_shape() {
 fn inverse_non_square_raises() {
     let m = matrix(vec![irow(&[1, 2, 3])]).unwrap();
     assert!(inverse(&m).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Row reduction and rank
+// ---------------------------------------------------------------------------
+
+#[test]
+fn row_reduce_identity_2x2_unchanged() {
+    let eye = identity_matrix(2).unwrap();
+    let reduced = row_reduce(&eye).unwrap();
+    assert_eq!(
+        matrix_entries(&reduced),
+        vec![vec![(1, 1), (0, 1)], vec![(0, 1), (1, 1)]]
+    );
+}
+
+#[test]
+fn row_reduce_zero_matrix_3x3() {
+    let zero = zero_matrix(3, 3).unwrap();
+    let reduced = row_reduce(&zero).unwrap();
+    assert!(matrix_entries(&reduced)
+        .into_iter()
+        .flatten()
+        .all(|entry| entry == (0, 1)));
+}
+
+#[test]
+fn row_reduce_full_rank_2x2_to_identity() {
+    let m = matrix(vec![irow(&[2, 4]), irow(&[1, 3])]).unwrap();
+    let reduced = row_reduce(&m).unwrap();
+    assert_eq!(
+        matrix_entries(&reduced),
+        vec![vec![(1, 1), (0, 1)], vec![(0, 1), (1, 1)]]
+    );
+}
+
+#[test]
+fn row_reduce_singular_3x3() {
+    let m = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6]), irow(&[7, 8, 9])]).unwrap();
+    let reduced = row_reduce(&m).unwrap();
+    assert_eq!(
+        matrix_entries(&reduced),
+        vec![
+            vec![(1, 1), (0, 1), (-1, 1)],
+            vec![(0, 1), (1, 1), (2, 1)],
+            vec![(0, 1), (0, 1), (0, 1)]
+        ]
+    );
+}
+
+#[test]
+fn row_reduce_rational_dependent_rows() {
+    let m = matrix(vec![vec![rat(1, 2), int(1)], vec![int(1), int(2)]]).unwrap();
+    let reduced = row_reduce(&m).unwrap();
+    assert_eq!(
+        matrix_entries(&reduced),
+        vec![vec![(1, 1), (2, 1)], vec![(0, 1), (0, 1)]]
+    );
+}
+
+#[test]
+fn rank_identity_and_zero() {
+    assert_eq!(rank(&identity_matrix(3).unwrap()).unwrap(), int(3));
+    assert_eq!(rank(&zero_matrix(3, 3).unwrap()).unwrap(), int(0));
+}
+
+#[test]
+fn rank_full_and_singular_matrices() {
+    let full = matrix(vec![irow(&[1, 2]), irow(&[3, 4])]).unwrap();
+    let singular = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6]), irow(&[7, 8, 9])]).unwrap();
+    assert_eq!(rank(&full).unwrap(), int(2));
+    assert_eq!(rank(&singular).unwrap(), int(2));
+}
+
+#[test]
+fn rank_rational_dependent_rows() {
+    let m = matrix(vec![vec![int(1), rat(1, 2)], vec![int(2), int(1)]]).unwrap();
+    assert_eq!(rank(&m).unwrap(), int(1));
+}
+
+#[test]
+fn rank_wide_and_tall_matrices() {
+    let wide = matrix(vec![irow(&[1, 0, 2, 1]), irow(&[0, 1, 3, -1])]).unwrap();
+    let tall = matrix(vec![
+        irow(&[1, 0]),
+        irow(&[0, 1]),
+        irow(&[1, 1]),
+        irow(&[2, 3]),
+    ])
+    .unwrap();
+    assert_eq!(rank(&wide).unwrap(), int(2));
+    assert_eq!(rank(&tall).unwrap(), int(2));
+}
+
+#[test]
+fn row_reduce_and_rank_reject_symbolic_entries() {
+    let m = matrix(vec![vec![sym("a"), int(1)], vec![int(0), int(1)]]).unwrap();
+    assert!(row_reduce(&m).is_err());
+    assert!(rank(&m).is_err());
 }


### PR DESCRIPTION
## Summary
- add exact rational Gauss-Jordan row_reduce and forward-elimination rank to Rust cas-matrix
- reject symbolic row_reduce/rank entries with MatrixError
- export the new APIs and add package-local parity tests/docs

## Validation
- cargo fmt -p cas-matrix
- cargo test -p cas-matrix
- cargo check -p cas-matrix

## Deferred parity gaps
- symbolic row reduction is intentionally unsupported in this slice
- larger-than-i64 output rationals report overflow because symbolic-ir literals are currently i64-backed