### PR TITLE
Wire TypeScript MACSYMA transcendental solve

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Wire direct `Solve(f(linear) = constant, var)` transcendental equations to
+  the TypeScript `cas-solve` `trySolveTranscendental` handler, returning
+  `List(...)` symbolic inverse and periodic-family solutions.
 - Wire `Solve(inequality, var)` to the TypeScript `cas-solve`
   `trySolveInequality` handler for polynomial inequalities, returning
   `List(...)` interval predicates and preserving unevaluated fallback behavior.

--- a/code/packages/typescript/macsyma-runtime/README.md
+++ b/code/packages/typescript/macsyma-runtime/README.md
@@ -14,5 +14,7 @@ This first runtime slice is intentionally small and browser-friendly:
   `cas-solve` linear-system solver
 - dispatches `Solve(inequality, var)` to the `cas-solve` polynomial
   inequality solver for interval predicates
+- dispatches direct `Solve(f(linear) = constant, var)` transcendental
+  equations to the `cas-solve` inverse-family solver
 - exposes a JSON helper whose recursive IR representation is safe for
   `JSON.stringify`

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -1,5 +1,5 @@
 import { compileMacsyma } from "@coding-adventures/macsyma-compiler";
-import { solveLinearSystem, trySolveInequality } from "@coding-adventures/cas-solve";
+import { solveLinearSystem, trySolveInequality, trySolveTranscendental } from "@coding-adventures/cas-solve";
 import {
   ACOS,
   ACOSH,
@@ -541,6 +541,11 @@ function solveHandler(_vm: VM, expr: IRApply): IRNode {
 
   if (variablesNode.kind === "symbol" && isInequality(equationsNode)) {
     const solutions = trySolveInequality(equationsNode, variablesNode);
+    return solutions === null ? expr : app(LIST, solutions);
+  }
+
+  if (variablesNode.kind === "symbol") {
+    const solutions = trySolveTranscendental(equationsNode, variablesNode);
     return solutions === null ? expr : app(LIST, solutions);
   }
 

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it } from "vitest";
 import {
   ADD,
   EQUAL,
+  EXP,
   GREATER,
   GREATER_EQUAL,
   LESS,
   LESS_EQUAL,
   LIST,
+  LOG,
   MUL,
   POW,
   RULE,
+  SIN,
   SOLVE,
   SUB,
   app,
@@ -315,6 +318,47 @@ describe("macsyma-runtime", () => {
     const session = new MacsymaSession();
     const expr = app(SOLVE, [
       app(GREATER, [app(sym("Sin"), [x]), int(0)]),
+      x,
+    ]);
+
+    const [result] = session.evalStatements([expr]);
+    expect(result.output).toEqual(expr);
+  });
+
+  it("solves direct transcendental equations through the cas-solve handler", () => {
+    const x = sym("x");
+    const session = new MacsymaSession();
+    const [expResult, sinResult] = session.evalStatements([
+      app(SOLVE, [
+        app(EQUAL, [app(EXP, [x]), int(2)]),
+        x,
+      ]),
+      app(SOLVE, [
+        app(EQUAL, [app(SIN, [x]), int(0)]),
+        x,
+      ]),
+    ]);
+
+    expect(expResult.output).toEqual(app(LIST, [
+      app(LOG, [int(2)]),
+    ]));
+    expect(sinResult.output).toEqual(app(LIST, [
+      app(sym("Add"), [
+        app(sym("Asin"), [int(0)]),
+        app(MUL, [int(2), app(MUL, [sym("%pi"), sym("FreeInteger")])]),
+      ]),
+      app(sym("Add"), [
+        app(SUB, [sym("%pi"), app(sym("Asin"), [int(0)])]),
+        app(MUL, [int(2), app(MUL, [sym("%pi"), sym("FreeInteger")])]),
+      ]),
+    ]));
+  });
+
+  it("keeps unsupported transcendental Solve calls unevaluated", () => {
+    const x = sym("x");
+    const session = new MacsymaSession();
+    const expr = app(SOLVE, [
+      app(EQUAL, [app(SIN, [app(SIN, [x])]), int(0)]),
       x,
     ]);
 


### PR DESCRIPTION
## Summary
- wire TypeScript MACSYMA `Solve(expr, var)` through `cas-solve` `trySolveTranscendental`
- return `List(...)` symbolic inverse and periodic-family solutions for direct `f(linear) = constant` equations
- preserve unevaluated fallback behavior for unsupported nested transcendental forms

## Validation
- `npm install && npm test && npm run build` in `code/packages/typescript/macsyma-runtime`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-transcendental-runtime.json` from `code/programs/go/build-tool`