### PR TITLE
feat(llm-cache+demo): disk persistence + wire into TSA demo (10x speedup)

### DIFF
--- a/code/packages/rust/adjudication-tsa-demo/BUILD
+++ b/code/packages/rust/adjudication-tsa-demo/BUILD
@@ -9,6 +9,7 @@ _targets = [
             "//code/packages/rust/adjudication-clarification",
             "//code/packages/rust/adjudication-ir",
             "//code/packages/rust/adjudication-pipeline",
+            "//code/packages/rust/llm-cache",
             "//code/packages/rust/llm-gateway",
             "//code/packages/rust/llm-primitives",
             "//code/packages/rust/llm-provider-ollama",

--- a/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-05-12
+
+### Added
+
+Optional disk-persisted prompt cache. When `ADJ_DEMO_CACHE_DIR=<path>`
+is set, every LLM client used by Arm B is wrapped in
+`CachingClient::with_disk_persistence`. A first run populates the
+cache directory; a second run replays every prompt from disk with
+zero round-trips to Ollama.
+
+Verified on the local TSA demo:
+
+- Cold run (gemma4:latest extractor + renderer + nli, llama3.1:8b
+  adversary, 9 LLM calls total): ~60 s wall-clock.
+- Warm run with the same cache dir: ~0.5 s of actual demo work
+  (rest is Rust binary launch).
+
+- `DemoConfig::cache_dir: Option<String>` — opt-in. Defaults to
+  `None` (in-memory cache only, which is essentially a no-op for a
+  one-shot binary).
+- `ADJ_DEMO_CACHE_DIR=<path>` env var to enable disk persistence
+  from the binary.
+- Side-by-side report header surfaces the cache configuration.
+
+### Notes
+
+ADJ06 retry rounds also benefit: when the model self-corrects an
+ADJ02 failure, the corrected prompt is cached so a re-run replays
+both the original failed attempt AND the correction at disk speed.
+
 ## [0.4.0] - 2026-05-12
 
 ### Added

--- a/code/packages/rust/adjudication-tsa-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-tsa-demo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-tsa-demo"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.4 wires the ADJ06 clarification dialogue into LlmExtracted mode — when the model's IR fails ADJ02 coverage, the framework re-prompts with the violation and the model usually corrects on the second try."
+description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.5 wraps every LLM client in `llm-cache::CachingClient` with optional disk persistence — set ADJ_DEMO_CACHE_DIR=<path> and a second run replays from disk with 0 LLM round-trips."
 
 [[bin]]
 name = "adjudication-tsa-demo"
@@ -13,6 +13,7 @@ adjudication-audit-trail = { path = "../adjudication-audit-trail" }
 adjudication-clarification = { path = "../adjudication-clarification" }
 adjudication-ir = { path = "../adjudication-ir" }
 adjudication-pipeline = { path = "../adjudication-pipeline" }
+llm-cache = { path = "../llm-cache" }
 llm-gateway = { path = "../llm-gateway" }
 llm-primitives = { path = "../llm-primitives" }
 llm-provider-ollama = { path = "../llm-provider-ollama" }

--- a/code/packages/rust/adjudication-tsa-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/lib.rs
@@ -66,6 +66,7 @@ use llm_gateway::{
 use adjudication_clarification::{
     retry_decompose_on_coverage_failure, ClarificationError, CoverageClarificationRequest,
 };
+use llm_cache::CachingClient;
 use llm_primitives::{
     decompose_text, DecomposeTextRequest, GatewayConfig, PrimitiveError, Role as PrimitiveRole,
 };
@@ -123,6 +124,12 @@ pub struct DemoConfig {
     /// (Blocked verdict on first failure). Default `2` — usually
     /// enough for a small model to self-correct.
     pub max_clarification_attempts: usize,
+    /// Optional directory where the LLM cache persists responses
+    /// across runs. When set, every LLM client used by Arm B is
+    /// wrapped in a `CachingClient::with_disk_persistence` and a
+    /// second run replays from disk with zero round-trips. Off by
+    /// default to keep the no-knobs invocation deterministic in CI.
+    pub cache_dir: Option<String>,
 }
 
 impl Default for DemoConfig {
@@ -135,6 +142,7 @@ impl Default for DemoConfig {
             source_text: "1 carry-on bag, matches.".into(),
             ir_mode: IrMode::HandBuilt,
             max_clarification_attempts: 2,
+            cache_dir: None,
         }
     }
 }
@@ -280,10 +288,10 @@ pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
     // GatewayConfig needs Box<dyn LlmClient>; we register clones of
     // the primary client for Extractor/Renderer/Nli/Plausibility so
     // each call site uses its own connection.
-    let extractor = Box::new(primary.clone()) as Box<dyn LlmClient>;
-    let renderer = Box::new(primary.clone()) as Box<dyn LlmClient>;
-    let nli = Box::new(primary.clone()) as Box<dyn LlmClient>;
-    let plausibility = Box::new(primary.clone()) as Box<dyn LlmClient>;
+    let extractor = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let renderer = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let nli = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let plausibility = wrap_with_cache(Box::new(primary.clone()), cfg);
     let mut gateway = GatewayConfig::new()
         .with_client(PrimitiveRole::Extractor, extractor)
         .with_client(PrimitiveRole::Renderer, renderer)
@@ -299,7 +307,7 @@ pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
             .with_timeout(cfg.timeout);
         gateway = gateway.with_client(
             PrimitiveRole::Adversary,
-            Box::new(adv_client) as Box<dyn LlmClient>,
+            wrap_with_cache(Box::new(adv_client) as Box<dyn LlmClient>, cfg),
         );
     }
 
@@ -1012,6 +1020,19 @@ fn parse_source_spans(
         spans.push(Span::new(document_id.clone(), start, end));
     }
     spans
+}
+
+/// Wrap an inner LLM client with a `CachingClient` if the demo
+/// config requests caching. Disk persistence is enabled when
+/// `cfg.cache_dir` is `Some`; otherwise the cache is in-memory only
+/// (and so won't help a single-shot binary run — but the demo also
+/// runs in tests and from the same process as other primitives,
+/// where in-memory hits do happen via the ADJ06 retry loop).
+fn wrap_with_cache(inner: Box<dyn LlmClient>, cfg: &DemoConfig) -> Box<dyn LlmClient> {
+    match &cfg.cache_dir {
+        Some(dir) => Box::new(CachingClient::with_disk_persistence(inner, dir)),
+        None => Box::new(CachingClient::new(inner)),
+    }
 }
 
 /// Render the first ADJ02 violation as a short string suitable for

--- a/code/packages/rust/adjudication-tsa-demo/src/main.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/main.rs
@@ -38,7 +38,8 @@ fn main() {
          primary model: `{model}` (Extractor/Renderer/Nli/Plausibility)\n\
          adversary:     {adv}\n\
          IR mode:       {mode:?}\n\
-         (override via ADJ_DEMO_{{ENDPOINT,MODEL,ADVERSARY_MODEL,SOURCE,IR_MODE}})\n",
+         cache:         {cache}\n\
+         (override via ADJ_DEMO_{{ENDPOINT,MODEL,ADVERSARY_MODEL,SOURCE,IR_MODE,CACHE_DIR}})\n",
         endpoint = cfg.endpoint,
         model = cfg.model,
         adv = cfg
@@ -47,6 +48,11 @@ fn main() {
             .map(|s| format!("`{s}` (Adversary)"))
             .unwrap_or_else(|| "(none; ADJ05 will Skip)".to_string()),
         mode = cfg.ir_mode,
+        cache = cfg
+            .cache_dir
+            .as_deref()
+            .map(|s| format!("disk persistence at {s}"))
+            .unwrap_or_else(|| "in-memory only".to_string()),
     );
 
     // --- Arm A ---
@@ -123,6 +129,9 @@ fn config_from_env() -> DemoConfig {
         if let Ok(parsed) = n.parse::<usize>() {
             cfg.max_clarification_attempts = parsed;
         }
+    }
+    if let Ok(dir) = std::env::var("ADJ_DEMO_CACHE_DIR") {
+        cfg.cache_dir = if dir.is_empty() { None } else { Some(dir) };
     }
     if let Ok(mode) = std::env::var("ADJ_DEMO_IR_MODE") {
         cfg.ir_mode = match mode.to_ascii_lowercase().as_str() {

--- a/code/packages/rust/llm-cache/CHANGELOG.md
+++ b/code/packages/rust/llm-cache/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-05-12
+
+### Added
+
+**Disk persistence.** The cache can now write each entry to a file
+keyed on the FNV-1a hash of the cache key, so cache hits survive
+process restarts. Built on the deterministic-prompts invariant —
+the same `(model, prompt_hash, schema_name)` always produces the
+same response, so persisting it is sound.
+
+- `CachingClient::with_disk_persistence(inner, dir)` — disk-backed
+  variant with an unbounded in-memory cache on top.
+- `CachingClient::with_disk_persistence_and_capacity(inner, dir, n)`
+  — both an in-memory bound AND disk persistence.
+- Disk hits are promoted to memory on first read so subsequent
+  lookups stay fast.
+- Best-effort I/O: malformed or unreadable files are silently
+  treated as misses (cache is an accelerator, not a database).
+- Hand-rolled JSON serialization (no serde derives on llm-gateway
+  types) — each entry is a self-describing object with `kind`,
+  the provider identity, usage, latency, and the typed response
+  payload.
+
+### Verified end-to-end
+
+Wrapping the TSA demo's gateway clients in
+`CachingClient::with_disk_persistence` produced a 10× wall-clock
+speedup on repeat runs against `gemma4:latest` + `llama3.1:8b`:
+
+- Cold run (9 LLM calls to Ollama): ~60 s
+- Warm run (9 disk hits, 0 LLM calls): ~0.5 s (excluding Rust
+  binary launch overhead)
+
+5 new tests cover: survive-new-client (disk hit on a fresh
+in-memory state), memory-promotion (disk hit promotes to memory),
+complete_json round-trip, empty-dir misses, and
+corrupted-file-falls-through-and-self-heals.
+
 ## [0.1.0] - 2026-05-12
 
 ### Added

--- a/code/packages/rust/llm-cache/Cargo.toml
+++ b/code/packages/rust/llm-cache/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "llm-cache"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "LM00c — content-addressed prompt cache. Wraps any LlmClient with a (prompt_version, prompt_hash)-keyed in-memory cache. Pure in-memory; zero third-party deps. Turns deterministic-prompt workloads into cache-amortised cost."
+description = "LM00c — content-addressed prompt cache. Wraps any LlmClient with a (model, prompt_hash[, schema_name])-keyed cache. v0.1 was in-memory only; v0.2 adds optional disk persistence (one JSON file per entry keyed on prompt hash) so the cache survives process restarts."
 
 [dependencies]
 llm-gateway = { path = "../llm-gateway" }

--- a/code/packages/rust/llm-cache/src/lib.rs
+++ b/code/packages/rust/llm-cache/src/lib.rs
@@ -45,11 +45,12 @@
 //!   prompts mean staleness doesn't really apply, but a future
 //!   version may add TTL for adversarial use cases.
 
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use llm_gateway::{
-    Capabilities, CompletionJsonResponse, CompletionRequest, CompletionResponse, JsonSchema,
-    LlmClient, LlmError, ProviderIdentity,
+    Capabilities, CompletionJsonResponse, CompletionRequest, CompletionResponse, FinishReason,
+    JsonSchema, LlmClient, LlmError, ProviderIdentity, TokenUsage,
 };
 use llm_primitives::fingerprint_prompt;
 
@@ -90,6 +91,180 @@ impl CacheStats {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Disk persistence (v0.2)
+// ---------------------------------------------------------------------------
+//
+// Each cache entry is one file under `<dir>/<sha-like>.json`. The
+// file name is derived from the cache key (FNV-1a hash of `model |
+// prompt_hash [| schema_name]`) so collisions are extremely
+// unlikely. The file contents are a JSON record with enough
+// information to reconstruct the typed response without needing
+// serde derives on `CompletionResponse` / `CompletionJsonResponse`.
+//
+// This module intentionally stays minimal: no compression, no
+// concurrent-write coordination, no atomic-rename. The cache is a
+// best-effort accelerator, not a database — corrupted entries are
+// silently treated as misses.
+
+/// Compute the on-disk file name for a cache key. Uses the same
+/// FNV-1a 64-bit hash as `fingerprint_prompt` so the filenames are
+/// short, ASCII, and never need escaping.
+fn key_to_filename(key: &str) -> String {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in key.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    format!("{:016x}.json", h)
+}
+
+/// Serialize a `CompletionResponse` as JSON we can write to disk.
+fn serialize_text(resp: &CompletionResponse) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "text",
+        "text": resp.text,
+        "model": resp.model,
+        "usage": {
+            "input_tokens": resp.usage.input_tokens,
+            "output_tokens": resp.usage.output_tokens,
+            "cached_tokens": resp.usage.cached_tokens,
+        },
+        "finish_reason": match resp.finish_reason {
+            FinishReason::Stop => "Stop",
+            FinishReason::MaxTokens => "MaxTokens",
+            FinishReason::Refusal => "Refusal",
+            FinishReason::Other => "Other",
+        },
+        "provider_id": serialize_provider(&resp.provider_id),
+        "latency_ms": resp.latency_ms,
+    })
+}
+
+fn serialize_json(resp: &CompletionJsonResponse) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "json",
+        "raw_text": resp.raw_text,
+        "parsed": resp.parsed,
+        "schema_valid": resp.schema_valid,
+        "model": resp.model,
+        "usage": {
+            "input_tokens": resp.usage.input_tokens,
+            "output_tokens": resp.usage.output_tokens,
+            "cached_tokens": resp.usage.cached_tokens,
+        },
+        "provider_id": serialize_provider(&resp.provider_id),
+        "latency_ms": resp.latency_ms,
+        "polyfill_used": resp.polyfill_used,
+    })
+}
+
+fn serialize_provider(p: &ProviderIdentity) -> serde_json::Value {
+    serde_json::json!({
+        "vendor": p.vendor,
+        "model_family": p.model_family,
+        "model_version": p.model_version,
+        "endpoint": p.endpoint,
+    })
+}
+
+fn deserialize_provider(v: &serde_json::Value) -> Option<ProviderIdentity> {
+    Some(ProviderIdentity {
+        vendor: v.get("vendor")?.as_str()?.to_string(),
+        model_family: v.get("model_family")?.as_str()?.to_string(),
+        model_version: v.get("model_version")?.as_str()?.to_string(),
+        endpoint: v
+            .get("endpoint")
+            .and_then(|x| x.as_str())
+            .map(str::to_string),
+    })
+}
+
+fn deserialize_usage(v: &serde_json::Value) -> TokenUsage {
+    TokenUsage {
+        input_tokens: v
+            .get("input_tokens")
+            .and_then(|x| x.as_u64())
+            .unwrap_or(0) as usize,
+        output_tokens: v
+            .get("output_tokens")
+            .and_then(|x| x.as_u64())
+            .unwrap_or(0) as usize,
+        cached_tokens: v
+            .get("cached_tokens")
+            .and_then(|x| x.as_u64())
+            .unwrap_or(0) as usize,
+    }
+}
+
+fn deserialize_finish_reason(s: &str) -> FinishReason {
+    match s {
+        "Stop" => FinishReason::Stop,
+        "MaxTokens" => FinishReason::MaxTokens,
+        "Refusal" => FinishReason::Refusal,
+        _ => FinishReason::Other,
+    }
+}
+
+fn deserialize_entry(v: &serde_json::Value) -> Option<CacheEntry> {
+    let kind = v.get("kind")?.as_str()?;
+    match kind {
+        "text" => {
+            let provider = deserialize_provider(v.get("provider_id")?)?;
+            Some(CacheEntry::Text(CompletionResponse {
+                text: v.get("text")?.as_str()?.to_string(),
+                model: v.get("model")?.as_str()?.to_string(),
+                usage: deserialize_usage(v.get("usage").unwrap_or(&serde_json::Value::Null)),
+                finish_reason: deserialize_finish_reason(
+                    v.get("finish_reason").and_then(|x| x.as_str()).unwrap_or("Other"),
+                ),
+                provider_id: provider,
+                latency_ms: v.get("latency_ms").and_then(|x| x.as_u64()).unwrap_or(0),
+            }))
+        }
+        "json" => {
+            let provider = deserialize_provider(v.get("provider_id")?)?;
+            Some(CacheEntry::Json(CompletionJsonResponse {
+                raw_text: v.get("raw_text")?.as_str()?.to_string(),
+                parsed: v.get("parsed").cloned().unwrap_or(serde_json::Value::Null),
+                schema_valid: v.get("schema_valid").and_then(|x| x.as_bool()).unwrap_or(false),
+                model: v.get("model")?.as_str()?.to_string(),
+                usage: deserialize_usage(v.get("usage").unwrap_or(&serde_json::Value::Null)),
+                provider_id: provider,
+                latency_ms: v.get("latency_ms").and_then(|x| x.as_u64()).unwrap_or(0),
+                polyfill_used: v
+                    .get("polyfill_used")
+                    .and_then(|x| x.as_bool())
+                    .unwrap_or(false),
+            }))
+        }
+        _ => None,
+    }
+}
+
+/// Best-effort load from disk. Returns `None` if the file doesn't
+/// exist, is unreadable, or is malformed.
+fn try_load_disk(dir: &Path, key: &str) -> Option<CacheEntry> {
+    let path = dir.join(key_to_filename(key));
+    let bytes = std::fs::read(&path).ok()?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    deserialize_entry(&v)
+}
+
+/// Best-effort write to disk. Errors are silently swallowed —
+/// failing to persist a cache entry should never break the demo.
+fn try_save_disk(dir: &Path, key: &str, entry: &CacheEntry) {
+    let _ = std::fs::create_dir_all(dir);
+    let path = dir.join(key_to_filename(key));
+    let v = match entry {
+        CacheEntry::Text(r) => serialize_text(r),
+        CacheEntry::Json(r) => serialize_json(r),
+    };
+    if let Ok(s) = serde_json::to_string(&v) {
+        let _ = std::fs::write(&path, s);
+    }
+}
+
 /// Wraps any `LlmClient` with a `(model, prompt_hash)`-keyed cache.
 ///
 /// Usage:
@@ -108,24 +283,61 @@ pub struct CachingClient {
     /// Maximum number of entries before FIFO eviction. `None` =
     /// unlimited.
     capacity: Option<usize>,
+    /// Directory under which entries are persisted. `None` = no
+    /// disk persistence (v0.1 behaviour).
+    disk_dir: Option<PathBuf>,
 }
 
 impl CachingClient {
-    /// Wrap an inner client with an unbounded cache.
+    /// Wrap an inner client with an unbounded in-memory cache.
     pub fn new(inner: Box<dyn LlmClient>) -> Self {
         Self {
             inner,
             state: Mutex::new(CacheState::default()),
             capacity: None,
+            disk_dir: None,
         }
     }
 
-    /// Wrap with a bounded cache (FIFO eviction on overflow).
+    /// Wrap with a bounded in-memory cache (FIFO eviction on overflow).
     pub fn with_capacity(inner: Box<dyn LlmClient>, capacity: usize) -> Self {
         Self {
             inner,
             state: Mutex::new(CacheState::default()),
             capacity: Some(capacity),
+            disk_dir: None,
+        }
+    }
+
+    /// Wrap with disk persistence. On lookup misses in memory, the
+    /// cache checks `dir/<hash>.json` and reconstitutes the entry if
+    /// present. On insert, the entry is also written to disk. The
+    /// directory is created on demand. Disk failures are silently
+    /// treated as cache misses — the cache is a best-effort
+    /// accelerator, not a database.
+    pub fn with_disk_persistence(
+        inner: Box<dyn LlmClient>,
+        dir: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            inner,
+            state: Mutex::new(CacheState::default()),
+            capacity: None,
+            disk_dir: Some(dir.into()),
+        }
+    }
+
+    /// Disk-backed cache with both a memory bound AND persistence.
+    pub fn with_disk_persistence_and_capacity(
+        inner: Box<dyn LlmClient>,
+        dir: impl Into<PathBuf>,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            inner,
+            state: Mutex::new(CacheState::default()),
+            capacity: Some(capacity),
+            disk_dir: Some(dir.into()),
         }
     }
 
@@ -156,32 +368,60 @@ impl CachingClient {
     }
 
     fn lookup(&self, key: &str) -> Option<CacheEntry> {
-        let mut s = self.state.lock().unwrap();
-        if let Some(entry) = s
-            .entries
-            .iter()
-            .rev()
-            .find(|(k, _)| k == key)
-            .map(|(_, v)| v.clone())
+        // Memory first.
         {
-            s.hits += 1;
-            return Some(entry);
+            let mut s = self.state.lock().unwrap();
+            if let Some(entry) = s
+                .entries
+                .iter()
+                .rev()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.clone())
+            {
+                s.hits += 1;
+                return Some(entry);
+            }
         }
+        // Disk fallback. On a disk hit, promote the entry to
+        // memory so subsequent lookups stay fast and the hit-rate
+        // counter reflects the memory-hit cost on later calls.
+        if let Some(dir) = &self.disk_dir {
+            if let Some(entry) = try_load_disk(dir, key) {
+                let mut s = self.state.lock().unwrap();
+                s.entries.retain(|(k, _)| k != key);
+                s.entries.push((key.to_string(), entry.clone()));
+                s.insertions.push(key.to_string());
+                if let Some(cap) = self.capacity {
+                    while s.entries.len() > cap {
+                        let oldest = s.insertions.remove(0);
+                        s.entries.retain(|(k, _)| k != &oldest);
+                    }
+                }
+                s.hits += 1;
+                return Some(entry);
+            }
+        }
+        let mut s = self.state.lock().unwrap();
         s.misses += 1;
         None
     }
 
     fn insert(&self, key: String, entry: CacheEntry) {
-        let mut s = self.state.lock().unwrap();
-        // O(n) but n is small in practice.
-        s.entries.retain(|(k, _)| k != &key);
-        s.entries.push((key.clone(), entry));
-        s.insertions.push(key);
-        if let Some(cap) = self.capacity {
-            while s.entries.len() > cap {
-                let oldest = s.insertions.remove(0);
-                s.entries.retain(|(k, _)| k != &oldest);
+        {
+            let mut s = self.state.lock().unwrap();
+            // O(n) but n is small in practice.
+            s.entries.retain(|(k, _)| k != &key);
+            s.entries.push((key.clone(), entry.clone()));
+            s.insertions.push(key.clone());
+            if let Some(cap) = self.capacity {
+                while s.entries.len() > cap {
+                    let oldest = s.insertions.remove(0);
+                    s.entries.retain(|(k, _)| k != &oldest);
+                }
             }
+        }
+        if let Some(dir) = &self.disk_dir {
+            try_save_disk(dir, &key, &entry);
         }
     }
 }
@@ -434,6 +674,129 @@ mod tests {
         let id = cached.identity();
         assert_eq!(id.vendor, "anthropic");
         assert_eq!(id.model_family, "claude-opus");
+    }
+
+    // ----- Disk persistence (v0.2) -----
+
+    fn tmp_dir(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        // Include the process id + nanos so concurrent tests don't
+        // collide. Bare `name` would clash on a `cargo test --jobs`.
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        p.push(format!("llm-cache-test-{name}-{pid}-{nanos}"));
+        // Best-effort clean previous run.
+        let _ = std::fs::remove_dir_all(&p);
+        p
+    }
+
+    #[test]
+    fn disk_persistence_survives_a_new_caching_client() {
+        let dir = tmp_dir("survive");
+        // First client populates the cache.
+        {
+            let inner = CountingClient::new();
+            let cached = CachingClient::with_disk_persistence(Box::new(inner), &dir);
+            let _ = cached.complete(req_with_text("hello")).unwrap();
+        }
+        // Second client (fresh in-memory state) should serve the
+        // request from disk on the first call.
+        let inner2 = CountingClient::new();
+        let calls2 = Arc::clone(&inner2.calls);
+        let cached2 = CachingClient::with_disk_persistence(Box::new(inner2), &dir);
+        let _ = cached2.complete(req_with_text("hello")).unwrap();
+        assert_eq!(calls2.load(Ordering::SeqCst), 0, "should hit disk, not call inner");
+        assert_eq!(cached2.stats().hits, 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn disk_persistence_promotes_to_memory_on_first_disk_hit() {
+        let dir = tmp_dir("promote");
+        {
+            let inner = CountingClient::new();
+            let cached = CachingClient::with_disk_persistence(Box::new(inner), &dir);
+            let _ = cached.complete(req_with_text("hello")).unwrap();
+        }
+        let inner2 = CountingClient::new();
+        let calls2 = Arc::clone(&inner2.calls);
+        let cached2 = CachingClient::with_disk_persistence(Box::new(inner2), &dir);
+        // First call: disk hit, promoted to memory.
+        let _ = cached2.complete(req_with_text("hello")).unwrap();
+        // Second call: memory hit (the disk path is bypassed).
+        let _ = cached2.complete(req_with_text("hello")).unwrap();
+        assert_eq!(calls2.load(Ordering::SeqCst), 0);
+        let s = cached2.stats();
+        assert_eq!(s.hits, 2);
+        assert_eq!(s.entries, 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn disk_persistence_survives_complete_json_responses() {
+        let dir = tmp_dir("json");
+        let schema = JsonSchema {
+            name: "Test".into(),
+            schema_json: "{}".into(),
+        };
+        {
+            let inner = CountingClient::new();
+            let cached = CachingClient::with_disk_persistence(Box::new(inner), &dir);
+            let _ = cached.complete_json(req_with_text("q"), &schema).unwrap();
+        }
+        let inner2 = CountingClient::new();
+        let json_calls2 = Arc::clone(&inner2.json_calls);
+        let cached2 = CachingClient::with_disk_persistence(Box::new(inner2), &dir);
+        let resp = cached2.complete_json(req_with_text("q"), &schema).unwrap();
+        assert_eq!(json_calls2.load(Ordering::SeqCst), 0);
+        assert_eq!(resp.parsed, serde_json::json!({ "ok": true }));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn disk_persistence_misses_when_dir_is_empty() {
+        let dir = tmp_dir("miss-empty");
+        let inner = CountingClient::new();
+        let calls = Arc::clone(&inner.calls);
+        let cached = CachingClient::with_disk_persistence(Box::new(inner), &dir);
+        let _ = cached.complete(req_with_text("hello")).unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(cached.stats().hits, 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn disk_persistence_treats_corrupted_files_as_misses() {
+        let dir = tmp_dir("corrupt");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Drop a malformed file into the dir; the cache must NOT
+        // crash and MUST fall through to calling the inner client.
+        let inner = CountingClient::new();
+        let calls = Arc::clone(&inner.calls);
+        let cached = CachingClient::with_disk_persistence(Box::new(inner), &dir);
+        let req = req_with_text("hello");
+        let key = cached.cache_key(&req);
+        let bad_path = dir.join(key_to_filename(&key));
+        std::fs::write(&bad_path, b"not valid json").unwrap();
+        let _ = cached.complete(req).unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        // After the call, the cache should have rewritten the file
+        // with a valid entry.
+        let written = std::fs::read(&bad_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&written).unwrap();
+        assert_eq!(parsed.get("kind").and_then(|x| x.as_str()), Some("text"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn key_to_filename_is_deterministic_and_short() {
+        let a = key_to_filename("alpha");
+        let b = key_to_filename("alpha");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), "0123456789abcdef.json".len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two coupled changes: `llm-cache 0.1 → 0.2` adds disk persistence, and `adjudication-tsa-demo 0.4 → 0.5` wraps every gateway client in `CachingClient::with_disk_persistence` when `ADJ_DEMO_CACHE_DIR=<path>` is set.

**Stacks on [#2866](https://github.com/adhithyan15/coding-adventures/pull/2866).**

## Measured speedup

Against `gemma4:latest` (extractor + renderer + nli) + `llama3.1:8b` (adversary), LlmExtracted mode, 9 LLM calls:

| | Wall clock |
|---|---|
| Cold run (no cache hits) | ~60 s |
| Warm run (9 disk hits, 0 Ollama calls) | ~0.5 s |

**10× speedup.** The cache is sound because every primitive uses `temperature: 0.0` and is content-addressed via `fingerprint_prompt` — identical inputs always produce identical outputs.

## What ships in llm-cache 0.2

- `CachingClient::with_disk_persistence(inner, dir)` and `with_disk_persistence_and_capacity`.
- Each entry is one JSON file under `<dir>/<hash>.json` (FNV-1a 64-bit hash of the cache key).
- Disk hits promote to memory.
- Corrupted files silently fall through to a miss and self-heal on next write.
- Hand-rolled JSON serialization — keeps llm-gateway types surface-stable (no new serde derives needed).
- 6 new tests cover: survive-new-client, memory-promotion, complete_json round-trip, empty-dir misses, corrupted-file fallthrough, filename-determinism.

## What ships in demo 0.5

- `DemoConfig::cache_dir: Option<String>` + `ADJ_DEMO_CACHE_DIR` env var.
- Every gateway client (Extractor/Renderer/Nli/Plausibility/Adversary) wrapped through `wrap_with_cache`.
- Side-by-side report header surfaces the cache state.

## ADJ06 interaction

When the model self-corrects after an ADJ02 violation, both the original failed prompt and the corrected re-prompt land in the cache. A re-run replays the entire dialogue at disk speed, including the correction round.

## Test plan

- [x] `cargo test -p llm-cache -p adjudication-tsa-demo` — 15 + 19 tests pass
- [x] Cold-run/warm-run timing measured: 10× speedup
- [x] 9 cache files written to disk by the cold run; warm run uses all 9
- [x] Cache corruption gracefully degrades to a miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)