### PR TITLE
Add Rust CAS 2D pretty-printer boxes

### DIFF
--- a/code/packages/rust/cas-pretty-printer/CHANGELOG.md
+++ b/code/packages/rust/cas-pretty-printer/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — cas-pretty-printer (Rust)
 
+## Unreleased
+
+### Added
+
+- `pretty_2d(node, dialect) -> String` with a Rust port of the Python 2D box
+  layout engine for atoms, negation, fractions, powers, square roots, infix
+  arithmetic, lists, and linear fallback.
+- Public box-layout primitives: `LayoutBox`, `atom`, `hbox`, `vbox`, and
+  `Align`.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-pretty-printer/README.md
+++ b/code/packages/rust/cas-pretty-printer/README.md
@@ -8,8 +8,15 @@ Rust port of the Python `cas-pretty-printer` package.
 
 ### `pretty(node, dialect) -> String`
 
-Format `node` as source text in the given dialect.  Currently produces
-single-line (linear) output.
+Format `node` as source text in the given dialect. Produces single-line
+(linear) output.
+
+### `pretty_2d(node, dialect) -> String`
+
+Format `node` with the 2D box layout engine. The layout supports atoms,
+negation, fractions, powers, square roots, addition, subtraction,
+multiplication, and lists; unsupported heads fall back to the linear
+function-call form.
 
 ### `format_lisp(node) -> String`
 
@@ -34,7 +41,7 @@ All four dialects share the same arithmetic sugar:
 
 ```rust
 use cas_pretty_printer::{pretty, format_lisp, MacsymaDialect, MathematicaDialect};
-use symbolic_ir::{apply, int, sym, ADD, POW, SIN};
+use symbolic_ir::{apply, int, sym, ADD, DIV, POW, SIN};
 
 let x = sym("x");
 
@@ -48,6 +55,9 @@ assert_eq!(pretty(&call, &MathematicaDialect), "Sin[x]");
 
 // Lisp debug form
 assert_eq!(format_lisp(&expr), "(Add (Pow x 2) 1)");
+
+let fraction = apply(sym(DIV), vec![int(1), int(2)]);
+assert_eq!(cas_pretty_printer::pretty_2d(&fraction, &MacsymaDialect), " 1 \n───\n 2 ");
 ```
 
 ## Extensibility

--- a/code/packages/rust/cas-pretty-printer/src/box_layout.rs
+++ b/code/packages/rust/cas-pretty-printer/src/box_layout.rs
@@ -1,0 +1,293 @@
+//! Two-dimensional text box layout for CAS pretty printing.
+//!
+//! A [`Box`] is a rectangular region of text with a baseline row. Horizontal
+//! composition aligns baselines, which lets fractions, powers, roots, and
+//! plain atoms sit together in one expression.
+
+use symbolic_ir::{IRApply, IRNode};
+
+use crate::dialect::Dialect;
+use crate::walker::format_node;
+
+/// A rectangular text region with a mathematical baseline row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Box {
+    /// Text rows in top-to-bottom order.
+    pub lines: Vec<String>,
+    /// Zero-based row index used for horizontal baseline alignment.
+    pub baseline: usize,
+}
+
+impl Box {
+    /// Construct a box from text rows and a baseline.
+    pub fn new(lines: Vec<String>, baseline: usize) -> Self {
+        Self { lines, baseline }
+    }
+
+    /// Width of the widest row.
+    pub fn width(&self) -> usize {
+        self.lines
+            .iter()
+            .map(|line| line.chars().count())
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Number of rows.
+    pub fn height(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// Render rows as a single newline-delimited string.
+    pub fn render(&self) -> String {
+        self.lines.join("\n")
+    }
+
+    /// Return a copy with every row padded to `target` character cells.
+    pub fn pad_width(&self, target: usize, align: Align) -> Self {
+        if target <= self.width() {
+            return self.clone();
+        }
+
+        let lines = self
+            .lines
+            .iter()
+            .map(|line| {
+                let pad = target.saturating_sub(line.chars().count());
+                match align {
+                    Align::Center => {
+                        let left = pad / 2;
+                        let right = pad - left;
+                        format!("{}{}{}", " ".repeat(left), line, " ".repeat(right))
+                    }
+                    Align::Left => format!("{}{}", line, " ".repeat(pad)),
+                    Align::Right => format!("{}{}", " ".repeat(pad), line),
+                }
+            })
+            .collect();
+
+        Self {
+            lines,
+            baseline: self.baseline,
+        }
+    }
+}
+
+/// Horizontal alignment used by [`Box::pad_width`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Align {
+    Center,
+    Left,
+    Right,
+}
+
+/// Create a single-line atom box.
+pub fn atom(text: impl Into<String>) -> Box {
+    Box::new(vec![text.into()], 0)
+}
+
+/// Align boxes on their baselines and concatenate them horizontally.
+pub fn hbox(boxes: &[Box], sep: &str) -> Box {
+    if boxes.is_empty() {
+        return atom("");
+    }
+
+    let baseline = boxes.iter().map(|b| b.baseline).max().unwrap_or(0);
+    let max_below = boxes
+        .iter()
+        .map(|b| b.height().saturating_sub(b.baseline + 1))
+        .max()
+        .unwrap_or(0);
+    let total_height = baseline + 1 + max_below;
+
+    let padded: Vec<Vec<String>> = boxes
+        .iter()
+        .map(|b| {
+            let above = baseline - b.baseline;
+            let below = total_height - b.height() - above;
+            let empty = " ".repeat(b.width());
+            let mut rows = Vec::with_capacity(total_height);
+            rows.extend(std::iter::repeat(empty.clone()).take(above));
+            rows.extend(b.lines.iter().cloned());
+            rows.extend(std::iter::repeat(empty).take(below));
+            rows
+        })
+        .collect();
+
+    let lines = (0..total_height)
+        .map(|row| {
+            padded
+                .iter()
+                .map(|box_rows| box_rows[row].as_str())
+                .collect::<Vec<_>>()
+                .join(sep)
+        })
+        .collect();
+
+    Box::new(lines, baseline)
+}
+
+/// Stack boxes vertically, centered to the widest box.
+pub fn vbox(boxes: &[Box]) -> Box {
+    if boxes.is_empty() {
+        return atom("");
+    }
+
+    let width = boxes.iter().map(Box::width).max().unwrap_or(0);
+    let lines = boxes
+        .iter()
+        .flat_map(|b| b.pad_width(width, Align::Center).lines)
+        .collect::<Vec<_>>();
+    let baseline = lines.len() / 2;
+
+    Box::new(lines, baseline)
+}
+
+/// Format `node` as a multi-line 2D string.
+pub fn pretty_2d(node: &IRNode, dialect: &dyn Dialect) -> String {
+    build_box(node, dialect).render()
+}
+
+fn build_box(node: &IRNode, dialect: &dyn Dialect) -> Box {
+    match node {
+        IRNode::Integer(v) => atom(dialect.format_integer(*v)),
+        IRNode::Rational(n, d) => atom(dialect.format_rational(*n, *d)),
+        IRNode::Float(v) => atom(dialect.format_float(*v)),
+        IRNode::Str(s) => atom(dialect.format_string(s)),
+        IRNode::Symbol(name) => atom(dialect.format_symbol(name)),
+        IRNode::Apply(apply) => build_apply_box(apply, dialect),
+    }
+}
+
+fn build_apply_box(node: &IRApply, dialect: &dyn Dialect) -> Box {
+    if let Some(sugared) = dialect.try_sugar(node) {
+        return build_box(&sugared, dialect);
+    }
+
+    let head_name = match &node.head {
+        IRNode::Symbol(s) => Some(s.as_str()),
+        _ => None,
+    };
+
+    match (head_name, node.args.as_slice()) {
+        (Some("Neg"), [inner]) => neg_box(build_box(inner, dialect)),
+        (Some("Div"), [num, den]) => div_box(build_box(num, dialect), build_box(den, dialect)),
+        (Some("Pow"), [base, exp]) => pow_box(build_box(base, dialect), build_box(exp, dialect)),
+        (Some("Sqrt"), [arg]) => sqrt_box(build_box(arg, dialect)),
+        (Some("Add"), [_, _, ..]) => infix_box(&node.args, " + ", dialect),
+        (Some("Sub"), [left, right]) => hbox(
+            &[
+                build_box(left, dialect),
+                atom(" - "),
+                build_box(right, dialect),
+            ],
+            "",
+        ),
+        (Some("Mul"), [_, _, ..]) => infix_box(&node.args, "*", dialect),
+        (Some("List"), args) => list_box(args, dialect),
+        _ => atom(format_node(
+            &IRNode::Apply(std::boxed::Box::new(node.clone())),
+            dialect,
+            0,
+        )),
+    }
+}
+
+fn neg_box(inner: Box) -> Box {
+    let lines = inner
+        .lines
+        .iter()
+        .enumerate()
+        .map(|(i, line)| {
+            if i == inner.baseline {
+                format!("-{line}")
+            } else {
+                format!(" {line}")
+            }
+        })
+        .collect();
+
+    Box::new(lines, inner.baseline)
+}
+
+fn div_box(num: Box, den: Box) -> Box {
+    let width = num.width().max(den.width()) + 2;
+    let num = num.pad_width(width, Align::Center);
+    let den = den.pad_width(width, Align::Center);
+    let mut lines = num.lines;
+    let baseline = lines.len();
+    lines.push("─".repeat(width));
+    lines.extend(den.lines);
+
+    Box::new(lines, baseline)
+}
+
+fn pow_box(base: Box, exp: Box) -> Box {
+    let base_blank = " ".repeat(base.width());
+    let exp_blank = " ".repeat(exp.width());
+    let mut lines = Vec::with_capacity(base.height() + exp.height());
+
+    lines.extend(
+        exp.lines
+            .iter()
+            .map(|line| format!("{}{}", base_blank, pad_right(line, exp.width()))),
+    );
+    lines.extend(
+        base.lines
+            .iter()
+            .map(|line| format!("{}{}", pad_right(line, base.width()), exp_blank)),
+    );
+
+    Box::new(lines, exp.height() + base.baseline)
+}
+
+fn sqrt_box(arg: Box) -> Box {
+    let arg_width = arg.width();
+    let inner_width = arg_width + 2;
+    let mut lines = Vec::with_capacity(arg.height() + 1);
+
+    lines.push(format!("  ┌{}┐", "─".repeat(inner_width)));
+    lines.extend(arg.lines.iter().enumerate().map(|(i, line)| {
+        let prefix = if i == arg.baseline {
+            "√ │"
+        } else {
+            "  │"
+        };
+        format!("{prefix} {} │", pad_right(line, arg_width))
+    }));
+
+    Box::new(lines, 1 + arg.baseline)
+}
+
+fn infix_box(args: &[IRNode], sep: &str, dialect: &dyn Dialect) -> Box {
+    let mut parts = Vec::with_capacity(args.len().saturating_mul(2).saturating_sub(1));
+    for (i, arg) in args.iter().enumerate() {
+        if i > 0 {
+            parts.push(atom(sep));
+        }
+        parts.push(build_box(arg, dialect));
+    }
+    hbox(&parts, "")
+}
+
+fn list_box(args: &[IRNode], dialect: &dyn Dialect) -> Box {
+    let (open, close) = dialect.list_brackets();
+    if args.is_empty() {
+        return atom(format!("{open}{close}"));
+    }
+
+    let mut parts = Vec::with_capacity(args.len().saturating_mul(2).saturating_sub(1));
+    for (i, arg) in args.iter().enumerate() {
+        if i > 0 {
+            parts.push(atom(", "));
+        }
+        parts.push(build_box(arg, dialect));
+    }
+
+    hbox(&[atom(open), hbox(&parts, ""), atom(close)], "")
+}
+
+fn pad_right(line: &str, width: usize) -> String {
+    let pad = width.saturating_sub(line.chars().count());
+    format!("{line}{}", " ".repeat(pad))
+}

--- a/code/packages/rust/cas-pretty-printer/src/lib.rs
+++ b/code/packages/rust/cas-pretty-printer/src/lib.rs
@@ -17,6 +17,16 @@
 //! assert_eq!(pretty(&expr, &MacsymaDialect), "x^2 + 1");
 //! ```
 //!
+//! Use [`pretty_2d`] for multi-line box layout:
+//!
+//! ```rust
+//! use cas_pretty_printer::{pretty_2d, MacsymaDialect};
+//! use symbolic_ir::{apply, int, sym, DIV};
+//!
+//! let expr = apply(sym(DIV), vec![int(1), int(2)]);
+//! assert_eq!(pretty_2d(&expr, &MacsymaDialect), " 1 \n───\n 2 ");
+//! ```
+//!
 //! For the always-prefix Lisp form, use [`format_lisp`] (which bypasses the
 //! walker entirely and ignores any registered head formatters):
 //!
@@ -65,6 +75,7 @@
 //! symbolic-ir  ←  cas-pretty-printer
 //! ```
 
+pub mod box_layout;
 pub mod dialect;
 pub mod lisp;
 pub mod macsyma;
@@ -73,6 +84,7 @@ pub mod mathematica;
 pub mod walker;
 
 // Re-export the public surface API.
+pub use box_layout::{atom, hbox, pretty_2d, vbox, Align, Box as LayoutBox};
 pub use dialect::{
     Dialect, PREC_ADD, PREC_AND, PREC_ATOM, PREC_CALL, PREC_CMP, PREC_MUL, PREC_NEG, PREC_NOT,
     PREC_OR, PREC_POW,

--- a/code/packages/rust/cas-pretty-printer/src/lisp.rs
+++ b/code/packages/rust/cas-pretty-printer/src/lisp.rs
@@ -143,12 +143,7 @@ pub fn format_lisp(node: &IRNode) -> String {
             if a.args.is_empty() {
                 format!("({})", head_text)
             } else {
-                let args_text = a
-                    .args
-                    .iter()
-                    .map(format_lisp)
-                    .collect::<Vec<_>>()
-                    .join(" ");
+                let args_text = a.args.iter().map(format_lisp).collect::<Vec<_>>().join(" ");
                 format!("({} {})", head_text, args_text)
             }
         }

--- a/code/packages/rust/cas-pretty-printer/src/maple.rs
+++ b/code/packages/rust/cas-pretty-printer/src/maple.rs
@@ -9,8 +9,9 @@
 
 use symbolic_ir::{IRApply, IRNode};
 
-use crate::dialect::{default_binary_op, default_function_name, default_precedence,
-    default_unary_op, Dialect};
+use crate::dialect::{
+    default_binary_op, default_function_name, default_precedence, default_unary_op, Dialect,
+};
 use crate::macsyma::macsyma_sugar;
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-pretty-printer/src/mathematica.rs
+++ b/code/packages/rust/cas-pretty-printer/src/mathematica.rs
@@ -14,9 +14,7 @@
 
 use symbolic_ir::{IRApply, IRNode};
 
-use crate::dialect::{
-    default_binary_op, default_precedence, default_unary_op, Dialect,
-};
+use crate::dialect::{default_binary_op, default_precedence, default_unary_op, Dialect};
 use crate::macsyma::macsyma_sugar;
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-pretty-printer/src/walker.rs
+++ b/code/packages/rust/cas-pretty-printer/src/walker.rs
@@ -67,9 +67,8 @@ use crate::dialect::{Dialect, PREC_ATOM};
 ///     format!("matrix({})", rows.join(", "))
 /// });
 /// ```
-pub type HeadFormatterFn = dyn Fn(&IRApply, &dyn Dialect, &dyn Fn(&IRNode) -> String) -> String
-    + Send
-    + Sync;
+pub type HeadFormatterFn =
+    dyn Fn(&IRApply, &dyn Dialect, &dyn Fn(&IRNode) -> String) -> String + Send + Sync;
 
 // The registry stores Arc<HeadFormatterFn> so we can clone the Arc out of
 // the map before calling the formatter, avoiding a deadlock when the
@@ -94,10 +93,7 @@ fn head_formatters() -> &'static Mutex<HashMap<String, Arc<HeadFormatterFn>>> {
 /// `Send + Sync + 'static`.
 pub fn register_head_formatter<F>(head_name: &str, formatter: F)
 where
-    F: Fn(&IRApply, &dyn Dialect, &dyn Fn(&IRNode) -> String) -> String
-        + Send
-        + Sync
-        + 'static,
+    F: Fn(&IRApply, &dyn Dialect, &dyn Fn(&IRNode) -> String) -> String + Send + Sync + 'static,
 {
     head_formatters()
         .lock()
@@ -227,11 +223,8 @@ fn format_apply(node: &IRApply, dialect: &dyn Dialect, min_prec: u32) -> String 
     // the Mutex across the user's callback (which may call pretty() itself,
     // causing a deadlock if we held the lock).
     if let Some(name) = head_name {
-        let maybe_fmt: Option<Arc<HeadFormatterFn>> = head_formatters()
-            .lock()
-            .unwrap()
-            .get(name)
-            .cloned();
+        let maybe_fmt: Option<Arc<HeadFormatterFn>> =
+            head_formatters().lock().unwrap().get(name).cloned();
         if let Some(formatter) = maybe_fmt {
             return formatter(node, dialect, &|child| format_node(child, dialect, 0));
         }
@@ -281,12 +274,11 @@ fn format_apply(node: &IRApply, dialect: &dyn Dialect, min_prec: u32) -> String 
                     .iter()
                     .enumerate()
                     .map(|(i, arg)| {
-                        let child_prec =
-                            if (right_assoc && i < n - 1) || (!right_assoc && i > 0) {
-                                prec + 1
-                            } else {
-                                prec
-                            };
+                        let child_prec = if (right_assoc && i < n - 1) || (!right_assoc && i > 0) {
+                            prec + 1
+                        } else {
+                            prec
+                        };
                         format_node(arg, dialect, child_prec)
                     })
                     .collect();

--- a/code/packages/rust/cas-pretty-printer/tests/tests.rs
+++ b/code/packages/rust/cas-pretty-printer/tests/tests.rs
@@ -4,12 +4,12 @@
 // code/packages/python/cas-pretty-printer/tests/.
 
 use cas_pretty_printer::{
-    format_lisp, pretty, register_head_formatter, unregister_head_formatter, MacsymaDialect,
-    MapleDialect, MathematicaDialect,
+    atom, format_lisp, hbox, pretty, pretty_2d, register_head_formatter, unregister_head_formatter,
+    vbox, Align, LayoutBox, MacsymaDialect, MapleDialect, MathematicaDialect,
 };
 use symbolic_ir::{
     apply, flt, int, rat, str_node, sym, IRNode, ADD, AND, COS, D, DIV, EQUAL, GREATER, INV, LESS,
-    LIST, MUL, NEG, NOT_EQUAL, OR, POW, SIN, SUB,
+    LIST, MUL, NEG, NOT_EQUAL, OR, POW, SIN, SQRT, SUB,
 };
 
 // Shorthand helpers used throughout.
@@ -625,4 +625,108 @@ fn custom_dialect_by_overriding_binary_ops() {
 
     let expr = apply(sym(ADD), vec![sym("a"), sym("b")]);
     assert_eq!(pretty(&expr, &VerboseDialect), "a plus b");
+}
+
+// ---------------------------------------------------------------------------
+// 2D box layout
+// ---------------------------------------------------------------------------
+
+#[test]
+fn box_atom_geometry() {
+    let b = atom("xy");
+    assert_eq!(b.width(), 2);
+    assert_eq!(b.height(), 1);
+    assert_eq!(b.baseline, 0);
+    assert_eq!(b.render(), "xy");
+}
+
+#[test]
+fn box_pad_width_alignment() {
+    assert_eq!(atom("x").pad_width(5, Align::Center).lines[0], "  x  ");
+    assert_eq!(atom("x").pad_width(4, Align::Left).lines[0], "x   ");
+    assert_eq!(atom("x").pad_width(4, Align::Right).lines[0], "   x");
+}
+
+#[test]
+fn hbox_aligns_baselines() {
+    let tall = LayoutBox::new(
+        vec![" n ".to_string(), "───".to_string(), " d ".to_string()],
+        1,
+    );
+    let b = hbox(&[atom("x"), atom(" + "), tall], "");
+    assert_eq!(b.baseline, 1);
+    assert_eq!(b.render(), "     n \nx + ───\n     d ");
+}
+
+#[test]
+fn vbox_centers_rows() {
+    let b = vbox(&[atom("wide"), atom("x")]);
+    assert_eq!(b.width(), 4);
+    assert_eq!(b.height(), 2);
+    assert_eq!(b.lines[1], " x  ");
+}
+
+#[test]
+fn pretty_2d_division_fraction_rows_and_bar() {
+    let expr = apply(sym(DIV), vec![int(1), int(2)]);
+    assert_eq!(pretty_2d(&expr, &MacsymaDialect), " 1 \n───\n 2 ");
+}
+
+#[test]
+fn pretty_2d_power_places_exponent_above_base() {
+    let expr = apply(sym(POW), vec![sym("x"), int(2)]);
+    assert_eq!(pretty_2d(&expr, &MacsymaDialect), " 2\nx ");
+}
+
+#[test]
+fn pretty_2d_sqrt_has_radical_and_overline() {
+    let expr = apply(sym(SQRT), vec![sym("x")]);
+    assert_eq!(pretty_2d(&expr, &MacsymaDialect), "  ┌───┐\n√ │ x │");
+}
+
+#[test]
+fn pretty_2d_nested_fraction_expands_height() {
+    let inner = apply(sym(DIV), vec![sym("y"), int(2)]);
+    let expr = apply(sym(DIV), vec![sym("x"), inner]);
+    assert_eq!(
+        pretty_2d(&expr, &MacsymaDialect),
+        "  x  \n─────\n  y  \n ─── \n  2  "
+    );
+}
+
+#[test]
+fn pretty_2d_infix_and_lists_use_box_layout() {
+    let frac = apply(sym(DIV), vec![int(1), int(2)]);
+    let expr = apply(
+        sym(LIST),
+        vec![
+            apply(sym(ADD), vec![sym("x"), frac]),
+            apply(sym(MUL), vec![sym("y"), int(3)]),
+        ],
+    );
+    assert_eq!(
+        pretty_2d(&expr, &MacsymaDialect),
+        "      1       \n[x + ───, y*3]\n      2       "
+    );
+}
+
+#[test]
+fn pretty_2d_neg_and_sub_match_rust_sugar() {
+    let expr = apply(sym(ADD), vec![sym("x"), apply(sym(NEG), vec![sym("y")])]);
+    assert_eq!(pretty_2d(&expr, &MacsymaDialect), "x - y");
+}
+
+#[test]
+fn pretty_2d_falls_back_to_linear_call() {
+    let expr = apply(
+        sym("MNewton"),
+        vec![apply(sym(SUB), vec![sym("x"), int(2)]), sym("x")],
+    );
+    assert_eq!(pretty_2d(&expr, &MacsymaDialect), "MNewton(x - 2, x)");
+}
+
+#[test]
+fn pretty_2d_leaves_linear_pretty_unchanged() {
+    let expr = apply(sym(DIV), vec![int(1), int(2)]);
+    assert_eq!(pretty(&expr, &MacsymaDialect), "1/2");
 }


### PR DESCRIPTION
## Summary
- port the Python cas-pretty-printer 2D box layout primitives to Rust
- add pretty_2d for atoms, Neg, Div, Pow, Sqrt, Add, Sub, Mul, List, and linear fallback
- add focused Rust tests for box geometry, fractions, powers, sqrt, nested fractions, lists, fallback, and unchanged linear pretty output
- update README and changelog

## Validation
- cargo fmt -p cas-pretty-printer
- cargo test -p cas-pretty-printer
- cargo check -p cas-pretty-printer

Cargo.lock was recreated during validation and removed before commit.