### PR TITLE
Wire Rust MACSYMA substitution

### DIFF
--- a/code/packages/rust/macsyma-runtime/BUILD
+++ b/code/packages/rust/macsyma-runtime/BUILD
@@ -1,1 +1,1 @@
-cargo test -p cas-list-operations -p cas-solve -p coding-adventures-macsyma-runtime -- --nocapture
+cargo test -p cas-list-operations -p cas-solve -p cas-substitution -p coding-adventures-macsyma-runtime -- --nocapture

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Wired `Subst(value, variable, expr)` to the Rust `cas-substitution`
+  structural substitution package.
 - Wired deterministic MACSYMA list heads (`Length`, `First`, `Rest`, `Last`,
   `Append`, `Join`, `Reverse`, `Range`, `Part`, `Map`, `Apply`, `Sort`, and
   `Flatten`) to the Rust `cas-list-operations` package.

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 cas-list-operations = { path = "../cas-list-operations" }
 cas-solve = { path = "../cas-solve" }
 cas-simplify = { path = "../cas-simplify" }
+cas-substitution = { path = "../cas-substitution" }
 cas-trig = { path = "../cas-trig" }
 coding-adventures-macsyma-compiler = { path = "../macsyma-compiler" }
 symbolic-ir = { path = "../symbolic-ir" }

--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -29,6 +29,11 @@ to the Rust `cas-solve` inverse-family solver. Supported `Exp`, `Log`, trig,
 and hyperbolic forms return `List(...)` symbolic inverse or periodic-family
 solutions; unsupported nested forms remain unevaluated.
 
+`Subst(value, variable, expr)` delegates to the Rust `cas-substitution`
+structural substitution package. `Subst` is held by the runtime so the
+substitution target remains symbolic even if the session has a binding for the
+same name.
+
 Deterministic list operations delegate to the Rust `cas-list-operations`
 package. `Length`, `First`, `Rest`, `Last`, `Append`, `Join`, `Reverse`,
 `Range`, `Part`, `Map`, `Apply`, `Sort`, and `Flatten` return list-operation

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -13,6 +13,7 @@ use cas_list_operations::{
 };
 use cas_simplify::simplify;
 use cas_solve::{solve_linear_system, try_solve_inequality, try_solve_transcendental, SOLVE};
+use cas_substitution::subst;
 use cas_trig::{expand_trig, trig_simplify};
 use coding_adventures_macsyma_compiler::{
     compile_macsyma_with_options, CompileError, CompileOptions, DISPLAY as COMPILER_DISPLAY,
@@ -47,6 +48,7 @@ const FACTOR: &str = "Factor";
 const FLOAT_FUNC: &str = "Float";
 const RAT_SIMPLIFY: &str = "RatSimplify";
 const SIMPLIFY: &str = "Simplify";
+const SUBST: &str = "Subst";
 const TRIG_EXPAND: &str = "TrigExpand";
 const TRIG_SIMPLIFY: &str = "TrigSimplify";
 const LENGTH: &str = "Length";
@@ -85,7 +87,7 @@ pub fn extend_macsyma_name_table(target: &mut HashMap<String, String>) {
 }
 
 const MACSYMA_NAME_TABLE: &[(&str, &str)] = &[
-    ("subst", "Subst"),
+    ("subst", SUBST),
     ("simplify", SIMPLIFY),
     ("expand", EXPAND),
     ("factor", FACTOR),
@@ -346,6 +348,7 @@ impl MacsymaBackend {
         handlers.insert(FLOAT_FUNC.to_string(), handler_fn(float_handler));
         handlers.insert(SOLVE.to_string(), handler_fn(solve_handler));
         handlers.insert(SIMPLIFY.to_string(), handler_fn(simplify_handler));
+        handlers.insert(SUBST.to_string(), handler_fn(subst_handler));
         handlers.insert(RAT_SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(TRIG_SIMPLIFY.to_string(), handler_fn(trig_simplify_handler));
         handlers.insert(TRIG_EXPAND.to_string(), handler_fn(trig_expand_handler));
@@ -399,7 +402,7 @@ impl MacsymaBackend {
             }),
         );
 
-        let held = [ASSIGN, DEFINE, IF, KILL, EV, SOLVE]
+        let held = [ASSIGN, DEFINE, IF, KILL, EV, SOLVE, SUBST]
             .into_iter()
             .map(str::to_string)
             .collect();
@@ -692,6 +695,14 @@ fn solve_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     solve_linear_system(&equations.args, &variables.args)
         .map(|rules| apply(sym(LIST), rules))
         .unwrap_or(fallback)
+}
+
+fn subst_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
+    let fallback = IRNode::Apply(Box::new(expr.clone()));
+    if expr.args.len() != 3 {
+        return fallback;
+    }
+    subst(expr.args[0].clone(), &expr.args[1], expr.args[2].clone())
 }
 
 fn list_handler<F>(arity: Option<usize>, body: F) -> Handler

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -8,6 +8,8 @@ use symbolic_ir::{
     LESS_EQUAL, LIST, LOG, MUL, POW, RULE, SIN, SUB,
 };
 
+const SUBST: &str = "Subst";
+
 #[test]
 fn evaluates_arithmetic_program() {
     let mut session = MacsymaSession::new();
@@ -499,6 +501,53 @@ fn keeps_unsupported_transcendental_solve_calls_unevaluated() {
 
     let mut session = MacsymaSession::new();
     let results = session.eval_statements(vec![expr.clone()]);
+    assert_eq!(results[0].output, expr);
+}
+
+#[test]
+fn evaluates_structural_substitution_through_cas_substitution() {
+    let x = sym("x");
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![
+        apply(
+            sym(SUBST),
+            vec![int(3), x.clone(), apply(sym(POW), vec![x.clone(), int(2)])],
+        ),
+        apply(
+            sym(SUBST),
+            vec![
+                sym("z"),
+                apply(sym(ADD), vec![x.clone(), int(1)]),
+                apply(
+                    sym(MUL),
+                    vec![
+                        apply(sym(ADD), vec![x.clone(), int(1)]),
+                        apply(sym(ADD), vec![x, int(1)]),
+                    ],
+                ),
+            ],
+        ),
+    ]);
+
+    assert_eq!(results[0].output, apply(sym(POW), vec![int(3), int(2)]));
+    assert_eq!(results[1].output, apply(sym(MUL), vec![sym("z"), sym("z")]));
+}
+
+#[test]
+fn keeps_substitution_variables_unevaluated() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("x : 5; subst(3, x, x^2);").unwrap();
+
+    assert_eq!(results[0].output, int(5));
+    assert_eq!(results[1].output, apply(sym(POW), vec![int(3), int(2)]));
+}
+
+#[test]
+fn keeps_invalid_substitution_calls_unevaluated() {
+    let expr = apply(sym(SUBST), vec![int(3), sym("x")]);
+    let mut session = MacsymaSession::new();
+    let results = session.eval_statements(vec![expr.clone()]);
+
     assert_eq!(results[0].output, expr);
 }
 


### PR DESCRIPTION
## Summary
- wire Rust MACSYMA `Subst(value, variable, expr)` through `cas-substitution`
- keep `Subst` held so substitution variables are not resolved from runtime bindings before replacement
- preserve unevaluated fallback behavior for invalid `Subst` arity and update Rust BUILD coverage

## Validation
- `cargo fmt -p coding-adventures-macsyma-runtime` in `code/packages/rust`
- `cargo test -p cas-substitution -p coding-adventures-macsyma-runtime -- --nocapture` in `code/packages/rust`
- `cargo test -p cas-list-operations -p cas-solve -p cas-substitution -p coding-adventures-macsyma-runtime -- --nocapture` in `code/packages/rust`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-macsyma-subst-runtime.json` from `code/programs/go/build-tool`