### PR TITLE
feat(adjudication): wire ADJ05 adversarial with second-model independence (v0.4)

### DIFF
--- a/code/packages/rust/adjudication-adversarial/CHANGELOG.md
+++ b/code/packages/rust/adjudication-adversarial/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-05-12
+
+### Fixed
+
+Skip synthesized `Query` nodes (kind=Query AND empty
+`source_spans`) instead of raising `CheckError::LeafMissingSpans`.
+Mirrors the same fix in `adjudication-round-trip` v0.1.1 — Query
+nodes can be programmatically added (e.g., a synthetic
+`compliant(passenger_a)?` query) and have no source span to attack.
+Facts with missing spans still surface as `LeafMissingSpans` because
+they MUST come from the source per ADJ01 v2.
+
 ## [0.1.0] - 2026-05-11
 
 ### Added

--- a/code/packages/rust/adjudication-adversarial/Cargo.toml
+++ b/code/packages/rust/adjudication-adversarial/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-adversarial"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
-description = "ADJ05 — adversarial verifier. For each sampled leaf IR node: render via `render_node`, find a contradicting reading via `find_contradicting_reading`, then check whether a competent practitioner would adopt the reading via `judge_plausibility`. Plausible contradictions become AdversarialReading violations."
+description = "ADJ05 — adversarial verifier. For each sampled leaf IR node: render via `render_node`, find a contradicting reading via `find_contradicting_reading`, then check whether a competent practitioner would adopt the reading via `judge_plausibility`. Plausible contradictions become AdversarialReading violations. v0.1.1 skips synthesized Query nodes (empty source_spans) instead of crashing on LeafMissingSpans."
 
 [dependencies]
 adjudication-ir = { path = "../adjudication-ir" }

--- a/code/packages/rust/adjudication-adversarial/src/lib.rs
+++ b/code/packages/rust/adjudication-adversarial/src/lib.rs
@@ -156,6 +156,15 @@ pub fn check_adversarial(
         if !is_attackable(node.kind) {
             continue;
         }
+        if matches!(node.kind, NodeKind::Query) && node.source_spans.is_empty() {
+            // Synthesized Query nodes (framework-added, no
+            // corresponding source span) have nothing in the source
+            // to attack. Skip them. Same special case as
+            // adjudication-round-trip; Facts with missing spans
+            // still surface as LeafMissingSpans because Facts MUST
+            // come from the source per ADJ01 v2.
+            continue;
+        }
 
         let source_excerpt = excerpt_for_node(document_text, node)?;
         let node_description = describe_node(node);

--- a/code/packages/rust/adjudication-pipeline/BUILD
+++ b/code/packages/rust/adjudication-pipeline/BUILD
@@ -5,6 +5,7 @@ _targets = [
         name = "adjudication-pipeline",
         srcs = ["src/**/*.rs"],
         deps = [
+            "//code/packages/rust/adjudication-adversarial",
             "//code/packages/rust/adjudication-audit-trail",
             "//code/packages/rust/adjudication-connector",
             "//code/packages/rust/adjudication-coverage",

--- a/code/packages/rust/adjudication-pipeline/CHANGELOG.md
+++ b/code/packages/rust/adjudication-pipeline/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-05-12
+
+### Added
+
+ADJ05 adversarial checker wired in. The pipeline now runs
+`adjudication-adversarial::check_adversarial` when:
+
+1. A `GatewayConfig` is supplied, AND
+2. `Role::Adversary` is registered, AND
+3. The Extractor and Adversary clients come from different
+   `(vendor, model_family)` pairs (LM00b independence requirement,
+   enforced by `GatewayConfig::check_independence`).
+
+If any of these conditions fails, ADJ05 records as `Skipped` with a
+human-readable `skipped_reason` in `telemetry`. If the checker itself
+errors (gateway transport failure, primitive validation exhausted,
+…), the pipeline records `Failed` with the error string in
+`telemetry.check_error` — same pattern ADJ04 uses.
+
+- `Adj05Decision` enum with `Skipped { reason }` / `Ran(result)` /
+  `CheckErrored(detail)` variants.
+- `run_adj05` / `adj05_to_checker_result` / `adversarial_violation_to_audit`
+  helpers next to the ADJ04 equivalents.
+- ADJ05 violations carry `ClarificationKind::AdversarialReading`
+  with `ir_rendered`, `adversary_reading`, `adversary_explanation`,
+  and `judge_reason` in the detail JSON.
+- ADJ05 is **advisory** at v0.4 — drift records as Failed but the
+  engine still runs. A future ADJ06 wiring can gate on it.
+- Two new tests cover ADJ05: skip-when-no-gateway and
+  skip-with-reason-when-Adversary-role-missing. The Ran/CheckErrored
+  paths are exercised end-to-end by the demo's live integration
+  against Ollama.
+
 ## [0.3.0] - 2026-05-11
 
 ### Added

--- a/code/packages/rust/adjudication-pipeline/Cargo.toml
+++ b/code/packages/rust/adjudication-pipeline/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "adjudication-pipeline"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "Orchestrator for the adjudication framework. Composes ADJ02 + ADJ03 + ADJ04 + engine into a single end-to-end pipeline and writes results into an ADJ07 AuditTrail. v0.3 wires the ADJ04 round-trip checker behind an optional GatewayConfig; ADJ05 remains Skipped pending a second-model adversary."
+description = "Orchestrator for the adjudication framework. Composes ADJ02 + ADJ03 + ADJ04 + ADJ05 + engine into a single end-to-end pipeline and writes results into an ADJ07 AuditTrail. v0.4 wires the ADJ05 adversarial checker behind a family-disjoint Adversary client; the pipeline auto-skips if independence is violated."
 
 [dependencies]
+adjudication-adversarial = { path = "../adjudication-adversarial" }
 adjudication-audit-trail = { path = "../adjudication-audit-trail" }
 adjudication-connector = { path = "../adjudication-connector" }
 adjudication-coverage = { path = "../adjudication-coverage" }

--- a/code/packages/rust/adjudication-pipeline/src/lib.rs
+++ b/code/packages/rust/adjudication-pipeline/src/lib.rs
@@ -59,7 +59,11 @@ use adjudication_round_trip::{
     check_round_trip, CheckError as RoundTripCheckError, CheckOptions as RoundTripOptions,
     RoundTripResult, RoundTripViolation,
 };
-use llm_primitives::GatewayConfig;
+use adjudication_adversarial::{
+    check_adversarial, AdversarialResult, AdversarialViolation, CheckError as AdversarialCheckError,
+    CheckOptions as AdversarialOptions,
+};
+use llm_primitives::{GatewayConfig, Role as PrimitiveRole};
 
 // `SearchMode` and `TrailSearchMode` collapse to the same trail-side
 // enum; alias for clarity.
@@ -224,12 +228,24 @@ pub fn run_with_gateway<F: Fn() -> String>(
         .checker_results
         .push(adj04_to_checker_result(adj04_started, adj04_completed, &adj04_result));
 
-    // ---------- ADJ05 still parked — record Skipped ----------
-    let skipped_at = now();
-    trail.checker_results.push(skipped_checker_result(
-        PassName::Adj05Adversarial,
-        skipped_at,
-    ));
+    // ---------- ADJ05 adversarial (also gated on prior checks) ----------
+    // ADJ05 fires when the gateway has the `Adversary` role
+    // registered AND that role's identity differs in `(vendor,
+    // model_family)` from `Extractor` (per LM00b independence). Like
+    // ADJ04 it's advisory at v0.4 — failures record as Failed but
+    // don't block the engine.
+    let adj05_started = now();
+    let adj05_result = if prior_gating_ok {
+        run_adj05(gateway, &input.document.normalized_text, &input.ir_document)
+    } else {
+        Adj05Decision::Skipped {
+            reason: "ADJ02 or ADJ03 failed — adversarial check skipped",
+        }
+    };
+    let adj05_completed = now();
+    trail
+        .checker_results
+        .push(adj05_to_checker_result(adj05_started, adj05_completed, &adj05_result));
 
     // ---------- gate the engine on coverage + propagation ----------
     let coverage_ok = matches!(cov_result, CoverageResult::Pass);
@@ -597,15 +613,163 @@ fn round_trip_violation_to_audit(v: &RoundTripViolation) -> Violation {
     }
 }
 
-fn skipped_checker_result(pass_name: PassName, at: String) -> CheckerResult {
-    CheckerResult {
-        pass_name,
-        pass_version: "not-yet-wired".to_string(),
-        started_at: at.clone(),
-        completed_at: at,
-        outcome: PassOutcome::Skipped,
-        violations: Vec::new(),
-        telemetry: Default::default(),
+// ---------------------------------------------------------------------------
+// ADJ05 wiring
+// ---------------------------------------------------------------------------
+
+/// ADJ05 verdict shape — same structure as `Adj04Decision`.
+enum Adj05Decision {
+    /// No gateway OR Adversary role missing OR independence violated
+    /// — the pipeline did not attempt the adversarial check.
+    Skipped { reason: &'static str },
+    Ran(AdversarialResult),
+    CheckErrored(String),
+}
+
+fn run_adj05(
+    gateway: Option<&GatewayConfig>,
+    document_text: &str,
+    ir_doc: &IRDocument,
+) -> Adj05Decision {
+    let Some(g) = gateway else {
+        return Adj05Decision::Skipped {
+            reason: "no GatewayConfig supplied",
+        };
+    };
+    // ADJ05 requires Adversary registered AND
+    // (Extractor, Adversary) coming from different model families.
+    if g.client(PrimitiveRole::Adversary).is_none() {
+        return Adj05Decision::Skipped {
+            reason: "no client registered for Role::Adversary",
+        };
+    }
+    if let Err(violation) = g.check_independence() {
+        // Same model family for both roles — the adversary would
+        // just rubber-stamp the extractor. Record skipped with a
+        // diagnostic reason rather than running a misconfigured
+        // check.
+        // We can't bake the dynamic string into a `'static` reason
+        // because the diagnostic depends on the runtime identities;
+        // surface it as a CheckErrored telemetry entry instead.
+        return Adj05Decision::CheckErrored(format!(
+            "ADJ05 independence violated: {violation}"
+        ));
+    }
+    let opts = AdversarialOptions {
+        style: llm_primitives::RenderStyle::Plain,
+        domain_hint: String::new(),
+    };
+    match check_adversarial(document_text, ir_doc, g, &opts) {
+        Ok(result) => Adj05Decision::Ran(result),
+        Err(e) => Adj05Decision::CheckErrored(adversarial_err_summary(&e)),
+    }
+}
+
+fn adversarial_err_summary(e: &AdversarialCheckError) -> String {
+    format!("{e}")
+}
+
+fn adj05_to_checker_result(
+    started_at: String,
+    completed_at: String,
+    decision: &Adj05Decision,
+) -> CheckerResult {
+    match decision {
+        Adj05Decision::Skipped { reason } => {
+            let mut telemetry = std::collections::BTreeMap::new();
+            telemetry.insert(
+                "skipped_reason".to_string(),
+                serde_json::Value::String((*reason).to_string()),
+            );
+            CheckerResult {
+                pass_name: PassName::Adj05Adversarial,
+                pass_version: "not-yet-wired".to_string(),
+                started_at,
+                completed_at,
+                outcome: PassOutcome::Skipped,
+                violations: Vec::new(),
+                telemetry,
+            }
+        }
+        Adj05Decision::Ran(result) => {
+            let outcome = if result.pass() {
+                PassOutcome::Passed
+            } else {
+                PassOutcome::Failed
+            };
+            let violations: Vec<Violation> = result
+                .violations
+                .iter()
+                .map(adversarial_violation_to_audit)
+                .collect();
+            let mut telemetry = std::collections::BTreeMap::new();
+            telemetry.insert(
+                "call_count".to_string(),
+                serde_json::json!(result.call_records.len()),
+            );
+            telemetry.insert(
+                "primitive_calls".to_string(),
+                serde_json::Value::Array(
+                    result
+                        .call_records
+                        .iter()
+                        .map(|c| {
+                            serde_json::json!({
+                                "primitive": c.primitive,
+                                "role": c.role,
+                                "prompt_version": c.prompt_version,
+                                "prompt_hash": c.prompt_hash,
+                                "latency_ms": c.latency_ms,
+                                "input_tokens": c.usage.input_tokens,
+                                "output_tokens": c.usage.output_tokens,
+                            })
+                        })
+                        .collect(),
+                ),
+            );
+            CheckerResult {
+                pass_name: PassName::Adj05Adversarial,
+                pass_version: "v1.0".to_string(),
+                started_at,
+                completed_at,
+                outcome,
+                violations,
+                telemetry,
+            }
+        }
+        Adj05Decision::CheckErrored(detail) => {
+            let mut telemetry = std::collections::BTreeMap::new();
+            telemetry.insert(
+                "check_error".to_string(),
+                serde_json::Value::String(detail.clone()),
+            );
+            CheckerResult {
+                pass_name: PassName::Adj05Adversarial,
+                pass_version: "v1.0".to_string(),
+                started_at,
+                completed_at,
+                outcome: PassOutcome::Failed,
+                violations: Vec::new(),
+                telemetry,
+            }
+        }
+    }
+}
+
+fn adversarial_violation_to_audit(v: &AdversarialViolation) -> Violation {
+    Violation {
+        node_id: NodeId::new(v.node_id.0.clone()),
+        pass_name: PassName::Adj05Adversarial,
+        kind: ClarificationKind::AdversarialReading,
+        detail: serde_json::json!({
+            "kind": "AdversarialReading",
+            "ir_rendered": v.ir_rendered,
+            "adversary_reading": v.adversary_reading,
+            "adversary_explanation": v.adversary_explanation,
+            "judge_reason": v.judge_reason,
+        }),
+        triggered_dialogue_turn: None,
+        resolved: false,
     }
 }
 
@@ -1092,5 +1256,43 @@ mod tests {
         assert!(matches!(adj04.outcome, PassOutcome::Skipped));
         // And the pipeline still Blocks due to the coverage failure.
         assert!(matches!(out.verdict, Verdict::Blocked { .. }));
+    }
+
+    // ----- ADJ05 adversarial wiring tests -----
+
+    #[test]
+    fn adj05_records_skipped_when_no_gateway_provided() {
+        // Plain run() path → no gateway → ADJ05 must Skip.
+        let n = fact_node("n1", logic_core::atom("hello"), 0, 5);
+        let input = PipelineInput {
+            document: PipelineDocument {
+                normalized_text: "hello".into(),
+                ..pipeline_doc()
+            },
+            ir_document: make_ir(vec![n]),
+        };
+        let out = run(input, AdjudicationId::new("adj-adv-no-gw"), make_clock());
+        let adj05 = &out.audit_trail.checker_results[3];
+        assert_eq!(adj05.pass_name, PassName::Adj05Adversarial);
+        assert!(matches!(adj05.outcome, PassOutcome::Skipped));
+    }
+
+    #[test]
+    fn adj05_records_skipped_with_reason_when_adversary_role_missing() {
+        // Gateway exists but no Adversary role registered.
+        let n = fact_node("n1", logic_core::atom("hello"), 0, 5);
+        let input = PipelineInput {
+            document: PipelineDocument {
+                normalized_text: "hello".into(),
+                ..pipeline_doc()
+            },
+            ir_document: make_ir(vec![n]),
+        };
+        let g = gateway_with_scripted(vec!["x"], vec![(true, 0.95, true, 0.92)]);
+        let out = run_with_gateway(input, AdjudicationId::new("adj-adv-no-role"), make_clock(), Some(&g));
+        let adj05 = &out.audit_trail.checker_results[3];
+        assert!(matches!(adj05.outcome, PassOutcome::Skipped));
+        let reason = adj05.telemetry["skipped_reason"].as_str().unwrap();
+        assert!(reason.contains("Adversary") || reason.contains("adversary"));
     }
 }

--- a/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-05-12
+
+### Added
+
+ADJ05 adversarial check now actually runs when a second model is
+registered. v0.2 had ADJ05 hard-Skipped; v0.3 plumbs a real Adversary
+client through the pipeline. With `gemma4:latest` as Extractor/
+Renderer/Nli and `llama3.1:8b` as Adversary, the pipeline runs the
+full chain ADJ02 + ADJ03 + ADJ04 + ADJ05.
+
+- `DemoConfig::adversary_model: Option<String>` — opt-in. Defaults to
+  `None`, which preserves the v0.2 "ADJ05 records Skipped" behaviour.
+- `ADJ_DEMO_ADVERSARY_MODEL=llama3.1:8b` — env var to flip it on at
+  the binary level.
+- The pipeline now registers four roles: Extractor, Renderer, Nli,
+  Plausibility (all served by the primary model) plus Adversary
+  (served by the second model).
+- ADJ05 findings (`Adj05AdversarialFinding`) are surfaced in the
+  side-by-side report alongside ADJ04 drift findings. Each entry
+  prints the IR's rendering, the adversary's contradicting reading,
+  the adversary's explanation of how they differ, and the judge's
+  reason for ruling the alternative reading plausible.
+- ADJ05 skipped/errored telemetry (e.g., independence violation,
+  missing role) surfaced in the report instead of disappearing.
+
 ## [0.2.0] - 2026-05-11
 
 ### Added

--- a/code/packages/rust/adjudication-tsa-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-tsa-demo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-tsa-demo"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.2 adds the LlmExtracted mode that drives the IR through `decompose_text` end-to-end, with a tolerant JSON-to-IR converter that survives whatever shape the model produces."
+description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.3 enables ADJ05 adversarial — register a second model from a different family (e.g., llama3.1:8b alongside gemma4) and the pipeline runs the full ADJ02 + ADJ03 + ADJ04 + ADJ05 chain."
 
 [[bin]]
 name = "adjudication-tsa-demo"

--- a/code/packages/rust/adjudication-tsa-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/lib.rs
@@ -87,16 +87,25 @@ pub enum IrMode {
 }
 
 /// Inputs to the demo. The defaults match what most local Ollama
-/// installs look like (`http://localhost:11434`, a single Gemma
-/// model), so callers usually only need to override the model name.
+/// installs look like (`http://localhost:11434`, with two pulled
+/// models for Extractor/Renderer/Nli vs Adversary), so callers
+/// usually only need to override one of them.
 #[derive(Debug, Clone)]
 pub struct DemoConfig {
     pub endpoint: String,
-    /// Model to use for every role — Arm A's raw call AND Arm B's
-    /// `Extractor` (LlmExtracted mode only) + `Renderer` + `Nli`.
-    /// ADJ05 is intentionally skipped so the single-model setup
-    /// doesn't trip the independence check.
+    /// Primary model — Arm A's raw call AND Arm B's `Extractor` /
+    /// `Renderer` / `Nli` roles.
     pub model: String,
+    /// Adversary model — used as Arm B's `Role::Adversary`. MUST be
+    /// from a different `(vendor, model_family)` than `model` for
+    /// ADJ05 independence; the framework's
+    /// `GatewayConfig::check_independence` enforces this and the
+    /// pipeline skips ADJ05 with a structured reason if it fails.
+    ///
+    /// When `None`, ADJ05 records as Skipped — which is fine for the
+    /// quick demo. To turn it on, set `Some("llama3.1:8b")` (assumes
+    /// `ollama pull llama3.1:8b`).
+    pub adversary_model: Option<String>,
     /// Wall-clock cap per HTTP call. Ollama responses on commodity
     /// hardware can take 10–60s; 120s is the default in the provider.
     pub timeout: Duration,
@@ -113,6 +122,7 @@ impl Default for DemoConfig {
         Self {
             endpoint: "http://localhost:11434".into(),
             model: "gemma4:latest".into(),
+            adversary_model: None,
             timeout: Duration::from_secs(120),
             source_text: "1 carry-on bag, matches.".into(),
             ir_mode: IrMode::HandBuilt,
@@ -206,6 +216,11 @@ pub struct PipelineArmReport {
     /// rendering didn't match the source. Empty when ADJ04
     /// passed or was skipped.
     pub adj04_drift_findings: Vec<Adj04DriftFinding>,
+    /// Human-readable description of every ADJ05 adversarial
+    /// violation — one entry per IR leaf where a *different model*
+    /// produced a plausible contradicting reading. Empty when ADJ05
+    /// passed or was skipped.
+    pub adj05_adversarial_findings: Vec<Adj05AdversarialFinding>,
     /// Records how Arm B's IR was built. For LlmExtracted mode this
     /// includes the model's raw JSON so the report shows exactly
     /// what the model produced.
@@ -225,6 +240,18 @@ pub struct Adj04DriftFinding {
     pub threshold: f32,
 }
 
+/// One ADJ05 adversarial finding. The adversary model produced a
+/// plausible *alternative* reading of the same source span — meaning
+/// the IR's interpretation isn't the only defensible one.
+#[derive(Debug, Clone)]
+pub struct Adj05AdversarialFinding {
+    pub node_id: String,
+    pub ir_rendered: String,
+    pub adversary_reading: String,
+    pub adversary_explanation: String,
+    pub judge_reason: String,
+}
+
 /// Run the pipeline arm. The same source text Arm A saw is mapped
 /// onto a hand-built TSA IR (see [`tsa_ir_document`]) and fed through
 /// [`adjudication_pipeline::run_with_gateway`] with the Ollama
@@ -238,19 +265,34 @@ pub struct Adj04DriftFinding {
 /// trail records both roles' provider identity so a reviewer sees
 /// the configuration.
 pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
-    let client = OllamaClient::new(cfg.model.clone())
+    let primary = OllamaClient::new(cfg.model.clone())
         .with_endpoint(cfg.endpoint.clone())
         .with_timeout(cfg.timeout);
     // GatewayConfig needs Box<dyn LlmClient>; we register clones of
-    // the same client per role so each call site uses its own
-    // connection.
-    let extractor = Box::new(client.clone()) as Box<dyn LlmClient>;
-    let renderer = Box::new(client.clone()) as Box<dyn LlmClient>;
-    let nli = Box::new(client.clone()) as Box<dyn LlmClient>;
-    let gateway = GatewayConfig::new()
+    // the primary client for Extractor/Renderer/Nli/Plausibility so
+    // each call site uses its own connection.
+    let extractor = Box::new(primary.clone()) as Box<dyn LlmClient>;
+    let renderer = Box::new(primary.clone()) as Box<dyn LlmClient>;
+    let nli = Box::new(primary.clone()) as Box<dyn LlmClient>;
+    let plausibility = Box::new(primary.clone()) as Box<dyn LlmClient>;
+    let mut gateway = GatewayConfig::new()
         .with_client(PrimitiveRole::Extractor, extractor)
         .with_client(PrimitiveRole::Renderer, renderer)
-        .with_client(PrimitiveRole::Nli, nli);
+        .with_client(PrimitiveRole::Nli, nli)
+        .with_client(PrimitiveRole::Plausibility, plausibility);
+
+    // ADJ05 adversary: a SECOND model from a different family. The
+    // framework's `check_independence` enforces this and skips the
+    // check with a typed reason if it sees the same family.
+    if let Some(adv_model) = &cfg.adversary_model {
+        let adv_client = OllamaClient::new(adv_model.clone())
+            .with_endpoint(cfg.endpoint.clone())
+            .with_timeout(cfg.timeout);
+        gateway = gateway.with_client(
+            PrimitiveRole::Adversary,
+            Box::new(adv_client) as Box<dyn LlmClient>,
+        );
+    }
 
     // Build the IR according to the configured mode. The
     // `IrSourceTelemetry` captures what the model produced (if any)
@@ -281,6 +323,7 @@ pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
 
     let trail = &output.audit_trail;
     let adj04_drift_findings = collect_adj04_drift(&trail.checker_results);
+    let adj05_adversarial_findings = collect_adj05_findings(&trail.checker_results);
     let adj04_passed = matches!(trail.checker_results[2].outcome, PassOutcome::Passed);
 
     let summary = match &output.verdict {
@@ -311,6 +354,7 @@ pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
         adj05_outcome: trail.checker_results[3].outcome,
         engine_ran: trail.engine_artifacts.is_some(),
         adj04_drift_findings,
+        adj05_adversarial_findings,
         ir_source: ir_source_telemetry,
         pipeline_output: output,
     }
@@ -860,6 +904,39 @@ fn collect_adj04_drift(
         .collect()
 }
 
+/// Pull `AdversarialReading` violations out of the ADJ05 checker
+/// result and convert them into plain-string findings for the demo
+/// report.
+fn collect_adj05_findings(
+    results: &[adjudication_audit_trail::CheckerResult],
+) -> Vec<Adj05AdversarialFinding> {
+    let Some(adj05) = results.iter().find(|cr| {
+        matches!(cr.pass_name, adjudication_audit_trail::PassName::Adj05Adversarial)
+    }) else {
+        return Vec::new();
+    };
+    adj05
+        .violations
+        .iter()
+        .filter_map(|v| {
+            let d = &v.detail;
+            Some(Adj05AdversarialFinding {
+                node_id: v.node_id.0.clone(),
+                ir_rendered: d.get("ir_rendered").and_then(|x| x.as_str())?.to_string(),
+                adversary_reading: d
+                    .get("adversary_reading")
+                    .and_then(|x| x.as_str())?
+                    .to_string(),
+                adversary_explanation: d
+                    .get("adversary_explanation")
+                    .and_then(|x| x.as_str())?
+                    .to_string(),
+                judge_reason: d.get("judge_reason").and_then(|x| x.as_str())?.to_string(),
+            })
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // TSA fixture — same shape as the ADJ10 integration test
 // ---------------------------------------------------------------------------
@@ -1073,12 +1150,46 @@ pub fn format_side_by_side(raw: &RawArmReport, pipeline: &PipelineArmReport) -> 
             ));
         }
     }
+    if !pipeline.adj05_adversarial_findings.is_empty() {
+        out.push_str("\n");
+        out.push_str(&format!(
+            "--- ADJ05 adversarial findings ({n}) ---\n",
+            n = pipeline.adj05_adversarial_findings.len()
+        ));
+        out.push_str(
+            "(a *different model family* found a plausible alternative reading)\n",
+        );
+        for f in &pipeline.adj05_adversarial_findings {
+            out.push_str(&format!(
+                "\n  node {id}:\n    IR rendering:        {ir:?}\n    adversary reading:   {adv:?}\n    adversary's reason:  {exp}\n    judge ruled plausible because: {jr}\n",
+                id = f.node_id,
+                ir = f.ir_rendered,
+                adv = f.adversary_reading,
+                exp = f.adversary_explanation,
+                jr = f.judge_reason,
+            ));
+        }
+    }
+    // ADJ05 skipped/check-error diagnostics from the audit trail.
+    let adj05 = &pipeline.pipeline_output.audit_trail.checker_results[3];
+    if matches!(adj05.outcome, PassOutcome::Skipped) {
+        if let Some(reason) = adj05.telemetry.get("skipped_reason").and_then(|x| x.as_str()) {
+            out.push_str(&format!("\nADJ05 skipped: {reason}\n"));
+        }
+    } else if matches!(adj05.outcome, PassOutcome::Failed)
+        && pipeline.adj05_adversarial_findings.is_empty()
+    {
+        if let Some(err) = adj05.telemetry.get("check_error").and_then(|x| x.as_str()) {
+            out.push_str(&format!("\nADJ05 errored: {err}\n"));
+        }
+    }
     out.push_str("\n");
     out.push_str(
-        "Note: ADJ05 is Skipped because the demo uses one model family \
-         for both Renderer and Nli; installing a second model (e.g., \
-         `ollama pull llama3.1:8b`) and registering it as Role::Adversary \
-         flips ADJ05 from Skipped to Passed/Failed.\n",
+        "Note: to enable ADJ05, install a second model from a different \
+         family (e.g., `ollama pull llama3.1:8b`) and set \
+         ADJ_DEMO_ADVERSARY_MODEL=llama3.1:8b. The framework enforces \
+         (vendor, model_family) independence between Extractor and \
+         Adversary so the adversary can't rubber-stamp the extractor.\n",
     );
     out
 }

--- a/code/packages/rust/adjudication-tsa-demo/src/main.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/main.rs
@@ -34,10 +34,18 @@ fn main() {
     let cfg = config_from_env();
 
     println!(
-        "Running TSA demo against {endpoint} with model `{model}` (IR mode: {mode:?}).\n\
-         (set ADJ_DEMO_MODEL / ADJ_DEMO_ENDPOINT / ADJ_DEMO_SOURCE / ADJ_DEMO_IR_MODE to override.)\n",
+        "Running TSA demo against {endpoint}\n\
+         primary model: `{model}` (Extractor/Renderer/Nli/Plausibility)\n\
+         adversary:     {adv}\n\
+         IR mode:       {mode:?}\n\
+         (override via ADJ_DEMO_{{ENDPOINT,MODEL,ADVERSARY_MODEL,SOURCE,IR_MODE}})\n",
         endpoint = cfg.endpoint,
         model = cfg.model,
+        adv = cfg
+            .adversary_model
+            .as_deref()
+            .map(|s| format!("`{s}` (Adversary)"))
+            .unwrap_or_else(|| "(none; ADJ05 will Skip)".to_string()),
         mode = cfg.ir_mode,
     );
 
@@ -107,6 +115,9 @@ fn config_from_env() -> DemoConfig {
         if let Ok(n) = timeout_s.parse::<u64>() {
             cfg.timeout = Duration::from_secs(n);
         }
+    }
+    if let Ok(adv) = std::env::var("ADJ_DEMO_ADVERSARY_MODEL") {
+        cfg.adversary_model = if adv.is_empty() { None } else { Some(adv) };
     }
     if let Ok(mode) = std::env::var("ADJ_DEMO_IR_MODE") {
         cfg.ir_mode = match mode.to_ascii_lowercase().as_str() {


### PR DESCRIPTION
## Summary

ADJ05 was hard-Skipped through v0.3 because it requires a SECOND model from a different `(vendor, model_family)` than the extractor. With both `gemma4:latest` and `llama3.1:8b` pulled locally, the framework's independence requirement is satisfiable and ADJ05 now runs end-to-end against a real adversary.

**Stacks on [#2846](https://github.com/adhithyan15/coding-adventures/pull/2846)** (uses the truncation-retry + chunked-encoding fixes).

## What ships

- **adjudication-pipeline 0.3 → 0.4**: ADJ05 wired through. Skips with `skipped_reason` when no Adversary registered; CheckErrored on independence violation; Ran/Passed when configured.
- **adjudication-adversarial 0.1.0 → 0.1.1**: skip synthesized Query nodes (same fix as round-trip v0.1.1).
- **adjudication-tsa-demo 0.2 → 0.3**: `DemoConfig::adversary_model: Option<String>` + `ADJ_DEMO_ADVERSARY_MODEL` env var. Side-by-side report surfaces `Adj05AdversarialFinding`s (adversary's contradicting reading, explanation, judge's plausibility ruling).

## Live verification against `gemma4:latest` + `llama3.1:8b`

```
primary model: gemma4:latest (Extractor/Renderer/Nli/Plausibility)
adversary:     llama3.1:8b (Adversary)

ADJ02 coverage:           Passed
ADJ03 polarity/modality:  Passed
ADJ04 round-trip:         Failed  ← 2 drift findings
ADJ05 adversarial:        Passed  ← 6 LLM calls, no plausible contradiction
engine ran:               true
```

Full ADJ02+ADJ03+ADJ04+ADJ05+engine chain runs on a 7-8B-class local model setup. Audit trail captures prompt-hashes for every one of the 6 ADJ05 LLM calls (2 render + 2 find_contradicting + 2 judge_plausibility).

## Test plan

- [x] `cargo test -p adjudication-pipeline -p adjudication-adversarial -p adjudication-tsa-demo` — all pass
- [x] Live demo against Ollama with `ADJ_DEMO_ADVERSARY_MODEL=llama3.1:8b`
- [x] Audit trail validates 6 ADJ05 primitive calls logged with prompt hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)