### PR TITLE
[codex] Add Rust cas-multivariate IR handlers

### DIFF
--- a/code/packages/rust/cas-multivariate/Cargo.toml
+++ b/code/packages/rust/cas-multivariate/Cargo.toml
@@ -6,3 +6,4 @@ description = "Multivariate rational polynomials, Groebner bases, reduction, and
 license = "MIT"
 
 [dependencies]
+symbolic-ir = { path = "../symbolic-ir" }

--- a/code/packages/rust/cas-multivariate/src/handlers.rs
+++ b/code/packages/rust/cas-multivariate/src/handlers.rs
@@ -1,0 +1,298 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, LIST, MUL, NEG, POW, RULE, SUB};
+
+use crate::{buchberger, ideal_solve, make_var, reduce_poly, MPoly, Rational};
+use crate::{GROEBNER, IDEAL_SOLVE, POLY_REDUCE};
+
+/// VM-neutral multivariate handler signature.
+///
+/// The handler receives a raw IR node and either returns the evaluated IR or
+/// the original node unchanged when conversion or solving cannot proceed.
+pub type MultivariateHandler = fn(&IRNode) -> IRNode;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversionError(pub String);
+
+impl fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ConversionError: {}", self.0)
+    }
+}
+
+impl std::error::Error for ConversionError {}
+
+pub fn ir_to_mpoly(node: &IRNode, var_list: &[String]) -> Result<MPoly, ConversionError> {
+    let nvars = var_list.len();
+    match node {
+        IRNode::Integer(n) => Ok(MPoly::constant(Rational::from_int(*n), nvars)),
+        IRNode::Rational(n, d) => Ok(MPoly::constant(Rational::new(*n, *d), nvars)),
+        IRNode::Symbol(name) => {
+            let Some(index) = var_list.iter().position(|v| v == name) else {
+                return Err(ConversionError(format!(
+                    "unrecognized symbol in polynomial context: {name}"
+                )));
+            };
+            Ok(make_var(index, nvars))
+        }
+        IRNode::Apply(app) => {
+            let Some(head) = head_name(&app.head) else {
+                return Err(ConversionError("non-symbol polynomial head".to_string()));
+            };
+            match head {
+                ADD => app.args.iter().try_fold(MPoly::zero(nvars), |acc, arg| {
+                    Ok(acc + ir_to_mpoly(arg, var_list)?)
+                }),
+                SUB => {
+                    if app.args.len() != 2 {
+                        return Err(ConversionError("Sub expects 2 arguments".to_string()));
+                    }
+                    Ok(ir_to_mpoly(&app.args[0], var_list)? - ir_to_mpoly(&app.args[1], var_list)?)
+                }
+                MUL => app
+                    .args
+                    .iter()
+                    .try_fold(MPoly::constant(1, nvars), |acc, arg| {
+                        Ok(acc * ir_to_mpoly(arg, var_list)?)
+                    }),
+                NEG => {
+                    if app.args.len() != 1 {
+                        return Err(ConversionError("Neg expects 1 argument".to_string()));
+                    }
+                    Ok(-ir_to_mpoly(&app.args[0], var_list)?)
+                }
+                POW => {
+                    if app.args.len() != 2 {
+                        return Err(ConversionError("Pow expects 2 arguments".to_string()));
+                    }
+                    let exponent = match app.args[1] {
+                        IRNode::Integer(n) if n >= 0 => usize::try_from(n).map_err(|_| {
+                            ConversionError("Pow exponent is too large".to_string())
+                        })?,
+                        _ => {
+                            return Err(ConversionError(
+                                "Pow exponent must be a non-negative integer".to_string(),
+                            ));
+                        }
+                    };
+                    let base = ir_to_mpoly(&app.args[0], var_list)?;
+                    let mut result = MPoly::constant(1, nvars);
+                    for _ in 0..exponent {
+                        result = result * base.clone();
+                    }
+                    Ok(result)
+                }
+                _ => Err(ConversionError(format!(
+                    "cannot convert head {head} to polynomial"
+                ))),
+            }
+        }
+        other => Err(ConversionError(format!(
+            "cannot convert {other:?} to polynomial"
+        ))),
+    }
+}
+
+pub fn mpoly_to_ir(poly: &MPoly, var_symbols: &[IRNode]) -> IRNode {
+    if poly.is_zero() {
+        return int(0);
+    }
+
+    let mut terms = Vec::new();
+    let monomials = poly.monomials_descending("grlex").unwrap_or_else(|_| {
+        let mut monomials: Vec<_> = poly.coeffs.keys().cloned().collect();
+        monomials.sort();
+        monomials
+    });
+
+    for monomial in monomials {
+        let coeff = poly.coeffs[&monomial];
+        let mut parts = Vec::new();
+        for (index, &exponent) in monomial.iter().enumerate() {
+            if exponent == 1 {
+                parts.push(var_symbols[index].clone());
+            } else if exponent > 1 {
+                parts.push(apply(
+                    sym(POW),
+                    vec![var_symbols[index].clone(), int(exponent as i64)],
+                ));
+            }
+        }
+
+        if parts.is_empty() {
+            terms.push(rational_to_ir(coeff));
+        } else if coeff == Rational::ONE {
+            terms.push(product_ir(parts));
+        } else if coeff == -Rational::ONE {
+            terms.push(apply(sym(NEG), vec![product_ir(parts)]));
+        } else {
+            let mut factors = vec![rational_to_ir(coeff)];
+            factors.extend(parts);
+            terms.push(apply(sym(MUL), factors));
+        }
+    }
+
+    if terms.len() == 1 {
+        terms.pop().unwrap()
+    } else {
+        apply(sym(ADD), terms)
+    }
+}
+
+pub fn extract_var_list(node: &IRNode) -> Option<Vec<String>> {
+    let args = list_args(node)?;
+    let mut names = Vec::with_capacity(args.len());
+    for arg in args {
+        match arg {
+            IRNode::Symbol(name) => names.push(name.clone()),
+            _ => return None,
+        }
+    }
+    Some(names)
+}
+
+pub fn extract_poly_list(node: &IRNode, var_list: &[String]) -> Option<Vec<MPoly>> {
+    let args = list_args(node)?;
+    let mut polys = Vec::with_capacity(args.len());
+    for arg in args {
+        polys.push(ir_to_mpoly(arg, var_list).ok()?);
+    }
+    Some(polys)
+}
+
+pub fn groebner_handler(expr: &IRNode) -> IRNode {
+    let Some(args) = handler_args(expr, GROEBNER) else {
+        return expr.clone();
+    };
+    if args.len() != 2 {
+        return expr.clone();
+    }
+    let Some(var_list) = extract_var_list(&args[1]).filter(|vars| !vars.is_empty()) else {
+        return expr.clone();
+    };
+    let Some(polys) = extract_poly_list(&args[0], &var_list) else {
+        return expr.clone();
+    };
+    let Ok(basis) = buchberger(&polys, "grlex") else {
+        return expr.clone();
+    };
+    let var_symbols: Vec<_> = var_list.iter().map(sym).collect();
+    apply(
+        sym(LIST),
+        basis
+            .iter()
+            .map(|poly| mpoly_to_ir(poly, &var_symbols))
+            .collect(),
+    )
+}
+
+pub fn poly_reduce_handler(expr: &IRNode) -> IRNode {
+    let Some(args) = handler_args(expr, POLY_REDUCE) else {
+        return expr.clone();
+    };
+    if args.len() != 3 {
+        return expr.clone();
+    }
+    let Some(var_list) = extract_var_list(&args[2]).filter(|vars| !vars.is_empty()) else {
+        return expr.clone();
+    };
+    let Ok(f_poly) = ir_to_mpoly(&args[0], &var_list) else {
+        return expr.clone();
+    };
+    let Some(polys) = extract_poly_list(&args[1], &var_list) else {
+        return expr.clone();
+    };
+    let Ok(remainder) = reduce_poly(&f_poly, &polys, "grlex") else {
+        return expr.clone();
+    };
+    let var_symbols: Vec<_> = var_list.iter().map(sym).collect();
+    mpoly_to_ir(&remainder, &var_symbols)
+}
+
+pub fn ideal_solve_handler(expr: &IRNode) -> IRNode {
+    let Some(args) = handler_args(expr, IDEAL_SOLVE) else {
+        return expr.clone();
+    };
+    if args.len() != 2 {
+        return expr.clone();
+    }
+    let Some(var_list) = extract_var_list(&args[1]).filter(|vars| !vars.is_empty()) else {
+        return expr.clone();
+    };
+    let Some(polys) = extract_poly_list(&args[0], &var_list) else {
+        return expr.clone();
+    };
+    let Some(solutions) = ideal_solve(&polys) else {
+        return expr.clone();
+    };
+
+    let var_symbols: Vec<_> = var_list.iter().map(sym).collect();
+    let solution_nodes: Vec<_> = solutions
+        .iter()
+        .filter(|solution| solution.len() == var_symbols.len())
+        .map(|solution| {
+            apply(
+                sym(LIST),
+                solution
+                    .iter()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        apply(
+                            sym(RULE),
+                            vec![var_symbols[index].clone(), rational_to_ir(*value)],
+                        )
+                    })
+                    .collect(),
+            )
+        })
+        .collect();
+
+    if solution_nodes.is_empty() {
+        expr.clone()
+    } else {
+        apply(sym(LIST), solution_nodes)
+    }
+}
+
+pub fn build_multivariate_handler_table() -> BTreeMap<&'static str, MultivariateHandler> {
+    BTreeMap::from([
+        (GROEBNER, groebner_handler as MultivariateHandler),
+        (POLY_REDUCE, poly_reduce_handler as MultivariateHandler),
+        (IDEAL_SOLVE, ideal_solve_handler as MultivariateHandler),
+    ])
+}
+
+fn head_name(node: &IRNode) -> Option<&str> {
+    match node {
+        IRNode::Symbol(name) => Some(name),
+        _ => None,
+    }
+}
+
+fn handler_args<'a>(node: &'a IRNode, head: &str) -> Option<&'a [IRNode]> {
+    match node {
+        IRNode::Apply(app) if app.head == sym(head) => Some(&app.args),
+        _ => None,
+    }
+}
+
+fn list_args(node: &IRNode) -> Option<&[IRNode]> {
+    handler_args(node, LIST)
+}
+
+fn product_ir(parts: Vec<IRNode>) -> IRNode {
+    if parts.len() == 1 {
+        parts.into_iter().next().unwrap()
+    } else {
+        apply(sym(MUL), parts)
+    }
+}
+
+fn rational_to_ir(value: Rational) -> IRNode {
+    if value.denom == 1 {
+        int(value.numer)
+    } else {
+        rat(value.numer, value.denom)
+    }
+}

--- a/code/packages/rust/cas-multivariate/src/lib.rs
+++ b/code/packages/rust/cas-multivariate/src/lib.rs
@@ -4,6 +4,7 @@
 //! bases, and small ideal solving via lex order back-substitution.
 
 pub mod groebner;
+pub mod handlers;
 pub mod monomial;
 pub mod polynomial;
 pub mod rational;
@@ -11,6 +12,11 @@ pub mod reduce;
 pub mod solve;
 
 pub use groebner::{buchberger, GrobnerError};
+pub use handlers::{
+    build_multivariate_handler_table, extract_poly_list, extract_var_list, groebner_handler,
+    ideal_solve_handler, ir_to_mpoly, mpoly_to_ir, poly_reduce_handler, ConversionError,
+    MultivariateHandler,
+};
 pub use monomial::{
     cmp_monomials, div_monomial, divides, lcm_monomial, total_degree, Monomial, MonomialOrder,
     MonomialOrderError,

--- a/code/packages/rust/cas-multivariate/tests/tests.rs
+++ b/code/packages/rust/cas-multivariate/tests/tests.rs
@@ -1,10 +1,13 @@
 use std::cmp::Ordering;
 
 use cas_multivariate::{
-    buchberger, cmp_monomials, div_monomial, div_reduction_step, divides, ideal_solve,
-    lcm_monomial, make_var, rational_roots, reduce_poly, s_poly, solve_univariate, total_degree,
-    GrobnerError, MPoly, MonomialOrder, Rational,
+    buchberger, build_multivariate_handler_table, cmp_monomials, div_monomial, div_reduction_step,
+    divides, groebner_handler, ideal_solve, ideal_solve_handler, ir_to_mpoly, lcm_monomial,
+    make_var, mpoly_to_ir, poly_reduce_handler, rational_roots, reduce_poly, s_poly,
+    solve_univariate, total_degree, GrobnerError, MPoly, MonomialOrder, Rational, GROEBNER,
+    IDEAL_SOLVE, POLY_REDUCE,
 };
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, LIST, MUL, NEG, POW, RULE, SUB};
 
 fn f(n: i64) -> Rational {
     Rational::from_int(n)
@@ -216,4 +219,186 @@ fn ideal_solve_none_cases() {
     let f2 = p2(&[([0, 1], f(1)), ([1, 0], f(-1))]);
     assert!(ideal_solve(&[f1, f2]).is_none());
     assert!(ideal_solve(&[]).is_none());
+}
+
+fn list(args: Vec<IRNode>) -> IRNode {
+    apply(sym(LIST), args)
+}
+
+#[test]
+fn ir_conversion_accepts_polynomial_subset() {
+    let vars = vec!["x".to_string(), "y".to_string()];
+    let expr = apply(
+        sym(ADD),
+        vec![
+            apply(
+                sym(MUL),
+                vec![rat(3, 2), apply(sym(POW), vec![sym("x"), int(2)]), sym("y")],
+            ),
+            apply(sym(NEG), vec![sym("x")]),
+            apply(sym(SUB), vec![int(5), rat(1, 2)]),
+        ],
+    );
+
+    assert_eq!(
+        ir_to_mpoly(&expr, &vars).unwrap(),
+        p2(&[([2, 1], frac(3, 2)), ([1, 0], f(-1)), ([0, 0], frac(9, 2))])
+    );
+}
+
+#[test]
+fn ir_conversion_rejects_non_polynomial_shapes() {
+    let vars = vec!["x".to_string()];
+    assert!(ir_to_mpoly(&sym("z"), &vars).is_err());
+    assert!(ir_to_mpoly(&apply(sym(POW), vec![sym("x"), int(-1)]), &vars).is_err());
+    assert!(ir_to_mpoly(&apply(sym("Sin"), vec![sym("x")]), &vars).is_err());
+}
+
+#[test]
+fn mpoly_to_ir_builds_canonical_polynomial_terms() {
+    let poly = p2(&[([2, 0], frac(3, 2)), ([0, 1], f(-1)), ([0, 0], f(4))]);
+    assert_eq!(
+        mpoly_to_ir(&poly, &[sym("x"), sym("y")]),
+        apply(
+            sym(ADD),
+            vec![
+                apply(
+                    sym(MUL),
+                    vec![rat(3, 2), apply(sym(POW), vec![sym("x"), int(2)])]
+                ),
+                apply(sym(NEG), vec![sym("y")]),
+                int(4),
+            ],
+        )
+    );
+}
+
+#[test]
+fn groebner_handler_returns_basis_list() {
+    let x_plus_y_minus_one = apply(
+        sym(ADD),
+        vec![sym("x"), sym("y"), apply(sym(NEG), vec![int(1)])],
+    );
+    let x_minus_y = apply(sym(SUB), vec![sym("x"), sym("y")]);
+    let call = apply(
+        sym(GROEBNER),
+        vec![
+            list(vec![x_plus_y_minus_one.clone(), x_minus_y.clone()]),
+            list(vec![sym("x"), sym("y")]),
+        ],
+    );
+
+    let result = groebner_handler(&call);
+    let IRNode::Apply(app) = result else {
+        panic!("expected List result");
+    };
+    assert_eq!(app.head, sym(LIST));
+    assert_eq!(app.args.len(), 2);
+
+    let vars = vec!["x".to_string(), "y".to_string()];
+    let basis: Vec<_> = app
+        .args
+        .iter()
+        .map(|arg| ir_to_mpoly(arg, &vars).unwrap())
+        .collect();
+    assert!(reduce_poly(
+        &ir_to_mpoly(&x_plus_y_minus_one, &vars).unwrap(),
+        &basis,
+        "grlex"
+    )
+    .unwrap()
+    .is_zero());
+    assert!(
+        reduce_poly(&ir_to_mpoly(&x_minus_y, &vars).unwrap(), &basis, "grlex")
+            .unwrap()
+            .is_zero()
+    );
+}
+
+#[test]
+fn poly_reduce_handler_returns_remainder() {
+    let call = apply(
+        sym(POLY_REDUCE),
+        vec![
+            apply(sym(POW), vec![sym("x"), int(2)]),
+            list(vec![apply(sym(SUB), vec![sym("x"), int(1)])]),
+            list(vec![sym("x")]),
+        ],
+    );
+
+    assert_eq!(poly_reduce_handler(&call), int(1));
+}
+
+#[test]
+fn ideal_solve_handler_returns_rule_lists() {
+    let call = apply(
+        sym(IDEAL_SOLVE),
+        vec![
+            list(vec![
+                apply(
+                    sym(ADD),
+                    vec![sym("x"), sym("y"), apply(sym(NEG), vec![int(1)])],
+                ),
+                apply(sym(SUB), vec![sym("x"), sym("y")]),
+            ]),
+            list(vec![sym("x"), sym("y")]),
+        ],
+    );
+
+    assert_eq!(
+        ideal_solve_handler(&call),
+        list(vec![list(vec![
+            apply(sym(RULE), vec![sym("x"), rat(1, 2)]),
+            apply(sym(RULE), vec![sym("y"), rat(1, 2)]),
+        ])])
+    );
+}
+
+#[test]
+fn handlers_fall_through_to_original_expr_on_failures() {
+    let bad_groebner = apply(
+        sym(GROEBNER),
+        vec![
+            list(vec![apply(sym("Sin"), vec![sym("x")])]),
+            list(vec![sym("x")]),
+        ],
+    );
+    assert_eq!(groebner_handler(&bad_groebner), bad_groebner);
+
+    let bad_reduce = apply(
+        sym(POLY_REDUCE),
+        vec![sym("z"), list(vec![sym("x")]), list(vec![sym("x")])],
+    );
+    assert_eq!(poly_reduce_handler(&bad_reduce), bad_reduce);
+
+    let unsolved = apply(
+        sym(IDEAL_SOLVE),
+        vec![
+            list(vec![apply(
+                sym(ADD),
+                vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)],
+            )]),
+            list(vec![sym("x")]),
+        ],
+    );
+    assert_eq!(ideal_solve_handler(&unsolved), unsolved);
+}
+
+#[test]
+fn build_handler_table_returns_callable_map() {
+    let table = build_multivariate_handler_table();
+    assert_eq!(table.len(), 3);
+    assert!(table.contains_key(GROEBNER));
+    assert!(table.contains_key(POLY_REDUCE));
+    assert!(table.contains_key(IDEAL_SOLVE));
+
+    let call = apply(
+        sym(POLY_REDUCE),
+        vec![
+            apply(sym(POW), vec![sym("x"), int(2)]),
+            list(vec![apply(sym(SUB), vec![sym("x"), int(1)])]),
+            list(vec![sym("x")]),
+        ],
+    );
+    assert_eq!(table[POLY_REDUCE](&call), int(1));
 }


### PR DESCRIPTION
## Summary
- add VM-neutral Groebner, PolyReduce, and IdealSolve handlers for Rust cas-multivariate
- add IR-to-MPoly and MPoly-to-IR conversion for integer, rational, symbol, add, sub, mul, neg, and nonnegative integer pow expressions
- add a callable multivariate handler table and focused parity/fallthrough tests

## Validation
- cargo fmt -p cas-multivariate
- cargo test -p cas-multivariate
- cargo check -p cas-multivariate

## Notes
- leaves unsupported conversion or unsolved systems unevaluated by returning the original IR expression
- no parser or lexer work included