### PR TITLE
Add Rust cas-matrix linear algebra APIs

### DIFF
--- a/code/packages/rust/cas-matrix/CHANGELOG.md
+++ b/code/packages/rust/cas-matrix/CHANGELOG.md
@@ -8,6 +8,12 @@
   forward-elimination `rank(m)` for integer/rational matrices.
 - Row-reduction tests covering identity, zero, full-rank, singular, rational
   dependent rows, wide/tall rank, and symbolic-entry errors.
+- Exact rational `norm(m)` and `frobenius_norm(m)` APIs, returning exact
+  integer/rational results or `Sqrt(...)` IR when needed.
+- Exact rational `lu_decompose(m)` with partial pivoting, returning
+  `List(L, U, P)`.
+- Exact rational `nullspace(m)`, `columnspace(m)`, and `rowspace(m)` APIs,
+  each returning basis matrices inside `List(...)` IR nodes.
 
 ## [0.1.0] — 2026-04-27
 

--- a/code/packages/rust/cas-matrix/README.md
+++ b/code/packages/rust/cas-matrix/README.md
@@ -26,6 +26,12 @@ All arithmetic produces unevaluated IR; pass through `cas_simplify::simplify` to
 | `inverse(m)` | Adjugate/determinant (symbolic) |
 | `row_reduce(m)` | Exact rational Gauss-Jordan RREF for integer/rational entries |
 | `rank(m)` | Exact rational row rank for integer/rational entries |
+| `norm(m)` | Exact Euclidean norm for row/column vectors |
+| `frobenius_norm(m)` | Exact Frobenius norm for numeric matrices |
+| `lu_decompose(m)` | Exact LU decomposition with partial pivoting; returns `List(L, U, P)` |
+| `nullspace(m)` | Exact null-space basis as `List(...)` of column-vector matrices |
+| `columnspace(m)` | Exact column-space basis from original pivot columns |
+| `rowspace(m)` | Exact row-space basis from non-zero RREF rows |
 
 ## Usage
 
@@ -49,8 +55,9 @@ let d = determinant(&m).unwrap();
 
 All fallible operations return `MatrixResult<IRNode>` (= `Result<IRNode, MatrixError>`).
 
-`row_reduce` and `rank` are numeric-only: integer and rational entries are
-accepted, while symbolic entries return `MatrixError`.
+`row_reduce`, `rank`, norms, LU decomposition, and subspace operations are
+numeric-only: integer and rational entries are accepted, while symbolic entries
+return `MatrixError`.
 
 ## Stack position
 

--- a/code/packages/rust/cas-matrix/src/lib.rs
+++ b/code/packages/rust/cas-matrix/src/lib.rs
@@ -46,16 +46,22 @@
 
 pub mod arithmetic;
 pub mod determinant;
+pub mod lu;
 pub mod matrix;
+pub mod norms;
 pub mod rowreduce;
+pub mod subspaces;
 
 pub use arithmetic::{
     add_matrices, dot, identity_matrix, scalar_multiply, sub_matrices, trace, transpose,
     zero_matrix,
 };
 pub use determinant::{determinant, inverse};
+pub use lu::lu_decompose;
 pub use matrix::{
     dimensions, get_entry, is_matrix, matrix, num_cols, num_rows, rows_of, MatrixError,
     MatrixResult, MATRIX,
 };
+pub use norms::{frobenius_norm, norm};
 pub use rowreduce::{rank, row_reduce};
+pub use subspaces::{columnspace, nullspace, rowspace};

--- a/code/packages/rust/cas-matrix/src/lu.rs
+++ b/code/packages/rust/cas-matrix/src/lu.rs
@@ -1,0 +1,93 @@
+//! LU decomposition with partial pivoting.
+//!
+//! Returns `List(L, U, P)` where `P * A = L * U`, matching the Python
+//! cas-matrix API shape.
+
+use symbolic_ir::{apply, sym, IRNode, LIST};
+
+use crate::matrix::{num_cols, num_rows, MatrixError, MatrixResult};
+use crate::rowreduce::{fracs_to_matrix, matrix_to_fracs, Frac};
+
+/// Compute the LU decomposition of a square numeric matrix.
+///
+/// The implementation uses exact rational arithmetic and partial pivoting.
+/// Singular matrices return `MatrixError`.
+pub fn lu_decompose(m: &IRNode) -> MatrixResult<IRNode> {
+    let n = num_rows(m)?;
+    let ncols = num_cols(m)?;
+    if n != ncols {
+        return Err(MatrixError(format!(
+            "lu_decompose: matrix must be square, got {n}×{ncols}"
+        )));
+    }
+
+    let mut u = matrix_to_fracs(m)?;
+    let mut l = identity_fracs(n);
+    let mut p = identity_fracs(n);
+
+    for k in 0..n {
+        let mut best_row = k;
+        let mut best_value = u[k][k].abs();
+        for (row, entries) in u.iter().enumerate().skip(k + 1) {
+            let candidate = entries[k].abs();
+            if greater_frac(candidate, best_value) {
+                best_value = candidate;
+                best_row = row;
+            }
+        }
+
+        if best_row != k {
+            u.swap(k, best_row);
+            p.swap(k, best_row);
+            for col in 0..k {
+                let tmp = l[k][col];
+                l[k][col] = l[best_row][col];
+                l[best_row][col] = tmp;
+            }
+        }
+
+        let pivot = u[k][k];
+        if pivot.is_zero() {
+            return Err(MatrixError(format!(
+                "lu_decompose: singular matrix (zero pivot at column {k})"
+            )));
+        }
+
+        for row in (k + 1)..n {
+            let factor = u[row][k] / pivot;
+            l[row][k] = factor;
+            for col in k..n {
+                u[row][col] = u[row][col] - factor * u[k][col];
+            }
+        }
+    }
+
+    Ok(apply(
+        sym(LIST),
+        vec![
+            fracs_to_matrix(l)?,
+            fracs_to_matrix(u)?,
+            fracs_to_matrix(p)?,
+        ],
+    ))
+}
+
+fn identity_fracs(n: usize) -> Vec<Vec<Frac>> {
+    (0..n)
+        .map(|row| {
+            (0..n)
+                .map(|col| {
+                    if row == col {
+                        Frac::from_i64(1)
+                    } else {
+                        Frac::zero()
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn greater_frac(left: Frac, right: Frac) -> bool {
+    left.numer * right.denom > right.numer * left.denom
+}

--- a/code/packages/rust/cas-matrix/src/norms.rs
+++ b/code/packages/rust/cas-matrix/src/norms.rs
@@ -1,0 +1,73 @@
+//! Exact vector and Frobenius norms for rational matrices.
+//!
+//! `norm` computes the Euclidean norm for a row or column vector.  Use
+//! `frobenius_norm` for a general matrix.
+
+use symbolic_ir::{apply, sym, IRNode, SQRT};
+
+use crate::matrix::{num_cols, num_rows, MatrixError, MatrixResult};
+use crate::rowreduce::{matrix_to_fracs, Frac};
+
+/// Compute the Euclidean norm of a row or column vector.
+///
+/// Numeric integer/rational entries are evaluated exactly.  Perfect-square
+/// sums return an integer/rational IR node; otherwise the result is
+/// `Sqrt(sum_of_squares)`.
+pub fn norm(m: &IRNode) -> MatrixResult<IRNode> {
+    let nr = num_rows(m)?;
+    let nc = num_cols(m)?;
+    if nr != 1 && nc != 1 {
+        return Err(MatrixError(format!(
+            "norm: Euclidean norm requires a column or row vector (got {nr}×{nc}); use frobenius_norm for matrices"
+        )));
+    }
+    norm_from_entries(m)
+}
+
+/// Compute the Frobenius norm of any numeric matrix.
+pub fn frobenius_norm(m: &IRNode) -> MatrixResult<IRNode> {
+    norm_from_entries(m)
+}
+
+fn norm_from_entries(m: &IRNode) -> MatrixResult<IRNode> {
+    let total = matrix_to_fracs(m)?
+        .into_iter()
+        .flatten()
+        .fold(Frac::zero(), |acc, entry| acc + entry * entry);
+    sqrt_frac(total)
+}
+
+fn sqrt_frac(total: Frac) -> MatrixResult<IRNode> {
+    if let Some(exact) = isqrt_frac(total) {
+        return exact.to_irnode();
+    }
+    Ok(apply(sym(SQRT), vec![total.to_irnode()?]))
+}
+
+fn isqrt_frac(value: Frac) -> Option<Frac> {
+    if value.numer < 0 || value.denom < 0 {
+        return None;
+    }
+    let numer = u128::try_from(value.numer).ok()?;
+    let denom = u128::try_from(value.denom).ok()?;
+    let sqrt_numer = isqrt(numer);
+    let sqrt_denom = isqrt(denom);
+    if sqrt_numer * sqrt_numer == numer && sqrt_denom * sqrt_denom == denom {
+        Some(Frac::new(sqrt_numer as i128, sqrt_denom as i128))
+    } else {
+        None
+    }
+}
+
+fn isqrt(n: u128) -> u128 {
+    if n < 2 {
+        return n;
+    }
+    let mut x = n;
+    let mut y = (x + n / x) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}

--- a/code/packages/rust/cas-matrix/src/rowreduce.rs
+++ b/code/packages/rust/cas-matrix/src/rowreduce.rs
@@ -93,14 +93,14 @@ pub fn rank(m: &IRNode) -> MatrixResult<IRNode> {
     Ok(int(rank as i64))
 }
 
-fn matrix_to_fracs(m: &IRNode) -> MatrixResult<Vec<Vec<Frac>>> {
+pub(crate) fn matrix_to_fracs(m: &IRNode) -> MatrixResult<Vec<Vec<Frac>>> {
     rows_of(m)?
         .into_iter()
         .map(|row| row.into_iter().map(entry_to_frac).collect())
         .collect()
 }
 
-fn entry_to_frac(entry: IRNode) -> MatrixResult<Frac> {
+pub(crate) fn entry_to_frac(entry: IRNode) -> MatrixResult<Frac> {
     match entry {
         IRNode::Integer(value) => Ok(Frac::from_i64(value)),
         IRNode::Rational(numer, denom) => Ok(Frac::new(numer as i128, denom as i128)),
@@ -110,7 +110,7 @@ fn entry_to_frac(entry: IRNode) -> MatrixResult<Frac> {
     }
 }
 
-fn fracs_to_matrix(rows: Vec<Vec<Frac>>) -> MatrixResult<IRNode> {
+pub(crate) fn fracs_to_matrix(rows: Vec<Vec<Frac>>) -> MatrixResult<IRNode> {
     rows.into_iter()
         .map(|row| row.into_iter().map(Frac::to_irnode).collect())
         .collect::<MatrixResult<Vec<Vec<IRNode>>>>()
@@ -121,17 +121,17 @@ fn fracs_to_matrix(rows: Vec<Vec<Frac>>) -> MatrixResult<IRNode> {
 ///
 /// `denom > 0`; the sign is always carried by `numer`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Frac {
-    numer: i128,
-    denom: i128,
+pub(crate) struct Frac {
+    pub(crate) numer: i128,
+    pub(crate) denom: i128,
 }
 
 impl Frac {
-    fn zero() -> Self {
+    pub(crate) fn zero() -> Self {
         Self { numer: 0, denom: 1 }
     }
 
-    fn new(numer: i128, denom: i128) -> Self {
+    pub(crate) fn new(numer: i128, denom: i128) -> Self {
         assert!(denom != 0, "Frac denominator must not be zero");
         if numer == 0 {
             return Self::zero();
@@ -148,18 +148,25 @@ impl Frac {
         }
     }
 
-    fn from_i64(value: i64) -> Self {
+    pub(crate) fn from_i64(value: i64) -> Self {
         Self {
             numer: value as i128,
             denom: 1,
         }
     }
 
-    fn is_zero(self) -> bool {
+    pub(crate) fn is_zero(self) -> bool {
         self.numer == 0
     }
 
-    fn to_irnode(self) -> MatrixResult<IRNode> {
+    pub(crate) fn abs(self) -> Self {
+        Self {
+            numer: self.numer.abs(),
+            denom: self.denom,
+        }
+    }
+
+    pub(crate) fn to_irnode(self) -> MatrixResult<IRNode> {
         let numer = i64::try_from(self.numer).map_err(|_| {
             MatrixError(format!(
                 "row_reduce/rank: numerator overflow: {}",

--- a/code/packages/rust/cas-matrix/src/subspaces.rs
+++ b/code/packages/rust/cas-matrix/src/subspaces.rs
@@ -1,0 +1,129 @@
+//! Nullspace, columnspace, and rowspace via exact RREF.
+//!
+//! Each public function returns a `List(...)` IR node containing matrix-vector
+//! basis elements.  Empty lists represent trivial subspaces.
+
+use symbolic_ir::{apply, sym, IRNode, LIST};
+
+use crate::matrix::{matrix, rows_of, MatrixResult};
+use crate::rowreduce::{matrix_to_fracs, Frac};
+
+/// Return a basis for the null space of `m`.
+///
+/// Basis vectors are returned as `n×1` column-vector matrices inside a
+/// `List(...)` node.
+pub fn nullspace(m: &IRNode) -> MatrixResult<IRNode> {
+    let frows = matrix_to_fracs(m)?;
+    let ncols = frows.first().map_or(0, |row| row.len());
+    let (pivot_cols, rref) = rref_pivot_info(&frows);
+    let free_cols: Vec<usize> = (0..ncols).filter(|col| !pivot_cols.contains(col)).collect();
+
+    let mut basis = Vec::new();
+    for free_col in free_cols {
+        let mut vector = vec![Frac::zero(); ncols];
+        vector[free_col] = Frac::from_i64(1);
+
+        for (pivot_row, pivot_col) in pivot_cols.iter().enumerate() {
+            vector[*pivot_col] = -rref[pivot_row][free_col];
+        }
+
+        let rows = vector
+            .into_iter()
+            .map(|entry| Ok(vec![entry.to_irnode()?]))
+            .collect::<MatrixResult<Vec<Vec<IRNode>>>>()?;
+        basis.push(matrix(rows)?);
+    }
+
+    Ok(apply(sym(LIST), basis))
+}
+
+/// Return a basis for the column space of `m`.
+///
+/// The basis uses pivot columns from the original input matrix.
+pub fn columnspace(m: &IRNode) -> MatrixResult<IRNode> {
+    let frows = matrix_to_fracs(m)?;
+    let (pivot_cols, _) = rref_pivot_info(&frows);
+    let orig_rows = rows_of(m)?;
+    let nrows = orig_rows.len();
+
+    let basis = pivot_cols
+        .into_iter()
+        .map(|col| {
+            let rows = (0..nrows)
+                .map(|row| vec![orig_rows[row][col].clone()])
+                .collect();
+            matrix(rows)
+        })
+        .collect::<MatrixResult<Vec<IRNode>>>()?;
+
+    Ok(apply(sym(LIST), basis))
+}
+
+/// Return a basis for the row space of `m`.
+///
+/// The basis consists of non-zero rows of the RREF as `1×n` row-vector
+/// matrices.
+pub fn rowspace(m: &IRNode) -> MatrixResult<IRNode> {
+    let frows = matrix_to_fracs(m)?;
+    let (_, rref) = rref_pivot_info(&frows);
+
+    let mut basis = Vec::new();
+    for row in rref {
+        if row.iter().any(|entry| !entry.is_zero()) {
+            let ir_row = row
+                .into_iter()
+                .map(Frac::to_irnode)
+                .collect::<MatrixResult<Vec<IRNode>>>()?;
+            basis.push(matrix(vec![ir_row])?);
+        }
+    }
+
+    Ok(apply(sym(LIST), basis))
+}
+
+fn rref_pivot_info(frows: &[Vec<Frac>]) -> (Vec<usize>, Vec<Vec<Frac>>) {
+    if frows.is_empty() || frows[0].is_empty() {
+        return (Vec::new(), frows.to_vec());
+    }
+
+    let nrows = frows.len();
+    let ncols = frows[0].len();
+    let mut rref = frows.to_vec();
+    let mut pivot_cols = Vec::new();
+    let mut pivot_row = 0;
+
+    for col in 0..ncols {
+        let pivot_pos = (pivot_row..nrows).find(|&row| !rref[row][col].is_zero());
+        let Some(pivot_pos) = pivot_pos else {
+            continue;
+        };
+
+        if pivot_pos != pivot_row {
+            rref.swap(pivot_row, pivot_pos);
+        }
+
+        let pivot = rref[pivot_row][col];
+        rref[pivot_row] = rref[pivot_row].iter().map(|entry| *entry / pivot).collect();
+
+        for row in 0..nrows {
+            if row == pivot_row {
+                continue;
+            }
+            let factor = rref[row][col];
+            if factor.is_zero() {
+                continue;
+            }
+            rref[row] = (0..ncols)
+                .map(|c| rref[row][c] - factor * rref[pivot_row][c])
+                .collect();
+        }
+
+        pivot_cols.push(col);
+        pivot_row += 1;
+        if pivot_row == nrows {
+            break;
+        }
+    }
+
+    (pivot_cols, rref)
+}

--- a/code/packages/rust/cas-matrix/tests/tests.rs
+++ b/code/packages/rust/cas-matrix/tests/tests.rs
@@ -4,11 +4,12 @@
 // code/packages/python/cas-matrix/tests/.
 
 use cas_matrix::{
-    add_matrices, determinant, dimensions, dot, get_entry, identity_matrix, inverse, is_matrix,
-    matrix, num_cols, num_rows, rank, row_reduce, scalar_multiply, sub_matrices, trace, transpose,
-    zero_matrix, MatrixError, MATRIX,
+    add_matrices, columnspace, determinant, dimensions, dot, frobenius_norm, get_entry,
+    identity_matrix, inverse, is_matrix, lu_decompose, matrix, norm, nullspace, num_cols, num_rows,
+    rank, row_reduce, rowspace, scalar_multiply, sub_matrices, trace, transpose, zero_matrix,
+    MatrixError, MATRIX,
 };
-use symbolic_ir::{apply, int, rat, sym, ADD, LIST, SUB};
+use symbolic_ir::{apply, int, rat, sym, ADD, LIST, SQRT, SUB};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,6 +34,13 @@ fn matrix_entries(m: &symbolic_ir::IRNode) -> Vec<Vec<(i64, i64)>> {
                 .collect()
         })
         .collect()
+}
+
+fn list_args(list: &symbolic_ir::IRNode) -> Vec<symbolic_ir::IRNode> {
+    match list {
+        symbolic_ir::IRNode::Apply(apply) if apply.head == sym(LIST) => apply.args.clone(),
+        other => panic!("expected List(...), got {other:?}"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -432,4 +440,104 @@ fn row_reduce_and_rank_reject_symbolic_entries() {
     let m = matrix(vec![vec![sym("a"), int(1)], vec![int(0), int(1)]]).unwrap();
     assert!(row_reduce(&m).is_err());
     assert!(rank(&m).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Norms
+// ---------------------------------------------------------------------------
+
+#[test]
+fn norm_exact_rational_vector() {
+    let v = matrix(vec![vec![rat(3, 5)], vec![rat(4, 5)]]).unwrap();
+    assert_eq!(norm(&v).unwrap(), int(1));
+}
+
+#[test]
+fn norm_non_square_sum_returns_sqrt() {
+    let v = matrix(vec![irow(&[1]), irow(&[1])]).unwrap();
+    assert_eq!(norm(&v).unwrap(), apply(sym(SQRT), vec![int(2)]));
+}
+
+#[test]
+fn frobenius_norm_exact_matrix() {
+    let m = matrix(vec![irow(&[1, 1]), irow(&[1, 1])]).unwrap();
+    assert_eq!(frobenius_norm(&m).unwrap(), int(2));
+}
+
+#[test]
+fn norm_rejects_non_vector() {
+    let m = matrix(vec![irow(&[1, 0]), irow(&[0, 1])]).unwrap();
+    assert!(norm(&m).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// LU decomposition
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lu_decompose_requires_pivoting() {
+    let m = matrix(vec![irow(&[0, 1]), irow(&[1, 0])]).unwrap();
+    let parts = list_args(&lu_decompose(&m).unwrap());
+    assert_eq!(parts.len(), 3);
+
+    let l = &parts[0];
+    let u = &parts[1];
+    let p = &parts[2];
+
+    assert_eq!(
+        matrix_entries(l),
+        vec![vec![(1, 1), (0, 1)], vec![(0, 1), (1, 1)]]
+    );
+    assert_eq!(
+        matrix_entries(u),
+        vec![vec![(1, 1), (0, 1)], vec![(0, 1), (1, 1)]]
+    );
+    assert_eq!(
+        matrix_entries(p),
+        vec![vec![(0, 1), (1, 1)], vec![(1, 1), (0, 1)]]
+    );
+}
+
+#[test]
+fn lu_decompose_rejects_singular_matrix() {
+    let m = matrix(vec![irow(&[1, 2]), irow(&[2, 4])]).unwrap();
+    assert!(lu_decompose(&m).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Subspaces
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nullspace_returns_column_vector_basis() {
+    let m = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6])]).unwrap();
+    let basis = list_args(&nullspace(&m).unwrap());
+    assert_eq!(basis.len(), 1);
+    assert_eq!(
+        matrix_entries(&basis[0]),
+        vec![vec![(1, 1)], vec![(-2, 1)], vec![(1, 1)]]
+    );
+}
+
+#[test]
+fn columnspace_uses_original_pivot_columns() {
+    let m = matrix(vec![irow(&[1, 2]), irow(&[2, 4])]).unwrap();
+    let basis = list_args(&columnspace(&m).unwrap());
+    assert_eq!(basis.len(), 1);
+    assert_eq!(matrix_entries(&basis[0]), vec![vec![(1, 1)], vec![(2, 1)]]);
+}
+
+#[test]
+fn rowspace_uses_nonzero_rref_rows() {
+    let m = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6])]).unwrap();
+    let basis = list_args(&rowspace(&m).unwrap());
+    assert_eq!(basis.len(), 2);
+    assert_eq!(
+        matrix_entries(&basis[0]),
+        vec![vec![(1, 1), (0, 1), (-1, 1)]]
+    );
+    assert_eq!(
+        matrix_entries(&basis[1]),
+        vec![vec![(0, 1), (1, 1), (2, 1)]]
+    );
 }


### PR DESCRIPTION
## Summary

- port exact Rust cas-matrix vector/Frobenius norms, LU decomposition with partial pivoting, and nullspace/columnspace/rowspace APIs
- return decomposition and subspace results as `List(...)` IR nodes matching the Python package shape
- add focused integration tests plus README/CHANGELOG updates

## Validation

- `cargo fmt -p cas-matrix`
- `cargo test -p cas-matrix`
- `cargo check -p cas-matrix`

Eigenvalues/eigenvectors are intentionally out of scope for this slice.