### PR TITLE
Add Python MACSYMA file execution

### DIFF
--- a/code/programs/python/macsyma-repl/CHANGELOG.md
+++ b/code/programs/python/macsyma-repl/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.0 — 2026-05-12
+
+### Added
+
+- Added non-interactive `--file` / `-f` execution for `.mac` source files.
+- Added `MacsymaLanguage.eval_file(path)`, which reads UTF-8 MACSYMA source and
+  evaluates it through the same session pipeline as interactive input.
+- Added regression coverage for suppressed statements, displayed outputs, and
+  parse-error exit status in file mode.
+
 ## 0.2.0 — 2026-04-27
 
 **Add Phase G control-flow and Phase 13 hyperbolic-function end-to-end REPL tests.**

--- a/code/programs/python/macsyma-repl/README.md
+++ b/code/programs/python/macsyma-repl/README.md
@@ -26,6 +26,15 @@ MACSYMA-on-symbolic-VM 0.1
 (%i4) quit;
 ```
 
+To run a file non-interactively:
+
+```
+uv run python main.py --file examples/session.mac
+```
+
+File mode evaluates the program through the same session pipeline as the REPL
+and prints only displayed outputs, without prompts or the interactive banner.
+
 ## Wiring
 
 ```
@@ -62,6 +71,7 @@ cas_pretty_printer.pretty(.., MacsymaDialect())
 - Single-line input — every input must end with ``;`` or ``$``. Multi-line
   buffering is a future extension (the REPL framework is missing the
   ``needs_more?`` hook today).
+- Non-interactive ``--file`` execution for `.mac` source files.
 - ``(%iN) `` global prompt; result printed when the statement ends with
   ``;``, suppressed when it ends with ``$``.
 - ``%``, ``%iN``, ``%oN`` resolve via :class:`History`.
@@ -74,7 +84,7 @@ cas_pretty_printer.pretty(.., MacsymaDialect())
 - No multi-line input.
 - No tab completion.
 - No syntax highlighting.
-- No ``batch("file.mac")`` file loading.
+- No in-language ``batch("file.mac")`` form.
 - No 2D output.
 
 ## Dependencies

--- a/code/programs/python/macsyma-repl/language.py
+++ b/code/programs/python/macsyma-repl/language.py
@@ -17,6 +17,7 @@ returns one combined string (one line per displayed result, or
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 from cas_pretty_printer import MacsymaDialect, pretty
 from coding_adventures_repl import Language
@@ -112,6 +113,16 @@ class MacsymaLanguage(Language):
         if not outputs:
             return ("ok", None)
         return ("ok", "\n".join(outputs))
+
+    def eval_file(self, path: str | Path) -> tuple[str, str | None] | str:
+        """Evaluate a MACSYMA source file through this session.
+
+        The file is read as UTF-8 and then passed through :meth:`eval`, so
+        statement terminators, history, assignments, and output suppression
+        match the interactive REPL path.
+        """
+        source = Path(path).read_text(encoding="utf-8")
+        return self.eval(source)
 
 
 def _split_wrapper(stmt: IRNode) -> tuple[bool, IRNode]:

--- a/code/programs/python/macsyma-repl/main.py
+++ b/code/programs/python/macsyma-repl/main.py
@@ -6,6 +6,10 @@ generic REPL framework's :func:`run` and runs it.
 
 from __future__ import annotations
 
+import argparse
+import sys
+from pathlib import Path
+
 from coding_adventures_repl import Repl
 
 from language import MacsymaLanguage
@@ -14,13 +18,33 @@ from prompt import MacsymaPrompt
 _BANNER = "MACSYMA-on-symbolic-VM 0.1\n(C) 2026 — derived from MACSYMA at MIT\n"
 
 
-def main() -> None:
-    """Start an interactive MACSYMA session on the current terminal."""
+def main(argv: list[str] | None = None) -> int:
+    """Run an interactive MACSYMA session or a non-interactive file."""
+    parser = argparse.ArgumentParser(description="Run the MACSYMA REPL.")
+    parser.add_argument(
+        "-f",
+        "--file",
+        type=Path,
+        help="Evaluate a .mac source file non-interactively.",
+    )
+    args = parser.parse_args(argv)
+
     language = MacsymaLanguage()
+    if args.file is not None:
+        result = language.eval_file(args.file)
+        if result == "quit":
+            return 0
+        status, output = result
+        if output:
+            stream = sys.stderr if status == "error" else sys.stdout
+            print(output, file=stream)
+        return 0 if status == "ok" else 1
+
     prompt = MacsymaPrompt(history=language.history)
     print(_BANNER)
     Repl.run(language=language, prompt=prompt)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/code/programs/python/macsyma-repl/pyproject.toml
+++ b/code/programs/python/macsyma-repl/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coding-adventures-macsyma-repl-program"
-version = "0.2.0"
+version = "0.3.0"
 description = "Interactive MACSYMA-flavored REPL on top of the symbolic VM."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/programs/python/macsyma-repl/tests/test_session.py
+++ b/code/programs/python/macsyma-repl/tests/test_session.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from coding_adventures_repl import Repl  # noqa: E402
 
 from language import MacsymaLanguage  # noqa: E402
+from main import main as macsyma_main  # noqa: E402
 from prompt import MacsymaPrompt  # noqa: E402
 
 
@@ -141,6 +142,36 @@ def test_auto_terminator_appended() -> None:
     """Input without a trailing ``;`` or ``$`` is treated as ``;``."""
     out = _run(["2 + 3", ":quit"])
     assert any(line == "(%o1) 5" for line in out)
+
+
+def test_eval_file_uses_same_session_semantics(tmp_path: Path) -> None:
+    program = tmp_path / "batch.mac"
+    program.write_text("x: 5$\nx + 1;\n2 + 3;\n", encoding="utf-8")
+
+    language = MacsymaLanguage()
+    result = language.eval_file(program)
+
+    assert result == ("ok", "(%o2) 6\n(%o3) 5")
+
+
+def test_cli_file_mode_prints_outputs_without_prompt(tmp_path: Path, capsys) -> None:
+    program = tmp_path / "batch.mac"
+    program.write_text("a: 2$\na + 3;\n", encoding="utf-8")
+
+    assert macsyma_main(["--file", str(program)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "(%o2) 5\n"
+    assert captured.err == ""
+
+
+def test_cli_file_mode_reports_errors_to_stderr(tmp_path: Path, capsys) -> None:
+    program = tmp_path / "bad.mac"
+    program.write_text("1 +;\n", encoding="utf-8")
+
+    assert macsyma_main(["--file", str(program)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "parse error:" in captured.err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `MacsymaLanguage.eval_file(path)` for UTF-8 `.mac` source execution through the existing session pipeline
- add `macsyma-repl --file/-f` non-interactive execution that prints displayed outputs without prompts
- document file mode and cover suppressed statements, output formatting, and parse-error exit status

## Validation
- `bash BUILD` in `code/programs/python/macsyma-repl`
- `.venv/bin/python -m pytest tests/ -v --tb=short` in `code/programs/python/macsyma-repl`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-python-macsyma-file-exec.json` from `code/programs/go/build-tool`
