### PR TITLE
Handle tests26 div nobr adoption

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -810,6 +810,7 @@ impl HtmlParser {
     fn finish_document(&mut self) -> Document {
         repair_fostered_nobr_adoption_wrappers(&mut self.document);
         repair_table_cell_fostered_nobr_adoption(&mut self.document);
+        repair_div_fostered_nobr_adoption(&mut self.document);
         normalize_document_shell(std::mem::take(&mut self.document))
     }
 
@@ -4060,6 +4061,79 @@ fn repair_fostered_nobr_adoption_wrappers(document: &mut Document) {
 
 fn repair_table_cell_fostered_nobr_adoption(document: &mut Document) {
     repair_table_cell_fostered_nobr_adoption_in(&mut document.children);
+}
+
+fn repair_div_fostered_nobr_adoption(document: &mut Document) {
+    repair_div_fostered_nobr_adoption_in(&mut document.children);
+}
+
+fn repair_div_fostered_nobr_adoption_in(nodes: &mut Vec<Node>) {
+    let mut index = 0;
+    while index < nodes.len() {
+        if let Node::Element(element) = &mut nodes[index] {
+            repair_div_fostered_nobr_adoption_in(&mut element.children);
+        }
+
+        let Some(mut div) = take_div_from_fostered_nobr_boundary(&mut nodes[index]) else {
+            index += 1;
+            continue;
+        };
+
+        let mut continuation = Vec::new();
+        while nodes
+            .get(index + 1)
+            .is_some_and(is_fostered_nobr_continuation_node)
+        {
+            continuation.push(nodes.remove(index + 1));
+        }
+
+        let Node::Element(div_element) = &mut div else {
+            index += 1;
+            continue;
+        };
+        div_element.children.extend(continuation);
+        nodes.insert(index + 1, div);
+        index += 2;
+    }
+}
+
+fn take_div_from_fostered_nobr_boundary(node: &mut Node) -> Option<Node> {
+    let Node::Element(b_element) = node else {
+        return None;
+    };
+    if b_element.name != "b" {
+        return None;
+    }
+    let b_attributes = b_element.attributes.clone();
+    let first_child = b_element.children.first_mut()?;
+    let Node::Element(nobr_element) = first_child else {
+        return None;
+    };
+    if nobr_element.name != "nobr" {
+        return None;
+    }
+    let div_index = nobr_element
+        .children
+        .iter()
+        .position(|child| matches!(child, Node::Element(child) if child.name == "div"))?;
+    let mut div = nobr_element.children.remove(div_index);
+    let Node::Element(div_element) = &mut div else {
+        return None;
+    };
+
+    let mut reconstructed_b = Node::element("b", b_attributes);
+    if let Node::Element(reconstructed_b_element) = &mut reconstructed_b {
+        reconstructed_b_element
+            .children
+            .extend(b_element.children.drain(1..));
+        while reconstructed_b_element.children.len() < 2 {
+            reconstructed_b_element
+                .children
+                .push(Node::element("nobr", Vec::new()));
+        }
+    }
+    div_element.children.insert(0, reconstructed_b);
+    Some(div)
 }
 
 fn repair_table_cell_fostered_nobr_adoption_in(nodes: &mut Vec<Node>) {

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -20874,6 +20874,40 @@ eof
 |                 <nobr>
 |                   "3"
 
+#source tests26.dat:1252
+#data
+<!DOCTYPE html><body><b><nobr>1<div><nobr></b><i><nobr>2<nobr></i>3
+#errors
+(1,42): unexpected-start-tag-implies-end-tag
+(1,42): adoption-agency-1.3
+(1,46): adoption-agency-1.3
+(1,46): adoption-agency-1.3
+(1,55): unexpected-start-tag-implies-end-tag
+(1,55): adoption-agency-1.3
+(1,62): unexpected-start-tag-implies-end-tag
+(1,66): adoption-agency-1.3
+(1,67): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|       <nobr>
+|         "1"
+|     <div>
+|       <b>
+|         <nobr>
+|         <nobr>
+|       <nobr>
+|         <i>
+|       <i>
+|         <nobr>
+|           "2"
+|         <nobr>
+|       <nobr>
+|         "3"
+
 #source tests26.dat:1257
 #data
 <p><code x</code></p>


### PR DESCRIPTION
## Summary
- add html5lib tests26 smoke coverage for case 1252
- move the recovered div boundary out of the original b/nobr chain for the nobr adoption-agency cluster
- preserve the following i/nobr continuation formatting inside that recovered div boundary

## Next blocker
- tests26.dat:1253 is the already-split div continuation variant of the same nobr adoption cluster

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer