### PR TITLE
[codex] Add Rust cubic solve parity slice

### DIFF
--- a/code/packages/rust/cas-solve/CHANGELOG.md
+++ b/code/packages/rust/cas-solve/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — cas-solve (Rust)
 
+## Unreleased
+
+### Added
+
+- `cubic` module: `solve_cubic(a, b, c, d) -> SolveResult` — solves cubic
+  equations via rational-root deflation plus a focused Cardano symbolic
+  fallback matching the Python reference's tested behavior.
+- `CBRT = "Cbrt"` head name constant for cubic Cardano expressions.
+- Cubic integration tests for quadratic delegation, exact rational roots,
+  repeated roots, rational fraction roots, symbolic Cardano, and casus
+  irreducibilis fallback.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-solve/Cargo.toml
+++ b/code/packages/rust/cas-solve/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cas-solve"
 version = "0.1.0"
 edition = "2021"
-description = "Closed-form equation solving over Q: linear and quadratic (Phase 1)"
+description = "Closed-form equation solving over Q: linear, quadratic, and cubic (Phase 1)"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/cas-solve/README.md
+++ b/code/packages/rust/cas-solve/README.md
@@ -1,12 +1,12 @@
 # cas-solve (Rust)
 
-Closed-form equation solving over ℚ (Phase 1: linear and quadratic).
+Closed-form equation solving over ℚ (Phase 1: linear, quadratic, and cubic).
 Rust port of the Python `cas-solve` package.
 
 ## Usage
 
 ```rust
-use cas_solve::{solve_linear, solve_quadratic, SolveResult};
+use cas_solve::{solve_cubic, solve_linear, solve_quadratic, SolveResult};
 use cas_solve::frac::Frac;
 use symbolic_ir::{int, rat};
 
@@ -19,13 +19,19 @@ let r2 = solve_quadratic(
     Frac::from_int(1), Frac::from_int(-5), Frac::from_int(6),
 );
 assert_eq!(r2, SolveResult::Solutions(vec![int(2), int(3)]));
+
+// x^3 - 6x^2 + 11x - 6 = 0  →  {1, 2, 3}
+let r3 = solve_cubic(
+    Frac::from_int(1), Frac::from_int(-6), Frac::from_int(11), Frac::from_int(-6),
+);
+assert_eq!(r3, SolveResult::Solutions(vec![int(1), int(2), int(3)]));
 ```
 
 ## SolveResult
 
 ```rust
 pub enum SolveResult {
-    Solutions(Vec<IRNode>),  // empty = no solution
+    Solutions(Vec<IRNode>),  // empty = no solution or unevaluated fallback
     All,                     // 0 = 0: every x satisfies
 }
 ```
@@ -38,6 +44,15 @@ pub enum SolveResult {
 | Positive, not a perfect square | `Div(Add/Sub(-b, Sqrt(disc)), 2a)` |
 | Zero | Single repeated rational root |
 | Negative | Complex roots `r ± k·%i` (Maxima `%i` imaginary unit) |
+
+## Cubic behavior
+
+`solve_cubic(a, b, c, d)` first delegates to `solve_quadratic` when `a = 0`.
+Otherwise it finds exact rational roots, deflates to a quadratic, and
+deduplicates repeated roots. If no rational root exists, it uses Cardano's
+formula with symbolic `Cbrt`, `Sqrt`, and `%i` IR nodes for the one-real /
+two-complex branch. The casus irreducibilis branch returns an empty solution
+list, matching the Python reference's unevaluated fallback behavior.
 
 ## Stack position
 

--- a/code/packages/rust/cas-solve/src/cubic.rs
+++ b/code/packages/rust/cas-solve/src/cubic.rs
@@ -1,0 +1,330 @@
+//! Cubic-equation closed form using rational roots and Cardano's formula.
+//!
+//! For `a*x^3 + b*x^2 + c*x + d = 0` with rational coefficients:
+//!
+//! 1. Try the rational-root theorem. When a rational root is found, deflate
+//!    the cubic and solve the residual quadratic.
+//! 2. If no rational root exists, use Cardano's formula for the depressed
+//!    cubic `t^3 + p*t + q = 0`.
+//!
+//! The casus irreducibilis branch (`D_cardano < 0`) intentionally returns an
+//! empty solution list, matching the Python reference's "leave unevaluated"
+//! behavior.
+
+use symbolic_ir::{apply, sym, IRNode, ADD, DIV, MUL, NEG, SQRT, SUB};
+
+use crate::frac::Frac;
+use crate::quadratic::{solve_quadratic, I_UNIT};
+use crate::SolveResult;
+
+/// Cube-root head used by Cardano symbolic fallback expressions.
+pub const CBRT: &str = "Cbrt";
+
+/// Solve `a*x^3 + b*x^2 + c*x + d = 0` over rationals, with complex IR roots
+/// where the closed form naturally produces them.
+///
+/// When `a == 0`, this delegates to [`solve_quadratic`]. Repeated roots are
+/// deduplicated. Cubics in casus irreducibilis return `Solutions(vec![])` so
+/// callers can treat the original expression as unevaluated.
+pub fn solve_cubic(a: Frac, b: Frac, c: Frac, d: Frac) -> SolveResult {
+    if a.is_zero() {
+        return solve_quadratic(b, c, d);
+    }
+
+    if let Some(root) = find_rational_root(a, b, c, d) {
+        let b2 = b + a * root;
+        let c2 = c + b2 * root;
+        let remainder = d + c2 * root;
+        if remainder.is_zero() {
+            let root_ir = root.to_irnode();
+            let SolveResult::Solutions(remaining) = solve_quadratic(a, b2, c2) else {
+                return SolveResult::Solutions(vec![root_ir]);
+            };
+            return SolveResult::Solutions(dedup_roots(
+                std::iter::once(root_ir).chain(remaining).collect(),
+            ));
+        }
+    }
+
+    let three = Frac::from_int(3);
+    let four = Frac::from_int(4);
+    let twenty_seven = Frac::from_int(27);
+    let a_inv = Frac::one() / a;
+
+    let p = c * a_inv - b * b * a_inv * a_inv / three;
+    let q = d * a_inv - b * c * a_inv * a_inv / three
+        + Frac::from_int(2) * b * b * b * a_inv * a_inv * a_inv / twenty_seven;
+    let shift = -b / (three * a);
+    let d_card = q * q / four + p * p * p / twenty_seven;
+
+    if d_card > Frac::zero() {
+        return SolveResult::Solutions(cardano_one_real_two_complex(q, shift, d_card));
+    }
+
+    if d_card == Frac::zero() {
+        return SolveResult::Solutions(cardano_repeated(p, q, shift));
+    }
+
+    SolveResult::Solutions(vec![])
+}
+
+fn cardano_one_real_two_complex(q: Frac, shift: Frac, d_card: Frac) -> Vec<IRNode> {
+    let neg_q_half = -q / Frac::from_int(2);
+
+    if let Some(sqrt_d) = try_exact_sqrt(d_card) {
+        let a_term = neg_q_half + sqrt_d;
+        let b_term = neg_q_half - sqrt_d;
+        if let (Some(cbrt_a), Some(cbrt_b)) = (try_exact_cbrt(a_term), try_exact_cbrt(b_term)) {
+            let t1 = cbrt_a + cbrt_b;
+            let x1 = t1 + shift;
+            let half_sum = -(cbrt_a + cbrt_b) / Frac::from_int(2);
+            let half_diff = (cbrt_a - cbrt_b) / Frac::from_int(2);
+            let mut roots = vec![x1.to_irnode()];
+
+            if half_diff.is_zero() {
+                let repeated = (half_sum + shift).to_irnode();
+                roots.push(repeated.clone());
+                roots.push(repeated);
+            } else {
+                let real_part = (half_sum + shift).to_irnode();
+                let imag = imag_term(half_diff);
+                roots.push(apply(sym(ADD), vec![real_part.clone(), imag.clone()]));
+                roots.push(apply(sym(SUB), vec![real_part, imag]));
+            }
+            return roots;
+        }
+    }
+
+    let sqrt_d_ir = sqrt_ir(d_card);
+    let neg_q_half_ir = neg_q_half.to_irnode();
+    let (cbrt_a, cbrt_b) = if neg_q_half.is_zero() {
+        (
+            apply(sym(CBRT), vec![sqrt_d_ir.clone()]),
+            apply(sym(CBRT), vec![apply(sym(NEG), vec![sqrt_d_ir])]),
+        )
+    } else {
+        (
+            apply(
+                sym(CBRT),
+                vec![apply(
+                    sym(ADD),
+                    vec![neg_q_half_ir.clone(), sqrt_d_ir.clone()],
+                )],
+            ),
+            apply(
+                sym(CBRT),
+                vec![apply(sym(SUB), vec![neg_q_half_ir, sqrt_d_ir])],
+            ),
+        )
+    };
+
+    let t1 = apply(sym(ADD), vec![cbrt_a.clone(), cbrt_b.clone()]);
+    let x1 = add_shift(t1, shift);
+
+    let minus_t1_half = apply(
+        sym(DIV),
+        vec![
+            apply(
+                sym(NEG),
+                vec![apply(sym(ADD), vec![cbrt_a.clone(), cbrt_b.clone()])],
+            ),
+            IRNode::Integer(2),
+        ],
+    );
+    let real_part = add_shift(minus_t1_half, shift);
+    let diff = apply(sym(SUB), vec![cbrt_a, cbrt_b]);
+    let imag_part = apply(
+        sym(MUL),
+        vec![
+            apply(
+                sym(DIV),
+                vec![
+                    apply(
+                        sym(MUL),
+                        vec![diff, apply(sym(SQRT), vec![IRNode::Integer(3)])],
+                    ),
+                    IRNode::Integer(2),
+                ],
+            ),
+            sym(I_UNIT),
+        ],
+    );
+
+    vec![
+        x1,
+        apply(sym(ADD), vec![real_part.clone(), imag_part.clone()]),
+        apply(sym(SUB), vec![real_part, imag_part]),
+    ]
+}
+
+fn cardano_repeated(p: Frac, q: Frac, shift: Frac) -> Vec<IRNode> {
+    if p.is_zero() && q.is_zero() {
+        return vec![shift.to_irnode()];
+    }
+
+    let neg_q_half = -q / Frac::from_int(2);
+    if let Some(cbrt_val) = try_exact_cbrt(neg_q_half) {
+        let t1 = Frac::from_int(2) * cbrt_val;
+        let t2 = -cbrt_val;
+        return dedup_roots(vec![(t1 + shift).to_irnode(), (t2 + shift).to_irnode()]);
+    }
+
+    let cbrt = apply(sym(CBRT), vec![neg_q_half.to_irnode()]);
+    vec![
+        add_shift(
+            apply(sym(MUL), vec![IRNode::Integer(2), cbrt.clone()]),
+            shift,
+        ),
+        add_shift(apply(sym(NEG), vec![cbrt]), shift),
+    ]
+}
+
+fn find_rational_root(a: Frac, b: Frac, c: Frac, d: Frac) -> Option<Frac> {
+    let lcm = fraction_lcm(&[a, b, c, d]);
+    let scaled_a = a.numer * (lcm / a.denom);
+    let scaled_d = d.numer * (lcm / d.denom);
+
+    if scaled_d == 0 {
+        return Some(Frac::zero());
+    }
+
+    for p in divisors(scaled_d.unsigned_abs()) {
+        for q in divisors(scaled_a.unsigned_abs()) {
+            for sign in [1, -1] {
+                let candidate = Frac::new(sign * p as i64, q as i64);
+                if eval_cubic(a, b, c, d, candidate).is_zero() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn eval_cubic(a: Frac, b: Frac, c: Frac, d: Frac, x: Frac) -> Frac {
+    a * x * x * x + b * x * x + c * x + d
+}
+
+fn divisors(n: u64) -> Vec<u64> {
+    if n == 0 {
+        return vec![0];
+    }
+
+    let mut divs = Vec::new();
+    let mut i = 1;
+    while i * i <= n {
+        if n % i == 0 {
+            divs.push(i);
+            if i != n / i {
+                divs.push(n / i);
+            }
+        }
+        i += 1;
+    }
+    divs.sort_unstable();
+    divs
+}
+
+fn fraction_lcm(fracs: &[Frac]) -> i64 {
+    fracs.iter().fold(1, |acc, f| lcm(acc, f.denom))
+}
+
+fn lcm(a: i64, b: i64) -> i64 {
+    a / gcd(a.unsigned_abs(), b.unsigned_abs()) as i64 * b
+}
+
+fn gcd(mut a: u64, mut b: u64) -> u64 {
+    while b != 0 {
+        let next = a % b;
+        a = b;
+        b = next;
+    }
+    a
+}
+
+fn try_exact_sqrt(value: Frac) -> Option<Frac> {
+    if value.numer < 0 {
+        return None;
+    }
+    match (isqrt(value.numer as u64), isqrt(value.denom as u64)) {
+        (Some(n), Some(d)) => Some(Frac::new(n as i64, d as i64)),
+        _ => None,
+    }
+}
+
+fn try_exact_cbrt(value: Frac) -> Option<Frac> {
+    if value.is_zero() {
+        return Some(Frac::zero());
+    }
+    let sign = if value.numer < 0 { -1 } else { 1 };
+    match (
+        icbrt(value.numer.unsigned_abs()),
+        icbrt(value.denom.unsigned_abs()),
+    ) {
+        (Some(n), Some(d)) => Some(Frac::new(sign * n as i64, d as i64)),
+        _ => None,
+    }
+}
+
+fn isqrt(n: u64) -> Option<u64> {
+    let r = (n as f64).sqrt() as u64;
+    for candidate in r.saturating_sub(1)..=r + 1 {
+        if candidate * candidate == n {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn icbrt(n: u64) -> Option<u64> {
+    if n == 0 {
+        return Some(0);
+    }
+    let r = (n as f64).cbrt() as u64;
+    for candidate in r.saturating_sub(1)..=r + 1 {
+        if candidate * candidate * candidate == n {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn sqrt_ir(value: Frac) -> IRNode {
+    try_exact_sqrt(value).map_or_else(
+        || apply(sym(SQRT), vec![value.to_irnode()]),
+        |sqrt| sqrt.to_irnode(),
+    )
+}
+
+fn imag_term(coef: Frac) -> IRNode {
+    if coef == Frac::one() {
+        return sym(I_UNIT);
+    }
+    if coef == -Frac::one() {
+        return apply(sym(NEG), vec![sym(I_UNIT)]);
+    }
+    apply(sym(MUL), vec![coef.to_irnode(), sym(I_UNIT)])
+}
+
+fn add_shift(node: IRNode, shift: Frac) -> IRNode {
+    if shift.is_zero() {
+        return node;
+    }
+
+    if shift.denom == 1 && shift.numer < 0 {
+        apply(sym(SUB), vec![node, IRNode::Integer(-shift.numer)])
+    } else {
+        apply(sym(ADD), vec![node, shift.to_irnode()])
+    }
+}
+
+fn dedup_roots(roots: Vec<IRNode>) -> Vec<IRNode> {
+    let mut deduped = Vec::new();
+    for root in roots {
+        if !deduped.contains(&root) {
+            deduped.push(root);
+        }
+    }
+    deduped
+}

--- a/code/packages/rust/cas-solve/src/frac.rs
+++ b/code/packages/rust/cas-solve/src/frac.rs
@@ -36,9 +36,16 @@ impl Frac {
             return Self { numer: 0, denom: 1 };
         }
         // Make denom positive.
-        let (n, d) = if denom < 0 { (-numer, -denom) } else { (numer, denom) };
+        let (n, d) = if denom < 0 {
+            (-numer, -denom)
+        } else {
+            (numer, denom)
+        };
         let g = gcd(n.unsigned_abs() as u128, d.unsigned_abs() as u128) as i64;
-        Self { numer: n / g, denom: d / g }
+        Self {
+            numer: n / g,
+            denom: d / g,
+        }
     }
 
     /// Construct from an integer: `n / 1`.
@@ -79,7 +86,10 @@ impl Frac {
 impl Neg for Frac {
     type Output = Self;
     fn neg(self) -> Self {
-        Self { numer: -self.numer, denom: self.denom }
+        Self {
+            numer: -self.numer,
+            denom: self.denom,
+        }
     }
 }
 
@@ -130,7 +140,11 @@ impl Frac {
         if numer == 0 {
             return Self { numer: 0, denom: 1 };
         }
-        let (n, d) = if denom < 0 { (-numer, -denom) } else { (numer, denom) };
+        let (n, d) = if denom < 0 {
+            (-numer, -denom)
+        } else {
+            (numer, denom)
+        };
         let g = gcd(n.unsigned_abs(), d.unsigned_abs()) as i128;
         Self {
             numer: (n / g) as i64,
@@ -140,7 +154,11 @@ impl Frac {
 }
 
 fn gcd(a: u128, b: u128) -> u128 {
-    if b == 0 { a } else { gcd(b, a % b) }
+    if b == 0 {
+        a
+    } else {
+        gcd(b, a % b)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-solve/src/lib.rs
+++ b/code/packages/rust/cas-solve/src/lib.rs
@@ -1,11 +1,11 @@
 //! # cas-solve
 //!
-//! Closed-form equation solving over ℚ (Phase 1: linear and quadratic).
+//! Closed-form equation solving over ℚ (Phase 1: linear, quadratic, and cubic).
 //!
 //! ## Quick start
 //!
 //! ```rust
-//! use cas_solve::{solve_linear, solve_quadratic, SolveResult};
+//! use cas_solve::{solve_cubic, solve_linear, solve_quadratic, SolveResult};
 //! use cas_solve::frac::Frac;
 //! use symbolic_ir::{int, rat};
 //!
@@ -18,6 +18,12 @@
 //!     Frac::from_int(1), Frac::from_int(-5), Frac::from_int(6),
 //! );
 //! assert_eq!(r2, SolveResult::Solutions(vec![int(2), int(3)]));
+//!
+//! // x^3 - 6x^2 + 11x - 6 = 0  →  {1, 2, 3}
+//! let r3 = solve_cubic(
+//!     Frac::from_int(1), Frac::from_int(-6), Frac::from_int(11), Frac::from_int(-6),
+//! );
+//! assert_eq!(r3, SolveResult::Solutions(vec![int(1), int(2), int(3)]));
 //! ```
 //!
 //! ## IR head names
@@ -28,16 +34,19 @@
 //! | [`NSOLVE`] | `"NSolve"` |
 //! | [`ROOTS`] | `"Roots"` |
 
+pub mod cubic;
 pub mod frac;
 pub mod linear;
 pub mod quadratic;
 
+pub use cubic::{solve_cubic, CBRT};
 pub use linear::solve_linear;
 pub use quadratic::{solve_quadratic, I_UNIT};
 
 /// The result of an equation-solve operation.
 ///
-/// - `Solutions(vec)` — zero, one, or two solutions (empty = no solution).
+/// - `Solutions(vec)` — zero or more solutions (empty = no solution or
+///   unevaluated symbolic fallback, depending on the solver).
 /// - `All` — every value of x satisfies the equation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SolveResult {

--- a/code/packages/rust/cas-solve/tests/tests.rs
+++ b/code/packages/rust/cas-solve/tests/tests.rs
@@ -3,12 +3,16 @@
 // Mirrors the Python reference tests in
 // code/packages/python/cas-solve/tests/.
 
-use cas_solve::{solve_linear, solve_quadratic, SolveResult};
 use cas_solve::frac::Frac;
+use cas_solve::{solve_cubic, solve_linear, solve_quadratic, SolveResult};
 use symbolic_ir::{int, rat, IRNode};
 
-fn frac(n: i64, d: i64) -> Frac { Frac::new(n, d) }
-fn fi(n: i64) -> Frac { Frac::from_int(n) }
+fn frac(n: i64, d: i64) -> Frac {
+    Frac::new(n, d)
+}
+fn fi(n: i64) -> Frac {
+    Frac::from_int(n)
+}
 
 // ---------------------------------------------------------------------------
 // solve_linear
@@ -177,4 +181,81 @@ fn quadratic_irrational_sqrt_node_shape() {
         }
         SolveResult::All => panic!("expected Solutions"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// solve_cubic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cubic_zero_leading_falls_back_to_quadratic() {
+    // 0x^3 + x^2 - 5x + 6 = 0 -> {2, 3}
+    let r = solve_cubic(fi(0), fi(1), fi(-5), fi(6));
+    assert_eq!(r, SolveResult::Solutions(vec![int(2), int(3)]));
+}
+
+#[test]
+fn cubic_three_rational_roots() {
+    // x^3 - 6x^2 + 11x - 6 = 0 -> {1, 2, 3}
+    let r = solve_cubic(fi(1), fi(-6), fi(11), fi(-6));
+    assert_eq!(r, SolveResult::Solutions(vec![int(1), int(2), int(3)]));
+}
+
+#[test]
+fn cubic_repeated_roots_are_deduplicated() {
+    // x^3 - 3x - 2 = (x + 1)^2(x - 2) -> {-1, 2}
+    let r = solve_cubic(fi(1), fi(0), fi(-3), fi(-2));
+    assert_eq!(r, SolveResult::Solutions(vec![int(-1), int(2)]));
+}
+
+#[test]
+fn cubic_rational_fraction_root() {
+    // 2x^3 - 3x^2 - 11x + 6 = (x + 2)(2x - 1)(x - 3)
+    let r = solve_cubic(fi(2), fi(-3), fi(-11), fi(6));
+    match r {
+        SolveResult::Solutions(roots) => {
+            assert_eq!(roots.len(), 3);
+            assert!(roots.contains(&int(-2)));
+            assert!(roots.contains(&rat(1, 2)));
+            assert!(roots.contains(&int(3)));
+        }
+        SolveResult::All => panic!("expected Solutions"),
+    }
+}
+
+#[test]
+fn cubic_rational_root_with_complex_pair() {
+    // x^3 + 1 = 0 -> -1 and a complex conjugate pair.
+    let r = solve_cubic(fi(1), fi(0), fi(0), fi(1));
+    match r {
+        SolveResult::Solutions(roots) => {
+            assert_eq!(roots.len(), 3);
+            assert!(roots.contains(&int(-1)));
+            let text = format!("{roots:?}");
+            assert!(text.contains("%i"), "expected complex roots in {text}");
+        }
+        SolveResult::All => panic!("expected Solutions"),
+    }
+}
+
+#[test]
+fn cubic_cardano_symbolic_one_real_two_complex() {
+    // x^3 + x + 1 has no rational root and D_cardano > 0.
+    let r = solve_cubic(fi(1), fi(0), fi(1), fi(1));
+    match r {
+        SolveResult::Solutions(roots) => {
+            assert_eq!(roots.len(), 3);
+            let text = format!("{roots:?}");
+            assert!(text.contains("Cbrt"), "expected Cbrt in {text}");
+            assert!(text.contains("%i"), "expected complex roots in {text}");
+        }
+        SolveResult::All => panic!("expected Solutions"),
+    }
+}
+
+#[test]
+fn cubic_casus_irreducibilis_returns_empty() {
+    // x^3 - 3x + 1 has three real irrational roots in the Python reference.
+    let r = solve_cubic(fi(1), fi(0), fi(-3), fi(1));
+    assert_eq!(r, SolveResult::Solutions(vec![]));
 }


### PR DESCRIPTION
## Summary
- add `solve_cubic(a, b, c, d)` to Rust `cas-solve` with quadratic delegation, rational-root deflation, repeated-root deduplication, and Cardano symbolic fallback
- export the public API and `Cbrt` head name from `lib.rs`
- add focused cubic integration tests plus README/CHANGELOG updates

## Validation
- `cargo fmt -p cas-solve`
- `cargo test -p cas-solve`
- `cargo check -p cas-solve`

## Scope
- limited to `code/packages/rust/cas-solve`
- no quartic, numeric, transcendental, or linear-system work included