### PR TITLE
Add Rust numeric polynomial solving for cas-solve

### DIFF
--- a/code/packages/rust/cas-solve/CHANGELOG.md
+++ b/code/packages/rust/cas-solve/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- `numeric` module: `Complex`, `nsolve_poly`, `roots_to_ir`, and
+  `nsolve_fraction_poly` — pure Rust Durand-Kerner numeric polynomial
+  root-finding plus `%i`-aware symbolic IR conversion.
+- Numeric solver integration tests for linear, quadratic, cubic, quintic,
+  constant-polynomial, complex-root, and fraction-coefficient cases.
 - `quartic` module: `solve_quartic(a, b, c, d, e) -> SolveResult` — solves
   quartic equations via rational-root deflation, biquadratic solving, and a
   bounded Ferrari fallback through the cubic solver.

--- a/code/packages/rust/cas-solve/Cargo.toml
+++ b/code/packages/rust/cas-solve/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cas-solve"
 version = "0.1.0"
 edition = "2021"
-description = "Closed-form equation solving over Q: linear, quadratic, cubic, and quartic"
+description = "Closed-form and numeric polynomial equation solving over symbolic IR"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/cas-solve/README.md
+++ b/code/packages/rust/cas-solve/README.md
@@ -1,12 +1,13 @@
 # cas-solve (Rust)
 
-Closed-form equation solving over ℚ: linear, quadratic, cubic, and quartic.
+Closed-form and numeric equation solving over ℚ: linear, quadratic, cubic,
+quartic, and Durand-Kerner polynomial roots.
 Rust port of the Python `cas-solve` package.
 
 ## Usage
 
 ```rust
-use cas_solve::{solve_cubic, solve_linear, solve_quadratic, solve_quartic, SolveResult};
+use cas_solve::{nsolve_poly, solve_cubic, solve_linear, solve_quadratic, solve_quartic, Complex, SolveResult};
 use cas_solve::frac::Frac;
 use symbolic_ir::{int, rat};
 
@@ -32,6 +33,14 @@ let r4 = solve_quartic(
     Frac::from_int(0), Frac::from_int(4),
 );
 assert!(matches!(r4, SolveResult::Solutions(roots) if roots.contains(&int(-2)) && roots.contains(&int(2))));
+
+// Numeric roots for x^2 + 1 = 0.
+let numeric = nsolve_poly(
+    &[Complex::new(1.0, 0.0), Complex::new(0.0, 0.0), Complex::new(1.0, 0.0)],
+    200,
+    1e-12,
+);
+assert_eq!(numeric.len(), 2);
 ```
 
 ## SolveResult
@@ -69,6 +78,15 @@ biquadratic quartics through the quadratic solver and uses Ferrari
 factorization for general quartics whose resolvent cubic has a usable rational
 root. Other resolvent cases return an empty solution list, matching the Python
 reference's unevaluated fallback behavior.
+
+## Numeric polynomial solving
+
+`nsolve_poly(coeffs, max_iter, tol)` accepts real or complex coefficients in
+decreasing degree order and normalizes by the leading coefficient. It uses the
+Durand-Kerner / Weierstrass iteration to return approximate complex roots for
+polynomials of arbitrary degree. `roots_to_ir` converts nearly-real roots to
+`Float` nodes and complex roots to `Add(Float(re), Mul(Float(im), %i))`.
+`nsolve_fraction_poly` is the exact-rational coefficient convenience wrapper.
 
 ## Stack position
 

--- a/code/packages/rust/cas-solve/src/lib.rs
+++ b/code/packages/rust/cas-solve/src/lib.rs
@@ -1,11 +1,12 @@
 //! # cas-solve
 //!
-//! Closed-form equation solving over ℚ: linear, quadratic, cubic, and quartic.
+//! Closed-form and numeric equation solving over ℚ: linear, quadratic, cubic,
+//! quartic, and Durand-Kerner polynomial roots.
 //!
 //! ## Quick start
 //!
 //! ```rust
-//! use cas_solve::{solve_cubic, solve_linear, solve_quadratic, solve_quartic, SolveResult};
+//! use cas_solve::{nsolve_poly, solve_cubic, solve_linear, solve_quadratic, solve_quartic, Complex, SolveResult};
 //! use cas_solve::frac::Frac;
 //! use symbolic_ir::{int, rat};
 //!
@@ -31,6 +32,14 @@
 //!     Frac::from_int(0), Frac::from_int(4),
 //! );
 //! assert!(matches!(r4, SolveResult::Solutions(roots) if roots.contains(&int(-2)) && roots.contains(&int(2))));
+//!
+//! // Numeric roots for x^2 + 1 = 0.
+//! let numeric = nsolve_poly(
+//!     &[Complex::new(1.0, 0.0), Complex::new(0.0, 0.0), Complex::new(1.0, 0.0)],
+//!     200,
+//!     1e-12,
+//! );
+//! assert_eq!(numeric.len(), 2);
 //! ```
 //!
 //! ## IR head names
@@ -44,11 +53,13 @@
 pub mod cubic;
 pub mod frac;
 pub mod linear;
+pub mod numeric;
 pub mod quadratic;
 pub mod quartic;
 
 pub use cubic::{solve_cubic, CBRT};
 pub use linear::solve_linear;
+pub use numeric::{nsolve_fraction_poly, nsolve_poly, roots_to_ir, Complex};
 pub use quadratic::{solve_quadratic, I_UNIT};
 pub use quartic::solve_quartic;
 

--- a/code/packages/rust/cas-solve/src/numeric.rs
+++ b/code/packages/rust/cas-solve/src/numeric.rs
@@ -1,0 +1,192 @@
+//! Numeric polynomial root-finding via Durand-Kerner iteration.
+//!
+//! Coefficients are supplied in decreasing degree order, matching the Python
+//! and TypeScript `cas-solve` ports: `[a_n, a_{n-1}, ..., a_0]`.
+
+use std::f64::consts::TAU;
+
+use symbolic_ir::{apply, flt, sym, IRNode, ADD, MUL};
+
+use crate::frac::Frac;
+use crate::quadratic::I_UNIT;
+
+/// A lightweight complex number used by the pure Rust numeric solver.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Complex {
+    pub re: f64,
+    pub im: f64,
+}
+
+impl Complex {
+    pub const fn new(re: f64, im: f64) -> Self {
+        Self { re, im }
+    }
+
+    pub fn abs(self) -> f64 {
+        self.re.hypot(self.im)
+    }
+}
+
+/// Find all roots of a polynomial numerically with Durand-Kerner iteration.
+///
+/// The polynomial is normalised by its non-zero leading coefficient before
+/// iteration. Constant polynomials return an empty root list.
+///
+/// # Panics
+///
+/// Panics when the leading coefficient is zero.
+pub fn nsolve_poly(coeffs: &[Complex], max_iter: usize, tol: f64) -> Vec<Complex> {
+    let degree = coeffs.len().saturating_sub(1);
+    if degree == 0 {
+        return Vec::new();
+    }
+
+    let lead = coeffs[0];
+    assert!(
+        lead.abs() != 0.0,
+        "nsolve_poly: leading coefficient must not be zero"
+    );
+    let poly: Vec<Complex> = coeffs.iter().map(|coef| *coef / lead).collect();
+
+    if degree == 1 {
+        return vec![-poly[1]];
+    }
+
+    let radius = initial_radius(&poly);
+    let mut roots: Vec<Complex> = (0..degree)
+        .map(|k| {
+            let theta = TAU * (k as f64) / (degree as f64) + 0.1;
+            Complex::new(radius * theta.cos(), radius * theta.sin())
+        })
+        .collect();
+
+    for _ in 0..max_iter {
+        let mut max_delta = 0.0_f64;
+        let mut next = roots.clone();
+
+        for i in 0..degree {
+            let mut denom = Complex::new(1.0, 0.0);
+            for j in 0..degree {
+                if i == j {
+                    continue;
+                }
+                let mut diff = roots[i] - roots[j];
+                if diff.abs() < 1e-300 {
+                    diff = Complex::new(1e-300, 0.0);
+                }
+                denom = denom * diff;
+            }
+
+            let delta = eval_poly(&poly, roots[i]) / denom;
+            next[i] = roots[i] - delta;
+            max_delta = max_delta.max(delta.abs());
+        }
+
+        roots = next;
+        if max_delta < tol {
+            break;
+        }
+    }
+
+    roots
+}
+
+/// Convert numeric roots to symbolic IR nodes.
+///
+/// Nearly-real roots become `Float(re)`. Complex roots become
+/// `Add(Float(re), Mul(Float(im), %i))`, preserving the MACSYMA imaginary-unit
+/// convention used by the exact solvers.
+pub fn roots_to_ir(roots: &[Complex]) -> Vec<IRNode> {
+    roots
+        .iter()
+        .map(|root| {
+            if root.im.abs() < 1e-10 {
+                flt(root.re)
+            } else {
+                apply(
+                    sym(ADD),
+                    vec![
+                        flt(root.re),
+                        apply(sym(MUL), vec![flt(root.im), sym(I_UNIT)]),
+                    ],
+                )
+            }
+        })
+        .collect()
+}
+
+/// Convenience wrapper for exact rational coefficient input.
+pub fn nsolve_fraction_poly(coeffs: &[Frac]) -> Vec<IRNode> {
+    let numeric: Vec<Complex> = coeffs
+        .iter()
+        .map(|coef| Complex::new(coef.numer as f64 / coef.denom as f64, 0.0))
+        .collect();
+    roots_to_ir(&nsolve_poly(&numeric, 200, 1e-12))
+}
+
+fn eval_poly(poly: &[Complex], z: Complex) -> Complex {
+    poly.iter()
+        .fold(Complex::new(0.0, 0.0), |acc, coef| acc * z + *coef)
+}
+
+fn initial_radius(poly: &[Complex]) -> f64 {
+    let degree = poly.len().saturating_sub(1);
+    if degree == 0 {
+        return 1.0;
+    }
+    let cauchy = 1.0 + poly[1..].iter().map(|coef| coef.abs()).fold(0.0, f64::max);
+    let lagrange = if poly[degree].abs() > 1e-300 {
+        poly[degree].abs().powf(1.0 / degree as f64)
+    } else {
+        1.0
+    };
+    cauchy.min(10.0).max(lagrange).max(0.5)
+}
+
+impl std::ops::Add for Complex {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.re + rhs.re, self.im + rhs.im)
+    }
+}
+
+impl std::ops::Sub for Complex {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new(self.re - rhs.re, self.im - rhs.im)
+    }
+}
+
+impl std::ops::Neg for Complex {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::new(-self.re, -self.im)
+    }
+}
+
+impl std::ops::Mul for Complex {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self::new(
+            self.re * rhs.re - self.im * rhs.im,
+            self.re * rhs.im + self.im * rhs.re,
+        )
+    }
+}
+
+impl std::ops::Div for Complex {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        let denom = rhs.re * rhs.re + rhs.im * rhs.im;
+        assert!(denom != 0.0, "complex division by zero");
+        Self::new(
+            (self.re * rhs.re + self.im * rhs.im) / denom,
+            (self.im * rhs.re - self.re * rhs.im) / denom,
+        )
+    }
+}

--- a/code/packages/rust/cas-solve/tests/tests.rs
+++ b/code/packages/rust/cas-solve/tests/tests.rs
@@ -4,7 +4,10 @@
 // code/packages/python/cas-solve/tests/.
 
 use cas_solve::frac::Frac;
-use cas_solve::{solve_cubic, solve_linear, solve_quadratic, solve_quartic, SolveResult};
+use cas_solve::{
+    nsolve_fraction_poly, nsolve_poly, roots_to_ir, solve_cubic, solve_linear, solve_quadratic,
+    solve_quartic, Complex, SolveResult,
+};
 use symbolic_ir::{int, rat, IRNode};
 
 fn frac(n: i64, d: i64) -> Frac {
@@ -12,6 +15,30 @@ fn frac(n: i64, d: i64) -> Frac {
 }
 fn fi(n: i64) -> Frac {
     Frac::from_int(n)
+}
+
+fn c(re: f64, im: f64) -> Complex {
+    Complex::new(re, im)
+}
+
+fn assert_numeric_roots_close(actual: &[Complex], expected: &[Complex]) {
+    assert_eq!(actual.len(), expected.len());
+    let mut used = vec![false; actual.len()];
+    for want in expected {
+        let mut matched = false;
+        for (i, got) in actual.iter().enumerate() {
+            if used[i] {
+                continue;
+            }
+            let distance = ((*got - *want).abs()).min((*got - c(want.re, -want.im)).abs());
+            if distance < 1e-7 {
+                used[i] = true;
+                matched = true;
+                break;
+            }
+        }
+        assert!(matched, "missing root {want:?} in {actual:?}");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -340,4 +367,86 @@ fn quartic_ferrari_complex_roots() {
 fn quartic_no_usable_resolvent_root_returns_empty() {
     let r = solve_quartic(fi(1), fi(0), fi(0), fi(1), fi(1));
     assert_eq!(r, SolveResult::Solutions(vec![]));
+}
+
+// ---------------------------------------------------------------------------
+// nsolve_poly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nsolve_linear_root() {
+    let roots = nsolve_poly(&[c(2.0, 0.0), c(-4.0, 0.0)], 200, 1e-12);
+    assert_numeric_roots_close(&roots, &[c(2.0, 0.0)]);
+}
+
+#[test]
+fn nsolve_quadratic_real_roots() {
+    let roots = nsolve_poly(&[c(1.0, 0.0), c(0.0, 0.0), c(-1.0, 0.0)], 200, 1e-12);
+    assert_numeric_roots_close(&roots, &[c(-1.0, 0.0), c(1.0, 0.0)]);
+}
+
+#[test]
+fn nsolve_quadratic_complex_roots() {
+    let roots = nsolve_poly(&[c(1.0, 0.0), c(0.0, 0.0), c(1.0, 0.0)], 200, 1e-12);
+    assert_numeric_roots_close(&roots, &[c(0.0, 1.0), c(0.0, -1.0)]);
+}
+
+#[test]
+fn nsolve_cubic_three_real_roots() {
+    let roots = nsolve_poly(
+        &[c(1.0, 0.0), c(-6.0, 0.0), c(11.0, 0.0), c(-6.0, 0.0)],
+        200,
+        1e-12,
+    );
+    assert_numeric_roots_close(&roots, &[c(1.0, 0.0), c(2.0, 0.0), c(3.0, 0.0)]);
+}
+
+#[test]
+fn nsolve_quintic_unit_roots() {
+    let roots = nsolve_poly(
+        &[
+            c(1.0, 0.0),
+            c(0.0, 0.0),
+            c(0.0, 0.0),
+            c(0.0, 0.0),
+            c(0.0, 0.0),
+            c(-1.0, 0.0),
+        ],
+        300,
+        1e-12,
+    );
+    assert_eq!(roots.len(), 5);
+    assert!(roots.iter().all(|root| (root.abs() - 1.0).abs() < 1e-8));
+}
+
+#[test]
+fn nsolve_constant_polynomial_returns_empty() {
+    assert!(nsolve_poly(&[c(5.0, 0.0)], 200, 1e-12).is_empty());
+}
+
+#[test]
+fn roots_to_ir_preserves_real_and_complex_roots() {
+    let roots = [c(2.0, 0.0), c(1.5, -0.25)];
+    let ir = roots_to_ir(&roots);
+    assert_eq!(ir.len(), 2);
+    assert_eq!(ir[0], IRNode::Float(2.0));
+    let text = format!("{:?}", ir[1]);
+    assert!(text.contains("%i"), "expected complex IR in {text}");
+}
+
+#[test]
+fn nsolve_fraction_poly_returns_float_ir_roots() {
+    let ir = nsolve_fraction_poly(&[fi(1), fi(-6), fi(11), fi(-6)]);
+    assert_eq!(ir.len(), 3);
+    let mut values: Vec<f64> = ir
+        .iter()
+        .map(|node| match node {
+            IRNode::Float(value) => *value,
+            other => panic!("expected float root, got {other:?}"),
+        })
+        .collect();
+    values.sort_by(f64::total_cmp);
+    assert!((values[0] - 1.0).abs() < 1e-7);
+    assert!((values[1] - 2.0).abs() < 1e-7);
+    assert!((values[2] - 3.0).abs() < 1e-7);
 }


### PR DESCRIPTION
## Summary
- add pure Rust Durand-Kerner numeric polynomial solving with lightweight complex numbers
- add `roots_to_ir` and `nsolve_fraction_poly` helpers for `%i`-aware symbolic IR output
- cover linear, quadratic, cubic, quintic, constant-polynomial, complex-root, and fraction-coefficient cases

## Validation
- `cargo fmt -p cas-solve --check`
- `cargo test -p cas-solve`