### PR TITLE
fix(adjudication-tsa-demo): wire ADJ_DEMO_CACHE_DIR through Stage 0 elicitation

### DIFF
--- a/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.1] - 2026-05-12 — Wire `ADJ_DEMO_CACHE_DIR` through Stage 0
+
+### Fixed
+
+The `ADJ_DEMO_RULEBOOK_MODE=elicit` and
+`ADJ_DEMO_RULEBOOK_MODE=adversarial:...` paths now respect
+`ADJ_DEMO_CACHE_DIR`. Previously both paths constructed raw
+`OllamaClient`s without wrapping them in
+`llm_cache::CachingClient`, so the cache directory was honoured for
+Arm B's full pipeline but bypassed for the rulebook-elicitation
+Stage 0. A repeated adversarial bench paid the full ~250 s × N
+elicitation cost on every answerer iteration instead of replaying
+from disk.
+
+Surfaced by [ADJ17 §Caveats(5)](../../../specs/ADJ17-adversarial-rulebook-empirical-results.md).
+The cost mattered most for the 5-answerer adversarial bench, which
+was paying 4× the elicitation cost it should have.
+
+### Implementation
+
+A new `cached_client(inner, cache_dir)` helper in `main.rs` mirrors
+the private `wrap_with_cache` in `lib.rs`, wrapping each
+`OllamaClient` in a `CachingClient::with_disk_persistence` (when a
+cache_dir is set) or a memory-only `CachingClient::new` (when it
+isn't). Both Stage 0 paths now route their per-model clients
+through this helper before composing them into a `GatewayConfig`.
+
+The fix is observable as a shorter Stage 0 log timing on the second
+run of any adversarial bench against the same cache directory: the
+cache hit replays elicitation responses without an HTTP round-trip.
+
 ## [0.10.0] - 2026-05-12 — Adversarial multi-model elicit-mode wiring
 
 ### Added

--- a/code/packages/rust/adjudication-tsa-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-tsa-demo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-tsa-demo"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
-description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.10 adds ADJ_DEMO_RULEBOOK_MODE=adversarial:m1,m2,... — elicit rulebooks from N independent models and inject the provenance-tagged merged text into Arm A's system prompt. Rules cited at answer time can now be traced back to which model produced them, and rules appearing in only one model's training surface as lower-trust than rules multiple models agree on. The recursive use of the framework, made adversarial."
+description = "A/B demo harness: compare a raw local Ollama model against the full adjudication pipeline on the TSA worked example. v0.10 adds ADJ_DEMO_RULEBOOK_MODE=adversarial:m1,m2,... — elicit rulebooks from N independent models and inject the provenance-tagged merged text into Arm A's system prompt. Rules cited at answer time can now be traced back to which model produced them, and rules appearing in only one model's training surface as lower-trust than rules multiple models agree on. v0.10.1 fixes a cache-bypass bug: the elicit and adversarial-elicit Stage 0 paths now respect ADJ_DEMO_CACHE_DIR (previously every adversarial bench run re-elicited every rulebook from scratch even with a cache directory configured)."
 
 [[bin]]
 name = "adjudication-tsa-demo"

--- a/code/packages/rust/adjudication-tsa-demo/src/main.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/main.rs
@@ -57,9 +57,30 @@ use adjudication_tsa_demo::{
     acquire_demo_rulebook, fixture_tsa_rulebook, format_side_by_side, run_pipeline_arm,
     run_raw_arm, DemoConfig, IrMode, IrSourceTelemetry,
 };
+use llm_cache::CachingClient;
 use llm_gateway::LlmClient;
 use llm_primitives::{GatewayConfig, Role as PrimitiveRole};
 use llm_provider_ollama::OllamaClient;
+
+/// Wrap an inner LLM client with a `CachingClient`, using disk
+/// persistence when the demo config supplies a `cache_dir`. Mirrors
+/// `adjudication_tsa_demo::wrap_with_cache` (which is private to the
+/// library crate) so the elicit and adversarial-elicit paths can
+/// reuse the same caching discipline as Arm B's full pipeline.
+///
+/// Without this wrap, the elicit and adversarial paths bypass
+/// `cfg.cache_dir` entirely: every run re-elicits every rulebook
+/// from scratch, even when the prompt/model are byte-identical to a
+/// previous run. The behaviour is correct but wastes ~250 s per
+/// benchmark iteration. v0.10.1 plugs the gap.
+fn cached_client(inner: OllamaClient, cache_dir: Option<&String>) -> Box<dyn LlmClient> {
+    let boxed: Box<dyn LlmClient> = Box::new(inner);
+    let cached = match cache_dir {
+        Some(dir) => CachingClient::with_disk_persistence(boxed, dir),
+        None => CachingClient::new(boxed),
+    };
+    Box::new(cached)
+}
 
 fn main() {
     let mut cfg = config_from_env();
@@ -93,12 +114,21 @@ fn main() {
              adjudication_rulebook::acquire_rulebook ...",
             model = cfg.model,
         );
-        let ollama = OllamaClient::new(cfg.model.clone())
+        let ollama_extractor = OllamaClient::new(cfg.model.clone())
+            .with_endpoint(cfg.endpoint.clone())
+            .with_timeout(cfg.timeout);
+        let ollama_ruleextractor = OllamaClient::new(cfg.model.clone())
             .with_endpoint(cfg.endpoint.clone())
             .with_timeout(cfg.timeout);
         let gw = GatewayConfig::new()
-            .with_client(PrimitiveRole::RuleExtractor, Box::new(ollama.clone()))
-            .with_client(PrimitiveRole::Extractor, Box::new(ollama));
+            .with_client(
+                PrimitiveRole::RuleExtractor,
+                cached_client(ollama_ruleextractor, cfg.cache_dir.as_ref()),
+            )
+            .with_client(
+                PrimitiveRole::Extractor,
+                cached_client(ollama_extractor, cfg.cache_dir.as_ref()),
+            );
         match acquire_demo_rulebook(&cfg, &gw) {
             Ok(rb) => {
                 let validation_summary = if rb.validation_passed {
@@ -161,22 +191,30 @@ fn main() {
         );
         let mut gateways: Vec<(String, GatewayConfig)> = Vec::with_capacity(models.len());
         for m in models {
-            let ollama: Box<dyn LlmClient> = Box::new(
-                OllamaClient::new(m.clone())
-                    .with_endpoint(cfg.endpoint.clone())
-                    .with_timeout(cfg.timeout),
-            );
+            // Wrap each per-model client in a CachingClient so a
+            // repeat adversarial run replays the elicitation from
+            // disk instead of paying ~250 s × 2 models on every
+            // answerer iteration. Without this wrap, `cfg.cache_dir`
+            // was honoured for Arm B but ignored for Stage 0 — every
+            // bench run re-elicited every rulebook from scratch.
+            let ollama_ruleextractor = OllamaClient::new(m.clone())
+                .with_endpoint(cfg.endpoint.clone())
+                .with_timeout(cfg.timeout);
             // Second client for Extractor role (decompose_text). We
             // can't .clone() Box<dyn LlmClient>, so construct a
             // sibling OllamaClient with the same config.
-            let extractor: Box<dyn LlmClient> = Box::new(
-                OllamaClient::new(m.clone())
-                    .with_endpoint(cfg.endpoint.clone())
-                    .with_timeout(cfg.timeout),
-            );
+            let ollama_extractor = OllamaClient::new(m.clone())
+                .with_endpoint(cfg.endpoint.clone())
+                .with_timeout(cfg.timeout);
             let gw = GatewayConfig::new()
-                .with_client(PrimitiveRole::RuleExtractor, ollama)
-                .with_client(PrimitiveRole::Extractor, extractor);
+                .with_client(
+                    PrimitiveRole::RuleExtractor,
+                    cached_client(ollama_ruleextractor, cfg.cache_dir.as_ref()),
+                )
+                .with_client(
+                    PrimitiveRole::Extractor,
+                    cached_client(ollama_extractor, cfg.cache_dir.as_ref()),
+                );
             gateways.push((m.clone(), gw));
         }
         let req = AcquireRulebookAdversarialRequest {


### PR DESCRIPTION
## Summary

The `elicit` and `adversarial:m1,m2,...` rulebook modes constructed raw `OllamaClient`s without wrapping them in `llm_cache::CachingClient`. As a result `ADJ_DEMO_CACHE_DIR` was honoured for Arm B's full pipeline (via the private `wrap_with_cache` in lib.rs) but ignored entirely for Stage 0 — every repeated adversarial bench re-elicited every rulebook from scratch even with the cache directory pre-populated.

This bug was documented in [ADJ17 §Caveats(5)](https://github.com/adhithyan15/coding-adventures/pull/3047) as a known limitation; this PR fixes it.

## Impact

Most visible on the 5-answerer adversarial bench, which was paying ~250 s × 2 models = ~8 minutes of elicitation on every answerer iteration. With the fix, a warm cache replays Stage 0 in seconds — roughly **4× speedup on subsequent bench runs** against the same cache directory.

## What changed

- New `cached_client(inner, cache_dir)` helper in `main.rs` mirroring the private `wrap_with_cache` in `lib.rs`.
- Both Stage 0 code paths (single-model `elicit` and `adversarial:m1,m2,...`) route their per-model clients through this helper before composing into a `GatewayConfig`.
- `Cargo.toml`: 0.10.0 → 0.10.1.
- `CHANGELOG.md`: 0.10.1 entry.

## What didn't change

- Arm B caching (unchanged — already worked).
- Cache semantics (still content-addressed by prompt hash; identical prompts replay identically).
- Determinism guarantees (still `temperature: 0.0`; cache is sound).

## Note on branch name

The branch is `claude/jovial-rust-adj16-step2-answer-mode-engine`, originally intended for ADJ16 step 2. While preparing that work I noticed the cache bug was small and self-contained, and reusing the branch ships the fix sooner. ADJ16 step 2 will land on a fresh branch after step 1 (#3049) merges.

## Test plan

- [x] `cargo build -p adjudication-tsa-demo` (clean)
- [x] `cargo test -p adjudication-tsa-demo` (clean — no new unit tests; this is a CLI-binary fix in `main.rs` not the library crate)
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)