### PR TITLE
Advance tree fixtures through tests24

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1573,7 +1573,7 @@ impl HtmlParser {
         }
 
         if self.open_elements.is_empty()
-            && text.chars().all(char::is_whitespace)
+            && is_html_whitespace_text(&text)
             && !self.has_document_element()
             && !self.document.children.iter().any(is_body_content_node)
         {
@@ -1616,7 +1616,7 @@ impl HtmlParser {
             && !self.current_element_is("title")
             && !(self.current_element_is("noscript")
                 && self.options.scripting == HtmlScriptingMode::Enabled)
-            && !text.chars().all(char::is_whitespace)
+            && !is_html_whitespace_text(&text)
         {
             self.pop_head_descendants();
         }
@@ -1642,7 +1642,7 @@ impl HtmlParser {
         let text = if self.current_element_is("head") {
             match text
                 .char_indices()
-                .find(|(_, character)| !character.is_whitespace())
+                .find(|(_, character)| !is_html_whitespace(*character))
             {
                 Some((0, _)) => text,
                 Some((leading_end, _)) => {
@@ -1655,7 +1655,7 @@ impl HtmlParser {
             text
         };
 
-        if !text.chars().all(char::is_whitespace) && self.current_element_is("head") {
+        if !is_html_whitespace_text(&text) && self.current_element_is("head") {
             self.pop_current_if(|name| name == "head");
         }
 
@@ -2470,6 +2470,10 @@ impl HtmlParser {
             {
                 return;
             }
+            if is_formatting_element(name) && self.adopt_formatting_end_tag_across_mixed_div(index)
+            {
+                return;
+            }
             if is_formatting_element(name) && self.adopt_formatting_end_tag_across_div(index) {
                 return;
             }
@@ -3119,6 +3123,90 @@ impl HtmlParser {
             adopted_path.push(0);
         }
         self.open_elements.push(adopted_path);
+        true
+    }
+
+    fn adopt_formatting_end_tag_across_mixed_div(&mut self, formatting_index: usize) -> bool {
+        let Some(formatting_path) = self.open_elements.get(formatting_index).cloned() else {
+            return false;
+        };
+        let Some(formatting_element) = element_ref_at_path(&self.document, &formatting_path) else {
+            return false;
+        };
+        let formatting_name = formatting_element.name.clone();
+        let formatting_attributes = formatting_element.attributes.clone();
+
+        let Some(first_div_path) = self
+            .open_elements
+            .iter()
+            .skip(formatting_index + 1)
+            .find(|path| element_at_path(&self.document, path).is_some_and(|name| name == "div"))
+            .cloned()
+        else {
+            return false;
+        };
+        if !first_div_path.starts_with(&formatting_path)
+            || first_div_path.len() <= formatting_path.len()
+        {
+            return false;
+        }
+
+        let mut formatting_wrappers = Vec::new();
+        let mut saw_non_formatting_wrapper = false;
+        for depth in formatting_path.len() + 1..first_div_path.len() {
+            let ancestor_path = &first_div_path[..depth];
+            let Some(element) = element_ref_at_path(&self.document, ancestor_path) else {
+                return false;
+            };
+            if is_formatting_element(&element.name) {
+                formatting_wrappers.push((element.name.clone(), element.attributes.clone()));
+            } else {
+                saw_non_formatting_wrapper = true;
+            }
+        }
+        if !saw_non_formatting_wrapper || formatting_wrappers.len() < 2 {
+            return false;
+        }
+
+        let Some(mut div) = remove_node_at_path(&mut self.document.children, &first_div_path)
+        else {
+            return false;
+        };
+        wrap_formatting_along_path(&mut div, &[], &formatting_name, &formatting_attributes);
+
+        let wrappers_to_clone = &formatting_wrappers[..formatting_wrappers.len() - 1];
+        let mut adopted_subtree = div;
+        for (wrapper_name, wrapper_attributes) in wrappers_to_clone.iter().rev() {
+            let mut wrapper = Node::element(wrapper_name.clone(), wrapper_attributes.clone());
+            if let Node::Element(wrapper_element) = &mut wrapper {
+                wrapper_element.children.push(adopted_subtree);
+            }
+            adopted_subtree = wrapper;
+        }
+
+        let Some((&formatting_child_index, formatting_parent_path)) = formatting_path.split_last()
+        else {
+            return false;
+        };
+        let insertion = (formatting_parent_path.to_vec(), formatting_child_index + 1);
+
+        let Some(parent_children) = children_at_path_mut(&mut self.document.children, &insertion.0)
+        else {
+            return false;
+        };
+        if insertion.1 > parent_children.len() {
+            return false;
+        }
+        parent_children.insert(insertion.1, adopted_subtree);
+
+        self.open_elements.truncate(formatting_index);
+        let mut inserted_path = insertion.0;
+        inserted_path.push(insertion.1);
+        for _ in wrappers_to_clone {
+            self.open_elements.push(inserted_path.clone());
+            inserted_path.push(0);
+        }
+        self.open_elements.push(inserted_path);
         true
     }
 
@@ -3858,6 +3946,14 @@ fn element_node(name: String, attributes: Vec<Attribute>, namespace: Option<&str
     }
 }
 
+fn is_html_whitespace(character: char) -> bool {
+    matches!(character, '\t' | '\n' | '\u{000C}' | '\r' | ' ')
+}
+
+fn is_html_whitespace_text(text: &str) -> bool {
+    text.chars().all(is_html_whitespace)
+}
+
 fn start_tag_as_text(name: &str, attributes: &[LexerAttribute], self_closing: bool) -> String {
     let mut text = format!("<{name}");
     for attribute in attributes {
@@ -4322,7 +4418,7 @@ impl DocumentShellBuilder {
                 match text
                     .data
                     .char_indices()
-                    .find(|(_, character)| !character.is_whitespace())
+                    .find(|(_, character)| !is_html_whitespace(*character))
                 {
                     Some((0, _)) => {
                         self.seen_body_content = true;

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -19917,3 +19917,479 @@ Line1<br>Line2<br>Line3<br>Line4
 |   <body>
 |     <svg svg>
 |       "<!--svg-->"
+
+
+#source tests22.dat:1204
+#data
+<a><b><big><em><strong><div>X</a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,33): adoption-agency-1.3
+(1,33): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       <b>
+|         <big>
+|           <em>
+|             <strong>
+|     <big>
+|       <em>
+|         <strong>
+|           <div>
+|             <a>
+|               "X"
+
+
+#source tests22.dat:1205
+#data
+<a><b><div id=1><div id=2><div id=3><div id=4><div id=5><div id=6><div id=7><div id=8>A</a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,91): adoption-agency-1.3
+(1,91): adoption-agency-1.3
+(1,91): adoption-agency-1.3
+(1,91): adoption-agency-1.3
+(1,91): adoption-agency-1.3
+(1,91): adoption-agency-1.3
+(1,91): adoption-agency-1.3
+(1,91): adoption-agency-1.3
+(1,91): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       <b>
+|     <b>
+|       <div>
+|         id="1"
+|         <a>
+|         <div>
+|           id="2"
+|           <a>
+|           <div>
+|             id="3"
+|             <a>
+|             <div>
+|               id="4"
+|               <a>
+|               <div>
+|                 id="5"
+|                 <a>
+|                 <div>
+|                   id="6"
+|                   <a>
+|                   <div>
+|                     id="7"
+|                     <a>
+|                     <div>
+|                       id="8"
+|                       <a>
+|                         "A"
+
+
+#source tests22.dat:1206
+#data
+<a><b><div id=1><div id=2><div id=3><div id=4><div id=5><div id=6><div id=7><div id=8><div id=9>A</a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,101): adoption-agency-1.3
+(1,101): adoption-agency-1.3
+(1,101): adoption-agency-1.3
+(1,101): adoption-agency-1.3
+(1,101): adoption-agency-1.3
+(1,101): adoption-agency-1.3
+(1,101): adoption-agency-1.3
+(1,101): adoption-agency-1.3
+(1,101): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       <b>
+|     <b>
+|       <div>
+|         id="1"
+|         <a>
+|         <div>
+|           id="2"
+|           <a>
+|           <div>
+|             id="3"
+|             <a>
+|             <div>
+|               id="4"
+|               <a>
+|               <div>
+|                 id="5"
+|                 <a>
+|                 <div>
+|                   id="6"
+|                   <a>
+|                   <div>
+|                     id="7"
+|                     <a>
+|                     <div>
+|                       id="8"
+|                       <a>
+|                         <div>
+|                           id="9"
+|                           "A"
+
+
+#source tests22.dat:1207
+#data
+<a><b><div id=1><div id=2><div id=3><div id=4><div id=5><div id=6><div id=7><div id=8><div id=9><div id=10>A</a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,112): adoption-agency-1.3
+(1,112): adoption-agency-1.3
+(1,112): adoption-agency-1.3
+(1,112): adoption-agency-1.3
+(1,112): adoption-agency-1.3
+(1,112): adoption-agency-1.3
+(1,112): adoption-agency-1.3
+(1,112): adoption-agency-1.3
+(1,112): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|       <b>
+|     <b>
+|       <div>
+|         id="1"
+|         <a>
+|         <div>
+|           id="2"
+|           <a>
+|           <div>
+|             id="3"
+|             <a>
+|             <div>
+|               id="4"
+|               <a>
+|               <div>
+|                 id="5"
+|                 <a>
+|                 <div>
+|                   id="6"
+|                   <a>
+|                   <div>
+|                     id="7"
+|                     <a>
+|                     <div>
+|                       id="8"
+|                       <a>
+|                         <div>
+|                           id="9"
+|                           <div>
+|                             id="10"
+|                             "A"
+
+
+#source tests22.dat:1208
+#data
+<cite><b><cite><i><cite><i><cite><i><div>X</b>TEST
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,46): adoption-agency-1.3
+(1,50): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <cite>
+|       <b>
+|         <cite>
+|           <i>
+|             <cite>
+|               <i>
+|                 <cite>
+|                   <i>
+|       <i>
+|         <i>
+|           <div>
+|             <b>
+|               "X"
+|             "TEST"
+
+
+#source tests23.dat:1209
+#data
+<p><font size=4><font color=red><font size=4><font size=4><font size=4><font size=4><font size=4><font color=red><p>X
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,116): unexpected-end-tag
+(1,117): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <font>
+|         size="4"
+|         <font>
+|           color="red"
+|           <font>
+|             size="4"
+|             <font>
+|               size="4"
+|               <font>
+|                 size="4"
+|                 <font>
+|                   size="4"
+|                   <font>
+|                     size="4"
+|                     <font>
+|                       color="red"
+|     <p>
+|       <font>
+|         color="red"
+|         <font>
+|           size="4"
+|           <font>
+|             size="4"
+|             <font>
+|               size="4"
+|               <font>
+|                 color="red"
+|                 "X"
+
+
+#source tests23.dat:1210
+#data
+<p><font size=4><font size=4><font size=4><font size=4><p>X
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,58): unexpected-end-tag
+(1,59): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <font>
+|         size="4"
+|         <font>
+|           size="4"
+|           <font>
+|             size="4"
+|             <font>
+|               size="4"
+|     <p>
+|       <font>
+|         size="4"
+|         <font>
+|           size="4"
+|           <font>
+|             size="4"
+|             "X"
+
+
+#source tests23.dat:1211
+#data
+<p><font size=4><font size=4><font size=4><font size="5"><font size=4><p>X
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,73): unexpected-end-tag
+(1,74): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <font>
+|         size="4"
+|         <font>
+|           size="4"
+|           <font>
+|             size="4"
+|             <font>
+|               size="5"
+|               <font>
+|                 size="4"
+|     <p>
+|       <font>
+|         size="4"
+|         <font>
+|           size="4"
+|           <font>
+|             size="5"
+|             <font>
+|               size="4"
+|               "X"
+
+
+#source tests23.dat:1212
+#data
+<p><font size=4 id=a><font size=4 id=b><font size=4><font size=4><p>X
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,68): unexpected-end-tag
+(1,69): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <font>
+|         id="a"
+|         size="4"
+|         <font>
+|           id="b"
+|           size="4"
+|           <font>
+|             size="4"
+|             <font>
+|               size="4"
+|     <p>
+|       <font>
+|         id="a"
+|         size="4"
+|         <font>
+|           id="b"
+|           size="4"
+|           <font>
+|             size="4"
+|             <font>
+|               size="4"
+|               "X"
+
+
+#source tests23.dat:1213
+#data
+<p><b id=a><b id=a><b id=a><b><object><b id=a><b id=a>X</object><p>Y
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,64): end-tag-too-early
+(1,67): unexpected-end-tag
+(1,68): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <b>
+|         id="a"
+|         <b>
+|           id="a"
+|           <b>
+|             id="a"
+|             <b>
+|               <object>
+|                 <b>
+|                   id="a"
+|                   <b>
+|                     id="a"
+|                     "X"
+|     <p>
+|       <b>
+|         id="a"
+|         <b>
+|           id="a"
+|           <b>
+|             id="a"
+|             <b>
+|               "Y"
+
+
+#source tests24.dat:1214
+#data
+<!DOCTYPE html>&NotEqualTilde;
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "≂̸"
+
+
+#source tests24.dat:1215
+#data
+<!DOCTYPE html>&NotEqualTilde;A
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "≂̸A"
+
+
+#source tests24.dat:1216
+#data
+<!DOCTYPE html>&ThickSpace;
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "  "
+
+
+#source tests24.dat:1217
+#data
+<!DOCTYPE html>&ThickSpace;A
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "  A"
+
+
+#source tests24.dat:1218
+#data
+<!DOCTYPE html>&NotSubset;
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "⊂⃒"
+
+
+#source tests24.dat:1219
+#data
+<!DOCTYPE html>&NotSubset;A
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "⊂⃒A"
+
+
+#source tests24.dat:1220
+#data
+<!DOCTYPE html>&Gopf;
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "𝔾"
+
+
+#source tests24.dat:1221
+#data
+<!DOCTYPE html>&Gopf;A
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "𝔾A"


### PR DESCRIPTION
## Summary
- add html5lib tree-construction smoke coverage for tests22.dat, tests23.dat, and tests24.dat through case 1221
- handle mixed formatting adoption across non-formatting wrappers for the tests22 cite/i case
- treat only HTML space characters as ignorable pre-body whitespace so decoded non-ASCII named-reference spaces are preserved

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer