### PR TITLE
Wire Rust MACSYMA transcendental solve

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Wired direct `Solve(f(linear) = constant, variable)` transcendental equations
+  to the Rust `cas-solve` `try_solve_transcendental` handler, returning
+  `List(...)` symbolic inverse and periodic-family solutions.
 - Wired `Solve(inequality, variable)` to the Rust `cas-solve`
   `try_solve_inequality` handler, returning `List(...)` interval predicates
   for supported one-variable polynomial inequalities.

--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -23,3 +23,8 @@ inequality solver. Supported one-variable polynomial inequalities return
 `List(...)` interval predicates such as `Greater(x, 1)` or
 `And(GreaterEqual(x, -1), LessEqual(x, 1))`; unsupported inequalities remain
 unevaluated.
+
+Direct `Solve(f(linear) = constant, variable)` transcendental equations delegate
+to the Rust `cas-solve` inverse-family solver. Supported `Exp`, `Log`, trig,
+and hyperbolic forms return `List(...)` symbolic inverse or periodic-family
+solutions; unsupported nested forms remain unevaluated.

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use cas_simplify::simplify;
-use cas_solve::{solve_linear_system, try_solve_inequality, SOLVE};
+use cas_solve::{solve_linear_system, try_solve_inequality, try_solve_transcendental, SOLVE};
 use cas_trig::{expand_trig, trig_simplify};
 use coding_adventures_macsyma_compiler::{
     compile_macsyma_with_options, CompileError, CompileOptions, DISPLAY as COMPILER_DISPLAY,
@@ -608,6 +608,12 @@ fn solve_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
 
     if matches!(expr.args[1], IRNode::Symbol(_)) && is_inequality(&expr.args[0]) {
         return try_solve_inequality(&expr.args[0], &expr.args[1])
+            .map(|solutions| apply(sym(LIST), solutions))
+            .unwrap_or(fallback);
+    }
+
+    if matches!(expr.args[1], IRNode::Symbol(_)) {
+        return try_solve_transcendental(&expr.args[0], &expr.args[1])
             .map(|solutions| apply(sym(LIST), solutions))
             .unwrap_or(fallback);
     }

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -4,8 +4,8 @@ use coding_adventures_macsyma_runtime::{
 };
 use std::collections::HashMap;
 use symbolic_ir::{
-    apply, int, rat, sym, ADD, AND, DIV, EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, LIST,
-    MUL, POW, RULE, SUB,
+    apply, int, rat, sym, ADD, AND, ASIN, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, LESS,
+    LESS_EQUAL, LIST, LOG, MUL, POW, RULE, SIN, SUB,
 };
 
 #[test]
@@ -409,6 +409,89 @@ fn keeps_unsupported_inequality_solve_calls_unevaluated() {
             apply(
                 sym(GREATER),
                 vec![apply(sym("Sin"), vec![x.clone()]), int(0)],
+            ),
+            x,
+        ],
+    );
+
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![expr.clone()]);
+    assert_eq!(results[0].output, expr);
+}
+
+#[test]
+fn solves_direct_transcendental_equations_through_cas_solve() {
+    let x = sym("x");
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![
+        apply(
+            sym(SOLVE),
+            vec![
+                apply(sym(EQUAL), vec![apply(sym(EXP), vec![x.clone()]), int(2)]),
+                x.clone(),
+            ],
+        ),
+        apply(
+            sym(SOLVE),
+            vec![
+                apply(sym(EQUAL), vec![apply(sym(SIN), vec![x.clone()]), int(0)]),
+                x,
+            ],
+        ),
+    ]);
+
+    assert_eq!(
+        results[0].output,
+        apply(sym(LIST), vec![apply(sym(LOG), vec![int(2)])])
+    );
+    assert_eq!(
+        results[1].output,
+        apply(
+            sym(LIST),
+            vec![
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(sym(ASIN), vec![int(0)]),
+                        apply(
+                            sym(MUL),
+                            vec![
+                                int(2),
+                                apply(sym(MUL), vec![sym("%pi"), sym("FreeInteger")])
+                            ],
+                        ),
+                    ],
+                ),
+                apply(
+                    sym(ADD),
+                    vec![
+                        apply(sym(SUB), vec![sym("%pi"), apply(sym(ASIN), vec![int(0)])]),
+                        apply(
+                            sym(MUL),
+                            vec![
+                                int(2),
+                                apply(sym(MUL), vec![sym("%pi"), sym("FreeInteger")])
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
+fn keeps_unsupported_transcendental_solve_calls_unevaluated() {
+    let x = sym("x");
+    let expr = apply(
+        sym(SOLVE),
+        vec![
+            apply(
+                sym(EQUAL),
+                vec![
+                    apply(sym(SIN), vec![apply(sym(SIN), vec![x.clone()])]),
+                    int(0),
+                ],
             ),
             x,
         ],


### PR DESCRIPTION
## Summary
- wire Rust MACSYMA `Solve(expr, var)` through `cas-solve` `try_solve_transcendental`
- return `List(...)` symbolic inverse and periodic-family solutions for direct `f(linear) = constant` equations
- preserve unevaluated fallback behavior for unsupported nested transcendental forms

## Validation
- `cargo fmt -p coding-adventures-macsyma-runtime` in `code/packages/rust`
- `cargo test -p cas-solve -p coding-adventures-macsyma-runtime -- --nocapture` in `code/packages/rust`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-macsyma-transcendental-runtime.json` from `code/programs/go/build-tool`