### PR TITLE
feat(adjudication-ir): v3 — multi-directed acyclic graph IR

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -179,17 +179,20 @@ members = [
     "prolog-lexer",
     "prolog-parser",
     "prolog-loader",
-    "adjudication-connector",
-    "adjudication-polarity-modality",
-    "adjudication-coverage",
-    "adjudication-audit-trail",
-    "adjudication-adversarial",
-    "adjudication-pipeline",
-    "adjudication-round-trip",
-    "adjudication-clarification",
-    "adjudication-clinical-demo",
-    "adjudication-contract-demo",
-    "adjudication-tsa-demo",
+    # Temporarily excluded while ADJ01 v3 graph-IR migration lands.
+    # See ADJ01-adjudication-ir-grammar.md §"Status" for the sequence
+    # of follow-up PRs that re-add each consumer after migrating it.
+    # "adjudication-connector",            # ADJ01 v3: edge lowering to Prolog
+    # "adjudication-polarity-modality",    # ADJ03 v3: propagation along Contains
+    # "adjudication-coverage",             # ADJ02 v3: flat tile + DAG check
+    "adjudication-audit-trail",            # references IR only in doc strings
+    # "adjudication-adversarial",          # uses IR types
+    # "adjudication-pipeline",             # orchestrates the above
+    # "adjudication-round-trip",           # ADJ04 v3 needs edge rendering
+    "adjudication-clarification",          # references IR via primitives only
+    # "adjudication-clinical-demo",        # HandBuilt IR; v3 migration follows
+    # "adjudication-contract-demo",        # HandBuilt IR; v3 migration follows
+    # "adjudication-tsa-demo",             # canonical demo; v3 migration last
     "loss-functions",
     "markov-chain",
     "note-frequency",

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -179,20 +179,17 @@ members = [
     "prolog-lexer",
     "prolog-parser",
     "prolog-loader",
-    # Temporarily excluded while ADJ01 v3 graph-IR migration lands.
-    # See ADJ01-adjudication-ir-grammar.md §"Status" for the sequence
-    # of follow-up PRs that re-add each consumer after migrating it.
-    # "adjudication-connector",            # ADJ01 v3: edge lowering to Prolog
-    # "adjudication-polarity-modality",    # ADJ03 v3: propagation along Contains
-    # "adjudication-coverage",             # ADJ02 v3: flat tile + DAG check
-    "adjudication-audit-trail",            # references IR only in doc strings
-    # "adjudication-adversarial",          # uses IR types
-    # "adjudication-pipeline",             # orchestrates the above
-    # "adjudication-round-trip",           # ADJ04 v3 needs edge rendering
-    "adjudication-clarification",          # references IR via primitives only
-    # "adjudication-clinical-demo",        # HandBuilt IR; v3 migration follows
-    # "adjudication-contract-demo",        # HandBuilt IR; v3 migration follows
-    # "adjudication-tsa-demo",             # canonical demo; v3 migration last
+    "adjudication-connector",
+    "adjudication-polarity-modality",
+    "adjudication-coverage",
+    "adjudication-audit-trail",
+    "adjudication-adversarial",
+    "adjudication-pipeline",
+    "adjudication-round-trip",
+    "adjudication-clarification",
+    "adjudication-clinical-demo",
+    "adjudication-contract-demo",
+    "adjudication-tsa-demo",
     "loss-functions",
     "markov-chain",
     "note-frequency",

--- a/code/packages/rust/adjudication-adversarial/src/lib.rs
+++ b/code/packages/rust/adjudication-adversarial/src/lib.rs
@@ -506,8 +506,6 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![Span::new(DocumentId::new("doc1"), start, end)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         }
@@ -517,6 +515,7 @@ mod tests {
         IRDocument {
             document_id: DocumentId::new("doc1"),
             nodes,
+            edges: Vec::new(),
         }
     }
 
@@ -591,7 +590,7 @@ mod tests {
     #[test]
     fn no_attackable_nodes_means_no_calls_no_violations() {
         let mut n = fact("g", Term::Atom("group".into()), 0, 5);
-        n.kind = NodeKind::TextRun;
+        n.kind = NodeKind::Section;
         let g = GatewayConfig::new(); // no clients required
         let r = check_adversarial(make_doc(), &ir(vec![n]), &g, &CheckOptions::default()).unwrap();
         assert!(r.pass());

--- a/code/packages/rust/adjudication-clinical-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-clinical-demo/src/lib.rs
@@ -282,8 +282,6 @@ pub fn clinical_ir_document(source_text: &str) -> IRDocument {
             modality: Modality::Present,
             source_spans: vec![Span::new(doc_id.clone(), 0, 30)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -295,8 +293,6 @@ pub fn clinical_ir_document(source_text: &str) -> IRDocument {
             modality: Modality::Present,
             source_spans: vec![Span::new(doc_id.clone(), 30, 42)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -308,8 +304,6 @@ pub fn clinical_ir_document(source_text: &str) -> IRDocument {
             modality: Modality::Present,
             source_spans: vec![Span::new(doc_id.clone(), 42, 64)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -322,8 +316,6 @@ pub fn clinical_ir_document(source_text: &str) -> IRDocument {
             modality: Modality::Present,
             source_spans: vec![Span::new(doc_id.clone(), 0, len)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -337,8 +329,6 @@ pub fn clinical_ir_document(source_text: &str) -> IRDocument {
         modality: Modality::Present,
         source_spans: vec![],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: Default::default(),
     });
@@ -346,6 +336,7 @@ pub fn clinical_ir_document(source_text: &str) -> IRDocument {
     IRDocument {
         document_id: doc_id,
         nodes,
+        edges: Vec::new(),
     }
 }
 

--- a/code/packages/rust/adjudication-connector/src/lib.rs
+++ b/code/packages/rust/adjudication-connector/src/lib.rs
@@ -26,8 +26,8 @@
 //! Any other compound functor used at a Rule node yields
 //! [`LoweringError::UnknownRuleSubtype`].
 
-use adjudication_ir::{IRDocument, IRNode, NodeId, NodeKind, Polarity};
-use logic_core::{Number, Term};
+use adjudication_ir::{EdgeRelation, IRDocument, IRNode, NodeId, NodeKind, Polarity};
+use logic_core::{atom, compound, Number, Term};
 use logic_engine::{
     search, BodyLiteral, Fact, KnowledgeBase, Probability, Rule, SearchMode, SearchResult,
 };
@@ -90,15 +90,60 @@ pub fn lower_to_kb(ir_doc: &IRDocument) -> Result<KnowledgeBase, LoweringError> 
             | NodeKind::Uncertainty
             | NodeKind::Exception
             | NodeKind::Discarded
-            | NodeKind::TextRun => {
-                // v2: TextRun nodes carry only structural decomposition
-                // and do not produce engine clauses. Query nodes are
-                // returned by extract_queries; Uncertainty / Exception /
-                // Discarded participate in clarification, audit, and
-                // rule priority but do not lower to clauses.
+            | NodeKind::Section
+            | NodeKind::Entity => {
+                // Query nodes are returned by extract_queries;
+                // Uncertainty / Exception / Discarded participate in
+                // clarification, audit, and rule priority. Section is
+                // structural metadata only. Entity is a deduplicated
+                // atom reference target; its content is lowered when
+                // a mentioning Fact or Rule is lowered. None produce
+                // independent engine clauses in v3.
             }
         }
     }
+
+    // Edge lowering: emit one Prolog clause per typed edge so the
+    // engine can reason about the relationship structure. The clauses
+    // use the EdgeRelation's `as_str()` name as the functor:
+    //
+    //     excepts(<source_id>, <target_id>).
+    //     applies_to(<source_id>, <target_id>).
+    //     cites(<source_id>, <target_id>).
+    //     ...
+    //
+    // For now we lower every edge uniformly. Domain-specific
+    // optimizations (e.g., compiling `Excepts` into per-rule exception
+    // bodies, compiling `Contains` into a structural-only relation
+    // that the engine ignores) follow as the engine grows.
+    for edge in &ir_doc.edges {
+        // Skip Contains: it's structural metadata. The engine doesn't
+        // need to know about document hierarchy.
+        if edge.relation == EdgeRelation::Contains {
+            continue;
+        }
+        let functor = edge.relation.as_str().replace('-', "_");
+        let head = compound(
+            &functor,
+            vec![atom(&edge.source.0), atom(&edge.target.0)],
+        );
+        // Edge polarity / modality semantics: an Affirmed/Present edge
+        // emits the clause as-is. Denied edges are recorded but not
+        // emitted as positive clauses (the engine would have to use a
+        // separate negative-knowledge mechanism). For now we skip
+        // Denied edges and emit a deny_ functor; the engine treats it
+        // as a witness for audit-trail replay.
+        if edge.polarity == Polarity::Denied {
+            let deny_head = compound(
+                &format!("not_{functor}"),
+                vec![atom(&edge.source.0), atom(&edge.target.0)],
+            );
+            kb.add_fact(Fact::certain(deny_head));
+        } else {
+            kb.add_fact(Fact::certain(head));
+        }
+    }
+
     Ok(kb)
 }
 
@@ -378,8 +423,6 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![span()],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: empty_meta(),
         }
@@ -394,8 +437,6 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![span()],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: empty_meta(),
         }
@@ -410,8 +451,6 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![span()],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: empty_meta(),
         }
@@ -426,8 +465,6 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![span()],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: empty_meta(),
         }
@@ -442,6 +479,7 @@ mod tests {
         let doc = IRDocument {
             document_id: doc_id(),
             nodes: vec![],
+            edges: vec![],
         };
         let kb = lower_to_kb(&doc).unwrap();
         assert!(kb.is_all_certain()); // vacuously
@@ -452,6 +490,7 @@ mod tests {
         let doc = IRDocument {
             document_id: doc_id(),
             nodes: vec![affirmed_fact_node("F1", atom("ok"))],
+            edges: vec![],
         };
         let kb = lower_to_kb(&doc).unwrap();
         // We can't directly observe internals; instead, run a search.
@@ -477,6 +516,7 @@ mod tests {
         let doc = IRDocument {
             document_id: doc_id(),
             nodes: vec![denied_fact_node("F1", atom("absent"))],
+            edges: vec![],
         };
         let kb = lower_to_kb(&doc).unwrap();
         // Sanity: the KB has at least one rule (the NAF rule).
@@ -498,6 +538,7 @@ mod tests {
                 affirmed_fact_node("F2", atom("present")),
                 query_node("Q1", atom("present")),
             ],
+            edges: vec![],
         };
         let results = run_adjudication(&doc).unwrap();
         match &results[0].result {
@@ -535,6 +576,7 @@ mod tests {
                     compound("parent", vec![atom("homer"), atom("bart")]),
                 ),
             ],
+            edges: vec![],
         };
 
         let results = run_adjudication(&doc).unwrap();
@@ -566,6 +608,7 @@ mod tests {
                 rule_node("R1", rule_term),
                 query_node("Q1", atom("alarm")),
             ],
+            edges: vec![],
         };
 
         let results = run_adjudication(&doc).unwrap();
@@ -591,6 +634,7 @@ mod tests {
         let doc = IRDocument {
             document_id: doc_id(),
             nodes: vec![rule_node("R1", rule_term)],
+            edges: vec![],
         };
 
         let kb = lower_to_kb(&doc).unwrap();
@@ -632,6 +676,7 @@ mod tests {
                 rule_node("R1", rule_term.clone()),
                 query_node("Q1", atom("p")),
             ],
+            edges: vec![],
         };
         let r1 = run_adjudication(&doc1).unwrap();
         match &r1[0].result {
@@ -648,6 +693,7 @@ mod tests {
                 rule_node("R1", rule_term),
                 query_node("Q1", atom("p")),
             ],
+            edges: vec![],
         };
         let r2 = run_adjudication(&doc2).unwrap();
         match &r2[0].result {
@@ -664,6 +710,7 @@ mod tests {
                 "R1",
                 compound("unknownify", vec![atom("x")]),
             )],
+            edges: vec![],
         };
         match lower_to_kb(&doc) {
             Err(LoweringError::UnknownRuleSubtype { functor, .. }) => {
@@ -682,6 +729,7 @@ mod tests {
                 "R1",
                 compound("definitional", vec![atom("h")]),
             )],
+            edges: vec![],
         };
         match lower_to_kb(&doc) {
             Err(LoweringError::InvalidRuleArity {
@@ -704,6 +752,7 @@ mod tests {
         let doc = IRDocument {
             document_id: doc_id(),
             nodes: vec![rule_node("R1", rule_term)],
+            edges: vec![],
         };
         match lower_to_kb(&doc) {
             Err(LoweringError::InvalidProbability { .. }) => {}
@@ -720,6 +769,7 @@ mod tests {
         let doc = IRDocument {
             document_id: doc_id(),
             nodes: vec![rule_node("R1", rule_term)],
+            edges: vec![],
         };
         match lower_to_kb(&doc) {
             Err(LoweringError::ProbabilityOutOfRange { value, .. }) => {
@@ -738,6 +788,7 @@ mod tests {
         let doc = IRDocument {
             document_id: doc_id(),
             nodes: vec![rule_node("R1", rule_term)],
+            edges: vec![],
         };
         match lower_to_kb(&doc) {
             Err(LoweringError::InvalidRuleBodyList { .. }) => {}
@@ -754,6 +805,7 @@ mod tests {
                 affirmed_fact_node("F1", atom("a")),
                 query_node("Q2", atom("b")),
             ],
+            edges: vec![],
         };
         let queries = extract_queries(&doc);
         assert_eq!(queries, vec![atom("a"), atom("b")]);
@@ -769,6 +821,7 @@ mod tests {
         let doc = IRDocument {
             document_id: doc_id(),
             nodes: vec![rule_node("R1", rule_term), query_node("Q1", atom("h"))],
+            edges: vec![],
         };
         let results = run_adjudication(&doc).unwrap();
         match &results[0].result {

--- a/code/packages/rust/adjudication-connector/tests/test_end_to_end.rs
+++ b/code/packages/rust/adjudication-connector/tests/test_end_to_end.rs
@@ -32,8 +32,6 @@ fn fact(id: &str, term: Term, polarity: Polarity, start: usize, end: usize) -> I
         modality: Modality::Present,
         source_spans: vec![span(start, end)],
         confidence: 0.95,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: HashMap::new(),
     }
@@ -48,8 +46,6 @@ fn rule(id: &str, term: Term, start: usize, end: usize) -> IRNode {
         modality: Modality::Present,
         source_spans: vec![span(start, end)],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: HashMap::new(),
     }
@@ -64,8 +60,6 @@ fn query(id: &str, term: Term, start: usize, end: usize) -> IRNode {
         modality: Modality::Present,
         source_spans: vec![span(start, end)],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: HashMap::new(),
     }
@@ -132,6 +126,7 @@ fn deterministic_grandparent_adjudication() {
                 160,
             ),
         ],
+        edges: vec![],
     };
 
     let results = run_adjudication(&doc).unwrap();
@@ -192,6 +187,7 @@ fn probabilistic_alarm_adjudication() {
             ),
             query("Q1", atom("alarm"), 71, 100),
         ],
+        edges: vec![],
     };
 
     let results = run_adjudication(&doc).unwrap();
@@ -249,6 +245,7 @@ fn mixed_deterministic_and_probabilistic_adjudication() {
             ),
             query("Q1", atom("pneumonia"), 81, 100),
         ],
+        edges: vec![],
     };
 
     let results = run_adjudication(&doc).unwrap();
@@ -277,6 +274,7 @@ fn multiple_queries_each_get_their_own_result() {
             query("Q2", atom("b"), 31, 40),
             query("Q3", atom("c"), 41, 50), // not in KB
         ],
+        edges: vec![],
     };
 
     let results = run_adjudication(&doc).unwrap();

--- a/code/packages/rust/adjudication-contract-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-contract-demo/src/lib.rs
@@ -292,8 +292,6 @@ pub fn contract_ir_document(source_text: &str) -> IRDocument {
             // even though the Exception lives inside it as a child.
             source_spans: vec![Span::new(doc_id.clone(), 0, len)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -308,8 +306,6 @@ pub fn contract_ir_document(source_text: &str) -> IRDocument {
             // validator requires).
             source_spans: vec![Span::new(doc_id.clone(), p1, len)],
             confidence: 1.0,
-            part_of: Some(NodeId::new("R1")),
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -322,8 +318,6 @@ pub fn contract_ir_document(source_text: &str) -> IRDocument {
             modality: Modality::Conditional,
             source_spans: vec![Span::new(doc_id.clone(), 0, len)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -337,8 +331,6 @@ pub fn contract_ir_document(source_text: &str) -> IRDocument {
         modality: Modality::Present,
         source_spans: vec![],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: Default::default(),
     });
@@ -346,6 +338,7 @@ pub fn contract_ir_document(source_text: &str) -> IRDocument {
     IRDocument {
         document_id: doc_id,
         nodes,
+        edges: Vec::new(),
     }
 }
 
@@ -428,29 +421,12 @@ mod tests {
         assert_eq!(ir.nodes[0].modality, Modality::Conditional);
     }
 
-    #[test]
-    fn exception_references_rule_via_part_of() {
-        let ir = contract_ir_document(CANONICAL_SOURCE);
-        let exception = &ir.nodes[1];
-        assert_eq!(
-            exception.part_of.as_ref().map(|n| n.0.as_str()),
-            Some("R1")
-        );
-    }
-
-    #[test]
-    fn root_node_tiles_the_document() {
-        // ADJ02 v2 requires root nodes (part_of=None) to tile the
-        // document. R1 is the only root in this fixture; E1 is a
-        // child of R1. R1 must cover [0, len) exactly.
-        let ir = contract_ir_document(CANONICAL_SOURCE);
-        let r1 = &ir.nodes[0];
-        assert_eq!(r1.id.0, "R1");
-        assert!(r1.part_of.is_none(), "R1 must be a root");
-        assert_eq!(r1.source_spans.len(), 1);
-        assert_eq!(r1.source_spans[0].start, 0);
-        assert_eq!(r1.source_spans[0].end, CANONICAL_SOURCE.len());
-    }
+    // The v2 `exception_references_rule_via_part_of` and
+    // `root_node_tiles_the_document` tests asserted on the obsolete
+    // `part_of` field; ADJ01 v3 expresses Exception→Rule attachment
+    // via `Excepts` edges instead. Equivalent tests will be added
+    // when the contract demo emits the v3 graph IR directly (the
+    // current path is HandBuilt and predates v3).
 
     #[test]
     fn exception_span_is_contained_within_rule_span() {

--- a/code/packages/rust/adjudication-coverage/src/lib.rs
+++ b/code/packages/rust/adjudication-coverage/src/lib.rs
@@ -1,36 +1,38 @@
-//! # adjudication-coverage — ADJ02 v2 structural tree-coverage check.
+//! # adjudication-coverage — ADJ02 v3 flat-tile coverage check.
 //!
 //! Reference implementation of
-//! [`ADJ02` v2](../../../specs/ADJ02-coverage-checker.md). The check
-//! is a **structural tree-tiling check** over the hierarchical IR
-//! from ADJ01 v2 — language-agnostic by construction, deterministic,
-//! linear in IR node count, no tagger, no stopword list, no NegEx
-//! triggers.
+//! [`ADJ02` v3](../../../specs/ADJ02-coverage-checker.md), built on
+//! top of the v3 graph IR ([`adjudication_ir`]).
 //!
-//! ## The invariant
+//! ## What v3 changes
 //!
-//! > Every byte of the document's normalized text is in the source
-//! > spans of some leaf in the IR's decomposition tree.
+//! v2's structural-tree-tiling check (children's spans tile the
+//! TextRun parent's spans, recursively) is replaced by a **flat
+//! tiling** of the union of every node and edge `source_spans`
+//! against the document's byte range. The discipline is the same —
+//! every byte must be accounted for, no overlaps, no gaps — but the
+//! check is no longer tied to the now-removed `TextRun` /
+//! `part_of` tree shape.
 //!
-//! Equivalent to five structural conditions:
+//! ## What this crate adds on top of `adjudication_ir::validate`
 //!
-//! 1. **Span validity** — every span has `start < end`, both within
-//!    the document's bounds.
-//! 2. **Root coverage** — the union of root nodes' source_spans
-//!    equals the document's full byte range.
-//! 3. **Parent-child containment** — child spans inside parent's.
-//! 4. **TextRun tiling** — each TextRun's children's spans union to
-//!    the parent's spans.
-//! 5. **No `Unparseable`** — any `Discarded` node with reason
-//!    `Unparseable` is a hard coverage failure.
+//! `adjudication_ir::validate` reports coverage gaps and overlaps
+//! relative to the IR's *self-determined* span range
+//! `[min_start, max_end)` — it doesn't know the document's actual
+//! length. This crate carries the [`Document`]'s normalized text
+//! length and verifies the IR tiles all the way to the end of the
+//! document.
 //!
-//! Conditions 1, 3, 4 are already enforced by
-//! `adjudication_ir::validate`. This crate adds conditions 2 and 5
-//! and packages all five violations into a `CoverageResult` shape
-//! suitable for ADJ06 clarification.
+//! Plus, it surfaces the framework-level invariants ADJ02 owns:
+//!
+//! - `UnparseableDiscarded` — any `Discarded` node with
+//!   `discard_reason = Unparseable` is a hard coverage failure (ADJ01
+//!   rule). The extractor must produce a meaningful node, never an
+//!   admission of incompetence.
 
 use adjudication_ir::{
-    validate, DiscardReason, DocumentId, IRDocument, NodeId, NodeKind, ValidationError,
+    validate, DiscardReason, DocumentId, IRDocument, NodeOrEdgeId, NodeKind, SpanLocation,
+    ValidationError,
 };
 
 // ---------------------------------------------------------------------------
@@ -38,7 +40,7 @@ use adjudication_ir::{
 // ---------------------------------------------------------------------------
 
 /// The document under coverage analysis. The check reads only
-/// `normalized_text.len()` — it never inspects the bytes.
+/// `normalized_text.len()` — it never inspects the bytes themselves.
 #[derive(Debug, Clone)]
 pub struct Document {
     pub id: DocumentId,
@@ -52,21 +54,21 @@ pub enum CoverageResult {
     Fail { violations: Vec<CoverageViolation> },
 }
 
-/// One coverage violation. Maps to an ADJ06 clarification question
-/// shape.
+/// One coverage violation. Each variant maps to a clarification-
+/// question shape consumed by ADJ06.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CoverageViolation {
-    /// A span cites a different document than the one under check.
+    /// A node's or edge's span cites a different document.
     SpanWrongDocument {
-        node_id: NodeId,
+        location: SpanLocation,
         expected: DocumentId,
         found: DocumentId,
     },
 
-    /// A span's `start >= end` or extends beyond the document's
+    /// A span's `start >= end`, or extends beyond the document's
     /// byte length.
     InvalidSpan {
-        node_id: NodeId,
+        location: SpanLocation,
         start: usize,
         end: usize,
         document_len: usize,
@@ -74,85 +76,104 @@ pub enum CoverageViolation {
 
     /// A `Discarded` node has reason `Unparseable`. Always a hard
     /// coverage failure per ADJ01.
-    UnparseableDiscarded { node_id: NodeId },
+    UnparseableDiscarded { node_id: adjudication_ir::NodeId },
 
-    /// The union of root nodes' source_spans does not equal the
-    /// document's full byte range. `missing_ranges` enumerates the
-    /// uncovered byte ranges.
-    RootsDoNotTileDocument { missing_ranges: Vec<(usize, usize)> },
+    /// Some byte range of the document is not in any node's or
+    /// edge's source_spans.
+    CoverageGap { missing_ranges: Vec<(usize, usize)> },
 
-    /// A node's `part_of` references an id that doesn't exist.
-    DanglingPartOf { node_id: NodeId, missing_parent: NodeId },
-
-    /// A child's source spans extend beyond its structural parent's.
-    ChildSpansExceedParent { child_id: NodeId, parent_id: NodeId },
-
-    /// A `TextRun`'s children's spans, taken together, do not tile
-    /// its own spans. `missing_ranges` enumerates the gaps inside
-    /// the parent.
-    ChildrenDoNotTileParent {
-        parent_id: NodeId,
-        missing_ranges: Vec<(usize, usize)>,
+    /// Some byte range appears in more than one source_span (across
+    /// nodes and edges, after synthesized-object exemption).
+    CoverageOverlap {
+        ranges: Vec<(usize, usize)>,
+        participants: Vec<NodeOrEdgeId>,
     },
 
-    /// A non-TextRun node has children. Only TextRun may be a
-    /// structural parent.
-    NonTextRunHasChildren {
-        parent_id: NodeId,
-        parent_kind: NodeKind,
-        children: Vec<NodeId>,
-    },
-
-    /// A `part_of` cycle in the decomposition.
-    PartOfCycle { participants: Vec<NodeId> },
+    /// `adjudication_ir::validate` returned an error that isn't a
+    /// coverage concern. The propagation / acyclicity / kind-rule
+    /// errors live on other checkers; reported here so callers can
+    /// dispatch.
+    UpstreamValidationError { kind: String },
 }
 
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
-/// Run the structural coverage check. Returns `Pass` or
-/// `Fail { violations }`.
+/// Run the flat-tile coverage check.
 ///
-/// The check does not call an LLM; it does not consult a tagger;
-/// it does not classify tokens. The LLM-produced decomposition tree
-/// already encoded what counts as content; this check verifies the
-/// tree's structural completeness.
+/// 1. Delegates the bulk of the tiling check to
+///    [`adjudication_ir::validate`] and translates coverage-related
+///    errors into [`CoverageViolation`]s.
+/// 2. Checks that the IR's coverage reaches the document's
+///    `normalized_text.len()`. If the IR tiles `[0, max_end)` but
+///    `max_end < doc_len`, the gap is reported.
+/// 3. Checks for `Discarded(Unparseable)` nodes — always a hard
+///    failure per ADJ01.
 pub fn check_coverage(doc: &Document, ir_doc: &IRDocument) -> CoverageResult {
-    let mut violations = Vec::new();
+    let mut violations: Vec<CoverageViolation> = Vec::new();
+    let doc_len = doc.normalized_text.len();
 
-    // 1, 3, 4 — delegated to adjudication_ir::validate, which
-    // enforces ADJ01's well-formedness rules including all the
-    // tree-shape invariants.
     if let Err(e) = validate(ir_doc) {
-        violations.extend(translate_validation_error(e, doc));
+        match e {
+            ValidationError::InvalidSpan { location, start, end } => {
+                violations.push(CoverageViolation::InvalidSpan {
+                    location,
+                    start,
+                    end,
+                    document_len: doc_len,
+                });
+            }
+            ValidationError::SpanDocumentMismatch { location, expected, found } => {
+                violations.push(CoverageViolation::SpanWrongDocument {
+                    location,
+                    expected,
+                    found,
+                });
+            }
+            ValidationError::CoverageGap { missing_ranges } => {
+                violations.push(CoverageViolation::CoverageGap { missing_ranges });
+            }
+            ValidationError::CoverageOverlap { ranges, participants } => {
+                violations.push(CoverageViolation::CoverageOverlap { ranges, participants });
+            }
+            other => {
+                violations.push(CoverageViolation::UpstreamValidationError {
+                    kind: format!("{other:?}"),
+                });
+            }
+        }
     }
 
-    // 2. Root coverage: roots union to (0, doc_len).
-    let doc_len = doc.normalized_text.len();
-    let mut root_spans: Vec<(usize, usize)> = ir_doc
+    // Document-end gap: validate() doesn't know doc_len, so we check
+    // that the IR's max source-span end reaches it.
+    let max_end: usize = ir_doc
         .nodes
         .iter()
-        .filter(|n| n.part_of.is_none())
         .flat_map(|n| n.source_spans.iter())
         .filter(|s| s.document_id == doc.id)
-        .map(|s| (s.start, s.end))
-        .collect();
-    root_spans.sort_by_key(|(s, _)| *s);
-    let root_merged = merge_ranges(root_spans);
-    let document_range = if doc_len > 0 {
-        vec![(0, doc_len)]
-    } else {
-        vec![]
-    };
-    let missing = subtract_intervals(document_range.clone(), root_merged.clone());
-    if !missing.is_empty() && !document_range.is_empty() {
-        violations.push(CoverageViolation::RootsDoNotTileDocument {
-            missing_ranges: missing,
-        });
+        .map(|s| s.end)
+        .chain(
+            ir_doc
+                .edges
+                .iter()
+                .flat_map(|e| e.source_spans.iter())
+                .filter(|s| s.document_id == doc.id)
+                .map(|s| s.end),
+        )
+        .max()
+        .unwrap_or(0);
+    if doc_len > 0 && max_end < doc_len {
+        // Don't double-report if validate already reported a gap.
+        let already = violations.iter().any(|v| matches!(v, CoverageViolation::CoverageGap { .. }));
+        if !already {
+            violations.push(CoverageViolation::CoverageGap {
+                missing_ranges: vec![(max_end, doc_len)],
+            });
+        }
     }
 
-    // 5. Hard rule: Unparseable Discarded is a coverage failure.
+    // Unparseable Discarded is always a hard failure.
     for node in &ir_doc.nodes {
         if node.kind == NodeKind::Discarded
             && node.discard_reason == Some(DiscardReason::Unparseable)
@@ -170,110 +191,7 @@ pub fn check_coverage(doc: &Document, ir_doc: &IRDocument) -> CoverageResult {
     }
 }
 
-fn translate_validation_error(e: ValidationError, doc: &Document) -> Vec<CoverageViolation> {
-    let mut out = Vec::new();
-    match e {
-        ValidationError::InvalidSpan {
-            node_id, start, end,
-        } => out.push(CoverageViolation::InvalidSpan {
-            node_id,
-            start,
-            end,
-            document_len: doc.normalized_text.len(),
-        }),
-        ValidationError::SpanDocumentMismatch {
-            node_id, expected, found,
-        } => out.push(CoverageViolation::SpanWrongDocument {
-            node_id,
-            expected,
-            found,
-        }),
-        ValidationError::DanglingPartOf {
-            node_id, missing_parent,
-        } => out.push(CoverageViolation::DanglingPartOf {
-            node_id,
-            missing_parent,
-        }),
-        ValidationError::ChildSpansExceedParent {
-            child_id, parent_id,
-        } => out.push(CoverageViolation::ChildSpansExceedParent {
-            child_id,
-            parent_id,
-        }),
-        ValidationError::ChildrenDoNotTileParent {
-            parent_id, missing_ranges,
-        } => out.push(CoverageViolation::ChildrenDoNotTileParent {
-            parent_id,
-            missing_ranges,
-        }),
-        ValidationError::NonTextRunHasChildren {
-            parent_id, parent_kind, children,
-        } => out.push(CoverageViolation::NonTextRunHasChildren {
-            parent_id,
-            parent_kind,
-            children,
-        }),
-        ValidationError::PartOfCycle { participants } => {
-            out.push(CoverageViolation::PartOfCycle { participants })
-        }
-        // Other adjudication-ir validation errors (DuplicateNodeId,
-        // FactWithUncertainPolarity, etc.) are not coverage concerns
-        // per ADJ02; they belong to ADJ01 well-formedness.
-        _ => {}
-    }
-    out
-}
-
-/// Merge overlapping / adjacent byte-range intervals.
-fn merge_ranges(mut rs: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
-    if rs.is_empty() {
-        return rs;
-    }
-    rs.sort_by_key(|(s, _)| *s);
-    let mut out = Vec::with_capacity(rs.len());
-    let mut cur = rs[0];
-    for (s, e) in rs.into_iter().skip(1) {
-        if s <= cur.1 {
-            cur.1 = cur.1.max(e);
-        } else {
-            out.push(cur);
-            cur = (s, e);
-        }
-    }
-    out.push(cur);
-    out
-}
-
-/// Bytes in `parent` not covered by any range in `children`.
-fn subtract_intervals(
-    parent: Vec<(usize, usize)>,
-    children: Vec<(usize, usize)>,
-) -> Vec<(usize, usize)> {
-    let parent_merged = merge_ranges(parent);
-    let child_merged = merge_ranges(children);
-    let mut out = Vec::new();
-    for (p_start, p_end) in parent_merged {
-        let mut cursor = p_start;
-        for &(c_start, c_end) in &child_merged {
-            if c_end <= cursor || c_start >= p_end {
-                continue;
-            }
-            if c_start > cursor {
-                out.push((cursor, c_start.min(p_end)));
-            }
-            cursor = cursor.max(c_end);
-            if cursor >= p_end {
-                break;
-            }
-        }
-        if cursor < p_end {
-            out.push((cursor, p_end));
-        }
-    }
-    out
-}
-
-// Re-export Span and NodeId for caller convenience.
+// Re-export common types for caller convenience.
 pub use adjudication_ir::{NodeId as IrNodeId, Span as IrSpan};
 
 // ---------------------------------------------------------------------------
@@ -283,7 +201,7 @@ pub use adjudication_ir::{NodeId as IrNodeId, Span as IrSpan};
 #[cfg(test)]
 mod tests {
     use super::*;
-    use adjudication_ir::{IRNode, Modality, Polarity, Span};
+    use adjudication_ir::{IRNode, Modality, NodeId, Polarity, Span};
     use logic_core::{atom, compound};
     use std::collections::HashMap;
 
@@ -302,23 +220,7 @@ mod tests {
         Span::new(doc_id(), start, end)
     }
 
-    fn text_run(id: &str, start: usize, end: usize, part_of: Option<&str>) -> IRNode {
-        IRNode {
-            id: NodeId::new(id),
-            kind: NodeKind::TextRun,
-            term: compound("text_run", vec![]),
-            polarity: Polarity::Inherit,
-            modality: Modality::Inherit,
-            source_spans: vec![span_of(start, end)],
-            confidence: 1.0,
-            part_of: part_of.map(NodeId::new),
-            lowered_from: None,
-            discard_reason: None,
-            metadata: HashMap::new(),
-        }
-    }
-
-    fn fact_leaf(id: &str, start: usize, end: usize, part_of: Option<&str>) -> IRNode {
+    fn fact_leaf(id: &str, start: usize, end: usize) -> IRNode {
         IRNode {
             id: NodeId::new(id),
             kind: NodeKind::Fact,
@@ -327,8 +229,6 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![span_of(start, end)],
             confidence: 0.9,
-            part_of: part_of.map(NodeId::new),
-            lowered_from: None,
             discard_reason: None,
             metadata: HashMap::new(),
         }
@@ -340,6 +240,7 @@ mod tests {
         let ir = IRDocument {
             document_id: doc_id(),
             nodes: vec![],
+            edges: vec![],
         };
         assert_eq!(check_coverage(&doc, &ir), CoverageResult::Pass);
     }
@@ -350,74 +251,73 @@ mod tests {
         let ir = IRDocument {
             document_id: doc_id(),
             nodes: vec![],
-        };
-        match check_coverage(&doc, &ir) {
-            CoverageResult::Fail { violations } => {
-                let has_root_miss = violations.iter().any(|v| matches!(
-                    v,
-                    CoverageViolation::RootsDoNotTileDocument { missing_ranges }
-                        if missing_ranges == &vec![(0, 11)]
-                ));
-                assert!(has_root_miss, "expected RootsDoNotTileDocument: {:?}", violations);
-            }
-            other => panic!("expected Fail, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn single_root_textrun_with_one_child_tiling_full_doc_passes() {
-        let doc = mk_doc("hello world");
-        let parent = text_run("T0", 0, 11, None);
-        let leaf = fact_leaf("F1", 0, 11, Some("T0"));
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![parent, leaf],
-        };
-        assert_eq!(check_coverage(&doc, &ir), CoverageResult::Pass);
-    }
-
-    #[test]
-    fn root_tile_gap_reported_with_missing_range() {
-        // doc 0..50 but only one root TextRun at 0..30
-        let doc = mk_doc(&"x".repeat(50));
-        let parent = text_run("T0", 0, 30, None);
-        let leaf = fact_leaf("F1", 0, 30, Some("T0"));
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![parent, leaf],
-        };
-        match check_coverage(&doc, &ir) {
-            CoverageResult::Fail { violations } => {
-                let has_missing = violations.iter().any(|v| matches!(
-                    v,
-                    CoverageViolation::RootsDoNotTileDocument { missing_ranges }
-                        if missing_ranges == &vec![(30, 50)]
-                ));
-                assert!(has_missing, "expected (30, 50) missing: {:?}", violations);
-            }
-            other => panic!("expected Fail, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn child_gap_within_textrun_reported_with_missing_range() {
-        // Root TextRun 0..50, two children 0..20 and 30..50 — gap 20..30.
-        let doc = mk_doc(&"x".repeat(50));
-        let parent = text_run("T0", 0, 50, None);
-        let leaf1 = fact_leaf("F1", 0, 20, Some("T0"));
-        let leaf2 = fact_leaf("F2", 30, 50, Some("T0"));
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![parent, leaf1, leaf2],
+            edges: vec![],
         };
         match check_coverage(&doc, &ir) {
             CoverageResult::Fail { violations } => {
                 let has_gap = violations.iter().any(|v| matches!(
                     v,
-                    CoverageViolation::ChildrenDoNotTileParent { missing_ranges, .. }
-                        if missing_ranges == &vec![(20, 30)]
+                    CoverageViolation::CoverageGap { missing_ranges }
+                        if missing_ranges == &vec![(0, 11)]
                 ));
-                assert!(has_gap, "expected ChildrenDoNotTileParent(20..30): {:?}", violations);
+                assert!(has_gap, "expected (0,11) CoverageGap: {:?}", violations);
+            }
+            other => panic!("expected Fail, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn single_fact_tiling_full_doc_passes() {
+        let doc = mk_doc("hello world");
+        let leaf = fact_leaf("F1", 0, 11);
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![leaf],
+            edges: vec![],
+        };
+        assert_eq!(check_coverage(&doc, &ir), CoverageResult::Pass);
+    }
+
+    #[test]
+    fn doc_end_gap_detected() {
+        // Doc 0..50; only F1 covers 0..30. Gap 30..50 should report.
+        let doc = mk_doc(&"x".repeat(50));
+        let leaf = fact_leaf("F1", 0, 30);
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![leaf],
+            edges: vec![],
+        };
+        match check_coverage(&doc, &ir) {
+            CoverageResult::Fail { violations } => {
+                let has_gap = violations.iter().any(|v| matches!(
+                    v,
+                    CoverageViolation::CoverageGap { missing_ranges }
+                        if missing_ranges == &vec![(30, 50)]
+                ));
+                assert!(has_gap, "expected (30,50) gap: {:?}", violations);
+            }
+            other => panic!("expected Fail, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn mid_doc_gap_detected() {
+        // Two facts at 0..20 and 30..50 leave 20..30 uncovered.
+        let doc = mk_doc(&"x".repeat(50));
+        let f1 = fact_leaf("F1", 0, 20);
+        let f2 = fact_leaf("F2", 30, 50);
+        let ir = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![f1, f2],
+            edges: vec![],
+        };
+        match check_coverage(&doc, &ir) {
+            CoverageResult::Fail { violations } => {
+                let has_gap = violations
+                    .iter()
+                    .any(|v| matches!(v, CoverageViolation::CoverageGap { .. }));
+                assert!(has_gap, "expected gap: {:?}", violations);
             }
             other => panic!("expected Fail, got {:?}", other),
         }
@@ -426,7 +326,6 @@ mod tests {
     #[test]
     fn unparseable_discarded_always_fails() {
         let doc = mk_doc(&"x".repeat(20));
-        let parent = text_run("T0", 0, 20, None);
         let discard = IRNode {
             id: NodeId::new("D1"),
             kind: NodeKind::Discarded,
@@ -435,14 +334,13 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![span_of(0, 20)],
             confidence: 1.0,
-            part_of: Some(NodeId::new("T0")),
-            lowered_from: None,
             discard_reason: Some(DiscardReason::Unparseable),
             metadata: HashMap::new(),
         };
         let ir = IRDocument {
             document_id: doc_id(),
-            nodes: vec![parent, discard],
+            nodes: vec![discard],
+            edges: vec![],
         };
         match check_coverage(&doc, &ir) {
             CoverageResult::Fail { violations } => {
@@ -456,9 +354,8 @@ mod tests {
     }
 
     #[test]
-    fn discarded_with_pleasantry_reason_is_ok() {
+    fn discarded_with_pleasantry_is_ok() {
         let doc = mk_doc(&"x".repeat(20));
-        let parent = text_run("T0", 0, 20, None);
         let discard = IRNode {
             id: NodeId::new("D1"),
             kind: NodeKind::Discarded,
@@ -467,62 +364,14 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![span_of(0, 20)],
             confidence: 1.0,
-            part_of: Some(NodeId::new("T0")),
-            lowered_from: None,
             discard_reason: Some(DiscardReason::Pleasantry),
             metadata: HashMap::new(),
         };
         let ir = IRDocument {
             document_id: doc_id(),
-            nodes: vec![parent, discard],
+            nodes: vec![discard],
+            edges: vec![],
         };
         assert_eq!(check_coverage(&doc, &ir), CoverageResult::Pass);
-    }
-
-    #[test]
-    fn nested_textruns_tile_correctly_passes() {
-        let doc = mk_doc(&"x".repeat(50));
-        let outer = text_run("T0", 0, 50, None);
-        let inner = text_run("T1", 0, 50, Some("T0"));
-        let leaf = fact_leaf("F1", 0, 50, Some("T1"));
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![outer, inner, leaf],
-        };
-        assert_eq!(check_coverage(&doc, &ir), CoverageResult::Pass);
-    }
-
-    #[test]
-    fn merge_ranges_combines_adjacent_intervals() {
-        assert_eq!(
-            merge_ranges(vec![(0, 5), (5, 10), (15, 20)]),
-            vec![(0, 10), (15, 20)]
-        );
-    }
-
-    #[test]
-    fn subtract_intervals_finds_gaps() {
-        assert_eq!(
-            subtract_intervals(vec![(0, 50)], vec![(10, 20), (30, 40)]),
-            vec![(0, 10), (20, 30), (40, 50)]
-        );
-    }
-
-    #[test]
-    fn dangling_part_of_surfaces_as_coverage_violation() {
-        let doc = mk_doc(&"x".repeat(20));
-        let leaf = fact_leaf("F1", 0, 20, Some("DOES_NOT_EXIST"));
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![leaf],
-        };
-        match check_coverage(&doc, &ir) {
-            CoverageResult::Fail { violations } => {
-                assert!(violations
-                    .iter()
-                    .any(|v| matches!(v, CoverageViolation::DanglingPartOf { .. })));
-            }
-            other => panic!("expected Fail, got {:?}", other),
-        }
     }
 }

--- a/code/packages/rust/adjudication-ir/CHANGELOG.md
+++ b/code/packages/rust/adjudication-ir/CHANGELOG.md
@@ -2,6 +2,141 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-05-12 — ADJ01 v3 multi-directed acyclic graph
+
+### Changed (breaking)
+
+The crate's surface area is rebuilt to match
+[ADJ01 v3](../../specs/ADJ01-adjudication-ir-grammar.md). v2's
+hierarchical decomposition tree (with `part_of` and `lowered_from`
+fields on `IRNode` and the content-free `TextRun` grouping kind)
+becomes a single multi-directed acyclic graph of typed nodes and
+typed `IREdge`s. The tree was sufficient for small narratives but
+cannot represent the relationships that emerge at scale: rule
+citations, cross-references, table-row membership, provenance
+chains, exception scoping, temporal supersession.
+
+The closed-set edge-relation taxonomy organizes 30+ relations into
+eleven groups plus a `DomainSpecific(name)` escape hatch:
+
+  1. Structural — `Contains`, `Precedes`, `Heading`
+  2. Identity — `Mentions`, `SameAs`, `Refers`
+  3. Rule modification — `Excepts`, `Refines`, `Generalizes`,
+     `Supersedes`, `Restricts`
+  4. Application — `AppliesTo`, `AppliesWhen`, `Concludes`
+  5. Provenance — `DerivedFrom`, `JustifiedBy`, `ElicitedFrom`
+  6. Tabular — `RowOf`, `ColumnOf`, `HeaderOf`, `CellOf`
+  7. Temporal — `Before`, `After`, `During`, `EffectiveAt`,
+     `SupersededAt`
+  8. Cross-source — `ConflictsWith`, `Confirms`, `DependsOn`
+  9. Discourse — `Defines`, `Restates`, `Cites`
+ 10. Refinement — `Clarifies` (replaces v2's `lowered_from`)
+ 11. Escape hatch — `DomainSpecific(name)`
+
+### Added
+
+- `IREdge { id, source, target, relation, polarity, modality,
+  source_spans, confidence, metadata }` — first-class edge struct
+  alongside `IRNode`.
+- `EdgeId` opaque identifier mirroring `NodeId`.
+- `EdgeRelation` enum with all 30+ closed-set variants plus
+  `DomainSpecific(String)` escape hatch and an `as_str()` method
+  for audit-trail records.
+- `NodeKind::Section` — meaningful structural unit (paragraph,
+  sentence, table, row, cell, heading). Carries the structural type
+  in its `term`; its `source_spans` cover only the meta-text
+  (heading, numbering, delimiters), not the content.
+- `NodeKind::Entity` — deduplicated reference target for atoms or
+  compound terms mentioned at multiple sites. May have empty
+  `source_spans` (synthesized).
+- `IRDocument.edges: Vec<IREdge>` top-level collection.
+- `IRDocument::adjacency_out(node_id)` / `adjacency_in(node_id)`
+  helpers for callers that want a graph-adjacency view.
+- `IRDocument::node(id)` / `edge(id)` lookup helpers.
+- `SpanLocation { Node(NodeId), Edge(EdgeId) }` discriminator on
+  span-related `ValidationError`s so callers can attribute span
+  failures to either a node or an edge.
+- `InheritField { Polarity, Modality }` discriminator on
+  `Inherit`-related errors.
+- `NodeOrEdgeId { Node(NodeId), Edge(EdgeId) }` for coverage-
+  overlap participant attribution.
+- Eleven new `ValidationError` variants for edge well-formedness
+  (`DanglingEdgeSource`, `DanglingEdgeTarget`, `SelfLoopEdge`,
+  `DuplicateEdgeId`, `InheritOnEdge`, `InvalidDomainSpecificName`,
+  `InvalidRelationSourceKind`, `InvalidRelationTargetKind`,
+  `IncompatibleClarification`, `UnattachedException`, `GraphCycle`)
+  and three for coverage and propagation
+  (`CoverageGap`, `CoverageOverlap`, `InheritWithoutParent`,
+  `PropagationConflict`).
+
+### Removed (breaking)
+
+- `NodeKind::TextRun` — replaced by `NodeKind::Section` with a
+  meaningful `term`.
+- `IRNode.part_of: Option<NodeId>` — replaced by
+  `EdgeRelation::Contains` edges. A node's structural parent is no
+  longer a field on the node; it's an edge in the graph.
+- `IRNode.lowered_from: Option<NodeId>` — replaced by
+  `EdgeRelation::Clarifies` edges.
+- v2's `ValidationError` variants tied to the tree shape:
+  `LoweringCycle`, `DanglingLoweredFrom`, `LoweringExpandsSpans`,
+  `IncompatibleLowering`, `DanglingPartOf`, `PartOfCycle`,
+  `NonTextRunHasChildren`, `ChildSpansExceedParent`,
+  `ChildrenDoNotTileParent` — replaced by `GraphCycle`,
+  `IncompatibleClarification`, `CoverageGap`, `CoverageOverlap`,
+  etc.
+- `validate_structural_tree` and `validate_lowering_dag`
+  module-private helpers — replaced by the graph-shaped
+  `check_acyclicity`, `check_coverage`, `check_propagation`, and
+  per-relation invariant checks.
+
+### Invariants (v3 well-formedness summary)
+
+`validate` enforces all nine of:
+
+  1. Node-kind constraints (e.g., `Fact.polarity != Uncertain`).
+  2. Edge well-formedness (source/target exist, relation legal,
+     `Inherit` rejected on edges, DomainSpecific name validation).
+  3. Identifier uniqueness (nodes and edges separately).
+  4. Span validity (offsets are valid byte ranges in this document).
+  5. Coverage — flat tile of `(nodes ∪ edges).source_spans` against
+     `[0, max_end)`, with synthesized-object exemption (empty-span
+     Query, Entity, and synthesized edges).
+  6. Acyclicity — `(Nodes, Edges)` is a DAG across ALL edge
+     relations.
+  7. Propagation consistency — for every node with
+     `polarity = Inherit`, all `Contains` parents agree on the
+     effective polarity (and similarly for modality).
+  8. Edge-relation endpoint kind constraints (e.g., `Excepts` must
+     go `Exception -> Rule`; `RowOf` must target a `Section`).
+  9. Exception attachment — every Exception node is the source of
+     at least one `Excepts` edge.
+
+### Migration
+
+Backwards compatibility is deliberately broken. v2 IR documents do
+not load as v3. Downstream consumers that depend on this crate
+(adjudication-coverage, adjudication-polarity-modality,
+adjudication-round-trip, adjudication-adversarial,
+adjudication-connector, adjudication-pipeline, the demos, and
+llm-primitives) are temporarily excluded from the workspace
+`members` list while their migration PRs land. Each consumer's
+migration is sized to land as its own PR per the sequence in
+[`ADJ01 v3 §"Status"`](../../specs/ADJ01-adjudication-ir-grammar.md).
+
+### Tests
+
+24 unit tests cover empty doc, single-node tiling, duplicate ids
+(node + edge), per-kind polarity rules, edge endpoint existence,
+self-loop, relation source/target kind constraints, `Inherit` on
+edges, `Inherit` on nodes without parent, graph cycle, unattached
+exception, coverage gap (mid-document and at-start), coverage
+overlap, synthesized-Query exemption, Entity dedup with Mentions
+edge tiling, single-parent Contains propagation, multi-parent
+`PropagationConflict`, `DomainSpecific` name collision, `Clarifies`
+kind incompatibility, adjacency helpers, Discarded-without-reason,
+and a worked TSA-style example end-to-end.
+
 ## [0.2.0] - 2026-05-11 — ADJ01 v2 hierarchical decomposition
 
 ### Added

--- a/code/packages/rust/adjudication-ir/Cargo.toml
+++ b/code/packages/rust/adjudication-ir/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-ir"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
-description = "The typed intermediate representation for rule-based adjudication (ADJ01)."
+description = "The typed intermediate representation for rule-based adjudication (ADJ01 v3): multi-directed acyclic graph IR with typed edges, replacing v2's hierarchical decomposition tree. Adds IREdge alongside IRNode with a closed eleven-group edge-relation taxonomy (structural, identity, rule-modification, application, provenance, tabular, temporal, cross-source, discourse, refinement, and a DomainSpecific escape hatch), drops TextRun + part_of + lowered_from, adds Section and Entity node kinds, and switches coverage to a flat tile of (nodes ∪ edges).source_spans with a uniform DAG acyclicity check."
 
 [dependencies]
 logic-core = { path = "../logic-core" }

--- a/code/packages/rust/adjudication-ir/src/lib.rs
+++ b/code/packages/rust/adjudication-ir/src/lib.rs
@@ -1,18 +1,41 @@
-//! # adjudication-ir — the typed IR for rule-based adjudication.
+//! # adjudication-ir — the typed IR for rule-based adjudication (v3).
 //!
-//! Reference implementation of [`ADJ01`](../../../specs/ADJ01-adjudication-ir-grammar.md).
-//! Defines every IR node shape, the polarity / modality lattices, the
-//! lowering DAG, and a total `validate` function that enforces every
-//! well-formedness rule before any downstream component touches the
-//! document.
+//! Reference implementation of
+//! [`ADJ01 v3`](../../../specs/ADJ01-adjudication-ir-grammar.md).
+//! Defines node shapes, edge shapes, the closed-set edge-relation
+//! taxonomy, the polarity / modality lattices, and a total
+//! [`validate`] function that enforces every well-formedness
+//! invariant before any downstream component touches the document.
 //!
-//! ## Why a separate IR crate
+//! ## What v3 changes
 //!
-//! The IR sits above the term layer (`logic-core`) and below the
-//! checker passes (ADJ02..ADJ05), the dialogue (ADJ06), the audit
-//! trail (ADJ07), and the rule-compilation pipeline (ADJ09). All of
-//! those consume IR documents; none should reconstruct the grammar
-//! locally.
+//! v2's hierarchical decomposition tree (with `part_of` and
+//! `lowered_from` fields and the content-free `TextRun` grouping
+//! kind) becomes a single **multi-directed acyclic graph** of typed
+//! nodes and typed [`IREdge`]s. The tree was sufficient for small
+//! narratives but cannot represent the relationships that emerge at
+//! scale: rule citations, cross-references, table-row membership,
+//! provenance chains, exception scoping, temporal supersession.
+//! v3 promotes each of those to a first-class IR edge with a typed
+//! [`EdgeRelation`] from a closed eleven-group taxonomy.
+//!
+//! Key v2 → v3 differences:
+//!
+//! - [`IRNode`] drops `part_of` and `lowered_from`. Both move into
+//!   typed edges ([`EdgeRelation::Contains`] and
+//!   [`EdgeRelation::Clarifies`] respectively).
+//! - [`NodeKind`] drops `TextRun`; replaced by [`NodeKind::Section`]
+//!   (a *meaningful* structural grouping that carries its type in
+//!   the node's term) and [`NodeKind::Entity`] (a deduplicated
+//!   reference target).
+//! - New top-level [`IREdge`] alongside [`IRNode`]; the on-wire
+//!   shape gains an `edges: [IREdge]` field.
+//! - Coverage v3 is a *flat tile* of `(nodes ∪ edges).source_spans`
+//!   against `[0, len(document))`; no recursive tree descent.
+//! - A **DAG acyclicity** invariant is added across all edge
+//!   relations.
+//! - Propagation runs along [`EdgeRelation::Contains`] edges with a
+//!   multi-parent [`ValidationError::PropagationConflict`] check.
 //!
 //! ## Layer Position
 //!
@@ -20,23 +43,31 @@
 //!    logic-core (LP00)            ← Term, LogicVar, Substitution, unify
 //!         │
 //!         ▼
-//!    adjudication-ir              ← this crate (ADJ01)
+//!    adjudication-ir              ← this crate (ADJ01 v3)
 //!         │
-//!         ├── ADJ02 coverage checker
-//!         ├── ADJ03 polarity/modality checker
-//!         ├── ADJ04 round-trip checker
-//!         ├── ADJ05 adversarial verifier
-//!         ├── ADJ06 clarification dialogue
-//!         └── ADJ09 rule compilation
+//!         ├── ADJ02 coverage + DAG check
+//!         ├── ADJ03 polarity/modality propagation
+//!         ├── ADJ04 round-trip
+//!         ├── ADJ05 adversarial
+//!         ├── ADJ06 clarification
+//!         └── ADJ09 / ADJ14 rule compilation + elicitation
 //! ```
+//!
+//! ## Worked example
+//!
+//! See [`ADJ01 §"Worked Example (Graph Form)"`](../../../specs/ADJ01-adjudication-ir-grammar.md)
+//! for the canonical TSA worked example end-to-end. The same example
+//! appears in the integration tests below.
+
+#![deny(unsafe_code)]
 
 use std::collections::{HashMap, HashSet};
 
 use logic_core::Term;
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Identifiers
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 /// Stable identifier for a document. Opaque to this crate; deployments
 /// typically use UUIDv4 strings, but any unique identifier is acceptable
@@ -50,7 +81,7 @@ impl DocumentId {
     }
 }
 
-/// Stable identifier for an IRNode within a document.
+/// Stable identifier for an [`IRNode`] within a document.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NodeId(pub String);
 
@@ -60,9 +91,22 @@ impl NodeId {
     }
 }
 
-// ---------------------------------------------------------------------------
+/// Stable identifier for an [`IREdge`] within a document.
+///
+/// Convention: `"E1", "E2", ...` for human-readable edges, mirroring
+/// the `"N1", "N2", ...` convention for nodes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EdgeId(pub String);
+
+impl EdgeId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+// ===========================================================================
 // Spans
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 /// A byte-offset range into a document's normalized text.
 ///
@@ -79,14 +123,10 @@ pub struct Span {
 
 impl Span {
     pub fn new(document_id: DocumentId, start: usize, end: usize) -> Self {
-        Self {
-            document_id,
-            start,
-            end,
-        }
+        Self { document_id, start, end }
     }
 
-    /// `true` iff `self.start < self.end` and they refer to the same document.
+    /// `true` iff `self.start < self.end`.
     pub fn is_valid(&self) -> bool {
         self.start < self.end
     }
@@ -100,37 +140,40 @@ impl Span {
     }
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Lattices: Polarity, Modality
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
-/// Whether the node asserts, denies, or records uncertainty about its
-/// term. The lattice is flat — no element subsumes another, and there
-/// is no `Unknown` value. The absence of evidence is represented by
-/// the absence of a node (coverage enforces this).
+/// Whether the node or edge asserts, denies, or records uncertainty
+/// about itself. The lattice is flat — no element subsumes another,
+/// and there is no `Unknown` value. The absence of evidence is
+/// represented by the absence of a node/edge (coverage enforces this).
 ///
-/// **v2**: `Inherit` lets a node defer to its structural ancestor's
-/// polarity (per `ADJ01` v2 propagation). A `Polarity::Inherit` value
-/// on a node means "use the nearest non-`Inherit` ancestor's value";
-/// only the root (or a leaf with no overriding ancestor) needs a
-/// concrete value.
+/// [`Polarity::Inherit`] on a *node* with [`EdgeRelation::Contains`]
+/// parents means "use the parent's effective polarity" — propagation
+/// per ADJ03 v3.
+///
+/// [`Polarity::Inherit`] on an *edge* has no well-defined meaning and
+/// is rejected by [`validate`] (see
+/// [`ValidationError::InheritOnEdge`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Polarity {
     Affirmed,
     Denied,
     Uncertain,
-    /// Take the parent's effective polarity (v2 propagation).
+    /// Defer to the propagation ancestor's effective polarity. Valid
+    /// only on nodes that have at least one `Contains` parent.
     Inherit,
 }
 
 /// The temporal / hypothetical / ownership context of the term. Flat
 /// lattice. Combining modalities requires multiple nodes, not a join.
 ///
-/// `RuledOut` and `Denied` (a polarity value) are *not* synonyms. See
-/// `ADJ01 §"Modality"` and `ADJ03 §"RuledOut vs. Denied"`.
+/// `RuledOut` and `Denied` (a polarity value) are **not** synonyms.
+/// See [`ADJ01 §"Modality"`](../../../specs/ADJ01-adjudication-ir-grammar.md).
 ///
-/// **v2**: `Inherit` mirrors `Polarity::Inherit` — defer to the
-/// structural ancestor's modality.
+/// [`Modality::Inherit`] follows the same propagation rule as
+/// [`Polarity::Inherit`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Modality {
     Present,
@@ -140,41 +183,52 @@ pub enum Modality {
     FamilyHistory,
     RuledOut,
     Conditional,
-    /// Take the parent's effective modality (v2 propagation).
+    /// Defer to the propagation ancestor's effective modality.
     Inherit,
 }
 
-// ---------------------------------------------------------------------------
-// Node kinds and discard reasons
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Node kinds, discard reasons
+// ===========================================================================
 
 /// The role a node plays in the IR.
 ///
-/// **v2**: adds `TextRun` — a non-leaf node that exists only to
-/// carry the structural decomposition of the document (per `ADJ01`
-/// v2). `TextRun` nodes group children but do not themselves
-/// represent a domain claim; their `term` is conventionally the
-/// zero-arity compound `text_run/0` and is not consumed by
-/// validators.
+/// **v3** drops `TextRun` (replaced by [`Section`](NodeKind::Section)
+/// which carries meaningful structural metadata) and adds
+/// [`Entity`](NodeKind::Entity) for deduplicated reference targets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NodeKind {
-    /// Non-leaf decomposition node (v2).
-    TextRun,
+    /// A claim about the world.
     Fact,
+    /// A question the adjudication is asked.
     Query,
+    /// The source explicitly raised a question without answering it.
     Uncertainty,
+    /// Produced by the rule-compilation pipeline (`ADJ09`) or
+    /// rulebook elicitation (`ADJ14`).
     Rule,
+    /// A carve-out attached to one or more Rules via `Excepts` edges.
     Exception,
+    /// An explicit span the extractor judged irrelevant.
     Discarded,
+    /// A structural unit: paragraph, sentence, subsection, list item,
+    /// table, row, column, cell, heading. The node's term names the
+    /// kind (e.g., `paragraph(_)`, `row(3)`); its source_spans cover
+    /// the *meta-text* (heading, numbering, delimiters), not the
+    /// content. Content is reached via `Contains` edges.
+    Section,
+    /// A deduplicated reference target for an atom or compound term
+    /// mentioned at multiple sites. Mentioning nodes connect via
+    /// `Mentions` edges. May have empty source_spans if synthesized.
+    Entity,
 }
 
-/// Controlled vocabulary for `Discarded` nodes' `discard_reason` field.
-/// Coverage analysis (`ADJ02`) audits these to ensure dropped spans are
-/// dropped *for a reason*, not silently.
+/// Controlled vocabulary for [`NodeKind::Discarded`] nodes'
+/// `discard_reason` field.
 ///
-/// `Unparseable` is always a coverage failure (see `ADJ02`): an extractor
-/// that produces a `Discarded(Unparseable)` triggers clarification rather
-/// than shipping the node.
+/// `Unparseable` is always a coverage failure: an extractor that
+/// produces a `Discarded(Unparseable)` triggers ADJ06 clarification
+/// rather than shipping the node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DiscardReason {
     Pleasantry,
@@ -186,29 +240,148 @@ pub enum DiscardReason {
     ExplicitlyOutOfScope,
 }
 
-// ---------------------------------------------------------------------------
-// IRNode and IRDocument
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Edge relation taxonomy (closed set + escape hatch)
+// ===========================================================================
+
+/// Closed-set typed relation between two nodes. Adding a new variant
+/// is an ADJ01 version bump (v3 → v4). The
+/// [`EdgeRelation::DomainSpecific`] escape hatch accommodates
+/// deployments that need a relation the framework doesn't yet ship.
+///
+/// Grouped per ADJ01 v3 §"The Edge-Relation Taxonomy". The grouping
+/// is documentation, not enforcement: the validator only checks the
+/// per-relation source/target kind invariants
+/// (see [`relation_endpoint_constraints`] below for the table).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EdgeRelation {
+    // --- 1. Structural ---
+    Contains,
+    Precedes,
+    Heading,
+
+    // --- 2. Identity ---
+    Mentions,
+    SameAs,
+    Refers,
+
+    // --- 3. Rule modification ---
+    Excepts,
+    Refines,
+    Generalizes,
+    Supersedes,
+    Restricts,
+
+    // --- 4. Application ---
+    AppliesTo,
+    AppliesWhen,
+    Concludes,
+
+    // --- 5. Provenance ---
+    DerivedFrom,
+    JustifiedBy,
+    ElicitedFrom,
+
+    // --- 6. Tabular ---
+    RowOf,
+    ColumnOf,
+    HeaderOf,
+    CellOf,
+
+    // --- 7. Temporal ---
+    Before,
+    After,
+    During,
+    EffectiveAt,
+    SupersededAt,
+
+    // --- 8. Cross-source ---
+    ConflictsWith,
+    Confirms,
+    DependsOn,
+
+    // --- 9. Discourse ---
+    Defines,
+    Restates,
+    Cites,
+
+    // --- 10. Refinement (clarification lineage) ---
+    Clarifies,
+
+    // --- 11. Escape hatch ---
+    /// Deployment-specific relation. The name MUST be non-empty and
+    /// MUST NOT collide with the names of any closed-set relation
+    /// (case-sensitive comparison). Validators record it but do not
+    /// interpret it.
+    DomainSpecific(String),
+}
+
+impl EdgeRelation {
+    /// Stable kebab-case name for audit-trail records.
+    pub fn as_str(&self) -> &str {
+        match self {
+            EdgeRelation::Contains => "contains",
+            EdgeRelation::Precedes => "precedes",
+            EdgeRelation::Heading => "heading",
+            EdgeRelation::Mentions => "mentions",
+            EdgeRelation::SameAs => "same-as",
+            EdgeRelation::Refers => "refers",
+            EdgeRelation::Excepts => "excepts",
+            EdgeRelation::Refines => "refines",
+            EdgeRelation::Generalizes => "generalizes",
+            EdgeRelation::Supersedes => "supersedes",
+            EdgeRelation::Restricts => "restricts",
+            EdgeRelation::AppliesTo => "applies-to",
+            EdgeRelation::AppliesWhen => "applies-when",
+            EdgeRelation::Concludes => "concludes",
+            EdgeRelation::DerivedFrom => "derived-from",
+            EdgeRelation::JustifiedBy => "justified-by",
+            EdgeRelation::ElicitedFrom => "elicited-from",
+            EdgeRelation::RowOf => "row-of",
+            EdgeRelation::ColumnOf => "column-of",
+            EdgeRelation::HeaderOf => "header-of",
+            EdgeRelation::CellOf => "cell-of",
+            EdgeRelation::Before => "before",
+            EdgeRelation::After => "after",
+            EdgeRelation::During => "during",
+            EdgeRelation::EffectiveAt => "effective-at",
+            EdgeRelation::SupersededAt => "superseded-at",
+            EdgeRelation::ConflictsWith => "conflicts-with",
+            EdgeRelation::Confirms => "confirms",
+            EdgeRelation::DependsOn => "depends-on",
+            EdgeRelation::Defines => "defines",
+            EdgeRelation::Restates => "restates",
+            EdgeRelation::Cites => "cites",
+            EdgeRelation::Clarifies => "clarifies",
+            EdgeRelation::DomainSpecific(name) => name.as_str(),
+        }
+    }
+
+    /// `true` iff this relation is the closed set (not `DomainSpecific`).
+    pub fn is_closed_set(&self) -> bool {
+        !matches!(self, EdgeRelation::DomainSpecific(_))
+    }
+}
+
+// ===========================================================================
+// IRNode and IREdge
+// ===========================================================================
 
 /// A single node in the IR. Every field corresponds 1:1 to a field
-/// in `ADJ01 §"IR Nodes"` (v2 schema).
+/// in [`ADJ01 §"IR Nodes"`](../../../specs/ADJ01-adjudication-ir-grammar.md).
 ///
 /// Three properties are non-negotiable (enforced by [`validate`]):
 ///
-/// 1. Every IR node is span-grounded (`source_spans` is non-empty for
-///    every kind except `Rule` which cites rulebook spans).
-/// 2. `polarity` and `modality` are always set (may be `Inherit`).
-/// 3. `Discarded` is an explicit node citing both the span being
-///    discarded and the reason (`DiscardReason`); silently omitting a
-///    span is not a valid representation of "irrelevant".
-///
-/// **v2 additions**:
-///
-/// - `part_of: Option<NodeId>` — the structural-tree parent. A node
-///   with `part_of = None` is at a document root.
-/// - `polarity` and `modality` may carry `Inherit` to defer to the
-///   ancestor's effective value (propagation).
-/// - `TextRun` node kind is the non-leaf decomposition node.
+/// 1. Every IR node is span-grounded — `source_spans` is non-empty
+///    except for [`NodeKind::Query`] (synthesized queries are
+///    allowed) and [`NodeKind::Entity`] (synthesized entities are
+///    allowed).
+/// 2. `polarity` and `modality` are always set; may be `Inherit` on a
+///    node that has at least one `Contains` parent.
+/// 3. [`NodeKind::Discarded`] is an explicit node citing both the
+///    span being discarded and the reason ([`DiscardReason`]);
+///    silently omitting a span is not a valid representation of
+///    "irrelevant".
 #[derive(Debug, Clone, PartialEq)]
 pub struct IRNode {
     pub id: NodeId,
@@ -218,56 +391,129 @@ pub struct IRNode {
     pub modality: Modality,
     pub source_spans: Vec<Span>,
     /// Extractor's self-reported confidence. Informational only; not
-    /// used by the type check.
+    /// used by [`validate`].
     pub confidence: f64,
-    /// Structural parent in the decomposition tree (v2). A node with
-    /// `part_of = None` is at a document root.
-    pub part_of: Option<NodeId>,
-    /// If present, points to the parent node in the lowering DAG.
-    pub lowered_from: Option<NodeId>,
-    /// Required iff `kind == Discarded`.
+    /// Required iff `kind == Discarded`; must be `None` otherwise.
     pub discard_reason: Option<DiscardReason>,
     /// Free-form extension for downstream consumers. The framework
     /// reserves any key beginning with `adj.` for future use.
     pub metadata: HashMap<String, String>,
 }
 
-/// An IR document is a container of nodes belonging to one input
-/// document. The `document_id` matches the input's identifier; nodes'
-/// `source_spans` reference offsets into that document's normalized
-/// text.
+/// A single directed edge in the IR.
+///
+/// Edges are **directed**: `source` and `target` are not symmetric.
+/// Multiple edges may exist between the same pair of nodes provided
+/// they have different [`EdgeRelation`] values (hence
+/// *multi-directed*).
+///
+/// Edge `source_spans` cover the **textual marker** that signals the
+/// relation — "except", "see §5", ",", "and" — not the spans of the
+/// related nodes themselves. A synthesized edge (engine-emitted, not
+/// extracted from text) carries empty `source_spans`; it is recorded
+/// in the audit trail but does not tile any source bytes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IREdge {
+    pub id: EdgeId,
+    pub source: NodeId,
+    pub target: NodeId,
+    pub relation: EdgeRelation,
+    /// Edge polarity. `Inherit` is *not* allowed (rejected by
+    /// [`validate`]); use `Affirmed` for the default.
+    pub polarity: Polarity,
+    /// Edge modality. `Inherit` is *not* allowed.
+    pub modality: Modality,
+    pub source_spans: Vec<Span>,
+    pub confidence: f64,
+    pub metadata: HashMap<String, String>,
+}
+
+// ===========================================================================
+// IRDocument
+// ===========================================================================
+
+/// An IR document is a container of nodes *and* edges belonging to
+/// one input document. The `document_id` matches the input's
+/// identifier; nodes' and edges' `source_spans` reference offsets
+/// into that document's normalized text.
+///
+/// Two top-level collections, populated independently. The graph
+/// structure emerges from edges referring to nodes by id; nodes do
+/// not know which edges connect them. (Callers that need an
+/// adjacency view can build one with [`adjacency_in`] /
+/// [`adjacency_out`].)
 #[derive(Debug, Clone, PartialEq)]
 pub struct IRDocument {
     pub document_id: DocumentId,
     pub nodes: Vec<IRNode>,
+    pub edges: Vec<IREdge>,
 }
 
-// ---------------------------------------------------------------------------
-// Validation
-// ---------------------------------------------------------------------------
+impl IRDocument {
+    /// New empty document.
+    pub fn new(document_id: DocumentId) -> Self {
+        Self {
+            document_id,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        }
+    }
+
+    /// Look up a node by id. `None` if no node has this id.
+    pub fn node(&self, id: &NodeId) -> Option<&IRNode> {
+        self.nodes.iter().find(|n| &n.id == id)
+    }
+
+    /// Look up an edge by id.
+    pub fn edge(&self, id: &EdgeId) -> Option<&IREdge> {
+        self.edges.iter().find(|e| &e.id == id)
+    }
+
+    /// Outgoing edges from a node. Returns an empty iterator if the
+    /// node has no outgoing edges (or doesn't exist).
+    pub fn adjacency_out<'a>(&'a self, node_id: &'a NodeId) -> impl Iterator<Item = &'a IREdge> {
+        self.edges.iter().filter(move |e| &e.source == node_id)
+    }
+
+    /// Incoming edges to a node.
+    pub fn adjacency_in<'a>(&'a self, node_id: &'a NodeId) -> impl Iterator<Item = &'a IREdge> {
+        self.edges.iter().filter(move |e| &e.target == node_id)
+    }
+}
+
+// ===========================================================================
+// Validation: ValidationError
+// ===========================================================================
 
 /// Every reason an IR document can fail well-formedness.
 ///
-/// Each variant corresponds to a numbered rule from `ADJ01 §"Well-
-/// Formedness Summary"`. Returning a specific variant rather than a
-/// generic error lets callers surface precise feedback to the extractor.
+/// Each variant corresponds to a numbered rule from
+/// [`ADJ01 §"Well-Formedness Summary"`](../../../specs/ADJ01-adjudication-ir-grammar.md).
+/// Returning a specific variant rather than a generic error lets
+/// callers (especially ADJ06 clarification) surface precise feedback
+/// to the extractor.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
+    // ----- Node-shape violations -----
+
     /// A node's `source_spans` was empty when the kind requires at
     /// least one span.
-    MissingSourceSpans { node_id: NodeId, kind: NodeKind },
+    MissingSourceSpans {
+        node_id: NodeId,
+        kind: NodeKind,
+    },
 
     /// A span had `start >= end` (degenerate range).
     InvalidSpan {
-        node_id: NodeId,
+        location: SpanLocation,
         start: usize,
         end: usize,
     },
 
-    /// A node's source span cites a document other than the IRDocument's
-    /// `document_id`. (Cross-document references are out of scope here.)
+    /// A span cites a document other than the IRDocument's
+    /// `document_id`. Cross-document references are out of scope.
     SpanDocumentMismatch {
-        node_id: NodeId,
+        location: SpanLocation,
         expected: DocumentId,
         found: DocumentId,
     },
@@ -277,268 +523,574 @@ pub enum ValidationError {
     FactWithUncertainPolarity { node_id: NodeId },
 
     /// `kind = Uncertainty`, but `polarity` is not `Uncertain`.
-    UncertaintyWithDefinitePolarity { node_id: NodeId, polarity: Polarity },
+    UncertaintyWithDefinitePolarity {
+        node_id: NodeId,
+        polarity: Polarity,
+    },
 
-    /// `kind = Query`, but `polarity` is not `Affirmed`. Querying `¬p`
-    /// is itself a question; we represent the question as an Affirmed
-    /// query and require the polarity field to be Affirmed.
-    QueryWithNonAffirmedPolarity { node_id: NodeId, polarity: Polarity },
+    /// `kind = Query`, but `polarity` is not `Affirmed` (or
+    /// `Inherit`).
+    QueryWithNonAffirmedPolarity {
+        node_id: NodeId,
+        polarity: Polarity,
+    },
 
-    /// `kind = Discarded`, but `discard_reason` is absent. Every
-    /// Discarded node must declare why.
+    /// `kind = Exception`, but `polarity` is not `Affirmed` (or
+    /// `Inherit`).
+    ExceptionWithNonAffirmedPolarity {
+        node_id: NodeId,
+        polarity: Polarity,
+    },
+
+    /// `kind = Discarded`, but `discard_reason` is absent.
     DiscardedWithoutReason { node_id: NodeId },
 
-    /// `kind != Discarded`, but `discard_reason` is set. Only Discarded
-    /// nodes carry a discard reason.
-    NonDiscardedWithReason { node_id: NodeId, kind: NodeKind },
-
-    /// A node's `lowered_from` points to an id that doesn't exist in
-    /// the document.
-    DanglingLoweredFrom {
+    /// `kind != Discarded`, but `discard_reason` is set. Only
+    /// Discarded nodes carry a discard reason.
+    NonDiscardedWithReason {
         node_id: NodeId,
-        missing_parent: NodeId,
-    },
-
-    /// The lowering DAG has a cycle. Detected by topological-sort
-    /// failure; the cycle's participating ids are reported.
-    LoweringCycle { participants: Vec<NodeId> },
-
-    /// A lowered node's spans are not a subset of its parent's spans —
-    /// lowering should only narrow provenance, not invent it.
-    LoweringExpandsSpans {
-        child_id: NodeId,
-        parent_id: NodeId,
-    },
-
-    /// A lowered node's kind is not compatible with its parent's kind
-    /// under the `kind ≺ kind` relation from ADJ01.
-    IncompatibleLowering {
-        child_id: NodeId,
-        parent_id: NodeId,
-        child_kind: NodeKind,
-        parent_kind: NodeKind,
+        kind: NodeKind,
     },
 
     /// Two nodes share the same `NodeId`.
     DuplicateNodeId { id: NodeId },
 
-    // ----- v2 structural-decomposition violations -----
+    /// Two edges share the same `EdgeId`.
+    DuplicateEdgeId { id: EdgeId },
 
-    /// A node's `part_of` points to an id that doesn't exist.
-    DanglingPartOf {
-        node_id: NodeId,
-        missing_parent: NodeId,
+    // ----- Edge well-formedness -----
+
+    /// An edge's `source` references a node that doesn't exist.
+    DanglingEdgeSource {
+        edge_id: EdgeId,
+        missing: NodeId,
     },
 
-    /// `part_of` edges form a cycle.
-    PartOfCycle { participants: Vec<NodeId> },
+    /// An edge's `target` references a node that doesn't exist.
+    DanglingEdgeTarget {
+        edge_id: EdgeId,
+        missing: NodeId,
+    },
 
-    /// A non-TextRun node has children that point to it via `part_of`.
-    /// Only TextRun nodes can be structural parents in v2.
-    NonTextRunHasChildren {
-        parent_id: NodeId,
+    /// An edge connects a node to itself. v3 forbids self-loops; the
+    /// DAG check catches them but this variant gives a sharper
+    /// diagnostic when the cycle is length-1.
+    SelfLoopEdge { edge_id: EdgeId, node: NodeId },
+
+    /// An edge carries `Polarity::Inherit` or `Modality::Inherit` —
+    /// neither is valid on edges (only on nodes that have at least
+    /// one `Contains` parent).
+    InheritOnEdge {
+        edge_id: EdgeId,
+        offending: InheritField,
+    },
+
+    /// An [`EdgeRelation::DomainSpecific`] variant has an empty name
+    /// or a name that collides with a closed-set relation.
+    InvalidDomainSpecificName {
+        edge_id: EdgeId,
+        name: String,
+    },
+
+    /// The relation's source-kind constraint is violated. See
+    /// [`relation_endpoint_constraints`] for the full table.
+    InvalidRelationSourceKind {
+        edge_id: EdgeId,
+        relation: EdgeRelation,
+        source_kind: NodeKind,
+    },
+
+    /// The relation's target-kind constraint is violated.
+    InvalidRelationTargetKind {
+        edge_id: EdgeId,
+        relation: EdgeRelation,
+        target_kind: NodeKind,
+    },
+
+    // ----- Graph-level violations -----
+
+    /// The graph (nodes + edges) contains a cycle.
+    GraphCycle { participants: Vec<NodeId> },
+
+    /// A `Clarifies` edge connects nodes whose kinds are not
+    /// compatible under the refinement-kind compatibility table.
+    IncompatibleClarification {
+        edge_id: EdgeId,
+        child_kind: NodeKind,
         parent_kind: NodeKind,
-        children: Vec<NodeId>,
     },
 
-    /// A child node's source spans are not contained within its
-    /// structural parent's source spans.
-    ChildSpansExceedParent {
-        child_id: NodeId,
-        parent_id: NodeId,
+    /// An `Exception` node has no outgoing `Excepts` edge.
+    UnattachedException { node_id: NodeId },
+
+    // ----- Coverage -----
+
+    /// Some byte of the document is not in any node's or edge's
+    /// `source_spans`. Lists the uncovered ranges.
+    CoverageGap { missing_ranges: Vec<(usize, usize)> },
+
+    /// Some byte appears in more than one source_span (across nodes
+    /// and edges, after exempting synthesized objects). Lists the
+    /// overlapping byte ranges and the participants.
+    CoverageOverlap {
+        ranges: Vec<(usize, usize)>,
+        participants: Vec<NodeOrEdgeId>,
     },
 
-    /// A TextRun's children's source spans, taken together, do not
-    /// tile its own source spans. `missing_ranges` lists the
-    /// uncovered byte ranges.
-    ChildrenDoNotTileParent {
-        parent_id: NodeId,
-        missing_ranges: Vec<(usize, usize)>,
+    // ----- Propagation -----
+
+    /// A node has `polarity = Inherit` but no `Contains` parent to
+    /// inherit from.
+    InheritWithoutParent {
+        node_id: NodeId,
+        field: InheritField,
+    },
+
+    /// A node with `polarity = Inherit` has multiple `Contains`
+    /// parents whose effective polarities disagree.
+    PropagationConflict {
+        node_id: NodeId,
+        field: InheritField,
+        candidates: Vec<(NodeId, &'static str)>,
     },
 }
 
-/// Validate an IR document. Returns `Ok(())` iff every rule in
-/// `ADJ01 §"Well-Formedness Summary"` is satisfied; otherwise returns
-/// the first violation found.
-///
-/// Validation is **total** — no partial well-formedness. A caller that
-/// receives `Err(_)` must not pass the document to any downstream
-/// component.
-pub fn validate(doc: &IRDocument) -> Result<(), ValidationError> {
-    // 0. Duplicate node ids fail immediately. Detection of subsequent
-    //    rules can assume ids are unique.
-    let mut seen_ids: HashSet<&NodeId> = HashSet::new();
-    for n in &doc.nodes {
-        if !seen_ids.insert(&n.id) {
-            return Err(ValidationError::DuplicateNodeId { id: n.id.clone() });
-        }
-    }
+/// Where a span lives — on a node or an edge. Used by
+/// [`ValidationError`] to point at the offending entity in
+/// span-related variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpanLocation {
+    Node(NodeId),
+    Edge(EdgeId),
+}
 
-    // 1. Per-node structural rules.
+/// Which of polarity / modality triggered an `Inherit`-related
+/// violation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InheritField {
+    Polarity,
+    Modality,
+}
+
+/// Identifier discriminator for `CoverageOverlap` participants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeOrEdgeId {
+    Node(NodeId),
+    Edge(EdgeId),
+}
+
+// ===========================================================================
+// Validation: top-level entry point
+// ===========================================================================
+
+/// Validate an IR document.
+///
+/// Returns `Ok(())` iff every rule in
+/// [`ADJ01 §"Well-Formedness Summary"`](../../../specs/ADJ01-adjudication-ir-grammar.md)
+/// is satisfied; otherwise returns the first violation found.
+///
+/// Validation is **total** — no partial well-formedness. A caller
+/// that receives `Err(_)` must not pass the document to any
+/// downstream component.
+///
+/// Order of checks (each early-returns on failure):
+///
+/// 1. Duplicate node ids.
+/// 2. Duplicate edge ids.
+/// 3. Per-node structural rules.
+/// 4. Per-edge structural rules (incl. endpoint existence,
+///    `Inherit` rejection, DomainSpecific name validation,
+///    relation-kind constraints).
+/// 5. `Clarifies`-edge kind compatibility.
+/// 6. Exception attachment (every Exception has an outgoing
+///    `Excepts` edge).
+/// 7. Graph acyclicity (DFS, all edges treated uniformly).
+/// 8. Coverage tiling (flat, across nodes and edges).
+/// 9. Propagation consistency (multi-parent agreement on
+///    `Contains`-inherited polarity / modality).
+pub fn validate(doc: &IRDocument) -> Result<(), ValidationError> {
+    check_duplicate_node_ids(doc)?;
+    check_duplicate_edge_ids(doc)?;
+
     for n in &doc.nodes {
         validate_per_node(n, doc)?;
     }
+    for e in &doc.edges {
+        validate_per_edge(e, doc)?;
+    }
 
-    // 2. Lowering DAG rules: no cycles, parent exists, kind compatible,
-    //    span subset.
-    validate_lowering_dag(doc)?;
+    check_clarifies_compatibility(doc)?;
+    check_exception_attachment(doc)?;
 
-    // 3. Structural decomposition tree (v2): part_of edges form a
-    //    forest; only TextRun nodes have children; children's spans
-    //    fit inside parent's; TextRun children's spans tile the
-    //    parent's spans.
-    validate_structural_tree(doc)?;
+    check_acyclicity(doc)?;
+
+    check_coverage(doc)?;
+
+    check_propagation(doc)?;
 
     Ok(())
 }
 
+// ===========================================================================
+// Validation: id uniqueness
+// ===========================================================================
+
+fn check_duplicate_node_ids(doc: &IRDocument) -> Result<(), ValidationError> {
+    let mut seen: HashSet<&NodeId> = HashSet::new();
+    for n in &doc.nodes {
+        if !seen.insert(&n.id) {
+            return Err(ValidationError::DuplicateNodeId { id: n.id.clone() });
+        }
+    }
+    Ok(())
+}
+
+fn check_duplicate_edge_ids(doc: &IRDocument) -> Result<(), ValidationError> {
+    let mut seen: HashSet<&EdgeId> = HashSet::new();
+    for e in &doc.edges {
+        if !seen.insert(&e.id) {
+            return Err(ValidationError::DuplicateEdgeId { id: e.id.clone() });
+        }
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// Validation: per-node rules
+// ===========================================================================
+
 fn validate_per_node(n: &IRNode, doc: &IRDocument) -> Result<(), ValidationError> {
-    // Span basics.
-    if n.kind != NodeKind::Rule {
-        // Rules cite rulebook spans; other kinds cite the input document.
-        if n.source_spans.is_empty() {
-            return Err(ValidationError::MissingSourceSpans {
-                node_id: n.id.clone(),
-                kind: n.kind,
+    // Span basics. Query and Entity may have empty source_spans
+    // (synthesized objects); everything else must cite at least one
+    // span and every span must be valid + cite this document.
+    let synthesizable = matches!(n.kind, NodeKind::Query | NodeKind::Entity);
+    if !synthesizable && n.source_spans.is_empty() {
+        return Err(ValidationError::MissingSourceSpans {
+            node_id: n.id.clone(),
+            kind: n.kind,
+        });
+    }
+    for span in &n.source_spans {
+        if !span.is_valid() {
+            return Err(ValidationError::InvalidSpan {
+                location: SpanLocation::Node(n.id.clone()),
+                start: span.start,
+                end: span.end,
             });
         }
-        for span in &n.source_spans {
-            if !span.is_valid() {
-                return Err(ValidationError::InvalidSpan {
-                    node_id: n.id.clone(),
-                    start: span.start,
-                    end: span.end,
-                });
-            }
-            if span.document_id != doc.document_id {
-                return Err(ValidationError::SpanDocumentMismatch {
-                    node_id: n.id.clone(),
-                    expected: doc.document_id.clone(),
-                    found: span.document_id.clone(),
-                });
-            }
+        if span.document_id != doc.document_id {
+            return Err(ValidationError::SpanDocumentMismatch {
+                location: SpanLocation::Node(n.id.clone()),
+                expected: doc.document_id.clone(),
+                found: span.document_id.clone(),
+            });
         }
     }
 
-    // Kind-specific rules. v2 allows Polarity::Inherit on any kind
-    // that takes a declared polarity (the actual value is resolved
-    // via ancestor lookup in propagation_check). The pre-Inherit
-    // value-specific rules only fire on a *declared* (non-Inherit)
-    // value.
-    match n.kind {
-        NodeKind::TextRun => {
-            // TextRun nodes have no domain claim; their term is a
-            // placeholder. They may carry polarity/modality (for
-            // propagation) but no other constraints.
-            if n.discard_reason.is_some() {
-                return Err(ValidationError::NonDiscardedWithReason {
-                    node_id: n.id.clone(),
-                    kind: n.kind,
-                });
-            }
+    // discard_reason iff Discarded.
+    match (n.kind, n.discard_reason.is_some()) {
+        (NodeKind::Discarded, false) => {
+            return Err(ValidationError::DiscardedWithoutReason {
+                node_id: n.id.clone(),
+            });
         }
-        NodeKind::Fact => {
+        (k, true) if k != NodeKind::Discarded => {
+            return Err(ValidationError::NonDiscardedWithReason {
+                node_id: n.id.clone(),
+                kind: k,
+            });
+        }
+        _ => {}
+    }
+
+    // Kind-specific polarity rules. `Inherit` is admitted as a
+    // "delegate to parent" sentinel; propagation will check it has a
+    // parent and the agreement holds.
+    match n.kind {
+        NodeKind::Fact | NodeKind::Rule => {
             if n.polarity == Polarity::Uncertain {
                 return Err(ValidationError::FactWithUncertainPolarity {
                     node_id: n.id.clone(),
                 });
             }
-            if n.discard_reason.is_some() {
-                return Err(ValidationError::NonDiscardedWithReason {
-                    node_id: n.id.clone(),
-                    kind: n.kind,
-                });
-            }
         }
         NodeKind::Query => {
-            if n.polarity != Polarity::Affirmed && n.polarity != Polarity::Inherit {
+            if !matches!(n.polarity, Polarity::Affirmed | Polarity::Inherit) {
                 return Err(ValidationError::QueryWithNonAffirmedPolarity {
                     node_id: n.id.clone(),
                     polarity: n.polarity,
                 });
             }
-            if n.discard_reason.is_some() {
-                return Err(ValidationError::NonDiscardedWithReason {
+        }
+        NodeKind::Exception => {
+            if !matches!(n.polarity, Polarity::Affirmed | Polarity::Inherit) {
+                return Err(ValidationError::ExceptionWithNonAffirmedPolarity {
                     node_id: n.id.clone(),
-                    kind: n.kind,
+                    polarity: n.polarity,
                 });
             }
         }
         NodeKind::Uncertainty => {
-            if n.polarity != Polarity::Uncertain && n.polarity != Polarity::Inherit {
+            if !matches!(n.polarity, Polarity::Uncertain | Polarity::Inherit) {
                 return Err(ValidationError::UncertaintyWithDefinitePolarity {
                     node_id: n.id.clone(),
                     polarity: n.polarity,
                 });
             }
-            if n.discard_reason.is_some() {
-                return Err(ValidationError::NonDiscardedWithReason {
-                    node_id: n.id.clone(),
-                    kind: n.kind,
-                });
-            }
         }
-        NodeKind::Rule => {
-            if n.polarity == Polarity::Uncertain {
-                return Err(ValidationError::FactWithUncertainPolarity {
-                    node_id: n.id.clone(),
-                });
-            }
-            if n.discard_reason.is_some() {
-                return Err(ValidationError::NonDiscardedWithReason {
-                    node_id: n.id.clone(),
-                    kind: n.kind,
-                });
-            }
-        }
-        NodeKind::Exception => {
-            if n.polarity != Polarity::Affirmed && n.polarity != Polarity::Inherit {
-                return Err(ValidationError::QueryWithNonAffirmedPolarity {
-                    node_id: n.id.clone(),
-                    polarity: n.polarity,
-                });
-            }
-            if n.discard_reason.is_some() {
-                return Err(ValidationError::NonDiscardedWithReason {
-                    node_id: n.id.clone(),
-                    kind: n.kind,
-                });
-            }
-        }
-        NodeKind::Discarded => {
-            if n.discard_reason.is_none() {
-                return Err(ValidationError::DiscardedWithoutReason {
-                    node_id: n.id.clone(),
-                });
-            }
+        NodeKind::Section | NodeKind::Entity | NodeKind::Discarded => {
+            // No polarity constraint beyond "set to something legal";
+            // the lattice itself is the legal set.
         }
     }
 
     Ok(())
 }
 
-fn validate_lowering_dag(doc: &IRDocument) -> Result<(), ValidationError> {
+// ===========================================================================
+// Validation: per-edge rules
+// ===========================================================================
+
+fn validate_per_edge(e: &IREdge, doc: &IRDocument) -> Result<(), ValidationError> {
+    // Endpoint existence.
     let by_id: HashMap<&NodeId, &IRNode> = doc.nodes.iter().map(|n| (&n.id, n)).collect();
+    let Some(source) = by_id.get(&e.source) else {
+        return Err(ValidationError::DanglingEdgeSource {
+            edge_id: e.id.clone(),
+            missing: e.source.clone(),
+        });
+    };
+    let Some(target) = by_id.get(&e.target) else {
+        return Err(ValidationError::DanglingEdgeTarget {
+            edge_id: e.id.clone(),
+            missing: e.target.clone(),
+        });
+    };
 
-    // Parent existence + per-edge constraints.
-    for child in &doc.nodes {
-        let Some(parent_id) = &child.lowered_from else {
-            continue;
-        };
-        let Some(parent) = by_id.get(parent_id) else {
-            return Err(ValidationError::DanglingLoweredFrom {
-                node_id: child.id.clone(),
-                missing_parent: parent_id.clone(),
+    // Self-loops are always wrong (v3 forbids cycles uniformly; a
+    // self-loop is a length-1 cycle).
+    if e.source == e.target {
+        return Err(ValidationError::SelfLoopEdge {
+            edge_id: e.id.clone(),
+            node: e.source.clone(),
+        });
+    }
+
+    // `Inherit` rejection on edges.
+    if e.polarity == Polarity::Inherit {
+        return Err(ValidationError::InheritOnEdge {
+            edge_id: e.id.clone(),
+            offending: InheritField::Polarity,
+        });
+    }
+    if e.modality == Modality::Inherit {
+        return Err(ValidationError::InheritOnEdge {
+            edge_id: e.id.clone(),
+            offending: InheritField::Modality,
+        });
+    }
+
+    // DomainSpecific name validation.
+    if let EdgeRelation::DomainSpecific(name) = &e.relation {
+        if name.is_empty() || closed_set_names().any(|known| known == name) {
+            return Err(ValidationError::InvalidDomainSpecificName {
+                edge_id: e.id.clone(),
+                name: name.clone(),
             });
-        };
+        }
+    }
 
-        // Kind compatibility per ADJ01 §"Lowering Rules":
-        //   Fact            ≺ Fact
-        //   Uncertainty     ≺ Fact          (clarification resolution)
-        //   Uncertainty     ≺ Uncertainty
-        //   Query           ≺ Query
-        //   Rule            ≺ Rule
-        //   Discarded cannot be lowered or lowered-to.
+    // Span validity (edges have spans too; empty is allowed for
+    // synthesized edges).
+    for span in &e.source_spans {
+        if !span.is_valid() {
+            return Err(ValidationError::InvalidSpan {
+                location: SpanLocation::Edge(e.id.clone()),
+                start: span.start,
+                end: span.end,
+            });
+        }
+        if span.document_id != doc.document_id {
+            return Err(ValidationError::SpanDocumentMismatch {
+                location: SpanLocation::Edge(e.id.clone()),
+                expected: doc.document_id.clone(),
+                found: span.document_id.clone(),
+            });
+        }
+    }
+
+    // Relation endpoint-kind constraints.
+    let (allow_source, allow_target) = relation_endpoint_constraints(&e.relation);
+    if !allow_source(source.kind) {
+        return Err(ValidationError::InvalidRelationSourceKind {
+            edge_id: e.id.clone(),
+            relation: e.relation.clone(),
+            source_kind: source.kind,
+        });
+    }
+    if !allow_target(target.kind) {
+        return Err(ValidationError::InvalidRelationTargetKind {
+            edge_id: e.id.clone(),
+            relation: e.relation.clone(),
+            target_kind: target.kind,
+        });
+    }
+
+    Ok(())
+}
+
+/// Names of all closed-set relations as kebab-case strings. Used to
+/// validate that a `DomainSpecific(name)` doesn't collide with a
+/// known relation.
+fn closed_set_names() -> impl Iterator<Item = &'static str> {
+    const NAMES: &[&str] = &[
+        "contains",
+        "precedes",
+        "heading",
+        "mentions",
+        "same-as",
+        "refers",
+        "excepts",
+        "refines",
+        "generalizes",
+        "supersedes",
+        "restricts",
+        "applies-to",
+        "applies-when",
+        "concludes",
+        "derived-from",
+        "justified-by",
+        "elicited-from",
+        "row-of",
+        "column-of",
+        "header-of",
+        "cell-of",
+        "before",
+        "after",
+        "during",
+        "effective-at",
+        "superseded-at",
+        "conflicts-with",
+        "confirms",
+        "depends-on",
+        "defines",
+        "restates",
+        "cites",
+        "clarifies",
+    ];
+    NAMES.iter().copied()
+}
+
+/// Per-relation source/target kind constraints, per
+/// [`ADJ01 §"Relation-Specific Invariants"`](../../../specs/ADJ01-adjudication-ir-grammar.md).
+/// Returns a pair of predicates `(source_ok, target_ok)`.
+fn relation_endpoint_constraints(
+    rel: &EdgeRelation,
+) -> (fn(NodeKind) -> bool, fn(NodeKind) -> bool) {
+    fn any(_: NodeKind) -> bool {
+        true
+    }
+    fn section_only(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Section)
+    }
+    fn rule_only(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Rule)
+    }
+    fn exception_only(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Exception)
+    }
+    fn entity_only(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Entity)
+    }
+    fn rule_or_entity(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Rule | NodeKind::Entity)
+    }
+    fn entity_or_fact(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Entity | NodeKind::Fact)
+    }
+    fn fact_or_entity(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Fact | NodeKind::Entity)
+    }
+    fn fact_only(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Fact)
+    }
+    fn rule_or_fact(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Rule | NodeKind::Fact)
+    }
+    fn fact_or_query(k: NodeKind) -> bool {
+        matches!(k, NodeKind::Fact | NodeKind::Query)
+    }
+    fn non_entity(k: NodeKind) -> bool {
+        !matches!(k, NodeKind::Entity)
+    }
+
+    match rel {
+        EdgeRelation::Contains => (section_only, any),
+        EdgeRelation::Precedes => (section_only, section_only),
+        EdgeRelation::Heading => (section_only, section_only),
+
+        EdgeRelation::Mentions => (non_entity, entity_only),
+        EdgeRelation::SameAs => (entity_only, entity_only),
+        EdgeRelation::Refers => (any, any),
+
+        EdgeRelation::Excepts => (exception_only, rule_only),
+        EdgeRelation::Refines => (rule_only, rule_only),
+        EdgeRelation::Generalizes => (rule_only, rule_only),
+        EdgeRelation::Supersedes => (rule_only, rule_only),
+        EdgeRelation::Restricts => (rule_only, rule_only),
+
+        EdgeRelation::AppliesTo => (rule_only, entity_or_fact),
+        EdgeRelation::AppliesWhen => (rule_only, any),
+        EdgeRelation::Concludes => (rule_only, fact_or_entity),
+
+        EdgeRelation::DerivedFrom => (fact_only, fact_only),
+        EdgeRelation::JustifiedBy => (fact_or_query, rule_or_fact),
+        EdgeRelation::ElicitedFrom => (rule_only, entity_only),
+
+        EdgeRelation::RowOf => (any, section_only),
+        EdgeRelation::ColumnOf => (any, section_only),
+        EdgeRelation::HeaderOf => (section_only, section_only),
+        EdgeRelation::CellOf => (any, section_only),
+
+        EdgeRelation::Before => (any, any),
+        EdgeRelation::After => (any, any),
+        EdgeRelation::During => (any, any),
+        EdgeRelation::EffectiveAt => (rule_only, entity_only),
+        EdgeRelation::SupersededAt => (rule_only, entity_only),
+
+        EdgeRelation::ConflictsWith => (rule_only, rule_only),
+        EdgeRelation::Confirms => (rule_only, rule_only),
+        EdgeRelation::DependsOn => (rule_or_entity, rule_or_entity),
+
+        EdgeRelation::Defines => (any, entity_only),
+        EdgeRelation::Restates => (any, any),
+        EdgeRelation::Cites => (any, entity_only),
+
+        EdgeRelation::Clarifies => (any, any),
+
+        EdgeRelation::DomainSpecific(_) => (any, any),
+    }
+}
+
+// ===========================================================================
+// Validation: Clarifies kind compatibility
+// ===========================================================================
+
+fn check_clarifies_compatibility(doc: &IRDocument) -> Result<(), ValidationError> {
+    let by_id: HashMap<&NodeId, &IRNode> = doc.nodes.iter().map(|n| (&n.id, n)).collect();
+    for e in &doc.edges {
+        if e.relation != EdgeRelation::Clarifies {
+            continue;
+        }
+        let child = by_id[&e.source];
+        let parent = by_id[&e.target];
+        // Per ADJ01 v3, child ←Clarifies← parent allowed pairs:
+        //   (parent=Fact,        child=Fact)
+        //   (parent=Uncertainty, child=Fact)
+        //   (parent=Uncertainty, child=Uncertainty)
+        //   (parent=Query,       child=Query)
+        //   (parent=Rule,        child=Rule)
+        // Note: source = child (clarified), target = parent (original).
         let compat = matches!(
             (parent.kind, child.kind),
             (NodeKind::Fact, NodeKind::Fact)
@@ -548,234 +1100,390 @@ fn validate_lowering_dag(doc: &IRDocument) -> Result<(), ValidationError> {
                 | (NodeKind::Rule, NodeKind::Rule)
         );
         if !compat {
-            return Err(ValidationError::IncompatibleLowering {
-                child_id: child.id.clone(),
-                parent_id: parent.id.clone(),
+            return Err(ValidationError::IncompatibleClarification {
+                edge_id: e.id.clone(),
                 child_kind: child.kind,
                 parent_kind: parent.kind,
             });
         }
-
-        // Span subset: every child span must be contained in some
-        // parent span.
-        for child_span in &child.source_spans {
-            let contained = parent
-                .source_spans
-                .iter()
-                .any(|ps| ps.contains(child_span));
-            if !contained {
-                return Err(ValidationError::LoweringExpandsSpans {
-                    child_id: child.id.clone(),
-                    parent_id: parent.id.clone(),
-                });
-            }
-        }
     }
+    Ok(())
+}
 
-    // Cycle detection (Kahn's algorithm).
-    let mut indegree: HashMap<&NodeId, usize> = doc.nodes.iter().map(|n| (&n.id, 0)).collect();
+// ===========================================================================
+// Validation: Exception attachment
+// ===========================================================================
+
+fn check_exception_attachment(doc: &IRDocument) -> Result<(), ValidationError> {
     for n in &doc.nodes {
-        if let Some(p) = &n.lowered_from {
-            *indegree.entry(p).or_insert(0) += 1;
+        if n.kind != NodeKind::Exception {
+            continue;
+        }
+        let has_excepts = doc
+            .edges
+            .iter()
+            .any(|e| e.source == n.id && e.relation == EdgeRelation::Excepts);
+        if !has_excepts {
+            return Err(ValidationError::UnattachedException {
+                node_id: n.id.clone(),
+            });
         }
     }
-    let mut queue: Vec<&NodeId> = indegree
+    Ok(())
+}
+
+// ===========================================================================
+// Validation: graph acyclicity
+// ===========================================================================
+
+fn check_acyclicity(doc: &IRDocument) -> Result<(), ValidationError> {
+    // Adjacency: source -> [target ...]. Uses NodeId for keys.
+    let mut adj: HashMap<&NodeId, Vec<&NodeId>> = HashMap::new();
+    for n in &doc.nodes {
+        adj.insert(&n.id, Vec::new());
+    }
+    for e in &doc.edges {
+        if let Some(targets) = adj.get_mut(&e.source) {
+            targets.push(&e.target);
+        }
+    }
+
+    // Iterative DFS with three colors. Captures the participating
+    // cycle when one is found.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+    let mut color: HashMap<&NodeId, Color> = doc
+        .nodes
         .iter()
-        .filter(|(_, &d)| d == 0)
-        .map(|(k, _)| *k)
+        .map(|n| (&n.id, Color::White))
         .collect();
-    let mut visited = 0usize;
-    while let Some(id) = queue.pop() {
-        visited += 1;
-        if let Some(node) = by_id.get(id) {
-            if let Some(p) = &node.lowered_from {
-                let d = indegree.entry(p).or_insert(0);
-                *d = d.saturating_sub(1);
-                if *d == 0 {
-                    queue.push(p);
+    let mut path: Vec<&NodeId> = Vec::new();
+    let mut on_path: HashSet<&NodeId> = HashSet::new();
+
+    for start in doc.nodes.iter().map(|n| &n.id) {
+        if color[start] != Color::White {
+            continue;
+        }
+        // Iterative DFS to avoid blowing the stack on long chains.
+        // Frame = (node, index into its adj list).
+        let mut stack: Vec<(&NodeId, usize)> = vec![(start, 0)];
+        path.push(start);
+        on_path.insert(start);
+        color.insert(start, Color::Gray);
+
+        while let Some(&(node, idx)) = stack.last() {
+            let neighbors = adj.get(node).map(|v| v.as_slice()).unwrap_or(&[]);
+            if idx < neighbors.len() {
+                let next = neighbors[idx];
+                // Advance the index on this frame.
+                stack.last_mut().unwrap().1 += 1;
+                match color[next] {
+                    Color::White => {
+                        color.insert(next, Color::Gray);
+                        path.push(next);
+                        on_path.insert(next);
+                        stack.push((next, 0));
+                    }
+                    Color::Gray => {
+                        // Cycle. Reconstruct it: from `next` to end of
+                        // `path` is the cycle.
+                        let start_idx = path.iter().position(|p| *p == next).unwrap();
+                        let participants: Vec<NodeId> =
+                            path[start_idx..].iter().map(|&n| n.clone()).collect();
+                        return Err(ValidationError::GraphCycle { participants });
+                    }
+                    Color::Black => {
+                        // Already finalized; skip.
+                    }
                 }
+            } else {
+                // Done with this node.
+                color.insert(node, Color::Black);
+                let popped = path.pop().unwrap();
+                on_path.remove(popped);
+                stack.pop();
             }
         }
-    }
-    if visited != doc.nodes.len() {
-        // At least one cycle exists; collect the remaining indegree>0 ids.
-        let participants: Vec<NodeId> = indegree
-            .into_iter()
-            .filter(|(_, d)| *d > 0)
-            .map(|(k, _)| k.clone())
-            .collect();
-        return Err(ValidationError::LoweringCycle { participants });
     }
 
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Structural decomposition tree (v2)
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// Validation: coverage (flat tiling)
+// ===========================================================================
 
-fn validate_structural_tree(doc: &IRDocument) -> Result<(), ValidationError> {
+fn check_coverage(doc: &IRDocument) -> Result<(), ValidationError> {
+    // Gather every span that participates in tiling. Synthesized
+    // objects (Query nodes, Entity nodes, edges with empty spans) are
+    // exempt.
+    let mut spans: Vec<((usize, usize), NodeOrEdgeId)> = Vec::new();
+    for n in &doc.nodes {
+        let synthesizable = matches!(n.kind, NodeKind::Query | NodeKind::Entity);
+        if synthesizable && n.source_spans.is_empty() {
+            continue;
+        }
+        for s in &n.source_spans {
+            spans.push(((s.start, s.end), NodeOrEdgeId::Node(n.id.clone())));
+        }
+    }
+    for e in &doc.edges {
+        for s in &e.source_spans {
+            spans.push(((s.start, s.end), NodeOrEdgeId::Edge(e.id.clone())));
+        }
+    }
+
+    // If there's nothing to tile (empty document or all synthesized),
+    // we're done.
+    if spans.is_empty() {
+        return Ok(());
+    }
+
+    // Determine the document's byte span as the smallest interval
+    // covering all participants. (We don't have a stored
+    // `document_length` field; this approximates "0 to max(end)" and
+    // requires min start = 0. A future API may take an explicit
+    // length.)
+    let min_start = spans.iter().map(|((s, _), _)| *s).min().unwrap();
+    let max_end = spans.iter().map(|((_, e), _)| *e).max().unwrap();
+
+    if min_start > 0 {
+        // The document doesn't start at byte 0 — that's a gap of
+        // [0, min_start).
+        return Err(ValidationError::CoverageGap {
+            missing_ranges: vec![(0, min_start)],
+        });
+    }
+
+    // Sort spans by start to detect overlaps and gaps.
+    spans.sort_by_key(|((s, _), _)| *s);
+
+    let mut prev_end: usize = 0;
+    let mut overlap_ranges: Vec<(usize, usize)> = Vec::new();
+    let mut overlap_participants: Vec<NodeOrEdgeId> = Vec::new();
+    let mut last_participant: Option<NodeOrEdgeId> = None;
+    for ((start, end), owner) in &spans {
+        if *start > prev_end {
+            // Gap from prev_end to start (within the document range).
+            return Err(ValidationError::CoverageGap {
+                missing_ranges: vec![(prev_end, *start)],
+            });
+        }
+        if *start < prev_end {
+            // Overlap. Record the overlap range and the two
+            // participants.
+            overlap_ranges.push((*start, prev_end.min(*end)));
+            if let Some(prev) = &last_participant {
+                if !overlap_participants.contains(prev) {
+                    overlap_participants.push(prev.clone());
+                }
+            }
+            if !overlap_participants.contains(owner) {
+                overlap_participants.push(owner.clone());
+            }
+        }
+        prev_end = prev_end.max(*end);
+        last_participant = Some(owner.clone());
+    }
+
+    if !overlap_ranges.is_empty() {
+        return Err(ValidationError::CoverageOverlap {
+            ranges: overlap_ranges,
+            participants: overlap_participants,
+        });
+    }
+
+    if prev_end < max_end {
+        // shouldn't happen given how max_end is computed; defensive.
+        return Err(ValidationError::CoverageGap {
+            missing_ranges: vec![(prev_end, max_end)],
+        });
+    }
+
+    Ok(())
+}
+
+// ===========================================================================
+// Validation: propagation consistency
+// ===========================================================================
+
+fn check_propagation(doc: &IRDocument) -> Result<(), ValidationError> {
     let by_id: HashMap<&NodeId, &IRNode> = doc.nodes.iter().map(|n| (&n.id, n)).collect();
 
-    // 1. Parent existence + parent-must-be-TextRun + parent-child
-    //    span containment.
-    let mut children_of: HashMap<NodeId, Vec<&IRNode>> = HashMap::new();
-    for child in &doc.nodes {
-        let Some(parent_id) = &child.part_of else {
-            continue;
-        };
-        let Some(parent) = by_id.get(parent_id) else {
-            return Err(ValidationError::DanglingPartOf {
-                node_id: child.id.clone(),
-                missing_parent: parent_id.clone(),
-            });
-        };
-        // Spans subset (the per-edge check from ADJ02 v2 / ADJ01 v2).
-        for child_span in &child.source_spans {
-            let contained = parent.source_spans.iter().any(|ps| ps.contains(child_span));
-            if !contained {
-                return Err(ValidationError::ChildSpansExceedParent {
-                    child_id: child.id.clone(),
-                    parent_id: parent.id.clone(),
-                });
-            }
-        }
-        children_of
-            .entry(parent_id.clone())
-            .or_default()
-            .push(child);
-    }
-
-    // 2. Only TextRun nodes may have children.
-    for parent in &doc.nodes {
-        if parent.kind != NodeKind::TextRun {
-            if let Some(kids) = children_of.get(&parent.id) {
-                if !kids.is_empty() {
-                    return Err(ValidationError::NonTextRunHasChildren {
-                        parent_id: parent.id.clone(),
-                        parent_kind: parent.kind,
-                        children: kids.iter().map(|c| c.id.clone()).collect(),
-                    });
-                }
-            }
-        }
-    }
-
-    // 3. Cycle detection in part_of edges (Kahn-style: every node has
-    //    at most one parent, so we can detect a cycle by counting
-    //    nodes reachable from the roots).
-    let roots: Vec<&IRNode> = doc.nodes.iter().filter(|n| n.part_of.is_none()).collect();
-    let mut visited: HashSet<NodeId> = HashSet::new();
-    let mut stack: Vec<&IRNode> = roots.clone();
-    while let Some(node) = stack.pop() {
-        if !visited.insert(node.id.clone()) {
-            // Already visited via a different parent — that's a cycle
-            // (single-parent tree expected).
+    // Build a reverse index: child -> [parents via Contains].
+    let mut contains_parents: HashMap<&NodeId, Vec<&NodeId>> = HashMap::new();
+    for e in &doc.edges {
+        if e.relation != EdgeRelation::Contains {
             continue;
         }
-        if let Some(kids) = children_of.get(&node.id) {
-            for k in kids {
-                stack.push(*k);
-            }
-        }
-    }
-    if visited.len() != doc.nodes.len() {
-        let participants: Vec<NodeId> = doc
-            .nodes
-            .iter()
-            .filter(|n| !visited.contains(&n.id))
-            .map(|n| n.id.clone())
-            .collect();
-        return Err(ValidationError::PartOfCycle { participants });
+        contains_parents.entry(&e.target).or_default().push(&e.source);
     }
 
-    // 4. TextRun tiling: children's spans union to parent's spans.
-    //    Empty TextRun (no children) is flagged as "doesn't tile";
-    //    that's the right diagnostic.
-    for parent in &doc.nodes {
-        if parent.kind != NodeKind::TextRun {
-            continue;
-        }
-        let kids = children_of.get(&parent.id).cloned().unwrap_or_default();
-        let child_spans: Vec<(usize, usize)> = kids
-            .iter()
-            .flat_map(|k| k.source_spans.iter())
-            .filter(|s| s.document_id == doc.document_id)
-            .map(|s| (s.start, s.end))
-            .collect();
-        let parent_spans: Vec<(usize, usize)> = parent
-            .source_spans
-            .iter()
-            .filter(|s| s.document_id == doc.document_id)
-            .map(|s| (s.start, s.end))
-            .collect();
-        let missing = subtract_intervals(parent_spans, child_spans);
-        if !missing.is_empty() {
-            return Err(ValidationError::ChildrenDoNotTileParent {
-                parent_id: parent.id.clone(),
-                missing_ranges: missing,
-            });
-        }
+    for n in &doc.nodes {
+        check_inherit_one_field(n, &by_id, &contains_parents, InheritField::Polarity)?;
+        check_inherit_one_field(n, &by_id, &contains_parents, InheritField::Modality)?;
     }
-
     Ok(())
 }
 
-/// Merge a list of (start, end) byte ranges into sorted, non-
-/// overlapping intervals.
-fn merge_ranges(mut rs: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
-    if rs.is_empty() {
-        return rs;
+fn check_inherit_one_field(
+    n: &IRNode,
+    by_id: &HashMap<&NodeId, &IRNode>,
+    contains_parents: &HashMap<&NodeId, Vec<&NodeId>>,
+    field: InheritField,
+) -> Result<(), ValidationError> {
+    let is_inherit = match field {
+        InheritField::Polarity => n.polarity == Polarity::Inherit,
+        InheritField::Modality => n.modality == Modality::Inherit,
+    };
+    if !is_inherit {
+        return Ok(());
     }
-    rs.sort_by_key(|(s, _)| *s);
-    let mut out = Vec::with_capacity(rs.len());
-    let mut cur = rs[0];
-    for (s, e) in rs.into_iter().skip(1) {
-        if s <= cur.1 {
-            cur.1 = cur.1.max(e);
-        } else {
-            out.push(cur);
-            cur = (s, e);
+
+    // Find Contains parents.
+    let parents = match contains_parents.get(&n.id) {
+        Some(ps) if !ps.is_empty() => ps,
+        _ => {
+            return Err(ValidationError::InheritWithoutParent {
+                node_id: n.id.clone(),
+                field,
+            });
+        }
+    };
+
+    // Effective value lookup with memoization (per-field). Each lookup
+    // walks Contains parents transitively; cycles can't happen here
+    // because acyclicity already passed.
+    let mut memo: HashMap<&NodeId, EffectivePolarityOrModality> = HashMap::new();
+    let mut candidates: Vec<(NodeId, &'static str)> = Vec::new();
+    for p_id in parents {
+        let v = resolve_effective(p_id, by_id, contains_parents, field, &mut memo);
+        match v {
+            EffectivePolarityOrModality::Polarity(p) => {
+                candidates.push(((*p_id).clone(), polarity_name(p)));
+            }
+            EffectivePolarityOrModality::Modality(m) => {
+                candidates.push(((*p_id).clone(), modality_name(m)));
+            }
+            EffectivePolarityOrModality::StillInherit => {
+                // A parent itself has Inherit but no further parent —
+                // earlier check (InheritWithoutParent) would have
+                // caught it. Defensive: surface as conflict candidate.
+                candidates.push(((*p_id).clone(), "Inherit"));
+            }
         }
     }
-    out.push(cur);
-    out
+
+    // Multi-parent agreement check.
+    if candidates.len() >= 2 {
+        let first = candidates[0].1;
+        if candidates.iter().any(|(_, v)| *v != first) {
+            return Err(ValidationError::PropagationConflict {
+                node_id: n.id.clone(),
+                field,
+                candidates,
+            });
+        }
+    }
+    Ok(())
 }
 
-/// Return the byte ranges in `parent` that are not covered by any
-/// range in `children`. Used to compute `missing_ranges` for
-/// `ChildrenDoNotTileParent`.
-fn subtract_intervals(
-    parent: Vec<(usize, usize)>,
-    children: Vec<(usize, usize)>,
-) -> Vec<(usize, usize)> {
-    let parent_merged = merge_ranges(parent);
-    let child_merged = merge_ranges(children);
-    let mut out = Vec::new();
-    for (p_start, p_end) in parent_merged {
-        let mut cursor = p_start;
-        for &(c_start, c_end) in &child_merged {
-            if c_end <= cursor || c_start >= p_end {
-                continue;
-            }
-            if c_start > cursor {
-                out.push((cursor, c_start.min(p_end)));
-            }
-            cursor = cursor.max(c_end);
-            if cursor >= p_end {
-                break;
-            }
-        }
-        if cursor < p_end {
-            out.push((cursor, p_end));
-        }
-    }
-    out
+enum EffectivePolarityOrModality {
+    Polarity(Polarity),
+    Modality(Modality),
+    StillInherit,
 }
 
-// ---------------------------------------------------------------------------
-// Inline unit tests
-// ---------------------------------------------------------------------------
+/// Iterative walk along `Contains` parents. Iterative on purpose:
+/// `check_acyclicity` already guarantees the graph is a DAG, but a
+/// long linear chain of `Contains` edges (each node carrying
+/// `Inherit` polarity) is still a legitimate input shape and would
+/// otherwise grow the call stack proportional to chain length. The
+/// O(N) `visited` `Vec` here grows on the heap, so worst-case
+/// behaviour is graceful allocation failure rather than stack
+/// overflow.
+fn resolve_effective<'a>(
+    start: &'a NodeId,
+    by_id: &HashMap<&NodeId, &'a IRNode>,
+    contains_parents: &HashMap<&'a NodeId, Vec<&'a NodeId>>,
+    field: InheritField,
+    memo: &mut HashMap<&'a NodeId, EffectivePolarityOrModality>,
+) -> EffectivePolarityOrModality {
+    let mut visited: Vec<&'a NodeId> = Vec::new();
+    let mut cursor: &'a NodeId = start;
+
+    let final_value = loop {
+        if let Some(v) = memo.get(cursor) {
+            break clone_eff(v);
+        }
+        let node = by_id[cursor];
+        let is_inherit = match field {
+            InheritField::Polarity => node.polarity == Polarity::Inherit,
+            InheritField::Modality => node.modality == Modality::Inherit,
+        };
+        if !is_inherit {
+            break match field {
+                InheritField::Polarity => {
+                    EffectivePolarityOrModality::Polarity(node.polarity)
+                }
+                InheritField::Modality => {
+                    EffectivePolarityOrModality::Modality(node.modality)
+                }
+            };
+        }
+        // Inherit: walk to the first Contains parent (if any).
+        visited.push(cursor);
+        match contains_parents.get(cursor).and_then(|ps| ps.first()) {
+            Some(parent) => cursor = parent,
+            None => break EffectivePolarityOrModality::StillInherit,
+        }
+    };
+
+    // Backfill memo for every node we walked so the next caller
+    // short-circuits at the first hit.
+    for id in visited {
+        memo.insert(id, clone_eff(&final_value));
+    }
+    final_value
+}
+
+fn clone_eff(v: &EffectivePolarityOrModality) -> EffectivePolarityOrModality {
+    match v {
+        EffectivePolarityOrModality::Polarity(p) => EffectivePolarityOrModality::Polarity(*p),
+        EffectivePolarityOrModality::Modality(m) => EffectivePolarityOrModality::Modality(*m),
+        EffectivePolarityOrModality::StillInherit => EffectivePolarityOrModality::StillInherit,
+    }
+}
+
+fn polarity_name(p: Polarity) -> &'static str {
+    match p {
+        Polarity::Affirmed => "Affirmed",
+        Polarity::Denied => "Denied",
+        Polarity::Uncertain => "Uncertain",
+        Polarity::Inherit => "Inherit",
+    }
+}
+
+fn modality_name(m: Modality) -> &'static str {
+    match m {
+        Modality::Present => "Present",
+        Modality::Past => "Past",
+        Modality::Future => "Future",
+        Modality::Hypothetical => "Hypothetical",
+        Modality::FamilyHistory => "FamilyHistory",
+        Modality::RuledOut => "RuledOut",
+        Modality::Conditional => "Conditional",
+        Modality::Inherit => "Inherit",
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
 
 #[cfg(test)]
 mod tests {
@@ -786,7 +1494,7 @@ mod tests {
         Span::new(doc.clone(), start, end)
     }
 
-    fn ok_fact(id: &str, doc: &DocumentId, start: usize, end: usize) -> IRNode {
+    fn fact(id: &str, doc: &DocumentId, start: usize, end: usize) -> IRNode {
         IRNode {
             id: NodeId::new(id),
             kind: NodeKind::Fact,
@@ -795,196 +1503,84 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![span(doc, start, end)],
             confidence: 0.9,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: HashMap::new(),
         }
     }
 
-    /// v2 helper: build a TextRun parent node.
-    fn ok_text_run(id: &str, doc: &DocumentId, start: usize, end: usize) -> IRNode {
+    fn section(id: &str, doc: &DocumentId, start: usize, end: usize) -> IRNode {
         IRNode {
             id: NodeId::new(id),
-            kind: NodeKind::TextRun,
-            term: compound("text_run", vec![]),
-            polarity: Polarity::Inherit,
-            modality: Modality::Inherit,
+            kind: NodeKind::Section,
+            term: compound("paragraph", vec![]),
+            polarity: Polarity::Affirmed,
+            modality: Modality::Present,
             source_spans: vec![span(doc, start, end)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn entity(id: &str, name: &str) -> IRNode {
+        IRNode {
+            id: NodeId::new(id),
+            kind: NodeKind::Entity,
+            term: atom(name),
+            polarity: Polarity::Affirmed,
+            modality: Modality::Present,
+            source_spans: vec![],
+            confidence: 1.0,
+            discard_reason: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn edge(
+        id: &str,
+        source: &str,
+        target: &str,
+        relation: EdgeRelation,
+        spans: Vec<Span>,
+    ) -> IREdge {
+        IREdge {
+            id: EdgeId::new(id),
+            source: NodeId::new(source),
+            target: NodeId::new(target),
+            relation,
+            polarity: Polarity::Affirmed,
+            modality: Modality::Present,
+            source_spans: spans,
+            confidence: 1.0,
             metadata: HashMap::new(),
         }
     }
 
     #[test]
     fn empty_document_is_well_formed() {
-        let doc = IRDocument {
-            document_id: DocumentId::new("doc1"),
-            nodes: vec![],
-        };
-        assert!(validate(&doc).is_ok());
-    }
-
-    #[test]
-    fn single_well_formed_fact_passes() {
-        let doc_id = DocumentId::new("doc1");
-        let n = ok_fact("F1", &doc_id, 0, 10);
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
+        let doc = IRDocument::new(DocumentId::new("doc1"));
         assert_eq!(validate(&doc), Ok(()));
     }
 
     #[test]
-    fn fact_with_uncertain_polarity_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("F1", &doc_id, 0, 10);
-        n.polarity = Polarity::Uncertain;
+    fn single_well_formed_fact_tiling_document() {
+        let did = DocumentId::new("doc1");
+        let n = fact("F1", &did, 0, 10);
         let doc = IRDocument {
-            document_id: doc_id,
+            document_id: did,
             nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::FactWithUncertainPolarity { .. })
-        ));
-    }
-
-    #[test]
-    fn uncertainty_with_definite_polarity_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("U1", &doc_id, 0, 10);
-        n.kind = NodeKind::Uncertainty;
-        n.polarity = Polarity::Affirmed;
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::UncertaintyWithDefinitePolarity { .. })
-        ));
-    }
-
-    #[test]
-    fn query_with_denied_polarity_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("Q1", &doc_id, 0, 10);
-        n.kind = NodeKind::Query;
-        n.polarity = Polarity::Denied;
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::QueryWithNonAffirmedPolarity { .. })
-        ));
-    }
-
-    #[test]
-    fn discarded_without_reason_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("D1", &doc_id, 0, 10);
-        n.kind = NodeKind::Discarded;
-        // discard_reason left None
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::DiscardedWithoutReason { .. })
-        ));
-    }
-
-    #[test]
-    fn discarded_with_reason_passes() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("D1", &doc_id, 0, 10);
-        n.kind = NodeKind::Discarded;
-        n.discard_reason = Some(DiscardReason::Pleasantry);
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
+            edges: vec![],
         };
         assert_eq!(validate(&doc), Ok(()));
-    }
-
-    #[test]
-    fn non_discarded_with_reason_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("F1", &doc_id, 0, 10);
-        n.discard_reason = Some(DiscardReason::Pleasantry);
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::NonDiscardedWithReason { .. })
-        ));
-    }
-
-    #[test]
-    fn empty_source_spans_rejected_for_fact() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("F1", &doc_id, 0, 10);
-        n.source_spans.clear();
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::MissingSourceSpans { .. })
-        ));
-    }
-
-    #[test]
-    fn invalid_span_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("F1", &doc_id, 10, 5); // start > end
-        // ok_fact constructs with valid span; override here:
-        n.source_spans = vec![Span::new(doc_id.clone(), 10, 5)];
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::InvalidSpan { .. })
-        ));
-    }
-
-    #[test]
-    fn span_referencing_different_document_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let other = DocumentId::new("doc2");
-        let mut n = ok_fact("F1", &doc_id, 0, 10);
-        n.source_spans = vec![Span::new(other, 0, 10)];
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::SpanDocumentMismatch { .. })
-        ));
     }
 
     #[test]
     fn duplicate_node_id_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let n1 = ok_fact("F1", &doc_id, 0, 10);
-        let n2 = ok_fact("F1", &doc_id, 11, 20);
+        let did = DocumentId::new("doc1");
         let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n1, n2],
+            document_id: did.clone(),
+            nodes: vec![fact("F1", &did, 0, 5), fact("F1", &did, 5, 10)],
+            edges: vec![],
         };
         assert!(matches!(
             validate(&doc),
@@ -993,314 +1589,496 @@ mod tests {
     }
 
     #[test]
-    fn dangling_lowered_from_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("F1", &doc_id, 0, 10);
-        n.lowered_from = Some(NodeId::new("DOES_NOT_EXIST"));
+    fn duplicate_edge_id_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut n1 = fact("F1", &did, 0, 5);
+        n1.kind = NodeKind::Exception;
+        let mut n2 = fact("R1", &did, 5, 10);
+        n2.kind = NodeKind::Rule;
         let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![n],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::DanglingLoweredFrom { .. })
-        ));
-    }
-
-    #[test]
-    fn lowering_fact_to_fact_with_span_subset_passes() {
-        let doc_id = DocumentId::new("doc1");
-        let parent = ok_fact("F1", &doc_id, 0, 100);
-        let mut child = ok_fact("F1a", &doc_id, 10, 50);
-        child.lowered_from = Some(NodeId::new("F1"));
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent, child],
-        };
-        assert_eq!(validate(&doc), Ok(()));
-    }
-
-    #[test]
-    fn lowering_to_wider_span_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let parent = ok_fact("F1", &doc_id, 10, 50);
-        let mut child = ok_fact("F1a", &doc_id, 0, 100); // wider than parent
-        child.lowered_from = Some(NodeId::new("F1"));
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent, child],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::LoweringExpandsSpans { .. })
-        ));
-    }
-
-    #[test]
-    fn lowering_fact_to_uncertainty_rejected() {
-        // Per ADJ01: Fact cannot lower to Uncertainty (would be a
-        // coverage failure at the root).
-        let doc_id = DocumentId::new("doc1");
-        let parent = ok_fact("F1", &doc_id, 0, 100);
-        let mut child = ok_fact("U1", &doc_id, 10, 50);
-        child.kind = NodeKind::Uncertainty;
-        child.polarity = Polarity::Uncertain;
-        child.lowered_from = Some(NodeId::new("F1"));
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent, child],
-        };
-        assert!(matches!(
-            validate(&doc),
-            Err(ValidationError::IncompatibleLowering { .. })
-        ));
-    }
-
-    #[test]
-    fn lowering_uncertainty_to_fact_passes() {
-        // Clarification resolves uncertainty to a fact.
-        let doc_id = DocumentId::new("doc1");
-        let mut parent = ok_fact("U1", &doc_id, 0, 100);
-        parent.kind = NodeKind::Uncertainty;
-        parent.polarity = Polarity::Uncertain;
-        let mut child = ok_fact("F1a", &doc_id, 10, 50);
-        child.lowered_from = Some(NodeId::new("U1"));
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent, child],
-        };
-        assert_eq!(validate(&doc), Ok(()));
-    }
-
-    #[test]
-    fn lowering_cycle_rejected() {
-        // F1 -> F2 -> F1 forms a cycle.
-        let doc_id = DocumentId::new("doc1");
-        let mut n1 = ok_fact("F1", &doc_id, 0, 100);
-        let mut n2 = ok_fact("F2", &doc_id, 0, 100);
-        n1.lowered_from = Some(NodeId::new("F2"));
-        n2.lowered_from = Some(NodeId::new("F1"));
-        let doc = IRDocument {
-            document_id: doc_id,
+            document_id: did.clone(),
             nodes: vec![n1, n2],
+            edges: vec![
+                edge("E1", "F1", "R1", EdgeRelation::Excepts, vec![]),
+                edge("E1", "F1", "R1", EdgeRelation::Excepts, vec![]),
+            ],
         };
         assert!(matches!(
             validate(&doc),
-            Err(ValidationError::LoweringCycle { .. })
+            Err(ValidationError::DuplicateEdgeId { .. })
         ));
     }
 
     #[test]
-    fn rule_does_not_require_source_spans() {
-        // Rules cite rulebook spans which may be from a different
-        // document or none at all in the structural check (the rule
-        // pipeline enforces its own rules).
-        let doc_id = DocumentId::new("doc1");
-        let mut n = ok_fact("R1", &doc_id, 0, 0);
-        n.kind = NodeKind::Rule;
-        n.source_spans.clear();
-        // Other Rule constraints still apply: polarity != Uncertain,
-        // no discard_reason. Both already true via ok_fact defaults.
+    fn fact_with_uncertain_polarity_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut n = fact("F1", &did, 0, 10);
+        n.polarity = Polarity::Uncertain;
         let doc = IRDocument {
-            document_id: doc_id,
+            document_id: did,
             nodes: vec![n],
-        };
-        assert_eq!(validate(&doc), Ok(()));
-    }
-
-    #[test]
-    fn span_contains_self_is_true() {
-        let doc = DocumentId::new("d");
-        let s = Span::new(doc.clone(), 5, 10);
-        assert!(s.contains(&s));
-    }
-
-    #[test]
-    fn span_contains_handles_equality_at_boundaries() {
-        let doc = DocumentId::new("d");
-        let outer = Span::new(doc.clone(), 5, 10);
-        let inner = Span::new(doc.clone(), 5, 8); // shares start
-        let inner2 = Span::new(doc.clone(), 7, 10); // shares end
-        assert!(outer.contains(&inner));
-        assert!(outer.contains(&inner2));
-    }
-
-    #[test]
-    fn span_contains_rejects_different_documents() {
-        let outer = Span::new(DocumentId::new("d1"), 0, 100);
-        let inner = Span::new(DocumentId::new("d2"), 10, 20);
-        assert!(!outer.contains(&inner));
-    }
-
-    // ----- v2 hierarchical-decomposition tests -----
-
-    /// A TextRun parent containing one Fact child that tiles its span.
-    #[test]
-    fn textrun_with_one_child_tiling_full_span_passes() {
-        let doc_id = DocumentId::new("doc1");
-        let mut parent = ok_text_run("T0", &doc_id, 0, 30);
-        let mut child = ok_fact("F1", &doc_id, 0, 30);
-        child.part_of = Some(NodeId::new("T0"));
-        // parent's polarity stays Inherit; that's fine for structural check
-        // (propagation is ADJ03's concern, not validate's).
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent.clone(), child.clone()],
-        };
-        // Avoid unused-mut warnings.
-        let _ = parent;
-        let _ = child;
-        assert_eq!(validate(&doc), Ok(()));
-    }
-
-    /// A TextRun with two adjacent children that together tile the span.
-    #[test]
-    fn textrun_with_children_that_jointly_tile_parent_passes() {
-        let doc_id = DocumentId::new("doc1");
-        let parent = ok_text_run("T0", &doc_id, 0, 50);
-        let mut c1 = ok_fact("F1", &doc_id, 0, 20);
-        let mut c2 = ok_fact("F2", &doc_id, 20, 50);
-        c1.part_of = Some(NodeId::new("T0"));
-        c2.part_of = Some(NodeId::new("T0"));
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent, c1, c2],
-        };
-        assert_eq!(validate(&doc), Ok(()));
-    }
-
-    /// Children leaving a byte-gap fail with ChildrenDoNotTileParent and
-    /// the missing range is reported.
-    #[test]
-    fn textrun_with_gap_in_children_fails_with_missing_range() {
-        let doc_id = DocumentId::new("doc1");
-        let parent = ok_text_run("T0", &doc_id, 0, 50);
-        let mut c1 = ok_fact("F1", &doc_id, 0, 20);
-        let mut c2 = ok_fact("F2", &doc_id, 30, 50);
-        c1.part_of = Some(NodeId::new("T0"));
-        c2.part_of = Some(NodeId::new("T0"));
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent, c1, c2],
-        };
-        match validate(&doc) {
-            Err(ValidationError::ChildrenDoNotTileParent { parent_id, missing_ranges }) => {
-                assert_eq!(parent_id, NodeId::new("T0"));
-                assert_eq!(missing_ranges, vec![(20, 30)]);
-            }
-            other => panic!("expected ChildrenDoNotTileParent, got {:?}", other),
-        }
-    }
-
-    /// A TextRun with no children fails the tile check — its entire
-    /// span is reported missing.
-    #[test]
-    fn empty_textrun_fails_with_full_missing_range() {
-        let doc_id = DocumentId::new("doc1");
-        let parent = ok_text_run("T0", &doc_id, 0, 50);
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent],
-        };
-        match validate(&doc) {
-            Err(ValidationError::ChildrenDoNotTileParent {
-                missing_ranges, ..
-            }) => {
-                assert_eq!(missing_ranges, vec![(0, 50)]);
-            }
-            other => panic!("expected ChildrenDoNotTileParent, got {:?}", other),
-        }
-    }
-
-    /// A non-TextRun cannot have children; if it does, NonTextRunHasChildren
-    /// fires.
-    #[test]
-    fn fact_with_child_via_part_of_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let parent = ok_fact("F0", &doc_id, 0, 30);
-        let mut child = ok_fact("F1", &doc_id, 0, 30);
-        child.part_of = Some(NodeId::new("F0"));
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent, child],
-        };
-        match validate(&doc) {
-            Err(ValidationError::NonTextRunHasChildren { parent_kind, .. }) => {
-                assert_eq!(parent_kind, NodeKind::Fact);
-            }
-            other => panic!("expected NonTextRunHasChildren, got {:?}", other),
-        }
-    }
-
-    /// `part_of` pointing to a nonexistent node fires DanglingPartOf.
-    #[test]
-    fn dangling_part_of_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let mut child = ok_fact("F1", &doc_id, 0, 30);
-        child.part_of = Some(NodeId::new("DOES_NOT_EXIST"));
-        let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![child],
+            edges: vec![],
         };
         assert!(matches!(
             validate(&doc),
-            Err(ValidationError::DanglingPartOf { .. })
+            Err(ValidationError::FactWithUncertainPolarity { .. })
         ));
     }
 
-    /// Child spans extending beyond parent fail with ChildSpansExceedParent.
     #[test]
-    fn child_spans_exceeding_parent_rejected() {
-        let doc_id = DocumentId::new("doc1");
-        let parent = ok_text_run("T0", &doc_id, 10, 30);
-        let mut child = ok_fact("F1", &doc_id, 0, 30); // 0..30 outside 10..30
-        child.part_of = Some(NodeId::new("T0"));
+    fn dangling_edge_source_rejected() {
+        let did = DocumentId::new("doc1");
+        let r = {
+            let mut r = fact("R1", &did, 0, 10);
+            r.kind = NodeKind::Rule;
+            r
+        };
         let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![parent, child],
+            document_id: did,
+            nodes: vec![r],
+            edges: vec![edge("E1", "GHOST", "R1", EdgeRelation::Excepts, vec![])],
         };
         assert!(matches!(
             validate(&doc),
-            Err(ValidationError::ChildSpansExceedParent { .. })
+            Err(ValidationError::DanglingEdgeSource { .. })
         ));
     }
 
-    /// Polarity::Inherit on a Fact / Query / Uncertainty is accepted in v2.
-    /// (The v1 strict checks gated on Inherit would have failed.)
     #[test]
-    fn inherit_polarity_accepted_on_each_kind() {
-        let doc_id = DocumentId::new("doc1");
-        let mut fact = ok_fact("F1", &doc_id, 0, 10);
-        fact.polarity = Polarity::Inherit;
+    fn dangling_edge_target_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut excpt = fact("X1", &did, 0, 10);
+        excpt.kind = NodeKind::Exception;
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![excpt],
+            edges: vec![edge("E1", "X1", "GHOST", EdgeRelation::Excepts, vec![])],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::DanglingEdgeTarget { .. })
+        ));
+    }
 
-        let mut q = ok_fact("Q1", &doc_id, 10, 20);
+    #[test]
+    fn self_loop_edge_rejected() {
+        let did = DocumentId::new("doc1");
+        let r = {
+            let mut r = fact("R1", &did, 0, 10);
+            r.kind = NodeKind::Rule;
+            r
+        };
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![r],
+            edges: vec![edge("E1", "R1", "R1", EdgeRelation::Refines, vec![])],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::SelfLoopEdge { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_relation_source_kind_rejected() {
+        let did = DocumentId::new("doc1");
+        let f = fact("F1", &did, 0, 5);
+        let mut r = fact("R1", &did, 5, 10);
+        r.kind = NodeKind::Rule;
+        // Excepts requires source kind = Exception; F1 is Fact.
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![f, r],
+            edges: vec![edge("E1", "F1", "R1", EdgeRelation::Excepts, vec![])],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::InvalidRelationSourceKind { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_relation_target_kind_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut x = fact("X1", &did, 0, 5);
+        x.kind = NodeKind::Exception;
+        let f = fact("F1", &did, 5, 10);
+        // Excepts requires target kind = Rule; F1 is Fact.
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![x, f],
+            edges: vec![edge("E1", "X1", "F1", EdgeRelation::Excepts, vec![])],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::InvalidRelationTargetKind { .. })
+        ));
+    }
+
+    #[test]
+    fn inherit_polarity_on_edge_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut x = fact("X1", &did, 0, 5);
+        x.kind = NodeKind::Exception;
+        let mut r = fact("R1", &did, 5, 10);
+        r.kind = NodeKind::Rule;
+        let mut bad = edge("E1", "X1", "R1", EdgeRelation::Excepts, vec![]);
+        bad.polarity = Polarity::Inherit;
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![x, r],
+            edges: vec![bad],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::InheritOnEdge {
+                offending: InheritField::Polarity,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn graph_cycle_rejected() {
+        // Three rules R1 -> R2 -> R3 -> R1 with Refines edges.
+        let did = DocumentId::new("doc1");
+        let r1 = {
+            let mut r = fact("R1", &did, 0, 5);
+            r.kind = NodeKind::Rule;
+            r
+        };
+        let r2 = {
+            let mut r = fact("R2", &did, 5, 10);
+            r.kind = NodeKind::Rule;
+            r
+        };
+        let r3 = {
+            let mut r = fact("R3", &did, 10, 15);
+            r.kind = NodeKind::Rule;
+            r
+        };
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![r1, r2, r3],
+            edges: vec![
+                edge("E1", "R1", "R2", EdgeRelation::Refines, vec![]),
+                edge("E2", "R2", "R3", EdgeRelation::Refines, vec![]),
+                edge("E3", "R3", "R1", EdgeRelation::Refines, vec![]),
+            ],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::GraphCycle { .. })
+        ));
+    }
+
+    #[test]
+    fn unattached_exception_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut x = fact("X1", &did, 0, 10);
+        x.kind = NodeKind::Exception;
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![x],
+            edges: vec![],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::UnattachedException { .. })
+        ));
+    }
+
+    #[test]
+    fn coverage_gap_detected() {
+        let did = DocumentId::new("doc1");
+        let doc = IRDocument {
+            document_id: did.clone(),
+            nodes: vec![fact("F1", &did, 0, 5), fact("F2", &did, 10, 15)],
+            edges: vec![],
+        };
+        let err = validate(&doc).unwrap_err();
+        match err {
+            ValidationError::CoverageGap { missing_ranges } => {
+                assert_eq!(missing_ranges, vec![(5, 10)]);
+            }
+            other => panic!("expected CoverageGap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coverage_starts_at_nonzero_detected() {
+        let did = DocumentId::new("doc1");
+        let doc = IRDocument {
+            document_id: did.clone(),
+            nodes: vec![fact("F1", &did, 5, 10)],
+            edges: vec![],
+        };
+        let err = validate(&doc).unwrap_err();
+        match err {
+            ValidationError::CoverageGap { missing_ranges } => {
+                assert_eq!(missing_ranges, vec![(0, 5)]);
+            }
+            other => panic!("expected CoverageGap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coverage_overlap_detected() {
+        let did = DocumentId::new("doc1");
+        let doc = IRDocument {
+            document_id: did.clone(),
+            nodes: vec![fact("F1", &did, 0, 10), fact("F2", &did, 5, 15)],
+            edges: vec![],
+        };
+        let err = validate(&doc).unwrap_err();
+        match err {
+            ValidationError::CoverageOverlap { .. } => (),
+            other => panic!("expected CoverageOverlap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn synthesized_query_does_not_break_tiling() {
+        let did = DocumentId::new("doc1");
+        // F1 tiles [0,10); Q1 is synthesized with empty spans.
+        let f = fact("F1", &did, 0, 10);
+        let mut q = fact("Q1", &did, 0, 0);
         q.kind = NodeKind::Query;
-        q.polarity = Polarity::Inherit;
-
-        let mut u = ok_fact("U1", &doc_id, 20, 30);
-        u.kind = NodeKind::Uncertainty;
-        u.polarity = Polarity::Inherit;
-
+        q.source_spans.clear();
         let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![fact, q, u],
+            document_id: did,
+            nodes: vec![f, q],
+            edges: vec![],
         };
         assert_eq!(validate(&doc), Ok(()));
     }
 
-    /// Nested TextRun decomposition (parent TextRun → child TextRun → leaf)
-    /// validates if all tilings hold.
     #[test]
-    fn nested_textrun_decomposition_validates() {
-        let doc_id = DocumentId::new("doc1");
-        let outer = ok_text_run("T0", &doc_id, 0, 50);
-        let mut inner = ok_text_run("T1", &doc_id, 0, 50);
-        inner.part_of = Some(NodeId::new("T0"));
-        let mut leaf = ok_fact("F1", &doc_id, 0, 50);
-        leaf.part_of = Some(NodeId::new("T1"));
+    fn entity_dedup_with_mentions_edge_validates() {
+        let did = DocumentId::new("doc1");
+        // F1 spans [0,30); entity E_p (no spans); a Mentions edge from
+        // F1 to E_p with spans=[5,14) (the bytes "passenger"). Coverage
+        // tiles via F1's [0,30); the edge's mention span is INSIDE
+        // F1's span — which is an overlap. That's a coverage violation
+        // by design: edges and nodes can't double-cover.
+        //
+        // The correct shape is: F1's span doesn't include "passenger",
+        // and the edge tiles those bytes. Re-do.
+        let f1 = fact("F1", &did, 0, 5);
+        let f2 = fact("F2", &did, 14, 30);
+        let e_p = entity("Ep", "passenger");
+        let mention = edge(
+            "E1",
+            "F1",
+            "Ep",
+            EdgeRelation::Mentions,
+            vec![span(&did, 5, 14)],
+        );
         let doc = IRDocument {
-            document_id: doc_id,
-            nodes: vec![outer, inner, leaf],
+            document_id: did,
+            nodes: vec![f1, f2, e_p],
+            edges: vec![mention],
+        };
+        assert_eq!(validate(&doc), Ok(()));
+    }
+
+    #[test]
+    fn contains_propagation_single_parent_passes() {
+        let did = DocumentId::new("doc1");
+        // Section S1 (Denied) -> Contains F1 with Inherit polarity.
+        let mut s1 = section("S1", &did, 0, 5);
+        s1.polarity = Polarity::Denied;
+        let mut f1 = fact("F1", &did, 5, 10);
+        f1.polarity = Polarity::Inherit;
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![s1, f1],
+            edges: vec![edge("E1", "S1", "F1", EdgeRelation::Contains, vec![])],
+        };
+        assert_eq!(validate(&doc), Ok(()));
+    }
+
+    #[test]
+    fn contains_propagation_conflict_detected() {
+        let did = DocumentId::new("doc1");
+        // Two Sections cover F1 via Contains, with disagreeing
+        // polarities. F1's Inherit triggers a conflict.
+        let mut s1 = section("S1", &did, 0, 5);
+        s1.polarity = Polarity::Affirmed;
+        let mut s2 = section("S2", &did, 10, 15);
+        s2.polarity = Polarity::Denied;
+        let mut f1 = fact("F1", &did, 5, 10);
+        f1.polarity = Polarity::Inherit;
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![s1, s2, f1],
+            edges: vec![
+                edge("E1", "S1", "F1", EdgeRelation::Contains, vec![]),
+                edge("E2", "S2", "F1", EdgeRelation::Contains, vec![]),
+            ],
+        };
+        let err = validate(&doc).unwrap_err();
+        match err {
+            ValidationError::PropagationConflict {
+                field: InheritField::Polarity,
+                ..
+            } => (),
+            other => panic!("expected PropagationConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inherit_without_parent_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut f = fact("F1", &did, 0, 10);
+        f.polarity = Polarity::Inherit;
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![f],
+            edges: vec![],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::InheritWithoutParent { .. })
+        ));
+    }
+
+    #[test]
+    fn domain_specific_collision_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut x = fact("X1", &did, 0, 5);
+        x.kind = NodeKind::Exception;
+        let mut r = fact("R1", &did, 5, 10);
+        r.kind = NodeKind::Rule;
+        let bad_edge = edge(
+            "E1",
+            "X1",
+            "R1",
+            EdgeRelation::DomainSpecific("excepts".to_string()),
+            vec![],
+        );
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![x, r],
+            edges: vec![bad_edge],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::InvalidDomainSpecificName { .. })
+        ));
+    }
+
+    #[test]
+    fn clarifies_kind_compatibility_enforced() {
+        // Fact ←Clarifies← Uncertainty is OK; Uncertainty ←Clarifies← Fact is NOT.
+        let did = DocumentId::new("doc1");
+        let mut original = fact("F1", &did, 0, 10);
+        // Original is a Fact; clarified is an Uncertainty — forbidden.
+        let mut clarified = fact("U1", &did, 0, 10);
+        clarified.kind = NodeKind::Uncertainty;
+        clarified.polarity = Polarity::Uncertain;
+        // Two nodes with the same span overlap. To make coverage clean,
+        // use distinct spans.
+        original.source_spans = vec![span(&did, 0, 5)];
+        clarified.source_spans = vec![span(&did, 5, 10)];
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![original, clarified],
+            edges: vec![edge(
+                "E1",
+                "U1",
+                "F1",
+                EdgeRelation::Clarifies,
+                vec![],
+            )],
+        };
+        // Should fail because Fact ←Clarifies← Uncertainty is not allowed:
+        // (parent=Fact, child=Uncertainty) is missing from the
+        // compatibility table.
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::IncompatibleClarification { .. })
+        ));
+    }
+
+    #[test]
+    fn adjacency_helpers_work() {
+        let did = DocumentId::new("doc1");
+        let f1 = fact("F1", &did, 0, 5);
+        let f2 = fact("F2", &did, 5, 10);
+        let e = edge("E1", "F1", "F2", EdgeRelation::DerivedFrom, vec![]);
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![f1, f2],
+            edges: vec![e],
+        };
+        let n1 = NodeId::new("F1");
+        let n2 = NodeId::new("F2");
+        assert_eq!(doc.adjacency_out(&n1).count(), 1);
+        assert_eq!(doc.adjacency_out(&n2).count(), 0);
+        assert_eq!(doc.adjacency_in(&n1).count(), 0);
+        assert_eq!(doc.adjacency_in(&n2).count(), 1);
+    }
+
+    #[test]
+    fn discarded_without_reason_rejected() {
+        let did = DocumentId::new("doc1");
+        let mut n = fact("D1", &did, 0, 10);
+        n.kind = NodeKind::Discarded;
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![n],
+            edges: vec![],
+        };
+        assert!(matches!(
+            validate(&doc),
+            Err(ValidationError::DiscardedWithoutReason { .. })
+        ));
+    }
+
+    #[test]
+    fn worked_example_tsa_validates() {
+        // Mini version of the ADJ01 v3 §"Worked Example" using a
+        // shorter source and a subset of the relationships. Spans are
+        // illustrative; the goal is to exercise the validator on a
+        // realistic-shaped graph.
+        let did = DocumentId::new("tsa-1540-111a");
+        let mut s1 = section("N1", &did, 0, 12);
+        s1.term = compound("section", vec![atom("1")]);
+        let mut s2 = section("N2", &did, 12, 28);
+        s2.term = compound("heading", vec![atom("2")]);
+        let mut r3 = fact("N3", &did, 28, 96);
+        r3.kind = NodeKind::Rule;
+        r3.metadata
+            .insert("as_of".to_string(), "2026-05-12".to_string());
+        let mut x4 = fact("N4", &did, 100, 168);
+        x4.kind = NodeKind::Exception;
+        let e_passenger = entity("Ep", "passenger");
+
+        // Coverage-tiling spans:
+        //   N1: [0, 12)   structural marker "§1540.111(a) "
+        //   N2: [12, 28)  heading
+        //   N3: [28, 96)  rule body
+        //   gap to fill:  [96, 100) — a connective span
+        //   N4: [100, 168) exception
+        let excepts_edge_marker = edge(
+            "E1",
+            "N4",
+            "N3",
+            EdgeRelation::Excepts,
+            vec![span(&did, 96, 100)],
+        );
+        let mention_passenger = edge(
+            "E2",
+            "N3",
+            "Ep",
+            EdgeRelation::Mentions,
+            vec![],
+        );
+        let doc = IRDocument {
+            document_id: did,
+            nodes: vec![s1, s2, r3, x4, e_passenger],
+            edges: vec![excepts_edge_marker, mention_passenger],
         };
         assert_eq!(validate(&doc), Ok(()));
     }

--- a/code/packages/rust/adjudication-pipeline/src/lib.rs
+++ b/code/packages/rust/adjudication-pipeline/src/lib.rs
@@ -355,19 +355,26 @@ fn coverage_to_checker_result(
 }
 
 fn coverage_violation_to_audit(v: &CoverageViolation) -> Violation {
+    use adjudication_ir::SpanLocation;
+    let span_loc_node_id = |loc: &SpanLocation| -> NodeId {
+        match loc {
+            SpanLocation::Node(id) => ir_node_id_to_audit(id),
+            SpanLocation::Edge(eid) => NodeId::new(format!("edge:{}", eid.0)),
+        }
+    };
     let (node_id, detail) = match v {
         CoverageViolation::SpanWrongDocument {
-            node_id, expected, found,
+            location, expected, found,
         } => (
-            ir_node_id_to_audit(node_id),
+            span_loc_node_id(location),
             serde_json::json!({
                 "kind": "SpanWrongDocument",
                 "expected": &expected.0,
                 "found": &found.0,
             }),
         ),
-        CoverageViolation::InvalidSpan { node_id, .. } => (
-            ir_node_id_to_audit(node_id),
+        CoverageViolation::InvalidSpan { location, .. } => (
+            span_loc_node_id(location),
             serde_json::json!({ "kind": "InvalidSpan" }),
         ),
         // Catch-all: every other variant gets its Debug rendering. The
@@ -440,10 +447,29 @@ fn propagation_to_checker_result(
 
 fn propagation_violation_to_audit(v: &PropagationViolation) -> Violation {
     let (node_id, kind, detail) = match v {
-        PropagationViolation::InheritChainUnresolved { node_id } => (
+        PropagationViolation::InheritWithoutParent { node_id, field } => (
             ir_node_id_to_audit(node_id),
             ClarificationKind::InheritChainUnresolved,
-            serde_json::json!({ "kind": "InheritChainUnresolved" }),
+            serde_json::json!({
+                "kind": "InheritWithoutParent",
+                "field": format!("{field:?}"),
+            }),
+        ),
+        PropagationViolation::MultiParentConflict {
+            node_id,
+            field,
+            candidates,
+        } => (
+            ir_node_id_to_audit(node_id),
+            ClarificationKind::AmbiguousPolarity,
+            serde_json::json!({
+                "kind": "MultiParentConflict",
+                "field": format!("{field:?}"),
+                "candidates": candidates
+                    .iter()
+                    .map(|(id, v)| serde_json::json!({ "parent": &id.0, "value": v }))
+                    .collect::<Vec<_>>(),
+            }),
         ),
         PropagationViolation::RuledOutMustBeAffirmed {
             node_id,
@@ -454,6 +480,14 @@ fn propagation_violation_to_audit(v: &PropagationViolation) -> Violation {
             serde_json::json!({
                 "kind": "RuledOutMustBeAffirmed",
                 "actual_polarity": format!("{actual_polarity:?}"),
+            }),
+        ),
+        PropagationViolation::UpstreamValidationError { kind } => (
+            NodeId::new(String::new()),
+            ClarificationKind::InheritChainUnresolved,
+            serde_json::json!({
+                "kind": "UpstreamValidationError",
+                "detail": kind,
             }),
         ),
     };
@@ -824,6 +858,7 @@ mod tests {
         IRDocument {
             document_id: IRDocumentId::new("doc1"),
             nodes,
+            edges: Vec::new(),
         }
     }
 
@@ -836,8 +871,6 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![Span::new(IRDocumentId::new("doc1"), start, end)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         }

--- a/code/packages/rust/adjudication-pipeline/tests/integration_adj10_tsa.rs
+++ b/code/packages/rust/adjudication-pipeline/tests/integration_adj10_tsa.rs
@@ -67,8 +67,6 @@ fn tsa_ir_document() -> IRDocument {
         modality: Modality::Present,
         source_spans: vec![Span::new(doc_id.clone(), 0, 16)],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: Default::default(),
     };
@@ -81,8 +79,6 @@ fn tsa_ir_document() -> IRDocument {
         modality: Modality::Present,
         source_spans: vec![Span::new(doc_id.clone(), 16, 24)],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: Default::default(),
     };
@@ -97,8 +93,6 @@ fn tsa_ir_document() -> IRDocument {
         // from source). Coverage check allows zero-span queries.
         source_spans: vec![],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: Default::default(),
     };
@@ -106,6 +100,7 @@ fn tsa_ir_document() -> IRDocument {
     IRDocument {
         document_id: doc_id,
         nodes: vec![f1, f2, q1],
+        edges: vec![],
     }
 }
 
@@ -234,8 +229,6 @@ fn tsa_pipeline_blocks_on_out_of_bounds_span() {
         // Span 100..200 — way past the 24-byte document.
         source_spans: vec![Span::new(doc_id.clone(), 100, 200)],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: Default::default(),
     };
@@ -244,7 +237,8 @@ fn tsa_pipeline_blocks_on_out_of_bounds_span() {
         ir_document: IRDocument {
             document_id: doc_id,
             nodes: vec![bad_fact],
-        },
+        edges: vec![],
+    },
     };
     let out = run(
         input,

--- a/code/packages/rust/adjudication-polarity-modality/src/lib.rs
+++ b/code/packages/rust/adjudication-polarity-modality/src/lib.rs
@@ -1,38 +1,42 @@
-//! # adjudication-polarity-modality — ADJ03 v2 propagation check.
+//! # adjudication-polarity-modality — ADJ03 v3 propagation check.
 //!
 //! Reference implementation of
-//! [`ADJ03` v2](../../../specs/ADJ03-polarity-modality-checker.md).
-//! The check is a **structural propagation consistency check** over
-//! the hierarchical IR from ADJ01 v2. The LLM declares polarity /
-//! modality at each level of the decomposition tree; the framework
-//! verifies the declarations are self-consistent.
+//! [`ADJ03` v3](../../../specs/ADJ03-polarity-modality-checker.md).
+//! Built on top of the v3 graph IR ([`adjudication_ir`]):
+//! propagation now runs along [`EdgeRelation::Contains`] edges (was
+//! `part_of` in v2), and multi-parent disagreement is a structural
+//! violation.
 //!
-//! No trigger taxonomy. No NegEx. No scope detector. No English
-//! assumption. Language-agnostic by construction.
+//! ## What this crate adds on top of `adjudication_ir::validate`
 //!
-//! ## The invariant
+//! `adjudication_ir::validate` already enforces:
 //!
-//! A leaf's **effective** polarity / modality is the value declared
-//! on the nearest ancestor (or, if every ancestor is `Inherit`, the
-//! leaf's own declaration or the framework default). A leaf cannot
-//! silently contradict its ancestor — any declared override surfaces
-//! in the audit trail and may trigger clarification via ADJ06.
+//! - `Inherit` polarity / modality on a node *requires* at least one
+//!   `Contains` parent (`InheritWithoutParent`).
+//! - Multiple `Contains` parents must agree on the effective value
+//!   (`PropagationConflict`).
 //!
-//! ## Violations vs. warnings
+//! This crate runs that validation and additionally reports:
 //!
-//! - **Violation** (gates adjudication): `InheritChainUnresolved`,
-//!   `RuledOutMustBeAffirmed`.
-//! - **Warning** (recorded, does not gate by default):
-//!   `LeafOverridesAncestorPolarity`, `LeafOverridesAncestorModality`.
-//!
-//! The default policy is *warn-do-not-block* because legitimate
-//! overrides are common in real documents ("Denies chest pain,
-//! fever, palpitations; admits shortness of breath."). A deployment
-//! can configure warnings-as-errors for strict semantics.
+//! - **`RuledOutMustBeAffirmed`** — a hard ADJ01 rule (gating
+//!   violation): if `modality = RuledOut` the polarity must be
+//!   `Affirmed`. `RuledOut` is a clinician's adjudication, not a
+//!   polarity flip.
+//! - **`LeafOverridesAncestorPolarity` / `LeafOverridesAncestorModality`**
+//!   — non-gating warnings recorded in the audit trail. A node that
+//!   carries a *concrete* polarity / modality (not `Inherit`) and
+//!   whose value differs from its `Contains` parent's effective value
+//!   is recorded for review. The default policy is *warn, do not
+//!   block* because legitimate overrides are common in real text
+//!   ("denies X, Y; admits Z"). Deployments can promote warnings to
+//!   errors via configuration.
 
 use std::collections::HashMap;
 
-use adjudication_ir::{IRDocument, IRNode, Modality, NodeId, NodeKind, Polarity};
+use adjudication_ir::{
+    validate, EdgeRelation, IRDocument, IRNode, InheritField, Modality, NodeId, NodeKind,
+    Polarity, ValidationError,
+};
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -51,37 +55,54 @@ impl PropagationResult {
     }
 }
 
-/// Gating failures. The propagation check fails if any of these
-/// is non-empty.
+/// Gating failures. The propagation check fails if any of these is
+/// non-empty.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PropagationViolation {
-    /// Every ancestor up to the root declared `Inherit` AND the node
-    /// itself declared `Inherit`. With no concrete value anywhere in
-    /// the chain, the effective value cannot be resolved.
-    InheritChainUnresolved { node_id: NodeId },
+    /// A node has `polarity = Inherit` (or `modality = Inherit`) but
+    /// no `Contains` parent. Surfaced from
+    /// [`ValidationError::InheritWithoutParent`].
+    InheritWithoutParent {
+        node_id: NodeId,
+        field: InheritField,
+    },
 
-    /// A leaf with `modality = RuledOut` must have `polarity =
-    /// Affirmed` (per ADJ01 hard rule). RuledOut is the clinician's
-    /// adjudication, not a polarity flip.
+    /// A node with `Inherit` has multiple `Contains` parents whose
+    /// effective values disagree. Surfaced from
+    /// [`ValidationError::PropagationConflict`].
+    MultiParentConflict {
+        node_id: NodeId,
+        field: InheritField,
+        candidates: Vec<(NodeId, String)>,
+    },
+
+    /// A node with `modality = RuledOut` must have `polarity =
+    /// Affirmed` per ADJ01.
     RuledOutMustBeAffirmed {
         node_id: NodeId,
         actual_polarity: Polarity,
     },
+
+    /// `adjudication_ir::validate` returned an error that isn't a
+    /// propagation concern; the propagation check returns it
+    /// faithfully so callers can route to the correct checker.
+    UpstreamValidationError { kind: String },
 }
 
 /// Non-gating warnings. Recorded in the audit trail; may be promoted
 /// to errors via configuration.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PropagationWarning {
-    /// A leaf's declared polarity overrides its ancestor's. Worth a
-    /// review (often legitimate, e.g. "denies X, Y; admits Z").
+    /// A node's declared polarity differs from its `Contains` parent's
+    /// effective polarity.
     LeafOverridesAncestorPolarity {
         node_id: NodeId,
         declared: Polarity,
         ancestor: Polarity,
     },
 
-    /// A leaf's declared modality overrides its ancestor's.
+    /// A node's declared modality differs from its `Contains` parent's
+    /// effective modality.
     LeafOverridesAncestorModality {
         node_id: NodeId,
         declared: Modality,
@@ -95,55 +116,83 @@ pub enum PropagationWarning {
 
 /// Run the propagation consistency check.
 ///
-/// Walks every non-TextRun, non-Discarded leaf, resolves its
-/// effective polarity / modality from the ancestor chain, and:
-///
-/// - Emits `InheritChainUnresolved` if the chain has no concrete
-///   value (a gating violation).
-/// - Emits `RuledOutMustBeAffirmed` if `modality = RuledOut` but
-///   polarity isn't Affirmed (a gating violation).
-/// - Emits `LeafOverridesAncestor*` if the leaf's declared value is
-///   non-Inherit and differs from the ancestor's effective value
-///   (warnings).
+/// 1. Calls [`adjudication_ir::validate`] and translates any
+///    `Inherit`-related errors into [`PropagationViolation`]s. Other
+///    validation errors are surfaced as
+///    `UpstreamValidationError { kind }`.
+/// 2. Walks every non-`Section`, non-`Discarded` node and checks the
+///    `RuledOut`/`Affirmed` constraint.
+/// 3. For nodes with a *concrete* (non-`Inherit`) polarity / modality
+///    that have at least one `Contains` parent, compares to each
+///    parent's effective value and emits a `LeafOverridesAncestor*`
+///    warning when they differ.
 pub fn check_propagation(ir_doc: &IRDocument) -> PropagationResult {
     let mut violations = Vec::new();
     let mut warnings = Vec::new();
 
-    let by_id: HashMap<NodeId, &IRNode> = ir_doc
-        .nodes
-        .iter()
-        .map(|n| (n.id.clone(), n))
-        .collect();
-
-    // Pre-compute effective polarity/modality for every node, with
-    // memoization. The lookup uses ancestor traversal.
-    let mut eff_polarity: HashMap<NodeId, Polarity> = HashMap::new();
-    let mut eff_modality: HashMap<NodeId, Modality> = HashMap::new();
-    for node in &ir_doc.nodes {
-        let ep = resolve_effective_polarity(node, &by_id, &mut eff_polarity);
-        let em = resolve_effective_modality(node, &by_id, &mut eff_modality);
-
-        if ep == Polarity::Inherit {
-            violations.push(PropagationViolation::InheritChainUnresolved {
-                node_id: node.id.clone(),
-            });
-        }
-        if em == Modality::Inherit {
-            violations.push(PropagationViolation::InheritChainUnresolved {
-                node_id: node.id.clone(),
-            });
+    // Run validate first. If the IR has a structural integrity problem
+    // (cycle, dangling edge endpoint, duplicate id, …), we can't
+    // safely walk Contains edges to resolve effective polarity — the
+    // walk could either recurse indefinitely on a cycle or index a
+    // missing node. Return early with the upstream error and let the
+    // caller route to the right checker (coverage / acyclicity /
+    // edge-validity).
+    if let Err(e) = validate(ir_doc) {
+        match e {
+            ValidationError::InheritWithoutParent { node_id, field } => {
+                violations.push(PropagationViolation::InheritWithoutParent { node_id, field });
+            }
+            ValidationError::PropagationConflict { node_id, field, candidates } => {
+                violations.push(PropagationViolation::MultiParentConflict {
+                    node_id,
+                    field,
+                    candidates: candidates
+                        .into_iter()
+                        .map(|(id, s)| (id, s.to_string()))
+                        .collect(),
+                });
+            }
+            other => {
+                // Structural integrity error: report and stop. The
+                // Contains-edge walk below would be unsafe.
+                violations.push(PropagationViolation::UpstreamValidationError {
+                    kind: format!("{other:?}"),
+                });
+                return PropagationResult { violations, warnings };
+            }
         }
     }
 
-    // Walk every leaf. TextRun nodes don't participate. Discarded
-    // nodes are skipped (their polarity and modality are formally
-    // fixed by ADJ01).
+    // Build an adjacency view of `Contains` parents per node.
+    let mut contains_parents: HashMap<&NodeId, Vec<&NodeId>> = HashMap::new();
+    for e in &ir_doc.edges {
+        if e.relation == EdgeRelation::Contains {
+            contains_parents.entry(&e.target).or_default().push(&e.source);
+        }
+    }
+    let by_id: HashMap<&NodeId, &IRNode> = ir_doc.nodes.iter().map(|n| (&n.id, n)).collect();
+
+    // Memo for effective polarity/modality lookups. Pre-populate by
+    // resolving every node once (the iterative resolvers only cache
+    // nodes on the *walked* path, not the starting node — so we
+    // capture the return value here so subsequent lookups by
+    // parent-id always succeed).
+    let mut eff_polarity: HashMap<NodeId, Polarity> = HashMap::new();
+    let mut eff_modality: HashMap<NodeId, Modality> = HashMap::new();
     for node in &ir_doc.nodes {
-        if node.kind == NodeKind::TextRun || node.kind == NodeKind::Discarded {
+        let p = resolve_effective_polarity(node, &by_id, &contains_parents, &mut eff_polarity);
+        eff_polarity.insert(node.id.clone(), p);
+        let m = resolve_effective_modality(node, &by_id, &contains_parents, &mut eff_modality);
+        eff_modality.insert(node.id.clone(), m);
+    }
+
+    // RuledOut + override warnings.
+    for node in &ir_doc.nodes {
+        if matches!(node.kind, NodeKind::Section | NodeKind::Discarded | NodeKind::Entity) {
             continue;
         }
 
-        // RuledOut + non-Affirmed = hard rule violation.
+        // Hard rule: RuledOut requires Affirmed.
         if node.modality == Modality::RuledOut && node.polarity != Polarity::Affirmed {
             violations.push(PropagationViolation::RuledOutMustBeAffirmed {
                 node_id: node.id.clone(),
@@ -151,86 +200,120 @@ pub fn check_propagation(ir_doc: &IRDocument) -> PropagationResult {
             });
         }
 
-        // Check declared-vs-ancestor for non-Inherit leaf
-        // declarations.
-        if let Some(parent_id) = &node.part_of {
-            let parent_eff_p = eff_polarity.get(parent_id).copied().unwrap_or(Polarity::Affirmed);
-            let parent_eff_m = eff_modality.get(parent_id).copied().unwrap_or(Modality::Present);
-
-            if node.polarity != Polarity::Inherit && node.polarity != parent_eff_p {
-                warnings.push(PropagationWarning::LeafOverridesAncestorPolarity {
-                    node_id: node.id.clone(),
-                    declared: node.polarity,
-                    ancestor: parent_eff_p,
-                });
+        // Override warnings — emitted only when the node carries a
+        // concrete (non-Inherit) value AND has at least one Contains
+        // parent.
+        let Some(parents) = contains_parents.get(&node.id) else {
+            continue;
+        };
+        let any_parent = parents.first().copied();
+        if let Some(parent_id) = any_parent {
+            if node.polarity != Polarity::Inherit {
+                if let Some(parent_eff) = eff_polarity.get(parent_id) {
+                    if *parent_eff != node.polarity && *parent_eff != Polarity::Inherit {
+                        warnings.push(PropagationWarning::LeafOverridesAncestorPolarity {
+                            node_id: node.id.clone(),
+                            declared: node.polarity,
+                            ancestor: *parent_eff,
+                        });
+                    }
+                }
             }
-            if node.modality != Modality::Inherit && node.modality != parent_eff_m {
-                warnings.push(PropagationWarning::LeafOverridesAncestorModality {
-                    node_id: node.id.clone(),
-                    declared: node.modality,
-                    ancestor: parent_eff_m,
-                });
+            if node.modality != Modality::Inherit {
+                if let Some(parent_eff) = eff_modality.get(parent_id) {
+                    if *parent_eff != node.modality && *parent_eff != Modality::Inherit {
+                        warnings.push(PropagationWarning::LeafOverridesAncestorModality {
+                            node_id: node.id.clone(),
+                            declared: node.modality,
+                            ancestor: *parent_eff,
+                        });
+                    }
+                }
             }
         }
     }
 
-    PropagationResult {
-        violations,
-        warnings,
-    }
+    PropagationResult { violations, warnings }
 }
 
 // ---------------------------------------------------------------------------
 // Effective polarity / modality resolution (with memoisation)
 // ---------------------------------------------------------------------------
 
-fn resolve_effective_polarity(
-    node: &IRNode,
-    by_id: &HashMap<NodeId, &IRNode>,
+/// Iterative `Contains`-chain walk. Iterative on purpose: cycles and
+/// long linear chains are both safe — cycles are caught by
+/// `validate()` upstream (we return early when one is reported), and
+/// long chains are bounded by the heap-allocated `visited` Vec rather
+/// than the OS thread stack.
+///
+/// If a parent id is missing from `by_id` (a dangling edge that
+/// somehow survived validate), the walk treats the missing parent as
+/// terminal and returns `Inherit` — graceful degradation rather than
+/// a panic.
+fn resolve_effective_polarity<'a>(
+    start: &'a IRNode,
+    by_id: &HashMap<&'a NodeId, &'a IRNode>,
+    contains_parents: &HashMap<&'a NodeId, Vec<&'a NodeId>>,
     cache: &mut HashMap<NodeId, Polarity>,
 ) -> Polarity {
-    if let Some(v) = cache.get(&node.id) {
+    if let Some(v) = cache.get(&start.id) {
         return *v;
     }
-    let v = if node.polarity != Polarity::Inherit {
-        node.polarity
-    } else if let Some(parent_id) = &node.part_of {
-        if let Some(parent) = by_id.get(parent_id) {
-            resolve_effective_polarity(parent, by_id, cache)
-        } else {
-            // Dangling part_of — ADJ02 catches this; default here.
-            Polarity::Affirmed
+    let mut visited: Vec<&'a NodeId> = Vec::new();
+    let mut cursor: &'a IRNode = start;
+    let final_value = loop {
+        if let Some(v) = cache.get(&cursor.id) {
+            break *v;
         }
-    } else {
-        // Root with Inherit declared and no ancestor — chain is
-        // unresolved.
-        Polarity::Inherit
+        if cursor.polarity != Polarity::Inherit {
+            break cursor.polarity;
+        }
+        visited.push(&cursor.id);
+        match contains_parents.get(&cursor.id).and_then(|ps| ps.first()) {
+            Some(parent_id) => match by_id.get(parent_id) {
+                Some(parent) => cursor = *parent,
+                None => break Polarity::Inherit,
+            },
+            None => break Polarity::Inherit,
+        }
     };
-    cache.insert(node.id.clone(), v);
-    v
+    for id in visited {
+        cache.insert(id.clone(), final_value);
+    }
+    final_value
 }
 
-fn resolve_effective_modality(
-    node: &IRNode,
-    by_id: &HashMap<NodeId, &IRNode>,
+fn resolve_effective_modality<'a>(
+    start: &'a IRNode,
+    by_id: &HashMap<&'a NodeId, &'a IRNode>,
+    contains_parents: &HashMap<&'a NodeId, Vec<&'a NodeId>>,
     cache: &mut HashMap<NodeId, Modality>,
 ) -> Modality {
-    if let Some(v) = cache.get(&node.id) {
+    if let Some(v) = cache.get(&start.id) {
         return *v;
     }
-    let v = if node.modality != Modality::Inherit {
-        node.modality
-    } else if let Some(parent_id) = &node.part_of {
-        if let Some(parent) = by_id.get(parent_id) {
-            resolve_effective_modality(parent, by_id, cache)
-        } else {
-            Modality::Present
+    let mut visited: Vec<&'a NodeId> = Vec::new();
+    let mut cursor: &'a IRNode = start;
+    let final_value = loop {
+        if let Some(v) = cache.get(&cursor.id) {
+            break *v;
         }
-    } else {
-        Modality::Inherit
+        if cursor.modality != Modality::Inherit {
+            break cursor.modality;
+        }
+        visited.push(&cursor.id);
+        match contains_parents.get(&cursor.id).and_then(|ps| ps.first()) {
+            Some(parent_id) => match by_id.get(parent_id) {
+                Some(parent) => cursor = *parent,
+                None => break Modality::Inherit,
+            },
+            None => break Modality::Inherit,
+        }
     };
-    cache.insert(node.id.clone(), v);
-    v
+    for id in visited {
+        cache.insert(id.clone(), final_value);
+    }
+    final_value
 }
 
 // ---------------------------------------------------------------------------
@@ -240,9 +323,11 @@ fn resolve_effective_modality(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use adjudication_ir::{DocumentId, Span};
+    use adjudication_ir::{
+        DocumentId, EdgeId, EdgeRelation, IREdge, Polarity, Span,
+    };
     use logic_core::{atom, compound};
-    use std::collections::HashMap;
+    use std::collections::HashMap as Map;
 
     fn doc_id() -> DocumentId {
         DocumentId::new("doc1")
@@ -252,37 +337,21 @@ mod tests {
         Span::new(doc_id(), start, end)
     }
 
-    fn text_run(
-        id: &str,
-        start: usize,
-        end: usize,
-        part_of: Option<&str>,
-        polarity: Polarity,
-        modality: Modality,
-    ) -> IRNode {
+    fn section(id: &str, start: usize, end: usize, polarity: Polarity, modality: Modality) -> IRNode {
         IRNode {
             id: NodeId::new(id),
-            kind: NodeKind::TextRun,
-            term: compound("text_run", vec![]),
+            kind: NodeKind::Section,
+            term: compound("paragraph", vec![]),
             polarity,
             modality,
             source_spans: vec![span_of(start, end)],
             confidence: 1.0,
-            part_of: part_of.map(NodeId::new),
-            lowered_from: None,
             discard_reason: None,
-            metadata: HashMap::new(),
+            metadata: Map::new(),
         }
     }
 
-    fn fact_leaf(
-        id: &str,
-        start: usize,
-        end: usize,
-        part_of: Option<&str>,
-        polarity: Polarity,
-        modality: Modality,
-    ) -> IRNode {
+    fn fact(id: &str, start: usize, end: usize, polarity: Polarity, modality: Modality) -> IRNode {
         IRNode {
             id: NodeId::new(id),
             kind: NodeKind::Fact,
@@ -291,240 +360,110 @@ mod tests {
             modality,
             source_spans: vec![span_of(start, end)],
             confidence: 0.9,
-            part_of: part_of.map(NodeId::new),
-            lowered_from: None,
             discard_reason: None,
-            metadata: HashMap::new(),
+            metadata: Map::new(),
         }
     }
 
-    /// Single leaf with concrete polarity → Pass, no warnings.
-    #[test]
-    fn single_leaf_with_concrete_polarity_passes() {
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![fact_leaf(
-                "F1",
-                0,
-                10,
-                None,
-                Polarity::Affirmed,
-                Modality::Present,
-            )],
-        };
-        let r = check_propagation(&ir);
-        assert!(r.pass());
-        assert!(r.warnings.is_empty());
-    }
-
-    /// Parent TextRun with Denied polarity, child Fact with Inherit
-    /// → child inherits Denied. No warning.
-    #[test]
-    fn child_inherits_parent_denied_polarity() {
-        let parent = text_run("T0", 0, 30, None, Polarity::Denied, Modality::Present);
-        let child = fact_leaf("F1", 0, 30, Some("T0"), Polarity::Inherit, Modality::Inherit);
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![parent, child],
-        };
-        let r = check_propagation(&ir);
-        assert!(r.pass(), "violations: {:?}", r.violations);
-        assert!(r.warnings.is_empty(), "warnings: {:?}", r.warnings);
-    }
-
-    /// Parent Denied, child explicitly Affirmed → override warning,
-    /// but does not gate.
-    #[test]
-    fn child_overriding_parent_polarity_emits_warning() {
-        let parent = text_run("T0", 0, 30, None, Polarity::Denied, Modality::Present);
-        let child = fact_leaf("F1", 0, 30, Some("T0"), Polarity::Affirmed, Modality::Present);
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![parent, child],
-        };
-        let r = check_propagation(&ir);
-        assert!(r.pass()); // warnings don't gate
-        let has_override = r.warnings.iter().any(|w| matches!(
-            w,
-            PropagationWarning::LeafOverridesAncestorPolarity { declared: Polarity::Affirmed, ancestor: Polarity::Denied, .. }
-        ));
-        assert!(has_override, "expected polarity override warning: {:?}", r.warnings);
-    }
-
-    /// RuledOut + Affirmed = pass (the canonical RuledOut shape).
-    #[test]
-    fn ruled_out_with_affirmed_polarity_passes() {
-        let leaf = fact_leaf(
-            "F1",
-            0,
-            30,
-            None,
-            Polarity::Affirmed,
-            Modality::RuledOut,
-        );
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![leaf],
-        };
-        let r = check_propagation(&ir);
-        assert!(r.pass());
-    }
-
-    /// RuledOut + Denied = gating violation (the clinical/legal
-    /// distinction enforced as a hard rule).
-    #[test]
-    fn ruled_out_with_denied_polarity_violates() {
-        let leaf = fact_leaf(
-            "F1",
-            0,
-            30,
-            None,
-            Polarity::Denied,
-            Modality::RuledOut,
-        );
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![leaf],
-        };
-        let r = check_propagation(&ir);
-        assert!(!r.pass());
-        assert!(r.violations.iter().any(|v| matches!(
-            v,
-            PropagationViolation::RuledOutMustBeAffirmed { .. }
-        )));
-    }
-
-    /// Parent Inherit + child Inherit + no ancestor → unresolved
-    /// chain.
-    #[test]
-    fn unresolvable_inherit_chain_violates() {
-        let parent = text_run("T0", 0, 30, None, Polarity::Inherit, Modality::Inherit);
-        let child = fact_leaf("F1", 0, 30, Some("T0"), Polarity::Inherit, Modality::Inherit);
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![parent, child],
-        };
-        let r = check_propagation(&ir);
-        assert!(!r.pass(), "expected violations, got {:?}", r);
-        assert!(r.violations.iter().any(|v| matches!(
-            v,
-            PropagationViolation::InheritChainUnresolved { .. }
-        )));
-    }
-
-    /// Multi-level inheritance: grandchild inherits from grandparent.
-    #[test]
-    fn multilevel_inheritance_through_textruns() {
-        let outer = text_run("T0", 0, 50, None, Polarity::Denied, Modality::Past);
-        let inner = text_run("T1", 0, 50, Some("T0"), Polarity::Inherit, Modality::Inherit);
-        let leaf = fact_leaf(
-            "F1",
-            0,
-            50,
-            Some("T1"),
-            Polarity::Inherit,
-            Modality::Inherit,
-        );
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![outer, inner, leaf],
-        };
-        let r = check_propagation(&ir);
-        assert!(r.pass());
-        assert!(r.warnings.is_empty());
-    }
-
-    /// Legitimate override case: parent Denied with siblings inheriting
-    /// Denied + one sibling explicitly Affirmed.
-    #[test]
-    fn list_of_denials_with_one_affirmation_emits_one_warning() {
-        let parent = text_run("T0", 0, 100, None, Polarity::Denied, Modality::Present);
-        let c1 = fact_leaf("F1", 0, 25, Some("T0"), Polarity::Inherit, Modality::Inherit);
-        let c2 = fact_leaf("F2", 25, 50, Some("T0"), Polarity::Inherit, Modality::Inherit);
-        let c3 = fact_leaf("F3", 50, 75, Some("T0"), Polarity::Inherit, Modality::Inherit);
-        // The one explicit Affirmed amid the implicit Denieds.
-        let c4 = fact_leaf("F4", 75, 100, Some("T0"), Polarity::Affirmed, Modality::Present);
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![parent, c1, c2, c3, c4],
-        };
-        let r = check_propagation(&ir);
-        assert!(r.pass());
-        // Exactly one override warning (on F4); modality is Present
-        // which matches the parent's effective Present, so no modality
-        // warning. c1..c3 inherit cleanly.
-        let polarity_overrides = r.warnings.iter().filter(|w| matches!(
-            w,
-            PropagationWarning::LeafOverridesAncestorPolarity { .. }
-        )).count();
-        assert_eq!(polarity_overrides, 1, "warnings: {:?}", r.warnings);
-    }
-
-    /// TextRun nodes themselves don't generate override warnings —
-    /// only leaves do.
-    #[test]
-    fn textrun_does_not_emit_override_warnings() {
-        let outer = text_run("T0", 0, 50, None, Polarity::Denied, Modality::Present);
-        // Child TextRun that overrides; should not emit a warning
-        // (only leaves do).
-        let inner = text_run(
-            "T1",
-            0,
-            50,
-            Some("T0"),
-            Polarity::Affirmed,
-            Modality::Present,
-        );
-        let leaf = fact_leaf(
-            "F1",
-            0,
-            50,
-            Some("T1"),
-            Polarity::Inherit,
-            Modality::Inherit,
-        );
-        let ir = IRDocument {
-            document_id: doc_id(),
-            nodes: vec![outer, inner, leaf],
-        };
-        let r = check_propagation(&ir);
-        assert!(r.pass());
-        // Leaf F1's effective polarity is Affirmed (inherits from T1
-        // which overrode T0). Since F1 declared Inherit, no warning
-        // — the warning would only fire if F1 itself declared a
-        // non-Inherit value disagreeing with T1.
-        assert!(
-            r.warnings.is_empty(),
-            "intermediate TextRun overrides should not generate warnings: {:?}",
-            r.warnings
-        );
-    }
-
-    /// Discarded nodes are skipped from the check.
-    #[test]
-    fn discarded_nodes_are_skipped() {
-        let parent = text_run("T0", 0, 30, None, Polarity::Denied, Modality::Present);
-        // A Discarded node with Affirmed (which would override
-        // ancestor's Denied if checked) is skipped per ADJ03.
-        let discard = IRNode {
-            id: NodeId::new("D1"),
-            kind: NodeKind::Discarded,
-            term: atom("discarded"),
+    fn contains(id: &str, source: &str, target: &str) -> IREdge {
+        IREdge {
+            id: EdgeId::new(id),
+            source: NodeId::new(source),
+            target: NodeId::new(target),
+            relation: EdgeRelation::Contains,
             polarity: Polarity::Affirmed,
             modality: Modality::Present,
-            source_spans: vec![span_of(0, 30)],
+            source_spans: vec![],
             confidence: 1.0,
-            part_of: Some(NodeId::new("T0")),
-            lowered_from: None,
-            discard_reason: Some(adjudication_ir::DiscardReason::Pleasantry),
-            metadata: HashMap::new(),
-        };
-        let ir = IRDocument {
+            metadata: Map::new(),
+        }
+    }
+
+    #[test]
+    fn empty_doc_passes() {
+        let doc = IRDocument {
             document_id: doc_id(),
-            nodes: vec![parent, discard],
+            nodes: vec![],
+            edges: vec![],
         };
-        let r = check_propagation(&ir);
-        assert!(r.pass());
-        assert!(r.warnings.is_empty());
+        let result = check_propagation(&doc);
+        assert!(result.violations.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn section_with_inherit_child_resolves_via_contains() {
+        // Section (Denied) → Contains → Fact (Inherit polarity).
+        let s = section("S1", 0, 5, Polarity::Denied, Modality::Present);
+        let mut f = fact("F1", 5, 10, Polarity::Inherit, Modality::Present);
+        let doc = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![s, f],
+            edges: vec![contains("E1", "S1", "F1")],
+        };
+        let r = check_propagation(&doc);
+        assert!(r.pass(), "expected pass, got {:?}", r);
+    }
+
+    #[test]
+    fn leaf_override_emits_warning() {
+        // Section (Denied) → Contains → Fact (Affirmed). Concrete
+        // override; should warn but not violate.
+        let s = section("S1", 0, 5, Polarity::Denied, Modality::Present);
+        let f = fact("F1", 5, 10, Polarity::Affirmed, Modality::Present);
+        let doc = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![s, f],
+            edges: vec![contains("E1", "S1", "F1")],
+        };
+        let r = check_propagation(&doc);
+        assert!(r.pass(), "expected violations empty");
+        let has_warning = r.warnings.iter().any(|w| {
+            matches!(
+                w,
+                PropagationWarning::LeafOverridesAncestorPolarity {
+                    declared: Polarity::Affirmed,
+                    ancestor: Polarity::Denied,
+                    ..
+                }
+            )
+        });
+        assert!(has_warning, "expected polarity override warning: {:?}", r.warnings);
+    }
+
+    #[test]
+    fn ruledout_with_non_affirmed_polarity_violates() {
+        // A Fact with RuledOut modality and Denied polarity is a hard
+        // ADJ01 violation.
+        let f = fact("F1", 0, 10, Polarity::Denied, Modality::RuledOut);
+        let doc = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![f],
+            edges: vec![],
+        };
+        let r = check_propagation(&doc);
+        let has_v = r.violations.iter().any(|v| {
+            matches!(v, PropagationViolation::RuledOutMustBeAffirmed { .. })
+        });
+        assert!(has_v, "expected RuledOutMustBeAffirmed: {:?}", r);
+    }
+
+    #[test]
+    fn inherit_without_parent_violates() {
+        // Fact with Inherit polarity, no Contains parent.
+        let mut f = fact("F1", 0, 10, Polarity::Inherit, Modality::Present);
+        // Suppress the Discarded-related coverage error by also
+        // ensuring the doc isn't structurally broken otherwise; F1
+        // alone tiles [0, 10).
+        f.kind = NodeKind::Fact;
+        let doc = IRDocument {
+            document_id: doc_id(),
+            nodes: vec![f],
+            edges: vec![],
+        };
+        let r = check_propagation(&doc);
+        // Either InheritWithoutParent or UpstreamValidationError —
+        // both are gating.
+        assert!(!r.pass());
     }
 }

--- a/code/packages/rust/adjudication-round-trip/src/lib.rs
+++ b/code/packages/rust/adjudication-round-trip/src/lib.rs
@@ -449,8 +449,6 @@ mod tests {
             modality: Modality::Present,
             source_spans: vec![Span::new(DocumentId::new("doc1"), start, end)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         }
@@ -460,6 +458,7 @@ mod tests {
         IRDocument {
             document_id: DocumentId::new("doc1"),
             nodes,
+            edges: Vec::new(),
         }
     }
 
@@ -473,7 +472,7 @@ mod tests {
         // ignores them. A document with only TextRuns yields zero
         // violations and zero LLM calls.
         let mut n = fact("g", Term::Atom("group".into()), 0, 5);
-        n.kind = NodeKind::TextRun;
+        n.kind = NodeKind::Section;
         let g = GatewayConfig::new();
         let r = check_round_trip(make_doc(), &ir(vec![n]), &g, &CheckOptions::default()).unwrap();
         assert!(r.violations.is_empty());

--- a/code/packages/rust/adjudication-tsa-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/lib.rs
@@ -751,6 +751,7 @@ fn json_to_ir_document(
         IRDocument {
             document_id,
             nodes,
+            edges: Vec::new(),
         },
         warnings,
     ))
@@ -820,18 +821,13 @@ fn flatten_nodes(
         }
     };
     *idx_counter += 1;
-    if node.part_of.is_none() {
-        node.part_of = parent.cloned();
-    }
-    // Clear any stale part_of pointer; the LLM may have produced one
-    // referencing a parent we dropped during flattening. ADJ01 v2
-    // requires part_of to point to an existing node — better to
-    // drop a stale pointer than leave a dangling reference.
-    if let Some(p) = &node.part_of {
-        if !out.iter().any(|n| n.id == *p) {
-            node.part_of = None;
-        }
-    }
+    // ADJ01 v3: structural parents are now expressed via `Contains`
+    // edges, not a `part_of` field. The decompose_text v4 prompt
+    // (follow-up PR) will teach the LLM to emit those edges directly.
+    // Until then, this flattening path drops the v2 parent-pointer
+    // logic and lets the resulting IR be a flat list of leaves —
+    // coverage will tile if the leaves collectively span the source.
+    let _ = parent; // suppress unused-var warning
     out.push(node);
 }
 
@@ -844,8 +840,6 @@ fn synth_query_node(document_id: &DocumentId) -> IRNode {
         modality: Modality::Present,
         source_spans: Vec::new(),
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: {
             let mut m = std::collections::HashMap::new();
@@ -957,14 +951,6 @@ fn json_to_ir_node(
             .get("confidence")
             .and_then(|x| x.as_f64())
             .unwrap_or(1.0),
-        part_of: obj
-            .get("part_of")
-            .and_then(|x| x.as_str())
-            .map(|s| NodeId::new(s.to_string())),
-        lowered_from: obj
-            .get("lowered_from")
-            .and_then(|x| x.as_str())
-            .map(|s| NodeId::new(s.to_string())),
         discard_reason: None,
         metadata: Default::default(),
     })
@@ -972,13 +958,17 @@ fn json_to_ir_node(
 
 fn parse_node_kind(s: &str) -> Option<NodeKind> {
     match s.to_ascii_lowercase().as_str() {
-        "textrun" | "text_run" => Some(NodeKind::TextRun),
+        // ADJ01 v3: "textrun" inputs (legacy LLM responses) map to
+        // Section. The decompose_text v4 prompt will teach the LLM to
+        // emit "section" directly with a proper structural term.
+        "textrun" | "text_run" | "section" => Some(NodeKind::Section),
         "fact" => Some(NodeKind::Fact),
         "query" => Some(NodeKind::Query),
         "uncertainty" => Some(NodeKind::Uncertainty),
         "rule" => Some(NodeKind::Rule),
         "exception" => Some(NodeKind::Exception),
         "discarded" => Some(NodeKind::Discarded),
+        "entity" => Some(NodeKind::Entity),
         _ => None,
     }
 }
@@ -1324,8 +1314,6 @@ pub fn tsa_ir_document(source_text: &str) -> IRDocument {
             modality: Modality::Present,
             source_spans: vec![Span::new(doc_id.clone(), 0, 16)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -1337,8 +1325,6 @@ pub fn tsa_ir_document(source_text: &str) -> IRDocument {
             modality: Modality::Present,
             source_spans: vec![Span::new(doc_id.clone(), 16, 24)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -1351,8 +1337,6 @@ pub fn tsa_ir_document(source_text: &str) -> IRDocument {
             modality: Modality::Present,
             source_spans: vec![Span::new(doc_id.clone(), 0, len)],
             confidence: 1.0,
-            part_of: None,
-            lowered_from: None,
             discard_reason: None,
             metadata: Default::default(),
         });
@@ -1366,8 +1350,6 @@ pub fn tsa_ir_document(source_text: &str) -> IRDocument {
         modality: Modality::Present,
         source_spans: vec![],
         confidence: 1.0,
-        part_of: None,
-        lowered_from: None,
         discard_reason: None,
         metadata: Default::default(),
     });
@@ -1375,6 +1357,7 @@ pub fn tsa_ir_document(source_text: &str) -> IRDocument {
     IRDocument {
         document_id: doc_id,
         nodes,
+        edges: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

Rewrites \`adjudication-ir\` to implement [ADJ01 v3](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/ADJ01-adjudication-ir-grammar.md): a multi-directed acyclic graph IR with typed edges, replacing v2's hierarchical decomposition tree. The closed-set \`EdgeRelation\` enum organizes 30+ relations into eleven groups plus a \`DomainSpecific(name)\` escape hatch.

## What the validator now checks (all 9 invariants from ADJ01 v3)

1. Node-kind constraints
2. Edge well-formedness (endpoints exist, relation legal, no self-loops, \`Inherit\` rejected on edges, \`DomainSpecific\` name collision against the closed-set names)
3. Identifier uniqueness for nodes and edges separately
4. Span validity
5. **Coverage** — flat tile of \`(nodes ∪ edges).source_spans\` against \`[0, max_end)\`, with synthesized-object exemption (empty-span Query, Entity, and synthesized edges)
6. **Acyclicity** — iterative three-color DFS across all edge relations
7. **Propagation consistency** — multi-parent \`Contains\` agreement on \`Inherit\` polarity/modality
8. Per-relation endpoint-kind constraints (e.g., \`Excepts: Exception → Rule\`)
9. Exception attachment — every Exception has an outgoing \`Excepts\` edge

## Stack-safety hardening

Both \`check_acyclicity\` and the \`Contains\`-chain walk in \`resolve_effective\` are **iterative**. The latter was recursive in the initial draft; the security review caught it as a DoS vector — a long linear \`Contains\` chain (~40K nodes was enough to overflow the 8 MB main-thread stack) would crash the validator. The iterative form trades heap-\`Vec\` growth for graceful allocation failure rather than a process abort.

## Workspace consequence

v2 types are gone, so every crate that depended on the old IR (\`adjudication-coverage\`, \`adjudication-polarity-modality\`, \`adjudication-round-trip\`, \`adjudication-adversarial\`, \`adjudication-connector\`, \`adjudication-pipeline\`, \`adjudication-clinical-demo\`, \`adjudication-contract-demo\`, \`adjudication-tsa-demo\`) is **temporarily commented out** of the workspace \`members\` list. \`adjudication-audit-trail\`, \`adjudication-clarification\`, and \`llm-primitives\` reference IR only in doc strings and continue to build clean.

The exclusion is documented inline with the migration plan; each consumer gets its own follow-up PR.

## Migration sequence (follow-up PRs)

| # | Crate | What changes |
|---|---|---|
| 1 | \`adjudication-coverage\` | ADJ02 v3: flat tile + DAG check |
| 2 | \`adjudication-polarity-modality\` | ADJ03 v3: propagation along \`Contains\` |
| 3 | \`adjudication-connector\` | edge lowering to Prolog clauses |
| 4 | \`adjudication-round-trip\` | ADJ04 v3: graph rendering |
| 5 | \`adjudication-adversarial\` | ADJ05 v3 |
| 6 | \`adjudication-pipeline\` | orchestrator wiring |
| 7 | \`llm-primitives\` (\`decompose_text\` v4) | teach the LLM to emit edges |
| 8 | demos (TSA, clinical, contract) | migrate to v3 IR |
| 9 | \`adjudication-rulebook\` (new) | ADJ14 implementation against v3 |

Each re-adds its crate to the workspace \`members\` list as it migrates.

## Test plan

- [x] 26 unit tests in \`adjudication-ir\` — all pass; cover every \`ValidationError\` variant, the synthesized-object exemption, multi-parent propagation conflict, \`DomainSpecific\` name collision, \`Clarifies\` kind compatibility, adjacency helpers, and a worked TSA-style example end-to-end
- [x] \`adjudication-audit-trail\`, \`adjudication-clarification\`, \`llm-primitives\` still build clean
- [x] Security review passed (round 1 found a stack-overflow vector in \`resolve_effective\`; round 2 verified the iterative fix)
- [ ] Wait for CI green
- [ ] Follow-up PRs land each excluded consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)