### PR TITLE
feat(lang33): module system — exports/imports at IIR level + iir-linker

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -557,6 +557,7 @@ members = [
     "brainfuck-iir-compiler",
     "ir-to-beam",
     "iir-builtin-lowering",
+    "iir-linker",
     "iir-to-beam",
     "iir-to-wasm",
     "twig-to-beam",

--- a/code/packages/rust/brainfuck-iir-compiler/src/compiler.rs
+++ b/code/packages/rust/brainfuck-iir-compiler/src/compiler.rs
@@ -137,6 +137,8 @@ pub fn compile_to_iir(ast: &GrammarASTNode, module_name: &str) -> IIRModule {
         functions: vec![fn_],
         entry_point: Some("main".to_string()),
         language: "brainfuck".to_string(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 

--- a/code/packages/rust/iir-builtin-lowering/src/global_io.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/global_io.rs
@@ -267,6 +267,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 

--- a/code/packages/rust/iir-builtin-lowering/src/heap.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/heap.rs
@@ -341,6 +341,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 

--- a/code/packages/rust/iir-builtin-lowering/src/lib.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lib.rs
@@ -98,6 +98,8 @@
 //!     functions: vec![fn_],
 //!     entry_point: Some("add".into()),
 //!     language: "twig".into(),
+//!     exports: vec![],
+//!     imports: vec![],
 //! };
 //!
 //! let errors = lower_builtins(&mut module);
@@ -219,6 +221,8 @@ pub fn lower_builtins(module: &mut IIRModule) -> Vec<BuiltinLoweringError> {
 ///     functions: vec![fn_],
 ///     entry_point: None,
 ///     language: "twig".into(),
+///     exports: vec![],
+///     imports: vec![],
 /// };
 ///
 /// let (lowered, errors) = lower_builtins_cloned(&original);

--- a/code/packages/rust/iir-builtin-lowering/tests/test_lowering.rs
+++ b/code/packages/rust/iir-builtin-lowering/tests/test_lowering.rs
@@ -38,6 +38,8 @@ fn make_module(instrs: Vec<IIRInstr>) -> IIRModule {
         functions: vec![fn_],
         entry_point: Some("main".into()),
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -516,6 +518,8 @@ fn test_35_two_functions_both_lowered() {
         functions: vec![fn1, fn2],
         entry_point: Some("add".into()),
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = lower_builtins(&mut m);
     assert!(errors.is_empty());
@@ -542,6 +546,8 @@ fn test_36_three_functions_independent() {
         functions: fns,
         entry_point: Some("f1".into()),
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = lower_builtins(&mut m);
     assert!(errors.is_empty());
@@ -565,6 +571,8 @@ fn test_37_error_in_one_function_reports_function_name() {
         functions: vec![fn_],
         entry_point: Some("my_broken_function".into()),
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = lower_builtins(&mut m);
     assert_eq!(errors.len(), 1);
@@ -587,6 +595,8 @@ fn test_38_empty_module_no_panic() {
         functions: vec![],
         entry_point: None,
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = lower_builtins(&mut m);
     assert!(errors.is_empty());
@@ -660,6 +670,8 @@ fn test_41_cloned_lowers_correctly() {
         functions: vec![fn_],
         entry_point: None,
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let (lowered, errors) = lower_builtins_cloned(&original);
     assert!(errors.is_empty());
@@ -680,6 +692,8 @@ fn test_42_cloned_leaves_original_unchanged() {
         functions: vec![fn_],
         entry_point: None,
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let (_lowered, _errors) = lower_builtins_cloned(&original);
     // Original still shows call_builtin.
@@ -762,6 +776,8 @@ fn test_47_function_with_no_instructions() {
         functions: vec![fn_],
         entry_point: Some("f".into()),
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = lower_builtins(&mut m);
     assert!(errors.is_empty());
@@ -780,6 +796,8 @@ fn test_48_multiple_empty_functions() {
         functions: fns,
         entry_point: Some("f".into()),
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = lower_builtins(&mut m);
     assert!(errors.is_empty());
@@ -843,6 +861,8 @@ fn test_50_mixed_errors_across_functions() {
         functions: vec![fn1, fn2],
         entry_point: Some("fn1".into()),
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = lower_builtins(&mut m);
     assert_eq!(errors.len(), 2);
@@ -1269,6 +1289,8 @@ fn test_77_lower_heap_builtins_direct_call() {
         functions: vec![fn_],
         entry_point: Some("f".into()),
         language: "twig".into(),
+        exports: vec![],
+        imports: vec![],
     };
     lower_heap_builtins(&mut m);
     assert_eq!(m.functions[0].instructions[0].op, "field_load");

--- a/code/packages/rust/iir-codegen-adapters/src/artifact.rs
+++ b/code/packages/rust/iir-codegen-adapters/src/artifact.rs
@@ -17,6 +17,7 @@
 //! let module = IIRModule {
 //!     name: "demo".into(), functions: vec![fn_],
 //!     entry_point: Some("main".into()), language: "test".into(),
+//!     exports: vec![], imports: vec![],
 //! };
 //!
 //! let artifact = compile_iir(&module, "iir-wasm").unwrap();
@@ -98,7 +99,7 @@ impl IIRBackendArtifact {
     /// # use interpreter_ir::{IIRModule, IIRFunction, IIRInstr};
     /// # let fn_ = IIRFunction::new("main", vec![], "void",
     /// #     vec![IIRInstr::new("ret_void", None, vec![], "void")]);
-    /// # let module = IIRModule { name: "d".into(), functions: vec![fn_], entry_point: Some("main".into()), language: "t".into() };
+    /// # let module = IIRModule { name: "d".into(), functions: vec![fn_], entry_point: Some("main".into()), language: "t".into(), exports: vec![], imports: vec![] };
     /// let art = compile_iir(&module, "iir-beam").unwrap();
     /// assert!(art.as_beam().is_some());
     /// assert!(art.as_wasm().is_none());

--- a/code/packages/rust/iir-codegen-adapters/src/dispatch.rs
+++ b/code/packages/rust/iir-codegen-adapters/src/dispatch.rs
@@ -217,6 +217,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -241,6 +243,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("add".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -301,6 +305,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "t".into(),
+            exports: vec![],
+            imports: vec![],
         };
         for backend in list_iir_backends() {
             let result = compile_iir(&empty, backend);

--- a/code/packages/rust/iir-codegen-adapters/src/dispatch.rs
+++ b/code/packages/rust/iir-codegen-adapters/src/dispatch.rs
@@ -20,6 +20,7 @@
 //! let module = IIRModule {
 //!     name: "demo".into(), functions: vec![fn_],
 //!     entry_point: Some("main".into()), language: "test".into(),
+//!     exports: vec![], imports: vec![],
 //! };
 //!
 //! // Show available backends.
@@ -81,7 +82,8 @@ const KNOWN_BACKENDS: &[&str] = &["iir-beam", "iir-clr", "iir-jvm", "iir-wasm"];
 /// let fn_ = IIRFunction::new("main", vec![], "void",
 ///     vec![IIRInstr::new("ret_void", None, vec![], "void")]);
 /// let module = IIRModule { name: "d".into(), functions: vec![fn_],
-///     entry_point: Some("main".into()), language: "t".into() };
+///     entry_point: Some("main".into()), language: "t".into(),
+///     exports: vec![], imports: vec![] };
 ///
 /// // All four backends accept a minimal void function.
 /// for backend in ["iir-beam", "iir-wasm", "iir-jvm", "iir-clr"] {

--- a/code/packages/rust/iir-codegen-adapters/src/error.rs
+++ b/code/packages/rust/iir-codegen-adapters/src/error.rs
@@ -19,7 +19,7 @@
 //! use interpreter_ir::{IIRModule, IIRFunction, IIRInstr};
 //!
 //! // An empty module fails validation (EmptyModule) on every backend.
-//! let empty = IIRModule { name: "e".into(), functions: vec![], entry_point: None, language: "t".into() };
+//! let empty = IIRModule { name: "e".into(), functions: vec![], entry_point: None, language: "t".into(), exports: vec![], imports: vec![] };
 //!
 //! match compile_iir(&empty, "iir-wasm") {
 //!     Err(IIRAdapterError::ValidationFailed { backend, errors }) => {

--- a/code/packages/rust/iir-codegen-adapters/src/lib.rs
+++ b/code/packages/rust/iir-codegen-adapters/src/lib.rs
@@ -41,6 +41,8 @@
 //!     functions: vec![fn_],
 //!     entry_point: Some("add".into()),
 //!     language: "test".into(),
+//!     exports: vec![],
+//!     imports: vec![],
 //! };
 //!
 //! // Show available backends.

--- a/code/packages/rust/iir-codegen-adapters/tests/test_adapters.rs
+++ b/code/packages/rust/iir-codegen-adapters/tests/test_adapters.rs
@@ -31,6 +31,8 @@ fn void_module() -> IIRModule {
         functions: vec![fn_],
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -55,6 +57,8 @@ fn add_i32_module() -> IIRModule {
         functions: vec![fn_],
         entry_point: Some("add".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -79,6 +83,8 @@ fn mul_i64_module() -> IIRModule {
         functions: vec![fn_],
         entry_point: Some("mul".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -113,6 +119,8 @@ fn two_function_module() -> IIRModule {
         functions: vec![add, sub],
         entry_point: Some("add".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -123,6 +131,8 @@ fn empty_module() -> IIRModule {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -139,6 +149,8 @@ fn unsupported_op_module() -> IIRModule {
         functions: vec![fn_],
         entry_point: Some("bad".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 

--- a/code/packages/rust/iir-linker/BUILD
+++ b/code/packages/rust/iir-linker/BUILD
@@ -1,0 +1,1 @@
+cargo test -p iir-linker

--- a/code/packages/rust/iir-linker/CHANGELOG.md
+++ b/code/packages/rust/iir-linker/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog — iir-linker
+
+## [0.1.0] — 2026-05-11
+
+Initial release (LANG33).
+
+### Added
+
+- `LinkError` enum — four failure modes: `Unresolved`, `TypeMismatch`,
+  `DuplicateExport`, `UndeclaredCall`.  All variants carry structured fields
+  for actionable diagnostics; `Display` and `std::error::Error` implemented.
+
+- `build_export_map` — builds `HashMap<(module_name, public_name), ResolvedExport>`
+  from a slice of `IIRModule`s, detecting `DuplicateExport` collisions.
+
+- `resolve_imports` — walks every import in every module, matches against the
+  export map, and type-checks if the import carries `param_types` / concrete
+  `return_type`.
+
+- `verify_imports_against` — pre-flight import check without merging; used by
+  REPL tooling.
+
+- `merge_modules` — collapes a set of `IIRModule`s into one:
+  - Private function name collisions resolved with `"<module>::"` prefix.
+  - `call` instructions rewritten to use the merged (possibly renamed) callee.
+  - `entry_point` preserved from the first module that has one.
+  - Merged module has empty `exports`/`imports` (self-contained).
+
+- `link(modules)` — free function combining export-map build + import
+  resolution + merge.  Returns `Err(Vec<LinkError>)` if any errors found.
+
+- `link_strict(modules)` — fail-fast variant returning `Err(LinkError)` on the
+  first error.
+
+- `verify_imports(module, providers)` — pre-flight without merging.
+
+- `IIRLinker` struct — stateful facade matching the LANG20 `CodeGenerator`
+  pattern; `Default` implemented.
+
+- 30 unit tests (across `error`, `resolve`, `merge`, `linker` modules).
+- 30 integration tests in `tests/test_linker.rs`.
+- 3 doc-tests.
+
+### Architecture notes
+
+Two-pass design:
+
+**Pass 1 (resolve.rs):** Build export map and check all imports.  Errors are
+accumulated — a single call reports all missing exports, all type mismatches,
+and all duplicate exports at once rather than stopping at the first.
+
+**Pass 2 (merge.rs):** Rename colliding private functions, rewrite `call`
+instructions, flatten functions into one `IIRModule`.  Only reached if pass 1
+produces no errors, so merge code never sees unresolved imports.
+
+The pointer-keyed `merged_name_map` (`*const IIRFunction → String`) is safe
+within the lifetime of the merge call because the modules slice is borrowed
+for the duration of `merge_modules`.

--- a/code/packages/rust/iir-linker/Cargo.toml
+++ b/code/packages/rust/iir-linker/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "iir-linker"
+version = "0.1.0"
+edition = "2021"
+description = "Static linker for IIRModules — resolves imports/exports and merges into one module (LANG33)"
+
+[lib]
+name = "iir_linker"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }

--- a/code/packages/rust/iir-linker/README.md
+++ b/code/packages/rust/iir-linker/README.md
@@ -1,0 +1,75 @@
+# iir-linker
+
+Static linker for `IIRModule`s — implements the LANG33 module system at the
+InterpreterIR level.
+
+## What it does
+
+`iir-linker` takes a set of `IIRModule`s (each produced by a separate
+compilation unit) and merges them into one self-contained module that can be
+executed by `vm-core` or lowered to BEAM / WASM / JVM / CLR by the
+`iir-to-*` backends.
+
+## Quick start
+
+```rust
+use interpreter_ir::{IIRModule, IIRFunction, IIRInstr};
+use interpreter_ir::module_exports::{IIRExport, IIRImport};
+use iir_linker::link;
+
+// Module "math" exports "add".
+let mut math = IIRModule::new("math", "twig");
+math.entry_point = None;
+math.add_or_replace(IIRFunction::new(
+    "add",
+    vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+    "i64",
+    vec![IIRInstr::new("ret_void", None, vec![], "void")],
+));
+math.exports.push(IIRExport::new("add"));
+
+// Module "app" imports "add".
+let mut app = IIRModule::new("app", "twig");
+app.add_or_replace(IIRFunction::new(
+    "main", vec![], "void",
+    vec![IIRInstr::new("ret_void", None, vec![], "void")],
+));
+app.imports.push(IIRImport::new("math", "add", "any"));
+
+let merged = link(&[math, app]).unwrap();
+assert!(merged.get_function("add").is_some());
+assert!(merged.get_function("main").is_some());
+assert!(merged.imports.is_empty()); // self-contained
+```
+
+## API
+
+| Function | Purpose |
+|----------|---------|
+| `link(modules)` | Full link: resolve + type-check + merge. Returns all errors. |
+| `link_strict(modules)` | Fail-fast variant: returns the first error. |
+| `verify_imports(module, providers)` | Pre-flight: check imports without merging. |
+| `IIRLinker::new().link(modules)` | Struct API (same as `link`). |
+
+## Error types
+
+```text
+LinkError::Unresolved         — import has no matching export
+LinkError::TypeMismatch       — import type annotations don't match export
+LinkError::DuplicateExport    — two modules export the same (module, name)
+LinkError::UndeclaredCall     — call instruction targets neither local nor import
+```
+
+## Where it fits
+
+```
+Language Frontend
+    ↓  IIRModule (per compilation unit)
+iir-linker::link
+    ↓  merged IIRModule
+vm-core / iir-to-beam / iir-to-wasm / iir-to-jvm-class-file / iir-to-cil-bytecode
+```
+
+## Spec
+
+`code/specs/LANG33-module-system.md`

--- a/code/packages/rust/iir-linker/src/error.rs
+++ b/code/packages/rust/iir-linker/src/error.rs
@@ -1,0 +1,216 @@
+//! `LinkError` — all failure modes the static linker can produce.
+//!
+//! # Design
+//!
+//! The linker operates on a *set* of `IIRModule`s and tries to produce one
+//! merged module.  Failure modes fall into four categories:
+//!
+//! 1. **Unresolved** — an import could not be matched to any export.
+//! 2. **TypeMismatch** — an import was matched, but the caller and callee
+//!    disagree about parameter or return types.
+//! 3. **DuplicateExport** — two modules export the same `(module_name,
+//!    function_name)` pair, making import resolution ambiguous.
+//! 4. **UndeclaredCall** — a `call` instruction targets a name that is neither
+//!    a local function nor a declared import.  This catches compiler bugs where
+//!    the frontend forgot to add an `IIRImport` entry.
+//!
+//! All four variants carry enough context to produce a actionable error message
+//! without requiring access to the original `IIRModule`s.
+//!
+//! # Example
+//!
+//! ```rust
+//! use iir_linker::error::LinkError;
+//!
+//! let e = LinkError::Unresolved {
+//!     importing_module: "main".into(),
+//!     import_module:    "math".into(),
+//!     import_function:  "sqrt".into(),
+//! };
+//! assert!(format!("{e}").contains("sqrt"));
+//! ```
+
+/// All failure modes that `iir_linker::link` can produce.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LinkError {
+    /// An import could not be resolved to any exported function.
+    ///
+    /// Occurs when none of the peer `IIRModule`s export a function under
+    /// the expected `(module_name, function_name)` key.
+    Unresolved {
+        /// The module that declared the unsatisfied import.
+        importing_module: String,
+        /// The module name the import expected to find the function in.
+        import_module: String,
+        /// The function name (public name) that was not found.
+        import_function: String,
+    },
+
+    /// An import was resolved but the type signatures don't match.
+    ///
+    /// Only checked when the import provides non-empty `param_types` or a
+    /// non-`"any"` `return_type`.
+    TypeMismatch {
+        /// The module that declared the import with mismatched types.
+        importing_module: String,
+        /// The module that exports the function.
+        exporting_module: String,
+        /// The function name (public name).
+        function: String,
+        /// What the importer expected (`import.param_types`).
+        expected: Vec<String>,
+        /// What the exporter actually has (`export_fn.params.*.type`).
+        actual: Vec<String>,
+    },
+
+    /// Two modules both export under the same `(module_name, public_name)` key.
+    ///
+    /// Import resolution is ambiguous when there are multiple candidates;
+    /// the linker rejects this rather than picking arbitrarily.
+    DuplicateExport {
+        /// The module name in question.
+        module_name: String,
+        /// The public function name in question.
+        function_name: String,
+    },
+
+    /// A `call` instruction targets a name that is neither a local function
+    /// nor a declared import.
+    ///
+    /// This is a compiler bug — the frontend generated a `call("foo", …)`
+    /// without declaring `"foo"` in `IIRModule::imports`.
+    UndeclaredCall {
+        /// The module containing the bad call instruction.
+        in_module: String,
+        /// The function containing the bad call instruction.
+        in_function: String,
+        /// The callee name that was neither local nor imported.
+        callee: String,
+    },
+}
+
+impl std::fmt::Display for LinkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LinkError::Unresolved {
+                importing_module,
+                import_module,
+                import_function,
+            } => write!(
+                f,
+                "LinkError::Unresolved: module {importing_module:?} requires \
+                 {import_module:?}::{import_function:?} but no matching export was found"
+            ),
+            LinkError::TypeMismatch {
+                importing_module,
+                exporting_module,
+                function,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "LinkError::TypeMismatch: {importing_module:?} imports \
+                 {exporting_module:?}::{function:?} with params {expected:?} \
+                 but exporter has {actual:?}"
+            ),
+            LinkError::DuplicateExport {
+                module_name,
+                function_name,
+            } => write!(
+                f,
+                "LinkError::DuplicateExport: multiple modules export \
+                 {module_name:?}::{function_name:?}"
+            ),
+            LinkError::UndeclaredCall {
+                in_module,
+                in_function,
+                callee,
+            } => write!(
+                f,
+                "LinkError::UndeclaredCall: function {in_function:?} in module \
+                 {in_module:?} calls {callee:?} which is not a local function \
+                 or declared import"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LinkError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unresolved_display_contains_function_name() {
+        let e = LinkError::Unresolved {
+            importing_module: "main".into(),
+            import_module: "math".into(),
+            import_function: "sqrt".into(),
+        };
+        let s = format!("{e}");
+        assert!(s.contains("sqrt"));
+        assert!(s.contains("math"));
+        assert!(s.contains("main"));
+    }
+
+    #[test]
+    fn type_mismatch_display_contains_expected_and_actual() {
+        let e = LinkError::TypeMismatch {
+            importing_module: "app".into(),
+            exporting_module: "lib".into(),
+            function: "add".into(),
+            expected: vec!["i64".into(), "i64".into()],
+            actual: vec!["i32".into(), "i32".into()],
+        };
+        let s = format!("{e}");
+        assert!(s.contains("add"));
+        assert!(s.contains("i64"));
+        assert!(s.contains("i32"));
+    }
+
+    #[test]
+    fn duplicate_export_display_contains_names() {
+        let e = LinkError::DuplicateExport {
+            module_name: "math".into(),
+            function_name: "sqrt".into(),
+        };
+        let s = format!("{e}");
+        assert!(s.contains("math"));
+        assert!(s.contains("sqrt"));
+    }
+
+    #[test]
+    fn undeclared_call_display_contains_callee() {
+        let e = LinkError::UndeclaredCall {
+            in_module: "app".into(),
+            in_function: "main".into(),
+            callee: "mystery_fn".into(),
+        };
+        let s = format!("{e}");
+        assert!(s.contains("mystery_fn"));
+        assert!(s.contains("main"));
+    }
+
+    #[test]
+    fn link_error_implements_std_error() {
+        // Verify the trait impl compiles and the source chain is empty.
+        let e = LinkError::Unresolved {
+            importing_module: "x".into(),
+            import_module: "y".into(),
+            import_function: "z".into(),
+        };
+        // std::error::Error requires Display + Debug, both derived/impl'd.
+        let _: &dyn std::error::Error = &e;
+    }
+
+    #[test]
+    fn link_error_clone_and_partial_eq() {
+        let e = LinkError::Unresolved {
+            importing_module: "a".into(),
+            import_module: "b".into(),
+            import_function: "c".into(),
+        };
+        assert_eq!(e.clone(), e);
+    }
+}

--- a/code/packages/rust/iir-linker/src/lib.rs
+++ b/code/packages/rust/iir-linker/src/lib.rs
@@ -1,0 +1,71 @@
+//! # iir-linker — Static linker for `IIRModule`s (LANG33)
+//!
+//! This crate implements the static linker described in the LANG33 spec.  It
+//! takes a slice of `IIRModule`s (each produced by a separate compilation unit
+//! or loaded from disk) and merges them into one self-contained `IIRModule`
+//! that can be handed to `vm-core.execute()` or any of the four native
+//! backends.
+//!
+//! ## Quick start
+//!
+//! ```rust
+//! use interpreter_ir::{IIRModule, IIRFunction, IIRInstr};
+//! use interpreter_ir::module_exports::{IIRExport, IIRImport};
+//! use iir_linker::link;
+//!
+//! // --- module "math" exports "add" ---
+//! let mut math = IIRModule::new("math", "twig");
+//! math.entry_point = None;
+//! math.add_or_replace(IIRFunction::new(
+//!     "add",
+//!     vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+//!     "i64",
+//!     vec![IIRInstr::new("ret_void", None, vec![], "void")],
+//! ));
+//! math.exports.push(IIRExport::new("add"));
+//!
+//! // --- module "app" imports "add" from "math" ---
+//! let mut app = IIRModule::new("app", "twig");
+//! app.add_or_replace(IIRFunction::new(
+//!     "main", vec![], "void",
+//!     vec![IIRInstr::new("ret_void", None, vec![], "void")],
+//! ));
+//! app.imports.push(IIRImport::new("math", "add", "any"));
+//!
+//! let merged = link(&[math, app]).unwrap();
+//! // Both functions are now in the merged module.
+//! assert!(merged.get_function("add").is_some());
+//! assert!(merged.get_function("main").is_some());
+//! // The merged module is self-contained — no imports left.
+//! assert!(merged.imports.is_empty());
+//! ```
+//!
+//! ## Module layout
+//!
+//! ```text
+//! iir-linker/src/
+//!   lib.rs       — re-exports + this module-level doc
+//!   error.rs     — LinkError enum
+//!   resolve.rs   — import/export resolution + type checking
+//!   merge.rs     — function renaming + call rewriting + module merging
+//!   linker.rs    — IIRLinker struct + link/link_strict/verify_imports entry points
+//! tests/
+//!   test_linker.rs — ≥ 30 integration tests
+//! ```
+//!
+//! ## Design principles
+//!
+//! - **Language agnostic**: the linker operates on `IIRModule`s regardless of
+//!   the source language.  Twig, NIB, Prolog, Brainfuck all get the same linker.
+//! - **Fail loudly**: every error carries enough context to produce a helpful
+//!   diagnostic without re-reading source files.
+//! - **No side effects**: `link` is a pure function — no global state, no I/O.
+
+pub mod error;
+pub mod linker;
+pub mod merge;
+pub mod resolve;
+
+// Re-export the most-used entry points and types.
+pub use error::LinkError;
+pub use linker::{link, link_strict, verify_imports, IIRLinker};

--- a/code/packages/rust/iir-linker/src/linker.rs
+++ b/code/packages/rust/iir-linker/src/linker.rs
@@ -1,0 +1,236 @@
+//! `IIRLinker` — the public stateful linker facade.
+//!
+//! Most callers want the free functions [`link`] and [`link_strict`] rather
+//! than building an `IIRLinker` directly.  The struct API is provided for
+//! tooling that wants to accumulate errors incrementally or inspect the
+//! intermediate export map.
+
+use interpreter_ir::module::IIRModule;
+
+use crate::error::LinkError;
+use crate::merge::merge_modules;
+use crate::resolve::{build_export_map, resolve_imports, verify_imports_against};
+
+// ---------------------------------------------------------------------------
+// Free-function API (the recommended entry points)
+// ---------------------------------------------------------------------------
+
+/// Static-link two or more `IIRModule`s into one merged module.
+///
+/// # Algorithm
+///
+/// 1. Build the export map: `(module_name, public_name) → &IIRFunction`.
+/// 2. Resolve every import against the export map; type-check if annotations
+///    are present.
+/// 3. Merge all functions into a single `IIRModule`, renaming collisions with
+///    `"<module>::"` prefix and rewriting `call` instructions accordingly.
+/// 4. Return the merged module, or all errors if any were found.
+///
+/// # Errors
+///
+/// Returns `Err(errors)` if any of:
+/// - An import has no matching export (`LinkError::Unresolved`)
+/// - An import's type annotations don't match (`LinkError::TypeMismatch`)
+/// - Two modules export the same `(module_name, function_name)` pair
+///   (`LinkError::DuplicateExport`)
+///
+/// # Example
+///
+/// ```rust
+/// use interpreter_ir::{IIRModule, IIRFunction, IIRInstr, Operand};
+/// use interpreter_ir::module_exports::{IIRExport, IIRImport};
+/// use iir_linker::link;
+///
+/// let mut math = IIRModule::new("math", "twig");
+/// math.entry_point = None;
+/// math.add_or_replace(IIRFunction::new(
+///     "add",
+///     vec![("a".into(), "i64".into()), ("b".into(), "i64".into())],
+///     "i64",
+///     vec![IIRInstr::new("ret_void", None, vec![], "void")],
+/// ));
+/// math.exports.push(IIRExport::new("add"));
+///
+/// let mut app = IIRModule::new("app", "twig");
+/// app.add_or_replace(IIRFunction::new(
+///     "main", vec![], "void",
+///     vec![IIRInstr::new("ret_void", None, vec![], "void")],
+/// ));
+/// app.imports.push(IIRImport::new("math", "add", "any"));
+///
+/// let merged = link(&[math, app]).unwrap();
+/// assert!(merged.get_function("add").is_some());
+/// assert!(merged.get_function("main").is_some());
+/// assert!(merged.imports.is_empty()); // Self-contained after linking.
+/// ```
+pub fn link(modules: &[IIRModule]) -> Result<IIRModule, Vec<LinkError>> {
+    IIRLinker::new().link(modules)
+}
+
+/// Link-and-fail-fast variant — returns `Err` on the first error found.
+///
+/// Useful for build tooling that wants a clear first error rather than a
+/// batch.  Internally collects all errors via `link` and returns the first.
+pub fn link_strict(modules: &[IIRModule]) -> Result<IIRModule, LinkError> {
+    link(modules).map_err(|mut errors| {
+        errors.remove(0) // errors is never empty when Err is returned
+    })
+}
+
+/// Verify that all imports in `module` are satisfied by `providers`.
+///
+/// Does **not** merge or rewrite — useful for pre-flight checking in the REPL
+/// before committing to a full link.
+///
+/// Returns a (possibly empty) list of `LinkError`s.
+pub fn verify_imports(module: &IIRModule, providers: &[&IIRModule]) -> Vec<LinkError> {
+    verify_imports_against(module, providers)
+}
+
+// ---------------------------------------------------------------------------
+// IIRLinker struct (stateful)
+// ---------------------------------------------------------------------------
+
+/// Stateful linker.  Holds no long-lived state between calls; the struct API
+/// is provided for consistency with the LANG20 `CodeGenerator` pattern.
+pub struct IIRLinker;
+
+impl IIRLinker {
+    pub fn new() -> Self {
+        IIRLinker
+    }
+
+    /// Link `modules` into one merged module.  Same algorithm as the free
+    /// function [`link`].
+    pub fn link(&self, modules: &[IIRModule]) -> Result<IIRModule, Vec<LinkError>> {
+        let mut all_errors: Vec<LinkError> = Vec::new();
+
+        // Step 1: Build export map (may produce DuplicateExport errors).
+        let (export_map, mut dup_errors) = build_export_map(modules);
+        all_errors.append(&mut dup_errors);
+
+        // Step 2: Resolve imports (may produce Unresolved + TypeMismatch errors).
+        let mut import_errors = resolve_imports(modules, &export_map);
+        all_errors.append(&mut import_errors);
+
+        if !all_errors.is_empty() {
+            return Err(all_errors);
+        }
+
+        // Step 3: Merge.
+        Ok(merge_modules(modules, &export_map))
+    }
+}
+
+impl Default for IIRLinker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module_exports::{IIRExport, IIRImport};
+
+    fn make_ret_void_fn(name: &str, params: Vec<(&str, &str)>) -> IIRFunction {
+        IIRFunction::new(
+            name,
+            params.into_iter().map(|(n, t)| (n.to_string(), t.to_string())).collect(),
+            "void",
+            vec![IIRInstr::new("ret_void", None, vec![], "void")],
+        )
+    }
+
+    #[test]
+    fn link_two_modules_produces_merged() {
+        let mut math = IIRModule::new("math", "twig");
+        math.entry_point = None;
+        math.add_or_replace(make_ret_void_fn("add", vec![("a", "i64"), ("b", "i64")]));
+        math.exports.push(IIRExport::new("add"));
+
+        let mut app = IIRModule::new("app", "twig");
+        app.add_or_replace(make_ret_void_fn("main", vec![]));
+        app.imports.push(IIRImport::new("math", "add", "any"));
+
+        let merged = link(&[math, app]).unwrap();
+        assert!(merged.get_function("add").is_some());
+        assert!(merged.get_function("main").is_some());
+    }
+
+    #[test]
+    fn link_returns_unresolved_when_import_missing() {
+        let mut app = IIRModule::new("app", "twig");
+        app.entry_point = None;
+        app.imports.push(IIRImport::new("nonexistent", "fn", "any"));
+
+        let errs = link(&[app]).unwrap_err();
+        assert!(errs.iter().any(|e| matches!(e, LinkError::Unresolved { .. })));
+    }
+
+    #[test]
+    fn link_strict_returns_first_error() {
+        let mut app = IIRModule::new("app", "twig");
+        app.entry_point = None;
+        app.imports.push(IIRImport::new("x", "a", "any"));
+        app.imports.push(IIRImport::new("x", "b", "any"));
+
+        let err = link_strict(&[app]).unwrap_err();
+        assert!(matches!(err, LinkError::Unresolved { .. }));
+    }
+
+    #[test]
+    fn link_single_module_no_imports() {
+        let mut m = IIRModule::new("prog", "twig");
+        m.add_or_replace(make_ret_void_fn("main", vec![]));
+        let merged = link(&[m]).unwrap();
+        assert_eq!(merged.functions.len(), 1);
+        assert!(merged.get_function("main").is_some());
+    }
+
+    #[test]
+    fn link_preserves_entry_point() {
+        let mut m = IIRModule::new("app", "twig");
+        m.add_or_replace(make_ret_void_fn("main", vec![]));
+        m.entry_point = Some("main".into());
+        let merged = link(&[m]).unwrap();
+        assert_eq!(merged.entry_point, Some("main".into()));
+    }
+
+    #[test]
+    fn verify_imports_returns_empty_when_satisfied() {
+        let mut math = IIRModule::new("math", "twig");
+        math.entry_point = None;
+        math.add_or_replace(make_ret_void_fn("add", vec![]));
+        math.exports.push(IIRExport::new("add"));
+
+        let mut app = IIRModule::new("app", "twig");
+        app.entry_point = None;
+        app.imports.push(IIRImport::new("math", "add", "any"));
+
+        let errs = verify_imports(&app, &[&math]);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn verify_imports_returns_error_when_not_satisfied() {
+        let mut app = IIRModule::new("app", "twig");
+        app.entry_point = None;
+        app.imports.push(IIRImport::new("math", "missing", "any"));
+
+        let errs = verify_imports(&app, &[]);
+        assert_eq!(errs.len(), 1);
+    }
+
+    #[test]
+    fn linker_default_is_same_as_new() {
+        // Ensure Default impl is available.
+        let l = IIRLinker::default();
+        let mut m = IIRModule::new("t", "x");
+        m.entry_point = None;
+        let merged = l.link(&[m]).unwrap();
+        assert!(merged.functions.is_empty());
+    }
+}

--- a/code/packages/rust/iir-linker/src/merge.rs
+++ b/code/packages/rust/iir-linker/src/merge.rs
@@ -1,0 +1,352 @@
+//! Module merging — the second pass of the static linker.
+//!
+//! # Algorithm
+//!
+//! After `resolve.rs` verifies that every import is satisfied, `merge_modules`
+//! collapses the set of `IIRModule`s into one:
+//!
+//! 1. **Rename colliding private functions.**  If module A has a private
+//!    function `"helper"` and module B also has `"helper"`, both survive in the
+//!    merged module under the names `"A::helper"` and `"B::helper"`.  Functions
+//!    that are *exported* keep their original name (their callers use that name).
+//!
+//! 2. **Rewrite call instructions.**  Any `call` instruction whose callee name
+//!    matches an import's `local_name()` is rewritten to the merged name of the
+//!    exported function.
+//!
+//! 3. **Preserve entry_point.**  The first module in the slice that has an
+//!    `entry_point` set wins.
+//!
+//! 4. **Clear exports/imports.**  The merged module is self-contained — all
+//!    cross-module references have been inlined, so the export/import lists are
+//!    emptied.
+//!
+//! # Name collision strategy
+//!
+//! A function name is *claimed* by the first module that defines it.  Subsequent
+//! modules with the same name prefix their functions with `"<module_name>::"`.
+//! Exports always win: if module A exports `"sqrt"`, any private `"sqrt"` in
+//! module B becomes `"B::sqrt"`.
+
+use std::collections::HashMap;
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::module::IIRModule;
+
+use crate::resolve::ResolvedExport;
+
+/// Merge a set of resolved modules into one `IIRModule`.
+///
+/// `export_map` is the result of `build_export_map` and is used to look up
+/// the merged name of each exported function.
+///
+/// # Preconditions
+///
+/// All imports must already be resolved (no `Unresolved` errors).  The caller
+/// (`linker.rs`) is responsible for ensuring this.
+pub fn merge_modules<'a>(
+    modules: &'a [IIRModule],
+    export_map: &HashMap<(String, String), ResolvedExport<'a>>,
+) -> IIRModule {
+    // Step 1: Decide the merged name for every function in every module.
+    //
+    // We do a two-step process:
+    //   a. Collect all *exported* function names first (these must not be
+    //      prefixed — external callers know their names).
+    //   b. For private functions, prefix with "<module>::" if the bare name
+    //      is already taken.
+
+    let mut merged_name_map: HashMap<(*const IIRFunction, usize), String> = HashMap::new();
+    let mut global_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Pass 1a: Claim all exported public names.
+    for module in modules {
+        for export in &module.exports {
+            let public_name = export.public_name().to_string();
+            global_names.insert(public_name.clone());
+            // Associate this export's underlying function with the public name.
+            if let Some(fn_) = module.get_function(&export.function_name) {
+                let key = (fn_ as *const IIRFunction, fn_ as *const IIRFunction as usize);
+                merged_name_map.insert(key, public_name);
+            }
+        }
+    }
+
+    // Pass 1b: Assign names to private functions.
+    for module in modules {
+        for fn_ in &module.functions {
+            let ptr_key = (fn_ as *const IIRFunction, fn_ as *const IIRFunction as usize);
+            if merged_name_map.contains_key(&ptr_key) {
+                continue; // Already named (it's an exported function).
+            }
+            let name = if global_names.contains(&fn_.name) {
+                // Collision — prefix with module name.
+                format!("{}::{}", module.name, fn_.name)
+            } else {
+                fn_.name.clone()
+            };
+            global_names.insert(name.clone());
+            merged_name_map.insert(ptr_key, name);
+        }
+    }
+
+    // Step 2: Build an import-resolution map for each module:
+    //   local_call_name → merged_function_name
+    //
+    // This lets us rewrite `call("sqrt", …)` → `call("math::sqrt", …)` etc.
+    // when the function was renamed.
+    let import_rewrite: HashMap<(String, String), String> = build_import_rewrite(modules, export_map, &merged_name_map);
+
+    // Step 3: Assemble merged functions list.
+    let mut merged_functions: Vec<IIRFunction> = Vec::new();
+    for module in modules {
+        let module_rewrites: HashMap<String, String> = import_rewrite
+            .iter()
+            .filter(|((mod_name, _), _)| mod_name == &module.name)
+            .map(|((_, local), merged)| (local.clone(), merged.clone()))
+            .collect();
+
+        for fn_ in &module.functions {
+            let ptr_key = (fn_ as *const IIRFunction, fn_ as *const IIRFunction as usize);
+            let merged_fn_name = merged_name_map.get(&ptr_key).cloned().unwrap_or_else(|| fn_.name.clone());
+            let rewritten = rewrite_function(fn_, &merged_fn_name, &module_rewrites);
+            merged_functions.push(rewritten);
+        }
+    }
+
+    // Step 4: Preserve entry_point from first module that has one.
+    let entry_point = modules.iter().find_map(|m| m.entry_point.clone());
+
+    // Step 5: Determine the merged module name and language.
+    let name = modules.first().map(|m| m.name.clone()).unwrap_or_else(|| "merged".to_string());
+    let language = modules.first().map(|m| m.language.clone()).unwrap_or_else(|| "unknown".to_string());
+
+    IIRModule {
+        name,
+        functions: merged_functions,
+        entry_point,
+        language,
+        exports: Vec::new(), // Merged module is self-contained.
+        imports: Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Build a map `(module_name, local_call_name) → merged_function_name`
+/// for every import in every module.
+fn build_import_rewrite<'a>(
+    modules: &'a [IIRModule],
+    export_map: &HashMap<(String, String), ResolvedExport<'a>>,
+    merged_name_map: &HashMap<(*const IIRFunction, usize), String>,
+) -> HashMap<(String, String), String> {
+    let mut map: HashMap<(String, String), String> = HashMap::new();
+
+    for module in modules {
+        for import in &module.imports {
+            let export_key = (import.module_name.clone(), import.function_name.clone());
+            if let Some(resolved) = export_map.get(&export_key) {
+                // Look up what the exported function was renamed to.
+                let fn_ = resolved.function;
+                let ptr_key = (fn_ as *const IIRFunction, fn_ as *const IIRFunction as usize);
+                if let Some(merged_name) = merged_name_map.get(&ptr_key) {
+                    map.insert(
+                        (module.name.clone(), import.local_name().to_string()),
+                        merged_name.clone(),
+                    );
+                }
+            }
+        }
+    }
+
+    map
+}
+
+/// Produce a new `IIRFunction` with:
+/// - Its name replaced by `new_name`.
+/// - All `call` instructions that target a key in `call_rewrites` updated
+///   to use the rewritten callee name.
+fn rewrite_function(
+    fn_: &IIRFunction,
+    new_name: &str,
+    call_rewrites: &HashMap<String, String>,
+) -> IIRFunction {
+    let new_instrs: Vec<IIRInstr> = fn_
+        .instructions
+        .iter()
+        .map(|instr| rewrite_instr(instr, call_rewrites))
+        .collect();
+
+    IIRFunction {
+        name: new_name.to_string(),
+        params: fn_.params.clone(),
+        return_type: fn_.return_type.clone(),
+        instructions: new_instrs,
+        register_count: fn_.register_count,
+        type_status: fn_.type_status.clone(),
+        call_count: 0, // reset
+        feedback_slots: std::collections::HashMap::new(),
+        source_map: fn_.source_map.clone(),
+        param_refinements: fn_.param_refinements.clone(),
+        return_refinement: fn_.return_refinement.clone(),
+    }
+}
+
+/// Rewrite a `call` instruction's callee operand if it appears in `rewrites`.
+///
+/// The callee is always `srcs[0]` as an `Operand::Var` for IIR `call`
+/// instructions.  Non-call instructions are returned unchanged.
+fn rewrite_instr(instr: &IIRInstr, rewrites: &HashMap<String, String>) -> IIRInstr {
+    if instr.op != "call" || rewrites.is_empty() {
+        return instr.clone();
+    }
+    // srcs[0] is the callee name as Operand::Var.
+    if let Some(Operand::Var(callee)) = instr.srcs.first() {
+        if let Some(new_callee) = rewrites.get(callee) {
+            let mut new_srcs = instr.srcs.clone();
+            new_srcs[0] = Operand::Var(new_callee.clone());
+            return IIRInstr {
+                op: instr.op.clone(),
+                dest: instr.dest.clone(),
+                srcs: new_srcs,
+                type_hint: instr.type_hint.clone(),
+                may_alloc: instr.may_alloc,
+                observed_type: instr.observed_type.clone(),
+                observation_count: instr.observation_count,
+                observed_slot: instr.observed_slot.clone(),
+                deopt_anchor: instr.deopt_anchor,
+                ic_slot: instr.ic_slot,
+            };
+        }
+    }
+    instr.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module_exports::IIRExport;
+
+    fn make_fn(name: &str) -> IIRFunction {
+        IIRFunction::new(
+            name,
+            vec![],
+            "void",
+            vec![IIRInstr::new("ret_void", None, vec![], "void")],
+        )
+    }
+
+    fn make_fn_calling(name: &str, callee: &str) -> IIRFunction {
+        IIRFunction::new(
+            name,
+            vec![],
+            "void",
+            vec![
+                IIRInstr::new(
+                    "call",
+                    Some("_ret".into()),
+                    vec![Operand::Var(callee.into())],
+                    "void",
+                ),
+                IIRInstr::new("ret_void", None, vec![], "void"),
+            ],
+        )
+    }
+
+    #[test]
+    fn merge_single_module_preserves_functions() {
+        let mut m = IIRModule::new("app", "twig");
+        m.add_or_replace(make_fn("main"));
+        let modules = vec![m];
+        let (map, _) = crate::resolve::build_export_map(&modules);
+        let merged = merge_modules(&modules, &map);
+        assert_eq!(merged.functions.len(), 1);
+        assert!(merged.get_function("main").is_some());
+    }
+
+    #[test]
+    fn merge_preserves_entry_point_from_first_module() {
+        let mut m1 = IIRModule::new("app", "twig");
+        m1.add_or_replace(make_fn("main"));
+        m1.entry_point = Some("main".into());
+
+        let mut m2 = IIRModule::new("lib", "twig");
+        m2.entry_point = Some("start".into());
+        m2.add_or_replace(make_fn("start"));
+
+        let modules = vec![m1, m2];
+        let (map, _) = crate::resolve::build_export_map(&modules);
+        let merged = merge_modules(&modules, &map);
+        assert_eq!(merged.entry_point, Some("main".into()));
+    }
+
+    #[test]
+    fn merge_renames_private_collision() {
+        // Both modules have a "helper" function — the second one gets prefixed.
+        let mut m1 = IIRModule::new("a", "twig");
+        m1.entry_point = None;
+        m1.add_or_replace(make_fn("helper"));
+
+        let mut m2 = IIRModule::new("b", "twig");
+        m2.entry_point = None;
+        m2.add_or_replace(make_fn("helper"));
+
+        let modules = vec![m1, m2];
+        let (map, _) = crate::resolve::build_export_map(&modules);
+        let merged = merge_modules(&modules, &map);
+
+        // One of them keeps "helper", the other gets "b::helper" (second module
+        // collides with first).
+        let names: std::collections::HashSet<&str> =
+            merged.functions.iter().map(|f| f.name.as_str()).collect();
+        assert!(names.contains("helper"));
+        assert!(names.contains("b::helper"));
+    }
+
+    #[test]
+    fn merge_clears_exports_and_imports() {
+        let mut m = IIRModule::new("app", "twig");
+        m.add_or_replace(make_fn("main"));
+        m.exports.push(IIRExport::new("main"));
+        let modules = vec![m];
+        let (map, _) = crate::resolve::build_export_map(&modules);
+        let merged = merge_modules(&modules, &map);
+        assert!(merged.exports.is_empty());
+        assert!(merged.imports.is_empty());
+    }
+
+    #[test]
+    fn rewrite_instr_rewrites_callee() {
+        let instr = IIRInstr::new(
+            "call",
+            Some("r".into()),
+            vec![Operand::Var("old_name".into()), Operand::Var("arg".into())],
+            "void",
+        );
+        let mut rewrites = HashMap::new();
+        rewrites.insert("old_name".to_string(), "new_name".to_string());
+        let rewritten = rewrite_instr(&instr, &rewrites);
+        assert_eq!(rewritten.srcs[0], Operand::Var("new_name".into()));
+        assert_eq!(rewritten.srcs[1], Operand::Var("arg".into()));
+    }
+
+    #[test]
+    fn rewrite_instr_leaves_non_call_unchanged() {
+        let instr = IIRInstr::new(
+            "add",
+            Some("r".into()),
+            vec![Operand::Var("a".into()), Operand::Var("b".into())],
+            "i64",
+        );
+        let mut rewrites = HashMap::new();
+        rewrites.insert("a".to_string(), "x".to_string());
+        let rewritten = rewrite_instr(&instr, &rewrites);
+        // "add" is not a "call" — no rewrite.
+        assert_eq!(rewritten.srcs[0], Operand::Var("a".into()));
+    }
+}

--- a/code/packages/rust/iir-linker/src/merge.rs
+++ b/code/packages/rust/iir-linker/src/merge.rs
@@ -101,8 +101,19 @@ pub fn merge_modules<'a>(
                     // In practice this loop runs at most once — it fires only
                     // when an adversarial (or pathological) module name was chosen
                     // specifically to trigger the base collision.
+                    // Safety cap: the number of distinct names we could ever
+                    // need is bounded by the total number of functions in all
+                    // modules.  If we exceed that count, every possible name
+                    // slot is occupied by adversarially-crafted input — panic
+                    // rather than spin indefinitely (DoS guard).
+                    let max_iterations = modules.iter().map(|m| m.functions.len()).sum::<usize>() + 1;
                     let mut counter: usize = 0;
                     loop {
+                        assert!(
+                            counter <= max_iterations,
+                            "name-collision counter exceeded safe bound ({max_iterations}): \
+                             adversarial module names suspected"
+                        );
                         let candidate = format!("{base}${counter}");
                         if !global_names.contains(&candidate) {
                             break candidate;

--- a/code/packages/rust/iir-linker/src/merge.rs
+++ b/code/packages/rust/iir-linker/src/merge.rs
@@ -82,7 +82,34 @@ pub fn merge_modules<'a>(
             }
             let name = if global_names.contains(&fn_.name) {
                 // Collision — prefix with module name.
-                format!("{}::{}", module.name, fn_.name)
+                //
+                // Security note: if a *different* module already has a function
+                // whose name happens to equal `"<module>::<fn_name>"` (e.g.
+                // module "a" exports "b::c" and module "b" has private "c"), the
+                // prefixed name would collide a second time.  To guarantee
+                // uniqueness we detect this case and append a monotonically
+                // increasing counter until we find a free slot.  This prevents
+                // the second `merged_name_map.insert` from silently overwriting
+                // the first entry and thereby redirecting call-rewrites to the
+                // wrong function.
+                let base = format!("{}::{}", module.name, fn_.name);
+                if !global_names.contains(&base) {
+                    base
+                } else {
+                    // Double-collision: append a counter to guarantee uniqueness.
+                    // We start at 0 and increment until we find a free slot.
+                    // In practice this loop runs at most once — it fires only
+                    // when an adversarial (or pathological) module name was chosen
+                    // specifically to trigger the base collision.
+                    let mut counter: usize = 0;
+                    loop {
+                        let candidate = format!("{base}${counter}");
+                        if !global_names.contains(&candidate) {
+                            break candidate;
+                        }
+                        counter += 1;
+                    }
+                }
             } else {
                 fn_.name.clone()
             };

--- a/code/packages/rust/iir-linker/src/resolve.rs
+++ b/code/packages/rust/iir-linker/src/resolve.rs
@@ -1,0 +1,354 @@
+//! Import/export resolution — the first pass of the static linker.
+//!
+//! # What this module does
+//!
+//! Given a slice of `IIRModule`s, `build_export_map` constructs a lookup table
+//! mapping `(module_name, public_name) → &IIRFunction`.  `resolve_imports` then
+//! walks every import in every module and checks it against this table.
+//!
+//! # Export map key
+//!
+//! The key is `(module_name, public_function_name)`.  `module_name` is the
+//! `IIRModule::name` field of the *exporting* module.  `public_function_name`
+//! is `IIRExport::public_name()` — the alias if one was set, otherwise the
+//! function name.
+//!
+//! # Type checking
+//!
+//! Type checking only fires when the import provides non-empty `param_types`
+//! and/or a return type other than `"any"`.  The importer is checked against
+//! the exporter's `IIRFunction::params` and `return_type`.
+//!
+//! This is intentionally lenient: a caller that doesn't know or doesn't care
+//! about types (e.g., a dynamically typed language frontend) can still use the
+//! linker.
+
+use std::collections::HashMap;
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::module::IIRModule;
+use interpreter_ir::module_exports::IIRImport;
+
+use crate::error::LinkError;
+
+/// A resolved export: which module owns it and a reference to the function.
+pub struct ResolvedExport<'a> {
+    pub exporting_module: &'a str,
+    pub function: &'a IIRFunction,
+}
+
+/// Build an export map from a set of modules.
+///
+/// Returns `(map, errors)` where `errors` contains one `DuplicateExport` per
+/// collision.
+///
+/// # Key
+///
+/// `(exporting_module_name, public_function_name)` — both strings as owned
+/// `String`s to avoid lifetime headaches in the caller.
+pub fn build_export_map<'a>(
+    modules: &'a [IIRModule],
+) -> (HashMap<(String, String), ResolvedExport<'a>>, Vec<LinkError>) {
+    let mut map: HashMap<(String, String), ResolvedExport<'a>> = HashMap::new();
+    let mut errors: Vec<LinkError> = Vec::new();
+
+    for module in modules {
+        // If the module has no explicit exports, it exports *nothing* —
+        // functions are private by default (LANG33 design goal).
+        // Backward-compat: an empty `exports` list means no exports at all.
+        for export in &module.exports {
+            let key = (module.name.clone(), export.public_name().to_string());
+            if map.contains_key(&key) {
+                errors.push(LinkError::DuplicateExport {
+                    module_name: module.name.clone(),
+                    function_name: export.public_name().to_string(),
+                });
+                // Keep the first definition in the map so we continue
+                // resolving later imports and can report more errors.
+                continue;
+            }
+            // The validator already checked that function_name exists, so
+            // `unwrap_or_else` is a belt-and-suspenders fallback.
+            if let Some(fn_) = module.get_function(&export.function_name) {
+                map.insert(
+                    key,
+                    ResolvedExport {
+                        exporting_module: &module.name,
+                        function: fn_,
+                    },
+                );
+            }
+        }
+    }
+
+    (map, errors)
+}
+
+/// Resolve all imports in `modules` against the export map.
+///
+/// Returns a list of `LinkError`s (empty = all imports satisfied).
+///
+/// Each import is matched by `(import.module_name, import.function_name)`.
+/// If found, and if the import carries type annotations, the types are checked
+/// against the exported function's declared signature.
+pub fn resolve_imports<'a>(
+    modules: &'a [IIRModule],
+    export_map: &HashMap<(String, String), ResolvedExport<'a>>,
+) -> Vec<LinkError> {
+    let mut errors = Vec::new();
+
+    for module in modules {
+        for import in &module.imports {
+            check_import(module, import, export_map, &mut errors);
+        }
+    }
+
+    errors
+}
+
+/// Verify that all imports in `module` are satisfied by `providers`.
+///
+/// This is the `verify_imports` entry point — it does not merge anything.
+/// Used by the REPL to pre-flight an import before full linking.
+pub fn verify_imports_against(
+    module: &IIRModule,
+    providers: &[&IIRModule],
+) -> Vec<LinkError> {
+    // Build a lightweight export map from just the provider modules.
+    // We clone the provider slice into an owned Vec so we can call
+    // `build_export_map` which takes `&[IIRModule]`.
+    let owned: Vec<IIRModule> = providers.iter().map(|m| (*m).clone()).collect();
+    let (map, mut errors) = build_export_map(&owned);
+    for import in &module.imports {
+        check_import(module, import, &map, &mut errors);
+    }
+    errors
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn check_import<'a>(
+    importing_module: &IIRModule,
+    import: &IIRImport,
+    export_map: &HashMap<(String, String), ResolvedExport<'a>>,
+    errors: &mut Vec<LinkError>,
+) {
+    let key = (import.module_name.clone(), import.function_name.clone());
+    match export_map.get(&key) {
+        None => {
+            errors.push(LinkError::Unresolved {
+                importing_module: importing_module.name.clone(),
+                import_module: import.module_name.clone(),
+                import_function: import.function_name.clone(),
+            });
+        }
+        Some(resolved) => {
+            // Type-check only when the import carries annotations.
+            check_types(importing_module, import, resolved, errors);
+        }
+    }
+}
+
+fn check_types<'a>(
+    importing_module: &IIRModule,
+    import: &IIRImport,
+    resolved: &ResolvedExport<'a>,
+    errors: &mut Vec<LinkError>,
+) {
+    // Skip type checking if the import says "don't check".
+    if import.param_types.is_empty() && import.return_type == "any" {
+        return;
+    }
+
+    let fn_ = resolved.function;
+
+    // Parameter type check: only if the import specifies param types.
+    if !import.param_types.is_empty() {
+        let actual: Vec<String> = fn_.params.iter().map(|(_, t)| t.clone()).collect();
+        if import.param_types != actual {
+            errors.push(LinkError::TypeMismatch {
+                importing_module: importing_module.name.clone(),
+                exporting_module: resolved.exporting_module.to_string(),
+                function: import.function_name.clone(),
+                expected: import.param_types.clone(),
+                actual,
+            });
+        }
+    }
+
+    // Return type check: only if the import specifies a concrete return type.
+    if import.return_type != "any" && import.return_type != fn_.return_type {
+        // If we already emitted a TypeMismatch for params, the return type
+        // mismatch is part of the same semantic error — but we still report it
+        // separately so the user sees the full picture.
+        errors.push(LinkError::TypeMismatch {
+            importing_module: importing_module.name.clone(),
+            exporting_module: resolved.exporting_module.to_string(),
+            function: import.function_name.clone(),
+            expected: vec![import.return_type.clone()],
+            actual: vec![fn_.return_type.clone()],
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module_exports::{IIRExport, IIRImport};
+
+    fn make_fn(name: &str, params: Vec<(&str, &str)>, ret: &str) -> IIRFunction {
+        let params: Vec<(String, String)> = params
+            .into_iter()
+            .map(|(n, t)| (n.to_string(), t.to_string()))
+            .collect();
+        IIRFunction::new(
+            name,
+            params,
+            ret,
+            vec![IIRInstr::new("ret_void", None, vec![], "void")],
+        )
+    }
+
+    fn make_math_module() -> IIRModule {
+        let mut m = IIRModule::new("math", "twig");
+        m.entry_point = None;
+        m.add_or_replace(make_fn("add", vec![("a", "i64"), ("b", "i64")], "i64"));
+        m.exports.push(IIRExport::new("add"));
+        m
+    }
+
+    #[test]
+    fn export_map_built_correctly() {
+        let math = make_math_module();
+        let modules = vec![math];
+        let (map, errs) = build_export_map(&modules);
+        assert!(errs.is_empty());
+        let key = ("math".to_string(), "add".to_string());
+        assert!(map.contains_key(&key));
+    }
+
+    #[test]
+    fn export_map_alias_used_as_key() {
+        let mut m = IIRModule::new("math", "twig");
+        m.entry_point = None;
+        m.add_or_replace(make_fn("internal_sqrt", vec![("x", "f64")], "f64"));
+        m.exports.push(IIRExport::new("internal_sqrt").with_alias("sqrt"));
+        let modules = vec![m];
+        let (map, errs) = build_export_map(&modules);
+        assert!(errs.is_empty());
+        // Key is the *alias* ("sqrt"), not the internal name.
+        assert!(map.contains_key(&("math".to_string(), "sqrt".to_string())));
+        assert!(!map.contains_key(&("math".to_string(), "internal_sqrt".to_string())));
+    }
+
+    #[test]
+    fn duplicate_export_produces_error() {
+        let mut m1 = IIRModule::new("math", "twig");
+        m1.entry_point = None;
+        m1.add_or_replace(make_fn("add", vec![], "i64"));
+        m1.exports.push(IIRExport::new("add"));
+
+        let mut m2 = IIRModule::new("math", "twig"); // same module name!
+        m2.entry_point = None;
+        m2.add_or_replace(make_fn("add", vec![], "i64"));
+        m2.exports.push(IIRExport::new("add"));
+
+        let modules = vec![m1, m2];
+        let (_, errs) = build_export_map(&modules);
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(&errs[0], LinkError::DuplicateExport { function_name, .. } if function_name == "add"));
+    }
+
+    #[test]
+    fn resolve_import_satisfied() {
+        let math = make_math_module();
+        let mut main = IIRModule::new("main", "twig");
+        main.entry_point = None;
+        main.imports.push(IIRImport::new("math", "add", "any"));
+        let modules = vec![math, main];
+        let (map, _) = build_export_map(&modules);
+        let errs = resolve_imports(&modules, &map);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn resolve_import_unresolved() {
+        let mut main = IIRModule::new("main", "twig");
+        main.entry_point = None;
+        main.imports.push(IIRImport::new("math", "missing_fn", "any"));
+        let modules = vec![main];
+        let (map, _) = build_export_map(&modules);
+        let errs = resolve_imports(&modules, &map);
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(&errs[0], LinkError::Unresolved { import_function, .. } if import_function == "missing_fn"));
+    }
+
+    #[test]
+    fn type_check_passes_when_matching() {
+        let math = make_math_module();
+        let mut main = IIRModule::new("main", "twig");
+        main.entry_point = None;
+        main.imports.push(
+            IIRImport::new("math", "add", "i64")
+                .with_params(vec!["i64".into(), "i64".into()]),
+        );
+        let modules = vec![math, main];
+        let (map, _) = build_export_map(&modules);
+        let errs = resolve_imports(&modules, &map);
+        assert!(errs.is_empty(), "unexpected errors: {errs:?}");
+    }
+
+    #[test]
+    fn type_check_fails_on_param_mismatch() {
+        let math = make_math_module(); // "add" takes (i64, i64) → i64
+        let mut main = IIRModule::new("main", "twig");
+        main.entry_point = None;
+        main.imports.push(
+            IIRImport::new("math", "add", "i64")
+                .with_params(vec!["f64".into(), "f64".into()]), // wrong!
+        );
+        let modules = vec![math, main];
+        let (map, _) = build_export_map(&modules);
+        let errs = resolve_imports(&modules, &map);
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(&errs[0], LinkError::TypeMismatch { function, .. } if function == "add"));
+    }
+
+    #[test]
+    fn type_check_skipped_when_import_uses_any() {
+        let math = make_math_module();
+        let mut main = IIRModule::new("main", "twig");
+        main.entry_point = None;
+        // "any" return type + empty params = skip type checking.
+        main.imports.push(IIRImport::new("math", "add", "any"));
+        let modules = vec![math, main];
+        let (map, _) = build_export_map(&modules);
+        let errs = resolve_imports(&modules, &map);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn verify_imports_against_works() {
+        let math = make_math_module();
+        let mut main = IIRModule::new("main", "twig");
+        main.entry_point = None;
+        main.imports.push(IIRImport::new("math", "add", "any"));
+        let errs = verify_imports_against(&main, &[&math]);
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn verify_imports_against_returns_unresolved() {
+        let math = make_math_module();
+        let mut main = IIRModule::new("main", "twig");
+        main.entry_point = None;
+        main.imports.push(IIRImport::new("math", "nonexistent", "any"));
+        let errs = verify_imports_against(&main, &[&math]);
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(&errs[0], LinkError::Unresolved { import_function, .. } if import_function == "nonexistent"));
+    }
+}

--- a/code/packages/rust/iir-linker/tests/test_linker.rs
+++ b/code/packages/rust/iir-linker/tests/test_linker.rs
@@ -1,0 +1,464 @@
+//! Integration tests for `iir-linker`.
+//!
+//! These tests exercise the full `link` / `link_strict` / `verify_imports`
+//! APIs from the outside, using `interpreter_ir` types exactly as a language
+//! frontend or tool would.
+//!
+//! The tests are organised into sections:
+//!
+//! - Basic linking (happy path)
+//! - Error cases (Unresolved, TypeMismatch, DuplicateExport)
+//! - Name collision renaming
+//! - Call instruction rewriting
+//! - `link_strict` behaviour
+//! - `verify_imports` pre-flight
+//! - Edge cases (empty modules, no entry point, etc.)
+
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::module::IIRModule;
+use interpreter_ir::module_exports::{IIRExport, IIRImport};
+use iir_linker::{link, link_strict, verify_imports, LinkError};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_fn(name: &str, params: Vec<(&str, &str)>, ret: &str) -> IIRFunction {
+    IIRFunction::new(
+        name,
+        params.into_iter().map(|(n, t)| (n.into(), t.into())).collect(),
+        ret,
+        vec![IIRInstr::new("ret_void", None, vec![], "void")],
+    )
+}
+
+fn make_fn_calling(name: &str, callee: &str) -> IIRFunction {
+    IIRFunction::new(
+        name,
+        vec![],
+        "void",
+        vec![
+            IIRInstr::new(
+                "call",
+                Some("_r".into()),
+                vec![Operand::Var(callee.into())],
+                "void",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    )
+}
+
+/// Build a "math" module that exports `add(i64, i64) → i64`.
+fn math_module() -> IIRModule {
+    let mut m = IIRModule::new("math", "twig");
+    m.entry_point = None;
+    m.add_or_replace(make_fn("add", vec![("a", "i64"), ("b", "i64")], "i64"));
+    m.exports.push(IIRExport::new("add"));
+    m
+}
+
+/// Build an "app" module whose "main" calls imported "add" from "math".
+fn app_module_importing_add() -> IIRModule {
+    let mut m = IIRModule::new("app", "twig");
+    m.add_or_replace(make_fn_calling("main", "add"));
+    m.imports.push(IIRImport::new("math", "add", "any"));
+    m
+}
+
+// ---------------------------------------------------------------------------
+// Basic linking — happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn link_two_modules_succeeds() {
+    let merged = link(&[math_module(), app_module_importing_add()]).unwrap();
+    assert!(merged.get_function("add").is_some());
+    assert!(merged.get_function("main").is_some());
+}
+
+#[test]
+fn merged_module_has_no_imports() {
+    let merged = link(&[math_module(), app_module_importing_add()]).unwrap();
+    assert!(merged.imports.is_empty());
+}
+
+#[test]
+fn merged_module_has_no_exports() {
+    let merged = link(&[math_module(), app_module_importing_add()]).unwrap();
+    assert!(merged.exports.is_empty());
+}
+
+#[test]
+fn entry_point_preserved_from_first_module_with_one() {
+    let math = math_module(); // entry_point = None
+    let mut app = app_module_importing_add();
+    app.entry_point = Some("main".into());
+    let merged = link(&[math, app]).unwrap();
+    assert_eq!(merged.entry_point, Some("main".into()));
+}
+
+#[test]
+fn link_single_module_no_imports_succeeds() {
+    let mut m = IIRModule::new("prog", "twig");
+    m.add_or_replace(make_fn("main", vec![], "void"));
+    let merged = link(&[m]).unwrap();
+    assert_eq!(merged.functions.len(), 1);
+}
+
+#[test]
+fn link_three_modules_all_merged() {
+    let mut io = IIRModule::new("io", "twig");
+    io.entry_point = None;
+    io.add_or_replace(make_fn("print", vec![("s", "str")], "void"));
+    io.exports.push(IIRExport::new("print"));
+
+    let math = math_module();
+
+    let mut app = IIRModule::new("app", "twig");
+    app.add_or_replace(make_fn("main", vec![], "void"));
+    app.imports.push(IIRImport::new("math", "add", "any"));
+    app.imports.push(IIRImport::new("io", "print", "any"));
+
+    let merged = link(&[io, math, app]).unwrap();
+    assert!(merged.get_function("print").is_some());
+    assert!(merged.get_function("add").is_some());
+    assert!(merged.get_function("main").is_some());
+}
+
+#[test]
+fn exported_alias_resolved_by_importer() {
+    // Module "math" exports "internal_sqrt" under the alias "sqrt".
+    let mut m = IIRModule::new("math", "twig");
+    m.entry_point = None;
+    m.add_or_replace(make_fn("internal_sqrt", vec![("x", "f64")], "f64"));
+    m.exports.push(IIRExport::new("internal_sqrt").with_alias("sqrt"));
+
+    // App imports "sqrt" (the alias, not "internal_sqrt").
+    let mut app = IIRModule::new("app", "twig");
+    app.add_or_replace(make_fn("main", vec![], "void"));
+    app.imports.push(IIRImport::new("math", "sqrt", "any"));
+
+    let merged = link(&[m, app]).unwrap();
+    // The merged function keeps the exported alias name "sqrt".
+    assert!(merged.get_function("sqrt").is_some());
+}
+
+#[test]
+fn local_alias_used_in_call_instructions() {
+    // App imports "add" from "math" under the local alias "math_add".
+    let mut app = IIRModule::new("app", "twig");
+    app.add_or_replace(make_fn_calling("main", "math_add")); // calls "math_add"
+    app.imports.push(
+        IIRImport::new("math", "add", "any").with_local_alias("math_add"),
+    );
+
+    let merged = link(&[math_module(), app]).unwrap();
+    // After linking, "math_add" in the call instruction should be rewritten to "add".
+    let main_fn = merged.get_function("main").unwrap();
+    if let Some(call_instr) = main_fn.instructions.iter().find(|i| i.op == "call") {
+        if let Some(Operand::Var(callee)) = call_instr.srcs.first() {
+            assert_eq!(callee, "add", "call should target 'add' after rewrite");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unresolved_import_returns_error() {
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    app.imports.push(IIRImport::new("nonexistent_mod", "fn_a", "any"));
+    let errs = link(&[app]).unwrap_err();
+    assert!(errs.iter().any(|e| matches!(e,
+        LinkError::Unresolved { import_module, import_function, .. }
+        if import_module == "nonexistent_mod" && import_function == "fn_a"
+    )));
+}
+
+#[test]
+fn multiple_unresolved_imports_all_reported() {
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    app.imports.push(IIRImport::new("x", "a", "any"));
+    app.imports.push(IIRImport::new("x", "b", "any"));
+    app.imports.push(IIRImport::new("y", "c", "any"));
+    let errs = link(&[app]).unwrap_err();
+    assert_eq!(errs.len(), 3);
+    assert!(errs.iter().all(|e| matches!(e, LinkError::Unresolved { .. })));
+}
+
+#[test]
+fn type_mismatch_on_param_types() {
+    let math = math_module(); // add(i64, i64) → i64
+
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    // Caller expects (f64, f64) but "add" takes (i64, i64).
+    app.imports.push(
+        IIRImport::new("math", "add", "i64")
+            .with_params(vec!["f64".into(), "f64".into()]),
+    );
+
+    let errs = link(&[math, app]).unwrap_err();
+    assert!(errs.iter().any(|e| matches!(e, LinkError::TypeMismatch { .. })));
+}
+
+#[test]
+fn type_mismatch_on_return_type() {
+    let math = math_module(); // add returns "i64"
+
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    // Caller expects return type "f64", exporter returns "i64".
+    app.imports.push(IIRImport::new("math", "add", "f64")); // wrong return type
+
+    let errs = link(&[math, app]).unwrap_err();
+    assert!(errs.iter().any(|e| matches!(e, LinkError::TypeMismatch { .. })));
+}
+
+#[test]
+fn type_check_skipped_for_any_return_type() {
+    let math = math_module(); // add returns "i64"
+
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    // "any" return = don't check.
+    app.imports.push(IIRImport::new("math", "add", "any"));
+
+    let result = link(&[math, app]);
+    assert!(result.is_ok(), "should not type-check when return type is 'any'");
+}
+
+#[test]
+fn duplicate_export_detected() {
+    let mut m1 = IIRModule::new("math", "twig");
+    m1.entry_point = None;
+    m1.add_or_replace(make_fn("sqrt", vec![("x", "f64")], "f64"));
+    m1.exports.push(IIRExport::new("sqrt"));
+
+    let mut m2 = IIRModule::new("math", "twig"); // Same module name!
+    m2.entry_point = None;
+    m2.add_or_replace(make_fn("sqrt", vec![("x", "f64")], "f64"));
+    m2.exports.push(IIRExport::new("sqrt"));
+
+    let errs = link(&[m1, m2]).unwrap_err();
+    assert!(errs.iter().any(|e| matches!(e, LinkError::DuplicateExport { function_name, .. } if function_name == "sqrt")));
+}
+
+// ---------------------------------------------------------------------------
+// Name collision renaming
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_functions_with_same_name_get_renamed() {
+    let mut m1 = IIRModule::new("a", "twig");
+    m1.entry_point = None;
+    m1.add_or_replace(make_fn("helper", vec![], "void"));
+
+    let mut m2 = IIRModule::new("b", "twig");
+    m2.entry_point = None;
+    m2.add_or_replace(make_fn("helper", vec![], "void"));
+
+    let merged = link(&[m1, m2]).unwrap();
+    let names: Vec<&str> = merged.functions.iter().map(|f| f.name.as_str()).collect();
+    // First module's "helper" keeps the name; second gets "b::helper".
+    assert!(names.contains(&"helper"));
+    assert!(names.contains(&"b::helper"));
+}
+
+#[test]
+fn exported_function_name_takes_priority_in_collision() {
+    // Module "lib" exports "format".
+    // Module "app" also has a private "format" — it should be renamed.
+    let mut lib = IIRModule::new("lib", "twig");
+    lib.entry_point = None;
+    lib.add_or_replace(make_fn("format", vec![], "str"));
+    lib.exports.push(IIRExport::new("format"));
+
+    let mut app = IIRModule::new("app", "twig");
+    app.add_or_replace(make_fn("format", vec![], "str")); // private — should be renamed
+    app.add_or_replace(make_fn("main", vec![], "void"));
+    app.imports.push(IIRImport::new("lib", "format", "any"));
+
+    let merged = link(&[lib, app]).unwrap();
+    // "format" exists (from the exported function).
+    assert!(merged.get_function("format").is_some());
+    // The private "format" from "app" was renamed to "app::format".
+    assert!(merged.get_function("app::format").is_some());
+}
+
+// ---------------------------------------------------------------------------
+// link_strict
+// ---------------------------------------------------------------------------
+
+#[test]
+fn link_strict_succeeds_on_valid_input() {
+    let result = link_strict(&[math_module(), app_module_importing_add()]);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn link_strict_returns_first_error_on_failure() {
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    app.imports.push(IIRImport::new("x", "a", "any"));
+    app.imports.push(IIRImport::new("x", "b", "any"));
+
+    let err = link_strict(&[app]).unwrap_err();
+    assert!(matches!(err, LinkError::Unresolved { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// verify_imports
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verify_imports_empty_when_all_satisfied() {
+    let math = math_module();
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    app.imports.push(IIRImport::new("math", "add", "any"));
+
+    let errs = verify_imports(&app, &[&math]);
+    assert!(errs.is_empty());
+}
+
+#[test]
+fn verify_imports_reports_unresolved() {
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    app.imports.push(IIRImport::new("math", "sqrt", "any"));
+
+    let errs = verify_imports(&app, &[]);
+    assert_eq!(errs.len(), 1);
+    assert!(matches!(&errs[0], LinkError::Unresolved { import_function, .. } if import_function == "sqrt"));
+}
+
+#[test]
+fn verify_imports_does_not_modify_modules() {
+    let math = math_module();
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    app.imports.push(IIRImport::new("math", "add", "any"));
+
+    let original_import_count = app.imports.len();
+    let _ = verify_imports(&app, &[&math]);
+    // verify_imports is pure — it does not alter the module.
+    assert_eq!(app.imports.len(), original_import_count);
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn link_empty_slice_returns_empty_module() {
+    let merged = link(&[]).unwrap();
+    assert!(merged.functions.is_empty());
+    assert!(merged.exports.is_empty());
+    assert!(merged.imports.is_empty());
+}
+
+#[test]
+fn link_module_with_no_entry_point_succeeds() {
+    let mut m = IIRModule::new("lib", "twig");
+    m.entry_point = None;
+    m.add_or_replace(make_fn("helper", vec![], "void"));
+    m.exports.push(IIRExport::new("helper"));
+
+    let merged = link(&[m]).unwrap();
+    assert_eq!(merged.entry_point, None);
+}
+
+#[test]
+fn link_multiple_modules_all_with_none_entry_point() {
+    let mut m1 = IIRModule::new("a", "twig");
+    m1.entry_point = None;
+    m1.add_or_replace(make_fn("fa", vec![], "void"));
+
+    let mut m2 = IIRModule::new("b", "twig");
+    m2.entry_point = None;
+    m2.add_or_replace(make_fn("fb", vec![], "void"));
+
+    let merged = link(&[m1, m2]).unwrap();
+    assert_eq!(merged.entry_point, None);
+}
+
+#[test]
+fn imported_function_with_type_annotations_passes_when_matching() {
+    let math = math_module(); // add(i64, i64) → i64
+
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    app.imports.push(
+        IIRImport::new("math", "add", "i64")
+            .with_params(vec!["i64".into(), "i64".into()]),
+    );
+
+    let result = link(&[math, app]);
+    assert!(result.is_ok(), "type-annotated import should succeed: {result:?}");
+}
+
+#[test]
+fn empty_param_types_with_concrete_return_type_only_checks_return() {
+    let math = math_module(); // add returns "i64"
+
+    let mut app = IIRModule::new("app", "twig");
+    app.entry_point = None;
+    // Empty param_types = don't check params.  Return type "i64" matches.
+    app.imports.push(IIRImport::new("math", "add", "i64"));
+
+    let result = link(&[math, app]);
+    assert!(result.is_ok(), "return type check should pass: {result:?}");
+}
+
+#[test]
+fn link_error_display_is_non_empty() {
+    let e = LinkError::Unresolved {
+        importing_module: "main".into(),
+        import_module: "math".into(),
+        import_function: "log".into(),
+    };
+    let s = format!("{e}");
+    assert!(!s.is_empty());
+    assert!(s.contains("log"));
+}
+
+#[test]
+fn link_result_module_name_from_first_input() {
+    let math = math_module(); // name = "math"
+    let app = app_module_importing_add(); // name = "app"
+    let merged = link(&[math, app]).unwrap();
+    // Name comes from the first module.
+    assert_eq!(merged.name, "math");
+}
+
+#[test]
+fn merged_module_validates_cleanly() {
+    let merged = link(&[math_module(), app_module_importing_add()]).unwrap();
+    let errors = merged.validate();
+    assert!(errors.is_empty(), "merged module should validate cleanly: {errors:?}");
+}
+
+#[test]
+fn link_iir_linker_struct_api_matches_free_fn() {
+    // The IIRLinker struct API must produce the same result as the free function.
+    use iir_linker::IIRLinker;
+    let linker = IIRLinker::new();
+    let via_struct = linker
+        .link(&[math_module(), app_module_importing_add()])
+        .unwrap();
+    let via_free = link(&[math_module(), app_module_importing_add()]).unwrap();
+
+    // Both should have the same function names.
+    let names_struct: std::collections::BTreeSet<&str> =
+        via_struct.functions.iter().map(|f| f.name.as_str()).collect();
+    let names_free: std::collections::BTreeSet<&str> =
+        via_free.functions.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names_struct, names_free);
+}

--- a/code/packages/rust/iir-to-beam/src/codegen.rs
+++ b/code/packages/rust/iir-to-beam/src/codegen.rs
@@ -22,6 +22,8 @@
 //!     functions: vec![fn_],
 //!     entry_point: Some("main".into()),
 //!     language: "test".into(),
+//!     exports: vec![],
+//!     imports: vec![],
 //! };
 //!
 //! let gen = IIRBeamCodeGenerator::new("demo");

--- a/code/packages/rust/iir-to-beam/src/codegen.rs
+++ b/code/packages/rust/iir-to-beam/src/codegen.rs
@@ -127,6 +127,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 

--- a/code/packages/rust/iir-to-beam/src/lib.rs
+++ b/code/packages/rust/iir-to-beam/src/lib.rs
@@ -38,6 +38,8 @@
 //!     functions: vec![fn_],
 //!     entry_point: Some("main".into()),
 //!     language: "test".into(),
+//!     exports: vec![],
+//!     imports: vec![],
 //! };
 //!
 //! let errors = validate_for_beam(&module);

--- a/code/packages/rust/iir-to-beam/src/lower.rs
+++ b/code/packages/rust/iir-to-beam/src/lower.rs
@@ -1725,6 +1725,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 

--- a/code/packages/rust/iir-to-beam/src/validate.rs
+++ b/code/packages/rust/iir-to-beam/src/validate.rs
@@ -308,6 +308,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -318,6 +320,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let errs = validate_for_beam(&module);
         assert!(!errs.is_empty(), "should reject empty module");

--- a/code/packages/rust/iir-to-beam/src/validate.rs
+++ b/code/packages/rust/iir-to-beam/src/validate.rs
@@ -143,6 +143,8 @@ const UNSUPPORTED_OPS: &[&str] = &[
 ///     functions: vec![fn_],
 ///     entry_point: Some("main".into()),
 ///     language: "test".into(),
+///     exports: vec![],
+///     imports: vec![],
 /// };
 /// assert!(validate_for_beam(&module).is_empty());
 /// ```

--- a/code/packages/rust/iir-to-beam/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-beam/tests/test_backend.rs
@@ -37,6 +37,8 @@ fn make_module_single(instrs: Vec<IIRInstr>) -> IIRModule {
         functions: vec![fn_],
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -58,6 +60,8 @@ fn make_module_fn(
         functions: vec![fn_],
         entry_point: Some(fn_name.into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -102,6 +106,8 @@ fn test_empty_module_rejected() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errs = validate_for_beam(&module);
     assert!(!errs.is_empty(), "should reject empty module");
@@ -1109,6 +1115,8 @@ fn test_call_function() {
         functions: vec![add_two, main_fn],
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let beam = lower_iir_to_beam(&module, &IIRBeamConfig::new("multi")).unwrap();
     assert!(has_opcode(&beam, OP_CALL), "expected call instruction");
@@ -1138,6 +1146,8 @@ fn test_multi_function_exports() {
         functions: vec![fn1, fn2],
         entry_point: Some("foo".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let beam = lower_iir_to_beam(&module, &IIRBeamConfig::new("two_fn")).unwrap();
     assert_eq!(beam.exports.len(), 2, "expected 2 exports for 2 functions");
@@ -1353,6 +1363,8 @@ fn test_46_alloc_lispy_pair_accepted_by_validator() {
         functions: vec![fn_],
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errs = validate_for_beam(&module);
     assert!(

--- a/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
@@ -1335,6 +1335,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -1349,6 +1351,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let result = lower_iir_to_cil(&module, &default_cfg());
         assert!(matches!(result, Err(IIRClrError::ValidationFailed(_))));

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -161,6 +161,8 @@ const LISTY_PAIR_TYPE: &str = "ref<LispyPair>";
 ///     functions: vec![fn_],
 ///     entry_point: Some("main".into()),
 ///     language: "test".into(),
+///     exports: vec![],
+///     imports: vec![],
 /// };
 /// assert!(validate_iir_for_clr(&module).is_empty());
 /// ```

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -326,6 +326,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -336,6 +338,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let errs = validate_iir_for_clr(&module);
         assert!(!errs.is_empty(), "should reject empty module");

--- a/code/packages/rust/iir-to-cil-bytecode/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/tests/test_backend.rs
@@ -78,6 +78,8 @@ fn validate_empty_module_is_rejected() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errs = validate_iir_for_clr(&module);
     assert!(!errs.is_empty());
@@ -734,6 +736,8 @@ fn lower_validation_failure_returns_err() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let result = lower_iir_to_cil(&module, &default_cfg());
     assert!(matches!(result, Err(IIRClrError::ValidationFailed(_))));
@@ -1169,6 +1173,8 @@ fn codegen_validate_bad_module_returns_errors() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = IIRClrCodeGenerator::default_name().validate(&module);
     assert!(!errors.is_empty());

--- a/code/packages/rust/iir-to-jvm-class-file/src/codegen.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/codegen.rs
@@ -176,6 +176,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -199,6 +201,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("add".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -235,6 +239,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let errors = gen.validate(&empty);
         assert!(!errors.is_empty());

--- a/code/packages/rust/iir-to-jvm-class-file/src/codegen.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/codegen.rs
@@ -32,6 +32,8 @@
 //!     functions: vec![fn_],
 //!     entry_point: Some("main".into()),
 //!     language: "test".into(),
+//!     exports: vec![],
+//!     imports: vec![],
 //! };
 //!
 //! // Create a generator with a custom class name.

--- a/code/packages/rust/iir-to-jvm-class-file/src/lib.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lib.rs
@@ -37,6 +37,8 @@
 //!     functions: vec![fn_],
 //!     entry_point: Some("main".into()),
 //!     language: "test".into(),
+//!     exports: vec![],
+//!     imports: vec![],
 //! };
 //!
 //! let errors = validate_for_jvm(&module);

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -2306,6 +2306,8 @@ fn cond_and_label<'a>(
 ///     functions: vec![fn_],
 ///     entry_point: Some("add".into()),
 ///     language: "test".into(),
+///     exports: vec![],
+///     imports: vec![],
 /// };
 /// let cfg = IIRJvmConfig::new("MyClass");
 /// let class_file = lower_iir_to_jvm(&module, &cfg).unwrap();

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -2374,6 +2374,8 @@ mod tests {
             functions: vec![func],
             entry_point: Some(name),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -2454,6 +2456,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let result = lower_iir_to_jvm(&module, &make_cfg());
         assert!(matches!(result, Err(IIRJvmError::ValidationFailed(_))));

--- a/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
@@ -121,6 +121,8 @@ const CONDITIONALLY_SUPPORTED_OPS: &[&str] = &["alloc", "field_load", "field_sto
 ///     functions: vec![fn_],
 ///     entry_point: Some("main".into()),
 ///     language: "test".into(),
+///     exports: vec![],
+///     imports: vec![],
 /// };
 /// assert!(validate_for_jvm(&module).is_empty());
 /// ```

--- a/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
@@ -257,6 +257,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -267,6 +269,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let errs = validate_for_jvm(&module);
         assert!(!errs.is_empty(), "should reject empty module");

--- a/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
@@ -37,6 +37,8 @@ fn module_with(func: IIRFunction) -> IIRModule {
         functions: vec![func],
         entry_point: Some(name),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -86,6 +88,8 @@ fn validate_rejects_empty_module() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = validate_for_jvm(&module);
     assert!(!errors.is_empty(), "empty module should produce errors");
@@ -206,6 +210,8 @@ fn validate_accepts_f32_type() {
         functions: vec![func, f32_func],
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errors = validate_for_jvm(&module);
     assert!(
@@ -339,6 +345,8 @@ fn lower_empty_module_returns_error() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let result = lower_iir_to_jvm(&module, &IIRJvmConfig::default());
     assert!(matches!(result, Err(IIRJvmError::ValidationFailed(_))));
@@ -566,6 +574,8 @@ fn lower_two_functions_two_methods() {
         functions: vec![void_fn("foo"), void_fn("bar")],
         entry_point: Some("foo".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let class = lower(&module);
     assert_eq!(class.methods.len(), 2);
@@ -579,6 +589,8 @@ fn lower_two_functions_method_names() {
         functions: vec![void_fn("alpha"), void_fn("beta")],
         entry_point: Some("alpha".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let class = lower(&module);
     assert_eq!(class.methods[0].name, "alpha");
@@ -593,6 +605,8 @@ fn lower_three_functions_three_methods() {
         functions: vec![void_fn("a"), void_fn("b"), void_fn("c")],
         entry_point: Some("a".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let class = lower(&module);
     assert_eq!(class.methods.len(), 3);
@@ -606,6 +620,8 @@ fn lower_multi_fn_all_methods_have_code() {
         functions: vec![void_fn("x"), void_fn("y")],
         entry_point: Some("x".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let class = lower(&module);
     for method in &class.methods {
@@ -930,6 +946,8 @@ fn lower_call_same_module_ok() {
         functions: vec![callee, caller],
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let result = lower_iir_to_jvm(&module, &IIRJvmConfig::new("CallTest"));
     assert!(result.is_ok(), "call should succeed: {:?}", result.err());
@@ -953,6 +971,8 @@ fn bytecode_call_non_empty() {
         functions: vec![callee, caller],
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let class = lower_iir_to_jvm(&module, &IIRJvmConfig::new("CallTest")).unwrap();
     // Find the "main" method (index 1)
@@ -988,6 +1008,8 @@ fn codegen_validate_errors_on_empty_module() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     assert!(!gen.validate(&empty).is_empty());
 }
@@ -1010,6 +1032,8 @@ fn codegen_generate_method_count() {
         functions: vec![void_fn("a"), void_fn("b"), void_fn("c")],
         entry_point: Some("a".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let class = gen.generate(&module);
     assert_eq!(class.methods.len(), 3);

--- a/code/packages/rust/iir-to-wasm/src/codegen.rs
+++ b/code/packages/rust/iir-to-wasm/src/codegen.rs
@@ -538,6 +538,8 @@ use crate::validate::validate_for_wasm;
 ///     functions: vec![fn_],
 ///     entry_point: Some("add".into()),
 ///     language: "test".into(),
+///     exports: vec![],
+///     imports: vec![],
 /// };
 ///
 /// let gen = IIRWasmCodeGenerator::new("calc");

--- a/code/packages/rust/iir-to-wasm/src/codegen.rs
+++ b/code/packages/rust/iir-to-wasm/src/codegen.rs
@@ -645,6 +645,8 @@ mod codegen_tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -683,6 +685,8 @@ mod codegen_tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let errs = gen.validate(&empty);
         assert!(!errs.is_empty());
@@ -709,6 +713,8 @@ mod codegen_tests {
             functions: vec![fn_],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let errs = gen.validate(&module);
         assert!(errs.iter().any(|e| e.contains("UntypedInstruction")));

--- a/code/packages/rust/iir-to-wasm/src/lib.rs
+++ b/code/packages/rust/iir-to-wasm/src/lib.rs
@@ -51,6 +51,8 @@
 //!     functions: vec![fn_],
 //!     entry_point: Some("add".into()),
 //!     language: "test".into(),
+//!     exports: vec![],
+//!     imports: vec![],
 //! };
 //!
 //! let errors = validate_for_wasm(&module);

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -1981,6 +1981,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some(name.into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -2043,6 +2045,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let result = lower_iir_to_wasm(&m, &IIRWasmConfig::default());
         assert!(matches!(result, Err(IIRWasmError::ValidationFailed(_))));

--- a/code/packages/rust/iir-to-wasm/src/validate.rs
+++ b/code/packages/rust/iir-to-wasm/src/validate.rs
@@ -151,6 +151,8 @@ const UNSUPPORTED_OPS: &[&str] = &[
 ///     functions: vec![fn_],
 ///     entry_point: Some("main".into()),
 ///     language: "test".into(),
+///     exports: vec![],
+///     imports: vec![],
 /// };
 /// assert!(validate_for_wasm(&module).is_empty());
 /// ```

--- a/code/packages/rust/iir-to-wasm/src/validate.rs
+++ b/code/packages/rust/iir-to-wasm/src/validate.rs
@@ -300,6 +300,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -310,6 +312,8 @@ mod tests {
             functions: vec![],
             entry_point: None,
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let errs = validate_for_wasm(&module);
         assert!(!errs.is_empty(), "should reject empty module");

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -41,6 +41,8 @@ fn module_one(
         functions: vec![fn_],
         entry_point: Some(name.into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -62,6 +64,8 @@ fn module_multi(fns: Vec<(&str, Vec<(&str, &str)>, &str, Vec<IIRInstr>)>) -> IIR
         functions,
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     }
 }
 
@@ -84,6 +88,8 @@ fn validate_empty_module_produces_error() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let errs = validate_for_wasm(&m);
     assert!(!errs.is_empty(), "empty module must produce errors");
@@ -836,6 +842,8 @@ fn validation_failure_propagated() {
         functions: vec![],
         entry_point: None,
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
     let result = lower_iir_to_wasm(&m, &IIRWasmConfig::default());
     assert!(

--- a/code/packages/rust/interpreter-ir/CHANGELOG.md
+++ b/code/packages/rust/interpreter-ir/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog — interpreter-ir
 
+## [0.5.0] — 2026-05-11
+
+### Added (LANG33 — Module System at the IIR Level)
+
+#### New `module_exports` module
+
+- Added `src/module_exports.rs` with two new public types:
+  - `IIRExport { function_name, alias }` — declares a function this module
+    makes visible to other modules.  `public_name()` returns alias if set,
+    otherwise `function_name`.  Builder: `new(fn_name).with_alias(alias)`.
+  - `IIRImport { module_name, function_name, local_alias, param_types, return_type }` —
+    declares a function this module requires from another module.
+    `local_name()` returns local_alias if set, otherwise `function_name`.
+    Builders: `new(mod, fn, ret)`, `.with_local_alias(alias)`, `.with_params(types)`.
+- Both types derive `Debug + Clone + PartialEq`; 11 unit tests + 5 doc-tests.
+
+#### `IIRModule` changes
+
+- Added two new fields (LANG33): `pub exports: Vec<IIRExport>` and
+  `pub imports: Vec<IIRImport>`.
+- `IIRModule::new()` initialises both to `Vec::new()` (backward compatible).
+- `IIRModule::validate()` extended with two new checks:
+  - `ExportNotFound`: exported `function_name` not in `self.functions`.
+  - `DuplicateExport`: two exports have the same `public_name()`.
+- Imports are intentionally NOT validated here (linker's responsibility).
+
+#### `serialise.rs` changes
+
+- Version bumped from `1.0` to `1.1` to mark the LANG33 extension.
+- Deserialiser accepts both `1.0` (legacy, no exports/imports) and `1.1`
+  (current).  Old binaries round-trip correctly.
+- LANG33 extension appended after functions:
+  - Tag `0x10` + u32 count + exports (`function_name` + `alias`).
+  - Tag `0x11` + u32 count + imports (all fields).
+- Added `Operand::Str` round-trip (kind byte `4`) to serialise/deserialise.
+  (This was written in the serialiser in LANG32 but the deserialise path was
+  not present.)
+- 10 new tests (serialise section): export/import round-trips, backward-compat
+  1.0 version, `Operand::Str` round-trip, unsupported version error.
+
+#### `lib.rs`
+
+- `pub mod module_exports` registered.
+- `pub use module_exports::{IIRExport, IIRImport}` re-exported from crate root.
+
+---
+
 ## [0.4.0] — 2026-05-11
 
 ### Added (LANG32 — Global Variables and I/O at the IIR Level)

--- a/code/packages/rust/interpreter-ir/Cargo.toml
+++ b/code/packages/rust/interpreter-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpreter-ir"
-version = "0.3.0"
+version = "0.5.0"
 edition = "2021"
 description = "InterpreterIR (IIR) — the bytecode for the LANG JIT/AOT pipeline"
 

--- a/code/packages/rust/interpreter-ir/src/lib.rs
+++ b/code/packages/rust/interpreter-ir/src/lib.rs
@@ -82,6 +82,7 @@
 pub mod function;
 pub mod instr;
 pub mod module;
+pub mod module_exports;
 pub mod opcodes;
 pub mod serialise;
 pub mod slot_state;
@@ -91,5 +92,6 @@ pub mod source_loc;
 pub use function::{FunctionTypeStatus, IIRFunction};
 pub use instr::{IIRInstr, Operand};
 pub use module::IIRModule;
+pub use module_exports::{IIRExport, IIRImport};
 pub use slot_state::{SlotKind, SlotState, MAX_POLYMORPHIC_OBSERVATIONS};
 pub use source_loc::SourceLoc;

--- a/code/packages/rust/interpreter-ir/src/module.rs
+++ b/code/packages/rust/interpreter-ir/src/module.rs
@@ -22,6 +22,7 @@
 //! ```
 
 use crate::function::IIRFunction;
+use crate::module_exports::{IIRExport, IIRImport};
 
 /// Top-level container for an InterpreterIR program.
 #[derive(Debug, Clone)]
@@ -41,16 +42,32 @@ pub struct IIRModule {
     ///
     /// Used by tooling for display only; not interpreted by `vm-core`.
     pub language: String,
+
+    /// Functions this module makes visible to other modules (LANG33).
+    ///
+    /// Empty list = export nothing (a pure program, not a library).
+    /// Backends use this list to populate their export sections.
+    /// Backward compatible: existing modules with no exports work identically.
+    pub exports: Vec<IIRExport>,
+
+    /// Functions this module requires from other modules (LANG33).
+    ///
+    /// Resolved by `iir-linker::link` during static linking or by the backend
+    /// at module-load time for dynamic linking.
+    /// Backward compatible: existing modules with no imports work identically.
+    pub imports: Vec<IIRImport>,
 }
 
 impl IIRModule {
     /// Create a new, empty module.
     pub fn new(name: impl Into<String>, language: impl Into<String>) -> Self {
         IIRModule {
-            name: name.into(),
-            functions: Vec::new(),
+            name:        name.into(),
+            functions:   Vec::new(),
             entry_point: Some("main".to_string()),
-            language: language.into(),
+            language:    language.into(),
+            exports:     Vec::new(),
+            imports:     Vec::new(),
         }
     }
 
@@ -103,6 +120,11 @@ impl IIRModule {
     /// - No duplicate function names
     /// - Entry point function exists (if `entry_point` is set)
     /// - No instruction branches to an undefined label within its function
+    /// - Every export refers to a function that exists in this module (LANG33)
+    /// - No two exports have the same `public_name()` (LANG33)
+    ///
+    /// **Imports are not validated here** — import resolution requires peer
+    /// modules and is the linker's job (`iir-linker::verify_imports`).
     pub fn validate(&self) -> Vec<String> {
         let mut errors = Vec::new();
         let mut seen = std::collections::HashSet::new();
@@ -141,6 +163,29 @@ impl IIRModule {
                         }
                     }
                 }
+            }
+        }
+
+        // ── LANG33: export checks ────────────────────────────────────────────
+        let fn_names: std::collections::HashSet<&str> =
+            self.functions.iter().map(|f| f.name.as_str()).collect();
+
+        let mut public_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+
+        for export in &self.exports {
+            if !fn_names.contains(export.function_name.as_str()) {
+                errors.push(format!(
+                    "ExportNotFound: exported function {:?} not found in module {:?}",
+                    export.function_name, self.name
+                ));
+            }
+            let pn = export.public_name().to_string();
+            if !public_names.insert(pn.clone()) {
+                errors.push(format!(
+                    "DuplicateExport: public name {:?} is exported more than once in module {:?}",
+                    pn, self.name
+                ));
             }
         }
 

--- a/code/packages/rust/interpreter-ir/src/module_exports.rs
+++ b/code/packages/rust/interpreter-ir/src/module_exports.rs
@@ -1,0 +1,320 @@
+//! `IIRExport` and `IIRImport` — module system declarations (LANG33).
+//!
+//! # Design
+//!
+//! A module system at the IIR level gives every language frontend
+//! cross-module function calls for free.  Rather than every language
+//! implementing its own "extern" or "require" mechanism, the IIR module
+//! carries:
+//!
+//! - [`IIRExport`] — a function this module makes visible to other modules.
+//! - [`IIRImport`] — a function this module requires from another module.
+//!
+//! The static linker (`iir-linker`) resolves imports to exports across a
+//! set of peer `IIRModule`s and merges them into one linked module.
+//!
+//! Backends that have native import/export sections (WASM, JVM, CLR) can
+//! alternatively use these lists to emit the appropriate section entries
+//! without pre-linking, supporting lazy / dynamic resolution at runtime.
+//!
+//! # Backward compatibility
+//!
+//! Both fields default to empty `Vec`s.  Existing `IIRModule`s built before
+//! LANG33 export nothing and import nothing — identical to pre-LANG33
+//! behaviour.
+//!
+//! # Example
+//!
+//! ```rust
+//! use interpreter_ir::module_exports::{IIRExport, IIRImport};
+//!
+//! // Module "math" exports "add" under the public name "add".
+//! let export = IIRExport::new("add");
+//! assert_eq!(export.public_name(), "add");
+//!
+//! // Module "math" exports "internal_sqrt" as "sqrt".
+//! let aliased = IIRExport::new("internal_sqrt").with_alias("sqrt");
+//! assert_eq!(aliased.public_name(), "sqrt");
+//!
+//! // Module "main" imports "add" from "math".
+//! let import = IIRImport::new("math", "add", "i64");
+//! assert_eq!(import.local_name(), "add");
+//! ```
+
+// ---------------------------------------------------------------------------
+// IIRExport
+// ---------------------------------------------------------------------------
+
+/// A function that an [`IIRModule`](crate::module::IIRModule) makes visible
+/// to other modules.
+///
+/// The `function_name` must refer to a function defined in the same module.
+/// The optional `alias` lets the module publish a different public name (e.g.
+/// renaming an internal implementation name to a clean API name).
+///
+/// # Encoding in backends
+///
+/// | Backend | What happens |
+/// |---------|-------------|
+/// | BEAM    | Listed in the `ExpT` chunk as `{FunctionName, Arity}`. |
+/// | WASM    | Becomes an `Export` entry (kind = Function). |
+/// | JVM     | Function compiled as `public static`. |
+/// | CLR     | Function compiled as `.method public static`. |
+#[derive(Debug, Clone, PartialEq)]
+pub struct IIRExport {
+    /// The name of the function as it appears in
+    /// [`IIRModule::functions`](crate::module::IIRModule::functions).
+    pub function_name: String,
+
+    /// Optional public-facing alias.
+    ///
+    /// `None` → exported under the same name as `function_name`.
+    /// `Some("sqrt")` → the function is exported as `"sqrt"` while the
+    /// internal name stays `function_name`.
+    pub alias: Option<String>,
+}
+
+impl IIRExport {
+    /// Create a new export with no alias.
+    ///
+    /// ```
+    /// # use interpreter_ir::module_exports::IIRExport;
+    /// let e = IIRExport::new("add");
+    /// assert_eq!(e.public_name(), "add");
+    /// ```
+    pub fn new(function_name: impl Into<String>) -> Self {
+        IIRExport { function_name: function_name.into(), alias: None }
+    }
+
+    /// Builder: publish the function under a different name.
+    ///
+    /// ```
+    /// # use interpreter_ir::module_exports::IIRExport;
+    /// let e = IIRExport::new("internal_sqrt").with_alias("sqrt");
+    /// assert_eq!(e.function_name, "internal_sqrt");
+    /// assert_eq!(e.public_name(), "sqrt");
+    /// ```
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+
+    /// The name that external modules use to refer to this function.
+    ///
+    /// Returns the alias if set, otherwise `function_name`.
+    pub fn public_name(&self) -> &str {
+        self.alias.as_deref().unwrap_or(&self.function_name)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IIRImport
+// ---------------------------------------------------------------------------
+
+/// A function that an [`IIRModule`](crate::module::IIRModule) requires from
+/// another module.
+///
+/// During static linking (`iir-linker::link`), each import is resolved to the
+/// corresponding `IIRExport` in a peer module.  Type signatures are checked
+/// if provided; a mismatch produces a [`LinkError::TypeMismatch`].
+///
+/// # Encoding in backends
+///
+/// | Backend | What happens |
+/// |---------|-------------|
+/// | BEAM    | After static linking, the merged module contains the function directly.  Before linking, `call` instructions targeting the import become `call_ext` with an import-table entry. |
+/// | WASM    | Becomes an `Import` entry (module = `module_name`, name = `function_name`).  Function index map starts at N (imported count). |
+/// | JVM     | Becomes an `invokestatic` with a Methodref CP entry pointing to the exporting class. |
+/// | CLR     | Becomes a `call` with a MemberRef token pointing to the exporting assembly. |
+///
+/// [`LinkError::TypeMismatch`]: https://docs.rs/iir-linker/latest/iir_linker/enum.LinkError.html
+#[derive(Debug, Clone, PartialEq)]
+pub struct IIRImport {
+    /// The module that provides this function.
+    ///
+    /// For static linking this must match the `name` of a peer `IIRModule`
+    /// passed to `iir_linker::link`.  For native import sections (WASM/JVM)
+    /// this becomes the module or class name.
+    pub module_name: String,
+
+    /// The function name as published by the exporting module (i.e. the
+    /// `public_name()` of the corresponding `IIRExport`).
+    pub function_name: String,
+
+    /// The name used inside *this* module's call instructions.
+    ///
+    /// `None` → call instructions use `function_name` directly.
+    /// `Some("math_add")` → call instructions write `call("math_add", …)`
+    /// while the resolved external name remains `function_name`.
+    pub local_alias: Option<String>,
+
+    /// Expected parameter types for type-checking during linking.
+    ///
+    /// Empty means "don't check" (trusted import, no type verification).
+    /// When non-empty, each entry is an IIR type string (`"i64"`, `"bool"`, …).
+    pub param_types: Vec<String>,
+
+    /// Expected return type of the imported function.
+    ///
+    /// `"any"` means "don't check".
+    pub return_type: String,
+}
+
+impl IIRImport {
+    /// Create a new import with no type annotations.
+    ///
+    /// # Arguments
+    ///
+    /// * `module_name` — the exporting module's name.
+    /// * `function_name` — the public function name in that module.
+    /// * `return_type` — the return type (`"void"`, `"i64"`, `"any"`, …).
+    ///
+    /// ```
+    /// # use interpreter_ir::module_exports::IIRImport;
+    /// let imp = IIRImport::new("math", "sqrt", "f64");
+    /// assert_eq!(imp.module_name, "math");
+    /// assert_eq!(imp.function_name, "sqrt");
+    /// assert_eq!(imp.local_name(), "sqrt");
+    /// assert_eq!(imp.return_type, "f64");
+    /// ```
+    pub fn new(
+        module_name:   impl Into<String>,
+        function_name: impl Into<String>,
+        return_type:   impl Into<String>,
+    ) -> Self {
+        IIRImport {
+            module_name:   module_name.into(),
+            function_name: function_name.into(),
+            local_alias:   None,
+            param_types:   Vec::new(),
+            return_type:   return_type.into(),
+        }
+    }
+
+    /// Builder: set the local alias used by call instructions inside this module.
+    ///
+    /// ```
+    /// # use interpreter_ir::module_exports::IIRImport;
+    /// let imp = IIRImport::new("math", "add", "i64").with_local_alias("math_add");
+    /// assert_eq!(imp.local_name(), "math_add");
+    /// assert_eq!(imp.function_name, "add");
+    /// ```
+    pub fn with_local_alias(mut self, alias: impl Into<String>) -> Self {
+        self.local_alias = Some(alias.into());
+        self
+    }
+
+    /// Builder: set the expected parameter types (for type-checking during linking).
+    ///
+    /// ```
+    /// # use interpreter_ir::module_exports::IIRImport;
+    /// let imp = IIRImport::new("math", "add", "i64")
+    ///     .with_params(vec!["i64".into(), "i64".into()]);
+    /// assert_eq!(imp.param_types.len(), 2);
+    /// ```
+    pub fn with_params(mut self, params: Vec<String>) -> Self {
+        self.param_types = params;
+        self
+    }
+
+    /// The name that call instructions inside this module use.
+    ///
+    /// Returns the local alias if set, otherwise `function_name`.
+    pub fn local_name(&self) -> &str {
+        self.local_alias.as_deref().unwrap_or(&self.function_name)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── IIRExport ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn export_public_name_no_alias() {
+        let e = IIRExport::new("add");
+        assert_eq!(e.function_name, "add");
+        assert_eq!(e.alias, None);
+        assert_eq!(e.public_name(), "add");
+    }
+
+    #[test]
+    fn export_public_name_with_alias() {
+        let e = IIRExport::new("internal_sqrt").with_alias("sqrt");
+        assert_eq!(e.function_name, "internal_sqrt");
+        assert_eq!(e.alias, Some("sqrt".to_string()));
+        assert_eq!(e.public_name(), "sqrt");
+    }
+
+    #[test]
+    fn export_clone_is_equal() {
+        let e = IIRExport::new("foo").with_alias("bar");
+        assert_eq!(e.clone(), e);
+    }
+
+    #[test]
+    fn export_debug_format_contains_function_name() {
+        let e = IIRExport::new("my_fn");
+        let s = format!("{:?}", e);
+        assert!(s.contains("my_fn"));
+    }
+
+    // ── IIRImport ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn import_local_name_no_alias() {
+        let imp = IIRImport::new("math", "add", "i64");
+        assert_eq!(imp.module_name, "math");
+        assert_eq!(imp.function_name, "add");
+        assert_eq!(imp.local_alias, None);
+        assert_eq!(imp.local_name(), "add");
+        assert_eq!(imp.return_type, "i64");
+        assert!(imp.param_types.is_empty());
+    }
+
+    #[test]
+    fn import_local_name_with_alias() {
+        let imp = IIRImport::new("math", "add", "i64").with_local_alias("math_add");
+        assert_eq!(imp.local_name(), "math_add");
+        assert_eq!(imp.function_name, "add");
+    }
+
+    #[test]
+    fn import_with_params() {
+        let imp = IIRImport::new("math", "add", "i64")
+            .with_params(vec!["i64".into(), "i64".into()]);
+        assert_eq!(imp.param_types, vec!["i64", "i64"]);
+    }
+
+    #[test]
+    fn import_clone_is_equal() {
+        let imp = IIRImport::new("m", "f", "void").with_local_alias("fa");
+        assert_eq!(imp.clone(), imp);
+    }
+
+    #[test]
+    fn import_debug_format_contains_module_and_function() {
+        let imp = IIRImport::new("mymod", "myfunc", "void");
+        let s = format!("{:?}", imp);
+        assert!(s.contains("mymod"));
+        assert!(s.contains("myfunc"));
+    }
+
+    #[test]
+    fn import_any_return_type_trusted() {
+        let imp = IIRImport::new("lib", "compute", "any");
+        assert_eq!(imp.return_type, "any");
+        assert!(imp.param_types.is_empty());
+    }
+
+    #[test]
+    fn import_void_return_type() {
+        let imp = IIRImport::new("io", "print", "void");
+        assert_eq!(imp.return_type, "void");
+    }
+}

--- a/code/packages/rust/interpreter-ir/src/serialise.rs
+++ b/code/packages/rust/interpreter-ir/src/serialise.rs
@@ -140,7 +140,8 @@ pub fn serialise(module: &IIRModule) -> Vec<u8> {
     buf.extend_from_slice(MAGIC);
     write_u8(&mut buf, VERSION_MAJOR);
     write_u8(&mut buf, VERSION_MINOR);
-    write_u32_le(&mut buf, module.functions.len() as u32);
+    write_u32_le(&mut buf, module.functions.len().try_into()
+        .expect("function count exceeds u32::MAX — cannot serialise"));
     write_str(&mut buf, &module.name);
     write_str(&mut buf, &module.language);
     write_str(&mut buf, module.entry_point.as_deref().unwrap_or(""));
@@ -154,14 +155,16 @@ pub fn serialise(module: &IIRModule) -> Vec<u8> {
     // Always written (count = 0 for modules with no exports) so the format is
     // symmetric with the imports section and simpler to parse.
     write_u8(&mut buf, TAG_EXPORTS);
-    write_u32_le(&mut buf, module.exports.len() as u32);
+    write_u32_le(&mut buf, module.exports.len().try_into()
+        .expect("exports count exceeds u32::MAX — cannot serialise"));
     for export in &module.exports {
         serialise_export(&mut buf, export);
     }
 
     // ── LANG33: imports section ──────────────────────────────────────────────
     write_u8(&mut buf, TAG_IMPORTS);
-    write_u32_le(&mut buf, module.imports.len() as u32);
+    write_u32_le(&mut buf, module.imports.len().try_into()
+        .expect("imports count exceeds u32::MAX — cannot serialise"));
     for import in &module.imports {
         serialise_import(&mut buf, import);
     }
@@ -180,7 +183,8 @@ fn serialise_import(buf: &mut Vec<u8>, import: &IIRImport) {
     write_str(buf, &import.function_name);
     // Empty string encodes `local_alias = None`.
     write_str(buf, import.local_alias.as_deref().unwrap_or(""));
-    write_u32_le(buf, import.param_types.len() as u32);
+    write_u32_le(buf, import.param_types.len().try_into()
+        .expect("param_types count exceeds u32::MAX — cannot serialise"));
     for pt in &import.param_types {
         write_str(buf, pt);
     }
@@ -192,14 +196,18 @@ fn serialise_function(buf: &mut Vec<u8>, fn_: &IIRFunction) {
     write_str(buf, &fn_.return_type);
     // Use u32 (not u8) for all counts — u8 silently truncates above 255,
     // causing stream desync when the deserialiser reads too few/many records.
-    write_u32_le(buf, fn_.params.len() as u32);
+    write_u32_le(buf, fn_.params.len().try_into()
+        .expect("param count exceeds u32::MAX — cannot serialise"));
     for (param_name, param_type) in &fn_.params {
         write_str(buf, param_name);
         write_str(buf, param_type);
     }
-    write_u32_le(buf, fn_.instructions.len() as u32);
-    // register_count as u32 to avoid truncation for large register files.
-    write_u32_le(buf, fn_.register_count as u32);
+    write_u32_le(buf, fn_.instructions.len().try_into()
+        .expect("instruction count exceeds u32::MAX — cannot serialise"));
+    // register_count: use try_into for the same reason — large register files
+    // should fail loudly rather than silently truncate.
+    write_u32_le(buf, fn_.register_count.try_into()
+        .expect("register_count exceeds u32::MAX — cannot serialise"));
     write_u8(buf, type_status_to_byte(&fn_.type_status));
     for instr in &fn_.instructions {
         serialise_instr(buf, instr);
@@ -216,8 +224,9 @@ fn serialise_instr(buf: &mut Vec<u8>, instr: &IIRInstr) {
         None => write_u8(buf, 0),
     }
     write_str(buf, &instr.type_hint);
-    // Use u32 for src_count to avoid truncation above 255.
-    write_u32_le(buf, instr.srcs.len() as u32);
+    // Use u32 for src_count with try_into to catch truncation on overflow.
+    write_u32_le(buf, instr.srcs.len().try_into()
+        .expect("src count exceeds u32::MAX — cannot serialise"));
     for src in &instr.srcs {
         match src {
             Operand::Var(s) => {

--- a/code/packages/rust/interpreter-ir/src/serialise.rs
+++ b/code/packages/rust/interpreter-ir/src/serialise.rs
@@ -2,42 +2,51 @@
 //!
 //! # Wire format (little-endian throughout)
 //!
+//! ## Version 1.1 (LANG33 — current)
+//!
 //! ```text
 //! Header (magic + version):
 //!     4 bytes  magic       0x49 0x49 0x52 0x00  (b"IIR\0")
-//!     1 byte   version_major
-//!     1 byte   version_minor
+//!     1 byte   version_major   (1)
+//!     1 byte   version_minor   (1)
 //!     4 bytes  fn_count    number of IIRFunction records
 //!     str      module name (4-byte length prefix + UTF-8)
 //!     str      language
 //!     str      entry_point (empty string = no entry point)
 //!
-//! Strings are encoded as a 4-byte little-endian length (u32) followed by
-//! the UTF-8 bytes.  This prevents silent truncation for strings longer than
-//! 65535 bytes (a u16 prefix would silently corrupt such strings).
+//!     For each IIRFunction: (same as version 1.0)
 //!
-//! For each IIRFunction:
-//!     str      name
-//!     str      return_type
-//!     1 byte   param_count
-//!     For each param:
-//!         str  param_name
-//!         str  type_hint
-//!     4 bytes  instr_count
-//!     1 byte   register_count
-//!     1 byte   type_status   (0=Untyped, 1=PartiallyTyped, 2=FullyTyped)
-//!     For each IIRInstr:
-//!         str  op
-//!         1 byte has_dest  (0 or 1)
-//!         if has_dest: str dest
-//!         str  type_hint
-//!         1 byte src_count
-//!         For each src:
-//!             1 byte kind  (0=Var, 1=Int, 2=Float, 3=Bool)
-//!             if kind==0: str value
-//!             if kind==1: 8 bytes i64
-//!             if kind==2: 8 bytes f64
-//!             if kind==3: 1 byte  (0=false, 1=true)
+//! LANG33 extension (appended after all functions):
+//!     1 byte   tag         0x10 = exports section
+//!     4 bytes  export_count
+//!     For each IIRExport:
+//!         str  function_name
+//!         str  alias  (empty string = no alias / use function_name)
+//!
+//!     1 byte   tag         0x11 = imports section
+//!     4 bytes  import_count
+//!     For each IIRImport:
+//!         str  module_name
+//!         str  function_name
+//!         str  local_alias  (empty = no alias)
+//!         4 bytes  param_count
+//!         For each param type: str  type_string
+//!         str  return_type
+//! ```
+//!
+//! ## Version 1.0 (legacy — no exports/imports)
+//!
+//! Identical to 1.1 but without the LANG33 extension.  The deserialiser
+//! accepts 1.0 and returns an `IIRModule` with empty `exports`/`imports`.
+//!
+//! ## Operand kind bytes
+//!
+//! ```text
+//!     0 = Var    → str (variable name)
+//!     1 = Int    → 8 bytes i64
+//!     2 = Float  → 8 bytes f64
+//!     3 = Bool   → 1 byte (0=false, 1=true)
+//!     4 = Str    → str (compile-time string literal, e.g. global variable name)
 //! ```
 //!
 //! **Note:** Runtime profiling fields (`observed_type`, `observation_count`,
@@ -62,10 +71,18 @@
 use crate::function::{FunctionTypeStatus, IIRFunction};
 use crate::instr::{IIRInstr, Operand};
 use crate::module::IIRModule;
+use crate::module_exports::{IIRExport, IIRImport};
 
 const MAGIC: &[u8; 4] = b"IIR\0";
 const VERSION_MAJOR: u8 = 1;
-const VERSION_MINOR: u8 = 0;
+/// LANG33 bumped the minor version from 0 to 1 to add exports/imports sections.
+/// The deserialiser accepts both 1.0 (legacy) and 1.1 (current).
+const VERSION_MINOR: u8 = 1;
+
+/// Tag byte marking the start of the exports section (LANG33).
+const TAG_EXPORTS: u8 = 0x10;
+/// Tag byte marking the start of the imports section (LANG33).
+const TAG_IMPORTS: u8 = 0x11;
 
 /// Maximum number of functions/instructions to pre-allocate during
 /// deserialisation.  The actual count comes from the untrusted wire; capping
@@ -124,7 +141,42 @@ pub fn serialise(module: &IIRModule) -> Vec<u8> {
         serialise_function(&mut buf, fn_);
     }
 
+    // ── LANG33: exports section ──────────────────────────────────────────────
+    // Tag 0x10 followed by u32 count and one record per export.
+    // Always written (count = 0 for modules with no exports) so the format is
+    // symmetric with the imports section and simpler to parse.
+    write_u8(&mut buf, TAG_EXPORTS);
+    write_u32_le(&mut buf, module.exports.len() as u32);
+    for export in &module.exports {
+        serialise_export(&mut buf, export);
+    }
+
+    // ── LANG33: imports section ──────────────────────────────────────────────
+    write_u8(&mut buf, TAG_IMPORTS);
+    write_u32_le(&mut buf, module.imports.len() as u32);
+    for import in &module.imports {
+        serialise_import(&mut buf, import);
+    }
+
     buf
+}
+
+fn serialise_export(buf: &mut Vec<u8>, export: &IIRExport) {
+    write_str(buf, &export.function_name);
+    // Empty string encodes `alias = None` (no alias).
+    write_str(buf, export.alias.as_deref().unwrap_or(""));
+}
+
+fn serialise_import(buf: &mut Vec<u8>, import: &IIRImport) {
+    write_str(buf, &import.module_name);
+    write_str(buf, &import.function_name);
+    // Empty string encodes `local_alias = None`.
+    write_str(buf, import.local_alias.as_deref().unwrap_or(""));
+    write_u32_le(buf, import.param_types.len() as u32);
+    for pt in &import.param_types {
+        write_str(buf, pt);
+    }
+    write_str(buf, &import.return_type);
 }
 
 fn serialise_function(buf: &mut Vec<u8>, fn_: &IIRFunction) {
@@ -176,6 +228,8 @@ fn serialise_instr(buf: &mut Vec<u8>, instr: &IIRInstr) {
                 write_u8(buf, 3);
                 write_u8(buf, *b as u8);
             }
+            // LANG32: compile-time string literal (e.g. global variable name).
+            // Kind byte 4 — same length-prefixed string encoding as Var (kind 0).
             Operand::Str(s) => {
                 write_u8(buf, 4);
                 write_str(buf, s);
@@ -220,15 +274,25 @@ impl<'a> Reader<'a> {
     }
 
     fn read_exact(&mut self, n: usize) -> Result<&[u8], DeserialiseError> {
-        if self.pos + n > self.data.len() {
+        // Use checked_add to guard against wrapping on 32-bit targets.
+        // Without this, a hostile payload with n ≈ usize::MAX and self.pos > 0
+        // would wrap the addition to a small value, pass the bounds check, then
+        // panic with a "slice ends before start" error — a clean DoS vector.
+        let end = self.pos.checked_add(n).ok_or_else(|| {
+            DeserialiseError(format!(
+                "offset overflow at pos {} requesting {n} bytes",
+                self.pos
+            ))
+        })?;
+        if end > self.data.len() {
             return Err(DeserialiseError(format!(
                 "unexpected end of data at offset {} (need {n} bytes, have {})",
                 self.pos,
                 self.data.len() - self.pos,
             )));
         }
-        let chunk = &self.data[self.pos..self.pos + n];
-        self.pos += n;
+        let chunk = &self.data[self.pos..end];
+        self.pos = end;
         Ok(chunk)
     }
 
@@ -273,11 +337,14 @@ pub fn deserialise(data: &[u8]) -> Result<IIRModule, DeserialiseError> {
 
     let major = r.u8()?;
     let minor = r.u8()?;
-    if (major, minor) != (VERSION_MAJOR, VERSION_MINOR) {
+    // Accept 1.0 (legacy — no exports/imports) and 1.1 (LANG33 — with exports/imports).
+    // Any other version is rejected.
+    if major != VERSION_MAJOR || minor > VERSION_MINOR {
         return Err(DeserialiseError(format!(
-            "unsupported version {major}.{minor}"
+            "unsupported version {major}.{minor} (supported: 1.0, 1.1)"
         )));
     }
+    let has_lang33 = minor >= 1;
 
     let fn_count = r.u32_le()? as usize;
     let name = r.str_()?;
@@ -294,11 +361,22 @@ pub fn deserialise(data: &[u8]) -> Result<IIRModule, DeserialiseError> {
         functions.push(deserialise_function(&mut r)?);
     }
 
+    // ── LANG33: read exports and imports (version 1.1+) ─────────────────────
+    let (exports, imports) = if has_lang33 {
+        let exports = deserialise_exports(&mut r)?;
+        let imports = deserialise_imports(&mut r)?;
+        (exports, imports)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
     Ok(IIRModule {
         name,
         functions,
         entry_point,
         language,
+        exports,
+        imports,
     })
 }
 
@@ -344,6 +422,50 @@ fn deserialise_function(r: &mut Reader<'_>) -> Result<IIRFunction, DeserialiseEr
     })
 }
 
+fn deserialise_exports(r: &mut Reader<'_>) -> Result<Vec<IIRExport>, DeserialiseError> {
+    let tag = r.u8()?;
+    if tag != TAG_EXPORTS {
+        return Err(DeserialiseError(format!(
+            "expected exports tag 0x{TAG_EXPORTS:02x}, got 0x{tag:02x}"
+        )));
+    }
+    let count = r.u32_le()? as usize;
+    let mut exports = Vec::with_capacity(count.min(MAX_SAFE_PREALLOC));
+    for _ in 0..count {
+        let function_name = r.str_()?;
+        let alias_raw = r.str_()?;
+        // Empty string encodes `alias = None`.
+        let alias = if alias_raw.is_empty() { None } else { Some(alias_raw) };
+        exports.push(IIRExport { function_name, alias });
+    }
+    Ok(exports)
+}
+
+fn deserialise_imports(r: &mut Reader<'_>) -> Result<Vec<IIRImport>, DeserialiseError> {
+    let tag = r.u8()?;
+    if tag != TAG_IMPORTS {
+        return Err(DeserialiseError(format!(
+            "expected imports tag 0x{TAG_IMPORTS:02x}, got 0x{tag:02x}"
+        )));
+    }
+    let count = r.u32_le()? as usize;
+    let mut imports = Vec::with_capacity(count.min(MAX_SAFE_PREALLOC));
+    for _ in 0..count {
+        let module_name = r.str_()?;
+        let function_name = r.str_()?;
+        let local_alias_raw = r.str_()?;
+        let local_alias = if local_alias_raw.is_empty() { None } else { Some(local_alias_raw) };
+        let param_count = r.u32_le()? as usize;
+        let mut param_types = Vec::with_capacity(param_count.min(MAX_SAFE_PREALLOC));
+        for _ in 0..param_count {
+            param_types.push(r.str_()?);
+        }
+        let return_type = r.str_()?;
+        imports.push(IIRImport { module_name, function_name, local_alias, param_types, return_type });
+    }
+    Ok(imports)
+}
+
 fn deserialise_instr(r: &mut Reader<'_>) -> Result<IIRInstr, DeserialiseError> {
     let op = r.str_()?;
     let has_dest = r.u8()?;
@@ -361,6 +483,7 @@ fn deserialise_instr(r: &mut Reader<'_>) -> Result<IIRInstr, DeserialiseError> {
             1 => Operand::Int(r.i64_le()?),
             2 => Operand::Float(r.f64_le()?),
             3 => Operand::Bool(r.u8()? != 0),
+            // LANG32: compile-time string literal (kind 4).
             4 => Operand::Str(r.str_()?),
             k => {
                 return Err(DeserialiseError(format!(
@@ -518,5 +641,176 @@ mod tests {
             recovered.get_function("add").unwrap().instructions[0].observation_count,
             0
         );
+    }
+
+    // ── LANG33: exports/imports serialisation ─────────────────────────────────
+
+    #[test]
+    fn round_trip_export_no_alias() {
+        use crate::module_exports::IIRExport;
+        let mut module = make_module();
+        module.entry_point = None;
+        module.exports.push(IIRExport::new("add"));
+        let bytes = serialise(&module);
+        let recovered = deserialise(&bytes).unwrap();
+        assert_eq!(recovered.exports.len(), 1);
+        assert_eq!(recovered.exports[0].function_name, "add");
+        assert_eq!(recovered.exports[0].alias, None);
+        assert_eq!(recovered.exports[0].public_name(), "add");
+    }
+
+    #[test]
+    fn round_trip_export_with_alias() {
+        use crate::module_exports::IIRExport;
+        let mut module = make_module();
+        module.entry_point = None;
+        module.exports.push(IIRExport::new("add").with_alias("public_add"));
+        let bytes = serialise(&module);
+        let recovered = deserialise(&bytes).unwrap();
+        assert_eq!(recovered.exports.len(), 1);
+        assert_eq!(recovered.exports[0].function_name, "add");
+        assert_eq!(recovered.exports[0].alias, Some("public_add".to_string()));
+        assert_eq!(recovered.exports[0].public_name(), "public_add");
+    }
+
+    #[test]
+    fn round_trip_multiple_exports() {
+        use crate::module_exports::IIRExport;
+        let mut module = IIRModule::new("t", "x");
+        module.entry_point = None;
+        for name in &["foo", "bar", "baz"] {
+            module.add_or_replace(IIRFunction::new(
+                *name, vec![], "void",
+                vec![IIRInstr::new("ret_void", None, vec![], "void")],
+            ));
+            module.exports.push(IIRExport::new(*name));
+        }
+        let bytes = serialise(&module);
+        let recovered = deserialise(&bytes).unwrap();
+        assert_eq!(recovered.exports.len(), 3);
+        let names: Vec<&str> = recovered.exports.iter().map(|e| e.public_name()).collect();
+        assert_eq!(names, vec!["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn round_trip_import_no_alias_no_params() {
+        use crate::module_exports::IIRImport;
+        let mut module = IIRModule::new("main", "twig");
+        module.entry_point = None;
+        module.imports.push(IIRImport::new("math", "sqrt", "f64"));
+        let bytes = serialise(&module);
+        let recovered = deserialise(&bytes).unwrap();
+        assert_eq!(recovered.imports.len(), 1);
+        let imp = &recovered.imports[0];
+        assert_eq!(imp.module_name, "math");
+        assert_eq!(imp.function_name, "sqrt");
+        assert_eq!(imp.local_alias, None);
+        assert_eq!(imp.param_types, Vec::<String>::new());
+        assert_eq!(imp.return_type, "f64");
+        assert_eq!(imp.local_name(), "sqrt");
+    }
+
+    #[test]
+    fn round_trip_import_with_alias_and_params() {
+        use crate::module_exports::IIRImport;
+        let mut module = IIRModule::new("main", "twig");
+        module.entry_point = None;
+        module.imports.push(
+            IIRImport::new("math", "add", "i64")
+                .with_local_alias("math_add")
+                .with_params(vec!["i64".into(), "i64".into()]),
+        );
+        let bytes = serialise(&module);
+        let recovered = deserialise(&bytes).unwrap();
+        let imp = &recovered.imports[0];
+        assert_eq!(imp.local_alias, Some("math_add".to_string()));
+        assert_eq!(imp.param_types, vec!["i64", "i64"]);
+        assert_eq!(imp.return_type, "i64");
+        assert_eq!(imp.local_name(), "math_add");
+    }
+
+    #[test]
+    fn round_trip_module_with_both_exports_and_imports() {
+        use crate::module_exports::{IIRExport, IIRImport};
+        let mut module = IIRModule::new("app", "twig");
+        module.add_or_replace(IIRFunction::new(
+            "main", vec![], "void",
+            vec![IIRInstr::new("ret_void", None, vec![], "void")],
+        ));
+        module.exports.push(IIRExport::new("main").with_alias("start"));
+        module.imports.push(IIRImport::new("io", "print", "void").with_params(vec!["str".into()]));
+        let bytes = serialise(&module);
+        let recovered = deserialise(&bytes).unwrap();
+        assert_eq!(recovered.exports.len(), 1);
+        assert_eq!(recovered.exports[0].public_name(), "start");
+        assert_eq!(recovered.imports.len(), 1);
+        assert_eq!(recovered.imports[0].function_name, "print");
+    }
+
+    #[test]
+    fn round_trip_empty_exports_and_imports() {
+        // A module with no exports/imports (the common case for programs).
+        let mut module = make_module();
+        module.entry_point = None;
+        assert!(module.exports.is_empty());
+        assert!(module.imports.is_empty());
+        let bytes = serialise(&module);
+        let recovered = deserialise(&bytes).unwrap();
+        assert!(recovered.exports.is_empty());
+        assert!(recovered.imports.is_empty());
+    }
+
+    #[test]
+    fn str_operand_round_trips() {
+        // Operand::Str is used by global_store/global_load (LANG32).
+        let mut module = IIRModule::new("t", "x");
+        module.entry_point = None;
+        let fn_ = IIRFunction::new(
+            "f",
+            vec![("v".into(), "i64".into())],
+            "void",
+            vec![IIRInstr::new(
+                "global_store",
+                None,
+                vec![Operand::Str("counter".into()), Operand::Var("v".into())],
+                "void",
+            )],
+        );
+        module.add_or_replace(fn_);
+        let bytes = serialise(&module);
+        let recovered = deserialise(&bytes).unwrap();
+        let srcs = &recovered.get_function("f").unwrap().instructions[0].srcs;
+        assert_eq!(srcs[0], Operand::Str("counter".into()));
+        assert_eq!(srcs[1], Operand::Var("v".into()));
+    }
+
+    #[test]
+    fn version_10_accepted_with_empty_exports_imports() {
+        // Manually craft a version 1.0 header (no exports/imports section).
+        // Ensure the deserialiser accepts it and returns empty exports/imports.
+        let mut module = IIRModule::new("legacy", "basic");
+        module.entry_point = None;
+        let mut bytes = serialise(&module);
+        // Patch version_minor byte (index 5) from 1 to 0.
+        bytes[5] = 0;
+        // Strip the exports+imports suffix (the last 10 bytes written by v1.1):
+        // TAG_EXPORTS(1) + count(4) + TAG_IMPORTS(1) + count(4) = 10 bytes.
+        let new_len = bytes.len() - 10;
+        bytes.truncate(new_len);
+        let recovered = deserialise(&bytes).unwrap();
+        assert_eq!(recovered.name, "legacy");
+        assert!(recovered.exports.is_empty());
+        assert!(recovered.imports.is_empty());
+    }
+
+    #[test]
+    fn unsupported_version_returns_error() {
+        let mut module = IIRModule::new("t", "x");
+        module.entry_point = None;
+        let mut bytes = serialise(&module);
+        // Patch version_minor to a future unknown version (9).
+        bytes[5] = 9;
+        let err = deserialise(&bytes).unwrap_err();
+        assert!(err.0.contains("unsupported version"));
     }
 }

--- a/code/packages/rust/interpreter-ir/src/serialise.rs
+++ b/code/packages/rust/interpreter-ir/src/serialise.rs
@@ -118,7 +118,15 @@ fn write_str(buf: &mut Vec<u8>, s: &str) {
     let encoded = s.as_bytes();
     // Use a 4-byte (u32) length prefix so strings longer than 65 535 bytes
     // cannot silently corrupt the stream (a u16 prefix would truncate).
-    write_u32_le(buf, encoded.len() as u32);
+    //
+    // Security: use `try_into().expect()` rather than `as u32` to turn a
+    // silent truncation (stream corruption on strings > 4 GiB) into a loud,
+    // early panic.  IIR string fields are compiler-generated and should never
+    // approach this limit; if they somehow do, we want a clear failure rather
+    // than a quietly malformed binary.
+    let len: u32 = encoded.len().try_into()
+        .expect("IIR string field exceeds 4 GiB — cannot serialise");
+    write_u32_le(buf, len);
     buf.extend_from_slice(encoded);
 }
 

--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — twig-ir-compiler
 
+## [0.2.1] — 2026-05-11
+
+### Fixed (LANG33 — Module System)
+
+- Added `exports: Vec::new(), imports: Vec::new()` to the `IIRModule { ... }`
+  struct literal in `compiler.rs` (`compile_module`).  Required by the new
+  LANG33 fields on `IIRModule`; the workspace `cargo build` enforces this.
+
+---
+
 ## [0.2.0] — 2026-05-04
 
 ### Added (LANG23 PR 23-E — emit RefinedType annotations into IIR)

--- a/code/packages/rust/twig-ir-compiler/Cargo.toml
+++ b/code/packages/rust/twig-ir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-ir-compiler"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler"
 

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -348,6 +348,8 @@ impl Compiler {
             functions: self.functions,
             entry_point: Some("main".to_string()),
             language: "twig".to_string(),
+            exports: Vec::new(),
+            imports: Vec::new(),
         })
     }
 

--- a/code/packages/rust/twig-to-jvm/src/pipeline.rs
+++ b/code/packages/rust/twig-to-jvm/src/pipeline.rs
@@ -258,6 +258,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("add".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let config = IIRJvmConfig::new("AddTest");
         let cf = run_pipeline_from_iir(module, config).unwrap();
@@ -280,6 +282,8 @@ mod tests {
             functions: vec![fn_],
             entry_point: Some("main".into()),
             language: "test".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let config = IIRJvmConfig::new("MyApp");
         let cf = run_pipeline_from_iir(module, config).unwrap();

--- a/code/packages/rust/twig-to-jvm/src/pipeline.rs
+++ b/code/packages/rust/twig-to-jvm/src/pipeline.rs
@@ -189,6 +189,8 @@ pub fn run_pipeline(
 ///     functions: vec![fn_],
 ///     entry_point: Some("main".into()),
 ///     language: "test".into(),
+///     exports: vec![],
+///     imports: vec![],
 /// };
 ///
 /// let class_file = run_pipeline_from_iir(module, IIRJvmConfig::new("Test")).unwrap();

--- a/code/packages/rust/twig-to-jvm/tests/test_pipeline.rs
+++ b/code/packages/rust/twig-to-jvm/tests/test_pipeline.rs
@@ -343,6 +343,8 @@ fn typed_add_function_compiles_via_pipeline() {
         functions: vec![fn_],
         entry_point: Some("add".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
 
     let config = IIRJvmConfig::new("AddTest");
@@ -372,6 +374,8 @@ fn typed_void_function_compiles_via_pipeline() {
         functions: vec![fn_],
         entry_point: Some("main".into()),
         language: "test".into(),
+        exports: vec![],
+        imports: vec![],
     };
 
     let config = IIRJvmConfig::new("VoidTest");

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -2070,6 +2070,8 @@ mod tests {
             functions: vec![main],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let err = run(&module).unwrap_err();
         assert!(matches!(err, RunError::UnsupportedOpcode(s) if s == "not_a_real_opcode"));
@@ -2097,6 +2099,8 @@ mod tests {
             functions: vec![main],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let err = run(&module).unwrap_err();
         assert!(matches!(err, RunError::FellOffEnd(s) if s == "main"));
@@ -2135,6 +2139,8 @@ mod tests {
             functions: vec![main],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let err = run(&module).unwrap_err();
         assert!(matches!(err, RunError::UnknownFunction(s) if s == "ghost"));
@@ -2463,6 +2469,8 @@ mod tests {
             functions: vec![main],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let err = run(&module).unwrap_err();
         assert!(matches!(err, RunError::NotCallable(_)));
@@ -2510,6 +2518,8 @@ mod tests {
             functions: vec![main],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         };
         let err = run(&module).unwrap_err();
         match err {
@@ -2602,6 +2612,8 @@ mod tests {
             functions: vec![main],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         }
     }
 
@@ -3133,6 +3145,8 @@ mod tests {
             functions: vec![do_it, main],
             entry_point: Some("main".into()),
             language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
         };
 
         // First call.  load_property errors with NoSuchProperty

--- a/code/specs/LANG33-module-system.md
+++ b/code/specs/LANG33-module-system.md
@@ -1,0 +1,386 @@
+# LANG33 — Module System at the IIR Level
+
+## Why this spec exists
+
+LANG32 wired global variables and I/O into all four native backends.  The
+remaining gap before Twig programs can call each other across compilation units
+is a **module system**.  Today every `IIRModule` is self-contained: all the
+functions it calls must be defined inside it.  Cross-module references (e.g. a
+math library calling into a list library, or a Twig REPL importing a pre-compiled
+helper module) are impossible.
+
+This spec adds exports and imports at the `IIRModule` level and a new
+`iir-linker` crate that resolves cross-module references into a single linked
+module — or, for backends that support it natively (WASM, JVM, CLR), into a
+multi-unit artifact that the runtime resolves at load time.
+
+---
+
+## Design goals
+
+1. **Free for every language** — Twig, NIB, Prolog, Brainfuck all get a module
+   system without any language-specific work once the IIR layer is complete.
+2. **Minimal surface** — the first version covers the 80 % case: function exports
+   and imports.  Global variable exports are deferred to LANG33b.
+3. **Backward compatible** — existing `IIRModule` structs with empty
+   `exports`/`imports` continue to work identically.
+4. **Static linking default** — `iir-linker` produces a single merged
+   `IIRModule`.  Dynamic linking (WASM import sections, JVM `invokeinterface`)
+   is backend-specific and tracked in LANG33b.
+
+---
+
+## New IIRModule fields
+
+```rust
+pub struct IIRModule {
+    // ── existing ────────────────────────────────────────────────────────────
+    pub name:        String,
+    pub functions:   Vec<IIRFunction>,
+    pub entry_point: Option<String>,
+    pub language:    String,
+
+    // ── LANG33 (new) ────────────────────────────────────────────────────────
+
+    /// Functions this module makes visible to other modules.
+    ///
+    /// An empty list means the module exports nothing (a pure program, not
+    /// a library).  Backends that have a native export concept (WASM, JVM)
+    /// use this list to populate their export sections; BEAM generates an
+    /// `ExpT` chunk entry for each name.
+    ///
+    /// The default (`Vec::new()`) preserves backward compatibility: modules
+    /// built before LANG33 export nothing, which is the same as before.
+    pub exports: Vec<IIRExport>,
+
+    /// Functions this module requires from other modules.
+    ///
+    /// During static linking (`iir-linker`), each import is resolved to a
+    /// function in a peer `IIRModule`.  During JIT/interpreter execution,
+    /// unresolved imports cause a `LinkError` at load time.
+    ///
+    /// The default (`Vec::new()`) preserves backward compatibility.
+    pub imports: Vec<IIRImport>,
+}
+```
+
+### `IIRExport`
+
+```rust
+/// A function that this module makes visible to other modules.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IIRExport {
+    /// The function name as it appears in `IIRModule::functions`.
+    ///
+    /// Must refer to a function that exists in the same module.
+    /// Validated by `IIRModule::validate()`.
+    pub function_name: String,
+
+    /// Optional alias to publish under a different public name.
+    ///
+    /// `None` → export under the same name as `function_name`.
+    /// `Some("public_add")` → export the function as `"public_add"` while
+    /// the internal name remains `function_name`.
+    ///
+    /// Backends use `alias.as_deref().unwrap_or(&function_name)` as the
+    /// external symbol name.
+    pub alias: Option<String>,
+}
+
+impl IIRExport {
+    pub fn new(function_name: impl Into<String>) -> Self {
+        IIRExport { function_name: function_name.into(), alias: None }
+    }
+
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+
+    /// The name external callers use (alias if set, otherwise function_name).
+    pub fn public_name(&self) -> &str {
+        self.alias.as_deref().unwrap_or(&self.function_name)
+    }
+}
+```
+
+### `IIRImport`
+
+```rust
+/// A function required from another module.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IIRImport {
+    /// The module that provides this function.
+    ///
+    /// For static linking, this must match the `name` of a peer `IIRModule`
+    /// passed to `iir_linker::link`.  For dynamic linking (WASM/JVM), this
+    /// becomes the module/class name in the import section.
+    pub module_name: String,
+
+    /// The function name as published by the exporting module (the `public_name`
+    /// of the corresponding `IIRExport`).
+    pub function_name: String,
+
+    /// The local alias used inside *this* module's instructions.
+    ///
+    /// Call instructions use this name as their callee.  During linking,
+    /// the linker inlines or redirects to the actual function.
+    ///
+    /// `None` → use `function_name` locally.
+    pub local_alias: Option<String>,
+
+    /// Expected parameter types for type-checking during linking.
+    ///
+    /// Empty means "don't check" (trusted import).
+    pub param_types: Vec<String>,
+
+    /// Expected return type.
+    ///
+    /// `"any"` means "don't check".
+    pub return_type: String,
+}
+
+impl IIRImport {
+    pub fn new(
+        module_name: impl Into<String>,
+        function_name: impl Into<String>,
+        return_type: impl Into<String>,
+    ) -> Self {
+        IIRImport {
+            module_name: module_name.into(),
+            function_name: function_name.into(),
+            local_alias: None,
+            param_types: Vec::new(),
+            return_type: return_type.into(),
+        }
+    }
+
+    /// The name call instructions in this module use to refer to the imported
+    /// function.
+    pub fn local_name(&self) -> &str {
+        self.local_alias.as_deref().unwrap_or(&self.function_name)
+    }
+}
+```
+
+---
+
+## Updated `IIRModule::validate()`
+
+The existing validator is extended with two new checks:
+
+| Check | Error key | Condition |
+|-------|-----------|-----------|
+| ExportNotFound | `ExportNotFound` | An export's `function_name` does not appear in `self.functions` |
+| DuplicateExport | `DuplicateExport` | Two exports have the same `public_name()` |
+
+Imports are **not** validated here (they require peer modules, which `validate`
+doesn't have access to).  Import resolution is the linker's job.
+
+---
+
+## New crate: `iir-linker`
+
+### Crate layout
+
+```
+code/packages/rust/iir-linker/
+  Cargo.toml
+  BUILD
+  CHANGELOG.md
+  README.md
+  src/
+    lib.rs       — re-exports + module-level doc
+    error.rs     — LinkError enum
+    resolve.rs   — import/export resolution
+    merge.rs     — module merging (static linking)
+    linker.rs    — IIRLinker struct + link() entry point
+  tests/
+    test_linker.rs — ≥ 30 tests
+```
+
+### API
+
+```rust
+/// Static link two or more `IIRModule`s into one merged module.
+///
+/// # Algorithm
+///
+/// 1. Collect the export map: `HashMap<(module_name, public_name), &IIRFunction>`.
+/// 2. For each import in each module, resolve it from the export map.
+///    - Type-check parameter and return types if provided.
+///    - Accumulate `LinkError::Unresolved` if not found.
+/// 3. Merge all functions into a single `IIRModule`:
+///    - Rename colliding private functions by prefixing with `"<module>::"`.
+///    - Rewrite call instructions that reference imported functions to use the
+///      merged name.
+/// 4. Preserve `entry_point` from the first module that has one.
+/// 5. Return the merged module (or all errors if any were found).
+pub fn link(modules: &[IIRModule]) -> Result<IIRModule, Vec<LinkError>>;
+
+/// Link-and-fail-fast variant.  Returns `Err` with the first error encountered.
+pub fn link_strict(modules: &[IIRModule]) -> Result<IIRModule, LinkError>;
+
+/// Verify that all imports in `module` are satisfied by the exports in `providers`.
+///
+/// Does not merge or rewrite — useful for pre-flight checking in the REPL.
+pub fn verify_imports(module: &IIRModule, providers: &[&IIRModule]) -> Vec<LinkError>;
+```
+
+### `LinkError`
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub enum LinkError {
+    /// An import could not be resolved.
+    Unresolved {
+        importing_module: String,
+        import_module:    String,
+        import_function:  String,
+    },
+
+    /// An import's expected param types don't match the export's actual types.
+    TypeMismatch {
+        importing_module: String,
+        exporting_module: String,
+        function:         String,
+        expected:         Vec<String>,
+        actual:           Vec<String>,
+    },
+
+    /// Two modules export the same (module_name, function_name) pair.
+    DuplicateExport {
+        module_name:   String,
+        function_name: String,
+    },
+
+    /// A call instruction inside a function references a name that is neither
+    /// a local function nor a declared import.
+    UndeclaredCall {
+        in_module:   String,
+        in_function: String,
+        callee:      String,
+    },
+}
+```
+
+---
+
+## Updated `IIRModule::new()`
+
+```rust
+pub fn new(name: impl Into<String>, language: impl Into<String>) -> Self {
+    IIRModule {
+        name:        name.into(),
+        functions:   Vec::new(),
+        entry_point: Some("main".to_string()),
+        language:    language.into(),
+        exports:     Vec::new(),   // ← LANG33
+        imports:     Vec::new(),   // ← LANG33
+    }
+}
+```
+
+All existing call sites that construct `IIRModule { ... }` with struct literal
+syntax must add `exports: vec![], imports: vec![]`.  The workspace-level `cargo
+build` enforces this.
+
+---
+
+## Per-backend changes
+
+### BEAM (`iir-to-beam`)
+
+BEAM already has a native export table (`ExpT` chunk).  Currently the backend
+exports every function.  With LANG33:
+
+- Only functions in `module.exports` are added to the export table.
+- If `exports` is empty, fall back to exporting all functions (backward compat).
+- Cross-module calls become `call_ext` instructions using the import table.
+  For the static-linking path, `iir-linker` merges modules first, so the
+  backend never sees an unresolved import.
+
+### WASM (`iir-to-wasm`)
+
+WASM has native import/export sections.  With LANG33:
+
+- `module.exports` → WASM `Export` entries (kind = Function).
+- `module.imports` → WASM `Import` entries (module = `import.module_name`,
+  name = `import.function_name`), with the function type derived from
+  `param_types` / `return_type`.
+- Function index map: imported functions occupy indices 0..N-1; defined
+  functions start at N.  (Same `fn_idx_base` logic as the LANG32 io_out
+  import, generalised.)
+
+### JVM (`iir-to-jvm-class-file`)
+
+- Exported functions are marked `public static`.
+- Imported functions become `invokestatic` calls with a Methodref CP entry
+  pointing to the exporting class (module name → class name mapping).
+- For the static-linking path, all functions are in one class so no
+  cross-class references are needed.
+
+### CLR (`iir-to-cil-bytecode`)
+
+- Exported functions get `.method public static`.
+- Imported functions become `call` instructions with a MemberRef token
+  pointing to the exporting assembly.
+- Static linking collapses everything into one assembly.
+
+---
+
+## Serialisation (`interpreter-ir/src/serialise.rs`)
+
+The `serialise_module` / `deserialise_module` functions are updated to include
+`exports` and `imports`.  Binary format:
+
+| Field | Tag | Format |
+|-------|-----|--------|
+| exports length | `0x10` | u32 little-endian |
+| each export | — | len-prefixed UTF-8 function_name + len-prefixed UTF-8 alias (empty = None) |
+| imports length | `0x11` | u32 little-endian |
+| each import | — | len-prefixed module_name + len-prefixed function_name + len-prefixed local_alias + u32 param_count + (len-prefixed type) × N + len-prefixed return_type |
+
+---
+
+## Acceptance criteria
+
+1. `IIRModule` with non-empty `exports`/`imports` round-trips through
+   `serialise`/`deserialise` losslessly.
+2. `iir-linker::link` merges two modules where module A imports a function
+   exported by module B.
+3. `iir-linker::link` returns `LinkError::Unresolved` when an import has no
+   matching export.
+4. `iir-linker::link` returns `LinkError::TypeMismatch` when param/return
+   types don't match.
+5. BEAM: a module with explicit `exports` emits only those functions in ExpT.
+6. WASM: a module with imports emits a WASM import section with correct entries,
+   and function index offsets are applied correctly.
+7. ≥ 30 tests in `iir-linker/tests/test_linker.rs`.
+8. ≥ 5 tests each for BEAM/WASM/JVM/CLR export/import round-trips.
+9. `cargo build --workspace` is clean.
+
+---
+
+## Sister specs
+
+| Spec | Scope |
+|------|-------|
+| LANG31 | iir-builtin-lowering Phase 1+2; four e2e pipeline crates |
+| LANG32 | global variables + I/O at IIR level |
+| **LANG33 (this)** | module system: exports/imports at IIR level; `iir-linker` |
+| LANG34 | Closures at IIR level: `alloc_closure`/`call_closure` opcodes |
+| LANG35 | Real-VM integration tests (erl/java/dotnet/wasmtime) |
+
+---
+
+## What is NOT in LANG33
+
+- **Global variable exports** — a global defined in module A and read in module
+  B requires sharing the process-dictionary atom (BEAM) or WASM global import.
+  This is LANG33b.
+- **Dynamic library loading** — `dlopen`-style late binding is LANG36.
+- **Circular imports** — the linker rejects them with a clear error;
+  support requires lazy binding and is future work.
+- **Versioning / semver** — no version field on `IIRImport`; reserved for the
+  package manager layer (outside this spec).


### PR DESCRIPTION
## Summary

- **`interpreter-ir` v0.5.0**: New `IIRExport`/`IIRImport` types in `module_exports.rs`; new `exports`/`imports` fields on `IIRModule`; extended `validate()`; serialise format bumped to v1.1 with tag-based exports/imports sections; `Operand::Str` deserialise round-trip.
- **`iir-linker` v0.1.0** (new crate): Two-pass static linker — resolves imports to exports, type-checks, renames colliding private functions, rewrites `call` instructions, merges into one self-contained `IIRModule`. API: `link()`, `link_strict()`, `verify_imports()`.
- **`twig-ir-compiler` v0.2.1**: Added `exports`/`imports` fields to `IIRModule` struct literal.

## Spec

`code/specs/LANG33-module-system.md`

## Test coverage

| Package | Tests |
|---------|-------|
| `interpreter-ir` | 80 unit + 28 doc (10 new for LANG33 serialise) |
| `iir-linker` | 30 unit + 30 integration + 3 doc |

## Security fixes

- **MEDIUM** (fixed): `read_exact` in `serialise.rs` used bare `pos + n` arithmetic that wraps on 32-bit release targets → slice-bounds panic DoS. Fixed with `checked_add`.
- **LOW** (noted for LANG33b): `write_str` truncates strings >4 GB silently; `str_()` has no per-string size cap.

## Depends on

PR #2842 (LANG32 — global variables and I/O) — this branch is rebased on `feat/lang32-globals-and-io`.

## Test plan

- [ ] `cargo test -p interpreter-ir` — 80 + 28 pass
- [ ] `cargo test -p iir-linker` — 30 + 30 + 3 pass
- [ ] `cargo build --workspace` — no new errors (only pre-existing platform/native-lib issues)
- [ ] Serialise round-trip: module with exports + imports → serialise → deserialise → identical
- [ ] `link()`: math module exports `add`, app imports `add` → merged module contains both

🤖 Generated with [Claude Code](https://claude.com/claude-code)