### PR TITLE
Add Board VM Bluetooth open error coverage

### DIFF
--- a/code/packages/rust/board-vm-bluetooth/README.md
+++ b/code/packages/rust/board-vm-bluetooth/README.md
@@ -7,7 +7,9 @@ The crate keeps Bluetooth connection endpoint shapes in Rust so language
 frontends can stay thin. It validates and normalizes endpoint strings for the
 BLE GATT and Bluetooth Classic RFCOMM transports, and it exposes a backend
 opening trait so OS-specific adapters can return concrete Board VM raw-frame
-transports without moving endpoint policy into Ruby/Python/Lua.
+transports without moving endpoint policy into Ruby/Python/Lua. Backend open
+failures remain `BluetoothOpenError`s so callers can report platform or adapter
+setup problems before raw-frame exchange starts.
 
 The first host adapter is `MacosBluetoothBackend`, which resolves Bluetooth
 Classic RFCOMM endpoints onto macOS `/dev/cu.*` serial devices. BLE GATT opening

--- a/code/packages/rust/board-vm-bluetooth/src/lib.rs
+++ b/code/packages/rust/board-vm-bluetooth/src/lib.rs
@@ -1683,6 +1683,8 @@ mod tests {
         rfcomm_read: Vec<u8>,
         ble_opened: Vec<String>,
         rfcomm_opened: Vec<(String, u8)>,
+        ble_open_error: Option<BluetoothOpenError>,
+        rfcomm_open_error: Option<BluetoothOpenError>,
     }
 
     impl BluetoothBackend for FakeBluetoothBackend {
@@ -1694,6 +1696,9 @@ mod tests {
             endpoint: &BleGattEndpoint,
         ) -> Result<Self::BleGattLink, BluetoothOpenError> {
             self.ble_opened.push(endpoint.device.clone());
+            if let Some(error) = self.ble_open_error.take() {
+                return Err(error);
+            }
             Ok(FakeBleGattLink {
                 writes: Vec::new(),
                 notifications: std::mem::take(&mut self.ble_notifications),
@@ -1707,6 +1712,9 @@ mod tests {
         ) -> Result<Self::RfcommStream, BluetoothOpenError> {
             self.rfcomm_opened
                 .push((endpoint.device.clone(), endpoint.channel));
+            if let Some(error) = self.rfcomm_open_error.take() {
+                return Err(error);
+            }
             Ok(FakeRfcommStream::new(std::mem::take(&mut self.rfcomm_read)))
         }
     }
@@ -2448,6 +2456,53 @@ Device 11:22:33:44:55:66 (public)
         );
         assert_eq!(transport.device(), "ESP32-BoardVM");
         assert_eq!(&raw_out[..response_len], response);
+        assert_eq!(backend.rfcomm_opened, vec![("ESP32-BoardVM".to_owned(), 3)]);
+    }
+
+    #[test]
+    fn backend_opener_propagates_ble_gatt_open_errors() {
+        let endpoint = parse_bluetooth_endpoint(&format!(
+            "ble://esp32?service={SERVICE_UUID}&write={WRITE_UUID}&notify={NOTIFY_UUID}"
+        ))
+        .unwrap();
+        let mut backend = FakeBluetoothBackend {
+            ble_open_error: Some(BluetoothOpenError::Backend {
+                message: "BLE adapter unavailable".to_owned(),
+            }),
+            ..FakeBluetoothBackend::default()
+        };
+
+        let result = open_bluetooth_endpoint::<_, 32>(&mut backend, endpoint);
+
+        assert_eq!(
+            result.err(),
+            Some(BluetoothOpenError::Backend {
+                message: "BLE adapter unavailable".to_owned(),
+            })
+        );
+        assert_eq!(backend.ble_opened, vec!["esp32".to_owned()]);
+        assert!(backend.rfcomm_opened.is_empty());
+    }
+
+    #[test]
+    fn backend_opener_propagates_rfcomm_open_errors() {
+        let endpoint = parse_bluetooth_endpoint("btspp://ESP32-BoardVM:3").unwrap();
+        let mut backend = FakeBluetoothBackend {
+            rfcomm_open_error: Some(BluetoothOpenError::Backend {
+                message: "RFCOMM device missing".to_owned(),
+            }),
+            ..FakeBluetoothBackend::default()
+        };
+
+        let result = open_bluetooth_endpoint::<_, 32>(&mut backend, endpoint);
+
+        assert_eq!(
+            result.err(),
+            Some(BluetoothOpenError::Backend {
+                message: "RFCOMM device missing".to_owned(),
+            })
+        );
+        assert!(backend.ble_opened.is_empty());
         assert_eq!(backend.rfcomm_opened, vec![("ESP32-BoardVM".to_owned(), 3)]);
     }
 


### PR DESCRIPTION
## Summary
- add BLE GATT and RFCOMM backend opener coverage for propagated open failures
- assert backend setup errors remain BluetoothOpenError before raw-frame transport use
- document the Bluetooth open/error boundary for platform and adapter setup failures

## Validation
- cargo test -p board-vm-bluetooth
- cargo test -p board-vm-cli -p board-vm-language-core -p board-vm-tcp
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check