### PR TITLE
[codex] Add TS cas-complex polar forms

### DIFF
--- a/code/packages/typescript/cas-complex/CHANGELOG.md
+++ b/code/packages/typescript/cas-complex/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Port complex normalization, part extraction, conjugation, modulus, argument,
   and integer powers to pure TypeScript.
+- Add Python-compatible `rectForm` and symbolic `polarForm` helpers.

--- a/code/packages/typescript/cas-complex/README.md
+++ b/code/packages/typescript/cas-complex/README.md
@@ -9,6 +9,8 @@ so browser-side CAS paths can normalize complex expressions directly.
 | Function | Description |
 |---|---|
 | `complexNormalize(z)` | Rewrite `z` into canonical `a + b*I` form |
+| `rectForm(z)` | Python-compatible alias for rectangular normalization |
+| `polarForm(z)` | Rewrite complex `z` as symbolic `r*Exp(I*theta)` |
 | `splitComplex(z)` | Return `[real, imag]` parts as real-valued IR nodes |
 | `realPart(z)` | Extract real part `Re(z)` |
 | `imagPart(z)` | Extract imaginary part `Im(z)` |
@@ -25,3 +27,7 @@ treated as opaque real atoms.
 
 Zero parts are suppressed: `0 + 2*I` becomes `Mul(2, I)`, `3 + 0*I` becomes
 `3`, and `0 + 1*I` becomes `I`.
+
+`polarForm` mirrors the Python `PolarForm` structure for expressions containing
+`I`: `Mul(Sqrt(Add(Pow(real, 2), Pow(imag, 2))), Exp(Mul(I, Atan2(imag, real))))`.
+Pure real expressions return unevaluated `PolarForm(z)`.

--- a/code/packages/typescript/cas-complex/src/index.ts
+++ b/code/packages/typescript/cas-complex/src/index.ts
@@ -22,6 +22,11 @@ export const IM = "Im";
 export const CONJUGATE = "Conjugate";
 export const ABS = "Abs";
 export const ARG = "Arg";
+export const RECT_FORM = "RectForm";
+export const POLAR_FORM = "PolarForm";
+export const EXP = "Exp";
+export const SQRT = "Sqrt";
+export const ATAN2 = "Atan2";
 
 export const IMAGINARY_UNIT_NODE = sym(IMAGINARY_UNIT);
 export const RE_HEAD = sym(RE);
@@ -29,12 +34,32 @@ export const IM_HEAD = sym(IM);
 export const CONJUGATE_HEAD = sym(CONJUGATE);
 export const ABS_HEAD = sym(ABS);
 export const ARG_HEAD = sym(ARG);
+export const RECT_FORM_HEAD = sym(RECT_FORM);
+export const POLAR_FORM_HEAD = sym(POLAR_FORM);
+export const EXP_HEAD = sym(EXP);
+export const SQRT_HEAD = sym(SQRT);
+export const ATAN2_HEAD = sym(ATAN2);
 
 export type ComplexParts = readonly [real: IRNode, imag: IRNode];
 
 export function complexNormalize(expr: IRNode): IRNode {
   const [re, im] = splitComplex(expr);
   return assemble(re, im);
+}
+
+export function rectForm(expr: IRNode): IRNode {
+  return complexNormalize(expr);
+}
+
+export function polarForm(expr: IRNode): IRNode {
+  if (!containsImaginary(expr)) return app(POLAR_FORM_HEAD, [expr]);
+
+  const normalized = complexNormalize(expr);
+  const [re, im] = splitComplex(normalized);
+
+  const r = app(SQRT_HEAD, [app(ADD, [app(POW, [re, int(2)]), app(POW, [im, int(2)])])]);
+  const theta = app(ATAN2_HEAD, [im, re]);
+  return app(MUL, [r, app(EXP_HEAD, [app(MUL, [IMAGINARY_UNIT_NODE, theta])])]);
 }
 
 export function splitComplex(expr: IRNode): ComplexParts {
@@ -58,6 +83,11 @@ export function realPart(expr: IRNode): IRNode {
 
 export function imagPart(expr: IRNode): IRNode {
   return splitComplex(expr)[1];
+}
+
+export function containsImaginary(expr: IRNode): boolean {
+  if (equals(expr, IMAGINARY_UNIT_NODE)) return true;
+  return expr.kind === "apply" && expr.args.some((arg) => containsImaginary(arg));
 }
 
 export function conjugate(expr: IRNode): IRNode {

--- a/code/packages/typescript/cas-complex/tests/cas-complex.test.ts
+++ b/code/packages/typescript/cas-complex/tests/cas-complex.test.ts
@@ -2,14 +2,21 @@ import { describe, expect, it } from "vitest";
 import {
   ARG_HEAD,
   ABS_HEAD,
+  ATAN2_HEAD,
+  EXP_HEAD,
   IMAGINARY_UNIT,
+  IMAGINARY_UNIT_NODE,
+  POLAR_FORM_HEAD,
+  SQRT_HEAD,
   argument,
   complexNormalize,
   complexPow,
   conjugate,
   imagPart,
   modulus,
+  polarForm,
   realPart,
+  rectForm,
   splitComplex,
 } from "../src/index";
 import { ADD, MUL, NEG, POW, SUB, app, equals, int, numberNode, sym, type IRNode } from "@coding-adventures/symbolic-ir";
@@ -63,6 +70,39 @@ describe("complexNormalize", () => {
     const result = complexNormalize(app(MUL, [z34(), oneMinusTwoI]));
     expect(equals(realPart(result), int(11))).toBe(true);
     expect(equals(imagPart(result), int(-2))).toBe(true);
+  });
+});
+
+describe("rectForm and polarForm", () => {
+  it("rectForm delegates to rectangular normalization", () => {
+    const onePlusTwoI = app(ADD, [int(1), app(MUL, [int(2), sym(IMAGINARY_UNIT)])]);
+    const result = rectForm(onePlusTwoI);
+    expect(equals(realPart(result), int(1))).toBe(true);
+    expect(equals(imagPart(result), int(2))).toBe(true);
+  });
+
+  it("builds symbolic polar form for numeric rectangular complex expressions", () => {
+    const result = polarForm(z34());
+    const expected = app(MUL, [
+      app(SQRT_HEAD, [app(ADD, [app(POW, [int(3), int(2)]), app(POW, [int(4), int(2)])])]),
+      app(EXP_HEAD, [app(MUL, [IMAGINARY_UNIT_NODE, app(ATAN2_HEAD, [int(4), int(3)])])]),
+    ]);
+    expect(equals(result, expected)).toBe(true);
+  });
+
+  it("builds symbolic polar form for symbolic rectangular complex expressions", () => {
+    const expr = app(ADD, [sym("a"), app(MUL, [sym("b"), sym(IMAGINARY_UNIT)])]);
+    const result = polarForm(expr);
+    const expected = app(MUL, [
+      app(SQRT_HEAD, [app(ADD, [app(POW, [sym("a"), int(2)]), app(POW, [sym("b"), int(2)])])]),
+      app(EXP_HEAD, [app(MUL, [IMAGINARY_UNIT_NODE, app(ATAN2_HEAD, [sym("b"), sym("a")])])]),
+    ]);
+    expect(equals(result, expected)).toBe(true);
+  });
+
+  it("leaves pure real expressions as unevaluated PolarForm", () => {
+    expect(equals(polarForm(sym("x")), app(POLAR_FORM_HEAD, [sym("x")]))).toBe(true);
+    expect(equals(polarForm(int(3)), app(POLAR_FORM_HEAD, [int(3)]))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- export RectForm/PolarForm-related heads for TypeScript cas-complex
- add rectForm as the rectangular normalization entrypoint
- add symbolic polarForm construction matching the Python reference shape, with pure real fallback to unevaluated PolarForm
- cover numeric, symbolic, and real fallback cases in focused Vitest tests

## Validation
- npm install
- npm run build
- npm test
- npm run test:coverage