### PR TITLE
Wire Rust MACSYMA inequality solve

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Wired `Solve(inequality, variable)` to the Rust `cas-solve`
+  `try_solve_inequality` handler, returning `List(...)` interval predicates
+  for supported one-variable polynomial inequalities.
 - Wired `linsolve` / `Solve(List(...), List(...))` to the Rust `cas-solve`
   exact linear-system solver.
 - Added runtime coverage for integer systems, rational systems, and non-linear

--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -17,3 +17,9 @@ The runtime also wires MACSYMA `linsolve`/`Solve(List(...), List(...))` calls to
 the Rust `cas-solve` exact linear-system solver. Supported systems return
 `List(Rule(variable, value), ...)`; unsupported or non-linear systems remain as
 unevaluated `Solve(...)` IR nodes.
+
+`Solve(inequality, variable)` also delegates to the Rust `cas-solve` polynomial
+inequality solver. Supported one-variable polynomial inequalities return
+`List(...)` interval predicates such as `Greater(x, 1)` or
+`And(GreaterEqual(x, -1), LessEqual(x, 1))`; unsupported inequalities remain
+unevaluated.

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -8,13 +8,16 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use cas_simplify::simplify;
-use cas_solve::{solve_linear_system, SOLVE};
+use cas_solve::{solve_linear_system, try_solve_inequality, SOLVE};
 use cas_trig::{expand_trig, trig_simplify};
 use coding_adventures_macsyma_compiler::{
     compile_macsyma_with_options, CompileError, CompileOptions, DISPLAY as COMPILER_DISPLAY,
     SUPPRESS as COMPILER_SUPPRESS,
 };
-use symbolic_ir::{apply, sym, IRApply, IRNode, ASSIGN, DEFINE, IF, LIST, POW};
+use symbolic_ir::{
+    apply, sym, IRApply, IRNode, ASSIGN, DEFINE, GREATER, GREATER_EQUAL, IF, LESS, LESS_EQUAL,
+    LIST, POW,
+};
 use symbolic_vm::backend::{handler_fn, Backend, Handler};
 use symbolic_vm::handlers::build_handler_table;
 use symbolic_vm::VM;
@@ -603,6 +606,12 @@ fn solve_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
         return fallback;
     }
 
+    if matches!(expr.args[1], IRNode::Symbol(_)) && is_inequality(&expr.args[0]) {
+        return try_solve_inequality(&expr.args[0], &expr.args[1])
+            .map(|solutions| apply(sym(LIST), solutions))
+            .unwrap_or(fallback);
+    }
+
     let Some(equations) = apply_with_head(&expr.args[0], LIST) else {
         return fallback;
     };
@@ -620,6 +629,18 @@ fn solve_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     solve_linear_system(&equations.args, &variables.args)
         .map(|rules| apply(sym(LIST), rules))
         .unwrap_or(fallback)
+}
+
+fn is_inequality(node: &IRNode) -> bool {
+    match node {
+        IRNode::Apply(apply) => {
+            is_head_name(&apply.head, LESS)
+                || is_head_name(&apply.head, GREATER)
+                || is_head_name(&apply.head, LESS_EQUAL)
+                || is_head_name(&apply.head, GREATER_EQUAL)
+        }
+        _ => false,
+    }
 }
 
 fn numer_fold(node: IRNode) -> IRNode {

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -3,7 +3,10 @@ use coding_adventures_macsyma_runtime::{
     extend_macsyma_name_table, macsyma_name_table, MacsymaSession, EV, KILL,
 };
 use std::collections::HashMap;
-use symbolic_ir::{apply, int, rat, sym, ADD, DIV, EQUAL, LIST, MUL, POW, RULE, SUB};
+use symbolic_ir::{
+    apply, int, rat, sym, ADD, AND, DIV, EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, LIST,
+    MUL, POW, RULE, SUB,
+};
 
 #[test]
 fn evaluates_arithmetic_program() {
@@ -291,6 +294,123 @@ fn keeps_non_linear_solve_calls_unevaluated() {
                 )],
             ),
             apply(sym(LIST), vec![x]),
+        ],
+    );
+
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![expr.clone()]);
+    assert_eq!(results[0].output, expr);
+}
+
+#[test]
+fn solves_polynomial_inequalities_through_cas_solve() {
+    let x = sym("x");
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![
+        apply(
+            sym(SOLVE),
+            vec![
+                apply(
+                    sym(GREATER),
+                    vec![apply(sym(SUB), vec![x.clone(), int(1)]), int(0)],
+                ),
+                x.clone(),
+            ],
+        ),
+        apply(
+            sym(SOLVE),
+            vec![
+                apply(
+                    sym(GREATER),
+                    vec![
+                        apply(
+                            sym(SUB),
+                            vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+                        ),
+                        int(0),
+                    ],
+                ),
+                x.clone(),
+            ],
+        ),
+        apply(
+            sym(SOLVE),
+            vec![
+                apply(
+                    sym(LESS_EQUAL),
+                    vec![
+                        apply(
+                            sym(SUB),
+                            vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+                        ),
+                        int(0),
+                    ],
+                ),
+                x.clone(),
+            ],
+        ),
+        apply(
+            sym(SOLVE),
+            vec![
+                apply(
+                    sym(GREATER_EQUAL),
+                    vec![apply(sym(POW), vec![x.clone(), int(2)]), int(0)],
+                ),
+                x.clone(),
+            ],
+        ),
+    ]);
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(LIST),
+            vec![apply(sym(GREATER), vec![x.clone(), int(1)])]
+        )
+    );
+    assert_eq!(
+        results[1].output,
+        apply(
+            sym(LIST),
+            vec![
+                apply(sym(LESS), vec![x.clone(), int(-1)]),
+                apply(sym(GREATER), vec![x.clone(), int(1)]),
+            ],
+        )
+    );
+    assert_eq!(
+        results[2].output,
+        apply(
+            sym(LIST),
+            vec![apply(
+                sym(AND),
+                vec![
+                    apply(sym(GREATER_EQUAL), vec![x.clone(), int(-1)]),
+                    apply(sym(LESS_EQUAL), vec![x.clone(), int(1)]),
+                ],
+            )],
+        )
+    );
+    assert_eq!(
+        results[3].output,
+        apply(
+            sym(LIST),
+            vec![apply(sym(GREATER_EQUAL), vec![int(0), int(0)])],
+        )
+    );
+}
+
+#[test]
+fn keeps_unsupported_inequality_solve_calls_unevaluated() {
+    let x = sym("x");
+    let expr = apply(
+        sym(SOLVE),
+        vec![
+            apply(
+                sym(GREATER),
+                vec![apply(sym("Sin"), vec![x.clone()]), int(0)],
+            ),
+            x,
         ],
     );
 


### PR DESCRIPTION
## Summary
- route `Solve(inequality, variable)` through the Rust `cas-solve` `try_solve_inequality` handler
- return `List(...)` interval predicates for supported one-variable polynomial inequalities and preserve unevaluated fallback behavior
- document the runtime surface alongside the existing `linsolve` / linear-system wiring

## Validation
- `cargo test -p cas-solve -p coding-adventures-macsyma-runtime -- --nocapture` in `code/packages/rust`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-macsyma-inequality-runtime.json` from `code/programs/go/build-tool`