### PR TITLE
[codex] Port TS number theory parity helpers

### DIFF
--- a/code/packages/typescript/cas-number-theory/README.md
+++ b/code/packages/typescript/cas-number-theory/README.md
@@ -3,4 +3,4 @@
 Pure TypeScript number-theory helpers for symbolic CAS packages.
 
 The package uses `bigint` internally and exposes arithmetic, primality,
-integer factorization, CRT, and a symbolic-IR factorization helper.
+divisor, integer factorization, CRT, and a symbolic-IR factorization helper.

--- a/code/packages/typescript/cas-number-theory/src/index.ts
+++ b/code/packages/typescript/cas-number-theory/src/index.ts
@@ -123,6 +123,16 @@ export function nextPrime(nInput: IntegerLike): bigint {
   return candidate;
 }
 
+export function prevPrime(nInput: IntegerLike): bigint | null {
+  const n = toBigInt(nInput);
+  if (n <= 2n) return null;
+  let candidate = n - 1n;
+  if (candidate === 2n) return 2n;
+  if (candidate % 2n === 0n) candidate -= 1n;
+  while (candidate >= 2n && !isPrime(candidate)) candidate -= 2n;
+  return candidate >= 2n ? candidate : null;
+}
+
 export function nthPrime(kInput: number): bigint {
   if (!Number.isInteger(kInput) || kInput < 1) {
     throw new RangeError("nthPrime: k must be a positive integer");
@@ -167,6 +177,73 @@ export function factorInteger(nInput: IntegerLike): PrimeFactor[] {
 
   if (n > 1n) factors.push([n, 1]);
   return factors;
+}
+
+export function divisors(nInput: IntegerLike): bigint[] {
+  const n = abs(toBigInt(nInput));
+  if (n === 0n) return [];
+
+  const divs = new Set<bigint>();
+  let candidate = 1n;
+  while (candidate * candidate <= n) {
+    if (n % candidate === 0n) {
+      divs.add(candidate);
+      divs.add(n / candidate);
+    }
+    candidate += 1n;
+  }
+
+  return Array.from(divs).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+export function moebiusMu(nInput: IntegerLike): number {
+  const n = toBigInt(nInput);
+  if (n <= 0n) throw new RangeError(`moebiusMu requires n > 0, got ${n}`);
+  if (n === 1n) return 1;
+
+  const factors = factorInteger(n);
+  if (factors.some(([, exponent]) => exponent > 1)) return 0;
+  return factors.length % 2 === 0 ? 1 : -1;
+}
+
+export function jacobiSymbol(aInput: IntegerLike, nInput: IntegerLike): number {
+  let a = toBigInt(aInput);
+  let n = toBigInt(nInput);
+  if (n <= 0n || n % 2n === 0n) {
+    throw new RangeError(`jacobiSymbol requires odd positive n, got ${n}`);
+  }
+
+  a = mod(a, n);
+  let result = 1;
+  while (a !== 0n) {
+    while (a % 2n === 0n) {
+      a /= 2n;
+      const nMod8 = n % 8n;
+      if (nMod8 === 3n || nMod8 === 5n) result = -result;
+    }
+
+    const previousA = a;
+    a = n;
+    n = previousA;
+    if (a % 4n === 3n && n % 4n === 3n) result = -result;
+    a %= n;
+  }
+
+  return n === 1n ? result : 0;
+}
+
+export function integerLength(nInput: IntegerLike, baseInput: IntegerLike = 10): number {
+  let n = abs(toBigInt(nInput));
+  const base = toBigInt(baseInput);
+  if (base < 2n) throw new RangeError(`integerLength requires base >= 2, got ${base}`);
+  if (n === 0n) return 1;
+
+  let count = 0;
+  while (n > 0n) {
+    n /= base;
+    count += 1;
+  }
+  return count;
 }
 
 export function factorizeIr(expr: IRNode): IRNode {

--- a/code/packages/typescript/cas-number-theory/tests/number-theory.test.ts
+++ b/code/packages/typescript/cas-number-theory/tests/number-theory.test.ts
@@ -2,16 +2,21 @@ import { describe, expect, it } from "vitest";
 import { MUL, POW, app, int, sym } from "@coding-adventures/symbolic-ir";
 import {
   crt,
+  divisors,
   extendedGcd,
   factorInteger,
   factorizeIr,
   gcd,
+  integerLength,
   isPrime,
+  jacobiSymbol,
   lcm,
   modInverse,
   modPow,
+  moebiusMu,
   nextPrime,
   nthPrime,
+  prevPrime,
   primesUpTo,
   totient,
 } from "../src/index";
@@ -47,6 +52,46 @@ describe("arithmetic", () => {
     expect(modPow(3, 0, 7)).toBe(1n);
     expect(modPow(100, 100, 1)).toBe(0n);
   });
+
+  it("enumerates positive divisors of absolute values", () => {
+    expect(divisors(1)).toEqual([1n]);
+    expect(divisors(12)).toEqual([1n, 2n, 3n, 4n, 6n, 12n]);
+    expect(divisors(-12)).toEqual([1n, 2n, 3n, 4n, 6n, 12n]);
+    expect(divisors(30)).toEqual([1n, 2n, 3n, 5n, 6n, 10n, 15n, 30n]);
+    expect(divisors(0)).toEqual([]);
+  });
+
+  it("computes the Moebius function from factor multiplicities", () => {
+    expect(moebiusMu(1)).toBe(1);
+    expect(moebiusMu(2)).toBe(-1);
+    expect(moebiusMu(3)).toBe(-1);
+    expect(moebiusMu(4)).toBe(0);
+    expect(moebiusMu(9)).toBe(0);
+    expect(moebiusMu(6)).toBe(1);
+    expect(moebiusMu(30)).toBe(-1);
+    expect(() => moebiusMu(0)).toThrow(RangeError);
+  });
+
+  it("computes Jacobi symbols for positive odd moduli", () => {
+    expect(jacobiSymbol(2, 3)).toBe(-1);
+    expect(jacobiSymbol(1, 5)).toBe(1);
+    expect(jacobiSymbol(0, 5)).toBe(0);
+    expect(jacobiSymbol(-1, 7)).toBe(-1);
+    expect(jacobiSymbol(1001, 9907)).toBe(-1);
+    expect(() => jacobiSymbol(2, 4)).toThrow(RangeError);
+    expect(() => jacobiSymbol(2, 0)).toThrow(RangeError);
+  });
+
+  it("counts integer digits in a base", () => {
+    expect(integerLength(0)).toBe(1);
+    expect(integerLength(9)).toBe(1);
+    expect(integerLength(10)).toBe(2);
+    expect(integerLength(100)).toBe(3);
+    expect(integerLength(8, 2)).toBe(4);
+    expect(integerLength(-100)).toBe(3);
+    expect(integerLength(255, 16)).toBe(2);
+    expect(() => integerLength(10, 1)).toThrow(RangeError);
+  });
 });
 
 describe("primality", () => {
@@ -67,6 +112,11 @@ describe("primality", () => {
     expect(primesUpTo(100)).toHaveLength(25);
     expect(nextPrime(0)).toBe(2n);
     expect(nextPrime(13)).toBe(17n);
+    expect(prevPrime(10)).toBe(7n);
+    expect(prevPrime(3)).toBe(2n);
+    expect(prevPrime(2)).toBeNull();
+    expect(prevPrime(1)).toBeNull();
+    expect(prevPrime(-10)).toBeNull();
     expect(nthPrime(1)).toBe(2n);
     expect(nthPrime(10)).toBe(29n);
   });


### PR DESCRIPTION
## Summary
- add TypeScript exports for prevPrime, divisors, moebiusMu, jacobiSymbol, and integerLength
- mirror Python reference behavior and requested divisor zero/negative semantics with focused Vitest coverage
- update the package README public helper summary

## Validation
- npm install
- npm run build
- npm test
- npm run test:coverage