### PR TITLE
[codex] Report Board VM smoke upload metadata

### DIFF
--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -820,6 +820,7 @@ fn parse_u32_number(value: String, option: &'static str) -> Result<u32, CliError
 pub struct SmokeReport {
     pub hello: HelloAckInfo,
     pub descriptor: BoardDescriptorInfo,
+    pub upload: UploadReport,
     pub run: RunReportInfo,
 }
 
@@ -1014,7 +1015,7 @@ where
                 source: source.into(),
             }
         })?;
-    client
+    let upload = client
         .upload_program(options.program_id, &module[..module_len])
         .map_err(|source| CliError::Smoke {
             stage: SmokeStage::UploadBlink,
@@ -1029,6 +1030,7 @@ where
     Ok(SmokeReport {
         hello,
         descriptor,
+        upload,
         run,
     })
 }
@@ -2422,6 +2424,9 @@ mod tests {
         assert_eq!(report.descriptor.board_id, LOOPBACK_BOARD_ID);
         assert_eq!(report.descriptor.runtime_id, LOOPBACK_RUNTIME_ID);
         assert_eq!(report.descriptor.max_program_bytes, 512);
+        assert_eq!(report.upload.program_id, 7);
+        assert_eq!(report.upload.total_len as usize, BLINK_MODULE_LEN);
+        assert_ne!(report.upload.program_crc32, 0);
         assert_eq!(report.run.program_id, 7);
         assert_eq!(report.run.status, RunStatus::Running);
         assert!(report.run.instructions_executed > 0);
@@ -2453,6 +2458,9 @@ mod tests {
         assert_eq!(report.hello.runtime_name, LOOPBACK_RUNTIME_ID);
         assert_eq!(report.hello.host_nonce, 0xABCD_1234);
         assert_eq!(report.descriptor.board_id, LOOPBACK_BOARD_ID);
+        assert_eq!(report.upload.program_id, 8);
+        assert_eq!(report.upload.total_len as usize, BLINK_MODULE_LEN);
+        assert_ne!(report.upload.program_crc32, 0);
         assert_eq!(report.run.program_id, 8);
         assert_eq!(report.run.status, RunStatus::Running);
         assert_eq!(report.run.open_handles, 1);
@@ -2510,6 +2518,9 @@ mod tests {
         assert_eq!(report.hello.runtime_name, LOOPBACK_RUNTIME_ID);
         assert_eq!(report.hello.host_nonce, 0xBEEF_CAFE);
         assert_eq!(report.descriptor.board_id, LOOPBACK_BOARD_ID);
+        assert_eq!(report.upload.program_id, 9);
+        assert_eq!(report.upload.total_len as usize, BLINK_MODULE_LEN);
+        assert_ne!(report.upload.program_crc32, 0);
         assert_eq!(report.run.program_id, 9);
         assert_eq!(report.run.status, RunStatus::Running);
         assert!(event_count > 0);

--- a/code/packages/rust/board-vm-cli/src/main.rs
+++ b/code/packages/rust/board-vm-cli/src/main.rs
@@ -100,6 +100,10 @@ fn run_command(command: CliCommand) -> Result<(), board_vm_cli::CliError> {
                 report.descriptor.capabilities.len()
             );
             println!(
+                "upload program_id={} bytes={} crc32=0x{:08X}",
+                report.upload.program_id, report.upload.total_len, report.upload.program_crc32
+            );
+            println!(
                 "blink program_id={} status={:?} instructions={} elapsed_ms={} open_handles={}",
                 report.run.program_id,
                 report.run.status,


### PR DESCRIPTION
## Summary
- preserve the upload report in Board VM smoke results
- print uploaded program bytes and CRC in the CLI smoke summary
- assert upload metadata across loopback, Bluetooth wire, and TCP endpoint smoke coverage

## Validation
- cargo test -p board-vm-cli
- cargo test -p board-vm-language-core -p board-vm-bluetooth -p board-vm-tcp
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check