### PR TITLE
Render MACSYMA display2d output in TypeScript

### DIFF
--- a/code/packages/typescript/macsyma-runtime/BUILD
+++ b/code/packages/typescript/macsyma-runtime/BUILD
@@ -11,6 +11,7 @@ cd ../macsyma-parser && npm ci --quiet
 cd ../macsyma-compiler && npm ci --quiet
 cd ../cas-list-operations && npm ci --quiet
 cd ../cas-pattern-matching && npm ci --quiet
+cd ../cas-pretty-printer && npm ci --quiet
 cd ../cas-simplify && npm ci --quiet
 cd ../cas-solve && npm ci --quiet
 cd ../cas-substitution && npm ci --quiet

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Route `ev(expr, display2d)` JSON and browser display text through the
+  TypeScript `cas-pretty-printer` 2D MACSYMA box renderer while preserving the
+  symbolic IR result for history and downstream evaluation.
 - Wire `TrigReduce` runtime dispatch to the TypeScript `cas-trig` package.
 - Wire `Simplify`, `RatSimplify`, `TrigSimplify`, and `TrigExpand` runtime
   heads to the TypeScript `cas-simplify` and `cas-trig` packages.

--- a/code/packages/typescript/macsyma-runtime/package-lock.json
+++ b/code/packages/typescript/macsyma-runtime/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
         "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+        "@coding-adventures/cas-pretty-printer": "file:../cas-pretty-printer",
         "@coding-adventures/cas-simplify": "file:../cas-simplify",
         "@coding-adventures/cas-solve": "file:../cas-solve",
         "@coding-adventures/cas-substitution": "file:../cas-substitution",
@@ -55,6 +56,19 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../cas-pretty-printer": {
+      "name": "@coding-adventures/cas-pretty-printer",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
@@ -344,6 +358,10 @@
     },
     "node_modules/@coding-adventures/cas-pattern-matching": {
       "resolved": "../cas-pattern-matching",
+      "link": true
+    },
+    "node_modules/@coding-adventures/cas-pretty-printer": {
+      "resolved": "../cas-pretty-printer",
       "link": true
     },
     "node_modules/@coding-adventures/cas-simplify": {

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -23,6 +23,7 @@
     "@coding-adventures/state-machine": "file:../state-machine",
     "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
     "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+    "@coding-adventures/cas-pretty-printer": "file:../cas-pretty-printer",
     "@coding-adventures/cas-simplify": "file:../cas-simplify",
     "@coding-adventures/cas-solve": "file:../cas-solve",
     "@coding-adventures/cas-substitution": "file:../cas-substitution",

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -14,6 +14,7 @@ import {
   sortList,
 } from "@coding-adventures/cas-list-operations";
 import { simplify as simplifyCas } from "@coding-adventures/cas-simplify";
+import { MacsymaDialect, pretty } from "@coding-adventures/cas-pretty-printer";
 import { solveLinearSystem, trySolveInequality, trySolveTranscendental } from "@coding-adventures/cas-solve";
 import { subst } from "@coding-adventures/cas-substitution";
 import { expandTrig, trigReduce, trigSimplify } from "@coding-adventures/cas-trig";
@@ -241,6 +242,7 @@ export interface EvalResult {
   readonly outputIndex: number;
   readonly input: IRNode;
   readonly output: IRNode;
+  readonly outputText: string;
   readonly display: boolean;
 }
 
@@ -410,10 +412,11 @@ export class MacsymaSession {
     const inputIndex = this.sessionHistory.recordInput(input);
     const output = this.vm.eval(input);
     const outputIndex = this.sessionHistory.recordOutput(output);
+    const outputText = displayTextFor(input, output);
     if (isKillAll(input)) {
       this.sessionHistory.reset();
     }
-    return { inputIndex, outputIndex, input, output, display };
+    return { inputIndex, outputIndex, input, output, outputText, display };
   }
 }
 
@@ -500,7 +503,7 @@ function resultToJson(result: EvalResult): JsonEvalResult {
     outputIndex: result.outputIndex,
     display: result.display,
     inputText: toDisplayString(result.input),
-    outputText: toDisplayString(result.output),
+    outputText: result.outputText,
     inputIr: irToJson(result.input),
     outputIr: irToJson(result.output),
   };
@@ -706,6 +709,19 @@ function numerFold(node: IRNode): IRNode {
     default:
       return node;
   }
+}
+
+function displayTextFor(input: IRNode, output: IRNode): string {
+  if (hasEvFlag(input, "display2d")) {
+    return pretty(output, MacsymaDialect, "2d");
+  }
+  return toDisplayString(output);
+}
+
+function hasEvFlag(input: IRNode, flag: string): boolean {
+  return input.kind === "apply"
+    && equals(input.head, EV)
+    && input.args.slice(1).some((arg) => arg.kind === "symbol" && arg.name === flag);
 }
 
 function isKillAll(input: IRNode): boolean {

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -293,6 +293,16 @@ describe("macsyma-runtime", () => {
     expect(trigsimpResult.output).toEqual(int(1));
   });
 
+  it("routes Ev display2d through the MACSYMA box pretty-printer", () => {
+    const payload = JSON.parse(evalSourceJson("ev(1/(x + 1), display2d);"));
+    const [result] = payload.results;
+
+    expect(payload.visibleOutputs).toEqual([result.outputText]);
+    expect(result.outputText).toContain("\n");
+    expect(result.outputText).toContain("─");
+    expect(result.outputText).toContain("x + 1");
+  });
+
   it("evaluates trigreduce through cas-trig", () => {
     const x = sym("x");
     const session = new MacsymaSession();

--- a/code/programs/typescript/macsyma-browser-repl/BUILD
+++ b/code/programs/typescript/macsyma-browser-repl/BUILD
@@ -11,6 +11,7 @@ cd ../../../packages/typescript/macsyma-parser && npm ci --quiet
 cd ../../../packages/typescript/macsyma-compiler && npm ci --quiet
 cd ../../../packages/typescript/cas-list-operations && npm ci --quiet
 cd ../../../packages/typescript/cas-pattern-matching && npm ci --quiet
+cd ../../../packages/typescript/cas-pretty-printer && npm ci --quiet
 cd ../../../packages/typescript/cas-simplify && npm ci --quiet
 cd ../../../packages/typescript/cas-solve && npm ci --quiet
 cd ../../../packages/typescript/cas-substitution && npm ci --quiet

--- a/code/programs/typescript/macsyma-browser-repl/package-lock.json
+++ b/code/programs/typescript/macsyma-browser-repl/package-lock.json
@@ -228,6 +228,7 @@
       "dependencies": {
         "@coding-adventures/cas-list-operations": "file:../cas-list-operations",
         "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+        "@coding-adventures/cas-pretty-printer": "file:../cas-pretty-printer",
         "@coding-adventures/cas-simplify": "file:../cas-simplify",
         "@coding-adventures/cas-solve": "file:../cas-solve",
         "@coding-adventures/cas-substitution": "file:../cas-substitution",

--- a/code/programs/typescript/macsyma-browser-repl/src/App.tsx
+++ b/code/programs/typescript/macsyma-browser-repl/src/App.tsx
@@ -145,7 +145,7 @@ function toEntry(result: EvalResult): TranscriptEntry {
     inputIndex: result.inputIndex,
     outputIndex: result.outputIndex,
     input: toDisplayString(result.input),
-    output: toDisplayString(result.output),
+    output: result.outputText,
     display: result.display,
   };
 }

--- a/code/programs/typescript/macsyma-browser-repl/tests/App.test.tsx
+++ b/code/programs/typescript/macsyma-browser-repl/tests/App.test.tsx
@@ -47,4 +47,17 @@ describe("Macsyma browser REPL", () => {
     expect(await transcript.findByText("6")).toBeInTheDocument();
     expect(transcript.getByText("%i2")).toBeInTheDocument();
   });
+
+  it("renders display2d outputs from the runtime transcript text", async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText("MACSYMA source"), {
+      target: { value: "ev(1/(x + 1), display2d);" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+
+    const transcript = within(screen.getByLabelText("Transcript"));
+    expect(await transcript.findByText((content) => content.includes("─") && content.includes("x + 1")))
+      .toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- route `ev(expr, display2d)` output text through the TypeScript MACSYMA 2D box pretty-printer
- keep symbolic IR outputs unchanged for history and downstream evaluation while exposing formatted transcript text
- teach the browser REPL to use runtime-provided display text and validate the 2D transcript path

## Validation
- `npm test` in `code/packages/typescript/macsyma-runtime`
- `npm run build` in `code/packages/typescript/macsyma-runtime`
- `npm test && npm run build` in `code/programs/typescript/macsyma-browser-repl`
- Browser smoke test at `http://127.0.0.1:5173/coding-adventures/macsyma/` with `ev(1/(x + 1), display2d);`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-display2d.json` from `code/programs/go/build-tool`