### PR TITLE
[codex] Advance HTML tree construction fixtures

### DIFF
--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -5809,19 +5809,29 @@ from = "comment_start_dash"
 matcher = { eof = true }
 to = "done"
 consume = false
-actions = ["parse_error(eof-in-comment)", "emit_current_token", "emit(EOF)"]
+actions = [
+  "parse_error(eof-in-comment)",
+  "append_comment(-)",
+  "emit_current_token",
+  "emit(EOF)",
+]
 
 [[transitions]]
 from = "comment_start_dash"
 matcher = { literal = "\u0000" }
 to = "comment"
-actions = ["parse_error(unexpected-null-character)", "append_comment_replacement"]
+actions = [
+  "parse_error(unexpected-null-character)",
+  "append_comment(-)",
+  "append_comment_replacement",
+]
 
 [[transitions]]
 from = "comment_start_dash"
 matcher = { anything = true }
 to = "comment"
-actions = ["append_comment(current)"]
+consume = false
+actions = ["append_comment(-)"]
 
 [[transitions]]
 from = "comment"

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -12189,6 +12189,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(eof-in-comment)".to_string(),
+                "append_comment(-)".to_string(),
                 "emit_current_token".to_string(),
                 "emit(EOF)".to_string(),
             ],
@@ -12206,6 +12207,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_push: Vec::new(),
             actions: vec![
                 "parse_error(unexpected-null-character)".to_string(),
+                "append_comment(-)".to_string(),
                 "append_comment_replacement".to_string(),
             ],
             consume: true,
@@ -12221,9 +12223,9 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
-                "append_comment(current)".to_string(),
+                "append_comment(-)".to_string(),
             ],
-            consume: true,
+            consume: false,
         },
         TransitionDefinition {
             from: "comment".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -1922,6 +1922,23 @@ fn default_html_lexer_reports_recoverable_comment_eof_diagnostic() {
 }
 
 #[test]
+fn default_html_lexer_preserves_comment_start_dash_before_text() {
+    let mut lexer = create_html_lexer().unwrap();
+
+    lexer.push("<!---x").unwrap();
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![Token::Comment("-x".to_string()), Token::Eof]
+    );
+    assert!(lexer
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.code == "eof-in-comment"));
+}
+
+#[test]
 fn default_html_lexer_does_not_include_comment_end_dashes_at_eof() {
     let tokens = lex_html("<!--x--").unwrap();
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1054,6 +1054,18 @@ impl HtmlParser {
             return;
         }
         if !in_foreign_content
+            && matches!(name.as_str(), "param" | "source" | "track")
+            && !self.current_element_is("object")
+            && !self.has_open_element("body")
+            && !self.document_has_body_element()
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-pre-body-void-start-tag",
+                format!("start tag `<{name}>` before body was ignored"),
+            ));
+            return;
+        }
+        if !in_foreign_content
             && self.open_elements.is_empty()
             && self.has_document_element()
             && !self.document_has_body_element()
@@ -1296,6 +1308,10 @@ impl HtmlParser {
             self.close_open_element_if(|name| name == "select");
         }
 
+        if !in_foreign_content && name == "table" && self.current_element_is_table_structure() {
+            self.close_element("table");
+        }
+
         if !in_foreign_content
             && name == "form"
             && self.current_element_is_table_structure()
@@ -1316,6 +1332,28 @@ impl HtmlParser {
 
         if !in_foreign_content && name == "meta" && self.current_element_is_table_structure() {
             self.insert_node_before_open_table(Node::element(name, attributes));
+            return;
+        }
+
+        if !in_foreign_content && name == "title" && self.current_element_is_table_structure() {
+            if let Some(path) = self.insert_node_before_open_table(Node::element(name, attributes))
+            {
+                self.open_elements.push(path);
+            }
+            return;
+        }
+
+        if !in_foreign_content
+            && name == "li"
+            && self.has_open_table_context()
+            && (self.current_element_is_table_structure()
+                || self.current_parent_is_fostered_before_open_table())
+        {
+            self.close_open_element_if(|name| name == "li");
+            if let Some(path) = self.insert_node_before_open_table(Node::element(name, attributes))
+            {
+                self.open_elements.push(path);
+            }
             return;
         }
 
@@ -1722,13 +1760,13 @@ impl HtmlParser {
             return;
         }
 
+        let pending_formatting_is_before_open_table = self
+            .previous_pending_formatting_path_before_open_table()
+            .is_some();
         if (!text.chars().all(char::is_whitespace)
             || !self.pending_formatting_reconstruction.is_empty())
             && (!self.current_parent_has_table_ancestor()
-                || !self
-                    .pending_formatting_reconstruction
-                    .iter()
-                    .any(|(name, _)| name == "a")
+                || !pending_formatting_is_before_open_table
                 || self.current_parent_is_fostered_before_open_table())
             && !self.current_parent_is_inside_previous_pending_formatting_before_open_table()
         {
@@ -1993,6 +2031,14 @@ impl HtmlParser {
             return;
         }
         if self.has_open_table_context()
+            && !self.current_parent_is_fostered_before_open_table()
+            && self
+                .previous_pending_formatting_path_before_open_table()
+                .is_some()
+        {
+            return;
+        }
+        if self.has_open_table_context()
             && self
                 .pending_formatting_reconstruction
                 .iter()
@@ -2187,6 +2233,9 @@ impl HtmlParser {
         else {
             return;
         };
+        if !matches!(pending_name.as_str(), "a" | "nobr") {
+            return;
+        }
         let Some(table_path) = self
             .open_elements
             .iter()
@@ -2267,6 +2316,7 @@ impl HtmlParser {
             return;
         };
 
+        let mut pending_formatting = Vec::new();
         while self.open_elements.len() > table_stack_index + 1 {
             let Some(path) = self.open_elements.last() else {
                 break;
@@ -2277,7 +2327,15 @@ impl HtmlParser {
             if !is_fostered_formatting {
                 break;
             }
+            if let Some(element) = element_ref_at_path(&self.document, path) {
+                pending_formatting.push((element.name.clone(), element.attributes.clone()));
+            }
             self.open_elements.pop();
+        }
+        if !pending_formatting.is_empty() {
+            pending_formatting.reverse();
+            self.pending_formatting_reconstruction =
+                trim_formatting_reconstruction_noah_ark(pending_formatting);
         }
     }
 
@@ -2579,6 +2637,9 @@ impl HtmlParser {
             }
             if name == "form" {
                 self.form_element_pointer_set = false;
+                self.generate_implied_end_tags_above(index);
+                self.open_elements.remove(index);
+                return;
             }
             if matches!(name, "div" | "p" | "select") {
                 self.capture_formatting_above(index);
@@ -2598,6 +2659,16 @@ impl HtmlParser {
             "unexpected-end-tag",
             format!("end tag `</{name}>` did not match an open element"),
         ));
+    }
+
+    fn generate_implied_end_tags_above(&mut self, lower_bound: usize) {
+        while self.open_elements.len() > lower_bound + 1
+            && self
+                .current_element_name()
+                .is_some_and(is_implied_end_tag_element)
+        {
+            self.open_elements.pop();
+        }
     }
 
     fn close_pending_formatting_in_table_context(&mut self, name: &str) -> bool {
@@ -2693,7 +2764,7 @@ impl HtmlParser {
 
     fn apply_simple_implied_end_tags(&mut self, incoming_name: &str) {
         if incoming_name == "p" {
-            if !self.current_parent_has_element_ancestor("button") {
+            if self.current_parent_has_open_element_in_button_scope("p") {
                 self.close_open_element_if(|name| name == "p");
             }
         } else if incoming_name == "li" {
@@ -2790,13 +2861,13 @@ impl HtmlParser {
     }
 
     fn apply_select_implied_contexts(&mut self, incoming_name: &str) -> bool {
-        if incoming_name != "select" || !self.has_open_element("select") {
+        if !matches!(incoming_name, "input" | "select") || !self.has_open_element("select") {
             return false;
         }
 
         self.close_open_element_if(|name| name == "option");
         self.close_open_element_if(|name| name == "select");
-        true
+        incoming_name == "select"
     }
 
     fn close_open_element_silently(&mut self, name: &str) -> bool {
@@ -3688,6 +3759,25 @@ impl HtmlParser {
                 current_parent_path.starts_with(path)
                     && element_at_path(&self.document, path).is_some_and(|name| name == target_name)
             })
+    }
+
+    fn current_parent_has_open_element_in_button_scope(&self, target_name: &str) -> bool {
+        let current_parent_path = self.current_parent_path();
+        for path in self.open_elements.iter().rev() {
+            if !current_parent_path.starts_with(path) {
+                continue;
+            }
+            let Some(name) = element_at_path(&self.document, path) else {
+                continue;
+            };
+            if name == target_name {
+                return true;
+            }
+            if is_button_scope_boundary(name) {
+                return false;
+            }
+        }
+        false
     }
 
     fn current_parent_has_element_in_table_scope(&self, target_name: &str) -> bool {
@@ -5422,6 +5512,29 @@ fn special_scope_blocks_end_tag(name: &str) -> bool {
     !matches!(name, "form") && !is_special_element(name)
 }
 
+fn is_button_scope_boundary(name: &str) -> bool {
+    matches!(
+        name,
+        "applet"
+            | "caption"
+            | "html"
+            | "table"
+            | "td"
+            | "th"
+            | "marquee"
+            | "object"
+            | "template"
+            | "button"
+    )
+}
+
+fn is_implied_end_tag_element(name: &str) -> bool {
+    matches!(
+        name,
+        "dd" | "dt" | "li" | "optgroup" | "option" | "p" | "rb" | "rp" | "rt" | "rtc"
+    )
+}
+
 fn is_heading_element(name: &str) -> bool {
     matches!(name, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
 }
@@ -6077,7 +6190,7 @@ mod tests {
         );
 
         let body = body(&output.document);
-        assert_eq!(body.children.len(), 2);
+        assert_eq!(body.children.len(), 1);
 
         let form = element(&body.children[0]);
         assert_eq!(form.name, "form");
@@ -6091,7 +6204,7 @@ mod tests {
         assert_eq!(input.name, "input");
         assert_eq!(input.attribute("name"), Some("x"));
 
-        let paragraph = element(&body.children[1]);
+        let paragraph = element(&div.children[2]);
         assert_eq!(paragraph.name, "p");
         assert_eq!(paragraph.children, vec![Node::text("After")]);
     }

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -23286,3 +23286,1154 @@ foo"
 |   <body>
 |     <p>
 |       <table>
+
+#source tests6.dat:2
+#data
+<!doctype html><form><div></form><div>
+#errors
+(1,33): end-tag-too-early-ignored
+(1,38): expected-closing-tag-but-got-eof
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <form>
+|       <div>
+|         <div>
+
+#source tests6.dat:3
+#data
+<!doctype html><title>&amp;</title>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <title>
+|       "&"
+|   <body>
+
+
+#source tests6.dat:4
+#data
+<!doctype html><title><!--&amp;--></title>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <title>
+|       "<!--&-->"
+|   <body>
+
+
+#source tests6.dat:5
+#data
+<!doctype>
+#errors
+(1,10): expected-doctype-name-but-got-right-bracket
+(1,10): unknown-doctype
+#new-errors
+(1:10) missing-doctype-name
+#document
+| <!DOCTYPE >
+| <html>
+|   <head>
+|   <body>
+
+
+#source tests6.dat:6
+#data
+<!---x
+#errors
+(1,6): eof-in-comment
+(1,6): expected-doctype-but-got-eof
+#new-errors
+(1:7) eof-in-comment
+#document
+| <!-- -x -->
+| <html>
+|   <head>
+|   <body>
+
+
+#source tests6.dat:8
+#data
+<frameset></frameset>
+foo
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(2,1): unexpected-char-after-frameset
+(2,2): unexpected-char-after-frameset
+(2,3): unexpected-char-after-frameset
+#document
+| <html>
+|   <head>
+|   <frameset>
+|   "
+"
+
+
+#source tests6.dat:9
+#data
+<frameset></frameset>
+<noframes>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(2,10): expected-named-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <frameset>
+|   "
+"
+|   <noframes>
+
+
+#source tests6.dat:10
+#data
+<frameset></frameset>
+<div>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(2,5): unexpected-start-tag-after-frameset
+#document
+| <html>
+|   <head>
+|   <frameset>
+|   "
+"
+
+
+#source tests6.dat:11
+#data
+<frameset></frameset>
+</html>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <frameset>
+|   "
+"
+
+
+#source tests6.dat:12
+#data
+<frameset></frameset>
+</div>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(2,6): unexpected-end-tag-after-frameset
+#document
+| <html>
+|   <head>
+|   <frameset>
+|   "
+"
+
+
+#source tests6.dat:13
+#data
+<form><form>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,12): unexpected-start-tag
+(1,12): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <form>
+
+
+#source tests6.dat:14
+#data
+<button><button>
+#errors
+(1,8): expected-doctype-but-got-start-tag
+(1,16): unexpected-start-tag-implies-end-tag
+(1,16): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <button>
+|     <button>
+
+
+#source tests6.dat:15
+#data
+<table><tr><td></th>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,20): unexpected-end-tag
+(1,20): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+
+
+#source tests6.dat:16
+#data
+<table><caption><td>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,20): unexpected-cell-in-table-body
+(1,20): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <caption>
+|       <tbody>
+|         <tr>
+|           <td>
+
+
+#source tests6.dat:17
+#data
+<table><caption><div>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,21): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <caption>
+|         <div>
+
+
+#source tests6.dat:19
+#data
+<table><caption><div></caption>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,31): expected-one-end-tag-but-got-another
+(1,31): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <caption>
+|         <div>
+
+
+#source tests6.dat:20
+#data
+<table><caption></table>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <caption>
+
+
+#source tests6.dat:22
+#data
+<table><caption></body></col></colgroup></html></tbody></td></tfoot></th></thead></tr>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,23): unexpected-end-tag
+(1,29): unexpected-end-tag
+(1,40): unexpected-end-tag
+(1,47): unexpected-end-tag
+(1,55): unexpected-end-tag
+(1,60): unexpected-end-tag
+(1,68): unexpected-end-tag
+(1,73): unexpected-end-tag
+(1,81): unexpected-end-tag
+(1,86): unexpected-end-tag
+(1,86): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <caption>
+
+
+#source tests6.dat:23
+#data
+<table><caption><div></div>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,27): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <caption>
+|         <div>
+
+
+#source tests6.dat:24
+#data
+<table><tr><td></body></caption></col></colgroup></html>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,22): unexpected-end-tag
+(1,32): unexpected-end-tag
+(1,38): unexpected-end-tag
+(1,49): unexpected-end-tag
+(1,56): unexpected-end-tag
+(1,56): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+
+
+#source tests6.dat:26
+#data
+<table><colgroup>foo
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,18): foster-parenting-character-in-table
+(1,19): foster-parenting-character-in-table
+(1,20): foster-parenting-character-in-table
+(1,20): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     "foo"
+|     <table>
+|       <colgroup>
+
+
+#source tests6.dat:28
+#data
+<table><colgroup></col>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,23): no-end-tag
+(1,23): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <colgroup>
+
+
+#source tests6.dat:29
+#data
+<frameset><div>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(1,15): unexpected-start-tag-in-frameset
+(1,15): eof-in-frameset
+#document
+| <html>
+|   <head>
+|   <frameset>
+
+
+#source tests6.dat:31
+#data
+<frameset></div>
+#errors
+(1,10): expected-doctype-but-got-start-tag
+(1,16): unexpected-end-tag-in-frameset
+(1,16): eof-in-frameset
+#document
+| <html>
+|   <head>
+|   <frameset>
+
+
+#source tests6.dat:33
+#data
+<table><tr><div>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,16): unexpected-start-tag-implies-table-voodoo
+(1,16): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|     <table>
+|       <tbody>
+|         <tr>
+
+
+#source tests6.dat:36
+#data
+<table><tr><div><td>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,16): foster-parenting-start-tag
+(1,20): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+
+
+#source tests6.dat:38
+#data
+<table><tbody></thead>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,22): unexpected-end-tag-in-table-body
+(1,22): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+
+
+#source tests6.dat:40
+#data
+<table><tbody></body></caption></col></colgroup></html></td></th></tr>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,21): unexpected-end-tag-in-table-body
+(1,31): unexpected-end-tag-in-table-body
+(1,37): unexpected-end-tag-in-table-body
+(1,48): unexpected-end-tag-in-table-body
+(1,55): unexpected-end-tag-in-table-body
+(1,60): unexpected-end-tag-in-table-body
+(1,65): unexpected-end-tag-in-table-body
+(1,70): unexpected-end-tag-in-table-body
+(1,70): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+
+
+#source tests6.dat:41
+#data
+<table><tbody></div>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,20): unexpected-end-tag-implies-table-voodoo
+(1,20): end-tag-too-early
+(1,20): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+
+
+#source tests6.dat:42
+#data
+<table><table>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,14): unexpected-start-tag-implies-end-tag
+(1,14): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|     <table>
+
+
+#source tests6.dat:43
+#data
+<table></body></caption></col></colgroup></html></tbody></td></tfoot></th></thead></tr>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,14): unexpected-end-tag
+(1,24): unexpected-end-tag
+(1,30): unexpected-end-tag
+(1,41): unexpected-end-tag
+(1,48): unexpected-end-tag
+(1,56): unexpected-end-tag
+(1,61): unexpected-end-tag
+(1,69): unexpected-end-tag
+(1,74): unexpected-end-tag
+(1,82): unexpected-end-tag
+(1,87): unexpected-end-tag
+(1,87): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+
+
+#source tests6.dat:46
+#data
+<html><frameset></frameset></html> 
+#errors
+(1,6): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <frameset>
+|   " "
+
+
+#source tests6.dat:47
+#data
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"><html></html>
+#errors
+(1,50): doctype-has-public-identifier
+#document
+| <!DOCTYPE html "-//W3C//DTD HTML 4.01//EN" "">
+| <html>
+|   <head>
+|   <body>
+
+
+#source tests6.dat:48
+#data
+<param><frameset></frameset>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,17): unexpected-start-tag
+#document
+| <html>
+|   <head>
+|   <frameset>
+
+
+#source tests6.dat:49
+#data
+<source><frameset></frameset>
+#errors
+(1,8): expected-doctype-but-got-start-tag
+(1,18): unexpected-start-tag
+#document
+| <html>
+|   <head>
+|   <frameset>
+
+
+#source tests6.dat:50
+#data
+<track><frameset></frameset>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,17): unexpected-start-tag
+#document
+| <html>
+|   <head>
+|   <frameset>
+
+
+#source tests6.dat:51
+#data
+</html><frameset></frameset>
+#errors
+(1,7): expected-doctype-but-got-end-tag
+(1,17): expected-eof-but-got-start-tag
+(1,17): unexpected-start-tag
+#document
+| <html>
+|   <head>
+|   <frameset>
+
+
+#source tests6.dat:52
+#data
+</body><frameset></frameset>
+#errors
+(1,7): expected-doctype-but-got-end-tag
+(1,17): unexpected-start-tag-after-body
+(1,17): unexpected-start-tag
+#document
+| <html>
+|   <head>
+|   <frameset>
+
+#source tests7.dat:2
+#data
+<!doctype html><table><title>X</title></table>
+#errors
+(1,29): unexpected-start-tag-implies-table-voodoo
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <title>
+|       "X"
+|     <table>
+
+
+#source tests7.dat:3
+#data
+<!doctype html><head></head><title>X</title>
+#errors
+(1,35): unexpected-start-tag-out-of-my-head
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <title>
+|       "X"
+|   <body>
+
+
+#source tests7.dat:4
+#data
+<!doctype html></head><title>X</title>
+#errors
+(1,29): unexpected-start-tag-out-of-my-head
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <title>
+|       "X"
+|   <body>
+
+
+#source tests7.dat:5
+#data
+<!doctype html></head><base>X
+#errors
+(1,28): unexpected-start-tag-out-of-my-head
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <base>
+|   <body>
+|     "X"
+
+
+#source tests7.dat:6
+#data
+<!doctype html></head><basefont>X
+#errors
+(1,32): unexpected-start-tag-out-of-my-head
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <basefont>
+|   <body>
+|     "X"
+
+
+#source tests7.dat:7
+#data
+<!doctype html></head><bgsound>X
+#errors
+(1,31): unexpected-start-tag-out-of-my-head
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <bgsound>
+|   <body>
+|     "X"
+
+
+#source tests7.dat:8
+#data
+<!doctype html><table><meta></table>
+#errors
+(1,28): unexpected-start-tag-implies-table-voodoo
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <meta>
+|     <table>
+
+
+#source tests7.dat:9
+#data
+<!doctype html><table>X<tr><td><table> <meta></table></table>
+#errors
+unexpected text in table
+(1,45): unexpected-start-tag-implies-table-voodoo
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "X"
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+|             <meta>
+|             <table>
+|               " "
+
+
+#source tests7.dat:10
+#data
+<!doctype html><html> <head>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+
+
+#source tests7.dat:11
+#data
+<!doctype html> <head>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+
+
+#source tests7.dat:12
+#data
+<!doctype html><table><style> <tr>x </style> </table>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <style>
+|         " <tr>x "
+|       " "
+
+
+#source tests7.dat:13
+#data
+<!doctype html><table><TBODY><script> <tr>x </script> </table>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <script>
+|           " <tr>x "
+|         " "
+
+
+#source tests7.dat:14
+#data
+<!doctype html><p><applet><p>X</p></applet>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <applet>
+|         <p>
+|           "X"
+
+
+#source tests7.dat:15
+#data
+<!doctype html><p><object type="application/x-non-existant-plugin"><p>X</p></object>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <object>
+|         type="application/x-non-existant-plugin"
+|         <p>
+|           "X"
+
+
+#source tests7.dat:16
+#data
+<!doctype html><listing>
+X</listing>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <listing>
+|       "X"
+
+
+#source tests7.dat:17
+#data
+<!doctype html><select><input>X
+#errors
+1:32: ERROR: Premature end of file. Currently open tags: html, body, select.
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|     <input>
+|     "X"
+
+
+#source tests7.dat:18
+#data
+<!doctype html><select><select>X
+#errors
+1:24: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select.
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|     "X"
+
+
+#source tests7.dat:19
+#data
+<!doctype html><table><input type=hidDEN></table>
+#errors
+(1,41): unexpected-hidden-input-in-table
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <input>
+|         type="hidDEN"
+
+
+#source tests7.dat:20
+#data
+<!doctype html><table>X<input type=hidDEN></table>
+#errors
+(1,23): foster-parenting-character
+(1,42): unexpected-hidden-input-in-table
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     "X"
+|     <table>
+|       <input>
+|         type="hidDEN"
+
+
+#source tests7.dat:21
+#data
+<!doctype html><table>  <input type=hidDEN></table>
+#errors
+(1,43): unexpected-hidden-input-in-table
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       "  "
+|       <input>
+|         type="hidDEN"
+
+
+#source tests7.dat:22
+#data
+<!doctype html><table>  <input type='hidDEN'></table>
+#errors
+(1,45): unexpected-hidden-input-in-table
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       "  "
+|       <input>
+|         type="hidDEN"
+
+
+#source tests7.dat:23
+#data
+<!doctype html><table><input type=" hidden"><input type=hidDEN></table>
+#errors
+(1,44): unexpected-start-tag-implies-table-voodoo
+(1,63): unexpected-hidden-input-in-table
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <input>
+|       type=" hidden"
+|     <table>
+|       <input>
+|         type="hidDEN"
+
+
+#source tests7.dat:24
+#data
+<!doctype html><table><select>X<tr>
+#errors
+(1,30): unexpected-start-tag-implies-table-voodoo
+(1,35): unexpected-table-element-start-tag-in-select-in-table
+(1,35): eof-in-table
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       "X"
+|     <table>
+|       <tbody>
+|         <tr>
+
+
+#source tests7.dat:25
+#data
+<!doctype html><select>X</select>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       "X"
+
+
+#source tests7.dat:26
+#data
+<!DOCTYPE hTmL><html></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+
+
+#source tests7.dat:27
+#data
+<!DOCTYPE HTML><html></html>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+
+
+#source tests7.dat:29
+#data
+<div><p>a</x> b
+#errors
+(1,5): expected-doctype-but-got-start-tag
+(1,13): unexpected-end-tag
+(1,15): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       <p>
+|         "a b"
+
+
+#source tests7.dat:30
+#data
+<table><tr><td><code></code> </table>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+|             <code>
+|             " "
+
+
+#source tests7.dat:31
+#data
+<table><b><tr><td>aaa</td></tr>bbb</table>ccc
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,10): foster-parenting-start-tag
+(1,32): foster-parenting-character
+(1,33): foster-parenting-character
+(1,34): foster-parenting-character
+(1,45): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|     <b>
+|       "bbb"
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+|             "aaa"
+|     <b>
+|       "ccc"
+
+
+#source tests7.dat:32
+#data
+A<table><tr> B</tr> B</table>
+#errors
+(1,1): expected-doctype-but-got-chars
+(1,13): foster-parenting-character
+(1,14): foster-parenting-character
+(1,20): foster-parenting-character
+(1,21): foster-parenting-character
+#document
+| <html>
+|   <head>
+|   <body>
+|     "A B B"
+|     <table>
+|       <tbody>
+|         <tr>
+
+
+#source tests7.dat:33
+#data
+A<table><tr> B</tr> </em>C</table>
+#errors
+(1,1): expected-doctype-but-got-chars
+(1,13): foster-parenting-character
+(1,14): foster-parenting-character
+(1,25): unexpected-end-tag
+(1,25): unexpected-end-tag-in-special-element
+(1,26): foster-parenting-character
+#document
+| <html>
+|   <head>
+|   <body>
+|     "A BC"
+|     <table>
+|       <tbody>
+|         <tr>
+|         " "
+
+
+#source tests7.dat:34
+#data
+<select><keygen>
+#errors
+1:1: ERROR: Expected a doctype token
+1:17: ERROR: Premature end of file. Currently open tags: html, body, select.
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <keygen>
+
+#source tests8.dat:6
+#data
+<table><li><li></table>
+#errors
+(1,7): expected-doctype-but-got-start-tag
+(1,11): foster-parenting-start-tag
+(1,15): foster-parenting-start-tag
+#document
+| <html>
+|   <head>
+|   <body>
+|     <li>
+|     <li>
+|     <table>
+
+
+#source tests8.dat:7
+#data
+x<table>x
+#errors
+(1,1): expected-doctype-but-got-chars
+(1,9): foster-parenting-character
+(1,9): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     "xx"
+|     <table>
+
+
+#source tests8.dat:8
+#data
+x<table><table>x
+#errors
+(1,1): expected-doctype-but-got-chars
+(1,15): unexpected-start-tag-implies-end-tag
+(1,16): foster-parenting-character
+(1,16): eof-in-table
+#document
+| <html>
+|   <head>
+|   <body>
+|     "x"
+|     <table>
+|     "x"
+|     <table>
+
+
+#source tests8.dat:9
+#data
+<b>a<div></div><div></b>y
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,24): adoption-agency-1.3
+(1,25): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <b>
+|       "a"
+|       <div>
+|     <div>
+|       <b>
+|       "y"
+
+


### PR DESCRIPTION
## Summary
- Add 74 more full-document html5lib tree-construction smoke cases across tests6.dat, tests7.dat, and tests8.dat.
- Fix table/form/select recovery needed by those cases, including form end-tag stack removal, pre-body void handling, fostered formatting reconstruction, table-context list-item/title/input handling, and nested table reprocessing.
- Keep the lexer TOML and generated Rust in sync for comment-start-dash handling and cover `<!---x` with a regression test.

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer`

## Next Known Blocker
- `tests8.dat:10` (`<a><div><p></a>`) still needs the deeper anchor adoption-agency repair.