### PR TITLE
feat(image-gpu-core): MX05 Phase 4.4 — dispatch-routing half (v0.8.0)

### DIFF
--- a/code/packages/rust/image-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/image-gpu-core/CHANGELOG.md
@@ -1,5 +1,113 @@
 # Changelog — image-gpu-core
 
+## 0.8.0 — 2026-05-12
+
+### Added — MX05 Phase 4.4 (dispatch-routing half of the loop)
+
+Closes the **dispatch** half of the specialised-kernel routing loop.
+When a placed graph has exactly one non-Const Compute op and that
+op's specialised kernel is installed on the metal executor,
+image-gpu-core now routes the dispatch through the
+`ExecutorRequest::DispatchSpecialised` protocol message instead of
+the generic `Dispatch { graph }` path.
+
+```
+runtime ─Dispatch{prep_graph}─►  metal-executor  (allocate buffers, upload constants)
+runtime ─DispatchSpecialised{handle, inputs, outputs}─►  metal-executor.SpecialisedTable[handle]
+                                                  ─►  installed_closure(buffers...)
+                                                  ─►  DispatchDone
+runtime ─DownloadBuffer─►  metal-executor  (returns output bytes)
+```
+
+#### What's new
+
+- **`pub fn specialised_dispatch_count() -> usize`** — new public
+  counter (process-wide, monotonic, atomic).  Distinct from
+  `specialised_install_count` — that counts how many kernels are
+  installed; this counts how many *invocations* went through
+  `DispatchSpecialised`.  Always `0` on non-Apple builds (no Metal
+  executor to dispatch on).
+- **`drive_specialisation` now returns `HashMap<u32, u64>`** —
+  `(op_index → installed_handle)` for every Compute op whose
+  specialised kernel is currently installed on the metal executor.
+  The dispatcher uses this map to decide whether to route through
+  `dispatch_specialised_via` (when the map covers all non-Const
+  Compute ops in the graph).
+- **`single_non_const_compute_with_handle(placed, installed_per_op)`**
+  — helper that returns `Some((op_index, handle))` iff the placed
+  graph contains exactly one non-Const Compute op and that op has
+  an installed specialised kernel.  Multi-op routing is later phase
+  work — that's `None` for V0.8.0 and the dispatcher falls back to
+  the generic path.
+- **`dispatch_specialised_via(transport, placed, compute_op_idx,
+  handle, output_residency, output_byte_count)`** — the routing
+  function itself.  Strategy:
+    1. Strip the single non-Const Compute op from `placed.ops`.
+    2. Fire `Dispatch { prep_graph }` so matrix-metal's existing
+       handler allocates buffers and uploads constants under the
+       planner-assigned BufferIds.  This sidesteps the
+       protocol-`AllocBuffer`-uses-server-IDs mismatch.
+    3. Fire `DispatchSpecialised { handle, inputs, outputs }` where
+       `inputs` is `ir_op.inputs()` trimmed to the installed
+       kernel's `input_buffer_count` (so a kernel with a folded RHS
+       constant only sees the LHS buffer, not both).
+    4. Download the output via `DownloadBuffer`.
+    5. Bump `SPECIALISED_DISPATCH_COUNT` on success.
+- **`INSTALLED_KERNEL_METADATA: Mutex<HashMap<u64, (usize, usize)>>`**
+  side-table — records `(input_buffer_count, output_buffer_count)`
+  for each installed handle.  Populated by
+  `try_auto_install_specialised`; read by `dispatch_specialised_via`
+  when trimming `ir_op.inputs()` to the right count.
+
+#### Test
+
+`dispatch_specialised_via_produces_correct_output` (Apple-only):
+
+Builds a manually-placed `Op::Add(A, B) → C` graph pinned to metal
+where `A = [1, 2, 3, 4]` and `B = [7, 7, 7, 7]` (the constant to
+fold).  Installs the Add+constant-7.0 kernel directly via
+`MetalExecutor::install_specialised_from_emitted`, then calls
+`dispatch_specialised_via` and asserts:
+
+1. `specialised_dispatch_count` rose by exactly one.
+2. The downloaded output is `[8.0, 9.0, 10.0, 11.0]` — same as the
+   generic Add would produce.
+
+Total test count: 29 → 30.
+
+#### Why not a planner-driven end-to-end test?
+
+The cost model in matrix-runtime currently prefers CPU over metal
+for the `Op::Add(f32) → f32` shape regardless of `N`: the per-element
+host→device transfer cost (`bytes / host_to_device_bw = 4N/50` ns)
+exceeds the CPU per-element compute cost (`N/40` ns), so the planner
+never picks metal for a graph that does Add of two constants no
+matter how large.  A real planner-picks-metal scenario needs either
+(a) a heavier op like `Op::MatMul` (Phase 4.5 emitter work),
+(b) more realistic profile numbers (Apple Silicon's unified memory
+is ~200 GB/s effective bandwidth, not the conservative 50 GB/s
+we currently advertise), or (c) constants persistent across
+invocations (a future protocol extension).
+
+V0.8.0 ships the protocol-level routing in isolation; the
+planner-side decision logic is covered by existing tests in
+matrix-runtime/src/planner.rs.  The two compose naturally once a
+heavier emitter shape lands.
+
+#### What this still doesn't do
+
+- **Multi-op specialised graphs** — V0.8.0 only handles
+  single-Compute-op graphs.  A graph with `Add(x, y) → Mul(_, z) → out`
+  falls back to generic dispatch even when both Add and Mul have
+  installed kernels.  Multi-op routing requires interleaving
+  per-op DispatchSpecialised calls with intermediate buffer
+  management, which is the next phase's scope.
+- **matrix-cpu auto-install + dispatch routing** — Phase 4.3
+  noted that matrix-cpu's `CpuSpecialiser` emits opaque handles
+  without closure sources, so there's nothing for image-gpu-core
+  to auto-install on CPU.  Same constraint here for dispatch
+  routing: the CPU path always goes generic.  Future phase work.
+
 ## 0.7.0 — 2026-05-12
 
 ### Added — MX05 Phase 4.3 (runtime-side auto-installer; **install** half of the loop)

--- a/code/packages/rust/image-gpu-core/Cargo.toml
+++ b/code/packages/rust/image-gpu-core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "image-gpu-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
-description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). Each operation is a MatrixIR graph dispatched through matrix-runtime. v0.3 wires the optional matrix-metal GPU backend with transparent fallback to matrix-cpu. v0.4 wires the MX05 specialisation pipeline. v0.5 installs matrix_cpu::CpuSpecialiser. v0.6 adds tensor-byte sampling so DefaultPolicy fires on real constant-input observations. v0.7 (MX05 Phase 4.3) adds the runtime-side auto-installer: when SpecRouter::route returns a cached SpecialisedKernel, this crate auto-compiles the emitted MSL via msl_emitter and installs it onto the metal executor, with a new specialised_install_count() counter for visibility. Dispatch-routing through DispatchSpecialised is Phase 4.4 work."
+description = "IMG06: image-domain library built on the matrix execution layer (MX01–MX04). v0.3 wires the optional matrix-metal GPU backend. v0.4 wires the MX05 specialisation pipeline. v0.5 installs CpuSpecialiser. v0.6 adds tensor-byte sampling. v0.7 (MX05 Phase 4.3) adds the runtime-side auto-installer with a specialised_install_count() counter. v0.8 (MX05 Phase 4.4) closes the dispatch half: when a single-Compute-op graph has an installed specialised kernel on metal, image-gpu-core now routes the dispatch through ExecutorRequest::DispatchSpecialised (a prep Dispatch sets up buffers, then DispatchSpecialised invokes the installed kernel by handle). Counter specialised_dispatch_count() tracks how many invocations went specialised."
 
 [dependencies]
 matrix-ir         = { path = "../matrix-ir" }

--- a/code/packages/rust/image-gpu-core/src/lib.rs
+++ b/code/packages/rust/image-gpu-core/src/lib.rs
@@ -66,7 +66,10 @@ pub use pipeline::last_executor;
 /// invocation.  The two converge under normal operation; they diverge
 /// briefly while installs are in flight or when the emitter doesn't
 /// support a given `SpecKey` shape.
-pub use pipeline::{profiler_observations, spec_cache_len, specialised_install_count};
+pub use pipeline::{
+    profiler_observations, spec_cache_len, specialised_dispatch_count,
+    specialised_install_count,
+};
 
 use matrix_ir::{DType, GraphBuilder, Shape};
 

--- a/code/packages/rust/image-gpu-core/src/pipeline.rs
+++ b/code/packages/rust/image-gpu-core/src/pipeline.rs
@@ -238,6 +238,33 @@ pub fn specialised_install_count() -> usize {
     0
 }
 
+/// **MX05 Phase 4.4.**  Number of dispatches the runtime has routed
+/// through `ExecutorRequest::DispatchSpecialised` so far — i.e. how
+/// often the dispatch path actually invoked an installed specialised
+/// kernel rather than the generic op-by-op pipeline.
+///
+/// Process-wide counter, monotonic, never resets.  Distinct from:
+/// - [`spec_cache_len`] — kernels emitted by the specialiser.
+/// - [`specialised_install_count`] — kernels compiled and registered
+///   with an executor.
+/// - This counter — kernels actually *invoked* at dispatch time.
+///
+/// All three should track together under steady-state load: every
+/// installed kernel sees at least one dispatch eventually.  The
+/// invariant `dispatch ≥ install ≥ cache` holds in V0.8.0 (each step
+/// gates the next).  Always `0` on non-Apple builds — see the cfg
+/// equivalent for `specialised_install_count`.
+pub fn specialised_dispatch_count() -> usize {
+    SPECIALISED_DISPATCH_COUNT.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Backing storage for [`specialised_dispatch_count`].  Atomic so the
+/// hot path doesn't need a mutex; relaxed ordering is sufficient
+/// because the counter is observational, not a synchronisation
+/// primitive.
+static SPECIALISED_DISPATCH_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 // ─────────────────────── MX05 Phase 4.3 — auto-installer ───────────────────────
 //
 // When `SpecRouter::route` returns `Some(SpecialisedKernel)`, this
@@ -272,6 +299,36 @@ pub fn specialised_install_count() -> usize {
 fn installed_handles() -> &'static Mutex<HashSet<u64>> {
     static SLOT: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();
     SLOT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// **MX05 Phase 4.4.**  Per-handle metadata recorded at install time
+/// so the dispatch-routing path can validate buffer counts without
+/// re-emitting the kernel.  The tuple is
+/// `(input_buffer_count, output_buffer_count)`.
+///
+/// Why a side-table rather than threading through the
+/// `MetalExecutor`: the executor's `SpecialisedTable` stores boxed
+/// closures keyed by handle but doesn't expose introspection on the
+/// closure's expected argument shape.  Tracking these counts on the
+/// runtime side avoids piercing the closure abstraction and keeps
+/// the dispatcher's check cheap (one mutex lookup).
+#[cfg(feature = "metal-backend")]
+fn installed_kernel_metadata() -> &'static Mutex<HashMap<u64, (usize, usize)>> {
+    static SLOT: OnceLock<Mutex<HashMap<u64, (usize, usize)>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// **Test-only**.  Manually record kernel metadata for a handle.
+/// Used by integration tests that install a kernel directly via
+/// `MetalExecutor::install_specialised_from_emitted` rather than
+/// going through the auto-installer.
+#[cfg(all(test, feature = "metal-backend"))]
+pub(crate) fn record_test_kernel_metadata(handle: u64, n_in: usize, n_out: usize) {
+    let mut md = match installed_kernel_metadata().lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    md.insert(handle, (n_in, n_out));
 }
 
 /// **MX05 Phase 4.3.**  Try to auto-install a `SpecialisedKernel` onto
@@ -317,16 +374,31 @@ fn try_auto_install_specialised(specialised: &SpecialisedKernel) -> bool {
     else {
         return false;
     };
+    // **MX05 Phase 4.4.**  Stash the kernel's input/output buffer
+    // counts before the EmittedKernel is consumed by the install
+    // call.  The dispatch-routing path reads these counts to trim
+    // `ir_op.inputs()` down to just the buffers the specialised
+    // kernel actually consumes (e.g. an Add-with-folded-constant
+    // kernel takes 1 input, not the IR-level 2).
+    let n_in = emitted.input_buffer_count;
+    let n_out = emitted.output_buffer_count;
     match backend
         .executor
         .install_specialised_from_emitted(specialised.handle, emitted)
     {
         Ok(()) => {
-            let mut installed = match installed_handles().lock() {
+            {
+                let mut installed = match installed_handles().lock() {
+                    Ok(g) => g,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                installed.insert(specialised.handle);
+            }
+            let mut md = match installed_kernel_metadata().lock() {
                 Ok(g) => g,
                 Err(poisoned) => poisoned.into_inner(),
             };
-            installed.insert(specialised.handle);
+            md.insert(specialised.handle, (n_in, n_out));
             true
         }
         Err(_) => {
@@ -359,9 +431,23 @@ fn try_auto_install_specialised(_specialised: &matrix_runtime::SpecialisedKernel
 /// Pure observation work; no behavioural change to the dispatch.
 /// Cost: O(constants × bytes-per-constant) on each call, capped by
 /// the 16 MiB per-tensor limit (so ≤ a few MB scanned per dispatch).
-fn drive_specialisation(placed: &ComputeGraph) {
+///
+/// **Returns** a map `op_index → installed_handle` covering every
+/// Compute op whose `SpecKey` produced a kernel and where the kernel
+/// is currently installed on the metal executor.  An op's index is
+/// **absent** from the map when (a) the policy didn't fire, or
+/// (b) the policy fired but the emitter doesn't support the SpecKey,
+/// or (c) installation failed.  Callers use this map to decide
+/// whether to route through [`dispatch_specialised_via`] (when all
+/// non-Const Compute ops have entries) or fall back to the generic
+/// `Dispatch` path.
+fn drive_specialisation(placed: &ComputeGraph) -> HashMap<u32, u64> {
     let p = profiler();
     p.record_dispatch(placed);
+
+    // **MX05 Phase 4.4.**  Per-op installed-handle map populated
+    // during the route-and-install loop below.
+    let mut installed_per_op: HashMap<u32, u64> = HashMap::new();
 
     let subhash = Profiler::subhash(placed);
 
@@ -445,11 +531,41 @@ fn drive_specialisation(placed: &ComputeGraph) {
             // semantics.  Returning `None` from `route` (the policy
             // declined, or no specialiser matched) is the common
             // fast path and incurs zero cost here.
+            //
+            // **MX05 Phase 4.4.**  Whether install was a fresh hit
+            // or a no-op, if the handle is *currently installed*
+            // we record `(op_index, handle)` so the dispatcher can
+            // route this op through `DispatchSpecialised`.  See
+            // `handle_is_installed` for what "installed" means.
             if let Some(spec) = r.route(observation, ir_op.wire_tag(), out_dtype, executor.0) {
                 let _ = try_auto_install_specialised(&spec);
+                if handle_is_installed(spec.handle) {
+                    installed_per_op.insert(op_idx as u32, spec.handle);
+                }
             }
         }
     }
+
+    installed_per_op
+}
+
+/// **MX05 Phase 4.4.**  True iff the given handle is recorded in
+/// `INSTALLED_HANDLES`.  Used by [`drive_specialisation`] to populate
+/// the per-op installed-handle map even on cache hits where
+/// `try_auto_install_specialised` would have short-circuited and
+/// returned `false`.
+#[cfg(feature = "metal-backend")]
+fn handle_is_installed(handle: u64) -> bool {
+    let installed = match installed_handles().lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    installed.contains(&handle)
+}
+
+#[cfg(not(feature = "metal-backend"))]
+fn handle_is_installed(_handle: u64) -> bool {
+    false
 }
 
 // ─────────────────────────── Public entry point ───────────────────────────
@@ -519,7 +635,7 @@ fn dispatch_via(
     output_byte_count: usize,
     executor_name: &'static str,
 ) -> Result<Vec<u8>, GpuError> {
-    drive_specialisation(&placed);
+    let installed_per_op = drive_specialisation(&placed);
 
     let output_residency = placed
         .outputs
@@ -530,6 +646,46 @@ fn dispatch_via(
         .ok_or_else(|| {
             GpuError::Other(format!("output tensor {} not in placed graph", output_id.0))
         })?;
+
+    // **MX05 Phase 4.4.**  If this graph has exactly one non-Const
+    // Compute op and that op's specialised kernel is installed,
+    // route through `dispatch_specialised_via` — a setup `Dispatch`
+    // for the prep ops followed by a `DispatchSpecialised` for the
+    // single non-Const Compute op.  Otherwise use the existing
+    // generic `Dispatch { graph }` path.
+    //
+    // We restrict to "exactly one non-Const Compute op" for V0.8.0
+    // because multi-op routing requires interleaving setup +
+    // specialised dispatches, which is more buffer-management code
+    // than fits cleanly here.  Phase 4.5 (or later) will extend the
+    // routing to multi-op graphs.
+    if executor_name == "metal" {
+        if let Some((compute_idx, handle)) =
+            single_non_const_compute_with_handle(&placed, &installed_per_op)
+        {
+            // Returns Ok on success; on error we deliberately fall
+            // through to the generic path so the dispatch still
+            // succeeds.  Specialised routing is an optimisation, not
+            // a correctness guarantee.
+            //
+            // The counter is incremented inside
+            // `dispatch_specialised_via` itself so direct tests of
+            // that helper also see the bump.
+            if let Ok(data) = dispatch_specialised_via(
+                transport,
+                &placed,
+                compute_idx,
+                handle,
+                output_residency,
+                output_byte_count,
+            ) {
+                set_last_executor(Some(executor_name));
+                return Ok(data);
+            }
+        }
+    }
+    // Suppress unused-variable warning when not on metal-backend.
+    let _ = installed_per_op;
 
     let resp = block_on(transport.request(ExecutorRequest::Dispatch {
         job_id: 1,
@@ -580,6 +736,226 @@ fn dispatch_via(
     // `last_executor()` at whatever it was before, so callers don't
     // see a stale "we ran on metal" message after a mid-dispatch error.
     set_last_executor(Some(executor_name));
+    Ok(data)
+}
+
+/// **MX05 Phase 4.4.**  Inspect `placed.ops` and return
+/// `Some((compute_op_index, installed_handle))` iff the graph has
+/// exactly one non-Const Compute op and that op's specialised kernel
+/// is installed.  Otherwise return `None` to fall back to the generic
+/// dispatch path.
+///
+/// Restricted to single-op graphs in V0.8.0 — multi-op routing is
+/// the next phase's scope.  See `dispatch_specialised_via` for what
+/// "single-op routing" actually does at the protocol level.
+fn single_non_const_compute_with_handle(
+    placed: &ComputeGraph,
+    installed_per_op: &HashMap<u32, u64>,
+) -> Option<(usize, u64)> {
+    let mut found: Option<(usize, u64)> = None;
+    for (idx, op) in placed.ops.iter().enumerate() {
+        if let PlacedOp::Compute { op: ir_op, .. } = op {
+            if matches!(ir_op, Op::Const { .. }) {
+                continue; // Const ops are setup, not compute proper.
+            }
+            // Found a non-Const Compute op.  If we'd already found
+            // one, this is a multi-op graph — abort.
+            if found.is_some() {
+                return None;
+            }
+            let handle = installed_per_op.get(&(idx as u32)).copied()?;
+            found = Some((idx, handle));
+        }
+    }
+    found
+}
+
+/// **MX05 Phase 4.4.**  Run a graph that has exactly one non-Const
+/// Compute op through the `DispatchSpecialised` path.
+///
+/// Strategy: send a "prep dispatch" with the *original* placed graph
+/// minus the single non-Const Compute op — this lets matrix-metal's
+/// existing dispatch handler do all the buffer management
+/// (allocate, upload constants, free) under the planner-assigned
+/// BufferIds.  Then fire one `DispatchSpecialised` for the Compute
+/// op using those same planner-assigned BufferIds in `inputs` /
+/// `outputs`.  Finally download the output.
+///
+/// Why not "manage buffers in image-gpu-core ourselves": the
+/// `AllocBuffer` protocol message returns *server-assigned*
+/// BufferIds that don't match the planner-assigned IDs the placed
+/// graph references.  Going through `Dispatch { prep_graph }` lets
+/// the executor's internal allocator use planner IDs (which is its
+/// existing graph-walking pattern), keeping the BufferId space
+/// consistent across the prep + specialised + download dance.
+///
+/// The output buffer is in the placed graph's outputs at
+/// `output_residency.buffer` and survives between dispatches because
+/// the prep graph doesn't issue `Free` for it (Free ops in the
+/// placed graph all run during prep; the Compute op's output is
+/// allocated by its `Alloc` op which *is* in the prep graph).
+///
+/// Returns Err if any protocol step fails so the caller can fall
+/// back to generic dispatch.
+fn dispatch_specialised_via(
+    transport: &LocalTransport,
+    placed: &ComputeGraph,
+    compute_op_idx: usize,
+    handle: u64,
+    output_residency: compute_ir::Residency,
+    output_byte_count: usize,
+) -> Result<Vec<u8>, GpuError> {
+    // Step 1: extract the Compute op's input / output BufferIds,
+    // trimmed to the count the installed kernel actually expects.
+    //
+    // The emitter folds at least one input into the kernel source
+    // (that's the whole point of specialisation), so the installed
+    // kernel's `input_buffer_count` is strictly less than the IR
+    // op's input count.  We take the **first** `n_in` IR inputs as
+    // the buffers to pass — this matches the emitter convention
+    // that *trailing* slots are folded.  See `msl_emitter` for the
+    // current folding convention (Add: RHS folded).  Future emitter
+    // shapes that fold non-trailing slots will need to encode the
+    // mapping in the SpecKey.
+    let (n_in, _n_out) = {
+        let md = match installed_kernel_metadata().lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        md.get(&handle).copied().ok_or_else(|| {
+            GpuError::Other(format!(
+                "no kernel metadata for handle 0x{:016X} — did the install side run?",
+                handle
+            ))
+        })?
+    };
+    let (input_bufs, output_buf) = {
+        let pop = &placed.ops[compute_op_idx];
+        let PlacedOp::Compute { op: ir_op, .. } = pop else {
+            return Err(GpuError::Other("not a Compute op".to_string()));
+        };
+        let ir_inputs = ir_op.inputs();
+        if n_in > ir_inputs.len() {
+            return Err(GpuError::Other(format!(
+                "specialised kernel expects {} inputs but op has only {}",
+                n_in,
+                ir_inputs.len()
+            )));
+        }
+        let inputs: Vec<compute_ir::BufferId> = ir_inputs
+            .iter()
+            .take(n_in)
+            .map(|in_id| {
+                placed
+                    .tensor(*in_id)
+                    .map(|t| t.residency.buffer)
+                    .ok_or_else(|| {
+                        GpuError::Other(format!("tensor {} not in placed graph", in_id.0))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let out_id = ir_op.output();
+        let out_buf = placed
+            .tensor(out_id)
+            .map(|t| t.residency.buffer)
+            .ok_or_else(|| {
+                GpuError::Other(format!("output tensor {} not in placed graph", out_id.0))
+            })?;
+        (inputs, out_buf)
+    };
+
+    // Step 2: build a "prep graph" = placed without the single
+    // non-Const Compute op.  All Const + Alloc + Free + Transfer
+    // ops stay, so matrix-metal allocates buffers and uploads
+    // constants under planner-assigned IDs.
+    let prep_graph = ComputeGraph {
+        format_version: placed.format_version,
+        tensors: placed.tensors.clone(),
+        inputs: placed.inputs.clone(),
+        outputs: placed.outputs.clone(),
+        constants: placed.constants.clone(),
+        ops: placed
+            .ops
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != compute_op_idx)
+            .map(|(_, op)| op.clone())
+            .collect(),
+    };
+
+    // Step 3: fire prep Dispatch.
+    let prep_resp = block_on(transport.request(ExecutorRequest::Dispatch {
+        job_id: 100,
+        graph: prep_graph,
+    }))
+    .map_err(|e| GpuError::Other(format!("prep dispatch: {:?}", e)))?;
+    match prep_resp {
+        ExecutorResponse::DispatchDone { .. } => {}
+        ExecutorResponse::Error { code, message, .. } => {
+            return Err(GpuError::Other(format!(
+                "prep dispatch error 0x{:04X}: {}",
+                code.0, message
+            )));
+        }
+        other => {
+            return Err(GpuError::Other(format!(
+                "unexpected response to prep Dispatch: {:?}",
+                other
+            )));
+        }
+    }
+
+    // Step 4: fire DispatchSpecialised for the single Compute op.
+    let spec_resp = block_on(transport.request(ExecutorRequest::DispatchSpecialised {
+        job_id: 101,
+        handle,
+        inputs: input_bufs,
+        outputs: vec![output_buf],
+    }))
+    .map_err(|e| GpuError::Other(format!("specialised dispatch: {:?}", e)))?;
+    match spec_resp {
+        ExecutorResponse::DispatchDone { .. } => {}
+        ExecutorResponse::Error { code, message, .. } => {
+            return Err(GpuError::Other(format!(
+                "specialised dispatch error 0x{:04X}: {}",
+                code.0, message
+            )));
+        }
+        other => {
+            return Err(GpuError::Other(format!(
+                "unexpected response to DispatchSpecialised: {:?}",
+                other
+            )));
+        }
+    }
+
+    // Step 5: download the output.
+    let download = block_on(transport.request(ExecutorRequest::DownloadBuffer {
+        buffer: output_residency.buffer,
+        offset: 0,
+        len: output_byte_count as u64,
+    }))
+    .map_err(|e| GpuError::Other(format!("download: {:?}", e)))?;
+    let data = match download {
+        ExecutorResponse::BufferData { data, .. } => data,
+        ExecutorResponse::Error { code, message, .. } => {
+            return Err(GpuError::Other(format!(
+                "download error 0x{:04X}: {}",
+                code.0, message
+            )));
+        }
+        other => {
+            return Err(GpuError::Other(format!(
+                "unexpected response to DownloadBuffer: {:?}",
+                other
+            )));
+        }
+    };
+
+    // Successful specialised dispatch → bump the counter.  Atomic
+    // increment is `Relaxed` because the counter is observational.
+    SPECIALISED_DISPATCH_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
     Ok(data)
 }
 
@@ -914,6 +1290,222 @@ mod tests {
              Add-with-constant graph; before = {}, after = {}",
             before,
             after
+        );
+    }
+
+    /// **MX05 Phase 4.4 end-to-end dispatch-routing test.**  Builds a
+    /// placed graph manually pinned to metal, installs an
+    /// `Add-with-constant` specialised kernel on the metal executor,
+    /// then drives `dispatch_specialised_via` directly and asserts:
+    ///
+    /// 1. `specialised_dispatch_count` rises above zero — proves the
+    ///    `DispatchSpecialised` request actually fired and the metal
+    ///    executor returned `DispatchDone`.
+    /// 2. The downloaded output bytes match what the generic kernel
+    ///    would compute — the specialised path is functionally
+    ///    equivalent.  Inputs are `[1, 2, 3, 4]` and a folded constant
+    ///    of `7.0`, so the output must be `[8, 9, 10, 11]`.
+    ///
+    /// # Why manually-built, not planner-driven?
+    ///
+    /// The cost model in matrix-runtime currently prefers CPU over
+    /// metal for the `Op::Add(f32, f32) -> f32` shape regardless of
+    /// `N` — the per-element host→device transfer cost
+    /// (`bytes / host_to_device_bw = N*4 / 50` ns) exceeds the CPU
+    /// per-element compute cost (`N / 40` ns), and `Op::Add` is only
+    /// 1 flop/element so even very large graphs don't tip the
+    /// balance.  To drive a real planner-picks-metal scenario we'd
+    /// need either (a) a heavier op like `Op::MatMul` (Phase 4.5
+    /// emitter work), (b) more realistic profile numbers (Apple
+    /// Silicon's unified memory is closer to 200 GB/s effective
+    /// bandwidth), or (c) constants persistent across invocations
+    /// (a future protocol extension).  This test side-steps the
+    /// planner concern and verifies the *protocol-level* dispatch
+    /// routing in isolation — the planner-side decision logic is
+    /// covered by existing tests in matrix-runtime/src/planner.rs.
+    ///
+    /// Apple-only: without a real Metal device the dispatch-specialised
+    /// path can't fire.
+    #[cfg(all(feature = "metal-backend", target_vendor = "apple"))]
+    #[test]
+    fn dispatch_specialised_via_produces_correct_output() {
+        use crate::specialised_dispatch_count;
+        use compute_ir::{
+            BufferId, ComputeGraph, ExecutorId as ComputeExecutorId, OpTiming as PlanOpTiming,
+            PlacedConstant, PlacedOp, PlacedTensor, Residency, WIRE_FORMAT_VERSION,
+        };
+        use matrix_ir::{DType, Op, Shape, TensorId};
+
+        // Step 1: ensure metal is available; otherwise we'd be testing
+        // matrix-metal's non-Apple stubs which short-circuit.
+        let backend = match metal_backend() {
+            Some(b) => b,
+            None => return, // Skip on environments without Metal.
+        };
+
+        // Step 2: emit + compile + install an Add-with-constant
+        // kernel under a known handle.  Bypass the auto-installer so
+        // the test is hermetic.
+        let constant: f32 = 7.0;
+        let spec_key = matrix_runtime::SpecKey {
+            op_kind: 0x07, // Op::Add
+            dtype: DType::F32,
+            shape_class: matrix_runtime::ShapeClass::Dynamic,
+            range_class: matrix_runtime::RangeClass::Constant {
+                bytes: constant.to_le_bytes().to_vec(),
+            },
+            backend_id: 1, // metal convention
+        };
+        const TEST_HANDLE: u64 = 0xC0DE_C0DE_C0DE_C0DE;
+        let emitted = matrix_metal::emit_specialised_kernel(&spec_key, TEST_HANDLE)
+            .expect("emitter must support the canonical Add+const f32 SpecKey");
+        // Capture metadata before `emitted` is consumed by install.
+        let n_in = emitted.input_buffer_count;
+        let n_out = emitted.output_buffer_count;
+        backend
+            .executor
+            .install_specialised_from_emitted(TEST_HANDLE, emitted)
+            .expect("install must succeed on a real Metal device");
+        // Replicate what `try_auto_install_specialised` records so
+        // `dispatch_specialised_via` can find the metadata.
+        record_test_kernel_metadata(TEST_HANDLE, n_in, n_out);
+
+        // Step 3: build a placed ComputeGraph pinned to metal that:
+        //   Op::Const → tensor A (the variable operand bytes)
+        //   Op::Const → tensor B (the constant 7.0 × 4)
+        //   PlacedOp::Alloc → output buffer
+        //   Op::Add(A, B) → tensor C
+        // The B tensor / constant is what the specialised kernel
+        // folds in.  After `dispatch_specialised_via` removes the
+        // Add op, the prep-graph just allocates buffers and uploads
+        // the two constants.  Then DispatchSpecialised invokes the
+        // installed Add+7.0 kernel reading from A and writing to C.
+        let metal_exec_id = ComputeExecutorId(1);
+        let a_residency = Residency {
+            executor: metal_exec_id,
+            buffer: BufferId(10),
+        };
+        let b_residency = Residency {
+            executor: metal_exec_id,
+            buffer: BufferId(11),
+        };
+        let c_residency = Residency {
+            executor: metal_exec_id,
+            buffer: BufferId(12),
+        };
+        let a_bytes: Vec<u8> = [1.0_f32, 2.0, 3.0, 4.0]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        let b_bytes: Vec<u8> = [constant; 4]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        let f32_shape4 = Shape::from(&[4u32]);
+
+        let tensor_a = PlacedTensor {
+            id: TensorId(0),
+            dtype: DType::F32,
+            shape: f32_shape4.clone(),
+            residency: a_residency,
+        };
+        let tensor_b = PlacedTensor {
+            id: TensorId(1),
+            dtype: DType::F32,
+            shape: f32_shape4.clone(),
+            residency: b_residency,
+        };
+        let tensor_c = PlacedTensor {
+            id: TensorId(2),
+            dtype: DType::F32,
+            shape: f32_shape4.clone(),
+            residency: c_residency,
+        };
+
+        let const_a = PlacedConstant {
+            tensor: TensorId(0),
+            residency: a_residency,
+            bytes: a_bytes,
+        };
+        let const_b = PlacedConstant {
+            tensor: TensorId(1),
+            residency: b_residency,
+            bytes: b_bytes,
+        };
+
+        // Const ops materialise the constants from the table into
+        // their declared buffers.  The Add op consumes them.
+        let placed = ComputeGraph {
+            format_version: WIRE_FORMAT_VERSION,
+            inputs: vec![],
+            outputs: vec![tensor_c.clone()],
+            constants: vec![const_a, const_b],
+            ops: vec![
+                PlacedOp::Compute {
+                    op: Op::Const {
+                        constant: 0,
+                        output: TensorId(0),
+                    },
+                    executor: metal_exec_id,
+                    timing: PlanOpTiming { estimated_ns: 0 },
+                },
+                PlacedOp::Compute {
+                    op: Op::Const {
+                        constant: 1,
+                        output: TensorId(1),
+                    },
+                    executor: metal_exec_id,
+                    timing: PlanOpTiming { estimated_ns: 0 },
+                },
+                PlacedOp::Alloc {
+                    residency: c_residency,
+                    bytes: 16,
+                },
+                PlacedOp::Compute {
+                    op: Op::Add {
+                        lhs: TensorId(0),
+                        rhs: TensorId(1),
+                        output: TensorId(2),
+                    },
+                    executor: metal_exec_id,
+                    timing: PlanOpTiming { estimated_ns: 0 },
+                },
+            ],
+            tensors: vec![tensor_a, tensor_b, tensor_c.clone()],
+        };
+
+        // Step 4: call dispatch_specialised_via.  The Add op is at
+        // index 3.
+        let before = specialised_dispatch_count();
+        let bytes = dispatch_specialised_via(
+            &backend.transport,
+            &placed,
+            3, // index of the Add op in `placed.ops`
+            TEST_HANDLE,
+            c_residency,
+            16,
+        )
+        .expect("specialised dispatch must succeed");
+        let after = specialised_dispatch_count();
+
+        // Step 5: assertions.
+        assert!(
+            after > before,
+            "specialised_dispatch_count must rise after a successful \
+             DispatchSpecialised; before = {}, after = {}",
+            before,
+            after
+        );
+
+        // Expected output: A + constant = [1, 2, 3, 4] + 7.0 = [8, 9, 10, 11].
+        let result: Vec<f32> = bytes
+            .chunks(4)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect();
+        assert_eq!(
+            result,
+            vec![8.0, 9.0, 10.0, 11.0],
+            "specialised Add+7.0 kernel output must match generic Add"
         );
     }
 }

--- a/code/specs/MX05-tiered-specialisation-runtime.md
+++ b/code/specs/MX05-tiered-specialisation-runtime.md
@@ -242,6 +242,29 @@ The compile happens in a background worker thread so live dispatches
 aren't blocked.  Once ready, the specialised pipeline is inserted
 into the cache.
 
+> **Implementation status (Phase 4.4 landed — dispatch-routing half of the loop)**:
+> `image-gpu-core` v0.8.0 closes the dispatch side of the routing
+> loop.  When a placed graph has exactly one non-Const Compute op and
+> that op's specialised kernel is installed on the metal executor,
+> image-gpu-core routes the dispatch through
+> `ExecutorRequest::DispatchSpecialised` instead of the generic
+> `Dispatch { graph }` request.  Strategy: strip the single Compute
+> op from `placed.ops`, fire a prep `Dispatch` so matrix-metal's
+> existing handler allocates buffers and uploads constants under
+> planner-assigned BufferIds (sidestepping the
+> protocol-`AllocBuffer`-uses-server-IDs mismatch), then fire one
+> `DispatchSpecialised { handle, inputs, outputs }` where `inputs` is
+> `ir_op.inputs()` trimmed to the installed kernel's
+> `input_buffer_count` (so an Add-with-folded-RHS kernel only sees
+> the LHS buffer).  New public `specialised_dispatch_count()` counter
+> tracks how many invocations went through `DispatchSpecialised`.
+> Test `dispatch_specialised_via_produces_correct_output` builds an
+> `Op::Add(A=[1,2,3,4], B=[7,7,7,7])` graph manually pinned to metal,
+> installs the Add+7.0 specialised kernel directly, and verifies the
+> downloaded output is `[8, 9, 10, 11]` — the specialised kernel
+> matches the generic Add bit-for-bit.  Limited to single-Compute-op
+> graphs in V0.8.0; multi-op routing is later phase work.
+
 > **Implementation status (Phase 4.3 landed — runtime auto-installer, install half of the loop)**:
 > `image-gpu-core` v0.7.0 closes the install side of the specialised-
 > kernel loop.  `drive_specialisation` now consumes the


### PR DESCRIPTION
## Summary

Closes the **dispatch** half of the specialised-kernel routing loop. When a placed graph has exactly one non-Const Compute op and that op's specialised kernel is installed on the metal executor, image-gpu-core now routes the dispatch through \`ExecutorRequest::DispatchSpecialised\` instead of generic \`Dispatch { graph }\`.

## Protocol-level sequence

\`\`\`
runtime ─Dispatch{prep_graph}─►        metal  (allocates buffers, uploads constants)
runtime ─DispatchSpecialised{handle}─► metal.SpecialisedTable[handle]
                                        ─►  installed closure
                                        ─►  DispatchDone
runtime ─DownloadBuffer─►              metal  (output bytes)
\`\`\`

The \"prep dispatch\" sidesteps the protocol-AllocBuffer-uses-server-IDs mismatch: matrix-metal's existing handler walks placed.ops and allocates buffers under planner-assigned BufferIds, which the subsequent DispatchSpecialised references directly.

## What's new

- **\`specialised_dispatch_count() -> usize\`** — atomic process-wide counter. Distinct from \`specialised_install_count\`: cache → install → dispatch are three counters at three pipeline stages.
- **\`drive_specialisation\` now returns \`HashMap<u32, u64>\`** — \`(op_index → installed_handle)\` for every Compute op with an installed kernel.
- **\`single_non_const_compute_with_handle\`** — gate function. Returns Some iff the graph has exactly one non-Const Compute op with an installed kernel; multi-op routing is later phase work.
- **\`dispatch_specialised_via(...)\`** — the routing function. Strips the Compute op, fires prep Dispatch, fires DispatchSpecialised, downloads, bumps counter.
- **\`INSTALLED_KERNEL_METADATA\`** side-table — records \`(n_in, n_out)\` per handle so dispatch can trim \`ir_op.inputs()\` to the right count (Add-with-folded-RHS = 1 input, not 2).

## Test

\`dispatch_specialised_via_produces_correct_output\` (Apple-only): builds manually-placed \`Op::Add(A=[1,2,3,4], B=[7,7,7,7]) → C\` pinned to metal, installs the Add+7.0 kernel directly, calls \`dispatch_specialised_via\`, asserts:
1. \`specialised_dispatch_count\` rose by 1
2. Output is \`[8.0, 9.0, 10.0, 11.0]\` — matches generic Add bit-for-bit

## Why not a planner-driven end-to-end test?

The cost model in matrix-runtime prefers CPU over metal for \`Op::Add(f32)\` regardless of N — per-element transfer cost (\`4N/50\` ns) exceeds CPU compute (\`N/40\` ns), and Add is only 1 flop/element. A real planner-picks-metal scenario needs (a) a heavier op like MatMul (Phase 4.5 emitter work), (b) more realistic profile numbers, or (c) constants persistent across invocations. V0.8.0 ships the protocol-level routing in isolation; the planner-side decision is covered by existing tests.

## What this still doesn't do

- Multi-op specialised graphs — single-Compute-op only in V0.8.0
- matrix-cpu auto-install + dispatch routing — CpuSpecialiser doesn't emit closure sources yet

## Test plan

- [x] image-gpu-core: 30 tests pass (1 new)
- [x] All other affected crates: green
- [x] Linux cross-compile clean
- [x] Security review passed (1 round): n_in=0 case is safe (no unsafe code), lock-ordering is sequential (no deadlock), TOCTOU on metadata is correctness-only.
- [x] Spec MX05 updated with \"Phase 4.4 landed — dispatch-routing half\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)