### PR TITLE
Add TypeScript cas-solve transcendental basics

### DIFF
--- a/code/packages/typescript/cas-solve/CHANGELOG.md
+++ b/code/packages/typescript/cas-solve/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `trySolveTranscendental` for direct Phase 26-style transcendental
+  equations `f(linear) = constant` across trig, exp/log, and hyperbolic heads.
 - Add `trySolveInequality` for Phase 27-style polynomial inequality solving
   over rational univariate polynomials up to degree 4.
 - Add `solveLinearSystem` with exact Gaussian elimination, `Equal(lhs, rhs)`

--- a/code/packages/typescript/cas-solve/README.md
+++ b/code/packages/typescript/cas-solve/README.md
@@ -15,6 +15,7 @@ bindings.
 | `solveQuartic(a, b, c, d, e)` | Solve `a*x^4 + b*x^3 + c*x^2 + d*x + e = 0` |
 | `solveLinearSystem(equations, variables)` | Solve exact square linear systems and return `Rule(var, value)` nodes |
 | `trySolveInequality(ineq, variable)` | Solve polynomial inequalities up to degree 4 and return interval conditions |
+| `trySolveTranscendental(eq, variable)` | Solve direct `f(linear) = constant` transcendental equations |
 | `nsolvePoly(coeffs)` | Numerically solve a polynomial via Durand-Kerner |
 | `rootsToIr(roots)` / `nsolveFractionPoly(coeffs)` | Convert numeric roots to symbolic IR |
 
@@ -42,6 +43,12 @@ IR nodes, normalizes `lhs op rhs` to a univariate rational polynomial in the
 requested variable, and returns interval predicates such as `Less(x, a)`,
 `GreaterEqual(x, a)`, or bounded `And(...)` ranges. Unsupported non-polynomial
 inputs return `null`.
+
+`trySolveTranscendental` accepts `Equal(lhs, rhs)` or a bare expression treated
+as equal to zero. It handles direct equations where one side is a supported
+transcendental function of a linear expression in the requested variable and
+the other side is constant with respect to that variable. The first slice covers
+`Sin`, `Cos`, `Tan`, `Exp`, `Log`, `Sinh`, `Cosh`, and `Tanh`.
 
 `nsolvePoly` accepts real or complex coefficients in descending degree order,
 normalizes by the leading coefficient, and returns all roots as `{ re, im }`

--- a/code/packages/typescript/cas-solve/src/index.ts
+++ b/code/packages/typescript/cas-solve/src/index.ts
@@ -1,18 +1,32 @@
 import {
   ADD,
   AND,
+  ACOS,
+  ACOSH,
+  ASIN,
+  ASINH,
+  ATAN,
+  ATANH,
+  COS,
+  COSH,
   DIV,
   EQUAL,
+  EXP,
   GREATER,
   GREATER_EQUAL,
   LESS,
   LESS_EQUAL,
+  LOG,
   MUL,
   NEG,
   POW,
   RULE,
+  SIN,
+  SINH,
   SQRT,
   SUB,
+  TAN,
+  TANH,
   app,
   equals,
   int,
@@ -28,6 +42,7 @@ export const NSOLVE = "NSolve";
 export const ROOTS = "Roots";
 export const I_UNIT = "%i";
 export const CBRT = "Cbrt";
+export const FREE_INTEGER = "FreeInteger";
 const MAX_INEQUALITY_DEGREE = 4;
 const REAL_ROOT_TOL = 1e-8;
 
@@ -336,6 +351,13 @@ export function trySolveInequality(ineq: IRNode, variable: IRSymbol): readonly I
   return solvePolynomialSign(coeffs, variable, wantPositive, strict);
 }
 
+export function trySolveTranscendental(eq: IRNode, variable: IRSymbol): readonly IRNode[] | null {
+  const split = splitEqual(eq);
+  if (split === null) return tryFuncEqConst(eq, int(0), variable);
+  return tryFuncEqConst(split[0], split[1], variable)
+    ?? tryFuncEqConst(split[1], split[0], variable);
+}
+
 export function nsolvePoly(
   coeffs: readonly (number | Complex)[],
   maxIter = 200,
@@ -579,6 +601,74 @@ function initialRadius(poly: readonly Complex[]): number {
   const constant = complexAbs(poly[degree]);
   const lagrange = constant > 1e-300 ? constant ** (1 / degree) : 1;
   return Math.max(Math.min(cauchy, 10), lagrange, 0.5);
+}
+
+function tryFuncEqConst(funcSide: IRNode, constSide: IRNode, variable: IRSymbol): readonly IRNode[] | null {
+  if (!isConstWrt(constSide, variable)) return null;
+  if (funcSide.kind !== "apply" || funcSide.head.kind !== "symbol" || funcSide.args.length !== 1) {
+    return null;
+  }
+
+  const linear = extractLinear(funcSide.args[0], variable);
+  if (linear === null) return null;
+  const [a, b] = linear;
+  const twoPiK = app(MUL, [int(2), app(MUL, [sym("%pi"), sym(FREE_INTEGER)])]);
+  const head = funcSide.head.name;
+
+  if (head === SIN.name) {
+    const asinC = app(ASIN, [constSide]);
+    return [
+      solveLinearForValue(a, b, app(ADD, [asinC, twoPiK])),
+      solveLinearForValue(a, b, app(ADD, [app(SUB, [sym("%pi"), asinC]), twoPiK])),
+    ];
+  }
+
+  if (head === COS.name) {
+    const acosC = app(ACOS, [constSide]);
+    return [
+      solveLinearForValue(a, b, app(ADD, [acosC, twoPiK])),
+      solveLinearForValue(a, b, app(ADD, [app(NEG, [acosC]), twoPiK])),
+    ];
+  }
+
+  if (head === TAN.name) {
+    return [solveLinearForValue(a, b, app(ADD, [app(ATAN, [constSide]), app(MUL, [sym("%pi"), sym(FREE_INTEGER)])]))];
+  }
+
+  if (head === EXP.name) return [solveLinearForValue(a, b, app(LOG, [constSide]))];
+  if (head === LOG.name) return [solveLinearForValue(a, b, app(EXP, [constSide]))];
+  if (head === SINH.name) return [solveLinearForValue(a, b, app(ASINH, [constSide]))];
+  if (head === COSH.name) {
+    const acoshC = app(ACOSH, [constSide]);
+    return [
+      solveLinearForValue(a, b, acoshC),
+      solveLinearForValue(a, b, app(NEG, [acoshC])),
+    ];
+  }
+  if (head === TANH.name) return [solveLinearForValue(a, b, app(ATANH, [constSide]))];
+
+  return null;
+}
+
+function splitEqual(node: IRNode): readonly [IRNode, IRNode] | null {
+  return isApplyHead(node, EQUAL.name) && node.args.length === 2 ? [node.args[0], node.args[1]] : null;
+}
+
+function extractLinear(node: IRNode, variable: IRSymbol): readonly [Frac, Frac] | null {
+  const coeffs = extractPolynomial(node, variable.name, 1);
+  if (coeffs === null || coeffs.length !== 2 || coeffs[1].isZero()) return null;
+  return [coeffs[1], coeffs[0]];
+}
+
+function solveLinearForValue(a: Frac, b: Frac, value: IRNode): IRNode {
+  const shifted = b.isZero() ? value : app(SUB, [value, b.toIrNode()]);
+  return a.equals(Frac.one()) ? shifted : app(DIV, [shifted, a.toIrNode()]);
+}
+
+function isConstWrt(node: IRNode, variable: IRSymbol): boolean {
+  if (node.kind === "symbol") return node.name !== variable.name;
+  return node.kind !== "apply"
+    || (isConstWrt(node.head, variable) && node.args.every((arg) => isConstWrt(arg, variable)));
 }
 
 function equationToRow(

--- a/code/packages/typescript/cas-solve/tests/cas-solve.test.ts
+++ b/code/packages/typescript/cas-solve/tests/cas-solve.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { ADD, AND, DIV, EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, MUL, POW, RULE, SQRT, SUB, app, equals, int, numberNode, rational, sym, type IRNode, type IRSymbol } from "@coding-adventures/symbolic-ir";
+import { ACOSH, ADD, AND, ASIN, ASINH, ATAN, ATANH, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, LOG, MUL, NEG, POW, RULE, SIN, SINH, SQRT, SUB, TAN, TANH, app, equals, int, numberNode, rational, sym, type IRNode, type IRSymbol } from "@coding-adventures/symbolic-ir";
 import {
   ALL_SOLUTIONS,
   CBRT,
+  FREE_INTEGER,
   Frac,
   I_UNIT,
   nsolveFractionPoly,
@@ -14,6 +15,7 @@ import {
   solveQuadratic,
   solveQuartic,
   trySolveInequality,
+  trySolveTranscendental,
   type SolveResult,
 } from "../src/index";
 
@@ -402,5 +404,57 @@ describe("trySolveInequality", () => {
     }
     expect(trySolveInequality(app(GREATER, [app(sym("Sin"), [x]), int(0)]), x)).toBeNull();
     expect(trySolveInequality(eq(x, int(0)), x)).toBeNull();
+  });
+});
+
+describe("trySolveTranscendental", () => {
+  const x = sym("x");
+
+  it("solves direct exponential and logarithmic equations", () => {
+    expectNodes(
+      trySolveTranscendental(eq(app(EXP, [x]), int(2)), x),
+      [app(LOG, [int(2)])],
+    );
+    expectNodes(
+      trySolveTranscendental(eq(app(LOG, [add(mul(int(2), x), int(3))]), int(5)), x),
+      [app(DIV, [app(SUB, [app(EXP, [int(5)]), int(3)]), int(2)])],
+    );
+  });
+
+  it("solves direct trig equations with periodic families", () => {
+    const twoPiK = app(MUL, [int(2), app(MUL, [sym("%pi"), sym(FREE_INTEGER)])]);
+    expectNodes(
+      trySolveTranscendental(eq(app(SIN, [x]), int(0)), x),
+      [
+        app(ADD, [app(ASIN, [int(0)]), twoPiK]),
+        app(ADD, [app(SUB, [sym("%pi"), app(ASIN, [int(0)])]), twoPiK]),
+      ],
+    );
+    expectNodes(
+      trySolveTranscendental(eq(app(TAN, [add(mul(int(2), x), int(1))]), int(3)), x),
+      [app(DIV, [app(SUB, [app(ADD, [app(ATAN, [int(3)]), app(MUL, [sym("%pi"), sym(FREE_INTEGER)])]), int(1)]), int(2)])],
+    );
+  });
+
+  it("solves direct hyperbolic equations", () => {
+    expectNodes(
+      trySolveTranscendental(eq(app(SINH, [x]), int(2)), x),
+      [app(ASINH, [int(2)])],
+    );
+    expectNodes(
+      trySolveTranscendental(eq(app(TANH, [add(x, int(4))]), rational(1, 2)), x),
+      [app(SUB, [app(ATANH, [rational(1, 2)]), int(4)])],
+    );
+    expectNodes(
+      trySolveTranscendental(eq(app(sym("Cosh"), [x]), int(3)), x),
+      [app(ACOSH, [int(3)]), app(NEG, [app(ACOSH, [int(3)])])],
+    );
+  });
+
+  it("handles bare and reversed equations and rejects unsupported patterns", () => {
+    expect(trySolveTranscendental(app(EXP, [x]), x)?.length).toBe(1);
+    expect(trySolveTranscendental(eq(int(2), app(EXP, [x])), x)?.length).toBe(1);
+    expect(trySolveTranscendental(eq(app(SIN, [sym("y")]), int(0)), x)).toBeNull();
+    expect(trySolveTranscendental(eq(app(SIN, [app(SIN, [x])]), int(0)), x)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add `trySolveTranscendental` for direct Phase 26-style `f(linear) = constant` equations in TypeScript `cas-solve`
- cover trig periodic families, exp/log inverses, and hyperbolic inverses with exact linear back-solving
- document the new API and add parity tests for direct, reversed, bare-expression, and unsupported cases

## Validation
- `npm test && npm run build` in `code/packages/typescript/cas-solve`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-cas-solve-transcendental-basic.json` from `code/programs/go/build-tool`