### PR TITLE
Add Python MACSYMA showtime diagnostics

### DIFF
--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/backend.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/backend.py
@@ -27,6 +27,7 @@ from contextlib import contextmanager
 from symbolic_ir import IRFloat, IRNode, IRSymbol
 from symbolic_vm import SymbolicBackend
 from symbolic_vm.backend import Handler
+from symbolic_vm.handlers import FALSE, TRUE
 
 from macsyma_runtime.cas_handlers import build_cas_handler_table
 from macsyma_runtime.handlers import (
@@ -63,6 +64,9 @@ class MacsymaBackend(SymbolicBackend):
     #: flag. Phase A defaults true; not consulted yet.
     simp: bool
 
+    #: Whether the REPL should report per-statement wall-clock timing.
+    showtime: bool
+
     #: The session's I/O history, owned by the REPL but referenced by
     #: the backend so VM lookups can resolve `%`, `%iN`, `%oN`.
     history: History
@@ -72,6 +76,7 @@ class MacsymaBackend(SymbolicBackend):
         self.history = history if history is not None else History()
         self.numer = False
         self.simp = True
+        self.showtime = False
 
         # Patch the inherited handler table with the runtime's heads.
         # ``SymbolicBackend.__init__`` filled ``self._handlers`` already
@@ -97,6 +102,7 @@ class MacsymaBackend(SymbolicBackend):
         # containing ``%pi`` or ``%e`` is evaluated.
         self._env["%pi"] = IRFloat(math.pi)
         self._env["%e"] = IRFloat(math.e)
+        self._env["showtime"] = FALSE
 
         # Pre-bind the standard MACSYMA constants so users can write
         # ``%pi`` and ``%e`` without defining them first.  These are
@@ -137,6 +143,15 @@ class MacsymaBackend(SymbolicBackend):
         No-op if the name was never bound. Used by the ``Kill`` handler.
         """
         self._env.pop(name, None)
+        if name == "showtime":
+            self.showtime = False
+            self._env["showtime"] = FALSE
+
+    def bind(self, name: str, value: IRNode) -> None:
+        """Bind ``name`` and keep MACSYMA option flags in sync."""
+        super().bind(name, value)
+        if name == "showtime":
+            self.showtime = value == TRUE
 
     def reset_environment(self) -> None:
         """Clear every user-introduced binding.
@@ -148,11 +163,11 @@ class MacsymaBackend(SymbolicBackend):
         # Cheapest correct approach: re-run the parent ``__init__``
         # state setup. We don't want to re-install handlers (that would
         # drop our runtime overrides), so we touch only ``_env``.
-        from symbolic_vm.handlers import FALSE, TRUE
-
         self._env.clear()
         self._env["True"] = TRUE
         self._env["False"] = FALSE
+        self._env["showtime"] = FALSE
+        self.showtime = False
         self.history.reset()
 
     # ---- name lookup with history fallback ----------------------------

--- a/code/packages/python/macsyma-runtime/tests/test_backend_init.py
+++ b/code/packages/python/macsyma-runtime/tests/test_backend_init.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import math
 
-from symbolic_ir import IRFloat
+from symbolic_ir import ASSIGN, IRApply, IRFloat, IRSymbol
+from symbolic_vm import VM
 
 from macsyma_runtime import DISPLAY, EV, KILL, SUPPRESS, History, MacsymaBackend
 
@@ -24,6 +25,31 @@ def test_default_flags() -> None:
     b = MacsymaBackend()
     assert b.numer is False
     assert b.simp is True
+    assert b.showtime is False
+    assert b.lookup("showtime") == IRSymbol("False")
+
+
+def test_showtime_flag_tracks_assignment() -> None:
+    b = MacsymaBackend()
+    vm = VM(b)
+
+    vm.eval(IRApply(ASSIGN, (IRSymbol("showtime"), IRSymbol("True"))))
+    assert b.showtime is True
+    assert b.lookup("showtime") == IRSymbol("True")
+
+    vm.eval(IRApply(ASSIGN, (IRSymbol("showtime"), IRSymbol("False"))))
+    assert b.showtime is False
+    assert b.lookup("showtime") == IRSymbol("False")
+
+
+def test_kill_showtime_restores_default_flag() -> None:
+    b = MacsymaBackend()
+    b.bind("showtime", IRSymbol("True"))
+
+    b.unbind("showtime")
+
+    assert b.showtime is False
+    assert b.lookup("showtime") == IRSymbol("False")
 
 
 def test_runtime_handlers_installed() -> None:

--- a/code/programs/python/macsyma-repl/language.py
+++ b/code/programs/python/macsyma-repl/language.py
@@ -17,6 +17,7 @@ returns one combined string (one display block per displayed result, or
 from __future__ import annotations
 
 import re
+import time
 from pathlib import Path
 
 from coding_adventures_repl import Language
@@ -103,15 +104,20 @@ class MacsymaLanguage(Language):
         outputs: list[str] = []
         for stmt in statements:
             displayed, inner = _split_wrapper(stmt)
+            show_timing = self.backend.showtime and not _is_showtime_assignment(inner)
+            start = time.perf_counter()
             try:
                 result = self.vm.eval(inner)
             except Exception as exc:
                 return ("error", f"runtime error: {exc}")
+            elapsed = time.perf_counter() - start
             self.history.record_input(inner)
             self.history.record_output(result)
             if displayed:
                 idx = len(self.history.outputs)
                 outputs.append(f"(%o{idx}) {output_text_for(inner, result)}")
+            if show_timing:
+                outputs.append(_format_timing(elapsed))
 
         if not outputs:
             return ("ok", None)
@@ -145,3 +151,20 @@ def _split_wrapper(stmt: IRNode) -> tuple[bool, IRNode]:
         if stmt.head.name == "Suppress":
             return False, stmt.args[0]
     return True, stmt
+
+
+def _format_timing(elapsed: float) -> str:
+    """Return the user-facing line for ``showtime:true`` diagnostics."""
+    return f"Evaluation took {elapsed:.6f} seconds."
+
+
+def _is_showtime_assignment(expr: IRNode) -> bool:
+    """Return whether ``expr`` toggles the ``showtime`` option flag."""
+    return (
+        isinstance(expr, IRApply)
+        and isinstance(expr.head, IRSymbol)
+        and expr.head.name == "Assign"
+        and len(expr.args) == 2
+        and isinstance(expr.args[0], IRSymbol)
+        and expr.args[0].name == "showtime"
+    )

--- a/code/programs/python/macsyma-repl/tests/test_session.py
+++ b/code/programs/python/macsyma-repl/tests/test_session.py
@@ -7,6 +7,7 @@ and verifies the recorded transcript.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -44,6 +45,10 @@ def _run(inputs: list[str]) -> list[str]:
         mode="sync",
     )
     return outputs
+
+
+def _output_lines(outputs: list[str]) -> list[str]:
+    return [line for output in outputs for line in output.splitlines()]
 
 
 # ---------------------------------------------------------------------------
@@ -142,6 +147,30 @@ def test_auto_terminator_appended() -> None:
     """Input without a trailing ``;`` or ``$`` is treated as ``;``."""
     out = _run(["2 + 3", ":quit"])
     assert any(line == "(%o1) 5" for line in out)
+
+
+def test_showtime_appends_timing_after_displayed_statement() -> None:
+    out = _output_lines(_run(["showtime:true$", "2 + 3;", ":quit"]))
+
+    assert any(line == "(%o2) 5" for line in out)
+    assert any(
+        re.fullmatch(r"Evaluation took \d+\.\d{6} seconds\.", line)
+        for line in out
+    )
+
+
+def test_showtime_false_disables_timing() -> None:
+    out = _output_lines(_run(["showtime:true$", "showtime:false$", "2 + 3;", ":quit"]))
+
+    assert any(line == "(%o3) 5" for line in out)
+    assert not any(line.startswith("Evaluation took ") for line in out)
+
+
+def test_showtime_reports_suppressed_statement_timing() -> None:
+    out = _output_lines(_run(["showtime:true$", "2 + 3$", ":quit"]))
+
+    assert not any(line.startswith("(%o2) ") for line in out)
+    assert any(line.startswith("Evaluation took ") for line in out)
 
 
 def test_eval_file_uses_same_session_semantics(tmp_path: Path) -> None:

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -242,7 +242,7 @@ The Risch integration suite is ~85% complete. Known remaining gaps:
 |---|---|
 | **Friendly error messages** | Syntax errors from the parser surface as raw Python exceptions. Should produce MACSYMA-style messages: `Incorrect syntax: …` with the offending token highlighted. |
 | **`?` help system** | No documentation lookup. A thin wrapper over docstrings would cover most cases. |
-| **`showtime`** | MACSYMA's wall-clock / GC timing per expression. Useful for performance work. |
+| **`showtime`** | Python REPL supports `showtime:true` / `showtime:false` wall-clock timing per expression. TypeScript and Rust runtime parity still pending. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add a Python MACSYMA `showtime` option flag backed by the runtime environment
- have the Python REPL emit per-statement wall-clock diagnostics when `showtime:true` is active
- document that Python `showtime` is now covered while TypeScript and Rust parity remains pending

## Validation
- `bash BUILD` from `code/programs/python/macsyma-repl`
- `bash BUILD` from `code/packages/python/macsyma-runtime`
- `.venv/bin/python -m ruff check language.py main.py prompt.py tests` from `code/programs/python/macsyma-repl`
- `.venv/bin/python -m ruff check src tests` from `code/packages/python/macsyma-runtime`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-python-macsyma-showtime.json` from `code/programs/go/build-tool`
- `git diff --check`