### PR TITLE
Add homegrown server stress tests

### DIFF
--- a/code/packages/rust/embeddable-http-server/CHANGELOG.md
+++ b/code/packages/rust/embeddable-http-server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add an ignored native-server stress test for concurrent HTTP/1 pipelined
+  requests over real sockets.
+
 ## 0.1.0
 
 - Add the initial HTTP/1 embeddable server primitive.

--- a/code/packages/rust/embeddable-http-server/README.md
+++ b/code/packages/rust/embeddable-http-server/README.md
@@ -6,3 +6,14 @@ This crate owns HTTP/1 request framing and response serialization while leaving
 application work behind a handler callback. The eventual language bridges can
 wrap this crate and map requests into Rack-style or WSGI-style application
 objects without having to reimplement the socket runtime.
+
+Ignored stress coverage binds the native TCP-backed HTTP server and drives
+concurrent pipelined requests over real sockets:
+
+```bash
+EMBEDDABLE_HTTP_STRESS_CLIENTS=256 \
+EMBEDDABLE_HTTP_STRESS_REQUESTS_PER_CLIENT=8 \
+  cargo test -p embeddable-http-server \
+  native_http_server_handles_pipelined_requests_under_concurrent_load \
+  -- --ignored --nocapture
+```

--- a/code/packages/rust/embeddable-http-server/src/lib.rs
+++ b/code/packages/rust/embeddable-http-server/src/lib.rs
@@ -450,6 +450,15 @@ fn resolve_first_socket_addr<A: ToSocketAddrs>(addr: A) -> Result<SocketAddr, Pl
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{self, Read, Write};
+    use std::net::{Shutdown, TcpStream};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    const DEFAULT_STRESS_CLIENTS: usize = 128;
+    const DEFAULT_STRESS_REQUESTS_PER_CLIENT: usize = 4;
 
     fn connection() -> TcpConnectionInfo {
         TcpConnectionInfo {
@@ -534,5 +543,171 @@ mod tests {
         let text = String::from_utf8(result.write).expect("response utf8");
         assert!(text.starts_with("HTTP/1.1 501 Not Implemented\r\n"));
         assert!(result.close);
+    }
+
+    #[test]
+    #[ignore]
+    fn native_http_server_handles_pipelined_requests_under_concurrent_load() {
+        let client_count = stress_count("EMBEDDABLE_HTTP_STRESS_CLIENTS", DEFAULT_STRESS_CLIENTS);
+        let requests_per_client = stress_count(
+            "EMBEDDABLE_HTTP_STRESS_REQUESTS_PER_CLIENT",
+            DEFAULT_STRESS_REQUESTS_PER_CLIENT,
+        );
+        let expected_requests = client_count.saturating_mul(requests_per_client);
+        let seen_requests = Arc::new(AtomicUsize::new(0));
+        let handler_seen = Arc::clone(&seen_requests);
+        let options = HttpServerOptions {
+            tcp: TcpRuntimeOptions {
+                max_connections: client_count.saturating_add(64),
+                read_buffer_size: 2048,
+                poll_timeout: Duration::from_millis(1),
+                ..TcpRuntimeOptions::default()
+            },
+            ..HttpServerOptions::default()
+        };
+        let mut server = bind_native_http_server(("127.0.0.1", 0), options, move |request| {
+            handler_seen.fetch_add(1, Ordering::SeqCst);
+            HttpResponse::ok(format!("ok:{}:{}", request.method(), request.target()))
+                .with_header("Content-Type", "text/plain")
+        })
+        .expect("bind native HTTP server");
+        let addr = server.local_addr();
+        let stop = server.stop_handle();
+        let server_thread = thread::spawn(move || server.serve());
+        let barrier = Arc::new(Barrier::new(client_count));
+
+        let clients = (0..client_count)
+            .map(|client_index| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    exercise_http_client(addr, client_index, requests_per_client)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for client in clients {
+            client
+                .join()
+                .expect("HTTP stress client thread")
+                .expect("HTTP stress client");
+        }
+
+        stop.stop();
+        server_thread
+            .join()
+            .expect("HTTP server thread")
+            .expect("HTTP server result");
+        assert_eq!(seen_requests.load(Ordering::SeqCst), expected_requests);
+    }
+
+    fn stress_count(var: &str, default: usize) -> usize {
+        std::env::var(var)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(default)
+    }
+
+    fn exercise_http_client(
+        addr: SocketAddr,
+        client_index: usize,
+        requests_per_client: usize,
+    ) -> io::Result<()> {
+        let mut stream = TcpStream::connect(addr)?;
+        stream.set_nodelay(true)?;
+        stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+
+        let mut request_bytes = Vec::new();
+        let mut expected_bodies = Vec::with_capacity(requests_per_client);
+        for request_index in 0..requests_per_client {
+            let target = format!("/stress/{client_index}/{request_index}");
+            expected_bodies.push(format!("ok:GET:{target}"));
+            request_bytes.extend_from_slice(
+                format!(
+                    "GET {target} HTTP/1.1\r\nHost: localhost\r\n{}\r\n",
+                    if request_index + 1 == requests_per_client {
+                        "Connection: close\r\n"
+                    } else {
+                        ""
+                    }
+                )
+                .as_bytes(),
+            );
+        }
+
+        stream.write_all(&request_bytes)?;
+        stream.shutdown(Shutdown::Write)?;
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response)?;
+        let text = String::from_utf8(response).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("HTTP response was not UTF-8: {error}"),
+            )
+        })?;
+        let response_count = text.matches("HTTP/1.1 200 OK\r\n").count();
+        if response_count != requests_per_client {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("expected {requests_per_client} responses, got {response_count}: {text}"),
+            ));
+        }
+        for body in expected_bodies {
+            if !text.contains(&body) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("missing response body {body}: {text}"),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    fn bind_native_http_server<A, F>(
+        addr: A,
+        options: HttpServerOptions,
+        handler: F,
+    ) -> Result<HttpServer<transport_platform::bsd::KqueueTransportPlatform>, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+    {
+        HttpServer::bind_kqueue(addr, options, handler)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn bind_native_http_server<A, F>(
+        addr: A,
+        options: HttpServerOptions,
+        handler: F,
+    ) -> Result<HttpServer<transport_platform::linux::EpollTransportPlatform>, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+    {
+        HttpServer::bind_epoll(addr, options, handler)
+    }
+
+    #[cfg(target_os = "windows")]
+    fn bind_native_http_server<A, F>(
+        addr: A,
+        options: HttpServerOptions,
+        handler: F,
+    ) -> Result<HttpServer<transport_platform::windows::WindowsTransportPlatform>, PlatformError>
+    where
+        A: ToSocketAddrs,
+        F: Fn(HttpRequest) -> HttpResponse + Send + Sync + 'static,
+    {
+        HttpServer::bind_windows(addr, options, handler)
     }
 }

--- a/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
+++ b/code/packages/rust/embeddable-tcp-server/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this package will be documented in this file.
 - Added a `build_runtime_mailbox` path that can consume either stdio-backed or
   thread-pool-backed mailbox submitters.
 - Added integration coverage for the in-process thread-pool mailbox path.
+- Added an ignored in-process mailbox stress test for configurable concurrent
+  real TCP clients without requiring a Python worker.
 
 ## [0.1.1] - 2026-04-22
 

--- a/code/packages/rust/embeddable-tcp-server/README.md
+++ b/code/packages/rust/embeddable-tcp-server/README.md
@@ -90,3 +90,13 @@ The integration tests launch a real Rust TCP listener, start the Python Mini
 Redis worker process, send RESP commands through a socket, and assert that the
 Python-produced RESP replies come back through the generic embeddable server
 seam.
+
+Ignored stress coverage can drive the in-process mailbox path through many real
+TCP clients without requiring Python:
+
+```bash
+EMBEDDABLE_TCP_SERVER_STRESS_CLIENTS=512 \
+  cargo test -p embeddable-tcp-server \
+  inprocess_mailbox_server_sustains_configured_concurrent_clients \
+  -- --ignored --nocapture
+```

--- a/code/packages/rust/embeddable-tcp-server/src/lib.rs
+++ b/code/packages/rust/embeddable-tcp-server/src/lib.rs
@@ -1233,11 +1233,13 @@ mod tests {
     use resp_protocol::{decode, encode, RespValue};
     use serde::{Deserialize, Serialize};
     use std::io::{Read, Write};
-    use std::net::TcpStream;
+    use std::net::{SocketAddr, TcpStream};
     use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Barrier};
     use std::thread;
     use std::time::Duration;
 
+    const DEFAULT_STRESS_CLIENTS: usize = 128;
     const MAX_TCP_CHUNK_BYTES: usize = 1024 * 1024;
 
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1342,14 +1344,14 @@ mod tests {
             .map(|program| WorkerCommand::new(program, vec!["-c".to_string(), script.to_string()]))
     }
 
-    fn execute_scripted_worker(script: &str) -> Result<TcpOutputFrame, WorkerError> {
-        let worker_command = scripted_worker(script).expect("python interpreter");
+    fn execute_scripted_worker(script: &str) -> Option<Result<TcpOutputFrame, WorkerError>> {
+        let worker_command = scripted_worker(script)?;
         let mut worker = StdioJobWorker::<TcpInputJob, TcpOutputFrame>::spawn(&worker_command)
             .expect("spawn scripted worker");
-        worker.execute(TcpInputJob {
+        Some(worker.execute(TcpInputJob {
             stream_id: "test-stream".to_string(),
             bytes_hex: hex_encode(command(&[b"PING"])),
-        })
+        }))
     }
 
     fn handle_tcp_bytes(
@@ -1511,7 +1513,11 @@ assert payload["stream_id"] == "test-stream"
 assert payload["bytes_hex"].startswith("2a")
 print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result":{"status":"ok","payload":{"writes_hex":[],"close":False}},"metadata":body["metadata"]}}), flush=True)
 "#;
-        execute_scripted_worker(script).expect("opaque TCP bytes response");
+        let Some(result) = execute_scripted_worker(script) else {
+            eprintln!("skipping test because no Python interpreter was found");
+            return;
+        };
+        result.expect("opaque TCP bytes response");
     }
 
     fn start_test_server(
@@ -1546,6 +1552,14 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
             .set_read_timeout(Some(Duration::from_secs(3)))
             .expect("set read timeout");
         stream
+    }
+
+    fn connect_stress_client(addr: SocketAddr) -> io::Result<TcpStream> {
+        let stream = TcpStream::connect(addr)?;
+        stream.set_nodelay(true)?;
+        stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+        Ok(stream)
     }
 
     fn stop_server(server: EmbeddableTcpServer<()>, handle: thread::JoinHandle<io::Result<()>>) {
@@ -1804,11 +1818,19 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
         worker_count: usize,
         worker_queue_depth: usize,
     ) -> (EmbeddableTcpServer<()>, thread::JoinHandle<io::Result<()>>) {
+        start_async_inprocess_test_server_with_options(worker_count, worker_queue_depth, 64)
+    }
+
+    fn start_async_inprocess_test_server_with_options(
+        worker_count: usize,
+        worker_queue_depth: usize,
+        max_connections: usize,
+    ) -> (EmbeddableTcpServer<()>, thread::JoinHandle<io::Result<()>>) {
         let server = EmbeddableTcpServer::new_inprocess_mailbox(
             EmbeddableTcpServerOptions {
                 host: "127.0.0.1".to_string(),
                 port: 0,
-                max_connections: 64,
+                max_connections,
                 event_loop_threads: 1,
                 worker_processes: worker_count.max(1),
                 worker_queue_depth,
@@ -1835,6 +1857,14 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
         (server, handle)
     }
 
+    fn stress_count(var: &str, default: usize) -> usize {
+        std::env::var(var)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(default)
+    }
+
     fn assert_scripted_worker_maps_control_results() {
         let error_script = r#"
 import json, sys
@@ -1842,7 +1872,11 @@ frame = json.loads(sys.stdin.readline())
 body = frame["body"]
 print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result":{"status":"error","error":{"code":"worker_failed","message":"boom","retryable":False,"origin":"worker","detail":None}},"metadata":body["metadata"]}}), flush=True)
 "#;
-        let error = execute_scripted_worker(error_script).expect_err("worker error should fail");
+        let Some(result) = execute_scripted_worker(error_script) else {
+            eprintln!("skipping test because no Python interpreter was found");
+            return;
+        };
+        let error = result.expect_err("worker error should fail");
         assert!(error.to_string().contains("worker_failed: boom"));
 
         let cancelled = r#"
@@ -1851,7 +1885,9 @@ frame = json.loads(sys.stdin.readline())
 body = frame["body"]
 print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result":{"status":"cancelled","cancellation":{"message":"stopped"}},"metadata":body["metadata"]}}), flush=True)
 "#;
-        let error = execute_scripted_worker(cancelled).expect_err("cancelled job should fail");
+        let error = execute_scripted_worker(cancelled)
+            .expect("python interpreter should stay available")
+            .expect_err("cancelled job should fail");
         assert!(error.to_string().contains("cancelled job: stopped"));
 
         let timed_out = r#"
@@ -1860,7 +1896,9 @@ frame = json.loads(sys.stdin.readline())
 body = frame["body"]
 print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result":{"status":"timed_out","timeout":{"message":"too slow"}},"metadata":body["metadata"]}}), flush=True)
 "#;
-        let error = execute_scripted_worker(timed_out).expect_err("timed out job should fail");
+        let error = execute_scripted_worker(timed_out)
+            .expect("python interpreter should stay available")
+            .expect_err("timed out job should fail");
         assert!(error.to_string().contains("timed out job: too slow"));
     }
 
@@ -2012,7 +2050,11 @@ print(json.dumps({"version":1,"kind":"response","body":{"id":body["id"],"result"
     fn stdio_worker_rejects_mismatched_response_ids() {
         let script = scripted_success_response(r#"body["id"] + "-wrong""#);
 
-        let error = execute_scripted_worker(&script).expect_err("mismatched response should fail");
+        let Some(result) = execute_scripted_worker(&script) else {
+            eprintln!("skipping test because no Python interpreter was found");
+            return;
+        };
+        let error = result.expect_err("mismatched response should fail");
         assert!(error.to_string().contains("response id mismatch"));
     }
 
@@ -2162,6 +2204,54 @@ emit(second, "second")
         let mut response = vec![0u8; request_len];
         stream.read_exact(&mut response).expect("read response");
         assert_eq!(response, request);
+        stop_server(server, handle);
+    }
+
+    #[test]
+    #[ignore]
+    fn inprocess_mailbox_server_sustains_configured_concurrent_clients() {
+        let client_count = stress_count(
+            "EMBEDDABLE_TCP_SERVER_STRESS_CLIENTS",
+            DEFAULT_STRESS_CLIENTS,
+        );
+        let (server, handle) = start_async_inprocess_test_server_with_options(
+            8,
+            client_count.saturating_add(64),
+            client_count.saturating_add(64),
+        );
+        let addr = server.local_addr();
+        let barrier = Arc::new(Barrier::new(client_count));
+        let clients = (0..client_count)
+            .map(|client_index| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || -> io::Result<()> {
+                    barrier.wait();
+                    let mut stream = connect_stress_client(addr)?;
+                    let payload = format!("stress-client-{client_index:04}").into_bytes();
+                    stream.write_all(&payload)?;
+                    let mut response = vec![0u8; payload.len()];
+                    stream.read_exact(&mut response)?;
+                    if response != payload {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "client {client_index} received {}",
+                                String::from_utf8_lossy(&response)
+                            ),
+                        ));
+                    }
+                    Ok(())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for client in clients {
+            client
+                .join()
+                .expect("TCP stress client thread")
+                .expect("TCP stress client");
+        }
+
         stop_server(server, handle);
     }
 


### PR DESCRIPTION
## Summary
- add ignored real-socket stress coverage for the embeddable TCP server in-process mailbox path
- add ignored real-socket stress coverage for the embeddable HTTP server with concurrent pipelined requests
- document the stress-test env knobs and keep Python-dependent worker tests skippable when no interpreter is available

## Tests
- cargo test -p embeddable-tcp-server -p embeddable-http-server
- cargo test -p embeddable-tcp-server inprocess_mailbox_server_sustains_configured_concurrent_clients -- --ignored --nocapture
- cargo test -p embeddable-http-server native_http_server_handles_pipelined_requests_under_concurrent_load -- --ignored --nocapture