### PR TITLE
Wire TypeScript MACSYMA inequality solve

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Wire `Solve(inequality, var)` to the TypeScript `cas-solve`
+  `trySolveInequality` handler for polynomial inequalities, returning
+  `List(...)` interval predicates and preserving unevaluated fallback behavior.
 - Wire `Solve(List(...), List(...))` / `linsolve` to the TypeScript
   `cas-solve` exact linear-system solver, returning `List(Rule(var, value))`
   for square systems and preserving unevaluated fallback behavior.

--- a/code/packages/typescript/macsyma-runtime/README.md
+++ b/code/packages/typescript/macsyma-runtime/README.md
@@ -12,5 +12,7 @@ This first runtime slice is intentionally small and browser-friendly:
 - pre-binds `%pi`, `%e`, and `%i`
 - dispatches `linsolve` / `Solve(List(...), List(...))` to the exact
   `cas-solve` linear-system solver
+- dispatches `Solve(inequality, var)` to the `cas-solve` polynomial
+  inequality solver for interval predicates
 - exposes a JSON helper whose recursive IR representation is safe for
   `JSON.stringify`

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -1,5 +1,5 @@
 import { compileMacsyma } from "@coding-adventures/macsyma-compiler";
-import { solveLinearSystem } from "@coding-adventures/cas-solve";
+import { solveLinearSystem, trySolveInequality } from "@coding-adventures/cas-solve";
 import {
   ACOS,
   ACOSH,
@@ -13,7 +13,11 @@ import {
   EXP,
   FACTOR,
   FALSE,
+  GREATER,
+  GREATER_EQUAL,
   INTEGRATE,
+  LESS,
+  LESS_EQUAL,
   LIST,
   LOG,
   SIN,
@@ -534,6 +538,12 @@ function makeEvHandler(): Handler {
 function solveHandler(_vm: VM, expr: IRApply): IRNode {
   if (expr.args.length !== 2) return expr;
   const [equationsNode, variablesNode] = expr.args;
+
+  if (variablesNode.kind === "symbol" && isInequality(equationsNode)) {
+    const solutions = trySolveInequality(equationsNode, variablesNode);
+    return solutions === null ? expr : app(LIST, solutions);
+  }
+
   if (!isList(equationsNode) || !isList(variablesNode)) return expr;
 
   const variables: IRSymbol[] = [];
@@ -544,6 +554,14 @@ function solveHandler(_vm: VM, expr: IRApply): IRNode {
 
   const rules = solveLinearSystem(equationsNode.args, variables);
   return rules === null ? expr : app(LIST, rules);
+}
+
+function isInequality(node: IRNode): node is IRApply {
+  return node.kind === "apply"
+    && (equals(node.head, LESS)
+      || equals(node.head, GREATER)
+      || equals(node.head, LESS_EQUAL)
+      || equals(node.head, GREATER_EQUAL));
 }
 
 function evalSupportedFlag(vm: VM, result: IRNode, head: IRSymbol): IRNode {

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   ADD,
   EQUAL,
+  GREATER,
+  GREATER_EQUAL,
+  LESS,
+  LESS_EQUAL,
   LIST,
   MUL,
   POW,
@@ -260,6 +264,58 @@ describe("macsyma-runtime", () => {
     const expr = app(SOLVE, [
       app(LIST, [app(EQUAL, [app(POW, [x, int(2)]), int(4)])]),
       app(LIST, [x]),
+    ]);
+
+    const [result] = session.evalStatements([expr]);
+    expect(result.output).toEqual(expr);
+  });
+
+  it("solves polynomial inequalities through the cas-solve handler", () => {
+    const x = sym("x");
+    const session = new MacsymaSession();
+    const [linear, quadratic, bounded, allReals] = session.evalStatements([
+      app(SOLVE, [
+        app(GREATER, [app(SUB, [x, int(1)]), int(0)]),
+        x,
+      ]),
+      app(SOLVE, [
+        app(GREATER, [app(SUB, [app(POW, [x, int(2)]), int(1)]), int(0)]),
+        x,
+      ]),
+      app(SOLVE, [
+        app(LESS_EQUAL, [app(SUB, [app(POW, [x, int(2)]), int(1)]), int(0)]),
+        x,
+      ]),
+      app(SOLVE, [
+        app(GREATER_EQUAL, [app(POW, [x, int(2)]), int(0)]),
+        x,
+      ]),
+    ]);
+
+    expect(linear.output).toEqual(app(LIST, [
+      app(GREATER, [x, int(1)]),
+    ]));
+    expect(quadratic.output).toEqual(app(LIST, [
+      app(LESS, [x, int(-1)]),
+      app(GREATER, [x, int(1)]),
+    ]));
+    expect(bounded.output).toEqual(app(LIST, [
+      app(sym("And"), [
+        app(GREATER_EQUAL, [x, int(-1)]),
+        app(LESS_EQUAL, [x, int(1)]),
+      ]),
+    ]));
+    expect(allReals.output).toEqual(app(LIST, [
+      app(GREATER_EQUAL, [int(0), int(0)]),
+    ]));
+  });
+
+  it("keeps unsupported inequality Solve calls unevaluated", () => {
+    const x = sym("x");
+    const session = new MacsymaSession();
+    const expr = app(SOLVE, [
+      app(GREATER, [app(sym("Sin"), [x]), int(0)]),
+      x,
     ]);
 
     const [result] = session.evalStatements([expr]);


### PR DESCRIPTION
## Summary
- route `Solve(inequality, var)` through the TypeScript `cas-solve` `trySolveInequality` handler
- return `List(...)` interval predicates for supported polynomial inequalities and keep unsupported calls unevaluated
- document the runtime surface alongside the existing `linsolve` / linear-system wiring

## Validation
- `npm test && npm run build` in `code/packages/typescript/macsyma-runtime`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-inequality-runtime.json` from `code/programs/go/build-tool`