### PR TITLE
[codex] Port matchdeclare rule store to Rust

### DIFF
--- a/code/packages/rust/cas-pattern-matching/CHANGELOG.md
+++ b/code/packages/rust/cas-pattern-matching/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — cas-pattern-matching (Rust)
 
+## Unreleased
+
+### Added
+
+- `MatchDeclareContext` with declare / forget / query APIs and Python-compatible
+  predicate-to-`Blank` constraint compilation.
+- `RuleStore` for named compiled rules used by `defrule` / `apply1` / `apply2`
+  style flows.
+- Focused tests for match declarations, predicate constraints, nested pattern
+  compilation, end-to-end rewrite behavior, and rule-store operations.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-pattern-matching/README.md
+++ b/code/packages/rust/cas-pattern-matching/README.md
@@ -44,6 +44,29 @@ let expr = apply(sym(ADD), vec![apply(sym(ADD), vec![sym("z"), int(0)]), int(0)]
 assert_eq!(rewrite(expr, &[r], 100).unwrap(), sym("z"));
 ```
 
+## Match declarations and named rules
+
+`MatchDeclareContext` ports the MACSYMA `matchdeclare` layer.  It records
+which symbols are pattern variables, maps predicate tags such as `integerp`
+and `stringp` to `Blank(T)` constraints, and compiles raw rule patterns into
+matcher-ready `Pattern(name, Blank(...))` nodes.
+
+```rust
+use cas_pattern_matching::{rule, MatchDeclareContext, RuleStore};
+use symbolic_ir::{apply, int, sym, ADD};
+
+let mut ctx = MatchDeclareContext::new();
+ctx.declare("n", "integerp");
+
+let lhs = ctx.compile_pattern(&apply(sym(ADD), vec![sym("n"), sym("n")]));
+let rhs = apply(sym("Mul"), vec![int(2), ctx.compile_pattern(&sym("n"))]);
+let r = rule(lhs, rhs);
+
+let mut rules = RuleStore::new();
+rules.store("double", r);
+assert!(rules.contains("double"));
+```
+
 ## Note on RHS patterns
 
 RHS expressions reference captured variables via `Pattern(name, inner)` nodes

--- a/code/packages/rust/cas-pattern-matching/src/defrule_engine.rs
+++ b/code/packages/rust/cas-pattern-matching/src/defrule_engine.rs
@@ -1,0 +1,64 @@
+//! Named-rule store for `defrule` / `apply1` / `apply2` style flows.
+//!
+//! The store intentionally does not compile or validate rules.  Callers compile
+//! rule left/right sides with [`crate::MatchDeclareContext`] and then store the
+//! resulting `Rule(lhs, rhs)` IR node here.
+
+use std::collections::HashMap;
+
+use symbolic_ir::IRNode;
+
+/// Mutable map from rule name to compiled `Rule` IR node.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuleStore {
+    rules: HashMap<String, IRNode>,
+}
+
+impl RuleStore {
+    /// Create an empty rule store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Install or replace a named rule.
+    pub fn store(&mut self, name: impl Into<String>, rule: IRNode) {
+        self.rules.insert(name.into(), rule);
+    }
+
+    /// Return the rule for `name`, if present.
+    pub fn get(&self, name: &str) -> Option<&IRNode> {
+        self.rules.get(name)
+    }
+
+    /// Remove a named rule, if present.
+    pub fn remove(&mut self, name: &str) {
+        self.rules.remove(name);
+    }
+
+    /// Remove all rules.
+    pub fn clear(&mut self) {
+        self.rules.clear();
+    }
+
+    /// Return all rule names in sorted order.
+    pub fn names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.rules.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Number of stored rules.
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    /// True when no rules are stored.
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// True when `name` is present.
+    pub fn contains(&self, name: &str) -> bool {
+        self.rules.contains_key(name)
+    }
+}

--- a/code/packages/rust/cas-pattern-matching/src/lib.rs
+++ b/code/packages/rust/cas-pattern-matching/src/lib.rs
@@ -31,11 +31,15 @@
 //! ```
 
 pub mod bindings;
+pub mod defrule_engine;
+pub mod matchdeclare;
 pub mod matcher;
 pub mod nodes;
 pub mod rewriter;
 
 pub use bindings::Bindings;
+pub use defrule_engine::RuleStore;
+pub use matchdeclare::MatchDeclareContext;
 pub use matcher::match_pattern;
 pub use nodes::{blank, blank_typed, named, rule, rule_delayed};
 pub use rewriter::{apply_rule, rewrite, RewriteCycleError};

--- a/code/packages/rust/cas-pattern-matching/src/matchdeclare.rs
+++ b/code/packages/rust/cas-pattern-matching/src/matchdeclare.rs
@@ -1,0 +1,99 @@
+//! MACSYMA-style `matchdeclare` state and pattern compilation.
+//!
+//! A [`MatchDeclareContext`] records which bare symbols should be treated as
+//! pattern variables.  [`MatchDeclareContext::compile_pattern`] then walks an
+//! arbitrary `IRNode` tree and replaces declared symbols with
+//! `Pattern(name, Blank(...))` nodes understood by the matcher.
+
+use std::collections::HashMap;
+
+use symbolic_ir::{IRApply, IRNode};
+
+use crate::nodes::{blank, blank_typed, named};
+
+/// Per-VM store of `matchdeclare` declarations.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MatchDeclareContext {
+    declarations: HashMap<String, String>,
+}
+
+impl MatchDeclareContext {
+    /// Create an empty declaration context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record `sym_name` as a pattern variable constrained by `pred_tag`.
+    ///
+    /// Predicate tags are stored lowercased.  Unknown tags are preserved for
+    /// query purposes and compile to an unconstrained `Blank()` fallback.
+    pub fn declare(&mut self, sym_name: impl Into<String>, pred_tag: impl AsRef<str>) {
+        self.declarations
+            .insert(sym_name.into(), pred_tag.as_ref().to_ascii_lowercase());
+    }
+
+    /// Remove one declaration, if present.
+    pub fn forget(&mut self, sym_name: &str) {
+        self.declarations.remove(sym_name);
+    }
+
+    /// Remove all declarations.
+    pub fn forget_all(&mut self) {
+        self.declarations.clear();
+    }
+
+    /// True when `sym_name` is declared as a pattern variable.
+    pub fn is_declared(&self, sym_name: &str) -> bool {
+        self.declarations.contains_key(sym_name)
+    }
+
+    /// Return the normalized predicate tag for `sym_name`, if declared.
+    pub fn get_predicate(&self, sym_name: &str) -> Option<&str> {
+        self.declarations.get(sym_name).map(String::as_str)
+    }
+
+    /// Compile a raw pattern tree into matcher-ready pattern nodes.
+    ///
+    /// Every declared `Symbol(name)` becomes `Pattern(name, Blank(...))`.
+    /// Compound apply heads and arguments are both walked recursively.
+    pub fn compile_pattern(&self, pattern: &IRNode) -> IRNode {
+        self.walk(pattern)
+    }
+
+    fn walk(&self, node: &IRNode) -> IRNode {
+        match node {
+            IRNode::Symbol(name) => {
+                if let Some(pred_tag) = self.declarations.get(name) {
+                    named(name, blank_for_predicate(pred_tag))
+                } else {
+                    node.clone()
+                }
+            }
+            IRNode::Apply(apply) => IRNode::Apply(Box::new(IRApply {
+                head: self.walk(&apply.head),
+                args: apply.args.iter().map(|arg| self.walk(arg)).collect(),
+            })),
+            _ => node.clone(),
+        }
+    }
+}
+
+fn blank_for_predicate(pred_tag: &str) -> IRNode {
+    match predicate_blank_head(pred_tag) {
+        Some(head) => blank_typed(head),
+        None => blank(),
+    }
+}
+
+fn predicate_blank_head(pred_tag: &str) -> Option<&'static str> {
+    match pred_tag {
+        "integerp" => Some("Integer"),
+        "symbolp" => Some("Symbol"),
+        "floatp" => Some("Float"),
+        "rationalp" => Some("Rational"),
+        "listp" => Some("List"),
+        "stringp" => Some("String"),
+        "true" | "all" | "any" | "numberp" => None,
+        _ => None,
+    }
+}

--- a/code/packages/rust/cas-pattern-matching/src/matcher.rs
+++ b/code/packages/rust/cas-pattern-matching/src/matcher.rs
@@ -39,11 +39,7 @@ use crate::nodes::{blank_head_constraint, is_blank, is_pattern, pattern_inner, p
 /// assert_eq!(b.get("a"), Some(&int(1)));
 /// assert_eq!(b.get("b"), Some(&int(2)));
 /// ```
-pub fn match_pattern(
-    pattern: &IRNode,
-    target: &IRNode,
-    bindings: Bindings,
-) -> Option<Bindings> {
+pub fn match_pattern(pattern: &IRNode, target: &IRNode, bindings: Bindings) -> Option<Bindings> {
     // Case 1 & 2: Blank(?) wildcards
     if is_blank(pattern) {
         if let IRNode::Apply(apply) = pattern {
@@ -92,11 +88,7 @@ pub fn match_pattern(
 }
 
 /// Match two `IRApply` nodes: head must match, then args zip pairwise.
-fn match_apply(
-    pattern: &IRApply,
-    target: &IRApply,
-    bindings: Bindings,
-) -> Option<Bindings> {
+fn match_apply(pattern: &IRApply, target: &IRApply, bindings: Bindings) -> Option<Bindings> {
     // Head must match.
     let after_head = match_pattern(&pattern.head, &target.head, bindings)?;
 

--- a/code/packages/rust/cas-pattern-matching/tests/test_pattern_matching.rs
+++ b/code/packages/rust/cas-pattern-matching/tests/test_pattern_matching.rs
@@ -2,9 +2,18 @@
 
 use cas_pattern_matching::{
     apply_rule, blank, blank_typed, match_pattern, named, rewrite, rule, rule_delayed, Bindings,
-    RewriteCycleError,
+    MatchDeclareContext, RewriteCycleError, RuleStore,
 };
-use symbolic_ir::{apply, flt, int, rat, sym, ADD, MUL, POW};
+use symbolic_ir::{
+    apply, flt, int, rat, str_node, sym, IRApply, IRNode, ADD, COS, LIST, MUL, POW, SIN,
+};
+
+fn as_apply(node: &IRNode) -> &IRApply {
+    match node {
+        IRNode::Apply(apply) => apply,
+        other => panic!("expected Apply, got {other:?}"),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Blank — unconstrained wildcard
@@ -174,20 +183,14 @@ fn apply_rejects_different_arg_count() {
 #[test]
 fn rule_fires_and_substitutes() {
     // Pow(x_, 0) → 1
-    let r = rule(
-        apply(sym(POW), vec![named("x", blank()), int(0)]),
-        int(1),
-    );
+    let r = rule(apply(sym(POW), vec![named("x", blank()), int(0)]), int(1));
     let target = apply(sym(POW), vec![sym("z"), int(0)]);
     assert_eq!(apply_rule(&r, &target), Some(int(1)));
 }
 
 #[test]
 fn rule_returns_none_on_no_match() {
-    let r = rule(
-        apply(sym(POW), vec![named("x", blank()), int(0)]),
-        int(1),
-    );
+    let r = rule(apply(sym(POW), vec![named("x", blank()), int(0)]), int(1));
     assert_eq!(apply_rule(&r, &sym("y")), None);
 }
 
@@ -207,10 +210,7 @@ fn rule_substitutes_captured_pattern_in_rhs() {
 #[test]
 fn rule_delayed_behaves_same_as_rule() {
     let x = named("x", blank());
-    let r = rule_delayed(
-        apply(sym(ADD), vec![x.clone(), int(0)]),
-        x.clone(),
-    );
+    let r = rule_delayed(apply(sym(ADD), vec![x.clone(), int(0)]), x.clone());
     let target = apply(sym(ADD), vec![int(7), int(0)]);
     assert_eq!(apply_rule(&r, &target), Some(int(7)));
 }
@@ -291,7 +291,10 @@ fn rewrite_returns_error_on_non_converging() {
     );
     let expr = apply(sym("f"), vec![int(1)]);
     let result = rewrite(expr, &[r1, r2], 10);
-    assert!(matches!(result, Err(RewriteCycleError { max_iterations: 10 })));
+    assert!(matches!(
+        result,
+        Err(RewriteCycleError { max_iterations: 10 })
+    ));
 }
 
 // ---------------------------------------------------------------------------
@@ -326,4 +329,205 @@ fn bindings_iter() {
     pairs.sort_by_key(|(k, _)| *k);
     assert_eq!(pairs[0], ("a", &int(1)));
     assert_eq!(pairs[1], ("b", &int(2)));
+}
+
+// ---------------------------------------------------------------------------
+// MatchDeclareContext — mutation, queries, and predicate constraints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn matchdeclare_mutation_and_queries() {
+    let mut ctx = MatchDeclareContext::new();
+
+    assert!(!ctx.is_declared("x"));
+    assert_eq!(ctx.get_predicate("x"), None);
+
+    ctx.declare("x", "IntegerP");
+    assert!(ctx.is_declared("x"));
+    assert_eq!(ctx.get_predicate("x"), Some("integerp"));
+
+    ctx.declare("x", "floatp");
+    assert_eq!(ctx.get_predicate("x"), Some("floatp"));
+
+    ctx.declare("y", "any");
+    ctx.forget("x");
+    assert!(!ctx.is_declared("x"));
+    assert!(ctx.is_declared("y"));
+
+    ctx.forget("missing");
+    ctx.forget_all();
+    assert!(!ctx.is_declared("y"));
+}
+
+#[test]
+fn matchdeclare_predicate_constraints_match_python_mapping() {
+    let cases = [
+        ("true", None),
+        ("all", None),
+        ("any", None),
+        ("numberp", None),
+        ("integerp", Some("Integer")),
+        ("symbolp", Some("Symbol")),
+        ("floatp", Some("Float")),
+        ("rationalp", Some("Rational")),
+        ("listp", Some("List")),
+        ("stringp", Some("String")),
+        ("unknownp", None),
+    ];
+
+    for (pred_tag, expected_head) in cases {
+        let mut ctx = MatchDeclareContext::new();
+        ctx.declare("x", pred_tag);
+        let compiled = ctx.compile_pattern(&sym("x"));
+        let pattern = match compiled {
+            IRNode::Apply(pattern) => pattern,
+            other => panic!("expected Pattern apply, got {other:?}"),
+        };
+        assert_eq!(pattern.args[0], sym("x"));
+
+        let blank = match &pattern.args[1] {
+            IRNode::Apply(blank) => blank,
+            other => panic!("expected Blank apply, got {other:?}"),
+        };
+        match expected_head {
+            Some(head) => assert_eq!(blank.args, vec![sym(head)]),
+            None => assert!(blank.args.is_empty()),
+        }
+    }
+}
+
+#[test]
+fn matchdeclare_typed_constraints_work_with_matcher() {
+    let mut ctx = MatchDeclareContext::new();
+    ctx.declare("n", "integerp");
+    ctx.declare("s", "stringp");
+    ctx.declare("xs", "listp");
+
+    assert!(match_pattern(&ctx.compile_pattern(&sym("n")), &int(3), Bindings::empty()).is_some());
+    assert!(match_pattern(
+        &ctx.compile_pattern(&sym("n")),
+        &sym("not_an_int"),
+        Bindings::empty()
+    )
+    .is_none());
+    assert!(match_pattern(
+        &ctx.compile_pattern(&sym("s")),
+        &str_node("hello"),
+        Bindings::empty()
+    )
+    .is_some());
+    assert!(match_pattern(
+        &ctx.compile_pattern(&sym("xs")),
+        &apply(sym(LIST), vec![int(1), int(2)]),
+        Bindings::empty()
+    )
+    .is_some());
+}
+
+#[test]
+fn matchdeclare_compile_pattern_walks_nested_heads_and_args() {
+    let mut ctx = MatchDeclareContext::new();
+    ctx.declare("f", "symbolp");
+    ctx.declare("x", "any");
+    ctx.declare("n", "integerp");
+
+    let raw = apply(
+        sym("f"),
+        vec![
+            apply(sym(SIN), vec![sym("x")]),
+            apply(sym(POW), vec![sym("x"), sym("n")]),
+            sym("y"),
+        ],
+    );
+    let compiled = ctx.compile_pattern(&raw);
+
+    let outer = match compiled {
+        IRNode::Apply(apply) => apply,
+        other => panic!("expected Apply, got {other:?}"),
+    };
+    assert!(cas_pattern_matching::nodes::is_pattern(&outer.head));
+    assert!(cas_pattern_matching::nodes::is_pattern(
+        &as_apply(&outer.args[0]).args[0]
+    ));
+    assert!(cas_pattern_matching::nodes::is_pattern(
+        &as_apply(&outer.args[1]).args[0]
+    ));
+    assert!(cas_pattern_matching::nodes::is_pattern(
+        &as_apply(&outer.args[1]).args[1]
+    ));
+    assert_eq!(outer.args[2], sym("y"));
+}
+
+#[test]
+fn matchdeclare_end_to_end_apply_rule_and_rewrite() {
+    let mut ctx = MatchDeclareContext::new();
+    ctx.declare("x", "any");
+
+    let x = sym("x");
+    let lhs = apply(
+        sym(ADD),
+        vec![
+            apply(sym(POW), vec![apply(sym(SIN), vec![x.clone()]), int(2)]),
+            apply(sym(POW), vec![apply(sym(COS), vec![x.clone()]), int(2)]),
+        ],
+    );
+    let trig_rule = rule(ctx.compile_pattern(&lhs), int(1));
+
+    let t = sym("t");
+    let target = apply(
+        sym(ADD),
+        vec![
+            apply(sym(POW), vec![apply(sym(SIN), vec![t.clone()]), int(2)]),
+            apply(sym(POW), vec![apply(sym(COS), vec![t]), int(2)]),
+        ],
+    );
+    assert_eq!(apply_rule(&trig_rule, &target), Some(int(1)));
+
+    let pow_lhs = apply(sym(POW), vec![x.clone(), int(1)]);
+    let pow_rule = rule(ctx.compile_pattern(&pow_lhs), ctx.compile_pattern(&x));
+    let expr = apply(
+        sym(ADD),
+        vec![
+            apply(sym(POW), vec![sym("a"), int(1)]),
+            apply(sym(POW), vec![sym("b"), int(1)]),
+        ],
+    );
+    assert_eq!(
+        rewrite(expr, &[pow_rule], 100).unwrap(),
+        apply(sym(ADD), vec![sym("a"), sym("b")])
+    );
+}
+
+#[test]
+fn rulestore_operations() {
+    let mut store = RuleStore::new();
+    assert!(store.is_empty());
+    assert_eq!(store.len(), 0);
+    assert_eq!(store.names(), Vec::<String>::new());
+    assert_eq!(store.get("missing"), None);
+
+    let r1 = rule(sym("x"), int(1));
+    let r2 = rule(sym("y"), int(2));
+    let r3 = rule(sym("z"), int(3));
+
+    store.store("middle", r2.clone());
+    store.store("alpha", r1.clone());
+    store.store("zebra", r3.clone());
+
+    assert_eq!(store.len(), 3);
+    assert!(store.contains("alpha"));
+    assert!(!store.contains("ghost"));
+    assert_eq!(store.get("alpha"), Some(&r1));
+    assert_eq!(store.names(), vec!["alpha", "middle", "zebra"]);
+
+    store.store("alpha", r2.clone());
+    assert_eq!(store.len(), 3);
+    assert_eq!(store.get("alpha"), Some(&r2));
+
+    store.remove("alpha");
+    store.remove("ghost");
+    assert!(!store.contains("alpha"));
+
+    store.clear();
+    assert!(store.is_empty());
 }


### PR DESCRIPTION
## Summary
- Add Rust MatchDeclareContext with mutation/query APIs and Python-compatible predicate-to-Blank compilation
- Add RuleStore for named compiled rules
- Cover predicate constraints, nested compile_pattern, apply_rule/rewrite integration, and store operations
- Document the new layer in README and CHANGELOG

## Validation
- cargo fmt -p cas-pattern-matching
- cargo test -p cas-pattern-matching
- cargo check -p cas-pattern-matching

Ready for review.