### PR TITLE
Add Rust linear system solving for cas-solve

### DIFF
--- a/code/packages/rust/cas-solve/CHANGELOG.md
+++ b/code/packages/rust/cas-solve/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- `linear_system` module: `solve_linear_system(equations, variables)` — exact
+  Gaussian elimination with `Equal(lhs, rhs)` normalization, zero-form
+  equations, and `Rule(var, value)` IR output.
+- Linear-system integration tests for integer, rational, 3x3, zero-form,
+  singular, non-linear, and wrong-size systems.
 - `numeric` module: `Complex`, `nsolve_poly`, `roots_to_ir`, and
   `nsolve_fraction_poly` — pure Rust Durand-Kerner numeric polynomial
   root-finding plus `%i`-aware symbolic IR conversion.

--- a/code/packages/rust/cas-solve/README.md
+++ b/code/packages/rust/cas-solve/README.md
@@ -88,6 +88,14 @@ polynomials of arbitrary degree. `roots_to_ir` converts nearly-real roots to
 `Float` nodes and complex roots to `Add(Float(re), Mul(Float(im), %i))`.
 `nsolve_fraction_poly` is the exact-rational coefficient convenience wrapper.
 
+## Linear systems
+
+`solve_linear_system(equations, variables)` accepts `Equal(lhs, rhs)` nodes or
+zero-form expressions, linearizes them over the provided variables, and solves
+square systems with exact Gaussian elimination. It returns `Rule(var, value)`
+IR nodes in variable order, or `None` for non-linear, singular, empty, or
+non-square systems.
+
 ## Stack position
 
 ```

--- a/code/packages/rust/cas-solve/src/lib.rs
+++ b/code/packages/rust/cas-solve/src/lib.rs
@@ -53,12 +53,14 @@
 pub mod cubic;
 pub mod frac;
 pub mod linear;
+pub mod linear_system;
 pub mod numeric;
 pub mod quadratic;
 pub mod quartic;
 
 pub use cubic::{solve_cubic, CBRT};
 pub use linear::solve_linear;
+pub use linear_system::solve_linear_system;
 pub use numeric::{nsolve_fraction_poly, nsolve_poly, roots_to_ir, Complex};
 pub use quadratic::{solve_quadratic, I_UNIT};
 pub use quartic::solve_quartic;

--- a/code/packages/rust/cas-solve/src/linear_system.rs
+++ b/code/packages/rust/cas-solve/src/linear_system.rs
@@ -1,0 +1,247 @@
+//! Exact linear-system solving with Gaussian elimination.
+//!
+//! Equations may be `Equal(lhs, rhs)` nodes or zero-form expressions. Results
+//! are returned as `Rule(var, value)` IR nodes in the same order as `variables`.
+
+use std::collections::HashMap;
+
+use symbolic_ir::{apply, sym, IRNode, ADD, EQUAL, MUL, NEG, POW, RULE, SUB};
+
+use crate::frac::Frac;
+
+/// Solve a square linear system over exact rational coefficients.
+///
+/// Returns `None` for empty, non-square, singular, or non-linear systems.
+pub fn solve_linear_system(equations: &[IRNode], variables: &[IRNode]) -> Option<Vec<IRNode>> {
+    let dimension = variables.len();
+    if equations.len() != dimension || dimension == 0 {
+        return None;
+    }
+
+    let mut variable_columns = HashMap::new();
+    for (index, variable) in variables.iter().enumerate() {
+        if let IRNode::Symbol(name) = variable {
+            variable_columns.insert(name.clone(), index);
+        } else {
+            return None;
+        }
+    }
+
+    let mut matrix = Vec::with_capacity(dimension);
+    for equation in equations {
+        matrix.push(equation_to_row(equation, &variable_columns, dimension)?);
+    }
+
+    for col in 0..dimension {
+        let pivot_row = (col..dimension)
+            .max_by(|lhs, rhs| frac_abs_cmp(matrix[*lhs][col], matrix[*rhs][col]))
+            .expect("non-empty pivot range");
+        if matrix[pivot_row][col].is_zero() {
+            return None;
+        }
+        matrix.swap(col, pivot_row);
+
+        let pivot = matrix[col][col];
+        for row in (col + 1)..dimension {
+            if matrix[row][col].is_zero() {
+                continue;
+            }
+            let factor = matrix[row][col] / pivot;
+            for j in col..=dimension {
+                matrix[row][j] = matrix[row][j] - factor * matrix[col][j];
+            }
+        }
+    }
+
+    let mut solution = vec![Frac::zero(); dimension];
+    for row in (0..dimension).rev() {
+        if matrix[row][row].is_zero() {
+            return None;
+        }
+        let mut rhs = matrix[row][dimension];
+        for (col, value) in solution.iter().enumerate().skip(row + 1) {
+            rhs = rhs - matrix[row][col] * *value;
+        }
+        solution[row] = rhs / matrix[row][row];
+    }
+
+    Some(
+        variables
+            .iter()
+            .zip(solution)
+            .map(|(variable, value)| apply(sym(RULE), vec![variable.clone(), value.to_irnode()]))
+            .collect(),
+    )
+}
+
+fn equation_to_row(
+    equation: &IRNode,
+    variable_columns: &HashMap<String, usize>,
+    dimension: usize,
+) -> Option<Vec<Frac>> {
+    let normalized;
+    let expr = if let IRNode::Apply(apply_node) = equation {
+        if is_head_name(&apply_node.head, EQUAL) && apply_node.args.len() == 2 {
+            normalized = apply(
+                sym(SUB),
+                vec![apply_node.args[0].clone(), apply_node.args[1].clone()],
+            );
+            &normalized
+        } else {
+            equation
+        }
+    } else {
+        equation
+    };
+
+    let linear = linear_eval(expr, variable_columns, dimension)?;
+    let mut row = linear.coeffs;
+    row.push(-linear.constant);
+    Some(row)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LinearForm {
+    coeffs: Vec<Frac>,
+    constant: Frac,
+}
+
+fn linear_eval(
+    node: &IRNode,
+    variable_columns: &HashMap<String, usize>,
+    dimension: usize,
+) -> Option<LinearForm> {
+    if let Some(constant) = node_to_frac(node) {
+        return Some(LinearForm {
+            coeffs: zero_vector(dimension),
+            constant,
+        });
+    }
+
+    if let IRNode::Symbol(name) = node {
+        let column = *variable_columns.get(name)?;
+        let mut coeffs = zero_vector(dimension);
+        coeffs[column] = Frac::one();
+        return Some(LinearForm {
+            coeffs,
+            constant: Frac::zero(),
+        });
+    }
+
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    let head = match &apply_node.head {
+        IRNode::Symbol(name) => name.as_str(),
+        _ => return None,
+    };
+
+    match head {
+        ADD => {
+            let mut coeffs = zero_vector(dimension);
+            let mut constant = Frac::zero();
+            for arg in &apply_node.args {
+                let form = linear_eval(arg, variable_columns, dimension)?;
+                coeffs = add_vectors(&coeffs, &form.coeffs);
+                constant = constant + form.constant;
+            }
+            Some(LinearForm { coeffs, constant })
+        }
+        SUB if apply_node.args.len() == 2 => {
+            let lhs = linear_eval(&apply_node.args[0], variable_columns, dimension)?;
+            let rhs = linear_eval(&apply_node.args[1], variable_columns, dimension)?;
+            Some(LinearForm {
+                coeffs: sub_vectors(&lhs.coeffs, &rhs.coeffs),
+                constant: lhs.constant - rhs.constant,
+            })
+        }
+        NEG if apply_node.args.len() == 1 => {
+            let form = linear_eval(&apply_node.args[0], variable_columns, dimension)?;
+            Some(LinearForm {
+                coeffs: form.coeffs.into_iter().map(|coef| -coef).collect(),
+                constant: -form.constant,
+            })
+        }
+        MUL => linear_eval_product(&apply_node.args, variable_columns, dimension),
+        POW if apply_node.args.len() == 2 => match &apply_node.args[1] {
+            IRNode::Integer(0) => Some(LinearForm {
+                coeffs: zero_vector(dimension),
+                constant: Frac::one(),
+            }),
+            IRNode::Integer(1) => linear_eval(&apply_node.args[0], variable_columns, dimension),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn linear_eval_product(
+    args: &[IRNode],
+    variable_columns: &HashMap<String, usize>,
+    dimension: usize,
+) -> Option<LinearForm> {
+    let mut scalar = Frac::one();
+    let mut linear_part: Option<LinearForm> = None;
+
+    for arg in args {
+        if let Some(value) = node_to_frac(arg) {
+            scalar = scalar * value;
+            continue;
+        }
+
+        let form = linear_eval(arg, variable_columns, dimension)?;
+        if is_zero_vector(&form.coeffs) {
+            scalar = scalar * form.constant;
+        } else if linear_part.is_some() {
+            return None;
+        } else {
+            linear_part = Some(form);
+        }
+    }
+
+    if let Some(form) = linear_part {
+        Some(LinearForm {
+            coeffs: form.coeffs.into_iter().map(|coef| coef * scalar).collect(),
+            constant: form.constant * scalar,
+        })
+    } else {
+        Some(LinearForm {
+            coeffs: zero_vector(dimension),
+            constant: scalar,
+        })
+    }
+}
+
+fn node_to_frac(node: &IRNode) -> Option<Frac> {
+    match node {
+        IRNode::Integer(value) => Some(Frac::from_int(*value)),
+        IRNode::Rational(numer, denom) => Some(Frac::new(*numer, *denom)),
+        _ => None,
+    }
+}
+
+fn zero_vector(length: usize) -> Vec<Frac> {
+    vec![Frac::zero(); length]
+}
+
+fn add_vectors(lhs: &[Frac], rhs: &[Frac]) -> Vec<Frac> {
+    lhs.iter().zip(rhs).map(|(a, b)| *a + *b).collect()
+}
+
+fn sub_vectors(lhs: &[Frac], rhs: &[Frac]) -> Vec<Frac> {
+    lhs.iter().zip(rhs).map(|(a, b)| *a - *b).collect()
+}
+
+fn is_zero_vector(values: &[Frac]) -> bool {
+    values.iter().all(Frac::is_zero)
+}
+
+fn frac_abs_cmp(lhs: Frac, rhs: Frac) -> std::cmp::Ordering {
+    let lhs_abs = (lhs.numer as i128).abs() * rhs.denom as i128;
+    let rhs_abs = (rhs.numer as i128).abs() * lhs.denom as i128;
+    lhs_abs.cmp(&rhs_abs)
+}
+
+fn is_head_name(node: &IRNode, expected: &str) -> bool {
+    matches!(node, IRNode::Symbol(name) if name == expected)
+}

--- a/code/packages/rust/cas-solve/tests/tests.rs
+++ b/code/packages/rust/cas-solve/tests/tests.rs
@@ -5,10 +5,10 @@
 
 use cas_solve::frac::Frac;
 use cas_solve::{
-    nsolve_fraction_poly, nsolve_poly, roots_to_ir, solve_cubic, solve_linear, solve_quadratic,
-    solve_quartic, Complex, SolveResult,
+    nsolve_fraction_poly, nsolve_poly, roots_to_ir, solve_cubic, solve_linear, solve_linear_system,
+    solve_quadratic, solve_quartic, Complex, SolveResult,
 };
-use symbolic_ir::{int, rat, IRNode};
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, EQUAL, MUL, POW, RULE, SUB};
 
 fn frac(n: i64, d: i64) -> Frac {
     Frac::new(n, d)
@@ -39,6 +39,40 @@ fn assert_numeric_roots_close(actual: &[Complex], expected: &[Complex]) {
         }
         assert!(matched, "missing root {want:?} in {actual:?}");
     }
+}
+
+fn eq(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(EQUAL), vec![lhs, rhs])
+}
+
+fn add(args: Vec<IRNode>) -> IRNode {
+    apply(sym(ADD), args)
+}
+
+fn sub(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(SUB), vec![lhs, rhs])
+}
+
+fn mul(args: Vec<IRNode>) -> IRNode {
+    apply(sym(MUL), args)
+}
+
+fn pow(base: IRNode, exponent: IRNode) -> IRNode {
+    apply(sym(POW), vec![base, exponent])
+}
+
+fn rule_value(rules: &[IRNode], variable: &IRNode) -> IRNode {
+    rules
+        .iter()
+        .find_map(|rule| match rule {
+            IRNode::Apply(apply_node)
+                if apply_node.head == sym(RULE) && apply_node.args.first() == Some(variable) =>
+            {
+                Some(apply_node.args[1].clone())
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("missing rule for {variable:?}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -449,4 +483,120 @@ fn nsolve_fraction_poly_returns_float_ir_roots() {
     assert!((values[0] - 1.0).abs() < 1e-7);
     assert!((values[1] - 2.0).abs() < 1e-7);
     assert!((values[2] - 3.0).abs() < 1e-7);
+}
+
+// ---------------------------------------------------------------------------
+// solve_linear_system
+// ---------------------------------------------------------------------------
+
+#[test]
+fn linear_system_2x2_simple() {
+    let x = sym("x");
+    let y = sym("y");
+    let result = solve_linear_system(
+        &[
+            eq(add(vec![x.clone(), y.clone()]), int(3)),
+            eq(sub(x.clone(), y.clone()), int(1)),
+        ],
+        &[x.clone(), y.clone()],
+    )
+    .expect("expected unique solution");
+
+    assert_eq!(rule_value(&result, &x), int(2));
+    assert_eq!(rule_value(&result, &y), int(1));
+}
+
+#[test]
+fn linear_system_rational_solution() {
+    let x = sym("x");
+    let y = sym("y");
+    let result = solve_linear_system(
+        &[
+            eq(
+                add(vec![
+                    mul(vec![int(2), x.clone()]),
+                    mul(vec![int(3), y.clone()]),
+                ]),
+                int(7),
+            ),
+            eq(sub(mul(vec![int(4), x.clone()]), y.clone()), int(1)),
+        ],
+        &[x.clone(), y.clone()],
+    )
+    .expect("expected unique solution");
+
+    assert_eq!(rule_value(&result, &x), rat(5, 7));
+    assert_eq!(rule_value(&result, &y), rat(13, 7));
+}
+
+#[test]
+fn linear_system_3x3_and_zero_form() {
+    let x = sym("x");
+    let y = sym("y");
+    let z = sym("z");
+    let result = solve_linear_system(
+        &[
+            eq(add(vec![x.clone(), y.clone(), z.clone()]), int(6)),
+            eq(add(vec![mul(vec![int(2), x.clone()]), y.clone()]), int(5)),
+            eq(z.clone(), int(3)),
+        ],
+        &[x.clone(), y.clone(), z.clone()],
+    )
+    .expect("expected unique solution");
+
+    assert_eq!(rule_value(&result, &x), int(2));
+    assert_eq!(rule_value(&result, &y), int(1));
+    assert_eq!(rule_value(&result, &z), int(3));
+
+    let zero_form = solve_linear_system(
+        &[add(vec![x.clone(), y.clone()]), sub(x.clone(), y.clone())],
+        &[x.clone(), y.clone()],
+    )
+    .expect("expected unique zero-form solution");
+    assert_eq!(rule_value(&zero_form, &x), int(0));
+    assert_eq!(rule_value(&zero_form, &y), int(0));
+}
+
+#[test]
+fn linear_system_rejects_bad_systems() {
+    let x = sym("x");
+    let y = sym("y");
+    assert!(solve_linear_system(
+        &[eq(add(vec![x.clone(), y.clone()]), int(3))],
+        &[x.clone(), y.clone()]
+    )
+    .is_none());
+    assert!(solve_linear_system(&[], &[]).is_none());
+    assert!(solve_linear_system(
+        &[
+            eq(add(vec![x.clone(), y.clone()]), int(1)),
+            eq(
+                add(vec![
+                    mul(vec![int(2), x.clone()]),
+                    mul(vec![int(2), y.clone()])
+                ]),
+                int(2)
+            ),
+        ],
+        &[x.clone(), y.clone()],
+    )
+    .is_none());
+    assert!(solve_linear_system(&[eq(pow(x.clone(), int(2)), int(4))], &[x]).is_none());
+}
+
+#[test]
+fn linear_system_returns_rule_nodes_in_variable_order() {
+    let x = sym("x");
+    let y = sym("y");
+    let result = solve_linear_system(
+        &[
+            eq(add(vec![x.clone(), y.clone()]), int(3)),
+            eq(sub(x.clone(), y.clone()), int(1)),
+        ],
+        &[x.clone(), y.clone()],
+    )
+    .expect("expected unique solution");
+
+    assert_eq!(result[0], apply(sym(RULE), vec![x, int(2)]));
+    assert_eq!(result[1], apply(sym(RULE), vec![y, int(1)]));
 }


### PR DESCRIPTION
## Summary
- add exact Rust `solve_linear_system` Gaussian elimination for square systems
- normalize `Equal(lhs, rhs)` and zero-form equations into linear rows
- return `Rule(var, value)` IR nodes and cover rational, singular, non-linear, and zero-form cases

## Validation
- `cargo fmt -p cas-solve --check`
- `cargo test -p cas-solve`