### PR TITLE
Add Board VM Bluetooth request size guard coverage

### DIFF
--- a/code/packages/rust/board-vm-bluetooth/README.md
+++ b/code/packages/rust/board-vm-bluetooth/README.md
@@ -18,9 +18,9 @@ delegate/run-loop adapter for service-filtered BLE GATT connections,
 characteristic writes, and notification reads. The BLE raw-frame transport
 buffers split notifications, preserves extra bytes for the next response, and
 rejects empty or unterminated notification streams. BLE GATT and RFCOMM raw-frame
-adapters report oversized or unterminated responses as `ResponseTooLarge` through
-the shared client transport trait, while link and stream failures are exposed as
-`Io`.
+adapters report oversized outgoing frames and oversized or unterminated responses
+as `ResponseTooLarge` through the shared client transport trait, while link and
+stream failures are exposed as `Io`.
 
 OS-specific scanners can also pass discovered device metadata into
 `board_vm_endpoint_candidates`. The macOS scanner reads `system_profiler`, the

--- a/code/packages/rust/board-vm-bluetooth/src/lib.rs
+++ b/code/packages/rust/board-vm-bluetooth/src/lib.rs
@@ -2227,6 +2227,23 @@ Device 11:22:33:44:55:66 (public)
     }
 
     #[test]
+    fn ble_gatt_raw_transport_maps_oversized_requests_to_response_too_large() {
+        let endpoint = parse_ble_gatt_endpoint(&format!(
+            "ble://esp32?service={SERVICE_UUID}&write={WRITE_UUID}&notify={NOTIFY_UUID}"
+        ))
+        .unwrap();
+        let link = FakeBleGattLink::default();
+        let mut transport = BoardBleGattTransport::<_, 4>::new(endpoint, link);
+        let mut raw_out = [0u8; 16];
+
+        assert_eq!(
+            RawFrameTransport::exchange_raw_frame(&mut transport, &[0xAA; 8], &mut raw_out),
+            Err(TransportError::ResponseTooLarge)
+        );
+        assert!(transport.link().writes.is_empty());
+    }
+
+    #[test]
     fn ble_gatt_raw_transport_maps_write_failures_to_io() {
         let endpoint = parse_ble_gatt_endpoint(&format!(
             "ble://esp32?service={SERVICE_UUID}&write={WRITE_UUID}&notify={NOTIFY_UUID}"
@@ -2298,6 +2315,20 @@ Device 11:22:33:44:55:66 (public)
             RawFrameTransport::exchange_raw_frame(&mut transport, &[0xAA], &mut raw_out),
             Err(TransportError::ResponseTooLarge)
         );
+    }
+
+    #[test]
+    fn rfcomm_raw_transport_maps_oversized_requests_to_response_too_large() {
+        let endpoint = parse_rfcomm_endpoint("btspp://ESP32-BoardVM:3").unwrap();
+        let stream = FakeRfcommStream::new(Vec::new());
+        let mut transport = BoardRfcommTransport::<_, 4>::from_stream(endpoint, stream);
+        let mut raw_out = [0u8; 16];
+
+        assert_eq!(
+            RawFrameTransport::exchange_raw_frame(&mut transport, &[0xAA; 8], &mut raw_out),
+            Err(TransportError::ResponseTooLarge)
+        );
+        assert!(transport.into_inner().written.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add BLE GATT and RFCOMM raw transport coverage for oversized outgoing raw frames
- assert request-size guard failures map through RawFrameTransport as ResponseTooLarge
- verify oversized requests are rejected before fake Bluetooth writes are attempted

## Validation
- cargo test -p board-vm-bluetooth
- cargo test -p board-vm-cli -p board-vm-language-core -p board-vm-tcp
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check