### PR TITLE
[codex] Add Rust cas-mnewton handler table

### DIFF
--- a/code/packages/rust/cas-mnewton/CHANGELOG.md
+++ b/code/packages/rust/cas-mnewton/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## 0.1.0
 
+- Add VM-neutral `mnewton_handler` and `build_mnewton_handler_table` parity
+  surface for `MNewton` callback injection.
 - Add Rust Newton-Raphson root finder parity with Python `cas-mnewton`.

--- a/code/packages/rust/cas-mnewton/README.md
+++ b/code/packages/rust/cas-mnewton/README.md
@@ -11,3 +11,10 @@ tests.
 convergence, returns the original function expression when the input cannot be
 evaluated numerically, and reports `MNewtonError::ZeroDerivative` when Newton's
 step is undefined.
+
+`mnewton_handler(expr, eval, diff)` is the VM-neutral handler layer for
+`MNewton(f, x, x0)` and `MNewton(f, x, x0, tol)`. It validates the IR shape,
+injects evaluator and derivative callbacks, returns malformed calls unchanged,
+and catches `MNewtonError` as an unevaluated expression.
+
+`build_mnewton_handler_table()` returns a callable table keyed by `MNEWTON`.

--- a/code/packages/rust/cas-mnewton/src/handlers.rs
+++ b/code/packages/rust/cas-mnewton/src/handlers.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+
+use symbolic_ir::IRNode;
+
+use crate::newton::{ir_to_float, mnewton_solve, MNewtonOptions, MNEWTON};
+
+pub type EvalFn = dyn FnMut(IRNode) -> IRNode;
+pub type DiffFn = dyn FnMut(&IRNode, &IRNode) -> IRNode;
+pub type MNewtonHandler = fn(&IRNode, &mut EvalFn, &mut DiffFn) -> IRNode;
+pub type MNewtonHandlerTable = HashMap<&'static str, MNewtonHandler>;
+
+pub fn mnewton_handler(expr: &IRNode, eval_fn: &mut EvalFn, diff_fn: &mut DiffFn) -> IRNode {
+    let IRNode::Apply(apply_node) = expr else {
+        return expr.clone();
+    };
+    if !matches!(&apply_node.head, IRNode::Symbol(name) if name == MNEWTON) {
+        return expr.clone();
+    }
+    if apply_node.args.len() != 3 && apply_node.args.len() != 4 {
+        return expr.clone();
+    }
+
+    let f_ir = &apply_node.args[0];
+    let x_sym = &apply_node.args[1];
+    let x0_ir = &apply_node.args[2];
+    if !matches!(x_sym, IRNode::Symbol(_)) || ir_to_float(x0_ir).is_none() {
+        return expr.clone();
+    }
+
+    let mut options = MNewtonOptions::default();
+    if let Some(tol_ir) = apply_node.args.get(3) {
+        let Some(tol) = ir_to_float(tol_ir) else {
+            return expr.clone();
+        };
+        options.tol = tol;
+    }
+
+    match mnewton_solve(f_ir, x_sym, x0_ir, eval_fn, diff_fn, options) {
+        Ok(result) => result,
+        Err(_) => expr.clone(),
+    }
+}
+
+pub fn build_mnewton_handler_table() -> MNewtonHandlerTable {
+    HashMap::from([(MNEWTON, mnewton_handler as MNewtonHandler)])
+}

--- a/code/packages/rust/cas-mnewton/src/lib.rs
+++ b/code/packages/rust/cas-mnewton/src/lib.rs
@@ -9,6 +9,11 @@
 //! This shape avoids an import cycle with `symbolic-vm` and keeps the core
 //! suitable for standalone Rust and WASM use.
 
+mod handlers;
 mod newton;
 
+pub use handlers::{
+    build_mnewton_handler_table, mnewton_handler, DiffFn, EvalFn, MNewtonHandler,
+    MNewtonHandlerTable,
+};
 pub use newton::{ir_to_float, mnewton_solve, MNewtonError, MNewtonOptions, MNEWTON};

--- a/code/packages/rust/cas-mnewton/tests/tests.rs
+++ b/code/packages/rust/cas-mnewton/tests/tests.rs
@@ -1,4 +1,7 @@
-use cas_mnewton::{ir_to_float, mnewton_solve, MNewtonError, MNewtonOptions};
+use cas_mnewton::{
+    build_mnewton_handler_table, ir_to_float, mnewton_handler, mnewton_solve, MNewtonError,
+    MNewtonOptions, MNEWTON,
+};
 use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, COS, MUL, POW, SIN, SUB};
 
 fn eval(node: IRNode) -> IRNode {
@@ -77,6 +80,12 @@ fn diff(node: &IRNode, var: &IRNode) -> IRNode {
 fn solve(f: IRNode, x0: IRNode) -> IRNode {
     let x = sym("x");
     mnewton_solve(&f, &x, &x0, eval, diff, MNewtonOptions::default()).unwrap()
+}
+
+fn handle(expr: &IRNode) -> IRNode {
+    let mut eval_fn = eval;
+    let mut diff_fn = diff;
+    mnewton_handler(expr, &mut eval_fn, &mut diff_fn)
 }
 
 fn assert_close(node: IRNode, expected: f64, tol: f64) {
@@ -212,4 +221,73 @@ fn solves_sin_root_near_pi() {
     let x = sym("x");
     let f = apply(sym(SIN), vec![x]);
     assert_close(solve(f, IRNode::Float(3.0)), std::f64::consts::PI, 1e-8);
+}
+
+#[test]
+fn handler_solves_mnewton_apply_nodes() {
+    let x = sym("x");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(2)],
+    );
+    let expr = apply(sym(MNEWTON), vec![f, x, IRNode::Float(1.5)]);
+
+    assert_close(handle(&expr), 2.0_f64.sqrt(), 1e-8);
+}
+
+#[test]
+fn handler_accepts_optional_numeric_tolerance() {
+    let x = sym("x");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(2)],
+    );
+    let expr = apply(sym(MNEWTON), vec![f, x, IRNode::Float(1.5), rat(1, 10_000)]);
+
+    assert_close(handle(&expr), 2.0_f64.sqrt(), 1e-3);
+}
+
+#[test]
+fn handler_returns_expression_for_malformed_inputs() {
+    let x = sym("x");
+    let f = apply(sym(SUB), vec![x.clone(), int(2)]);
+    let wrong_head = apply(sym("Other"), vec![f.clone(), x.clone(), int(1)]);
+    let wrong_arity = apply(sym(MNEWTON), vec![f.clone(), x.clone()]);
+    let nonsymbol_variable = apply(sym(MNEWTON), vec![f.clone(), int(1), int(1)]);
+    let symbolic_start = apply(sym(MNEWTON), vec![f.clone(), x.clone(), sym("a")]);
+    let symbolic_tol = apply(
+        sym(MNEWTON),
+        vec![f.clone(), x, IRNode::Float(1.0), sym("eps")],
+    );
+
+    assert_eq!(handle(&wrong_head), wrong_head);
+    assert_eq!(handle(&wrong_arity), wrong_arity);
+    assert_eq!(handle(&nonsymbol_variable), nonsymbol_variable);
+    assert_eq!(handle(&symbolic_start), symbolic_start);
+    assert_eq!(handle(&symbolic_tol), symbolic_tol);
+}
+
+#[test]
+fn handler_catches_newton_errors() {
+    let x = sym("x");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+    );
+    let expr = apply(sym(MNEWTON), vec![f, x, IRNode::Float(0.0)]);
+
+    assert_eq!(handle(&expr), expr);
+}
+
+#[test]
+fn handler_table_is_keyed_by_mnewton() {
+    let table = build_mnewton_handler_table();
+    let handler = table.get(MNEWTON).copied().expect("MNewton handler");
+    let x = sym("x");
+    let f = apply(sym(SUB), vec![x.clone(), int(7)]);
+    let expr = apply(sym(MNEWTON), vec![f, x, IRNode::Float(0.0)]);
+    let mut eval_fn = eval;
+    let mut diff_fn = diff;
+
+    assert_close(handler(&expr, &mut eval_fn, &mut diff_fn), 7.0, 1e-9);
 }


### PR DESCRIPTION
## Summary
- add VM-neutral `mnewton_handler(expr, eval, diff)` for `MNewton(f, x, x0[, tol])`
- expose `build_mnewton_handler_table()` as a callable map keyed by `MNEWTON`
- cover handler convergence, malformed input fallthrough, tolerance, error catching, and table lookup

## Validation
- `cargo fmt -p cas-mnewton`
- `cargo test -p cas-mnewton`
- `cargo check -p cas-mnewton`

## Scope
Only `code/packages/rust/cas-mnewton` was changed. Generated `code/packages/rust/Cargo.lock` was removed after validation.