### PR TITLE
Summarize smart-home event stream transports

### DIFF
--- a/code/packages/rust/smart-home-event-streams/CHANGELOG.md
+++ b/code/packages/rust/smart-home-event-streams/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this package will be documented in this file.
 - `EventStreamFleetSummary` and `event_stream_fleet_summary_at()` for compact
   supervisor health, cursor coverage, gap, heartbeat, and restart-readiness
   rollups across stream workers.
+- Transport-family counts and helpers on `EventStreamFleetSummary` for
+  supervisor coverage views.
 
 ## [0.1.0] - 2026-05-08
 

--- a/code/packages/rust/smart-home-event-streams/README.md
+++ b/code/packages/rust/smart-home-event-streams/README.md
@@ -22,6 +22,7 @@ radio workers a shared deterministic shape for:
 - restart plans that a runtime supervisor can inspect before spawning workers
 - deterministic state queries for dashboards, supervisors, and read-only tools
 - compact fleet summaries for supervisor health and restart-readiness checks
+- transport-family counts in fleet summaries for supervisor coverage views
 
 Protocol-specific transport clients, payload parsers, and adapter actors live in
 integration crates. This crate owns the boring rules that should stay the same

--- a/code/packages/rust/smart-home-event-streams/src/lib.rs
+++ b/code/packages/rust/smart-home-event-streams/src/lib.rs
@@ -931,6 +931,12 @@ pub struct EventStreamFleetSummary {
     pub total_pending_gaps: u32,
     pub restart_plans: usize,
     pub reconnect_ready_streams: usize,
+    pub server_sent_event_streams: usize,
+    pub websocket_streams: usize,
+    pub mqtt_subscription_streams: usize,
+    pub cloud_webhook_streams: usize,
+    pub serial_frame_streams: usize,
+    pub radio_report_streams: usize,
 }
 
 impl EventStreamFleetSummary {
@@ -960,6 +966,18 @@ impl EventStreamFleetSummary {
                 summary.local_streams += 1;
             } else {
                 summary.cloud_streams += 1;
+            }
+            match state.spec.transport {
+                EventStreamTransport::ServerSentEvents => {
+                    summary.server_sent_event_streams += 1;
+                }
+                EventStreamTransport::WebSocket => summary.websocket_streams += 1,
+                EventStreamTransport::MqttSubscription => {
+                    summary.mqtt_subscription_streams += 1;
+                }
+                EventStreamTransport::CloudWebhook => summary.cloud_webhook_streams += 1,
+                EventStreamTransport::SerialFrames => summary.serial_frame_streams += 1,
+                EventStreamTransport::RadioReports => summary.radio_report_streams += 1,
             }
             if state.spec.transport.needs_cursor() {
                 summary.cursor_required_streams += 1;
@@ -996,6 +1014,21 @@ impl EventStreamFleetSummary {
 
     pub fn unhealthy_streams(&self) -> usize {
         self.degraded_streams + self.disconnected_streams + self.backing_off_streams
+    }
+
+    pub fn transport_count(&self, transport: EventStreamTransport) -> usize {
+        match transport {
+            EventStreamTransport::ServerSentEvents => self.server_sent_event_streams,
+            EventStreamTransport::WebSocket => self.websocket_streams,
+            EventStreamTransport::MqttSubscription => self.mqtt_subscription_streams,
+            EventStreamTransport::CloudWebhook => self.cloud_webhook_streams,
+            EventStreamTransport::SerialFrames => self.serial_frame_streams,
+            EventStreamTransport::RadioReports => self.radio_report_streams,
+        }
+    }
+
+    pub fn has_transport(&self, transport: EventStreamTransport) -> bool {
+        self.transport_count(transport) > 0
     }
 }
 
@@ -2106,10 +2139,22 @@ mod tests {
                 total_pending_gaps: 2,
                 restart_plans: 3,
                 reconnect_ready_streams: 1,
+                server_sent_event_streams: 1,
+                websocket_streams: 1,
+                mqtt_subscription_streams: 1,
+                cloud_webhook_streams: 1,
+                serial_frame_streams: 0,
+                radio_report_streams: 0,
             }
         );
         assert_eq!(summary.unhealthy_streams(), 2);
         assert!(summary.has_supervision_work());
+        assert_eq!(
+            summary.transport_count(EventStreamTransport::MqttSubscription),
+            1
+        );
+        assert!(summary.has_transport(EventStreamTransport::CloudWebhook));
+        assert!(!summary.has_transport(EventStreamTransport::RadioReports));
         assert!(!summary.is_empty());
 
         let empty = event_stream_fleet_summary_at([], 1_700);


### PR DESCRIPTION
## Summary
- add transport-family counts to EventStreamFleetSummary
- expose transport count/presence helpers for supervisor coverage views
- document the event stream fleet transport summary surface

## Tests
- cargo test -p smart-home-event-streams
- git diff --check