### PR TITLE
Add executor protocol surface summary

### DIFF
--- a/code/packages/rust/executor-protocol/CHANGELOG.md
+++ b/code/packages/rust/executor-protocol/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `executor-protocol` are documented here.  The
 format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- `ProtocolSurfaceSummary` plus `protocol_surface_summary()` for
+  payload-free host/tool/catalog introspection of protocol version,
+  frame version, message counts, kernel-source counts, and specialised
+  dispatch support.
+- Public message-surface count constants:
+  `EXECUTOR_REQUEST_VARIANTS`, `EXECUTOR_RESPONSE_VARIANTS`,
+  `EXECUTOR_EVENT_VARIANTS`, and `KERNEL_SOURCE_VARIANTS`.
+
 ## [0.2.0] — 2026-05-05
 
 ### Added — MX05 Phase 4.1 protocol surface

--- a/code/packages/rust/executor-protocol/README.md
+++ b/code/packages/rust/executor-protocol/README.md
@@ -25,6 +25,8 @@ This crate defines:
 - **Local transport** — `LocalTransport` for in-process executors
 - **Async runner** — `block_on` (hand-rolled minimal poll loop, ~50 lines)
 - **Kernel cache** — `KernelCacheKey` (SipHash-based content key)
+- **Surface summary** — `ProtocolSurfaceSummary` for host/catalog
+  introspection without constructing protocol payloads
 
 V1 ships only `LocalTransport`.  Future transports (TCP, Unix sockets,
 ZeroMQ, NATS, WebSocket) are designed for, not shipped.
@@ -98,6 +100,26 @@ format on every `request()` call in **debug builds**.  This catches
 "I accidentally put a non-serializable type in the protocol" bugs at
 PR-test time.  Release builds skip the round-trip.
 
+## Protocol surface summary
+
+`protocol_surface_summary()` returns a compact, payload-free snapshot of
+the crate's executor boundary:
+
+```rust
+use executor_protocol::{
+    protocol_surface_summary, ErrorCode, PROTOCOL_VERSION,
+};
+
+let summary = protocol_surface_summary();
+assert_eq!(summary.protocol_version, PROTOCOL_VERSION);
+assert!(summary.supports_dispatch_specialised);
+assert_eq!(summary.not_implemented_code, ErrorCode::NOT_IMPLEMENTED);
+```
+
+Chief-of-Staff host/tool/catalog code can persist this summary in
+capability catalogs without logging kernel source text, buffers, or
+sample message payloads.
+
 ## Security
 
 The wire decoder accepts untrusted input (a remote executor could be
@@ -111,7 +133,7 @@ and `compute-ir`:
 - Varint capped at 10 bytes
 - UTF-8 validated for string fields
 - Truncation-at-every-position and 1024-iteration random-byte fuzz tests
-- All 12 message variants exhaustively round-tripped
+- Top-level message variants exhaustively round-tripped
 
 ## Testing
 
@@ -135,7 +157,7 @@ Test methodology (per spec MX03 §"Test methodology"):
 
 ```
 $ cargo tree -p executor-protocol
-executor-protocol v0.1.0
+executor-protocol v0.2.0
 ├── compute-ir v0.1.0
 │   └── matrix-ir v0.1.0
 └── matrix-ir v0.1.0

--- a/code/packages/rust/executor-protocol/src/lib.rs
+++ b/code/packages/rust/executor-protocol/src/lib.rs
@@ -50,8 +50,9 @@ mod kernel_cache;
 
 pub use frame::{MessageFrame, MessageKind};
 pub use messages::{
-    BackendProfile, ErrorCode, ExecutorEvent, ExecutorRequest, ExecutorResponse,
-    KernelSource, OpTiming,
+    BackendProfile, ErrorCode, ExecutorEvent, ExecutorRequest, ExecutorResponse, KernelSource,
+    OpTiming, EXECUTOR_EVENT_VARIANTS, EXECUTOR_REQUEST_VARIANTS, EXECUTOR_RESPONSE_VARIANTS,
+    KERNEL_SOURCE_VARIANTS,
 };
 pub use transport::{Transport, TransportError};
 pub use local::LocalTransport;
@@ -73,3 +74,72 @@ pub use wire::WireError;
 ///   Forward-compatible with v1 senders: every existing variant
 ///   still encodes/decodes byte-identically.
 pub const PROTOCOL_VERSION: u32 = 2;
+
+/// Compact, payload-free description of the current protocol surface.
+///
+/// Hosts and catalogs can persist or compare this value without
+/// constructing sample [`ExecutorRequest`] payloads or exposing kernel
+/// source bytes in diagnostics.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct ProtocolSurfaceSummary {
+    /// Payload protocol version expected inside [`MessageFrame`] payloads.
+    pub protocol_version: u32,
+    /// Top-level frame layout version.
+    pub frame_version: u8,
+    /// Number of [`MessageKind`] variants accepted by this crate.
+    pub message_kinds: usize,
+    /// Number of [`ExecutorRequest`] variants.
+    pub request_variants: usize,
+    /// Number of [`ExecutorResponse`] variants.
+    pub response_variants: usize,
+    /// Number of [`ExecutorEvent`] variants.
+    pub event_variants: usize,
+    /// Number of [`KernelSource`] variants.
+    pub kernel_source_variants: usize,
+    /// Whether `DispatchSpecialised` is part of this protocol surface.
+    pub supports_dispatch_specialised: bool,
+    /// Soft-refusal code used when a known request shape is not wired up.
+    pub not_implemented_code: ErrorCode,
+}
+
+impl ProtocolSurfaceSummary {
+    /// Summary for the protocol surface compiled into this crate.
+    pub const fn current() -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            frame_version: frame::FRAME_VERSION,
+            message_kinds: 3,
+            request_variants: EXECUTOR_REQUEST_VARIANTS,
+            response_variants: EXECUTOR_RESPONSE_VARIANTS,
+            event_variants: EXECUTOR_EVENT_VARIANTS,
+            kernel_source_variants: KERNEL_SOURCE_VARIANTS,
+            supports_dispatch_specialised: true,
+            not_implemented_code: ErrorCode::NOT_IMPLEMENTED,
+        }
+    }
+}
+
+/// Return a compact, payload-free summary of the current executor
+/// protocol surface.
+pub const fn protocol_surface_summary() -> ProtocolSurfaceSummary {
+    ProtocolSurfaceSummary::current()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_surface_summary_reports_current_contract() {
+        let summary = protocol_surface_summary();
+        assert_eq!(summary.protocol_version, PROTOCOL_VERSION);
+        assert_eq!(summary.frame_version, frame::FRAME_VERSION);
+        assert_eq!(summary.message_kinds, 3);
+        assert_eq!(summary.request_variants, EXECUTOR_REQUEST_VARIANTS);
+        assert_eq!(summary.response_variants, EXECUTOR_RESPONSE_VARIANTS);
+        assert_eq!(summary.event_variants, EXECUTOR_EVENT_VARIANTS);
+        assert_eq!(summary.kernel_source_variants, KERNEL_SOURCE_VARIANTS);
+        assert!(summary.supports_dispatch_specialised);
+        assert_eq!(summary.not_implemented_code, ErrorCode::NOT_IMPLEMENTED);
+    }
+}

--- a/code/packages/rust/executor-protocol/src/messages.rs
+++ b/code/packages/rust/executor-protocol/src/messages.rs
@@ -12,6 +12,18 @@
 
 use compute_ir::{BufferId, ComputeGraph, ExecutorId, KernelId};
 
+/// Number of [`KernelSource`] variants in the current protocol surface.
+pub const KERNEL_SOURCE_VARIANTS: usize = 7;
+
+/// Number of [`ExecutorRequest`] variants in the current protocol surface.
+pub const EXECUTOR_REQUEST_VARIANTS: usize = 11;
+
+/// Number of [`ExecutorResponse`] variants in the current protocol surface.
+pub const EXECUTOR_RESPONSE_VARIANTS: usize = 11;
+
+/// Number of [`ExecutorEvent`] variants in the current protocol surface.
+pub const EXECUTOR_EVENT_VARIANTS: usize = 3;
+
 /// Kernel source code in the per-backend language.  V1 ships with a
 /// fixed set of variants matching the GPU APIs we have in scope; the
 /// `Native` variant is an escape hatch for backends whose source
@@ -390,10 +402,109 @@ mod tests {
             },
         ];
         let mut tags: Vec<u8> = reqs.iter().map(|r| r.wire_tag()).collect();
+        assert_eq!(tags.len(), EXECUTOR_REQUEST_VARIANTS);
         tags.sort();
         let len = tags.len();
         tags.dedup();
         assert_eq!(tags.len(), len);
+    }
+
+    #[test]
+    fn response_tags_unique() {
+        let responses = [
+            ExecutorResponse::Registered {
+                executor_id: ExecutorId(0),
+            },
+            ExecutorResponse::KernelReady {
+                kernel_id: KernelId(0),
+            },
+            ExecutorResponse::BufferAllocated {
+                buffer: BufferId(0),
+            },
+            ExecutorResponse::BufferUploaded {
+                buffer: BufferId(0),
+            },
+            ExecutorResponse::DispatchDone {
+                job_id: 0,
+                timings: Vec::new(),
+            },
+            ExecutorResponse::BufferData {
+                buffer: BufferId(0),
+                data: Vec::new(),
+            },
+            ExecutorResponse::BufferFreed,
+            ExecutorResponse::Cancelled { job_id: 0 },
+            ExecutorResponse::Alive {
+                profile: stub_profile(),
+            },
+            ExecutorResponse::ShuttingDown,
+            ExecutorResponse::Error {
+                code: ErrorCode::NOT_IMPLEMENTED,
+                message: String::new(),
+                job_id: None,
+            },
+        ];
+        let mut tags: Vec<u8> = responses.iter().map(|r| r.wire_tag()).collect();
+        assert_eq!(tags.len(), EXECUTOR_RESPONSE_VARIANTS);
+        tags.sort();
+        let len = tags.len();
+        tags.dedup();
+        assert_eq!(tags.len(), len);
+    }
+
+    #[test]
+    fn event_tags_unique() {
+        let events = [
+            ExecutorEvent::BufferLost {
+                buffer: BufferId(0),
+                reason: String::new(),
+            },
+            ExecutorEvent::ProfileUpdated {
+                profile: stub_profile(),
+            },
+            ExecutorEvent::ShuttingDown,
+        ];
+        let mut tags: Vec<u8> = events.iter().map(|e| e.wire_tag()).collect();
+        assert_eq!(tags.len(), EXECUTOR_EVENT_VARIANTS);
+        tags.sort();
+        let len = tags.len();
+        tags.dedup();
+        assert_eq!(tags.len(), len);
+    }
+
+    #[test]
+    fn kernel_source_variant_count_is_documented() {
+        let sources = [
+            KernelSource::Msl {
+                code: String::new(),
+                entry: String::new(),
+            },
+            KernelSource::CudaC {
+                code: String::new(),
+                entry: String::new(),
+            },
+            KernelSource::Glsl {
+                code: String::new(),
+                entry: String::new(),
+            },
+            KernelSource::SpirV {
+                bytes: Vec::new(),
+                entry: String::new(),
+            },
+            KernelSource::Wgsl {
+                code: String::new(),
+                entry: String::new(),
+            },
+            KernelSource::OpenClC {
+                code: String::new(),
+                entry: String::new(),
+            },
+            KernelSource::Native {
+                backend: String::new(),
+                blob: Vec::new(),
+            },
+        ];
+        assert_eq!(sources.len(), KERNEL_SOURCE_VARIANTS);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add public executor protocol surface counts and a payload-free ProtocolSurfaceSummary
- expose protocol_surface_summary() for host/tool/catalog introspection
- document the summary API and add focused count/contract tests

## Tests
- cargo test -p executor-protocol