### PR TITLE
Add storage summary page overviews

### DIFF
--- a/code/packages/rust/storage-core/CHANGELOG.md
+++ b/code/packages/rust/storage-core/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this package will be documented in this file.
 - Default `StorageBackend::get_summary` and `StorageBackend::list_summaries`
   helpers so higher-level stores can build list/read models without depending
   on full record bodies.
+- `StorageSummaryPageOverview` for aggregate read-side counts, page-boundary
+  keys, and pagination state over body-free summary pages.
 - Conformance coverage for summary reads matching stat/list semantics.
 
 ## [0.1.0] - 2026-04-18

--- a/code/packages/rust/storage-core/README.md
+++ b/code/packages/rust/storage-core/README.md
@@ -15,7 +15,8 @@ It is deliberately more structured than the existing CAS `BlobStore` trait:
 ## What this crate owns
 
 - `StorageRecord`, `StorageRecordSummary`, `StoragePutInput`, `StorageStat`,
-  `StoragePage`, `StorageSummaryPage`, and `StorageLease`
+  `StoragePage`, `StorageSummaryPage`, `StorageSummaryPageOverview`, and
+  `StorageLease`
 - `StorageBackend`, the backend trait implemented by local-folder, SQLite, and
   future backends
 - `InMemoryStorageBackend`, a pure Rust backend for tests and examples
@@ -109,6 +110,8 @@ assert_eq!(input.namespace, "context");
 helpers. Backends can override them to serve read models without loading record
 bodies, while simple implementations can rely on the default projection from
 `stat()` and `list()`.
+`StorageSummaryPage::overview()` provides aggregate counts and page-boundary
+keys for cheap runtime telemetry over those body-free listings.
 
 ## Development
 

--- a/code/packages/rust/storage-core/src/lib.rs
+++ b/code/packages/rust/storage-core/src/lib.rs
@@ -395,6 +395,51 @@ impl StorageSummaryPage {
     pub fn len(&self) -> usize {
         self.records.len()
     }
+
+    /// Return aggregate read-side facts for this summary page.
+    pub fn overview(&self) -> StorageSummaryPageOverview {
+        StorageSummaryPageOverview {
+            record_count: self.records.len(),
+            total_body_len: self.records.iter().map(|record| record.body_len).sum(),
+            total_metadata_keys: self
+                .records
+                .iter()
+                .map(|record| record.metadata_key_count)
+                .sum(),
+            first_key: self.records.first().map(|record| record.key.clone()),
+            last_key: self.records.last().map(|record| record.key.clone()),
+            next_cursor: self.next_cursor.clone(),
+        }
+    }
+}
+
+/// Aggregate read-side facts for one compact summary page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageSummaryPageOverview {
+    pub record_count: usize,
+    pub total_body_len: usize,
+    pub total_metadata_keys: usize,
+    pub first_key: Option<String>,
+    pub last_key: Option<String>,
+    pub next_cursor: Option<String>,
+}
+
+impl StorageSummaryPageOverview {
+    pub fn is_empty(&self) -> bool {
+        self.record_count == 0
+    }
+
+    pub fn has_more(&self) -> bool {
+        self.next_cursor.is_some()
+    }
+
+    pub fn spans_multiple_records(&self) -> bool {
+        self.record_count > 1
+    }
+
+    pub fn has_metadata(&self) -> bool {
+        self.total_metadata_keys > 0
+    }
 }
 
 /// An advisory lease for background operations such as index rebuilds or
@@ -1209,30 +1254,61 @@ mod tests {
     #[test]
     fn storage_page_projects_summary_page() {
         let page = StoragePage {
-            records: vec![StorageRecord::new(
-                "context",
-                "entries/demo.json",
-                Revision::new("r1").unwrap(),
-                "application/json",
-                metadata(),
-                b"demo".to_vec(),
-                20,
-                30,
-            )
-            .unwrap()],
+            records: vec![
+                StorageRecord::new(
+                    "context",
+                    "entries/alpha.json",
+                    Revision::new("r1").unwrap(),
+                    "application/json",
+                    metadata(),
+                    b"alpha".to_vec(),
+                    20,
+                    30,
+                )
+                .unwrap(),
+                StorageRecord::new(
+                    "context",
+                    "entries/beta.json",
+                    Revision::new("r2").unwrap(),
+                    "application/json",
+                    metadata(),
+                    b"beta".to_vec(),
+                    21,
+                    31,
+                )
+                .unwrap(),
+            ],
             next_cursor: Some("entries/demo.json".to_string()),
         };
 
         let summary_page = page.summary_page();
-        assert_eq!(page.len(), 1);
+        assert_eq!(page.len(), 2);
         assert!(!page.is_empty());
-        assert_eq!(summary_page.len(), 1);
+        assert_eq!(summary_page.len(), 2);
         assert!(!summary_page.is_empty());
         assert_eq!(
             summary_page.next_cursor.as_deref(),
             Some("entries/demo.json")
         );
-        assert_eq!(summary_page.records[0].body_len, 4);
+        assert_eq!(summary_page.records[0].body_len, 5);
+
+        let overview = summary_page.overview();
+        assert_eq!(
+            overview,
+            StorageSummaryPageOverview {
+                record_count: 2,
+                total_body_len: 9,
+                total_metadata_keys: 2,
+                first_key: Some("entries/alpha.json".to_string()),
+                last_key: Some("entries/beta.json".to_string()),
+                next_cursor: Some("entries/demo.json".to_string()),
+            }
+        );
+        assert!(!overview.is_empty());
+        assert!(overview.has_more());
+        assert!(overview.spans_multiple_records());
+        assert!(overview.has_metadata());
+        assert!(StorageSummaryPage::empty().overview().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `StorageSummaryPageOverview` for aggregate counts, body lengths, metadata-key totals, page-boundary keys, and pagination state
- expose `StorageSummaryPage::overview()` plus helper predicates for empty/more/multi-record/metadata checks
- document the overview primitive in `storage-core` README and changelog

## Tests
- `cargo test -p storage-core`
