### PR TITLE
Add Rust number theory handler table

### DIFF
--- a/code/packages/rust/cas-number-theory/src/handlers.rs
+++ b/code/packages/rust/cas-number-theory/src/handlers.rs
@@ -1,0 +1,183 @@
+//! VM-neutral handlers for number-theory IR heads.
+//!
+//! The handlers intentionally avoid depending on `symbolic-vm`. They accept an
+//! already-built `IRApply`, fold fully numeric calls, and return the original
+//! expression unchanged when the call is symbolic or malformed.
+
+use std::collections::BTreeMap;
+
+use symbolic_ir::{apply, int, sym, IRApply, IRNode};
+
+use crate::{
+    crt, divisors, factor_integer, integer_length, is_prime, jacobi_symbol, moebius_mu, next_prime,
+    prev_prime, totient,
+};
+
+pub type Handler = fn(&IRApply) -> IRNode;
+
+const LIST: &str = "List";
+const TRUE: &str = "True";
+const FALSE: &str = "False";
+
+pub fn is_prime_handler(expr: &IRApply) -> IRNode {
+    let Some([n]) = unary_int_args(expr) else {
+        return unevaluated(expr);
+    };
+    if is_prime(n) {
+        sym(TRUE)
+    } else {
+        sym(FALSE)
+    }
+}
+
+pub fn next_prime_handler(expr: &IRApply) -> IRNode {
+    let Some([n]) = unary_int_args(expr) else {
+        return unevaluated(expr);
+    };
+    int(next_prime(n))
+}
+
+pub fn prev_prime_handler(expr: &IRApply) -> IRNode {
+    let Some([n]) = unary_int_args(expr) else {
+        return unevaluated(expr);
+    };
+    prev_prime(n).map(int).unwrap_or_else(|| unevaluated(expr))
+}
+
+pub fn factor_integer_handler(expr: &IRApply) -> IRNode {
+    let Some([n]) = unary_int_args(expr) else {
+        return unevaluated(expr);
+    };
+    if n <= 0 {
+        return unevaluated(expr);
+    }
+    let pairs = factor_integer(n)
+        .into_iter()
+        .map(|(prime, exponent)| apply(sym(LIST), vec![int(prime), int(exponent as i64)]))
+        .collect();
+    apply(sym(LIST), pairs)
+}
+
+pub fn divisors_handler(expr: &IRApply) -> IRNode {
+    let Some([n]) = unary_int_args(expr) else {
+        return unevaluated(expr);
+    };
+    if n <= 0 {
+        return unevaluated(expr);
+    }
+    apply(sym(LIST), divisors(n).into_iter().map(int).collect())
+}
+
+pub fn totient_handler(expr: &IRApply) -> IRNode {
+    let Some([n]) = unary_int_args(expr) else {
+        return unevaluated(expr);
+    };
+    if n <= 0 {
+        return unevaluated(expr);
+    }
+    int(totient(n))
+}
+
+pub fn moebius_mu_handler(expr: &IRApply) -> IRNode {
+    let Some([n]) = unary_int_args(expr) else {
+        return unevaluated(expr);
+    };
+    if n <= 0 {
+        return unevaluated(expr);
+    }
+    int(moebius_mu(n))
+}
+
+pub fn jacobi_symbol_handler(expr: &IRApply) -> IRNode {
+    let Some([a, n]) = binary_int_args(expr) else {
+        return unevaluated(expr);
+    };
+    if n <= 0 || n % 2 == 0 {
+        return unevaluated(expr);
+    }
+    int(jacobi_symbol(a, n))
+}
+
+pub fn chinese_remainder_handler(expr: &IRApply) -> IRNode {
+    if expr.args.len() != 2 {
+        return unevaluated(expr);
+    }
+    let Some(remainders) = list_ints(&expr.args[0]) else {
+        return unevaluated(expr);
+    };
+    let Some(moduli) = list_ints(&expr.args[1]) else {
+        return unevaluated(expr);
+    };
+    crt(&remainders, &moduli)
+        .map(int)
+        .unwrap_or_else(|| unevaluated(expr))
+}
+
+pub fn integer_length_handler(expr: &IRApply) -> IRNode {
+    if expr.args.len() != 1 && expr.args.len() != 2 {
+        return unevaluated(expr);
+    }
+    let Some(n) = as_int(&expr.args[0]) else {
+        return unevaluated(expr);
+    };
+    let base = match expr.args.get(1) {
+        Some(node) => match as_int(node) {
+            Some(base) if base >= 2 => base,
+            _ => return unevaluated(expr),
+        },
+        None => 10,
+    };
+    int(integer_length(n, base))
+}
+
+pub fn build_number_theory_handler_table() -> BTreeMap<&'static str, Handler> {
+    BTreeMap::from([
+        ("IsPrime", is_prime_handler as Handler),
+        ("NextPrime", next_prime_handler as Handler),
+        ("PrevPrime", prev_prime_handler as Handler),
+        ("FactorInteger", factor_integer_handler as Handler),
+        ("Divisors", divisors_handler as Handler),
+        ("Totient", totient_handler as Handler),
+        ("MoebiusMu", moebius_mu_handler as Handler),
+        ("JacobiSymbol", jacobi_symbol_handler as Handler),
+        ("ChineseRemainder", chinese_remainder_handler as Handler),
+        ("IntegerLength", integer_length_handler as Handler),
+    ])
+}
+
+fn unary_int_args(expr: &IRApply) -> Option<[i64; 1]> {
+    if expr.args.len() == 1 {
+        as_int(&expr.args[0]).map(|n| [n])
+    } else {
+        None
+    }
+}
+
+fn binary_int_args(expr: &IRApply) -> Option<[i64; 2]> {
+    if expr.args.len() == 2 {
+        Some([as_int(&expr.args[0])?, as_int(&expr.args[1])?])
+    } else {
+        None
+    }
+}
+
+fn as_int(node: &IRNode) -> Option<i64> {
+    match node {
+        IRNode::Integer(n) => Some(*n),
+        _ => None,
+    }
+}
+
+fn list_ints(node: &IRNode) -> Option<Vec<i64>> {
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    match &apply_node.head {
+        IRNode::Symbol(name) if name == LIST => apply_node.args.iter().map(as_int).collect(),
+        _ => None,
+    }
+}
+
+fn unevaluated(expr: &IRApply) -> IRNode {
+    IRNode::Apply(Box::new(expr.clone()))
+}

--- a/code/packages/rust/cas-number-theory/src/lib.rs
+++ b/code/packages/rust/cas-number-theory/src/lib.rs
@@ -33,6 +33,7 @@
 pub mod arithmetic;
 pub mod crt;
 pub mod factorize;
+pub mod handlers;
 pub mod primality;
 
 // Re-export the full public API.
@@ -48,6 +49,13 @@ pub use primality::{is_prime, next_prime, nth_prime, prev_prime, primes_up_to};
 
 // factorize
 pub use factorize::{factor_integer, factorize_ir};
+
+// handlers
+pub use handlers::{
+    build_number_theory_handler_table, chinese_remainder_handler, divisors_handler,
+    factor_integer_handler, integer_length_handler, is_prime_handler, jacobi_symbol_handler,
+    moebius_mu_handler, next_prime_handler, prev_prime_handler, totient_handler, Handler,
+};
 
 // crt
 pub use crt::crt;

--- a/code/packages/rust/cas-number-theory/tests/tests.rs
+++ b/code/packages/rust/cas-number-theory/tests/tests.rs
@@ -1,9 +1,11 @@
 // Integration tests for cas-number-theory.
 
 use cas_number_theory::{
-    crt, divisors, extended_gcd, factor_integer, factorize_ir, gcd, integer_length, is_prime,
-    jacobi_symbol, lcm, mod_inverse, mod_pow, moebius_mu, next_prime, nth_prime, prev_prime,
-    primes_up_to, totient,
+    build_number_theory_handler_table, chinese_remainder_handler, crt, divisors, extended_gcd,
+    factor_integer, factor_integer_handler, factorize_ir, gcd, integer_length,
+    integer_length_handler, is_prime, is_prime_handler, jacobi_symbol, jacobi_symbol_handler, lcm,
+    mod_inverse, mod_pow, moebius_mu, next_prime, nth_prime, prev_prime, primes_up_to, totient,
+    totient_handler,
 };
 use symbolic_ir::{apply, int, sym, IRNode, MUL, POW};
 
@@ -479,4 +481,111 @@ fn crt_large_moduli() {
     let result = crt(&[1, 2], &[101, 103]).unwrap();
     assert_eq!(result % 101, 1);
     assert_eq!(result % 103, 2);
+}
+
+// ---------------------------------------------------------------------------
+// handlers
+// ---------------------------------------------------------------------------
+
+fn call(head: &str, args: Vec<IRNode>) -> symbolic_ir::IRApply {
+    symbolic_ir::IRApply {
+        head: sym(head),
+        args,
+    }
+}
+
+#[test]
+fn number_theory_handler_table_exposes_python_heads() {
+    let table = build_number_theory_handler_table();
+    assert!(table.contains_key("IsPrime"));
+    assert!(table.contains_key("NextPrime"));
+    assert!(table.contains_key("PrevPrime"));
+    assert!(table.contains_key("FactorInteger"));
+    assert!(table.contains_key("Divisors"));
+    assert!(table.contains_key("Totient"));
+    assert!(table.contains_key("MoebiusMu"));
+    assert!(table.contains_key("JacobiSymbol"));
+    assert!(table.contains_key("ChineseRemainder"));
+    assert!(table.contains_key("IntegerLength"));
+}
+
+#[test]
+fn primality_and_totient_handlers_fold_integer_calls() {
+    assert_eq!(
+        is_prime_handler(&call("IsPrime", vec![int(97)])),
+        sym("True")
+    );
+    assert_eq!(
+        is_prime_handler(&call("IsPrime", vec![int(100)])),
+        sym("False")
+    );
+    assert_eq!(totient_handler(&call("Totient", vec![int(36)])), int(12));
+}
+
+#[test]
+fn factor_integer_handler_returns_list_of_prime_exponent_pairs() {
+    assert_eq!(
+        factor_integer_handler(&call("FactorInteger", vec![int(360)])),
+        apply(
+            sym("List"),
+            vec![
+                apply(sym("List"), vec![int(2), int(3)]),
+                apply(sym("List"), vec![int(3), int(2)]),
+                apply(sym("List"), vec![int(5), int(1)]),
+            ]
+        )
+    );
+}
+
+#[test]
+fn chinese_remainder_handler_accepts_integer_lists() {
+    let remainders = apply(sym("List"), vec![int(2), int(3), int(2)]);
+    let moduli = apply(sym("List"), vec![int(3), int(5), int(7)]);
+    assert_eq!(
+        chinese_remainder_handler(&call("ChineseRemainder", vec![remainders, moduli])),
+        int(23)
+    );
+}
+
+#[test]
+fn jacobi_and_integer_length_handlers_fold_valid_calls() {
+    assert_eq!(
+        jacobi_symbol_handler(&call("JacobiSymbol", vec![int(1001), int(9907)])),
+        int(-1)
+    );
+    assert_eq!(
+        integer_length_handler(&call("IntegerLength", vec![int(100)])),
+        int(3)
+    );
+    assert_eq!(
+        integer_length_handler(&call("IntegerLength", vec![int(8), int(2)])),
+        int(4)
+    );
+}
+
+#[test]
+fn handlers_leave_symbolic_or_invalid_calls_unevaluated() {
+    let symbolic = call("IsPrime", vec![sym("n")]);
+    assert_eq!(
+        is_prime_handler(&symbolic),
+        IRNode::Apply(Box::new(symbolic.clone()))
+    );
+
+    let invalid_factor = call("FactorInteger", vec![int(0)]);
+    assert_eq!(
+        factor_integer_handler(&invalid_factor),
+        IRNode::Apply(Box::new(invalid_factor))
+    );
+
+    let invalid_jacobi = call("JacobiSymbol", vec![int(2), int(4)]);
+    assert_eq!(
+        jacobi_symbol_handler(&invalid_jacobi),
+        IRNode::Apply(Box::new(invalid_jacobi))
+    );
+
+    let invalid_base = call("IntegerLength", vec![int(8), int(1)]);
+    assert_eq!(
+        integer_length_handler(&invalid_base),
+        IRNode::Apply(Box::new(invalid_base))
+    );
 }


### PR DESCRIPTION
## Summary
- add VM-neutral Rust handlers for number-theory IR heads matching the Python package
- export a handler table for `IsPrime`, `FactorInteger`, `ChineseRemainder`, `IntegerLength`, and related heads
- cover numeric folding plus symbolic/invalid unevaluated fallbacks

## Validation
- `cargo fmt -p cas-number-theory`
- `cargo test -p cas-number-theory`
- `cargo check -p cas-number-theory`