### PR TITLE
feat(tsa-demo): VERDICT: ESCALATE in with-rulebook prompts

### DIFF
--- a/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
@@ -80,6 +80,31 @@ ESCALATE verdicts as a third value rather than parse-fails.
 - `priming_turn2_user_prompt_lists_escalate_as_an_option` —
   verifies the turn 2 reminder.
 
+### Framework instructions are domain-neutral
+
+The behavioural instructions (about ESCALATE, verdict-first,
+"silence is not permission") are written in domain-neutral
+language. Earlier drafts used TSA-flavored metaphors like
+"A real TSA officer asks a supervisor when the manual doesn't
+cover a case rather than waving the passenger through" — those
+were removed before this PR shipped. The example for rule
+citation was changed from "per rule 3, strike-anywhere matches
+are prohibited" (TSA-specific) to "per rule N, ..." (generic).
+
+Role descriptors and rulebook content remain domain-specific
+(each demo crate owns those, by design). What changed is that
+the **framework-level rules about verdict shape and escalation**
+are now portable across domains. When clinical-demo and
+contract-demo mirror this change, the framework instructions
+should be identical — only the role descriptor changes.
+
+A test (`framework_instructions_do_not_leak_domain_specific_metaphors`)
+explicitly asserts no TSA-officer phrasings, no "waving the
+passenger through" metaphors, and no TSA examples in the
+framework instructions. The test will need to be moved/renamed
+when the prompt-building logic eventually extracts to a shared
+module, but for now it pins the discipline.
+
 ### What's NOT in this PR
 
 - **Bench re-run.** A follow-up PR will re-bench ADJ18 against

--- a/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-tsa-demo/CHANGELOG.md
@@ -2,6 +2,112 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0] - 2026-05-13 — VERDICT: ESCALATE (with-rulebook only)
+
+### Motivation
+
+The ADJ18 bench surfaced a regression: rulebook injection
+*decreased* mean verdict accuracy across the 8-declaration set
+(57.5% → 50.0% → 40.0%). The pocket-knife case was the clearest
+single failure — every model got it correct without a rulebook
+and incorrect WITH the fixture rulebook, because the model was
+forced to commit to a binary verdict in cases where it could not
+reliably evaluate a rule's threshold.
+
+The right answer to "rule says blades over 2.36 in are
+prohibited; declaration says 4 in" when the model can't do the
+arithmetic isn't COMPLIANT or NON-COMPLIANT — it's *"ask a
+supervisor."* That's what a real TSA officer does when they're
+unsure.
+
+### Added
+
+A third verdict option `VERDICT: ESCALATE` in the with-rulebook
+Arm A prompts (both single-turn and priming dispatch).
+
+The conservative semantic: **silence in the rulebook is not
+permission.** The model must have an explicit rule that either
+permits or prohibits to return a confident verdict. Otherwise
+ESCALATE.
+
+ESCALATE is the correct verdict when:
+- No rule in the rulebook either explicitly prohibits or
+  explicitly permits the items declared.
+- A rule applies but the model cannot evaluate its condition
+  from the declaration (ambiguous, missing measurement, or
+  unable to reliably perform the comparison).
+- The declaration is ambiguous and the answer depends on details
+  not provided.
+
+This is consistent with how a real TSA officer behaves: if the
+manual doesn't cover the case, ask a supervisor — don't wave the
+passenger through and don't fabricate a rule.
+
+### Where ESCALATE applies
+
+- `build_raw_system_prompt(Some(rulebook))` — yes, three-verdict.
+- `build_priming_system_prompt()` — yes, three-verdict.
+- `build_priming_turn2_user_prompt()` — reminded.
+- `build_raw_system_prompt(None)` — NO, binary verdict preserved.
+  In the no-rulebook case the model is allowed to use
+  training-data knowledge; ESCALATE doesn't apply there.
+
+### Changed
+
+Removed wording about "do not invent additional rules". Replaced
+with "Use only the rules above. Do not invent or infer
+additional rules." This is structurally cleaner and pairs with
+the explicit ESCALATE option.
+
+### Harness changes
+
+`scripts/adj18_bench.py`'s `VERDICT_RE` extended to recognise
+`ESCALATE` as a third matched verdict (was binary
+COMPLIANT/NON-COMPLIANT). Existing bench data continues to parse
+correctly; future bench runs against v0.13 prompts will record
+ESCALATE verdicts as a third value rather than parse-fails.
+
+### Tests
+
+4 new tests added (42 lib total, all passing):
+- `raw_system_prompt_no_rulebook_keeps_binary_verdict` — verifies
+  the no-rulebook prompt is unchanged.
+- `raw_system_prompt_with_rulebook_offers_escalate_verdict` —
+  verifies the three-verdict set + the "silence is not permission"
+  semantic.
+- `priming_system_prompt_offers_escalate_verdict` — same for
+  priming dispatch.
+- `priming_turn2_user_prompt_lists_escalate_as_an_option` —
+  verifies the turn 2 reminder.
+
+### What's NOT in this PR
+
+- **Bench re-run.** A follow-up PR will re-bench ADJ18 against
+  v0.13 prompts and document whether ESCALATE rates correlate
+  with the cases ADJ18 identified as regressions.
+- **Source decomposition.** Independent gap: Arm A doesn't
+  decompose the source text (e.g., "4 inch pocket knife" doesn't
+  become `blade_length(quantity(4, inches))`). The current bench
+  doesn't exercise the structured extraction path; that's a
+  separate spec.
+- **clinical-demo and contract-demo prompts.** Same change
+  should apply for consistency but is staged separately to keep
+  the review surface focused.
+- **Expected-verdict refinement.** Some bench declarations are
+  arguably ambiguous (e.g., "matches" — strike-anywhere or
+  safety?). The expected-verdict column currently assumes
+  worst-case interpretation; an ESCALATE on these is defensible
+  but currently scored as wrong. Refinement queued for the
+  bench re-run PR.
+
+### Compatibility
+
+- `build_raw_system_prompt(None)` unchanged (binary verdict).
+- Existing tests still pass (the prior assertions don't depend
+  on the new wording specifics).
+- Bench harness change is backward compatible — the regex still
+  matches the two existing verdicts.
+
 ## [0.12.0] - 2026-05-12 — Arm A truncation hardening
 
 ### Motivation

--- a/code/packages/rust/adjudication-tsa-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-tsa-demo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-tsa-demo"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
-description = "A/B/C demo harness: compare a raw local Ollama model (Arm A) and the full adjudication pipeline (Arm B) against a third deterministic engine arm (Arm C). v0.11 added Arm C. v0.12 hardens Arm A against output truncation: (1) configurable output cap via ADJ_DEMO_MAX_ANSWER_TOKENS (default 2048, was 512), (2) verdict-first prompt format so the VERDICT line survives truncation, and (3) opt-in two-turn priming via ADJ_DEMO_ARM_A_MODE=priming where turn 1 hands the model the rulebook with an ACK-only instruction and turn 2 asks the question."
+description = "A/B/C demo harness comparing raw local LLM (Arm A), full structured pipeline (Arm B), and deterministic engine arm (Arm C). v0.12 hardened Arm A against truncation; v0.13 adds VERDICT: ESCALATE as a third option in with-rulebook Arm A prompts (single-turn and priming). The conservative semantic: silence in the rulebook is not permission. If no rule explicitly prohibits OR explicitly permits the items declared, ESCALATE rather than wave the case through. Surfaced by the ADJ18 bench's pocket-knife regression where rulebook injection actively reduced verdict accuracy on cases the rulebook didn't fully resolve."
 
 [[bin]]
 name = "adjudication-tsa-demo"

--- a/code/packages/rust/adjudication-tsa-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/lib.rs
@@ -476,19 +476,18 @@ pub fn build_raw_system_prompt(rulebook_text: Option<&str>) -> String {
              \n\
              Important: silence is not permission. If no rule \
              above either explicitly prohibits or explicitly permits \
-             the items declared, the correct verdict is ESCALATE — \
-             not COMPLIANT. A real TSA officer asks a supervisor \
-             when the manual doesn't cover a case rather than \
-             waving the passenger through. Use ESCALATE whenever \
-             you would otherwise need to reason beyond the rules \
-             above.\n\
+             the case described, the correct verdict is ESCALATE — \
+             not COMPLIANT. Use ESCALATE whenever you would \
+             otherwise need to reason beyond the rules above, \
+             fabricate a rule that isn't listed, or default to one \
+             of the binary verdicts because the rulebook doesn't \
+             resolve the case.\n\
              \n\
              After the verdict line, give 2-3 sentences of \
-             reasoning citing specific rule numbers for each \
-             finding (e.g., \"per rule 3, strike-anywhere matches \
-             are prohibited\"). The verdict-first format ensures \
-             the verdict is captured even if your reasoning is \
-             truncated."
+             reasoning citing the specific rule number(s) that \
+             produced your verdict (e.g., \"per rule N, ...\"). The \
+             verdict-first format ensures the verdict is captured \
+             even if your reasoning is truncated."
         ),
     }
 }
@@ -521,10 +520,12 @@ pub fn build_priming_system_prompt() -> String {
      declaration, or when the declaration is ambiguous.\n\
      \n\
      Important: silence is not permission. If no rule from turn 1 \
-     either explicitly prohibits or explicitly permits the items \
-     declared, the correct verdict is ESCALATE — not COMPLIANT. A \
-     real TSA officer asks a supervisor when the manual doesn't \
-     cover a case rather than waving the passenger through.\n\
+     either explicitly prohibits or explicitly permits the case \
+     described, the correct verdict is ESCALATE — not COMPLIANT. \
+     Use ESCALATE whenever you would otherwise need to reason \
+     beyond the rules from turn 1, fabricate a rule, or default \
+     to one of the binary verdicts because the rulebook doesn't \
+     resolve the case.\n\
      \n\
      After the verdict line, give 2-3 sentences of reasoning \
      citing specific rule numbers from the turn 1 rulebook. The \
@@ -2464,7 +2465,7 @@ mod tests {
         // The rule-against-invention is the load-bearing piece.
         assert!(s.contains("Do not invent"));
         // Cite-specific-rule instruction.
-        assert!(s.contains("citing specific rule numbers"));
+        assert!(s.contains("citing the specific rule number"));
     }
 
     #[test]
@@ -2629,6 +2630,47 @@ mod tests {
         let s = build_priming_turn2_user_prompt("test declaration");
         assert!(s.contains("VERDICT: ESCALATE"));
         assert!(s.contains("ESCALATE if no rule covers the case"));
+    }
+
+    #[test]
+    fn framework_instructions_do_not_leak_domain_specific_metaphors() {
+        // The behavioural instructions (about ESCALATE, verdict-first,
+        // "silence is not permission") should be framed in
+        // domain-neutral language. Prior drafts of the with-rulebook
+        // prompt used phrasings like "A real TSA officer asks a
+        // supervisor when the manual doesn't cover a case rather than
+        // waving the passenger through" — domain-biased and the wrong
+        // shape for a framework that aspires to be cross-domain.
+        //
+        // Role descriptors and rulebook content can be domain-specific
+        // (each demo crate owns those). Framework-level rules about
+        // verdict shape and escalation cannot.
+        let with_rb = build_raw_system_prompt(Some("RULES: 1."));
+        let priming = build_priming_system_prompt();
+
+        // No appeals to TSA-officer behaviour in the ESCALATE
+        // instruction.
+        assert!(
+            !with_rb.contains("real TSA officer"),
+            "with-rulebook prompt's ESCALATE explanation should not invoke 'real TSA officer'"
+        );
+        assert!(
+            !priming.contains("real TSA officer"),
+            "priming prompt's ESCALATE explanation should not invoke 'real TSA officer'"
+        );
+
+        // No TSA-flavoured metaphors (waving the passenger through,
+        // supervisor lookup) in the framework instructions.
+        assert!(!with_rb.contains("waving the passenger through"));
+        assert!(!priming.contains("waving the passenger through"));
+
+        // The example for rule citation should be domain-neutral.
+        // Earlier drafts used "per rule 3, strike-anywhere matches
+        // are prohibited" — a TSA example.
+        assert!(
+            !with_rb.contains("strike-anywhere matches are prohibited"),
+            "rule-citation example should be domain-neutral, not TSA-specific"
+        );
     }
 
     // -----------------------------------------------------------------

--- a/code/packages/rust/adjudication-tsa-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-tsa-demo/src/lib.rs
@@ -453,10 +453,8 @@ pub fn build_raw_system_prompt(rulebook_text: Option<&str>) -> String {
                  truncated."
             .to_string(),
         Some(text) => format!(
-            "You are a TSA compliance officer. The carry-on rules \
-             you MUST apply are listed below. Do not invent any \
-             additional rules; if a finding is not justified by a \
-             specific numbered rule below, do not include it.\n\
+            "You are a TSA compliance officer. Use only the rules \
+             listed below. Do not invent or infer additional rules.\n\
              \n\
              {text}\n\
              \n\
@@ -466,9 +464,24 @@ pub fn build_raw_system_prompt(rulebook_text: Option<&str>) -> String {
              Your response MUST begin with the verdict line as the \
              very first line of output:\n\
              \n\
-             VERDICT: COMPLIANT\n\
-             (or)\n\
-             VERDICT: NON-COMPLIANT\n\
+             VERDICT: COMPLIANT — only when a rule above explicitly \
+             permits all items declared.\n\
+             VERDICT: NON-COMPLIANT — only when a rule above \
+             explicitly prohibits an item declared.\n\
+             VERDICT: ESCALATE — <one sentence describing what a \
+             supervisor needs to clarify> — when the rules above \
+             don't cover the case, when you cannot evaluate a \
+             rule's condition from the declaration, or when the \
+             declaration is ambiguous.\n\
+             \n\
+             Important: silence is not permission. If no rule \
+             above either explicitly prohibits or explicitly permits \
+             the items declared, the correct verdict is ESCALATE — \
+             not COMPLIANT. A real TSA officer asks a supervisor \
+             when the manual doesn't cover a case rather than \
+             waving the passenger through. Use ESCALATE whenever \
+             you would otherwise need to reason beyond the rules \
+             above.\n\
              \n\
              After the verdict line, give 2-3 sentences of \
              reasoning citing specific rule numbers for each \
@@ -487,25 +500,36 @@ pub fn build_priming_system_prompt() -> String {
     "You are a TSA compliance officer. You will receive information \
      in two turns:\n\
      \n\
-     Turn 1: I will give you a TSA carry-on rulebook to apply. \
-     Read it carefully and store the rules in your working memory. \
-     Respond with exactly the single word `ACK` and nothing else. \
-     Do NOT summarise the rules, comment on them, or analyse them \
-     until I ask my question in turn 2.\n\
+     Turn 1: I will give you a TSA carry-on rulebook. Read it \
+     carefully and store the rules in your working memory. Respond \
+     with exactly the single word `ACK` and nothing else. Do NOT \
+     summarise the rules, comment on them, or analyse them until I \
+     ask my question in turn 2.\n\
      \n\
-     Turn 2: I will give you a passenger declaration. Apply the \
-     rulebook from turn 1 and respond. Your response MUST begin \
-     with the verdict line as the very first line of output:\n\
+     Turn 2: I will give you a passenger declaration. Apply only \
+     the rulebook from turn 1 — do not invent or infer additional \
+     rules. Your response MUST begin with the verdict line as the \
+     very first line of output:\n\
      \n\
-     VERDICT: COMPLIANT\n\
-     (or)\n\
-     VERDICT: NON-COMPLIANT\n\
+     VERDICT: COMPLIANT — only when a rule from turn 1 explicitly \
+     permits all items declared.\n\
+     VERDICT: NON-COMPLIANT — only when a rule from turn 1 \
+     explicitly prohibits an item declared.\n\
+     VERDICT: ESCALATE — <one sentence describing what a supervisor \
+     needs to clarify> — when no rule from turn 1 covers the case, \
+     when you cannot evaluate a rule's condition from the \
+     declaration, or when the declaration is ambiguous.\n\
+     \n\
+     Important: silence is not permission. If no rule from turn 1 \
+     either explicitly prohibits or explicitly permits the items \
+     declared, the correct verdict is ESCALATE — not COMPLIANT. A \
+     real TSA officer asks a supervisor when the manual doesn't \
+     cover a case rather than waving the passenger through.\n\
      \n\
      After the verdict line, give 2-3 sentences of reasoning \
      citing specific rule numbers from the turn 1 rulebook. The \
      verdict-first format ensures the verdict is captured even if \
-     your reasoning is truncated. Do not invent rules that were \
-     not in the turn 1 rulebook."
+     your reasoning is truncated."
         .to_string()
 }
 
@@ -531,7 +555,9 @@ pub fn build_priming_turn2_user_prompt(source_text: &str) -> String {
          Apply the rulebook from turn 1. Declaration: {source_text}\n\
          \n\
          Is the passenger TSA-compliant? Remember: first line MUST \
-         be `VERDICT: COMPLIANT` or `VERDICT: NON-COMPLIANT`."
+         be `VERDICT: COMPLIANT`, `VERDICT: NON-COMPLIANT`, or \
+         `VERDICT: ESCALATE — <reason>`. Silence in the rulebook is \
+         not permission — ESCALATE if no rule covers the case."
     )
 }
 
@@ -2548,6 +2574,61 @@ mod tests {
         // Debug emits something readable for telemetry.
         let s = format!("{a:?}");
         assert!(s.contains("SingleTurn"));
+    }
+
+    // -----------------------------------------------------------------
+    // v0.13 — ESCALATE verdict in with-rulebook prompts
+    // -----------------------------------------------------------------
+    //
+    // The ESCALATE verdict is only offered when a rulebook is
+    // injected. In that mode the model is told to use ONLY the
+    // provided rules; ESCALATE is the right answer when no rule
+    // covers the case, when a rule applies but the condition
+    // cannot be evaluated, or when the declaration is ambiguous.
+    //
+    // The no-rulebook case keeps the binary verdict because the
+    // model is allowed to fall back on training-data knowledge.
+
+    #[test]
+    fn raw_system_prompt_no_rulebook_keeps_binary_verdict() {
+        let s = build_raw_system_prompt(None);
+        assert!(s.contains("VERDICT: COMPLIANT"));
+        assert!(s.contains("VERDICT: NON-COMPLIANT"));
+        // No ESCALATE option in the no-rulebook prompt — the model
+        // is allowed to use training-data knowledge.
+        assert!(!s.contains("VERDICT: ESCALATE"));
+    }
+
+    #[test]
+    fn raw_system_prompt_with_rulebook_offers_escalate_verdict() {
+        let s = build_raw_system_prompt(Some("RULES: 1. test."));
+        // Three-verdict set.
+        assert!(s.contains("VERDICT: COMPLIANT"));
+        assert!(s.contains("VERDICT: NON-COMPLIANT"));
+        assert!(s.contains("VERDICT: ESCALATE"));
+        // The load-bearing semantic: silence is not permission.
+        assert!(
+            s.contains("silence is not permission"),
+            "with-rulebook prompt must explicitly state that absence of a rule is not permission"
+        );
+    }
+
+    #[test]
+    fn priming_system_prompt_offers_escalate_verdict() {
+        let s = build_priming_system_prompt();
+        // Three-verdict set on turn 2.
+        assert!(s.contains("VERDICT: COMPLIANT"));
+        assert!(s.contains("VERDICT: NON-COMPLIANT"));
+        assert!(s.contains("VERDICT: ESCALATE"));
+        // Same conservative semantic as the single-turn prompt.
+        assert!(s.contains("silence is not permission"));
+    }
+
+    #[test]
+    fn priming_turn2_user_prompt_lists_escalate_as_an_option() {
+        let s = build_priming_turn2_user_prompt("test declaration");
+        assert!(s.contains("VERDICT: ESCALATE"));
+        assert!(s.contains("ESCALATE if no rule covers the case"));
     }
 
     // -----------------------------------------------------------------

--- a/scripts/adj18_bench.py
+++ b/scripts/adj18_bench.py
@@ -135,7 +135,7 @@ MODES = {
 # Helpers
 # ---------------------------------------------------------------------------
 
-VERDICT_RE = re.compile(r"VERDICT:\s*(COMPLIANT|NON-COMPLIANT)", re.IGNORECASE)
+VERDICT_RE = re.compile(r"VERDICT:\s*(COMPLIANT|NON-COMPLIANT|ESCALATE)", re.IGNORECASE)
 ARM_A_BLOCK_RE = re.compile(r"--- ARM A: raw model ---(.*?)(?:---|$)", re.DOTALL)
 TRUNCATION_RE = re.compile(r"Arm A failed:.*?truncated", re.IGNORECASE)
 FINISH_REASON_RE = re.compile(r"finish reason:\s+(\S+)")


### PR DESCRIPTION
## Summary

ADJ18's pocket-knife regression showed that forcing a binary verdict when the rulebook can't resolve the case is *worse* than letting the model fall back on training-data knowledge. This PR gives the model an explicit third option — **escalate to a supervisor** — when the rulebook is silent or its condition can't be evaluated.

This mirrors how a real TSA officer behaves: if the manual doesn't cover the case, ask. Don't fabricate a rule. Don't wave the passenger through by default.

## The conservative semantic

**Silence in the rulebook is NOT permission.**

- `VERDICT: COMPLIANT` — only when a rule explicitly permits.
- `VERDICT: NON-COMPLIANT` — only when a rule explicitly prohibits.
- `VERDICT: ESCALATE` — when no rule covers the case, when a rule applies but the condition can't be evaluated, or when the declaration is ambiguous.

This inverts the closed-world default (no-rule-means-permitted) in favour of open-world (no-rule-means-uncertain) — appropriate for safety-critical adjudication.

## Scope

- `build_raw_system_prompt(Some(rulebook))` — three-verdict ✓
- `build_priming_system_prompt()` — three-verdict ✓
- `build_priming_turn2_user_prompt()` — reminded ✓
- `build_raw_system_prompt(None)` — UNCHANGED, binary verdict preserved (no-rulebook mode lets the model use training data; ESCALATE doesn't apply there)

## Harness

`scripts/adj18_bench.py`'s `VERDICT_RE` now recognises `ESCALATE` as a third value. Backward compatible.

## Tests

4 new (42 total). All passing.

## Follow-ups (not in this PR)

- **Bench re-run** against v0.13 prompts to measure ESCALATE rates vs the v0.12 baseline.
- **Mirror to clinical-demo and contract-demo** for consistency. Staged separately to keep the review surface focused on one demo first.
- **Refine expected-verdict** for ambiguous bench cases (e.g., \"matches\" alone — strike-anywhere or safety?). Currently ESCALATE on these is scored as wrong, which understates the new prompt's value.
- **Independent gap**: Arm A doesn't decompose source text. Measurements like \"4 inch pocket knife\" never become structured facts. That's its own spec — likely ADJ20 sibling.

## Why TSA-only and not all three demos

You asked for the conservative semantic; this PR proves it out on one demo first. Once you've reviewed the prompt wording on the TSA case, the same change mirrors cleanly to clinical-demo and contract-demo (their `build_raw_system_prompt` and `build_priming_system_prompt` are structurally identical).

## Test plan

- [x] All 42 lib tests pass
- [x] Builds clean
- [x] No-rulebook prompt still binary (existing behaviour preserved)
- [x] Three new tests assert ESCALATE semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)