### PR TITLE
[codex] Port TS cas-matrix linear algebra

### DIFF
--- a/code/packages/typescript/cas-matrix/CHANGELOG.md
+++ b/code/packages/typescript/cas-matrix/CHANGELOG.md
@@ -4,3 +4,5 @@
 
 - Port matrix construction, shape helpers, arithmetic, determinant, and inverse
   to pure TypeScript.
+- Add exact rational norms, LU decomposition with partial pivoting, and
+  nullspace/columnspace/rowspace basis operations.

--- a/code/packages/typescript/cas-matrix/README.md
+++ b/code/packages/typescript/cas-matrix/README.md
@@ -30,3 +30,8 @@ fold numeric entries.
 | `inverse(m)` | Symbolic adjugate inverse |
 | `rowReduce(m)` | Exact rational reduced row echelon form for integer/rational matrices |
 | `rank(m)` | Exact rational matrix rank for integer/rational matrices |
+| `norm(m)` / `frobeniusNorm(m)` | Exact Euclidean vector norm or Frobenius matrix norm |
+| `luDecompose(m)` | Exact LU decomposition with partial pivoting, returned as `List(L, U, P)` |
+| `nullspace(m)` | Exact rational nullspace basis as `List(columnVector, ...)` |
+| `columnspace(m)` | Exact rational columnspace basis from original pivot columns |
+| `rowspace(m)` | Exact rational rowspace basis from non-zero RREF rows |

--- a/code/packages/typescript/cas-matrix/src/index.ts
+++ b/code/packages/typescript/cas-matrix/src/index.ts
@@ -4,6 +4,7 @@ import {
   LIST,
   MUL,
   NEG,
+  SQRT,
   SUB,
   app,
   headName,
@@ -241,6 +242,109 @@ export function rank(node: IRNode): IRInteger {
   return int(nonZeroRows);
 }
 
+export function norm(node: IRNode, kind?: string): IRNode {
+  const rows = rowsOf(node);
+  const nrows = rows.length;
+  const ncols = rows[0]?.length ?? 0;
+  if (kind !== undefined && kind !== "frobenius") {
+    throw new MatrixError(`norm: unknown norm kind ${JSON.stringify(kind)}; use 'frobenius' or undefined`);
+  }
+  if (kind === undefined && ncols !== 1 && nrows !== 1) {
+    throw new MatrixError(
+      `norm: Euclidean norm requires a column or row vector (got ${nrows}x${ncols}); use norm(M, 'frobenius') for matrices`,
+    );
+  }
+
+  const total = matrixToRationals(node)
+    .flat()
+    .reduce((acc, entry) => acc.add(entry.mul(entry)), RationalValue.zero());
+  return sqrtRationalToIr(total);
+}
+
+export function frobeniusNorm(node: IRNode): IRNode {
+  return norm(node, "frobenius");
+}
+
+export function luDecompose(node: IRNode): IRNode {
+  const n = numRows(node);
+  const ncols = numCols(node);
+  if (n !== ncols) {
+    throw new MatrixError(`luDecompose: matrix must be square, got ${n}x${ncols}`);
+  }
+
+  const u = matrixToRationals(node).map((row) => [...row]);
+  const l = identityRationals(n);
+  const p = identityRationals(n);
+
+  for (let k = 0; k < n; k += 1) {
+    let bestRow = k;
+    for (let row = k + 1; row < n; row += 1) {
+      if (compareAbsRational(u[row][k], u[bestRow][k]) > 0) {
+        bestRow = row;
+      }
+    }
+
+    if (bestRow !== k) {
+      [u[k], u[bestRow]] = [u[bestRow], u[k]];
+      [p[k], p[bestRow]] = [p[bestRow], p[k]];
+      for (let col = 0; col < k; col += 1) {
+        [l[k][col], l[bestRow][col]] = [l[bestRow][col], l[k][col]];
+      }
+    }
+
+    const pivot = u[k][k];
+    if (pivot.isZero()) {
+      throw new MatrixError(`luDecompose: singular matrix (zero pivot at column ${k})`);
+    }
+
+    for (let row = k + 1; row < n; row += 1) {
+      const factor = u[row][k].div(pivot);
+      l[row][k] = factor;
+      for (let col = k; col < n; col += 1) {
+        u[row][col] = u[row][col].sub(factor.mul(u[k][col]));
+      }
+    }
+  }
+
+  return app(LIST, [rationalsToMatrix(l), rationalsToMatrix(u), rationalsToMatrix(p)]);
+}
+
+export function nullspace(node: IRNode): IRNode {
+  const frows = matrixToRationals(node);
+  const ncols = frows[0]?.length ?? 0;
+  const { pivotCols, rref } = rrefPivotInfo(frows);
+  const pivotSet = new Set(pivotCols);
+  const basis: IRNode[] = [];
+
+  for (let freeCol = 0; freeCol < ncols; freeCol += 1) {
+    if (pivotSet.has(freeCol)) continue;
+
+    const vector = Array.from({ length: ncols }, () => RationalValue.zero());
+    vector[freeCol] = RationalValue.one();
+    pivotCols.forEach((pivotCol, pivotRow) => {
+      vector[pivotCol] = rref[pivotRow][freeCol].neg();
+    });
+    basis.push(rationalsToMatrix(vector.map((entry) => [entry])));
+  }
+
+  return app(LIST, basis);
+}
+
+export function columnspace(node: IRNode): IRNode {
+  const { pivotCols } = rrefPivotInfo(matrixToRationals(node));
+  const originalRows = rowsOf(node);
+  const basis = pivotCols.map((col) => matrix(originalRows.map((row) => [row[col]])));
+  return app(LIST, basis);
+}
+
+export function rowspace(node: IRNode): IRNode {
+  const { rref } = rrefPivotInfo(matrixToRationals(node));
+  const basis = rref
+    .filter((row) => row.some((entry) => !entry.isZero()))
+    .map((row) => rationalsToMatrix([row]));
+  return app(LIST, basis);
+}
+
 function rowArgs(row: IRNode): IRNode[] {
   if (row.kind === "apply" && headName(row.head) === LIST.name) {
     return [...row.args];
@@ -297,6 +401,93 @@ function rationalToIr(value: RationalValue): IRNode {
   return value.denom === 1n ? int(value.numer) : rational(value.numer, value.denom);
 }
 
+function rationalsToMatrix(rows: readonly (readonly RationalValue[])[]): IRNode {
+  return matrix(rows.map((row) => row.map(rationalToIr)));
+}
+
+function identityRationals(n: number): RationalValue[][] {
+  return Array.from({ length: n }, (_, row) =>
+    Array.from({ length: n }, (_, col) => (row === col ? RationalValue.one() : RationalValue.zero())));
+}
+
+function rrefPivotInfo(rows: readonly (readonly RationalValue[])[]): { pivotCols: number[]; rref: RationalValue[][] } {
+  const rref = rows.map((row) => [...row]);
+  const nrows = rref.length;
+  const ncols = rref[0]?.length ?? 0;
+  const pivotCols: number[] = [];
+  let pivotRow = 0;
+
+  for (let col = 0; col < ncols && pivotRow < nrows; col += 1) {
+    let pivotPos = -1;
+    for (let row = pivotRow; row < nrows; row += 1) {
+      if (!rref[row][col].isZero()) {
+        pivotPos = row;
+        break;
+      }
+    }
+    if (pivotPos === -1) continue;
+
+    if (pivotPos !== pivotRow) {
+      [rref[pivotRow], rref[pivotPos]] = [rref[pivotPos], rref[pivotRow]];
+    }
+
+    const pivot = rref[pivotRow][col];
+    rref[pivotRow] = rref[pivotRow].map((entry) => entry.div(pivot));
+
+    for (let row = 0; row < nrows; row += 1) {
+      if (row === pivotRow) continue;
+      const factor = rref[row][col];
+      if (factor.isZero()) continue;
+      rref[row] = rref[row].map((entry, entryCol) => entry.sub(factor.mul(rref[pivotRow][entryCol])));
+    }
+
+    pivotCols.push(col);
+    pivotRow += 1;
+  }
+
+  return { pivotCols, rref };
+}
+
+function sqrtRationalToIr(value: RationalValue): IRNode {
+  if (value.numer < 0n) return app(SQRT, [rationalToIr(value)]);
+  const numerRoot = exactIntegerSqrt(value.numer);
+  const denomRoot = exactIntegerSqrt(value.denom);
+  if (numerRoot !== null && denomRoot !== null) {
+    return rationalToIr(new RationalValue(numerRoot, denomRoot));
+  }
+  return app(SQRT, [rationalToIr(value)]);
+}
+
+function exactIntegerSqrt(value: bigint): bigint | null {
+  const root = integerSqrt(value);
+  return root * root === value ? root : null;
+}
+
+function integerSqrt(value: bigint): bigint {
+  if (value < 0n) throw new RangeError("integerSqrt requires a non-negative input");
+  if (value < 2n) return value;
+  let low = 1n;
+  let high = value;
+  while (low <= high) {
+    const mid = (low + high) / 2n;
+    const square = mid * mid;
+    if (square === value) return mid;
+    if (square < value) {
+      low = mid + 1n;
+    } else {
+      high = mid - 1n;
+    }
+  }
+  return high;
+}
+
+function compareAbsRational(a: RationalValue, b: RationalValue): number {
+  const left = abs(a.numer) * b.denom;
+  const right = abs(b.numer) * a.denom;
+  if (left === right) return 0;
+  return left > right ? 1 : -1;
+}
+
 class RationalValue {
   readonly numer: bigint;
   readonly denom: bigint;
@@ -314,12 +505,28 @@ class RationalValue {
     this.denom = d / g;
   }
 
+  static zero(): RationalValue {
+    return new RationalValue(0n, 1n);
+  }
+
+  static one(): RationalValue {
+    return new RationalValue(1n, 1n);
+  }
+
   isZero(): boolean {
     return this.numer === 0n;
   }
 
+  add(other: RationalValue): RationalValue {
+    return new RationalValue(this.numer * other.denom + other.numer * this.denom, this.denom * other.denom);
+  }
+
   sub(other: RationalValue): RationalValue {
     return new RationalValue(this.numer * other.denom - other.numer * this.denom, this.denom * other.denom);
+  }
+
+  neg(): RationalValue {
+    return new RationalValue(-this.numer, this.denom);
   }
 
   mul(other: RationalValue): RationalValue {

--- a/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
+++ b/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
@@ -3,26 +3,32 @@ import {
   MATRIX,
   MatrixError,
   addMatrices,
+  columnspace,
   determinant,
   dimensions,
   dot,
+  frobeniusNorm,
   getEntry,
   identityMatrix,
   inverse,
   isMatrix,
+  luDecompose,
   matrix,
+  norm,
   numCols,
   numRows,
+  nullspace,
   rank,
   rowsOf,
   rowReduce,
+  rowspace,
   scalarMultiply,
   subMatrices,
   trace,
   transpose,
   zeroMatrix,
 } from "../src/index";
-import { ADD, LIST, MUL, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { ADD, LIST, MUL, SQRT, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
 
 function irow(values: readonly number[]): IRNode[] {
   return values.map((value) => int(value));
@@ -197,5 +203,77 @@ describe("rowReduce and rank", () => {
     const m = matrix([[sym("a"), int(1)], [int(0), int(1)]]);
     expect(() => rowReduce(m)).toThrow(MatrixError);
     expect(() => rank(m)).toThrow(MatrixError);
+  });
+});
+
+describe("norms", () => {
+  it("computes exact Euclidean vector norms", () => {
+    const column = matrix([irow([3]), irow([4])]);
+    const row = matrix([irow([3, 4])]);
+    const rationalVector = matrix([[rational(3, 5)], [rational(4, 5)]]);
+    expect(norm(column)).toEqual(int(5));
+    expect(norm(row)).toEqual(int(5));
+    expect(norm(rationalVector)).toEqual(int(1));
+  });
+
+  it("returns Sqrt for non-perfect-square norms", () => {
+    expect(norm(matrix([irow([1]), irow([1])]))).toEqual(app(SQRT, [int(2)]));
+  });
+
+  it("computes Frobenius norms and rejects matrix Euclidean norms", () => {
+    expect(frobeniusNorm(matrix([irow([1, 1]), irow([1, 1])]))).toEqual(int(2));
+    expect(norm(identityMatrix(3), "frobenius")).toEqual(app(SQRT, [int(3)]));
+    expect(() => norm(matrix([irow([1, 2]), irow([3, 4])]))).toThrow(MatrixError);
+    expect(() => norm(matrix([irow([1, 2])]), "spectral")).toThrow(MatrixError);
+  });
+});
+
+describe("LU decomposition", () => {
+  it("returns List(L, U, P) for matrices that require pivoting", () => {
+    const result = luDecompose(matrix([irow([0, 1]), irow([1, 0])]));
+    expect(result).toEqual(app(LIST, [
+      identityMatrix(2),
+      identityMatrix(2),
+      matrix([irow([0, 1]), irow([1, 0])]),
+    ]));
+  });
+
+  it("keeps exact rational multipliers", () => {
+    const result = luDecompose(matrix([irow([2, 1]), irow([1, 3])]));
+    expect(result.kind).toBe("apply");
+    if (result.kind !== "apply") return;
+    const [l, u, p] = result.args;
+    expect(l).toEqual(matrix([[int(1), int(0)], [rational(1, 2), int(1)]]));
+    expect(u).toEqual(matrix([[int(2), int(1)], [int(0), rational(5, 2)]]));
+    expect(p).toEqual(identityMatrix(2));
+  });
+
+  it("rejects singular and non-square matrices", () => {
+    expect(() => luDecompose(zeroMatrix(2, 2))).toThrow(MatrixError);
+    expect(() => luDecompose(matrix([irow([1, 2, 3]), irow([4, 5, 6])]))).toThrow(MatrixError);
+  });
+});
+
+describe("subspaces", () => {
+  it("computes nullspace bases as a List of column-vector matrices", () => {
+    const basis = nullspace(matrix([irow([1, 2, 3]), irow([4, 5, 6])]));
+    expect(basis).toEqual(app(LIST, [
+      matrix([irow([1]), irow([-2]), irow([1])]),
+    ]));
+    expect(nullspace(identityMatrix(2))).toEqual(app(LIST, []));
+  });
+
+  it("computes columnspace from original pivot columns", () => {
+    const basis = columnspace(matrix([irow([1, 2]), irow([2, 4])]));
+    expect(basis).toEqual(app(LIST, [
+      matrix([irow([1]), irow([2])]),
+    ]));
+  });
+
+  it("computes rowspace from non-zero RREF rows", () => {
+    const basis = rowspace(matrix([irow([1, 2, 3]), irow([2, 4, 6])]));
+    expect(basis).toEqual(app(LIST, [
+      matrix([irow([1, 2, 3])]),
+    ]));
   });
 });


### PR DESCRIPTION
## Summary
- port exact TypeScript cas-matrix norms and Frobenius norm over symbolic IR matrices
- add exact LU decomposition with partial pivoting returning `List(L, U, P)`
- add RREF-derived nullspace, columnspace, and rowspace APIs returning `List(...)` basis nodes
- document the new public APIs and add focused Vitest coverage

## Validation
- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage`

Eigenvalues/eigenvectors are intentionally out of scope for this slice.