### PR TITLE
[codex] Handle anchor adoption across paragraphs

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -3470,7 +3470,7 @@ impl HtmlParser {
                     if path.len() == first_div_path.len() + 1 && path.starts_with(&first_div_path) {
                         let child_index = *path.last()?;
                         element_at_path(&self.document, path)
-                            .is_some_and(is_paragraph_boundary_element)
+                            .is_some_and(|name| name == "p" || is_paragraph_boundary_element(name))
                             .then_some(child_index)
                     } else {
                         None
@@ -4726,9 +4726,14 @@ fn seed_formatting_around_boundary_child(
             reconstructed_element.children = wrapped_children;
         }
         element.children.insert(0, reconstructed_formatting);
+    } else {
+        element.children.insert(
+            0,
+            Node::element(formatting_name.to_string(), formatting_attributes.to_vec()),
+        );
     }
 
-    let adjusted_boundary_index = usize::from(boundary_child_index > 0);
+    let adjusted_boundary_index = 1;
     let Some(Node::Element(boundary_element)) = element.children.get_mut(adjusted_boundary_index)
     else {
         return;

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -24437,3 +24437,21 @@ x<table><table>x
 |       "y"
 
 
+
+#source tests8.dat:10
+#data
+<a><div><p></a>
+#errors
+(1,3): expected-doctype-but-got-start-tag
+(1,15): adoption-agency-1.3
+(1,15): adoption-agency-1.3
+(1,15): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <a>
+|     <div>
+|       <a>
+|       <p>
+|         <a>


### PR DESCRIPTION
## Summary
- Add the final full-document tests8.dat html5lib tree-construction smoke case.
- Treat `<p>` as a formatting adoption boundary when repairing formatting across `<div>`.
- Preserve the empty reconstructed formatting sibling before the paragraph while also seeding the reconstructed anchor inside the paragraph.

## Validation
- `cargo test -p coding-adventures-html-parser -p coding-adventures-html-lexer`

## Notes
- This completes the full-document tests8.dat coverage already started by #2966.