### PR TITLE
[codex] Add TypeScript CAS identity rules

### DIFF
--- a/code/packages/typescript/cas-simplify/BUILD
+++ b/code/packages/typescript/cas-simplify/BUILD
@@ -1,3 +1,4 @@
+cd ../cas-pattern-matching && npm ci --quiet
 npm ci --quiet
 npm run build
 npx vitest run --coverage

--- a/code/packages/typescript/cas-simplify/package-lock.json
+++ b/code/packages/typescript/cas-simplify/package-lock.json
@@ -9,9 +9,24 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
       },
       "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-pattern-matching": {
+      "name": "@coding-adventures/cas-pattern-matching",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
@@ -100,6 +115,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/cas-pattern-matching": {
+      "resolved": "../cas-pattern-matching",
+      "link": true
     },
     "node_modules/@coding-adventures/symbolic-ir": {
       "resolved": "../symbolic-ir",

--- a/code/packages/typescript/cas-simplify/package.json
+++ b/code/packages/typescript/cas-simplify/package.json
@@ -13,6 +13,7 @@
   "author": "Adhithya Rajasekaran",
   "license": "MIT",
   "dependencies": {
+    "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
   },
   "devDependencies": {

--- a/code/packages/typescript/cas-simplify/src/index.ts
+++ b/code/packages/typescript/cas-simplify/src/index.ts
@@ -17,12 +17,15 @@ import {
   rational,
   structuralKey,
 } from "@coding-adventures/symbolic-ir";
+import { isRewriteCycleError, rewrite } from "@coding-adventures/cas-pattern-matching";
+import { IDENTITY_RULES } from "./rules";
 
 export { AssumptionContext } from "./assumptions";
 export { IMAGINARY_UNIT, demoivre, exponentialize } from "./exponentialize";
 export * from "./heads";
 export { logcontract, logexpand } from "./logcontract";
 export { radcan } from "./radcan";
+export { IDENTITY_RULES, buildIdentityRules } from "./rules";
 
 export function canonical(node: IRNode): IRNode {
   if (node.kind !== "apply") return node;
@@ -88,7 +91,10 @@ function simplifyOnce(node: IRNode): IRNode {
     if (arg.kind === "apply" && headName(arg.head) === NEG.name && arg.args.length === 1) return arg.args[0];
   }
   if (name === EXP.name && args.length === 1 && isZero(args[0])) return int(1);
-  return app(head, args);
+
+  const simplified = app(head, args);
+  const rewritten = rewrite(simplified, IDENTITY_RULES);
+  return isRewriteCycleError(rewritten) ? simplified : rewritten;
 }
 
 function simplifyAdd(args: readonly IRNode[]): IRNode {

--- a/code/packages/typescript/cas-simplify/src/rules.ts
+++ b/code/packages/typescript/cas-simplify/src/rules.ts
@@ -1,0 +1,52 @@
+import { blank, named, rule } from "@coding-adventures/cas-pattern-matching";
+import {
+  ADD,
+  COS,
+  DIV,
+  EXP,
+  LOG,
+  MUL,
+  POW,
+  SIN,
+  SUB,
+  app,
+  int,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+
+/**
+ * Build and return the algebraic identity rules consumed by the pattern rewriter.
+ *
+ * Pattern variables use `named("x", blank())`, not `sym("x")`, so RHS
+ * substitution can replace captures with the matched expression.
+ */
+export function buildIdentityRules(): IRNode[] {
+  const x = () => named("x", blank());
+  const zero = int(0);
+  const one = int(1);
+
+  return [
+    rule(app(ADD, [x(), zero]), x()),
+    rule(app(ADD, [zero, x()]), x()),
+
+    rule(app(MUL, [x(), one]), x()),
+    rule(app(MUL, [one, x()]), x()),
+    rule(app(MUL, [x(), zero]), zero),
+    rule(app(MUL, [zero, x()]), zero),
+
+    rule(app(POW, [x(), zero]), one),
+    rule(app(POW, [x(), one]), x()),
+    rule(app(POW, [one, x()]), one),
+
+    rule(app(SUB, [x(), x()]), zero),
+    rule(app(DIV, [x(), x()]), one),
+
+    rule(app(LOG, [app(EXP, [x()])]), x()),
+    rule(app(EXP, [app(LOG, [x()])]), x()),
+
+    rule(app(SIN, [zero]), zero),
+    rule(app(COS, [zero]), one),
+  ];
+}
+
+export const IDENTITY_RULES: readonly IRNode[] = Object.freeze(buildIdentityRules());

--- a/code/packages/typescript/cas-simplify/tests/simplify.test.ts
+++ b/code/packages/typescript/cas-simplify/tests/simplify.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { ADD, MUL, NEG, POW, app, int, sym } from "@coding-adventures/symbolic-ir";
-import { canonical, numericFold, simplify } from "../src/index";
+import { blank, named, rewrite, rule } from "@coding-adventures/cas-pattern-matching";
+import { ADD, EXP, LOG, MUL, NEG, POW, app, int, sym } from "@coding-adventures/symbolic-ir";
+import { IDENTITY_RULES, buildIdentityRules, canonical, numericFold, simplify } from "../src/index";
 
 describe("cas-simplify", () => {
   it("canonicalizes flattened commutative expressions", () => {
@@ -16,6 +17,35 @@ describe("cas-simplify", () => {
   it("applies identity simplification to fixed point", () => {
     const expr = app(MUL, [int(1), app(ADD, [sym("x"), int(0)])]);
     expect(simplify(expr)).toEqual(sym("x"));
+  });
+
+  it("exports a fresh identity rule table matching the Python and Rust parity set", () => {
+    const rules = buildIdentityRules();
+    const x = named("x", blank());
+
+    expect(IDENTITY_RULES).toHaveLength(15);
+    expect(rules).toHaveLength(15);
+    expect(rules).not.toBe(buildIdentityRules());
+    expect(rules[0]).toEqual(rule(app(ADD, [x, int(0)]), x));
+    expect(rules[11]).toEqual(rule(app(LOG, [app(EXP, [x])]), x));
+    for (const candidate of rules) {
+      expect(candidate.kind).toBe("apply");
+      if (candidate.kind === "apply") {
+        expect(candidate.head).toEqual(sym("Rule"));
+        expect(candidate.args).toHaveLength(2);
+      }
+    }
+  });
+
+  it("rewrites additive identity through the identity rule table", () => {
+    expect(rewrite(app(ADD, [sym("x"), int(0)]), IDENTITY_RULES)).toEqual(sym("x"));
+  });
+
+  it("rewrites log and exp inverses through captured pattern variables", () => {
+    const expr = app(LOG, [app(EXP, [app(ADD, [sym("x"), int(1)])])]);
+
+    expect(rewrite(expr, IDENTITY_RULES)).toEqual(app(ADD, [sym("x"), int(1)]));
+    expect(simplify(expr)).toEqual(app(ADD, [int(1), sym("x")]));
   });
 
   it("simplifies double negation", () => {

--- a/code/packages/typescript/cas-simplify/tsconfig.json
+++ b/code/packages/typescript/cas-simplify/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": ".",
+    "preserveSymlinks": true,
     "skipLibCheck": true,
     "types": ["vitest/globals"]
   },


### PR DESCRIPTION
## Summary
- Add a TypeScript cas-simplify identity-rule table mirroring the Python/Rust parity set.
- Export `buildIdentityRules()` and readonly `IDENTITY_RULES` from the package surface.
- Run the identity table through `simplify` as a final rewrite pass, including `Log(Exp(x_)) -> x_` / `Exp(Log(x_)) -> x_`, while preserving existing simplification behavior.
- Add focused tests for table shape, `named("x", blank())` captures, and matcher rewrites.

## Validation
- `npm install` in `code/packages/typescript/cas-simplify`
- `npm run build`
- `npm test` - 2 files / 20 tests passed
- `npm run test:coverage` - 2 files / 20 tests passed; all files 90.41% statements, 75.4% branches; `rules.ts` 100%

## Notes
- Write set is confined to `code/packages/typescript/cas-simplify/**`.
- Added `preserveSymlinks` so the package-local TypeScript build resolves linked local dependencies consistently.