### PR TITLE
Wire TypeScript MACSYMA list operations

### DIFF
--- a/code/packages/typescript/macsyma-runtime/BUILD
+++ b/code/packages/typescript/macsyma-runtime/BUILD
@@ -9,6 +9,7 @@ cd ../symbolic-vm && npm ci --quiet
 cd ../macsyma-lexer && npm ci --quiet
 cd ../macsyma-parser && npm ci --quiet
 cd ../macsyma-compiler && npm ci --quiet
+cd ../cas-list-operations && npm ci --quiet
 cd ../cas-solve && npm ci --quiet
 npm ci --quiet
 npx vitest run --coverage

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Wire deterministic MACSYMA list heads (`Length`, `First`, `Rest`, `Last`,
+  `Append`, `Reverse`, `Range`, `Map`, `Apply`, `Sort`, `Part`, `Flatten`,
+  and `Join`) to the TypeScript `cas-list-operations` package.
 - Wire direct `Solve(f(linear) = constant, var)` transcendental equations to
   the TypeScript `cas-solve` `trySolveTranscendental` handler, returning
   `List(...)` symbolic inverse and periodic-family solutions.

--- a/code/packages/typescript/macsyma-runtime/README.md
+++ b/code/packages/typescript/macsyma-runtime/README.md
@@ -16,5 +16,8 @@ This first runtime slice is intentionally small and browser-friendly:
   inequality solver for interval predicates
 - dispatches direct `Solve(f(linear) = constant, var)` transcendental
   equations to the `cas-solve` inverse-family solver
+- dispatches deterministic list operations such as `Length`, `First`, `Rest`,
+  `Last`, `Append`, `Reverse`, `Range`, `Map`, `Apply`, `Sort`, `Part`,
+  `Flatten`, and `Join` to `cas-list-operations`
 - exposes a JSON helper whose recursive IR representation is safe for
   `JSON.stringify`

--- a/code/packages/typescript/macsyma-runtime/package-lock.json
+++ b/code/packages/typescript/macsyma-runtime/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
         "@coding-adventures/cas-solve": "file:../cas-solve",
         "@coding-adventures/directed-graph": "file:../directed-graph",
         "@coding-adventures/grammar-tools": "file:../grammar-tools",
@@ -23,6 +24,19 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-list-operations": {
+      "name": "@coding-adventures/cas-list-operations",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
@@ -264,6 +278,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/cas-list-operations": {
+      "resolved": "../cas-list-operations",
+      "link": true
     },
     "node_modules/@coding-adventures/cas-solve": {
       "resolved": "../cas-solve",

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -21,6 +21,7 @@
     "@coding-adventures/macsyma-parser": "file:../macsyma-parser",
     "@coding-adventures/parser": "file:../parser",
     "@coding-adventures/state-machine": "file:../state-machine",
+    "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
     "@coding-adventures/cas-solve": "file:../cas-solve",
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
     "@coding-adventures/symbolic-vm": "file:../symbolic-vm"

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -1,4 +1,18 @@
 import { compileMacsyma } from "@coding-adventures/macsyma-compiler";
+import {
+  append,
+  applyList,
+  first,
+  flatten,
+  last,
+  length,
+  mapList,
+  part,
+  range as rangeList,
+  rest,
+  reverse,
+  sortList,
+} from "@coding-adventures/cas-list-operations";
 import { solveLinearSystem, trySolveInequality, trySolveTranscendental } from "@coding-adventures/cas-solve";
 import {
   ACOS,
@@ -50,6 +64,19 @@ export const EXPAND = sym("Expand");
 export const RAT_SIMPLIFY = sym("RatSimplify");
 export const TRIG_SIMPLIFY = sym("TrigSimplify");
 export const FLOAT_FUNC = sym("Float");
+export const LENGTH = sym("Length");
+export const FIRST = sym("First");
+export const REST = sym("Rest");
+export const LAST = sym("Last");
+export const APPEND = sym("Append");
+export const REVERSE = sym("Reverse");
+export const RANGE = sym("Range");
+export const MAP = sym("Map");
+export const APPLY = sym("Apply");
+export const SORT = sym("Sort");
+export const PART = sym("Part");
+export const FLATTEN = sym("Flatten");
+export const JOIN = sym("Join");
 
 export const MACSYMA_NAME_TABLE: ReadonlyMap<string, IRSymbol> = new Map<string, IRSymbol>([
   ["diff", D],
@@ -84,20 +111,20 @@ export const MACSYMA_NAME_TABLE: ReadonlyMap<string, IRSymbol> = new Map<string,
   ["taylor", sym("Taylor")],
   ["limit", sym("Limit")],
   ["float", FLOAT_FUNC],
-  ["length", sym("Length")],
-  ["first", sym("First")],
-  ["rest", sym("Rest")],
-  ["last", sym("Last")],
-  ["append", sym("Append")],
-  ["reverse", sym("Reverse")],
+  ["length", LENGTH],
+  ["first", FIRST],
+  ["rest", REST],
+  ["last", LAST],
+  ["append", APPEND],
+  ["reverse", REVERSE],
   ["makelist", sym("MakeList")],
-  ["map", sym("Map")],
-  ["apply", sym("Apply")],
+  ["map", MAP],
+  ["apply", APPLY],
   ["sublist", sym("Select")],
-  ["sort", sym("Sort")],
-  ["part", sym("Part")],
-  ["flatten", sym("Flatten")],
-  ["join", sym("Join")],
+  ["sort", SORT],
+  ["part", PART],
+  ["flatten", FLATTEN],
+  ["join", JOIN],
   ["matrix", sym("Matrix")],
   ["transpose", sym("Transpose")],
   ["determinant", sym("Determinant")],
@@ -281,6 +308,19 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(KILL.name, makeKillHandler(this));
     table.set(EV.name, makeEvHandler());
     table.set(SOLVE.name, solveHandler);
+    table.set(LENGTH.name, listHandler(1, ([value]) => length(value)));
+    table.set(FIRST.name, listHandler(1, ([value]) => first(value)));
+    table.set(REST.name, listHandler(1, ([value]) => rest(value)));
+    table.set(LAST.name, listHandler(1, ([value]) => last(value)));
+    table.set(REVERSE.name, listHandler(1, ([value]) => reverse(value)));
+    table.set(APPEND.name, listHandler(null, (args) => append(...args)));
+    table.set(JOIN.name, listHandler(null, (args) => append(...args)));
+    table.set(RANGE.name, listHandler(null, rangeHandler));
+    table.set(MAP.name, listHandler(2, ([head, value]) => mapList(head, value)));
+    table.set(APPLY.name, listHandler(2, ([head, value]) => applyList(head, value)));
+    table.set(SORT.name, listHandler(1, ([value]) => sortList(value)));
+    table.set(PART.name, listHandler(2, ([value, index]) => part(value, integerArgument(index))));
+    table.set(FLATTEN.name, listHandler(null, flattenHandler));
     this.runtimeTable = table;
     this.runtimeHeld = new Set([...super.holdHeads(), KILL.name, EV.name, SOLVE.name]);
   }
@@ -559,6 +599,43 @@ function solveHandler(_vm: VM, expr: IRApply): IRNode {
 
   const rules = solveLinearSystem(equationsNode.args, variables);
   return rules === null ? expr : app(LIST, rules);
+}
+
+function listHandler(
+  arity: number | null,
+  body: (args: readonly IRNode[]) => IRNode,
+): Handler {
+  return (_vm, expr) => {
+    if (arity !== null && expr.args.length !== arity) return expr;
+    try {
+      return body(expr.args);
+    } catch {
+      return expr;
+    }
+  };
+}
+
+function rangeHandler(args: readonly IRNode[]): IRNode {
+  if (args.length < 1 || args.length > 3) throw new Error("Range takes 1 to 3 arguments");
+  const start = integerArgument(args[0]);
+  const stop = args.length >= 2 ? integerArgument(args[1]) : undefined;
+  const step = args.length >= 3 ? integerArgument(args[2]) : 1;
+  return rangeList(start, stop, step);
+}
+
+function flattenHandler(args: readonly IRNode[]): IRNode {
+  if (args.length < 1 || args.length > 2) throw new Error("Flatten takes 1 or 2 arguments");
+  const depth = args.length === 2 ? integerArgument(args[1]) : 1;
+  return flatten(args[0], depth);
+}
+
+function integerArgument(node: IRNode): number {
+  if (node.kind !== "integer") throw new Error("expected integer argument");
+  const value = Number(node.value);
+  if (!Number.isSafeInteger(value) || BigInt(value) !== node.value) {
+    throw new Error("integer argument is outside the safe integer range");
+  }
+  return value;
 }
 
 function isInequality(node: IRNode): node is IRApply {

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -24,15 +24,28 @@ import {
 import { VM } from "@coding-adventures/symbolic-vm";
 import {
   ALL_SYMBOL,
+  APPEND,
+  APPLY,
   DISPLAY,
   EV,
   EXPAND,
+  FIRST,
+  FLATTEN,
   History,
+  JOIN,
   KILL,
+  LAST,
+  LENGTH,
   MACSYMA_NAME_TABLE,
   MacsymaBackend,
   MacsymaSession,
+  MAP,
+  PART,
   RAT_SIMPLIFY,
+  RANGE,
+  REST,
+  REVERSE,
+  SORT,
   SUPPRESS,
   extendCompilerNameTable,
   evalSourceJson,
@@ -169,6 +182,7 @@ describe("macsyma-runtime", () => {
     expect(backend.handlers().has(KILL.name)).toBe(true);
     expect(backend.handlers().has(EV.name)).toBe(true);
     expect(backend.handlers().has(SOLVE.name)).toBe(true);
+    expect(backend.handlers().has(LENGTH.name)).toBe(true);
     expect(backend.holdHeads().has(KILL.name)).toBe(true);
     expect(backend.holdHeads().has(EV.name)).toBe(true);
     expect(backend.holdHeads().has(SOLVE.name)).toBe(true);
@@ -364,6 +378,68 @@ describe("macsyma-runtime", () => {
 
     const [result] = session.evalStatements([expr]);
     expect(result.output).toEqual(expr);
+  });
+
+  it("evaluates deterministic list operations through cas-list-operations", () => {
+    const xs = app(LIST, [int(1), int(2), int(3)]);
+    const nested = app(LIST, [int(1), app(LIST, [int(2), app(LIST, [int(3)])])]);
+    const session = new MacsymaSession();
+    const [
+      lengthResult,
+      firstResult,
+      restResult,
+      lastResult,
+      reverseResult,
+      appendResult,
+      joinResult,
+      rangeResult,
+      partResult,
+      mapResult,
+      applyResult,
+      sortResult,
+      flattenResult,
+    ] = session.evalStatements([
+      app(LENGTH, [xs]),
+      app(FIRST, [xs]),
+      app(REST, [xs]),
+      app(LAST, [xs]),
+      app(REVERSE, [xs]),
+      app(APPEND, [app(LIST, [int(1)]), app(LIST, [int(2), int(3)])]),
+      app(JOIN, [app(LIST, [int(1)]), app(LIST, [int(2)])]),
+      app(RANGE, [int(1), int(5), int(2)]),
+      app(PART, [xs, int(-1)]),
+      app(MAP, [sym("f"), app(LIST, [sym("x"), sym("y")])]),
+      app(APPLY, [ADD, app(LIST, [sym("x"), sym("y")])]),
+      app(SORT, [app(LIST, [sym("b"), sym("a")])]),
+      app(FLATTEN, [nested, int(-1)]),
+    ]);
+
+    expect(lengthResult.output).toEqual(int(3));
+    expect(firstResult.output).toEqual(int(1));
+    expect(restResult.output).toEqual(app(LIST, [int(2), int(3)]));
+    expect(lastResult.output).toEqual(int(3));
+    expect(reverseResult.output).toEqual(app(LIST, [int(3), int(2), int(1)]));
+    expect(appendResult.output).toEqual(app(LIST, [int(1), int(2), int(3)]));
+    expect(joinResult.output).toEqual(app(LIST, [int(1), int(2)]));
+    expect(rangeResult.output).toEqual(app(LIST, [int(1), int(3), int(5)]));
+    expect(partResult.output).toEqual(int(3));
+    expect(mapResult.output).toEqual(app(LIST, [
+      app(sym("f"), [sym("x")]),
+      app(sym("f"), [sym("y")]),
+    ]));
+    expect(applyResult.output).toEqual(app(ADD, [sym("x"), sym("y")]));
+    expect(sortResult.output).toEqual(app(LIST, [sym("a"), sym("b")]));
+    expect(flattenResult.output).toEqual(app(LIST, [int(1), int(2), int(3)]));
+  });
+
+  it("keeps invalid list operation calls unevaluated", () => {
+    const session = new MacsymaSession();
+    const badPart = app(PART, [app(LIST, [int(1)]), int(0)]);
+    const badLength = app(LENGTH, [sym("x")]);
+    const [partResult, lengthResult] = session.evalStatements([badPart, badLength]);
+
+    expect(partResult.output).toEqual(badPart);
+    expect(lengthResult.output).toEqual(badLength);
   });
 
   it("returns rational linsolve results", () => {

--- a/code/programs/typescript/macsyma-browser-repl/BUILD
+++ b/code/programs/typescript/macsyma-browser-repl/BUILD
@@ -9,6 +9,7 @@ cd ../../../packages/typescript/symbolic-vm && npm ci --quiet
 cd ../../../packages/typescript/macsyma-lexer && npm ci --quiet
 cd ../../../packages/typescript/macsyma-parser && npm ci --quiet
 cd ../../../packages/typescript/macsyma-compiler && npm ci --quiet
+cd ../../../packages/typescript/cas-list-operations && npm ci --quiet
 cd ../../../packages/typescript/cas-solve && npm ci --quiet
 cd ../../../packages/typescript/macsyma-runtime && npm ci --quiet
 npm ci --quiet


### PR DESCRIPTION
## Summary
- wire deterministic TypeScript MACSYMA list heads through `cas-list-operations`
- support `Length`, `First`, `Rest`, `Last`, `Append`, `Join`, `Reverse`, `Range`, `Part`, `Map`, `Apply`, `Sort`, and `Flatten`
- preserve unevaluated fallback behavior for invalid list calls and update standalone BUILD prerequisites

## Validation
- `npm install` in `code/packages/typescript/macsyma-runtime`
- `npm test && npm run build` in `code/packages/typescript/macsyma-runtime`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-list-runtime.json` from `code/programs/go/build-tool`