### PR TITLE
[codex] Add TS AlgFactor handler table

### DIFF
--- a/code/packages/typescript/cas-algebraic/src/index.ts
+++ b/code/packages/typescript/cas-algebraic/src/index.ts
@@ -16,6 +16,16 @@ import {
 
 export const ALG_FACTOR = sym("AlgFactor");
 
+export type AlgFactorEvalFn = (node: IRNode) => IRNode;
+
+export interface AlgFactorEvaluator {
+  eval(node: IRNode): IRNode;
+}
+
+export type AlgFactorHandlerEvaluator = AlgFactorEvalFn | AlgFactorEvaluator;
+
+export type AlgFactorHandler = (expr: IRNode, evaluator?: AlgFactorHandlerEvaluator) => IRNode;
+
 export interface RationalValue {
   readonly numer: bigint;
   readonly denom: bigint;
@@ -139,6 +149,33 @@ export function algFactorIr(poly: IRNode, sqrtD: IRNode, variable: IRNode): IRNo
   return factors === null ? null : factorsToIr(factors, variable, sqrtD);
 }
 
+function algFactorNormalizedIr(poly: IRNode, sqrtD: IRNode, variable: IRNode): IRNode | null {
+  const d = extractRadicalD(sqrtD);
+  if (d === null) return null;
+  const rationalCoeffs = irToRationalPoly(poly, variable);
+  if (rationalCoeffs === null) return null;
+  const commonDenom = rationalCoeffs.reduce((acc, coeff) => lcm(acc, coeff.denom), 1n);
+  const coeffs = rationalCoeffs.map((coeff) => coeff.numer * (commonDenom / coeff.denom));
+  const factors = factorOverExtension(trimBigint(coeffs), d);
+  return factors === null ? null : factorsToIr(factors, variable, sqrtD);
+}
+
+export function algFactorHandler(expr: IRNode, evaluator?: AlgFactorHandlerEvaluator): IRNode {
+  if (expr.kind !== "apply" || !equals(expr.head, ALG_FACTOR) || expr.args.length !== 2) return expr;
+  const [poly, sqrtD] = expr.args;
+  const evaluatedPoly = evaluatePolynomial(poly, evaluator);
+  const variable = findPolynomialVariable(evaluatedPoly);
+  if (variable === null) return expr;
+  return algFactorNormalizedIr(evaluatedPoly, sqrtD, variable) ?? expr;
+}
+
+export function buildAlgFactorHandlerTable(): ReadonlyMap<string, AlgFactorHandler> {
+  return new Map([[ALG_FACTOR.name, algFactorHandler]]);
+}
+
+export const alg_factor_handler = algFactorHandler;
+export const build_alg_factor_handler_table = buildAlgFactorHandlerTable;
+
 export function factorsToIr(factors: readonly AlgPoly[], variable: IRNode, sqrtD: IRNode): IRNode {
   if (factors.length === 0) return int(1);
   return factors.map((factor) => algPolyToIr(factor, variable, sqrtD))
@@ -232,6 +269,23 @@ function irToRationalPoly(node: IRNode, variable: IRNode): RationalValue[] | nul
 
 function integerPolyToAlgPoly(poly: readonly bigint[]): AlgPoly {
   return poly.map((coeff) => algCoeff(ratValue(coeff), ZERO));
+}
+
+const CONSTANT_SYMBOL_NAMES = new Set(["True", "False", "%pi", "%e", "%i"]);
+
+function evaluatePolynomial(poly: IRNode, evaluator: AlgFactorHandlerEvaluator | undefined): IRNode {
+  if (evaluator === undefined) return poly;
+  return typeof evaluator === "function" ? evaluator(poly) : evaluator.eval(poly);
+}
+
+function findPolynomialVariable(node: IRNode): IRNode | null {
+  if (node.kind === "symbol") return CONSTANT_SYMBOL_NAMES.has(node.name) ? null : node;
+  if (node.kind !== "apply") return null;
+  for (const arg of node.args) {
+    const found = findPolynomialVariable(arg);
+    if (found !== null) return found;
+  }
+  return null;
 }
 
 function algCoeff(rationalPart: RationalValue, radicalPart: RationalValue): AlgCoeff {
@@ -355,6 +409,10 @@ function gcd(mutA: bigint, mutB: bigint): bigint {
     a = t;
   }
   return a;
+}
+
+function lcm(a: bigint, b: bigint): bigint {
+  return a === 0n || b === 0n ? 0n : (a / gcd(a, b)) * b;
 }
 
 function abs(value: bigint): bigint {

--- a/code/packages/typescript/cas-algebraic/tests/cas-algebraic.test.ts
+++ b/code/packages/typescript/cas-algebraic/tests/cas-algebraic.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { ADD, MUL, POW, SQRT, SUB, app, int, sym } from "@coding-adventures/symbolic-ir";
+import { ADD, MUL, POW, SQRT, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
 import {
+  ALG_FACTOR,
   algFactorIr,
+  algFactorHandler,
+  buildAlgFactorHandlerTable,
   extractRadicalD,
   factorOverExtension,
   rationalSquareRoot,
@@ -11,6 +14,10 @@ import {
 
 function sqrtD(d: bigint | number) {
   return app(SQRT, [int(d)]);
+}
+
+function algFactor(poly: IRNode, radical: IRNode) {
+  return app(ALG_FACTOR, [poly, radical]);
 }
 
 describe("rationalSquareRoot", () => {
@@ -85,5 +92,66 @@ describe("IR adapter", () => {
   it("returns null for non-polynomials", () => {
     const x = sym("x");
     expect(algFactorIr(app(sym("Sin"), [x]), sqrtD(2), x)).toBeNull();
+  });
+});
+
+describe("AlgFactor handler", () => {
+  it("registers a table entry under AlgFactor", () => {
+    const table = buildAlgFactorHandlerTable();
+    expect([...table.keys()]).toEqual(["AlgFactor"]);
+    expect(table.get("AlgFactor")).toBe(algFactorHandler);
+  });
+
+  it("falls through unchanged for wrong arity", () => {
+    const expr = app(ALG_FACTOR, [int(1), sqrtD(2), int(3)]);
+    expect(algFactorHandler(expr)).toBe(expr);
+  });
+
+  it("falls through unchanged for non-Sqrt extensions", () => {
+    const x = sym("x");
+    const expr = algFactor(app(SUB, [app(POW, [x, int(2)]), int(2)]), int(2));
+    expect(algFactorHandler(expr)).toBe(expr);
+  });
+
+  it("falls through unchanged for non-polynomial inputs", () => {
+    const x = sym("x");
+    const expr = algFactor(app(sym("Sin"), [x]), sqrtD(2));
+    expect(algFactorHandler(expr)).toBe(expr);
+  });
+
+  it("falls through unchanged for irreducible polynomials", () => {
+    const x = sym("x");
+    const expr = algFactor(app(ADD, [app(POW, [x, int(2)]), int(1)]), sqrtD(2));
+    expect(algFactorHandler(expr)).toBe(expr);
+  });
+
+  it("factors AlgFactor(x^2 - 2, Sqrt(2)) to product IR", () => {
+    const x = sym("x");
+    const expr = algFactor(app(SUB, [app(POW, [x, int(2)]), int(2)]), sqrtD(2));
+    const result = algFactorHandler(expr);
+    expect(result.kind).toBe("apply");
+    expect(result.kind === "apply" && equals(result.head, MUL)).toBe(true);
+  });
+
+  it("clears rational polynomial denominators in the handler path", () => {
+    const x = sym("x");
+    const expr = algFactor(app(SUB, [app(MUL, [rational(1, 2), app(POW, [x, int(2)])]), int(1)]), sqrtD(2));
+    const result = algFactorHandler(expr);
+    expect(result.kind).toBe("apply");
+    expect(result.kind === "apply" && equals(result.head, MUL)).toBe(true);
+  });
+
+  it("uses an evaluator callback before polynomial conversion", () => {
+    const x = sym("x");
+    const y = sym("y");
+    const normalized = app(SUB, [app(POW, [x, int(2)]), int(2)]);
+    const expr = algFactor(y, sqrtD(2));
+    const result = algFactorHandler(expr, {
+      eval(node) {
+        return equals(node, y) ? normalized : node;
+      },
+    });
+    expect(result.kind).toBe("apply");
+    expect(result.kind === "apply" && equals(result.head, MUL)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add a browser-safe AlgFactor handler entrypoint and handler table exports for @coding-adventures/cas-algebraic
- keep the handler VM-neutral with optional evaluator support for polynomial normalization before coefficient conversion
- preserve fallthrough behavior for wrong arity, non-Sqrt extensions, non-polynomials, and irreducible inputs

## Validation
- npm install
- npm run build
- npm test: 19 tests passed
- npm run test:coverage: 19 tests passed, 96.6% line coverage

## Notes
- no parser/lexer work
- write set is limited to code/packages/typescript/cas-algebraic/**