### PR TITLE
Scaffold Board VM CoreBluetooth BLE connector

### DIFF
--- a/code/packages/rust/board-vm-bluetooth/README.md
+++ b/code/packages/rust/board-vm-bluetooth/README.md
@@ -11,7 +11,10 @@ transports without moving endpoint policy into Ruby/Python/Lua.
 
 The first host adapter is `MacosBluetoothBackend`, which resolves Bluetooth
 Classic RFCOMM endpoints onto macOS `/dev/cu.*` serial devices. BLE GATT opening
-stays explicit and returns a backend error until the CoreBluetooth adapter lands.
+routes through an injectable `MacosCoreBluetoothBleConnector`; the default
+connector reports an explicit backend error until the real CoreBluetooth
+delegate/run-loop adapter lands, while tests and future OS code can already
+exercise the same Board VM raw-frame transport path.
 
 OS-specific scanners can also pass discovered device metadata into
 `board_vm_endpoint_candidates`. The Rust planner filters for Board VM BLE

--- a/code/packages/rust/board-vm-bluetooth/src/lib.rs
+++ b/code/packages/rust/board-vm-bluetooth/src/lib.rs
@@ -208,6 +208,56 @@ pub trait MacosRfcommDeviceResolver {
     fn rfcomm_device_paths(&mut self) -> Result<Vec<String>, BluetoothOpenError>;
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MacosCoreBluetoothBleOpenRequest {
+    pub device: String,
+    pub service_uuid: String,
+    pub write_characteristic_uuid: String,
+    pub notify_characteristic_uuid: String,
+}
+
+impl MacosCoreBluetoothBleOpenRequest {
+    pub fn from_endpoint(endpoint: &BleGattEndpoint) -> Self {
+        Self {
+            device: endpoint.device.clone(),
+            service_uuid: endpoint.service_uuid.clone(),
+            write_characteristic_uuid: endpoint.write_characteristic_uuid.clone(),
+            notify_characteristic_uuid: endpoint.notify_characteristic_uuid.clone(),
+        }
+    }
+}
+
+pub trait MacosCoreBluetoothBleConnector {
+    type BleGattLink: BleGattIo;
+
+    fn open_ble_gatt(
+        &mut self,
+        request: &MacosCoreBluetoothBleOpenRequest,
+    ) -> Result<Self::BleGattLink, BluetoothOpenError>;
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct UnavailableCoreBluetoothBleConnector;
+
+impl MacosCoreBluetoothBleConnector for UnavailableCoreBluetoothBleConnector {
+    type BleGattLink = UnsupportedBleGattLink;
+
+    fn open_ble_gatt(
+        &mut self,
+        request: &MacosCoreBluetoothBleOpenRequest,
+    ) -> Result<Self::BleGattLink, BluetoothOpenError> {
+        Err(BluetoothOpenError::Backend {
+            message: format!(
+                "macOS CoreBluetooth BLE GATT adapter is not wired yet for {} service {} write {} notify {}",
+                request.device,
+                request.service_uuid,
+                request.write_characteristic_uuid,
+                request.notify_characteristic_uuid
+            ),
+        })
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct MacosDevRfcommDeviceResolver;
 
@@ -231,25 +281,40 @@ impl MacosRfcommDeviceResolver for MacosDevRfcommDeviceResolver {
     }
 }
 
-pub struct MacosBluetoothBackend<R = MacosDevRfcommDeviceResolver> {
+pub struct MacosBluetoothBackend<
+    R = MacosDevRfcommDeviceResolver,
+    C = UnavailableCoreBluetoothBleConnector,
+> {
     resolver: R,
+    ble_connector: C,
 }
 
-impl MacosBluetoothBackend<MacosDevRfcommDeviceResolver> {
+impl MacosBluetoothBackend<MacosDevRfcommDeviceResolver, UnavailableCoreBluetoothBleConnector> {
     pub fn new() -> Self {
         Self::with_resolver(MacosDevRfcommDeviceResolver)
     }
 }
 
-impl Default for MacosBluetoothBackend<MacosDevRfcommDeviceResolver> {
+impl Default
+    for MacosBluetoothBackend<MacosDevRfcommDeviceResolver, UnavailableCoreBluetoothBleConnector>
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<R> MacosBluetoothBackend<R> {
+impl<R> MacosBluetoothBackend<R, UnavailableCoreBluetoothBleConnector> {
     pub const fn with_resolver(resolver: R) -> Self {
-        Self { resolver }
+        Self::with_resolver_and_ble_connector(resolver, UnavailableCoreBluetoothBleConnector)
+    }
+}
+
+impl<R, C> MacosBluetoothBackend<R, C> {
+    pub const fn with_resolver_and_ble_connector(resolver: R, ble_connector: C) -> Self {
+        Self {
+            resolver,
+            ble_connector,
+        }
     }
 
     pub const fn resolver(&self) -> &R {
@@ -259,22 +324,30 @@ impl<R> MacosBluetoothBackend<R> {
     pub fn resolver_mut(&mut self) -> &mut R {
         &mut self.resolver
     }
+
+    pub const fn ble_connector(&self) -> &C {
+        &self.ble_connector
+    }
+
+    pub fn ble_connector_mut(&mut self) -> &mut C {
+        &mut self.ble_connector
+    }
 }
 
-impl<R> BluetoothBackend for MacosBluetoothBackend<R>
+impl<R, C> BluetoothBackend for MacosBluetoothBackend<R, C>
 where
     R: MacosRfcommDeviceResolver,
+    C: MacosCoreBluetoothBleConnector,
 {
-    type BleGattLink = UnsupportedBleGattLink;
+    type BleGattLink = C::BleGattLink;
     type RfcommStream = File;
 
     fn open_ble_gatt(
         &mut self,
-        _endpoint: &BleGattEndpoint,
+        endpoint: &BleGattEndpoint,
     ) -> Result<Self::BleGattLink, BluetoothOpenError> {
-        Err(BluetoothOpenError::Backend {
-            message: "macOS BLE GATT opening is not wired yet".to_owned(),
-        })
+        let request = MacosCoreBluetoothBleOpenRequest::from_endpoint(endpoint);
+        self.ble_connector.open_ble_gatt(&request)
     }
 
     fn open_rfcomm(
@@ -1182,6 +1255,27 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct FakeCoreBluetoothBleConnector {
+        requests: Vec<MacosCoreBluetoothBleOpenRequest>,
+        notifications: VecDeque<Vec<u8>>,
+    }
+
+    impl MacosCoreBluetoothBleConnector for FakeCoreBluetoothBleConnector {
+        type BleGattLink = FakeBleGattLink;
+
+        fn open_ble_gatt(
+            &mut self,
+            request: &MacosCoreBluetoothBleOpenRequest,
+        ) -> Result<Self::BleGattLink, BluetoothOpenError> {
+            self.requests.push(request.clone());
+            Ok(FakeBleGattLink {
+                writes: Vec::new(),
+                notifications: std::mem::take(&mut self.notifications),
+            })
+        }
+    }
+
     #[test]
     fn parses_ble_gatt_query_endpoint() {
         let endpoint = parse_ble_gatt_endpoint(&format!(
@@ -1496,6 +1590,49 @@ Bluetooth:
         assert_eq!(transport.device(), "esp32");
         assert_eq!(&raw_out[..response_len], response);
         assert_eq!(backend.ble_opened, vec!["esp32".to_owned()]);
+    }
+
+    #[test]
+    fn macos_backend_uses_core_bluetooth_ble_connector_for_gatt_open() {
+        let endpoint = parse_ble_gatt_endpoint(&format!(
+            "ble://esp32?service={SERVICE_UUID}&write={WRITE_UUID}&notify={NOTIFY_UUID}"
+        ))
+        .unwrap();
+        let response = [0x41, 0x42];
+        let mut response_wire = [0u8; 16];
+        let response_wire_len = encode_wire_frame(&response, &mut response_wire).unwrap();
+        let mut backend = MacosBluetoothBackend::with_resolver_and_ble_connector(
+            FixedRfcommPaths::default(),
+            FakeCoreBluetoothBleConnector {
+                requests: Vec::new(),
+                notifications: VecDeque::from([response_wire[..response_wire_len].to_vec()]),
+            },
+        );
+
+        let mut transport = open_bluetooth_endpoint::<_, 32>(
+            &mut backend,
+            BluetoothEndpoint::BleGatt(endpoint.clone()),
+        )
+        .unwrap();
+        let mut raw_out = [0u8; 16];
+        let response_len = transport.exchange_raw_frame(&[0x40], &mut raw_out).unwrap();
+
+        assert_eq!(
+            backend.ble_connector().requests,
+            vec![MacosCoreBluetoothBleOpenRequest::from_endpoint(&endpoint)]
+        );
+        assert_eq!(
+            transport.endpoint_transport(),
+            BluetoothEndpointTransport::BleGatt
+        );
+        assert_eq!(transport.device(), "esp32");
+        assert_eq!(&raw_out[..response_len], response);
+        match transport {
+            BoardBluetoothTransport::BleGatt(transport) => {
+                assert_eq!(transport.link().writes[0].0, WRITE_UUID);
+            }
+            BoardBluetoothTransport::Rfcomm(_) => panic!("expected BLE GATT transport"),
+        }
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -788,7 +788,10 @@ fn language_bluetooth_ble_open_plan(
         backend: backend.to_owned(),
         status: "unavailable".to_owned(),
         stream_path: None,
-        message: Some("BLE GATT backend opening is not wired yet".to_owned()),
+        message: Some(
+            "BLE GATT backend opening has CoreBluetooth connector groundwork but no runtime adapter yet"
+                .to_owned(),
+        ),
     }
 }
 
@@ -2726,6 +2729,7 @@ mod tests {
             LanguageHostEndpointTransport::BluetoothLeGatt
         );
         assert!(ble.stream_path.is_none());
+        assert!(ble.message.as_deref().unwrap().contains("CoreBluetooth"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a Rust-owned macOS CoreBluetooth BLE open request and injectable BLE connector for Board VM Bluetooth backends
- route `MacosBluetoothBackend::open_ble_gatt` through the connector while keeping RFCOMM behavior intact
- update language-core BLE backend plan messaging and document the CoreBluetooth groundwork

## Validation
- cargo test -p board-vm-bluetooth -p board-vm-language-core
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check
- git diff --cached --check

PR #2771 has merged; this continues the Board VM Bluetooth backend loop with CoreBluetooth BLE GATT groundwork.