### PR TITLE
Expose Board VM Bluetooth backend plans to languages

### DIFF
--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -70,6 +70,10 @@ function M.bluetooth_endpoint(endpoint)
     return native().bluetooth_endpoint(endpoint)
 end
 
+function M.bluetooth_backend(endpoint)
+    return native().bluetooth_backend(endpoint)
+end
+
 function M.bluetooth_devices()
     return native().bluetooth_devices()
 end
@@ -255,6 +259,75 @@ function TcpTransport:close()
 end
 
 M.TcpTransport = TcpTransport
+
+local BluetoothTransport = {}
+BluetoothTransport.__index = BluetoothTransport
+
+function BluetoothTransport.new(options)
+    options = options or {}
+    local endpoint = tostring(options.endpoint or "")
+    local backend = options.backend or M.bluetooth_backend(endpoint)
+    if backend == nil then
+        error("unsupported Board VM Bluetooth endpoint: " .. endpoint)
+    end
+    return setmetatable({
+        endpoint = endpoint,
+        timeout_ms = options.timeout_ms or 1000,
+        backend = backend,
+        stream_path = backend.stream_path,
+        file = nil,
+    }, BluetoothTransport)
+end
+
+function BluetoothTransport:status()
+    return self.backend.status
+end
+
+function BluetoothTransport:_io()
+    if self.file then
+        return self.file
+    end
+    if self.backend.status ~= "ready" or self.stream_path == nil or tostring(self.stream_path) == "" then
+        error("failed to open Board VM Bluetooth endpoint " ..
+            self.endpoint .. ": " .. tostring(self.backend.message or "Bluetooth backend is not ready"))
+    end
+    local file, err = io.open(self.stream_path, "r+b")
+    if file == nil then
+        error("failed to open Board VM Bluetooth stream " .. tostring(self.stream_path) .. ": " .. tostring(err))
+    end
+    self.file = file
+    return self.file
+end
+
+function BluetoothTransport:write(frame)
+    assert(self:_io():write(frame))
+    assert(self:_io():flush())
+end
+
+function BluetoothTransport:transact(frame, options)
+    options = options or {}
+    self:write(frame)
+    local chunks = {}
+    while true do
+        local byte = self:_io():read(1)
+        if byte == nil or byte == "" then
+            error("Board VM Bluetooth endpoint " .. self.endpoint .. " closed")
+        end
+        table.insert(chunks, byte)
+        if byte:byte(1) == 0 then
+            return table.concat(chunks)
+        end
+    end
+end
+
+function BluetoothTransport:close()
+    if self.file then
+        self.file:close()
+        self.file = nil
+    end
+end
+
+M.BluetoothTransport = BluetoothTransport
 
 local function clone_table(value)
     if type(value) ~= "table" then
@@ -577,6 +650,7 @@ function Connection.new(options)
         transport = options.transport,
         endpoint = options.endpoint,
         timeout_ms = options.timeout_ms or 1000,
+        bluetooth_backend_plan = options.bluetooth_backend_plan,
     }, Connection)
 end
 
@@ -627,6 +701,18 @@ function Connection:active_transport()
         self.transport = TcpTransport.new({
             endpoint = self.endpoint,
             timeout_ms = self.timeout_ms,
+        })
+        return self.transport
+    end
+    if connection_uses_bluetooth_endpoint(self.connection_option) then
+        if self.endpoint == nil or tostring(self.endpoint) == "" then
+            error((self.connection_option.display_name or "Board VM Bluetooth connection") ..
+                " requires a Board VM Bluetooth endpoint; pass endpoint = ... or choose via = \"serial\"")
+        end
+        self.transport = BluetoothTransport.new({
+            endpoint = self.endpoint,
+            timeout_ms = self.timeout_ms,
+            backend = self.bluetooth_backend_plan,
         })
         return self.transport
     end
@@ -702,6 +788,7 @@ function M.connect(selector, options)
         transport = options.transport,
         endpoint = endpoint,
         timeout_ms = options.timeout_ms,
+        bluetooth_backend_plan = options.bluetooth_backend_plan,
     })
 end
 

--- a/code/packages/lua/board_vm_native/src/lib.rs
+++ b/code/packages/lua/board_vm_native/src/lib.rs
@@ -8,6 +8,7 @@ use board_vm_host::{
     DEFAULT_RUN_FLAGS,
 };
 use board_vm_language_core::{
+    bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
     bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
     build_caps_query_wire_frame, build_hello_wire_frame, build_program_begin_wire_frame,
     build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_wire_frame,
@@ -16,10 +17,10 @@ use board_vm_language_core::{
     discover_devices_from_paths, esp_upload_options_for_target, host_endpoint_transport_name,
     known_targets, onboard_led_kind, parse_bluetooth_endpoint as core_parse_bluetooth_endpoint,
     pico_uf2_upload_options_for_target, wireless_transport_name, BoardVmLanguageSession,
-    BuiltWireFrame, LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
-    LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
-    LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
-    LanguageTargetInfo, LanguageWirelessInterface,
+    BuiltWireFrame, LanguageBluetoothBackendOpenPlan, LanguageBluetoothDiscoveredDevice,
+    LanguageBluetoothEndpoint, LanguageBluetoothEndpointCandidate, LanguageConnectionOption,
+    LanguageCoreError, LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed,
+    LanguagePicoUf2UploadOptions, LanguageTargetInfo, LanguageWirelessInterface,
 };
 use lua_bridge::{
     get_str, luaL_Reg, luaL_checkinteger, lua_Integer, lua_State, lua_createtable, lua_getfield,
@@ -357,6 +358,20 @@ unsafe fn push_bluetooth_endpoint(L: *mut lua_State, endpoint: &LanguageBluetoot
     push_optional_int(L, "channel", endpoint.channel);
 }
 
+unsafe fn push_bluetooth_backend_open_plan(
+    L: *mut lua_State,
+    plan: &LanguageBluetoothBackendOpenPlan,
+) {
+    lua_bridge::lua_newtable(L);
+    let key = CString::new("endpoint").unwrap();
+    push_bluetooth_endpoint(L, &plan.endpoint);
+    lua_setfield(L, -2, key.as_ptr());
+    set_str(L, "backend", &plan.backend);
+    set_str(L, "status", &plan.status);
+    push_optional_str(L, "stream_path", plan.stream_path.as_deref());
+    push_optional_str(L, "message", plan.message.as_deref());
+}
+
 unsafe fn push_bluetooth_endpoint_candidate(
     L: *mut lua_State,
     candidate: &LanguageBluetoothEndpointCandidate,
@@ -546,6 +561,15 @@ unsafe extern "C" fn lua_bluetooth_endpoint(L: *mut lua_State) -> c_int {
     1
 }
 
+unsafe extern "C" fn lua_bluetooth_backend(L: *mut lua_State) -> c_int {
+    let endpoint = get_str(L, 1).unwrap_or_else(|| raise_error(L, "endpoint must be a string"));
+    match core_bluetooth_backend_open_plan(&endpoint) {
+        Some(plan) => push_bluetooth_backend_open_plan(L, &plan),
+        None => lua_pushnil(L),
+    }
+    1
+}
+
 unsafe extern "C" fn lua_bluetooth_endpoint_candidates(L: *mut lua_State) -> c_int {
     let devices = read_bluetooth_discovered_devices(L, 1);
     let candidates = bluetooth_endpoint_candidates_from_devices(&devices);
@@ -705,7 +729,7 @@ unsafe extern "C" fn lua_defaults(L: *mut lua_State) -> c_int {
     1
 }
 
-struct FuncTable([luaL_Reg; 19]);
+struct FuncTable([luaL_Reg; 20]);
 unsafe impl Sync for FuncTable {}
 
 static FUNCS: FuncTable = FuncTable([
@@ -724,6 +748,10 @@ static FUNCS: FuncTable = FuncTable([
     luaL_Reg {
         name: b"bluetooth_endpoint\0".as_ptr() as *const _,
         func: Some(lua_bluetooth_endpoint),
+    },
+    luaL_Reg {
+        name: b"bluetooth_backend\0".as_ptr() as *const _,
+        func: Some(lua_bluetooth_backend),
     },
     luaL_Reg {
         name: b"bluetooth_endpoint_candidates\0".as_ptr() as *const _,

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -248,6 +248,54 @@ describe("coding_adventures.board_vm_native", function()
         )
     end)
 
+    it("builds Bluetooth transports from Rust backend plans", function()
+        local backend = {
+            endpoint = board_vm.bluetooth_endpoint("btspp://ESP32-BoardVM:3"),
+            backend = "macos_rfcomm",
+            status = "ready",
+            stream_path = "/dev/cu.ESP32-BoardVM",
+            message = nil,
+        }
+        local transport = board_vm.BluetoothTransport.new({
+            endpoint = "btspp://ESP32-BoardVM:3",
+            timeout_ms = 500,
+            backend = backend,
+        })
+
+        assert.are.equal("btspp://ESP32-BoardVM:3", transport.endpoint)
+        assert.are.equal("ready", transport:status())
+        assert.are.equal("/dev/cu.ESP32-BoardVM", transport.stream_path)
+        assert.are.equal("bluetooth_classic_rfcomm", transport.backend.endpoint.endpoint_transport)
+    end)
+
+    it("connects Bluetooth sessions through Rust backend plans", function()
+        local connection = board_vm.connect("esp32", {
+            via = "bluetooth_classic",
+            bluetooth_devices = {
+                {
+                    id = "esp32-board-vm",
+                    name = "ESP32 Board VM",
+                    paired = true,
+                    board_vm_rfcomm_channels = { 3 },
+                },
+            },
+            bluetooth_backend_plan = {
+                endpoint = board_vm.bluetooth_endpoint("btspp://esp32-board-vm:3"),
+                backend = "macos_rfcomm",
+                status = "ready",
+                stream_path = "/dev/cu.ESP32-BoardVM",
+                message = nil,
+            },
+        })
+        local session = connection:session()
+
+        assert.is_nil(connection.port)
+        assert.are.equal("bluetooth_classic", connection:connection_transport())
+        assert.are.equal("btspp://esp32-board-vm:3", connection.endpoint)
+        assert.are.equal("macos_rfcomm", session.transport.backend.backend)
+        assert.are.equal("/dev/cu.ESP32-BoardVM", session.transport.stream_path)
+    end)
+
     it("builds TCP transports for Wi-Fi endpoints", function()
         local connection = board_vm.connect("uno-r4-wifi", {
             via = "Wi-Fi",

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -471,6 +471,71 @@ class TcpTransport:
             raise OSError(f"failed to read Board VM response from {self.endpoint}: {error}") from error
 
 
+class BluetoothTransport:
+    FRAME_DELIMITER = b"\x00"
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
+        backend: dict[str, Any] | None = None,
+    ):
+        self.endpoint = str(endpoint)
+        self.timeout_ms = int(timeout_ms)
+        self.backend = dict(backend or bluetooth_backend(self.endpoint) or {})
+        if not self.backend:
+            raise ValueError(f"unsupported Board VM Bluetooth endpoint: {self.endpoint}")
+        self.stream_path = self.backend.get("stream_path")
+        self._stream: Any = None
+
+    @property
+    def status(self) -> str:
+        return str(self.backend.get("status"))
+
+    def transact(self, frame: bytes, timeout_ms: int | None = None) -> bytes:
+        self.write(frame)
+        return self._read_frame(timeout_ms=self.timeout_ms if timeout_ms is None else int(timeout_ms))
+
+    def write(self, frame: bytes) -> None:
+        try:
+            self._io().write(bytes(frame))
+            self._io().flush()
+        except OSError as error:
+            raise OSError(f"failed to write Board VM frame to {self.endpoint}: {error}") from error
+
+    def close(self) -> None:
+        if self._stream is not None:
+            self._stream.close()
+            self._stream = None
+
+    def _io(self) -> Any:
+        if self._stream is None:
+            if self.status != "ready" or not self.stream_path:
+                message = self.backend.get("message") or "Bluetooth backend is not ready"
+                raise OSError(f"failed to open Board VM Bluetooth endpoint {self.endpoint}: {message}")
+            try:
+                self._stream = open(str(self.stream_path), "r+b", buffering=0)
+            except OSError as error:
+                raise OSError(
+                    f"failed to open Board VM Bluetooth stream {self.stream_path}: {error}"
+                ) from error
+        return self._stream
+
+    def _read_frame(self, *, timeout_ms: int) -> bytes:
+        response = bytearray()
+        try:
+            while True:
+                byte = self._io().read(1)
+                if not byte:
+                    raise OSError(f"Board VM Bluetooth endpoint {self.endpoint} closed")
+                response.extend(byte)
+                if byte == self.FRAME_DELIMITER:
+                    return bytes(response)
+        except OSError as error:
+            raise OSError(f"failed to read Board VM response from {self.endpoint}: {error}") from error
+
+
 class Session:
     def __init__(self, *, next_request_id: int = 1, transport: Any = None, timeout_ms: int = 1000):
         self.next_request_id = next_request_id
@@ -1291,6 +1356,8 @@ class Connection:
         pico_runtime_port: bool = True,
         pico_runtime_port_wait_ms: int = DEFAULT_PICO_RUNTIME_PORT_WAIT_MS,
         pico_runtime_port_poll_ms: int = DEFAULT_PICO_RUNTIME_PORT_POLL_MS,
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
+        bluetooth_backend_plan: dict[str, Any] | None = None,
         esp_upload_options: dict[str, Any] | None = None,
         pico_uf2_upload_options: dict[str, Any] | None = None,
     ):
@@ -1308,6 +1375,8 @@ class Connection:
         self.pico_runtime_port = pico_runtime_port
         self.pico_runtime_port_wait_ms = int(pico_runtime_port_wait_ms)
         self.pico_runtime_port_poll_ms = int(pico_runtime_port_poll_ms)
+        self.timeout_ms = int(timeout_ms)
+        self.bluetooth_backend_plan = None if bluetooth_backend_plan is None else dict(bluetooth_backend_plan)
         self.esp_upload_options = dict(esp_upload_options or {})
         self.pico_uf2_upload_options = dict(pico_uf2_upload_options or {})
 
@@ -1394,7 +1463,20 @@ class Connection:
                     f"{display_name} requires a Board VM TCP endpoint; "
                     "pass endpoint='tcp://host:port' or choose via='serial'"
                 )
-            self.transport = TcpTransport(self.endpoint, timeout_ms=DEFAULT_TIMEOUT_MS)
+            self.transport = TcpTransport(self.endpoint, timeout_ms=self.timeout_ms)
+            return self.transport
+        if self._bluetooth_endpoint_connection():
+            if self.endpoint is None or not self.endpoint:
+                display_name = self.connection_option.get("display_name", self.connection_transport)
+                raise ValueError(
+                    f"{display_name} requires a Board VM Bluetooth endpoint; "
+                    "pass endpoint=... or choose via='serial'"
+                )
+            self.transport = BluetoothTransport(
+                self.endpoint,
+                timeout_ms=self.timeout_ms,
+                backend=self.bluetooth_backend_plan,
+            )
             return self.transport
         return None
 
@@ -1403,6 +1485,9 @@ class Connection:
             self.connection_option.get("endpoint_transport") == "tcp_socket"
             or self.connection_option.get("endpoint_scheme") == "tcp"
         )
+
+    def _bluetooth_endpoint_connection(self) -> bool:
+        return _connection_uses_bluetooth_endpoint(self.connection_option)
 
     def rediscover_runtime_port(self) -> BoardDevice:
         deadline = time.monotonic() + (self.pico_runtime_port_wait_ms / 1000)
@@ -1456,6 +1541,15 @@ def find_target(board_id: str) -> BoardTarget | None:
 def bluetooth_endpoint(endpoint: str) -> dict[str, Any] | None:
     parsed = _native.bluetooth_endpoint(str(endpoint))
     return None if parsed is None else dict(parsed)
+
+
+def bluetooth_backend(endpoint: str) -> dict[str, Any] | None:
+    plan = _native.bluetooth_backend(str(endpoint))
+    if plan is None:
+        return None
+    value = dict(plan)
+    value["endpoint"] = dict(value["endpoint"])
+    return value
 
 
 def bluetooth_devices() -> list[dict[str, Any]]:
@@ -1979,6 +2073,8 @@ def connect(
     transport: Any = None,
     endpoint: str | None = None,
     bluetooth_devices: Iterable[dict[str, Any]] | None = None,
+    bluetooth_backend_plan: dict[str, Any] | None = None,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
     runner: Any = None,
     cargo_workspace: str | pathlib.Path | None = None,
     firmware_image: str | pathlib.Path | None = None,
@@ -2062,6 +2158,8 @@ def connect(
         pico_runtime_port=pico_runtime_port,
         pico_runtime_port_wait_ms=pico_runtime_port_wait_ms,
         pico_runtime_port_poll_ms=pico_runtime_port_poll_ms,
+        timeout_ms=timeout_ms,
+        bluetooth_backend_plan=bluetooth_backend_plan,
         esp_upload_options=esp_upload_options,
         pico_uf2_upload_options=pico_uf2_upload_options,
     )
@@ -2194,6 +2292,7 @@ __all__ = [
     "BoardDescriptor",
     "BoardTarget",
     "BOOT_POLICIES",
+    "BluetoothTransport",
     "Capability",
     "Connection",
     "DEFAULT_PICO_RUNTIME_PORT_POLL_MS",
@@ -2212,6 +2311,7 @@ __all__ = [
     "Session",
     "SessionResult",
     "TcpTransport",
+    "bluetooth_backend",
     "bluetooth_connection_endpoint",
     "bluetooth_devices",
     "bluetooth_endpoint",

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -9,6 +9,7 @@ use board_vm_host::{
     GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
+    bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
     bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
     build_caps_query_wire_frame, build_gpio_handle_close_module, build_gpio_handle_read_module,
     build_gpio_handle_write_module, build_gpio_open_module, build_gpio_read_module,
@@ -27,7 +28,7 @@ use board_vm_language_core::{
     parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
     program_format_name, raw_module_len, run_status_name, wireless_transport_name,
     BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
+    LanguageBluetoothBackendOpenPlan, LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
     LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
     LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
     LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
@@ -494,6 +495,24 @@ unsafe extern "C" fn py_bluetooth_endpoint(_module: PyObjectPtr, args: PyObjectP
     }
 }
 
+unsafe extern "C" fn py_bluetooth_backend(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let endpoint = match parse_arg_str(args, 0) {
+        Some(value) => value,
+        None => {
+            set_error(
+                type_error_class(),
+                "bluetooth_backend() requires endpoint as str",
+            );
+            return ptr::null_mut();
+        }
+    };
+
+    match core_bluetooth_backend_open_plan(&endpoint) {
+        Some(plan) => language_bluetooth_backend_open_plan_to_py(&plan),
+        None => py_none(),
+    }
+}
+
 unsafe extern "C" fn py_bluetooth_endpoint_candidates(
     _module: PyObjectPtr,
     args: PyObjectPtr,
@@ -956,6 +975,36 @@ unsafe fn language_bluetooth_endpoint_to_py(endpoint: &LanguageBluetoothEndpoint
         endpoint
             .channel
             .map(|value| usize_to_py(value as usize))
+            .unwrap_or_else(|| py_none()),
+    );
+    dict
+}
+
+unsafe fn language_bluetooth_backend_open_plan_to_py(
+    plan: &LanguageBluetoothBackendOpenPlan,
+) -> PyObjectPtr {
+    let dict = PyDict_New();
+    dict_set(
+        dict,
+        "endpoint",
+        language_bluetooth_endpoint_to_py(&plan.endpoint),
+    );
+    dict_set(dict, "backend", str_to_py(&plan.backend));
+    dict_set(dict, "status", str_to_py(&plan.status));
+    dict_set(
+        dict,
+        "stream_path",
+        plan.stream_path
+            .as_ref()
+            .map(|value| str_to_py(value))
+            .unwrap_or_else(|| py_none()),
+    );
+    dict_set(
+        dict,
+        "message",
+        plan.message
+            .as_ref()
+            .map(|value| str_to_py(value))
             .unwrap_or_else(|| py_none()),
     );
     dict
@@ -1515,7 +1564,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 31] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 32] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1665,6 +1714,12 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_bluetooth_endpoint),
             ml_flags: METH_VARARGS,
             ml_doc: b"Parse a Board VM Bluetooth endpoint in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"bluetooth_backend\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_bluetooth_backend),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Plan Board VM Bluetooth backend opening in Rust.\0".as_ptr() as *const c_char,
         },
         PyMethodDef {
             ml_name: b"bluetooth_endpoint_candidates\0".as_ptr() as *const c_char,

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -9,6 +9,7 @@ from board_vm_native import (
     BoardDevice,
     BoardDescriptor,
     BoardTarget,
+    BluetoothTransport,
     Connection,
     EspUploadOptions,
     PicoUf2UploadOptions,
@@ -251,6 +252,23 @@ def test_bluetooth_endpoint_candidates_are_planned_by_rust_language_core():
     assert ble["requires_pairing"] is True
 
 
+def test_bluetooth_transport_uses_rust_backend_open_plan():
+    plan = {
+        "endpoint": bluetooth_endpoint("btspp://ESP32-BoardVM:3"),
+        "backend": "macos_rfcomm",
+        "status": "ready",
+        "stream_path": "/dev/cu.ESP32-BoardVM",
+        "message": None,
+    }
+
+    transport = BluetoothTransport("btspp://ESP32-BoardVM:3", backend=plan)
+
+    assert transport.endpoint == "btspp://ESP32-BoardVM:3"
+    assert transport.status == "ready"
+    assert transport.stream_path == "/dev/cu.ESP32-BoardVM"
+    assert transport.backend["endpoint"]["endpoint_transport"] == "bluetooth_classic_rfcomm"
+
+
 def test_bluetooth_endpoint_candidates_default_to_host_discovery(monkeypatch):
     monkeypatch.setattr(
         board_vm_native_module._native,
@@ -390,6 +408,37 @@ def test_connect_auto_selects_bluetooth_endpoint_candidates():
         "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e"
         "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e"
     )
+
+
+def test_connect_builds_a_bluetooth_transport_from_rust_backend_plan():
+    connection = connect(
+        "esp32",
+        via="bluetooth_classic",
+        bluetooth_devices=[
+            {
+                "id": "esp32-board-vm",
+                "name": "ESP32 Board VM",
+                "paired": True,
+                "board_vm_rfcomm_channels": [3],
+            }
+        ],
+        bluetooth_backend_plan={
+            "endpoint": bluetooth_endpoint("btspp://esp32-board-vm:3"),
+            "backend": "macos_rfcomm",
+            "status": "ready",
+            "stream_path": "/dev/cu.ESP32-BoardVM",
+            "message": None,
+        },
+    )
+
+    transport = connection.session().transport
+
+    assert connection.port is None
+    assert connection.connection_transport == "bluetooth_classic"
+    assert connection.endpoint == "btspp://esp32-board-vm:3"
+    assert isinstance(transport, BluetoothTransport)
+    assert transport.backend["backend"] == "macos_rfcomm"
+    assert transport.stream_path == "/dev/cu.ESP32-BoardVM"
 
 
 def test_connect_builds_a_tcp_transport_for_wifi_endpoints():

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -10,6 +10,7 @@ use board_vm_host::{
     GPIO_WRITE_MODULE_LEN, TIME_NOW_MODULE_LEN, TIME_SLEEP_MS_MODULE_LEN,
 };
 use board_vm_language_core::{
+    bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
     bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
     build_caps_query_wire_frame, build_gpio_handle_close_module, build_gpio_handle_read_module,
     build_gpio_handle_write_module, build_gpio_open_module, build_gpio_read_module,
@@ -28,7 +29,7 @@ use board_vm_language_core::{
     parse_bluetooth_endpoint as core_parse_bluetooth_endpoint, pico_uf2_upload_options_for_target,
     program_format_name, raw_module_len, run_status_name, wireless_transport_name,
     BoardVmLanguageSession, DecodedLanguageResponse, DecodedLanguageResponseBody,
-    LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
+    LanguageBluetoothBackendOpenPlan, LanguageBluetoothDiscoveredDevice, LanguageBluetoothEndpoint,
     LanguageBluetoothEndpointCandidate, LanguageConnectionOption, LanguageCoreError,
     LanguageEspUploadOptions, LanguageHostDevice, LanguageOnboardLed, LanguagePicoUf2UploadOptions,
     LanguageTargetInfo, LanguageValue, LanguageWirelessInterface,
@@ -428,6 +429,15 @@ extern "C" fn native_bluetooth_endpoint(_self_val: VALUE, endpoint_val: VALUE) -
         .unwrap_or_else(|| ruby_bridge::raise_arg_error("endpoint must be a Ruby String"));
     match core_parse_bluetooth_endpoint(&endpoint) {
         Some(endpoint) => bluetooth_endpoint_to_rb(&endpoint),
+        None => ruby_bridge::nil_value(),
+    }
+}
+
+extern "C" fn native_bluetooth_backend(_self_val: VALUE, endpoint_val: VALUE) -> VALUE {
+    let endpoint = ruby_bridge::str_from_rb(endpoint_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("endpoint must be a Ruby String"));
+    match core_bluetooth_backend_open_plan(&endpoint) {
+        Some(plan) => bluetooth_backend_open_plan_to_rb(&plan),
         None => ruby_bridge::nil_value(),
     }
 }
@@ -833,6 +843,30 @@ fn bluetooth_endpoint_to_rb(endpoint: &LanguageBluetoothEndpoint) -> VALUE {
         endpoint
             .channel
             .map(rb_usize)
+            .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash
+}
+
+fn bluetooth_backend_open_plan_to_rb(plan: &LanguageBluetoothBackendOpenPlan) -> VALUE {
+    let hash = ruby_bridge::hash_new();
+    hash_set(hash, "endpoint", bluetooth_endpoint_to_rb(&plan.endpoint));
+    hash_set(hash, "backend", ruby_bridge::str_to_rb(&plan.backend));
+    hash_set(hash, "status", ruby_bridge::str_to_rb(&plan.status));
+    hash_set(
+        hash,
+        "stream_path",
+        plan.stream_path
+            .as_ref()
+            .map(|value| ruby_bridge::str_to_rb(value))
+            .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash_set(
+        hash,
+        "message",
+        plan.message
+            .as_ref()
+            .map(|value| ruby_bridge::str_to_rb(value))
             .unwrap_or_else(ruby_bridge::nil_value),
     );
     hash
@@ -1353,6 +1387,12 @@ pub extern "C" fn Init_board_vm_native() {
         native,
         "bluetooth_endpoint",
         native_bluetooth_endpoint as *const c_void,
+        1,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "bluetooth_backend",
+        native_bluetooth_backend as *const c_void,
         1,
     );
     ruby_bridge::define_module_function_raw(

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -150,6 +150,10 @@ module CodingAdventures
       Native.bluetooth_endpoint(endpoint.to_s)
     end
 
+    def bluetooth_backend(endpoint)
+      Native.bluetooth_backend(endpoint.to_s)
+    end
+
     def bluetooth_devices
       Native.bluetooth_devices
     end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/connection.rb
@@ -43,7 +43,8 @@ module CodingAdventures
         pico_uf2_upload_options: nil,
         pico_runtime_port: true,
         pico_runtime_port_wait_ms: DEFAULT_PICO_RUNTIME_PORT_WAIT_MS,
-        pico_runtime_port_poll_ms: DEFAULT_PICO_RUNTIME_PORT_POLL_MS
+        pico_runtime_port_poll_ms: DEFAULT_PICO_RUNTIME_PORT_POLL_MS,
+        bluetooth_backend_plan: nil
       )
         @board = board
         @port = port
@@ -78,6 +79,7 @@ module CodingAdventures
         @pico_runtime_port = pico_runtime_port
         @pico_runtime_port_wait_ms = pico_runtime_port_wait_ms
         @pico_runtime_port_poll_ms = pico_runtime_port_poll_ms
+        @bluetooth_backend_plan = bluetooth_backend_plan
       end
 
       def led
@@ -522,6 +524,19 @@ module CodingAdventures
           return @transport = TcpTransport.new(endpoint: endpoint, timeout_ms: timeout_ms)
         end
 
+        if bluetooth_endpoint_connection?
+          unless endpoint && !endpoint.to_s.empty?
+            raise TransportError,
+              "#{connection_display_name} requires a Board VM Bluetooth endpoint; pass endpoint: ... or choose via: :serial"
+          end
+
+          return @transport = BluetoothTransport.new(
+            endpoint: endpoint,
+            timeout_ms: timeout_ms,
+            backend: @bluetooth_backend_plan
+          )
+        end
+
         unless serial_connection?
           raise TransportError,
             "#{connection_display_name} requires an injected Board VM transport endpoint; pass transport: or choose via: :serial"
@@ -537,6 +552,13 @@ module CodingAdventures
         connection_option &&
           (connection_option["endpoint_transport"] == "tcp_socket" ||
             connection_option["endpoint_scheme"] == "tcp")
+      end
+
+      def bluetooth_endpoint_connection?
+        connection_option &&
+          (["bluetooth_le", "bluetooth_classic"].include?(connection_option["transport"]) ||
+            ["bluetooth_le_gatt", "bluetooth_classic_rfcomm"].include?(connection_option["endpoint_transport"]) ||
+            ["ble", "btspp", "rfcomm"].include?(connection_option["endpoint_scheme"]))
       end
 
       def connection_display_name

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
@@ -218,5 +218,83 @@ module CodingAdventures
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
     end
+
+    class BluetoothTransport
+      FRAME_DELIMITER = "\x00".b
+
+      attr_reader :endpoint, :backend, :stream_path
+
+      def initialize(endpoint:, timeout_ms:, backend: nil)
+        @endpoint = endpoint.to_s
+        @timeout_ms = timeout_ms
+        @backend = backend || BoardVM.bluetooth_backend(@endpoint)
+        raise TransportError, "unsupported Board VM Bluetooth endpoint #{@endpoint.inspect}" unless @backend
+
+        @stream_path = @backend["stream_path"]
+        @io = nil
+      end
+
+      def status
+        @backend["status"]
+      end
+
+      def transact(frame, timeout_ms: @timeout_ms)
+        write(frame)
+        read_frame(timeout_ms: timeout_ms)
+      end
+
+      def write(frame)
+        io.write(frame.b)
+        io.flush
+      rescue SystemCallError, IOError => e
+        raise TransportError, "failed to write Board VM frame to #{@endpoint}: #{e.message}"
+      end
+
+      def close
+        @io&.close
+      ensure
+        @io = nil
+      end
+
+      private
+
+      def io
+        @io ||= begin
+          unless status == "ready" && @stream_path && !@stream_path.empty?
+            message = @backend["message"] || "Bluetooth backend is not ready"
+            raise TransportError, "failed to open Board VM Bluetooth endpoint #{@endpoint}: #{message}"
+          end
+          File.open(@stream_path, "r+b")
+        rescue SystemCallError => e
+          raise TransportError, "failed to open Board VM Bluetooth stream #{@stream_path}: #{e.message}"
+        end
+      end
+
+      def read_frame(timeout_ms:)
+        deadline = monotonic_now + (timeout_ms.to_f / 1000.0)
+        response = +"".b
+
+        loop do
+          remaining = deadline - monotonic_now
+          raise TransportError, "timed out waiting for Board VM response on #{@endpoint}" if remaining <= 0
+
+          readable = IO.select([io], nil, nil, remaining)
+          next if readable.nil?
+
+          byte = io.read_nonblock(1, exception: false)
+          next if byte == :wait_readable
+          raise TransportError, "Board VM Bluetooth endpoint #{@endpoint} closed" if byte.nil? || byte.empty?
+
+          response << byte
+          return response if byte == FRAME_DELIMITER
+        end
+      rescue SystemCallError, IOError => e
+        raise TransportError, "failed to read Board VM response from #{@endpoint}: #{e.message}"
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
   end
 end

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -268,6 +268,57 @@ module CodingAdventures
           "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e", connection.endpoint
       end
 
+      def test_bluetooth_transport_uses_rust_backend_open_plan
+        transport = BluetoothTransport.new(
+          endpoint: "btspp://ESP32-BoardVM:3",
+          timeout_ms: 500,
+          backend: {
+            "endpoint" => BoardVM.bluetooth_endpoint("btspp://ESP32-BoardVM:3"),
+            "backend" => "macos_rfcomm",
+            "status" => "ready",
+            "stream_path" => "/dev/cu.ESP32-BoardVM",
+            "message" => nil
+          }
+        )
+
+        assert_equal "btspp://ESP32-BoardVM:3", transport.endpoint
+        assert_equal "ready", transport.status
+        assert_equal "/dev/cu.ESP32-BoardVM", transport.stream_path
+        assert_equal "bluetooth_classic_rfcomm", transport.backend.fetch("endpoint").fetch("endpoint_transport")
+      end
+
+      def test_connect_builds_a_bluetooth_transport_from_rust_backend_plan
+        connection = BoardVM.esp32(
+          via: "bluetooth_classic",
+          bluetooth_devices: [
+            {
+              "id" => "esp32-board-vm",
+              "name" => "ESP32 Board VM",
+              "paired" => true,
+              "board_vm_rfcomm_channels" => [3]
+            }
+          ],
+          bluetooth_backend_plan: {
+            "endpoint" => BoardVM.bluetooth_endpoint("btspp://esp32-board-vm:3"),
+            "backend" => "macos_rfcomm",
+            "status" => "ready",
+            "stream_path" => "/dev/cu.ESP32-BoardVM",
+            "message" => nil
+          },
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new
+        )
+
+        transport = connection.send(:active_transport)
+
+        assert_nil connection.port
+        assert_equal "bluetooth_classic", connection.connection_transport
+        assert_equal "btspp://esp32-board-vm:3", connection.endpoint
+        assert_instance_of BluetoothTransport, transport
+        assert_equal "macos_rfcomm", transport.backend.fetch("backend")
+        assert_equal "/dev/cu.ESP32-BoardVM", transport.stream_path
+      end
+
       def test_connect_builds_a_tcp_transport_for_wifi_endpoints
         connection = BoardVM.uno_r4_wifi(
           via: "Wi-Fi",

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -18,10 +18,12 @@ use std::str;
 
 use board_vm_bluetooth::{
     board_vm_endpoint_candidates as board_vm_bluetooth_endpoint_candidates,
-    discover_bluetooth_devices as discover_board_vm_bluetooth_devices,
+    discover_bluetooth_devices as discover_board_vm_bluetooth_devices, macos_rfcomm_device_path,
     parse_bluetooth_endpoint as parse_board_vm_bluetooth_endpoint, BluetoothDiscoveredDevice,
     BluetoothEndpoint, BluetoothEndpointCandidate,
 };
+#[cfg(target_os = "macos")]
+use board_vm_bluetooth::{MacosDevRfcommDeviceResolver, MacosRfcommDeviceResolver};
 use board_vm_esp_rom::{
     DEFAULT_BAUD_RATE as ESP_DEFAULT_BAUD_RATE,
     DEFAULT_FLASH_BLOCK_SIZE as ESP_DEFAULT_FLASH_BLOCK_SIZE,
@@ -343,6 +345,15 @@ pub struct LanguageBluetoothEndpointCandidate {
     pub display_name: String,
     pub paired: bool,
     pub requires_pairing: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageBluetoothBackendOpenPlan {
+    pub endpoint: LanguageBluetoothEndpoint,
+    pub backend: String,
+    pub status: String,
+    pub stream_path: Option<String>,
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -675,6 +686,126 @@ pub fn discover_bluetooth_devices() -> Vec<LanguageBluetoothDiscoveredDevice> {
 pub fn discover_bluetooth_endpoint_candidates() -> Vec<LanguageBluetoothEndpointCandidate> {
     let devices = discover_bluetooth_devices();
     bluetooth_endpoint_candidates_from_devices(&devices)
+}
+
+pub fn bluetooth_backend_open_plan(endpoint: &str) -> Option<LanguageBluetoothBackendOpenPlan> {
+    let endpoint = parse_board_vm_bluetooth_endpoint(endpoint).ok()?;
+    match endpoint {
+        BluetoothEndpoint::BleGatt(endpoint) => Some(language_bluetooth_ble_open_plan(endpoint)),
+        BluetoothEndpoint::Rfcomm(endpoint) => {
+            #[cfg(target_os = "macos")]
+            {
+                let mut resolver = MacosDevRfcommDeviceResolver;
+                match resolver.rfcomm_device_paths() {
+                    Ok(paths) => Some(language_bluetooth_rfcomm_open_plan_from_paths(
+                        endpoint, paths,
+                    )),
+                    Err(error) => {
+                        let endpoint =
+                            language_bluetooth_endpoint(BluetoothEndpoint::Rfcomm(endpoint))?;
+                        Some(LanguageBluetoothBackendOpenPlan {
+                            endpoint,
+                            backend: "macos_rfcomm".to_owned(),
+                            status: "unavailable".to_owned(),
+                            stream_path: None,
+                            message: Some(format!(
+                                "macOS RFCOMM device discovery failed: {error:?}"
+                            )),
+                        })
+                    }
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let endpoint = language_bluetooth_endpoint(BluetoothEndpoint::Rfcomm(endpoint))?;
+                Some(unsupported_bluetooth_backend_open_plan(endpoint))
+            }
+        }
+    }
+}
+
+pub fn bluetooth_backend_open_plan_from_rfcomm_paths<I, S>(
+    endpoint: &str,
+    paths: I,
+) -> Option<LanguageBluetoothBackendOpenPlan>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let endpoint = parse_board_vm_bluetooth_endpoint(endpoint).ok()?;
+    match endpoint {
+        BluetoothEndpoint::BleGatt(endpoint) => Some(language_bluetooth_ble_open_plan(endpoint)),
+        BluetoothEndpoint::Rfcomm(endpoint) => Some(
+            language_bluetooth_rfcomm_open_plan_from_paths(endpoint, paths),
+        ),
+    }
+}
+
+fn language_bluetooth_rfcomm_open_plan_from_paths<I, S>(
+    endpoint: board_vm_bluetooth::RfcommEndpoint,
+    paths: I,
+) -> LanguageBluetoothBackendOpenPlan
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let stream_path = macos_rfcomm_device_path(&endpoint, paths);
+    let device = endpoint.device.clone();
+    let channel = endpoint.channel;
+    let endpoint = language_bluetooth_endpoint(BluetoothEndpoint::Rfcomm(endpoint))
+        .expect("parsed RFCOMM endpoint should map to language metadata");
+    match stream_path {
+        Some(stream_path) => LanguageBluetoothBackendOpenPlan {
+            endpoint,
+            backend: "macos_rfcomm".to_owned(),
+            status: "ready".to_owned(),
+            stream_path: Some(stream_path),
+            message: None,
+        },
+        None => LanguageBluetoothBackendOpenPlan {
+            endpoint,
+            backend: "macos_rfcomm".to_owned(),
+            status: "not_found".to_owned(),
+            stream_path: None,
+            message: Some(format!(
+                "no macOS RFCOMM serial device found for {device} channel {channel}"
+            )),
+        },
+    }
+}
+
+fn language_bluetooth_ble_open_plan(
+    endpoint: board_vm_bluetooth::BleGattEndpoint,
+) -> LanguageBluetoothBackendOpenPlan {
+    let endpoint = language_bluetooth_endpoint(BluetoothEndpoint::BleGatt(endpoint))
+        .expect("parsed BLE endpoint should map to language metadata");
+    #[cfg(target_os = "macos")]
+    let backend = "macos_core_bluetooth";
+    #[cfg(not(target_os = "macos"))]
+    let backend = "unsupported";
+    LanguageBluetoothBackendOpenPlan {
+        endpoint,
+        backend: backend.to_owned(),
+        status: "unavailable".to_owned(),
+        stream_path: None,
+        message: Some("BLE GATT backend opening is not wired yet".to_owned()),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn unsupported_bluetooth_backend_open_plan(
+    endpoint: LanguageBluetoothEndpoint,
+) -> LanguageBluetoothBackendOpenPlan {
+    LanguageBluetoothBackendOpenPlan {
+        endpoint,
+        backend: "unsupported".to_owned(),
+        status: "unsupported".to_owned(),
+        stream_path: None,
+        message: Some(format!(
+            "Board VM Bluetooth backend opening is unsupported on {}",
+            std::env::consts::OS
+        )),
+    }
 }
 
 fn language_bluetooth_discovered_device(
@@ -2550,6 +2681,51 @@ mod tests {
         );
         assert!(!ble.paired);
         assert!(ble.requires_pairing);
+    }
+
+    #[test]
+    fn bluetooth_backend_open_plan_is_owned_by_rust_language_core() {
+        let plan = bluetooth_backend_open_plan_from_rfcomm_paths(
+            "btspp://ESP32-BoardVM:3",
+            ["/dev/tty.ESP32-BoardVM", "/dev/cu.ESP32-BoardVM"],
+        )
+        .unwrap();
+
+        assert_eq!(plan.backend, "macos_rfcomm");
+        assert_eq!(plan.status, "ready");
+        assert_eq!(
+            plan.endpoint.endpoint_transport,
+            LanguageHostEndpointTransport::BluetoothClassicRfcomm
+        );
+        assert_eq!(plan.endpoint.endpoint, "btspp://ESP32-BoardVM:3");
+        assert_eq!(plan.stream_path.as_deref(), Some("/dev/cu.ESP32-BoardVM"));
+        assert_eq!(plan.message, None);
+
+        let missing = bluetooth_backend_open_plan_from_rfcomm_paths(
+            "btspp://ESP32-BoardVM:3",
+            ["/dev/cu.NotBoardVM"],
+        )
+        .unwrap();
+        assert_eq!(missing.backend, "macos_rfcomm");
+        assert_eq!(missing.status, "not_found");
+        assert_eq!(missing.stream_path, None);
+        assert!(missing
+            .message
+            .as_deref()
+            .unwrap()
+            .contains("no macOS RFCOMM serial device found"));
+
+        let ble = bluetooth_backend_open_plan_from_rfcomm_paths(
+            "ble://uno-r4-wifi/180f/2a19/2a1a",
+            ["/dev/cu.ESP32-BoardVM"],
+        )
+        .unwrap();
+        assert_eq!(ble.status, "unavailable");
+        assert_eq!(
+            ble.endpoint.endpoint_transport,
+            LanguageHostEndpointTransport::BluetoothLeGatt
+        );
+        assert!(ble.stream_path.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Rust-owned Bluetooth backend open plans for language frontends, including macOS RFCOMM stream discovery and BLE unavailable metadata
- expose bluetooth_backend through Ruby, Python, and Lua native bridges
- wire Ruby/Python/Lua connect/session helpers to build Bluetooth transports from Rust backend plans

## Validation
- cargo test -p board-vm-language-core -p ruby-bridge -p python-bridge -p lua-bridge
- BUNDLE_PATH=vendor/bundle bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- bash BUILD in code/packages/lua/board_vm_native
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check
- git diff --cached --check

PR #2748 has merged; this continues the Board VM Bluetooth language/backend handoff loop.