### PR TITLE
feat(clinical+contract demos): mirror ESCALATE verdict from tsa-demo v0.13

### DIFF
--- a/code/packages/rust/adjudication-clinical-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-clinical-demo/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-05-13 — VERDICT: ESCALATE (mirrors tsa-demo v0.13)
+
+### Added
+
+Mirrors [tsa-demo v0.13](../adjudication-tsa-demo/CHANGELOG.md):
+adds `VERDICT: ESCALATE` as a third option in with-rulebook Arm A
+prompts.
+
+Conservative semantic: silence in the rulebook is not permission.
+If no rule explicitly supports discharge or indicates further
+evaluation, ESCALATE — not SAFE_TO_DISCHARGE.
+
+### Scope
+
+- `build_raw_system_prompt(Some(rulebook))` — three-verdict.
+- `build_priming_system_prompt()` — three-verdict.
+- `build_priming_turn2_user_prompt()` — reminded.
+- `build_raw_system_prompt(None)` — UNCHANGED, binary verdict.
+
+### Framework instructions are domain-neutral
+
+The framework-level rules match tsa-demo's wording. Role
+descriptors and rulebook content stay clinical-specific.
+
+### Tests
+
+5 new tests (20 lib total). Existing test updated for the
+"citing the specific rule number(s)" wording.
+
 ## [0.3.0] - 2026-05-13 — v0.12 parity (rulebook injection + priming)
 
 ### Added

--- a/code/packages/rust/adjudication-clinical-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-clinical-demo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-clinical-demo"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "A/B demo harness for clinical notes: run a short patient assessment through both a raw local model and the structured adjudication pipeline. v0.3 brings parity with adjudication-tsa-demo v0.12: rulebook injection (fixture_clinical_rulebook + ADJ_DEMO_RULEBOOK_MODE env var), configurable max_answer_tokens (default 2048), verdict-first prompt format, and opt-in two-turn priming dispatch (ADJ_DEMO_ARM_A_MODE=priming). Required for the ADJ19 cross-domain bench."
+description = "A/B demo harness for clinical notes. v0.3 brought parity with adjudication-tsa-demo v0.12 (rulebook injection, priming dispatch, max_answer_tokens). v0.4 mirrors tsa-demo v0.13: adds VERDICT: ESCALATE as a third option in with-rulebook Arm A prompts (single-turn and priming), with the conservative semantic that silence in the rulebook is not permission. Framework-level instructions are domain-neutral; role descriptors and rulebook content remain clinical-specific."
 
 [[bin]]
 name = "adjudication-clinical-demo"

--- a/code/packages/rust/adjudication-clinical-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-clinical-demo/src/lib.rs
@@ -296,10 +296,8 @@ pub fn build_raw_system_prompt(rulebook_text: Option<&str>) -> String {
                  your reasoning is truncated."
             .to_string(),
         Some(text) => format!(
-            "You are a primary-care triage assistant. The clinical triage \
-             rules you MUST apply are listed below. Do not invent any \
-             additional rules; if a finding is not justified by a specific \
-             numbered rule below, do not include it.\n\
+            "You are a primary-care triage assistant. Use only the rules \
+             listed below. Do not invent or infer additional rules.\n\
              \n\
              {text}\n\
              \n\
@@ -309,14 +307,27 @@ pub fn build_raw_system_prompt(rulebook_text: Option<&str>) -> String {
              Your response MUST begin with the verdict line as the very \
              first line of output:\n\
              \n\
-             VERDICT: SAFE_TO_DISCHARGE\n\
-             (or)\n\
-             VERDICT: KEEP_FOR_OBSERVATION\n\
+             VERDICT: SAFE_TO_DISCHARGE — only when a rule above explicitly \
+             supports discharge for all findings declared.\n\
+             VERDICT: KEEP_FOR_OBSERVATION — only when a rule above \
+             explicitly indicates observation or further evaluation.\n\
+             VERDICT: ESCALATE — <one sentence describing what a supervisor \
+             needs to clarify> — when the rules above don't cover the case, \
+             when you cannot evaluate a rule's condition from the \
+             assessment, or when the assessment is ambiguous.\n\
+             \n\
+             Important: silence is not permission. If no rule above either \
+             explicitly supports discharge or explicitly indicates further \
+             evaluation, the correct verdict is ESCALATE — not \
+             SAFE_TO_DISCHARGE. Use ESCALATE whenever you would otherwise \
+             need to reason beyond the rules above, fabricate a rule that \
+             isn't listed, or default to one of the binary verdicts because \
+             the rulebook doesn't resolve the case.\n\
              \n\
              After the verdict line, give 2-3 sentences of reasoning citing \
-             specific rule numbers for each finding. The verdict-first \
-             format ensures the verdict is captured even if your reasoning \
-             is truncated."
+             the specific rule number(s) that produced your verdict (e.g., \
+             \"per rule N, ...\"). The verdict-first format ensures the \
+             verdict is captured even if your reasoning is truncated."
         ),
     }
 }
@@ -335,19 +346,32 @@ pub fn build_priming_system_prompt() -> String {
      summarise the rules, comment on them, or analyse them until I \
      ask my question in turn 2.\n\
      \n\
-     Turn 2: I will give you a patient assessment. Apply the \
-     rulebook from turn 1 and respond. Your response MUST begin \
-     with the verdict line as the very first line of output:\n\
+     Turn 2: I will give you a patient assessment. Apply only the \
+     rulebook from turn 1 — do not invent or infer additional \
+     rules. Your response MUST begin with the verdict line as the \
+     very first line of output:\n\
      \n\
-     VERDICT: SAFE_TO_DISCHARGE\n\
-     (or)\n\
-     VERDICT: KEEP_FOR_OBSERVATION\n\
+     VERDICT: SAFE_TO_DISCHARGE — only when a rule from turn 1 \
+     explicitly supports discharge.\n\
+     VERDICT: KEEP_FOR_OBSERVATION — only when a rule from turn 1 \
+     explicitly indicates observation or further evaluation.\n\
+     VERDICT: ESCALATE — <one sentence describing what a supervisor \
+     needs to clarify> — when no rule from turn 1 covers the case, \
+     when you cannot evaluate a rule's condition from the \
+     assessment, or when the assessment is ambiguous.\n\
      \n\
-     After the verdict line, give 2-3 sentences of reasoning citing \
-     specific rule numbers from the turn 1 rulebook. The \
-     verdict-first format ensures the verdict is captured even if \
-     your reasoning is truncated. Do not invent rules that were not \
-     in the turn 1 rulebook."
+     Important: silence is not permission. If no rule from turn 1 \
+     either explicitly supports discharge or explicitly indicates \
+     further evaluation, the correct verdict is ESCALATE — not \
+     SAFE_TO_DISCHARGE. Use ESCALATE whenever you would otherwise \
+     need to reason beyond the rules from turn 1, fabricate a \
+     rule, or default to one of the binary verdicts because the \
+     rulebook doesn't resolve the case.\n\
+     \n\
+     After the verdict line, give 2-3 sentences of reasoning \
+     citing the specific rule number(s) from the turn 1 rulebook. \
+     The verdict-first format ensures the verdict is captured even \
+     if your reasoning is truncated."
         .to_string()
 }
 
@@ -373,7 +397,9 @@ pub fn build_priming_turn2_user_prompt(source_text: &str) -> String {
          Apply the rulebook from turn 1. Assessment: {source_text}\n\
          \n\
          Is this patient safe to discharge? Remember: first line MUST \
-         be `VERDICT: SAFE_TO_DISCHARGE` or `VERDICT: KEEP_FOR_OBSERVATION`."
+         be `VERDICT: SAFE_TO_DISCHARGE`, `VERDICT: KEEP_FOR_OBSERVATION`, \
+         or `VERDICT: ESCALATE — <reason>`. Silence in the rulebook is \
+         not permission — ESCALATE if no rule covers the case."
     )
 }
 
@@ -759,7 +785,7 @@ mod tests {
         let with_rb = build_raw_system_prompt(Some("rule x"));
         assert!(with_rb.contains("first line"));
         assert!(with_rb.contains("Do not invent"));
-        assert!(with_rb.contains("citing specific rule numbers"));
+        assert!(with_rb.contains("citing the specific rule number"));
     }
 
     #[test]
@@ -812,5 +838,75 @@ mod tests {
         assert_ne!(a, c);
         let s = format!("{a:?}");
         assert!(s.contains("SingleTurn"));
+    }
+
+    // -----------------------------------------------------------------
+    // v0.4 — ESCALATE verdict in with-rulebook prompts (mirrors tsa)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn raw_system_prompt_no_rulebook_keeps_binary_verdict() {
+        let s = build_raw_system_prompt(None);
+        assert!(s.contains("VERDICT: SAFE_TO_DISCHARGE"));
+        assert!(s.contains("VERDICT: KEEP_FOR_OBSERVATION"));
+        assert!(!s.contains("VERDICT: ESCALATE"));
+    }
+
+    #[test]
+    fn raw_system_prompt_with_rulebook_offers_escalate_verdict() {
+        let s = build_raw_system_prompt(Some("RULES: 1. test."));
+        assert!(s.contains("VERDICT: SAFE_TO_DISCHARGE"));
+        assert!(s.contains("VERDICT: KEEP_FOR_OBSERVATION"));
+        assert!(s.contains("VERDICT: ESCALATE"));
+        assert!(
+            s.contains("silence is not permission"),
+            "with-rulebook prompt must state silence-is-not-permission"
+        );
+    }
+
+    #[test]
+    fn priming_system_prompt_offers_escalate_verdict() {
+        let s = build_priming_system_prompt();
+        assert!(s.contains("VERDICT: SAFE_TO_DISCHARGE"));
+        assert!(s.contains("VERDICT: KEEP_FOR_OBSERVATION"));
+        assert!(s.contains("VERDICT: ESCALATE"));
+        assert!(s.contains("silence is not permission"));
+    }
+
+    #[test]
+    fn priming_turn2_user_prompt_lists_escalate_as_an_option() {
+        let s = build_priming_turn2_user_prompt("test assessment");
+        assert!(s.contains("VERDICT: ESCALATE"));
+        assert!(s.contains("ESCALATE if no rule covers the case"));
+    }
+
+    #[test]
+    fn framework_instructions_do_not_leak_clinical_specific_metaphors() {
+        // Same discipline as tsa-demo's framework-instruction test.
+        // The behavioural instructions about ESCALATE / verdict-first
+        // / silence-is-not-permission should be in domain-neutral
+        // language. Role descriptors and rulebook content stay
+        // domain-specific (each demo crate owns those).
+        let with_rb = build_raw_system_prompt(Some("RULES: 1."));
+        let priming = build_priming_system_prompt();
+
+        // No appeals to physician / nurse / hospital behaviour in the
+        // framework instructions about ESCALATE.
+        for needle in &[
+            "a real physician",
+            "a real nurse",
+            "a real triage officer asks",
+            "a real attending",
+            "consulting a colleague",
+        ] {
+            assert!(
+                !with_rb.contains(needle),
+                "with-rulebook prompt's framework instructions should not invoke {needle:?}"
+            );
+            assert!(
+                !priming.contains(needle),
+                "priming prompt's framework instructions should not invoke {needle:?}"
+            );
+        }
     }
 }

--- a/code/packages/rust/adjudication-contract-demo/CHANGELOG.md
+++ b/code/packages/rust/adjudication-contract-demo/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-05-13 — VERDICT: ESCALATE (mirrors tsa-demo v0.13)
+
+### Added
+
+Mirrors [tsa-demo v0.13](../adjudication-tsa-demo/CHANGELOG.md):
+adds `VERDICT: ESCALATE` as a third option in with-rulebook Arm A
+prompts.
+
+Conservative semantic: silence in the rulebook is not permission.
+If no rule explicitly affirms or excuses the obligation, ESCALATE
+— not OBLIGATION_HOLDS / OBLIGATION_EXCUSED.
+
+### Scope
+
+- `build_raw_system_prompt(Some(rulebook))` — three-verdict.
+- `build_priming_system_prompt()` — three-verdict.
+- `build_priming_turn2_user_prompt()` — reminded.
+- `build_raw_system_prompt(None)` — UNCHANGED, binary verdict.
+
+### Framework instructions are domain-neutral
+
+Framework-level rules match tsa-demo's wording. Role descriptors
+and rulebook content stay contract-specific.
+
+### Tests
+
+5 new tests (19 lib total). Existing test updated for the
+"citing the specific rule number(s)" wording.
+
 ## [0.3.0] - 2026-05-13 — v0.12 parity (rulebook injection + priming)
 
 ### Added

--- a/code/packages/rust/adjudication-contract-demo/Cargo.toml
+++ b/code/packages/rust/adjudication-contract-demo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "adjudication-contract-demo"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "A/B demo harness for contract clauses. Third domain alongside adjudication-tsa-demo and adjudication-clinical-demo; reuses the same checkers + engine to demonstrate generality. v0.3 brings parity with adjudication-tsa-demo v0.12: rulebook injection (fixture_contract_rulebook + ADJ_DEMO_RULEBOOK_MODE env var), configurable max_answer_tokens (default 2048), verdict-first prompt format, and opt-in two-turn priming dispatch. Required for the ADJ19 cross-domain bench."
+description = "A/B demo harness for contract clauses. Third domain alongside adjudication-tsa-demo and adjudication-clinical-demo. v0.3 brought parity with adjudication-tsa-demo v0.12. v0.4 mirrors tsa-demo v0.13: adds VERDICT: ESCALATE as a third option in with-rulebook Arm A prompts, with the conservative semantic that silence in the rulebook is not permission. Framework-level instructions are domain-neutral; role descriptors and rulebook content remain contract-specific."
 
 [[bin]]
 name = "adjudication-contract-demo"

--- a/code/packages/rust/adjudication-contract-demo/src/lib.rs
+++ b/code/packages/rust/adjudication-contract-demo/src/lib.rs
@@ -285,10 +285,8 @@ pub fn build_raw_system_prompt(rulebook_text: Option<&str>) -> String {
                  your reasoning is truncated."
             .to_string(),
         Some(text) => format!(
-            "You are a contract-review assistant. The contract-clause rules \
-             you MUST apply are listed below. Do not invent any additional \
-             rules; if a finding is not justified by a specific numbered rule \
-             below, do not include it.\n\
+            "You are a contract-review assistant. Use only the rules \
+             listed below. Do not invent or infer additional rules.\n\
              \n\
              {text}\n\
              \n\
@@ -298,14 +296,30 @@ pub fn build_raw_system_prompt(rulebook_text: Option<&str>) -> String {
              Your response MUST begin with the verdict line as the very \
              first line of output:\n\
              \n\
-             VERDICT: OBLIGATION_HOLDS\n\
-             (or)\n\
-             VERDICT: OBLIGATION_EXCUSED\n\
+             VERDICT: OBLIGATION_HOLDS — only when a rule above \
+             explicitly affirms the obligation.\n\
+             VERDICT: OBLIGATION_EXCUSED — only when a rule above \
+             explicitly excuses the obligation.\n\
+             VERDICT: ESCALATE — <one sentence describing what a \
+             supervisor needs to clarify> — when the rules above don't \
+             cover the case, when you cannot evaluate a rule's \
+             condition from the clause, or when the clause is \
+             ambiguous.\n\
              \n\
-             After the verdict line, give 2-3 sentences of reasoning citing \
-             specific rule numbers for each finding. The verdict-first format \
-             ensures the verdict is captured even if your reasoning is \
-             truncated."
+             Important: silence is not permission. If no rule above \
+             either explicitly affirms the obligation or explicitly \
+             excuses it, the correct verdict is ESCALATE — not one of \
+             the binary verdicts. Use ESCALATE whenever you would \
+             otherwise need to reason beyond the rules above, \
+             fabricate a rule that isn't listed, or default to one of \
+             the binary verdicts because the rulebook doesn't resolve \
+             the case.\n\
+             \n\
+             After the verdict line, give 2-3 sentences of reasoning \
+             citing the specific rule number(s) that produced your \
+             verdict (e.g., \"per rule N, ...\"). The verdict-first \
+             format ensures the verdict is captured even if your \
+             reasoning is truncated."
         ),
     }
 }
@@ -323,19 +337,32 @@ pub fn build_priming_system_prompt() -> String {
      summarise the rules, comment on them, or analyse them until I \
      ask my question in turn 2.\n\
      \n\
-     Turn 2: I will give you a contract clause. Apply the rulebook \
-     from turn 1 and respond. Your response MUST begin with the \
-     verdict line as the very first line of output:\n\
+     Turn 2: I will give you a contract clause. Apply only the \
+     rulebook from turn 1 — do not invent or infer additional \
+     rules. Your response MUST begin with the verdict line as the \
+     very first line of output:\n\
      \n\
-     VERDICT: OBLIGATION_HOLDS\n\
-     (or)\n\
-     VERDICT: OBLIGATION_EXCUSED\n\
+     VERDICT: OBLIGATION_HOLDS — only when a rule from turn 1 \
+     explicitly affirms the obligation.\n\
+     VERDICT: OBLIGATION_EXCUSED — only when a rule from turn 1 \
+     explicitly excuses the obligation.\n\
+     VERDICT: ESCALATE — <one sentence describing what a supervisor \
+     needs to clarify> — when no rule from turn 1 covers the case, \
+     when you cannot evaluate a rule's condition from the clause, \
+     or when the clause is ambiguous.\n\
      \n\
-     After the verdict line, give 2-3 sentences of reasoning citing \
-     specific rule numbers from the turn 1 rulebook. The \
-     verdict-first format ensures the verdict is captured even if \
-     your reasoning is truncated. Do not invent rules that were not \
-     in the turn 1 rulebook."
+     Important: silence is not permission. If no rule from turn 1 \
+     either explicitly affirms the obligation or explicitly excuses \
+     it, the correct verdict is ESCALATE — not one of the binary \
+     verdicts. Use ESCALATE whenever you would otherwise need to \
+     reason beyond the rules from turn 1, fabricate a rule, or \
+     default to one of the binary verdicts because the rulebook \
+     doesn't resolve the case.\n\
+     \n\
+     After the verdict line, give 2-3 sentences of reasoning \
+     citing the specific rule number(s) from the turn 1 rulebook. \
+     The verdict-first format ensures the verdict is captured even \
+     if your reasoning is truncated."
         .to_string()
 }
 
@@ -359,8 +386,10 @@ pub fn build_priming_turn2_user_prompt(source_text: &str) -> String {
          Apply the rulebook from turn 1. Contract clause: {source_text}\n\
          \n\
          Does the seller have to deliver the goods? Remember: first \
-         line MUST be `VERDICT: OBLIGATION_HOLDS` or \
-         `VERDICT: OBLIGATION_EXCUSED`."
+         line MUST be `VERDICT: OBLIGATION_HOLDS`, \
+         `VERDICT: OBLIGATION_EXCUSED`, or \
+         `VERDICT: ESCALATE — <reason>`. Silence in the rulebook is \
+         not permission — ESCALATE if no rule covers the case."
     )
 }
 
@@ -734,7 +763,7 @@ mod tests {
         let with_rb = build_raw_system_prompt(Some("rule x"));
         assert!(with_rb.contains("first line"));
         assert!(with_rb.contains("Do not invent"));
-        assert!(with_rb.contains("citing specific rule numbers"));
+        assert!(with_rb.contains("citing the specific rule number"));
     }
 
     #[test]
@@ -785,5 +814,68 @@ mod tests {
         assert_eq!(a, b);
         let c = ArmAMode::Priming;
         assert_ne!(a, c);
+    }
+
+    // -----------------------------------------------------------------
+    // v0.4 — ESCALATE verdict in with-rulebook prompts (mirrors tsa)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn raw_system_prompt_no_rulebook_keeps_binary_verdict() {
+        let s = build_raw_system_prompt(None);
+        assert!(s.contains("VERDICT: OBLIGATION_HOLDS"));
+        assert!(s.contains("VERDICT: OBLIGATION_EXCUSED"));
+        assert!(!s.contains("VERDICT: ESCALATE"));
+    }
+
+    #[test]
+    fn raw_system_prompt_with_rulebook_offers_escalate_verdict() {
+        let s = build_raw_system_prompt(Some("RULES: 1. test."));
+        assert!(s.contains("VERDICT: OBLIGATION_HOLDS"));
+        assert!(s.contains("VERDICT: OBLIGATION_EXCUSED"));
+        assert!(s.contains("VERDICT: ESCALATE"));
+        assert!(s.contains("silence is not permission"));
+    }
+
+    #[test]
+    fn priming_system_prompt_offers_escalate_verdict() {
+        let s = build_priming_system_prompt();
+        assert!(s.contains("VERDICT: OBLIGATION_HOLDS"));
+        assert!(s.contains("VERDICT: OBLIGATION_EXCUSED"));
+        assert!(s.contains("VERDICT: ESCALATE"));
+        assert!(s.contains("silence is not permission"));
+    }
+
+    #[test]
+    fn priming_turn2_user_prompt_lists_escalate_as_an_option() {
+        let s = build_priming_turn2_user_prompt("test clause");
+        assert!(s.contains("VERDICT: ESCALATE"));
+        assert!(s.contains("ESCALATE if no rule covers the case"));
+    }
+
+    #[test]
+    fn framework_instructions_do_not_leak_contract_specific_metaphors() {
+        // Same discipline as tsa-demo and clinical-demo. The
+        // ESCALATE / verdict-first instructions should be
+        // domain-neutral.
+        let with_rb = build_raw_system_prompt(Some("RULES: 1."));
+        let priming = build_priming_system_prompt();
+
+        for needle in &[
+            "a real attorney",
+            "a real lawyer",
+            "a real contract-review officer",
+            "consulting senior counsel",
+            "escalate to legal",
+        ] {
+            assert!(
+                !with_rb.contains(needle),
+                "with-rulebook prompt should not invoke {needle:?}"
+            );
+            assert!(
+                !priming.contains(needle),
+                "priming prompt should not invoke {needle:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Mirrors PR [#3066](https://github.com/adhithyan15/coding-adventures/pull/3066) (tsa-demo v0.13) to clinical-demo (v0.4) and contract-demo (v0.4). All three demo crates now share the same framework-level instructions about VERDICT: ESCALATE and the conservative \"silence is not permission\" semantic.

## What's domain-neutral vs domain-specific

**Domain-neutral (word-for-word identical across all 3 demos)**:
- The verdict-line discipline
- The ESCALATE explanation
- The \"silence is not permission\" clause
- The 'do not invent or infer additional rules' instruction

**Domain-specific (each demo owns its own)**:
- Role descriptor (triage assistant / contract reviewer / TSA officer)
- Verdict label set (SAFE_TO_DISCHARGE / OBLIGATION_HOLDS / COMPLIANT etc.)
- Domain framing (\"patient assessment\" / \"contract clause\" / \"passenger declaration\")
- Rulebook content

## Tests

5 new per demo (20 lib in clinical, 19 in contract). Existing tests updated for the new wording.

Each demo also gets its own `framework_instructions_do_not_leak_*_specific_metaphors` test as a regression guard against future domain bias creeping back in (no \"a real physician\", no \"a real attorney\", etc. in framework-level instructions).

## Compatibility

- `DemoConfig` fields unchanged. `run_raw_arm(cfg)` signature unchanged.
- Default behaviour preserved (modulo verdict line position).
- No-rulebook prompts unchanged (binary verdict).

## Test plan

- [x] All 20 clinical tests pass
- [x] All 19 contract tests pass
- [x] Both crates build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)