### PR TITLE
Add TypeScript MACSYMA declare property queries

### DIFF
--- a/code/packages/typescript/cas-simplify/CHANGELOG.md
+++ b/code/packages/typescript/cas-simplify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add deterministic `AssumptionContext.factsFor(...)` and
+  `AssumptionContext.symbolsWithFacts()` metadata queries for MACSYMA property
+  inspection.
+
 ## 0.1.0
 
 - Add canonicalization, numeric folding, and fixed-point simplification.

--- a/code/packages/typescript/cas-simplify/src/assumptions.ts
+++ b/code/packages/typescript/cas-simplify/src/assumptions.ts
@@ -143,6 +143,17 @@ export class AssumptionContext {
     return (this.facts.get(symbolName)?.size ?? 0) > 0;
   }
 
+  factsFor(symbolName: string): readonly string[] {
+    return [...(this.facts.get(symbolName) ?? [])].sort();
+  }
+
+  symbolsWithFacts(): readonly string[] {
+    return [...this.facts.entries()]
+      .filter(([, facts]) => facts.size > 0)
+      .map(([name]) => name)
+      .sort();
+  }
+
   private add(symbolName: string, fact: string): void {
     const existing = this.facts.get(symbolName);
     if (existing === undefined) {

--- a/code/packages/typescript/cas-simplify/tests/phase21.test.ts
+++ b/code/packages/typescript/cas-simplify/tests/phase21.test.ts
@@ -68,6 +68,8 @@ describe("AssumptionContext", () => {
     expect(ctx.isTrueRelation(app(EQUAL, [y, int(0)]))).toBe(false);
     expect(ctx.isInteger("n")).toBe(true);
     expect(ctx.hasAnyFacts("x")).toBe(true);
+    expect(ctx.factsFor("n")).toEqual(["integer"]);
+    expect(ctx.symbolsWithFacts()).toEqual(["n", "x", "y"]);
 
     ctx.forgetRelation(greaterZero(x));
     expect(ctx.isPositive("x")).toBeUndefined();
@@ -84,6 +86,17 @@ describe("AssumptionContext", () => {
     expect(ctx.signOf("x")).toBe(-1);
     expect(ctx.isNonneg("y")).toBe(true);
     expect(ctx.isNegative("y")).toBe(false);
+  });
+
+  it("returns deterministic fact and symbol metadata", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeProperty(n, sym("positive"));
+    ctx.assumeProperty(n, sym("integer"));
+    ctx.assumeRelation(greaterZero(x));
+
+    expect(ctx.factsFor("n")).toEqual(["integer", "positive"]);
+    expect(ctx.factsFor("missing")).toEqual([]);
+    expect(ctx.symbolsWithFacts()).toEqual(["n", "x"]);
   });
 });
 

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Wire `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
+  TypeScript MACSYMA session assumption context so declared properties feed
+  property queries and assumption-backed relation checks.
 - Route `ev(expr, display2d)` JSON and browser display text through the
   TypeScript `cas-pretty-printer` 2D MACSYMA box renderer while preserving the
   symbolic IR result for history and downstream evaluation.

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -13,7 +13,7 @@ import {
   reverse,
   sortList,
 } from "@coding-adventures/cas-list-operations";
-import { simplify as simplifyCas } from "@coding-adventures/cas-simplify";
+import { AssumptionContext, simplify as simplifyCas } from "@coding-adventures/cas-simplify";
 import { MacsymaDialect, pretty } from "@coding-adventures/cas-pretty-printer";
 import { solveLinearSystem, trySolveInequality, trySolveTranscendental } from "@coding-adventures/cas-solve";
 import { subst } from "@coding-adventures/cas-substitution";
@@ -21,6 +21,7 @@ import { expandTrig, trigReduce, trigSimplify } from "@coding-adventures/cas-tri
 import {
   ACOS,
   ACOSH,
+  ASSUME,
   ASIN,
   ASINH,
   ATAN,
@@ -31,9 +32,11 @@ import {
   EXP,
   FACTOR,
   FALSE,
+  FORGET,
   GREATER,
   GREATER_EQUAL,
   INTEGRATE,
+  IS,
   LESS,
   LESS_EQUAL,
   LIST,
@@ -63,6 +66,9 @@ export const SUPPRESS = sym("Suppress");
 export const KILL = sym("Kill");
 export const EV = sym("Ev");
 export const ALL_SYMBOL = sym("all");
+export const DECLARE = sym("Declare");
+export const PROPERTIES = sym("Properties");
+export const PROP_VARS = sym("PropVars");
 
 export const SIMPLIFY = sym("Simplify");
 export const EXPAND = sym("Expand");
@@ -200,9 +206,12 @@ export const MACSYMA_NAME_TABLE: ReadonlyMap<string, IRSymbol> = new Map<string,
   ["kill", KILL],
   ["ev", EV],
   ["block", sym("Block")],
-  ["assume", sym("Assume")],
-  ["forget", sym("Forget")],
-  ["is", sym("Is")],
+  ["assume", ASSUME],
+  ["forget", FORGET],
+  ["is", IS],
+  ["declare", DECLARE],
+  ["properties", PROPERTIES],
+  ["propvars", PROP_VARS],
   ["matchdeclare", sym("MatchDeclare")],
   ["defrule", sym("DefRule")],
   ["apply1", sym("Apply1")],
@@ -303,6 +312,7 @@ export class History {
 
 export class MacsymaBackend extends SymbolicBackend {
   numer = false;
+  readonly assumptions = new AssumptionContext();
   private readonly runtimeTable: ReadonlyMap<string, Handler>;
   private readonly runtimeHeld: ReadonlySet<string>;
 
@@ -315,6 +325,12 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(SUPPRESS.name, suppressHandler);
     table.set(KILL.name, makeKillHandler(this));
     table.set(EV.name, makeEvHandler());
+    table.set(ASSUME.name, assumeHandler);
+    table.set(FORGET.name, forgetHandler);
+    table.set(IS.name, isHandler);
+    table.set(DECLARE.name, declareHandler);
+    table.set(PROPERTIES.name, propertiesHandler);
+    table.set(PROP_VARS.name, propvarsHandler);
     table.set(SOLVE.name, solveHandler);
     table.set(SUBST.name, substHandler);
     table.set(SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
@@ -336,7 +352,19 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(PART.name, listHandler(2, ([value, index]) => part(value, integerArgument(index))));
     table.set(FLATTEN.name, listHandler(null, flattenHandler));
     this.runtimeTable = table;
-    this.runtimeHeld = new Set([...super.holdHeads(), KILL.name, EV.name, SOLVE.name, SUBST.name]);
+    this.runtimeHeld = new Set([
+      ...super.holdHeads(),
+      KILL.name,
+      EV.name,
+      ASSUME.name,
+      FORGET.name,
+      IS.name,
+      DECLARE.name,
+      PROPERTIES.name,
+      PROP_VARS.name,
+      SOLVE.name,
+      SUBST.name,
+    ]);
   }
 
   override lookup(name: string): IRNode | undefined {
@@ -590,6 +618,64 @@ function makeEvHandler(): Handler {
 
     return result;
   };
+}
+
+function assumeHandler(vm: VM, expr: IRApply): IRNode {
+  const ctx = assumptionContext(vm);
+  if (ctx === undefined) return expr;
+  if (expr.args.length === 1) {
+    ctx.assumeRelation(expr.args[0]);
+  } else if (expr.args.length === 2) {
+    ctx.assumeProperty(expr.args[0], expr.args[1]);
+  }
+  return sym("done");
+}
+
+function forgetHandler(vm: VM, expr: IRApply): IRNode {
+  const ctx = assumptionContext(vm);
+  if (ctx === undefined) return expr;
+  if (expr.args.length === 0) {
+    ctx.forgetAll();
+  } else {
+    ctx.forgetRelation(expr.args[0]);
+  }
+  return sym("done");
+}
+
+function isHandler(vm: VM, expr: IRApply): IRNode {
+  const ctx = assumptionContext(vm);
+  if (ctx === undefined || expr.args.length !== 1) return expr;
+  const result = ctx.isTrueRelation(expr.args[0]);
+  if (result === true) return TRUE;
+  if (result === false) return FALSE;
+  return sym("unknown");
+}
+
+function declareHandler(vm: VM, expr: IRApply): IRNode {
+  const ctx = assumptionContext(vm);
+  if (ctx === undefined || expr.args.length % 2 !== 0) return expr;
+  for (let i = 0; i < expr.args.length; i += 2) {
+    ctx.assumeProperty(expr.args[i], expr.args[i + 1]);
+  }
+  return sym("done");
+}
+
+function propertiesHandler(vm: VM, expr: IRApply): IRNode {
+  const ctx = assumptionContext(vm);
+  if (ctx === undefined || expr.args.length !== 1) return expr;
+  const [target] = expr.args;
+  if (target.kind !== "symbol") return app(LIST, []);
+  return app(LIST, ctx.factsFor(target.name).map((fact) => sym(fact)));
+}
+
+function propvarsHandler(vm: VM, expr: IRApply): IRNode {
+  const ctx = assumptionContext(vm);
+  if (ctx === undefined || expr.args.length !== 0) return expr;
+  return app(LIST, ctx.symbolsWithFacts().map((name) => sym(name)));
+}
+
+function assumptionContext(vm: VM): AssumptionContext | undefined {
+  return vm.backend instanceof MacsymaBackend ? vm.backend.assumptions : undefined;
 }
 
 function solveHandler(_vm: VM, expr: IRApply): IRNode {

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   ADD,
+  ASSUME,
   EQUAL,
   EXP,
+  FORGET,
   GREATER,
   GREATER_EQUAL,
+  IS,
   LESS,
   LESS_EQUAL,
   LIST,
@@ -16,6 +19,7 @@ import {
   SOLVE,
   SUB,
   SUBST,
+  TRUE,
   app,
   int,
   numberNode,
@@ -27,6 +31,7 @@ import {
   ALL_SYMBOL,
   APPEND,
   APPLY,
+  DECLARE,
   DISPLAY,
   EV,
   EXPAND,
@@ -42,6 +47,8 @@ import {
   MacsymaSession,
   MAP,
   PART,
+  PROP_VARS,
+  PROPERTIES,
   RAT_SIMPLIFY,
   RANGE,
   REST,
@@ -78,11 +85,20 @@ describe("macsyma-runtime", () => {
     expect(SUPPRESS).toEqual(sym("Suppress"));
     expect(KILL).toEqual(sym("Kill"));
     expect(EV).toEqual(sym("Ev"));
+    expect(DECLARE).toEqual(sym("Declare"));
+    expect(PROPERTIES).toEqual(sym("Properties"));
+    expect(PROP_VARS).toEqual(sym("PropVars"));
   });
 
   it("exports MACSYMA name-table routes and extends maps idempotently", () => {
     expect(MACSYMA_NAME_TABLE.get("kill")).toEqual(KILL);
     expect(MACSYMA_NAME_TABLE.get("ev")).toEqual(EV);
+    expect(MACSYMA_NAME_TABLE.get("assume")).toEqual(ASSUME);
+    expect(MACSYMA_NAME_TABLE.get("forget")).toEqual(FORGET);
+    expect(MACSYMA_NAME_TABLE.get("is")).toEqual(IS);
+    expect(MACSYMA_NAME_TABLE.get("declare")).toEqual(DECLARE);
+    expect(MACSYMA_NAME_TABLE.get("properties")).toEqual(PROPERTIES);
+    expect(MACSYMA_NAME_TABLE.get("propvars")).toEqual(PROP_VARS);
     expect(MACSYMA_NAME_TABLE.get("expand")).toEqual(EXPAND);
     expect(MACSYMA_NAME_TABLE.get("simplify")).toEqual(SIMPLIFY);
     expect(MACSYMA_NAME_TABLE.get("ratsimp")).toEqual(RAT_SIMPLIFY);
@@ -186,10 +202,16 @@ describe("macsyma-runtime", () => {
     expect(backend.lookup("not_history")).toBeUndefined();
   });
 
-  it("registers held Kill and Ev runtime handlers", () => {
+  it("registers held runtime handlers", () => {
     const backend = new MacsymaBackend(new History());
     expect(backend.handlers().has(KILL.name)).toBe(true);
     expect(backend.handlers().has(EV.name)).toBe(true);
+    expect(backend.handlers().has(ASSUME.name)).toBe(true);
+    expect(backend.handlers().has(FORGET.name)).toBe(true);
+    expect(backend.handlers().has(IS.name)).toBe(true);
+    expect(backend.handlers().has(DECLARE.name)).toBe(true);
+    expect(backend.handlers().has(PROPERTIES.name)).toBe(true);
+    expect(backend.handlers().has(PROP_VARS.name)).toBe(true);
     expect(backend.handlers().has(SOLVE.name)).toBe(true);
     expect(backend.handlers().has(SUBST.name)).toBe(true);
     expect(backend.handlers().has(SIMPLIFY.name)).toBe(true);
@@ -200,6 +222,12 @@ describe("macsyma-runtime", () => {
     expect(backend.handlers().has(LENGTH.name)).toBe(true);
     expect(backend.holdHeads().has(KILL.name)).toBe(true);
     expect(backend.holdHeads().has(EV.name)).toBe(true);
+    expect(backend.holdHeads().has(ASSUME.name)).toBe(true);
+    expect(backend.holdHeads().has(FORGET.name)).toBe(true);
+    expect(backend.holdHeads().has(IS.name)).toBe(true);
+    expect(backend.holdHeads().has(DECLARE.name)).toBe(true);
+    expect(backend.holdHeads().has(PROPERTIES.name)).toBe(true);
+    expect(backend.holdHeads().has(PROP_VARS.name)).toBe(true);
     expect(backend.holdHeads().has(SOLVE.name)).toBe(true);
     expect(backend.holdHeads().has(SUBST.name)).toBe(true);
   });
@@ -234,6 +262,48 @@ describe("macsyma-runtime", () => {
     session.evalSource("x : 5; 1; kill(all);");
     expect(session.history().nextInputIndex()).toBe(1);
     expect(session.evalSource("x;")[0].output).toEqual(sym("x"));
+  });
+
+  it("assume, is, and forget share session assumptions", () => {
+    const session = new MacsymaSession();
+    const [assumeResult, trueResult, forgetResult, unknownResult] = session.evalSource(
+      "assume(x > 0); is(x > 0); forget(); is(x > 0);",
+    );
+
+    expect(assumeResult.output).toEqual(sym("done"));
+    expect(trueResult.output).toEqual(TRUE);
+    expect(forgetResult.output).toEqual(sym("done"));
+    expect(unknownResult.output).toEqual(sym("unknown"));
+  });
+
+  it("declare feeds properties into is queries", () => {
+    const session = new MacsymaSession();
+    const [declareResult, query] = session.evalSource("declare(x, positive); is(x > 0);");
+
+    expect(declareResult.input).toEqual(app(DECLARE, [sym("x"), sym("positive")]));
+    expect(declareResult.output).toEqual(sym("done"));
+    expect(query.output).toEqual(TRUE);
+  });
+
+  it("properties lists declared properties deterministically", () => {
+    const session = new MacsymaSession();
+    const [, result] = session.evalSource("declare(n, integer, n, positive); properties(n);");
+
+    expect(result.output).toEqual(app(LIST, [sym("integer"), sym("positive")]));
+  });
+
+  it("propvars lists symbols with declared properties deterministically", () => {
+    const session = new MacsymaSession();
+    const [, , result] = session.evalSource("declare(z, integer); declare(a, positive); propvars();");
+
+    expect(result.output).toEqual(app(LIST, [sym("a"), sym("z")]));
+  });
+
+  it("properties queries raw symbols even when they are bound", () => {
+    const session = new MacsymaSession();
+    const [, , result] = session.evalSource("x : 10; declare(x, integer); properties(x);");
+
+    expect(result.output).toEqual(app(LIST, [sym("integer")]));
   });
 
   it("Ev numer and float coerce evaluated exact results to floats", () => {


### PR DESCRIPTION
## Summary
- add TypeScript assumption metadata query helpers for declared properties
- wire `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` through the TypeScript MACSYMA runtime
- keep property declarations backed by the MACSYMA session assumption context so they feed relation checks and property queries

## Validation
- `npm test` in `code/packages/typescript/cas-simplify`
- `npm run build` in `code/packages/typescript/cas-simplify`
- `npm test` in `code/packages/typescript/macsyma-runtime`
- `npm run build` in `code/packages/typescript/macsyma-runtime`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-properties.json` from `code/programs/go/build-tool`
- `git diff --check`
