### PR TITLE
feat(adjudication-tsa-demo): elicit-mode wiring + stage-0 visibility fixes

### DIFF
--- a/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-05-12 — elicit-mode wiring + visibility fixes
+
+### Added
+
+- **`ADJ_DEMO_RULEBOOK_MODE=elicit`** — the binary's main loop now
+  calls `adjudication_rulebook::acquire_rulebook` against the
+  configured model BEFORE Arm A runs, then injects the elicited
+  rulebook text into Arm A's system prompt. This is the recursive
+  use of the framework: the model is judged against rules it just
+  produced from its own weights, audited by the same checker
+  discipline that protects extracted facts.
+
+  Flow when `ADJ_DEMO_RULEBOOK_MODE=elicit`:
+  ```text
+  [stage 0] elicit_rules + decompose_text + validate
+            → Tentative Rulebook + audit_trail
+  [arm A]   run_raw_arm(cfg with rulebook_text=Some(rb.source_text))
+  [arm B]   run_pipeline_arm — unchanged
+  ```
+
+- **`ADJ_DEMO_DUMP_RULEBOOK=1`** — companion to elicit-mode. When
+  set, prints the elicited rulebook text to stdout between
+  `----- BEGIN RULEBOOK -----` and `----- END RULEBOOK -----`
+  markers. Useful for reviewers who want to see what each model
+  produced.
+
+### Fixed
+
+- **Stage 0 failures now print to stdout too**. Previously the
+  elicitation failure message went only to stderr, which benchmark
+  scripts that capture only stdout treated as silent success. Now
+  the failure log line shows up in both streams; benchmark scripts
+  can grep stdout for `"[stage 0] rulebook elicitation FAILED:"`.
+- The success-path log line now reports the **validation
+  diagnostic** when `validation_passed = false`, not just the
+  boolean — so reviewers see *why* the rulebook IR failed
+  `adjudication_ir::validate` (most commonly a coverage gap or a
+  schema-invalid response from the model).
+
+### Note on the qwen2.5:1.5b "silent" failure observed in ADJ15
+
+The first ADJ15 benchmark run flagged a "silent failure" on
+qwen2.5:1.5b — the demo binary's stage-0 success log line was
+missing but no error was visible. After re-running with the
+visibility fix, the failure mode is now clear: the model **collapses
+into degenerate repetition** during the rulebook decompose phase,
+producing 90+ identical IR nodes (`{"functor": "authority", "args":
+[{"atom": "tsoa"}]}`) until it exhausts the output-token budget
+mid-string. `complete_json_with_truncation_retry` correctly
+surfaces `Gateway(SchemaInvalid { ... EOF while parsing ... })`;
+the demo prints the typed error and falls back to no-rulebook
+mode. The framework's behaviour is correct (graceful degradation,
+clear diagnostic); the failure itself is an upstream small-model
+coherence issue, not a framework bug. Recorded for follow-up:
+investigating prompt-level anti-repetition mitigations and / or
+explicit `max_nodes` caps in `decompose_text`.
+
+### Unused-mut warning fixed
+
+`json_to_ir_flat`'s `node` binding doesn't need `mut` after the
+v3 cascade dropped the `part_of` re-write logic. Cleanup.
+
 ## [0.7.0] - 2026-05-12
 
 ### Added

--- a/code/packages/rust/adjudication-tsa-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-tsa-demo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-tsa-demo"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
-description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.8 adds Arm A rulebook injection — the raw arm can now be run with or without an explicit rulebook in its system prompt, exposing the difference between unaided hallucination and rule-grounded reasoning. Pair with adjudication-rulebook to elicit a Tentative rulebook from the LLM's own weights and use that as the injected text."
+description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.9 wires ADJ_DEMO_RULEBOOK_MODE=elicit into the binary's main loop (Stage 0 calls acquire_rulebook from adjudication-rulebook, the resulting Tentative rulebook is injected into Arm A's system prompt — the recursive use of the framework on itself), adds ADJ_DEMO_DUMP_RULEBOOK=1 for reviewer visibility, and surfaces stage-0 failures on stdout (not just stderr) so benchmark scripts that capture only stdout no longer treat them as silent."
 
 [[bin]]
 name = "adjudication-tsa-demo"

--- a/code/packages/rust/adjudication-tsa-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/lib.rs
@@ -917,7 +917,7 @@ fn flatten_nodes(
     }
 
     // Leaf node — convert it.
-    let mut node = match json_to_ir_node(
+    let node = match json_to_ir_node(
         v,
         *idx_counter,
         document_id,

--- a/code/packages/rust/adjudication-tsa-demo/src/main.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/main.rs
@@ -25,6 +25,16 @@
 //! # Inject a rulebook from a file (e.g., one elicited via
 //! # adjudication_rulebook::acquire_rulebook and persisted):
 //! ADJ_DEMO_RULEBOOK_MODE=path/to/rulebook.txt cargo run -p adjudication-tsa-demo
+//!
+//! # Elicit a rulebook from the model's own weights, then inject it
+//! # into Arm A's system prompt. This is the recursive use of the
+//! # framework on itself.
+//! ADJ_DEMO_RULEBOOK_MODE=elicit cargo run -p adjudication-tsa-demo
+//!
+//! # When using elicit-mode, also dump the elicited rulebook text
+//! # to stdout so you can inspect what the model produced:
+//! ADJ_DEMO_RULEBOOK_MODE=elicit ADJ_DEMO_DUMP_RULEBOOK=1 \
+//!     cargo run -p adjudication-tsa-demo
 //! ```
 //!
 //! The binary is intentionally environment-variable driven rather
@@ -34,12 +44,82 @@
 use std::time::Duration;
 
 use adjudication_tsa_demo::{
-    fixture_tsa_rulebook, format_side_by_side, run_pipeline_arm, run_raw_arm, DemoConfig, IrMode,
-    IrSourceTelemetry,
+    acquire_demo_rulebook, fixture_tsa_rulebook, format_side_by_side, run_pipeline_arm,
+    run_raw_arm, DemoConfig, IrMode, IrSourceTelemetry,
 };
+use llm_primitives::{GatewayConfig, Role as PrimitiveRole};
+use llm_provider_ollama::OllamaClient;
 
 fn main() {
-    let cfg = config_from_env();
+    let mut cfg = config_from_env();
+    let elicit_requested = std::env::var("ADJ_DEMO_RULEBOOK_MODE")
+        .map(|s| s == "elicit")
+        .unwrap_or(false);
+
+    // If the user asked for ADJ_DEMO_RULEBOOK_MODE=elicit, run the
+    // rulebook-acquisition phase before Arm A. The acquired rulebook
+    // text gets stashed in `cfg.rulebook_text` so `run_raw_arm`
+    // injects it as the system prompt. This is the recursive use of
+    // the framework on itself.
+    if elicit_requested {
+        println!(
+            "[stage 0] eliciting TSA rulebook from `{model}` via \
+             adjudication_rulebook::acquire_rulebook ...",
+            model = cfg.model,
+        );
+        let ollama = OllamaClient::new(cfg.model.clone())
+            .with_endpoint(cfg.endpoint.clone())
+            .with_timeout(cfg.timeout);
+        let gw = GatewayConfig::new()
+            .with_client(PrimitiveRole::RuleExtractor, Box::new(ollama.clone()))
+            .with_client(PrimitiveRole::Extractor, Box::new(ollama));
+        match acquire_demo_rulebook(&cfg, &gw) {
+            Ok(rb) => {
+                let validation_summary = if rb.validation_passed {
+                    "OK".to_string()
+                } else {
+                    format!(
+                        "FAILED ({})",
+                        rb.validation_error
+                            .as_deref()
+                            .unwrap_or("(no diagnostic)")
+                    )
+                };
+                println!(
+                    "[stage 0] elicited {bytes} bytes of rulebook text from \
+                     `{model}` (trust={trust}, validation={validation})",
+                    bytes = rb.source_text.len(),
+                    model = cfg.model,
+                    trust = rb.trust.as_str(),
+                    validation = validation_summary,
+                );
+                if std::env::var("ADJ_DEMO_DUMP_RULEBOOK").is_ok() {
+                    println!(
+                        "[stage 0] elicited rulebook source_text:\n\
+                         ----- BEGIN RULEBOOK -----\n\
+                         {text}\n\
+                         ----- END RULEBOOK -----",
+                        text = rb.source_text,
+                    );
+                }
+                cfg.rulebook_text = Some(rb.source_text);
+            }
+            Err(e) => {
+                // Print to BOTH stdout and stderr. Benchmark tooling
+                // often captures only stdout; the failure must not be
+                // silent. Surfacing the typed error to stdout matches
+                // the success-path log line so log-grepping benchmark
+                // scripts can detect either outcome.
+                let msg = format!(
+                    "[stage 0] rulebook elicitation FAILED: {e}\n\
+                     [stage 0] continuing without rulebook (Arm A will \
+                     run the v0.7 baseline behaviour)."
+                );
+                println!("{msg}");
+                eprintln!("{msg}");
+            }
+        }
+    }
 
     println!(
         "Running TSA demo against {endpoint}\n\
@@ -168,6 +248,11 @@ fn config_from_env() -> DemoConfig {
         cfg.rulebook_text = match mode.as_str() {
             "" | "none" => None,
             "fixture" => Some(fixture_tsa_rulebook()),
+            // `elicit` is handled later in `main()` — it needs a
+            // gateway, which isn't available at config-load time.
+            // Leave rulebook_text = None here; main() fills it in
+            // after acquire_demo_rulebook runs.
+            "elicit" => None,
             path => match std::fs::read_to_string(path) {
                 Ok(text) => Some(text),
                 Err(e) => {


### PR DESCRIPTION
## Summary

Wires the recursive rulebook-elicitation flow into the demo binary's main loop, fixes the \"silent stage-0 failure\" UX issue [ADJ15](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/ADJ15-recursive-rulebook-empirical-results.md) flagged, and adds a reviewer-visibility flag.

## What's new

- **\`ADJ_DEMO_RULEBOOK_MODE=elicit\`** — before Arm A runs, the binary calls \`adjudication_rulebook::acquire_rulebook\` against the configured model and injects the resulting Tentative Rulebook's \`source_text\` into Arm A's system prompt. Recursive use of the framework on itself.
- **\`ADJ_DEMO_DUMP_RULEBOOK=1\`** — companion flag. When set alongside elicit-mode, prints the elicited rulebook text to stdout between \`----- BEGIN RULEBOOK -----\` / \`----- END RULEBOOK -----\` markers, for reviewers who want to inspect what each model produced.

## Fixed

- **Stage 0 failures now print to BOTH stdout AND stderr.** Previously only \`eprintln!\`, which the ADJ15 benchmark script (capturing only stdout) treated as silent success. The success and failure log lines now share the same stream — log-grepping benchmark scripts can detect either outcome.
- **Success-path log line reports the validation diagnostic** when \`validation_passed = false\`, not just the boolean. Reviewers now see *why* the rulebook IR failed \`adjudication_ir::validate\`.

## Investigation note on ADJ15's qwen2.5:1.5b \"silent\" failure

After the visibility fix, the failure mode is clear: the model **collapses into degenerate repetition** during the decompose phase, producing 90+ identical \`{\"functor\": \"authority\", \"args\": [{\"atom\": \"tsoa\"}]}\` Fact nodes until it exhausts the output-token budget mid-string. \`complete_json_with_truncation_retry\` correctly surfaces \`Gateway(SchemaInvalid { ... EOF while parsing a string at line 769 column 1 })\`, the demo prints the typed error, and falls back to no-rulebook mode.

**The framework's behaviour is correct** (graceful degradation, clear diagnostic). The failure itself is an upstream small-model coherence issue, recorded for follow-up: explore prompt-level anti-repetition mitigations, possibly an explicit \`max_nodes\` cap or repetition detector in \`decompose_text\`'s response validator.

## Test plan

- [x] 24 \`adjudication-tsa-demo\` tests pass
- [x] Security review passed
- [x] Reproduced 1.5B failure with visibility fix → typed \`SchemaInvalid\` now visible in stdout
- [x] gemma4 elicit-mode smoke test → still flips verdict to NON-COMPLIANT with rule citation
- [ ] CI green
- [ ] Follow-up: rerun ADJ15 benchmark with v0.9 demo, document any changes (ADJ15.1?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)