### PR TITLE
feat(llm-primitives): decompose_text v3 — delimiter-awareness rule (the 'Let's eat, Bob' rule)

### DIFF
--- a/code/packages/rust/llm-primitives/CHANGELOG.md
+++ b/code/packages/rust/llm-primitives/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-05-12
+
+### Changed
+
+`decompose_text` system prompt bumped to `decompose-text-v3` with an
+explicit **punctuation and delimiter awareness rule** (rule 11). The
+v2 prompt covered structural shape (flat nodes, exact field names,
+tiling spans) but said nothing about how delimiters can flip meaning.
+A single comma can invert intent — the canonical example baked into
+the prompt:
+
+* `"Let's eat, Bob."` — Bob is being invited to a meal.
+* `"Let's eat Bob."` — Bob is the meal.
+
+The bytes differ by one comma; the meaning differs by an order of
+magnitude. The ADJ02 coverage rule already forces the model to
+account for every byte, but covering a byte is not the same as
+reading it correctly. v3 explicitly directs the model to scan
+surrounding punctuation before assigning a `term`:
+
+* commas separating list items vs vocatives
+* periods ending sentences vs abbreviations
+* quotes scoping a quoted phrase vs marking emphasis
+* colons introducing definitions vs ratios
+* parentheses denoting asides vs grouping
+
+When punctuation is load-bearing or ambiguous, the model is told to
+prefer an `Uncertainty` node with `polarity: "Uncertain"` over a
+confident guess. This pairs with the v0.4 ADJ06 adversarial-retry
+flow: the adversary can now find punctuation-driven alt readings and
+hand them back for an `Uncertainty` rewrite.
+
+**Audit-trail impact**: every `LlmCallRecord.prompt_version` for
+`decompose_text` now reads `"decompose-text-v3"`. Cached responses
+keyed on `(prompt_version, prompt_hash)` from v2 will miss and
+re-run against the new prompt — intentional, since the model is
+being asked to do strictly more work.
+
 ## [0.8.0] - 2026-05-12
 
 ### Changed

--- a/code/packages/rust/llm-primitives/Cargo.toml
+++ b/code/packages/rust/llm-primitives/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "llm-primitives"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
-description = "LM00b — typed LLM primitives layer. v0.8 ships a much-improved decompose_text prompt (v2) with a concrete worked example, prevents nested-children output, and produces clean flat IRs from small models like Gemma 4."
+description = "LM00b — typed LLM primitives layer. v0.9 bumps the decompose_text prompt to v3 with an explicit punctuation/delimiter awareness rule (the `Let's eat, Bob` rule): commas, periods, quotes, and colons can flip meaning, so the model is told to scan them before assigning a term, and to prefer an Uncertainty node when punctuation is load-bearing or ambiguous."
 
 [dependencies]
 llm-gateway = { path = "../llm-gateway" }

--- a/code/packages/rust/llm-primitives/src/decompose_text.rs
+++ b/code/packages/rust/llm-primitives/src/decompose_text.rs
@@ -149,6 +149,19 @@ to answer.\n\
 `{\"functor\": \"pred\", \"args\": [...]}` for compound claims. Args \
 recursively use the same term shape.\n\
 10. **`document_id` is the DOCUMENT_ID from the user message, verbatim.**\n\
+11. **Punctuation and delimiters can flip meaning — read them carefully.** \
+A single comma, period, colon, or quote mark can invert the intent \
+of an otherwise-identical string. Two famous examples:\n\
+   * `\"Let's eat, Bob.\"` — Bob is being invited to a meal.\n\
+   * `\"Let's eat Bob.\"` — Bob is the meal.\n\
+The bytes differ by one comma; the meaning differs by an order \
+of magnitude. Before assigning a `term`, scan the surrounding \
+punctuation: commas separating list items vs vocatives; periods \
+ending sentences vs abbreviations; quotes scoping a quoted phrase \
+vs marking emphasis; colons introducing definitions vs ratios; \
+parentheses denoting asides vs grouping. If the punctuation is \
+ambiguous or load-bearing, prefer an `Uncertainty` node with \
+`polarity: \"Uncertain\"` over a confident guess.\n\
 \n\
 Respond with the JSON object only. No prose, no markdown, no \
 backticks.";
@@ -402,7 +415,7 @@ mod tests {
 
         assert_eq!(resp.call_record.primitive, "decompose_text");
         assert_eq!(resp.call_record.role, "extractor");
-        assert_eq!(resp.call_record.prompt_version, "decompose-text-v2");
+        assert_eq!(resp.call_record.prompt_version, "decompose-text-v3");
         assert!(!resp.call_record.prompt_hash.is_empty());
         assert_eq!(resp.call_record.usage.input_tokens, 700);
         assert_eq!(resp.call_record.usage.output_tokens, 320);

--- a/code/packages/rust/llm-primitives/src/lib.rs
+++ b/code/packages/rust/llm-primitives/src/lib.rs
@@ -370,7 +370,7 @@ impl From<LlmError> for PrimitiveError {
 // prompt: every `LlmCallRecord` carries the version, so replay
 // matches `(prompt_version, prompt_hash)`.
 
-pub const DECOMPOSE_TEXT_PROMPT_VERSION: &str = "decompose-text-v2";
+pub const DECOMPOSE_TEXT_PROMPT_VERSION: &str = "decompose-text-v3";
 pub const RENDER_NODE_PROMPT_VERSION: &str = "render-node-v1";
 pub const ENTAIL_PROMPT_VERSION: &str = "entail-v1";
 pub const ADVERSARY_PROMPT_VERSION: &str = "adversary-v1";
@@ -882,7 +882,7 @@ mod tests {
     fn prompt_version_constants_are_stable() {
         // Locking the constants down — bumping any of these is an
         // audit-trail-affecting change and should be a separate PR.
-        assert_eq!(DECOMPOSE_TEXT_PROMPT_VERSION, "decompose-text-v2");
+        assert_eq!(DECOMPOSE_TEXT_PROMPT_VERSION, "decompose-text-v3");
         assert_eq!(RENDER_NODE_PROMPT_VERSION, "render-node-v1");
         assert_eq!(ENTAIL_PROMPT_VERSION, "entail-v1");
         assert_eq!(ADVERSARY_PROMPT_VERSION, "adversary-v1");


### PR DESCRIPTION
## Summary

- Bumps the `decompose_text` system prompt to `decompose-text-v3` with an explicit **punctuation and delimiter awareness rule** (rule 11). The canonical example baked into the prompt: \`\"Let's eat, Bob.\"\` (Bob is invited to a meal) vs \`\"Let's eat Bob.\"\` (Bob is the meal) — the bytes differ by one comma; the meaning differs by an order of magnitude.
- ADJ02 coverage already forces the model to account for every byte, but **covering a byte is not the same as reading it correctly**. v3 directs the model to scan surrounding punctuation (commas separating list items vs vocatives; periods ending sentences vs abbreviations; quotes; colons; parentheses) before assigning a \`term\`, and to prefer an \`Uncertainty\` node when punctuation is load-bearing or ambiguous.
- Pairs naturally with the v0.4 ADJ06 adversarial-retry flow: the adversary can find punctuation-driven alt readings and the extractor can rewrite as Uncertainty on retry, instead of guessing twice.

## Changes

- \`DECOMPOSE_TEXT_PROMPT_VERSION\`: \`decompose-text-v2\` → \`decompose-text-v3\`
- \`llm-primitives\` crate: \`0.8.0\` → \`0.9.0\`
- Version-lock test + happy-path \`prompt_version\` assertion updated
- CHANGELOG entry explaining the rule, the audit-trail impact (cache misses are intentional), and the pairing with ADJ06

## Audit-trail impact

Every \`LlmCallRecord.prompt_version\` for \`decompose_text\` now reads \`\"decompose-text-v3\"\`. Cached responses keyed on \`(prompt_version, prompt_hash)\` from v2 will miss and re-run against the new prompt — intentional, since the model is being asked to do strictly more work.

## Test plan

- [x] \`cargo test -p llm-primitives\` — 72/72 pass
- [x] \`cargo build -p {adjudication-clarification, adjudication-pipeline, adjudication-tsa-demo, adjudication-round-trip, adjudication-adversarial}\` — clean
- [x] Security review (no input flows touched; this is a static \`&str\` constant)
- [ ] Wait for CI green
- [ ] (Follow-up) Re-run the TSA benchmark against gemma4:8B / qwen2.5:3B/1.5B/0.5B and update \`code/specs/ADJ12-small-model-benchmarks.md\` if behaviour shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)