### PR TITLE
Wire Rust MACSYMA list operations

### DIFF
--- a/code/packages/rust/macsyma-runtime/BUILD
+++ b/code/packages/rust/macsyma-runtime/BUILD
@@ -1,1 +1,1 @@
-cargo test -p cas-solve -p coding-adventures-macsyma-runtime -- --nocapture
+cargo test -p cas-list-operations -p cas-solve -p coding-adventures-macsyma-runtime -- --nocapture

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Wired deterministic MACSYMA list heads (`Length`, `First`, `Rest`, `Last`,
+  `Append`, `Join`, `Reverse`, `Range`, `Part`, `Map`, `Apply`, `Sort`, and
+  `Flatten`) to the Rust `cas-list-operations` package.
 - Wired direct `Solve(f(linear) = constant, variable)` transcendental equations
   to the Rust `cas-solve` `try_solve_transcendental` handler, returning
   `List(...)` symbolic inverse and periodic-family solutions.

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -6,6 +6,7 @@ description = "MACSYMA runtime session facade over the Rust symbolic VM"
 license = "MIT"
 
 [dependencies]
+cas-list-operations = { path = "../cas-list-operations" }
 cas-solve = { path = "../cas-solve" }
 cas-simplify = { path = "../cas-simplify" }
 cas-trig = { path = "../cas-trig" }

--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -28,3 +28,8 @@ Direct `Solve(f(linear) = constant, variable)` transcendental equations delegate
 to the Rust `cas-solve` inverse-family solver. Supported `Exp`, `Log`, trig,
 and hyperbolic forms return `List(...)` symbolic inverse or periodic-family
 solutions; unsupported nested forms remain unevaluated.
+
+Deterministic list operations delegate to the Rust `cas-list-operations`
+package. `Length`, `First`, `Rest`, `Last`, `Append`, `Join`, `Reverse`,
+`Range`, `Part`, `Map`, `Apply`, `Sort`, and `Flatten` return list-operation
+results while invalid calls remain unevaluated.

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -7,6 +7,10 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
+use cas_list_operations::{
+    append, apply_ as list_apply, first, flatten, join, last, length, map_ as list_map, part,
+    range_ as list_range, rest, reverse, sort_, ListOperationError, ListResult,
+};
 use cas_simplify::simplify;
 use cas_solve::{solve_linear_system, try_solve_inequality, try_solve_transcendental, SOLVE};
 use cas_trig::{expand_trig, trig_simplify};
@@ -45,6 +49,19 @@ const RAT_SIMPLIFY: &str = "RatSimplify";
 const SIMPLIFY: &str = "Simplify";
 const TRIG_EXPAND: &str = "TrigExpand";
 const TRIG_SIMPLIFY: &str = "TrigSimplify";
+const LENGTH: &str = "Length";
+const FIRST: &str = "First";
+const REST: &str = "Rest";
+const LAST: &str = "Last";
+const APPEND: &str = "Append";
+const REVERSE: &str = "Reverse";
+const RANGE: &str = "Range";
+const MAP: &str = "Map";
+const APPLY_HEAD: &str = "Apply";
+const SORT: &str = "Sort";
+const PART: &str = "Part";
+const FLATTEN: &str = "Flatten";
+const JOIN: &str = "Join";
 
 /// Return the runtime extension table for MACSYMA surface function names.
 ///
@@ -77,20 +94,20 @@ const MACSYMA_NAME_TABLE: &[(&str, &str)] = &[
     ("linsolve", "Solve"),
     ("taylor", "Taylor"),
     ("limit", "Limit"),
-    ("length", "Length"),
-    ("first", "First"),
-    ("rest", "Rest"),
-    ("last", "Last"),
-    ("append", "Append"),
-    ("reverse", "Reverse"),
+    ("length", LENGTH),
+    ("first", FIRST),
+    ("rest", REST),
+    ("last", LAST),
+    ("append", APPEND),
+    ("reverse", REVERSE),
     ("makelist", "MakeList"),
-    ("map", "Map"),
-    ("apply", "Apply"),
+    ("map", MAP),
+    ("apply", APPLY_HEAD),
     ("sublist", "Select"),
-    ("sort", "Sort"),
-    ("part", "Part"),
-    ("flatten", "Flatten"),
-    ("join", "Join"),
+    ("sort", SORT),
+    ("part", PART),
+    ("flatten", FLATTEN),
+    ("join", JOIN),
     ("matrix", "Matrix"),
     ("transpose", "Transpose"),
     ("determinant", "Determinant"),
@@ -332,6 +349,46 @@ impl MacsymaBackend {
         handlers.insert(RAT_SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(TRIG_SIMPLIFY.to_string(), handler_fn(trig_simplify_handler));
         handlers.insert(TRIG_EXPAND.to_string(), handler_fn(trig_expand_handler));
+        handlers.insert(
+            LENGTH.to_string(),
+            list_handler(Some(1), |args| length(&args[0])),
+        );
+        handlers.insert(
+            FIRST.to_string(),
+            list_handler(Some(1), |args| first(&args[0])),
+        );
+        handlers.insert(
+            REST.to_string(),
+            list_handler(Some(1), |args| rest(&args[0])),
+        );
+        handlers.insert(
+            LAST.to_string(),
+            list_handler(Some(1), |args| last(&args[0])),
+        );
+        handlers.insert(
+            REVERSE.to_string(),
+            list_handler(Some(1), |args| reverse(&args[0])),
+        );
+        handlers.insert(APPEND.to_string(), list_handler(None, append));
+        handlers.insert(JOIN.to_string(), list_handler(None, join));
+        handlers.insert(RANGE.to_string(), list_handler(None, range_handler));
+        handlers.insert(
+            MAP.to_string(),
+            list_handler(Some(2), |args| list_map(args[0].clone(), &args[1])),
+        );
+        handlers.insert(
+            APPLY_HEAD.to_string(),
+            list_handler(Some(2), |args| list_apply(args[0].clone(), &args[1])),
+        );
+        handlers.insert(
+            SORT.to_string(),
+            list_handler(Some(1), |args| sort_(&args[0])),
+        );
+        handlers.insert(
+            PART.to_string(),
+            list_handler(Some(2), |args| part(&args[0], integer_argument(&args[1])?)),
+        );
+        handlers.insert(FLATTEN.to_string(), list_handler(None, flatten_handler));
 
         let kill_state = state.clone();
         handlers.insert(
@@ -635,6 +692,56 @@ fn solve_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     solve_linear_system(&equations.args, &variables.args)
         .map(|rules| apply(sym(LIST), rules))
         .unwrap_or(fallback)
+}
+
+fn list_handler<F>(arity: Option<usize>, body: F) -> Handler
+where
+    F: Fn(&[IRNode]) -> ListResult<IRNode> + Send + Sync + 'static,
+{
+    Arc::new(move |_vm, expr| {
+        let fallback = IRNode::Apply(Box::new(expr.clone()));
+        if arity.is_some_and(|expected| expr.args.len() != expected) {
+            return fallback;
+        }
+        body(&expr.args).unwrap_or(fallback)
+    })
+}
+
+fn range_handler(args: &[IRNode]) -> ListResult<IRNode> {
+    if !(1..=3).contains(&args.len()) {
+        return Err(ListOperationError("Range takes 1 to 3 arguments".into()));
+    }
+    let start = integer_argument(&args[0])?;
+    let stop = if args.len() >= 2 {
+        Some(integer_argument(&args[1])?)
+    } else {
+        None
+    };
+    let step = if args.len() >= 3 {
+        integer_argument(&args[2])?
+    } else {
+        1
+    };
+    list_range(start, stop, step)
+}
+
+fn flatten_handler(args: &[IRNode]) -> ListResult<IRNode> {
+    if !(1..=2).contains(&args.len()) {
+        return Err(ListOperationError("Flatten takes 1 or 2 arguments".into()));
+    }
+    let depth = if args.len() == 2 {
+        integer_argument(&args[1])?
+    } else {
+        1
+    };
+    flatten(&args[0], depth)
+}
+
+fn integer_argument(node: &IRNode) -> ListResult<i64> {
+    match node {
+        IRNode::Integer(value) => Ok(*value),
+        _ => Err(ListOperationError("expected integer argument".into())),
+    }
 }
 
 fn is_inequality(node: &IRNode) -> bool {

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -503,6 +503,107 @@ fn keeps_unsupported_transcendental_solve_calls_unevaluated() {
 }
 
 #[test]
+fn evaluates_deterministic_list_operations_through_cas_list_operations() {
+    let xs = apply(sym(LIST), vec![int(1), int(2), int(3)]);
+    let nested = apply(
+        sym(LIST),
+        vec![
+            int(1),
+            apply(sym(LIST), vec![int(2), apply(sym(LIST), vec![int(3)])]),
+        ],
+    );
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![
+        apply(sym("Length"), vec![xs.clone()]),
+        apply(sym("First"), vec![xs.clone()]),
+        apply(sym("Rest"), vec![xs.clone()]),
+        apply(sym("Last"), vec![xs.clone()]),
+        apply(sym("Reverse"), vec![xs.clone()]),
+        apply(
+            sym("Append"),
+            vec![
+                apply(sym(LIST), vec![int(1)]),
+                apply(sym(LIST), vec![int(2), int(3)]),
+            ],
+        ),
+        apply(
+            sym("Join"),
+            vec![
+                apply(sym(LIST), vec![int(1)]),
+                apply(sym(LIST), vec![int(2)]),
+            ],
+        ),
+        apply(sym("Range"), vec![int(1), int(5), int(2)]),
+        apply(sym("Part"), vec![xs.clone(), int(-1)]),
+        apply(
+            sym("Map"),
+            vec![sym("f"), apply(sym(LIST), vec![sym("x"), sym("y")])],
+        ),
+        apply(
+            sym("Apply"),
+            vec![sym(ADD), apply(sym(LIST), vec![sym("x"), sym("y")])],
+        ),
+        apply(
+            sym("Sort"),
+            vec![apply(sym(LIST), vec![sym("b"), sym("a")])],
+        ),
+        apply(sym("Flatten"), vec![nested, int(-1)]),
+    ]);
+
+    assert_eq!(results[0].output, int(3));
+    assert_eq!(results[1].output, int(1));
+    assert_eq!(results[2].output, apply(sym(LIST), vec![int(2), int(3)]));
+    assert_eq!(results[3].output, int(3));
+    assert_eq!(
+        results[4].output,
+        apply(sym(LIST), vec![int(3), int(2), int(1)])
+    );
+    assert_eq!(
+        results[5].output,
+        apply(sym(LIST), vec![int(1), int(2), int(3)])
+    );
+    assert_eq!(results[6].output, apply(sym(LIST), vec![int(1), int(2)]));
+    assert_eq!(
+        results[7].output,
+        apply(sym(LIST), vec![int(1), int(3), int(5)])
+    );
+    assert_eq!(results[8].output, int(3));
+    assert_eq!(
+        results[9].output,
+        apply(
+            sym(LIST),
+            vec![
+                apply(sym("f"), vec![sym("x")]),
+                apply(sym("f"), vec![sym("y")])
+            ]
+        )
+    );
+    assert_eq!(
+        results[10].output,
+        apply(sym(ADD), vec![sym("x"), sym("y")])
+    );
+    assert_eq!(
+        results[11].output,
+        apply(sym(LIST), vec![sym("a"), sym("b")])
+    );
+    assert_eq!(
+        results[12].output,
+        apply(sym(LIST), vec![int(1), int(2), int(3)])
+    );
+}
+
+#[test]
+fn keeps_invalid_list_operation_calls_unevaluated() {
+    let bad_part = apply(sym("Part"), vec![apply(sym(LIST), vec![int(1)]), int(0)]);
+    let bad_length = apply(sym("Length"), vec![sym("x")]);
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![bad_part.clone(), bad_length.clone()]);
+
+    assert_eq!(results[0].output, bad_part);
+    assert_eq!(results[1].output, bad_length);
+}
+
+#[test]
 fn returns_rational_linsolve_results() {
     let x = sym("x");
     let y = sym("y");


### PR DESCRIPTION
## Summary
- wire deterministic Rust MACSYMA list heads through `cas-list-operations`
- support `Length`, `First`, `Rest`, `Last`, `Append`, `Join`, `Reverse`, `Range`, `Part`, `Map`, `Apply`, `Sort`, and `Flatten`
- preserve unevaluated fallback behavior for invalid list calls and update Rust BUILD coverage

## Validation
- `cargo fmt -p coding-adventures-macsyma-runtime` in `code/packages/rust`
- `cargo test -p cas-list-operations -p cas-solve -p coding-adventures-macsyma-runtime -- --nocapture` in `code/packages/rust`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-macsyma-list-runtime.json` from `code/programs/go/build-tool`