### PR TITLE
Add TypeScript linear system solving for cas-solve

### DIFF
--- a/code/packages/typescript/cas-solve/CHANGELOG.md
+++ b/code/packages/typescript/cas-solve/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `solveLinearSystem` with exact Gaussian elimination, `Equal(lhs, rhs)`
+  normalization, zero-form equations, and `Rule(var, value)` IR output.
 - Add pure TypeScript Durand-Kerner numeric polynomial solving plus IR
   conversion helpers for numeric roots.
 - Add pure TypeScript quartic solving parity with rational-root deflation,

--- a/code/packages/typescript/cas-solve/README.md
+++ b/code/packages/typescript/cas-solve/README.md
@@ -13,6 +13,7 @@ bindings.
 | `solveQuadratic(a, b, c)` | Solve `a*x^2 + b*x + c = 0` |
 | `solveCubic(a, b, c, d)` | Solve `a*x^3 + b*x^2 + c*x + d = 0` |
 | `solveQuartic(a, b, c, d, e)` | Solve `a*x^4 + b*x^3 + c*x^2 + d*x + e = 0` |
+| `solveLinearSystem(equations, variables)` | Solve exact square linear systems and return `Rule(var, value)` nodes |
 | `nsolvePoly(coeffs)` | Numerically solve a polynomial via Durand-Kerner |
 | `rootsToIr(roots)` / `nsolveFractionPoly(coeffs)` | Convert numeric roots to symbolic IR |
 
@@ -29,6 +30,11 @@ solution list for casus irreducibilis.
 `solveQuartic` follows the Python package's quartic path: rational-root
 deflation first, biquadratic solving for even quartics, and Ferrari
 factorization when the resolvent cubic has a usable rational root.
+
+`solveLinearSystem` accepts `Equal(lhs, rhs)` nodes or zero-form expressions,
+linearizes them over the provided variables, and solves square systems with
+exact Gaussian elimination. It returns `null` for non-linear, singular, empty,
+or non-square systems.
 
 `nsolvePoly` accepts real or complex coefficients in descending degree order,
 normalizes by the leading coefficient, and returns all roots as `{ re, im }`

--- a/code/packages/typescript/cas-solve/src/index.ts
+++ b/code/packages/typescript/cas-solve/src/index.ts
@@ -1,4 +1,22 @@
-import { ADD, DIV, MUL, NEG, SQRT, SUB, app, equals, int, numberNode, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import {
+  ADD,
+  DIV,
+  EQUAL,
+  MUL,
+  NEG,
+  POW,
+  RULE,
+  SQRT,
+  SUB,
+  app,
+  equals,
+  int,
+  numberNode,
+  rational,
+  sym,
+  type IRNode,
+  type IRSymbol,
+} from "@coding-adventures/symbolic-ir";
 
 export const SOLVE = "Solve";
 export const NSOLVE = "NSolve";
@@ -249,6 +267,54 @@ export function solveQuartic(a: Frac, b: Frac, c: Frac, d: Frac, e: Frac): Solve
   return solutions(dedupRoots(shifted));
 }
 
+export function solveLinearSystem(
+  equations: readonly IRNode[],
+  variables: readonly IRSymbol[],
+): readonly IRNode[] | null {
+  const dimension = variables.length;
+  if (equations.length !== dimension || dimension === 0) return null;
+
+  const variableColumns = new Map<string, number>();
+  variables.forEach((variable, index) => variableColumns.set(variable.name, index));
+
+  const matrix: Frac[][] = [];
+  for (const equation of equations) {
+    const row = equationToRow(equation, variableColumns, dimension);
+    if (row === null) return null;
+    matrix.push([...row]);
+  }
+
+  for (let col = 0; col < dimension; col += 1) {
+    let pivotRow = col;
+    for (let row = col + 1; row < dimension; row += 1) {
+      if (fracAbsCompare(matrix[row][col], matrix[pivotRow][col]) > 0) pivotRow = row;
+    }
+    if (matrix[pivotRow][col].isZero()) return null;
+    [matrix[col], matrix[pivotRow]] = [matrix[pivotRow], matrix[col]];
+
+    const pivot = matrix[col][col];
+    for (let row = col + 1; row < dimension; row += 1) {
+      if (matrix[row][col].isZero()) continue;
+      const factor = matrix[row][col].div(pivot);
+      for (let j = col; j <= dimension; j += 1) {
+        matrix[row][j] = matrix[row][j].sub(factor.mul(matrix[col][j]));
+      }
+    }
+  }
+
+  const solution = Array.from({ length: dimension }, () => Frac.zero());
+  for (let row = dimension - 1; row >= 0; row -= 1) {
+    if (matrix[row][row].isZero()) return null;
+    let rhs = matrix[row][dimension];
+    for (let col = row + 1; col < dimension; col += 1) {
+      rhs = rhs.sub(matrix[row][col].mul(solution[col]));
+    }
+    solution[row] = rhs.div(matrix[row][row]);
+  }
+
+  return variables.map((variable, index) => app(RULE, [variable, solution[index].toIrNode()]));
+}
+
 export function nsolvePoly(
   coeffs: readonly (number | Complex)[],
   maxIter = 200,
@@ -492,6 +558,138 @@ function initialRadius(poly: readonly Complex[]): number {
   const constant = complexAbs(poly[degree]);
   const lagrange = constant > 1e-300 ? constant ** (1 / degree) : 1;
   return Math.max(Math.min(cauchy, 10), lagrange, 0.5);
+}
+
+function equationToRow(
+  equation: IRNode,
+  variableColumns: ReadonlyMap<string, number>,
+  dimension: number,
+): readonly Frac[] | null {
+  const expr = isApplyHead(equation, EQUAL.name) && equation.args.length === 2
+    ? app(SUB, [equation.args[0], equation.args[1]])
+    : equation;
+  const linear = linearEval(expr, variableColumns, dimension);
+  if (linear === null) return null;
+  return [...linear.coeffs, linear.constant.neg()];
+}
+
+function nodeToFrac(node: IRNode): Frac | null {
+  if (node.kind === "integer") return Frac.fromInt(node.value);
+  if (node.kind === "rational") return new Frac(node.numer, node.denom);
+  return null;
+}
+
+interface LinearForm {
+  readonly coeffs: readonly Frac[];
+  readonly constant: Frac;
+}
+
+function linearEval(
+  node: IRNode,
+  variableColumns: ReadonlyMap<string, number>,
+  dimension: number,
+): LinearForm | null {
+  const constant = nodeToFrac(node);
+  if (constant !== null) return { coeffs: zeroVector(dimension), constant };
+
+  if (node.kind === "symbol") {
+    const column = variableColumns.get(node.name);
+    if (column === undefined) return null;
+    const coeffs = zeroVector(dimension);
+    coeffs[column] = Frac.one();
+    return { coeffs, constant: Frac.zero() };
+  }
+
+  if (node.kind !== "apply" || node.head.kind !== "symbol") return null;
+  const head = node.head.name;
+
+  if (head === ADD.name) {
+    let coeffs = zeroVector(dimension);
+    let value = Frac.zero();
+    for (const arg of node.args) {
+      const form = linearEval(arg, variableColumns, dimension);
+      if (form === null) return null;
+      coeffs = addVectors(coeffs, form.coeffs);
+      value = value.add(form.constant);
+    }
+    return { coeffs, constant: value };
+  }
+
+  if (head === SUB.name && node.args.length === 2) {
+    const lhs = linearEval(node.args[0], variableColumns, dimension);
+    const rhs = linearEval(node.args[1], variableColumns, dimension);
+    if (lhs === null || rhs === null) return null;
+    return { coeffs: subVectors(lhs.coeffs, rhs.coeffs), constant: lhs.constant.sub(rhs.constant) };
+  }
+
+  if (head === NEG.name && node.args.length === 1) {
+    const form = linearEval(node.args[0], variableColumns, dimension);
+    if (form === null) return null;
+    return {
+      coeffs: form.coeffs.map((coef) => coef.neg()),
+      constant: form.constant.neg(),
+    };
+  }
+
+  if (head === MUL.name) {
+    let scalar = Frac.one();
+    let linearPart: LinearForm | null = null;
+    for (const arg of node.args) {
+      const scalarFactor = nodeToFrac(arg);
+      if (scalarFactor !== null) {
+        scalar = scalar.mul(scalarFactor);
+        continue;
+      }
+
+      const form = linearEval(arg, variableColumns, dimension);
+      if (form === null) return null;
+      if (isZeroVector(form.coeffs)) {
+        scalar = scalar.mul(form.constant);
+      } else {
+        if (linearPart !== null) return null;
+        linearPart = form;
+      }
+    }
+    if (linearPart === null) return { coeffs: zeroVector(dimension), constant: scalar };
+    return {
+      coeffs: linearPart.coeffs.map((coef) => coef.mul(scalar)),
+      constant: linearPart.constant.mul(scalar),
+    };
+  }
+
+  if (head === POW.name && node.args.length === 2 && node.args[1].kind === "integer") {
+    if (node.args[1].value === 0n) return { coeffs: zeroVector(dimension), constant: Frac.one() };
+    if (node.args[1].value === 1n) return linearEval(node.args[0], variableColumns, dimension);
+    return null;
+  }
+
+  return null;
+}
+
+function zeroVector(length: number): Frac[] {
+  return Array.from({ length }, () => Frac.zero());
+}
+
+function addVectors(lhs: readonly Frac[], rhs: readonly Frac[]): Frac[] {
+  return lhs.map((coef, index) => coef.add(rhs[index]));
+}
+
+function subVectors(lhs: readonly Frac[], rhs: readonly Frac[]): Frac[] {
+  return lhs.map((coef, index) => coef.sub(rhs[index]));
+}
+
+function isZeroVector(values: readonly Frac[]): boolean {
+  return values.every((value) => value.isZero());
+}
+
+function fracAbsCompare(lhs: Frac, rhs: Frac): number {
+  const l = abs(lhs.numer) * rhs.denom;
+  const r = abs(rhs.numer) * lhs.denom;
+  return l < r ? -1 : l > r ? 1 : 0;
+}
+
+function isApplyHead(node: IRNode, head: string): node is Extract<IRNode, { readonly kind: "apply" }> {
+  return node.kind === "apply" && node.head.kind === "symbol" && node.head.name === head;
 }
 
 function fractionDenominatorLcm(...values: readonly Frac[]): bigint {

--- a/code/packages/typescript/cas-solve/tests/cas-solve.test.ts
+++ b/code/packages/typescript/cas-solve/tests/cas-solve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ADD, DIV, MUL, SQRT, app, equals, int, numberNode, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { ADD, DIV, EQUAL, MUL, POW, RULE, SQRT, SUB, app, equals, int, numberNode, rational, sym, type IRNode, type IRSymbol } from "@coding-adventures/symbolic-ir";
 import {
   ALL_SOLUTIONS,
   CBRT,
@@ -10,6 +10,7 @@ import {
   rootsToIr,
   solveCubic,
   solveLinear,
+  solveLinearSystem,
   solveQuadratic,
   solveQuartic,
   type SolveResult,
@@ -62,6 +63,35 @@ function expectNumericRootsClose(
     expect(match).not.toBe(-1);
     used[match] = true;
   }
+}
+
+function eq(lhs: IRNode, rhs: IRNode): IRNode {
+  return app(EQUAL, [lhs, rhs]);
+}
+
+function add(...args: readonly IRNode[]): IRNode {
+  return app(ADD, args);
+}
+
+function sub(lhs: IRNode, rhs: IRNode): IRNode {
+  return app(SUB, [lhs, rhs]);
+}
+
+function mul(...args: readonly IRNode[]): IRNode {
+  return app(MUL, args);
+}
+
+function pow(base: IRNode, exponent: IRNode): IRNode {
+  return app(POW, [base, exponent]);
+}
+
+function ruleValue(rules: readonly IRNode[], variable: IRSymbol): IRNode {
+  for (const rule of rules) {
+    if (rule.kind === "apply" && equals(rule.head, RULE) && equals(rule.args[0], variable)) {
+      return rule.args[1];
+    }
+  }
+  throw new Error(`missing rule for ${variable.name}`);
 }
 
 describe("Frac", () => {
@@ -248,5 +278,71 @@ describe("nsolvePoly", () => {
     expect(values[0]).toBeCloseTo(1, 8);
     expect(values[1]).toBeCloseTo(2, 8);
     expect(values[2]).toBeCloseTo(3, 8);
+  });
+});
+
+describe("solveLinearSystem", () => {
+  const x = sym("x");
+  const y = sym("y");
+  const z = sym("z");
+
+  it("solves simple exact 2x2 systems", () => {
+    const result = solveLinearSystem([
+      eq(add(x, y), int(3)),
+      eq(sub(x, y), int(1)),
+    ], [x, y]);
+
+    expect(result).not.toBeNull();
+    expect(ruleValue(result ?? [], x)).toEqual(int(2));
+    expect(ruleValue(result ?? [], y)).toEqual(int(1));
+  });
+
+  it("solves systems with rational results", () => {
+    const result = solveLinearSystem([
+      eq(add(mul(int(2), x), mul(int(3), y)), int(7)),
+      eq(sub(mul(int(4), x), y), int(1)),
+    ], [x, y]);
+
+    expect(result).not.toBeNull();
+    expect(ruleValue(result ?? [], x)).toEqual(rational(5, 7));
+    expect(ruleValue(result ?? [], y)).toEqual(rational(13, 7));
+  });
+
+  it("solves 3x3 systems and zero-form equations", () => {
+    const result = solveLinearSystem([
+      eq(add(x, y, z), int(6)),
+      eq(add(mul(int(2), x), y), int(5)),
+      eq(z, int(3)),
+    ], [x, y, z]);
+
+    expect(result).not.toBeNull();
+    expect(ruleValue(result ?? [], x)).toEqual(int(2));
+    expect(ruleValue(result ?? [], y)).toEqual(int(1));
+    expect(ruleValue(result ?? [], z)).toEqual(int(3));
+
+    const zeroForm = solveLinearSystem([add(x, y), sub(x, y)], [x, y]);
+    expect(ruleValue(zeroForm ?? [], x)).toEqual(int(0));
+    expect(ruleValue(zeroForm ?? [], y)).toEqual(int(0));
+  });
+
+  it("returns null for wrong-size, empty, singular, and non-linear systems", () => {
+    expect(solveLinearSystem([eq(add(x, y), int(3))], [x, y])).toBeNull();
+    expect(solveLinearSystem([], [])).toBeNull();
+    expect(solveLinearSystem([
+      eq(add(x, y), int(1)),
+      eq(add(mul(int(2), x), mul(int(2), y)), int(2)),
+    ], [x, y])).toBeNull();
+    expect(solveLinearSystem([eq(pow(x, int(2)), int(4))], [x])).toBeNull();
+  });
+
+  it("returns Rule nodes in variable order", () => {
+    const result = solveLinearSystem([
+      eq(add(x, y), int(3)),
+      eq(sub(x, y), int(1)),
+    ], [x, y]);
+
+    expect(result?.length).toBe(2);
+    expect(result?.[0]).toEqual(app(RULE, [x, int(2)]));
+    expect(result?.[1]).toEqual(app(RULE, [y, int(1)]));
   });
 });


### PR DESCRIPTION
## Summary
- add exact `solveLinearSystem` Gaussian elimination for square systems
- normalize `Equal(lhs, rhs)` and zero-form equations into linear rows
- return `Rule(var, value)` IR nodes and cover rational, singular, non-linear, and zero-form cases

## Validation
- `npm test && npm run build` in `code/packages/typescript/cas-solve`