### PR TITLE
Add Rust cas-complex polar form API

### DIFF
--- a/code/packages/rust/cas-complex/CHANGELOG.md
+++ b/code/packages/rust/cas-complex/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — cas-complex (Rust)
 
+## Unreleased
+
+### Added
+
+- `rect_form(expr)` public API as the RectForm-style wrapper around
+  `complex_normalize(expr)`.
+- `polar_form(expr)` public API returning symbolic
+  `Mul(r, Exp(Mul(I, theta)))` for complex expressions, with unevaluated
+  `PolarForm(expr)` fallback for real/symbolic expressions.
+- `RECT_FORM`, `POLAR_FORM`, and `ATAN2` head-name constants.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-complex/README.md
+++ b/code/packages/rust/cas-complex/README.md
@@ -14,6 +14,8 @@ modulus, argument, and integer powers via De Moivre's theorem.
 | `conjugate(z)` | Complex conjugate: `a + b·I → a − b·I` |
 | `modulus(z)` | Modulus `|z| = √(a² + b²)` → `IRFloat` |
 | `argument(z)` | Argument `arg(z) = atan2(b, a)` in `(−π, π]` → `IRFloat` |
+| `rect_form(z)` | Public RectForm-style normalization to `a + b·I` |
+| `polar_form(z)` | Symbolic `r·Exp(I·θ)` form, or unevaluated `PolarForm(z)` for real/symbolic inputs |
 | `complex_pow(z, n)` | Integer power via De Moivre's theorem |
 
 ## Normalization

--- a/code/packages/rust/cas-complex/src/constants.rs
+++ b/code/packages/rust/cas-complex/src/constants.rs
@@ -35,6 +35,8 @@
 //! | [`CONJUGATE`] | `"Conjugate"` | Complex conjugate head |
 //! | [`ABS`] | `"Abs"` | Complex modulus head |
 //! | [`ARG`] | `"Arg"` | Complex argument (angle) head |
+//! | [`RECT_FORM`] | `"RectForm"` | Rectangular-form wrapper head |
+//! | [`POLAR_FORM`] | `"PolarForm"` | Polar-form wrapper head |
 
 /// Symbol name for the imaginary unit `i` (√−1).
 pub const IMAGINARY_UNIT: &str = "I";
@@ -53,3 +55,12 @@ pub const ABS: &str = "Abs";
 
 /// Head for the complex argument (phase angle): `Arg(z)`.
 pub const ARG: &str = "Arg";
+
+/// Head for rectangular form: `RectForm(z)`.
+pub const RECT_FORM: &str = "RectForm";
+
+/// Head for polar form: `PolarForm(z)`.
+pub const POLAR_FORM: &str = "PolarForm";
+
+/// Head for the two-argument arctangent: `Atan2(y, x)`.
+pub const ATAN2: &str = "Atan2";

--- a/code/packages/rust/cas-complex/src/lib.rs
+++ b/code/packages/rust/cas-complex/src/lib.rs
@@ -12,7 +12,7 @@
 //! | [`constants`] | Symbol name constants (`IMAGINARY_UNIT`, `RE`, `IM`, …) |
 //! | [`normalize`] | [`complex_normalize`] — rewrite to canonical `a + b·I` form |
 //! | [`parts`] | [`real_part`], [`imag_part`], [`conjugate`] |
-//! | [`polar`] | [`modulus`], [`argument`] |
+//! | [`polar`] | [`modulus`], [`argument`], [`rect_form`], [`polar_form`] |
 //! | [`power`] | [`complex_pow`] — integer powers via De Moivre's theorem |
 //!
 //! ## Quick start
@@ -55,8 +55,8 @@ pub mod power;
 
 // Re-export the public API.
 
-pub use constants::{ABS, ARG, CONJUGATE, IMAGINARY_UNIT, IM, RE};
+pub use constants::{ABS, ARG, ATAN2, CONJUGATE, IM, IMAGINARY_UNIT, POLAR_FORM, RE, RECT_FORM};
 pub use normalize::complex_normalize;
 pub use parts::{conjugate, imag_part, real_part};
-pub use polar::{argument, modulus};
+pub use polar::{argument, modulus, polar_form, rect_form};
 pub use power::complex_pow;

--- a/code/packages/rust/cas-complex/src/normalize.rs
+++ b/code/packages/rust/cas-complex/src/normalize.rs
@@ -65,9 +65,7 @@ pub fn complex_normalize(expr: &IRNode) -> IRNode {
 pub(crate) fn split_complex(expr: &IRNode) -> (IRNode, IRNode) {
     match expr {
         // Numeric literals are purely real.
-        IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_) => {
-            (expr.clone(), int(0))
-        }
+        IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_) => (expr.clone(), int(0)),
 
         // The imaginary unit symbol I: re=0, im=1
         IRNode::Symbol(name) if name == IMAGINARY_UNIT => (int(0), int(1)),
@@ -116,7 +114,10 @@ pub(crate) fn split_complex(expr: &IRNode) -> (IRNode, IRNode) {
                         let (ar, ai) = split_complex(arg);
                         // new_re = re*ar − im*ai
                         // new_im = re*ai + im*ar
-                        let new_re = sub_ir(mul_ir(re.clone(), ar.clone()), mul_ir(im.clone(), ai.clone()));
+                        let new_re = sub_ir(
+                            mul_ir(re.clone(), ar.clone()),
+                            mul_ir(im.clone(), ai.clone()),
+                        );
                         let new_im = add_ir(mul_ir(re, ai), mul_ir(im, ar));
                         re = new_re;
                         im = new_im;
@@ -160,10 +161,10 @@ fn i_power(n: i64) -> (IRNode, IRNode) {
     // Normalise n to [0, 4) using Euclidean remainder.
     let r = n.rem_euclid(4);
     match r {
-        0 => (int(1), int(0)),   // 1
-        1 => (int(0), int(1)),   // i
-        2 => (int(-1), int(0)),  // -1
-        3 => (int(0), int(-1)),  // -i
+        0 => (int(1), int(0)),  // 1
+        1 => (int(0), int(1)),  // i
+        2 => (int(-1), int(0)), // -1
+        3 => (int(0), int(-1)), // -i
         _ => unreachable!(),
     }
 }

--- a/code/packages/rust/cas-complex/src/polar.rs
+++ b/code/packages/rust/cas-complex/src/polar.rs
@@ -28,10 +28,60 @@
 //! | `i`   | `1.0` | `π/2` |
 //! | `-i`  | `1.0` | `-π/2` |
 
-use symbolic_ir::{apply, flt, sym, IRNode};
+use symbolic_ir::{apply, flt, int, sym, IRNode, ADD, EXP, MUL, POW, SQRT};
 
-use crate::constants::{ABS, ARG};
-use crate::normalize::split_complex;
+use crate::constants::{ABS, ARG, ATAN2, IMAGINARY_UNIT, POLAR_FORM};
+use crate::normalize::{complex_normalize, split_complex};
+
+/// Rewrite `expr` as rectangular `a + b·I` form.
+///
+/// This is the public RectForm-style wrapper around [`complex_normalize`].
+/// Purely real expressions are returned unchanged by the normalizer.
+pub fn rect_form(expr: &IRNode) -> IRNode {
+    complex_normalize(expr)
+}
+
+/// Rewrite `expr` as symbolic polar form `r * Exp(I * theta)`.
+///
+/// For expressions containing the imaginary unit, this returns:
+///
+/// ```text
+/// Mul(Sqrt(Add(Pow(real, 2), Pow(imag, 2))),
+///     Exp(Mul(I, Atan2(imag, real))))
+/// ```
+///
+/// Pure real/symbolic inputs mirror the Python reference by returning an
+/// unevaluated `PolarForm(expr)` node.
+pub fn polar_form(expr: &IRNode) -> IRNode {
+    if !contains_imaginary(expr) {
+        return apply(sym(POLAR_FORM), vec![expr.clone()]);
+    }
+
+    let normalized = complex_normalize(expr);
+    let (real, imag) = split_complex(&normalized);
+    let two = int(2);
+    let radius = apply(
+        sym(SQRT),
+        vec![apply(
+            sym(ADD),
+            vec![
+                apply(sym(POW), vec![real.clone(), two.clone()]),
+                apply(sym(POW), vec![imag.clone(), two]),
+            ],
+        )],
+    );
+    let theta = apply(sym(ATAN2), vec![imag, real]);
+    apply(
+        sym(MUL),
+        vec![
+            radius,
+            apply(
+                sym(EXP),
+                vec![apply(sym(MUL), vec![sym(IMAGINARY_UNIT), theta])],
+            ),
+        ],
+    )
+}
 
 // ---------------------------------------------------------------------------
 // Modulus
@@ -112,5 +162,13 @@ fn to_float(n: &IRNode) -> Option<f64> {
         IRNode::Float(v) => Some(*v),
         IRNode::Rational(numer, denom) => Some(*numer as f64 / *denom as f64),
         _ => None,
+    }
+}
+
+fn contains_imaginary(expr: &IRNode) -> bool {
+    match expr {
+        IRNode::Symbol(name) => name == IMAGINARY_UNIT,
+        IRNode::Apply(a) => a.args.iter().any(contains_imaginary),
+        _ => false,
     }
 }

--- a/code/packages/rust/cas-complex/tests/tests.rs
+++ b/code/packages/rust/cas-complex/tests/tests.rs
@@ -1,15 +1,26 @@
 // Integration tests for cas-complex.
 
 use cas_complex::{
-    argument, complex_normalize, complex_pow, conjugate, imag_part, modulus, real_part,
-    IMAGINARY_UNIT,
+    argument, complex_normalize, complex_pow, conjugate, imag_part, modulus, polar_form, real_part,
+    rect_form, IMAGINARY_UNIT, POLAR_FORM,
 };
-use symbolic_ir::{apply, int, sym, IRNode, ADD, MUL, NEG, POW, SUB};
 use std::f64::consts::{FRAC_PI_2, PI};
+use symbolic_ir::{apply, int, sym, IRNode, ADD, EXP, MUL, NEG, POW, SQRT, SUB};
 
 // Helper: build 3 + 4*I
 fn z_3_4() -> IRNode {
-    apply(sym(ADD), vec![int(3), apply(sym(MUL), vec![int(4), sym(IMAGINARY_UNIT)])])
+    apply(
+        sym(ADD),
+        vec![int(3), apply(sym(MUL), vec![int(4), sym(IMAGINARY_UNIT)])],
+    )
+}
+
+// Helper: build 1 + 2*I
+fn z_1_2() -> IRNode {
+    apply(
+        sym(ADD),
+        vec![int(1), apply(sym(MUL), vec![int(2), sym(IMAGINARY_UNIT)])],
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +100,10 @@ fn normalize_i_pow_neg1_is_neg_i() {
 fn normalize_mul_two_complex() {
     // (1 + I) * (1 - I) = 1 - I + I - I^2 = 1 + 1 = 2
     let a = apply(sym(ADD), vec![int(1), sym(IMAGINARY_UNIT)]);
-    let b = apply(sym(ADD), vec![int(1), apply(sym(NEG), vec![sym(IMAGINARY_UNIT)])]);
+    let b = apply(
+        sym(ADD),
+        vec![int(1), apply(sym(NEG), vec![sym(IMAGINARY_UNIT)])],
+    );
     let product = apply(sym(MUL), vec![a, b]);
     let r = complex_normalize(&product);
     assert_eq!(real_part(&r), int(2));
@@ -120,7 +134,10 @@ fn normalize_3_4i_times_1_minus_2i() {
     // (3 + 4i)(1 - 2i) = 3 - 6i + 4i - 8i^2 = 3 - 2i + 8 = 11 - 2i
     let a = z_3_4();
     // 1 - 2*I as Sub(1, Mul(2, I))
-    let b = apply(sym(SUB), vec![int(1), apply(sym(MUL), vec![int(2), sym(IMAGINARY_UNIT)])]);
+    let b = apply(
+        sym(SUB),
+        vec![int(1), apply(sym(MUL), vec![int(2), sym(IMAGINARY_UNIT)])],
+    );
     let product = apply(sym(MUL), vec![a, b]);
     let r = complex_normalize(&product);
     assert_eq!(real_part(&r), int(11));
@@ -259,6 +276,54 @@ fn argument_of_i_is_pi_over_2() {
     } else {
         panic!("expected Float");
     }
+}
+
+// ---------------------------------------------------------------------------
+// rect_form / polar_form
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rect_form_normalizes_1_plus_2i() {
+    let result = rect_form(&z_1_2());
+    assert_eq!(real_part(&result), int(1));
+    assert_eq!(imag_part(&result), int(2));
+}
+
+#[test]
+fn polar_form_3_plus_4i_returns_symbolic_radius_and_angle() {
+    let expected = apply(
+        sym(MUL),
+        vec![
+            apply(
+                sym(SQRT),
+                vec![apply(
+                    sym(ADD),
+                    vec![
+                        apply(sym(POW), vec![int(3), int(2)]),
+                        apply(sym(POW), vec![int(4), int(2)]),
+                    ],
+                )],
+            ),
+            apply(
+                sym(EXP),
+                vec![apply(
+                    sym(MUL),
+                    vec![
+                        sym(IMAGINARY_UNIT),
+                        apply(sym("Atan2"), vec![int(4), int(3)]),
+                    ],
+                )],
+            ),
+        ],
+    );
+
+    assert_eq!(polar_form(&z_3_4()), expected);
+}
+
+#[test]
+fn polar_form_symbolic_real_returns_unevaluated_wrapper() {
+    let x = sym("x");
+    assert_eq!(polar_form(&x), apply(sym(POLAR_FORM), vec![x]));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add public rect_form and polar_form APIs for Rust cas-complex
- mirror the Python PolarForm structure with Sqrt/Add/Pow radius and Atan2 angle
- export RectForm/PolarForm-related constants and add focused tests/docs

## Validation
- cargo fmt -p cas-complex
- cargo test -p cas-complex
- cargo check -p cas-complex