### PR TITLE
Add Thread neighbor table summaries

### DIFF
--- a/code/packages/rust/thread-mle/CHANGELOG.md
+++ b/code/packages/rust/thread-mle/CHANGELOG.md
@@ -19,5 +19,7 @@ All notable changes to this package will be documented in this file.
   partition, and prefix state for D23-facing health reads.
 - Thread supervisor action projections that classify diagnostic drift into
   stable repair intents for runtime supervisors.
+- Neighbor table summaries for cheap runtime/read-model projections of parent,
+  child, router, stale-neighbor, and parent-candidate state.
 - Neighbor table primitives for parent/child/router relationships, stale
   timeout expiry, link margin tracking, and parent-candidate selection.

--- a/code/packages/rust/thread-mle/README.md
+++ b/code/packages/rust/thread-mle/README.md
@@ -17,6 +17,8 @@ This crate starts the D27 Thread control-plane layer above 6LoWPAN:
   connectivity, partition, and prefix data from MLE messages
 - supervisor action projections that turn diagnostic drift into stable repair
   intents for runtime supervisors
+- neighbor table summaries for cheap runtime/read-model projections of parent,
+  child, router, stale-neighbor, and parent-candidate state
 - deterministic parent/child attach-state skeleton
 - neighbor table primitives for parent/child/router relationships, link margin,
   timeout freshness, and parent-candidate selection

--- a/code/packages/rust/thread-mle/src/lib.rs
+++ b/code/packages/rust/thread-mle/src/lib.rs
@@ -749,6 +749,44 @@ pub struct NeighborTable {
     parent: Option<ThreadNeighborId>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NeighborTableSummary {
+    pub local_role: DeviceRole,
+    pub neighbor_count: usize,
+    pub parent: Option<ThreadNeighborId>,
+    pub child_count: usize,
+    pub router_count: usize,
+    pub stale_neighbor_count: usize,
+    pub best_parent_candidate: Option<ThreadNeighborId>,
+}
+
+impl NeighborTableSummary {
+    pub fn is_empty(self) -> bool {
+        self.neighbor_count == 0
+    }
+
+    pub fn has_parent(self) -> bool {
+        self.parent.is_some()
+    }
+
+    pub fn has_stale_neighbors(self) -> bool {
+        self.stale_neighbor_count > 0
+    }
+
+    pub fn has_parent_candidate(self) -> bool {
+        self.best_parent_candidate.is_some()
+    }
+
+    pub fn needs_attach(self) -> bool {
+        self.local_role == DeviceRole::Detached
+            || (self.local_role == DeviceRole::Child && self.parent.is_none())
+    }
+
+    pub fn has_routing_surface(self) -> bool {
+        self.local_role.can_route() || self.router_count > 0
+    }
+}
+
 impl NeighborTable {
     pub fn new(local_role: DeviceRole) -> Self {
         Self {
@@ -833,6 +871,20 @@ impl NeighborTable {
                 neighbor.last_heard_at_ms,
             )
         })
+    }
+
+    pub fn summary_at(&self, now_ms: u64) -> NeighborTableSummary {
+        NeighborTableSummary {
+            local_role: self.local_role,
+            neighbor_count: self.len(),
+            parent: self.parent().map(|neighbor| neighbor.neighbor_id),
+            child_count: self.children().count(),
+            router_count: self.routers().count(),
+            stale_neighbor_count: self.stale_neighbors_at(now_ms).len(),
+            best_parent_candidate: self
+                .best_parent_candidate()
+                .map(|neighbor| neighbor.neighbor_id),
+        }
     }
 
     pub fn diagnostic_snapshot(
@@ -1631,6 +1683,26 @@ mod tests {
             table.best_parent_candidate().unwrap().neighbor_id,
             ThreadNeighborId(0x3000)
         );
+
+        let summary = table.summary_at(1_250);
+        assert_eq!(
+            summary,
+            NeighborTableSummary {
+                local_role: DeviceRole::Child,
+                neighbor_count: 3,
+                parent: Some(ThreadNeighborId(0x1000)),
+                child_count: 1,
+                router_count: 2,
+                stale_neighbor_count: 0,
+                best_parent_candidate: Some(ThreadNeighborId(0x3000)),
+            }
+        );
+        assert!(!summary.is_empty());
+        assert!(summary.has_parent());
+        assert!(!summary.has_stale_neighbors());
+        assert!(summary.has_parent_candidate());
+        assert!(!summary.needs_attach());
+        assert!(summary.has_routing_surface());
     }
 
     #[test]
@@ -1840,9 +1912,12 @@ mod tests {
         ));
 
         assert!(table.stale_neighbors_at(1_499).is_empty());
+        assert_eq!(table.summary_at(1_500).stale_neighbor_count, 1);
+        assert!(table.summary_at(1_500).has_stale_neighbors());
         assert_eq!(table.expire_stale(1_500), vec![ThreadNeighborId(0x1000)]);
         assert!(table.parent().is_none());
         assert!(table.is_empty());
+        assert!(table.summary_at(1_500).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a `NeighborTableSummary` projection for Thread neighbor counts, parent state, stale-neighbor counts, and best parent candidates
- expose helper predicates for attach, parent, stale-neighbor, routing-surface, and candidate checks
- document the read-model summary surface in the Thread MLE README and changelog

## Tests
- `cargo test -p thread-mle`
