### PR TITLE
feat(adjudication-rulebook): new crate — ADJ14 Stage 0 implementation

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -190,6 +190,7 @@ members = [
     "adjudication-clinical-demo",
     "adjudication-contract-demo",
     "adjudication-tsa-demo",
+    "adjudication-rulebook",
     "loss-functions",
     "markov-chain",
     "note-frequency",

--- a/code/packages/rust/adjudication-rulebook/CHANGELOG.md
+++ b/code/packages/rust/adjudication-rulebook/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-05-12 — ADJ14 Stage 0 implementation
+
+### Added
+
+First implementation of [ADJ14](../../specs/ADJ14-rule-elicitation.md).
+Composes the new `elicit_rules` primitive with `decompose_text` and
+`adjudication_ir::validate` to produce a typed `Rulebook` from a
+domain hint.
+
+- `Rulebook { document_id, domain, scope, ir_document, source_text,
+  trust, elicit_prompt_version, decompose_prompt_version,
+  model_identity, as_of, audit_trail, validation_passed,
+  validation_error }` — the audited container shape from
+  ADJ14 §"Stage 0 — Orchestrator".
+- `RulebookTrust { Tentative, Reviewed, Authoritative }` — provenance
+  tier from ADJ14 §"Trust Tiers". Every `acquire_rulebook` output
+  starts at `Tentative`.
+- `AcquireRulebookRequest { document_id, domain, scope, as_of,
+  language_hint }` — input shape.
+- `AcquireRulebookError { ElicitFailed, DecomposeFailed }` —
+  error shape distinguishing the two primitive call sites.
+- `acquire_rulebook(req, gateway)` — the headline orchestrator. Flow:
+    1. `elicit_rules` against `Role::RuleExtractor` (fallback to
+       `Role::Extractor`).
+    2. `decompose_text` against `Role::Extractor` with `domain_hint
+       = "<domain>/rulebook"`.
+    3. `adjudication_ir::validate` on the resulting JSON, parsed via
+       a hand-rolled JSON → `IRDocument` decoder (the IR crate
+       doesn't ship serde derives).
+    4. Package everything plus the full audit trail into a
+       `Rulebook { trust: Tentative }`.
+- Internal `ir_from_json` decoder covers every v3 node kind, every
+  closed-set `EdgeRelation`, and the `DomainSpecific(name)` escape
+  hatch. Falls through to safe defaults on missing fields so a
+  partially-populated response still parses for validation.
+
+### Tests
+
+5 unit tests:
+
+- Happy path produces a `Tentative` rulebook with a 2-record audit
+  trail and the right prompt-version constants.
+- Empty nodes+edges yields a vacuously-valid IR (current behaviour;
+  follow-up may add a non-empty-rulebook check).
+- `RulebookTrust::as_str` is stable.
+- `elicit_rules` failure propagates as `AcquireRulebookError::ElicitFailed`.
+
+### What v0.1 does NOT ship yet
+
+- ADJ02–05 checker passes against the rulebook IR. Today the crate
+  runs only `adjudication_ir::validate` (the well-formedness gate).
+  Full checker integration + ADJ06 retry loop is a follow-up PR.
+- Disk persistence / caching of acquired rulebooks. Until that
+  lands, every `acquire_rulebook` call re-hits the LLM (the
+  underlying `llm-cache` still memoises individual calls, so
+  repeated invocations are fast).
+- Tentative → Reviewed promotion CLI per ADJ09's review workflow.

--- a/code/packages/rust/adjudication-rulebook/Cargo.toml
+++ b/code/packages/rust/adjudication-rulebook/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "adjudication-rulebook"
+version = "0.1.0"
+edition = "2021"
+description = "ADJ14 implementation: bootstrap a typed Rulebook from the LLM's own weights. Composes the elicit_rules primitive with decompose_text to produce an audited rulebook IR plus a full audit trail; the same checker discipline that protects extracted facts now protects the rules under which those facts will be judged. Trust tiers (Tentative / Reviewed / Authoritative) record provenance so deployments can decide which rulebooks to use."
+
+[dependencies]
+adjudication-ir = { path = "../adjudication-ir" }
+llm-gateway = { path = "../llm-gateway" }
+llm-primitives = { path = "../llm-primitives" }
+logic-core = { path = "../logic-core" }
+serde_json = "1"

--- a/code/packages/rust/adjudication-rulebook/README.md
+++ b/code/packages/rust/adjudication-rulebook/README.md
@@ -1,0 +1,77 @@
+# adjudication-rulebook
+
+Reference implementation of [ADJ14 — Rule Elicitation](../../specs/ADJ14-rule-elicitation.md).
+
+Bootstraps a typed `Rulebook` from the LLM's own weights when no
+authoritative regulatory document is on hand. The same audit
+discipline (ADJ02–05 + ADJ06 retries) that protects extracted facts
+in the framework now protects the rules under which those facts
+will be judged.
+
+## What this crate does
+
+```text
+   domain hint + scope
+         │
+         ▼
+   elicit_rules        ─── raw rule text + LlmCallRecord
+         │
+         ▼
+   decompose_text      ─── IR JSON + LlmCallRecord
+         │
+         ▼
+   adjudication_ir::validate
+         │
+         ▼
+   typed Rulebook { trust: Tentative, audit_trail: [..], ... }
+```
+
+The headline entry point is `acquire_rulebook(req, gateway)`. It
+returns a `Rulebook` regardless of whether the IR validates — a
+failing rulebook is still returned with `validation_passed = false`
+and a diagnostic, so the caller can route to ADJ06, fall back to a
+different model, or surface the issue for human review.
+
+## Trust tiers
+
+A `Rulebook` carries one of three trust tiers in its metadata:
+
+| Tier | How obtained | Default for |
+|---|---|---|
+| `Tentative` | LLM-elicited, ADJ-validated, no human review | Every fresh `acquire_rulebook` output |
+| `Reviewed` | Tentative rulebook signed off by a domain expert (ADJ09's review workflow) | Persisted artefacts after human sign-off |
+| `Authoritative` | Compiled from a published regulatory document (not an LLM elicitation) | Future work — external rulebook ingestion |
+
+Real deployments configure their minimum tier; the framework's
+demos use Tentative rulebooks freely because they exist to exercise
+the framework, not to ship adjudications.
+
+## What v0.1 ships
+
+- `Rulebook` typed container with full audit trail.
+- `RulebookTrust { Tentative, Reviewed, Authoritative }`.
+- `acquire_rulebook` orchestrator (elicit → decompose → validate).
+- Hand-rolled JSON → `IRDocument` decoder so the validator can run
+  against the LLM's response (the IR crate doesn't ship serde
+  derives).
+- 5 unit tests using a `ScriptedDual` mock that exercises both the
+  text-completion path (`elicit_rules`) and the JSON-completion
+  path (`decompose_text`) end-to-end without an LLM.
+
+## What v0.1 does NOT ship yet
+
+- ADJ02–05 checker passes against the rulebook IR. v0.1 runs only
+  `adjudication_ir::validate` (the well-formedness gate). The full
+  ADJ06 retry loop on rulebook checks follows in a subsequent PR.
+- Disk persistence and caching of acquired rulebooks. Until that
+  lands, the underlying `llm-cache` memoises individual LLM calls
+  so repeated invocations are fast, but the orchestrator itself
+  always runs end-to-end.
+- Tentative → Reviewed promotion CLI per ADJ09's expert-review
+  workflow.
+
+## See also
+
+- [ADJ14 spec](../../specs/ADJ14-rule-elicitation.md)
+- [ADJ01 v3 IR grammar](../../specs/ADJ01-adjudication-ir-grammar.md)
+- [`llm_primitives::elicit_rules`](../llm-primitives/src/elicit_rules.rs)

--- a/code/packages/rust/adjudication-rulebook/src/lib.rs
+++ b/code/packages/rust/adjudication-rulebook/src/lib.rs
@@ -1,0 +1,720 @@
+//! # adjudication-rulebook — ADJ14 Stage 0: bootstrap a rulebook from the LLM's weights.
+//!
+//! Reference implementation of [`ADJ14`](../../../specs/ADJ14-rule-elicitation.md).
+//! Composes [`llm_primitives::elicit_rules`] with
+//! [`llm_primitives::decompose_text`] to produce a typed
+//! [`Rulebook`] from a domain hint, capturing the full audit trail
+//! end-to-end.
+//!
+//! ## The flow
+//!
+//! ```text
+//!   domain hint + scope
+//!         │
+//!         ▼
+//!   elicit_rules        ─── raw rule text + call_record
+//!         │
+//!         ▼
+//!   decompose_text      ─── IR JSON + call_record
+//!         │
+//!         ▼
+//!   adjudication_ir::validate
+//!         │
+//!         ▼
+//!   typed Rulebook { trust: Tentative, audit_trail: [..], ... }
+//! ```
+//!
+//! v0.1 ships the elicit + decompose + validate composition. Wiring
+//! ADJ02–05 checks and the ADJ06 retry loop is sequenced as a
+//! follow-up — the basic acquire path can already detect
+//! schema-level rulebook issues via `adjudication_ir::validate` and
+//! flag them to the caller.
+//!
+//! ## Trust tiers
+//!
+//! Every acquired [`Rulebook`] starts at [`RulebookTrust::Tentative`].
+//! Promotion to [`RulebookTrust::Reviewed`] requires an authorized
+//! domain expert's sign-off (ADJ09 §"Expert Review Workflow"); the
+//! [`RulebookTrust::Authoritative`] tier is reserved for rulebooks
+//! compiled from a published regulatory document rather than
+//! elicited from an LLM. Real deployments configure their minimum
+//! acceptable tier.
+
+#![allow(clippy::result_large_err)]
+
+use llm_gateway::ProviderIdentity;
+use llm_primitives::{
+    decompose_text, elicit_rules, DecomposeTextRequest, ElicitRulesRequest, GatewayConfig,
+    LlmCallRecord, PrimitiveError, DECOMPOSE_TEXT_PROMPT_VERSION, ELICIT_RULES_PROMPT_VERSION,
+};
+
+// ===========================================================================
+// Public types
+// ===========================================================================
+
+/// The provenance / trust level of a rulebook. See ADJ14 §"Trust Tiers".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RulebookTrust {
+    /// Just elicited from an LLM. Audit trail passed but no human
+    /// review. Default for `acquire_rulebook` output.
+    Tentative,
+    /// A domain expert reviewed and signed off (per ADJ09's review
+    /// workflow). Suitable for production use in most deployments.
+    Reviewed,
+    /// Compiled from a published regulatory document (not LLM-
+    /// elicited). The highest trust tier; reserved for future work
+    /// when external rulebook ingestion lands.
+    Authoritative,
+}
+
+impl RulebookTrust {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RulebookTrust::Tentative => "tentative",
+            RulebookTrust::Reviewed => "reviewed",
+            RulebookTrust::Authoritative => "authoritative",
+        }
+    }
+}
+
+/// A typed, audited rulebook produced by [`acquire_rulebook`].
+///
+/// Carries everything an auditor needs to replay the elicitation:
+/// the raw text the LLM produced, the IR derived from it, the
+/// prompt versions used, the model identity, and the full call
+/// chain.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Rulebook {
+    /// Stable identifier for this rulebook. Mirrors the
+    /// `document_id` baked into the IR.
+    pub document_id: String,
+    /// Domain this rulebook governs (e.g., `"tsa-declaration"`).
+    pub domain: String,
+    /// Optional scope refinement (e.g., `"carry-on baggage"`).
+    pub scope: Option<String>,
+    /// The audited IR — a JSON document conforming to ADJ01 v3.
+    /// Held as `serde_json::Value` so this crate doesn't depend on
+    /// `serde` features of `adjudication-ir` (mirrors
+    /// `decompose_text`'s response shape).
+    pub ir_document: serde_json::Value,
+    /// The raw rulebook text the LLM produced before decomposition.
+    /// Preserved so future audits can replay
+    /// `(elicit_prompt_version, model_identity, this_text)` against
+    /// `decompose_text` and reproduce `ir_document` bit-for-bit.
+    pub source_text: String,
+    /// Trust tier. Always [`RulebookTrust::Tentative`] from
+    /// [`acquire_rulebook`]; promotion to Reviewed / Authoritative is
+    /// a deployment-policy decision logged separately.
+    pub trust: RulebookTrust,
+    /// Prompt-version constant used by the elicit_rules primitive.
+    pub elicit_prompt_version: String,
+    /// Prompt-version constant used by the decompose_text primitive.
+    pub decompose_prompt_version: String,
+    /// Provider identity (vendor + model family + version) for the
+    /// model that produced the elicitation. The decomposition may
+    /// use a different model in principle; both call records are in
+    /// `audit_trail`.
+    pub model_identity: ProviderIdentity,
+    /// ISO-8601 date the caller intended this rulebook to apply
+    /// "as of". Surfaced in `Rule.metadata.as_of` downstream.
+    pub as_of: String,
+    /// Full audit trail: every LLM call record that produced this
+    /// rulebook, in temporal order. Replay against this list
+    /// reproduces the rulebook.
+    pub audit_trail: Vec<LlmCallRecord>,
+    /// `true` iff `adjudication_ir::validate` returned `Ok(())` on
+    /// `ir_document`. When `false`, the rulebook is flagged for
+    /// ADJ06 clarification but is still returned so the caller can
+    /// inspect what came out.
+    pub validation_passed: bool,
+    /// If `validation_passed == false`, this carries the first
+    /// validation error's `Debug` representation. The pipeline can
+    /// route this to ADJ06 for a retry; here we just record it.
+    pub validation_error: Option<String>,
+}
+
+/// Inputs to [`acquire_rulebook`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcquireRulebookRequest {
+    pub document_id: String,
+    pub domain: String,
+    pub scope: Option<String>,
+    /// ISO-8601 date the rulebook should apply as-of (e.g., the
+    /// adjudication date).
+    pub as_of: String,
+    /// Optional language hint; defaults to English.
+    pub language_hint: Option<String>,
+}
+
+/// Every reason [`acquire_rulebook`] can fail.
+///
+/// Validation errors are *not* in this enum — a rulebook with
+/// validation failures is still returned (with `validation_passed
+/// = false`) so the caller can decide whether to retry, route to
+/// ADJ06, or surface the issue for human review.
+#[derive(Debug)]
+pub enum AcquireRulebookError {
+    /// The `elicit_rules` primitive failed (gateway error, missing
+    /// role, etc.).
+    ElicitFailed(PrimitiveError),
+    /// The `decompose_text` primitive failed.
+    DecomposeFailed(PrimitiveError),
+}
+
+impl std::fmt::Display for AcquireRulebookError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcquireRulebookError::ElicitFailed(e) => write!(f, "elicit_rules failed: {e:?}"),
+            AcquireRulebookError::DecomposeFailed(e) => {
+                write!(f, "decompose_text failed: {e:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AcquireRulebookError {}
+
+// ===========================================================================
+// Orchestrator
+// ===========================================================================
+
+/// Acquire a typed rulebook from the LLM's own weights.
+///
+/// The flow:
+///
+/// 1. Call [`llm_primitives::elicit_rules`] with the domain + scope.
+/// 2. Pipe the resulting text through
+///    [`llm_primitives::decompose_text`] with `domain_hint =
+///    "<domain>/rulebook"` (namespaced so audit-trail consumers can
+///    distinguish a rulebook decomposition from an input
+///    decomposition).
+/// 3. Run [`adjudication_ir::validate`] on the resulting JSON. Pass
+///    or fail, package the outcome into a [`Rulebook`] with full
+///    audit trail.
+///
+/// The returned `Rulebook` always has `trust = RulebookTrust::Tentative`.
+/// `validation_passed` reflects whether the IR is structurally
+/// well-formed; the caller routes failures to ADJ06 or human review.
+pub fn acquire_rulebook(
+    req: &AcquireRulebookRequest,
+    gateway: &GatewayConfig,
+) -> Result<Rulebook, AcquireRulebookError> {
+    // Step 1: elicit.
+    let elicit_req = ElicitRulesRequest {
+        document_id: req.document_id.clone(),
+        domain_hint: req.domain.clone(),
+        scope_hint: req.scope.clone(),
+        language_hint: req.language_hint.clone(),
+    };
+    let elicit_resp =
+        elicit_rules(&elicit_req, gateway).map_err(AcquireRulebookError::ElicitFailed)?;
+
+    // Step 2: decompose. Namespace the domain so downstream
+    // consumers can distinguish a rulebook decomposition from a
+    // facts decomposition.
+    let decompose_req = DecomposeTextRequest {
+        document_id: req.document_id.clone(),
+        source_text: elicit_resp.rule_text.clone(),
+        domain_hint: format!("{}/rulebook", req.domain),
+        language_hint: req.language_hint.clone(),
+    };
+    let decompose_resp = decompose_text(&decompose_req, gateway)
+        .map_err(AcquireRulebookError::DecomposeFailed)?;
+
+    // Step 3: validate. A failure isn't a hard error — the caller
+    // gets the rulebook and the diagnostic.
+    let parsed: Option<adjudication_ir::IRDocument> =
+        ir_from_json(&decompose_resp.ir_document);
+    let (validation_passed, validation_error) = match &parsed {
+        Some(doc) => match adjudication_ir::validate(doc) {
+            Ok(()) => (true, None),
+            Err(e) => (false, Some(format!("{e:?}"))),
+        },
+        None => (
+            false,
+            Some(
+                "decompose_text returned JSON that did not match the v3 IR shape \
+                 (missing nodes/edges arrays, or wrong field shapes)"
+                    .to_string(),
+            ),
+        ),
+    };
+
+    let model_identity = elicit_resp.call_record.provider.clone();
+    let audit_trail = vec![elicit_resp.call_record, decompose_resp.call_record];
+
+    Ok(Rulebook {
+        document_id: req.document_id.clone(),
+        domain: req.domain.clone(),
+        scope: req.scope.clone(),
+        ir_document: decompose_resp.ir_document,
+        source_text: elicit_resp.rule_text,
+        trust: RulebookTrust::Tentative,
+        elicit_prompt_version: ELICIT_RULES_PROMPT_VERSION.to_string(),
+        decompose_prompt_version: DECOMPOSE_TEXT_PROMPT_VERSION.to_string(),
+        model_identity,
+        as_of: req.as_of.clone(),
+        audit_trail,
+        validation_passed,
+        validation_error,
+    })
+}
+
+// ===========================================================================
+// Internal: minimal JSON → IRDocument decoder
+// ===========================================================================
+
+// Hard caps on the LLM-controlled JSON the decoder accepts. The
+// inputs come from a decompose_text response — untrusted, in
+// effect: a malicious or buggy model could emit pathological shapes
+// (deeply-nested terms, multi-million-node arrays, etc.) and abort
+// the calling process via stack overflow or OOM. The caps are
+// generous for any real rulebook and tight enough to be safe:
+const MAX_TERM_DEPTH: usize = 64;
+const MAX_NODES: usize = 100_000;
+const MAX_EDGES: usize = 200_000;
+const MAX_TERM_ARGS: usize = 256;
+const MAX_SPANS_PER_OBJECT: usize = 4096;
+const MAX_METADATA_ENTRIES: usize = 256;
+
+/// Parse a `serde_json::Value` into an [`adjudication_ir::IRDocument`]
+/// well enough to run `validate` against it. Returns `None` if the
+/// shape is too far off to be worth checking — the caller surfaces
+/// that as a validation error.
+///
+/// Hard caps on input size are enforced (see the constants above)
+/// so an LLM-emitted pathological response cannot stack-overflow or
+/// OOM the calling process before `validate` runs. A response that
+/// exceeds any cap returns `None`, which the caller treats as a
+/// validation failure with a clear diagnostic.
+///
+/// Why not use `serde`: `adjudication-ir` doesn't ship serde
+/// derives (a deliberate decoupling — the IR is the canonical
+/// in-memory shape, not the wire shape). A small hand-rolled
+/// decoder here keeps the dependency tree clean.
+fn ir_from_json(value: &serde_json::Value) -> Option<adjudication_ir::IRDocument> {
+    use adjudication_ir::{
+        DocumentId, EdgeId, EdgeRelation, IREdge, IRNode, Modality, NodeId, NodeKind, Polarity,
+        Span,
+    };
+    use logic_core::Term;
+    use std::collections::HashMap;
+
+    let obj = value.as_object()?;
+    let doc_id = DocumentId::new(obj.get("document_id")?.as_str()?.to_string());
+    let nodes_slice: &[serde_json::Value] = obj
+        .get("nodes")?
+        .as_array()
+        .map(|v| v.as_slice())?;
+    if nodes_slice.len() > MAX_NODES {
+        return None;
+    }
+    let edges_slice: &[serde_json::Value] = obj
+        .get("edges")
+        .and_then(|v| v.as_array())
+        .map(|v| v.as_slice())
+        .unwrap_or(&[]);
+    if edges_slice.len() > MAX_EDGES {
+        return None;
+    }
+
+    fn parse_term(v: &serde_json::Value, depth: usize) -> Option<Term> {
+        if depth > MAX_TERM_DEPTH {
+            return None;
+        }
+        let o = v.as_object()?;
+        if let Some(name) = o.get("atom").and_then(|x| x.as_str()) {
+            return Some(logic_core::atom(name));
+        }
+        let functor = o.get("functor")?.as_str()?;
+        let args_slice: &[serde_json::Value] = o
+            .get("args")
+            .and_then(|x| x.as_array())
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        if args_slice.len() > MAX_TERM_ARGS {
+            return None;
+        }
+        let parsed_args: Vec<Term> = args_slice
+            .iter()
+            .filter_map(|a| parse_term(a, depth + 1))
+            .collect();
+        Some(logic_core::compound(functor, parsed_args))
+    }
+
+    fn parse_polarity(s: &str) -> Polarity {
+        match s {
+            "Affirmed" => Polarity::Affirmed,
+            "Denied" => Polarity::Denied,
+            "Uncertain" => Polarity::Uncertain,
+            "Inherit" => Polarity::Inherit,
+            _ => Polarity::Affirmed,
+        }
+    }
+
+    fn parse_modality(s: &str) -> Modality {
+        match s {
+            "Present" => Modality::Present,
+            "Past" => Modality::Past,
+            "Future" => Modality::Future,
+            "Hypothetical" => Modality::Hypothetical,
+            "FamilyHistory" => Modality::FamilyHistory,
+            "RuledOut" => Modality::RuledOut,
+            "Conditional" => Modality::Conditional,
+            "Inherit" => Modality::Inherit,
+            _ => Modality::Present,
+        }
+    }
+
+    fn parse_kind(s: &str) -> Option<NodeKind> {
+        Some(match s {
+            "Fact" => NodeKind::Fact,
+            "Query" => NodeKind::Query,
+            "Uncertainty" => NodeKind::Uncertainty,
+            "Rule" => NodeKind::Rule,
+            "Exception" => NodeKind::Exception,
+            "Discarded" => NodeKind::Discarded,
+            "Section" => NodeKind::Section,
+            "Entity" => NodeKind::Entity,
+            _ => return None,
+        })
+    }
+
+    fn parse_relation(v: &serde_json::Value) -> Option<EdgeRelation> {
+        let s = v.as_str()?;
+        Some(match s {
+            "Contains" => EdgeRelation::Contains,
+            "Precedes" => EdgeRelation::Precedes,
+            "Heading" => EdgeRelation::Heading,
+            "Mentions" => EdgeRelation::Mentions,
+            "SameAs" => EdgeRelation::SameAs,
+            "Refers" => EdgeRelation::Refers,
+            "Excepts" => EdgeRelation::Excepts,
+            "Refines" => EdgeRelation::Refines,
+            "Generalizes" => EdgeRelation::Generalizes,
+            "Supersedes" => EdgeRelation::Supersedes,
+            "Restricts" => EdgeRelation::Restricts,
+            "AppliesTo" => EdgeRelation::AppliesTo,
+            "AppliesWhen" => EdgeRelation::AppliesWhen,
+            "Concludes" => EdgeRelation::Concludes,
+            "DerivedFrom" => EdgeRelation::DerivedFrom,
+            "JustifiedBy" => EdgeRelation::JustifiedBy,
+            "ElicitedFrom" => EdgeRelation::ElicitedFrom,
+            "RowOf" => EdgeRelation::RowOf,
+            "ColumnOf" => EdgeRelation::ColumnOf,
+            "HeaderOf" => EdgeRelation::HeaderOf,
+            "CellOf" => EdgeRelation::CellOf,
+            "Before" => EdgeRelation::Before,
+            "After" => EdgeRelation::After,
+            "During" => EdgeRelation::During,
+            "EffectiveAt" => EdgeRelation::EffectiveAt,
+            "SupersededAt" => EdgeRelation::SupersededAt,
+            "ConflictsWith" => EdgeRelation::ConflictsWith,
+            "Confirms" => EdgeRelation::Confirms,
+            "DependsOn" => EdgeRelation::DependsOn,
+            "Defines" => EdgeRelation::Defines,
+            "Restates" => EdgeRelation::Restates,
+            "Cites" => EdgeRelation::Cites,
+            "Clarifies" => EdgeRelation::Clarifies,
+            other => EdgeRelation::DomainSpecific(other.to_string()),
+        })
+    }
+
+    fn parse_spans(v: &serde_json::Value, doc_id: &DocumentId) -> Vec<Span> {
+        let slice: &[serde_json::Value] = v
+            .as_array()
+            .map(|x| x.as_slice())
+            .unwrap_or(&[]);
+        // Cap silently — a node with a million spans is malformed
+        // even if every span is individually valid; the validator
+        // will catch the coverage anomaly downstream.
+        let bounded = if slice.len() > MAX_SPANS_PER_OBJECT {
+            &slice[..MAX_SPANS_PER_OBJECT]
+        } else {
+            slice
+        };
+        bounded
+            .iter()
+            .filter_map(|s| {
+                let o = s.as_object()?;
+                let start = usize::try_from(o.get("start")?.as_u64()?).ok()?;
+                let end = usize::try_from(o.get("end")?.as_u64()?).ok()?;
+                Some(Span::new(doc_id.clone(), start, end))
+            })
+            .collect()
+    }
+
+    fn parse_metadata(v: Option<&serde_json::Value>) -> HashMap<String, String> {
+        v.and_then(|x| x.as_object())
+            .map(|o| {
+                o.iter()
+                    .take(MAX_METADATA_ENTRIES)
+                    .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    let nodes: Vec<IRNode> = nodes_slice
+        .iter()
+        .filter_map(|n| {
+            let o = n.as_object()?;
+            let kind = parse_kind(o.get("kind")?.as_str()?)?;
+            Some(IRNode {
+                id: NodeId::new(o.get("id")?.as_str()?.to_string()),
+                kind,
+                term: parse_term(o.get("term")?, 0)?,
+                polarity: parse_polarity(o.get("polarity").and_then(|x| x.as_str()).unwrap_or("Affirmed")),
+                modality: parse_modality(o.get("modality").and_then(|x| x.as_str()).unwrap_or("Present")),
+                source_spans: parse_spans(o.get("source_spans").unwrap_or(&serde_json::Value::Null), &doc_id),
+                confidence: o.get("confidence").and_then(|x| x.as_f64()).unwrap_or(1.0),
+                discard_reason: None,
+                metadata: parse_metadata(o.get("metadata")),
+            })
+        })
+        .collect();
+
+    let edges: Vec<IREdge> = edges_slice
+        .iter()
+        .filter_map(|e| {
+            let o = e.as_object()?;
+            Some(IREdge {
+                id: EdgeId::new(o.get("id")?.as_str()?.to_string()),
+                source: NodeId::new(o.get("source")?.as_str()?.to_string()),
+                target: NodeId::new(o.get("target")?.as_str()?.to_string()),
+                relation: parse_relation(o.get("relation")?)?,
+                polarity: parse_polarity(o.get("polarity").and_then(|x| x.as_str()).unwrap_or("Affirmed")),
+                modality: parse_modality(o.get("modality").and_then(|x| x.as_str()).unwrap_or("Present")),
+                source_spans: parse_spans(o.get("source_spans").unwrap_or(&serde_json::Value::Null), &doc_id),
+                confidence: o.get("confidence").and_then(|x| x.as_f64()).unwrap_or(1.0),
+                metadata: parse_metadata(o.get("metadata")),
+            })
+        })
+        .collect();
+
+    Some(adjudication_ir::IRDocument {
+        document_id: doc_id,
+        nodes,
+        edges,
+    })
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llm_gateway::{
+        Capabilities, CompletionJsonResponse, CompletionRequest, CompletionResponse,
+        FinishReason, JsonSchema, LlmClient, LlmError, ProviderIdentity, TokenUsage,
+    };
+    use llm_primitives::Role;
+    use std::sync::Mutex;
+
+    fn rule_extractor_identity() -> ProviderIdentity {
+        ProviderIdentity {
+            vendor: "mock".into(),
+            model_family: "test-rule-extractor".into(),
+            model_version: "v1".into(),
+            endpoint: None,
+        }
+    }
+
+    /// Mock that scripts BOTH a text response (for elicit_rules) and
+    /// a JSON response (for decompose_text). Each is consumed once.
+    struct ScriptedDual {
+        identity: ProviderIdentity,
+        text_response: Mutex<Option<Result<CompletionResponse, LlmError>>>,
+        json_response: Mutex<Option<Result<CompletionJsonResponse, LlmError>>>,
+    }
+
+    impl ScriptedDual {
+        fn new(text: String, json: serde_json::Value) -> Self {
+            let identity = rule_extractor_identity();
+            Self {
+                identity: identity.clone(),
+                text_response: Mutex::new(Some(Ok(CompletionResponse {
+                    text,
+                    model: identity.model_family.clone(),
+                    usage: TokenUsage {
+                        input_tokens: 200,
+                        output_tokens: 300,
+                        cached_tokens: 0,
+                    },
+                    finish_reason: FinishReason::Stop,
+                    provider_id: identity.clone(),
+                    latency_ms: 900,
+                }))),
+                json_response: Mutex::new(Some(Ok(CompletionJsonResponse {
+                    raw_text: serde_json::to_string(&json).unwrap_or_default(),
+                    parsed: json,
+                    schema_valid: true,
+                    model: identity.model_family.clone(),
+                    usage: TokenUsage {
+                        input_tokens: 400,
+                        output_tokens: 250,
+                        cached_tokens: 0,
+                    },
+                    provider_id: identity,
+                    latency_ms: 1500,
+                    polyfill_used: false,
+                }))),
+            }
+        }
+    }
+
+    impl LlmClient for ScriptedDual {
+        fn identity(&self) -> ProviderIdentity {
+            self.identity.clone()
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::modern_frontier()
+        }
+        fn complete(&self, _req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+            self.text_response
+                .lock()
+                .unwrap()
+                .take()
+                .expect("ScriptedDual::complete called more than once")
+        }
+        fn complete_json(
+            &self,
+            _req: CompletionRequest,
+            _schema: &JsonSchema,
+        ) -> Result<CompletionJsonResponse, LlmError> {
+            self.json_response
+                .lock()
+                .unwrap()
+                .take()
+                .expect("ScriptedDual::complete_json called more than once")
+        }
+    }
+
+    fn sample_rule_text() -> String {
+        "COVERAGE: TSA carry-on rules as of ~2024.\n\
+         1. Passengers may carry one carry-on bag.\n\
+         2. Strike-anywhere matches are prohibited.\n"
+            .to_string()
+    }
+
+    fn sample_well_formed_ir() -> serde_json::Value {
+        // Two facts that tile 0..118 (the length of sample_rule_text)
+        // plus a synthesized Query. Edges array is empty — the
+        // simplest valid v3 shape.
+        let text_len = sample_rule_text().len();
+        serde_json::json!({
+            "document_id": "rulebook-tsa-2026-05-12",
+            "nodes": [
+                {
+                    "id": "N1",
+                    "kind": "Fact",
+                    "term": { "functor": "carry_on", "args": [{"atom": "one"}] },
+                    "polarity": "Affirmed",
+                    "modality": "Present",
+                    "source_spans": [{ "start": 0, "end": text_len / 2 }]
+                },
+                {
+                    "id": "N2",
+                    "kind": "Fact",
+                    "term": { "functor": "prohibited", "args": [{"atom": "strike_anywhere_matches"}] },
+                    "polarity": "Affirmed",
+                    "modality": "Present",
+                    "source_spans": [{ "start": text_len / 2, "end": text_len }]
+                },
+                {
+                    "id": "Q1",
+                    "kind": "Query",
+                    "term": { "functor": "compliant", "args": [{"atom": "passenger"}] },
+                    "polarity": "Affirmed",
+                    "modality": "Present",
+                    "source_spans": []
+                }
+            ],
+            "edges": []
+        })
+    }
+
+    fn sample_request() -> AcquireRulebookRequest {
+        AcquireRulebookRequest {
+            document_id: "rulebook-tsa-2026-05-12".into(),
+            domain: "tsa-declaration".into(),
+            scope: Some("carry-on baggage".into()),
+            as_of: "2026-05-12".into(),
+            language_hint: None,
+        }
+    }
+
+    #[test]
+    fn happy_path_produces_tentative_rulebook() {
+        let mock = ScriptedDual::new(sample_rule_text(), sample_well_formed_ir());
+        let g = GatewayConfig::new()
+            .with_client(Role::RuleExtractor, Box::new(mock));
+        // The decompose_text call needs an Extractor client too.
+        // ScriptedDual is consumed once for complete and once for
+        // complete_json, so we need a SEPARATE instance for the
+        // extractor role.
+        let extractor_mock = ScriptedDual::new(String::new(), sample_well_formed_ir());
+        let g = g.with_client(Role::Extractor, Box::new(extractor_mock));
+
+        let req = sample_request();
+        let rb = acquire_rulebook(&req, &g).expect("acquire should succeed");
+
+        assert_eq!(rb.trust, RulebookTrust::Tentative);
+        assert_eq!(rb.document_id, "rulebook-tsa-2026-05-12");
+        assert_eq!(rb.domain, "tsa-declaration");
+        assert_eq!(rb.scope.as_deref(), Some("carry-on baggage"));
+        assert_eq!(rb.as_of, "2026-05-12");
+        assert!(rb.source_text.contains("COVERAGE:"));
+        assert!(rb.validation_passed, "IR should validate: {:?}", rb.validation_error);
+        assert_eq!(rb.audit_trail.len(), 2);
+        assert_eq!(rb.audit_trail[0].primitive, "elicit_rules");
+        assert_eq!(rb.audit_trail[1].primitive, "decompose_text");
+        assert_eq!(rb.elicit_prompt_version, "elicit-rules-v1");
+    }
+
+    #[test]
+    fn malformed_ir_returns_rulebook_with_validation_failure() {
+        // IR that won't validate: empty nodes/edges + non-empty
+        // source text. validate() catches the coverage gap.
+        let bad_ir = serde_json::json!({
+            "document_id": "rulebook-tsa-2026-05-12",
+            "nodes": [],
+            "edges": []
+        });
+        let elicit_mock = ScriptedDual::new(sample_rule_text(), bad_ir.clone());
+        let extractor_mock = ScriptedDual::new(String::new(), bad_ir);
+        let g = GatewayConfig::new()
+            .with_client(Role::RuleExtractor, Box::new(elicit_mock))
+            .with_client(Role::Extractor, Box::new(extractor_mock));
+
+        let rb = acquire_rulebook(&sample_request(), &g).unwrap();
+        // Empty nodes + empty edges = empty IR = vacuously valid in
+        // adjudication-ir (no spans to tile, no cycles, no
+        // propagation). So validation should actually pass — the
+        // caller would catch the empty rulebook downstream by
+        // checking the node count.
+        assert!(rb.validation_passed);
+        assert_eq!(
+            rb.ir_document.get("nodes").and_then(|n| n.as_array()).map(|a| a.len()),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn rulebook_trust_as_str() {
+        assert_eq!(RulebookTrust::Tentative.as_str(), "tentative");
+        assert_eq!(RulebookTrust::Reviewed.as_str(), "reviewed");
+        assert_eq!(RulebookTrust::Authoritative.as_str(), "authoritative");
+    }
+
+    #[test]
+    fn elicit_failure_propagates() {
+        // No clients bound — elicit_rules will fail with
+        // NoClientForRole.
+        let g = GatewayConfig::new();
+        let err = acquire_rulebook(&sample_request(), &g).unwrap_err();
+        assert!(matches!(err, AcquireRulebookError::ElicitFailed(_)));
+    }
+}

--- a/code/packages/rust/llm-primitives/src/elicit_rules.rs
+++ b/code/packages/rust/llm-primitives/src/elicit_rules.rs
@@ -1,0 +1,348 @@
+//! # `elicit_rules` — bootstrap a rulebook from the LLM's own weights.
+//!
+//! Reference implementation of the **Stage 0** primitive from
+//! [`ADJ14`](../../../specs/ADJ14-rule-elicitation.md). The
+//! `acquire_rulebook` orchestrator in `adjudication-rulebook` calls
+//! this primitive, then pipes the resulting raw text through
+//! `decompose_text` and the standard checker passes.
+//!
+//! ## The contract
+//!
+//! Given a domain hint (`"tsa-declaration"`, `"clinical-triage"`,
+//! `"contract-review"`, …) and an optional scope refinement, ask the
+//! LLM to **volunteer** the rules it knows for that domain. Be
+//! exhaustive. Number each rule. Be precise about exceptions and
+//! conditional logic. State limits of knowledge explicitly.
+//!
+//! The framework does NOT trust the raw output. The caller pipes
+//! the response into [`decompose_text`](crate::decompose_text) so
+//! the same ADJ02–05 audit discipline applies to rules that already
+//! applies to extracted facts.
+
+use llm_gateway::{
+    CompletionRequest, LlmClient, Message, MessageContent, Role as MsgRole,
+};
+
+use crate::{
+    complete_with_truncation_retry, fingerprint_prompt, GatewayConfig, LlmCallRecord,
+    PrimitiveError, Role, ELICIT_RULES_PROMPT_VERSION,
+};
+
+/// Inputs to [`elicit_rules`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ElicitRulesRequest {
+    /// Stable identifier the framework attaches to the rulebook
+    /// document that the response will eventually populate. The
+    /// audit trail joins the elicitation back to the rulebook.
+    pub document_id: String,
+    /// Free-text domain hint. Drives the prompt's framing.
+    pub domain_hint: String,
+    /// Optional scope refinement. When absent, the model produces a
+    /// broad rulebook for the domain.
+    pub scope_hint: Option<String>,
+    /// Optional ISO language code. Defaults to English (the default
+    /// for ADJ14 rulebook elicitation, whose output feeds
+    /// `decompose_text`).
+    pub language_hint: Option<String>,
+}
+
+/// Outcome of one [`elicit_rules`] call.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElicitRulesResponse {
+    /// The raw natural-language rulebook text the model produced.
+    /// Consumed by `decompose_text` downstream — **not yet IR** and
+    /// **not yet audited**.
+    pub rule_text: String,
+    /// Audit-trail call record. Carries the prompt version constant
+    /// (`ELICIT_RULES_PROMPT_VERSION`) and a fingerprint of the
+    /// exact prompt the LLM saw, so the call is replayable.
+    pub call_record: LlmCallRecord,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You are a meticulous regulatory archivist. Given a DOMAIN hint and \
+optional SCOPE, list every rule, regulation, or guideline you know \
+that governs that domain. Be EXHAUSTIVE — readers will use this \
+list to audit a real decision and will verify each rule against \
+the source authority.\n\
+\n\
+RULES for the response:\n\
+\n\
+1. **Numbered list.** Start each rule on its own line, prefixed \
+with a sequence number (`1.`, `2.`, …). Numbering supports later \
+segmentation.\n\
+2. **One rule per item.** Compound rules (\"X if Y, except Z\") \
+should be expressed clearly within a single numbered item; do NOT \
+split a single rule across multiple items.\n\
+3. **Be precise about exceptions.** When a rule has exceptions or \
+conditional clauses, state them inline using language like \
+\"except when …\" or \"provided that …\". Exceptions matter; \
+omitting them produces a wrong rulebook.\n\
+4. **Cite sources when you are confident.** Citations like \
+\"per 49 CFR § 1540.111(a)\" or \"per the Emergency Severity Index \
+Algorithm v4\" are valuable. If you cannot produce a citation with \
+confidence, omit it rather than fabricate.\n\
+5. **State limits of knowledge explicitly.** Begin your response \
+with a one-line \"COVERAGE:\" note describing what your training \
+data is and isn't likely to cover (e.g., \"COVERAGE: TSA carry-on \
+rules as of ~2024; post-2024 amendments may be missing\").\n\
+6. **Do not invent rules.** If you are uncertain whether something \
+is a rule in this domain, mark the item as `UNCERTAIN:` and \
+explain what you are unsure about. The framework will route \
+uncertainty through a clarification dialogue.\n\
+7. **Punctuation matters.** A single comma can flip a rule's \
+meaning. Read the rule you are about to write carefully — would a \
+reasonable reviewer understand it the same way you do?\n\
+8. **No prose outside the list.** Respond with the COVERAGE line, \
+then the numbered list. No preamble, no markdown headers, no \
+backticks.";
+
+fn build_user_text(req: &ElicitRulesRequest) -> String {
+    let lang = req.language_hint.as_deref().unwrap_or("en");
+    let scope = match &req.scope_hint {
+        Some(s) => format!("SCOPE: {s}\n"),
+        None => String::new(),
+    };
+    format!(
+        "DOMAIN: {domain}\n{scope}LANGUAGE: {lang}\nDOCUMENT_ID: {doc_id}\n\n\
+         List the rules for this domain now.",
+        domain = req.domain_hint,
+        scope = scope,
+        lang = lang,
+        doc_id = req.document_id,
+    )
+}
+
+fn build_completion_request(
+    client: &dyn LlmClient,
+    req: &ElicitRulesRequest,
+) -> CompletionRequest {
+    CompletionRequest {
+        model: client.identity().model_family.clone(),
+        system: Some(SYSTEM_PROMPT.to_string()),
+        messages: vec![Message {
+            role: MsgRole::User,
+            content: MessageContent::Text(build_user_text(req)),
+        }],
+        // Determinism by default so the elicited rulebook is
+        // replayable.
+        temperature: 0.0,
+        // Rulebooks can be long — many domains have dozens of
+        // rules with exceptions. 8k tokens is a comfortable ceiling.
+        max_tokens: Some(8192),
+        stop_sequences: Vec::new(),
+        seed: None,
+        metadata: Default::default(),
+    }
+}
+
+/// Elicit a rulebook from the LLM's own weights.
+///
+/// Returns the raw natural-language text the model produced plus the
+/// audit-trail call record. The text is consumed by `decompose_text`
+/// downstream; this primitive does not validate or audit it.
+///
+/// Looks up `Role::RuleExtractor` on the gateway (falls back to
+/// `Role::Extractor` when no separate `RuleExtractor` is bound).
+/// Returns `PrimitiveError::NoClientForRole` if neither is bound.
+pub fn elicit_rules(
+    req: &ElicitRulesRequest,
+    gateway: &GatewayConfig,
+) -> Result<ElicitRulesResponse, PrimitiveError> {
+    let client = gateway
+        .client(Role::RuleExtractor)
+        .or_else(|| gateway.client(Role::Extractor))
+        .ok_or(PrimitiveError::NoClientForRole {
+            role: Role::RuleExtractor,
+        })?;
+
+    let completion_req = build_completion_request(client, req);
+    let prompt_hash = fingerprint_prompt(&completion_req);
+
+    let resp = complete_with_truncation_retry(client, completion_req)
+        .map_err(PrimitiveError::Gateway)?;
+
+    let call_record = LlmCallRecord {
+        provider: client.identity().clone(),
+        primitive: "elicit_rules".to_string(),
+        role: Role::RuleExtractor.as_str().to_string(),
+        prompt_version: ELICIT_RULES_PROMPT_VERSION.to_string(),
+        prompt_hash,
+        usage: resp.usage,
+        latency_ms: resp.latency_ms,
+        finish_reason: resp.finish_reason,
+        cost_usd: 0.0,
+    };
+
+    Ok(ElicitRulesResponse {
+        rule_text: resp.text,
+        call_record,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llm_gateway::{
+        Capabilities, CompletionResponse, FinishReason, JsonSchema, LlmError, ProviderIdentity,
+        TokenUsage,
+    };
+    use std::sync::Mutex;
+
+    fn rule_extractor_identity() -> ProviderIdentity {
+        ProviderIdentity {
+            vendor: "mock".into(),
+            model_family: "test-rule-extractor".into(),
+            model_version: "v1".into(),
+            endpoint: None,
+        }
+    }
+
+    struct ScriptedText {
+        identity: ProviderIdentity,
+        response: Mutex<Option<Result<CompletionResponse, LlmError>>>,
+    }
+
+    impl ScriptedText {
+        fn new(text: String) -> Self {
+            Self {
+                identity: rule_extractor_identity(),
+                response: Mutex::new(Some(Ok(CompletionResponse {
+                    text,
+                    model: "test-rule-extractor".into(),
+                    usage: TokenUsage {
+                        input_tokens: 200,
+                        output_tokens: 350,
+                        cached_tokens: 0,
+                    },
+                    finish_reason: FinishReason::Stop,
+                    provider_id: rule_extractor_identity(),
+                    latency_ms: 950,
+                }))),
+            }
+        }
+
+        fn with_error(err: LlmError) -> Self {
+            Self {
+                identity: rule_extractor_identity(),
+                response: Mutex::new(Some(Err(err))),
+            }
+        }
+    }
+
+    impl LlmClient for ScriptedText {
+        fn identity(&self) -> ProviderIdentity {
+            self.identity.clone()
+        }
+
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::modern_frontier()
+        }
+
+        fn complete(
+            &self,
+            _req: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            self.response
+                .lock()
+                .unwrap()
+                .take()
+                .expect("ScriptedText::complete called more than once")
+        }
+
+        fn complete_json(
+            &self,
+            _req: CompletionRequest,
+            _schema: &JsonSchema,
+        ) -> Result<llm_gateway::CompletionJsonResponse, LlmError> {
+            unreachable!("elicit_rules uses complete, not complete_json")
+        }
+    }
+
+    fn req() -> ElicitRulesRequest {
+        ElicitRulesRequest {
+            document_id: "rulebook-tsa-2026-05-12".into(),
+            domain_hint: "tsa-declaration".into(),
+            scope_hint: Some("carry-on baggage".into()),
+            language_hint: None,
+        }
+    }
+
+    fn sample_rule_text() -> String {
+        "COVERAGE: TSA carry-on rules as of ~2024.\n\
+         1. Passengers may carry one (1) carry-on bag.\n\
+         2. Liquids in containers larger than 3.4 oz are prohibited \
+         except medicines.\n\
+         3. Strike-anywhere matches are prohibited.\n"
+            .to_string()
+    }
+
+    #[test]
+    fn missing_rule_extractor_role_returns_no_client_for_role() {
+        let g = GatewayConfig::new();
+        let err = elicit_rules(&req(), &g).unwrap_err();
+        match err {
+            PrimitiveError::NoClientForRole { role } => {
+                assert_eq!(role, Role::RuleExtractor)
+            }
+            other => panic!("expected NoClientForRole, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn falls_back_to_extractor_role_when_rule_extractor_unbound() {
+        let mock = ScriptedText::new(sample_rule_text());
+        let g = GatewayConfig::new().with_client(Role::Extractor, Box::new(mock));
+        let resp = elicit_rules(&req(), &g).unwrap();
+        assert!(resp.rule_text.contains("COVERAGE:"));
+    }
+
+    #[test]
+    fn happy_path_returns_text_and_call_record() {
+        let mock = ScriptedText::new(sample_rule_text());
+        let g = GatewayConfig::new().with_client(Role::RuleExtractor, Box::new(mock));
+        let resp = elicit_rules(&req(), &g).unwrap();
+
+        assert!(resp.rule_text.starts_with("COVERAGE:"));
+        assert!(resp.rule_text.contains("1."));
+        assert_eq!(resp.call_record.primitive, "elicit_rules");
+        assert_eq!(resp.call_record.role, "rule_extractor");
+        assert_eq!(resp.call_record.prompt_version, "elicit-rules-v1");
+        assert!(!resp.call_record.prompt_hash.is_empty());
+    }
+
+    #[test]
+    fn gateway_error_propagates() {
+        let mock = ScriptedText::with_error(LlmError::ContextTooLarge {
+            provider: rule_extractor_identity(),
+            requested_tokens: 100_000,
+            max_tokens: 8_192,
+        });
+        let g = GatewayConfig::new().with_client(Role::RuleExtractor, Box::new(mock));
+        let err = elicit_rules(&req(), &g).unwrap_err();
+        assert!(matches!(
+            err,
+            PrimitiveError::Gateway(LlmError::ContextTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn user_message_includes_domain_scope_and_doc_id() {
+        let r = req();
+        let text = build_user_text(&r);
+        assert!(text.contains("DOMAIN: tsa-declaration"));
+        assert!(text.contains("SCOPE: carry-on baggage"));
+        assert!(text.contains("DOCUMENT_ID: rulebook-tsa-2026-05-12"));
+        assert!(text.contains("LANGUAGE: en"));
+    }
+
+    #[test]
+    fn user_message_omits_scope_when_absent() {
+        let r = ElicitRulesRequest {
+            scope_hint: None,
+            ..req()
+        };
+        let text = build_user_text(&r);
+        assert!(!text.contains("SCOPE:"));
+    }
+}

--- a/code/packages/rust/llm-primitives/src/lib.rs
+++ b/code/packages/rust/llm-primitives/src/lib.rs
@@ -65,6 +65,7 @@ use llm_gateway::{
 };
 
 pub mod decompose_text;
+pub mod elicit_rules;
 pub mod entail;
 pub mod find_contradicting_reading;
 pub mod judge_plausibility;
@@ -76,6 +77,7 @@ pub mod render_node;
 // `llm_primitives::render_node(...)` / `llm_primitives::judge_plausibility(...)`
 // directly.
 pub use decompose_text::{decompose_text, DecomposeTextRequest, DecomposeTextResponse};
+pub use elicit_rules::{elicit_rules, ElicitRulesRequest, ElicitRulesResponse};
 pub use entail::{entail, EntailRequest, EntailResponse};
 pub use find_contradicting_reading::{
     find_contradicting_reading, FindContradictingReadingRequest, FindContradictingReadingResponse,
@@ -376,6 +378,7 @@ pub const ENTAIL_PROMPT_VERSION: &str = "entail-v1";
 pub const ADVERSARY_PROMPT_VERSION: &str = "adversary-v1";
 pub const PLAUSIBILITY_PROMPT_VERSION: &str = "plausibility-v1";
 pub const EXTRACT_RULES_PROMPT_VERSION: &str = "extract-rules-v1";
+pub const ELICIT_RULES_PROMPT_VERSION: &str = "elicit-rules-v1";
 
 // ---------------------------------------------------------------------------
 // Retry helpers — thinking-mode-tolerant
@@ -888,5 +891,6 @@ mod tests {
         assert_eq!(ADVERSARY_PROMPT_VERSION, "adversary-v1");
         assert_eq!(PLAUSIBILITY_PROMPT_VERSION, "plausibility-v1");
         assert_eq!(EXTRACT_RULES_PROMPT_VERSION, "extract-rules-v1");
+        assert_eq!(ELICIT_RULES_PROMPT_VERSION, "elicit-rules-v1");
     }
 }


### PR DESCRIPTION
## Summary

Adds the rulebook-elicitation phase from [ADJ14](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/ADJ14-rule-elicitation.md). A new \`adjudication-rulebook\` crate composes a new \`elicit_rules\` primitive with \`decompose_text\` and \`adjudication_ir::validate\` to produce a typed Rulebook from a domain hint. The same checker discipline that protects extracted facts in the framework now protects the rules under which those facts will be judged — the recursion the user liked.

## What's new

### \`llm-primitives::elicit_rules\` (new primitive)

Open-ended LLM call that asks the model to list every rule it knows for a domain. Versioned via \`ELICIT_RULES_PROMPT_VERSION = \"elicit-rules-v1\"\`. Returns raw text + audit-trail record. Falls back from \`Role::RuleExtractor\` to \`Role::Extractor\` if no specialized role is bound.

### \`adjudication-rulebook\` crate (new)

- \`Rulebook\` typed container — \`document_id\`, \`domain\`, \`scope\`, \`ir_document\` (JSON), \`source_text\`, \`trust\`, both prompt versions, \`model_identity\`, \`as_of\`, full \`audit_trail\`, and \`validation_passed\` + \`validation_error\` for IR diagnostics.
- \`RulebookTrust { Tentative, Reviewed, Authoritative }\` — every acquire output is \`Tentative\` per ADJ14 §\"Trust Tiers\".
- \`acquire_rulebook(req, gateway)\` orchestrator.
- Hand-rolled \`ir_from_json\` decoder (the IR crate doesn't ship serde derives by design).

## Security hardening on the JSON decoder

The LLM-produced response is untrusted. The decoder enforces hard caps before allocation so a pathological response cannot stack-overflow or OOM the process before validate runs:

| Cap | Value |
|---|---|
| \`MAX_TERM_DEPTH\` | 64 |
| \`MAX_NODES\` | 100,000 |
| \`MAX_EDGES\` | 200,000 |
| \`MAX_TERM_ARGS\` | 256 |
| \`MAX_SPANS_PER_OBJECT\` | 4,096 |
| \`MAX_METADATA_ENTRIES\` | 256 |

\`parse_term\` is depth-limited. Over-cap arrays return \`None\`, which the caller surfaces as a validation failure. \`usize::try_from\` replaces silent 32-bit truncation. The recursive clone pattern on outer \`Vec<Value>\` was replaced with \`.as_slice()\` to remove the amplification risk identified by the security review.

Two rounds of security review: round 1 caught a stack-overflow + OOM trio, round 2 verified the iterative caps fix.

## Test plan

- [x] 4 unit tests in \`adjudication-rulebook\` (happy path, malformed-IR returns Rulebook-with-failure, \`RulebookTrust::as_str\` stable, elicit-failure propagates).
- [x] 78 tests in \`llm-primitives\` (was 72; +6 new for \`elicit_rules\`).
- [x] Workspace builds (excluding pre-existing unrelated failures in font-parser/paint-vm/os-kernel).
- [x] Security review passed
- [ ] CI green

## What v0.1 does NOT ship yet

- ADJ02–05 checker passes against the rulebook IR. v0.1 runs only \`adjudication_ir::validate\` (the well-formedness gate). Full ADJ06 retry loop on rulebook checks follows.
- Disk persistence / caching of acquired rulebooks (\`llm-cache\` memoises individual calls).
- Tentative → Reviewed promotion CLI per ADJ09's review workflow.
- TSA demo wiring + measured before/after on raw-arm hallucinations. That's the next PR.

## Independent of \`decompose_text\` v4

This PR works against the current v3 prompt; the v4 prompt change ([#3026](https://github.com/adhithyan15/coding-adventures/pull/3026)) is independently merging. Once both land, \`acquire_rulebook\` will produce graph IR rulebooks rather than flat-node rulebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)