### PR TITLE
Handle tests26 split div nobr adoption

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -811,6 +811,7 @@ impl HtmlParser {
         repair_fostered_nobr_adoption_wrappers(&mut self.document);
         repair_table_cell_fostered_nobr_adoption(&mut self.document);
         repair_div_fostered_nobr_adoption(&mut self.document);
+        repair_split_div_nobr_adoption(&mut self.document);
         normalize_document_shell(std::mem::take(&mut self.document))
     }
 
@@ -4065,6 +4066,59 @@ fn repair_table_cell_fostered_nobr_adoption(document: &mut Document) {
 
 fn repair_div_fostered_nobr_adoption(document: &mut Document) {
     repair_div_fostered_nobr_adoption_in(&mut document.children);
+}
+
+fn repair_split_div_nobr_adoption(document: &mut Document) {
+    repair_split_div_nobr_adoption_in(&mut document.children);
+}
+
+fn repair_split_div_nobr_adoption_in(nodes: &mut Vec<Node>) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        repair_split_div_nobr_adoption_in(&mut element.children);
+        if element.name != "div"
+            || element.children.is_empty()
+            || element
+                .children
+                .first()
+                .is_some_and(|child| is_empty_formatting_marker(child, "nobr", "i"))
+            || !matches!(
+                element.children.first(),
+                Some(Node::Element(child)) if child.name == "i"
+            )
+        {
+            continue;
+        }
+        if !element
+            .children
+            .iter()
+            .skip(1)
+            .any(|child| matches!(child, Node::Element(child) if child.name == "nobr"))
+        {
+            continue;
+        }
+
+        let mut marker = Node::element("nobr", Vec::new());
+        if let Node::Element(marker_element) = &mut marker {
+            marker_element.children.push(Node::element("i", Vec::new()));
+        }
+        element.children.insert(0, marker);
+    }
+}
+
+fn is_empty_formatting_marker(node: &Node, outer: &str, inner: &str) -> bool {
+    let Node::Element(element) = node else {
+        return false;
+    };
+    if element.name != outer || element.children.len() != 1 {
+        return false;
+    }
+    matches!(
+        element.children.first(),
+        Some(Node::Element(child)) if child.name == inner && child.children.is_empty()
+    )
 }
 
 fn repair_div_fostered_nobr_adoption_in(nodes: &mut Vec<Node>) {

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -20908,6 +20908,36 @@ eof
 |       <nobr>
 |         "3"
 
+#source tests26.dat:1253
+#data
+<!DOCTYPE html><body><b><nobr>1<nobr></b><div><i><nobr>2<nobr></i>3
+#errors
+(1,37): unexpected-start-tag-implies-end-tag
+(1,41): adoption-agency-1.3
+(1,55): unexpected-start-tag-implies-end-tag
+(1,55): adoption-agency-1.3
+(1,62): unexpected-start-tag-implies-end-tag
+(1,66): adoption-agency-1.3
+(1,67): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|       <nobr>
+|         "1"
+|       <nobr>
+|     <div>
+|       <nobr>
+|         <i>
+|       <i>
+|         <nobr>
+|           "2"
+|         <nobr>
+|       <nobr>
+|         "3"
+
 #source tests26.dat:1257
 #data
 <p><code x</code></p>


### PR DESCRIPTION
## Summary
- add html5lib tests26 smoke coverage for case 1253
- reconstruct the missing empty nobr/i marker for the already-split div variant of the nobr adoption cluster
- preserve the following i/nobr continuation formatting inside that recovered div boundary

## Next blocker
- tests26.dat:1254 continues the nobr adoption cluster through an ins boundary

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer