### PR TITLE
Add context snapshot summaries

### DIFF
--- a/code/packages/rust/context-store/CHANGELOG.md
+++ b/code/packages/rust/context-store/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
   body-free session lifecycle and checkpoint coverage over selected headers.
 - `ContextTranscriptSummary` and `transcript_summary()` for bounded body-free
   transcript counts by entry kind, metadata coverage, and time span.
+- `ContextSnapshotSummary` and `snapshot_summary()` for bounded compaction
+  checkpoint counts, reference counts, and token estimate ranges.
 
 ## [0.1.0] - 2026-04-18
 

--- a/code/packages/rust/context-store/README.md
+++ b/code/packages/rust/context-store/README.md
@@ -13,6 +13,7 @@ Chief of Staff runtime needs.
 - body-free `ContextEntrySummary` projections for read-side transcript indexes
 - `ContextTranscriptSummary` aggregates for entry kind and time-span coverage
 - `ContextSnapshot` checkpoints for compaction/resume
+- `ContextSnapshotSummary` aggregates for compaction checkpoint coverage
 - compare-and-swap session updates on top of `storage-core`
 - bounded transcript reads by cursor, entry kind, timestamp range, and limit
 - bounded session header listing by owner, status, sort, and limit
@@ -37,6 +38,7 @@ Chief of Staff runtime needs.
 - `fetch_ordered_entries()`
 - `create_snapshot()`
 - `list_snapshots()`
+- `snapshot_summary()`
 - `fetch_latest_snapshot()`
 - `compact_before_entry()`
 - `archive_session()`
@@ -44,6 +46,10 @@ Chief of Staff runtime needs.
 `transcript_summary()` uses the same bounded transcript window options as
 `fetch_entry_summaries()` and returns counts by entry kind, metadata coverage,
 and first/latest timestamps without reading opaque entry bodies.
+
+`snapshot_summary()` uses the same bounded snapshot filters as
+`list_snapshots()` and returns compaction checkpoint counts, reference counts,
+and token estimate ranges without reading transcript bodies.
 
 ## Development
 

--- a/code/packages/rust/context-store/src/lib.rs
+++ b/code/packages/rust/context-store/src/lib.rs
@@ -337,6 +337,77 @@ pub struct ContextSnapshot {
     pub artifact_refs: Vec<String>,
 }
 
+/// Compact aggregate over compaction snapshots for read-side inspectors.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ContextSnapshotSummary {
+    pub total_snapshots: usize,
+    pub included_entry_refs: usize,
+    pub summary_refs: usize,
+    pub memory_refs: usize,
+    pub artifact_refs: usize,
+    pub snapshots_with_memory_refs: usize,
+    pub snapshots_with_artifact_refs: usize,
+    pub total_token_estimate: u64,
+    pub min_token_estimate: Option<u64>,
+    pub max_token_estimate: Option<u64>,
+}
+
+impl ContextSnapshotSummary {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_snapshots<'a, I>(snapshots: I) -> Self
+    where
+        I: IntoIterator<Item = &'a ContextSnapshot>,
+    {
+        let mut summary = Self::empty();
+        for snapshot in snapshots {
+            summary.total_snapshots += 1;
+            summary.included_entry_refs += snapshot.included_entry_ids.len();
+            summary.summary_refs += snapshot.summary_refs.len();
+            summary.memory_refs += snapshot.memory_refs.len();
+            summary.artifact_refs += snapshot.artifact_refs.len();
+            summary.total_token_estimate = summary
+                .total_token_estimate
+                .saturating_add(snapshot.token_estimate);
+            summary.min_token_estimate = Some(
+                summary
+                    .min_token_estimate
+                    .map_or(snapshot.token_estimate, |tokens| {
+                        tokens.min(snapshot.token_estimate)
+                    }),
+            );
+            summary.max_token_estimate = Some(
+                summary
+                    .max_token_estimate
+                    .map_or(snapshot.token_estimate, |tokens| {
+                        tokens.max(snapshot.token_estimate)
+                    }),
+            );
+            if !snapshot.memory_refs.is_empty() {
+                summary.snapshots_with_memory_refs += 1;
+            }
+            if !snapshot.artifact_refs.is_empty() {
+                summary.snapshots_with_artifact_refs += 1;
+            }
+        }
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_snapshots == 0
+    }
+
+    pub fn has_memory_refs(&self) -> bool {
+        self.memory_refs > 0
+    }
+
+    pub fn has_artifact_refs(&self) -> bool {
+        self.artifact_refs > 0
+    }
+}
+
 /// Portable ordering for bounded snapshot list/read tools.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum SnapshotListSort {
@@ -778,6 +849,16 @@ impl<S: StorageBackend> ContextStore<S> {
             snapshots.truncate(limit);
         }
         Ok(snapshots)
+    }
+
+    /// Summarize selected compaction snapshots without reading transcript bodies.
+    pub fn snapshot_summary(
+        &self,
+        session_id: &str,
+        options: SnapshotListOptions,
+    ) -> Result<ContextSnapshotSummary, StorageError> {
+        let snapshots = self.list_snapshots(session_id, options)?;
+        Ok(ContextSnapshotSummary::from_snapshots(&snapshots))
     }
 
     /// Create a compaction snapshot that covers all entries up to and including
@@ -2021,6 +2102,38 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["entry-3"]
         );
+
+        let summary = store
+            .snapshot_summary(
+                "demo",
+                SnapshotListOptions::new()
+                    .with_memory_ref("memory-shared")
+                    .sorted_by(SnapshotListSort::TokenEstimateAsc),
+            )
+            .unwrap();
+        assert_eq!(
+            summary,
+            ContextSnapshotSummary {
+                total_snapshots: 2,
+                included_entry_refs: 4,
+                summary_refs: 2,
+                memory_refs: 3,
+                artifact_refs: 1,
+                snapshots_with_memory_refs: 2,
+                snapshots_with_artifact_refs: 1,
+                total_token_estimate: 40,
+                min_token_estimate: Some(10),
+                max_token_estimate: Some(30),
+            }
+        );
+        assert!(summary.has_memory_refs());
+        assert!(summary.has_artifact_refs());
+        assert!(!summary.is_empty());
+
+        let empty = ContextSnapshotSummary::from_snapshots([]);
+        assert!(empty.is_empty());
+        assert_eq!(empty.min_token_estimate, None);
+        assert_eq!(empty.max_token_estimate, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add ContextSnapshotSummary for compact compaction checkpoint rollups
- expose snapshot_summary() alongside bounded snapshot listing
- document the D18A/D18D snapshot summary surface

## Tests
- cargo test -p context-store