### PR TITLE
Add Rust reciprocal hyperbolic symbolic VM parity

### DIFF
--- a/code/packages/rust/symbolic-ir/CHANGELOG.md
+++ b/code/packages/rust/symbolic-ir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — symbolic-ir (Rust)
 
+## Unreleased
+
+### Added
+
+- First-class reciprocal hyperbolic head constants: `COTH`, `SECH`, and `CSCH`.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/symbolic-ir/src/lib.rs
+++ b/code/packages/rust/symbolic-ir/src/lib.rs
@@ -354,6 +354,9 @@ pub const TANH: &str = "Tanh";
 pub const ASINH: &str = "Asinh";
 pub const ACOSH: &str = "Acosh";
 pub const ATANH: &str = "Atanh";
+pub const COTH: &str = "Coth";
+pub const SECH: &str = "Sech";
+pub const CSCH: &str = "Csch";
 
 // Calculus
 pub const D: &str = "D";
@@ -427,6 +430,13 @@ mod tests {
     fn rational_keeps_numerator_zero() {
         // 0/anything == 0 (integer zero)
         assert_eq!(IRNode::rational(0, 5), IRNode::Integer(0));
+    }
+
+    #[test]
+    fn reciprocal_hyperbolic_heads_are_first_class_constants() {
+        assert_eq!(sym(COTH), IRNode::Symbol("Coth".to_string()));
+        assert_eq!(sym(SECH), IRNode::Symbol("Sech".to_string()));
+        assert_eq!(sym(CSCH), IRNode::Symbol("Csch".to_string()));
     }
 
     #[test]

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -8,6 +8,9 @@
   differentiation of arithmetic, elementary, hyperbolic, and inverse
   hyperbolic expressions; `StrictBackend` continues to reject `D` as an
   unknown head.
+- Numeric and symbolic handlers for reciprocal hyperbolic heads `Coth`,
+  `Sech`, and `Csch`, including `sech(0) = 1` and undefined-at-zero checks for
+  `coth`/`csch`.
 
 ## [0.1.0] — 2026-04-27
 

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -24,9 +24,9 @@
 use std::collections::HashMap;
 
 use symbolic_ir::{
-    IRApply, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ASSIGN, ATAN, ATANH, COS, COSH, D, DEFINE,
-    DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INTEGRATE, INV, LESS, LESS_EQUAL, LOG, MUL, NEG,
-    NOT, NOT_EQUAL, OR, POW, SIN, SINH, SQRT, SUB, TAN, TANH,
+    IRApply, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ASSIGN, ATAN, ATANH, COS, COSH, COTH,
+    CSCH, D, DEFINE, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INTEGRATE, INV, LESS, LESS_EQUAL,
+    LOG, MUL, NEG, NOT, NOT_EQUAL, OR, POW, SECH, SIN, SINH, SQRT, SUB, TAN, TANH,
 };
 
 use crate::backend::Handler;
@@ -676,6 +676,31 @@ fn tanh_handler(simplify: bool) -> Handler {
     })
 }
 
+fn coth_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
+        single_recip_hyp(&expr, COTH, |x| x.cosh() / x.sinh(), true, &[], simplify)
+    })
+}
+
+fn sech_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
+        single_recip_hyp(
+            &expr,
+            SECH,
+            |x| 1.0 / x.cosh(),
+            false,
+            &[(Numeric::Int(0), IRNode::Integer(1))],
+            simplify,
+        )
+    })
+}
+
+fn csch_handler(simplify: bool) -> Handler {
+    std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
+        single_recip_hyp(&expr, CSCH, |x| 1.0 / x.sinh(), true, &[], simplify)
+    })
+}
+
 fn asinh_handler(simplify: bool) -> Handler {
     std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
         single_trig(
@@ -725,6 +750,35 @@ fn single_trig(
     }
     let a = &expr.args[0];
     if let Some(va) = to_numeric(a) {
+        for (input, output) in exact_cases {
+            if va == *input {
+                return output.clone();
+            }
+        }
+        return IRNode::Float(f(va.to_f64()));
+    }
+    if !simplify {
+        panic!("{name} requires a numeric argument: {expr}");
+    }
+    IRNode::Apply(Box::new(expr.clone()))
+}
+
+fn single_recip_hyp(
+    expr: &IRApply,
+    name: &str,
+    f: fn(f64) -> f64,
+    undefined_at_zero: bool,
+    exact_cases: &[(Numeric, IRNode)],
+    simplify: bool,
+) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr.clone()));
+    }
+    let a = &expr.args[0];
+    if let Some(va) = to_numeric(a) {
+        if undefined_at_zero && va.is_zero() {
+            panic!("{name} undefined at zero: {expr}");
+        }
         for (input, output) in exact_cases {
             if va == *input {
                 return output.clone();
@@ -1188,14 +1242,14 @@ fn diff(f: &IRNode, x: &str) -> IRNode {
             );
             apply_node(DIV, vec![diff(inner, x), denom])
         }
-        ("Coth", [inner]) => {
+        (COTH, [inner]) => {
             let denom = apply_node(
                 POW,
                 vec![apply_node(SINH, vec![inner.clone()]), IRNode::Integer(2)],
             );
             apply_node(NEG, vec![apply_node(DIV, vec![diff(inner, x), denom])])
         }
-        ("Sech", [inner]) => {
+        (SECH, [inner]) => {
             let numer = apply_node(
                 MUL,
                 vec![diff(inner, x), apply_node(SINH, vec![inner.clone()])],
@@ -1206,7 +1260,7 @@ fn diff(f: &IRNode, x: &str) -> IRNode {
             );
             apply_node(NEG, vec![apply_node(DIV, vec![numer, denom])])
         }
-        ("Csch", [inner]) => {
+        (CSCH, [inner]) => {
             let numer = apply_node(
                 MUL,
                 vec![diff(inner, x), apply_node(COSH, vec![inner.clone()])],
@@ -1322,6 +1376,9 @@ pub fn build_handler_table(simplify: bool) -> HashMap<String, Handler> {
     m.insert(SINH.to_string(), sinh_handler(simplify));
     m.insert(COSH.to_string(), cosh_handler(simplify));
     m.insert(TANH.to_string(), tanh_handler(simplify));
+    m.insert(COTH.to_string(), coth_handler(simplify));
+    m.insert(SECH.to_string(), sech_handler(simplify));
+    m.insert(CSCH.to_string(), csch_handler(simplify));
     m.insert(ASINH.to_string(), asinh_handler(simplify));
     m.insert(ACOSH.to_string(), acosh_handler(simplify));
     m.insert(ATANH.to_string(), atanh_handler(simplify));

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -4,8 +4,9 @@
 //! directly and evaluating them under each backend.
 
 use symbolic_ir::{
-    apply, flt, int, rat, sym, ACOSH, ADD, AND, ASINH, ASSIGN, ATANH, COS, COSH, D, DEFINE, DIV,
-    EXP, IF, INTEGRATE, LIST, LOG, MUL, NEG, NOT, OR, POW, SIN, SINH, SQRT, SUB, TAN, TANH,
+    apply, flt, int, rat, sym, ACOSH, ADD, AND, ASINH, ASSIGN, ATANH, COS, COSH, COTH, CSCH, D,
+    DEFINE, DIV, EXP, IF, INTEGRATE, LIST, LOG, MUL, NEG, NOT, OR, POW, SECH, SIN, SINH, SQRT, SUB,
+    TAN, TANH,
 };
 use symbolic_vm::{StrictBackend, SymbolicBackend, VM};
 
@@ -27,6 +28,16 @@ fn d(f: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
 
 fn integrate(f: symbolic_ir::IRNode) -> symbolic_ir::IRNode {
     symbolic().eval(apply(sym(INTEGRATE), vec![f, sym("x")]))
+}
+
+fn assert_float_close(node: symbolic_ir::IRNode, expected: f64) {
+    let symbolic_ir::IRNode::Float(actual) = node else {
+        panic!("expected Float({expected:?}), got {node}");
+    };
+    assert!(
+        (actual - expected).abs() < 1e-12,
+        "expected {expected:?}, got {actual:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -266,6 +277,46 @@ fn sin_symbolic_stays() {
     assert_eq!(symbolic().eval(expr.clone()), expr);
 }
 
+#[test]
+fn reciprocal_hyperbolic_numeric_identities() {
+    let x = 1.25_f64;
+    assert_float_close(
+        symbolic().eval(apply(sym(COTH), vec![flt(x)])),
+        x.cosh() / x.sinh(),
+    );
+    assert_float_close(
+        symbolic().eval(apply(sym(SECH), vec![flt(x)])),
+        1.0 / x.cosh(),
+    );
+    assert_float_close(
+        symbolic().eval(apply(sym(CSCH), vec![flt(x)])),
+        1.0 / x.sinh(),
+    );
+    assert_eq!(symbolic().eval(apply(sym(SECH), vec![int(0)])), int(1));
+}
+
+#[test]
+fn reciprocal_hyperbolic_symbolic_stays_held() {
+    let coth = apply(sym(COTH), vec![sym("x")]);
+    let sech = apply(sym(SECH), vec![sym("x")]);
+    let csch = apply(sym(CSCH), vec![sym("x")]);
+    assert_eq!(symbolic().eval(coth.clone()), coth);
+    assert_eq!(symbolic().eval(sech.clone()), sech);
+    assert_eq!(symbolic().eval(csch.clone()), csch);
+}
+
+#[test]
+#[should_panic(expected = "Coth undefined at zero")]
+fn coth_zero_panics() {
+    symbolic().eval(apply(sym(COTH), vec![int(0)]));
+}
+
+#[test]
+#[should_panic(expected = "Csch undefined at zero")]
+fn csch_zero_panics() {
+    symbolic().eval(apply(sym(CSCH), vec![int(0)]));
+}
+
 // ---------------------------------------------------------------------------
 // Symbolic derivative handler
 // ---------------------------------------------------------------------------
@@ -474,7 +525,7 @@ fn derivative_hyperbolic_chain_rules() {
 #[test]
 fn derivative_reciprocal_hyperbolic_chain_rules() {
     assert_eq!(
-        d(apply(sym("Coth"), vec![sym("x")])),
+        d(apply(sym(COTH), vec![sym("x")])),
         apply(
             sym(NEG),
             vec![apply(
@@ -487,7 +538,7 @@ fn derivative_reciprocal_hyperbolic_chain_rules() {
         )
     );
     assert_eq!(
-        d(apply(sym("Sech"), vec![sym("x")])),
+        d(apply(sym(SECH), vec![sym("x")])),
         apply(
             sym(NEG),
             vec![apply(
@@ -500,7 +551,7 @@ fn derivative_reciprocal_hyperbolic_chain_rules() {
         )
     );
     assert_eq!(
-        d(apply(sym("Csch"), vec![sym("x")])),
+        d(apply(sym(CSCH), vec![sym("x")])),
         apply(
             sym(NEG),
             vec![apply(
@@ -508,6 +559,60 @@ fn derivative_reciprocal_hyperbolic_chain_rules() {
                 vec![
                     apply(sym(COSH), vec![sym("x")]),
                     apply(sym(POW), vec![apply(sym(SINH), vec![sym("x")]), int(2)]),
+                ],
+            )],
+        )
+    );
+
+    let inner = apply(
+        sym(ADD),
+        vec![apply(sym(MUL), vec![int(2), sym("x")]), int(1)],
+    );
+    assert_eq!(
+        d(apply(sym(COTH), vec![inner.clone()])),
+        apply(
+            sym(NEG),
+            vec![apply(
+                sym(DIV),
+                vec![
+                    int(2),
+                    apply(sym(POW), vec![apply(sym(SINH), vec![inner]), int(2)]),
+                ],
+            )],
+        )
+    );
+
+    let triple_x = apply(sym(MUL), vec![int(3), sym("x")]);
+    assert_eq!(
+        d(apply(sym(SECH), vec![triple_x.clone()])),
+        apply(
+            sym(NEG),
+            vec![apply(
+                sym(DIV),
+                vec![
+                    apply(
+                        sym(MUL),
+                        vec![int(3), apply(sym(SINH), vec![triple_x.clone()])]
+                    ),
+                    apply(sym(POW), vec![apply(sym(COSH), vec![triple_x]), int(2)]),
+                ],
+            )],
+        )
+    );
+
+    let half_x = apply(sym(DIV), vec![sym("x"), int(2)]);
+    assert_eq!(
+        d(apply(sym(CSCH), vec![half_x.clone()])),
+        apply(
+            sym(NEG),
+            vec![apply(
+                sym(DIV),
+                vec![
+                    apply(
+                        sym(MUL),
+                        vec![rat(1, 2), apply(sym(COSH), vec![half_x.clone()])],
+                    ),
+                    apply(sym(POW), vec![apply(sym(SINH), vec![half_x]), int(2)]),
                 ],
             )],
         )


### PR DESCRIPTION
## Summary
- add first-class Rust symbolic-ir constants for Coth, Sech, and Csch
- wire symbolic-vm numeric/symbolic handlers for reciprocal hyperbolic heads
- update derivative rules/tests to use the constants and Python-matching Sinh/Cosh formulas

## Validation
- cargo fmt -p symbolic-ir -p symbolic-vm
- cargo test -p symbolic-ir -p symbolic-vm
- cargo check -p symbolic-ir -p symbolic-vm

## Notes
- Rust-only slice; no parser/lexer work.
- Coth(0) and Csch(0) panic as undefined numeric evaluation, while Sech(0) folds to 1.