### PR TITLE
feat(image-gpu-core, matrix-metal): MX05 Phase 4.3 — runtime auto-installer (install half of the loop)

### DIFF
--- a/code/packages/rust/image-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/image-gpu-core/CHANGELOG.md
@@ -1,5 +1,92 @@
 # Changelog — image-gpu-core
 
+## 0.7.0 — 2026-05-12
+
+### Added — MX05 Phase 4.3 (runtime-side auto-installer; **install** half of the loop)
+
+Closes the install half of the spec-routing loop opened by matrix-metal
+Phase 4.2.  When `SpecRouter::route` returns a `SpecialisedKernel`,
+image-gpu-core now auto-compiles the kernel and installs it onto the
+metal executor — proving the chain:
+
+```
+sampler → policy → router → cache → msl_emitter → MetalExecutor::install_specialised_from_emitted
+```
+
+Phase 4.4 will land the **dispatch** half: replacing the generic
+`Dispatch { graph }` request with per-op `DispatchSpecialised` requests
+that actually invoke the installed kernels.  Split into a separate PR
+to keep this one reviewable.
+
+#### What's new
+
+- **`MetalBackend`** now holds an `Arc<matrix_metal::MetalExecutor>`
+  alongside the `LocalTransport`.  Previous code only kept the
+  transport (boxed `Fn`); the executor reference is needed so
+  image-gpu-core can call `install_specialised_from_emitted` directly.
+- **`try_auto_install_specialised(&SpecialisedKernel)`** — new
+  internal function.  When the router emits a specialised kernel,
+  this:
+    1. Checks a process-wide `INSTALLED_HANDLES: Mutex<HashSet<u64>>`
+       for idempotency.
+    2. Calls `matrix_metal::emit_specialised_kernel` to convert the
+       `SpecKey` + handle into an `EmittedKernel`.
+    3. Calls `MetalExecutor::install_specialised_from_emitted` to
+       compile the MSL and register the dispatching closure under
+       the handle.
+    4. Records the handle as installed (so repeat hits in the
+       `SpecRouter` cache don't pay MSL compilation cost more than
+       once).
+  Returns `false` on any short-circuit (already installed, emitter
+  doesn't support the SpecKey shape, compile failure, no metal
+  backend).  Compile failures don't mark the handle as installed so
+  a future emitter fix can retry.
+- **`drive_specialisation`** now consumes the router's return value
+  and feeds it to `try_auto_install_specialised`.  Previously
+  `r.route(...)` was called for its side effect on the cache and the
+  return discarded.
+- **`pub fn specialised_install_count() -> usize`** — new public
+  hook.  Distinct from `spec_cache_len`: the cache tracks emitted
+  handles; this counter tracks how many of those handles have
+  actually been compiled and registered with an executor.  Always
+  `0` on non-Apple builds (the matrix-cpu auto-install path will
+  land in a later phase — `CpuSpecialiser` emits opaque handles
+  today, not closure sources).
+
+#### Integration test
+
+`auto_installer_registers_kernel_after_threshold` (Apple-only):
+
+- Builds a 4-element f32 Add-with-constant graph using
+  `matrix_ir::GraphBuilder` directly.
+- Runs it 1100 times — enough for `DefaultPolicy`'s 1000-invocation
+  threshold to fire on the constant input.
+- Asserts that `specialised_install_count()` rises above zero.
+
+This is the first test in image-gpu-core where a kernel actually
+gets compiled and installed onto an executor through the entire
+specialisation pipeline.  Test count: 28 → 29.
+
+#### What this still doesn't do (Phase 4.4 territory)
+
+- The next dispatch of the same graph still goes through generic
+  `Dispatch { graph }` — the installed specialised kernel is
+  registered but not yet invoked.
+- matrix-cpu auto-install — `CpuSpecialiser` produces handles
+  without closure sources, so there's nothing to install.  Phase
+  4.5 will either extend `CpuSpecialiser` to emit closure-producing
+  metadata or land a separate cpu-emit pipeline.
+
+#### Stub additions in matrix-metal
+
+So image-gpu-core compiles cleanly on non-Apple CI:
+
+- `MetalExecutor::install_specialised(handle, kernel)` — no-op
+  stub on non-Apple.
+- `MetalExecutor::install_specialised_from_emitted(handle, emitted)`
+  — returns `Err("unavailable on non-Apple targets")` on non-Apple.
+- `MetalExecutor::specialised_count()` — always `0` on non-Apple.
+
 ## 0.6.0 — 2026-05-05
 
 ### Added — MX05 Phase 4.2 (tensor-byte sampling)

--- a/code/packages/rust/image-gpu-core/Cargo.toml
+++ b/code/packages/rust/image-gpu-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "image-gpu-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
-description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). Each operation is a MatrixIR graph dispatched through matrix-runtime. v0.3 wires the optional matrix-metal GPU backend with transparent fallback to matrix-cpu. v0.4 wires the MX05 specialisation pipeline (Profiler + SpecRouter) into every dispatch. v0.5 installs matrix_cpu::CpuSpecialiser. v0.6 adds tensor-byte sampling in drive_specialisation so DefaultPolicy fires on real constant-input observations; the temporary HotPolicy workaround is gone and the threshold returns to spec MX05's 1000-invocation default."
+description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). Each operation is a MatrixIR graph dispatched through matrix-runtime. v0.3 wires the optional matrix-metal GPU backend with transparent fallback to matrix-cpu. v0.4 wires the MX05 specialisation pipeline. v0.5 installs matrix_cpu::CpuSpecialiser. v0.6 adds tensor-byte sampling so DefaultPolicy fires on real constant-input observations. v0.7 (MX05 Phase 4.3) adds the runtime-side auto-installer: when SpecRouter::route returns a cached SpecialisedKernel, this crate auto-compiles the emitted MSL via msl_emitter and installs it onto the metal executor, with a new specialised_install_count() counter for visibility. Dispatch-routing through DispatchSpecialised is Phase 4.4 work."
 
 [dependencies]
 matrix-ir         = { path = "../matrix-ir" }

--- a/code/packages/rust/image-gpu-core/src/lib.rs
+++ b/code/packages/rust/image-gpu-core/src/lib.rs
@@ -58,7 +58,15 @@ pub use pipeline::last_executor;
 /// Phase 4 lands a real specialiser).  [`spec_cache_len`] reports
 /// how many specialised kernels are cached process-wide; always 0
 /// while the no-op specialiser is installed in V1.
-pub use pipeline::{profiler_observations, spec_cache_len};
+///
+/// **MX05 Phase 4.3** adds [`specialised_install_count`] —
+/// distinct from [`spec_cache_len`], this counter tracks how many
+/// cached handles have actually been auto-installed onto a backing
+/// executor (today: metal) so they're ready for `DispatchSpecialised`
+/// invocation.  The two converge under normal operation; they diverge
+/// briefly while installs are in flight or when the emitter doesn't
+/// support a given `SpecKey` shape.
+pub use pipeline::{profiler_observations, spec_cache_len, specialised_install_count};
 
 use matrix_ir::{DType, GraphBuilder, Shape};
 

--- a/code/packages/rust/image-gpu-core/src/pipeline.rs
+++ b/code/packages/rust/image-gpu-core/src/pipeline.rs
@@ -845,11 +845,13 @@ mod tests {
     ///           → SpecialisedTable grows
     /// ```
     ///
-    /// Apple-only — no metal executor on Linux / Windows CI, so
-    /// `specialised_install_count` stays at 0 there by definition.
-    /// The non-metal CI runners still exercise the
-    /// `#[cfg(not(feature = "metal-backend"))]` stub through normal
-    /// compilation; the runtime-behaviour assertion only runs on macOS.
+    /// Apple-only — `metal-backend` is feature-gated *at compile
+    /// time* and is enabled by default on every platform, but the
+    /// actual Metal device is only available at runtime on Apple
+    /// targets (`MetalExecutor::new` returns `Err` elsewhere).  So
+    /// we gate on `target_vendor = "apple"` rather than the feature
+    /// flag — on Linux/Windows CI, `specialised_install_count`
+    /// stays at 0 by definition and there's nothing to assert.
     ///
     /// Test scope intentionally limited:
     /// - We only assert that the **install** side fires.  Phase 4.4
@@ -862,7 +864,7 @@ mod tests {
     ///   filters happen to hit that exact shape.  Future emitter
     ///   extensions (Sub/Mul/Div) will broaden the surface so that
     ///   real filters drive the install path automatically.
-    #[cfg(feature = "metal-backend")]
+    #[cfg(all(feature = "metal-backend", target_vendor = "apple"))]
     #[test]
     fn auto_installer_registers_kernel_after_threshold() {
         use crate::specialised_install_count;

--- a/code/packages/rust/image-gpu-core/src/pipeline.rs
+++ b/code/packages/rust/image-gpu-core/src/pipeline.rs
@@ -65,7 +65,15 @@ use std::cell::Cell;
 use std::collections::HashMap;
 #[cfg(feature = "metal-backend")]
 use std::collections::HashSet;
+#[cfg(feature = "metal-backend")]
+use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(not(feature = "metal-backend"))]
 use std::sync::OnceLock;
+// matrix_profile re-exports SpecialisedKernel via matrix_runtime; we
+// take it directly so the auto-installer can pattern-match on its
+// `key` field.
+#[cfg(feature = "metal-backend")]
+use matrix_runtime::SpecialisedKernel;
 
 // ─────────────────────────── Last-executor reporting ───────────────────────────
 
@@ -108,6 +116,13 @@ fn set_last_executor(name: Option<&'static str>) {
 
 #[cfg(feature = "metal-backend")]
 struct MetalBackend {
+    /// **MX05 Phase 4.3.**  Direct reference to the metal executor so
+    /// the auto-installer ([`try_auto_install_specialised`]) can call
+    /// [`MetalExecutor::install_specialised_from_emitted`] when the
+    /// `SpecRouter` produces a kernel.  Previously this module only
+    /// kept the `LocalTransport`, which hides the executor behind a
+    /// boxed `Fn` and offers no direct install API.
+    executor: Arc<matrix_metal::MetalExecutor>,
     transport: LocalTransport,
     profile: executor_protocol::BackendProfile,
 }
@@ -115,11 +130,20 @@ struct MetalBackend {
 #[cfg(feature = "metal-backend")]
 fn metal_backend() -> Option<&'static MetalBackend> {
     static SLOT: OnceLock<Option<MetalBackend>> = OnceLock::new();
-    SLOT.get_or_init(|| match matrix_metal::local_transport() {
-        Ok(transport) => Some(MetalBackend {
-            transport,
-            profile: matrix_metal::profile(),
-        }),
+    SLOT.get_or_init(|| match matrix_metal::MetalExecutor::new() {
+        Ok(exec) => {
+            // Pattern mirrors `matrix_metal::local_transport`, but we
+            // keep the `Arc<MetalExecutor>` alongside the transport so
+            // image-gpu-core can call install methods on it directly.
+            let exec = Arc::new(exec);
+            let exec2 = exec.clone();
+            let transport = LocalTransport::new(move |req| exec2.handle(req));
+            Some(MetalBackend {
+                executor: exec,
+                transport,
+                profile: matrix_metal::profile(),
+            })
+        }
         Err(_) => None,
     })
     .as_ref()
@@ -184,6 +208,138 @@ pub fn profiler_observations() -> Vec<matrix_runtime::ProfileObservation> {
 /// distinct `SpecKey`.
 pub fn spec_cache_len() -> usize {
     spec_router().cache_len()
+}
+
+/// **MX05 Phase 4.3.**  Number of specialised kernels that have been
+/// auto-installed onto a backing executor via the runtime auto-installer.
+///
+/// Distinct from [`spec_cache_len`] — the cache tracks emitted handles,
+/// while this counter tracks how many of those handles have actually
+/// been turned into compiled pipelines and registered with an executor.
+/// The two converge under normal operation but diverge briefly while
+/// installs are in flight or when an install fails (e.g. compilation
+/// rejects the emitted MSL).
+///
+/// On non-Apple targets this always returns `0` — there's no Metal
+/// executor to install onto, and the matrix-cpu auto-install path
+/// (which would need a closure source, not just a handle) is later
+/// MX05 phase work.
+#[cfg(feature = "metal-backend")]
+pub fn specialised_install_count() -> usize {
+    match metal_backend() {
+        Some(b) => b.executor.specialised_count(),
+        None => 0,
+    }
+}
+
+/// **MX05 Phase 4.3.**  No-op stub for non-Apple targets.  Always `0`.
+#[cfg(not(feature = "metal-backend"))]
+pub fn specialised_install_count() -> usize {
+    0
+}
+
+// ─────────────────────── MX05 Phase 4.3 — auto-installer ───────────────────────
+//
+// When `SpecRouter::route` returns `Some(SpecialisedKernel)`, this
+// module attempts to *install* the kernel onto the backing executor
+// so that future invocations can dispatch through the protocol-level
+// `DispatchSpecialised` path.
+//
+// V0.3.0 ships the **install side only**:
+//
+//   * Auto-install on metal: cache hit → `msl_emitter::emit_specialised_kernel`
+//     → `MetalExecutor::install_specialised_from_emitted`.  Backed by an
+//     `INSTALLED_HANDLES: HashSet<u64>` so re-installs are skipped.
+//
+//   * matrix-cpu auto-install: deferred to a later phase.  `CpuSpecialiser`
+//     only emits opaque handles today — it doesn't carry a closure
+//     source, so there's no auto-install translation available yet.
+//     The matrix-cpu Phase 4.1 install API works (and tests cover it
+//     in matrix-cpu's integration suite), it just isn't invoked
+//     automatically from here yet.
+//
+//   * **Dispatch-routing side:** the next dispatch still goes through
+//     generic `Dispatch { graph }`.  Phase 4.4 will land
+//     `dispatch_specialised_via` that walks the placed graph,
+//     fires per-op `DispatchSpecialised` requests, and proves the
+//     end-to-end DispatchDone → speedup loop.  Splitting that work
+//     into its own PR keeps Phase 4.3 reviewable.
+
+/// Process-wide set of handles we've already attempted to install
+/// onto a metal executor.  Initialisation is lazy so non-metal builds
+/// never allocate.
+#[cfg(feature = "metal-backend")]
+fn installed_handles() -> &'static Mutex<HashSet<u64>> {
+    static SLOT: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// **MX05 Phase 4.3.**  Try to auto-install a `SpecialisedKernel` onto
+/// the metal executor, returning `true` if a fresh install happened.
+///
+/// Idempotent across calls with the same handle — `INSTALLED_HANDLES`
+/// tracks which handles we've already installed so repeat hits in the
+/// `SpecRouter` cache don't pay MSL compilation cost more than once.
+///
+/// Returns `false` when:
+/// - metal isn't available (non-Apple build, or `MetalExecutor::new`
+///   failed at startup);
+/// - `msl_emitter::emit_specialised_kernel` returns `None`
+///   (Phase 4.2's emitter only supports a small set of SpecKey shapes);
+/// - the handle was already installed in a prior call;
+/// - compilation failed (rare — MSL emitter is bug-free for the
+///   shapes it claims to support, but the install API returns Err
+///   here just in case).  In the compile-fail case we **don't** mark
+///   the handle as installed so a future emitter fix can retry.
+///
+/// Hot-path cost: one mutex acquire on `INSTALLED_HANDLES`, plus
+/// (on miss) one MSL compile (~few ms on Apple Silicon) and one
+/// mutex acquire inside `MetalExecutor::install_specialised_from_emitted`.
+/// Subsequent calls with the same handle are a single mutex acquire
+/// and a `HashSet::contains` — sub-microsecond.
+#[cfg(feature = "metal-backend")]
+fn try_auto_install_specialised(specialised: &SpecialisedKernel) -> bool {
+    let Some(backend) = metal_backend() else {
+        return false;
+    };
+    // Fast path: skip if already installed.
+    {
+        let installed = match installed_handles().lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if installed.contains(&specialised.handle) {
+            return false;
+        }
+    }
+    // Slow path: emit MSL, compile, install.
+    let Some(emitted) = matrix_metal::emit_specialised_kernel(&specialised.key, specialised.handle)
+    else {
+        return false;
+    };
+    match backend
+        .executor
+        .install_specialised_from_emitted(specialised.handle, emitted)
+    {
+        Ok(()) => {
+            let mut installed = match installed_handles().lock() {
+                Ok(g) => g,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            installed.insert(specialised.handle);
+            true
+        }
+        Err(_) => {
+            // Don't mark as installed — a future emitter/compiler fix
+            // may want to retry this handle.
+            false
+        }
+    }
+}
+
+#[cfg(not(feature = "metal-backend"))]
+fn try_auto_install_specialised(_specialised: &matrix_runtime::SpecialisedKernel) -> bool {
+    false
 }
 
 /// Drive the MX05 specialisation pipeline for one placed graph:
@@ -282,7 +438,16 @@ fn drive_specialisation(placed: &ComputeGraph) {
                 Some(t) => t.dtype,
                 None => continue,
             };
-            let _ = r.route(observation, ir_op.wire_tag(), out_dtype, executor.0);
+            // **MX05 Phase 4.3.**  When the router returns a fresh
+            // (or cached) specialised kernel, ask the auto-installer
+            // to register it with the metal executor.  Idempotent;
+            // see `try_auto_install_specialised` for the install
+            // semantics.  Returning `None` from `route` (the policy
+            // declined, or no specialiser matched) is the common
+            // fast path and incurs zero cost here.
+            if let Some(spec) = r.route(observation, ir_op.wire_tag(), out_dtype, executor.0) {
+                let _ = try_auto_install_specialised(&spec);
+            }
         }
     }
 }
@@ -663,6 +828,90 @@ mod tests {
         assert!(
             total_tensor_observations > 0,
             "expected at least one TensorObservation populated after gpu_invert; got 0"
+        );
+    }
+
+    /// **MX05 Phase 4.3 end-to-end auto-installer test.**  Builds a
+    /// hot graph whose Add op has a stable f32 constant on at least one
+    /// input, drives it past the `DefaultPolicy` 1000-invocation
+    /// threshold, and asserts that `specialised_install_count` rises
+    /// above zero — proving the chain:
+    ///
+    /// ```text
+    ///   route() returns Some(SpecialisedKernel)
+    ///     → try_auto_install_specialised()
+    ///       → msl_emitter::emit_specialised_kernel(...)
+    ///         → MetalExecutor::install_specialised_from_emitted(...)
+    ///           → SpecialisedTable grows
+    /// ```
+    ///
+    /// Apple-only — no metal executor on Linux / Windows CI, so
+    /// `specialised_install_count` stays at 0 there by definition.
+    /// The non-metal CI runners still exercise the
+    /// `#[cfg(not(feature = "metal-backend"))]` stub through normal
+    /// compilation; the runtime-behaviour assertion only runs on macOS.
+    ///
+    /// Test scope intentionally limited:
+    /// - We only assert that the **install** side fires.  Phase 4.4
+    ///   will land the dispatch-routing side (replacing the generic
+    ///   `Dispatch { graph }` request with per-op `DispatchSpecialised`
+    ///   requests) and add its own end-to-end speedup test.
+    /// - We use raw `matrix_ir::GraphBuilder` rather than a public
+    ///   filter because v0.6.0's `msl_emitter` only knows
+    ///   `Op::Add + F32 + Constant`, and none of the existing public
+    ///   filters happen to hit that exact shape.  Future emitter
+    ///   extensions (Sub/Mul/Div) will broaden the surface so that
+    ///   real filters drive the install path automatically.
+    #[cfg(feature = "metal-backend")]
+    #[test]
+    fn auto_installer_registers_kernel_after_threshold() {
+        use crate::specialised_install_count;
+        use matrix_ir::{DType, GraphBuilder, Shape};
+
+        // Snapshot the install count *before* this test runs — other
+        // tests in this process may have already populated the table,
+        // so we look for a delta rather than an absolute value.
+        let before = specialised_install_count();
+
+        // Run the same Add-of-constants graph 1100 times.  Both
+        // operands are stable f32 constants, so the DefaultPolicy's
+        // constant-input check will fire once `tensor_observations`
+        // accumulates enough samples (~1000 invocations).
+        for _ in 0..1100 {
+            let mut g = GraphBuilder::new();
+            // Use 4-element f32 vectors so the emitter's
+            // `add_f32 + folded constant` kernel has a meaningful
+            // workload (4 elements × 1 thread per element).
+            let a_bytes: Vec<u8> = [1.0_f32, 2.0, 3.0, 4.0]
+                .iter()
+                .flat_map(|v| v.to_le_bytes())
+                .collect();
+            let b_bytes: Vec<u8> = [7.0_f32, 7.0, 7.0, 7.0]
+                .iter()
+                .flat_map(|v| v.to_le_bytes())
+                .collect();
+            let a = g.constant(DType::F32, Shape::from(&[4u32]), a_bytes);
+            let b = g.constant(DType::F32, Shape::from(&[4u32]), b_bytes);
+            let c = g.add(&a, &b);
+            g.output(&c);
+            let graph = g.build().expect("graph builds");
+            let _ = crate::pipeline::run_graph_with_constant_inputs(&graph, c.id, 16);
+        }
+
+        let after = specialised_install_count();
+        // The install count must rise — under DefaultPolicy + the
+        // matrix-cpu specialiser + the metal-side msl_emitter
+        // auto-install, at least one Add-with-constant kernel must
+        // have been emitted, compiled, and registered with the metal
+        // executor.  If this assertion fails it means *some* link in
+        // the chain (sampling, policy, router, emitter, compile,
+        // install) regressed.
+        assert!(
+            after > before,
+            "expected auto-installer to fire after 1100 invocations of an \
+             Add-with-constant graph; before = {}, after = {}",
+            before,
+            after
         );
     }
 }

--- a/code/packages/rust/matrix-metal/CHANGELOG.md
+++ b/code/packages/rust/matrix-metal/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — matrix-metal
 
+## 0.6.1 — 2026-05-12
+
+### Added — non-Apple stubs for the Phase 4.2 install API
+
+So downstream crates (image-gpu-core, matrix-runtime) can call
+`install_specialised_from_emitted` and friends without `#[cfg]`-gating
+every call site:
+
+- `MetalExecutor::install_specialised(handle, kernel)` — no-op on
+  non-Apple.
+- `MetalExecutor::install_specialised_from_emitted(handle, emitted)`
+  — returns `Err("unavailable on non-Apple targets")` on non-Apple.
+- `MetalExecutor::specialised_count()` — returns `0` on non-Apple.
+
+No behaviour change on Apple targets.
+
 ## 0.6.0 — 2026-05-12
 
 ### Added — MX05 Phase 4.2 (MSL emitter + specialised dispatch lands on Metal)

--- a/code/packages/rust/matrix-metal/Cargo.toml
+++ b/code/packages/rust/matrix-metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-metal"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "First real GPU executor for the matrix execution layer. Lowers a subset of MatrixIR ops to MSL kernels and dispatches via the metal-compute crate. Falls back to CPU automatically (via the planner's capability filter) for ops it doesn't yet support. v0.6 (MX05 Phase 4.2) ships the MSL emitter — given a SpecKey it generates an MSL kernel string with observed constants folded in as literal values — plus the per-handle specialised pipeline table and live DispatchSpecialised handler that runs on Apple targets."
 license = "MIT"

--- a/code/packages/rust/matrix-metal/src/lib.rs
+++ b/code/packages/rust/matrix-metal/src/lib.rs
@@ -646,7 +646,36 @@ impl MetalExecutor {
     }
 
     pub fn set_our_id(&self, _id: ExecutorId) {}
+
+    /// **MX05 Phase 4.2 stub (non-Apple)**.  No-op — there's no
+    /// specialised-kernel table without a Metal device.  Image-gpu-core
+    /// and the matrix-runtime auto-installer call this on every
+    /// platform; on non-Apple builds it's a contract-preserving no-op.
+    pub fn install_specialised(
+        &self,
+        _handle: u64,
+        _kernel: Box<dyn for<'a> Fn(&'a (), &[compute_ir::BufferId], &[compute_ir::BufferId]) -> Result<Vec<OpTiming>, String> + Send>,
+    ) {
+    }
+
+    /// **MX05 Phase 4.2 stub (non-Apple)**.  Always returns an error —
+    /// we have nothing to compile against.
+    pub fn install_specialised_from_emitted(
+        &self,
+        _handle: u64,
+        _emitted: EmittedKernel,
+    ) -> Result<(), String> {
+        Err("matrix-metal: install_specialised_from_emitted unavailable on non-Apple targets".to_string())
+    }
+
+    /// **MX05 Phase 4.2 stub (non-Apple)**.  Always `0`.
+    pub fn specialised_count(&self) -> usize {
+        0
+    }
 }
+
+#[cfg(not(target_vendor = "apple"))]
+use executor_protocol::OpTiming;
 
 #[cfg(not(target_vendor = "apple"))]
 pub fn local_transport() -> Result<LocalTransport, String> {

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -242,6 +242,29 @@ The compile happens in a background worker thread so live dispatches
 aren't blocked.  Once ready, the specialised pipeline is inserted
 into the cache.
 
+> **Implementation status (Phase 4.3 landed — runtime auto-installer, install half of the loop)**:
+> `image-gpu-core` v0.7.0 closes the install side of the specialised-
+> kernel loop.  `drive_specialisation` now consumes the
+> `SpecRouter::route` return value (previously discarded) and feeds
+> each `SpecialisedKernel` to a new `try_auto_install_specialised`
+> helper.  On metal targets the helper emits MSL via the Phase 4.2
+> `msl_emitter`, compiles it through `MetalExecutor::install_specialised_from_emitted`,
+> and records the handle in a process-wide `INSTALLED_HANDLES` set
+> for idempotency.  New public `image_gpu_core::specialised_install_count()`
+> counter exposes the result distinct from `spec_cache_len()` — the
+> first counts kernels actually compiled and registered, the second
+> counts emitted handles in the cache.  End-to-end test
+> `auto_installer_registers_kernel_after_threshold` drives a hot
+> Add-with-constant graph 1100 times and asserts the install counter
+> rises above zero — the first test in the workspace where a kernel
+> traverses the *entire* sampler → policy → router → cache → emitter
+> → compile → install pipeline.  Phase 4.4 will close the **dispatch**
+> half (replacing generic `Dispatch { graph }` with per-op
+> `DispatchSpecialised` requests that actually invoke the installed
+> kernels).  matrix-cpu auto-install is also Phase 4.4+ work —
+> `CpuSpecialiser` emits opaque handles today, not closure sources,
+> so there's nothing to translate yet.
+
 > **Implementation status (Phase 4.2 landed — matrix-metal MSL emitter + specialised dispatch)**:
 > `matrix-metal` v0.6.0 grows the GPU side of what matrix-cpu got in
 > Phase 4.1.  Three pieces land together:


### PR DESCRIPTION
## Summary

Closes the **install** side of the specialised-kernel routing loop opened by matrix-metal Phase 4.2 (#2912). When \`SpecRouter::route\` returns a cached \`SpecialisedKernel\`, image-gpu-core now auto-compiles the kernel and installs it onto the metal executor.

```
sampler → policy → router → cache → msl_emitter → MetalExecutor::install_specialised_from_emitted
```

**Phase 4.4 will close the dispatch half** (replacing generic \`Dispatch { graph }\` with per-op \`DispatchSpecialised\` requests). Splitting into a separate PR keeps Phase 4.3 reviewable.

## image-gpu-core v0.7.0

- \`MetalBackend\` now holds \`Arc<MetalExecutor>\` alongside \`LocalTransport\` so the auto-installer can call \`install_specialised_from_emitted\` directly.
- \`try_auto_install_specialised(&SpecialisedKernel)\` — new internal helper. Idempotent via a process-wide \`Mutex<HashSet<u64>>\`. On a new handle: emits MSL → compiles → installs. Compile failures don't mark the handle as installed so a future emitter fix can retry.
- \`drive_specialisation\` now consumes the router's return value (previously discarded).
- New public \`specialised_install_count() -> usize\` — distinct from \`spec_cache_len\`. The cache counts emitted handles; this counter counts handles actually compiled and registered with an executor.

## matrix-metal v0.6.1

Non-Apple stubs added to \`MetalExecutor\` so image-gpu-core compiles cleanly on Linux/Windows CI without \`#[cfg]\`-gating every call site:
- \`install_specialised\` — no-op
- \`install_specialised_from_emitted\` — returns Err
- \`specialised_count\` — returns 0

No behaviour change on Apple targets.

## End-to-end test

\`auto_installer_registers_kernel_after_threshold\` (Apple-only): drives a 4-element f32 Add-with-constant graph 1100 times, asserts \`specialised_install_count()\` rises above zero. **First test in image-gpu-core where a kernel traverses the full pipeline.**

## Security review (passed)

- TOCTOU on handle insert — benign (HashSet::insert is idempotent; worst case is duplicate MSL compile cost, not a vuln).
- Unbounded \`INSTALLED_HANDLES\` growth — bounded upstream by SpecCache.
- Lock-ordering between INSTALLED_HANDLES and executor mutex — the two locks are never held simultaneously, no deadlock.

## What this still doesn't do (Phase 4.4 territory)

- The next dispatch still goes through generic \`Dispatch { graph }\` — installed kernels are registered but not yet invoked.
- matrix-cpu auto-install — \`CpuSpecialiser\` emits opaque handles without closure sources, so there's nothing to translate yet. Phase 4.5 work.

## Test plan

- [x] image-gpu-core: 29 tests pass (1 new)
- [x] matrix-metal: 19 unit + 25 integration tests pass
- [x] matrix-cpu: 33 unit + 23 integration tests pass
- [x] matrix-runtime: 17 + 8 tests pass
- [x] Linux cross-compile clean via \`cargo check --target x86_64-unknown-linux-gnu\`
- [x] Security review passed (1 round)
- [x] Spec MX05 updated with \"Phase 4.3 landed — runtime auto-installer, install half of the loop\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)