### PR TITLE
Wire Rust MACSYMA trigreduce

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Wired `TrigReduce(expr)` and `ev(expr, trigreduce)` to the Rust `cas-trig`
+  power-reduction walker.
 - Wired `Subst(value, variable, expr)` to the Rust `cas-substitution`
   structural substitution package.
 - Wired deterministic MACSYMA list heads (`Length`, `First`, `Rest`, `Last`,

--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -38,3 +38,7 @@ Deterministic list operations delegate to the Rust `cas-list-operations`
 package. `Length`, `First`, `Rest`, `Last`, `Append`, `Join`, `Reverse`,
 `Range`, `Part`, `Map`, `Apply`, `Sort`, and `Flatten` return list-operation
 results while invalid calls remain unevaluated.
+
+`TrigReduce(expr)` and `ev(expr, trigreduce)` delegate to the Rust `cas-trig`
+power-reduction walker, so MACSYMA sessions can rewrite supported sine/cosine
+powers and `sin(x)cos(x)` products to multiple-angle forms.

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -14,7 +14,7 @@ use cas_list_operations::{
 use cas_simplify::simplify;
 use cas_solve::{solve_linear_system, try_solve_inequality, try_solve_transcendental, SOLVE};
 use cas_substitution::subst;
-use cas_trig::{expand_trig, trig_simplify};
+use cas_trig::{expand_trig, trig_reduce, trig_simplify};
 use coding_adventures_macsyma_compiler::{
     compile_macsyma_with_options, CompileError, CompileOptions, DISPLAY as COMPILER_DISPLAY,
     SUPPRESS as COMPILER_SUPPRESS,
@@ -50,6 +50,7 @@ const RAT_SIMPLIFY: &str = "RatSimplify";
 const SIMPLIFY: &str = "Simplify";
 const SUBST: &str = "Subst";
 const TRIG_EXPAND: &str = "TrigExpand";
+const TRIG_REDUCE: &str = "TrigReduce";
 const TRIG_SIMPLIFY: &str = "TrigSimplify";
 const LENGTH: &str = "Length";
 const FIRST: &str = "First";
@@ -160,7 +161,7 @@ const MACSYMA_NAME_TABLE: &[(&str, &str)] = &[
     ("cbrt", "Cbrt"),
     ("trigsimp", TRIG_SIMPLIFY),
     ("trigexpand", TRIG_EXPAND),
-    ("trigreduce", "TrigReduce"),
+    ("trigreduce", TRIG_REDUCE),
     ("collect", "Collect"),
     ("together", "Together"),
     ("ratsimp", RAT_SIMPLIFY),
@@ -352,6 +353,7 @@ impl MacsymaBackend {
         handlers.insert(RAT_SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(TRIG_SIMPLIFY.to_string(), handler_fn(trig_simplify_handler));
         handlers.insert(TRIG_EXPAND.to_string(), handler_fn(trig_expand_handler));
+        handlers.insert(TRIG_REDUCE.to_string(), handler_fn(trig_reduce_handler));
         handlers.insert(
             LENGTH.to_string(),
             list_handler(Some(1), |args| length(&args[0])),
@@ -628,6 +630,9 @@ fn ev_handler(vm: &mut VM, expr: IRApply) -> IRNode {
     if flags.contains("trigsimp") {
         result = vm.eval(apply(sym(TRIG_SIMPLIFY), vec![result]));
     }
+    if flags.contains("trigreduce") {
+        result = vm.eval(apply(sym(TRIG_REDUCE), vec![result]));
+    }
 
     result
 }
@@ -658,6 +663,13 @@ fn trig_expand_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
         return IRNode::Apply(Box::new(expr));
     }
     expand_trig(&expr.args[0])
+}
+
+fn trig_reduce_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    trig_reduce(&expr.args[0])
 }
 
 fn solve_handler(_vm: &mut VM, expr: IRApply) -> IRNode {

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -4,7 +4,7 @@ use coding_adventures_macsyma_runtime::{
 };
 use std::collections::HashMap;
 use symbolic_ir::{
-    apply, int, rat, sym, ADD, AND, ASIN, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, LESS,
+    apply, int, rat, sym, ADD, AND, ASIN, COS, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, LESS,
     LESS_EQUAL, LIST, LOG, MUL, POW, RULE, SIN, SUB,
 };
 
@@ -209,6 +209,30 @@ fn ev_routes_supported_flags_and_preserves_unsupported_heads() {
     assert_eq!(
         results[2].output,
         apply(sym("Expand"), vec![apply(sym(ADD), vec![sym("x"), int(1)])])
+    );
+}
+
+#[test]
+fn trigreduce_routes_through_macsyma_runtime() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("trigreduce(sin(x)^2); ev(cos(x)^2, trigreduce);")
+        .unwrap();
+    let cos_2x = apply(sym(COS), vec![apply(sym(MUL), vec![int(2), sym("x")])]);
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(MUL),
+            vec![rat(1, 2), apply(sym(SUB), vec![int(1), cos_2x.clone()])]
+        )
+    );
+    assert_eq!(
+        results[1].output,
+        apply(
+            sym(MUL),
+            vec![rat(1, 2), apply(sym(ADD), vec![int(1), cos_2x])]
+        )
     );
 }
 


### PR DESCRIPTION
## Summary
- register Rust MACSYMA `TrigReduce` with the runtime backend
- route `ev(..., trigreduce)` through the Rust `cas-trig::trig_reduce` walker
- cover direct and `ev`-flag reductions through `MacsymaSession`

## Validation
- `cargo fmt -p coding-adventures-macsyma-runtime`
- `cargo test -p cas-trig -p coding-adventures-macsyma-runtime`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-macsyma-trigreduce-runtime.json` from `code/programs/go/build-tool`
