### PR TITLE
[codex] Expose CoreBluetooth BLE transport to language sessions

### DIFF
--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -74,6 +74,10 @@ function M.bluetooth_backend(endpoint)
     return native().bluetooth_backend(endpoint)
 end
 
+function M.bluetooth_transact(endpoint, frame)
+    return native().bluetooth_transact(endpoint, frame)
+end
+
 function M.bluetooth_devices()
     return native().bluetooth_devices()
 end
@@ -275,6 +279,7 @@ function BluetoothTransport.new(options)
         timeout_ms = options.timeout_ms or 1000,
         backend = backend,
         stream_path = backend.stream_path,
+        native_transport = not not backend.native_transport,
         file = nil,
     }, BluetoothTransport)
 end
@@ -300,11 +305,19 @@ function BluetoothTransport:_io()
 end
 
 function BluetoothTransport:write(frame)
+    if self.native_transport then
+        error("native Board VM Bluetooth transport requires transact(frame, options)")
+    end
+
     assert(self:_io():write(frame))
     assert(self:_io():flush())
 end
 
 function BluetoothTransport:transact(frame, options)
+    if self.native_transport then
+        return M.bluetooth_transact(self.endpoint, frame)
+    end
+
     options = options or {}
     self:write(frame)
     local chunks = {}

--- a/code/packages/lua/board_vm_native/src/lib.rs
+++ b/code/packages/lua/board_vm_native/src/lib.rs
@@ -9,10 +9,10 @@ use board_vm_host::{
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
-    bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
-    build_caps_query_wire_frame, build_hello_wire_frame, build_program_begin_wire_frame,
-    build_program_chunk_wire_frame, build_program_end_wire_frame, build_run_wire_frame,
-    connection_options_for_target, connection_transport_name, detect_target,
+    bluetooth_endpoint_candidates_from_devices, bluetooth_transact_wire_frame, board_family_name,
+    build_blink_module, build_caps_query_wire_frame, build_hello_wire_frame,
+    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
+    build_run_wire_frame, connection_options_for_target, connection_transport_name, detect_target,
     discover_bluetooth_devices as core_discover_bluetooth_devices, discover_devices,
     discover_devices_from_paths, esp_upload_options_for_target, host_endpoint_transport_name,
     known_targets, onboard_led_kind, parse_bluetooth_endpoint as core_parse_bluetooth_endpoint,
@@ -369,6 +369,7 @@ unsafe fn push_bluetooth_backend_open_plan(
     set_str(L, "backend", &plan.backend);
     set_str(L, "status", &plan.status);
     push_optional_str(L, "stream_path", plan.stream_path.as_deref());
+    set_bool(L, "native_transport", plan.native_transport);
     push_optional_str(L, "message", plan.message.as_deref());
 }
 
@@ -570,6 +571,18 @@ unsafe extern "C" fn lua_bluetooth_backend(L: *mut lua_State) -> c_int {
     1
 }
 
+unsafe extern "C" fn lua_bluetooth_transact(L: *mut lua_State) -> c_int {
+    let endpoint = get_str(L, 1).unwrap_or_else(|| raise_error(L, "endpoint must be a string"));
+    let wire = check_bytes(L, 2, "wire_frame");
+    let mut response = vec![0u8; wire.len().saturating_add(4096).max(4096)];
+    let len = core_result(
+        L,
+        bluetooth_transact_wire_frame(&endpoint, &wire, &mut response),
+    );
+    push_bytes(L, &response[..len]);
+    1
+}
+
 unsafe extern "C" fn lua_bluetooth_endpoint_candidates(L: *mut lua_State) -> c_int {
     let devices = read_bluetooth_discovered_devices(L, 1);
     let candidates = bluetooth_endpoint_candidates_from_devices(&devices);
@@ -729,7 +742,7 @@ unsafe extern "C" fn lua_defaults(L: *mut lua_State) -> c_int {
     1
 }
 
-struct FuncTable([luaL_Reg; 20]);
+struct FuncTable([luaL_Reg; 21]);
 unsafe impl Sync for FuncTable {}
 
 static FUNCS: FuncTable = FuncTable([
@@ -752,6 +765,10 @@ static FUNCS: FuncTable = FuncTable([
     luaL_Reg {
         name: b"bluetooth_backend\0".as_ptr() as *const _,
         func: Some(lua_bluetooth_backend),
+    },
+    luaL_Reg {
+        name: b"bluetooth_transact\0".as_ptr() as *const _,
+        func: Some(lua_bluetooth_transact),
     },
     luaL_Reg {
         name: b"bluetooth_endpoint_candidates\0".as_ptr() as *const _,

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -268,6 +268,42 @@ describe("coding_adventures.board_vm_native", function()
         assert.are.equal("bluetooth_classic_rfcomm", transport.backend.endpoint.endpoint_transport)
     end)
 
+    it("delegates native Bluetooth transactions to Rust", function()
+        local endpoint = "ble://uno-r4-wifi/180f/2a19/2a1a"
+        local calls = {}
+        local original = board_vm.bluetooth_transact
+        local ok, err = pcall(function()
+            board_vm.bluetooth_transact = function(actual_endpoint, frame)
+                table.insert(calls, { endpoint = actual_endpoint, frame = frame })
+                return "response"
+            end
+            local transport = board_vm.BluetoothTransport.new({
+                endpoint = endpoint,
+                timeout_ms = 500,
+                backend = {
+                    endpoint = board_vm.bluetooth_endpoint(endpoint),
+                    backend = "macos_core_bluetooth",
+                    status = "ready",
+                    stream_path = nil,
+                    native_transport = true,
+                    message = nil,
+                },
+            })
+
+            assert.is_true(transport.native_transport)
+            assert.are.equal("response", transport:transact("request"))
+            assert.are.equal(endpoint, calls[1].endpoint)
+            assert.are.equal("request", calls[1].frame)
+            assert.has_error(function()
+                transport:write("request")
+            end, "native Board VM Bluetooth transport requires transact(frame, options)")
+        end)
+        board_vm.bluetooth_transact = original
+        if not ok then
+            error(err)
+        end
+    end)
+
     it("connects Bluetooth sessions through Rust backend plans", function()
         local connection = board_vm.connect("esp32", {
             via = "bluetooth_classic",

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -487,6 +487,7 @@ class BluetoothTransport:
         if not self.backend:
             raise ValueError(f"unsupported Board VM Bluetooth endpoint: {self.endpoint}")
         self.stream_path = self.backend.get("stream_path")
+        self.native_transport = bool(self.backend.get("native_transport"))
         self._stream: Any = None
 
     @property
@@ -494,10 +495,16 @@ class BluetoothTransport:
         return str(self.backend.get("status"))
 
     def transact(self, frame: bytes, timeout_ms: int | None = None) -> bytes:
+        if self.native_transport:
+            return bluetooth_transact(self.endpoint, bytes(frame))
+
         self.write(frame)
         return self._read_frame(timeout_ms=self.timeout_ms if timeout_ms is None else int(timeout_ms))
 
     def write(self, frame: bytes) -> None:
+        if self.native_transport:
+            raise OSError("native Board VM Bluetooth transport requires transact(frame, timeout_ms=...)")
+
         try:
             self._io().write(bytes(frame))
             self._io().flush()
@@ -1552,6 +1559,10 @@ def bluetooth_backend(endpoint: str) -> dict[str, Any] | None:
     return value
 
 
+def bluetooth_transact(endpoint: str, frame: bytes | bytearray) -> bytes:
+    return bytes(_native.bluetooth_transact(str(endpoint), bytes(frame)))
+
+
 def bluetooth_devices() -> list[dict[str, Any]]:
     return [dict(device) for device in _native.bluetooth_devices()]
 
@@ -2316,6 +2327,7 @@ __all__ = [
     "bluetooth_devices",
     "bluetooth_endpoint",
     "bluetooth_endpoint_candidates",
+    "bluetooth_transact",
     "connection_option_list",
     "connect",
     "connection_options",

--- a/code/packages/python/board-vm-native/src/lib.rs
+++ b/code/packages/python/board-vm-native/src/lib.rs
@@ -10,12 +10,12 @@ use board_vm_host::{
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
-    bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
-    build_caps_query_wire_frame, build_gpio_handle_close_module, build_gpio_handle_read_module,
-    build_gpio_handle_write_module, build_gpio_open_module, build_gpio_read_module,
-    build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
-    build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
-    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    bluetooth_endpoint_candidates_from_devices, bluetooth_transact_wire_frame, board_family_name,
+    build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
+    build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
+    build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
+    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
+    build_raw_module, build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, connection_transport_name, decode_wire_response,
@@ -513,6 +513,28 @@ unsafe extern "C" fn py_bluetooth_backend(_module: PyObjectPtr, args: PyObjectPt
     }
 }
 
+unsafe extern "C" fn py_bluetooth_transact(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let endpoint = match parse_arg_str(args, 0) {
+        Some(value) => value,
+        None => {
+            set_error(
+                type_error_class(),
+                "bluetooth_transact() requires endpoint as str",
+            );
+            return ptr::null_mut();
+        }
+    };
+    let wire = match parse_arg_bytes(args, 1, "wire_frame") {
+        Some(value) => value,
+        None => return ptr::null_mut(),
+    };
+    let mut response = vec![0u8; wire.len().saturating_add(4096).max(4096)];
+    match bluetooth_transact_wire_frame(&endpoint, &wire, &mut response) {
+        Ok(len) => bytes_to_py(&response[..len]),
+        Err(error) => raise_core_error("bluetooth_transact", error),
+    }
+}
+
 unsafe extern "C" fn py_bluetooth_endpoint_candidates(
     _module: PyObjectPtr,
     args: PyObjectPtr,
@@ -999,6 +1021,7 @@ unsafe fn language_bluetooth_backend_open_plan_to_py(
             .map(|value| str_to_py(value))
             .unwrap_or_else(|| py_none()),
     );
+    dict_set(dict, "native_transport", bool_to_py(plan.native_transport));
     dict_set(
         dict,
         "message",
@@ -1564,7 +1587,7 @@ unsafe fn raise_core_error(context: &str, error: LanguageCoreError) -> PyObjectP
 
 #[no_mangle]
 pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
-    let methods: &'static mut [PyMethodDef; 32] = Box::leak(Box::new([
+    let methods: &'static mut [PyMethodDef; 33] = Box::leak(Box::new([
         PyMethodDef {
             ml_name: b"hello_wire\0".as_ptr() as *const c_char,
             ml_meth: Some(py_hello_wire),
@@ -1720,6 +1743,13 @@ pub unsafe extern "C" fn PyInit_board_vm_native() -> PyObjectPtr {
             ml_meth: Some(py_bluetooth_backend),
             ml_flags: METH_VARARGS,
             ml_doc: b"Plan Board VM Bluetooth backend opening in Rust.\0".as_ptr() as *const c_char,
+        },
+        PyMethodDef {
+            ml_name: b"bluetooth_transact\0".as_ptr() as *const c_char,
+            ml_meth: Some(py_bluetooth_transact),
+            ml_flags: METH_VARARGS,
+            ml_doc: b"Exchange one Board VM Bluetooth wire frame through Rust-owned transport.\0"
+                .as_ptr() as *const c_char,
         },
         PyMethodDef {
             ml_name: b"bluetooth_endpoint_candidates\0".as_ptr() as *const c_char,

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -269,6 +269,37 @@ def test_bluetooth_transport_uses_rust_backend_open_plan():
     assert transport.backend["endpoint"]["endpoint_transport"] == "bluetooth_classic_rfcomm"
 
 
+def test_bluetooth_transport_delegates_native_transact_to_rust(monkeypatch):
+    endpoint = "ble://uno-r4-wifi/180f/2a19/2a1a"
+    calls = []
+
+    def fake_bluetooth_transact(actual_endpoint, frame):
+        calls.append((actual_endpoint, frame))
+        return b"response"
+
+    monkeypatch.setattr(board_vm_native_module, "bluetooth_transact", fake_bluetooth_transact)
+    plan = {
+        "endpoint": bluetooth_endpoint(endpoint),
+        "backend": "macos_core_bluetooth",
+        "status": "ready",
+        "stream_path": None,
+        "native_transport": True,
+        "message": None,
+    }
+
+    transport = BluetoothTransport(endpoint, backend=plan)
+
+    assert transport.native_transport is True
+    assert transport.transact(b"request") == b"response"
+    assert calls == [(endpoint, b"request")]
+    try:
+        transport.write(b"request")
+    except OSError as error:
+        assert "native Board VM Bluetooth transport" in str(error)
+    else:
+        raise AssertionError("expected native Bluetooth write to fail")
+
+
 def test_bluetooth_endpoint_candidates_default_to_host_discovery(monkeypatch):
     monkeypatch.setattr(
         board_vm_native_module._native,

--- a/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
+++ b/code/packages/ruby/board_vm/ext/board_vm_native/src/lib.rs
@@ -11,12 +11,12 @@ use board_vm_host::{
 };
 use board_vm_language_core::{
     bluetooth_backend_open_plan as core_bluetooth_backend_open_plan,
-    bluetooth_endpoint_candidates_from_devices, board_family_name, build_blink_module,
-    build_caps_query_wire_frame, build_gpio_handle_close_module, build_gpio_handle_read_module,
-    build_gpio_handle_write_module, build_gpio_open_module, build_gpio_read_module,
-    build_gpio_write_module, build_hello_wire_frame, build_program_begin_wire_frame,
-    build_program_chunk_wire_frame, build_program_end_wire_frame, build_raw_module,
-    build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
+    bluetooth_endpoint_candidates_from_devices, bluetooth_transact_wire_frame, board_family_name,
+    build_blink_module, build_caps_query_wire_frame, build_gpio_handle_close_module,
+    build_gpio_handle_read_module, build_gpio_handle_write_module, build_gpio_open_module,
+    build_gpio_read_module, build_gpio_write_module, build_hello_wire_frame,
+    build_program_begin_wire_frame, build_program_chunk_wire_frame, build_program_end_wire_frame,
+    build_raw_module, build_run_background_wire_frame, build_run_wire_frame, build_stop_wire_frame,
     build_store_program_wire_frame, build_time_now_module, build_time_sleep_ms_module,
     capability_board_metadata, capability_bytecode_callable, capability_flag_names,
     capability_protocol_feature, connection_transport_name, decode_wire_response,
@@ -442,6 +442,21 @@ extern "C" fn native_bluetooth_backend(_self_val: VALUE, endpoint_val: VALUE) ->
     }
 }
 
+extern "C" fn native_bluetooth_transact(
+    _self_val: VALUE,
+    endpoint_val: VALUE,
+    wire_val: VALUE,
+) -> VALUE {
+    let endpoint = ruby_bridge::str_from_rb(endpoint_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("endpoint must be a Ruby String"));
+    let wire = ruby_bridge::bytes_from_rb(wire_val)
+        .unwrap_or_else(|| ruby_bridge::raise_arg_error("wire frame must be a binary String"));
+    let mut response = vec![0u8; wire.len().saturating_add(4096).max(4096)];
+    let len = bluetooth_transact_wire_frame(&endpoint, &wire, &mut response)
+        .unwrap_or_else(|error| raise_core_error("bluetooth_transact", error));
+    ruby_bridge::bytes_to_rb(&response[..len])
+}
+
 extern "C" fn native_bluetooth_endpoint_candidates(_self_val: VALUE, devices_val: VALUE) -> VALUE {
     let devices = bluetooth_discovered_devices_from_rb(devices_val);
     bluetooth_endpoint_candidates_to_rb(&bluetooth_endpoint_candidates_from_devices(&devices))
@@ -860,6 +875,11 @@ fn bluetooth_backend_open_plan_to_rb(plan: &LanguageBluetoothBackendOpenPlan) ->
             .as_ref()
             .map(|value| ruby_bridge::str_to_rb(value))
             .unwrap_or_else(ruby_bridge::nil_value),
+    );
+    hash_set(
+        hash,
+        "native_transport",
+        ruby_bridge::bool_to_rb(plan.native_transport),
     );
     hash_set(
         hash,
@@ -1394,6 +1414,12 @@ pub extern "C" fn Init_board_vm_native() {
         "bluetooth_backend",
         native_bluetooth_backend as *const c_void,
         1,
+    );
+    ruby_bridge::define_module_function_raw(
+        native,
+        "bluetooth_transact",
+        native_bluetooth_transact as *const c_void,
+        2,
     );
     ruby_bridge::define_module_function_raw(
         native,

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -154,6 +154,10 @@ module CodingAdventures
       Native.bluetooth_backend(endpoint.to_s)
     end
 
+    def bluetooth_transact(endpoint, frame)
+      Native.bluetooth_transact(endpoint.to_s, frame.b)
+    end
+
     def bluetooth_devices
       Native.bluetooth_devices
     end

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm/transport.rb
@@ -231,6 +231,7 @@ module CodingAdventures
         raise TransportError, "unsupported Board VM Bluetooth endpoint #{@endpoint.inspect}" unless @backend
 
         @stream_path = @backend["stream_path"]
+        @native_transport = !!@backend["native_transport"]
         @io = nil
       end
 
@@ -238,12 +239,22 @@ module CodingAdventures
         @backend["status"]
       end
 
+      def native_transport?
+        @native_transport
+      end
+
       def transact(frame, timeout_ms: @timeout_ms)
+        return BoardVM.bluetooth_transact(@endpoint, frame) if native_transport?
+
         write(frame)
         read_frame(timeout_ms: timeout_ms)
       end
 
       def write(frame)
+        if native_transport?
+          raise TransportError, "native Board VM Bluetooth transport requires #transact"
+        end
+
         io.write(frame.b)
         io.flush
       rescue SystemCallError, IOError => e

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -287,6 +287,39 @@ module CodingAdventures
         assert_equal "bluetooth_classic_rfcomm", transport.backend.fetch("endpoint").fetch("endpoint_transport")
       end
 
+      def test_bluetooth_transport_delegates_native_transact_to_rust
+        endpoint = "ble://uno-r4-wifi/180f/2a19/2a1a"
+        calls = []
+        original = BoardVM.method(:bluetooth_transact)
+        verbose = $VERBOSE
+        $VERBOSE = nil
+        BoardVM.define_singleton_method(:bluetooth_transact) do |actual_endpoint, frame|
+          calls << [actual_endpoint, frame]
+          "response".b
+        end
+
+        transport = BluetoothTransport.new(
+          endpoint: endpoint,
+          timeout_ms: 500,
+          backend: {
+            "endpoint" => BoardVM.bluetooth_endpoint(endpoint),
+            "backend" => "macos_core_bluetooth",
+            "status" => "ready",
+            "stream_path" => nil,
+            "native_transport" => true,
+            "message" => nil
+          }
+        )
+
+        assert transport.native_transport?
+        assert_equal "response".b, transport.transact("request".b)
+        assert_equal [[endpoint, "request".b]], calls
+        assert_raises(TransportError) { transport.write("request".b) }
+      ensure
+        BoardVM.define_singleton_method(:bluetooth_transact, original) if original
+        $VERBOSE = verbose
+      end
+
       def test_connect_builds_a_bluetooth_transport_from_rust_backend_plan
         connection = BoardVM.esp32(
           via: "bluetooth_classic",

--- a/code/packages/rust/board-vm-language-core/Cargo.toml
+++ b/code/packages/rust/board-vm-language-core/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 board-vm-bluetooth = { path = "../board-vm-bluetooth" }
+board-vm-client = { path = "../board-vm-client" }
 board-vm-esp-rom = { path = "../board-vm-esp-rom" }
 board-vm-host = { path = "../board-vm-host" }
 board-vm-protocol = { path = "../board-vm-protocol" }

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -19,11 +19,16 @@ use std::str;
 use board_vm_bluetooth::{
     board_vm_endpoint_candidates as board_vm_bluetooth_endpoint_candidates,
     discover_bluetooth_devices as discover_board_vm_bluetooth_devices, macos_rfcomm_device_path,
-    parse_bluetooth_endpoint as parse_board_vm_bluetooth_endpoint, BluetoothDiscoveredDevice,
-    BluetoothEndpoint, BluetoothEndpointCandidate,
+    open_bluetooth_endpoint, parse_bluetooth_endpoint as parse_board_vm_bluetooth_endpoint,
+    BluetoothBackend, BluetoothDiscoveredDevice, BluetoothEndpoint, BluetoothEndpointCandidate,
+    BluetoothOpenError,
 };
 #[cfg(target_os = "macos")]
-use board_vm_bluetooth::{MacosDevRfcommDeviceResolver, MacosRfcommDeviceResolver};
+use board_vm_bluetooth::{
+    MacosBluetoothBackend, MacosCoreBluetoothRuntimeBleConnector, MacosDevRfcommDeviceResolver,
+    MacosRfcommDeviceResolver,
+};
+use board_vm_client::{RawFrameTransport, TransportError};
 use board_vm_esp_rom::{
     DEFAULT_BAUD_RATE as ESP_DEFAULT_BAUD_RATE,
     DEFAULT_FLASH_BLOCK_SIZE as ESP_DEFAULT_FLASH_BLOCK_SIZE,
@@ -76,6 +81,9 @@ pub enum BoardVmLanguageStatusCode {
     ProtocolError = 5,
     HostError = 6,
     Panic = 7,
+    BluetoothEndpointError = 8,
+    BluetoothOpenError = 9,
+    TransportError = 10,
 }
 
 #[repr(C)]
@@ -353,6 +361,7 @@ pub struct LanguageBluetoothBackendOpenPlan {
     pub backend: String,
     pub status: String,
     pub stream_path: Option<String>,
+    pub native_transport: bool,
     pub message: Option<String>,
 }
 
@@ -708,6 +717,7 @@ pub fn bluetooth_backend_open_plan(endpoint: &str) -> Option<LanguageBluetoothBa
                             backend: "macos_rfcomm".to_owned(),
                             status: "unavailable".to_owned(),
                             stream_path: None,
+                            native_transport: false,
                             message: Some(format!(
                                 "macOS RFCOMM device discovery failed: {error:?}"
                             )),
@@ -741,6 +751,54 @@ where
     }
 }
 
+pub fn bluetooth_transact_wire_frame(
+    endpoint: &str,
+    wire_frame: &[u8],
+    response_out: &mut [u8],
+) -> Result<usize, LanguageCoreError> {
+    let endpoint = parse_board_vm_bluetooth_endpoint(endpoint)
+        .map_err(|_| LanguageCoreError::BluetoothEndpoint)?;
+    #[cfg(target_os = "macos")]
+    {
+        let mut backend = MacosBluetoothBackend::with_resolver_and_ble_connector(
+            MacosDevRfcommDeviceResolver,
+            MacosCoreBluetoothRuntimeBleConnector::new(),
+        );
+        bluetooth_transact_wire_frame_with_backend::<_, 4096>(
+            &mut backend,
+            endpoint,
+            wire_frame,
+            response_out,
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (endpoint, wire_frame, response_out);
+        Err(LanguageCoreError::BluetoothOpen)
+    }
+}
+
+pub fn bluetooth_transact_wire_frame_with_backend<B, const WIRE_BYTES: usize>(
+    backend: &mut B,
+    endpoint: BluetoothEndpoint,
+    wire_frame: &[u8],
+    response_out: &mut [u8],
+) -> Result<usize, LanguageCoreError>
+where
+    B: BluetoothBackend,
+{
+    let mut transport = open_bluetooth_endpoint::<_, WIRE_BYTES>(backend, endpoint)?;
+    let mut raw_request = vec![0u8; wire_frame.len().max(64)];
+    let raw_request_len = decode_wire_frame(wire_frame, &mut raw_request)?;
+    let mut raw_response = vec![0u8; response_out.len().max(64)];
+    let raw_response_len =
+        transport.exchange_raw_frame(&raw_request[..raw_request_len], &mut raw_response)?;
+    Ok(encode_wire_frame(
+        &raw_response[..raw_response_len],
+        response_out,
+    )?)
+}
+
 fn language_bluetooth_rfcomm_open_plan_from_paths<I, S>(
     endpoint: board_vm_bluetooth::RfcommEndpoint,
     paths: I,
@@ -760,6 +818,7 @@ where
             backend: "macos_rfcomm".to_owned(),
             status: "ready".to_owned(),
             stream_path: Some(stream_path),
+            native_transport: false,
             message: None,
         },
         None => LanguageBluetoothBackendOpenPlan {
@@ -767,6 +826,7 @@ where
             backend: "macos_rfcomm".to_owned(),
             status: "not_found".to_owned(),
             stream_path: None,
+            native_transport: false,
             message: Some(format!(
                 "no macOS RFCOMM serial device found for {device} channel {channel}"
             )),
@@ -780,18 +840,29 @@ fn language_bluetooth_ble_open_plan(
     let endpoint = language_bluetooth_endpoint(BluetoothEndpoint::BleGatt(endpoint))
         .expect("parsed BLE endpoint should map to language metadata");
     #[cfg(target_os = "macos")]
-    let backend = "macos_core_bluetooth";
+    {
+        LanguageBluetoothBackendOpenPlan {
+            endpoint,
+            backend: "macos_core_bluetooth".to_owned(),
+            status: "ready".to_owned(),
+            stream_path: None,
+            native_transport: true,
+            message: None,
+        }
+    }
     #[cfg(not(target_os = "macos"))]
-    let backend = "unsupported";
-    LanguageBluetoothBackendOpenPlan {
-        endpoint,
-        backend: backend.to_owned(),
-        status: "unavailable".to_owned(),
-        stream_path: None,
-        message: Some(
-            "BLE GATT CoreBluetooth runtime adapter is available in Rust but not exposed through language sessions yet"
-                .to_owned(),
-        ),
+    {
+        LanguageBluetoothBackendOpenPlan {
+            endpoint,
+            backend: "unsupported".to_owned(),
+            status: "unsupported".to_owned(),
+            stream_path: None,
+            native_transport: false,
+            message: Some(format!(
+                "Board VM Bluetooth BLE GATT opening is unsupported on {}",
+                std::env::consts::OS
+            )),
+        }
     }
 }
 
@@ -804,6 +875,7 @@ fn unsupported_bluetooth_backend_open_plan(
         backend: "unsupported".to_owned(),
         status: "unsupported".to_owned(),
         stream_path: None,
+        native_transport: false,
         message: Some(format!(
             "Board VM Bluetooth backend opening is unsupported on {}",
             std::env::consts::OS
@@ -1314,6 +1386,9 @@ pub enum LanguageCoreError {
     OutputTooSmall,
     Protocol(ProtocolError),
     Host(HostError),
+    BluetoothEndpoint,
+    BluetoothOpen,
+    Transport,
 }
 
 impl From<ProtocolError> for LanguageCoreError {
@@ -1330,6 +1405,21 @@ impl From<HostError> for LanguageCoreError {
         match value {
             HostError::OutputTooSmall => Self::OutputTooSmall,
             other => Self::Host(other),
+        }
+    }
+}
+
+impl From<BluetoothOpenError> for LanguageCoreError {
+    fn from(_value: BluetoothOpenError) -> Self {
+        Self::BluetoothOpen
+    }
+}
+
+impl From<TransportError> for LanguageCoreError {
+    fn from(value: TransportError) -> Self {
+        match value {
+            TransportError::ResponseTooLarge => Self::OutputTooSmall,
+            TransportError::Io => Self::Transport,
         }
     }
 }
@@ -2229,6 +2319,27 @@ pub unsafe extern "C" fn board_vm_language_decode_wire_frame(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn board_vm_language_bluetooth_transact_wire_frame(
+    endpoint_ptr: *const u8,
+    endpoint_len: u64,
+    wire_frame: *const u8,
+    wire_frame_len: u64,
+    response_out: *mut u8,
+    response_cap: u64,
+) -> BoardVmLanguageStatus {
+    catch_status(|| {
+        let endpoint = unsafe { utf8_from_ptr(endpoint_ptr, endpoint_len, "endpoint") }?;
+        let wire_frame = unsafe { in_slice(wire_frame, wire_frame_len, "wire_frame") }?;
+        let response_out = unsafe { out_slice(response_out, response_cap, "response_out") }?;
+        let len = bluetooth_transact_wire_frame(endpoint, wire_frame, response_out)?;
+        Ok(BoardVmLanguageStatus {
+            len: len as u64,
+            ..BoardVmLanguageStatus::ok()
+        })
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn board_vm_language_default_program_id() -> u16 {
     DEFAULT_PROGRAM_ID
 }
@@ -2370,6 +2481,9 @@ fn status_code_for_error(error: &LanguageCoreError) -> BoardVmLanguageStatusCode
         LanguageCoreError::OutputTooSmall => BoardVmLanguageStatusCode::OutputTooSmall,
         LanguageCoreError::Protocol(_) => BoardVmLanguageStatusCode::ProtocolError,
         LanguageCoreError::Host(_) => BoardVmLanguageStatusCode::HostError,
+        LanguageCoreError::BluetoothEndpoint => BoardVmLanguageStatusCode::BluetoothEndpointError,
+        LanguageCoreError::BluetoothOpen => BoardVmLanguageStatusCode::BluetoothOpenError,
+        LanguageCoreError::Transport => BoardVmLanguageStatusCode::TransportError,
     }
 }
 
@@ -2489,6 +2603,7 @@ unsafe fn utf8_from_ptr<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use board_vm_bluetooth::{BleGattEndpoint, BleGattIo, BluetoothOpenError, RfcommEndpoint};
     use board_vm_protocol::{
         decode_program_begin, decode_program_chunk, decode_program_end, decode_run_request,
         encode_caps_report, encode_frame, encode_hello_ack, encode_value, encode_wire_frame,
@@ -2496,6 +2611,7 @@ mod tests {
         RunStatus, Value, FLAG_IS_RESPONSE, GOLDEN_HELLO_WIRE_FRAME_BVM_V1,
         RUN_FLAG_BACKGROUND_RUN, RUN_FLAG_KEEP_HANDLES_AFTER_RUN, RUN_FLAG_RESET_VM_BEFORE_RUN,
     };
+    use std::io::{Read, Write};
 
     #[test]
     fn hello_wire_frame_matches_protocol_golden_vector() {
@@ -2702,6 +2818,7 @@ mod tests {
         );
         assert_eq!(plan.endpoint.endpoint, "btspp://ESP32-BoardVM:3");
         assert_eq!(plan.stream_path.as_deref(), Some("/dev/cu.ESP32-BoardVM"));
+        assert!(!plan.native_transport);
         assert_eq!(plan.message, None);
 
         let missing = bluetooth_backend_open_plan_from_rfcomm_paths(
@@ -2712,6 +2829,7 @@ mod tests {
         assert_eq!(missing.backend, "macos_rfcomm");
         assert_eq!(missing.status, "not_found");
         assert_eq!(missing.stream_path, None);
+        assert!(!missing.native_transport);
         assert!(missing
             .message
             .as_deref()
@@ -2723,13 +2841,123 @@ mod tests {
             ["/dev/cu.ESP32-BoardVM"],
         )
         .unwrap();
-        assert_eq!(ble.status, "unavailable");
         assert_eq!(
             ble.endpoint.endpoint_transport,
             LanguageHostEndpointTransport::BluetoothLeGatt
         );
         assert!(ble.stream_path.is_none());
-        assert!(ble.message.as_deref().unwrap().contains("CoreBluetooth"));
+        #[cfg(target_os = "macos")]
+        {
+            assert_eq!(ble.backend, "macos_core_bluetooth");
+            assert_eq!(ble.status, "ready");
+            assert!(ble.native_transport);
+            assert!(ble.message.is_none());
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert_eq!(ble.status, "unsupported");
+            assert!(!ble.native_transport);
+            assert!(ble.message.as_deref().unwrap().contains("unsupported"));
+        }
+    }
+
+    #[test]
+    fn bluetooth_transact_wire_frame_is_owned_by_rust_language_core() {
+        struct FakeBleLink {
+            response: Vec<u8>,
+            writes: Vec<Vec<u8>>,
+        }
+
+        impl BleGattIo for FakeBleLink {
+            fn write_characteristic(
+                &mut self,
+                _characteristic_uuid: &str,
+                bytes: &[u8],
+            ) -> Result<(), board_vm_bluetooth::BluetoothTransportError> {
+                self.writes.push(bytes.to_vec());
+                Ok(())
+            }
+
+            fn read_notification(
+                &mut self,
+                _characteristic_uuid: &str,
+                out: &mut [u8],
+            ) -> Result<usize, board_vm_bluetooth::BluetoothTransportError> {
+                let len = self.response.len();
+                out[..len].copy_from_slice(&self.response);
+                Ok(len)
+            }
+        }
+
+        struct FakeRfcommStream;
+
+        impl Read for FakeRfcommStream {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                Ok(0)
+            }
+        }
+
+        impl Write for FakeRfcommStream {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        struct FakeBackend {
+            response: Vec<u8>,
+            opened_device: Option<String>,
+        }
+
+        impl BluetoothBackend for FakeBackend {
+            type BleGattLink = FakeBleLink;
+            type RfcommStream = FakeRfcommStream;
+
+            fn open_ble_gatt(
+                &mut self,
+                endpoint: &BleGattEndpoint,
+            ) -> Result<Self::BleGattLink, BluetoothOpenError> {
+                self.opened_device = Some(endpoint.device.clone());
+                Ok(FakeBleLink {
+                    response: self.response.clone(),
+                    writes: Vec::new(),
+                })
+            }
+
+            fn open_rfcomm(
+                &mut self,
+                _endpoint: &RfcommEndpoint,
+            ) -> Result<Self::RfcommStream, BluetoothOpenError> {
+                Err(BluetoothOpenError::UnsupportedPlatform { platform: "test" })
+            }
+        }
+
+        let endpoint =
+            parse_board_vm_bluetooth_endpoint("ble://uno-r4-wifi/180f/2a19/2a1a").unwrap();
+        let mut wire_request = [0u8; 32];
+        let wire_request_len = encode_wire_frame(b"request", &mut wire_request).unwrap();
+        let mut wire_response = [0u8; 32];
+        let wire_response_len = encode_wire_frame(b"response", &mut wire_response).unwrap();
+
+        let mut backend = FakeBackend {
+            response: wire_response[..wire_response_len].to_vec(),
+            opened_device: None,
+        };
+        let mut out = [0u8; 32];
+
+        let len = bluetooth_transact_wire_frame_with_backend::<_, 32>(
+            &mut backend,
+            endpoint,
+            &wire_request[..wire_request_len],
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(&out[..len], &wire_response[..wire_response_len]);
+        assert_eq!(backend.opened_device.as_deref(), Some("uno-r4-wifi"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expose Rust-owned Bluetooth wire-frame transactions from board-vm-language-core
- mark macOS BLE backend plans as native transports and route Ruby, Python, and Lua Bluetooth sessions through the Rust transport
- add language-level tests proving native Bluetooth transports use transact instead of file-backed streams

## Validation
- cargo test -p board-vm-bluetooth -p board-vm-language-core -p ruby-bridge -p python-bridge -p lua-bridge
- BUNDLE_PATH=vendor/bundle bash BUILD in code/packages/ruby/board_vm
- bash BUILD in code/packages/python/board-vm-native
- bash BUILD in code/packages/lua/board_vm_native
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check