### PR TITLE
Add generic job protocol summary helpers

### DIFF
--- a/code/packages/rust/generic-job-protocol/CHANGELOG.md
+++ b/code/packages/rust/generic-job-protocol/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   exponential backoff, and exhausted-attempt decisions.
 - Added terminal job response status helpers and `JobResponseSummary` for
   compact runtime read models.
+- Added terminal status and response-summary predicates for shared read-side
+  success, failure, retry, cancel, and timeout classification.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/rust/generic-job-protocol/README.md
+++ b/code/packages/rust/generic-job-protocol/README.md
@@ -14,6 +14,8 @@ bridges:
   exponential backoff using the same metadata across runtimes.
 - `JobResponseSummary` captures terminal status, retryability, trace, and attempt
   facts for runtime read models.
+- Terminal status and response-summary helpers provide shared read-side
+  success, failure, retry, cancel, and timeout classification.
 - JSON-line codec helpers provide a phase-one process/stdio wire format.
 
 It intentionally does not implement a thread pool, process pool, TCP runtime, or

--- a/code/packages/rust/generic-job-protocol/src/lib.rs
+++ b/code/packages/rust/generic-job-protocol/src/lib.rs
@@ -407,6 +407,24 @@ pub enum JobTerminalStatus {
     TimedOut,
 }
 
+impl JobTerminalStatus {
+    pub fn is_success(self) -> bool {
+        matches!(self, Self::Ok)
+    }
+
+    pub fn is_failure(self) -> bool {
+        !self.is_success()
+    }
+
+    pub fn is_cancelled(self) -> bool {
+        matches!(self, Self::Cancelled)
+    }
+
+    pub fn is_timed_out(self) -> bool {
+        matches!(self, Self::TimedOut)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct JobResponseSummary {
@@ -417,6 +435,28 @@ pub struct JobResponseSummary {
     pub retryable_error: bool,
     pub error_code: Option<String>,
     pub message: Option<String>,
+}
+
+impl JobResponseSummary {
+    pub fn is_success(&self) -> bool {
+        self.status.is_success()
+    }
+
+    pub fn is_failure(&self) -> bool {
+        self.status.is_failure()
+    }
+
+    pub fn is_retryable_failure(&self) -> bool {
+        self.is_failure() && self.retryable_error
+    }
+
+    pub fn was_cancelled(&self) -> bool {
+        self.status.is_cancelled()
+    }
+
+    pub fn timed_out(&self) -> bool {
+        self.status.is_timed_out()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -796,6 +836,11 @@ mod tests {
 
         assert_eq!(response.terminal_status(), JobTerminalStatus::Error);
         assert!(response.is_failure());
+        assert!(summary.is_failure());
+        assert!(summary.is_retryable_failure());
+        assert!(!summary.is_success());
+        assert!(!summary.was_cancelled());
+        assert!(!summary.timed_out());
         assert_eq!(
             summary,
             JobResponseSummary {
@@ -830,10 +875,56 @@ mod tests {
 
         assert_eq!(ok.terminal_status(), JobTerminalStatus::Ok);
         assert!(ok.is_success());
+        assert!(ok.terminal_status().is_success());
+        assert!(!ok.terminal_status().is_failure());
         assert_eq!(cancelled.terminal_status(), JobTerminalStatus::Cancelled);
         assert!(cancelled.is_failure());
+        assert!(cancelled.terminal_status().is_cancelled());
         assert_eq!(timed_out.terminal_status(), JobTerminalStatus::TimedOut);
         assert!(timed_out.is_failure());
+        assert!(timed_out.terminal_status().is_timed_out());
+    }
+
+    #[test]
+    fn response_summary_helpers_classify_terminal_states() {
+        let ok_summary = JobResponse::ok(
+            "job-1",
+            EchoPayload {
+                text: "done".to_string(),
+            },
+        )
+        .summary();
+        let cancelled_summary: JobResponse<EchoPayload> = JobResponse {
+            id: "job-2".to_string(),
+            result: JobResult::Cancelled {
+                cancellation: JobCancellation {
+                    message: "user stopped job".to_string(),
+                },
+            },
+            metadata: JobMetadata::default(),
+        };
+        let timed_out_summary: JobResponse<EchoPayload> = JobResponse {
+            id: "job-3".to_string(),
+            result: JobResult::TimedOut {
+                timeout: JobTimeout {
+                    message: "deadline exceeded".to_string(),
+                },
+            },
+            metadata: JobMetadata::default(),
+        };
+
+        assert!(ok_summary.is_success());
+        assert!(!ok_summary.is_failure());
+
+        let cancelled_summary = cancelled_summary.summary();
+        assert!(cancelled_summary.is_failure());
+        assert!(cancelled_summary.was_cancelled());
+        assert!(!cancelled_summary.is_retryable_failure());
+
+        let timed_out_summary = timed_out_summary.summary();
+        assert!(timed_out_summary.is_failure());
+        assert!(timed_out_summary.timed_out());
+        assert!(!timed_out_summary.was_cancelled());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add shared terminal status predicates for success, failure, cancellation, and timeout
- add response-summary helpers for read-side retry, cancel, and timeout classification
- document and test protocol-level summary classification helpers

## Tests
- cargo test -p generic-job-protocol
- git diff --check origin/main...HEAD