### PR TITLE
Add generic job request summaries

### DIFF
--- a/code/packages/rust/generic-job-protocol/CHANGELOG.md
+++ b/code/packages/rust/generic-job-protocol/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   exponential backoff, and exhausted-attempt decisions.
 - Added terminal job response status helpers and `JobResponseSummary` for
   compact runtime read models.
+- Added request and metadata summaries for payload-free queue/routing read
+  models.
 - Added terminal status and response-summary predicates for shared read-side
   success, failure, retry, cancel, and timeout classification.
 

--- a/code/packages/rust/generic-job-protocol/README.md
+++ b/code/packages/rust/generic-job-protocol/README.md
@@ -14,6 +14,8 @@ bridges:
   exponential backoff using the same metadata across runtimes.
 - `JobResponseSummary` captures terminal status, retryability, trace, and attempt
   facts for runtime read models.
+- `JobRequestSummary` and `JobMetadataSummary` expose queue/routing facts without
+  requiring runtimes to inspect payload types.
 - Terminal status and response-summary helpers provide shared read-side
   success, failure, retry, cancel, and timeout classification.
 - JSON-line codec helpers provide a phase-one process/stdio wire format.

--- a/code/packages/rust/generic-job-protocol/src/lib.rs
+++ b/code/packages/rust/generic-job-protocol/src/lib.rs
@@ -44,6 +44,13 @@ impl<T> JobRequest<T> {
         validate_required_token("id", &self.id)?;
         self.metadata.validate()
     }
+
+    pub fn summary(&self) -> JobRequestSummary {
+        JobRequestSummary {
+            id: self.id.clone(),
+            metadata: self.metadata.summary(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -234,6 +241,53 @@ impl JobMetadata {
         }
         Ok(())
     }
+
+    pub fn summary(&self) -> JobMetadataSummary {
+        JobMetadataSummary {
+            has_deadline: self.deadline_at_ms.is_some(),
+            priority: self.priority,
+            has_affinity_key: self.affinity_key.is_some(),
+            has_sequence: self.sequence.is_some(),
+            attempt: self.attempt,
+            is_retry: self.attempt > 0,
+            has_trace_id: self.trace_id.is_some(),
+            tag_count: self.tags.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobMetadataSummary {
+    pub has_deadline: bool,
+    pub priority: i32,
+    pub has_affinity_key: bool,
+    pub has_sequence: bool,
+    pub attempt: u32,
+    pub is_retry: bool,
+    pub has_trace_id: bool,
+    pub tag_count: usize,
+}
+
+impl JobMetadataSummary {
+    pub fn is_routable(self) -> bool {
+        self.has_affinity_key
+    }
+
+    pub fn is_ordered(self) -> bool {
+        self.has_sequence
+    }
+
+    pub fn is_traceable(self) -> bool {
+        self.has_trace_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JobRequestSummary {
+    pub id: String,
+    pub metadata: JobMetadataSummary,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -761,6 +815,60 @@ mod tests {
         assert_eq!(metadata.remaining_deadline_ms_at(260), Some(0));
         assert_eq!(metadata.next_attempt().attempt, 3);
         metadata.validate().unwrap();
+
+        let summary = metadata.summary();
+        assert_eq!(
+            summary,
+            JobMetadataSummary {
+                has_deadline: true,
+                priority: 10,
+                has_affinity_key: true,
+                has_sequence: true,
+                attempt: 2,
+                is_retry: true,
+                has_trace_id: true,
+                tag_count: 1,
+            }
+        );
+        assert!(summary.is_routable());
+        assert!(summary.is_ordered());
+        assert!(summary.is_traceable());
+    }
+
+    #[test]
+    fn request_summary_captures_metadata_without_payload() {
+        let request = JobRequest::new(
+            "job-7",
+            EchoPayload {
+                text: "payload should stay opaque".to_string(),
+            },
+        )
+        .with_metadata(
+            JobMetadata::default()
+                .with_created_at_ms(10)
+                .with_deadline_at_ms(20)
+                .with_affinity_key("worker-a")
+                .with_sequence(3)
+                .with_trace_id("trace-7")
+                .with_tag("queue", "interactive"),
+        );
+
+        assert_eq!(
+            request.summary(),
+            JobRequestSummary {
+                id: "job-7".to_string(),
+                metadata: JobMetadataSummary {
+                    has_deadline: true,
+                    priority: 0,
+                    has_affinity_key: true,
+                    has_sequence: true,
+                    attempt: 0,
+                    is_retry: false,
+                    has_trace_id: true,
+                    tag_count: 1,
+                },
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add payload-free JobRequestSummary and JobMetadataSummary read models
- expose metadata predicates for routable, ordered, and traceable jobs
- document the queue/routing summary surface in generic-job-protocol

## Tests
- cargo test -p generic-job-protocol