### PR TITLE
Add generic job runtime drain outcomes

### DIFF
--- a/code/packages/rust/generic-job-runtime/CHANGELOG.md
+++ b/code/packages/rust/generic-job-runtime/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this package will be documented in this file.
 - Added `JobResponseDrainSummary` and
   `JobExecutor::drain_response_summary_batch()` for aggregated D18C supervisor
   response-drain read models.
+- Added `JobResponseDrainOutcome` and helper predicates for classifying drained
+  response-summary batches without reinterpreting raw terminal counters.
 - Added queue-pressure percentages and recommended supervision actions for
   executor snapshots so D18C supervisors can choose backpressure, worker
   restart, or graceful-drain behavior without reinterpreting raw counters.

--- a/code/packages/rust/generic-job-runtime/README.md
+++ b/code/packages/rust/generic-job-runtime/README.md
@@ -28,6 +28,8 @@ targets.
   need terminal status, retryability, trace, and attempt facts.
 - Aggregated response-summary drain batches for supervisor/read-side tools that
   need terminal counts without retaining response payloads.
+- Drain outcome helpers for classifying empty, successful, failed, and
+  retryable-failed response batches.
 - Non-consuming executor snapshots for supervisor/read-side tools, including
   live workers, in-flight jobs, queued jobs, running jobs, and saturation.
 - Snapshot health classification for D18C supervisors to distinguish idle,

--- a/code/packages/rust/generic-job-runtime/src/lib.rs
+++ b/code/packages/rust/generic-job-runtime/src/lib.rs
@@ -272,6 +272,14 @@ pub struct JobResponseDrainSummary {
     pub retryable_error_count: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobResponseDrainOutcome {
+    Empty,
+    AllSucceeded,
+    Failed,
+    RetryableFailure,
+}
+
 impl JobResponseDrainSummary {
     pub fn from_responses<I>(responses: I) -> Self
     where
@@ -316,8 +324,28 @@ impl JobResponseDrainSummary {
             .saturating_add(self.timed_out_count)
     }
 
+    pub fn has_failures(&self) -> bool {
+        self.failure_count() > 0
+    }
+
     pub fn has_retryable_errors(&self) -> bool {
         self.retryable_error_count > 0
+    }
+
+    pub fn needs_retry_supervision(&self) -> bool {
+        self.has_retryable_errors()
+    }
+
+    pub fn outcome(&self) -> JobResponseDrainOutcome {
+        if self.is_empty() {
+            JobResponseDrainOutcome::Empty
+        } else if self.has_retryable_errors() {
+            JobResponseDrainOutcome::RetryableFailure
+        } else if self.has_failures() {
+            JobResponseDrainOutcome::Failed
+        } else {
+            JobResponseDrainOutcome::AllSucceeded
+        }
     }
 }
 
@@ -1719,8 +1747,43 @@ for line in sys.stdin:
         assert_eq!(batch.timed_out_count, 0);
         assert_eq!(batch.retryable_error_count, 1);
         assert_eq!(batch.failure_count(), 2);
+        assert!(batch.has_failures());
         assert!(batch.has_retryable_errors());
+        assert!(batch.needs_retry_supervision());
+        assert_eq!(batch.outcome(), JobResponseDrainOutcome::RetryableFailure);
         assert!(!batch.is_empty());
+    }
+
+    #[test]
+    fn response_drain_summary_classifies_empty_success_and_failed_batches() {
+        let empty = JobResponseDrainSummary::from_responses(Vec::new());
+        let success = JobResponseDrainSummary::from_responses([JobResponseSummary {
+            id: "job-ok".to_string(),
+            status: JobTerminalStatus::Ok,
+            attempt: 1,
+            trace_id: None,
+            retryable_error: false,
+            error_code: None,
+            message: None,
+        }]);
+        let failed = JobResponseDrainSummary::from_responses([JobResponseSummary {
+            id: "job-cancelled".to_string(),
+            status: JobTerminalStatus::Cancelled,
+            attempt: 1,
+            trace_id: None,
+            retryable_error: false,
+            error_code: None,
+            message: Some("cancelled by supervisor".to_string()),
+        }]);
+
+        assert_eq!(empty.outcome(), JobResponseDrainOutcome::Empty);
+        assert!(!empty.has_failures());
+        assert!(!empty.needs_retry_supervision());
+        assert_eq!(success.outcome(), JobResponseDrainOutcome::AllSucceeded);
+        assert!(!success.has_failures());
+        assert_eq!(failed.outcome(), JobResponseDrainOutcome::Failed);
+        assert!(failed.has_failures());
+        assert!(!failed.needs_retry_supervision());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `JobResponseDrainOutcome` for D18C response-drain batch classification
- expose helper predicates for failure and retry supervision decisions
- document and test empty, all-success, failed, and retryable-failed drain batches

## Tests
- `cargo test -p generic-job-runtime`
- `git diff --check origin/main...HEAD`
