### PR TITLE
Wire TypeScript MACSYMA trigreduce

### DIFF
--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Wire `TrigReduce` runtime dispatch to the TypeScript `cas-trig` package.
 - Wire `Simplify`, `RatSimplify`, `TrigSimplify`, and `TrigExpand` runtime
   heads to the TypeScript `cas-simplify` and `cas-trig` packages.
 - Wire `Subst(value, variable, expr)` to the TypeScript `cas-substitution`

--- a/code/packages/typescript/macsyma-runtime/README.md
+++ b/code/packages/typescript/macsyma-runtime/README.md
@@ -19,7 +19,7 @@ This first runtime slice is intentionally small and browser-friendly:
 - dispatches `Subst(value, variable, expr)` to `cas-substitution`
   structural substitution
 - dispatches `Simplify` / `RatSimplify` to `cas-simplify`
-- dispatches `TrigSimplify` / `TrigExpand` to `cas-trig`
+- dispatches `TrigSimplify`, `TrigExpand`, and `TrigReduce` to `cas-trig`
 - dispatches deterministic list operations such as `Length`, `First`, `Rest`,
   `Last`, `Append`, `Reverse`, `Range`, `Map`, `Apply`, `Sort`, `Part`,
   `Flatten`, and `Join` to `cas-list-operations`

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { simplify as simplifyCas } from "@coding-adventures/cas-simplify";
 import { solveLinearSystem, trySolveInequality, trySolveTranscendental } from "@coding-adventures/cas-solve";
 import { subst } from "@coding-adventures/cas-substitution";
-import { expandTrig, trigSimplify } from "@coding-adventures/cas-trig";
+import { expandTrig, trigReduce, trigSimplify } from "@coding-adventures/cas-trig";
 import {
   ACOS,
   ACOSH,
@@ -68,6 +68,7 @@ export const EXPAND = sym("Expand");
 export const RAT_SIMPLIFY = sym("RatSimplify");
 export const TRIG_SIMPLIFY = sym("TrigSimplify");
 export const TRIG_EXPAND = sym("TrigExpand");
+export const TRIG_REDUCE = sym("TrigReduce");
 export const FLOAT_FUNC = sym("Float");
 export const LENGTH = sym("Length");
 export const FIRST = sym("First");
@@ -170,7 +171,7 @@ export const MACSYMA_NAME_TABLE: ReadonlyMap<string, IRSymbol> = new Map<string,
   ["cbrt", sym("Cbrt")],
   ["trigsimp", TRIG_SIMPLIFY],
   ["trigexpand", TRIG_EXPAND],
-  ["trigreduce", sym("TrigReduce")],
+  ["trigreduce", TRIG_REDUCE],
   ["collect", sym("Collect")],
   ["together", sym("Together")],
   ["ratsimp", RAT_SIMPLIFY],
@@ -318,6 +319,7 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(RAT_SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
     table.set(TRIG_SIMPLIFY.name, unaryHandler((value) => simplifyCas(trigSimplify(value))));
     table.set(TRIG_EXPAND.name, unaryHandler((value) => expandTrig(value)));
+    table.set(TRIG_REDUCE.name, unaryHandler((value) => trigReduce(value)));
     table.set(LENGTH.name, listHandler(1, ([value]) => length(value)));
     table.set(FIRST.name, listHandler(1, ([value]) => first(value)));
     table.set(REST.name, listHandler(1, ([value]) => rest(value)));
@@ -580,6 +582,7 @@ function makeEvHandler(): Handler {
     if (flags.has("ratsimp")) result = evalSupportedFlag(vm, result, RAT_SIMPLIFY);
     if (flags.has("trigsimp")) result = evalSupportedFlag(vm, result, TRIG_SIMPLIFY);
     if (flags.has("trigexpand")) result = evalSupportedFlag(vm, result, TRIG_EXPAND);
+    if (flags.has("trigreduce")) result = evalSupportedFlag(vm, result, TRIG_REDUCE);
     if (flags.has("numer") || flags.has("float")) result = numerFold(result);
 
     return result;

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -50,6 +50,7 @@ import {
   SIMPLIFY,
   SUPPRESS,
   TRIG_EXPAND,
+  TRIG_REDUCE,
   TRIG_SIMPLIFY,
   extendCompilerNameTable,
   evalSourceJson,
@@ -87,6 +88,7 @@ describe("macsyma-runtime", () => {
     expect(MACSYMA_NAME_TABLE.get("ratsimp")).toEqual(RAT_SIMPLIFY);
     expect(MACSYMA_NAME_TABLE.get("trigsimp")).toEqual(TRIG_SIMPLIFY);
     expect(MACSYMA_NAME_TABLE.get("trigexpand")).toEqual(TRIG_EXPAND);
+    expect(MACSYMA_NAME_TABLE.get("trigreduce")).toEqual(TRIG_REDUCE);
 
     const target = new Map<string, typeof KILL>();
     extendCompilerNameTable(target);
@@ -194,6 +196,7 @@ describe("macsyma-runtime", () => {
     expect(backend.handlers().has(RAT_SIMPLIFY.name)).toBe(true);
     expect(backend.handlers().has(TRIG_SIMPLIFY.name)).toBe(true);
     expect(backend.handlers().has(TRIG_EXPAND.name)).toBe(true);
+    expect(backend.handlers().has(TRIG_REDUCE.name)).toBe(true);
     expect(backend.handlers().has(LENGTH.name)).toBe(true);
     expect(backend.holdHeads().has(KILL.name)).toBe(true);
     expect(backend.holdHeads().has(EV.name)).toBe(true);
@@ -288,6 +291,24 @@ describe("macsyma-runtime", () => {
 
     expect(ratsimpResult.output).toEqual(sym("x"));
     expect(trigsimpResult.output).toEqual(int(1));
+  });
+
+  it("evaluates trigreduce through cas-trig", () => {
+    const x = sym("x");
+    const session = new MacsymaSession();
+    const [direct, viaEv] = session.evalStatements([
+      app(TRIG_REDUCE, [app(POW, [app(SIN, [x]), int(2)])]),
+      app(EV, [app(POW, [app(sym("Cos"), [x]), int(2)]), sym("trigreduce")]),
+    ]);
+
+    expect(direct.output).toEqual(app(MUL, [
+      rational(1, 2),
+      app(SUB, [int(1), app(sym("Cos"), [app(MUL, [int(2), x])])]),
+    ]));
+    expect(viaEv.output).toEqual(app(MUL, [
+      rational(1, 2),
+      app(ADD, [int(1), app(sym("Cos"), [app(MUL, [int(2), x])])]),
+    ]));
   });
 
   it("evaluates function definitions across statements", () => {


### PR DESCRIPTION
## Summary
- wire TypeScript MACSYMA `TrigReduce` through the existing `cas-trig` `trigReduce` implementation
- route `ev(..., trigreduce)` through the runtime handler table
- cover direct and `ev`-flag trig power reductions in the MACSYMA runtime tests

## Validation
- `npm install && npm test && npm run build` in `code/packages/typescript/macsyma-runtime`
- `build-tool -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-trigreduce-runtime.json` from `code/programs/go/build-tool`