### PR TITLE
Render MACSYMA display2d output in Rust

### DIFF
--- a/code/packages/rust/macsyma-runtime/BUILD
+++ b/code/packages/rust/macsyma-runtime/BUILD
@@ -1,1 +1,1 @@
-cargo test -p cas-list-operations -p cas-solve -p cas-substitution -p coding-adventures-macsyma-runtime -- --nocapture
+cargo test -p cas-list-operations -p cas-pretty-printer -p cas-solve -p cas-substitution -p coding-adventures-macsyma-runtime -- --nocapture

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Routed `ev(expr, display2d)` result presentation through the Rust
+  `cas-pretty-printer` 2D MACSYMA box renderer while preserving the symbolic IR
+  result for history and downstream evaluation.
 - Wired `TrigReduce(expr)` and `ev(expr, trigreduce)` to the Rust `cas-trig`
   power-reduction walker.
 - Wired `Subst(value, variable, expr)` to the Rust `cas-substitution`

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [dependencies]
 cas-list-operations = { path = "../cas-list-operations" }
+cas-pretty-printer = { path = "../cas-pretty-printer" }
 cas-solve = { path = "../cas-solve" }
 cas-simplify = { path = "../cas-simplify" }
 cas-substitution = { path = "../cas-substitution" }

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -11,6 +11,7 @@ use cas_list_operations::{
     append, apply_ as list_apply, first, flatten, join, last, length, map_ as list_map, part,
     range_ as list_range, rest, reverse, sort_, ListOperationError, ListResult,
 };
+use cas_pretty_printer::{pretty, pretty_2d, MacsymaDialect};
 use cas_simplify::simplify;
 use cas_solve::{solve_linear_system, try_solve_inequality, try_solve_transcendental, SOLVE};
 use cas_substitution::subst;
@@ -223,6 +224,8 @@ pub struct EvalResult {
     pub input: IRNode,
     /// The evaluated output expression.
     pub output: IRNode,
+    /// Presentation text selected by MACSYMA display flags.
+    pub output_text: String,
     /// Whether this statement should be shown by a REPL. `;` displays, `$`
     /// suppresses.
     pub display: bool,
@@ -503,6 +506,7 @@ impl MacsymaSession {
         let kill_all = is_kill_all(&input);
         let output = self.vm.eval(resolved_input);
         let output_index = self.history.record_output(output.clone());
+        let output_text = display_text_for(&input, &output);
         if kill_all {
             self.history.reset();
         }
@@ -511,6 +515,7 @@ impl MacsymaSession {
             output_index,
             input,
             output,
+            output_text,
             display,
         }
     }
@@ -791,6 +796,26 @@ fn numer_fold(node: IRNode) -> IRNode {
             apply_node(head, args.into_iter().map(numer_fold).collect())
         }
         other => other,
+    }
+}
+
+fn display_text_for(input: &IRNode, output: &IRNode) -> String {
+    if has_ev_flag(input, "display2d") {
+        pretty_2d(output, &MacsymaDialect)
+    } else {
+        pretty(output, &MacsymaDialect)
+    }
+}
+
+fn has_ev_flag(input: &IRNode, flag: &str) -> bool {
+    match input {
+        IRNode::Apply(apply) if is_head_name(&apply.head, EV) => apply
+            .args
+            .iter()
+            .skip(1)
+            .filter_map(symbol_name)
+            .any(|name| name.eq_ignore_ascii_case(flag)),
+        _ => false,
     }
 }
 

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -213,6 +213,23 @@ fn ev_routes_supported_flags_and_preserves_unsupported_heads() {
 }
 
 #[test]
+fn ev_display2d_routes_output_text_through_box_pretty_printer() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("ev(1/(x + 1), display2d);").unwrap();
+
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(DIV),
+            vec![int(1), apply(sym(ADD), vec![sym("x"), int(1)])]
+        )
+    );
+    assert!(results[0].output_text.contains('\n'));
+    assert!(results[0].output_text.contains('─'));
+    assert!(results[0].output_text.contains("x + 1"));
+}
+
+#[test]
 fn trigreduce_routes_through_macsyma_runtime() {
     let mut session = MacsymaSession::new();
     let results = session

--- a/code/packages/rust/macsyma-wasm/src/lib.rs
+++ b/code/packages/rust/macsyma-wasm/src/lib.rs
@@ -139,7 +139,7 @@ impl JsonEvalResult {
             output_index: result.output_index,
             display: result.display,
             input_macsyma: pretty(&result.input, &MacsymaDialect),
-            output_macsyma: pretty(&result.output, &MacsymaDialect),
+            output_macsyma: result.output_text,
             input_lisp: format_lisp(&result.input),
             output_lisp: format_lisp(&result.output),
             input_ir: JsonIrNode::from_ir(&result.input),
@@ -302,6 +302,19 @@ mod tests {
         assert_eq!(output["head"]["name"], "Mul");
         assert_eq!(output["args"][0]["name"], "x");
         assert_eq!(payload["results"][0]["output_lisp"], "(Mul x (Pow y 2))");
+    }
+
+    #[test]
+    fn uses_runtime_display_text_for_display2d() {
+        let payload = json(&eval_source_json("ev(1/(x + 1), display2d);"));
+        let output = payload["results"][0]["output_macsyma"]
+            .as_str()
+            .expect("output_macsyma should be string");
+
+        assert!(output.contains('\n'));
+        assert!(output.contains('─'));
+        assert!(output.contains("x + 1"));
+        assert_eq!(payload["visible_outputs"][0], output);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route Rust `ev(expr, display2d)` presentation through the MACSYMA 2D box pretty-printer
- keep evaluated symbolic IR unchanged while adding display text to runtime results
- make the Rust WASM JSON facade use runtime-provided display text for visible outputs

## Validation
- `CARGO_INCREMENTAL=0 cargo test -j1 -p cas-pretty-printer -p coding-adventures-macsyma-runtime -p coding-adventures-macsyma-wasm` in `code/packages/rust`
- `cargo fmt -p coding-adventures-macsyma-runtime -p coding-adventures-macsyma-wasm` in `code/packages/rust`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-macsyma-display2d.json` from `code/programs/go/build-tool`