### PR TITLE
Wire TypeScript MACSYMA linsolve to cas-solve

### DIFF
--- a/code/packages/typescript/macsyma-runtime/BUILD
+++ b/code/packages/typescript/macsyma-runtime/BUILD
@@ -9,5 +9,6 @@ cd ../symbolic-vm && npm ci --quiet
 cd ../macsyma-lexer && npm ci --quiet
 cd ../macsyma-parser && npm ci --quiet
 cd ../macsyma-compiler && npm ci --quiet
+cd ../cas-solve && npm ci --quiet
 npm ci --quiet
 npx vitest run --coverage

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Wire `Solve(List(...), List(...))` / `linsolve` to the TypeScript
+  `cas-solve` exact linear-system solver, returning `List(Rule(var, value))`
+  for square systems and preserving unevaluated fallback behavior.
+
 ## 0.1.0
 
 - Add pure TypeScript MACSYMA runtime sessions, history lookup, display

--- a/code/packages/typescript/macsyma-runtime/README.md
+++ b/code/packages/typescript/macsyma-runtime/README.md
@@ -10,5 +10,7 @@ This first runtime slice is intentionally small and browser-friendly:
 - preserves `;` display versus `$` suppress metadata
 - tracks `%`, `%iN`, and `%oN` history
 - pre-binds `%pi`, `%e`, and `%i`
+- dispatches `linsolve` / `Solve(List(...), List(...))` to the exact
+  `cas-solve` linear-system solver
 - exposes a JSON helper whose recursive IR representation is safe for
   `JSON.stringify`

--- a/code/packages/typescript/macsyma-runtime/package-lock.json
+++ b/code/packages/typescript/macsyma-runtime/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@coding-adventures/cas-solve": "file:../cas-solve",
         "@coding-adventures/directed-graph": "file:../directed-graph",
         "@coding-adventures/grammar-tools": "file:../grammar-tools",
         "@coding-adventures/lexer": "file:../lexer",
@@ -19,6 +20,20 @@
         "@coding-adventures/state-machine": "file:../state-machine",
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
         "@coding-adventures/symbolic-vm": "file:../symbolic-vm"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-solve": {
+      "name": "@coding-adventures/cas-solve",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -249,6 +264,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/cas-solve": {
+      "resolved": "../cas-solve",
+      "link": true
     },
     "node_modules/@coding-adventures/directed-graph": {
       "resolved": "../directed-graph",

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -21,6 +21,7 @@
     "@coding-adventures/macsyma-parser": "file:../macsyma-parser",
     "@coding-adventures/parser": "file:../parser",
     "@coding-adventures/state-machine": "file:../state-machine",
+    "@coding-adventures/cas-solve": "file:../cas-solve",
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
     "@coding-adventures/symbolic-vm": "file:../symbolic-vm"
   },

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -1,4 +1,5 @@
 import { compileMacsyma } from "@coding-adventures/macsyma-compiler";
+import { solveLinearSystem } from "@coding-adventures/cas-solve";
 import {
   ACOS,
   ACOSH,
@@ -13,6 +14,7 @@ import {
   FACTOR,
   FALSE,
   INTEGRATE,
+  LIST,
   LOG,
   SIN,
   SINH,
@@ -274,8 +276,9 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(SUPPRESS.name, suppressHandler);
     table.set(KILL.name, makeKillHandler(this));
     table.set(EV.name, makeEvHandler());
+    table.set(SOLVE.name, solveHandler);
     this.runtimeTable = table;
-    this.runtimeHeld = new Set([...super.holdHeads(), KILL.name, EV.name]);
+    this.runtimeHeld = new Set([...super.holdHeads(), KILL.name, EV.name, SOLVE.name]);
   }
 
   override lookup(name: string): IRNode | undefined {
@@ -528,6 +531,21 @@ function makeEvHandler(): Handler {
   };
 }
 
+function solveHandler(_vm: VM, expr: IRApply): IRNode {
+  if (expr.args.length !== 2) return expr;
+  const [equationsNode, variablesNode] = expr.args;
+  if (!isList(equationsNode) || !isList(variablesNode)) return expr;
+
+  const variables: IRSymbol[] = [];
+  for (const variable of variablesNode.args) {
+    if (variable.kind !== "symbol") return expr;
+    variables.push(variable);
+  }
+
+  const rules = solveLinearSystem(equationsNode.args, variables);
+  return rules === null ? expr : app(LIST, rules);
+}
+
 function evalSupportedFlag(vm: VM, result: IRNode, head: IRSymbol): IRNode {
   if (!vm.backend.handlers().has(head.name)) return result;
   try {
@@ -535,6 +553,10 @@ function evalSupportedFlag(vm: VM, result: IRNode, head: IRSymbol): IRNode {
   } catch {
     return result;
   }
+}
+
+function isList(node: IRNode): node is IRApply {
+  return node.kind === "apply" && equals(node.head, LIST);
 }
 
 function numerFold(node: IRNode): IRNode {

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
   ADD,
+  EQUAL,
+  LIST,
   MUL,
   POW,
+  RULE,
+  SOLVE,
+  SUB,
   app,
   int,
   numberNode,
+  rational,
   sym,
 } from "@coding-adventures/symbolic-ir";
 import { VM } from "@coding-adventures/symbolic-vm";
@@ -155,8 +161,10 @@ describe("macsyma-runtime", () => {
     const backend = new MacsymaBackend(new History());
     expect(backend.handlers().has(KILL.name)).toBe(true);
     expect(backend.handlers().has(EV.name)).toBe(true);
+    expect(backend.handlers().has(SOLVE.name)).toBe(true);
     expect(backend.holdHeads().has(KILL.name)).toBe(true);
     expect(backend.holdHeads().has(EV.name)).toBe(true);
+    expect(backend.holdHeads().has(SOLVE.name)).toBe(true);
   });
 
   it("kills single and multiple bindings without evaluating names first", () => {
@@ -217,6 +225,65 @@ describe("macsyma-runtime", () => {
     const session = new MacsymaSession();
     const [result] = session.evalSource("(x + 0) * (y^2);");
     expect(result.output).toEqual(app(MUL, [sym("x"), app(POW, [sym("y"), int(2)])]));
+  });
+
+  it("evaluates linsolve linear systems through the cas-solve handler", () => {
+    const x = sym("x");
+    const y = sym("y");
+    const session = new MacsymaSession();
+    const [result] = session.evalStatements([
+      app(sym("linsolve"), [
+        app(LIST, [
+          app(EQUAL, [app(ADD, [x, y]), int(3)]),
+          app(EQUAL, [app(SUB, [x, y]), int(1)]),
+        ]),
+        app(LIST, [x, y]),
+      ]),
+    ]);
+
+    expect(result.input).toEqual(app(SOLVE, [
+      app(LIST, [
+        app(EQUAL, [app(ADD, [x, y]), int(3)]),
+        app(EQUAL, [app(SUB, [x, y]), int(1)]),
+      ]),
+      app(LIST, [x, y]),
+    ]));
+    expect(result.output).toEqual(app(LIST, [
+      app(RULE, [x, int(2)]),
+      app(RULE, [y, int(1)]),
+    ]));
+  });
+
+  it("keeps unsolved or non-linear Solve calls unevaluated", () => {
+    const x = sym("x");
+    const session = new MacsymaSession();
+    const expr = app(SOLVE, [
+      app(LIST, [app(EQUAL, [app(POW, [x, int(2)]), int(4)])]),
+      app(LIST, [x]),
+    ]);
+
+    const [result] = session.evalStatements([expr]);
+    expect(result.output).toEqual(expr);
+  });
+
+  it("returns rational linsolve results", () => {
+    const x = sym("x");
+    const y = sym("y");
+    const session = new MacsymaSession();
+    const [result] = session.evalStatements([
+      app(SOLVE, [
+        app(LIST, [
+          app(EQUAL, [app(ADD, [app(MUL, [int(2), x]), app(MUL, [int(3), y])]), int(7)]),
+          app(EQUAL, [app(SUB, [app(MUL, [int(4), x]), y]), int(1)]),
+        ]),
+        app(LIST, [x, y]),
+      ]),
+    ]);
+
+    expect(result.output).toEqual(app(LIST, [
+      app(RULE, [x, rational(5, 7)]),
+      app(RULE, [y, rational(13, 7)]),
+    ]));
   });
 
   it("pre-binds MACSYMA constants", () => {

--- a/code/programs/typescript/macsyma-browser-repl/BUILD
+++ b/code/programs/typescript/macsyma-browser-repl/BUILD
@@ -9,6 +9,7 @@ cd ../../../packages/typescript/symbolic-vm && npm ci --quiet
 cd ../../../packages/typescript/macsyma-lexer && npm ci --quiet
 cd ../../../packages/typescript/macsyma-parser && npm ci --quiet
 cd ../../../packages/typescript/macsyma-compiler && npm ci --quiet
+cd ../../../packages/typescript/cas-solve && npm ci --quiet
 cd ../../../packages/typescript/macsyma-runtime && npm ci --quiet
 npm ci --quiet
 npm run build


### PR DESCRIPTION
## Summary
- wire `Solve(List(...), List(...))` and `linsolve` through the TypeScript `cas-solve` exact linear-system solver
- hold `Solve` evaluation so `Equal(...)` equations reach the handler intact
- add runtime coverage for integer/rational systems and unevaluated non-linear fallback

## Validation
- `npm test && npm run build` in `code/packages/typescript/macsyma-runtime`