### PR TITLE
Return Rust transform handler tables

### DIFF
--- a/code/packages/rust/cas-fourier/src/lib.rs
+++ b/code/packages/rust/cas-fourier/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use symbolic_ir::{apply, int, sym, IRNode, ADD, COS, DIV, EXP, MUL, NEG, POW, SIN, SQRT, SUB};
 
 pub const FOURIER: &str = "Fourier";
@@ -8,6 +10,7 @@ pub const IMAGINARY_UNIT: &str = "ImaginaryUnit";
 pub const PI: &str = "%pi";
 
 pub type EvalFn = dyn Fn(IRNode) -> IRNode;
+pub type Handler = fn(&IRNode, &EvalFn) -> IRNode;
 
 pub fn fourier_transform(f: IRNode, t: IRNode, omega: IRNode) -> IRNode {
     if let Some((a, b)) = binary_args(&f, ADD) {
@@ -63,8 +66,11 @@ pub fn ifourier_handler(expr: &IRNode, eval: &EvalFn) -> IRNode {
     ))
 }
 
-pub fn build_fourier_handler_table() -> Vec<&'static str> {
-    vec![FOURIER, IFOURIER]
+pub fn build_fourier_handler_table() -> BTreeMap<&'static str, Handler> {
+    BTreeMap::from([
+        (FOURIER, fourier_handler as Handler),
+        (IFOURIER, ifourier_handler as Handler),
+    ])
 }
 
 fn forward_lookup(f: &IRNode, t: &IRNode, omega: &IRNode) -> Option<IRNode> {

--- a/code/packages/rust/cas-fourier/tests/tests.rs
+++ b/code/packages/rust/cas-fourier/tests/tests.rs
@@ -134,7 +134,19 @@ fn handlers() {
         ifourier_handler(&apply(sym(IFOURIER), vec![int(1), w(), t()]), &id),
         apply(sym(DIRAC_DELTA), vec![t()])
     );
-    assert_eq!(build_fourier_handler_table(), vec![FOURIER, IFOURIER]);
+    let table = build_fourier_handler_table();
+    assert!(table.contains_key(FOURIER));
+    assert!(table.contains_key(IFOURIER));
+    assert_eq!(
+        table[FOURIER](
+            &apply(
+                sym(FOURIER),
+                vec![apply(sym(DIRAC_DELTA), vec![t()]), t(), w()]
+            ),
+            &id
+        ),
+        int(1)
+    );
 }
 
 fn contains_head(node: &symbolic_ir::IRNode, head: &str) -> bool {

--- a/code/packages/rust/cas-laplace/src/lib.rs
+++ b/code/packages/rust/cas-laplace/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use symbolic_ir::{
     apply, int, rat, sym, IRNode, ADD, COS, COSH, DIV, EXP, MUL, NEG, POW, SIN, SINH, SUB,
 };
@@ -8,6 +10,7 @@ pub const DIRAC_DELTA: &str = "DiracDelta";
 pub const UNIT_STEP: &str = "UnitStep";
 
 pub type EvalFn = dyn Fn(IRNode) -> IRNode;
+pub type Handler = fn(&IRNode, &EvalFn) -> IRNode;
 
 pub fn laplace_transform(f: IRNode, t: IRNode, s: IRNode) -> IRNode {
     if let Some((a, b)) = binary_args(&f, ADD) {
@@ -91,8 +94,21 @@ pub fn unit_step_handler(expr: &IRNode) -> IRNode {
     }
 }
 
-pub fn build_laplace_handler_table() -> Vec<&'static str> {
-    vec![LAPLACE, ILT, DIRAC_DELTA, UNIT_STEP]
+pub fn build_laplace_handler_table() -> BTreeMap<&'static str, Handler> {
+    BTreeMap::from([
+        (LAPLACE, laplace_handler as Handler),
+        (ILT, ilt_handler as Handler),
+        (DIRAC_DELTA, dirac_delta_eval_handler as Handler),
+        (UNIT_STEP, unit_step_eval_handler as Handler),
+    ])
+}
+
+fn dirac_delta_eval_handler(expr: &IRNode, _eval: &EvalFn) -> IRNode {
+    dirac_delta_handler(expr)
+}
+
+fn unit_step_eval_handler(expr: &IRNode, _eval: &EvalFn) -> IRNode {
+    unit_step_handler(expr)
 }
 
 fn table_lookup(f: &IRNode, t: &IRNode, s: &IRNode) -> Option<IRNode> {

--- a/code/packages/rust/cas-laplace/tests/tests.rs
+++ b/code/packages/rust/cas-laplace/tests/tests.rs
@@ -117,9 +117,19 @@ fn special_heads_and_handlers() {
         unit_step_handler(&apply(sym(UNIT_STEP), vec![int(4)])),
         int(1)
     );
+    let id = |node| node;
+    let table = build_laplace_handler_table();
+    assert!(table.contains_key(LAPLACE));
+    assert!(table.contains_key(ILT));
+    assert!(table.contains_key(DIRAC_DELTA));
+    assert!(table.contains_key(UNIT_STEP));
     assert_eq!(
-        build_laplace_handler_table(),
-        vec![LAPLACE, ILT, DIRAC_DELTA, UNIT_STEP]
+        table[DIRAC_DELTA](&apply(sym(DIRAC_DELTA), vec![int(0)]), &id),
+        int(1)
+    );
+    assert_eq!(
+        table[UNIT_STEP](&apply(sym(UNIT_STEP), vec![int(0)]), &id),
+        rat(1, 2)
     );
 }
 


### PR DESCRIPTION
## Summary
- make Rust `cas-fourier` and `cas-laplace` handler table builders return callable dispatch maps
- keep existing handlers and add wrappers for Laplace special-function handlers
- cover table lookup and invocation in package tests

## Validation
- `cargo fmt -p cas-fourier -p cas-laplace`
- `cargo test -p cas-fourier -p cas-laplace`
- `cargo check -p cas-fourier -p cas-laplace`