### PR TITLE
Add Rust cas-algebraic AlgFactor handler

### DIFF
--- a/code/packages/rust/cas-algebraic/src/handlers.rs
+++ b/code/packages/rust/cas-algebraic/src/handlers.rs
@@ -1,0 +1,76 @@
+use std::collections::BTreeMap;
+
+use symbolic_ir::{IRApply, IRNode};
+
+use crate::{
+    algebraic::factor_over_extension,
+    ir::{extract_radical_d, factors_to_ir, ir_to_cleared_integer_poly, ALG_FACTOR},
+};
+
+pub type AlgFactorHandler = fn(&IRApply) -> IRNode;
+pub type AlgFactorHandlerTable = BTreeMap<&'static str, AlgFactorHandler>;
+
+pub fn alg_factor_handler(expr: &IRApply) -> IRNode {
+    if !is_alg_factor_application(expr) {
+        return original_expr(expr);
+    }
+
+    let poly_ir = expr.args[0].clone();
+    alg_factor_handler_from_poly(expr, &poly_ir)
+}
+
+pub fn alg_factor_handler_with_eval<F>(expr: &IRApply, eval: F) -> IRNode
+where
+    F: FnOnce(&IRNode) -> IRNode,
+{
+    if !is_alg_factor_application(expr) {
+        return original_expr(expr);
+    }
+
+    let poly_ir = eval(&expr.args[0]);
+    alg_factor_handler_from_poly(expr, &poly_ir)
+}
+
+pub fn build_alg_factor_handler_table() -> AlgFactorHandlerTable {
+    let mut table = BTreeMap::new();
+    table.insert(ALG_FACTOR, alg_factor_handler as AlgFactorHandler);
+    table
+}
+
+fn alg_factor_handler_from_poly(expr: &IRApply, poly_ir: &IRNode) -> IRNode {
+    let sqrt_ir = &expr.args[1];
+    let Some(d) = extract_radical_d(sqrt_ir) else {
+        return original_expr(expr);
+    };
+    let Some(variable) = find_variable(poly_ir) else {
+        return original_expr(expr);
+    };
+    let Some(coeffs) = ir_to_cleared_integer_poly(poly_ir, &variable) else {
+        return original_expr(expr);
+    };
+    let Some(factors) = factor_over_extension(&coeffs, d) else {
+        return original_expr(expr);
+    };
+
+    factors_to_ir(&factors, &variable, sqrt_ir)
+}
+
+fn is_alg_factor_application(expr: &IRApply) -> bool {
+    expr.head == IRNode::Symbol(ALG_FACTOR.to_string()) && expr.args.len() == 2
+}
+
+fn original_expr(expr: &IRApply) -> IRNode {
+    IRNode::Apply(Box::new(expr.clone()))
+}
+
+fn find_variable(node: &IRNode) -> Option<IRNode> {
+    match node {
+        IRNode::Symbol(name) if !is_constant_name(name) => Some(node.clone()),
+        IRNode::Apply(apply) => apply.args.iter().find_map(find_variable),
+        _ => None,
+    }
+}
+
+fn is_constant_name(name: &str) -> bool {
+    matches!(name, "True" | "False" | "%pi" | "%e" | "%i")
+}

--- a/code/packages/rust/cas-algebraic/src/ir.rs
+++ b/code/packages/rust/cas-algebraic/src/ir.rs
@@ -103,6 +103,19 @@ pub fn ir_to_integer_poly(node: &IRNode, variable: &IRNode) -> Option<Vec<i64>> 
     trim_trailing_zeros(out)
 }
 
+pub fn ir_to_cleared_integer_poly(node: &IRNode, variable: &IRNode) -> Option<Vec<i64>> {
+    let coeffs = ir_to_rational_poly(node, variable)?;
+    let lcm = coeffs
+        .iter()
+        .try_fold(1_i64, |acc, coeff| checked_lcm(acc, coeff.denom))?;
+
+    let mut out = Vec::with_capacity(coeffs.len());
+    for coeff in coeffs {
+        out.push(coeff.numer.checked_mul(lcm / coeff.denom)?);
+    }
+    trim_trailing_zeros(out)
+}
+
 fn ir_to_rational_poly(node: &IRNode, variable: &IRNode) -> Option<Vec<Rational>> {
     if node == variable {
         return Some(vec![Rational::ZERO, Rational::ONE]);
@@ -175,6 +188,20 @@ fn trim_trailing_zeros(mut poly: Vec<i64>) -> Option<Vec<i64>> {
         poly.pop();
     }
     Some(poly)
+}
+
+fn checked_lcm(lhs: i64, rhs: i64) -> Option<i64> {
+    let gcd = integer_gcd(lhs.unsigned_abs(), rhs.unsigned_abs()) as i64;
+    (lhs / gcd).checked_mul(rhs)
+}
+
+fn integer_gcd(mut a: u64, mut b: u64) -> u64 {
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
 }
 
 fn poly_add(lhs: &[Rational], rhs: &[Rational]) -> Vec<Rational> {

--- a/code/packages/rust/cas-algebraic/src/lib.rs
+++ b/code/packages/rust/cas-algebraic/src/lib.rs
@@ -6,6 +6,7 @@
 //! `cas-factor` to split any integer factors already visible over `Z`.
 
 pub mod algebraic;
+pub mod handlers;
 pub mod ir;
 pub mod rational;
 
@@ -13,8 +14,12 @@ pub use algebraic::{
     factor_over_extension, try_split_depressed_quartic, try_split_quadratic, try_split_single,
     AlgCoeff, AlgPoly,
 };
+pub use handlers::{
+    alg_factor_handler, alg_factor_handler_with_eval, build_alg_factor_handler_table,
+    AlgFactorHandler, AlgFactorHandlerTable,
+};
 pub use ir::{
     alg_coeff_to_ir, alg_factor_ir, alg_poly_to_ir, extract_radical_d, factors_to_ir,
-    ir_to_integer_poly, ALG_FACTOR,
+    ir_to_cleared_integer_poly, ir_to_integer_poly, ALG_FACTOR,
 };
 pub use rational::{rational_square_root, Rational};

--- a/code/packages/rust/cas-algebraic/tests/tests.rs
+++ b/code/packages/rust/cas-algebraic/tests/tests.rs
@@ -1,11 +1,19 @@
 use cas_algebraic::{
-    alg_factor_ir, extract_radical_d, factor_over_extension, rational_square_root,
-    try_split_depressed_quartic, try_split_quadratic, Rational,
+    alg_factor_handler, alg_factor_handler_with_eval, alg_factor_ir,
+    build_alg_factor_handler_table, extract_radical_d, factor_over_extension, rational_square_root,
+    try_split_depressed_quartic, try_split_quadratic, Rational, ALG_FACTOR,
 };
-use symbolic_ir::{apply, int, sym, ADD, MUL, POW, SQRT, SUB};
+use symbolic_ir::{apply, int, rat, sym, IRApply, IRNode, ADD, MUL, POW, SQRT, SUB};
 
 fn sqrt_d(d: i64) -> symbolic_ir::IRNode {
     apply(sym(SQRT), vec![int(d)])
+}
+
+fn alg_factor_apply(args: Vec<IRNode>) -> IRApply {
+    IRApply {
+        head: sym(ALG_FACTOR),
+        args,
+    }
 }
 
 #[test]
@@ -105,4 +113,109 @@ fn ir_adapter_returns_none_for_non_polynomial() {
     let x = sym("x");
     let sin_x = apply(sym("Sin"), vec![x.clone()]);
     assert!(alg_factor_ir(&sin_x, &sqrt_d(2), &x).is_none());
+}
+
+#[test]
+fn handler_table_registers_alg_factor() {
+    let table = build_alg_factor_handler_table();
+    assert!(table.contains_key(ALG_FACTOR));
+}
+
+#[test]
+fn handler_returns_original_for_wrong_arity() {
+    let expr = alg_factor_apply(vec![int(1)]);
+    let original = IRNode::Apply(Box::new(expr.clone()));
+
+    assert_eq!(alg_factor_handler(&expr), original);
+}
+
+#[test]
+fn handler_returns_original_for_non_sqrt_extension() {
+    let x = sym("x");
+    let poly = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(2)],
+    );
+    let expr = alg_factor_apply(vec![poly, int(2)]);
+    let original = IRNode::Apply(Box::new(expr.clone()));
+
+    assert_eq!(alg_factor_handler(&expr), original);
+}
+
+#[test]
+fn handler_returns_original_for_non_polynomial() {
+    let x = sym("x");
+    let sin_x = apply(sym("Sin"), vec![x.clone()]);
+    let expr = alg_factor_apply(vec![sin_x, sqrt_d(2)]);
+    let original = IRNode::Apply(Box::new(expr.clone()));
+
+    assert_eq!(alg_factor_handler(&expr), original);
+}
+
+#[test]
+fn handler_returns_original_for_irreducible_polynomial() {
+    let x = sym("x");
+    let x2_plus_1 = apply(
+        sym(ADD),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+    );
+    let expr = alg_factor_apply(vec![x2_plus_1, sqrt_d(2)]);
+    let original = IRNode::Apply(Box::new(expr.clone()));
+
+    assert_eq!(alg_factor_handler(&expr), original);
+}
+
+#[test]
+fn handler_factors_x2_minus_2_over_sqrt_two() {
+    let x = sym("x");
+    let x2_minus_2 = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(2)],
+    );
+    let expr = alg_factor_apply(vec![x2_minus_2, sqrt_d(2)]);
+
+    let result = alg_factor_handler(&expr);
+
+    match result {
+        IRNode::Apply(apply) => assert_eq!(apply.head, sym(MUL)),
+        other => panic!("expected product IR, got {other:?}"),
+    }
+}
+
+#[test]
+fn handler_clears_rational_coefficients_before_factoring() {
+    let x = sym("x");
+    let half_x2 = apply(
+        sym(MUL),
+        vec![rat(1, 2), apply(sym(POW), vec![x.clone(), int(2)])],
+    );
+    let poly = apply(sym(SUB), vec![half_x2, int(1)]);
+    let expr = alg_factor_apply(vec![poly, sqrt_d(2)]);
+
+    let result = alg_factor_handler(&expr);
+
+    match result {
+        IRNode::Apply(apply) => assert_eq!(apply.head, sym(MUL)),
+        other => panic!("expected product IR after clearing denominators, got {other:?}"),
+    }
+}
+
+#[test]
+fn handler_evaluates_polynomial_before_conversion() {
+    let x = sym("x");
+    let normalized = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(2)],
+    );
+    let expr = alg_factor_apply(vec![apply(sym("NormalizeMe"), vec![x]), sqrt_d(2)]);
+    let original = IRNode::Apply(Box::new(expr.clone()));
+
+    assert_eq!(alg_factor_handler(&expr), original);
+
+    let result = alg_factor_handler_with_eval(&expr, |_| normalized);
+
+    match result {
+        IRNode::Apply(apply) => assert_eq!(apply.head, sym(MUL)),
+        other => panic!("expected product IR after eval callback, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary
- add VM-neutral Rust AlgFactor handler exports for `IRApply` dispatch plus an eval-callback variant
- add an `AlgFactor` handler table builder mirroring the Python package registration shape
- preserve unevaluated fallthrough for wrong arity, non-Sqrt extension, non-polynomial input, and irreducible cases
- clear rational polynomial denominators before factoring, matching the Python handler bridge

## Validation
- `cargo fmt -p cas-algebraic`
- `cargo test -p cas-algebraic`
- `cargo check -p cas-algebraic`

## Notes
- no parser/lexer work
- no `symbolic-vm` dependency added
- generated `code/packages/rust/Cargo.lock` was removed after validation