### PR TITLE
Add TypeScript numeric polynomial solving for cas-solve

### DIFF
--- a/code/packages/typescript/cas-solve/CHANGELOG.md
+++ b/code/packages/typescript/cas-solve/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add pure TypeScript Durand-Kerner numeric polynomial solving plus IR
+  conversion helpers for numeric roots.
 - Add pure TypeScript quartic solving parity with rational-root deflation,
   biquadratic solving, and Ferrari factorization through the cubic solver.
 - Add pure TypeScript cubic closed-form solving parity for rational roots,

--- a/code/packages/typescript/cas-solve/README.md
+++ b/code/packages/typescript/cas-solve/README.md
@@ -13,6 +13,8 @@ bindings.
 | `solveQuadratic(a, b, c)` | Solve `a*x^2 + b*x + c = 0` |
 | `solveCubic(a, b, c, d)` | Solve `a*x^3 + b*x^2 + c*x + d = 0` |
 | `solveQuartic(a, b, c, d, e)` | Solve `a*x^4 + b*x^3 + c*x^2 + d*x + e = 0` |
+| `nsolvePoly(coeffs)` | Numerically solve a polynomial via Durand-Kerner |
+| `rootsToIr(roots)` / `nsolveFractionPoly(coeffs)` | Convert numeric roots to symbolic IR |
 
 `solveQuadratic` returns rational roots when the discriminant is a perfect
 square, symbolic `Sqrt` roots for positive irrational discriminants, and `%i`
@@ -27,3 +29,8 @@ solution list for casus irreducibilis.
 `solveQuartic` follows the Python package's quartic path: rational-root
 deflation first, biquadratic solving for even quartics, and Ferrari
 factorization when the resolvent cubic has a usable rational root.
+
+`nsolvePoly` accepts real or complex coefficients in descending degree order,
+normalizes by the leading coefficient, and returns all roots as `{ re, im }`
+objects. `nsolveFractionPoly` is a convenience wrapper for exact `Frac`
+coefficients that returns IR float/complex roots.

--- a/code/packages/typescript/cas-solve/package.json
+++ b/code/packages/typescript/cas-solve/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coding-adventures/cas-solve",
   "version": "0.1.0",
-  "description": "Pure TypeScript closed-form linear, quadratic, cubic, and quartic equation solving over symbolic IR",
+  "description": "Pure TypeScript closed-form and numeric polynomial equation solving over symbolic IR",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/code/packages/typescript/cas-solve/src/index.ts
+++ b/code/packages/typescript/cas-solve/src/index.ts
@@ -1,4 +1,4 @@
-import { ADD, DIV, MUL, NEG, SQRT, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { ADD, DIV, MUL, NEG, SQRT, SUB, app, equals, int, numberNode, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
 
 export const SOLVE = "Solve";
 export const NSOLVE = "NSolve";
@@ -7,6 +7,11 @@ export const I_UNIT = "%i";
 export const CBRT = "Cbrt";
 
 export type IntegerLike = bigint | number | string;
+
+export interface Complex {
+  readonly re: number;
+  readonly im: number;
+}
 
 export type SolveResult =
   | { readonly kind: "solutions"; readonly roots: readonly IRNode[] }
@@ -244,6 +249,60 @@ export function solveQuartic(a: Frac, b: Frac, c: Frac, d: Frac, e: Frac): Solve
   return solutions(dedupRoots(shifted));
 }
 
+export function nsolvePoly(
+  coeffs: readonly (number | Complex)[],
+  maxIter = 200,
+  tol = 1e-12,
+): readonly Complex[] {
+  const degree = coeffs.length - 1;
+  if (degree <= 0) return [];
+
+  const lead = toComplex(coeffs[0]);
+  if (complexAbs(lead) === 0) throw new RangeError("nsolvePoly: leading coefficient must not be zero");
+  const poly = coeffs.map((coef) => complexDiv(toComplex(coef), lead));
+
+  if (degree === 1) {
+    return [complexNeg(poly[1])];
+  }
+
+  const radius = initialRadius(poly);
+  let roots = Array.from({ length: degree }, (_, k) => {
+    const theta = (2 * Math.PI * k) / degree + 0.1;
+    return complex(radius * Math.cos(theta), radius * Math.sin(theta));
+  });
+
+  for (let iter = 0; iter < maxIter; iter += 1) {
+    let maxDelta = 0;
+    const next = [...roots];
+    for (let i = 0; i < degree; i += 1) {
+      const z = roots[i];
+      let denom = complex(1, 0);
+      for (let j = 0; j < degree; j += 1) {
+        if (i === j) continue;
+        const diff = complexSub(z, roots[j]);
+        denom = complexMul(denom, complexAbs(diff) < 1e-300 ? complex(1e-300, 0) : diff);
+      }
+      const delta = complexDiv(evalPoly(poly, z), denom);
+      next[i] = complexSub(z, delta);
+      maxDelta = Math.max(maxDelta, complexAbs(delta));
+    }
+    roots = next;
+    if (maxDelta < tol) break;
+  }
+  return roots;
+}
+
+export function rootsToIr(roots: readonly Complex[]): readonly IRNode[] {
+  return roots.map((root) => {
+    if (Math.abs(root.im) < 1e-10) return numberNode(root.re);
+    return app(ADD, [numberNode(root.re), app(MUL, [numberNode(root.im), sym(I_UNIT)])]);
+  });
+}
+
+export function nsolveFractionPoly(coeffs: readonly Frac[]): readonly IRNode[] {
+  return rootsToIr(nsolvePoly(coeffs.map((coef) => Number(coef.numer) / Number(coef.denom))));
+}
+
 type SqrtResult =
   | { readonly kind: "rational"; readonly value: Frac }
   | { readonly kind: "irrational"; readonly value: IRNode };
@@ -386,6 +445,53 @@ function evalQuartic(a: Frac, b: Frac, c: Frac, d: Frac, e: Frac, x: Frac): Frac
   const x3 = x2.mul(x);
   const x4 = x3.mul(x);
   return a.mul(x4).add(b.mul(x3)).add(c.mul(x2)).add(d.mul(x)).add(e);
+}
+
+function complex(re: number, im: number): Complex {
+  return Object.freeze({ re, im });
+}
+
+function toComplex(value: number | Complex): Complex {
+  return typeof value === "number" ? complex(value, 0) : value;
+}
+
+function complexAdd(lhs: Complex, rhs: Complex): Complex {
+  return complex(lhs.re + rhs.re, lhs.im + rhs.im);
+}
+
+function complexSub(lhs: Complex, rhs: Complex): Complex {
+  return complex(lhs.re - rhs.re, lhs.im - rhs.im);
+}
+
+function complexNeg(value: Complex): Complex {
+  return complex(-value.re, -value.im);
+}
+
+function complexMul(lhs: Complex, rhs: Complex): Complex {
+  return complex(lhs.re * rhs.re - lhs.im * rhs.im, lhs.re * rhs.im + lhs.im * rhs.re);
+}
+
+function complexDiv(lhs: Complex, rhs: Complex): Complex {
+  const denom = rhs.re * rhs.re + rhs.im * rhs.im;
+  if (denom === 0) throw new RangeError("complex division by zero");
+  return complex((lhs.re * rhs.re + lhs.im * rhs.im) / denom, (lhs.im * rhs.re - lhs.re * rhs.im) / denom);
+}
+
+function complexAbs(value: Complex): number {
+  return Math.hypot(value.re, value.im);
+}
+
+function evalPoly(poly: readonly Complex[], z: Complex): Complex {
+  return poly.reduce((acc, coef) => complexAdd(complexMul(acc, z), coef), complex(0, 0));
+}
+
+function initialRadius(poly: readonly Complex[]): number {
+  const degree = poly.length - 1;
+  if (degree <= 0) return 1;
+  const cauchy = 1 + Math.max(...poly.slice(1).map(complexAbs));
+  const constant = complexAbs(poly[degree]);
+  const lagrange = constant > 1e-300 ? constant ** (1 / degree) : 1;
+  return Math.max(Math.min(cauchy, 10), lagrange, 0.5);
 }
 
 function fractionDenominatorLcm(...values: readonly Frac[]): bigint {

--- a/code/packages/typescript/cas-solve/tests/cas-solve.test.ts
+++ b/code/packages/typescript/cas-solve/tests/cas-solve.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { ADD, DIV, MUL, SQRT, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { ADD, DIV, MUL, SQRT, app, equals, int, numberNode, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
 import {
   ALL_SOLUTIONS,
   CBRT,
   Frac,
   I_UNIT,
+  nsolveFractionPoly,
+  nsolvePoly,
+  rootsToIr,
   solveCubic,
   solveLinear,
   solveQuadratic,
@@ -44,6 +47,21 @@ function containsSymbol(node: IRNode, name: string): boolean {
 function containsHead(node: IRNode, name: string): boolean {
   return node.kind === "apply"
     && ((node.head.kind === "symbol" && node.head.name === name) || node.args.some((arg) => containsHead(arg, name)));
+}
+
+function expectNumericRootsClose(
+  computed: readonly { readonly re: number; readonly im: number }[],
+  expected: readonly { readonly re: number; readonly im: number }[],
+  tol = 1e-8,
+): void {
+  expect(computed.length).toBe(expected.length);
+  const used = new Array(expected.length).fill(false);
+  for (const root of computed) {
+    const match = expected.findIndex((candidate, index) =>
+      !used[index] && Math.hypot(root.re - candidate.re, root.im - candidate.im) < tol);
+    expect(match).not.toBe(-1);
+    used[match] = true;
+  }
 }
 
 describe("Frac", () => {
@@ -188,5 +206,47 @@ describe("solveQuartic", () => {
 
   it("leaves quartics without a usable rational resolvent root unevaluated", () => {
     expectSolutions(solveQuartic(fi(1), fi(0), fi(0), fi(1), fi(1)), []);
+  });
+});
+
+describe("nsolvePoly", () => {
+  it("solves linear, quadratic, and cubic polynomials numerically", () => {
+    expectNumericRootsClose(nsolvePoly([1, -2]), [{ re: 2, im: 0 }], 1e-10);
+    expectNumericRootsClose(nsolvePoly([1, 0, -1]), [{ re: 1, im: 0 }, { re: -1, im: 0 }]);
+    expectNumericRootsClose(nsolvePoly([1, 0, 1]), [{ re: 0, im: 1 }, { re: 0, im: -1 }]);
+    expectNumericRootsClose(nsolvePoly([1, -6, 11, -6]), [
+      { re: 1, im: 0 },
+      { re: 2, im: 0 },
+      { re: 3, im: 0 },
+    ]);
+  });
+
+  it("solves quintics and returns no roots for constants", () => {
+    const roots = nsolvePoly([1, 0, 0, 0, 0, -1]);
+    expect(roots.length).toBe(5);
+    roots.forEach((root) => expect(Math.abs(Math.hypot(root.re, root.im) - 1)).toBeLessThan(1e-8));
+    expect(nsolvePoly([5])).toEqual([]);
+  });
+
+  it("converts numeric roots to symbolic IR", () => {
+    expect(rootsToIr([{ re: 2, im: 1e-15 }, { re: -3, im: -1e-14 }])).toEqual([
+      numberNode(2),
+      numberNode(-3),
+    ]);
+    const complexRoot = rootsToIr([{ re: 1, im: 2 }])[0];
+    expect(complexRoot.kind).toBe("apply");
+    expect(containsSymbol(complexRoot, I_UNIT)).toBe(true);
+  });
+
+  it("wraps fraction coefficients and returns IR roots", () => {
+    const roots = nsolveFractionPoly([fi(1), fi(-6), fi(11), fi(-6)]);
+    expect(roots.length).toBe(3);
+    const values = roots
+      .filter((root) => root.kind === "float")
+      .map((root) => root.kind === "float" ? root.value : 0)
+      .sort((a, b) => a - b);
+    expect(values[0]).toBeCloseTo(1, 8);
+    expect(values[1]).toBeCloseTo(2, 8);
+    expect(values[2]).toBeCloseTo(3, 8);
   });
 });


### PR DESCRIPTION
## Summary
- add pure TypeScript Durand-Kerner numeric polynomial solving with real/complex coefficients
- add `rootsToIr` and `nsolveFractionPoly` helpers for `%i`-aware symbolic IR output
- cover linear/quadratic/cubic/quintic numeric roots, constant polynomials, Vieta-style radius behavior, and IR conversion

## Validation
- `npm test && npm run build` in `code/packages/typescript/cas-solve`