### PR TITLE
Add TypeScript quartic solver parity for cas-solve

### DIFF
--- a/code/packages/typescript/cas-solve/CHANGELOG.md
+++ b/code/packages/typescript/cas-solve/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add pure TypeScript quartic solving parity with rational-root deflation,
+  biquadratic solving, and Ferrari factorization through the cubic solver.
 - Add pure TypeScript cubic closed-form solving parity for rational roots,
   repeated roots, quadratic delegation, and Cardano symbolic fallback.
 

--- a/code/packages/typescript/cas-solve/README.md
+++ b/code/packages/typescript/cas-solve/README.md
@@ -12,6 +12,7 @@ bindings.
 | `solveLinear(a, b)` | Solve `a*x + b = 0` |
 | `solveQuadratic(a, b, c)` | Solve `a*x^2 + b*x + c = 0` |
 | `solveCubic(a, b, c, d)` | Solve `a*x^3 + b*x^2 + c*x + d = 0` |
+| `solveQuartic(a, b, c, d, e)` | Solve `a*x^4 + b*x^3 + c*x^2 + d*x + e = 0` |
 
 `solveQuadratic` returns rational roots when the discriminant is a perfect
 square, symbolic `Sqrt` roots for positive irrational discriminants, and `%i`
@@ -22,3 +23,7 @@ quadratic solver so exact rational and repeated roots stay exact. When no
 rational root exists it follows the Python package's Cardano behavior, returning
 symbolic `Cbrt`/`Sqrt` expressions for the one-real-root case and an empty
 solution list for casus irreducibilis.
+
+`solveQuartic` follows the Python package's quartic path: rational-root
+deflation first, biquadratic solving for even quartics, and Ferrari
+factorization when the resolvent cubic has a usable rational root.

--- a/code/packages/typescript/cas-solve/package.json
+++ b/code/packages/typescript/cas-solve/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coding-adventures/cas-solve",
   "version": "0.1.0",
-  "description": "Pure TypeScript closed-form linear and quadratic equation solving over symbolic IR",
+  "description": "Pure TypeScript closed-form linear, quadratic, cubic, and quartic equation solving over symbolic IR",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/code/packages/typescript/cas-solve/src/index.ts
+++ b/code/packages/typescript/cas-solve/src/index.ts
@@ -169,6 +169,81 @@ export function solveCubic(a: Frac, b: Frac, c: Frac, d: Frac): SolveResult {
   return solutions([]);
 }
 
+export function solveQuartic(a: Frac, b: Frac, c: Frac, d: Frac, e: Frac): SolveResult {
+  if (a.isZero()) return solveCubic(b, c, d, e);
+
+  const rationalRoot = findRationalRootQuartic(a, b, c, d, e);
+  if (rationalRoot !== null) {
+    const b2 = b.add(a.mul(rationalRoot));
+    const c2 = c.add(b2.mul(rationalRoot));
+    const d2 = d.add(c2.mul(rationalRoot));
+    const remainder = e.add(d2.mul(rationalRoot));
+    if (remainder.isZero()) {
+      const remaining = solveCubic(a, b2, c2, d2);
+      if (remaining.kind === "all") return solutions([rationalRoot.toIrNode()]);
+      return solutions(dedupRoots([rationalRoot.toIrNode(), ...remaining.roots]));
+    }
+  }
+
+  const two = Frac.fromInt(2);
+  const four = Frac.fromInt(4);
+  const eight = Frac.fromInt(8);
+  const sixteen = Frac.fromInt(16);
+  const twoFiftySix = Frac.fromInt(256);
+  const a2 = a.mul(a);
+  const a3 = a2.mul(a);
+  const a4 = a3.mul(a);
+  const b2 = b.mul(b);
+  const b3 = b2.mul(b);
+  const b4 = b2.mul(b2);
+
+  const p = c.div(a).sub(Frac.fromInt(3).mul(b2).div(eight.mul(a2)));
+  const q = b3.div(eight.mul(a3)).sub(b.mul(c).div(two.mul(a2))).add(d.div(a));
+  const rCoef = Frac.fromInt(-3).mul(b4).div(twoFiftySix.mul(a4))
+    .add(b2.mul(c).div(sixteen.mul(a3)))
+    .sub(b.mul(d).div(four.mul(a2)))
+    .add(e.div(a));
+  const shift = b.neg().div(four.mul(a));
+
+  if (q.isZero()) {
+    const uRoots = solveQuadratic(Frac.one(), p, rCoef);
+    if (uRoots.kind === "all") return solutions([]);
+    return solutions(dedupRoots(uRoots.roots.flatMap((root) => {
+      const t = app(SQRT, [root]);
+      return [addShift(t, shift), addShift(app(NEG, [t]), shift)];
+    })));
+  }
+
+  const ra = Frac.fromInt(8);
+  const rb = Frac.fromInt(8).mul(p);
+  const rc = two.mul(p).mul(p).sub(Frac.fromInt(8).mul(rCoef));
+  const rd = q.mul(q).neg();
+  const resolventRoots = solveCubic(ra, rb, rc, rd);
+  if (resolventRoots.kind === "all" || resolventRoots.roots.length === 0) return solutions([]);
+
+  let m: Frac | null = null;
+  for (const root of resolventRoots.roots) {
+    if (root.kind === "integer") {
+      m = new Frac(root.value);
+      break;
+    }
+    if (root.kind === "rational") {
+      m = new Frac(root.numer, root.denom);
+      break;
+    }
+  }
+  if (m === null || m.isZero()) return solutions([]);
+
+  const alpha = p.div(two).add(m.mul(m).div(two)).sub(q.div(two.mul(m)));
+  const beta = p.div(two).add(m.mul(m).div(two)).add(q.div(two.mul(m)));
+  const roots1 = solveQuadratic(Frac.one(), m, alpha);
+  const roots2 = solveQuadratic(Frac.one(), m.neg(), beta);
+  const shifted: IRNode[] = [];
+  if (roots1.kind === "solutions") shifted.push(...roots1.roots.map((root) => addShift(root, shift)));
+  if (roots2.kind === "solutions") shifted.push(...roots2.roots.map((root) => addShift(root, shift)));
+  return solutions(dedupRoots(shifted));
+}
+
 type SqrtResult =
   | { readonly kind: "rational"; readonly value: Frac }
   | { readonly kind: "irrational"; readonly value: IRNode };
@@ -282,8 +357,35 @@ function findRationalRoot(a: Frac, b: Frac, c: Frac, d: Frac): Frac | null {
   return null;
 }
 
+function findRationalRootQuartic(a: Frac, b: Frac, c: Frac, d: Frac, e: Frac): Frac | null {
+  const scale = fractionDenominatorLcm(a, b, c, d, e);
+  const scaledA = scaleFractionToInteger(a, scale);
+  const scaledE = scaleFractionToInteger(e, scale);
+
+  if (scaledE === 0n) return Frac.zero();
+
+  const pDivs = divisors(abs(scaledE));
+  const qDivs = divisors(abs(scaledA));
+  for (const pValue of pDivs) {
+    for (const qValue of qDivs) {
+      for (const sign of [1n, -1n]) {
+        const candidate = new Frac(sign * pValue, qValue);
+        if (evalQuartic(a, b, c, d, e, candidate).isZero()) return candidate;
+      }
+    }
+  }
+  return null;
+}
+
 function evalCubic(a: Frac, b: Frac, c: Frac, d: Frac, x: Frac): Frac {
   return a.mul(x).mul(x).mul(x).add(b.mul(x).mul(x)).add(c.mul(x)).add(d);
+}
+
+function evalQuartic(a: Frac, b: Frac, c: Frac, d: Frac, e: Frac, x: Frac): Frac {
+  const x2 = x.mul(x);
+  const x3 = x2.mul(x);
+  const x4 = x3.mul(x);
+  return a.mul(x4).add(b.mul(x3)).add(c.mul(x2)).add(d.mul(x)).add(e);
 }
 
 function fractionDenominatorLcm(...values: readonly Frac[]): bigint {

--- a/code/packages/typescript/cas-solve/tests/cas-solve.test.ts
+++ b/code/packages/typescript/cas-solve/tests/cas-solve.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { ADD, DIV, MUL, SQRT, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
-import { ALL_SOLUTIONS, CBRT, Frac, I_UNIT, solveCubic, solveLinear, solveQuadratic, type SolveResult } from "../src/index";
+import {
+  ALL_SOLUTIONS,
+  CBRT,
+  Frac,
+  I_UNIT,
+  solveCubic,
+  solveLinear,
+  solveQuadratic,
+  solveQuartic,
+  type SolveResult,
+} from "../src/index";
 
 function frac(n: number, d: number): Frac {
   return new Frac(n, d);
@@ -139,5 +149,44 @@ describe("solveCubic", () => {
 
   it("leaves casus irreducibilis unevaluated as an empty solution list", () => {
     expectSolutions(solveCubic(fi(1), fi(0), fi(-3), fi(1)), []);
+  });
+});
+
+describe("solveQuartic", () => {
+  it("delegates to cubic when quartic coefficient is zero", () => {
+    expectContainsSolutions(solveQuartic(fi(0), fi(1), fi(-6), fi(11), fi(-6)), [int(1), int(2), int(3)]);
+  });
+
+  it("finds four rational roots through rational-root deflation", () => {
+    expectContainsSolutions(solveQuartic(fi(1), fi(0), fi(-10), fi(0), fi(9)), [int(-3), int(-1), int(1), int(3)]);
+    expectContainsSolutions(solveQuartic(fi(1), fi(-10), fi(35), fi(-50), fi(24)), [int(1), int(2), int(3), int(4)]);
+  });
+
+  it("handles zero roots and deduplicates repeated roots", () => {
+    expectContainsSolutions(solveQuartic(fi(1), fi(-1), fi(0), fi(0), fi(0)), [int(0), int(1)]);
+    expectContainsSolutions(solveQuartic(fi(1), fi(1), fi(0), fi(0), fi(0)), [int(-1), int(0)]);
+  });
+
+  it("uses the biquadratic path for no-rational-root even quartics", () => {
+    const result = solveQuartic(fi(1), fi(0), fi(4), fi(0), fi(3));
+    expect(result.kind).toBe("solutions");
+    if (result.kind === "solutions") {
+      expect(result.roots.length).toBe(4);
+      expect(result.roots.every((root) => containsHead(root, "Sqrt") || containsHead(root, "Neg"))).toBe(true);
+    }
+  });
+
+  it("uses Ferrari factorization when the resolvent has a rational root", () => {
+    const result = solveQuartic(fi(1), fi(0), fi(1), fi(2), fi(6));
+    expect(result.kind).toBe("solutions");
+    if (result.kind === "solutions") {
+      expect(result.roots.length).toBe(4);
+      expect(result.roots.every((root) => root.kind === "apply")).toBe(true);
+      expect(result.roots.some((root) => containsSymbol(root, I_UNIT))).toBe(true);
+    }
+  });
+
+  it("leaves quartics without a usable rational resolvent root unevaluated", () => {
+    expectSolutions(solveQuartic(fi(1), fi(0), fi(0), fi(1), fi(1)), []);
   });
 });


### PR DESCRIPTION
## Summary
- add `solveQuartic` to TypeScript `cas-solve` with rational-root deflation, biquadratic solving, and Ferrari factorization via the cubic solver
- cover delegation, rational roots, zero roots, biquadratic complex roots, Ferrari complex roots, and unevaluated resolvent fallback
- update docs/package metadata to include quartic solving parity

## Validation
- `npm test && npm run build` in `code/packages/typescript/cas-solve`