### PR TITLE
Add TS reciprocal hyperbolic symbolic VM parity

### DIFF
--- a/code/packages/typescript/symbolic-ir/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-ir/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added first-class reciprocal hyperbolic head symbols `COTH`, `SECH`, and
+  `CSCH` for `Coth`, `Sech`, and `Csch`.
+
 ## [0.1.0] - 2026-05-08
 
 ### Added

--- a/code/packages/typescript/symbolic-ir/src/index.ts
+++ b/code/packages/typescript/symbolic-ir/src/index.ts
@@ -220,6 +220,9 @@ export const TANH = sym("Tanh");
 export const ASINH = sym("Asinh");
 export const ACOSH = sym("Acosh");
 export const ATANH = sym("Atanh");
+export const COTH = sym("Coth");
+export const SECH = sym("Sech");
+export const CSCH = sym("Csch");
 
 // Calculus and CAS heads
 export const D = sym("D");

--- a/code/packages/typescript/symbolic-ir/tests/symbolic-ir.test.ts
+++ b/code/packages/typescript/symbolic-ir/tests/symbolic-ir.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   ADD,
+  COTH,
+  CSCH,
   MUL,
   POW,
+  SECH,
   app,
   equals,
   int,
@@ -48,5 +51,12 @@ describe("symbolic-ir", () => {
     const x = sym("x");
     const expr = app(ADD, [app(POW, [x, int(2)]), int(1)]);
     expect(toDisplayString(expr)).toBe("Add(Pow(x, 2), 1)");
+  });
+
+  it("exports reciprocal hyperbolic heads as first-class symbols", () => {
+    const x = sym("x");
+    expect(app(COTH, [x])).toEqual(app(sym("Coth"), [x]));
+    expect(toDisplayString(app(SECH, [x]))).toBe("Sech(x)");
+    expect(structuralKey(app(CSCH, [x]))).toBe('A:S:"Csch"(S:"x")');
   });
 });

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added a symbolic-backend-only `D` handler for pure IR differentiation,
   including arithmetic, power, elementary, hyperbolic, and inverse hyperbolic
   chain rules.
+- Added reciprocal hyperbolic `Coth`, `Sech`, and `Csch` numeric handlers and
+  derivative chain rules expressed via `Sinh`/`Cosh`.
 
 ## [0.1.0] - 2026-05-08
 

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -10,6 +10,8 @@ import {
   ATANH,
   COS,
   COSH,
+  COTH,
+  CSCH,
   D,
   DEFINE,
   DIV,
@@ -33,6 +35,7 @@ import {
   NOT_EQUAL,
   OR,
   POW,
+  SECH,
   SIN,
   SINH,
   SQRT,
@@ -283,6 +286,9 @@ function buildHandlerTable(simplify: boolean): ReadonlyMap<string, Handler> {
   table.set(ASINH.name, elementary("Asinh", Math.asinh, new Map([["0", int(0)]]), simplify));
   table.set(ACOSH.name, elementary("Acosh", Math.acosh, new Map(), simplify));
   table.set(ATANH.name, elementary("Atanh", Math.atanh, new Map([["0", int(0)]]), simplify));
+  table.set(COTH.name, elementary("Coth", (x) => Math.cosh(x) / Math.sinh(x), new Map(), simplify));
+  table.set(SECH.name, elementary("Sech", (x) => 1 / Math.cosh(x), new Map([["0", int(1)]]), simplify));
+  table.set(CSCH.name, elementary("Csch", (x) => 1 / Math.sinh(x), new Map(), simplify));
 
   table.set(EQUAL.name, (_vm, expr) => boolNode(equals(binaryArgs(expr)[0], binaryArgs(expr)[1])));
   table.set(NOT_EQUAL.name, (_vm, expr) => boolNode(!equals(binaryArgs(expr)[0], binaryArgs(expr)[1])));
@@ -561,6 +567,30 @@ function diff(f: IRNode, x: IRNode): IRNode {
     }
     if (equals(f.head, ATANH)) {
       return app(DIV, [innerDiff, app(SUB, [int(1), app(POW, [inner, int(2)])])]);
+    }
+    if (equals(f.head, COTH)) {
+      return app(NEG, [
+        app(DIV, [
+          innerDiff,
+          app(POW, [app(SINH, [inner]), int(2)]),
+        ]),
+      ]);
+    }
+    if (equals(f.head, SECH)) {
+      return app(NEG, [
+        app(DIV, [
+          app(MUL, [innerDiff, app(SINH, [inner])]),
+          app(POW, [app(COSH, [inner]), int(2)]),
+        ]),
+      ]);
+    }
+    if (equals(f.head, CSCH)) {
+      return app(NEG, [
+        app(DIV, [
+          app(MUL, [innerDiff, app(COSH, [inner])]),
+          app(POW, [app(SINH, [inner]), int(2)]),
+        ]),
+      ]);
     }
   }
 

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -7,6 +7,8 @@ import {
   ATANH,
   COS,
   COSH,
+  COTH,
+  CSCH,
   D,
   DEFINE,
   DIV,
@@ -20,6 +22,7 @@ import {
   MUL,
   NEG,
   POW,
+  SECH,
   SIN,
   SINH,
   SQRT,
@@ -89,6 +92,21 @@ describe("symbolic-vm", () => {
   it("evaluates elementary numeric functions and exact identities", () => {
     const vm = new VM(new SymbolicBackend());
     expect(vm.eval(app(SIN, [int(0)]))).toEqual(int(0));
+  });
+
+  it("evaluates reciprocal hyperbolic numeric functions and exact identities", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(COTH, [numberNode(1.2)]))).toEqual(numberNode(Math.cosh(1.2) / Math.sinh(1.2)));
+    expect(vm.eval(app(SECH, [numberNode(0.7)]))).toEqual(numberNode(1 / Math.cosh(0.7)));
+    expect(vm.eval(app(CSCH, [numberNode(0.5)]))).toEqual(numberNode(1 / Math.sinh(0.5)));
+    expect(vm.eval(app(SECH, [int(0)]))).toEqual(int(1));
+  });
+
+  it("leaves reciprocal hyperbolic symbolic applications held", () => {
+    const vm = new VM(new SymbolicBackend());
+    expect(vm.eval(app(COTH, [sym("x")]))).toEqual(app(COTH, [sym("x")]));
+    expect(vm.eval(app(SECH, [sym("x")]))).toEqual(app(SECH, [sym("x")]));
+    expect(vm.eval(app(CSCH, [sym("x")]))).toEqual(app(CSCH, [sym("x")]));
   });
 
   it("evaluates comparisons and held if branches", () => {
@@ -190,6 +208,24 @@ describe("symbolic-vm", () => {
     );
     expect(vm.eval(app(D, [app(ATANH, [sym("x")]), sym("x")]))).toEqual(
       app(DIV, [int(1), app(SUB, [int(1), app(POW, [sym("x"), int(2)])])]),
+    );
+  });
+
+  it("applies reciprocal hyperbolic chain rules through Sinh and Cosh", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const square = app(POW, [x, int(2)]);
+    expect(vm.eval(app(D, [app(COTH, [x]), x]))).toEqual(
+      app(NEG, [app(DIV, [int(1), app(POW, [app(SINH, [x]), int(2)])])]),
+    );
+    expect(vm.eval(app(D, [app(SECH, [x]), x]))).toEqual(
+      app(NEG, [app(DIV, [app(SINH, [x]), app(POW, [app(COSH, [x]), int(2)])])]),
+    );
+    expect(vm.eval(app(D, [app(CSCH, [x]), x]))).toEqual(
+      app(NEG, [app(DIV, [app(COSH, [x]), app(POW, [app(SINH, [x]), int(2)])])]),
+    );
+    expect(vm.eval(app(D, [app(COTH, [square]), x]))).toEqual(
+      app(NEG, [app(DIV, [app(MUL, [int(2), x]), app(POW, [app(SINH, [square]), int(2)])])]),
     );
   });
 


### PR DESCRIPTION
## Summary
- add first-class TypeScript symbolic-ir heads for `Coth`, `Sech`, and `Csch`
- add symbolic-vm numeric handlers for reciprocal hyperbolic functions
- add derivative chain rules expressed through `Sinh`/`Cosh`, matching the Python symbolic-vm formulas and avoiding self-recursive reciprocal-head derivatives
- cover numeric identities, held symbolic applications, and derivative structure/chain behavior

## Validation
- `npm ci` in `code/packages/typescript/symbolic-ir`
- `npm run build` in `code/packages/typescript/symbolic-ir`
- `npm test` in `code/packages/typescript/symbolic-ir` — 7 tests passed
- `npm run test:coverage` in `code/packages/typescript/symbolic-ir` — 7 tests passed, 83.51% lines
- `npm ci` in `code/packages/typescript/symbolic-vm`
- `npm run build` in `code/packages/typescript/symbolic-vm`
- `npm test` in `code/packages/typescript/symbolic-vm` — 31 tests passed
- `npm run test:coverage` in `code/packages/typescript/symbolic-vm` — 31 tests passed, 83.58% lines