### PR TITLE
Wire Rust MACSYMA linsolve to cas-solve

### DIFF
--- a/code/packages/rust/macsyma-runtime/BUILD
+++ b/code/packages/rust/macsyma-runtime/BUILD
@@ -1,1 +1,1 @@
-cargo test -p coding-adventures-macsyma-runtime -- --nocapture
+cargo test -p cas-solve -p coding-adventures-macsyma-runtime -- --nocapture

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.1] - 2026-05-12
+
+### Added
+
+- Wired `linsolve` / `Solve(List(...), List(...))` to the Rust `cas-solve`
+  exact linear-system solver.
+- Added runtime coverage for integer systems, rational systems, and non-linear
+  fallback.
+
 ## [0.1.0] - 2026-05-08
 
 ### Added

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -6,6 +6,7 @@ description = "MACSYMA runtime session facade over the Rust symbolic VM"
 license = "MIT"
 
 [dependencies]
+cas-solve = { path = "../cas-solve" }
 cas-simplify = { path = "../cas-simplify" }
 cas-trig = { path = "../cas-trig" }
 coding-adventures-macsyma-compiler = { path = "../macsyma-compiler" }

--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -12,3 +12,8 @@ replacement pass. `%` resolves to the previous output, `%iN` resolves to the
 N-th recorded input expression, and `%oN` resolves to the N-th recorded output.
 The symbolic VM backend remains unchanged, so direct backend lookup of history
 names is intentionally out of scope for this Rust parity slice.
+
+The runtime also wires MACSYMA `linsolve`/`Solve(List(...), List(...))` calls to
+the Rust `cas-solve` exact linear-system solver. Supported systems return
+`List(Rule(variable, value), ...)`; unsupported or non-linear systems remain as
+unevaluated `Solve(...)` IR nodes.

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -8,12 +8,13 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use cas_simplify::simplify;
+use cas_solve::{solve_linear_system, SOLVE};
 use cas_trig::{expand_trig, trig_simplify};
 use coding_adventures_macsyma_compiler::{
     compile_macsyma_with_options, CompileError, CompileOptions, DISPLAY as COMPILER_DISPLAY,
     SUPPRESS as COMPILER_SUPPRESS,
 };
-use symbolic_ir::{apply, sym, IRApply, IRNode, ASSIGN, DEFINE, IF, POW};
+use symbolic_ir::{apply, sym, IRApply, IRNode, ASSIGN, DEFINE, IF, LIST, POW};
 use symbolic_vm::backend::{handler_fn, Backend, Handler};
 use symbolic_vm::handlers::build_handler_table;
 use symbolic_vm::VM;
@@ -323,6 +324,7 @@ impl MacsymaBackend {
         handlers.insert(SUPPRESS_HEAD.to_string(), handler_fn(suppress_handler));
         handlers.insert(EV.to_string(), handler_fn(ev_handler));
         handlers.insert(FLOAT_FUNC.to_string(), handler_fn(float_handler));
+        handlers.insert(SOLVE.to_string(), handler_fn(solve_handler));
         handlers.insert(SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(RAT_SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(TRIG_SIMPLIFY.to_string(), handler_fn(trig_simplify_handler));
@@ -337,7 +339,7 @@ impl MacsymaBackend {
             }),
         );
 
-        let held = [ASSIGN, DEFINE, IF, KILL, EV]
+        let held = [ASSIGN, DEFINE, IF, KILL, EV, SOLVE]
             .into_iter()
             .map(str::to_string)
             .collect();
@@ -595,6 +597,31 @@ fn trig_expand_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     expand_trig(&expr.args[0])
 }
 
+fn solve_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
+    let fallback = IRNode::Apply(Box::new(expr.clone()));
+    if expr.args.len() != 2 {
+        return fallback;
+    }
+
+    let Some(equations) = apply_with_head(&expr.args[0], LIST) else {
+        return fallback;
+    };
+    let Some(variables) = apply_with_head(&expr.args[1], LIST) else {
+        return fallback;
+    };
+    if !variables
+        .args
+        .iter()
+        .all(|variable| matches!(variable, IRNode::Symbol(_)))
+    {
+        return fallback;
+    }
+
+    solve_linear_system(&equations.args, &variables.args)
+        .map(|rules| apply(sym(LIST), rules))
+        .unwrap_or(fallback)
+}
+
 fn numer_fold(node: IRNode) -> IRNode {
     match node {
         IRNode::Integer(n) => IRNode::Float(n as f64),
@@ -640,6 +667,13 @@ fn is_head_name(head: &IRNode, expected: &str) -> bool {
 fn symbol_name(node: &IRNode) -> Option<&str> {
     match node {
         IRNode::Symbol(name) => Some(name),
+        _ => None,
+    }
+}
+
+fn apply_with_head<'a>(node: &'a IRNode, expected: &str) -> Option<&'a IRApply> {
+    match node {
+        IRNode::Apply(apply) if is_head_name(&apply.head, expected) => Some(apply),
         _ => None,
     }
 }

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -1,8 +1,9 @@
+use cas_solve::SOLVE;
 use coding_adventures_macsyma_runtime::{
     extend_macsyma_name_table, macsyma_name_table, MacsymaSession, EV, KILL,
 };
 use std::collections::HashMap;
-use symbolic_ir::{apply, int, rat, sym, ADD, DIV, MUL, POW};
+use symbolic_ir::{apply, int, rat, sym, ADD, DIV, EQUAL, LIST, MUL, POW, RULE, SUB};
 
 #[test]
 fn evaluates_arithmetic_program() {
@@ -215,4 +216,137 @@ fn manual_kill_and_ev_heads_are_first_class() {
     ]);
     assert_eq!(results[0].output, sym("done"));
     assert_eq!(results[1].output, symbolic_ir::flt(1.5));
+}
+
+#[test]
+fn evaluates_linsolve_linear_systems_through_cas_solve() {
+    let x = sym("x");
+    let y = sym("y");
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![apply(
+        sym("linsolve"),
+        vec![
+            apply(
+                sym(LIST),
+                vec![
+                    apply(
+                        sym(EQUAL),
+                        vec![apply(sym(ADD), vec![x.clone(), y.clone()]), int(3)],
+                    ),
+                    apply(
+                        sym(EQUAL),
+                        vec![apply(sym(SUB), vec![x.clone(), y.clone()]), int(1)],
+                    ),
+                ],
+            ),
+            apply(sym(LIST), vec![x.clone(), y.clone()]),
+        ],
+    )]);
+
+    assert_eq!(
+        results[0].input,
+        apply(
+            sym(SOLVE),
+            vec![
+                apply(
+                    sym(LIST),
+                    vec![
+                        apply(
+                            sym(EQUAL),
+                            vec![apply(sym(ADD), vec![x.clone(), y.clone()]), int(3)]
+                        ),
+                        apply(
+                            sym(EQUAL),
+                            vec![apply(sym(SUB), vec![x.clone(), y.clone()]), int(1)]
+                        ),
+                    ],
+                ),
+                apply(sym(LIST), vec![x.clone(), y.clone()]),
+            ],
+        )
+    );
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(LIST),
+            vec![
+                apply(sym(RULE), vec![x.clone(), int(2)]),
+                apply(sym(RULE), vec![y.clone(), int(1)]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn keeps_non_linear_solve_calls_unevaluated() {
+    let x = sym("x");
+    let expr = apply(
+        sym(SOLVE),
+        vec![
+            apply(
+                sym(LIST),
+                vec![apply(
+                    sym(EQUAL),
+                    vec![apply(sym(POW), vec![x.clone(), int(2)]), int(4)],
+                )],
+            ),
+            apply(sym(LIST), vec![x]),
+        ],
+    );
+
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![expr.clone()]);
+    assert_eq!(results[0].output, expr);
+}
+
+#[test]
+fn returns_rational_linsolve_results() {
+    let x = sym("x");
+    let y = sym("y");
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![apply(
+        sym(SOLVE),
+        vec![
+            apply(
+                sym(LIST),
+                vec![
+                    apply(
+                        sym(EQUAL),
+                        vec![
+                            apply(
+                                sym(ADD),
+                                vec![
+                                    apply(sym(MUL), vec![int(2), x.clone()]),
+                                    apply(sym(MUL), vec![int(3), y.clone()]),
+                                ],
+                            ),
+                            int(7),
+                        ],
+                    ),
+                    apply(
+                        sym(EQUAL),
+                        vec![
+                            apply(
+                                sym(SUB),
+                                vec![apply(sym(MUL), vec![int(4), x.clone()]), y.clone()],
+                            ),
+                            int(1),
+                        ],
+                    ),
+                ],
+            ),
+            apply(sym(LIST), vec![x.clone(), y.clone()]),
+        ],
+    )]);
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(LIST),
+            vec![
+                apply(sym(RULE), vec![x.clone(), rat(5, 7)]),
+                apply(sym(RULE), vec![y.clone(), rat(13, 7)]),
+            ],
+        )
+    );
 }


### PR DESCRIPTION
## Summary
- wire Rust MACSYMA `linsolve` / `Solve(List(...), List(...))` through `cas-solve` exact linear-system solving
- hold `Solve` arguments so `Equal(...)` systems reach the handler intact
- add runtime coverage for integer systems, rational systems, and non-linear fallback

## Validation
- `cargo test -p cas-solve -p coding-adventures-macsyma-runtime -- --nocapture` in `code/packages/rust`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-macsyma-linsolve.json` from `code/programs/go/build-tool`