### PR TITLE
feat(cdc6600-simulator): Layer 07t — CDC 6600 (1964) behavioral simulator

### DIFF
--- a/code/packages/python/cdc6600-simulator/CHANGELOG.md
+++ b/code/packages/python/cdc6600-simulator/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## [0.1.0] — 2026-05-12
+
+### Added
+
+- Initial release: CDC 6600 (1964) behavioral simulator — Layer 07t
+- `CDC6600State` frozen dataclass: `p` (parcel pointer), `x[8]` (60-bit), `a[8]` (18-bit), `b[8]` (18-bit), `memory[4096]` (60-bit words)
+- `CDC6600Simulator` implementing the SIM00 `Simulator[CDC6600State]` protocol
+- **Format 1 (15-bit) instructions**: TXB, TBX, TAX, TXA, IXPB, IXMB, IXXP, IXXM, BXND, BXOR, BXXR, BXMR, LSHL, LSHR, IBBP, IBBM, IAAP, IAAM, CMPEQ, CMPLT, CMPGT, IXMUL
+- **Format 2 (30-bit) instructions**: LDXI, LDBI, LDAI, LDX, STX, LDB, STB, JEQ, JNE, JXZ, JXN, JMP, JSR, RET
+- HALT on all-zeros 15-bit parcel
+- B0 hardwired to zero (writes silently discarded)
+- Instruction packing: 4 parcels per 60-bit word (big-endian, MSB = parcel 0)
+- `short_instr(f, i, j, k)` and `long_instr(f, i, j, K)` encoding helpers
+- `HALT` constant (`b"\x00\x00"`)
+- Memory bounds checking with `ValueError` on out-of-bounds access
+- `max_steps` guard to terminate infinite loops
+
+### Design Decisions
+
+- **Two's-complement integers** used instead of one's-complement (the real CDC 6600).
+  For programs that avoid the ±0 edge case, behaviour is identical.
+- **60-bit word memory**: 4096 words instead of the real 131,072. Sufficient for
+  all test programs; easily extended by changing `MEMORY_WORDS`.
+- **B7 as link register** for JSR/RET: the real CDC 6600 had no dedicated link register;
+  this simulator uses B7 by convention (matching common CDC 6600 programming practice).
+- **No floating-point**: X registers hold 60-bit integers only; FP instructions omitted.
+- **No scoreboarding**: sequential execution only; functional units invisible to programs.
+- **No peripheral processors (PPs)**: I/O simulation omitted.

--- a/code/packages/python/cdc6600-simulator/README.md
+++ b/code/packages/python/cdc6600-simulator/README.md
@@ -1,0 +1,80 @@
+# CDC 6600 Simulator — Layer 07t
+
+Behavioral simulator for the **CDC 6600 (1964)**, the world's first supercomputer,
+designed by Seymour Cray at Control Data Corporation.
+
+## Architecture
+
+| Feature | Value |
+|---------|-------|
+| Word width | 60 bits |
+| Registers | X0–X7 (60-bit), A0–A7 (18-bit), B0–B7 (18-bit) |
+| B0 | Hardwired to 0 |
+| Memory | 4096 × 60-bit words |
+| Instruction sizes | 15-bit (short) or 30-bit (long) |
+| Packing | 4 parcels per 60-bit word |
+| HALT | All-zeros 15-bit parcel |
+
+## Usage
+
+```python
+from cdc6600_simulator import CDC6600Simulator, HALT, long_instr, short_instr
+from cdc6600_simulator.simulator import F_LDXI, F_IXXP, F_JNE, F_LDBI, F_TXB, F_IBBM
+
+sim = CDC6600Simulator()
+
+# Sum 1+2+...+10 = 55
+prog = (
+    long_instr(F_LDXI, 1, 0, 0)   +   # X1 = 0
+    long_instr(F_LDBI, 1, 0, 10)  +   # B1 = 10
+    long_instr(F_LDBI, 2, 0, 1)   +   # B2 = 1
+    short_instr(F_TXB, 3, 1, 0)   +   # X3 = B1
+    short_instr(F_IXXP, 1, 1, 3)  +   # X1 += X3
+    short_instr(F_IBBM, 1, 1, 2)  +   # B1 -= 1
+    long_instr(F_JNE, 0, 1, 6)    +   # if B1!=0: goto P=6 (loop top)
+    HALT
+)
+
+result = sim.execute(prog)
+print(result.final_state.x1)   # 55
+```
+
+## Instruction Encoding
+
+### Short (15-bit) — `short_instr(f, i, j, k)`
+```
+[14:9] f  opcode (6 bits)
+[ 8:6] i  destination register
+[ 5:3] j  left source
+[ 2:0] k  right source
+```
+
+### Long (30-bit) — `long_instr(f, i, j, K)`
+```
+First parcel  [14:9] f, [8:6] i, [5:3] j, [2:0] K[17:15]
+Second parcel [14:0] K[14:0]
+```
+
+## SIM00 Protocol
+
+Implements `Simulator[CDC6600State]`:
+
+| Method | Description |
+|--------|-------------|
+| `reset()` | Zero all state |
+| `load(program)` | Reset + pack bytes into 60-bit words |
+| `step()` → `StepTrace` | Execute one instruction |
+| `execute(program, max_steps)` → `ExecutionResult` | Run to HALT |
+| `get_state()` → `CDC6600State` | Frozen snapshot |
+
+## Series Position
+
+This is Layer 07t in the CPU simulator series:
+
+```
+07a RISC-V → 07b ARM → 07c Wasm → 07d Intel 4004 → 07e ARM1 → 07f Intel 8008
+→ 07g GE-225 → 07h IBM 704 → 07i Intel 8080 → 07j MOS 6502 → 07k Z80
+→ 07l Manchester Baby → 07m Intel 8086 → 07n Motorola 68000 → 07o PDP-11
+→ 07p Intel 8051 → 07q MIPS R2000 → 07r SPARC V8 → 07s DEC Alpha AXP
+→ [07t CDC 6600]  ← YOU ARE HERE
+```

--- a/code/packages/python/cdc6600-simulator/pyproject.toml
+++ b/code/packages/python/cdc6600-simulator/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-cdc6600-simulator"
+version = "0.1.0"
+description = "CDC 6600 (1964) behavioral simulator — Layer 07t"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "coding-adventures-simulator-protocol",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cdc6600_simulator"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=cdc6600_simulator --cov-report=term-missing --cov-fail-under=80"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+ignore = ["E501", "E701", "E702"]
+
+[tool.uv.sources]
+coding-adventures-simulator-protocol = { path = "../simulator-protocol" }

--- a/code/packages/python/cdc6600-simulator/src/cdc6600_simulator/__init__.py
+++ b/code/packages/python/cdc6600-simulator/src/cdc6600_simulator/__init__.py
@@ -1,0 +1,15 @@
+"""CDC 6600 (1964) behavioral simulator — Layer 07t."""
+
+from .simulator import HALT, CDC6600Simulator, long_instr, short_instr
+from .state import MASK18, MASK60, CDC6600State, make_initial_state
+
+__all__ = [
+    "CDC6600Simulator",
+    "CDC6600State",
+    "HALT",
+    "MASK18",
+    "MASK60",
+    "long_instr",
+    "make_initial_state",
+    "short_instr",
+]

--- a/code/packages/python/cdc6600-simulator/src/cdc6600_simulator/simulator.py
+++ b/code/packages/python/cdc6600-simulator/src/cdc6600_simulator/simulator.py
@@ -1,0 +1,704 @@
+"""
+CDC 6600 (1964) Behavioral Simulator
+======================================
+
+The CDC 6600 was the world's first supercomputer — designed by Seymour Cray at
+Control Data Corporation.  This module implements a behavioral simulation of its
+Central Processor (CP) instruction set.
+
+Architecture at a glance
+------------------------
+
+  Word width:   60 bits (unusual; Cray picked 60 to maximise FP precision in
+                discrete logic without needing a full 64-bit datapath in 1964)
+
+  Registers:
+    X0–X7   60-bit "operand" registers  (integer and float data)
+    A0–A7   18-bit "address" registers  (memory addresses, up to 262,143 words)
+    B0–B7   18-bit "index" registers    (loop counters; B0 hardwired to 0)
+
+  Program counter:
+    P       "parcel pointer" — word_index × 4 + parcel_index (0–3).
+            Instructions are packed four 15-bit parcels per 60-bit word.
+
+  Instruction sizes:
+    Short   15 bits  (one parcel)  — register-to-register ops
+    Long    30 bits  (two parcels) — load-immediate, memory, branches
+
+  Memory:   4 096 sixty-bit words (behavioural subset of 131 072)
+
+Instruction encoding
+---------------------
+
+Short (15-bit):
+  [14:9]  f   opcode (6 bits)
+  [ 8:6]  i   destination register index (3 bits)
+  [ 5:3]  j   left-source register index (3 bits)
+  [ 2:0]  k   right-source register index (3 bits)
+
+Long (30-bit) — occupies two consecutive parcels:
+  [29:24]  f   opcode (6 bits)
+  [23:21]  i   destination register index (3 bits)
+  [20:18]  j   source register index / condition register (3 bits)
+  [17: 0]  K   18-bit constant (address, immediate, or branch target)
+
+HALT: a 15-bit all-zeros parcel (0x0000) halts the simulator.
+
+Signed arithmetic
+-----------------
+The real CDC 6600 used one's-complement.  This simulator uses Python ints
+(two's-complement) masked to 60 bits, interpreting bit 59 as the sign bit for
+comparison instructions.  Programs that avoid the ±0 corner case behave
+identically to one's-complement hardware.
+"""
+
+from __future__ import annotations
+
+from simulator_protocol import (
+    ExecutionResult,
+    Simulator,
+    StepTrace,
+)
+
+from .state import (
+    MASK18,
+    MASK60,
+    MEMORY_WORDS,
+    CDC6600State,
+    make_initial_state,
+    sext60,
+)
+
+# ── Opcode constants ────────────────────────────────────────────────────────────
+#
+# Short (15-bit) opcodes — f field values for Format 1 instructions.
+
+F_TXB   = 1    # Xi = zero_extend60(Bj)
+F_TBX   = 2    # Bi = Xj[17:0]
+F_TAX   = 3    # Xi = zero_extend60(Aj)
+F_TXA   = 4    # Ai = Xj[17:0]
+F_IXPB  = 5    # Xi = Xj + Bk  (integer add X+B)
+F_IXMB  = 6    # Xi = Xj - Bk  (integer subtract X-B)
+F_IXXP  = 7    # Xi = Xj + Xk  (integer add X+X)
+F_IXXM  = 8    # Xi = Xj - Xk  (integer subtract X-X)
+F_BXND  = 9    # Xi = Xj & Xk  (boolean AND)
+F_BXOR  = 10   # Xi = Xj | Xk  (boolean OR)
+F_BXXR  = 11   # Xi = Xj ^ Xk  (boolean XOR)
+F_BXMR  = 12   # Xi = ~Xj      (boolean complement; k ignored)
+F_LSHL  = 13   # Xi = Xj << (Bk & 63)
+F_LSHR  = 14   # Xi = Xj >> (Bk & 63)
+F_IBBP  = 15   # Bi = Bj + Bk  (B-register add)
+F_IBBM  = 16   # Bi = Bj - Bk  (B-register subtract)
+F_IAAP  = 17   # Ai = Aj + Bk  (A-register add)
+F_IAAM  = 18   # Ai = Aj - Bk  (A-register subtract)
+F_CMPEQ = 19   # Bi = 1 if Xj == Xk else 0
+F_CMPLT = 20   # Bi = 1 if signed(Xj) < signed(Xk) else 0
+F_CMPGT = 21   # Bi = 1 if signed(Xj) > signed(Xk) else 0
+F_IXMUL = 22   # Xi = (Xj * Xk)[59:0]
+
+# Long (30-bit) opcodes — f field values for Format 2 instructions.
+
+F_LDXI  = 32   # Xi = K  (load 18-bit zero-extended constant)
+F_LDBI  = 33   # Bi = K
+F_LDAI  = 34   # Ai = K
+F_LDX   = 35   # Xi = mem[Aj + K]
+F_STX   = 36   # mem[Ai + K] = Xj
+F_LDB   = 37   # Bi = mem[Aj + K][17:0]
+F_STB   = 38   # mem[Ai + K][17:0] = Bj  (zero rest of word)
+F_JEQ   = 40   # if Bj == 0: P = K
+F_JNE   = 41   # if Bj != 0: P = K
+F_JXZ   = 42   # if Xj == 0: P = K
+F_JXN   = 43   # if Xj != 0: P = K
+F_JMP   = 44   # P = K  (unconditional branch)
+F_JSR   = 45   # B7 = P+2; P = K
+F_RET   = 46   # P = Bj
+
+
+class CDC6600Simulator(Simulator[CDC6600State]):
+    """
+    Behavioral simulator for the CDC 6600 Central Processor (1964).
+
+    Usage
+    -----
+    >>> sim = CDC6600Simulator()
+    >>> # Encode: LDXI X1, 42  then HALT
+    >>> prog = long_instr(F_LDXI, 1, 0, 42) + HALT
+    >>> result = sim.execute(prog)
+    >>> result.final_state.x1
+    42
+    """
+
+    def __init__(self) -> None:
+        self._state: CDC6600State = make_initial_state()
+
+    # ── SIM00 Protocol ─────────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Zero all registers and memory; set P=0; clear halted flag."""
+        self._state = make_initial_state()
+
+    def load(self, program: bytes) -> None:
+        """
+        Reset, then pack *program* bytes into 60-bit memory words.
+
+        Each pair of bytes encodes one 15-bit parcel (big-endian, high-nibble
+        used, low bit of second byte always 0):
+
+            parcel_value = int.from_bytes(two_bytes, "big") >> 1
+
+        Wait — actually parcels ARE 15-bit but we store them packed into 60-bit
+        words with no padding bits.  The encoding is:
+
+            bytes[0:2]  → parcel 0 of word 0 (bits [59:45])
+            bytes[2:4]  → parcel 1 of word 0 (bits [44:30])
+            bytes[4:6]  → parcel 2 of word 0 (bits [29:15])
+            bytes[6:8]  → parcel 3 of word 0 (bits [14: 0])
+            bytes[8:10] → parcel 0 of word 1  …
+
+        Each 2-byte chunk encodes one 15-bit parcel as a big-endian unsigned
+        integer (the low bit of each 2-byte chunk is unused / zero).  We mask
+        to 15 bits and shift into position.
+
+        For 30-bit long instructions the caller emits 4 bytes (two parcels of
+        15 bits each) by calling ``long_instr()``.
+
+        The program is padded with zero bytes to fill the last word.
+        """
+        self.reset()
+
+        # Pad to a multiple of 8 bytes (4 parcels × 2 bytes = one 60-bit word)
+        if len(program) % 8:
+            program = program + b"\x00" * (8 - len(program) % 8)
+
+        mem = list(self._state.memory)
+        word_idx = 0
+        for offset in range(0, len(program), 8):
+            if word_idx >= MEMORY_WORDS:
+                break
+            word = 0
+            for parcel in range(4):
+                chunk = program[offset + parcel * 2 : offset + parcel * 2 + 2]
+                p_val = int.from_bytes(chunk, "big") & 0x7FFF   # 15 bits
+                word = (word << 15) | p_val
+            mem[word_idx] = word
+            word_idx += 1
+
+        self._state = CDC6600State(
+            p=0,
+            x=self._state.x,
+            a=self._state.a,
+            b=self._state.b,
+            memory=tuple(mem),
+            halted=False,
+        )
+
+    def step(self) -> StepTrace:
+        """
+        Fetch and execute one instruction (15- or 30-bit parcel), advance P.
+
+        Returns a StepTrace describing what happened.
+        """
+        state = self._state
+        p_before = state.p
+
+        if state.halted:
+            self._state = CDC6600State(
+                p=state.p, x=state.x, a=state.a, b=state.b,
+                memory=state.memory, halted=True,
+            )
+            return StepTrace(
+                pc_before=p_before,
+                pc_after=p_before,
+                mnemonic="HALT",
+                description="HALT (already halted)",
+            )
+
+        try:
+            mnemonic, p_after = self._fetch_and_execute()
+            description = f"{mnemonic} @ parcel 0x{p_before:04X}"
+            return StepTrace(
+                pc_before=p_before,
+                pc_after=p_after,
+                mnemonic=mnemonic,
+                description=description,
+            )
+        except Exception as exc:
+            err_msg = f"ERROR: {exc}"
+            return StepTrace(
+                pc_before=p_before,
+                pc_after=p_before,
+                mnemonic=err_msg,
+                description=err_msg,
+            )
+
+    def execute(
+        self, program: bytes, max_steps: int = 100_000
+    ) -> ExecutionResult:
+        """
+        Load *program*, run until halted or *max_steps* reached.
+
+        Returns an :class:`ExecutionResult` with the final state and all
+        :class:`StepTrace` records.
+        """
+        self.load(program)
+        traces: list[StepTrace] = []
+        error: str | None = None
+
+        for _ in range(max_steps):
+            if self._state.halted:
+                break
+            trace = self.step()
+            traces.append(trace)
+            if self._state.halted:
+                break
+            if trace.mnemonic.startswith("ERROR:"):
+                error = trace.mnemonic
+                break
+        else:
+            error = f"max_steps ({max_steps}) exceeded"
+
+        return ExecutionResult(
+            halted=self._state.halted,
+            steps=len(traces),
+            final_state=self._state,
+            error=error,
+            traces=traces,
+        )
+
+    def get_state(self) -> CDC6600State:
+        """Return a frozen snapshot of the current simulator state."""
+        return self._state
+
+    # ── Internal helpers ───────────────────────────────────────────────────────
+
+    def _read_parcel(self, p: int) -> int:
+        """
+        Read one 15-bit parcel from parcel address *p*.
+
+        Parcel addresses:  word = p // 4,  parcel_in_word = p % 4.
+        The four parcels in a 60-bit word are stored most-significant first:
+
+            parcel 0 → bits [59:45] (shift right by 45)
+            parcel 1 → bits [44:30] (shift right by 30)
+            parcel 2 → bits [29:15] (shift right by 15)
+            parcel 3 → bits [14: 0] (shift right by  0)
+        """
+        word_idx = p // 4
+        parcel_in_word = p % 4
+        if word_idx >= MEMORY_WORDS:
+            return 0
+        word = self._state.memory[word_idx]
+        shift = (3 - parcel_in_word) * 15
+        return (word >> shift) & 0x7FFF
+
+    def _write_parcel(self, p: int, value: int) -> None:
+        """Write one 15-bit parcel to parcel address *p* (used during load)."""
+        word_idx = p // 4
+        parcel_in_word = p % 4
+        if word_idx >= MEMORY_WORDS:
+            return
+        mem = list(self._state.memory)
+        shift = (3 - parcel_in_word) * 15
+        mask = 0x7FFF << shift
+        mem[word_idx] = (mem[word_idx] & ~mask) | ((value & 0x7FFF) << shift)
+        self._state = CDC6600State(
+            p=self._state.p,
+            x=self._state.x,
+            a=self._state.a,
+            b=self._state.b,
+            memory=tuple(mem),
+            halted=self._state.halted,
+        )
+
+    def _fetch_and_execute(self) -> tuple[str, int]:
+        """
+        Fetch one instruction starting at the current parcel address P,
+        execute it, update the state, and return (mnemonic, new_P).
+
+        All register and memory updates are applied atomically by building
+        new tuples and replacing ``self._state``.
+        """
+        state = self._state
+        p = state.p
+
+        # ── Fetch first parcel ───────────────────────────────────────────────
+        p0 = self._read_parcel(p)
+
+        # HALT: all-zeros parcel
+        if p0 == 0:
+            self._state = CDC6600State(
+                p=p, x=state.x, a=state.a, b=state.b,
+                memory=state.memory, halted=True,
+            )
+            return "HALT", p
+
+        f = (p0 >> 9) & 0x3F    # opcode (bits [14:9])
+        i = (p0 >> 6) & 0x07    # destination register (bits [8:6])
+        j = (p0 >> 3) & 0x07    # left source register  (bits [5:3])
+        k = (p0 >> 0) & 0x07    # right source register (bits [2:0])
+
+        # ── Determine instruction length ─────────────────────────────────────
+        # Long instructions (Format 2) use opcodes 32–63 (≥ 32 = bit 5 set).
+        if f >= 32:
+            # Fetch second parcel for the 18-bit K field
+            p1 = self._read_parcel(p + 1)
+            # K is built from the low 3 bits of j-field in p0 and all of p1:
+            # Actually: the long format packs the full K across both parcels.
+            # p0 already contains f(6), i(3), j(3), and the upper 3 bits of K.
+            # Let's re-decode properly:
+            #   p0[14:9] = f (6 bits)
+            #   p0[8:6]  = i (3 bits)
+            #   p0[5:3]  = j (3 bits)  — repurposed as source/condition reg
+            #   p0[2:0]  = K[17:15]    (upper 3 bits of K)
+            # p1[14:0]   = K[14:0]     (lower 15 bits of K)
+            K_high = k & 0x7               # 3 bits from low of first parcel
+            K_low  = p1 & 0x7FFF           # 15 bits from second parcel
+            K      = (K_high << 15) | K_low
+            new_p  = p + 2
+            return self._exec_long(f, i, j, K, new_p)
+        else:
+            new_p = p + 1
+            return self._exec_short(f, i, j, k, new_p)
+
+    def _exec_short(
+        self, f: int, i: int, j: int, k: int, new_p: int
+    ) -> tuple[str, int]:
+        """Execute a 15-bit (Format 1) instruction."""
+        state = self._state
+
+        # Working copies of register banks as lists for mutation
+        x = list(state.x)
+        a = list(state.a)
+        b = list(state.b)
+
+        Xj = state.x[j]
+        Xk = state.x[k]
+        Aj = state.a[j]
+        Bj = state.b[j]
+        Bk = state.b[k]
+
+        mnemonic = "?"
+
+        if f == F_TXB:
+            # Xi = zero_extend60(Bj) — transmit B register to X register
+            x[i] = Bj & MASK60
+            mnemonic = f"TXB X{i},B{j}"
+
+        elif f == F_TBX:
+            # Bi = Xj[17:0] — transmit lower 18 bits of X to B register
+            if i != 0:
+                b[i] = Xj & MASK18
+            mnemonic = f"TBX B{i},X{j}"
+
+        elif f == F_TAX:
+            # Xi = zero_extend60(Aj) — transmit A register to X register
+            x[i] = Aj & MASK60
+            mnemonic = f"TAX X{i},A{j}"
+
+        elif f == F_TXA:
+            # Ai = Xj[17:0] — transmit lower 18 bits of X to A register
+            a[i] = Xj & MASK18
+            mnemonic = f"TXA A{i},X{j}"
+
+        elif f == F_IXPB:
+            # Xi = Xj + Bk (integer; Bk zero-extended to 60 bits)
+            x[i] = (Xj + (Bk & MASK18)) & MASK60
+            mnemonic = f"IXPB X{i},X{j},B{k}"
+
+        elif f == F_IXMB:
+            # Xi = Xj - Bk
+            x[i] = (Xj - (Bk & MASK18)) & MASK60
+            mnemonic = f"IXMB X{i},X{j},B{k}"
+
+        elif f == F_IXXP:
+            # Xi = Xj + Xk (60-bit integer add)
+            x[i] = (Xj + Xk) & MASK60
+            mnemonic = f"IXXP X{i},X{j},X{k}"
+
+        elif f == F_IXXM:
+            # Xi = Xj - Xk (60-bit integer subtract)
+            x[i] = (Xj - Xk) & MASK60
+            mnemonic = f"IXXM X{i},X{j},X{k}"
+
+        elif f == F_BXND:
+            # Xi = Xj & Xk (boolean AND)
+            x[i] = (Xj & Xk) & MASK60
+            mnemonic = f"BXND X{i},X{j},X{k}"
+
+        elif f == F_BXOR:
+            # Xi = Xj | Xk (boolean OR)
+            x[i] = (Xj | Xk) & MASK60
+            mnemonic = f"BXOR X{i},X{j},X{k}"
+
+        elif f == F_BXXR:
+            # Xi = Xj ^ Xk (boolean XOR, "exclusive or")
+            x[i] = (Xj ^ Xk) & MASK60
+            mnemonic = f"BXXR X{i},X{j},X{k}"
+
+        elif f == F_BXMR:
+            # Xi = ~Xj (boolean complement; k ignored)
+            x[i] = (~Xj) & MASK60
+            mnemonic = f"BXMR X{i},X{j}"
+
+        elif f == F_LSHL:
+            # Xi = Xj << (Bk & 63) logical left shift
+            shift = Bk & 63
+            x[i] = (Xj << shift) & MASK60
+            mnemonic = f"LSHL X{i},X{j},B{k}"
+
+        elif f == F_LSHR:
+            # Xi = Xj >> (Bk & 63) logical right shift (zero-fill)
+            shift = Bk & 63
+            x[i] = (Xj & MASK60) >> shift   # guaranteed non-negative (& MASK60)
+            mnemonic = f"LSHR X{i},X{j},B{k}"
+
+        elif f == F_IBBP:
+            # Bi = Bj + Bk (18-bit integer add; B0 protected)
+            if i != 0:
+                b[i] = (Bj + Bk) & MASK18
+            mnemonic = f"IBBP B{i},B{j},B{k}"
+
+        elif f == F_IBBM:
+            # Bi = Bj - Bk (18-bit integer subtract; B0 protected)
+            if i != 0:
+                b[i] = (Bj - Bk) & MASK18
+            mnemonic = f"IBBM B{i},B{j},B{k}"
+
+        elif f == F_IAAP:
+            # Ai = Aj + Bk (18-bit address add)
+            a[i] = (Aj + Bk) & MASK18
+            mnemonic = f"IAAP A{i},A{j},B{k}"
+
+        elif f == F_IAAM:
+            # Ai = Aj - Bk (18-bit address subtract)
+            a[i] = (Aj - Bk) & MASK18
+            mnemonic = f"IAAM A{i},A{j},B{k}"
+
+        elif f == F_CMPEQ:
+            # Bi = 1 if Xj == Xk else 0 (compare into B register)
+            if i != 0:
+                b[i] = 1 if Xj == Xk else 0
+            mnemonic = f"CMPEQ B{i},X{j},X{k}"
+
+        elif f == F_CMPLT:
+            # Bi = 1 if signed(Xj) < signed(Xk) else 0
+            sj = sext60(Xj)
+            sk = sext60(Xk)
+            if i != 0:
+                b[i] = 1 if sj < sk else 0
+            mnemonic = f"CMPLT B{i},X{j},X{k}"
+
+        elif f == F_CMPGT:
+            # Bi = 1 if signed(Xj) > signed(Xk) else 0
+            sj = sext60(Xj)
+            sk = sext60(Xk)
+            if i != 0:
+                b[i] = 1 if sj > sk else 0
+            mnemonic = f"CMPGT B{i},X{j},X{k}"
+
+        elif f == F_IXMUL:
+            # Xi = (Xj * Xk)[59:0] — lower 60 bits of 60-bit integer multiply
+            x[i] = (Xj * Xk) & MASK60
+            mnemonic = f"IXMUL X{i},X{j},X{k}"
+
+        else:
+            raise ValueError(
+                f"Unknown short opcode f={f} (octal {f:o}) at parcel 0x{state.p:04X}"
+            )
+
+        # B0 must always read as 0 (enforce invariant)
+        b[0] = 0
+
+        self._state = CDC6600State(
+            p=new_p,
+            x=tuple(x),
+            a=tuple(a),
+            b=tuple(b),
+            memory=state.memory,
+            halted=False,
+        )
+        return mnemonic, new_p
+
+    def _exec_long(
+        self, f: int, i: int, j: int, K: int, new_p: int
+    ) -> tuple[str, int]:
+        """Execute a 30-bit (Format 2) instruction."""
+        state = self._state
+        x = list(state.x)
+        a = list(state.a)
+        b = list(state.b)
+        mem = list(state.memory)
+
+        halted = False
+        branched = False
+        branch_target = 0
+        mnemonic = "?"
+
+        if f == F_LDXI:
+            # Xi = K (18-bit zero-extended constant into 60-bit X register)
+            x[i] = K & MASK18
+            mnemonic = f"LDXI X{i},{K}"
+
+        elif f == F_LDBI:
+            # Bi = K (18-bit constant into B register; B0 protected)
+            if i != 0:
+                b[i] = K & MASK18
+            mnemonic = f"LDBI B{i},{K}"
+
+        elif f == F_LDAI:
+            # Ai = K (18-bit constant into A register)
+            a[i] = K & MASK18
+            mnemonic = f"LDAI A{i},{K}"
+
+        elif f == F_LDX:
+            # Xi = mem[Aj + K] — load 60-bit word from memory into Xi
+            addr = (state.a[j] + K) & MASK18
+            if addr >= MEMORY_WORDS:
+                raise ValueError(
+                    f"LDX: memory address {addr} out of bounds (max {MEMORY_WORDS - 1})"
+                )
+            x[i] = state.memory[addr] & MASK60
+            mnemonic = f"LDX X{i},A{j}+{K}"
+
+        elif f == F_STX:
+            # mem[Ai + K] = Xj — store Xj to memory
+            addr = (state.a[i] + K) & MASK18
+            if addr >= MEMORY_WORDS:
+                raise ValueError(
+                    f"STX: memory address {addr} out of bounds (max {MEMORY_WORDS - 1})"
+                )
+            mem[addr] = state.x[j] & MASK60
+            mnemonic = f"STX A{i}+{K},X{j}"
+
+        elif f == F_LDB:
+            # Bi = mem[Aj + K][17:0] — load lower 18 bits of a word into Bi
+            addr = (state.a[j] + K) & MASK18
+            if addr >= MEMORY_WORDS:
+                raise ValueError(
+                    f"LDB: memory address {addr} out of bounds (max {MEMORY_WORDS - 1})"
+                )
+            if i != 0:
+                b[i] = state.memory[addr] & MASK18
+            mnemonic = f"LDB B{i},A{j}+{K}"
+
+        elif f == F_STB:
+            # mem[Ai + K][17:0] = Bj — store Bj into lower 18 bits of word
+            addr = (state.a[i] + K) & MASK18
+            if addr >= MEMORY_WORDS:
+                raise ValueError(
+                    f"STB: memory address {addr} out of bounds (max {MEMORY_WORDS - 1})"
+                )
+            mem[addr] = state.b[j] & MASK18
+            mnemonic = f"STB A{i}+{K},B{j}"
+
+        elif f == F_JEQ:
+            # if Bj == 0: P = K  (branch if B register equals zero)
+            mnemonic = f"JEQ B{j}==0,{K}"
+            if state.b[j] == 0:
+                branched = True
+                branch_target = K
+
+        elif f == F_JNE:
+            # if Bj != 0: P = K  (branch if B register non-zero)
+            mnemonic = f"JNE B{j}!=0,{K}"
+            if state.b[j] != 0:
+                branched = True
+                branch_target = K
+
+        elif f == F_JXZ:
+            # if Xj == 0: P = K  (branch if X register equals zero)
+            mnemonic = f"JXZ X{j}==0,{K}"
+            if state.x[j] == 0:
+                branched = True
+                branch_target = K
+
+        elif f == F_JXN:
+            # if Xj != 0: P = K  (branch if X register non-zero)
+            mnemonic = f"JXN X{j}!=0,{K}"
+            if state.x[j] != 0:
+                branched = True
+                branch_target = K
+
+        elif f == F_JMP:
+            # P = K  (unconditional branch; i and j fields ignored)
+            mnemonic = f"JMP {K}"
+            branched = True
+            branch_target = K
+
+        elif f == F_JSR:
+            # B7 = P+2 (return address); P = K  (call subroutine)
+            b[7] = new_p & MASK18   # new_p is already P+2 from fetch
+            mnemonic = f"JSR B7={new_p},P={K}"
+            branched = True
+            branch_target = K
+
+        elif f == F_RET:
+            # P = Bj  (return: jump to parcel address stored in Bj)
+            mnemonic = f"RET P=B{j}"
+            branched = True
+            branch_target = state.b[j] & MASK18
+
+        else:
+            raise ValueError(
+                f"Unknown long opcode f={f} (octal {f:o}) at parcel 0x{state.p:04X}"
+            )
+
+        # B0 must always stay zero
+        b[0] = 0
+
+        final_p = branch_target if branched else new_p
+
+        self._state = CDC6600State(
+            p=final_p,
+            x=tuple(x),
+            a=tuple(a),
+            b=tuple(b),
+            memory=tuple(mem),
+            halted=halted,
+        )
+        return mnemonic, final_p
+
+
+# ── Encoding helpers (exported for use in tests and programs) ──────────────────
+
+
+def short_instr(f: int, i: int, j: int, k: int) -> bytes:
+    """
+    Encode a 15-bit CDC 6600 short instruction into 2 bytes (big-endian).
+
+    The 15-bit value is stored right-aligned in the 16-bit big-endian integer,
+    i.e. the high bit of the first byte is always 0.
+
+        Bit layout in two bytes:
+          byte 0: [0][f5][f4][f3][f2][f1][f0][i2]
+          byte 1: [i1][i0][j2][j1][j0][k2][k1][k0]
+
+    Example:
+        short_instr(F_IXXP, 1, 2, 3)  →  b'\\x0e\\x13'
+        f=7, i=1, j=2, k=3
+        = 0b000_0111_001_010_011 = 0x0393 … wait that's 15 bits:
+        bits: 000111 001 010 011 → 0x1CB = 459
+    """
+    v = ((f & 0x3F) << 9) | ((i & 0x7) << 6) | ((j & 0x7) << 3) | (k & 0x7)
+    return v.to_bytes(2, "big")
+
+
+def long_instr(f: int, i: int, j: int, K: int) -> bytes:
+    """
+    Encode a 30-bit CDC 6600 long instruction into 4 bytes (big-endian).
+
+    The 30-bit value is split across two consecutive 15-bit parcels:
+      first parcel  (bits [29:15]): f(6), i(3), j(3), K[17:15](3)
+      second parcel (bits [14: 0]): K[14:0](15)
+
+    Each parcel is stored right-aligned in a 16-bit big-endian value.
+    """
+    K = K & 0x3FFFF   # clamp to 18 bits
+    K_high = (K >> 15) & 0x7     # top 3 bits of K
+    K_low  = K & 0x7FFF          # bottom 15 bits of K
+    first  = ((f & 0x3F) << 9) | ((i & 0x7) << 6) | ((j & 0x7) << 3) | K_high
+    second = K_low
+    return first.to_bytes(2, "big") + second.to_bytes(2, "big")
+
+
+HALT: bytes = b"\x00\x00"   # 15-bit all-zeros parcel — stops the simulator

--- a/code/packages/python/cdc6600-simulator/src/cdc6600_simulator/state.py
+++ b/code/packages/python/cdc6600-simulator/src/cdc6600_simulator/state.py
@@ -1,0 +1,158 @@
+"""
+CDC 6600 (1964) State Dataclass
+================================
+
+The CDC 6600 has three distinct register types — a forward-looking design
+that anticipated the "load/store ISA" philosophy decades before RISC:
+
+  X0–X7   60-bit operand registers   (floating-point / integer data)
+  A0–A7   18-bit address registers   (memory addresses)
+  B0–B7   18-bit index registers     (loop counters / increments, B0 == 0)
+
+Memory is an array of 60-bit words; all arithmetic fits in Python's
+arbitrary-precision integers, masked to the appropriate width.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Bit-width constants ────────────────────────────────────────────────────────
+
+MASK60: int = (1 << 60) - 1   # 60-bit unsigned mask: 0xFFF_FFFF_FFFF_FFFF
+MASK18: int = (1 << 18) - 1   # 18-bit unsigned mask: 0x3_FFFF
+SIGN60: int = 1 << 59          # sign bit of a 60-bit quantity
+SIGN18: int = 1 << 17          # sign bit of an 18-bit quantity
+
+MEMORY_WORDS: int = 4096       # 4 096 × 60-bit words (4 096 × 60 bits = ~30 KB)
+NREGS: int = 8                 # 8 registers in each bank (X, A, B)
+
+
+def sext60(v: int) -> int:
+    """Sign-extend a 60-bit masked value to a Python signed int."""
+    v = v & MASK60
+    if v & SIGN60:
+        return v - (1 << 60)
+    return v
+
+
+def sext18(v: int) -> int:
+    """Sign-extend an 18-bit masked value to a Python signed int."""
+    v = v & MASK18
+    if v & SIGN18:
+        return v - (1 << 18)
+    return v
+
+
+# ── Immutable state snapshot ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CDC6600State:
+    """
+    Complete, immutable snapshot of the CDC 6600 simulator at one moment in time.
+
+    Fields
+    ------
+    p       Parcel address — word_index × 4 + parcel_index (0–3).
+            Analogous to the Program Counter on other architectures.
+    x       Eight 60-bit operand registers X0–X7.
+    a       Eight 18-bit address registers A0–A7.
+    b       Eight 18-bit index/increment registers B0–B7.
+            B0 is always 0; attempts to write it are silently discarded.
+    memory  4096 sixty-bit words stored as a tuple of Python ints.
+    halted  True once a HALT (zero parcel) has been executed.
+    """
+
+    p: int                    # parcel address
+    x: tuple[int, ...]        # 8 × 60-bit
+    a: tuple[int, ...]        # 8 × 18-bit
+    b: tuple[int, ...]        # 8 × 18-bit (b[0] always 0)
+    memory: tuple[int, ...]   # 4096 × 60-bit words
+    halted: bool
+
+    # ── Convenience properties for individual registers ────────────────────────
+
+    @property
+    def x0(self) -> int: return self.x[0]
+
+    @property
+    def x1(self) -> int: return self.x[1]
+
+    @property
+    def x2(self) -> int: return self.x[2]
+
+    @property
+    def x3(self) -> int: return self.x[3]
+
+    @property
+    def x4(self) -> int: return self.x[4]
+
+    @property
+    def x5(self) -> int: return self.x[5]
+
+    @property
+    def x6(self) -> int: return self.x[6]
+
+    @property
+    def x7(self) -> int: return self.x[7]
+
+    @property
+    def a0(self) -> int: return self.a[0]
+
+    @property
+    def a1(self) -> int: return self.a[1]
+
+    @property
+    def a2(self) -> int: return self.a[2]
+
+    @property
+    def a3(self) -> int: return self.a[3]
+
+    @property
+    def a4(self) -> int: return self.a[4]
+
+    @property
+    def a5(self) -> int: return self.a[5]
+
+    @property
+    def a6(self) -> int: return self.a[6]
+
+    @property
+    def a7(self) -> int: return self.a[7]
+
+    @property
+    def b0(self) -> int: return 0  # always zero
+
+    @property
+    def b1(self) -> int: return self.b[1]
+
+    @property
+    def b2(self) -> int: return self.b[2]
+
+    @property
+    def b3(self) -> int: return self.b[3]
+
+    @property
+    def b4(self) -> int: return self.b[4]
+
+    @property
+    def b5(self) -> int: return self.b[5]
+
+    @property
+    def b6(self) -> int: return self.b[6]
+
+    @property
+    def b7(self) -> int: return self.b[7]
+
+
+def make_initial_state() -> CDC6600State:
+    """Return the power-on / reset state: all registers and memory zeroed, P=0."""
+    return CDC6600State(
+        p=0,
+        x=tuple(0 for _ in range(NREGS)),
+        a=tuple(0 for _ in range(NREGS)),
+        b=tuple(0 for _ in range(NREGS)),
+        memory=tuple(0 for _ in range(MEMORY_WORDS)),
+        halted=False,
+    )

--- a/code/packages/python/cdc6600-simulator/tests/test_coverage.py
+++ b/code/packages/python/cdc6600-simulator/tests/test_coverage.py
@@ -1,0 +1,245 @@
+"""Edge-case and coverage tests for the CDC 6600 simulator."""
+
+import pytest
+
+from cdc6600_simulator import HALT, CDC6600Simulator, long_instr, short_instr
+from cdc6600_simulator.simulator import (
+    F_IBBP,
+    F_IXXP,
+    F_JMP,
+    F_LDBI,
+    F_LDXI,
+    F_STX,
+    F_TBX,
+)
+from cdc6600_simulator.state import MASK18, MASK60, MEMORY_WORDS
+
+
+def preset(sim, *, x=None, a=None, b=None):
+    s = sim.get_state()
+    nx = list(s.x)
+    na = list(s.a)
+    nb = list(s.b)
+    if x:
+        for idx, val in x.items():
+            nx[idx] = val & MASK60
+    if a:
+        for idx, val in a.items():
+            na[idx] = val & MASK18
+    if b:
+        for idx, val in b.items():
+            if idx != 0:
+                nb[idx] = val & MASK18
+    from cdc6600_simulator.state import CDC6600State
+    sim._state = CDC6600State(
+        p=s.p, x=tuple(nx), a=tuple(na), b=tuple(nb),
+        memory=s.memory, halted=s.halted,
+    )
+
+
+# ── B0 hardwired zero ─────────────────────────────────────────────────────────
+
+def test_b0_reads_as_zero():
+    # LDBI B0, 99 should not change B0
+    s_after = CDC6600Simulator().execute(
+        long_instr(F_LDBI, 0, 0, 99) + HALT
+    ).final_state
+    assert s_after.b0 == 0
+
+
+def test_ibbp_into_b0_ignored():
+    # IBBP B0, B1, B2 — write to B0 should be silently discarded
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IBBP, 0, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, b={1: 10, 2: 5})
+    result = sim.execute(prog)
+    assert result.final_state.b0 == 0
+
+
+def test_tbx_into_b0_ignored():
+    # TBX B0, X1 — write to B0 should be silently discarded
+    sim = CDC6600Simulator()
+    prog = short_instr(F_TBX, 0, 1, 0) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 42})
+    result = sim.execute(prog)
+    assert result.final_state.b0 == 0
+
+
+# ── HALT on all-zeros parcel ──────────────────────────────────────────────────
+
+def test_halt_parcel_stops_execution():
+    # An all-zeros program halts immediately at P=0
+    sim = CDC6600Simulator()
+    result = sim.execute(b"\x00" * 8)
+    assert result.halted
+
+
+def test_halt_after_instructions():
+    # Explicit HALT after one instruction
+    prog = long_instr(F_LDXI, 1, 0, 5) + HALT
+    sim = CDC6600Simulator()
+    result = sim.execute(prog)
+    assert result.halted
+    assert result.final_state.x1 == 5
+
+
+# ── 60-bit arithmetic mask ────────────────────────────────────────────────────
+
+def test_ixxp_stays_60bit():
+    # MASK60 + 1 should wrap to 0 (not overflow into 61st bit)
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXXP, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: MASK60, 2: 1})
+    result = sim.execute(prog)
+    assert result.final_state.x3 == 0
+    # Ensure the result fits in 60 bits
+    assert result.final_state.x3 <= MASK60
+
+
+def test_ixxp_never_exceeds_mask60():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXXP, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: MASK60, 2: MASK60})
+    result = sim.execute(prog)
+    v = result.final_state.x3
+    assert v <= MASK60
+
+
+# ── A/B register 18-bit mask ──────────────────────────────────────────────────
+
+def test_b_register_wraps_18bit():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IBBP, 1, 2, 3) + HALT
+    sim.load(prog)
+    preset(sim, b={2: MASK18, 3: 1})
+    result = sim.execute(prog)
+    assert result.final_state.b1 == 0
+
+
+def test_ldai_max_18bit():
+    sim = CDC6600Simulator()
+    result = sim.execute(long_instr(F_LDXI, 0, 0, 0) + long_instr(F_LDBI, 1, 0, MASK18) + HALT)
+    assert result.final_state.b1 == MASK18
+
+
+# ── max_steps guard ───────────────────────────────────────────────────────────
+
+def test_max_steps_exceeded_returns_error():
+    # JMP 0 forever — must stop after max_steps
+    sim = CDC6600Simulator()
+    prog = long_instr(F_JMP, 0, 0, 0)   # jump to parcel 0
+    result = sim.execute(prog, max_steps=5)
+    assert not result.ok
+    assert result.error is not None
+    assert "max_steps" in result.error
+
+
+def test_max_steps_steps_count():
+    sim = CDC6600Simulator()
+    prog = long_instr(F_JMP, 0, 0, 0)
+    result = sim.execute(prog, max_steps=7)
+    assert result.steps == 7
+
+
+# ── Memory bounds ─────────────────────────────────────────────────────────────
+
+def test_stx_out_of_bounds():
+    from cdc6600_simulator.simulator import F_LDAI
+    sim = CDC6600Simulator()
+    prog = (
+        long_instr(F_LDAI, 1, 0, MEMORY_WORDS) +   # A1 = 4096 (out of bounds)
+        long_instr(F_STX, 1, 2, 0) +                # STX: mem[A1+0] → error
+        HALT
+    )
+    result = sim.execute(prog)
+    assert not result.ok
+
+
+# ── State immutability ────────────────────────────────────────────────────────
+
+def test_frozen_state_x_immutable():
+    sim = CDC6600Simulator()
+    s = sim.get_state()
+    with pytest.raises((AttributeError, TypeError)):
+        s.x = (99,) * 8  # type: ignore[misc]
+
+
+def test_frozen_state_p_immutable():
+    sim = CDC6600Simulator()
+    s = sim.get_state()
+    with pytest.raises((AttributeError, TypeError)):
+        s.p = 999  # type: ignore[misc]
+
+
+def test_snapshot_not_modified_by_step():
+    sim = CDC6600Simulator()
+    sim.load(long_instr(F_LDXI, 1, 0, 42) + HALT)
+    snap = sim.get_state()
+    x1_before = snap.x1
+    sim.step()
+    # snap is frozen; sim has advanced but snap holds the old value
+    assert snap.x1 == x1_before
+    assert sim.get_state().x1 == 42
+
+
+# ── Parcel packing / memory word layout ──────────────────────────────────────
+
+def test_load_packs_parcels_into_word():
+    # Verify that the first word contains what we loaded
+    sim = CDC6600Simulator()
+    # Encode LDXI X1,5 (30-bit = 2 parcels) then two HALT parcels
+    prog = long_instr(F_LDXI, 1, 0, 5) + HALT + HALT
+    sim.load(prog)
+    s = sim.get_state()
+    # Word 0 should be non-zero (contains the LDXI instruction)
+    assert s.memory[0] != 0
+
+
+def test_load_second_word_is_halt():
+    # Program exactly 8 bytes → word 0 used, word 1 should be zero
+    sim = CDC6600Simulator()
+    prog = long_instr(F_LDXI, 1, 0, 7) + HALT + HALT   # exactly 8 bytes
+    sim.load(prog)
+    s = sim.get_state()
+    assert s.memory[1] == 0
+
+
+# ── Already-halted step ───────────────────────────────────────────────────────
+
+def test_step_when_already_halted():
+    sim = CDC6600Simulator()
+    sim.execute(HALT)
+    trace = sim.step()
+    assert "HALT" in trace.mnemonic
+
+
+# ── Convenience properties ────────────────────────────────────────────────────
+
+def test_state_convenience_x_properties():
+    sim = CDC6600Simulator()
+    prog = b"".join(
+        long_instr(F_LDXI, i, 0, i * 10)
+        for i in range(8)
+    ) + HALT
+    result = sim.execute(prog)
+    s = result.final_state
+    assert s.x0 == 0
+    assert s.x1 == 10
+    assert s.x7 == 70
+
+
+def test_state_convenience_b_properties():
+    sim = CDC6600Simulator()
+    prog = b"".join(
+        long_instr(F_LDBI, i, 0, i + 1) if i != 0 else b""
+        for i in range(8)
+    ) + HALT
+    result = sim.execute(prog)
+    s = result.final_state
+    assert s.b0 == 0
+    assert s.b1 == 2
+    assert s.b7 == 8

--- a/code/packages/python/cdc6600-simulator/tests/test_instructions.py
+++ b/code/packages/python/cdc6600-simulator/tests/test_instructions.py
@@ -1,0 +1,685 @@
+"""Per-instruction correctness tests for the CDC 6600 simulator."""
+
+
+from cdc6600_simulator import HALT, CDC6600Simulator, long_instr, short_instr
+from cdc6600_simulator.simulator import (
+    F_BXMR,
+    F_BXND,
+    F_BXOR,
+    F_BXXR,
+    F_CMPEQ,
+    F_CMPGT,
+    F_CMPLT,
+    F_IAAM,
+    F_IAAP,
+    F_IBBM,
+    F_IBBP,
+    F_IXMB,
+    F_IXMUL,
+    F_IXPB,
+    F_IXXM,
+    F_IXXP,
+    F_JEQ,
+    F_JMP,
+    F_JNE,
+    F_JSR,
+    F_JXN,
+    F_JXZ,
+    F_LDAI,
+    F_LDB,
+    F_LDBI,
+    F_LDX,
+    F_LDXI,
+    F_LSHL,
+    F_LSHR,
+    F_RET,
+    F_STB,
+    F_STX,
+    F_TAX,
+    F_TBX,
+    F_TXA,
+    F_TXB,
+)
+from cdc6600_simulator.state import MASK18, MASK60
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def run(prog: bytes) -> "CDC6600State":  # noqa: F821
+    sim = CDC6600Simulator()
+    result = sim.execute(prog)
+    assert result.ok, f"Program failed: {result.error}"
+    return result.final_state
+
+
+def preset(sim: CDC6600Simulator, *, x=None, a=None, b=None) -> None:
+    """Manually set register values in a loaded simulator before stepping."""
+    s = sim.get_state()
+    nx = list(s.x)
+    na = list(s.a)
+    nb = list(s.b)
+    if x:
+        for idx, val in x.items():
+            nx[idx] = val & MASK60
+    if a:
+        for idx, val in a.items():
+            na[idx] = val & MASK18
+    if b:
+        for idx, val in b.items():
+            if idx != 0:  # B0 stays 0
+                nb[idx] = val & MASK18
+    from cdc6600_simulator.state import CDC6600State
+    sim._state = CDC6600State(
+        p=s.p, x=tuple(nx), a=tuple(na), b=tuple(nb),
+        memory=s.memory, halted=s.halted,
+    )
+
+
+def run_from_current(sim: CDC6600Simulator, max_steps: int = 1000):
+    """
+    Run the simulator from its current state WITHOUT calling load() again.
+
+    execute() calls load() internally which would wipe preset register values.
+    Use this after preset() to run from the manually-configured state.
+    """
+    for _ in range(max_steps):
+        if sim.get_state().halted:
+            break
+        trace = sim.step()
+        if sim.get_state().halted:
+            break
+        if trace.mnemonic.startswith("ERROR:"):
+            return sim.get_state(), trace.mnemonic   # (state, error)
+    return sim.get_state(), None   # (state, error=None)
+
+
+# ── TXB: Xi = Bj ──────────────────────────────────────────────────────────────
+
+def test_txb_basic():
+    # Load B1=99, then TXB X2,B1 → X2 should be 99
+    prog = long_instr(F_LDBI, 1, 0, 99) + short_instr(F_TXB, 2, 1, 0) + HALT
+    s = run(prog)
+    assert s.x2 == 99
+
+
+def test_txb_zero_extends():
+    # B registers are 18-bit; verify zero-extension into 60-bit X
+    prog = long_instr(F_LDBI, 1, 0, 0x3FFFF) + short_instr(F_TXB, 3, 1, 0) + HALT
+    s = run(prog)
+    assert s.x3 == 0x3FFFF
+    # MSB of 60-bit word should NOT be set (zero extension, not sign extension)
+    assert s.x3 & (1 << 59) == 0
+
+
+# ── TBX: Bi = Xj[17:0] ────────────────────────────────────────────────────────
+
+def test_tbx_basic():
+    # Load X1=42, then TBX B2,X1 → B2=42
+    prog = long_instr(F_LDXI, 1, 0, 42) + short_instr(F_TBX, 2, 1, 0) + HALT
+    s = run(prog)
+    assert s.b2 == 42
+
+
+def test_tbx_masks_to_18bit():
+    # X register has 60-bit value; only lower 18 bits go into B
+    sim = CDC6600Simulator()
+    # Set X1 = 0xFFF_FFFF_FFFF_FFFF (max 60-bit)
+    prog = short_instr(F_TBX, 2, 1, 0) + HALT
+    sim.load(prog)
+    preset(sim, x={1: MASK60})
+    sim.step()  # TBX B2, X1
+    s = sim.get_state()
+    assert s.b2 == MASK18
+
+
+# ── TAX: Xi = Aj ──────────────────────────────────────────────────────────────
+
+def test_tax_basic():
+    # Load A3=100, then TAX X4,A3 → X4=100
+    prog = long_instr(F_LDAI, 3, 0, 100) + short_instr(F_TAX, 4, 3, 0) + HALT
+    s = run(prog)
+    assert s.x4 == 100
+
+
+# ── TXA: Ai = Xj[17:0] ────────────────────────────────────────────────────────
+
+def test_txa_basic():
+    # Load X2=200, then TXA A5,X2 → A5=200
+    prog = long_instr(F_LDXI, 2, 0, 200) + short_instr(F_TXA, 5, 2, 0) + HALT
+    s = run(prog)
+    assert s.a5 == 200
+
+
+# ── IXPB: Xi = Xj + Bk ───────────────────────────────────────────────────────
+
+def test_ixpb_basic():
+    # X1=10, B2=5 → IXPB X3,X1,B2 → X3=15
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXPB, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 10}, b={2: 5})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 15
+
+
+def test_ixpb_wraps_60bit():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXPB, 1, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: MASK60}, b={2: 1})
+    state, _ = run_from_current(sim)
+    assert state.x1 == 0   # wraps around at 60 bits
+
+
+# ── IXMB: Xi = Xj - Bk ───────────────────────────────────────────────────────
+
+def test_ixmb_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXMB, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 20}, b={2: 7})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 13
+
+
+# ── IXXP: Xi = Xj + Xk ───────────────────────────────────────────────────────
+
+def test_ixxp_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXXP, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 100, 2: 200})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 300
+
+
+def test_ixxp_wraps_60bit():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXXP, 1, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: MASK60, 2: 1})
+    state, _ = run_from_current(sim)
+    assert state.x1 == 0
+
+
+# ── IXXM: Xi = Xj - Xk ───────────────────────────────────────────────────────
+
+def test_ixxm_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXXM, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 50, 2: 13})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 37
+
+
+def test_ixxm_underflow_wraps():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXXM, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 0, 2: 1})
+    state, _ = run_from_current(sim)
+    assert state.x3 == MASK60   # 0 - 1 = all-ones in 60-bit
+
+
+# ── BXND: Xi = Xj & Xk ───────────────────────────────────────────────────────
+
+def test_bxnd_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_BXND, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 0xFF0F, 2: 0x0FFF})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 0x0F0F
+
+
+# ── BXOR: Xi = Xj | Xk ───────────────────────────────────────────────────────
+
+def test_bxor_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_BXOR, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 0xF0F0, 2: 0x0F0F})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 0xFFFF
+
+
+# ── BXXR: Xi = Xj ^ Xk ───────────────────────────────────────────────────────
+
+def test_bxxr_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_BXXR, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 0xAAAA, 2: 0xAAAA})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 0   # XOR with itself = 0
+
+
+def test_bxxr_nonzero():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_BXXR, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 0b1010, 2: 0b1100})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 0b0110
+
+
+# ── BXMR: Xi = ~Xj ───────────────────────────────────────────────────────────
+
+def test_bxmr_all_zeros():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_BXMR, 1, 2, 0) + HALT
+    sim.load(prog)
+    preset(sim, x={2: 0})
+    state, _ = run_from_current(sim)
+    assert state.x1 == MASK60   # ~0 = all-ones (60 bits)
+
+
+def test_bxmr_all_ones():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_BXMR, 1, 2, 0) + HALT
+    sim.load(prog)
+    preset(sim, x={2: MASK60})
+    state, _ = run_from_current(sim)
+    assert state.x1 == 0
+
+
+# ── LSHL / LSHR ───────────────────────────────────────────────────────────────
+
+def test_lshl_basic():
+    # X1=1, B2=4 → LSHL X3,X1,B2 → X3=16
+    sim = CDC6600Simulator()
+    prog = short_instr(F_LSHL, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 1}, b={2: 4})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 16
+
+
+def test_lshr_basic():
+    # X1=256, B2=4 → LSHR X3,X1,B2 → X3=16
+    sim = CDC6600Simulator()
+    prog = short_instr(F_LSHR, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 256}, b={2: 4})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 16
+
+
+def test_lshr_zero_fills():
+    # Shift MSB of 60-bit word right — must not sign-extend
+    sim = CDC6600Simulator()
+    prog = short_instr(F_LSHR, 3, 1, 2) + HALT
+    sim.load(prog)
+    # X1 = only bit 59 set
+    preset(sim, x={1: 1 << 59}, b={2: 1})
+    state, _ = run_from_current(sim)
+    # After logical right-shift by 1, bit 59 becomes 0 (zero-fill)
+    assert state.x3 == (1 << 58)
+    assert state.x3 & (1 << 59) == 0
+
+
+# ── IBBP / IBBM ───────────────────────────────────────────────────────────────
+
+def test_ibbp_basic():
+    # B1=10, B2=7 → IBBP B3,B1,B2 → B3=17
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IBBP, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, b={1: 10, 2: 7})
+    state, _ = run_from_current(sim)
+    assert state.b3 == 17
+
+
+def test_ibbm_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IBBM, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, b={1: 20, 2: 5})
+    state, _ = run_from_current(sim)
+    assert state.b3 == 15
+
+
+def test_ibbp_wraps_18bit():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IBBP, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, b={1: MASK18, 2: 1})
+    state, _ = run_from_current(sim)
+    assert state.b3 == 0   # wraps at 18 bits
+
+
+# ── IAAP / IAAM ───────────────────────────────────────────────────────────────
+
+def test_iaap_basic():
+    # A1=100, B2=50 → IAAP A3,A1,B2 → A3=150
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IAAP, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, a={1: 100}, b={2: 50})
+    state, _ = run_from_current(sim)
+    assert state.a3 == 150
+
+
+def test_iaam_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IAAM, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, a={1: 100}, b={2: 30})
+    state, _ = run_from_current(sim)
+    assert state.a3 == 70
+
+
+# ── CMPEQ / CMPLT / CMPGT ────────────────────────────────────────────────────
+
+def test_cmpeq_true():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_CMPEQ, 1, 2, 3) + HALT
+    sim.load(prog)
+    preset(sim, x={2: 42, 3: 42})
+    state, _ = run_from_current(sim)
+    assert state.b1 == 1
+
+
+def test_cmpeq_false():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_CMPEQ, 1, 2, 3) + HALT
+    sim.load(prog)
+    preset(sim, x={2: 42, 3: 43})
+    state, _ = run_from_current(sim)
+    assert state.b1 == 0
+
+
+def test_cmplt_true():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_CMPLT, 1, 2, 3) + HALT
+    sim.load(prog)
+    # 5 < 10 → B1=1
+    preset(sim, x={2: 5, 3: 10})
+    state, _ = run_from_current(sim)
+    assert state.b1 == 1
+
+
+def test_cmplt_false():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_CMPLT, 1, 2, 3) + HALT
+    sim.load(prog)
+    # 10 < 5 → false → B1=0
+    preset(sim, x={2: 10, 3: 5})
+    state, _ = run_from_current(sim)
+    assert state.b1 == 0
+
+
+def test_cmpgt_true():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_CMPGT, 1, 2, 3) + HALT
+    sim.load(prog)
+    preset(sim, x={2: 99, 3: 1})
+    state, _ = run_from_current(sim)
+    assert state.b1 == 1
+
+
+def test_cmpgt_false():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_CMPGT, 1, 2, 3) + HALT
+    sim.load(prog)
+    preset(sim, x={2: 1, 3: 99})
+    state, _ = run_from_current(sim)
+    assert state.b1 == 0
+
+
+# ── IXMUL ─────────────────────────────────────────────────────────────────────
+
+def test_ixmul_basic():
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXMUL, 3, 1, 2) + HALT
+    sim.load(prog)
+    preset(sim, x={1: 12, 2: 11})
+    state, _ = run_from_current(sim)
+    assert state.x3 == 132
+
+
+def test_ixmul_large():
+    # Verify lower-60-bit truncation
+    sim = CDC6600Simulator()
+    prog = short_instr(F_IXMUL, 3, 1, 2) + HALT
+    sim.load(prog)
+    # 2^30 * 2^30 = 2^60, which truncates to 0 in a 60-bit mask
+    preset(sim, x={1: 1 << 30, 2: 1 << 30})
+    state, _ = run_from_current(sim)
+    # (2^30)*(2^30) = 2^60 → masked to 60 bits → 0
+    assert state.x3 == 0
+
+
+# ── LDXI / LDBI / LDAI ────────────────────────────────────────────────────────
+
+def test_ldxi_basic():
+    s = run(long_instr(F_LDXI, 1, 0, 255) + HALT)
+    assert s.x1 == 255
+
+
+def test_ldxi_max():
+    s = run(long_instr(F_LDXI, 2, 0, 0x3FFFF) + HALT)
+    assert s.x2 == 0x3FFFF
+
+
+def test_ldbi_basic():
+    s = run(long_instr(F_LDBI, 1, 0, 77) + HALT)
+    assert s.b1 == 77
+
+
+def test_ldai_basic():
+    s = run(long_instr(F_LDAI, 2, 0, 512) + HALT)
+    assert s.a2 == 512
+
+
+# ── LDX / STX (memory) ────────────────────────────────────────────────────────
+
+def test_stx_ldx_roundtrip():
+    # Store X1=12345 at address 100, then load it back into X2
+    prog = (
+        long_instr(F_LDXI, 1, 0, 12345) +   # X1 = 12345
+        long_instr(F_LDAI, 2, 0, 100) +      # A2 = 100  (address)
+        long_instr(F_STX, 2, 1, 0) +         # mem[A2+0] = X1
+        long_instr(F_LDAI, 3, 0, 100) +      # A3 = 100
+        long_instr(F_LDX, 4, 3, 0) +         # X4 = mem[A3+0]
+        HALT
+    )
+    s = run(prog)
+    assert s.x4 == 12345
+
+
+def test_stx_offset():
+    # Store X1=99 at address A2+5 = 105
+    prog = (
+        long_instr(F_LDXI, 1, 0, 99) +
+        long_instr(F_LDAI, 2, 0, 100) +
+        long_instr(F_STX, 2, 1, 5) +         # mem[A2+5 = 105] = X1
+        long_instr(F_LDX, 3, 2, 5) +         # X3 = mem[A2+5]
+        HALT
+    )
+    s = run(prog)
+    assert s.x3 == 99
+
+
+def test_ldx_out_of_bounds():
+    # Accessing address >= 4096 should raise ValueError
+    from cdc6600_simulator.state import MEMORY_WORDS
+    sim = CDC6600Simulator()
+    prog = (
+        long_instr(F_LDAI, 1, 0, MEMORY_WORDS) +  # A1 = 4096 (out of bounds)
+        long_instr(F_LDX, 2, 1, 0) +               # LDX X2, A1+0 → error
+        HALT
+    )
+    result = sim.execute(prog)
+    assert not result.ok
+
+
+# ── LDB / STB ─────────────────────────────────────────────────────────────────
+
+def test_stb_ldb_roundtrip():
+    # Store B1=777 to memory, then load into B2
+    prog = (
+        long_instr(F_LDBI, 1, 0, 777) +      # B1 = 777
+        long_instr(F_LDAI, 3, 0, 200) +      # A3 = 200
+        long_instr(F_STB, 3, 1, 0) +         # mem[A3+0][17:0] = B1
+        long_instr(F_LDB, 2, 3, 0) +         # B2 = mem[A3+0][17:0]
+        HALT
+    )
+    s = run(prog)
+    assert s.b2 == 777
+
+
+# ── JEQ / JNE ─────────────────────────────────────────────────────────────────
+
+def test_jeq_taken():
+    # B1=0 → JEQ should branch to skip the LDXI X1,99 and land at LDXI X2,1
+    # Layout: (parcel 0-1: JEQ B1==0, target=4) (2-3: LDXI X1,99) (4-5: LDXI X2,1) (6: HALT)
+    # Parcels: 0=JEQ hi, 1=JEQ lo, 2=LDXI hi, 3=LDXI lo, 4=LDXI hi, 5=LDXI lo, 6=HALT
+    prog = (
+        long_instr(F_JEQ, 0, 1, 4) +      # if B1==0: P=4  (skip next long instr)
+        long_instr(F_LDXI, 1, 0, 99) +    # skipped: X1=99
+        long_instr(F_LDXI, 2, 0, 1) +     # X2=1
+        HALT
+    )
+    s = run(prog)
+    assert s.x1 == 0    # X1 was never set (branch taken over LDXI X1,99)
+    assert s.x2 == 1
+
+
+def test_jeq_not_taken():
+    # B1=5 (non-zero) → JEQ not taken
+    sim = CDC6600Simulator()
+    prog = (
+        long_instr(F_JEQ, 0, 1, 4) +      # if B1==0: P=4 (NOT taken since B1=5)
+        long_instr(F_LDXI, 1, 0, 99) +    # X1=99 (should execute)
+        long_instr(F_LDXI, 2, 0, 1) +
+        HALT
+    )
+    sim.load(prog)
+    preset(sim, b={1: 5})
+    state, _ = run_from_current(sim)
+    assert state.x1 == 99
+
+
+def test_jne_taken():
+    # B1=3 (non-zero) → JNE taken, skip LDXI X1,99
+    sim = CDC6600Simulator()
+    prog = (
+        long_instr(F_JNE, 0, 1, 4) +      # if B1!=0: P=4
+        long_instr(F_LDXI, 1, 0, 99) +    # skipped
+        long_instr(F_LDXI, 2, 0, 7) +     # X2=7
+        HALT
+    )
+    sim.load(prog)
+    preset(sim, b={1: 3})
+    state, _ = run_from_current(sim)
+    assert state.x1 == 0
+    assert state.x2 == 7
+
+
+# ── JXZ / JXN ─────────────────────────────────────────────────────────────────
+
+def test_jxz_taken():
+    # X1=0 → JXZ taken
+    prog = (
+        long_instr(F_JXZ, 0, 1, 4) +      # if X1==0: P=4
+        long_instr(F_LDXI, 2, 0, 55) +    # skipped: X2=55
+        long_instr(F_LDXI, 3, 0, 11) +    # X3=11
+        HALT
+    )
+    s = run(prog)
+    assert s.x2 == 0    # skipped
+    assert s.x3 == 11
+
+
+def test_jxn_taken():
+    sim = CDC6600Simulator()
+    prog = (
+        long_instr(F_JXN, 0, 1, 4) +      # if X1!=0: P=4
+        long_instr(F_LDXI, 2, 0, 55) +    # skipped
+        long_instr(F_LDXI, 3, 0, 11) +
+        HALT
+    )
+    sim.load(prog)
+    preset(sim, x={1: 42})
+    state, _ = run_from_current(sim)
+    assert state.x2 == 0    # skipped
+    assert state.x3 == 11
+
+
+# ── JMP (unconditional) ───────────────────────────────────────────────────────
+
+def test_jmp_basic():
+    # JMP to parcel 4, skipping LDXI X1,99 at parcels 2-3
+    prog = (
+        long_instr(F_JMP, 0, 0, 4) +      # JMP P=4
+        long_instr(F_LDXI, 1, 0, 99) +    # skipped
+        long_instr(F_LDXI, 2, 0, 7) +     # X2=7
+        HALT
+    )
+    s = run(prog)
+    assert s.x1 == 0
+    assert s.x2 == 7
+
+
+# ── JSR / RET ─────────────────────────────────────────────────────────────────
+
+def test_jsr_saves_return_address():
+    # JSR to parcel 4 should save return parcel address (2) in B7.
+    # Layout:
+    #   P=0,1: JSR target=4  (2 parcels; saves B7=2)
+    #   P=2:   HALT           (not reached by JSR)
+    #   P=3:   HALT           (padding to align subroutine at P=4)
+    #   P=4,5: LDXI X1,42    (subroutine body)
+    #   P=6:   HALT
+    prog = (
+        long_instr(F_JSR, 0, 0, 4) +      # P=0,1: B7=2; P=4
+        HALT +                             # P=2: not reached
+        HALT +                             # P=3: padding
+        long_instr(F_LDXI, 1, 0, 42) +    # P=4,5: X1=42
+        HALT                               # P=6
+    )
+    s = run(prog)
+    assert s.x1 == 42
+    assert s.b7 == 2   # return address = parcel after JSR (P=2)
+
+
+def test_ret_returns_to_caller():
+    # Simple call/return: JSR to subroutine, RET back, check result
+    # Layout:
+    #   P=0,1: JSR to P=6 (subroutine start)   [saves B7=2]
+    #   P=2,3: LDXI X2,100  (after return)
+    #   P=4:   HALT
+    #   P=5:   padding (HALT)
+    #   P=6,7: LDXI X1,42   (subroutine body)
+    #   P=8,9: RET B7        (return)
+    prog = (
+        long_instr(F_JSR, 0, 0, 6) +      # P=0: call subroutine at P=6
+        long_instr(F_LDXI, 2, 0, 100) +   # P=2: X2=100 (runs after return)
+        HALT +                             # P=4
+        HALT +                             # P=5 (padding)
+        long_instr(F_LDXI, 1, 0, 42) +    # P=6: subroutine: X1=42
+        long_instr(F_RET, 0, 7, 0) +      # P=8: RET P=B7
+        HALT
+    )
+    s = run(prog)
+    assert s.x1 == 42    # subroutine ran
+    assert s.x2 == 100   # caller continued after return
+
+
+# ── Unknown opcode ────────────────────────────────────────────────────────────
+
+def test_unknown_short_opcode():
+    # Opcode 63 (0x3F) is not defined — should error
+    prog = short_instr(63, 0, 0, 0) + HALT
+    sim = CDC6600Simulator()
+    result = sim.execute(prog)
+    assert not result.ok
+
+
+def test_unknown_long_opcode():
+    # Opcode 63 (in long range >= 32, but 63 is not defined)
+    prog = long_instr(63, 0, 0, 0) + HALT
+    sim = CDC6600Simulator()
+    result = sim.execute(prog)
+    assert not result.ok

--- a/code/packages/python/cdc6600-simulator/tests/test_programs.py
+++ b/code/packages/python/cdc6600-simulator/tests/test_programs.py
@@ -1,0 +1,438 @@
+"""End-to-end program tests for the CDC 6600 simulator.
+
+Each test encodes a small hand-assembled program and verifies the result.
+Programs are described in pseudocode alongside the encoding for readability.
+
+Parcel address arithmetic
+--------------------------
+- Short (15-bit) instruction = 1 parcel → advances P by 1
+- Long (30-bit) instruction  = 2 parcels → advances P by 2
+- Branch targets are parcel addresses (NOT byte offsets)
+
+Helper function ``assemble()`` concatenates bytes and returns the program.
+"""
+
+from cdc6600_simulator import HALT, CDC6600Simulator, long_instr, short_instr
+from cdc6600_simulator.simulator import (
+    F_BXXR,
+    F_CMPLT,
+    F_IAAP,
+    F_IBBM,
+    F_IXMUL,
+    F_IXXP,
+    F_JEQ,
+    F_JMP,
+    F_JNE,
+    F_JSR,
+    F_LDAI,
+    F_LDBI,
+    F_LDX,
+    F_LDXI,
+    F_RET,
+    F_STX,
+    F_TXB,
+)
+
+
+def assemble(*pieces: bytes) -> bytes:
+    return b"".join(pieces)
+
+
+def run(prog: bytes, max_steps: int = 10_000):
+    sim = CDC6600Simulator()
+    result = sim.execute(prog, max_steps=max_steps)
+    assert result.ok, f"Program error: {result.error}"
+    return result.final_state
+
+
+# ── Program 1: Sum 1 + 2 + … + 10 = 55 ──────────────────────────────────────
+#
+# Pseudocode:
+#   X1 = 0         (accumulator)
+#   B1 = 10        (counter: counts down from 10 to 0)
+#   B2 = 1         (constant 1 for decrement)
+#   loop:
+#     TXB X3, B1   (X3 = B1 as 60-bit value)
+#     IXXP X1, X1, X3  (X1 += X3)
+#     IBBM B1, B1, B2  (B1 -= 1)
+#     JNE B1!=0, loop  (if B1 != 0 goto loop)
+#   HALT
+#
+# Parcel layout:
+#   P= 0,1:  LDXI X1, 0       (2 parcels)
+#   P= 2,3:  LDBI B1, 10      (2 parcels)
+#   P= 4,5:  LDBI B2, 1       (2 parcels)
+#   P= 6:    TXB  X3, B1      (1 parcel) ← loop top
+#   P= 7:    IXXP X1, X1, X3 (1 parcel)
+#   P= 8:    IBBM B1, B1, B2 (1 parcel)
+#   P= 9,10: JNE  B1!=0, 6   (2 parcels → next P=11)
+#   P=11:    HALT
+
+def test_sum_1_to_10():
+    prog = assemble(
+        long_instr(F_LDXI, 1, 0, 0),        # P=0: X1=0
+        long_instr(F_LDBI, 1, 0, 10),       # P=2: B1=10
+        long_instr(F_LDBI, 2, 0, 1),        # P=4: B2=1
+        # loop top at P=6:
+        short_instr(F_TXB, 3, 1, 0),        # P=6: X3=B1
+        short_instr(F_IXXP, 1, 1, 3),       # P=7: X1+=X3
+        short_instr(F_IBBM, 1, 1, 2),       # P=8: B1-=B2
+        long_instr(F_JNE, 0, 1, 6),         # P=9: if B1!=0 goto P=6
+        HALT,                                # P=11
+    )
+    s = run(prog)
+    assert s.x1 == 55
+
+
+# ── Program 2: Factorial 5! = 120 ─────────────────────────────────────────────
+#
+# Pseudocode:
+#   X1 = 1         (accumulator, starts at 1)
+#   B1 = 5         (counter: 5, 4, 3, 2, 1)
+#   B2 = 1
+#   loop:
+#     TXB X2, B1   (X2 = B1 as 60-bit)
+#     IXMUL X1, X1, X2  (X1 *= X2)
+#     IBBM B1, B1, B2   (B1 -= 1)
+#     JNE B1!=0, loop
+#   HALT
+
+def test_factorial_5():
+    prog = assemble(
+        long_instr(F_LDXI, 1, 0, 1),        # P=0: X1=1
+        long_instr(F_LDBI, 1, 0, 5),        # P=2: B1=5
+        long_instr(F_LDBI, 2, 0, 1),        # P=4: B2=1
+        # loop top at P=6:
+        short_instr(F_TXB, 2, 1, 0),        # P=6: X2=B1
+        short_instr(F_IXMUL, 1, 1, 2),      # P=7: X1*=X2
+        short_instr(F_IBBM, 1, 1, 2),       # P=8: B1-=1
+        long_instr(F_JNE, 0, 1, 6),         # P=9: if B1!=0 goto P=6
+        HALT,                                # P=11
+    )
+    s = run(prog)
+    assert s.x1 == 120
+
+
+# ── Program 3: Fibonacci F(0)..F(9) written to memory, verify F(9)=34 ─────────
+#
+# F(0)=0, F(1)=1, F(2)=1, F(3)=2, F(4)=3, F(5)=5, F(6)=8, F(7)=13, F(8)=21, F(9)=34
+#
+# Pseudocode:
+#   mem[200] = 0   (F0)
+#   mem[201] = 1   (F1)
+#   A1 = 200       (base address)
+#   B1 = 2         (index into mem, starts at 2)
+#   B5 = 10        (stop when B1 == 10)
+#   B2 = 1         (constant 1)
+#   loop:
+#     if B1 == B5: done
+#     X3 = mem[A1 + B1 - 2]  (prev-prev)
+#     X4 = mem[A1 + B1 - 1]  (prev)
+#     X5 = X3 + X4
+#     mem[A1 + B1] = X5
+#     B1 += 1
+#   done:
+#   X1 = mem[A1 + 9]   (load F(9))
+#   HALT
+
+def test_fibonacci_f9():
+    # Store F(0)=0 and F(1)=1 before the loop
+    # We'll use A2 for relative addressing tricks
+    #
+    # Simpler approach: pre-store F0,F1 and iterate 8 more steps
+    # using indirect addressing: A1=200, compute each F(n) = F(n-2) + F(n-1)
+    #
+    # Encoding note: LDX Xi, Aj+K uses static offset K; we can't use a dynamic
+    # B-register offset for LDX directly.  Instead we move A1 forward each step.
+    #
+    # Strategy: use B1 as loop counter (8 iterations), A1 = base=200
+    #   each iter: load from A1+0 (F(n-2)) and A1+1 (F(n-1)), store to A1+2,
+    #   then increment A1 by 1 (IAAP A1, A1, B2) where B2=1.
+
+    prog = assemble(
+        # Store F(0)=0 and F(1)=1 at words 200 and 201
+        long_instr(F_LDXI, 1, 0, 0),        # P=0:  X1 = 0
+        long_instr(F_LDAI, 1, 0, 200),      # P=2:  A1 = 200
+        long_instr(F_STX, 1, 1, 0),         # P=4:  mem[A1+0=200] = X1 (F0=0)
+        long_instr(F_LDXI, 1, 0, 1),        # P=6:  X1 = 1
+        long_instr(F_STX, 1, 1, 1),         # P=8:  mem[A1+1=201] = X1 (F1=1)
+        # Setup loop: A1=200, B1=8 iterations, B2=1
+        long_instr(F_LDAI, 1, 0, 200),      # P=10: A1=200
+        long_instr(F_LDBI, 1, 0, 8),        # P=12: B1=8 (loop count)
+        long_instr(F_LDBI, 2, 0, 1),        # P=14: B2=1 (stride)
+        # loop top at P=16:
+        #   X3 = mem[A1+0]   (F(n-2))
+        #   X4 = mem[A1+1]   (F(n-1))
+        #   X5 = X3 + X4
+        #   mem[A1+2] = X5
+        #   A1 += 1  (IAAP A1, A1, B2)
+        #   B1 -= 1  (IBBM B1, B1, B2)
+        #   JNE B1!=0, P=16
+        long_instr(F_LDX, 3, 1, 0),         # P=16: X3=mem[A1+0]
+        long_instr(F_LDX, 4, 1, 1),         # P=18: X4=mem[A1+1]
+        short_instr(F_IXXP, 5, 3, 4),       # P=20: X5=X3+X4
+        long_instr(F_STX, 1, 5, 2),         # P=21: mem[A1+2]=X5
+        short_instr(F_IAAP, 1, 1, 2),       # P=23: A1+=1
+        short_instr(F_IBBM, 1, 1, 2),       # P=24: B1-=1
+        long_instr(F_JNE, 0, 1, 16),        # P=25: if B1!=0 goto P=16
+        # After loop: A1=208, F(9) is at address 200+9=209 but we advanced A1
+        # to 200+8=208; F(9)=mem[208+1]=mem[209]? No: A1 starts at 200 and
+        # we do +1 each iter, so after 8 iters A1=208. F(9) is stored to
+        # mem[A1+2] when A1=207 (last iter). Let me verify:
+        #   iter1: A1=200 → store F(2) to mem[202], then A1→201
+        #   iter2: A1=201 → store F(3) to mem[203], then A1→202
+        #   ...
+        #   iter8: A1=207 → store F(9) to mem[209], then A1→208
+        # So F(9) is at address 209. To load it we need A1=209 or use A1=208, offset=1.
+        # After the loop A1=208.
+        long_instr(F_LDX, 1, 1, 1),         # P=27: X1=mem[A1+1=209]=F(9)
+        HALT,                                # P=29
+    )
+    s = run(prog)
+    assert s.x1 == 34
+
+
+# ── Program 4: Subroutine call/return ─────────────────────────────────────────
+#
+# Subroutine "double": X1 = X1 + X1 (doubles X1)
+# Main: X1=21; call double; verify X1=42
+
+def test_subroutine_call_return():
+    # Layout:
+    #   P= 0,1: LDXI X1, 21
+    #   P= 2,3: JSR to P=8 (double subroutine)
+    #   P= 4,5: LDXI X2, 99  (verify this runs after return)
+    #   P= 6:   HALT
+    #   P= 7:   HALT  (padding to align subroutine)
+    #   P= 8:   IXXP X1,X1,X1  (X1 = X1+X1)
+    #   P= 9,10: RET B7
+    #   P=11:   HALT
+
+    prog = assemble(
+        long_instr(F_LDXI, 1, 0, 21),       # P=0:  X1=21
+        long_instr(F_JSR, 0, 0, 8),         # P=2:  call P=8; B7=4
+        long_instr(F_LDXI, 2, 0, 99),       # P=4:  X2=99 (after return)
+        HALT,                                # P=6
+        HALT,                                # P=7  (padding)
+        short_instr(F_IXXP, 1, 1, 1),       # P=8:  X1=X1+X1 (double)
+        long_instr(F_RET, 0, 7, 0),         # P=9:  RET (P=B7=4)
+        HALT,                                # P=11
+    )
+    s = run(prog)
+    assert s.x1 == 42
+    assert s.x2 == 99
+
+
+# ── Program 5: Array sum using LDX + IAAP loop ────────────────────────────────
+#
+# Sum an array of 5 values stored at words 500–504: [3, 7, 11, 2, 6] = 29
+
+def test_array_sum():
+    # First we need to store the array values, then sum them.
+    # Array: mem[500]=3, mem[501]=7, mem[502]=11, mem[503]=2, mem[504]=6
+
+    prog = assemble(
+        # Store array values at addresses 500–504
+        long_instr(F_LDAI, 1, 0, 500),       # P=0:  A1=500
+        long_instr(F_LDXI, 2, 0, 3),         # P=2:  X2=3
+        long_instr(F_STX, 1, 2, 0),          # P=4:  mem[500]=3
+        long_instr(F_LDXI, 2, 0, 7),         # P=6:  X2=7
+        long_instr(F_STX, 1, 2, 1),          # P=8:  mem[501]=7
+        long_instr(F_LDXI, 2, 0, 11),        # P=10: X2=11
+        long_instr(F_STX, 1, 2, 2),          # P=12: mem[502]=11
+        long_instr(F_LDXI, 2, 0, 2),         # P=14: X2=2
+        long_instr(F_STX, 1, 2, 3),          # P=16: mem[503]=2
+        long_instr(F_LDXI, 2, 0, 6),         # P=18: X2=6
+        long_instr(F_STX, 1, 2, 4),          # P=20: mem[504]=6
+        # Now sum: A1=500, X1=0 (sum), B1=5 (count), B2=1 (stride)
+        long_instr(F_LDAI, 1, 0, 500),       # P=22: A1=500
+        long_instr(F_LDXI, 1, 0, 0),         # P=24: X1=0 (sum)
+        long_instr(F_LDBI, 1, 0, 5),         # P=26: B1=5
+        long_instr(F_LDBI, 2, 0, 1),         # P=28: B2=1
+        # loop top at P=30:
+        #   X3 = mem[A1+0]
+        #   X1 += X3
+        #   A1 += 1
+        #   B1 -= 1
+        #   JNE B1!=0, P=30
+        long_instr(F_LDX, 3, 1, 0),          # P=30: X3=mem[A1]
+        short_instr(F_IXXP, 1, 1, 3),        # P=32: X1+=X3
+        short_instr(F_IAAP, 1, 1, 2),        # P=33: A1+=B2
+        short_instr(F_IBBM, 1, 1, 2),        # P=34: B1-=B2
+        long_instr(F_JNE, 0, 1, 30),         # P=35: if B1!=0 goto P=30
+        HALT,                                 # P=37
+    )
+    s = run(prog)
+    assert s.x1 == 29
+
+
+# ── Program 6: XOR-based swap ─────────────────────────────────────────────────
+#
+# Swap X1 and X2 using XOR without a temporary:
+#   X1 ^= X2
+#   X2 ^= X1
+#   X1 ^= X2
+
+def test_xor_swap():
+    from cdc6600_simulator.state import CDC6600State
+
+    sim = CDC6600Simulator()
+    prog = assemble(
+        short_instr(F_BXXR, 1, 1, 2),   # X1 = X1 ^ X2
+        short_instr(F_BXXR, 2, 2, 1),   # X2 = X2 ^ X1 (= X2 ^ (X1_orig ^ X2) = X1_orig)
+        short_instr(F_BXXR, 1, 1, 2),   # X1 = X1 ^ X2 (= (X1_orig^X2) ^ X1_orig = X2_orig)
+        HALT,
+    )
+    sim.load(prog)
+    # Set X1=111, X2=222  (X0 is index 0, X1 is index 1, X2 is index 2)
+    s = sim.get_state()
+    sim._state = CDC6600State(
+        p=0, x=(0, 111, 222, 0, 0, 0, 0, 0),
+        a=s.a, b=s.b, memory=s.memory, halted=False,
+    )
+    # Run from current state (don't call execute() — it would re-load)
+    for _ in range(100):
+        if sim.get_state().halted:
+            break
+        sim.step()
+    final = sim.get_state()
+    assert final.x1 == 222
+    assert final.x2 == 111
+
+
+# ── Program 7: Count-down loop using JEQ ──────────────────────────────────────
+#
+# Use JEQ (branch if B == 0) for a count-down:
+#   B1 = 5
+#   X1 = 0
+#   loop:
+#     B1 -= 1
+#     X1 = X1 + 1  (via TXB + IXXP)
+#     JEQ B1==0, done
+#     JMP loop
+#   done:
+#     HALT
+
+def test_countdown_loop():
+    # P= 0,1: LDBI B1, 5
+    # P= 2,3: LDBI B2, 1   (decrement constant)
+    # P= 4,5: LDXI X1, 0   (counter)
+    # P= 6:   IBBM B1, B1, B2   ← loop top
+    # P= 7:   TXB  X2, B2   (X2 = 1)
+    # P= 8:   IXXP X1, X1, X2  (X1 += 1)
+    # P= 9,10: JEQ B1==0, 14   (branch to HALT if done)
+    # P=11,12: JMP 6
+    # P=13:   HALT  (padding)
+    # P=14:   HALT
+    prog = assemble(
+        long_instr(F_LDBI, 1, 0, 5),        # P=0:  B1=5
+        long_instr(F_LDBI, 2, 0, 1),        # P=2:  B2=1
+        long_instr(F_LDXI, 1, 0, 0),        # P=4:  X1=0
+        # loop at P=6:
+        short_instr(F_IBBM, 1, 1, 2),       # P=6:  B1-=1
+        short_instr(F_TXB, 2, 2, 0),        # P=7:  X2=B2=1
+        short_instr(F_IXXP, 1, 1, 2),       # P=8:  X1+=1
+        long_instr(F_JEQ, 0, 1, 14),        # P=9:  if B1==0 goto P=14 (HALT)
+        long_instr(F_JMP, 0, 0, 6),         # P=11: goto P=6
+        HALT,                                # P=13
+        HALT,                                # P=14 (landing pad)
+    )
+    s = run(prog)
+    assert s.x1 == 5   # loop ran 5 times, incrementing X1 each time
+
+
+# ── Program 8: Maximum of two values using CMPGT ──────────────────────────────
+#
+# Compute max(X1, X2) → X3
+#   CMPGT B1, X1, X2   (B1=1 if X1 > X2)
+#   JNE B1 != 0, take_x1   (if B1=1, X3=X1)
+#   X3 = X2  (X1 <= X2)
+#   JMP done
+#   take_x1: X3 = X1
+#   done: HALT
+
+def test_max_two_values():
+    from cdc6600_simulator.state import CDC6600State
+
+    sim = CDC6600Simulator()
+    # Correct layout:
+    prog2 = assemble(
+        # P=0: CMPLT B1, X1, X2  (B1=1 if X1<X2, meaning X2 is max)
+        short_instr(F_CMPLT, 1, 1, 2),
+        # P=1,2: JNE B1!=0, P=7  (if X1<X2, jump to "X3=X2" at P=7)
+        long_instr(F_JNE, 0, 1, 7),
+        # P=3: X1>=X2 path: X3=X1
+        short_instr(F_IXXP, 3, 1, 0),      # X3 = X1+0 = X1
+        # P=4,5: JMP P=9
+        long_instr(F_JMP, 0, 0, 9),
+        # P=6: padding
+        HALT,
+        # P=7: X1<X2 path: X3=X2
+        short_instr(F_IXXP, 3, 2, 0),      # X3 = X2+0 = X2
+        # P=8: padding (so P=9 is next)
+        HALT,
+        # P=9: HALT
+        HALT,
+    )
+
+    def run_with_x(x1, x2):
+        sim.load(prog2)
+        s = sim.get_state()
+        sim._state = CDC6600State(
+            p=0, x=(0, x1, x2, 0, 0, 0, 0, 0),
+            a=s.a, b=s.b, memory=s.memory, halted=False,
+        )
+        for _ in range(100):
+            if sim.get_state().halted:
+                break
+            sim.step()
+        return sim.get_state()
+
+    # Test with X1=10, X2=30 → max=30
+    assert run_with_x(10, 30).x3 == 30
+
+    # Test with X1=50, X2=20 → max=50
+    assert run_with_x(50, 20).x3 == 50
+
+
+# ── Program 9: Memory copy ─────────────────────────────────────────────────────
+#
+# Copy 4 words from addresses [300..303] to [400..403]
+
+def test_memory_copy():
+    # Store source data [10,20,30,40] at 300-303, then copy to 400-403.
+    # Parcel counts: each long_instr=2, each short_instr=1.
+    # Setup: 9 long = 18 + 4 long = 8 → 26 parcels; loop at P=26.
+
+    prog2 = assemble(
+        # Store [10, 20, 30, 40] at addresses 300–303
+        long_instr(F_LDAI, 1, 0, 300),       # P=0
+        long_instr(F_LDXI, 2, 0, 10),        # P=2
+        long_instr(F_STX, 1, 2, 0),          # P=4
+        long_instr(F_LDXI, 2, 0, 20),        # P=6
+        long_instr(F_STX, 1, 2, 1),          # P=8
+        long_instr(F_LDXI, 2, 0, 30),        # P=10
+        long_instr(F_STX, 1, 2, 2),          # P=12
+        long_instr(F_LDXI, 2, 0, 40),        # P=14
+        long_instr(F_STX, 1, 2, 3),          # P=16
+        # Setup
+        long_instr(F_LDAI, 1, 0, 300),       # P=18
+        long_instr(F_LDAI, 2, 0, 400),       # P=20
+        long_instr(F_LDBI, 1, 0, 4),         # P=22
+        long_instr(F_LDBI, 2, 0, 1),         # P=24
+        # loop at P=26:
+        long_instr(F_LDX, 3, 1, 0),          # P=26: X3=mem[A1]
+        long_instr(F_STX, 2, 3, 0),          # P=28: mem[A2]=X3
+        short_instr(F_IAAP, 1, 1, 2),        # P=30: A1+=1
+        short_instr(F_IAAP, 2, 2, 2),        # P=31: A2+=1
+        short_instr(F_IBBM, 1, 1, 2),        # P=32: B1-=1
+        long_instr(F_JNE, 0, 1, 26),         # P=33: if B1!=0 goto P=26
+        HALT,                                 # P=35
+    )
+
+    s = run(prog2)
+    # Verify destination addresses 400–403 hold [10, 20, 30, 40]
+    assert s.memory[400] == 10
+    assert s.memory[401] == 20
+    assert s.memory[402] == 30
+    assert s.memory[403] == 40

--- a/code/packages/python/cdc6600-simulator/tests/test_protocol.py
+++ b/code/packages/python/cdc6600-simulator/tests/test_protocol.py
@@ -1,0 +1,219 @@
+"""SIM00 protocol compliance tests for CDC6600Simulator."""
+
+from simulator_protocol import ExecutionResult, Simulator, StepTrace
+
+from cdc6600_simulator import HALT, CDC6600Simulator, CDC6600State, long_instr
+from cdc6600_simulator.simulator import F_LDXI
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def simple_prog() -> bytes:
+    """LDXI X1, 7  then HALT — smallest non-trivial program."""
+    return long_instr(F_LDXI, 1, 0, 7) + HALT
+
+
+# ── isinstance checks ──────────────────────────────────────────────────────────
+
+def test_is_simulator():
+    sim = CDC6600Simulator()
+    assert isinstance(sim, Simulator)
+
+
+def test_is_concrete_simulator():
+    sim = CDC6600Simulator()
+    assert isinstance(sim, CDC6600Simulator)
+
+
+# ── reset() ───────────────────────────────────────────────────────────────────
+
+def test_reset_clears_registers():
+    sim = CDC6600Simulator()
+    sim.execute(simple_prog())
+    sim.reset()
+    s = sim.get_state()
+    assert s.x == tuple(0 for _ in range(8))
+    assert s.a == tuple(0 for _ in range(8))
+    assert s.b == tuple(0 for _ in range(8))
+
+
+def test_reset_clears_memory():
+    sim = CDC6600Simulator()
+    sim.execute(simple_prog())
+    sim.reset()
+    s = sim.get_state()
+    assert all(w == 0 for w in s.memory)
+
+
+def test_reset_sets_p_zero():
+    sim = CDC6600Simulator()
+    sim.execute(simple_prog())
+    sim.reset()
+    assert sim.get_state().p == 0
+
+
+def test_reset_clears_halted():
+    sim = CDC6600Simulator()
+    sim.execute(simple_prog())
+    assert sim.get_state().halted
+    sim.reset()
+    assert not sim.get_state().halted
+
+
+# ── load() ────────────────────────────────────────────────────────────────────
+
+def test_load_resets_state():
+    sim = CDC6600Simulator()
+    sim.execute(simple_prog())
+    sim.load(simple_prog())
+    s = sim.get_state()
+    assert s.p == 0
+    assert not s.halted
+
+
+def test_load_places_bytes_in_memory():
+    sim = CDC6600Simulator()
+    sim.load(simple_prog())
+    s = sim.get_state()
+    # The word 0 should be non-zero (contains the LDXI instruction + HALT parcel)
+    assert s.memory[0] != 0
+
+
+# ── step() ────────────────────────────────────────────────────────────────────
+
+def test_step_returns_step_trace():
+    sim = CDC6600Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    assert isinstance(trace, StepTrace)
+
+
+def test_step_trace_has_pc_before():
+    sim = CDC6600Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    assert trace.pc_before == 0
+
+
+def test_step_trace_has_pc_after():
+    sim = CDC6600Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    # LDXI is a 30-bit (2-parcel) instruction → P advances by 2
+    assert trace.pc_after == 2
+
+
+def test_step_trace_has_mnemonic():
+    sim = CDC6600Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    assert "LDXI" in trace.mnemonic
+
+
+def test_step_trace_description_not_empty():
+    sim = CDC6600Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    assert trace.description
+
+
+def test_step_when_halted_returns_halt_trace():
+    sim = CDC6600Simulator()
+    sim.execute(simple_prog())
+    trace = sim.step()
+    assert "HALT" in trace.mnemonic
+    assert trace.pc_before == trace.pc_after
+
+
+def test_step_advances_p():
+    sim = CDC6600Simulator()
+    sim.load(simple_prog())
+    sim.step()   # LDXI (2 parcels)
+    assert sim.get_state().p == 2
+
+
+# ── execute() ─────────────────────────────────────────────────────────────────
+
+def test_execute_returns_execution_result():
+    sim = CDC6600Simulator()
+    result = sim.execute(simple_prog())
+    assert isinstance(result, ExecutionResult)
+
+
+def test_execute_halted_true():
+    sim = CDC6600Simulator()
+    result = sim.execute(simple_prog())
+    assert result.halted
+
+
+def test_execute_ok():
+    sim = CDC6600Simulator()
+    result = sim.execute(simple_prog())
+    assert result.ok
+
+
+def test_execute_steps_positive():
+    sim = CDC6600Simulator()
+    result = sim.execute(simple_prog())
+    assert result.steps > 0
+
+
+def test_execute_final_state_is_cdc6600state():
+    sim = CDC6600Simulator()
+    result = sim.execute(simple_prog())
+    assert isinstance(result.final_state, CDC6600State)
+
+
+def test_execute_x1_set():
+    sim = CDC6600Simulator()
+    result = sim.execute(simple_prog())
+    assert result.final_state.x1 == 7
+
+
+def test_execute_traces_list():
+    sim = CDC6600Simulator()
+    result = sim.execute(simple_prog())
+    assert isinstance(result.traces, list)
+    assert len(result.traces) > 0
+
+
+def test_execute_no_error_on_success():
+    sim = CDC6600Simulator()
+    result = sim.execute(simple_prog())
+    assert result.error is None
+
+
+def test_execute_max_steps_exceeded():
+    sim = CDC6600Simulator()
+    from cdc6600_simulator.simulator import F_JMP
+    inf_loop = long_instr(F_JMP, 0, 0, 0)  # jump to parcel 0 — infinite loop
+    result = sim.execute(inf_loop, max_steps=10)
+    assert not result.ok
+    assert result.error is not None
+
+
+# ── get_state() ───────────────────────────────────────────────────────────────
+
+def test_get_state_returns_cdc6600state():
+    sim = CDC6600Simulator()
+    assert isinstance(sim.get_state(), CDC6600State)
+
+
+def test_get_state_snapshot_not_mutated():
+    sim = CDC6600Simulator()
+    sim.load(simple_prog())
+    snap = sim.get_state()
+    p_before = snap.p
+    sim.step()
+    # The snapshot is frozen — its p is unchanged
+    assert snap.p == p_before
+
+
+def test_get_state_is_frozen():
+    sim = CDC6600Simulator()
+    s = sim.get_state()
+    raised = False
+    try:
+        s.p = 99  # type: ignore[misc]
+    except (AttributeError, TypeError):
+        raised = True
+    assert raised, "Frozen dataclass should not allow attribute assignment"

--- a/code/specs/07t-cdc6600-simulator.md
+++ b/code/specs/07t-cdc6600-simulator.md
@@ -1,0 +1,355 @@
+# Layer 07t — CDC 6600 (1964) Behavioral Simulator
+
+## Overview
+
+The Control Data Corporation 6600 (1964) was the world's **first supercomputer**,
+designed by Seymour Cray at Control Data Corporation.  It ran at 40 MHz with a
+60-bit word architecture and achieved roughly 10 MFLOPS — three times faster than
+any contemporary machine.  It held the title of world's fastest computer until
+1969 when the CDC 7600 (also by Cray) superseded it.
+
+Historical significance:
+- **First machine called a "supercomputer"** — the term was coined for it
+- **Scoreboarding** — first use of out-of-order execution via a hardware scoreboard
+- **10 Peripheral Processors (PPs)** — first use of satellite processors for I/O,
+  freeing the Central Processor (CP) for pure arithmetic
+- **3 register types** — X (operand), A (address), B (index) — an orthogonal design
+  ahead of its time
+- Seymour Cray's first major design; set the template for Cray supercomputers
+
+Comparison with prior simulators in this series:
+
+| Feature | Alpha AXP (07s) | CDC 6600 (07t) |
+|---------|-----------------|----------------|
+| Year    | 1992            | 1964           |
+| Word width | 64 bits      | **60 bits**    |
+| GPRs    | 32 × 64-bit     | 8 × 60-bit (X), 8 × 18-bit (A), 8 × 18-bit (B) |
+| Instruction size | 32-bit fixed | **15-bit or 30-bit**, packed 4 per word |
+| Condition codes | None | None (branches test register directly) |
+| Endianness | Little | **Big** (MSB = bit 59 of each 60-bit word) |
+| Memory words | 64-bit bytes | **60-bit words** |
+
+---
+
+## Architecture
+
+### Register Set
+
+#### X Registers (Operand Registers): X0–X7
+- 8 registers, each **60 bits** wide
+- Hold integer or floating-point operands
+- X0 is a general-purpose register (unlike B0, it is NOT hardwired to zero)
+- All arithmetic results go into an X register
+
+#### A Registers (Address Registers): A0–A7
+- 8 registers, each **18 bits** wide (addresses up to 262,143 words)
+- Hold memory addresses
+- In hardware, writing to A1–A5 automatically triggers a memory **read** into
+  the corresponding X register; writing to A6–A7 triggers a memory **write** from
+  the corresponding X register.  This simulator implements explicit load/store
+  instructions that capture this semantics cleanly.
+- A0 is general-purpose (no automatic memory side effect)
+
+#### B Registers (Index/Increment Registers): B0–B7
+- 8 registers, each **18 bits** wide
+- Used for loop counters, array indices, and integer arithmetic
+- **B0 is hardwired to 0** — reads always return 0; writes are ignored
+
+### Program Counter (P Register)
+- The CDC 6600 calls this the "P" register (for "Parcel")
+- Points to a **parcel address** — word × 4 + parcel_index (0–3)
+- 15-bit instruction advances P by 1; 30-bit instruction advances P by 2
+- Branch target is a parcel address
+
+### Memory
+- Behavioral simulation uses **4096 sixty-bit words** (sufficient for test programs)
+- Real CDC 6600: 131,072 sixty-bit words (1 M-word optional)
+- Big-endian: bit 59 is the most-significant bit of each 60-bit word
+
+### Instruction Packing
+
+Each 60-bit memory word holds **four 15-bit parcels** (p0–p3):
+
+```
+Word bits: [59:45] = parcel 0 (p0, most significant)
+           [44:30] = parcel 1 (p1)
+           [29:15] = parcel 2 (p2)
+           [14: 0] = parcel 3 (p3, least significant)
+```
+
+Instructions are either **15 bits** (one parcel) or **30 bits** (two parcels).
+
+---
+
+## Instruction Formats
+
+### Format 1 — Short (15 bits)
+
+```
+Bits [14:9] = f   (6-bit opcode)
+Bits [ 8:6] = i   (3-bit destination register index)
+Bits [ 5:3] = j   (3-bit source register index, left operand)
+Bits [ 2:0] = k   (3-bit source register index, right operand)
+```
+
+Used for register-to-register operations.  Examples:
+- `Xi = Xj + Xk` (integer add)
+- `Xi = Xj & Xk` (boolean AND)
+- `Bi = Bj + Bk` (B-register add)
+
+### Format 2 — Long (30 bits)
+
+```
+Bits [29:24] = f   (6-bit opcode)
+Bits [23:21] = i   (3-bit destination register index)
+Bits [20:18] = j   (3-bit source register index)
+Bits [17: 0] = K   (18-bit constant, address, or branch target)
+```
+
+Used for load-immediate, memory access, and branches.
+
+### HALT Instruction
+- HALT is encoded as a **15-bit all-zeros parcel** (`0x0000`)
+- When the simulator encounters parcel value 0x0000, execution stops
+- An uninitialised memory region (all zeros) will halt immediately — convenient
+  for test programs that fall off the end of their code
+
+---
+
+## Instruction Set (Subset Implemented)
+
+Opcodes are given in decimal and octal (CDC documentation used octal).
+
+### Format 1 — Register-to-Register (15 bits)
+
+| f (dec) | f (oct) | Mnemonic | Operation |
+|---------|---------|----------|-----------|
+| 1  | 01 | TXB  | Xi = zero_extend60(Bj) |
+| 2  | 02 | TBX  | Bi = Xj[17:0] |
+| 3  | 03 | TAX  | Xi = zero_extend60(Aj) |
+| 4  | 04 | TXA  | Ai = Xj[17:0] |
+| 5  | 05 | IXPB | Xi = Xj + zero_extend60(Bk) (integer add X+B) |
+| 6  | 06 | IXMB | Xi = Xj - zero_extend60(Bk) (integer subtract X-B) |
+| 7  | 07 | IXXP | Xi = Xj + Xk (integer add X+X, 60-bit) |
+| 8  | 10 | IXXM | Xi = Xj - Xk (integer subtract X-X, 60-bit) |
+| 9  | 11 | BXND | Xi = Xj & Xk (boolean AND) |
+| 10 | 12 | BXOR | Xi = Xj \| Xk (boolean OR) |
+| 11 | 13 | BXXR | Xi = Xj ^ Xk (boolean XOR, "exclusive or") |
+| 12 | 14 | BXMR | Xi = ~Xj (boolean complement; k ignored) |
+| 13 | 15 | LSHL | Xi = Xj << (Bk & 63) (logical shift left) |
+| 14 | 16 | LSHR | Xi = Xj >> (Bk & 63) (logical shift right, zero-fill) |
+| 15 | 17 | IBBP | Bi = Bj + Bk (B-register integer add, 18-bit) |
+| 16 | 20 | IBBM | Bi = Bj - Bk (B-register integer subtract, 18-bit) |
+| 17 | 21 | IAAP | Ai = Aj + Bk (address register add, 18-bit) |
+| 18 | 22 | IAAM | Ai = Aj - Bk (address register subtract, 18-bit) |
+| 19 | 23 | CMPEQ | Bi = 1 if Xj == Xk else 0 (compare into B) |
+| 20 | 24 | CMPLT | Bi = 1 if signed(Xj) < signed(Xk) else 0 |
+| 21 | 25 | CMPGT | Bi = 1 if signed(Xj) > signed(Xk) else 0 |
+| 22 | 26 | IXMUL | Xi = (Xj * Xk)[59:0] (lower 60 bits of integer multiply) |
+
+### Format 2 — Long / Immediate (30 bits)
+
+| f (dec) | f (oct) | Mnemonic | Operation |
+|---------|---------|----------|-----------|
+| 32 | 40 | LDXI | Xi = K (load 18-bit zero-extended constant into Xi) |
+| 33 | 41 | LDBI | Bi = K (load 18-bit constant into Bi) |
+| 34 | 42 | LDAI | Ai = K (load 18-bit constant into Ai) |
+| 35 | 43 | LDX  | Xi = mem[Aj + K] (load Xi from memory at word address Aj+K) |
+| 36 | 44 | STX  | mem[Ai + K] = Xj (store Xj to memory) |
+| 37 | 45 | LDB  | Bi = mem[Aj + K][17:0] (load lower 18 bits of word into Bi) |
+| 38 | 46 | STB  | mem[Ai + K][17:0] = Bj (store Bj into lower 18 bits of word) |
+| 40 | 50 | JEQ  | if Bj == 0: P = K (conditional branch, jump if B zero) |
+| 41 | 51 | JNE  | if Bj != 0: P = K |
+| 42 | 52 | JXZ  | if Xj == 0: P = K (jump if X register zero) |
+| 43 | 53 | JXN  | if Xj != 0: P = K |
+| 44 | 54 | JMP  | P = K (unconditional branch to parcel address K) |
+| 45 | 55 | JSR  | B7 = P+2; P = K (call: save return parcel addr in B7) |
+| 46 | 56 | RET  | P = Bj (return: jump to parcel address in Bj) |
+
+---
+
+## Signed Integer Convention
+
+The CDC 6600 uses **one's-complement** arithmetic for negative numbers (different
+from the two's-complement used by all modern processors).  However, this simulator
+uses **Python's arbitrary-precision integers** with explicit masking to 60 bits, and
+interprets sign via bit 59 (the most-significant bit):
+
+```
+Positive: bit59 == 0, value in [0, 2^59 - 1]
+Negative: bit59 == 1, value = -(~x & MASK60) in one's-complement terms
+```
+
+For simplicity, this simulator uses **two's-complement** semantics internally
+(standard Python int), masked to 60 bits.  The behaviour of CMPLT/CMPGT uses
+Python's `ctypes.c_int64` sign-extension truncated to 60 bits (bit 59 as sign).
+Programs that don't rely on one's-complement edge cases will behave identically.
+
+---
+
+## SIM00 Protocol
+
+```python
+class CDC6600Simulator(Simulator[CDC6600State]):
+    def reset(self) -> None: ...
+    def load(self, program: bytes) -> None: ...
+    def step(self) -> StepTrace: ...
+    def execute(self, program: bytes, max_steps: int = 100_000) -> ExecutionResult: ...
+    def get_state(self) -> CDC6600State: ...
+```
+
+`CDC6600State` is a `frozen=True` dataclass:
+
+```python
+@dataclass(frozen=True)
+class CDC6600State:
+    p:      int                 # parcel address (word*4 + parcel_index)
+    x:      tuple[int, ...]     # 8 × 60-bit operand registers (X0–X7)
+    a:      tuple[int, ...]     # 8 × 18-bit address registers (A0–A7)
+    b:      tuple[int, ...]     # 8 × 18-bit index registers (B0–B7, B0==0)
+    memory: tuple[int, ...]     # 4096 × 60-bit words
+    halted: bool
+```
+
+Convenience properties on `CDC6600State`: `.x0`–`.x7`, `.a0`–`.a7`, `.b0`–`.b7`.
+
+---
+
+## Program Encoding Helpers
+
+Programs are passed as `bytes`.  Each pair of bytes encodes one 15-bit parcel
+(big-endian, high byte first, high-nibble padding):
+
+```python
+def parcel(f, i, j, k):
+    """Encode a 15-bit short instruction."""
+    return ((f & 0x3F) << 9 | (i & 7) << 6 | (j & 7) << 3 | (k & 7)).to_bytes(2, "big")
+
+def long_instr(f, i, j, K):
+    """Encode a 30-bit long instruction as 4 bytes."""
+    word = (f & 0x3F) << 24 | (i & 7) << 21 | (j & 7) << 18 | (K & 0x3FFFF)
+    return word.to_bytes(4, "big")
+
+HALT = b"\x00\x00"   # 15-bit all-zeros parcel
+```
+
+The `load()` method packs parcels from the byte stream into 60-bit memory words
+(4 parcels per word, big-endian).
+
+---
+
+## Package Layout
+
+```
+code/packages/python/cdc6600-simulator/
+├── pyproject.toml
+├── README.md
+├── CHANGELOG.md
+├── src/
+│   └── cdc6600_simulator/
+│       ├── __init__.py
+│       ├── py.typed
+│       ├── state.py        (CDC6600State, constants)
+│       └── simulator.py    (CDC6600Simulator — instruction dispatch)
+└── tests/
+    ├── test_protocol.py
+    ├── test_instructions.py
+    ├── test_programs.py
+    └── test_coverage.py
+```
+
+---
+
+## Design Notes
+
+### Why 60-bit Words?
+
+Seymour Cray chose 60 bits as the word size to get the best balance of precision for
+scientific computation (more than 32-bit IEEE float but achievable in discrete logic)
+while avoiding 64 bits (which would have required more hardware).  The 60-bit word
+gives 48 bits of mantissa for floating-point — far more precise than the 23-bit
+single-precision float later standardized.
+
+### Why 3 Register Types?
+
+X registers hold large 60-bit quantities (floating-point and integer values).
+A and B registers are smaller (18 bits) because address spaces in 1964 were
+measured in thousands of words, not gigabytes.  Having separate narrow registers for
+addresses and loop counters freed the X registers entirely for data — an early form
+of architectural register classification.
+
+### Scoreboarding (Hardware, Omitted Here)
+
+The real CDC 6600 could execute up to 10 instructions in parallel across 8 functional
+units.  The scoreboard tracked which functional units were in use and stalled only
+when a true data dependency existed.  This behavioral simulator executes all
+instructions sequentially — the functional units and scoreboard are invisible to
+programs that do not rely on precise timing.
+
+### Why One's-Complement? (And Why We Approximate)
+
+One's-complement arithmetic was preferred in 1964 because it simplified hardware
+design (no carry-propagation needed for the "end-around carry" trick).  It also means
+there are two representations of zero (+0 and −0), which affects comparison semantics.
+For this behavioral simulator, two's-complement is used throughout (standard Python
+ints), and the single edge case (−0 vs +0) is irrelevant to instruction-set testing.
+
+---
+
+## Simplifications
+
+1. **No floating-point** — X registers hold 60-bit integers; FP instructions omitted
+2. **No peripheral processors (PPs)** — No I/O simulation
+3. **Two's-complement integers** — Not true one's-complement (edge cases differ)
+4. **4096-word memory** — Truncated from 131,072 words
+5. **No scoreboarding** — Sequential execution only
+6. **No exchange jump** — The CDC 6600's context-switch instruction is omitted
+7. **B7 is the link register** — JSR saves return parcel address in B7 (convention
+   used in this simulator; the hardware had no dedicated link register)
+
+---
+
+## Test Plan
+
+| Test module | What it covers |
+|-------------|----------------|
+| test_protocol.py | SIM00 compliance: all 5 methods, return types |
+| test_protocol.py | reset() zeros all state; P=0 |
+| test_protocol.py | load() packs bytes into 60-bit words |
+| test_protocol.py | execute() returns ExecutionResult |
+| test_protocol.py | step() returns StepTrace with pc_before/pc_after |
+| test_protocol.py | get_state() is frozen; step() does not mutate snapshot |
+| test_instructions.py | TXB: Xi = Bj (B to X transmit) |
+| test_instructions.py | TBX: Bi = Xj[17:0] (X to B transmit) |
+| test_instructions.py | TAX: Xi = Aj (A to X transmit) |
+| test_instructions.py | TXA: Ai = Xj[17:0] (X to A transmit) |
+| test_instructions.py | IXPB: Xi = Xj + Bk (add B into X) |
+| test_instructions.py | IXMB: Xi = Xj - Bk |
+| test_instructions.py | IXXP: Xi = Xj + Xk (integer add X+X) |
+| test_instructions.py | IXXM: Xi = Xj - Xk |
+| test_instructions.py | BXND, BXOR, BXXR, BXMR (boolean ops) |
+| test_instructions.py | LSHL, LSHR (shift by Bk) |
+| test_instructions.py | IBBP, IBBM (B-register integer arithmetic) |
+| test_instructions.py | IAAP, IAAM (A-register arithmetic) |
+| test_instructions.py | CMPEQ, CMPLT, CMPGT (compare into B) |
+| test_instructions.py | IXMUL: lower 60 bits of multiply |
+| test_instructions.py | LDXI, LDBI, LDAI (load immediate) |
+| test_instructions.py | LDX, STX (load/store X registers) |
+| test_instructions.py | LDB, STB (load/store B registers via memory) |
+| test_instructions.py | JEQ, JNE (branch on B register) |
+| test_instructions.py | JXZ, JXN (branch on X register) |
+| test_instructions.py | JMP (unconditional branch) |
+| test_instructions.py | JSR/RET (subroutine call/return via B7) |
+| test_coverage.py | B0 hardwired zero (writes ignored) |
+| test_coverage.py | HALT on all-zeros parcel |
+| test_coverage.py | Unknown opcode raises ValueError |
+| test_coverage.py | max_steps guard terminates infinite loop |
+| test_coverage.py | 60-bit mask: arithmetic stays within 60 bits |
+| test_coverage.py | A/B register 18-bit mask |
+| test_coverage.py | Memory bounds checking |
+| test_programs.py | Sum 1–10 using IXXP + JNE loop |
+| test_programs.py | Factorial 5! using IXMUL + JNE loop |
+| test_programs.py | Fibonacci using LDX/STX + loop |
+| test_programs.py | Subroutine call/return using JSR/RET |
+| test_programs.py | Array sum using LDX + IAAP loop |
+| test_programs.py | Boolean operations: XOR-based swap |


### PR DESCRIPTION
## Summary

- Implements Layer 07t: a behavioral simulator for the CDC 6600 (1964), the world's first supercomputer, designed by Seymour Cray
- Conforms to the SIM00 `Simulator[CDC6600State]` protocol with `reset()`, `load()`, `step()`, `execute()`, and `get_state()`
- 22 short instructions (register transfers, arithmetic, logic, shifts, comparisons) + 14 long instructions (immediate loads, memory ops, branches, subroutine call/return)
- 60-bit word architecture with three register banks: X[8] (60-bit operand), A[8] (18-bit address), B[8] (18-bit index, B0 hardwired zero)
- Variable-length instruction encoding: 15-bit parcels (4 per 60-bit word), short instructions = 1 parcel, long instructions = 2 parcels

## Test plan

- [x] 109 tests passing across 4 test files (protocol, instructions, coverage, programs)
- [x] 95%+ test coverage
- [x] End-to-end programs: sum 1–10, factorial 5!, Fibonacci F(9), subroutine call/return, array sum, XOR swap, countdown loop, max of two values, memory copy
- [x] ruff clean (no lint errors)
- [x] Security review passed — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)