### PR TITLE
[codex] Add TypeScript MNewton handlers

### DIFF
--- a/code/packages/typescript/cas-mnewton/CHANGELOG.md
+++ b/code/packages/typescript/cas-mnewton/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Add TypeScript Newton-Raphson root finder parity with Python and Rust
   `cas-mnewton`.
+- Add VM-neutral `MNewton` handler API and handler table builder.

--- a/code/packages/typescript/cas-mnewton/README.md
+++ b/code/packages/typescript/cas-mnewton/README.md
@@ -10,3 +10,8 @@ callers provide an evaluator callback and a symbolic derivative callback.
 convergence, returns the original function expression when numeric evaluation
 cannot proceed, and throws `MNewtonError` when the derivative is zero before a
 Newton step.
+
+For VM integration, `mnewtonHandler(expr, evalFn, diffFn)` handles
+`MNewton(f, x, x0)` and `MNewton(f, x, x0, tol)` without depending on a
+specific VM implementation. `buildMNewtonHandlerTable()` returns the dispatch
+map keyed by the `MNewton` head name.

--- a/code/packages/typescript/cas-mnewton/src/index.ts
+++ b/code/packages/typescript/cas-mnewton/src/index.ts
@@ -1,7 +1,7 @@
 import { subst } from "@coding-adventures/cas-substitution";
-import { numberNode, type IRNode } from "@coding-adventures/symbolic-ir";
+import { equals, numberNode, sym, type IRApply, type IRNode } from "@coding-adventures/symbolic-ir";
 
-export const MNEWTON = "MNewton";
+export const MNEWTON = sym("MNewton");
 
 export interface MNewtonOptions {
   readonly tol?: number;
@@ -10,6 +10,7 @@ export interface MNewtonOptions {
 
 export type EvalFn = (node: IRNode) => IRNode;
 export type DiffFn = (node: IRNode, variable: IRNode) => IRNode;
+export type MNewtonHandler = (expr: IRNode, evalFn: EvalFn, diffFn: DiffFn) => IRNode;
 
 export class MNewtonError extends Error {
   constructor(readonly x: number) {
@@ -65,4 +66,38 @@ export function mnewtonSolve(
   }
 
   return numberNode(xN);
+}
+
+export function mnewtonHandler(expr: IRNode, evalFn: EvalFn, diffFn: DiffFn): IRNode {
+  const args = applyArgs(expr, MNEWTON);
+  if (args === undefined || (args.length !== 3 && args.length !== 4)) return expr;
+
+  const [fIr, xSym, x0Ir, tolIr] = args;
+  if (xSym.kind !== "symbol" || irToFloat(x0Ir) === undefined) return expr;
+
+  let options: MNewtonOptions = {};
+  if (tolIr !== undefined) {
+    const tol = irToFloat(tolIr);
+    if (tol === undefined) return expr;
+    options = { tol };
+  }
+
+  try {
+    return mnewtonSolve(fIr, xSym, x0Ir, evalFn, diffFn, options);
+  } catch (error) {
+    if (error instanceof MNewtonError) return expr;
+    throw error;
+  }
+}
+
+export function buildMNewtonHandlerTable(): ReadonlyMap<string, MNewtonHandler> {
+  return new Map([[MNEWTON.name, mnewtonHandler]]);
+}
+
+function applyArgs(node: IRNode, head: IRNode): readonly IRNode[] | undefined {
+  return isApplyOf(node, head) ? node.args : undefined;
+}
+
+function isApplyOf(node: IRNode, head: IRNode): node is IRApply {
+  return node.kind === "apply" && equals(node.head, head);
 }

--- a/code/packages/typescript/cas-mnewton/tests/cas-mnewton.test.ts
+++ b/code/packages/typescript/cas-mnewton/tests/cas-mnewton.test.ts
@@ -14,7 +14,14 @@ import {
   sym,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
-import { MNewtonError, irToFloat, mnewtonSolve } from "../src/index";
+import {
+  MNEWTON,
+  MNewtonError,
+  buildMNewtonHandlerTable,
+  irToFloat,
+  mnewtonHandler,
+  mnewtonSolve,
+} from "../src/index";
 
 function evalNode(node: IRNode): IRNode {
   if (node.kind !== "apply") return node;
@@ -173,5 +180,45 @@ describe("mnewtonSolve", () => {
   it("solves a sine root near pi", () => {
     const x = sym("x");
     expectClose(solve(app(SIN, [x]), numberNode(3)), Math.PI, 1e-8);
+  });
+});
+
+describe("mnewtonHandler", () => {
+  it("exports a handler table keyed by MNEWTON", () => {
+    const table = buildMNewtonHandlerTable();
+    expect(table.get(MNEWTON.name)).toBe(mnewtonHandler);
+    expect([...table.keys()]).toEqual([MNEWTON.name]);
+  });
+
+  it("solves MNewton(f, x, x0) expressions", () => {
+    const x = sym("x");
+    const expr = app(MNEWTON, [app(SUB, [app(POW, [x, int(2)]), int(2)]), x, numberNode(1.5)]);
+    expectClose(mnewtonHandler(expr, evalNode, diff), Math.sqrt(2), 1e-8);
+  });
+
+  it("accepts an optional numeric tolerance", () => {
+    const x = sym("x");
+    const expr = app(MNEWTON, [app(SUB, [app(POW, [x, int(2)]), int(2)]), x, numberNode(1.5), rational(1, 1000)]);
+    expectClose(mnewtonHandler(expr, evalNode, diff), Math.sqrt(2), 1e-3);
+  });
+
+  it("returns the expression unchanged for malformed calls", () => {
+    const x = sym("x");
+    const f = app(SUB, [x, int(2)]);
+    const wrongHead = app(SUB, [f, x, int(0)]);
+    const wrongArity = app(MNEWTON, [f, x]);
+    const nonSymbolVariable = app(MNEWTON, [f, app(ADD, [x, int(1)]), int(0)]);
+    const symbolicX0 = app(MNEWTON, [f, x, sym("a")]);
+    const symbolicTol = app(MNEWTON, [f, x, int(0), sym("tol")]);
+
+    for (const expr of [wrongHead, wrongArity, nonSymbolVariable, symbolicX0, symbolicTol]) {
+      expect(equals(mnewtonHandler(expr, evalNode, diff), expr)).toBe(true);
+    }
+  });
+
+  it("returns the expression unchanged when Newton hits a zero derivative", () => {
+    const x = sym("x");
+    const expr = app(MNEWTON, [app(SUB, [app(POW, [x, int(2)]), int(1)]), x, int(0)]);
+    expect(equals(mnewtonHandler(expr, evalNode, diff), expr)).toBe(true);
   });
 });

--- a/code/packages/typescript/cas-mnewton/tsconfig.json
+++ b/code/packages/typescript/cas-mnewton/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
+    "preserveSymlinks": true,
     "moduleResolution": "Bundler",
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
## Summary
- Add a VM-neutral `mnewtonHandler(expr, evalFn, diffFn)` for `MNewton(f, x, x0)` and optional tolerance calls.
- Export `MNEWTON` as the IR head symbol and `buildMNewtonHandlerTable()` keyed by `MNEWTON.name`.
- Cover malformed arity, non-symbol variables, non-numeric x0/tol, convergence, and zero-derivative fallthrough.

## Validation
- `npm install`
- `npm run build`
- `npm test`
- `npm run test:coverage`

Coverage: 94.8% lines for `cas-mnewton`.