### PR TITLE
feat(adjudication-tsa-demo): adversarial multi-model rulebook injection mode

### DIFF
--- a/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2026-05-12 — Adversarial multi-model elicit-mode wiring
+
+### Added
+
+`ADJ_DEMO_RULEBOOK_MODE=adversarial:model1,model2,...` — elicit
+rulebooks from N independent models and inject the
+provenance-tagged merged text into Arm A's system prompt. Builds
+on `adjudication_rulebook::acquire_rulebook_adversarial` (added in
+that crate's v0.2) and the existing elicit-mode plumbing (v0.9).
+
+The demo binary parses the comma-separated model list, builds one
+OllamaClient + GatewayConfig per model, and dispatches the
+adversarial elicit. Each model's outcome is logged with a checkmark
+or cross plus byte count and validation status:
+
+```text
+[stage 0] adversarial elicitation across 2 models: gemma4:latest, llama3.1:8b
+[stage 0] adversarial elicit: 2/2 models succeeded (0 failed)
+[stage 0]   ✓ `gemma4:latest`: 1938 bytes (validation=FAILED (...))
+[stage 0]   ✓ `llama3.1:8b`: 1709 bytes (validation=FAILED (...))
+```
+
+A reviewer reading Arm A's answer can grep the cited rule back to
+the `=== RULEBOOK FROM <model> ===` section header in the audit
+trail and see which model produced it. A rule appearing in only
+one model's section is lower-trust than one in both.
+
+`ADJ_DEMO_DUMP_RULEBOOK=1` works in adversarial mode too — dumps
+the full provenance-tagged merged rulebook between markers.
+
+### Why this matters
+
+ADJ15's empirical results showed single-model recursive elicitation
+flips verdicts at 3B+ but every elicited rulebook had at least one
+fabrication (the matches-as-flammable-materials leap, the
+fabricated doctor's-note exception, the wrong knife-length limit).
+Multi-model elicitation reduces this risk: a fabricated rule that
+appears in only one model's training shows up as a single-source
+rule in the merged text, where reviewers can spot it. Rules
+multiple models produced independently are higher trust.
+
+24 unit tests still pass. Demo binary smoke-tested with
+`adversarial:gemma4:latest,llama3.1:8b`.
+
 ## [0.9.0] - 2026-05-12 — elicit-mode wiring + visibility fixes
 
 ### Added

--- a/code/packages/rust/adjudication-tsa-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-tsa-demo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-tsa-demo"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
-description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.9 wires ADJ_DEMO_RULEBOOK_MODE=elicit into the binary's main loop (Stage 0 calls acquire_rulebook from adjudication-rulebook, the resulting Tentative rulebook is injected into Arm A's system prompt — the recursive use of the framework on itself), adds ADJ_DEMO_DUMP_RULEBOOK=1 for reviewer visibility, and surfaces stage-0 failures on stdout (not just stderr) so benchmark scripts that capture only stdout no longer treat them as silent."
+description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.10 adds ADJ_DEMO_RULEBOOK_MODE=adversarial:m1,m2,... — elicit rulebooks from N independent models and inject the provenance-tagged merged text into Arm A's system prompt. Rules cited at answer time can now be traced back to which model produced them, and rules appearing in only one model's training surface as lower-trust than rules multiple models agree on. The recursive use of the framework, made adversarial."
 
 [[bin]]
 name = "adjudication-tsa-demo"

--- a/code/packages/rust/adjudication-tsa-demo/src/main.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/main.rs
@@ -35,6 +35,13 @@
 //! # to stdout so you can inspect what the model produced:
 //! ADJ_DEMO_RULEBOOK_MODE=elicit ADJ_DEMO_DUMP_RULEBOOK=1 \
 //!     cargo run -p adjudication-tsa-demo
+//!
+//! # Adversarial multi-model elicitation: elicit rulebooks from N
+//! # independent models, concatenate with provenance tags, inject
+//! # the merged text into Arm A. A rule cited at answer time can
+//! # be traced back to the specific model that produced it.
+//! ADJ_DEMO_RULEBOOK_MODE=adversarial:gemma4:latest,llama3.1:8b \
+//!     cargo run -p adjudication-tsa-demo
 //! ```
 //!
 //! The binary is intentionally environment-variable driven rather
@@ -43,18 +50,37 @@
 
 use std::time::Duration;
 
+use adjudication_rulebook::{
+    acquire_rulebook_adversarial, AcquireRulebookAdversarialRequest, PerModelOutcome,
+};
 use adjudication_tsa_demo::{
     acquire_demo_rulebook, fixture_tsa_rulebook, format_side_by_side, run_pipeline_arm,
     run_raw_arm, DemoConfig, IrMode, IrSourceTelemetry,
 };
+use llm_gateway::LlmClient;
 use llm_primitives::{GatewayConfig, Role as PrimitiveRole};
 use llm_provider_ollama::OllamaClient;
 
 fn main() {
     let mut cfg = config_from_env();
-    let elicit_requested = std::env::var("ADJ_DEMO_RULEBOOK_MODE")
-        .map(|s| s == "elicit")
-        .unwrap_or(false);
+    let rb_mode = std::env::var("ADJ_DEMO_RULEBOOK_MODE").unwrap_or_default();
+    let elicit_requested = rb_mode == "elicit";
+    let adversarial_models: Option<Vec<String>> = if let Some(rest) =
+        rb_mode.strip_prefix("adversarial:")
+    {
+        let models: Vec<String> = rest
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if models.is_empty() {
+            None
+        } else {
+            Some(models)
+        }
+    } else {
+        None
+    };
 
     // If the user asked for ADJ_DEMO_RULEBOOK_MODE=elicit, run the
     // rulebook-acquisition phase before Arm A. The acquired rulebook
@@ -118,6 +144,95 @@ fn main() {
                 println!("{msg}");
                 eprintln!("{msg}");
             }
+        }
+    }
+
+    // Adversarial multi-model elicitation. For each model in the
+    // comma-separated list, build an OllamaClient + GatewayConfig
+    // and call adjudication_rulebook::acquire_rulebook_adversarial.
+    // The merged provenance-tagged rulebook text becomes Arm A's
+    // injected prompt — a rule cited at answer time can be traced
+    // back to which model produced it.
+    if let Some(models) = adversarial_models.as_ref() {
+        println!(
+            "[stage 0] adversarial elicitation across {n} models: {list}",
+            n = models.len(),
+            list = models.join(", "),
+        );
+        let mut gateways: Vec<(String, GatewayConfig)> = Vec::with_capacity(models.len());
+        for m in models {
+            let ollama: Box<dyn LlmClient> = Box::new(
+                OllamaClient::new(m.clone())
+                    .with_endpoint(cfg.endpoint.clone())
+                    .with_timeout(cfg.timeout),
+            );
+            // Second client for Extractor role (decompose_text). We
+            // can't .clone() Box<dyn LlmClient>, so construct a
+            // sibling OllamaClient with the same config.
+            let extractor: Box<dyn LlmClient> = Box::new(
+                OllamaClient::new(m.clone())
+                    .with_endpoint(cfg.endpoint.clone())
+                    .with_timeout(cfg.timeout),
+            );
+            let gw = GatewayConfig::new()
+                .with_client(PrimitiveRole::RuleExtractor, ollama)
+                .with_client(PrimitiveRole::Extractor, extractor);
+            gateways.push((m.clone(), gw));
+        }
+        let req = AcquireRulebookAdversarialRequest {
+            document_id_prefix: "rulebook-tsa-adversarial".to_string(),
+            domain: "tsa-declaration".to_string(),
+            scope: Some("carry-on baggage".to_string()),
+            as_of: "2026-05-12".to_string(),
+            language_hint: None,
+        };
+        let adv = acquire_rulebook_adversarial(&req, gateways);
+        println!(
+            "[stage 0] adversarial elicit: {ok}/{total} models succeeded ({fail} failed)",
+            ok = adv.successful_count,
+            total = adv.per_model.len(),
+            fail = adv.failed_count,
+        );
+        for outcome in &adv.per_model {
+            match outcome {
+                PerModelOutcome::Acquired { model_label, rulebook } => {
+                    let validation_summary = if rulebook.validation_passed {
+                        "OK".to_string()
+                    } else {
+                        format!(
+                            "FAILED ({})",
+                            rulebook.validation_error.as_deref().unwrap_or("(no diagnostic)")
+                        )
+                    };
+                    println!(
+                        "[stage 0]   ✓ `{model_label}`: {bytes} bytes (validation={validation})",
+                        bytes = rulebook.source_text.len(),
+                        validation = validation_summary,
+                    );
+                }
+                PerModelOutcome::Failed { model_label, error_summary } => {
+                    let msg = format!("[stage 0]   ✗ `{model_label}` FAILED: {error_summary}");
+                    println!("{msg}");
+                    eprintln!("{msg}");
+                }
+            }
+        }
+        if std::env::var("ADJ_DEMO_DUMP_RULEBOOK").is_ok() && !adv.merged_source_text.is_empty() {
+            println!(
+                "[stage 0] merged adversarial rulebook (provenance-tagged):\n\
+                 ----- BEGIN RULEBOOK -----\n\
+                 {text}\n\
+                 ----- END RULEBOOK -----",
+                text = adv.merged_source_text,
+            );
+        }
+        if !adv.merged_source_text.is_empty() {
+            cfg.rulebook_text = Some(adv.merged_source_text);
+        } else {
+            let msg = "[stage 0] adversarial elicit: ALL models failed; \
+                       continuing without rulebook.";
+            println!("{msg}");
+            eprintln!("{msg}");
         }
     }
 
@@ -248,11 +363,13 @@ fn config_from_env() -> DemoConfig {
         cfg.rulebook_text = match mode.as_str() {
             "" | "none" => None,
             "fixture" => Some(fixture_tsa_rulebook()),
-            // `elicit` is handled later in `main()` — it needs a
-            // gateway, which isn't available at config-load time.
-            // Leave rulebook_text = None here; main() fills it in
-            // after acquire_demo_rulebook runs.
+            // `elicit` and `adversarial:...` are handled later in
+            // `main()` — they need a gateway, which isn't available
+            // at config-load time. Leave rulebook_text = None here;
+            // main() fills it in after the corresponding orchestrator
+            // runs.
             "elicit" => None,
+            mode if mode.starts_with("adversarial:") => None,
             path => match std::fs::read_to_string(path) {
                 Ok(text) => Some(text),
                 Err(e) => {


### PR DESCRIPTION
## Summary

Wires \`ADJ_DEMO_RULEBOOK_MODE=adversarial:m1,m2,...\` into the demo binary's main loop. Each model in the comma-separated list gets its own OllamaClient + GatewayConfig; the demo dispatches [\`adjudication_rulebook::acquire_rulebook_adversarial\`](https://github.com/adhithyan15/coding-adventures/blob/main/code/packages/rust/adjudication-rulebook/src/lib.rs); the resulting provenance-tagged merged rulebook text becomes Arm A's injected system prompt.

## Output shape

\`\`\`text
[stage 0] adversarial elicitation across 2 models: gemma4:latest, llama3.1:8b
[stage 0] adversarial elicit: 2/2 models succeeded (0 failed)
[stage 0]   ✓ \`gemma4:latest\`: 2170 bytes (validation=FAILED (CoverageGap { ... }))
[stage 0]   ✓ \`llama3.1:8b\`: 2546 bytes (validation=FAILED (CoverageGap { ... }))
\`\`\`

A reviewer reading the answer can trace any cited rule back to the \`=== RULEBOOK FROM <model> ===\` section header in the merged text. Rules appearing in only one section are lower-trust than rules multiple models produced.

## Smoke test result

Locally smoke-tested with \`ADJ_DEMO_MODEL=qwen2.5:3b ADJ_DEMO_RULEBOOK_MODE=adversarial:gemma4:latest,llama3.1:8b\`. The 3B answerer cited \"rule 3\" from the merged adversarial rulebook with materially better categorical reasoning than its [ADJ15](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/ADJ15-recursive-rulebook-empirical-results.md) single-model result:

| | Single-model elicit (ADJ15) | Adversarial elicit (this PR) |
|---|---|---|
| qwen2.5:3b reasoning | *\"matches fall under the category of liquids/gels/aerosols/creams (rule 3)\"* — categorically wrong | *\"matches, which are prohibited in carry-on baggage per rule 3. Strike-anywhere matches are considered a weapon or explosive\"* — defensible categorical leap |
| Verdict | NON-COMPLIANT | NON-COMPLIANT |

The verdict is the same in both modes, but the *reasoning* improved when the model had two independent rulebooks to choose rules from.

## Also fixes

A spurious warning: the previous \`config_from_env\` logic treated any non-\`{none,fixture,elicit}\` value as a file path and warned when \`fs::read\` failed. Now also recognises the \`adversarial:\` prefix and skips the file-read attempt.

## Test plan

- [x] 24 unit tests pass
- [x] Security review passed (model name flows are JSON-safe; operator-controlled env-var threat model is appropriate for the demo)
- [x] Smoke test against ollama
- [ ] CI green
- [ ] Follow-up: full n>1 adversarial benchmark across the ADJ12 lineup; document as ADJ16 / ADJ15 successor

🤖 Generated with [Claude Code](https://claude.com/claude-code)