### PR TITLE
feat(spice-engine): add controlled sources VCVS/VCCS/CCCS/CCVS (v0.10.0)

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## [0.10.0] — 2026-05-12
+
+### Added
+
+- **Four controlled (dependent) source elements** — the full set of SPICE
+  E/G/F/H elements is now available:
+
+  | Class | SPICE letter | Type | Controlling quantity |
+  |-------|-------------|------|----------------------|
+  | `VCVS` | E | Voltage-Controlled Voltage Source | `V(ctrl+) − V(ctrl−)` |
+  | `VCCS` | G | Voltage-Controlled Current Source | `V(ctrl+) − V(ctrl−)` |
+  | `CCCS` | F | Current-Controlled Current Source | `I(ctrl_source)` |
+  | `CCVS` | H | Current-Controlled Voltage Source | `I(ctrl_source)` |
+
+  All four sources work across every analysis type: DC operating point,
+  DC sweep, AC sweep, transient, `.TF`, `.SENS`, `.MC`, and `.NOISE`.
+
+  **VCVS** (`E` element) — voltage follower / amplifier:
+  ```
+  V(n_plus, n_minus) = gain × [V(ctrl_plus) − V(ctrl_minus)]
+  ```
+  Introduces a new MNA branch unknown (like `VoltageSource`).  Used to
+  model op-amps, buffers, and any ideal voltage amplifier.
+
+  **VCCS** (`G` element) — transconductance amplifier:
+  ```
+  I(n_plus → n_minus) = gm × [V(ctrl_plus) − V(ctrl_minus)]
+  ```
+  No branch unknown needed; stamps off-diagonal entries in the MNA G
+  matrix.  Identical primitive to the internal `gm` stamp used for
+  MOSFETs and BJTs.  Used for op-amp macromodels, FET small-signal
+  models, etc.
+
+  **CCCS** (`F` element) — current mirror / current amplifier:
+  ```
+  I(n_plus → n_minus) = beta × I(ctrl_source)
+  ```
+  The controlling current is the branch current of a named
+  `VoltageSource` (use a 0 V source as an ideal ammeter).  No new
+  branch unknown.  Node convention: positive current flows FROM
+  `n_plus` through the external circuit TO `n_minus` (SPICE standard).
+
+  **CCVS** (`H` element) — transresistance amplifier:
+  ```
+  V(n_plus, n_minus) = transresistance × I(ctrl_source)
+  ```
+  Introduces a new MNA branch unknown.  Used to model transimpedance
+  amplifiers, current-to-voltage converters, etc.
+
+- **`TfResult.gain` property** — convenient alias for
+  `TfResult.transfer_ratio` (dimensionless voltage gain when the input
+  is a `VoltageSource`).  Both names are now valid; `transfer_ratio` is
+  retained for backward compatibility.
+
+### Fixed
+
+- **CCCS MNA stamp sign** — the previous stamp had reversed polarity:
+  it injected current at `n_minus` instead of `n_plus`, contradicting
+  both the docstring (`I(n_plus → n_minus) = beta × I_ctrl`) and the
+  SPICE `F` element convention.  The corrected stamp uses `−beta` at
+  `n_plus` and `+beta` at `n_minus` so that current correctly exits
+  `n_plus` into the external circuit.  Existing circuits that worked
+  around the old sign by swapping n_plus/n_minus should be updated to
+  use the standard SPICE node order.
+
+---
+
 ## [0.9.0] — 2026-05-08
 
 ### Added

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -1,6 +1,10 @@
 # spice-engine
 
-SPICE-compatible analog circuit simulator. Modified Nodal Analysis (MNA) with Newton-Raphson DC operating-point solver and forward-Euler transient analysis.
+SPICE-compatible analog circuit simulator. Modified Nodal Analysis (MNA) with
+Newton-Raphson DC, trapezoidal transient, AC small-signal sweep, DC transfer
+function (`.TF`), DC parameter sweep (`.DC`), sensitivity analysis (`.SENS`),
+Monte Carlo (`.MC`), noise analysis (`.NOISE`), and all four SPICE controlled
+sources (VCVS / VCCS / CCCS / CCVS).
 
 See [`code/specs/spice-engine.md`](../../../specs/spice-engine.md).
 
@@ -9,7 +13,7 @@ See [`code/specs/spice-engine.md`](../../../specs/spice-engine.md).
 ```python
 from spice_engine import Circuit, Resistor, VoltageSource, dc_op
 
-# Voltage divider: V1 = 10V, R1 = 1k, R2 = 1k -> V_mid should be 5V
+# Voltage divider: V1 = 10V, R1 = 1k, R2 = 1k -> V_mid = 5V
 circuit = Circuit()
 circuit.add(VoltageSource("V1", "vin", "0", voltage=10.0))
 circuit.add(Resistor("R1", "vin", "vmid", 1000.0))
@@ -17,30 +21,110 @@ circuit.add(Resistor("R2", "vmid", "0", 1000.0))
 
 result = dc_op(circuit)
 print(result.node_voltages)        # {"vin": 10.0, "vmid": 5.0}
-print(result.branch_currents)      # {"I(V1)": -0.005}  (5 mA flowing in)
-print(result.converged)
+print(result.branch_currents)      # {"I(V1)": -0.005}
+print(result.converged)            # True
 ```
 
-## v0.1.0 scope
+## Supported elements
 
-- Element classes: `Resistor`, `Capacitor`, `Inductor`, `VoltageSource`, `CurrentSource`, `Diode` (Shockley), `Mosfet` (uses mosfet_models.MOSFET).
-- `Circuit` container with `add()`.
-- MNA matrix construction (one stamp function per element type).
-- Gaussian elimination linear solver with partial pivoting.
-- `dc_op(circuit, max_iterations, tol)`: Newton-Raphson DC solver. Iterates linearization until x converges to within tol.
-- `transient(circuit, t_stop, t_step)`: forward-Euler with capacitor companion models (C/h conductance + history current source).
-- Diode + MOSFET nonlinearities handled via Newton iteration.
-- Ground node identifiers: `'0'`, `'gnd'`, `'GND'`.
+| Class | SPICE | Description |
+|-------|-------|-------------|
+| `Resistor` | R | Ohmic resistor |
+| `Capacitor` | C | Linear capacitor (with optional initial voltage) |
+| `Inductor` | L | Linear inductor |
+| `VoltageSource` | V | Independent voltage source |
+| `CurrentSource` | I | Independent current source |
+| `Diode` | D | Shockley diode model |
+| `Mosfet` | M | MOSFET (uses `mosfet_models.MOSFET`) |
+| `BJT` | Q | Bipolar transistor (simplified Ebers-Moll) |
+| `VCVS` | E | Voltage-Controlled Voltage Source |
+| `VCCS` | G | Voltage-Controlled Current Source |
+| `CCCS` | F | Current-Controlled Current Source |
+| `CCVS` | H | Current-Controlled Voltage Source |
 
-## Out of scope (v0.2.0)
+## Supported analyses
 
-- AC analysis (.ac) with frequency sweep.
-- Backward-Euler / trapezoidal / Gear-2 transient methods.
-- Adaptive timestep with LTE control.
-- Convergence aids: Gmin stepping, source stepping, pseudo-transient continuation.
-- SPICE3 netlist parser (`.tran`, `.dc`, `.ac` directives).
-- BJTs, JFETs.
-- Verilog-A behavioral models.
-- Sparse matrix solver (currently O(n³) Gaussian elimination).
+| Function | SPICE | Description |
+|----------|-------|-------------|
+| `dc_op` | `.OP` | DC operating point (Newton-Raphson) |
+| `transient` | `.TRAN` | Time-domain transient (trapezoidal/BE, adaptive timestep) |
+| `ac_sweep` | `.AC` | Small-signal AC frequency sweep |
+| `tf` | `.TF` | DC transfer function, input/output impedance |
+| `dc_sweep` | `.DC` | DC parameter sweep |
+| `sens_dc` | `.SENS` | DC sensitivity analysis |
+| `mc_dc` | `.MC` | Monte Carlo DC analysis |
+| `noise_ac` | `.NOISE` | Small-signal noise PSD (adjoint method) |
+
+## Controlled source examples
+
+### VCVS — unity-gain buffer
+
+```python
+from spice_engine import Circuit, VoltageSource, VCVS, Resistor, dc_op
+
+c = Circuit([
+    VoltageSource("Vin", "in", "0", 5.0),
+    VCVS("E1", "out", "0", ctrl_plus="in", ctrl_minus="0", gain=1.0),
+    Resistor("Rload", "out", "0", 1000.0),
+])
+r = dc_op(c)
+print(r.node_voltages["out"])   # 5.0 V — perfect buffer
+```
+
+### VCCS — transconductance amplifier
+
+```python
+from spice_engine import Circuit, VoltageSource, VCCS, Resistor, dc_op
+
+c = Circuit([
+    VoltageSource("Vin", "in", "0", 1.0),
+    VCCS("G1", "out", "0", ctrl_plus="in", ctrl_minus="0", gm=0.01),
+    Resistor("Rout", "out", "0", 1000.0),
+])
+r = dc_op(c)
+print(r.node_voltages["out"])   # 10.0 V  (gm * Vin * Rout = 0.01 * 1 * 1000)
+```
+
+### CCCS — current mirror
+
+```python
+from spice_engine import Circuit, VoltageSource, Resistor, CCCS, dc_op
+
+c = Circuit([
+    VoltageSource("Vin", "in", "0", 1.0),
+    Resistor("Rin", "in", "mid", 1000.0),
+    VoltageSource("Vsense", "mid", "0", 0.0),   # 0 V ammeter
+    CCCS("F1", "out", "0", ctrl_source="Vsense", beta=2.0),
+    Resistor("Rload", "out", "0", 500.0),
+])
+r = dc_op(c)
+# I_ctrl = 1V/1kΩ = 1mA; I_out = 2 * 1mA = 2mA; V_out = 2mA * 500Ω = 1V
+print(r.node_voltages["out"])   # 1.0 V
+```
+
+### CCVS — transresistance amplifier
+
+```python
+from spice_engine import Circuit, VoltageSource, Resistor, CCVS, dc_op
+
+c = Circuit([
+    VoltageSource("Vin", "in", "0", 1.0),
+    Resistor("Rin", "in", "mid", 1000.0),
+    VoltageSource("Vsense", "mid", "0", 0.0),
+    CCVS("H1", "out", "0", ctrl_source="Vsense", transresistance=500.0),
+    Resistor("Rload", "out", "0", 100.0),
+])
+r = dc_op(c)
+# V_out = rm * I_ctrl = 500 * 1mA = 0.5V
+print(r.node_voltages["out"])   # 0.5 V
+```
+
+## Node conventions
+
+- Ground is any of `"0"`, `"gnd"`, or `"GND"`.
+- CCCS and CCVS use a `VoltageSource` named `ctrl_source` as an ideal ammeter
+  (set its voltage to `0.0`).
+- CCCS node convention: `F1 n+ n-` → positive current exits `n_plus` into the
+  external circuit (same as SPICE F element).
 
 MIT.

--- a/code/packages/python/spice-engine/pyproject.toml
+++ b/code/packages/python/spice-engine/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-spice-engine"
-version = "0.9.0"
-description = "SPICE-compatible analog circuit simulator with MNA + Newton-Raphson DC + transient + AC small-signal sweep + DC transfer function (.TF) + DC parameter sweep (.DC) + DC sensitivity analysis (.SENS) + Monte Carlo (.MC) + noise analysis (.NOISE)."
+version = "0.10.0"
+description = "SPICE-compatible analog circuit simulator with MNA + Newton-Raphson DC + transient + AC small-signal sweep + DC transfer function (.TF) + DC parameter sweep (.DC) + DC sensitivity analysis (.SENS) + Monte Carlo (.MC) + noise analysis (.NOISE) + controlled sources (VCVS, VCCS, CCCS, CCVS)."
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -1,7 +1,11 @@
-"""spice-engine: SPICE-compatible analog simulator (MNA + DC + transient + AC + DC sweep + .SENS + .MC + .NOISE)."""
+"""spice-engine: SPICE-compatible analog simulator (MNA + DC + transient + AC + DC sweep + .SENS + .MC + .NOISE + controlled sources)."""
 
 from spice_engine.elements import (
     BJT,
+    CCCS,
+    CCVS,
+    VCCS,
+    VCVS,
     Capacitor,
     CurrentSource,
     Diode,
@@ -38,12 +42,14 @@ from spice_engine.engine import (
     transient,
 )
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 __all__ = [
     "AcPoint",
     "AcResult",
     "BJT",
+    "CCCS",
+    "CCVS",
     "Capacitor",
     "Circuit",
     "CurrentSource",
@@ -65,6 +71,8 @@ __all__ = [
     "TfResult",
     "TransientPoint",
     "TransientResult",
+    "VCCS",
+    "VCVS",
     "VoltageSource",
     "__version__",
     "ac_sweep",

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -147,6 +147,237 @@ class BJT:
     Vt: float = 0.02585     # thermal voltage (V) at ~300 K
 
 
+# ---------------------------------------------------------------------------
+# Controlled (dependent) sources — SPICE E / G / F / H elements
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class VCVS:
+    """Voltage-Controlled Voltage Source (SPICE ``E`` element).
+
+    The output voltage is proportional to the voltage difference between two
+    controlling nodes:
+
+        V(n_plus, n_minus) = gain × [V(ctrl_plus) − V(ctrl_minus)]
+
+    MNA stamp
+    ---------
+    Like an independent VoltageSource, a VCVS introduces a **branch unknown**
+    for its output current (call it ``I_k``).  The KVL constraint equation
+    and the output-port KCL rows look like this in the MNA matrix::
+
+        row n_plus  : … + I_k = 0
+        row n_minus : … − I_k = 0
+        row k (KVL) : V_n_plus − V_n_minus
+                      − gain × V_ctrl_plus + gain × V_ctrl_minus = 0
+
+    In matrix notation (with column indices for ctrl_plus / ctrl_minus
+    written as ``cp`` / ``cm``)::
+
+        G[n_plus][k]   +=  1       (KCL: I_k exits n_plus)
+        G[n_minus][k]  -=  1       (KCL: I_k enters n_minus)
+        G[k][n_plus]   +=  1       (KVL: +V_n_plus)
+        G[k][n_minus]  -=  1       (KVL: −V_n_minus)
+        G[k][cp]       -=  gain    (KVL: −gain × V_ctrl_plus)
+        G[k][cm]       +=  gain    (KVL: +gain × V_ctrl_minus)
+        b[k]            =  0       (KVL RHS: ideal V-source → always 0)
+
+    The branch unknown index ``k`` is ``n_nodes + position`` where
+    ``position`` is the element's index in the ``_branch_sources`` list.
+
+    Parameters
+    ----------
+    name:
+        Instance name, e.g. ``"E1"``.
+    n_plus, n_minus:
+        Output port nodes (positive and negative terminals).
+    ctrl_plus, ctrl_minus:
+        Controlling (sensing) port nodes.
+    gain:
+        Dimensionless voltage gain (can be negative for inverting behaviour).
+
+    Examples
+    --------
+    Unity-gain buffer (voltage follower):
+
+        E1 out 0 in 0 1.0
+
+    Inverting amplifier with gain −10:
+
+        E_amp out 0 in 0 -10.0
+    """
+
+    name: str
+    n_plus: str    # output positive
+    n_minus: str   # output negative
+    ctrl_plus: str   # controlling node +
+    ctrl_minus: str  # controlling node −
+    gain: float    # dimensionless voltage gain
+
+
+@dataclass(frozen=True, slots=True)
+class VCCS:
+    """Voltage-Controlled Current Source (SPICE ``G`` element).
+
+    The output current is proportional to the voltage difference between two
+    controlling nodes:
+
+        I(n_plus → n_minus) = gm × [V(ctrl_plus) − V(ctrl_minus)]
+
+    MNA stamp
+    ---------
+    A VCCS does **not** introduce a branch unknown — it contributes only
+    conductance (off-diagonal) entries into the MNA G matrix.  These entries
+    implement the current injection in KCL::
+
+        G[n_plus][ctrl_plus]   +=  gm
+        G[n_plus][ctrl_minus]  -=  gm
+        G[n_minus][ctrl_plus]  -=  gm
+        G[n_minus][ctrl_minus] +=  gm
+
+    This is identical to the MOSFET/BJT transconductance stamp used internally
+    by ``_stamp_bjt`` and ``_stamp_mosfet``.  A standalone ``VCCS`` element
+    exposes the same primitive to circuit users (op-amp macromodels, etc.).
+
+    Parameters
+    ----------
+    name:
+        Instance name, e.g. ``"G1"``.
+    n_plus, n_minus:
+        Output port nodes.  Positive current flows from n_plus through the
+        external circuit to n_minus.
+    ctrl_plus, ctrl_minus:
+        Controlling (sensing) port nodes.
+    gm:
+        Transconductance in Siemens (A/V).
+
+    Examples
+    --------
+    VCCS with gm = 0.1 A/V, controlled by the differential voltage "in"−"0":
+
+        G1 out 0 in 0 0.1
+
+    Two-port macromodel amplifier (control port + output port):
+
+        Rin  in   0  1e6   # high-impedance input
+        G1   out  0  in 0  0.02   # gm = 20 mA/V
+        Rout out  0  5000  # 5 kΩ output resistance
+    """
+
+    name: str
+    n_plus: str    # output positive
+    n_minus: str   # output negative
+    ctrl_plus: str   # controlling node +
+    ctrl_minus: str  # controlling node −
+    gm: float      # transconductance (A/V)
+
+
+@dataclass(frozen=True, slots=True)
+class CCCS:
+    """Current-Controlled Current Source (SPICE ``F`` element).
+
+    The output current is proportional to the current flowing through a
+    designated controlling element (a ``VoltageSource`` used as an ammeter):
+
+        I(n_plus → n_minus) = beta × I(ctrl_source)
+
+    where ``I(ctrl_source)`` is the branch current of the controlling
+    ``VoltageSource`` (positive = current flowing into its ``n_plus`` terminal
+    in the MNA convention).
+
+    MNA stamp
+    ---------
+    Because the controlling current is already a branch unknown ``x[k_ctrl]``
+    (the column corresponding to the controlling ``VoltageSource``), a CCCS
+    adds off-diagonal entries in the MNA rows for its output nodes::
+
+        G[n_plus][k_ctrl]   +=  beta
+        G[n_minus][k_ctrl]  -=  beta
+
+    No new branch unknown is needed.  The controlling ``VoltageSource`` is
+    typically a 0 V source inserted purely as an ideal ammeter::
+
+        V_sense  mid  mid_2  0.0   # 0 V, just measures current
+        F1       out  0      V_sense  beta
+
+    Parameters
+    ----------
+    name:
+        Instance name, e.g. ``"F1"``.
+    n_plus, n_minus:
+        Output port nodes.
+    ctrl_source:
+        **Name** of the controlling ``VoltageSource`` (e.g. ``"V_sense"``).
+        A ``ValueError`` is raised at simulation time if no ``VoltageSource``
+        with this name exists in the circuit.
+    beta:
+        Dimensionless current gain.
+
+    Examples
+    --------
+    Current mirror (simplified):
+
+        V_sense  a  b  0.0       # 0 V ammeter in controlling branch
+        F1       c  0  V_sense   2.0   # mirror with gain 2
+    """
+
+    name: str
+    n_plus: str    # output positive
+    n_minus: str   # output negative
+    ctrl_source: str  # name of controlling VoltageSource
+    beta: float    # dimensionless current gain
+
+
+@dataclass(frozen=True, slots=True)
+class CCVS:
+    """Current-Controlled Voltage Source (SPICE ``H`` element).
+
+    The output voltage is proportional to the current flowing through a
+    designated controlling element (a ``VoltageSource`` used as an ammeter):
+
+        V(n_plus, n_minus) = transresistance × I(ctrl_source)
+
+    MNA stamp
+    ---------
+    Like a VCVS, a CCVS introduces a **branch unknown** for its own output
+    current (call it ``I_k``).  The KVL equation references the controlling
+    branch current ``x[k_ctrl]``::
+
+        G[n_plus][k]       +=  1
+        G[n_minus][k]      -=  1
+        G[k][n_plus]       +=  1
+        G[k][n_minus]      -=  1
+        G[k][k_ctrl]       -=  transresistance   (KVL: −rm × I_ctrl)
+        b[k]                =  0
+
+    Reading the KVL row: ``V_n_plus − V_n_minus − rm × x[k_ctrl] = 0``.
+
+    Parameters
+    ----------
+    name:
+        Instance name, e.g. ``"H1"``.
+    n_plus, n_minus:
+        Output port nodes.
+    ctrl_source:
+        **Name** of the controlling ``VoltageSource`` (e.g. ``"V_sense"``).
+    transresistance:
+        Transresistance (transimpedance) in Ohms.
+
+    Examples
+    --------
+    Transresistance amplifier with rm = 1000 Ω:
+
+        V_sense  in  0  0.0         # 0 V ammeter, measures input current
+        H1       out 0  V_sense  1000.0
+    """
+
+    name: str
+    n_plus: str    # output positive
+    n_minus: str   # output negative
+    ctrl_source: str  # name of controlling VoltageSource
+    transresistance: float  # Ohms
+
+
 Element = (
     Resistor
     | Capacitor
@@ -156,4 +387,8 @@ Element = (
     | Diode
     | Mosfet
     | BJT
+    | VCVS
+    | VCCS
+    | CCCS
+    | CCVS
 )

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -55,6 +55,10 @@ from dataclasses import dataclass, field
 
 from spice_engine.elements import (
     BJT,
+    CCCS,
+    CCVS,
+    VCCS,
+    VCVS,
     Capacitor,
     CurrentSource,
     Diode,
@@ -194,6 +198,11 @@ class TfResult:
     output_impedance: float
     converged: bool = True
 
+    @property
+    def gain(self) -> float:
+        """Alias for :attr:`transfer_ratio` — convenient shorthand for voltage gain."""
+        return self.transfer_ratio
+
 
 @dataclass(frozen=True)
 class DcSweepPoint:
@@ -299,11 +308,52 @@ def _element_nodes(el: Element) -> list[str]:
         return [el.drain, el.gate, el.source, el.body]
     if isinstance(el, BJT):
         return [el.collector, el.base, el.emitter]
+    if isinstance(el, (VCVS, VCCS)):
+        # Both output nodes and controlling nodes become part of the circuit
+        return [el.n_plus, el.n_minus, el.ctrl_plus, el.ctrl_minus]
+    if isinstance(el, (CCCS, CCVS)):
+        # Output nodes only (controlling branch is referenced by name, not nodes)
+        return [el.n_plus, el.n_minus]
     return []
 
 
 def _voltage_sources(circuit: Circuit) -> list[VoltageSource]:
+    """Return all independent VoltageSource elements (for sens/mc perturbation)."""
     return [el for el in circuit.elements if isinstance(el, VoltageSource)]
+
+
+def _branch_sources(
+    circuit: Circuit,
+) -> list[VoltageSource | VCVS | CCVS]:
+    """Elements that require a branch unknown (current variable) in MNA.
+
+    All three element types introduce a KVL constraint row and a corresponding
+    branch-current column in the MNA matrix.  The ordering is stable:
+
+        1. All ``VoltageSource`` elements (preserves existing branch indices)
+        2. All ``VCVS`` elements
+        3. All ``CCVS`` elements
+
+    The branch index for an element ``el`` is::
+
+        branch_idx = n_nodes + _branch_sources(circuit).index(el)
+
+    where ``n_nodes = len(_node_index(circuit)[0])``.
+
+    Note: ``CCCS`` (F element) does **not** appear here because it only adds
+    off-diagonal conductance entries and needs no branch unknown of its own.
+    ``VCCS`` (G element) likewise needs no branch unknown.
+    """
+    vsrcs: list[VoltageSource | VCVS | CCVS] = [
+        el for el in circuit.elements if isinstance(el, VoltageSource)
+    ]
+    vcvs_list: list[VoltageSource | VCVS | CCVS] = [
+        el for el in circuit.elements if isinstance(el, VCVS)
+    ]
+    ccvs_list: list[VoltageSource | VCVS | CCVS] = [
+        el for el in circuit.elements if isinstance(el, CCVS)
+    ]
+    return vsrcs + vcvs_list + ccvs_list
 
 
 def _is_ground(name: str) -> bool:
@@ -323,9 +373,9 @@ def dc_op(
 ) -> DcResult:
     """Solve DC operating point via Newton-Raphson on a linearized MNA."""
     node_to_idx, nodes = _node_index(circuit)
-    vsrcs = _voltage_sources(circuit)
+    branch_srcs = _branch_sources(circuit)
     n = len(nodes)
-    m = len(vsrcs)
+    m = len(branch_srcs)
     size = n + m
 
     # Initial guess: all zeros
@@ -337,13 +387,13 @@ def dc_op(
         b = [0.0] * size
 
         for el in circuit.elements:
-            _stamp_dc(el, G, b, x, node_to_idx, vsrcs)
+            _stamp_dc(el, G, b, x, node_to_idx, branch_srcs)
 
         # Solve G x_new = b via Gaussian elimination.
         try:
             x_new = _solve(G, b)
         except ZeroDivisionError:
-            return DcResult({n: x[i] for n, i in node_to_idx.items()},
+            return DcResult({nd: x[i] for nd, i in node_to_idx.items()},
                             {}, iterations=it, converged=False)
 
         # Check convergence
@@ -352,8 +402,8 @@ def dc_op(
         if max_delta < tol:
             break
 
-    node_v = {n: x[i] for n, i in node_to_idx.items()}
-    branch_i = {f"I({vs.name})": x[n + i] for i, vs in enumerate(vsrcs)}
+    node_v = {nd: x[i] for nd, i in node_to_idx.items()}
+    branch_i = {f"I({el.name})": x[n + i] for i, el in enumerate(branch_srcs)}
     return DcResult(node_v, branch_i, iterations=it + 1, converged=max_delta < tol)
 
 
@@ -363,14 +413,15 @@ def _stamp_dc(
     b: list[float],
     x: list[float],
     node_to_idx: dict[str, int],
-    vsrcs: list[VoltageSource],
+    branch_srcs: list[VoltageSource | VCVS | CCVS],
 ) -> None:
     """Stamp one element's MNA contribution at the current operating point."""
+    n_nodes = len(node_to_idx)
     if isinstance(el, Resistor):
         _stamp_g(G, node_to_idx, el.n_plus, el.n_minus, 1.0 / el.resistance)
     elif isinstance(el, VoltageSource):
-        i = vsrcs.index(el)
-        _stamp_vsrc(G, b, node_to_idx, el, len(node_to_idx) + i)
+        i = branch_srcs.index(el)
+        _stamp_vsrc(G, b, node_to_idx, el, n_nodes + i)
     elif isinstance(el, CurrentSource):
         if not _is_ground(el.n_plus):
             b[node_to_idx[el.n_plus]] -= el.current
@@ -382,6 +433,31 @@ def _stamp_dc(
         _stamp_mosfet(G, b, x, node_to_idx, el)
     elif isinstance(el, BJT):
         _stamp_bjt(G, b, x, node_to_idx, el)
+    elif isinstance(el, VCCS):
+        _stamp_vccs(G, node_to_idx, el.n_plus, el.n_minus,
+                    el.ctrl_plus, el.ctrl_minus, el.gm)
+    elif isinstance(el, VCVS):
+        i = branch_srcs.index(el)
+        _stamp_vcvs(G, b, node_to_idx, el, n_nodes + i)
+    elif isinstance(el, CCCS):
+        ctrl_el = _find_branch_source(branch_srcs, el.ctrl_source)
+        if ctrl_el is None:
+            raise ValueError(
+                f"CCCS '{el.name}' references controlling source "
+                f"'{el.ctrl_source}' which does not exist in the circuit."
+            )
+        ctrl_idx = n_nodes + branch_srcs.index(ctrl_el)
+        _stamp_cccs(G, node_to_idx, el, ctrl_idx)
+    elif isinstance(el, CCVS):
+        i = branch_srcs.index(el)
+        ctrl_el = _find_branch_source(branch_srcs, el.ctrl_source)
+        if ctrl_el is None:
+            raise ValueError(
+                f"CCVS '{el.name}' references controlling source "
+                f"'{el.ctrl_source}' which does not exist in the circuit."
+            )
+        ctrl_idx = n_nodes + branch_srcs.index(ctrl_el)
+        _stamp_ccvs(G, b, node_to_idx, el, n_nodes + i, ctrl_idx)
     elif isinstance(el, Capacitor):
         # In DC, capacitors are open circuits — no conductance contribution
         pass
@@ -423,6 +499,155 @@ def _stamp_vsrc(
         G[j][branch_idx] = -1.0
         G[branch_idx][j] = -1.0
     b[branch_idx] = el.voltage
+
+
+# ---------------------------------------------------------------------------
+# Controlled-source MNA stamps
+# ---------------------------------------------------------------------------
+
+
+def _find_branch_source(
+    branch_srcs: list[VoltageSource | VCVS | CCVS],
+    name: str,
+) -> VoltageSource | VCVS | CCVS | None:
+    """Return the branch-source element with the given name, or None."""
+    for el in branch_srcs:
+        if el.name == name:
+            return el
+    return None
+
+
+def _stamp_vccs(
+    G: list[list[float]],
+    node_to_idx: dict[str, int],
+    n_plus: str,
+    n_minus: str,
+    ctrl_plus: str,
+    ctrl_minus: str,
+    gm: float,
+) -> None:
+    """Stamp a VCCS: I(n_plus→n_minus) = gm × [V(ctrl_plus) − V(ctrl_minus)].
+
+    MNA off-diagonal entries (no branch unknown needed):
+
+        G[n_plus][ctrl_plus]   +=  gm
+        G[n_plus][ctrl_minus]  -=  gm
+        G[n_minus][ctrl_plus]  -=  gm
+        G[n_minus][ctrl_minus] +=  gm
+
+    This is the same stamp used internally for MOSFET/BJT transconductance.
+    """
+    if not _is_ground(n_plus):
+        rp = node_to_idx[n_plus]
+        if not _is_ground(ctrl_plus):
+            G[rp][node_to_idx[ctrl_plus]] += gm
+        if not _is_ground(ctrl_minus):
+            G[rp][node_to_idx[ctrl_minus]] -= gm
+    if not _is_ground(n_minus):
+        rm = node_to_idx[n_minus]
+        if not _is_ground(ctrl_plus):
+            G[rm][node_to_idx[ctrl_plus]] -= gm
+        if not _is_ground(ctrl_minus):
+            G[rm][node_to_idx[ctrl_minus]] += gm
+
+
+def _stamp_vcvs(
+    G: list[list[float]],
+    b: list[float],
+    node_to_idx: dict[str, int],
+    el: VCVS,
+    branch_idx: int,
+) -> None:
+    """Stamp a VCVS: V(n_plus,n_minus) = gain × [V(ctrl_plus) − V(ctrl_minus)].
+
+    KCL rows for the output port (identical to VoltageSource structure):
+
+        G[n_plus][k]   += 1    G[k][n_plus]   += 1
+        G[n_minus][k]  -= 1    G[k][n_minus]  -= 1
+
+    KVL row contribution from the controlling nodes:
+
+        G[k][ctrl_plus]  -= gain    (from +V_ctrl_plus term moved to LHS)
+        G[k][ctrl_minus] += gain    (from −V_ctrl_minus term moved to LHS)
+
+    b[k] = 0 (ideal source, no DC offset).
+    """
+    if not _is_ground(el.n_plus):
+        p = node_to_idx[el.n_plus]
+        G[p][branch_idx] += 1.0
+        G[branch_idx][p] += 1.0
+    if not _is_ground(el.n_minus):
+        q = node_to_idx[el.n_minus]
+        G[q][branch_idx] -= 1.0
+        G[branch_idx][q] -= 1.0
+    if not _is_ground(el.ctrl_plus):
+        G[branch_idx][node_to_idx[el.ctrl_plus]] -= el.gain
+    if not _is_ground(el.ctrl_minus):
+        G[branch_idx][node_to_idx[el.ctrl_minus]] += el.gain
+    b[branch_idx] = 0.0
+
+
+def _stamp_cccs(
+    G: list[list[float]],
+    node_to_idx: dict[str, int],
+    el: CCCS,
+    ctrl_branch_idx: int,
+) -> None:
+    """Stamp a CCCS: I(n_plus→n_minus) = beta × I(ctrl_source).
+
+    In the MNA G·x = b framework, a positive branch current ``I_ctrl``
+    (which represents current leaving ``ctrl.n_plus`` through the source) is
+    used as the controlling quantity.  The CCCS output must inject current
+    INTO ``n_plus`` (so that it exits ``n_plus`` into the external circuit
+    toward ``n_minus``).  An injected current appears as a NEGATIVE term in
+    the "leaving-current" KCL sum, so the stamp is:
+
+        G[n_plus][ctrl_branch_idx]  -= beta   (injection at n_plus)
+        G[n_minus][ctrl_branch_idx] += beta   (removal at n_minus)
+
+    This matches the SPICE ``F`` element convention: positive current flows
+    from ``n_plus`` through the external circuit to ``n_minus``.
+
+    No new branch unknown is needed; this is a pure off-diagonal entry in
+    the branch-current column of the controlling source.
+    """
+    if not _is_ground(el.n_plus):
+        G[node_to_idx[el.n_plus]][ctrl_branch_idx] -= el.beta
+    if not _is_ground(el.n_minus):
+        G[node_to_idx[el.n_minus]][ctrl_branch_idx] += el.beta
+
+
+def _stamp_ccvs(
+    G: list[list[float]],
+    b: list[float],
+    node_to_idx: dict[str, int],
+    el: CCVS,
+    branch_idx: int,
+    ctrl_branch_idx: int,
+) -> None:
+    """Stamp a CCVS: V(n_plus,n_minus) = transresistance × I(ctrl_source).
+
+    KCL rows for the output port (like VoltageSource / VCVS):
+
+        G[n_plus][k]   += 1    G[k][n_plus]   += 1
+        G[n_minus][k]  -= 1    G[k][n_minus]  -= 1
+
+    KVL row: V_out_p − V_out_m − rm × x[ctrl_branch_idx] = 0
+
+        G[k][ctrl_branch_idx] -= transresistance
+
+    b[k] = 0.
+    """
+    if not _is_ground(el.n_plus):
+        p = node_to_idx[el.n_plus]
+        G[p][branch_idx] += 1.0
+        G[branch_idx][p] += 1.0
+    if not _is_ground(el.n_minus):
+        q = node_to_idx[el.n_minus]
+        G[q][branch_idx] -= 1.0
+        G[branch_idx][q] -= 1.0
+    G[branch_idx][ctrl_branch_idx] -= el.transresistance
+    b[branch_idx] = 0.0
 
 
 def _stamp_diode(
@@ -1240,7 +1465,7 @@ def _stamp_ac(
     b: list[complex],
     omega: float,
     node_to_idx: dict[str, int],
-    vsrcs: list[VoltageSource],
+    branch_srcs: list[VoltageSource | VCVS | CCVS],
     dc_x: list[float],
 ) -> None:
     """Stamp one element's AC small-signal contribution at angular frequency ω.
@@ -1248,6 +1473,8 @@ def _stamp_ac(
     Linear elements (R, C, L, V, I) use their exact complex admittances.
     Nonlinear elements (Diode, MOSFET, BJT) are linearised at the DC operating
     point provided in ``dc_x``.
+    Controlled sources (VCVS, VCCS, CCVS, CCCS) are linear and are stamped
+    using their real-valued gains (frequency-independent).
 
     VoltageSource AC handling
     -------------------------
@@ -1268,13 +1495,14 @@ def _stamp_ac(
         Angular frequency ω = 2πf (rad/s).
     node_to_idx : dict[str, int]
         Node-to-row-index map (ground excluded).
-    vsrcs : list[VoltageSource]
-        All voltage sources in the circuit (determines branch-variable index).
+    branch_srcs : list[VoltageSource | VCVS | CCVS]
+        All branch-unknown sources in the circuit (determines column indices).
     dc_x : list[float]
         DC operating-point vector (node voltages then branch currents), indexed
         by ``node_to_idx``.  Used to compute small-signal parameters for
         nonlinear devices.
     """
+    n_nodes = len(node_to_idx)
     if isinstance(el, Resistor):
         # Purely real admittance: Y = 1/R
         _stamp_g_c(G, node_to_idx, el.n_plus, el.n_minus, (1.0 + 0j) / el.resistance)
@@ -1295,8 +1523,8 @@ def _stamp_ac(
     elif isinstance(el, VoltageSource):
         # Ideal voltage source stamp: adds branch current as an unknown.
         # Uses += so multiple elements don't overwrite each other's entries.
-        i = vsrcs.index(el)
-        branch = len(node_to_idx) + i
+        i = branch_srcs.index(el)
+        branch = n_nodes + i
         if not _is_ground(el.n_plus):
             p = node_to_idx[el.n_plus]
             G[p][branch] += 1.0 + 0j
@@ -1313,6 +1541,63 @@ def _stamp_ac(
             b[node_to_idx[el.n_plus]] -= el.current + 0j
         if not _is_ground(el.n_minus):
             b[node_to_idx[el.n_minus]] += el.current + 0j
+
+    elif isinstance(el, VCCS):
+        # Frequency-independent transconductance: same stamp as DC.
+        _stamp_vccs(G, node_to_idx, el.n_plus, el.n_minus,
+                    el.ctrl_plus, el.ctrl_minus, el.gm)  # type: ignore[arg-type]
+
+    elif isinstance(el, VCVS):
+        # Voltage-controlled voltage source — same stamp as DC.
+        i = branch_srcs.index(el)
+        branch = n_nodes + i
+        if not _is_ground(el.n_plus):
+            p = node_to_idx[el.n_plus]
+            G[p][branch] += 1.0 + 0j
+            G[branch][p] += 1.0 + 0j
+        if not _is_ground(el.n_minus):
+            q = node_to_idx[el.n_minus]
+            G[q][branch] -= 1.0 + 0j
+            G[branch][q] -= 1.0 + 0j
+        if not _is_ground(el.ctrl_plus):
+            G[branch][node_to_idx[el.ctrl_plus]] -= el.gain + 0j
+        if not _is_ground(el.ctrl_minus):
+            G[branch][node_to_idx[el.ctrl_minus]] += el.gain + 0j
+        b[branch] += 0j
+
+    elif isinstance(el, CCCS):
+        ctrl_bsrc = _find_branch_source(branch_srcs, el.ctrl_source)
+        if ctrl_bsrc is None:
+            raise ValueError(
+                f"CCCS '{el.name}' references controlling source "
+                f"'{el.ctrl_source}' which does not exist in the circuit."
+            )
+        ctrl_branch = n_nodes + branch_srcs.index(ctrl_bsrc)
+        if not _is_ground(el.n_plus):
+            G[node_to_idx[el.n_plus]][ctrl_branch] -= el.beta + 0j
+        if not _is_ground(el.n_minus):
+            G[node_to_idx[el.n_minus]][ctrl_branch] += el.beta + 0j
+
+    elif isinstance(el, CCVS):
+        i = branch_srcs.index(el)
+        branch = n_nodes + i
+        if not _is_ground(el.n_plus):
+            p = node_to_idx[el.n_plus]
+            G[p][branch] += 1.0 + 0j
+            G[branch][p] += 1.0 + 0j
+        if not _is_ground(el.n_minus):
+            q = node_to_idx[el.n_minus]
+            G[q][branch] -= 1.0 + 0j
+            G[branch][q] -= 1.0 + 0j
+        ctrl_bsrc = _find_branch_source(branch_srcs, el.ctrl_source)
+        if ctrl_bsrc is None:
+            raise ValueError(
+                f"CCVS '{el.name}' references controlling source "
+                f"'{el.ctrl_source}' which does not exist in the circuit."
+            )
+        ctrl_branch = n_nodes + branch_srcs.index(ctrl_bsrc)
+        G[branch][ctrl_branch] -= el.transresistance + 0j
+        b[branch] += 0j
 
     elif isinstance(el, Diode):
         # Small-signal model: linearised conductance gd = (Is/Vt)·exp(Vd/Vt).
@@ -1475,17 +1760,17 @@ def ac_sweep(
     # ---- DC operating point --------------------------------------------------
     dc = dc_op(circuit)
     node_to_idx, _nodes = _node_index(circuit)
-    vsrcs = _voltage_sources(circuit)
+    branch_srcs = _branch_sources(circuit)
     n_nodes = len(node_to_idx)
-    n_vsrcs = len(vsrcs)
-    size = n_nodes + n_vsrcs
+    n_branch = len(branch_srcs)
+    size = n_nodes + n_branch
 
     # Reconstruct the indexed dc_x vector from the DcResult dict.
     dc_x: list[float] = [0.0] * size
     for name, idx in node_to_idx.items():
         dc_x[idx] = dc.node_voltages.get(name, 0.0)
-    for i, vs in enumerate(vsrcs):
-        dc_x[n_nodes + i] = dc.branch_currents.get(f"I({vs.name})", 0.0)
+    for i, bs in enumerate(branch_srcs):
+        dc_x[n_nodes + i] = dc.branch_currents.get(f"I({bs.name})", 0.0)
 
     # ---- Frequency grid -------------------------------------------------------
     if n_points < 1:
@@ -1513,7 +1798,7 @@ def ac_sweep(
         b_c: list[complex] = [0j] * size
 
         for el in circuit.elements:
-            _stamp_ac(el, G_c, b_c, omega, node_to_idx, vsrcs, dc_x)
+            _stamp_ac(el, G_c, b_c, omega, node_to_idx, branch_srcs, dc_x)
 
         try:
             x_c = _solve_complex(G_c, b_c)
@@ -1596,14 +1881,16 @@ _ = cmath  # noqa: F841
 def _build_ss_matrix(
     circuit: Circuit,
     node_to_idx: dict[str, int],
-    vsrcs: list[VoltageSource],
+    branch_srcs: list[VoltageSource | VCVS | CCVS],
     dc_x: list[float],
 ) -> list[list[float]]:
     """Build the real DC small-signal MNA conductance matrix (ω = 0).
 
     This is the real-valued analogue of the complex :func:`_stamp_ac` loop.
     Independent sources are excluded (zeroed), leaving only conductance and
-    structural KVL/KCL entries.
+    structural KVL/KCL entries.  Controlled sources (VCVS, VCCS, CCCS, CCVS)
+    are included with their full gains — they are not "zeroed" because they
+    are dependent sources, not independent excitations.
 
     Stamping rules
     --------------
@@ -1620,6 +1907,14 @@ def _build_ss_matrix(
     +-------------------+-----------------------------------------------+
     | CurrentSource     | skipped (independent source → zero in ss)     |
     +-------------------+-----------------------------------------------+
+    | VCCS              | off-diagonal gm entries                       |
+    +-------------------+-----------------------------------------------+
+    | VCVS              | KVL/KCL entries + gain row (b NOT set)        |
+    +-------------------+-----------------------------------------------+
+    | CCCS              | off-diagonal beta entries                     |
+    +-------------------+-----------------------------------------------+
+    | CCVS              | KVL/KCL entries + transresistance (b NOT set) |
+    +-------------------+-----------------------------------------------+
     | Diode             | gd = (Is/Vt) · exp(Vd/Vt) at DC OP           |
     +-------------------+-----------------------------------------------+
     | MOSFET            | gds + gm VCCS at DC OP                        |
@@ -1633,18 +1928,18 @@ def _build_ss_matrix(
         The circuit being analysed.
     node_to_idx : dict[str, int]
         Node-to-row-index mapping (ground excluded).
-    vsrcs : list[VoltageSource]
-        Ordered list of voltage sources (determines branch column indices).
+    branch_srcs : list[VoltageSource | VCVS | CCVS]
+        Ordered list of branch-unknown sources (determines column indices).
     dc_x : list[float]
         DC operating-point vector (node voltages then branch currents).
 
     Returns
     -------
     list[list[float]]
-        Square real MNA matrix of size ``(n_nodes + n_vsrcs)^2``.
+        Square real MNA matrix of size ``(n_nodes + n_branch_srcs)^2``.
     """
     n_nodes = len(node_to_idx)
-    size = n_nodes + len(vsrcs)
+    size = n_nodes + len(branch_srcs)
     G: list[list[float]] = [[0.0] * size for _ in range(size)]
 
     for el in circuit.elements:
@@ -1664,7 +1959,7 @@ def _build_ss_matrix(
         elif isinstance(el, VoltageSource):
             # Stamp structural KVL/KCL entries exactly as in _stamp_vsrc, but
             # intentionally leave b alone (independent source zeroed).
-            i = vsrcs.index(el)
+            i = branch_srcs.index(el)
             branch_idx = n_nodes + i
             if not _is_ground(el.n_plus):
                 p = node_to_idx[el.n_plus]
@@ -1678,6 +1973,39 @@ def _build_ss_matrix(
         elif isinstance(el, CurrentSource):
             # Independent current source → zero in small-signal analysis.
             pass
+
+        elif isinstance(el, VCCS):
+            # Frequency-independent; stamp real transconductance.
+            _stamp_vccs(G, node_to_idx, el.n_plus, el.n_minus,
+                        el.ctrl_plus, el.ctrl_minus, el.gm)
+
+        elif isinstance(el, VCVS):
+            # Dependent source — stamp full KVL/KCL + gain (not zeroed).
+            b_dummy: list[float] = [0.0] * size
+            _stamp_vcvs(G, b_dummy, node_to_idx, el,
+                        n_nodes + branch_srcs.index(el))
+
+        elif isinstance(el, CCCS):
+            ctrl_el = _find_branch_source(branch_srcs, el.ctrl_source)
+            if ctrl_el is None:
+                raise ValueError(
+                    f"CCCS '{el.name}' references controlling source "
+                    f"'{el.ctrl_source}' which does not exist in the circuit."
+                )
+            ctrl_idx = n_nodes + branch_srcs.index(ctrl_el)
+            _stamp_cccs(G, node_to_idx, el, ctrl_idx)
+
+        elif isinstance(el, CCVS):
+            ctrl_el = _find_branch_source(branch_srcs, el.ctrl_source)
+            if ctrl_el is None:
+                raise ValueError(
+                    f"CCVS '{el.name}' references controlling source "
+                    f"'{el.ctrl_source}' which does not exist in the circuit."
+                )
+            ctrl_idx = n_nodes + branch_srcs.index(ctrl_el)
+            b_dummy2: list[float] = [0.0] * size
+            _stamp_ccvs(G, b_dummy2, node_to_idx, el,
+                        n_nodes + branch_srcs.index(el), ctrl_idx)
 
         elif isinstance(el, Diode):
             # Small-signal conductance: gd = dI/dVd = (Is/Vt)·exp(Vd/Vt).
@@ -1822,19 +2150,19 @@ def tf(
     # ---- Step 1: DC operating point ------------------------------------------
     dc = dc_op(circuit, max_iterations=max_iterations, tol=tol)
     node_to_idx, _nodes = _node_index(circuit)
-    vsrcs = _voltage_sources(circuit)
+    branch_srcs_tf = _branch_sources(circuit)
     n_nodes = len(node_to_idx)
-    size = n_nodes + len(vsrcs)
+    size = n_nodes + len(branch_srcs_tf)
 
     # Reconstruct the indexed dc_x vector from the DcResult dicts.
     dc_x: list[float] = [0.0] * size
     for name, idx in node_to_idx.items():
         dc_x[idx] = dc.node_voltages.get(name, 0.0)
-    for i, vs in enumerate(vsrcs):
-        dc_x[n_nodes + i] = dc.branch_currents.get(f"I({vs.name})", 0.0)
+    for i, bs in enumerate(branch_srcs_tf):
+        dc_x[n_nodes + i] = dc.branch_currents.get(f"I({bs.name})", 0.0)
 
     # ---- Step 2: Small-signal conductance matrix -----------------------------
-    G_ss = _build_ss_matrix(circuit, node_to_idx, vsrcs, dc_x)
+    G_ss = _build_ss_matrix(circuit, node_to_idx, branch_srcs_tf, dc_x)
 
     # ---- Locate the input source element ------------------------------------
     input_el: Element | None = None
@@ -1869,7 +2197,7 @@ def tf(
 
     if isinstance(input_el, VoltageSource):
         # 1 V across the source: set the KVL constraint row b[branch] = 1.0.
-        vsrc_idx = vsrcs.index(input_el)
+        vsrc_idx = branch_srcs_tf.index(input_el)
         b_fwd[n_nodes + vsrc_idx] = 1.0
     else:
         # CurrentSource: inject 1 A following the same sign convention as the
@@ -1895,7 +2223,7 @@ def tf(
 
     # Input impedance
     if isinstance(input_el, VoltageSource):
-        vsrc_idx = vsrcs.index(input_el)
+        vsrc_idx = branch_srcs_tf.index(input_el)
         i_branch = x_fwd[n_nodes + vsrc_idx]
         # MNA convention: x[branch] < 0 when the source delivers current
         # (the branch current enters n_plus FROM the circuit, not from the
@@ -3137,17 +3465,17 @@ def noise_ac(
 
     # ---- Matrix bookkeeping --------------------------------------------------
     node_to_idx, _nodes = _node_index(circuit)
-    vsrcs = _voltage_sources(circuit)
+    branch_srcs_noise = _branch_sources(circuit)
     n_nodes = len(node_to_idx)
-    n_vsrcs = len(vsrcs)
-    size = n_nodes + n_vsrcs
+    n_branch_noise = len(branch_srcs_noise)
+    size = n_nodes + n_branch_noise
 
     # Reconstruct dc_x solution vector for linearisation of nonlinear devices.
     dc_x: list[float] = [0.0] * size
     for name, idx in node_to_idx.items():
         dc_x[idx] = dc.node_voltages.get(name, 0.0)
-    for i, vs in enumerate(vsrcs):
-        dc_x[n_nodes + i] = dc.branch_currents.get(f"I({vs.name})", 0.0)
+    for i, bs in enumerate(branch_srcs_noise):
+        dc_x[n_nodes + i] = dc.branch_currents.get(f"I({bs.name})", 0.0)
 
     # ---- Validate output node -----------------------------------------------
     if _is_ground(output_node):
@@ -3199,7 +3527,7 @@ def noise_ac(
         G_c: list[list[complex]] = [[0j] * size for _ in range(size)]
         b_c: list[complex] = [0j] * size  # dummy RHS for stamping (unused)
         for el in circuit.elements:
-            _stamp_ac(el, G_c, b_c, omega, node_to_idx, vsrcs, dc_x)
+            _stamp_ac(el, G_c, b_c, omega, node_to_idx, branch_srcs_noise, dc_x)
 
         # Transpose G_c → G_T for the adjoint solve.
         # G_T[i][j] = G_c[j][i]
@@ -3263,7 +3591,7 @@ def noise_ac(
         input_referred_psd = 0.0
         if input_el is not None:
             if isinstance(input_el, VoltageSource):
-                vs_idx = vsrcs.index(input_el)
+                vs_idx = branch_srcs_noise.index(input_el)
                 H_sig = v_adj[n_nodes + vs_idx]
             else:  # CurrentSource
                 h_n_plus: complex = (

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -54,6 +54,21 @@ Test organisation
 50. Noise analysis: shot noise (Diode and BJT)
 51. Noise analysis: frequency sweep and defaults
 52. Noise analysis: error cases and edge cases
+53. Controlled sources: VCCS dataclass
+54. Controlled sources: VCVS dataclass
+55. Controlled sources: CCCS dataclass
+56. Controlled sources: CCVS dataclass
+57. DC analysis: VCCS (voltage-controlled current source)
+58. DC analysis: VCVS (voltage-controlled voltage source)
+59. DC analysis: CCCS (current-controlled current source)
+60. DC analysis: CCVS (current-controlled voltage source)
+61. AC analysis: controlled sources
+62. DC sweep: VCVS
+63. Transient: controlled sources
+64. TF analysis: VCVS
+65. Sensitivity: VCVS
+66. Monte Carlo: VCVS
+67. Error cases: unknown ctrl_source
 """
 
 import cmath
@@ -64,6 +79,10 @@ import pytest
 
 from spice_engine import (
     BJT,
+    CCCS,
+    CCVS,
+    VCCS,
+    VCVS,
     AcPoint,
     AcResult,
     Capacitor,
@@ -3765,3 +3784,742 @@ def test_noise_noiseentry_is_frozen() -> None:
     entry = result.points[0].entries[0]
     with pytest.raises((AttributeError, TypeError)):
         entry.output_psd = -1.0  # type: ignore[misc]
+
+
+# ── Section 53: VCCS element dataclass ───────────────────────────────────────
+
+
+def test_vccs_frozen() -> None:
+    """VCCS is a frozen dataclass (immutable after construction)."""
+    g = VCCS("G1", "out", "0", "in", "0", gm=0.01)
+    with pytest.raises((AttributeError, TypeError)):
+        g.gm = 0.02  # type: ignore[misc]
+
+
+def test_vccs_fields() -> None:
+    """VCCS stores all six fields correctly."""
+    g = VCCS("G1", "out", "0", "in", "0", gm=0.02)
+    assert g.name == "G1"
+    assert g.n_plus == "out"
+    assert g.n_minus == "0"
+    assert g.ctrl_plus == "in"
+    assert g.ctrl_minus == "0"
+    assert g.gm == pytest.approx(0.02)
+
+
+def test_vccs_negative_gm() -> None:
+    """VCCS accepts negative gm (for sign-inverting configurations)."""
+    g = VCCS("G_inv", "out", "0", "in", "0", gm=-0.05)
+    assert g.gm == pytest.approx(-0.05)
+
+
+def test_vccs_in_element_union() -> None:
+    """VCCS is accepted as a circuit element (Element type alias includes it)."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "0", "out", "in", "0", gm=0.01),
+    ])
+    assert len(c.elements) == 3
+
+
+# ── Section 54: VCVS element dataclass ───────────────────────────────────────
+
+
+def test_vcvs_frozen() -> None:
+    """VCVS is a frozen dataclass (immutable after construction)."""
+    e = VCVS("E1", "out", "0", "vin", "0", gain=2.0)
+    with pytest.raises((AttributeError, TypeError)):
+        e.gain = 3.0  # type: ignore[misc]
+
+
+def test_vcvs_fields() -> None:
+    """VCVS stores all six fields correctly."""
+    e = VCVS("E1", "out", "0", "vin", "0", gain=-10.0)
+    assert e.name == "E1"
+    assert e.n_plus == "out"
+    assert e.n_minus == "0"
+    assert e.ctrl_plus == "vin"
+    assert e.ctrl_minus == "0"
+    assert e.gain == pytest.approx(-10.0)
+
+
+def test_vcvs_differential_ctrl() -> None:
+    """VCVS can have a non-ground ctrl_minus (differential sensing)."""
+    e = VCVS("Ediff", "out", "0", "vp", "vm", gain=5.0)
+    assert e.ctrl_plus == "vp"
+    assert e.ctrl_minus == "vm"
+    assert e.gain == pytest.approx(5.0)
+
+
+def test_vcvs_in_element_union() -> None:
+    """VCVS is accepted as a circuit element."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 5.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    assert len(c.elements) == 3
+
+
+# ── Section 55: CCCS element dataclass ───────────────────────────────────────
+
+
+def test_cccs_frozen() -> None:
+    """CCCS is a frozen dataclass (immutable after construction)."""
+    f = CCCS("F1", "out", "0", "Vsense", beta=2.0)
+    with pytest.raises((AttributeError, TypeError)):
+        f.beta = 3.0  # type: ignore[misc]
+
+
+def test_cccs_fields() -> None:
+    """CCCS stores all five fields correctly."""
+    f = CCCS("F1", "out", "0", "Vsense", beta=5.0)
+    assert f.name == "F1"
+    assert f.n_plus == "out"
+    assert f.n_minus == "0"
+    assert f.ctrl_source == "Vsense"
+    assert f.beta == pytest.approx(5.0)
+
+
+def test_cccs_negative_beta() -> None:
+    """CCCS accepts negative beta (current direction reversal)."""
+    f = CCCS("Finv", "out", "0", "Vsense", beta=-1.0)
+    assert f.beta == pytest.approx(-1.0)
+
+
+def test_cccs_in_element_union() -> None:
+    """CCCS is accepted as a circuit element."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCCS("F1", "out", "0", "Vsense", beta=2.0),
+        Resistor("Rload", "out", "0", 500.0),
+    ])
+    assert len(c.elements) == 5
+
+
+# ── Section 56: CCVS element dataclass ───────────────────────────────────────
+
+
+def test_ccvs_frozen() -> None:
+    """CCVS is a frozen dataclass (immutable after construction)."""
+    h = CCVS("H1", "out", "0", "Vsense", transresistance=1000.0)
+    with pytest.raises((AttributeError, TypeError)):
+        h.transresistance = 2000.0  # type: ignore[misc]
+
+
+def test_ccvs_fields() -> None:
+    """CCVS stores all five fields correctly."""
+    h = CCVS("H1", "out", "0", "Vsense", transresistance=500.0)
+    assert h.name == "H1"
+    assert h.n_plus == "out"
+    assert h.n_minus == "0"
+    assert h.ctrl_source == "Vsense"
+    assert h.transresistance == pytest.approx(500.0)
+
+
+def test_ccvs_in_element_union() -> None:
+    """CCVS is accepted as a circuit element."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCVS("H1", "out", "0", "Vsense", transresistance=500.0),
+    ])
+    assert len(c.elements) == 4
+
+
+# ── Section 57: DC analysis – VCCS ───────────────────────────────────────────
+
+
+def test_vccs_dc_inverting() -> None:
+    """VCCS(out, 0, in, 0, gm) inverts: V_out = -gm * R_load * V_in.
+
+    MNA analysis: VCCS stamps G[out][in] += gm.  Rload stamps G[out][out] +=
+    1/R.  KCL at ``out``: (1/R)*V_out + gm*V_in = 0 → V_out = -gm*R*V_in.
+    """
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "out", "0", "in", "0", gm=0.01),
+    ])
+    r = dc_op(c)
+    # V_out = -0.01 * 100 * 1.0 = -1.0 V
+    assert r.node_voltages["out"] == pytest.approx(-1.0, abs=1e-9)
+
+
+def test_vccs_dc_noninverting() -> None:
+    """VCCS(0, out, in, 0, gm) non-inverts: V_out = +gm * R_load * V_in.
+
+    Swapping n_plus and n_minus flips the sign of all stamp entries, so the
+    current injection at ``out`` is in the opposite direction.
+    KCL at ``out``: (1/R)*V_out - gm*V_in = 0 → V_out = +gm*R*V_in.
+    """
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "0", "out", "in", "0", gm=0.01),
+    ])
+    r = dc_op(c)
+    # V_out = +0.01 * 100 * 1.0 = +1.0 V
+    assert r.node_voltages["out"] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_vccs_dc_zero_gm() -> None:
+    """VCCS with gm=0 injects no current (equivalent to open circuit)."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 5.0),
+        Resistor("Rload", "out", "0", 1000.0),
+        VCCS("G1", "out", "0", "in", "0", gm=0.0),
+    ])
+    r = dc_op(c)
+    # No current injected → Rload has no current → V_out = 0
+    assert r.node_voltages["out"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_vccs_dc_gain_scaling() -> None:
+    """VCCS output scales linearly with gm and R_load."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 2.0),
+        Resistor("Rload", "out", "0", 50.0),
+        VCCS("G1", "0", "out", "in", "0", gm=0.02),
+    ])
+    r = dc_op(c)
+    # V_out = gm * R * V_in = 0.02 * 50 * 2.0 = 2.0 V
+    assert r.node_voltages["out"] == pytest.approx(2.0, abs=1e-9)
+
+
+def test_vccs_dc_differential_ctrl() -> None:
+    """VCCS senses V(ctrl_plus) − V(ctrl_minus) for a differential input."""
+    # V_p = 3V, V_m = 1V → V_diff = 2V → V_out = gm * R * V_diff
+    c = Circuit([
+        VoltageSource("Vp", "vp", "0", 3.0),
+        VoltageSource("Vm", "vm", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "0", "out", "vp", "vm", gm=0.01),
+    ])
+    r = dc_op(c)
+    # V_out = 0.01 * 100 * (3 - 1) = 2.0 V
+    assert r.node_voltages["out"] == pytest.approx(2.0, abs=1e-9)
+
+
+# ── Section 58: DC analysis – VCVS ───────────────────────────────────────────
+
+
+def test_vcvs_dc_unity_buffer() -> None:
+    """VCVS with gain=1 is a perfect unity-gain voltage buffer.
+
+    KVL: V_out − 1.0 × V_vin = 0 → V_out = V_vin.
+    The load has no effect because the VCVS is an ideal (zero-output-
+    impedance) voltage source.
+    """
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 5.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    r = dc_op(c)
+    assert r.node_voltages["out"] == pytest.approx(5.0, abs=1e-9)
+
+
+def test_vcvs_dc_inverting_gain() -> None:
+    """VCVS with gain=-2 inverts and amplifies: V_out = -2 × V_in."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 3.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=-2.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    r = dc_op(c)
+    assert r.node_voltages["out"] == pytest.approx(-6.0, abs=1e-9)
+
+
+def test_vcvs_dc_large_gain() -> None:
+    """VCVS with a large positive gain (open-loop op-amp macromodel)."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 0.001),  # 1 mV input
+        VCVS("E1", "out", "0", "vin", "0", gain=1000.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    r = dc_op(c)
+    # V_out = 1000 * 0.001 = 1.0 V
+    assert r.node_voltages["out"] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_vcvs_dc_differential_ctrl() -> None:
+    """VCVS senses V(ctrl_plus) − V(ctrl_minus) for a differential input."""
+    c = Circuit([
+        VoltageSource("Vp", "vp", "0", 4.0),
+        VoltageSource("Vm", "vm", "0", 1.0),
+        VCVS("E1", "out", "0", "vp", "vm", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    r = dc_op(c)
+    # V_diff = 4 - 1 = 3V → V_out = 1.0 * 3 = 3.0V
+    assert r.node_voltages["out"] == pytest.approx(3.0, abs=1e-9)
+
+
+def test_vcvs_dc_branch_current_recorded() -> None:
+    """dc_op records I(E1) in branch_currents for a VCVS element."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 5.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    r = dc_op(c)
+    assert "I(E1)" in r.branch_currents
+    # Rload current = V_out / R_load = 5.0 / 1000 = 5 mA
+    # VCVS sinks this current from its output terminal
+    assert abs(r.branch_currents["I(E1)"]) == pytest.approx(5e-3, rel=1e-6)
+
+
+def test_vcvs_dc_load_independent() -> None:
+    """VCVS output voltage is independent of load (ideal voltage source)."""
+    def _vout(rload: float) -> float:
+        c = Circuit([
+            VoltageSource("Vin", "vin", "0", 2.0),
+            VCVS("E1", "out", "0", "vin", "0", gain=3.0),
+            Resistor("Rload", "out", "0", rload),
+        ])
+        return dc_op(c).node_voltages["out"]
+
+    # V_out = 6V regardless of load
+    assert _vout(100.0) == pytest.approx(6.0, abs=1e-9)
+    assert _vout(10_000.0) == pytest.approx(6.0, abs=1e-9)
+
+
+# ── Section 59: DC analysis – CCCS ───────────────────────────────────────────
+
+
+def _cccs_circuit(beta: float = 2.0, r_load: float = 500.0) -> Circuit:
+    """Standard CCCS test circuit.
+
+    Topology: Vin(1V) → Rin(1kΩ) → Vsense(0V) → GND.
+    CCCS F1 controlled by Vsense, output into Rload.
+
+    I_ctrl = V_in / R_in = 1V / 1kΩ = 1 mA (Vsense is a 0V ammeter).
+
+    SPICE convention: ``F1 n+ n-`` means positive current flows from ``n+``
+    through the EXTERNAL circuit to ``n-``.  Here n_plus="out", n_minus="0"
+    so 2 mA flows from "out" through Rload to ground: V_out = +beta*I*R_load.
+    """
+    return Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCCS("F1", "out", "0", "Vsense", beta),
+        Resistor("Rload", "out", "0", r_load),
+    ])
+
+
+def test_cccs_dc_basic() -> None:
+    """CCCS mirrors and scales current: V_out = beta × I_ctrl × R_load."""
+    r = dc_op(_cccs_circuit(beta=2.0, r_load=500.0))
+    # V_out = 2 * 1e-3 * 500 = 1.0 V
+    assert r.node_voltages["out"] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_cccs_dc_unity_beta() -> None:
+    """CCCS with beta=1.0 replicates the controlling current exactly."""
+    r = dc_op(_cccs_circuit(beta=1.0, r_load=1000.0))
+    # V_out = 1 * 1e-3 * 1000 = 1.0 V
+    assert r.node_voltages["out"] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_cccs_dc_zero_beta() -> None:
+    """CCCS with beta=0 injects no output current (open circuit)."""
+    r = dc_op(_cccs_circuit(beta=0.0, r_load=500.0))
+    assert r.node_voltages["out"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_cccs_dc_negative_beta() -> None:
+    """CCCS with beta=-1 reverses the current direction."""
+    r = dc_op(_cccs_circuit(beta=-1.0, r_load=500.0))
+    # V_out = -1 * 1e-3 * 500 = -0.5 V
+    assert r.node_voltages["out"] == pytest.approx(-0.5, abs=1e-9)
+
+
+def test_cccs_dc_higher_gain() -> None:
+    """CCCS with larger beta amplifies proportionally."""
+    r = dc_op(_cccs_circuit(beta=5.0, r_load=200.0))
+    # V_out = 5 * 1e-3 * 200 = 1.0 V
+    assert r.node_voltages["out"] == pytest.approx(1.0, abs=1e-9)
+
+
+# ── Section 60: DC analysis – CCVS ───────────────────────────────────────────
+
+
+def _ccvs_circuit(rm: float = 500.0) -> Circuit:
+    """Standard CCVS test circuit.
+
+    Topology: Vin(1V) → Rin(1kΩ) → Vsense(0V) → GND.
+    CCVS H1 controlled by Vsense forces V_out = rm × I_ctrl.
+
+    I_ctrl = V_in / R_in = 1V / 1kΩ = 1 mA.
+    V_out  = rm × I_ctrl = rm × 1 mA.
+    """
+    return Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCVS("H1", "out", "0", "Vsense", rm),
+    ])
+
+
+def test_ccvs_dc_basic() -> None:
+    """CCVS forces V_out = rm × I_ctrl."""
+    r = dc_op(_ccvs_circuit(rm=500.0))
+    # V_out = 500 * 1e-3 = 0.5 V
+    assert r.node_voltages["out"] == pytest.approx(0.5, abs=1e-9)
+
+
+def test_ccvs_dc_unit_transresistance() -> None:
+    """CCVS with rm=1000 Ω: V_out = 1 kΩ × 1 mA = 1 V."""
+    r = dc_op(_ccvs_circuit(rm=1000.0))
+    assert r.node_voltages["out"] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_ccvs_dc_zero_transresistance() -> None:
+    """CCVS with rm=0 is a short circuit (ideal wire from output to ground)."""
+    r = dc_op(_ccvs_circuit(rm=0.0))
+    assert r.node_voltages["out"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_ccvs_dc_with_load() -> None:
+    """CCVS output voltage is independent of load (ideal voltage source)."""
+    c_no_load = _ccvs_circuit(rm=500.0)
+    c_with_load = Circuit(
+        list(c_no_load.elements)
+        + [Resistor("Rload", "out", "0", 100.0)]
+    )
+    r = dc_op(c_with_load)
+    # V_out is still 0.5V regardless of the load resistance
+    assert r.node_voltages["out"] == pytest.approx(0.5, abs=1e-9)
+
+
+def test_ccvs_dc_branch_current_recorded() -> None:
+    """dc_op records I(H1) in branch_currents for a CCVS element."""
+    r = dc_op(_ccvs_circuit(rm=500.0))
+    assert "I(H1)" in r.branch_currents
+
+
+# ── Section 61: AC analysis – controlled sources ─────────────────────────────
+
+
+def test_vcvs_ac_unity_buffer() -> None:
+    """VCVS unity buffer passes AC signal unattenuated at all frequencies."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 1.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = ac_sweep(c, f_start=1.0, f_stop=1e6, n_points=5)
+    for pt in result.points:
+        assert abs(pt.node_voltages["out"]) == pytest.approx(1.0, rel=1e-6)
+
+
+def test_vcvs_ac_gain() -> None:
+    """VCVS with gain=3 scales AC voltage by 3 at all frequencies."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 1.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=3.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = ac_sweep(c, f_start=1.0, f_stop=1e4, n_points=3)
+    for pt in result.points:
+        assert abs(pt.node_voltages["out"]) == pytest.approx(3.0, rel=1e-6)
+
+
+def test_vccs_ac_transconductance() -> None:
+    """VCCS produces frequency-independent transconductance in AC analysis."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "0", "out", "in", "0", gm=0.01),
+    ])
+    result = ac_sweep(c, f_start=1.0, f_stop=1e6, n_points=5)
+    for pt in result.points:
+        # V_out = gm * R_load * V_in = 0.01 * 100 * 1 = 1.0
+        assert abs(pt.node_voltages["out"]) == pytest.approx(1.0, rel=1e-6)
+
+
+def test_cccs_ac_current_gain() -> None:
+    """CCCS scales controlling AC current by beta at all frequencies."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCCS("F1", "out", "0", "Vsense", 2.0),
+        Resistor("Rload", "out", "0", 500.0),
+    ])
+    result = ac_sweep(c, f_start=1.0, f_stop=1e3, n_points=3)
+    for pt in result.points:
+        # V_out = beta * (V_in/R_in) * R_load = 2 * (1/1000) * 500 = 1.0
+        assert abs(pt.node_voltages["out"]) == pytest.approx(1.0, rel=1e-6)
+
+
+def test_ccvs_ac_transresistance() -> None:
+    """CCVS passes AC signal via transresistance at all frequencies."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCVS("H1", "out", "0", "Vsense", 500.0),
+        Resistor("Rload", "out", "0", 100.0),
+    ])
+    result = ac_sweep(c, f_start=1.0, f_stop=1e4, n_points=3)
+    for pt in result.points:
+        # V_out = rm * (V_in/R_in) = 500 * (1/1000) = 0.5
+        assert abs(pt.node_voltages["out"]) == pytest.approx(0.5, rel=1e-6)
+
+
+# ── Section 62: DC sweep – VCVS ──────────────────────────────────────────────
+
+
+def test_vcvs_dc_sweep_linear() -> None:
+    """VCVS output tracks dc_sweep of input source linearly (gain=2)."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 0.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=2.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = dc_sweep(c, "Vin", 0.0, 3.0, 1.0)
+    v_outs = [pt.node_voltages["out"] for pt in result.points]
+    # At V_in = 0, 1, 2, 3: V_out = 0, 2, 4, 6
+    assert v_outs == pytest.approx([0.0, 2.0, 4.0, 6.0], abs=1e-9)
+
+
+def test_vccs_dc_sweep() -> None:
+    """VCCS output tracks dc_sweep — V_out = -gm * R * V_in at each point."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 0.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "out", "0", "in", "0", gm=0.01),
+    ])
+    result = dc_sweep(c, "Vin", 0.0, 2.0, 1.0)
+    v_outs = [pt.node_voltages["out"] for pt in result.points]
+    # V_out = -gm * R * V_in = -0.01 * 100 * V_in = -V_in
+    assert v_outs == pytest.approx([0.0, -1.0, -2.0], abs=1e-9)
+
+
+# ── Section 63: Transient – controlled sources ────────────────────────────────
+
+
+def test_vcvs_transient_unity() -> None:
+    """VCVS unity buffer reproduces the DC input in every transient timestep."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 3.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = transient(c, t_stop=1e-3, t_step=1e-4)
+    for pt in result.points:
+        assert pt.node_voltages["out"] == pytest.approx(3.0, abs=1e-6)
+
+
+def test_vccs_transient() -> None:
+    """VCCS works correctly during transient analysis (DC-steady circuit)."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "0", "out", "in", "0", gm=0.01),
+    ])
+    result = transient(c, t_stop=1e-3, t_step=1e-4)
+    for pt in result.points:
+        assert pt.node_voltages["out"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_cccs_transient() -> None:
+    """CCCS works correctly during transient analysis."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCCS("F1", "out", "0", "Vsense", 2.0),
+        Resistor("Rload", "out", "0", 500.0),
+    ])
+    result = transient(c, t_stop=1e-3, t_step=1e-4)
+    for pt in result.points:
+        assert pt.node_voltages["out"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_ccvs_transient() -> None:
+    """CCVS works correctly during transient analysis."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCVS("H1", "out", "0", "Vsense", 500.0),
+        Resistor("Rload", "out", "0", 100.0),
+    ])
+    result = transient(c, t_stop=1e-3, t_step=1e-4)
+    for pt in result.points:
+        assert pt.node_voltages["out"] == pytest.approx(0.5, abs=1e-6)
+
+
+# ── Section 64: TF analysis – VCVS ───────────────────────────────────────────
+
+
+def test_vcvs_tf_unity() -> None:
+    """Transfer function of VCVS unity buffer is gain = 1.0."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 1.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = tf(c, output_node="out", input_source="Vin")
+    assert result.gain == pytest.approx(1.0, rel=1e-6)
+
+
+def test_vcvs_tf_gain_two() -> None:
+    """TF analysis returns the correct gain=2 for a VCVS amplifier."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 1.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=2.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = tf(c, output_node="out", input_source="Vin")
+    assert result.gain == pytest.approx(2.0, rel=1e-6)
+
+
+def test_vcvs_tf_inverting() -> None:
+    """TF analysis returns negative gain for an inverting VCVS."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 1.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=-5.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = tf(c, output_node="out", input_source="Vin")
+    assert result.gain == pytest.approx(-5.0, rel=1e-6)
+
+
+def test_cccs_tf() -> None:
+    """TF analysis works for circuits containing a CCCS."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCCS("F1", "out", "0", "Vsense", 2.0),
+        Resistor("Rload", "out", "0", 500.0),
+    ])
+    result = tf(c, output_node="out", input_source="Vin")
+    # TF = V_out / V_in = beta * R_load / R_in = 2 * 500 / 1000 = 1.0
+    assert result.gain == pytest.approx(1.0, rel=1e-6)
+
+
+def test_ccvs_tf() -> None:
+    """TF analysis works for circuits containing a CCVS."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rin", "in", "mid", 1000.0),
+        VoltageSource("Vsense", "mid", "0", 0.0),
+        CCVS("H1", "out", "0", "Vsense", 500.0),
+        Resistor("Rload", "out", "0", 100.0),
+    ])
+    result = tf(c, output_node="out", input_source="Vin")
+    # TF = V_out / V_in = rm / R_in = 500 / 1000 = 0.5
+    assert result.gain == pytest.approx(0.5, rel=1e-6)
+
+
+# ── Section 65: Sensitivity – VCVS ───────────────────────────────────────────
+
+
+def test_vcvs_sens_dc_runs() -> None:
+    """sens_dc runs without error in a circuit containing a VCVS."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 5.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = sens_dc(c, "out")
+    assert isinstance(result.entries, list)
+    assert result.nominal_voltage == pytest.approx(5.0, abs=1e-9)
+
+
+def test_vccs_sens_dc_runs() -> None:
+    """sens_dc runs without error in a circuit containing a VCCS."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "0", "out", "in", "0", gm=0.01),
+    ])
+    result = sens_dc(c, "out")
+    assert isinstance(result.entries, list)
+    assert result.nominal_voltage == pytest.approx(1.0, abs=1e-9)
+
+
+# ── Section 66: Monte Carlo – VCVS ───────────────────────────────────────────
+
+
+def test_vcvs_mc_dc_runs() -> None:
+    """mc_dc runs without error in a circuit containing a VCVS."""
+    c = Circuit([
+        VoltageSource("Vin", "vin", "0", 5.0),
+        VCVS("E1", "out", "0", "vin", "0", gain=1.0),
+        Resistor("Rload", "out", "0", 1000.0),
+    ])
+    result = mc_dc(c, "out", 5, seed=42)
+    assert len(result.points) == 5
+    # All trials should converge to roughly 5V (VCVS gain not varied by MC)
+    for pt in result.points:
+        assert abs(pt.node_voltages["out"] - 5.0) < 1.0
+
+
+def test_vccs_mc_dc_runs() -> None:
+    """mc_dc runs without error in a circuit containing a VCCS."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        VCCS("G1", "0", "out", "in", "0", gm=0.01),
+    ])
+    result = mc_dc(c, "out", 5, seed=0)
+    assert len(result.points) == 5
+
+
+# ── Section 67: Error cases – unknown ctrl_source ────────────────────────────
+
+
+def test_cccs_dc_unknown_ctrl_source_raises() -> None:
+    """CCCS referencing a non-existent VoltageSource raises ValueError at
+    simulation time."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        CCCS("F1", "out", "0", "Vnonexistent", beta=2.0),
+    ])
+    with pytest.raises(ValueError, match="Vnonexistent"):
+        dc_op(c)
+
+
+def test_ccvs_dc_unknown_ctrl_source_raises() -> None:
+    """CCVS referencing a non-existent VoltageSource raises ValueError at
+    simulation time."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        CCVS("H1", "out", "0", "Vnonexistent", transresistance=100.0),
+    ])
+    with pytest.raises(ValueError, match="Vnonexistent"):
+        dc_op(c)
+
+
+def test_cccs_ac_unknown_ctrl_source_raises() -> None:
+    """CCCS with unknown ctrl_source also raises ValueError in AC analysis."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        Resistor("Rload", "out", "0", 100.0),
+        CCCS("F1", "out", "0", "Vbad", beta=1.0),
+    ])
+    with pytest.raises(ValueError, match="Vbad"):
+        ac_sweep(c, f_start=1.0, f_stop=1e3, n_points=2)
+
+
+def test_ccvs_ac_unknown_ctrl_source_raises() -> None:
+    """CCVS with unknown ctrl_source also raises ValueError in AC analysis."""
+    c = Circuit([
+        VoltageSource("Vin", "in", "0", 1.0),
+        CCVS("H1", "out", "0", "Vbad", transresistance=500.0),
+        Resistor("Rload", "out", "0", 100.0),
+    ])
+    with pytest.raises(ValueError, match="Vbad"):
+        ac_sweep(c, f_start=1.0, f_stop=1e3, n_points=2)


### PR DESCRIPTION
## Summary

- Implements all four SPICE dependent/controlled source elements: VCVS (E), VCCS (G), CCCS (F), and CCVS (H)
- Each element correctly stamps the MNA G-matrix and b-vector using proper KVL/KCL formulations
- Adds `TfResult.gain` property as a convenient alias for `transfer_ratio`
- Fixes a sign error in the CCCS stamp (was injecting current in the wrong direction; corrected to match SPICE F-element convention where positive current exits n_plus)
- Bumps package version to 0.10.0

## Changes

**New element classes** (`elements.py`):
- `VCVS` — voltage-controlled voltage source (gain `A`, requires branch unknown)
- `VCCS` — voltage-controlled current source (transconductance `gm`, no branch unknown)
- `CCCS` — current-controlled current source (current gain `beta`, no branch unknown)
- `CCVS` — current-controlled voltage source (transresistance `rm`, requires branch unknown)

**Engine refactors** (`engine.py`):
- `_branch_sources()` replaces `_voltage_sources()` — now collects VoltageSource, VCVS, and CCVS together since all three require MNA branch unknowns
- `_stamp_vcvs()`, `_stamp_vccs()`, `_stamp_cccs()`, `_stamp_ccvs()` with matching AC variants
- All DC/AC/TF/SENS/MC analyses updated to use `branch_srcs` and the new stamp functions

**Tests** (`tests/test_engine.py`):
- 287 tests pass, 85% coverage
- New test groups: `test_vcvs_*`, `test_vccs_*`, `test_cccs_*`, `test_ccvs_*`
- Tests cover DC op, transient, AC sweep, and `.TF` for each controlled source type
- Fixed `_cccs_circuit` helper to use SPICE-correct node order (was swapped as workaround for wrong stamp)

## Test plan

- [x] All 287 tests pass (`pytest`)
- [x] Coverage ≥ 80% (`pytest --cov`)
- [x] Linting clean (`ruff check src/ tests/`)
- [x] Security review passed (no findings)
- [x] CHANGELOG.md updated for v0.10.0
- [x] README.md updated with element table, analysis table, and 4 code examples (one per controlled source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)