### PR TITLE
feat(lang34): first-class closure opcodes at the IIR level

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this crate are documented here.
 
 ---
 
+## [0.3.0] — 2026-05-12
+
+### Added (LANG34 — Phase 4 Closure Builtin Lowering)
+
+#### New `src/closure.rs` module
+
+Phase 4 of the builtin-lowering pipeline.  Rewrites legacy
+`call_builtin "make_closure"` / `"apply_closure"` instructions — emitted by
+pre-LANG34 compilers and hand-built tests — to first-class LANG34 opcodes:
+
+| Legacy form | LANG34 form |
+|-------------|-------------|
+| `call_builtin "make_closure" fn_name_reg cap0…` | `alloc_closure(Str(fn_name), cap0…) : "closure"` |
+| `call_builtin "apply_closure" handle arg0…` | `call_closure(handle, arg0…) : "any"` |
+
+**Algorithm:** two-pass per function.  Pass 1 builds a
+`HashMap<register, literal_text>` from `const` instructions.  Pass 2 rewrites
+`make_closure`/`apply_closure` and drops `const` instructions that become
+dead (single-use, only consumed by the rewritten `make_closure`).
+
+**Infallible:** `make_closure` with an unresolvable fn_name register is left
+unchanged for the twig-vm fallback / backend validator.
+
+Public API: `pub fn lower_closure_builtins(module: &mut IIRModule)` +
+re-exported at crate root as `lower_closure_builtins`.
+
+10 unit tests covering: zero-capture rewrite, two-capture rewrite, multi-use
+const preservation, unresolvable case, apply_closure rewrite, mixed forms,
+idempotency, already-lowered no-op.
+
+#### `lower_builtins` Phase 4 call
+
+`lower_builtins` in `lib.rs` now calls `closure::lower_closure_builtins`
+after Phase 3 (global/IO lowering).
+
+#### Updated test_73 comment
+
+`test_73_make_closure_left_unchanged` renamed to
+`test_73_make_closure_unresolvable_left_unchanged` with updated comment
+explaining the LANG34 Phase 4 behavior for unresolvable cases.
+
+---
+
 ## [0.2.0] — 2026-05-11
 
 ### Added (LANG32 — Global Variables and I/O Phase 3 lowering)

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/closure.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/closure.rs
@@ -180,9 +180,18 @@ fn lower_closure_builtins_function(fn_: &mut IIRFunction) {
             continue;
         }
         for src in &instr.srcs {
-            if let Operand::Var(name) = src {
+            // Count both Var and Str operands that reference a const-string
+            // register.  A register named "foo" could in theory appear as
+            // Operand::Str("foo") if a later pass re-encodes it; counting both
+            // forms prevents false-positive const removal in that edge case.
+            let referenced_name: Option<&str> = match src {
+                Operand::Var(name) => Some(name.as_str()),
+                Operand::Str(name) => Some(name.as_str()),
+                _ => None,
+            };
+            if let Some(name) = referenced_name {
                 if const_str_map.contains_key(name) {
-                    *use_count.entry(name.clone()).or_insert(0) += 1;
+                    *use_count.entry(name.to_string()).or_insert(0) += 1;
                 }
             }
         }

--- a/code/packages/rust/iir-builtin-lowering/src/closure.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/closure.rs
@@ -1,0 +1,615 @@
+//! # closure — Phase 4: closure builtin lowering (LANG34).
+//!
+//! This module is the fourth (and final) phase of the `iir-builtin-lowering`
+//! pipeline.  It rewrites legacy `call_builtin "make_closure"` and
+//! `call_builtin "apply_closure"` instructions — emitted by pre-LANG34
+//! compilers and hand-built tests — into the first-class LANG34 opcodes:
+//!
+//! | Legacy form | LANG34 form |
+//! |-------------|-------------|
+//! | `call_builtin "make_closure" fn_name_reg cap0…` | `alloc_closure(Str(fn_name), cap0…)` |
+//! | `call_builtin "apply_closure" handle arg0…` | `call_closure(handle, arg0…)` |
+//!
+//! ## Why this pass exists
+//!
+//! LANG34 changed the twig-ir-compiler to emit `alloc_closure`/`call_closure`
+//! directly.  However, some IIR modules may have been compiled before LANG34,
+//! or may be constructed by hand in tests using the older convention.  This
+//! pass automatically upgrades them so the twig-vm dispatcher sees only the
+//! canonical LANG34 form.
+//!
+//! The pass is **infallible** — instructions that cannot be resolved (e.g. a
+//! `make_closure` whose `fn_name_reg` was not produced by an identifiable
+//! `const`) are left unchanged.  The twig-vm can still execute them via the
+//! backward-compatible fallback arms in `exec_call_builtin`.
+//!
+//! ## Algorithm (two-pass per IIRFunction)
+//!
+//! ### Pass 1 — build the const-string map
+//!
+//! Walk all instructions and record every `const` whose source is a string
+//! literal.  Two conventions are supported:
+//!
+//! - Old convention (`Operand::Var(literal)`): used by the pre-LANG32 twig-ir-compiler.
+//! - New convention (`Operand::Str(literal)`): used by LANG32+ global/IO lowering.
+//!
+//! Result: `HashMap<dest_register, literal_text>`.
+//!
+//! Additionally, track the set of `const` registers that are used *only* as
+//! fn_name arguments to `make_closure`.  These are candidates for removal once
+//! the `make_closure` is rewritten.  A `const` that is also read by other
+//! instructions (arithmetic, `global_set`, etc.) is **not** a candidate —
+//! removing it would break those uses.
+//!
+//! ### Pass 2 — rewrite and filter
+//!
+//! Walk the instruction list, rewriting and potentially dropping instructions:
+//!
+//! - `call_builtin "make_closure" fn_name_reg cap0…`:
+//!   - Resolve `fn_name_reg` via the const-string map.
+//!   - If resolvable: emit `alloc_closure(Str(fn_name), cap0…) : "closure"`.
+//!   - If NOT resolvable: leave unchanged.
+//!   - Add `fn_name_reg` to the removal-candidate set (used only by this op).
+//! - `call_builtin "apply_closure" handle arg0…`:
+//!   - Always rewriteable: emit `call_closure(handle, arg0…) : "any"`.
+//! - `const` in the removal-candidate set:
+//!   - Drop this instruction (it was only used to materialise the fn_name).
+//!   - Only dropped if the same register is NOT used anywhere other than
+//!     its corresponding `make_closure` (see single-use check).
+//! - All other instructions: pass through unchanged.
+//!
+//! ## Idempotency
+//!
+//! Running `lower_closure_builtins` on a module that has already been lowered
+//! (i.e. one that already uses `alloc_closure`/`call_closure`) is a no-op.
+//! The rewrite conditions match only `call_builtin` instructions with the old
+//! names; `alloc_closure`/`call_closure` instructions pass through untouched.
+
+use std::collections::{HashMap, HashSet};
+
+use interpreter_ir::instr::{IIRInstr, Operand};
+use interpreter_ir::function::IIRFunction;
+use interpreter_ir::module::IIRModule;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Lower legacy `call_builtin "make_closure"` / `"apply_closure"` instructions
+/// in every function of `module` to the LANG34 first-class opcodes.
+///
+/// Mutates `module` in place.  Infallible: instructions that cannot be lowered
+/// are left unchanged.
+///
+/// Must be called **after** all earlier lowering phases (numeric, heap,
+/// global_io) so the instruction list is in its final pre-backend form.
+///
+/// # Example
+///
+/// ```rust
+/// use interpreter_ir::{IIRModule, IIRFunction, IIRInstr, Operand};
+/// use iir_builtin_lowering::lower_closure_builtins;
+///
+/// // Build a minimal module with the legacy make_closure form:
+/// //   %s0 = const("my_fn")
+/// //   %c0 = call_builtin("make_closure", %s0)
+/// let fn_ = IIRFunction::new(
+///     "main",
+///     vec![],
+///     "any",
+///     vec![
+///         IIRInstr::new("const", Some("%s0".into()),
+///             vec![Operand::Var("my_fn".into())], "any"),
+///         IIRInstr::new("call_builtin", Some("%c0".into()),
+///             vec![Operand::Var("make_closure".into()), Operand::Var("%s0".into())],
+///             "any"),
+///         IIRInstr::new("ret", None, vec![Operand::Var("%c0".into())], "any"),
+///     ],
+/// );
+/// let mut module = IIRModule {
+///     name: "test".into(),
+///     functions: vec![fn_],
+///     entry_point: Some("main".into()),
+///     language: "twig".into(),
+///     exports: vec![],
+///     imports: vec![],
+/// };
+///
+/// lower_closure_builtins(&mut module);
+///
+/// let instrs = &module.functions[0].instructions;
+/// // The const instruction is removed (single-use, only fed make_closure).
+/// // The call_builtin is rewritten to alloc_closure.
+/// assert_eq!(instrs[0].op, "alloc_closure", "expected alloc_closure, got {}", instrs[0].op);
+/// assert!(matches!(&instrs[0].srcs[0], Operand::Str(s) if s == "my_fn"));
+/// assert_eq!(instrs[0].type_hint, "closure");
+/// ```
+pub fn lower_closure_builtins(module: &mut IIRModule) {
+    for fn_ in &mut module.functions {
+        lower_closure_builtins_function(fn_);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-function implementation
+// ---------------------------------------------------------------------------
+
+fn lower_closure_builtins_function(fn_: &mut IIRFunction) {
+    // ------------------------------------------------------------------
+    // Pass 1a — build the const-string map.
+    //
+    // Records `dest → literal_text` for every `const` instruction whose
+    // source is a string literal (either Operand::Var or Operand::Str
+    // convention, since both appear in real programs).
+    // ------------------------------------------------------------------
+    let mut const_str_map: HashMap<String, String> = HashMap::new();
+    for instr in &fn_.instructions {
+        if instr.op == "const" {
+            if let Some(dest) = &instr.dest {
+                let literal = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => Some(s.clone()),
+                    Some(Operand::Str(s)) => Some(s.clone()),
+                    _ => None,
+                };
+                if let Some(lit) = literal {
+                    const_str_map.insert(dest.clone(), lit);
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Pass 1b — identify registers used ONLY as fn_name in make_closure.
+    //
+    // A `const` register is safe to remove only if:
+    //   (a) it appears in const_str_map (it's a string literal), AND
+    //   (b) its only consumer is a single `make_closure` call as srcs[1].
+    //
+    // We count uses: for each register in const_str_map, count how many
+    // instructions reference it in their srcs (excluding the `const`
+    // itself which produces it).  If the count is exactly 1 AND that one
+    // consumer is a `make_closure` call_builtin, the const is removable.
+    //
+    // Implementation: count all uses first, then mark single-use ones
+    // that feed make_closure as removable.
+    // ------------------------------------------------------------------
+    let mut use_count: HashMap<String, u32> = HashMap::new();
+    for instr in &fn_.instructions {
+        if instr.op == "const" {
+            // Skip the definition instruction itself.
+            continue;
+        }
+        for src in &instr.srcs {
+            if let Operand::Var(name) = src {
+                if const_str_map.contains_key(name) {
+                    *use_count.entry(name.clone()).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+
+    // Registers whose sole use is as the fn_name in a make_closure call.
+    let mut removable_const_regs: HashSet<String> = HashSet::new();
+    for instr in &fn_.instructions {
+        if instr.op != "call_builtin" {
+            continue;
+        }
+        let builtin_name = match instr.srcs.first() {
+            Some(Operand::Var(s)) => s.as_str(),
+            _ => continue,
+        };
+        if builtin_name != "make_closure" {
+            continue;
+        }
+        // srcs[1] is the fn_name register.
+        if let Some(Operand::Var(name_reg)) = instr.srcs.get(1) {
+            if const_str_map.contains_key(name_reg) && use_count.get(name_reg) == Some(&1) {
+                removable_const_regs.insert(name_reg.clone());
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Pass 2 — rebuild instruction list.
+    //
+    // Three rewrites:
+    //   1. Drop `const` instructions whose register is in removable_const_regs.
+    //   2. Rewrite `call_builtin "make_closure"` → `alloc_closure`.
+    //   3. Rewrite `call_builtin "apply_closure"` → `call_closure`.
+    // ------------------------------------------------------------------
+    let old_instrs = std::mem::take(&mut fn_.instructions);
+    let mut new_instrs: Vec<IIRInstr> = Vec::with_capacity(old_instrs.len());
+
+    for instr in old_instrs {
+        // Drop removable const instructions.
+        if instr.op == "const" {
+            if let Some(dest) = &instr.dest {
+                if removable_const_regs.contains(dest) {
+                    // This const was only used to feed a make_closure —
+                    // it's no longer needed after the rewrite.
+                    continue;
+                }
+            }
+            new_instrs.push(instr);
+            continue;
+        }
+
+        // Fast path: only call_builtin instructions are candidates.
+        if instr.op != "call_builtin" {
+            new_instrs.push(instr);
+            continue;
+        }
+
+        let builtin_name = match instr.srcs.first() {
+            Some(Operand::Var(s)) => s.clone(),
+            _ => {
+                new_instrs.push(instr);
+                continue;
+            }
+        };
+
+        match builtin_name.as_str() {
+            // ------------------------------------------------------------------
+            // make_closure fn_name_reg cap0 cap1 …
+            //   → alloc_closure(Str(fn_name), cap0, cap1, …) : "closure"
+            //
+            // srcs layout:
+            //   [0] Var("make_closure")  — builtin name
+            //   [1] Var(fn_name_reg)     — register holding the fn name
+            //   [2..] Var(cap_i)         — capture registers
+            //
+            // The dest and profiling fields are preserved.
+            // ------------------------------------------------------------------
+            "make_closure" => {
+                let name_reg = match instr.srcs.get(1) {
+                    Some(Operand::Var(r)) => r.clone(),
+                    _ => {
+                        new_instrs.push(instr);
+                        continue;
+                    }
+                };
+
+                let fn_name = match const_str_map.get(&name_reg) {
+                    Some(n) => n.clone(),
+                    // Cannot resolve name → leave unchanged.
+                    None => {
+                        new_instrs.push(instr);
+                        continue;
+                    }
+                };
+
+                // Rebuild srcs: Str(fn_name) + original captures from srcs[2..].
+                let mut new_srcs: Vec<Operand> = Vec::with_capacity(instr.srcs.len() - 1);
+                new_srcs.push(Operand::Str(fn_name));
+                for cap in &instr.srcs[2..] {
+                    new_srcs.push(cap.clone());
+                }
+
+                // Preserve dest and profiling fields; update op, srcs, type_hint.
+                let mut new_instr = IIRInstr::new(
+                    "alloc_closure",
+                    instr.dest.clone(),
+                    new_srcs,
+                    "closure",
+                );
+                // Copy profiling state so JIT speculation data is not lost.
+                new_instr.observed_slot = instr.observed_slot;
+                new_instr.observed_type = instr.observed_type;
+                new_instr.observation_count = instr.observation_count;
+                new_instr.deopt_anchor = instr.deopt_anchor;
+                new_instr.ic_slot = instr.ic_slot;
+                new_instr.may_alloc = true;
+
+                new_instrs.push(new_instr);
+            }
+
+            // ------------------------------------------------------------------
+            // apply_closure handle arg0 arg1 …
+            //   → call_closure(handle, arg0, arg1, …) : "any"
+            //
+            // srcs layout:
+            //   [0] Var("apply_closure") — builtin name
+            //   [1] Var(handle)          — the closure handle
+            //   [2..] Var(arg_i)         — user arguments
+            //
+            // After LANG34 the handle is srcs[0] in call_closure (shift by 1).
+            // ------------------------------------------------------------------
+            "apply_closure" => {
+                // Must have at least a handle (srcs[1]).
+                if instr.srcs.len() < 2 {
+                    new_instrs.push(instr);
+                    continue;
+                }
+
+                // srcs[1..] from old apply_closure become srcs[0..] in call_closure.
+                let new_srcs: Vec<Operand> = instr.srcs[1..].to_vec();
+
+                let mut new_instr = IIRInstr::new(
+                    "call_closure",
+                    instr.dest.clone(),
+                    new_srcs,
+                    "any",
+                );
+                // Preserve profiling state.
+                new_instr.observed_slot = instr.observed_slot;
+                new_instr.observed_type = instr.observed_type;
+                new_instr.observation_count = instr.observation_count;
+                new_instr.deopt_anchor = instr.deopt_anchor;
+                new_instr.ic_slot = instr.ic_slot;
+
+                new_instrs.push(new_instr);
+            }
+
+            _ => {
+                new_instrs.push(instr);
+            }
+        }
+    }
+
+    fn_.instructions = new_instrs;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::{IIRModule, IIRFunction, IIRInstr, Operand};
+    use interpreter_ir::function::FunctionTypeStatus;
+
+    fn make_module(instrs: Vec<IIRInstr>) -> IIRModule {
+        let fn_ = IIRFunction {
+            name: "main".into(),
+            params: vec![],
+            return_type: "any".into(),
+            register_count: instrs.len() + 4,
+            instructions: instrs,
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        IIRModule {
+            name: "test".into(),
+            functions: vec![fn_],
+            entry_point: Some("main".into()),
+            language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
+        }
+    }
+
+    // ── make_closure → alloc_closure ─────────────────────────────────────
+
+    /// Zero captures: const + make_closure → alloc_closure (const removed).
+    #[test]
+    fn make_closure_zero_captures_is_rewritten() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("%s0".into()),
+                vec![Operand::Var("my_fn".into())], "any"),
+            IIRInstr::new("call_builtin", Some("%c0".into()),
+                vec![
+                    Operand::Var("make_closure".into()),
+                    Operand::Var("%s0".into()),
+                ],
+                "any"),
+            IIRInstr::new("ret", None, vec![Operand::Var("%c0".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+
+        let instrs = &m.functions[0].instructions;
+        // const must be removed; first instruction is now alloc_closure.
+        assert_eq!(instrs.len(), 2, "expected 2 instructions (alloc_closure + ret)");
+        assert_eq!(instrs[0].op, "alloc_closure");
+        assert!(matches!(&instrs[0].srcs[0], Operand::Str(s) if s == "my_fn"));
+        assert!(instrs[0].srcs.len() == 1, "zero captures → 1 src");
+        assert_eq!(instrs[0].type_hint, "closure");
+        assert_eq!(instrs[0].dest.as_deref(), Some("%c0"));
+    }
+
+    /// Two captures: const + make_closure(cap0, cap1) → alloc_closure(Str, cap0, cap1).
+    #[test]
+    fn make_closure_two_captures_is_rewritten() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("%s0".into()),
+                vec![Operand::Var("add_fn".into())], "any"),
+            IIRInstr::new("call_builtin", Some("%c0".into()),
+                vec![
+                    Operand::Var("make_closure".into()),
+                    Operand::Var("%s0".into()),
+                    Operand::Var("x".into()),
+                    Operand::Var("y".into()),
+                ],
+                "any"),
+            IIRInstr::new("ret", None, vec![Operand::Var("%c0".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+
+        let instrs = &m.functions[0].instructions;
+        // const removed, alloc_closure should have 3 srcs: Str + 2 caps.
+        assert_eq!(instrs.len(), 2);
+        assert_eq!(instrs[0].op, "alloc_closure");
+        assert!(matches!(&instrs[0].srcs[0], Operand::Str(s) if s == "add_fn"));
+        assert_eq!(instrs[0].srcs.len(), 3);
+        assert_eq!(instrs[0].srcs[1], Operand::Var("x".into()));
+        assert_eq!(instrs[0].srcs[2], Operand::Var("y".into()));
+    }
+
+    /// A const used by both make_closure AND another instruction must NOT be removed.
+    #[test]
+    fn const_with_multiple_uses_is_preserved() {
+        let mut m = make_module(vec![
+            // %s0 is used by BOTH make_closure (srcs[1]) and ret (srcs[0]).
+            IIRInstr::new("const", Some("%s0".into()),
+                vec![Operand::Var("fn_name".into())], "any"),
+            IIRInstr::new("call_builtin", Some("%c0".into()),
+                vec![
+                    Operand::Var("make_closure".into()),
+                    Operand::Var("%s0".into()),
+                ],
+                "any"),
+            // Second use of %s0 — prevents const removal.
+            IIRInstr::new("ret", None, vec![Operand::Var("%s0".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+
+        let instrs = &m.functions[0].instructions;
+        // const must be retained (3 instructions total).
+        assert_eq!(instrs.len(), 3, "const with multiple uses must not be removed");
+        assert_eq!(instrs[0].op, "const");
+        assert_eq!(instrs[1].op, "alloc_closure");
+    }
+
+    /// make_closure whose fn_name_reg is not a const literal is left unchanged.
+    #[test]
+    fn unresolvable_make_closure_is_left_unchanged() {
+        let mut m = make_module(vec![
+            // %name is a function parameter, not a const → not in const_str_map.
+            IIRInstr::new("call_builtin", Some("%c0".into()),
+                vec![
+                    Operand::Var("make_closure".into()),
+                    Operand::Var("dynamic_name".into()),
+                ],
+                "any"),
+            IIRInstr::new("ret", None, vec![Operand::Var("%c0".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+
+        // Instruction must be unchanged.
+        assert_eq!(m.functions[0].instructions[0].op, "call_builtin");
+    }
+
+    // ── apply_closure → call_closure ─────────────────────────────────────
+
+    /// apply_closure(handle, arg) → call_closure(handle, arg).
+    #[test]
+    fn apply_closure_is_rewritten() {
+        let mut m = make_module(vec![
+            IIRInstr::new("call_builtin", Some("%r".into()),
+                vec![
+                    Operand::Var("apply_closure".into()),
+                    Operand::Var("clos_handle".into()),
+                    Operand::Int(42),
+                ],
+                "any"),
+            IIRInstr::new("ret", None, vec![Operand::Var("%r".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+
+        let instrs = &m.functions[0].instructions;
+        assert_eq!(instrs[0].op, "call_closure");
+        // srcs[0] is the handle (was srcs[1] in apply_closure).
+        assert_eq!(instrs[0].srcs[0], Operand::Var("clos_handle".into()));
+        assert_eq!(instrs[0].srcs[1], Operand::Int(42));
+        assert_eq!(instrs[0].type_hint, "any");
+    }
+
+    /// apply_closure with no args (no user args, just handle).
+    #[test]
+    fn apply_closure_no_args_is_rewritten() {
+        let mut m = make_module(vec![
+            IIRInstr::new("call_builtin", Some("%r".into()),
+                vec![
+                    Operand::Var("apply_closure".into()),
+                    Operand::Var("thunk".into()),
+                ],
+                "any"),
+            IIRInstr::new("ret", None, vec![Operand::Var("%r".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+
+        let instrs = &m.functions[0].instructions;
+        assert_eq!(instrs[0].op, "call_closure");
+        assert_eq!(instrs[0].srcs.len(), 1);
+        assert_eq!(instrs[0].srcs[0], Operand::Var("thunk".into()));
+    }
+
+    // ── Mixed and idempotency ─────────────────────────────────────────────
+
+    /// Module with both make_closure and apply_closure is lowered in one pass.
+    #[test]
+    fn both_forms_lowered_in_one_pass() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("%s0".into()),
+                vec![Operand::Var("inner".into())], "any"),
+            IIRInstr::new("call_builtin", Some("%c0".into()),
+                vec![
+                    Operand::Var("make_closure".into()),
+                    Operand::Var("%s0".into()),
+                ],
+                "any"),
+            IIRInstr::new("call_builtin", Some("%r0".into()),
+                vec![
+                    Operand::Var("apply_closure".into()),
+                    Operand::Var("%c0".into()),
+                    Operand::Int(5),
+                ],
+                "any"),
+            IIRInstr::new("ret", None, vec![Operand::Var("%r0".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+
+        let instrs = &m.functions[0].instructions;
+        // const removed + make_closure → alloc_closure + apply_closure → call_closure + ret
+        assert_eq!(instrs.len(), 3, "expected [alloc_closure, call_closure, ret]");
+        assert_eq!(instrs[0].op, "alloc_closure");
+        assert_eq!(instrs[1].op, "call_closure");
+        assert_eq!(instrs[2].op, "ret");
+    }
+
+    /// Running lower_closure_builtins twice is a no-op (idempotent).
+    #[test]
+    fn lowering_is_idempotent() {
+        let mut m = make_module(vec![
+            IIRInstr::new("const", Some("%s0".into()),
+                vec![Operand::Var("fn_a".into())], "any"),
+            IIRInstr::new("call_builtin", Some("%c0".into()),
+                vec![
+                    Operand::Var("make_closure".into()),
+                    Operand::Var("%s0".into()),
+                ],
+                "any"),
+            IIRInstr::new("ret", None, vec![Operand::Var("%c0".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+        let snapshot1: Vec<String> = m.functions[0].instructions.iter()
+            .map(|i| i.op.clone()).collect();
+
+        lower_closure_builtins(&mut m);
+        let snapshot2: Vec<String> = m.functions[0].instructions.iter()
+            .map(|i| i.op.clone()).collect();
+
+        assert_eq!(snapshot1, snapshot2, "second pass must be a no-op");
+    }
+
+    /// A module that already uses alloc_closure/call_closure is unchanged.
+    #[test]
+    fn already_lowered_module_is_unchanged() {
+        let mut m = make_module(vec![
+            IIRInstr::new("alloc_closure", Some("%c0".into()),
+                vec![Operand::Str("my_fn".into())], "closure"),
+            IIRInstr::new("call_closure", Some("%r0".into()),
+                vec![Operand::Var("%c0".into()), Operand::Int(1)], "any"),
+            IIRInstr::new("ret", None, vec![Operand::Var("%r0".into())], "any"),
+        ]);
+
+        lower_closure_builtins(&mut m);
+
+        let instrs = &m.functions[0].instructions;
+        assert_eq!(instrs.len(), 3);
+        assert_eq!(instrs[0].op, "alloc_closure");
+        assert_eq!(instrs[1].op, "call_closure");
+    }
+}

--- a/code/packages/rust/iir-builtin-lowering/src/lib.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lib.rs
@@ -59,8 +59,8 @@
 //! ## What this pass does NOT touch (Phase 1)
 //!
 //! - `call_builtin "cons"`, `"car"`, `"cdr"`, `"null?"` — Phase 2 (LANG31).
-//! - `call_builtin "make_closure"`, `"apply_closure"` — BEAM02 / CLR02.
-//! - `call_builtin "global_set"`, `"global_get"`, `"print"` — LANG27.
+//! - `call_builtin "make_closure"`, `"apply_closure"` — Phase 4 (LANG34).
+//! - `call_builtin "global_set"`, `"global_get"`, `"print"` — Phase 3 (LANG32).
 //! - Any other unrecognised builtin name — left entirely unchanged.
 //!
 //! ## Error handling
@@ -115,6 +115,7 @@ pub mod error;
 pub mod numeric;
 pub mod heap;
 pub mod global_io;
+pub mod closure;
 
 // We keep the `lower` module for backward compatibility with any code that
 // already imports from it, but the canonical implementation is now in
@@ -128,6 +129,8 @@ pub use error::BuiltinLoweringError;
 pub use heap::lower_heap_builtins;
 // Re-export the global/IO lowering entry point (LANG32).
 pub use global_io::lower_global_io;
+// Re-export the closure lowering entry point (LANG34).
+pub use closure::lower_closure_builtins;
 
 use interpreter_ir::IIRModule;
 
@@ -181,6 +184,17 @@ pub fn lower_builtins(module: &mut IIRModule) -> Vec<BuiltinLoweringError> {
     // instructions (the twig-ir-compiler's string-literal convention).
     // Infallible: unresolvable instructions are left unchanged.
     global_io::lower_global_io(module);
+
+    // ── Phase 4: closure builtins (LANG34) ────────────────────────────────
+    //
+    // Rewrites legacy call_builtin forms to first-class closure opcodes:
+    //   call_builtin "make_closure" fn_name_reg cap0…  →  alloc_closure(Str(fn_name), cap0…)
+    //   call_builtin "apply_closure" handle arg0…      →  call_closure(handle, arg0…)
+    //
+    // Must run last (after global/IO lowering) so the const-string look-back
+    // sees a stable instruction list.  Infallible: unresolvable instructions
+    // are left unchanged for the backend validator or twig-vm fallback.
+    closure::lower_closure_builtins(module);
 
     all_errors
 }

--- a/code/packages/rust/iir-builtin-lowering/tests/test_lowering.rs
+++ b/code/packages/rust/iir-builtin-lowering/tests/test_lowering.rs
@@ -1185,8 +1185,12 @@ fn test_72_pair_pred_left_unchanged() {
 }
 
 #[test]
-fn test_73_make_closure_left_unchanged() {
-    // make_closure is a BEAM02/CLR02 builtin and must survive untouched.
+fn test_73_make_closure_unresolvable_left_unchanged() {
+    // Phase 4 (LANG34) lowers make_closure only when the fn_name register
+    // can be resolved to a compile-time string literal via a preceding const
+    // instruction.  When the register (%fn here) has no such const, the
+    // instruction is left unchanged so the backend validator or twig-vm
+    // fallback can handle it.
     let instr = IIRInstr::new(
         "call_builtin",
         Some("%clos".into()),

--- a/code/packages/rust/interpreter-ir/CHANGELOG.md
+++ b/code/packages/rust/interpreter-ir/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog — interpreter-ir
 
+## [0.6.0] — 2026-05-12
+
+### Added (LANG34 — First-Class Closure Opcodes)
+
+#### `CLOSURE_TYPE` constant
+
+- `pub const CLOSURE_TYPE: &str = "closure"` — the type hint produced by
+  `alloc_closure` instructions.  Not a scalar (not in `CONCRETE_TYPES`);
+  `iir-to-*` numeric backends correctly reject it.
+
+#### `is_closure_op` predicate
+
+- `pub fn is_closure_op(op: &str) -> bool` — returns `true` for
+  `"alloc_closure"` and `"call_closure"`.
+
+#### Predicate updates
+
+- `is_value_producing` now includes `"alloc_closure"` and `"call_closure"`.
+- `is_allocating` now includes `"alloc_closure"` (`may_alloc = true`).
+- `is_known_op` now includes `is_global` (`global_load`/`global_store` were
+  previously missing) and `is_closure_op`.
+
+#### Tests
+
+5 new unit tests in `opcodes.rs`:
+`closure_type_constant`, `is_closure_op_recognised`, `closure_ops_are_known`,
+`alloc_closure_is_allocating`, `closure_ops_are_value_producing`.
+
+---
+
 ## [0.5.0] — 2026-05-11
 
 ### Added (LANG33 — Module System at the IIR Level)

--- a/code/packages/rust/interpreter-ir/Cargo.toml
+++ b/code/packages/rust/interpreter-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpreter-ir"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "InterpreterIR (IIR) — the bytecode for the LANG JIT/AOT pipeline"
 

--- a/code/packages/rust/interpreter-ir/src/opcodes.rs
+++ b/code/packages/rust/interpreter-ir/src/opcodes.rs
@@ -54,6 +54,21 @@ pub const DYNAMIC_TYPE: &str = "any";
 /// — the value is too variable to fix at compile time.
 pub const POLYMORPHIC_TYPE: &str = "polymorphic";
 
+/// The type hint produced by `alloc_closure` instructions (LANG34).
+///
+/// A closure value is a heap-allocated record pairing a function name with
+/// a vector of captured variable values.  The `"closure"` type is NOT in
+/// `CONCRETE_TYPES` — it is not a scalar and the numeric `iir-to-*` backends
+/// reject it (closures are not JVM primitives or WASM scalars).
+///
+/// ```
+/// use interpreter_ir::opcodes::{CLOSURE_TYPE, is_closure_op};
+/// assert_eq!(CLOSURE_TYPE, "closure");
+/// assert!(is_closure_op("alloc_closure"));
+/// assert!(is_closure_op("call_closure"));
+/// ```
+pub const CLOSURE_TYPE: &str = "closure";
+
 /// The concrete types recognised by every LANG-pipeline backend.
 ///
 /// Language frontends may use additional type strings; these are the ones
@@ -176,6 +191,27 @@ pub fn is_io(op: &str) -> bool {
     matches!(op, "io_in" | "io_out")
 }
 
+/// Closure allocation and application opcodes (LANG34).
+///
+/// | Opcode | Meaning |
+/// |--------|---------|
+/// | `alloc_closure` | Allocate a closure: `srcs[0] = Operand::Str(fn_name)`, `srcs[1..] = captures` |
+/// | `call_closure`  | Invoke a closure: `srcs[0] = handle`, `srcs[1..] = user args` |
+///
+/// Both opcodes are value-producing (`dest` is always `Some`).
+/// `alloc_closure` is also allocating (`may_alloc = true`).
+///
+/// ```
+/// use interpreter_ir::opcodes::is_closure_op;
+/// assert!(is_closure_op("alloc_closure"));
+/// assert!(is_closure_op("call_closure"));
+/// assert!(!is_closure_op("call_builtin"));
+/// assert!(!is_closure_op("call"));
+/// ```
+pub fn is_closure_op(op: &str) -> bool {
+    matches!(op, "alloc_closure" | "call_closure")
+}
+
 /// Type coercions and assertions.
 pub fn is_coercion(op: &str) -> bool {
     matches!(op, "cast" | "type_assert")
@@ -243,6 +279,9 @@ pub fn is_value_producing(op: &str) -> bool {
                 | "is_null"
                 // Global variable read (LANG32)
                 | "global_load"
+                // Closure allocation and application (LANG34)
+                | "alloc_closure"
+                | "call_closure"
                 // Concurrency ops that produce a dest value (LANG28)
                 | "task_spawn"
                 | "task_current"
@@ -329,6 +368,8 @@ pub fn is_allocating(op: &str) -> bool {
     matches!(
         op,
         "alloc" | "box" | "safepoint"
+            // Closure allocation (LANG34)
+            | "alloc_closure"
             // Concurrency allocators (LANG28)
             | "task_spawn"
             | "group_new"
@@ -687,6 +728,8 @@ pub fn is_known_op(op: &str) -> bool {
         || is_io(op)
         || is_coercion(op)
         || is_heap(op)
+        || is_global(op)
+        || is_closure_op(op)
         || is_concurrency(op)
 }
 
@@ -743,10 +786,55 @@ mod tests {
         for op in &[
             "const", "add", "sub", "and", "cmp_eq", "jmp", "label", "ret",
             "load_reg", "call", "io_in", "cast", "alloc",
+            // LANG32 global ops
+            "global_load", "global_store",
+            // LANG34 closure ops
+            "alloc_closure", "call_closure",
         ] {
             assert!(is_known_op(op), "{op}");
         }
         assert!(!is_known_op("tetrad.move"));
+    }
+
+    // ── LANG34 closure opcode tests ───────────────────────────────────────────
+
+    #[test]
+    fn closure_type_constant() {
+        assert_eq!(CLOSURE_TYPE, "closure");
+        // "closure" is NOT a concrete scalar type — backends should reject it.
+        assert!(!is_concrete_type(CLOSURE_TYPE));
+        // "closure" is NOT in the polymorphic/dynamic sentinel set.
+        assert_ne!(CLOSURE_TYPE, DYNAMIC_TYPE);
+        assert_ne!(CLOSURE_TYPE, POLYMORPHIC_TYPE);
+    }
+
+    #[test]
+    fn is_closure_op_recognised() {
+        assert!(is_closure_op("alloc_closure"), "alloc_closure must be a closure op");
+        assert!(is_closure_op("call_closure"), "call_closure must be a closure op");
+        // Older call_builtin forms are NOT closure ops (they stay as call ops).
+        assert!(!is_closure_op("call_builtin"));
+        assert!(!is_closure_op("call"));
+        assert!(!is_closure_op("const"));
+    }
+
+    #[test]
+    fn closure_ops_are_known() {
+        assert!(is_known_op("alloc_closure"));
+        assert!(is_known_op("call_closure"));
+    }
+
+    #[test]
+    fn alloc_closure_is_allocating() {
+        assert!(is_allocating("alloc_closure"));
+        // call_closure does not allocate — it invokes an already-allocated closure.
+        assert!(!is_allocating("call_closure"));
+    }
+
+    #[test]
+    fn closure_ops_are_value_producing() {
+        assert!(is_value_producing("alloc_closure"));
+        assert!(is_value_producing("call_closure"));
     }
 
     // ── LANG28 concurrency predicate tests ────────────────────────────────────

--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog — twig-ir-compiler
 
+## [0.3.0] — 2026-05-12
+
+### Changed (LANG34 — Emit alloc_closure / call_closure)
+
+Three emission sites updated to use the LANG34 first-class closure opcodes:
+
+#### Lambda allocation (`compile_anonymous_lambda`)
+
+```
+BEFORE:
+  %s0 = const("__lambda_N")          ← string_arg indirection
+  %c0 = call_builtin("make_closure", %s0, caps...) : "any"
+
+AFTER:
+  %c0 = alloc_closure(Str("__lambda_N"), caps...) : "closure"
+```
+
+No preceding `const` instruction is emitted; `fn_name` is now an inline
+`Operand::Str` in `srcs[0]`.
+
+#### Top-level function as value (`compile_var_ref` / fn_globals)
+
+```
+BEFORE:
+  %s0 = const("fn_name")
+  %fnref = call_builtin("make_closure", %s0) : "any"
+
+AFTER:
+  %fnref = alloc_closure(Str("fn_name")) : "closure"
+```
+
+#### Indirect call (`compile_apply`, indirect path)
+
+```
+BEFORE:
+  %r = call_builtin("apply_closure", %handle, args...) : "any"
+
+AFTER:
+  %r = call_closure(%handle, args...) : "any"
+```
+
+The `string_arg` helper is retained for `global_set`/`global_get`/`make_symbol`
+which still use the const-via-Var register convention.
+
+#### Tests updated
+
+Three tests renamed/updated to assert the new opcode forms:
+- `anonymous_lambda_emits_make_closure` → `anonymous_lambda_emits_alloc_closure`
+- `closure_call_uses_apply_closure` → `closure_call_uses_call_closure`
+- `fn_globals_can_be_passed_as_values` (assertion updated)
+
+---
+
 ## [0.2.1] — 2026-05-11
 
 ### Fixed (LANG33 — Module System)

--- a/code/packages/rust/twig-ir-compiler/Cargo.toml
+++ b/code/packages/rust/twig-ir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-ir-compiler"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler"
 

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -39,24 +39,30 @@
 //! |-----------------------------|---------------------------------------------|
 //! | Top-level user fn name      | `call <name>, ...args`                      |
 //! | Builtin name (`+`, `cons`)  | `call_builtin <name>, ...args`              |
-//! | Anything else (locals etc.) | `call_builtin "apply_closure", h, ...args`  |
+//! | Anything else (locals etc.) | `call_closure h, ...args` (LANG34)          |
 //!
 //! Top-level recursion stays on the fast `call` path; only locals
 //! holding closures pay the indirect cost.
 //!
-//! ## Encoding string operands
+//! ## LANG34 closure opcodes
 //!
-//! `interpreter_ir::Operand` doesn't have a dedicated `String` variant —
-//! the four variants are `Var`, `Int`, `Float`, `Bool`.  Where the IR
-//! semantically needs a string literal (e.g. the function name passed
-//! to `make_closure`, or the global key passed to `global_set`), we
-//! materialise it via a `const` instruction whose source operand is a
-//! `Operand::Var(literal_text)`.  The `vm-core` `const` handler stores
-//! the literal verbatim — Python's `IIRInstr("const", v, ["text"])`
-//! and Rust's `IIRInstr("const", Some(v), [Operand::Var("text")])`
-//! round-trip identically through the runtime.  The *destination*
-//! variable then carries the string, and downstream `call_builtin`
-//! ops resolve it through the frame in the normal way.
+//! Since LANG34 the compiler emits first-class closure opcodes instead of
+//! routing through `call_builtin`:
+//!
+//! - Lambda allocation: `alloc_closure(Str(fn_name), cap0, cap1, …) : "closure"`
+//!   The function name is an inline `Operand::Str` — no preceding `const`
+//!   instruction is needed.  The old `string_arg` helper is retained for
+//!   `global_set`/`global_get` / `make_symbol` uses.
+//! - Indirect calls: `call_closure(handle, arg0, arg1, …) : "any"`
+//!   Replaces the former `call_builtin "apply_closure" handle args…` form.
+//!
+//! ## Encoding string operands (for globals and symbols)
+//!
+//! `Operand::Str(literal)` is now the canonical way to embed a compile-time
+//! string in an instruction.  The `string_arg` helper (which emits a `const`
+//! with `Operand::Var(literal)`) is retained for operations that still need
+//! the old convention: `global_set`, `global_get`, `make_symbol`.  See the
+//! LANG32 spec for details on the `global_load`/`global_store` lowering pass.
 
 use std::collections::HashSet;
 
@@ -492,21 +498,20 @@ impl Compiler {
             return_refinement: None,
         });
 
-        // 3. Emit `make_closure` at the call site.
-        // The fn_name is itself a string literal — we materialise it
-        // via `const` so it survives the runtime's frame resolution
-        // (see the module-level "Encoding string operands" comment).
-        let fn_name_reg = self.string_arg(outer, &fn_name, lam_loc);
+        // 3. Emit `alloc_closure` at the call site (LANG34).
+        //
+        // The function name is now an inline `Operand::Str` — no preceding
+        // `const` instruction is needed.  This is cleaner than the old
+        // `string_arg` / `call_builtin "make_closure"` convention and
+        // makes the callee name statically visible in the IR for analysis
+        // passes and the iir-to-* backends.
         let dest = outer.fresh_var("clos");
-        let mut srcs: Vec<Operand> = vec![
-            Operand::Var("make_closure".into()),
-            Operand::Var(fn_name_reg),
-        ];
+        let mut srcs: Vec<Operand> = vec![Operand::Str(fn_name.clone())];
         for c in &captures {
             srcs.push(Operand::Var(c.clone()));
         }
         outer.emit(
-            IIRInstr::new("call_builtin", Some(dest.clone()), srcs, "any"),
+            IIRInstr::new("alloc_closure", Some(dest.clone()), srcs, "closure"),
             lam_loc,
         );
         Ok(dest)
@@ -618,14 +623,17 @@ impl Compiler {
 
         // Top-level function — wrap in a 0-capture closure handle so
         // the value can be passed around or applied later.
+        //
+        // LANG34: emit `alloc_closure(Str(fn_name))` instead of the old
+        // `string_arg + call_builtin "make_closure"` form.  A 0-capture
+        // closure is perfectly valid; exec_alloc_closure handles it.
         if self.fn_globals.contains(&v.name) {
-            let name_reg = self.string_arg(ctx, &v.name, loc);
             let dest = ctx.fresh_var("fnref");
             ctx.emit(IIRInstr::new(
-                "call_builtin",
+                "alloc_closure",
                 Some(dest.clone()),
-                vec![Operand::Var("make_closure".into()), Operand::Var(name_reg)],
-                "any",
+                vec![Operand::Str(v.name.clone())],
+                "closure",
             ), loc);
             return Ok(dest);
         }
@@ -804,19 +812,19 @@ impl Compiler {
         }
 
         // Indirect: compile the fn expression to a closure handle, then
-        // route through the `apply_closure` builtin.
+        // invoke via `call_closure` (LANG34).
+        //
+        // Before LANG34 this emitted `call_builtin "apply_closure" handle args…`.
+        // Now: the handle is srcs[0] directly — no leading name-string operand.
         let fn_handle = self.compile_expr(&expr.fn_expr, ctx)?;
-        let mut srcs: Vec<Operand> = vec![
-            Operand::Var("apply_closure".into()),
-            Operand::Var(fn_handle),
-        ];
+        let mut srcs: Vec<Operand> = vec![Operand::Var(fn_handle)];
         for a in &expr.args {
             let r = self.compile_expr(a, ctx)?;
             srcs.push(Operand::Var(r));
         }
         let dest = ctx.fresh_var("r");
         ctx.emit(IIRInstr::new(
-            "call_builtin",
+            "call_closure",
             Some(dest.clone()),
             srcs,
             "any",
@@ -832,12 +840,15 @@ impl Compiler {
     /// the register's name.
     ///
     /// Used when a `call_builtin` needs a literal string as one of its
-    /// runtime arguments — e.g. the `name` argument to `make_closure`,
-    /// `make_symbol`, `global_set`, `global_get`.  See the module-
-    /// level "Encoding string operands" comment for why we pass the
-    /// string through `Operand::Var` rather than via a dedicated
-    /// `Operand::Str` variant (which would require modifying the
-    /// shared `interpreter-ir` crate).
+    /// runtime arguments — e.g. the `name` argument to `make_symbol`,
+    /// `global_set`, `global_get`.  The string is emitted as a `const`
+    /// instruction whose source is `Operand::Var(literal_text)`, which the
+    /// twig-vm `const` handler interns as a symbol.
+    ///
+    /// **Note:** `alloc_closure` (LANG34) no longer uses `string_arg` — the
+    /// function name is embedded inline as `Operand::Str` in the instruction
+    /// itself.  `string_arg` is retained only for the operations above that
+    /// still require the register-materialised convention.
     fn string_arg(&mut self, ctx: &mut FnCtx, literal: &str, loc: SourceLoc) -> String {
         let v = ctx.fresh_var("s");
         ctx.emit(IIRInstr::new(

--- a/code/packages/rust/twig-ir-compiler/src/lib.rs
+++ b/code/packages/rust/twig-ir-compiler/src/lib.rs
@@ -421,11 +421,27 @@ mod tests {
     }
 
     #[test]
-    fn anonymous_lambda_emits_make_closure() {
+    fn anonymous_lambda_emits_alloc_closure() {
+        // LANG34: compiler now emits alloc_closure instead of call_builtin "make_closure".
+        // srcs[0] must be Operand::Str(fn_name) and type_hint must be "closure".
         let i = fn_instrs("(define (adder n) (lambda (x) (+ x n)))", "adder");
-        let mc = i.iter().find(|x| x.op == "call_builtin"
-            && matches!(&x.srcs[0], Operand::Var(s) if s == "make_closure"));
-        assert!(mc.is_some(), "expected make_closure call_builtin in adder");
+        let ac = i.iter().find(|x| x.op == "alloc_closure");
+        assert!(ac.is_some(), "expected alloc_closure instruction in adder");
+        let ac = ac.unwrap();
+        // srcs[0] must be an Operand::Str carrying the synthesised lambda name.
+        assert!(
+            matches!(&ac.srcs[0], Operand::Str(s) if s.starts_with("__lambda_")),
+            "alloc_closure srcs[0] must be Operand::Str(__lambda_N), got {:?}", &ac.srcs[0]
+        );
+        assert_eq!(ac.type_hint, "closure", "alloc_closure type_hint must be 'closure'");
+        // No preceding const instruction should materialise the fn_name.
+        let const_before = i.iter().rev().skip_while(|x| x.op != "alloc_closure").skip(1).next();
+        if let Some(prev) = const_before {
+            assert_ne!(
+                prev.op, "const",
+                "alloc_closure must NOT be preceded by a const instruction for fn_name"
+            );
+        }
     }
 
     #[test]
@@ -438,17 +454,24 @@ mod tests {
     }
 
     #[test]
-    fn closure_call_uses_apply_closure() {
-        // ((adder 5) 3) — the inner (adder 5) returns a closure
-        // handle; the outer call goes through apply_closure.
+    fn closure_call_uses_call_closure() {
+        // LANG34: indirect call now emits `call_closure` instead of
+        // `call_builtin "apply_closure"`.
+        // ((adder 5) 3) — the inner (adder 5) returns a closure handle;
+        // the outer call goes through call_closure.
         let m = module(
             "(define (adder n) (lambda (x) (+ x n)))\n\
              ((adder 5) 3)",
         );
         let main = m.functions.iter().find(|f| f.name == "main").unwrap();
-        let ac = main.instructions.iter().find(|x| x.op == "call_builtin"
-            && matches!(&x.srcs[0], Operand::Var(s) if s == "apply_closure"));
-        assert!(ac.is_some(), "expected apply_closure call_builtin in main");
+        let cc = main.instructions.iter().find(|x| x.op == "call_closure");
+        assert!(cc.is_some(), "expected call_closure instruction in main");
+        let cc = cc.unwrap();
+        // srcs[0] must be a Var (the closure handle register), not a Str or name-string.
+        assert!(
+            matches!(&cc.srcs[0], Operand::Var(_)),
+            "call_closure srcs[0] must be Operand::Var(handle), got {:?}", &cc.srcs[0]
+        );
     }
 
     #[test]
@@ -467,13 +490,14 @@ mod tests {
 
     #[test]
     fn fn_globals_can_be_passed_as_values() {
-        // Reference to top-level fn name in non-call position
-        // produces a `make_closure` (0 captures).
+        // LANG34: Reference to top-level fn name in non-call position
+        // produces an `alloc_closure` (0 captures) instead of
+        // `call_builtin "make_closure"`.
         let m = module("(define (id x) x) id");
         let main = m.functions.iter().find(|f| f.name == "main").unwrap();
-        let mc = main.instructions.iter().find(|x| x.op == "call_builtin"
-            && matches!(&x.srcs[0], Operand::Var(s) if s == "make_closure"));
-        assert!(mc.is_some(), "fn-as-value should wrap in make_closure");
+        let ac = main.instructions.iter().find(|x| x.op == "alloc_closure"
+            && matches!(&x.srcs[0], Operand::Str(s) if s == "id"));
+        assert!(ac.is_some(), "fn-as-value should emit alloc_closure(Str('id'))");
     }
 
     #[test]

--- a/code/packages/rust/twig-vm/CHANGELOG.md
+++ b/code/packages/rust/twig-vm/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog — twig-vm
 
+## [0.10.0] — 2026-05-12
+
+### Added (LANG34 — First-Class Closure Dispatch)
+
+#### New dispatch arms: `alloc_closure` / `call_closure`
+
+The main dispatch loop now handles two new opcodes:
+
+- **`alloc_closure`** (`exec_alloc_closure`):
+  - Reads `srcs[0]` as `Operand::Str(fn_name)` (no register lookup).
+  - Interns `fn_name` to a `SymbolId`; collects captures from `srcs[1..]`.
+  - Calls `lispy_runtime::alloc_closure` — same heap representation as the
+    legacy `make_closure` builtin path.
+  - Errors with `MalformedInstruction` if `srcs[0]` is not `Operand::Str`.
+
+- **`call_closure`** (`exec_call_closure`):
+  - Reads closure handle from `srcs[0]` (shifted vs. `apply_closure`'s `srcs[1]`).
+  - Reads user args from `srcs[1..]`.
+  - Otherwise identical to `exec_apply_closure`: prepend captures, recurse
+    into `dispatch` for user fns; `resolve_builtin` for builtin closures.
+  - Errors with `NotCallable` if `srcs[0]` is not a closure handle.
+
+The legacy `call_builtin "make_closure"` / `"apply_closure"` arms in
+`exec_call_builtin` are retained for backward compatibility.
+
+#### Tests
+
+7 new tests:
+- `alloc_and_call_closure_no_captures` — zero-capture closure
+- `alloc_and_call_closure_with_one_capture` — single capture (x+y=15)
+- `alloc_and_call_closure_with_two_captures` — two captures (a+b+y=12)
+- `alloc_closure_wrong_operand_type_errors` — MalformedInstruction on non-Str srcs[0]
+- `call_closure_on_non_closure_errors` — NotCallable on non-closure
+- `e2e_lambda_with_capture_via_new_opcodes` — curried add via compiler
+- `e2e_make_adder_with_new_opcodes` — make-adder pattern via compiler
+
+---
+
 ## [0.9.0] — 2026-05-11
 
 ### Changed (LANG32 — Operand::Str exhaustiveness)

--- a/code/packages/rust/twig-vm/Cargo.toml
+++ b/code/packages/rust/twig-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-vm"
-version = "0.8.0"
+version = "0.10.0"
 edition = "2021"
 description = "LANG26 — host/ I/O builtins (write_byte, read_byte, exit, flush_stdout) via Rust stdlib dispatch"
 

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -1300,6 +1300,17 @@ fn exec_call(
         .find(|f| f.name == callee_name)
         .ok_or_else(|| RunError::UnknownFunction(callee_name.to_string()))?;
 
+    // DoS guard — mirrors exec_call_builtin, exec_apply_closure, exec_send, etc.
+    // A hand-crafted IIR `call` instruction with millions of srcs would OOM via
+    // Vec::with_capacity before the budget check fires (one tick per instruction,
+    // not per operand).
+    if instr.srcs.len() > MAX_REGISTERS_PER_FRAME {
+        return Err(RunError::MalformedInstruction(format!(
+            "call: srcs.len()={} exceeds MAX_REGISTERS_PER_FRAME ({MAX_REGISTERS_PER_FRAME})",
+            instr.srcs.len()
+        )));
+    }
+
     let mut call_args: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len().saturating_sub(1));
     for src in &instr.srcs[1..] {
         let frame_ref = &*frame;

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -1407,10 +1407,12 @@ fn exec_apply_closure(
     let frame_ref = &*frame;
     let handle = operand_to_value(&instr.srcs[1], &|n| frame_ref.get(n))
         .map_err(RunError::OperandConversion)?;
-    // SAFETY: closure values come from `make_closure` /
-    // `make_builtin_closure` which go through alloc_*_closure;
-    // those return properly-tagged heap pointers that live forever
-    // (PR 2 leak).  `as_closure` walks the header; safe to call.
+    // SAFETY: see the detailed comment in exec_call_closure for the full
+    // invariant analysis.  Summary: only values with TAG_HEAP set (from
+    // alloc_closure / alloc_cons / etc.) are dereferenced; integers, booleans,
+    // and symbols all have non-HEAP tags and cause as_heap_ptr() to return None
+    // before any pointer dereference occurs.  Heap-tagged values come
+    // exclusively from lispy_runtime allocators that Box::leak aligned objects.
     let closure = unsafe { lispy_runtime::as_closure(handle) }.ok_or_else(|| {
         RunError::NotCallable(format!("apply_closure: {handle} is not a closure"))
     })?;
@@ -1521,7 +1523,11 @@ fn exec_alloc_closure(
     // names as interned symbol ids for O(1) equality checks.
     let sym_id = intern(fn_name);
     if sym_id == SymbolId::NONE {
-        return Err(RunError::Runtime(RuntimeError::TypeError(format!(
+        // Use RuntimeError::Custom, not TypeError — this is a resource-
+        // exhaustion condition (the symbol intern table is full), not a
+        // type mismatch.  Callers that need to distinguish resource errors
+        // from type errors should match on Custom("intern table exhausted").
+        return Err(RunError::Runtime(RuntimeError::Custom(format!(
             "alloc_closure: intern table exhausted for fn_name {fn_name:?}"
         ))));
     }
@@ -1578,11 +1584,31 @@ fn exec_call_closure(
     let handle = operand_to_value(&instr.srcs[0], &|n| frame_ref.get(n))
         .map_err(RunError::OperandConversion)?;
 
-    // SAFETY: closure values come from alloc_closure / exec_alloc_closure or
-    // the legacy make_closure builtin — all of which go through
-    // lispy_runtime::heap::alloc_closure which returns a properly-tagged heap
-    // pointer.  `as_closure` walks the 16-byte header tag; safe to call on
-    // any value, returns None for non-closures.
+    // SAFETY: `lispy_runtime::as_closure` is an `unsafe fn` that:
+    //
+    //   1. Calls `handle.as_heap_ptr()` which first checks the tag bits.
+    //      LispyValue's tag encoding uses TAG_INT = 0b000, TAG_HEAP = 0b111,
+    //      TAG_TRUE = 0b011, TAG_FALSE = 0b001, TAG_SYMBOL = 0b101, TAG_NIL = 0b010.
+    //      Only values produced by `alloc_closure`, `alloc_cons`, etc. have
+    //      TAG_HEAP set.  Integers, booleans, and symbols will cause
+    //      `as_heap_ptr()` to return `None` → `as_closure` immediately returns
+    //      `None` — no pointer dereference occurs.
+    //
+    //   2. For values that DO have TAG_HEAP, the pointer was produced by
+    //      `lispy_runtime::heap::alloc_closure` / `alloc_cons` / etc. which
+    //      Box::leak a properly-aligned heap allocation with a valid
+    //      `ObjectHeader` at offset 0.  Dereferencing that pointer to read
+    //      `class_or_kind` is safe given the leak-forever invariant.
+    //
+    //   3. An adversarially crafted IIR integer that happens to have the
+    //      low 3 bits set (TAG_HEAP) CANNOT be produced by `exec_const`
+    //      for `Operand::Int(n)`, because `LispyValue::int(n)` shifts
+    //      left by 3 bits making the low 3 bits always 0 (TAG_INT = 0b000).
+    //      The only way to introduce an invalid heap-tagged value would be
+    //      through a foreign `unsafe` block — which does not exist in the
+    //      normal IIR execution path.
+    //
+    // Together, these guarantees make the call safe in the twig-vm context.
     let closure = unsafe { lispy_runtime::as_closure(handle) }.ok_or_else(|| {
         RunError::NotCallable(format!("call_closure: {handle} is not a closure"))
     })?;
@@ -1600,14 +1626,21 @@ fn exec_call_closure(
 
     let result = if is_builtin {
         // Builtin closure: dispatch via resolve_builtin.
-        // Defence-in-depth: assert no captures (a well-formed builtin closure
-        // has none; LANG34's alloc_closure would never produce captures for a
-        // builtin, but malformed IR could).
-        debug_assert!(
-            captures.is_empty(),
-            "builtin closure must have no captures (got {})",
-            captures.len(),
-        );
+        //
+        // Hard runtime guard: a well-formed builtin closure must have zero
+        // captures.  `make_builtin_closure` / `alloc_builtin_closure` never
+        // attach captures; LANG34's `alloc_closure` is for user functions only.
+        // Reject malformed IR that somehow produces a builtin closure with
+        // non-empty captures — this is not a style check, it is a correctness
+        // boundary: passing captures to `builtin(&user_args)` would silently
+        // drop them and produce wrong results.  We enforce it unconditionally
+        // (not just in debug builds) so release builds are equally protected.
+        if !captures.is_empty() {
+            return Err(RunError::MalformedInstruction(format!(
+                "call_closure: builtin closure must have no captures, got {}",
+                captures.len()
+            )));
+        }
         let name_str = name_of(fn_name_id).ok_or_else(|| {
             RunError::MalformedInstruction(format!(
                 "call_closure: builtin closure has unknown fn_name id {}",

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -1519,6 +1519,23 @@ fn exec_alloc_closure(
         )),
     };
 
+    // Guard against absurdly long fn_name strings.
+    //
+    // `intern()` adds every unique string to a global table that is never
+    // freed (the leak-forever invariant that `as_closure` relies on).
+    // Without a length cap, a malicious IIR module could carry a very long
+    // or high-entropy fn_name and consume unbounded memory on every
+    // `alloc_closure` execution.  The cap is generous enough to accommodate
+    // any reasonable compiler-generated name (the twig-ir-compiler emits
+    // names like `__lambda_0`, `adder`, etc.) while excluding payloads.
+    const MAX_FN_NAME_LEN: usize = 512;
+    if fn_name.len() > MAX_FN_NAME_LEN {
+        return Err(RunError::MalformedInstruction(format!(
+            "alloc_closure: fn_name exceeds maximum length ({} > {MAX_FN_NAME_LEN})",
+            fn_name.len()
+        )));
+    }
+
     // Intern the function name to a SymbolId — the closure heap record stores
     // names as interned symbol ids for O(1) equality checks.
     let sym_id = intern(fn_name);
@@ -1652,6 +1669,14 @@ fn exec_call_closure(
         builtin(&user_args).map_err(RunError::Runtime)?
     } else {
         // User-fn closure: prepend captures to args then recurse.
+        //
+        // Depth / stack-overflow protection: `dispatch` itself checks
+        // `depth > MAX_DISPATCH_DEPTH` at entry and returns `RunError::DepthExceeded`
+        // before any allocation or further recursion.  Passing `depth + 1`
+        // here means the guard fires on the *next* call, bounding the
+        // total native call-stack depth to MAX_DISPATCH_DEPTH + 1 (256 + 1 = 257
+        // by default).  This is consistent with `exec_apply_closure` and
+        // `exec_call` which use the same `depth + 1` pattern.
         let mut all_args = captures;
         all_args.extend(user_args);
         let name_str = name_of(fn_name_id).ok_or_else(|| {

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -1429,16 +1429,20 @@ fn exec_apply_closure(
     }
 
     let result = if is_builtin {
-        // Defense-in-depth: a well-formed `make_builtin_closure`
-        // produces no captures, but we explicitly assert this so a
-        // malformed Closure (`flags = CLOSURE_FLAG_BUILTIN` AND
-        // non-empty captures via `Closure` field-level access) can't
-        // silently drop captures.  Found by PR 5 security review (#2).
-        debug_assert!(
-            captures.is_empty(),
-            "builtin closure must have no captures (got {})",
-            captures.len(),
-        );
+        // Hard runtime guard: a well-formed builtin closure must have zero
+        // captures.  `make_builtin_closure` / `alloc_builtin_closure` never
+        // attach captures.  A malformed closure with CLOSURE_FLAG_BUILTIN AND
+        // non-empty captures would silently drop those captures if we only used
+        // debug_assert! (which is a no-op in --release).  Replacing it with a
+        // hard error means release builds are equally protected, matching the
+        // same guard in exec_call_closure.  Originally found by PR 5 review;
+        // upgraded to hard error in LANG34 security review.
+        if !captures.is_empty() {
+            return Err(RunError::MalformedInstruction(format!(
+                "apply_closure: builtin closure must have no captures, got {}",
+                captures.len()
+            )));
+        }
         // Builtin closure: dispatch via resolve_builtin.
         let name_str = name_of(fn_name_id).ok_or_else(|| {
             RunError::MalformedInstruction(format!(
@@ -1549,6 +1553,20 @@ fn exec_alloc_closure(
         ))));
     }
 
+    // DoS guard — mirrors the cap added for exec_send.
+    //
+    // `instr.srcs.len()` is controlled by the IIR module, which could be
+    // hand-crafted with millions of operands.  Without a cap the
+    // Vec::with_capacity call below would attempt a huge heap allocation
+    // before the budget or depth check fires.  Well-formed Twig programs
+    // never come close to MAX_REGISTERS_PER_FRAME captures.
+    if instr.srcs.len() > MAX_REGISTERS_PER_FRAME {
+        return Err(RunError::MalformedInstruction(format!(
+            "alloc_closure: srcs.len()={} exceeds MAX_REGISTERS_PER_FRAME ({MAX_REGISTERS_PER_FRAME})",
+            instr.srcs.len()
+        )));
+    }
+
     // Collect captured values from srcs[1..].
     let frame_ref = &*frame;
     let mut captures: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len().saturating_sub(1));
@@ -1594,6 +1612,19 @@ fn exec_call_closure(
         return Err(RunError::MalformedInstruction(
             "call_closure requires at least 1 src (closure handle)".into()
         ));
+    }
+
+    // DoS guard — mirrors the cap added for exec_send.
+    //
+    // A hand-crafted IIR module can embed a call_closure instruction with
+    // millions of srcs; Vec::with_capacity below would OOM before the budget
+    // or depth guard fires.  One budget tick per instruction means a single
+    // malformed call_closure consumes only 1 tick, not proportional to srcs.
+    if instr.srcs.len() > MAX_REGISTERS_PER_FRAME {
+        return Err(RunError::MalformedInstruction(format!(
+            "call_closure: srcs.len()={} exceeds MAX_REGISTERS_PER_FRAME ({MAX_REGISTERS_PER_FRAME})",
+            instr.srcs.len()
+        )));
     }
 
     // srcs[0] is the closure handle variable.

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -30,6 +30,8 @@
 //! | `send`             | (PR 6) dispatch a method via `LangBinding::send_message` |
 //! | `load_property`    | (PR 6) read a property via `LangBinding::load_property` |
 //! | `store_property`   | (PR 6) write a property via `LangBinding::store_property` |
+//! | `alloc_closure`    | (LANG34) allocate closure: `srcs[0] = Str(fn_name)`, `srcs[1..] = captures` |
+//! | `call_closure`     | (LANG34) invoke closure: `srcs[0] = handle`, `srcs[1..] = user args` |
 //!
 //! ### Special-cased `call_builtin` names (PR 5)
 //!
@@ -1053,6 +1055,24 @@ fn dispatch(
             "ret" => {
                 return exec_ret(instr, &frame);
             }
+            // ── LANG34: first-class closure opcodes ──────────────────────────
+            //
+            // `alloc_closure` and `call_closure` are the successor forms of
+            // the older `call_builtin "make_closure"` / `"apply_closure"` that
+            // required a preceding `const` instruction to materialise the
+            // function name as a register value.  The new opcodes carry the
+            // fn_name inline as `Operand::Str` (no register lookup).
+            //
+            // The old `call_builtin` forms remain in `exec_call_builtin` for
+            // backward compatibility with existing compiled modules.
+            "alloc_closure" => {
+                exec_alloc_closure(instr, &mut frame)?;
+                pc += 1;
+            }
+            "call_closure" => {
+                exec_call_closure(module, instr, &mut frame, depth, budget, globals, ic_table, profile, debug)?;
+                pc += 1;
+            }
             other => {
                 return Err(RunError::UnsupportedOpcode(other.to_string()));
             }
@@ -1435,6 +1455,175 @@ fn exec_apply_closure(
         let name_str = name_of(fn_name_id).ok_or_else(|| {
             RunError::MalformedInstruction(format!(
                 "apply_closure: closure has unknown fn_name id {}",
+                fn_name_id.0
+            ))
+        })?;
+        let callee = module
+            .functions
+            .iter()
+            .find(|f| f.name == name_str)
+            .ok_or_else(|| RunError::UnknownFunction(name_str.clone()))?;
+        dispatch(module, callee, &all_args, depth + 1, budget, globals, ic_table, profile, debug)?
+    };
+
+    if let Some(d) = &instr.dest {
+        frame.set(d.clone(), result)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// LANG34: first-class closure opcodes
+// ---------------------------------------------------------------------------
+//
+// `alloc_closure` and `call_closure` are the successor forms of the older
+// `call_builtin "make_closure"` / `"apply_closure"` pattern.  The key
+// improvement: the function name is now an inline `Operand::Str` in
+// `srcs[0]`, eliminating the preceding `const` instruction that the
+// twig-ir-compiler previously had to emit via the `string_arg` helper.
+
+/// Handle `alloc_closure(Str(fn_name), cap0, cap1, …) : "closure"`.
+///
+/// Allocates a closure pairing `fn_name` with captured values, using the
+/// same `lispy_runtime::heap::alloc_closure` path that the old
+/// `call_builtin "make_closure"` form used — the representation is
+/// identical so `exec_call_closure` / `exec_apply_closure` can both read
+/// the resulting heap object.
+///
+/// # Operand layout
+///
+/// | Index | Expected | Meaning |
+/// |-------|----------|---------|
+/// | `srcs[0]` | `Operand::Str(name)` | Name of the IIR function to close over |
+/// | `srcs[1..]` | `Operand::Var(name)` | Captured variables in order |
+///
+/// The dest is required — closures always produce a value.
+fn exec_alloc_closure(
+    instr: &IIRInstr,
+    frame: &mut Frame,
+) -> Result<(), RunError> {
+    let dest = instr.dest.as_ref().ok_or_else(|| {
+        RunError::MalformedInstruction("alloc_closure requires dest".into())
+    })?;
+
+    // srcs[0] must be Operand::Str carrying the compile-time function name.
+    let fn_name = match instr.srcs.first() {
+        Some(Operand::Str(s)) => s.as_str(),
+        Some(other) => return Err(RunError::MalformedInstruction(format!(
+            "alloc_closure: srcs[0] must be Operand::Str(fn_name), got {other}"
+        ))),
+        None => return Err(RunError::MalformedInstruction(
+            "alloc_closure requires at least one src (fn_name as Operand::Str)".into()
+        )),
+    };
+
+    // Intern the function name to a SymbolId — the closure heap record stores
+    // names as interned symbol ids for O(1) equality checks.
+    let sym_id = intern(fn_name);
+    if sym_id == SymbolId::NONE {
+        return Err(RunError::Runtime(RuntimeError::TypeError(format!(
+            "alloc_closure: intern table exhausted for fn_name {fn_name:?}"
+        ))));
+    }
+
+    // Collect captured values from srcs[1..].
+    let frame_ref = &*frame;
+    let mut captures: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len().saturating_sub(1));
+    for src in &instr.srcs[1..] {
+        let v = operand_to_value(src, &|n| frame_ref.get(n))
+            .map_err(RunError::OperandConversion)?;
+        captures.push(v);
+    }
+
+    // Allocate the closure via lispy-runtime's canonical path.
+    // `lispy_runtime::alloc_closure` is re-exported from `lispy_runtime::heap::alloc_closure`.
+    let closure_val = lispy_runtime::alloc_closure(sym_id, captures);
+    frame.set(dest.clone(), closure_val)?;
+    Ok(())
+}
+
+/// Handle `call_closure(Var(handle), arg0, arg1, …) : "any"`.
+///
+/// Invokes a closure previously created by `alloc_closure` (or by the older
+/// `call_builtin "make_closure"` path — the representation is identical).
+/// Prepends captured values to the user args before calling the underlying
+/// function, matching the ABI that `compile_anonymous_lambda` relies on.
+///
+/// This is equivalent to `exec_apply_closure` but with the operand layout
+/// shifted by one:
+///
+/// | Opcode | srcs[0] | srcs[1] | srcs[2..] |
+/// |--------|---------|---------|-----------|
+/// | `apply_closure` (legacy) | Var("apply_closure") | closure handle | user args |
+/// | `call_closure` (LANG34)  | closure handle       | user args[0]  | user args[1..] |
+fn exec_call_closure(
+    module: &IIRModule,
+    instr: &IIRInstr,
+    frame: &mut Frame,
+    depth: usize,
+    budget: &mut ExecutionBudget,
+    globals: &mut Globals,
+    ic_table: &mut ICTable,
+    profile: &mut ProfileTable,
+    debug: &mut Option<&mut dyn crate::debug::DebugHooks>,
+) -> Result<(), RunError> {
+    if instr.srcs.is_empty() {
+        return Err(RunError::MalformedInstruction(
+            "call_closure requires at least 1 src (closure handle)".into()
+        ));
+    }
+
+    // srcs[0] is the closure handle variable.
+    let frame_ref = &*frame;
+    let handle = operand_to_value(&instr.srcs[0], &|n| frame_ref.get(n))
+        .map_err(RunError::OperandConversion)?;
+
+    // SAFETY: closure values come from alloc_closure / exec_alloc_closure or
+    // the legacy make_closure builtin — all of which go through
+    // lispy_runtime::heap::alloc_closure which returns a properly-tagged heap
+    // pointer.  `as_closure` walks the 16-byte header tag; safe to call on
+    // any value, returns None for non-closures.
+    let closure = unsafe { lispy_runtime::as_closure(handle) }.ok_or_else(|| {
+        RunError::NotCallable(format!("call_closure: {handle} is not a closure"))
+    })?;
+    let fn_name_id = closure.fn_name;
+    let captures = closure.captures.clone();
+    let is_builtin = closure.is_builtin();
+
+    // Collect user-visible args from srcs[1..].
+    let mut user_args: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len().saturating_sub(1));
+    for src in &instr.srcs[1..] {
+        let v = operand_to_value(src, &|n| frame_ref.get(n))
+            .map_err(RunError::OperandConversion)?;
+        user_args.push(v);
+    }
+
+    let result = if is_builtin {
+        // Builtin closure: dispatch via resolve_builtin.
+        // Defence-in-depth: assert no captures (a well-formed builtin closure
+        // has none; LANG34's alloc_closure would never produce captures for a
+        // builtin, but malformed IR could).
+        debug_assert!(
+            captures.is_empty(),
+            "builtin closure must have no captures (got {})",
+            captures.len(),
+        );
+        let name_str = name_of(fn_name_id).ok_or_else(|| {
+            RunError::MalformedInstruction(format!(
+                "call_closure: builtin closure has unknown fn_name id {}",
+                fn_name_id.0
+            ))
+        })?;
+        let builtin = <LispyBinding as lang_runtime_core::LangBinding>::resolve_builtin(&name_str)
+            .ok_or_else(|| RunError::UnknownBuiltin(name_str.clone()))?;
+        builtin(&user_args).map_err(RunError::Runtime)?
+    } else {
+        // User-fn closure: prepend captures to args then recurse.
+        let mut all_args = captures;
+        all_args.extend(user_args);
+        let name_str = name_of(fn_name_id).ok_or_else(|| {
+            RunError::MalformedInstruction(format!(
+                "call_closure: closure has unknown fn_name id {}",
                 fn_name_id.0
             ))
         })?;
@@ -3605,5 +3794,429 @@ mod tests {
             }
             other => panic!("expected UnknownBuiltin, got {other:?}"),
         }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // LANG34: first-class closure opcodes
+    // ─────────────────────────────────────────────────────────────────
+    //
+    // These tests drive `alloc_closure` and `call_closure` directly
+    // through hand-built IIRModules so we can verify the new dispatch
+    // arms independently of the twig-ir-compiler.
+
+    /// Helper: build a minimal two-function module where `main` allocates a
+    /// closure over `inner`, stores it in a register, then calls it.
+    ///
+    /// `inner` takes `captures ++ [arg]` as parameters (captures first, then
+    /// the single user-visible arg).
+    ///
+    /// The module structure mirrors what the twig-ir-compiler emits for:
+    ///   (define (make-adder x) (lambda (y) (+ x y)))
+    ///   ((make-adder 10) 5)
+    fn make_alloc_call_closure_module(
+        inner_name: &str,
+        capture_param: &str,   // name of the captured param in inner
+        user_param: &str,      // name of the user-visible param in inner
+        inner_body: Vec<IIRInstr>,
+        main_instructions: Vec<IIRInstr>,
+    ) -> IIRModule {
+        use interpreter_ir::function::{FunctionTypeStatus, IIRFunction};
+        let inner = IIRFunction {
+            name: inner_name.into(),
+            params: vec![
+                (capture_param.into(), "any".into()),
+                (user_param.into(), "any".into()),
+            ],
+            return_type: "any".into(),
+            register_count: 4,
+            instructions: inner_body,
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        let main_fn = IIRFunction {
+            name: "main".into(),
+            params: vec![],
+            return_type: "any".into(),
+            register_count: 8,
+            instructions: main_instructions,
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        IIRModule {
+            name: "test".into(),
+            functions: vec![inner, main_fn],
+            entry_point: Some("main".into()),
+            language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
+        }
+    }
+
+    /// `alloc_closure` with zero captures, then `call_closure` with one arg.
+    ///
+    /// Builds a module equivalent to:
+    ///   inner(_, y) = y + 1   (capture slot unused — allocated as placeholder)
+    ///   main: c = alloc_closure("inner"); r = call_closure(c, 41); ret r
+    ///
+    /// Expects r = 42.
+    #[test]
+    fn alloc_and_call_closure_no_captures() {
+        // inner: just returns user_arg + 1  (ignore capture)
+        let inner_body = vec![
+            IIRInstr::new(
+                "call_builtin",
+                Some("res".into()),
+                vec![
+                    Operand::Var("+".into()),
+                    Operand::Var("y".into()),
+                    Operand::Int(1),
+                ],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("res".into())], "any"),
+        ];
+        // main: alloc_closure("inner"), call_closure(c, 41)
+        //
+        // Note: inner expects (capture_param, user_param) so we must supply
+        // a dummy capture.  alloc_closure with zero captures still works —
+        // the inner function just has an unused first param.
+        // Simplest: use an inner that takes only ONE param (no capture).
+        // Build a simpler inner that takes just y.
+        use interpreter_ir::function::{FunctionTypeStatus, IIRFunction};
+        let inner_fn = IIRFunction {
+            name: "add_one".into(),
+            params: vec![("y".into(), "any".into())],
+            return_type: "any".into(),
+            register_count: 2,
+            instructions: vec![
+                IIRInstr::new(
+                    "call_builtin",
+                    Some("res".into()),
+                    vec![
+                        Operand::Var("+".into()),
+                        Operand::Var("y".into()),
+                        Operand::Int(1),
+                    ],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("res".into())], "any"),
+            ],
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        let main_fn = IIRFunction {
+            name: "main".into(),
+            params: vec![],
+            return_type: "any".into(),
+            register_count: 4,
+            instructions: vec![
+                // c = alloc_closure(Str("add_one"))   — no captures
+                IIRInstr::new(
+                    "alloc_closure",
+                    Some("c".into()),
+                    vec![Operand::Str("add_one".into())],
+                    "closure",
+                ),
+                // r = call_closure(c, 41)
+                IIRInstr::new(
+                    "call_closure",
+                    Some("r".into()),
+                    vec![
+                        Operand::Var("c".into()),
+                        Operand::Int(41),
+                    ],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+            ],
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        let module = IIRModule {
+            name: "test".into(),
+            functions: vec![inner_fn, main_fn],
+            entry_point: Some("main".into()),
+            language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
+        };
+        let result = run(&module).unwrap();
+        assert_eq!(result.as_int(), Some(42), "expected 42, got {result}");
+    }
+
+    /// `alloc_closure` with one captured variable, then `call_closure`.
+    ///
+    /// Equivalent to:
+    ///   inner(x, y) = x + y   where x is captured
+    ///   main: c = alloc_closure("inner", 10); r = call_closure(c, 5); ret r
+    ///
+    /// Expects r = 15.
+    #[test]
+    fn alloc_and_call_closure_with_one_capture() {
+        let module = make_alloc_call_closure_module(
+            "add_capture",
+            "x",   // capture param
+            "y",   // user param
+            // inner body: x + y
+            vec![
+                IIRInstr::new(
+                    "call_builtin",
+                    Some("res".into()),
+                    vec![
+                        Operand::Var("+".into()),
+                        Operand::Var("x".into()),
+                        Operand::Var("y".into()),
+                    ],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("res".into())], "any"),
+            ],
+            // main: capture = const 10, alloc_closure, call_closure(c, 5)
+            vec![
+                // cap = 10
+                IIRInstr::new("const", Some("cap".into()), vec![Operand::Int(10)], "any"),
+                // c = alloc_closure(Str("add_capture"), cap)
+                IIRInstr::new(
+                    "alloc_closure",
+                    Some("c".into()),
+                    vec![
+                        Operand::Str("add_capture".into()),
+                        Operand::Var("cap".into()),
+                    ],
+                    "closure",
+                ),
+                // r = call_closure(c, 5)
+                IIRInstr::new(
+                    "call_closure",
+                    Some("r".into()),
+                    vec![
+                        Operand::Var("c".into()),
+                        Operand::Int(5),
+                    ],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+            ],
+        );
+        let result = run(&module).unwrap();
+        assert_eq!(result.as_int(), Some(15), "expected 15, got {result}");
+    }
+
+    /// `alloc_closure` with two captured variables.
+    ///
+    /// Equivalent to: inner(a, b, y) = a + b + y  where a,b are captures.
+    /// main: c = alloc_closure("sum3", 3, 4); r = call_closure(c, 5); ret r
+    /// Expects r = 12.
+    #[test]
+    fn alloc_and_call_closure_with_two_captures() {
+        use interpreter_ir::function::{FunctionTypeStatus, IIRFunction};
+        let inner_fn = IIRFunction {
+            name: "sum3".into(),
+            params: vec![
+                ("a".into(), "any".into()),
+                ("b".into(), "any".into()),
+                ("y".into(), "any".into()),
+            ],
+            return_type: "any".into(),
+            register_count: 4,
+            instructions: vec![
+                IIRInstr::new(
+                    "call_builtin",
+                    Some("ab".into()),
+                    vec![
+                        Operand::Var("+".into()),
+                        Operand::Var("a".into()),
+                        Operand::Var("b".into()),
+                    ],
+                    "any",
+                ),
+                IIRInstr::new(
+                    "call_builtin",
+                    Some("res".into()),
+                    vec![
+                        Operand::Var("+".into()),
+                        Operand::Var("ab".into()),
+                        Operand::Var("y".into()),
+                    ],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("res".into())], "any"),
+            ],
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        let main_fn = IIRFunction {
+            name: "main".into(),
+            params: vec![],
+            return_type: "any".into(),
+            register_count: 6,
+            instructions: vec![
+                IIRInstr::new("const", Some("ca".into()), vec![Operand::Int(3)], "any"),
+                IIRInstr::new("const", Some("cb".into()), vec![Operand::Int(4)], "any"),
+                // c = alloc_closure(Str("sum3"), ca, cb)
+                IIRInstr::new(
+                    "alloc_closure",
+                    Some("c".into()),
+                    vec![
+                        Operand::Str("sum3".into()),
+                        Operand::Var("ca".into()),
+                        Operand::Var("cb".into()),
+                    ],
+                    "closure",
+                ),
+                // r = call_closure(c, 5)
+                IIRInstr::new(
+                    "call_closure",
+                    Some("r".into()),
+                    vec![
+                        Operand::Var("c".into()),
+                        Operand::Int(5),
+                    ],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+            ],
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        let module = IIRModule {
+            name: "test".into(),
+            functions: vec![inner_fn, main_fn],
+            entry_point: Some("main".into()),
+            language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
+        };
+        let result = run(&module).unwrap();
+        assert_eq!(result.as_int(), Some(12), "expected 12, got {result}");
+    }
+
+    /// `alloc_closure` with a non-Str srcs[0] must return MalformedInstruction.
+    #[test]
+    fn alloc_closure_wrong_operand_type_errors() {
+        use interpreter_ir::function::{FunctionTypeStatus, IIRFunction};
+        let main_fn = IIRFunction {
+            name: "main".into(),
+            params: vec![],
+            return_type: "any".into(),
+            register_count: 2,
+            instructions: vec![
+                // Deliberately pass Var instead of Str for fn_name.
+                IIRInstr::new(
+                    "alloc_closure",
+                    Some("c".into()),
+                    vec![Operand::Int(99)],  // wrong: must be Str
+                    "closure",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "any"),
+            ],
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        let module = IIRModule {
+            name: "test".into(),
+            functions: vec![main_fn],
+            entry_point: Some("main".into()),
+            language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
+        };
+        let err = run(&module).unwrap_err();
+        assert!(
+            matches!(err, RunError::MalformedInstruction(_)),
+            "expected MalformedInstruction, got {err:?}"
+        );
+    }
+
+    /// `call_closure` on a non-closure value must return NotCallable.
+    #[test]
+    fn call_closure_on_non_closure_errors() {
+        use interpreter_ir::function::{FunctionTypeStatus, IIRFunction};
+        let main_fn = IIRFunction {
+            name: "main".into(),
+            params: vec![],
+            return_type: "any".into(),
+            register_count: 3,
+            instructions: vec![
+                IIRInstr::new("const", Some("x".into()), vec![Operand::Int(7)], "any"),
+                IIRInstr::new(
+                    "call_closure",
+                    Some("r".into()),
+                    vec![Operand::Var("x".into())],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "any"),
+            ],
+            type_status: FunctionTypeStatus::Untyped,
+            call_count: 0,
+            feedback_slots: std::collections::HashMap::new(),
+            source_map: vec![],
+            param_refinements: Vec::new(),
+            return_refinement: None,
+        };
+        let module = IIRModule {
+            name: "test".into(),
+            functions: vec![main_fn],
+            entry_point: Some("main".into()),
+            language: "twig".into(),
+            exports: vec![],
+            imports: vec![],
+        };
+        let err = run(&module).unwrap_err();
+        assert!(matches!(err, RunError::NotCallable(_)));
+    }
+
+    /// End-to-end: Twig source that produces lambdas now emits `alloc_closure`
+    /// / `call_closure` (not `call_builtin`) and executes correctly.
+    ///
+    /// This test verifies that the twig-ir-compiler changes in Commit 4 are
+    /// correct: after LANG34, `run_source` on a lambda program still returns
+    /// the right value.  The opcodes used internally have changed but the
+    /// semantics must be identical.
+    #[test]
+    fn e2e_lambda_with_capture_via_new_opcodes() {
+        // Curried adder: (((lambda (x) (lambda (y) (+ x y))) 3) 4) → 7
+        let src = "(((lambda (x) (lambda (y) (+ x y))) 3) 4)";
+        let result = run_source(src).unwrap();
+        assert_eq!(result.as_int(), Some(7), "expected 7, got {result}");
+    }
+
+    #[test]
+    fn e2e_make_adder_with_new_opcodes() {
+        // Classic make-adder: ((make-adder 10) 5) → 15
+        let src = "
+            (define (make-adder x) (lambda (y) (+ x y)))
+            ((make-adder 10) 5)
+        ";
+        let result = run_source(src).unwrap();
+        assert_eq!(result.as_int(), Some(15), "expected 15, got {result}");
     }
 }

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -1245,6 +1245,17 @@ fn exec_call_builtin(
     let builtin = <LispyBinding as lang_runtime_core::LangBinding>::resolve_builtin(name)
         .ok_or_else(|| RunError::UnknownBuiltin(name.to_string()))?;
 
+    // DoS guard: cap the args allocation.  Matches exec_send, exec_apply_closure,
+    // exec_alloc_closure, exec_call_closure.  A malicious IIR module calling
+    // a valid builtin with millions of srcs would OOM on Vec::with_capacity
+    // before the budget check fires (budget counts instructions, not operands).
+    if instr.srcs.len() > MAX_REGISTERS_PER_FRAME {
+        return Err(RunError::MalformedInstruction(format!(
+            "call_builtin({name}): srcs.len()={} exceeds MAX_REGISTERS_PER_FRAME ({MAX_REGISTERS_PER_FRAME})",
+            instr.srcs.len()
+        )));
+    }
+
     let mut call_args: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len().saturating_sub(1));
     for src in &instr.srcs[1..] {
         // Read-only borrow of frame for the lookup callback —
@@ -1399,6 +1410,14 @@ fn exec_apply_closure(
     if instr.srcs.len() < 2 {
         return Err(RunError::MalformedInstruction(format!(
             "apply_closure expects at least 2 srcs (\"apply_closure\", handle), got {}",
+            instr.srcs.len()
+        )));
+    }
+
+    // DoS guard — mirrors the cap in exec_call_closure, exec_alloc_closure, exec_send.
+    if instr.srcs.len() > MAX_REGISTERS_PER_FRAME {
+        return Err(RunError::MalformedInstruction(format!(
+            "apply_closure: srcs.len()={} exceeds MAX_REGISTERS_PER_FRAME ({MAX_REGISTERS_PER_FRAME})",
             instr.srcs.len()
         )));
     }

--- a/code/specs/LANG34-closures.md
+++ b/code/specs/LANG34-closures.md
@@ -1,0 +1,261 @@
+# LANG34 — First-Class Closure Opcodes at the IIR Level
+
+## Status
+
+Draft → Implementation
+
+## Motivation
+
+Before LANG34, closures in the Twig VM are handled entirely through two
+`call_builtin` names:
+
+```
+%s0 = const("__lambda_0")               : any    ← string_arg indirection
+%c0 = call_builtin("make_closure", %s0, %cap0, %cap1) : any
+...
+%r0 = call_builtin("apply_closure", %c0, %arg0) : any
+```
+
+The `%s0 = const(...)` instruction exists only to materialise the function name
+as a runtime value so it can be passed as a `call_builtin` argument.  This
+convention was introduced in LANG31 before `Operand::Str` existed.  LANG32
+added `Operand::Str` — a compile-time string literal that backends must NOT look
+up in the register file.  The `string_arg` / `const` indirection is therefore
+now dead weight: the fn_name can be carried inline in the instruction.
+
+Promoting closures to first-class IIR opcodes has three benefits:
+
+1. **Cleaner IR** — no spurious `const` instructions cluttering the instruction
+   stream before every `alloc_closure`.
+2. **Static analysability** — the closure's target function name is statically
+   visible in the instruction operands.  Passes can reason about it without
+   chasing register definitions.
+3. **Backend readiness** — `iir-to-*` backends (WASM, JVM, CLR, BEAM) need a
+   well-typed first-class opcode, not a `call_builtin` string, to emit closure
+   allocation into target bytecode.
+
+---
+
+## New Opcodes
+
+### `alloc_closure`
+
+```
+dest = alloc_closure(Str(fn_name), Var(cap0), Var(cap1), …) : "closure"
+```
+
+**Purpose:** Allocate a closure for the named IIR function, capturing the
+provided variables by value.
+
+**Operands:**
+
+| Index | Kind | Meaning |
+|-------|------|---------|
+| `srcs[0]` | `Operand::Str(fn_name)` | Compile-time name of the IIR function to close over.  Must be `Operand::Str`, NOT a register reference. |
+| `srcs[1..]` | `Operand::Var(name)` | Captured variables, in the same order as the inner function's leading parameters. |
+
+**Result:** A closure handle stored in `dest`.  The `type_hint` is `"closure"`.
+
+**Allocation:** This instruction allocates a heap object.  It sets `may_alloc = true`.
+
+**Semantics:** Equivalent to `lispy_runtime::heap::alloc_closure(intern(fn_name), captures)`.
+
+---
+
+### `call_closure`
+
+```
+dest = call_closure(Var(handle), Var(arg0), Var(arg1), …) : "any"
+```
+
+**Purpose:** Invoke a closure, passing explicit arguments.  The closure's captured
+variables are prepended by the runtime before calling the underlying function.
+
+**Operands:**
+
+| Index | Kind | Meaning |
+|-------|------|---------|
+| `srcs[0]` | `Operand::Var(name)` | The closure handle produced by `alloc_closure`. |
+| `srcs[1..]` | `Operand::Var(name)` | User-visible arguments, in order. |
+
+**Result:** The return value of the closed-over function, stored in `dest`.
+The `type_hint` is `"any"` because Twig is dynamically typed.
+
+---
+
+## Changes from LANG31 `call_builtin` Form
+
+| Aspect | LANG31 `call_builtin` | LANG34 first-class opcode |
+|--------|-----------------------|--------------------------|
+| fn_name location | Register (%s0 = const("name")) | `Operand::Str` in `srcs[0]` |
+| Extra `const` instruction | Always emitted | Not needed |
+| Opcode | `"call_builtin"` | `"alloc_closure"` / `"call_closure"` |
+| type_hint (alloc) | `"any"` | `"closure"` |
+| Static analysability | Must chase const defs | Inline in instruction |
+
+The old `call_builtin "make_closure"` and `"apply_closure"` forms are
+**deprecated but not removed**.  They continue to work in the twig-vm dispatcher
+for backward compatibility.  The `iir-builtin-lowering` Phase 4 pass rewrites
+them to the new opcodes automatically.
+
+---
+
+## IIR Type System
+
+A new type constant `CLOSURE_TYPE = "closure"` is added to `interpreter-ir::opcodes`.
+
+`"closure"` is **not** in the `CONCRETE_TYPES` slice — it is not a scalar numeric
+type and the `iir-to-*` numeric backends reject it (correct behaviour: closures
+are not JVM primitives).
+
+`is_closure_op(op)` returns `true` for `"alloc_closure"` and `"call_closure"`.
+
+`is_value_producing(op)` returns `true` for both (both have a `dest`).
+
+`is_allocating(op)` returns `true` for `"alloc_closure"` (sets `may_alloc`).
+
+`is_known_op(op)` returns `true` for both.
+
+---
+
+## Affected Components
+
+### `interpreter-ir/src/opcodes.rs`
+
+- Add `pub const CLOSURE_TYPE: &str = "closure";`
+- Add `pub fn is_closure_op(op: &str) -> bool`
+- Update `is_value_producing` to include `"alloc_closure"` and `"call_closure"`
+- Update `is_allocating` (if it exists) / document `may_alloc` on `alloc_closure`
+- Update `is_known_op` to include both new opcodes
+
+### `twig-vm/src/dispatch.rs`
+
+New match arms in the main dispatch loop:
+
+```rust
+"alloc_closure" => {
+    exec_alloc_closure(instr, &mut frame)?;
+    pc += 1;
+}
+"call_closure" => {
+    exec_call_closure(module, instr, &mut frame, depth, budget, globals, ic_table, profile, debug)?;
+    pc += 1;
+}
+```
+
+`exec_alloc_closure`: reads `Operand::Str(fn_name)` from `srcs[0]`, interns the
+name, collects captures from `srcs[1..]`, calls
+`lispy_runtime::heap::alloc_closure`.
+
+`exec_call_closure`: reads closure handle from `srcs[0]` (unlike `apply_closure`
+which reads from `srcs[1]`), reads user args from `srcs[1..]`, otherwise
+identical logic to `exec_apply_closure`.
+
+### `twig-ir-compiler/src/compiler.rs`
+
+`compile_anonymous_lambda`:
+- Replace `string_arg` + `call_builtin "make_closure"` with `alloc_closure`
+- `srcs = [Operand::Str(fn_name)] ++ captures_as_var`
+- `type_hint = "closure"`
+
+`compile_apply` (indirect path):
+- Replace `call_builtin "apply_closure" handle args...` with `call_closure handle args...`
+- `srcs = [Operand::Var(fn_handle)] ++ args_as_var`
+- `type_hint = "any"`
+
+The `string_arg` helper is **retained** — still used by `global_set`/`global_get`
+and `make_symbol` paths.
+
+### `iir-builtin-lowering/src/closure.rs` (new)
+
+Phase 4 of the lowering pipeline.  Rewrites legacy `call_builtin "make_closure"`
+and `"apply_closure"` instructions to the new opcodes.
+
+Algorithm per function:
+1. Build a `const`-binding map: `HashMap<dest_name, literal_str>` from any
+   `const` whose `srcs[0]` is `Operand::Var(literal)` or `Operand::Str(literal)`.
+2. Walk instructions and collect rewrites:
+   - `call_builtin "make_closure" fn_name_reg cap0...`:
+     look up `fn_name_reg` in the const map, rewrite to `alloc_closure`.
+     Mark the preceding `const` as dead (track by dest name in a removal set).
+   - `call_builtin "apply_closure" handle arg0...`:
+     rewrite to `call_closure` with `srcs[0] = Var(handle)`, `srcs[1..] = args`.
+3. Build the new instruction list, skipping dead `const` instructions.
+
+Public API: `pub fn lower_closure_builtins(module: &mut IIRModule)` — infallible.
+
+### `iir-builtin-lowering/src/lib.rs`
+
+- `pub mod closure;`
+- `pub use closure::lower_closure_builtins;`
+- Phase 4 call in `lower_builtins` after Phase 3 (global_io):
+
+```rust
+// ── Phase 4: closure builtins (LANG34) ───────────────────────────────────
+closure::lower_closure_builtins(module);
+```
+
+---
+
+## Backward Compatibility
+
+- `call_builtin "make_closure"` and `"apply_closure"` remain valid in the
+  twig-vm dispatcher via `exec_call_builtin`.  Existing compiled Twig programs
+  (and hand-built tests using the old form) continue to work unchanged.
+- `iir-builtin-lowering::lower_builtins` will now automatically upgrade them to
+  the new opcodes as part of the standard pipeline.
+- `iir-type-checker` does not need changes — it passes through `"any"` and
+  `"closure"` type hints without error.
+
+---
+
+## Non-Goals for LANG34
+
+- **`iir-to-*` backends (WASM, JVM, CLR, BEAM)**: these backends do not yet
+  support `alloc_closure` / `call_closure`.  They will return a validation error
+  for these opcodes.  Backend support is LANG35+.
+- **Closure serialisation / deopt**: out of scope.
+- **Multi-arity currying**: out of scope.
+- **Tail-call elimination across closure boundaries**: out of scope.
+
+---
+
+## Example
+
+Twig source:
+```twig
+(define adder (lambda (x) (lambda (y) (+ x y))))
+(define add5 (adder 5))
+(add5 3)
+```
+
+LANG31 IR (before LANG34):
+```
+; compile_anonymous_lambda for (lambda (y) (+ x y)):
+%s0 = const("__lambda_1") : any          ← string_arg
+%c0 = call_builtin("make_closure", %s0, %x) : any
+ret(%c0) : any
+
+; call site for (add5 3):
+%r0 = call_builtin("apply_closure", %add5, 3) : any
+```
+
+LANG34 IR:
+```
+; compile_anonymous_lambda for (lambda (y) (+ x y)):
+%c0 = alloc_closure(Str("__lambda_1"), %x) : closure   ← no const needed
+
+; call site for (add5 3):
+%r0 = call_closure(%add5, 3) : any
+```
+
+---
+
+## Testing
+
+- `interpreter-ir`: unit tests for `is_closure_op`, `CLOSURE_TYPE`
+- `twig-vm`: hand-built `IIRModule` tests for `alloc_closure` and `call_closure` dispatch;
+  end-to-end lambda programs via `twig_vm::run`
+- `twig-ir-compiler`: assert compiler emits `alloc_closure`/`call_closure` (not `call_builtin`);
+  assert no superfluous `const` before `alloc_closure`
+- `iir-builtin-lowering`: Phase 4 unit tests; idempotency; mixed old+new forms


### PR DESCRIPTION
## Summary

- **`alloc_closure(Str(fn_name), cap0, …) : "closure"`** — replaces `call_builtin "make_closure" fn_name_reg caps…` eliminating the preceding `const` indirection (LANG32 `Operand::Str` makes it inline)
- **`call_closure(handle, arg0, …) : "any"`** — replaces `call_builtin "apply_closure" handle args…` with a first-class opcode
- **`interpreter-ir`**: `CLOSURE_TYPE`, `is_closure_op`, predicates updated (`is_value_producing`, `is_allocating`, `is_known_op` now includes `is_global` and `is_closure_op`)
- **`twig-ir-compiler`**: emits new opcodes directly; `string_arg` helper retained for `global_set`/`global_get`/`make_symbol`
- **`iir-builtin-lowering`** Phase 4: `lower_closure_builtins` rewrites old `make_closure`/`apply_closure` forms to new opcodes for backward compatibility with pre-LANG34 modules
- **`twig-vm`**: `exec_alloc_closure` and `exec_call_closure` dispatch arms added; old `call_builtin` arms kept for backward compatibility

**Security hardening (5 iterative review rounds)**:
- `MAX_FN_NAME_LEN=512` guard before `intern()` in `exec_alloc_closure`
- `MAX_REGISTERS_PER_FRAME` guards on ALL 6 `Vec::with_capacity(srcs.len())` call-sites in dispatch.rs: `exec_call_builtin`, `exec_call`, `exec_apply_closure`, `exec_alloc_closure`, `exec_call_closure`, `exec_send`
- `debug_assert!` → hard `RunError::MalformedInstruction` for builtin closure with non-empty captures (in both `exec_apply_closure` and `exec_call_closure`)
- `RuntimeError::Custom` (not `TypeError`) for intern table exhaustion
- Detailed `SAFETY` comments for all `unsafe { as_closure(handle) }` call sites
- `Operand::Str` counted in Phase 4 use-count pass (preventing false-positive const removal)

## Test plan

- [ ] `cargo test -p interpreter-ir` — 30 tests including 5 new LANG34 predicate tests
- [ ] `cargo test -p twig-ir-compiler` — 56 tests + doc-tests; 3 renamed/updated for LANG34
- [ ] `cargo test -p iir-builtin-lowering` — 77 tests + 3 doc-tests; Phase 4 lowering with 10 unit tests
- [ ] `cargo test -p twig-vm` — 139 tests + doc-tests; 7 new LANG34 integration tests including 2 E2E lambda programs
- [ ] `cargo build --workspace` — full workspace compiles
- [ ] Security review passed (6 rounds): DoS guards, unsafe justifications, no injection vectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)