### PR TITLE
Add Board VM RFCOMM smoke coverage

### DIFF
--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -2691,6 +2691,44 @@ blink program_id=3 status=Halted instructions=7 elapsed_ms=250 stack_depth=1 ope
     }
 
     #[test]
+    fn smoke_sequence_runs_over_rfcomm_wire_transport() {
+        let endpoint = "btspp://uno-r4-wifi:1";
+        let options = SmokeOptions {
+            port: None,
+            endpoint: Some(endpoint.to_owned()),
+            board: "auto".to_owned(),
+            baud_rate: DEFAULT_BAUD_RATE,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+            program_id: 10,
+            instruction_budget: 200,
+            host_nonce: 0xCAFE_BABE,
+        };
+        let transport = LanguageBluetoothTransport::<_, 2048>::with_transactor(
+            endpoint,
+            LoopbackBluetoothWireTransactor::new(),
+        );
+
+        let report = run_smoke_with_transport(&options, transport).unwrap();
+
+        assert_eq!(
+            report.connection.transport,
+            SmokeConnectionTransport::BluetoothClassicRfcomm
+        );
+        assert_eq!(report.connection.label, format!("endpoint={endpoint}"));
+        assert_eq!(report.connection.timeout_ms, DEFAULT_TIMEOUT_MS);
+        assert_eq!(report.hello.board_name, LOOPBACK_BOARD_ID);
+        assert_eq!(report.hello.runtime_name, LOOPBACK_RUNTIME_ID);
+        assert_eq!(report.hello.host_nonce, 0xCAFE_BABE);
+        assert_eq!(report.descriptor.board_id, LOOPBACK_BOARD_ID);
+        assert_eq!(report.upload.program_id, 10);
+        assert_eq!(report.upload.total_len as usize, BLINK_MODULE_LEN);
+        assert_ne!(report.upload.program_crc32, 0);
+        assert_eq!(report.run.program_id, 10);
+        assert_eq!(report.run.status, RunStatus::Running);
+        assert_eq!(report.run.open_handles, 1);
+    }
+
+    #[test]
     fn smoke_endpoint_runs_over_tcp_loopback_transport() {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let address = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary
- add CLI smoke coverage for a Bluetooth Classic RFCOMM endpoint using the Rust-owned Bluetooth wire transport
- assert RFCOMM smoke runs report the bluetooth_classic_rfcomm connection transport metadata
- keep the language-facing path thin over the existing Rust endpoint parsing and transport wiring

## Validation
- cargo test -p board-vm-cli
- cargo test -p board-vm-language-core -p board-vm-bluetooth -p board-vm-tcp
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check