### PR TITLE
Add TypeScript MACSYMA showtime diagnostics

### DIFF
--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -253,6 +253,7 @@ export interface EvalResult {
   readonly output: IRNode;
   readonly outputText: string;
   readonly display: boolean;
+  readonly timingText?: string;
 }
 
 export class History {
@@ -312,6 +313,7 @@ export class History {
 
 export class MacsymaBackend extends SymbolicBackend {
   numer = false;
+  showtime = false;
   readonly assumptions = new AssumptionContext();
   private readonly runtimeTable: ReadonlyMap<string, Handler>;
   private readonly runtimeHeld: ReadonlySet<string>;
@@ -373,6 +375,21 @@ export class MacsymaBackend extends SymbolicBackend {
     return this.history.resolveHistorySymbol(name);
   }
 
+  override bind(name: string, value: IRNode): void {
+    super.bind(name, value);
+    if (name === "showtime") {
+      this.showtime = equals(value, TRUE);
+    }
+  }
+
+  override unbind(name: string): void {
+    super.unbind(name);
+    if (name === "showtime") {
+      this.showtime = false;
+      super.bind("showtime", FALSE);
+    }
+  }
+
   override handlers(): ReadonlyMap<string, Handler> {
     return this.runtimeTable;
   }
@@ -385,6 +402,8 @@ export class MacsymaBackend extends SymbolicBackend {
     this.env.clear();
     this.env.set(TRUE.name, TRUE);
     this.env.set(FALSE.name, FALSE);
+    this.showtime = false;
+    this.env.set("showtime", FALSE);
     this.bindMacsymaConstants();
     this.history.reset();
   }
@@ -403,6 +422,7 @@ export class MacsymaBackend extends SymbolicBackend {
     this.bind("%pi", numberNode(Math.PI));
     this.bind("%e", numberNode(Math.E));
     this.bind("%i", sym("ImaginaryUnit"));
+    this.bind("showtime", this.showtime ? TRUE : FALSE);
   }
 }
 
@@ -437,14 +457,25 @@ export class MacsymaSession {
 
   private evalStatement(statement: IRNode): EvalResult {
     const [input, display] = unwrapDisplay(statement);
+    const showTiming = this.backend.showtime && !isShowtimeAssignment(input);
+    const startedAt = Date.now();
     const inputIndex = this.sessionHistory.recordInput(input);
     const output = this.vm.eval(input);
+    const elapsedSeconds = (Date.now() - startedAt) / 1000;
     const outputIndex = this.sessionHistory.recordOutput(output);
     const outputText = displayTextFor(input, output);
     if (isKillAll(input)) {
       this.sessionHistory.reset();
     }
-    return { inputIndex, outputIndex, input, output, outputText, display };
+    return {
+      inputIndex,
+      outputIndex,
+      input,
+      output,
+      outputText,
+      display,
+      ...(showTiming ? { timingText: formatTiming(elapsedSeconds) } : {}),
+    };
   }
 }
 
@@ -466,6 +497,7 @@ export interface JsonEvalResult {
   readonly display: boolean;
   readonly inputText: string;
   readonly outputText: string;
+  readonly timingText?: string;
   readonly inputIr: JsonIrNode;
   readonly outputIr: JsonIrNode;
 }
@@ -510,7 +542,10 @@ function evalResponseOk(results: readonly EvalResult[], history: History): JsonE
   return {
     ok: true,
     results: jsonResults,
-    visibleOutputs: jsonResults.filter((result) => result.display).map((result) => result.outputText),
+    visibleOutputs: jsonResults.flatMap((result) => [
+      ...(result.display ? [result.outputText] : []),
+      ...(result.timingText === undefined ? [] : [result.timingText]),
+    ]),
     history: historyToJson(history),
   };
 }
@@ -532,6 +567,7 @@ function resultToJson(result: EvalResult): JsonEvalResult {
     display: result.display,
     inputText: toDisplayString(result.input),
     outputText: result.outputText,
+    ...(result.timingText === undefined ? {} : { timingText: result.timingText }),
     inputIr: irToJson(result.input),
     outputIr: irToJson(result.output),
   };
@@ -814,6 +850,19 @@ function isKillAll(input: IRNode): boolean {
   return input.kind === "apply"
     && equals(input.head, KILL)
     && input.args.some((arg) => arg.kind === "symbol" && arg.name === ALL_SYMBOL.name);
+}
+
+function isShowtimeAssignment(input: IRNode): boolean {
+  return input.kind === "apply"
+    && input.head.kind === "symbol"
+    && input.head.name === "Assign"
+    && input.args.length === 2
+    && input.args[0].kind === "symbol"
+    && input.args[0].name === "showtime";
+}
+
+function formatTiming(elapsedSeconds: number): string {
+  return `Evaluation took ${elapsedSeconds.toFixed(6)} seconds.`;
 }
 
 function integerIndex(value: number): boolean {

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -4,6 +4,7 @@ import {
   ASSUME,
   EQUAL,
   EXP,
+  FALSE,
   FORGET,
   GREATER,
   GREATER_EQUAL,
@@ -130,6 +131,49 @@ describe("macsyma-runtime", () => {
     expect(killResult.input).toEqual(app(KILL, [sym("x")]));
     expect(evResult.input).toEqual(app(EV, [app(ADD, [int(1), int(2)]), sym("numer")]));
     expect(evResult.output).toEqual(numberNode(3));
+  });
+
+  it("tracks the showtime option flag through normal assignments", () => {
+    const session = new MacsymaSession();
+    const [enabled, timed, disabled, untimed] = session.evalSource(
+      "showtime:true$ 2 + 3; showtime:false$ 4 + 5;",
+    );
+
+    expect(enabled.output).toEqual(TRUE);
+    expect(timed.output).toEqual(int(5));
+    expect(timed.timingText).toMatch(/^Evaluation took \d+\.\d{6} seconds\.$/);
+    expect(disabled.output).toEqual(FALSE);
+    expect(disabled.timingText).toBeUndefined();
+    expect(untimed.output).toEqual(int(9));
+    expect(untimed.timingText).toBeUndefined();
+  });
+
+  it("reports showtime diagnostics for suppressed statements", () => {
+    const session = new MacsymaSession();
+    const [, suppressed] = session.evalSource("showtime:true$ 2 + 3$");
+
+    expect(suppressed.display).toBe(false);
+    expect(suppressed.output).toEqual(int(5));
+    expect(suppressed.timingText).toMatch(/^Evaluation took \d+\.\d{6} seconds\.$/);
+  });
+
+  it("restores showtime to false when killed", () => {
+    const backend = new MacsymaBackend(new History());
+    backend.bind("showtime", TRUE);
+
+    backend.unbind("showtime");
+
+    expect(backend.showtime).toBe(false);
+    expect(backend.lookup("showtime")).toEqual(FALSE);
+  });
+
+  it("includes showtime diagnostics in JSON visible outputs", () => {
+    const payload = JSON.parse(evalSourceJson("showtime:true$ 2 + 3$"));
+    const [, result] = payload.results;
+
+    expect(result.display).toBe(false);
+    expect(result.timingText).toMatch(/^Evaluation took \d+\.\d{6} seconds\.$/);
+    expect(payload.visibleOutputs).toEqual([result.timingText]);
   });
 
   it("records and resolves history references", () => {

--- a/code/programs/typescript/macsyma-browser-repl/src/App.tsx
+++ b/code/programs/typescript/macsyma-browser-repl/src/App.tsx
@@ -14,6 +14,7 @@ interface TranscriptEntry {
   readonly input: string;
   readonly output: string;
   readonly display: boolean;
+  readonly timingText?: string;
 }
 
 export function App(): JSX.Element {
@@ -129,6 +130,9 @@ export function App(): JSX.Element {
                     <pre>{entry.input}</pre>
                     <div className="prompt">%o{entry.outputIndex}</div>
                     <pre>{entry.display ? entry.output : "$"}</pre>
+                    {entry.timingText === undefined ? null : (
+                      <div className="timing">{entry.timingText}</div>
+                    )}
                   </li>
                 ))}
               </ol>
@@ -147,6 +151,7 @@ function toEntry(result: EvalResult): TranscriptEntry {
     input: toDisplayString(result.input),
     output: result.outputText,
     display: result.display,
+    ...(result.timingText === undefined ? {} : { timingText: result.timingText }),
   };
 }
 

--- a/code/programs/typescript/macsyma-browser-repl/src/styles.css
+++ b/code/programs/typescript/macsyma-browser-repl/src/styles.css
@@ -248,6 +248,14 @@ pre {
   word-break: break-word;
 }
 
+.timing {
+  grid-column: 2;
+  padding: 0 14px 12px;
+  color: #5c685f;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.85rem;
+}
+
 .suppressed {
   opacity: 0.68;
 }

--- a/code/programs/typescript/macsyma-browser-repl/tests/App.test.tsx
+++ b/code/programs/typescript/macsyma-browser-repl/tests/App.test.tsx
@@ -60,4 +60,17 @@ describe("Macsyma browser REPL", () => {
     expect(await transcript.findByText((content) => content.includes("─") && content.includes("x + 1")))
       .toBeInTheDocument();
   });
+
+  it("renders showtime diagnostics from the runtime transcript metadata", async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText("MACSYMA source"), {
+      target: { value: "showtime:true$\n2 + 3$" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+
+    const transcript = within(screen.getByLabelText("Transcript"));
+    expect(await transcript.findByText(/^Evaluation took \d+\.\d{6} seconds\.$/)).toBeInTheDocument();
+    expect(transcript.queryByText("%o2")).toBeInTheDocument();
+  });
 });

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -242,7 +242,7 @@ The Risch integration suite is ~85% complete. Known remaining gaps:
 |---|---|
 | **Friendly error messages** | Syntax errors from the parser surface as raw Python exceptions. Should produce MACSYMA-style messages: `Incorrect syntax: …` with the offending token highlighted. |
 | **`?` help system** | No documentation lookup. A thin wrapper over docstrings would cover most cases. |
-| **`showtime`** | Python REPL supports `showtime:true` / `showtime:false` wall-clock timing per expression. TypeScript and Rust runtime parity still pending. |
+| **`showtime`** | Python and TypeScript sessions support `showtime:true` / `showtime:false` wall-clock timing per expression. Rust runtime parity still pending. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add TypeScript MACSYMA `showtime` session state backed by normal assignments
- include optional per-statement timing metadata in runtime and JSON results
- render showtime diagnostics in the browser transcript and update the pending-work spec

## Validation
- `npm test` from `code/packages/typescript/macsyma-runtime`
- `npm run build` from `code/packages/typescript/macsyma-runtime`
- `npm test` from `code/programs/typescript/macsyma-browser-repl`
- `npm run build` from `code/programs/typescript/macsyma-browser-repl`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-ts-macsyma-showtime.json` from `code/programs/go/build-tool`
- `git diff --check`