### PR TITLE
Add Rust cas-solve transcendental basics

### DIFF
--- a/code/packages/rust/cas-solve/CHANGELOG.md
+++ b/code/packages/rust/cas-solve/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- `transcendental` module: `try_solve_transcendental(eq, variable)` — direct
+  `f(linear) = constant` solving for trig, exponential/logarithmic, and
+  hyperbolic functions with symbolic inverse and periodic-family output.
+- Transcendental integration tests for exp/log, trig periodic families,
+  hyperbolic inverses, reversed equations, bare zero-form expressions, and
+  unsupported nested/non-variable cases.
 - `linear_system` module: `solve_linear_system(equations, variables)` — exact
   Gaussian elimination with `Equal(lhs, rhs)` normalization, zero-form
   equations, and `Rule(var, value)` IR output.

--- a/code/packages/rust/cas-solve/README.md
+++ b/code/packages/rust/cas-solve/README.md
@@ -104,6 +104,14 @@ polynomial, and returns interval predicates for degree-four-or-lower
 polynomials. Exact rational roots are preserved where possible; irrational
 boundaries fall back to numeric `Float` nodes.
 
+## Direct transcendental equations
+
+`try_solve_transcendental(eq, variable)` accepts `Equal(lhs, rhs)` nodes or a
+bare expression treated as `expr = 0`. It solves direct `f(linear) = constant`
+forms for `Sin`, `Cos`, `Tan`, `Exp`, `Log`, `Sinh`, `Cosh`, and `Tanh`,
+returning symbolic inverse expressions and periodic families using
+`FreeInteger`.
+
 ## Stack position
 
 ```

--- a/code/packages/rust/cas-solve/src/lib.rs
+++ b/code/packages/rust/cas-solve/src/lib.rs
@@ -1,7 +1,7 @@
 //! # cas-solve
 //!
 //! Closed-form and numeric equation solving over ℚ: linear, quadratic, cubic,
-//! quartic, and Durand-Kerner polynomial roots.
+//! quartic, Durand-Kerner polynomial roots, and direct transcendental forms.
 //!
 //! ## Quick start
 //!
@@ -58,6 +58,7 @@ pub mod linear_system;
 pub mod numeric;
 pub mod quadratic;
 pub mod quartic;
+pub mod transcendental;
 
 pub use cubic::{solve_cubic, CBRT};
 pub use inequality::try_solve_inequality;
@@ -66,6 +67,7 @@ pub use linear_system::solve_linear_system;
 pub use numeric::{nsolve_fraction_poly, nsolve_poly, roots_to_ir, Complex};
 pub use quadratic::{solve_quadratic, I_UNIT};
 pub use quartic::solve_quartic;
+pub use transcendental::{try_solve_transcendental, FREE_INTEGER};
 
 /// The result of an equation-solve operation.
 ///

--- a/code/packages/rust/cas-solve/src/transcendental.rs
+++ b/code/packages/rust/cas-solve/src/transcendental.rs
@@ -1,0 +1,298 @@
+//! Direct transcendental equation solving in one variable.
+//!
+//! This handles the Phase 26 package-level slice for equations of the form
+//! `f(linear) = constant`, preserving symbolic inverse functions and periodic
+//! integer families where appropriate.
+
+use symbolic_ir::{
+    apply, int, sym, IRNode, ACOS, ACOSH, ADD, ASIN, ASINH, ATAN, ATANH, COS, COSH, DIV, EQUAL,
+    EXP, LOG, MUL, NEG, POW, SIN, SINH, SUB, TAN, TANH,
+};
+
+use crate::frac::Frac;
+
+pub const FREE_INTEGER: &str = "FreeInteger";
+
+/// Try to solve a direct transcendental equation in one variable.
+///
+/// Accepts `Equal(lhs, rhs)` or a bare expression treated as `expr = 0`.
+/// Returns:
+/// - `Some(vec![...])` for supported direct `f(linear) = constant` forms.
+/// - `None` when the equation is not in the supported direct form.
+pub fn try_solve_transcendental(eq: &IRNode, variable: &IRNode) -> Option<Vec<IRNode>> {
+    let IRNode::Symbol(var_name) = variable else {
+        return None;
+    };
+
+    if let Some((lhs, rhs)) = split_equal(eq) {
+        return try_func_eq_const(lhs, rhs, var_name)
+            .or_else(|| try_func_eq_const(rhs, lhs, var_name));
+    }
+
+    try_func_eq_const(eq, &int(0), var_name)
+}
+
+fn try_func_eq_const(
+    func_side: &IRNode,
+    const_side: &IRNode,
+    variable: &str,
+) -> Option<Vec<IRNode>> {
+    if !is_const_wrt(const_side, variable) {
+        return None;
+    }
+
+    let IRNode::Apply(apply_node) = func_side else {
+        return None;
+    };
+    if apply_node.args.len() != 1 {
+        return None;
+    }
+    let IRNode::Symbol(head) = &apply_node.head else {
+        return None;
+    };
+
+    let (a, b) = extract_linear(&apply_node.args[0], variable)?;
+    let two_pi_k = apply(
+        sym(MUL),
+        vec![int(2), apply(sym(MUL), vec![sym("%pi"), sym(FREE_INTEGER)])],
+    );
+
+    match head.as_str() {
+        SIN => {
+            let asin_c = apply(sym(ASIN), vec![const_side.clone()]);
+            Some(vec![
+                solve_linear_for_value(
+                    a,
+                    b,
+                    apply(sym(ADD), vec![asin_c.clone(), two_pi_k.clone()]),
+                ),
+                solve_linear_for_value(
+                    a,
+                    b,
+                    apply(
+                        sym(ADD),
+                        vec![apply(sym(SUB), vec![sym("%pi"), asin_c]), two_pi_k],
+                    ),
+                ),
+            ])
+        }
+        COS => {
+            let acos_c = apply(sym(ACOS), vec![const_side.clone()]);
+            Some(vec![
+                solve_linear_for_value(
+                    a,
+                    b,
+                    apply(sym(ADD), vec![acos_c.clone(), two_pi_k.clone()]),
+                ),
+                solve_linear_for_value(
+                    a,
+                    b,
+                    apply(sym(ADD), vec![apply(sym(NEG), vec![acos_c]), two_pi_k]),
+                ),
+            ])
+        }
+        TAN => Some(vec![solve_linear_for_value(
+            a,
+            b,
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(ATAN), vec![const_side.clone()]),
+                    apply(sym(MUL), vec![sym("%pi"), sym(FREE_INTEGER)]),
+                ],
+            ),
+        )]),
+        EXP => Some(vec![solve_linear_for_value(
+            a,
+            b,
+            apply(sym(LOG), vec![const_side.clone()]),
+        )]),
+        LOG => Some(vec![solve_linear_for_value(
+            a,
+            b,
+            apply(sym(EXP), vec![const_side.clone()]),
+        )]),
+        SINH => Some(vec![solve_linear_for_value(
+            a,
+            b,
+            apply(sym(ASINH), vec![const_side.clone()]),
+        )]),
+        COSH => {
+            let acosh_c = apply(sym(ACOSH), vec![const_side.clone()]);
+            Some(vec![
+                solve_linear_for_value(a, b, acosh_c.clone()),
+                solve_linear_for_value(a, b, apply(sym(NEG), vec![acosh_c])),
+            ])
+        }
+        TANH => Some(vec![solve_linear_for_value(
+            a,
+            b,
+            apply(sym(ATANH), vec![const_side.clone()]),
+        )]),
+        _ => None,
+    }
+}
+
+fn split_equal(node: &IRNode) -> Option<(&IRNode, &IRNode)> {
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    if is_head_name(&apply_node.head, EQUAL) && apply_node.args.len() == 2 {
+        Some((&apply_node.args[0], &apply_node.args[1]))
+    } else {
+        None
+    }
+}
+
+fn extract_linear(node: &IRNode, variable: &str) -> Option<(Frac, Frac)> {
+    let coeffs = extract_polynomial(node, variable, 1)?;
+    if coeffs.len() != 2 || coeffs[1].is_zero() {
+        return None;
+    }
+    Some((coeffs[1], coeffs[0]))
+}
+
+fn solve_linear_for_value(a: Frac, b: Frac, value: IRNode) -> IRNode {
+    let shifted = if b.is_zero() {
+        value
+    } else {
+        apply(sym(SUB), vec![value, b.to_irnode()])
+    };
+    if a == Frac::one() {
+        shifted
+    } else {
+        apply(sym(DIV), vec![shifted, a.to_irnode()])
+    }
+}
+
+fn is_const_wrt(node: &IRNode, variable: &str) -> bool {
+    match node {
+        IRNode::Symbol(name) => name != variable,
+        IRNode::Apply(apply_node) => {
+            is_const_wrt(&apply_node.head, variable)
+                && apply_node
+                    .args
+                    .iter()
+                    .all(|arg| is_const_wrt(arg, variable))
+        }
+        _ => true,
+    }
+}
+
+fn extract_polynomial(node: &IRNode, variable: &str, max_degree: usize) -> Option<Vec<Frac>> {
+    if let Some(constant) = node_to_frac(node) {
+        return Some(vec![constant]);
+    }
+
+    if let IRNode::Symbol(name) = node {
+        if name != variable {
+            return None;
+        }
+        return Some(vec![Frac::zero(), Frac::one()]);
+    }
+
+    let IRNode::Apply(apply_node) = node else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply_node.head else {
+        return None;
+    };
+
+    match head.as_str() {
+        ADD => {
+            let mut result = vec![Frac::zero()];
+            for arg in &apply_node.args {
+                let poly = extract_polynomial(arg, variable, max_degree)?;
+                result = add_polynomials(&result, &poly);
+                if result.len() - 1 > max_degree {
+                    return None;
+                }
+            }
+            Some(trim_polynomial(&result))
+        }
+        SUB if apply_node.args.len() == 2 => {
+            let lhs = extract_polynomial(&apply_node.args[0], variable, max_degree)?;
+            let rhs = extract_polynomial(&apply_node.args[1], variable, max_degree)?;
+            Some(trim_polynomial(&add_polynomials(
+                &lhs,
+                &scale_polynomial(&rhs, Frac::from_int(-1)),
+            )))
+        }
+        NEG if apply_node.args.len() == 1 => {
+            let poly = extract_polynomial(&apply_node.args[0], variable, max_degree)?;
+            Some(scale_polynomial(&poly, Frac::from_int(-1)))
+        }
+        MUL => {
+            let mut result = vec![Frac::one()];
+            for arg in &apply_node.args {
+                let poly = extract_polynomial(arg, variable, max_degree)?;
+                result = multiply_polynomials(&result, &poly, max_degree)?;
+            }
+            Some(trim_polynomial(&result))
+        }
+        POW if apply_node.args.len() == 2 => {
+            let IRNode::Integer(exponent) = &apply_node.args[1] else {
+                return None;
+            };
+            if *exponent < 0 || *exponent as usize > max_degree {
+                return None;
+            }
+            let base = extract_polynomial(&apply_node.args[0], variable, max_degree)?;
+            let mut result = vec![Frac::one()];
+            for _ in 0..*exponent {
+                result = multiply_polynomials(&result, &base, max_degree)?;
+            }
+            Some(trim_polynomial(&result))
+        }
+        _ => None,
+    }
+}
+
+fn add_polynomials(lhs: &[Frac], rhs: &[Frac]) -> Vec<Frac> {
+    let len = lhs.len().max(rhs.len());
+    trim_polynomial(
+        &(0..len)
+            .map(|i| {
+                lhs.get(i).copied().unwrap_or_else(Frac::zero)
+                    + rhs.get(i).copied().unwrap_or_else(Frac::zero)
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn scale_polynomial(poly: &[Frac], scalar: Frac) -> Vec<Frac> {
+    trim_polynomial(&poly.iter().map(|coef| *coef * scalar).collect::<Vec<_>>())
+}
+
+fn multiply_polynomials(lhs: &[Frac], rhs: &[Frac], max_degree: usize) -> Option<Vec<Frac>> {
+    let mut result = vec![Frac::zero(); lhs.len() + rhs.len() - 1];
+    for (i, lhs_coef) in lhs.iter().enumerate() {
+        for (j, rhs_coef) in rhs.iter().enumerate() {
+            if i + j > max_degree {
+                return None;
+            }
+            result[i + j] = result[i + j] + *lhs_coef * *rhs_coef;
+        }
+    }
+    Some(trim_polynomial(&result))
+}
+
+fn trim_polynomial(poly: &[Frac]) -> Vec<Frac> {
+    let mut end = poly.len().saturating_sub(1);
+    while end > 0 && poly[end].is_zero() {
+        end -= 1;
+    }
+    poly[..=end].to_vec()
+}
+
+fn node_to_frac(node: &IRNode) -> Option<Frac> {
+    match node {
+        IRNode::Integer(value) => Some(Frac::from_int(*value)),
+        IRNode::Rational(numer, denom) => Some(Frac::new(*numer, *denom)),
+        _ => None,
+    }
+}
+
+fn is_head_name(node: &IRNode, expected: &str) -> bool {
+    matches!(node, IRNode::Symbol(name) if name == expected)
+}

--- a/code/packages/rust/cas-solve/tests/tests.rs
+++ b/code/packages/rust/cas-solve/tests/tests.rs
@@ -6,11 +6,13 @@
 use cas_solve::frac::Frac;
 use cas_solve::{
     nsolve_fraction_poly, nsolve_poly, roots_to_ir, solve_cubic, solve_linear, solve_linear_system,
-    solve_quadratic, solve_quartic, try_solve_inequality, Complex, SolveResult,
+    solve_quadratic, solve_quartic, try_solve_inequality, try_solve_transcendental, Complex,
+    SolveResult, FREE_INTEGER,
 };
 use symbolic_ir::{
-    apply, int, rat, sym, IRNode, ADD, AND, EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, MUL,
-    POW, RULE, SUB,
+    apply, int, rat, sym, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ATAN, ATANH, COS, COSH, DIV,
+    EQUAL, EXP, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, LOG, MUL, NEG, POW, RULE, SIN, SINH, SUB,
+    TAN, TANH,
 };
 
 fn frac(n: i64, d: i64) -> Frac {
@@ -733,4 +735,138 @@ fn inequality_numeric_boundaries_and_rejects_non_polynomials() {
     )
     .is_none());
     assert!(try_solve_inequality(&eq(x.clone(), int(0)), &x).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// try_solve_transcendental
+// ---------------------------------------------------------------------------
+
+#[test]
+fn transcendental_solves_exp_and_log_linear_forms() {
+    let x = sym("x");
+    expect_nodes(
+        try_solve_transcendental(&eq(apply(sym(EXP), vec![x.clone()]), int(2)), &x),
+        vec![apply(sym(LOG), vec![int(2)])],
+    );
+    expect_nodes(
+        try_solve_transcendental(
+            &eq(
+                apply(
+                    sym(LOG),
+                    vec![add(vec![mul(vec![int(2), x.clone()]), int(3)])],
+                ),
+                int(5),
+            ),
+            &x,
+        ),
+        vec![apply(
+            sym(DIV),
+            vec![sub(apply(sym(EXP), vec![int(5)]), int(3)), int(2)],
+        )],
+    );
+}
+
+#[test]
+fn transcendental_solves_trig_periodic_families() {
+    let x = sym("x");
+    let two_pi_k = apply(
+        sym(MUL),
+        vec![int(2), apply(sym(MUL), vec![sym("%pi"), sym(FREE_INTEGER)])],
+    );
+
+    expect_nodes(
+        try_solve_transcendental(&eq(apply(sym(SIN), vec![x.clone()]), int(0)), &x),
+        vec![
+            add(vec![apply(sym(ASIN), vec![int(0)]), two_pi_k.clone()]),
+            add(vec![
+                sub(sym("%pi"), apply(sym(ASIN), vec![int(0)])),
+                two_pi_k.clone(),
+            ]),
+        ],
+    );
+
+    expect_nodes(
+        try_solve_transcendental(&eq(apply(sym(COS), vec![x.clone()]), int(1)), &x),
+        vec![
+            add(vec![apply(sym(ACOS), vec![int(1)]), two_pi_k.clone()]),
+            add(vec![
+                apply(sym(NEG), vec![apply(sym(ACOS), vec![int(1)])]),
+                two_pi_k,
+            ]),
+        ],
+    );
+
+    expect_nodes(
+        try_solve_transcendental(
+            &eq(
+                apply(
+                    sym(TAN),
+                    vec![add(vec![mul(vec![int(2), x.clone()]), int(1)])],
+                ),
+                int(3),
+            ),
+            &x,
+        ),
+        vec![apply(
+            sym(DIV),
+            vec![
+                sub(
+                    add(vec![
+                        apply(sym(ATAN), vec![int(3)]),
+                        apply(sym(MUL), vec![sym("%pi"), sym(FREE_INTEGER)]),
+                    ]),
+                    int(1),
+                ),
+                int(2),
+            ],
+        )],
+    );
+}
+
+#[test]
+fn transcendental_solves_hyperbolic_forms() {
+    let x = sym("x");
+    expect_nodes(
+        try_solve_transcendental(&eq(apply(sym(SINH), vec![x.clone()]), int(2)), &x),
+        vec![apply(sym(ASINH), vec![int(2)])],
+    );
+    expect_nodes(
+        try_solve_transcendental(
+            &eq(
+                apply(sym(TANH), vec![add(vec![x.clone(), int(4)])]),
+                rat(1, 2),
+            ),
+            &x,
+        ),
+        vec![sub(apply(sym(ATANH), vec![rat(1, 2)]), int(4))],
+    );
+    expect_nodes(
+        try_solve_transcendental(&eq(apply(sym(COSH), vec![x.clone()]), int(3)), &x),
+        vec![
+            apply(sym(ACOSH), vec![int(3)]),
+            apply(sym(NEG), vec![apply(sym(ACOSH), vec![int(3)])]),
+        ],
+    );
+}
+
+#[test]
+fn transcendental_accepts_reversed_and_bare_expressions_and_rejects_non_direct_forms() {
+    let x = sym("x");
+    assert_eq!(
+        try_solve_transcendental(&apply(sym(EXP), vec![x.clone()]), &x),
+        Some(vec![apply(sym(LOG), vec![int(0)])])
+    );
+    assert_eq!(
+        try_solve_transcendental(&eq(int(2), apply(sym(EXP), vec![x.clone()])), &x),
+        Some(vec![apply(sym(LOG), vec![int(2)])])
+    );
+    assert!(try_solve_transcendental(&eq(apply(sym(SIN), vec![sym("y")]), int(0)), &x).is_none());
+    assert!(try_solve_transcendental(
+        &eq(
+            apply(sym(SIN), vec![apply(sym(SIN), vec![x.clone()])]),
+            int(0)
+        ),
+        &x
+    )
+    .is_none());
 }


### PR DESCRIPTION
## Summary
- add `try_solve_transcendental` for direct Phase 26-style `f(linear) = constant` equations in Rust `cas-solve`
- cover trig periodic families, exp/log inverses, and hyperbolic inverses with exact linear back-solving
- document the new API and add parity tests for direct, reversed, bare-expression, and unsupported cases

## Validation
- `cargo fmt -p cas-solve && cargo test -p cas-solve -- --nocapture` in `code/packages/rust`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-cas-solve-transcendental-basic.json` from `code/programs/go/build-tool`