### PR TITLE
feat(prolog-loader): ProblogProgram builder + 18 ProbLog E2E tests

### DIFF
--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -154,6 +154,18 @@ impl Rule {
             probability: Probability::Certain,
         }
     }
+
+    /// Construct a `Rule` with explicit probability `p`. Mirrors
+    /// [`Fact::with_probability`]: the `id` is a sentinel
+    /// `RuleId(u64::MAX)` that the KB overwrites on insert.
+    pub fn with_probability(head: Term, body: Vec<BodyLiteral>, p: f64) -> Self {
+        Self {
+            id: RuleId(u64::MAX),
+            head,
+            body,
+            probability: Probability::Value(p),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/prolog-loader/CHANGELOG.md
+++ b/code/packages/rust/prolog-loader/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-05-11
+
+### Added
+
+- `problog` module — builder API for probabilistic Prolog programs.
+  Bridges the (working) engine half of ProbLog —
+  `Fact::with_probability`, `Rule::with_probability`, the WMC
+  backend in `logic_engine::wmc` — and the (not-yet-built) source
+  half (the ISO-Prolog grammar doesn't recognise `0.7::fact.` yet).
+- `ProblogProgram` builder with chainable
+  `with_fact` / `with_prob_fact(p, term)` /
+  `with_rule(head, body)` / `with_prob_rule(p, head, body)` /
+  `with_query(goals)` methods, plus `build_kb()` (no execute),
+  `execute()` (AutoDetect), and `execute_with_mode(mode)`.
+- Multi-goal queries on the ProbLog path use the same synthetic-head
+  rewrite as the deterministic loader — head atom
+  `__problog_query_N`, unsourcable because `_`-prefixed identifiers
+  tokenise as variables.
+- Re-exported at the crate root: `prolog_loader::ProblogProgram`.
+- 9 new unit tests + 9 new integration tests in
+  `tests/integration_problog_e2e.rs`. Coverage: single probabilistic
+  fact, conjunctive rule over independent probabilistic facts (WMC
+  multiplies), probabilistic rule gating a certain premise, mixed
+  deterministic/probabilistic programs, unprovable queries return
+  0.0, boundary probabilities 0.0 and 1.0, multi-goal queries via
+  the synthetic-head rewrite, deterministic-only program through the
+  ProbLog builder, `build_kb()` without executing.
+
+### Notes
+
+Engine half of the ProbLog E2E story; the source half — accepting
+`0.7::edge(a, b).` syntax — is gated on grammar work. When that
+lands, a future `load_problog_source(src)` will be a thin wrapper
+translating parsed clauses into the same `ProblogProgram` builder
+calls these tests exercise.
+
+### Companion change in logic-engine
+
+`Rule::with_probability(head, body, p)` added to mirror
+`Fact::with_probability`. Purely additive.
+
 ## [0.2.0] - 2026-05-11
 
 ### Added

--- a/code/packages/rust/prolog-loader/Cargo.toml
+++ b/code/packages/rust/prolog-loader/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "prolog-loader"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "Load Prolog source text into a logic-engine KnowledgeBase. Closes the text → engine pipeline. v0.2 adds `execute` / `run_all_queries` end-to-end runner and a 14-test integration suite."
+description = "Load Prolog source text into a logic-engine KnowledgeBase. v0.2 adds `execute` / `run_all_queries` end-to-end runner. v0.3 adds the `ProblogProgram` builder for probabilistic programs (WMC-backed)."
 
 [dependencies]
 prolog-parser = { path = "../prolog-parser" }

--- a/code/packages/rust/prolog-loader/src/lib.rs
+++ b/code/packages/rust/prolog-loader/src/lib.rs
@@ -18,6 +18,9 @@ use logic_engine::{search, BodyLiteral, Fact, KnowledgeBase, Rule, SearchMode, S
 use parser::grammar_parser::GrammarParseError;
 use prolog_parser::{collect_clauses_and_queries, ProgramItem};
 
+pub mod problog;
+pub use problog::ProblogProgram;
+
 /// Top-level result of loading a Prolog source string.
 #[derive(Debug)]
 pub struct LoadedProgram {

--- a/code/packages/rust/prolog-loader/src/problog.rs
+++ b/code/packages/rust/prolog-loader/src/problog.rs
@@ -1,0 +1,305 @@
+//! # `problog` — builder API for probabilistic Prolog programs
+//!
+//! Bridges the gap between the **engine half** of the ProbLog story
+//! (which already works — `logic_engine` ships
+//! `Fact::with_probability` / `Rule::with_probability` plus the WMC
+//! backend) and the **source half** (which still needs grammar work
+//! to accept `0.7::edge(a, b).`-style syntax).
+//!
+//! Until the grammar lands, callers can compose a probabilistic
+//! program declaratively via [`ProblogProgram`] and exercise the
+//! end-to-end engine path without touching the parser.
+//!
+//! ## What "probabilistic Prolog" means here
+//!
+//! Each Fact carries an annotation `Certain` or `Value(p)`. Each
+//! Rule does too. The engine runs `search(query, kb, AutoDetect)`:
+//!
+//! - If every clause used in any proof is `Certain`, the cheap
+//!   `FindFirst` path returns at most one binding.
+//! - If any clause is probabilistic, the `EnumerateAll` path returns
+//!   a `ProofDAG` + the engine's WMC.
+//!
+//! That gives `P(query)`, the standard ProbLog semantics, under the
+//! independence assumption baked into the WMC implementation
+//! (`logic_engine::wmc`).
+//!
+//! ## When the grammar supports `0.7::` source syntax
+//!
+//! This builder stays useful regardless — it's the **typed API**
+//! consumers and tests reach for to construct programs without
+//! round-tripping through text. A future `load_problog_source(src)`
+//! will be a thin wrapper that converts parsed clauses into
+//! `ProblogProgram::with_prob_fact` / `with_prob_rule` calls.
+
+use logic_core::Term;
+use logic_engine::{search, BodyLiteral, Fact, KnowledgeBase, Rule, SearchMode};
+
+use crate::QueryRun;
+
+/// A probabilistic Prolog program under construction. Mirrors a
+/// `.pl` file: facts, rules, and queries. Builder methods are
+/// chainable. Drive to completion with [`Self::execute`].
+#[derive(Debug, Default)]
+pub struct ProblogProgram {
+    facts: Vec<Fact>,
+    rules: Vec<Rule>,
+    queries: Vec<Vec<Term>>,
+}
+
+impl ProblogProgram {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a deterministic fact. Same semantics as
+    /// `Fact::certain(term)`.
+    pub fn with_fact(mut self, term: Term) -> Self {
+        self.facts.push(Fact::certain(term));
+        self
+    }
+
+    /// Add a probabilistic fact: `p :: term.`. `p` must be in
+    /// `[0, 1]`. Out-of-range values are accepted as-is so callers
+    /// can deliberately encode boundary conditions in tests; the WMC
+    /// backend treats anything outside `[0, 1]` as a programmer
+    /// error.
+    pub fn with_prob_fact(mut self, p: f64, term: Term) -> Self {
+        self.facts.push(Fact::with_probability(term, p));
+        self
+    }
+
+    /// Add a deterministic rule `head :- body[0], body[1], ...`.
+    pub fn with_rule(mut self, head: Term, body: Vec<BodyLiteral>) -> Self {
+        self.rules.push(Rule::certain(head, body));
+        self
+    }
+
+    /// Add a probabilistic rule `p :: head :- body[0], ...`. The
+    /// rule's whole derivation is gated on a Bernoulli coin: with
+    /// probability `p` the rule fires, with probability `1 - p` it
+    /// does not.
+    pub fn with_prob_rule(mut self, p: f64, head: Term, body: Vec<BodyLiteral>) -> Self {
+        self.rules.push(Rule::with_probability(head, body, p));
+        self
+    }
+
+    /// Add a top-level `?- g1, g2, ..., gn.` query.
+    pub fn with_query(mut self, goals: Vec<Term>) -> Self {
+        self.queries.push(goals);
+        self
+    }
+
+    /// Build a [`KnowledgeBase`] without running any queries. Useful
+    /// for callers that want to add more clauses programmatically
+    /// after the builder hands them the KB.
+    pub fn build_kb(self) -> (KnowledgeBase, Vec<Vec<Term>>) {
+        let mut kb = KnowledgeBase::new();
+        for f in self.facts {
+            kb.add_fact(f);
+        }
+        for r in self.rules {
+            kb.add_rule(r);
+        }
+        (kb, self.queries)
+    }
+
+    /// Build the KB, run every query through `logic_engine::search`,
+    /// and return the resulting [`QueryRun`]s alongside the KB. The
+    /// default search mode is `AutoDetect`, which uses the cheap
+    /// `FindFirst` path on a certain-only KB and falls back to
+    /// `EnumerateAll` + WMC when any clause is probabilistic.
+    pub fn execute(self) -> (KnowledgeBase, Vec<QueryRun>) {
+        self.execute_with_mode(SearchMode::AutoDetect)
+    }
+
+    /// Same as [`Self::execute`] but with an explicit search mode.
+    /// Tests use this to force `EnumerateAll` on a certain-only
+    /// program so they can read back the WMC value (which is `1.0`
+    /// on a deterministic proof).
+    pub fn execute_with_mode(self, mode: SearchMode) -> (KnowledgeBase, Vec<QueryRun>) {
+        let (mut kb, queries) = self.build_kb();
+        let mut runs = Vec::with_capacity(queries.len());
+        for (i, goals) in queries.into_iter().enumerate() {
+            let searched = match goals.len() {
+                0 => Term::Atom("true".to_string()),
+                1 => goals[0].clone(),
+                _ => {
+                    // Same synthetic-head rewrite as the deterministic
+                    // `run_all_queries` path. `__problog_query_N` cannot
+                    // collide with user source because identifiers
+                    // starting with `_` are variables, not atoms.
+                    let head = Term::Atom(format!("__problog_query_{i}"));
+                    let body: Vec<BodyLiteral> =
+                        goals.iter().cloned().map(BodyLiteral::Pos).collect();
+                    kb.add_rule(Rule::certain(head.clone(), body));
+                    head
+                }
+            };
+            let result = search(&searched, &kb, mode);
+            runs.push(QueryRun {
+                goals,
+                searched,
+                result,
+            });
+        }
+        (kb, runs)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logic_core::{atom, compound, var};
+    use logic_engine::{BodyLiteral, SearchResult};
+
+    fn assert_close(actual: f64, expected: f64, tol: f64) {
+        assert!(
+            (actual - expected).abs() < tol,
+            "expected {expected} ± {tol}, got {actual}",
+        );
+    }
+
+    #[test]
+    fn deterministic_fact_via_builder_succeeds_with_probability_one() {
+        // The builder still works for fully deterministic programs;
+        // ProbLog should subsume Prolog.
+        let (_kb, runs) = ProblogProgram::new()
+            .with_fact(atom("sunny"))
+            .with_query(vec![atom("sunny")])
+            .execute();
+        assert_eq!(runs.len(), 1);
+        assert!(runs[0].succeeded());
+        assert_eq!(runs[0].probability(), 1.0);
+    }
+
+    #[test]
+    fn single_probabilistic_fact_returns_its_probability() {
+        // The textbook ProbLog "Bernoulli coin" example: a single
+        // probabilistic fact, query it, get its probability back.
+        let (_kb, runs) = ProblogProgram::new()
+            .with_prob_fact(0.7, atom("rain"))
+            .with_query(vec![atom("rain")])
+            .execute();
+        assert_eq!(runs.len(), 1);
+        assert!(runs[0].succeeded(), "rain has positive probability");
+        assert_close(runs[0].probability(), 0.7, 1e-9);
+    }
+
+    #[test]
+    fn two_independent_probabilistic_facts_in_a_conjunctive_rule_multiply() {
+        // Independence: P(alarm) = P(burglary) * P(triggers_alarm)
+        // when the only rule is `alarm :- burglary, triggers_alarm.`
+        // Both probabilistic facts are independent in the WMC's
+        // distribution semantics.
+        let (_kb, runs) = ProblogProgram::new()
+            .with_prob_fact(0.1, atom("burglary"))
+            .with_prob_fact(0.9, atom("triggers_alarm"))
+            .with_rule(
+                atom("alarm"),
+                vec![
+                    BodyLiteral::Pos(atom("burglary")),
+                    BodyLiteral::Pos(atom("triggers_alarm")),
+                ],
+            )
+            .with_query(vec![atom("alarm")])
+            .execute();
+        assert_eq!(runs.len(), 1);
+        assert!(runs[0].succeeded());
+        assert_close(runs[0].probability(), 0.1 * 0.9, 1e-9);
+    }
+
+    #[test]
+    fn probabilistic_rule_attenuates_a_certain_premise() {
+        // `0.4 :: smoker(X) :- adult(X).` plus `adult(alice).`
+        // gives P(smoker(alice)) = 0.4 — the rule's coin gates the
+        // derivation, the premise is fully certain.
+        let (_kb, runs) = ProblogProgram::new()
+            .with_fact(compound("adult", vec![atom("alice")]))
+            .with_prob_rule(
+                0.4,
+                compound("smoker", vec![Term::Var(var("X"))]),
+                vec![BodyLiteral::Pos(compound("adult", vec![Term::Var(var("X"))]))],
+            )
+            .with_query(vec![compound("smoker", vec![atom("alice")])])
+            .execute();
+        assert_eq!(runs.len(), 1);
+        assert!(runs[0].succeeded());
+        assert_close(runs[0].probability(), 0.4, 1e-9);
+    }
+
+    #[test]
+    fn unprovable_query_returns_zero() {
+        // No proof at all → P = 0.
+        let (_kb, runs) = ProblogProgram::new()
+            .with_prob_fact(0.5, atom("rain"))
+            .with_query(vec![atom("snow")])
+            .execute();
+        assert_eq!(runs.len(), 1);
+        assert!(!runs[0].succeeded());
+        assert_eq!(runs[0].probability(), 0.0);
+    }
+
+    #[test]
+    fn boundary_probability_one_behaves_like_certain() {
+        // A fact at p=1.0 should still be provable; the WMC value
+        // is exactly 1.0 (no floating-point drift on this boundary).
+        let (_kb, runs) = ProblogProgram::new()
+            .with_prob_fact(1.0, atom("guaranteed"))
+            .with_query(vec![atom("guaranteed")])
+            .execute_with_mode(SearchMode::EnumerateAll);
+        assert!(runs[0].succeeded());
+        assert_close(runs[0].probability(), 1.0, 1e-12);
+    }
+
+    #[test]
+    fn boundary_probability_zero_makes_query_fail() {
+        // A fact at p=0.0 is degenerate — provable in proof space
+        // but with zero probability mass.
+        let (_kb, runs) = ProblogProgram::new()
+            .with_prob_fact(0.0, atom("impossible"))
+            .with_query(vec![atom("impossible")])
+            .execute_with_mode(SearchMode::EnumerateAll);
+        assert!(!runs[0].succeeded(), "P=0 ⇒ no probability mass on this query");
+        assert_close(runs[0].probability(), 0.0, 1e-12);
+    }
+
+    #[test]
+    fn build_kb_returns_kb_and_queries_without_executing() {
+        // The non-running build path lets callers extend the KB
+        // before search.
+        let (mut kb, queries) = ProblogProgram::new()
+            .with_prob_fact(0.3, atom("a"))
+            .with_query(vec![atom("a")])
+            .build_kb();
+        assert_eq!(queries.len(), 1);
+        // Add a second probabilistic fact after the fact (sic).
+        kb.add_fact(Fact::with_probability(atom("b"), 0.5));
+        // Sanity-check that the engine still works.
+        let r = search(&atom("b"), &kb, SearchMode::EnumerateAll);
+        match r {
+            SearchResult::EnumerateAllResult { probability, .. } => {
+                assert_close(probability, 0.5, 1e-9);
+            }
+            other => panic!("expected EnumerateAllResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_goal_query_uses_synthetic_head_and_multiplies_probabilities() {
+        // Two independent probabilistic facts in a query. The
+        // synthetic head wraps the conjunction in a rule so the
+        // engine can run it.
+        let (_kb, runs) = ProblogProgram::new()
+            .with_prob_fact(0.4, atom("p"))
+            .with_prob_fact(0.25, atom("q"))
+            .with_query(vec![atom("p"), atom("q")])
+            .execute();
+        assert_eq!(runs.len(), 1);
+        assert_close(runs[0].probability(), 0.4 * 0.25, 1e-9);
+    }
+}

--- a/code/packages/rust/prolog-loader/tests/integration_problog_e2e.rs
+++ b/code/packages/rust/prolog-loader/tests/integration_problog_e2e.rs
@@ -1,0 +1,170 @@
+//! End-to-end integration tests for the ProbLog (probabilistic
+//! Prolog) pipeline.
+//!
+//! These tests exercise the engine + WMC backend through the
+//! `ProblogProgram` builder API. They're the regression check that
+//! a probabilistic Prolog program — facts and rules with explicit
+//! `Probability::Value(p)` — produces the right WMC answers when
+//! run through `logic_engine::search` under `EnumerateAll` mode.
+//!
+//! ## Why builder API instead of source text
+//!
+//! The ISO-Prolog grammar does not yet recognise the `0.7::fact.`
+//! syntax (the lexer rejects a clause starting with a `FLOAT`
+//! token). When the grammar gains a probabilistic-clause production,
+//! `load_problog_source(src)` will be a thin wrapper that translates
+//! parsed clauses into the same builder calls these tests use. The
+//! engine half — what we test here — is already complete.
+//!
+//! ## Coverage
+//!
+//! - Single probabilistic fact: P(query) = annotation.
+//! - Conjunctive rule over independent probabilistic facts:
+//!   P(combined) = product (assumed-independent WMC).
+//! - Probabilistic rule over a certain premise:
+//!   P(head) = rule's annotation.
+//! - Boundary probabilities 0.0 and 1.0.
+//! - Multi-goal queries via the synthetic-head rewrite.
+//! - Mixed deterministic and probabilistic clauses in one program.
+
+use logic_core::{atom, compound, var, Term};
+use logic_engine::{BodyLiteral, SearchMode};
+use prolog_loader::ProblogProgram;
+
+fn assert_close(actual: f64, expected: f64, tol: f64) {
+    assert!(
+        (actual - expected).abs() < tol,
+        "expected {expected} ± {tol}, got {actual}",
+    );
+}
+
+#[test]
+fn rain_with_prob_0_7_yields_probability_0_7() {
+    let (_kb, runs) = ProblogProgram::new()
+        .with_prob_fact(0.7, atom("rain"))
+        .with_query(vec![atom("rain")])
+        .execute();
+    assert_eq!(runs.len(), 1);
+    assert_close(runs[0].probability(), 0.7, 1e-9);
+}
+
+#[test]
+fn alarm_via_conjunctive_rule_multiplies_independent_factors() {
+    // alarm :- burglary, triggers_alarm.
+    // 0.05 :: burglary.
+    // 0.95 :: triggers_alarm.
+    // ?- alarm.
+    // → 0.05 * 0.95 = 0.0475
+    let (_kb, runs) = ProblogProgram::new()
+        .with_prob_fact(0.05, atom("burglary"))
+        .with_prob_fact(0.95, atom("triggers_alarm"))
+        .with_rule(
+            atom("alarm"),
+            vec![
+                BodyLiteral::Pos(atom("burglary")),
+                BodyLiteral::Pos(atom("triggers_alarm")),
+            ],
+        )
+        .with_query(vec![atom("alarm")])
+        .execute();
+    assert_close(runs[0].probability(), 0.05 * 0.95, 1e-9);
+}
+
+#[test]
+fn probabilistic_rule_gates_a_certain_premise() {
+    // 0.4 :: smoker(X) :- adult(X).
+    // adult(alice).
+    // ?- smoker(alice).
+    // → 0.4
+    let (_kb, runs) = ProblogProgram::new()
+        .with_fact(compound("adult", vec![atom("alice")]))
+        .with_prob_rule(
+            0.4,
+            compound("smoker", vec![Term::Var(var("X"))]),
+            vec![BodyLiteral::Pos(compound("adult", vec![Term::Var(var("X"))]))],
+        )
+        .with_query(vec![compound("smoker", vec![atom("alice")])])
+        .execute();
+    assert_close(runs[0].probability(), 0.4, 1e-9);
+}
+
+#[test]
+fn mixed_deterministic_and_probabilistic_program_works() {
+    // Deterministic family rules + one probabilistic fact gating an
+    // observation. Verifies AutoDetect routes the program through
+    // EnumerateAll (some clauses are uncertain) and the WMC value
+    // comes out right.
+    let (_kb, runs) = ProblogProgram::new()
+        .with_fact(compound(
+            "parent",
+            vec![atom("alice"), atom("bob")],
+        ))
+        .with_rule(
+            compound(
+                "ancestor",
+                vec![Term::Var(var("X")), Term::Var(var("Y"))],
+            ),
+            vec![BodyLiteral::Pos(compound(
+                "parent",
+                vec![Term::Var(var("X")), Term::Var(var("Y"))],
+            ))],
+        )
+        .with_prob_fact(0.3, atom("observed"))
+        .with_query(vec![
+            compound("ancestor", vec![atom("alice"), atom("bob")]),
+            atom("observed"),
+        ])
+        .execute();
+
+    // Two-goal query: ancestor(alice, bob) is certain, observed has
+    // probability 0.3. The synthetic-head rewrite combines them in a
+    // single rule; WMC returns 0.3.
+    assert_close(runs[0].probability(), 0.3, 1e-9);
+}
+
+#[test]
+fn unprovable_query_returns_zero_probability() {
+    let (_kb, runs) = ProblogProgram::new()
+        .with_prob_fact(0.5, atom("a"))
+        .with_query(vec![atom("nonexistent")])
+        .execute();
+    assert!(!runs[0].succeeded());
+    assert_eq!(runs[0].probability(), 0.0);
+}
+
+#[test]
+fn probability_one_behaves_like_certain_in_enumerate_all_mode() {
+    let (_kb, runs) = ProblogProgram::new()
+        .with_prob_fact(1.0, atom("guaranteed"))
+        .with_query(vec![atom("guaranteed")])
+        .execute_with_mode(SearchMode::EnumerateAll);
+    assert_close(runs[0].probability(), 1.0, 1e-12);
+}
+
+#[test]
+fn probability_zero_makes_query_fail() {
+    let (_kb, runs) = ProblogProgram::new()
+        .with_prob_fact(0.0, atom("impossible"))
+        .with_query(vec![atom("impossible")])
+        .execute_with_mode(SearchMode::EnumerateAll);
+    assert!(!runs[0].succeeded());
+    assert_close(runs[0].probability(), 0.0, 1e-12);
+}
+
+#[test]
+fn empty_program_has_no_queries() {
+    let (_kb, runs) = ProblogProgram::new().execute();
+    assert!(runs.is_empty());
+}
+
+#[test]
+fn deterministic_program_via_builder_returns_probability_one() {
+    // The ProbLog builder must handle deterministic programs gracefully:
+    // a program with no probabilistic clauses should run on the
+    // FindFirst path under AutoDetect and report probability 1.0.
+    let (_kb, runs) = ProblogProgram::new()
+        .with_fact(atom("sunny"))
+        .with_query(vec![atom("sunny")])
+        .execute();
+    assert_eq!(runs[0].probability(), 1.0);
+}


### PR DESCRIPTION
## Summary

**Second of three E2E test goals** (Prolog ✅ #2752, **ProbLog ✅ this PR**, semantic source map pending).

- New \`problog\` module on \`prolog-loader\` + \`ProblogProgram\` builder API.
- Companion 6-line addition to \`logic-engine\`: \`Rule::with_probability\`.
- 18 new tests covering single prob fact, conjunctive rules over independent prob facts (WMC multiplies), probabilistic rule gating a certain premise, mixed programs, boundaries, multi-goal queries, etc.
- Bumps \`prolog-loader\` to **v0.3.0**.
- Clippy clean.

## What lands

\`\`\`rust
use prolog_loader::ProblogProgram;
use logic_core::{atom, compound, var, Term};
use logic_engine::BodyLiteral;

let (_kb, runs) = ProblogProgram::new()
    .with_prob_fact(0.05, atom(\"burglary\"))
    .with_prob_fact(0.95, atom(\"triggers_alarm\"))
    .with_rule(
        atom(\"alarm\"),
        vec![
            BodyLiteral::Pos(atom(\"burglary\")),
            BodyLiteral::Pos(atom(\"triggers_alarm\")),
        ],
    )
    .with_query(vec![atom(\"alarm\")])
    .execute();

assert!((runs[0].probability() - 0.05 * 0.95).abs() < 1e-9);  // 0.0475
\`\`\`

## Why a builder API, not source parsing

The ISO-Prolog grammar **doesn't yet recognise** \`0.7::edge(a, b).\` syntax — the lexer rejects a clause starting with a FLOAT token (probed and confirmed in this PR's exploration). That's grammar work that has its own PR queue.

Meanwhile, the **engine half** of ProbLog — \`Fact::with_probability\`, \`Rule::with_probability\`, and the WMC backend — is already complete. This PR gives it a typed front door so the WMC pipeline can be tested end-to-end immediately. When the grammar lands, a future \`load_problog_source(src)\` will be a thin wrapper translating parsed clauses into these same builder calls.

## Companion change in logic-engine

\`Rule::with_probability(head, body, p)\` — 6 lines, mirrors \`Fact::with_probability\`. Purely additive, no call site impact.

## Test coverage (18 new)

**9 unit (src/problog.rs):**
- builder roundtrips deterministic program
- single prob fact → P = annotation
- conjunctive rule, independent prob facts → product
- prob rule, certain premise → P = rule annotation
- unprovable query → P = 0.0
- boundary P=1.0 behaves like Certain
- boundary P=0.0 makes query fail
- \`build_kb()\` without execute
- multi-goal queries via synthetic-head rewrite

**9 integration (tests/integration_problog_e2e.rs):**
- rain @ 0.7 → 0.7
- alarm via conjunction → 0.0475
- smoker prob rule → 0.4
- mixed deterministic + probabilistic
- unprovable → 0.0
- P=1.0 behaves like Certain
- P=0.0 makes query fail
- empty program
- deterministic-only via ProbLog builder → 1.0

## Stack

Stacked on [#2752 (prolog-loader E2E runner)](https://github.com/adhithyan15/coding-adventures/pull/2752). Cleanest to merge #2752 first, then rebase this one. The conflict will be a trivial version bump cascade (this PR is v0.3.0; #2752 made it v0.2.0).

## Test plan

- [x] \`cargo test -p prolog-loader\` — 18 unit + 14 integration_e2e + 9 integration_problog_e2e = 41 passing
- [x] \`cargo clippy -p prolog-loader --tests --no-deps -- -D warnings\` — clean
- [ ] CI green
- [ ] User sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)