### PR TITLE
Wire TypeScript MACSYMA simplification handlers

### DIFF
--- a/code/packages/typescript/cas-simplify/src/index.ts
+++ b/code/packages/typescript/cas-simplify/src/index.ts
@@ -18,14 +18,14 @@ import {
   structuralKey,
 } from "@coding-adventures/symbolic-ir";
 import { isRewriteCycleError, rewrite } from "@coding-adventures/cas-pattern-matching";
-import { IDENTITY_RULES } from "./rules";
+import { IDENTITY_RULES } from "./rules.js";
 
-export { AssumptionContext } from "./assumptions";
-export { IMAGINARY_UNIT, demoivre, exponentialize } from "./exponentialize";
-export * from "./heads";
-export { logcontract, logexpand } from "./logcontract";
-export { radcan } from "./radcan";
-export { IDENTITY_RULES, buildIdentityRules } from "./rules";
+export { AssumptionContext } from "./assumptions.js";
+export { IMAGINARY_UNIT, demoivre, exponentialize } from "./exponentialize.js";
+export * from "./heads.js";
+export { logcontract, logexpand } from "./logcontract.js";
+export { radcan } from "./radcan.js";
+export { IDENTITY_RULES, buildIdentityRules } from "./rules.js";
 
 export function canonical(node: IRNode): IRNode {
   if (node.kind !== "apply") return node;

--- a/code/packages/typescript/cas-simplify/src/logcontract.ts
+++ b/code/packages/typescript/cas-simplify/src/logcontract.ts
@@ -1,5 +1,5 @@
 import { ADD, DIV, IRNode, LOG, MUL, POW, SUB, app, headName } from "@coding-adventures/symbolic-ir";
-import { AssumptionContext } from "./assumptions";
+import { AssumptionContext } from "./assumptions.js";
 
 export function logcontract(expr: IRNode): IRNode {
   if (expr.kind !== "apply") return expr;

--- a/code/packages/typescript/cas-simplify/src/radcan.ts
+++ b/code/packages/typescript/cas-simplify/src/radcan.ts
@@ -11,7 +11,7 @@ import {
   int,
   rational,
 } from "@coding-adventures/symbolic-ir";
-import { AssumptionContext } from "./assumptions";
+import { AssumptionContext } from "./assumptions.js";
 
 interface Fraction {
   readonly numer: bigint;

--- a/code/packages/typescript/macsyma-runtime/BUILD
+++ b/code/packages/typescript/macsyma-runtime/BUILD
@@ -10,7 +10,10 @@ cd ../macsyma-lexer && npm ci --quiet
 cd ../macsyma-parser && npm ci --quiet
 cd ../macsyma-compiler && npm ci --quiet
 cd ../cas-list-operations && npm ci --quiet
+cd ../cas-pattern-matching && npm ci --quiet
+cd ../cas-simplify && npm ci --quiet
 cd ../cas-solve && npm ci --quiet
 cd ../cas-substitution && npm ci --quiet
+cd ../cas-trig && npm ci --quiet
 npm ci --quiet
 npx vitest run --coverage

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Wire `Simplify`, `RatSimplify`, `TrigSimplify`, and `TrigExpand` runtime
+  heads to the TypeScript `cas-simplify` and `cas-trig` packages.
 - Wire `Subst(value, variable, expr)` to the TypeScript `cas-substitution`
   structural substitution package.
 - Wire deterministic MACSYMA list heads (`Length`, `First`, `Rest`, `Last`,

--- a/code/packages/typescript/macsyma-runtime/README.md
+++ b/code/packages/typescript/macsyma-runtime/README.md
@@ -18,6 +18,8 @@ This first runtime slice is intentionally small and browser-friendly:
   equations to the `cas-solve` inverse-family solver
 - dispatches `Subst(value, variable, expr)` to `cas-substitution`
   structural substitution
+- dispatches `Simplify` / `RatSimplify` to `cas-simplify`
+- dispatches `TrigSimplify` / `TrigExpand` to `cas-trig`
 - dispatches deterministic list operations such as `Length`, `First`, `Rest`,
   `Last`, `Append`, `Reverse`, `Range`, `Map`, `Apply`, `Sort`, `Part`,
   `Flatten`, and `Join` to `cas-list-operations`

--- a/code/packages/typescript/macsyma-runtime/package-lock.json
+++ b/code/packages/typescript/macsyma-runtime/package-lock.json
@@ -10,8 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
+        "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+        "@coding-adventures/cas-simplify": "file:../cas-simplify",
         "@coding-adventures/cas-solve": "file:../cas-solve",
         "@coding-adventures/cas-substitution": "file:../cas-substitution",
+        "@coding-adventures/cas-trig": "file:../cas-trig",
         "@coding-adventures/directed-graph": "file:../directed-graph",
         "@coding-adventures/grammar-tools": "file:../grammar-tools",
         "@coding-adventures/lexer": "file:../lexer",
@@ -43,6 +46,34 @@
         "vitest": "^3.0.0"
       }
     },
+    "../cas-pattern-matching": {
+      "name": "@coding-adventures/cas-pattern-matching",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-simplify": {
+      "name": "@coding-adventures/cas-simplify",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
     "../cas-solve": {
       "name": "@coding-adventures/cas-solve",
       "version": "0.1.0",
@@ -65,6 +96,20 @@
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
       },
       "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-trig": {
+      "name": "@coding-adventures/cas-trig",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
@@ -297,12 +342,24 @@
       "resolved": "../cas-list-operations",
       "link": true
     },
+    "node_modules/@coding-adventures/cas-pattern-matching": {
+      "resolved": "../cas-pattern-matching",
+      "link": true
+    },
+    "node_modules/@coding-adventures/cas-simplify": {
+      "resolved": "../cas-simplify",
+      "link": true
+    },
     "node_modules/@coding-adventures/cas-solve": {
       "resolved": "../cas-solve",
       "link": true
     },
     "node_modules/@coding-adventures/cas-substitution": {
       "resolved": "../cas-substitution",
+      "link": true
+    },
+    "node_modules/@coding-adventures/cas-trig": {
+      "resolved": "../cas-trig",
       "link": true
     },
     "node_modules/@coding-adventures/directed-graph": {

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -22,8 +22,11 @@
     "@coding-adventures/parser": "file:../parser",
     "@coding-adventures/state-machine": "file:../state-machine",
     "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
+    "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+    "@coding-adventures/cas-simplify": "file:../cas-simplify",
     "@coding-adventures/cas-solve": "file:../cas-solve",
     "@coding-adventures/cas-substitution": "file:../cas-substitution",
+    "@coding-adventures/cas-trig": "file:../cas-trig",
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
     "@coding-adventures/symbolic-vm": "file:../symbolic-vm"
   },

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -13,8 +13,10 @@ import {
   reverse,
   sortList,
 } from "@coding-adventures/cas-list-operations";
+import { simplify as simplifyCas } from "@coding-adventures/cas-simplify";
 import { solveLinearSystem, trySolveInequality, trySolveTranscendental } from "@coding-adventures/cas-solve";
 import { subst } from "@coding-adventures/cas-substitution";
+import { expandTrig, trigSimplify } from "@coding-adventures/cas-trig";
 import {
   ACOS,
   ACOSH,
@@ -61,9 +63,11 @@ export const KILL = sym("Kill");
 export const EV = sym("Ev");
 export const ALL_SYMBOL = sym("all");
 
+export const SIMPLIFY = sym("Simplify");
 export const EXPAND = sym("Expand");
 export const RAT_SIMPLIFY = sym("RatSimplify");
 export const TRIG_SIMPLIFY = sym("TrigSimplify");
+export const TRIG_EXPAND = sym("TrigExpand");
 export const FLOAT_FUNC = sym("Float");
 export const LENGTH = sym("Length");
 export const FIRST = sym("First");
@@ -103,7 +107,7 @@ export const MACSYMA_NAME_TABLE: ReadonlyMap<string, IRSymbol> = new Map<string,
   ["sum", SUM],
   ["product", sym("Product")],
   ["subst", SUBST],
-  ["simplify", sym("Simplify")],
+  ["simplify", SIMPLIFY],
   ["expand", EXPAND],
   ["factor", FACTOR],
   ["solve", SOLVE],
@@ -165,7 +169,7 @@ export const MACSYMA_NAME_TABLE: ReadonlyMap<string, IRSymbol> = new Map<string,
   ["demoivre", sym("DeMoivre")],
   ["cbrt", sym("Cbrt")],
   ["trigsimp", TRIG_SIMPLIFY],
-  ["trigexpand", sym("TrigExpand")],
+  ["trigexpand", TRIG_EXPAND],
   ["trigreduce", sym("TrigReduce")],
   ["collect", sym("Collect")],
   ["together", sym("Together")],
@@ -310,6 +314,10 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(EV.name, makeEvHandler());
     table.set(SOLVE.name, solveHandler);
     table.set(SUBST.name, substHandler);
+    table.set(SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
+    table.set(RAT_SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
+    table.set(TRIG_SIMPLIFY.name, unaryHandler((value) => simplifyCas(trigSimplify(value))));
+    table.set(TRIG_EXPAND.name, unaryHandler((value) => expandTrig(value)));
     table.set(LENGTH.name, listHandler(1, ([value]) => length(value)));
     table.set(FIRST.name, listHandler(1, ([value]) => first(value)));
     table.set(REST.name, listHandler(1, ([value]) => rest(value)));
@@ -571,6 +579,7 @@ function makeEvHandler(): Handler {
     if (flags.has("factor")) result = evalSupportedFlag(vm, result, FACTOR);
     if (flags.has("ratsimp")) result = evalSupportedFlag(vm, result, RAT_SIMPLIFY);
     if (flags.has("trigsimp")) result = evalSupportedFlag(vm, result, TRIG_SIMPLIFY);
+    if (flags.has("trigexpand")) result = evalSupportedFlag(vm, result, TRIG_EXPAND);
     if (flags.has("numer") || flags.has("float")) result = numerFold(result);
 
     return result;
@@ -607,6 +616,17 @@ function substHandler(_vm: VM, expr: IRApply): IRNode {
   if (expr.args.length !== 3) return expr;
   const [value, variable, target] = expr.args;
   return subst(value, variable, target);
+}
+
+function unaryHandler(body: (value: IRNode) => IRNode): Handler {
+  return (_vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    try {
+      return body(expr.args[0]);
+    } catch {
+      return expr;
+    }
+  };
 }
 
 function listHandler(

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -47,7 +47,10 @@ import {
   REST,
   REVERSE,
   SORT,
+  SIMPLIFY,
   SUPPRESS,
+  TRIG_EXPAND,
+  TRIG_SIMPLIFY,
   extendCompilerNameTable,
   evalSourceJson,
 } from "../src/index.js";
@@ -80,7 +83,10 @@ describe("macsyma-runtime", () => {
     expect(MACSYMA_NAME_TABLE.get("kill")).toEqual(KILL);
     expect(MACSYMA_NAME_TABLE.get("ev")).toEqual(EV);
     expect(MACSYMA_NAME_TABLE.get("expand")).toEqual(EXPAND);
+    expect(MACSYMA_NAME_TABLE.get("simplify")).toEqual(SIMPLIFY);
     expect(MACSYMA_NAME_TABLE.get("ratsimp")).toEqual(RAT_SIMPLIFY);
+    expect(MACSYMA_NAME_TABLE.get("trigsimp")).toEqual(TRIG_SIMPLIFY);
+    expect(MACSYMA_NAME_TABLE.get("trigexpand")).toEqual(TRIG_EXPAND);
 
     const target = new Map<string, typeof KILL>();
     extendCompilerNameTable(target);
@@ -184,6 +190,10 @@ describe("macsyma-runtime", () => {
     expect(backend.handlers().has(EV.name)).toBe(true);
     expect(backend.handlers().has(SOLVE.name)).toBe(true);
     expect(backend.handlers().has(SUBST.name)).toBe(true);
+    expect(backend.handlers().has(SIMPLIFY.name)).toBe(true);
+    expect(backend.handlers().has(RAT_SIMPLIFY.name)).toBe(true);
+    expect(backend.handlers().has(TRIG_SIMPLIFY.name)).toBe(true);
+    expect(backend.handlers().has(TRIG_EXPAND.name)).toBe(true);
     expect(backend.handlers().has(LENGTH.name)).toBe(true);
     expect(backend.holdHeads().has(KILL.name)).toBe(true);
     expect(backend.holdHeads().has(EV.name)).toBe(true);
@@ -236,6 +246,48 @@ describe("macsyma-runtime", () => {
     const [result] = session.evalSource("ev(x + 0, expand);");
 
     expect(result.output).toEqual(sym("x"));
+  });
+
+  it("evaluates simplify and ratsimp through cas-simplify", () => {
+    const x = sym("x");
+    const expr = app(MUL, [app(ADD, [x, int(0)]), int(1)]);
+    const session = new MacsymaSession();
+    const [simplifyResult, ratsimpResult, badArity] = session.evalStatements([
+      app(sym("simplify"), [expr]),
+      app(RAT_SIMPLIFY, [expr]),
+      app(SIMPLIFY, [expr, int(1)]),
+    ]);
+
+    expect(simplifyResult.input).toEqual(app(SIMPLIFY, [expr]));
+    expect(simplifyResult.output).toEqual(x);
+    expect(ratsimpResult.output).toEqual(x);
+    expect(badArity.output).toEqual(app(SIMPLIFY, [x, int(1)]));
+  });
+
+  it("evaluates trigsimp and trigexpand through cas-trig", () => {
+    const x = sym("x");
+    const y = sym("y");
+    const session = new MacsymaSession();
+    const [simplifyResult, expandResult] = session.evalStatements([
+      app(TRIG_SIMPLIFY, [app(ADD, [app(SIN, [int(0)]), app(sym("Cos"), [int(0)])])]),
+      app(TRIG_EXPAND, [app(SIN, [app(ADD, [x, y])])]),
+    ]);
+
+    expect(simplifyResult.output).toEqual(int(1));
+    expect(expandResult.output).toEqual(app(ADD, [
+      app(MUL, [app(SIN, [x]), app(sym("Cos"), [y])]),
+      app(MUL, [app(sym("Cos"), [x]), app(SIN, [y])]),
+    ]));
+  });
+
+  it("routes Ev simplify flags through runtime handlers", () => {
+    const session = new MacsymaSession();
+    const [ratsimpResult, trigsimpResult] = session.evalSource(
+      "ev((x + 0) * 1, ratsimp); ev(sin(0) + cos(0), trigsimp);",
+    );
+
+    expect(ratsimpResult.output).toEqual(sym("x"));
+    expect(trigsimpResult.output).toEqual(int(1));
   });
 
   it("evaluates function definitions across statements", () => {

--- a/code/programs/typescript/macsyma-browser-repl/BUILD
+++ b/code/programs/typescript/macsyma-browser-repl/BUILD
@@ -10,8 +10,11 @@ cd ../../../packages/typescript/macsyma-lexer && npm ci --quiet
 cd ../../../packages/typescript/macsyma-parser && npm ci --quiet
 cd ../../../packages/typescript/macsyma-compiler && npm ci --quiet
 cd ../../../packages/typescript/cas-list-operations && npm ci --quiet
+cd ../../../packages/typescript/cas-pattern-matching && npm ci --quiet
+cd ../../../packages/typescript/cas-simplify && npm ci --quiet
 cd ../../../packages/typescript/cas-solve && npm ci --quiet
 cd ../../../packages/typescript/cas-substitution && npm ci --quiet
+cd ../../../packages/typescript/cas-trig && npm ci --quiet
 cd ../../../packages/typescript/macsyma-runtime && npm ci --quiet
 npm ci --quiet
 npm run build


### PR DESCRIPTION
## Summary
- wire TypeScript MACSYMA `Simplify`, `RatSimplify`, `TrigSimplify`, and `TrigExpand` through `cas-simplify` and `cas-trig`
- route `ev(..., ratsimp)`, `ev(..., trigsimp)`, and `ev(..., trigexpand)` through runtime handlers
- fix `cas-simplify` relative ESM imports so downstream static linking works under NodeNext builds
- update standalone BUILD prerequisites for runtime and browser REPL packages

## Validation
- `npm install && npm test && npm run build` in `code/packages/typescript/cas-simplify`
- `npm install && npm test && npm run build` in `code/packages/typescript/macsyma-runtime`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-simplify-runtime.json` from `code/programs/go/build-tool`