### PR TITLE
Add Rust MACSYMA declare property queries

### DIFF
--- a/code/packages/rust/cas-simplify/CHANGELOG.md
+++ b/code/packages/rust/cas-simplify/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — cas-simplify (Rust)
 
+## Unreleased
+
+### Added
+
+- Added deterministic `AssumptionContext::facts_for(...)` and
+  `AssumptionContext::symbols_with_facts()` metadata queries for MACSYMA
+  property inspection.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-simplify/src/assumptions.rs
+++ b/code/packages/rust/cas-simplify/src/assumptions.rs
@@ -75,7 +75,7 @@ impl AssumptionContext {
     }
 
     pub fn is_positive(&self, sym_name: &str) -> Option<bool> {
-        let facts = self.facts_for(sym_name);
+        let facts = self.fact_set(sym_name);
         if facts.contains(POSITIVE) {
             Some(true)
         } else if facts.contains(NEGATIVE) || facts.contains(ZERO) {
@@ -86,7 +86,7 @@ impl AssumptionContext {
     }
 
     pub fn is_negative(&self, sym_name: &str) -> Option<bool> {
-        let facts = self.facts_for(sym_name);
+        let facts = self.fact_set(sym_name);
         if facts.contains(NEGATIVE) {
             Some(true)
         } else if facts.contains(POSITIVE) || facts.contains(ZERO) || facts.contains(NONNEG) {
@@ -97,7 +97,7 @@ impl AssumptionContext {
     }
 
     pub fn is_nonneg(&self, sym_name: &str) -> Option<bool> {
-        let facts = self.facts_for(sym_name);
+        let facts = self.fact_set(sym_name);
         if facts.contains(NONNEG) || facts.contains(POSITIVE) || facts.contains(ZERO) {
             Some(true)
         } else if facts.contains(NEGATIVE) {
@@ -108,11 +108,11 @@ impl AssumptionContext {
     }
 
     pub fn is_integer(&self, sym_name: &str) -> bool {
-        self.facts_for(sym_name).contains(INTEGER)
+        self.fact_set(sym_name).contains(INTEGER)
     }
 
     pub fn sign_of(&self, sym_name: &str) -> Option<i8> {
-        let facts = self.facts_for(sym_name);
+        let facts = self.fact_set(sym_name);
         if facts.contains(POSITIVE) {
             Some(1)
         } else if facts.contains(NEGATIVE) {
@@ -126,7 +126,7 @@ impl AssumptionContext {
 
     pub fn is_true_relation(&self, expr: &IRNode) -> Option<bool> {
         let (sym_name, head) = relation_against_zero(expr)?;
-        let facts = self.facts_for(sym_name);
+        let facts = self.fact_set(sym_name);
         match head {
             GREATER => self.is_positive(sym_name),
             LESS => self.is_negative(sym_name),
@@ -179,6 +179,27 @@ impl AssumptionContext {
             .is_some_and(|facts| !facts.is_empty())
     }
 
+    pub fn facts_for(&self, sym_name: &str) -> Vec<&'static str> {
+        let mut facts: Vec<_> = self
+            .facts
+            .get(sym_name)
+            .map(|facts| facts.iter().copied().collect())
+            .unwrap_or_default();
+        facts.sort_unstable();
+        facts
+    }
+
+    pub fn symbols_with_facts(&self) -> Vec<String> {
+        let mut names: Vec<_> = self
+            .facts
+            .iter()
+            .filter(|(_, facts)| !facts.is_empty())
+            .map(|(name, _)| name.clone())
+            .collect();
+        names.sort();
+        names
+    }
+
     fn add(&mut self, sym_name: &str, fact: &'static str) {
         self.facts
             .entry(sym_name.to_string())
@@ -195,7 +216,7 @@ impl AssumptionContext {
         }
     }
 
-    fn facts_for(&self, sym_name: &str) -> HashSet<&'static str> {
+    fn fact_set(&self, sym_name: &str) -> HashSet<&'static str> {
         self.facts.get(sym_name).cloned().unwrap_or_default()
     }
 }

--- a/code/packages/rust/cas-simplify/tests/tests.rs
+++ b/code/packages/rust/cas-simplify/tests/tests.rs
@@ -467,11 +467,38 @@ fn assumptions_track_relation_and_property_facts() {
     assert_eq!(ctx.is_nonneg("b"), Some(true));
     ctx.assume_property(&sym("n"), &sym("integer"));
     assert!(ctx.is_integer("n"));
+    assert_eq!(ctx.facts_for("n"), vec!["integer"]);
+    assert_eq!(
+        ctx.symbols_with_facts(),
+        vec![
+            "a".to_string(),
+            "b".to_string(),
+            "n".to_string(),
+            "x".to_string(),
+            "y".to_string(),
+            "z".to_string(),
+        ]
+    );
 
     ctx.forget_relation(&apply(sym(GREATER), vec![x(), int(0)]));
     assert_eq!(ctx.is_positive("x"), None);
     ctx.forget_all();
     assert!(!ctx.has_any_facts("n"));
+}
+
+#[test]
+fn assumptions_return_deterministic_fact_metadata() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_property(&sym("n"), &sym("positive"));
+    ctx.assume_property(&sym("n"), &sym("integer"));
+    ctx.assume_relation(&apply(sym(GREATER), vec![x(), int(0)]));
+
+    assert_eq!(ctx.facts_for("n"), vec!["integer", "positive"]);
+    assert_eq!(ctx.facts_for("missing"), Vec::<&'static str>::new());
+    assert_eq!(
+        ctx.symbols_with_facts(),
+        vec!["n".to_string(), "x".to_string()]
+    );
 }
 
 #[test]

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Wired `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
+  Rust MACSYMA session assumption context so declared properties feed property
+  queries and assumption-backed relation checks.
+
 ## [0.1.1] - 2026-05-12
 
 ### Added

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -12,7 +12,7 @@ use cas_list_operations::{
     range_ as list_range, rest, reverse, sort_, ListOperationError, ListResult,
 };
 use cas_pretty_printer::{pretty, pretty_2d, MacsymaDialect};
-use cas_simplify::simplify;
+use cas_simplify::{simplify, AssumptionContext};
 use cas_solve::{solve_linear_system, try_solve_inequality, try_solve_transcendental, SOLVE};
 use cas_substitution::subst;
 use cas_trig::{expand_trig, trig_reduce, trig_simplify};
@@ -42,11 +42,20 @@ pub const KILL: &str = "Kill";
 pub const EV: &str = "Ev";
 /// Sentinel symbol matched by `Kill(all)`.
 pub const ALL: &str = "all";
+/// Runtime-owned head for declaring MACSYMA symbol properties.
+pub const DECLARE: &str = "Declare";
+/// Runtime-owned head for querying properties declared on a symbol.
+pub const PROPERTIES: &str = "Properties";
+/// Runtime-owned head for querying symbols with declared properties.
+pub const PROP_VARS: &str = "PropVars";
 
+const ASSUME: &str = "Assume";
 const DONE: &str = "done";
 const EXPAND: &str = "Expand";
 const FACTOR: &str = "Factor";
 const FLOAT_FUNC: &str = "Float";
+const FORGET: &str = "Forget";
+const IS: &str = "Is";
 const RAT_SIMPLIFY: &str = "RatSimplify";
 const SIMPLIFY: &str = "Simplify";
 const SUBST: &str = "Subst";
@@ -193,6 +202,9 @@ const MACSYMA_NAME_TABLE: &[(&str, &str)] = &[
     ("assume", "Assume"),
     ("forget", "Forget"),
     ("is", "Is"),
+    ("declare", DECLARE),
+    ("properties", PROPERTIES),
+    ("propvars", PROP_VARS),
     ("matchdeclare", "MatchDeclare"),
     ("defrule", "Defrule"),
     ("apply1", "Apply1"),
@@ -305,11 +317,15 @@ fn parse_history_index(digits: &str) -> Option<usize> {
 #[derive(Debug, Clone)]
 struct MacsymaBackendState {
     env: HashMap<String, IRNode>,
+    assumptions: AssumptionContext,
 }
 
 impl MacsymaBackendState {
     fn new() -> Self {
-        Self { env: initial_env() }
+        Self {
+            env: initial_env(),
+            assumptions: AssumptionContext::new(),
+        }
     }
 
     fn unbind(&mut self, name: &str) {
@@ -357,6 +373,37 @@ impl MacsymaBackend {
         handlers.insert(TRIG_SIMPLIFY.to_string(), handler_fn(trig_simplify_handler));
         handlers.insert(TRIG_EXPAND.to_string(), handler_fn(trig_expand_handler));
         handlers.insert(TRIG_REDUCE.to_string(), handler_fn(trig_reduce_handler));
+
+        let assume_state = state.clone();
+        handlers.insert(
+            ASSUME.to_string(),
+            Arc::new(move |_vm, expr| assume_handler(&assume_state, expr)),
+        );
+        let forget_state = state.clone();
+        handlers.insert(
+            FORGET.to_string(),
+            Arc::new(move |_vm, expr| forget_handler(&forget_state, expr)),
+        );
+        let is_state = state.clone();
+        handlers.insert(
+            IS.to_string(),
+            Arc::new(move |_vm, expr| is_handler(&is_state, expr)),
+        );
+        let declare_state = state.clone();
+        handlers.insert(
+            DECLARE.to_string(),
+            Arc::new(move |_vm, expr| declare_handler(&declare_state, expr)),
+        );
+        let properties_state = state.clone();
+        handlers.insert(
+            PROPERTIES.to_string(),
+            Arc::new(move |_vm, expr| properties_handler(&properties_state, expr)),
+        );
+        let propvars_state = state.clone();
+        handlers.insert(
+            PROP_VARS.to_string(),
+            Arc::new(move |_vm, expr| propvars_handler(&propvars_state, expr)),
+        );
         handlers.insert(
             LENGTH.to_string(),
             list_handler(Some(1), |args| length(&args[0])),
@@ -407,10 +454,13 @@ impl MacsymaBackend {
             }),
         );
 
-        let held = [ASSIGN, DEFINE, IF, KILL, EV, SOLVE, SUBST]
-            .into_iter()
-            .map(str::to_string)
-            .collect();
+        let held = [
+            ASSIGN, DEFINE, IF, KILL, EV, ASSUME, FORGET, IS, DECLARE, PROPERTIES, PROP_VARS,
+            SOLVE, SUBST,
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
 
         Self {
             state,
@@ -605,6 +655,84 @@ fn display_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
 
 fn suppress_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     display_handler(_vm, expr)
+}
+
+fn assume_handler(state: &Arc<Mutex<MacsymaBackendState>>, expr: IRApply) -> IRNode {
+    let mut state = state.lock().expect("macsyma backend state poisoned");
+    match expr.args.as_slice() {
+        [relation] => state.assumptions.assume_relation(relation),
+        [symbol, property] => state.assumptions.assume_property(symbol, property),
+        _ => {}
+    }
+    sym(DONE)
+}
+
+fn forget_handler(state: &Arc<Mutex<MacsymaBackendState>>, expr: IRApply) -> IRNode {
+    let mut state = state.lock().expect("macsyma backend state poisoned");
+    if expr.args.is_empty() {
+        state.assumptions.forget_all();
+    } else {
+        state.assumptions.forget_relation(&expr.args[0]);
+    }
+    sym(DONE)
+}
+
+fn is_handler(state: &Arc<Mutex<MacsymaBackendState>>, expr: IRApply) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    let state = state.lock().expect("macsyma backend state poisoned");
+    match state.assumptions.is_true_relation(&expr.args[0]) {
+        Some(true) => sym("True"),
+        Some(false) => sym("False"),
+        None => sym("unknown"),
+    }
+}
+
+fn declare_handler(state: &Arc<Mutex<MacsymaBackendState>>, expr: IRApply) -> IRNode {
+    if expr.args.len() % 2 != 0 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    let mut state = state.lock().expect("macsyma backend state poisoned");
+    for pair in expr.args.chunks_exact(2) {
+        state.assumptions.assume_property(&pair[0], &pair[1]);
+    }
+    sym(DONE)
+}
+
+fn properties_handler(state: &Arc<Mutex<MacsymaBackendState>>, expr: IRApply) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    let Some(name) = symbol_name(&expr.args[0]) else {
+        return apply(sym(LIST), vec![]);
+    };
+    let state = state.lock().expect("macsyma backend state poisoned");
+    apply(
+        sym(LIST),
+        state
+            .assumptions
+            .facts_for(name)
+            .into_iter()
+            .map(sym)
+            .collect(),
+    )
+}
+
+fn propvars_handler(state: &Arc<Mutex<MacsymaBackendState>>, expr: IRApply) -> IRNode {
+    if !expr.args.is_empty() {
+        return IRNode::Apply(Box::new(expr));
+    }
+    let state = state.lock().expect("macsyma backend state poisoned");
+    apply(
+        sym(LIST),
+        state
+            .assumptions
+            .symbols_with_facts()
+            .into_iter()
+            .map(|name| sym(&name))
+            .collect(),
+    )
 }
 
 fn ev_handler(vm: &mut VM, expr: IRApply) -> IRNode {

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -1,6 +1,7 @@
 use cas_solve::SOLVE;
 use coding_adventures_macsyma_runtime::{
-    extend_macsyma_name_table, macsyma_name_table, MacsymaSession, EV, KILL,
+    extend_macsyma_name_table, macsyma_name_table, MacsymaSession, DECLARE, EV, KILL, PROPERTIES,
+    PROP_VARS,
 };
 use std::collections::HashMap;
 use symbolic_ir::{
@@ -135,6 +136,15 @@ fn exports_and_extends_runtime_name_table_idempotently() {
         table.get("trigsimp").map(String::as_str),
         Some("TrigSimplify")
     );
+    assert_eq!(table.get("assume").map(String::as_str), Some("Assume"));
+    assert_eq!(table.get("forget").map(String::as_str), Some("Forget"));
+    assert_eq!(table.get("is").map(String::as_str), Some("Is"));
+    assert_eq!(table.get("declare").map(String::as_str), Some(DECLARE));
+    assert_eq!(
+        table.get("properties").map(String::as_str),
+        Some(PROPERTIES)
+    );
+    assert_eq!(table.get("propvars").map(String::as_str), Some(PROP_VARS));
 
     let mut target = HashMap::from([("custom".to_string(), "CustomHead".to_string())]);
     extend_macsyma_name_table(&mut target);
@@ -169,6 +179,70 @@ fn kill_all_clears_bindings_and_history() {
     let results = session.eval_source("x; %;").unwrap();
     assert_eq!(results[0].output, sym("x"));
     assert_eq!(results[1].output, sym("x"));
+}
+
+#[test]
+fn assume_is_and_forget_share_session_assumptions() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("assume(x > 0); is(x > 0); forget(); is(x > 0);")
+        .unwrap();
+
+    assert_eq!(results[0].output, sym("done"));
+    assert_eq!(results[1].output, sym("True"));
+    assert_eq!(results[2].output, sym("done"));
+    assert_eq!(results[3].output, sym("unknown"));
+}
+
+#[test]
+fn declare_feeds_properties_into_is_queries() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("declare(x, positive); is(x > 0);")
+        .unwrap();
+
+    assert_eq!(
+        results[0].input,
+        apply(sym(DECLARE), vec![sym("x"), sym("positive")])
+    );
+    assert_eq!(results[0].output, sym("done"));
+    assert_eq!(results[1].output, sym("True"));
+}
+
+#[test]
+fn properties_lists_declared_properties_deterministically() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("declare(n, integer, n, positive); properties(n);")
+        .unwrap();
+
+    assert_eq!(
+        results[1].output,
+        apply(sym(LIST), vec![sym("integer"), sym("positive")])
+    );
+}
+
+#[test]
+fn propvars_lists_symbols_with_declared_properties_deterministically() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("declare(z, integer); declare(a, positive); propvars();")
+        .unwrap();
+
+    assert_eq!(
+        results[2].output,
+        apply(sym(LIST), vec![sym("a"), sym("z")])
+    );
+}
+
+#[test]
+fn properties_queries_raw_symbols_even_when_bound() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("x : 10; declare(x, integer); properties(x);")
+        .unwrap();
+
+    assert_eq!(results[2].output, apply(sym(LIST), vec![sym("integer")]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Rust assumption metadata query helpers for declared properties
- wire `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` through the Rust MACSYMA runtime
- keep property declarations backed by the MACSYMA session assumption context so they feed relation checks and property queries

## Validation
- `cargo fmt -p cas-simplify -p coding-adventures-macsyma-runtime` from `code/packages/rust`
- `cargo test -p cas-simplify -p coding-adventures-macsyma-runtime` from `code/packages/rust`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-rust-macsyma-properties.json` from `code/programs/go/build-tool`
- `git diff --check`
