### PR TITLE
[codex] Add Bluetooth endpoint picker UX

### DIFF
--- a/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
+++ b/code/packages/lua/board_vm_native/src/coding_adventures/board_vm_native/init.lua
@@ -156,21 +156,67 @@ local function bluetooth_endpoint_choice_list(candidates)
     for index, candidate in ipairs(candidates) do
         local endpoint = candidate.endpoint or {}
         local display_name = candidate.display_name or candidate.device or endpoint.endpoint
-        table.insert(lines, tostring(index) .. ". " .. tostring(display_name) .. " - " .. tostring(endpoint.endpoint))
+        local pairing = ""
+        if candidate.requires_pairing then
+            pairing = " [pairing required]"
+        elseif candidate.paired then
+            pairing = " [paired]"
+        end
+        table.insert(lines, tostring(index) .. ". " .. tostring(display_name) .. pairing .. " - " .. tostring(endpoint.endpoint))
     end
     return table.concat(lines, "\n")
 end
 
-function M.bluetooth_connection_endpoint(connection_option, devices)
+local function bluetooth_endpoint_matches(connection_option, devices)
     local matches = {}
     for _, candidate in ipairs(M.bluetooth_endpoint_candidates(devices)) do
         if bluetooth_candidate_matches_connection(candidate, connection_option) then
             table.insert(matches, candidate)
         end
     end
+    return matches
+end
+
+function M.pick_bluetooth_endpoint(connection_option, devices, options)
+    options = options or {}
+    local matches = options.candidates or bluetooth_endpoint_matches(connection_option, devices)
 
     if #matches == 1 then
         return tostring(matches[1].endpoint.endpoint)
+    end
+
+    local display_name = connection_option.display_name or connection_option.transport or "Bluetooth"
+    if #matches == 0 then
+        error(display_name ..
+            " found no Board VM Bluetooth endpoints; pair or power on the board, pass endpoint = ..., or choose via = \"serial\"")
+    end
+
+    local output = options.output or io.stdout
+    output:write(bluetooth_endpoint_choice_list(matches) .. "\n")
+    output:write("Select Bluetooth endpoint [1-" .. tostring(#matches) .. "]: ")
+    local choice = options.input and options.input() or io.read("*l")
+    local index = tonumber(choice)
+    if index == nil or index < 1 or index > #matches then
+        error("Invalid Board VM Bluetooth endpoint selection: " .. string.format("%q", tostring(choice)))
+    end
+
+    return tostring(matches[index].endpoint.endpoint)
+end
+
+function M.bluetooth_connection_endpoint(connection_option, devices, options)
+    options = options or {}
+    local matches = bluetooth_endpoint_matches(connection_option, devices)
+
+    if #matches == 1 then
+        return tostring(matches[1].endpoint.endpoint)
+    end
+
+    if options.pick then
+        return M.pick_bluetooth_endpoint(connection_option, devices, {
+            candidates = matches,
+            input = options.input,
+            output = options.output,
+        })
     end
 
     local display_name = connection_option.display_name or connection_option.transport or "Bluetooth"
@@ -790,7 +836,11 @@ function M.connect(selector, options)
 
     local endpoint = options.endpoint
     if endpoint == nil and connection_uses_bluetooth_endpoint(connection_option) then
-        endpoint = M.bluetooth_connection_endpoint(connection_option, options.bluetooth_devices)
+        endpoint = M.bluetooth_connection_endpoint(connection_option, options.bluetooth_devices, {
+            pick = options.pick or options.pick_bluetooth_endpoint,
+            input = options.input,
+            output = options.output,
+        })
     end
 
     return Connection.new({

--- a/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
+++ b/code/packages/lua/board_vm_native/tests/test_board_vm_native.lua
@@ -155,6 +155,51 @@ describe("coding_adventures.board_vm_native", function()
         )
     end)
 
+    it("prompts for Bluetooth endpoints with pairing status", function()
+        local rendered = {}
+        local output = {
+            write = function(_, text)
+                table.insert(rendered, text)
+            end,
+        }
+        local connection = board_vm.connect("uno-r4-wifi", {
+            via = "BLE",
+            bluetooth_devices = {
+                {
+                    id = "uno-a",
+                    name = "Uno A",
+                    address = "AA:BB:CC:DD:EE:01",
+                    service_uuids = { "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" },
+                },
+                {
+                    id = "uno-b",
+                    name = "Uno B",
+                    address = "AA:BB:CC:DD:EE:02",
+                    paired = true,
+                    service_uuids = { "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" },
+                },
+            },
+            pick_bluetooth_endpoint = true,
+            input = function()
+                return "2"
+            end,
+            output = output,
+        })
+
+        assert.are.equal("bluetooth_le", connection:connection_transport())
+        assert.are.equal(
+            "ble://AA:BB:CC:DD:EE:02" ..
+            "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e" ..
+            "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e" ..
+            "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e",
+            connection.endpoint
+        )
+        local text = table.concat(rendered)
+        assert.is_true(text:find("1. Uno A [pairing required]", 1, true) ~= nil)
+        assert.is_true(text:find("2. Uno B [paired]", 1, true) ~= nil)
+        assert.is_true(text:find("Select Bluetooth endpoint [1-2]: ", 1, true) ~= nil)
+    end)
+
     it("classifies host devices through Rust-owned discovery rules", function()
         local devices = board_vm.devices({
             "/dev/cu.usbmodem1101",

--- a/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
+++ b/code/packages/python/board-vm-native/src/board_vm_native/__init__.py
@@ -1612,15 +1612,21 @@ def bluetooth_connection_endpoint(
     connection_option: dict[str, Any],
     *,
     devices: Iterable[dict[str, Any]] | None = None,
+    pick: bool = False,
+    input_func: Any = input,
+    output: Any = None,
 ) -> str:
     option = dict(connection_option)
-    matches = [
-        candidate
-        for candidate in bluetooth_endpoint_candidates(devices)
-        if _bluetooth_candidate_matches_connection(candidate, option)
-    ]
+    matches = _bluetooth_endpoint_matches(option, devices)
     if len(matches) == 1:
         return str(matches[0]["endpoint"]["endpoint"])
+    if pick:
+        return pick_bluetooth_endpoint(
+            option,
+            candidates=matches,
+            input_func=input_func,
+            output=output,
+        )
 
     display_name = option.get("display_name") or option.get("transport") or "Bluetooth"
     if not matches:
@@ -1633,6 +1639,40 @@ def bluetooth_connection_endpoint(
         f"Multiple Board VM Bluetooth endpoints match {display_name}; pass endpoint=...\n"
         f"{_bluetooth_endpoint_choice_list(matches)}"
     )
+
+
+def pick_bluetooth_endpoint(
+    connection_option: dict[str, Any],
+    *,
+    devices: Iterable[dict[str, Any]] | None = None,
+    candidates: Iterable[dict[str, Any]] | None = None,
+    input_func: Any = input,
+    output: Any = None,
+) -> str:
+    option = dict(connection_option)
+    matches = list(candidates) if candidates is not None else _bluetooth_endpoint_matches(option, devices)
+    if len(matches) == 1:
+        return str(matches[0]["endpoint"]["endpoint"])
+
+    display_name = option.get("display_name") or option.get("transport") or "Bluetooth"
+    if not matches:
+        raise ValueError(
+            f"{display_name} found no Board VM Bluetooth endpoints; "
+            "pair or power on the board, pass endpoint=..., or choose via='serial'"
+        )
+
+    output = sys.stdout if output is None else output
+    output.write(_bluetooth_endpoint_choice_list(matches))
+    output.write("\n")
+    output.write(f"Select Bluetooth endpoint [1-{len(matches)}]: ")
+    choice = input_func("")
+    try:
+        index = int(str(choice).strip())
+    except ValueError as error:
+        raise ValueError(f"Invalid Board VM Bluetooth endpoint selection: {choice!r}") from error
+    if not 1 <= index <= len(matches):
+        raise ValueError(f"Invalid Board VM Bluetooth endpoint selection: {choice!r}")
+    return str(matches[index - 1]["endpoint"]["endpoint"])
 
 
 def _bluetooth_device_field(device: Any, key: str) -> Any:
@@ -1673,6 +1713,17 @@ def _bluetooth_candidate_matches_connection(
     )
 
 
+def _bluetooth_endpoint_matches(
+    connection_option: dict[str, Any],
+    devices: Iterable[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    return [
+        candidate
+        for candidate in bluetooth_endpoint_candidates(devices)
+        if _bluetooth_candidate_matches_connection(candidate, connection_option)
+    ]
+
+
 def _bluetooth_endpoint_choice_list(candidates: Iterable[dict[str, Any]]) -> str:
     lines = []
     for index, candidate in enumerate(candidates, start=1):
@@ -1682,8 +1733,18 @@ def _bluetooth_endpoint_choice_list(candidates: Iterable[dict[str, Any]]) -> str
             or candidate.get("device")
             or endpoint["endpoint"]
         )
-        lines.append(f"{index}. {display_name} - {endpoint['endpoint']}")
+        lines.append(
+            f"{index}. {display_name}{_bluetooth_candidate_pairing_status(candidate)} - {endpoint['endpoint']}"
+        )
     return "\n".join(lines)
+
+
+def _bluetooth_candidate_pairing_status(candidate: dict[str, Any]) -> str:
+    if candidate.get("requires_pairing"):
+        return " [pairing required]"
+    if candidate.get("paired"):
+        return " [paired]"
+    return ""
 
 
 def connection_options(selector: str) -> list[dict[str, Any]]:
@@ -2085,6 +2146,7 @@ def connect(
     endpoint: str | None = None,
     bluetooth_devices: Iterable[dict[str, Any]] | None = None,
     bluetooth_backend_plan: dict[str, Any] | None = None,
+    pick_bluetooth_endpoint: bool = False,
     timeout_ms: int = DEFAULT_TIMEOUT_MS,
     runner: Any = None,
     cargo_workspace: str | pathlib.Path | None = None,
@@ -2153,6 +2215,9 @@ def connect(
         selected_endpoint = bluetooth_connection_endpoint(
             selected_connection_option,
             devices=bluetooth_devices,
+            pick=pick or pick_bluetooth_endpoint,
+            input_func=input_func,
+            output=output,
         )
     connection = Connection(
         target=target,
@@ -2342,6 +2407,7 @@ __all__ = [
     "known_targets",
     "pico",
     "pico_w",
+    "pick_bluetooth_endpoint",
     "pick_connection_option",
     "pico_uf2_mount",
     "pico_uf2_upload_command",

--- a/code/packages/python/board-vm-native/tests/test_board_vm_native.py
+++ b/code/packages/python/board-vm-native/tests/test_board_vm_native.py
@@ -35,6 +35,7 @@ from board_vm_native import (
     pico_uf2_mounts,
     pico_uf2_upload_options,
     pick_connection_option,
+    pick_bluetooth_endpoint,
     pick_device,
     pico,
     runtime_devices,
@@ -348,6 +349,45 @@ def test_bluetooth_connection_endpoint_filters_to_the_selected_transport():
         "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e"
         "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e"
     )
+
+
+def test_connect_can_prompt_for_bluetooth_endpoint_with_pairing_status():
+    output = io.StringIO()
+
+    connection = connect(
+        "uno-r4-wifi",
+        via="BLE",
+        bluetooth_devices=[
+            {
+                "id": "uno-a",
+                "name": "Uno A",
+                "address": "AA:BB:CC:DD:EE:01",
+                "service_uuids": ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"],
+            },
+            {
+                "id": "uno-b",
+                "name": "Uno B",
+                "address": "AA:BB:CC:DD:EE:02",
+                "paired": True,
+                "service_uuids": ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"],
+            },
+        ],
+        pick_bluetooth_endpoint=True,
+        input_func=lambda _prompt: "2",
+        output=output,
+    )
+
+    assert connection.connection_transport == "bluetooth_le"
+    assert connection.endpoint == (
+        "ble://AA:BB:CC:DD:EE:02"
+        "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+        "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+        "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+    )
+    rendered = output.getvalue()
+    assert "1. Uno A [pairing required]" in rendered
+    assert "2. Uno B [paired]" in rendered
+    assert "Select Bluetooth endpoint [1-2]: " in rendered
 
 
 def test_connection_options_can_be_selected_without_exposing_ports():

--- a/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
+++ b/code/packages/ruby/board_vm/lib/coding_adventures/board_vm.rb
@@ -182,13 +182,12 @@ module CodingAdventures
       Native.bluetooth_endpoint_candidates(normalized)
     end
 
-    def bluetooth_connection_endpoint(connection_option, devices: nil)
+    def bluetooth_connection_endpoint(connection_option, devices: nil, pick: false, input: $stdin, output: $stdout)
       option = normalize_connection_option_hash(connection_option)
-      matches = bluetooth_endpoint_candidates(devices).select do |candidate|
-        bluetooth_candidate_matches_connection?(candidate, option)
-      end
+      matches = bluetooth_endpoint_matches(option, devices)
 
       return matches.first.fetch("endpoint").fetch("endpoint").to_s if matches.length == 1
+      return pick_bluetooth_endpoint(option, candidates: matches, input: input, output: output) if pick
 
       display_name = option["display_name"] || option["transport"] || "Bluetooth"
       if matches.empty?
@@ -200,6 +199,29 @@ module CodingAdventures
       raise DeviceSelectionError,
         "Multiple Board VM Bluetooth endpoints match #{display_name}; pass endpoint: ...\n" \
         "#{bluetooth_endpoint_choice_list(matches)}"
+    end
+
+    def pick_bluetooth_endpoint(connection_option, devices: nil, candidates: nil, input: $stdin, output: $stdout)
+      option = normalize_connection_option_hash(connection_option)
+      matches = candidates || bluetooth_endpoint_matches(option, devices)
+      return matches.first.fetch("endpoint").fetch("endpoint").to_s if matches.length == 1
+
+      display_name = option["display_name"] || option["transport"] || "Bluetooth"
+      if matches.empty?
+        raise DeviceSelectionError,
+          "#{display_name} found no Board VM Bluetooth endpoints; " \
+          "pair or power on the board, pass endpoint: ..., or choose via: :serial"
+      end
+
+      output.puts bluetooth_endpoint_choice_list(matches)
+      output.print "Select Bluetooth endpoint [1-#{matches.length}]: "
+      choice = input.gets
+      index = Integer(choice.to_s.strip, exception: false)
+      unless index && index.between?(1, matches.length)
+        raise DeviceSelectionError, "Invalid Board VM Bluetooth endpoint selection: #{choice.inspect}"
+      end
+
+      matches.fetch(index - 1).fetch("endpoint").fetch("endpoint").to_s
     end
 
     def connection_options(board)
@@ -373,6 +395,7 @@ module CodingAdventures
       via: nil,
       connection_option: nil,
       pick_connection: false,
+      pick_bluetooth_endpoint: false,
       **options
     )
       selection = connection_selection(
@@ -392,7 +415,10 @@ module CodingAdventures
       if resolved_endpoint.nil? && connection_uses_bluetooth_endpoint?(selection.fetch(:connection_option))
         resolved_endpoint = bluetooth_connection_endpoint(
           selection.fetch(:connection_option),
-          devices: bluetooth_devices
+          devices: bluetooth_devices,
+          pick: pick || pick_bluetooth_endpoint,
+          input: input,
+          output: output
         )
       end
       connection = Connection.new(
@@ -545,12 +571,27 @@ module CodingAdventures
         (endpoint_scheme && endpoint["endpoint_scheme"] == endpoint_scheme)
     end
 
+    def bluetooth_endpoint_matches(connection_option, devices)
+      option = normalize_connection_option_hash(connection_option)
+      bluetooth_endpoint_candidates(devices).select do |candidate|
+        bluetooth_candidate_matches_connection?(candidate, option)
+      end
+    end
+
     def bluetooth_endpoint_choice_list(candidates)
       candidates.each_with_index.map do |candidate, index|
         endpoint = candidate.fetch("endpoint")
         display_name = candidate["display_name"] || candidate["device"] || endpoint.fetch("endpoint")
-        "#{index + 1}. #{display_name} - #{endpoint.fetch("endpoint")}"
+        pairing = bluetooth_candidate_pairing_status(candidate)
+        "#{index + 1}. #{display_name}#{pairing} - #{endpoint.fetch("endpoint")}"
       end.join("\n")
+    end
+
+    def bluetooth_candidate_pairing_status(candidate)
+      return " [pairing required]" if candidate["requires_pairing"]
+      return " [paired]" if candidate["paired"]
+
+      ""
     end
 
     def flash_without_port?(board, flash)

--- a/code/packages/ruby/board_vm/test/test_board_vm.rb
+++ b/code/packages/ruby/board_vm/test/test_board_vm.rb
@@ -179,6 +179,43 @@ module CodingAdventures
           "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e", endpoint
       end
 
+      def test_connect_can_prompt_for_bluetooth_endpoint_with_pairing_status
+        output = StringIO.new
+
+        connection = BoardVM.uno_r4_wifi(
+          via: "BLE",
+          bluetooth_devices: [
+            {
+              "id" => "uno-a",
+              "name" => "Uno A",
+              "address" => "AA:BB:CC:DD:EE:01",
+              "service_uuids" => ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"]
+            },
+            {
+              "id" => "uno-b",
+              "name" => "Uno B",
+              "address" => "AA:BB:CC:DD:EE:02",
+              "paired" => true,
+              "service_uuids" => ["6E400001-B5A3-F393-E0A9-E50E24DCCA9E"]
+            }
+          ],
+          pick_bluetooth_endpoint: true,
+          input: StringIO.new("2\n"),
+          output: output,
+          cargo_workspace: "/repo/code/packages/rust",
+          runner: FakeRunner.new
+        )
+
+        assert_equal "bluetooth_le", connection.connection_transport
+        assert_equal "ble://AA:BB:CC:DD:EE:02" \
+          "?service=6e400001-b5a3-f393-e0a9-e50e24dcca9e" \
+          "&write=6e400002-b5a3-f393-e0a9-e50e24dcca9e" \
+          "&notify=6e400003-b5a3-f393-e0a9-e50e24dcca9e", connection.endpoint
+        assert_includes output.string, "1. Uno A [pairing required]"
+        assert_includes output.string, "2. Uno B [paired]"
+        assert_includes output.string, "Select Bluetooth endpoint [1-2]: "
+      end
+
       def test_connection_options_can_be_selected_without_exposing_ports
         default = BoardVM.select_connection_option(:uno_r4_wifi)
         wifi = BoardVM.select_connection_option(:uno_r4_wifi, transport: :wifi)


### PR DESCRIPTION
## Summary
- add promptable Bluetooth endpoint picker helpers for Ruby, Python, and Lua
- annotate endpoint choice lists with paired or pairing-required state
- let language `connect` flows opt into endpoint prompting with `pick_bluetooth_endpoint`

## Validation
- `BUNDLE_PATH=vendor/bundle bash BUILD` in `code/packages/ruby/board_vm`
- `bash BUILD` in `code/packages/python/board-vm-native`
- `bash BUILD` in `code/packages/lua/board_vm_native`
- `cargo test -p board-vm-bluetooth -p board-vm-language-core -p ruby-bridge -p python-bridge -p lua-bridge` in `code/packages/rust`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
