### PR TITLE
Route TypeScript CAS matrix arithmetic through matrix backend

### DIFF
--- a/code/packages/typescript/cas-matrix/CHANGELOG.md
+++ b/code/packages/typescript/cas-matrix/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Route concrete numeric TypeScript matrix arithmetic through the shared
+  `matrix` backend dispatch point while preserving symbolic and exact-rational
+  fallback behavior.
+
 ## 0.1.0
 
 - Port matrix construction, shape helpers, arithmetic, determinant, and inverse

--- a/code/packages/typescript/cas-matrix/README.md
+++ b/code/packages/typescript/cas-matrix/README.md
@@ -11,6 +11,11 @@ Every cell is an arbitrary `IRNode`. Arithmetic returns symbolic expressions
 such as `Add`, `Sub`, `Mul`, `Div`, and `Neg`; downstream simplification can
 fold numeric entries.
 
+When all relevant entries are concrete integers/floats, transpose,
+addition/subtraction, scalar multiplication, and matrix multiplication route
+through the shared TypeScript `matrix` backend. Symbolic and exact-rational
+inputs keep the CAS fallback paths.
+
 ## Operations
 
 | Function | Description |

--- a/code/packages/typescript/cas-matrix/src/index.ts
+++ b/code/packages/typescript/cas-matrix/src/index.ts
@@ -15,7 +15,7 @@ import {
   type IRInteger,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
-import { Matrix } from "matrix";
+import { Matrix, getMatrixBackend } from "matrix";
 
 export const MATRIX = "Matrix";
 export const MATRIX_HEAD = sym(MATRIX);
@@ -97,7 +97,7 @@ export function transpose(node: IRNode): IRNode {
   const rows = rowsOf(node);
   const backend = tryBackendRows(rows);
   if (backend !== undefined) {
-    return matrixFromBackend(backend.matrix.transpose(), backend.integerOutput);
+    return matrixFromBackend(getMatrixBackend().transpose(backend.matrix), backend.integerOutput);
   }
   const nrows = rows.length;
   const ncols = rows[0]?.length ?? 0;
@@ -111,7 +111,7 @@ export function addMatrices(a: IRNode, b: IRNode): IRNode {
   checkSameShape(aRows, bRows, "add");
   const backend = tryBackendBinary(aRows, bRows);
   if (backend !== undefined) {
-    return matrixFromBackend(backend.left.add(backend.right), backend.integerOutput);
+    return matrixFromBackend(getMatrixBackend().add(backend.left, backend.right), backend.integerOutput);
   }
   return matrix(elementwise(aRows, bRows, (x, y) => app(ADD, [x, y])));
 }
@@ -122,7 +122,7 @@ export function subMatrices(a: IRNode, b: IRNode): IRNode {
   checkSameShape(aRows, bRows, "sub");
   const backend = tryBackendBinary(aRows, bRows);
   if (backend !== undefined) {
-    return matrixFromBackend(backend.left.subtract(backend.right), backend.integerOutput);
+    return matrixFromBackend(getMatrixBackend().subtract(backend.left, backend.right), backend.integerOutput);
   }
   return matrix(elementwise(aRows, bRows, (x, y) => app(SUB, [x, y])));
 }
@@ -131,7 +131,7 @@ export function scalarMultiply(scalar: IRNode, node: IRNode): IRNode {
   const rows = rowsOf(node);
   const backend = tryBackendScalar(scalar, rows);
   if (backend !== undefined) {
-    return matrixFromBackend(backend.matrix.scale(backend.scalar), backend.integerOutput);
+    return matrixFromBackend(getMatrixBackend().scale(backend.matrix, backend.scalar), backend.integerOutput);
   }
   return matrix(rows.map((row) => row.map((cell) => app(MUL, [scalar, cell]))));
 }
@@ -159,7 +159,7 @@ export function dot(a: IRNode, b: IRNode): IRNode {
   }
   const backend = tryBackendBinary(aRows, bRows);
   if (backend !== undefined) {
-    return matrixFromBackend(backend.left.dot(backend.right), backend.integerOutput);
+    return matrixFromBackend(getMatrixBackend().dot(backend.left, backend.right), backend.integerOutput);
   }
   const bCols = bRows[0]?.length ?? 0;
   return matrix(aRows.map((row) =>

--- a/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
+++ b/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
@@ -29,6 +29,7 @@ import {
   zeroMatrix,
 } from "../src/index";
 import { ADD, LIST, MUL, SQRT, SUB, app, equals, int, numberNode, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { Matrix, getMatrixBackend, resetMatrixBackend, setMatrixBackend, type MatrixBackend } from "matrix";
 
 function irow(values: readonly number[]): IRNode[] {
   return values.map((value) => int(value));
@@ -146,6 +147,48 @@ describe("arithmetic", () => {
     expect(numCols(c)).toBe(1);
     expect(equals(getEntry(c, 1, 1), int(11))).toBe(true);
     expect(() => dot(a, matrix([irow([3, 4])]))).toThrow(MatrixError);
+  });
+
+  it("routes numeric matrix arithmetic through the shared matrix backend", () => {
+    const calls: string[] = [];
+    const base = getMatrixBackend();
+    const backend: MatrixBackend = {
+      name: "cas-test-backend",
+      add(left: Matrix, right: Matrix) {
+        calls.push("add");
+        return base.add(left, right);
+      },
+      subtract(left: Matrix, right: Matrix) {
+        calls.push("subtract");
+        return base.subtract(left, right);
+      },
+      scale(mat: Matrix, scalar: number) {
+        calls.push("scale");
+        return base.scale(mat, scalar);
+      },
+      transpose(mat: Matrix) {
+        calls.push("transpose");
+        return base.transpose(mat);
+      },
+      dot(left: Matrix, right: Matrix) {
+        calls.push("dot");
+        return base.dot(left, right);
+      },
+    };
+
+    setMatrixBackend(backend);
+    try {
+      const a = matrix([irow([1, 2])]);
+      const b = matrix([irow([3, 4])]);
+      expect(equals(getEntry(addMatrices(a, b), 1, 2), int(6))).toBe(true);
+      expect(equals(getEntry(scalarMultiply(int(2), a), 1, 1), int(2))).toBe(true);
+      expect(equals(getEntry(transpose(a), 2, 1), int(2))).toBe(true);
+      expect(equals(getEntry(dot(a, matrix([irow([5]), irow([6])])), 1, 1), int(17))).toBe(true);
+    } finally {
+      resetMatrixBackend();
+    }
+
+    expect(calls).toEqual(["add", "scale", "transpose", "dot"]);
   });
 
   it("falls back to symbolic dot products when entries are symbolic", () => {

--- a/code/packages/typescript/matrix/CHANGELOG.md
+++ b/code/packages/typescript/matrix/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the TypeScript matrix package will be documented here.
 
 ## Unreleased
 
+### Added
+- Added a `MatrixBackend` contract plus pure-JS `CpuMatrixBackend` with
+  `getMatrixBackend`, `setMatrixBackend`, and `resetMatrixBackend`, giving
+  browser and host callers a shared dispatch point for dense numeric matrix
+  operations.
+
 ### Changed
 - Exposed `src/matrix.ts` as the package module entry so Vite/browser builds
   can bundle the Matrix implementation as ESM.

--- a/code/packages/typescript/matrix/README.md
+++ b/code/packages/typescript/matrix/README.md
@@ -11,7 +11,7 @@ npm install
 ## Usage
 
 ```typescript
-import { Matrix } from "./src/matrix";
+import { Matrix, getMatrixBackend, setMatrixBackend } from "./src/matrix";
 
 // Construction
 const M = new Matrix([[1, 2, 3], [4, 5, 6]]);
@@ -56,6 +56,10 @@ M.transpose();       // swap rows and columns
 // Equality
 M.equals(other);     // exact element-wise comparison
 M.close(other, 1e-9); // approximate comparison within tolerance
+
+// Backend dispatch
+getMatrixBackend().dot(M, other); // default pure-JS CPU backend
+setMatrixBackend(customBackend);  // host-installed backend for CAS/image callers
 ```
 
 ## Design Principles
@@ -73,5 +77,5 @@ npx jest --verbose
 
 ## Package Structure
 
-- `src/matrix.ts` -- Matrix class with all operations
+- `src/matrix.ts` -- Matrix class, backend contract, and pure-JS CPU backend
 - `tests/matrix.test.ts` -- Jest test suite (47 tests)

--- a/code/packages/typescript/matrix/src/matrix.ts
+++ b/code/packages/typescript/matrix/src/matrix.ts
@@ -31,6 +31,62 @@ function assertMatrixIndex(index: number, limit: number, axis: "row" | "col"): v
   }
 }
 
+/**
+ * Backend contract for dense numeric matrix operations.
+ *
+ * The default implementation is pure JavaScript and delegates to Matrix
+ * methods. Hosts can install a different backend, such as a browser/WebGPU
+ * executor or a native bridge, without changing CAS or image-domain callers.
+ */
+export interface MatrixBackend {
+  readonly name: string;
+
+  add(left: Matrix, right: Matrix): Matrix;
+  subtract(left: Matrix, right: Matrix): Matrix;
+  scale(matrix: Matrix, scalar: number): Matrix;
+  transpose(matrix: Matrix): Matrix;
+  dot(left: Matrix, right: Matrix): Matrix;
+}
+
+export class CpuMatrixBackend implements MatrixBackend {
+  readonly name = "cpu";
+
+  add(left: Matrix, right: Matrix): Matrix {
+    return left.add(right);
+  }
+
+  subtract(left: Matrix, right: Matrix): Matrix {
+    return left.subtract(right);
+  }
+
+  scale(matrix: Matrix, scalar: number): Matrix {
+    return matrix.scale(scalar);
+  }
+
+  transpose(matrix: Matrix): Matrix {
+    return matrix.transpose();
+  }
+
+  dot(left: Matrix, right: Matrix): Matrix {
+    return left.dot(right);
+  }
+}
+
+const CPU_MATRIX_BACKEND = new CpuMatrixBackend();
+let activeMatrixBackend: MatrixBackend = CPU_MATRIX_BACKEND;
+
+export function getMatrixBackend(): MatrixBackend {
+  return activeMatrixBackend;
+}
+
+export function setMatrixBackend(backend: MatrixBackend): void {
+  activeMatrixBackend = backend;
+}
+
+export function resetMatrixBackend(): void {
+  activeMatrixBackend = CPU_MATRIX_BACKEND;
+}
+
 export class Matrix {
   data: number[][];
   rows: number;

--- a/code/packages/typescript/matrix/tests/matrix.test.ts
+++ b/code/packages/typescript/matrix/tests/matrix.test.ts
@@ -1,4 +1,10 @@
-import { Matrix } from "../src/matrix";
+import {
+  Matrix,
+  getMatrixBackend,
+  resetMatrixBackend,
+  setMatrixBackend,
+  type MatrixBackend,
+} from "../src/matrix";
 
 // ─── Original Base Tests ─────────────────────────────────────────────
 
@@ -52,6 +58,53 @@ describe("Matrix Base Operations", () => {
     expect(F.data).toEqual([[32.0]]);
 
     expect(() => A.dot(E)).toThrow("Dot product inner dimensions strictly mismatch.");
+  });
+});
+
+describe("Matrix Backend", () => {
+  afterEach(() => {
+    resetMatrixBackend();
+  });
+
+  it("uses the pure JS CPU backend by default", () => {
+    const backend = getMatrixBackend();
+    expect(backend.name).toBe("cpu");
+    expect(backend.dot(
+      new Matrix([[1, 2]]),
+      new Matrix([[3], [4]]),
+    ).data).toEqual([[11]]);
+  });
+
+  it("allows hosts to install a compatible backend", () => {
+    const calls: string[] = [];
+    const base = getMatrixBackend();
+    const backend: MatrixBackend = {
+      name: "test-backend",
+      add(left, right) {
+        calls.push("add");
+        return base.add(left, right);
+      },
+      subtract(left, right) {
+        calls.push("subtract");
+        return base.subtract(left, right);
+      },
+      scale(matrix, scalar) {
+        calls.push("scale");
+        return base.scale(matrix, scalar);
+      },
+      transpose(matrix) {
+        calls.push("transpose");
+        return base.transpose(matrix);
+      },
+      dot(left, right) {
+        calls.push("dot");
+        return base.dot(left, right);
+      },
+    };
+
+    setMatrixBackend(backend);
+    expect(getMatrixBackend().dot(new Matrix([[2]]), new Matrix([[5]])).data).toEqual([[10]]);
+    expect(calls).toEqual(["dot"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a shared TypeScript `MatrixBackend` contract with a pure-JS CPU implementation and host-installable backend hooks
- route concrete numeric `cas-matrix` transpose/add/subtract/scale/dot operations through the shared backend dispatch point
- keep symbolic and exact-rational CAS fallback behavior unchanged, with tests proving backend dispatch and fallback coverage

## Validation
- `npm test -- --runInBand && npm run build` in `code/packages/typescript/matrix`
- `npm test && npm run build` in `code/packages/typescript/cas-matrix`