### PR TITLE
Port TS advanced CAS limit slice

### DIFF
--- a/code/packages/typescript/cas-limit-series/src/index.ts
+++ b/code/packages/typescript/cas-limit-series/src/index.ts
@@ -1,15 +1,26 @@
 import { subst } from "@coding-adventures/cas-substitution";
 import {
   ADD,
+  ATAN,
+  COS,
+  COSH,
   DIV,
+  EXP,
+  LOG,
   MUL,
   NEG,
   POW,
+  SIN,
+  SINH,
+  SQRT,
   SUB,
+  TAN,
+  TANH,
   app,
   equals,
   headName,
   int,
+  numberNode,
   rational,
   sym,
   type IRNode,
@@ -21,6 +32,17 @@ export const SERIES = "Series";
 export const BIG_O = "BigO";
 
 export type IntegerLike = bigint | number | string;
+export type LimitDirection = "plus" | "minus";
+export type LimitCallback = (node: IRNode) => IRNode | null | undefined;
+export type LimitDerivativeCallback = (node: IRNode, variable: IRNode) => IRNode | null | undefined;
+
+export interface LimitAdvancedOptions {
+  readonly direction?: LimitDirection;
+  readonly differentiate?: LimitDerivativeCallback;
+  readonly simplify?: LimitCallback;
+  readonly evaluate?: LimitCallback;
+  readonly maxDepth?: number;
+}
 
 export class PolynomialError extends Error {
   constructor(message: string) {
@@ -113,6 +135,15 @@ export function limitDirect(expr: IRNode, variable: IRNode, point: IRNode): IRNo
   return out;
 }
 
+export function limitAdvanced(
+  expr: IRNode,
+  variable: IRNode,
+  point: IRNode,
+  options: LimitAdvancedOptions = {},
+): IRNode {
+  return limitAdvancedInner(expr, variable, point, options, 0);
+}
+
 export function taylorPolynomial(expr: IRNode, variable: IRNode, point: IRNode, order: number): IRNode {
   if (!Number.isInteger(order) || order < 0) {
     throw new RangeError("taylorPolynomial order must be a non-negative integer");
@@ -129,6 +160,285 @@ function looksIndeterminate(node: IRNode): boolean {
     && node.args.length === 2
     && isIntegerValue(node.args[0], 0n)
     && isIntegerValue(node.args[1], 0n);
+}
+
+const INF_THRESHOLD = 1e100;
+const EPSILON = 1e-300;
+const DEFAULT_MAX_DEPTH = 8;
+const INF = sym("inf");
+const MINF = sym("minf");
+
+function limitAdvancedInner(
+  expr: IRNode,
+  variable: IRNode,
+  point: IRNode,
+  options: LimitAdvancedOptions,
+  depth: number,
+): IRNode {
+  if (depth > (options.maxDepth ?? DEFAULT_MAX_DEPTH)) {
+    return buildUnevaluatedLimit(expr, variable, point, options.direction);
+  }
+
+  const pointValue = pointToNumber(point);
+  if (Number.isNaN(pointValue)) {
+    return buildUnevaluatedLimit(expr, variable, point, options.direction);
+  }
+
+  const epsilon = options.direction === "minus" ? -EPSILON : EPSILON;
+  const testPoint = Number.isFinite(pointValue) ? pointValue + epsilon : pointValue;
+  const testValue = evalAtNumber(expr, variable, testPoint);
+  if (isInfiniteLike(testValue)) {
+    return testValue > 0 ? INF : MINF;
+  }
+  if (Number.isNaN(testValue)) {
+    return handleIndeterminateForm(expr, variable, point, options, depth);
+  }
+
+  let substituted = subst(point, variable, expr);
+  substituted = applyLimitCallbacks(substituted, options);
+  const exactValue = numericEval(substituted);
+  if (!Number.isNaN(exactValue)) {
+    if (isInfiniteLike(exactValue)) {
+      return exactValue > 0 ? INF : MINF;
+    }
+    return substituted;
+  }
+
+  return handleIndeterminateForm(expr, variable, point, options, depth);
+}
+
+function handleIndeterminateForm(
+  expr: IRNode,
+  variable: IRNode,
+  point: IRNode,
+  options: LimitAdvancedOptions,
+  depth: number,
+): IRNode {
+  const exactPoint = pointToNumber(point);
+  if (Number.isNaN(exactPoint)) {
+    return buildUnevaluatedLimit(expr, variable, point, options.direction);
+  }
+
+  if (expr.kind === "apply" && headName(expr.head) === DIV.name && expr.args.length === 2) {
+    const [numer, denom] = expr.args;
+    const numerValue = evalAtNumber(numer, variable, exactPoint);
+    const denomValue = evalAtNumber(denom, variable, exactPoint);
+    const zeroZero = numerValue === 0 && denomValue === 0;
+    const infInf = isInfiniteLike(numerValue) && isInfiniteLike(denomValue);
+    if ((zeroZero || infInf) && options.differentiate !== undefined) {
+      return lhopital(numer, denom, variable, point, options, depth);
+    }
+  }
+
+  if (expr.kind === "apply" && headName(expr.head) === MUL.name && expr.args.length === 2) {
+    const rewritten = rewriteZeroInfinityProduct(expr.args[0], expr.args[1], variable, point, exactPoint, options, depth);
+    if (rewritten !== null) return rewritten;
+  }
+
+  if (expr.kind === "apply" && headName(expr.head) === POW.name && expr.args.length === 2) {
+    const rewritten = rewriteIndeterminatePower(expr.args[0], expr.args[1], variable, point, exactPoint, options, depth);
+    if (rewritten !== null) return rewritten;
+  }
+
+  return buildUnevaluatedLimit(expr, variable, point, options.direction);
+}
+
+function lhopital(
+  numer: IRNode,
+  denom: IRNode,
+  variable: IRNode,
+  point: IRNode,
+  options: LimitAdvancedOptions,
+  depth: number,
+): IRNode {
+  const dNumer = options.differentiate?.(numer, variable);
+  const dDenom = options.differentiate?.(denom, variable);
+  if (dNumer === null || dNumer === undefined || dDenom === null || dDenom === undefined) {
+    return buildUnevaluatedLimit(app(DIV, [numer, denom]), variable, point, options.direction);
+  }
+  const ratio = applyLimitCallbacks(app(DIV, [
+    applyLimitCallbacks(dNumer, options),
+    applyLimitCallbacks(dDenom, options),
+  ]), options);
+  return limitAdvancedInner(ratio, variable, point, options, depth + 1);
+}
+
+function rewriteZeroInfinityProduct(
+  a: IRNode,
+  b: IRNode,
+  variable: IRNode,
+  point: IRNode,
+  exactPoint: number,
+  options: LimitAdvancedOptions,
+  depth: number,
+): IRNode | null {
+  if (options.differentiate === undefined) return null;
+  const aValue = evalAtNumber(a, variable, exactPoint);
+  const bValue = evalAtNumber(b, variable, exactPoint);
+  if (aValue === 0 && isInfiniteLike(bValue)) {
+    return limitAdvancedInner(app(DIV, [b, app(DIV, [int(1), a])]), variable, point, {
+      ...options,
+      direction: undefined,
+    }, depth + 1);
+  }
+  if (bValue === 0 && isInfiniteLike(aValue)) {
+    return limitAdvancedInner(app(DIV, [a, app(DIV, [int(1), b])]), variable, point, {
+      ...options,
+      direction: undefined,
+    }, depth + 1);
+  }
+  return null;
+}
+
+function rewriteIndeterminatePower(
+  base: IRNode,
+  exponent: IRNode,
+  variable: IRNode,
+  point: IRNode,
+  exactPoint: number,
+  options: LimitAdvancedOptions,
+  depth: number,
+): IRNode | null {
+  const baseValue = evalAtNumber(base, variable, exactPoint);
+  const exponentValue = evalAtNumber(exponent, variable, exactPoint);
+  const oneToInfinity = Math.abs(baseValue - 1) < 1e-10 && isInfiniteLike(exponentValue);
+  const zeroToZero = baseValue === 0 && exponentValue === 0;
+  const infinityToZero = isInfiniteLike(baseValue) && exponentValue === 0;
+  if (!(oneToInfinity || zeroToZero || infinityToZero)) return null;
+
+  if (options.differentiate === undefined) {
+    return buildUnevaluatedLimit(app(POW, [base, exponent]), variable, point, options.direction);
+  }
+
+  const exponentLimit = limitAdvancedInner(app(MUL, [exponent, app(LOG, [base])]), variable, point, {
+    ...options,
+    direction: undefined,
+  }, depth + 1);
+  if (isLimitNode(exponentLimit)) {
+    return buildUnevaluatedLimit(app(POW, [base, exponent]), variable, point, options.direction);
+  }
+  return applyLimitCallbacks(app(EXP, [exponentLimit]), options);
+}
+
+function applyLimitCallbacks(node: IRNode, options: LimitAdvancedOptions): IRNode {
+  let out = node;
+  const simplified = options.simplify?.(out);
+  if (simplified !== null && simplified !== undefined) out = simplified;
+  const evaluated = options.evaluate?.(out);
+  if (evaluated !== null && evaluated !== undefined) out = evaluated;
+  return out;
+}
+
+function buildUnevaluatedLimit(expr: IRNode, variable: IRNode, point: IRNode, direction?: LimitDirection): IRNode {
+  const args = direction === undefined ? [expr, variable, point] : [expr, variable, point, sym(direction)];
+  return app(sym(LIMIT), args);
+}
+
+function isLimitNode(node: IRNode): boolean {
+  return node.kind === "apply" && headName(node.head) === LIMIT;
+}
+
+function evalAtNumber(expr: IRNode, variable: IRNode, point: number): number {
+  const pointNode = Number.isFinite(point) ? numberNode(point) : point > 0 ? INF : MINF;
+  return numericEval(subst(pointNode, variable, expr));
+}
+
+function pointToNumber(point: IRNode): number {
+  return numericEval(point);
+}
+
+function numericEval(node: IRNode): number {
+  try {
+    return numericEvalUnsafe(node);
+  } catch {
+    return Number.NaN;
+  }
+}
+
+function numericEvalUnsafe(node: IRNode): number {
+  switch (node.kind) {
+    case "integer":
+      return Number(node.value);
+    case "rational":
+      return Number(node.numer) / Number(node.denom);
+    case "float":
+      return node.value;
+    case "symbol":
+      if (node.name === "inf") return Number.POSITIVE_INFINITY;
+      if (node.name === "minf") return Number.NEGATIVE_INFINITY;
+      if (node.name === "%pi") return Math.PI;
+      if (node.name === "%e") return Math.E;
+      return Number.NaN;
+    case "string":
+      return Number.NaN;
+    case "apply":
+      return numericEvalApply(node);
+  }
+}
+
+function numericEvalApply(node: Extract<IRNode, { readonly kind: "apply" }>): number {
+  const name = headName(node.head);
+  const args = node.args;
+  if (name === ADD.name) return args.reduce((sum, arg) => sum + numericEvalUnsafe(arg), 0);
+  if (name === SUB.name && args.length === 2) return numericEvalUnsafe(args[0]) - numericEvalUnsafe(args[1]);
+  if (name === MUL.name) return args.reduce((product, arg) => product * numericEvalUnsafe(arg), 1);
+  if (name === DIV.name && args.length === 2) {
+    const numer = numericEvalUnsafe(args[0]);
+    const denom = numericEvalUnsafe(args[1]);
+    if (denom === 0) {
+      if (numer === 0) return Number.NaN;
+      return Math.sign(numer) >= 0 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+    }
+    return numer / denom;
+  }
+  if (name === NEG.name && args.length === 1) return -numericEvalUnsafe(args[0]);
+  if (name === POW.name && args.length === 2) {
+    const base = numericEvalUnsafe(args[0]);
+    const exponent = numericEvalUnsafe(args[1]);
+    if (Math.abs(base - 1) < 1e-10 && isInfiniteLike(exponent)) return Number.NaN;
+    if (base === 0 && exponent === 0) return Number.NaN;
+    if (isInfiniteLike(base) && exponent === 0) return Number.NaN;
+    if (base < 0 && !Number.isInteger(exponent)) return Number.NaN;
+    return base ** exponent;
+  }
+  if (name === SQRT.name && args.length === 1) {
+    const value = numericEvalUnsafe(args[0]);
+    return value < 0 ? Number.NaN : Math.sqrt(value);
+  }
+  if (name === EXP.name && args.length === 1) return safeExp(numericEvalUnsafe(args[0]));
+  if (name === LOG.name && args.length === 1) {
+    const value = numericEvalUnsafe(args[0]);
+    if (value === 0) return Number.NEGATIVE_INFINITY;
+    if (value < 0) return Number.NaN;
+    return Math.log(value);
+  }
+  if (name === SIN.name && args.length === 1) {
+    const value = numericEvalUnsafe(args[0]);
+    return Number.isFinite(value) ? Math.sin(value) : Number.NaN;
+  }
+  if (name === COS.name && args.length === 1) {
+    const value = numericEvalUnsafe(args[0]);
+    return Number.isFinite(value) ? Math.cos(value) : Number.NaN;
+  }
+  if (name === TAN.name && args.length === 1) {
+    const value = numericEvalUnsafe(args[0]);
+    return Number.isFinite(value) ? Math.tan(value) : Number.NaN;
+  }
+  if (name === ATAN.name && args.length === 1) return Math.atan(numericEvalUnsafe(args[0]));
+  if (name === SINH.name && args.length === 1) return Math.sinh(numericEvalUnsafe(args[0]));
+  if (name === COSH.name && args.length === 1) return Math.cosh(numericEvalUnsafe(args[0]));
+  if (name === TANH.name && args.length === 1) return Math.tanh(numericEvalUnsafe(args[0]));
+  return Number.NaN;
+}
+
+function safeExp(value: number): number {
+  if (value === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
+  if (value === Number.NEGATIVE_INFINITY) return 0;
+  return Math.exp(value);
+}
+
+function isInfiniteLike(value: number): boolean {
+  return Number.isFinite(value) ? Math.abs(value) > INF_THRESHOLD : !Number.isNaN(value);
 }
 
 function toCoefficients(expr: IRNode, variable: IRNode): Frac[] {

--- a/code/packages/typescript/cas-limit-series/tests/cas-limit-series.test.ts
+++ b/code/packages/typescript/cas-limit-series/tests/cas-limit-series.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { ADD, DIV, MUL, POW, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
-import { LIMIT, PolynomialError, limitDirect, taylorPolynomial } from "../src/index";
+import { ADD, DIV, MUL, NEG, POW, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { LIMIT, PolynomialError, limitAdvanced, limitDirect, taylorPolynomial } from "../src/index";
 
 function expectEqual(actual: IRNode, expected: IRNode): void {
   expect(equals(actual, expected), `${display(actual)} !== ${display(expected)}`).toBe(true);
@@ -8,6 +8,91 @@ function expectEqual(actual: IRNode, expected: IRNode): void {
 
 function display(node: IRNode): string {
   return JSON.stringify(node, (_key, value) => (typeof value === "bigint" ? value.toString() : value));
+}
+
+function differentiateFixture(node: IRNode, variable: IRNode): IRNode {
+  if (equals(node, variable)) return int(1);
+  if (node.kind === "integer" || node.kind === "rational" || node.kind === "float" || node.kind === "symbol") {
+    return int(0);
+  }
+  if (node.kind !== "apply") return int(0);
+  if (equals(node.head, ADD)) return app(ADD, node.args.map((arg) => differentiateFixture(arg, variable)));
+  if (equals(node.head, SUB) && node.args.length === 2) {
+    return app(SUB, [
+      differentiateFixture(node.args[0], variable),
+      differentiateFixture(node.args[1], variable),
+    ]);
+  }
+  if (equals(node.head, NEG) && node.args.length === 1) return app(NEG, [differentiateFixture(node.args[0], variable)]);
+  if (equals(node.head, MUL) && node.args.length === 2) {
+    const [f, g] = node.args;
+    return app(ADD, [
+      app(MUL, [differentiateFixture(f, variable), g]),
+      app(MUL, [f, differentiateFixture(g, variable)]),
+    ]);
+  }
+  if (equals(node.head, DIV) && node.args.length === 2) {
+    const [f, g] = node.args;
+    return app(DIV, [
+      app(SUB, [
+        app(MUL, [differentiateFixture(f, variable), g]),
+        app(MUL, [f, differentiateFixture(g, variable)]),
+      ]),
+      app(POW, [g, int(2)]),
+    ]);
+  }
+  if (equals(node.head, POW) && node.args.length === 2 && node.args[1].kind === "integer") {
+    const [base, exponent] = node.args;
+    if (exponent.value === 0n) return int(0);
+    return app(MUL, [
+      app(MUL, [int(exponent.value), app(POW, [base, int(exponent.value - 1n)])]),
+      differentiateFixture(base, variable),
+    ]);
+  }
+  return int(0);
+}
+
+function evaluateFixture(node: IRNode): IRNode {
+  if (node.kind !== "apply") return node;
+  const args = node.args.map(evaluateFixture);
+  if (equals(node.head, ADD)) {
+    if (args.every(isIntegerNode)) return int(args.reduce((sum, arg) => sum + arg.value, 0n));
+    const nonzero = args.filter((arg) => !isIntegerValue(arg, 0n));
+    if (nonzero.length === 1) return nonzero[0];
+  }
+  if (equals(node.head, SUB) && args.length === 2) {
+    if (isIntegerNode(args[0]) && isIntegerNode(args[1])) return int(args[0].value - args[1].value);
+    if (isIntegerValue(args[1], 0n)) return args[0];
+  }
+  if (equals(node.head, NEG) && args.length === 1 && isIntegerNode(args[0])) return int(-args[0].value);
+  if (equals(node.head, MUL)) {
+    if (args.every(isIntegerNode)) return int(args.reduce((product, arg) => product * arg.value, 1n));
+    if (args.length === 2 && isIntegerValue(args[0], 1n)) return args[1];
+    if (args.length === 2 && isIntegerValue(args[1], 1n)) return args[0];
+  }
+  if (equals(node.head, DIV) && args.length === 2) {
+    const [numer, denom] = args;
+    if (equals(numer, denom)) return int(1);
+    if (isIntegerValue(denom, 1n)) return numer;
+    if (isIntegerNode(numer) && isIntegerNode(denom) && denom.value !== 0n) return rational(numer.value, denom.value);
+  }
+  if (equals(node.head, POW) && args.length === 2) {
+    const [base, exponent] = args;
+    if (isIntegerValue(exponent, 0n)) return int(1);
+    if (isIntegerValue(exponent, 1n)) return base;
+    if (isIntegerNode(base) && isIntegerNode(exponent) && exponent.value >= 0n) {
+      return int(base.value ** exponent.value);
+    }
+  }
+  return app(node.head, args);
+}
+
+function isIntegerNode(node: IRNode): node is Extract<IRNode, { readonly kind: "integer" }> {
+  return node.kind === "integer";
+}
+
+function isIntegerValue(node: IRNode, value: bigint): boolean {
+  return isIntegerNode(node) && node.value === value;
 }
 
 describe("limitDirect", () => {
@@ -42,6 +127,50 @@ describe("limitDirect", () => {
 
   it("keeps constants unchanged", () => {
     expectEqual(limitDirect(int(42), sym("x"), int(5)), int(42));
+  });
+});
+
+describe("limitAdvanced", () => {
+  it("returns a direct finite result after exact substitution", () => {
+    const x = sym("x");
+    const expr = app(ADD, [app(POW, [x, int(2)]), int(1)]);
+    expectEqual(limitAdvanced(expr, x, int(2), { evaluate: evaluateFixture }), int(5));
+  });
+
+  it("returns unevaluated Limit for indeterminate quotients without callbacks", () => {
+    const x = sym("x");
+    const expr = app(DIV, [
+      app(SUB, [app(POW, [x, int(2)]), int(1)]),
+      app(SUB, [x, int(1)]),
+    ]);
+    expectEqual(limitAdvanced(expr, x, int(1)), app(sym(LIMIT), [expr, x, int(1)]));
+  });
+
+  it("uses injected differentiation for a simple L'Hopital rational form", () => {
+    const x = sym("x");
+    const expr = app(DIV, [
+      app(SUB, [app(POW, [x, int(2)]), int(1)]),
+      app(SUB, [x, int(1)]),
+    ]);
+    expectEqual(limitAdvanced(expr, x, int(1), {
+      differentiate: differentiateFixture,
+      evaluate: evaluateFixture,
+    }), int(2));
+  });
+
+  it("rewrites a zero-times-infinity product into a quotient form", () => {
+    const x = sym("x");
+    const expr = app(MUL, [x, app(DIV, [int(1), x])]);
+    expectEqual(limitAdvanced(expr, x, int(0), {
+      differentiate: differentiateFixture,
+      evaluate: evaluateFixture,
+    }), int(1));
+  });
+
+  it("keeps indeterminate powers unevaluated without callbacks", () => {
+    const x = sym("x");
+    const expr = app(POW, [x, x]);
+    expectEqual(limitAdvanced(expr, x, int(0), { direction: "plus" }), app(sym(LIMIT), [expr, x, int(0), sym("plus")]));
   });
 });
 

--- a/code/packages/typescript/cas-limit-series/tsconfig.json
+++ b/code/packages/typescript/cas-limit-series/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "preserveSymlinks": true,
     "strict": true,
     "declaration": true,
     "outDir": "dist",


### PR DESCRIPTION
## Summary
- Add `limitAdvanced(expr, variable, point, options?)` for the TS cas-limit-series package.
- Port numeric limit classification helpers for finite values, infinities, NaN/indeterminate forms, one-sided probes, and `inf`/`minf` sentinels.
- Add callback-driven L'Hopital handling plus focused `0*inf` and indeterminate power exp/log rewrites that fall back to unevaluated `Limit(...)` when callbacks cannot finish the work.
- Keep the package VM-independent and browser-safe; callbacks can inject differentiate/simplify/evaluate behavior.

## Validation
- `npm install`
- `npm run build`
- `npm test` (21 tests passed)
- `npm run test:coverage` (21 tests passed, coverage report generated)

## Limitations
- This is a focused slice, not a complete symbolic limit engine.
- L'Hopital and rewrite reductions require injected callbacks for symbolic differentiation/simplification.
- Direct finite results return the substituted IR unless callers provide simplification/evaluation callbacks.