### PR TITLE
spec(adj02, adj03): land v3 revisions matching the graph IR

### DIFF
--- a/code/specs/ADJ02-coverage-checker.md
+++ b/code/specs/ADJ02-coverage-checker.md
@@ -1,12 +1,93 @@
-# ADJ02 — Coverage Checker: Structural Tree Check Over the Hierarchical IR
+# ADJ02 — Coverage Checker: Flat Tiling and DAG Acyclicity Over the Graph IR
 
-> **Pending revision to v3 (2026-05-12)** to match
-> [`ADJ01 v3`](ADJ01-adjudication-ir-grammar.md): coverage becomes a
-> *flat tiling* check over the union of node and edge `source_spans`
-> (no recursive tree descent), and a separate **DAG acyclicity**
-> invariant is added. The v2 content below describes the previous
-> structural-tree check and is preserved until the v3 revision lands
-> alongside the `adjudication-coverage` crate's v3 update.
+> **Revision v3 (2026-05-12): flat tiling + DAG acyclicity.** v2's
+> recursive tree-tiling check (children tile parent's spans,
+> recursively) is replaced by a **flat tile** of the union of every
+> node and edge `source_spans` against `[0, len(document))`, with a
+> companion **DAG acyclicity** invariant added across the typed
+> edge graph. Both flow from the [ADJ01 v3](ADJ01-adjudication-ir-grammar.md)
+> shift from a hierarchical decomposition tree to a multi-directed
+> acyclic graph IR.
+>
+> Two coverage rules in one check:
+>
+> 1. **Flat tile.** The union of `source_spans` across all nodes and
+>    all edges must cover `[0, len(document))` exactly once. No gaps.
+>    No overlaps. Synthesized objects (Query nodes with empty spans,
+>    Entity nodes with empty spans, engine-emitted edges with empty
+>    spans) are exempt from tiling.
+> 2. **Acyclicity.** The directed graph `(Nodes, Edges)` formed by
+>    treating every edge as `source → target` must be acyclic. The
+>    check applies uniformly across all `EdgeRelation`s — `Excepts`,
+>    `Refers`, `Contains`, …, even `Refines` and `Supersedes` that
+>    could otherwise loop on amendment chains.
+>
+> Implementation lives in [`adjudication-coverage`](../packages/rust/adjudication-coverage),
+> which is now a thin façade over `adjudication_ir::validate` plus
+> the document-length-aware end-gap check and the
+> `Discarded(Unparseable)` hard rule. Cycle detection is in
+> `adjudication_ir::validate` (`check_acyclicity` — iterative
+> three-colour DFS, `O(|V| + |E|)`, stack-safe by construction).
+>
+> The v2 prose below is preserved as the historical record of why
+> the framework moved from a tagger-based check to a structural
+> check; the v3 algorithm is a generalisation of that move.
+
+## v3 Coverage Invariant (formal)
+
+```text
+Let N = set of IRNodes, E = set of IREdges,
+    spans(x) = x.source_spans for any node or edge x.
+
+Let exempt(x) = (x.kind == Query AND spans(x) is empty)
+            OR (x.kind == Entity AND spans(x) is empty)
+            OR (x is an IREdge AND spans(x) is empty).
+
+Coverage holds iff:
+
+    ⋃ { spans(x) : x ∈ N ∪ E, NOT exempt(x) }
+       = [0, len(document))
+
+    AND no byte appears in more than one source_span across N ∪ E.
+```
+
+The check is `O((|N| + |E|) · S)` time where `S` is the maximum
+span count per object, sortable to `O(K log K)` where `K` is the
+total span count — well under a millisecond for any reasonable
+document.
+
+## v3 Acyclicity Invariant (formal)
+
+```text
+Let G = (N, →) where n₁ → n₂ iff ∃ e ∈ E with
+    e.source = n₁ AND e.target = n₂.
+
+Acyclicity holds iff G has no directed cycle:
+    ∀ n ∈ N, ¬∃ path n → n₁ → n₂ → … → n
+```
+
+Detection: iterative three-colour DFS (`White / Gray / Black`).
+When a `Gray → Gray` edge is followed, the cycle's participants
+(from the second Gray to the end of the current path) are returned
+as the violation. The algorithm is iterative for stack safety —
+adversarial inputs with long linear chains cannot blow the OS
+thread stack.
+
+## v3 ADJ06 Clarification Mapping
+
+A coverage failure produces one of:
+
+| Violation | Clarification question |
+|---|---|
+| `CoverageGap { missing_ranges }` | "Bytes `[s, e)` aren't accounted for. Either emit a node/edge that covers them, or emit a `Discarded` with a reason." |
+| `CoverageOverlap { ranges, participants }` | "Bytes `[s, e)` are claimed by both `<participant₁>` and `<participant₂>`. Decide which owns them." |
+| `GraphCycle { participants }` | "Edges form a cycle through `[participant ids]`. Break it: drop one edge or re-target a node." |
+| `UnparseableDiscarded { node_id }` | "Node `<id>` was discarded as Unparseable. Re-extract: every span must produce a typed claim." |
+
+The v2 `ChildrenDoNotTileParent` and `NonTextRunHasChildren`
+violations are gone — the graph IR has no tree shape to violate.
+
+---
 
 > **Revision v2 (2026-05-11): structural coverage.** v1 of this spec
 > defined coverage as a token-level check driven by a language-

--- a/code/specs/ADJ03-polarity-modality-checker.md
+++ b/code/specs/ADJ03-polarity-modality-checker.md
@@ -1,13 +1,70 @@
-# ADJ03 — Polarity and Modality Checker: Propagation Consistency
+# ADJ03 — Polarity and Modality Checker: Propagation Along `Contains` Edges
 
-> **Pending revision to v3 (2026-05-12)** to match
-> [`ADJ01 v3`](ADJ01-adjudication-ir-grammar.md): propagation runs
-> along `Contains` edges rather than the `part_of` field, and a
-> `PropagationConflict` check is added for nodes with multiple
-> `Contains` parents whose effective values disagree. The v2 content
-> below describes propagation through the v2 tree and is preserved
-> until the v3 revision lands alongside the
-> `adjudication-polarity-modality` crate's v3 update.
+> **Revision v3 (2026-05-12): edge-driven propagation.** v2's
+> propagation walked the `part_of` tree from leaf to root,
+> resolving `Inherit` against the structural parent. v3 walks
+> `Contains` edges instead (the graph-IR equivalent), and adds a
+> **multi-parent agreement check** since a v3 node can have more
+> than one `Contains` parent.
+>
+> The propagation algorithm:
+>
+> 1. **Concrete value wins.** If a node carries a non-`Inherit`
+>    polarity (or modality), that value is its effective value.
+> 2. **Inherit walks parents.** For an `Inherit` node, follow each
+>    incoming `Contains` edge to its parent and recursively resolve
+>    the parent's effective value.
+> 3. **Multi-parent must agree.** If a node has multiple `Contains`
+>    parents and `polarity = Inherit`, every parent's effective
+>    polarity must be the same. Disagreement is a
+>    `PropagationConflict` validation error that lists the
+>    conflicting candidates so ADJ06 can ask the model to pick.
+> 4. **No-parent Inherit is invalid.** A node with `polarity =
+>    Inherit` and no incoming `Contains` edge is an
+>    `InheritWithoutParent` error — the inheritance chain dead-ends
+>    with no value to inherit.
+>
+> Beyond v3-IR-specific propagation, this checker also enforces:
+>
+> - **RuledOut requires Affirmed.** A node with `modality = RuledOut`
+>   MUST have `polarity = Affirmed`. ADJ01 hard rule; clinical
+>   adjudications treat `RuledOut` as a domain answer, not a
+>   polarity flip.
+> - **Leaf-override warnings.** A node with a concrete (non-`Inherit`)
+>   polarity that disagrees with its `Contains` parent's effective
+>   value is recorded as a warning, not a violation. Legitimate
+>   overrides ("denies X, Y; admits Z") are common; the default
+>   policy is *warn, do not block*. Deployments can promote warnings
+>   to errors via configuration.
+>
+> Stack safety: both `validate()` in `adjudication-ir` and the
+> override-warning walk in `adjudication-polarity-modality` use
+> iterative `Contains`-chain traversal with a heap-allocated
+> `visited` Vec. Long linear chains (or pathological adversarial
+> input) cannot blow the thread stack.
+>
+> Implementation lives in [`adjudication-polarity-modality`](../packages/rust/adjudication-polarity-modality),
+> which is now a thin façade over `adjudication_ir::validate` plus
+> the `RuledOut` rule and the override-warning machinery.
+>
+> The v2 prose below describes the equivalent walk over `part_of`
+> trees; the algorithm is the same, the graph shape changed.
+
+## v3 ADJ06 Clarification Mapping
+
+A propagation failure produces one of:
+
+| Violation | Clarification question |
+|---|---|
+| `InheritWithoutParent { node_id, field }` | "Node `<id>` declares `<field> = Inherit` but has no `Contains` parent to inherit from. Either declare a concrete value or add a `Contains` edge from a parent that has one." |
+| `MultiParentConflict { node_id, field, candidates }` | "Node `<id>`'s `Contains` parents disagree on effective `<field>`: `[(parent₁, value₁), (parent₂, value₂), …]`. Either set a concrete value on the node, or fix one of the parents so they agree." |
+| `RuledOutMustBeAffirmed { node_id, actual_polarity }` | "Node `<id>` has `modality = RuledOut` but `polarity = <actual>`. `RuledOut` is a domain answer, not a polarity flip — set `polarity = Affirmed`." |
+
+`LeafOverridesAncestor*` warnings do not produce clarification
+questions by default; they're recorded in the audit trail and can
+be promoted to clarifications via deployment config.
+
+---
 
 > **Revision v2 (2026-05-11): propagation consistency.** v1 of this
 > spec described a NegEx/ConText-style trigger-detection check that


### PR DESCRIPTION
## Summary

Promotes ADJ02 and ADJ03's \"pending revision to v3\" banners to fully-described v3 revisions, matching the already-shipped graph IR implementation. Docs-only — the v3 algorithms have been live in [\`adjudication-ir\`](https://github.com/adhithyan15/coding-adventures/blob/main/code/packages/rust/adjudication-ir/src/lib.rs), [\`adjudication-coverage\`](https://github.com/adhithyan15/coding-adventures/blob/main/code/packages/rust/adjudication-coverage/src/lib.rs), and [\`adjudication-polarity-modality\`](https://github.com/adhithyan15/coding-adventures/blob/main/code/packages/rust/adjudication-polarity-modality/src/lib.rs) since the cascade migration landed.

## ADJ02 v3 — flat tile + DAG acyclicity

- Union of \`(nodes ∪ edges).source_spans\` = \`[0, len(document))\` with no gaps, no overlaps.
- Synthesized objects (Query / Entity / spanless edges) are exempt from tiling.
- DAG acyclicity across ALL EdgeRelations, via iterative three-colour DFS (stack-safe).
- Formal definitions + four-row ADJ06 clarification mapping (\`CoverageGap\`, \`CoverageOverlap\`, \`GraphCycle\`, \`UnparseableDiscarded\`).

## ADJ03 v3 — propagation along \`Contains\` edges

- Propagation walks \`Contains\` edges instead of the v2 \`part_of\` field.
- New multi-parent agreement check: when a node has \`Inherit\` polarity and multiple \`Contains\` parents, all parents must agree on the effective value; disagreement is \`PropagationConflict\`.
- \`InheritWithoutParent\` violation when a node has no \`Contains\` parent.
- Stack-safe iterative walk.
- RuledOut + non-Affirmed hard rule preserved.
- Leaf-override warnings preserved.
- Three-row ADJ06 clarification mapping.

The historical v2 prose remains in both files as a record of the prior tree-shaped algorithm; the v3 sections at the top describe the current, shipped implementation.

## Test plan

- [x] Docs-only diff — no code or tests touched.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)