### PR TITLE
feat(powerpc601-simulator): Layer 07u — PowerPC 601 (1992) behavioral simulator

### DIFF
--- a/code/packages/python/powerpc601-simulator/BUILD
+++ b/code/packages/python/powerpc601-simulator/BUILD
@@ -1,0 +1,4 @@
+uv venv --quiet --clear
+uv pip install -e ../simulator-protocol -e ".[dev]" --quiet
+.venv/bin/ruff check src/ tests/
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/powerpc601-simulator/CHANGELOG.md
+++ b/code/packages/python/powerpc601-simulator/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [0.1.0] — 2026-05-12
+
+### Added
+- Initial implementation of the PowerPC 601 (1992) behavioral simulator (Layer 07u)
+- `PowerPC601State` — frozen dataclass with `cia`, `gpr` (32 × 32-bit), `lr`, `ctr`, `xer`, `cr`, `memory` (64 KiB), `halted`
+- `PowerPC601Simulator` implementing `Simulator[PowerPC601State]` (SIM00 protocol):
+  - `reset()`, `load()`, `step()`, `execute()`, `get_state()`
+- Instruction set (integer subset):
+  - **Arithmetic**: `add`, `addc`, `adde`, `subf`, `subfic`, `neg`, `mullw`, `divw`, `divwu`
+  - **Immediate arithmetic**: `addi`, `addis`
+  - **Logical**: `and`, `or`, `xor`, `nand`, `nor`, `cntlzw`
+  - **Logical immediate**: `andi.`, `andis.`, `ori`, `oris`, `xori`
+  - **Shift**: `slw`, `srw`, `sraw`, `srawi`
+  - **Compare**: `cmpw`, `cmplw`, `cmpwi`, `cmplwi`
+  - **Load**: `lwz`, `lwzu`, `lbz`, `lbzu`, `lhz`, `lhzu`, `lha`
+  - **Store**: `stw`, `stwu`, `stb`, `stbu`, `sth`
+  - **Branch**: `b`, `bl`, `bc` (all BO combinations), `blr`, `bctr`, `bctrl`
+  - **Special registers**: `mfspr`/`mtspr` (LR=8, CTR=9, XER=1), `mfcr`, `mtcrf`
+  - **HALT**: `0x00000000`
+- Encoding helpers exported: `i_form`, `b_form`, `d_form`, `x_form`, `xo_form`, `xfx_form`, `xl_form`
+- Constants exported: `HALT`, `BO_ALWAYS`, `BO_TRUE`, `BO_FALSE`, `BO_BDNZ`, `BO_BDZ`, `BI_LT`, `BI_GT`, `BI_EQ`, `BI_SO`, `SPR_LR`, `SPR_CTR`, `SPR_XER`, `MASK32`, `MEM_SIZE`, `XER_CA`, `XER_OV`, `XER_SO`
+- Test suite: 109 tests across 4 test files (protocol, instructions, coverage, programs)
+- End-to-end program tests: sum 1–10, factorial 5!, Fibonacci F(9), subroutine call/return, array sum, memory copy, XOR swap, max of two values, countdown loop, 64-bit add
+- Spec: `code/specs/07u-powerpc601-simulator.md`

--- a/code/packages/python/powerpc601-simulator/README.md
+++ b/code/packages/python/powerpc601-simulator/README.md
@@ -1,0 +1,114 @@
+# powerpc601-simulator
+
+**Layer 07u** — Behavioral simulator for the **PowerPC 601 (1992)** integer
+instruction set, implementing the SIM00 `Simulator[PowerPC601State]` protocol.
+
+## Background
+
+The PowerPC 601 was the first processor from the AIM alliance (Apple, IBM,
+Motorola) and powered the original Power Macintosh line in March 1994.
+It brought RISC principles — clean 32-bit fixed-width instructions,
+large register file, load/store architecture — to consumer desktops at a time
+when Intel's x86 still dominated with CISC complexity.
+
+The PowerPC ISA introduced:
+- **32 general-purpose 32-bit registers** (vs. 8 on x86)
+- **Fixed 32-bit instruction encoding** — no variable-length prefixes
+- **Condition Register (CR)** — 8 × 4-bit fields (LT, GT, EQ, SO per field)
+- **Count Register (CTR)** — hardware loop counter (bdnz/bdz)
+- **Link Register (LR)** — dedicated return address register (bl/blr)
+- **Big-endian** byte ordering
+
+## Installation
+
+```bash
+pip install coding-adventures-powerpc601-simulator
+```
+
+Or from source with uv:
+
+```bash
+uv pip install -e ".[dev]"
+```
+
+## Quick Start
+
+```python
+from powerpc601_simulator import (
+    PowerPC601Simulator,
+    HALT, d_form, xo_form, b_form,
+    BO_BDNZ, SPR_CTR,
+)
+from powerpc601_simulator.simulator import (
+    PO_ADDI, PO_BC, PO_X31, XO_MTSPR, XO_ADD,
+)
+
+# Sum 1 + 2 + ... + 10 = 55
+prog = (
+    d_form(PO_ADDI, 5, 0, 10)                    # r5 = 10
+    + xfx_form(PO_X31, 5, SPR_CTR, XO_MTSPR)    # CTR = 10
+    + d_form(PO_ADDI, 4, 0, 1)                   # r4 = 1 (counter)
+    + d_form(PO_ADDI, 3, 0, 0)                   # r3 = 0 (accumulator)
+    # loop:
+    + xo_form(PO_X31, 3, 3, 4, 0, XO_ADD)       # r3 += r4
+    + d_form(PO_ADDI, 4, 4, 1)                   # r4++
+    + b_form(PO_BC, BO_BDNZ, 0, -8)             # bdnz
+    + HALT
+)
+
+sim = PowerPC601Simulator()
+result = sim.execute(prog)
+assert result.final_state.r3 == 55
+```
+
+## Architecture Summary
+
+| Feature          | Value                                        |
+|------------------|----------------------------------------------|
+| Year             | 1992                                         |
+| Transistors      | 2.8 million                                  |
+| Clock speed      | 50–80 MHz                                    |
+| Word width       | 32-bit                                       |
+| Instruction size | 32-bit fixed                                 |
+| GPRs             | 32 × 32-bit (GPR0–GPR31)                   |
+| Special regs     | LR, CTR, XER, CR                            |
+| Endianness       | Big-endian                                   |
+| Memory (sim)     | 64 KiB byte-addressed flat                  |
+
+## Simulated Instructions
+
+| Category          | Instructions                                      |
+|-------------------|---------------------------------------------------|
+| Arithmetic        | add, addc, adde, subf, subfic, neg, mullw, divw, divwu |
+| Immediate arith   | addi, addis                                       |
+| Logical           | and, or, xor, nand, nor, cntlzw                 |
+| Logical immediate | andi., andis., ori, oris, xori                  |
+| Shift             | slw, srw, sraw, srawi                            |
+| Compare           | cmpw, cmplw, cmpwi, cmplwi                       |
+| Load              | lwz, lwzu, lbz, lbzu, lhz, lhzu, lha           |
+| Store             | stw, stwu, stb, stbu, sth                        |
+| Branch            | b, bl, bc (blt/bge/bgt/ble/beq/bne/bdnz/bdz)  |
+| Branch LR/CTR     | blr, bctr, bctrl                                 |
+| Special regs      | mfspr, mtspr (LR, CTR, XER), mfcr, mtcrf        |
+| HALT              | 0x00000000 (all-zeros word)                      |
+
+## SIM00 Protocol
+
+Implements `Simulator[PowerPC601State]` from `coding-adventures-simulator-protocol`:
+
+```python
+sim.reset()                        # Zero all state
+sim.load(program: bytes)           # Reset + load program at address 0
+trace = sim.step()                 # Execute one instruction
+result = sim.execute(program)      # Load + run to HALT
+state = sim.get_state()            # Frozen PowerPC601State snapshot
+```
+
+## Simplifications
+
+- No floating-point (FPR0–31 not simulated)
+- No MMU / virtual memory translation
+- OE=0 / Rc=0: arithmetic never sets XER[SO/OV] or CR0 automatically
+- No hardware exceptions or interrupts
+- GPR0-as-zero applies only in EA calculations (loads/stores/addi)
+- Memory: 64 KiB (vs. 4 GiB on real hardware)

--- a/code/packages/python/powerpc601-simulator/pyproject.toml
+++ b/code/packages/python/powerpc601-simulator/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-powerpc601-simulator"
+version = "0.1.0"
+description = "PowerPC 601 (1992) behavioral simulator — Layer 07u"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "coding-adventures-simulator-protocol",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/powerpc601_simulator"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=powerpc601_simulator --cov-report=term-missing --cov-fail-under=80"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+ignore = ["E501", "E701", "E702"]
+

--- a/code/packages/python/powerpc601-simulator/src/powerpc601_simulator/__init__.py
+++ b/code/packages/python/powerpc601-simulator/src/powerpc601_simulator/__init__.py
@@ -1,0 +1,63 @@
+"""PowerPC 601 (1992) behavioral simulator — Layer 07u."""
+
+from .simulator import (
+    BI_EQ,
+    BI_GT,
+    BI_LT,
+    BI_SO,
+    BO_ALWAYS,
+    BO_BDNZ,
+    BO_BDZ,
+    BO_FALSE,
+    BO_TRUE,
+    HALT,
+    SPR_CTR,
+    SPR_LR,
+    SPR_XER,
+    PowerPC601Simulator,
+    b_form,
+    d_form,
+    i_form,
+    x_form,
+    xfx_form,
+    xl_form,
+    xo_form,
+)
+from .state import MASK32, MEM_SIZE, XER_CA, XER_OV, XER_SO, PowerPC601State, make_initial_state
+
+__all__ = [
+    # Simulator and state
+    "PowerPC601Simulator",
+    "PowerPC601State",
+    "make_initial_state",
+    # Constants
+    "HALT",
+    "MASK32",
+    "MEM_SIZE",
+    "XER_CA",
+    "XER_OV",
+    "XER_SO",
+    # SPR numbers
+    "SPR_XER",
+    "SPR_LR",
+    "SPR_CTR",
+    # BO constants
+    "BO_ALWAYS",
+    "BO_TRUE",
+    "BO_FALSE",
+    "BO_BDNZ",
+    "BO_BDZ",
+    # BI constants
+    "BI_LT",
+    "BI_GT",
+    "BI_EQ",
+    "BI_SO",
+    # Encoding helpers
+    "i_form",
+    "b_form",
+    "d_form",
+    "x_form",
+    "xo_form",
+    "xfx_form",
+    "xl_form",
+]

--- a/code/packages/python/powerpc601-simulator/src/powerpc601_simulator/simulator.py
+++ b/code/packages/python/powerpc601-simulator/src/powerpc601_simulator/simulator.py
@@ -1,0 +1,1465 @@
+"""
+PowerPC 601 (1992) Behavioral Simulator
+=========================================
+
+The PowerPC 601 was the first chip produced by the AIM alliance (Apple, IBM,
+Motorola) and powered the original Power Macintosh.  This module implements a
+behavioral simulation of its integer instruction set.
+
+Architecture at a glance
+------------------------
+
+  Word width:   32 bits (big-endian)
+
+  Registers:
+    GPR0–GPR31  32-bit general-purpose registers
+                GPR0 is treated as 0 when used as rA in effective-address
+                calculations (loads, stores, addi, addis), but otherwise
+                holds its actual value.
+    LR          Link Register — stores return address after bl/bctrl
+    CTR         Count Register — decremented by bdnz-style branches;
+                also used as indirect branch target
+    XER         Fixed-Point Exception Register:
+                  bit 31 (MSB) = SO (Summary Overflow)
+                  bit 30       = OV (Overflow)
+                  bit 29       = CA (Carry)
+    CR          Condition Register — 8 × 4-bit fields CR0…CR7.
+                CR0 occupies the most-significant nibble (bits [31:28]).
+                Each field: [LT(3), GT(2), EQ(1), SO(0)] from high to low.
+    CIA         Current Instruction Address (the program counter)
+
+  Instruction encoding:
+    All instructions are exactly 32 bits (4 bytes), big-endian.
+    Primary opcode occupies bits [31:26] (MSB side in PPC notation = Python
+    bit-positions 31..26 of a big-endian 32-bit word).
+
+  Memory:   65 536 byte-addressed bytes.  Big-endian word reads/writes.
+
+  HALT:     Instruction word 0x00000000 (all zeros).  Not a valid PowerPC
+            instruction; the simulator halts immediately on encountering it.
+
+Instruction formats
+-------------------
+
+I-form (branch unconditional):
+  [31:26] OPCD  [25: 2] LI (24-bit signed)  [1] AA  [0] LK
+
+B-form (branch conditional):
+  [31:26] OPCD  [25:21] BO  [20:16] BI  [15:2] BD (14-bit signed)  [1] AA  [0] LK
+
+D-form (load/store/arithmetic immediate):
+  [31:26] OPCD  [25:21] rD  [20:16] rA  [15:0] imm (16-bit)
+
+X-form (register–register, logic, compare, shift):
+  [31:26] OPCD  [25:21] rS  [20:16] rA  [15:11] rB  [10:1] XO  [0] Rc
+
+XO-form (integer arithmetic):
+  [31:26] OPCD  [25:21] rD  [20:16] rA  [15:11] rB  [10] OE  [9:1] XO  [0] Rc
+
+XFX-form (move to/from special registers):
+  [31:26] OPCD  [25:21] rS  [20:11] SPR (split encoding)  [10:1] XO  [0] –
+
+XL-form (branch via LR/CTR):
+  [31:26] OPCD  [25:21] BO  [20:16] BI  [15:11] BH  [10:1] XO  [0] LK
+
+Signed arithmetic
+-----------------
+All arithmetic uses Python integers masked to 32 bits.  Signed operations
+sign-extend the 32-bit result before comparison.  XER[CA] is set on
+carry-out from bit 31 for addc/adde/subfic; XER[SO/OV] are not simulated
+(OE=0 for all instructions in this behavioral subset).
+"""
+
+from __future__ import annotations
+
+from simulator_protocol import ExecutionResult, Simulator, StepTrace
+
+from .state import (
+    MASK32,
+    MEM_SIZE,
+    XER_CA,
+    XER_SO,
+    PowerPC601State,
+    make_initial_state,
+    sext16,
+    sext32,
+)
+
+# ── HALT word ───────────────────────────────────────────────────────────────────
+
+HALT: bytes = b"\x00\x00\x00\x00"
+
+# ── SPR numbers ─────────────────────────────────────────────────────────────────
+
+SPR_XER: int = 1    # Fixed-point exception register
+SPR_LR:  int = 8    # Link register
+SPR_CTR: int = 9    # Count register
+
+# ── Branch BO field constants ────────────────────────────────────────────────────
+# (BO[0] = bit 4 = most significant of the 5-bit BO integer)
+
+BO_ALWAYS: int = 20   # 0b10100 — branch always; ignore CTR and CR
+BO_TRUE:   int = 18   # 0b10010 — branch if CR[BI] = 1; don't test CTR
+BO_FALSE:  int = 16   # 0b10000 — branch if CR[BI] = 0; don't test CTR
+BO_BDNZ:   int = 4    # 0b00100 — decrement CTR; branch if CTR ≠ 0; ignore CR
+BO_BDZ:    int = 12   # 0b01100 — decrement CTR; branch if CTR = 0; ignore CR
+
+# ── CR bit indices (BI field values for CR0) ────────────────────────────────────
+
+BI_LT: int = 0   # CR0.LT — less than
+BI_GT: int = 1   # CR0.GT — greater than
+BI_EQ: int = 2   # CR0.EQ — equal
+BI_SO: int = 3   # CR0.SO — summary overflow
+
+# ── Primary opcodes ─────────────────────────────────────────────────────────────
+
+PO_SUBFIC   = 8    # D-form: SIMM - rA, set CA
+PO_CMPLI    = 10   # D-form: unsigned compare immediate
+PO_CMPI     = 11   # D-form: signed compare immediate
+PO_ADDI     = 14   # D-form: add immediate
+PO_ADDIS    = 15   # D-form: add immediate shifted
+PO_BC       = 16   # B-form: branch conditional
+PO_B        = 18   # I-form: branch (unconditional/link)
+PO_BX       = 19   # XL-form: bclr / bcctr
+PO_ORI      = 24   # D-form: or immediate
+PO_ORIS     = 25   # D-form: or immediate shifted
+PO_XORI     = 26   # D-form: xor immediate
+PO_ANDI_DOT = 28   # D-form: and immediate (sets CR0)
+PO_ANDIS_DOT = 29  # D-form: and immediate shifted (sets CR0)
+PO_X31      = 31   # X/XO/XFX-form: most register-register ops
+
+PO_LWZ  = 32   # D-form: load word and zero
+PO_LWZU = 33   # D-form: load word and zero with update
+PO_LBZ  = 34   # D-form: load byte and zero
+PO_LBZU = 35   # D-form: load byte and zero with update
+PO_STW  = 36   # D-form: store word
+PO_STWU = 37   # D-form: store word with update
+PO_STB  = 38   # D-form: store byte
+PO_STBU = 39   # D-form: store byte with update
+PO_LHZ  = 40   # D-form: load halfword and zero
+PO_LHZU = 41   # D-form: load halfword and zero with update
+PO_LHA  = 42   # D-form: load halfword algebraic (sign-extend)
+PO_STH  = 44   # D-form: store halfword
+
+# ── Secondary opcodes for PO_X31 ────────────────────────────────────────────────
+# X-form secondary opcodes use bits [10:1] (10-bit XO from a 32-bit word)
+
+XO_CMP    = 0     # X-form: signed compare
+XO_ADDC   = 10    # XO-form: add carrying
+XO_CNTLZW = 26   # X-form: count leading zeros word
+XO_AND    = 28    # X-form: and
+XO_CMPL   = 32    # X-form: unsigned compare
+XO_SUBF   = 40    # XO-form: subtract from
+XO_NOR    = 124   # X-form: nor
+XO_ADDE   = 138   # XO-form: add extended
+XO_NEG    = 104   # XO-form: negate
+XO_MFCR   = 19    # XFX-form: move from CR
+XO_MTCRF  = 144   # XFX-form: move to CR fields
+XO_OR     = 444   # X-form: or
+XO_MULLW  = 235   # XO-form: multiply low word
+XO_XOR    = 316   # X-form: xor
+XO_MFSPR  = 339   # XFX-form: move from SPR
+XO_NAND   = 476   # X-form: nand
+XO_DIVWU  = 459   # XO-form: divide word unsigned
+XO_MTSPR  = 467   # XFX-form: move to SPR
+XO_ADD    = 266   # XO-form: add
+XO_DIVW   = 491   # XO-form: divide word signed
+XO_SLW    = 24    # X-form: shift left word
+XO_SRW    = 536   # X-form: shift right word
+XO_SRAW   = 792   # X-form: shift right algebraic word
+XO_SRAWI  = 824   # X-form: shift right algebraic word immediate
+
+# ── Secondary opcodes for PO_BX (opcode 19) ─────────────────────────────────────
+
+XO_BCLR  = 16    # XL-form: branch to LR
+XO_BCCTR = 528   # XL-form: branch to CTR
+
+
+# ── Instruction encoding helpers ─────────────────────────────────────────────────
+
+
+def i_form(opcode: int, byte_offset: int, AA: int = 0, LK: int = 0) -> bytes:
+    """
+    Encode an I-form instruction (branch unconditional).
+
+    byte_offset — signed byte offset from CIA (or absolute address if AA=1).
+    LK=1 sets the link bit (saves CIA+4 → LR).
+
+    Encoding: [OPCD:6][LI:24][AA:1][LK:1]
+    LI is the byte_offset divided by 4 (instructions are 4-byte aligned).
+    """
+    LI = (byte_offset >> 2) & 0xFF_FFFF  # 24-bit field
+    v = (opcode << 26) | (LI << 2) | (AA << 1) | LK
+    return v.to_bytes(4, "big")
+
+
+def b_form(
+    opcode: int, BO: int, BI: int, byte_offset: int, AA: int = 0, LK: int = 0
+) -> bytes:
+    """
+    Encode a B-form instruction (branch conditional).
+
+    byte_offset — signed byte offset from CIA (or absolute if AA=1).
+    BO — 5-bit branch options (use BO_TRUE, BO_FALSE, BO_ALWAYS, BO_BDNZ, BO_BDZ).
+    BI — 5-bit CR bit index (BI_LT=0, BI_GT=1, BI_EQ=2, BI_SO=3 for CR0).
+    """
+    BD = (byte_offset >> 2) & 0x3FFF  # 14-bit field
+    v = (opcode << 26) | (BO << 21) | (BI << 16) | (BD << 2) | (AA << 1) | LK
+    return v.to_bytes(4, "big")
+
+
+def d_form(opcode: int, rD: int, rA: int, imm: int) -> bytes:
+    """
+    Encode a D-form instruction (immediate arithmetic, load, store, compare).
+
+    imm — 16-bit immediate; stored as-is (caller responsible for masking).
+    For signed operands pass the signed value; it will be masked to 16 bits.
+    For unsigned operands (ori, xori, andi.) pass the unsigned value directly.
+    """
+    v = (opcode << 26) | (rD << 21) | (rA << 16) | (imm & 0xFFFF)
+    return v.to_bytes(4, "big")
+
+
+def x_form(opcode: int, rS: int, rA: int, rB: int, xo: int, rc: int = 0) -> bytes:
+    """
+    Encode an X-form instruction (register–register, logic, shift, compare).
+
+    [OPCD:6][rS:5][rA:5][rB:5][XO:10][Rc:1]
+    """
+    v = (opcode << 26) | (rS << 21) | (rA << 16) | (rB << 11) | (xo << 1) | rc
+    return v.to_bytes(4, "big")
+
+
+def xo_form(
+    opcode: int, rD: int, rA: int, rB: int, oe: int, xo: int, rc: int = 0
+) -> bytes:
+    """
+    Encode an XO-form instruction (integer arithmetic).
+
+    [OPCD:6][rD:5][rA:5][rB:5][OE:1][XO:9][Rc:1]
+    """
+    v = (opcode << 26) | (rD << 21) | (rA << 16) | (rB << 11) | (oe << 10) | (xo << 1) | rc
+    return v.to_bytes(4, "big")
+
+
+def xfx_form(opcode: int, rS: int, spr: int, xo: int) -> bytes:
+    """
+    Encode an XFX-form instruction (move to/from special registers).
+
+    The 10-bit SPR is stored split: SPR[5:9] at bits [20:16], SPR[0:4] at bits [15:11].
+
+    [OPCD:6][rS:5][SPR[5:9]:5][SPR[0:4]:5][XO:10][0:1]
+    """
+    spr_enc = ((spr & 0x1F) << 5) | ((spr >> 5) & 0x1F)
+    v = (opcode << 26) | (rS << 21) | (spr_enc << 11) | (xo << 1)
+    return v.to_bytes(4, "big")
+
+
+def xl_form(opcode: int, BO: int, BI: int, BH: int, xo: int, lk: int = 0) -> bytes:
+    """
+    Encode an XL-form instruction (branch via LR or CTR).
+
+    [OPCD:6][BO:5][BI:5][BH:5][XO:10][LK:1]
+    """
+    v = (opcode << 26) | (BO << 21) | (BI << 16) | (BH << 11) | (xo << 1) | lk
+    return v.to_bytes(4, "big")
+
+
+# ── Simulator ───────────────────────────────────────────────────────────────────
+
+
+class PowerPC601Simulator(Simulator[PowerPC601State]):
+    """
+    Behavioral simulator for the PowerPC 601 (1992) integer instruction set.
+
+    Implements the SIM00 Simulator[PowerPC601State] protocol:
+      reset()       — zero all state
+      load(prog)    — reset + copy program bytes into memory
+      step()        — fetch-decode-execute one instruction; return StepTrace
+      execute(prog) — load + step loop until HALT or max_steps
+      get_state()   — return frozen state snapshot
+
+    Simplifications:
+    - No floating-point (FPR0–31 not simulated)
+    - No MMU / virtual memory
+    - OE=0 / Rc=0 for arithmetic (XER[SO/OV] never set by arithmetic)
+    - Only compare instructions and andi./andis. update CR
+    - Misaligned accesses succeed (address masked to alignment boundary)
+    - No hardware exceptions; unknown opcodes emit an ERROR trace
+    """
+
+    def __init__(self) -> None:
+        self._state: PowerPC601State = make_initial_state()
+
+    # ── SIM00 protocol ────────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Zero all registers, memory, CIA, and halted flag."""
+        self._state = make_initial_state()
+
+    def load(self, program: bytes) -> None:
+        """
+        Reset the simulator and copy program bytes into memory starting at address 0.
+
+        The program is written byte-by-byte.  Bytes beyond MEM_SIZE are silently
+        truncated.  Instructions are executed starting at CIA=0.
+        """
+        self.reset()
+        mem = list(self._state.memory)
+        for i, b in enumerate(program):
+            if i >= MEM_SIZE:
+                break
+            mem[i] = b
+        self._state = PowerPC601State(
+            cia=0,
+            gpr=self._state.gpr,
+            lr=self._state.lr,
+            ctr=self._state.ctr,
+            xer=self._state.xer,
+            cr=self._state.cr,
+            memory=tuple(mem),
+            halted=False,
+        )
+
+    def step(self) -> StepTrace:
+        """
+        Fetch, decode, and execute one instruction at CIA.
+
+        Returns a StepTrace with the PC before/after, mnemonic, and description.
+        If already halted, returns a no-op HALT trace without advancing CIA.
+        """
+        cia = self._state.cia
+
+        if self._state.halted:
+            return StepTrace(
+                pc_before=cia,
+                pc_after=cia,
+                mnemonic="HALT",
+                description="Simulator is halted.",
+            )
+
+        instr = self._fetch32(cia)
+
+        if instr == 0:
+            # All-zeros word — HALT
+            self._state = PowerPC601State(
+                cia=cia,
+                gpr=self._state.gpr,
+                lr=self._state.lr,
+                ctr=self._state.ctr,
+                xer=self._state.xer,
+                cr=self._state.cr,
+                memory=self._state.memory,
+                halted=True,
+            )
+            return StepTrace(
+                pc_before=cia,
+                pc_after=cia,
+                mnemonic="HALT",
+                description=f"HALT at CIA=0x{cia:04X}.",
+            )
+
+        return self._execute_instr(instr, cia)
+
+    def execute(
+        self, program: bytes, max_steps: int = 100_000
+    ) -> ExecutionResult[PowerPC601State]:
+        """
+        Load program and step until halted or max_steps exceeded.
+
+        Returns an ExecutionResult with final state, trace list, and status.
+        """
+        self.load(program)
+        traces: list[StepTrace] = []
+        for _ in range(max_steps):
+            trace = self.step()
+            traces.append(trace)
+            if trace.mnemonic.startswith("ERROR:"):
+                return ExecutionResult(
+                    halted=False,
+                    steps=len(traces),
+                    final_state=self._state,
+                    traces=traces,
+                    error=trace.mnemonic,
+                )
+            if self._state.halted:
+                return ExecutionResult(
+                    halted=True,
+                    steps=len(traces),
+                    final_state=self._state,
+                    traces=traces,
+                    error=None,
+                )
+        return ExecutionResult(
+            halted=False,
+            steps=max_steps,
+            final_state=self._state,
+            traces=traces,
+            error=f"max_steps={max_steps} exceeded",
+        )
+
+    def get_state(self) -> PowerPC601State:
+        """Return an immutable snapshot of the current simulator state."""
+        return self._state
+
+    # ── Memory helpers ────────────────────────────────────────────────────────
+
+    def _fetch32(self, addr: int) -> int:
+        """Read a big-endian 32-bit word from memory at addr."""
+        addr = addr & (MEM_SIZE - 1)
+        m = self._state.memory
+        return (m[addr] << 24) | (m[addr + 1] << 16) | (m[addr + 2] << 8) | m[addr + 3]
+
+    def _load32(self, addr: int) -> int:
+        """Load a big-endian 32-bit word from memory (word-aligned)."""
+        addr = addr & ~3 & (MEM_SIZE - 1)
+        m = self._state.memory
+        return (m[addr] << 24) | (m[addr + 1] << 16) | (m[addr + 2] << 8) | m[addr + 3]
+
+    def _load16z(self, addr: int) -> int:
+        """Load a big-endian 16-bit halfword (zero-extended)."""
+        addr = addr & ~1 & (MEM_SIZE - 1)
+        m = self._state.memory
+        return (m[addr] << 8) | m[addr + 1]
+
+    def _load16a(self, addr: int) -> int:
+        """Load a big-endian 16-bit halfword (sign-extended to 32 bits)."""
+        v = self._load16z(addr)
+        if v & 0x8000:
+            return v - 0x10000
+        return v
+
+    def _load8(self, addr: int) -> int:
+        """Load a single byte (zero-extended)."""
+        return self._state.memory[addr & (MEM_SIZE - 1)]
+
+    def _store32(self, addr: int, val: int, gpr: list[int],
+                 lr: int, ctr: int, xer: int, cr: int) -> tuple[int, ...]:
+        """Return a new memory tuple with a 32-bit big-endian word written at addr."""
+        addr = addr & ~3 & (MEM_SIZE - 1)
+        val = val & MASK32
+        mem = list(self._state.memory)
+        mem[addr]     = (val >> 24) & 0xFF
+        mem[addr + 1] = (val >> 16) & 0xFF
+        mem[addr + 2] = (val >> 8)  & 0xFF
+        mem[addr + 3] =  val        & 0xFF
+        return tuple(mem)
+
+    def _store16(self, addr: int, val: int) -> tuple[int, ...]:
+        """Return a new memory tuple with a 16-bit big-endian halfword written."""
+        addr = addr & ~1 & (MEM_SIZE - 1)
+        val = val & 0xFFFF
+        mem = list(self._state.memory)
+        mem[addr]     = (val >> 8) & 0xFF
+        mem[addr + 1] =  val       & 0xFF
+        return tuple(mem)
+
+    def _store8(self, addr: int, val: int) -> tuple[int, ...]:
+        """Return a new memory tuple with a single byte written."""
+        addr = addr & (MEM_SIZE - 1)
+        mem = list(self._state.memory)
+        mem[addr] = val & 0xFF
+        return tuple(mem)
+
+    # ── CR helpers ────────────────────────────────────────────────────────────
+
+    def _update_cr_field(
+        self, cr: int, field: int, lt: int, gt: int, eq: int, so: int
+    ) -> int:
+        """
+        Update one 4-bit CR field (0=CR0, 7=CR7).
+
+        The nibble bits are [LT, GT, EQ, SO] from most to least significant.
+        Shifts the nibble into the correct position within the 32-bit CR integer.
+        """
+        nibble = (lt << 3) | (gt << 2) | (eq << 1) | so
+        shift = 28 - field * 4
+        mask = 0xF << shift
+        return (cr & ~mask) | (nibble << shift)
+
+    def _compare_signed(
+        self, a: int, b: int, xer: int, cr: int, field: int
+    ) -> int:
+        """Set a CR field from signed comparison of a and b."""
+        sa, sb = sext32(a), sext32(b)
+        lt = 1 if sa < sb else 0
+        gt = 1 if sa > sb else 0
+        eq = 1 if sa == sb else 0
+        so = 1 if (xer & XER_SO) else 0
+        return self._update_cr_field(cr, field, lt, gt, eq, so)
+
+    def _compare_unsigned(
+        self, a: int, b: int, xer: int, cr: int, field: int
+    ) -> int:
+        """Set a CR field from unsigned comparison of a and b."""
+        ua, ub = a & MASK32, b & MASK32
+        lt = 1 if ua < ub else 0
+        gt = 1 if ua > ub else 0
+        eq = 1 if ua == ub else 0
+        so = 1 if (xer & XER_SO) else 0
+        return self._update_cr_field(cr, field, lt, gt, eq, so)
+
+    def _update_cr0_from_result(self, result: int, xer: int, cr: int) -> int:
+        """Update CR0 based on a 32-bit arithmetic/logical result (signed)."""
+        s = sext32(result)
+        lt = 1 if s < 0 else 0
+        gt = 1 if s > 0 else 0
+        eq = 1 if s == 0 else 0
+        so = 1 if (xer & XER_SO) else 0
+        return self._update_cr_field(cr, 0, lt, gt, eq, so)
+
+    # ── Branch evaluation ─────────────────────────────────────────────────────
+
+    def _eval_branch(self, bo: int, bi: int, ctr: int, cr: int) -> tuple[bool, int]:
+        """
+        Evaluate a conditional branch.
+
+        Returns (should_branch, new_ctr).
+
+        BO bit layout (bit 4 = MSB of the 5-bit integer, as extracted
+        from the instruction word with `(instr >> 21) & 0x1F`):
+          BO[0] = (bo >> 4) & 1  — if 1, don't decrement/test CTR
+          BO[1] = (bo >> 3) & 1  — CTR test: 0 = branch if CTR≠0, 1 = if CTR=0
+          BO[2] = (bo >> 2) & 1  — if 1, don't test CR condition bit
+          BO[3] = (bo >> 1) & 1  — CR test: 1 = branch if bit=1, 0 = branch if bit=0
+          BO[4] = bo & 1         — branch prediction hint (ignored)
+        """
+        bo0 = (bo >> 4) & 1
+        bo1 = (bo >> 3) & 1
+        bo2 = (bo >> 2) & 1
+        bo3 = (bo >> 1) & 1
+
+        # CTR condition
+        if bo0 == 0:
+            ctr = (ctr - 1) & MASK32
+            ctr_ok = (ctr != 0) if bo1 == 0 else (ctr == 0)
+        else:
+            ctr_ok = True
+
+        # CR condition
+        if bo2 == 0:
+            cr_bit = (cr >> (31 - bi)) & 1
+            cond_ok = (cr_bit == bo3)
+        else:
+            cond_ok = True
+
+        return ctr_ok and cond_ok, ctr
+
+    # ── Effective address ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _ea(gpr: list[int], ra: int, d: int) -> int:
+        """Compute effective address for D-form load/store/addi.
+
+        If rA = 0, the base is 0 (not GPR0's contents).
+        d is the sign-extended 16-bit displacement.
+        """
+        base = 0 if ra == 0 else gpr[ra]
+        return (base + d) & MASK32
+
+    # ── Main instruction dispatch ─────────────────────────────────────────────
+
+    def _execute_instr(self, instr: int, cia: int) -> StepTrace:
+        """
+        Decode and execute a 32-bit instruction word.
+
+        Extracts the primary opcode from bits [31:26] of the 32-bit integer
+        (where bit 31 is the MSB in our Python representation of a big-endian
+        word).  Dispatches to the appropriate handler.
+        """
+        opcd = (instr >> 26) & 0x3F
+
+        if opcd == PO_ADDI:
+            return self._exec_addi(instr, cia)
+        elif opcd == PO_ADDIS:
+            return self._exec_addis(instr, cia)
+        elif opcd == PO_SUBFIC:
+            return self._exec_subfic(instr, cia)
+        elif opcd == PO_ORI:
+            return self._exec_ori(instr, cia)
+        elif opcd == PO_ORIS:
+            return self._exec_oris(instr, cia)
+        elif opcd == PO_XORI:
+            return self._exec_xori(instr, cia)
+        elif opcd == PO_ANDI_DOT:
+            return self._exec_andi_dot(instr, cia)
+        elif opcd == PO_ANDIS_DOT:
+            return self._exec_andis_dot(instr, cia)
+        elif opcd == PO_CMPI:
+            return self._exec_cmpi(instr, cia)
+        elif opcd == PO_CMPLI:
+            return self._exec_cmpli(instr, cia)
+        elif opcd == PO_LWZ:
+            return self._exec_lwz(instr, cia)
+        elif opcd == PO_LWZU:
+            return self._exec_lwzu(instr, cia)
+        elif opcd == PO_LBZ:
+            return self._exec_lbz(instr, cia)
+        elif opcd == PO_LBZU:
+            return self._exec_lbzu(instr, cia)
+        elif opcd == PO_LHZ:
+            return self._exec_lhz(instr, cia)
+        elif opcd == PO_LHZU:
+            return self._exec_lhzu(instr, cia)
+        elif opcd == PO_LHA:
+            return self._exec_lha(instr, cia)
+        elif opcd == PO_STW:
+            return self._exec_stw(instr, cia)
+        elif opcd == PO_STWU:
+            return self._exec_stwu(instr, cia)
+        elif opcd == PO_STB:
+            return self._exec_stb(instr, cia)
+        elif opcd == PO_STBU:
+            return self._exec_stbu(instr, cia)
+        elif opcd == PO_STH:
+            return self._exec_sth(instr, cia)
+        elif opcd == PO_B:
+            return self._exec_b(instr, cia)
+        elif opcd == PO_BC:
+            return self._exec_bc(instr, cia)
+        elif opcd == PO_BX:
+            return self._exec_bx(instr, cia)
+        elif opcd == PO_X31:
+            return self._exec_x31(instr, cia)
+        else:
+            # Unknown opcode — emit an error trace and halt
+            self._state = PowerPC601State(
+                cia=cia,
+                gpr=self._state.gpr,
+                lr=self._state.lr,
+                ctr=self._state.ctr,
+                xer=self._state.xer,
+                cr=self._state.cr,
+                memory=self._state.memory,
+                halted=True,
+            )
+            return StepTrace(
+                pc_before=cia,
+                pc_after=cia,
+                mnemonic=f"ERROR: unknown opcode {opcd}",
+                description=f"Unknown primary opcode {opcd} (instr=0x{instr:08X}) at CIA=0x{cia:04X}.",
+            )
+
+    # ── Instruction implementations ───────────────────────────────────────────
+
+    # D-form helpers
+
+    def _exec_addi(self, instr: int, cia: int) -> StepTrace:
+        """
+        addi rD, rA, SIMM   (opcode 14)
+
+        rD = (rA == 0 ? 0 : GPR[rA]) + sign_extend(SIMM)
+
+        The special rA=0 rule lets 'li rD, val' be encoded as 'addi rD, 0, val'.
+        """
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        simm = sext16(instr & 0xFFFF)
+        base = 0 if ra == 0 else self._state.gpr[ra]
+        result = (base + simm) & MASK32
+        gpr = list(self._state.gpr)
+        gpr[rd] = result
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        mnem = f"addi r{rd}, r{ra}, {simm}"
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=mnem,
+                         description=f"r{rd} = 0x{result:08X}")
+
+    def _exec_addis(self, instr: int, cia: int) -> StepTrace:
+        """
+        addis rD, rA, SIMM  (opcode 15)
+
+        rD = (rA == 0 ? 0 : GPR[rA]) + (SIMM << 16)
+
+        'lis rD, val' = 'addis rD, 0, val' — loads a 16-bit constant into the
+        upper half of rD (lower half zeroed).
+        """
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        simm = sext16(instr & 0xFFFF)
+        base = 0 if ra == 0 else self._state.gpr[ra]
+        result = (base + (simm << 16)) & MASK32
+        gpr = list(self._state.gpr)
+        gpr[rd] = result
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        mnem = f"addis r{rd}, r{ra}, {simm}"
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=mnem,
+                         description=f"r{rd} = 0x{result:08X}")
+
+    def _exec_subfic(self, instr: int, cia: int) -> StepTrace:
+        """
+        subfic rD, rA, SIMM  (opcode 8)
+
+        rD = SIMM - GPR[rA]; sets XER[CA] on borrow-out.
+
+        The carry flag CA is set if there is no borrow, i.e., SIMM >= GPR[rA]
+        (unsigned).  PowerPC uses "carry = no borrow" convention.
+        """
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        simm = sext16(instr & 0xFFFF) & MASK32
+        ra_val = self._state.gpr[ra]
+        # subfic: result = ~rA + SIMM + 1  (subtract from: SIMM - rA)
+        result = (simm - ra_val) & MASK32
+        # CA set if ~rA + SIMM + 1 >= 2^32 i.e. no borrow
+        # Equivalently: (SIMM as unsigned) >= (rA as unsigned)
+        ca = 1 if (simm & MASK32) >= (ra_val & MASK32) else 0
+        xer = (self._state.xer & ~XER_CA) | (XER_CA if ca else 0)
+        gpr = list(self._state.gpr)
+        gpr[rd] = result
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        mnem = f"subfic r{rd}, r{ra}, {sext16(instr & 0xFFFF)}"
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=mnem,
+                         description=f"r{rd} = 0x{result:08X}, CA={ca}")
+
+    def _exec_ori(self, instr: int, cia: int) -> StepTrace:
+        """ori rA, rS, UIMM — rA = GPR[rS] | UIMM (zero-extended)."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        uimm = instr & 0xFFFF
+        result = (self._state.gpr[rs] | uimm) & MASK32
+        gpr = list(self._state.gpr)
+        gpr[ra] = result
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"ori r{ra}, r{rs}, {uimm}",
+                         description=f"r{ra} = 0x{result:08X}")
+
+    def _exec_oris(self, instr: int, cia: int) -> StepTrace:
+        """oris rA, rS, UIMM — rA = GPR[rS] | (UIMM << 16)."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        uimm = instr & 0xFFFF
+        result = (self._state.gpr[rs] | (uimm << 16)) & MASK32
+        gpr = list(self._state.gpr)
+        gpr[ra] = result
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"oris r{ra}, r{rs}, {uimm}",
+                         description=f"r{ra} = 0x{result:08X}")
+
+    def _exec_xori(self, instr: int, cia: int) -> StepTrace:
+        """xori rA, rS, UIMM — rA = GPR[rS] ^ UIMM (zero-extended)."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        uimm = instr & 0xFFFF
+        result = (self._state.gpr[rs] ^ uimm) & MASK32
+        gpr = list(self._state.gpr)
+        gpr[ra] = result
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"xori r{ra}, r{rs}, {uimm}",
+                         description=f"r{ra} = 0x{result:08X}")
+
+    def _exec_andi_dot(self, instr: int, cia: int) -> StepTrace:
+        """andi. rA, rS, UIMM — rA = rS & UIMM; always updates CR0."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        uimm = instr & 0xFFFF
+        result = (self._state.gpr[rs] & uimm) & MASK32
+        gpr = list(self._state.gpr)
+        gpr[ra] = result
+        new_cr = self._update_cr0_from_result(result, self._state.xer, self._state.cr)
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=new_cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"andi. r{ra}, r{rs}, {uimm}",
+                         description=f"r{ra} = 0x{result:08X}; CR0 updated")
+
+    def _exec_andis_dot(self, instr: int, cia: int) -> StepTrace:
+        """andis. rA, rS, UIMM — rA = rS & (UIMM << 16); updates CR0."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        uimm = instr & 0xFFFF
+        result = (self._state.gpr[rs] & (uimm << 16)) & MASK32
+        gpr = list(self._state.gpr)
+        gpr[ra] = result
+        new_cr = self._update_cr0_from_result(result, self._state.xer, self._state.cr)
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=new_cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"andis. r{ra}, r{rs}, {uimm}",
+                         description=f"r{ra} = 0x{result:08X}; CR0 updated")
+
+    def _exec_cmpi(self, instr: int, cia: int) -> StepTrace:
+        """
+        cmpwi crfD, rA, SIMM  (opcode 11)
+
+        Signed comparison of GPR[rA] with sign_extend(SIMM).
+        Updates CR field crfD (bits [8:6] of the instruction).
+        """
+        crfd = (instr >> 23) & 0x7
+        ra   = (instr >> 16) & 0x1F
+        simm = sext16(instr & 0xFFFF)
+        new_cr = self._compare_signed(
+            self._state.gpr[ra], simm & MASK32, self._state.xer, self._state.cr, crfd
+        )
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=new_cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4,
+                         mnemonic=f"cmpwi cr{crfd}, r{ra}, {simm}",
+                         description=f"CR{crfd} = 0x{(new_cr >> (28 - crfd * 4)) & 0xF:X}")
+
+    def _exec_cmpli(self, instr: int, cia: int) -> StepTrace:
+        """
+        cmplwi crfD, rA, UIMM  (opcode 10)
+
+        Unsigned comparison of GPR[rA] with UIMM (zero-extended).
+        """
+        crfd = (instr >> 23) & 0x7
+        ra   = (instr >> 16) & 0x1F
+        uimm = instr & 0xFFFF
+        new_cr = self._compare_unsigned(
+            self._state.gpr[ra], uimm, self._state.xer, self._state.cr, crfd
+        )
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=new_cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4,
+                         mnemonic=f"cmplwi cr{crfd}, r{ra}, {uimm}",
+                         description=f"CR{crfd} = 0x{(new_cr >> (28 - crfd * 4)) & 0xF:X}")
+
+    # Load instructions
+
+    def _exec_lwz(self, instr: int, cia: int) -> StepTrace:
+        """lwz rD, d(rA) — load 4-byte word, zero-extend to 32 bits."""
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        val = self._load32(ea)
+        gpr = list(self._state.gpr)
+        gpr[rd] = val
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"lwz r{rd}, {d}(r{ra})",
+                         description=f"r{rd} = MEM[0x{ea:04X}] = 0x{val:08X}")
+
+    def _exec_lwzu(self, instr: int, cia: int) -> StepTrace:
+        """lwzu rD, d(rA) — load word, update rA = EA."""
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        val = self._load32(ea)
+        gpr = list(self._state.gpr)
+        gpr[rd] = val
+        gpr[ra] = ea
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"lwzu r{rd}, {d}(r{ra})",
+                         description=f"r{rd} = MEM[0x{ea:04X}] = 0x{val:08X}; r{ra} updated")
+
+    def _exec_lbz(self, instr: int, cia: int) -> StepTrace:
+        """lbz rD, d(rA) — load byte, zero-extended."""
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        val = self._load8(ea)
+        gpr = list(self._state.gpr)
+        gpr[rd] = val
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"lbz r{rd}, {d}(r{ra})",
+                         description=f"r{rd} = MEM[0x{ea:04X}] = 0x{val:02X}")
+
+    def _exec_lbzu(self, instr: int, cia: int) -> StepTrace:
+        """lbzu rD, d(rA) — load byte, zero-extended, update rA."""
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        val = self._load8(ea)
+        gpr = list(self._state.gpr)
+        gpr[rd] = val
+        gpr[ra] = ea
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"lbzu r{rd}, {d}(r{ra})",
+                         description=f"r{rd} = 0x{val:02X}; r{ra} = 0x{ea:04X}")
+
+    def _exec_lhz(self, instr: int, cia: int) -> StepTrace:
+        """lhz rD, d(rA) — load 16-bit halfword, zero-extended."""
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        val = self._load16z(ea)
+        gpr = list(self._state.gpr)
+        gpr[rd] = val
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"lhz r{rd}, {d}(r{ra})",
+                         description=f"r{rd} = 0x{val:04X}")
+
+    def _exec_lhzu(self, instr: int, cia: int) -> StepTrace:
+        """lhzu rD, d(rA) — load halfword zero-extended, update rA."""
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        val = self._load16z(ea)
+        gpr = list(self._state.gpr)
+        gpr[rd] = val
+        gpr[ra] = ea
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"lhzu r{rd}, {d}(r{ra})",
+                         description=f"r{rd} = 0x{val:04X}; r{ra} = 0x{ea:04X}")
+
+    def _exec_lha(self, instr: int, cia: int) -> StepTrace:
+        """lha rD, d(rA) — load halfword algebraic (sign-extended to 32 bits)."""
+        rd = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        val = self._load16a(ea) & MASK32
+        gpr = list(self._state.gpr)
+        gpr[rd] = val
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"lha r{rd}, {d}(r{ra})",
+                         description=f"r{rd} = 0x{val:08X}")
+
+    # Store instructions
+
+    def _exec_stw(self, instr: int, cia: int) -> StepTrace:
+        """stw rS, d(rA) — store 4-byte word."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        new_mem = self._store32(ea, self._state.gpr[rs],
+                                list(self._state.gpr), self._state.lr,
+                                self._state.ctr, self._state.xer, self._state.cr)
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=new_mem, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"stw r{rs}, {d}(r{ra})",
+                         description=f"MEM[0x{ea:04X}] = 0x{self._state.memory[ea & ~3 & (MEM_SIZE-1)]:02X}...")
+
+    def _exec_stwu(self, instr: int, cia: int) -> StepTrace:
+        """stwu rS, d(rA) — store word, update rA = EA."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        new_mem = self._store32(ea, self._state.gpr[rs],
+                                list(self._state.gpr), self._state.lr,
+                                self._state.ctr, self._state.xer, self._state.cr)
+        gpr = list(self._state.gpr)
+        gpr[ra] = ea
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=new_mem, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"stwu r{rs}, {d}(r{ra})",
+                         description=f"MEM[0x{ea:04X}] = r{rs}; r{ra} = 0x{ea:04X}")
+
+    def _exec_stb(self, instr: int, cia: int) -> StepTrace:
+        """stb rS, d(rA) — store low byte of rS."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        new_mem = self._store8(ea, self._state.gpr[rs] & 0xFF)
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=new_mem, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"stb r{rs}, {d}(r{ra})",
+                         description=f"MEM[0x{ea:04X}] = 0x{self._state.gpr[rs] & 0xFF:02X}")
+
+    def _exec_stbu(self, instr: int, cia: int) -> StepTrace:
+        """stbu rS, d(rA) — store byte, update rA."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        new_mem = self._store8(ea, self._state.gpr[rs] & 0xFF)
+        gpr = list(self._state.gpr)
+        gpr[ra] = ea
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=new_mem, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"stbu r{rs}, {d}(r{ra})",
+                         description=f"MEM[0x{ea:04X}] = 0x{self._state.gpr[rs] & 0xFF:02X}; r{ra} = 0x{ea:04X}")
+
+    def _exec_sth(self, instr: int, cia: int) -> StepTrace:
+        """sth rS, d(rA) — store low 16-bit halfword of rS."""
+        rs = (instr >> 21) & 0x1F
+        ra = (instr >> 16) & 0x1F
+        d  = sext16(instr & 0xFFFF)
+        ea = self._ea(list(self._state.gpr), ra, d)
+        new_mem = self._store16(ea, self._state.gpr[rs] & 0xFFFF)
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=new_mem, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=f"sth r{rs}, {d}(r{ra})",
+                         description=f"MEM[0x{ea:04X}] = 0x{self._state.gpr[rs] & 0xFFFF:04X}")
+
+    # Branch instructions
+
+    def _exec_b(self, instr: int, cia: int) -> StepTrace:
+        """
+        b / bl  (opcode 18, I-form)
+
+        LI is the 24-bit signed field; byte offset = sign_extend(LI) << 2.
+        If AA=0, branch is PC-relative (CIA + offset).
+        If LK=1, CIA+4 is saved to LR before branching.
+        """
+        # Extract LI from bits [25:2], sign-extend the 24-bit field
+        li = (instr >> 2) & 0xFF_FFFF
+        if li & 0x80_0000:
+            li -= 0x100_0000
+        byte_off = li << 2
+        aa = (instr >> 1) & 1
+        lk =  instr       & 1
+        lr = self._state.lr
+        if lk:
+            lr = cia + 4
+        target = (byte_off if aa else cia + byte_off) & MASK32
+        self._state = PowerPC601State(
+            cia=target, gpr=self._state.gpr, lr=lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        mnem = f"bl 0x{target:04X}" if lk else f"b 0x{target:04X}"
+        return StepTrace(pc_before=cia, pc_after=target, mnemonic=mnem,
+                         description=f"CIA → 0x{target:04X}" + (f"; LR = 0x{lr:04X}" if lk else ""))
+
+    def _exec_bc(self, instr: int, cia: int) -> StepTrace:
+        """
+        bc BO, BI, BD  (opcode 16, B-form)
+
+        Conditional branch.  BD is 14-bit signed; byte offset = BD << 2.
+        BO and BI control CTR decrement and CR bit testing.
+        """
+        bo = (instr >> 21) & 0x1F
+        bi = (instr >> 16) & 0x1F
+        bd = (instr >> 2) & 0x3FFF
+        if bd & 0x2000:
+            bd -= 0x4000
+        byte_off = bd << 2
+        aa = (instr >> 1) & 1
+        lk =  instr       & 1
+
+        should_branch, new_ctr = self._eval_branch(bo, bi, self._state.ctr, self._state.cr)
+        lr = self._state.lr
+        if lk:
+            lr = cia + 4
+        if should_branch:
+            target = (byte_off if aa else cia + byte_off) & MASK32
+        else:
+            target = cia + 4
+        self._state = PowerPC601State(
+            cia=target, gpr=self._state.gpr, lr=lr, ctr=new_ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=target,
+                         mnemonic=f"bc {bo}, {bi}, 0x{(cia + byte_off) & MASK32:04X}",
+                         description=f"branch {'taken' if should_branch else 'not taken'}; CIA → 0x{target:04X}")
+
+    def _exec_bx(self, instr: int, cia: int) -> StepTrace:
+        """
+        bclr / bcctr  (opcode 19, XL-form)
+
+        XO=16:  branch to LR (blr = bclr 20, 0)
+        XO=528: branch to CTR (bctr = bcctr 20, 0; bctrl = bcctr 20, 0, lk=1)
+        """
+        bo  = (instr >> 21) & 0x1F
+        bi  = (instr >> 16) & 0x1F
+        xo  = (instr >>  1) & 0x3FF
+        lk  =  instr        & 1
+
+        should_branch, new_ctr = self._eval_branch(bo, bi, self._state.ctr, self._state.cr)
+        lr_val = self._state.lr
+        new_lr = cia + 4 if lk else lr_val
+
+        if xo == XO_BCLR:
+            branch_target = lr_val & ~3  # branch to LR (aligned)
+            mnem = "blr" if (bo == BO_ALWAYS and not lk) else f"bclr {bo}, {bi}"
+        elif xo == XO_BCCTR:
+            branch_target = self._state.ctr & ~3  # branch to CTR
+            mnem = "bctrl" if lk else ("bctr" if bo == BO_ALWAYS else f"bcctr {bo}, {bi}")
+        else:
+            # Unknown XL sub-opcode
+            self._state = PowerPC601State(
+                cia=cia, gpr=self._state.gpr, lr=lr_val, ctr=self._state.ctr,
+                xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=True,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia,
+                             mnemonic=f"ERROR: unknown XL xo={xo}",
+                             description=f"Unknown XL XO={xo}")
+
+        target = branch_target if should_branch else cia + 4
+        self._state = PowerPC601State(
+            cia=target, gpr=self._state.gpr, lr=new_lr, ctr=new_ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=target, mnemonic=mnem,
+                         description=f"CIA → 0x{target:04X}" + (f"; LR = 0x{new_lr:04X}" if lk else ""))
+
+    def _exec_x31(self, instr: int, cia: int) -> StepTrace:
+        """
+        Dispatch all OPCD=31 instructions by their secondary opcode (XO).
+
+        The XO field occupies bits [10:1] (10 bits) for X-form,
+        or bits [9:1] (9 bits) for XO-form.  We check the 10-bit field
+        first; arithmetic XO-form opcodes fit in 9 bits so they never
+        collide with the 10-bit values (the OE bit at position 10 is 0
+        for the ops we support).
+        """
+        xo10 = (instr >> 1) & 0x3FF   # 10-bit secondary opcode (X-form)
+        xo9  = xo10 & 0x1FF            # 9-bit secondary opcode (XO-form, OE=0 subset)
+        rd   = (instr >> 21) & 0x1F
+        ra   = (instr >> 16) & 0x1F
+        rb   = (instr >> 11) & 0x1F
+
+        # ── Compare (X-form, XO bits [10:1]) ─────────────────────────────────
+        if xo10 == XO_CMP:
+            crfd = (instr >> 23) & 0x7
+            new_cr = self._compare_signed(
+                self._state.gpr[ra], self._state.gpr[rb],
+                self._state.xer, self._state.cr, crfd,
+            )
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+                xer=self._state.xer, cr=new_cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"cmpw cr{crfd}, r{ra}, r{rb}",
+                             description=f"CR{crfd} = 0x{(new_cr >> (28 - crfd * 4)) & 0xF:X}")
+
+        if xo10 == XO_CMPL:
+            crfd = (instr >> 23) & 0x7
+            new_cr = self._compare_unsigned(
+                self._state.gpr[ra], self._state.gpr[rb],
+                self._state.xer, self._state.cr, crfd,
+            )
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+                xer=self._state.xer, cr=new_cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"cmplw cr{crfd}, r{ra}, r{rb}",
+                             description=f"CR{crfd} = 0x{(new_cr >> (28 - crfd * 4)) & 0xF:X}")
+
+        # ── Logical / shift (X-form) ───────────────────────────────────────────
+        if xo10 == XO_AND:
+            return self._x31_logic(instr, cia, rd, ra, rb, "and",
+                                   self._state.gpr[rd] & self._state.gpr[rb])
+        if xo10 == XO_OR:
+            rs = rd  # X-form uses rS at bits [25:21]
+            result = self._state.gpr[rs] | self._state.gpr[rb]
+            return self._x31_logic(instr, cia, rs, ra, rb, "or", result)
+        if xo10 == XO_XOR:
+            rs = rd
+            result = self._state.gpr[rs] ^ self._state.gpr[rb]
+            return self._x31_logic(instr, cia, rs, ra, rb, "xor", result)
+        if xo10 == XO_NAND:
+            result = ~(self._state.gpr[rd] & self._state.gpr[rb])
+            return self._x31_logic(instr, cia, rd, ra, rb, "nand", result)
+        if xo10 == XO_NOR:
+            rs = rd
+            result = ~(self._state.gpr[rs] | self._state.gpr[rb])
+            return self._x31_logic(instr, cia, rs, ra, rb, "nor", result)
+        if xo10 == XO_CNTLZW:
+            val = self._state.gpr[rd] & MASK32  # rS is at rd field in X-form
+            result = 0
+            if val == 0:
+                result = 32
+            else:
+                v = val
+                while not (v & 0x8000_0000):
+                    result += 1
+                    v <<= 1
+            gpr = list(self._state.gpr)
+            gpr[ra] = result
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+                xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"cntlzw r{ra}, r{rd}",
+                             description=f"r{ra} = {result} (leading zeros of r{rd}=0x{val:08X})")
+
+        if xo10 == XO_SLW:
+            rs = rd
+            n = self._state.gpr[rb] & 0x3F
+            result = 0 if n >= 32 else (self._state.gpr[rs] << n) & MASK32
+            return self._x31_logic(instr, cia, rs, ra, rb, "slw", result)
+
+        if xo10 == XO_SRW:
+            rs = rd
+            n = self._state.gpr[rb] & 0x3F
+            result = 0 if n >= 32 else (self._state.gpr[rs] & MASK32) >> n
+            return self._x31_logic(instr, cia, rs, ra, rb, "srw", result)
+
+        if xo10 == XO_SRAW:
+            rs = rd
+            n = self._state.gpr[rb] & 0x3F
+            n = min(n, 31)
+            src = sext32(self._state.gpr[rs])
+            result = (src >> n) & MASK32
+            # CA = 1 if src negative and any 1-bits shifted out
+            ca = 1 if (src < 0 and (self._state.gpr[rs] & ((1 << n) - 1))) else 0
+            xer = (self._state.xer & ~XER_CA) | (XER_CA if ca else 0)
+            gpr = list(self._state.gpr)
+            gpr[ra] = result
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+                xer=xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"sraw r{ra}, r{rs}, r{rb}",
+                             description=f"r{ra} = 0x{result:08X}, CA={ca}")
+
+        if xo10 == XO_SRAWI:
+            rs = rd
+            sh = rb  # shift amount is in the rB field (5-bit SH)
+            src = sext32(self._state.gpr[rs])
+            result = (src >> sh) & MASK32
+            ca = 1 if (src < 0 and (self._state.gpr[rs] & ((1 << sh) - 1))) else 0
+            xer = (self._state.xer & ~XER_CA) | (XER_CA if ca else 0)
+            gpr = list(self._state.gpr)
+            gpr[ra] = result
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+                xer=xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"srawi r{ra}, r{rs}, {sh}",
+                             description=f"r{ra} = 0x{result:08X}, CA={ca}")
+
+        # ── Move to/from special registers (XFX-form) ─────────────────────────
+        if xo10 == XO_MFSPR:
+            spr_enc = (instr >> 11) & 0x3FF
+            spr = ((spr_enc & 0x1F) << 5) | (spr_enc >> 5)
+            if spr == SPR_LR:
+                val = self._state.lr
+                spr_name = "LR"
+            elif spr == SPR_CTR:
+                val = self._state.ctr
+                spr_name = "CTR"
+            elif spr == SPR_XER:
+                val = self._state.xer
+                spr_name = "XER"
+            else:
+                val = 0
+                spr_name = f"SPR{spr}"
+            gpr = list(self._state.gpr)
+            gpr[rd] = val
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+                xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"mfspr r{rd}, {spr_name}",
+                             description=f"r{rd} = {spr_name} = 0x{val:08X}")
+
+        if xo10 == XO_MTSPR:
+            spr_enc = (instr >> 11) & 0x3FF
+            spr = ((spr_enc & 0x1F) << 5) | (spr_enc >> 5)
+            val = self._state.gpr[rd]  # rS is in the rD field for mtspr
+            new_lr  = self._state.lr
+            new_ctr = self._state.ctr
+            new_xer = self._state.xer
+            if spr == SPR_LR:
+                new_lr = val & MASK32
+                spr_name = "LR"
+            elif spr == SPR_CTR:
+                new_ctr = val & MASK32
+                spr_name = "CTR"
+            elif spr == SPR_XER:
+                new_xer = val & MASK32
+                spr_name = "XER"
+            else:
+                spr_name = f"SPR{spr}"
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=self._state.gpr, lr=new_lr, ctr=new_ctr,
+                xer=new_xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"mtspr {spr_name}, r{rd}",
+                             description=f"{spr_name} = 0x{val:08X}")
+
+        if xo10 == XO_MFCR:
+            gpr = list(self._state.gpr)
+            gpr[rd] = self._state.cr
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+                xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"mfcr r{rd}",
+                             description=f"r{rd} = CR = 0x{self._state.cr:08X}")
+
+        if xo10 == XO_MTCRF:
+            fxm = (instr >> 12) & 0xFF  # 8-bit field mask (bits [19:12])
+            rs_val = self._state.gpr[rd]  # rS is at rd bits
+            new_cr = self._state.cr
+            for bit in range(8):
+                if fxm & (0x80 >> bit):
+                    shift = 28 - bit * 4
+                    mask = 0xF << shift
+                    nibble = (rs_val >> shift) & 0xF
+                    new_cr = (new_cr & ~mask) | (nibble << shift)
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+                xer=self._state.xer, cr=new_cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"mtcrf 0x{fxm:02X}, r{rd}",
+                             description=f"CR = 0x{new_cr:08X}")
+
+        # ── XO-form arithmetic (secondary opcode is 9-bit, OE=0) ──────────────
+        if xo9 == XO_ADD:
+            result = (self._state.gpr[ra] + self._state.gpr[rb]) & MASK32
+            return self._x31_gpr(cia, rd, result, f"add r{rd}, r{ra}, r{rb}")
+
+        if xo9 == XO_SUBF:
+            result = (self._state.gpr[rb] - self._state.gpr[ra]) & MASK32
+            return self._x31_gpr(cia, rd, result, f"subf r{rd}, r{ra}, r{rb}")
+
+        if xo9 == XO_NEG:
+            result = (-self._state.gpr[ra]) & MASK32
+            return self._x31_gpr(cia, rd, result, f"neg r{rd}, r{ra}")
+
+        if xo9 == XO_ADDC:
+            full = self._state.gpr[ra] + self._state.gpr[rb]
+            result = full & MASK32
+            ca = 1 if full > MASK32 else 0
+            xer = (self._state.xer & ~XER_CA) | (XER_CA if ca else 0)
+            gpr = list(self._state.gpr)
+            gpr[rd] = result
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+                xer=xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"addc r{rd}, r{ra}, r{rb}",
+                             description=f"r{rd} = 0x{result:08X}, CA={ca}")
+
+        if xo9 == XO_ADDE:
+            ca_in = 1 if (self._state.xer & XER_CA) else 0
+            full = self._state.gpr[ra] + self._state.gpr[rb] + ca_in
+            result = full & MASK32
+            ca = 1 if full > MASK32 else 0
+            xer = (self._state.xer & ~XER_CA) | (XER_CA if ca else 0)
+            gpr = list(self._state.gpr)
+            gpr[rd] = result
+            self._state = PowerPC601State(
+                cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+                xer=xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+            )
+            return StepTrace(pc_before=cia, pc_after=cia + 4,
+                             mnemonic=f"adde r{rd}, r{ra}, r{rb}",
+                             description=f"r{rd} = 0x{result:08X}, CA={ca}")
+
+        if xo9 == XO_MULLW:
+            # signed multiply, keep low 32 bits
+            a = sext32(self._state.gpr[ra])
+            b = sext32(self._state.gpr[rb])
+            result = (a * b) & MASK32
+            return self._x31_gpr(cia, rd, result, f"mullw r{rd}, r{ra}, r{rb}")
+
+        if xo9 == XO_DIVW:
+            a = sext32(self._state.gpr[ra])
+            b = sext32(self._state.gpr[rb])
+            if b == 0:
+                result = 0  # division by zero — undefined; return 0
+            else:
+                result = int(a / b) & MASK32  # truncate toward zero
+            return self._x31_gpr(cia, rd, result, f"divw r{rd}, r{ra}, r{rb}")
+
+        if xo9 == XO_DIVWU:
+            a = self._state.gpr[ra] & MASK32
+            b = self._state.gpr[rb] & MASK32
+            result = (a // b if b != 0 else 0) & MASK32
+            return self._x31_gpr(cia, rd, result, f"divwu r{rd}, r{ra}, r{rb}")
+
+        # Unknown OPCD=31 secondary opcode
+        self._state = PowerPC601State(
+            cia=cia, gpr=self._state.gpr, lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=True,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia,
+                         mnemonic=f"ERROR: unknown x31 xo={xo10}",
+                         description=f"Unknown OPCD=31 XO={xo10} (instr=0x{instr:08X}) at CIA=0x{cia:04X}.")
+
+    # ── X31 helper: write GPR result ──────────────────────────────────────────
+
+    def _x31_gpr(self, cia: int, rd: int, result: int, mnem: str) -> StepTrace:
+        """Commit a computed result to GPR[rd] and advance CIA by 4."""
+        result = result & MASK32
+        gpr = list(self._state.gpr)
+        gpr[rd] = result
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=self._state.cr, memory=self._state.memory, halted=False,
+        )
+        return StepTrace(pc_before=cia, pc_after=cia + 4, mnemonic=mnem,
+                         description=f"r{rd} = 0x{result:08X}")
+
+    def _x31_logic(
+        self, instr: int, cia: int, rs: int, ra: int, rb: int, mnem: str, result: int
+    ) -> StepTrace:
+        """
+        Write a logical result to GPR[rA] and advance CIA.
+
+        In X-form logic instructions, the result goes to rA (not rD/rS).
+        rS is the "source" in the rD slot; rB is the second source.
+        result is the raw Python integer — it will be masked to 32 bits.
+        """
+        result = result & MASK32
+        gpr = list(self._state.gpr)
+        gpr[ra] = result
+        rc = instr & 1
+        new_cr = self._state.cr
+        if rc:
+            new_cr = self._update_cr0_from_result(result, self._state.xer, self._state.cr)
+        self._state = PowerPC601State(
+            cia=cia + 4, gpr=tuple(gpr), lr=self._state.lr, ctr=self._state.ctr,
+            xer=self._state.xer, cr=new_cr, memory=self._state.memory, halted=False,
+        )
+        dot = "." if rc else ""
+        return StepTrace(pc_before=cia, pc_after=cia + 4,
+                         mnemonic=f"{mnem}{dot} r{ra}, r{rs}, r{rb}",
+                         description=f"r{ra} = 0x{result:08X}")

--- a/code/packages/python/powerpc601-simulator/src/powerpc601_simulator/state.py
+++ b/code/packages/python/powerpc601-simulator/src/powerpc601_simulator/state.py
@@ -1,0 +1,212 @@
+"""
+PowerPC 601 (1992) State Dataclass
+====================================
+
+The PowerPC 601 was IBM/Apple/Motorola's first PowerPC chip, launched in 1992
+and powering the original Power Macintosh line (1994).  It brought RISC
+principles — large register file, load/store architecture, fixed-size
+instructions — to the consumer desktop market.
+
+Register set at a glance
+------------------------
+  GPR0–GPR31   32 × 32-bit general-purpose registers
+               (GPR0 is treated as 0 in effective-address calculations,
+               but holds a real value for non-address operations)
+  LR           Link Register   — saved return address (32-bit)
+  CTR          Count Register  — branch countdown / indirect call (32-bit)
+  XER          Fixed-Point Exception Register (32-bit):
+                 bit 0 = SO (Summary Overflow)
+                 bit 1 = OV (Overflow)
+                 bit 2 = CA (Carry)
+  CR           Condition Register (32-bit), divided into 8 four-bit fields:
+                 CR0 (bits 0–3, MSB side) … CR7 (bits 28–31, LSB side).
+                 Each field: [LT, GT, EQ, SO]
+  CIA          Current Instruction Address (the program counter), 32-bit,
+               always a multiple of 4.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Architecture constants ─────────────────────────────────────────────────────
+
+MASK32: int = 0xFFFF_FFFF       # 32-bit unsigned mask
+SIGN32: int = 0x8000_0000       # sign bit of a 32-bit quantity
+MEM_SIZE: int = 65536           # 64 KiB flat byte-addressed memory
+NUM_GPRS: int = 32              # GPR0 through GPR31
+
+# XER bit positions (bit 0 = MSB in PowerPC convention, bit 31 = LSB)
+# Stored as a Python integer: bit 31 of XER maps to Python bit weight 2^31.
+XER_SO: int = 1 << 31   # Summary Overflow  (bit 0 in PPC, bit 31 in Python int)
+XER_OV: int = 1 << 30   # Overflow          (bit 1 in PPC, bit 30 in Python int)
+XER_CA: int = 1 << 29   # Carry             (bit 2 in PPC, bit 29 in Python int)
+
+# CR bit positions within the 32-bit CR integer.
+# CR0 occupies the top nibble (bits [31:28] of the Python integer).
+# CR0.LT = bit 31, CR0.GT = bit 30, CR0.EQ = bit 29, CR0.SO = bit 28.
+# CR bit BI (0-indexed from MSB) corresponds to Python bit weight 2^(31-BI).
+CR_LT_SHIFT: int = 31   # CR0.LT in Python bit weight
+CR_GT_SHIFT: int = 30   # CR0.GT
+CR_EQ_SHIFT: int = 29   # CR0.EQ
+CR_SO_SHIFT: int = 28   # CR0.SO (CR0 field)
+
+
+def sext16(v: int) -> int:
+    """Sign-extend a 16-bit value to a Python signed integer."""
+    v = v & 0xFFFF
+    if v & 0x8000:
+        return v - 0x10000
+    return v
+
+
+def sext32(v: int) -> int:
+    """Reinterpret a masked 32-bit value as a signed Python integer."""
+    v = v & MASK32
+    if v & SIGN32:
+        return v - 0x1_0000_0000
+    return v
+
+
+# ── Immutable state snapshot ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PowerPC601State:
+    """
+    Complete, immutable snapshot of the PowerPC 601 simulator at one moment.
+
+    Fields
+    ------
+    cia     Current Instruction Address (program counter), 32-bit, multiple of 4.
+    gpr     32 × 32-bit general-purpose registers (GPR0–GPR31).
+            GPR0 participates in EA = 0 for address calculations when rA=0,
+            but otherwise holds a real value.
+    lr      Link Register — set by bl/bctrl; used by blr.
+    ctr     Count Register — decremented by bdnz-style branches; indirect target.
+    xer     XER register: [SO, OV, CA, ...] in bits [31, 30, 29, ...].
+    cr      Condition Register: 8 × 4-bit fields, CR0 in the MSB nibble.
+    memory  65536 bytes stored as a tuple of Python ints (each 0–255).
+    halted  True once the simulator fetches the all-zero HALT word.
+    """
+
+    cia: int                    # current instruction address, 32-bit
+    gpr: tuple[int, ...]        # 32 × 32-bit GPRs
+    lr: int                     # link register
+    ctr: int                    # count register
+    xer: int                    # XER: SO/OV/CA and byte count
+    cr: int                     # condition register (8 × 4-bit fields)
+    memory: tuple[int, ...]     # 65 536 bytes
+    halted: bool
+
+    # ── Convenience properties for registers ─────────────────────────────────
+
+    @property
+    def r0(self) -> int: return self.gpr[0]
+    @property
+    def r1(self) -> int: return self.gpr[1]
+    @property
+    def r2(self) -> int: return self.gpr[2]
+    @property
+    def r3(self) -> int: return self.gpr[3]
+    @property
+    def r4(self) -> int: return self.gpr[4]
+    @property
+    def r5(self) -> int: return self.gpr[5]
+    @property
+    def r6(self) -> int: return self.gpr[6]
+    @property
+    def r7(self) -> int: return self.gpr[7]
+    @property
+    def r8(self) -> int: return self.gpr[8]
+    @property
+    def r9(self) -> int: return self.gpr[9]
+    @property
+    def r10(self) -> int: return self.gpr[10]
+    @property
+    def r11(self) -> int: return self.gpr[11]
+    @property
+    def r12(self) -> int: return self.gpr[12]
+    @property
+    def r13(self) -> int: return self.gpr[13]
+    @property
+    def r14(self) -> int: return self.gpr[14]
+    @property
+    def r15(self) -> int: return self.gpr[15]
+    @property
+    def r16(self) -> int: return self.gpr[16]
+    @property
+    def r17(self) -> int: return self.gpr[17]
+    @property
+    def r18(self) -> int: return self.gpr[18]
+    @property
+    def r19(self) -> int: return self.gpr[19]
+    @property
+    def r20(self) -> int: return self.gpr[20]
+    @property
+    def r21(self) -> int: return self.gpr[21]
+    @property
+    def r22(self) -> int: return self.gpr[22]
+    @property
+    def r23(self) -> int: return self.gpr[23]
+    @property
+    def r24(self) -> int: return self.gpr[24]
+    @property
+    def r25(self) -> int: return self.gpr[25]
+    @property
+    def r26(self) -> int: return self.gpr[26]
+    @property
+    def r27(self) -> int: return self.gpr[27]
+    @property
+    def r28(self) -> int: return self.gpr[28]
+    @property
+    def r29(self) -> int: return self.gpr[29]
+    @property
+    def r30(self) -> int: return self.gpr[30]
+    @property
+    def r31(self) -> int: return self.gpr[31]
+
+    # ── CR field helpers ──────────────────────────────────────────────────────
+
+    def cr_field(self, n: int) -> int:
+        """Return the 4-bit CR field n (0=CR0, 7=CR7)."""
+        return (self.cr >> (28 - n * 4)) & 0xF
+
+    @property
+    def cr0(self) -> int:
+        """CR0 nibble: [LT, GT, EQ, SO] from MSB to LSB."""
+        return (self.cr >> 28) & 0xF
+
+    @property
+    def cr0_lt(self) -> bool:
+        """CR0 Less-Than bit."""
+        return bool((self.cr >> 31) & 1)
+
+    @property
+    def cr0_gt(self) -> bool:
+        """CR0 Greater-Than bit."""
+        return bool((self.cr >> 30) & 1)
+
+    @property
+    def cr0_eq(self) -> bool:
+        """CR0 Equal bit."""
+        return bool((self.cr >> 29) & 1)
+
+    @property
+    def cr0_so(self) -> bool:
+        """CR0 Summary-Overflow bit."""
+        return bool((self.cr >> 28) & 1)
+
+
+def make_initial_state() -> PowerPC601State:
+    """Return the power-on / reset state: all registers and memory zeroed, CIA=0."""
+    return PowerPC601State(
+        cia=0,
+        gpr=tuple(0 for _ in range(NUM_GPRS)),
+        lr=0,
+        ctr=0,
+        xer=0,
+        cr=0,
+        memory=tuple(0 for _ in range(MEM_SIZE)),
+        halted=False,
+    )

--- a/code/packages/python/powerpc601-simulator/tests/conftest.py
+++ b/code/packages/python/powerpc601-simulator/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared test helpers for the PowerPC 601 simulator test suite."""
+
+from powerpc601_simulator import PowerPC601Simulator, PowerPC601State
+
+
+def run_from_current(
+    sim: PowerPC601Simulator, max_steps: int = 1000
+) -> tuple[PowerPC601State, str | None]:
+    """Step an already-loaded simulator without re-loading (preserves preset registers)."""
+    for _ in range(max_steps):
+        if sim.get_state().halted:
+            break
+        trace = sim.step()
+        if sim.get_state().halted:
+            break
+        if trace.mnemonic.startswith("ERROR:"):
+            return sim.get_state(), trace.mnemonic
+    return sim.get_state(), None

--- a/code/packages/python/powerpc601-simulator/tests/test_coverage.py
+++ b/code/packages/python/powerpc601-simulator/tests/test_coverage.py
@@ -1,0 +1,292 @@
+"""Edge-case and coverage tests for the PowerPC 601 simulator."""
+
+from powerpc601_simulator import (
+    HALT,
+    PowerPC601Simulator,
+    PowerPC601State,
+    d_form,
+    i_form,
+    xfx_form,
+    xo_form,
+)
+from powerpc601_simulator.simulator import (
+    PO_ADDI,
+    PO_B,
+    PO_CMPI,
+    PO_LWZ,
+    PO_STW,
+    PO_X31,
+    XO_ADD,
+    XO_DIVW,
+    XO_DIVWU,
+    XO_MFSPR,
+    XO_NEG,
+)
+
+# ── 32-bit masking ────────────────────────────────────────────────────────────
+
+
+def test_add_wraps_32bit():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_ADD) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 0xFFFF_FFFF
+    gpr[4] = 1
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0  # wraps to 0
+
+
+def test_neg_of_zero():
+    prog = xo_form(PO_X31, 5, 3, 0, 0, XO_NEG) + HALT
+    result = PowerPC601Simulator().execute(prog)
+    assert result.final_state.r5 == 0  # -0 = 0 in two's complement
+
+
+def test_neg_min_int():
+    """Negating the minimum 32-bit signed value overflows back to itself."""
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 0, 0, XO_NEG) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 0x8000_0000
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0x8000_0000  # -INT_MIN = INT_MIN (overflow)
+
+
+# ── Memory big-endian ─────────────────────────────────────────────────────────
+
+
+def test_stw_big_endian_byte_order():
+    """stw writes MSB first."""
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_STW, 3, 0, 0x300) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 0x01_02_03_04
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.memory[0x300] == 0x01
+    assert s.memory[0x301] == 0x02
+    assert s.memory[0x302] == 0x03
+    assert s.memory[0x303] == 0x04
+
+
+def test_lwz_big_endian_byte_order():
+    """lwz reads MSB-first big-endian."""
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LWZ, 3, 0, 0x300) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    mem[0x300] = 0xDE; mem[0x301] = 0xAD; mem[0x302] = 0xBE; mem[0x303] = 0xEF
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0xDEAD_BEEF
+
+
+# ── HALT semantics ────────────────────────────────────────────────────────────
+
+
+def test_halt_on_all_zeros():
+    """0x00000000 halts immediately."""
+    sim = PowerPC601Simulator()
+    result = sim.execute(HALT)
+    assert result.halted
+    assert result.final_state.cia == 0
+
+
+def test_step_on_halted_stays():
+    """Stepping when already halted returns HALT trace without advancing CIA."""
+    sim = PowerPC601Simulator()
+    sim.execute(HALT)
+    trace = sim.step()
+    assert "HALT" in trace.mnemonic
+    assert trace.pc_before == trace.pc_after
+
+
+# ── Unknown opcode ────────────────────────────────────────────────────────────
+
+
+def test_unknown_opcode_halts():
+    """An unrecognized opcode causes an ERROR trace and halts."""
+    bad = bytes([0b00000101, 0, 0, 0])  # primary opcode 1 is not implemented
+    sim = PowerPC601Simulator()
+    result = sim.execute(bad)
+    assert not result.ok
+
+
+# ── GPR0 base-register-zero rule ─────────────────────────────────────────────
+
+
+def test_gpr0_as_base_is_zero_for_lwz():
+    """lwz rD, d(r0) uses 0 as base, not GPR0's value."""
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LWZ, 5, 0, 0x100) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[0] = 0xDEAD  # would corrupt EA if GPR0 were used
+    mem = list(s0.memory)
+    mem[0x100] = 0; mem[0x101] = 0; mem[0x102] = 0; mem[0x103] = 0x42
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr), "memory": tuple(mem)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0x42  # loaded from address 0x100, not 0xDEAD+0x100
+
+
+def test_gpr0_as_source_for_add_is_real():
+    """GPR0 participates normally in arithmetic (only address calc is special)."""
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 0, 3, 0, XO_ADD) + HALT  # add r5, r0, r3
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[0] = 10
+    gpr[3] = 20
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r5 == 30  # GPR0 used at face value in arithmetic
+
+
+# ── State immutability ────────────────────────────────────────────────────────
+
+
+def test_state_gpr_immutable():
+    sim = PowerPC601Simulator()
+    s = sim.get_state()
+    raised = False
+    try:
+        s.gpr = (0,) * 32  # type: ignore[misc]
+    except (AttributeError, TypeError):
+        raised = True
+    assert raised
+
+
+def test_snapshot_independence():
+    """get_state() returns a separate frozen snapshot."""
+    sim = PowerPC601Simulator()
+    sim.load(d_form(PO_ADDI, 3, 0, 1) + HALT)
+    snap1 = sim.get_state()
+    sim.step()
+    snap2 = sim.get_state()
+    assert snap1.cia == 0
+    assert snap2.cia == 4
+
+
+# ── Carry flag details ────────────────────────────────────────────────────────
+
+
+def test_addi_does_not_set_carry():
+    """addi never sets XER[CA]."""
+    from powerpc601_simulator import XER_CA
+    result = PowerPC601Simulator().execute(d_form(PO_ADDI, 3, 0, -1) + HALT)
+    assert not (result.final_state.xer & XER_CA)
+
+
+# ── CR field isolation ────────────────────────────────────────────────────────
+
+
+def test_cmpwi_only_updates_target_field():
+    """cmpwi cr1 should not touch CR0."""
+    sim = PowerPC601Simulator()
+    prog = (
+        d_form(PO_CMPI, 0, 3, 5)     # cmpwi cr0, r3, 5  → sets CR0
+        + d_form(PO_CMPI, 1 << 2, 4, 10)  # cmpwi cr1, r4, 10
+        + HALT
+    )
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 3   # cr0: lt
+    gpr[4] = 10  # cr1: eq
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.cr0_lt                   # CR0 still lt
+    assert (s.cr_field(1) >> 1) & 1   # CR1.EQ set
+
+
+# ── divw / divwu by zero ─────────────────────────────────────────────────────
+
+
+def test_divw_by_zero_returns_zero():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_DIVW) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 100; gpr[4] = 0
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0  # implementation defined; returns 0
+
+
+def test_divwu_by_zero_returns_zero():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_DIVWU) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 100; gpr[4] = 0
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0
+
+
+# ── mfspr unknown SPR reads as 0 ─────────────────────────────────────────────
+
+
+def test_mfspr_unknown_spr_is_zero():
+    sim = PowerPC601Simulator()
+    prog = xfx_form(PO_X31, 5, 99, XO_MFSPR) + HALT  # SPR 99 is not simulated
+    result = sim.execute(prog)
+    assert result.final_state.r5 == 0
+
+
+# ── bc with absolute address ──────────────────────────────────────────────────
+
+
+def test_b_absolute():
+    """b absolute: AA=1 targets an absolute address."""
+    # Place a HALT at absolute address 8 and use b with AA=1
+    sim = PowerPC601Simulator()
+    prog = (
+        i_form(PO_B, 8, AA=1)         # b 8 (absolute) → jump to byte 8
+        + d_form(PO_ADDI, 3, 0, 99)   # [4] skipped
+        + HALT                          # [8]
+    )
+    result = sim.execute(prog)
+    assert result.final_state.r3 == 0
+
+
+# ── Large immediate sign extension ───────────────────────────────────────────
+
+
+def test_addi_sign_extends_negative():
+    """addi with -1 (0xFFFF) should give 0xFFFF_FFFF."""
+    s = PowerPC601Simulator().execute(d_form(PO_ADDI, 3, 0, 0xFFFF) + HALT).final_state
+    assert s.r3 == 0xFFFF_FFFF
+
+
+# ── execute clears previous state ─────────────────────────────────────────────
+
+
+def test_execute_resets_between_calls():
+    sim = PowerPC601Simulator()
+    sim.execute(d_form(PO_ADDI, 3, 0, 42) + HALT)
+    assert sim.get_state().r3 == 42
+    sim.execute(HALT)
+    assert sim.get_state().r3 == 0  # reset between calls

--- a/code/packages/python/powerpc601-simulator/tests/test_instructions.py
+++ b/code/packages/python/powerpc601-simulator/tests/test_instructions.py
@@ -1,0 +1,991 @@
+"""Per-instruction unit tests for the PowerPC 601 simulator."""
+
+from powerpc601_simulator import (
+    BI_EQ,
+    BI_LT,
+    BO_ALWAYS,
+    BO_BDNZ,
+    BO_BDZ,
+    BO_FALSE,
+    BO_TRUE,
+    HALT,
+    SPR_CTR,
+    SPR_LR,
+    PowerPC601Simulator,
+    PowerPC601State,
+    b_form,
+    d_form,
+    i_form,
+    x_form,
+    xfx_form,
+    xl_form,
+    xo_form,
+)
+from powerpc601_simulator.simulator import (
+    PO_ADDI,
+    PO_ADDIS,
+    PO_ANDI_DOT,
+    PO_ANDIS_DOT,
+    PO_B,
+    PO_BC,
+    PO_BX,
+    PO_CMPI,
+    PO_CMPLI,
+    PO_LBZ,
+    PO_LBZU,
+    PO_LHA,
+    PO_LHZ,
+    PO_LHZU,
+    PO_LWZ,
+    PO_LWZU,
+    PO_ORI,
+    PO_ORIS,
+    PO_STB,
+    PO_STBU,
+    PO_STH,
+    PO_STW,
+    PO_STWU,
+    PO_SUBFIC,
+    PO_X31,
+    PO_XORI,
+    XO_ADD,
+    XO_ADDC,
+    XO_ADDE,
+    XO_AND,
+    XO_BCCTR,
+    XO_BCLR,
+    XO_CMP,
+    XO_CMPL,
+    XO_CNTLZW,
+    XO_DIVW,
+    XO_DIVWU,
+    XO_MFCR,
+    XO_MFSPR,
+    XO_MTCRF,
+    XO_MTSPR,
+    XO_MULLW,
+    XO_NAND,
+    XO_NEG,
+    XO_NOR,
+    XO_OR,
+    XO_SLW,
+    XO_SRAW,
+    XO_SRAWI,
+    XO_SRW,
+    XO_SUBF,
+    XO_XOR,
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def run(prog: bytes) -> PowerPC601State:
+    """Execute a program and return the final state.  Asserts execution is ok."""
+    sim = PowerPC601Simulator()
+    result = sim.execute(prog)
+    assert result.ok, f"execution failed: {result.error}"
+    return result.final_state
+
+
+def preset(sim: PowerPC601Simulator, *, gpr=None, lr=None, ctr=None, xer=None, cr=None):
+    """Manually override registers in the simulator state (after load, before step)."""
+    s = sim.get_state()
+    new_gpr = list(s.gpr)
+    if gpr:
+        for idx, val in gpr.items():
+            new_gpr[idx] = val & 0xFFFF_FFFF
+    sim._state = PowerPC601State(  # noqa: SLF001
+        cia=s.cia,
+        gpr=tuple(new_gpr),
+        lr=(lr & 0xFFFF_FFFF) if lr is not None else s.lr,
+        ctr=(ctr & 0xFFFF_FFFF) if ctr is not None else s.ctr,
+        xer=xer if xer is not None else s.xer,
+        cr=cr if cr is not None else s.cr,
+        memory=s.memory,
+        halted=s.halted,
+    )
+
+
+def run_from_current(sim: PowerPC601Simulator, max_steps: int = 1000) -> tuple[PowerPC601State, str | None]:
+    """Step the already-loaded simulator without re-loading (preserves preset registers)."""
+    for _ in range(max_steps):
+        if sim.get_state().halted:
+            break
+        trace = sim.step()
+        if sim.get_state().halted:
+            break
+        if trace.mnemonic.startswith("ERROR:"):
+            return sim.get_state(), trace.mnemonic
+    return sim.get_state(), None
+
+
+# ── addi ──────────────────────────────────────────────────────────────────────
+
+
+def test_addi_positive():
+    prog = d_form(PO_ADDI, 3, 0, 100) + HALT
+    s = run(prog)
+    assert s.r3 == 100
+
+
+def test_addi_negative():
+    prog = d_form(PO_ADDI, 4, 0, -1) + HALT
+    s = run(prog)
+    assert s.r4 == 0xFFFF_FFFF
+
+
+def test_addi_rA_zero_means_zero():
+    """addi rD, 0, val uses 0 as base, not GPR0's value."""
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_ADDI, 3, 0, 99) + HALT
+    sim.load(prog)
+    preset(sim, gpr={0: 9999})  # set GPR0 to something
+    s, _ = run_from_current(sim)
+    assert s.r3 == 99  # still 0 + 99, not 9999 + 99
+
+
+def test_addi_rA_nonzero_adds():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_ADDI, 5, 3, 10) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 20})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 30
+
+
+def test_addi_wrap32():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_ADDI, 6, 6, 1) + HALT
+    sim.load(prog)
+    preset(sim, gpr={6: 0xFFFF_FFFF})
+    s, _ = run_from_current(sim)
+    assert s.r6 == 0
+
+
+# ── addis ─────────────────────────────────────────────────────────────────────
+
+
+def test_addis_load_upper():
+    """lis r3, 1  =  addis r3, 0, 1  → r3 = 0x0001_0000"""
+    prog = d_form(PO_ADDIS, 3, 0, 1) + HALT
+    s = run(prog)
+    assert s.r3 == 0x0001_0000
+
+
+def test_addis_adds_shifted():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_ADDIS, 4, 3, 2) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0x0000_0001})
+    s, _ = run_from_current(sim)
+    assert s.r4 == 0x0002_0001
+
+
+# ── subfic ────────────────────────────────────────────────────────────────────
+
+
+def test_subfic_basic():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_SUBFIC, 5, 3, 10) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 3})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 7   # 10 - 3 = 7
+
+
+def test_subfic_ca_set_when_no_borrow():
+    from powerpc601_simulator import XER_CA
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_SUBFIC, 5, 3, 10) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 3})  # 10 >= 3 unsigned → no borrow → CA=1
+    s, _ = run_from_current(sim)
+    assert s.xer & XER_CA
+
+
+def test_subfic_ca_clear_on_borrow():
+    from powerpc601_simulator import XER_CA
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_SUBFIC, 5, 3, 3) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 10})  # 3 < 10 unsigned → borrow → CA=0
+    s, _ = run_from_current(sim)
+    assert not (s.xer & XER_CA)
+
+
+# ── ori / oris / xori ─────────────────────────────────────────────────────────
+
+
+def test_ori_basic():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_ORI, 5, 3, 0xF0) + HALT  # ori r3, r5, 0xF0 — rS=r5, rA=r3
+    sim.load(prog)
+    preset(sim, gpr={5: 0x0F})
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0xFF
+
+
+def test_oris_shifted():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_ORIS, 5, 4, 0x0001) + HALT  # oris r4, r5, 0x0001 — rS=r5, rA=r4
+    sim.load(prog)
+    preset(sim, gpr={5: 0xFFFF})
+    s, _ = run_from_current(sim)
+    assert s.r4 == 0x0001_FFFF
+
+
+def test_xori_basic():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_XORI, 5, 3, 0xFF) + HALT  # xori r3, r5, 0xFF — rS=r5, rA=r3
+    sim.load(prog)
+    preset(sim, gpr={5: 0xAA})
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0x55
+
+
+# ── andi. / andis. ────────────────────────────────────────────────────────────
+
+
+def test_andi_dot_zero_sets_cr0_eq():
+    prog = d_form(PO_ANDI_DOT, 3, 4, 0xFF) + HALT  # andi. r4, r3, 0xFF — rS=r3=0 → r4=0
+    s = run(prog)
+    assert s.cr0_eq
+
+
+def test_andi_dot_nonzero_sets_cr0_gt():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_ANDI_DOT, 3, 4, 0xFF) + HALT  # andi. r4, r3, 0xFF — rS=r3, rA=r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0x0A})  # r3=rS=0x0A; r4 = 0x0A & 0xFF = 0x0A > 0 → GT
+    s, _ = run_from_current(sim)
+    assert s.cr0_gt
+
+
+def test_andi_dot_negative_sets_cr0_lt():
+    """andi. UIMM is zero-extended so bit 31 is always 0; use andis. to set bit 31."""
+    sim = PowerPC601Simulator()
+    # andis. r4, r3, 0x8000 → r4 = r3 & (0x8000 << 16) = 0x8000_0000 → CR0.LT
+    prog = d_form(PO_ANDIS_DOT, 3, 4, 0x8000) + HALT  # rS=r3, rA=r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF})
+    s, _ = run_from_current(sim)
+    assert s.cr0_lt
+
+
+def test_andis_dot_updates_cr0():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_ANDIS_DOT, 3, 4, 0x0001) + HALT  # andis. r4, r3, 0x0001 — rS=r3, rA=r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0x0001_0000})  # r4 = r3 & (0x0001 << 16) = 0x0001_0000 → GT
+    s, _ = run_from_current(sim)
+    assert s.r4 == 0x0001_0000
+    assert s.cr0_gt
+
+
+# ── cmpwi / cmplwi ───────────────────────────────────────────────────────────
+
+
+def test_cmpwi_less_than():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_CMPI, 0 << 2, 3, 10) + HALT  # cmpwi cr0, r3, 10
+    sim.load(prog)
+    preset(sim, gpr={3: 5})
+    s, _ = run_from_current(sim)
+    assert s.cr0_lt
+
+
+def test_cmpwi_greater_than():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_CMPI, 0 << 2, 3, 5) + HALT  # cmpwi cr0, r3, 5
+    sim.load(prog)
+    preset(sim, gpr={3: 10})
+    s, _ = run_from_current(sim)
+    assert s.cr0_gt
+
+
+def test_cmpwi_equal():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_CMPI, 0 << 2, 3, 7) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 7})
+    s, _ = run_from_current(sim)
+    assert s.cr0_eq
+
+
+def test_cmpwi_signed():
+    """cmpwi should treat -1 as less than 0."""
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_CMPI, 0 << 2, 3, 0) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF})  # -1 signed
+    s, _ = run_from_current(sim)
+    assert s.cr0_lt
+
+
+def test_cmplwi_unsigned():
+    """cmplwi treats -1 (0xFFFF_FFFF) as greater than 0."""
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_CMPLI, 0 << 2, 3, 0) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF})
+    s, _ = run_from_current(sim)
+    assert s.cr0_gt
+
+
+def test_cmpwi_cr1():
+    """Compare into CR1 (crfD=1)."""
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_CMPI, 1 << 2, 3, 0) + HALT  # cmpwi cr1, r3, 0
+    sim.load(prog)
+    preset(sim, gpr={3: 0})
+    s, _ = run_from_current(sim)
+    # CR1.EQ should be set (bit 2 of CR1 nibble)
+    assert (s.cr_field(1) >> 1) & 1  # EQ bit of CR1
+
+
+# ── add / subf / neg / mullw / divw / divwu ──────────────────────────────────
+
+
+def test_add():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_ADD) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 15, 4: 27})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 42
+
+
+def test_subf():
+    """subf rD, rA, rB → rD = rB - rA."""
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_SUBF) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 3, 4: 10})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 7
+
+
+def test_neg():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 0, 0, XO_NEG) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 5})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0xFFFF_FFFB  # -5 as unsigned 32-bit
+
+
+def test_mullw():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_MULLW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 6, 4: 7})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 42
+
+
+def test_divw():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_DIVW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 20, 4: 4})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 5
+
+
+def test_divw_truncates_toward_zero():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_DIVW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFD, 4: 2})  # -3 / 2 = -1 (truncated toward 0)
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0xFFFF_FFFF  # -1 as 32-bit
+
+
+def test_divwu():
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_DIVWU) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 100, 4: 7})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 14  # 100 // 7 = 14
+
+
+def test_addc_sets_carry():
+    from powerpc601_simulator import XER_CA
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_ADDC) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF, 4: 1})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0
+    assert s.xer & XER_CA
+
+
+def test_adde_uses_carry():
+    from powerpc601_simulator import XER_CA
+    sim = PowerPC601Simulator()
+    prog = xo_form(PO_X31, 5, 3, 4, 0, XO_ADDE) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 1, 4: 2}, xer=XER_CA)  # CA=1
+    s, _ = run_from_current(sim)
+    assert s.r5 == 4   # 1 + 2 + 1 = 4
+
+
+# ── and / or / xor / nand / nor / cntlzw ────────────────────────────────────
+
+
+def test_and():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_AND) + HALT  # and r5, r3, r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFF, 4: 0xF0})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0xF0
+
+
+def test_or():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_OR) + HALT  # or r5, r3, r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0x0F, 4: 0xF0})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0xFF
+
+
+def test_xor():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_XOR) + HALT  # xor r5, r3, r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFF, 4: 0x0F})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0xF0
+
+
+def test_nand():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_NAND) + HALT  # nand r5, r3, r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF, 4: 0xFFFF_FFFF})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0   # ~(all_ones & all_ones) = 0
+
+
+def test_nor():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_NOR) + HALT  # nor r5, r3, r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0x0000_FFFF, 4: 0xFFFF_0000})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0   # ~(0xFFFF_FFFF) masked to 32 = 0
+
+
+def test_cntlzw_all_ones():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 0, XO_CNTLZW) + HALT  # cntlzw r5, r3
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0
+
+
+def test_cntlzw_zero():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 0, XO_CNTLZW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 32
+
+
+def test_cntlzw_one():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 0, XO_CNTLZW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 1})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 31
+
+
+# ── slw / srw / sraw / srawi ─────────────────────────────────────────────────
+
+
+def test_slw():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_SLW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 1, 4: 4})  # 1 << 4 = 16
+    s, _ = run_from_current(sim)
+    assert s.r5 == 16
+
+
+def test_slw_ge32_is_zero():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_SLW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF, 4: 32})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0
+
+
+def test_srw():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_SRW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0x100, 4: 4})  # 256 >> 4 = 16
+    s, _ = run_from_current(sim)
+    assert s.r5 == 16
+
+
+def test_srw_ge32_is_zero():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_SRW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF, 4: 32})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0
+
+
+def test_sraw_sign_extends():
+    """sraw propagates the sign bit."""
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_SRAW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0x8000_0000, 4: 1})  # -2^31 >> 1
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0xC000_0000  # -2^31 / 2 = -2^30
+
+
+def test_srawi_basic():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 2, XO_SRAWI) + HALT  # srawi r5, r3, 2
+    sim.load(prog)
+    preset(sim, gpr={3: 20})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 5
+
+
+def test_sraw_ca_set_for_negative_with_shifted_bits():
+    from powerpc601_simulator import XER_CA
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 3, 5, 4, XO_SRAW) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF, 4: 1})  # -1 >> 1; loses the LSB which is 1
+    s, _ = run_from_current(sim)
+    assert s.xer & XER_CA  # negative and shifted out a 1-bit
+
+
+# ── cmpw / cmplw (X-form) ────────────────────────────────────────────────────
+
+
+def test_cmpw_lt():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 0, 3, 4, XO_CMP) + HALT  # cmpw cr0, r3, r4
+    sim.load(prog)
+    preset(sim, gpr={3: 1, 4: 2})
+    s, _ = run_from_current(sim)
+    assert s.cr0_lt
+
+
+def test_cmpw_gt():
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 0, 3, 4, XO_CMP) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 10, 4: 5})
+    s, _ = run_from_current(sim)
+    assert s.cr0_gt
+
+
+def test_cmplw_unsigned():
+    """cmplw treats 0xFFFF_FFFF as greater than 0."""
+    sim = PowerPC601Simulator()
+    prog = x_form(PO_X31, 0, 3, 4, XO_CMPL) + HALT  # cmplw cr0, r3, r4
+    sim.load(prog)
+    preset(sim, gpr={3: 0xFFFF_FFFF, 4: 0})
+    s, _ = run_from_current(sim)
+    assert s.cr0_gt
+
+
+# ── lwz / lwzu / lbz / lbzu / lhz / lhzu / lha ───────────────────────────────
+
+
+def test_lwz_loads_word():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LWZ, 3, 0, 0x200) + HALT
+    sim.load(prog)
+    # Manually write a value into memory at 0x200
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    mem[0x200] = 0x12; mem[0x201] = 0x34; mem[0x202] = 0xAB; mem[0x203] = 0xCD
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0x1234_ABCD
+
+
+def test_lwzu_updates_ra():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LWZU, 3, 4, 4) + HALT  # lwzu r3, 4(r4) — EA = r4+4
+    sim.load(prog)
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    mem[0x100] = 0; mem[0x101] = 0; mem[0x102] = 0; mem[0x103] = 0x42
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    preset(sim, gpr={4: 0x100 - 4})  # so EA = 0x100
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0x42
+    assert s.r4 == 0x100
+
+
+def test_lbz_zero_extends():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LBZ, 3, 0, 0x10) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    mem[0x10] = 0xFF
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0xFF  # zero-extended
+
+
+def test_lhz_loads_halfword():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LHZ, 5, 0, 0x20) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    mem[0x20] = 0xBE; mem[0x21] = 0xEF
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0xBEEF
+
+
+def test_lha_sign_extends():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LHA, 5, 0, 0x20) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    mem[0x20] = 0xFF; mem[0x21] = 0xFF  # -1 as 16-bit
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0xFFFF_FFFF  # sign-extended to 32 bits
+
+
+def test_lhzu_updates_ra():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LHZU, 5, 4, 2) + HALT  # lhzu r5, 2(r4)
+    sim.load(prog)
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    mem[0x102] = 0x12; mem[0x103] = 0x34
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    preset(sim, gpr={4: 0x100})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0x1234
+    assert s.r4 == 0x102
+
+
+def test_lbzu_updates_ra():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_LBZU, 5, 4, 1) + HALT
+    sim.load(prog)
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    mem[0x11] = 0x77
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    preset(sim, gpr={4: 0x10})
+    s, _ = run_from_current(sim)
+    assert s.r5 == 0x77
+    assert s.r4 == 0x11
+
+
+# ── stw / stwu / stb / stbu / sth ────────────────────────────────────────────
+
+
+def test_stw_stores_word():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_STW, 3, 0, 0x200) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xDEAD_BEEF})
+    s, _ = run_from_current(sim)
+    assert s.memory[0x200] == 0xDE
+    assert s.memory[0x201] == 0xAD
+    assert s.memory[0x202] == 0xBE
+    assert s.memory[0x203] == 0xEF
+
+
+def test_stwu_updates_ra():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_STWU, 3, 4, 4) + HALT  # stwu r3, 4(r4)
+    sim.load(prog)
+    preset(sim, gpr={3: 0x1234_5678, 4: 0x100})
+    s, _ = run_from_current(sim)
+    assert s.memory[0x104] == 0x12
+    assert s.r4 == 0x104
+
+
+def test_stb_stores_byte():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_STB, 3, 0, 0x50) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0x1234_56AB})
+    s, _ = run_from_current(sim)
+    assert s.memory[0x50] == 0xAB  # low byte only
+
+
+def test_stbu_updates_ra():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_STBU, 3, 4, 1) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xCC, 4: 0x20})
+    s, _ = run_from_current(sim)
+    assert s.memory[0x21] == 0xCC
+    assert s.r4 == 0x21
+
+
+def test_sth_stores_halfword():
+    sim = PowerPC601Simulator()
+    prog = d_form(PO_STH, 3, 0, 0x60) + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0xABCD})
+    s, _ = run_from_current(sim)
+    assert s.memory[0x60] == 0xAB
+    assert s.memory[0x61] == 0xCD
+
+
+# ── b / bl ────────────────────────────────────────────────────────────────────
+
+
+def test_b_jumps():
+    """b +8 skips one 4-byte instruction."""
+    # Layout: [0] b +8  [4] addi r3,0,99  [8] HALT
+    prog = (
+        i_form(PO_B, 8)            # jump over next instruction
+        + d_form(PO_ADDI, 3, 0, 99)  # should be skipped
+        + HALT
+    )
+    s = run(prog)
+    assert s.r3 == 0  # addi skipped
+
+
+def test_bl_saves_lr():
+    """bl saves CIA+4 to LR."""
+    # Layout: [0] bl +8  [4] HALT  [8] addi r3,0,1  [12] HALT
+    prog = (
+        i_form(PO_B, 8, LK=1)      # bl to +8
+        + HALT                       # [4] never reached in first pass
+        + d_form(PO_ADDI, 3, 0, 1)  # [8]
+        + HALT                       # [12]
+    )
+    s = run(prog)
+    assert s.lr == 4    # LR = CIA+4 = 0+4
+
+
+def test_b_backward():
+    """Backward branch: b -4 loops until something stops."""
+    # Use a counter: dec CTR via mtspr; then bdnz loops
+    # Simpler: just verify that a negative branch target works by using bc
+    # Layout: [0] addi r3,0,1  [4] b -4 ... would loop forever.
+    # Instead test via execute result after max_steps
+    prog = d_form(PO_ADDI, 0, 0, 0) + i_form(PO_B, -4)  # NOP then loop
+    result = PowerPC601Simulator().execute(prog, max_steps=5)
+    assert not result.ok  # should hit max_steps
+
+
+# ── bc (conditional branch) ───────────────────────────────────────────────────
+
+
+def test_bc_beq_taken():
+    """beq branches when CR0.EQ=1."""
+    sim = PowerPC601Simulator()
+    # [0] cmpwi r3, 0  [4] beq +8  [8] addi r3,0,99  [12] HALT
+    prog = (
+        d_form(PO_CMPI, 0, 3, 0)         # cmpwi cr0, r3, 0
+        + b_form(PO_BC, BO_TRUE, BI_EQ, 8)  # beq +8 (skip next)
+        + d_form(PO_ADDI, 3, 0, 99)        # r3 = 99 (skipped)
+        + HALT
+    )
+    sim.load(prog)
+    preset(sim, gpr={3: 0})
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0  # addi was skipped
+
+
+def test_bc_beq_not_taken():
+    sim = PowerPC601Simulator()
+    prog = (
+        d_form(PO_CMPI, 0, 3, 0)           # cmpwi cr0, r3, 0
+        + b_form(PO_BC, BO_TRUE, BI_EQ, 8)   # beq +8
+        + d_form(PO_ADDI, 3, 0, 99)          # r3 = 99 (executed when not taken)
+        + HALT
+    )
+    sim.load(prog)
+    preset(sim, gpr={3: 5})  # r3 != 0 → EQ not set → branch not taken
+    s, _ = run_from_current(sim)
+    assert s.r3 == 99
+
+
+def test_bc_blt_taken():
+    sim = PowerPC601Simulator()
+    prog = (
+        d_form(PO_CMPI, 0, 3, 10)            # cmpwi cr0, r3, 10
+        + b_form(PO_BC, BO_TRUE, BI_LT, 8)    # blt +8
+        + d_form(PO_ADDI, 3, 0, 99)           # skipped
+        + HALT
+    )
+    sim.load(prog)
+    preset(sim, gpr={3: 5})
+    s, _ = run_from_current(sim)
+    assert s.r3 == 5  # addi skipped
+
+
+def test_bc_bne_taken():
+    sim = PowerPC601Simulator()
+    prog = (
+        d_form(PO_CMPI, 0, 3, 10)             # cmpwi cr0, r3, 10
+        + b_form(PO_BC, BO_FALSE, BI_EQ, 8)   # bne +8 (branch if EQ=0)
+        + d_form(PO_ADDI, 3, 0, 99)           # skipped
+        + HALT
+    )
+    sim.load(prog)
+    preset(sim, gpr={3: 5})  # 5 != 10 → EQ=0 → bne taken
+    s, _ = run_from_current(sim)
+    assert s.r3 == 5
+
+
+def test_bc_bdnz():
+    """bdnz decrements CTR and branches while CTR != 0."""
+    sim = PowerPC601Simulator()
+    # [0] addi r3, r3, 1   [4] bdnz -4 (back to 0)  [8] HALT
+    prog = (
+        d_form(PO_ADDI, 3, 3, 1)          # r3 += 1
+        + b_form(PO_BC, BO_BDNZ, 0, -4)   # bdnz back to [0]
+        + HALT
+    )
+    sim.load(prog)
+    preset(sim, gpr={3: 0}, ctr=5)  # loop 5 times
+    s, _ = run_from_current(sim)
+    assert s.r3 == 5
+    assert s.ctr == 0
+
+
+def test_bc_bdz():
+    """bdz branches when CTR reaches 0."""
+    sim = PowerPC601Simulator()
+    # [0] bdz +8  [4] addi r3,0,99  [8] HALT
+    prog = (
+        b_form(PO_BC, BO_BDZ, 0, 8)      # bdz to [8] if CTR==0 after dec
+        + d_form(PO_ADDI, 3, 0, 99)       # [4] skipped when CTR was 1
+        + HALT                              # [8]
+    )
+    sim.load(prog)
+    preset(sim, ctr=1)  # CTR=1 → after dec = 0 → branch taken
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0  # addi skipped
+
+
+# ── blr / bctr / bctrl ────────────────────────────────────────────────────────
+
+
+def test_blr_branches_to_lr():
+    sim = PowerPC601Simulator()
+    # [0] blr  → jumps to LR
+    # Set LR to point to [8]: [4] addi r3,0,99  [8] HALT
+    prog = (
+        xl_form(PO_BX, BO_ALWAYS, 0, 0, XO_BCLR)  # blr
+        + d_form(PO_ADDI, 3, 0, 99)                  # [4] skipped
+        + HALT                                         # [8]
+    )
+    sim.load(prog)
+    preset(sim, lr=8)
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0  # addi at [4] was skipped
+
+
+def test_bctr_branches_to_ctr():
+    sim = PowerPC601Simulator()
+    prog = (
+        xl_form(PO_BX, BO_ALWAYS, 0, 0, XO_BCCTR)  # bctr
+        + d_form(PO_ADDI, 3, 0, 99)                   # [4] skipped
+        + HALT                                          # [8]
+    )
+    sim.load(prog)
+    preset(sim, ctr=8)
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0  # skipped
+
+
+def test_bctrl_saves_lr():
+    sim = PowerPC601Simulator()
+    prog = (
+        xl_form(PO_BX, BO_ALWAYS, 0, 0, XO_BCCTR, lk=1)  # bctrl
+        + HALT                                                # [4] (LR target)
+        + HALT                                                # [8]
+    )
+    sim.load(prog)
+    preset(sim, ctr=8)  # branches to [8]
+    s, _ = run_from_current(sim)
+    assert s.lr == 4  # CIA+4 saved to LR
+
+
+# ── mfspr / mtspr / mfcr / mtcrf ────────────────────────────────────────────
+
+
+def test_mtspr_lr_and_mfspr_lr():
+    sim = PowerPC601Simulator()
+    prog = (
+        xfx_form(PO_X31, 3, SPR_LR, XO_MTSPR)  # mtspr LR, r3
+        + xfx_form(PO_X31, 5, SPR_LR, XO_MFSPR)  # mfspr r5, LR
+        + HALT
+    )
+    sim.load(prog)
+    preset(sim, gpr={3: 0xDEAD_BEEF})
+    s, _ = run_from_current(sim)
+    assert s.lr == 0xDEAD_BEEF
+    assert s.r5 == 0xDEAD_BEEF
+
+
+def test_mtspr_ctr_and_mfspr_ctr():
+    sim = PowerPC601Simulator()
+    prog = (
+        xfx_form(PO_X31, 3, SPR_CTR, XO_MTSPR)
+        + xfx_form(PO_X31, 5, SPR_CTR, XO_MFSPR)
+        + HALT
+    )
+    sim.load(prog)
+    preset(sim, gpr={3: 42})
+    s, _ = run_from_current(sim)
+    assert s.ctr == 42
+    assert s.r5 == 42
+
+
+def test_mfcr_reads_cr():
+    sim = PowerPC601Simulator()
+    prog = (
+        x_form(PO_X31, 3, 0, 0, XO_MFCR)  # mfcr r3
+        + HALT
+    )
+    sim.load(prog)
+    preset(sim, cr=0xABCD_EF01)
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0xABCD_EF01
+
+
+def test_mtcrf_updates_selected_fields():
+    sim = PowerPC601Simulator()
+    # FXM=0xFF updates all CR fields
+    prog = (
+        x_form(PO_X31, 3, 0xFF, 0, XO_MTCRF) + HALT  # mtcrf 0xFF, r3
+    )
+    # Wait — mtcrf encoding: [OPCD:6][rS:5][1:1][FXM:8][--:1][rB:5][XO:10][0:1]
+    # FXM is at bits [20:12] = positions [19:12] in Python bit notation
+    # Let me encode this properly using the raw instruction:
+    # OPCD=31 at [31:26], rS at [25:21], bit20=1, FXM at [19:12], XO=144 at [10:1]
+    fxm = 0xFF
+    rs = 3
+    raw = (PO_X31 << 26) | (rs << 21) | (1 << 20) | (fxm << 12) | (XO_MTCRF << 1)
+    prog = raw.to_bytes(4, "big") + HALT
+    sim.load(prog)
+    preset(sim, gpr={3: 0x1234_5678})
+    s, _ = run_from_current(sim)
+    assert s.cr == 0x1234_5678

--- a/code/packages/python/powerpc601-simulator/tests/test_programs.py
+++ b/code/packages/python/powerpc601-simulator/tests/test_programs.py
@@ -1,0 +1,398 @@
+"""End-to-end program tests for the PowerPC 601 simulator.
+
+Each test runs a complete program that solves a real algorithmic task,
+verifying that the instruction set works correctly in combination.
+"""
+
+from powerpc601_simulator import (
+    BI_GT,
+    BO_ALWAYS,
+    BO_BDNZ,
+    BO_TRUE,
+    HALT,
+    SPR_CTR,
+    PowerPC601Simulator,
+    PowerPC601State,
+    b_form,
+    d_form,
+    i_form,
+    x_form,
+    xfx_form,
+    xl_form,
+    xo_form,
+)
+from powerpc601_simulator.simulator import (
+    PO_ADDI,
+    PO_B,
+    PO_BC,
+    PO_BX,
+    PO_LWZ,
+    PO_STW,
+    PO_X31,
+    XO_ADD,
+    XO_BCLR,
+    XO_CMP,
+    XO_MTSPR,
+    XO_MULLW,
+    XO_OR,
+    XO_XOR,
+)
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+
+
+def run(prog: bytes) -> PowerPC601State:
+    sim = PowerPC601Simulator()
+    result = sim.execute(prog)
+    assert result.ok, f"program failed: {result.error}"
+    return result.final_state
+
+
+# ── Program 1: Sum 1 through 10 = 55 ─────────────────────────────────────────
+#
+# r3 = accumulator (starts at 0)
+# r4 = counter (1 to 10)
+# CTR = loop count = 10
+#
+# loop:
+#   r3 += r4       (add r3, r3, r4)
+#   r4 += 1        (addi r4, r4, 1)
+#   bdnz loop      (decrement CTR; branch if CTR != 0)
+# HALT
+
+
+def test_sum_1_to_10():
+    """Sum 1+2+…+10 = 55."""
+    # Layout (each instruction is 4 bytes):
+    # [0]  addi r5, 0, 10     r5 = 10
+    # [4]  mtspr CTR, r5      CTR = 10
+    # [8]  addi r4, 0, 1      r4 = 1 (addend, increments each iteration)
+    # [12] addi r3, 0, 0      r3 = 0 (accumulator)
+    # [16] add r3, r3, r4     r3 += r4        ← loop start
+    # [20] addi r4, r4, 1     r4++
+    # [24] bdnz -8             back to [16]
+    # [28] HALT
+    prog = (
+        d_form(PO_ADDI, 5, 0, 10)                # [0]  r5 = 10
+        + xfx_form(PO_X31, 5, SPR_CTR, XO_MTSPR) # [4]  CTR = r5 = 10
+        + d_form(PO_ADDI, 4, 0, 1)               # [8]  r4 = 1
+        + d_form(PO_ADDI, 3, 0, 0)               # [12] r3 = 0
+        + xo_form(PO_X31, 3, 3, 4, 0, XO_ADD)   # [16] loop: r3 += r4
+        + d_form(PO_ADDI, 4, 4, 1)               # [20] r4++
+        + b_form(PO_BC, BO_BDNZ, 0, -8)          # [24] bdnz to [16]
+        + HALT                                     # [28]
+    )
+    s = run(prog)
+    assert s.r3 == 55
+
+
+# ── Program 2: Factorial 5! = 120 ────────────────────────────────────────────
+#
+# r3 = result (starts at 1)
+# r4 = counter (starts at 5, decrements to 1)
+# CTR = 4 (we multiply r3 by 5, 4, 3, 2)
+#
+# loop:
+#   r3 = r3 * r4   (mullw r3, r3, r4)
+#   r4 -= 1        (addi r4, r4, -1)
+#   bdnz loop
+# HALT
+
+
+def test_factorial_5():
+    """5! = 120."""
+    prog = (
+        d_form(PO_ADDI, 3, 0, 1)                  # r3 = 1
+        + d_form(PO_ADDI, 4, 0, 5)                # r4 = 5
+        + d_form(PO_ADDI, 5, 0, 4)                # r5 = 4 (loop count)
+        + xfx_form(PO_X31, 5, SPR_CTR, XO_MTSPR)  # CTR = 4
+        # loop @ [16]:
+        + xo_form(PO_X31, 3, 3, 4, 0, XO_MULLW)  # r3 *= r4
+        + d_form(PO_ADDI, 4, 4, -1)               # r4--
+        + b_form(PO_BC, BO_BDNZ, 0, -8)           # bdnz to [16]
+        + HALT
+    )
+    s = run(prog)
+    assert s.r3 == 120
+
+
+# ── Program 3: Fibonacci F(9) = 34 ───────────────────────────────────────────
+#
+# Uses registers for state:
+# r3 = F(n-2), r4 = F(n-1), r5 = F(n)
+# r6 = loop counter (0 to 7 = 8 iterations to go from F(1)=1 to F(9))
+
+
+def test_fibonacci_f9():
+    """F(9) = 34, starting from F(1)=1, F(2)=1."""
+    # Layout:
+    # [0]  addi r3, 0, 1      r3 = F(1) = 1
+    # [4]  addi r4, 0, 1      r4 = F(2) = 1
+    # [8]  addi r6, 0, 7      r6 = 7 (need 7 more additions: F(3)…F(9))
+    # [12] mtspr CTR, r6      CTR = 7
+    # [16] add r5, r3, r4     r5 = r3 + r4   ← loop start
+    # [20] or r3, r4, r4      r3 = r4 (mr: move r4 → r3)
+    # [24] or r4, r5, r5      r4 = r5 (mr: move r5 → r4)
+    # [28] bdnz -12            back to [16]
+    # [32] HALT
+    prog = (
+        d_form(PO_ADDI, 3, 0, 1)                  # [0]  r3 = F(1) = 1
+        + d_form(PO_ADDI, 4, 0, 1)                # [4]  r4 = F(2) = 1
+        + d_form(PO_ADDI, 6, 0, 7)                # [8]  r6 = 7
+        + xfx_form(PO_X31, 6, SPR_CTR, XO_MTSPR)  # [12] CTR = 7
+        + xo_form(PO_X31, 5, 3, 4, 0, XO_ADD)    # [16] r5 = r3 + r4
+        + x_form(PO_X31, 4, 3, 4, XO_OR)          # [20] r3 = r4  (mr r3, r4)
+        + x_form(PO_X31, 5, 4, 5, XO_OR)          # [24] r4 = r5  (mr r4, r5)
+        + b_form(PO_BC, BO_BDNZ, 0, -12)           # [28] bdnz to [16]
+        + HALT                                      # [32]
+    )
+    s = run(prog)
+    assert s.r4 == 34   # F(9) ends up in r4
+
+
+# ── Program 4: Subroutine call and return ─────────────────────────────────────
+#
+# Calls a subroutine that doubles r3, returns via blr.
+
+
+def test_subroutine_call_return():
+    """bl / blr subroutine call and return."""
+    # Layout:
+    # [0]  addi r3, 0, 21    r3 = 21
+    # [4]  bl +12            call subroutine at [16]   (LR = 8)
+    # [8]  HALT
+    # [12] HALT (padding)
+    # [16] add r3, r3, r3   double r3  ← subroutine
+    # [20] blr               return to LR
+    prog = (
+        d_form(PO_ADDI, 3, 0, 21)               # [0]  r3 = 21
+        + i_form(PO_B, 12, LK=1)                # [4]  bl +12 → [16]
+        + HALT                                   # [8]
+        + HALT                                   # [12] padding
+        + xo_form(PO_X31, 3, 3, 3, 0, XO_ADD)  # [16] r3 = r3 + r3 = 42
+        + xl_form(PO_BX, BO_ALWAYS, 0, 0, XO_BCLR)  # [20] blr
+    )
+    s = run(prog)
+    assert s.r3 == 42   # doubled
+    assert s.lr == 8    # LR saved by bl at [4]: CIA+4 = 8
+
+
+# ── Program 5: Array sum ──────────────────────────────────────────────────────
+#
+# Sum of array [10, 20, 30, 40, 50] = 150, stored in memory.
+# r3 = base address of array
+# r4 = accumulator
+# r5 = loop count
+# Load each word and accumulate.
+
+
+def test_array_sum():
+    """Sum array [10, 20, 30, 40, 50] = 150."""
+    base = 0x400   # array starts at address 0x400
+    # Build array in memory via stw instructions at the start
+    # Array: [10, 20, 30, 40, 50] at 0x400..0x413
+    prog = (
+        d_form(PO_ADDI, 3, 0, base)               # r3 = base address
+        + d_form(PO_ADDI, 4, 0, 0)               # r4 = 0 (accumulator)
+        + d_form(PO_ADDI, 5, 0, 5)               # r5 = 5 (loop count)
+        + xfx_form(PO_X31, 5, SPR_CTR, XO_MTSPR) # CTR = 5
+        # loop @ [16]:
+        + d_form(PO_LWZ, 6, 3, 0)               # r6 = MEM[r3]
+        + xo_form(PO_X31, 4, 4, 6, 0, XO_ADD)   # r4 += r6
+        + d_form(PO_ADDI, 3, 3, 4)              # r3 += 4 (next word)
+        + b_form(PO_BC, BO_BDNZ, 0, -12)        # bdnz to [16]
+        + HALT
+    )
+    sim = PowerPC601Simulator()
+    sim.load(prog)
+    # Write the array into memory at base
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    for i, v in enumerate([10, 20, 30, 40, 50]):
+        addr = base + i * 4
+        mem[addr]     = (v >> 24) & 0xFF
+        mem[addr + 1] = (v >> 16) & 0xFF
+        mem[addr + 2] = (v >> 8)  & 0xFF
+        mem[addr + 3] =  v        & 0xFF
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+
+    from conftest import run_from_current
+    s, err = run_from_current(sim)
+    assert err is None
+    assert s.r4 == 150
+
+
+# ── Program 6: Maximum of two values ─────────────────────────────────────────
+#
+# r3 = max(r3, r4) using cmpw and conditional branch.
+
+
+def test_max_two_values():
+    """Compute max(15, 27) = 27."""
+    # [0]  cmpw cr0, r3, r4   compare r3 and r4
+    # [4]  bgt  +4             if r3 > r4 skip the move
+    # [8]  or r3, r4, r4       r3 = r4  (mr r3, r4)
+    # [12] HALT
+    prog = (
+        x_form(PO_X31, 0, 3, 4, XO_CMP)           # cmpw cr0, r3, r4
+        + b_form(PO_BC, BO_TRUE, BI_GT, 8)         # bgt +8 (skip move)
+        + x_form(PO_X31, 4, 3, 4, XO_OR)           # r3 = r4
+        + HALT
+    )
+    sim = PowerPC601Simulator()
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 15; gpr[4] = 27
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r3 == 27
+
+
+def test_max_two_values_first_wins():
+    prog = (
+        x_form(PO_X31, 0, 3, 4, XO_CMP)
+        + b_form(PO_BC, BO_TRUE, BI_GT, 8)
+        + x_form(PO_X31, 4, 3, 4, XO_OR)
+        + HALT
+    )
+    sim = PowerPC601Simulator()
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 100; gpr[4] = 50
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r3 == 100
+
+
+# ── Program 7: Memory copy ────────────────────────────────────────────────────
+#
+# Copy 4 words from source region to destination region.
+
+
+def test_memory_copy():
+    """Copy 4 words from 0x500 to 0x600."""
+    src = 0x500; dst = 0x600
+    prog = (
+        d_form(PO_ADDI, 3, 0, src)               # r3 = src
+        + d_form(PO_ADDI, 4, 0, dst)             # r4 = dst
+        + d_form(PO_ADDI, 5, 0, 4)               # r5 = 4 (word count)
+        + xfx_form(PO_X31, 5, SPR_CTR, XO_MTSPR) # CTR = 4
+        # loop @ [16]:
+        + d_form(PO_LWZ, 6, 3, 0)               # r6 = MEM[r3]
+        + d_form(PO_STW, 6, 4, 0)               # MEM[r4] = r6
+        + d_form(PO_ADDI, 3, 3, 4)              # r3 += 4
+        + d_form(PO_ADDI, 4, 4, 4)              # r4 += 4
+        + b_form(PO_BC, BO_BDNZ, 0, -16)        # bdnz to [16]
+        + HALT
+    )
+    sim = PowerPC601Simulator()
+    sim.load(prog)
+    s0 = sim.get_state()
+    mem = list(s0.memory)
+    src_data = [0x1111_1111, 0x2222_2222, 0x3333_3333, 0x4444_4444]
+    for i, v in enumerate(src_data):
+        addr = src + i * 4
+        mem[addr]     = (v >> 24) & 0xFF
+        mem[addr + 1] = (v >> 16) & 0xFF
+        mem[addr + 2] = (v >> 8)  & 0xFF
+        mem[addr + 3] =  v        & 0xFF
+    sim._state = PowerPC601State(**{**s0.__dict__, "memory": tuple(mem)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, err = run_from_current(sim)
+    assert err is None
+    for i, expected in enumerate(src_data):
+        addr = dst + i * 4
+        word = (s.memory[addr] << 24 | s.memory[addr + 1] << 16
+                | s.memory[addr + 2] << 8 | s.memory[addr + 3])
+        assert word == expected, f"word {i}: expected 0x{expected:08X}, got 0x{word:08X}"
+
+
+# ── Program 8: XOR-based register swap ───────────────────────────────────────
+#
+# Swap r3 and r4 using three XOR operations (no temp register).
+
+
+def test_xor_swap():
+    """Swap r3 and r4 without a temporary register using XOR."""
+    # x_form(opcode, rS, rA, rB, xo): rA = rS ^ rB
+    prog = (
+        x_form(PO_X31, 3, 3, 4, XO_XOR)   # r3 = r3 ^ r4  (rS=3, rA=3, rB=4)
+        + x_form(PO_X31, 4, 4, 3, XO_XOR)  # r4 = r4 ^ r3  (rS=4, rA=4, rB=3) = original r3
+        + x_form(PO_X31, 3, 3, 4, XO_XOR)  # r3 = r3 ^ r4  (rS=3, rA=3, rB=4) = original r4
+        + HALT
+    )
+    sim = PowerPC601Simulator()
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 0xAAAA_AAAA; gpr[4] = 0x5555_5555
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r3 == 0x5555_5555
+    assert s.r4 == 0xAAAA_AAAA
+
+
+# ── Program 9: Count-down with bdz ───────────────────────────────────────────
+
+
+def test_countdown_with_bdz():
+    """Count CTR from 5 down to 0, accumulate total iterations."""
+    # r3 = number of times the body executed
+    # [0]  addi r3, r3, 1      r3++
+    # [4]  bdz +4               if CTR==0 after dec, jump to [8]
+    # [8]  b -8                 else loop back
+    # [12] HALT
+    prog = (
+        d_form(PO_ADDI, 3, 3, 1)         # [0] r3++
+        + b_form(PO_BC, 12, 0, 8)         # [4] bdz +8 → skip b, go to HALT
+        + i_form(PO_B, -8)                # [8] b -8 → back to [0]
+        + HALT                             # [12]
+    )
+    sim = PowerPC601Simulator()
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 0
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr), "ctr": 5})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, err = run_from_current(sim)
+    assert err is None
+    assert s.r3 == 5
+
+
+# ── Program 10: 64-bit add (two 32-bit halves) ───────────────────────────────
+#
+# Demonstrates addc / adde for multi-word arithmetic.
+# Computes (r3:r4) + (r5:r6) → (r7:r8)
+# where r3/r5 are low words and r4/r6 are high words.
+
+
+def test_64bit_add():
+    """Add two 64-bit numbers using addc/adde."""
+    from powerpc601_simulator.simulator import XO_ADDC, XO_ADDE
+    # 0x0000_0001_FFFF_FFFE + 0x0000_0001_0000_0002 = 0x0000_0003_0000_0000
+    # Low:  0xFFFF_FFFE + 0x0000_0002 = 0x1_0000_0000 → low=0x0000_0000, CA=1
+    # High: 0x0000_0001 + 0x0000_0001 + CA=1 = 0x0000_0003
+    prog = (
+        xo_form(PO_X31, 7, 3, 5, 0, XO_ADDC)   # r7 = r3 + r5 (low), set CA
+        + xo_form(PO_X31, 8, 4, 6, 0, XO_ADDE) # r8 = r4 + r6 + CA (high)
+        + HALT
+    )
+    sim = PowerPC601Simulator()
+    sim.load(prog)
+    s0 = sim.get_state()
+    gpr = list(s0.gpr)
+    gpr[3] = 0xFFFF_FFFE  # low of first
+    gpr[4] = 0x0000_0001  # high of first
+    gpr[5] = 0x0000_0002  # low of second
+    gpr[6] = 0x0000_0001  # high of second
+    sim._state = PowerPC601State(**{**s0.__dict__, "gpr": tuple(gpr)})  # type: ignore[arg-type]
+    from conftest import run_from_current
+    s, _ = run_from_current(sim)
+    assert s.r7 == 0x0000_0000  # low result
+    assert s.r8 == 0x0000_0003  # high result

--- a/code/packages/python/powerpc601-simulator/tests/test_protocol.py
+++ b/code/packages/python/powerpc601-simulator/tests/test_protocol.py
@@ -1,0 +1,240 @@
+"""SIM00 protocol compliance tests for PowerPC601Simulator."""
+
+from simulator_protocol import ExecutionResult, Simulator, StepTrace
+
+from powerpc601_simulator import (
+    HALT,
+    PowerPC601Simulator,
+    PowerPC601State,
+    d_form,
+    i_form,
+)
+from powerpc601_simulator.simulator import PO_ADDI, PO_B
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def simple_prog() -> bytes:
+    """addi r3, 0, 42  then HALT — smallest non-trivial program."""
+    return d_form(PO_ADDI, 3, 0, 42) + HALT
+
+
+# ── isinstance checks ──────────────────────────────────────────────────────────
+
+
+def test_is_simulator():
+    sim = PowerPC601Simulator()
+    assert isinstance(sim, Simulator)
+
+
+def test_is_concrete_simulator():
+    sim = PowerPC601Simulator()
+    assert isinstance(sim, PowerPC601Simulator)
+
+
+# ── reset() ───────────────────────────────────────────────────────────────────
+
+
+def test_reset_clears_gprs():
+    sim = PowerPC601Simulator()
+    sim.execute(simple_prog())
+    sim.reset()
+    s = sim.get_state()
+    assert s.gpr == tuple(0 for _ in range(32))
+
+
+def test_reset_clears_special_regs():
+    sim = PowerPC601Simulator()
+    sim.execute(simple_prog())
+    sim.reset()
+    s = sim.get_state()
+    assert s.lr == 0
+    assert s.ctr == 0
+    assert s.xer == 0
+    assert s.cr == 0
+
+
+def test_reset_clears_memory():
+    sim = PowerPC601Simulator()
+    sim.execute(simple_prog())
+    sim.reset()
+    s = sim.get_state()
+    assert all(b == 0 for b in s.memory)
+
+
+def test_reset_sets_cia_zero():
+    sim = PowerPC601Simulator()
+    sim.execute(simple_prog())
+    sim.reset()
+    assert sim.get_state().cia == 0
+
+
+def test_reset_clears_halted():
+    sim = PowerPC601Simulator()
+    sim.execute(simple_prog())
+    assert sim.get_state().halted
+    sim.reset()
+    assert not sim.get_state().halted
+
+
+# ── load() ────────────────────────────────────────────────────────────────────
+
+
+def test_load_resets_state():
+    sim = PowerPC601Simulator()
+    sim.execute(simple_prog())
+    sim.load(simple_prog())
+    s = sim.get_state()
+    assert s.cia == 0
+    assert not s.halted
+
+
+def test_load_places_bytes_in_memory():
+    sim = PowerPC601Simulator()
+    sim.load(simple_prog())
+    s = sim.get_state()
+    # First 4 bytes encode the addi instruction — memory[0] must be non-zero
+    assert s.memory[0] != 0
+
+
+# ── step() ────────────────────────────────────────────────────────────────────
+
+
+def test_step_returns_step_trace():
+    sim = PowerPC601Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    assert isinstance(trace, StepTrace)
+
+
+def test_step_trace_has_pc_before():
+    sim = PowerPC601Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    assert trace.pc_before == 0
+
+
+def test_step_trace_has_pc_after():
+    sim = PowerPC601Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    # addi is a single 32-bit instruction → CIA advances by 4
+    assert trace.pc_after == 4
+
+
+def test_step_trace_has_mnemonic():
+    sim = PowerPC601Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    assert "addi" in trace.mnemonic
+
+
+def test_step_trace_description_not_empty():
+    sim = PowerPC601Simulator()
+    sim.load(simple_prog())
+    trace = sim.step()
+    assert trace.description
+
+
+def test_step_when_halted_returns_halt_trace():
+    sim = PowerPC601Simulator()
+    sim.execute(simple_prog())
+    trace = sim.step()
+    assert "HALT" in trace.mnemonic
+    assert trace.pc_before == trace.pc_after
+
+
+def test_step_advances_cia():
+    sim = PowerPC601Simulator()
+    sim.load(simple_prog())
+    sim.step()   # addi (4 bytes)
+    assert sim.get_state().cia == 4
+
+
+# ── execute() ─────────────────────────────────────────────────────────────────
+
+
+def test_execute_returns_execution_result():
+    sim = PowerPC601Simulator()
+    result = sim.execute(simple_prog())
+    assert isinstance(result, ExecutionResult)
+
+
+def test_execute_halted_true():
+    sim = PowerPC601Simulator()
+    result = sim.execute(simple_prog())
+    assert result.halted
+
+
+def test_execute_ok():
+    sim = PowerPC601Simulator()
+    result = sim.execute(simple_prog())
+    assert result.ok
+
+
+def test_execute_steps_positive():
+    sim = PowerPC601Simulator()
+    result = sim.execute(simple_prog())
+    assert result.steps > 0
+
+
+def test_execute_final_state_is_powerpc601state():
+    sim = PowerPC601Simulator()
+    result = sim.execute(simple_prog())
+    assert isinstance(result.final_state, PowerPC601State)
+
+
+def test_execute_r3_set():
+    sim = PowerPC601Simulator()
+    result = sim.execute(simple_prog())
+    assert result.final_state.r3 == 42
+
+
+def test_execute_traces_list():
+    sim = PowerPC601Simulator()
+    result = sim.execute(simple_prog())
+    assert isinstance(result.traces, list)
+    assert len(result.traces) > 0
+
+
+def test_execute_no_error_on_success():
+    sim = PowerPC601Simulator()
+    result = sim.execute(simple_prog())
+    assert result.error is None
+
+
+def test_execute_max_steps_exceeded():
+    sim = PowerPC601Simulator()
+    # Infinite loop: b 0 (branch to self)
+    inf_loop = i_form(PO_B, 0)   # b 0 (branch to CIA+0 = itself)
+    result = sim.execute(inf_loop, max_steps=10)
+    assert not result.ok
+    assert result.error is not None
+
+
+# ── get_state() ───────────────────────────────────────────────────────────────
+
+
+def test_get_state_returns_powerpc601state():
+    sim = PowerPC601Simulator()
+    assert isinstance(sim.get_state(), PowerPC601State)
+
+
+def test_get_state_snapshot_not_mutated():
+    sim = PowerPC601Simulator()
+    sim.load(simple_prog())
+    snap = sim.get_state()
+    cia_before = snap.cia
+    sim.step()
+    assert snap.cia == cia_before
+
+
+def test_get_state_is_frozen():
+    sim = PowerPC601Simulator()
+    s = sim.get_state()
+    raised = False
+    try:
+        s.cia = 99  # type: ignore[misc]
+    except (AttributeError, TypeError):
+        raised = True
+    assert raised, "Frozen dataclass should not allow attribute assignment"

--- a/code/specs/07u-powerpc601-simulator.md
+++ b/code/specs/07u-powerpc601-simulator.md
@@ -1,0 +1,445 @@
+# Layer 07u — PowerPC 601 (1992) Behavioral Simulator
+
+## Overview
+
+The **PowerPC 601** (1992) was the first processor produced under the AIM alliance
+(Apple, IBM, Motorola).  It powered the original Power Macintosh line (March 1994),
+BeOS developer machines, and early PowerPC workstations.  The 601 is a hybrid:
+it implements the new PowerPC ISA but retains backward compatibility with IBM's
+older POWER architecture (the 603/604 dropped the POWER legacy ops).
+
+Historical significance:
+- **First PowerPC chip**: launched the AIM alliance that kept Apple competitive
+  against x86 through 2006 when Apple switched to Intel
+- **RISC revolution in consumer hardware**: brought clean load/store RISC to the
+  desktop at a time when Intel's x86 still ruled via CISC inertia
+- **Big-endian powerhouse**: classic Mac OS, BeOS, and early Linux ran big-endian;
+  the ISA later added bi-endian support
+- **Scoreboard heritage via POWER**: the 601 executed up to three instructions per
+  cycle using a unified pipeline, borrowing scoreboarding ideas that trace back to
+  Seymour Cray's CDC 6600 (the previous layer in this series)
+
+Comparison with prior simulators:
+
+| Feature          | CDC 6600 (07t)               | PowerPC 601 (07u)               |
+|------------------|------------------------------|---------------------------------|
+| Year             | 1964                         | 1992                            |
+| Word width       | 60 bits                      | **32 bits**                     |
+| GPRs             | 8 × 60-bit X + 8 × 18-bit A/B | **32 × 32-bit GPR**            |
+| Special regs     | None (no LR/CTR equiv.)      | **LR, CTR, CR, XER**           |
+| Instruction size | 15-bit or 30-bit (variable)  | **32-bit fixed**                |
+| Endianness       | Big                          | **Big** (bi-endian optional)    |
+| Memory model     | Word-addressed (60-bit words)| **Byte-addressed**              |
+| Condition codes  | None (branch tests register) | **CR register (8 × 4-bit)**    |
+
+---
+
+## Architecture
+
+### General-Purpose Registers: GPR0–GPR31
+
+- 32 registers, each **32 bits** wide
+- **GPR0 special case**: when GPR0 appears as the `rA` field in instructions that
+  compute an effective address (loads, stores, `addi`, `addis`), the value used is
+  **0** (not the contents of GPR0).  GPR0 still holds its value for all other
+  operations (logical ops, arithmetic ops as source/destination, etc.).
+- No register is hardwired to zero like MIPS R0 or Alpha R31; the GPR0 rule applies
+  only in effective-address calculations.
+
+### Special-Purpose Registers
+
+#### Link Register (LR)
+- 32 bits
+- Set to the address of the next instruction by `bl` (branch and link) and `bctrl`
+- Used as a branch target by `blr` (branch to link register)
+- Read/written via `mfspr` / `mtspr` with SPR=8
+
+#### Count Register (CTR)
+- 32 bits
+- Used as a decrement counter by `bdnz`-style conditional branches
+- Used as a branch target by `bctr` / `bctrl`
+- Read/written via `mfspr` / `mtspr` with SPR=9
+
+#### XER (Fixed-Point Exception Register)
+- 32 bits
+- Bit 0 (MSB): **SO** — Summary Overflow (sticky; set by overflow, never cleared by
+  instructions in this simulator)
+- Bit 1: **OV** — Overflow (set by arithmetic overflow)
+- Bit 2: **CA** — Carry (set by carry out of bit 31 in add/subtract variants)
+- Bits 3–31: not simulated
+- Read/written via `mfspr` / `mtspr` with SPR=1
+
+#### Condition Register (CR)
+- 32 bits
+- Divided into 8 four-bit fields: **CR0** (bits 0–3, most significant) through **CR7**
+  (bits 28–31, least significant).  PowerPC bit 0 = MSB.
+- Within each field, the bit pattern is: `[LT, GT, EQ, SO]`
+  - **LT** (Less Than, bit 0 of field): 1 if result < 0 (signed)
+  - **GT** (Greater Than, bit 1 of field): 1 if result > 0 (signed)
+  - **EQ** (Equal, bit 2 of field): 1 if result == 0
+  - **SO** (Summary Overflow, bit 3 of field): copy of XER[SO] at compare time
+- **CR0** is updated automatically by `andi.`, `andis.`, and any instruction with
+  the `Rc=1` bit set (e.g., `add.`, `and.`).  This simulator implements `Rc=0`
+  for all arithmetic/logical instructions unless explicitly noted.
+- **Any CRn** field is updated by `cmpw`, `cmplw`, `cmpwi`, `cmplwi`.
+- Read/written via `mfcr` / `mtcrf`; individual bits via `mcrxr` (not simulated).
+
+#### CIA (Current Instruction Address)
+- The program counter; always a multiple of 4 (instructions are 4-byte aligned)
+- Called `cia` in this simulator's state
+- Advances by 4 after each non-branch instruction
+
+---
+
+## Memory
+
+- **Byte-addressed flat address space**
+- Simulation uses **65 536 bytes (64 KiB)** — sufficient for all test programs
+- **Big-endian**: multi-byte values store the most significant byte at the lowest
+  address (opposite of x86 little-endian)
+- Word (32-bit) accesses must be **4-byte aligned**; halfword (16-bit) must be
+  **2-byte aligned**.  This simulator does not raise alignment exceptions — it
+  masks the address (`addr & ~3` for words, `addr & ~1` for halfwords).
+
+---
+
+## Instruction Formats
+
+All PowerPC instructions are exactly **32 bits**.  Bit 0 is the most significant.
+
+### I-Form (Branch Unconditional)
+
+```
+ 0  1  2  3  4  5  6  7  8  9 10 11 12 ... 29 30 31
+[     OPCD     ][                LI              ][AA][LK]
+```
+
+- **OPCD** (bits 0–5): primary opcode = 18
+- **LI** (bits 6–29): 24-bit signed integer; effective branch offset = LI × 4
+- **AA** (bit 30): absolute address flag (0 = PC-relative, 1 = absolute)
+- **LK** (bit 31): link flag (1 = save CIA+4 to LR before branching)
+- `b target` = OPCD=18, AA=0, LK=0
+- `bl target` = OPCD=18, AA=0, LK=1
+
+### B-Form (Branch Conditional)
+
+```
+ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 ... 29 30 31
+[     OPCD     ][     BO     ][     BI     ][        BD        ][AA][LK]
+```
+
+- **OPCD** = 16
+- **BO** (bits 6–10): 5-bit branch options field (see below)
+- **BI** (bits 11–15): 5-bit CR bit index (0 = CR0.LT, 1 = CR0.GT, 2 = CR0.EQ, ...)
+- **BD** (bits 16–29): 14-bit signed integer; offset = BD × 4
+- `bc BO, BI, target` — conditional branch
+
+#### BO Field Encoding
+
+| BO (decimal) | BO (binary) | Meaning                                |
+|--------------|-------------|----------------------------------------|
+| 20           | 10100       | Branch always (unconditional)          |
+| 18           | 10010       | Branch if CR[BI] = 1 (don't test CTR) |
+| 16           | 10000       | Branch if CR[BI] = 0 (don't test CTR) |
+|  4           | 00100       | Decrement CTR; branch if CTR ≠ 0, don't test CR (`bdnz`) |
+| 12           | 01100       | Decrement CTR; branch if CTR = 0, don't test CR (`bdz`)  |
+
+Full decoding (BO[0] is the MSB of the 5-bit field = bit 4 of the integer value):
+1. If BO[0] = 0: decrement CTR; `ctr_ok = (CTR ≠ 0) XOR BO[1]`
+   If BO[0] = 1: `ctr_ok = True`
+2. Let `cr_bit = CR[BI]` (bit BI of CR, 0 = MSB).
+   If BO[2] = 0: `cond_ok = (cr_bit == BO[3])`
+   If BO[2] = 1: `cond_ok = True`
+3. Branch if `ctr_ok AND cond_ok`
+
+### D-Form (Immediate / Load / Store)
+
+```
+ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+[     OPCD     ][      rD     ][      rA     ][                  imm / d                   ]
+```
+
+- **rD** (bits 6–10): destination register
+- **rA** (bits 11–15): source / base register
+- **imm / d** (bits 16–31): 16-bit immediate (sign-extended for arithmetic/memory;
+  zero-extended for `andi.`, `ori`, `xori`, `andis.`, `oris`, `cmplwi`)
+
+### X-Form (Register–Register Logic / Shift / Compare)
+
+```
+ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+[     OPCD     ][      rS     ][      rA     ][      rB     ][            XO             ][Rc]
+```
+
+- Primary **OPCD** = 31 for most X-form instructions
+- **XO** (bits 21–30): 10-bit secondary opcode
+
+### XO-Form (Integer Arithmetic)
+
+```
+ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+[     OPCD     ][      rD     ][      rA     ][      rB     ][OE][           XO          ][Rc]
+```
+
+- Primary **OPCD** = 31
+- **OE** (bit 21): overflow enable (this simulator always treats OE=0)
+- **XO** (bits 22–30): 9-bit secondary opcode
+
+### XFX-Form (Move to/from Special Registers)
+
+```
+ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+[     OPCD     ][      rS     ][  SPR[5:9]  ][  SPR[0:4]  ][            XO             ][--]
+```
+
+- **OPCD** = 31
+- The 10-bit SPR field is stored split: SPR bits 5–9 at instruction bits 11–15, SPR bits 0–4 at instruction bits 16–20
+- **XO** = 339 for `mfspr`, 467 for `mtspr`, 19 for `mfcr`, 144 for `mtcrf`
+
+### XL-Form (Branch via LR / CTR)
+
+```
+ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+[     OPCD     ][     BO      ][     BI     ][     BH     ][            XO             ][LK]
+```
+
+- Primary **OPCD** = 19
+- **XO** = 16 for `bclr` (branch to LR), 528 for `bcctr` (branch to CTR)
+- `blr` = `bclr 20, 0` (unconditional branch to LR)
+- `bctr` = `bcctr 20, 0` (unconditional branch to CTR)
+- `bctrl` = `bcctr 20, 0` with LK=1
+
+---
+
+## Instruction Set (Simulated Subset)
+
+### Integer Arithmetic (XO-form, OPCD=31)
+
+| Mnemonic          | XO  | Operation                                   | Notes          |
+|-------------------|-----|---------------------------------------------|----------------|
+| `add rD,rA,rB`    | 266 | rD = rA + rB                                |                |
+| `addc rD,rA,rB`   |  10 | rD = rA + rB; set CA                        | carry out       |
+| `adde rD,rA,rB`   | 138 | rD = rA + rB + XER[CA]; set CA             | add extended    |
+| `subf rD,rA,rB`   |  40 | rD = rB − rA  ("subtract from")            |                |
+| `neg rD,rA`       | 104 | rD = −rA                                    | rB=0           |
+| `mullw rD,rA,rB`  | 235 | rD = low32(rA × rB)  (signed)              |                |
+| `divw rD,rA,rB`   | 491 | rD = rA ÷ rB  (signed)                     | truncates toward 0 |
+| `divwu rD,rA,rB`  | 459 | rD = rA ÷ rB  (unsigned)                   |                |
+
+### Integer Arithmetic Immediate (D-form)
+
+| Mnemonic              | OPCD | Operation                                     | Notes             |
+|-----------------------|------|-----------------------------------------------|-------------------|
+| `addi rD,rA,SIMM`     |  14  | rD = (rA\|0) + SIMM                          | `li rD,val` = `addi rD,0,val` |
+| `addis rD,rA,SIMM`    |  15  | rD = (rA\|0) + (SIMM << 16)                 | `lis rD,val` = `addis rD,0,val` |
+| `subfic rD,rA,SIMM`   |   8  | rD = SIMM − rA; set CA                        |                   |
+
+### Logical (X-form, OPCD=31)
+
+| Mnemonic           | XO  | Operation              |
+|--------------------|-----|------------------------|
+| `and rA,rS,rB`     |  28 | rA = rS & rB           |
+| `or rA,rS,rB`      | 444 | rA = rS \| rB          |
+| `xor rA,rS,rB`     | 316 | rA = rS ^ rB           |
+| `nand rA,rS,rB`    | 476 | rA = ~(rS & rB)        |
+| `nor rA,rS,rB`     | 124 | rA = ~(rS \| rB)       |
+| `cntlzw rA,rS`     |  26 | rA = count leading zeros of rS (32-bit) |
+
+### Logical Immediate (D-form)
+
+| Mnemonic              | OPCD | Operation                          | Sets CR0? |
+|-----------------------|------|------------------------------------|-----------|
+| `andi. rA,rS,UIMM`   |  28  | rA = rS & UIMM (zero-extended)    | Yes       |
+| `andis. rA,rS,UIMM`  |  29  | rA = rS & (UIMM << 16)            | Yes       |
+| `ori rA,rS,UIMM`     |  24  | rA = rS \| UIMM (zero-extended)   | No        |
+| `oris rA,rS,UIMM`    |  25  | rA = rS \| (UIMM << 16)           | No        |
+| `xori rA,rS,UIMM`    |  26  | rA = rS ^ UIMM (zero-extended)    | No        |
+
+### Shift / Rotate (X-form, OPCD=31)
+
+| Mnemonic            | XO  | Operation                                     |
+|---------------------|-----|-----------------------------------------------|
+| `slw rA,rS,rB`      |  24 | rA = rS << n; 0 if n ≥ 32  (n = rB & 0x3F)  |
+| `srw rA,rS,rB`      | 536 | rA = rS >> n; 0 if n ≥ 32  (logical shift)   |
+| `sraw rA,rS,rB`     | 792 | rA = signed(rS) >> n; sets CA               |
+| `srawi rA,rS,SH`    | 824 | rA = signed(rS) >> SH; sets CA (SH in rB field) |
+
+For `sraw`/`srawi`, XER[CA] is set if the operand is negative and any 1-bits are
+shifted out; otherwise CA is cleared.
+
+### Compare (X-form, OPCD=31)
+
+| Mnemonic              | XO | Operation                         |
+|-----------------------|----|-----------------------------------|
+| `cmpw crfD,rA,rB`     |  0 | Signed compare; set CR field crfD |
+| `cmplw crfD,rA,rB`    | 32 | Unsigned compare; set CR crfD     |
+
+The `crfD` field occupies bits 6–8 of the instruction (the upper 3 bits of the
+rS/rD position); bits 9–10 are 0.
+
+### Compare Immediate (D-form)
+
+| Mnemonic               | OPCD | Operation                          |
+|------------------------|------|------------------------------------|
+| `cmpwi crfD,rA,SIMM`  |  11  | Signed compare immediate          |
+| `cmplwi crfD,rA,UIMM` |  10  | Unsigned compare immediate        |
+
+### Load (D-form)
+
+| Mnemonic           | OPCD | Operation                              | Update rA? |
+|--------------------|------|----------------------------------------|------------|
+| `lwz rD,d(rA)`    |  32  | rD = MEM[EA:EA+3] (4 bytes)           | No         |
+| `lwzu rD,d(rA)`   |  33  | rD = MEM[EA:EA+3]; rA = EA            | Yes        |
+| `lbz rD,d(rA)`    |  34  | rD = zero_extend(MEM[EA])             | No         |
+| `lbzu rD,d(rA)`   |  35  | rD = zero_extend(MEM[EA]); rA = EA   | Yes        |
+| `lhz rD,d(rA)`    |  40  | rD = zero_extend(MEM[EA:EA+1])       | No         |
+| `lha rD,d(rA)`    |  42  | rD = sign_extend(MEM[EA:EA+1])       | No         |
+
+EA = (rA == 0 ? 0 : GPR[rA]) + sign_extend(d)
+
+### Store (D-form)
+
+| Mnemonic           | OPCD | Operation                              | Update rA? |
+|--------------------|------|----------------------------------------|------------|
+| `stw rS,d(rA)`    |  36  | MEM[EA:EA+3] = rS                     | No         |
+| `stwu rS,d(rA)`   |  37  | MEM[EA:EA+3] = rS; rA = EA            | Yes        |
+| `stb rS,d(rA)`    |  38  | MEM[EA] = rS[24:31] (low byte)        | No         |
+| `stbu rS,d(rA)`   |  39  | MEM[EA] = rS[24:31]; rA = EA          | Yes        |
+| `sth rS,d(rA)`    |  44  | MEM[EA:EA+1] = rS[16:31] (low half)  | No         |
+
+### Branch (I-form, OPCD=18)
+
+| Mnemonic    | LK | Operation                     |
+|-------------|-----|-------------------------------|
+| `b target`  | 0   | CIA += sign_extend(LI) × 4   |
+| `bl target` | 1   | LR = CIA+4; CIA += LI × 4    |
+
+### Branch Conditional (B-form, OPCD=16)
+
+| Mnemonic          | BO | BI | Operation                     |
+|-------------------|----|----|-------------------------------|
+| `blt target`      | 18 | 0  | Branch if CR0.LT = 1         |
+| `bge target`      | 16 | 0  | Branch if CR0.LT = 0         |
+| `bgt target`      | 18 | 1  | Branch if CR0.GT = 1         |
+| `ble target`      | 16 | 1  | Branch if CR0.GT = 0         |
+| `beq target`      | 18 | 2  | Branch if CR0.EQ = 1         |
+| `bne target`      | 16 | 2  | Branch if CR0.EQ = 0         |
+| `bdnz target`     |  4 | 0  | Decrement CTR; branch if CTR ≠ 0 |
+| `bdz target`      | 12 | 0  | Decrement CTR; branch if CTR = 0  |
+
+### Branch via LR / CTR (XL-form, OPCD=19)
+
+| Mnemonic  | XO  | LK | Operation               |
+|-----------|-----|----|-------------------------|
+| `blr`     | 16  | 0  | CIA = LR (branch to LR)|
+| `bctrl`   | 528 | 1  | LR = CIA+4; CIA = CTR  |
+| `bctr`    | 528 | 0  | CIA = CTR              |
+
+### Move to/from Special Registers (XFX-form, OPCD=31)
+
+| Mnemonic       | XO  | SPR | Operation         |
+|----------------|-----|-----|-------------------|
+| `mfspr rD,XER` | 339 |   1 | rD = XER          |
+| `mfspr rD,LR`  | 339 |   8 | rD = LR           |
+| `mfspr rD,CTR` | 339 |   9 | rD = CTR          |
+| `mtspr XER,rS` | 467 |   1 | XER = rS          |
+| `mtspr LR,rS`  | 467 |   8 | LR = rS           |
+| `mtspr CTR,rS` | 467 |   9 | CTR = rS          |
+| `mfcr rD`      |  19 | n/a | rD = CR           |
+| `mtcrf FXM,rS` | 144 | n/a | Update CR fields selected by FXM mask |
+
+`mtcrf FXM, rS` updates each nibble of CR where the corresponding bit in the 8-bit
+FXM mask is 1.  FXM=0xFF updates all of CR; FXM=0x80 updates only CR0.
+
+### HALT
+
+- Instruction word `0x00000000` — the all-zeros 32-bit word
+- Not a valid PowerPC instruction; the simulator halts when it fetches it
+- Exported as `HALT: bytes = b"\x00\x00\x00\x00"`
+
+---
+
+## Encoding Helpers (exported from the package)
+
+```python
+HALT: bytes                              # b"\x00\x00\x00\x00"
+
+# SPR numbers
+SPR_XER: int = 1
+SPR_LR:  int = 8
+SPR_CTR: int = 9
+
+# BO values for common branch patterns
+BO_ALWAYS: int = 20
+BO_TRUE:   int = 18   # branch if CR[BI] = 1
+BO_FALSE:  int = 16   # branch if CR[BI] = 0
+BO_BDNZ:   int = 4    # decrement CTR, branch if CTR ≠ 0
+BO_BDZ:    int = 12   # decrement CTR, branch if CTR = 0
+
+# CR0 bit indices
+BI_LT: int = 0   # CR0.LT
+BI_GT: int = 1   # CR0.GT
+BI_EQ: int = 2   # CR0.EQ
+BI_SO: int = 3   # CR0.SO
+
+# Instruction encoding helpers
+def i_form(opcode, byte_offset, AA=0, LK=0) -> bytes   # I-form
+def b_form(opcode, BO, BI, byte_offset, AA=0, LK=0) -> bytes  # B-form
+def d_form(opcode, rD, rA, imm) -> bytes               # D-form
+def x_form(opcode, rS, rA, rB, xo, rc=0) -> bytes      # X-form
+def xo_form(opcode, rD, rA, rB, oe, xo, rc=0) -> bytes # XO-form
+def xfx_form(opcode, rS, spr, xo) -> bytes             # XFX-form
+def xl_form(opcode, BO, BI, BH, xo, lk=0) -> bytes     # XL-form
+```
+
+---
+
+## State Snapshot
+
+```python
+@dataclass(frozen=True)
+class PowerPC601State:
+    cia:    int               # current instruction address (PC), 32-bit
+    gpr:    tuple[int, ...]   # 32 × 32-bit general-purpose registers
+    lr:     int               # link register, 32-bit
+    ctr:    int               # count register, 32-bit
+    xer:    int               # XER: [SO, OV, CA, ...], 32-bit
+    cr:     int               # condition register, 32-bit (8 × 4-bit nibbles)
+    memory: tuple[int, ...]   # 65536 bytes (each int is 0–255)
+    halted: bool
+```
+
+Convenience properties: `r0` through `r31` alias into `gpr`.
+
+---
+
+## SIM00 Protocol Compliance
+
+The simulator implements `Simulator[PowerPC601State]`:
+
+| Method              | Behaviour                                                    |
+|---------------------|--------------------------------------------------------------|
+| `reset()`           | Zeroes all registers, memory, and halted flag; CIA = 0      |
+| `load(program)`     | Calls `reset()`, then copies `program` bytes into memory[0] |
+| `step()`            | Fetches one 32-bit instruction at CIA; executes it; returns `StepTrace` |
+| `execute(program)`  | Calls `load(program)`, then steps until halted or `max_steps` exceeded |
+| `get_state()`       | Returns an immutable frozen `PowerPC601State` snapshot       |
+
+---
+
+## Simplifications vs Real Hardware
+
+1. **No floating-point** — FPR0–FPR31 are not simulated; the FPU is outside scope.
+2. **No MMU / address translation** — all addresses are physical.
+3. **No hardware exceptions** — undefined instructions halt the simulator; no
+   interrupt vectors, no SRESET.
+4. **No OE (overflow enable)** — XER[SO/OV] are never set by arithmetic in this
+   simulator (simulating OE=0 for all ops).
+5. **No Rc (record condition)** — arithmetic instructions don't set CR0 (simulating
+   Rc=0); only compare instructions and `andi.`/`andis.` set CR fields.
+6. **No memory-mapped I/O** — no peripheral simulation.
+7. **No POWER legacy instructions** — only the clean PowerPC ISA subset.
+8. **Alignment is relaxed** — misaligned loads/stores succeed (address masked to
+   alignment boundary instead of faulting).
+9. **64-bit memory model** — the real 601 has a 32-bit address bus; the simulator's
+   65 536-byte address space is a behavioral subset.


### PR DESCRIPTION
## Summary

- Implements the PowerPC 601 (1992), the first AIM alliance chip (Apple / IBM / Motorola) and the processor that powered the original Power Macintosh, as a behavioral simulator following the SIM00 protocol
- Full 32-bit integer ISA: arithmetic (add/subf/neg/mullw/divw/divwu), logical (and/or/xor/nand/nor/cntlzw), shifts (slw/srw/sraw/srawi), compare (cmpw/cmplw/cmpwi/cmplwi), loads (lwz/lbz/lhz/lha + update variants), stores (stw/stb/sth + update variants), branches (b/bl/bc/blr/bctr/bctrl), and SPR access (mfspr/mtspr/mfcr/mtcrf)
- 137 tests, 98.11% coverage: protocol compliance, per-instruction unit tests, edge cases, and 11 end-to-end programs (sum 1–10, 5!, F(9), subroutine call/return, array sum, memory copy, XOR swap, max of two values, countdown, 64-bit add)

## Test plan

- [x] All 137 tests pass locally (`pytest tests/ -v`)
- [x] Coverage at 98.11% (threshold: 80%)
- [x] `ruff check src/ tests/` clean
- [x] Security review passed — no vulnerabilities found
- [x] BUILD file verified with clean venv install

🤖 Generated with [Claude Code](https://claude.com/claude-code)