### PR TITLE
Add friendly MACSYMA syntax diagnostics

### DIFF
--- a/code/packages/python/macsyma-parser/src/macsyma_parser/__init__.py
+++ b/code/packages/python/macsyma-parser/src/macsyma_parser/__init__.py
@@ -16,9 +16,14 @@ Usage::
     print(ast.rule_name)  # "program"
 """
 
-from macsyma_parser.parser import create_macsyma_parser, parse_macsyma
+from macsyma_parser.parser import (
+    create_macsyma_parser,
+    format_macsyma_syntax_error,
+    parse_macsyma,
+)
 
 __all__ = [
     "create_macsyma_parser",
+    "format_macsyma_syntax_error",
     "parse_macsyma",
 ]

--- a/code/packages/python/macsyma-parser/src/macsyma_parser/parser.py
+++ b/code/packages/python/macsyma-parser/src/macsyma_parser/parser.py
@@ -66,3 +66,26 @@ def parse_macsyma(source: str) -> ASTNode:
         assert ast.rule_name == "program"
     """
     return create_macsyma_parser(source).parse()
+
+
+def format_macsyma_syntax_error(source: str, error: BaseException) -> str:
+    """Format parser/lexer failures as a MACSYMA-style syntax diagnostic."""
+    line = getattr(getattr(error, "token", None), "line", None)
+    column = getattr(getattr(error, "token", None), "column", None)
+    message = _strip_parse_prefix(str(error))
+    if isinstance(line, int) and isinstance(column, int) and line >= 1 and column >= 1:
+        source_line = source.splitlines()[line - 1] if line <= len(source.splitlines()) else ""
+        caret = " " * (column - 1) + "^"
+        return f"Incorrect syntax at line {line}, column {column}: {message}\n{source_line}\n{caret}"
+    return f"Incorrect syntax: {message}"
+
+
+def _strip_parse_prefix(message: str) -> str:
+    prefixes = ("Parse error: ",)
+    for prefix in prefixes:
+        if message.startswith(prefix):
+            return message[len(prefix) :]
+    if message.startswith("Parse error at "):
+        _, _, rest = message.partition(": ")
+        return rest or message
+    return message

--- a/code/packages/python/macsyma-parser/tests/test_parser.py
+++ b/code/packages/python/macsyma-parser/tests/test_parser.py
@@ -10,7 +10,7 @@ name, number of statements, key nonterminal types appearing.
 from __future__ import annotations
 
 from lang_parser import ASTNode, find_nodes
-from macsyma_parser import parse_macsyma
+from macsyma_parser import format_macsyma_syntax_error, parse_macsyma
 
 
 def test_single_expression_statement() -> None:
@@ -129,3 +129,22 @@ def test_empty_program() -> None:
 def test_returns_ast_node() -> None:
     ast = parse_macsyma("1;")
     assert isinstance(ast, ASTNode)
+
+
+def test_formats_parser_error_with_line_column_and_caret() -> None:
+    source = "1 +;"
+    try:
+        parse_macsyma(source)
+    except Exception as exc:
+        message = format_macsyma_syntax_error(source, exc)
+    else:  # pragma: no cover - this input must stay invalid
+        raise AssertionError("expected parser failure")
+
+    assert message.startswith("Incorrect syntax at line 1, column ")
+    assert "1 +;" in message
+    assert "^" in message
+
+
+def test_formats_parser_error_without_token_metadata() -> None:
+    message = format_macsyma_syntax_error("1 +;", ValueError("plain failure"))
+    assert message == "Incorrect syntax: plain failure"

--- a/code/packages/rust/macsyma-compiler/src/lib.rs
+++ b/code/packages/rust/macsyma-compiler/src/lib.rs
@@ -6,9 +6,9 @@
 use std::error::Error;
 use std::fmt;
 
-use coding_adventures_macsyma_parser::parse_macsyma;
+use coding_adventures_macsyma_parser::create_macsyma_parser;
 use lexer::token::Token;
-use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode, GrammarParseError};
 use symbolic_ir::{
     apply, flt, int, str_node, sym, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ASSIGN, ATAN,
     ATANH, COS, COSH, D, DEFINE, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INTEGRATE, LESS,
@@ -57,8 +57,22 @@ pub fn compile_macsyma_with_options(
     source: &str,
     options: CompileOptions,
 ) -> Result<Vec<IRNode>, CompileError> {
-    let ast = parse_macsyma(source);
+    let mut parser = create_macsyma_parser(source);
+    let ast = parser
+        .parse()
+        .map_err(|err| CompileError::new(format_macsyma_syntax_error(source, &err)))?;
     Compiler::new(options).compile_program(&ast)
+}
+
+pub fn format_macsyma_syntax_error(source: &str, error: &GrammarParseError) -> String {
+    let line = error.token.line;
+    let column = error.token.column;
+    let source_line = source.lines().nth(line.saturating_sub(1)).unwrap_or("");
+    let caret = format!("{}^", " ".repeat(column.saturating_sub(1)));
+    format!(
+        "Incorrect syntax at line {line}, column {column}: {}\n{source_line}\n{caret}",
+        error.message
+    )
 }
 
 pub struct Compiler {

--- a/code/packages/rust/macsyma-compiler/tests/test_compiler.rs
+++ b/code/packages/rust/macsyma-compiler/tests/test_compiler.rs
@@ -111,6 +111,15 @@ fn compiles_lists_and_optional_terminator_wrappers() {
 }
 
 #[test]
+fn formats_parser_failures_as_macsyma_syntax_diagnostics() {
+    let err = compile_macsyma("1 + ;").expect_err("invalid syntax should fail");
+    let message = err.to_string();
+    assert!(message.starts_with("Incorrect syntax at line 1, column "));
+    assert!(message.contains("1 + ;\n"));
+    assert!(message.contains("^"));
+}
+
+#[test]
 fn compiles_if_expressions_to_symbolic_if() {
     assert_eq!(
         one("if x < 0 then -x else x;"),

--- a/code/packages/rust/macsyma-wasm/src/lib.rs
+++ b/code/packages/rust/macsyma-wasm/src/lib.rs
@@ -325,7 +325,7 @@ mod tests {
         assert!(payload["error"]["message"]
             .as_str()
             .unwrap()
-            .contains("parse"));
+            .starts_with("Incorrect syntax at line 1, column "));
     }
 
     #[test]

--- a/code/packages/typescript/macsyma-compiler/src/index.ts
+++ b/code/packages/typescript/macsyma-compiler/src/index.ts
@@ -1,6 +1,6 @@
 import type { Token } from "@coding-adventures/lexer";
 import { parseMacsyma } from "@coding-adventures/macsyma-parser";
-import { isASTNode } from "@coding-adventures/parser";
+import { GrammarParseError, isASTNode } from "@coding-adventures/parser";
 import type { ASTNode } from "@coding-adventures/parser";
 import {
   ACOS,
@@ -122,8 +122,26 @@ export interface CompileOptions {
 }
 
 export function compileMacsyma(input: string | ASTNode, options: CompileOptions = {}): IRNode[] {
-  const ast = typeof input === "string" ? parseMacsyma(input) : input;
+  const ast = typeof input === "string" ? parseMacsymaFriendly(input) : input;
   return new Compiler(options).compileProgram(ast);
+}
+
+export function formatMacsymaSyntaxError(source: string, error: unknown): string {
+  if (error instanceof GrammarParseError && error.token !== null) {
+    const { line, column } = error.token;
+    const sourceLine = source.split(/\r?\n/)[line - 1] ?? "";
+    const caret = " ".repeat(Math.max(0, column - 1)) + "^";
+    return `Incorrect syntax at line ${line}, column ${column}: ${stripParsePrefix(error.message)}\n${sourceLine}\n${caret}`;
+  }
+  return `Incorrect syntax: ${stripParsePrefix(errorMessage(error))}`;
+}
+
+function parseMacsymaFriendly(source: string): ASTNode {
+  try {
+    return parseMacsyma(source);
+  } catch (error) {
+    throw new CompileError(formatMacsymaSyntaxError(source, error));
+  }
 }
 
 export class Compiler {
@@ -433,4 +451,19 @@ function canonicalCallHead(head: IRNode): IRNode {
 
 function isSameSymbol(node: IRNode, symbol: IRSymbol): boolean {
   return node.kind === "symbol" && node.name === symbol.name;
+}
+
+function stripParsePrefix(message: string): string {
+  if (message.startsWith("Parse error: ")) {
+    return message.slice("Parse error: ".length);
+  }
+  if (message.startsWith("Parse error at ")) {
+    const separator = message.indexOf(": ");
+    return separator === -1 ? message : message.slice(separator + 2);
+  }
+  return message;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/code/packages/typescript/macsyma-compiler/tests/compiler.test.ts
+++ b/code/packages/typescript/macsyma-compiler/tests/compiler.test.ts
@@ -74,6 +74,12 @@ describe("macsyma compiler", () => {
     ]);
   });
 
+  it("formats parser failures as MACSYMA syntax diagnostics", () => {
+    expect(() => compileMacsyma("1 + ;")).toThrow(
+      /Incorrect syntax at line 1, column \d+: .*\n1 \+ ;\n\s+\^/,
+    );
+  });
+
   it("compiles if expressions to symbolic If", () => {
     expect(one("if x < 0 then -x else x;")).toEqual(app(IF, [
       app(LESS, [sym("x"), int(0)]),

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -716,6 +716,8 @@ describe("macsyma-runtime", () => {
     const payload = JSON.parse(session.evalJson("1 + ;"));
     expect(payload.ok).toBe(false);
     expect(payload.error.kind).toBe("runtime");
+    expect(payload.error.message).toMatch(/^Incorrect syntax at line 1, column \d+:/);
+    expect(payload.error.message).toContain("1 + ;\n");
     expect(payload.history.inputCount).toBe(1);
   });
 

--- a/code/programs/python/macsyma-repl/language.py
+++ b/code/programs/python/macsyma-repl/language.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from coding_adventures_repl import Language
 from macsyma_compiler import compile_macsyma
 from macsyma_compiler.compiler import _STANDARD_FUNCTIONS
-from macsyma_parser import parse_macsyma
+from macsyma_parser import format_macsyma_syntax_error, parse_macsyma
 from macsyma_runtime import (
     History,
     MacsymaBackend,
@@ -99,7 +99,7 @@ class MacsymaLanguage(Language):
             ast = parse_macsyma(source)
             statements = compile_macsyma(ast, wrap_terminators=True)
         except Exception as exc:
-            return ("error", f"parse error: {exc}")
+            return ("error", format_macsyma_syntax_error(source, exc))
 
         outputs: list[str] = []
         for stmt in statements:

--- a/code/programs/python/macsyma-repl/tests/test_session.py
+++ b/code/programs/python/macsyma-repl/tests/test_session.py
@@ -209,7 +209,9 @@ def test_cli_file_mode_reports_errors_to_stderr(tmp_path: Path, capsys) -> None:
     assert macsyma_main(["--file", str(program)]) == 1
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert "parse error:" in captured.err
+    assert "Incorrect syntax at line 1, column" in captured.err
+    assert "1 +;" in captured.err
+    assert "^" in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -240,7 +240,7 @@ The Risch integration suite is ~85% complete. Known remaining gaps:
 
 | Feature | Notes |
 |---|---|
-| **Friendly error messages** | Syntax errors from the parser surface as raw Python exceptions. Should produce MACSYMA-style messages: `Incorrect syntax: …` with the offending token highlighted. |
+| **Friendly error messages** | Python, TypeScript, and Rust MACSYMA syntax failures now surface as `Incorrect syntax ...` diagnostics with line/column and a caret where parser token metadata is available. |
 | **`?` help system** | No documentation lookup. A thin wrapper over docstrings would cover most cases. |
 | **`showtime`** | Python, TypeScript, and Rust sessions support `showtime:true` / `showtime:false` wall-clock timing per expression, including suppressed statements. |
 


### PR DESCRIPTION
## Summary
- add MACSYMA-style `Incorrect syntax` diagnostics with line/column and caret output in Python parser/REPL file mode
- wrap TypeScript parser failures in friendly compiler/runtime JSON messages
- return Rust compiler parse failures as `CompileError` diagnostics instead of parser panics
- update the pending-work spec to mark friendly syntax diagnostics covered across Python, TypeScript, and Rust

## Validation
- `bash BUILD` from `code/packages/python/macsyma-parser`
- `bash BUILD` from `code/programs/python/macsyma-repl`
- `npm test && npm run build` from `code/packages/typescript/macsyma-compiler`
- `npm test && npm run build` from `code/packages/typescript/macsyma-runtime`
- `cargo fmt -p coding-adventures-macsyma-compiler -p coding-adventures-macsyma-runtime` from `code/packages/rust`
- `cargo test -p coding-adventures-macsyma-compiler` from `code/packages/rust`
- `cargo test -p coding-adventures-macsyma-runtime` from `code/packages/rust`
- `cargo test -p coding-adventures-macsyma-wasm` from `code/packages/rust`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-macsyma-friendly-errors.json` from `code/programs/go/build-tool`
- `git diff --check`
