### PR TITLE
Wire TypeScript MACSYMA substitution

### DIFF
--- a/code/packages/typescript/macsyma-runtime/BUILD
+++ b/code/packages/typescript/macsyma-runtime/BUILD
@@ -11,5 +11,6 @@ cd ../macsyma-parser && npm ci --quiet
 cd ../macsyma-compiler && npm ci --quiet
 cd ../cas-list-operations && npm ci --quiet
 cd ../cas-solve && npm ci --quiet
+cd ../cas-substitution && npm ci --quiet
 npm ci --quiet
 npx vitest run --coverage

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Wire `Subst(value, variable, expr)` to the TypeScript `cas-substitution`
+  structural substitution package.
 - Wire deterministic MACSYMA list heads (`Length`, `First`, `Rest`, `Last`,
   `Append`, `Reverse`, `Range`, `Map`, `Apply`, `Sort`, `Part`, `Flatten`,
   and `Join`) to the TypeScript `cas-list-operations` package.

--- a/code/packages/typescript/macsyma-runtime/README.md
+++ b/code/packages/typescript/macsyma-runtime/README.md
@@ -16,6 +16,8 @@ This first runtime slice is intentionally small and browser-friendly:
   inequality solver for interval predicates
 - dispatches direct `Solve(f(linear) = constant, var)` transcendental
   equations to the `cas-solve` inverse-family solver
+- dispatches `Subst(value, variable, expr)` to `cas-substitution`
+  structural substitution
 - dispatches deterministic list operations such as `Length`, `First`, `Rest`,
   `Last`, `Append`, `Reverse`, `Range`, `Map`, `Apply`, `Sort`, `Part`,
   `Flatten`, and `Join` to `cas-list-operations`

--- a/code/packages/typescript/macsyma-runtime/package-lock.json
+++ b/code/packages/typescript/macsyma-runtime/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
         "@coding-adventures/cas-solve": "file:../cas-solve",
+        "@coding-adventures/cas-substitution": "file:../cas-substitution",
         "@coding-adventures/directed-graph": "file:../directed-graph",
         "@coding-adventures/grammar-tools": "file:../grammar-tools",
         "@coding-adventures/lexer": "file:../lexer",
@@ -51,6 +52,19 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-substitution": {
+      "name": "@coding-adventures/cas-substitution",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
@@ -285,6 +299,10 @@
     },
     "node_modules/@coding-adventures/cas-solve": {
       "resolved": "../cas-solve",
+      "link": true
+    },
+    "node_modules/@coding-adventures/cas-substitution": {
+      "resolved": "../cas-substitution",
       "link": true
     },
     "node_modules/@coding-adventures/directed-graph": {

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -23,6 +23,7 @@
     "@coding-adventures/state-machine": "file:../state-machine",
     "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
     "@coding-adventures/cas-solve": "file:../cas-solve",
+    "@coding-adventures/cas-substitution": "file:../cas-substitution",
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
     "@coding-adventures/symbolic-vm": "file:../symbolic-vm"
   },

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -14,6 +14,7 @@ import {
   sortList,
 } from "@coding-adventures/cas-list-operations";
 import { solveLinearSystem, trySolveInequality, trySolveTranscendental } from "@coding-adventures/cas-solve";
+import { subst } from "@coding-adventures/cas-substitution";
 import {
   ACOS,
   ACOSH,
@@ -308,6 +309,7 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(KILL.name, makeKillHandler(this));
     table.set(EV.name, makeEvHandler());
     table.set(SOLVE.name, solveHandler);
+    table.set(SUBST.name, substHandler);
     table.set(LENGTH.name, listHandler(1, ([value]) => length(value)));
     table.set(FIRST.name, listHandler(1, ([value]) => first(value)));
     table.set(REST.name, listHandler(1, ([value]) => rest(value)));
@@ -322,7 +324,7 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(PART.name, listHandler(2, ([value, index]) => part(value, integerArgument(index))));
     table.set(FLATTEN.name, listHandler(null, flattenHandler));
     this.runtimeTable = table;
-    this.runtimeHeld = new Set([...super.holdHeads(), KILL.name, EV.name, SOLVE.name]);
+    this.runtimeHeld = new Set([...super.holdHeads(), KILL.name, EV.name, SOLVE.name, SUBST.name]);
   }
 
   override lookup(name: string): IRNode | undefined {
@@ -599,6 +601,12 @@ function solveHandler(_vm: VM, expr: IRApply): IRNode {
 
   const rules = solveLinearSystem(equationsNode.args, variables);
   return rules === null ? expr : app(LIST, rules);
+}
+
+function substHandler(_vm: VM, expr: IRApply): IRNode {
+  if (expr.args.length !== 3) return expr;
+  const [value, variable, target] = expr.args;
+  return subst(value, variable, target);
 }
 
 function listHandler(

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -15,6 +15,7 @@ import {
   SIN,
   SOLVE,
   SUB,
+  SUBST,
   app,
   int,
   numberNode,
@@ -182,10 +183,12 @@ describe("macsyma-runtime", () => {
     expect(backend.handlers().has(KILL.name)).toBe(true);
     expect(backend.handlers().has(EV.name)).toBe(true);
     expect(backend.handlers().has(SOLVE.name)).toBe(true);
+    expect(backend.handlers().has(SUBST.name)).toBe(true);
     expect(backend.handlers().has(LENGTH.name)).toBe(true);
     expect(backend.holdHeads().has(KILL.name)).toBe(true);
     expect(backend.holdHeads().has(EV.name)).toBe(true);
     expect(backend.holdHeads().has(SOLVE.name)).toBe(true);
+    expect(backend.holdHeads().has(SUBST.name)).toBe(true);
   });
 
   it("kills single and multiple bindings without evaluating names first", () => {
@@ -377,6 +380,38 @@ describe("macsyma-runtime", () => {
     ]);
 
     const [result] = session.evalStatements([expr]);
+    expect(result.output).toEqual(expr);
+  });
+
+  it("evaluates structural substitution through cas-substitution", () => {
+    const x = sym("x");
+    const session = new MacsymaSession();
+    const [simple, compound] = session.evalStatements([
+      app(SUBST, [int(3), x, app(POW, [x, int(2)])]),
+      app(SUBST, [
+        sym("z"),
+        app(ADD, [x, int(1)]),
+        app(MUL, [app(ADD, [x, int(1)]), app(ADD, [x, int(1)])]),
+      ]),
+    ]);
+
+    expect(simple.output).toEqual(app(POW, [int(3), int(2)]));
+    expect(compound.output).toEqual(app(MUL, [sym("z"), sym("z")]));
+  });
+
+  it("keeps substitution variables unevaluated", () => {
+    const session = new MacsymaSession();
+    const [bindResult, substResult] = session.evalSource("x : 5; subst(3, x, x^2);");
+
+    expect(bindResult.output).toEqual(int(5));
+    expect(substResult.output).toEqual(app(POW, [int(3), int(2)]));
+  });
+
+  it("keeps invalid substitution calls unevaluated", () => {
+    const session = new MacsymaSession();
+    const expr = app(SUBST, [int(3), sym("x")]);
+    const [result] = session.evalStatements([expr]);
+
     expect(result.output).toEqual(expr);
   });
 

--- a/code/programs/typescript/macsyma-browser-repl/BUILD
+++ b/code/programs/typescript/macsyma-browser-repl/BUILD
@@ -11,6 +11,7 @@ cd ../../../packages/typescript/macsyma-parser && npm ci --quiet
 cd ../../../packages/typescript/macsyma-compiler && npm ci --quiet
 cd ../../../packages/typescript/cas-list-operations && npm ci --quiet
 cd ../../../packages/typescript/cas-solve && npm ci --quiet
+cd ../../../packages/typescript/cas-substitution && npm ci --quiet
 cd ../../../packages/typescript/macsyma-runtime && npm ci --quiet
 npm ci --quiet
 npm run build


### PR DESCRIPTION
## Summary
- wire TypeScript MACSYMA `Subst(value, variable, expr)` through `cas-substitution`
- keep `Subst` held so substitution variables are not resolved from runtime bindings before replacement
- preserve unevaluated fallback behavior for invalid `Subst` arity and update standalone BUILD prerequisites

## Validation
- `npm install` in `code/packages/typescript/macsyma-runtime`
- `npm test && npm run build` in `code/packages/typescript/macsyma-runtime`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-subst-runtime.json` from `code/programs/go/build-tool`