### PR TITLE
feat(matrix-cpu): MX05 Phase 4.1 — DispatchSpecialised executes installed kernels (v0.4.0)

### DIFF
--- a/code/packages/rust/matrix-cpu/CHANGELOG.md
+++ b/code/packages/rust/matrix-cpu/CHANGELOG.md
@@ -2,6 +2,102 @@
 
 All notable changes to `matrix-cpu` are documented here.
 
+## [0.4.0] — 2026-05-12
+
+### Added — MX05 Phase 4.1 (specialised dispatch lands on CPU)
+
+- New `SpecialisedTable` (internal module `specialised_table`) — a
+  per-`CpuExecutor` table of installed specialised kernel closures,
+  keyed by the opaque `u64` handle that `CpuSpecialiser` emits.
+  Wraps a `HashMap<u64, Box<SpecialisedKernelFn>>` with installation
+  semantics (re-install replaces, ready for Phase 5 deoptimisation).
+- New `SpecialisedKernelFn` type alias —
+  `dyn Fn(&mut BufferStore, &[BufferId], &[BufferId]) -> Result<Vec<OpTiming>, String> + Send + Sync`.
+  Bounded by `Fn` (not `FnMut`) so a specialised kernel is statically
+  pure with respect to its captured environment; all per-call mutation
+  goes through the `&mut BufferStore` argument.
+- New `CpuExecutor::install_specialised(handle, kernel)` API.  Locks
+  the executor's internal `Mutex<State>` and inserts the closure
+  under `handle`.  Re-installing a previously-installed handle
+  replaces the closure.
+- New `CpuExecutor::specialised_count()` accessor — number of
+  installed specialised kernels.  Test/metric only; matches the
+  shape of `BufferStore::len`.
+- **`ExecutorRequest::DispatchSpecialised` handler is now live.**  On
+  handle hit: invokes the installed closure with the request's
+  `inputs`/`outputs` buffer ids and `&mut BufferStore`, returns
+  `DispatchDone { job_id, timings }` on success, or
+  `Error { code: RUNTIME_ERROR, .. }` if the closure errs.  On handle
+  miss: returns `Error { code: NOT_IMPLEMENTED, .. }` so the runtime
+  can fall back to the generic `Dispatch` path with the original
+  `ComputeGraph`.
+
+### Security hardening
+
+- **Panic-safe specialised dispatch.**  The closure invocation is
+  wrapped in `std::panic::catch_unwind(AssertUnwindSafe(...))` so a
+  panicking kernel (e.g. one that indexes attacker-supplied empty
+  `inputs[0]` and triggers an out-of-bounds panic) becomes a clean
+  `Error { code: RUNTIME_ERROR, message: "specialised kernel 0x…
+  panicked: …", .. }` response instead of unwinding through the
+  mutex guard and out of `handle()`.  This honours the existing
+  contract documented on `CpuExecutor::handle()`: "a single bad
+  request cannot DoS the executor for all subsequent clients".
+  Caught during the pre-push security review.
+
+### What this unlocks
+
+Up to v0.3.0, the Phase 4 pipeline emitted handles and populated
+`SpecCache` but no executor *did* anything with them — every
+dispatch still walked the generic `ComputeGraph` op-by-op.  Phase 4.1
+closes that loop on the CPU side: `DispatchSpecialised` now returns
+`DispatchDone` for installed handles.  matrix-metal's MSL emitter
+(Phase 4.2) will follow the same plumbing pattern but compile to
+`MetalComputePipelineState` cached by handle.
+
+### Tests (12 new, all passing)
+
+In `specialised_table::tests`:
+
+- `install_then_lookup_finds_kernel`
+- `lookup_of_missing_handle_returns_none`
+- `install_overwrites_prior_kernel`
+- `kernel_can_read_inputs_and_write_outputs`
+- `kernel_error_propagates`
+- `specialised_table_is_send_sync`
+- `debug_impl_shows_handles_not_pointers`
+
+In `tests/integration.rs` (§6 MX05 Phase 4.1):
+
+- `dispatch_specialised_returns_not_implemented_when_handle_unknown`
+- `dispatch_specialised_returns_dispatch_done_after_install`
+- `dispatch_specialised_kernel_error_becomes_runtime_error`
+- `install_specialised_overwrites_prior_kernel`
+- `dispatch_specialised_kernel_can_call_real_eval` — installs a
+  real f32 add closure, fires DispatchSpecialised, downloads the
+  result, asserts numerical correctness.  This is the test that
+  proves the full round-trip works.
+- `dispatch_specialised_kernel_panic_becomes_runtime_error_not_unwind`
+  — security regression for the `catch_unwind` hardening above.
+  Asserts that a panicking kernel surfaces as `RUNTIME_ERROR` and
+  that the executor still answers Heartbeat normally afterwards.
+
+Total test count: 33 unit + 23 integration (was 26 + 17).
+
+### Notes
+
+- The Phase 4.1 spec comment in `specialiser.rs` ("matrix-cpu can
+  store these in a per-handle `Vec<Box<dyn Fn>>`") is now realised —
+  except as a `HashMap<u64, ...>` since handles are sparse FNV-1a
+  hashes, not contiguous indices.
+- This release does **not** yet wire `SpecRouter` cache hits to
+  `install_specialised` automatically — that's a matrix-runtime
+  concern (next phase: runtime observes a cache hit, looks up the
+  `SpecialisedKernel`, installs a closure into the target executor,
+  routes the next invocation to `DispatchSpecialised`).  The
+  plumbing on the *executor* side, which is the harder of the two,
+  lands here.
+
 ## [0.3.0] — 2026-05-05
 
 ### Added — MX05 Phase 4 (first real backend Specialiser)

--- a/code/packages/rust/matrix-cpu/Cargo.toml
+++ b/code/packages/rust/matrix-cpu/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "matrix-cpu"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "CPU reference executor for the matrix execution layer. Implements every matrix-ir op on every dtype using straight-line Rust. The always-available safety net that supports operations no GPU backend can take. v0.3 adds CpuSpecialiser — the first backend `Specialiser` implementation, hooking the MX05 Phase 4 specialisation pipeline up to a real backend. Zero external dependencies."
+description = "CPU reference executor for the matrix execution layer. Implements every matrix-ir op on every dtype using straight-line Rust. The always-available safety net that supports operations no GPU backend can take. v0.4 (MX05 Phase 4.1) adds the per-handle specialised kernel table and live DispatchSpecialised handler: install a closure under a u64 handle via install_specialised, then DispatchSpecialised invokes it and returns DispatchDone instead of NOT_IMPLEMENTED. Zero external dependencies."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/matrix-cpu/src/lib.rs
+++ b/code/packages/rust/matrix-cpu/src/lib.rs
@@ -33,9 +33,11 @@ mod buffers;
 mod calibrate;
 mod dispatch;
 mod eval;
+mod specialised_table;
 mod specialiser;
 
 pub use calibrate::calibrate;
+pub use specialised_table::{SpecialisedKernelFn, SpecialisedTable};
 pub use specialiser::{specialiser, CpuSpecialiser};
 
 use compute_ir::{BufferId, KernelId};
@@ -99,6 +101,12 @@ struct State {
     /// (KernelId → ()).  Tracking it lets us answer `KernelReady` for
     /// the same kernel id repeatedly without complaint.
     kernels: std::collections::HashMap<KernelId, ()>,
+    /// **MX05 Phase 4.1.**  Per-handle table of installed specialised
+    /// kernel closures.  Looked up by `DispatchSpecialised { handle, .. }`
+    /// to find the closure to invoke instead of replaying a full
+    /// `ComputeGraph` op-by-op.  Empty on a fresh executor; populated
+    /// via [`CpuExecutor::install_specialised`].
+    specialised: SpecialisedTable,
     /// Next buffer id to assign.  Monotonic.
     next_buffer: u64,
 }
@@ -110,9 +118,50 @@ impl CpuExecutor {
             state: Mutex::new(State {
                 buffers: BufferStore::new(),
                 kernels: std::collections::HashMap::new(),
+                specialised: SpecialisedTable::new(),
                 next_buffer: 1,
             }),
         }
+    }
+
+    /// **MX05 Phase 4.1.**  Install a specialised kernel closure under
+    /// the given handle.  Subsequent `ExecutorRequest::DispatchSpecialised
+    /// { handle, .. }` requests carrying this handle invoke the closure
+    /// instead of returning `NOT_IMPLEMENTED`.
+    ///
+    /// The handle is opaque to this executor — its meaning is owned by
+    /// the [`CpuSpecialiser`] that emitted it (an FNV-1a hash of a
+    /// `SpecKey`).  Installation is the in-process equivalent of the
+    /// future "upload-specialised-kernel" protocol message; remote
+    /// transports will land that wire format in a later phase.
+    ///
+    /// Re-installing a previously-installed handle replaces the
+    /// closure — the path Phase 5 deoptimisation will use to swap in
+    /// a fresh kernel when an observed assumption fails.
+    ///
+    /// ## Mutex semantics
+    ///
+    /// Installation goes through the same `Mutex<State>` as every
+    /// other request, so a thread installing a kernel cannot race
+    /// with a thread dispatching one.  Acquiring this lock is the
+    /// price we pay for a `Send + Sync` executor.
+    pub fn install_specialised(&self, handle: u64, kernel: Box<SpecialisedKernelFn>) {
+        let mut s = match self.state.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        s.specialised.install(handle, kernel);
+    }
+
+    /// Number of specialised kernels currently installed.  Test-only
+    /// in spirit, but exposed publicly because integration tests in
+    /// downstream crates (matrix-runtime, image-gpu-core) will want it.
+    pub fn specialised_count(&self) -> usize {
+        let s = match self.state.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        s.specialised.len()
     }
 
     /// Process one request and produce a response.  Pure (modulo
@@ -211,18 +260,93 @@ impl CpuExecutor {
 
             ExecutorRequest::Shutdown => ExecutorResponse::ShuttingDown,
 
-            // V1 of `DispatchSpecialised` is the protocol surface only.
-            // matrix-cpu doesn't yet maintain a per-handle kernel
-            // table — that's MX05 Phase 4.1 work.  Reply with
-            // NOT_IMPLEMENTED so the runtime falls back to the
-            // generic `Dispatch` path.
-            ExecutorRequest::DispatchSpecialised { job_id, .. } => ExecutorResponse::Error {
-                code: ErrorCode::NOT_IMPLEMENTED,
-                message: "matrix-cpu doesn't yet execute specialised kernels; \
-                          MX05 Phase 4.1 will install the per-handle table"
-                    .to_string(),
-                job_id: Some(job_id),
-            },
+            // ──── MX05 Phase 4.1 — specialised dispatch ────
+            //
+            // Look the handle up in the per-executor specialised
+            // table.  Hit: invoke the closure with the supplied
+            // input/output buffer ids and return `DispatchDone`.
+            // Miss: return `NOT_IMPLEMENTED` so the runtime falls
+            // back to the generic `Dispatch` path with the original
+            // `ComputeGraph`.
+            //
+            // We split the borrow so the closure can take `&mut
+            // BufferStore` while the rest of `state` is otherwise
+            // untouched.  The `specialised` table is borrowed
+            // immutably (only the `Box<dyn Fn>` is invoked, never
+            // mutated by dispatch itself).
+            ExecutorRequest::DispatchSpecialised {
+                job_id,
+                handle,
+                inputs,
+                outputs,
+            } => {
+                // Re-borrow the two fields independently so the
+                // closure call doesn't conflict with the table lookup.
+                let State {
+                    ref mut buffers,
+                    ref specialised,
+                    ..
+                } = *s;
+                match specialised.get(handle) {
+                    Some(kernel) => {
+                        // Wrap the closure call in `catch_unwind` so a
+                        // panicking kernel (e.g. an out-of-bounds index
+                        // on attacker-supplied empty `inputs`) becomes
+                        // a clean `RUNTIME_ERROR` instead of unwinding
+                        // through the mutex guard and out of `handle()`.
+                        // This honours the contract documented on
+                        // `handle()` itself: "a single bad request
+                        // cannot DoS the executor for all subsequent
+                        // clients".  We use `AssertUnwindSafe` because
+                        // the &mut BufferStore reference may carry
+                        // partial writes across the unwind, which is
+                        // semantically fine — the next request sees
+                        // the partial state and bounds-checks anew on
+                        // every buffer access.
+                        let result = std::panic::catch_unwind(
+                            std::panic::AssertUnwindSafe(|| kernel(buffers, &inputs, &outputs)),
+                        );
+                        match result {
+                            Ok(Ok(timings)) => ExecutorResponse::DispatchDone { job_id, timings },
+                            Ok(Err(e)) => ExecutorResponse::Error {
+                                code: ErrorCode::RUNTIME_ERROR,
+                                message: format!("specialised kernel {}: {}", handle, e),
+                                job_id: Some(job_id),
+                            },
+                            Err(panic) => {
+                                // Extract a panic message if it was a
+                                // String or &'static str — the two
+                                // common payloads.  Anything else
+                                // becomes "unknown panic payload".
+                                let msg = if let Some(s) = panic.downcast_ref::<String>() {
+                                    s.clone()
+                                } else if let Some(s) = panic.downcast_ref::<&'static str>() {
+                                    (*s).to_string()
+                                } else {
+                                    "unknown panic payload".to_string()
+                                };
+                                ExecutorResponse::Error {
+                                    code: ErrorCode::RUNTIME_ERROR,
+                                    message: format!(
+                                        "specialised kernel 0x{:016X} panicked: {}",
+                                        handle, msg
+                                    ),
+                                    job_id: Some(job_id),
+                                }
+                            }
+                        }
+                    }
+                    None => ExecutorResponse::Error {
+                        code: ErrorCode::NOT_IMPLEMENTED,
+                        message: format!(
+                            "no specialised kernel installed for handle 0x{:016X}; \
+                             install one via CpuExecutor::install_specialised",
+                            handle
+                        ),
+                        job_id: Some(job_id),
+                    },
+                }
+            }
         }
     }
 }

--- a/code/packages/rust/matrix-cpu/src/specialised_table.rs
+++ b/code/packages/rust/matrix-cpu/src/specialised_table.rs
@@ -1,0 +1,289 @@
+//! `SpecialisedTable` — per-`CpuExecutor` table of installed specialised
+//! kernel closures, keyed by the opaque `u64` handle that
+//! [`CpuSpecialiser`] emits.
+//!
+//! # MX05 Phase 4.1 — what this module unlocks
+//!
+//! Up to Phase 4 the pipeline looked like this:
+//!
+//! ```text
+//!   sampler  →  policy  →  SpecRouter  →  CpuSpecialiser
+//!                                              │
+//!                                              ▼
+//!                                          SpecCache
+//!                                          (handle stored,
+//!                                           never invoked)
+//! ```
+//!
+//! The cache filled up but no one *did* anything with the handles —
+//! the dispatch path still walked the generic `ComputeGraph` for
+//! every op.  Phase 4.1 closes that loop:
+//!
+//! ```text
+//!   runtime  ──DispatchSpecialised(handle, in, out)──►  CpuExecutor
+//!                                                        │
+//!                                          handle ──►  SpecialisedTable
+//!                                                        │
+//!                                                        ▼
+//!                                              Box<dyn SpecialisedKernelFn>
+//!                                                        │
+//!                                                        ▼
+//!                                                  reads inputs,
+//!                                                  writes outputs,
+//!                                                  returns timings
+//! ```
+//!
+//! Phase 4.1 is intentionally minimum-viable on the *kernel* side —
+//! the closures we install in tests are simple byte-copies and
+//! single-op replays.  What this lands is the **plumbing**: the
+//! protocol-level `DispatchSpecialised` request, which already exists
+//! at the wire layer, now has an executor that answers `DispatchDone`
+//! instead of `NOT_IMPLEMENTED`.
+//!
+//! Later phases extend the closures themselves:
+//!
+//! - Phase 4.2: matrix-metal emits MSL strings keyed by handle and
+//!   compiles to `MetalComputePipelineState`.
+//! - Phase 5:   deoptimisation — closures self-invalidate when an
+//!   observed assumption proves wrong, and the table evicts them.
+//!
+//! # Closure signature
+//!
+//! ```ignore
+//! fn(&mut BufferStore, &[BufferId], &[BufferId]) -> Result<Vec<OpTiming>, String>
+//! ```
+//!
+//! The closure gets `&mut BufferStore` so it can read/write tensor
+//! bytes directly — no copies, no extra protocol round-trips.  It
+//! gets the runtime-supplied input/output `BufferId` lists from the
+//! `DispatchSpecialised` request payload.  It returns per-op timings
+//! using the same `OpTiming` shape as the generic `Dispatch` path,
+//! so the runtime's downstream profiler doesn't need a separate code
+//! path for specialised dispatches.
+//!
+//! # Why a HashMap
+//!
+//! Handles are 64-bit FNV-1a hashes of `SpecKey` — sparse and
+//! deterministic but not contiguous.  `HashMap<u64, _>` is the right
+//! shape; the table is read-mostly (one install per cache miss, many
+//! dispatches per install) so hashing cost on lookup is negligible
+//! relative to the kernel itself.
+//!
+//! # Send + Sync
+//!
+//! The boxed closure must be `Send + Sync` because `CpuExecutor`
+//! lives behind an `Arc<Mutex<_>>` and may be invoked from any
+//! thread.  Bounded by `dyn Fn(...) + Send + Sync`.
+
+use crate::buffers::BufferStore;
+use compute_ir::BufferId;
+use executor_protocol::OpTiming;
+use std::collections::HashMap;
+
+/// Boxed signature for a specialised CPU kernel.  See the module docs
+/// for what each argument means.
+///
+/// ## Why `Fn`, not `FnMut`
+///
+/// A specialised kernel is logically pure with respect to its
+/// closure environment: the same `(handle, inputs, outputs)` call
+/// must produce the same effect every invocation, otherwise the
+/// observer model behind specialisation breaks.  `Fn` enforces that
+/// statically — the kernel cannot mutate captured state across calls.
+/// All mutation goes through the `&mut BufferStore` argument, which
+/// is per-call and explicit.
+pub type SpecialisedKernelFn =
+    dyn Fn(&mut BufferStore, &[BufferId], &[BufferId]) -> Result<Vec<OpTiming>, String>
+        + Send
+        + Sync;
+
+/// Per-executor table of installed specialised kernel closures.
+///
+/// Wrapping the underlying map in a named type (rather than a bare
+/// `HashMap`) gives us:
+///
+/// - A natural place to hang invariants (e.g. "installation is
+///   monotonic in V1 — no eviction") and document them.
+/// - A choke point where Phase 5 deoptimisation can add an `evict()`
+///   method without touching every call site.
+/// - A `Debug` impl that hides the closures' pointer values, which
+///   are noisy and unstable across builds.
+#[derive(Default)]
+pub struct SpecialisedTable {
+    /// `handle → kernel closure`.  Boxed so the table is sized.
+    kernels: HashMap<u64, Box<SpecialisedKernelFn>>,
+}
+
+impl SpecialisedTable {
+    /// Construct an empty table.
+    pub fn new() -> Self {
+        SpecialisedTable {
+            kernels: HashMap::new(),
+        }
+    }
+
+    /// Install a kernel under `handle`.  Overwrites any prior closure
+    /// at the same handle.  Overwriting is intentionally allowed so
+    /// future deoptimisation can swap a closure for a fresh one
+    /// without a separate `evict-then-install` dance.
+    pub fn install(&mut self, handle: u64, kernel: Box<SpecialisedKernelFn>) {
+        self.kernels.insert(handle, kernel);
+    }
+
+    /// Look up a kernel by handle.  Returns `None` if the handle was
+    /// never installed.
+    pub fn get(&self, handle: u64) -> Option<&SpecialisedKernelFn> {
+        self.kernels.get(&handle).map(|boxed| boxed.as_ref())
+    }
+
+    /// True iff the handle is installed.
+    pub fn contains(&self, handle: u64) -> bool {
+        self.kernels.contains_key(&handle)
+    }
+
+    /// Number of installed kernels.  Useful for tests and metrics.
+    pub fn len(&self) -> usize {
+        self.kernels.len()
+    }
+
+    /// Whether the table has no installed kernels.
+    pub fn is_empty(&self) -> bool {
+        self.kernels.is_empty()
+    }
+}
+
+impl std::fmt::Debug for SpecialisedTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Show just the handle set; closure addresses are noise.
+        let handles: Vec<u64> = self.kernels.keys().copied().collect();
+        f.debug_struct("SpecialisedTable")
+            .field("installed_handles", &handles)
+            .finish()
+    }
+}
+
+// ────────────────────────── tests ──────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Install a no-op kernel and verify it can be looked up by handle.
+    #[test]
+    fn install_then_lookup_finds_kernel() {
+        let mut t = SpecialisedTable::new();
+        assert!(!t.contains(0xABCD));
+        t.install(0xABCD, Box::new(|_, _, _| Ok(vec![])));
+        assert!(t.contains(0xABCD));
+        assert_eq!(t.len(), 1);
+        assert!(t.get(0xABCD).is_some());
+    }
+
+    /// Lookup of a never-installed handle returns `None` cleanly —
+    /// the executor will use this to fall back to `NOT_IMPLEMENTED`.
+    #[test]
+    fn lookup_of_missing_handle_returns_none() {
+        let t = SpecialisedTable::new();
+        assert!(t.get(0xFEED).is_none());
+        assert!(!t.contains(0xFEED));
+    }
+
+    /// Re-installing the same handle is allowed and replaces the closure.
+    /// This is the path Phase 5 deoptimisation will use.
+    #[test]
+    fn install_overwrites_prior_kernel() {
+        let mut t = SpecialisedTable::new();
+        let calls_v1 = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls_v2 = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        {
+            let c = calls_v1.clone();
+            t.install(
+                42,
+                Box::new(move |_, _, _| {
+                    c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(vec![])
+                }),
+            );
+        }
+        // First invocation runs v1.
+        let mut buffers = BufferStore::new();
+        let _ = t.get(42).unwrap()(&mut buffers, &[], &[]);
+        assert_eq!(calls_v1.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        // Overwrite with v2; subsequent calls hit v2 only.
+        {
+            let c = calls_v2.clone();
+            t.install(
+                42,
+                Box::new(move |_, _, _| {
+                    c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(vec![])
+                }),
+            );
+        }
+        let _ = t.get(42).unwrap()(&mut buffers, &[], &[]);
+        assert_eq!(calls_v1.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(calls_v2.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    /// A kernel can read input buffers and write output buffers via
+    /// the `&mut BufferStore` argument.  This is the path real
+    /// specialised kernels will use.
+    #[test]
+    fn kernel_can_read_inputs_and_write_outputs() {
+        let mut buffers = BufferStore::new();
+        buffers.alloc(BufferId(1), 4);
+        buffers.alloc(BufferId(2), 4);
+        buffers.write(BufferId(1), 0, &[7, 8, 9, 10]).unwrap();
+
+        let mut t = SpecialisedTable::new();
+        // Identity-copy kernel: read input[0], write to output[0].
+        t.install(
+            99,
+            Box::new(|bufs, inputs, outputs| {
+                let src = bufs.read(inputs[0], 0, 4)?;
+                bufs.write(outputs[0], 0, &src)?;
+                Ok(vec![OpTiming { op_index: 0, ns: 0 }])
+            }),
+        );
+
+        let timings = t.get(99).unwrap()(&mut buffers, &[BufferId(1)], &[BufferId(2)]).unwrap();
+        assert_eq!(timings.len(), 1);
+        let out = buffers.read(BufferId(2), 0, 4).unwrap();
+        assert_eq!(out, vec![7, 8, 9, 10]);
+    }
+
+    /// A kernel that fails returns its error to the caller — the
+    /// executor will translate this into an `Error` response with
+    /// `RUNTIME_ERROR`, matching the generic `Dispatch` failure path.
+    #[test]
+    fn kernel_error_propagates() {
+        let mut t = SpecialisedTable::new();
+        t.install(
+            0,
+            Box::new(|_, _, _| Err("intentional failure".to_string())),
+        );
+        let mut buffers = BufferStore::new();
+        let r = t.get(0).unwrap()(&mut buffers, &[], &[]);
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err(), "intentional failure");
+    }
+
+    /// `SpecialisedTable` must be `Send + Sync` so `CpuExecutor`'s
+    /// `Mutex<State>` stays `Send + Sync`.
+    #[test]
+    fn specialised_table_is_send_sync() {
+        fn require_send_sync<T: Send + Sync>() {}
+        require_send_sync::<SpecialisedTable>();
+    }
+
+    /// `Debug` impl prints handles, not closure pointers.
+    #[test]
+    fn debug_impl_shows_handles_not_pointers() {
+        let mut t = SpecialisedTable::new();
+        t.install(0xCAFE, Box::new(|_, _, _| Ok(vec![])));
+        let printed = format!("{:?}", t);
+        assert!(printed.contains("51966"), "should contain decimal 0xCAFE: {}", printed);
+    }
+}

--- a/code/packages/rust/matrix-cpu/tests/integration.rs
+++ b/code/packages/rust/matrix-cpu/tests/integration.rs
@@ -750,3 +750,312 @@ fn local_transport_full_pipeline() {
     };
     assert_eq!(result, vec![4.0, 10.0, 18.0]);
 }
+
+// ─────────────── 6. MX05 Phase 4.1 — specialised dispatch ───────────────
+//
+// These tests exercise the full DispatchSpecialised path end-to-end:
+// install a closure via CpuExecutor::install_specialised, fire a
+// DispatchSpecialised request, observe DispatchDone (or a NOT_IMPLEMENTED
+// fall-through when the handle is unknown).
+
+use matrix_cpu::SpecialisedKernelFn;
+use std::sync::Arc;
+
+/// Helper: get a `CpuExecutor` wrapped in `Arc` so we can both install
+/// kernels and pass a clone into a `LocalTransport` for request routing.
+fn arc_executor() -> Arc<CpuExecutor> {
+    Arc::new(CpuExecutor::new())
+}
+
+fn transport_for(exec: Arc<CpuExecutor>) -> LocalTransport {
+    LocalTransport::new(move |req| exec.handle(req))
+}
+
+#[test]
+fn dispatch_specialised_returns_not_implemented_when_handle_unknown() {
+    // The fall-through path: no closure installed, DispatchSpecialised
+    // must still answer with a recognisable NOT_IMPLEMENTED so the
+    // runtime can fall back to the generic Dispatch route.
+    let exec = arc_executor();
+    let t = transport_for(exec);
+    let resp = block_on(t.request(ExecutorRequest::DispatchSpecialised {
+        job_id: 7,
+        handle: 0xDEAD_BEEF_DEAD_BEEF,
+        inputs: vec![],
+        outputs: vec![],
+    }))
+    .unwrap();
+    match resp {
+        ExecutorResponse::Error { code, job_id, .. } => {
+            assert_eq!(code, executor_protocol::ErrorCode::NOT_IMPLEMENTED);
+            assert_eq!(job_id, Some(7));
+        }
+        other => panic!("expected NOT_IMPLEMENTED error, got {:?}", other),
+    }
+}
+
+#[test]
+fn dispatch_specialised_returns_dispatch_done_after_install() {
+    // The happy path: install a closure under handle H, fire
+    // DispatchSpecialised with handle H, get DispatchDone back.
+    let exec = arc_executor();
+
+    // Identity-copy kernel: read input[0], write input[0]'s bytes to
+    // output[0].  Proves the dispatch path can actually read and
+    // write tensor bytes through the BufferStore.
+    let kernel: Box<SpecialisedKernelFn> = Box::new(|bufs, inputs, outputs| {
+        let src = bufs.read(inputs[0], 0, 4)?;
+        bufs.write(outputs[0], 0, &src)?;
+        Ok(vec![executor_protocol::OpTiming { op_index: 0, ns: 0 }])
+    });
+    exec.install_specialised(0xC0FF_EE00_C0FF_EE00, kernel);
+    assert_eq!(exec.specialised_count(), 1);
+
+    let t = transport_for(exec.clone());
+
+    // Allocate two buffers and seed the input.
+    let buf_in = match block_on(t.request(ExecutorRequest::AllocBuffer { bytes: 4 })).unwrap() {
+        ExecutorResponse::BufferAllocated { buffer } => buffer,
+        _ => panic!(),
+    };
+    let buf_out = match block_on(t.request(ExecutorRequest::AllocBuffer { bytes: 4 })).unwrap() {
+        ExecutorResponse::BufferAllocated { buffer } => buffer,
+        _ => panic!(),
+    };
+    block_on(t.request(ExecutorRequest::UploadBuffer {
+        buffer: buf_in,
+        offset: 0,
+        data: vec![0xAA, 0xBB, 0xCC, 0xDD],
+    }))
+    .unwrap();
+
+    let resp = block_on(t.request(ExecutorRequest::DispatchSpecialised {
+        job_id: 42,
+        handle: 0xC0FF_EE00_C0FF_EE00,
+        inputs: vec![buf_in],
+        outputs: vec![buf_out],
+    }))
+    .unwrap();
+
+    match resp {
+        ExecutorResponse::DispatchDone { job_id, timings } => {
+            assert_eq!(job_id, 42);
+            assert_eq!(timings.len(), 1);
+        }
+        other => panic!("expected DispatchDone, got {:?}", other),
+    }
+
+    // Verify the bytes actually landed in the output buffer.
+    let down = block_on(t.request(ExecutorRequest::DownloadBuffer {
+        buffer: buf_out,
+        offset: 0,
+        len: 4,
+    }))
+    .unwrap();
+    match down {
+        ExecutorResponse::BufferData { data, .. } => {
+            assert_eq!(data, vec![0xAA, 0xBB, 0xCC, 0xDD]);
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn dispatch_specialised_kernel_error_becomes_runtime_error() {
+    // A kernel that returns Err must surface as ErrorCode::RUNTIME_ERROR
+    // with the kernel's message embedded.  Same shape as generic
+    // Dispatch failures.
+    let exec = arc_executor();
+    let kernel: Box<SpecialisedKernelFn> = Box::new(|_, _, _| {
+        Err("intentional kernel failure".to_string())
+    });
+    exec.install_specialised(0x1234, kernel);
+    let t = transport_for(exec);
+
+    let resp = block_on(t.request(ExecutorRequest::DispatchSpecialised {
+        job_id: 99,
+        handle: 0x1234,
+        inputs: vec![],
+        outputs: vec![],
+    }))
+    .unwrap();
+    match resp {
+        ExecutorResponse::Error { code, message, job_id } => {
+            assert_eq!(code, executor_protocol::ErrorCode::RUNTIME_ERROR);
+            assert_eq!(job_id, Some(99));
+            assert!(message.contains("intentional kernel failure"));
+        }
+        other => panic!("expected Error, got {:?}", other),
+    }
+}
+
+#[test]
+fn install_specialised_overwrites_prior_kernel() {
+    // Re-installing the same handle replaces the closure — the path
+    // Phase 5 deoptimisation will use when an observed assumption fails.
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let exec = arc_executor();
+    let v1_calls = Arc::new(AtomicUsize::new(0));
+    let v2_calls = Arc::new(AtomicUsize::new(0));
+
+    {
+        let c = v1_calls.clone();
+        exec.install_specialised(
+            7,
+            Box::new(move |_, _, _| {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok(vec![])
+            }),
+        );
+    }
+
+    let t = transport_for(exec.clone());
+    block_on(t.request(ExecutorRequest::DispatchSpecialised {
+        job_id: 1,
+        handle: 7,
+        inputs: vec![],
+        outputs: vec![],
+    }))
+    .unwrap();
+    assert_eq!(v1_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(v2_calls.load(Ordering::SeqCst), 0);
+
+    // Overwrite.
+    {
+        let c = v2_calls.clone();
+        exec.install_specialised(
+            7,
+            Box::new(move |_, _, _| {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok(vec![])
+            }),
+        );
+    }
+    // specialised_count stays at 1 — install replaces, doesn't accumulate.
+    assert_eq!(exec.specialised_count(), 1);
+
+    block_on(t.request(ExecutorRequest::DispatchSpecialised {
+        job_id: 2,
+        handle: 7,
+        inputs: vec![],
+        outputs: vec![],
+    }))
+    .unwrap();
+    assert_eq!(v1_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(v2_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn dispatch_specialised_kernel_can_call_real_eval() {
+    // A specialised kernel can wrap any logic, including replaying a
+    // real matrix-ir op.  Here we install a closure that adds two
+    // length-3 f32 vectors via raw byte arithmetic — the same effect
+    // as Op::Add, but routed through the specialised path.  This is
+    // the shape Phase 4.2's metal emitter will take, just in MSL.
+    let exec = arc_executor();
+    let kernel: Box<SpecialisedKernelFn> = Box::new(|bufs, inputs, outputs| {
+        let a_bytes = bufs.read(inputs[0], 0, 12)?;
+        let b_bytes = bufs.read(inputs[1], 0, 12)?;
+        let mut out_bytes = vec![0u8; 12];
+        for i in 0..3 {
+            let a = f32::from_le_bytes(a_bytes[i*4..i*4+4].try_into().unwrap());
+            let b = f32::from_le_bytes(b_bytes[i*4..i*4+4].try_into().unwrap());
+            let c = a + b;
+            out_bytes[i*4..i*4+4].copy_from_slice(&c.to_le_bytes());
+        }
+        bufs.write(outputs[0], 0, &out_bytes)?;
+        Ok(vec![executor_protocol::OpTiming { op_index: 0, ns: 0 }])
+    });
+    exec.install_specialised(0xADD3F32, kernel);
+
+    let t = transport_for(exec);
+    let buf_a = match block_on(t.request(ExecutorRequest::AllocBuffer { bytes: 12 })).unwrap() {
+        ExecutorResponse::BufferAllocated { buffer } => buffer,
+        _ => panic!(),
+    };
+    let buf_b = match block_on(t.request(ExecutorRequest::AllocBuffer { bytes: 12 })).unwrap() {
+        ExecutorResponse::BufferAllocated { buffer } => buffer,
+        _ => panic!(),
+    };
+    let buf_out = match block_on(t.request(ExecutorRequest::AllocBuffer { bytes: 12 })).unwrap() {
+        ExecutorResponse::BufferAllocated { buffer } => buffer,
+        _ => panic!(),
+    };
+    block_on(t.request(ExecutorRequest::UploadBuffer {
+        buffer: buf_a,
+        offset: 0,
+        data: f32_bytes(&[1.0, 2.0, 3.0]),
+    }))
+    .unwrap();
+    block_on(t.request(ExecutorRequest::UploadBuffer {
+        buffer: buf_b,
+        offset: 0,
+        data: f32_bytes(&[10.0, 20.0, 30.0]),
+    }))
+    .unwrap();
+
+    block_on(t.request(ExecutorRequest::DispatchSpecialised {
+        job_id: 0,
+        handle: 0xADD3F32,
+        inputs: vec![buf_a, buf_b],
+        outputs: vec![buf_out],
+    }))
+    .unwrap();
+
+    let down = block_on(t.request(ExecutorRequest::DownloadBuffer {
+        buffer: buf_out,
+        offset: 0,
+        len: 12,
+    }))
+    .unwrap();
+    match down {
+        ExecutorResponse::BufferData { data, .. } => {
+            assert_eq!(from_f32_bytes(&data), vec![11.0, 22.0, 33.0]);
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn dispatch_specialised_kernel_panic_becomes_runtime_error_not_unwind() {
+    // **Security-hardening regression test.**  The doc comment on
+    // `CpuExecutor::handle()` promises "a single bad request cannot
+    // DoS the executor for all subsequent clients".  An installed
+    // kernel that panics (e.g. due to attacker-supplied empty inputs
+    // triggering an out-of-bounds index) must surface as a clean
+    // `RUNTIME_ERROR` rather than unwinding through the mutex guard
+    // and out of `handle()`.
+    let exec = arc_executor();
+    let kernel: Box<SpecialisedKernelFn> = Box::new(|_bufs, inputs, _outputs| {
+        // Deliberately out-of-bounds — panics if `inputs` is empty.
+        let _ = inputs[0];
+        Ok(vec![])
+    });
+    exec.install_specialised(0x5BAD, kernel);
+
+    let t = transport_for(exec.clone());
+    let resp = block_on(t.request(ExecutorRequest::DispatchSpecialised {
+        job_id: 13,
+        handle: 0x5BAD,
+        inputs: vec![], // ← causes the panic
+        outputs: vec![],
+    }))
+    .unwrap();
+
+    match resp {
+        ExecutorResponse::Error { code, job_id, message } => {
+            assert_eq!(code, executor_protocol::ErrorCode::RUNTIME_ERROR);
+            assert_eq!(job_id, Some(13));
+            assert!(message.contains("panicked"), "message should mention panic: {}", message);
+        }
+        other => panic!("expected Error, got {:?}", other),
+    }
+
+    // **Crucial second assertion**: the executor still serves the
+    // *next* request normally.  If the panic had unwound through
+    // the mutex, the lock would be permanently poisoned (or worse,
+    // the process aborted) and this Heartbeat would fail.
+    let resp = block_on(t.request(ExecutorRequest::Heartbeat)).unwrap();
+    assert!(matches!(resp, ExecutorResponse::Alive { .. }));
+}

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -267,6 +267,29 @@ into the cache.
 > bytes are unchanged from V0.4.0; only the cache-size signal is
 > new.
 
+> **Implementation status (Phase 4.1 landed — specialised dispatch executes on CPU)**:
+> `matrix-cpu` v0.4.0 installs a per-handle closure table
+> (`SpecialisedTable`) on `CpuExecutor`.  New API
+> `CpuExecutor::install_specialised(handle, Box<dyn Fn>)` registers a
+> closure with signature
+> `fn(&mut BufferStore, &[BufferId], &[BufferId]) -> Result<Vec<OpTiming>, String>`
+> under the opaque `u64` handle emitted by `CpuSpecialiser`.
+> `ExecutorRequest::DispatchSpecialised { handle, inputs, outputs, .. }`
+> now does a real lookup: hit → invoke the closure, return
+> `DispatchDone { job_id, timings }`; miss → return
+> `Error { code: NOT_IMPLEMENTED, .. }` so the runtime falls back
+> to the generic `Dispatch` path.  This is the moment the spec MX05
+> promise that "the dispatch path actually invokes specialised
+> kernels" is realised — 12 new tests (7 unit + 5 integration) cover
+> install/lookup/overwrite/error/round-trip including a real f32
+> add closure that fires through DispatchSpecialised and produces
+> correct output bytes.  What's still pending: the runtime-side
+> piece that observes a `SpecRouter` cache hit and *automatically*
+> calls `install_specialised` on the target executor — a
+> matrix-runtime concern landing in the next phase.  Phase 4.2 will
+> mirror this plumbing in matrix-metal with an MSL emitter cached
+> by handle.
+
 > **Implementation status (Phase 4 minimum-viable landed — first real backend Specialiser)**:
 > `matrix_cpu::CpuSpecialiser` ships as the workspace's first real
 > `Specialiser` impl (previously every test and demo used


### PR DESCRIPTION
## Summary

Closes the loop opened by executor-protocol v0.2.0: handles emitted by `CpuSpecialiser` are now real things `matrix-cpu` can dispatch through. `DispatchSpecialised { handle, .. }` no longer always returns `NOT_IMPLEMENTED` — on a handle hit, it invokes the installed closure and returns `DispatchDone`.

## What this adds

- **`SpecialisedTable`** (new module): `HashMap<u64, Box<SpecialisedKernelFn>>` with install / get / contains / len. Re-install replaces (ready for Phase 5 deoptimisation).
- **`SpecialisedKernelFn`** type alias: `dyn Fn(&mut BufferStore, &[BufferId], &[BufferId]) -> Result<Vec<OpTiming>, String> + Send + Sync`. Bounded by `Fn` (not `FnMut`) so a kernel is statically pure w.r.t. its captured environment.
- **`CpuExecutor::install_specialised(handle, kernel)`** — installs a closure under the given handle. Goes through the same `Mutex<State>` as every other request, so install can't race with dispatch.
- **`CpuExecutor::specialised_count()`** — count accessor.
- **`DispatchSpecialised` handler arm**:
  - Handle hit → invoke closure, return `DispatchDone { job_id, timings }` (or `RUNTIME_ERROR` if the closure errs / panics)
  - Handle miss → `NOT_IMPLEMENTED` so the runtime falls back to generic `Dispatch`

## What this unlocks

Up to v0.3.0 the Phase 4 pipeline emitted handles and populated `SpecCache`, but no executor *did* anything with them — every dispatch still walked the generic `ComputeGraph` op-by-op. Phase 4.1 closes the loop on the CPU side. matrix-metal will follow with an MSL emitter (Phase 4.2). Next runtime-side work: matrix-runtime observing a cache hit and automatically calling \`install_specialised\` on the target executor.

## Security hardening

Pre-push security review caught one LOW finding: the doc comment on \`CpuExecutor::handle()\` promises \"a single bad request cannot DoS the executor for all subsequent clients\", but an installed kernel that panics (e.g. on attacker-supplied empty \`inputs[0]\`) would unwind through the mutex guard and break that promise. Fixed by wrapping the closure call in \`std::panic::catch_unwind(AssertUnwindSafe(...))\`, downcasting String and &'static str panic payloads, and returning a clean \`Error { code: RUNTIME_ERROR, message: \"specialised kernel 0x… panicked: …\" }\`. Regression test \`dispatch_specialised_kernel_panic_becomes_runtime_error_not_unwind\` covers it.

## Test plan

- [x] \`cargo test -p matrix-cpu\` — 33 unit + 23 integration tests pass (13 new)
- [x] \`cargo test -p matrix-runtime\` — 17 + 8 tests pass
- [x] \`cargo test -p image-gpu-core\` — 28 tests pass
- [x] \`cargo test -p matrix-metal\` — 17 tests pass
- [x] \`cargo test -p executor-protocol\` — 16 + 20 tests pass
- [x] Security review (2 rounds, LOW finding fixed before push)
- [x] Spec MX05 updated with \"Phase 4.1 landed\" status block

🤖 Generated with [Claude Code](https://claude.com/claude-code)