### PR TITLE
Advance tests20 button-scope tree fixtures

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -2213,6 +2213,24 @@ impl HtmlParser {
             "p" if !self.has_open_element("body")
                 && !self.document_has_body_element()
                 && !self.body_has_non_whitespace_child() => {}
+            "p" if self.current_parent_has_element_ancestor("button")
+                && !self.current_parent_has_element_in_button_scope("p") =>
+            {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-p-end-tag",
+                    "end tag `</p>` created and closed an implied `p` element",
+                ));
+                self.append_node(Node::element("p".to_string(), Vec::new()));
+            }
+            "p" if self.current_parent_has_table_ancestor()
+                && !self.current_parent_has_element_in_table_scope("p") =>
+            {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-p-end-tag",
+                    "end tag `</p>` created and closed an implied `p` element",
+                ));
+                self.insert_node_before_open_table(Node::element("p".to_string(), Vec::new()));
+            }
             "p" if self.has_open_element("p")
                 && !self.has_open_element_before_namespace_boundary("p") =>
             {
@@ -2337,7 +2355,11 @@ impl HtmlParser {
             if is_formatting_element(name) && self.adopt_formatting_end_tag_across_div(index) {
                 return;
             }
-            if special_scope_blocks_end_tag(name) && self.has_special_element_above(index) {
+            if special_scope_blocks_end_tag(name)
+                && self.has_special_element_above(index)
+                && !(is_paragraph_boundary_element(name)
+                    && self.has_element_above(index, |candidate| candidate == "button"))
+            {
                 return;
             }
             let path = self.open_elements[index].clone();
@@ -2460,13 +2482,19 @@ impl HtmlParser {
 
     fn apply_simple_implied_end_tags(&mut self, incoming_name: &str) {
         if incoming_name == "p" {
-            self.close_open_element_if(|name| name == "p");
+            if !self.current_parent_has_element_ancestor("button") {
+                self.close_open_element_if(|name| name == "p");
+            }
         } else if incoming_name == "li" {
-            self.close_open_element_if(|name| name == "p");
-            self.close_open_list_item_if_in_scope();
+            if !self.current_parent_has_element_ancestor("button") {
+                self.close_open_element_if(|name| name == "p");
+                self.close_open_list_item_if_in_scope();
+            }
         } else if incoming_name == "dt" || incoming_name == "dd" {
-            self.close_open_element_if(|name| name == "p");
-            self.close_open_element_if(|name| name == "dt" || name == "dd");
+            if !self.current_parent_has_element_ancestor("button") {
+                self.close_open_element_if(|name| name == "p");
+                self.close_open_element_if(|name| name == "dt" || name == "dd");
+            }
         } else if incoming_name == "option" {
             self.close_open_element_if(|name| name == "option");
         } else if incoming_name == "optgroup" {
@@ -2482,10 +2510,15 @@ impl HtmlParser {
             self.close_open_ruby_element_if(|name| name == "rb" || name == "rt" || name == "rp");
             self.close_open_ruby_element_if(|name| name == "rtc");
         } else if is_heading_element(incoming_name) {
-            self.close_open_element_if(|name| name == "p");
+            if !self.current_parent_has_element_ancestor("button") {
+                self.close_open_element_if(|name| name == "p");
+            }
             self.close_open_heading_if_in_scope(None);
         } else if is_paragraph_boundary_element(incoming_name) {
             if incoming_name == "table" && self.quirks_mode {
+                return;
+            }
+            if self.current_parent_has_element_ancestor("button") {
                 return;
             }
             self.close_open_element_if(|name| name == "p");
@@ -3301,6 +3334,45 @@ impl HtmlParser {
         })
     }
 
+    fn current_parent_has_element_ancestor(&self, ancestor_name: &str) -> bool {
+        let current_parent_path = self.current_parent_path();
+        self.open_elements.iter().any(|path| {
+            current_parent_path.starts_with(path)
+                && element_at_path(&self.document, path).is_some_and(|name| name == ancestor_name)
+        })
+    }
+
+    fn current_parent_has_element_in_button_scope(&self, target_name: &str) -> bool {
+        let current_parent_path = self.current_parent_path();
+        let Some(button_index) = self.open_elements.iter().rposition(|path| {
+            current_parent_path.starts_with(path)
+                && element_at_path(&self.document, path).is_some_and(|name| name == "button")
+        }) else {
+            return false;
+        };
+        self.open_elements
+            .iter()
+            .skip(button_index + 1)
+            .any(|path| {
+                current_parent_path.starts_with(path)
+                    && element_at_path(&self.document, path).is_some_and(|name| name == target_name)
+            })
+    }
+
+    fn current_parent_has_element_in_table_scope(&self, target_name: &str) -> bool {
+        let current_parent_path = self.current_parent_path();
+        let Some(table_index) = self.open_elements.iter().rposition(|path| {
+            current_parent_path.starts_with(path)
+                && element_at_path(&self.document, path).is_some_and(is_table_context_element)
+        }) else {
+            return false;
+        };
+        self.open_elements.iter().skip(table_index + 1).any(|path| {
+            current_parent_path.starts_with(path)
+                && element_at_path(&self.document, path).is_some_and(|name| name == target_name)
+        })
+    }
+
     fn has_special_element_above(&self, element_index: usize) -> bool {
         self.open_elements
             .iter()
@@ -3308,6 +3380,13 @@ impl HtmlParser {
             .any(|path| {
                 element_at_path(&self.document, path).is_some_and(is_special_scope_boundary_element)
             })
+    }
+
+    fn has_element_above(&self, element_index: usize, predicate: impl Fn(&str) -> bool) -> bool {
+        self.open_elements
+            .iter()
+            .skip(element_index + 1)
+            .any(|path| element_at_path(&self.document, path).is_some_and(&predicate))
     }
 
     fn pop_current_if(&mut self, predicate: impl FnOnce(&str) -> bool) {
@@ -4704,7 +4783,6 @@ fn is_paragraph_boundary_element(name: &str) -> bool {
         "article",
         "aside",
         "blockquote",
-        "button",
         "center",
         "details",
         "dialog",
@@ -5224,64 +5302,65 @@ mod tests {
     }
 
     #[test]
-    fn closes_paragraph_before_button_and_legacy_block_boundaries() {
+    fn keeps_buttons_inside_paragraph_and_closes_legacy_block_boundaries() {
         let document = parse_html(
             "<p>Button<button>Click<button>Again</button><p>Centered<center>Block</center><p>Search<search>Find</search><p>Heading<hgroup>Title</hgroup><p>Listing<listing>Block</listing><p>Directory<dir><li>Item",
         )
         .unwrap();
 
         let body = body(&document);
-        assert_eq!(body.children.len(), 13);
+        assert_eq!(body.children.len(), 11);
 
         let button_intro = element(&body.children[0]);
         assert_eq!(button_intro.name, "p");
-        assert_eq!(button_intro.children, vec![Node::text("Button")]);
+        assert_eq!(button_intro.children.len(), 3);
+        assert_eq!(button_intro.children[0], Node::text("Button"));
 
-        let first_button = element(&body.children[1]);
+        let first_button = element(&button_intro.children[1]);
         assert_eq!(first_button.name, "button");
         assert_eq!(first_button.children, vec![Node::text("Click")]);
 
-        let second_button = element(&body.children[2]);
+        let second_button = element(&button_intro.children[2]);
         assert_eq!(second_button.name, "button");
         assert_eq!(second_button.children, vec![Node::text("Again")]);
 
-        let centered_intro = element(&body.children[3]);
+        let centered_intro = element(&body.children[1]);
         assert_eq!(centered_intro.name, "p");
         assert_eq!(centered_intro.children, vec![Node::text("Centered")]);
 
-        let center = element(&body.children[4]);
+        let center = element(&body.children[2]);
         assert_eq!(center.name, "center");
         assert_eq!(center.children, vec![Node::text("Block")]);
 
-        let search_intro = element(&body.children[5]);
+        let search_intro = element(&body.children[3]);
         assert_eq!(search_intro.name, "p");
         assert_eq!(search_intro.children, vec![Node::text("Search")]);
 
-        let search = element(&body.children[6]);
+        let search = element(&body.children[4]);
         assert_eq!(search.name, "search");
         assert_eq!(search.children, vec![Node::text("Find")]);
 
-        let heading_intro = element(&body.children[7]);
+        let heading_intro = element(&body.children[5]);
         assert_eq!(heading_intro.name, "p");
         assert_eq!(heading_intro.children, vec![Node::text("Heading")]);
 
-        let hgroup = element(&body.children[8]);
+        let hgroup = element(&body.children[6]);
         assert_eq!(hgroup.name, "hgroup");
         assert_eq!(hgroup.children, vec![Node::text("Title")]);
 
-        let listing_intro = element(&body.children[9]);
+        let listing_intro = element(&body.children[7]);
         assert_eq!(listing_intro.name, "p");
         assert_eq!(listing_intro.children, vec![Node::text("Listing")]);
 
-        let listing = element(&body.children[10]);
+        let listing = element(&body.children[8]);
         assert_eq!(listing.name, "listing");
         assert_eq!(listing.children, vec![Node::text("Block")]);
 
-        let directory_intro = element(&body.children[11]);
+        let directory_intro = element(&body.children[9]);
         assert_eq!(directory_intro.name, "p");
         assert_eq!(directory_intro.children, vec![Node::text("Directory")]);
 
-        let directory = element(&body.children[12]);
+        let directory = element(&body.children[10]);
         assert_eq!(directory.name, "dir");
         assert_eq!(directory.children.len(), 1);
         let item = element(&directory.children[0]);

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -18593,3 +18593,678 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <p>
 |         "c"
 |       "d"
+
+
+#source tests20.dat:1117
+#data
+<!doctype html><p><button><button>
+#errors
+(1,34): unexpected-start-tag-implies-end-tag
+(1,34): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|       <button>
+
+
+#source tests20.dat:1118
+#data
+<!doctype html><p><button><address>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <address>
+
+
+#source tests20.dat:1119
+#data
+<!doctype html><p><button><article>
+#errors
+(1,36): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <article>
+
+
+#source tests20.dat:1120
+#data
+<!doctype html><p><button><aside>
+#errors
+(1,34): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <aside>
+
+
+#source tests20.dat:1121
+#data
+<!doctype html><p><button><blockquote>
+#errors
+(1,38): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <blockquote>
+
+
+#source tests20.dat:1122
+#data
+<!doctype html><p><button><center>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <center>
+
+
+#source tests20.dat:1123
+#data
+<!doctype html><p><button><details>
+#errors
+(1,36): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <details>
+
+
+#source tests20.dat:1124
+#data
+<!doctype html><p><button><dialog>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <dialog>
+
+
+#source tests20.dat:1125
+#data
+<!doctype html><p><button><dir>
+#errors
+(1,32): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <dir>
+
+
+#source tests20.dat:1126
+#data
+<!doctype html><p><button><div>
+#errors
+(1,32): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <div>
+
+
+#source tests20.dat:1127
+#data
+<!doctype html><p><button><dl>
+#errors
+(1,31): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <dl>
+
+
+#source tests20.dat:1128
+#data
+<!doctype html><p><button><fieldset>
+#errors
+(1,37): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <fieldset>
+
+
+#source tests20.dat:1129
+#data
+<!doctype html><p><button><figcaption>
+#errors
+(1,39): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <figcaption>
+
+
+#source tests20.dat:1130
+#data
+<!doctype html><p><button><figure>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <figure>
+
+
+#source tests20.dat:1131
+#data
+<!doctype html><p><button><footer>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <footer>
+
+
+#source tests20.dat:1132
+#data
+<!doctype html><p><button><header>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <header>
+
+
+#source tests20.dat:1133
+#data
+<!doctype html><p><button><hgroup>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <hgroup>
+
+
+#source tests20.dat:1134
+#data
+<!doctype html><p><button><main>
+#errors
+(1,33): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <main>
+
+
+#source tests20.dat:1135
+#data
+<!doctype html><p><button><menu>
+#errors
+(1,32): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <menu>
+
+
+#source tests20.dat:1136
+#data
+<!doctype html><p><button><nav>
+#errors
+(1,32): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <nav>
+
+
+#source tests20.dat:1137
+#data
+<!doctype html><p><button><ol>
+#errors
+(1,31): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <ol>
+
+
+#source tests20.dat:1138
+#data
+<!doctype html><p><button><p>
+#errors
+(1,29): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <p>
+
+
+#source tests20.dat:1139
+#data
+<!doctype html><p><button><search>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <search>
+
+
+#source tests20.dat:1140
+#data
+<!doctype html><p><button><section>
+#errors
+(1,36): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <section>
+
+
+#source tests20.dat:1141
+#data
+<!doctype html><p><button><summary>
+#errors
+(1,36): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <summary>
+
+
+#source tests20.dat:1142
+#data
+<!doctype html><p><button><ul>
+#errors
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <ul>
+
+
+#source tests20.dat:1143
+#data
+<!doctype html><p><button><h1>
+#errors
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <h1>
+
+
+#source tests20.dat:1144
+#data
+<!doctype html><p><button><h6>
+#errors
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <h6>
+
+
+#source tests20.dat:1145
+#data
+<!doctype html><p><button><listing>
+#errors
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <listing>
+
+
+#source tests20.dat:1146
+#data
+<!doctype html><p><button><pre>
+#errors
+(1,31): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <pre>
+
+
+#source tests20.dat:1147
+#data
+<!doctype html><p><button><form>
+#errors
+(1,32): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <form>
+
+
+#source tests20.dat:1148
+#data
+<!doctype html><p><button><li>
+#errors
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <li>
+
+
+#source tests20.dat:1149
+#data
+<!doctype html><p><button><dd>
+#errors
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <dd>
+
+
+#source tests20.dat:1150
+#data
+<!doctype html><p><button><dt>
+#errors
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <dt>
+
+
+#source tests20.dat:1151
+#data
+<!doctype html><p><button><plaintext>
+#errors
+(1,37): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <plaintext>
+
+
+#source tests20.dat:1152
+#data
+<!doctype html><p><button><table>
+#errors
+(1,33): eof-in-table
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <table>
+
+
+#source tests20.dat:1153
+#data
+<!doctype html><p><button><hr>
+#errors
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <hr>
+
+
+#source tests20.dat:1154
+#data
+<!doctype html><p><button><xmp>
+#errors
+(1,31): expected-named-closing-tag-but-got-eof
+(1,31): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <xmp>
+
+
+#source tests20.dat:1155
+#data
+<!doctype html><p><button></p>
+#errors
+(1,30): unexpected-end-tag
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <button>
+|         <p>
+
+
+#source tests20.dat:1156
+#data
+<!doctype html><button><p></button>x
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <button>
+|       <p>
+|     "x"
+
+
+#source tests20.dat:1157
+#data
+<!doctype html><address><button></address>a
+#errors
+(1,42): end-tag-too-early
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <address>
+|       <button>
+|     "a"
+
+
+#source tests20.dat:1158
+#data
+<p><table></p>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,14): unexpected-end-tag-implies-table-voodoo
+(1,14): unexpected-end-tag
+(1,14): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <p>
+|       <table>
+
+
+#source tests20.dat:1159
+#data
+<!doctype html><svg>
+#errors
+(1,20): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <svg svg>
+
+
+#source tests20.dat:1160
+#data
+<!doctype html><p><figcaption>
+#errors
+(1,30): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <figcaption>
+
+
+#source tests20.dat:1161
+#data
+<!doctype html><p><summary>
+#errors
+(1,27): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <summary>


### PR DESCRIPTION
## Summary
- add the first 45 tests20.dat full-document html5lib tree-construction smoke cases, bringing coverage through case 1,161
- align button handling with button scope so paragraph/block starts inside `<button>` stay nested instead of closing the outer paragraph
- recover implied `p` end tags across button/table scope for the new fixtures

## Tests
- cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump -- --exact
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer

## Next blocker
- tests20.dat:1162, input `<!doctype html><form><table><form>`, needs nested form handling in table context without regressing prior tests16 form/table recovery.