### PR TITLE
[codex] Add MACSYMA pretty-printer parity sugar

### DIFF
--- a/code/packages/typescript/cas-pretty-printer/src/index.ts
+++ b/code/packages/typescript/cas-pretty-printer/src/index.ts
@@ -52,12 +52,20 @@ export const MacsymaDialect: Dialect = {
     TrigReduce: "trigreduce",
     Select: "sublist",
     MakeList: "makelist",
+    Inverse: "invert",
     Re: "realpart",
     Im: "imagpart",
     Arg: "carg",
+    RectForm: "rectform",
+    PolarForm: "polarform",
     IsPrime: "primep",
+    NextPrime: "next_prime",
+    PrevPrime: "prev_prime",
     FactorInteger: "ifactor",
+    Divisors: "divisors",
+    Totient: "totient",
     MoebiusMu: "moebius",
+    JacobiSymbol: "jacobi",
     ChineseRemainder: "chinese",
     IntegerLength: "numdigits",
   },
@@ -180,11 +188,22 @@ function sugarApply(node: Extract<IRNode, { kind: "apply" }>): IRNode {
   const name = headName(node.head);
   if (name === ADD.name && node.args.length === 2) {
     const [a, b] = node.args;
-    if (b.kind === "apply" && headName(b.head) === NEG.name && b.args.length === 1) {
-      return { kind: "apply", head: SUB, args: Object.freeze([a, b.args[0]]) };
+    const sugaredB = b.kind === "apply" ? sugarApply(b) : b;
+    if (sugaredB.kind === "apply" && headName(sugaredB.head) === NEG.name && sugaredB.args.length === 1) {
+      return { kind: "apply", head: SUB, args: Object.freeze([a, sugaredB.args[0]]) };
     }
     if (a.kind === "integer" && a.value < 0n) {
       return { kind: "apply", head: SUB, args: Object.freeze([b, { kind: "integer", value: -a.value }]) };
+    }
+  }
+  if (name === MUL.name && node.args.length >= 2) {
+    const [a, b] = node.args;
+    if (a.kind === "integer" && a.value === -1n) {
+      const rest = node.args.slice(1);
+      const inner = rest.length === 1
+        ? rest[0]
+        : { kind: "apply" as const, head: MUL, args: Object.freeze(rest) };
+      return { kind: "apply", head: NEG, args: Object.freeze([inner]) };
     }
   }
   if (name === MUL.name && node.args.length === 2) {
@@ -192,8 +211,12 @@ function sugarApply(node: Extract<IRNode, { kind: "apply" }>): IRNode {
     if (b.kind === "apply" && headName(b.head) === INV.name && b.args.length === 1) {
       return { kind: "apply", head: DIV, args: Object.freeze([a, b.args[0]]) };
     }
-    if (a.kind === "integer" && a.value === -1n) {
-      return { kind: "apply", head: NEG, args: Object.freeze([b]) };
+    if (b.kind === "apply" && headName(b.head) === NEG.name && b.args.length === 1) {
+      return {
+        kind: "apply",
+        head: NEG,
+        args: Object.freeze([{ kind: "apply", head: MUL, args: Object.freeze([a, b.args[0]]) }]),
+      };
     }
   }
   return node;

--- a/code/packages/typescript/cas-pretty-printer/tests/pretty-printer.test.ts
+++ b/code/packages/typescript/cas-pretty-printer/tests/pretty-printer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ADD, LIST, MUL, NEG, POW, app, int, sym } from "@coding-adventures/symbolic-ir";
+import { ADD, INV, LIST, MUL, NEG, POW, app, int, sym } from "@coding-adventures/symbolic-ir";
 import { MacsymaDialect, MathematicaDialect, formatLisp, pretty } from "../src/index";
 
 describe("cas-pretty-printer", () => {
@@ -16,6 +16,50 @@ describe("cas-pretty-printer", () => {
   it("formats common MACSYMA sugar", () => {
     expect(pretty(app(ADD, [sym("x"), app(NEG, [sym("y")])]))).toBe("x - y");
     expect(pretty(app(MUL, [int(-1), sym("x")]))).toBe("-x");
+  });
+
+  it("formats MACSYMA subtraction sugar for negative literals and products", () => {
+    expect(pretty(app(ADD, [int(-5), sym("y")]))).toBe("y - 5");
+    expect(pretty(app(ADD, [sym("a"), app(MUL, [sym("b"), app(NEG, [sym("c")])])]))).toBe("a - b * c");
+  });
+
+  it("formats MACSYMA multiplication sugar for inverse and negative factors", () => {
+    expect(pretty(app(MUL, [sym("a"), app(INV, [sym("b")])]))).toBe("a / b");
+    expect(pretty(app(MUL, [sym("a"), app(NEG, [sym("b")])]))).toBe("-(a * b)");
+    expect(pretty(app(MUL, [int(-1), sym("x"), sym("y")]))).toBe("-(x * y)");
+  });
+
+  it("formats MACSYMA function aliases", () => {
+    const aliases: ReadonlyArray<readonly [string, string]> = [
+      ["Select", "sublist"],
+      ["MakeList", "makelist"],
+      ["Inverse", "invert"],
+      ["RatSimplify", "ratsimp"],
+      ["Apart", "partfrac"],
+      ["TrigSimplify", "trigsimp"],
+      ["TrigExpand", "trigexpand"],
+      ["TrigReduce", "trigreduce"],
+      ["Re", "realpart"],
+      ["Im", "imagpart"],
+      ["Arg", "carg"],
+      ["RectForm", "rectform"],
+      ["PolarForm", "polarform"],
+      ["IsPrime", "primep"],
+      ["NextPrime", "next_prime"],
+      ["PrevPrime", "prev_prime"],
+      ["FactorInteger", "ifactor"],
+      ["Divisors", "divisors"],
+      ["Totient", "totient"],
+      ["MoebiusMu", "moebius"],
+      ["JacobiSymbol", "jacobi"],
+      ["ChineseRemainder", "chinese"],
+      ["IntegerLength", "numdigits"],
+    ];
+
+    for (const [head, alias] of aliases) {
+      expect(pretty(app(sym(head), [sym("x")]), MacsymaDialect)).toBe(`${alias}(x)`);
+    }
+    expect(pretty(sym("ImaginaryUnit"), MacsymaDialect)).toBe("%i");
   });
 
   it("formats dialect-specific calls and lists", () => {


### PR DESCRIPTION
## Summary
- add missing MACSYMA function-name aliases to the TypeScript CAS pretty-printer
- mirror Python reference sugar for negative literals, inverse factors, negative factors, and one-level subtraction from negative products
- add focused Vitest coverage for aliases and sugar while preserving existing TypeScript spacing conventions

## Validation
- npm install
- npm run build
- npm test
- npm run test:coverage