### PR TITLE
Handle post-head and table-cell parser edges

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -719,6 +719,7 @@ pub struct HtmlParser {
     options: HtmlParseOptions,
     quirks_mode: bool,
     strip_next_leading_lf: bool,
+    explicit_head_end_seen: bool,
     explicit_body_end_seen: bool,
     explicit_body_start_seen: bool,
     explicit_html_end_seen: bool,
@@ -739,6 +740,7 @@ impl Default for HtmlParser {
             options: HtmlParseOptions::default(),
             quirks_mode: true,
             strip_next_leading_lf: false,
+            explicit_head_end_seen: false,
             explicit_body_end_seen: false,
             explicit_body_start_seen: false,
             explicit_html_end_seen: false,
@@ -786,6 +788,7 @@ impl HtmlParser {
             options,
             quirks_mode: true,
             strip_next_leading_lf: false,
+            explicit_head_end_seen: false,
             explicit_body_end_seen: false,
             explicit_body_start_seen: false,
             explicit_html_end_seen: false,
@@ -1581,6 +1584,17 @@ impl HtmlParser {
             && !self.has_document_element()
             && !self.document.children.iter().any(is_body_content_node)
         {
+            if self.explicit_head_end_seen {
+                let mut html = Node::element("html".to_string(), Vec::new());
+                if let Node::Element(html_element) = &mut html {
+                    html_element
+                        .children
+                        .push(Node::element("head".to_string(), Vec::new()));
+                    html_element.children.push(Node::text(text));
+                }
+                self.document.push_child(html);
+                return;
+            }
             return;
         }
 
@@ -1783,6 +1797,22 @@ impl HtmlParser {
             }
         }
         let node = Node::comment(comment);
+        if self.explicit_head_end_seen
+            && self.current_element_is("head")
+            && self.has_document_element()
+            && !self.document_has_body_element()
+            && !self.body_has_non_whitespace_child()
+        {
+            if let Some(Node::Element(html)) = self
+                .document
+                .children
+                .iter_mut()
+                .find(|node| matches!(node, Node::Element(element) if element.name == "html"))
+            {
+                html.children.push(node);
+                return;
+            }
+        }
         if self.open_elements.is_empty()
             && self.has_document_element()
             && !self.explicit_html_end_seen
@@ -2327,6 +2357,9 @@ impl HtmlParser {
         if name == "body" {
             self.explicit_body_end_seen = true;
         }
+        if name == "head" {
+            self.explicit_head_end_seen = true;
+        }
         if name == "html" {
             self.explicit_html_end_seen = true;
         }
@@ -2375,6 +2408,15 @@ impl HtmlParser {
                 && !self.body_has_non_whitespace_child() => {}
             "p" if self.current_parent_has_element_ancestor("button")
                 && !self.current_parent_has_element_in_button_scope("p") =>
+            {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-p-end-tag",
+                    "end tag `</p>` created and closed an implied `p` element",
+                ));
+                self.append_node(Node::element("p".to_string(), Vec::new()));
+            }
+            "p" if self.current_parent_has_table_cell_ancestor()
+                && !self.current_parent_has_element_in_table_scope("p") =>
             {
                 self.diagnostics.push(ParserDiagnostic::new(
                     "unexpected-p-end-tag",
@@ -3614,6 +3656,15 @@ impl HtmlParser {
         })
     }
 
+    fn current_parent_has_table_cell_ancestor(&self) -> bool {
+        let current_parent_path = self.current_parent_path();
+        self.open_elements.iter().any(|path| {
+            current_parent_path.starts_with(path)
+                && element_at_path(&self.document, path)
+                    .is_some_and(|name| matches!(name, "td" | "th"))
+        })
+    }
+
     fn current_parent_has_element_ancestor(&self, ancestor_name: &str) -> bool {
         let current_parent_path = self.current_parent_path();
         self.open_elements.iter().any(|path| {
@@ -4779,6 +4830,8 @@ impl DocumentShellBuilder {
                     None => {
                         if !self.head_children.is_empty() {
                             self.push_head_text(text.data);
+                        } else if self.seen_head_element {
+                            self.pre_body_html_children.push(Node::Text(text));
                         }
                     }
                 }
@@ -7002,11 +7055,11 @@ mod tests {
         let html = html(&document);
         assert_eq!(element(&html.children[0]).name, "head");
         assert!(matches!(html.children[1], Node::Comment(_)));
+        assert!(matches!(html.children[2], Node::Comment(_)));
         let head = element(&html.children[0]);
         assert_eq!(element(&head.children[0]).name, "style");
-        assert!(matches!(head.children[1], Node::Comment(_)));
-        assert_eq!(element(&head.children[2]).name, "script");
-        assert_eq!(element(&html.children[2]).name, "body");
+        assert_eq!(element(&head.children[1]).name, "script");
+        assert_eq!(element(&html.children[3]).name, "body");
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -22921,3 +22921,368 @@ x"
 |         xlink href="foo"
 |         xml lang="en"
 |       "bar"
+
+#source tests2.dat:61
+#data
+<!DOCTYPE html><table><tr><td></p></table>
+#errors
+(1,34): unexpected-end-tag
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+|             <p>
+
+#source tests2.dat:62
+#data
+<!DOCTYPE <!DOCTYPE HTML>><!--<!--x-->-->
+#errors
+(1,20): expected-space-or-right-bracket-in-doctype
+(1,25): unknown-doctype
+(1,35): unexpected-char-in-comment
+#new-errors
+(1:21) invalid-character-sequence-after-doctype-name
+(1:35) nested-comment
+#document
+| <!DOCTYPE <!doctype>
+| <html>
+|   <head>
+|   <body>
+|     ">"
+|     <!-- <!--x -->
+|     "-->"
+
+#source tests2.dat:63
+#data
+<!doctype html><div><form></form><div></div></div>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       <form>
+|       <div>
+
+#source tests3.dat:3
+#data
+<head></head><!-- --><style></style><!-- --><script></script>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,28): unexpected-start-tag-out-of-my-head
+(1,52): unexpected-start-tag-out-of-my-head
+#document
+| <html>
+|   <head>
+|     <style>
+|     <script>
+|   <!--   -->
+|   <!--   -->
+|   <body>
+
+#source tests6.dat:1
+#data
+<!doctype html></head> <head>
+#errors
+(1,29): unexpected-start-tag
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   " "
+|   <body>
+#source tests3.dat:4
+#data
+<head></head><!-- -->x<style></style><!-- --><script></script>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <!--   -->
+|   <body>
+|     "x"
+|     <style>
+|     <!--   -->
+|     <script>
+
+#source tests3.dat:5
+#data
+<!DOCTYPE html><html><head></head><body><pre>
+</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+
+#source tests3.dat:6
+#data
+<!DOCTYPE html><html><head></head><body><pre>
+foo</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "foo"
+
+#source tests3.dat:7
+#data
+<!DOCTYPE html><html><head></head><body><pre>
+
+foo</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "
+foo"
+
+#source tests3.dat:8
+#data
+<!DOCTYPE html><html><head></head><body><pre>
+foo
+</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "foo
+"
+
+#source tests3.dat:9
+#data
+<!DOCTYPE html><html><head></head><body><pre>x</pre><span>
+</span></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "x"
+|     <span>
+|       "
+"
+
+#source tests3.dat:10
+#data
+<!DOCTYPE html><html><head></head><body><pre>x
+y</pre></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "x
+y"
+
+#source tests3.dat:11
+#data
+<!DOCTYPE html><html><head></head><body><pre>x<div>
+y</pre></body></html>
+#errors
+(2,7): end-tag-too-early
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "x"
+|       <div>
+|         "
+y"
+
+#source tests3.dat:12
+#data
+<!DOCTYPE html><pre>&#x0a;&#x0a;A</pre>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <pre>
+|       "
+A"
+
+#source tests3.dat:13
+#data
+<!DOCTYPE html><HTML><META><HEAD></HEAD></HTML>
+#errors
+(1,33): two-heads-are-not-better-than-one
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <meta>
+|   <body>
+
+#source tests3.dat:14
+#data
+<!DOCTYPE html><HTML><HEAD><head></HEAD></HTML>
+#errors
+(1,33): two-heads-are-not-better-than-one
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+
+#source tests3.dat:15
+#data
+<textarea>foo<span>bar</span><i>baz
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(1,35): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+|       "foo<span>bar</span><i>baz"
+
+#source tests3.dat:16
+#data
+<title>foo<span>bar</em><i>baz
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,30): expected-named-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|     <title>
+|       "foo<span>bar</em><i>baz"
+|   <body>
+
+#source tests3.dat:17
+#data
+<!DOCTYPE html><textarea>
+</textarea>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+
+#source tests3.dat:18
+#data
+<!DOCTYPE html><textarea>
+foo</textarea>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+|       "foo"
+
+#source tests3.dat:19
+#data
+<!DOCTYPE html><textarea>
+
+foo</textarea>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <textarea>
+|       "
+foo"
+
+#source tests3.dat:20
+#data
+<!DOCTYPE html><html><head></head><body><ul><li><div><p><li></ul></body></html>
+#errors
+(1,60): end-tag-too-early
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <ul>
+|       <li>
+|         <div>
+|           <p>
+|       <li>
+
+#source tests3.dat:21
+#data
+<!doctype html><nobr><nobr><nobr>
+#errors
+(1,27): unexpected-start-tag-implies-end-tag
+(1,33): unexpected-start-tag-implies-end-tag
+(1,33): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <nobr>
+|     <nobr>
+|     <nobr>
+
+#source tests3.dat:22
+#data
+<!doctype html><nobr><nobr></nobr><nobr>
+#errors
+(1,27): unexpected-start-tag-implies-end-tag
+(1,40): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <nobr>
+|     <nobr>
+|     <nobr>
+
+#source tests3.dat:23
+#data
+<!doctype html><html><body><p><table></table></body></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|     <table>
+
+#source tests3.dat:24
+#data
+<p><table></table>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <table>


### PR DESCRIPTION
## Summary
- recover stray </p> inside table cells by inserting the implied empty paragraph into the active td/th instead of foster-parenting it before the table
- keep comments after an explicit </head> as html-level pre-body siblings while still allowing late style/script nodes to populate head
- preserve whitespace after an explicit head close as pre-body html text where html5lib expects it
- add 26 more html5lib tree-construction smoke cases: tests2.dat 61-63, tests3.dat 3-24, and tests6.dat 1

## Known next blockers
- tests6.dat:2: nested form recovery around </form> inside a div
- tests7.dat:2: foster-parenting <title> inside table
- tests8.dat:6: foster-parenting list items inside table

## Tests
- cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer