### PR TITLE
Port Kronecker residual factoring to Rust cas-factor

### DIFF
--- a/code/packages/rust/cas-factor/CHANGELOG.md
+++ b/code/packages/rust/cas-factor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — cas-factor (Rust)
 
+## Unreleased
+
+### Added
+
+- `kronecker` module with public `kronecker_factor(p)` for primitive integer
+  polynomial residual splitting.
+- Recursive residual factoring in `factor_integer_polynomial`, covering
+  Sophie Germain quartics, `x^4 + x^2 + 1`, and repeated quadratic residuals.
+- Focused Kronecker and integration tests for residual factoring parity with
+  the Python/TypeScript `cas-factor` implementations.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-factor/README.md
+++ b/code/packages/rust/cas-factor/README.md
@@ -3,11 +3,15 @@
 Univariate integer polynomial factoring over ℤ.
 Rust port of the Python `cas-factor` package.
 
-## Phase 1: linear factors via the rational-root test
+## Phase 1/2: linear factors and Kronecker residual splitting
 
 Phase 1 uses the **Rational Root Theorem**: any integer root `r` of
 `a_0 + a_1·x + … + a_n·x^n` must divide `a_0`.  We enumerate all
 `±divisors(a_0)` and test each.
+
+Phase 2 uses Kronecker's method to split primitive integer residuals. This
+covers examples such as `x^4 + 4`, `x^4 + x^2 + 1`, and repeated irreducible
+quadratics. BZH is intentionally left for a later Rust phase.
 
 ```rust
 use cas_factor::factor_integer_polynomial;
@@ -25,10 +29,16 @@ assert_eq!(c, 2);
 assert_eq!(f, vec![(vec![1, 1], 2)]);
 // [1, 1] = 1 + x = x + 1, multiplicity 2
 
-// x^2 + 1 — irreducible over Q (Phase 2 handles these)
+// x^2 + 1 — irreducible over Q
 let (c, f) = factor_integer_polynomial(&[1, 0, 1]);
 assert_eq!(c, 1);
 assert_eq!(f, vec![(vec![1, 0, 1], 1)]);
+
+// x^4 + 4 = (x^2 - 2x + 2)(x^2 + 2x + 2)
+let (c, mut f) = factor_integer_polynomial(&[4, 0, 0, 0, 1]);
+f.sort_by_key(|(factor, _)| factor.clone());
+assert_eq!(c, 1);
+assert_eq!(f, vec![(vec![2, -2, 1], 1), (vec![2, 2, 1], 1)]);
 ```
 
 ## Polynomial representation
@@ -53,6 +63,7 @@ value: a_0 a_1 a_2   represents  a_0 + a_1·x + a_2·x^2
 | `divisors(n)` | All positive divisors of |n| |
 | `find_integer_roots(p)` | Integer roots via rational-root test |
 | `extract_linear_factors(p)` | All linear factors with multiplicities |
+| `kronecker_factor(p)` | One non-trivial Kronecker factor/cofactor split |
 
 ## Stack position
 

--- a/code/packages/rust/cas-factor/src/factor.rs
+++ b/code/packages/rust/cas-factor/src/factor.rs
@@ -3,9 +3,9 @@
 //! Given an integer polynomial as a coefficient list, returns:
 //!
 //! 1. The integer **content** — the GCD of every coefficient (always positive).
-//! 2. A list of `(factor_coeffs, multiplicity)` pairs.  Phase 1 only finds
-//!    *linear* factors via the rational-root test; any irreducible residual is
-//!    appended with multiplicity 1.
+//! 2. A list of `(factor_coeffs, multiplicity)` pairs. Phase 1 finds
+//!    *linear* factors via the rational-root test; Phase 2 recursively splits
+//!    residuals with Kronecker's method.
 //!
 //! # Examples
 //!
@@ -29,13 +29,14 @@
 //! assert_eq!(factors, vec![(vec![1, 0, 1], 1)]);
 //! ```
 
-use crate::polynomial::{content, normalize, primitive_part};
+use crate::kronecker::kronecker_factor;
+use crate::polynomial::{content, degree, normalize, primitive_part};
 use crate::rational_roots::extract_linear_factors;
 
 /// A factored polynomial: `Vec<(coeffs, multiplicity)>`.
 pub type FactorList = Vec<(Vec<i64>, usize)>;
 
-/// Factor a univariate integer polynomial over ℤ (linear factors only).
+/// Factor a univariate integer polynomial over ℤ.
 ///
 /// # Returns
 ///
@@ -47,6 +48,7 @@ pub type FactorList = Vec<(Vec<i64>, usize)>;
 /// - One entry `([-root, 1], mult)` per integer root found.
 /// - Optionally one entry for the irreducible residual (if it isn't `[1]` or
 ///   `[-1]`).
+/// - Residual factors found by Kronecker's method, or one irreducible residual.
 pub fn factor_integer_polynomial(p: &[i64]) -> (i64, FactorList) {
     if p.is_empty() {
         return (0, vec![]);
@@ -71,9 +73,40 @@ pub fn factor_integer_polynomial(p: &[i64]) -> (i64, FactorList) {
         // The trailing -1 is absorbed into the content sign.
         c = -c;
     } else if !residual_norm.is_empty() && residual_norm != vec![1i64] {
-        // Non-trivial irreducible residual.
-        factors.push((residual_norm, 1));
+        factors.extend(factor_residual(&residual_norm));
     }
 
     (c, factors)
+}
+
+fn factor_residual(residual: &[i64]) -> FactorList {
+    let mut factors = std::collections::BTreeMap::<Vec<i64>, usize>::new();
+    let mut queue = vec![normalize(residual)];
+
+    while let Some(piece) = queue.pop() {
+        let mut piece = normalize(&piece);
+        if piece.is_empty() || degree(&piece) <= 0 {
+            continue;
+        }
+
+        if degree(&piece) == 1 {
+            if piece.last().is_some_and(|&lead| lead < 0) {
+                piece = piece.into_iter().map(|coeff| -coeff).collect();
+            }
+            *factors.entry(piece).or_insert(0) += 1;
+            continue;
+        }
+
+        if let Some((factor, cofactor)) = kronecker_factor(&piece) {
+            queue.push(factor);
+            queue.push(cofactor);
+        } else {
+            if piece.last().is_some_and(|&lead| lead < 0) {
+                piece = piece.into_iter().map(|coeff| -coeff).collect();
+            }
+            *factors.entry(piece).or_insert(0) += 1;
+        }
+    }
+
+    factors.into_iter().collect()
 }

--- a/code/packages/rust/cas-factor/src/kronecker.rs
+++ b/code/packages/rust/cas-factor/src/kronecker.rs
@@ -1,0 +1,326 @@
+//! Kronecker factor splitting for primitive integer polynomials.
+//!
+//! This module searches for one non-trivial factor/cofactor pair over `Z[x]`.
+//! Linear integer-root extraction is still handled by `rational_roots`; this
+//! phase is for residual quadratics and higher-degree pieces with no linear
+//! roots.
+
+use crate::polynomial::{degree, divisors, evaluate, normalize, Poly};
+
+const MAX_COMBOS: usize = 10_000;
+
+/// Find one non-trivial factor/cofactor pair using Kronecker's method.
+///
+/// `p` is expected to be primitive. The returned factor and cofactor are
+/// normalized to positive leading coefficient.
+pub fn kronecker_factor(p: &[i64]) -> Option<(Poly, Poly)> {
+    let p = normalize(p);
+    let d = degree(&p);
+    if d < 2 {
+        return None;
+    }
+
+    for k in 1..=(d as usize / 2) {
+        let points = eval_points(k + 1);
+        let values: Vec<i64> = points.iter().map(|&point| evaluate(&p, point)).collect();
+        if values.iter().any(|&value| value == 0) {
+            continue;
+        }
+
+        let divisor_sets: Vec<Vec<i64>> =
+            values.iter().map(|&value| signed_divisors(value)).collect();
+        if divisor_sets.iter().any(Vec::is_empty) {
+            continue;
+        }
+
+        let mut combos_tried = 0usize;
+        let mut combo = Vec::with_capacity(divisor_sets.len());
+        if let Some(split) =
+            search_combos(&p, &points, &divisor_sets, 0, &mut combo, &mut combos_tried)
+        {
+            return Some(split);
+        }
+    }
+
+    None
+}
+
+fn search_combos(
+    p: &[i64],
+    points: &[i64],
+    divisor_sets: &[Vec<i64>],
+    index: usize,
+    combo: &mut Vec<i64>,
+    combos_tried: &mut usize,
+) -> Option<(Poly, Poly)> {
+    if *combos_tried >= MAX_COMBOS {
+        return None;
+    }
+
+    if index == divisor_sets.len() {
+        *combos_tried += 1;
+        let coeffs = lagrange_interpolate(points, combo)?;
+        let mut candidate = Vec::with_capacity(coeffs.len());
+        for coeff in coeffs {
+            candidate.push(coeff.to_i64()?);
+        }
+
+        let candidate = normalize_positive_leading(&candidate);
+        if candidate.len() <= 1 || candidate.len() >= p.len() {
+            return None;
+        }
+
+        let cofactor = divides_exactly(p, &candidate)?;
+        return Some((candidate, normalize_positive_leading(&cofactor)));
+    }
+
+    for &value in &divisor_sets[index] {
+        combo.push(value);
+        if let Some(split) = search_combos(p, points, divisor_sets, index + 1, combo, combos_tried)
+        {
+            return Some(split);
+        }
+        combo.pop();
+        if *combos_tried >= MAX_COMBOS {
+            break;
+        }
+    }
+
+    None
+}
+
+fn eval_points(count: usize) -> Vec<i64> {
+    let mut points = Vec::with_capacity(count);
+    let mut i = 0i64;
+    while points.len() < count {
+        if i == 0 {
+            points.push(0);
+        } else {
+            points.push(i);
+            if points.len() < count {
+                points.push(-i);
+            }
+        }
+        i += 1;
+    }
+    points
+}
+
+fn signed_divisors(value: i64) -> Vec<i64> {
+    if value == 0 {
+        return vec![];
+    }
+
+    divisors(value)
+        .into_iter()
+        .flat_map(|divisor| [divisor, -divisor])
+        .collect()
+}
+
+fn lagrange_interpolate(xs: &[i64], ys: &[i64]) -> Option<Vec<Rational>> {
+    let n = xs.len();
+    let mut result = vec![Rational::zero(); n];
+
+    for i in 0..n {
+        let mut denom = Rational::one();
+        for j in 0..n {
+            if i == j {
+                continue;
+            }
+            let diff = xs[i] - xs[j];
+            if diff == 0 {
+                return None;
+            }
+            denom = denom.mul(Rational::from_i64(diff));
+        }
+
+        let weight = Rational::from_i64(ys[i]).div(denom)?;
+        let mut basis = vec![Rational::one()];
+        for j in 0..n {
+            if i == j {
+                continue;
+            }
+
+            let mut next = vec![Rational::zero(); basis.len() + 1];
+            for (k, coeff) in basis.iter().enumerate() {
+                next[k + 1] = next[k + 1].add(*coeff);
+                next[k] = next[k].sub(coeff.mul(Rational::from_i64(xs[j])));
+            }
+            basis = next;
+        }
+
+        for (k, coeff) in basis.iter().enumerate() {
+            result[k] = result[k].add(weight.mul(*coeff));
+        }
+    }
+
+    Some(result)
+}
+
+fn divides_exactly(p: &[i64], candidate: &[i64]) -> Option<Poly> {
+    let dividend: Vec<Rational> = p.iter().map(|&coeff| Rational::from_i64(coeff)).collect();
+    let divisor: Vec<Rational> = candidate
+        .iter()
+        .map(|&coeff| Rational::from_i64(coeff))
+        .collect();
+    let (quotient, remainder) = poly_divmod_frac(dividend, divisor)?;
+    if !remainder.is_empty() {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(quotient.len());
+    for coeff in quotient {
+        out.push(coeff.to_i64()?);
+    }
+    Some(normalize(&out))
+}
+
+fn poly_divmod_frac(
+    mut dividend: Vec<Rational>,
+    mut divisor: Vec<Rational>,
+) -> Option<(Vec<Rational>, Vec<Rational>)> {
+    trim_rational(&mut dividend);
+    trim_rational(&mut divisor);
+    if divisor.is_empty() {
+        return None;
+    }
+
+    let divisor_degree = divisor.len() - 1;
+    let mut quotient = vec![Rational::zero(); dividend.len().saturating_sub(divisor.len()) + 1];
+
+    while dividend.len() > divisor_degree {
+        let lead = dividend[dividend.len() - 1].div(divisor[divisor.len() - 1])?;
+        let shift = dividend.len() - divisor.len();
+        quotient[shift] = lead;
+        for k in 0..divisor.len() {
+            dividend[shift + k] = dividend[shift + k].sub(lead.mul(divisor[k]));
+        }
+        trim_rational(&mut dividend);
+    }
+
+    trim_rational(&mut quotient);
+    Some((quotient, dividend))
+}
+
+fn trim_rational(values: &mut Vec<Rational>) {
+    while values.last().is_some_and(Rational::is_zero) {
+        values.pop();
+    }
+}
+
+fn normalize_positive_leading(poly: &[i64]) -> Poly {
+    let normalized = normalize(poly);
+    if normalized.last().is_some_and(|&lead| lead < 0) {
+        normalized.into_iter().map(|coeff| -coeff).collect()
+    } else {
+        normalized
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Rational {
+    numer: i128,
+    denom: i128,
+}
+
+impl Rational {
+    fn new(numer: i128, denom: i128) -> Option<Self> {
+        if denom == 0 {
+            return None;
+        }
+        if numer == 0 {
+            return Some(Self::zero());
+        }
+
+        let sign = if denom < 0 { -1 } else { 1 };
+        let numer = numer * sign;
+        let denom = denom.abs();
+        let g = gcd_i128(numer.abs(), denom);
+        Some(Self {
+            numer: numer / g,
+            denom: denom / g,
+        })
+    }
+
+    fn zero() -> Self {
+        Self { numer: 0, denom: 1 }
+    }
+
+    fn one() -> Self {
+        Self { numer: 1, denom: 1 }
+    }
+
+    fn from_i64(value: i64) -> Self {
+        Self {
+            numer: value as i128,
+            denom: 1,
+        }
+    }
+
+    fn add(self, rhs: Self) -> Self {
+        Self::new(
+            self.numer * rhs.denom + rhs.numer * self.denom,
+            self.denom * rhs.denom,
+        )
+        .expect("non-zero denominator")
+    }
+
+    fn sub(self, rhs: Self) -> Self {
+        Self::new(
+            self.numer * rhs.denom - rhs.numer * self.denom,
+            self.denom * rhs.denom,
+        )
+        .expect("non-zero denominator")
+    }
+
+    fn mul(self, rhs: Self) -> Self {
+        Self::new(self.numer * rhs.numer, self.denom * rhs.denom).expect("non-zero denominator")
+    }
+
+    fn div(self, rhs: Self) -> Option<Self> {
+        Self::new(self.numer * rhs.denom, self.denom * rhs.numer)
+    }
+
+    fn is_zero(&self) -> bool {
+        self.numer == 0
+    }
+
+    fn to_i64(self) -> Option<i64> {
+        if self.denom != 1 {
+            return None;
+        }
+        i64::try_from(self.numer).ok()
+    }
+}
+
+fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
+    a = a.abs();
+    b = b.abs();
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signed_divisors_include_both_signs() {
+        assert_eq!(signed_divisors(4), vec![1, -1, 2, -2, 4, -4]);
+    }
+
+    #[test]
+    fn rational_reduces_negative_denominator() {
+        assert_eq!(
+            Rational::new(2, -4),
+            Some(Rational {
+                numer: -1,
+                denom: 2
+            })
+        );
+    }
+}

--- a/code/packages/rust/cas-factor/src/lib.rs
+++ b/code/packages/rust/cas-factor/src/lib.rs
@@ -1,7 +1,7 @@
 //! # cas-factor
 //!
-//! Univariate integer polynomial factoring over ℤ (Phase 1: linear factors
-//! via the rational-root test).
+//! Univariate integer polynomial factoring over ℤ (linear factors plus
+//! Kronecker residual splitting).
 //!
 //! ## Quick start
 //!
@@ -24,11 +24,11 @@
 //! Polynomials are `Vec<i64>` coefficient lists with the constant term first:
 //! `[a_0, a_1, ..., a_n]` represents `a_0 + a_1·x + … + a_n·x^n`.
 //!
-//! ## What Phase 1 covers
+//! ## What the current Rust port covers
 //!
 //! Phase 1 uses the Rational Root Theorem to find all **integer** roots.
-//! Any irreducible residual (e.g., `x^2 + 1`) is appended with multiplicity 1.
-//! Full Kronecker factorization and factoring over ℚ is Phase 2.
+//! Phase 2 uses Kronecker's method to split primitive residuals such as
+//! `x^4 + 4` and `x^4 + x^2 + 1`. BZH is intentionally not implemented yet.
 //!
 //! ## IR head names
 //!
@@ -40,10 +40,12 @@
 //! | [`IRREDUCIBLE`] | `"Irreducible"` |
 
 pub mod factor;
+pub mod kronecker;
 pub mod polynomial;
 pub mod rational_roots;
 
 pub use factor::{factor_integer_polynomial, FactorList};
+pub use kronecker::kronecker_factor;
 pub use polynomial::{
     content, degree, divide_linear, divisors, evaluate, normalize, primitive_part, Poly,
 };

--- a/code/packages/rust/cas-factor/src/rational_roots.rs
+++ b/code/packages/rust/cas-factor/src/rational_roots.rs
@@ -51,10 +51,7 @@ pub fn find_integer_roots(p: &[i64]) -> Vec<i64> {
     }
     // Candidate set: ±divisors(constant_term).
     let pos_divs = divisors(constant);
-    let mut candidates: Vec<i64> = pos_divs
-        .iter()
-        .flat_map(|&d| [d, -d])
-        .collect();
+    let mut candidates: Vec<i64> = pos_divs.iter().flat_map(|&d| [d, -d]).collect();
     candidates.sort_unstable();
     candidates.dedup();
 

--- a/code/packages/rust/cas-factor/tests/tests.rs
+++ b/code/packages/rust/cas-factor/tests/tests.rs
@@ -5,7 +5,7 @@
 
 use cas_factor::{
     content, degree, divide_linear, divisors, evaluate, extract_linear_factors,
-    factor_integer_polynomial, find_integer_roots, normalize, primitive_part,
+    factor_integer_polynomial, find_integer_roots, kronecker_factor, normalize, primitive_part,
 };
 
 // ---------------------------------------------------------------------------
@@ -164,6 +164,37 @@ fn extract_mixed_linear_and_irreducible() {
 }
 
 // ---------------------------------------------------------------------------
+// kronecker
+// ---------------------------------------------------------------------------
+
+#[test]
+fn kronecker_splits_sophie_germain() {
+    let split = kronecker_factor(&[4, 0, 0, 0, 1]).expect("x^4 + 4 should split");
+    let mut factors = vec![split.0, split.1];
+    factors.sort();
+    assert_eq!(factors, vec![vec![2, -2, 1], vec![2, 2, 1]]);
+}
+
+#[test]
+fn kronecker_splits_x4_plus_x2_plus_one() {
+    let split = kronecker_factor(&[1, 0, 1, 0, 1]).expect("x^4 + x^2 + 1 should split");
+    let mut factors = vec![split.0, split.1];
+    factors.sort();
+    assert_eq!(factors, vec![vec![1, -1, 1], vec![1, 1, 1]]);
+}
+
+#[test]
+fn kronecker_splits_repeated_quadratic_once() {
+    let split = kronecker_factor(&[1, 0, 2, 0, 1]).expect("(x^2 + 1)^2 should split");
+    assert_eq!(split, (vec![1, 0, 1], vec![1, 0, 1]));
+}
+
+#[test]
+fn kronecker_leaves_irreducible_quadratic() {
+    assert_eq!(kronecker_factor(&[1, 0, 1]), None);
+}
+
+// ---------------------------------------------------------------------------
 // factor_integer_polynomial
 // ---------------------------------------------------------------------------
 
@@ -194,6 +225,29 @@ fn factor_irreducible_quadratic() {
 }
 
 #[test]
+fn factor_sophie_germain_with_kronecker_residual() {
+    let (c, mut factors) = factor_integer_polynomial(&[4, 0, 0, 0, 1]);
+    assert_eq!(c, 1);
+    factors.sort_by_key(|(f, _)| f.clone());
+    assert_eq!(factors, vec![(vec![2, -2, 1], 1), (vec![2, 2, 1], 1)]);
+}
+
+#[test]
+fn factor_x4_plus_x2_plus_one_with_kronecker_residual() {
+    let (c, mut factors) = factor_integer_polynomial(&[1, 0, 1, 0, 1]);
+    assert_eq!(c, 1);
+    factors.sort_by_key(|(f, _)| f.clone());
+    assert_eq!(factors, vec![(vec![1, -1, 1], 1), (vec![1, 1, 1], 1)]);
+}
+
+#[test]
+fn factor_repeated_quadratic_with_kronecker_residual() {
+    let (c, factors) = factor_integer_polynomial(&[1, 0, 2, 0, 1]);
+    assert_eq!(c, 1);
+    assert_eq!(factors, vec![(vec![1, 0, 1], 2)]);
+}
+
+#[test]
 fn factor_cubic() {
     // x^3 - 6x^2 + 11x - 6 = (x-1)(x-2)(x-3)
     let (c, mut factors) = factor_integer_polynomial(&[-6, 11, -6, 1]);
@@ -211,8 +265,7 @@ fn factor_with_zero_root() {
     let (c, mut factors) = factor_integer_polynomial(&[0, -1, 0, 1]);
     assert_eq!(c, 1);
     factors.sort_by_key(|(f, _)| f.clone());
-    let expected: Vec<(Vec<i64>, usize)> =
-        vec![(vec![-1, 1], 1), (vec![0, 1], 1), (vec![1, 1], 1)];
+    let expected: Vec<(Vec<i64>, usize)> = vec![(vec![-1, 1], 1), (vec![0, 1], 1), (vec![1, 1], 1)];
     assert_eq!(factors, expected);
 }
 


### PR DESCRIPTION
## Summary
- add a public Rust kronecker_factor API for primitive integer polynomial splits
- recursively apply Kronecker splitting inside factor_integer_polynomial residual factoring
- cover Sophie Germain, x^4+x^2+1, repeated quadratic, irreducible quadratic, and integration cases

## Validation
- cargo fmt -p cas-factor
- cargo test -p cas-factor
- cargo check -p cas-factor