### PR TITLE
Add MACSYMA question-mark help

### DIFF
--- a/code/packages/python/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/python/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added a small MACSYMA help catalog plus `?` query parsing helpers for REPL
+  and session frontends.
 - Added MACSYMA session-property operations: `declare(sym, property, ...)`,
   `properties(sym)`, and `propvars()`, backed by the VM assumption context so
   declared properties feed `is(...)` and simplification.

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/__init__.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/__init__.py
@@ -36,6 +36,7 @@ from macsyma_runtime.heads import (
     SUPPRESS,
 )
 from macsyma_runtime.history import History
+from macsyma_runtime.help import help_text, parse_help_query
 from macsyma_runtime.name_table import (
     MACSYMA_NAME_TABLE,
     extend_compiler_name_table,
@@ -60,5 +61,7 @@ __all__ = [
     "SUPPRESS",
     "extend_compiler_name_table",
     "has_ev_flag",
+    "help_text",
     "output_text_for",
+    "parse_help_query",
 ]

--- a/code/packages/python/macsyma-runtime/src/macsyma_runtime/help.py
+++ b/code/packages/python/macsyma-runtime/src/macsyma_runtime/help.py
@@ -1,0 +1,59 @@
+"""Small MACSYMA help catalog used by REPL/session frontends."""
+
+from __future__ import annotations
+
+_TOPICS: dict[str, str] = {
+    "arithmetic": "Arithmetic: use +, -, *, /, and ^. Example: expand((x + 1)^2);",
+    "calculus": "Calculus: diff(expr, var), integrate(expr, var), limit(expr, var, point), and taylor(expr, var, point, order).",
+    "diff": "diff(expr, var) differentiates expr with respect to var. Example: diff(x^3, x);",
+    "integrate": "integrate(expr, var) computes an antiderivative when supported. Example: integrate(x^2, x);",
+    "solve": "solve(expr, var) solves equations or supported inequalities. Use linsolve([...], [...]) for linear systems and nsolve(poly, var) for numeric polynomial roots.",
+    "matrix": "Matrix tools: matrix([...], ...), transpose, determinant, invert, dot, rank, rowreduce, ident, zeromatrix, and matrix_size.",
+    "lists": "List tools: length, first, rest, last, append, reverse, range, map, apply, sublist, sort, part, flatten, join, and makelist.",
+    "assumptions": "Assumptions: assume(x > 0), declare(x, positive), is(x > 0), forget(), properties(x), and propvars().",
+    "properties": "properties(symbol) lists declared properties. propvars() lists symbols with declared properties.",
+    "display": "Display: terminate with ; to show output and $ to suppress it. ev(expr, display2d) renders 2D output.",
+    "history": "History: % is the last output; %iN and %oN refer to input and output number N.",
+    "showtime": "showtime:true enables per-expression timing; showtime:false disables it.",
+    "repl": "REPL commands: :quit exits. Use --file path.mac for batch execution.",
+}
+
+_ALIASES = {
+    "d": "diff",
+    "derivative": "diff",
+    "integral": "integrate",
+    "matrices": "matrix",
+    "list": "lists",
+    "assume": "assumptions",
+    "declare": "assumptions",
+    "propvars": "properties",
+    "display2d": "display",
+    "%": "history",
+    "timing": "showtime",
+    "quit": "repl",
+}
+
+
+def parse_help_query(source: str) -> str | None:
+    """Return the requested help topic if ``source`` is a ``?`` query."""
+    stripped = source.strip()
+    if not stripped.startswith("?"):
+        return None
+    topic = stripped.lstrip("?").strip()
+    if topic.endswith((";", "$")):
+        topic = topic[:-1].strip()
+    return topic
+
+
+def help_text(topic: str | None = None) -> str:
+    """Return user-facing MACSYMA help text for ``topic``."""
+    key = (topic or "").strip().lower()
+    if not key:
+        topics = ", ".join(sorted(_TOPICS))
+        return f"MACSYMA help topics: {topics}. Use ? topic for details."
+    key = _ALIASES.get(key, key)
+    if key in _TOPICS:
+        return _TOPICS[key]
+    topics = ", ".join(sorted(_TOPICS))
+    return f"No MACSYMA help topic named {topic!r}. Available topics: {topics}."
+

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `?` / `? topic` help-query handling for Rust MACSYMA sessions.
 - Wired `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
   Rust MACSYMA session assumption context so declared properties feed property
   queries and assumption-backed relation checks.

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -22,8 +22,8 @@ use coding_adventures_macsyma_compiler::{
     SUPPRESS as COMPILER_SUPPRESS,
 };
 use symbolic_ir::{
-    apply, sym, IRApply, IRNode, ASSIGN, DEFINE, GREATER, GREATER_EQUAL, IF, LESS, LESS_EQUAL,
-    LIST, POW,
+    apply, str_node, sym, IRApply, IRNode, ASSIGN, DEFINE, GREATER, GREATER_EQUAL, IF, LESS,
+    LESS_EQUAL, LIST, POW,
 };
 use symbolic_vm::backend::{handler_fn, Backend, Handler};
 use symbolic_vm::handlers::build_handler_table;
@@ -228,6 +228,122 @@ const MACSYMA_NAME_TABLE: &[(&str, &str)] = &[
     ("fresnel_c", "FresnelC"),
     ("lambert_w", "LambertW"),
 ];
+
+const MACSYMA_HELP_TOPICS: &[(&str, &str)] = &[
+    (
+        "arithmetic",
+        "Arithmetic: use +, -, *, /, and ^. Example: expand((x + 1)^2);",
+    ),
+    (
+        "calculus",
+        "Calculus: diff(expr, var), integrate(expr, var), limit(expr, var, point), and taylor(expr, var, point, order).",
+    ),
+    (
+        "diff",
+        "diff(expr, var) differentiates expr with respect to var. Example: diff(x^3, x);",
+    ),
+    (
+        "integrate",
+        "integrate(expr, var) computes an antiderivative when supported. Example: integrate(x^2, x);",
+    ),
+    (
+        "solve",
+        "solve(expr, var) solves equations or supported inequalities. Use linsolve([...], [...]) for linear systems and nsolve(poly, var) for numeric polynomial roots.",
+    ),
+    (
+        "matrix",
+        "Matrix tools: matrix([...], ...), transpose, determinant, invert, dot, rank, rowreduce, ident, zeromatrix, and matrix_size.",
+    ),
+    (
+        "lists",
+        "List tools: length, first, rest, last, append, reverse, range, map, apply, sublist, sort, part, flatten, join, and makelist.",
+    ),
+    (
+        "assumptions",
+        "Assumptions: assume(x > 0), declare(x, positive), is(x > 0), forget(), properties(x), and propvars().",
+    ),
+    (
+        "properties",
+        "properties(symbol) lists declared properties. propvars() lists symbols with declared properties.",
+    ),
+    (
+        "display",
+        "Display: terminate with ; to show output and $ to suppress it. ev(expr, display2d) renders 2D output.",
+    ),
+    (
+        "history",
+        "History: % is the last output; %iN and %oN refer to input and output number N.",
+    ),
+    (
+        "showtime",
+        "showtime:true enables per-expression timing; showtime:false disables it.",
+    ),
+    (
+        "repl",
+        "REPL commands: :quit exits. Use --file path.mac for batch execution.",
+    ),
+];
+
+const MACSYMA_HELP_ALIASES: &[(&str, &str)] = &[
+    ("d", "diff"),
+    ("derivative", "diff"),
+    ("integral", "integrate"),
+    ("matrices", "matrix"),
+    ("list", "lists"),
+    ("assume", "assumptions"),
+    ("declare", "assumptions"),
+    ("propvars", "properties"),
+    ("display2d", "display"),
+    ("%", "history"),
+    ("timing", "showtime"),
+    ("quit", "repl"),
+];
+
+/// Return the requested topic for a MACSYMA `?` help query.
+pub fn parse_macsyma_help_query(source: &str) -> Option<String> {
+    let stripped = source.trim();
+    if !stripped.starts_with('?') {
+        return None;
+    }
+    let mut topic = stripped.trim_start_matches('?').trim().to_string();
+    if topic.ends_with(';') || topic.ends_with('$') {
+        topic.truncate(topic.len() - 1);
+        topic = topic.trim().to_string();
+    }
+    Some(topic)
+}
+
+/// Return user-facing MACSYMA help text for `topic`.
+pub fn macsyma_help_text(topic: Option<&str>) -> String {
+    let raw_key = topic.unwrap_or("").trim().to_ascii_lowercase();
+    if raw_key.is_empty() {
+        return format!(
+            "MACSYMA help topics: {}. Use ? topic for details.",
+            sorted_help_topics().join(", ")
+        );
+    }
+    let key = MACSYMA_HELP_ALIASES
+        .iter()
+        .find_map(|(alias, target)| (*alias == raw_key).then_some(*target))
+        .unwrap_or(raw_key.as_str());
+    if let Some((_, text)) = MACSYMA_HELP_TOPICS.iter().find(|(name, _)| *name == key) {
+        return (*text).to_string();
+    }
+    format!(
+        "No MACSYMA help topic named {:?}. Available topics: {}.",
+        topic.unwrap_or(""),
+        sorted_help_topics().join(", ")
+    )
+}
+
+fn sorted_help_topics() -> Vec<&'static str> {
+    let mut topics = MACSYMA_HELP_TOPICS
+        .iter()
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>();
+    topics.sort_unstable();
+    topics
+}
 
 /// One evaluated MACSYMA statement.
 #[derive(Debug, Clone, PartialEq)]
@@ -558,6 +674,9 @@ impl MacsymaSession {
 
     /// Compile and evaluate every statement in `source`.
     pub fn eval_source(&mut self, source: &str) -> Result<Vec<EvalResult>, CompileError> {
+        if let Some(topic) = parse_macsyma_help_query(source) {
+            return Ok(vec![self.eval_help_query(&topic)]);
+        }
         let statements = compile_macsyma_with_options(
             source,
             CompileOptions {
@@ -603,6 +722,28 @@ impl MacsymaSession {
             output_text,
             display,
             timing_text: show_timing.then(|| format_timing(elapsed.as_secs_f64())),
+        }
+    }
+
+    fn eval_help_query(&mut self, topic: &str) -> EvalResult {
+        let query = if topic.is_empty() {
+            "?".to_string()
+        } else {
+            format!("? {topic}")
+        };
+        let text = macsyma_help_text(Some(topic));
+        let input = str_node(query);
+        let output = str_node(text.clone());
+        let input_index = self.history.record_input(input.clone());
+        let output_index = self.history.record_output(output.clone());
+        EvalResult {
+            input_index,
+            output_index,
+            input,
+            output,
+            output_text: text,
+            display: true,
+            timing_text: None,
         }
     }
 }

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -1,7 +1,7 @@
 use cas_solve::SOLVE;
 use coding_adventures_macsyma_runtime::{
-    extend_macsyma_name_table, macsyma_name_table, MacsymaSession, DECLARE, EV, KILL, PROPERTIES,
-    PROP_VARS,
+    extend_macsyma_name_table, macsyma_help_text, macsyma_name_table, parse_macsyma_help_query,
+    MacsymaSession, DECLARE, EV, KILL, PROPERTIES, PROP_VARS,
 };
 use std::collections::HashMap;
 use symbolic_ir::{
@@ -52,6 +52,34 @@ fn reports_showtime_diagnostics_for_suppressed_statements() {
     assert_eq!(results[1].output, int(5));
     assert!(!results[1].display);
     assert_timing_text(results[1].timing_text.as_deref());
+}
+
+#[test]
+fn parses_and_renders_question_mark_help() {
+    assert_eq!(
+        parse_macsyma_help_query("? solve;").as_deref(),
+        Some("solve")
+    );
+    assert_eq!(parse_macsyma_help_query("solve(x, x);"), None);
+    assert!(macsyma_help_text(Some("solve")).contains("solve(expr, var)"));
+
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("? solve").unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].display);
+    assert!(results[0].output_text.contains("solve(expr, var)"));
+    assert!(matches!(results[0].input, symbolic_ir::IRNode::Str(_)));
+    assert!(matches!(results[0].output, symbolic_ir::IRNode::Str(_)));
+}
+
+#[test]
+fn question_mark_without_topic_lists_help_topics() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("?").unwrap();
+
+    assert!(results[0].output_text.contains("MACSYMA help topics:"));
+    assert!(results[0].output_text.contains("solve"));
 }
 
 #[test]

--- a/code/packages/rust/macsyma-wasm/src/lib.rs
+++ b/code/packages/rust/macsyma-wasm/src/lib.rs
@@ -329,6 +329,17 @@ mod tests {
     }
 
     #[test]
+    fn reports_help_queries_as_json_visible_output() {
+        let payload = json(&eval_source_json("? solve"));
+        assert_eq!(payload["ok"], true);
+        assert!(payload["visible_outputs"][0]
+            .as_str()
+            .unwrap()
+            .contains("solve(expr, var)"));
+        assert_eq!(payload["results"][0]["output_ir"]["kind"], "string");
+    }
+
+    #[test]
     fn can_reset_history_without_recreating_session() {
         let mut session = MacsymaWasmSession::new();
         session.eval_json("1; 2;");

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `?` / `? topic` help-query handling for TypeScript MACSYMA sessions and
+  JSON responses.
 - Wire `assume`, `forget`, `is`, `declare`, `properties`, and `propvars` to a
   TypeScript MACSYMA session assumption context so declared properties feed
   property queries and assumption-backed relation checks.

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -53,6 +53,7 @@ import {
   app,
   equals,
   numberNode,
+  stringNode,
   sym,
   toDisplayString,
   type IRApply,
@@ -231,6 +232,58 @@ export const MACSYMA_NAME_TABLE: ReadonlyMap<string, IRSymbol> = new Map<string,
   ["fresnel_c", sym("FresnelC")],
   ["lambert_w", sym("LambertW")],
 ]);
+
+const MACSYMA_HELP_TOPICS: Readonly<Record<string, string>> = Object.freeze({
+  arithmetic: "Arithmetic: use +, -, *, /, and ^. Example: expand((x + 1)^2);",
+  calculus: "Calculus: diff(expr, var), integrate(expr, var), limit(expr, var, point), and taylor(expr, var, point, order).",
+  diff: "diff(expr, var) differentiates expr with respect to var. Example: diff(x^3, x);",
+  integrate: "integrate(expr, var) computes an antiderivative when supported. Example: integrate(x^2, x);",
+  solve: "solve(expr, var) solves equations or supported inequalities. Use linsolve([...], [...]) for linear systems and nsolve(poly, var) for numeric polynomial roots.",
+  matrix: "Matrix tools: matrix([...], ...), transpose, determinant, invert, dot, rank, rowreduce, ident, zeromatrix, and matrix_size.",
+  lists: "List tools: length, first, rest, last, append, reverse, range, map, apply, sublist, sort, part, flatten, join, and makelist.",
+  assumptions: "Assumptions: assume(x > 0), declare(x, positive), is(x > 0), forget(), properties(x), and propvars().",
+  properties: "properties(symbol) lists declared properties. propvars() lists symbols with declared properties.",
+  display: "Display: terminate with ; to show output and $ to suppress it. ev(expr, display2d) renders 2D output.",
+  history: "History: % is the last output; %iN and %oN refer to input and output number N.",
+  showtime: "showtime:true enables per-expression timing; showtime:false disables it.",
+  repl: "REPL commands: :quit exits. Use --file path.mac for batch execution.",
+});
+
+const MACSYMA_HELP_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  d: "diff",
+  derivative: "diff",
+  integral: "integrate",
+  matrices: "matrix",
+  list: "lists",
+  assume: "assumptions",
+  declare: "assumptions",
+  propvars: "properties",
+  display2d: "display",
+  "%": "history",
+  timing: "showtime",
+  quit: "repl",
+});
+
+export function parseMacsymaHelpQuery(source: string): string | undefined {
+  const stripped = source.trim();
+  if (!stripped.startsWith("?")) return undefined;
+  let topic = stripped.replace(/^\?+/, "").trim();
+  if (topic.endsWith(";") || topic.endsWith("$")) {
+    topic = topic.slice(0, -1).trim();
+  }
+  return topic;
+}
+
+export function macsymaHelpText(topic = ""): string {
+  const rawKey = topic.trim().toLowerCase();
+  if (rawKey === "") {
+    return `MACSYMA help topics: ${Object.keys(MACSYMA_HELP_TOPICS).sort().join(", ")}. Use ? topic for details.`;
+  }
+  const key = MACSYMA_HELP_ALIASES[rawKey] ?? rawKey;
+  const text = MACSYMA_HELP_TOPICS[key];
+  if (text !== undefined) return text;
+  return `No MACSYMA help topic named ${JSON.stringify(topic)}. Available topics: ${Object.keys(MACSYMA_HELP_TOPICS).sort().join(", ")}.`;
+}
 
 export type CompilerNameTableTarget =
   | Map<string, IRSymbol>
@@ -436,6 +489,10 @@ export class MacsymaSession {
   }
 
   evalSource(source: string): EvalResult[] {
+    const helpTopic = parseMacsymaHelpQuery(source);
+    if (helpTopic !== undefined) {
+      return [this.evalHelpQuery(helpTopic)];
+    }
     return this.evalStatements(compileMacsyma(source, { wrapTerminators: true }));
   }
 
@@ -475,6 +532,23 @@ export class MacsymaSession {
       outputText,
       display,
       ...(showTiming ? { timingText: formatTiming(elapsedSeconds) } : {}),
+    };
+  }
+
+  private evalHelpQuery(topic: string): EvalResult {
+    const query = topic === "" ? "?" : `? ${topic}`;
+    const text = macsymaHelpText(topic);
+    const input = stringNode(query);
+    const output = stringNode(text);
+    const inputIndex = this.sessionHistory.recordInput(input);
+    const outputIndex = this.sessionHistory.recordOutput(output);
+    return {
+      inputIndex,
+      outputIndex,
+      input,
+      output,
+      outputText: text,
+      display: true,
     };
   }
 }

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -62,6 +62,8 @@ import {
   TRIG_SIMPLIFY,
   extendCompilerNameTable,
   evalSourceJson,
+  macsymaHelpText,
+  parseMacsymaHelpQuery,
 } from "../src/index.js";
 
 describe("macsyma-runtime", () => {
@@ -174,6 +176,28 @@ describe("macsyma-runtime", () => {
     expect(result.display).toBe(false);
     expect(result.timingText).toMatch(/^Evaluation took \d+\.\d{6} seconds\.$/);
     expect(payload.visibleOutputs).toEqual([result.timingText]);
+  });
+
+  it("parses and renders MACSYMA question-mark help", () => {
+    expect(parseMacsymaHelpQuery("? solve;")).toBe("solve");
+    expect(parseMacsymaHelpQuery("solve(x, x);")).toBeUndefined();
+    expect(macsymaHelpText("solve")).toContain("solve(expr, var)");
+
+    const session = new MacsymaSession();
+    const [result] = session.evalSource("? solve");
+
+    expect(result.display).toBe(true);
+    expect(result.outputText).toContain("solve(expr, var)");
+    expect(result.input.kind).toBe("string");
+    expect(result.output.kind).toBe("string");
+  });
+
+  it("includes question-mark help in JSON visible outputs", () => {
+    const payload = JSON.parse(evalSourceJson("?"));
+
+    expect(payload.ok).toBe(true);
+    expect(payload.visibleOutputs[0]).toContain("MACSYMA help topics:");
+    expect(payload.results[0].outputText).toContain("MACSYMA help topics:");
   });
 
   it("records and resolves history references", () => {

--- a/code/programs/python/macsyma-repl/CHANGELOG.md
+++ b/code/programs/python/macsyma-repl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added `?` / `? topic` help queries backed by the shared MACSYMA help catalog.
 - Route visible REPL output through `macsyma_runtime.output_text_for(...)`, so
   `ev(expr, display2d)` displays the 2D MACSYMA box layout in interactive and
   `--file` execution.

--- a/code/programs/python/macsyma-repl/language.py
+++ b/code/programs/python/macsyma-repl/language.py
@@ -28,7 +28,9 @@ from macsyma_runtime import (
     History,
     MacsymaBackend,
     extend_compiler_name_table,
+    help_text,
     output_text_for,
+    parse_help_query,
 )
 from symbolic_ir import IRApply, IRNode, IRSymbol
 from symbolic_vm import VM
@@ -82,6 +84,9 @@ class MacsymaLanguage(Language):
             return ("ok", None)
         if stripped.lower() in _QUIT_COMMANDS:
             return "quit"
+        help_topic = parse_help_query(stripped)
+        if help_topic is not None:
+            return ("ok", help_text(help_topic))
 
         # Auto-append ``;`` so a line typed without a terminator still
         # parses (better UX than rejecting valid expressions).

--- a/code/programs/python/macsyma-repl/tests/test_session.py
+++ b/code/programs/python/macsyma-repl/tests/test_session.py
@@ -149,6 +149,20 @@ def test_auto_terminator_appended() -> None:
     assert any(line == "(%o1) 5" for line in out)
 
 
+def test_question_mark_help_lists_topics() -> None:
+    out = _output_lines(_run(["?", ":quit"]))
+
+    assert any("MACSYMA help topics:" in line for line in out)
+    assert any("solve" in line for line in out)
+
+
+def test_question_mark_help_topic() -> None:
+    out = _output_lines(_run(["? solve", ":quit"]))
+
+    assert any("solve(expr, var)" in line for line in out)
+    assert not any(line.startswith("(%o1)") for line in out)
+
+
 def test_showtime_appends_timing_after_displayed_statement() -> None:
     out = _output_lines(_run(["showtime:true$", "2 + 3;", ":quit"]))
 

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -241,7 +241,7 @@ The Risch integration suite is ~85% complete. Known remaining gaps:
 | Feature | Notes |
 |---|---|
 | **Friendly error messages** | Python, TypeScript, and Rust MACSYMA syntax failures now surface as `Incorrect syntax ...` diagnostics with line/column and a caret where parser token metadata is available. |
-| **`?` help system** | No documentation lookup. A thin wrapper over docstrings would cover most cases. |
+| **`?` help system** | Python, TypeScript, and Rust sessions support `?` and `? topic` with a small curated help catalog for core runtime/CAS topics. |
 | **`showtime`** | Python, TypeScript, and Rust sessions support `showtime:true` / `showtime:false` wall-clock timing per expression, including suppressed statements. |
 
 ---


### PR DESCRIPTION
## Summary
- add a curated MACSYMA help catalog and `?` / `? topic` parsing helpers
- wire help queries through Python REPL, TypeScript sessions/JSON, and Rust sessions/WASM JSON
- update the SPICE/MACSYMA pending-work spec to mark the help-system item covered

## Validation
- `bash BUILD` from `code/packages/python/macsyma-runtime`
- `bash BUILD` from `code/programs/python/macsyma-repl`
- `npm ci && npm test && npm run build` from `code/packages/typescript/macsyma-runtime`
- `cargo test -p coding-adventures-macsyma-runtime` from `code/packages/rust`
- `cargo fmt -p coding-adventures-macsyma-runtime -p coding-adventures-macsyma-wasm` from `code/packages/rust`
- `cargo test -p coding-adventures-macsyma-wasm` from `code/packages/rust`
- `go run . -root ../../../.. -diff-base origin/main -validate-build-files -detect-languages -emit-plan /tmp/ca-build-plan-macsyma-help-system.json` from `code/programs/go/build-tool`
- `git diff --check`