### PR TITLE
[codex] Port TS matchdeclare rule store

### DIFF
--- a/code/packages/typescript/cas-pattern-matching/CHANGELOG.md
+++ b/code/packages/typescript/cas-pattern-matching/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added `MatchDeclareContext` for predicate-aware pattern declaration
+  compilation.
+- Added `RuleStore` for named compiled rewrite rules.
+
 ## 0.1.0
 
 - Initial TypeScript port of structural pattern matching, rule application,

--- a/code/packages/typescript/cas-pattern-matching/README.md
+++ b/code/packages/typescript/cas-pattern-matching/README.md
@@ -9,3 +9,8 @@ Patterns are ordinary `IRNode` trees using sentinel heads:
 - `Pattern(name, inner)`
 - `Rule(lhs, rhs)`
 - `RuleDelayed(lhs, rhs)`
+
+`MatchDeclareContext` ports the MACSYMA-style declaration layer: declared
+symbols compile into `Pattern(name, Blank(...))` nodes with predicate-derived
+constraints. `RuleStore` provides a small named-rule registry for storing and
+retrieving compiled rules before `applyRule` or `rewrite`.

--- a/code/packages/typescript/cas-pattern-matching/src/index.ts
+++ b/code/packages/typescript/cas-pattern-matching/src/index.ts
@@ -56,6 +56,100 @@ export class Bindings {
   }
 }
 
+const PREDICATE_TO_BLANK_HEAD = new Map<string, string | null>([
+  ["true", null],
+  ["all", null],
+  ["any", null],
+  ["integerp", "Integer"],
+  ["symbolp", "Symbol"],
+  ["floatp", "Float"],
+  ["rationalp", "Rational"],
+  ["numberp", null],
+  ["listp", "List"],
+  ["stringp", "String"],
+]);
+
+export class MatchDeclareContext {
+  private readonly declarations = new Map<string, string>();
+
+  declare(symbolName: string, predicateTag: string): void {
+    this.declarations.set(symbolName, predicateTag.toLowerCase());
+  }
+
+  forget(symbolName: string): void {
+    this.declarations.delete(symbolName);
+  }
+
+  forgetAll(): void {
+    this.declarations.clear();
+  }
+
+  isDeclared(symbolName: string): boolean {
+    return this.declarations.has(symbolName);
+  }
+
+  getPredicate(symbolName: string): string | undefined {
+    return this.declarations.get(symbolName);
+  }
+
+  compilePattern(pattern: IRNode): IRNode {
+    return this.walk(pattern);
+  }
+
+  private walk(node: IRNode): IRNode {
+    if (node.kind === "symbol") {
+      const predicate = this.declarations.get(node.name);
+      if (predicate === undefined) return node;
+
+      const blankHead = PREDICATE_TO_BLANK_HEAD.get(predicate);
+      return named(node.name, blankHead === undefined || blankHead === null ? blank() : blankTyped(blankHead));
+    }
+
+    if (node.kind === "apply") {
+      const nextHead = this.walk(node.head);
+      const nextArgs = node.args.map((arg) => this.walk(arg));
+      if (nextHead === node.head && nextArgs.every((arg, index) => arg === node.args[index])) {
+        return node;
+      }
+      return app(nextHead, nextArgs);
+    }
+
+    return node;
+  }
+}
+
+export class RuleStore {
+  private readonly rules = new Map<string, IRNode>();
+
+  store(name: string, rewriteRule: IRNode): void {
+    this.rules.set(name, rewriteRule);
+  }
+
+  get(name: string): IRNode | undefined {
+    return this.rules.get(name);
+  }
+
+  remove(name: string): void {
+    this.rules.delete(name);
+  }
+
+  clear(): void {
+    this.rules.clear();
+  }
+
+  names(): string[] {
+    return [...this.rules.keys()].sort();
+  }
+
+  contains(name: string): boolean {
+    return this.rules.has(name);
+  }
+
+  get size(): number {
+    return this.rules.size;
+  }
+}
+
 export interface RewriteCycleError {
   readonly kind: "rewrite-cycle";
   readonly maxIterations: number;

--- a/code/packages/typescript/cas-pattern-matching/tests/pattern-matching.test.ts
+++ b/code/packages/typescript/cas-pattern-matching/tests/pattern-matching.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { ADD, MUL, POW, app, int, numberNode, rational, sym } from "@coding-adventures/symbolic-ir";
+import { ADD, COS, LIST, MUL, POW, SIN, app, int, numberNode, rational, stringNode, sym } from "@coding-adventures/symbolic-ir";
 import {
   Bindings,
+  MatchDeclareContext,
+  RuleStore,
   applyRule,
   blank,
   blankTyped,
+  isPattern,
   isRewriteCycleError,
   matchPattern,
   named,
@@ -110,6 +113,148 @@ describe("rewrite", () => {
     if (isRewriteCycleError(result)) {
       expect(result.maxIterations).toBe(10);
     }
+  });
+});
+
+describe("matchdeclare context", () => {
+  it("mutates and queries declarations", () => {
+    const ctx = new MatchDeclareContext();
+    expect(ctx.isDeclared("x")).toBe(false);
+    expect(ctx.getPredicate("x")).toBeUndefined();
+
+    ctx.declare("x", "IntegerP");
+    expect(ctx.isDeclared("x")).toBe(true);
+    expect(ctx.getPredicate("x")).toBe("integerp");
+
+    ctx.declare("x", "floatp");
+    expect(ctx.getPredicate("x")).toBe("floatp");
+
+    ctx.forget("x");
+    expect(ctx.isDeclared("x")).toBe(false);
+
+    ctx.declare("a", "any");
+    ctx.declare("b", "symbolp");
+    ctx.forgetAll();
+    expect(ctx.isDeclared("a")).toBe(false);
+    expect(ctx.isDeclared("b")).toBe(false);
+  });
+
+  it("maps predicates to matcher blank constraints", () => {
+    const integerCtx = new MatchDeclareContext();
+    integerCtx.declare("n", "integerp");
+    const integerPattern = integerCtx.compilePattern(sym("n"));
+    expect(isPattern(integerPattern)).toBe(true);
+    expect(matchPattern(integerPattern, int(3))).not.toBeNull();
+    expect(matchPattern(integerPattern, sym("x"))).toBeNull();
+
+    const symbolCtx = new MatchDeclareContext();
+    symbolCtx.declare("s", "symbolp");
+    expect(matchPattern(symbolCtx.compilePattern(sym("s")), sym("x"))).not.toBeNull();
+    expect(matchPattern(symbolCtx.compilePattern(sym("s")), int(1))).toBeNull();
+
+    const floatCtx = new MatchDeclareContext();
+    floatCtx.declare("f", "floatp");
+    expect(matchPattern(floatCtx.compilePattern(sym("f")), numberNode(1.5))).not.toBeNull();
+    expect(matchPattern(floatCtx.compilePattern(sym("f")), rational(3, 2))).toBeNull();
+
+    const rationalCtx = new MatchDeclareContext();
+    rationalCtx.declare("r", "rationalp");
+    expect(matchPattern(rationalCtx.compilePattern(sym("r")), rational(1, 4))).not.toBeNull();
+    expect(matchPattern(rationalCtx.compilePattern(sym("r")), numberNode(0.25))).toBeNull();
+
+    const listCtx = new MatchDeclareContext();
+    listCtx.declare("xs", "listp");
+    expect(matchPattern(listCtx.compilePattern(sym("xs")), app(LIST, [int(1), int(2)]))).not.toBeNull();
+    expect(matchPattern(listCtx.compilePattern(sym("xs")), sym("xs"))).toBeNull();
+
+    const stringCtx = new MatchDeclareContext();
+    stringCtx.declare("text", "stringp");
+    expect(matchPattern(stringCtx.compilePattern(sym("text")), stringNode("hello"))).not.toBeNull();
+    expect(matchPattern(stringCtx.compilePattern(sym("text")), sym("hello"))).toBeNull();
+  });
+
+  it("keeps unconstrained and unknown predicates safe", () => {
+    for (const tag of ["true", "all", "any", "numberp", "mysteryp"]) {
+      const ctx = new MatchDeclareContext();
+      ctx.declare("x", tag);
+      const compiled = ctx.compilePattern(sym("x"));
+      expect(matchPattern(compiled, int(1))).not.toBeNull();
+      expect(matchPattern(compiled, sym("anything"))).not.toBeNull();
+    }
+  });
+
+  it("recursively compiles apply heads and arguments", () => {
+    const ctx = new MatchDeclareContext();
+    ctx.declare("f", "symbolp");
+    ctx.declare("x", "any");
+    ctx.declare("n", "integerp");
+
+    const raw = app(sym("f"), [app(ADD, [sym("x"), sym("n")])]);
+    const compiled = ctx.compilePattern(raw);
+    expect(compiled.kind).toBe("apply");
+    if (compiled.kind !== "apply") return;
+    expect(isPattern(compiled.head)).toBe(true);
+    expect(isPattern(compiled.args[0].kind === "apply" ? compiled.args[0].args[0] : sym("bad"))).toBe(true);
+
+    const target = app(SIN, [app(ADD, [sym("theta"), int(2)])]);
+    const bindings = matchPattern(compiled, target);
+    expect(bindings?.get("f")).toEqual(SIN);
+    expect(bindings?.get("x")).toEqual(sym("theta"));
+    expect(bindings?.get("n")).toEqual(int(2));
+
+    expect(matchPattern(compiled, app(SIN, [app(ADD, [sym("theta"), sym("two")])]))).toBeNull();
+  });
+
+  it("supports end-to-end applyRule and rewrite flows", () => {
+    const ctx = new MatchDeclareContext();
+    ctx.declare("x", "any");
+    const x = sym("x");
+    const lhs = app(ADD, [
+      app(POW, [app(SIN, [x]), int(2)]),
+      app(POW, [app(COS, [x]), int(2)]),
+    ]);
+    const pythagorean = rule(ctx.compilePattern(lhs), int(1));
+    const theta = sym("theta");
+    const target = app(ADD, [
+      app(POW, [app(SIN, [theta]), int(2)]),
+      app(POW, [app(COS, [theta]), int(2)]),
+    ]);
+    expect(applyRule(pythagorean, target)).toEqual(int(1));
+
+    const removePowerOne = rule(ctx.compilePattern(app(POW, [x, int(1)])), ctx.compilePattern(x));
+    expect(rewrite(app(ADD, [app(POW, [sym("a"), int(1)]), app(POW, [sym("b"), int(1)])]), [removePowerOne]))
+      .toEqual(app(ADD, [sym("a"), sym("b")]));
+  });
+});
+
+describe("rule store", () => {
+  it("stores, queries, removes, and clears named rules", () => {
+    const store = new RuleStore();
+    expect(store.size).toBe(0);
+    expect(store.names()).toEqual([]);
+    expect(store.contains("r1")).toBe(false);
+    expect(store.get("r1")).toBeUndefined();
+
+    const first = rule(sym("x"), int(1));
+    const second = rule(sym("y"), int(2));
+    store.store("r2", second);
+    store.store("r1", first);
+    expect(store.size).toBe(2);
+    expect(store.contains("r1")).toBe(true);
+    expect(store.get("r1")).toBe(first);
+    expect(store.names()).toEqual(["r1", "r2"]);
+
+    store.store("r1", second);
+    expect(store.size).toBe(2);
+    expect(store.get("r1")).toBe(second);
+
+    store.remove("r2");
+    store.remove("missing");
+    expect(store.names()).toEqual(["r1"]);
+
+    store.clear();
+    expect(store.size).toBe(0);
+    expect(store.names()).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `MatchDeclareContext` with declaration mutation/query APIs and predicate-aware pattern compilation.
- Add `RuleStore` for named compiled rules.
- Cover predicate constraints, nested pattern compilation, end-to-end rule/rewrite flows, and store operations in Vitest.
- Briefly document the new layer in README and CHANGELOG.

## Validation
- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage`
