### PR TITLE
Add artifact store inventory summaries

### DIFF
--- a/code/packages/rust/artifact-store/CHANGELOG.md
+++ b/code/packages/rust/artifact-store/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   session/tool/job/agent attribution coverage over selected artifact manifests.
 - `ArtifactManifestSummary` and `manifest_summary()` for compact collection,
   content-type, and label coverage over selected artifact manifests.
+- `ArtifactInventorySummary` and `inventory_summary()` to compose catalog,
+  provenance, and manifest status into one bounded read-side inventory view.
 - `ArtifactRevisionHistorySummary` and `revision_history_summary()` for
   bounded lineage, metadata, and body-size aggregates over revision history.
 

--- a/code/packages/rust/artifact-store/README.md
+++ b/code/packages/rust/artifact-store/README.md
@@ -14,6 +14,7 @@ bodies so plans, exports, screenshots, and reports can be referenced by ID.
 - catalog summaries for retention and revision coverage over selected artifacts
 - provenance summaries for session/tool/job/agent attribution coverage
 - manifest summaries for collection, content-type, and label coverage
+- inventory summaries that compose catalog, provenance, and manifest status
 - bounded revision-history listing without returning opaque bodies
 - revision-history summaries for lineage, metadata, and body-size coverage
 
@@ -35,6 +36,7 @@ bodies so plans, exports, screenshots, and reports can be referenced by ID.
 - `catalog_summary()`
 - `provenance_summary()`
 - `manifest_summary()`
+- `inventory_summary()`
 - `list_by_collection()`
 - `attach_labels()`
 - `mark_retention()`
@@ -59,6 +61,10 @@ manifests or revision bodies.
 coverage over the same selected manifests. This lets status tools spot mixed
 artifact inventories, unlabeled outputs, and broad content classes before
 fetching revision bodies.
+
+`inventory_summary()` composes catalog, provenance, and manifest summaries over
+the same selected manifests. This gives D18A/D18D status tools one bounded
+read-side response for lifecycle, attribution, and manifest-shape checks.
 
 `ArtifactRevisionListOptions` gives read-side tools a bounded revision history
 view with oldest-first or latest-first ordering, an optional revision cursor,

--- a/code/packages/rust/artifact-store/src/lib.rs
+++ b/code/packages/rust/artifact-store/src/lib.rs
@@ -326,6 +326,50 @@ impl ArtifactManifestSummary {
     }
 }
 
+/// Composite manifest inventory for read-side D18A/D18D status tools.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ArtifactInventorySummary {
+    pub catalog: ArtifactCatalogSummary,
+    pub provenance: ArtifactProvenanceSummary,
+    pub manifest: ArtifactManifestSummary,
+}
+
+impl ArtifactInventorySummary {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_artifacts<'a, I>(artifacts: I) -> Self
+    where
+        I: IntoIterator<Item = &'a Artifact>,
+    {
+        let artifacts = artifacts.into_iter().collect::<Vec<_>>();
+        Self {
+            catalog: ArtifactCatalogSummary::from_artifacts(artifacts.iter().copied()),
+            provenance: ArtifactProvenanceSummary::from_artifacts(artifacts.iter().copied()),
+            manifest: ArtifactManifestSummary::from_artifacts(artifacts),
+        }
+    }
+
+    pub fn total_artifacts(&self) -> usize {
+        self.catalog.total_artifacts
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_artifacts() == 0
+    }
+
+    pub fn durable_artifacts(&self) -> usize {
+        self.catalog.durable_artifacts()
+    }
+
+    pub fn needs_inventory_attention(&self) -> bool {
+        self.catalog.has_unrevisioned_artifacts()
+            || self.provenance.has_unattributed_artifacts()
+            || self.manifest.has_unlabeled_artifacts()
+    }
+}
+
 /// Input used when first creating an artifact manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateArtifactInput {
@@ -680,6 +724,14 @@ impl<S: StorageBackend> ArtifactStore<S> {
     ) -> Result<ArtifactManifestSummary, StorageError> {
         let artifacts = self.list_artifacts(options)?;
         Ok(ArtifactManifestSummary::from_artifacts(&artifacts))
+    }
+
+    pub fn inventory_summary(
+        &self,
+        options: ArtifactListOptions,
+    ) -> Result<ArtifactInventorySummary, StorageError> {
+        let artifacts = self.list_artifacts(options)?;
+        Ok(ArtifactInventorySummary::from_artifacts(&artifacts))
     }
 
     pub fn attach_labels(
@@ -1615,6 +1667,87 @@ mod tests {
         assert_eq!(empty, ArtifactManifestSummary::empty());
         assert!(empty.is_empty());
         assert!(!empty.has_labels());
+    }
+
+    #[test]
+    fn inventory_summary_composes_manifest_level_status() {
+        let store = ArtifactStore::new(InMemoryStorageBackend::new());
+        for (artifact_id, collection, content_type, labels, session_id, tool_id) in [
+            (
+                "plan",
+                "plans",
+                "text/plain",
+                vec!["draft"],
+                Some("session-a"),
+                Some("artifact.write"),
+            ),
+            (
+                "export",
+                "exports",
+                "application/json",
+                vec!["deliverable"],
+                Some("session-a"),
+                Some("artifact.export"),
+            ),
+            ("scratch", "scratch", "image/png", Vec::new(), None, None),
+        ] {
+            let _ = store
+                .create_artifact(CreateArtifactInput {
+                    artifact_id: artifact_id.to_string(),
+                    collection: collection.to_string(),
+                    name: artifact_id.to_string(),
+                    content_type: content_type.to_string(),
+                    labels: labels.into_iter().map(str::to_string).collect(),
+                    provenance: ArtifactProvenance {
+                        session_id: session_id.map(str::to_string),
+                        tool_id: tool_id.map(str::to_string),
+                        job_id: None,
+                        agent_id: None,
+                    },
+                })
+                .unwrap();
+        }
+        let _ = store
+            .mark_retention("export", ArtifactRetention::Exported)
+            .unwrap();
+        let _ = store
+            .append_revision(
+                "export",
+                AppendRevisionInput {
+                    revision_id: "rev-1".to_string(),
+                    metadata: JsonValue::Object(vec![]),
+                    body: b"{}".to_vec(),
+                },
+            )
+            .unwrap();
+
+        let summary = store.inventory_summary(ArtifactListOptions::new()).unwrap();
+
+        assert_eq!(summary.total_artifacts(), 3);
+        assert_eq!(summary.durable_artifacts(), 1);
+        assert_eq!(summary.catalog.exported_artifacts, 1);
+        assert_eq!(summary.catalog.artifacts_with_revisions, 1);
+        assert_eq!(summary.catalog.artifacts_without_revisions, 2);
+        assert_eq!(summary.provenance.session_scoped_artifacts, 2);
+        assert_eq!(summary.provenance.artifacts_without_provenance, 1);
+        assert_eq!(summary.manifest.unique_collections, 3);
+        assert_eq!(summary.manifest.json_artifacts, 1);
+        assert_eq!(summary.manifest.image_artifacts, 1);
+        assert!(summary.needs_inventory_attention());
+        assert!(!summary.is_empty());
+
+        let session_summary = store
+            .inventory_summary(ArtifactListOptions::new().for_session("session-a"))
+            .unwrap();
+        assert_eq!(session_summary.total_artifacts(), 2);
+        assert_eq!(session_summary.provenance.artifacts_without_provenance, 0);
+        assert!(!session_summary.manifest.has_unlabeled_artifacts());
+
+        let empty = store
+            .inventory_summary(ArtifactListOptions::new().for_collection("missing"))
+            .unwrap();
+        assert_eq!(empty, ArtifactInventorySummary::empty());
+        assert!(empty.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `ArtifactInventorySummary` as a composite read-side view over catalog, provenance, and manifest summaries
- expose `ArtifactStore::inventory_summary` so D18A/D18D status tools can fetch lifecycle, attribution, and manifest-shape status in one bounded manifest query
- document the new inventory summary API in the artifact-store README and changelog

## Tests
- `cargo test -p artifact-store`
- `git diff --check`
