### PR TITLE
Route CAS matrix numeric ops through shared matrix backends

### DIFF
--- a/code/packages/rust/cas-matrix/Cargo.toml
+++ b/code/packages/rust/cas-matrix/Cargo.toml
@@ -6,4 +6,8 @@ description = "Matrix operations over symbolic IR (construction, arithmetic, det
 license = "MIT"
 
 [dependencies]
+compute-ir = { path = "../compute-ir" }
+executor-protocol = { path = "../executor-protocol" }
+matrix-cpu = { path = "../matrix-cpu" }
+matrix-ir = { path = "../matrix-ir" }
 symbolic-ir = { path = "../symbolic-ir" }

--- a/code/packages/rust/cas-matrix/src/arithmetic.rs
+++ b/code/packages/rust/cas-matrix/src/arithmetic.rs
@@ -2,10 +2,10 @@
 //!
 //! ## Symbolic output
 //!
-//! Every arithmetic step is wrapped as unevaluated `IRApply(ADD/SUB/MUL/…)`
-//! rather than collapsed to a numeric value.  Pass the result through
-//! `cas_simplify::simplify` (or any downstream numeric-fold pass) to reduce
-//! numeric entries.
+//! Concrete integer/float matrix arithmetic is routed through the shared
+//! matrix execution backend.  Symbolic and exact-rational inputs fall back to
+//! unevaluated `IRApply(ADD/SUB/MUL/…)` nodes so downstream CAS passes can
+//! simplify them without losing exactness.
 //!
 //! ## Constructors
 //!
@@ -14,6 +14,9 @@
 
 use symbolic_ir::{apply, int, sym, IRNode, ADD, MUL, SUB};
 
+use crate::backend::{
+    try_elementwise, try_matmul, try_scalar_multiply, try_transpose, BackendBinaryOp,
+};
 use crate::matrix::{matrix, rows_of, MatrixError, MatrixResult};
 
 // ---------------------------------------------------------------------------
@@ -79,6 +82,9 @@ pub fn transpose(m: &IRNode) -> MatrixResult<IRNode> {
     if rows.is_empty() {
         return matrix(vec![vec![]]); // shouldn't happen given invariants
     }
+    if let Some(result) = try_transpose(&rows) {
+        return result;
+    }
     let nrows = rows.len();
     let ncols = rows[0].len();
     let new_rows: Vec<Vec<IRNode>> = (0..ncols)
@@ -108,6 +114,9 @@ pub fn add_matrices(a: &IRNode, b: &IRNode) -> MatrixResult<IRNode> {
     let a_rows = rows_of(a)?;
     let b_rows = rows_of(b)?;
     check_same_shape(&a_rows, &b_rows, "add")?;
+    if let Some(result) = try_elementwise(&a_rows, &b_rows, BackendBinaryOp::Add) {
+        return result;
+    }
     let new_rows = elementwise(a_rows, b_rows, |x, y| apply(sym(ADD), vec![x, y]));
     matrix(new_rows)
 }
@@ -119,6 +128,9 @@ pub fn sub_matrices(a: &IRNode, b: &IRNode) -> MatrixResult<IRNode> {
     let a_rows = rows_of(a)?;
     let b_rows = rows_of(b)?;
     check_same_shape(&a_rows, &b_rows, "sub")?;
+    if let Some(result) = try_elementwise(&a_rows, &b_rows, BackendBinaryOp::Sub) {
+        return result;
+    }
     let new_rows = elementwise(a_rows, b_rows, |x, y| apply(sym(SUB), vec![x, y]));
     matrix(new_rows)
 }
@@ -135,6 +147,9 @@ pub fn sub_matrices(a: &IRNode, b: &IRNode) -> MatrixResult<IRNode> {
 /// ```
 pub fn scalar_multiply(scalar: &IRNode, m: &IRNode) -> MatrixResult<IRNode> {
     let rows = rows_of(m)?;
+    if let Some(result) = try_scalar_multiply(scalar, &rows) {
+        return result;
+    }
     let new_rows: Vec<Vec<IRNode>> = rows
         .into_iter()
         .map(|row| {
@@ -211,6 +226,9 @@ pub fn dot(a: &IRNode, b: &IRNode) -> MatrixResult<IRNode> {
         return Err(MatrixError(format!(
             "dot: cols(A)={a_cols} != rows(B)={b_row_count}"
         )));
+    }
+    if let Some(result) = try_matmul(&a_rows, &b_rows) {
+        return result;
     }
     let b_cols = b_rows[0].len();
     let new_rows: Vec<Vec<IRNode>> = (0..a_rows.len())

--- a/code/packages/rust/cas-matrix/src/backend.rs
+++ b/code/packages/rust/cas-matrix/src/backend.rs
@@ -1,0 +1,470 @@
+//! Bridge from CAS matrices to the shared matrix execution backend.
+//!
+//! The matrix execution layer only supports machine numeric dtypes today, so
+//! this module handles concrete integer/float matrices and leaves symbolic or
+//! exact-rational inputs to the CAS fallback paths.
+
+use compute_ir::{
+    BufferId, ComputeGraph, OpTiming as PlanOpTiming, PlacedOp, PlacedTensor, Residency,
+    CPU_EXECUTOR,
+};
+use executor_protocol::{ExecutorRequest, ExecutorResponse};
+use matrix_cpu::CpuExecutor;
+use matrix_ir::{DType, Op, Shape, TensorId};
+use symbolic_ir::{flt, int, IRNode};
+
+use crate::matrix::{matrix, MatrixError, MatrixResult};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BackendBinaryOp {
+    Add,
+    Sub,
+    Mul,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BackendDType {
+    I32,
+    F32,
+}
+
+impl BackendDType {
+    fn matrix_dtype(self) -> DType {
+        match self {
+            BackendDType::I32 => DType::I32,
+            BackendDType::F32 => DType::F32,
+        }
+    }
+
+    fn size_bytes(self) -> usize {
+        self.matrix_dtype().size_bytes()
+    }
+}
+
+pub(crate) fn try_transpose(rows: &[Vec<IRNode>]) -> Option<MatrixResult<IRNode>> {
+    let nrows = rows.len();
+    let ncols = rows.first().map_or(0, |row| row.len());
+    let dtype = dtype_for_rows(rows)?;
+    let input = encode_rows(rows, dtype)?;
+    Some(
+        run_unary(
+            Op::Transpose {
+                input: TensorId(0),
+                perm: vec![1, 0],
+                output: TensorId(1),
+            },
+            &[nrows, ncols],
+            &[ncols, nrows],
+            input,
+            dtype,
+        )
+        .and_then(|bytes| decode_rows(&bytes, ncols, nrows, dtype))
+        .and_then(matrix),
+    )
+}
+
+pub(crate) fn try_elementwise(
+    lhs: &[Vec<IRNode>],
+    rhs: &[Vec<IRNode>],
+    op: BackendBinaryOp,
+) -> Option<MatrixResult<IRNode>> {
+    let nrows = lhs.len();
+    let ncols = lhs.first().map_or(0, |row| row.len());
+    let dtype = dtype_for_two_rows(lhs, rhs)?;
+    let lhs_bytes = encode_rows(lhs, dtype)?;
+    let rhs_bytes = encode_rows(rhs, dtype)?;
+
+    Some(
+        run_binary(
+            op,
+            &[nrows, ncols],
+            &[nrows, ncols],
+            lhs_bytes,
+            rhs_bytes,
+            dtype,
+        )
+        .and_then(|bytes| decode_rows(&bytes, nrows, ncols, dtype))
+        .and_then(matrix),
+    )
+}
+
+pub(crate) fn try_scalar_multiply(
+    scalar: &IRNode,
+    rows: &[Vec<IRNode>],
+) -> Option<MatrixResult<IRNode>> {
+    let nrows = rows.len();
+    let ncols = rows.first().map_or(0, |row| row.len());
+    let dtype = dtype_for_scalar_and_rows(scalar, rows)?;
+    let lhs = encode_scalar_matrix(scalar, nrows * ncols, dtype)?;
+    let rhs = encode_rows(rows, dtype)?;
+
+    Some(
+        run_binary(
+            BackendBinaryOp::Mul,
+            &[nrows, ncols],
+            &[nrows, ncols],
+            lhs,
+            rhs,
+            dtype,
+        )
+        .and_then(|bytes| decode_rows(&bytes, nrows, ncols, dtype))
+        .and_then(matrix),
+    )
+}
+
+pub(crate) fn try_matmul(lhs: &[Vec<IRNode>], rhs: &[Vec<IRNode>]) -> Option<MatrixResult<IRNode>> {
+    let lhs_rows = lhs.len();
+    let lhs_cols = lhs.first().map_or(0, |row| row.len());
+    let rhs_rows = rhs.len();
+    let rhs_cols = rhs.first().map_or(0, |row| row.len());
+    let dtype = dtype_for_two_rows(lhs, rhs)?;
+    let lhs_bytes = encode_rows(lhs, dtype)?;
+    let rhs_bytes = encode_rows(rhs, dtype)?;
+
+    Some(
+        run_matmul(
+            &[lhs_rows, lhs_cols],
+            &[rhs_rows, rhs_cols],
+            lhs_bytes,
+            rhs_bytes,
+            dtype,
+        )
+        .and_then(|bytes| decode_rows(&bytes, lhs_rows, rhs_cols, dtype))
+        .and_then(matrix),
+    )
+}
+
+fn dtype_for_rows(rows: &[Vec<IRNode>]) -> Option<BackendDType> {
+    let mut dtype = BackendDType::I32;
+    for row in rows {
+        for cell in row {
+            dtype = merge_dtype(dtype, dtype_for_node(cell)?)?;
+        }
+    }
+    Some(dtype)
+}
+
+fn dtype_for_two_rows(lhs: &[Vec<IRNode>], rhs: &[Vec<IRNode>]) -> Option<BackendDType> {
+    merge_dtype(dtype_for_rows(lhs)?, dtype_for_rows(rhs)?)
+}
+
+fn dtype_for_scalar_and_rows(scalar: &IRNode, rows: &[Vec<IRNode>]) -> Option<BackendDType> {
+    merge_dtype(dtype_for_node(scalar)?, dtype_for_rows(rows)?)
+}
+
+fn dtype_for_node(node: &IRNode) -> Option<BackendDType> {
+    match node {
+        IRNode::Integer(value) if i32::try_from(*value).is_ok() => Some(BackendDType::I32),
+        IRNode::Float(value) if value.is_finite() => Some(BackendDType::F32),
+        _ => None,
+    }
+}
+
+fn merge_dtype(lhs: BackendDType, rhs: BackendDType) -> Option<BackendDType> {
+    match (lhs, rhs) {
+        (BackendDType::I32, BackendDType::I32) => Some(BackendDType::I32),
+        (BackendDType::I32, BackendDType::F32) | (BackendDType::F32, BackendDType::I32) => {
+            Some(BackendDType::F32)
+        }
+        (BackendDType::F32, BackendDType::F32) => Some(BackendDType::F32),
+    }
+}
+
+fn encode_rows(rows: &[Vec<IRNode>], dtype: BackendDType) -> Option<Vec<u8>> {
+    let values = rows.iter().flat_map(|row| row.iter());
+    encode_nodes(values, dtype)
+}
+
+fn encode_scalar_matrix(scalar: &IRNode, len: usize, dtype: BackendDType) -> Option<Vec<u8>> {
+    encode_nodes(std::iter::repeat(scalar).take(len), dtype)
+}
+
+fn encode_nodes<'a>(
+    nodes: impl Iterator<Item = &'a IRNode>,
+    dtype: BackendDType,
+) -> Option<Vec<u8>> {
+    let mut bytes = Vec::new();
+    for node in nodes {
+        match (dtype, node) {
+            (BackendDType::I32, IRNode::Integer(value)) => {
+                let value = i32::try_from(*value).ok()?;
+                bytes.extend_from_slice(&value.to_le_bytes());
+            }
+            (BackendDType::F32, IRNode::Integer(value)) => {
+                bytes.extend_from_slice(&(*value as f32).to_le_bytes());
+            }
+            (BackendDType::F32, IRNode::Float(value)) if value.is_finite() => {
+                bytes.extend_from_slice(&(*value as f32).to_le_bytes());
+            }
+            _ => return None,
+        }
+    }
+    Some(bytes)
+}
+
+fn decode_rows(
+    bytes: &[u8],
+    nrows: usize,
+    ncols: usize,
+    dtype: BackendDType,
+) -> MatrixResult<Vec<Vec<IRNode>>> {
+    let mut rows = Vec::with_capacity(nrows);
+    match dtype {
+        BackendDType::I32 => {
+            let expected = nrows * ncols * dtype.size_bytes();
+            if bytes.len() != expected {
+                return Err(MatrixError(format!(
+                    "matrix backend: expected {expected} output bytes, got {}",
+                    bytes.len()
+                )));
+            }
+            for row in 0..nrows {
+                let mut cells = Vec::with_capacity(ncols);
+                for col in 0..ncols {
+                    let offset = (row * ncols + col) * 4;
+                    let arr: [u8; 4] = bytes[offset..offset + 4]
+                        .try_into()
+                        .map_err(|_| MatrixError("matrix backend: malformed i32 output".into()))?;
+                    cells.push(int(i32::from_le_bytes(arr) as i64));
+                }
+                rows.push(cells);
+            }
+        }
+        BackendDType::F32 => {
+            let expected = nrows * ncols * dtype.size_bytes();
+            if bytes.len() != expected {
+                return Err(MatrixError(format!(
+                    "matrix backend: expected {expected} output bytes, got {}",
+                    bytes.len()
+                )));
+            }
+            for row in 0..nrows {
+                let mut cells = Vec::with_capacity(ncols);
+                for col in 0..ncols {
+                    let offset = (row * ncols + col) * 4;
+                    let arr: [u8; 4] = bytes[offset..offset + 4]
+                        .try_into()
+                        .map_err(|_| MatrixError("matrix backend: malformed f32 output".into()))?;
+                    cells.push(flt(f32::from_le_bytes(arr) as f64));
+                }
+                rows.push(cells);
+            }
+        }
+    }
+    Ok(rows)
+}
+
+fn run_unary(
+    op: Op,
+    input_shape: &[usize],
+    output_shape: &[usize],
+    input: Vec<u8>,
+    dtype: BackendDType,
+) -> MatrixResult<Vec<u8>> {
+    run_backend(
+        vec![(TensorId(0), input_shape.to_vec(), input)],
+        TensorId(1),
+        output_shape,
+        dtype,
+        op,
+    )
+}
+
+fn run_binary(
+    op: BackendBinaryOp,
+    shape: &[usize],
+    output_shape: &[usize],
+    lhs: Vec<u8>,
+    rhs: Vec<u8>,
+    dtype: BackendDType,
+) -> MatrixResult<Vec<u8>> {
+    let op = match op {
+        BackendBinaryOp::Add => Op::Add {
+            lhs: TensorId(0),
+            rhs: TensorId(1),
+            output: TensorId(2),
+        },
+        BackendBinaryOp::Sub => Op::Sub {
+            lhs: TensorId(0),
+            rhs: TensorId(1),
+            output: TensorId(2),
+        },
+        BackendBinaryOp::Mul => Op::Mul {
+            lhs: TensorId(0),
+            rhs: TensorId(1),
+            output: TensorId(2),
+        },
+    };
+    run_backend(
+        vec![
+            (TensorId(0), shape.to_vec(), lhs),
+            (TensorId(1), shape.to_vec(), rhs),
+        ],
+        TensorId(2),
+        output_shape,
+        dtype,
+        op,
+    )
+}
+
+fn run_matmul(
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
+    lhs: Vec<u8>,
+    rhs: Vec<u8>,
+    dtype: BackendDType,
+) -> MatrixResult<Vec<u8>> {
+    let output_shape = [lhs_shape[0], rhs_shape[1]];
+    run_backend(
+        vec![
+            (TensorId(0), lhs_shape.to_vec(), lhs),
+            (TensorId(1), rhs_shape.to_vec(), rhs),
+        ],
+        TensorId(2),
+        &output_shape,
+        dtype,
+        Op::MatMul {
+            a: TensorId(0),
+            b: TensorId(1),
+            output: TensorId(2),
+        },
+    )
+}
+
+fn run_backend(
+    inputs: Vec<(TensorId, Vec<usize>, Vec<u8>)>,
+    output_id: TensorId,
+    output_shape: &[usize],
+    dtype: BackendDType,
+    op: Op,
+) -> MatrixResult<Vec<u8>> {
+    let exec = CpuExecutor::new();
+    let mut placed_inputs = Vec::with_capacity(inputs.len());
+    let mut tensors = Vec::with_capacity(inputs.len() + 1);
+
+    for (tensor, shape, bytes) in inputs {
+        let buffer = alloc(&exec, bytes.len())?;
+        upload(&exec, buffer, bytes)?;
+        let placed = placed(tensor, dtype, &shape, buffer)?;
+        placed_inputs.push(placed.clone());
+        tensors.push(placed);
+    }
+
+    let output_bytes = byte_len(output_shape, dtype)?;
+    let output_buffer = alloc(&exec, output_bytes)?;
+    let output = placed(output_id, dtype, output_shape, output_buffer)?;
+    let output_residency = output.residency;
+    tensors.push(output.clone());
+
+    let graph = ComputeGraph {
+        format_version: compute_ir::WIRE_FORMAT_VERSION,
+        inputs: placed_inputs,
+        outputs: vec![output],
+        constants: vec![],
+        ops: vec![
+            PlacedOp::Alloc {
+                residency: output_residency,
+                bytes: output_bytes as u64,
+            },
+            PlacedOp::Compute {
+                op,
+                executor: CPU_EXECUTOR,
+                timing: PlanOpTiming { estimated_ns: 0 },
+            },
+        ],
+        tensors,
+    };
+    graph
+        .validate()
+        .map_err(|err| MatrixError(format!("matrix backend validate: {err:?}")))?;
+
+    match exec.handle(ExecutorRequest::Dispatch { job_id: 1, graph }) {
+        ExecutorResponse::DispatchDone { .. } => {}
+        ExecutorResponse::Error { message, .. } => {
+            return Err(MatrixError(format!("matrix backend dispatch: {message}")));
+        }
+        other => {
+            return Err(MatrixError(format!(
+                "matrix backend dispatch: unexpected response {other:?}"
+            )));
+        }
+    }
+
+    download(&exec, output_buffer, output_bytes)
+}
+
+fn alloc(exec: &CpuExecutor, bytes: usize) -> MatrixResult<BufferId> {
+    match exec.handle(ExecutorRequest::AllocBuffer {
+        bytes: bytes as u64,
+    }) {
+        ExecutorResponse::BufferAllocated { buffer } => Ok(buffer),
+        ExecutorResponse::Error { message, .. } => {
+            Err(MatrixError(format!("matrix backend alloc: {message}")))
+        }
+        other => Err(MatrixError(format!(
+            "matrix backend alloc: unexpected response {other:?}"
+        ))),
+    }
+}
+
+fn upload(exec: &CpuExecutor, buffer: BufferId, data: Vec<u8>) -> MatrixResult<()> {
+    match exec.handle(ExecutorRequest::UploadBuffer {
+        buffer,
+        offset: 0,
+        data,
+    }) {
+        ExecutorResponse::BufferUploaded { .. } => Ok(()),
+        ExecutorResponse::Error { message, .. } => {
+            Err(MatrixError(format!("matrix backend upload: {message}")))
+        }
+        other => Err(MatrixError(format!(
+            "matrix backend upload: unexpected response {other:?}"
+        ))),
+    }
+}
+
+fn download(exec: &CpuExecutor, buffer: BufferId, len: usize) -> MatrixResult<Vec<u8>> {
+    match exec.handle(ExecutorRequest::DownloadBuffer {
+        buffer,
+        offset: 0,
+        len: len as u64,
+    }) {
+        ExecutorResponse::BufferData { data, .. } => Ok(data),
+        ExecutorResponse::Error { message, .. } => {
+            Err(MatrixError(format!("matrix backend download: {message}")))
+        }
+        other => Err(MatrixError(format!(
+            "matrix backend download: unexpected response {other:?}"
+        ))),
+    }
+}
+
+fn placed(
+    id: TensorId,
+    dtype: BackendDType,
+    shape: &[usize],
+    buffer: BufferId,
+) -> MatrixResult<PlacedTensor> {
+    let dims: Result<Vec<u32>, _> = shape.iter().copied().map(u32::try_from).collect();
+    Ok(PlacedTensor {
+        id,
+        dtype: dtype.matrix_dtype(),
+        shape: Shape::from(
+            &dims.map_err(|_| MatrixError("matrix backend: shape too large".into()))?,
+        ),
+        residency: Residency {
+            executor: CPU_EXECUTOR,
+            buffer,
+        },
+    })
+}
+
+fn byte_len(shape: &[usize], dtype: BackendDType) -> MatrixResult<usize> {
+    let elements = shape.iter().try_fold(1usize, |acc, dim| {
+        acc.checked_mul(*dim)
+            .ok_or_else(|| MatrixError("matrix backend: shape overflow".into()))
+    })?;
+    elements
+        .checked_mul(dtype.size_bytes())
+        .ok_or_else(|| MatrixError("matrix backend: byte size overflow".into()))
+}

--- a/code/packages/rust/cas-matrix/src/lib.rs
+++ b/code/packages/rust/cas-matrix/src/lib.rs
@@ -11,9 +11,11 @@
 //!     ... ])
 //! ```
 //!
-//! where every `cell` is an arbitrary `IRNode`.  Arithmetic operations produce
-//! un-simplified IR: each entry is an `IRApply(ADD/SUB/MUL/DIV/NEG, …)`.
-//! Pass results through `cas_simplify::simplify` to reduce numeric entries.
+//! where every `cell` is an arbitrary `IRNode`.  Concrete integer/float
+//! arithmetic uses the shared matrix execution backend (`matrix-ir` →
+//! `compute-ir` → `matrix-cpu`).  Symbolic and exact-rational arithmetic stays
+//! in un-simplified IR: each entry is an `IRApply(ADD/SUB/MUL/DIV/NEG, …)`.
+//! Pass those results through `cas_simplify::simplify` to reduce them.
 //!
 //! ## Quick start
 //!
@@ -45,6 +47,7 @@
 //! ```
 
 pub mod arithmetic;
+mod backend;
 pub mod determinant;
 pub mod lu;
 pub mod matrix;

--- a/code/packages/rust/cas-matrix/tests/tests.rs
+++ b/code/packages/rust/cas-matrix/tests/tests.rs
@@ -9,7 +9,7 @@ use cas_matrix::{
     rank, row_reduce, rowspace, scalar_multiply, sub_matrices, trace, transpose, zero_matrix,
     MatrixError, MATRIX,
 };
-use symbolic_ir::{apply, int, rat, sym, ADD, LIST, SQRT, SUB};
+use symbolic_ir::{apply, flt, int, rat, sym, ADD, LIST, MUL, SQRT, SUB};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -30,6 +30,21 @@ fn matrix_entries(m: &symbolic_ir::IRNode) -> Vec<Vec<(i64, i64)>> {
                     symbolic_ir::IRNode::Integer(value) => (value, 1),
                     symbolic_ir::IRNode::Rational(numer, denom) => (numer, denom),
                     other => panic!("expected numeric entry, got {other:?}"),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn integer_entries(m: &symbolic_ir::IRNode) -> Vec<Vec<i64>> {
+    cas_matrix::rows_of(m)
+        .unwrap()
+        .into_iter()
+        .map(|row| {
+            row.into_iter()
+                .map(|entry| match entry {
+                    symbolic_ir::IRNode::Integer(value) => value,
+                    other => panic!("expected integer entry, got {other:?}"),
                 })
                 .collect()
         })
@@ -182,13 +197,22 @@ fn add_matrices_shape() {
 }
 
 #[test]
-fn add_matrices_entry_is_add_node() {
+fn add_matrices_integer_entries_use_matrix_backend() {
     let a = matrix(vec![irow(&[1, 2])]).unwrap();
     let b = matrix(vec![irow(&[3, 4])]).unwrap();
     let c = add_matrices(&a, &b).unwrap();
-    // Entry (1,1) should be Add(1, 3)
-    let e = get_entry(&c, 1, 1).unwrap();
-    assert_eq!(e, apply(sym(ADD), vec![int(1), int(3)]));
+    assert_eq!(integer_entries(&c), vec![vec![4, 6]]);
+}
+
+#[test]
+fn add_matrices_symbolic_entries_fall_back_to_add_node() {
+    let a = matrix(vec![vec![sym("x")]]).unwrap();
+    let b = matrix(vec![vec![int(3)]]).unwrap();
+    let c = add_matrices(&a, &b).unwrap();
+    assert_eq!(
+        get_entry(&c, 1, 1).unwrap(),
+        apply(sym(ADD), vec![sym("x"), int(3)])
+    );
 }
 
 #[test]
@@ -208,12 +232,22 @@ fn sub_matrices_shape() {
 }
 
 #[test]
-fn sub_matrices_entry_is_sub_node() {
+fn sub_matrices_integer_entries_use_matrix_backend() {
     let a = matrix(vec![irow(&[1, 2])]).unwrap();
     let b = matrix(vec![irow(&[3, 4])]).unwrap();
     let c = sub_matrices(&a, &b).unwrap();
-    let e = get_entry(&c, 1, 1).unwrap();
-    assert_eq!(e, apply(sym(SUB), vec![int(1), int(3)]));
+    assert_eq!(integer_entries(&c), vec![vec![-2, -2]]);
+}
+
+#[test]
+fn sub_matrices_symbolic_entries_fall_back_to_sub_node() {
+    let a = matrix(vec![vec![sym("x")]]).unwrap();
+    let b = matrix(vec![vec![int(3)]]).unwrap();
+    let c = sub_matrices(&a, &b).unwrap();
+    assert_eq!(
+        get_entry(&c, 1, 1).unwrap(),
+        apply(sym(SUB), vec![sym("x"), int(3)])
+    );
 }
 
 #[test]
@@ -222,6 +256,23 @@ fn scalar_multiply_shape() {
     let out = scalar_multiply(&int(3), &m).unwrap();
     assert_eq!(num_rows(&out).unwrap(), 1);
     assert_eq!(num_cols(&out).unwrap(), 2);
+}
+
+#[test]
+fn scalar_multiply_integer_entries_use_matrix_backend() {
+    let m = matrix(vec![irow(&[1, 2])]).unwrap();
+    let out = scalar_multiply(&int(3), &m).unwrap();
+    assert_eq!(integer_entries(&out), vec![vec![3, 6]]);
+}
+
+#[test]
+fn scalar_multiply_symbolic_entries_fall_back_to_mul_node() {
+    let m = matrix(vec![vec![sym("x")]]).unwrap();
+    let out = scalar_multiply(&int(3), &m).unwrap();
+    assert_eq!(
+        get_entry(&out, 1, 1).unwrap(),
+        apply(sym(MUL), vec![int(3), sym("x")])
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +302,40 @@ fn dot_3x3_with_identity_shape() {
     let c = dot(&a, &eye).unwrap();
     assert_eq!(num_rows(&c).unwrap(), 3);
     assert_eq!(num_cols(&c).unwrap(), 3);
+}
+
+#[test]
+fn dot_integer_entries_use_matrix_backend() {
+    let a = matrix(vec![irow(&[1, 2]), irow(&[3, 4])]).unwrap();
+    let b = matrix(vec![irow(&[5, 6]), irow(&[7, 8])]).unwrap();
+    let c = dot(&a, &b).unwrap();
+    assert_eq!(integer_entries(&c), vec![vec![19, 22], vec![43, 50]]);
+}
+
+#[test]
+fn dot_symbolic_entries_fall_back_to_add_mul_nodes() {
+    let a = matrix(vec![vec![sym("x"), int(2)]]).unwrap();
+    let b = matrix(vec![vec![int(3)], vec![int(4)]]).unwrap();
+    let c = dot(&a, &b).unwrap();
+    assert_eq!(
+        get_entry(&c, 1, 1).unwrap(),
+        apply(
+            sym(ADD),
+            vec![
+                apply(sym(MUL), vec![sym("x"), int(3)]),
+                apply(sym(MUL), vec![int(2), int(4)])
+            ]
+        )
+    );
+}
+
+#[test]
+fn float_entries_use_matrix_backend_f32_path() {
+    let a = matrix(vec![vec![flt(1.5), flt(2.0)]]).unwrap();
+    let b = matrix(vec![vec![flt(0.5), flt(4.0)]]).unwrap();
+    let c = add_matrices(&a, &b).unwrap();
+    assert_eq!(get_entry(&c, 1, 1).unwrap(), flt(2.0));
+    assert_eq!(get_entry(&c, 1, 2).unwrap(), flt(6.0));
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/cas-matrix/package-lock.json
+++ b/code/packages/typescript/cas-matrix/package-lock.json
@@ -9,13 +9,23 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
+        "matrix": "file:../matrix"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "../matrix": {
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "ts-jest": "^29.0.0",
+        "typescript": "^5.0.0"
       }
     },
     "../symbolic-ir": {
@@ -1681,6 +1691,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/matrix": {
+      "resolved": "../matrix",
+      "link": true
     },
     "node_modules/minimatch": {
       "version": "10.2.5",

--- a/code/packages/typescript/cas-matrix/package.json
+++ b/code/packages/typescript/cas-matrix/package.json
@@ -13,7 +13,8 @@
   "author": "Adhithya Rajasekaran",
   "license": "MIT",
   "dependencies": {
-    "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+    "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
+    "matrix": "file:../matrix"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/code/packages/typescript/cas-matrix/src/index.ts
+++ b/code/packages/typescript/cas-matrix/src/index.ts
@@ -9,11 +9,13 @@ import {
   app,
   headName,
   int,
+  numberNode,
   rational,
   sym,
   type IRInteger,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
+import { Matrix } from "matrix";
 
 export const MATRIX = "Matrix";
 export const MATRIX_HEAD = sym(MATRIX);
@@ -93,6 +95,10 @@ export function zeroMatrix(nrows: number, ncols: number): IRNode {
 
 export function transpose(node: IRNode): IRNode {
   const rows = rowsOf(node);
+  const backend = tryBackendRows(rows);
+  if (backend !== undefined) {
+    return matrixFromBackend(backend.matrix.transpose(), backend.integerOutput);
+  }
   const nrows = rows.length;
   const ncols = rows[0]?.length ?? 0;
   return matrix(Array.from({ length: ncols }, (_, j) =>
@@ -103,6 +109,10 @@ export function addMatrices(a: IRNode, b: IRNode): IRNode {
   const aRows = rowsOf(a);
   const bRows = rowsOf(b);
   checkSameShape(aRows, bRows, "add");
+  const backend = tryBackendBinary(aRows, bRows);
+  if (backend !== undefined) {
+    return matrixFromBackend(backend.left.add(backend.right), backend.integerOutput);
+  }
   return matrix(elementwise(aRows, bRows, (x, y) => app(ADD, [x, y])));
 }
 
@@ -110,11 +120,20 @@ export function subMatrices(a: IRNode, b: IRNode): IRNode {
   const aRows = rowsOf(a);
   const bRows = rowsOf(b);
   checkSameShape(aRows, bRows, "sub");
+  const backend = tryBackendBinary(aRows, bRows);
+  if (backend !== undefined) {
+    return matrixFromBackend(backend.left.subtract(backend.right), backend.integerOutput);
+  }
   return matrix(elementwise(aRows, bRows, (x, y) => app(SUB, [x, y])));
 }
 
 export function scalarMultiply(scalar: IRNode, node: IRNode): IRNode {
-  return matrix(rowsOf(node).map((row) => row.map((cell) => app(MUL, [scalar, cell]))));
+  const rows = rowsOf(node);
+  const backend = tryBackendScalar(scalar, rows);
+  if (backend !== undefined) {
+    return matrixFromBackend(backend.matrix.scale(backend.scalar), backend.integerOutput);
+  }
+  return matrix(rows.map((row) => row.map((cell) => app(MUL, [scalar, cell]))));
 }
 
 export function trace(node: IRNode): IRNode {
@@ -137,6 +156,10 @@ export function dot(a: IRNode, b: IRNode): IRNode {
   const bRowCount = bRows.length;
   if (aCols !== bRowCount) {
     throw new MatrixError(`dot: cols(A)=${aCols} != rows(B)=${bRowCount}`);
+  }
+  const backend = tryBackendBinary(aRows, bRows);
+  if (backend !== undefined) {
+    return matrixFromBackend(backend.left.dot(backend.right), backend.integerOutput);
   }
   const bCols = bRows[0]?.length ?? 0;
   return matrix(aRows.map((row) =>
@@ -364,6 +387,85 @@ function checkSameShape(a: MatrixRows, b: MatrixRows, op: string): void {
 
 function elementwise(a: MatrixRows, b: MatrixRows, f: (x: IRNode, y: IRNode) => IRNode): MatrixRows {
   return a.map((row, i) => row.map((cell, j) => f(cell, b[i][j])));
+}
+
+interface BackendRows {
+  readonly matrix: Matrix;
+  readonly integerOutput: boolean;
+}
+
+interface BackendBinary {
+  readonly left: Matrix;
+  readonly right: Matrix;
+  readonly integerOutput: boolean;
+}
+
+interface BackendScalar {
+  readonly matrix: Matrix;
+  readonly scalar: number;
+  readonly integerOutput: boolean;
+}
+
+function tryBackendRows(rows: MatrixRows): BackendRows | undefined {
+  let integerOutput = true;
+  const values: number[][] = [];
+  for (const row of rows) {
+    const outRow: number[] = [];
+    for (const cell of row) {
+      const value = nodeToBackendNumber(cell);
+      if (value === undefined) return undefined;
+      if (cell.kind !== "integer") integerOutput = false;
+      outRow.push(value);
+    }
+    values.push(outRow);
+  }
+  return { matrix: new Matrix(values), integerOutput };
+}
+
+function tryBackendBinary(left: MatrixRows, right: MatrixRows): BackendBinary | undefined {
+  const leftBackend = tryBackendRows(left);
+  const rightBackend = tryBackendRows(right);
+  if (leftBackend === undefined || rightBackend === undefined) return undefined;
+  return {
+    left: leftBackend.matrix,
+    right: rightBackend.matrix,
+    integerOutput: leftBackend.integerOutput && rightBackend.integerOutput,
+  };
+}
+
+function tryBackendScalar(scalar: IRNode, rows: MatrixRows): BackendScalar | undefined {
+  const matrixBackend = tryBackendRows(rows);
+  const scalarValue = nodeToBackendNumber(scalar);
+  if (matrixBackend === undefined || scalarValue === undefined) return undefined;
+  return {
+    matrix: matrixBackend.matrix,
+    scalar: scalarValue,
+    integerOutput: matrixBackend.integerOutput && scalar.kind === "integer",
+  };
+}
+
+function nodeToBackendNumber(node: IRNode): number | undefined {
+  switch (node.kind) {
+    case "integer": {
+      const value = Number(node.value);
+      return Number.isSafeInteger(value) && BigInt(value) === node.value ? value : undefined;
+    }
+    case "float":
+      return Number.isFinite(node.value) ? node.value : undefined;
+    default:
+      return undefined;
+  }
+}
+
+function matrixFromBackend(out: Matrix, integerOutput: boolean): IRNode {
+  return matrix(out.data.map((row) => row.map((value) => backendNumberToNode(value, integerOutput))));
+}
+
+function backendNumberToNode(value: number, integerOutput: boolean): IRNode {
+  if (integerOutput && Number.isSafeInteger(value)) {
+    return int(value);
+  }
+  return numberNode(value);
 }
 
 function det(rows: MatrixRows): IRNode {

--- a/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
+++ b/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
@@ -28,7 +28,7 @@ import {
   transpose,
   zeroMatrix,
 } from "../src/index";
-import { ADD, LIST, MUL, SQRT, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { ADD, LIST, MUL, SQRT, SUB, app, equals, int, numberNode, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
 
 function irow(values: readonly number[]): IRNode[] {
   return values.map((value) => int(value));
@@ -98,29 +98,64 @@ describe("arithmetic", () => {
   it("adds and subtracts elementwise", () => {
     const a = matrix([irow([1, 2])]);
     const b = matrix([irow([3, 4])]);
-    expect(equals(getEntry(addMatrices(a, b), 1, 1), app(ADD, [int(1), int(3)]))).toBe(true);
-    expect(equals(getEntry(subMatrices(a, b), 1, 1), app(SUB, [int(1), int(3)]))).toBe(true);
+    expect(equals(getEntry(addMatrices(a, b), 1, 1), int(4))).toBe(true);
+    expect(equals(getEntry(subMatrices(a, b), 1, 1), int(-2))).toBe(true);
     expect(() => addMatrices(a, matrix([irow([1])]))).toThrow(MatrixError);
+  });
+
+  it("falls back to symbolic add and subtract when entries are symbolic", () => {
+    const a = matrix([[sym("x")]]);
+    const b = matrix([[int(3)]]);
+    expect(equals(getEntry(addMatrices(a, b), 1, 1), app(ADD, [sym("x"), int(3)]))).toBe(true);
+    expect(equals(getEntry(subMatrices(a, b), 1, 1), app(SUB, [sym("x"), int(3)]))).toBe(true);
   });
 
   it("scalar-multiplies entries", () => {
     const out = scalarMultiply(int(3), matrix([irow([1, 2])]));
     expect(numRows(out)).toBe(1);
     expect(numCols(out)).toBe(2);
-    expect(equals(getEntry(out, 1, 2), app(MUL, [int(3), int(2)]))).toBe(true);
+    expect(equals(getEntry(out, 1, 2), int(6))).toBe(true);
   });
 
-  it("performs symbolic dot products", () => {
+  it("falls back to symbolic scalar multiplication when entries are symbolic", () => {
+    const out = scalarMultiply(int(3), matrix([[sym("x")]]));
+    expect(numRows(out)).toBe(1);
+    expect(numCols(out)).toBe(1);
+    expect(equals(getEntry(out, 1, 1), app(MUL, [int(3), sym("x")]))).toBe(true);
+  });
+
+  it("uses backend float arithmetic for float matrices", () => {
+    const out = addMatrices(
+      matrix([[numberNode(1.5), numberNode(2)]]),
+      matrix([[numberNode(0.5), numberNode(4)]]),
+    );
+    expect(equals(getEntry(out, 1, 1), numberNode(2))).toBe(true);
+    expect(equals(getEntry(out, 1, 2), numberNode(6))).toBe(true);
+  });
+
+  it("keeps exact rationals in symbolic fallback", () => {
+    const out = scalarMultiply(rational(1, 2), matrix([irow([2])]));
+    expect(equals(getEntry(out, 1, 1), app(MUL, [rational(1, 2), int(2)]))).toBe(true);
+  });
+
+  it("performs backend dot products for integer matrices", () => {
     const a = matrix([irow([1, 2])]);
     const b = matrix([irow([3]), irow([4])]);
     const c = dot(a, b);
     expect(numRows(c)).toBe(1);
     expect(numCols(c)).toBe(1);
+    expect(equals(getEntry(c, 1, 1), int(11))).toBe(true);
+    expect(() => dot(a, matrix([irow([3, 4])]))).toThrow(MatrixError);
+  });
+
+  it("falls back to symbolic dot products when entries are symbolic", () => {
+    const a = matrix([[sym("x"), int(2)]]);
+    const b = matrix([irow([3]), irow([4])]);
+    const c = dot(a, b);
     expect(equals(
       getEntry(c, 1, 1),
-      app(ADD, [app(MUL, [int(1), int(3)]), app(MUL, [int(2), int(4)])]),
+      app(ADD, [app(MUL, [sym("x"), int(3)]), app(MUL, [int(2), int(4)])]),
     )).toBe(true);
-    expect(() => dot(a, matrix([irow([3, 4])]))).toThrow(MatrixError);
   });
 
   it("computes symbolic trace", () => {

--- a/code/packages/typescript/matrix/package.json
+++ b/code/packages/typescript/matrix/package.json
@@ -5,6 +5,14 @@
   "main": "dist/matrix.js",
   "module": "src/matrix.ts",
   "types": "dist/matrix.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/matrix.ts",
+      "import": "./src/matrix.ts",
+      "require": "./dist/matrix.js",
+      "default": "./src/matrix.ts"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "test": "jest"


### PR DESCRIPTION
## Summary
- route Rust `cas-matrix` concrete integer/float transpose, add, subtract, scalar multiply, and dot through the shared `matrix-ir`/`compute-ir`/`matrix-cpu` execution path
- route TypeScript `cas-matrix` concrete numeric operations through the existing pure-TS `matrix` backend while keeping symbolic and exact-rational fallback IR
- expose the TypeScript `matrix` package source entry for workspace/browser consumers and add backend/fallback tests for both CAS packages

## Validation
- `cargo test -p cas-matrix && cargo check -p cas-matrix`
- `cargo test -p matrix-cpu -p compute-ir -p matrix-ir`
- `npm run build && npm test` in `code/packages/typescript/cas-matrix`
- `npm install && npm run build && npm test` in `code/packages/typescript/matrix`