### PR TITLE
Add generic job runtime queue pressure bands

### DIFF
--- a/code/packages/rust/generic-job-runtime/CHANGELOG.md
+++ b/code/packages/rust/generic-job-runtime/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this package will be documented in this file.
 - Added queue-pressure percentages and recommended supervision actions for
   executor snapshots so D18C supervisors can choose backpressure, worker
   restart, or graceful-drain behavior without reinterpreting raw counters.
+- Added queue-pressure bands and percent-threshold helpers for stable D18C
+  backpressure read models.
 
 ## [0.1.1] - 2026-04-22
 

--- a/code/packages/rust/generic-job-runtime/README.md
+++ b/code/packages/rust/generic-job-runtime/README.md
@@ -32,6 +32,8 @@ targets.
   retryable-failed response batches.
 - Non-consuming executor snapshots for supervisor/read-side tools, including
   live workers, in-flight jobs, queued jobs, running jobs, and saturation.
+- Queue-pressure bands and percent-threshold checks for D18C supervisors that
+  need stable read-side backpressure signals.
 - Snapshot health classification for D18C supervisors to distinguish idle,
   busy, saturated, draining, and offline executors.
 - Snapshot supervision recommendations for backpressure, worker restart, and

--- a/code/packages/rust/generic-job-runtime/src/lib.rs
+++ b/code/packages/rust/generic-job-runtime/src/lib.rs
@@ -84,6 +84,14 @@ pub enum ExecutorHealth {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutorQueuePressure {
+    Idle,
+    Nominal,
+    Elevated,
+    Saturated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutorSupervisionAction {
     None,
     ObserveDraining,
@@ -137,6 +145,22 @@ impl ExecutorSnapshot {
         }
         let percent = self.in_flight_jobs.saturating_mul(100) / self.max_queue_depth;
         percent.min(100) as u8
+    }
+
+    pub fn queue_pressure(&self) -> ExecutorQueuePressure {
+        if self.in_flight_jobs == 0 {
+            ExecutorQueuePressure::Idle
+        } else if self.is_saturated() {
+            ExecutorQueuePressure::Saturated
+        } else if self.queue_pressure_percent() >= 75 {
+            ExecutorQueuePressure::Elevated
+        } else {
+            ExecutorQueuePressure::Nominal
+        }
+    }
+
+    pub fn exceeds_queue_pressure_percent(&self, threshold: u8) -> bool {
+        self.queue_pressure_percent() > threshold.min(100)
     }
 
     pub fn recommended_supervision_action(&self) -> ExecutorSupervisionAction {
@@ -1896,6 +1920,8 @@ for line in sys.stdin:
         assert!(snapshot.is_saturated());
         assert_eq!(snapshot.pending_jobs(), 2);
         assert_eq!(snapshot.health(), ExecutorHealth::Saturated);
+        assert_eq!(snapshot.queue_pressure(), ExecutorQueuePressure::Saturated);
+        assert!(snapshot.exceeds_queue_pressure_percent(75));
         assert!(!snapshot.has_live_capacity());
         assert!(snapshot.needs_supervisor_attention());
         assert!(!snapshot.shutting_down);
@@ -1948,6 +1974,8 @@ for line in sys.stdin:
         };
         assert_eq!(idle.health(), ExecutorHealth::Idle);
         assert_eq!(idle.queue_pressure_percent(), 0);
+        assert_eq!(idle.queue_pressure(), ExecutorQueuePressure::Idle);
+        assert!(!idle.exceeds_queue_pressure_percent(0));
         assert_eq!(
             idle.recommended_supervision_action(),
             ExecutorSupervisionAction::None
@@ -1963,11 +1991,25 @@ for line in sys.stdin:
         assert_eq!(busy.health(), ExecutorHealth::Busy);
         assert_eq!(busy.pending_jobs(), 1);
         assert_eq!(busy.queue_pressure_percent(), 25);
+        assert_eq!(busy.queue_pressure(), ExecutorQueuePressure::Nominal);
+        assert!(busy.exceeds_queue_pressure_percent(20));
+        assert!(!busy.exceeds_queue_pressure_percent(25));
         assert_eq!(
             busy.recommended_supervision_action(),
             ExecutorSupervisionAction::None
         );
         assert!(busy.has_live_capacity());
+
+        let elevated = ExecutorSnapshot {
+            in_flight_jobs: 3,
+            queued_jobs: 2,
+            running_jobs: 1,
+            ..idle.clone()
+        };
+        assert_eq!(elevated.health(), ExecutorHealth::Busy);
+        assert_eq!(elevated.queue_pressure_percent(), 75);
+        assert_eq!(elevated.queue_pressure(), ExecutorQueuePressure::Elevated);
+        assert!(elevated.exceeds_queue_pressure_percent(74));
 
         let saturated = ExecutorSnapshot {
             in_flight_jobs: 4,
@@ -1977,6 +2019,8 @@ for line in sys.stdin:
         };
         assert_eq!(saturated.health(), ExecutorHealth::Saturated);
         assert_eq!(saturated.queue_pressure_percent(), 100);
+        assert_eq!(saturated.queue_pressure(), ExecutorQueuePressure::Saturated);
+        assert!(!saturated.exceeds_queue_pressure_percent(100));
         assert_eq!(
             saturated.recommended_supervision_action(),
             ExecutorSupervisionAction::ApplyBackpressure


### PR DESCRIPTION
## Summary
- add stable executor queue-pressure bands for idle, nominal, elevated, and saturated snapshots
- add percent-threshold helpers so D18C supervisors can trigger backpressure without reinterpreting raw counters
- document and test the new read-side pressure classifications

## Tests
- `cargo test -p generic-job-runtime`
- `git diff --check origin/main...HEAD`
