### PR TITLE
[codex] Add TypeScript CAS 2D box pretty printer

### DIFF
--- a/code/packages/typescript/cas-pretty-printer/CHANGELOG.md
+++ b/code/packages/typescript/cas-pretty-printer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add a TypeScript 2D box layout engine and `pretty2D`/`style: "2d"` pretty-printing for core CAS expressions.
+
 ## 0.1.0
 
 - Add Lisp and infix CAS dialect pretty-printing for symbolic IR.

--- a/code/packages/typescript/cas-pretty-printer/README.md
+++ b/code/packages/typescript/cas-pretty-printer/README.md
@@ -5,3 +5,8 @@ Dialect-aware pretty-printer for TypeScript symbolic IR.
 The package mirrors the Python/Rust `cas-pretty-printer` layer for the browser
 runtime. It supports Lisp prefix output and source-like MACSYMA, Mathematica,
 and Maple dialects.
+
+`pretty(expr)` keeps the existing linear output. Use
+`pretty(expr, MacsymaDialect, { style: "2d" })` or `pretty2D(expr)` for the
+box-based two-dimensional layout used by fractions, powers, square roots,
+arithmetic, and lists.

--- a/code/packages/typescript/cas-pretty-printer/src/index.ts
+++ b/code/packages/typescript/cas-pretty-printer/src/index.ts
@@ -9,11 +9,17 @@ import {
   NEG,
   NOT_EQUAL,
   POW,
+  SQRT,
   SUB,
   headName,
 } from "@coding-adventures/symbolic-ir";
 
 export type DialectName = "macsyma" | "mathematica" | "maple";
+export type PrettyStyle = "linear" | "2d";
+
+export interface PrettyOptions {
+  readonly style?: PrettyStyle;
+}
 
 export interface Dialect {
   readonly name: DialectName;
@@ -131,8 +137,86 @@ export function formatLisp(node: IRNode): string {
   }
 }
 
-export function pretty(node: IRNode, dialect: Dialect = MacsymaDialect): string {
+export class Box {
+  readonly lines: readonly string[];
+  readonly baseline: number;
+
+  constructor(lines: readonly string[], baseline: number) {
+    this.lines = Object.freeze([...lines]);
+    this.baseline = baseline;
+  }
+
+  get width(): number {
+    return this.lines.reduce((max, line) => Math.max(max, line.length), 0);
+  }
+
+  get height(): number {
+    return this.lines.length;
+  }
+
+  render(): string {
+    return this.lines.join("\n");
+  }
+
+  padWidth(target: number, align: "center" | "left" | "right" = "center"): Box {
+    if (target <= this.width) return this;
+
+    return new Box(this.lines.map((line) => {
+      const pad = target - line.length;
+      if (align === "left") return line + " ".repeat(pad);
+      if (align === "right") return " ".repeat(pad) + line;
+
+      const leftPad = Math.floor(pad / 2);
+      return " ".repeat(leftPad) + line + " ".repeat(pad - leftPad);
+    }), this.baseline);
+  }
+}
+
+export function atomBox(text: string): Box {
+  return new Box([text], 0);
+}
+
+export function hbox(boxes: readonly Box[], sep = ""): Box {
+  if (boxes.length === 0) return atomBox("");
+
+  const commonBaseline = Math.max(...boxes.map((box) => box.baseline));
+  const maxBelow = Math.max(...boxes.map((box) => box.height - box.baseline - 1));
+  const totalHeight = commonBaseline + 1 + maxBelow;
+
+  const padded = boxes.map((box) => {
+    const aboveRows = commonBaseline - box.baseline;
+    const belowRows = totalHeight - box.height - aboveRows;
+    const empty = " ".repeat(box.width);
+    return [
+      ...Array.from({ length: aboveRows }, () => empty),
+      ...box.lines,
+      ...Array.from({ length: belowRows }, () => empty),
+    ];
+  });
+
+  const lines = Array.from({ length: totalHeight }, (_, row) => padded.map((rows) => rows[row]).join(sep));
+  return new Box(lines, commonBaseline);
+}
+
+export function vbox(boxes: readonly Box[]): Box {
+  if (boxes.length === 0) return atomBox("");
+
+  const width = Math.max(...boxes.map((box) => box.width));
+  const lines = boxes.flatMap((box) => box.padWidth(width).lines);
+  return new Box(lines, Math.floor(lines.length / 2));
+}
+
+export function pretty(node: IRNode, dialect: Dialect = MacsymaDialect, options: PrettyOptions | PrettyStyle = {}): string {
+  const style = typeof options === "string" ? options : (options.style ?? "linear");
+  if (style === "2d") return pretty2D(node, dialect);
+  if (style !== "linear") {
+    throw new Error(`unsupported style: ${style}`);
+  }
   return format(node, dialect, 0);
+}
+
+export function pretty2D(node: IRNode, dialect: Dialect = MacsymaDialect): string {
+  return box(node, dialect).render();
 }
 
 function format(node: IRNode, dialect: Dialect, parentPrecedence: number): string {
@@ -220,6 +304,107 @@ function sugarApply(node: Extract<IRNode, { kind: "apply" }>): IRNode {
     }
   }
   return node;
+}
+
+function box(node: IRNode, dialect: Dialect): Box {
+  switch (node.kind) {
+    case "symbol":
+      return atomBox(dialect.formatSymbol?.(node.name) ?? node.name);
+    case "integer":
+      return atomBox(node.value.toString());
+    case "rational":
+      return atomBox(`${node.numer}/${node.denom}`);
+    case "float":
+      return atomBox(String(node.value));
+    case "string":
+      return atomBox(JSON.stringify(node.value));
+    case "apply":
+      return boxApply(node, dialect);
+  }
+}
+
+function boxApply(node: Extract<IRNode, { kind: "apply" }>, dialect: Dialect): Box {
+  const sugar = sugarApply(node);
+  if (sugar !== node) return box(sugar, dialect);
+
+  const name = headName(node.head);
+  if (name === NEG.name && node.args.length === 1) {
+    const inner = box(node.args[0], dialect);
+    return new Box(inner.lines.map((line, i) => i === inner.baseline ? `-${line}` : ` ${line}`), inner.baseline);
+  }
+
+  if (name === DIV.name && node.args.length === 2) {
+    return divBox(box(node.args[0], dialect), box(node.args[1], dialect));
+  }
+
+  if (name === POW.name && node.args.length === 2) {
+    return powBox(box(node.args[0], dialect), box(node.args[1], dialect));
+  }
+
+  if (name === SQRT.name && node.args.length === 1) {
+    return sqrtBox(box(node.args[0], dialect));
+  }
+
+  if (name === ADD.name && node.args.length >= 2) {
+    return hbox(intersperseBoxes(node.args.map((arg) => box(arg, dialect)), atomBox(" + ")));
+  }
+
+  if (name === SUB.name && node.args.length === 2) {
+    return hbox([box(node.args[0], dialect), atomBox(" - "), box(node.args[1], dialect)]);
+  }
+
+  if (name === MUL.name && node.args.length >= 2) {
+    return hbox(intersperseBoxes(node.args.map((arg) => box(arg, dialect)), atomBox("*")));
+  }
+
+  if (name === LIST.name) {
+    const [open, close] = dialect.listBrackets ?? ["[", "]"];
+    if (node.args.length === 0) return atomBox(`${open}${close}`);
+    return hbox([
+      atomBox(open),
+      hbox(intersperseBoxes(node.args.map((arg) => box(arg, dialect)), atomBox(", "))),
+      atomBox(close),
+    ]);
+  }
+
+  return atomBox(format(node, dialect, 0));
+}
+
+function divBox(numBox: Box, denBox: Box): Box {
+  const barWidth = Math.max(numBox.width, denBox.width) + 2;
+  const num = numBox.padWidth(barWidth);
+  const den = denBox.padWidth(barWidth);
+  return new Box([...num.lines, "─".repeat(barWidth), ...den.lines], num.height);
+}
+
+function powBox(baseBox: Box, expBox: Box): Box {
+  const baseBlank = " ".repeat(baseBox.width);
+  const expBlank = " ".repeat(expBox.width);
+  const expRows = expBox.lines.map((line) => baseBlank + line.padEnd(expBox.width, " "));
+  const baseRows = baseBox.lines.map((line) => line.padEnd(baseBox.width, " ") + expBlank);
+  return new Box([...expRows, ...baseRows], expBox.height + baseBox.baseline);
+}
+
+function sqrtBox(argBox: Box): Box {
+  const argWidth = argBox.width;
+  const innerWidth = argWidth + 2;
+  const lines = [
+    `  ┌${"─".repeat(innerWidth)}┐`,
+    ...argBox.lines.map((line, i) => {
+      const content = ` ${line.padEnd(argWidth, " ")} `;
+      return i === argBox.baseline ? `√ │${content}│` : `  │${content}│`;
+    }),
+  ];
+  return new Box(lines, argBox.baseline + 1);
+}
+
+function intersperseBoxes(boxes: readonly Box[], separator: Box): Box[] {
+  const parts: Box[] = [];
+  for (const [index, box] of boxes.entries()) {
+    if (index > 0) parts.push(separator);
+    parts.push(box);
+  }
+  return parts;
 }
 
 function functionName(name: string, dialect: Dialect): string {

--- a/code/packages/typescript/cas-pretty-printer/tests/pretty-printer.test.ts
+++ b/code/packages/typescript/cas-pretty-printer/tests/pretty-printer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { ADD, INV, LIST, MUL, NEG, POW, app, int, sym } from "@coding-adventures/symbolic-ir";
-import { MacsymaDialect, MathematicaDialect, formatLisp, pretty } from "../src/index";
+import { ADD, DIV, INV, LIST, MUL, NEG, POW, SQRT, app, int, numberNode, rational, stringNode, sym } from "@coding-adventures/symbolic-ir";
+import { Box, MacsymaDialect, MathematicaDialect, atomBox, formatLisp, hbox, pretty, pretty2D, vbox } from "../src/index";
 
 describe("cas-pretty-printer", () => {
   it("formats Lisp prefix trees", () => {
@@ -66,5 +66,109 @@ describe("cas-pretty-printer", () => {
     const expr = app(LIST, [sym("x"), app(sym("Sin"), [sym("x")])]);
     expect(pretty(expr, MacsymaDialect)).toBe("[x, sin(x)]");
     expect(pretty(expr, MathematicaDialect)).toBe("{x, Sin[x]}");
+  });
+
+  it("keeps the default pretty API linear while accepting explicit linear style", () => {
+    const expr = app(DIV, [sym("x"), sym("y")]);
+    expect(pretty(expr)).toBe("x / y");
+    expect(pretty(expr, MacsymaDialect, { style: "linear" })).toBe("x / y");
+  });
+});
+
+describe("2D box layout", () => {
+  it("builds atom geometry", () => {
+    const box = atomBox("42");
+    expect(box.width).toBe(2);
+    expect(box.height).toBe(1);
+    expect(box.baseline).toBe(0);
+    expect(box.lines).toEqual(["42"]);
+    expect(box.render()).toBe("42");
+  });
+
+  it("pads atom boxes by alignment", () => {
+    expect(atomBox("x").padWidth(5).lines).toEqual(["  x  "]);
+    expect(atomBox("x").padWidth(4, "left").lines).toEqual(["x   "]);
+    expect(atomBox("x").padWidth(4, "right").lines).toEqual(["   x"]);
+  });
+
+  it("composes hbox and vbox primitives", () => {
+    expect(hbox([atomBox("a"), atomBox("b")], " ").render()).toBe("a b");
+
+    const stacked = vbox([atomBox("wide"), atomBox("x")]);
+    expect(stacked.width).toBe(4);
+    expect(stacked.height).toBe(2);
+    expect(stacked.lines).toEqual(["wide", " x  "]);
+  });
+
+  it("aligns hbox inputs on their baselines", () => {
+    const fraction = new Box([" a ", "───", " b "], 1);
+    const rendered = hbox([atomBox("x"), atomBox(" + "), fraction]).render();
+    expect(rendered).toBe([
+      "     a ",
+      "x + ───",
+      "     b ",
+    ].join("\n"));
+  });
+
+  it("renders division as numerator, bar, and denominator rows", () => {
+    expect(pretty2D(app(DIV, [sym("x"), sym("y")]))).toBe([
+      " x ",
+      "───",
+      " y ",
+    ].join("\n"));
+    expect(pretty(app(DIV, [sym("x"), sym("y")]), MacsymaDialect, { style: "2d" })).toContain("───");
+  });
+
+  it("renders power exponents above the base row", () => {
+    expect(pretty2D(app(POW, [sym("x"), int(2)]))).toBe([
+      " 2",
+      "x ",
+    ].join("\n"));
+  });
+
+  it("renders square root with a radical and overline", () => {
+    expect(pretty2D(app(SQRT, [sym("x")]))).toBe([
+      "  ┌───┐",
+      "√ │ x │",
+    ].join("\n"));
+  });
+
+  it("renders nested fractions with baseline-preserving rows", () => {
+    const expr = app(DIV, [app(DIV, [sym("x"), sym("y")]), sym("z")]);
+    expect(pretty2D(expr)).toBe([
+      "  x  ",
+      " ─── ",
+      "  y  ",
+      "─────",
+      "  z  ",
+    ].join("\n"));
+  });
+
+  it("renders arithmetic and list forms in 2D", () => {
+    expect(pretty(app(NEG, [sym("x")]), MacsymaDialect, "2d")).toBe("-x");
+    expect(pretty(app(ADD, [sym("x"), sym("y")]), MacsymaDialect, "2d")).toBe("x + y");
+    expect(pretty(app(ADD, [sym("x"), app(NEG, [sym("y")])]), MacsymaDialect, "2d")).toBe("x - y");
+    expect(pretty(app(MUL, [sym("x"), sym("y")]), MacsymaDialect, "2d")).toBe("x*y");
+    expect(pretty(app(LIST, [sym("x"), app(DIV, [int(1), int(2)])]), MacsymaDialect, "2d")).toBe([
+      "     1  ",
+      "[x, ───]",
+      "     2  ",
+    ].join("\n"));
+  });
+
+  it("formats leaf nodes in 2D", () => {
+    expect(pretty(int(42), MacsymaDialect, "2d")).toBe("42");
+    expect(pretty(rational(1, 2), MacsymaDialect, "2d")).toBe("1/2");
+    expect(pretty(numberNode(3.14), MacsymaDialect, "2d")).toBe("3.14");
+    expect(pretty(stringNode("hello"), MacsymaDialect, "2d")).toBe("\"hello\"");
+  });
+
+  it("falls back to linear formatting for unsupported heads", () => {
+    const expr = app(sym("Sin"), [app(ADD, [sym("x"), int(1)])]);
+    expect(pretty(expr, MacsymaDialect, { style: "2d" })).toBe("sin(x + 1)");
+  });
+
+  it("rejects unknown pretty styles at runtime", () => {
+    expect(() => pretty(sym("x"), MacsymaDialect, { style: "3d" as "linear" })).toThrow(/unsupported style/);
   });
 });


### PR DESCRIPTION
## Summary

- Port the Python CAS 2D box layout primitives to the TypeScript cas-pretty-printer package.
- Add `pretty2D` plus `pretty(..., { style: "2d" })` / `pretty(..., "2d")` support while preserving default linear output.
- Cover atom geometry, hbox/vbox composition, fractions, powers, square roots, nested fractions, lists, fallback formatting, and style validation.
- Document the 2D entrypoints in README and CHANGELOG.

## Validation

- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage`
