### PR TITLE
feat(llm-primitives): decompose_text v4 prompt teaches the graph IR

### DIFF
--- a/code/packages/rust/llm-primitives/CHANGELOG.md
+++ b/code/packages/rust/llm-primitives/CHANGELOG.md
@@ -2,6 +2,94 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2026-05-12
+
+### Changed (breaking on-the-wire shape)
+
+`decompose_text` system prompt bumped to **`decompose-text-v4`** to
+teach the LLM the multi-directed acyclic graph IR shape introduced
+in [ADJ01 v3](../../specs/ADJ01-adjudication-ir-grammar.md). The
+JSON response now has **two top-level arrays**:
+
+```jsonc
+{
+  "document_id": "...",
+  "nodes": [ /* IRNode objects */ ],
+  "edges": [ /* IREdge objects, REQUIRED, at minimum [] */ ]
+}
+```
+
+#### What changed about nodes
+
+- `NodeKind` drops `TextRun`; adds `Section` (a structural unit
+  whose `term` names the unit type — `paragraph(_)`, `sentence(_)`,
+  `table(_)`, `row(_)`, `cell(_)`, `heading(_)`, …) and `Entity` (a
+  deduplicated reference target with possibly-empty `source_spans`).
+- `IRNode` drops the `part_of` and `lowered_from` fields; structural
+  parents now live in `Contains` edges and clarification lineage in
+  `Clarifies` edges.
+- A Section's `source_spans` cover only the meta-text (heading,
+  numbering, delimiters), **not** the content; the content lives in
+  other nodes reached via `Contains` edges.
+- `Inherit` polarity / modality is valid **only** on nodes that have
+  at least one incoming `Contains` edge.
+
+#### What's new about edges
+
+- Closed-set `relation` taxonomy with 30+ variants in eleven
+  groups, listed verbatim in the prompt: Structural, Identity, Rule
+  modification, Application, Provenance, Tabular, Temporal,
+  Cross-source, Discourse, Refinement, plus an inherent escape via
+  `Refers` + metadata when nothing fits (the prompt asks the model
+  not to invent new relation names).
+- Edges carry `source`, `target`, `relation`, `polarity`, `modality`,
+  `source_spans`, and `confidence`. Their `source_spans` cover the
+  *textual marker* that signals the relation (`except`, `see §5`,
+  the comma between list items), not the spans of the related
+  nodes themselves. Synthesized edges carry empty `source_spans`.
+
+#### Coverage rule
+
+- The flat tile now covers `(nodes ∪ edges).source_spans` rather
+  than only nodes. Every byte from 0 to `len(SOURCE_bytes)` must
+  appear in exactly one `source_span` across both arrays —
+  synthesized objects (Query / Entity / spanless edges) are exempt.
+- The model can choose, byte by byte, whether a connective belongs
+  to a node or to an edge.
+
+#### Worked example
+
+The prompt includes a complete v4 worked example for the canonical
+`\"1 carry-on bag, matches.\"` source (24 bytes):
+
+- N1 Fact `carry_on(1)` spans `[0, 14)`
+- N2 Fact `prohibited(matches)` spans `[16, 23)`
+- S1 Section `sentence` spans `[14, 16) ∪ [23, 24)` (the comma and
+  the trailing period)
+- Q1 Query synthesized
+- E1, E2 `Contains` edges from S1 to N1 and N2 (empty spans)
+
+Coverage: `[0,14) + [14,16) + [16,23) + [23,24) = [0, 24)`. ✓
+
+#### Other rules
+
+- Exception nodes MUST be the source of at least one `Excepts`
+  edge — re-states what the validator already enforces, but having
+  it in the prompt cuts down on ADJ06 round-trips.
+- Acyclicity: the graph (nodes, edges) MUST be a DAG across ALL
+  relations. The prompt forbids self-loops and transitive cycles
+  uniformly; the validator catches anything the model misses.
+- The Banff-magnet punctuation rule (rule 18 in v4, was rule 11 in
+  v3) is preserved verbatim.
+
+### Audit-trail impact
+
+Every `LlmCallRecord.prompt_version` for `decompose_text` now reads
+`\"decompose-text-v4\"`. Cached responses keyed on
+`(prompt_version, prompt_hash)` from v3 will miss and re-run — the
+model is being asked to produce a fundamentally different shape so
+the misses are intentional.
+
 ## [0.9.0] - 2026-05-12
 
 ### Changed

--- a/code/packages/rust/llm-primitives/Cargo.toml
+++ b/code/packages/rust/llm-primitives/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "llm-primitives"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
-description = "LM00b — typed LLM primitives layer. v0.9 bumps the decompose_text prompt to v3 with an explicit punctuation/delimiter awareness rule (the `Let's eat, Bob` rule): commas, periods, quotes, and colons can flip meaning, so the model is told to scan them before assigning a term, and to prefer an Uncertainty node when punctuation is load-bearing or ambiguous."
+description = "LM00b — typed LLM primitives layer. v0.10 bumps the decompose_text prompt to v4 to teach the LLM the multi-directed acyclic graph IR shape from ADJ01 v3: the response now has top-level `nodes` and `edges` arrays, edges carry a typed `relation` from a closed taxonomy (Contains, Mentions, Excepts, Cites, RowOf, etc.), nodes drop `part_of`/`lowered_from` (replaced by Contains/Clarifies edges), and node kinds add Section (structural unit) and Entity (deduplicated reference target) while dropping TextRun. Includes a worked example showing both arrays end-to-end."
 
 [dependencies]
 llm-gateway = { path = "../llm-gateway" }

--- a/code/packages/rust/llm-primitives/src/decompose_text.rs
+++ b/code/packages/rust/llm-primitives/src/decompose_text.rs
@@ -84,7 +84,9 @@ pub struct DecomposeTextResponse {
 
 const SYSTEM_PROMPT: &str = "\
 You are a precise document-to-IR extractor. Given a SOURCE document \
-and a DOMAIN hint, produce a FLAT JSON document with this exact shape:\n\
+and a DOMAIN hint, produce a JSON document with TWO top-level \
+collections — `nodes` (typed claims) and `edges` (typed relationships) \
+— in this exact shape:\n\
 \n\
 {\n\
   \"document_id\": \"<copy DOCUMENT_ID verbatim>\",\n\
@@ -96,6 +98,18 @@ and a DOMAIN hint, produce a FLAT JSON document with this exact shape:\n\
       \"polarity\":     \"Affirmed\",\n\
       \"modality\":     \"Present\",\n\
       \"source_spans\": [ { \"start\": 0, \"end\": 16 } ]\n\
+    },\n\
+    ...\n\
+  ],\n\
+  \"edges\": [\n\
+    {\n\
+      \"id\":           \"E1\",\n\
+      \"source\":       \"<source NodeId>\",\n\
+      \"target\":       \"<target NodeId>\",\n\
+      \"relation\":     \"<relation name>\",\n\
+      \"polarity\":     \"Affirmed\",\n\
+      \"modality\":     \"Present\",\n\
+      \"source_spans\": [ { \"start\": 14, \"end\": 16 } ]\n\
     },\n\
     ...\n\
   ]\n\
@@ -110,48 +124,127 @@ Correct output:\n\
     { \"id\": \"N1\", \"kind\": \"Fact\",\n\
       \"term\": { \"functor\": \"carry_on\", \"args\": [ { \"atom\": \"1\" } ] },\n\
       \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
-      \"source_spans\": [ { \"start\": 0, \"end\": 16 } ] },\n\
+      \"source_spans\": [ { \"start\": 0, \"end\": 14 } ] },\n\
     { \"id\": \"N2\", \"kind\": \"Fact\",\n\
       \"term\": { \"functor\": \"prohibited\", \"args\": [ { \"atom\": \"matches\" } ] },\n\
       \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
-      \"source_spans\": [ { \"start\": 16, \"end\": 24 } ] },\n\
+      \"source_spans\": [ { \"start\": 16, \"end\": 23 } ] },\n\
+    { \"id\": \"S1\", \"kind\": \"Section\",\n\
+      \"term\": { \"functor\": \"sentence\", \"args\": [] },\n\
+      \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
+      \"source_spans\": [ { \"start\": 14, \"end\": 16 }, { \"start\": 23, \"end\": 24 } ] },\n\
     { \"id\": \"Q1\", \"kind\": \"Query\",\n\
       \"term\": { \"functor\": \"compliant\", \"args\": [ { \"atom\": \"passenger\" } ] },\n\
+      \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
+      \"source_spans\": [] }\n\
+  ],\n\
+  \"edges\": [\n\
+    { \"id\": \"E1\", \"source\": \"S1\", \"target\": \"N1\",\n\
+      \"relation\": \"Contains\",\n\
+      \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
+      \"source_spans\": [] },\n\
+    { \"id\": \"E2\", \"source\": \"S1\", \"target\": \"N2\",\n\
+      \"relation\": \"Contains\",\n\
       \"polarity\": \"Affirmed\", \"modality\": \"Present\",\n\
       \"source_spans\": [] }\n\
   ]\n\
 }\n\
 \n\
+The Section node owns the connective bytes (the `, ` between N1 and \
+N2, and the trailing `.`). N1 owns the `1 carry-on bag` substring; \
+N2 owns the `matches` substring. The two `Contains` edges record \
+that the Section groups N1 and N2 — semantic structure that the \
+checker passes use. Coverage adds up: N1[0,14] + S1[14,16] + \
+N2[16,23] + S1[23,24] = [0,24).\n\
+\n\
 RULES (every rule is mandatory, no exceptions):\n\
 \n\
-1. **Flat `nodes` array.** Do NOT nest nodes inside a `children` field. \
-Every node is a top-level entry in the `nodes` array.\n\
+## NODE rules\n\
+\n\
+1. **Flat `nodes` array.** Do NOT nest nodes inside a `children` \
+field. Every node is a top-level entry.\n\
 2. **Field names are exact.** Use `kind` (not `node_type`), `term` \
 (not `text`), `source_spans` (not `spans`). Stick to the example.\n\
 3. **`kind` is one of**: `Fact`, `Query`, `Uncertainty`, `Rule`, \
-`Exception`, `Discarded`.\n\
-4. **Spans TILE the source.** The union of all `source_spans` across \
-non-Query nodes must cover every byte from 0 to `len(SOURCE_bytes)` \
-exactly once. No gaps. No overlaps. INCLUDING whitespace and \
-punctuation — assign these to the adjacent Fact's span.\n\
-5. **Spans are byte offsets**, not character indices. `start` and \
-`end` are integers; `0 <= start < end <= len(SOURCE_bytes)`. \
-For ASCII text byte offsets equal character indices.\n\
-6. **Query nodes have empty `source_spans: []`** — they're \
-synthesized questions, not extracted from source. Every IR document \
-should include at least one Query node so the engine has something \
-to answer.\n\
-7. **`polarity` is one of**: `Affirmed`, `Denied`, `Uncertain`, \
-`Inherit`. Default to `Affirmed`.\n\
-8. **`modality` is one of**: `Present`, `Past`, `Future`, `Hypothetical`, \
-`FamilyHistory`, `RuledOut`, `Conditional`, `Inherit`. Default to `Present`.\n\
-9. **`term`** is either `{\"atom\": \"name\"}` for atomic claims or \
+`Exception`, `Discarded`, `Section`, `Entity`.\n\
+   * `Section` is a structural unit (paragraph, sentence, table, \
+row, cell, heading). Its `source_spans` cover ONLY the meta-text \
+of the unit (heading, numbering, delimiters), NOT the content. \
+The content lives in other nodes connected by `Contains` edges.\n\
+   * `Entity` is a deduplicated reference target. When the same \
+atom is mentioned multiple times, emit ONE Entity node (with \
+empty `source_spans` is acceptable since it's synthesized) and \
+emit `Mentions` edges from each mention site to it.\n\
+4. **`polarity` is one of**: `Affirmed`, `Denied`, `Uncertain`, \
+`Inherit`. Default to `Affirmed`. `Inherit` is valid ONLY on nodes \
+that have at least one incoming `Contains` edge (the polarity is \
+inherited from the parent Section).\n\
+5. **`modality` is one of**: `Present`, `Past`, `Future`, \
+`Hypothetical`, `FamilyHistory`, `RuledOut`, `Conditional`, \
+`Inherit`. Default to `Present`.\n\
+6. **`term`** is either `{\"atom\": \"name\"}` for atomic claims or \
 `{\"functor\": \"pred\", \"args\": [...]}` for compound claims. Args \
 recursively use the same term shape.\n\
-10. **`document_id` is the DOCUMENT_ID from the user message, verbatim.**\n\
-11. **Punctuation and delimiters can flip meaning — read them carefully.** \
-A single comma, period, colon, or quote mark can invert the intent \
-of an otherwise-identical string. Two famous examples:\n\
+7. **Query nodes have empty `source_spans: []`** — they're \
+synthesized questions. Entity nodes MAY have empty `source_spans` \
+when synthesized. Every other kind MUST have non-empty \
+`source_spans`.\n\
+\n\
+## EDGE rules\n\
+\n\
+8. **`edges` is required**, at minimum an empty array `[]` for \
+trivial documents. Every relationship between nodes MUST be \
+expressed as an explicit edge; do not encode relationships through \
+node order, term-argument nesting, or metadata strings.\n\
+9. **`relation` is one of** (closed set):\n\
+   * Structural: `Contains`, `Precedes`, `Heading`\n\
+   * Identity: `Mentions`, `SameAs`, `Refers`\n\
+   * Rule modification: `Excepts`, `Refines`, `Generalizes`, \
+`Supersedes`, `Restricts`\n\
+   * Application: `AppliesTo`, `AppliesWhen`, `Concludes`\n\
+   * Provenance: `DerivedFrom`, `JustifiedBy`, `ElicitedFrom`\n\
+   * Tabular: `RowOf`, `ColumnOf`, `HeaderOf`, `CellOf`\n\
+   * Temporal: `Before`, `After`, `During`, `EffectiveAt`, \
+`SupersededAt`\n\
+   * Cross-source: `ConflictsWith`, `Confirms`, `DependsOn`\n\
+   * Discourse: `Defines`, `Restates`, `Cites`\n\
+   * Refinement: `Clarifies`\n\
+   If none of these fit, do not invent a name — use `Refers` and \
+attach metadata.\n\
+10. **Edge `source_spans` cover the TEXTUAL MARKER that signals \
+the relation** — the word `except`, the phrase `see §5`, the \
+comma between list items — NOT the spans of the related nodes. A \
+synthesized edge with no textual marker has `source_spans: []`.\n\
+11. **`Excepts` edges connect Exception nodes to Rule nodes.** \
+Every Exception MUST be the source of at least one `Excepts` edge.\n\
+12. **No cycles.** The graph (nodes, edges) MUST be acyclic across \
+ALL relations. Specifically: an edge cannot point a node back to \
+itself directly or transitively through any other edges.\n\
+\n\
+## COVERAGE rules\n\
+\n\
+13. **Spans TILE the source.** The union of all `source_spans` \
+across nodes and edges must cover every byte from 0 to \
+`len(SOURCE_bytes)` exactly once. No gaps. No overlaps. INCLUDING \
+whitespace and punctuation. Choose how to assign each byte: to a \
+node (the content) or to an edge (the connective marker).\n\
+14. **Spans are byte offsets**, not character indices. `start` and \
+`end` are integers; `0 <= start < end <= len(SOURCE_bytes)`. For \
+ASCII text byte offsets equal character indices.\n\
+15. **Synthesized objects are exempt from tiling**: Query nodes \
+with empty spans, Entity nodes with empty spans, and edges with \
+empty spans (those without a textual marker) do not contribute to \
+the tiling. Use them freely; the validator skips them.\n\
+\n\
+## Other\n\
+\n\
+16. **`document_id` is the DOCUMENT_ID from the user message, \
+verbatim.**\n\
+17. **Every IR document should include at least one Query node** so \
+the engine has something to answer.\n\
+18. **Punctuation and delimiters can flip meaning — read them \
+carefully.** A single comma, period, colon, or quote mark can \
+invert the intent of an otherwise-identical string:\n\
    * `\"Let's eat, Bob.\"` — Bob is being invited to a meal.\n\
    * `\"Let's eat Bob.\"` — Bob is the meal.\n\
 The bytes differ by one comma; the meaning differs by an order \
@@ -168,10 +261,11 @@ backticks.";
 
 const RESPONSE_SCHEMA: &str = r#"{
     "type": "object",
-    "required": ["document_id", "nodes"],
+    "required": ["document_id", "nodes", "edges"],
     "properties": {
         "document_id": { "type": "string", "minLength": 1 },
-        "nodes":       { "type": "array",  "minItems": 0 }
+        "nodes":       { "type": "array",  "minItems": 0 },
+        "edges":       { "type": "array",  "minItems": 0 }
     },
     "additionalProperties": true
 }"#;
@@ -415,7 +509,7 @@ mod tests {
 
         assert_eq!(resp.call_record.primitive, "decompose_text");
         assert_eq!(resp.call_record.role, "extractor");
-        assert_eq!(resp.call_record.prompt_version, "decompose-text-v3");
+        assert_eq!(resp.call_record.prompt_version, "decompose-text-v4");
         assert!(!resp.call_record.prompt_hash.is_empty());
         assert_eq!(resp.call_record.usage.input_tokens, 700);
         assert_eq!(resp.call_record.usage.output_tokens, 320);

--- a/code/packages/rust/llm-primitives/src/lib.rs
+++ b/code/packages/rust/llm-primitives/src/lib.rs
@@ -370,7 +370,7 @@ impl From<LlmError> for PrimitiveError {
 // prompt: every `LlmCallRecord` carries the version, so replay
 // matches `(prompt_version, prompt_hash)`.
 
-pub const DECOMPOSE_TEXT_PROMPT_VERSION: &str = "decompose-text-v3";
+pub const DECOMPOSE_TEXT_PROMPT_VERSION: &str = "decompose-text-v4";
 pub const RENDER_NODE_PROMPT_VERSION: &str = "render-node-v1";
 pub const ENTAIL_PROMPT_VERSION: &str = "entail-v1";
 pub const ADVERSARY_PROMPT_VERSION: &str = "adversary-v1";
@@ -882,7 +882,7 @@ mod tests {
     fn prompt_version_constants_are_stable() {
         // Locking the constants down — bumping any of these is an
         // audit-trail-affecting change and should be a separate PR.
-        assert_eq!(DECOMPOSE_TEXT_PROMPT_VERSION, "decompose-text-v3");
+        assert_eq!(DECOMPOSE_TEXT_PROMPT_VERSION, "decompose-text-v4");
         assert_eq!(RENDER_NODE_PROMPT_VERSION, "render-node-v1");
         assert_eq!(ENTAIL_PROMPT_VERSION, "entail-v1");
         assert_eq!(ADVERSARY_PROMPT_VERSION, "adversary-v1");


### PR DESCRIPTION
## Summary

Bumps the \`decompose_text\` system prompt to **\`decompose-text-v4\`** to match [ADJ01 v3](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/ADJ01-adjudication-ir-grammar.md). The JSON response now carries two top-level arrays — \`nodes\` (typed claims) and \`edges\` (typed relationships) — replacing v3's flat node-only shape.

## What the prompt now teaches

- **JSON shape**: top-level \`edges: [...]\` array is required (empty is fine for trivial docs).
- **NodeKind**: \`TextRun\` is gone; new kinds \`Section\` (structural unit with a meaningful \`term\` like \`paragraph\`, \`sentence\`, \`row\`) and \`Entity\` (deduplicated reference target).
- **IRNode** loses \`part_of\` and \`lowered_from\` — structural parents become \`Contains\` edges, clarification lineage becomes \`Clarifies\` edges.
- **EdgeRelation taxonomy** enumerated verbatim in the prompt, eleven groups, 30+ relations: Structural, Identity, Rule modification, Application, Provenance, Tabular, Temporal, Cross-source, Discourse, Refinement. Closed set — the prompt instructs the model not to invent names.
- **Coverage tile** now spans \`(nodes ∪ edges).source_spans\` against the document. Connectives belong to edges; node content belongs to nodes. Every byte gets one home.
- **Section source_spans cover only the meta-text** (heading, numbering, delimiters), NOT content — content lives in other nodes via \`Contains\` edges.
- **Inherit** polarity/modality valid only on nodes with at least one \`Contains\` parent.
- **Acyclicity**: graph must be a DAG across all relations; no self-loops, no transitive cycles.
- **Exception attachment**: every Exception MUST be source of at least one \`Excepts\` edge — restated in the prompt so the model emits the edge alongside the node.

The Banff-magnet punctuation rule (was rule 11 in v3) is preserved verbatim as rule 18 in v4.

## Worked example

For the canonical \`\"1 carry-on bag, matches.\"\` source (24 bytes):

- \`N1\` Fact \`carry_on(1)\` spans \`[0, 14)\`
- \`N2\` Fact \`prohibited(matches)\` spans \`[16, 23)\`
- \`S1\` Section \`sentence\` spans \`[14, 16) ∪ [23, 24)\` — the comma+space and trailing period
- \`Q1\` Query (synthesized)
- \`E1, E2\` \`Contains\` edges \`S1 → N1\`, \`S1 → N2\`

Coverage: \`[0,14) + [14,16) + [16,23) + [23,24) = [0, 24)\`. ✓

## Audit-trail impact

\`LlmCallRecord.prompt_version\` for \`decompose_text\` now reads \`\"decompose-text-v4\"\`. Cached v3 responses miss and re-run — the model is being asked to produce a fundamentally different shape, so the misses are intentional.

## Test plan

- [x] 72 \`llm-primitives\` tests pass (only the prompt-version-lock and call-record assertions needed updating)
- [x] Security review passed (no executable scaffolding changes; static string + schema constants)
- [ ] CI green
- [ ] Follow-ups: \`adjudication-rulebook\` crate (ADJ14 implementation) and TSA demo wiring with measured before/after on raw-arm hallucinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)