### PR TITLE
[codex] Summarize Board VM smoke output from Rust

### DIFF
--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -1513,6 +1513,24 @@ fn write_descriptor<W>(output: &mut W, descriptor: &BoardDescriptorInfo) -> Resu
 where
     W: Write,
 {
+    write_descriptor_summary(output, descriptor)?;
+    for capability in &descriptor.capabilities {
+        writeln!(
+            output,
+            "cap id=0x{:04X} version={} flags=0x{:04X} name={}",
+            capability.id, capability.version, capability.flags, capability.name
+        )?;
+    }
+    Ok(())
+}
+
+fn write_descriptor_summary<W>(
+    output: &mut W,
+    descriptor: &BoardDescriptorInfo,
+) -> Result<(), CliError>
+where
+    W: Write,
+{
     writeln!(
         output,
         "caps board={} runtime={} max_program_bytes={} stack={} handles={} store={} capabilities={}",
@@ -1524,13 +1542,6 @@ where
         descriptor.supports_store_program,
         descriptor.capabilities.len()
     )?;
-    for capability in &descriptor.capabilities {
-        writeln!(
-            output,
-            "cap id=0x{:04X} version={} flags=0x{:04X} name={}",
-            capability.id, capability.version, capability.flags, capability.name
-        )?;
-    }
     Ok(())
 }
 
@@ -1550,10 +1561,17 @@ fn write_run<W>(output: &mut W, run: &RunReportInfo) -> Result<(), CliError>
 where
     W: Write,
 {
+    write_labeled_run(output, "run", run)
+}
+
+fn write_labeled_run<W>(output: &mut W, label: &str, run: &RunReportInfo) -> Result<(), CliError>
+where
+    W: Write,
+{
     if run.returns.is_empty() {
         writeln!(
             output,
-            "run program_id={} status={:?} instructions={} elapsed_ms={} stack_depth={} open_handles={}",
+            "{label} program_id={} status={:?} instructions={} elapsed_ms={} stack_depth={} open_handles={}",
             run.program_id,
             run.status,
             run.instructions_executed,
@@ -1564,7 +1582,7 @@ where
     } else {
         writeln!(
             output,
-            "run program_id={} status={:?} instructions={} elapsed_ms={} stack_depth={} open_handles={} returns=[{}]",
+            "{label} program_id={} status={:?} instructions={} elapsed_ms={} stack_depth={} open_handles={} returns=[{}]",
             run.program_id,
             run.status,
             run.instructions_executed,
@@ -1575,6 +1593,16 @@ where
         )?;
     }
     Ok(())
+}
+
+pub fn write_smoke_report<W>(output: &mut W, report: &SmokeReport) -> Result<(), CliError>
+where
+    W: Write,
+{
+    write_hello(output, &report.hello)?;
+    write_descriptor_summary(output, &report.descriptor)?;
+    write_upload(output, &report.upload)?;
+    write_labeled_run(output, "blink", &report.run)
 }
 
 fn format_run_values(values: &[RunValue]) -> String {
@@ -1636,7 +1664,7 @@ pub fn usage() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use board_vm_client::TransportError;
+    use board_vm_client::{CapabilityInfo, TransportError};
     use board_vm_loopback::{LoopbackBoard, LOOPBACK_BOARD_ID, LOOPBACK_RUNTIME_ID};
     use board_vm_protocol::RunStatus;
 
@@ -2432,6 +2460,59 @@ mod tests {
         assert!(report.run.instructions_executed > 0);
         assert_eq!(report.run.open_handles, 1);
         assert!(report.run.returns.is_empty());
+    }
+
+    #[test]
+    fn smoke_report_writer_includes_upload_and_full_run_summary() {
+        let report = SmokeReport {
+            hello: HelloAckInfo {
+                selected_version: 1,
+                board_name: "loopback-uno-r4".to_owned(),
+                runtime_name: "board-vm-loopback".to_owned(),
+                host_nonce: 0x1234_ABCD,
+                board_nonce: 0xAABB_CCDD,
+                max_frame_payload: 512,
+            },
+            descriptor: BoardDescriptorInfo {
+                board_id: "loopback-uno-r4".to_owned(),
+                runtime_id: "board-vm-loopback".to_owned(),
+                max_program_bytes: 512,
+                max_stack_values: 8,
+                max_handles: 4,
+                supports_store_program: true,
+                capabilities: vec![CapabilityInfo {
+                    id: board_vm_protocol::CAP_PROGRAM_RAM_EXEC,
+                    version: 1,
+                    flags: board_vm_protocol::CAP_FLAG_PROTOCOL_FEATURE,
+                    name: "program.ram_exec".to_owned(),
+                }],
+            },
+            upload: UploadReport {
+                program_id: 3,
+                total_len: 42,
+                program_crc32: 0xCAFE_BABE,
+            },
+            run: RunReportInfo {
+                program_id: 3,
+                status: RunStatus::Halted,
+                instructions_executed: 7,
+                elapsed_ms: 250,
+                stack_depth: 1,
+                open_handles: 0,
+                returns: vec![RunValue::U32(99)],
+            },
+        };
+        let mut out = Vec::new();
+
+        write_smoke_report(&mut out, &report).unwrap();
+
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "hello board=loopback-uno-r4 runtime=board-vm-loopback protocol=1 host_nonce=0x1234ABCD board_nonce=0xAABBCCDD\n\
+caps board=loopback-uno-r4 runtime=board-vm-loopback max_program_bytes=512 stack=8 handles=4 store=true capabilities=1\n\
+upload program_id=3 bytes=42 crc32=0xCAFEBABE\n\
+blink program_id=3 status=Halted instructions=7 elapsed_ms=250 stack_depth=1 open_handles=0 returns=[99]\n"
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-cli/src/main.rs
+++ b/code/packages/rust/board-vm-cli/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use board_vm_cli::{
     format_onboard_led, list_pico_bootsel_mounts, list_ports, list_targets, parse_args,
     run_eject_blink, run_esp_detect, run_esp_upload, run_pico_uf2_upload, run_repl, run_smoke,
-    usage, CliCommand,
+    usage, write_smoke_report, CliCommand,
 };
 
 fn main() {
@@ -82,36 +82,8 @@ fn run_command(command: CliCommand) -> Result<(), board_vm_cli::CliError> {
         }
         CliCommand::Smoke(options) => {
             let report = run_smoke(&options)?;
-            println!(
-                "hello board={} runtime={} protocol={} host_nonce=0x{:08X} board_nonce=0x{:08X}",
-                report.hello.board_name,
-                report.hello.runtime_name,
-                report.hello.selected_version,
-                report.hello.host_nonce,
-                report.hello.board_nonce
-            );
-            println!(
-                "caps board={} runtime={} max_program_bytes={} stack={} handles={} capabilities={}",
-                report.descriptor.board_id,
-                report.descriptor.runtime_id,
-                report.descriptor.max_program_bytes,
-                report.descriptor.max_stack_values,
-                report.descriptor.max_handles,
-                report.descriptor.capabilities.len()
-            );
-            println!(
-                "upload program_id={} bytes={} crc32=0x{:08X}",
-                report.upload.program_id, report.upload.total_len, report.upload.program_crc32
-            );
-            println!(
-                "blink program_id={} status={:?} instructions={} elapsed_ms={} open_handles={}",
-                report.run.program_id,
-                report.run.status,
-                report.run.instructions_executed,
-                report.run.elapsed_ms,
-                report.run.open_handles
-            );
-            Ok(())
+            let mut stdout = std::io::stdout();
+            write_smoke_report(&mut stdout, &report)
         }
         CliCommand::Repl(options) => {
             let stdin = std::io::stdin();


### PR DESCRIPTION
## Summary
- add a Rust-owned Board VM smoke report formatter
- route the smoke CLI output through the shared formatter
- include upload metadata, store support, stack depth, and return values in smoke summaries

## Validation
- cargo test -p board-vm-cli
- cargo test -p board-vm-language-core -p board-vm-bluetooth -p board-vm-tcp
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check