### PR TITLE
Port Rust advanced limit slice

### DIFF
--- a/code/packages/rust/cas-limit-series/src/lib.rs
+++ b/code/packages/rust/cas-limit-series/src/lib.rs
@@ -1,6 +1,7 @@
 //! # cas-limit-series
 //!
-//! Limit (direct substitution) and polynomial Taylor series over symbolic IR.
+//! Limit (direct substitution and focused advanced forms) plus polynomial
+//! Taylor series over symbolic IR.
 //!
 //! Rust port of the Python `cas-limit-series` package.
 //!
@@ -54,9 +55,11 @@
 //! ```
 
 pub mod limit;
+pub mod limit_advanced;
 pub mod taylor;
 
 pub use limit::limit_direct;
+pub use limit_advanced::{limit_advanced, LimitAdvancedOptions, LimitDirection};
 pub use taylor::{taylor_polynomial, PolynomialError};
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-limit-series/src/limit_advanced.rs
+++ b/code/packages/rust/cas-limit-series/src/limit_advanced.rs
@@ -1,0 +1,425 @@
+//! Advanced limit handling with injectable simplification and differentiation.
+//!
+//! This module is a focused Rust port of Python's `limit_advanced.py`.  It
+//! keeps the crate WASM-friendly and independent from the symbolic VM by taking
+//! optional callbacks for differentiation and evaluation.  When a callback is
+//! needed but absent, the result is returned as an unevaluated `Limit(...)`.
+
+use cas_substitution::subst;
+use symbolic_ir::{
+    apply, flt, int, sym, IRNode, ADD, ATAN, COS, COSH, DIV, EXP, LOG, MUL, NEG, POW, SIN, SINH,
+    SQRT, SUB, TAN, TANH,
+};
+
+use crate::LIMIT;
+
+const EPS: f64 = 1e-300;
+const INF_THRESHOLD: f64 = 1e100;
+const DEFAULT_MAX_DEPTH: usize = 8;
+
+/// Direction for one-sided limit classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitDirection {
+    /// Approach from the right.
+    Plus,
+    /// Approach from the left.
+    Minus,
+}
+
+/// Differentiation callback used by L'Hopital-style reductions.
+pub type DiffFn<'a> = dyn Fn(&IRNode, &IRNode) -> IRNode + 'a;
+
+/// Optional evaluation/simplification callback for intermediate IR.
+pub type EvalFn<'a> = dyn Fn(IRNode) -> IRNode + 'a;
+
+/// Options for [`limit_advanced`].
+#[derive(Default)]
+pub struct LimitAdvancedOptions<'a> {
+    /// Optional one-sided direction.
+    pub direction: Option<LimitDirection>,
+    /// Optional symbolic derivative callback.
+    pub diff_fn: Option<&'a DiffFn<'a>>,
+    /// Optional VM/simplifier callback.
+    pub eval_fn: Option<&'a EvalFn<'a>>,
+    /// Optional recursion limit. Defaults to 8, matching the Python slice.
+    pub max_depth: Option<usize>,
+}
+
+/// Compute an advanced limit for common indeterminate forms.
+///
+/// The implementation first classifies the expression numerically around the
+/// limit point.  Direct finite cases return the exact substituted IR.  Common
+/// indeterminate forms (`0/0`, `inf/inf`, `0*inf`, and selected power forms)
+/// are reduced with injected callbacks when available; otherwise an unevaluated
+/// `Limit(expr, var, point[, direction])` node is returned.
+pub fn limit_advanced<'a>(
+    expr: IRNode,
+    var: &IRNode,
+    point: IRNode,
+    options: LimitAdvancedOptions<'a>,
+) -> IRNode {
+    let max_depth = options.max_depth.unwrap_or(DEFAULT_MAX_DEPTH);
+    limit_advanced_inner(expr, var, point, &options, 0, max_depth)
+}
+
+fn limit_advanced_inner(
+    expr: IRNode,
+    var: &IRNode,
+    point: IRNode,
+    options: &LimitAdvancedOptions<'_>,
+    depth: usize,
+    max_depth: usize,
+) -> IRNode {
+    if depth > max_depth {
+        return build_unevaluated(expr, var, point, options.direction);
+    }
+
+    let pt_f = num_eval(&point);
+    if pt_f.is_nan() {
+        return build_unevaluated(expr, var, point, options.direction);
+    }
+
+    let eps = if options.direction == Some(LimitDirection::Minus) {
+        -EPS
+    } else {
+        EPS
+    };
+    let test_pt = if pt_f.is_infinite() { pt_f } else { pt_f + eps };
+    let val = eval_at_float(&expr, var, test_pt);
+
+    if is_effectively_inf(val) {
+        return infinity_symbol(val.is_sign_positive());
+    }
+
+    if val.is_nan() {
+        return handle_form(expr, var, point, options, depth, max_depth);
+    }
+
+    let mut subst_result = subst(point.clone(), var, expr.clone());
+    if let Some(eval_fn) = options.eval_fn {
+        subst_result = eval_fn(subst_result);
+    }
+    let exact_val = num_eval(&subst_result);
+
+    if !exact_val.is_nan() {
+        if exact_val.is_infinite() {
+            return infinity_symbol(exact_val.is_sign_positive());
+        }
+        return subst_result;
+    }
+
+    handle_form(expr, var, point, options, depth, max_depth)
+}
+
+fn handle_form(
+    expr: IRNode,
+    var: &IRNode,
+    point: IRNode,
+    options: &LimitAdvancedOptions<'_>,
+    depth: usize,
+    max_depth: usize,
+) -> IRNode {
+    let exact_pt = num_eval(&point);
+
+    if let IRNode::Apply(a) = &expr {
+        if a.head == sym(DIV) && a.args.len() == 2 {
+            let numer = &a.args[0];
+            let denom = &a.args[1];
+            let n_val = eval_at_float(numer, var, exact_pt);
+            let d_val = eval_at_float(denom, var, exact_pt);
+            let zero_zero = n_val == 0.0 && d_val == 0.0;
+            let inf_inf = is_effectively_inf(n_val) && is_effectively_inf(d_val);
+            if zero_zero || inf_inf {
+                if let Some(diff_fn) = options.diff_fn {
+                    return lhopital_step(
+                        numer, denom, var, point, options, diff_fn, depth, max_depth,
+                    );
+                }
+            }
+        }
+
+        if a.head == sym(MUL) && a.args.len() == 2 {
+            if let Some(result) = zero_inf_rewrite(
+                &a.args[0], &a.args[1], var, &point, exact_pt, options, depth, max_depth,
+            ) {
+                return result;
+            }
+        }
+
+        if a.head == sym(POW) && a.args.len() == 2 {
+            if let Some(result) = pow_exp_log(
+                &a.args[0], &a.args[1], var, &point, exact_pt, options, depth, max_depth,
+            ) {
+                return result;
+            }
+        }
+    }
+
+    build_unevaluated(expr, var, point, options.direction)
+}
+
+fn lhopital_step(
+    numer: &IRNode,
+    denom: &IRNode,
+    var: &IRNode,
+    point: IRNode,
+    options: &LimitAdvancedOptions<'_>,
+    diff_fn: &DiffFn<'_>,
+    depth: usize,
+    max_depth: usize,
+) -> IRNode {
+    let mut d_numer = diff_fn(numer, var);
+    let mut d_denom = diff_fn(denom, var);
+    if let Some(eval_fn) = options.eval_fn {
+        d_numer = eval_fn(d_numer);
+        d_denom = eval_fn(d_denom);
+    }
+    let mut new_ratio = apply(sym(DIV), vec![d_numer, d_denom]);
+    if let Some(eval_fn) = options.eval_fn {
+        new_ratio = eval_fn(new_ratio);
+    }
+    limit_advanced_inner(new_ratio, var, point, options, depth + 1, max_depth)
+}
+
+fn zero_inf_rewrite(
+    a: &IRNode,
+    b: &IRNode,
+    var: &IRNode,
+    point: &IRNode,
+    exact_pt: f64,
+    options: &LimitAdvancedOptions<'_>,
+    depth: usize,
+    max_depth: usize,
+) -> Option<IRNode> {
+    let a_val = eval_at_float(a, var, exact_pt);
+    let b_val = eval_at_float(b, var, exact_pt);
+
+    if a_val == 0.0 && is_effectively_inf(b_val) {
+        let one_over_a = apply(sym(DIV), vec![int(1), a.clone()]);
+        let mut new_expr = apply(sym(DIV), vec![b.clone(), one_over_a]);
+        if let Some(eval_fn) = options.eval_fn {
+            new_expr = eval_fn(new_expr);
+        }
+        let rewritten_options = without_direction(options);
+        return Some(limit_advanced_inner(
+            new_expr,
+            var,
+            point.clone(),
+            &rewritten_options,
+            depth + 1,
+            max_depth,
+        ));
+    }
+
+    if b_val == 0.0 && is_effectively_inf(a_val) {
+        let one_over_b = apply(sym(DIV), vec![int(1), b.clone()]);
+        let mut new_expr = apply(sym(DIV), vec![a.clone(), one_over_b]);
+        if let Some(eval_fn) = options.eval_fn {
+            new_expr = eval_fn(new_expr);
+        }
+        let rewritten_options = without_direction(options);
+        return Some(limit_advanced_inner(
+            new_expr,
+            var,
+            point.clone(),
+            &rewritten_options,
+            depth + 1,
+            max_depth,
+        ));
+    }
+
+    None
+}
+
+fn pow_exp_log(
+    base: &IRNode,
+    exponent: &IRNode,
+    var: &IRNode,
+    point: &IRNode,
+    exact_pt: f64,
+    options: &LimitAdvancedOptions<'_>,
+    depth: usize,
+    max_depth: usize,
+) -> Option<IRNode> {
+    let b_val = eval_at_float(base, var, exact_pt);
+    let e_val = eval_at_float(exponent, var, exact_pt);
+
+    let is_1_inf = (b_val - 1.0).abs() < 1e-10 && is_effectively_inf(e_val);
+    let is_0_0 = b_val == 0.0 && e_val == 0.0;
+    let is_inf_0 = is_effectively_inf(b_val) && e_val == 0.0;
+
+    if !(is_1_inf || is_0_0 || is_inf_0) {
+        return None;
+    }
+
+    let log_base = apply(sym(LOG), vec![base.clone()]);
+    let mut product = apply(sym(MUL), vec![exponent.clone(), log_base]);
+    if let Some(eval_fn) = options.eval_fn {
+        product = eval_fn(product);
+    }
+    let rewritten_options = without_direction(options);
+    let exponent_limit = limit_advanced_inner(
+        product,
+        var,
+        point.clone(),
+        &rewritten_options,
+        depth + 1,
+        max_depth,
+    );
+    let mut result = apply(sym(EXP), vec![exponent_limit]);
+    if let Some(eval_fn) = options.eval_fn {
+        result = eval_fn(result);
+    }
+    Some(result)
+}
+
+fn build_unevaluated(
+    expr: IRNode,
+    var: &IRNode,
+    point: IRNode,
+    direction: Option<LimitDirection>,
+) -> IRNode {
+    let mut args = vec![expr, var.clone(), point];
+    if let Some(direction) = direction {
+        args.push(match direction {
+            LimitDirection::Plus => sym("plus"),
+            LimitDirection::Minus => sym("minus"),
+        });
+    }
+    apply(sym(LIMIT), args)
+}
+
+fn infinity_symbol(positive: bool) -> IRNode {
+    if positive {
+        sym("inf")
+    } else {
+        sym("minf")
+    }
+}
+
+fn eval_at_float(expr: &IRNode, var: &IRNode, pt: f64) -> f64 {
+    let substituted = subst(flt(pt), var, expr.clone());
+    num_eval(&substituted)
+}
+
+fn is_effectively_inf(v: f64) -> bool {
+    v.is_infinite() || v.abs() > INF_THRESHOLD
+}
+
+fn num_eval(node: &IRNode) -> f64 {
+    ev(node)
+}
+
+fn ev(node: &IRNode) -> f64 {
+    match node {
+        IRNode::Integer(v) => *v as f64,
+        IRNode::Rational(n, d) => *n as f64 / *d as f64,
+        IRNode::Float(v) => *v,
+        IRNode::Symbol(name) => match name.as_str() {
+            "inf" => f64::INFINITY,
+            "minf" => f64::NEG_INFINITY,
+            "%pi" => std::f64::consts::PI,
+            "%e" => std::f64::consts::E,
+            _ => f64::NAN,
+        },
+        IRNode::Str(_) => f64::NAN,
+        IRNode::Apply(a) => ev_apply(&a.head, &a.args),
+    }
+}
+
+fn ev_apply(head: &IRNode, args: &[IRNode]) -> f64 {
+    let Some(head) = symbol_name(head) else {
+        return f64::NAN;
+    };
+
+    match head {
+        ADD => args.iter().map(ev).sum(),
+        SUB if args.len() == 2 => ev(&args[0]) - ev(&args[1]),
+        MUL => args.iter().map(ev).product(),
+        DIV if args.len() == 2 => {
+            let numer = ev(&args[0]);
+            let denom = ev(&args[1]);
+            if denom == 0.0 {
+                if numer == 0.0 {
+                    f64::NAN
+                } else {
+                    numer.signum() * f64::INFINITY
+                }
+            } else {
+                numer / denom
+            }
+        }
+        NEG if args.len() == 1 => -ev(&args[0]),
+        POW if args.len() == 2 => ev_pow(&args[0], &args[1]),
+        SQRT if args.len() == 1 => {
+            let val = ev(&args[0]);
+            if val < 0.0 {
+                f64::NAN
+            } else {
+                val.sqrt()
+            }
+        }
+        EXP if args.len() == 1 => ev(&args[0]).exp(),
+        LOG if args.len() == 1 => {
+            let val = ev(&args[0]);
+            if val == 0.0 {
+                f64::NEG_INFINITY
+            } else if val < 0.0 {
+                f64::NAN
+            } else {
+                val.ln()
+            }
+        }
+        SIN if args.len() == 1 => ev_trig(&args[0], f64::sin),
+        COS if args.len() == 1 => ev_trig(&args[0], f64::cos),
+        TAN if args.len() == 1 => ev_trig(&args[0], f64::tan),
+        ATAN if args.len() == 1 => ev(&args[0]).atan(),
+        SINH if args.len() == 1 => ev(&args[0]).sinh(),
+        COSH if args.len() == 1 => ev(&args[0]).cosh(),
+        TANH if args.len() == 1 => ev(&args[0]).tanh(),
+        _ => f64::NAN,
+    }
+}
+
+fn ev_pow(base: &IRNode, exponent: &IRNode) -> f64 {
+    let base = ev(base);
+    let exp_val = ev(exponent);
+    if (base - 1.0).abs() < 1e-10 && is_effectively_inf(exp_val) {
+        return f64::NAN;
+    }
+    if base == 0.0 && exp_val == 0.0 {
+        return f64::NAN;
+    }
+    if is_effectively_inf(base) && exp_val == 0.0 {
+        return f64::NAN;
+    }
+    if base < 0.0 && exp_val.fract() != 0.0 {
+        return f64::NAN;
+    }
+    base.powf(exp_val)
+}
+
+fn ev_trig(arg: &IRNode, f: fn(f64) -> f64) -> f64 {
+    let val = ev(arg);
+    if val.is_infinite() {
+        f64::NAN
+    } else {
+        f(val)
+    }
+}
+
+fn symbol_name(node: &IRNode) -> Option<&str> {
+    match node {
+        IRNode::Symbol(name) => Some(name.as_str()),
+        _ => None,
+    }
+}
+
+fn without_direction<'a>(options: &LimitAdvancedOptions<'a>) -> LimitAdvancedOptions<'a> {
+    LimitAdvancedOptions {
+        direction: None,
+        diff_fn: options.diff_fn,
+        eval_fn: options.eval_fn,
+        max_depth: options.max_depth,
+    }
+}

--- a/code/packages/rust/cas-limit-series/src/taylor.rs
+++ b/code/packages/rust/cas-limit-series/src/taylor.rs
@@ -98,11 +98,17 @@ impl Frac {
         }
         let (n, d) = if d < 0 { (-n, -d) } else { (n, d) };
         let g = gcd(n.unsigned_abs(), d.unsigned_abs()) as i128;
-        Self { numer: n / g, denom: d / g }
+        Self {
+            numer: n / g,
+            denom: d / g,
+        }
     }
 
     fn from_i64(v: i64) -> Self {
-        Self { numer: v as i128, denom: 1 }
+        Self {
+            numer: v as i128,
+            denom: 1,
+        }
     }
 
     fn is_zero(&self) -> bool {
@@ -135,14 +141,20 @@ impl Frac {
 impl std::ops::Add for Frac {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        Frac::new(self.numer * rhs.denom + rhs.numer * self.denom, self.denom * rhs.denom)
+        Frac::new(
+            self.numer * rhs.denom + rhs.numer * self.denom,
+            self.denom * rhs.denom,
+        )
     }
 }
 
 impl std::ops::Sub for Frac {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        self + Frac { numer: -rhs.numer, denom: rhs.denom }
+        self + Frac {
+            numer: -rhs.numer,
+            denom: rhs.denom,
+        }
     }
 }
 

--- a/code/packages/rust/cas-limit-series/tests/tests.rs
+++ b/code/packages/rust/cas-limit-series/tests/tests.rs
@@ -3,8 +3,11 @@
 // Mirrors the Python reference tests in
 // code/packages/python/cas-limit-series/tests/.
 
-use cas_limit_series::{limit_direct, taylor_polynomial, PolynomialError, LIMIT};
-use symbolic_ir::{apply, int, sym, ADD, DIV, MUL, POW, SUB};
+use cas_limit_series::{
+    limit_advanced, limit_direct, taylor_polynomial, LimitAdvancedOptions, LimitDirection,
+    PolynomialError, LIMIT,
+};
+use symbolic_ir::{apply, int, sym, IRNode, ADD, DIV, EXP, LOG, MUL, POW, SUB};
 
 // ---------------------------------------------------------------------------
 // limit_direct
@@ -14,7 +17,10 @@ use symbolic_ir::{apply, int, sym, ADD, DIV, MUL, POW, SUB};
 fn limit_polynomial_at_finite_point() {
     // lim_{x→2} x^2 + 1  →  Add(Pow(2, 2), 1)  (un-simplified)
     let x = sym("x");
-    let expr = apply(sym(ADD), vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)]);
+    let expr = apply(
+        sym(ADD),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+    );
     let out = limit_direct(expr, &x, int(2));
     let expected = apply(
         sym(ADD),
@@ -68,6 +74,223 @@ fn limit_constant_unchanged() {
     // lim_{x→5} 42  →  42
     let x = sym("x");
     assert_eq!(limit_direct(int(42), &x, int(5)), int(42));
+}
+
+// ---------------------------------------------------------------------------
+// limit_advanced
+// ---------------------------------------------------------------------------
+
+fn test_diff(expr: &IRNode, var: &IRNode) -> IRNode {
+    if expr == var {
+        return int(1);
+    }
+    match expr {
+        IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_) | IRNode::Symbol(_) => {
+            int(0)
+        }
+        IRNode::Str(_) => int(0),
+        IRNode::Apply(a) if a.head == sym(ADD) => apply(
+            sym(ADD),
+            a.args.iter().map(|arg| test_diff(arg, var)).collect(),
+        ),
+        IRNode::Apply(a) if a.head == sym(SUB) && a.args.len() == 2 => apply(
+            sym(SUB),
+            vec![test_diff(&a.args[0], var), test_diff(&a.args[1], var)],
+        ),
+        IRNode::Apply(a) if a.head == sym(MUL) && a.args.len() == 2 => {
+            let f = &a.args[0];
+            let g = &a.args[1];
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(MUL), vec![test_diff(f, var), g.clone()]),
+                    apply(sym(MUL), vec![f.clone(), test_diff(g, var)]),
+                ],
+            )
+        }
+        IRNode::Apply(a) if a.head == sym(POW) && a.args.len() == 2 => {
+            if let IRNode::Integer(n) = a.args[1] {
+                if n == 0 {
+                    int(0)
+                } else {
+                    apply(
+                        sym(MUL),
+                        vec![
+                            apply(
+                                sym(MUL),
+                                vec![int(n), apply(sym(POW), vec![a.args[0].clone(), int(n - 1)])],
+                            ),
+                            test_diff(&a.args[0], var),
+                        ],
+                    )
+                }
+            } else {
+                int(0)
+            }
+        }
+        _ => int(0),
+    }
+}
+
+fn test_eval(node: IRNode) -> IRNode {
+    match node {
+        IRNode::Apply(a) => {
+            let args: Vec<_> = a.args.into_iter().map(test_eval).collect();
+            if a.head == sym(ADD) {
+                if args.iter().all(|arg| matches!(arg, IRNode::Integer(_))) {
+                    return int(args.iter().map(as_int).sum());
+                }
+            }
+            if a.head == sym(SUB) && args.len() == 2 {
+                if let (IRNode::Integer(lhs), IRNode::Integer(rhs)) = (&args[0], &args[1]) {
+                    return int(lhs - rhs);
+                }
+            }
+            if a.head == sym(MUL) {
+                if args.iter().any(|arg| *arg == int(0)) {
+                    return int(0);
+                }
+                let non_one: Vec<_> = args.into_iter().filter(|arg| *arg != int(1)).collect();
+                if non_one.is_empty() {
+                    return int(1);
+                }
+                if non_one.len() == 1 {
+                    return non_one[0].clone();
+                }
+                if non_one.iter().all(|arg| matches!(arg, IRNode::Integer(_))) {
+                    return int(non_one.iter().map(as_int).product());
+                }
+                return apply(sym(MUL), non_one);
+            }
+            if a.head == sym(DIV) && args.len() == 2 {
+                if args[1] == int(1) {
+                    return args[0].clone();
+                }
+                if let (IRNode::Integer(lhs), IRNode::Integer(rhs)) = (&args[0], &args[1]) {
+                    if *rhs != 0 && lhs % rhs == 0 {
+                        return int(lhs / rhs);
+                    }
+                }
+            }
+            if a.head == sym(POW) && args.len() == 2 {
+                if args[1] == int(0) {
+                    return int(1);
+                }
+                if args[1] == int(1) {
+                    return args[0].clone();
+                }
+                if let (IRNode::Integer(base), IRNode::Integer(exp)) = (&args[0], &args[1]) {
+                    if let Ok(exp) = u32::try_from(*exp) {
+                        return int(base.pow(exp));
+                    }
+                }
+            }
+            apply(a.head, args)
+        }
+        other => other,
+    }
+}
+
+fn as_int(node: &IRNode) -> i64 {
+    match node {
+        IRNode::Integer(v) => *v,
+        _ => panic!("expected integer, got {node:?}"),
+    }
+}
+
+#[test]
+fn limit_advanced_direct_finite_result() {
+    let x = sym("x");
+    let expr = apply(
+        sym(ADD),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+    );
+    let out = limit_advanced(
+        expr,
+        &x,
+        int(2),
+        LimitAdvancedOptions {
+            eval_fn: Some(&test_eval),
+            ..Default::default()
+        },
+    );
+    assert_eq!(out, int(5));
+}
+
+#[test]
+fn limit_advanced_indeterminate_without_callbacks_is_unevaluated() {
+    let x = sym("x");
+    let expr = apply(sym(DIV), vec![x.clone(), x.clone()]);
+    let out = limit_advanced(expr.clone(), &x, int(0), LimitAdvancedOptions::default());
+    assert_eq!(out, apply(sym(LIMIT), vec![expr, x, int(0)]));
+}
+
+#[test]
+fn limit_advanced_callback_lhopital_simple_rational() {
+    let x = sym("x");
+    let numer = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+    );
+    let denom = apply(sym(SUB), vec![x.clone(), int(1)]);
+    let expr = apply(sym(DIV), vec![numer, denom]);
+    let out = limit_advanced(
+        expr,
+        &x,
+        int(1),
+        LimitAdvancedOptions {
+            diff_fn: Some(&test_diff),
+            eval_fn: Some(&test_eval),
+            ..Default::default()
+        },
+    );
+    assert_eq!(out, int(2));
+}
+
+#[test]
+fn limit_advanced_one_sided_infinity() {
+    let x = sym("x");
+    let expr = apply(sym(DIV), vec![int(1), x.clone()]);
+    let out = limit_advanced(
+        expr,
+        &x,
+        int(0),
+        LimitAdvancedOptions {
+            direction: Some(LimitDirection::Minus),
+            ..Default::default()
+        },
+    );
+    assert_eq!(out, sym("minf"));
+}
+
+#[test]
+fn limit_advanced_power_rewrite_falls_back_inside_exp() {
+    let x = sym("x");
+    let expr = apply(sym(POW), vec![x.clone(), x.clone()]);
+    let out = limit_advanced(
+        expr,
+        &x,
+        int(0),
+        LimitAdvancedOptions {
+            direction: Some(LimitDirection::Plus),
+            ..Default::default()
+        },
+    );
+    let expected_inner = apply(
+        sym(LIMIT),
+        vec![
+            apply(
+                sym(DIV),
+                vec![
+                    apply(sym(LOG), vec![x.clone()]),
+                    apply(sym(DIV), vec![int(1), x.clone()]),
+                ],
+            ),
+            x,
+            int(0),
+        ],
+    );
+    assert_eq!(out, apply(sym(EXP), vec![expected_inner]));
 }
 
 // ---------------------------------------------------------------------------
@@ -196,7 +419,10 @@ fn taylor_linear_at_nonzero_point() {
     //   k=1: 3
     // → 5 + 3·(x-1)
     let x = sym("x");
-    let expr = apply(sym(ADD), vec![apply(sym(MUL), vec![int(3), x.clone()]), int(2)]);
+    let expr = apply(
+        sym(ADD),
+        vec![apply(sym(MUL), vec![int(3), x.clone()]), int(2)],
+    );
     let out = taylor_polynomial(&expr, &x, &int(1), 1).unwrap();
     // Should be Add(5, Mul(3, Sub(x, 1)))
     if let symbolic_ir::IRNode::Apply(a) = &out {


### PR DESCRIPTION
## Summary
- Add a focused Rust `limit_advanced` module for direct finite limits, numeric classification, infinity sentinels, L'Hopital-ready `0/0` and `inf/inf`, `0*inf` quotient rewrites, and selected `Pow` exp/log rewrites.
- Keep symbolic VM integration injectable through `LimitAdvancedOptions` callbacks for differentiation and simplification, falling back to unevaluated `Limit(...)` when callbacks are absent.
- Export the new API and add focused tests for direct finite substitution, callback-free indeterminate fallback, callback-driven L'Hopital on a rational form, one-sided infinity, and a power rewrite fallback.

## Validation
- `cargo fmt -p cas-limit-series`
- `cargo test -p cas-limit-series`
- `cargo check -p cas-limit-series`

## Limitations
- This does not add parser/lexer work or symbolic VM wiring.
- Full L'Hopital coverage depends on caller-provided derivative/evaluator callbacks.
- Broader indeterminate families such as `inf - inf` remain unevaluated for a later slice.