### PR TITLE
Port Rust macsyma-runtime history references

### DIFF
--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -5,5 +5,10 @@ and `symbolic-vm`.
 
 This first slice is intentionally small: it compiles MACSYMA source, evaluates
 statements through the Rust symbolic VM, preserves `;` versus `$` display
-metadata, and records in-memory `%i`/`%o`-style history for a future REPL/WASM
-facade.
+metadata, and records in-memory `%i`/`%o`-style history for a REPL/WASM facade.
+
+History lookup is implemented in this runtime layer with a structural pre-eval
+replacement pass. `%` resolves to the previous output, `%iN` resolves to the
+N-th recorded input expression, and `%oN` resolves to the N-th recorded output.
+The symbolic VM backend remains unchanged, so direct backend lookup of history
+names is intentionally out of scope for this Rust parity slice.

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -7,7 +7,7 @@
 use coding_adventures_macsyma_compiler::{
     compile_macsyma_with_options, CompileError, CompileOptions, DISPLAY, SUPPRESS,
 };
-use symbolic_ir::{sym, IRNode};
+use symbolic_ir::{sym, IRApply, IRNode};
 use symbolic_vm::{SymbolicBackend, VM};
 
 /// One evaluated MACSYMA statement.
@@ -56,6 +56,22 @@ impl History {
         self.outputs.last()
     }
 
+    pub fn resolve_history_symbol(&self, name: &str) -> Option<&IRNode> {
+        if name == "%" {
+            return self.last_output();
+        }
+
+        if let Some(digits) = name.strip_prefix("%i") {
+            let index = parse_history_index(digits)?;
+            return self.get_input(index);
+        }
+        if let Some(digits) = name.strip_prefix("%o") {
+            let index = parse_history_index(digits)?;
+            return self.get_output(index);
+        }
+        None
+    }
+
     pub fn next_input_index(&self) -> usize {
         self.inputs.len() + 1
     }
@@ -72,6 +88,13 @@ impl History {
         self.inputs.clear();
         self.outputs.clear();
     }
+}
+
+fn parse_history_index(digits: &str) -> Option<usize> {
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse::<usize>().ok()
 }
 
 /// Stateful MACSYMA evaluator over the Rust symbolic VM.
@@ -123,7 +146,8 @@ impl MacsymaSession {
     fn eval_statement(&mut self, statement: IRNode) -> EvalResult {
         let (input, display) = unwrap_display(statement);
         let input_index = self.history.record_input(input.clone());
-        let output = self.vm.eval(input.clone());
+        let resolved_input = resolve_history_references(&self.history, input.clone());
+        let output = self.vm.eval(resolved_input);
         let output_index = self.history.record_output(output.clone());
         EvalResult {
             input_index,
@@ -138,6 +162,26 @@ impl MacsymaSession {
 impl Default for MacsymaSession {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn resolve_history_references(history: &History, node: IRNode) -> IRNode {
+    match node {
+        IRNode::Symbol(name) => history
+            .resolve_history_symbol(&name)
+            .cloned()
+            .unwrap_or(IRNode::Symbol(name)),
+        IRNode::Apply(apply) => {
+            let IRApply { head, args } = *apply;
+            IRNode::Apply(Box::new(IRApply {
+                head: resolve_history_references(history, head),
+                args: args
+                    .into_iter()
+                    .map(|arg| resolve_history_references(history, arg))
+                    .collect(),
+            }))
+        }
+        other => other,
     }
 }
 

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -1,5 +1,5 @@
 use coding_adventures_macsyma_runtime::MacsymaSession;
-use symbolic_ir::{apply, int, sym, MUL, POW};
+use symbolic_ir::{apply, int, sym, ADD, MUL, POW};
 
 #[test]
 fn evaluates_arithmetic_program() {
@@ -28,6 +28,50 @@ fn records_input_and_output_history() {
     assert_eq!(results[1].input_index, 2);
     assert_eq!(session.history().get_output(1), Some(&int(5)));
     assert_eq!(session.history().last_output(), Some(&int(7)));
+}
+
+#[test]
+fn resolves_history_symbols_from_history_table() {
+    let mut session = MacsymaSession::new();
+    session.eval_source("x; 7;").unwrap();
+
+    assert_eq!(session.history().resolve_history_symbol("%"), Some(&int(7)));
+    assert_eq!(
+        session.history().resolve_history_symbol("%i1"),
+        Some(&sym("x"))
+    );
+    assert_eq!(
+        session.history().resolve_history_symbol("%o2"),
+        Some(&int(7))
+    );
+    assert_eq!(session.history().resolve_history_symbol("%foo"), None);
+    assert_eq!(session.history().resolve_history_symbol("%i999"), None);
+}
+
+#[test]
+fn evaluates_percent_as_previous_output() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("2 + 3; % * 2;").unwrap();
+
+    assert_eq!(results[0].output, int(5));
+    assert_eq!(results[1].input, apply(sym(MUL), vec![sym("%"), int(2)]));
+    assert_eq!(results[1].output, int(10));
+}
+
+#[test]
+fn evaluates_numbered_input_and_output_history_references() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("2 + 3; % * 2; %i1; %o2;").unwrap();
+
+    let original_input = apply(sym(ADD), vec![int(2), int(3)]);
+    assert_eq!(results[0].output, int(5));
+    assert_eq!(results[1].output, int(10));
+    assert_eq!(results[2].input, sym("%i1"));
+    assert_eq!(results[2].output, int(5));
+    assert_eq!(results[3].input, sym("%o2"));
+    assert_eq!(results[3].output, int(10));
+    assert_eq!(session.history().get_input(1), Some(&original_input));
+    assert_eq!(session.history().get_input(3), Some(&sym("%i1")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add History::resolve_history_symbol for %, %iN, and %oN lookups
- Resolve history references structurally in macsyma-runtime before VM evaluation while preserving original compiled input history
- Add package-local parity tests and document runtime-layer scope

## Validation
- cargo fmt -p coding-adventures-macsyma-runtime
- cargo test -p coding-adventures-macsyma-runtime
- cargo check -p coding-adventures-macsyma-runtime

## Deferred parity gaps
- Direct symbolic-vm backend history fallback remains out of scope for this Rust slice; runtime pre-eval replacement covers eval_source/eval_statements without touching symbolic-vm.