### PR TITLE
Tighten TS macsyma runtime history parity

### DIFF
--- a/code/packages/typescript/macsyma-runtime/package-lock.json
+++ b/code/packages/typescript/macsyma-runtime/package-lock.json
@@ -13,6 +13,8 @@
         "@coding-adventures/grammar-tools": "file:../grammar-tools",
         "@coding-adventures/lexer": "file:../lexer",
         "@coding-adventures/macsyma-compiler": "file:../macsyma-compiler",
+        "@coding-adventures/macsyma-lexer": "file:../macsyma-lexer",
+        "@coding-adventures/macsyma-parser": "file:../macsyma-parser",
         "@coding-adventures/parser": "file:../parser",
         "@coding-adventures/state-machine": "file:../state-machine",
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
@@ -79,6 +81,41 @@
         "@coding-adventures/parser": "file:../parser",
         "@coding-adventures/state-machine": "file:../state-machine",
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../macsyma-lexer": {
+      "name": "@coding-adventures/macsyma-lexer",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/directed-graph": "file:../directed-graph",
+        "@coding-adventures/grammar-tools": "file:../grammar-tools",
+        "@coding-adventures/lexer": "file:../lexer",
+        "@coding-adventures/state-machine": "file:../state-machine"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../macsyma-parser": {
+      "name": "@coding-adventures/macsyma-parser",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/directed-graph": "file:../directed-graph",
+        "@coding-adventures/grammar-tools": "file:../grammar-tools",
+        "@coding-adventures/lexer": "file:../lexer",
+        "@coding-adventures/macsyma-lexer": "file:../macsyma-lexer",
+        "@coding-adventures/parser": "file:../parser",
+        "@coding-adventures/state-machine": "file:../state-machine"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -227,6 +264,14 @@
     },
     "node_modules/@coding-adventures/macsyma-compiler": {
       "resolved": "../macsyma-compiler",
+      "link": true
+    },
+    "node_modules/@coding-adventures/macsyma-lexer": {
+      "resolved": "../macsyma-lexer",
+      "link": true
+    },
+    "node_modules/@coding-adventures/macsyma-parser": {
+      "resolved": "../macsyma-parser",
       "link": true
     },
     "node_modules/@coding-adventures/parser": {

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -17,6 +17,8 @@
     "@coding-adventures/grammar-tools": "file:../grammar-tools",
     "@coding-adventures/lexer": "file:../lexer",
     "@coding-adventures/macsyma-compiler": "file:../macsyma-compiler",
+    "@coding-adventures/macsyma-lexer": "file:../macsyma-lexer",
+    "@coding-adventures/macsyma-parser": "file:../macsyma-parser",
     "@coding-adventures/parser": "file:../parser",
     "@coding-adventures/state-machine": "file:../state-machine",
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir",

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -59,6 +59,17 @@ export class History {
     this.inputNodes.length = 0;
     this.outputNodes.length = 0;
   }
+
+  resolveHistorySymbol(name: string): IRNode | undefined {
+    if (name === "%") return this.lastOutput();
+    if (name.startsWith("%i") && /^\d+$/.test(name.slice(2))) {
+      return this.getInput(Number(name.slice(2)));
+    }
+    if (name.startsWith("%o") && /^\d+$/.test(name.slice(2))) {
+      return this.getOutput(Number(name.slice(2)));
+    }
+    return undefined;
+  }
 }
 
 export class MacsymaBackend extends SymbolicBackend {
@@ -70,12 +81,9 @@ export class MacsymaBackend extends SymbolicBackend {
   }
 
   override lookup(name: string): IRNode | undefined {
-    if (name === "%") return this.history.lastOutput();
-    const inputMatch = /^%i([1-9]\d*)$/.exec(name);
-    if (inputMatch !== null) return this.history.getInput(Number(inputMatch[1]));
-    const outputMatch = /^%o([1-9]\d*)$/.exec(name);
-    if (outputMatch !== null) return this.history.getOutput(Number(outputMatch[1]));
-    return super.lookup(name);
+    const envValue = super.lookup(name);
+    if (envValue !== undefined) return envValue;
+    return this.history.resolveHistorySymbol(name);
   }
 }
 

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -7,7 +7,7 @@ import {
   int,
   sym,
 } from "@coding-adventures/symbolic-ir";
-import { MacsymaSession, evalSourceJson } from "../src/index.js";
+import { History, MacsymaBackend, MacsymaSession, evalSourceJson } from "../src/index.js";
 
 describe("macsyma-runtime", () => {
   it("evaluates arithmetic programs", () => {
@@ -38,6 +38,62 @@ describe("macsyma-runtime", () => {
     expect(session.history().getInput(1)).toEqual(app(ADD, [int(2), int(3)]));
     expect(session.history().getOutput(1)).toEqual(int(5));
     expect(session.history().nextInputIndex()).toBe(5);
+  });
+
+  it("exposes Python-parity history symbol resolution", () => {
+    const history = new History();
+    const input = app(ADD, [int(2), int(3)]);
+    history.recordInput(input);
+    history.recordOutput(int(5));
+    history.recordOutput(int(10));
+
+    expect(history.resolveHistorySymbol("%")).toEqual(int(10));
+    expect(history.resolveHistorySymbol("%i1")).toEqual(input);
+    expect(history.resolveHistorySymbol("%o1")).toEqual(int(5));
+    expect(history.resolveHistorySymbol("%o2")).toEqual(int(10));
+  });
+
+  it("returns undefined for unknown or out-of-range history symbols", () => {
+    const history = new History();
+    history.recordInput(sym("x"));
+    history.recordOutput(int(1));
+
+    expect(history.resolveHistorySymbol("xyz")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%foo")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%i999")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%o999")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%i0")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%o0")).toBeUndefined();
+  });
+
+  it("returns undefined for history symbols before any history is recorded", () => {
+    const history = new History();
+    expect(history.resolveHistorySymbol("%")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%i1")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%o1")).toBeUndefined();
+  });
+
+  it("clears resolvable history symbols on reset", () => {
+    const history = new History();
+    history.recordInput(int(1));
+    history.recordOutput(int(2));
+    history.reset();
+
+    expect(history.nextInputIndex()).toBe(1);
+    expect(history.resolveHistorySymbol("%")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%i1")).toBeUndefined();
+    expect(history.resolveHistorySymbol("%o1")).toBeUndefined();
+  });
+
+  it("keeps env bindings ahead of history fallback in backend lookup", () => {
+    const history = new History();
+    history.recordOutput(int(42));
+    const backend = new MacsymaBackend(history);
+    backend.bind("%o1", int(99));
+
+    expect(backend.lookup("%o1")).toEqual(int(99));
+    expect(backend.lookup("%")).toEqual(int(42));
+    expect(backend.lookup("not_history")).toBeUndefined();
   });
 
   it("evaluates function definitions across statements", () => {


### PR DESCRIPTION
## Summary
- add History.resolveHistorySymbol for %, %iN, and %oN parity with Python
- refactor MacsymaBackend.lookup to preserve env binding precedence before history fallback
- add package-local tests for %, %iN, %oN, unknown names, no-history, reset, and env precedence
- add direct local macsyma parser/lexer dependencies so package-local install/build resolves compiler imports

## Validation
- npm install
- npm run build
- npm test
- npm run test:coverage

## Deferred parity gaps
- no broader symbolic-vm, cas-matrix, grammar-tool, or parser changes in this PR
- remaining MACSYMA runtime parity outside history lookup is left for future package-specific work