### PR TITLE
Add capability cage secure env wrappers

### DIFF
--- a/code/packages/rust/capability-cage/CHANGELOG.md
+++ b/code/packages/rust/capability-cage/CHANGELOG.md
@@ -10,6 +10,8 @@
   actuation, plus same-resource read/write overlap.
 - Added audit envelope primitives: `Operation<T>`, `OperationRecord`,
   `OperationDecision`, `AuditSink`, `NoopAuditSink`, and `VecAuditSink`.
+- Added `secure_env::read_var` / `write_var` plus backend hooks and test
+  scripting for manifest-checked environment variable access.
 
 ## 0.1.0 — 2026-05-08
 

--- a/code/packages/rust/capability-cage/README.md
+++ b/code/packages/rust/capability-cage/README.md
@@ -69,6 +69,7 @@ assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
 | `audit`         | `Operation<T>`, `OperationRecord`, and `AuditSink` envelope types |
 | `backend`       | `Backend` trait + `OpenBackend` / `TestBackend` / `DenyAllBackend`, `with_backend(...)` guard |
 | `secure_file`   | `read_file` / `write_file` / `create_file` / `delete_file` / `list_dir` |
+| `secure_env`    | `read_var` / `write_var` for manifest-checked environment access |
 
 ## Backend swap
 
@@ -92,8 +93,7 @@ default parallel test scheduler.
 
 Spec-defined but landing in subsequent PRs:
 
-- `secure_net` / `secure_proc` / `secure_env` / `secure_time` /
-  `secure_stdio` modules
+- `secure_net` / `secure_proc` / `secure_time` / `secure_stdio` modules
 - `build.rs` codegen for `package_manifest()`
 - Cross-language conformance suite shared with the Go cage
 - The CI lint that rejects raw stdlib usage

--- a/code/packages/rust/capability-cage/src/backend.rs
+++ b/code/packages/rust/capability-cage/src/backend.rs
@@ -6,8 +6,9 @@
 //! `host-runtime-rust` crate (future) installs its own backend that
 //! routes secure calls over the host channel.
 //!
-//! V1 scope: file-system methods only. Network, process, env, time,
-//! and stdio methods land in subsequent PRs.
+//! V1 scope started with file-system methods. Environment access now has the
+//! same backend seam. Network, process, time, and stdio methods land in
+//! subsequent PRs.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -24,6 +25,8 @@ pub trait Backend: Send + Sync {
     fn create_file(&self, path: &Path) -> io::Result<()>;
     fn delete_file(&self, path: &Path) -> io::Result<()>;
     fn list_dir(&self, path: &Path) -> io::Result<Vec<String>>;
+    fn read_env(&self, name: &str) -> io::Result<Option<String>>;
+    fn write_env(&self, name: &str, value: &str) -> io::Result<()>;
 }
 
 /// The default backend. Delegates straight to [`std::fs`].
@@ -59,6 +62,22 @@ impl Backend for OpenBackend {
             }
         }
         Ok(names)
+    }
+
+    fn read_env(&self, name: &str) -> io::Result<Option<String>> {
+        match std::env::var(name) {
+            Ok(value) => Ok(Some(value)),
+            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(std::env::VarError::NotUnicode(_)) => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("environment variable {name} is not valid Unicode"),
+            )),
+        }
+    }
+
+    fn write_env(&self, name: &str, value: &str) -> io::Result<()> {
+        std::env::set_var(name, value);
+        Ok(())
     }
 }
 
@@ -103,6 +122,20 @@ impl Backend for DenyAllBackend {
             "DenyAllBackend refused fs.list",
         ))
     }
+
+    fn read_env(&self, _name: &str) -> io::Result<Option<String>> {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "DenyAllBackend refused env.read",
+        ))
+    }
+
+    fn write_env(&self, _name: &str, _value: &str) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "DenyAllBackend refused env.write",
+        ))
+    }
 }
 
 /// A backend that records every call into an internal log. Useful in
@@ -116,6 +149,7 @@ pub struct TestBackend {
     log: Mutex<Vec<TestBackendCall>>,
     file_responses: Mutex<Vec<(PathBuf, Vec<u8>)>>,
     dir_responses: Mutex<Vec<(PathBuf, Vec<String>)>>,
+    env_responses: Mutex<Vec<(String, String)>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,6 +159,8 @@ pub enum TestBackendCall {
     CreateFile(PathBuf),
     DeleteFile(PathBuf),
     ListDir(PathBuf),
+    ReadEnv(String),
+    WriteEnv(String, String),
 }
 
 impl TestBackend {
@@ -133,6 +169,7 @@ impl TestBackend {
             log: Mutex::new(Vec::new()),
             file_responses: Mutex::new(Vec::new()),
             dir_responses: Mutex::new(Vec::new()),
+            env_responses: Mutex::new(Vec::new()),
         }
     }
 
@@ -152,6 +189,15 @@ impl TestBackend {
             .lock()
             .unwrap()
             .push((path.into(), entries));
+        self
+    }
+
+    /// Script a response for an environment variable read.
+    pub fn with_env_response(self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env_responses
+            .lock()
+            .unwrap()
+            .push((name.into(), value.into()));
         self
     }
 
@@ -222,6 +268,29 @@ impl Backend for TestBackend {
             .map(|(_, e)| e.clone())
             .unwrap_or_default();
         Ok(entries)
+    }
+
+    fn read_env(&self, name: &str) -> io::Result<Option<String>> {
+        self.log
+            .lock()
+            .unwrap()
+            .push(TestBackendCall::ReadEnv(name.to_string()));
+        let value = self
+            .env_responses
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(candidate, _)| candidate == name)
+            .map(|(_, value)| value.clone());
+        Ok(value)
+    }
+
+    fn write_env(&self, name: &str, value: &str) -> io::Result<()> {
+        self.log.lock().unwrap().push(TestBackendCall::WriteEnv(
+            name.to_string(),
+            value.to_string(),
+        ));
+        Ok(())
     }
 }
 
@@ -335,6 +404,14 @@ mod tests {
             b.list_dir(Path::new("./x")).unwrap_err().kind(),
             io::ErrorKind::PermissionDenied
         );
+        assert_eq!(
+            b.read_env("TOKEN").unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            b.write_env("TOKEN", "secret").unwrap_err().kind(),
+            io::ErrorKind::PermissionDenied
+        );
     }
 
     #[test]
@@ -374,5 +451,19 @@ mod tests {
         let b = TestBackend::new().with_dir_response("./dir", vec!["a.txt".into(), "b.txt".into()]);
         let entries = b.list_dir(Path::new("./dir")).unwrap();
         assert_eq!(entries, vec!["a.txt".to_string(), "b.txt".to_string()]);
+    }
+
+    #[test]
+    fn test_backend_records_env_access() {
+        let b = TestBackend::new().with_env_response("TOKEN", "secret");
+        assert_eq!(b.read_env("TOKEN").unwrap(), Some("secret".to_string()));
+        b.write_env("MODE", "test").unwrap();
+
+        let calls = b.calls();
+        assert_eq!(calls.len(), 2);
+        assert!(matches!(&calls[0], TestBackendCall::ReadEnv(name) if name == "TOKEN"));
+        assert!(
+            matches!(&calls[1], TestBackendCall::WriteEnv(name, value) if name == "MODE" && value == "test")
+        );
     }
 }

--- a/code/packages/rust/capability-cage/src/lib.rs
+++ b/code/packages/rust/capability-cage/src/lib.rs
@@ -5,8 +5,9 @@
 //! V1 scope: foundational types, manifest loading and validation, glob
 //! matcher, the [`Backend`] trait with [`OpenBackend`] / [`TestBackend`]
 //! / [`DenyAllBackend`] implementations, audit envelope types, and the
-//! [`secure_file`] family of secure-wrapper functions. Other secure-wrapper
-//! categories (`net`, `proc`, `env`, `time`, `stdio`) land in subsequent PRs.
+//! [`secure_file`] / [`secure_env`] secure-wrapper families. Other
+//! secure-wrapper categories (`net`, `proc`, `time`, `stdio`) land in
+//! subsequent PRs.
 
 mod audit;
 mod backend;
@@ -15,6 +16,7 @@ mod category;
 mod errors;
 mod glob;
 mod manifest;
+pub mod secure_env;
 pub mod secure_file;
 
 pub use audit::{

--- a/code/packages/rust/capability-cage/src/secure_env.rs
+++ b/code/packages/rust/capability-cage/src/secure_env.rs
@@ -1,0 +1,108 @@
+//! Secure-wrapper functions for the `env` capability category.
+//!
+//! These wrappers mirror [`crate::secure_file`]: every call checks the
+//! manifest first, then delegates to the current backend. Environment variable
+//! names are the manifest targets, so callers grant individual variables or
+//! globbed variable families.
+
+use std::io;
+
+use crate::backend::current_backend;
+use crate::category::{Action, Category};
+use crate::errors::CapabilityViolationError;
+use crate::manifest::Manifest;
+
+/// Read one environment variable as Unicode.
+///
+/// Missing variables return `Ok(None)`. Non-Unicode variables are reported by
+/// the backend as [`io::ErrorKind::InvalidData`].
+pub fn read_var(manifest: &Manifest, name: &str) -> io::Result<Option<String>> {
+    check(manifest, Action::Read, name)?;
+    current_backend().read_env(name)
+}
+
+/// Set one environment variable.
+pub fn write_var(manifest: &Manifest, name: &str, value: &str) -> io::Result<()> {
+    check(manifest, Action::Write, name)?;
+    current_backend().write_env(name, value)
+}
+
+fn check(manifest: &Manifest, action: Action, name: &str) -> io::Result<()> {
+    manifest
+        .check(Category::Env, action, name)
+        .map_err(violation_to_io)
+}
+
+fn violation_to_io(err: CapabilityViolationError) -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, err)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::backend::{with_backend, TestBackend, TestBackendCall};
+    use crate::capability::Capability;
+
+    fn manifest_with(action: Action, target: &str) -> Manifest {
+        Manifest::new(vec![
+            Capability::new(Category::Env, action, target, "test").unwrap()
+        ])
+    }
+
+    #[test]
+    fn read_var_calls_backend_when_allowed() {
+        let backend = Arc::new(TestBackend::new().with_env_response("TOKEN", "secret"));
+        let _guard = with_backend(backend.clone());
+        let manifest = manifest_with(Action::Read, "TOKEN");
+
+        let value = read_var(&manifest, "TOKEN").unwrap();
+
+        assert_eq!(value, Some("secret".to_string()));
+        assert!(matches!(&backend.calls()[0], TestBackendCall::ReadEnv(name) if name == "TOKEN"));
+    }
+
+    #[test]
+    fn read_var_denied_without_manifest_entry() {
+        let backend = Arc::new(TestBackend::new().with_env_response("TOKEN", "secret"));
+        let _guard = with_backend(backend.clone());
+
+        let err = read_var(&Manifest::empty(), "TOKEN").unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        let underlying = err.into_inner().expect("expected source error");
+        let violation = underlying
+            .downcast_ref::<CapabilityViolationError>()
+            .expect("expected CapabilityViolationError");
+        assert_eq!(violation.category, Category::Env);
+        assert_eq!(violation.action, Action::Read);
+        assert_eq!(violation.target, "TOKEN");
+        assert!(backend.calls().is_empty(), "backend was called on denial");
+    }
+
+    #[test]
+    fn write_var_calls_backend_when_allowed() {
+        let backend = Arc::new(TestBackend::new());
+        let _guard = with_backend(backend.clone());
+        let manifest = manifest_with(Action::Write, "MODE");
+
+        write_var(&manifest, "MODE", "test").unwrap();
+
+        assert!(
+            matches!(&backend.calls()[0], TestBackendCall::WriteEnv(name, value) if name == "MODE" && value == "test")
+        );
+    }
+
+    #[test]
+    fn glob_target_matches_variable_family() {
+        let backend = Arc::new(TestBackend::new().with_env_response("APP_TOKEN", "secret"));
+        let _guard = with_backend(backend);
+        let manifest = manifest_with(Action::Read, "APP_*");
+
+        assert_eq!(
+            read_var(&manifest, "APP_TOKEN").unwrap(),
+            Some("secret".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add secure_env::read_var and write_var for manifest-checked environment access
- extend the capability-cage backend trait, OpenBackend, DenyAllBackend, and TestBackend with env read/write hooks
- document secure_env as the first non-file secure wrapper category

## Tests
- cargo test -p capability-cage