### PR TITLE
Port trig reduce parity to Rust cas-trig

### DIFF
--- a/code/packages/rust/cas-trig/CHANGELOG.md
+++ b/code/packages/rust/cas-trig/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — cas-trig (Rust)
 
+## Unreleased
+
+### Added
+
+- `trig_reduce(expr)` — recursively rewrites `Pow(Sin(x), n)` and
+  `Pow(Cos(x), n)` for `2 <= n <= 6`, plus matching `Sin(x) * Cos(x)`
+  products, to deterministic multiple-angle IR forms.
+
+### Changed
+
+- `power_reduce(expr)` is now a compatibility wrapper around `trig_reduce(expr)`.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-trig/README.md
+++ b/code/packages/rust/cas-trig/README.md
@@ -1,7 +1,7 @@
 # cas-trig (Rust)
 
 Symbolic trigonometry operations over the shared CAS IR: exact special
-values, numeric evaluation, angle-addition expansion, and power reduction.
+values, numeric evaluation, angle-addition expansion, and trig reduction.
 
 ## Operations
 
@@ -15,7 +15,8 @@ values, numeric evaluation, angle-addition expansion, and power reduction.
 | `acos_eval(arg)` | Evaluate `acos(arg)` — numeric, unevaluated out-of-domain |
 | `trig_simplify(expr)` | Walk a tree and evaluate all trig nodes |
 | `expand_trig(expr)` | Expand `sin/cos(a±b)` via angle-addition formulas |
-| `power_reduce(expr)` | Reduce `sin²/cos²` to half-angle forms |
+| `trig_reduce(expr)` | Reduce `sinⁿ/cosⁿ` for n ≤ 6 and `sin(x)cos(x)` to multiple-angle forms |
+| `power_reduce(expr)` | Compatibility wrapper for `trig_reduce(expr)` |
 
 ## Special-value table
 
@@ -47,7 +48,7 @@ Each `*_eval` function applies three tiers in order:
 ## Usage
 
 ```rust
-use cas_trig::{sin_eval, cos_eval, tan_eval, expand_trig, power_reduce, PI};
+use cas_trig::{sin_eval, cos_eval, tan_eval, expand_trig, trig_reduce, PI};
 use symbolic_ir::{apply, int, rat, sym, SIN, POW, MUL};
 
 // sin(π/6) = 1/2  (exact)
@@ -63,7 +64,7 @@ let _expanded = expand_trig(&expr);
 
 // sin²(x) → half-angle form
 let sin_sq = apply(sym(POW), vec![apply(sym(SIN), vec![sym("x")]), int(2)]);
-let _reduced = power_reduce(&sin_sq);
+let _reduced = trig_reduce(&sin_sq);
 ```
 
 ## Stack position

--- a/code/packages/rust/cas-trig/src/expand.rs
+++ b/code/packages/rust/cas-trig/src/expand.rs
@@ -157,9 +157,7 @@ fn expand_cos(arg: &IRNode) -> IRNode {
             add(mul(cos_a, cos_b), mul(sin_a, sin_b))
         }
         // cos(−a) = cos(a)
-        IRNode::Apply(a) if is_head(&a.head, "Neg") && a.args.len() == 1 => {
-            expand_cos(&a.args[0])
-        }
+        IRNode::Apply(a) if is_head(&a.head, "Neg") && a.args.len() == 1 => expand_cos(&a.args[0]),
         // cos(2·a) = cos²(a) − sin²(a)
         IRNode::Apply(a) if is_head(&a.head, "Mul") && a.args.len() == 2 => {
             if let Some(inner) = extract_double_angle(&a.args) {

--- a/code/packages/rust/cas-trig/src/lib.rs
+++ b/code/packages/rust/cas-trig/src/lib.rs
@@ -9,7 +9,7 @@
 //! | **Special values** | `sin(π/6)`, `cos(π/4)`, `tan(π/3)` etc. returned as exact `Integer`, `Rational`, or `Sqrt(…)` IR nodes |
 //! | **Numeric evaluation** | Any fully-numeric argument (Integer, Float, Rational, or `Pi`) → `Float` with near-integer snapping |
 //! | **Angle addition** | `sin(a±b)` and `cos(a±b)` expanded via the angle-addition identities (opt-in via `expand_trig`) |
-//! | **Power reduction** | `sin²(x)` and `cos²(x)` rewritten to half-angle forms (opt-in via `power_reduce`) |
+//! | **Trig reduction** | `sinⁿ(x)` and `cosⁿ(x)` for n ≤ 6, plus `sin(x)cos(x)`, rewritten to multiple-angle forms (opt-in via `trig_reduce`) |
 //! | **Tree walker** | `trig_simplify` applies evaluation rules everywhere in an expression tree |
 //!
 //! ## Special-value table
@@ -31,7 +31,7 @@
 //!
 //! ```rust
 //! use cas_trig::{sin_eval, cos_eval, tan_eval, trig_simplify, expand_trig,
-//!                power_reduce, PI};
+//!                trig_reduce, PI};
 //! use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, COS, MUL, POW, SIN};
 //!
 //! // sin(π/6) = 1/2 (exact)
@@ -58,7 +58,7 @@
 //!
 //! // Reduce sin²(x)
 //! let sin_sq = apply(sym(POW), vec![apply(sym(SIN), vec![sym("x")]), int(2)]);
-//! let _reduced = power_reduce(&sin_sq);
+//! let _reduced = trig_reduce(&sin_sq);
 //! ```
 
 pub mod constants;
@@ -72,7 +72,7 @@ pub mod special;
 pub use constants::{E_SYMBOL as E, PI_SYMBOL as PI};
 pub use expand::expand_trig;
 pub use numeric::to_float;
-pub use reduce::power_reduce;
+pub use reduce::{power_reduce, trig_reduce};
 pub use simplify::{
     acos_eval, asin_eval, atan_eval, cos_eval, extract_pi_multiple, sin_eval, tan_eval,
     trig_simplify,

--- a/code/packages/rust/cas-trig/src/reduce.rs
+++ b/code/packages/rust/cas-trig/src/reduce.rs
@@ -1,50 +1,43 @@
-//! Power-reduction identities for sin² and cos².
+//! TrigReduce identities for powers and simple products.
 //!
-//! The half-angle identities rewrite squared trig functions into expressions
-//! involving `cos(2x)`, removing the power:
+//! The reduction identities rewrite powers of trig functions into multiple-angle
+//! expressions, removing powers where this package has explicit formulas:
 //!
 //! ```text
 //! sin²(x) = (1 − cos(2x)) / 2  =  Mul(1/2, Sub(1, Cos(Mul(2, x))))
 //! cos²(x) = (1 + cos(2x)) / 2  =  Mul(1/2, Add(1, Cos(Mul(2, x))))
-//! ```
-//!
-//! ## Derivation
-//!
-//! Both identities follow from the double-angle formula:
-//!
-//! ```text
-//! cos(2x) = 1 − 2·sin²(x)   ⟹   sin²(x) = (1 − cos(2x)) / 2
-//! cos(2x) = 2·cos²(x) − 1   ⟹   cos²(x) = (1 + cos(2x)) / 2
+//! sin³(x) = (3sin(x) − sin(3x)) / 4
+//! cos³(x) = (3cos(x) + cos(3x)) / 4
+//! sin(x)cos(x) = sin(2x) / 2
 //! ```
 //!
 //! ## Scope
 //!
-//! `power_reduce` applies only to `Pow(Sin(x), 2)` and `Pow(Cos(x), 2)`.
-//! Higher powers (e.g. `sin⁴(x)`) can be reduced by applying `power_reduce`
-//! multiple times, but the caller is responsible for iterating.  (Phase 5b
-//! of the integration roadmap handles the general `sinⁿ` case via the IBP
-//! reduction formula.)
+//! `trig_reduce` applies hard-coded exact formulas for `Sin(x)^n` and
+//! `Cos(x)^n` where `2 <= n <= 6`, plus the product-to-sum identity for
+//! `Sin(x) * Cos(x)` with the same argument. Powers above 6 are left as powers.
 //!
-//! The function traverses the full expression tree recursively so that nested
-//! trig powers inside a larger expression are also reduced.
+//! `power_reduce` remains available as a compatibility wrapper around
+//! `trig_reduce`.
 
-use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, COS, MUL, SUB};
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, COS, MUL, POW, SIN, SUB};
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Walk `expr` and reduce `sin²(x)` and `cos²(x)` to half-angle forms.
+/// Walk `expr` and reduce supported trig powers/products to multiple-angle forms.
 ///
-/// Applied to `Pow(Sin(…), 2)` → `Mul(1/2, Sub(1, Cos(Mul(2, …))))`,
-/// and to `Pow(Cos(…), 2)` → `Mul(1/2, Add(1, Cos(Mul(2, …))))`.
+/// Applies hard-coded formulas for `Pow(Sin(…), n)` and `Pow(Cos(…), n)`
+/// where `2 <= n <= 6`, and rewrites `Mul(Sin(x), Cos(x))` to
+/// `Mul(1/2, Sin(Mul(2, x)))`.
 ///
 /// All other expressions are recursed into unchanged.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use cas_trig::power_reduce;
+/// use cas_trig::trig_reduce;
 /// use symbolic_ir::{apply, int, rat, sym, ADD, COS, MUL, POW, SIN, SUB};
 ///
 /// // sin²(x) → (1 − cos(2x)) / 2
@@ -52,7 +45,7 @@ use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, COS, MUL, SUB};
 ///     apply(sym(SIN), vec![sym("x")]),
 ///     int(2),
 /// ]);
-/// let reduced = power_reduce(&sin_sq);
+/// let reduced = trig_reduce(&sin_sq);
 /// let expected = apply(sym(MUL), vec![
 ///     rat(1, 2),
 ///     apply(sym(SUB), vec![int(1), apply(sym(COS), vec![
@@ -60,58 +53,257 @@ use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, COS, MUL, SUB};
 /// ]);
 /// assert_eq!(reduced, expected);
 /// ```
-pub fn power_reduce(expr: &IRNode) -> IRNode {
+pub fn trig_reduce(expr: &IRNode) -> IRNode {
     match expr {
         IRNode::Apply(a) => {
             let head = match &a.head {
                 IRNode::Symbol(s) => s.as_str(),
                 _ => {
-                    let reduced: Vec<_> = a.args.iter().map(power_reduce).collect();
+                    let reduced: Vec<_> = a.args.iter().map(trig_reduce).collect();
                     return apply(a.head.clone(), reduced);
                 }
             };
 
-            // Pow(…, 2): check whether the base is Sin or Cos
-            if head == "Pow" && a.args.len() == 2 {
-                if a.args[1] == IRNode::Integer(2) {
-                    if let Some(inner) = extract_sin_arg(&a.args[0]) {
-                        return sin_squared(inner);
-                    }
-                    if let Some(inner) = extract_cos_arg(&a.args[0]) {
-                        return cos_squared(inner);
+            let reduced_args: Vec<_> = a.args.iter().map(trig_reduce).collect();
+
+            if head == POW && reduced_args.len() == 2 {
+                if let IRNode::Integer(n) = &reduced_args[1] {
+                    if *n >= 2 {
+                        if let Some(reduced) = reduce_power(&reduced_args[0], *n) {
+                            return reduced;
+                        }
                     }
                 }
             }
 
-            // Otherwise: recurse into args
-            let reduced: Vec<_> = a.args.iter().map(power_reduce).collect();
-            apply(a.head.clone(), reduced)
+            if head == MUL {
+                if let Some(reduced) = reduce_sin_cos_product(&reduced_args) {
+                    return reduced;
+                }
+            }
+
+            apply(a.head.clone(), reduced_args)
         }
         _ => expr.clone(),
     }
+}
+
+/// Compatibility alias for callers that imported the original sin²/cos² API.
+pub fn power_reduce(expr: &IRNode) -> IRNode {
+    trig_reduce(expr)
 }
 
 // ---------------------------------------------------------------------------
 // Reduction builders
 // ---------------------------------------------------------------------------
 
+fn reduce_power(base: &IRNode, n: i64) -> Option<IRNode> {
+    if let Some(inner) = extract_sin_arg(base) {
+        return sin_power(inner, n);
+    }
+    if let Some(inner) = extract_cos_arg(base) {
+        return cos_power(inner, n);
+    }
+    None
+}
+
+fn sin_power(inner: &IRNode, n: i64) -> Option<IRNode> {
+    match n {
+        2 => Some(sin_squared(inner)),
+        3 => Some(frac(
+            apply(
+                sym(SUB),
+                vec![
+                    apply(sym(MUL), vec![int(3), apply(sym(SIN), vec![inner.clone()])]),
+                    sin_nx(3, inner),
+                ],
+            ),
+            4,
+        )),
+        4 => Some(frac(
+            apply(
+                sym(ADD),
+                vec![
+                    apply(
+                        sym(SUB),
+                        vec![int(3), apply(sym(MUL), vec![int(4), cos_nx(2, inner)])],
+                    ),
+                    cos_nx(4, inner),
+                ],
+            ),
+            8,
+        )),
+        5 => Some(frac(
+            apply(
+                sym(ADD),
+                vec![
+                    apply(
+                        sym(SUB),
+                        vec![
+                            apply(
+                                sym(MUL),
+                                vec![int(10), apply(sym(SIN), vec![inner.clone()])],
+                            ),
+                            apply(sym(MUL), vec![int(5), sin_nx(3, inner)]),
+                        ],
+                    ),
+                    sin_nx(5, inner),
+                ],
+            ),
+            16,
+        )),
+        6 => Some(frac(
+            apply(
+                sym(SUB),
+                vec![
+                    apply(
+                        sym(ADD),
+                        vec![
+                            apply(
+                                sym(SUB),
+                                vec![int(10), apply(sym(MUL), vec![int(15), cos_nx(2, inner)])],
+                            ),
+                            apply(sym(MUL), vec![int(6), cos_nx(4, inner)]),
+                        ],
+                    ),
+                    cos_nx(6, inner),
+                ],
+            ),
+            32,
+        )),
+        _ => None,
+    }
+}
+
+fn cos_power(inner: &IRNode, n: i64) -> Option<IRNode> {
+    match n {
+        2 => Some(cos_squared(inner)),
+        3 => Some(frac(
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(MUL), vec![int(3), apply(sym(COS), vec![inner.clone()])]),
+                    cos_nx(3, inner),
+                ],
+            ),
+            4,
+        )),
+        4 => Some(frac(
+            apply(
+                sym(ADD),
+                vec![
+                    apply(
+                        sym(ADD),
+                        vec![int(3), apply(sym(MUL), vec![int(4), cos_nx(2, inner)])],
+                    ),
+                    cos_nx(4, inner),
+                ],
+            ),
+            8,
+        )),
+        5 => Some(frac(
+            apply(
+                sym(ADD),
+                vec![
+                    apply(
+                        sym(ADD),
+                        vec![
+                            apply(
+                                sym(MUL),
+                                vec![int(10), apply(sym(COS), vec![inner.clone()])],
+                            ),
+                            apply(sym(MUL), vec![int(5), cos_nx(3, inner)]),
+                        ],
+                    ),
+                    cos_nx(5, inner),
+                ],
+            ),
+            16,
+        )),
+        6 => Some(frac(
+            apply(
+                sym(ADD),
+                vec![
+                    apply(
+                        sym(ADD),
+                        vec![
+                            apply(
+                                sym(ADD),
+                                vec![int(10), apply(sym(MUL), vec![int(15), cos_nx(2, inner)])],
+                            ),
+                            apply(sym(MUL), vec![int(6), cos_nx(4, inner)]),
+                        ],
+                    ),
+                    cos_nx(6, inner),
+                ],
+            ),
+            32,
+        )),
+        _ => None,
+    }
+}
+
 /// `sin²(inner)` → `Mul(1/2, Sub(1, Cos(Mul(2, inner))))`
 fn sin_squared(inner: &IRNode) -> IRNode {
-    // First reduce any trig powers inside `inner` as well.
-    let inner_r = power_reduce(inner);
-    let double_arg = apply(sym(MUL), vec![int(2), inner_r]);
-    let cos_2x = apply(sym(COS), vec![double_arg]);
-    let numer = apply(sym(SUB), vec![int(1), cos_2x]);
-    apply(sym(MUL), vec![rat(1, 2), numer])
+    frac(apply(sym(SUB), vec![int(1), cos_nx(2, inner)]), 2)
 }
 
 /// `cos²(inner)` → `Mul(1/2, Add(1, Cos(Mul(2, inner))))`
 fn cos_squared(inner: &IRNode) -> IRNode {
-    let inner_r = power_reduce(inner);
-    let double_arg = apply(sym(MUL), vec![int(2), inner_r]);
-    let cos_2x = apply(sym(COS), vec![double_arg]);
-    let numer = apply(sym(ADD), vec![int(1), cos_2x]);
-    apply(sym(MUL), vec![rat(1, 2), numer])
+    frac(apply(sym(ADD), vec![int(1), cos_nx(2, inner)]), 2)
+}
+
+fn reduce_sin_cos_product(args: &[IRNode]) -> Option<IRNode> {
+    if args.len() < 2 {
+        return None;
+    }
+
+    let mut sin_arg: Option<&IRNode> = None;
+    let mut cos_arg: Option<&IRNode> = None;
+    let mut other = Vec::new();
+
+    for arg in args {
+        if sin_arg.is_none() {
+            if let Some(inner) = extract_sin_arg(arg) {
+                sin_arg = Some(inner);
+                continue;
+            }
+        }
+        if cos_arg.is_none() {
+            if let Some(inner) = extract_cos_arg(arg) {
+                cos_arg = Some(inner);
+                continue;
+            }
+        }
+        other.push(arg.clone());
+    }
+
+    let (Some(sin_arg), Some(cos_arg)) = (sin_arg, cos_arg) else {
+        return None;
+    };
+    if sin_arg != cos_arg {
+        return None;
+    }
+
+    let sin_2x_half = frac(sin_nx(2, sin_arg), 2);
+    if other.is_empty() {
+        return Some(sin_2x_half);
+    }
+
+    other.push(sin_2x_half);
+    Some(apply(sym(MUL), other))
+}
+
+fn sin_nx(n: i64, inner: &IRNode) -> IRNode {
+    apply(sym(SIN), vec![apply(sym(MUL), vec![int(n), inner.clone()])])
+}
+
+fn cos_nx(n: i64, inner: &IRNode) -> IRNode {
+    apply(sym(COS), vec![apply(sym(MUL), vec![int(n), inner.clone()])])
+}
+
+fn frac(numerator: IRNode, denominator: i64) -> IRNode {
+    apply(sym(MUL), vec![rat(1, denominator), numerator])
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-trig/src/simplify.rs
+++ b/code/packages/rust/cas-trig/src/simplify.rs
@@ -34,8 +34,9 @@
 use symbolic_ir::{apply, sym, IRNode, ACOS, ASIN, ATAN, COS, SIN, TAN};
 
 use crate::constants::PI_SYMBOL;
-use crate::numeric::{acos_numeric, asin_numeric, atan_numeric, cos_numeric, sin_numeric,
-                     tan_numeric, to_float};
+use crate::numeric::{
+    acos_numeric, asin_numeric, atan_numeric, cos_numeric, sin_numeric, tan_numeric, to_float,
+};
 use crate::special::{cos_at_pi_multiple, sin_at_pi_multiple, tan_at_pi_multiple};
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-trig/tests/tests.rs
+++ b/code/packages/rust/cas-trig/tests/tests.rs
@@ -1,7 +1,7 @@
 // Integration tests for cas-trig.
 
 use cas_trig::{
-    asin_eval, atan_eval, cos_eval, expand_trig, power_reduce, sin_eval, tan_eval,
+    asin_eval, atan_eval, cos_eval, expand_trig, power_reduce, sin_eval, tan_eval, trig_reduce,
     trig_simplify, PI,
 };
 use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, COS, MUL, NEG, POW, SIN, SQRT, SUB, TAN};
@@ -18,6 +18,30 @@ fn pi_mult(n: i64, d: i64) -> IRNode {
 /// Build `Sqrt(n)`.
 fn sqrt_of(n: i64) -> IRNode {
     apply(sym(SQRT), vec![int(n)])
+}
+
+fn sin_of(arg: IRNode) -> IRNode {
+    apply(sym(SIN), vec![arg])
+}
+
+fn cos_of(arg: IRNode) -> IRNode {
+    apply(sym(COS), vec![arg])
+}
+
+fn pow_of(base: IRNode, exp: i64) -> IRNode {
+    apply(sym(POW), vec![base, int(exp)])
+}
+
+fn sin_nx(n: i64, x: IRNode) -> IRNode {
+    sin_of(apply(sym(MUL), vec![int(n), x]))
+}
+
+fn cos_nx(n: i64, x: IRNode) -> IRNode {
+    cos_of(apply(sym(MUL), vec![int(n), x]))
+}
+
+fn frac(numerator: IRNode, denominator: i64) -> IRNode {
+    apply(sym(MUL), vec![rat(1, denominator), numerator])
 }
 
 // ---------------------------------------------------------------------------
@@ -423,10 +447,13 @@ fn trig_simplify_cos_of_pi() {
 #[test]
 fn trig_simplify_walks_into_add() {
     // Add(Sin(0), Cos(Pi)) → both trig nodes simplified
-    let expr = apply(sym(ADD), vec![
-        apply(sym(SIN), vec![int(0)]),
-        apply(sym(COS), vec![sym(PI)]),
-    ]);
+    let expr = apply(
+        sym(ADD),
+        vec![
+            apply(sym(SIN), vec![int(0)]),
+            apply(sym(COS), vec![sym(PI)]),
+        ],
+    );
     let result = trig_simplify(&expr);
     if let IRNode::Apply(a) = &result {
         assert_eq!(a.args[0], int(0));
@@ -446,10 +473,7 @@ fn trig_simplify_symbolic_stays_unevaluated() {
 #[test]
 fn trig_simplify_nested_cos_then_sin() {
     // Sin(Mul(1/2, Pi)) → 1, inside a Mul
-    let expr = apply(sym(MUL), vec![
-        int(3),
-        apply(sym(SIN), vec![pi_mult(1, 2)]),
-    ]);
+    let expr = apply(sym(MUL), vec![int(3), apply(sym(SIN), vec![pi_mult(1, 2)])]);
     let result = trig_simplify(&expr);
     if let IRNode::Apply(a) = &result {
         assert_eq!(a.head, sym(MUL));
@@ -466,76 +490,104 @@ fn trig_simplify_nested_cos_then_sin() {
 #[test]
 fn expand_sin_of_sum() {
     // sin(x + y) → sin(x)·cos(y) + cos(x)·sin(y)
-    let expr = apply(sym(SIN), vec![
-        apply(sym(ADD), vec![sym("x"), sym("y")])
-    ]);
-    let expected = apply(sym(ADD), vec![
-        apply(sym(MUL), vec![
-            apply(sym(SIN), vec![sym("x")]),
-            apply(sym(COS), vec![sym("y")]),
-        ]),
-        apply(sym(MUL), vec![
-            apply(sym(COS), vec![sym("x")]),
-            apply(sym(SIN), vec![sym("y")]),
-        ]),
-    ]);
+    let expr = apply(sym(SIN), vec![apply(sym(ADD), vec![sym("x"), sym("y")])]);
+    let expected = apply(
+        sym(ADD),
+        vec![
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(SIN), vec![sym("x")]),
+                    apply(sym(COS), vec![sym("y")]),
+                ],
+            ),
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(COS), vec![sym("x")]),
+                    apply(sym(SIN), vec![sym("y")]),
+                ],
+            ),
+        ],
+    );
     assert_eq!(expand_trig(&expr), expected);
 }
 
 #[test]
 fn expand_cos_of_sum() {
     // cos(x + y) → cos(x)·cos(y) - sin(x)·sin(y)
-    let expr = apply(sym(COS), vec![
-        apply(sym(ADD), vec![sym("x"), sym("y")])
-    ]);
-    let expected = apply(sym(SUB), vec![
-        apply(sym(MUL), vec![
-            apply(sym(COS), vec![sym("x")]),
-            apply(sym(COS), vec![sym("y")]),
-        ]),
-        apply(sym(MUL), vec![
-            apply(sym(SIN), vec![sym("x")]),
-            apply(sym(SIN), vec![sym("y")]),
-        ]),
-    ]);
+    let expr = apply(sym(COS), vec![apply(sym(ADD), vec![sym("x"), sym("y")])]);
+    let expected = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(COS), vec![sym("x")]),
+                    apply(sym(COS), vec![sym("y")]),
+                ],
+            ),
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(SIN), vec![sym("x")]),
+                    apply(sym(SIN), vec![sym("y")]),
+                ],
+            ),
+        ],
+    );
     assert_eq!(expand_trig(&expr), expected);
 }
 
 #[test]
 fn expand_sin_of_difference() {
     // sin(x - y) → sin(x)·cos(y) - cos(x)·sin(y)
-    let expr = apply(sym(SIN), vec![
-        apply(sym(SUB), vec![sym("x"), sym("y")])
-    ]);
-    let expected = apply(sym(SUB), vec![
-        apply(sym(MUL), vec![
-            apply(sym(SIN), vec![sym("x")]),
-            apply(sym(COS), vec![sym("y")]),
-        ]),
-        apply(sym(MUL), vec![
-            apply(sym(COS), vec![sym("x")]),
-            apply(sym(SIN), vec![sym("y")]),
-        ]),
-    ]);
+    let expr = apply(sym(SIN), vec![apply(sym(SUB), vec![sym("x"), sym("y")])]);
+    let expected = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(SIN), vec![sym("x")]),
+                    apply(sym(COS), vec![sym("y")]),
+                ],
+            ),
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(COS), vec![sym("x")]),
+                    apply(sym(SIN), vec![sym("y")]),
+                ],
+            ),
+        ],
+    );
     assert_eq!(expand_trig(&expr), expected);
 }
 
 #[test]
 fn expand_cos_of_difference() {
     // cos(x - y) → cos(x)·cos(y) + sin(x)·sin(y)
-    let expr = apply(sym(COS), vec![
-        apply(sym(SUB), vec![sym("x"), sym("y")])
-    ]);
-    let expected = apply(sym(ADD), vec![
-        apply(sym(MUL), vec![
-            apply(sym(COS), vec![sym("x")]),
-            apply(sym(COS), vec![sym("y")]),
-        ]),
-        apply(sym(MUL), vec![
-            apply(sym(SIN), vec![sym("x")]),
-            apply(sym(SIN), vec![sym("y")]),
-        ]),
-    ]);
+    let expr = apply(sym(COS), vec![apply(sym(SUB), vec![sym("x"), sym("y")])]);
+    let expected = apply(
+        sym(ADD),
+        vec![
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(COS), vec![sym("x")]),
+                    apply(sym(COS), vec![sym("y")]),
+                ],
+            ),
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(SIN), vec![sym("x")]),
+                    apply(sym(SIN), vec![sym("y")]),
+                ],
+            ),
+        ],
+    );
     assert_eq!(expand_trig(&expr), expected);
 }
 
@@ -558,31 +610,36 @@ fn expand_cos_of_neg() {
 #[test]
 fn expand_sin_double_angle() {
     // sin(2*x) → 2*sin(x)*cos(x)
-    let expr = apply(sym(SIN), vec![
-        apply(sym(MUL), vec![int(2), sym("x")])
-    ]);
-    let expected = apply(sym(MUL), vec![
-        int(2),
-        apply(sym(MUL), vec![
-            apply(sym(SIN), vec![sym("x")]),
-            apply(sym(COS), vec![sym("x")]),
-        ]),
-    ]);
+    let expr = apply(sym(SIN), vec![apply(sym(MUL), vec![int(2), sym("x")])]);
+    let expected = apply(
+        sym(MUL),
+        vec![
+            int(2),
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(SIN), vec![sym("x")]),
+                    apply(sym(COS), vec![sym("x")]),
+                ],
+            ),
+        ],
+    );
     assert_eq!(expand_trig(&expr), expected);
 }
 
 #[test]
 fn expand_cos_double_angle() {
     // cos(2*x) → cos(x)^2 - sin(x)^2  [represented as Mul(Cos(x), Cos(x)) - Mul(Sin(x), Sin(x))]
-    let expr = apply(sym(COS), vec![
-        apply(sym(MUL), vec![int(2), sym("x")])
-    ]);
+    let expr = apply(sym(COS), vec![apply(sym(MUL), vec![int(2), sym("x")])]);
     let sin_x = apply(sym(SIN), vec![sym("x")]);
     let cos_x = apply(sym(COS), vec![sym("x")]);
-    let expected = apply(sym(SUB), vec![
-        apply(sym(MUL), vec![cos_x.clone(), cos_x]),
-        apply(sym(MUL), vec![sin_x.clone(), sin_x]),
-    ]);
+    let expected = apply(
+        sym(SUB),
+        vec![
+            apply(sym(MUL), vec![cos_x.clone(), cos_x]),
+            apply(sym(MUL), vec![sin_x.clone(), sin_x]),
+        ],
+    );
     assert_eq!(expand_trig(&expr), expected);
 }
 
@@ -606,30 +663,24 @@ fn expand_atom_unchanged() {
 #[test]
 fn reduce_sin_squared() {
     // sin²(x) → (1 - cos(2x)) / 2  = Mul(1/2, Sub(1, Cos(Mul(2, x))))
-    let expr = apply(sym(POW), vec![
-        apply(sym(SIN), vec![sym("x")]),
-        int(2),
-    ]);
+    let expr = apply(sym(POW), vec![apply(sym(SIN), vec![sym("x")]), int(2)]);
     let cos_2x = apply(sym(COS), vec![apply(sym(MUL), vec![int(2), sym("x")])]);
-    let expected = apply(sym(MUL), vec![
-        rat(1, 2),
-        apply(sym(SUB), vec![int(1), cos_2x]),
-    ]);
+    let expected = apply(
+        sym(MUL),
+        vec![rat(1, 2), apply(sym(SUB), vec![int(1), cos_2x])],
+    );
     assert_eq!(power_reduce(&expr), expected);
 }
 
 #[test]
 fn reduce_cos_squared() {
     // cos²(x) → (1 + cos(2x)) / 2  = Mul(1/2, Add(1, Cos(Mul(2, x))))
-    let expr = apply(sym(POW), vec![
-        apply(sym(COS), vec![sym("x")]),
-        int(2),
-    ]);
+    let expr = apply(sym(POW), vec![apply(sym(COS), vec![sym("x")]), int(2)]);
     let cos_2x = apply(sym(COS), vec![apply(sym(MUL), vec![int(2), sym("x")])]);
-    let expected = apply(sym(MUL), vec![
-        rat(1, 2),
-        apply(sym(ADD), vec![int(1), cos_2x]),
-    ]);
+    let expected = apply(
+        sym(MUL),
+        vec![rat(1, 2), apply(sym(ADD), vec![int(1), cos_2x])],
+    );
     assert_eq!(power_reduce(&expr), expected);
 }
 
@@ -669,6 +720,205 @@ fn reduce_walks_into_add() {
 fn reduce_atom_unchanged() {
     assert_eq!(power_reduce(&int(7)), int(7));
     assert_eq!(power_reduce(&sym("y")), sym("y"));
+}
+
+#[test]
+fn trig_reduce_sin_cubed() {
+    // sin³(x) → (3sin(x) - sin(3x)) / 4
+    let x = sym("x");
+    let expr = pow_of(sin_of(x.clone()), 3);
+    let expected = frac(
+        apply(
+            sym(SUB),
+            vec![
+                apply(sym(MUL), vec![int(3), sin_of(x.clone())]),
+                sin_nx(3, x),
+            ],
+        ),
+        4,
+    );
+    assert_eq!(trig_reduce(&expr), expected);
+}
+
+#[test]
+fn trig_reduce_cos_cubed() {
+    // cos³(x) → (3cos(x) + cos(3x)) / 4
+    let x = sym("x");
+    let expr = pow_of(cos_of(x.clone()), 3);
+    let expected = frac(
+        apply(
+            sym(ADD),
+            vec![
+                apply(sym(MUL), vec![int(3), cos_of(x.clone())]),
+                cos_nx(3, x),
+            ],
+        ),
+        4,
+    );
+    assert_eq!(trig_reduce(&expr), expected);
+}
+
+#[test]
+fn trig_reduce_sin_fourth_and_fifth() {
+    let x = sym("x");
+    let sin_fourth = pow_of(sin_of(x.clone()), 4);
+    let expected_fourth = frac(
+        apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(SUB),
+                    vec![int(3), apply(sym(MUL), vec![int(4), cos_nx(2, x.clone())])],
+                ),
+                cos_nx(4, x.clone()),
+            ],
+        ),
+        8,
+    );
+    assert_eq!(trig_reduce(&sin_fourth), expected_fourth);
+
+    let sin_fifth = pow_of(sin_of(x.clone()), 5);
+    let expected_fifth = frac(
+        apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(SUB),
+                    vec![
+                        apply(sym(MUL), vec![int(10), sin_of(x.clone())]),
+                        apply(sym(MUL), vec![int(5), sin_nx(3, x.clone())]),
+                    ],
+                ),
+                sin_nx(5, x),
+            ],
+        ),
+        16,
+    );
+    assert_eq!(trig_reduce(&sin_fifth), expected_fifth);
+}
+
+#[test]
+fn trig_reduce_cos_fourth_and_fifth() {
+    let x = sym("x");
+    let cos_fourth = pow_of(cos_of(x.clone()), 4);
+    let expected_fourth = frac(
+        apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(ADD),
+                    vec![int(3), apply(sym(MUL), vec![int(4), cos_nx(2, x.clone())])],
+                ),
+                cos_nx(4, x.clone()),
+            ],
+        ),
+        8,
+    );
+    assert_eq!(trig_reduce(&cos_fourth), expected_fourth);
+
+    let cos_fifth = pow_of(cos_of(x.clone()), 5);
+    let expected_fifth = frac(
+        apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(sym(MUL), vec![int(10), cos_of(x.clone())]),
+                        apply(sym(MUL), vec![int(5), cos_nx(3, x.clone())]),
+                    ],
+                ),
+                cos_nx(5, x),
+            ],
+        ),
+        16,
+    );
+    assert_eq!(trig_reduce(&cos_fifth), expected_fifth);
+}
+
+#[test]
+fn trig_reduce_sixth_powers() {
+    let x = sym("x");
+    let sin_sixth = pow_of(sin_of(x.clone()), 6);
+    let expected_sin = frac(
+        apply(
+            sym(SUB),
+            vec![
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(
+                            sym(SUB),
+                            vec![
+                                int(10),
+                                apply(sym(MUL), vec![int(15), cos_nx(2, x.clone())]),
+                            ],
+                        ),
+                        apply(sym(MUL), vec![int(6), cos_nx(4, x.clone())]),
+                    ],
+                ),
+                cos_nx(6, x.clone()),
+            ],
+        ),
+        32,
+    );
+    assert_eq!(trig_reduce(&sin_sixth), expected_sin);
+
+    let cos_sixth = pow_of(cos_of(x.clone()), 6);
+    let expected_cos = frac(
+        apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(
+                            sym(ADD),
+                            vec![
+                                int(10),
+                                apply(sym(MUL), vec![int(15), cos_nx(2, x.clone())]),
+                            ],
+                        ),
+                        apply(sym(MUL), vec![int(6), cos_nx(4, x.clone())]),
+                    ],
+                ),
+                cos_nx(6, x),
+            ],
+        ),
+        32,
+    );
+    assert_eq!(trig_reduce(&cos_sixth), expected_cos);
+}
+
+#[test]
+fn trig_reduce_sin_cos_product() {
+    let x = sym("x");
+    let expr = apply(sym(MUL), vec![sin_of(x.clone()), cos_of(x.clone())]);
+    assert_eq!(trig_reduce(&expr), frac(sin_nx(2, x), 2));
+}
+
+#[test]
+fn trig_reduce_scalar_sin_cos_product() {
+    let x = sym("x");
+    let expr = apply(sym(MUL), vec![int(3), sin_of(x.clone()), cos_of(x.clone())]);
+    let expected = apply(sym(MUL), vec![int(3), frac(sin_nx(2, x), 2)]);
+    assert_eq!(trig_reduce(&expr), expected);
+}
+
+#[test]
+fn trig_reduce_nested_recursion() {
+    let y = sym("y");
+    let inner = pow_of(sin_of(y.clone()), 2);
+    let expr = apply(sym(ADD), vec![int(1), sin_of(inner)]);
+    let reduced_inner = frac(apply(sym(SUB), vec![int(1), cos_nx(2, y)]), 2);
+    let expected = apply(sym(ADD), vec![int(1), sin_of(reduced_inner)]);
+    assert_eq!(trig_reduce(&expr), expected);
+}
+
+#[test]
+fn trig_reduce_power_above_six_keeps_outer_power() {
+    let expr = pow_of(sin_of(sym("x")), 7);
+    assert_eq!(trig_reduce(&expr), expr);
 }
 
 // ---------------------------------------------------------------------------
@@ -730,9 +980,7 @@ fn angle_addition_sin_numerically() {
     // sin(a + b) = sin(a)cos(b) + cos(a)sin(b) — verify at a=1.1, b=0.7
     let a = IRNode::Float(1.1);
     let b = IRNode::Float(0.7);
-    let expr = apply(sym(SIN), vec![
-        apply(sym(ADD), vec![a.clone(), b.clone()])
-    ]);
+    let expr = apply(sym(SIN), vec![apply(sym(ADD), vec![a.clone(), b.clone()])]);
     let expanded = expand_trig(&expr);
     let direct: f64 = (1.1_f64 + 0.7).sin();
     check_near(&expanded, direct, 1e-10);
@@ -742,9 +990,7 @@ fn angle_addition_sin_numerically() {
 fn double_angle_sin_numerically() {
     // sin(2x) = 2*sin(x)*cos(x) — verify at x = 0.8
     let x = IRNode::Float(0.8);
-    let expr = apply(sym(SIN), vec![
-        apply(sym(MUL), vec![int(2), x.clone()])
-    ]);
+    let expr = apply(sym(SIN), vec![apply(sym(MUL), vec![int(2), x.clone()])]);
     let expanded = expand_trig(&expr);
     let direct: f64 = (2.0 * 0.8_f64).sin();
     check_near(&expanded, direct, 1e-10);


### PR DESCRIPTION
## Summary
- add public trig_reduce and keep power_reduce as a compatibility wrapper
- port hard-coded Sin/Cos power reductions through degree 6 plus Sin(x)Cos(x) product-to-sum handling
- add focused cas-trig tests for higher powers, products, scalar passthrough, recursion, and >6 passthrough

## Validation
- cargo fmt -p cas-trig
- cargo test -p cas-trig
- cargo check -p cas-trig