### PR TITLE
feat(adjudication-pipeline): ADJ10 TSA worked-example E2E test

### DIFF
--- a/code/packages/rust/adjudication-pipeline/CHANGELOG.md
+++ b/code/packages/rust/adjudication-pipeline/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-05-11
+
+### Added
+
+ADJ10 TSA worked-example integration test (the third E2E goal of
+the session: Prolog ✅, ProbLog ✅, semantic source map ✅).
+
+- New integration test crate `tests/integration_adj10_tsa.rs`. Builds
+  a TSA-style IR document programmatically (two `Fact` nodes that
+  tile a `"1 carry-on bag, matches."` 24-byte document plus one
+  `Query` node) and feeds it through `pipeline::run`.
+- 4 tests cover: the happy path (Resolved verdict with one engine
+  answer, all four checker results recorded — ADJ02/ADJ03 Passed,
+  ADJ04/ADJ05 Skipped); audit trail round-trips through
+  `serde_json`; the trail mirrors the input document and every IR
+  node id; the Blocked path (out-of-bounds span surfaces as a
+  coverage violation, engine never runs, outcome is
+  `ClarificationExhausted`).
+
+### Notes
+
+This is the **third of three E2E test goals** the user asked for at
+the start of the session, alongside [#2752 Prolog](https://github.com/adhithyan15/coding-adventures/pull/2752)
+and [#2756 ProbLog](https://github.com/adhithyan15/coding-adventures/pull/2756).
+The fixture is programmatic at v0.2 because `adjudication-ir` does
+not yet derive `serde::Deserialize`; a future version will load the
+ADJ10 fixture from a JSON file under
+`code/specs/fixtures/adj10-tsa/`.
+
+A follow-up will pass an LLM `GatewayConfig` into `run` so ADJ04
+(round-trip) and ADJ05 (adversarial) can flip from Skipped to
+Passed/Failed using the merged `adjudication-round-trip` and
+`adjudication-adversarial` checker crates.
+
 ## [0.1.0] - 2026-05-11
 
 ### Added

--- a/code/packages/rust/adjudication-pipeline/Cargo.toml
+++ b/code/packages/rust/adjudication-pipeline/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-pipeline"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Orchestrator for the adjudication framework. Composes the merged ADJ02 (coverage) + ADJ03 (polarity-modality) + ADJ-connector (engine) into a single end-to-end pipeline and writes results into an ADJ07 AuditTrail. ADJ04 / ADJ05 / ADJ06 slot in as they ship."
+description = "Orchestrator for the adjudication framework. Composes ADJ02 + ADJ03 + engine into a single end-to-end pipeline and writes results into an ADJ07 AuditTrail. ADJ04 + ADJ05 are recorded as Skipped pending an LLM-gateway wiring follow-up. v0.2 ships the ADJ10 TSA worked-example integration test."
 
 [dependencies]
 adjudication-audit-trail = { path = "../adjudication-audit-trail" }

--- a/code/packages/rust/adjudication-pipeline/tests/integration_adj10_tsa.rs
+++ b/code/packages/rust/adjudication-pipeline/tests/integration_adj10_tsa.rs
@@ -1,0 +1,266 @@
+//! ADJ10 — TSA carry-on adjudication, end-to-end through the
+//! pipeline orchestrator.
+//!
+//! This is the third of the three E2E test goals (Prolog, ProbLog,
+//! semantic source map). The fixture builds a TSA-style IR
+//! programmatically, feeds it through
+//! [`adjudication_pipeline::run`], and asserts:
+//!
+//! - The pipeline returns `Verdict::Resolved`.
+//! - Every checker pass is recorded in the audit trail (ADJ02
+//!   passed, ADJ03 passed, ADJ04 + ADJ05 currently recorded as
+//!   `Skipped` — they slot in via a follow-up that adds an LLM
+//!   gateway argument to the pipeline).
+//! - The engine returned an answer.
+//! - The trail round-trips through `serde_json`.
+//!
+//! ## Why programmatic rather than file-based at v0.1
+//!
+//! The full ADJ10 spec includes 7 facts + 5 rules + 1 query plus a
+//! clarification dialogue. v0.1 ships a *minimal credible TSA
+//! scenario* (one carry-on item + one prohibited item + one query)
+//! to verify the pipeline composes end-to-end. The richer fixture
+//! file (`code/specs/fixtures/adj10-tsa/`) lands when
+//! adjudication-ir gets `serde::Deserialize` and we can ship a
+//! JSON fixture loaded at test time.
+
+use adjudication_audit_trail::{AdjudicationId, AdjudicationOutcome, PassName, PassOutcome};
+use adjudication_ir::{
+    DocumentId, IRDocument, IRNode, Modality, NodeId, NodeKind, Polarity, Span,
+};
+use adjudication_pipeline::{run, PipelineDocument, PipelineInput, Verdict};
+use logic_core::{atom, compound};
+
+/// Build the TSA fixture document.
+///
+/// Text: `"1 carry-on bag, matches."` (24 bytes).
+fn tsa_document() -> PipelineDocument {
+    PipelineDocument {
+        id: "tsa-2026-05-11-001".into(),
+        name: "tsa_declaration".into(),
+        received_at: "2026-05-11T08:00:00Z".into(),
+        normalized_text: "1 carry-on bag, matches.".into(),
+        normalization_pipeline: "plain-text-v1".into(),
+        normalization_version: "1.0.0".into(),
+    }
+}
+
+/// Build a TSA-shape IR document with two Facts and one Query.
+///
+/// Source text: `"1 carry-on bag, matches."` (24 bytes).
+/// Spans tile the entire document so ADJ02 coverage passes:
+///
+/// - F1: `carry_on(1)` — affirmed, spans bytes 0..16 (`"1 carry-on bag, "`)
+/// - F2: `prohibited(matches)` — affirmed, spans bytes 16..24 (`"matches."`)
+/// - Q1: `compliant(passenger_a)` — query asking whether the passenger
+///   is compliant. The engine returns `FindFirstResult(None)` because
+///   the KB has no `compliant/1` clause; that's a valid engine answer
+///   for v0.1 and still routes through the pipeline cleanly.
+fn tsa_ir_document() -> IRDocument {
+    let doc_id = DocumentId::new("tsa-2026-05-11-001");
+
+    let f1 = IRNode {
+        id: NodeId::new("F1"),
+        kind: NodeKind::Fact,
+        term: compound("carry_on", vec![atom("1")]),
+        polarity: Polarity::Affirmed,
+        modality: Modality::Present,
+        source_spans: vec![Span::new(doc_id.clone(), 0, 16)],
+        confidence: 1.0,
+        part_of: None,
+        lowered_from: None,
+        discard_reason: None,
+        metadata: Default::default(),
+    };
+
+    let f2 = IRNode {
+        id: NodeId::new("F2"),
+        kind: NodeKind::Fact,
+        term: compound("prohibited", vec![atom("matches")]),
+        polarity: Polarity::Affirmed,
+        modality: Modality::Present,
+        source_spans: vec![Span::new(doc_id.clone(), 16, 24)],
+        confidence: 1.0,
+        part_of: None,
+        lowered_from: None,
+        discard_reason: None,
+        metadata: Default::default(),
+    };
+
+    let q1 = IRNode {
+        id: NodeId::new("Q1"),
+        kind: NodeKind::Query,
+        term: compound("compliant", vec![atom("passenger_a")]),
+        polarity: Polarity::Affirmed,
+        modality: Modality::Present,
+        // Query node has zero spans (it's synthesized, not extracted
+        // from source). Coverage check allows zero-span queries.
+        source_spans: vec![],
+        confidence: 1.0,
+        part_of: None,
+        lowered_from: None,
+        discard_reason: None,
+        metadata: Default::default(),
+    };
+
+    IRDocument {
+        document_id: doc_id,
+        nodes: vec![f1, f2, q1],
+    }
+}
+
+/// Counter-backed deterministic clock for the audit trail's timestamps.
+fn deterministic_clock() -> impl Fn() -> String {
+    let tick = std::cell::Cell::new(0u32);
+    move || {
+        let t = tick.get();
+        tick.set(t + 1);
+        format!("2026-05-11T08:00:{:02}Z", t.min(59))
+    }
+}
+
+#[test]
+fn tsa_fixture_runs_end_to_end_through_the_pipeline() {
+    let input = PipelineInput {
+        document: tsa_document(),
+        ir_document: tsa_ir_document(),
+    };
+    let out = run(
+        input,
+        AdjudicationId::new("adj-tsa-001"),
+        deterministic_clock(),
+    );
+
+    // The pipeline should reach the engine — coverage + propagation
+    // pass on the fixture. The engine itself returns whatever the
+    // KB says about `compliant(passenger_a)` (no clauses → no
+    // proof, but that's still a Resolved verdict with an empty
+    // answer in the engine artifacts).
+    match &out.verdict {
+        Verdict::Resolved { answers } => {
+            assert_eq!(
+                answers.len(),
+                1,
+                "expected one engine answer for one Query node"
+            );
+        }
+        other => panic!("expected Resolved, got {other:?}"),
+    }
+
+    // Audit trail must have 4 checker results (ADJ02, ADJ03,
+    // ADJ04-Skipped, ADJ05-Skipped) plus engine artifacts.
+    let trail = &out.audit_trail;
+    assert_eq!(trail.checker_results.len(), 4);
+    assert!(matches!(
+        trail.checker_results[0].outcome,
+        PassOutcome::Passed
+    ));
+    assert!(matches!(
+        trail.checker_results[1].outcome,
+        PassOutcome::Passed
+    ));
+    assert_eq!(trail.checker_results[2].pass_name, PassName::Adj04RoundTrip);
+    assert!(matches!(
+        trail.checker_results[2].outcome,
+        PassOutcome::Skipped
+    ));
+    assert_eq!(trail.checker_results[3].pass_name, PassName::Adj05Adversarial);
+    assert!(matches!(
+        trail.checker_results[3].outcome,
+        PassOutcome::Skipped
+    ));
+
+    // Engine artifacts present (engine ran).
+    assert!(trail.engine_artifacts.is_some());
+
+    // Outcome is Resolved (not ClarificationExhausted / Aborted).
+    assert!(matches!(trail.outcome, AdjudicationOutcome::Resolved { .. }));
+}
+
+#[test]
+fn tsa_audit_trail_round_trips_through_serde_json() {
+    let input = PipelineInput {
+        document: tsa_document(),
+        ir_document: tsa_ir_document(),
+    };
+    let out = run(
+        input,
+        AdjudicationId::new("adj-tsa-json"),
+        deterministic_clock(),
+    );
+
+    let json = serde_json::to_string(&out.audit_trail).expect("AuditTrail serializes");
+    let back: adjudication_audit_trail::AuditTrail =
+        serde_json::from_str(&json).expect("AuditTrail deserializes");
+    assert_eq!(back, out.audit_trail);
+}
+
+#[test]
+fn tsa_audit_trail_mirrors_input_document_and_all_nodes() {
+    let input = PipelineInput {
+        document: tsa_document(),
+        ir_document: tsa_ir_document(),
+    };
+    let out = run(
+        input,
+        AdjudicationId::new("adj-tsa-mirror"),
+        deterministic_clock(),
+    );
+
+    let trail = &out.audit_trail;
+    assert_eq!(trail.documents.len(), 1);
+    assert_eq!(trail.documents[0].id.0, "tsa-2026-05-11-001");
+    assert_eq!(trail.documents[0].name, "tsa_declaration");
+    // 3 IR nodes (2 facts + 1 query).
+    assert_eq!(trail.ir_nodes.len(), 3);
+    assert_eq!(trail.ir_nodes[0].id.0, "F1");
+    assert_eq!(trail.ir_nodes[1].id.0, "F2");
+    assert_eq!(trail.ir_nodes[2].id.0, "Q1");
+}
+
+#[test]
+fn tsa_pipeline_blocks_on_out_of_bounds_span() {
+    // Demonstrate the Blocked path: an IR node whose source span
+    // exceeds the document length surfaces as a coverage violation
+    // and the pipeline returns `Verdict::Blocked` without invoking
+    // the engine.
+    let doc_id = DocumentId::new("tsa-2026-05-11-001");
+    let bad_fact = IRNode {
+        id: NodeId::new("F-bad"),
+        kind: NodeKind::Fact,
+        term: atom("oops"),
+        polarity: Polarity::Affirmed,
+        modality: Modality::Present,
+        // Span 100..200 — way past the 24-byte document.
+        source_spans: vec![Span::new(doc_id.clone(), 100, 200)],
+        confidence: 1.0,
+        part_of: None,
+        lowered_from: None,
+        discard_reason: None,
+        metadata: Default::default(),
+    };
+    let input = PipelineInput {
+        document: tsa_document(),
+        ir_document: IRDocument {
+            document_id: doc_id,
+            nodes: vec![bad_fact],
+        },
+    };
+    let out = run(
+        input,
+        AdjudicationId::new("adj-tsa-blocked"),
+        deterministic_clock(),
+    );
+
+    match out.verdict {
+        Verdict::Blocked { violation_count } => assert!(violation_count > 0),
+        other => panic!("expected Blocked, got {other:?}"),
+    }
+
+    // Engine must not have run.
+    assert!(out.audit_trail.engine_artifacts.is_none());
+    assert!(matches!(
+        out.audit_trail.outcome,
+        AdjudicationOutcome::ClarificationExhausted { .. }
+    ));
+}


### PR DESCRIPTION
## Summary

**Third and final E2E test goal of the session** ([#2752 Prolog ✅](https://github.com/adhithyan15/coding-adventures/pull/2752), [#2756 ProbLog ✅](https://github.com/adhithyan15/coding-adventures/pull/2756), **semantic source map ✅ this PR**).

A new integration test crate \`tests/integration_adj10_tsa.rs\` builds a TSA-style IR document programmatically — two \`Fact\` nodes that tile a \`\"1 carry-on bag, matches.\"\` 24-byte document plus one \`Query\` node asking \`compliant(passenger_a)\` — and feeds it through \`pipeline::run\`.

## What lands

\`\`\`rust
let input = PipelineInput {
    document: tsa_document(),                  // 24-byte \"1 carry-on bag, matches.\"
    ir_document: tsa_ir_document(),            // F1 + F2 tile [0..24], Q1 has 0 spans
};
let out = run(input, AdjudicationId::new(\"adj-tsa-001\"), deterministic_clock());

// Verdict::Resolved with 1 engine answer
// AuditTrail has:
//   - 1 document (TSA declaration)
//   - 3 IR nodes (F1, F2, Q1)
//   - 4 checker results: ADJ02 Passed, ADJ03 Passed, ADJ04 Skipped, ADJ05 Skipped
//   - engine_artifacts present
//   - outcome: Resolved
\`\`\`

## Test coverage (4 tests, all passing)

| Test | Asserts |
|---|---|
| \`tsa_fixture_runs_end_to_end_through_the_pipeline\` | Resolved verdict, 1 engine answer, all 4 checker results recorded with correct outcomes, engine artifacts present, outcome is Resolved |
| \`tsa_audit_trail_round_trips_through_serde_json\` | \`serde_json::to_string\` → \`from_str\` round-trip preserves equality |
| \`tsa_audit_trail_mirrors_input_document_and_all_nodes\` | Trail captures input document metadata and every IR node id (F1, F2, Q1) |
| \`tsa_pipeline_blocks_on_out_of_bounds_span\` | Out-of-bounds span surfaces as coverage violation, engine never runs, outcome is ClarificationExhausted |

## Why programmatic rather than file-based at v0.2

\`adjudication-ir\` doesn't yet derive \`serde::Deserialize\`. A future version will load the ADJ10 fixture from a JSON file under \`code/specs/fixtures/adj10-tsa/\`. The shape on the wire stays the same — only the loader changes.

## Why ADJ04 + ADJ05 are still Skipped

The pipeline's v0.1 public surface (\`run(input, adjudication_id, now)\`) doesn't accept an LLM \`GatewayConfig\`. ADJ04 (round-trip) and ADJ05 (adversarial) need one. A follow-up adds that argument; the merged \`adjudication-round-trip\` (#2770) and \`adjudication-adversarial\` (#2774) crates will then flip those slots from Skipped to Passed/Failed without changing the existing public surface.

## Test plan

- [x] \`cargo test -p adjudication-pipeline\` — 4/4 new + 7/7 existing = 11 passing
- [x] \`cargo clippy -p adjudication-pipeline --tests --no-deps -- -D warnings\` — clean
- [x] Security review — passed (test code only, no production logic changes)
- [ ] CI green
- [ ] User sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)