### PR TITLE
[codex] Add Rust number theory parity helpers

### DIFF
--- a/code/packages/rust/cas-number-theory/src/arithmetic.rs
+++ b/code/packages/rust/cas-number-theory/src/arithmetic.rs
@@ -39,6 +39,8 @@
 //! The formula used here: for each prime factor `p` of `n`,
 //! multiply the running total by `(p − 1) / p`.
 
+use crate::factor_integer;
+
 // ---------------------------------------------------------------------------
 // GCD / LCM
 // ---------------------------------------------------------------------------
@@ -182,6 +184,158 @@ pub fn totient(n: i64) -> i64 {
         result -= result / n;
     }
     result
+}
+
+// ---------------------------------------------------------------------------
+// Divisors and multiplicative functions
+// ---------------------------------------------------------------------------
+
+/// Return the sorted positive divisors of `|n|`.
+///
+/// Returns an empty vector for `n = 0`.
+///
+/// # Examples
+///
+/// ```rust
+/// use cas_number_theory::divisors;
+///
+/// assert_eq!(divisors(1), vec![1]);
+/// assert_eq!(divisors(12), vec![1, 2, 3, 4, 6, 12]);
+/// assert_eq!(divisors(-12), vec![1, 2, 3, 4, 6, 12]);
+/// assert_eq!(divisors(0), Vec::<i64>::new());
+/// ```
+pub fn divisors(n: i64) -> Vec<i64> {
+    let n = n.abs();
+    if n == 0 {
+        return vec![];
+    }
+
+    let mut divs = Vec::new();
+    let mut i = 1i64;
+    while i * i <= n {
+        if n % i == 0 {
+            divs.push(i);
+            let pair = n / i;
+            if pair != i {
+                divs.push(pair);
+            }
+        }
+        i += 1;
+    }
+    divs.sort_unstable();
+    divs
+}
+
+/// Möbius function μ(n).
+///
+/// Returns `0` if `n <= 0` or if `n` has a squared prime factor.  Otherwise
+/// returns `(-1)^k`, where `k` is the number of distinct prime factors.
+///
+/// # Examples
+///
+/// ```rust
+/// use cas_number_theory::moebius_mu;
+///
+/// assert_eq!(moebius_mu(1), 1);
+/// assert_eq!(moebius_mu(2), -1);
+/// assert_eq!(moebius_mu(4), 0);
+/// assert_eq!(moebius_mu(6), 1);
+/// ```
+pub fn moebius_mu(n: i64) -> i64 {
+    if n <= 0 {
+        return 0;
+    }
+    if n == 1 {
+        return 1;
+    }
+
+    let factors = factor_integer(n);
+    if factors.iter().any(|(_, exp)| *exp > 1) {
+        return 0;
+    }
+    if factors.len() % 2 == 0 {
+        1
+    } else {
+        -1
+    }
+}
+
+/// Jacobi symbol `(a/n)`.
+///
+/// `n` must be a positive odd integer.  Returns `-1`, `0`, or `1`.
+///
+/// # Panics
+///
+/// Panics when `n <= 0` or `n` is even.
+///
+/// # Examples
+///
+/// ```rust
+/// use cas_number_theory::jacobi_symbol;
+///
+/// assert_eq!(jacobi_symbol(2, 3), -1);
+/// assert_eq!(jacobi_symbol(1, 5), 1);
+/// assert_eq!(jacobi_symbol(0, 5), 0);
+/// ```
+pub fn jacobi_symbol(mut a: i64, mut n: i64) -> i64 {
+    assert!(n > 0 && n % 2 == 1, "jacobi_symbol requires odd positive n");
+
+    a = a.rem_euclid(n);
+    let mut result = 1i64;
+    while a != 0 {
+        while a % 2 == 0 {
+            a /= 2;
+            if matches!(n % 8, 3 | 5) {
+                result = -result;
+            }
+        }
+
+        std::mem::swap(&mut a, &mut n);
+        if a % 4 == 3 && n % 4 == 3 {
+            result = -result;
+        }
+        a %= n;
+    }
+
+    if n == 1 {
+        result
+    } else {
+        0
+    }
+}
+
+/// Number of digits of `|n|` in `base`.
+///
+/// Zero has length `1`.
+///
+/// # Panics
+///
+/// Panics when `base < 2`.
+///
+/// # Examples
+///
+/// ```rust
+/// use cas_number_theory::integer_length;
+///
+/// assert_eq!(integer_length(0, 10), 1);
+/// assert_eq!(integer_length(100, 10), 3);
+/// assert_eq!(integer_length(8, 2), 4);
+/// assert_eq!(integer_length(-100, 10), 3);
+/// ```
+pub fn integer_length(n: i64, base: i64) -> i64 {
+    assert!(base >= 2, "integer_length requires base >= 2");
+
+    let mut n = n.abs();
+    if n == 0 {
+        return 1;
+    }
+
+    let mut count = 0i64;
+    while n > 0 {
+        n /= base;
+        count += 1;
+    }
+    count
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-number-theory/src/crt.rs
+++ b/code/packages/rust/cas-number-theory/src/crt.rs
@@ -99,8 +99,8 @@ pub fn crt(remainders: &[i64], moduli: &[i64]) -> Option<i64> {
         // (M/g)·s ≡ 1 (mod n/g), i.e. s is the inverse of M/g mod n/g.
         let n_g = n / g;
         // Avoid overflow by using i128 for the intermediate product.
-        let t = ((diff / g).rem_euclid(n_g) as i128 * s.rem_euclid(n_g) as i128
-            % n_g as i128) as i64;
+        let t =
+            ((diff / g).rem_euclid(n_g) as i128 * s.rem_euclid(n_g) as i128 % n_g as i128) as i64;
         let t = t.rem_euclid(n_g); // ensure non-negative
 
         // New modulus is lcm(M, n).

--- a/code/packages/rust/cas-number-theory/src/lib.rs
+++ b/code/packages/rust/cas-number-theory/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! | Module | Functions |
 //! |--------|-----------|
-//! | [`arithmetic`] | [`gcd`], [`lcm`], [`extended_gcd`], [`totient`], [`mod_inverse`], [`mod_pow`] |
-//! | [`primality`] | [`is_prime`], [`primes_up_to`], [`next_prime`], [`nth_prime`] |
+//! | [`arithmetic`] | [`gcd`], [`lcm`], [`extended_gcd`], [`totient`], [`divisors`], [`moebius_mu`], [`jacobi_symbol`], [`integer_length`], [`mod_inverse`], [`mod_pow`] |
+//! | [`primality`] | [`is_prime`], [`primes_up_to`], [`next_prime`], [`prev_prime`], [`nth_prime`] |
 //! | [`factorize`] | [`factor_integer`], [`factorize_ir`] |
 //! | [`crt`] | [`crt`] |
 //!
@@ -38,10 +38,13 @@ pub mod primality;
 // Re-export the full public API.
 
 // arithmetic
-pub use arithmetic::{extended_gcd, gcd, lcm, mod_inverse, mod_pow, totient};
+pub use arithmetic::{
+    divisors, extended_gcd, gcd, integer_length, jacobi_symbol, lcm, mod_inverse, mod_pow,
+    moebius_mu, totient,
+};
 
 // primality
-pub use primality::{is_prime, next_prime, nth_prime, primes_up_to};
+pub use primality::{is_prime, next_prime, nth_prime, prev_prime, primes_up_to};
 
 // factorize
 pub use factorize::{factor_integer, factorize_ir};

--- a/code/packages/rust/cas-number-theory/src/primality.rs
+++ b/code/packages/rust/cas-number-theory/src/primality.rs
@@ -140,6 +140,41 @@ pub fn next_prime(n: i64) -> i64 {
     }
 }
 
+/// Return the largest prime strictly less than `n`.
+///
+/// Returns `None` when there is no such prime.
+///
+/// # Examples
+///
+/// ```rust
+/// use cas_number_theory::prev_prime;
+///
+/// assert_eq!(prev_prime(10), Some(7));
+/// assert_eq!(prev_prime(3), Some(2));
+/// assert_eq!(prev_prime(2), None);
+/// ```
+pub fn prev_prime(n: i64) -> Option<i64> {
+    if n <= 2 {
+        return None;
+    }
+
+    let mut candidate = n - 1;
+    if candidate == 2 {
+        return Some(2);
+    }
+    if candidate % 2 == 0 {
+        candidate -= 1;
+    }
+
+    while candidate >= 2 {
+        if is_prime(candidate) {
+            return Some(candidate);
+        }
+        candidate -= 2;
+    }
+    None
+}
+
 /// Return the `k`-th prime (1-indexed: `nth_prime(1) = 2`).
 ///
 /// # Examples

--- a/code/packages/rust/cas-number-theory/tests/tests.rs
+++ b/code/packages/rust/cas-number-theory/tests/tests.rs
@@ -1,8 +1,9 @@
 // Integration tests for cas-number-theory.
 
 use cas_number_theory::{
-    crt, extended_gcd, factor_integer, factorize_ir, gcd, is_prime, lcm, mod_inverse, mod_pow,
-    next_prime, nth_prime, primes_up_to, totient,
+    crt, divisors, extended_gcd, factor_integer, factorize_ir, gcd, integer_length, is_prime,
+    jacobi_symbol, lcm, mod_inverse, mod_pow, moebius_mu, next_prime, nth_prime, prev_prime,
+    primes_up_to, totient,
 };
 use symbolic_ir::{apply, int, sym, IRNode, MUL, POW};
 
@@ -80,7 +81,13 @@ fn extended_gcd_bezout_identity() {
     // Verify a*s + b*t = g for various inputs.
     for (a, b) in &[(3i64, 5), (12, 8), (100, 37), (7, 13), (0, 5)] {
         let (g, s, t) = extended_gcd(*a, *b);
-        assert_eq!(a * s + b * t, g, "Bézout identity failed for ({}, {})", a, b);
+        assert_eq!(
+            a * s + b * t,
+            g,
+            "Bézout identity failed for ({}, {})",
+            a,
+            b
+        );
         assert_eq!(g, gcd(*a, *b));
     }
 }
@@ -112,16 +119,16 @@ fn totient_prime() {
 #[test]
 fn totient_prime_power() {
     // φ(p^k) = p^(k-1)·(p-1)
-    assert_eq!(totient(4), 2);   // φ(2²) = 2
-    assert_eq!(totient(8), 4);   // φ(2³) = 4
-    assert_eq!(totient(9), 6);   // φ(3²) = 6
+    assert_eq!(totient(4), 2); // φ(2²) = 2
+    assert_eq!(totient(8), 4); // φ(2³) = 4
+    assert_eq!(totient(9), 6); // φ(3²) = 6
 }
 
 #[test]
 fn totient_composite() {
-    assert_eq!(totient(12), 4);   // φ(4·3) = 2·2
-    assert_eq!(totient(36), 12);  // φ(4·9) = 2·6
-    assert_eq!(totient(30), 8);   // φ(2·3·5) = 1·2·4
+    assert_eq!(totient(12), 4); // φ(4·3) = 2·2
+    assert_eq!(totient(36), 12); // φ(4·9) = 2·6
+    assert_eq!(totient(30), 8); // φ(2·3·5) = 1·2·4
 }
 
 #[test]
@@ -131,18 +138,87 @@ fn totient_nonpositive() {
 }
 
 // ---------------------------------------------------------------------------
+// arithmetic — divisors / moebius / jacobi / integer_length
+// ---------------------------------------------------------------------------
+
+#[test]
+fn divisors_python_examples() {
+    assert_eq!(divisors(1), vec![1]);
+    assert_eq!(divisors(12), vec![1, 2, 3, 4, 6, 12]);
+    assert_eq!(divisors(30), vec![1, 2, 3, 5, 6, 10, 15, 30]);
+}
+
+#[test]
+fn divisors_abs_and_zero() {
+    assert_eq!(divisors(-12), vec![1, 2, 3, 4, 6, 12]);
+    assert_eq!(divisors(0), Vec::<i64>::new());
+}
+
+#[test]
+fn moebius_python_examples() {
+    assert_eq!(moebius_mu(1), 1);
+    assert_eq!(moebius_mu(2), -1);
+    assert_eq!(moebius_mu(3), -1);
+    assert_eq!(moebius_mu(4), 0);
+    assert_eq!(moebius_mu(9), 0);
+    assert_eq!(moebius_mu(6), 1);
+}
+
+#[test]
+fn moebius_nonpositive_returns_zero() {
+    assert_eq!(moebius_mu(0), 0);
+    assert_eq!(moebius_mu(-6), 0);
+}
+
+#[test]
+fn jacobi_symbol_python_examples() {
+    assert_eq!(jacobi_symbol(2, 3), -1);
+    assert_eq!(jacobi_symbol(1, 5), 1);
+    assert_eq!(jacobi_symbol(0, 5), 0);
+    assert_eq!(jacobi_symbol(1001, 9907), -1);
+}
+
+#[test]
+#[should_panic(expected = "jacobi_symbol requires odd positive n")]
+fn jacobi_symbol_even_modulus_panics() {
+    jacobi_symbol(2, 4);
+}
+
+#[test]
+#[should_panic(expected = "jacobi_symbol requires odd positive n")]
+fn jacobi_symbol_nonpositive_modulus_panics() {
+    jacobi_symbol(2, -5);
+}
+
+#[test]
+fn integer_length_python_examples() {
+    assert_eq!(integer_length(0, 10), 1);
+    assert_eq!(integer_length(9, 10), 1);
+    assert_eq!(integer_length(10, 10), 2);
+    assert_eq!(integer_length(100, 10), 3);
+    assert_eq!(integer_length(8, 2), 4);
+    assert_eq!(integer_length(-100, 10), 3);
+}
+
+#[test]
+#[should_panic(expected = "integer_length requires base >= 2")]
+fn integer_length_invalid_base_panics() {
+    integer_length(10, 1);
+}
+
+// ---------------------------------------------------------------------------
 // arithmetic — mod_inverse
 // ---------------------------------------------------------------------------
 
 #[test]
 fn mod_inverse_basic() {
-    assert_eq!(mod_inverse(3, 7), Some(5));   // 3*5=15≡1 (mod 7)
+    assert_eq!(mod_inverse(3, 7), Some(5)); // 3*5=15≡1 (mod 7)
     assert_eq!(mod_inverse(1, 5), Some(1));
 }
 
 #[test]
 fn mod_inverse_no_inverse() {
-    assert_eq!(mod_inverse(2, 4), None);   // gcd(2,4)=2≠1
+    assert_eq!(mod_inverse(2, 4), None); // gcd(2,4)=2≠1
     assert_eq!(mod_inverse(6, 9), None);
 }
 
@@ -152,9 +228,9 @@ fn mod_inverse_no_inverse() {
 
 #[test]
 fn mod_pow_basic() {
-    assert_eq!(mod_pow(2, 10, 1000), 24);   // 2^10 = 1024 ≡ 24 (mod 1000)
-    assert_eq!(mod_pow(3, 4, 7), 4);         // 81 ≡ 4 (mod 7)
-    assert_eq!(mod_pow(3, 0, 7), 1);         // anything^0 = 1
+    assert_eq!(mod_pow(2, 10, 1000), 24); // 2^10 = 1024 ≡ 24 (mod 1000)
+    assert_eq!(mod_pow(3, 4, 7), 4); // 81 ≡ 4 (mod 7)
+    assert_eq!(mod_pow(3, 0, 7), 1); // anything^0 = 1
 }
 
 #[test]
@@ -227,6 +303,16 @@ fn next_prime_basic() {
     assert_eq!(next_prime(2), 3);
     assert_eq!(next_prime(10), 11);
     assert_eq!(next_prime(13), 17);
+}
+
+#[test]
+fn prev_prime_basic() {
+    assert_eq!(prev_prime(10), Some(7));
+    assert_eq!(prev_prime(3), Some(2));
+    assert_eq!(prev_prime(2), None);
+    assert_eq!(prev_prime(1), None);
+    assert_eq!(prev_prime(0), None);
+    assert_eq!(prev_prime(-10), None);
 }
 
 #[test]
@@ -376,7 +462,11 @@ fn crt_solution_unique_mod_lcm() {
     // Result should be in [0, lcm(moduli)).
     let result = crt(&[2, 3, 2], &[3, 5, 7]).unwrap();
     // lcm(3,5,7) = 105
-    assert!(result >= 0 && result < 105, "result {} not in [0, 105)", result);
+    assert!(
+        result >= 0 && result < 105,
+        "result {} not in [0, 105)",
+        result
+    );
     // Verify each congruence.
     assert_eq!(result % 3, 2);
     assert_eq!(result % 5, 3);


### PR DESCRIPTION
## Summary
- add Rust public helpers for prev_prime, divisors, moebius_mu, jacobi_symbol, and integer_length
- export the new APIs from cas-number-theory
- add focused tests mirroring Python examples plus Rust edge behavior for divisors and invalid preconditions

## Validation
- cargo fmt -p cas-number-theory
- cargo test -p cas-number-theory
- cargo check -p cas-number-theory