### PR TITLE
Add TypeScript trigReduce parity

### DIFF
--- a/code/packages/typescript/cas-trig/CHANGELOG.md
+++ b/code/packages/typescript/cas-trig/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add `trigReduce` parity for Python `cas_trig.trig_reduce` power/product
+  reductions through degree 6, while keeping `powerReduce` as a compatibility
+  wrapper.
+
 ## 0.1.0
 
 - Port trigonometric special values, numeric evaluation, simplification,

--- a/code/packages/typescript/cas-trig/README.md
+++ b/code/packages/typescript/cas-trig/README.md
@@ -11,7 +11,8 @@ package mirrors the Rust `cas-trig` crate and runs without native bindings.
 | `atanEval`, `asinEval`, `acosEval` | Numeric inverse trig evaluation with symbolic fallback |
 | `trigSimplify(expr)` | Bottom-up simplification of trig nodes |
 | `expandTrig(expr)` | Angle-addition and double-angle expansion for `Sin`/`Cos` |
-| `powerReduce(expr)` | Half-angle reduction for `Sin(x)^2` and `Cos(x)^2` |
+| `trigReduce(expr)` | Power and product reductions for `Sin`/`Cos`, including powers through degree 6 |
+| `powerReduce(expr)` | Compatibility alias for `trigReduce(expr)` |
 | `extractPiMultiple(expr)` | Recognize `(n/d) * Pi` shapes |
 
 Special values are exact for rational multiples of `Pi` with reduced

--- a/code/packages/typescript/cas-trig/src/index.ts
+++ b/code/packages/typescript/cas-trig/src/index.ts
@@ -175,14 +175,111 @@ export function expandTrig(expr: IRNode): IRNode {
 }
 
 export function powerReduce(expr: IRNode): IRNode {
-  if (expr.kind !== "apply") return expr;
-  if (headName(expr.head) === "Pow" && expr.args.length === 2 && equals(expr.args[1], int(2))) {
-    const sinArg = unaryArg(expr.args[0], "Sin");
-    if (sinArg !== null) return sinSquared(sinArg);
-    const cosArg = unaryArg(expr.args[0], "Cos");
-    if (cosArg !== null) return cosSquared(cosArg);
+  return trigReduce(expr);
+}
+
+export function trigReduce(expr: IRNode): IRNode {
+  let current = expr;
+  for (let i = 0; i < 20; i += 1) {
+    const next = reduceWalk(current);
+    if (equals(next, current)) return next;
+    current = next;
   }
-  return app(expr.head, expr.args.map(powerReduce));
+  return current;
+}
+
+function reduceWalk(expr: IRNode): IRNode {
+  if (expr.kind !== "apply") return expr;
+  const reducedArgs = expr.args.map(reduceWalk);
+  const name = headName(expr.head);
+
+  if (name === "Pow" && reducedArgs.length === 2) {
+    const [base, exponent] = reducedArgs;
+    if (exponent.kind === "integer" && exponent.value >= 2n && exponent.value <= 6n) {
+      const reducedPower = reduceTrigPower(base, Number(exponent.value));
+      if (reducedPower !== null) return reducedPower;
+    }
+  }
+
+  if (name === "Mul") {
+    const product = reduceSinCosProduct(reducedArgs);
+    if (product !== null) return product;
+  }
+
+  return app(expr.head, reducedArgs);
+}
+
+function reduceTrigPower(base: IRNode, exponent: number): IRNode | null {
+  const sinArg = unaryArg(base, "Sin");
+  if (sinArg !== null) return sinPower(sinArg, exponent);
+  const cosArg = unaryArg(base, "Cos");
+  if (cosArg !== null) return cosPower(cosArg, exponent);
+  return null;
+}
+
+function sinPower(x: IRNode, exponent: number): IRNode | null {
+  switch (exponent) {
+    case 2:
+      return sinSquared(x);
+    case 3:
+      return frac(sub(mul(int(3), app(SIN, [x])), sinNx(3, x)), 4);
+    case 4:
+      return frac(add(sub(int(3), mul(int(4), cosNx(2, x))), cosNx(4, x)), 8);
+    case 5:
+      return frac(add(sub(mul(int(10), app(SIN, [x])), mul(int(5), sinNx(3, x))), sinNx(5, x)), 16);
+    case 6:
+      return frac(sub(add(sub(int(10), mul(int(15), cosNx(2, x))), mul(int(6), cosNx(4, x))), cosNx(6, x)), 32);
+    default:
+      return null;
+  }
+}
+
+function cosPower(x: IRNode, exponent: number): IRNode | null {
+  switch (exponent) {
+    case 2:
+      return cosSquared(x);
+    case 3:
+      return frac(add(mul(int(3), app(COS, [x])), cosNx(3, x)), 4);
+    case 4:
+      return frac(add(add(int(3), mul(int(4), cosNx(2, x))), cosNx(4, x)), 8);
+    case 5:
+      return frac(add(add(mul(int(10), app(COS, [x])), mul(int(5), cosNx(3, x))), cosNx(5, x)), 16);
+    case 6:
+      return frac(add(add(add(int(10), mul(int(15), cosNx(2, x))), mul(int(6), cosNx(4, x))), cosNx(6, x)), 32);
+    default:
+      return null;
+  }
+}
+
+function reduceSinCosProduct(args: readonly IRNode[]): IRNode | null {
+  if (args.length < 2) return null;
+
+  let sinArg: IRNode | null = null;
+  let cosArg: IRNode | null = null;
+  const other: IRNode[] = [];
+
+  for (const arg of args) {
+    if (sinArg === null) {
+      const currentSinArg = unaryArg(arg, "Sin");
+      if (currentSinArg !== null) {
+        sinArg = currentSinArg;
+        continue;
+      }
+    }
+    if (cosArg === null) {
+      const currentCosArg = unaryArg(arg, "Cos");
+      if (currentCosArg !== null) {
+        cosArg = currentCosArg;
+        continue;
+      }
+    }
+    other.push(arg);
+  }
+
+  if (sinArg === null || cosArg === null || !equals(sinArg, cosArg)) return null;
+
+  const halfSinDoubleAngle = frac(sinNx(2, sinArg), 2);
+  return other.length === 0 ? halfSinDoubleAngle : app(MUL, [...other, halfSinDoubleAngle]);
 }
 
 function sinNumeric(value: number): IRNode {
@@ -296,17 +393,27 @@ function extractDoubleAngle(args: readonly IRNode[]): IRNode | null {
 }
 
 function sinSquared(inner: IRNode): IRNode {
-  const innerReduced = powerReduce(inner);
-  return app(MUL, [rational(1, 2), app(SUB, [int(1), app(COS, [app(MUL, [int(2), innerReduced])])])]);
+  return frac(app(SUB, [int(1), cosNx(2, inner)]), 2);
 }
 
 function cosSquared(inner: IRNode): IRNode {
-  const innerReduced = powerReduce(inner);
-  return app(MUL, [rational(1, 2), app(ADD, [int(1), app(COS, [app(MUL, [int(2), innerReduced])])])]);
+  return frac(app(ADD, [int(1), cosNx(2, inner)]), 2);
 }
 
 function unaryArg(node: IRNode, name: string): IRNode | null {
   return node.kind === "apply" && headName(node.head) === name && node.args.length === 1 ? node.args[0] : null;
+}
+
+function sinNx(n: number, x: IRNode): IRNode {
+  return app(SIN, [mul(int(n), x)]);
+}
+
+function cosNx(n: number, x: IRNode): IRNode {
+  return app(COS, [mul(int(n), x)]);
+}
+
+function frac(numerator: IRNode, denominator: number): IRNode {
+  return app(MUL, [rational(1, denominator), numerator]);
 }
 
 function add(a: IRNode, b: IRNode): IRNode {

--- a/code/packages/typescript/cas-trig/tests/cas-trig.test.ts
+++ b/code/packages/typescript/cas-trig/tests/cas-trig.test.ts
@@ -10,6 +10,7 @@ import {
   powerReduce,
   sinEval,
   tanEval,
+  trigReduce,
   trigSimplify,
 } from "../src/index";
 import {
@@ -178,5 +179,115 @@ describe("powerReduce", () => {
       expect(equals(result.head, ADD)).toBe(true);
       expect(result.args.every((arg) => arg.kind === "apply" && equals(arg.head, MUL))).toBe(true);
     }
+  });
+});
+
+describe("trigReduce", () => {
+  it("keeps powerReduce-compatible square reductions", () => {
+    const x = sym("x");
+    const cos2x = app(COS, [app(MUL, [int(2), x])]);
+    expect(equals(trigReduce(app(POW, [app(SIN, [x]), int(2)])), app(MUL, [rational(1, 2), app(SUB, [int(1), cos2x])]))).toBe(true);
+    expect(equals(trigReduce(app(POW, [app(COS, [x]), int(2)])), app(MUL, [rational(1, 2), app(ADD, [int(1), cos2x])]))).toBe(true);
+  });
+
+  it("reduces cubic trig powers to multiple-angle forms", () => {
+    const x = sym("x");
+    expect(equals(trigReduce(app(POW, [app(SIN, [x]), int(3)])), app(MUL, [
+      rational(1, 4),
+      app(SUB, [
+        app(MUL, [int(3), app(SIN, [x])]),
+        app(SIN, [app(MUL, [int(3), x])]),
+      ]),
+    ]))).toBe(true);
+    expect(equals(trigReduce(app(POW, [app(COS, [x]), int(3)])), app(MUL, [
+      rational(1, 4),
+      app(ADD, [
+        app(MUL, [int(3), app(COS, [x])]),
+        app(COS, [app(MUL, [int(3), x])]),
+      ]),
+    ]))).toBe(true);
+  });
+
+  it("reduces fourth, fifth, and sixth powers", () => {
+    const x = sym("x");
+    expect(equals(trigReduce(app(POW, [app(SIN, [x]), int(4)])), app(MUL, [
+      rational(1, 8),
+      app(ADD, [
+        app(SUB, [int(3), app(MUL, [int(4), app(COS, [app(MUL, [int(2), x])])])]),
+        app(COS, [app(MUL, [int(4), x])]),
+      ]),
+    ]))).toBe(true);
+    expect(equals(trigReduce(app(POW, [app(COS, [x]), int(5)])), app(MUL, [
+      rational(1, 16),
+      app(ADD, [
+        app(ADD, [
+          app(MUL, [int(10), app(COS, [x])]),
+          app(MUL, [int(5), app(COS, [app(MUL, [int(3), x])])]),
+        ]),
+        app(COS, [app(MUL, [int(5), x])]),
+      ]),
+    ]))).toBe(true);
+    expect(equals(trigReduce(app(POW, [app(SIN, [x]), int(6)])), app(MUL, [
+      rational(1, 32),
+      app(SUB, [
+        app(ADD, [
+          app(SUB, [int(10), app(MUL, [int(15), app(COS, [app(MUL, [int(2), x])])])]),
+          app(MUL, [int(6), app(COS, [app(MUL, [int(4), x])])]),
+        ]),
+        app(COS, [app(MUL, [int(6), x])]),
+      ]),
+    ]))).toBe(true);
+  });
+
+  it("reduces sin-cos products and preserves scalar multipliers", () => {
+    const x = sym("x");
+    expect(equals(trigReduce(app(MUL, [app(SIN, [x]), app(COS, [x])])), app(MUL, [
+      rational(1, 2),
+      app(SIN, [app(MUL, [int(2), x])]),
+    ]))).toBe(true);
+    expect(equals(trigReduce(app(MUL, [int(5), app(SIN, [x]), app(COS, [x])])), app(MUL, [
+      int(5),
+      app(MUL, [rational(1, 2), app(SIN, [app(MUL, [int(2), x])])]),
+    ]))).toBe(true);
+  });
+
+  it("recurses through nested expressions until stable", () => {
+    const x = sym("x");
+    const y = sym("y");
+    const expr = app(ADD, [
+      app(POW, [app(SIN, [app(POW, [app(COS, [x]), int(2)])]), int(2)]),
+      app(MUL, [app(SIN, [y]), app(COS, [y]), app(SIN, [x]), app(COS, [x])]),
+    ]);
+    const result = trigReduce(expr);
+
+    expect(equals(result, expr)).toBe(false);
+    expect(equals(result, app(ADD, [
+      app(MUL, [
+        rational(1, 2),
+        app(SUB, [
+          int(1),
+          app(COS, [
+            app(MUL, [
+              int(2),
+              app(MUL, [rational(1, 2), app(ADD, [int(1), app(COS, [app(MUL, [int(2), x])])])]),
+            ]),
+          ]),
+        ]),
+      ]),
+      app(MUL, [
+        app(MUL, [rational(1, 2), app(SIN, [app(MUL, [int(2), y])])]),
+        app(MUL, [rational(1, 2), app(SIN, [app(MUL, [int(2), x])])]),
+      ]),
+    ]))).toBe(true);
+  });
+
+  it("leaves powers greater than six unchanged after reducing children", () => {
+    const x = sym("x");
+    const expr = app(POW, [app(SIN, [x]), int(7)]);
+    expect(equals(trigReduce(expr), expr)).toBe(true);
+    expect(equals(trigReduce(app(POW, [app(SIN, [app(POW, [app(COS, [x]), int(2)])]), int(7)])), app(POW, [
+      app(SIN, [app(MUL, [rational(1, 2), app(ADD, [int(1), app(COS, [app(MUL, [int(2), x])])])])]),
+      int(7),
+    ]))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add exported trigReduce with recursive trig power reductions through degree 6
- keep powerReduce as a compatibility wrapper over trigReduce
- add product-to-sum, scalar product, nested recursion, and >6 passthrough tests
- update cas-trig README and changelog

## Validation
- npm install
- npm run build
- npm test
- npm run test:coverage