### PR TITLE
feat(llm-cache+demo): surface cache hit/miss stats in TSA report

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -188,6 +188,7 @@ members = [
     "adjudication-round-trip",
     "adjudication-clarification",
     "adjudication-clinical-demo",
+    "adjudication-contract-demo",
     "adjudication-tsa-demo",
     "loss-functions",
     "markov-chain",

--- a/code/packages/rust/adjudication-contract-demo/BUILD
+++ b/code/packages/rust/adjudication-contract-demo/BUILD
@@ -1,0 +1,19 @@
+load("code/packages/starlark/library-rules/rust_library.star", "rust_library")
+
+_targets = [
+    rust_library(
+        name = "adjudication-contract-demo",
+        srcs = ["src/**/*.rs"],
+        deps = [
+            "//code/packages/rust/adjudication-audit-trail",
+            "//code/packages/rust/adjudication-clarification",
+            "//code/packages/rust/adjudication-ir",
+            "//code/packages/rust/adjudication-pipeline",
+            "//code/packages/rust/llm-cache",
+            "//code/packages/rust/llm-gateway",
+            "//code/packages/rust/llm-primitives",
+            "//code/packages/rust/llm-provider-ollama",
+            "//code/packages/rust/logic-core",
+        ],
+    ),
+]

--- a/code/packages/rust/adjudication-contract-demo/BUILD_windows
+++ b/code/packages/rust/adjudication-contract-demo/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p adjudication-contract-demo -- --nocapture

--- a/code/packages/rust/adjudication-contract-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-contract-demo/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-05-12
+
+### Added
+
+Third-domain A/B demo: contract-clause review. After TSA and
+clinical, contracts give us a domain whose IR shape exercises the
+**rule + exception** machinery (`NodeKind::Rule` with `Conditional`
+modality + `NodeKind::Exception` linked to the rule via `part_of`)
+in a way the earlier demos did not.
+
+- `DemoConfig`, `run_raw_arm`, `run_pipeline_arm`,
+  `contract_ir_document`, `format_side_by_side` — same shape as
+  the TSA + clinical demos.
+- Canonical 105-byte fixture `"If the buyer pays within 30 days,
+  the seller delivers the goods, unless the goods are out of stock."`
+  decomposed as a Conditional Rule + Affirmed Exception + Query
+  (rule spans bytes 0..p1 where p1 is the byte index of " unless",
+  exception spans p1..len, so they tile).
+- Binary at `cargo run -p adjudication-contract-demo`.
+- 7 offline unit tests cover canonical IR shape, Conditional
+  modality, part_of link from exception to rule, span tiling,
+  fallback behavior, and config defaults.

--- a/code/packages/rust/adjudication-contract-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-contract-demo/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "adjudication-contract-demo"
+version = "0.1.0"
+edition = "2021"
+description = "A/B demo harness for contract clauses: run a short obligation clause through both a raw local model and the structured adjudication pipeline. Third domain alongside adjudication-tsa-demo and adjudication-clinical-demo; reuses the same checkers + engine to demonstrate generality."
+
+[[bin]]
+name = "adjudication-contract-demo"
+path = "src/main.rs"
+
+[dependencies]
+adjudication-audit-trail = { path = "../adjudication-audit-trail" }
+adjudication-clarification = { path = "../adjudication-clarification" }
+adjudication-ir = { path = "../adjudication-ir" }
+adjudication-pipeline = { path = "../adjudication-pipeline" }
+llm-cache = { path = "../llm-cache" }
+llm-gateway = { path = "../llm-gateway" }
+llm-primitives = { path = "../llm-primitives" }
+llm-provider-ollama = { path = "../llm-provider-ollama" }
+logic-core = { path = "../logic-core" }
+serde_json = "1"

--- a/code/packages/rust/adjudication-contract-demo/README.md
+++ b/code/packages/rust/adjudication-contract-demo/README.md
@@ -1,0 +1,64 @@
+# adjudication-contract-demo (Rust)
+
+Third-domain A/B demo. Same framework, contract-review domain.
+
+## Why a third demo
+
+After TSA (compliance) and clinical (triage), contracts give us a
+domain whose IR shape is meaningfully different: the **rule +
+exception** structure (`NodeKind::Rule` with `Conditional` modality
++ `NodeKind::Exception` referencing the rule via `part_of`).
+
+Small models often produce IRs that drop the exception entirely.
+This is exactly the kind of structural omission the framework's
+ADJ02 + ADJ03 are designed to catch.
+
+## The fixture (105 bytes)
+
+```text
+If the buyer pays within 30 days, the seller delivers the goods, unless the goods are out of stock.
+```
+
+Hand-built IR:
+
+| Node | Kind      | Modality      | Term                                                      |
+|------|-----------|---------------|-----------------------------------------------------------|
+| R1   | Rule      | Conditional   | `implies(payment_within(30_days), delivers(seller, goods))` |
+| E1   | Exception | Present       | `out_of_stock(goods)` — `part_of: R1`                     |
+| Q1   | Query     | Present       | `delivers(seller, goods)?`                                |
+
+Span tiling: R1 covers bytes 0..p1, E1 covers p1..end where `p1` is
+the byte index where `" unless"` starts. ADJ02 passes; ADJ03 sees
+the Conditional rule with an Affirmed exception; ADJ04 round-trips
+each; ADJ05 attacks each.
+
+## Quick start
+
+```bash
+ollama serve     # in another terminal
+ollama pull gemma4:latest
+ollama pull llama3.1:8b      # for ADJ05
+
+ADJ_DEMO_ENDPOINT=http://127.0.0.1:11434 \
+  ADJ_DEMO_ADVERSARY_MODEL=llama3.1:8b \
+  cargo run -p adjudication-contract-demo
+```
+
+## Env vars
+
+Same set as the other demos: `ADJ_DEMO_{ENDPOINT, MODEL,
+ADVERSARY_MODEL, SOURCE, CACHE_DIR, TIMEOUT_SECS, AUDIT}`.
+
+## What v0.1 ships
+
+- `DemoConfig`, `run_raw_arm`, `run_pipeline_arm`,
+  `contract_ir_document`, `format_side_by_side`.
+- 7 offline tests cover canonical IR shape, conditional modality,
+  `part_of` link from exception to rule, span tiling, fallback
+  behavior.
+
+## What v0.1 deliberately does NOT do
+
+- LlmExtracted mode. Hand-built IR is the v0.1 baseline.
+- Real legal authority. The IR shape is illustrative, not a
+  contract-law reference.

--- a/code/packages/rust/adjudication-contract-demo/required_capabilities.json
+++ b/code/packages/rust/adjudication-contract-demo/required_capabilities.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/adjudication-contract-demo",
+  "capabilities": [
+    { "category": "net",    "action": "connect", "target": "127.0.0.1:11434", "justification": "Default Ollama endpoint." },
+    { "category": "net",    "action": "connect", "target": "*:11434",        "justification": "Non-localhost Ollama via ADJ_DEMO_ENDPOINT." },
+    { "category": "net",    "action": "dns",     "target": "*",              "justification": "OllamaClient resolves endpoint host before connecting." },
+    { "category": "env",    "action": "read",    "target": "ADJ_DEMO_ENDPOINT",         "justification": "Override Ollama endpoint." },
+    { "category": "env",    "action": "read",    "target": "ADJ_DEMO_MODEL",            "justification": "Override primary model." },
+    { "category": "env",    "action": "read",    "target": "ADJ_DEMO_ADVERSARY_MODEL",  "justification": "ADJ05 adversary model." },
+    { "category": "env",    "action": "read",    "target": "ADJ_DEMO_SOURCE",           "justification": "Override the contract clause text." },
+    { "category": "env",    "action": "read",    "target": "ADJ_DEMO_TIMEOUT_SECS",     "justification": "Override HTTP timeout." },
+    { "category": "env",    "action": "read",    "target": "ADJ_DEMO_AUDIT",            "justification": "Enable audit-trail dump." },
+    { "category": "env",    "action": "read",    "target": "ADJ_DEMO_CACHE_DIR",        "justification": "Enable disk-persisted prompt cache." },
+    { "category": "fs",     "action": "read",    "target": "*", "justification": "llm-cache reads cache files from ADJ_DEMO_CACHE_DIR." },
+    { "category": "fs",     "action": "write",   "target": "*", "justification": "llm-cache writes cache files to ADJ_DEMO_CACHE_DIR." },
+    { "category": "fs",     "action": "create",  "target": "*", "justification": "llm-cache creates the cache directory on demand." },
+    { "category": "stdout", "action": "write",   "target": "*", "justification": "Side-by-side report + optional audit-trail dump." }
+  ],
+  "justification": "Third-domain demo binary. Same OS surface as adjudication-tsa-demo and adjudication-clinical-demo."
+}

--- a/code/packages/rust/adjudication-contract-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-contract-demo/src/lib.rs
@@ -1,0 +1,456 @@
+//! # adjudication-contract-demo — contract-clause A/B demo
+//!
+//! Third domain alongside `adjudication-tsa-demo` (compliance) and
+//! `adjudication-clinical-demo` (triage). Same shape; the source is
+//! a short obligation clause and the IR captures the conditional
+//! structure ("if X, then Y, unless Z").
+//!
+//! Why contracts: conditional + exception structure is exactly what
+//! ADJ03 modality tracking (`Conditional` modality on rules) and the
+//! IR's Exception node kind were designed for. A small model often
+//! produces an IR that drops the exception entirely; the structured
+//! pipeline catches that omission.
+//!
+//! ## Canonical fixture (105 bytes)
+//!
+//! ```text
+//! If the buyer pays within 30 days, the seller delivers the goods, unless the goods are out of stock.
+//! ```
+//!
+//! Hand-built IR:
+//!
+//! - R1: `payment_within(30_days) -> delivery`, Modality `Conditional`.
+//! - E1: `out_of_stock` exception attached to R1, polarity Affirmed.
+//! - Q1: `delivers(seller, goods)?` — the query.
+
+use std::time::Duration;
+
+use adjudication_audit_trail::{AdjudicationId, PassOutcome};
+use adjudication_ir::{
+    DocumentId, IRDocument, IRNode, Modality, NodeId, NodeKind, Polarity, Span,
+};
+use adjudication_pipeline::{
+    run_with_gateway, PipelineDocument, PipelineInput, PipelineOutput, Verdict,
+};
+use llm_cache::CachingClient;
+use llm_gateway::{
+    CompletionRequest, FinishReason, LlmClient, LlmError, Message, MessageContent, Role as MsgRole,
+};
+use llm_primitives::{GatewayConfig, Role as PrimitiveRole};
+use llm_provider_ollama::OllamaClient;
+use logic_core::{atom, compound};
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct DemoConfig {
+    pub endpoint: String,
+    pub model: String,
+    pub adversary_model: Option<String>,
+    pub timeout: Duration,
+    pub source_text: String,
+    pub cache_dir: Option<String>,
+}
+
+const CANONICAL_SOURCE: &str =
+    "If the buyer pays within 30 days, the seller delivers the goods, unless the goods are out of stock.";
+
+impl Default for DemoConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "http://localhost:11434".into(),
+            model: "gemma4:latest".into(),
+            adversary_model: None,
+            timeout: Duration::from_secs(120),
+            source_text: CANONICAL_SOURCE.into(),
+            cache_dir: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Arm A
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct RawArmReport {
+    pub prompt: String,
+    pub answer: String,
+    pub model: String,
+    pub input_tokens: usize,
+    pub output_tokens: usize,
+    pub latency_ms: u64,
+    pub finish_reason: FinishReason,
+}
+
+pub fn run_raw_arm(cfg: &DemoConfig) -> Result<RawArmReport, LlmError> {
+    let client = OllamaClient::new(cfg.model.clone())
+        .with_endpoint(cfg.endpoint.clone())
+        .with_timeout(cfg.timeout);
+    let prompt = format!(
+        "CONTRACT CLAUSE: {src}\n\nDoes the seller have to deliver the goods?",
+        src = cfg.source_text,
+    );
+    let req = CompletionRequest {
+        model: cfg.model.clone(),
+        system: Some(
+            "You are a contract-review assistant. Given a contract clause, decide \
+             whether the obligation it describes is currently in force. Explain \
+             in 2-3 sentences, then end with a final line: `VERDICT: OBLIGATION_HOLDS` \
+             or `VERDICT: OBLIGATION_EXCUSED`."
+                .into(),
+        ),
+        messages: vec![Message {
+            role: MsgRole::User,
+            content: MessageContent::Text(prompt.clone()),
+        }],
+        temperature: 0.0,
+        max_tokens: Some(512),
+        stop_sequences: Vec::new(),
+        seed: Some(42),
+        metadata: Default::default(),
+    };
+    let resp = client.complete(req)?;
+    Ok(RawArmReport {
+        prompt,
+        answer: resp.text,
+        model: resp.model,
+        input_tokens: resp.usage.input_tokens,
+        output_tokens: resp.usage.output_tokens,
+        latency_ms: resp.latency_ms,
+        finish_reason: resp.finish_reason,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Arm B
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct PipelineArmReport {
+    pub verdict_summary: String,
+    pub pipeline_output: PipelineOutput,
+    pub adj02_outcome: PassOutcome,
+    pub adj03_outcome: PassOutcome,
+    pub adj04_outcome: PassOutcome,
+    pub adj05_outcome: PassOutcome,
+    pub engine_ran: bool,
+}
+
+pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
+    let primary = OllamaClient::new(cfg.model.clone())
+        .with_endpoint(cfg.endpoint.clone())
+        .with_timeout(cfg.timeout);
+    let extractor = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let renderer = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let nli = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let plausibility = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let mut gateway = GatewayConfig::new()
+        .with_client(PrimitiveRole::Extractor, extractor)
+        .with_client(PrimitiveRole::Renderer, renderer)
+        .with_client(PrimitiveRole::Nli, nli)
+        .with_client(PrimitiveRole::Plausibility, plausibility);
+    if let Some(adv) = &cfg.adversary_model {
+        let adv_client = OllamaClient::new(adv.clone())
+            .with_endpoint(cfg.endpoint.clone())
+            .with_timeout(cfg.timeout);
+        gateway = gateway.with_client(
+            PrimitiveRole::Adversary,
+            wrap_with_cache(Box::new(adv_client) as Box<dyn LlmClient>, cfg),
+        );
+    }
+    let input = PipelineInput {
+        document: PipelineDocument {
+            id: "contract-demo-001".into(),
+            name: "contract_clause".into(),
+            received_at: "2026-05-12T00:00:00Z".into(),
+            normalized_text: cfg.source_text.clone(),
+            normalization_pipeline: "plain-text-v1".into(),
+            normalization_version: "1.0.0".into(),
+        },
+        ir_document: contract_ir_document(&cfg.source_text),
+    };
+    let tick = std::cell::Cell::new(0u32);
+    let now = move || {
+        let t = tick.get();
+        tick.set(t + 1);
+        format!("2026-05-12T00:00:{:02}Z", t.min(59))
+    };
+    let output = run_with_gateway(
+        input,
+        AdjudicationId::new("adj-contract-demo"),
+        now,
+        Some(&gateway),
+    );
+    let trail = &output.audit_trail;
+    let summary = match &output.verdict {
+        Verdict::Resolved { answers } => {
+            format!("Resolved with {n} engine answer(s)", n = answers.len())
+        }
+        Verdict::Blocked { violation_count } => {
+            format!("Blocked with {violation_count} violation(s)")
+        }
+        Verdict::EngineError(detail) => format!("EngineError: {detail}"),
+    };
+    PipelineArmReport {
+        verdict_summary: summary,
+        adj02_outcome: trail.checker_results[0].outcome,
+        adj03_outcome: trail.checker_results[1].outcome,
+        adj04_outcome: trail.checker_results[2].outcome,
+        adj05_outcome: trail.checker_results[3].outcome,
+        engine_ran: trail.engine_artifacts.is_some(),
+        pipeline_output: output,
+    }
+}
+
+fn wrap_with_cache(inner: Box<dyn LlmClient>, cfg: &DemoConfig) -> Box<dyn LlmClient> {
+    match &cfg.cache_dir {
+        Some(dir) => Box::new(CachingClient::with_disk_persistence(inner, dir)),
+        None => Box::new(CachingClient::new(inner)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Contract IR fixture
+// ---------------------------------------------------------------------------
+
+/// Build the canonical contract IR. Conditional rule + exception
+/// shape — the IR's `NodeKind::Rule` + `NodeKind::Exception`
+/// machinery shines here.
+///
+/// Layout for the 105-byte canonical source:
+///
+/// - Bytes 0..51:  `"If the buyer pays within 30 days, the seller "`...
+///   wait, byte counts vary. Use computed spans below.
+///
+/// Three IR fragments:
+/// - R1: spans bytes [0..p1) — the conditional rule.
+/// - E1: spans bytes [p1..end) — the exception clause.
+/// - Q1: synthesized query (no source spans).
+///
+/// `p1` is the byte index where `unless` starts, so the spans tile.
+pub fn contract_ir_document(source_text: &str) -> IRDocument {
+    let doc_id = DocumentId::new("contract-demo-001");
+    let len = source_text.len();
+    let mut nodes = Vec::new();
+
+    if source_text == CANONICAL_SOURCE {
+        // ADJ02 v2 requires root nodes (`part_of = None`) to TILE the
+        // document. The Exception is a non-root refinement (`part_of:
+        // R1`) and so doesn't count toward tiling — only R1 does. R1
+        // spans the entire 105-byte sentence; E1 carves out the
+        // "unless..." portion as a child node.
+        let p1 = source_text.find(" unless").map(|i| i + 1).unwrap_or(len / 2);
+        nodes.push(IRNode {
+            id: NodeId::new("R1"),
+            kind: NodeKind::Rule,
+            // The engine recognises rule subtypes `definitional/2`
+            // and `probabilistic/3`. We use the definitional shape:
+            //   definitional(head, [body...])
+            // Lists use the Prolog cons form `.( head, tail )` ending
+            // in `[]`. Here the head is `delivers(seller, goods)` and
+            // the body is `[ payment_within(30_days) ]`.
+            term: compound(
+                "definitional",
+                vec![
+                    compound("delivers", vec![atom("seller"), atom("goods")]),
+                    compound(
+                        ".",
+                        vec![
+                            compound("payment_within", vec![atom("30_days")]),
+                            atom("[]"),
+                        ],
+                    ),
+                ],
+            ),
+            polarity: Polarity::Affirmed,
+            modality: Modality::Conditional,
+            // Cover the entire source so the document tiles cleanly
+            // even though the Exception lives inside it as a child.
+            source_spans: vec![Span::new(doc_id.clone(), 0, len)],
+            confidence: 1.0,
+            part_of: None,
+            lowered_from: None,
+            discard_reason: None,
+            metadata: Default::default(),
+        });
+        nodes.push(IRNode {
+            id: NodeId::new("E1"),
+            kind: NodeKind::Exception,
+            term: compound("out_of_stock", vec![atom("goods")]),
+            polarity: Polarity::Affirmed,
+            modality: Modality::Present,
+            // Exception carves the "unless..." portion out of R1.
+            // Its span is contained in R1's span (which the IR
+            // validator requires).
+            source_spans: vec![Span::new(doc_id.clone(), p1, len)],
+            confidence: 1.0,
+            part_of: Some(NodeId::new("R1")),
+            lowered_from: None,
+            discard_reason: None,
+            metadata: Default::default(),
+        });
+    } else if len > 0 {
+        nodes.push(IRNode {
+            id: NodeId::new("R1"),
+            kind: NodeKind::Rule,
+            term: compound("clause", vec![atom("text")]),
+            polarity: Polarity::Affirmed,
+            modality: Modality::Conditional,
+            source_spans: vec![Span::new(doc_id.clone(), 0, len)],
+            confidence: 1.0,
+            part_of: None,
+            lowered_from: None,
+            discard_reason: None,
+            metadata: Default::default(),
+        });
+    }
+
+    nodes.push(IRNode {
+        id: NodeId::new("Q1"),
+        kind: NodeKind::Query,
+        term: compound("delivers", vec![atom("seller"), atom("goods")]),
+        polarity: Polarity::Affirmed,
+        modality: Modality::Present,
+        source_spans: vec![],
+        confidence: 1.0,
+        part_of: None,
+        lowered_from: None,
+        discard_reason: None,
+        metadata: Default::default(),
+    });
+
+    IRDocument {
+        document_id: doc_id,
+        nodes,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+pub fn format_side_by_side(raw: &RawArmReport, pipe: &PipelineArmReport) -> String {
+    let mut out = String::new();
+    out.push_str("============================================================\n");
+    out.push_str("  Contract adjudication: raw model vs structured pipeline\n");
+    out.push_str("============================================================\n\n");
+    out.push_str("--- ARM A: raw model ---\n");
+    out.push_str(&format!("model:           {}\n", raw.model));
+    out.push_str(&format!(
+        "tokens (in/out): {} / {}\n",
+        raw.input_tokens, raw.output_tokens
+    ));
+    out.push_str(&format!("latency:         {} ms\n", raw.latency_ms));
+    out.push_str("answer:\n");
+    for line in raw.answer.lines() {
+        out.push_str(&format!("  {line}\n"));
+    }
+    out.push_str("\n--- ARM B: structured pipeline ---\n");
+    out.push_str(&format!("verdict:         {}\n", pipe.verdict_summary));
+    out.push_str(&format!(
+        "ADJ02 coverage:           {}\n",
+        format_outcome(&pipe.adj02_outcome)
+    ));
+    out.push_str(&format!(
+        "ADJ03 polarity/modality:  {}\n",
+        format_outcome(&pipe.adj03_outcome)
+    ));
+    out.push_str(&format!(
+        "ADJ04 round-trip:         {}\n",
+        format_outcome(&pipe.adj04_outcome)
+    ));
+    out.push_str(&format!(
+        "ADJ05 adversarial:        {}\n",
+        format_outcome(&pipe.adj05_outcome)
+    ));
+    out.push_str(&format!("engine ran:               {}\n", pipe.engine_ran));
+    out
+}
+
+fn format_outcome(o: &PassOutcome) -> &'static str {
+    match o {
+        PassOutcome::Passed => "Passed",
+        PassOutcome::Failed => "Failed",
+        PassOutcome::Skipped => "Skipped",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_source_yields_rule_exception_query() {
+        let ir = contract_ir_document(CANONICAL_SOURCE);
+        assert_eq!(ir.nodes.len(), 3);
+        assert_eq!(ir.nodes[0].kind, NodeKind::Rule);
+        assert_eq!(ir.nodes[1].kind, NodeKind::Exception);
+        assert_eq!(ir.nodes[2].kind, NodeKind::Query);
+    }
+
+    #[test]
+    fn rule_is_conditional_modality() {
+        let ir = contract_ir_document(CANONICAL_SOURCE);
+        assert_eq!(ir.nodes[0].modality, Modality::Conditional);
+    }
+
+    #[test]
+    fn exception_references_rule_via_part_of() {
+        let ir = contract_ir_document(CANONICAL_SOURCE);
+        let exception = &ir.nodes[1];
+        assert_eq!(
+            exception.part_of.as_ref().map(|n| n.0.as_str()),
+            Some("R1")
+        );
+    }
+
+    #[test]
+    fn root_node_tiles_the_document() {
+        // ADJ02 v2 requires root nodes (part_of=None) to tile the
+        // document. R1 is the only root in this fixture; E1 is a
+        // child of R1. R1 must cover [0, len) exactly.
+        let ir = contract_ir_document(CANONICAL_SOURCE);
+        let r1 = &ir.nodes[0];
+        assert_eq!(r1.id.0, "R1");
+        assert!(r1.part_of.is_none(), "R1 must be a root");
+        assert_eq!(r1.source_spans.len(), 1);
+        assert_eq!(r1.source_spans[0].start, 0);
+        assert_eq!(r1.source_spans[0].end, CANONICAL_SOURCE.len());
+    }
+
+    #[test]
+    fn exception_span_is_contained_within_rule_span() {
+        let ir = contract_ir_document(CANONICAL_SOURCE);
+        let r1 = &ir.nodes[0];
+        let e1 = &ir.nodes[1];
+        let r1s = &r1.source_spans[0];
+        let e1s = &e1.source_spans[0];
+        assert!(r1s.start <= e1s.start);
+        assert!(e1s.end <= r1s.end);
+    }
+
+    #[test]
+    fn non_canonical_text_falls_back_to_single_rule_plus_query() {
+        let ir = contract_ir_document("some other clause text");
+        assert_eq!(ir.nodes.len(), 2);
+        assert_eq!(ir.nodes[0].kind, NodeKind::Rule);
+        assert_eq!(ir.nodes[1].kind, NodeKind::Query);
+    }
+
+    #[test]
+    fn empty_source_yields_query_only() {
+        let ir = contract_ir_document("");
+        assert_eq!(ir.nodes.len(), 1);
+        assert_eq!(ir.nodes[0].kind, NodeKind::Query);
+    }
+
+    #[test]
+    fn default_config_uses_canonical_source_text() {
+        let cfg = DemoConfig::default();
+        assert!(cfg.source_text.contains("buyer pays"));
+        assert!(cfg.source_text.contains("unless"));
+    }
+}

--- a/code/packages/rust/adjudication-contract-demo/src/main.rs
+++ b/code/packages/rust/adjudication-contract-demo/src/main.rs
@@ -1,0 +1,73 @@
+//! Contract-clause adjudication demo binary.
+
+use std::time::Duration;
+
+use adjudication_contract_demo::{
+    format_side_by_side, run_pipeline_arm, run_raw_arm, DemoConfig,
+};
+
+fn main() {
+    let cfg = config_from_env();
+    println!(
+        "Running contract demo against {endpoint}\n\
+         primary model: `{model}`\n\
+         adversary:     {adv}\n\
+         cache:         {cache}\n",
+        endpoint = cfg.endpoint,
+        model = cfg.model,
+        adv = cfg
+            .adversary_model
+            .as_deref()
+            .map(|s| format!("`{s}` (Adversary)"))
+            .unwrap_or_else(|| "(none; ADJ05 will Skip)".to_string()),
+        cache = cfg
+            .cache_dir
+            .as_deref()
+            .map(|s| format!("disk persistence at {s}"))
+            .unwrap_or_else(|| "in-memory only".to_string()),
+    );
+    println!("[arm A] asking the raw model directly...");
+    let raw = match run_raw_arm(&cfg) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!(
+                "Arm A failed: {e}\n\nHint: is Ollama running? Try `ollama pull {model}`.",
+                model = cfg.model
+            );
+            std::process::exit(1);
+        }
+    };
+    println!("[arm B] running the structured pipeline...");
+    let pipe = run_pipeline_arm(&cfg);
+    println!("\n{}", format_side_by_side(&raw, &pipe));
+    if std::env::var("ADJ_DEMO_AUDIT").is_ok() {
+        if let Ok(json) = serde_json::to_string_pretty(&pipe.pipeline_output.audit_trail) {
+            println!("--- full audit trail (ADJ07-v1) ---\n{json}");
+        }
+    }
+}
+
+fn config_from_env() -> DemoConfig {
+    let mut cfg = DemoConfig::default();
+    if let Ok(v) = std::env::var("ADJ_DEMO_ENDPOINT") {
+        cfg.endpoint = v;
+    }
+    if let Ok(v) = std::env::var("ADJ_DEMO_MODEL") {
+        cfg.model = v;
+    }
+    if let Ok(v) = std::env::var("ADJ_DEMO_SOURCE") {
+        cfg.source_text = v;
+    }
+    if let Ok(v) = std::env::var("ADJ_DEMO_ADVERSARY_MODEL") {
+        cfg.adversary_model = if v.is_empty() { None } else { Some(v) };
+    }
+    if let Ok(v) = std::env::var("ADJ_DEMO_TIMEOUT_SECS") {
+        if let Ok(n) = v.parse::<u64>() {
+            cfg.timeout = Duration::from_secs(n);
+        }
+    }
+    if let Ok(v) = std::env::var("ADJ_DEMO_CACHE_DIR") {
+        cfg.cache_dir = if v.is_empty() { None } else { Some(v) };
+    }
+    cfg
+}

--- a/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2026-05-12
+
+### Added
+
+`PipelineArmReport::cache_stats` — aggregate `CacheStats` across
+every role's `CachingClient`. Side-by-side report prints a
+`cache: N hits / M misses (X% hit rate), K entries` line whenever
+any cache activity happened, making the cache's economic value
+visible.
+
+Measured against the canonical TSA fixture (gemma4 + llama3.1):
+
+- Cold run: `2 hits / 9 misses (18%)` — the two hits come from
+  `render_node` being called by both ADJ04 and ADJ05 with the same
+  prompts, so the second checker hits the in-memory cache.
+- Warm run with persisted cache: `11 hits / 0 misses (100%)`.
+
 ## [0.5.0] - 2026-05-12
 
 ### Added

--- a/code/packages/rust/adjudication-tsa-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-tsa-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adjudication-tsa-demo"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.5 wraps every LLM client in `llm-cache::CachingClient` with optional disk persistence — set ADJ_DEMO_CACHE_DIR=<path> and a second run replays from disk with 0 LLM round-trips."
 

--- a/code/packages/rust/adjudication-tsa-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/lib.rs
@@ -66,7 +66,7 @@ use llm_gateway::{
 use adjudication_clarification::{
     retry_decompose_on_coverage_failure, ClarificationError, CoverageClarificationRequest,
 };
-use llm_cache::CachingClient;
+use llm_cache::{CacheStats, CacheStatsHandle, CachingClient};
 use llm_primitives::{
     decompose_text, DecomposeTextRequest, GatewayConfig, PrimitiveError, Role as PrimitiveRole,
 };
@@ -242,6 +242,12 @@ pub struct PipelineArmReport {
     /// includes the model's raw JSON so the report shows exactly
     /// what the model produced.
     pub ir_source: IrSourceTelemetry,
+    /// Aggregate cache stats across every role's `CachingClient`.
+    /// Populated regardless of whether disk persistence is enabled;
+    /// hit rate is 0% on first run, climbs as the same prompts are
+    /// re-issued (most often via the ADJ06 retry loop within a
+    /// single run, or across runs when `cache_dir` is set).
+    pub cache_stats: CacheStats,
 }
 
 /// One ADJ04 drift finding pulled out of the audit trail. Mirrors
@@ -288,10 +294,11 @@ pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
     // GatewayConfig needs Box<dyn LlmClient>; we register clones of
     // the primary client for Extractor/Renderer/Nli/Plausibility so
     // each call site uses its own connection.
-    let extractor = wrap_with_cache(Box::new(primary.clone()), cfg);
-    let renderer = wrap_with_cache(Box::new(primary.clone()), cfg);
-    let nli = wrap_with_cache(Box::new(primary.clone()), cfg);
-    let plausibility = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let (extractor, h_extractor) = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let (renderer, h_renderer) = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let (nli, h_nli) = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let (plausibility, h_plausibility) = wrap_with_cache(Box::new(primary.clone()), cfg);
+    let mut cache_handles = vec![h_extractor, h_renderer, h_nli, h_plausibility];
     let mut gateway = GatewayConfig::new()
         .with_client(PrimitiveRole::Extractor, extractor)
         .with_client(PrimitiveRole::Renderer, renderer)
@@ -305,10 +312,9 @@ pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
         let adv_client = OllamaClient::new(adv_model.clone())
             .with_endpoint(cfg.endpoint.clone())
             .with_timeout(cfg.timeout);
-        gateway = gateway.with_client(
-            PrimitiveRole::Adversary,
-            wrap_with_cache(Box::new(adv_client) as Box<dyn LlmClient>, cfg),
-        );
+        let (adv_boxed, h_adv) = wrap_with_cache(Box::new(adv_client) as Box<dyn LlmClient>, cfg);
+        cache_handles.push(h_adv);
+        gateway = gateway.with_client(PrimitiveRole::Adversary, adv_boxed);
     }
 
     // Build the IR according to the configured mode. The
@@ -483,6 +489,9 @@ pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
         Verdict::EngineError(detail) => format!("EngineError: {detail}"),
     };
 
+    // Aggregate cache stats across every role's CachingClient.
+    let aggregate_cache_stats = aggregate_stats(&cache_handles);
+
     PipelineArmReport {
         verdict_summary: summary,
         adj02_outcome: trail.checker_results[0].outcome,
@@ -493,8 +502,21 @@ pub fn run_pipeline_arm(cfg: &DemoConfig) -> PipelineArmReport {
         adj04_drift_findings,
         adj05_adversarial_findings,
         ir_source: ir_source_telemetry,
+        cache_stats: aggregate_cache_stats,
         pipeline_output: output,
     }
+}
+
+/// Sum hits/misses/entries across a fleet of `CacheStatsHandle`s.
+fn aggregate_stats(handles: &[CacheStatsHandle]) -> CacheStats {
+    let mut total = CacheStats::default();
+    for h in handles {
+        let s = h.stats();
+        total.hits = total.hits.saturating_add(s.hits);
+        total.misses = total.misses.saturating_add(s.misses);
+        total.entries = total.entries.saturating_add(s.entries);
+    }
+    total
 }
 
 /// How Arm B's IR was built — recorded so the report can show the
@@ -1022,17 +1044,19 @@ fn parse_source_spans(
     spans
 }
 
-/// Wrap an inner LLM client with a `CachingClient` if the demo
-/// config requests caching. Disk persistence is enabled when
-/// `cfg.cache_dir` is `Some`; otherwise the cache is in-memory only
-/// (and so won't help a single-shot binary run — but the demo also
-/// runs in tests and from the same process as other primitives,
-/// where in-memory hits do happen via the ADJ06 retry loop).
-fn wrap_with_cache(inner: Box<dyn LlmClient>, cfg: &DemoConfig) -> Box<dyn LlmClient> {
-    match &cfg.cache_dir {
-        Some(dir) => Box::new(CachingClient::with_disk_persistence(inner, dir)),
-        None => Box::new(CachingClient::new(inner)),
-    }
+/// Wrap an inner LLM client with a `CachingClient`. Returns both
+/// the boxed client (for the gateway) and a stats handle (for the
+/// demo to read hit rates after the run completes).
+fn wrap_with_cache(
+    inner: Box<dyn LlmClient>,
+    cfg: &DemoConfig,
+) -> (Box<dyn LlmClient>, CacheStatsHandle) {
+    let cached = match &cfg.cache_dir {
+        Some(dir) => CachingClient::with_disk_persistence(inner, dir),
+        None => CachingClient::new(inner),
+    };
+    let handle = cached.stats_handle();
+    (Box::new(cached) as Box<dyn LlmClient>, handle)
 }
 
 /// Render the first ADJ02 violation as a short string suitable for
@@ -1314,6 +1338,16 @@ pub fn format_side_by_side(raw: &RawArmReport, pipeline: &PipelineArmReport) -> 
     out.push_str(&format!("engine ran:               {}\n", pipeline.engine_ran));
     if let Some(art) = &pipeline.pipeline_output.audit_trail.engine_artifacts {
         out.push_str(&format!("engine version:           {}\n", art.engine_version));
+    }
+    let cs = &pipeline.cache_stats;
+    if cs.hits + cs.misses > 0 {
+        out.push_str(&format!(
+            "cache:                    {hits} hits / {misses} misses ({rate:.0}% hit rate), {entries} entries\n",
+            hits = cs.hits,
+            misses = cs.misses,
+            rate = cs.hit_rate() * 100.0,
+            entries = cs.entries,
+        ));
     }
     // ADJ02 coverage violations — surface so the user sees WHY the
     // pipeline blocked when it did.

--- a/code/packages/rust/llm-cache/CHANGELOG.md
+++ b/code/packages/rust/llm-cache/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-05-12
+
+### Added
+
+`CacheStatsHandle` — a cloneable handle on a `CachingClient`'s
+stats. Callers can hold the handle even after the typed
+`CachingClient` is moved into a `Box<dyn LlmClient>` and registered
+in a `GatewayConfig`, then read stats after the run completes.
+
+- `CachingClient::stats_handle()` returns a `CacheStatsHandle`
+  backed by an `Arc<Mutex<CacheState>>` (the internal state is
+  now Arc-wrapped, which is a non-breaking change to existing
+  callers).
+- `CacheStatsHandle::stats()` snapshots the live state.
+
+### Why
+
+The TSA / clinical / contract demos all wrap their LLM clients in
+`CachingClient` then surrender them to a `GatewayConfig`. With v0.2
+the demo couldn't read hit rates afterwards; v0.3 lets each demo
+print a clean `cache: N hits / M misses (X% hit rate)` line in the
+side-by-side report — which makes the cache's economic value
+visible to the reader.
+
 ## [0.2.0] - 2026-05-12
 
 ### Added

--- a/code/packages/rust/llm-cache/Cargo.toml
+++ b/code/packages/rust/llm-cache/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "llm-cache"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "LM00c — content-addressed prompt cache. Wraps any LlmClient with a (model, prompt_hash[, schema_name])-keyed cache. v0.1 was in-memory only; v0.2 adds optional disk persistence (one JSON file per entry keyed on prompt hash) so the cache survives process restarts."
+description = "LM00c — content-addressed prompt cache. v0.3 adds CacheStatsHandle, a cloneable handle on a CachingClient's stats so callers can read hit/miss rates after the typed client has been wrapped in Box<dyn LlmClient>."
 
 [dependencies]
 llm-gateway = { path = "../llm-gateway" }

--- a/code/packages/rust/llm-cache/src/lib.rs
+++ b/code/packages/rust/llm-cache/src/lib.rs
@@ -46,7 +46,7 @@
 //!   version may add TTL for adversarial use cases.
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use llm_gateway::{
     Capabilities, CompletionJsonResponse, CompletionRequest, CompletionResponse, FinishReason,
@@ -277,9 +277,29 @@ fn try_save_disk(dir: &Path, key: &str, entry: &CacheEntry) {
 /// let stats = cached.stats();
 /// println!("hit rate: {:.0}%", stats.hit_rate() * 100.0);
 /// ```
+/// Shareable handle to a `CachingClient`'s stats. Callers can clone
+/// this and inspect stats after the typed client has been wrapped
+/// in a `Box<dyn LlmClient>` and surrendered to a `GatewayConfig`.
+#[derive(Clone)]
+pub struct CacheStatsHandle {
+    state: Arc<Mutex<CacheState>>,
+}
+
+impl CacheStatsHandle {
+    /// Snapshot of cache telemetry at the time of the call.
+    pub fn stats(&self) -> CacheStats {
+        let s = self.state.lock().unwrap();
+        CacheStats {
+            hits: s.hits,
+            misses: s.misses,
+            entries: s.entries.len(),
+        }
+    }
+}
+
 pub struct CachingClient {
     inner: Box<dyn LlmClient>,
-    state: Mutex<CacheState>,
+    state: Arc<Mutex<CacheState>>,
     /// Maximum number of entries before FIFO eviction. `None` =
     /// unlimited.
     capacity: Option<usize>,
@@ -293,7 +313,7 @@ impl CachingClient {
     pub fn new(inner: Box<dyn LlmClient>) -> Self {
         Self {
             inner,
-            state: Mutex::new(CacheState::default()),
+            state: Arc::new(Mutex::new(CacheState::default())),
             capacity: None,
             disk_dir: None,
         }
@@ -303,7 +323,7 @@ impl CachingClient {
     pub fn with_capacity(inner: Box<dyn LlmClient>, capacity: usize) -> Self {
         Self {
             inner,
-            state: Mutex::new(CacheState::default()),
+            state: Arc::new(Mutex::new(CacheState::default())),
             capacity: Some(capacity),
             disk_dir: None,
         }
@@ -321,7 +341,7 @@ impl CachingClient {
     ) -> Self {
         Self {
             inner,
-            state: Mutex::new(CacheState::default()),
+            state: Arc::new(Mutex::new(CacheState::default())),
             capacity: None,
             disk_dir: Some(dir.into()),
         }
@@ -335,7 +355,7 @@ impl CachingClient {
     ) -> Self {
         Self {
             inner,
-            state: Mutex::new(CacheState::default()),
+            state: Arc::new(Mutex::new(CacheState::default())),
             capacity: Some(capacity),
             disk_dir: Some(dir.into()),
         }
@@ -348,6 +368,16 @@ impl CachingClient {
             hits: s.hits,
             misses: s.misses,
             entries: s.entries.len(),
+        }
+    }
+
+    /// Cloneable handle on this cache's stats. Useful after the
+    /// typed `CachingClient` has been wrapped in
+    /// `Box<dyn LlmClient>` and surrendered to a `GatewayConfig` —
+    /// callers stash the handle and read stats at any later point.
+    pub fn stats_handle(&self) -> CacheStatsHandle {
+        CacheStatsHandle {
+            state: Arc::clone(&self.state),
         }
     }
 


### PR DESCRIPTION
## Summary

Make the cache's economic value visible. Plumbs aggregate cache stats from `CachingClient` through the TSA demo's `PipelineArmReport` into the side-by-side report.

**Stacks on [#2874](https://github.com/adhithyan15/coding-adventures/pull/2874).**

## Measured on gemma4:latest + llama3.1:8b (TSA, LlmExtracted)

```
Cold run:  cache: 2 hits / 9 misses (18% hit rate), 9 entries
Warm run:  cache: 11 hits / 0 misses (100% hit rate), 9 entries
```

The 2 cold-run hits are `render_node` being called by both ADJ04 and ADJ05 with the same prompts — second checker hits the in-memory cache. The warm run serves every prompt from disk.

## llm-cache 0.2 → 0.3

- Internal state is now `Arc<Mutex<CacheState>>` (non-breaking).
- New `CacheStatsHandle` (cloneable) + `CachingClient::stats_handle()`.

## demo 0.5 → 0.6

- `wrap_with_cache` now returns `(Box<dyn LlmClient>, CacheStatsHandle)`.
- After the pipeline run, `aggregate_stats` sums handles across all roles.
- Side-by-side report prints `cache: N hits / M misses (X% hit rate), K entries` when there's activity.

## Test plan

- [x] `cargo test -p llm-cache -p adjudication-tsa-demo` — 15 + 19 tests pass
- [x] Live cold/warm runs measured: 0% → 100% hit rate as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)